### PR TITLE
fix(preprod): Align snapshot comment approval status

### DIFF
--- a/src/sentry/preprod/snapshots/utils.py
+++ b/src/sentry/preprod/snapshots/utils.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from sentry.preprod.models import PreprodArtifact, PreprodBuildConfiguration
 from sentry.preprod.snapshots.models import (
     PreprodSnapshotComparison,
@@ -61,30 +63,35 @@ def find_head_snapshot_artifacts_awaiting_base(
     )
 
 
-def _comparison_has_changes(
-    comparison: PreprodSnapshotComparison,
-    fail_on_added: bool = False,
-    fail_on_removed: bool = True,
-    fail_on_changed: bool = True,
-    fail_on_renamed: bool = False,
+@dataclass(frozen=True)
+class SnapshotChangeCriteria:
+    """Snapshot change categories relevant to a consumer."""
+
+    added: bool
+    removed: bool
+    changed: bool
+    renamed: bool
+
+
+def _comparison_matches_change_criteria(
+    comparison: PreprodSnapshotComparison, criteria: SnapshotChangeCriteria
 ) -> bool:
+    """Return whether a comparison contains a selected change category."""
     return (
-        (fail_on_changed and comparison.images_changed > 0)
-        or (fail_on_renamed and comparison.images_renamed > 0)
-        or (fail_on_added and comparison.images_added > 0)
-        or (fail_on_removed and comparison.images_removed > 0)
+        (criteria.changed and comparison.images_changed > 0)
+        or (criteria.renamed and comparison.images_renamed > 0)
+        or (criteria.added and comparison.images_added > 0)
+        or (criteria.removed and comparison.images_removed > 0)
     )
 
 
-def build_changes_map(
+def evaluate_snapshot_changes_by_artifact_id(
     artifacts: list[PreprodArtifact],
     snapshot_metrics_map: dict[int, PreprodSnapshotMetrics],
     comparisons_map: dict[int, PreprodSnapshotComparison],
-    fail_on_added: bool = False,
-    fail_on_removed: bool = True,
-    fail_on_changed: bool = True,
-    fail_on_renamed: bool = False,
+    criteria: SnapshotChangeCriteria,
 ) -> dict[int, bool]:
+    """Return whether each successfully compared artifact matches the selected change criteria."""
     changes_map: dict[int, bool] = {}
     for artifact in artifacts:
         metrics = snapshot_metrics_map.get(artifact.id)
@@ -93,11 +100,5 @@ def build_changes_map(
         comparison = comparisons_map.get(metrics.id)
         if not comparison or comparison.state != PreprodSnapshotComparison.State.SUCCESS:
             continue
-        changes_map[artifact.id] = _comparison_has_changes(
-            comparison,
-            fail_on_added=fail_on_added,
-            fail_on_removed=fail_on_removed,
-            fail_on_changed=fail_on_changed,
-            fail_on_renamed=fail_on_renamed,
-        )
+        changes_map[artifact.id] = _comparison_matches_change_criteria(comparison, criteria)
     return changes_map

--- a/src/sentry/preprod/vcs/pr_comments/snapshot_tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/snapshot_tasks.py
@@ -8,10 +8,14 @@ from taskbroker_client.retry import Retry
 
 from sentry.models.commitcomparison import CommitComparison
 from sentry.models.organization import Organization
+from sentry.models.project import Project
 from sentry.preprod.integration_utils import get_commit_context_client
 from sentry.preprod.models import PreprodArtifact, PreprodComparisonApproval
 from sentry.preprod.snapshots.models import PreprodSnapshotComparison, PreprodSnapshotMetrics
-from sentry.preprod.snapshots.utils import build_changes_map
+from sentry.preprod.snapshots.utils import (
+    SnapshotChangeCriteria,
+    evaluate_snapshot_changes_by_artifact_id,
+)
 from sentry.preprod.vcs.pr_comments.snapshot_templates import (
     format_missing_base_snapshot_pr_comment,
     format_snapshot_pr_comment,
@@ -22,6 +26,9 @@ from sentry.preprod.vcs.pr_comments.tasks import (
     lock_pr_comparisons_for_update,
     resolve_pr_comment_context,
     save_pr_comment_result,
+)
+from sentry.preprod.vcs.status_checks.snapshots.config import (
+    get_snapshot_approval_policy,
 )
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo.base import SiloMode
@@ -35,6 +42,15 @@ POST_ON_ADDED_OPTION_KEY = "sentry:preprod_snapshot_pr_comments_post_on_added"
 POST_ON_REMOVED_OPTION_KEY = "sentry:preprod_snapshot_pr_comments_post_on_removed"
 POST_ON_CHANGED_OPTION_KEY = "sentry:preprod_snapshot_pr_comments_post_on_changed"
 POST_ON_RENAMED_OPTION_KEY = "sentry:preprod_snapshot_pr_comments_post_on_renamed"
+
+
+def get_snapshot_pr_comment_reporting_criteria(project: Project) -> SnapshotChangeCriteria:
+    return SnapshotChangeCriteria(
+        added=project.get_option(POST_ON_ADDED_OPTION_KEY, default=False),
+        removed=project.get_option(POST_ON_REMOVED_OPTION_KEY, default=True),
+        changed=project.get_option(POST_ON_CHANGED_OPTION_KEY, default=True),
+        renamed=project.get_option(POST_ON_RENAMED_OPTION_KEY, default=False),
+    )
 
 
 @instrumented_task(
@@ -103,14 +119,14 @@ def create_preprod_snapshot_pr_comment_task(
             c.head_snapshot_metrics_id: c for c in comparisons_qs
         }
 
-        approvals_map: dict[int, PreprodComparisonApproval] = {}
+        approvals_by_artifact_id: dict[int, PreprodComparisonApproval] = {}
         approval_qs = PreprodComparisonApproval.objects.filter(
             preprod_artifact_id__in=artifact_ids,
             preprod_feature_type=PreprodComparisonApproval.FeatureType.SNAPSHOTS,
             approval_status=PreprodComparisonApproval.ApprovalStatus.APPROVED,
         )
         for approval in approval_qs:
-            approvals_map[approval.preprod_artifact_id] = approval
+            approvals_by_artifact_id[approval.preprod_artifact_id] = approval
 
         base_artifact_map = PreprodArtifact.get_base_artifacts_for_commit(all_artifacts)
 
@@ -145,31 +161,36 @@ def create_preprod_snapshot_pr_comment_task(
                     all_artifacts, snapshot_metrics_map, project=artifact.project
                 )
         else:
-            post_on_added = artifact.project.get_option(POST_ON_ADDED_OPTION_KEY, default=False)
-            post_on_removed = artifact.project.get_option(POST_ON_REMOVED_OPTION_KEY, default=True)
-            post_on_changed = artifact.project.get_option(POST_ON_CHANGED_OPTION_KEY, default=True)
-            post_on_renamed = artifact.project.get_option(POST_ON_RENAMED_OPTION_KEY, default=False)
-            changes_map = build_changes_map(
+            reporting_criteria = get_snapshot_pr_comment_reporting_criteria(artifact.project)
+            reportable_changes_by_artifact_id = evaluate_snapshot_changes_by_artifact_id(
                 all_artifacts,
                 snapshot_metrics_map,
                 comparisons_map,
-                fail_on_added=post_on_added,
-                fail_on_removed=post_on_removed,
-                fail_on_changed=post_on_changed,
-                fail_on_renamed=post_on_renamed,
+                reporting_criteria,
+            )
+            approval_policy = get_snapshot_approval_policy(artifact.project)
+            approval_requirements_by_artifact_id = (
+                evaluate_snapshot_changes_by_artifact_id(
+                    all_artifacts,
+                    snapshot_metrics_map,
+                    comparisons_map,
+                    approval_policy.criteria,
+                )
+                if approval_policy.enabled
+                else {}
             )
 
-            has_changes = any(changes_map.values())
-            # Failed comparisons and errored images are absent from changes_map
-            # (which only tracks SUCCESS state with diffs), so check
-            # comparisons_map directly to avoid suppressing these reports.
+            has_reportable_changes = any(reportable_changes_by_artifact_id.values())
+            # Failed comparisons and errored images are absent from
+            # reportable_changes_by_artifact_id (which only tracks SUCCESS state with diffs), so
+            # check comparisons_map directly to avoid suppressing these reports.
             has_failures_or_errors = any(
                 c.state == PreprodSnapshotComparison.State.FAILED
                 or (c.state == PreprodSnapshotComparison.State.SUCCESS and c.images_errored > 0)
                 for c in comparisons_map.values()
             )
             # Suppress brand-new comments on uneventful runs to avoid PR noise.
-            if not (has_changes or has_failures_or_errors or existing_comment_id):
+            if not (has_reportable_changes or has_failures_or_errors or existing_comment_id):
                 logger.info(
                     "preprod.snapshot_pr_comments.create.skipped_no_diff",
                     extra={"preprod_artifact_id": artifact.id},
@@ -181,8 +202,9 @@ def create_preprod_snapshot_pr_comment_task(
                 snapshot_metrics_map,
                 comparisons_map,
                 base_artifact_map,
-                changes_map,
-                approvals_map=approvals_map,
+                reportable_changes_by_artifact_id,
+                approval_requirements_by_artifact_id=approval_requirements_by_artifact_id,
+                approvals_by_artifact_id=approvals_by_artifact_id,
                 project=artifact.project,
             )
 

--- a/src/sentry/preprod/vcs/pr_comments/snapshot_templates.py
+++ b/src/sentry/preprod/vcs/pr_comments/snapshot_templates.py
@@ -35,13 +35,17 @@ def format_snapshot_pr_comment(
     snapshot_metrics_map: dict[int, PreprodSnapshotMetrics],
     comparisons_map: dict[int, PreprodSnapshotComparison],
     base_artifact_map: dict[int, PreprodArtifact],
-    changes_map: dict[int, bool],
-    approvals_map: dict[int, PreprodComparisonApproval] | None = None,
+    reportable_changes_by_artifact_id: dict[int, bool],
+    approvals_by_artifact_id: dict[int, PreprodComparisonApproval] | None = None,
     *,
+    approval_requirements_by_artifact_id: dict[int, bool] | None = None,
     project: Project,
 ) -> str:
     if not artifacts:
         raise ValueError("Cannot format PR comment for empty artifact list")
+
+    approval_requirements_by_artifact_id = approval_requirements_by_artifact_id or {}
+    approvals_by_artifact_id = approvals_by_artifact_id or {}
 
     table_rows = []
     total_errored = 0
@@ -86,12 +90,13 @@ def format_snapshot_pr_comment(
         elif comparison.state == PreprodSnapshotComparison.State.FAILED:
             table_rows.append(f"| {name_cell} | - | - | - | - | - | - | ❌ Comparison failed |")
         else:
-            has_changes = changes_map.get(artifact.id, False)
-            is_approved = approvals_map is not None and artifact.id in approvals_map
-            if has_changes and is_approved:
-                status = "✅ Approved"
-            elif has_changes:
-                status = "⏳ Needs approval"
+            has_reportable_changes = reportable_changes_by_artifact_id.get(artifact.id, False)
+            requires_approval = approval_requirements_by_artifact_id.get(artifact.id, False)
+            is_approved = artifact.id in approvals_by_artifact_id
+            if requires_approval:
+                status = "✅ Approved" if is_approved else "⏳ Needs approval"
+            elif has_reportable_changes:
+                status = "⚠️ Changes detected"
             else:
                 status = "✅ Unchanged"
 

--- a/src/sentry/preprod/vcs/status_checks/snapshots/config.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/config.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+
+from sentry.models.project import Project
+from sentry.preprod.snapshots.utils import SnapshotChangeCriteria
+
 ENABLED_OPTION_KEY = "sentry:preprod_snapshot_status_checks_enabled"
 FAIL_ON_ADDED_OPTION_KEY = "sentry:preprod_snapshot_status_checks_fail_on_added"
 FAIL_ON_REMOVED_OPTION_KEY = "sentry:preprod_snapshot_status_checks_fail_on_removed"
@@ -11,3 +16,36 @@ FAIL_ON_ADDED_DEFAULT = False
 FAIL_ON_REMOVED_DEFAULT = True
 FAIL_ON_CHANGED_DEFAULT = True
 FAIL_ON_RENAMED_DEFAULT = False
+
+
+@dataclass(frozen=True)
+class SnapshotApprovalPolicy:
+    """Whether snapshot approval is active and which change categories require it."""
+
+    enabled: bool
+    criteria: SnapshotChangeCriteria
+
+
+def get_snapshot_approval_policy(project: Project) -> SnapshotApprovalPolicy:
+    """Return the project's effective snapshot approval policy."""
+    enabled = project.get_option(ENABLED_OPTION_KEY, default=ENABLED_DEFAULT)
+    if not enabled:
+        return SnapshotApprovalPolicy(
+            enabled=False,
+            criteria=SnapshotChangeCriteria(
+                added=False,
+                removed=False,
+                changed=False,
+                renamed=False,
+            ),
+        )
+
+    return SnapshotApprovalPolicy(
+        enabled=True,
+        criteria=SnapshotChangeCriteria(
+            added=project.get_option(FAIL_ON_ADDED_OPTION_KEY, default=FAIL_ON_ADDED_DEFAULT),
+            removed=project.get_option(FAIL_ON_REMOVED_OPTION_KEY, default=FAIL_ON_REMOVED_DEFAULT),
+            changed=project.get_option(FAIL_ON_CHANGED_OPTION_KEY, default=FAIL_ON_CHANGED_DEFAULT),
+            renamed=project.get_option(FAIL_ON_RENAMED_OPTION_KEY, default=FAIL_ON_RENAMED_DEFAULT),
+        ),
+    )

--- a/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
@@ -15,19 +15,10 @@ from sentry.preprod.models import (
 )
 from sentry.preprod.snapshots.constants import MISSING_BASE_GRACE_PERIOD_SECONDS
 from sentry.preprod.snapshots.models import PreprodSnapshotComparison, PreprodSnapshotMetrics
-from sentry.preprod.snapshots.utils import build_changes_map
+from sentry.preprod.snapshots.utils import evaluate_snapshot_changes_by_artifact_id
 from sentry.preprod.url_utils import get_preprod_artifact_url
 from sentry.preprod.vcs.status_checks.snapshots.config import (
-    ENABLED_DEFAULT,
-    ENABLED_OPTION_KEY,
-    FAIL_ON_ADDED_DEFAULT,
-    FAIL_ON_ADDED_OPTION_KEY,
-    FAIL_ON_CHANGED_DEFAULT,
-    FAIL_ON_CHANGED_OPTION_KEY,
-    FAIL_ON_REMOVED_DEFAULT,
-    FAIL_ON_REMOVED_OPTION_KEY,
-    FAIL_ON_RENAMED_DEFAULT,
-    FAIL_ON_RENAMED_OPTION_KEY,
+    get_snapshot_approval_policy,
 )
 from sentry.preprod.vcs.status_checks.snapshots.templates import (
     format_first_snapshot_status_check_messages,
@@ -113,10 +104,8 @@ def create_preprod_snapshot_status_check_task(
         )
         return
 
-    status_checks_enabled = preprod_artifact.project.get_option(
-        ENABLED_OPTION_KEY, default=ENABLED_DEFAULT
-    )
-    if not status_checks_enabled:
+    approval_policy = get_snapshot_approval_policy(preprod_artifact.project)
+    if not approval_policy.enabled:
         logger.info(
             "preprod.snapshot_status_checks.create.disabled",
             extra={
@@ -125,19 +114,6 @@ def create_preprod_snapshot_status_check_task(
             },
         )
         return
-
-    fail_on_added = preprod_artifact.project.get_option(
-        FAIL_ON_ADDED_OPTION_KEY, default=FAIL_ON_ADDED_DEFAULT
-    )
-    fail_on_removed = preprod_artifact.project.get_option(
-        FAIL_ON_REMOVED_OPTION_KEY, default=FAIL_ON_REMOVED_DEFAULT
-    )
-    fail_on_changed = preprod_artifact.project.get_option(
-        FAIL_ON_CHANGED_OPTION_KEY, default=FAIL_ON_CHANGED_DEFAULT
-    )
-    fail_on_renamed = preprod_artifact.project.get_option(
-        FAIL_ON_RENAMED_OPTION_KEY, default=FAIL_ON_RENAMED_DEFAULT
-    )
 
     all_artifacts = list(preprod_artifact.get_sibling_artifacts_for_commit())
 
@@ -179,14 +155,11 @@ def create_preprod_snapshot_status_check_task(
     is_solo = not base_artifact_map
 
     if not is_solo:
-        changes_map = build_changes_map(
+        changes_map = evaluate_snapshot_changes_by_artifact_id(
             all_artifacts,
             snapshot_metrics_map,
             comparisons_map,
-            fail_on_added=fail_on_added,
-            fail_on_removed=fail_on_removed,
-            fail_on_changed=fail_on_changed,
-            fail_on_renamed=fail_on_renamed,
+            approval_policy.criteria,
         )
         for artifact in all_artifacts:
             if changes_map.get(artifact.id, False) and artifact.id not in approvals_map:

--- a/tests/sentry/preprod/vcs/pr_comments/test_snapshot_tasks.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_snapshot_tasks.py
@@ -10,6 +10,7 @@ from sentry.preprod.models import PreprodArtifact
 from sentry.preprod.snapshots.models import PreprodSnapshotComparison, PreprodSnapshotMetrics
 from sentry.preprod.vcs.pr_comments.snapshot_tasks import (
     create_preprod_snapshot_pr_comment_task,
+    get_snapshot_pr_comment_reporting_criteria,
     post_snapshot_pr_comment_task,
 )
 from sentry.shared_integrations.exceptions import ApiError
@@ -80,19 +81,19 @@ class CreatePreprodSnapshotPrCommentTaskTest(TestCase):
         return artifact, metrics
 
     @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.post_snapshot_pr_comment_task.delay")
-    @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.build_changes_map")
+    @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.evaluate_snapshot_changes_by_artifact_id")
     @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.get_commit_context_client")
     @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.format_snapshot_pr_comment")
     @patch("sentry.preprod.models.PreprodArtifact.get_base_artifacts_for_commit")
     def test_dispatches_subtask(
-        self, mock_get_base, mock_format, mock_get_client, mock_build_changes_map, mock_delay
+        self, mock_get_base, mock_format, mock_get_client, mock_evaluate_changes, mock_delay
     ):
         mock_get_client.return_value = Mock()
         mock_format.return_value = "## Sentry Snapshot Testing\n..."
 
         artifact, metrics = self._create_artifact_with_metrics()
         mock_get_base.return_value = {artifact.id: Mock()}
-        mock_build_changes_map.return_value = {artifact.id: True}
+        mock_evaluate_changes.return_value = {artifact.id: True}
 
         create_preprod_snapshot_pr_comment_task(artifact.id)
 
@@ -237,34 +238,74 @@ class CreatePreprodSnapshotPrCommentTaskTest(TestCase):
 
         mock_get_client.assert_not_called()
 
-    @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.post_snapshot_pr_comment_task.delay")
-    @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.build_changes_map")
-    @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.get_commit_context_client")
-    @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.format_snapshot_pr_comment")
-    @patch("sentry.preprod.models.PreprodArtifact.get_base_artifacts_for_commit")
-    def test_passes_post_on_options_to_build_changes_map(
-        self, mock_get_base, mock_format, mock_get_client, mock_build_changes_map, mock_delay
-    ):
-        mock_get_client.return_value = Mock()
-        mock_format.return_value = "body"
-
+    def test_snapshot_pr_comment_reporting_criteria_uses_options(self):
         self.project.update_option("sentry:preprod_snapshot_pr_comments_post_on_added", True)
         self.project.update_option("sentry:preprod_snapshot_pr_comments_post_on_removed", False)
         self.project.update_option("sentry:preprod_snapshot_pr_comments_post_on_changed", False)
         self.project.update_option("sentry:preprod_snapshot_pr_comments_post_on_renamed", True)
 
+        criteria = get_snapshot_pr_comment_reporting_criteria(self.project)
+
+        assert criteria.added is True
+        assert criteria.removed is False
+        assert criteria.changed is False
+        assert criteria.renamed is True
+
+    @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.post_snapshot_pr_comment_task.delay")
+    @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.get_commit_context_client")
+    @patch("sentry.preprod.models.PreprodArtifact.get_base_artifacts_for_commit")
+    def test_reportable_changes_without_approval_requirement(
+        self, mock_get_base, mock_get_client, mock_delay
+    ):
+        mock_get_client.return_value = Mock()
+        self.project.update_option("sentry:preprod_snapshot_pr_comments_post_on_added", True)
+        self.project.update_option("sentry:preprod_snapshot_status_checks_fail_on_added", False)
+
         artifact, metrics = self._create_artifact_with_metrics()
-        mock_get_base.return_value = {artifact.id: Mock()}
-        mock_build_changes_map.return_value = {artifact.id: True}
+        base_artifact, base_metrics = self._create_artifact_with_metrics(
+            with_commit_comparison=False, app_id="com.example.base"
+        )
+        mock_get_base.return_value = {artifact.id: base_artifact}
+        PreprodSnapshotComparison.objects.create(
+            head_snapshot_metrics=metrics,
+            base_snapshot_metrics=base_metrics,
+            state=PreprodSnapshotComparison.State.SUCCESS,
+            images_added=4,
+        )
 
         create_preprod_snapshot_pr_comment_task(artifact.id)
 
-        mock_build_changes_map.assert_called_once()
-        kwargs = mock_build_changes_map.call_args
-        assert kwargs[1]["fail_on_added"] is True
-        assert kwargs[1]["fail_on_removed"] is False
-        assert kwargs[1]["fail_on_changed"] is False
-        assert kwargs[1]["fail_on_renamed"] is True
+        comment_body = mock_delay.call_args.kwargs["comment_body"]
+        assert "Needs approval" not in comment_body
+        assert "Changes detected" in comment_body
+
+    @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.post_snapshot_pr_comment_task.delay")
+    @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.get_commit_context_client")
+    @patch("sentry.preprod.models.PreprodArtifact.get_base_artifacts_for_commit")
+    def test_disabled_status_checks_do_not_require_approval_in_comment(
+        self, mock_get_base, mock_get_client, mock_delay
+    ):
+        mock_get_client.return_value = Mock()
+        self.project.update_option("sentry:preprod_snapshot_status_checks_enabled", False)
+        self.project.update_option("sentry:preprod_snapshot_pr_comments_post_on_removed", True)
+
+        artifact, metrics = self._create_artifact_with_metrics()
+        base_artifact, base_metrics = self._create_artifact_with_metrics(
+            with_commit_comparison=False, app_id="com.example.base"
+        )
+        mock_get_base.return_value = {artifact.id: base_artifact}
+        PreprodSnapshotComparison.objects.create(
+            head_snapshot_metrics=metrics,
+            base_snapshot_metrics=base_metrics,
+            state=PreprodSnapshotComparison.State.SUCCESS,
+            images_removed=1,
+        )
+
+        create_preprod_snapshot_pr_comment_task(artifact.id)
+
+        comment_body = mock_delay.call_args.kwargs["comment_body"]
+        assert "Needs approval" not in comment_body
+        assert "Changes detected" in comment_body
 
 
 @cell_silo_test
@@ -373,19 +414,19 @@ class CreateSnapshotPrCommentSoloTest(CreatePreprodSnapshotPrCommentTaskTest):
         assert mock_delay.call_args.kwargs["comment_body"] == "missing body"
 
     @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.post_snapshot_pr_comment_task.delay")
-    @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.build_changes_map")
+    @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.evaluate_snapshot_changes_by_artifact_id")
     @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.get_commit_context_client")
     @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.format_snapshot_pr_comment")
     @patch("sentry.preprod.models.PreprodArtifact.get_base_artifacts_for_commit")
     def test_timeout_with_base_arrived_runs_normal_path(
-        self, mock_get_base, mock_format_normal, mock_get_client, mock_build_changes_map, mock_delay
+        self, mock_get_base, mock_format_normal, mock_get_client, mock_evaluate_changes, mock_delay
     ):
         mock_get_client.return_value = Mock()
         mock_format_normal.return_value = "normal body"
 
         head_artifact, head_metrics = self._create_artifact_with_metrics()
         mock_get_base.return_value = {head_artifact.id: Mock()}
-        mock_build_changes_map.return_value = {head_artifact.id: True}
+        mock_evaluate_changes.return_value = {head_artifact.id: True}
 
         create_preprod_snapshot_pr_comment_task(head_artifact.id, is_timeout_check=True)
 
@@ -394,12 +435,12 @@ class CreateSnapshotPrCommentSoloTest(CreatePreprodSnapshotPrCommentTaskTest):
         assert mock_delay.call_args.kwargs["comment_body"] == "normal body"
 
     @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.post_snapshot_pr_comment_task.delay")
-    @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.build_changes_map")
+    @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.evaluate_snapshot_changes_by_artifact_id")
     @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.get_commit_context_client")
     @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.format_snapshot_pr_comment")
     @patch("sentry.preprod.models.PreprodArtifact.get_base_artifacts_for_commit")
     def test_updates_existing_comment_when_no_changes(
-        self, mock_get_base, mock_format, mock_get_client, mock_build_changes_map, mock_delay
+        self, mock_get_base, mock_format, mock_get_client, mock_evaluate_changes, mock_delay
     ):
         mock_get_client.return_value = Mock()
         mock_format.return_value = "unchanged body"
@@ -419,7 +460,7 @@ class CreateSnapshotPrCommentSoloTest(CreatePreprodSnapshotPrCommentTaskTest):
 
         head_artifact, _ = self._create_artifact_with_metrics(commit_comparison=cc)
         mock_get_base.return_value = {head_artifact.id: Mock()}
-        mock_build_changes_map.return_value = {head_artifact.id: False}
+        mock_evaluate_changes.return_value = {head_artifact.id: False}
 
         create_preprod_snapshot_pr_comment_task(head_artifact.id)
 

--- a/tests/sentry/preprod/vcs/pr_comments/test_snapshot_templates.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_snapshot_templates.py
@@ -304,11 +304,35 @@ class FormatSnapshotPrCommentSuccessTest(SnapshotPrCommentTestBase):
             {head_metrics.id: comparison},
             {head_artifact.id: base_artifact},
             {head_artifact.id: True},
+            approval_requirements_by_artifact_id={head_artifact.id: True},
             project=self.project,
         )
 
         assert "Needs approval" in result
         assert "?selectedTypes=added,removed,changed,renamed" in result
+
+    def test_reported_changes_without_required_approval_show_changes_detected(self) -> None:
+        head_artifact, head_metrics = self._create_artifact_with_metrics()
+        base_artifact, base_metrics = self._create_artifact_with_metrics(app_id="com.example.base")
+        comparison = self._create_comparison(
+            head_metrics,
+            base_metrics,
+            images_added=4,
+            images_unchanged=5,
+        )
+
+        result = format_snapshot_pr_comment(
+            [head_artifact],
+            {head_artifact.id: head_metrics},
+            {head_metrics.id: comparison},
+            {head_artifact.id: base_artifact},
+            {head_artifact.id: True},
+            approval_requirements_by_artifact_id={head_artifact.id: False},
+            project=self.project,
+        )
+
+        assert "Changes detected" in result
+        assert "Needs approval" not in result
 
     def test_approved_shows_approved_status(self) -> None:
         head_artifact, head_metrics = self._create_artifact_with_metrics()
@@ -328,7 +352,8 @@ class FormatSnapshotPrCommentSuccessTest(SnapshotPrCommentTestBase):
             {head_metrics.id: comparison},
             {head_artifact.id: base_artifact},
             {head_artifact.id: True},
-            approvals_map={head_artifact.id: approval},
+            approvals_by_artifact_id={head_artifact.id: approval},
+            approval_requirements_by_artifact_id={head_artifact.id: True},
             project=self.project,
         )
 

--- a/tests/sentry/preprod/vcs/status_checks/snapshots/test_tasks.py
+++ b/tests/sentry/preprod/vcs/status_checks/snapshots/test_tasks.py
@@ -9,7 +9,11 @@ from sentry.integrations.source_code_management.status_check import StatusCheckS
 from sentry.models.commitcomparison import CommitComparison
 from sentry.preprod.models import PreprodArtifact
 from sentry.preprod.snapshots.models import PreprodSnapshotComparison, PreprodSnapshotMetrics
-from sentry.preprod.snapshots.utils import build_changes_map
+from sentry.preprod.snapshots.utils import (
+    SnapshotChangeCriteria,
+    evaluate_snapshot_changes_by_artifact_id,
+)
+from sentry.preprod.vcs.status_checks.snapshots.config import get_snapshot_approval_policy
 from sentry.preprod.vcs.status_checks.snapshots.tasks import (
     _compute_snapshot_status,
     create_preprod_snapshot_status_check_task,
@@ -65,13 +69,59 @@ class SnapshotTasksTestBase(TestCase):
         return artifact, head_metrics, comparison
 
 
+def _criteria(
+    *, added: bool = False, removed: bool = True, changed: bool = True, renamed: bool = False
+) -> SnapshotChangeCriteria:
+    return SnapshotChangeCriteria(
+        added=added,
+        removed=removed,
+        changed=changed,
+        renamed=renamed,
+    )
+
+
+@cell_silo_test
+class SnapshotApprovalPolicyTest(SnapshotTasksTestBase):
+    def test_disabled_status_checks_have_no_approval_criteria(self):
+        self.project.update_option("sentry:preprod_snapshot_status_checks_enabled", False)
+
+        policy = get_snapshot_approval_policy(self.project)
+
+        assert policy.enabled is False
+        assert policy.criteria == SnapshotChangeCriteria(
+            added=False,
+            removed=False,
+            changed=False,
+            renamed=False,
+        )
+
+    def test_enabled_status_checks_use_configured_approval_criteria(self):
+        self.project.update_option("sentry:preprod_snapshot_status_checks_enabled", True)
+        self.project.update_option("sentry:preprod_snapshot_status_checks_fail_on_added", True)
+        self.project.update_option("sentry:preprod_snapshot_status_checks_fail_on_removed", False)
+        self.project.update_option("sentry:preprod_snapshot_status_checks_fail_on_changed", False)
+        self.project.update_option("sentry:preprod_snapshot_status_checks_fail_on_renamed", True)
+
+        policy = get_snapshot_approval_policy(self.project)
+
+        assert policy.enabled is True
+        assert policy.criteria == SnapshotChangeCriteria(
+            added=True,
+            removed=False,
+            changed=False,
+            renamed=True,
+        )
+
+
 @cell_silo_test
 class ComputeSnapshotStatusTest(SnapshotTasksTestBase):
-    def _status_with_changes_map(self, artifact, metrics, approvals=None, **flags):
+    def _status_with_changes_map(self, artifact, metrics, approvals=None, criteria=None):
         artifacts = [artifact]
         metrics_map = {artifact.id: metrics}
         comparisons_map = {metrics.id: _get_comparison(metrics)}
-        changes_map = build_changes_map(artifacts, metrics_map, comparisons_map, **flags)
+        changes_map = evaluate_snapshot_changes_by_artifact_id(
+            artifacts, metrics_map, comparisons_map, criteria or _criteria()
+        )
         return _compute_snapshot_status(
             artifacts, metrics_map, comparisons_map, approvals or {}, changes_map
         )
@@ -83,14 +133,14 @@ class ComputeSnapshotStatusTest(SnapshotTasksTestBase):
     def test_images_added_fails_when_flag_on(self):
         artifact, metrics, _ = self._make_artifact_with_comparison(images_added=5)
         assert (
-            self._status_with_changes_map(artifact, metrics, fail_on_added=True)
+            self._status_with_changes_map(artifact, metrics, criteria=_criteria(added=True))
             == StatusCheckStatus.FAILURE
         )
 
     def test_images_removed_ignored_when_flag_off(self):
         artifact, metrics, _ = self._make_artifact_with_comparison(images_removed=3)
         assert (
-            self._status_with_changes_map(artifact, metrics, fail_on_removed=False)
+            self._status_with_changes_map(artifact, metrics, criteria=_criteria(removed=False))
             == StatusCheckStatus.SUCCESS
         )
 
@@ -105,7 +155,7 @@ class ComputeSnapshotStatusTest(SnapshotTasksTestBase):
     def test_images_changed_ignored_when_flag_off(self):
         artifact, metrics, _ = self._make_artifact_with_comparison(images_changed=2)
         assert (
-            self._status_with_changes_map(artifact, metrics, fail_on_changed=False)
+            self._status_with_changes_map(artifact, metrics, criteria=_criteria(changed=False))
             == StatusCheckStatus.SUCCESS
         )
 
@@ -116,7 +166,7 @@ class ComputeSnapshotStatusTest(SnapshotTasksTestBase):
     def test_images_renamed_fails_when_flag_on(self):
         artifact, metrics, _ = self._make_artifact_with_comparison(images_renamed=1)
         assert (
-            self._status_with_changes_map(artifact, metrics, fail_on_renamed=True)
+            self._status_with_changes_map(artifact, metrics, criteria=_criteria(renamed=True))
             == StatusCheckStatus.FAILURE
         )
 
@@ -126,72 +176,84 @@ class ComputeSnapshotStatusTest(SnapshotTasksTestBase):
 
 
 @cell_silo_test
-class BuildChangesMapTest(SnapshotTasksTestBase):
+class EvaluateSnapshotChangesByArtifactIdTest(SnapshotTasksTestBase):
     def test_added_ignored_when_flag_off(self):
         artifact, metrics, _ = self._make_artifact_with_comparison(images_added=5)
-        changes_map = build_changes_map(
-            [artifact], {artifact.id: metrics}, {metrics.id: _get_comparison(metrics)}
+        changes_map = evaluate_snapshot_changes_by_artifact_id(
+            [artifact],
+            {artifact.id: metrics},
+            {metrics.id: _get_comparison(metrics)},
+            _criteria(),
         )
         assert not any(changes_map.values())
 
     def test_added_detected_when_flag_on(self):
         artifact, metrics, _ = self._make_artifact_with_comparison(images_added=5)
-        changes_map = build_changes_map(
+        changes_map = evaluate_snapshot_changes_by_artifact_id(
             [artifact],
             {artifact.id: metrics},
             {metrics.id: _get_comparison(metrics)},
-            fail_on_added=True,
+            _criteria(added=True),
         )
         assert changes_map[artifact.id] is True
 
     def test_removed_ignored_when_flag_off(self):
         artifact, metrics, _ = self._make_artifact_with_comparison(images_removed=3)
-        changes_map = build_changes_map(
+        changes_map = evaluate_snapshot_changes_by_artifact_id(
             [artifact],
             {artifact.id: metrics},
             {metrics.id: _get_comparison(metrics)},
-            fail_on_removed=False,
+            _criteria(removed=False),
         )
         assert not any(changes_map.values())
 
     def test_removed_detected_by_default(self):
         artifact, metrics, _ = self._make_artifact_with_comparison(images_removed=3)
-        changes_map = build_changes_map(
-            [artifact], {artifact.id: metrics}, {metrics.id: _get_comparison(metrics)}
+        changes_map = evaluate_snapshot_changes_by_artifact_id(
+            [artifact],
+            {artifact.id: metrics},
+            {metrics.id: _get_comparison(metrics)},
+            _criteria(),
         )
         assert changes_map[artifact.id] is True
 
     def test_changed_detected_by_default(self):
         artifact, metrics, _ = self._make_artifact_with_comparison(images_changed=2)
-        changes_map = build_changes_map(
-            [artifact], {artifact.id: metrics}, {metrics.id: _get_comparison(metrics)}
+        changes_map = evaluate_snapshot_changes_by_artifact_id(
+            [artifact],
+            {artifact.id: metrics},
+            {metrics.id: _get_comparison(metrics)},
+            _criteria(),
         )
         assert changes_map[artifact.id] is True
 
     def test_changed_ignored_when_flag_off(self):
         artifact, metrics, _ = self._make_artifact_with_comparison(images_changed=2)
-        changes_map = build_changes_map(
+        changes_map = evaluate_snapshot_changes_by_artifact_id(
             [artifact],
             {artifact.id: metrics},
             {metrics.id: _get_comparison(metrics)},
-            fail_on_changed=False,
+            _criteria(changed=False),
         )
         assert not any(changes_map.values())
 
     def test_renamed_ignored_by_default(self):
         artifact, metrics, _ = self._make_artifact_with_comparison(images_renamed=1)
-        changes_map = build_changes_map(
-            [artifact], {artifact.id: metrics}, {metrics.id: _get_comparison(metrics)}
+        changes_map = evaluate_snapshot_changes_by_artifact_id(
+            [artifact],
+            {artifact.id: metrics},
+            {metrics.id: _get_comparison(metrics)},
+            _criteria(),
         )
         assert not any(changes_map.values())
 
     def test_renamed_detected_when_flag_on(self):
         artifact, metrics, _ = self._make_artifact_with_comparison(images_renamed=1)
-        changes_map = build_changes_map(
+        changes_map = evaluate_snapshot_changes_by_artifact_id(
             [artifact],
             {artifact.id: metrics},
             {metrics.id: _get_comparison(metrics)},
-            fail_on_renamed=True,
+            _criteria(renamed=True),
         )
         assert changes_map[artifact.id] is True
 
@@ -254,8 +316,11 @@ class SnapshotStatusCheckWithSkippedTest(SnapshotTasksTestBase):
         comparison.images_skipped = 100
         comparison.save(update_fields=["images_skipped"])
 
-        changes_map = build_changes_map(
-            [artifact], {artifact.id: metrics}, {metrics.id: comparison}
+        changes_map = evaluate_snapshot_changes_by_artifact_id(
+            [artifact],
+            {artifact.id: metrics},
+            {metrics.id: comparison},
+            _criteria(),
         )
         assert changes_map[artifact.id] is False
 


### PR DESCRIPTION
Snapshot PR comments now derive approval requirements from the same effective policy as the snapshot status check. A reportable change only displays **Needs approval** when status checks are enabled and that change category is configured to fail; otherwise the comment displays **Changes detected**.

This keeps PR-comment reporting preferences independent from approval policy while sharing the underlying change evaluator. It also covers disabled status checks and differing reporting/approval criteria with behavioral tests.

Refs EME-1249
