### PR TITLE
fix(explore): gate alert creation dropdown option behind metric alerts access

### DIFF
--- a/static/app/views/alerts/utils/index.tsx
+++ b/static/app/views/alerts/utils/index.tsx
@@ -22,6 +22,10 @@ export function isIssueAlert(data: CombinedAlerts) {
   return data.type === CombinedAlertType.ISSUE;
 }
 
+export function hasMetricAlerts(organization: Organization): boolean {
+  return organization.features.includes('incidents');
+}
+
 export const DATA_SOURCE_LABELS = {
   [Dataset.ERRORS]: t('Errors'),
   [Dataset.TRANSACTIONS]: t('Transactions'),

--- a/static/app/views/explore/components/chartContextMenu.tsx
+++ b/static/app/views/explore/components/chartContextMenu.tsx
@@ -7,6 +7,7 @@ import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {IconEllipsis} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {defined} from 'sentry/utils/defined';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
@@ -15,6 +16,7 @@ import {
   isVisualizeEquation,
   type Visualize,
 } from 'sentry/views/explore/queryParams/visualize';
+import {getMetricAlertsUpsellTooltip} from 'sentry/views/explore/utils/saveAsAlertMenuItem';
 import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
 
 export function ChartContextMenu({
@@ -42,6 +44,8 @@ export function ChartContextMenu({
         ? projects[0]
         : projects.find(p => p.id === `${pageFilters.selection.projects[0]}`);
 
+    const alertsUpsellTooltip = getMetricAlertsUpsellTooltip(organization);
+
     if (visualizeYAxes.length === 1) {
       const newAlertLabel = organization.features.includes('workflow-engine-ui')
         ? t('Create a Monitor')
@@ -52,7 +56,8 @@ export function ChartContextMenu({
         key: 'create-alert',
         textValue: newAlertLabel,
         label: newAlertLabel,
-        disabled: isVisualizeEquation(visualizeYAxes[0]!),
+        disabled: isVisualizeEquation(visualizeYAxes[0]!) || defined(alertsUpsellTooltip),
+        tooltip: alertsUpsellTooltip,
         to: getAlertsUrl({
           project,
           query,
@@ -99,11 +104,13 @@ export function ChartContextMenu({
         ? t('Create a Monitor for')
         : t('Create an Alert for');
 
+      const hasAccess = !defined(alertsUpsellTooltip);
       menuItems.push({
         key: 'create-alert',
         label: newAlertLabel,
-        children: alertsUrls ?? [],
-        disabled: !alertsUrls || alertsUrls.length === 0,
+        children: hasAccess ? alertsUrls : [],
+        disabled: !hasAccess || alertsUrls.length === 0,
+        tooltip: alertsUpsellTooltip,
         submenu: true,
       });
     }

--- a/static/app/views/explore/components/chartContextMenu.tsx
+++ b/static/app/views/explore/components/chartContextMenu.tsx
@@ -15,7 +15,10 @@ import {
   isVisualizeEquation,
   type Visualize,
 } from 'sentry/views/explore/queryParams/visualize';
-import {getMetricAlertsUpsellTooltip} from 'sentry/views/explore/utils/saveAsAlertMenuItem';
+import {
+  getCreateAlertLabel,
+  getMetricAlertsUpsellTooltip,
+} from 'sentry/views/explore/utils/saveAsAlertMenuItem';
 import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
 
 export function ChartContextMenu({
@@ -46,9 +49,7 @@ export function ChartContextMenu({
     const alertsUpsellTooltip = getMetricAlertsUpsellTooltip(organization);
 
     if (visualizeYAxes.length === 1) {
-      const newAlertLabel = organization.features.includes('workflow-engine-ui')
-        ? t('Create a Monitor')
-        : t('Create an Alert');
+      const newAlertLabel = getCreateAlertLabel(organization);
 
       const yAxis = visualizeYAxes[0]!.yAxis;
       menuItems.push({

--- a/static/app/views/explore/components/chartContextMenu.tsx
+++ b/static/app/views/explore/components/chartContextMenu.tsx
@@ -2,7 +2,7 @@ import {useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import Feature from 'sentry/components/acl/feature';
-import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {IconEllipsis} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -16,8 +16,8 @@ import {
   type Visualize,
 } from 'sentry/views/explore/queryParams/visualize';
 import {
-  getCreateAlertLabel,
-  getMetricAlertsUpsellTooltip,
+  getCreateAlertForLabel,
+  getSaveAsAlertMenuItem,
 } from 'sentry/views/explore/utils/saveAsAlertMenuItem';
 import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
 
@@ -38,7 +38,7 @@ export function ChartContextMenu({
   const {projects} = useProjects();
   const pageFilters = usePageFilters();
 
-  const items: MenuItemProps[] = useMemo(() => {
+  const items = useMemo(() => {
     const menuItems = [];
 
     const project =
@@ -46,36 +46,31 @@ export function ChartContextMenu({
         ? projects[0]
         : projects.find(p => p.id === `${pageFilters.selection.projects[0]}`);
 
-    const alertsUpsellTooltip = getMetricAlertsUpsellTooltip(organization);
-
     if (visualizeYAxes.length === 1) {
-      const newAlertLabel = getCreateAlertLabel(organization);
-
       const yAxis = visualizeYAxes[0]!.yAxis;
-      menuItems.push({
-        key: 'create-alert',
-        textValue: newAlertLabel,
-        label: newAlertLabel,
-        disabled: isVisualizeEquation(visualizeYAxes[0]!) || !!alertsUpsellTooltip,
-        tooltip: alertsUpsellTooltip,
-        to: getAlertsUrl({
-          project,
-          query,
-          pageFilters: pageFilters.selection,
-          aggregate: yAxis,
+      menuItems.push(
+        getSaveAsAlertMenuItem({
           organization,
-          dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
-          interval,
-        }),
-        onAction: () => {
-          trackAnalytics('trace_explorer.save_as', {
-            save_type: 'alert',
-            ui_source: 'chart',
+          disabled: isVisualizeEquation(visualizeYAxes[0]!),
+          to: getAlertsUrl({
+            project,
+            query,
+            pageFilters: pageFilters.selection,
+            aggregate: yAxis,
             organization,
-          });
-          return;
-        },
-      });
+            dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
+            interval,
+          }),
+          onAction: () => {
+            trackAnalytics('trace_explorer.save_as', {
+              save_type: 'alert',
+              ui_source: 'chart',
+              organization,
+            });
+            return;
+          },
+        })
+      );
     } else {
       const alertsUrls = visualizeYAxes.map((visualizeYAxis, index) => ({
         key: `${visualizeYAxis.yAxis}-${index}`,
@@ -100,19 +95,14 @@ export function ChartContextMenu({
         },
       }));
 
-      const newAlertLabel = organization.features.includes('workflow-engine-ui')
-        ? t('Create a Monitor for')
-        : t('Create an Alert for');
-
-      const hasAccess = !alertsUpsellTooltip;
-      menuItems.push({
-        key: 'create-alert',
-        label: newAlertLabel,
-        children: hasAccess ? alertsUrls : [],
-        disabled: !hasAccess || alertsUrls.length === 0,
-        tooltip: alertsUpsellTooltip,
-        submenu: true,
-      });
+      menuItems.push(
+        getSaveAsAlertMenuItem({
+          organization,
+          alertsUrls,
+          submenu: true,
+          label: getCreateAlertForLabel(organization),
+        })
+      );
     }
 
     const disableAddToDashboard = !organization.features.includes('dashboards-edit');

--- a/static/app/views/explore/components/chartContextMenu.tsx
+++ b/static/app/views/explore/components/chartContextMenu.tsx
@@ -7,7 +7,6 @@ import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {IconEllipsis} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {defined} from 'sentry/utils/defined';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
@@ -56,7 +55,7 @@ export function ChartContextMenu({
         key: 'create-alert',
         textValue: newAlertLabel,
         label: newAlertLabel,
-        disabled: isVisualizeEquation(visualizeYAxes[0]!) || defined(alertsUpsellTooltip),
+        disabled: isVisualizeEquation(visualizeYAxes[0]!) || !!alertsUpsellTooltip,
         tooltip: alertsUpsellTooltip,
         to: getAlertsUrl({
           project,
@@ -104,7 +103,7 @@ export function ChartContextMenu({
         ? t('Create a Monitor for')
         : t('Create an Alert for');
 
-      const hasAccess = !defined(alertsUpsellTooltip);
+      const hasAccess = !alertsUpsellTooltip;
       menuItems.push({
         key: 'create-alert',
         label: newAlertLabel,

--- a/static/app/views/explore/logs/logsGraph.tsx
+++ b/static/app/views/explore/logs/logsGraph.tsx
@@ -6,7 +6,7 @@ import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 
 import Feature from 'sentry/components/acl/feature';
-import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {IconClock, IconContract, IconEllipsis, IconExpand, IconGraph} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -62,10 +62,7 @@ import {
   getSamplingWarningReason,
   prettifyAggregation,
 } from 'sentry/views/explore/utils';
-import {
-  getCreateAlertLabel,
-  getMetricAlertsUpsellTooltip,
-} from 'sentry/views/explore/utils/saveAsAlertMenuItem';
+import {getSaveAsAlertMenuItem} from 'sentry/views/explore/utils/saveAsAlertMenuItem';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 import type {SortedTimeSeries} from 'sentry/views/insights/common/queries/useSortedTimeSeries';
 import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
@@ -308,23 +305,17 @@ function ContextMenu({interval, visualize}: {interval: string; visualize: Visual
   const aggregateFields = useQueryParamsAggregateFields();
   const aggregateSortBys = useQueryParamsAggregateSortBys();
 
-  const items: MenuItemProps[] = useMemo(() => {
+  const items = useMemo(() => {
     const project =
       projects.length === 1
         ? projects[0]
         : projects.find(p => p.id === `${pageFilters.selection.projects[0]}`);
 
     const disableAddToDashboard = !organization.features.includes('dashboards-edit');
-    const alertsUpsellTooltip = getMetricAlertsUpsellTooltip(organization);
-    const newAlertLabel = getCreateAlertLabel(organization);
 
     return [
-      {
-        key: 'create-alert',
-        textValue: newAlertLabel,
-        label: newAlertLabel,
-        disabled: defined(alertsUpsellTooltip),
-        tooltip: alertsUpsellTooltip,
+      getSaveAsAlertMenuItem({
+        organization,
         to: getAlertsUrl({
           project,
           query: search.formatString(),
@@ -343,7 +334,7 @@ function ContextMenu({interval, visualize}: {interval: string; visualize: Visual
           });
           return;
         },
-      },
+      }),
       {
         key: 'add-to-dashboard',
         textValue: t('Add to Dashboard'),

--- a/static/app/views/explore/logs/logsGraph.tsx
+++ b/static/app/views/explore/logs/logsGraph.tsx
@@ -62,7 +62,10 @@ import {
   getSamplingWarningReason,
   prettifyAggregation,
 } from 'sentry/views/explore/utils';
-import {getMetricAlertsUpsellTooltip} from 'sentry/views/explore/utils/saveAsAlertMenuItem';
+import {
+  getCreateAlertLabel,
+  getMetricAlertsUpsellTooltip,
+} from 'sentry/views/explore/utils/saveAsAlertMenuItem';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 import type {SortedTimeSeries} from 'sentry/views/insights/common/queries/useSortedTimeSeries';
 import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
@@ -313,12 +316,13 @@ function ContextMenu({interval, visualize}: {interval: string; visualize: Visual
 
     const disableAddToDashboard = !organization.features.includes('dashboards-edit');
     const alertsUpsellTooltip = getMetricAlertsUpsellTooltip(organization);
+    const newAlertLabel = getCreateAlertLabel(organization);
 
     return [
       {
         key: 'create-alert',
-        textValue: t('Create an Alert'),
-        label: t('Create an Alert'),
+        textValue: newAlertLabel,
+        label: newAlertLabel,
         disabled: defined(alertsUpsellTooltip),
         tooltip: alertsUpsellTooltip,
         to: getAlertsUrl({

--- a/static/app/views/explore/logs/logsGraph.tsx
+++ b/static/app/views/explore/logs/logsGraph.tsx
@@ -62,6 +62,7 @@ import {
   getSamplingWarningReason,
   prettifyAggregation,
 } from 'sentry/views/explore/utils';
+import {getMetricAlertsUpsellTooltip} from 'sentry/views/explore/utils/saveAsAlertMenuItem';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 import type {SortedTimeSeries} from 'sentry/views/insights/common/queries/useSortedTimeSeries';
 import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
@@ -311,12 +312,15 @@ function ContextMenu({interval, visualize}: {interval: string; visualize: Visual
         : projects.find(p => p.id === `${pageFilters.selection.projects[0]}`);
 
     const disableAddToDashboard = !organization.features.includes('dashboards-edit');
+    const alertsUpsellTooltip = getMetricAlertsUpsellTooltip(organization);
 
     return [
       {
         key: 'create-alert',
         textValue: t('Create an Alert'),
         label: t('Create an Alert'),
+        disabled: defined(alertsUpsellTooltip),
+        tooltip: alertsUpsellTooltip,
         to: getAlertsUrl({
           project,
           query: search.formatString(),

--- a/static/app/views/explore/logs/useSaveAsItems.spec.tsx
+++ b/static/app/views/explore/logs/useSaveAsItems.spec.tsx
@@ -42,10 +42,10 @@ describe('useSaveAsItems', () => {
   let saveQueryMock: jest.Mock;
   ProjectsStore.loadInitialData([project]);
 
-  function createWrapper() {
+  function createWrapper(org = organization) {
     return function ({children}: {children?: React.ReactNode}) {
       return (
-        <OrganizationContext.Provider value={organization}>
+        <OrganizationContext.Provider value={org}>
           <QueryClientProvider client={queryClient}>
             <LogsQueryParamsProvider
               analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
@@ -212,6 +212,52 @@ describe('useSaveAsItems', () => {
 
     expect(saveAsItems.some(item => item.key === 'update-query')).toBe(false);
     expect(saveAsItems.some(item => item.key === 'save-query')).toBe(true);
+  });
+
+  it('disables the alert option with an upsell tooltip when metric alerts are unavailable', () => {
+    const {result} = renderHookWithProviders(
+      () =>
+        useSaveAsItems({
+          visualizes: [new VisualizeFunction('count()')],
+          groupBys: ['message.template'],
+          interval: '5m',
+          mode: Mode.AGGREGATE,
+          search: new MutableSearch('message:"test error"'),
+          sortBys: [{field: 'timestamp', kind: 'desc'}],
+        }),
+      {additionalWrapper: createWrapper()}
+    );
+
+    const alertItem = result.current.find(item => item.key === 'create-alert');
+
+    expect(alertItem?.disabled).toBe(true);
+    expect(alertItem?.tooltip).toBe('Alerts are not available on your current plan.');
+    expect(alertItem?.children).toEqual([]);
+  });
+
+  it('enables the alert option when the org has metric alerts', () => {
+    const orgWithAlerts = OrganizationFixture({
+      features: ['ourlogs-enabled', 'incidents'],
+    });
+
+    const {result} = renderHookWithProviders(
+      () =>
+        useSaveAsItems({
+          visualizes: [new VisualizeFunction('count()')],
+          groupBys: ['message.template'],
+          interval: '5m',
+          mode: Mode.AGGREGATE,
+          search: new MutableSearch('message:"test error"'),
+          sortBys: [{field: 'timestamp', kind: 'desc'}],
+        }),
+      {additionalWrapper: createWrapper(orgWithAlerts)}
+    );
+
+    const alertItem = result.current.find(item => item.key === 'create-alert');
+
+    expect(alertItem?.disabled).toBe(false);
+    expect(alertItem?.tooltip).toBeUndefined();
+    expect(alertItem?.children).toHaveLength(1);
   });
 
   it('preserves the chart type when adding a dashboard widget', () => {

--- a/static/app/views/explore/logs/useSaveAsItems.spec.tsx
+++ b/static/app/views/explore/logs/useSaveAsItems.spec.tsx
@@ -105,18 +105,17 @@ describe('useSaveAsItems', () => {
   });
 
   it('should open save query modal when save as new query is clicked', () => {
-    const {result} = renderHookWithProviders(
-      () =>
-        useSaveAsItems({
-          visualizes: [new VisualizeFunction('count()')],
-          groupBys: ['message.template'],
-          interval: '5m',
-          mode: Mode.AGGREGATE,
-          search: new MutableSearch('message:"test error"'),
-          sortBys: [{field: 'timestamp', kind: 'desc'}],
-        }),
-      {additionalWrapper: createWrapper()}
-    );
+    const {result} = renderHookWithProviders(useSaveAsItems, {
+      additionalWrapper: createWrapper(),
+      initialProps: {
+        visualizes: [new VisualizeFunction('count()')],
+        groupBys: ['message.template'],
+        interval: '5m',
+        mode: Mode.AGGREGATE,
+        search: new MutableSearch('message:"test error"'),
+        sortBys: [{field: 'timestamp', kind: 'desc'}],
+      },
+    });
 
     const saveAsItems = result.current;
     const saveAsQuery = saveAsItems.find(item => item.key === 'save-query') as {
@@ -163,18 +162,17 @@ describe('useSaveAsItems', () => {
       })
     );
 
-    const {result} = renderHookWithProviders(
-      () =>
-        useSaveAsItems({
-          visualizes: [new VisualizeFunction('count()')],
-          groupBys: ['message.template'],
-          interval: '5m',
-          mode: Mode.AGGREGATE,
-          search: new MutableSearch('message:"test"'),
-          sortBys: [{field: 'timestamp', kind: 'desc'}],
-        }),
-      {additionalWrapper: createWrapper()}
-    );
+    const {result} = renderHookWithProviders(useSaveAsItems, {
+      additionalWrapper: createWrapper(),
+      initialProps: {
+        visualizes: [new VisualizeFunction('count()')],
+        groupBys: ['message.template'],
+        interval: '5m',
+        mode: Mode.AGGREGATE,
+        search: new MutableSearch('message:"test"'),
+        sortBys: [{field: 'timestamp', kind: 'desc'}],
+      },
+    });
 
     await waitFor(() => {
       expect(result.current.some(item => item.key === 'update-query')).toBe(true);
@@ -195,18 +193,17 @@ describe('useSaveAsItems', () => {
       })
     );
 
-    const {result} = renderHookWithProviders(
-      () =>
-        useSaveAsItems({
-          visualizes: [new VisualizeFunction('count()')],
-          groupBys: ['message.template'],
-          interval: '5m',
-          mode: Mode.AGGREGATE,
-          search: new MutableSearch('message:"test"'),
-          sortBys: [{field: 'timestamp', kind: 'desc'}],
-        }),
-      {additionalWrapper: createWrapper()}
-    );
+    const {result} = renderHookWithProviders(useSaveAsItems, {
+      additionalWrapper: createWrapper(),
+      initialProps: {
+        visualizes: [new VisualizeFunction('count()')],
+        groupBys: ['message.template'],
+        interval: '5m',
+        mode: Mode.AGGREGATE,
+        search: new MutableSearch('message:"test"'),
+        sortBys: [{field: 'timestamp', kind: 'desc'}],
+      },
+    });
 
     const saveAsItems = result.current;
 
@@ -215,18 +212,17 @@ describe('useSaveAsItems', () => {
   });
 
   it('disables the alert option with an upsell tooltip when metric alerts are unavailable', () => {
-    const {result} = renderHookWithProviders(
-      () =>
-        useSaveAsItems({
-          visualizes: [new VisualizeFunction('count()')],
-          groupBys: ['message.template'],
-          interval: '5m',
-          mode: Mode.AGGREGATE,
-          search: new MutableSearch('message:"test error"'),
-          sortBys: [{field: 'timestamp', kind: 'desc'}],
-        }),
-      {additionalWrapper: createWrapper()}
-    );
+    const {result} = renderHookWithProviders(useSaveAsItems, {
+      additionalWrapper: createWrapper(),
+      initialProps: {
+        visualizes: [new VisualizeFunction('count()')],
+        groupBys: ['message.template'],
+        interval: '5m',
+        mode: Mode.AGGREGATE,
+        search: new MutableSearch('message:"test error"'),
+        sortBys: [{field: 'timestamp', kind: 'desc'}],
+      },
+    });
 
     const alertItem = result.current.find(item => item.key === 'create-alert') as
       | {children: unknown[]; disabled: boolean; tooltip: string | undefined}
@@ -242,18 +238,17 @@ describe('useSaveAsItems', () => {
       features: ['ourlogs-enabled', 'incidents'],
     });
 
-    const {result} = renderHookWithProviders(
-      () =>
-        useSaveAsItems({
-          visualizes: [new VisualizeFunction('count()')],
-          groupBys: ['message.template'],
-          interval: '5m',
-          mode: Mode.AGGREGATE,
-          search: new MutableSearch('message:"test error"'),
-          sortBys: [{field: 'timestamp', kind: 'desc'}],
-        }),
-      {additionalWrapper: createWrapper(orgWithAlerts)}
-    );
+    const {result} = renderHookWithProviders(useSaveAsItems, {
+      additionalWrapper: createWrapper(orgWithAlerts),
+      initialProps: {
+        visualizes: [new VisualizeFunction('count()')],
+        groupBys: ['message.template'],
+        interval: '5m',
+        mode: Mode.AGGREGATE,
+        search: new MutableSearch('message:"test error"'),
+        sortBys: [{field: 'timestamp', kind: 'desc'}],
+      },
+    });
 
     const alertItem = result.current.find(item => item.key === 'create-alert') as
       | {children: unknown[]; disabled: boolean; tooltip: string | undefined}
@@ -269,20 +264,19 @@ describe('useSaveAsItems', () => {
       .spyOn(discoverUtils, 'handleAddQueryToDashboard')
       .mockImplementation(() => {});
 
-    const {result} = renderHookWithProviders(
-      () =>
-        useSaveAsItems({
-          visualizes: [
-            new VisualizeFunction('count(message)', {chartType: ChartType.LINE}),
-          ],
-          groupBys: ['message.template'],
-          interval: '5m',
-          mode: Mode.AGGREGATE,
-          search: new MutableSearch('message:"test error"'),
-          sortBys: [{field: 'timestamp', kind: 'desc'}],
-        }),
-      {additionalWrapper: createWrapper()}
-    );
+    const {result} = renderHookWithProviders(useSaveAsItems, {
+      additionalWrapper: createWrapper(),
+      initialProps: {
+        visualizes: [
+          new VisualizeFunction('count(message)', {chartType: ChartType.LINE}),
+        ],
+        groupBys: ['message.template'],
+        interval: '5m',
+        mode: Mode.AGGREGATE,
+        search: new MutableSearch('message:"test error"'),
+        sortBys: [{field: 'timestamp', kind: 'desc'}],
+      },
+    });
 
     const saveAsDashboard = result.current.find(
       item => item.key === 'add-to-dashboard'
@@ -298,20 +292,19 @@ describe('useSaveAsItems', () => {
   });
 
   it('should call saveQuery with correct parameters when modal saves', async () => {
-    const {result} = renderHookWithProviders(
-      () =>
-        useSaveAsItems({
-          visualizes: [new VisualizeFunction('count()')],
-          groupBys: ['message.template'],
-          // Note: useSaveQuery uses the value returned by useChartInterval()
-          // not the interval passed in as options.
-          interval: '5m',
-          mode: Mode.AGGREGATE,
-          search: new MutableSearch('message:"test error"'),
-          sortBys: [{field: 'timestamp', kind: 'desc'}],
-        }),
-      {additionalWrapper: createWrapper()}
-    );
+    const {result} = renderHookWithProviders(useSaveAsItems, {
+      additionalWrapper: createWrapper(),
+      initialProps: {
+        visualizes: [new VisualizeFunction('count()')],
+        groupBys: ['message.template'],
+        // Note: useSaveQuery uses the value returned by useChartInterval()
+        // not the interval passed in as options.
+        interval: '5m',
+        mode: Mode.AGGREGATE,
+        search: new MutableSearch('message:"test error"'),
+        sortBys: [{field: 'timestamp', kind: 'desc'}],
+      },
+    });
 
     const saveAsItems = result.current;
     const saveAsQuery = saveAsItems.find(item => item.key === 'save-query') as {

--- a/static/app/views/explore/logs/useSaveAsItems.spec.tsx
+++ b/static/app/views/explore/logs/useSaveAsItems.spec.tsx
@@ -228,7 +228,9 @@ describe('useSaveAsItems', () => {
       {additionalWrapper: createWrapper()}
     );
 
-    const alertItem = result.current.find(item => item.key === 'create-alert');
+    const alertItem = result.current.find(item => item.key === 'create-alert') as
+      | {children: unknown[]; disabled: boolean; tooltip: string | undefined}
+      | undefined;
 
     expect(alertItem?.disabled).toBe(true);
     expect(alertItem?.tooltip).toBe('Alerts are not available on your current plan.');
@@ -253,7 +255,9 @@ describe('useSaveAsItems', () => {
       {additionalWrapper: createWrapper(orgWithAlerts)}
     );
 
-    const alertItem = result.current.find(item => item.key === 'create-alert');
+    const alertItem = result.current.find(item => item.key === 'create-alert') as
+      | {children: unknown[]; disabled: boolean; tooltip: string | undefined}
+      | undefined;
 
     expect(alertItem?.disabled).toBe(false);
     expect(alertItem?.tooltip).toBeUndefined();

--- a/static/app/views/explore/logs/useSaveAsItems.tsx
+++ b/static/app/views/explore/logs/useSaveAsItems.tsx
@@ -37,6 +37,7 @@ import {useLogsSaveQuery} from 'sentry/views/explore/hooks/useSaveQuery';
 import {useQueryParamsId} from 'sentry/views/explore/queryParams/context';
 import type {Visualize} from 'sentry/views/explore/queryParams/visualize';
 import {TraceItemDataset} from 'sentry/views/explore/types';
+import {getSaveAsAlertMenuItem} from 'sentry/views/explore/utils/saveAsAlertMenuItem';
 import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
 
 import {isLogsEnabled} from './isLogsEnabled';
@@ -152,18 +153,7 @@ export function useSaveAsItems({
       };
     });
 
-    const newAlertLabel = organization.features.includes('workflow-engine-ui')
-      ? t('Monitor for')
-      : t('Alert for');
-
-    return {
-      key: 'create-alert',
-      label: newAlertLabel,
-      textValue: newAlertLabel,
-      children: alertsUrls ?? [],
-      disabled: !alertsUrls || alertsUrls.length === 0,
-      submenu: true,
-    };
+    return getSaveAsAlertMenuItem({organization, alertsUrls});
   }, [aggregates, interval, organization, pageFilters, project, search]);
 
   const saveAsDashboard = useMemo(() => {

--- a/static/app/views/explore/logs/useSaveAsItems.tsx
+++ b/static/app/views/explore/logs/useSaveAsItems.tsx
@@ -153,7 +153,7 @@ export function useSaveAsItems({
       };
     });
 
-    return getSaveAsAlertMenuItem({organization, alertsUrls});
+    return getSaveAsAlertMenuItem({organization, alertsUrls, submenu: true});
   }, [aggregates, interval, organization, pageFilters, project, search]);
 
   const saveAsDashboard = useMemo(() => {

--- a/static/app/views/explore/metrics/useSaveAsMetricItems.spec.tsx
+++ b/static/app/views/explore/metrics/useSaveAsMetricItems.spec.tsx
@@ -337,7 +337,9 @@ describe('useSaveAsMetricItems', () => {
       initialProps: {interval: '5m'},
     });
 
-    const alertItem = result.current.find(item => item.key === 'create-alert');
+    const alertItem = result.current.find(item => item.key === 'create-alert') as
+      | {children: unknown[]; disabled: boolean; tooltip: string | undefined}
+      | undefined;
 
     expect(alertItem?.disabled).toBe(true);
     expect(alertItem?.tooltip).toBe('Alerts are not available on your current plan.');

--- a/static/app/views/explore/metrics/useSaveAsMetricItems.spec.tsx
+++ b/static/app/views/explore/metrics/useSaveAsMetricItems.spec.tsx
@@ -39,16 +39,16 @@ const mockHandleAddMultipleQueriesToDashboard = jest.mocked(
 
 describe('useSaveAsMetricItems', () => {
   const organization = OrganizationFixture({
-    features: ['tracemetrics-enabled'],
+    features: ['tracemetrics-enabled', 'incidents'],
   });
   const project = ProjectFixture({id: '1'});
   const queryClient = makeTestQueryClient();
   ProjectsStore.loadInitialData([project]);
 
-  function createWrapper() {
+  function createWrapper(org = organization) {
     return function ({children}: {children?: React.ReactNode}) {
       return (
-        <OrganizationContext.Provider value={organization}>
+        <OrganizationContext.Provider value={org}>
           <QueryClientProvider client={queryClient}>
             <MockMetricQueryParamsContext>{children}</MockMetricQueryParamsContext>
           </QueryClientProvider>
@@ -303,6 +303,45 @@ describe('useSaveAsMetricItems', () => {
         ]),
       })
     );
+  });
+
+  it('disables the alert option with an upsell tooltip when metric alerts are unavailable', () => {
+    const orgWithoutAlerts = OrganizationFixture({features: ['tracemetrics-enabled']});
+
+    const encodedMetricQuery = encodeMetricQueryParams({
+      metric: {name: 'metric.a', type: 'counter'},
+      queryParams: new ReadableQueryParams({
+        extrapolate: true,
+        mode: Mode.AGGREGATE,
+        query: 'release:1.2.3',
+        aggregateCursor: '',
+        aggregateFields: [new VisualizeFunction('sum(value,metric.a,counter,none)')],
+        aggregateSortBys: [{field: 'sum(value,metric.a,counter,none)', kind: 'desc'}],
+        cursor: '',
+        fields: [],
+        sortBys: [],
+      }),
+    });
+
+    mockedUseLocation.mockReturnValue(
+      LocationFixture({
+        query: {
+          interval: '5m',
+          metric: [encodedMetricQuery],
+        },
+      })
+    );
+
+    const {result} = renderHook(useSaveAsMetricItems, {
+      wrapper: createWrapper(orgWithoutAlerts),
+      initialProps: {interval: '5m'},
+    });
+
+    const alertItem = result.current.find(item => item.key === 'create-alert');
+
+    expect(alertItem?.disabled).toBe(true);
+    expect(alertItem?.tooltip).toBe('Alerts are not available on your current plan.');
+    expect(alertItem?.children).toEqual([]);
   });
 
   it('formats alerts submenu labels for equations', () => {

--- a/static/app/views/explore/metrics/useSaveAsMetricItems.spec.tsx
+++ b/static/app/views/explore/metrics/useSaveAsMetricItems.spec.tsx
@@ -79,13 +79,10 @@ describe('useSaveAsMetricItems', () => {
   });
 
   it('should open save query modal when save as new query is clicked', () => {
-    const {result} = renderHook(
-      () =>
-        useSaveAsMetricItems({
-          interval: '5m',
-        }),
-      {wrapper: createWrapper()}
-    );
+    const {result} = renderHook(useSaveAsMetricItems, {
+      wrapper: createWrapper(),
+      initialProps: {interval: '5m'},
+    });
 
     const saveAsItems = result.current;
     const saveAsQuery = saveAsItems.find(item => item.key === 'save-query') as {
@@ -130,13 +127,10 @@ describe('useSaveAsMetricItems', () => {
       })
     );
 
-    const {result} = renderHook(
-      () =>
-        useSaveAsMetricItems({
-          interval: '5m',
-        }),
-      {wrapper: createWrapper()}
-    );
+    const {result} = renderHook(useSaveAsMetricItems, {
+      wrapper: createWrapper(),
+      initialProps: {interval: '5m'},
+    });
 
     await waitFor(() => {
       expect(result.current.some(item => item.key === 'update-query')).toBe(true);
@@ -155,13 +149,10 @@ describe('useSaveAsMetricItems', () => {
       })
     );
 
-    const {result} = renderHook(
-      () =>
-        useSaveAsMetricItems({
-          interval: '5m',
-        }),
-      {wrapper: createWrapper()}
-    );
+    const {result} = renderHook(useSaveAsMetricItems, {
+      wrapper: createWrapper(),
+      initialProps: {interval: '5m'},
+    });
 
     const saveAsItems = result.current;
 

--- a/static/app/views/explore/metrics/useSaveAsMetricItems.tsx
+++ b/static/app/views/explore/metrics/useSaveAsMetricItems.tsx
@@ -159,7 +159,7 @@ export function useSaveAsMetricItems(options: UseSaveAsMetricItemsOptions) {
         };
       });
 
-    return [getSaveAsAlertMenuItem({organization, alertsUrls})];
+    return [getSaveAsAlertMenuItem({organization, alertsUrls, submenu: true})];
   }, [metricQueries, organization, project, pageFilters, options.interval]);
 
   const addToDashboardItems = useMemo(() => {

--- a/static/app/views/explore/metrics/useSaveAsMetricItems.tsx
+++ b/static/app/views/explore/metrics/useSaveAsMetricItems.tsx
@@ -29,6 +29,7 @@ import {
 } from 'sentry/views/explore/queryParams/visualize';
 import {getVisualizeLabel} from 'sentry/views/explore/toolbar/toolbarVisualize';
 import {TraceItemDataset} from 'sentry/views/explore/types';
+import {getSaveAsAlertMenuItem} from 'sentry/views/explore/utils/saveAsAlertMenuItem';
 import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
 
 import {
@@ -158,20 +159,7 @@ export function useSaveAsMetricItems(options: UseSaveAsMetricItemsOptions) {
         };
       });
 
-    const newAlertLabel = organization.features.includes('workflow-engine-ui')
-      ? t('Monitor for')
-      : t('Alert for');
-
-    return [
-      {
-        key: 'create-alert',
-        label: newAlertLabel,
-        textValue: newAlertLabel,
-        children: alertsUrls,
-        disabled: alertsUrls.length === 0,
-        submenu: true,
-      },
-    ];
+    return [getSaveAsAlertMenuItem({organization, alertsUrls})];
   }, [metricQueries, organization, project, pageFilters, options.interval]);
 
   const addToDashboardItems = useMemo(() => {

--- a/static/app/views/explore/multiQueryMode/queryVisualizations/chart.tsx
+++ b/static/app/views/explore/multiQueryMode/queryVisualizations/chart.tsx
@@ -33,7 +33,10 @@ import {
 import {EXPLORE_CHART_TYPE_OPTIONS} from 'sentry/views/explore/spans/charts';
 import {ConfidenceFooter} from 'sentry/views/explore/spans/charts/confidenceFooter';
 import {combineConfidenceForSeries} from 'sentry/views/explore/utils';
-import {getMetricAlertsUpsellTooltip} from 'sentry/views/explore/utils/saveAsAlertMenuItem';
+import {
+  getCreateAlertLabel,
+  getMetricAlertsUpsellTooltip,
+} from 'sentry/views/explore/utils/saveAsAlertMenuItem';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 import type {SortedTimeSeries} from 'sentry/views/insights/common/queries/useSortedTimeSeries';
 import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
@@ -106,10 +109,11 @@ export function MultiQueryModeChart({
 
   if (defined(yAxes[0])) {
     const alertsUpsellTooltip = getMetricAlertsUpsellTooltip(organization);
+    const newAlertLabel = getCreateAlertLabel(organization);
     items.push({
       key: 'create-alert',
-      textValue: t('Create an Alert'),
-      label: t('Create an Alert'),
+      textValue: newAlertLabel,
+      label: newAlertLabel,
       disabled: defined(alertsUpsellTooltip),
       tooltip: alertsUpsellTooltip,
       to: getAlertsUrl({

--- a/static/app/views/explore/multiQueryMode/queryVisualizations/chart.tsx
+++ b/static/app/views/explore/multiQueryMode/queryVisualizations/chart.tsx
@@ -33,6 +33,7 @@ import {
 import {EXPLORE_CHART_TYPE_OPTIONS} from 'sentry/views/explore/spans/charts';
 import {ConfidenceFooter} from 'sentry/views/explore/spans/charts/confidenceFooter';
 import {combineConfidenceForSeries} from 'sentry/views/explore/utils';
+import {getMetricAlertsUpsellTooltip} from 'sentry/views/explore/utils/saveAsAlertMenuItem';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 import type {SortedTimeSeries} from 'sentry/views/insights/common/queries/useSortedTimeSeries';
 import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
@@ -104,10 +105,13 @@ export function MultiQueryModeChart({
       : projects.find(p => p.id === `${pageFilters.selection.projects[0]}`);
 
   if (defined(yAxes[0])) {
+    const alertsUpsellTooltip = getMetricAlertsUpsellTooltip(organization);
     items.push({
       key: 'create-alert',
       textValue: t('Create an Alert'),
       label: t('Create an Alert'),
+      disabled: defined(alertsUpsellTooltip),
+      tooltip: alertsUpsellTooltip,
       to: getAlertsUrl({
         project,
         query: queryParts.query,

--- a/static/app/views/explore/multiQueryMode/queryVisualizations/chart.tsx
+++ b/static/app/views/explore/multiQueryMode/queryVisualizations/chart.tsx
@@ -33,10 +33,7 @@ import {
 import {EXPLORE_CHART_TYPE_OPTIONS} from 'sentry/views/explore/spans/charts';
 import {ConfidenceFooter} from 'sentry/views/explore/spans/charts/confidenceFooter';
 import {combineConfidenceForSeries} from 'sentry/views/explore/utils';
-import {
-  getCreateAlertLabel,
-  getMetricAlertsUpsellTooltip,
-} from 'sentry/views/explore/utils/saveAsAlertMenuItem';
+import {getSaveAsAlertMenuItem} from 'sentry/views/explore/utils/saveAsAlertMenuItem';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 import type {SortedTimeSeries} from 'sentry/views/insights/common/queries/useSortedTimeSeries';
 import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
@@ -108,31 +105,27 @@ export function MultiQueryModeChart({
       : projects.find(p => p.id === `${pageFilters.selection.projects[0]}`);
 
   if (defined(yAxes[0])) {
-    const alertsUpsellTooltip = getMetricAlertsUpsellTooltip(organization);
-    const newAlertLabel = getCreateAlertLabel(organization);
-    items.push({
-      key: 'create-alert',
-      textValue: newAlertLabel,
-      label: newAlertLabel,
-      disabled: defined(alertsUpsellTooltip),
-      tooltip: alertsUpsellTooltip,
-      to: getAlertsUrl({
-        project,
-        query: queryParts.query,
-        pageFilters: pageFilters.selection,
-        aggregate: yAxes[0],
+    items.push(
+      getSaveAsAlertMenuItem({
         organization,
-        dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
-        interval,
-      }),
-      onAction: () => {
-        trackAnalytics('trace_explorer.save_as', {
-          save_type: 'alert',
-          ui_source: 'compare chart',
+        to: getAlertsUrl({
+          project,
+          query: queryParts.query,
+          pageFilters: pageFilters.selection,
+          aggregate: yAxes[0],
           organization,
-        });
-      },
-    });
+          dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
+          interval,
+        }),
+        onAction: () => {
+          trackAnalytics('trace_explorer.save_as', {
+            save_type: 'alert',
+            ui_source: 'compare chart',
+            organization,
+          });
+        },
+      })
+    );
   }
 
   const disableAddToDashboard = !organization.features.includes('dashboards-edit');

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -116,11 +116,7 @@ describe('ExploreToolbar', () => {
       return <ExploreToolbar />;
     }
 
-    render(
-      <Wrapper>
-        <Component />
-      </Wrapper>
-    );
+    render(<Component />, {additionalWrapper: Wrapper});
 
     const section = screen.getByTestId('section-visualizes');
 
@@ -137,11 +133,7 @@ describe('ExploreToolbar', () => {
       return <ExploreToolbar />;
     }
 
-    render(
-      <Wrapper>
-        <Component />
-      </Wrapper>
-    );
+    render(<Component />, {additionalWrapper: Wrapper});
 
     const section = screen.getByTestId('section-visualizes');
 
@@ -171,11 +163,7 @@ describe('ExploreToolbar', () => {
       return <ExploreToolbar />;
     }
 
-    render(
-      <Wrapper>
-        <Component />
-      </Wrapper>
-    );
+    render(<Component />, {additionalWrapper: Wrapper});
 
     const section = screen.getByTestId('section-visualizes');
 
@@ -196,11 +184,7 @@ describe('ExploreToolbar', () => {
       return <ExploreToolbar />;
     }
 
-    render(
-      <Wrapper>
-        <Component />
-      </Wrapper>
-    );
+    render(<Component />, {additionalWrapper: Wrapper});
 
     const section = screen.getByTestId('section-visualizes');
 
@@ -236,11 +220,7 @@ describe('ExploreToolbar', () => {
       return <ExploreToolbar />;
     }
 
-    render(
-      <Wrapper>
-        <Component />
-      </Wrapper>
-    );
+    render(<Component />, {additionalWrapper: Wrapper});
 
     const section = screen.getByTestId('section-visualizes');
 
@@ -279,11 +259,7 @@ describe('ExploreToolbar', () => {
       return <ExploreToolbar />;
     }
 
-    render(
-      <Wrapper>
-        <Component />
-      </Wrapper>
-    );
+    render(<Component />, {additionalWrapper: Wrapper});
 
     const section = screen.getByTestId('section-visualizes');
 
@@ -341,11 +317,7 @@ describe('ExploreToolbar', () => {
       groupBys = useQueryParamsGroupBys();
       return <ExploreToolbar />;
     }
-    render(
-      <Wrapper>
-        <Component />
-      </Wrapper>
-    );
+    render(<Component />, {additionalWrapper: Wrapper});
 
     let options: HTMLElement[];
     const section = screen.getByTestId('section-group-by');
@@ -679,11 +651,7 @@ describe('ExploreToolbar', () => {
       mode = useQueryParamsMode();
       return <ExploreToolbar />;
     }
-    render(
-      <Wrapper>
-        <Component />
-      </Wrapper>
-    );
+    render(<Component />, {additionalWrapper: Wrapper});
 
     expect(mode).toEqual(Mode.SAMPLES);
     expect(groupBys).toEqual(['']);
@@ -707,11 +675,7 @@ describe('ExploreToolbar', () => {
       mode = useQueryParamsMode();
       return <ExploreToolbar />;
     }
-    render(
-      <Wrapper>
-        <Component />
-      </Wrapper>
-    );
+    render(<Component />, {additionalWrapper: Wrapper});
 
     expect(mode).toEqual(Mode.SAMPLES);
     expect(groupBys).toEqual(['']);
@@ -731,11 +695,7 @@ describe('ExploreToolbar', () => {
       aggregateFields = useQueryParamsAggregateFields();
       return <ExploreToolbar />;
     }
-    render(
-      <Wrapper>
-        <Component />
-      </Wrapper>
-    );
+    render(<Component />, {additionalWrapper: Wrapper});
 
     expect(aggregateFields).toEqual([
       {groupBy: ''},
@@ -759,11 +719,7 @@ describe('ExploreToolbar', () => {
       sortBys = useQueryParamsSortBys();
       return <ExploreToolbar />;
     }
-    render(
-      <Wrapper>
-        <Component />
-      </Wrapper>
-    );
+    render(<Component />, {additionalWrapper: Wrapper});
 
     const section = screen.getByTestId('section-sort-by');
 
@@ -816,11 +772,7 @@ describe('ExploreToolbar', () => {
       sortBys = useQueryParamsAggregateSortBys();
       return <ExploreToolbar />;
     }
-    render(
-      <Wrapper>
-        <Component />
-      </Wrapper>
-    );
+    render(<Component />, {additionalWrapper: Wrapper});
 
     act(() => setMode(Mode.AGGREGATE));
 
@@ -893,11 +845,7 @@ describe('ExploreToolbar', () => {
       return <ExploreToolbar />;
     }
 
-    render(
-      <Wrapper>
-        <Component />
-      </Wrapper>
-    );
+    render(<Component />, {additionalWrapper: Wrapper});
 
     const section = screen.getByTestId('section-sort-by');
 
@@ -929,24 +877,20 @@ describe('ExploreToolbar', () => {
       return <ExploreToolbar />;
     }
     act(() => {
-      render(
-        <Wrapper>
-          <Component />
-        </Wrapper>,
-        {
-          organization,
-          initialRouterConfig: {
-            location: {
-              pathname: '/traces/',
-              query: {
-                visualize: encodeURIComponent(
-                  '{"chartType":1,"yAxes":["p95(span.duration)"]}'
-                ),
-              },
+      render(<Component />, {
+        additionalWrapper: Wrapper,
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: '/traces/',
+            query: {
+              visualize: encodeURIComponent(
+                '{"chartType":1,"yAxes":["p95(span.duration)"]}'
+              ),
             },
           },
-        }
-      );
+        },
+      });
     });
 
     const section = screen.getByTestId('section-save-as');
@@ -960,24 +904,20 @@ describe('ExploreToolbar', () => {
     function Component() {
       return <ExploreToolbar />;
     }
-    const {router} = render(
-      <Wrapper>
-        <Component />
-      </Wrapper>,
-      {
-        organization,
-        initialRouterConfig: {
-          location: {
-            pathname: '/traces/',
-            query: {
-              visualize: encodeURIComponent(
-                '{"chartType":1,"yAxes":["p95(span.duration)"]}'
-              ),
-            },
+    const {router} = render(<Component />, {
+      additionalWrapper: Wrapper,
+      organization,
+      initialRouterConfig: {
+        location: {
+          pathname: '/traces/',
+          query: {
+            visualize: encodeURIComponent(
+              '{"chartType":1,"yAxes":["p95(span.duration)"]}'
+            ),
           },
         },
-      }
-    );
+      },
+    });
 
     await userEvent.click(screen.getByRole('button', {name: 'Add Chart'}));
 
@@ -1001,24 +941,20 @@ describe('ExploreToolbar', () => {
     function Component() {
       return <ExploreToolbar />;
     }
-    const {router} = render(
-      <Wrapper>
-        <Component />
-      </Wrapper>,
-      {
-        organization,
-        initialRouterConfig: {
-          location: {
-            pathname: '/traces/',
-            query: {
-              visualize: encodeURIComponent(
-                '{"chartType":1,"yAxes":["avg(span.duration)"]}'
-              ),
-            },
+    const {router} = render(<Component />, {
+      additionalWrapper: Wrapper,
+      organization,
+      initialRouterConfig: {
+        location: {
+          pathname: '/traces/',
+          query: {
+            visualize: encodeURIComponent(
+              '{"chartType":1,"yAxes":["avg(span.duration)"]}'
+            ),
           },
         },
-      }
-    );
+      },
+    });
 
     const section = screen.getByTestId('section-save-as');
 
@@ -1047,24 +983,20 @@ describe('ExploreToolbar', () => {
     function Component() {
       return <ExploreToolbar />;
     }
-    render(
-      <Wrapper>
-        <Component />
-      </Wrapper>,
-      {
-        organization: orgWithoutAlerts,
-        initialRouterConfig: {
-          location: {
-            pathname: '/traces/',
-            query: {
-              visualize: encodeURIComponent(
-                '{"chartType":1,"yAxes":["avg(span.duration)"]}'
-              ),
-            },
+    render(<Component />, {
+      additionalWrapper: Wrapper,
+      organization: orgWithoutAlerts,
+      initialRouterConfig: {
+        location: {
+          pathname: '/traces/',
+          query: {
+            visualize: encodeURIComponent(
+              '{"chartType":1,"yAxes":["avg(span.duration)"]}'
+            ),
           },
         },
-      }
-    );
+      },
+    });
 
     const section = screen.getByTestId('section-save-as');
 
@@ -1079,24 +1011,20 @@ describe('ExploreToolbar', () => {
     function Component() {
       return <ExploreToolbar />;
     }
-    render(
-      <Wrapper>
-        <Component />
-      </Wrapper>,
-      {
-        organization,
-        initialRouterConfig: {
-          location: {
-            pathname: '/traces/',
-            query: {
-              visualize: encodeURIComponent(
-                '{"chartType":1,"yAxes":["count(span.duration)"]}'
-              ),
-            },
+    render(<Component />, {
+      additionalWrapper: Wrapper,
+      organization,
+      initialRouterConfig: {
+        location: {
+          pathname: '/traces/',
+          query: {
+            visualize: encodeURIComponent(
+              '{"chartType":1,"yAxes":["count(span.duration)"]}'
+            ),
           },
         },
-      }
-    );
+      },
+    });
 
     const section = screen.getByTestId('section-save-as');
 
@@ -1157,28 +1085,24 @@ describe('ExploreToolbar', () => {
       return <ExploreToolbar />;
     }
 
-    const {router} = render(
-      <Wrapper>
-        <Component />
-      </Wrapper>,
-      {
-        organization,
-        initialRouterConfig: {
-          location: {
-            pathname: '/traces/',
-            query: {
-              query: '',
-              visualize: '{"chartType":1,"yAxes":["count(span.duration)"]}',
-              groupBy: 'span.op',
-              sort: '-count(span.duration)',
-              field: 'count(span.duration)',
-              id: '123',
-              mode: 'aggregate',
-            },
+    const {router} = render(<Component />, {
+      additionalWrapper: Wrapper,
+      organization,
+      initialRouterConfig: {
+        location: {
+          pathname: '/traces/',
+          query: {
+            query: '',
+            visualize: '{"chartType":1,"yAxes":["count(span.duration)"]}',
+            groupBy: 'span.op',
+            sort: '-count(span.duration)',
+            field: 'count(span.duration)',
+            id: '123',
+            mode: 'aggregate',
           },
         },
-      }
-    );
+      },
+    });
     screen.getByRole('button', {name: /save as/i});
     const section = screen.getByTestId('section-sort-by');
     await userEvent.click(within(section).getByRole('button', {name: 'Desc'}));

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -36,7 +36,7 @@ jest.mock('sentry/actionCreators/modal');
 
 describe('ExploreToolbar', () => {
   const organization = OrganizationFixture({
-    features: ['dashboards-edit'],
+    features: ['dashboards-edit', 'incidents'],
   });
 
   beforeEach(() => {
@@ -1040,6 +1040,39 @@ describe('ExploreToolbar', () => {
       query: '',
       statsPeriod: '7d',
     });
+  });
+
+  it('disables the alert option when the org lacks metric alerts', async () => {
+    const orgWithoutAlerts = OrganizationFixture({features: ['dashboards-edit']});
+    function Component() {
+      return <ExploreToolbar />;
+    }
+    render(
+      <Wrapper>
+        <Component />
+      </Wrapper>,
+      {
+        organization: orgWithoutAlerts,
+        initialRouterConfig: {
+          location: {
+            pathname: '/traces/',
+            query: {
+              visualize: encodeURIComponent(
+                '{"chartType":1,"yAxes":["avg(span.duration)"]}'
+              ),
+            },
+          },
+        },
+      }
+    );
+
+    const section = screen.getByTestId('section-save-as');
+
+    await userEvent.click(within(section).getByRole('button', {name: /save as/i}));
+
+    expect(
+      within(section).getByRole('menuitemradio', {name: 'Alert for'})
+    ).toHaveAttribute('aria-disabled', 'true');
   });
 
   it('add to dashboard options correctly', async () => {

--- a/static/app/views/explore/toolbar/toolbarSaveAs.tsx
+++ b/static/app/views/explore/toolbar/toolbarSaveAs.tsx
@@ -160,7 +160,7 @@ export function ToolbarSaveAs() {
     },
   });
 
-  items.push(getSaveAsAlertMenuItem({organization, alertsUrls}));
+  items.push(getSaveAsAlertMenuItem({organization, alertsUrls, submenu: true}));
 
   const disableAddToDashboard = !organization.features.includes('dashboards-edit');
 

--- a/static/app/views/explore/toolbar/toolbarSaveAs.tsx
+++ b/static/app/views/explore/toolbar/toolbarSaveAs.tsx
@@ -46,6 +46,7 @@ import {
 import {Mode} from 'sentry/views/explore/queryParams/mode';
 import {isVisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
 import {TraceItemDataset} from 'sentry/views/explore/types';
+import {getSaveAsAlertMenuItem} from 'sentry/views/explore/utils/saveAsAlertMenuItem';
 import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
 
 export function ToolbarSaveAs() {
@@ -159,18 +160,7 @@ export function ToolbarSaveAs() {
     },
   });
 
-  const newAlertLabel = organization.features.includes('workflow-engine-ui')
-    ? t('Monitor for')
-    : t('Alert for');
-
-  items.push({
-    key: 'create-alert',
-    label: newAlertLabel,
-    textValue: newAlertLabel,
-    children: alertsUrls ?? [],
-    disabled: !alertsUrls || alertsUrls.length === 0,
-    submenu: true,
-  });
+  items.push(getSaveAsAlertMenuItem({organization, alertsUrls}));
 
   const disableAddToDashboard = !organization.features.includes('dashboards-edit');
 

--- a/static/app/views/explore/utils/saveAsAlertMenuItem.spec.tsx
+++ b/static/app/views/explore/utils/saveAsAlertMenuItem.spec.tsx
@@ -1,0 +1,74 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {
+  getMetricAlertsUpsellTooltip,
+  getSaveAsAlertMenuItem,
+} from 'sentry/views/explore/utils/saveAsAlertMenuItem';
+
+describe('getMetricAlertsUpsellTooltip', () => {
+  it('returns undefined when the organization has metric alerts', () => {
+    const organization = OrganizationFixture({features: ['incidents']});
+
+    expect(getMetricAlertsUpsellTooltip(organization)).toBeUndefined();
+  });
+
+  it('returns an alert upsell message when metric alerts are unavailable', () => {
+    const organization = OrganizationFixture({features: []});
+
+    expect(getMetricAlertsUpsellTooltip(organization)).toBe(
+      'Alerts are not available on your current plan.'
+    );
+  });
+
+  it('returns a monitor upsell message when workflow engine is enabled', () => {
+    const organization = OrganizationFixture({features: ['workflow-engine-ui']});
+
+    expect(getMetricAlertsUpsellTooltip(organization)).toBe(
+      'Monitors are not available on your current plan.'
+    );
+  });
+});
+
+describe('getSaveAsAlertMenuItem', () => {
+  const alertsUrls = [{key: 'count()-0', label: 'count()', to: '/alert/'}];
+
+  it('is enabled with children when the organization has metric alerts', () => {
+    const organization = OrganizationFixture({features: ['incidents']});
+
+    const item = getSaveAsAlertMenuItem({organization, alertsUrls});
+
+    expect(item.label).toBe('Alert for');
+    expect(item.disabled).toBe(false);
+    expect(item.tooltip).toBeUndefined();
+    expect(item.children).toEqual(alertsUrls);
+  });
+
+  it('is disabled with an upsell tooltip when metric alerts are unavailable', () => {
+    const organization = OrganizationFixture({features: []});
+
+    const item = getSaveAsAlertMenuItem({organization, alertsUrls});
+
+    expect(item.disabled).toBe(true);
+    expect(item.tooltip).toBe('Alerts are not available on your current plan.');
+    expect(item.children).toEqual([]);
+  });
+
+  it('is disabled when the organization has metric alerts but no aggregates', () => {
+    const organization = OrganizationFixture({features: ['incidents']});
+
+    const item = getSaveAsAlertMenuItem({organization, alertsUrls: []});
+
+    expect(item.disabled).toBe(true);
+    expect(item.tooltip).toBeUndefined();
+  });
+
+  it('uses the monitor label when workflow engine is enabled', () => {
+    const organization = OrganizationFixture({
+      features: ['incidents', 'workflow-engine-ui'],
+    });
+
+    const item = getSaveAsAlertMenuItem({organization, alertsUrls});
+
+    expect(item.label).toBe('Monitor for');
+  });
+});

--- a/static/app/views/explore/utils/saveAsAlertMenuItem.spec.tsx
+++ b/static/app/views/explore/utils/saveAsAlertMenuItem.spec.tsx
@@ -50,7 +50,7 @@ describe('getSaveAsAlertMenuItem', () => {
   it('is enabled with children when the organization has metric alerts', () => {
     const organization = OrganizationFixture({features: ['incidents']});
 
-    const item = getSaveAsAlertMenuItem({organization, alertsUrls});
+    const item = getSaveAsAlertMenuItem({organization, alertsUrls, submenu: true});
 
     expect(item).toEqual(
       expect.objectContaining({
@@ -65,7 +65,7 @@ describe('getSaveAsAlertMenuItem', () => {
   it('is disabled with an upsell tooltip when metric alerts are unavailable', () => {
     const organization = OrganizationFixture({features: []});
 
-    const item = getSaveAsAlertMenuItem({organization, alertsUrls});
+    const item = getSaveAsAlertMenuItem({organization, alertsUrls, submenu: true});
 
     expect(item).toEqual(
       expect.objectContaining({
@@ -79,7 +79,7 @@ describe('getSaveAsAlertMenuItem', () => {
   it('is disabled when the organization has metric alerts but no aggregates', () => {
     const organization = OrganizationFixture({features: ['incidents']});
 
-    const item = getSaveAsAlertMenuItem({organization, alertsUrls: []});
+    const item = getSaveAsAlertMenuItem({organization, alertsUrls: [], submenu: true});
 
     expect(item.disabled).toBe(true);
     expect(item.tooltip).toBeUndefined();
@@ -90,8 +90,66 @@ describe('getSaveAsAlertMenuItem', () => {
       features: ['incidents', 'workflow-engine-ui'],
     });
 
-    const item = getSaveAsAlertMenuItem({organization, alertsUrls});
+    const item = getSaveAsAlertMenuItem({organization, alertsUrls, submenu: true});
 
     expect(item.label).toBe('Monitor for');
+  });
+
+  it('uses the given label when one is provided', () => {
+    const organization = OrganizationFixture({features: ['incidents']});
+
+    const item = getSaveAsAlertMenuItem({
+      organization,
+      alertsUrls,
+      submenu: true,
+      label: 'Create an Alert for',
+    });
+
+    expect(item.label).toBe('Create an Alert for');
+  });
+
+  it('returns an actionable item with no children when not a submenu', () => {
+    const organization = OrganizationFixture({features: ['incidents']});
+    const onAction = jest.fn();
+
+    const item = getSaveAsAlertMenuItem({organization, to: '/alert/', onAction});
+
+    expect(item).toEqual(
+      expect.objectContaining({
+        label: 'Create an Alert',
+        disabled: false,
+        tooltip: undefined,
+        to: '/alert/',
+        onAction,
+      })
+    );
+    expect(item.children).toBeUndefined();
+  });
+
+  it('is disabled with an upsell tooltip when not a submenu and metric alerts are unavailable', () => {
+    const organization = OrganizationFixture({features: []});
+
+    const item = getSaveAsAlertMenuItem({
+      organization,
+      to: '/alert/',
+      onAction: jest.fn(),
+    });
+
+    expect(item.disabled).toBe(true);
+    expect(item.tooltip).toBe('Alerts are not available on your current plan.');
+  });
+
+  it('is disabled when the caller disables it for an unrelated reason', () => {
+    const organization = OrganizationFixture({features: ['incidents']});
+
+    const item = getSaveAsAlertMenuItem({
+      organization,
+      disabled: true,
+      to: '/alert/',
+      onAction: jest.fn(),
+    });
+
+    expect(item.disabled).toBe(true);
+    expect(item.tooltip).toBeUndefined();
   });
 });

--- a/static/app/views/explore/utils/saveAsAlertMenuItem.spec.tsx
+++ b/static/app/views/explore/utils/saveAsAlertMenuItem.spec.tsx
@@ -1,6 +1,7 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {
+  getCreateAlertLabel,
   getMetricAlertsUpsellTooltip,
   getSaveAsAlertMenuItem,
 } from 'sentry/views/explore/utils/saveAsAlertMenuItem';
@@ -29,6 +30,20 @@ describe('getMetricAlertsUpsellTooltip', () => {
   });
 });
 
+describe('getCreateAlertLabel', () => {
+  it('returns the alert label when workflow engine is disabled', () => {
+    const organization = OrganizationFixture({features: []});
+
+    expect(getCreateAlertLabel(organization)).toBe('Create an Alert');
+  });
+
+  it('returns the monitor label when workflow engine is enabled', () => {
+    const organization = OrganizationFixture({features: ['workflow-engine-ui']});
+
+    expect(getCreateAlertLabel(organization)).toBe('Create a Monitor');
+  });
+});
+
 describe('getSaveAsAlertMenuItem', () => {
   const alertsUrls = [{key: 'count()-0', label: 'count()', to: '/alert/'}];
 
@@ -37,10 +52,14 @@ describe('getSaveAsAlertMenuItem', () => {
 
     const item = getSaveAsAlertMenuItem({organization, alertsUrls});
 
-    expect(item.label).toBe('Alert for');
-    expect(item.disabled).toBe(false);
-    expect(item.tooltip).toBeUndefined();
-    expect(item.children).toEqual(alertsUrls);
+    expect(item).toEqual(
+      expect.objectContaining({
+        label: 'Alert for',
+        disabled: false,
+        tooltip: undefined,
+        children: alertsUrls,
+      })
+    );
   });
 
   it('is disabled with an upsell tooltip when metric alerts are unavailable', () => {
@@ -48,9 +67,13 @@ describe('getSaveAsAlertMenuItem', () => {
 
     const item = getSaveAsAlertMenuItem({organization, alertsUrls});
 
-    expect(item.disabled).toBe(true);
-    expect(item.tooltip).toBe('Alerts are not available on your current plan.');
-    expect(item.children).toEqual([]);
+    expect(item).toEqual(
+      expect.objectContaining({
+        disabled: true,
+        tooltip: 'Alerts are not available on your current plan.',
+        children: [],
+      })
+    );
   });
 
   it('is disabled when the organization has metric alerts but no aggregates', () => {

--- a/static/app/views/explore/utils/saveAsAlertMenuItem.tsx
+++ b/static/app/views/explore/utils/saveAsAlertMenuItem.tsx
@@ -1,11 +1,31 @@
+import type {LocationDescriptor} from 'history';
+
 import type {MenuItemProps} from 'sentry/components/dropdownMenu';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import {hasMetricAlerts} from 'sentry/views/alerts/utils';
 
-interface SaveAsAlertMenuItemOptions {
-  alertsUrls: MenuItemProps[];
+interface SaveAsAlertMenuItemBaseOptions {
   organization: Organization;
+  disabled?: boolean;
+}
+
+interface SaveAsAlertSubmenuOptions extends SaveAsAlertMenuItemBaseOptions {
+  alertsUrls: MenuItemProps[];
+  submenu: true;
+  label?: string;
+}
+
+interface SaveAsAlertActionOptions extends SaveAsAlertMenuItemBaseOptions {
+  onAction: () => void;
+  to: LocationDescriptor;
+  submenu?: false;
+}
+
+type SaveAsAlertMenuItemOptions = SaveAsAlertSubmenuOptions | SaveAsAlertActionOptions;
+
+function isMonitorOrg(organization: Organization): boolean {
+  return organization.features.includes('workflow-engine-ui');
 }
 
 export function getMetricAlertsUpsellTooltip(
@@ -14,32 +34,53 @@ export function getMetricAlertsUpsellTooltip(
   if (hasMetricAlerts(organization)) {
     return undefined;
   }
-  return organization.features.includes('workflow-engine-ui')
+  return isMonitorOrg(organization)
     ? t('Monitors are not available on your current plan.')
     : t('Alerts are not available on your current plan.');
 }
 
 export function getCreateAlertLabel(organization: Organization): string {
-  return organization.features.includes('workflow-engine-ui')
-    ? t('Create a Monitor')
-    : t('Create an Alert');
+  return isMonitorOrg(organization) ? t('Create a Monitor') : t('Create an Alert');
 }
 
-export function getSaveAsAlertMenuItem({
-  organization,
-  alertsUrls,
-}: SaveAsAlertMenuItemOptions): MenuItemProps {
-  const isMonitor = organization.features.includes('workflow-engine-ui');
-  const label = isMonitor ? t('Monitor for') : t('Alert for');
-  const hasAccess = hasMetricAlerts(organization);
+export function getCreateAlertForLabel(organization: Organization): string {
+  return isMonitorOrg(organization)
+    ? t('Create a Monitor for')
+    : t('Create an Alert for');
+}
+
+export function getSaveAsAlertMenuItem(
+  options: SaveAsAlertMenuItemOptions
+): MenuItemProps {
+  const {organization, disabled} = options;
+  const tooltip = getMetricAlertsUpsellTooltip(organization);
+  const hasAccess = !tooltip;
+
+  if (options.submenu) {
+    const {alertsUrls} = options;
+    const label =
+      options.label ?? (isMonitorOrg(organization) ? t('Monitor for') : t('Alert for'));
+
+    return {
+      key: 'create-alert',
+      label,
+      textValue: label,
+      children: hasAccess ? alertsUrls : [],
+      disabled: disabled || !hasAccess || alertsUrls.length === 0,
+      tooltip,
+      submenu: true,
+    };
+  }
+
+  const label = getCreateAlertLabel(organization);
 
   return {
     key: 'create-alert',
     label,
     textValue: label,
-    children: hasAccess ? alertsUrls : [],
-    disabled: !hasAccess || alertsUrls.length === 0,
-    tooltip: getMetricAlertsUpsellTooltip(organization),
-    submenu: true,
+    disabled: disabled || !hasAccess,
+    tooltip,
+    to: options.to,
+    onAction: options.onAction,
   };
 }

--- a/static/app/views/explore/utils/saveAsAlertMenuItem.tsx
+++ b/static/app/views/explore/utils/saveAsAlertMenuItem.tsx
@@ -1,0 +1,41 @@
+import type {MenuItemProps} from 'sentry/components/dropdownMenu';
+import {t} from 'sentry/locale';
+import type {Organization} from 'sentry/types/organization';
+import {hasMetricAlerts} from 'sentry/views/alerts/utils';
+
+interface SaveAsAlertMenuItemOptions {
+  alertsUrls: MenuItemProps[];
+  organization: Organization;
+}
+
+// Spans, logs, and metrics alerts all route through the metric alert flow,
+// which is gated by the `incidents` feature (absent on the developer plan).
+export function getMetricAlertsUpsellTooltip(
+  organization: Organization
+): string | undefined {
+  if (hasMetricAlerts(organization)) {
+    return undefined;
+  }
+  return organization.features.includes('workflow-engine-ui')
+    ? t('Monitors are not available on your current plan.')
+    : t('Alerts are not available on your current plan.');
+}
+
+export function getSaveAsAlertMenuItem({
+  organization,
+  alertsUrls,
+}: SaveAsAlertMenuItemOptions): MenuItemProps {
+  const isMonitor = organization.features.includes('workflow-engine-ui');
+  const label = isMonitor ? t('Monitor for') : t('Alert for');
+  const hasAccess = hasMetricAlerts(organization);
+
+  return {
+    key: 'create-alert',
+    label,
+    textValue: label,
+    children: hasAccess ? alertsUrls : [],
+    disabled: !hasAccess || alertsUrls.length === 0,
+    tooltip: getMetricAlertsUpsellTooltip(organization),
+    submenu: true,
+  };
+}

--- a/static/app/views/explore/utils/saveAsAlertMenuItem.tsx
+++ b/static/app/views/explore/utils/saveAsAlertMenuItem.tsx
@@ -19,6 +19,12 @@ export function getMetricAlertsUpsellTooltip(
     : t('Alerts are not available on your current plan.');
 }
 
+export function getCreateAlertLabel(organization: Organization): string {
+  return organization.features.includes('workflow-engine-ui')
+    ? t('Create a Monitor')
+    : t('Create an Alert');
+}
+
 export function getSaveAsAlertMenuItem({
   organization,
   alertsUrls,

--- a/static/app/views/explore/utils/saveAsAlertMenuItem.tsx
+++ b/static/app/views/explore/utils/saveAsAlertMenuItem.tsx
@@ -8,8 +8,6 @@ interface SaveAsAlertMenuItemOptions {
   organization: Organization;
 }
 
-// Spans, logs, and metrics alerts all route through the metric alert flow,
-// which is gated by the `incidents` feature (absent on the developer plan).
 export function getMetricAlertsUpsellTooltip(
   organization: Organization
 ): string | undefined {


### PR DESCRIPTION
Good: alert and monitor creation in Explore routes through the metric alert flow, which is gated by the `incidents` feature and is unavailable on the developer plan. So if users don't have access they won't be allowed to create the things.

Not good: the alert/monitor _menu_ entries weren't gated on that, so they always get shown regardless of permissions. So users are given a link in the menu but not able to finish that flow.

This disables the alert/monitor menu items with an explanatory tooltip when the org/user lacks metric alerts access:

<img width="739" height="405" alt="image" src="https://github.com/user-attachments/assets/761a1c8a-b875-4d1a-a271-c82e6f912426" />

Closes LOGS-746.