### PR TITLE
build(ui): Make TypeScript checker opt in

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "build": "NODE_OPTIONS='--max-old-space-size=4096' rspack --config ./rspack.config.ts",
     "build-js-loader": "node scripts/build-js-loader.ts",
     "build-js-po": "node build-utils/ts-extract-gettext.ts",
-    "build-profile": "NO_TS_FORK=1 rspack --profile --json > stats.json",
+    "build-profile": "rspack --profile --json > stats.json",
     "extract-form-fields": "node scripts/extractFormFields.ts",
     "gen:embed-widgets": "node scripts/genEmbedWidgets.ts",
     "gen:platform-info": "node scripts/genPlatformProductInfo.ts",

--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -81,7 +81,8 @@ const HAS_WEBPACK_DEV_SERVER_CONFIG =
 
 // User/tooling configurable environment variables
 const NO_DEV_SERVER = !!env.NO_DEV_SERVER; // Do not run webpack dev server
-const SHOULD_FORK_TS = DEV_MODE && !env.NO_TS_FORK; // Do not run fork-ts plugin (or if not dev env)
+// Type checking is resource intensive, enable it explicitly with ENABLE_TS_CHECKER=1.
+const SHOULD_CHECK_TYPES = DEV_MODE && Boolean(env.ENABLE_TS_CHECKER);
 const SHOULD_HOT_MODULE_RELOAD = DEV_MODE && !!env.SENTRY_UI_HOT_RELOAD;
 const SHOULD_ADD_RSDOCTOR = Boolean(env.RSDOCTOR);
 // Only entry points are eagerly built, lazy build routes. Saves memory and startup time.
@@ -430,7 +431,7 @@ const appConfig: Configuration = {
      */
     new rspack.DefinePlugin(DEFINED_ENV_VARS),
 
-    ...(SHOULD_FORK_TS
+    ...(SHOULD_CHECK_TYPES
       ? [
           new TsCheckerRspackPlugin({
             typescript: {


### PR DESCRIPTION
The Rspack TypeScript checker currently runs for every local development build. We were seeing native `tsc` processes pile up during rapid edits while an [upstream fix](https://github.com/rstackjs/ts-checker-rspack-plugin/pull/129) is being discussed.

Disable it by default and use `ENABLE_TS_CHECKER=1` to opt back in.