### PR TITLE
fix(replays): Repair bulk delete retry and job failure handling

### DIFF
--- a/src/sentry/replays/tasks.py
+++ b/src/sentry/replays/tasks.py
@@ -6,6 +6,7 @@ from typing import Any
 from google.cloud.exceptions import NotFound
 from taskbroker_client.constants import CompressionType
 from taskbroker_client.retry import Retry
+from taskbroker_client.state import current_task
 
 from sentry.replays.consumers.recording import commit_message, process_message
 from sentry.replays.lib.kafka import PROCESS_REPLAY_RECORDING_TASK_NAME, publish_replay_event
@@ -247,8 +248,13 @@ def run_bulk_replay_delete_job(
     except Exception:
         logger.exception("Bulk delete replays failed.")
 
-        job.status = DeletionJobStatus.FAILED
-        job.save()
+        # Marking the job failed makes every subsequent run a no-op (see the status guard
+        # above), so only do it once the task has no retries left. Otherwise re-raise and
+        # let the worker retry from the same offset.
+        task_state = current_task()
+        if task_state is None or not task_state.retries_remaining:
+            job.status = DeletionJobStatus.FAILED
+            job.save()
         raise
 
     # Compute the next offset to start from. If no further processing is required then this serves

--- a/src/sentry/replays/usecases/delete.py
+++ b/src/sentry/replays/usecases/delete.py
@@ -160,7 +160,7 @@ def fetch_rows_matching_pattern(
     # because our most likely failure is rate limit related. Blasting Snuba with more queries will
     # increase the chance of failure not reduce it.
     policy = ConditionalRetryPolicy(
-        test_function=lambda a, e: a < 5 and e in SNUBA_RETRY_EXCEPTIONS,
+        test_function=lambda a, e: a < 5 and isinstance(e, SNUBA_RETRY_EXCEPTIONS),
         delay_function=exponential_delay(1.0),
     )
     response = policy(

--- a/src/sentry/replays/usecases/delete.py
+++ b/src/sentry/replays/usecases/delete.py
@@ -167,7 +167,7 @@ def fetch_rows_matching_pattern(
         functools.partial(
             execute_query,
             query,
-            {"tenant_id": Organization.objects.filter(project__id=project_id).get().id},
+            {"organization_id": Organization.objects.filter(project__id=project_id).get().id},
             "replays.delete_replays_bulk",
         )
     )

--- a/tests/sentry/replays/tasks/test_delete_replays_bulk.py
+++ b/tests/sentry/replays/tasks/test_delete_replays_bulk.py
@@ -5,6 +5,8 @@ import uuid
 from collections.abc import Generator
 from unittest.mock import MagicMock, Mock, patch
 
+import pytest
+
 from sentry.replays.models import DeletionJobStatus, ReplayDeletionJobModel
 from sentry.replays.tasks import run_bulk_replay_delete_job
 from sentry.replays.testutils import mock_replay
@@ -14,6 +16,7 @@ from sentry.replays.usecases.delete import (
 )
 from sentry.testutils.cases import APITestCase, ReplaysSnubaTestCase
 from sentry.testutils.helpers import TaskRunner
+from sentry.utils.snuba import RateLimitExceeded, SnubaError
 
 
 class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
@@ -306,6 +309,52 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
             "organization_id": self.job.organization_id,
             "project_id": self.job.project_id,
         }
+
+    @patch("sentry.utils.retries.time.sleep")
+    @patch("sentry.replays.usecases.delete.execute_query")
+    def test_fetch_rows_matching_pattern_retries_snuba_errors(
+        self, mock_execute_query: MagicMock, mock_sleep: MagicMock
+    ) -> None:
+        """Transient Snuba errors are retried; the query succeeds on a later attempt."""
+        mock_execute_query.side_effect = [
+            SnubaError("read timed out"),
+            RateLimitExceeded("rate limited"),
+            {"data": []},
+        ]
+
+        result = fetch_rows_matching_pattern(
+            self.project.id,
+            self.range_start,
+            self.range_end,
+            query="",
+            environment=["prod"],
+            limit=50,
+            offset=0,
+        )
+
+        assert result == {"has_more": False, "rows": []}
+        assert mock_execute_query.call_count == 3
+
+    @patch("sentry.utils.retries.time.sleep")
+    @patch("sentry.replays.usecases.delete.execute_query")
+    def test_fetch_rows_matching_pattern_retries_exhausted(
+        self, mock_execute_query: MagicMock, mock_sleep: MagicMock
+    ) -> None:
+        """After the maximum number of attempts the error is raised to the caller."""
+        mock_execute_query.side_effect = SnubaError("read timed out")
+
+        with pytest.raises(SnubaError):
+            fetch_rows_matching_pattern(
+                self.project.id,
+                self.range_start,
+                self.range_end,
+                query="",
+                environment=["prod"],
+                limit=50,
+                offset=0,
+            )
+
+        assert mock_execute_query.call_count == 5
 
     @patch("requests.post")
     @patch("sentry.replays.tasks.fetch_rows_matching_pattern")

--- a/tests/sentry/replays/tasks/test_delete_replays_bulk.py
+++ b/tests/sentry/replays/tasks/test_delete_replays_bulk.py
@@ -381,6 +381,10 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
         assert result == {"has_more": False, "rows": []}
         assert mock_execute_query.call_count == 3
 
+        # Snuba allocation policies key quotas on organization_id.
+        tenant_ids = mock_execute_query.call_args[0][1]
+        assert tenant_ids == {"organization_id": self.project.organization.id}
+
     @patch("sentry.utils.retries.time.sleep")
     @patch("sentry.replays.usecases.delete.execute_query")
     def test_fetch_rows_matching_pattern_retries_exhausted(

--- a/tests/sentry/replays/tasks/test_delete_replays_bulk.py
+++ b/tests/sentry/replays/tasks/test_delete_replays_bulk.py
@@ -310,6 +310,52 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
             "project_id": self.job.project_id,
         }
 
+    @patch("sentry.replays.tasks.current_task")
+    @patch("sentry.replays.tasks.fetch_rows_matching_pattern")
+    def test_run_bulk_replay_delete_job_error_with_retries_remaining(
+        self, mock_fetch_rows: MagicMock, mock_current_task: MagicMock
+    ) -> None:
+        """An error on a non-terminal attempt re-raises without failing the job."""
+        mock_fetch_rows.side_effect = SnubaError("read timed out")
+        mock_current_task.return_value = Mock(retries_remaining=True)
+
+        with pytest.raises(SnubaError):
+            run_bulk_replay_delete_job(self.job.id, offset=0)
+
+        # The job is still runnable so the worker's retry is not a no-op.
+        self.job.refresh_from_db()
+        assert self.job.status == DeletionJobStatus.IN_PROGRESS
+
+    @patch("sentry.replays.tasks.current_task")
+    @patch("sentry.replays.tasks.fetch_rows_matching_pattern")
+    def test_run_bulk_replay_delete_job_error_on_final_attempt(
+        self, mock_fetch_rows: MagicMock, mock_current_task: MagicMock
+    ) -> None:
+        """An error on the terminal attempt marks the job failed."""
+        mock_fetch_rows.side_effect = SnubaError("read timed out")
+        mock_current_task.return_value = Mock(retries_remaining=False)
+
+        with pytest.raises(SnubaError):
+            run_bulk_replay_delete_job(self.job.id, offset=0)
+
+        self.job.refresh_from_db()
+        assert self.job.status == DeletionJobStatus.FAILED
+
+    @patch("sentry.replays.tasks.current_task")
+    @patch("sentry.replays.tasks.fetch_rows_matching_pattern")
+    def test_run_bulk_replay_delete_job_error_without_task_context(
+        self, mock_fetch_rows: MagicMock, mock_current_task: MagicMock
+    ) -> None:
+        """An error with no task context (direct call) marks the job failed."""
+        mock_fetch_rows.side_effect = SnubaError("read timed out")
+        mock_current_task.return_value = None
+
+        with pytest.raises(SnubaError):
+            run_bulk_replay_delete_job(self.job.id, offset=0)
+
+        self.job.refresh_from_db()
+        assert self.job.status == DeletionJobStatus.FAILED
+
     @patch("sentry.utils.retries.time.sleep")
     @patch("sentry.replays.usecases.delete.execute_query")
     def test_fetch_rows_matching_pattern_retries_snuba_errors(


### PR DESCRIPTION
A single transient Snuba error currently kills a bulk replay deletion job permanently. The query-level retry policy never fires, and the task marks the job `failed` before re-raising — so every taskbroker retry hits the status guard at the top of the task and exits without doing anything. Since bulk deletion is a PII-removal path, jobs were silently stopping mid-way after one 30-second timeout or rate limit.

Three fixes, one commit each:

- **Query retry policy never retried.** The predicate tested `e in SNUBA_RETRY_EXCEPTIONS`, comparing an exception instance against a tuple of classes — always false. Now uses `isinstance`, enabling the 5-attempt exponential backoff the surrounding comment always described.
- **Jobs failed on the first error instead of the last.** The task now consults `current_task().retries_remaining` and only marks the job `failed` on the terminal attempt (or when there is no task context, preserving direct-call behavior). Non-terminal failures re-raise so the worker retries from the same checkpointed offset, which is idempotent.
- **Snuba tenant ids used an unrecognized key.** The query sent `{"tenant_id": <org id>}`, which no Snuba allocation policy reads; it now sends `organization_id` like every other replay caller, so per-org quota enforcement and rate-limit error tagging apply to this referrer.

New tests cover retry-then-succeed, retries-exhausted, and all three job-failure branches — none of these paths had coverage, which is how the retry bug survived since the feature landed. Existing tests are unchanged.

This PR does not change the query itself: the timeout root cause (each page re-scans the job's full date range) is addressed separately in #120456. This change makes deletion jobs survive transient errors instead of being abandoned.

Refs SENTRY-5JN8