### PR TITLE
ref(issues): Decouple priority updates from Group

### DIFF
--- a/static/app/components/stream/group.spec.tsx
+++ b/static/app/components/stream/group.spec.tsx
@@ -9,6 +9,7 @@ import {EventOrGroupType} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import {GroupStatus, PriorityLevel} from 'sentry/types/group';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {getAnalyticsDataForGroup} from 'sentry/utils/events';
 import {IssueSelectionProvider} from 'sentry/views/issueList/issueSelectionContext';
 
 jest.mock('sentry/utils/analytics');
@@ -95,6 +96,15 @@ describe('StreamGroup', () => {
         data: expect.objectContaining({
           priority: 'high',
         }),
+      })
+    );
+    expect(trackAnalytics).toHaveBeenCalledWith(
+      'issue_details.set_priority',
+      expect.objectContaining({
+        ...getAnalyticsDataForGroup(group1),
+        organization: expect.objectContaining({slug: 'org-slug'}),
+        from_priority: group1.priority,
+        to_priority: PriorityLevel.HIGH,
       })
     );
   });

--- a/static/app/views/issueDetails/groupPriority.tsx
+++ b/static/app/views/issueDetails/groupPriority.tsx
@@ -24,6 +24,16 @@ type GroupDetailsPriorityProps = {
   onChange?: (priority: PriorityLevel) => void;
 };
 
+export type GroupPriorityControlProps = {
+  groupId: Group['id'];
+  issueType: Group['issueType'];
+  priority: PriorityLevel;
+  priorityLockedAt: Group['priorityLockedAt'];
+  projectId: Group['project']['id'];
+  onChange?: (priority: PriorityLevel) => void;
+  onChangeInitiated?: (priority: PriorityLevel) => void;
+};
+
 const PRIORITY_BARS: Record<PriorityLevel, 1 | 2 | 3> = {
   [PriorityLevel.HIGH]: 3,
   [PriorityLevel.MEDIUM]: 2,
@@ -33,22 +43,26 @@ const PRIORITY_BARS: Record<PriorityLevel, 1 | 2 | 3> = {
 const getPriorityUpdateSuccessMessage = (priority: PriorityLevel) =>
   t('Priority updated to %s', priority);
 
-function useChangePriority(group: Group, onChange?: (priority: PriorityLevel) => void) {
+function useChangePriority({
+  groupId,
+  priority,
+  projectId,
+  onChange,
+  onChangeInitiated,
+}: Pick<
+  GroupPriorityControlProps,
+  'groupId' | 'priority' | 'projectId' | 'onChange' | 'onChangeInitiated'
+>) {
   const api = useApi({persistInFlight: true});
   const organization = useOrganization();
   const queryClient = useQueryClient();
 
   return (nextPriority: PriorityLevel) => {
-    if (nextPriority === group.priority) {
+    if (nextPriority === priority) {
       return;
     }
 
-    trackAnalytics('issue_details.set_priority', {
-      organization,
-      ...getAnalyticsDataForGroup(group),
-      from_priority: group.priority,
-      to_priority: nextPriority,
-    });
+    onChangeInitiated?.(nextPriority);
 
     addLoadingMessage(t('Saving changes\u2026'));
     IssueListCacheStore.reset();
@@ -57,17 +71,17 @@ function useChangePriority(group: Group, onChange?: (priority: PriorityLevel) =>
       api,
       {
         orgId: organization.slug,
-        itemIds: [group.id],
+        itemIds: [groupId],
         data: {priority: nextPriority},
         failSilently: true,
-        project: [group.project.id],
+        project: [projectId],
       },
       {
         success: () => {
           queryClient.invalidateQueries({
             queryKey: groupQueryKey({
               organizationSlug: organization.slug,
-              groupId: group.id,
+              groupId,
             }),
           });
           clearIndicators();
@@ -83,20 +97,63 @@ function useChangePriority(group: Group, onChange?: (priority: PriorityLevel) =>
   };
 }
 
-export function GroupPriority({group, onChange}: GroupDetailsPriorityProps) {
-  const onChangePriority = useChangePriority(group, onChange);
+function useTrackPriorityChange(group: Group) {
+  const organization = useOrganization();
+
+  return (nextPriority: PriorityLevel) => {
+    trackAnalytics('issue_details.set_priority', {
+      organization,
+      ...getAnalyticsDataForGroup(group),
+      from_priority: group.priority,
+      to_priority: nextPriority,
+    });
+  };
+}
+
+export function GroupPriorityControl({
+  groupId,
+  issueType,
+  priority,
+  priorityLockedAt,
+  projectId,
+  onChange,
+  onChangeInitiated,
+}: GroupPriorityControlProps) {
+  const onChangePriority = useChangePriority({
+    groupId,
+    priority,
+    projectId,
+    onChange,
+    onChangeInitiated,
+  });
 
   // We can assume that when there is not `priorityLockedAt`, there were no
   // user edits to the priority.
-  const lastEditedBy = group.priorityLockedAt ? undefined : 'system';
+  const lastEditedBy = priorityLockedAt ? undefined : 'system';
 
   return (
     <GroupPriorityDropdown
-      disabled={group.issueType === 'metric_issue'}
-      groupId={group.id}
+      disabled={issueType === 'metric_issue'}
+      groupId={groupId}
       onChange={onChangePriority}
-      value={group.priority ?? PriorityLevel.MEDIUM}
+      value={priority}
       lastEditedBy={lastEditedBy}
+    />
+  );
+}
+
+export function GroupPriority({group, onChange}: GroupDetailsPriorityProps) {
+  const onChangeInitiated = useTrackPriorityChange(group);
+
+  return (
+    <GroupPriorityControl
+      groupId={group.id}
+      issueType={group.issueType}
+      priority={group.priority ?? PriorityLevel.MEDIUM}
+      priorityLockedAt={group.priorityLockedAt}
+      projectId={group.project.id}
+      onChange={onChange}
+      onChangeInitiated={onChangeInitiated}
     />
   );
 }
@@ -104,8 +161,14 @@ export function GroupPriority({group, onChange}: GroupDetailsPriorityProps) {
 export function GroupPriorityCommandPaletteAction({
   group,
 }: Pick<GroupDetailsPriorityProps, 'group'>) {
-  const onChangePriority = useChangePriority(group);
   const priority = group.priority ?? PriorityLevel.MEDIUM;
+  const onChangeInitiated = useTrackPriorityChange(group);
+  const onChangePriority = useChangePriority({
+    groupId: group.id,
+    priority,
+    projectId: group.project.id,
+    onChangeInitiated,
+  });
 
   return (
     <CMDKAction

--- a/static/app/views/seerWorkflows/overview/buildOverviewRows.spec.ts
+++ b/static/app/views/seerWorkflows/overview/buildOverviewRows.spec.ts
@@ -1,5 +1,5 @@
 import type {ExplorerAutofixState} from 'sentry/components/events/autofix/useExplorerAutofix';
-import {IssueCategory, IssueType, PriorityLevel} from 'sentry/types/group';
+import {IssueType, PriorityLevel} from 'sentry/types/group';
 import {
   buildAnalysis,
   buildOverviewRow,
@@ -84,7 +84,6 @@ function makeIssue(overrides: Partial<OverviewIssue> = {}): OverviewIssue {
     assignedTo: null,
     count: '100',
     id: '2',
-    issueCategory: IssueCategory.ERROR,
     issueType: IssueType.ERROR,
     lastSeen: '2026-07-20T12:00:00Z',
     level: 'error',
@@ -103,7 +102,6 @@ describe('buildOverviewRow', () => {
   it('preserves priority metadata from the issue response', () => {
     const row = buildOverviewRow(
       makeIssue({
-        issueCategory: IssueCategory.PERFORMANCE,
         issueType: IssueType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES,
         priority: null,
         priorityLockedAt: '2026-07-23T12:00:00Z',
@@ -116,7 +114,6 @@ describe('buildOverviewRow', () => {
 
     expect(row).toEqual(
       expect.objectContaining({
-        issueCategory: IssueCategory.PERFORMANCE,
         issueType: IssueType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES,
         priority: null,
         priorityLockedAt: '2026-07-23T12:00:00Z',

--- a/static/app/views/seerWorkflows/overview/buildOverviewRows.ts
+++ b/static/app/views/seerWorkflows/overview/buildOverviewRows.ts
@@ -233,7 +233,6 @@ export function buildOverviewRow(
     project: issue.project,
     assignedTo: issue.assignedTo ?? null,
     owners: issue.owners,
-    issueCategory: issue.issueCategory,
     issueType: issue.issueType,
     priority: issue.priority,
     priorityLockedAt: issue.priorityLockedAt,

--- a/static/app/views/seerWorkflows/overview/cardAction.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/cardAction.spec.tsx
@@ -1,6 +1,6 @@
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import {IssueCategory, IssueType, PriorityLevel} from 'sentry/types/group';
+import {IssueType, PriorityLevel} from 'sentry/types/group';
 import {
   deriveCardAction,
   IssuePrimaryAction,
@@ -18,7 +18,6 @@ function makeRow(overrides: Partial<OverviewRow> = {}): OverviewRow {
     assignedTo: null,
     eventCount: 1,
     id: '2',
-    issueCategory: IssueCategory.ERROR,
     issueType: IssueType.ERROR,
     lastActivityAt: '2026-07-14T10:00:00Z',
     lastSeen: '2026-07-14T09:00:00Z',

--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -477,19 +477,11 @@ export function IssueCard({
               </Stack>
               <Flex gap="xs" align="center">
                 <OverviewIssuePriority
-                  group={{
-                    assignedTo: row.assignedTo,
-                    count: String(row.eventCount),
-                    id: row.id,
-                    issueCategory: row.issueCategory,
-                    issueType: row.issueType,
-                    lastSeen: row.lastSeen,
-                    level: row.level,
-                    owners: row.owners,
-                    priority: row.priority,
-                    priorityLockedAt: row.priorityLockedAt,
-                    project: {id: row.project.id},
-                  }}
+                  groupId={row.id}
+                  issueType={row.issueType}
+                  priority={row.priority}
+                  priorityLockedAt={row.priorityLockedAt}
+                  projectId={row.project.id}
                 />
                 <OverviewIssueAssignee
                   groupId={row.id}

--- a/static/app/views/seerWorkflows/overview/overviewIssuePriority.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewIssuePriority.spec.tsx
@@ -12,46 +12,31 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
-import {
-  GroupActivityType,
-  IssueCategory,
-  IssueType,
-  PriorityLevel,
-} from 'sentry/types/group';
-import {trackAnalytics} from 'sentry/utils/analytics';
+import {GroupActivityType, IssueType, PriorityLevel} from 'sentry/types/group';
 
-import {
-  OverviewIssuePriority,
-  type OverviewIssuePriorityGroup,
-} from './overviewIssuePriority';
-
-jest.mock('sentry/utils/analytics');
+import {OverviewIssuePriority} from './overviewIssuePriority';
 
 describe('OverviewIssuePriority', () => {
   const organization = OrganizationFixture();
   const groupFixture = GroupFixture();
 
-  function makeGroup(
-    overrides: Partial<OverviewIssuePriorityGroup> = {}
-  ): OverviewIssuePriorityGroup {
-    return {
-      assignedTo: groupFixture.assignedTo,
-      count: groupFixture.count,
-      id: groupFixture.id,
-      issueCategory: groupFixture.issueCategory,
-      issueType: groupFixture.issueType,
-      lastSeen: groupFixture.lastSeen,
-      level: groupFixture.level,
-      owners: groupFixture.owners,
-      priority: groupFixture.priority,
-      priorityLockedAt: groupFixture.priorityLockedAt,
-      project: {id: groupFixture.project.id},
-      ...overrides,
-    };
+  function renderPriority(
+    overrides: Partial<React.ComponentProps<typeof OverviewIssuePriority>> = {}
+  ) {
+    render(
+      <OverviewIssuePriority
+        groupId={groupFixture.id}
+        issueType={groupFixture.issueType}
+        priority={groupFixture.priority}
+        priorityLockedAt={groupFixture.priorityLockedAt}
+        projectId={groupFixture.project.id}
+        {...overrides}
+      />,
+      {organization}
+    );
   }
 
   beforeEach(() => {
-    jest.mocked(trackAnalytics).mockClear();
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/prompts-activity/`,
       body: {data: {dismissed_ts: null}},
@@ -65,16 +50,10 @@ describe('OverviewIssuePriority', () => {
       body: {priority: PriorityLevel.HIGH},
     });
 
-    render(
-      <OverviewIssuePriority
-        group={makeGroup({
-          issueCategory: IssueCategory.PERFORMANCE,
-          issueType: IssueType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES,
-          priority: null,
-        })}
-      />,
-      {organization}
-    );
+    renderPriority({
+      issueType: IssueType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES,
+      priority: null,
+    });
 
     const priorityDropdown = screen.getByRole('button', {
       name: 'Modify issue priority',
@@ -98,16 +77,6 @@ describe('OverviewIssuePriority', () => {
         await screen.findByRole('button', {name: 'Modify issue priority'})
       ).getByText('High')
     ).toBeInTheDocument();
-
-    expect(trackAnalytics).toHaveBeenCalledWith(
-      'issue_details.set_priority',
-      expect.objectContaining({
-        from_priority: PriorityLevel.MEDIUM,
-        issue_category: IssueCategory.PERFORMANCE,
-        issue_type: IssueType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES,
-        to_priority: PriorityLevel.HIGH,
-      })
-    );
   });
 
   it('resolves the actor for a user-edited priority', async () => {
@@ -123,12 +92,7 @@ describe('OverviewIssuePriority', () => {
       },
     });
 
-    render(
-      <OverviewIssuePriority
-        group={makeGroup({priorityLockedAt: '2026-07-23T12:00:00Z'})}
-      />,
-      {organization}
-    );
+    renderPriority({priorityLockedAt: '2026-07-23T12:00:00Z'});
 
     await userEvent.click(screen.getByRole('button', {name: 'Modify issue priority'}));
 
@@ -139,15 +103,7 @@ describe('OverviewIssuePriority', () => {
   });
 
   it('disables priority changes for metric issues', () => {
-    render(
-      <OverviewIssuePriority
-        group={makeGroup({
-          issueCategory: IssueCategory.METRIC,
-          issueType: IssueType.METRIC_ISSUE,
-        })}
-      />,
-      {organization}
-    );
+    renderPriority({issueType: IssueType.METRIC_ISSUE});
 
     expect(screen.getByRole('button', {name: 'Modify issue priority'})).toBeDisabled();
   });

--- a/static/app/views/seerWorkflows/overview/overviewIssuePriority.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewIssuePriority.tsx
@@ -1,55 +1,57 @@
 import {useCallback, useState} from 'react';
 import {useQueryClient} from '@tanstack/react-query';
 
-import {PriorityLevel, type Group} from 'sentry/types/group';
+import {type IssueType, PriorityLevel} from 'sentry/types/group';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {GroupPriority} from 'sentry/views/issueDetails/groupPriority';
-
-export type OverviewIssuePriorityGroup = Pick<
-  Group,
-  | 'assignedTo'
-  | 'count'
-  | 'id'
-  | 'issueCategory'
-  | 'issueType'
-  | 'lastSeen'
-  | 'level'
-  | 'owners'
-  | 'priorityLockedAt'
-> & {
-  priority: PriorityLevel | null;
-  project: Pick<Group['project'], 'id'>;
-};
+import {GroupPriorityControl} from 'sentry/views/issueDetails/groupPriority';
 
 interface OverviewIssuePriorityProps {
-  group: OverviewIssuePriorityGroup;
+  groupId: string;
+  issueType: IssueType;
+  priority: PriorityLevel | null;
+  priorityLockedAt: string | null;
+  projectId: string;
 }
 
-export function OverviewIssuePriority({group}: OverviewIssuePriorityProps) {
+export function OverviewIssuePriority({
+  groupId,
+  issueType,
+  priority,
+  priorityLockedAt,
+  projectId,
+}: OverviewIssuePriorityProps) {
   const organization = useOrganization();
   const queryClient = useQueryClient();
   const issueIndexUrl = getApiUrl('/organizations/$organizationIdOrSlug/issues/', {
     path: {organizationIdOrSlug: organization.slug},
   });
   const [priorityOverride, setPriorityOverride] = useState<{
-    groupId: OverviewIssuePriorityGroup['id'];
+    groupId: string;
     priority: PriorityLevel;
   } | null>(null);
 
   const currentPriority =
-    priorityOverride?.groupId === group.id
+    priorityOverride?.groupId === groupId
       ? priorityOverride.priority
-      : (group.priority ?? PriorityLevel.MEDIUM);
-  const currentGroup = {...group, priority: currentPriority} as Group;
+      : (priority ?? PriorityLevel.MEDIUM);
 
   const handleSuccess = useCallback(
     (nextPriority: PriorityLevel) => {
-      setPriorityOverride({groupId: group.id, priority: nextPriority});
+      setPriorityOverride({groupId, priority: nextPriority});
       void queryClient.invalidateQueries({queryKey: [issueIndexUrl]});
     },
-    [group.id, issueIndexUrl, queryClient]
+    [groupId, issueIndexUrl, queryClient]
   );
 
-  return <GroupPriority group={currentGroup} onChange={handleSuccess} />;
+  return (
+    <GroupPriorityControl
+      groupId={groupId}
+      issueType={issueType}
+      priority={currentPriority}
+      priorityLockedAt={priorityLockedAt}
+      projectId={projectId}
+      onChange={handleSuccess}
+    />
+  );
 }

--- a/static/app/views/seerWorkflows/overview/types.ts
+++ b/static/app/views/seerWorkflows/overview/types.ts
@@ -97,7 +97,6 @@ export interface OverviewIssue {
   // Event count over the stats period; the endpoint returns it as a string.
   count: string;
   id: string;
-  issueCategory: Group['issueCategory'];
   issueType: Group['issueType'];
   lastSeen: string;
   level: Level;
@@ -151,7 +150,6 @@ export interface OverviewRow {
   assignedTo: Actor | null;
   eventCount: number;
   id: string;
-  issueCategory: Group['issueCategory'];
   issueType: Group['issueType'];
   // Most recent Seer activity on the run (state update, trigger, or
   // issue-level last-trigger timestamp); null when the run has no Seer-side


### PR DESCRIPTION
Priority updates now use a reusable control with scalar issue fields, so the Autofix Overview no longer fabricates and casts a partial `Group`. The existing `GroupPriority` wrapper continues to emit full issue-details analytics for callers that have complete group data, while the overview keeps its mutation, local label update, cache invalidation, metric disabling, and last-editor behavior without emitting partial analytics.

Follow-up to #120498 and [the original review comment](https://github.com/getsentry/sentry/pull/120498#discussion_r3641396093).
