### PR TITLE
ref(issues): Make preview priority and assignee icon-only

### DIFF
--- a/static/app/views/issueDetails/header/assigneeSelector.tsx
+++ b/static/app/views/issueDetails/header/assigneeSelector.tsx
@@ -36,8 +36,7 @@ interface GroupHeaderAssigneeSelectorProps {
   group: Group;
   project: Project;
   /**
-   * Show the assignee name next to the avatar. On by default; disable for compact
-   * surfaces (e.g. the issue preview) that want an avatar-only control.
+   * Show the assignee name next to the avatar. Defaults to true.
    */
   showLabel?: boolean;
 }

--- a/static/app/views/issueDetails/header/assigneeSelector.tsx
+++ b/static/app/views/issueDetails/header/assigneeSelector.tsx
@@ -35,6 +35,11 @@ interface GroupHeaderAssigneeSelectorProps {
   event: Event | null;
   group: Group;
   project: Project;
+  /**
+   * Show the assignee name next to the avatar. On by default; disable for compact
+   * surfaces (e.g. the issue preview) that want an avatar-only control.
+   */
+  showLabel?: boolean;
 }
 
 function getCurrentAssignmentActivity(group: Group): GroupActivityAssigned | undefined {
@@ -97,6 +102,7 @@ export function GroupHeaderAssigneeSelector({
   group,
   project,
   event,
+  showLabel = true,
 }: GroupHeaderAssigneeSelectorProps) {
   const theme = useTheme();
   const organization = useOrganization();
@@ -129,7 +135,7 @@ export function GroupHeaderAssigneeSelector({
       assigneeLoading={assigneeLoading}
       handleAssigneeChange={handleAssigneeChange}
       assignmentDetails={assignmentDetails}
-      showLabel
+      showLabel={showLabel}
       useOwnerAssignmentDetails={false}
       additionalMenuFooterItems={
         <MenuComponents.CTAButton

--- a/static/app/views/issueDetails/issuePreview/issuePreview.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreview.tsx
@@ -3,7 +3,7 @@ import {Fragment, type ReactNode} from 'react';
 import {LinkButton} from '@sentry/scraps/button';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {TabList, TabPanels, Tabs} from '@sentry/scraps/tabs';
-import {Heading, Text} from '@sentry/scraps/text';
+import {Heading} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {ErrorBoundary} from 'sentry/components/errorBoundary';
@@ -162,18 +162,13 @@ function IssuePreviewContent() {
           event={null}
         />
         <Flex align="center" wrap="wrap" gap="lg">
-          <Flex align="center" gap="xs">
-            <Text size="sm" variant="muted">
-              {t('Priority')}
-            </Text>
-            <GroupPriority group={group} />
-          </Flex>
-          <Flex align="center" gap="xs">
-            <Text size="sm" variant="muted">
-              {t('Assignee')}
-            </Text>
-            <GroupHeaderAssigneeSelector group={group} project={project} event={null} />
-          </Flex>
+          <GroupPriority group={group} />
+          <GroupHeaderAssigneeSelector
+            group={group}
+            project={project}
+            event={null}
+            showLabel={false}
+          />
         </Flex>
       </Flex>
       <Container paddingTop="md">


### PR DESCRIPTION
Matches the compact Figma layout for the issue preview action row: drops the "Priority" and "Assignee" text labels so the priority control and assignee avatar render icon-only, like the inbox row.

`GroupHeaderAssigneeSelector` gains an opt-in `showLabel` prop (defaults to on). The preview passes `showLabel={false}` for the avatar-only look; the full issue details header keeps its label and is unchanged.

Fixes ISWF-3093
