### PR TITLE
fix(logs): Break client-side log ordering ties by id

### DIFF
--- a/static/app/views/explore/logs/utils.spec.tsx
+++ b/static/app/views/explore/logs/utils.spec.tsx
@@ -229,4 +229,35 @@ describe('compareLogRowsBySortBys', () => {
       sortedIds([invalid, older], [{field: OurLogKnownFieldKey.TIMESTAMP, kind: 'desc'}])
     ).not.toThrow();
   });
+
+  it('breaks ties by id in the sort direction when precise timestamps are identical', () => {
+    const a = logRow('aaa', {[OurLogKnownFieldKey.TIMESTAMP_PRECISE]: 5_000});
+    const b = logRow('bbb', {[OurLogKnownFieldKey.TIMESTAMP_PRECISE]: 5_000});
+
+    const descending = sortedIds(
+      [a, b],
+      [{field: OurLogKnownFieldKey.TIMESTAMP, kind: 'desc'}]
+    );
+    const ascending = sortedIds(
+      [b, a],
+      [{field: OurLogKnownFieldKey.TIMESTAMP, kind: 'asc'}]
+    );
+
+    expect([descending, ascending]).toEqual([
+      ['bbb', 'aaa'],
+      ['aaa', 'bbb'],
+    ]);
+  });
+
+  it('does not break ties by id when a non-timestamp field leads the sort', () => {
+    const a = logRow('aaa', {[OurLogKnownFieldKey.SEVERITY]: 'error'});
+    const b = logRow('bbb', {[OurLogKnownFieldKey.SEVERITY]: 'error'});
+
+    const result = sortedIds(
+      [b, a],
+      [{field: OurLogKnownFieldKey.SEVERITY, kind: 'asc'}]
+    );
+
+    expect(result).toEqual(['bbb', 'aaa']);
+  });
 });

--- a/static/app/views/explore/logs/utils.tsx
+++ b/static/app/views/explore/logs/utils.tsx
@@ -291,6 +291,24 @@ export function compareLogRowsBySortBys(
       return direction;
     }
   }
+
+  // When a timestamp sort leads, the server resolves ties on the item id in the same
+  // direction so same-timestamp rows keep a strict, page-stable order. Mirror that here.
+  const leadingSort = sortBys[0];
+  if (
+    leadingSort?.field === OurLogKnownFieldKey.TIMESTAMP ||
+    leadingSort?.field === OurLogKnownFieldKey.TIMESTAMP_PRECISE
+  ) {
+    const idDirection = leadingSort.kind === 'desc' ? -1 : 1;
+    const aId = String(a[OurLogKnownFieldKey.ID] ?? '');
+    const bId = String(b[OurLogKnownFieldKey.ID] ?? '');
+    if (aId < bId) {
+      return -1 * idDirection;
+    }
+    if (aId > bId) {
+      return idDirection;
+    }
+  }
   return 0;
 }
 


### PR DESCRIPTION
The log row comparator (`compareLogRowsBySortBys`) returned `0` for rows sharing a precise timestamp, leaving their order unstable when the client re-sorts or merges paginated pages. This mirrors the server's tiebreaker: when a timestamp sort leads, resolve ties on the item `id` in the same direction so same-timestamp rows keep a strict, page-stable order. Non-timestamp-led sorts are unchanged.

Frontend half of LOGS-580; pairs with the backend ordering fix in #120500. Frontend/backend deploy independently, so they land as separate PRs.

Refs LOGS-580