### PR TITLE
fix(dashboards): Show correct types for Application Metrics filters

### DIFF
--- a/static/app/views/explore/hooks/useTraceItemAttributes.spec.tsx
+++ b/static/app/views/explore/hooks/useTraceItemAttributes.spec.tsx
@@ -250,4 +250,38 @@ describe('useTraceItemAttributes number filtering', () => {
     expect('custom_metric' in result.current.attributes).toBe(true);
     expect('another_metric' in result.current.attributes).toBe(true);
   });
+
+  it('keeps both a numeric metric and a boolean tag that share a base key for trace metrics', async () => {
+    const organization = OrganizationFixture();
+
+    // Numeric metric and an unrelated boolean tag sharing a base key.
+    addAttributeMock([
+      {attributeType: 'number', key: 'value', name: 'value'},
+      {attributeType: 'boolean', key: 'tags[value,boolean]', name: 'value'},
+    ]);
+
+    const {result} = renderHookWithProviders(
+      () => ({
+        number: useTraceItemAttributes(
+          {traceItemType: TraceItemDataset.TRACEMETRICS, enabled: true},
+          'number'
+        ),
+        boolean: useTraceItemAttributes(
+          {traceItemType: TraceItemDataset.TRACEMETRICS, enabled: true},
+          'boolean'
+        ),
+      }),
+      {organization}
+    );
+
+    await waitFor(() => {
+      expect(result.current.number.isLoading).toBe(false);
+      expect(result.current.boolean.isLoading).toBe(false);
+    });
+
+    // The numeric metric survives the dedup instead of being dropped...
+    expect('value' in result.current.number.attributes).toBe(true);
+    // ...and the boolean tag is still present too.
+    expect('tags[value,boolean]' in result.current.boolean.attributes).toBe(true);
+  });
 });

--- a/static/app/views/explore/hooks/useTraceItemAttributes.tsx
+++ b/static/app/views/explore/hooks/useTraceItemAttributes.tsx
@@ -111,7 +111,10 @@ function useTraceItemAttributeConfig({
   }, [data?.booleanAttributes, traceItemType]);
 
   const allNumberAttributes = useMemo(() => {
-    const shouldRemove = booleanBaseKeys.size > 0;
+    // Trace metrics can expose a numeric field and an unrelated boolean tag
+    // sharing a base key (e.g. `value` and `tags[value,boolean]`); keep both.
+    const shouldRemove =
+      traceItemType !== TraceItemDataset.TRACEMETRICS && booleanBaseKeys.size > 0;
     const attributes: TagCollection = {};
     const secondaryAliases: TagCollection = {};
 


### PR DESCRIPTION
Application Metrics (trace metrics) global filters showed a boolean **True/False** value picker for numeric attributes such as the reserved `value` metric.

## Root cause

The `trace-items/attributes/` endpoint returns a numeric metric and an unrelated boolean user tag that share a base key:

```json
{ "key": "value",               "name": "value", "attributeType": "number"  }
{ "key": "tags[value,boolean]", "name": "value", "attributeType": "boolean" }
```

The boolean-preference dedup in `useTraceItemAttributes` (added for spans' `is_transaction`, where number and boolean are the *same* concept) then dropped the numeric variant, leaving only the boolean and demoting the field to a True/False picker.

## Change

Scope that dedup so it does not run for trace metrics. The numeric metric and the boolean tag are genuinely different columns there, so both are kept with their correct types. Spans behavior is unchanged.

As a result the Application Metrics filter picker now offers both `value` (Number) and `value` (Boolean); the numeric one yields a normal value picker and the boolean one yields True/False.

Fixes DAIN-1788