### PR TITLE
fix(ourlogs): hide timestamp.sequence field

### DIFF
--- a/static/app/views/explore/logs/constants.tsx
+++ b/static/app/views/explore/logs/constants.tsx
@@ -58,6 +58,7 @@ const AlwaysHiddenLogFields: OurLogFieldKey[] = [
   OurLogKnownFieldKey.SEVERITY_NUMBER,
   OurLogKnownFieldKey.ITEM_TYPE,
   OurLogKnownFieldKey.TIMESTAMP_PRECISE,
+  OurLogKnownFieldKey.TIMESTAMP_SEQUENCE,
   'project.id',
   'project_id', // these are both aliases that might show up
 ];

--- a/static/app/views/explore/logs/types.tsx
+++ b/static/app/views/explore/logs/types.tsx
@@ -25,6 +25,7 @@ export enum OurLogKnownFieldKey {
   SPAN_ID = 'span_id',
   TIMESTAMP = 'timestamp',
   TIMESTAMP_PRECISE = 'timestamp_precise',
+  TIMESTAMP_SEQUENCE = 'timestamp.sequence',
   OBSERVED_TIMESTAMP_PRECISE = 'observed_timestamp',
   LOGGER = 'logger.name',
 


### PR DESCRIPTION
#120451 will expose an internal `timestamp.sequence` attribute used to break log ordering ties when logs share an identical `timestamp_precise`. It's an ordering aid, not something users should see, so this hides it from the logs UI alongside the other internal timestamp fields.

This PR should land first, before #120451, so users never see the field.

Closes LOGS-569.
