### PR TITLE
fix(seer): Hide autofix review cards without a valid PR [will revert soon]

### DIFF
--- a/static/app/views/seerWorkflows/overview/buildOverviewRows.ts
+++ b/static/app/views/seerWorkflows/overview/buildOverviewRows.ts
@@ -88,6 +88,10 @@ function extractPr(
   return pr ? {prUrl: pr.pr_url ?? undefined, prNumber: pr.pr_number ?? undefined} : {};
 }
 
+export function hasValidPr(state: ExplorerAutofixState | null): boolean {
+  return Boolean(extractPr(state).prUrl);
+}
+
 // The pending-input payload is untyped (Record<string, unknown>). The canonical
 // ask_user_question shape is {questions: [{question, options}]} (see
 // usePendingUserInput's AskUserQuestionData); fall back to a flat key otherwise.

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -165,8 +165,8 @@ describe('AutofixOverview', () => {
       body: [ProjectFixture()],
     });
 
-    // One issue lives in the review bucket (X-Hits 3 exceeds the returned
-    // body, proving the count comes from the header); the other four are empty.
+    // One issue lives in the review bucket (its count reflects the rendered
+    // valid-PR cards, not the X-Hits header); the other four are empty.
     mockSection(SECTION_QUERIES.review_pr, {body: [issue], hits: '3'});
     mockSection(SECTION_QUERIES.code_changes_ready);
     mockSection(SECTION_QUERIES.solution_ready);
@@ -205,9 +205,11 @@ describe('AutofixOverview', () => {
   it('renders the five status sections with server-provided counts', async () => {
     renderPage();
 
-    // Every section renders, in order, with its X-Hits count in the badge.
+    // Every section renders, in order. The review bucket counts only its
+    // cards with a real PR behind them (here 1, despite X-Hits 3); the other
+    // buckets show their X-Hits count.
     const reviewHeader = await screen.findByRole('button', {
-      name: 'Awaiting your review 3',
+      name: 'Awaiting your review 1',
     });
     expect(
       screen.getByRole('button', {name: 'Code changes ready 0'})
@@ -410,7 +412,7 @@ describe('AutofixOverview', () => {
     renderPage();
 
     const reviewHeader = await screen.findByRole('button', {
-      name: 'Awaiting your review 3',
+      name: 'Awaiting your review 1',
     });
     expect(
       await screen.findByRole('link', {
@@ -459,7 +461,7 @@ describe('AutofixOverview', () => {
     many.forEach(group => {
       MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/issues/${group.id}/autofix/`,
-        body: {autofix: null},
+        body: {autofix: makeAutofixState()},
       });
     });
     mockSection(SECTION_QUERIES.review_pr, {body: many, hits: '30'});
@@ -476,13 +478,40 @@ describe('AutofixOverview', () => {
   it('caps the section count badge at 100+ when hits exceed the fetch limit', async () => {
     // Only 100 issues are ever fetched per section, so an exact total above
     // that would overstate what scrolling can reveal.
-    mockSection(SECTION_QUERIES.review_pr, {body: [issue], hits: '150'});
+    mockSection(SECTION_QUERIES.code_changes_ready, {body: [issue], hits: '150'});
 
     renderPage();
 
     expect(
-      await screen.findByRole('button', {name: 'Awaiting your review 100+'})
+      await screen.findByRole('button', {name: 'Code changes ready 100+'})
     ).toBeInTheDocument();
+  });
+
+  it('hides review cards without a valid PR and counts only the rest', async () => {
+    const invalidIssue = GroupFixture({
+      id: '5',
+      shortId: 'PROJ-5',
+      title: 'Run with no PR behind it',
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/5/autofix/`,
+      body: {autofix: makeAutofixState({repo_pr_states: {}})},
+    });
+    mockSection(SECTION_QUERIES.review_pr, {body: [issue, invalidIssue], hits: '2'});
+
+    renderPage();
+
+    expect(
+      await screen.findByRole('button', {name: 'Awaiting your review 1'})
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole('link', {
+        name: 'Proxy requests fail without Authorization header',
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', {name: 'Run with no PR behind it'})
+    ).not.toBeInTheDocument();
   });
 
   it('surfaces the blocking question when a run awaits user input', async () => {

--- a/static/app/views/seerWorkflows/overview/sectionList.tsx
+++ b/static/app/views/seerWorkflows/overview/sectionList.tsx
@@ -18,6 +18,7 @@ import {SectionIssueCard} from './sectionIssueCard';
 import {STATUS_GROUP_META, StatusGroupTooltip, type StatusGroupKey} from './statusGroups';
 import type {OverviewView, SortValue} from './types';
 import {SECTION_LIMIT, useAutofixSections} from './useAutofixSections';
+import {useValidPrIssues} from './useValidPrIssues';
 
 function formatSectionCount(count: number | undefined) {
   if (count === undefined) {
@@ -52,6 +53,18 @@ export function SectionList({
     statsPeriod: period,
   });
 
+  // Cards in the review bucket sometimes have no PR behind them (the run's
+  // PR creation never completed). Hide those and count only what's left; the
+  // per-issue state queries here share cache keys with the cards' own
+  // enrichment, so nothing is fetched twice.
+  const reviewPrSection = sections.find(section => section.key === 'review_pr');
+  const {validIssues, isPending: prFilterPending} = useValidPrIssues({
+    enabled: Boolean(
+      enabled && reviewPrSection && !reviewPrSection.isPending && !reviewPrSection.isError
+    ),
+    issues: reviewPrSection?.issues ?? [],
+  });
+
   const firstLoad = isPending && sections.every(section => section.isPending);
   const allSectionsEmpty = sections.every(
     section => !section.isPending && !section.isError && section.issues.length === 0
@@ -82,6 +95,15 @@ export function SectionList({
       {sections.map(section => {
         const meta = STATUS_GROUP_META[section.key];
         const expanded = !collapsedGroups.includes(section.key);
+        const isReviewPr = section.key === 'review_pr';
+        const issues = isReviewPr ? validIssues : section.issues;
+        const count = isReviewPr
+          ? prFilterPending
+            ? undefined
+            : issues.length
+          : section.count;
+        const contentPending =
+          section.isPending || (isReviewPr && prFilterPending && issues.length === 0);
         return (
           <StatusGroup
             key={section.key}
@@ -100,16 +122,16 @@ export function SectionList({
                     <meta.Icon size="sm" aria-hidden />
                   </Tooltip>
                   <Text bold>{meta.label}</Text>
-                  <Badge variant="muted">{formatSectionCount(section.count)}</Badge>
+                  <Badge variant="muted">{formatSectionCount(count)}</Badge>
                 </Flex>
               </Disclosure.Title>
             </GroupHeader>
             <Disclosure.Content data-view={view}>
               {section.isError ? (
                 <LoadingError onRetry={section.refetch} />
-              ) : section.isPending ? (
+              ) : contentPending ? (
                 <LoadingIndicator />
-              ) : section.issues.length === 0 ? (
+              ) : issues.length === 0 ? (
                 <Container padding="md">
                   <Text as="p" variant="muted" size="sm">
                     {t('No issues')}
@@ -121,7 +143,7 @@ export function SectionList({
                   paddingTop={view === 'cards' ? 'sm' : '0'}
                   data-view={view}
                 >
-                  {section.issues.map(issue => (
+                  {issues.map(issue => (
                     <SectionIssueCard
                       key={issue.id}
                       issue={issue}

--- a/static/app/views/seerWorkflows/overview/useValidPrIssues.tsx
+++ b/static/app/views/seerWorkflows/overview/useValidPrIssues.tsx
@@ -1,0 +1,40 @@
+import {useQueries} from '@tanstack/react-query';
+
+import type {ExplorerAutofixState} from 'sentry/components/events/autofix/useExplorerAutofix';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+import {hasValidPr} from './buildOverviewRows';
+import {type OverviewIssue, QUERY_STALE_TIME} from './types';
+
+export function useValidPrIssues({
+  enabled,
+  issues,
+}: {
+  enabled: boolean;
+  issues: OverviewIssue[];
+}) {
+  const organization = useOrganization();
+
+  const results = useQueries({
+    queries: issues.map(issue => ({
+      ...apiOptions.as<{autofix: ExplorerAutofixState | null}>()(
+        '/organizations/$organizationIdOrSlug/issues/$issueId/autofix/',
+        {
+          path: {organizationIdOrSlug: organization.slug, issueId: issue.id},
+          query: {mode: 'explorer'},
+          staleTime: QUERY_STALE_TIME,
+        }
+      ),
+      enabled,
+    })),
+  });
+
+  return {
+    isPending: enabled && results.some(result => result.isPending),
+    validIssues: issues.filter((_, index) => {
+      const result = results[index]!;
+      return result.data ? hasValidPr(result.data.autofix) : false;
+    }),
+  };
+}


### PR DESCRIPTION
> [!WARNING]
> **Temporary mitigation — intended to be rolled back.** This papers over runs in the review bucket that have no PR behind them while the root cause (PR creation not completing for some runs) is investigated. Once that's fixed at the source, revert this.

## Description

On `/issues/autofix/overview`, some cards in the **Awaiting your review** section have no valid pull request behind them: the run's `repo_pr_states` never reached a completed PR with a URL, so the "Review PR" button silently falls back to linking the issue page instead of GitHub.

Until the underlying cause is fixed, this filters those cards out of the section:

- New `useValidPrIssues` hook eagerly fetches each review-bucket issue's autofix state (`/issues/$id/autofix/?mode=explorer`) and keeps only issues with a completed PR URL — the same `extractPr` condition the Review PR button uses (via a new `hasValidPr` helper), so the filter and the button can't disagree. The queries share cache keys with the cards' own enrichment, so nothing is fetched twice.
- The section's badge now counts the cards that actually render instead of the server's `X-Hits` total, showing `…` until the state queries settle. Other sections keep their server counts.

Trade-offs, accepted for a stopgap: the review section fires its per-issue state requests upfront rather than lazily on scroll, and if the section ever exceeds the 100-issue fetch limit the badge reflects only the fetched page (no `100+` for this section).