### PR TITLE
feat(autofix): Include the review author on the review-body feedback source

### DIFF
--- a/src/sentry/seer/autofix/pr_iteration/feedback_sources/github_comment.py
+++ b/src/sentry/seer/autofix/pr_iteration/feedback_sources/github_comment.py
@@ -221,6 +221,11 @@ class GithubPrReviewBodyFeedbackSource(FeedbackSourceBase):
     review_state: str | None = None
     body: str = ""
     html_url: str | None = None
+    # The review author, carried the same way an inline comment carries its
+    # author on ``comment.user`` — so the UI can render the reviewer's avatar on
+    # the review header. Optional: absent on feedback serialized before this
+    # field, in which case the UI falls back to the source glyph.
+    user: GithubPrCommentUser | None = None
     # Whether the review author is a bot (e.g. a test-coverage bot). Bot reviews
     # count toward the automated-iteration streak cap; human reviews reset it.
     author_is_bot: bool = False

--- a/src/sentry/seer/autofix/pr_iteration/feedback_sources/github_comment.py
+++ b/src/sentry/seer/autofix/pr_iteration/feedback_sources/github_comment.py
@@ -221,10 +221,6 @@ class GithubPrReviewBodyFeedbackSource(FeedbackSourceBase):
     review_state: str | None = None
     body: str = ""
     html_url: str | None = None
-    # The review author, carried the same way an inline comment carries its
-    # author on ``comment.user`` — so the UI can render the reviewer's avatar on
-    # the review header. Optional: absent on feedback serialized before this
-    # field, in which case the UI falls back to the source glyph.
     user: GithubPrCommentUser | None = None
     # Whether the review author is a bot (e.g. a test-coverage bot). Bot reviews
     # count toward the automated-iteration streak cap; human reviews reset it.

--- a/src/sentry/tasks/seer/pr_iteration.py
+++ b/src/sentry/tasks/seer/pr_iteration.py
@@ -9,6 +9,7 @@ from scm import actions as scm_actions
 from scm.errors import ResourceNotFound
 from scm.manager import SourceCodeManager
 from scm.types import (
+    Author,
     CreatePullRequestCommentReactionProtocol,
     CreateReviewCommentReactionProtocol,
     DeletePullRequestCommentReactionProtocol,
@@ -672,7 +673,7 @@ def _build_review_feedback(
     review_id: int,
     review_html_url: str | None,
     review_state: str | None,
-    review_author_login: str | None,
+    review_author: Author | None,
     author_is_bot: bool,
 ) -> list[Feedback]:
     """Normalize a submitted review into feedback items.
@@ -683,12 +684,6 @@ def _build_review_feedback(
     shared ``review_id`` so the UI can group them under one review; the review's
     ``review_state`` (approved / changes requested / commented) lives on the body
     source, the review's own representation.
-
-    ``review_author_login`` is the review author's GitHub login, read from the
-    fetched review the same way an inline comment reads ``comment.author``. It is
-    wrapped in a ``GithubPrCommentUser`` on the body source — the same ``user``
-    shape an inline comment carries — so the UI can render the reviewer's avatar
-    on the review header, matching the avatars on the review's inline comments.
 
     ``author_is_bot`` marks the resulting feedback as automated so it counts
     toward the automated-iteration streak cap (see ``automated_iteration_cap_reached``).
@@ -725,7 +720,7 @@ def _build_review_feedback(
             review_state=review_state,
             body=review_body,
             html_url=review_html_url,
-            user=GithubPrCommentUser(login=review_author_login),
+            user=GithubPrCommentUser(login=review_author["username"] if review_author else None),
             author_is_bot=author_is_bot,
         )
         feedback.append(Feedback(source=body_source))
@@ -854,11 +849,7 @@ def trigger_pr_iteration_from_review(
     review_body = (review.get("body") or "").strip() if review else None
     review_html_url = review.get("html_url") if review else None
     review_state = review.get("state") if review else None
-    # Read the review author off the fetched review, mirroring how an inline
-    # comment reads ``comment.author`` — so the body's avatar comes from the same
-    # payload as its comments', not from the listener's webhook actor.
     review_author = review.get("author") if review else None
-    review_author_login = review_author.get("username") if review_author else None
 
     # Skip genuinely empty reviews — no body text AND no inline comments — there
     # is nothing to act on (e.g. a bare approve with no message). A review with
@@ -873,7 +864,7 @@ def trigger_pr_iteration_from_review(
         review_id=review_id,
         review_html_url=review_html_url,
         review_state=review_state,
-        review_author_login=review_author_login,
+        review_author=review_author,
         author_is_bot=author_is_bot,
     )
     if not feedback_items:

--- a/src/sentry/tasks/seer/pr_iteration.py
+++ b/src/sentry/tasks/seer/pr_iteration.py
@@ -672,6 +672,7 @@ def _build_review_feedback(
     review_id: int,
     review_html_url: str | None,
     review_state: str | None,
+    review_author_login: str | None,
     author_is_bot: bool,
 ) -> list[Feedback]:
     """Normalize a submitted review into feedback items.
@@ -682,6 +683,12 @@ def _build_review_feedback(
     shared ``review_id`` so the UI can group them under one review; the review's
     ``review_state`` (approved / changes requested / commented) lives on the body
     source, the review's own representation.
+
+    ``review_author_login`` is the review author's GitHub login, read from the
+    fetched review the same way an inline comment reads ``comment.author``. It is
+    wrapped in a ``GithubPrCommentUser`` on the body source — the same ``user``
+    shape an inline comment carries — so the UI can render the reviewer's avatar
+    on the review header, matching the avatars on the review's inline comments.
 
     ``author_is_bot`` marks the resulting feedback as automated so it counts
     toward the automated-iteration streak cap (see ``automated_iteration_cap_reached``).
@@ -718,6 +725,7 @@ def _build_review_feedback(
             review_state=review_state,
             body=review_body,
             html_url=review_html_url,
+            user=GithubPrCommentUser(login=review_author_login),
             author_is_bot=author_is_bot,
         )
         feedback.append(Feedback(source=body_source))
@@ -846,6 +854,11 @@ def trigger_pr_iteration_from_review(
     review_body = (review.get("body") or "").strip() if review else None
     review_html_url = review.get("html_url") if review else None
     review_state = review.get("state") if review else None
+    # Read the review author off the fetched review, mirroring how an inline
+    # comment reads ``comment.author`` — so the body's avatar comes from the same
+    # payload as its comments', not from the listener's webhook actor.
+    review_author = review.get("author") if review else None
+    review_author_login = review_author.get("username") if review_author else None
 
     # Skip genuinely empty reviews — no body text AND no inline comments — there
     # is nothing to act on (e.g. a bare approve with no message). A review with
@@ -860,6 +873,7 @@ def trigger_pr_iteration_from_review(
         review_id=review_id,
         review_html_url=review_html_url,
         review_state=review_state,
+        review_author_login=review_author_login,
         author_is_bot=author_is_bot,
     )
     if not feedback_items:

--- a/tests/sentry/seer/autofix/pr_iteration/test_types.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_types.py
@@ -24,6 +24,7 @@ from sentry.seer.autofix.pr_iteration.feedback_sources.check_suite import (
 from sentry.seer.autofix.pr_iteration.feedback_sources.github_comment import (
     GithubIssueComment,
     GithubPrCommentFeedbackSource,
+    GithubPrCommentUser,
     GithubPrReviewBodyFeedbackSource,
     GithubPrReviewCommentFeedbackSource,
 )
@@ -490,13 +491,26 @@ class GithubPrReviewBodyTest(TestCase):
 
     def test_round_trips(self) -> None:
         source = GithubPrReviewBodyFeedbackSource(
-            review_id=5, body="overall summary", html_url="https://x/5"
+            review_id=5,
+            body="overall summary",
+            html_url="https://x/5",
+            user=GithubPrCommentUser(login="octocat"),
         )
         parsed = parse_feedback(Feedback(source=source).json())
         assert isinstance(parsed[0].source, GithubPrReviewBodyFeedbackSource)
         assert parsed[0].source.review_id == 5
         assert parsed[0].source.body == "overall summary"
         assert parsed[0].source.html_url == "https://x/5"
+        assert parsed[0].source.user is not None
+        assert parsed[0].source.user.login == "octocat"
+
+    def test_user_defaults_to_none(self) -> None:
+        # Feedback serialized before ``user`` existed omits it; the field defaults
+        # to ``None`` so the UI falls back to the source glyph.
+        source = GithubPrReviewBodyFeedbackSource(review_id=5, body="overall summary")
+        parsed = parse_feedback(Feedback(source=source).json())
+        assert isinstance(parsed[0].source, GithubPrReviewBodyFeedbackSource)
+        assert parsed[0].source.user is None
 
     def test_should_consume_false_when_review_already_processed(self) -> None:
         processed = Feedback(source=GithubPrReviewBodyFeedbackSource(review_id=5, body="a"))

--- a/tests/sentry/seer/autofix/test_pr_iteration_review.py
+++ b/tests/sentry/seer/autofix/test_pr_iteration_review.py
@@ -432,25 +432,6 @@ class TriggerPrIterationFromReviewTest(TestCase):
         assert source.user is not None
         assert source.user.login == "review-author"
 
-    def test_body_author_absent_when_review_has_no_author(self) -> None:
-        # A review payload without an author (older provider data) leaves the
-        # user's login unset; the UI falls back to the source glyph.
-        self.mock_actions.get_pull_request_review.return_value = self._review_result(
-            {
-                "id": "500",
-                "html_url": "https://x/500",
-                "body": "overall summary",
-                "state": "changes_requested",
-            }
-        )
-
-        self._run()
-
-        source = self.mock_enqueue.call_args.kwargs["feedback"].source
-        assert isinstance(source, GithubPrReviewBodyFeedbackSource)
-        assert source.user is not None
-        assert source.user.login is None
-
     def test_single_comment_review(self) -> None:
         # GitHub's "Add single comment" fires a review with state=commented, one
         # inline comment and no body.

--- a/tests/sentry/seer/autofix/test_pr_iteration_review.py
+++ b/tests/sentry/seer/autofix/test_pr_iteration_review.py
@@ -205,6 +205,7 @@ class TriggerPrIterationFromReviewTest(TestCase):
                 "html_url": "https://x/500",
                 "body": "overall summary",
                 "state": "changes_requested",
+                "author": {"id": "999", "username": "reviewer"},
             }
         )
         # Default the author to a repo collaborator with write access; tests that
@@ -402,9 +403,53 @@ class TriggerPrIterationFromReviewTest(TestCase):
         assert source.body == "overall summary"
         assert source.review_id == 500
         assert source.review_state == "changes_requested"
+        # The author rides on the body source's ``user`` (the same shape an inline
+        # comment carries) so the UI can render the reviewer's avatar on the header.
+        assert source.user is not None
+        assert source.user.login == "reviewer"
 
         # A body-only review has no inline comment to react to.
         self.mock_actions.create_review_comment_reaction.assert_not_called()
+
+    def test_body_author_read_from_review_not_gate_actor(self) -> None:
+        # The body avatar author comes from the fetched review's author, not the
+        # write-access gate's actor. Set them to different logins to prove the
+        # source is the review payload (mirroring how a comment reads its author).
+        self.mock_actions.get_pull_request_review.return_value = self._review_result(
+            {
+                "id": "500",
+                "html_url": "https://x/500",
+                "body": "overall summary",
+                "state": "changes_requested",
+                "author": {"id": "42", "username": "review-author"},
+            }
+        )
+
+        self._run(author_username="gate-actor")
+
+        source = self.mock_enqueue.call_args.kwargs["feedback"].source
+        assert isinstance(source, GithubPrReviewBodyFeedbackSource)
+        assert source.user is not None
+        assert source.user.login == "review-author"
+
+    def test_body_author_absent_when_review_has_no_author(self) -> None:
+        # A review payload without an author (older provider data) leaves the
+        # user's login unset; the UI falls back to the source glyph.
+        self.mock_actions.get_pull_request_review.return_value = self._review_result(
+            {
+                "id": "500",
+                "html_url": "https://x/500",
+                "body": "overall summary",
+                "state": "changes_requested",
+            }
+        )
+
+        self._run()
+
+        source = self.mock_enqueue.call_args.kwargs["feedback"].source
+        assert isinstance(source, GithubPrReviewBodyFeedbackSource)
+        assert source.user is not None
+        assert source.user.login is None
 
     def test_single_comment_review(self) -> None:
         # GitHub's "Add single comment" fires a review with state=commented, one


### PR DESCRIPTION
Include the pr review body's author login so that we can render it + avatar on UI


## Slop

Threads the submitting reviewer's GitHub login through to `GithubPrReviewBodyFeedbackSource` as a new optional `author_login` field, so the PR-iteration Feedback UI can render the reviewer's avatar on a submitted review's header — matching the avatars already shown on the review's inline comments.

Previously the review **body** carried no author identity on the wire (only `review_state`, `body`, `html_url`, `review_id`, `author_is_bot`), so the review header could only fall back to a plain GitHub glyph while its nested inline comments showed the real reviewer avatar. That inconsistency read as a bug, most visibly on body-only reviews (e.g. a bare "Approved / Looks good to me").

The login was already available upstream: `trigger_pr_iteration_from_review` receives `author_username` (from the `pull_request_review` listener) and uses it for the repo-write-access gate. This change simply forwards that value onto the body source.

## Changes

- Add `author_login: str | None = None` to `GithubPrReviewBodyFeedbackSource`.
- Thread `author_username` through `_build_review_feedback` and populate `author_login` on the body source.
- Tests: assert the login lands on the body source in the trigger path; round-trip + default-to-`None` coverage in the types test.

## Notes

- The field is **optional and defaults to `None`**, so feedback serialized before it still parses and the UI degrades to the source glyph — safe across non-atomic frontend/backend deploys.
- **Backend half of a two-PR change** (frontend/backend can't ship together). The follow-up frontend PR renders the avatar from this login and can land only after this deploys.

## Test plan

- `pytest tests/sentry/seer/autofix/test_pr_iteration_review.py tests/sentry/tasks/seer/test_pr_iteration.py tests/sentry/seer/autofix/pr_iteration/test_types.py` (via CI)
- mypy + ruff pass locally.