### PR TITLE
refactor(weekly-reports): Extract spans_count_by_project() helper

### DIFF
--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -710,6 +710,39 @@ def _get_transaction_projects(ctx: OrganizationReportContext) -> list[Project]:
     ]
 
 
+def spans_count_by_project(
+    projects: list[Project],
+    organization: Organization,
+    start: datetime,
+    end: datetime,
+    referrer: str,
+) -> dict[int, int]:
+    snuba_params = SnubaParams(
+        start=start,
+        end=end,
+        projects=projects,
+        organization=organization,
+    )
+    config = SearchResolverConfig(auto_fields=True)
+    result = Spans.run_table_query(
+        params=snuba_params,
+        query_string="is_transaction:1",
+        selected_columns=["project.id", "count()"],
+        orderby=None,
+        offset=0,
+        limit=len(projects),
+        referrer=referrer,
+        config=config,
+        sampling_mode=None,
+    )
+    counts: dict[int, int] = {}
+    for row in result.get("data", []):
+        project_id = row.get("project.id")
+        if project_id:
+            counts[int(project_id)] = row.get("count()", 0)
+    return counts
+
+
 def organization_top_spans(
     ctx: OrganizationReportContext,
     referrer: str,
@@ -760,22 +793,9 @@ def organization_top_spans(
         op="weekly_reports.spans_count_by_project",
         name="weekly_reports.spans_count_by_project",
     ):
-        count_by_project_result = Spans.run_table_query(
-            params=snuba_params,
-            query_string="is_transaction:1",
-            selected_columns=["project.id", "count()"],
-            orderby=None,
-            offset=0,
-            limit=len(projects),
-            referrer=referrer,
-            config=config,
-            sampling_mode=None,
+        ctx.spans_count_by_project = spans_count_by_project(
+            projects, ctx.organization, ctx.start, ctx.end, referrer
         )
-
-    for row in count_by_project_result.get("data", []):
-        project_id = row.get("project.id")
-        if project_id:
-            ctx.spans_count_by_project[int(project_id)] = row.get("count()", 0)
 
     for row in result.get("data", []):
         span_name = row.get("span.name", "")

--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -739,7 +739,7 @@ def spans_count_by_project(
     for row in result.get("data", []):
         project_id = row.get("project.id")
         if project_id:
-            counts[int(project_id)] = row.get("count()", 0)
+            counts[int(project_id)] = row.get("count()") or 0
     return counts
 
 


### PR DESCRIPTION
## Summary
- Extracts the inline `count()` query from `organization_top_spans()` into a reusable `spans_count_by_project()` helper function.
- No behavior change — the same Snuba EAP query runs, just factored out for reuse by upcoming WoW (Week-over-Week) spans work.

## Test plan
- [x] All 10 existing `OrganizationTopSpansTest` tests pass