### PR TITLE
feat(gdd): Schedule heal_stale_derived_data regularly

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1228,6 +1228,10 @@ TASKWORKER_REGION_SCHEDULES: ScheduleConfigMap = {
         "task": "issues:sentry.tasks.web_vitals_issue_detection.run_web_vitals_issue_detection",
         "schedule": crontab("0", "0", "*", "1,15", "*"),
     },
+    "heal-stale-derived-data": {
+        "task": "issues:sentry.issues.derived.tasks.heal_stale_derived_data",
+        "schedule": crontab("*/15", "*", "*", "*", "*"),
+    },
 }
 
 TASKWORKER_CONTROL_SCHEDULES: ScheduleConfigMap = {


### PR DESCRIPTION

Follow up to https://github.com/getsentry/sentry/pull/120516.
We need to actually schedule the task for it to be useful.
Every 15min should avoid reprocessing those that are being processed.
Fairly safe because we have an option to disable.