### PR TITLE
fix(trace): Remove eventTransaction in showJSONLink check

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -552,7 +552,7 @@ function EAPSpanNodeDetailsContent({
             node={node}
             organization={organization}
             onTabScrollToNode={onTabScrollToNode}
-            showJSONLink={isTransaction && !!eventTransaction}
+            showJSONLink={isTransaction}
             profileId={node.profileId}
             profilerId={node.profilerId}
             threadId={threadId}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -908,6 +908,9 @@ function NodeActions(props: {
 
   const transactionId = props.node.transactionId ?? '';
 
+  const canShowEAPSpanJSON =
+    getDiscoverDeprecation(props.organization) && isEAPSpanNode(props.node);
+
   const transactionProfileTarget = useMemo(() => {
     if (!props.profileId) {
       return null;
@@ -945,12 +948,12 @@ function NodeActions(props: {
           icon={<IconFocus />}
         />
       </Tooltip>
-      {props.showJSONLink && transactionId ? (
+      {props.showJSONLink && (canShowEAPSpanJSON || transactionId) ? (
         <Tooltip title={t('JSON')} skipWrapper>
           <ActionLinkButton
             onClick={() => traceAnalytics.trackViewEventJSON(props.organization)}
             href={
-              getDiscoverDeprecation(props.organization) && isEAPSpanNode(props.node)
+              canShowEAPSpanJSON
                 ? `/api/0/projects/${props.organization.slug}/${props.node.projectSlug}/trace-items/${props.node.id}/?item_type=spans&trace_id=${params.traceSlug}`
                 : `/api/0/projects/${props.organization.slug}/${props.node.projectSlug}/events/${transactionId}/json/`
             }


### PR DESCRIPTION
I'm gradually removing all references to `eventTransaction` from the EAP span version of the trace waterfall and span drawer (see BROWSE-646).

This PR removes it from the `showJSONLink` gate on `TraceDrawerComponents.NodeActions` - it actually works fine downstream already without a transaction, just had to make the `transactionId` check only affect the branch that uses the old transaction JSON URL.