### PR TITLE
feat(seer): Record agentic-triage-sort flag in agent run options

### DIFF
--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -627,6 +627,13 @@ class SeerAgentClient:
         ):
             opts["enable_streaming"] = True
 
+        if features.has(
+            "organizations:agentic-triage-sort",
+            self.organization,
+            actor=self.user,
+        ):
+            opts["is_agentic_triage_sort"] = True
+
         return opts
 
     def continue_run(


### PR DESCRIPTION
## Summary
- Thread the `organizations:agentic-triage-sort` feature flag into `_build_agent_run_options()` so it gets persisted on the run state and synced to BigQuery.
- This lets the autofix-data dashboard filter Sankey funnels by whether the org used the Snuba-based multi-factor candidate selection strategy vs the default fixability-only strategy.
- Follows the same pattern as other flag checks in the function (e.g., `seer-agent-source-code-search`, `seer-explorer-stream`).

## Test plan
- [ ] Existing seer agent tests pass (no new required args — flag defaults to `False`)
- [ ] Verify in staging that runs from orgs with the flag produce `agent_run_options.is_agentic_triage_sort: true` in BigQuery

🤖 Generated with [Claude Code](https://claude.com/claude-code)