### PR TITLE
feat(dashboards): Use canvas rendering for Heat Map and Categorical Bar widgets

### DIFF
--- a/static/app/views/dashboards/widgets/categoricalSeriesWidget/categoricalSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/categoricalSeriesWidget/categoricalSeriesWidgetVisualization.tsx
@@ -376,6 +376,7 @@ export function CategoricalSeriesWidgetVisualization(
     <BaseChart
       ref={mergeRefs(props.ref, props.chartRef, chartRef, handleChartRef)}
       autoHeightResize
+      renderer="canvas"
       series={seriesFromPlottables}
       legend={
         showLegend

--- a/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
@@ -324,6 +324,7 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
     <Stack height="100%">
       <BaseChart
         autoHeightResize
+        renderer="canvas"
         // will be grouped by date as we only support time as the x-axis right now.
         // TODO(nikki): eventually this might change and we'll pass in what kind of x-axis we have
         isGroupedByDate


### PR DESCRIPTION
Switch the Heat Map and Categorical Bar Chart widget visualizations to the ECharts `canvas` rendering. I did the same for time series charts in https://github.com/getsentry/sentry/pull/120208 and it went well. No sense having different rendering strategies for different Dashboards widgets!

Closes DAIN-1809