### PR TITLE
fix(issues): Show group lifetime first/last seen in inbox row

### DIFF
--- a/static/app/views/issueList/pages/issueSeenTimes.tsx
+++ b/static/app/views/issueList/pages/issueSeenTimes.tsx
@@ -10,10 +10,13 @@ import type {Group} from 'sentry/types/group';
  * issue card and the issue preview header.
  */
 export function IssueSeenTimes({group}: {group: Group}) {
+  const lastSeen = group.lifetime?.lastSeen ?? group.lastSeen;
+  const firstSeen = group.lifetime?.firstSeen ?? group.firstSeen;
+
   return (
     <Flex align="center" gap="xs" wrap="nowrap">
       <TimeSince
-        date={group.lastSeen}
+        date={lastSeen}
         suffix=""
         unitStyle="short"
         tooltipPrefix={t('Last Seen')}
@@ -21,7 +24,7 @@ export function IssueSeenTimes({group}: {group: Group}) {
       />
       <Text variant="muted">|</Text>
       <TimeSince
-        date={group.firstSeen}
+        date={firstSeen}
         suffix=""
         unitStyle="short"
         tooltipPrefix={t('First Seen')}


### PR DESCRIPTION
The inbox issue row (and the shared `IssueSeenTimes` component) used the top-level `group.firstSeen`/`lastSeen`, which are scoped to the selected time range in the issue list query. This meant the row showed a range-restricted first seen instead of the true group first seen.

Prefer `group.lifetime` values (the actual group lifetime, matching what the issue stream row does) and fall back to the top-level fields when `lifetime` is absent — e.g. the issue preview, which fetches a single issue where the top-level values are already the lifetime values.

Fixes [ISWF-3097](https://linear.app/getsentry/issue/ISWF-3097/fix-first-seen-in-inbox-row)