### PR TITLE
feat(seer): Attribute PR iteration starts to users

### DIFF
--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -384,6 +384,7 @@ def trigger_autofix_agent(
     feedback: Sequence[Feedback] | None = None,
     user: User | RpcUser | AnonymousUser | None = None,
     enable_bash_tools: bool = False,
+    actor_user_id: int | None = None,
 ) -> int:
     """
     Start or continue an agent-based autofix run.
@@ -529,6 +530,7 @@ def trigger_autofix_agent(
                     "event_type": sentry_app_event_type,
                     "event_payload": payload,
                     "organization_id": group.organization.id,
+                    "actor_user_id": actor_user_id if is_iteration_step else None,
                 }
             )
     except ValueError:

--- a/src/sentry/seer/autofix/pr_iteration/feedback_sources/github_comment.py
+++ b/src/sentry/seer/autofix/pr_iteration/feedback_sources/github_comment.py
@@ -120,6 +120,14 @@ class GithubPrCommentFeedbackSource(_GithubPrCommentFeedbackSourceBase):
     require_command: ClassVar[bool] = True
     type: Literal["github-pr-comment"] = "github-pr-comment"
 
+    @property
+    def is_automated(self) -> bool:
+        user = self.comment.user
+        if user is None:
+            return False
+        user_type = getattr(user, "type", "")
+        return (user.login or "").lower().endswith("[bot]") or str(user_type).lower() == "bot"
+
 
 class GithubPrReviewCommentFeedbackSource(_GithubPrCommentFeedbackSourceBase):
     """Feedback submitted as an inline GitHub PR review comment (``@sentry <feedback>``).

--- a/src/sentry/seer/autofix/pr_iteration/listeners/review.py
+++ b/src/sentry/seer/autofix/pr_iteration/listeners/review.py
@@ -158,6 +158,7 @@ def handle_pull_request_review_for_autofix_iteration(event: PullRequestReviewEve
             pr_number=pr_number,
             review_id=review_id,
             author_username=event.author.get("username"),
+            author_external_id=author_id,
             author_is_bot=event.is_bot,
         )
         dispatched = True

--- a/src/sentry/seer/autofix/pr_iteration/queue.py
+++ b/src/sentry/seer/autofix/pr_iteration/queue.py
@@ -20,6 +20,7 @@ class QueuedAutofixFeedback(BaseModel):
     group_id: int
     feedback: Feedback
     referrer: AutofixReferrer
+    actor_user_id: int | None = None
 
 
 def _feedback_queue_key(run_id: int) -> str:
@@ -34,6 +35,7 @@ def try_enqueue_autofix_feedback(
     feedback: Feedback,
     referrer: AutofixReferrer,
     run_state: SeerRunState,
+    actor_user_id: int | None = None,
 ) -> bool:
     if not feedback.source.should_queue(run_state):
         logger.info(
@@ -55,6 +57,7 @@ def try_enqueue_autofix_feedback(
             group_id=group_id,
             feedback=feedback,
             referrer=referrer,
+            actor_user_id=actor_user_id,
         ).json(),
     )
     redis.expire(key, _QUEUE_TTL_SECONDS)

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -382,6 +382,7 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                     feedback=feedback,
                     referrer=referrer,
                     run_state=run_state,
+                    actor_user_id=request.user.id,
                 )
 
                 consume_queued_autofix_feedback.apply_async(

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -4,7 +4,11 @@ from typing import Any
 from sentry import features, options
 from sentry.constants import DataCategory
 from sentry.issues.action_log.publish import action_context_scope
-from sentry.issues.action_log.types import SYSTEM_ACTOR, ActionSource
+from sentry.issues.action_log.types import (
+    SYSTEM_ACTOR,
+    ActionSource,
+    GroupActionActor,
+)
 from sentry.models.activity import Activity
 from sentry.models.group import Group
 from sentry.models.organization import Organization
@@ -568,6 +572,7 @@ def _create_seer_activity(
     group: Group,
     event_type: SentryAppEventType,
     event_payload: dict[str, Any],
+    actor_user_id: int | None = None,
 ) -> None:
     activity_type = SEER_EVENT_TO_ACTIVITY_TYPE.get(event_type)
     if not activity_type:
@@ -608,6 +613,7 @@ def _create_seer_activity(
     Activity.objects.create_group_activity(
         group,
         activity_type,
+        user_id=actor_user_id,
         data=activity_data if activity_data else None,
         send_notification=False,
     )
@@ -624,6 +630,7 @@ def process_autofix_updates(
     event_type: SentryAppEventType,
     event_payload: dict[str, Any],
     organization_id: int,
+    actor_user_id: int | None = None,
 ) -> None:
     """
     Use the registry to iterate over all entrypoints and check if this payload's run_id or group_id
@@ -663,9 +670,20 @@ def process_autofix_updates(
             lifecycle.record_halt(halt_reason="no_operator_access")
             return
 
+        activity_actor = SYSTEM_ACTOR
+        activity_user_id = None
+        if event_type == SentryAppEventType.SEER_ITERATION_STARTED and actor_user_id is not None:
+            activity_actor = GroupActionActor.user(actor_user_id)
+            activity_user_id = actor_user_id
+
         try:
-            with action_context_scope(ActionSource.SEER_EXPLORER, SYSTEM_ACTOR):
-                _create_seer_activity(group, event_type, event_payload)
+            with action_context_scope(ActionSource.SEER_EXPLORER, activity_actor):
+                _create_seer_activity(
+                    group,
+                    event_type,
+                    event_payload,
+                    actor_user_id=activity_user_id,
+                )
         except Exception:
             logger.exception(
                 "seer.activity_creation_failed",

--- a/src/sentry/tasks/seer/pr_iteration.py
+++ b/src/sentry/tasks/seer/pr_iteration.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterable
 from datetime import timedelta
 from typing import Any
 
@@ -32,6 +33,7 @@ from taskbroker_client.retry import Retry
 from sentry import options
 from sentry.cache import default_cache
 from sentry.integrations.services.integration import integration_service
+from sentry.integrations.utils.scm_actors import find_user_for_scm_actor
 from sentry.locks import locks
 from sentry.models.group import Group
 from sentry.models.organization import Organization
@@ -57,6 +59,7 @@ from sentry.seer.autofix.pr_iteration.feedback_sources.github_comment import (
     GithubPrReviewCommentFeedbackSource,
     GithubPullRequestReviewComment,
 )
+from sentry.seer.autofix.pr_iteration.feedback_sources.user_ui import UserUIFeedbackSource
 from sentry.seer.autofix.pr_iteration.queue import (
     QueuedAutofixFeedback,
     pop_queued_autofix_feedback,
@@ -99,6 +102,28 @@ def _get_feedback_referrer(items: list[QueuedAutofixFeedback]) -> AutofixReferre
     if len(referrers) == 1:
         return referrers.pop()
     return AutofixReferrer.UNKNOWN
+
+
+def _resolve_actor_user_id(items: Iterable[QueuedAutofixFeedback]) -> int | None:
+    """Resolve a single Sentry user from human feedback."""
+    actor_user_ids: set[int] = set()
+
+    for item in items:
+        source = item.feedback.source
+        if source.is_automated:
+            continue
+
+        actor_user_id = item.actor_user_id
+        if actor_user_id is None and isinstance(source, UserUIFeedbackSource):
+            # UI feedback serialized before actor_user_id was added still carries
+            # its authenticated Sentry user on the feedback source.
+            actor_user_id = source.user_id
+
+        if actor_user_id is None:
+            return None
+        actor_user_ids.add(actor_user_id)
+
+    return actor_user_ids.pop() if len(actor_user_ids) == 1 else None
 
 
 def trigger_consume_pr_iteration_feedback(
@@ -185,6 +210,7 @@ def consume_queued_autofix_feedback(
             return
 
         feedback_items = []
+        consumable_items: list[QueuedAutofixFeedback] = []
         # Keyed by (source class, id): issue-comment, review-comment, and review
         # (body) ids come from separate GitHub namespaces, so dedupe within each
         # concrete source type.
@@ -226,6 +252,7 @@ def consume_queued_autofix_feedback(
                 seen_check_suite_keys.add(suite_key)
 
             feedback_items.append(item.feedback)
+            consumable_items.append(item)
 
         if not feedback_items:
             logger.info(
@@ -242,6 +269,7 @@ def consume_queued_autofix_feedback(
                 run_id=run_id,
                 user_context="\n\n".join(item.text for item in feedback_items),
                 feedback=feedback_items,
+                actor_user_id=_resolve_actor_user_id(consumable_items),
             )
         except (
             PrIterationNoPullRequestException,
@@ -577,6 +605,16 @@ def trigger_pr_iteration_from_comment(
     if group_id is None:
         raise ValueError(f"Missing group id in agent run {agent_state.run_id}")
 
+    actor_user = (
+        find_user_for_scm_actor(
+            organization_id=organization_id,
+            integration_id=integration_id,
+            username=github_username,
+            external_id=getattr(comment.user, "id", None),
+        )
+        if not source.is_automated
+        else None
+    )
     try_enqueue_autofix_feedback(
         run_id=agent_state.run_id,
         organization_id=organization_id,
@@ -584,6 +622,7 @@ def trigger_pr_iteration_from_comment(
         feedback=feedback_obj,
         referrer=AutofixReferrer.GITHUB_PR_COMMENT,
         run_state=agent_state,
+        actor_user_id=actor_user.id if actor_user is not None else None,
     )
     trigger_consume_pr_iteration_feedback(
         run_id=agent_state.run_id,
@@ -739,6 +778,7 @@ def trigger_pr_iteration_from_review(
     pr_number: int,
     review_id: int,
     author_username: str | None = None,
+    author_external_id: str | int | None = None,
     author_is_bot: bool = False,
 ) -> None:
     """
@@ -870,6 +910,16 @@ def trigger_pr_iteration_from_review(
     if group_id is None:
         raise ValueError(f"Missing group id in agent run {agent_state.run_id}")
 
+    actor_user = (
+        find_user_for_scm_actor(
+            organization_id=organization_id,
+            integration_id=integration_id,
+            username=author_username,
+            external_id=author_external_id,
+        )
+        if not author_is_bot
+        else None
+    )
     for feedback_obj in feedback_items:
         try_enqueue_autofix_feedback(
             run_id=agent_state.run_id,
@@ -878,6 +928,7 @@ def trigger_pr_iteration_from_review(
             feedback=feedback_obj,
             referrer=AutofixReferrer.GITHUB_PR_REVIEW,
             run_state=agent_state,
+            actor_user_id=actor_user.id if actor_user is not None else None,
         )
 
     # A single consume pass drains everything queued above; trigger once using

--- a/tests/sentry/seer/autofix/pr_iteration/test_feedback_queue.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_feedback_queue.py
@@ -71,7 +71,12 @@ def _resolved_check_suite_source(
 
 class TryEnqueueAutofixFeedbackTest(TestCase):
     def _enqueue(
-        self, run_id: int, feedback: Feedback, *, run_state: SeerRunState | None = None
+        self,
+        run_id: int,
+        feedback: Feedback,
+        *,
+        run_state: SeerRunState | None = None,
+        actor_user_id: int | None = None,
     ) -> bool:
         return try_enqueue_autofix_feedback(
             run_id=run_id,
@@ -80,16 +85,18 @@ class TryEnqueueAutofixFeedbackTest(TestCase):
             feedback=feedback,
             referrer=AutofixReferrer.GITHUB_PR_COMMENT,
             run_state=run_state or _run_state(),
+            actor_user_id=actor_user_id,
         )
 
     def test_enqueues_when_should_queue(self) -> None:
         feedback = Feedback(source=UserUIFeedbackSource(user_id=1, user_feedback="fix it"))
 
-        assert self._enqueue(run_id=4242, feedback=feedback) is True
+        assert self._enqueue(run_id=4242, feedback=feedback, actor_user_id=17) is True
 
         queued = peek_queued_autofix_feedback(4242)
         assert len(queued) == 1
         assert queued[0].feedback.text == "fix it"
+        assert queued[0].actor_user_id == 17
 
     def test_skips_stale_feedback(self) -> None:
         feedback = Feedback(source=_resolved_check_suite_source())
@@ -132,6 +139,28 @@ class TryEnqueueAutofixFeedbackTest(TestCase):
 
 
 class ParseQueuedItemTest(TestCase):
+    def test_deserializes_legacy_item(self) -> None:
+        raw = json.dumps(
+            {
+                "organization_id": self.organization.id,
+                "group_id": 1,
+                "feedback": {
+                    "source": {
+                        "type": "user-ui",
+                        "user_id": 1,
+                        "user_feedback": "fix it",
+                    }
+                },
+                "referrer": AutofixReferrer.GROUP_AUTOFIX_ENDPOINT.value,
+            }
+        )
+
+        item = _parse_queued_item(raw)
+
+        assert item is not None
+        assert item.feedback.text == "fix it"
+        assert item.referrer == AutofixReferrer.GROUP_AUTOFIX_ENDPOINT
+
     def test_deserializes_check_suite_without_resolve(self) -> None:
         raw = json.dumps(
             {

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -527,9 +527,15 @@ class TestTriggerAutofixAgent(TestCase):
     @patch("sentry.quotas.backend.record_seer_run")
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
+    @patch("sentry.seer.autofix.autofix_agent.process_autofix_updates.apply_async")
     @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
     def test_pr_iteration_continued_run_increments_iteration_index(
-        self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
+        self,
+        mock_client_class,
+        mock_process_updates,
+        mock_broadcast,
+        mock_check_quota,
+        mock_record_run,
     ):
         """Continuing a PR iteration run computes the next iteration index and surfaces it."""
         mock_client = MagicMock()
@@ -545,17 +551,32 @@ class TestTriggerAutofixAgent(TestCase):
         )
         mock_client.continue_run.return_value = 67890
 
-        with self.feature("organizations:autofix-pr-iteration"):
+        with self.feature(
+            {
+                "organizations:autofix-pr-iteration": True,
+                "organizations:gen-ai-features": True,
+            }
+        ):
             trigger_autofix_agent(
                 group=self.group,
                 step=AutofixStep.PR_ITERATION,
                 referrer=AutofixReferrer.UNKNOWN,
                 run_id=67890,
+                actor_user_id=self.user.id,
             )
 
         call_kwargs = mock_broadcast.call_args.kwargs
         assert call_kwargs["event_name"] == SeerActionType.ITERATION_STARTED.value
-        assert call_kwargs["payload"]["iteration_index"] == 2
+        assert call_kwargs["payload"] == {
+            "run_id": 67890,
+            "sentry_run_id": None,
+            "group_id": self.group.id,
+            "iteration_index": 2,
+        }
+
+        process_kwargs = mock_process_updates.call_args.kwargs["kwargs"]
+        assert process_kwargs["actor_user_id"] == self.user.id
+        assert process_kwargs["event_payload"] == call_kwargs["payload"]
 
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
     @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")

--- a/tests/sentry/seer/autofix/test_pr_iteration_review.py
+++ b/tests/sentry/seer/autofix/test_pr_iteration_review.py
@@ -89,8 +89,9 @@ class HandlePullRequestReviewForAutofixIterationTest(TestCase):
         assert kwargs["integration_id"] == 42
         assert kwargs["pr_number"] == 7
         assert kwargs["review_id"] == 500
-        # Author is threaded to the task, which gates on its repo write access.
+        # Username gates repo write access; the stable id is preferred for user mapping.
         assert kwargs["author_username"] == "reviewer"
+        assert kwargs["author_external_id"] == "999"
         # Human authorship is threaded through so the task can apply the
         # automated-only streak cap.
         assert kwargs["author_is_bot"] is False
@@ -169,6 +170,7 @@ class TriggerPrIterationFromReviewTest(TestCase):
     mock_consume: MagicMock
     mock_make_scm: MagicMock
     mock_actions: MagicMock
+    mock_find_user: MagicMock
 
     def setUp(self) -> None:
         super().setUp()
@@ -190,6 +192,7 @@ class TriggerPrIterationFromReviewTest(TestCase):
             ("mock_consume", "consume_queued_autofix_feedback.apply_async"),
             ("mock_make_scm", "make_scm"),
             ("mock_actions", "scm_actions"),
+            ("mock_find_user", "find_user_for_scm_actor"),
         ):
             patcher = patch(f"{TASK_PATH}.{target}")
             setattr(self, attr, patcher.start())
@@ -210,6 +213,7 @@ class TriggerPrIterationFromReviewTest(TestCase):
         # Default the author to a repo collaborator with write access; tests that
         # exercise the gate override this.
         self.mock_actions.get_repository_user_permission.return_value = {"data": {"perms": "write"}}
+        self.mock_find_user.return_value = None
 
     def _agent_state(self, blocks: list[MemoryBlock] | None = None) -> SeerRunState:
         return SeerRunState(
@@ -271,7 +275,12 @@ class TriggerPrIterationFromReviewTest(TestCase):
     def _review_result(self, review: dict[str, Any]) -> dict[str, Any]:
         return {"data": review, "type": "github", "raw": {}}
 
-    def _run(self, author_username: str | None = "reviewer", author_is_bot: bool = False) -> None:
+    def _run(
+        self,
+        author_username: str | None = "reviewer",
+        author_external_id: str | int | None = "999",
+        author_is_bot: bool = False,
+    ) -> None:
         trigger_pr_iteration_from_review(
             organization_id=self.organization.id,
             repo_id=self.repo.id,
@@ -279,10 +288,12 @@ class TriggerPrIterationFromReviewTest(TestCase):
             pr_number=7,
             review_id=500,
             author_username=author_username,
+            author_external_id=author_external_id,
             author_is_bot=author_is_bot,
         )
 
     def test_batch_review_with_inline_comments_and_body(self) -> None:
+        self.mock_find_user.return_value = self.user
         self.mock_actions.get_review_comments.return_value = self._paginated(
             [
                 self._review_comment(comment_id="1", body="fix this"),
@@ -322,6 +333,15 @@ class TriggerPrIterationFromReviewTest(TestCase):
         assert all(
             c.kwargs["referrer"] == AutofixReferrer.GITHUB_PR_REVIEW
             for c in self.mock_enqueue.call_args_list
+        )
+        assert all(
+            c.kwargs["actor_user_id"] == self.user.id for c in self.mock_enqueue.call_args_list
+        )
+        self.mock_find_user.assert_called_once_with(
+            organization_id=self.organization.id,
+            integration_id=42,
+            username="reviewer",
+            external_id="999",
         )
         self.mock_consume.assert_called_once()
 

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -406,6 +406,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         mock_try_enqueue.assert_called_once()
         assert mock_try_enqueue.call_args.kwargs["run_id"] == 123
         assert mock_try_enqueue.call_args.kwargs["group_id"] == group.id
+        assert mock_try_enqueue.call_args.kwargs["actor_user_id"] == self.user.id
         mock_consume.apply_async.assert_called_once()
 
     @with_feature({"organizations:autofix-pr-iteration": False})

--- a/tests/sentry/seer/entrypoints/test_operator.py
+++ b/tests/sentry/seer/entrypoints/test_operator.py
@@ -4,6 +4,11 @@ from typing import Any, TypedDict, cast
 from unittest.mock import Mock, patch
 
 from fixtures.seer.webhooks import MOCK_RUN_ID
+from sentry.issues.action_log.types import (
+    ActionSource,
+    GroupActionActor,
+    SeerIterationStartedAction,
+)
 from sentry.models.activity import Activity
 from sentry.models.organization import Organization
 from sentry.models.pullrequest import (
@@ -43,6 +48,7 @@ from sentry.seer.models.run import SeerRunPullRequest, SeerRunType
 from sentry.sentry_apps.event_types import SentryAppEventType
 from sentry.testutils.asserts import assert_failure_metric
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.action_log import capture_action_log
 from sentry.testutils.helpers.options import override_options
 from sentry.types.activity import ActivityType
 
@@ -629,6 +635,29 @@ class SeerOperatorTest(TestCase):
         assert activity.data["run_id"] == MOCK_RUN_ID
         assert "changes" not in activity.data
         assert "code_changes" not in activity.data
+
+    @patch.object(SeerAutofixOperator, "has_access", return_value=True)
+    def test_iteration_started_activity_is_attributed_to_user(self, _mock_has_access):
+        event_payload = {"run_id": MOCK_RUN_ID, "group_id": self.group.id}
+
+        with capture_action_log() as action_log:
+            process_autofix_updates(
+                event_type=SentryAppEventType.SEER_ITERATION_STARTED,
+                event_payload=event_payload,
+                organization_id=self.organization.id,
+                actor_user_id=self.user.id,
+            )
+
+        activity = Activity.objects.get(
+            group=self.group, type=ActivityType.SEER_ITERATION_STARTED.value
+        )
+        assert activity.user_id == self.user.id
+        action_log.assert_logged(
+            SeerIterationStartedAction,
+            group_id=self.group.id,
+            source=ActionSource.SEER_EXPLORER,
+            actor=GroupActionActor.user(self.user.id),
+        )
 
     @patch.object(SeerAutofixOperator, "has_access", return_value=True)
     def test_create_seer_activity_all_mapped_event_types(self, _mock_has_access):

--- a/tests/sentry/tasks/seer/test_pr_iteration.py
+++ b/tests/sentry/tasks/seer/test_pr_iteration.py
@@ -44,7 +44,11 @@ class TriggerPrIterationFromCommentTest(TestCase):
             external_id="123",
             name="owner/repo",
         )
-        self.comment = {"id": 999, "body": "@sentry fix it", "user": {"login": "octocat"}}
+        self.comment = {
+            "id": 999,
+            "body": "@sentry fix it",
+            "user": {"id": 1234, "login": "octocat"},
+        }
         self.feedback = Feedback(source=GithubPrCommentFeedbackSource(comment=self.comment))
 
     def _agent_state(self, blocks: list[MemoryBlock] | None = None) -> SeerRunState:
@@ -90,6 +94,7 @@ class TriggerPrIterationFromCommentTest(TestCase):
     @patch(f"{TASK_PATH}._add_comment_reaction")
     @patch(f"{TASK_PATH}.make_scm")
     @patch(f"{TASK_PATH}._github_commenter_has_repo_write_access", return_value=True)
+    @patch(f"{TASK_PATH}.find_user_for_scm_actor")
     @patch(f"{TASK_PATH}.trigger_consume_pr_iteration_feedback")
     @patch(f"{TASK_PATH}.try_enqueue_autofix_feedback", return_value=True)
     @patch(f"{TASK_PATH}.get_agent_state_from_pr_id")
@@ -100,6 +105,7 @@ class TriggerPrIterationFromCommentTest(TestCase):
         mock_get_state: MagicMock,
         mock_enqueue: MagicMock,
         mock_trigger_consume: MagicMock,
+        mock_find_user: MagicMock,
         mock_has_access: MagicMock,
         mock_make_scm: MagicMock,
         mock_reaction: MagicMock,
@@ -108,6 +114,7 @@ class TriggerPrIterationFromCommentTest(TestCase):
         mock_get_integration.return_value = mock_integration
         agent_state = self._agent_state()
         mock_get_state.return_value = agent_state
+        mock_find_user.return_value = self.user
 
         self._call()
 
@@ -122,12 +129,19 @@ class TriggerPrIterationFromCommentTest(TestCase):
         assert kwargs["group_id"] == self.group.id
         assert kwargs["referrer"] == AutofixReferrer.GITHUB_PR_COMMENT
         assert kwargs["run_state"] is agent_state
+        assert kwargs["actor_user_id"] == self.user.id
         assert kwargs["feedback"].text == "fix it"
         source = kwargs["feedback"].source
         assert isinstance(source, GithubPrCommentFeedbackSource)
         # The comment was parsed into feedback once at mention time and threaded
         # through, so the source stores it rather than re-parsing the body.
         assert source.comment_feedback == "fix it"
+        mock_find_user.assert_called_once_with(
+            organization_id=self.organization.id,
+            integration_id=42,
+            username="octocat",
+            external_id=1234,
+        )
 
         mock_trigger_consume.assert_called_once()
         _, consume_kwargs = mock_trigger_consume.call_args
@@ -385,12 +399,18 @@ class ConsumeQueuedAutofixFeedbackTest(TestCase):
             metadata={"group_id": self.group.id} if metadata is None else metadata,
         )
 
-    def _queued(self, feedback: Feedback) -> QueuedAutofixFeedback:
+    def _queued(
+        self,
+        feedback: Feedback,
+        *,
+        actor_user_id: int | None = None,
+    ) -> QueuedAutofixFeedback:
         return QueuedAutofixFeedback(
             organization_id=self.organization.id,
             group_id=self.group.id,
             feedback=feedback,
             referrer=AutofixReferrer.GITHUB_PR_COMMENT,
+            actor_user_id=actor_user_id,
         )
 
     def _iteration_block(self, idx: int) -> MemoryBlock:
@@ -480,6 +500,40 @@ class ConsumeQueuedAutofixFeedbackTest(TestCase):
         _, kwargs = mock_trigger.call_args
         assert kwargs["group"].id == self.group.id
         assert [f.text for f in kwargs["feedback"]] == ["fix it"]
+        assert kwargs["actor_user_id"] == 1
+
+    @patch(f"{TASK_PATH}.trigger_autofix_agent")
+    @patch(f"{TASK_PATH}.pop_queued_autofix_feedback")
+    @patch(f"{TASK_PATH}.fetch_run_status")
+    def test_attributes_human_feedback_coalesced_with_automated_feedback(
+        self,
+        mock_fetch: MagicMock,
+        mock_pop: MagicMock,
+        mock_trigger: MagicMock,
+    ) -> None:
+        mock_fetch.return_value = self._state()
+        mock_pop.return_value = [
+            self._queued(
+                Feedback(source=UserUIFeedbackSource(user_id=1, user_feedback="fix it")),
+                actor_user_id=1,
+            ),
+            self._queued(
+                Feedback(
+                    source=GithubPrCommentFeedbackSource(
+                        comment={
+                            "id": 1001,
+                            "body": "@sentry automated feedback",
+                            "user": {"login": "dependabot[bot]", "type": "Bot"},
+                        }
+                    )
+                )
+            ),
+        ]
+
+        self._call()
+
+        mock_trigger.assert_called_once()
+        assert mock_trigger.call_args.kwargs["actor_user_id"] == 1
 
     @patch(f"{TASK_PATH}.trigger_autofix_agent")
     @patch(f"{TASK_PATH}.pop_queued_autofix_feedback")


### PR DESCRIPTION
Attributes "Pull request iteration started" activities to the Sentry user who triggered the iteration from the UI or GitHub.

If an iteration starts from more than one piece of feedback, we attribute it to a user only when all human feedback came from the same person. Otherwise it stays attributed to Seer.