### PR TITLE
feat(autofix): Carry review id and state on PR review feedback

### DIFF
--- a/src/sentry/seer/autofix/pr_iteration/feedback_sources/github_comment.py
+++ b/src/sentry/seer/autofix/pr_iteration/feedback_sources/github_comment.py
@@ -135,6 +135,13 @@ class GithubPrReviewCommentFeedbackSource(_GithubPrCommentFeedbackSourceBase):
     line: int | None = None
     start_line: int | None = None
     diff_hunk: str | None = None
+    # The GitHub review this inline comment was submitted as part of, shared with
+    # the review's ``GithubPrReviewBodyFeedbackSource.review_id`` so the UI can
+    # group a review's summary body and its inline comments under one parent. The
+    # review's state lives on that body source (the review's representation), not
+    # here. Optional: an inline comment delivered outside a submitted review has
+    # none, and feedback serialized before this field predates it.
+    review_id: int | None = None
     # Whether the review author is a bot (e.g. a test-coverage bot). Bot reviews
     # count toward the automated-iteration streak cap; human reviews reset it.
     author_is_bot: bool = False
@@ -207,6 +214,11 @@ class GithubPrReviewBodyFeedbackSource(FeedbackSourceBase):
     type: Literal["github-pr-review-body"] = "github-pr-review-body"
     # The GitHub review id, used to dedupe re-delivered reviews.
     review_id: int | None = None
+    # The submitted review's state — ``approved`` / ``changes_requested`` /
+    # ``commented`` / ``dismissed`` / ``pending`` (scm ``PullRequestReviewState``).
+    # Stored as a plain ``str`` so a future provider state can't break
+    # deserialization of replayed feedback.
+    review_state: str | None = None
     body: str = ""
     html_url: str | None = None
     # Whether the review author is a bot (e.g. a test-coverage bot). Bot reviews

--- a/src/sentry/tasks/seer/pr_iteration.py
+++ b/src/sentry/tasks/seer/pr_iteration.py
@@ -601,13 +601,17 @@ def _build_review_feedback(
     *,
     review_id: int,
     review_html_url: str | None,
+    review_state: str | None,
     author_is_bot: bool,
 ) -> list[Feedback]:
     """Normalize a submitted review into feedback items.
 
     Each inline comment becomes an anchored ``GithubPrReviewCommentFeedbackSource``
     (command gate relaxed) and the review's summary body, if any, becomes its own
-    non-anchored ``GithubPrReviewBodyFeedbackSource``.
+    non-anchored ``GithubPrReviewBodyFeedbackSource``. Every item carries the
+    shared ``review_id`` so the UI can group them under one review; the review's
+    ``review_state`` (approved / changes requested / commented) lives on the body
+    source, the review's own representation.
 
     ``author_is_bot`` marks the resulting feedback as automated so it counts
     toward the automated-iteration streak cap (see ``automated_iteration_cap_reached``).
@@ -632,13 +636,16 @@ def _build_review_feedback(
             user=GithubPrCommentUser(login=author["username"] if author else None),
         )
         source = GithubPrReviewCommentFeedbackSource(
-            comment=review_comment, author_is_bot=author_is_bot
+            comment=review_comment,
+            review_id=review_id,
+            author_is_bot=author_is_bot,
         )
         feedback.append(Feedback(source=source))
 
     if review_body:
         body_source = GithubPrReviewBodyFeedbackSource(
             review_id=review_id,
+            review_state=review_state,
             body=review_body,
             html_url=review_html_url,
             author_is_bot=author_is_bot,
@@ -768,6 +775,7 @@ def trigger_pr_iteration_from_review(
     review = _fetch_review_body(scm, pr_number=pr_number, review_id=review_id)
     review_body = (review.get("body") or "").strip() if review else None
     review_html_url = review.get("html_url") if review else None
+    review_state = review.get("state") if review else None
 
     # Skip genuinely empty reviews — no body text AND no inline comments — there
     # is nothing to act on (e.g. a bare approve with no message). A review with
@@ -781,6 +789,7 @@ def trigger_pr_iteration_from_review(
         review_body,
         review_id=review_id,
         review_html_url=review_html_url,
+        review_state=review_state,
         author_is_bot=author_is_bot,
     )
     if not feedback_items:

--- a/tests/sentry/seer/autofix/test_pr_iteration_review.py
+++ b/tests/sentry/seer/autofix/test_pr_iteration_review.py
@@ -200,7 +200,12 @@ class TriggerPrIterationFromReviewTest(TestCase):
         self.mock_make_scm.return_value = MagicMock(spec=_ScmStub)
         self.mock_actions.get_review_comments.return_value = self._paginated([])
         self.mock_actions.get_pull_request_review.return_value = self._review_result(
-            {"id": "500", "html_url": "https://x/500", "body": "overall summary"}
+            {
+                "id": "500",
+                "html_url": "https://x/500",
+                "body": "overall summary",
+                "state": "changes_requested",
+            }
         )
         # Default the author to a repo collaborator with write access; tests that
         # exercise the gate override this.
@@ -303,6 +308,11 @@ class TriggerPrIterationFromReviewTest(TestCase):
         assert len(comment_sources) == 2
         assert len(body_sources) == 1
         assert body_sources[0].body == "overall summary"
+        # The shared review id lands on every item from the review — both inline
+        # comments and the body — so the UI can group them under one review. The
+        # review's state lives on the body source (the review's representation).
+        assert all(s.review_id == 500 for s in sources)
+        assert body_sources[0].review_state == "changes_requested"
         # The SCM ``url`` maps onto the source's ``html_url``; the UI drops
         # comments without it, so this is what surfaces the feedback.
         assert {s.comment.html_url for s in comment_sources} == {
@@ -391,6 +401,7 @@ class TriggerPrIterationFromReviewTest(TestCase):
         assert isinstance(source, GithubPrReviewBodyFeedbackSource)
         assert source.body == "overall summary"
         assert source.review_id == 500
+        assert source.review_state == "changes_requested"
 
         # A body-only review has no inline comment to react to.
         self.mock_actions.create_review_comment_reaction.assert_not_called()
@@ -455,6 +466,9 @@ class TriggerPrIterationFromReviewTest(TestCase):
         self.mock_enqueue.assert_called_once()
         source = self.mock_enqueue.call_args.kwargs["feedback"].source
         assert isinstance(source, GithubPrReviewCommentFeedbackSource)
+        # The review 404'd, but the inline comment still flows through, tagged with
+        # its review id for grouping (no body source is emitted to carry state).
+        assert source.review_id == 500
 
     def test_skips_when_no_agent_state(self) -> None:
         self.mock_get_state.return_value = None


### PR DESCRIPTION
## Summary

A submitted GitHub PR review is flattened into independent feedback items — one per inline comment plus one for the summary body — with nothing tying them together. The inline-comment source also dropped the review id it was built from, so the two couldn't be correlated after the fact.

This change threads through the metadata a UI needs to **group a review's body and inline comments under one parent** and **label the group by review state**:

- **`review_id`** is now set on `GithubPrReviewCommentFeedbackSource` (it was already on the body source, but discarded when building the comment source). This is the shared join key that links every item of a review.
- **`review_state`** (`approved` / `changes_requested` / `commented` / `dismissed` / `pending`) is added to the **body source** — the review's own representation — read off the `Review` the task already fetches. No extra API call, no change to the task signature or the listener.

## Design: state lives on the body source, not the comment

`review_state` is a property of the *review*, not of an individual comment, so it lives only on `GithubPrReviewBodyFeedbackSource`. The comment source carries just `review_id` (the grouping key).

One consequence for the consuming UI: a comment-only review (changes requested, inline comments, no summary) emits comments with a `review_id` but **no body source** — so there's no state for that group. The UI should treat the group's state label as **optional**: group by `review_id`, render the state when a body source is present, omit it otherwise.

## Why `review_state` is stored as `str`, not the scm `Literal`

These feedback items are serialized into `SeerRunState` and replayed later. A strict `Literal` would turn a future GitHub/scm state value into a deserialization failure on old or in-flight blobs. The producer stays type-safe (it reads from the typed `Review`); only the at-rest field is loosened. This matches the existing `pr_metrics` `review_state: str` convention.

Both new fields are optional (`None` default) and additive, so previously-serialized feedback deserializes unchanged.

## Follow-up

A frontend PR will consume `review_id` + `review_state` to render the grouped, state-labelled feedback list. Backend lands first (frontend/backend are not atomically deployed).

## Test plan

- Extended `tests/sentry/seer/autofix/test_pr_iteration_review.py`:
  - batch review asserts `review_id` lands on **all** items (comments + body), and `review_state` on the body source
  - body-only review asserts state on the body source
  - review-404 path asserts the inline comment still flows through tagged with its `review_id` (no body source to carry state)
- `mypy` clean on all changed files.
- ⚠️ Could not run the suite locally (it requires Redis/devservices, which I don't spin up here) — relying on CI to execute the assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)