### PR TITLE
ref(pr-metrics): Drop attribution confidence ordering and unused signal type

### DIFF
--- a/src/sentry/analytics/events/pr_metrics_events.py
+++ b/src/sentry/analytics/events/pr_metrics_events.py
@@ -99,7 +99,9 @@ class PrCloseMetricsEvent(analytics.Event):
     opened_and_closed_by_same_actor: bool | None = None
     # The point-in-time attribution snapshot at emit time: a JSON-encoded list of
     # the active (is_valid=True) attributions, each {signal_type, source,
-    # signal_details}, ordered by attribution priority (highest-confidence first).
+    # signal_details}. A PR can carry more than one; all are emitted equally, with
+    # no ranking between them — each is a definite attribution, not a probabilistic
+    # guess. List order carries no meaning and isn't guaranteed; don't rely on it.
     attributions: str = "[]"
     # Distinct ``AutofixReferrer`` values (e.g. "slack", "night_shift") behind the
     # Seer runs that produced this PR's attributions, resolved via ``SeerRun`` at

--- a/src/sentry/models/pullrequest.py
+++ b/src/sentry/models/pullrequest.py
@@ -46,7 +46,6 @@ class PullRequestAttributionSignalType(models.TextChoices):
     SEER_DELEGATED_CLAUDE_CODE = "seer_delegated:claude_code"
     SEER_DELEGATED_UNKNOWN = "seer_delegated:unknown"
     MCP = "mcp"
-    UNKNOWN = "unknown"
 
 
 class PullRequestAttributionSource(models.TextChoices):

--- a/src/sentry/pr_metrics/attribution.py
+++ b/src/sentry/pr_metrics/attribution.py
@@ -30,19 +30,6 @@ from sentry.models.pullrequest import (
 
 logger = logging.getLogger(__name__)
 
-# Precedence for picking a PR's primary attribution when more than one valid
-# signal is present (highest first): direct agent-authored signals rank above
-# weaker heuristics like a bare issue reference.
-SIGNAL_TYPE_CONFIDENCE: dict[str, int] = {
-    PullRequestAttributionSignalType.SENTRY_APP: 100,
-    PullRequestAttributionSignalType.SEER_DELEGATED_CURSOR: 80,
-    PullRequestAttributionSignalType.SEER_DELEGATED_GITHUB_COPILOT: 80,
-    PullRequestAttributionSignalType.SEER_DELEGATED_CLAUDE_CODE: 80,
-    PullRequestAttributionSignalType.SEER_DELEGATED_UNKNOWN: 70,
-    PullRequestAttributionSignalType.MCP: 50,
-    PullRequestAttributionSignalType.UNKNOWN: 0,
-}
-
 
 class SentryAppSignalDetails(BaseModel):
     """Typed signal_details for SENTRY_APP attribution signals.
@@ -164,23 +151,6 @@ def record_attribution_signal(
             attribution.save(update_fields=["signal_details", "is_valid", "date_updated"])
 
         return attribution
-
-
-def recompute_pull_request_attribution(pull_request: PullRequest) -> str | None:
-    """Return the highest-confidence valid attribution signal for a PR.
-
-    Returns the winning ``signal_type``, or ``None`` when the PR has no valid
-    signals.
-    """
-    valid_signal_types = PullRequestAttribution.objects.filter(
-        pull_request=pull_request, is_valid=True
-    ).values_list("signal_type", flat=True)
-
-    return max(
-        valid_signal_types,
-        key=lambda signal_type: SIGNAL_TYPE_CONFIDENCE.get(signal_type, -1),
-        default=None,
-    )
 
 
 def _log_unresolved_reported_pull_request(

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -29,7 +29,6 @@ from sentry.models.pullrequest import (
 )
 from sentry.models.repository import Repository
 from sentry.pr_metrics import activity_doc
-from sentry.pr_metrics.attribution import SIGNAL_TYPE_CONFIDENCE
 from sentry.pr_metrics.contracts import (
     CLOSE_ACTION_CLOSED,
     CLOSE_ACTION_MERGED,
@@ -323,19 +322,18 @@ def is_pr_tracked(pull_request: PullRequest) -> bool:
 
 
 def active_attributions(pull_request: PullRequest) -> list[dict[str, Any]]:
-    """The PR's valid attribution signals, highest-confidence first.
+    """The PR's valid attribution signals — all of them, unranked.
 
     Each entry carries the ``signal_type``, ``source``, and ``signal_details`` so
-    the consumer sees the full picture, ordered by attribution priority so the
-    primary attribution leads. Ties break on ``signal_type`` then ``source`` for
-    a deterministic order. Shared by emission and the Seer judge forward so both
-    hand the consumer the same ordered snapshot.
+    the consumer sees the full picture. A PR can carry more than one valid signal
+    and every one is emitted equally — each is a definite attribution, so no
+    signal outranks another and the list order carries no meaning. Shared by
+    emission and the Seer judge forward so both hand the consumer the same set.
     """
     attributions = PullRequestAttribution.objects.filter(pull_request=pull_request, is_valid=True)
-    ordered = sorted(
-        attributions,
-        key=lambda a: (-SIGNAL_TYPE_CONFIDENCE.get(a.signal_type, -1), a.signal_type, a.source),
-    )
+    # Sorted only so the emitted list is reproducible run-to-run; the order isn't
+    # a contract (see above) and consumers must not read significance into it.
+    ordered = sorted(attributions, key=lambda a: (a.signal_type, a.source))
     return [
         {"signal_type": a.signal_type, "source": a.source, "signal_details": a.signal_details}
         for a in ordered

--- a/tests/sentry/pr_metrics/test_attribution.py
+++ b/tests/sentry/pr_metrics/test_attribution.py
@@ -11,7 +11,6 @@ from sentry.models.pullrequest import (
 from sentry.pr_metrics.attribution import (
     attribute_delegated_agent_pull_request,
     attribute_seer_created_pull_requests,
-    recompute_pull_request_attribution,
     record_attribution_signal,
 )
 from sentry.testutils.cases import TestCase
@@ -454,42 +453,3 @@ class RecordAttributionSignalTest(TestCase):
         second.refresh_from_db()
         assert second.signal_details == {"run_id": 9, "group_ids": [3], "pr_url": "https://x/2"}
         assert second.is_valid is True
-
-
-class RecomputePullRequestAttributionTest(TestCase):
-    def setUp(self) -> None:
-        self.repo = self.create_repo(self.project, name=REPO_NAME)
-        self.pull_request = self.create_pull_request(
-            organization_id=self.organization.id,
-            repository_id=self.repo.id,
-            key="42",
-        )
-
-    def _add(self, signal_type: str, is_valid: bool = True) -> None:
-        PullRequestAttribution.objects.create(
-            pull_request=self.pull_request,
-            signal_type=signal_type,
-            source=PullRequestAttributionSource.WEBHOOK_DATA,
-            is_valid=is_valid,
-        )
-
-    def test_returns_none_without_signals(self) -> None:
-        assert recompute_pull_request_attribution(self.pull_request) is None
-
-    def test_picks_highest_confidence_signal(self) -> None:
-        self._add(PullRequestAttributionSignalType.SENTRY_APP)
-        self._add(PullRequestAttributionSignalType.MCP)
-
-        assert (
-            recompute_pull_request_attribution(self.pull_request)
-            == PullRequestAttributionSignalType.SENTRY_APP
-        )
-
-    def test_ignores_invalid_signals(self) -> None:
-        self._add(PullRequestAttributionSignalType.SENTRY_APP, is_valid=False)
-        self._add(PullRequestAttributionSignalType.MCP)
-
-        assert (
-            recompute_pull_request_attribution(self.pull_request)
-            == PullRequestAttributionSignalType.MCP
-        )

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -665,22 +665,23 @@ class PrMetricsEmissionTest(TestCase):
         )
         assert active_attributions(self.pull_request) == [SENTRY_APP_ATTRIBUTION]
 
-    def test_active_attributions_ordered_by_priority_with_source_and_details(self) -> None:
-        # Lower-confidence signal recorded first, but ordered second.
+    def test_active_attributions_returns_all_valid_signals(self) -> None:
+        # A PR can carry more than one valid signal; all are returned, unranked.
+        # Order carries no meaning, so this asserts membership, not position.
+        self._track(PullRequestAttributionSignalType.SENTRY_APP)
         self._track(
             PullRequestAttributionSignalType.SEER_DELEGATED_CLAUDE_CODE,
             source=PullRequestAttributionSource.WEBHOOK_DATA,
             signal_details={"group_ids": [7]},
         )
-        self._track(PullRequestAttributionSignalType.SENTRY_APP)
-        assert active_attributions(self.pull_request) == [
-            SENTRY_APP_ATTRIBUTION,
-            {
-                "signal_type": "seer_delegated:claude_code",
-                "source": "webhook_data",
-                "signal_details": {"group_ids": [7]},
-            },
-        ]
+        result = active_attributions(self.pull_request)
+        assert len(result) == 2
+        assert SENTRY_APP_ATTRIBUTION in result
+        assert {
+            "signal_type": "seer_delegated:claude_code",
+            "source": "webhook_data",
+            "signal_details": {"group_ids": [7]},
+        } in result
 
     def test_resolve_autofix_referrers_empty_without_run_id(self) -> None:
         assert resolve_autofix_referrers(self.pull_request, [SENTRY_APP_ATTRIBUTION]) == []


### PR DESCRIPTION
## Summary

PR-metrics records every attribution signal a PR accrues and emits the whole set — on the analytics row and in the Seer judge request. Nothing downstream consumes a "primary" attribution, so the `SIGNAL_TYPE_CONFIDENCE` ranking only implied a significance the data never carried. Each recorded signal is a definite attribution, not a probabilistic score, so there is nothing to rank.

## Changes

- Remove `SIGNAL_TYPE_CONFIDENCE` and the confidence-based ordering in `active_attributions`; the emitted attribution list is now unranked. It's still sorted by `(signal_type, source)` solely for reproducible output, and the docstrings / analytics-field comment now state the order isn't significant and must not be relied upon.
- Delete the dead `recompute_pull_request_attribution` helper (was only referenced by tests).
- Remove the unused bare `UNKNOWN` attribution signal type. `SEER_DELEGATED_UNKNOWN` is **kept** — Seer can still return it via the delegated-agent match and judge callback, and it drives judge-eligibility.

## Notes

- No migration required: Sentry omits `choices` from migration state, so removing the enum member doesn't alter the recorded schema (`makemigrations` reports no changes).
- Backend-only. The `attributions` payload content is unchanged — only its (previously unused) ordering guarantee is dropped.

closes CW-1725