### PR TITLE
feat(autofix): Group PR review feedback under a state-labelled header

### DIFF
--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -149,6 +149,20 @@ interface GithubPrCommentFeedbackSource {
 interface GithubPrReviewCommentFeedbackSource {
   type: 'github-pr-review-comment';
   comment?: {html_url?: string; user?: {login: string}};
+  // The review this inline comment was submitted as part of. Shared with the
+  // review body's `review_id` so the UI can group a review's body and its inline
+  // comments under one parent. Optional: absent on feedback serialized before
+  // the backend began emitting it, and on comments left outside a review.
+  review_id?: number;
+}
+
+interface GithubPrReviewBodyFeedbackSource {
+  type: 'github-pr-review-body';
+  // The review's summary body is its own feedback item, keyed by `review_id` and
+  // labelled by `review_state` (approved / changes_requested / commented / …).
+  html_url?: string;
+  review_id?: number;
+  review_state?: string;
 }
 
 interface GithubPrReviewBodyFeedbackSource {

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -160,17 +160,15 @@ interface GithubPrReviewBodyFeedbackSource {
   type: 'github-pr-review-body';
   // The review's summary body is its own feedback item, keyed by `review_id` and
   // labelled by `review_state` (approved / changes_requested / commented / …).
-  html_url?: string;
-  review_id?: number;
-  review_state?: string;
-}
-
-interface GithubPrReviewBodyFeedbackSource {
-  type: 'github-pr-review-body';
   author_is_bot?: boolean;
   body?: string;
   html_url?: string;
   review_id?: number;
+  review_state?: string;
+  // The review author, carried the same way an inline comment carries its author
+  // on `comment.user`, so the UI can render the reviewer's avatar on the review
+  // header. Absent on feedback serialized before the backend began emitting it.
+  user?: {login?: string};
 }
 
 interface CheckSuiteFeedbackSource {

--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -946,6 +946,7 @@ describe('ArtifactCard', () => {
                 html_url: reviewUrl,
                 review_id: 7,
                 review_state: 'changes_requested',
+                user: {login: 'octocat'},
               },
             },
             {
@@ -991,6 +992,15 @@ describe('ArtifactCard', () => {
       expect(screen.getByText('Overall this needs work.')).toBeInTheDocument();
       expect(screen.getByText('Handle the null value here.')).toBeInTheDocument();
       expect(screen.getByText('And rename this variable.')).toBeInTheDocument();
+      // The header and both comments render the reviewer's GitHub avatar (one per
+      // row), so every row is attributed — no un-authored header glyph. The avatar
+      // URL carries a `?s=` size suffix, so match on the login prefix.
+      const octocatAvatars = screen
+        .getAllByRole('img')
+        .filter(img =>
+          img.getAttribute('src')?.startsWith('https://github.com/octocat.png')
+        );
+      expect(octocatAvatars).toHaveLength(3);
     });
 
     it('shows a state badge for a body-only review', () => {
@@ -1008,6 +1018,7 @@ describe('ArtifactCard', () => {
                 type: 'github-pr-review-body',
                 review_id: 8,
                 review_state: 'approved',
+                user: {login: 'octocat'},
               },
             },
           ],
@@ -1027,6 +1038,56 @@ describe('ArtifactCard', () => {
 
       expect(screen.getByText('Approved')).toBeInTheDocument();
       expect(screen.getByText('Looks good to me.')).toBeInTheDocument();
+      // A body-only approval still shows the reviewer's avatar on the header —
+      // the case a comment-borrowed login would miss.
+      const octocatAvatars = screen
+        .getAllByRole('img')
+        .filter(img =>
+          img.getAttribute('src')?.startsWith('https://github.com/octocat.png')
+        );
+      expect(octocatAvatars).toHaveLength(1);
+    });
+
+    it('falls back to the GitHub glyph when the review body has no author login', () => {
+      // Feedback serialized before the backend emitted `author_login` has no
+      // login, so the header shows the source glyph rather than an avatar image.
+      const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
+        ...mockAutofix,
+        runState: {
+          run_id: 123,
+          blocks: [],
+          status: 'completed',
+          updated_at: '2026-01-01T00:00:00Z',
+          queued_feedback: [
+            {
+              text: 'Looks good to me.',
+              source: {
+                type: 'github-pr-review-body',
+                review_id: 10,
+                review_state: 'approved',
+              },
+            },
+          ],
+        },
+      };
+
+      render(
+        <CodeChangesCard
+          groupId="1"
+          autofix={autofixWithQueued}
+          section={makeSection('code_changes', 'completed', [
+            [makePatch('org/repo', 'src/app.py')],
+          ])}
+        />,
+        {organization: prIterationOrganization}
+      );
+
+      expect(screen.getByText('Looks good to me.')).toBeInTheDocument();
+      // No GitHub avatar image — the header renders the source glyph instead.
+      const githubAvatars = screen
+        .queryAllByRole('img')
+        .filter(img => img.getAttribute('src')?.startsWith('https://github.com/'));
+      expect(githubAvatars).toHaveLength(0);
     });
 
     it('leaves a comment-only review (no body) ungrouped', () => {

--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -1,72 +1,70 @@
-import { OrganizationFixture } from "sentry-fixture/organization";
+import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import { render, screen, userEvent } from "sentry-test/reactTestingLibrary";
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import { CodingAgentProvider } from "sentry/components/events/autofix/types";
+import {CodingAgentProvider} from 'sentry/components/events/autofix/types';
 import type {
   AutofixArtifact,
   AutofixSection,
   RootCauseArtifact,
   SolutionArtifact,
   useExplorerAutofix,
-} from "sentry/components/events/autofix/useExplorerAutofix";
-import { CodeChangesCard } from "sentry/components/events/autofix/v3/codeChangesCard";
-import { CodingAgentsCard } from "sentry/components/events/autofix/v3/codingAgentsCard";
-import { PullRequestsCard } from "sentry/components/events/autofix/v3/pullRequestsCard";
-import { RootCauseCard } from "sentry/components/events/autofix/v3/rootCauseCard";
-import { SolutionCard } from "sentry/components/events/autofix/v3/solutionCard";
+} from 'sentry/components/events/autofix/useExplorerAutofix';
+import {CodeChangesCard} from 'sentry/components/events/autofix/v3/codeChangesCard';
+import {CodingAgentsCard} from 'sentry/components/events/autofix/v3/codingAgentsCard';
+import {PullRequestsCard} from 'sentry/components/events/autofix/v3/pullRequestsCard';
+import {RootCauseCard} from 'sentry/components/events/autofix/v3/rootCauseCard';
+import {SolutionCard} from 'sentry/components/events/autofix/v3/solutionCard';
 import type {
   ExplorerCodingAgentState,
   ExplorerFilePatch,
   RepoPRState,
-} from "sentry/views/seerExplorer/types";
+} from 'sentry/views/seerExplorer/types';
 
-jest.mock("sentry/views/seerExplorer/components/fileDiffViewer", () => ({
+jest.mock('sentry/views/seerExplorer/components/fileDiffViewer', () => ({
   FileDiffViewer: () => <div data-testid="file-diff-viewer" />,
 }));
 
 const prIterationOrganization = OrganizationFixture({
-  features: ["autofix-pr-iteration"],
+  features: ['autofix-pr-iteration'],
 });
 
 function makeSection(
   step: string,
-  status: AutofixSection["status"],
+  status: AutofixSection['status'],
   artifacts: AutofixArtifact[],
-  blocks: AutofixSection["blocks"] = [],
+  blocks: AutofixSection['blocks'] = []
 ): AutofixSection {
-  return { step, artifacts, blocks, status };
+  return {step, artifacts, blocks, status};
 }
 
-function makeAssistantBlock(
-  content: string | null,
-): AutofixSection["blocks"][number] {
+function makeAssistantBlock(content: string | null): AutofixSection['blocks'][number] {
   return {
-    id: "block-1",
-    timestamp: "2026-01-01T00:00:00Z",
-    message: { role: "assistant", content },
+    id: 'block-1',
+    timestamp: '2026-01-01T00:00:00Z',
+    message: {role: 'assistant', content},
   };
 }
 
 function makePrIterationBlock(
   iterationIndex: number,
-  feedback: { text: string; timestamp?: string; user?: any },
-): AutofixSection["blocks"][number] {
+  feedback: {text: string; timestamp?: string; user?: any}
+): AutofixSection['blocks'][number] {
   return {
     id: `block-pr-${iterationIndex}`,
-    timestamp: "2026-01-01T00:00:00Z",
+    timestamp: '2026-01-01T00:00:00Z',
     message: {
-      role: "user",
+      role: 'user',
       content: null,
       metadata: {
-        step: "pr_iteration",
+        step: 'pr_iteration',
         iteration_index: String(iterationIndex),
         feedback: JSON.stringify({
           text: feedback.text,
           timestamp: feedback.timestamp,
           source: feedback.user
-            ? { type: "user-ui", user: feedback.user }
-            : { type: "user-ui" },
+            ? {type: 'user-ui', user: feedback.user}
+            : {type: 'user-ui'},
         }),
       },
     },
@@ -76,7 +74,7 @@ function makePrIterationBlock(
 function makePatch(repoName: string, path: string): ExplorerFilePatch {
   return {
     repo_name: repoName,
-    diff: "",
+    diff: '',
     patch: {
       path,
       added: 1,
@@ -84,22 +82,22 @@ function makePatch(repoName: string, path: string): ExplorerFilePatch {
       hunks: [],
       source_file: path,
       target_file: path,
-      type: "M",
+      type: 'M',
     },
   } as ExplorerFilePatch;
 }
 
 function makePR(overrides: Partial<RepoPRState> = {}): RepoPRState {
   return {
-    repo_name: "org/repo",
+    repo_name: 'org/repo',
     pr_number: 42,
-    pr_url: "https://github.com/org/repo/pull/42",
-    branch_name: "fix/issue",
-    commit_sha: "abc123",
+    pr_url: 'https://github.com/org/repo/pull/42',
+    branch_name: 'fix/issue',
+    commit_sha: 'abc123',
     pr_creation_error: null,
-    pr_creation_status: "completed",
+    pr_creation_status: 'completed',
     pr_id: 1,
-    title: "Fix issue",
+    title: 'Fix issue',
     ...overrides,
   };
 }
@@ -122,124 +120,120 @@ const mockAutofixWithRunState: ReturnType<typeof useExplorerAutofix> = {
   runState: {
     run_id: 123,
     blocks: [],
-    status: "completed" as const,
-    updated_at: "2026-01-01T00:00:00Z",
+    status: 'completed' as const,
+    updated_at: '2026-01-01T00:00:00Z',
   },
 };
 
 function makeRootCauseArtifact(data: RootCauseArtifact | null) {
   return {
-    key: "root-cause",
-    reason: "Found root cause",
+    key: 'root-cause',
+    reason: 'Found root cause',
     data,
   };
 }
 
 function makeSolutionArtifact(data: SolutionArtifact | null) {
   return {
-    key: "solution",
-    reason: "Found solution",
+    key: 'solution',
+    reason: 'Found solution',
     data,
   };
 }
 
-describe("ArtifactCard", () => {
+describe('ArtifactCard', () => {
   beforeEach(() => {
     userEvent.setup();
-    jest.spyOn(navigator.clipboard, "writeText").mockResolvedValue();
+    jest.spyOn(navigator.clipboard, 'writeText').mockResolvedValue();
   });
 
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  describe("RootCauseCard", () => {
-    it("renders title and one_line_description summary", () => {
+  describe('RootCauseCard', () => {
+    it('renders title and one_line_description summary', () => {
       const artifact = makeRootCauseArtifact({
-        one_line_description: "Null pointer in user handler",
-        five_whys: ["why1", "why2"],
-        reproduction_steps: ["step1"],
+        one_line_description: 'Null pointer in user handler',
+        five_whys: ['why1', 'why2'],
+        reproduction_steps: ['step1'],
       });
 
       render(
         <RootCauseCard
           autofix={mockAutofix}
           groupId="1"
-          section={makeSection("root_cause", "completed", [artifact])}
-        />,
+          section={makeSection('root_cause', 'completed', [artifact])}
+        />
       );
 
-      expect(screen.getByText("Root Cause")).toBeInTheDocument();
-      expect(
-        screen.getByText("Null pointer in user handler"),
-      ).toBeInTheDocument();
+      expect(screen.getByText('Root Cause')).toBeInTheDocument();
+      expect(screen.getByText('Null pointer in user handler')).toBeInTheDocument();
     });
 
-    it("renders five_whys list items and heading", () => {
+    it('renders five_whys list items and heading', () => {
       const artifact = makeRootCauseArtifact({
-        one_line_description: "Bug",
-        five_whys: ["First why", "Second why", "Third why"],
+        one_line_description: 'Bug',
+        five_whys: ['First why', 'Second why', 'Third why'],
       });
 
       render(
         <RootCauseCard
           autofix={mockAutofix}
           groupId="1"
-          section={makeSection("root_cause", "completed", [artifact])}
-        />,
+          section={makeSection('root_cause', 'completed', [artifact])}
+        />
       );
 
-      expect(screen.getByText("Why did this happen?")).toBeInTheDocument();
-      expect(screen.getByText("First why")).toBeInTheDocument();
-      expect(screen.getByText("Second why")).toBeInTheDocument();
-      expect(screen.getByText("Third why")).toBeInTheDocument();
+      expect(screen.getByText('Why did this happen?')).toBeInTheDocument();
+      expect(screen.getByText('First why')).toBeInTheDocument();
+      expect(screen.getByText('Second why')).toBeInTheDocument();
+      expect(screen.getByText('Third why')).toBeInTheDocument();
     });
 
-    it("renders reproduction_steps when present", () => {
+    it('renders reproduction_steps when present', () => {
       const artifact = makeRootCauseArtifact({
-        one_line_description: "Bug",
-        five_whys: ["why1"],
-        reproduction_steps: ["Open the page", "Click button"],
+        one_line_description: 'Bug',
+        five_whys: ['why1'],
+        reproduction_steps: ['Open the page', 'Click button'],
       });
 
       render(
         <RootCauseCard
           autofix={mockAutofix}
           groupId="1"
-          section={makeSection("root_cause", "completed", [artifact])}
-        />,
+          section={makeSection('root_cause', 'completed', [artifact])}
+        />
       );
 
-      expect(screen.getByText("Reproduction Steps")).toBeInTheDocument();
-      expect(screen.getByText("Open the page")).toBeInTheDocument();
-      expect(screen.getByText("Click button")).toBeInTheDocument();
+      expect(screen.getByText('Reproduction Steps')).toBeInTheDocument();
+      expect(screen.getByText('Open the page')).toBeInTheDocument();
+      expect(screen.getByText('Click button')).toBeInTheDocument();
     });
 
-    it("renders card shell when artifact data is null", () => {
+    it('renders card shell when artifact data is null', () => {
       const artifact = makeRootCauseArtifact(null);
 
       render(
         <RootCauseCard
           autofix={mockAutofix}
           groupId="1"
-          section={makeSection("root_cause", "completed", [artifact])}
-        />,
+          section={makeSection('root_cause', 'completed', [artifact])}
+        />
       );
 
-      expect(screen.getByText("Root Cause")).toBeInTheDocument();
+      expect(screen.getByText('Root Cause')).toBeInTheDocument();
       expect(
         screen.getByText(
-          "Seer failed to generate a root cause. This one is on us. Try running it again.",
-        ),
+          'Seer failed to generate a root cause. This one is on us. Try running it again.'
+        )
       ).toBeInTheDocument();
-      expect(
-        screen.getByRole("button", { name: "Re-run" }),
-      ).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Re-run'})).toBeInTheDocument();
     });
 
-    it("handles empty five_whys with placeholder", () => {
+    it('handles empty five_whys with placeholder', () => {
       const artifact = makeRootCauseArtifact({
-        one_line_description: "Bug",
+        one_line_description: 'Bug',
         five_whys: [],
       });
 
@@ -247,297 +241,277 @@ describe("ArtifactCard", () => {
         <RootCauseCard
           autofix={mockAutofix}
           groupId="1"
-          section={makeSection("root_cause", "completed", [artifact])}
-        />,
+          section={makeSection('root_cause', 'completed', [artifact])}
+        />
       );
 
-      expect(screen.getByText("Root Cause")).toBeInTheDocument();
-      expect(
-        screen.queryByText("Why did this happen?"),
-      ).not.toBeInTheDocument();
+      expect(screen.getByText('Root Cause')).toBeInTheDocument();
+      expect(screen.queryByText('Why did this happen?')).not.toBeInTheDocument();
     });
 
-    it("copies markdown when copy button is clicked", async () => {
+    it('copies markdown when copy button is clicked', async () => {
       const artifact = makeRootCauseArtifact({
-        one_line_description: "Null pointer in user handler",
-        five_whys: ["Missing null check"],
-        reproduction_steps: ["Open page"],
+        one_line_description: 'Null pointer in user handler',
+        five_whys: ['Missing null check'],
+        reproduction_steps: ['Open page'],
       });
 
       render(
         <RootCauseCard
           autofix={mockAutofix}
           groupId="1"
-          section={makeSection("root_cause", "completed", [artifact])}
-        />,
+          section={makeSection('root_cause', 'completed', [artifact])}
+        />
       );
 
-      await userEvent.click(
-        screen.getByRole("button", { name: "Copy as Markdown" }),
-      );
+      await userEvent.click(screen.getByRole('button', {name: 'Copy as Markdown'}));
 
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
-        expect.stringContaining("Null pointer in user handler"),
+        expect.stringContaining('Null pointer in user handler')
       );
     });
 
-    it("does not show copy button when artifact data is null", () => {
+    it('does not show copy button when artifact data is null', () => {
       const artifact = makeRootCauseArtifact(null);
 
       render(
         <RootCauseCard
           autofix={mockAutofix}
           groupId="1"
-          section={makeSection("root_cause", "completed", [artifact])}
-        />,
+          section={makeSection('root_cause', 'completed', [artifact])}
+        />
       );
 
-      expect(
-        screen.queryByRole("button", { name: "Copy as Markdown" }),
-      ).toBeDisabled();
+      expect(screen.queryByRole('button', {name: 'Copy as Markdown'})).toBeDisabled();
     });
   });
 
-  describe("SolutionCard", () => {
-    it("renders title and one_line_summary", () => {
+  describe('SolutionCard', () => {
+    it('renders title and one_line_summary', () => {
       const artifact = makeSolutionArtifact({
-        one_line_summary: "Add null check before accessing user",
-        steps: [{ title: "Step 1", description: "Add guard" }],
+        one_line_summary: 'Add null check before accessing user',
+        steps: [{title: 'Step 1', description: 'Add guard'}],
       });
 
       render(
         <SolutionCard
           autofix={mockAutofix}
-          section={makeSection("solution", "completed", [artifact])}
-        />,
+          section={makeSection('solution', 'completed', [artifact])}
+        />
       );
 
-      expect(screen.getByText("Plan")).toBeInTheDocument();
+      expect(screen.getByText('Plan')).toBeInTheDocument();
       expect(
-        screen.getByText("Add null check before accessing user"),
+        screen.getByText('Add null check before accessing user')
       ).toBeInTheDocument();
     });
 
-    it("renders steps with title and description", () => {
+    it('renders steps with title and description', () => {
       const artifact = makeSolutionArtifact({
-        one_line_summary: "Fix the bug",
+        one_line_summary: 'Fix the bug',
         steps: [
-          { title: "Add validation", description: "Check input is not null" },
-          { title: "Update handler", description: "Handle edge case" },
+          {title: 'Add validation', description: 'Check input is not null'},
+          {title: 'Update handler', description: 'Handle edge case'},
         ],
       });
 
       render(
         <SolutionCard
           autofix={mockAutofix}
-          section={makeSection("solution", "completed", [artifact])}
-        />,
+          section={makeSection('solution', 'completed', [artifact])}
+        />
       );
 
-      expect(screen.getByText("Steps to Resolve")).toBeInTheDocument();
-      expect(screen.getByText("Add validation")).toBeInTheDocument();
-      expect(screen.getByText("Check input is not null")).toBeInTheDocument();
-      expect(screen.getByText("Update handler")).toBeInTheDocument();
-      expect(screen.getByText("Handle edge case")).toBeInTheDocument();
+      expect(screen.getByText('Steps to Resolve')).toBeInTheDocument();
+      expect(screen.getByText('Add validation')).toBeInTheDocument();
+      expect(screen.getByText('Check input is not null')).toBeInTheDocument();
+      expect(screen.getByText('Update handler')).toBeInTheDocument();
+      expect(screen.getByText('Handle edge case')).toBeInTheDocument();
     });
 
-    it("renders card shell when artifact data is null", () => {
+    it('renders card shell when artifact data is null', () => {
       const artifact = makeSolutionArtifact(null);
 
       render(
         <SolutionCard
           autofix={mockAutofix}
-          section={makeSection("solution", "completed", [artifact])}
-        />,
+          section={makeSection('solution', 'completed', [artifact])}
+        />
       );
 
-      expect(screen.getByText("Plan")).toBeInTheDocument();
+      expect(screen.getByText('Plan')).toBeInTheDocument();
       expect(
         screen.getByText(
-          "Seer failed to generate a plan. This one is on us. Try running it again.",
-        ),
+          'Seer failed to generate a plan. This one is on us. Try running it again.'
+        )
       ).toBeInTheDocument();
-      expect(
-        screen.getByRole("button", { name: "Re-run" }),
-      ).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Re-run'})).toBeInTheDocument();
     });
 
-    it("copies markdown when copy button is clicked", async () => {
+    it('copies markdown when copy button is clicked', async () => {
       const artifact = makeSolutionArtifact({
-        one_line_summary: "Add null check before accessing user",
-        steps: [{ title: "Add guard", description: "Check input" }],
+        one_line_summary: 'Add null check before accessing user',
+        steps: [{title: 'Add guard', description: 'Check input'}],
       });
 
       render(
         <SolutionCard
           autofix={mockAutofix}
-          section={makeSection("solution", "completed", [artifact])}
-        />,
+          section={makeSection('solution', 'completed', [artifact])}
+        />
       );
 
-      await userEvent.click(
-        screen.getByRole("button", { name: "Copy as Markdown" }),
-      );
+      await userEvent.click(screen.getByRole('button', {name: 'Copy as Markdown'}));
 
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
-        expect.stringContaining("Add null check before accessing user"),
+        expect.stringContaining('Add null check before accessing user')
       );
     });
 
-    it("does not show copy button when artifact data is null", () => {
+    it('does not show copy button when artifact data is null', () => {
       const artifact = makeSolutionArtifact(null);
 
       render(
         <SolutionCard
           autofix={mockAutofix}
-          section={makeSection("solution", "completed", [artifact])}
-        />,
+          section={makeSection('solution', 'completed', [artifact])}
+        />
       );
 
-      expect(
-        screen.queryByRole("button", { name: "Copy as Markdown" }),
-      ).toBeDisabled();
+      expect(screen.queryByRole('button', {name: 'Copy as Markdown'})).toBeDisabled();
     });
   });
 
-  describe("CodeChangesCard", () => {
-    it("renders single file in single repo", () => {
+  describe('CodeChangesCard', () => {
+    it('renders single file in single repo', () => {
       render(
         <CodeChangesCard
           groupId="1"
           autofix={mockAutofix}
-          section={makeSection("code_changes", "completed", [
-            [makePatch("org/repo", "src/app.py")],
+          section={makeSection('code_changes', 'completed', [
+            [makePatch('org/repo', 'src/app.py')],
           ])}
-        />,
+        />
       );
 
-      expect(screen.getByText("Code Changes")).toBeInTheDocument();
-      expect(screen.getByText("1 file changed in 1 repo")).toBeInTheDocument();
+      expect(screen.getByText('Code Changes')).toBeInTheDocument();
+      expect(screen.getByText('1 file changed in 1 repo')).toBeInTheDocument();
     });
 
-    it("renders multiple files in single repo", () => {
+    it('renders multiple files in single repo', () => {
       render(
         <CodeChangesCard
           groupId="1"
           autofix={mockAutofix}
-          section={makeSection("code_changes", "completed", [
+          section={makeSection('code_changes', 'completed', [
             [
-              makePatch("org/repo", "src/app.py"),
-              makePatch("org/repo", "src/utils.py"),
-              makePatch("org/repo", "src/models.py"),
+              makePatch('org/repo', 'src/app.py'),
+              makePatch('org/repo', 'src/utils.py'),
+              makePatch('org/repo', 'src/models.py'),
             ],
           ])}
-        />,
+        />
       );
 
-      expect(screen.getByText("3 files changed in 1 repo")).toBeInTheDocument();
+      expect(screen.getByText('3 files changed in 1 repo')).toBeInTheDocument();
     });
 
-    it("renders multiple files in multiple repos", () => {
+    it('renders multiple files in multiple repos', () => {
       render(
         <CodeChangesCard
           groupId="1"
           autofix={mockAutofix}
-          section={makeSection("code_changes", "completed", [
+          section={makeSection('code_changes', 'completed', [
             [
-              makePatch("org/repo-a", "src/app.py"),
-              makePatch("org/repo-a", "src/utils.py"),
-              makePatch("org/repo-b", "src/index.ts"),
+              makePatch('org/repo-a', 'src/app.py'),
+              makePatch('org/repo-a', 'src/utils.py'),
+              makePatch('org/repo-b', 'src/index.ts'),
             ],
           ])}
-        />,
+        />
       );
 
-      expect(
-        screen.getByText("3 files changed in 2 repos"),
-      ).toBeInTheDocument();
+      expect(screen.getByText('3 files changed in 2 repos')).toBeInTheDocument();
     });
 
-    it("renders repository name labels", () => {
+    it('renders repository name labels', () => {
       render(
         <CodeChangesCard
           groupId="1"
           autofix={mockAutofix}
-          section={makeSection("code_changes", "completed", [
+          section={makeSection('code_changes', 'completed', [
             [
-              makePatch("org/repo-a", "src/app.py"),
-              makePatch("org/repo-b", "src/index.ts"),
+              makePatch('org/repo-a', 'src/app.py'),
+              makePatch('org/repo-b', 'src/index.ts'),
             ],
           ])}
-        />,
+        />
       );
 
-      expect(screen.getByText("org/repo-a")).toBeInTheDocument();
-      expect(screen.getByText("org/repo-b")).toBeInTheDocument();
+      expect(screen.getByText('org/repo-a')).toBeInTheDocument();
+      expect(screen.getByText('org/repo-b')).toBeInTheDocument();
     });
 
-    it("renders card shell when no code changes artifact found", () => {
+    it('renders card shell when no code changes artifact found', () => {
       render(
         <CodeChangesCard
           groupId="1"
           autofix={mockAutofix}
-          section={makeSection("code_changes", "completed", [])}
-        />,
+          section={makeSection('code_changes', 'completed', [])}
+        />
       );
 
-      expect(screen.getByText("Code Changes")).toBeInTheDocument();
+      expect(screen.getByText('Code Changes')).toBeInTheDocument();
       expect(
         screen.getByText(
-          "Seer failed to generate a code change. This one is on us. Try running it again.",
-        ),
+          'Seer failed to generate a code change. This one is on us. Try running it again.'
+        )
       ).toBeInTheDocument();
-      expect(
-        screen.getByRole("button", { name: "Re-run" }),
-      ).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Re-run'})).toBeInTheDocument();
     });
 
-    it("copies markdown when copy button is clicked", async () => {
+    it('copies markdown when copy button is clicked', async () => {
       render(
         <CodeChangesCard
           groupId="1"
           autofix={mockAutofix}
-          section={makeSection("code_changes", "completed", [
-            [makePatch("org/repo", "src/app.py")],
+          section={makeSection('code_changes', 'completed', [
+            [makePatch('org/repo', 'src/app.py')],
           ])}
-        />,
+        />
       );
 
-      await userEvent.click(
-        screen.getByRole("button", { name: "Copy as Markdown" }),
-      );
+      await userEvent.click(screen.getByRole('button', {name: 'Copy as Markdown'}));
 
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
-        expect.stringContaining("Code Changes"),
+        expect.stringContaining('Code Changes')
       );
     });
 
-    it("does not show copy button when no patches", () => {
+    it('does not show copy button when no patches', () => {
       render(
         <CodeChangesCard
           groupId="1"
           autofix={mockAutofix}
-          section={makeSection("code_changes", "completed", [])}
-        />,
+          section={makeSection('code_changes', 'completed', [])}
+        />
       );
 
-      expect(
-        screen.queryByRole("button", { name: "Copy as Markdown" }),
-      ).toBeDisabled();
+      expect(screen.queryByRole('button', {name: 'Copy as Markdown'})).toBeDisabled();
     });
 
-    it("renders error state when all patches have no changes", () => {
+    it('renders error state when all patches have no changes', () => {
       const emptyPatch = {
-        repo_name: "org/repo",
-        diff: "",
+        repo_name: 'org/repo',
+        diff: '',
         patch: {
-          path: "src/app.py",
+          path: 'src/app.py',
           added: 0,
           removed: 0,
           hunks: [],
-          source_file: "src/app.py",
-          target_file: "src/app.py",
-          type: "M",
+          source_file: 'src/app.py',
+          target_file: 'src/app.py',
+          type: 'M',
         },
       } as ExplorerFilePatch;
 
@@ -545,21 +519,19 @@ describe("ArtifactCard", () => {
         <CodeChangesCard
           groupId="1"
           autofix={mockAutofix}
-          section={makeSection("code_changes", "completed", [[emptyPatch]])}
-        />,
+          section={makeSection('code_changes', 'completed', [[emptyPatch]])}
+        />
       );
 
       expect(
         screen.getByText(
-          "Seer failed to generate a code change. This one is on us. Try running it again.",
-        ),
+          'Seer failed to generate a code change. This one is on us. Try running it again.'
+        )
       ).toBeInTheDocument();
-      expect(
-        screen.getByRole("button", { name: "Re-run" }),
-      ).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Re-run'})).toBeInTheDocument();
     });
 
-    it("calls startStep when re-run button is clicked in error state", async () => {
+    it('calls startStep when re-run button is clicked in error state', async () => {
       const startStepMock = jest.fn();
       const autofixWithRunState = {
         ...mockAutofix,
@@ -567,8 +539,8 @@ describe("ArtifactCard", () => {
         runState: {
           run_id: 123,
           blocks: [],
-          status: "completed" as const,
-          updated_at: "2026-01-01T00:00:00Z",
+          status: 'completed' as const,
+          updated_at: '2026-01-01T00:00:00Z',
         },
       };
 
@@ -576,116 +548,106 @@ describe("ArtifactCard", () => {
         <CodeChangesCard
           groupId="1"
           autofix={autofixWithRunState}
-          section={makeSection("code_changes", "completed", [])}
-        />,
+          section={makeSection('code_changes', 'completed', [])}
+        />
       );
 
-      await userEvent.click(screen.getByRole("button", { name: "Re-run" }));
+      await userEvent.click(screen.getByRole('button', {name: 'Re-run'}));
       expect(startStepMock).toHaveBeenCalledWith(
-        "code_changes",
-        expect.objectContaining({ runId: 123 }),
+        'code_changes',
+        expect.objectContaining({runId: 123})
       );
     });
 
-    it("renders loading state when processing, not error", () => {
+    it('renders loading state when processing, not error', () => {
       render(
         <CodeChangesCard
           groupId="1"
           autofix={mockAutofix}
-          section={makeSection("code_changes", "processing", [])}
-        />,
+          section={makeSection('code_changes', 'processing', [])}
+        />
       );
 
-      expect(screen.getByText("Implementing changes…")).toBeInTheDocument();
+      expect(screen.getByText('Implementing changes…')).toBeInTheDocument();
       expect(
         screen.queryByText(
-          "Seer failed to generate a code change. This one is on us. Try running it again.",
-        ),
+          'Seer failed to generate a code change. This one is on us. Try running it again.'
+        )
       ).not.toBeInTheDocument();
     });
 
-    it("does not render file diff viewers in error state", () => {
+    it('does not render file diff viewers in error state', () => {
       render(
         <CodeChangesCard
           groupId="1"
           autofix={mockAutofix}
-          section={makeSection("code_changes", "completed", [])}
-        />,
+          section={makeSection('code_changes', 'completed', [])}
+        />
       );
 
-      expect(screen.queryByTestId("file-diff-viewer")).not.toBeInTheDocument();
+      expect(screen.queryByTestId('file-diff-viewer')).not.toBeInTheDocument();
     });
 
-    it("surfaces the agent explanation when no patches but a final message exists", () => {
+    it('surfaces the agent explanation when no patches but a final message exists', () => {
       render(
         <CodeChangesCard
           groupId="1"
           autofix={mockAutofixWithRunState}
           section={makeSection(
-            "code_changes",
-            "completed",
+            'code_changes',
+            'completed',
             [],
             [
               makeAssistantBlock(
-                "This fix requires a database migration, not a code change.",
+                'This fix requires a database migration, not a code change.'
               ),
-            ],
+            ]
           )}
-        />,
+        />
       );
 
       expect(
-        screen.getByText(
-          "Seer proposed a fix but couldn't apply it automatically",
-        ),
+        screen.getByText("Seer proposed a fix but couldn't apply it automatically")
       ).toBeInTheDocument();
       expect(
-        screen.getByText(
-          "This fix requires a database migration, not a code change.",
-        ),
+        screen.getByText('This fix requires a database migration, not a code change.')
       ).toBeInTheDocument();
       expect(
-        screen.getByRole("button", { name: "Add context & retry" }),
+        screen.getByRole('button', {name: 'Add context & retry'})
       ).toBeInTheDocument();
       // The generic "this one is on us" copy should not appear here.
       expect(
         screen.queryByText(
-          "Seer failed to generate a code change. This one is on us. Try running it again.",
-        ),
+          'Seer failed to generate a code change. This one is on us. Try running it again.'
+        )
       ).not.toBeInTheDocument();
     });
 
-    it("opens the context prompt from the explanation state", async () => {
+    it('opens the context prompt from the explanation state', async () => {
       render(
         <CodeChangesCard
           groupId="1"
           autofix={mockAutofixWithRunState}
           section={makeSection(
-            "code_changes",
-            "completed",
+            'code_changes',
+            'completed',
             [],
-            [
-              makeAssistantBlock(
-                "The relevant files are not in the connected repo.",
-              ),
-            ],
+            [makeAssistantBlock('The relevant files are not in the connected repo.')]
           )}
-        />,
+        />
       );
 
-      await userEvent.click(
-        screen.getByRole("button", { name: "Add context & retry" }),
-      );
+      await userEvent.click(screen.getByRole('button', {name: 'Add context & retry'}));
 
       expect(
-        screen.getByText("What additional context should Seer use?"),
+        screen.getByText('What additional context should Seer use?')
       ).toBeInTheDocument();
       expect(
-        screen.queryByRole("button", { name: "Add context & retry" }),
+        screen.queryByRole('button', {name: 'Add context & retry'})
       ).not.toBeInTheDocument();
     });
 
-    it("opens PR iteration feedback from explanation state when a PR exists", async () => {
+    it('opens PR iteration feedback from explanation state when a PR exists', async () => {
       const startStepMock = jest.fn();
       const autofixWithPR: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofixWithRunState,
@@ -693,9 +655,9 @@ describe("ArtifactCard", () => {
         runState: {
           run_id: 123,
           blocks: [],
-          status: "completed",
-          updated_at: "2026-01-01T00:00:00Z",
-          repo_pr_states: { "org/repo": makePR() },
+          status: 'completed',
+          updated_at: '2026-01-01T00:00:00Z',
+          repo_pr_states: {'org/repo': makePR()},
         },
       };
 
@@ -704,78 +666,70 @@ describe("ArtifactCard", () => {
           groupId="1"
           autofix={autofixWithPR}
           section={makeSection(
-            "code_changes",
-            "completed",
+            'code_changes',
+            'completed',
             [],
-            [
-              makeAssistantBlock(
-                "The relevant files are not in the connected repo.",
-              ),
-            ],
+            [makeAssistantBlock('The relevant files are not in the connected repo.')]
           )}
         />,
-        { organization: prIterationOrganization },
+        {organization: prIterationOrganization}
       );
 
-      await userEvent.click(
-        screen.getByRole("button", { name: "Add context & retry" }),
-      );
+      await userEvent.click(screen.getByRole('button', {name: 'Add context & retry'}));
 
       expect(
-        screen.getByText("Anything else you want to see on your PR?"),
+        screen.getByText('Anything else you want to see on your PR?')
       ).toBeInTheDocument();
       expect(
-        screen.queryByText("What additional context should Seer use?"),
+        screen.queryByText('What additional context should Seer use?')
       ).not.toBeInTheDocument();
 
-      await userEvent.type(screen.getByRole("textbox"), "Try the other repo");
-      await userEvent.click(screen.getByRole("button", { name: "Submit" }));
+      await userEvent.type(screen.getByRole('textbox'), 'Try the other repo');
+      await userEvent.click(screen.getByRole('button', {name: 'Submit'}));
 
-      expect(startStepMock).toHaveBeenCalledWith("pr_iteration", {
+      expect(startStepMock).toHaveBeenCalledWith('pr_iteration', {
         runId: 123,
-        userContext: "Try the other repo",
+        userContext: 'Try the other repo',
       });
     });
 
-    it("falls back to the generic failure copy when there is no explanation", () => {
+    it('falls back to the generic failure copy when there is no explanation', () => {
       render(
         <CodeChangesCard
           groupId="1"
           autofix={mockAutofix}
           section={makeSection(
-            "code_changes",
-            "completed",
+            'code_changes',
+            'completed',
             [],
-            [makeAssistantBlock("   ")],
+            [makeAssistantBlock('   ')]
           )}
-        />,
+        />
       );
 
       expect(
         screen.getByText(
-          "Seer failed to generate a code change. This one is on us. Try running it again.",
-        ),
+          'Seer failed to generate a code change. This one is on us. Try running it again.'
+        )
       ).toBeInTheDocument();
       expect(
-        screen.queryByText(
-          "Seer proposed a fix but couldn't apply it automatically",
-        ),
+        screen.queryByText("Seer proposed a fix but couldn't apply it automatically")
       ).not.toBeInTheDocument();
     });
 
-    it("silently ignores pr_iteration blocks with an unrecognized source type", () => {
-      const block: AutofixSection["blocks"][number] = {
-        id: "block-unknown",
-        timestamp: "2026-01-01T00:00:00Z",
+    it('silently ignores pr_iteration blocks with an unrecognized source type', () => {
+      const block: AutofixSection['blocks'][number] = {
+        id: 'block-unknown',
+        timestamp: '2026-01-01T00:00:00Z',
         message: {
-          role: "user",
+          role: 'user',
           content: null,
           metadata: {
-            step: "pr_iteration",
-            iteration_index: "0",
+            step: 'pr_iteration',
+            iteration_index: '0',
             feedback: JSON.stringify({
-              text: "ignored",
-              source: { type: "mystery" },
+              text: 'ignored',
+              source: {type: 'mystery'},
             }),
           },
         },
@@ -785,47 +739,45 @@ describe("ArtifactCard", () => {
           groupId="1"
           autofix={mockAutofix}
           section={makeSection(
-            "code_changes",
-            "completed",
-            [[makePatch("org/repo", "src/app.py")]],
-            [block],
+            'code_changes',
+            'completed',
+            [[makePatch('org/repo', 'src/app.py')]],
+            [block]
           )}
-        />,
+        />
       );
 
-      expect(screen.queryByText("Feedback")).not.toBeInTheDocument();
+      expect(screen.queryByText('Feedback')).not.toBeInTheDocument();
     });
 
-    it("renders feedback from pr_iteration blocks", () => {
+    it('renders feedback from pr_iteration blocks', () => {
       render(
         <CodeChangesCard
           groupId="1"
           autofix={mockAutofix}
           section={makeSection(
-            "code_changes",
-            "completed",
-            [[makePatch("org/repo", "src/app.py")]],
-            [makePrIterationBlock(1, { text: "Add a test for this" })],
+            'code_changes',
+            'completed',
+            [[makePatch('org/repo', 'src/app.py')]],
+            [makePrIterationBlock(1, {text: 'Add a test for this'})]
           )}
         />,
-        { organization: prIterationOrganization },
+        {organization: prIterationOrganization}
       );
 
-      expect(screen.getByText("Feedback")).toBeInTheDocument();
-      expect(screen.getByText("Add a test for this")).toBeInTheDocument();
+      expect(screen.getByText('Feedback')).toBeInTheDocument();
+      expect(screen.getByText('Add a test for this')).toBeInTheDocument();
     });
 
-    it("renders the latest feedback at the top of the list", () => {
+    it('renders the latest feedback at the top of the list', () => {
       const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofix,
         runState: {
           run_id: 123,
           blocks: [],
-          status: "completed",
-          updated_at: "2026-01-01T00:00:00Z",
-          queued_feedback: [
-            { text: "newest queued", source: { type: "user-ui" } },
-          ],
+          status: 'completed',
+          updated_at: '2026-01-01T00:00:00Z',
+          queued_feedback: [{text: 'newest queued', source: {type: 'user-ui'}}],
         },
       };
 
@@ -834,37 +786,35 @@ describe("ArtifactCard", () => {
           groupId="1"
           autofix={autofixWithQueued}
           section={makeSection(
-            "code_changes",
-            "completed",
-            [[makePatch("org/repo", "src/app.py")]],
+            'code_changes',
+            'completed',
+            [[makePatch('org/repo', 'src/app.py')]],
             [
-              makePrIterationBlock(0, { text: "first pass" }),
-              makePrIterationBlock(1, { text: "second pass" }),
-            ],
+              makePrIterationBlock(0, {text: 'first pass'}),
+              makePrIterationBlock(1, {text: 'second pass'}),
+            ]
           )}
         />,
-        { organization: prIterationOrganization },
+        {organization: prIterationOrganization}
       );
 
       const items = screen.getAllByText(/first pass|second pass|newest queued/);
-      expect(items.map((item) => item.textContent)).toEqual([
-        "newest queued",
-        "second pass",
-        "first pass",
+      expect(items.map(item => item.textContent)).toEqual([
+        'newest queued',
+        'second pass',
+        'first pass',
       ]);
     });
 
-    it("shows the code changes, not the loader, when feedback is only queued", () => {
+    it('shows the code changes, not the loader, when feedback is only queued', () => {
       const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofix,
         runState: {
           run_id: 123,
           blocks: [],
-          status: "completed",
-          updated_at: "2026-01-01T00:00:00Z",
-          queued_feedback: [
-            { text: "Make the button blue", source: { type: "user-ui" } },
-          ],
+          status: 'completed',
+          updated_at: '2026-01-01T00:00:00Z',
+          queued_feedback: [{text: 'Make the button blue', source: {type: 'user-ui'}}],
         },
       };
 
@@ -873,33 +823,29 @@ describe("ArtifactCard", () => {
           groupId="1"
           autofix={autofixWithQueued}
           section={makeSection(
-            "code_changes",
-            "completed",
-            [[makePatch("org/repo", "src/app.py")]],
-            [makePrIterationBlock(0, { text: "first pass" })],
+            'code_changes',
+            'completed',
+            [[makePatch('org/repo', 'src/app.py')]],
+            [makePrIterationBlock(0, {text: 'first pass'})]
           )}
         />,
-        { organization: prIterationOrganization },
+        {organization: prIterationOrganization}
       );
 
-      expect(screen.getByText("1 file changed in 1 repo")).toBeInTheDocument();
-      expect(screen.queryByText("Iterating on PR…")).not.toBeInTheDocument();
-      expect(
-        screen.queryByText("Implementing changes…"),
-      ).not.toBeInTheDocument();
+      expect(screen.getByText('1 file changed in 1 repo')).toBeInTheDocument();
+      expect(screen.queryByText('Iterating on PR…')).not.toBeInTheDocument();
+      expect(screen.queryByText('Implementing changes…')).not.toBeInTheDocument();
     });
 
-    it("renders queued feedback as a feedback item", () => {
+    it('renders queued feedback as a feedback item', () => {
       const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofix,
         runState: {
           run_id: 123,
           blocks: [],
-          status: "completed",
-          updated_at: "2026-01-01T00:00:00Z",
-          queued_feedback: [
-            { text: "Make the button blue", source: { type: "user-ui" } },
-          ],
+          status: 'completed',
+          updated_at: '2026-01-01T00:00:00Z',
+          queued_feedback: [{text: 'Make the button blue', source: {type: 'user-ui'}}],
         },
       };
 
@@ -907,26 +853,26 @@ describe("ArtifactCard", () => {
         <CodeChangesCard
           groupId="1"
           autofix={autofixWithQueued}
-          section={makeSection("code_changes", "completed", [
-            [makePatch("org/repo", "src/app.py")],
+          section={makeSection('code_changes', 'completed', [
+            [makePatch('org/repo', 'src/app.py')],
           ])}
         />,
-        { organization: prIterationOrganization },
+        {organization: prIterationOrganization}
       );
 
-      expect(screen.getByText("Feedback")).toBeInTheDocument();
-      expect(screen.getByText("Make the button blue")).toBeInTheDocument();
+      expect(screen.getByText('Feedback')).toBeInTheDocument();
+      expect(screen.getByText('Make the button blue')).toBeInTheDocument();
     });
 
-    it("renders queued feedback with missing source attribution", () => {
+    it('renders queued feedback with missing source attribution', () => {
       const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofix,
         runState: {
           run_id: 123,
           blocks: [],
-          status: "completed",
-          updated_at: "2026-01-01T00:00:00Z",
-          queued_feedback: [{ text: "Make the button blue" }],
+          status: 'completed',
+          updated_at: '2026-01-01T00:00:00Z',
+          queued_feedback: [{text: 'Make the button blue'}],
         },
       };
 
@@ -934,32 +880,32 @@ describe("ArtifactCard", () => {
         <CodeChangesCard
           groupId="1"
           autofix={autofixWithQueued}
-          section={makeSection("code_changes", "completed", [
-            [makePatch("org/repo", "src/app.py")],
+          section={makeSection('code_changes', 'completed', [
+            [makePatch('org/repo', 'src/app.py')],
           ])}
         />,
-        { organization: prIterationOrganization },
+        {organization: prIterationOrganization}
       );
 
       // The source is shown in the avatar tooltip, not prefixed on the comment.
-      expect(screen.getByText("Make the button blue")).toBeInTheDocument();
+      expect(screen.getByText('Make the button blue')).toBeInTheDocument();
     });
 
-    it("renders GitHub PR review comment feedback with attribution and a link", () => {
-      const commentUrl = "https://github.com/org/repo/pull/42#discussion_r123";
+    it('renders GitHub PR review comment feedback with attribution and a link', () => {
+      const commentUrl = 'https://github.com/org/repo/pull/42#discussion_r123';
       const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofix,
         runState: {
           run_id: 123,
           blocks: [],
-          status: "completed",
-          updated_at: "2026-01-01T00:00:00Z",
+          status: 'completed',
+          updated_at: '2026-01-01T00:00:00Z',
           queued_feedback: [
             {
-              text: "Please handle the null value.",
+              text: 'Please handle the null value.',
               source: {
-                type: "github-pr-review-comment",
-                comment: { html_url: commentUrl, user: { login: "octocat" } },
+                type: 'github-pr-review-comment',
+                comment: {html_url: commentUrl, user: {login: 'octocat'}},
               },
             },
           ],
@@ -970,60 +916,57 @@ describe("ArtifactCard", () => {
         <CodeChangesCard
           groupId="1"
           autofix={autofixWithQueued}
-          section={makeSection("code_changes", "completed", [
-            [makePatch("org/repo", "src/app.py")],
+          section={makeSection('code_changes', 'completed', [
+            [makePatch('org/repo', 'src/app.py')],
           ])}
         />,
-        { organization: prIterationOrganization },
+        {organization: prIterationOrganization}
       );
 
       // The comment text is plain; a trailing "Open in GitHub" arrow links out.
-      expect(
-        screen.getByText("Please handle the null value."),
-      ).toBeInTheDocument();
-      const feedbackLink = screen.getByRole("link", { name: "Open in GitHub" });
-      expect(feedbackLink).toHaveAttribute("href", commentUrl);
+      expect(screen.getByText('Please handle the null value.')).toBeInTheDocument();
+      const feedbackLink = screen.getByRole('link', {name: 'Open in GitHub'});
+      expect(feedbackLink).toHaveAttribute('href', commentUrl);
     });
 
-    it("groups a review body with its inline comments under a state header", () => {
-      const reviewUrl =
-        "https://github.com/org/repo/pull/42#pullrequestreview-999";
+    it('groups a review body with its inline comments under a state header', () => {
+      const reviewUrl = 'https://github.com/org/repo/pull/42#pullrequestreview-999';
       const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofix,
         runState: {
           run_id: 123,
           blocks: [],
-          status: "completed",
-          updated_at: "2026-01-01T00:00:00Z",
+          status: 'completed',
+          updated_at: '2026-01-01T00:00:00Z',
           queued_feedback: [
             {
-              text: "Overall this needs work.",
+              text: 'Overall this needs work.',
               source: {
-                type: "github-pr-review-body",
+                type: 'github-pr-review-body',
                 html_url: reviewUrl,
                 review_id: 7,
-                review_state: "changes_requested",
+                review_state: 'changes_requested',
               },
             },
             {
-              text: "Handle the null value here.",
+              text: 'Handle the null value here.',
               source: {
-                type: "github-pr-review-comment",
+                type: 'github-pr-review-comment',
                 review_id: 7,
                 comment: {
-                  html_url: "https://github.com/org/repo/pull/42#r1",
-                  user: { login: "octocat" },
+                  html_url: 'https://github.com/org/repo/pull/42#r1',
+                  user: {login: 'octocat'},
                 },
               },
             },
             {
-              text: "And rename this variable.",
+              text: 'And rename this variable.',
               source: {
-                type: "github-pr-review-comment",
+                type: 'github-pr-review-comment',
                 review_id: 7,
                 comment: {
-                  html_url: "https://github.com/org/repo/pull/42#r2",
-                  user: { login: "octocat" },
+                  html_url: 'https://github.com/org/repo/pull/42#r2',
+                  user: {login: 'octocat'},
                 },
               },
             },
@@ -1035,38 +978,36 @@ describe("ArtifactCard", () => {
         <CodeChangesCard
           groupId="1"
           autofix={autofixWithQueued}
-          section={makeSection("code_changes", "completed", [
-            [makePatch("org/repo", "src/app.py")],
+          section={makeSection('code_changes', 'completed', [
+            [makePatch('org/repo', 'src/app.py')],
           ])}
         />,
-        { organization: prIterationOrganization },
+        {organization: prIterationOrganization}
       );
 
       // The review state renders as a single header badge…
-      expect(screen.getByText("Changes requested")).toBeInTheDocument();
+      expect(screen.getByText('Changes requested')).toBeInTheDocument();
       // …with the body text and both inline comments beneath it.
-      expect(screen.getByText("Overall this needs work.")).toBeInTheDocument();
-      expect(
-        screen.getByText("Handle the null value here."),
-      ).toBeInTheDocument();
-      expect(screen.getByText("And rename this variable.")).toBeInTheDocument();
+      expect(screen.getByText('Overall this needs work.')).toBeInTheDocument();
+      expect(screen.getByText('Handle the null value here.')).toBeInTheDocument();
+      expect(screen.getByText('And rename this variable.')).toBeInTheDocument();
     });
 
-    it("shows a state badge for a body-only review", () => {
+    it('shows a state badge for a body-only review', () => {
       const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofix,
         runState: {
           run_id: 123,
           blocks: [],
-          status: "completed",
-          updated_at: "2026-01-01T00:00:00Z",
+          status: 'completed',
+          updated_at: '2026-01-01T00:00:00Z',
           queued_feedback: [
             {
-              text: "Looks good to me.",
+              text: 'Looks good to me.',
               source: {
-                type: "github-pr-review-body",
+                type: 'github-pr-review-body',
                 review_id: 8,
-                review_state: "approved",
+                review_state: 'approved',
               },
             },
           ],
@@ -1077,18 +1018,18 @@ describe("ArtifactCard", () => {
         <CodeChangesCard
           groupId="1"
           autofix={autofixWithQueued}
-          section={makeSection("code_changes", "completed", [
-            [makePatch("org/repo", "src/app.py")],
+          section={makeSection('code_changes', 'completed', [
+            [makePatch('org/repo', 'src/app.py')],
           ])}
         />,
-        { organization: prIterationOrganization },
+        {organization: prIterationOrganization}
       );
 
-      expect(screen.getByText("Approved")).toBeInTheDocument();
-      expect(screen.getByText("Looks good to me.")).toBeInTheDocument();
+      expect(screen.getByText('Approved')).toBeInTheDocument();
+      expect(screen.getByText('Looks good to me.')).toBeInTheDocument();
     });
 
-    it("leaves a comment-only review (no body) ungrouped", () => {
+    it('leaves a comment-only review (no body) ungrouped', () => {
       // GitHub's "Add single comment" fires a review with no summary body, so no
       // header is synthesized — the inline comment renders flat, with no badge.
       const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
@@ -1096,17 +1037,17 @@ describe("ArtifactCard", () => {
         runState: {
           run_id: 123,
           blocks: [],
-          status: "completed",
-          updated_at: "2026-01-01T00:00:00Z",
+          status: 'completed',
+          updated_at: '2026-01-01T00:00:00Z',
           queued_feedback: [
             {
-              text: "One quick nit.",
+              text: 'One quick nit.',
               source: {
-                type: "github-pr-review-comment",
+                type: 'github-pr-review-comment',
                 review_id: 9,
                 comment: {
-                  html_url: "https://github.com/org/repo/pull/42#r3",
-                  user: { login: "octocat" },
+                  html_url: 'https://github.com/org/repo/pull/42#r3',
+                  user: {login: 'octocat'},
                 },
               },
             },
@@ -1118,38 +1059,38 @@ describe("ArtifactCard", () => {
         <CodeChangesCard
           groupId="1"
           autofix={autofixWithQueued}
-          section={makeSection("code_changes", "completed", [
-            [makePatch("org/repo", "src/app.py")],
+          section={makeSection('code_changes', 'completed', [
+            [makePatch('org/repo', 'src/app.py')],
           ])}
         />,
-        { organization: prIterationOrganization },
+        {organization: prIterationOrganization}
       );
 
-      expect(screen.getByText("One quick nit.")).toBeInTheDocument();
+      expect(screen.getByText('One quick nit.')).toBeInTheDocument();
       // No review-state badge without a body source to carry the state.
-      expect(screen.queryByText("Changes requested")).not.toBeInTheDocument();
-      expect(screen.queryByText("Approved")).not.toBeInTheDocument();
-      expect(screen.queryByText("Commented")).not.toBeInTheDocument();
+      expect(screen.queryByText('Changes requested')).not.toBeInTheDocument();
+      expect(screen.queryByText('Approved')).not.toBeInTheDocument();
+      expect(screen.queryByText('Commented')).not.toBeInTheDocument();
     });
 
-    it("shows a formatted check-suite label instead of the raw feedback text", () => {
+    it('shows a formatted check-suite label instead of the raw feedback text', () => {
       const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofix,
         runState: {
           run_id: 123,
           blocks: [],
-          status: "completed",
-          updated_at: "2026-01-01T00:00:00Z",
+          status: 'completed',
+          updated_at: '2026-01-01T00:00:00Z',
           queued_feedback: [
             {
-              text: "raw text",
-              ui_text: "check suite for app CI failed",
+              text: 'raw text',
+              ui_text: 'check suite for app CI failed',
               source: {
-                type: "check-suite",
-                app_name: "CI",
+                type: 'check-suite',
+                app_name: 'CI',
                 event: {
-                  check_suite: { id: 999, head_sha: "abc123" },
-                  repository: { html_url: "https://github.com/org/repo" },
+                  check_suite: {id: 999, head_sha: 'abc123'},
+                  repository: {html_url: 'https://github.com/org/repo'},
                 },
               },
             },
@@ -1161,34 +1102,34 @@ describe("ArtifactCard", () => {
         <CodeChangesCard
           groupId="1"
           autofix={autofixWithQueued}
-          section={makeSection("code_changes", "completed", [
-            [makePatch("org/repo", "src/app.py")],
+          section={makeSection('code_changes', 'completed', [
+            [makePatch('org/repo', 'src/app.py')],
           ])}
         />,
-        { organization: prIterationOrganization },
+        {organization: prIterationOrganization}
       );
 
-      expect(screen.getByText("CI failure detected")).toBeInTheDocument();
+      expect(screen.getByText('CI failure detected')).toBeInTheDocument();
       expect(screen.queryByText(/raw text/)).not.toBeInTheDocument();
     });
 
-    it("links check-suite feedback to the failing check suite", () => {
+    it('links check-suite feedback to the failing check suite', () => {
       const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofix,
         runState: {
           run_id: 123,
           blocks: [],
-          status: "completed",
-          updated_at: "2026-01-01T00:00:00Z",
+          status: 'completed',
+          updated_at: '2026-01-01T00:00:00Z',
           queued_feedback: [
             {
-              text: "raw text",
+              text: 'raw text',
               source: {
-                type: "check-suite",
-                app_name: "CI",
+                type: 'check-suite',
+                app_name: 'CI',
                 event: {
-                  check_suite: { id: 999, head_sha: "abc123" },
-                  repository: { html_url: "https://github.com/org/repo" },
+                  check_suite: {id: 999, head_sha: 'abc123'},
+                  repository: {html_url: 'https://github.com/org/repo'},
                 },
               },
             },
@@ -1200,33 +1141,31 @@ describe("ArtifactCard", () => {
         <CodeChangesCard
           groupId="1"
           autofix={autofixWithQueued}
-          section={makeSection("code_changes", "completed", [
-            [makePatch("org/repo", "src/app.py")],
+          section={makeSection('code_changes', 'completed', [
+            [makePatch('org/repo', 'src/app.py')],
           ])}
         />,
-        { organization: prIterationOrganization },
+        {organization: prIterationOrganization}
       );
 
       // The label is plain text; a trailing "Open in GitHub" arrow links to the run.
-      expect(screen.getByText("CI failure detected")).toBeInTheDocument();
-      const link = screen.getByRole("link", { name: "Open in GitHub" });
+      expect(screen.getByText('CI failure detected')).toBeInTheDocument();
+      const link = screen.getByRole('link', {name: 'Open in GitHub'});
       expect(link).toHaveAttribute(
-        "href",
-        "https://github.com/org/repo/commit/abc123/checks?check_suite_id=999",
+        'href',
+        'https://github.com/org/repo/commit/abc123/checks?check_suite_id=999'
       );
     });
 
-    it("shows the code changes for queued feedback without the feature flag", () => {
+    it('shows the code changes for queued feedback without the feature flag', () => {
       const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofix,
         runState: {
           run_id: 123,
           blocks: [],
-          status: "completed",
-          updated_at: "2026-01-01T00:00:00Z",
-          queued_feedback: [
-            { text: "Make the button blue", source: { type: "user-ui" } },
-          ],
+          status: 'completed',
+          updated_at: '2026-01-01T00:00:00Z',
+          queued_feedback: [{text: 'Make the button blue', source: {type: 'user-ui'}}],
         },
       };
 
@@ -1234,151 +1173,141 @@ describe("ArtifactCard", () => {
         <CodeChangesCard
           groupId="1"
           autofix={autofixWithQueued}
-          section={makeSection("code_changes", "completed", [
-            [makePatch("org/repo", "src/app.py")],
+          section={makeSection('code_changes', 'completed', [
+            [makePatch('org/repo', 'src/app.py')],
           ])}
-        />,
+        />
       );
 
-      expect(screen.getByText("1 file changed in 1 repo")).toBeInTheDocument();
-      expect(
-        screen.queryByText("Implementing changes…"),
-      ).not.toBeInTheDocument();
-      expect(screen.queryByText("Iterating on PR…")).not.toBeInTheDocument();
+      expect(screen.getByText('1 file changed in 1 repo')).toBeInTheDocument();
+      expect(screen.queryByText('Implementing changes…')).not.toBeInTheDocument();
+      expect(screen.queryByText('Iterating on PR…')).not.toBeInTheDocument();
     });
 
-    it("does not render iteration feedback without the feature flag", () => {
+    it('does not render iteration feedback without the feature flag', () => {
       render(
         <CodeChangesCard
           groupId="1"
           autofix={mockAutofix}
           section={makeSection(
-            "code_changes",
-            "completed",
-            [[makePatch("org/repo", "src/app.py")]],
-            [makePrIterationBlock(1, { text: "Add a test for this" })],
+            'code_changes',
+            'completed',
+            [[makePatch('org/repo', 'src/app.py')]],
+            [makePrIterationBlock(1, {text: 'Add a test for this'})]
           )}
-        />,
+        />
       );
 
-      expect(screen.queryByText("Feedback")).not.toBeInTheDocument();
-      expect(screen.queryByText("Add a test for this")).not.toBeInTheDocument();
+      expect(screen.queryByText('Feedback')).not.toBeInTheDocument();
+      expect(screen.queryByText('Add a test for this')).not.toBeInTheDocument();
       expect(screen.queryByText(/- Latest/)).not.toBeInTheDocument();
     });
 
-    it("renders a one-based version tag for the latest iteration", () => {
+    it('renders a one-based version tag for the latest iteration', () => {
       render(
         <CodeChangesCard
           groupId="1"
           autofix={mockAutofix}
           section={makeSection(
-            "code_changes",
-            "completed",
-            [[makePatch("org/repo", "src/app.py")]],
+            'code_changes',
+            'completed',
+            [[makePatch('org/repo', 'src/app.py')]],
             [
-              makePrIterationBlock(0, { text: "first pass" }),
-              makePrIterationBlock(1, { text: "second pass" }),
-            ],
+              makePrIterationBlock(0, {text: 'first pass'}),
+              makePrIterationBlock(1, {text: 'second pass'}),
+            ]
           )}
         />,
-        { organization: prIterationOrganization },
+        {organization: prIterationOrganization}
       );
 
       // iteration_index is zero-based; the latest (1) renders as v2.
-      expect(screen.getByText("v2 - Latest")).toBeInTheDocument();
+      expect(screen.getByText('v2 - Latest')).toBeInTheDocument();
     });
 
-    it("does not render a version tag without iterations", () => {
+    it('does not render a version tag without iterations', () => {
       render(
         <CodeChangesCard
           groupId="1"
           autofix={mockAutofix}
-          section={makeSection("code_changes", "completed", [
-            [makePatch("org/repo", "src/app.py")],
+          section={makeSection('code_changes', 'completed', [
+            [makePatch('org/repo', 'src/app.py')],
           ])}
-        />,
+        />
       );
 
       expect(screen.queryByText(/- Latest/)).not.toBeInTheDocument();
     });
 
-    it("shows the iterating loading message when processing a pr_iteration", () => {
+    it('shows the iterating loading message when processing a pr_iteration', () => {
       render(
         <CodeChangesCard
           groupId="1"
           autofix={mockAutofix}
           section={makeSection(
-            "code_changes",
-            "processing",
+            'code_changes',
+            'processing',
             [],
-            [makePrIterationBlock(0, { text: "fix the CI failure" })],
+            [makePrIterationBlock(0, {text: 'fix the CI failure'})]
           )}
         />,
-        { organization: prIterationOrganization },
+        {organization: prIterationOrganization}
       );
 
-      expect(screen.getByText("Iterating on PR…")).toBeInTheDocument();
-      expect(
-        screen.queryByText("Implementing changes…"),
-      ).not.toBeInTheDocument();
+      expect(screen.getByText('Iterating on PR…')).toBeInTheDocument();
+      expect(screen.queryByText('Implementing changes…')).not.toBeInTheDocument();
     });
 
-    it("marks block feedback as processed when the section is not processing", () => {
+    it('marks block feedback as processed when the section is not processing', () => {
       render(
         <CodeChangesCard
           groupId="1"
           autofix={mockAutofix}
           section={makeSection(
-            "code_changes",
-            "completed",
-            [[makePatch("org/repo", "src/app.py")]],
-            [makePrIterationBlock(0, { text: "first pass" })],
+            'code_changes',
+            'completed',
+            [[makePatch('org/repo', 'src/app.py')]],
+            [makePrIterationBlock(0, {text: 'first pass'})]
           )}
         />,
-        { organization: prIterationOrganization },
+        {organization: prIterationOrganization}
       );
 
-      expect(screen.getByText("first pass")).toBeInTheDocument();
-      expect(screen.getByTestId("feedback-processed")).toBeInTheDocument();
+      expect(screen.getByText('first pass')).toBeInTheDocument();
+      expect(screen.getByTestId('feedback-processed')).toBeInTheDocument();
     });
 
-    it("marks the current iteration feedback as in progress while processing", () => {
+    it('marks the current iteration feedback as in progress while processing', () => {
       render(
         <CodeChangesCard
           groupId="1"
           autofix={mockAutofix}
           section={makeSection(
-            "code_changes",
-            "processing",
+            'code_changes',
+            'processing',
             [],
-            [makePrIterationBlock(0, { text: "fix the CI failure" })],
+            [makePrIterationBlock(0, {text: 'fix the CI failure'})]
           )}
         />,
-        { organization: prIterationOrganization },
+        {organization: prIterationOrganization}
       );
 
       // While processing, the row shows a spinner (there is also the card body
       // "Iterating on PR…" loader, hence getAllByTestId) and no processed check.
-      expect(screen.getByText("fix the CI failure")).toBeInTheDocument();
-      expect(screen.getAllByTestId("loading-indicator").length).toBeGreaterThan(
-        0,
-      );
-      expect(
-        screen.queryByTestId("feedback-processed"),
-      ).not.toBeInTheDocument();
+      expect(screen.getByText('fix the CI failure')).toBeInTheDocument();
+      expect(screen.getAllByTestId('loading-indicator').length).toBeGreaterThan(0);
+      expect(screen.queryByTestId('feedback-processed')).not.toBeInTheDocument();
     });
 
-    it("marks queued feedback with a queued label and no timestamp", () => {
+    it('marks queued feedback with a queued label and no timestamp', () => {
       const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofix,
         runState: {
           run_id: 123,
           blocks: [],
-          status: "completed",
-          updated_at: "2026-01-01T00:00:00Z",
-          queued_feedback: [
-            { text: "Make the button blue", source: { type: "user-ui" } },
-          ],
+          status: 'completed',
+          updated_at: '2026-01-01T00:00:00Z',
+          queued_feedback: [{text: 'Make the button blue', source: {type: 'user-ui'}}],
         },
       };
 
@@ -1386,29 +1315,27 @@ describe("ArtifactCard", () => {
         <CodeChangesCard
           groupId="1"
           autofix={autofixWithQueued}
-          section={makeSection("code_changes", "completed", [
-            [makePatch("org/repo", "src/app.py")],
+          section={makeSection('code_changes', 'completed', [
+            [makePatch('org/repo', 'src/app.py')],
           ])}
         />,
-        { organization: prIterationOrganization },
+        {organization: prIterationOrganization}
       );
 
-      expect(screen.getByText("Make the button blue")).toBeInTheDocument();
-      expect(screen.getByText("Queued")).toBeInTheDocument();
-      expect(
-        screen.queryByTestId("feedback-processed"),
-      ).not.toBeInTheDocument();
+      expect(screen.getByText('Make the button blue')).toBeInTheDocument();
+      expect(screen.getByText('Queued')).toBeInTheDocument();
+      expect(screen.queryByTestId('feedback-processed')).not.toBeInTheDocument();
     });
 
-    it("keeps reset enabled with the feature flag even when PRs exist", () => {
+    it('keeps reset enabled with the feature flag even when PRs exist', () => {
       const autofix: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofix,
         runState: {
           run_id: 123,
           blocks: [],
-          status: "completed",
-          updated_at: "2026-01-01T00:00:00Z",
-          repo_pr_states: { "org/repo": makePR() },
+          status: 'completed',
+          updated_at: '2026-01-01T00:00:00Z',
+          repo_pr_states: {'org/repo': makePR()},
         },
       };
 
@@ -1416,24 +1343,24 @@ describe("ArtifactCard", () => {
         <CodeChangesCard
           groupId="1"
           autofix={autofix}
-          section={makeSection("code_changes", "completed", [
-            [makePatch("org/repo", "src/app.py")],
+          section={makeSection('code_changes', 'completed', [
+            [makePatch('org/repo', 'src/app.py')],
           ])}
         />,
-        { organization: prIterationOrganization },
+        {organization: prIterationOrganization}
       );
 
-      expect(screen.getByRole("button", { name: "Re-run step" })).toBeEnabled();
+      expect(screen.getByRole('button', {name: 'Re-run step'})).toBeEnabled();
     });
 
-    it("disables reset with the feature flag while processing before any PR exists", () => {
+    it('disables reset with the feature flag while processing before any PR exists', () => {
       const autofix: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofix,
         runState: {
           run_id: 123,
           blocks: [],
-          status: "processing",
-          updated_at: "2026-01-01T00:00:00Z",
+          status: 'processing',
+          updated_at: '2026-01-01T00:00:00Z',
           repo_pr_states: {},
         },
       };
@@ -1442,27 +1369,25 @@ describe("ArtifactCard", () => {
         <CodeChangesCard
           groupId="1"
           autofix={autofix}
-          section={makeSection("code_changes", "completed", [
-            [makePatch("org/repo", "src/app.py")],
+          section={makeSection('code_changes', 'completed', [
+            [makePatch('org/repo', 'src/app.py')],
           ])}
         />,
-        { organization: prIterationOrganization },
+        {organization: prIterationOrganization}
       );
 
-      expect(
-        screen.getByRole("button", { name: "Re-run step" }),
-      ).toBeDisabled();
+      expect(screen.getByRole('button', {name: 'Re-run step'})).toBeDisabled();
     });
 
-    it("keeps reset enabled with the feature flag while processing once a PR exists", () => {
+    it('keeps reset enabled with the feature flag while processing once a PR exists', () => {
       const autofix: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofix,
         runState: {
           run_id: 123,
           blocks: [],
-          status: "processing",
-          updated_at: "2026-01-01T00:00:00Z",
-          repo_pr_states: { "org/repo": makePR() },
+          status: 'processing',
+          updated_at: '2026-01-01T00:00:00Z',
+          repo_pr_states: {'org/repo': makePR()},
         },
       };
 
@@ -1470,25 +1395,25 @@ describe("ArtifactCard", () => {
         <CodeChangesCard
           groupId="1"
           autofix={autofix}
-          section={makeSection("code_changes", "completed", [
-            [makePatch("org/repo", "src/app.py")],
+          section={makeSection('code_changes', 'completed', [
+            [makePatch('org/repo', 'src/app.py')],
           ])}
         />,
-        { organization: prIterationOrganization },
+        {organization: prIterationOrganization}
       );
 
-      expect(screen.getByRole("button", { name: "Re-run step" })).toBeEnabled();
+      expect(screen.getByRole('button', {name: 'Re-run step'})).toBeEnabled();
     });
 
-    it("disables reset without the feature flag when PRs exist", () => {
+    it('disables reset without the feature flag when PRs exist', () => {
       const autofix: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofix,
         runState: {
           run_id: 123,
           blocks: [],
-          status: "completed",
-          updated_at: "2026-01-01T00:00:00Z",
-          repo_pr_states: { "org/repo": makePR() },
+          status: 'completed',
+          updated_at: '2026-01-01T00:00:00Z',
+          repo_pr_states: {'org/repo': makePR()},
         },
       };
 
@@ -1496,26 +1421,24 @@ describe("ArtifactCard", () => {
         <CodeChangesCard
           groupId="1"
           autofix={autofix}
-          section={makeSection("code_changes", "completed", [
-            [makePatch("org/repo", "src/app.py")],
+          section={makeSection('code_changes', 'completed', [
+            [makePatch('org/repo', 'src/app.py')],
           ])}
-        />,
+        />
       );
 
-      expect(
-        screen.getByRole("button", { name: "Re-run step" }),
-      ).toBeDisabled();
+      expect(screen.getByRole('button', {name: 'Re-run step'})).toBeDisabled();
     });
 
-    it("disables reset while a coding agent is active", () => {
+    it('disables reset while a coding agent is active', () => {
       const autofix: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofix,
         runState: {
           run_id: 123,
           blocks: [],
-          status: "completed",
-          updated_at: "2026-01-01T00:00:00Z",
-          coding_agents: { a: {} as any },
+          status: 'completed',
+          updated_at: '2026-01-01T00:00:00Z',
+          coding_agents: {a: {} as any},
         },
       };
 
@@ -1523,27 +1446,25 @@ describe("ArtifactCard", () => {
         <CodeChangesCard
           groupId="1"
           autofix={autofix}
-          section={makeSection("code_changes", "completed", [
-            [makePatch("org/repo", "src/app.py")],
+          section={makeSection('code_changes', 'completed', [
+            [makePatch('org/repo', 'src/app.py')],
           ])}
         />,
-        { organization: prIterationOrganization },
+        {organization: prIterationOrganization}
       );
 
-      expect(
-        screen.getByRole("button", { name: "Re-run step" }),
-      ).toBeDisabled();
+      expect(screen.getByRole('button', {name: 'Re-run step'})).toBeDisabled();
     });
 
-    it("shows the PR iteration form mid-run when reset is requested", async () => {
+    it('shows the PR iteration form mid-run when reset is requested', async () => {
       const autofix: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofix,
         runState: {
           run_id: 123,
           blocks: [],
-          status: "processing",
-          updated_at: "2026-01-01T00:00:00Z",
-          repo_pr_states: { "org/repo": makePR() },
+          status: 'processing',
+          updated_at: '2026-01-01T00:00:00Z',
+          repo_pr_states: {'org/repo': makePR()},
         },
       };
 
@@ -1552,376 +1473,363 @@ describe("ArtifactCard", () => {
           groupId="1"
           autofix={autofix}
           section={makeSection(
-            "code_changes",
-            "processing",
+            'code_changes',
+            'processing',
             [],
-            [makePrIterationBlock(0, { text: "fix the CI failure" })],
+            [makePrIterationBlock(0, {text: 'fix the CI failure'})]
           )}
         />,
-        { organization: prIterationOrganization },
+        {organization: prIterationOrganization}
       );
 
-      await userEvent.click(
-        screen.getByRole("button", { name: "Re-run step" }),
-      );
+      await userEvent.click(screen.getByRole('button', {name: 'Re-run step'}));
       expect(
-        screen.getByText("Anything else you want to see on your PR?"),
+        screen.getByText('Anything else you want to see on your PR?')
       ).toBeInTheDocument();
     });
   });
 
-  describe("PullRequestsCard", () => {
-    it("renders PR link buttons with correct text and href", () => {
+  describe('PullRequestsCard', () => {
+    it('renders PR link buttons with correct text and href', () => {
       render(
         <PullRequestsCard
           autofix={mockAutofixWithRunState}
-          section={makeSection("pull_request", "completed", [[makePR()]])}
-        />,
+          section={makeSection('pull_request', 'completed', [[makePR()]])}
+        />
       );
 
-      expect(screen.getByText("Pull Requests")).toBeInTheDocument();
-      const button = screen.getByRole("button", {
-        name: "View org/repo#42",
+      expect(screen.getByText('Pull Requests')).toBeInTheDocument();
+      const button = screen.getByRole('button', {
+        name: 'View org/repo#42',
       });
-      expect(button).toHaveAttribute(
-        "href",
-        "https://github.com/org/repo/pull/42",
-      );
+      expect(button).toHaveAttribute('href', 'https://github.com/org/repo/pull/42');
     });
 
-    it("renders multiple PR buttons", () => {
+    it('renders multiple PR buttons', () => {
       render(
         <PullRequestsCard
           autofix={mockAutofixWithRunState}
-          section={makeSection("pull_request", "completed", [
+          section={makeSection('pull_request', 'completed', [
             [
               makePR({
-                repo_name: "org/repo-a",
+                repo_name: 'org/repo-a',
                 pr_number: 10,
-                pr_url: "https://pr/10",
+                pr_url: 'https://pr/10',
               }),
               makePR({
-                repo_name: "org/repo-b",
+                repo_name: 'org/repo-b',
                 pr_number: 20,
-                pr_url: "https://pr/20",
+                pr_url: 'https://pr/20',
               }),
             ],
           ])}
-        />,
+        />
       );
 
       expect(
-        screen.getByRole("button", { name: "View org/repo-a#10" }),
+        screen.getByRole('button', {name: 'View org/repo-a#10'})
       ).toBeInTheDocument();
       expect(
-        screen.getByRole("button", { name: "View org/repo-b#20" }),
+        screen.getByRole('button', {name: 'View org/repo-b#20'})
       ).toBeInTheDocument();
     });
 
-    it("skips PRs with missing pr_url or pr_number", () => {
+    it('skips PRs with missing pr_url or pr_number', () => {
       render(
         <PullRequestsCard
           autofix={mockAutofixWithRunState}
-          section={makeSection("pull_request", "completed", [
+          section={makeSection('pull_request', 'completed', [
             [
-              makePR({ repo_name: "org/repo-a", pr_url: null }),
-              makePR({ repo_name: "org/repo-b", pr_number: null }),
+              makePR({repo_name: 'org/repo-a', pr_url: null}),
+              makePR({repo_name: 'org/repo-b', pr_number: null}),
               makePR({
-                repo_name: "org/valid",
+                repo_name: 'org/valid',
                 pr_number: 55,
-                pr_url: "https://pr/55",
+                pr_url: 'https://pr/55',
               }),
             ],
           ])}
-        />,
+        />
       );
 
-      expect(
-        screen.getByRole("button", { name: /View org\/valid#55/ }),
-      ).toHaveAttribute("href", "https://pr/55");
+      expect(screen.getByRole('button', {name: /View org\/valid#55/})).toHaveAttribute(
+        'href',
+        'https://pr/55'
+      );
     });
 
-    it("copies markdown when copy button is clicked", async () => {
+    it('copies markdown when copy button is clicked', async () => {
       render(
         <PullRequestsCard
           autofix={mockAutofixWithRunState}
-          section={makeSection("pull_request", "completed", [[makePR()]])}
-        />,
+          section={makeSection('pull_request', 'completed', [[makePR()]])}
+        />
       );
 
-      await userEvent.click(
-        screen.getByRole("button", { name: "Copy as Markdown" }),
-      );
+      await userEvent.click(screen.getByRole('button', {name: 'Copy as Markdown'}));
 
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
-        expect.stringContaining("Pull Requests"),
+        expect.stringContaining('Pull Requests')
       );
     });
   });
 
-  describe("ArtifactCard expand/collapse", () => {
-    it("children are visible by default", () => {
+  describe('ArtifactCard expand/collapse', () => {
+    it('children are visible by default', () => {
       const artifact = makeRootCauseArtifact({
-        one_line_description: "Bug",
-        five_whys: ["Visible why"],
+        one_line_description: 'Bug',
+        five_whys: ['Visible why'],
       });
 
       render(
         <RootCauseCard
           autofix={mockAutofix}
           groupId="1"
-          section={makeSection("root_cause", "completed", [artifact])}
-        />,
+          section={makeSection('root_cause', 'completed', [artifact])}
+        />
       );
 
-      expect(screen.getByText("Visible why")).toBeInTheDocument();
+      expect(screen.getByText('Visible why')).toBeInTheDocument();
     });
 
-    it("clicking collapse button hides children", async () => {
+    it('clicking collapse button hides children', async () => {
       const artifact = makeRootCauseArtifact({
-        one_line_description: "Bug",
-        five_whys: ["Hidden why"],
+        one_line_description: 'Bug',
+        five_whys: ['Hidden why'],
       });
 
       render(
         <RootCauseCard
           autofix={mockAutofix}
           groupId="1"
-          section={makeSection("root_cause", "completed", [artifact])}
-        />,
+          section={makeSection('root_cause', 'completed', [artifact])}
+        />
       );
 
-      await userEvent.click(screen.getByRole("button", { name: "Root Cause" }));
+      await userEvent.click(screen.getByRole('button', {name: 'Root Cause'}));
 
-      expect(screen.queryByText("Bug")).not.toBeVisible();
-      expect(screen.queryByText("Hidden why")).not.toBeVisible();
+      expect(screen.queryByText('Bug')).not.toBeVisible();
+      expect(screen.queryByText('Hidden why')).not.toBeVisible();
     });
 
-    it("clicking again re-shows children", async () => {
+    it('clicking again re-shows children', async () => {
       const artifact = makeRootCauseArtifact({
-        one_line_description: "Bug",
-        five_whys: ["Toggle why"],
+        one_line_description: 'Bug',
+        five_whys: ['Toggle why'],
       });
 
       render(
         <RootCauseCard
           autofix={mockAutofix}
           groupId="1"
-          section={makeSection("root_cause", "completed", [artifact])}
-        />,
+          section={makeSection('root_cause', 'completed', [artifact])}
+        />
       );
 
-      expect(screen.getByText("Bug")).toBeVisible();
-      expect(screen.getByText("Toggle why")).toBeVisible();
+      expect(screen.getByText('Bug')).toBeVisible();
+      expect(screen.getByText('Toggle why')).toBeVisible();
 
-      await userEvent.click(screen.getByRole("button", { name: "Root Cause" }));
-      expect(screen.queryByText("Bug")).not.toBeVisible();
-      expect(screen.queryByText("Toggle why")).not.toBeVisible();
+      await userEvent.click(screen.getByRole('button', {name: 'Root Cause'}));
+      expect(screen.queryByText('Bug')).not.toBeVisible();
+      expect(screen.queryByText('Toggle why')).not.toBeVisible();
 
-      await userEvent.click(screen.getByRole("button", { name: "Root Cause" }));
-      expect(screen.getByText("Bug")).toBeVisible();
-      expect(screen.getByText("Toggle why")).toBeVisible();
+      await userEvent.click(screen.getByRole('button', {name: 'Root Cause'}));
+      expect(screen.getByText('Bug')).toBeVisible();
+      expect(screen.getByText('Toggle why')).toBeVisible();
     });
   });
 
   function makeCodingAgent(
-    overrides: Partial<ExplorerCodingAgentState> = {},
+    overrides: Partial<ExplorerCodingAgentState> = {}
   ): ExplorerCodingAgentState {
     return {
-      id: "agent-1",
-      name: "My Agent Task",
+      id: 'agent-1',
+      name: 'My Agent Task',
       provider: CodingAgentProvider.CURSOR_BACKGROUND_AGENT,
-      started_at: "2026-01-01T00:00:00Z",
-      status: "running",
+      started_at: '2026-01-01T00:00:00Z',
+      status: 'running',
       ...overrides,
     };
   }
 
-  describe("CodingAgentsCard", () => {
-    it("renders agent name based on Cursor provider", () => {
+  describe('CodingAgentsCard', () => {
+    it('renders agent name based on Cursor provider', () => {
       render(
         <CodingAgentsCard
           autofix={mockAutofix}
-          section={makeSection("coding_agents", "completed", [
+          section={makeSection('coding_agents', 'completed', [
             [
               makeCodingAgent({
                 provider: CodingAgentProvider.CURSOR_BACKGROUND_AGENT,
               }),
             ],
           ])}
-        />,
+        />
       );
 
-      expect(screen.getByText("Cursor Cloud Agent")).toBeInTheDocument();
+      expect(screen.getByText('Cursor Cloud Agent')).toBeInTheDocument();
     });
 
-    it("renders agent name based on Claude provider", () => {
+    it('renders agent name based on Claude provider', () => {
       render(
         <CodingAgentsCard
           autofix={mockAutofix}
-          section={makeSection("coding_agents", "completed", [
+          section={makeSection('coding_agents', 'completed', [
             [
               makeCodingAgent({
                 provider: CodingAgentProvider.CLAUDE_CODE_AGENT,
               }),
             ],
           ])}
-        />,
+        />
       );
 
-      expect(screen.getByText("Claude Agent")).toBeInTheDocument();
+      expect(screen.getByText('Claude Agent')).toBeInTheDocument();
     });
 
-    it("renders agent name based on GitHub Copilot provider", () => {
+    it('renders agent name based on GitHub Copilot provider', () => {
       render(
         <CodingAgentsCard
           autofix={mockAutofix}
-          section={makeSection("coding_agents", "completed", [
+          section={makeSection('coding_agents', 'completed', [
             [
               makeCodingAgent({
                 provider: CodingAgentProvider.GITHUB_COPILOT_AGENT,
               }),
             ],
           ])}
-        />,
+        />
       );
 
-      expect(screen.getByText("GitHub Copilot")).toBeInTheDocument();
+      expect(screen.getByText('GitHub Copilot')).toBeInTheDocument();
     });
 
-    it("renders default agent name for unknown provider", () => {
+    it('renders default agent name for unknown provider', () => {
       render(
         <CodingAgentsCard
           autofix={mockAutofix}
-          section={makeSection("coding_agents", "completed", [
-            [makeCodingAgent({ provider: "unknown_provider" as any })],
+          section={makeSection('coding_agents', 'completed', [
+            [makeCodingAgent({provider: 'unknown_provider' as any})],
           ])}
-        />,
+        />
       );
 
-      expect(screen.getByText("Coding Agent")).toBeInTheDocument();
+      expect(screen.getByText('Coding Agent')).toBeInTheDocument();
     });
 
-    it("renders agent status tags", () => {
+    it('renders agent status tags', () => {
       render(
         <CodingAgentsCard
           autofix={mockAutofix}
-          section={makeSection("coding_agents", "completed", [
-            [makeCodingAgent({ status: "running" })],
+          section={makeSection('coding_agents', 'completed', [
+            [makeCodingAgent({status: 'running'})],
           ])}
-        />,
+        />
       );
 
-      expect(screen.getByText("running")).toBeInTheDocument();
+      expect(screen.getByText('running')).toBeInTheDocument();
     });
 
     it('renders "Open in" link when agent_url is present', () => {
       render(
         <CodingAgentsCard
           autofix={mockAutofix}
-          section={makeSection("coding_agents", "completed", [
+          section={makeSection('coding_agents', 'completed', [
             [
               makeCodingAgent({
-                agent_url: "https://cursor.com/agent/1",
+                agent_url: 'https://cursor.com/agent/1',
               }),
             ],
           ])}
-        />,
+        />
       );
 
-      const link = screen.getByRole("button", { name: /Open in/ });
-      expect(link).toHaveAttribute("href", "https://cursor.com/agent/1");
+      const link = screen.getByRole('button', {name: /Open in/});
+      expect(link).toHaveAttribute('href', 'https://cursor.com/agent/1');
     });
 
-    it("renders result PR links when results have pr_url", () => {
+    it('renders result PR links when results have pr_url', () => {
       render(
         <CodingAgentsCard
           autofix={mockAutofix}
-          section={makeSection("coding_agents", "completed", [
+          section={makeSection('coding_agents', 'completed', [
             [
               makeCodingAgent({
                 results: [
                   {
-                    description: "Fixed",
-                    repo_full_name: "org/repo",
-                    repo_provider: "github",
-                    pr_url: "https://github.com/org/repo/pull/99",
+                    description: 'Fixed',
+                    repo_full_name: 'org/repo',
+                    repo_provider: 'github',
+                    pr_url: 'https://github.com/org/repo/pull/99',
                   },
                 ],
               }),
             ],
           ])}
-        />,
+        />
       );
 
-      const link = screen.getByRole("button", { name: "View Pull Request" });
-      expect(link).toHaveAttribute(
-        "href",
-        "https://github.com/org/repo/pull/99",
-      );
+      const link = screen.getByRole('button', {name: 'View Pull Request'});
+      expect(link).toHaveAttribute('href', 'https://github.com/org/repo/pull/99');
     });
 
-    it("handles multiple coding agents", () => {
+    it('handles multiple coding agents', () => {
       render(
         <CodingAgentsCard
           autofix={mockAutofix}
-          section={makeSection("coding_agents", "completed", [
+          section={makeSection('coding_agents', 'completed', [
             [
               makeCodingAgent({
-                id: "agent-1",
-                name: "Agent One",
-                status: "completed",
+                id: 'agent-1',
+                name: 'Agent One',
+                status: 'completed',
               }),
               makeCodingAgent({
-                id: "agent-2",
-                name: "Agent Two",
-                status: "running",
+                id: 'agent-2',
+                name: 'Agent Two',
+                status: 'running',
               }),
             ],
           ])}
-        />,
+        />
       );
 
-      expect(screen.getByText("Agent One")).toBeInTheDocument();
-      expect(screen.getByText("Agent Two")).toBeInTheDocument();
-      expect(screen.getByText("completed")).toBeInTheDocument();
-      expect(screen.getByText("running")).toBeInTheDocument();
+      expect(screen.getByText('Agent One')).toBeInTheDocument();
+      expect(screen.getByText('Agent Two')).toBeInTheDocument();
+      expect(screen.getByText('completed')).toBeInTheDocument();
+      expect(screen.getByText('running')).toBeInTheDocument();
     });
 
-    it("copies markdown when copy button is clicked", async () => {
+    it('copies markdown when copy button is clicked', async () => {
       render(
         <CodingAgentsCard
           autofix={mockAutofix}
-          section={makeSection("coding_agents", "completed", [
+          section={makeSection('coding_agents', 'completed', [
             [
               makeCodingAgent({
-                agent_url: "https://cursor.com/agent/1",
+                agent_url: 'https://cursor.com/agent/1',
               }),
             ],
           ])}
-        />,
+        />
       );
 
-      await userEvent.click(
-        screen.getByRole("button", { name: "Copy as Markdown" }),
-      );
+      await userEvent.click(screen.getByRole('button', {name: 'Copy as Markdown'}));
 
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
-        expect.stringContaining("Coding Agents"),
+        expect.stringContaining('Coding Agents')
       );
     });
 
-    it("does not show copy button when no artifacts", () => {
+    it('does not show copy button when no artifacts', () => {
       render(
         <CodingAgentsCard
           autofix={mockAutofix}
-          section={makeSection("coding_agents", "completed", [])}
-        />,
+          section={makeSection('coding_agents', 'completed', [])}
+        />
       );
 
-      expect(
-        screen.queryByRole("button", { name: "Copy as Markdown" }),
-      ).toBeDisabled();
+      expect(screen.queryByRole('button', {name: 'Copy as Markdown'})).toBeDisabled();
     });
   });
 });

--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -1131,7 +1131,7 @@ describe('ArtifactCard', () => {
       // No review-state badge without a body source to carry the state.
       expect(screen.queryByText('Changes requested')).not.toBeInTheDocument();
       expect(screen.queryByText('Approved')).not.toBeInTheDocument();
-      expect(screen.queryByText('Commented')).not.toBeInTheDocument();
+      expect(screen.queryByText('Reviewed')).not.toBeInTheDocument();
     });
 
     it('shows a formatted check-suite label instead of the raw feedback text', () => {

--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -1,68 +1,72 @@
-import {OrganizationFixture} from 'sentry-fixture/organization';
+import { OrganizationFixture } from "sentry-fixture/organization";
 
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import { render, screen, userEvent } from "sentry-test/reactTestingLibrary";
 
-import {CodingAgentProvider} from 'sentry/components/events/autofix/types';
+import { CodingAgentProvider } from "sentry/components/events/autofix/types";
 import type {
   AutofixArtifact,
   AutofixSection,
   RootCauseArtifact,
   SolutionArtifact,
   useExplorerAutofix,
-} from 'sentry/components/events/autofix/useExplorerAutofix';
-import {CodeChangesCard} from 'sentry/components/events/autofix/v3/codeChangesCard';
-import {CodingAgentsCard} from 'sentry/components/events/autofix/v3/codingAgentsCard';
-import {PullRequestsCard} from 'sentry/components/events/autofix/v3/pullRequestsCard';
-import {RootCauseCard} from 'sentry/components/events/autofix/v3/rootCauseCard';
-import {SolutionCard} from 'sentry/components/events/autofix/v3/solutionCard';
+} from "sentry/components/events/autofix/useExplorerAutofix";
+import { CodeChangesCard } from "sentry/components/events/autofix/v3/codeChangesCard";
+import { CodingAgentsCard } from "sentry/components/events/autofix/v3/codingAgentsCard";
+import { PullRequestsCard } from "sentry/components/events/autofix/v3/pullRequestsCard";
+import { RootCauseCard } from "sentry/components/events/autofix/v3/rootCauseCard";
+import { SolutionCard } from "sentry/components/events/autofix/v3/solutionCard";
 import type {
   ExplorerCodingAgentState,
   ExplorerFilePatch,
   RepoPRState,
-} from 'sentry/views/seerExplorer/types';
+} from "sentry/views/seerExplorer/types";
 
-jest.mock('sentry/views/seerExplorer/components/fileDiffViewer', () => ({
+jest.mock("sentry/views/seerExplorer/components/fileDiffViewer", () => ({
   FileDiffViewer: () => <div data-testid="file-diff-viewer" />,
 }));
 
-const prIterationOrganization = OrganizationFixture({features: ['autofix-pr-iteration']});
+const prIterationOrganization = OrganizationFixture({
+  features: ["autofix-pr-iteration"],
+});
 
 function makeSection(
   step: string,
-  status: AutofixSection['status'],
+  status: AutofixSection["status"],
   artifacts: AutofixArtifact[],
-  blocks: AutofixSection['blocks'] = []
+  blocks: AutofixSection["blocks"] = [],
 ): AutofixSection {
-  return {step, artifacts, blocks, status};
+  return { step, artifacts, blocks, status };
 }
 
-function makeAssistantBlock(content: string | null): AutofixSection['blocks'][number] {
+function makeAssistantBlock(
+  content: string | null,
+): AutofixSection["blocks"][number] {
   return {
-    id: 'block-1',
-    timestamp: '2026-01-01T00:00:00Z',
-    message: {role: 'assistant', content},
+    id: "block-1",
+    timestamp: "2026-01-01T00:00:00Z",
+    message: { role: "assistant", content },
   };
 }
 
 function makePrIterationBlock(
   iterationIndex: number,
-  feedback: {text: string; timestamp?: string; user?: any}
-): AutofixSection['blocks'][number] {
+  feedback: { text: string; timestamp?: string; user?: any },
+): AutofixSection["blocks"][number] {
   return {
     id: `block-pr-${iterationIndex}`,
-    timestamp: '2026-01-01T00:00:00Z',
+    timestamp: "2026-01-01T00:00:00Z",
     message: {
-      role: 'user',
+      role: "user",
       content: null,
       metadata: {
-        step: 'pr_iteration',
+        step: "pr_iteration",
         iteration_index: String(iterationIndex),
         feedback: JSON.stringify({
           text: feedback.text,
           timestamp: feedback.timestamp,
           source: feedback.user
-            ? {type: 'user-ui', user: feedback.user}
-            : {type: 'user-ui'},
+            ? { type: "user-ui", user: feedback.user }
+            : { type: "user-ui" },
         }),
       },
     },
@@ -72,7 +76,7 @@ function makePrIterationBlock(
 function makePatch(repoName: string, path: string): ExplorerFilePatch {
   return {
     repo_name: repoName,
-    diff: '',
+    diff: "",
     patch: {
       path,
       added: 1,
@@ -80,22 +84,22 @@ function makePatch(repoName: string, path: string): ExplorerFilePatch {
       hunks: [],
       source_file: path,
       target_file: path,
-      type: 'M',
+      type: "M",
     },
   } as ExplorerFilePatch;
 }
 
 function makePR(overrides: Partial<RepoPRState> = {}): RepoPRState {
   return {
-    repo_name: 'org/repo',
+    repo_name: "org/repo",
     pr_number: 42,
-    pr_url: 'https://github.com/org/repo/pull/42',
-    branch_name: 'fix/issue',
-    commit_sha: 'abc123',
+    pr_url: "https://github.com/org/repo/pull/42",
+    branch_name: "fix/issue",
+    commit_sha: "abc123",
     pr_creation_error: null,
-    pr_creation_status: 'completed',
+    pr_creation_status: "completed",
     pr_id: 1,
-    title: 'Fix issue',
+    title: "Fix issue",
     ...overrides,
   };
 }
@@ -118,120 +122,124 @@ const mockAutofixWithRunState: ReturnType<typeof useExplorerAutofix> = {
   runState: {
     run_id: 123,
     blocks: [],
-    status: 'completed' as const,
-    updated_at: '2026-01-01T00:00:00Z',
+    status: "completed" as const,
+    updated_at: "2026-01-01T00:00:00Z",
   },
 };
 
 function makeRootCauseArtifact(data: RootCauseArtifact | null) {
   return {
-    key: 'root-cause',
-    reason: 'Found root cause',
+    key: "root-cause",
+    reason: "Found root cause",
     data,
   };
 }
 
 function makeSolutionArtifact(data: SolutionArtifact | null) {
   return {
-    key: 'solution',
-    reason: 'Found solution',
+    key: "solution",
+    reason: "Found solution",
     data,
   };
 }
 
-describe('ArtifactCard', () => {
+describe("ArtifactCard", () => {
   beforeEach(() => {
     userEvent.setup();
-    jest.spyOn(navigator.clipboard, 'writeText').mockResolvedValue();
+    jest.spyOn(navigator.clipboard, "writeText").mockResolvedValue();
   });
 
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  describe('RootCauseCard', () => {
-    it('renders title and one_line_description summary', () => {
+  describe("RootCauseCard", () => {
+    it("renders title and one_line_description summary", () => {
       const artifact = makeRootCauseArtifact({
-        one_line_description: 'Null pointer in user handler',
-        five_whys: ['why1', 'why2'],
-        reproduction_steps: ['step1'],
+        one_line_description: "Null pointer in user handler",
+        five_whys: ["why1", "why2"],
+        reproduction_steps: ["step1"],
       });
 
       render(
         <RootCauseCard
           autofix={mockAutofix}
           groupId="1"
-          section={makeSection('root_cause', 'completed', [artifact])}
-        />
+          section={makeSection("root_cause", "completed", [artifact])}
+        />,
       );
 
-      expect(screen.getByText('Root Cause')).toBeInTheDocument();
-      expect(screen.getByText('Null pointer in user handler')).toBeInTheDocument();
+      expect(screen.getByText("Root Cause")).toBeInTheDocument();
+      expect(
+        screen.getByText("Null pointer in user handler"),
+      ).toBeInTheDocument();
     });
 
-    it('renders five_whys list items and heading', () => {
+    it("renders five_whys list items and heading", () => {
       const artifact = makeRootCauseArtifact({
-        one_line_description: 'Bug',
-        five_whys: ['First why', 'Second why', 'Third why'],
+        one_line_description: "Bug",
+        five_whys: ["First why", "Second why", "Third why"],
       });
 
       render(
         <RootCauseCard
           autofix={mockAutofix}
           groupId="1"
-          section={makeSection('root_cause', 'completed', [artifact])}
-        />
+          section={makeSection("root_cause", "completed", [artifact])}
+        />,
       );
 
-      expect(screen.getByText('Why did this happen?')).toBeInTheDocument();
-      expect(screen.getByText('First why')).toBeInTheDocument();
-      expect(screen.getByText('Second why')).toBeInTheDocument();
-      expect(screen.getByText('Third why')).toBeInTheDocument();
+      expect(screen.getByText("Why did this happen?")).toBeInTheDocument();
+      expect(screen.getByText("First why")).toBeInTheDocument();
+      expect(screen.getByText("Second why")).toBeInTheDocument();
+      expect(screen.getByText("Third why")).toBeInTheDocument();
     });
 
-    it('renders reproduction_steps when present', () => {
+    it("renders reproduction_steps when present", () => {
       const artifact = makeRootCauseArtifact({
-        one_line_description: 'Bug',
-        five_whys: ['why1'],
-        reproduction_steps: ['Open the page', 'Click button'],
+        one_line_description: "Bug",
+        five_whys: ["why1"],
+        reproduction_steps: ["Open the page", "Click button"],
       });
 
       render(
         <RootCauseCard
           autofix={mockAutofix}
           groupId="1"
-          section={makeSection('root_cause', 'completed', [artifact])}
-        />
+          section={makeSection("root_cause", "completed", [artifact])}
+        />,
       );
 
-      expect(screen.getByText('Reproduction Steps')).toBeInTheDocument();
-      expect(screen.getByText('Open the page')).toBeInTheDocument();
-      expect(screen.getByText('Click button')).toBeInTheDocument();
+      expect(screen.getByText("Reproduction Steps")).toBeInTheDocument();
+      expect(screen.getByText("Open the page")).toBeInTheDocument();
+      expect(screen.getByText("Click button")).toBeInTheDocument();
     });
 
-    it('renders card shell when artifact data is null', () => {
+    it("renders card shell when artifact data is null", () => {
       const artifact = makeRootCauseArtifact(null);
 
       render(
         <RootCauseCard
           autofix={mockAutofix}
           groupId="1"
-          section={makeSection('root_cause', 'completed', [artifact])}
-        />
+          section={makeSection("root_cause", "completed", [artifact])}
+        />,
       );
 
-      expect(screen.getByText('Root Cause')).toBeInTheDocument();
+      expect(screen.getByText("Root Cause")).toBeInTheDocument();
       expect(
         screen.getByText(
-          'Seer failed to generate a root cause. This one is on us. Try running it again.'
-        )
+          "Seer failed to generate a root cause. This one is on us. Try running it again.",
+        ),
       ).toBeInTheDocument();
-      expect(screen.getByRole('button', {name: 'Re-run'})).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Re-run" }),
+      ).toBeInTheDocument();
     });
 
-    it('handles empty five_whys with placeholder', () => {
+    it("handles empty five_whys with placeholder", () => {
       const artifact = makeRootCauseArtifact({
-        one_line_description: 'Bug',
+        one_line_description: "Bug",
         five_whys: [],
       });
 
@@ -239,277 +247,297 @@ describe('ArtifactCard', () => {
         <RootCauseCard
           autofix={mockAutofix}
           groupId="1"
-          section={makeSection('root_cause', 'completed', [artifact])}
-        />
+          section={makeSection("root_cause", "completed", [artifact])}
+        />,
       );
 
-      expect(screen.getByText('Root Cause')).toBeInTheDocument();
-      expect(screen.queryByText('Why did this happen?')).not.toBeInTheDocument();
+      expect(screen.getByText("Root Cause")).toBeInTheDocument();
+      expect(
+        screen.queryByText("Why did this happen?"),
+      ).not.toBeInTheDocument();
     });
 
-    it('copies markdown when copy button is clicked', async () => {
+    it("copies markdown when copy button is clicked", async () => {
       const artifact = makeRootCauseArtifact({
-        one_line_description: 'Null pointer in user handler',
-        five_whys: ['Missing null check'],
-        reproduction_steps: ['Open page'],
+        one_line_description: "Null pointer in user handler",
+        five_whys: ["Missing null check"],
+        reproduction_steps: ["Open page"],
       });
 
       render(
         <RootCauseCard
           autofix={mockAutofix}
           groupId="1"
-          section={makeSection('root_cause', 'completed', [artifact])}
-        />
+          section={makeSection("root_cause", "completed", [artifact])}
+        />,
       );
 
-      await userEvent.click(screen.getByRole('button', {name: 'Copy as Markdown'}));
+      await userEvent.click(
+        screen.getByRole("button", { name: "Copy as Markdown" }),
+      );
 
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
-        expect.stringContaining('Null pointer in user handler')
+        expect.stringContaining("Null pointer in user handler"),
       );
     });
 
-    it('does not show copy button when artifact data is null', () => {
+    it("does not show copy button when artifact data is null", () => {
       const artifact = makeRootCauseArtifact(null);
 
       render(
         <RootCauseCard
           autofix={mockAutofix}
           groupId="1"
-          section={makeSection('root_cause', 'completed', [artifact])}
-        />
+          section={makeSection("root_cause", "completed", [artifact])}
+        />,
       );
 
-      expect(screen.queryByRole('button', {name: 'Copy as Markdown'})).toBeDisabled();
+      expect(
+        screen.queryByRole("button", { name: "Copy as Markdown" }),
+      ).toBeDisabled();
     });
   });
 
-  describe('SolutionCard', () => {
-    it('renders title and one_line_summary', () => {
+  describe("SolutionCard", () => {
+    it("renders title and one_line_summary", () => {
       const artifact = makeSolutionArtifact({
-        one_line_summary: 'Add null check before accessing user',
-        steps: [{title: 'Step 1', description: 'Add guard'}],
+        one_line_summary: "Add null check before accessing user",
+        steps: [{ title: "Step 1", description: "Add guard" }],
       });
 
       render(
         <SolutionCard
           autofix={mockAutofix}
-          section={makeSection('solution', 'completed', [artifact])}
-        />
+          section={makeSection("solution", "completed", [artifact])}
+        />,
       );
 
-      expect(screen.getByText('Plan')).toBeInTheDocument();
+      expect(screen.getByText("Plan")).toBeInTheDocument();
       expect(
-        screen.getByText('Add null check before accessing user')
+        screen.getByText("Add null check before accessing user"),
       ).toBeInTheDocument();
     });
 
-    it('renders steps with title and description', () => {
+    it("renders steps with title and description", () => {
       const artifact = makeSolutionArtifact({
-        one_line_summary: 'Fix the bug',
+        one_line_summary: "Fix the bug",
         steps: [
-          {title: 'Add validation', description: 'Check input is not null'},
-          {title: 'Update handler', description: 'Handle edge case'},
+          { title: "Add validation", description: "Check input is not null" },
+          { title: "Update handler", description: "Handle edge case" },
         ],
       });
 
       render(
         <SolutionCard
           autofix={mockAutofix}
-          section={makeSection('solution', 'completed', [artifact])}
-        />
+          section={makeSection("solution", "completed", [artifact])}
+        />,
       );
 
-      expect(screen.getByText('Steps to Resolve')).toBeInTheDocument();
-      expect(screen.getByText('Add validation')).toBeInTheDocument();
-      expect(screen.getByText('Check input is not null')).toBeInTheDocument();
-      expect(screen.getByText('Update handler')).toBeInTheDocument();
-      expect(screen.getByText('Handle edge case')).toBeInTheDocument();
+      expect(screen.getByText("Steps to Resolve")).toBeInTheDocument();
+      expect(screen.getByText("Add validation")).toBeInTheDocument();
+      expect(screen.getByText("Check input is not null")).toBeInTheDocument();
+      expect(screen.getByText("Update handler")).toBeInTheDocument();
+      expect(screen.getByText("Handle edge case")).toBeInTheDocument();
     });
 
-    it('renders card shell when artifact data is null', () => {
+    it("renders card shell when artifact data is null", () => {
       const artifact = makeSolutionArtifact(null);
 
       render(
         <SolutionCard
           autofix={mockAutofix}
-          section={makeSection('solution', 'completed', [artifact])}
-        />
+          section={makeSection("solution", "completed", [artifact])}
+        />,
       );
 
-      expect(screen.getByText('Plan')).toBeInTheDocument();
+      expect(screen.getByText("Plan")).toBeInTheDocument();
       expect(
         screen.getByText(
-          'Seer failed to generate a plan. This one is on us. Try running it again.'
-        )
+          "Seer failed to generate a plan. This one is on us. Try running it again.",
+        ),
       ).toBeInTheDocument();
-      expect(screen.getByRole('button', {name: 'Re-run'})).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Re-run" }),
+      ).toBeInTheDocument();
     });
 
-    it('copies markdown when copy button is clicked', async () => {
+    it("copies markdown when copy button is clicked", async () => {
       const artifact = makeSolutionArtifact({
-        one_line_summary: 'Add null check before accessing user',
-        steps: [{title: 'Add guard', description: 'Check input'}],
+        one_line_summary: "Add null check before accessing user",
+        steps: [{ title: "Add guard", description: "Check input" }],
       });
 
       render(
         <SolutionCard
           autofix={mockAutofix}
-          section={makeSection('solution', 'completed', [artifact])}
-        />
+          section={makeSection("solution", "completed", [artifact])}
+        />,
       );
 
-      await userEvent.click(screen.getByRole('button', {name: 'Copy as Markdown'}));
+      await userEvent.click(
+        screen.getByRole("button", { name: "Copy as Markdown" }),
+      );
 
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
-        expect.stringContaining('Add null check before accessing user')
+        expect.stringContaining("Add null check before accessing user"),
       );
     });
 
-    it('does not show copy button when artifact data is null', () => {
+    it("does not show copy button when artifact data is null", () => {
       const artifact = makeSolutionArtifact(null);
 
       render(
         <SolutionCard
           autofix={mockAutofix}
-          section={makeSection('solution', 'completed', [artifact])}
-        />
+          section={makeSection("solution", "completed", [artifact])}
+        />,
       );
 
-      expect(screen.queryByRole('button', {name: 'Copy as Markdown'})).toBeDisabled();
+      expect(
+        screen.queryByRole("button", { name: "Copy as Markdown" }),
+      ).toBeDisabled();
     });
   });
 
-  describe('CodeChangesCard', () => {
-    it('renders single file in single repo', () => {
+  describe("CodeChangesCard", () => {
+    it("renders single file in single repo", () => {
       render(
         <CodeChangesCard
           groupId="1"
           autofix={mockAutofix}
-          section={makeSection('code_changes', 'completed', [
-            [makePatch('org/repo', 'src/app.py')],
+          section={makeSection("code_changes", "completed", [
+            [makePatch("org/repo", "src/app.py")],
           ])}
-        />
+        />,
       );
 
-      expect(screen.getByText('Code Changes')).toBeInTheDocument();
-      expect(screen.getByText('1 file changed in 1 repo')).toBeInTheDocument();
+      expect(screen.getByText("Code Changes")).toBeInTheDocument();
+      expect(screen.getByText("1 file changed in 1 repo")).toBeInTheDocument();
     });
 
-    it('renders multiple files in single repo', () => {
+    it("renders multiple files in single repo", () => {
       render(
         <CodeChangesCard
           groupId="1"
           autofix={mockAutofix}
-          section={makeSection('code_changes', 'completed', [
+          section={makeSection("code_changes", "completed", [
             [
-              makePatch('org/repo', 'src/app.py'),
-              makePatch('org/repo', 'src/utils.py'),
-              makePatch('org/repo', 'src/models.py'),
+              makePatch("org/repo", "src/app.py"),
+              makePatch("org/repo", "src/utils.py"),
+              makePatch("org/repo", "src/models.py"),
             ],
           ])}
-        />
+        />,
       );
 
-      expect(screen.getByText('3 files changed in 1 repo')).toBeInTheDocument();
+      expect(screen.getByText("3 files changed in 1 repo")).toBeInTheDocument();
     });
 
-    it('renders multiple files in multiple repos', () => {
+    it("renders multiple files in multiple repos", () => {
       render(
         <CodeChangesCard
           groupId="1"
           autofix={mockAutofix}
-          section={makeSection('code_changes', 'completed', [
+          section={makeSection("code_changes", "completed", [
             [
-              makePatch('org/repo-a', 'src/app.py'),
-              makePatch('org/repo-a', 'src/utils.py'),
-              makePatch('org/repo-b', 'src/index.ts'),
+              makePatch("org/repo-a", "src/app.py"),
+              makePatch("org/repo-a", "src/utils.py"),
+              makePatch("org/repo-b", "src/index.ts"),
             ],
           ])}
-        />
+        />,
       );
 
-      expect(screen.getByText('3 files changed in 2 repos')).toBeInTheDocument();
+      expect(
+        screen.getByText("3 files changed in 2 repos"),
+      ).toBeInTheDocument();
     });
 
-    it('renders repository name labels', () => {
+    it("renders repository name labels", () => {
       render(
         <CodeChangesCard
           groupId="1"
           autofix={mockAutofix}
-          section={makeSection('code_changes', 'completed', [
+          section={makeSection("code_changes", "completed", [
             [
-              makePatch('org/repo-a', 'src/app.py'),
-              makePatch('org/repo-b', 'src/index.ts'),
+              makePatch("org/repo-a", "src/app.py"),
+              makePatch("org/repo-b", "src/index.ts"),
             ],
           ])}
-        />
+        />,
       );
 
-      expect(screen.getByText('org/repo-a')).toBeInTheDocument();
-      expect(screen.getByText('org/repo-b')).toBeInTheDocument();
+      expect(screen.getByText("org/repo-a")).toBeInTheDocument();
+      expect(screen.getByText("org/repo-b")).toBeInTheDocument();
     });
 
-    it('renders card shell when no code changes artifact found', () => {
+    it("renders card shell when no code changes artifact found", () => {
       render(
         <CodeChangesCard
           groupId="1"
           autofix={mockAutofix}
-          section={makeSection('code_changes', 'completed', [])}
-        />
+          section={makeSection("code_changes", "completed", [])}
+        />,
       );
 
-      expect(screen.getByText('Code Changes')).toBeInTheDocument();
+      expect(screen.getByText("Code Changes")).toBeInTheDocument();
       expect(
         screen.getByText(
-          'Seer failed to generate a code change. This one is on us. Try running it again.'
-        )
+          "Seer failed to generate a code change. This one is on us. Try running it again.",
+        ),
       ).toBeInTheDocument();
-      expect(screen.getByRole('button', {name: 'Re-run'})).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Re-run" }),
+      ).toBeInTheDocument();
     });
 
-    it('copies markdown when copy button is clicked', async () => {
+    it("copies markdown when copy button is clicked", async () => {
       render(
         <CodeChangesCard
           groupId="1"
           autofix={mockAutofix}
-          section={makeSection('code_changes', 'completed', [
-            [makePatch('org/repo', 'src/app.py')],
+          section={makeSection("code_changes", "completed", [
+            [makePatch("org/repo", "src/app.py")],
           ])}
-        />
+        />,
       );
 
-      await userEvent.click(screen.getByRole('button', {name: 'Copy as Markdown'}));
+      await userEvent.click(
+        screen.getByRole("button", { name: "Copy as Markdown" }),
+      );
 
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
-        expect.stringContaining('Code Changes')
+        expect.stringContaining("Code Changes"),
       );
     });
 
-    it('does not show copy button when no patches', () => {
+    it("does not show copy button when no patches", () => {
       render(
         <CodeChangesCard
           groupId="1"
           autofix={mockAutofix}
-          section={makeSection('code_changes', 'completed', [])}
-        />
+          section={makeSection("code_changes", "completed", [])}
+        />,
       );
 
-      expect(screen.queryByRole('button', {name: 'Copy as Markdown'})).toBeDisabled();
+      expect(
+        screen.queryByRole("button", { name: "Copy as Markdown" }),
+      ).toBeDisabled();
     });
 
-    it('renders error state when all patches have no changes', () => {
+    it("renders error state when all patches have no changes", () => {
       const emptyPatch = {
-        repo_name: 'org/repo',
-        diff: '',
+        repo_name: "org/repo",
+        diff: "",
         patch: {
-          path: 'src/app.py',
+          path: "src/app.py",
           added: 0,
           removed: 0,
           hunks: [],
-          source_file: 'src/app.py',
-          target_file: 'src/app.py',
-          type: 'M',
+          source_file: "src/app.py",
+          target_file: "src/app.py",
+          type: "M",
         },
       } as ExplorerFilePatch;
 
@@ -517,19 +545,21 @@ describe('ArtifactCard', () => {
         <CodeChangesCard
           groupId="1"
           autofix={mockAutofix}
-          section={makeSection('code_changes', 'completed', [[emptyPatch]])}
-        />
+          section={makeSection("code_changes", "completed", [[emptyPatch]])}
+        />,
       );
 
       expect(
         screen.getByText(
-          'Seer failed to generate a code change. This one is on us. Try running it again.'
-        )
+          "Seer failed to generate a code change. This one is on us. Try running it again.",
+        ),
       ).toBeInTheDocument();
-      expect(screen.getByRole('button', {name: 'Re-run'})).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Re-run" }),
+      ).toBeInTheDocument();
     });
 
-    it('calls startStep when re-run button is clicked in error state', async () => {
+    it("calls startStep when re-run button is clicked in error state", async () => {
       const startStepMock = jest.fn();
       const autofixWithRunState = {
         ...mockAutofix,
@@ -537,8 +567,8 @@ describe('ArtifactCard', () => {
         runState: {
           run_id: 123,
           blocks: [],
-          status: 'completed' as const,
-          updated_at: '2026-01-01T00:00:00Z',
+          status: "completed" as const,
+          updated_at: "2026-01-01T00:00:00Z",
         },
       };
 
@@ -546,106 +576,116 @@ describe('ArtifactCard', () => {
         <CodeChangesCard
           groupId="1"
           autofix={autofixWithRunState}
-          section={makeSection('code_changes', 'completed', [])}
-        />
+          section={makeSection("code_changes", "completed", [])}
+        />,
       );
 
-      await userEvent.click(screen.getByRole('button', {name: 'Re-run'}));
+      await userEvent.click(screen.getByRole("button", { name: "Re-run" }));
       expect(startStepMock).toHaveBeenCalledWith(
-        'code_changes',
-        expect.objectContaining({runId: 123})
+        "code_changes",
+        expect.objectContaining({ runId: 123 }),
       );
     });
 
-    it('renders loading state when processing, not error', () => {
+    it("renders loading state when processing, not error", () => {
       render(
         <CodeChangesCard
           groupId="1"
           autofix={mockAutofix}
-          section={makeSection('code_changes', 'processing', [])}
-        />
+          section={makeSection("code_changes", "processing", [])}
+        />,
       );
 
-      expect(screen.getByText('Implementing changes…')).toBeInTheDocument();
+      expect(screen.getByText("Implementing changes…")).toBeInTheDocument();
       expect(
         screen.queryByText(
-          'Seer failed to generate a code change. This one is on us. Try running it again.'
-        )
+          "Seer failed to generate a code change. This one is on us. Try running it again.",
+        ),
       ).not.toBeInTheDocument();
     });
 
-    it('does not render file diff viewers in error state', () => {
+    it("does not render file diff viewers in error state", () => {
       render(
         <CodeChangesCard
           groupId="1"
           autofix={mockAutofix}
-          section={makeSection('code_changes', 'completed', [])}
-        />
+          section={makeSection("code_changes", "completed", [])}
+        />,
       );
 
-      expect(screen.queryByTestId('file-diff-viewer')).not.toBeInTheDocument();
+      expect(screen.queryByTestId("file-diff-viewer")).not.toBeInTheDocument();
     });
 
-    it('surfaces the agent explanation when no patches but a final message exists', () => {
+    it("surfaces the agent explanation when no patches but a final message exists", () => {
       render(
         <CodeChangesCard
           groupId="1"
           autofix={mockAutofixWithRunState}
           section={makeSection(
-            'code_changes',
-            'completed',
+            "code_changes",
+            "completed",
             [],
             [
               makeAssistantBlock(
-                'This fix requires a database migration, not a code change.'
+                "This fix requires a database migration, not a code change.",
               ),
-            ]
+            ],
           )}
-        />
+        />,
       );
 
       expect(
-        screen.getByText("Seer proposed a fix but couldn't apply it automatically")
+        screen.getByText(
+          "Seer proposed a fix but couldn't apply it automatically",
+        ),
       ).toBeInTheDocument();
       expect(
-        screen.getByText('This fix requires a database migration, not a code change.')
+        screen.getByText(
+          "This fix requires a database migration, not a code change.",
+        ),
       ).toBeInTheDocument();
       expect(
-        screen.getByRole('button', {name: 'Add context & retry'})
+        screen.getByRole("button", { name: "Add context & retry" }),
       ).toBeInTheDocument();
       // The generic "this one is on us" copy should not appear here.
       expect(
         screen.queryByText(
-          'Seer failed to generate a code change. This one is on us. Try running it again.'
-        )
+          "Seer failed to generate a code change. This one is on us. Try running it again.",
+        ),
       ).not.toBeInTheDocument();
     });
 
-    it('opens the context prompt from the explanation state', async () => {
+    it("opens the context prompt from the explanation state", async () => {
       render(
         <CodeChangesCard
           groupId="1"
           autofix={mockAutofixWithRunState}
           section={makeSection(
-            'code_changes',
-            'completed',
+            "code_changes",
+            "completed",
             [],
-            [makeAssistantBlock('The relevant files are not in the connected repo.')]
+            [
+              makeAssistantBlock(
+                "The relevant files are not in the connected repo.",
+              ),
+            ],
           )}
-        />
+        />,
       );
 
-      await userEvent.click(screen.getByRole('button', {name: 'Add context & retry'}));
+      await userEvent.click(
+        screen.getByRole("button", { name: "Add context & retry" }),
+      );
 
       expect(
-        screen.getByText('What additional context should Seer use?')
+        screen.getByText("What additional context should Seer use?"),
       ).toBeInTheDocument();
       expect(
-        screen.queryByRole('button', {name: 'Add context & retry'})
+        screen.queryByRole("button", { name: "Add context & retry" }),
       ).not.toBeInTheDocument();
     });
 
-    it('opens PR iteration feedback from explanation state when a PR exists', async () => {
+    it("opens PR iteration feedback from explanation state when a PR exists", async () => {
       const startStepMock = jest.fn();
       const autofixWithPR: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofixWithRunState,
@@ -653,9 +693,9 @@ describe('ArtifactCard', () => {
         runState: {
           run_id: 123,
           blocks: [],
-          status: 'completed',
-          updated_at: '2026-01-01T00:00:00Z',
-          repo_pr_states: {'org/repo': makePR()},
+          status: "completed",
+          updated_at: "2026-01-01T00:00:00Z",
+          repo_pr_states: { "org/repo": makePR() },
         },
       };
 
@@ -664,68 +704,79 @@ describe('ArtifactCard', () => {
           groupId="1"
           autofix={autofixWithPR}
           section={makeSection(
-            'code_changes',
-            'completed',
+            "code_changes",
+            "completed",
             [],
-            [makeAssistantBlock('The relevant files are not in the connected repo.')]
+            [
+              makeAssistantBlock(
+                "The relevant files are not in the connected repo.",
+              ),
+            ],
           )}
         />,
-        {organization: prIterationOrganization}
+        { organization: prIterationOrganization },
       );
 
-      await userEvent.click(screen.getByRole('button', {name: 'Add context & retry'}));
+      await userEvent.click(
+        screen.getByRole("button", { name: "Add context & retry" }),
+      );
 
       expect(
-        screen.getByText('Anything else you want to see on your PR?')
+        screen.getByText("Anything else you want to see on your PR?"),
       ).toBeInTheDocument();
       expect(
-        screen.queryByText('What additional context should Seer use?')
+        screen.queryByText("What additional context should Seer use?"),
       ).not.toBeInTheDocument();
 
-      await userEvent.type(screen.getByRole('textbox'), 'Try the other repo');
-      await userEvent.click(screen.getByRole('button', {name: 'Submit'}));
+      await userEvent.type(screen.getByRole("textbox"), "Try the other repo");
+      await userEvent.click(screen.getByRole("button", { name: "Submit" }));
 
-      expect(startStepMock).toHaveBeenCalledWith('pr_iteration', {
+      expect(startStepMock).toHaveBeenCalledWith("pr_iteration", {
         runId: 123,
-        userContext: 'Try the other repo',
+        userContext: "Try the other repo",
       });
     });
 
-    it('falls back to the generic failure copy when there is no explanation', () => {
+    it("falls back to the generic failure copy when there is no explanation", () => {
       render(
         <CodeChangesCard
           groupId="1"
           autofix={mockAutofix}
           section={makeSection(
-            'code_changes',
-            'completed',
+            "code_changes",
+            "completed",
             [],
-            [makeAssistantBlock('   ')]
+            [makeAssistantBlock("   ")],
           )}
-        />
+        />,
       );
 
       expect(
         screen.getByText(
-          'Seer failed to generate a code change. This one is on us. Try running it again.'
-        )
+          "Seer failed to generate a code change. This one is on us. Try running it again.",
+        ),
       ).toBeInTheDocument();
       expect(
-        screen.queryByText("Seer proposed a fix but couldn't apply it automatically")
+        screen.queryByText(
+          "Seer proposed a fix but couldn't apply it automatically",
+        ),
       ).not.toBeInTheDocument();
     });
 
-    it('silently ignores pr_iteration blocks with an unrecognized source type', () => {
-      const block: AutofixSection['blocks'][number] = {
-        id: 'block-unknown',
-        timestamp: '2026-01-01T00:00:00Z',
+    it("silently ignores pr_iteration blocks with an unrecognized source type", () => {
+      const block: AutofixSection["blocks"][number] = {
+        id: "block-unknown",
+        timestamp: "2026-01-01T00:00:00Z",
         message: {
-          role: 'user',
+          role: "user",
           content: null,
           metadata: {
-            step: 'pr_iteration',
-            iteration_index: '0',
-            feedback: JSON.stringify({text: 'ignored', source: {type: 'mystery'}}),
+            step: "pr_iteration",
+            iteration_index: "0",
+            feedback: JSON.stringify({
+              text: "ignored",
+              source: { type: "mystery" },
+            }),
           },
         },
       };
@@ -734,45 +785,47 @@ describe('ArtifactCard', () => {
           groupId="1"
           autofix={mockAutofix}
           section={makeSection(
-            'code_changes',
-            'completed',
-            [[makePatch('org/repo', 'src/app.py')]],
-            [block]
+            "code_changes",
+            "completed",
+            [[makePatch("org/repo", "src/app.py")]],
+            [block],
           )}
-        />
+        />,
       );
 
-      expect(screen.queryByText('Feedback')).not.toBeInTheDocument();
+      expect(screen.queryByText("Feedback")).not.toBeInTheDocument();
     });
 
-    it('renders feedback from pr_iteration blocks', () => {
+    it("renders feedback from pr_iteration blocks", () => {
       render(
         <CodeChangesCard
           groupId="1"
           autofix={mockAutofix}
           section={makeSection(
-            'code_changes',
-            'completed',
-            [[makePatch('org/repo', 'src/app.py')]],
-            [makePrIterationBlock(1, {text: 'Add a test for this'})]
+            "code_changes",
+            "completed",
+            [[makePatch("org/repo", "src/app.py")]],
+            [makePrIterationBlock(1, { text: "Add a test for this" })],
           )}
         />,
-        {organization: prIterationOrganization}
+        { organization: prIterationOrganization },
       );
 
-      expect(screen.getByText('Feedback')).toBeInTheDocument();
-      expect(screen.getByText('Add a test for this')).toBeInTheDocument();
+      expect(screen.getByText("Feedback")).toBeInTheDocument();
+      expect(screen.getByText("Add a test for this")).toBeInTheDocument();
     });
 
-    it('renders the latest feedback at the top of the list', () => {
+    it("renders the latest feedback at the top of the list", () => {
       const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofix,
         runState: {
           run_id: 123,
           blocks: [],
-          status: 'completed',
-          updated_at: '2026-01-01T00:00:00Z',
-          queued_feedback: [{text: 'newest queued', source: {type: 'user-ui'}}],
+          status: "completed",
+          updated_at: "2026-01-01T00:00:00Z",
+          queued_feedback: [
+            { text: "newest queued", source: { type: "user-ui" } },
+          ],
         },
       };
 
@@ -781,35 +834,37 @@ describe('ArtifactCard', () => {
           groupId="1"
           autofix={autofixWithQueued}
           section={makeSection(
-            'code_changes',
-            'completed',
-            [[makePatch('org/repo', 'src/app.py')]],
+            "code_changes",
+            "completed",
+            [[makePatch("org/repo", "src/app.py")]],
             [
-              makePrIterationBlock(0, {text: 'first pass'}),
-              makePrIterationBlock(1, {text: 'second pass'}),
-            ]
+              makePrIterationBlock(0, { text: "first pass" }),
+              makePrIterationBlock(1, { text: "second pass" }),
+            ],
           )}
         />,
-        {organization: prIterationOrganization}
+        { organization: prIterationOrganization },
       );
 
       const items = screen.getAllByText(/first pass|second pass|newest queued/);
-      expect(items.map(item => item.textContent)).toEqual([
-        'newest queued',
-        'second pass',
-        'first pass',
+      expect(items.map((item) => item.textContent)).toEqual([
+        "newest queued",
+        "second pass",
+        "first pass",
       ]);
     });
 
-    it('shows the code changes, not the loader, when feedback is only queued', () => {
+    it("shows the code changes, not the loader, when feedback is only queued", () => {
       const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofix,
         runState: {
           run_id: 123,
           blocks: [],
-          status: 'completed',
-          updated_at: '2026-01-01T00:00:00Z',
-          queued_feedback: [{text: 'Make the button blue', source: {type: 'user-ui'}}],
+          status: "completed",
+          updated_at: "2026-01-01T00:00:00Z",
+          queued_feedback: [
+            { text: "Make the button blue", source: { type: "user-ui" } },
+          ],
         },
       };
 
@@ -818,177 +873,157 @@ describe('ArtifactCard', () => {
           groupId="1"
           autofix={autofixWithQueued}
           section={makeSection(
-            'code_changes',
-            'completed',
-            [[makePatch('org/repo', 'src/app.py')]],
-            [makePrIterationBlock(0, {text: 'first pass'})]
+            "code_changes",
+            "completed",
+            [[makePatch("org/repo", "src/app.py")]],
+            [makePrIterationBlock(0, { text: "first pass" })],
           )}
         />,
-        {organization: prIterationOrganization}
+        { organization: prIterationOrganization },
       );
 
-      expect(screen.getByText('1 file changed in 1 repo')).toBeInTheDocument();
-      expect(screen.queryByText('Iterating on PR…')).not.toBeInTheDocument();
-      expect(screen.queryByText('Implementing changes…')).not.toBeInTheDocument();
-    });
-
-    it('renders queued feedback as a feedback item', () => {
-      const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
-        ...mockAutofix,
-        runState: {
-          run_id: 123,
-          blocks: [],
-          status: 'completed',
-          updated_at: '2026-01-01T00:00:00Z',
-          queued_feedback: [{text: 'Make the button blue', source: {type: 'user-ui'}}],
-        },
-      };
-
-      render(
-        <CodeChangesCard
-          groupId="1"
-          autofix={autofixWithQueued}
-          section={makeSection('code_changes', 'completed', [
-            [makePatch('org/repo', 'src/app.py')],
-          ])}
-        />,
-        {organization: prIterationOrganization}
-      );
-
-      expect(screen.getByText('Feedback')).toBeInTheDocument();
-      expect(screen.getByText('Make the button blue')).toBeInTheDocument();
-    });
-
-    it('renders queued feedback with missing source attribution', () => {
-      const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
-        ...mockAutofix,
-        runState: {
-          run_id: 123,
-          blocks: [],
-          status: 'completed',
-          updated_at: '2026-01-01T00:00:00Z',
-          queued_feedback: [{text: 'Make the button blue'}],
-        },
-      };
-
-      render(
-        <CodeChangesCard
-          groupId="1"
-          autofix={autofixWithQueued}
-          section={makeSection('code_changes', 'completed', [
-            [makePatch('org/repo', 'src/app.py')],
-          ])}
-        />,
-        {organization: prIterationOrganization}
-      );
-
-      // The source is shown in the avatar tooltip, not prefixed on the comment.
-      expect(screen.getByText('Make the button blue')).toBeInTheDocument();
-    });
-
-    it('renders GitHub PR review comment feedback with attribution and a link', () => {
-      const commentUrl = 'https://github.com/org/repo/pull/42#discussion_r123';
-      const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
-        ...mockAutofix,
-        runState: {
-          run_id: 123,
-          blocks: [],
-          status: 'completed',
-          updated_at: '2026-01-01T00:00:00Z',
-          queued_feedback: [
-            {
-              text: 'Please handle the null value.',
-              source: {
-                type: 'github-pr-review-comment',
-                comment: {html_url: commentUrl, user: {login: 'octocat'}},
-              },
-            },
-          ],
-        },
-      };
-
-      render(
-        <CodeChangesCard
-          groupId="1"
-          autofix={autofixWithQueued}
-          section={makeSection('code_changes', 'completed', [
-            [makePatch('org/repo', 'src/app.py')],
-          ])}
-        />,
-        {organization: prIterationOrganization}
-      );
-
-      // The comment text is plain; a trailing "Open in GitHub" arrow links out.
-      expect(screen.getByText('Please handle the null value.')).toBeInTheDocument();
-      const feedbackLink = screen.getByRole('link', {name: 'Open in GitHub'});
-      expect(feedbackLink).toHaveAttribute('href', commentUrl);
-    });
-
-    it('renders a GitHub PR review body as plain feedback text', () => {
-      const reviewUrl = 'https://github.com/org/repo/pull/42#pullrequestreview-999';
-      const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
-        ...mockAutofix,
-        runState: {
-          run_id: 123,
-          blocks: [],
-          status: 'completed',
-          updated_at: '2026-01-01T00:00:00Z',
-          queued_feedback: [
-            {
-              text: 'Overall this looks good, please add a test.',
-              source: {
-                type: 'github-pr-review-body',
-                review_id: 999,
-                body: 'Overall this looks good, please add a test.',
-                html_url: reviewUrl,
-              },
-            },
-          ],
-        },
-      };
-
-      render(
-        <CodeChangesCard
-          groupId="1"
-          autofix={autofixWithQueued}
-          section={makeSection('code_changes', 'completed', [
-            [makePatch('org/repo', 'src/app.py')],
-          ])}
-        />,
-        {organization: prIterationOrganization}
-      );
-
-      // Review bodies have no dedicated cell yet, so they fall through to the
-      // generic renderer: plain text with no external link. Grouping the body
-      // with its inline comments under a state header comes in a later change.
+      expect(screen.getByText("1 file changed in 1 repo")).toBeInTheDocument();
+      expect(screen.queryByText("Iterating on PR…")).not.toBeInTheDocument();
       expect(
-        screen.getByText('Overall this looks good, please add a test.')
-      ).toBeInTheDocument();
-      expect(
-        screen.queryByRole('link', {
-          name: 'Overall this looks good, please add a test.',
-        })
+        screen.queryByText("Implementing changes…"),
       ).not.toBeInTheDocument();
     });
 
-    it('shows a formatted check-suite label instead of the raw feedback text', () => {
+    it("renders queued feedback as a feedback item", () => {
       const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofix,
         runState: {
           run_id: 123,
           blocks: [],
-          status: 'completed',
-          updated_at: '2026-01-01T00:00:00Z',
+          status: "completed",
+          updated_at: "2026-01-01T00:00:00Z",
+          queued_feedback: [
+            { text: "Make the button blue", source: { type: "user-ui" } },
+          ],
+        },
+      };
+
+      render(
+        <CodeChangesCard
+          groupId="1"
+          autofix={autofixWithQueued}
+          section={makeSection("code_changes", "completed", [
+            [makePatch("org/repo", "src/app.py")],
+          ])}
+        />,
+        { organization: prIterationOrganization },
+      );
+
+      expect(screen.getByText("Feedback")).toBeInTheDocument();
+      expect(screen.getByText("Make the button blue")).toBeInTheDocument();
+    });
+
+    it("renders queued feedback with missing source attribution", () => {
+      const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
+        ...mockAutofix,
+        runState: {
+          run_id: 123,
+          blocks: [],
+          status: "completed",
+          updated_at: "2026-01-01T00:00:00Z",
+          queued_feedback: [{ text: "Make the button blue" }],
+        },
+      };
+
+      render(
+        <CodeChangesCard
+          groupId="1"
+          autofix={autofixWithQueued}
+          section={makeSection("code_changes", "completed", [
+            [makePatch("org/repo", "src/app.py")],
+          ])}
+        />,
+        { organization: prIterationOrganization },
+      );
+
+      // The source is shown in the avatar tooltip, not prefixed on the comment.
+      expect(screen.getByText("Make the button blue")).toBeInTheDocument();
+    });
+
+    it("renders GitHub PR review comment feedback with attribution and a link", () => {
+      const commentUrl = "https://github.com/org/repo/pull/42#discussion_r123";
+      const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
+        ...mockAutofix,
+        runState: {
+          run_id: 123,
+          blocks: [],
+          status: "completed",
+          updated_at: "2026-01-01T00:00:00Z",
           queued_feedback: [
             {
-              text: 'raw text',
-              ui_text: 'check suite for app CI failed',
+              text: "Please handle the null value.",
               source: {
-                type: 'check-suite',
-                app_name: 'CI',
-                event: {
-                  check_suite: {id: 999, head_sha: 'abc123'},
-                  repository: {html_url: 'https://github.com/org/repo'},
+                type: "github-pr-review-comment",
+                comment: { html_url: commentUrl, user: { login: "octocat" } },
+              },
+            },
+          ],
+        },
+      };
+
+      render(
+        <CodeChangesCard
+          groupId="1"
+          autofix={autofixWithQueued}
+          section={makeSection("code_changes", "completed", [
+            [makePatch("org/repo", "src/app.py")],
+          ])}
+        />,
+        { organization: prIterationOrganization },
+      );
+
+      // The comment text is plain; a trailing "Open in GitHub" arrow links out.
+      expect(
+        screen.getByText("Please handle the null value."),
+      ).toBeInTheDocument();
+      const feedbackLink = screen.getByRole("link", { name: "Open in GitHub" });
+      expect(feedbackLink).toHaveAttribute("href", commentUrl);
+    });
+
+    it("groups a review body with its inline comments under a state header", () => {
+      const reviewUrl =
+        "https://github.com/org/repo/pull/42#pullrequestreview-999";
+      const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
+        ...mockAutofix,
+        runState: {
+          run_id: 123,
+          blocks: [],
+          status: "completed",
+          updated_at: "2026-01-01T00:00:00Z",
+          queued_feedback: [
+            {
+              text: "Overall this needs work.",
+              source: {
+                type: "github-pr-review-body",
+                html_url: reviewUrl,
+                review_id: 7,
+                review_state: "changes_requested",
+              },
+            },
+            {
+              text: "Handle the null value here.",
+              source: {
+                type: "github-pr-review-comment",
+                review_id: 7,
+                comment: {
+                  html_url: "https://github.com/org/repo/pull/42#r1",
+                  user: { login: "octocat" },
+                },
+              },
+            },
+            {
+              text: "And rename this variable.",
+              source: {
+                type: "github-pr-review-comment",
+                review_id: 7,
+                comment: {
+                  html_url: "https://github.com/org/repo/pull/42#r2",
+                  user: { login: "octocat" },
                 },
               },
             },
@@ -1000,34 +1035,160 @@ describe('ArtifactCard', () => {
         <CodeChangesCard
           groupId="1"
           autofix={autofixWithQueued}
-          section={makeSection('code_changes', 'completed', [
-            [makePatch('org/repo', 'src/app.py')],
+          section={makeSection("code_changes", "completed", [
+            [makePatch("org/repo", "src/app.py")],
           ])}
         />,
-        {organization: prIterationOrganization}
+        { organization: prIterationOrganization },
       );
 
-      expect(screen.getByText('CI failure detected')).toBeInTheDocument();
+      // The review state renders as a single header badge…
+      expect(screen.getByText("Changes requested")).toBeInTheDocument();
+      // …with the body text and both inline comments beneath it.
+      expect(screen.getByText("Overall this needs work.")).toBeInTheDocument();
+      expect(
+        screen.getByText("Handle the null value here."),
+      ).toBeInTheDocument();
+      expect(screen.getByText("And rename this variable.")).toBeInTheDocument();
+    });
+
+    it("shows a state badge for a body-only review", () => {
+      const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
+        ...mockAutofix,
+        runState: {
+          run_id: 123,
+          blocks: [],
+          status: "completed",
+          updated_at: "2026-01-01T00:00:00Z",
+          queued_feedback: [
+            {
+              text: "Looks good to me.",
+              source: {
+                type: "github-pr-review-body",
+                review_id: 8,
+                review_state: "approved",
+              },
+            },
+          ],
+        },
+      };
+
+      render(
+        <CodeChangesCard
+          groupId="1"
+          autofix={autofixWithQueued}
+          section={makeSection("code_changes", "completed", [
+            [makePatch("org/repo", "src/app.py")],
+          ])}
+        />,
+        { organization: prIterationOrganization },
+      );
+
+      expect(screen.getByText("Approved")).toBeInTheDocument();
+      expect(screen.getByText("Looks good to me.")).toBeInTheDocument();
+    });
+
+    it("leaves a comment-only review (no body) ungrouped", () => {
+      // GitHub's "Add single comment" fires a review with no summary body, so no
+      // header is synthesized — the inline comment renders flat, with no badge.
+      const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
+        ...mockAutofix,
+        runState: {
+          run_id: 123,
+          blocks: [],
+          status: "completed",
+          updated_at: "2026-01-01T00:00:00Z",
+          queued_feedback: [
+            {
+              text: "One quick nit.",
+              source: {
+                type: "github-pr-review-comment",
+                review_id: 9,
+                comment: {
+                  html_url: "https://github.com/org/repo/pull/42#r3",
+                  user: { login: "octocat" },
+                },
+              },
+            },
+          ],
+        },
+      };
+
+      render(
+        <CodeChangesCard
+          groupId="1"
+          autofix={autofixWithQueued}
+          section={makeSection("code_changes", "completed", [
+            [makePatch("org/repo", "src/app.py")],
+          ])}
+        />,
+        { organization: prIterationOrganization },
+      );
+
+      expect(screen.getByText("One quick nit.")).toBeInTheDocument();
+      // No review-state badge without a body source to carry the state.
+      expect(screen.queryByText("Changes requested")).not.toBeInTheDocument();
+      expect(screen.queryByText("Approved")).not.toBeInTheDocument();
+      expect(screen.queryByText("Commented")).not.toBeInTheDocument();
+    });
+
+    it("shows a formatted check-suite label instead of the raw feedback text", () => {
+      const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
+        ...mockAutofix,
+        runState: {
+          run_id: 123,
+          blocks: [],
+          status: "completed",
+          updated_at: "2026-01-01T00:00:00Z",
+          queued_feedback: [
+            {
+              text: "raw text",
+              ui_text: "check suite for app CI failed",
+              source: {
+                type: "check-suite",
+                app_name: "CI",
+                event: {
+                  check_suite: { id: 999, head_sha: "abc123" },
+                  repository: { html_url: "https://github.com/org/repo" },
+                },
+              },
+            },
+          ],
+        },
+      };
+
+      render(
+        <CodeChangesCard
+          groupId="1"
+          autofix={autofixWithQueued}
+          section={makeSection("code_changes", "completed", [
+            [makePatch("org/repo", "src/app.py")],
+          ])}
+        />,
+        { organization: prIterationOrganization },
+      );
+
+      expect(screen.getByText("CI failure detected")).toBeInTheDocument();
       expect(screen.queryByText(/raw text/)).not.toBeInTheDocument();
     });
 
-    it('links check-suite feedback to the failing check suite', () => {
+    it("links check-suite feedback to the failing check suite", () => {
       const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofix,
         runState: {
           run_id: 123,
           blocks: [],
-          status: 'completed',
-          updated_at: '2026-01-01T00:00:00Z',
+          status: "completed",
+          updated_at: "2026-01-01T00:00:00Z",
           queued_feedback: [
             {
-              text: 'raw text',
+              text: "raw text",
               source: {
-                type: 'check-suite',
-                app_name: 'CI',
+                type: "check-suite",
+                app_name: "CI",
                 event: {
-                  check_suite: {id: 999, head_sha: 'abc123'},
-                  repository: {html_url: 'https://github.com/org/repo'},
+                  check_suite: { id: 999, head_sha: "abc123" },
+                  repository: { html_url: "https://github.com/org/repo" },
                 },
               },
             },
@@ -1039,31 +1200,33 @@ describe('ArtifactCard', () => {
         <CodeChangesCard
           groupId="1"
           autofix={autofixWithQueued}
-          section={makeSection('code_changes', 'completed', [
-            [makePatch('org/repo', 'src/app.py')],
+          section={makeSection("code_changes", "completed", [
+            [makePatch("org/repo", "src/app.py")],
           ])}
         />,
-        {organization: prIterationOrganization}
+        { organization: prIterationOrganization },
       );
 
       // The label is plain text; a trailing "Open in GitHub" arrow links to the run.
-      expect(screen.getByText('CI failure detected')).toBeInTheDocument();
-      const link = screen.getByRole('link', {name: 'Open in GitHub'});
+      expect(screen.getByText("CI failure detected")).toBeInTheDocument();
+      const link = screen.getByRole("link", { name: "Open in GitHub" });
       expect(link).toHaveAttribute(
-        'href',
-        'https://github.com/org/repo/commit/abc123/checks?check_suite_id=999'
+        "href",
+        "https://github.com/org/repo/commit/abc123/checks?check_suite_id=999",
       );
     });
 
-    it('shows the code changes for queued feedback without the feature flag', () => {
+    it("shows the code changes for queued feedback without the feature flag", () => {
       const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofix,
         runState: {
           run_id: 123,
           blocks: [],
-          status: 'completed',
-          updated_at: '2026-01-01T00:00:00Z',
-          queued_feedback: [{text: 'Make the button blue', source: {type: 'user-ui'}}],
+          status: "completed",
+          updated_at: "2026-01-01T00:00:00Z",
+          queued_feedback: [
+            { text: "Make the button blue", source: { type: "user-ui" } },
+          ],
         },
       };
 
@@ -1071,141 +1234,151 @@ describe('ArtifactCard', () => {
         <CodeChangesCard
           groupId="1"
           autofix={autofixWithQueued}
-          section={makeSection('code_changes', 'completed', [
-            [makePatch('org/repo', 'src/app.py')],
+          section={makeSection("code_changes", "completed", [
+            [makePatch("org/repo", "src/app.py")],
           ])}
-        />
+        />,
       );
 
-      expect(screen.getByText('1 file changed in 1 repo')).toBeInTheDocument();
-      expect(screen.queryByText('Implementing changes…')).not.toBeInTheDocument();
-      expect(screen.queryByText('Iterating on PR…')).not.toBeInTheDocument();
+      expect(screen.getByText("1 file changed in 1 repo")).toBeInTheDocument();
+      expect(
+        screen.queryByText("Implementing changes…"),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByText("Iterating on PR…")).not.toBeInTheDocument();
     });
 
-    it('does not render iteration feedback without the feature flag', () => {
+    it("does not render iteration feedback without the feature flag", () => {
       render(
         <CodeChangesCard
           groupId="1"
           autofix={mockAutofix}
           section={makeSection(
-            'code_changes',
-            'completed',
-            [[makePatch('org/repo', 'src/app.py')]],
-            [makePrIterationBlock(1, {text: 'Add a test for this'})]
+            "code_changes",
+            "completed",
+            [[makePatch("org/repo", "src/app.py")]],
+            [makePrIterationBlock(1, { text: "Add a test for this" })],
           )}
-        />
+        />,
       );
 
-      expect(screen.queryByText('Feedback')).not.toBeInTheDocument();
-      expect(screen.queryByText('Add a test for this')).not.toBeInTheDocument();
+      expect(screen.queryByText("Feedback")).not.toBeInTheDocument();
+      expect(screen.queryByText("Add a test for this")).not.toBeInTheDocument();
       expect(screen.queryByText(/- Latest/)).not.toBeInTheDocument();
     });
 
-    it('renders a one-based version tag for the latest iteration', () => {
+    it("renders a one-based version tag for the latest iteration", () => {
       render(
         <CodeChangesCard
           groupId="1"
           autofix={mockAutofix}
           section={makeSection(
-            'code_changes',
-            'completed',
-            [[makePatch('org/repo', 'src/app.py')]],
+            "code_changes",
+            "completed",
+            [[makePatch("org/repo", "src/app.py")]],
             [
-              makePrIterationBlock(0, {text: 'first pass'}),
-              makePrIterationBlock(1, {text: 'second pass'}),
-            ]
+              makePrIterationBlock(0, { text: "first pass" }),
+              makePrIterationBlock(1, { text: "second pass" }),
+            ],
           )}
         />,
-        {organization: prIterationOrganization}
+        { organization: prIterationOrganization },
       );
 
       // iteration_index is zero-based; the latest (1) renders as v2.
-      expect(screen.getByText('v2 - Latest')).toBeInTheDocument();
+      expect(screen.getByText("v2 - Latest")).toBeInTheDocument();
     });
 
-    it('does not render a version tag without iterations', () => {
+    it("does not render a version tag without iterations", () => {
       render(
         <CodeChangesCard
           groupId="1"
           autofix={mockAutofix}
-          section={makeSection('code_changes', 'completed', [
-            [makePatch('org/repo', 'src/app.py')],
+          section={makeSection("code_changes", "completed", [
+            [makePatch("org/repo", "src/app.py")],
           ])}
-        />
+        />,
       );
 
       expect(screen.queryByText(/- Latest/)).not.toBeInTheDocument();
     });
 
-    it('shows the iterating loading message when processing a pr_iteration', () => {
+    it("shows the iterating loading message when processing a pr_iteration", () => {
       render(
         <CodeChangesCard
           groupId="1"
           autofix={mockAutofix}
           section={makeSection(
-            'code_changes',
-            'processing',
+            "code_changes",
+            "processing",
             [],
-            [makePrIterationBlock(0, {text: 'fix the CI failure'})]
+            [makePrIterationBlock(0, { text: "fix the CI failure" })],
           )}
         />,
-        {organization: prIterationOrganization}
+        { organization: prIterationOrganization },
       );
 
-      expect(screen.getByText('Iterating on PR…')).toBeInTheDocument();
-      expect(screen.queryByText('Implementing changes…')).not.toBeInTheDocument();
+      expect(screen.getByText("Iterating on PR…")).toBeInTheDocument();
+      expect(
+        screen.queryByText("Implementing changes…"),
+      ).not.toBeInTheDocument();
     });
 
-    it('marks block feedback as processed when the section is not processing', () => {
+    it("marks block feedback as processed when the section is not processing", () => {
       render(
         <CodeChangesCard
           groupId="1"
           autofix={mockAutofix}
           section={makeSection(
-            'code_changes',
-            'completed',
-            [[makePatch('org/repo', 'src/app.py')]],
-            [makePrIterationBlock(0, {text: 'first pass'})]
+            "code_changes",
+            "completed",
+            [[makePatch("org/repo", "src/app.py")]],
+            [makePrIterationBlock(0, { text: "first pass" })],
           )}
         />,
-        {organization: prIterationOrganization}
+        { organization: prIterationOrganization },
       );
 
-      expect(screen.getByText('first pass')).toBeInTheDocument();
-      expect(screen.getByTestId('feedback-processed')).toBeInTheDocument();
+      expect(screen.getByText("first pass")).toBeInTheDocument();
+      expect(screen.getByTestId("feedback-processed")).toBeInTheDocument();
     });
 
-    it('marks the current iteration feedback as in progress while processing', () => {
+    it("marks the current iteration feedback as in progress while processing", () => {
       render(
         <CodeChangesCard
           groupId="1"
           autofix={mockAutofix}
           section={makeSection(
-            'code_changes',
-            'processing',
+            "code_changes",
+            "processing",
             [],
-            [makePrIterationBlock(0, {text: 'fix the CI failure'})]
+            [makePrIterationBlock(0, { text: "fix the CI failure" })],
           )}
         />,
-        {organization: prIterationOrganization}
+        { organization: prIterationOrganization },
       );
 
       // While processing, the row shows a spinner (there is also the card body
       // "Iterating on PR…" loader, hence getAllByTestId) and no processed check.
-      expect(screen.getByText('fix the CI failure')).toBeInTheDocument();
-      expect(screen.getAllByTestId('loading-indicator').length).toBeGreaterThan(0);
-      expect(screen.queryByTestId('feedback-processed')).not.toBeInTheDocument();
+      expect(screen.getByText("fix the CI failure")).toBeInTheDocument();
+      expect(screen.getAllByTestId("loading-indicator").length).toBeGreaterThan(
+        0,
+      );
+      expect(
+        screen.queryByTestId("feedback-processed"),
+      ).not.toBeInTheDocument();
     });
 
-    it('marks queued feedback with a queued label and no timestamp', () => {
+    it("marks queued feedback with a queued label and no timestamp", () => {
       const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofix,
         runState: {
           run_id: 123,
           blocks: [],
-          status: 'completed',
-          updated_at: '2026-01-01T00:00:00Z',
-          queued_feedback: [{text: 'Make the button blue', source: {type: 'user-ui'}}],
+          status: "completed",
+          updated_at: "2026-01-01T00:00:00Z",
+          queued_feedback: [
+            { text: "Make the button blue", source: { type: "user-ui" } },
+          ],
         },
       };
 
@@ -1213,27 +1386,29 @@ describe('ArtifactCard', () => {
         <CodeChangesCard
           groupId="1"
           autofix={autofixWithQueued}
-          section={makeSection('code_changes', 'completed', [
-            [makePatch('org/repo', 'src/app.py')],
+          section={makeSection("code_changes", "completed", [
+            [makePatch("org/repo", "src/app.py")],
           ])}
         />,
-        {organization: prIterationOrganization}
+        { organization: prIterationOrganization },
       );
 
-      expect(screen.getByText('Make the button blue')).toBeInTheDocument();
-      expect(screen.getByText('Queued')).toBeInTheDocument();
-      expect(screen.queryByTestId('feedback-processed')).not.toBeInTheDocument();
+      expect(screen.getByText("Make the button blue")).toBeInTheDocument();
+      expect(screen.getByText("Queued")).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("feedback-processed"),
+      ).not.toBeInTheDocument();
     });
 
-    it('keeps reset enabled with the feature flag even when PRs exist', () => {
+    it("keeps reset enabled with the feature flag even when PRs exist", () => {
       const autofix: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofix,
         runState: {
           run_id: 123,
           blocks: [],
-          status: 'completed',
-          updated_at: '2026-01-01T00:00:00Z',
-          repo_pr_states: {'org/repo': makePR()},
+          status: "completed",
+          updated_at: "2026-01-01T00:00:00Z",
+          repo_pr_states: { "org/repo": makePR() },
         },
       };
 
@@ -1241,24 +1416,24 @@ describe('ArtifactCard', () => {
         <CodeChangesCard
           groupId="1"
           autofix={autofix}
-          section={makeSection('code_changes', 'completed', [
-            [makePatch('org/repo', 'src/app.py')],
+          section={makeSection("code_changes", "completed", [
+            [makePatch("org/repo", "src/app.py")],
           ])}
         />,
-        {organization: prIterationOrganization}
+        { organization: prIterationOrganization },
       );
 
-      expect(screen.getByRole('button', {name: 'Re-run step'})).toBeEnabled();
+      expect(screen.getByRole("button", { name: "Re-run step" })).toBeEnabled();
     });
 
-    it('disables reset with the feature flag while processing before any PR exists', () => {
+    it("disables reset with the feature flag while processing before any PR exists", () => {
       const autofix: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofix,
         runState: {
           run_id: 123,
           blocks: [],
-          status: 'processing',
-          updated_at: '2026-01-01T00:00:00Z',
+          status: "processing",
+          updated_at: "2026-01-01T00:00:00Z",
           repo_pr_states: {},
         },
       };
@@ -1267,25 +1442,27 @@ describe('ArtifactCard', () => {
         <CodeChangesCard
           groupId="1"
           autofix={autofix}
-          section={makeSection('code_changes', 'completed', [
-            [makePatch('org/repo', 'src/app.py')],
+          section={makeSection("code_changes", "completed", [
+            [makePatch("org/repo", "src/app.py")],
           ])}
         />,
-        {organization: prIterationOrganization}
+        { organization: prIterationOrganization },
       );
 
-      expect(screen.getByRole('button', {name: 'Re-run step'})).toBeDisabled();
+      expect(
+        screen.getByRole("button", { name: "Re-run step" }),
+      ).toBeDisabled();
     });
 
-    it('keeps reset enabled with the feature flag while processing once a PR exists', () => {
+    it("keeps reset enabled with the feature flag while processing once a PR exists", () => {
       const autofix: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofix,
         runState: {
           run_id: 123,
           blocks: [],
-          status: 'processing',
-          updated_at: '2026-01-01T00:00:00Z',
-          repo_pr_states: {'org/repo': makePR()},
+          status: "processing",
+          updated_at: "2026-01-01T00:00:00Z",
+          repo_pr_states: { "org/repo": makePR() },
         },
       };
 
@@ -1293,25 +1470,25 @@ describe('ArtifactCard', () => {
         <CodeChangesCard
           groupId="1"
           autofix={autofix}
-          section={makeSection('code_changes', 'completed', [
-            [makePatch('org/repo', 'src/app.py')],
+          section={makeSection("code_changes", "completed", [
+            [makePatch("org/repo", "src/app.py")],
           ])}
         />,
-        {organization: prIterationOrganization}
+        { organization: prIterationOrganization },
       );
 
-      expect(screen.getByRole('button', {name: 'Re-run step'})).toBeEnabled();
+      expect(screen.getByRole("button", { name: "Re-run step" })).toBeEnabled();
     });
 
-    it('disables reset without the feature flag when PRs exist', () => {
+    it("disables reset without the feature flag when PRs exist", () => {
       const autofix: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofix,
         runState: {
           run_id: 123,
           blocks: [],
-          status: 'completed',
-          updated_at: '2026-01-01T00:00:00Z',
-          repo_pr_states: {'org/repo': makePR()},
+          status: "completed",
+          updated_at: "2026-01-01T00:00:00Z",
+          repo_pr_states: { "org/repo": makePR() },
         },
       };
 
@@ -1319,24 +1496,26 @@ describe('ArtifactCard', () => {
         <CodeChangesCard
           groupId="1"
           autofix={autofix}
-          section={makeSection('code_changes', 'completed', [
-            [makePatch('org/repo', 'src/app.py')],
+          section={makeSection("code_changes", "completed", [
+            [makePatch("org/repo", "src/app.py")],
           ])}
-        />
+        />,
       );
 
-      expect(screen.getByRole('button', {name: 'Re-run step'})).toBeDisabled();
+      expect(
+        screen.getByRole("button", { name: "Re-run step" }),
+      ).toBeDisabled();
     });
 
-    it('disables reset while a coding agent is active', () => {
+    it("disables reset while a coding agent is active", () => {
       const autofix: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofix,
         runState: {
           run_id: 123,
           blocks: [],
-          status: 'completed',
-          updated_at: '2026-01-01T00:00:00Z',
-          coding_agents: {a: {} as any},
+          status: "completed",
+          updated_at: "2026-01-01T00:00:00Z",
+          coding_agents: { a: {} as any },
         },
       };
 
@@ -1344,25 +1523,27 @@ describe('ArtifactCard', () => {
         <CodeChangesCard
           groupId="1"
           autofix={autofix}
-          section={makeSection('code_changes', 'completed', [
-            [makePatch('org/repo', 'src/app.py')],
+          section={makeSection("code_changes", "completed", [
+            [makePatch("org/repo", "src/app.py")],
           ])}
         />,
-        {organization: prIterationOrganization}
+        { organization: prIterationOrganization },
       );
 
-      expect(screen.getByRole('button', {name: 'Re-run step'})).toBeDisabled();
+      expect(
+        screen.getByRole("button", { name: "Re-run step" }),
+      ).toBeDisabled();
     });
 
-    it('shows the PR iteration form mid-run when reset is requested', async () => {
+    it("shows the PR iteration form mid-run when reset is requested", async () => {
       const autofix: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofix,
         runState: {
           run_id: 123,
           blocks: [],
-          status: 'processing',
-          updated_at: '2026-01-01T00:00:00Z',
-          repo_pr_states: {'org/repo': makePR()},
+          status: "processing",
+          updated_at: "2026-01-01T00:00:00Z",
+          repo_pr_states: { "org/repo": makePR() },
         },
       };
 
@@ -1371,363 +1552,376 @@ describe('ArtifactCard', () => {
           groupId="1"
           autofix={autofix}
           section={makeSection(
-            'code_changes',
-            'processing',
+            "code_changes",
+            "processing",
             [],
-            [makePrIterationBlock(0, {text: 'fix the CI failure'})]
+            [makePrIterationBlock(0, { text: "fix the CI failure" })],
           )}
         />,
-        {organization: prIterationOrganization}
+        { organization: prIterationOrganization },
       );
 
-      await userEvent.click(screen.getByRole('button', {name: 'Re-run step'}));
+      await userEvent.click(
+        screen.getByRole("button", { name: "Re-run step" }),
+      );
       expect(
-        screen.getByText('Anything else you want to see on your PR?')
+        screen.getByText("Anything else you want to see on your PR?"),
       ).toBeInTheDocument();
     });
   });
 
-  describe('PullRequestsCard', () => {
-    it('renders PR link buttons with correct text and href', () => {
+  describe("PullRequestsCard", () => {
+    it("renders PR link buttons with correct text and href", () => {
       render(
         <PullRequestsCard
           autofix={mockAutofixWithRunState}
-          section={makeSection('pull_request', 'completed', [[makePR()]])}
-        />
+          section={makeSection("pull_request", "completed", [[makePR()]])}
+        />,
       );
 
-      expect(screen.getByText('Pull Requests')).toBeInTheDocument();
-      const button = screen.getByRole('button', {
-        name: 'View org/repo#42',
+      expect(screen.getByText("Pull Requests")).toBeInTheDocument();
+      const button = screen.getByRole("button", {
+        name: "View org/repo#42",
       });
-      expect(button).toHaveAttribute('href', 'https://github.com/org/repo/pull/42');
+      expect(button).toHaveAttribute(
+        "href",
+        "https://github.com/org/repo/pull/42",
+      );
     });
 
-    it('renders multiple PR buttons', () => {
+    it("renders multiple PR buttons", () => {
       render(
         <PullRequestsCard
           autofix={mockAutofixWithRunState}
-          section={makeSection('pull_request', 'completed', [
+          section={makeSection("pull_request", "completed", [
             [
               makePR({
-                repo_name: 'org/repo-a',
+                repo_name: "org/repo-a",
                 pr_number: 10,
-                pr_url: 'https://pr/10',
+                pr_url: "https://pr/10",
               }),
               makePR({
-                repo_name: 'org/repo-b',
+                repo_name: "org/repo-b",
                 pr_number: 20,
-                pr_url: 'https://pr/20',
+                pr_url: "https://pr/20",
               }),
             ],
           ])}
-        />
+        />,
       );
 
       expect(
-        screen.getByRole('button', {name: 'View org/repo-a#10'})
+        screen.getByRole("button", { name: "View org/repo-a#10" }),
       ).toBeInTheDocument();
       expect(
-        screen.getByRole('button', {name: 'View org/repo-b#20'})
+        screen.getByRole("button", { name: "View org/repo-b#20" }),
       ).toBeInTheDocument();
     });
 
-    it('skips PRs with missing pr_url or pr_number', () => {
+    it("skips PRs with missing pr_url or pr_number", () => {
       render(
         <PullRequestsCard
           autofix={mockAutofixWithRunState}
-          section={makeSection('pull_request', 'completed', [
+          section={makeSection("pull_request", "completed", [
             [
-              makePR({repo_name: 'org/repo-a', pr_url: null}),
-              makePR({repo_name: 'org/repo-b', pr_number: null}),
+              makePR({ repo_name: "org/repo-a", pr_url: null }),
+              makePR({ repo_name: "org/repo-b", pr_number: null }),
               makePR({
-                repo_name: 'org/valid',
+                repo_name: "org/valid",
                 pr_number: 55,
-                pr_url: 'https://pr/55',
+                pr_url: "https://pr/55",
               }),
             ],
           ])}
-        />
+        />,
       );
 
-      expect(screen.getByRole('button', {name: /View org\/valid#55/})).toHaveAttribute(
-        'href',
-        'https://pr/55'
-      );
+      expect(
+        screen.getByRole("button", { name: /View org\/valid#55/ }),
+      ).toHaveAttribute("href", "https://pr/55");
     });
 
-    it('copies markdown when copy button is clicked', async () => {
+    it("copies markdown when copy button is clicked", async () => {
       render(
         <PullRequestsCard
           autofix={mockAutofixWithRunState}
-          section={makeSection('pull_request', 'completed', [[makePR()]])}
-        />
+          section={makeSection("pull_request", "completed", [[makePR()]])}
+        />,
       );
 
-      await userEvent.click(screen.getByRole('button', {name: 'Copy as Markdown'}));
+      await userEvent.click(
+        screen.getByRole("button", { name: "Copy as Markdown" }),
+      );
 
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
-        expect.stringContaining('Pull Requests')
+        expect.stringContaining("Pull Requests"),
       );
     });
   });
 
-  describe('ArtifactCard expand/collapse', () => {
-    it('children are visible by default', () => {
+  describe("ArtifactCard expand/collapse", () => {
+    it("children are visible by default", () => {
       const artifact = makeRootCauseArtifact({
-        one_line_description: 'Bug',
-        five_whys: ['Visible why'],
+        one_line_description: "Bug",
+        five_whys: ["Visible why"],
       });
 
       render(
         <RootCauseCard
           autofix={mockAutofix}
           groupId="1"
-          section={makeSection('root_cause', 'completed', [artifact])}
-        />
+          section={makeSection("root_cause", "completed", [artifact])}
+        />,
       );
 
-      expect(screen.getByText('Visible why')).toBeInTheDocument();
+      expect(screen.getByText("Visible why")).toBeInTheDocument();
     });
 
-    it('clicking collapse button hides children', async () => {
+    it("clicking collapse button hides children", async () => {
       const artifact = makeRootCauseArtifact({
-        one_line_description: 'Bug',
-        five_whys: ['Hidden why'],
+        one_line_description: "Bug",
+        five_whys: ["Hidden why"],
       });
 
       render(
         <RootCauseCard
           autofix={mockAutofix}
           groupId="1"
-          section={makeSection('root_cause', 'completed', [artifact])}
-        />
+          section={makeSection("root_cause", "completed", [artifact])}
+        />,
       );
 
-      await userEvent.click(screen.getByRole('button', {name: 'Root Cause'}));
+      await userEvent.click(screen.getByRole("button", { name: "Root Cause" }));
 
-      expect(screen.queryByText('Bug')).not.toBeVisible();
-      expect(screen.queryByText('Hidden why')).not.toBeVisible();
+      expect(screen.queryByText("Bug")).not.toBeVisible();
+      expect(screen.queryByText("Hidden why")).not.toBeVisible();
     });
 
-    it('clicking again re-shows children', async () => {
+    it("clicking again re-shows children", async () => {
       const artifact = makeRootCauseArtifact({
-        one_line_description: 'Bug',
-        five_whys: ['Toggle why'],
+        one_line_description: "Bug",
+        five_whys: ["Toggle why"],
       });
 
       render(
         <RootCauseCard
           autofix={mockAutofix}
           groupId="1"
-          section={makeSection('root_cause', 'completed', [artifact])}
-        />
+          section={makeSection("root_cause", "completed", [artifact])}
+        />,
       );
 
-      expect(screen.getByText('Bug')).toBeVisible();
-      expect(screen.getByText('Toggle why')).toBeVisible();
+      expect(screen.getByText("Bug")).toBeVisible();
+      expect(screen.getByText("Toggle why")).toBeVisible();
 
-      await userEvent.click(screen.getByRole('button', {name: 'Root Cause'}));
-      expect(screen.queryByText('Bug')).not.toBeVisible();
-      expect(screen.queryByText('Toggle why')).not.toBeVisible();
+      await userEvent.click(screen.getByRole("button", { name: "Root Cause" }));
+      expect(screen.queryByText("Bug")).not.toBeVisible();
+      expect(screen.queryByText("Toggle why")).not.toBeVisible();
 
-      await userEvent.click(screen.getByRole('button', {name: 'Root Cause'}));
-      expect(screen.getByText('Bug')).toBeVisible();
-      expect(screen.getByText('Toggle why')).toBeVisible();
+      await userEvent.click(screen.getByRole("button", { name: "Root Cause" }));
+      expect(screen.getByText("Bug")).toBeVisible();
+      expect(screen.getByText("Toggle why")).toBeVisible();
     });
   });
 
   function makeCodingAgent(
-    overrides: Partial<ExplorerCodingAgentState> = {}
+    overrides: Partial<ExplorerCodingAgentState> = {},
   ): ExplorerCodingAgentState {
     return {
-      id: 'agent-1',
-      name: 'My Agent Task',
+      id: "agent-1",
+      name: "My Agent Task",
       provider: CodingAgentProvider.CURSOR_BACKGROUND_AGENT,
-      started_at: '2026-01-01T00:00:00Z',
-      status: 'running',
+      started_at: "2026-01-01T00:00:00Z",
+      status: "running",
       ...overrides,
     };
   }
 
-  describe('CodingAgentsCard', () => {
-    it('renders agent name based on Cursor provider', () => {
+  describe("CodingAgentsCard", () => {
+    it("renders agent name based on Cursor provider", () => {
       render(
         <CodingAgentsCard
           autofix={mockAutofix}
-          section={makeSection('coding_agents', 'completed', [
+          section={makeSection("coding_agents", "completed", [
             [
               makeCodingAgent({
                 provider: CodingAgentProvider.CURSOR_BACKGROUND_AGENT,
               }),
             ],
           ])}
-        />
+        />,
       );
 
-      expect(screen.getByText('Cursor Cloud Agent')).toBeInTheDocument();
+      expect(screen.getByText("Cursor Cloud Agent")).toBeInTheDocument();
     });
 
-    it('renders agent name based on Claude provider', () => {
+    it("renders agent name based on Claude provider", () => {
       render(
         <CodingAgentsCard
           autofix={mockAutofix}
-          section={makeSection('coding_agents', 'completed', [
+          section={makeSection("coding_agents", "completed", [
             [
               makeCodingAgent({
                 provider: CodingAgentProvider.CLAUDE_CODE_AGENT,
               }),
             ],
           ])}
-        />
+        />,
       );
 
-      expect(screen.getByText('Claude Agent')).toBeInTheDocument();
+      expect(screen.getByText("Claude Agent")).toBeInTheDocument();
     });
 
-    it('renders agent name based on GitHub Copilot provider', () => {
+    it("renders agent name based on GitHub Copilot provider", () => {
       render(
         <CodingAgentsCard
           autofix={mockAutofix}
-          section={makeSection('coding_agents', 'completed', [
+          section={makeSection("coding_agents", "completed", [
             [
               makeCodingAgent({
                 provider: CodingAgentProvider.GITHUB_COPILOT_AGENT,
               }),
             ],
           ])}
-        />
+        />,
       );
 
-      expect(screen.getByText('GitHub Copilot')).toBeInTheDocument();
+      expect(screen.getByText("GitHub Copilot")).toBeInTheDocument();
     });
 
-    it('renders default agent name for unknown provider', () => {
+    it("renders default agent name for unknown provider", () => {
       render(
         <CodingAgentsCard
           autofix={mockAutofix}
-          section={makeSection('coding_agents', 'completed', [
-            [makeCodingAgent({provider: 'unknown_provider' as any})],
+          section={makeSection("coding_agents", "completed", [
+            [makeCodingAgent({ provider: "unknown_provider" as any })],
           ])}
-        />
+        />,
       );
 
-      expect(screen.getByText('Coding Agent')).toBeInTheDocument();
+      expect(screen.getByText("Coding Agent")).toBeInTheDocument();
     });
 
-    it('renders agent status tags', () => {
+    it("renders agent status tags", () => {
       render(
         <CodingAgentsCard
           autofix={mockAutofix}
-          section={makeSection('coding_agents', 'completed', [
-            [makeCodingAgent({status: 'running'})],
+          section={makeSection("coding_agents", "completed", [
+            [makeCodingAgent({ status: "running" })],
           ])}
-        />
+        />,
       );
 
-      expect(screen.getByText('running')).toBeInTheDocument();
+      expect(screen.getByText("running")).toBeInTheDocument();
     });
 
     it('renders "Open in" link when agent_url is present', () => {
       render(
         <CodingAgentsCard
           autofix={mockAutofix}
-          section={makeSection('coding_agents', 'completed', [
+          section={makeSection("coding_agents", "completed", [
             [
               makeCodingAgent({
-                agent_url: 'https://cursor.com/agent/1',
+                agent_url: "https://cursor.com/agent/1",
               }),
             ],
           ])}
-        />
+        />,
       );
 
-      const link = screen.getByRole('button', {name: /Open in/});
-      expect(link).toHaveAttribute('href', 'https://cursor.com/agent/1');
+      const link = screen.getByRole("button", { name: /Open in/ });
+      expect(link).toHaveAttribute("href", "https://cursor.com/agent/1");
     });
 
-    it('renders result PR links when results have pr_url', () => {
+    it("renders result PR links when results have pr_url", () => {
       render(
         <CodingAgentsCard
           autofix={mockAutofix}
-          section={makeSection('coding_agents', 'completed', [
+          section={makeSection("coding_agents", "completed", [
             [
               makeCodingAgent({
                 results: [
                   {
-                    description: 'Fixed',
-                    repo_full_name: 'org/repo',
-                    repo_provider: 'github',
-                    pr_url: 'https://github.com/org/repo/pull/99',
+                    description: "Fixed",
+                    repo_full_name: "org/repo",
+                    repo_provider: "github",
+                    pr_url: "https://github.com/org/repo/pull/99",
                   },
                 ],
               }),
             ],
           ])}
-        />
+        />,
       );
 
-      const link = screen.getByRole('button', {name: 'View Pull Request'});
-      expect(link).toHaveAttribute('href', 'https://github.com/org/repo/pull/99');
+      const link = screen.getByRole("button", { name: "View Pull Request" });
+      expect(link).toHaveAttribute(
+        "href",
+        "https://github.com/org/repo/pull/99",
+      );
     });
 
-    it('handles multiple coding agents', () => {
+    it("handles multiple coding agents", () => {
       render(
         <CodingAgentsCard
           autofix={mockAutofix}
-          section={makeSection('coding_agents', 'completed', [
+          section={makeSection("coding_agents", "completed", [
             [
               makeCodingAgent({
-                id: 'agent-1',
-                name: 'Agent One',
-                status: 'completed',
+                id: "agent-1",
+                name: "Agent One",
+                status: "completed",
               }),
               makeCodingAgent({
-                id: 'agent-2',
-                name: 'Agent Two',
-                status: 'running',
+                id: "agent-2",
+                name: "Agent Two",
+                status: "running",
               }),
             ],
           ])}
-        />
+        />,
       );
 
-      expect(screen.getByText('Agent One')).toBeInTheDocument();
-      expect(screen.getByText('Agent Two')).toBeInTheDocument();
-      expect(screen.getByText('completed')).toBeInTheDocument();
-      expect(screen.getByText('running')).toBeInTheDocument();
+      expect(screen.getByText("Agent One")).toBeInTheDocument();
+      expect(screen.getByText("Agent Two")).toBeInTheDocument();
+      expect(screen.getByText("completed")).toBeInTheDocument();
+      expect(screen.getByText("running")).toBeInTheDocument();
     });
 
-    it('copies markdown when copy button is clicked', async () => {
+    it("copies markdown when copy button is clicked", async () => {
       render(
         <CodingAgentsCard
           autofix={mockAutofix}
-          section={makeSection('coding_agents', 'completed', [
+          section={makeSection("coding_agents", "completed", [
             [
               makeCodingAgent({
-                agent_url: 'https://cursor.com/agent/1',
+                agent_url: "https://cursor.com/agent/1",
               }),
             ],
           ])}
-        />
+        />,
       );
 
-      await userEvent.click(screen.getByRole('button', {name: 'Copy as Markdown'}));
+      await userEvent.click(
+        screen.getByRole("button", { name: "Copy as Markdown" }),
+      );
 
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
-        expect.stringContaining('Coding Agents')
+        expect.stringContaining("Coding Agents"),
       );
     });
 
-    it('does not show copy button when no artifacts', () => {
+    it("does not show copy button when no artifacts", () => {
       render(
         <CodingAgentsCard
           autofix={mockAutofix}
-          section={makeSection('coding_agents', 'completed', [])}
-        />
+          section={makeSection("coding_agents", "completed", [])}
+        />,
       );
 
-      expect(screen.queryByRole('button', {name: 'Copy as Markdown'})).toBeDisabled();
+      expect(
+        screen.queryByRole("button", { name: "Copy as Markdown" }),
+      ).toBeDisabled();
     });
   });
 });

--- a/static/app/components/events/autofix/v3/codeChangesCard.stories.tsx
+++ b/static/app/components/events/autofix/v3/codeChangesCard.stories.tsx
@@ -78,10 +78,8 @@ function makePatch(repoName: string, path: string): ExplorerFilePatch {
  * A folded-in PR-iteration block. Its feedback drives one iteration and renders
  * as a `processed` item once the section is no longer processing.
  *
- * Accepts either a single feedback item or an array — a submitted PR review
- * serializes its body and inline comments together, so passing them as one
- * array (they share this block's `iteration_index`) is what lets the review
- * group under a single header. `parseFeedback` unwraps either shape.
+ * Pass an array to model a submitted review: its body + comments share this
+ * block's `iteration_index`, which is what lets them group under one header.
  */
 function makeFeedbackBlock(
   iterationIndex: number,
@@ -160,10 +158,8 @@ function githubPrCommentFeedback(text: string): RawFeedback {
   };
 }
 
-// An inline review comment. Pass `reviewId` to associate it with a review body
-// carrying the same id (and sharing an iteration block) so the two group under
-// one header; omit it for a standalone "Add single comment" review, which stays
-// flat.
+// Pass a `reviewId` matching a review body's to group them; omit it for a
+// standalone "Add single comment" review, which stays flat.
 function githubPrReviewCommentFeedback(
   text: string,
   {reviewId, login = 'octocat'}: {login?: string; reviewId?: number} = {}
@@ -182,10 +178,8 @@ function githubPrReviewCommentFeedback(
   };
 }
 
-// The summary body of a submitted PR review. It carries the review-level state
-// (`approved` / `changes_requested` / `commented`) that drives the header badge,
-// and its `reviewId` is the key inline comments group against. `body` may be
-// empty — a review can approve with no prose, in which case only the badge shows.
+// The summary body of a submitted PR review; `reviewState` drives the header
+// badge and `reviewId` is the key inline comments group against.
 function githubPrReviewBodyFeedback({
   body = '',
   reviewId,

--- a/static/app/components/events/autofix/v3/codeChangesCard.stories.tsx
+++ b/static/app/components/events/autofix/v3/codeChangesCard.stories.tsx
@@ -77,10 +77,15 @@ function makePatch(repoName: string, path: string): ExplorerFilePatch {
 /**
  * A folded-in PR-iteration block. Its feedback drives one iteration and renders
  * as a `processed` item once the section is no longer processing.
+ *
+ * Accepts either a single feedback item or an array — a submitted PR review
+ * serializes its body and inline comments together, so passing them as one
+ * array (they share this block's `iteration_index`) is what lets the review
+ * group under a single header. `parseFeedback` unwraps either shape.
  */
 function makeFeedbackBlock(
   iterationIndex: number,
-  feedback: RawFeedback
+  feedback: RawFeedback | RawFeedback[]
 ): AutofixSection['blocks'][number] {
   return {
     id: `block-pr-${iterationIndex}`,
@@ -155,7 +160,14 @@ function githubPrCommentFeedback(text: string): RawFeedback {
   };
 }
 
-function githubPrReviewCommentFeedback(text: string): RawFeedback {
+// An inline review comment. Pass `reviewId` to associate it with a review body
+// carrying the same id (and sharing an iteration block) so the two group under
+// one header; omit it for a standalone "Add single comment" review, which stays
+// flat.
+function githubPrReviewCommentFeedback(
+  text: string,
+  {reviewId, login = 'octocat'}: {login?: string; reviewId?: number} = {}
+): RawFeedback {
   return {
     text,
     timestamp: '2026-07-20T00:00:00Z',
@@ -163,8 +175,38 @@ function githubPrReviewCommentFeedback(text: string): RawFeedback {
       type: 'github-pr-review-comment',
       comment: {
         html_url: 'https://github.com/org/repo/pull/42#discussion_r1',
-        user: {login: 'octocat'},
+        user: {login},
       },
+      review_id: reviewId,
+    },
+  };
+}
+
+// The summary body of a submitted PR review. It carries the review-level state
+// (`approved` / `changes_requested` / `commented`) that drives the header badge,
+// and its `reviewId` is the key inline comments group against. `body` may be
+// empty — a review can approve with no prose, in which case only the badge shows.
+function githubPrReviewBodyFeedback({
+  body = '',
+  reviewId,
+  reviewState,
+  login = 'octocat',
+}: {
+  reviewState: string;
+  body?: string;
+  login?: string;
+  reviewId?: number;
+}): RawFeedback {
+  return {
+    text: body,
+    timestamp: '2026-07-20T00:00:00Z',
+    source: {
+      type: 'github-pr-review-body',
+      body,
+      html_url: 'https://github.com/org/repo/pull/42#pullrequestreview-1',
+      review_id: reviewId,
+      review_state: reviewState,
+      user: {login},
     },
   };
 }
@@ -277,6 +319,131 @@ export default Storybook.story('CodeChangesCard Feedback', story => {
               groupId="1"
               autofix={makeAutofix([userUiFeedback('Make the button blue', user)])}
               section={makeSection('completed', [])}
+            />
+          </FeatureWrapper>
+        </StatusExample>
+      </Stack>
+    );
+  });
+
+  story('PR reviews', () => {
+    return (
+      <Stack gap="xl">
+        <Text size="sm" variant="muted">
+          A submitted GitHub review groups its summary body and inline comments under one
+          header. The header carries a state badge (<code>Approved</code>,{' '}
+          <code>Changes requested</code>, or <code>Reviewed</code>), and the review's
+          inline comments nest beneath it with a left rule. The body and its comments
+          share one iteration block (mirroring a single review webhook), which is what
+          keys them together on <code>(iterationIndex, reviewId)</code>.
+        </Text>
+
+        <StatusExample label="Changes requested — a review body plus two inline comments, grouped under a danger badge.">
+          <FeatureWrapper>
+            <CodeChangesCard
+              groupId="1"
+              autofix={makeAutofix()}
+              section={makeSection('completed', [
+                makeFeedbackBlock(0, [
+                  githubPrReviewBodyFeedback({
+                    reviewId: 100,
+                    reviewState: 'changes_requested',
+                    body: 'A couple of blockers before this can merge — see inline.',
+                    login: 'octocat',
+                  }),
+                  githubPrReviewCommentFeedback('This branch is never hit — remove it.', {
+                    reviewId: 100,
+                    login: 'octocat',
+                  }),
+                  githubPrReviewCommentFeedback(
+                    'Guard against the null user before dereferencing.',
+                    {reviewId: 100, login: 'octocat'}
+                  ),
+                ]),
+              ])}
+            />
+          </FeatureWrapper>
+        </StatusExample>
+
+        <StatusExample label="Approved — a review body with one inline comment, grouped under a success badge.">
+          <FeatureWrapper>
+            <CodeChangesCard
+              groupId="1"
+              autofix={makeAutofix()}
+              section={makeSection('completed', [
+                makeFeedbackBlock(0, [
+                  githubPrReviewBodyFeedback({
+                    reviewId: 200,
+                    reviewState: 'approved',
+                    body: 'LGTM! One tiny nit inline, feel free to ignore.',
+                    login: 'monalisa',
+                  }),
+                  githubPrReviewCommentFeedback('Nit: prefer `const` here.', {
+                    reviewId: 200,
+                    login: 'monalisa',
+                  }),
+                ]),
+              ])}
+            />
+          </FeatureWrapper>
+        </StatusExample>
+
+        <StatusExample label="Commented — a review left with only inline comments and a body, no explicit approve/reject, grouped under a muted badge.">
+          <FeatureWrapper>
+            <CodeChangesCard
+              groupId="1"
+              autofix={makeAutofix()}
+              section={makeSection('completed', [
+                makeFeedbackBlock(0, [
+                  githubPrReviewBodyFeedback({
+                    reviewId: 300,
+                    reviewState: 'commented',
+                    body: 'A few thoughts, nothing blocking.',
+                    login: 'octocat',
+                  }),
+                  githubPrReviewCommentFeedback(
+                    'Could this be extracted into a helper?',
+                    {reviewId: 300, login: 'octocat'}
+                  ),
+                ]),
+              ])}
+            />
+          </FeatureWrapper>
+        </StatusExample>
+
+        <StatusExample label="Body-only review — an approval with no inline comments renders as a single row with just the badge.">
+          <FeatureWrapper>
+            <CodeChangesCard
+              groupId="1"
+              autofix={makeAutofix()}
+              section={makeSection('completed', [
+                makeFeedbackBlock(0, [
+                  githubPrReviewBodyFeedback({
+                    reviewId: 400,
+                    reviewState: 'approved',
+                    body: 'Ship it 🚀',
+                    login: 'monalisa',
+                  }),
+                ]),
+              ])}
+            />
+          </FeatureWrapper>
+        </StatusExample>
+
+        <StatusExample label="Comment-only review — GitHub's “Add single comment” has no body, so there's no header or badge; the comment stays flat.">
+          <FeatureWrapper>
+            <CodeChangesCard
+              groupId="1"
+              autofix={makeAutofix()}
+              section={makeSection('completed', [
+                makeFeedbackBlock(
+                  0,
+                  githubPrReviewCommentFeedback(
+                    'Drive-by comment, not part of a submitted review.',
+                    {login: 'octocat'}
+                  )
+                ),
+              ])}
             />
           </FeatureWrapper>
         </StatusExample>

--- a/static/app/components/events/autofix/v3/feedbackList.tsx
+++ b/static/app/components/events/autofix/v3/feedbackList.tsx
@@ -50,10 +50,20 @@ interface UserUiFeedback extends ParsedBaseFeedback {
 
 interface GithubPrCommentFeedback extends ParsedBaseFeedback {
   commentUrl: string;
-  sourceType: 'github-pr-comment' | 'github-pr-review-comment';
+  sourceType: 'github-pr-comment';
   githubUsername?: string;
+}
+
+// An inline comment left as part of a submitted review. `Omit<'sourceType'>`
+// because a discriminant can't be narrowed to a new literal through plain
+// `extends`; everything else (commentUrl, githubUsername) is shared.
+interface GithubPrReviewCommentFeedback extends Omit<
+  GithubPrCommentFeedback,
+  'sourceType'
+> {
+  sourceType: 'github-pr-review-comment';
   // Shared with the review body's `reviewId` to group a review's items under one
-  // header. Present only for `github-pr-review-comment`.
+  // header.
   reviewId?: number;
 }
 
@@ -82,6 +92,7 @@ interface OtherFeedback extends ParsedBaseFeedback {
 type ParsedFeedback =
   | UserUiFeedback
   | GithubPrCommentFeedback
+  | GithubPrReviewCommentFeedback
   | GithubPrReviewBodyFeedback
   | CheckSuiteFeedback
   | OtherFeedback;
@@ -109,14 +120,14 @@ function parseFeedbackItem(parsed: RawFeedback): ParsedFeedback | null {
       if (!commentUrl) {
         return null;
       }
-      return {
+      const comment = {
         ...base,
-        sourceType: source.type,
         githubUsername: source.comment?.user?.login,
         commentUrl,
-        reviewId:
-          source.type === 'github-pr-review-comment' ? source.review_id : undefined,
       };
+      return source.type === 'github-pr-review-comment'
+        ? {...comment, sourceType: source.type, reviewId: source.review_id}
+        : {...comment, sourceType: source.type};
     }
     case 'github-pr-review-body':
       return {

--- a/static/app/components/events/autofix/v3/feedbackList.tsx
+++ b/static/app/components/events/autofix/v3/feedbackList.tsx
@@ -54,9 +54,7 @@ interface GithubPrCommentFeedback extends ParsedBaseFeedback {
   githubUsername?: string;
 }
 
-// An inline comment left as part of a submitted review. `Omit<'sourceType'>`
-// because a discriminant can't be narrowed to a new literal through plain
-// `extends`; everything else (commentUrl, githubUsername) is shared.
+// An inline comment left as part of a submitted review.
 interface GithubPrReviewCommentFeedback extends Omit<
   GithubPrCommentFeedback,
   'sourceType'

--- a/static/app/components/events/autofix/v3/feedbackList.tsx
+++ b/static/app/components/events/autofix/v3/feedbackList.tsx
@@ -64,6 +64,9 @@ interface GithubPrCommentFeedback extends ParsedBaseFeedback {
 // comments. `text` may be empty (a review can have inline comments but no body).
 interface GithubPrReviewBodyFeedback extends ParsedBaseFeedback {
   sourceType: 'github-pr-review-body';
+  // The review author's GitHub login, used to render their avatar on the review
+  // header. Absent on feedback serialized before the backend emitted it, in
+  // which case the header falls back to the source glyph.
   githubUsername?: string;
   reviewId?: number;
   reviewState?: string;
@@ -123,6 +126,7 @@ function parseFeedbackItem(parsed: RawFeedback): ParsedFeedback | null {
       return {
         ...base,
         sourceType: 'github-pr-review-body',
+        githubUsername: source.user?.login,
         reviewId: source.review_id,
         reviewState: source.review_state,
         reviewUrl: source.html_url,
@@ -463,31 +467,36 @@ function UserUiAvatar({item}: {item: IterationFeedback}) {
   );
 }
 
+// Builds an `AvatarUser` from a bare GitHub login. We only get the login on the
+// wire (no Sentry user, no avatar URL), so point the avatar at GitHub's per-login
+// image (`github.com/<login>.png`). UserAvatar falls back to a letter avatar from
+// the login if the image fails to load. Returns null when there's no login.
+function githubAvatarUser(login: string | undefined): AvatarUser | null {
+  if (!login) {
+    return null;
+  }
+  return {
+    // GitHub's noreply email for the login. `email` must be present so
+    // UserAvatar's `isActor` check (`email === undefined`) treats this as an
+    // AvatarUser and honors the `avatar` field — an Actor is forced to a letter
+    // avatar. (The exact `ID+login@...` form needs the numeric GitHub user id,
+    // which isn't on the wire, so we use the id-less variant.)
+    email: `${login}@users.noreply.github.com`,
+    username: login,
+    name: login,
+    avatar: {avatarType: 'upload', avatarUrl: `https://github.com/${login}.png`},
+  } as AvatarUser;
+}
+
 function GithubAvatar({item}: {item: IterationFeedback}) {
   const login =
     item.sourceType === 'github-pr-comment' ||
     item.sourceType === 'github-pr-review-comment'
       ? item.githubUsername
       : undefined;
-  // We only get the GitHub login on the wire (no Sentry user, no avatar URL), so
-  // point the avatar at GitHub's per-login image (`github.com/<login>.png`).
-  // UserAvatar falls back to a letter avatar from the login if it fails to load.
-  const user = login
-    ? ({
-        // GitHub's noreply email for the login. `email` must be present so
-        // UserAvatar's `isActor` check (`email === undefined`) treats this as an
-        // AvatarUser and honors the `avatar` field — an Actor is forced to a
-        // letter avatar. (The exact `ID+login@...` form needs the numeric GitHub
-        // user id, which isn't on the wire, so we use the id-less variant.)
-        email: `${login}@users.noreply.github.com`,
-        username: login,
-        name: login,
-        avatar: {avatarType: 'upload', avatarUrl: `https://github.com/${login}.png`},
-      } as AvatarUser)
-    : null;
   return (
     <AuthorAvatar
-      user={user}
+      user={githubAvatarUser(login)}
       Icon={IconGithub}
       tooltip={postedOnLabel(login ?? null, t('GitHub'))}
     />
@@ -546,11 +555,19 @@ function GithubComment({item}: {item: IterationFeedback}) {
   return <CommentBody text={item.text} externalUrl={url} />;
 }
 
-// The review body has no author login on the wire, so it can't render an
-// authored avatar. Use GitHub as the primary glyph — the review's author is
-// already surfaced on its inline comments' avatars beneath the header.
-function GithubReviewBodyAvatar() {
-  return <PrimaryIconAvatar Icon={IconGithub} tooltip={t('Review on GitHub')} />;
+// The review header shows the reviewer's avatar, matching the inline comments
+// beneath it. Older feedback serialized before the login was on the wire has no
+// `githubUsername`; `AuthorAvatar` falls back to the GitHub glyph in that case.
+function GithubReviewBodyAvatar({item}: {item: IterationFeedback}) {
+  const login =
+    item.sourceType === 'github-pr-review-body' ? item.githubUsername : undefined;
+  return (
+    <AuthorAvatar
+      user={githubAvatarUser(login)}
+      Icon={IconGithub}
+      tooltip={postedOnLabel(login ?? null, t('GitHub'))}
+    />
+  );
 }
 
 // Maps a GitHub review state to a Tag variant + human label. Unknown/other

--- a/static/app/components/events/autofix/v3/feedbackList.tsx
+++ b/static/app/components/events/autofix/v3/feedbackList.tsx
@@ -52,21 +52,17 @@ interface GithubPrCommentFeedback extends ParsedBaseFeedback {
   commentUrl: string;
   sourceType: 'github-pr-comment' | 'github-pr-review-comment';
   githubUsername?: string;
-  // The review this inline comment belongs to, shared with the review body's
-  // `reviewId`. Present only for `github-pr-review-comment`; used to group a
-  // review's items under one header.
+  // Shared with the review body's `reviewId` to group a review's items under one
+  // header. Present only for `github-pr-review-comment`.
   reviewId?: number;
 }
 
-// The summary body of a submitted PR review — the review's own representation,
-// so it carries the review-level `reviewState` (approved / changes_requested /
-// …). Rendered as the header of a group whose children are the review's inline
-// comments. `text` may be empty (a review can have inline comments but no body).
+// The summary body of a submitted PR review: carries the review-level
+// `reviewState` and heads a group of the review's inline comments.
 interface GithubPrReviewBodyFeedback extends ParsedBaseFeedback {
   sourceType: 'github-pr-review-body';
-  // The review author's GitHub login, used to render their avatar on the review
-  // header. Absent on feedback serialized before the backend emitted it, in
-  // which case the header falls back to the source glyph.
+  // Absent on feedback serialized before the backend emitted it; the header then
+  // falls back to the source glyph.
   githubUsername?: string;
   reviewId?: number;
   reviewState?: string;
@@ -247,8 +243,6 @@ export function usePrIterationFeedback(
   return {feedback, latestIterationIndex};
 }
 
-// A rendered row is either a standalone feedback item or a review group: a
-// review-body header with its inline comments nested beneath.
 type FeedbackNode =
   | {item: IterationFeedback; type: 'item'}
   | {
@@ -257,19 +251,12 @@ type FeedbackNode =
       type: 'review';
     };
 
-// Group a review's body with its inline comments under one node, keying on
-// `(iterationIndex, reviewId)` — `reviewId` is unique per PR, and a review drives
-// exactly one iteration, so the pair can't collide across replays.
-//
-// A group forms only when a review *body* is present: the body carries the
-// review's state (the header badge) and is the review's representation. A
-// comment-only review (GitHub's "Add single comment", no body) therefore has no
-// header — its comments stay flat, as before. Comments whose body is in the same
-// batch are pulled into the group; everything else passes through in order.
-//
-// Order-independent: the caller renders newest-first (comments can precede their
-// body), so grouped comments are identified up front by reference and the group
-// is anchored at the body's position, rather than assuming the body comes first.
+// A group forms only when a review body is present (a comment-only review — e.g.
+// GitHub's "Add single comment" — stays flat). Keyed on `(iterationIndex,
+// reviewId)`: `reviewId` is unique per PR and a review drives exactly one
+// iteration, so the pair can't collide across replays. Grouped comments are
+// identified up front by reference and the group anchored at the body's position,
+// so the caller's newest-first order (a comment can precede its body) is handled.
 function groupFeedback(items: IterationFeedback[]): FeedbackNode[] {
   const key = (iterationIndex: number, reviewId: number) =>
     `${iterationIndex}:${reviewId}`;
@@ -281,8 +268,6 @@ function groupFeedback(items: IterationFeedback[]): FeedbackNode[] {
     }
   }
 
-  // Bucket each grouped comment under its body, tracking the comments to skip by
-  // reference so the flat pass drops them regardless of where they sit.
   const commentsByReview = new Map<string, IterationFeedback[]>();
   const groupedComments = new Set<IterationFeedback>();
   for (const item of items) {
@@ -302,7 +287,6 @@ function groupFeedback(items: IterationFeedback[]): FeedbackNode[] {
   const nodes: FeedbackNode[] = [];
   for (const item of items) {
     if (item.sourceType === 'github-pr-review-body' && item.reviewId !== undefined) {
-      // The body anchors the group at its own position in the list.
       const k = key(item.iterationIndex, item.reviewId);
       nodes.push({
         type: 'review',
@@ -345,10 +329,6 @@ export function FeedbackList({items}: {items: IterationFeedback[]}) {
   );
 }
 
-// A submitted review: the body row as a header (author avatar, state badge,
-// link, body text) with its inline comments indented beneath. The header row
-// reuses the standard `FeedbackItem` shell; the state badge rides in its comment
-// cell via `GithubReviewBodyComment`.
 function ReviewGroup({
   body,
   comments,
@@ -360,47 +340,32 @@ function ReviewGroup({
     <Stack gap="md">
       <FeedbackItem item={body} />
       {comments.length > 0 && (
-        <ReviewChildren>
+        // `marginLeft` aligns the tree rule under the header avatar's center
+        // (`AVATAR_SIZE / 2` === `space.lg`). `gap="0"` keeps rows abutting so
+        // their vertical segments join into one continuous rule.
+        <Stack gap="0" marginLeft="lg">
           {comments.map((comment, index) => (
             <ReviewChildRow key={`${comment.iterationIndex}-${index}`}>
               <FeedbackItem item={comment} />
             </ReviewChildRow>
           ))}
-        </ReviewChildren>
+        </Stack>
       )}
     </Stack>
   );
 }
 
-// How far the horizontal branch reaches from the vertical rule toward the
-// comment, and the radius of the elbow where the rule curves into the branch at
-// the last child.
 const TREE_BRANCH_WIDTH = 16;
 const TREE_ELBOW_RADIUS = 8;
 
-// Inline comments are indented under their review header and connected by a tree
-// rule on the left, so the group reads as one review. The rule sits under the
-// header avatar's center (`margin-left`); each row draws its own branch pointing
-// at the comment, and `ReviewChildRow` rounds the rule into the branch at the
-// last child.
-const ReviewChildren = styled('div')`
-  display: flex;
-  flex-direction: column;
-  margin-left: ${AVATAR_SIZE / 2}px;
-`;
-
-// One comment in the tree. Rows abut (no gap) so their vertical segments read as
-// one continuous rule; the inter-comment spacing is `padding-top` instead, which
-// the rule spans. The branch is anchored at `space.md + AVATAR_SIZE / 2` — the
-// vertical center of the comment's avatar (its first line) — so it stays aligned
-// even when the comment text wraps to multiple lines.
+// Rows abut (no gap) and space themselves with `padding-top` so their vertical
+// segments join into one continuous rule. The branch is anchored at the vertical
+// center of the comment's avatar so it holds when the comment text wraps.
 const ReviewChildRow = styled('div')`
   position: relative;
   padding-top: ${p => p.theme.space.md};
   padding-left: ${TREE_BRANCH_WIDTH + 12}px;
 
-  /* Vertical rule: full height on every row but the last, so abutting rows form
-     one unbroken line down the group. */
   &::before {
     content: '';
     position: absolute;
@@ -410,7 +375,6 @@ const ReviewChildRow = styled('div')`
     border-left: 1px solid ${p => p.theme.tokens.border.secondary};
   }
 
-  /* Horizontal branch pointing at the comment, centered on its avatar. */
   &::after {
     content: '';
     position: absolute;
@@ -420,9 +384,8 @@ const ReviewChildRow = styled('div')`
     border-top: 1px solid ${p => p.theme.tokens.border.secondary};
   }
 
-  /* Last child: replace the two straight segments with one L-shaped box so the
-     rule stops at the branch and curves into it (a rounded elbow) rather than
-     running past. */
+  /* One L-shaped box so the rule curves into the branch (rounded elbow) instead
+     of running past the last comment. */
   &:last-child::before {
     height: calc(${p => p.theme.space.md} + ${AVATAR_SIZE / 2}px);
     width: ${TREE_BRANCH_WIDTH}px;
@@ -607,9 +570,6 @@ function GithubComment({item}: {item: IterationFeedback}) {
   return <CommentBody text={item.text} externalUrl={url} />;
 }
 
-// The review header shows the reviewer's avatar, matching the inline comments
-// beneath it. Older feedback serialized before the login was on the wire has no
-// `githubUsername`; `AuthorAvatar` falls back to the GitHub glyph in that case.
 function GithubReviewBodyAvatar({item}: {item: IterationFeedback}) {
   const login =
     item.sourceType === 'github-pr-review-body' ? item.githubUsername : undefined;
@@ -622,9 +582,8 @@ function GithubReviewBodyAvatar({item}: {item: IterationFeedback}) {
   );
 }
 
-// Maps a GitHub review state to a Tag variant + human label. Unknown/other
-// states (dismissed, pending, or anything a future provider adds) fall back to
-// muted so the badge never crashes on an unmapped value.
+// Unmapped states (dismissed, pending, a future provider's) return null so the
+// badge is simply omitted rather than crashing.
 function reviewStateTag(
   state: string | undefined
 ): {label: string; variant: TagProps['variant']} | null {
@@ -640,9 +599,6 @@ function reviewStateTag(
   }
 }
 
-// The review-body header cell: a state badge (when known) followed by the body
-// text, with a trailing link out to the review. Body text may be empty for a
-// bare state change, in which case only the badge shows.
 function GithubReviewBodyComment({item}: {item: IterationFeedback}) {
   if (item.sourceType !== 'github-pr-review-body') {
     return null;
@@ -651,6 +607,7 @@ function GithubReviewBodyComment({item}: {item: IterationFeedback}) {
   return (
     <Flex align="center" gap="sm" wrap="wrap">
       {tag && <Tag variant={tag.variant}>{tag.label}</Tag>}
+      {/* A bare state change has no body — show just the link. */}
       {item.text ? (
         <CommentBody text={item.text} externalUrl={item.reviewUrl} />
       ) : (

--- a/static/app/components/events/autofix/v3/feedbackList.tsx
+++ b/static/app/components/events/autofix/v3/feedbackList.tsx
@@ -362,7 +362,9 @@ function ReviewGroup({
       {comments.length > 0 && (
         <ReviewChildren>
           {comments.map((comment, index) => (
-            <FeedbackItem key={`${comment.iterationIndex}-${index}`} item={comment} />
+            <ReviewChildRow key={`${comment.iterationIndex}-${index}`}>
+              <FeedbackItem item={comment} />
+            </ReviewChildRow>
           ))}
         </ReviewChildren>
       )}
@@ -370,16 +372,66 @@ function ReviewGroup({
   );
 }
 
-// Inline comments are indented under their review header and separated by a rule
-// on the left, so the group reads as one review. The indent aligns roughly under
-// the header's comment text (past the avatar column).
+// How far the horizontal branch reaches from the vertical rule toward the
+// comment, and the radius of the elbow where the rule curves into the branch at
+// the last child.
+const TREE_BRANCH_WIDTH = 16;
+const TREE_ELBOW_RADIUS = 8;
+
+// Inline comments are indented under their review header and connected by a tree
+// rule on the left, so the group reads as one review. The rule sits under the
+// header avatar's center (`margin-left`); each row draws its own branch pointing
+// at the comment, and `ReviewChildRow` rounds the rule into the branch at the
+// last child.
 const ReviewChildren = styled('div')`
   display: flex;
   flex-direction: column;
-  gap: ${p => p.theme.space.md};
   margin-left: ${AVATAR_SIZE / 2}px;
-  padding-left: ${p => p.theme.space.xl};
-  border-left: 1px solid ${p => p.theme.tokens.border.secondary};
+`;
+
+// One comment in the tree. Rows abut (no gap) so their vertical segments read as
+// one continuous rule; the inter-comment spacing is `padding-top` instead, which
+// the rule spans. The branch is anchored at `space.md + AVATAR_SIZE / 2` — the
+// vertical center of the comment's avatar (its first line) — so it stays aligned
+// even when the comment text wraps to multiple lines.
+const ReviewChildRow = styled('div')`
+  position: relative;
+  padding-top: ${p => p.theme.space.md};
+  padding-left: ${TREE_BRANCH_WIDTH + 12}px;
+
+  /* Vertical rule: full height on every row but the last, so abutting rows form
+     one unbroken line down the group. */
+  &::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0;
+    height: 100%;
+    border-left: 1px solid ${p => p.theme.tokens.border.secondary};
+  }
+
+  /* Horizontal branch pointing at the comment, centered on its avatar. */
+  &::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: calc(${p => p.theme.space.md} + ${AVATAR_SIZE / 2}px);
+    width: ${TREE_BRANCH_WIDTH}px;
+    border-top: 1px solid ${p => p.theme.tokens.border.secondary};
+  }
+
+  /* Last child: replace the two straight segments with one L-shaped box so the
+     rule stops at the branch and curves into it (a rounded elbow) rather than
+     running past. */
+  &:last-child::before {
+    height: calc(${p => p.theme.space.md} + ${AVATAR_SIZE / 2}px);
+    width: ${TREE_BRANCH_WIDTH}px;
+    border-bottom: 1px solid ${p => p.theme.tokens.border.secondary};
+    border-bottom-left-radius: ${TREE_ELBOW_RADIUS}px;
+  }
+  &:last-child::after {
+    display: none;
+  }
 `;
 
 // Each source type owns an `Avatar` and a `Comment` cell. `FeedbackItem` renders
@@ -582,7 +634,7 @@ function reviewStateTag(
     case 'changes_requested':
       return {label: t('Changes requested'), variant: 'danger'};
     case 'commented':
-      return {label: t('Commented'), variant: 'muted'};
+      return {label: t('Reviewed'), variant: 'muted'};
     default:
       return null;
   }

--- a/static/app/components/events/autofix/v3/feedbackList.tsx
+++ b/static/app/components/events/autofix/v3/feedbackList.tsx
@@ -337,12 +337,15 @@ function ReviewGroup({
   comments: IterationFeedback[];
 }) {
   return (
-    <Stack gap="md">
+    // `gap="0"`: all spacing lives inside the rows (their `padding-top`) so the
+    // tree rule spans it continuously. A gap here would sit outside every row —
+    // an uncovered blank stretch under the header, plus a double gap before the
+    // first comment.
+    <Stack gap="0">
       <FeedbackItem item={body} />
       {comments.length > 0 && (
         // `marginLeft` aligns the tree rule under the header avatar's center
-        // (`AVATAR_SIZE / 2` === `space.lg`). `gap="0"` keeps rows abutting so
-        // their vertical segments join into one continuous rule.
+        // (`AVATAR_SIZE / 2` === `space.lg`).
         <Stack gap="0" marginLeft="lg">
           {comments.map((comment, index) => (
             <ReviewChildRow key={`${comment.iterationIndex}-${index}`}>

--- a/static/app/components/events/autofix/v3/feedbackList.tsx
+++ b/static/app/components/events/autofix/v3/feedbackList.tsx
@@ -3,7 +3,8 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {LetterAvatar, UserAvatar} from '@sentry/scraps/avatar';
-import {Flex, Grid} from '@sentry/scraps/layout';
+import {Tag, type TagProps} from '@sentry/scraps/badge';
+import {Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
@@ -51,6 +52,22 @@ interface GithubPrCommentFeedback extends ParsedBaseFeedback {
   commentUrl: string;
   sourceType: 'github-pr-comment' | 'github-pr-review-comment';
   githubUsername?: string;
+  // The review this inline comment belongs to, shared with the review body's
+  // `reviewId`. Present only for `github-pr-review-comment`; used to group a
+  // review's items under one header.
+  reviewId?: number;
+}
+
+// The summary body of a submitted PR review — the review's own representation,
+// so it carries the review-level `reviewState` (approved / changes_requested /
+// …). Rendered as the header of a group whose children are the review's inline
+// comments. `text` may be empty (a review can have inline comments but no body).
+interface GithubPrReviewBodyFeedback extends ParsedBaseFeedback {
+  sourceType: 'github-pr-review-body';
+  githubUsername?: string;
+  reviewId?: number;
+  reviewState?: string;
+  reviewUrl?: string;
 }
 
 interface CheckSuiteFeedback extends ParsedBaseFeedback {
@@ -66,6 +83,7 @@ interface OtherFeedback extends ParsedBaseFeedback {
 type ParsedFeedback =
   | UserUiFeedback
   | GithubPrCommentFeedback
+  | GithubPrReviewBodyFeedback
   | CheckSuiteFeedback
   | OtherFeedback;
 
@@ -97,8 +115,18 @@ function parseFeedbackItem(parsed: RawFeedback): ParsedFeedback | null {
         sourceType: source.type,
         githubUsername: source.comment?.user?.login,
         commentUrl,
+        reviewId:
+          source.type === 'github-pr-review-comment' ? source.review_id : undefined,
       };
     }
+    case 'github-pr-review-body':
+      return {
+        ...base,
+        sourceType: 'github-pr-review-body',
+        reviewId: source.review_id,
+        reviewState: source.review_state,
+        reviewUrl: source.html_url,
+      };
     case 'check-suite': {
       const {head_sha: headSha, id: checkSuiteId} = source.event.check_suite;
       const repoUrl = source.event.repository.html_url;
@@ -215,20 +243,140 @@ export function usePrIterationFeedback(
   return {feedback, latestIterationIndex};
 }
 
+// A rendered row is either a standalone feedback item or a review group: a
+// review-body header with its inline comments nested beneath.
+type FeedbackNode =
+  | {item: IterationFeedback; type: 'item'}
+  | {
+      body: GithubPrReviewBodyFeedback & IterationFeedback;
+      comments: IterationFeedback[];
+      type: 'review';
+    };
+
+// Group a review's body with its inline comments under one node, keying on
+// `(iterationIndex, reviewId)` — `reviewId` is unique per PR, and a review drives
+// exactly one iteration, so the pair can't collide across replays.
+//
+// A group forms only when a review *body* is present: the body carries the
+// review's state (the header badge) and is the review's representation. A
+// comment-only review (GitHub's "Add single comment", no body) therefore has no
+// header — its comments stay flat, as before. Comments whose body is in the same
+// batch are pulled into the group; everything else passes through in order.
+//
+// Order-independent: the caller renders newest-first (comments can precede their
+// body), so grouped comments are identified up front by reference and the group
+// is anchored at the body's position, rather than assuming the body comes first.
+function groupFeedback(items: IterationFeedback[]): FeedbackNode[] {
+  const key = (iterationIndex: number, reviewId: number) =>
+    `${iterationIndex}:${reviewId}`;
+
+  const bodies = new Map<string, GithubPrReviewBodyFeedback & IterationFeedback>();
+  for (const item of items) {
+    if (item.sourceType === 'github-pr-review-body' && item.reviewId !== undefined) {
+      bodies.set(key(item.iterationIndex, item.reviewId), item);
+    }
+  }
+
+  // Bucket each grouped comment under its body, tracking the comments to skip by
+  // reference so the flat pass drops them regardless of where they sit.
+  const commentsByReview = new Map<string, IterationFeedback[]>();
+  const groupedComments = new Set<IterationFeedback>();
+  for (const item of items) {
+    if (item.sourceType !== 'github-pr-review-comment' || item.reviewId === undefined) {
+      continue;
+    }
+    const k = key(item.iterationIndex, item.reviewId);
+    if (!bodies.has(k)) {
+      continue;
+    }
+    const bucket = commentsByReview.get(k) ?? [];
+    bucket.push(item);
+    commentsByReview.set(k, bucket);
+    groupedComments.add(item);
+  }
+
+  const nodes: FeedbackNode[] = [];
+  for (const item of items) {
+    if (item.sourceType === 'github-pr-review-body' && item.reviewId !== undefined) {
+      // The body anchors the group at its own position in the list.
+      const k = key(item.iterationIndex, item.reviewId);
+      nodes.push({
+        type: 'review',
+        body: bodies.get(k)!,
+        comments: commentsByReview.get(k) ?? [],
+      });
+      continue;
+    }
+    if (groupedComments.has(item)) {
+      // Rendered under its group header; drop the flat row.
+      continue;
+    }
+    nodes.push({type: 'item', item});
+  }
+  return nodes;
+}
+
 export function FeedbackList({items}: {items: IterationFeedback[]}) {
   if (items.length === 0) {
     return null;
   }
 
+  const nodes = groupFeedback(items);
+
   return (
     <ArtifactDetails>
       <Text bold>{t('Feedback')}</Text>
-      {items.map((item, index) => (
-        <FeedbackItem key={`${item.iterationIndex}-${index}`} item={item} />
-      ))}
+      {nodes.map((node, index) =>
+        node.type === 'review' ? (
+          <ReviewGroup
+            key={`review-${node.body.iterationIndex}-${node.body.reviewId}-${index}`}
+            body={node.body}
+            comments={node.comments}
+          />
+        ) : (
+          <FeedbackItem key={`${node.item.iterationIndex}-${index}`} item={node.item} />
+        )
+      )}
     </ArtifactDetails>
   );
 }
+
+// A submitted review: the body row as a header (author avatar, state badge,
+// link, body text) with its inline comments indented beneath. The header row
+// reuses the standard `FeedbackItem` shell; the state badge rides in its comment
+// cell via `GithubReviewBodyComment`.
+function ReviewGroup({
+  body,
+  comments,
+}: {
+  body: GithubPrReviewBodyFeedback & IterationFeedback;
+  comments: IterationFeedback[];
+}) {
+  return (
+    <Stack gap="md">
+      <FeedbackItem item={body} />
+      {comments.length > 0 && (
+        <ReviewChildren>
+          {comments.map((comment, index) => (
+            <FeedbackItem key={`${comment.iterationIndex}-${index}`} item={comment} />
+          ))}
+        </ReviewChildren>
+      )}
+    </Stack>
+  );
+}
+
+// Inline comments are indented under their review header and separated by a rule
+// on the left, so the group reads as one review. The indent aligns roughly under
+// the header's comment text (past the avatar column).
+const ReviewChildren = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${p => p.theme.space.md};
+  margin-left: ${AVATAR_SIZE / 2}px;
+  padding-left: ${p => p.theme.space.xl};
+  border-left: 1px solid ${p => p.theme.tokens.border.secondary};
+`;
 
 // Each source type owns an `Avatar` and a `Comment` cell. `FeedbackItem` renders
 // the shared grid shell (avatar · comment · timestamp · status) and dispatches
@@ -243,6 +391,10 @@ const SOURCE: Record<
   'user-ui': {Avatar: UserUiAvatar, Comment: UserUiComment},
   'github-pr-comment': {Avatar: GithubAvatar, Comment: GithubComment},
   'github-pr-review-comment': {Avatar: GithubAvatar, Comment: GithubComment},
+  'github-pr-review-body': {
+    Avatar: GithubReviewBodyAvatar,
+    Comment: GithubReviewBodyComment,
+  },
   'check-suite': {Avatar: CheckSuiteAvatar, Comment: CheckSuiteComment},
   other: {Avatar: UnknownAvatarCell, Comment: OtherComment},
 };
@@ -392,6 +544,55 @@ function GithubComment({item}: {item: IterationFeedback}) {
       : undefined;
   // The comment text is plain; a trailing arrow links out to the PR comment.
   return <CommentBody text={item.text} externalUrl={url} />;
+}
+
+// The review body has no author login on the wire, so it can't render an
+// authored avatar. Use GitHub as the primary glyph — the review's author is
+// already surfaced on its inline comments' avatars beneath the header.
+function GithubReviewBodyAvatar() {
+  return <PrimaryIconAvatar Icon={IconGithub} tooltip={t('Review on GitHub')} />;
+}
+
+// Maps a GitHub review state to a Tag variant + human label. Unknown/other
+// states (dismissed, pending, or anything a future provider adds) fall back to
+// muted so the badge never crashes on an unmapped value.
+function reviewStateTag(
+  state: string | undefined
+): {label: string; variant: TagProps['variant']} | null {
+  switch (state) {
+    case 'approved':
+      return {label: t('Approved'), variant: 'success'};
+    case 'changes_requested':
+      return {label: t('Changes requested'), variant: 'danger'};
+    case 'commented':
+      return {label: t('Commented'), variant: 'muted'};
+    default:
+      return null;
+  }
+}
+
+// The review-body header cell: a state badge (when known) followed by the body
+// text, with a trailing link out to the review. Body text may be empty for a
+// bare state change, in which case only the badge shows.
+function GithubReviewBodyComment({item}: {item: IterationFeedback}) {
+  if (item.sourceType !== 'github-pr-review-body') {
+    return null;
+  }
+  const tag = reviewStateTag(item.reviewState);
+  return (
+    <Flex align="center" gap="sm" wrap="wrap">
+      {tag && <Tag variant={tag.variant}>{tag.label}</Tag>}
+      {item.text ? (
+        <CommentBody text={item.text} externalUrl={item.reviewUrl} />
+      ) : (
+        item.reviewUrl && (
+          <ExternalLink href={item.reviewUrl} aria-label={t('Open in GitHub')}>
+            <InlineOpenIcon size="xs" />
+          </ExternalLink>
+        )
+      )}
+    </Flex>
+  );
 }
 
 function CheckSuiteComment({item}: {item: IterationFeedback}) {


### PR DESCRIPTION
View the storybook for other variations 

https://sentry-a83ztg15x.sentry.dev/stories/product/components/events/autofix/v3/codechangescard/#pr-reviews

<img width="844" height="487" alt="image" src="https://github.com/user-attachments/assets/abc31e89-6d5d-45ad-85b7-a2f4ba636946" />


## Slop

Frontend follow-up to the backend PR (#120458), which adds `review_id` + `review_state` to PR-review feedback sources. This consumes them to render a **grouped, state-labelled** feedback list.

Before, a submitted review's summary body and its inline comments rendered as independent flat rows with no relationship, and the review state (approved / changes requested / commented) wasn't shown at all — the review-body source fell through to the generic `other` rendering.

Now:
- A review's **body + inline comments group under one header**, keyed on `(iterationIndex, reviewId)`.
- The header shows a **state badge** (`Approved` → success, `Changes requested` → danger, `Commented` → muted).
- Inline comments **nest beneath** the body with a left rule, so the group reads as one review.

## Grouping rules

- A group forms **only when a review body is present** — the body carries the state and is the review's representation.
- A **comment-only review** (GitHub's "Add single comment", no body) has no header; its comment stays flat.
- A **body-only review** renders as a single row with a badge.
- Grouping is **order-independent**: the list renders newest-first, so a comment can precede its body. Grouped comments are identified by reference up front rather than assuming body-first order. (A test caught this — the naive body-first skip double-rendered comments.)

Both wire fields are optional, so this degrades to the current flat rendering against feedback serialized before the backend emits them.

## Depends on

Backend PR #120458 (adds the fields). This is safe to land independently — until the backend deploys, the fields read `undefined` and the list renders exactly as today.

## Test plan

- Added 3 tests to `autofixCards.spec.tsx`: full group (body + 2 comments, asserts state badge + all text), body-only review (badge shown), comment-only review (no badge, stays flat).
- `pnpm typecheck` clean; `pnpm lint:js` clean; all 70 tests in the suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)