### PR TITLE
fix(perforce): downgrade connection-timeout log from exception to warning

### DIFF
--- a/src/sentry/integrations/perforce/integration.py
+++ b/src/sentry/integrations/perforce/integration.py
@@ -802,7 +802,12 @@ class PerforceInstallationApiStep:
                 f"Failed to connect to Perforce server: {e}. Please verify your server address and SSL fingerprint."
             )
         except Exception as e:
-            logger.exception(
+            # Network timeouts and similar transient errors are expected when
+            # users enter an unreachable server address.  The error is already
+            # surfaced to the user via the PipelineStepResult below, so logging
+            # at WARNING avoids generating a noisy Sentry error event for a
+            # routine user-facing failure.
+            logger.warning(
                 "perforce.setup.connection-verification-failed",
                 extra={
                     "p4port": validated_data.get("p4port"),

--- a/tests/sentry/integrations/perforce/test_integration.py
+++ b/tests/sentry/integrations/perforce/test_integration.py
@@ -1090,6 +1090,48 @@ class PerforceApiPipelineTest(APITestCase):
         assert "Failed to connect" in resp.data["data"]["detail"]
 
     @responses.activate
+    @patch(
+        "sentry.integrations.perforce.integration.PerforceClient.get_depots",
+        side_effect=TimeoutError("timed out"),
+    )
+    def test_timeout_returns_error_and_logs_warning(self, mock_get_depots) -> None:
+        """
+        A network timeout is an expected user-facing failure (bad server address,
+        unreachable host).  handle_post() must return an error response without
+        raising a Sentry error event — i.e. it must log at WARNING, not exception.
+        """
+        pipeline = self._init_pipeline_in_session()
+        pipeline.set_api_mode()
+        url = self._get_pipeline_url()
+
+        with self.assertLogs(
+            "sentry.integrations.perforce.integration", level="WARNING"
+        ) as log_ctx:
+            resp = self.client.post(
+                url,
+                data={
+                    "p4port": "ssl:unreachable.example.com:1666",
+                    "user": "user",
+                    "authType": "password",
+                    "password": "pass",
+                    "sslFingerprint": "AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01",
+                },
+                format="json",
+            )
+
+        assert resp.status_code == 400
+        assert "Unexpected error" in resp.data["data"]["detail"]
+
+        # Must be a WARNING record, not ERROR/CRITICAL (which would trigger a
+        # Sentry event via the logging SDK integration).
+        assert any(
+            r.levelname == "WARNING"
+            and "perforce.setup.connection-verification-failed" in r.getMessage()
+            for r in log_ctx.records
+        )
+        assert not any(r.levelname in ("ERROR", "CRITICAL") for r in log_ctx.records)
+
+    @responses.activate
     def test_missing_required_fields(self) -> None:
         pipeline = self._init_pipeline_in_session()
         pipeline.set_api_mode()


### PR DESCRIPTION
## Summary

Fixes noisy Sentry error events generated by expected network timeouts during Perforce integration setup.

- **Sentry issue**: https://sentry.io/organizations/sentry/issues/7608542410/
- **Triage session**: https://claude.ai/code/session_01C39YekYt2d19GvsvqEB1Ex

## Root Cause

In `PerforceInstallationApiStep.handle_post()`, the bare `except Exception` block that catches unexpected errors during connection verification called `logger.exception(...)`. Because `logger.exception()` calls `logger.error()` with `exc_info=True`, Sentry's logging SDK integration captures it as a full error event with a stack trace.

The issue title, `P4Exception: Perforce network read failed: timed out`, is a `TimeoutError` — a completely expected failure when a user enters an unreachable server address or a wrong port. The code already handles the failure gracefully by returning `PipelineStepResult.error(...)` to the user. Sending every such timeout to Sentry as an error creates noise without actionable signal.

## Fix

Changed `logger.exception(...)` to `logger.warning(...)` at the single call site in the `except Exception` block (line ~805 of `src/sentry/integrations/perforce/integration.py`). This keeps a log record for debugging while preventing the Sentry SDK from capturing routine user-caused timeouts as error events.

## What Was Ruled Out

- **Fixing the timeout itself**: Not appropriate. A timeout on an unreachable server is _expected_ behavior — users routinely enter wrong addresses during setup. The correct response is a graceful error to the user, not a retry or a longer timeout.
- **Downgrading other exception branches**: The `except ApiUnauthorized` and `except ApiError` branches do not call `logger.exception()` at all — they silently return an error response. Only the bare `except Exception` fallback was affected.
- **Catching `TimeoutError` specifically**: The `except ApiError` branch already handles Perforce-specific API errors; the bare `except Exception` is a true catch-all fallback. Narrowing it would risk missing other unexpected (non-timeout) exceptions that should still be investigated if they surface in the wild.

## Evidence from the Stack Trace

The captured event shows:
- **Logger**: `sentry.integrations.perforce.integration`
- **Mechanism**: `logging` (handled=True) — captured via Sentry's logging SDK integration, not an unhandled exception
- **Exception**: `P4Exception: Perforce network read failed: timed out`

The `handled=True` mechanism confirms the exception was caught and the user received an error response. The only reason it appeared in Sentry was the `logger.exception()` call.

## Test Coverage

Added `test_timeout_returns_error_and_logs_warning` to the existing `PerforceApiPipelineTest` class. The test:
- Simulates a `TimeoutError` from `get_depots()`
- Asserts the API returns HTTP 400 with an error message
- Asserts the log record is `WARNING` level (not `ERROR`/`CRITICAL`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01C39YekYt2d19GvsvqEB1Ex)_