### PR TITLE
fix(explore): Correct grammar in missing-replay tooltip

### DIFF
--- a/static/app/utils/discover/viewReplayLink.tsx
+++ b/static/app/utils/discover/viewReplayLink.tsx
@@ -25,7 +25,7 @@ export function ViewReplayLink({
     return (
       <Tooltip
         title={t(
-          'This replay may been rate-limited, deleted, or not stored due to the error-based replay sampling rate.'
+          'This replay may have been rate-limited, deleted, or not stored due to the error-based replay sampling rate.'
         )}
       >
         <EmptyValueContainer>{t('(missing)')}</EmptyValueContainer>


### PR DESCRIPTION
Lil grammar fix I found as part of LOGS-580.