### PR TITLE
feat(jira): Add status field to Jira search endpoint

### DIFF
--- a/src/sentry/integrations/jira/endpoints/search.py
+++ b/src/sentry/integrations/jira/endpoints/search.py
@@ -59,6 +59,26 @@ class JiraSearchEndpoint(IntegrationEndpoint):
 
         if field is None:
             return Response({"detail": "field is a required parameter"}, status=400)
+
+        if field == "status":
+            project_id = request.GET.get("project")
+            if not project_id:
+                return Response(
+                    {"detail": "project is a required parameter for status search"}, status=400
+                )
+            with ProjectManagementEvent(
+                action_type=ProjectManagementActionType.SEARCH_STATUSES,
+                integration=integration,
+            ).capture() as lifecycle:
+                lifecycle.add_extra("field", field)
+                try:
+                    response = jira_client.get_project_statuses(project_id)
+                except (ApiUnauthorized, ApiError) as e:
+                    lifecycle.record_halt(e)
+                    return Response({"detail": "Unable to fetch statuses from Jira"}, status=400)
+            statuses = [{"value": s["id"], "label": s["name"]} for s in response.get("values", [])]
+            return Response(statuses)
+
         if not query:
             return Response({"detail": "query is a required parameter"}, status=400)
 

--- a/src/sentry/integrations/project_management/metrics.py
+++ b/src/sentry/integrations/project_management/metrics.py
@@ -25,6 +25,7 @@ class ProjectManagementActionType(StrEnum):
     SEARCH_ISSUES = "search_issues"
     SEARCH_USERS = "search_users"
     SEARCH_PROJECTS = "search_projects"
+    SEARCH_STATUSES = "search_statuses"
     SEARCH_FIELD_AUTOCOMPLETE = "search_field_autocomplete"
 
 

--- a/tests/sentry/integrations/jira/test_search_endpoint.py
+++ b/tests/sentry/integrations/jira/test_search_endpoint.py
@@ -266,6 +266,74 @@ class JiraSearchEndpointTest(APITestCase):
 
     @responses.activate
     @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event", autospec=True)
+    def test_status_search(self, mock_record: mock.MagicMock) -> None:
+        responses.add(
+            responses.GET,
+            "https://example.atlassian.net/rest/api/2/statuses/search",
+            json={
+                "values": [
+                    {"id": "1", "name": "Open"},
+                    {"id": "3", "name": "In Progress"},
+                    {"id": "6", "name": "Closed"},
+                ],
+            },
+        )
+        self.login_as(self.user)
+
+        path = reverse(
+            "sentry-extensions-jira-search", args=[self.organization.slug, self.integration.id]
+        )
+
+        resp = self.client.get(f"{path}?field=status&project=10000")
+        assert resp.status_code == 200
+        assert resp.data == [
+            {"value": "1", "label": "Open"},
+            {"value": "3", "label": "In Progress"},
+            {"value": "6", "label": "Closed"},
+        ]
+        _assert_search_outcome(
+            mock_record, ProjectManagementActionType.SEARCH_STATUSES, EventLifecycleOutcome.SUCCESS
+        )
+
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event", autospec=True)
+    def test_status_search_missing_project(self, mock_record: mock.MagicMock) -> None:
+        self.login_as(self.user)
+
+        path = reverse(
+            "sentry-extensions-jira-search", args=[self.organization.slug, self.integration.id]
+        )
+
+        resp = self.client.get(f"{path}?field=status")
+        assert resp.status_code == 400
+        assert resp.data == {"detail": "project is a required parameter for status search"}
+
+    @responses.activate
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event", autospec=True)
+    def test_status_search_error(self, mock_record: mock.MagicMock) -> None:
+        responses.add(
+            responses.GET,
+            "https://example.atlassian.net/rest/api/2/statuses/search",
+            status=500,
+            body="Jira error",
+        )
+        self.login_as(self.user)
+
+        path = reverse(
+            "sentry-extensions-jira-search", args=[self.organization.slug, self.integration.id]
+        )
+
+        resp = self.client.get(f"{path}?field=status&project=10000")
+        assert resp.status_code == 400
+        assert resp.data == {"detail": "Unable to fetch statuses from Jira"}
+        _assert_search_outcome(
+            mock_record,
+            ProjectManagementActionType.SEARCH_STATUSES,
+            EventLifecycleOutcome.HALTED,
+            expected_exception=ApiError,
+        )
+
+    @responses.activate
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event", autospec=True)
     def test_project_search_with_pagination(self, mock_record: mock.MagicMock) -> None:
         responses.add(
             responses.GET,


### PR DESCRIPTION
- Adds `field=status` support to the Jira search endpoint (`/extensions/jira/search/`)
- Accepts a `project` query param (Jira project ID) and returns per-project statuses via `get_project_statuses()`

This is PR 1 of 3 for fixing our 10 project limit for showing per project labels in Jira(ISWF-1684). This will be used by the frontend to lazy-load statuses when a new project row is added.

### The plan + context PLS READ
----
Currently our Jira config endpoint logic creates a mapping between project -> list of (label_id, label), but we have the 10 project limit for this logic to avoid getting rate-limited. So the fallback logic for orgs with >10 projects is to not create a mapping and just load all the labels (which is what the ticket's about).

The plan is for the initial config to load ONLY the labels for projects that already have a saved config (IntegrationExternalProject). Then when a user adds a new project, then fetch the labels for said project from Jira.

PR 1: Add way to lazily fetch the new project's labels
PR 2: Modify the original Jira config logic to only create the mapping for saved projects
PR 3: Modify the frontend form to fetch labels upon new project dropdown row being added
