### PR TITLE
fix(logs): Break log ordering ties by id in all sampling modes

### DIFF
--- a/src/sentry/snuba/ourlogs.py
+++ b/src/sentry/snuba/ourlogs.py
@@ -15,6 +15,18 @@ from sentry.utils.tracing import trace
 logger = logging.getLogger("sentry.snuba.ourlogs")
 
 
+def _leading_timestamp_direction(orderby: list[str] | None) -> str | None:
+    """Returns the sort direction ('' or '-') when the orderby leads with a timestamp column,
+    otherwise None. Only a leading timestamp sort earns the precise-timestamp/id tiebreakers;
+    other sorts are left untouched."""
+    if not orderby:
+        return None
+    leading = orderby[0]
+    if leading.lstrip("-") in (constants.TIMESTAMP_ALIAS, constants.TIMESTAMP_PRECISE_ALIAS):
+        return "-" if leading.startswith("-") else ""
+    return None
+
+
 class OurLogs(rpc_dataset_common.RPCBase):
     DEFINITIONS = OURLOG_DEFINITIONS
 
@@ -42,26 +54,19 @@ class OurLogs(rpc_dataset_common.RPCBase):
         additional_queries: AdditionalQueries | None = None,
         max_string_length: int | None = None,
     ) -> EAPResponse:
-        """timestamp_precise is always displayed in the UI in lieu of timestamp but since the TraceItem table isn't a DateTime64
-        so we need to always order by it regardless of what is actually passed to the orderby.
-        Additionally, to ensure a strict order in the flex time sampling mode, we also order
-        by the item id."""
-        if (
-            orderby is not None
-            and len(orderby) == 1
-            and orderby[0].lstrip("-") == constants.TIMESTAMP_ALIAS
-        ):
-            direction = "-" if orderby[0][0] == "-" else ""
-            orderby.append(direction + constants.TIMESTAMP_PRECISE_ALIAS)
-            if constants.TIMESTAMP_PRECISE_ALIAS not in selected_columns:
-                selected_columns.append(constants.TIMESTAMP_PRECISE_ALIAS)
-
-            # When using highest accuracy flex time sampling, we make sure we sort by
-            # the item id as well to ensure we have a strict ordering.
-            if sampling_mode == "HIGHEST_ACCURACY_FLEX_TIME":
-                orderby.append(direction + "id")
-                if "id" not in selected_columns:
-                    selected_columns.append("id")
+        """The TraceItem table stores logs with a coarse `timestamp` (not a DateTime64, so no
+        sub-millisecond precision), which makes ordering by `timestamp` alone ambiguous for logs
+        sharing a millisecond. Whenever a timestamp sort leads the orderby we resolve ties on the
+        nanosecond `timestamp_precise`, then on the item `id`, giving a strict total order that is
+        stable across pages in every sampling mode."""
+        direction = _leading_timestamp_direction(orderby)
+        if orderby is not None and direction is not None:
+            ordered_aliases = {column.lstrip("-") for column in orderby}
+            for tiebreaker in (constants.TIMESTAMP_PRECISE_ALIAS, "id"):
+                if tiebreaker not in ordered_aliases:
+                    orderby.append(direction + tiebreaker)
+                    if tiebreaker not in selected_columns:
+                        selected_columns.append(tiebreaker)
 
         return cls._run_table_query(
             rpc_dataset_common.TableQuery(

--- a/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
@@ -663,6 +663,38 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase, 
 
         assert [row["message"] for row in response.data["data"]] == ["foo", "bar", "qux"]
 
+    def test_order_by_timestamp_breaks_ties_by_id_in_normal_sampling(self):
+        logs = [
+            self.create_ourlog(
+                {"body": "foo"},
+                timestamp=self.nine_mins_ago,
+                log_id=uuid4().hex,
+            ),
+            self.create_ourlog(
+                {"body": "bar"},
+                timestamp=self.ten_mins_ago,
+                log_id="1" + uuid4().hex[1:],
+            ),
+            self.create_ourlog(
+                {"body": "qux"},
+                timestamp=self.ten_mins_ago,
+                log_id="0" + uuid4().hex[1:],  # qux's id sorts after bar's id
+            ),
+        ]
+        self.store_eap_items(logs)
+        response = self.do_request(
+            {
+                "field": ["id", "timestamp", "message"],
+                "query": "",
+                "orderby": "-timestamp",
+                "project": self.project.id,
+                "dataset": self.dataset,
+            },
+        )
+        assert response.status_code == 200, response.content
+
+        assert [row["message"] for row in response.data["data"]] == ["foo", "bar", "qux"]
+
     def test_high_accuracy_flex_time_empty_page_no_next(self):
         response = self.do_request(
             {

--- a/tests/snuba/api/endpoints/test_organization_trace_logs.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_logs.py
@@ -151,6 +151,33 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsEndpointTestBase):
         assert log_data["trace"] == trace_id_1
         assert log_data["message"] == "foo"
 
+    def test_orders_ties_by_id(self) -> None:
+        trace_id = "1" * 32
+        self.store_eap_items(
+            [
+                self.create_ourlog(
+                    {"body": "bar", "trace_id": trace_id},
+                    timestamp=self.ten_mins_ago,
+                    log_id="1" + uuid4().hex[1:],
+                ),
+                self.create_ourlog(
+                    {"body": "qux", "trace_id": trace_id},
+                    timestamp=self.ten_mins_ago,
+                    log_id="0" + uuid4().hex[1:],  # qux's id sorts after bar's id
+                ),
+            ]
+        )
+
+        response = self.client.get(
+            self.url,
+            data={"traceId": trace_id},
+            format="json",
+        )
+        assert response.status_code == 200, response.content
+        # The default ["-timestamp", "-timestamp_precise"] orderby must still fall back to a
+        # strict, deterministic id order when timestamps are identical.
+        assert [row["message"] for row in response.data["data"]] == ["bar", "qux"]
+
     def test_orderby_validation(self) -> None:
         trace_id_1 = "1" * 32
         trace_id_2 = "2" * 32


### PR DESCRIPTION
Logs are stored with a coarse millisecond `timestamp`, so ordering by it alone is ambiguous for logs sharing a millisecond. The nanosecond `timestamp_precise` and `id` tiebreakers were only appended for a single-column `timestamp` orderby, and `id` only under flex-time sampling. That left the default NORMAL-sampling table view — and the trace/replay-frozen logs view, which sorts by `[-timestamp, -timestamp_precise]` — with no strict order, so same-millisecond logs came back nondeterministically and paginated inconsistently.

This resolves ties on `timestamp_precise` then `id` whenever a timestamp sort leads the orderby, regardless of sampling mode, for a strict, page-stable total order. Non-timestamp-led sorts are unchanged.

Part of LOGS-580 (backend half; the client-side comparator tiebreak ships as a separate frontend PR).

Refs LOGS-580