### PR TITLE
fix(preprod): link snapshot PR comments to /snapshots/ settings route

### DIFF
--- a/src/sentry/preprod/vcs/pr_comments/snapshot_templates.py
+++ b/src/sentry/preprod/vcs/pr_comments/snapshot_templates.py
@@ -170,7 +170,7 @@ def _selected_types_query(comparison: PreprodSnapshotComparison) -> str:
 
 def _format_settings_link(project: Project) -> str:
     settings_url = project.organization.absolute_url(
-        f"/settings/projects/{project.slug}/mobile-builds/", query="tab=snapshots"
+        f"/settings/projects/{project.slug}/snapshots/"
     )
     return f"[⚙️ {project.name} Snapshot Settings]({settings_url})"
 

--- a/tests/sentry/preprod/vcs/pr_comments/test_snapshot_templates.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_snapshot_templates.py
@@ -441,8 +441,7 @@ class FormatSnapshotPrCommentSuccessTest(SnapshotPrCommentTestBase):
             [artifact], {artifact.id: metrics}, {}, {}, {}, project=self.project
         )
 
-        assert f"/settings/projects/{self.project.slug}/mobile-builds/" in result
-        assert "tab=snapshots" in result
+        assert f"/settings/projects/{self.project.slug}/snapshots/" in result
         assert f"{self.project.name} Snapshot Settings" in result
 
 
@@ -516,8 +515,7 @@ class FormatSoloPrCommentTest(SnapshotPrCommentTestBase):
         assert "My App" in result
         assert "Snapshot diffs will appear when we have a base upload to compare against" in result
         assert "main branch" in result
-        assert f"/settings/projects/{self.project.slug}/mobile-builds/" in result
-        assert "tab=snapshots" in result
+        assert f"/settings/projects/{self.project.slug}/snapshots/" in result
         assert f"{self.project.name} Snapshot Settings" in result
 
     def test_solo_empty_artifacts_raises(self) -> None:
@@ -554,7 +552,7 @@ class FormatSoloPrCommentTest(SnapshotPrCommentTestBase):
         assert "4 uploaded" in result
         assert "Waiting for base snapshots to finish uploading" in result
         assert "~10 minutes" in result
-        assert f"/settings/projects/{self.project.slug}/mobile-builds/" in result
+        assert f"/settings/projects/{self.project.slug}/snapshots/" in result
 
     def test_waiting_for_base_empty_artifacts_raises(self) -> None:
         with pytest.raises(ValueError, match="Cannot format PR comment for empty artifact list"):
@@ -571,7 +569,7 @@ class FormatSoloPrCommentTest(SnapshotPrCommentTestBase):
         assert "2 uploaded" in result
         assert "No base snapshots found to compare against" in result
         assert "main branch" in result
-        assert f"/settings/projects/{self.project.slug}/mobile-builds/" in result
+        assert f"/settings/projects/{self.project.slug}/snapshots/" in result
 
     def test_missing_base_empty_artifacts_raises(self) -> None:
         with pytest.raises(ValueError, match="Cannot format PR comment for empty artifact list"):


### PR DESCRIPTION
The Snapshot Settings footer link on snapshot GitHub PR comments pointed at the
deprecated mobile-builds settings tab (`/settings/projects/<project>/mobile-builds/?tab=snapshots`)
instead of the dedicated snapshots settings page (`/settings/projects/<project>/snapshots/`).
This updates the single `_format_settings_link` helper, which feeds both the comparison
comment and all three solo-comment variants, so every snapshot PR comment now lands on
the right page — matching the status-check templates and the frontend project settings nav.

Fixes GH-120483
