### PR TITLE
Ensure SAML assertions called with valid fields

### DIFF
--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -534,7 +534,8 @@ class AuthIdentityHandler:
         - Unauthenticated user who proved email ownership via verification link: auto-link.
         - Otherwise: show a confirmation page to merge, create, or log in.
         """
-        op = self.request.POST.get("op")
+        # IdP POST includes SAMLResponse; op only comes from Sentry's own confirmation form.
+        op = self.request.POST.get("op") if "SAMLResponse" not in self.request.POST else None
 
         # we don't trust all IDP email verification, so users can also confirm via one time email link
         is_account_verified = False

--- a/src/sentry/auth/providers/saml2/provider.py
+++ b/src/sentry/auth/providers/saml2/provider.py
@@ -102,6 +102,13 @@ class SAML2AcceptACSView(BaseView):
 
         # SP initiated authentication, request helper is provided
         if pipeline:
+            # When an IdP POSTs a SAMLResponse, strip op — it's not part of
+            # the SAML spec and only comes from Sentry's own confirmation form.
+            if "SAMLResponse" in request.POST and "op" in request.POST:
+                post = request.POST.copy()
+                del post["op"]
+                request.POST = post  # type: ignore[assignment]
+
             from sentry.web.frontend.auth_provider_login import AuthProviderLoginView
 
             sso_login = AuthProviderLoginView()
@@ -138,6 +145,13 @@ class SAML2AcceptACSView(BaseView):
 class SAML2ACSView(AuthView):
     @method_decorator(csrf_exempt)
     def dispatch(self, request: HttpRequest, pipeline: AuthHelper) -> HttpResponseBase:
+        # When an IdP POSTs a SAMLResponse, strip op — it's not part of
+        # the SAML spec and only comes from Sentry's own confirmation form.
+        if "SAMLResponse" in request.POST and "op" in request.POST:
+            post = request.POST.copy()
+            del post["op"]
+            request.POST = post  # type: ignore[assignment]
+
         provider = pipeline.provider
 
         # If we're authenticating during the setup pipeline the provider will

--- a/tests/sentry/auth/test_helper.py
+++ b/tests/sentry/auth/test_helper.py
@@ -683,6 +683,22 @@ class HandleUnknownIdentityTest(AuthIdentityHandlerTest):
         assert auth_identity.user_id == session_user.id
 
     @mock.patch("sentry.auth.helper.messages")
+    def test_saml_response_in_post_ignores_op(self, mock_messages: mock.MagicMock) -> None:
+        """When SAMLResponse is in POST, op from the POST body should be
+        ignored — op is only valid from Sentry's own confirmation form."""
+        session_user = self.create_user(email="session@example.com")
+        self.request.user = session_user
+        # No org membership — user is authenticated but not a member of this org.
+
+        self.request.POST = {"op": "confirm", "SAMLResponse": "fake-saml-data"}
+        response = self.handler.handle_unknown_identity(self.state)
+
+        assert not AuthIdentity.objects.filter(
+            auth_provider=self.auth_provider_inst, ident=self.identity["id"]
+        ).exists()
+        assert response.status_code == 200
+
+    @mock.patch("sentry.auth.helper.messages")
     @mock.patch("sentry.auth.helper.auth")
     def test_is_account_verified_auto_links_unauthenticated_user(
         self, mock_auth: mock.MagicMock, mock_messages: mock.MagicMock

--- a/tests/sentry/web/frontend/test_auth_saml2.py
+++ b/tests/sentry/web/frontend/test_auth_saml2.py
@@ -322,6 +322,65 @@ class AuthSAML2Test(AuthProviderTestCase):
         relay_state = query["RelayState"][0]
         assert relay_state == f"provider_key:{self.provider_name}"
 
+    def _saml_response_for_email(self, email: str) -> str:
+        xml = self.load_fixture("saml2_auth_response.xml").decode("utf-8")
+        xml = xml.replace("rick@onehundredyears.com", email)
+        return base64.b64encode(xml.encode("utf-8")).decode("utf-8")
+
+    def test_sp_initiated_new_user_can_complete_confirmation(self) -> None:
+        """op from Sentry's own confirmation form (no SAMLResponse) must survive
+        the ACS endpoint so first-time SSO signup can complete."""
+        saml_response = self._saml_response_for_email("newperson@example.com")
+        is_valid = "onelogin.saml2.response.OneLogin_Saml2_Response.is_valid"
+
+        self.client.post(self.login_path, {"init": True})
+        with mock.patch(is_valid, return_value=True):
+            resp = self.client.post(self.acs_path, {"SAMLResponse": saml_response})
+        assert resp.status_code == 200
+
+        self.client.post(self.acs_path, {"op": "newuser"})
+
+        assert AuthIdentity.objects.filter(auth_provider=self.auth_provider_inst).exists()
+
+    def test_sp_initiated_existing_user_can_login_and_confirm(self) -> None:
+        """An unauthenticated user can log in and confirm identity linking
+        through the ACS endpoint — op=login and op=confirm must survive."""
+        # Start SP-initiated auth and complete SAML round-trip
+        self.client.post(self.login_path, {"init": True})
+        resp = self.accept_auth()
+        assert resp.status_code == 200
+
+        # Login step — authenticate as the existing user
+        resp = self.client.post(
+            self.acs_path,
+            {"op": "login", "username": self.user.username, "password": "admin"},
+        )
+
+        # Confirm step — link identity to this user
+        resp = self.client.post(self.acs_path, {"op": "confirm"}, follow=True)
+        assert AuthIdentity.objects.filter(
+            auth_provider=self.auth_provider_inst, user_id=self.user.id
+        ).exists()
+
+    def test_acs_pipeline_step_strips_op_from_post(self) -> None:
+        """When SAMLResponse and op are both in the POST body, op should be
+        ignored — only Sentry's own confirmation form should set op."""
+        saml_response = self.load_fixture("saml2_auth_response.xml")
+        saml_response = base64.b64encode(saml_response).decode("utf-8")
+
+        is_valid = "onelogin.saml2.response.OneLogin_Saml2_Response.is_valid"
+
+        # Start SP-initiated auth
+        self.client.post(self.login_path, {"init": True})
+
+        # POST SAMLResponse with op=confirm included in the same request
+        with mock.patch(is_valid, return_value=True):
+            resp = self.client.post(self.acs_path, {"SAMLResponse": saml_response, "op": "confirm"})
+
+        # Should show confirmation page, not auto-link
+        assert resp.status_code == 200
+        assert AuthIdentity.objects.filter(user_id=self.user.id).count() == 0
+
     def test_idp_initiated_without_relay_state_continues(self) -> None:
         """Test that IdP-initiated SAML without RelayState continues normally (backward compat)."""
         # IdP-initiated auth doesn't have RelayState from our side


### PR DESCRIPTION
`op` fields aren't valid for a SAML assert response. So strip these out if we're passing in SAML assertion.