### PR TITLE
fix(jira): Only load saved project status mappings 

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -148,6 +148,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:integrations-gitlab-project-management", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Temporary: log full Jira Cloud `issue.updated` webhook payloads so we can design project-change link rewriting.
     manager.add("organizations:jira-issue-updated-payload-logging", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Lazy-load Jira statuses per-project instead of pre-fetching all, to fix duplicate statuses for large orgs.
+    manager.add("organizations:jira-lazy-status-sync", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Use the paginated project endpoint in Jira org config to avoid timeouts on large instances.
     manager.add("organizations:jira-paginated-project-config", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable inviting billing members to organizations at the member limit.

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -187,7 +187,7 @@ class JiraIntegration(IssueSyncIntegration):
                     for p in client.get_projects_list()
                 ]
             if features.has("organizations:jira-lazy-status-sync", self.organization):
-                self._set_lazy_status_choices_in_organization_config(configuration)
+                configuration[0].update(self._get_lazy_status_config())
             else:
                 self._set_status_choices_in_organization_config(configuration, projects)
             configuration[0]["addDropdown"]["items"] = projects
@@ -266,14 +266,13 @@ class JiraIntegration(IssueSyncIntegration):
 
         return configuration
 
-    def _set_lazy_status_choices_in_organization_config(
-        self, configuration: list[dict[str, Any]]
-    ) -> list[dict[str, Any]]:
+    def _get_lazy_status_config(self) -> dict[str, Any]:
         """
         Pre-load statuses only for already-configured projects.
         """
         client = self.get_client()
 
+        mapped_selectors: dict[str, Any] = {}
         configured_projects = IntegrationExternalProject.objects.filter(
             organization_integration_id=self.org_integration.id
         )
@@ -285,18 +284,19 @@ class JiraIntegration(IssueSyncIntegration):
             except ApiError:
                 continue
             statuses = [(c["id"], c["name"]) for c in project_statuses]
-            configuration[0]["mappedSelectors"][project.external_id] = {
+            mapped_selectors[project.external_id] = {
                 "on_resolve": {"choices": statuses},
                 "on_unresolve": {"choices": statuses},
             }
 
-        configuration[0]["perItemMapping"] = True
-        configuration[0]["statusUrl"] = reverse(
-            "sentry-extensions-jira-search",
-            args=[self.organization.slug, self.model.id],
-        )
-
-        return configuration
+        return {
+            "mappedSelectors": mapped_selectors,
+            "perItemMapping": True,
+            "statusUrl": reverse(
+                "sentry-extensions-jira-search",
+                args=[self.organization.slug, self.model.id],
+            ),
+        }
 
     def _get_organization_config_default_values(self) -> list[dict[str, Any]]:
         return [

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -270,8 +270,7 @@ class JiraIntegration(IssueSyncIntegration):
         self, configuration: list[dict[str, Any]]
     ) -> list[dict[str, Any]]:
         """
-        Pre-load statuses only for already-configured projects and provide a
-        statusUrl so the frontend can lazy-load statuses for newly-added projects.
+        Pre-load statuses only for already-configured projects.
         """
         client = self.get_client()
 

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -186,7 +186,10 @@ class JiraIntegration(IssueSyncIntegration):
                     JiraProjectMapping(value=p["id"], label=p["name"])
                     for p in client.get_projects_list()
                 ]
-            self._set_status_choices_in_organization_config(configuration, projects)
+            if features.has("organizations:jira-lazy-status-sync", self.organization):
+                self._set_lazy_status_choices_in_organization_config(configuration)
+            else:
+                self._set_status_choices_in_organization_config(configuration, projects)
             configuration[0]["addDropdown"]["items"] = projects
         except ApiError:
             configuration[0]["disabled"] = True
@@ -260,6 +263,39 @@ class JiraIntegration(IssueSyncIntegration):
             "on_resolve": {"choices": statuses},
             "on_unresolve": {"choices": statuses},
         }
+
+        return configuration
+
+    def _set_lazy_status_choices_in_organization_config(
+        self, configuration: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        """
+        Pre-load statuses only for already-configured projects and provide a
+        statusUrl so the frontend can lazy-load statuses for newly-added projects.
+        """
+        client = self.get_client()
+
+        configured_projects = IntegrationExternalProject.objects.filter(
+            organization_integration_id=self.org_integration.id
+        )
+        for project in configured_projects:
+            try:
+                project_statuses = client.get_project_statuses(project.external_id).get(
+                    "values", []
+                )
+            except ApiError:
+                continue
+            statuses = [(c["id"], c["name"]) for c in project_statuses]
+            configuration[0]["mappedSelectors"][project.external_id] = {
+                "on_resolve": {"choices": statuses},
+                "on_unresolve": {"choices": statuses},
+            }
+
+        configuration[0]["perItemMapping"] = True
+        configuration[0]["statusUrl"] = reverse(
+            "sentry-extensions-jira-search",
+            args=[self.organization.slug, self.model.id],
+        )
 
         return configuration
 

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -27,6 +27,7 @@ from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.factories import EventType
 from sentry.testutils.helpers.datetime import before_now
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode, assume_test_silo_mode_of, control_silo_test
 from sentry.testutils.skips import requires_snuba
 from sentry.users.services.user.serial import serialize_rpc_user
@@ -1460,8 +1461,11 @@ class JiraIntegrationTest(APITestCase):
         assert config[0]["disabled"] is True
         assert "Unable to communicate" in config[0]["disabledReason"]
 
-    @responses.activate
-    def test_get_organization_config_lazy_status_with_configured_projects(self) -> None:
+    def _setup_jira_with_status_responses(
+        self,
+        projects: list[dict[str, str]] | None = None,
+        statuses: list[dict[str, str]] | None = None,
+    ) -> tuple[Integration, Any]:
         integration = self.create_provider_integration(
             provider="jira",
             name="Example Jira",
@@ -1474,6 +1478,37 @@ class JiraIntegrationTest(APITestCase):
         )
         integration.add_organization(self.organization, self.user)
         installation = integration.get_installation(self.organization.id)
+
+        if projects is None:
+            projects = [{"id": "10000", "name": "Project A"}]
+        responses.add(
+            responses.GET,
+            "https://example.atlassian.net/rest/api/2/project",
+            json=projects,
+        )
+
+        if statuses is not None:
+            responses.add(
+                responses.GET,
+                "https://example.atlassian.net/rest/api/2/statuses/search",
+                json={"values": statuses},
+            )
+
+        return integration, installation
+
+    @responses.activate
+    @with_feature("organizations:jira-lazy-status-sync")
+    def test_get_organization_config_lazy_status_with_configured_projects(self) -> None:
+        integration, installation = self._setup_jira_with_status_responses(
+            projects=[
+                {"id": "10000", "name": "Project A"},
+                {"id": "10001", "name": "Project B"},
+            ],
+            statuses=[
+                {"id": "1", "name": "Open"},
+                {"id": "6", "name": "Closed"},
+            ],
+        )
 
         org_integration = OrganizationIntegration.objects.get(
             organization_id=self.organization.id, integration=integration
@@ -1486,24 +1521,7 @@ class JiraIntegrationTest(APITestCase):
             unresolved_status="1",
         )
 
-        responses.add(
-            responses.GET,
-            "https://example.atlassian.net/rest/api/2/project",
-            json=[{"id": "10000", "name": "Project A"}, {"id": "10001", "name": "Project B"}],
-        )
-        responses.add(
-            responses.GET,
-            "https://example.atlassian.net/rest/api/2/statuses/search",
-            json={
-                "values": [
-                    {"id": "1", "name": "Open"},
-                    {"id": "6", "name": "Closed"},
-                ],
-            },
-        )
-
-        with self.feature("organizations:jira-lazy-status-sync"):
-            config = installation.get_organization_config()
+        config = installation.get_organization_config()
 
         assert config[0]["perItemMapping"] is True
         assert "statusUrl" in config[0]
@@ -1514,28 +1532,11 @@ class JiraIntegrationTest(APITestCase):
         assert "10001" not in config[0]["mappedSelectors"]
 
     @responses.activate
+    @with_feature("organizations:jira-lazy-status-sync")
     def test_get_organization_config_lazy_status_no_configured_projects(self) -> None:
-        integration = self.create_provider_integration(
-            provider="jira",
-            name="Example Jira",
-            metadata={
-                "oauth_client_id": "oauth-client-id",
-                "shared_secret": "a-super-secret-key-from-atlassian",
-                "base_url": "https://example.atlassian.net",
-                "domain_name": "example.atlassian.net",
-            },
-        )
-        integration.add_organization(self.organization, self.user)
-        installation = integration.get_installation(self.organization.id)
+        _integration, installation = self._setup_jira_with_status_responses()
 
-        responses.add(
-            responses.GET,
-            "https://example.atlassian.net/rest/api/2/project",
-            json=[{"id": "10000", "name": "Project A"}],
-        )
-
-        with self.feature("organizations:jira-lazy-status-sync"):
-            config = installation.get_organization_config()
+        config = installation.get_organization_config()
 
         assert config[0]["perItemMapping"] is True
         assert "statusUrl" in config[0]
@@ -1543,33 +1544,11 @@ class JiraIntegrationTest(APITestCase):
 
     @responses.activate
     def test_get_organization_config_flag_off_uses_existing_behavior(self) -> None:
-        integration = self.create_provider_integration(
-            provider="jira",
-            name="Example Jira",
-            metadata={
-                "oauth_client_id": "oauth-client-id",
-                "shared_secret": "a-super-secret-key-from-atlassian",
-                "base_url": "https://example.atlassian.net",
-                "domain_name": "example.atlassian.net",
-            },
-        )
-        integration.add_organization(self.organization, self.user)
-        installation = integration.get_installation(self.organization.id)
-
-        responses.add(
-            responses.GET,
-            "https://example.atlassian.net/rest/api/2/project",
-            json=[{"id": "10000", "name": "Project A"}],
-        )
-        responses.add(
-            responses.GET,
-            "https://example.atlassian.net/rest/api/2/statuses/search",
-            json={
-                "values": [
-                    {"id": "1", "name": "Open"},
-                    {"id": "6", "name": "Closed"},
-                ],
-            },
+        _integration, installation = self._setup_jira_with_status_responses(
+            statuses=[
+                {"id": "1", "name": "Open"},
+                {"id": "6", "name": "Closed"},
+            ],
         )
 
         config = installation.get_organization_config()

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -1460,6 +1460,127 @@ class JiraIntegrationTest(APITestCase):
         assert config[0]["disabled"] is True
         assert "Unable to communicate" in config[0]["disabledReason"]
 
+    @responses.activate
+    def test_get_organization_config_lazy_status_with_configured_projects(self) -> None:
+        integration = self.create_provider_integration(
+            provider="jira",
+            name="Example Jira",
+            metadata={
+                "oauth_client_id": "oauth-client-id",
+                "shared_secret": "a-super-secret-key-from-atlassian",
+                "base_url": "https://example.atlassian.net",
+                "domain_name": "example.atlassian.net",
+            },
+        )
+        integration.add_organization(self.organization, self.user)
+        installation = integration.get_installation(self.organization.id)
+
+        org_integration = OrganizationIntegration.objects.get(
+            organization_id=self.organization.id, integration=integration
+        )
+        IntegrationExternalProject.objects.create(
+            organization_integration_id=org_integration.id,
+            external_id="10000",
+            name="Project A",
+            resolved_status="6",
+            unresolved_status="1",
+        )
+
+        responses.add(
+            responses.GET,
+            "https://example.atlassian.net/rest/api/2/project",
+            json=[{"id": "10000", "name": "Project A"}, {"id": "10001", "name": "Project B"}],
+        )
+        responses.add(
+            responses.GET,
+            "https://example.atlassian.net/rest/api/2/statuses/search",
+            json={
+                "values": [
+                    {"id": "1", "name": "Open"},
+                    {"id": "6", "name": "Closed"},
+                ],
+            },
+        )
+
+        with self.feature("organizations:jira-lazy-status-sync"):
+            config = installation.get_organization_config()
+
+        assert config[0]["perItemMapping"] is True
+        assert "statusUrl" in config[0]
+        assert config[0]["mappedSelectors"]["10000"] == {
+            "on_resolve": {"choices": [("1", "Open"), ("6", "Closed")]},
+            "on_unresolve": {"choices": [("1", "Open"), ("6", "Closed")]},
+        }
+        assert "10001" not in config[0]["mappedSelectors"]
+
+    @responses.activate
+    def test_get_organization_config_lazy_status_no_configured_projects(self) -> None:
+        integration = self.create_provider_integration(
+            provider="jira",
+            name="Example Jira",
+            metadata={
+                "oauth_client_id": "oauth-client-id",
+                "shared_secret": "a-super-secret-key-from-atlassian",
+                "base_url": "https://example.atlassian.net",
+                "domain_name": "example.atlassian.net",
+            },
+        )
+        integration.add_organization(self.organization, self.user)
+        installation = integration.get_installation(self.organization.id)
+
+        responses.add(
+            responses.GET,
+            "https://example.atlassian.net/rest/api/2/project",
+            json=[{"id": "10000", "name": "Project A"}],
+        )
+
+        with self.feature("organizations:jira-lazy-status-sync"):
+            config = installation.get_organization_config()
+
+        assert config[0]["perItemMapping"] is True
+        assert "statusUrl" in config[0]
+        assert config[0]["mappedSelectors"] == {}
+
+    @responses.activate
+    def test_get_organization_config_flag_off_uses_existing_behavior(self) -> None:
+        integration = self.create_provider_integration(
+            provider="jira",
+            name="Example Jira",
+            metadata={
+                "oauth_client_id": "oauth-client-id",
+                "shared_secret": "a-super-secret-key-from-atlassian",
+                "base_url": "https://example.atlassian.net",
+                "domain_name": "example.atlassian.net",
+            },
+        )
+        integration.add_organization(self.organization, self.user)
+        installation = integration.get_installation(self.organization.id)
+
+        responses.add(
+            responses.GET,
+            "https://example.atlassian.net/rest/api/2/project",
+            json=[{"id": "10000", "name": "Project A"}],
+        )
+        responses.add(
+            responses.GET,
+            "https://example.atlassian.net/rest/api/2/statuses/search",
+            json={
+                "values": [
+                    {"id": "1", "name": "Open"},
+                    {"id": "6", "name": "Closed"},
+                ],
+            },
+        )
+
+        config = installation.get_organization_config()
+
+        assert config[0]["perItemMapping"] is True
+        assert "statusUrl" not in config[0]
+        assert config[0]["mappedSelectors"]["10000"] == {
+            "on_resolve": {"choices": [("1", "Open"), ("6", "Closed")]},
+            "on_unresolve": {"choices": [("1", "Open"), ("6", "Closed")]},
+        }
+
     def test_error_fields_from_json_issue_not_found(self) -> None:
         integration = self.create_provider_integration(provider="jira", name="Example Jira")
         integration.add_organization(self.organization, self.user)


### PR DESCRIPTION
Instead of fetching and loading all of the project status mappings. Load only the ones that are currently configured. We will dynamically fetch other project statuses when they are added (see PR 1 of stack)

Step 2 of lazy loading Jira project statuses