### PR TITLE
fix(ourlogs): break ordering ties with timestamp.sequence

### DIFF
--- a/src/sentry/search/eap/constants.py
+++ b/src/sentry/search/eap/constants.py
@@ -233,6 +233,7 @@ SENTRY_INTERNAL_PREFIXES = ["__sentry_internal", "sentry._internal."]
 
 # public alias that we want to be sure are consistent
 TIMESTAMP_PRECISE_ALIAS = "timestamp_precise"
+TIMESTAMP_SEQUENCE_ALIAS = "timestamp.sequence"
 TIMESTAMP_ALIAS = "timestamp"
 TRACE_ALIAS = "trace"
 

--- a/src/sentry/search/eap/ourlogs/attributes.py
+++ b/src/sentry/search/eap/ourlogs/attributes.py
@@ -73,6 +73,11 @@ OURLOG_ATTRIBUTE_DEFINITIONS = {
             search_type="number",
         ),
         ResolvedAttribute(
+            public_alias=constants.TIMESTAMP_SEQUENCE_ALIAS,
+            internal_name="sentry.timestamp.sequence",
+            search_type="integer",
+        ),
+        ResolvedAttribute(
             public_alias="payload_size",
             internal_name="sentry.payload_size_bytes",
             search_type="byte",

--- a/src/sentry/snuba/ourlogs.py
+++ b/src/sentry/snuba/ourlogs.py
@@ -63,12 +63,6 @@ class OurLogs(rpc_dataset_common.RPCBase):
                 if "id" not in selected_columns:
                     selected_columns.append("id")
             else:
-                # SDKs emit a per-millisecond sentry.timestamp.sequence counter so
-                # logs sharing a millisecond timestamp keep their emission order.
-                # Relay folds it into timestamp_precise as added nanoseconds, but
-                # timestamp_precise is a float64 whose precision at epoch-nanosecond
-                # magnitudes is coarser than that shift, so same-millisecond rows
-                # collapse back to a tie. Order by the integer sequence to break it.
                 orderby.append(direction + constants.TIMESTAMP_SEQUENCE_ALIAS)
                 if constants.TIMESTAMP_SEQUENCE_ALIAS not in selected_columns:
                     selected_columns.append(constants.TIMESTAMP_SEQUENCE_ALIAS)

--- a/src/sentry/snuba/ourlogs.py
+++ b/src/sentry/snuba/ourlogs.py
@@ -63,12 +63,12 @@ class OurLogs(rpc_dataset_common.RPCBase):
                 if "id" not in selected_columns:
                     selected_columns.append("id")
             else:
-                # Some SDK environments (e.g. Cloudflare Workers) can't produce
-                # sub-millisecond timestamps, so logs emitted in quick succession
-                # share an identical timestamp_precise. The SDK emits a monotonic
-                # sequence attribute to break those ties in emission order. Flex time
-                # sampling can't page over this mostly-absent attribute, so it relies
-                # on the item id above for strict ordering instead.
+                # SDKs emit a per-millisecond sentry.timestamp.sequence counter so
+                # logs sharing a millisecond timestamp keep their emission order.
+                # Relay folds it into timestamp_precise as added nanoseconds, but
+                # timestamp_precise is a float64 whose precision at epoch-nanosecond
+                # magnitudes is coarser than that shift, so same-millisecond rows
+                # collapse back to a tie. Order by the integer sequence to break it.
                 orderby.append(direction + constants.TIMESTAMP_SEQUENCE_ALIAS)
                 if constants.TIMESTAMP_SEQUENCE_ALIAS not in selected_columns:
                     selected_columns.append(constants.TIMESTAMP_SEQUENCE_ALIAS)

--- a/src/sentry/snuba/ourlogs.py
+++ b/src/sentry/snuba/ourlogs.py
@@ -62,6 +62,16 @@ class OurLogs(rpc_dataset_common.RPCBase):
                 orderby.append(direction + "id")
                 if "id" not in selected_columns:
                     selected_columns.append("id")
+            else:
+                # Some SDK environments (e.g. Cloudflare Workers) can't produce
+                # sub-millisecond timestamps, so logs emitted in quick succession
+                # share an identical timestamp_precise. The SDK emits a monotonic
+                # sequence attribute to break those ties in emission order. Flex time
+                # sampling can't page over this mostly-absent attribute, so it relies
+                # on the item id above for strict ordering instead.
+                orderby.append(direction + constants.TIMESTAMP_SEQUENCE_ALIAS)
+                if constants.TIMESTAMP_SEQUENCE_ALIAS not in selected_columns:
+                    selected_columns.append(constants.TIMESTAMP_SEQUENCE_ALIAS)
 
         return cls._run_table_query(
             rpc_dataset_common.TableQuery(

--- a/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
@@ -110,6 +110,59 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase, 
 
         assert meta["dataset"] == self.dataset
 
+    def test_timestamp_sequence_breaks_ties_when_timestamp_precise_is_equal(self) -> None:
+        shared_timestamp = self.ten_mins_ago
+        logs = [
+            self.create_ourlog(
+                {"body": "first"},
+                timestamp=shared_timestamp,
+                attributes={"sentry.timestamp.sequence": 0},
+            ),
+            self.create_ourlog(
+                {"body": "second"},
+                timestamp=shared_timestamp,
+                attributes={"sentry.timestamp.sequence": 1},
+            ),
+            self.create_ourlog(
+                {"body": "third"},
+                timestamp=shared_timestamp,
+                attributes={"sentry.timestamp.sequence": 2},
+            ),
+        ]
+        self.store_eap_items(logs)
+
+        ascending = self.do_request(
+            {
+                "field": ["log.body", "timestamp"],
+                "query": "",
+                "orderby": "timestamp",
+                "project": self.project.id,
+                "dataset": self.dataset,
+            }
+        )
+        descending = self.do_request(
+            {
+                "field": ["log.body", "timestamp"],
+                "query": "",
+                "orderby": "-timestamp",
+                "project": self.project.id,
+                "dataset": self.dataset,
+            }
+        )
+
+        assert ascending.status_code == 200, ascending.content
+        assert descending.status_code == 200, descending.content
+        assert [row["log.body"] for row in ascending.data["data"]] == [
+            "first",
+            "second",
+            "third",
+        ]
+        assert [row["log.body"] for row in descending.data["data"]] == [
+            "third",
+            "second",
+            "first",
+        ]
+
     def test_free_text_wildcard_filter(self) -> None:
         logs = [
             self.create_ourlog(
@@ -482,6 +535,7 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase, 
                 constants.TIMESTAMP_PRECISE_ALIAS: pytest.approx(
                     source.attributes["sentry.timestamp_precise"].int_value
                 ),
+                constants.TIMESTAMP_SEQUENCE_ALIAS: None,
                 "observed_timestamp": source.attributes[
                     "sentry.observed_timestamp_nanos"
                 ].string_value,
@@ -1102,6 +1156,7 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase, 
             {
                 "timestamp": ANY,
                 "timestamp_precise": ANY,
+                "timestamp.sequence": None,
                 "message": "log",
             }
         ]

--- a/tests/snuba/api/endpoints/test_organization_trace_logs.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_logs.py
@@ -308,6 +308,7 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsEndpointTestBase):
         assert orderby == [
             constants.TIMESTAMP_ALIAS,
             constants.TIMESTAMP_PRECISE_ALIAS,
+            constants.TIMESTAMP_SEQUENCE_ALIAS,
         ]
 
     def test_timestamp_precise_alias_and_orderby_desc(self) -> None:
@@ -348,6 +349,7 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsEndpointTestBase):
         assert orderby == [
             f"-{constants.TIMESTAMP_ALIAS}",
             f"-{constants.TIMESTAMP_PRECISE_ALIAS}",
+            f"-{constants.TIMESTAMP_SEQUENCE_ALIAS}",
         ]
 
     def test_replay_id_simple(self) -> None:


### PR DESCRIPTION
SDKs emit a per-millisecond `sentry.timestamp.sequence` counter so logs sharing a millisecond timestamp keep their emission order.

`timestamp_precise` can't recover that order on its own: it's stored as a float64, and at current epoch values a float64 only resolves down to ~256ns. So same-millisecond logs aren't reliably distinguishable by `timestamp_precise`. Wamp wump.

This adds the `timestamp.sequence` alias and orders by it as a tiebreaker after `timestamp` and `timestamp_precise`. So we get back the nice ordering it's meant for.

~#120452 contains corresponding frontend changes to hide it in the UI. That PR should land first so we don't get an awkward blip of showing it to users.~ ✅ 

Starts on LOGS-569.
