### PR TITLE
fix(seer): allow bot-authored PR reviews and comments to drive Autofix iterations

### DIFF
--- a/src/sentry/seer/autofix/pr_iteration/feedback_sources/github_comment.py
+++ b/src/sentry/seer/autofix/pr_iteration/feedback_sources/github_comment.py
@@ -119,6 +119,13 @@ class GithubPrCommentFeedbackSource(_GithubPrCommentFeedbackSourceBase):
     repo_name: str | None = None
     require_command: ClassVar[bool] = True
     type: Literal["github-pr-comment"] = "github-pr-comment"
+    # Whether the comment author is a bot. Bot comments count toward the
+    # automated-iteration streak cap; human comments reset it.
+    author_is_bot: bool = False
+
+    @property
+    def is_automated(self) -> bool:
+        return self.author_is_bot
 
 
 class GithubPrReviewCommentFeedbackSource(_GithubPrCommentFeedbackSourceBase):

--- a/src/sentry/seer/autofix/pr_iteration/mention.py
+++ b/src/sentry/seer/autofix/pr_iteration/mention.py
@@ -23,6 +23,7 @@ from typing import Any, NamedTuple
 from pydantic import ValidationError
 
 from sentry import features
+from sentry.integrations.github.utils import is_github_bot_login
 from sentry.integrations.services.integration import RpcIntegration
 from sentry.models.organization import Organization
 from sentry.models.repository import Repository
@@ -72,9 +73,14 @@ def _dispatch_autofix_iteration_from_comment(
     integration: RpcIntegration | None,
     log_extra: Mapping[str, Any],
 ) -> None:
+    user = comment.get("user") or {}
+    author_is_bot = user.get("type") == "Bot" or is_github_bot_login(user.get("login"))
+
     try:
         feedback = Feedback(
-            source=GithubPrCommentFeedbackSource(comment=comment, repo_name=repo.name)
+            source=GithubPrCommentFeedbackSource(
+                comment=comment, repo_name=repo.name, author_is_bot=author_is_bot
+            )
         )
     except ValidationError:
         logger.debug("autofix.pr_iteration.comment_trigger.skipped_not_command", extra=log_extra)
@@ -107,6 +113,7 @@ def _dispatch_autofix_iteration_from_comment(
         integration_id=integration.id,
         pr_number=pr_number,
         feedback=feedback.json(),
+        author_is_bot=author_is_bot,
     )
     return None
 

--- a/src/sentry/tasks/seer/pr_iteration.py
+++ b/src/sentry/tasks/seer/pr_iteration.py
@@ -448,6 +448,7 @@ def trigger_pr_iteration_from_comment(
     integration_id: int,
     pr_number: int,
     feedback: str,
+    author_is_bot: bool = False,
 ) -> None:
     """
     Resolve the Autofix run behind ``pr_number`` and kick off a PR iteration.
@@ -552,6 +553,19 @@ def trigger_pr_iteration_from_comment(
         )
         return None
 
+    # Cap bot-driven iterations so repeated @sentry pings can't loop without human
+    # input; a human comment always proceeds and resets the streak.
+    if author_is_bot and automated_iteration_cap_reached(agent_state):
+        metrics.incr("autofix.pr_iteration.comment_trigger.max_iterations_reached")
+        logger.info(
+            "autofix.pr_iteration.comment_trigger.max_iterations_reached",
+            extra={
+                "organization_id": organization_id,
+                "max_iterations": options.get("autofix.pr-iteration.max-iterations"),
+            },
+        )
+        return None
+
     try:
         scm = make_scm(organization_id, repo_id, referrer="seer")
     except Exception:
@@ -562,7 +576,7 @@ def trigger_pr_iteration_from_comment(
         )
         return None
 
-    if not _github_commenter_has_repo_write_access(scm, github_username):
+    if not author_is_bot and not _github_commenter_has_repo_write_access(scm, github_username):
         metrics.incr("autofix.pr_iteration.comment_trigger.unauthorized")
         logger.info(
             "autofix.pr_iteration.comment_trigger.unauthorized",
@@ -796,11 +810,8 @@ def trigger_pr_iteration_from_review(
         )
         return None
 
-    # Only bot reviews are capped: once the last N iterations were all automated,
-    # stop letting bots (test-coverage comments and the like) drive further ones —
-    # they'd loop forever without human input. A human review always proceeds and
-    # resets that streak. Bail before enqueueing or acking so we don't :eyes:-ack
-    # inline comments that never produce an iteration.
+    # Cap bot-driven iterations so automated reviews can't loop without human
+    # input; a human review always proceeds and resets the streak.
     if author_is_bot and automated_iteration_cap_reached(agent_state):
         metrics.incr("autofix.pr_iteration.review_trigger.max_iterations_reached")
         logger.info(
@@ -826,10 +837,9 @@ def trigger_pr_iteration_from_review(
         logger.warning("autofix.pr_iteration.review_trigger.unsupported_provider", extra=log_extra)
         return None
 
-    # Gate on repo write access before fetching, enqueueing, or acking: a review
-    # from someone without write/admin is silently dropped so an untrusted
-    # reviewer can't spend Autofix quota or inject feedback that rewrites the PR.
-    if not author_username or not _github_commenter_has_repo_write_access(scm, author_username):
+    if not author_is_bot and (
+        not author_username or not _github_commenter_has_repo_write_access(scm, author_username)
+    ):
         metrics.incr("autofix.pr_iteration.review_trigger.no_write_access")
         logger.info("autofix.pr_iteration.review_trigger.no_write_access", extra=log_extra)
         return None

--- a/tests/sentry/seer/autofix/test_pr_iteration_review.py
+++ b/tests/sentry/seer/autofix/test_pr_iteration_review.py
@@ -484,6 +484,9 @@ class TriggerPrIterationFromReviewTest(TestCase):
         self.mock_enqueue.assert_not_called()
         self.mock_consume.assert_not_called()
         self.mock_actions.create_review_comment_reaction.assert_not_called()
+        # The cap runs before make_scm and the write-access gate, so the
+        # collaborator check is never consulted.
+        self.mock_actions.get_repository_user_permission.assert_not_called()
 
     def test_human_review_proceeds_when_automated_streak_capped(self) -> None:
         # The streak cap only bounds automated (bot) reviews; a human review always
@@ -523,3 +526,20 @@ class TriggerPrIterationFromReviewTest(TestCase):
         self.mock_actions.get_repository_user_permission.assert_not_called()
         self.mock_enqueue.assert_not_called()
         self.mock_consume.assert_not_called()
+
+    def test_bot_review_proceeds_without_repo_write_access(self) -> None:
+        # A bot can only post a review once its App is installed on the repo with
+        # write access, so the per-user collaborator check is skipped for bots and
+        # the review drives an iteration even when the login has no write access.
+        self.mock_actions.get_repository_user_permission.return_value = {"data": {"perms": "none"}}
+        self.mock_actions.get_review_comments.return_value = self._paginated(
+            [self._review_comment(comment_id="1", body="add a test")]
+        )
+
+        self._run(author_is_bot=True)
+
+        self.mock_actions.get_repository_user_permission.assert_not_called()
+        self.mock_enqueue.assert_called()
+        self.mock_consume.assert_called_once()
+        self.mock_actions.create_review_comment_reaction.assert_called_once()
+        assert self.mock_actions.create_review_comment_reaction.call_args.args[3] == "eyes"

--- a/tests/sentry/tasks/seer/test_pr_iteration.py
+++ b/tests/sentry/tasks/seer/test_pr_iteration.py
@@ -78,13 +78,14 @@ class TriggerPrIterationFromCommentTest(TestCase):
         mock_integration.get_installation.return_value.get_client.return_value = mock_client
         return mock_integration
 
-    def _call(self) -> None:
+    def _call(self, *, author_is_bot: bool = False) -> None:
         trigger_pr_iteration_from_comment(
             organization_id=self.organization.id,
             repo_id=self.repo.id,
             integration_id=42,
             pr_number=7,
             feedback=self.feedback.json(),
+            author_is_bot=author_is_bot,
         )
 
     @patch(f"{TASK_PATH}._add_comment_reaction")
@@ -363,6 +364,77 @@ class TriggerPrIterationFromCommentTest(TestCase):
         mock_enqueue.assert_called_once()
         mock_trigger_consume.assert_called_once()
         mock_reaction.assert_called_once()
+
+    @patch(f"{TASK_PATH}._add_comment_reaction")
+    @patch(f"{TASK_PATH}.make_scm")
+    @patch(f"{TASK_PATH}._github_commenter_has_repo_write_access", return_value=False)
+    @patch(f"{TASK_PATH}.trigger_consume_pr_iteration_feedback")
+    @patch(f"{TASK_PATH}.try_enqueue_autofix_feedback", return_value=True)
+    @patch(f"{TASK_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{TASK_PATH}.integration_service.get_integration")
+    def test_bot_comment_proceeds_without_write_access(
+        self,
+        mock_get_integration: MagicMock,
+        mock_get_state: MagicMock,
+        mock_enqueue: MagicMock,
+        mock_trigger_consume: MagicMock,
+        mock_has_access: MagicMock,
+        mock_make_scm: MagicMock,
+        mock_reaction: MagicMock,
+    ) -> None:
+        # A bot can only post a comment once its App is installed on the repo with
+        # write access, so the per-user collaborator check is skipped for bots and
+        # the comment drives an iteration even though the helper would return False.
+        mock_get_integration.return_value = self._mock_integration()
+        mock_get_state.return_value = self._agent_state()
+
+        self._call(author_is_bot=True)
+
+        mock_has_access.assert_not_called()
+        mock_enqueue.assert_called_once()
+        mock_trigger_consume.assert_called_once()
+        mock_reaction.assert_called_once_with(
+            mock_make_scm.return_value,
+            source_type="github-pr-comment",
+            pr_number=7,
+            comment_id=999,
+            reaction="eyes",
+        )
+
+    @patch(f"{TASK_PATH}._add_comment_reaction")
+    @patch(f"{TASK_PATH}.make_scm")
+    @patch(f"{TASK_PATH}._github_commenter_has_repo_write_access", return_value=True)
+    @patch(f"{TASK_PATH}.trigger_consume_pr_iteration_feedback")
+    @patch(f"{TASK_PATH}.try_enqueue_autofix_feedback", return_value=True)
+    @patch(f"{TASK_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{TASK_PATH}.integration_service.get_integration")
+    def test_skips_bot_comment_when_automated_streak_capped(
+        self,
+        mock_get_integration: MagicMock,
+        mock_get_state: MagicMock,
+        mock_enqueue: MagicMock,
+        mock_trigger_consume: MagicMock,
+        mock_has_access: MagicMock,
+        mock_make_scm: MagicMock,
+        mock_reaction: MagicMock,
+    ) -> None:
+        # A bot comment past the automated-iteration streak cap is dropped by the
+        # cap, which runs before make_scm and the write-access gate — so the
+        # collaborator check is never consulted. (Iterations with no human feedback
+        # count as automated, so two trip a cap of 2.)
+        mock_get_integration.return_value = self._mock_integration()
+        mock_get_state.return_value = self._agent_state(
+            blocks=[self._iteration_block(1), self._iteration_block(2)]
+        )
+
+        with self.options({"autofix.pr-iteration.max-iterations": 2}):
+            self._call(author_is_bot=True)
+
+        mock_make_scm.assert_not_called()
+        mock_has_access.assert_not_called()
+        mock_enqueue.assert_not_called()
+        mock_trigger_consume.assert_not_called()
+        mock_reaction.assert_not_called()
 
 
 class ConsumeQueuedAutofixFeedbackTest(TestCase):


### PR DESCRIPTION
Allow bot-authored PR reviews and `@sentry` comments to drive Autofix PR iterations, while holding bots to the same repo-write bar as humans.

Bots were dropped at the per-user collaborator write-access gate, which a GitHub App's `[bot]` account can never pass — GitHub's collaborator API always reports `none` for a bot, since Apps use installation permissions, not collaborator status. Instead of bypassing the check, bots are now authorized via their App installation's write access (`contents` + `pull_requests` write), matching the human "can push" bar. A review-only bot (only `pull_requests: write`) is still gated. Humans are unchanged, the installation check fails closed on any error, and the automated-iteration cap remains the loop guard on both paths.

Fixes CW-1718.
