### PR TITLE
style(seer): Reword Seer workflow action and status labels

### DIFF
--- a/static/app/views/seerWorkflows/overview/cardAction.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/cardAction.spec.tsx
@@ -130,7 +130,7 @@ describe('IssuePrimaryAction', () => {
     {type: 'merged', label: 'Merged'},
     {type: 'code_changes_ready', label: 'Draft PR'},
     {type: 'solution_ready', label: 'Generate code'},
-    {type: 'needs_investigation', label: 'Approve Root Cause'},
+    {type: 'needs_investigation', label: 'Create Plan'},
   ] as Array<{label: string; type: Exclude<CardAction['type'], 'review_pr'>}>)(
     'renders the $label action for a completed $type card',
     ({type, label}) => {
@@ -143,7 +143,7 @@ describe('IssuePrimaryAction', () => {
   it.each([
     {type: 'code_changes_ready', label: 'Draft PR'},
     {type: 'solution_ready', label: 'Generate code'},
-    {type: 'needs_investigation', label: 'Approve Root Cause'},
+    {type: 'needs_investigation', label: 'Create Plan'},
   ] as Array<{label: string; type: Exclude<CardAction['type'], 'review_pr'>}>)(
     'opens the run drawer when the $label action is clicked',
     async ({type, label}) => {
@@ -179,7 +179,7 @@ describe('IssuePrimaryAction', () => {
     },
     {
       action: {type: 'needs_investigation'} as CardAction,
-      label: 'Approve Root Cause',
+      label: 'Create Plan',
       row: makeRow({runStatus: 'completed'}),
     },
     {

--- a/static/app/views/seerWorkflows/overview/cardAction.tsx
+++ b/static/app/views/seerWorkflows/overview/cardAction.tsx
@@ -64,7 +64,7 @@ const ACTION_META: Record<
   },
   needs_investigation: {
     Icon: IconSearch,
-    label: t('Approve Root Cause'),
+    label: t('Create Plan'),
     variant: 'secondary',
     description: t(
       'Seer stopped at a diagnosis. Review the root cause and approve it to continue.'

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -247,26 +247,24 @@ describe('AutofixOverview', () => {
     // cards with a real PR behind them (here 1, despite X-Hits 3); the other
     // buckets show their X-Hits count.
     const reviewHeader = await screen.findByRole('button', {
-      name: 'Awaiting your review 1',
+      name: 'Review Open PRs 1',
     });
+    expect(screen.getByRole('button', {name: 'Create PR 0'})).toBeInTheDocument();
     expect(
-      screen.getByRole('button', {name: 'Code changes ready 0'})
+      screen.getByRole('button', {name: 'Generate code changes 0'})
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('button', {name: 'Ready to generate code 0'})
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', {name: 'Needs investigation 0'})
+      screen.getByRole('button', {name: 'Confirm Root Cause 0'})
     ).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Merged 0'})).toBeInTheDocument();
 
     // The headers render in pipeline (SECTION_ORDER) order; reordering the
     // PIPELINE table reorders these and fails here.
     const orderedHeaders = [
-      /Awaiting your review/,
-      /Code changes ready/,
-      /Ready to generate code/,
-      /Needs investigation/,
+      /Review Open PRs/,
+      /Create PR/,
+      /Generate code changes/,
+      /Confirm Root Cause/,
       /Merged/,
     ].map(name => screen.getByRole('button', {name}));
     for (let index = 0; index < orderedHeaders.length - 1; index++) {
@@ -281,7 +279,7 @@ describe('AutofixOverview', () => {
     const titleLink = await screen.findByRole('link', {
       name: 'Proxy requests fail without Authorization header',
     });
-    const codeHeader = screen.getByRole('button', {name: 'Code changes ready 0'});
+    const codeHeader = screen.getByRole('button', {name: 'Create PR 0'});
     expect(
       reviewHeader.compareDocumentPosition(titleLink) & Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
@@ -458,7 +456,7 @@ describe('AutofixOverview', () => {
     renderPage();
 
     const reviewHeader = await screen.findByRole('button', {
-      name: 'Awaiting your review 1',
+      name: 'Review Open PRs 1',
     });
     expect(
       await screen.findByRole('link', {
@@ -514,7 +512,7 @@ describe('AutofixOverview', () => {
 
     renderPage();
 
-    await screen.findByRole('button', {name: 'Awaiting your review 30'});
+    await screen.findByRole('button', {name: 'Review Open PRs 30'});
     expect(screen.getAllByRole('link', {name: /Bulk issue/})).toHaveLength(30);
     expect(
       screen.queryByRole('button', {name: /Show \d+ more issue/})
@@ -529,7 +527,7 @@ describe('AutofixOverview', () => {
     renderPage();
 
     expect(
-      await screen.findByRole('button', {name: 'Code changes ready 100+'})
+      await screen.findByRole('button', {name: 'Create PR 100+'})
     ).toBeInTheDocument();
   });
 
@@ -548,7 +546,7 @@ describe('AutofixOverview', () => {
     renderPage();
 
     expect(
-      await screen.findByRole('button', {name: 'Awaiting your review 1'})
+      await screen.findByRole('button', {name: 'Review Open PRs 1'})
     ).toBeInTheDocument();
     expect(
       await screen.findByRole('link', {
@@ -679,7 +677,7 @@ describe('AutofixOverview', () => {
     // Focus mode hides the section list and offers the way back, keeping the
     // other params.
     expect(
-      screen.queryByRole('button', {name: /Awaiting your review/})
+      screen.queryByRole('button', {name: /Review Open PRs/})
     ).not.toBeInTheDocument();
     const backLink = screen.getByRole('button', {name: 'All issues'});
     expect(backLink).toHaveAttribute('href', expect.not.stringContaining('id=2'));
@@ -700,7 +698,7 @@ describe('AutofixOverview', () => {
     expect(await screen.findByText('No completed autofix runs yet.')).toBeInTheDocument();
     // The section list is replaced entirely by the empty state.
     expect(
-      screen.queryByRole('button', {name: /Awaiting your review/})
+      screen.queryByRole('button', {name: /Review Open PRs/})
     ).not.toBeInTheDocument();
   });
 
@@ -736,9 +734,7 @@ describe('AutofixOverview', () => {
       await screen.findByText('There was an error loading data.')
     ).toBeInTheDocument();
     expect(screen.queryByText('No completed autofix runs yet.')).not.toBeInTheDocument();
-    expect(
-      screen.getByRole('button', {name: /Awaiting your review/})
-    ).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: /Review Open PRs/})).toBeInTheDocument();
   });
 
   it('surfaces a per-section error while other sections still load', async () => {
@@ -804,7 +800,7 @@ describe('AutofixOverview', () => {
     renderPage();
 
     expect(
-      await screen.findByRole('button', {name: 'Awaiting your review 1'})
+      await screen.findByRole('button', {name: 'Review Open PRs 1'})
     ).toBeInTheDocument();
   });
 

--- a/static/app/views/seerWorkflows/overview/statusGroups.tsx
+++ b/static/app/views/seerWorkflows/overview/statusGroups.tsx
@@ -18,12 +18,12 @@ interface StatusGroupMeta {
 }
 
 export const STATUS_GROUP_META: Record<StatusGroupKey, StatusGroupMeta> = {
-  review_pr: {Icon: IconPullRequest, label: t('Awaiting your review')},
-  code_changes_ready: {Icon: IconCommit, label: t('Code changes ready')},
-  solution_ready: {Icon: IconCode, label: t('Ready to generate code')},
+  review_pr: {Icon: IconPullRequest, label: t('Review Open PRs')},
+  code_changes_ready: {Icon: IconCommit, label: t('Create PR')},
+  solution_ready: {Icon: IconCode, label: t('Generate code changes')},
   // Same magnifier as the card's Approve-Root-Cause action: these runs stopped at a
   // root cause, and their next steps are manual verify/decide work.
-  needs_investigation: {Icon: IconSearch, label: t('Needs investigation')},
+  needs_investigation: {Icon: IconSearch, label: t('Confirm Root Cause')},
   merged: {Icon: IconMerge, label: t('Merged')},
 };
 


### PR DESCRIPTION
Relabels the Seer workflow overview so each action and status names the next
step a user takes, rather than the state a run is currently in. This makes the
overview read as a to-do list of actions.

Card action (`cardAction.tsx`):

- `needs_investigation`: "Approve Root Cause" → "Create Plan"

Status groups (`statusGroups.tsx`):

| Key | Before | After |
|-----|--------|-------|
| `review_pr` | Awaiting your review | Review Open PRs |
| `code_changes_ready` | Code changes ready | Create PR |
| `solution_ready` | Ready to generate code | Generate code changes |
| `needs_investigation` | Needs investigation | Confirm Root Cause |

Copy-only; no behavior, icons, or grouping change.
