### PR TITLE
feat(gdd): Switch heal_stale_derived_data to build-and-promote path

### DIFF
--- a/src/sentry/issues/derived/tasks.py
+++ b/src/sentry/issues/derived/tasks.py
@@ -1,8 +1,17 @@
+from __future__ import annotations
+
 import logging
 import time
 from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING
+
+from django.db.models import Exists, OuterRef, Q, QuerySet
 
 from sentry.silo.base import SiloMode
+
+if TYPE_CHECKING:
+    from sentry.models.group import Group
+
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import issues_tasks
 from sentry.utils import metrics
@@ -20,6 +29,21 @@ _GENERATE_GROUP_TASK_KEY = "generate_group_derived_data"
 _MAX_GENERATION_RUNS = 20
 # Hard limit on group IDs loaded per project-level task to bound memory.
 _MAX_PROJECT_GROUPS = 10_000
+
+
+def _stale_pipeline_filter(qs: QuerySet[Group], pipeline_hash: str) -> QuerySet[Group]:
+    """Filter a Group queryset to only groups with a stale or NULL pipeline_hash."""
+    from sentry.issues.models.groupderiveddata import GroupDerivedData
+
+    return qs.filter(
+        Exists(
+            GroupDerivedData.objects.filter(
+                group_id=OuterRef("id"),
+            ).exclude(
+                pipeline_hash=pipeline_hash,
+            )
+        )
+    )
 
 
 @instrumented_task(
@@ -132,8 +156,6 @@ def process_project_derived_data(
     When *use_pipeline_hash* is True, also includes groups whose
     GroupDerivedData has a stale pipeline_hash.
     """
-    from django.db.models import Exists, OuterRef, Q
-
     from sentry import options
     from sentry.issues.derived.processing import PIPELINE
     from sentry.issues.models.groupderiveddata import GroupDerivedData
@@ -343,25 +365,30 @@ def process_project_derived_data_batch(
     namespace=issues_tasks,
     silo_mode=SiloMode.CELL,
 )
-def generate_project_derived_data(project_id: int, **kwargs: object) -> None:
-    """Generate derived data for every group in a project.
+def generate_project_derived_data(
+    project_id: int, *, stale_only: bool = False, **kwargs: object
+) -> None:
+    """Generate derived data for groups in a project via build-and-promote.
 
-    Partitions groups into ID ranges and fans out a batch task for each
-    range. Each batch calls ``build_and_promote_derived_data`` per group,
-    which replaces existing rows via CAS while they continue serving reads.
+    Fans out ``build_and_promote_derived_data`` batches, which replace
+    existing rows via CAS without deleting them.
+
+    When *stale_only* is True, only groups with a ``GroupDerivedData``
+    row whose ``pipeline_hash`` is outdated or NULL are included.
+    Groups without a row are not affected.
     """
     from sentry import options
+    from sentry.issues.derived.processing import PIPELINE
     from sentry.models.group import Group
 
     batch_size = options.get("issues.derived.project-batch-size")
     max_tasks = options.get("issues.derived.project-max-tasks")
 
     # TODO: support very large projects via paginated iteration
-    group_ids = list(
-        Group.objects.filter(project_id=project_id)
-        .order_by("id")
-        .values_list("id", flat=True)[:_MAX_PROJECT_GROUPS]
-    )
+    qs = Group.objects.filter(project_id=project_id)
+    if stale_only:
+        qs = _stale_pipeline_filter(qs, PIPELINE.pipeline_hash)
+    group_ids = list(qs.order_by("id").values_list("id", flat=True)[:_MAX_PROJECT_GROUPS])
 
     if not group_ids:
         return
@@ -395,6 +422,7 @@ def generate_project_derived_data(project_id: int, **kwargs: object) -> None:
             project_id=project_id,
             group_id_start=start,
             group_id_end=end,
+            stale_only=stale_only,
         )
 
     logger.info(
@@ -419,6 +447,8 @@ def generate_project_derived_data_batch(
     group_id_end: int,
     resume_generated_at: str | None = None,
     resume_pipeline_hash: str | None = None,
+    *,
+    stale_only: bool = False,
     **kwargs: object,
 ) -> None:
     """Generate derived data for groups in [group_id_start, group_id_end).
@@ -427,10 +457,14 @@ def generate_project_derived_data_batch(
     remaining range on per-group or batch timeout. On per-group timeout,
     the generation_id is passed through so the next run resumes from
     cached partial progress.
+
+    When *stale_only* is True, only groups with a ``GroupDerivedData``
+    row whose ``pipeline_hash`` is outdated or NULL are processed.
     """
     from taskbroker_client.state import current_task
 
     from sentry.issues.derived.processing import (
+        PIPELINE,
         GenerationId,
         GroupLogTimeout,
         PromotionFailed,
@@ -464,15 +498,14 @@ def generate_project_derived_data_batch(
     timeout_seconds = BATCH_RETRIGGER_TIMEOUT.total_seconds()
     start = time.monotonic()
 
-    group_ids = list(
-        Group.objects.filter(
-            project_id=project_id,
-            id__gte=group_id_start,
-            id__lt=group_id_end,
-        )
-        .order_by("id")
-        .values_list("id", flat=True)
+    qs = Group.objects.filter(
+        project_id=project_id,
+        id__gte=group_id_start,
+        id__lt=group_id_end,
     )
+    if stale_only:
+        qs = _stale_pipeline_filter(qs, PIPELINE.pipeline_hash)
+    group_ids = list(qs.order_by("id").values_list("id", flat=True))
 
     processed: dict[str, int] = {}
     rescheduled = False
@@ -508,6 +541,7 @@ def generate_project_derived_data_batch(
                 group_id_end=group_id_end,
                 resume_generated_at=gen_id.generated_at.isoformat() if gen_id else None,
                 resume_pipeline_hash=gen_id.pipeline_hash if gen_id else None,
+                stale_only=stale_only,
             )
             if activation_id:
                 mark_spawned(_GENERATE_BATCH_TASK_KEY, activation_id)
@@ -524,6 +558,7 @@ def generate_project_derived_data_batch(
                 project_id=project_id,
                 group_id_start=group_id + 1,
                 group_id_end=group_id_end,
+                stale_only=stale_only,
             )
             if activation_id:
                 mark_spawned(_GENERATE_BATCH_TASK_KEY, activation_id)
@@ -551,7 +586,7 @@ def generate_project_derived_data_batch(
 
 
 # ---------------------------------------------------------------------------
-# Self-healing: discover and reprocess stale pipeline hashes
+# Self-healing: rebuild groups with outdated pipeline hashes
 # ---------------------------------------------------------------------------
 
 
@@ -561,11 +596,13 @@ def generate_project_derived_data_batch(
     silo_mode=SiloMode.CELL,
 )
 def heal_stale_derived_data(**kwargs: object) -> None:
-    """Find projects with stale GroupDerivedData and trigger reprocessing.
+    """Find projects with stale GroupDerivedData and rebuild them.
 
-    Queries for distinct project_ids that have at least one GroupDerivedData
-    row with a pipeline_hash that doesn't match the current pipeline, then
-    schedules process_project_derived_data for up to N of them.
+    Stale means having a ``GroupDerivedData`` row whose ``pipeline_hash``
+    is NULL or doesn't match the current pipeline.
+
+    Schedules ``generate_project_derived_data(stale_only=True)`` for up
+    to N projects, which replaces rows via CAS without deleting them.
     """
     from sentry import options
     from sentry.issues.derived.processing import PIPELINE
@@ -589,7 +626,7 @@ def heal_stale_derived_data(**kwargs: object) -> None:
         return
 
     for project_id in project_ids:
-        process_project_derived_data.delay(project_id=project_id, use_pipeline_hash=True)
+        generate_project_derived_data.delay(project_id=project_id, stale_only=True)
 
     logger.info(
         "heal_stale_derived_data.scheduled",

--- a/src/sentry/issues/derived/tasks.py
+++ b/src/sentry/issues/derived/tasks.py
@@ -5,11 +5,12 @@ import time
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
-from django.db.models import Exists, OuterRef, Q, QuerySet
+from django.db.models import Exists, OuterRef, Q
 
 from sentry.silo.base import SiloMode
 
 if TYPE_CHECKING:
+    from sentry.db.models.manager.base_query_set import BaseQuerySet
     from sentry.models.group import Group
 
 from sentry.tasks.base import instrumented_task
@@ -31,7 +32,7 @@ _MAX_GENERATION_RUNS = 20
 _MAX_PROJECT_GROUPS = 10_000
 
 
-def _stale_pipeline_filter(qs: QuerySet[Group], pipeline_hash: str) -> QuerySet[Group]:
+def _stale_pipeline_filter(qs: BaseQuerySet[Group], pipeline_hash: str) -> BaseQuerySet[Group]:
     """Filter a Group queryset to only groups with a stale or NULL pipeline_hash."""
     from sentry.issues.models.groupderiveddata import GroupDerivedData
 

--- a/tests/sentry/issues/derived/test_tasks.py
+++ b/tests/sentry/issues/derived/test_tasks.py
@@ -6,6 +6,8 @@ from sentry.issues.derived import processing
 from sentry.issues.derived.processing import PIPELINE, GroupLogTimeout, process_group_log
 from sentry.issues.derived.tasks import (
     BATCH_RETRIGGER_TIMEOUT,
+    generate_project_derived_data,
+    generate_project_derived_data_batch,
     heal_stale_derived_data,
     process_project_derived_data,
     process_project_derived_data_batch,
@@ -302,6 +304,73 @@ class ProcessProjectDerivedDataBatchWithPipelineHashTest(DerivedDataTaskTestBase
 
 
 @with_feature("projects:issue-action-log-write-to-db")
+class GenerateProjectDerivedDataStaleOnlyTest(DerivedDataTaskTestBase):
+    def test_only_includes_stale_groups(self) -> None:
+        groups = self.create_unprocessed_groups(3)
+        group_ids = sorted(g.id for g in groups)
+
+        for gid in group_ids:
+            process_group_log(gid)
+
+        # Make one group stale
+        GroupDerivedData.objects.filter(group_id=group_ids[0]).update(pipeline_hash="stale")
+
+        with patch.object(generate_project_derived_data_batch, "delay") as mock_delay:
+            generate_project_derived_data(project_id=self.project.id, stale_only=True)
+
+        mock_delay.assert_called_once()
+        assert mock_delay.call_args[1]["group_id_start"] == group_ids[0]
+        assert mock_delay.call_args[1]["group_id_end"] == group_ids[0] + 1
+
+    def test_includes_null_hash_groups(self) -> None:
+        groups = self.create_unprocessed_groups(2)
+        group_ids = sorted(g.id for g in groups)
+
+        for gid in group_ids:
+            process_group_log(gid)
+
+        GroupDerivedData.objects.filter(group_id=group_ids[0]).update(pipeline_hash=None)
+
+        with patch.object(generate_project_derived_data_batch, "delay") as mock_delay:
+            generate_project_derived_data(project_id=self.project.id, stale_only=True)
+
+        mock_delay.assert_called_once()
+        assert mock_delay.call_args[1]["group_id_start"] == group_ids[0]
+
+    def test_excludes_current_hash_groups(self) -> None:
+        groups = self.create_unprocessed_groups(2)
+        group_ids = sorted(g.id for g in groups)
+
+        for gid in group_ids:
+            process_group_log(gid)
+
+        # All groups have the current hash — nothing to do
+        with patch.object(generate_project_derived_data_batch, "delay") as mock_delay:
+            generate_project_derived_data(project_id=self.project.id, stale_only=True)
+
+        mock_delay.assert_not_called()
+
+    def test_excludes_groups_without_gdd(self) -> None:
+        groups = self.create_unprocessed_groups(3)
+        group_ids = sorted(g.id for g in groups)
+
+        # Only process two groups — group_ids[2] has no GDD at all
+        process_group_log(group_ids[0])
+        process_group_log(group_ids[1])
+
+        # Make one stale
+        GroupDerivedData.objects.filter(group_id=group_ids[0]).update(pipeline_hash="stale")
+
+        with patch.object(generate_project_derived_data_batch, "delay") as mock_delay:
+            generate_project_derived_data(project_id=self.project.id, stale_only=True)
+
+        # Only the stale group should be included, not the one missing GDD
+        mock_delay.assert_called_once()
+        assert mock_delay.call_args[1]["group_id_start"] == group_ids[0]
+        assert mock_delay.call_args[1]["group_id_end"] == group_ids[0] + 1
+
+
+@with_feature("projects:issue-action-log-write-to-db")
 class HealStaleDerivedDataTest(DerivedDataTaskTestBase):
     def test_finds_stale_projects_and_schedules(self) -> None:
         groups = self.create_unprocessed_groups(2)
@@ -313,17 +382,17 @@ class HealStaleDerivedDataTest(DerivedDataTaskTestBase):
         # Make one group stale
         GroupDerivedData.objects.filter(group_id=group_ids[0]).update(pipeline_hash="stale")
 
-        with patch.object(process_project_derived_data, "delay") as mock_delay:
+        with patch.object(generate_project_derived_data, "delay") as mock_delay:
             heal_stale_derived_data()
 
-        mock_delay.assert_called_once_with(project_id=self.project.id, use_pipeline_hash=True)
+        mock_delay.assert_called_once_with(project_id=self.project.id, stale_only=True)
 
     def test_no_stale_data(self) -> None:
         groups = self.create_unprocessed_groups(2)
         for g in groups:
             process_group_log(g.id)
 
-        with patch.object(process_project_derived_data, "delay") as mock_delay:
+        with patch.object(generate_project_derived_data, "delay") as mock_delay:
             heal_stale_derived_data()
 
         mock_delay.assert_not_called()
@@ -335,7 +404,7 @@ class HealStaleDerivedDataTest(DerivedDataTaskTestBase):
 
         with (
             override_options({"issues.derived.heal-enabled": False}),
-            patch.object(process_project_derived_data, "delay") as mock_delay,
+            patch.object(generate_project_derived_data, "delay") as mock_delay,
         ):
             heal_stale_derived_data()
 
@@ -358,7 +427,7 @@ class HealStaleDerivedDataTest(DerivedDataTaskTestBase):
 
         with (
             override_options({"issues.derived.heal-project-limit": 2}),
-            patch.object(process_project_derived_data, "delay") as mock_delay,
+            patch.object(generate_project_derived_data, "delay") as mock_delay,
         ):
             heal_stale_derived_data()
 
@@ -369,7 +438,7 @@ class HealStaleDerivedDataTest(DerivedDataTaskTestBase):
         process_group_log(groups[0].id)
         GroupDerivedData.objects.filter(group_id=groups[0].id).update(pipeline_hash=None)
 
-        with patch.object(process_project_derived_data, "delay") as mock_delay:
+        with patch.object(generate_project_derived_data, "delay") as mock_delay:
             heal_stale_derived_data()
 
-        mock_delay.assert_called_once_with(project_id=self.project.id, use_pipeline_hash=True)
+        mock_delay.assert_called_once_with(project_id=self.project.id, stale_only=True)


### PR DESCRIPTION
Now that we have in-place replacement, we can update our project healing to regenerate without downtime.

We find a limited number of project projects with stale data, then trigger regeneration for their stale GroupDerivedData rows.

Fixes ISWF-3055.
