### PR TITLE
fix(perforce): handle P4Exception in setup connection verification to avoid Sentry noise

### DIFF
--- a/src/sentry/integrations/perforce/integration.py
+++ b/src/sentry/integrations/perforce/integration.py
@@ -30,6 +30,7 @@ from sentry.integrations.perforce.client import (
     PerforceClient,
     validate_p4port_transport,
 )
+from sentry.integrations.perforce.p4protocol import P4Exception
 from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.services.repository import RpcRepository
 from sentry.integrations.source_code_management.commit_context import CommitContextIntegration
@@ -800,6 +801,28 @@ class PerforceInstallationApiStep:
         except ApiError as e:
             return PipelineStepResult.error(
                 f"Failed to connect to Perforce server: {e}. Please verify your server address and SSL fingerprint."
+            )
+        except P4Exception as e:
+            # P4Exception is raised for predictable, user-fixable configuration
+            # errors that are not subclasses of ApiError/ApiUnauthorized.  The
+            # most common case is connecting to a Unicode-mode Perforce server
+            # with charset='none': the server rejects the client with
+            # "Unicode server permits only unicode enabled clients."
+            # Treat these as validation errors — return an actionable message
+            # and avoid the logger.exception() call in the catch-all below,
+            # which would generate unnecessary Sentry noise for a known-good
+            # user mistake.
+            error_msg = str(e).lower()
+            if "unicode server" in error_msg:
+                return PipelineStepResult.error(
+                    f"Failed to connect to Perforce server: {e}. "
+                    "This server requires a Unicode charset — set "
+                    "'Server Encoding' to 'Unicode server (UTF-8)' in the "
+                    "integration configuration."
+                )
+            return PipelineStepResult.error(
+                f"Failed to connect to Perforce server: {e}. "
+                "Please verify your server address and connection settings."
             )
         except Exception as e:
             logger.exception(


### PR DESCRIPTION
## Summary

Fixes Sentry issue [7489705374](https://sentry.io/organizations/sentry/issues/7489705374/).

When a user sets up a Perforce integration against a Unicode-mode server but leaves `charset='none'` (the default), the Perforce server rejects the connection with:

```
P4Exception: Unicode server permits only unicode enabled clients.
```

`P4Exception` is not a subclass of `ApiError` or `ApiUnauthorized`, so it fell through the specific handlers in `PerforceInstallationApiStep.handle_post` into the `except Exception` catch-all, which called `logger.exception()` — generating an ERROR-level Sentry event with a full stack trace for what is a predictable, user-fixable configuration mistake.

### Changes

- Import `P4Exception` from `sentry.integrations.perforce.p4protocol` in `integration.py`.
- Add a dedicated `except P4Exception` handler **before** the `except Exception` catch-all in `PerforceInstallationApiStep.handle_post`.
  - For the Unicode server case (`"unicode server"` in the error message), returns an actionable `PipelineStepResult.error(...)` telling the user to select a Unicode charset in the integration configuration.
  - For all other `P4Exception` cases, returns a generic connection-failure message.
  - Does **not** call `logger.exception()` — these are user-visible config errors, not application bugs.
- The `except Exception` catch-all is left intact for truly unexpected errors.

### Triage reasoning

- **Root cause**: `P4Exception` is a plain `Exception` subclass; it was never subclassing `ApiError`. The specific handlers for `ApiUnauthorized` and `ApiError` correctly cover errors that the `PerforceClient._connect()` context manager translates (it calls `_raise_for_connection_error` which raises `ApiError` for the unicode case when a password is present). However, when `_connect()` yields without running any authenticated command (e.g., no password supplied), the unicode rejection surfaces on the first `p4.run("depots")` call inside `get_depots()`, which is outside `_connect()`'s try/except, leaving `P4Exception` uncaught until the catch-all.
- **Ruled out**: Simply downgrading the log level in the catch-all — that would suppress noise for all unknown exceptions, not just expected user-config errors. Catching it in `client.py`/`get_depots()` was considered but adding a `P4Exception` handler at the call site in `integration.py` is the minimal, targeted fix that keeps error classification close to where the user-facing decision is made.

<!-- Sentry employees and contractors can delete or ignore the following. -->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKcW2sAtLT25Tu42i3gCJK)_