### PR TITLE
ref(issues): Pin progress tag right on the culprit row per design

### DIFF
--- a/static/app/views/issueDetails/issuePreview/issuePreview.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreview.tsx
@@ -118,7 +118,9 @@ function IssuePreviewContent() {
             />
           </Container>
           <Flex justify="between" align="center" gap="md">
-            <GroupStatusSubtitle group={group} project={project} />
+            <Flex flex="1" minWidth={0}>
+              <GroupStatusSubtitle group={group} project={project} />
+            </Flex>
             {group.derivedData?.progress && (
               <IssueProgressTag state={group.derivedData.progress} />
             )}


### PR DESCRIPTION
Follow-up to the merged issue-preview progress work (#120454), matching the Figma design.

The design places the progress tag right-aligned on the status/culprit row, with the status text growing and truncating and the tag pinned to the right (`flex: 1 0 0` text + `shrink-0` tag). The current markup put `GroupStatusSubtitle` and the tag as direct `justify="between"` siblings, so a long status line could squeeze the tag instead of truncating.

Wrap `GroupStatusSubtitle` in a growing `Flex flex="1" minWidth={0}` so it truncates cleanly and the `IssueProgressTag` stays pinned right, per the design.