### PR TITLE
ref(billing): Remove redundant isTrial field

### DIFF
--- a/static/gsAdmin/components/customerStatus.tsx
+++ b/static/gsAdmin/components/customerStatus.tsx
@@ -14,7 +14,7 @@ const getLabel = (item: Subscription) => {
   if (item.isEnterpriseTrial) {
     return `Trialing (${item.trialPlan} enterprise)`;
   }
-  if (item.isTrial) {
+  if (item.trialPlan !== null) {
     return `Trialing (${item.trialPlan})`;
   }
   if (item.isFree) {

--- a/static/gsAdmin/components/customerStatus.tsx
+++ b/static/gsAdmin/components/customerStatus.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import {InfoText} from '@sentry/scraps/info';
 
 import type {Subscription} from 'getsentry/types';
+import {isTrial} from 'getsentry/utils/billing';
 import {formatCurrency} from 'getsentry/utils/formatCurrency';
 
 type Props = {
@@ -14,7 +15,7 @@ const getLabel = (item: Subscription) => {
   if (item.isEnterpriseTrial) {
     return `Trialing (${item.trialPlan} enterprise)`;
   }
-  if (item.trialPlan !== null) {
+  if (isTrial(item)) {
     return `Trialing (${item.trialPlan})`;
   }
   if (item.isFree) {

--- a/static/gsAdmin/components/customers/customerOverview.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.tsx
@@ -648,7 +648,7 @@ export function CustomerOverview({customer, onAction, organization}: Props) {
         <DetailList>
           <DetailLabel title="Status">
             <CustomerStatus customer={customer} />
-            {customer.isTrial && (
+            {customer.trialPlan !== null && (
               <div>
                 <small>
                   <strong>{moment(customer.trialEnd).fromNow(true)} remaining</strong>{' '}

--- a/static/gsAdmin/components/customers/customerOverview.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.tsx
@@ -43,6 +43,7 @@ import {
   getActiveProductTrial,
   getBilledCategory,
   getProductTrial,
+  isTrial,
   RETENTION_SETTINGS_CATEGORIES,
 } from 'getsentry/utils/billing';
 import {
@@ -648,7 +649,7 @@ export function CustomerOverview({customer, onAction, organization}: Props) {
         <DetailList>
           <DetailLabel title="Status">
             <CustomerStatus customer={customer} />
-            {customer.trialPlan !== null && (
+            {isTrial(customer) && (
               <div>
                 <small>
                   <strong>{moment(customer.trialEnd).fromNow(true)} remaining</strong>{' '}

--- a/static/gsAdmin/components/trialSubscriptionAction.tsx
+++ b/static/gsAdmin/components/trialSubscriptionAction.tsx
@@ -11,6 +11,7 @@ import type {
   AdminConfirmRenderProps,
 } from 'admin/components/adminConfirmationModal';
 import type {Subscription} from 'getsentry/types';
+import {isTrial} from 'getsentry/utils/billing';
 
 type Props = AdminConfirmRenderProps & {
   subscription: Subscription;
@@ -69,7 +70,7 @@ export class TrialSubscriptionAction extends Component<Props, State> {
     if (startEnterpriseTrial) {
       return 'Start Enterprise Trial';
     }
-    return subscription.trialPlan === null ? 'Start Trial' : 'Extend Trial';
+    return isTrial(subscription) ? 'Extend Trial' : 'Start Trial';
   }
 
   render() {

--- a/static/gsAdmin/components/trialSubscriptionAction.tsx
+++ b/static/gsAdmin/components/trialSubscriptionAction.tsx
@@ -69,7 +69,7 @@ export class TrialSubscriptionAction extends Component<Props, State> {
     if (startEnterpriseTrial) {
       return 'Start Enterprise Trial';
     }
-    return subscription.isTrial ? 'Extend Trial' : 'Start Trial';
+    return subscription.trialPlan === null ? 'Start Trial' : 'Extend Trial';
   }
 
   render() {

--- a/static/gsAdmin/views/customerDetails.spec.tsx
+++ b/static/gsAdmin/views/customerDetails.spec.tsx
@@ -1298,7 +1298,7 @@ describe('Customer Details', () => {
     const cannotTrialOrg = OrganizationFixture({slug: 'cannot-trial-org'});
 
     it('renders Allow Trial in the dropdown', async () => {
-      setUpMocks(cannotTrialOrg, {canTrial: false, isTrial: false});
+      setUpMocks(cannotTrialOrg, {canTrial: false, trialPlan: null});
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
@@ -1320,7 +1320,7 @@ describe('Customer Details', () => {
     });
 
     it('hides Allow Trial in the dropdown when not eligible', async () => {
-      setUpMocks(organization, {canTrial: true, isTrial: false});
+      setUpMocks(organization, {canTrial: true, trialPlan: null});
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
@@ -1342,7 +1342,7 @@ describe('Customer Details', () => {
     });
 
     it('hides Allow Trial in the dropdown when on active trial', async () => {
-      setUpMocks(organization, {canTrial: false, isTrial: true});
+      setUpMocks(organization, {canTrial: false, trialPlan: 'am1_t'});
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
@@ -1370,7 +1370,7 @@ describe('Customer Details', () => {
         body: OrganizationFixture(),
       });
 
-      setUpMocks(cannotTrialOrg, {canTrial: false, isTrial: false});
+      setUpMocks(cannotTrialOrg, {canTrial: false, trialPlan: null});
 
       render(<CustomerDetails />, {
         initialRouterConfig: {
@@ -2096,7 +2096,7 @@ describe('Customer Details', () => {
     it('can end trial early', async () => {
       const trialOrg = OrganizationFixture();
 
-      setUpMocks(trialOrg, {isTrial: true});
+      setUpMocks(trialOrg, {trialPlan: 'am1_t'});
 
       const updateMock = MockApiClient.addMockResponse({
         url: `/customers/${trialOrg.slug}/`,

--- a/static/gsAdmin/views/customerDetails.tsx
+++ b/static/gsAdmin/views/customerDetails.tsx
@@ -210,6 +210,8 @@ export function CustomerDetails() {
     return null;
   }
 
+  const isTrial = subscription.trialPlan !== null;
+
   const activeDataType =
     (location.query.dataType as DataCategoryExact) ?? DataCategoryExact.ERROR;
 
@@ -397,14 +399,14 @@ export function CustomerDetails() {
             key: 'allowTrial',
             name: 'Allow Trial',
             help: 'Allow this account to opt-in to a trial period.',
-            visible: !subscription.canTrial && !subscription.isTrial,
+            visible: !subscription.canTrial && !isTrial,
             onAction: params => onUpdateMutation.mutate({...params, canTrial: true}),
           },
           {
             key: 'endTrialEarly',
             name: 'End Trial Early',
             help: 'End the current trial immediately.',
-            disabled: !subscription.isTrial,
+            disabled: !isTrial,
             disabledReason: 'This account is not on on trial.',
             onAction: params => onUpdateMutation.mutate({...params, endTrialEarly: true}),
           },
@@ -568,7 +570,7 @@ export function CustomerDetails() {
           },
           {
             key: 'startTrial',
-            name: subscription.isTrial ? 'Extend Trial' : 'Start Trial',
+            name: isTrial ? 'Extend Trial' : 'Start Trial',
             help: 'Start or extend a trial for this account.',
             confirmModalOpts: {
               renderModalSpecificContent: deps => (

--- a/static/gsAdmin/views/customerDetails.tsx
+++ b/static/gsAdmin/views/customerDetails.tsx
@@ -77,6 +77,7 @@ import {
   hasActiveVCFeature,
   hasPerformance,
   isBizPlanFamily,
+  isTrial,
   isUnlimitedReserved,
 } from 'getsentry/utils/billing';
 import {
@@ -209,8 +210,6 @@ export function CustomerDetails() {
   if (subscription === null || organization === null || billingConfig === null) {
     return null;
   }
-
-  const isTrial = subscription.trialPlan !== null;
 
   const activeDataType =
     (location.query.dataType as DataCategoryExact) ?? DataCategoryExact.ERROR;
@@ -399,14 +398,14 @@ export function CustomerDetails() {
             key: 'allowTrial',
             name: 'Allow Trial',
             help: 'Allow this account to opt-in to a trial period.',
-            visible: !subscription.canTrial && !isTrial,
+            visible: !subscription.canTrial && !isTrial(subscription),
             onAction: params => onUpdateMutation.mutate({...params, canTrial: true}),
           },
           {
             key: 'endTrialEarly',
             name: 'End Trial Early',
             help: 'End the current trial immediately.',
-            disabled: !isTrial,
+            disabled: !isTrial(subscription),
             disabledReason: 'This account is not on on trial.',
             onAction: params => onUpdateMutation.mutate({...params, endTrialEarly: true}),
           },
@@ -570,7 +569,7 @@ export function CustomerDetails() {
           },
           {
             key: 'startTrial',
-            name: isTrial ? 'Extend Trial' : 'Start Trial',
+            name: isTrial(subscription) ? 'Extend Trial' : 'Start Trial',
             help: 'Start or extend a trial for this account.',
             confirmModalOpts: {
               renderModalSpecificContent: deps => (

--- a/static/gsApp/components/crons/cronsBillingBanner.spec.tsx
+++ b/static/gsApp/components/crons/cronsBillingBanner.spec.tsx
@@ -38,7 +38,7 @@ describe('CronsBillingBanner', () => {
     const subscription = SubscriptionFixture({
       organization,
       trialEnd,
-      isTrial: true,
+      trialPlan: 'am1_t',
     });
 
     const mockApiCall = MockApiClient.addMockResponse({

--- a/static/gsApp/components/crons/cronsBillingBanner.tsx
+++ b/static/gsApp/components/crons/cronsBillingBanner.tsx
@@ -20,7 +20,7 @@ import type {
   Plan,
   Subscription,
 } from 'getsentry/types';
-import {displayBudgetName, getTrialDaysLeft} from 'getsentry/utils/billing';
+import {displayBudgetName, getTrialDaysLeft, isTrial} from 'getsentry/utils/billing';
 
 interface Props {
   organization: Organization;
@@ -86,7 +86,7 @@ export function CronsBillingBanner({organization, subscription}: Props) {
     return null;
   }
 
-  if (trialDaysLeft <= 7 && subscription.trialPlan !== null) {
+  if (trialDaysLeft <= 7 && isTrial(subscription)) {
     return (
       <TrialEndingBanner
         hasBillingAccess={hasBillingAccess}

--- a/static/gsApp/components/crons/cronsBillingBanner.tsx
+++ b/static/gsApp/components/crons/cronsBillingBanner.tsx
@@ -86,7 +86,7 @@ export function CronsBillingBanner({organization, subscription}: Props) {
     return null;
   }
 
-  if (trialDaysLeft <= 7 && subscription.isTrial) {
+  if (trialDaysLeft <= 7 && subscription.trialPlan !== null) {
     return (
       <TrialEndingBanner
         hasBillingAccess={hasBillingAccess}

--- a/static/gsApp/components/gsBanner.spec.tsx
+++ b/static/gsApp/components/gsBanner.spec.tsx
@@ -141,7 +141,7 @@ describe('GSBanner', () => {
       organization.slug,
       SubscriptionFixture({
         organization,
-        isTrial: true,
+        trialPlan: 'am1_t',
         hasDismissedTrialEndingNotice: false,
         plan: 'am1_t',
         trialEnd: now.add(2, 'day').toISOString(),
@@ -225,7 +225,7 @@ describe('GSBanner', () => {
       organization.slug,
       SubscriptionFixture({
         organization,
-        isTrial: true,
+        trialPlan: 'am1_business',
         hasDismissedTrialEndingNotice: false,
         plan: 'am1_business',
         trialEnd: now.add(2, 'day').toISOString(),

--- a/static/gsApp/components/memberInviteModalCustomization.tsx
+++ b/static/gsApp/components/memberInviteModalCustomization.tsx
@@ -11,7 +11,7 @@ import {OrganizationContext} from 'sentry/utils/organizationContext';
 import TrialStarter from 'getsentry/components/trialStarter';
 import UpgradeOrTrialButton from 'getsentry/components/upgradeOrTrialButton';
 import type {Subscription} from 'getsentry/types';
-import {getTrialLength, hasJustStartedPlanTrial} from 'getsentry/utils/billing';
+import {getTrialLength, hasJustStartedPlanTrial, isTrial} from 'getsentry/utils/billing';
 
 import {withSubscription} from './withSubscription';
 
@@ -36,7 +36,6 @@ function MemberInviteModalCustomization({
   subscription,
 }: MemberInviteProps) {
   const {totalMembers, canTrial, totalLicenses} = subscription;
-  const isTrial = subscription.trialPlan !== null;
   const usedSeats = totalMembers ?? 0;
   const isOverMemberLimit = totalLicenses > 0 && usedSeats >= totalLicenses;
 
@@ -69,7 +68,7 @@ function MemberInviteModalCustomization({
     }
 
     const allowedToStartTrial = organization.access.includes('org:billing');
-    const isExpired = !canTrial && !isTrial;
+    const isExpired = !canTrial && !isTrial(subscription);
     const trialLength = getTrialLength(organization);
 
     const trialStartText = t('Start your %s day Business Plan trial today!', trialLength);

--- a/static/gsApp/components/memberInviteModalCustomization.tsx
+++ b/static/gsApp/components/memberInviteModalCustomization.tsx
@@ -35,7 +35,8 @@ function MemberInviteModalCustomization({
   children,
   subscription,
 }: MemberInviteProps) {
-  const {totalMembers, canTrial, isTrial, totalLicenses} = subscription;
+  const {totalMembers, canTrial, totalLicenses} = subscription;
+  const isTrial = subscription.trialPlan !== null;
   const usedSeats = totalMembers ?? 0;
   const isOverMemberLimit = totalLicenses > 0 && usedSeats >= totalLicenses;
 

--- a/static/gsApp/components/tryBusinessSidebarItem.tsx
+++ b/static/gsApp/components/tryBusinessSidebarItem.tsx
@@ -37,7 +37,7 @@ function TryBusinessNavigationItem({
     false
   );
 
-  const isNew = !subscription.isTrial && subscription.canTrial;
+  const isNew = subscription.trialPlan === null && subscription.canTrial;
   const showIsNew = isNew && !tryBusinessSeen;
 
   return (
@@ -88,7 +88,7 @@ function TryBusinessSidebarItem(props: Props) {
   }, [props.organization]);
 
   const labelText = useMemo(() => {
-    if (props.subscription.isTrial) {
+    if (props.subscription.trialPlan !== null) {
       return t('My Sentry Trial');
     }
     if (!props.subscription.canTrial) {

--- a/static/gsApp/components/tryBusinessSidebarItem.tsx
+++ b/static/gsApp/components/tryBusinessSidebarItem.tsx
@@ -11,7 +11,7 @@ import {openUpsellModal} from 'getsentry/actionCreators/modal';
 import TrialStartedSidebarItem from 'getsentry/components/trialStartedSidebarItem';
 import {withSubscription} from 'getsentry/components/withSubscription';
 import type {Subscription} from 'getsentry/types';
-import {hasPerformance, isBizPlanFamily} from 'getsentry/utils/billing';
+import {hasPerformance, isBizPlanFamily, isTrial} from 'getsentry/utils/billing';
 
 const AUTO_OPEN_HASH = '#try-business';
 
@@ -37,7 +37,7 @@ function TryBusinessNavigationItem({
     false
   );
 
-  const isNew = subscription.trialPlan === null && subscription.canTrial;
+  const isNew = !isTrial(subscription) && subscription.canTrial;
   const showIsNew = isNew && !tryBusinessSeen;
 
   return (
@@ -88,7 +88,7 @@ function TryBusinessSidebarItem(props: Props) {
   }, [props.organization]);
 
   const labelText = useMemo(() => {
-    if (props.subscription.trialPlan !== null) {
+    if (isTrial(props.subscription)) {
       return t('My Sentry Trial');
     }
     if (!props.subscription.canTrial) {

--- a/static/gsApp/components/upgradeOrTrialButton.tsx
+++ b/static/gsApp/components/upgradeOrTrialButton.tsx
@@ -66,8 +66,7 @@ function UpgradeOrTrialButton({
 
   // can override action if we want
   const action =
-    _action ??
-    (subscription.canTrial && !isTrial(subscription) ? 'trial' : 'upgrade');
+    _action ?? (subscription.canTrial && !isTrial(subscription) ? 'trial' : 'upgrade');
 
   const childComponent =
     typeof children === 'function'

--- a/static/gsApp/components/upgradeOrTrialButton.tsx
+++ b/static/gsApp/components/upgradeOrTrialButton.tsx
@@ -66,7 +66,8 @@ function UpgradeOrTrialButton({
 
   // can override action if we want
   const action =
-    _action ?? (subscription.canTrial && !subscription.isTrial ? 'trial' : 'upgrade');
+    _action ??
+    (subscription.canTrial && subscription.trialPlan === null ? 'trial' : 'upgrade');
 
   const childComponent =
     typeof children === 'function'

--- a/static/gsApp/components/upgradeOrTrialButton.tsx
+++ b/static/gsApp/components/upgradeOrTrialButton.tsx
@@ -11,7 +11,7 @@ import {withApi} from 'sentry/utils/withApi';
 import {sendTrialRequest, sendUpgradeRequest} from 'getsentry/actionCreators/upsell';
 import {StartTrialButton} from 'getsentry/components/startTrialButton';
 import type {Subscription} from 'getsentry/types';
-import {getTrialLength} from 'getsentry/utils/billing';
+import {getTrialLength, isTrial} from 'getsentry/utils/billing';
 import {trackGetsentryAnalytics} from 'getsentry/utils/trackGetsentryAnalytics';
 
 type ChildRenderProps = {
@@ -67,7 +67,7 @@ function UpgradeOrTrialButton({
   // can override action if we want
   const action =
     _action ??
-    (subscription.canTrial && subscription.trialPlan === null ? 'trial' : 'upgrade');
+    (subscription.canTrial && !isTrial(subscription) ? 'trial' : 'upgrade');
 
   const childComponent =
     typeof children === 'function'

--- a/static/gsApp/components/upsellModal/details.spec.tsx
+++ b/static/gsApp/components/upsellModal/details.spec.tsx
@@ -31,7 +31,6 @@ describe('Upsell Modal Details', () => {
       organization,
       plan: 'am1_f',
       canTrial: true,
-      isTrial: false,
       isFree: true,
     });
 
@@ -56,7 +55,7 @@ describe('Upsell Modal Details', () => {
       organization,
       plan: 'am1_t',
       canTrial: false,
-      isTrial: true,
+      trialPlan: 'am1_t',
       isFree: false,
     });
 
@@ -83,7 +82,6 @@ describe('Upsell Modal Details', () => {
       organization,
       plan: 'am1_f',
       canTrial: true,
-      isTrial: false,
       isFree: true,
     });
 
@@ -110,7 +108,6 @@ describe('Upsell Modal Details', () => {
       organization,
       plan: 'am1_team',
       canTrial: true,
-      isTrial: false,
       isFree: false,
     });
 
@@ -134,7 +131,6 @@ describe('Upsell Modal Details', () => {
       organization,
       plan: 'mm2_a_100k',
       canTrial: true,
-      isTrial: false,
       isFree: false,
     });
 
@@ -158,7 +154,6 @@ describe('Upsell Modal Details', () => {
       organization,
       plan: 'mm2_a_100k',
       canTrial: true,
-      isTrial: false,
       isFree: false,
     });
 
@@ -194,7 +189,6 @@ describe('Upsell Modal Details', () => {
       organization,
       plan: 'am3_f',
       canTrial: true,
-      isTrial: false,
       isFree: true,
     });
 

--- a/static/gsApp/components/upsellModal/details.tsx
+++ b/static/gsApp/components/upsellModal/details.tsx
@@ -16,7 +16,7 @@ import {t, tct} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 
 import type {Subscription} from 'getsentry/types';
-import {getTrialLength, hasPerformance} from 'getsentry/utils/billing';
+import {getTrialLength, hasPerformance, isTrial} from 'getsentry/utils/billing';
 import {trackGetsentryAnalytics} from 'getsentry/utils/trackGetsentryAnalytics';
 
 import {FeatureList} from './featureList';
@@ -303,8 +303,37 @@ export class Details extends Component<Props, State> {
       ];
     }
 
-    return subscription.trialPlan === null
-      ? hasPerformance(subscription.planDetails)
+    return isTrial(subscription)
+      ? // If the subscription already has performance
+        hasPerformance(subscription.planDetails)
+        ? [
+            t(
+              `With your trial you have access to Sentry’s Power Features, which
+               offer a macro-level perspective of error trends and application
+               health, while also allowing you to drill down into a single
+               issue or event with Dashboards and Discover-powered queries.`
+            ),
+            t(
+              `We hope you’re enjoying these new features to create complex
+               queries against event data, see all issues across projects, and
+               view dashboards for a comprehensive and holistic view.`
+            ),
+          ]
+        : [
+            t(
+              `With your trial you have access to Sentry’s Performance Monitoring
+               features which give you deeper visibility into your frontend page
+               load times and database queries that are critical toward
+               delivering fast customer experiences.`
+            ),
+            t(
+              `With just five lines of code, you’re now able to highlight your
+               key transactions and set metric alerts to detect latency spikes.
+               You can also dive in and query across multiple projects for a
+               comprehensive view into your application.`
+            ),
+          ]
+      : hasPerformance(subscription.planDetails)
         ? [
             t(
               `We added a bunch of new features that made Sentry a whole lot better.
@@ -334,35 +363,6 @@ export class Details extends Component<Props, State> {
               `Confusing, we know. Basically, your Sentry organization is perfect just the way it is,
              but upgrade now if you want it to be even better. `
             ),
-          ]
-      : // If the subscription already has performance
-        hasPerformance(subscription.planDetails)
-        ? [
-            t(
-              `With your trial you have access to Sentry’s Power Features, which
-               offer a macro-level perspective of error trends and application
-               health, while also allowing you to drill down into a single
-               issue or event with Dashboards and Discover-powered queries.`
-            ),
-            t(
-              `We hope you’re enjoying these new features to create complex
-               queries against event data, see all issues across projects, and
-               view dashboards for a comprehensive and holistic view.`
-            ),
-          ]
-        : [
-            t(
-              `With your trial you have access to Sentry’s Performance Monitoring
-               features which give you deeper visibility into your frontend page
-               load times and database queries that are critical toward
-               delivering fast customer experiences.`
-            ),
-            t(
-              `With just five lines of code, you’re now able to highlight your
-               key transactions and set metric alerts to detect latency spikes.
-               You can also dive in and query across multiple projects for a
-               comprehensive view into your application.`
-            ),
           ];
   }
 
@@ -373,7 +373,7 @@ export class Details extends Component<Props, State> {
         'Start your trial again to invite team members, integrate with Sentry with services like Slack, GitHub, and Jira, and build custom dashboards to view issues across projects.'
       );
     }
-    return subscription.canTrial && subscription.trialPlan === null
+    return subscription.canTrial && !isTrial(subscription)
       ? t(
           'Enable all power features by starting your %s day trial',
           getTrialLength(organization)

--- a/static/gsApp/components/upsellModal/details.tsx
+++ b/static/gsApp/components/upsellModal/details.tsx
@@ -303,37 +303,8 @@ export class Details extends Component<Props, State> {
       ];
     }
 
-    return subscription.isTrial
-      ? // If the subscription already has performance
-        hasPerformance(subscription.planDetails)
-        ? [
-            t(
-              `With your trial you have access to Sentry’s Power Features, which
-               offer a macro-level perspective of error trends and application
-               health, while also allowing you to drill down into a single
-               issue or event with Dashboards and Discover-powered queries.`
-            ),
-            t(
-              `We hope you’re enjoying these new features to create complex
-               queries against event data, see all issues across projects, and
-               view dashboards for a comprehensive and holistic view.`
-            ),
-          ]
-        : [
-            t(
-              `With your trial you have access to Sentry’s Performance Monitoring
-               features which give you deeper visibility into your frontend page
-               load times and database queries that are critical toward
-               delivering fast customer experiences.`
-            ),
-            t(
-              `With just five lines of code, you’re now able to highlight your
-               key transactions and set metric alerts to detect latency spikes.
-               You can also dive in and query across multiple projects for a
-               comprehensive view into your application.`
-            ),
-          ]
-      : hasPerformance(subscription.planDetails)
+    return subscription.trialPlan === null
+      ? hasPerformance(subscription.planDetails)
         ? [
             t(
               `We added a bunch of new features that made Sentry a whole lot better.
@@ -363,6 +334,35 @@ export class Details extends Component<Props, State> {
               `Confusing, we know. Basically, your Sentry organization is perfect just the way it is,
              but upgrade now if you want it to be even better. `
             ),
+          ]
+      : // If the subscription already has performance
+        hasPerformance(subscription.planDetails)
+        ? [
+            t(
+              `With your trial you have access to Sentry’s Power Features, which
+               offer a macro-level perspective of error trends and application
+               health, while also allowing you to drill down into a single
+               issue or event with Dashboards and Discover-powered queries.`
+            ),
+            t(
+              `We hope you’re enjoying these new features to create complex
+               queries against event data, see all issues across projects, and
+               view dashboards for a comprehensive and holistic view.`
+            ),
+          ]
+        : [
+            t(
+              `With your trial you have access to Sentry’s Performance Monitoring
+               features which give you deeper visibility into your frontend page
+               load times and database queries that are critical toward
+               delivering fast customer experiences.`
+            ),
+            t(
+              `With just five lines of code, you’re now able to highlight your
+               key transactions and set metric alerts to detect latency spikes.
+               You can also dive in and query across multiple projects for a
+               comprehensive view into your application.`
+            ),
           ];
   }
 
@@ -373,7 +373,7 @@ export class Details extends Component<Props, State> {
         'Start your trial again to invite team members, integrate with Sentry with services like Slack, GitHub, and Jira, and build custom dashboards to view issues across projects.'
       );
     }
-    return subscription.canTrial && !subscription.isTrial
+    return subscription.canTrial && subscription.trialPlan === null
       ? t(
           'Enable all power features by starting your %s day trial',
           getTrialLength(organization)

--- a/static/gsApp/components/upsellModal/footer.spec.tsx
+++ b/static/gsApp/components/upsellModal/footer.spec.tsx
@@ -27,7 +27,6 @@ describe('Business Landing Footer', () => {
           ...subscription,
           plan: 'mm2_f',
           canTrial: true,
-          isTrial: false,
         }}
         organization={organization}
         onCloseModal={jest.fn()}
@@ -47,7 +46,7 @@ describe('Business Landing Footer', () => {
           ...subscription,
           plan: 'am1_t',
           canTrial: false,
-          isTrial: true,
+          trialPlan: 'am1_t',
         }}
         organization={organization}
         onCloseModal={jest.fn()}
@@ -68,7 +67,6 @@ describe('Business Landing Footer', () => {
           ...subscription,
           plan: 'mm2_f',
           canTrial: false,
-          isTrial: false,
         }}
         organization={organization}
         onCloseModal={jest.fn()}
@@ -88,7 +86,6 @@ describe('Business Landing Footer', () => {
           ...subscription,
           plan: 'mm2_a_500k',
           canTrial: false,
-          isTrial: false,
         }}
         organization={organization}
         onCloseModal={jest.fn()}
@@ -116,7 +113,6 @@ describe('Business Landing Footer', () => {
           ...subscription,
           plan: 'mm2_f',
           canTrial: false,
-          isTrial: false,
         }}
         organization={OrganizationFixture({
           ...organization,
@@ -155,7 +151,6 @@ describe('Business Landing Footer', () => {
           ...subscription,
           plan: 'mm2_f',
           canTrial: true,
-          isTrial: false,
         }}
         organization={OrganizationFixture({
           ...organization,

--- a/static/gsApp/components/upsellModal/footer.tsx
+++ b/static/gsApp/components/upsellModal/footer.tsx
@@ -8,7 +8,7 @@ import type {Organization} from 'sentry/types/organization';
 
 import UpgradeOrTrialButton from 'getsentry/components/upgradeOrTrialButton';
 import type {Subscription} from 'getsentry/types';
-import {getFriendlyPlanName} from 'getsentry/utils/billing';
+import {getFriendlyPlanName, isTrial} from 'getsentry/utils/billing';
 import {trackGetsentryAnalytics} from 'getsentry/utils/trackGetsentryAnalytics';
 
 interface UpsellFooterProps {
@@ -33,7 +33,7 @@ export function Footer({
     onSuccess: onCloseModal,
   };
 
-  const canTrial = subscription.canTrial && subscription.trialPlan === null;
+  const canTrial = subscription.canTrial && !isTrial(subscription);
 
   return (
     <Flex align="end" gap="md">

--- a/static/gsApp/components/upsellModal/footer.tsx
+++ b/static/gsApp/components/upsellModal/footer.tsx
@@ -33,7 +33,7 @@ export function Footer({
     onSuccess: onCloseModal,
   };
 
-  const canTrial = subscription.canTrial && !subscription.isTrial;
+  const canTrial = subscription.canTrial && subscription.trialPlan === null;
 
   return (
     <Flex align="end" gap="md">

--- a/static/gsApp/components/upsellModal/highlightedFeature.tsx
+++ b/static/gsApp/components/upsellModal/highlightedFeature.tsx
@@ -42,7 +42,7 @@ export function HighlightedFeature({feature, organization, subscription}: Props)
                 strong: <strong />,
               }
             )}
-        {!subscription.isTrial &&
+        {subscription.trialPlan === null &&
           tct(" You're currently on the [current] plan.", {
             current: subscription.planDetails.name,
           })}

--- a/static/gsApp/components/upsellModal/highlightedFeature.tsx
+++ b/static/gsApp/components/upsellModal/highlightedFeature.tsx
@@ -7,7 +7,7 @@ import type {Organization} from 'sentry/types/organization';
 
 import PlanFeature from 'getsentry/components/features/planFeature';
 import type {Subscription} from 'getsentry/types';
-import {displayPlanName, hasPerformance} from 'getsentry/utils/billing';
+import {displayPlanName, hasPerformance, isTrial} from 'getsentry/utils/billing';
 
 import type {Feature} from './types';
 
@@ -42,7 +42,7 @@ export function HighlightedFeature({feature, organization, subscription}: Props)
                 strong: <strong />,
               }
             )}
-        {subscription.trialPlan === null &&
+        {!isTrial(subscription) &&
           tct(" You're currently on the [current] plan.", {
             current: subscription.planDetails.name,
           })}

--- a/static/gsApp/components/upsellModal/index.tsx
+++ b/static/gsApp/components/upsellModal/index.tsx
@@ -20,8 +20,9 @@ type Props = ModalRenderProps & {
 };
 
 function UpsellModal({source, organization, subscription}: Props) {
-  const canTrial = subscription.canTrial && !subscription.isTrial;
-  const headerMessage = subscription.isTrial ? (
+  const isTrial = subscription.trialPlan !== null;
+  const canTrial = subscription.canTrial && !isTrial;
+  const headerMessage = isTrial ? (
     <div>
       <Subheader>
         {tn(

--- a/static/gsApp/components/upsellModal/index.tsx
+++ b/static/gsApp/components/upsellModal/index.tsx
@@ -9,7 +9,12 @@ import type {Organization} from 'sentry/types/organization';
 
 import {withSubscription} from 'getsentry/components/withSubscription';
 import type {Subscription} from 'getsentry/types';
-import {getTrialDaysLeft, getTrialLength, hasPerformance} from 'getsentry/utils/billing';
+import {
+  getTrialDaysLeft,
+  getTrialLength,
+  hasPerformance,
+  isTrial,
+} from 'getsentry/utils/billing';
 
 import {Details} from './details';
 
@@ -20,9 +25,8 @@ type Props = ModalRenderProps & {
 };
 
 function UpsellModal({source, organization, subscription}: Props) {
-  const isTrial = subscription.trialPlan !== null;
-  const canTrial = subscription.canTrial && !isTrial;
-  const headerMessage = isTrial ? (
+  const canTrial = subscription.canTrial && !isTrial(subscription);
+  const headerMessage = isTrial(subscription) ? (
     <div>
       <Subheader>
         {tn(

--- a/static/gsApp/components/upsellProvider.tsx
+++ b/static/gsApp/components/upsellProvider.tsx
@@ -16,7 +16,7 @@ import {sendTrialRequest, sendUpgradeRequest} from 'getsentry/actionCreators/ups
 import TrialStarter from 'getsentry/components/trialStarter';
 import {withSubscription} from 'getsentry/components/withSubscription';
 import type {Subscription} from 'getsentry/types';
-import {getTrialLength} from 'getsentry/utils/billing';
+import {getTrialLength, isTrial} from 'getsentry/utils/billing';
 import {
   trackGetsentryAnalytics,
   type GetsentryEventKey,
@@ -97,7 +97,7 @@ function UpsellProvider({
     return null;
   }
 
-  const canTrial = subscription.canTrial && subscription.trialPlan === null;
+  const canTrial = subscription.canTrial && !isTrial(subscription);
   const handleRequest = () => {
     const args = {
       api,

--- a/static/gsApp/components/upsellProvider.tsx
+++ b/static/gsApp/components/upsellProvider.tsx
@@ -97,7 +97,7 @@ function UpsellProvider({
     return null;
   }
 
-  const canTrial = subscription.canTrial && !subscription.isTrial;
+  const canTrial = subscription.canTrial && subscription.trialPlan === null;
   const handleRequest = () => {
     const args = {
       api,

--- a/static/gsApp/overrides/disabledMemberTooltip.spec.tsx
+++ b/static/gsApp/overrides/disabledMemberTooltip.spec.tsx
@@ -12,7 +12,6 @@ describe('MemberListHeader', () => {
   const sub = SubscriptionFixture({
     organization,
     canTrial: false,
-    isTrial: false,
     plan: 'am1_f',
   });
   SubscriptionStore.set(organization.slug, sub);

--- a/static/gsApp/overrides/memberListHeader.spec.tsx
+++ b/static/gsApp/overrides/memberListHeader.spec.tsx
@@ -26,7 +26,6 @@ describe('MemberListHeader', () => {
   const sub = SubscriptionFixture({
     organization,
     canTrial: false,
-    isTrial: false,
     plan: 'am1_f',
   });
   SubscriptionStore.set(organization.slug, sub);

--- a/static/gsApp/overrides/targetedOnboardingHeader.tsx
+++ b/static/gsApp/overrides/targetedOnboardingHeader.tsx
@@ -37,18 +37,21 @@ function TargetedOnboardingHeader({source, subscription}: Props) {
 
   // if trial is active, show info on that
   // otherwise show help button
-  const cta = subscription.isTrial ? (
-    <ActiveTrialWrapper
-      onClick={() => openUpsellModal({organization, source: 'targeted-onboarding'})}
-    >
-      <ActiveTrialHeader>{t('Trial is Active')}</ActiveTrialHeader>
-      <div>{tn('%s Day Left', '%s Days Left', getTrialDaysLeft(subscription) || 0)}</div>
-    </ActiveTrialWrapper>
-  ) : (
-    <NeedHelpLink href="https://www.sentry.help" onClick={trackClickNeedHelp}>
-      {t('Need help?')}
-    </NeedHelpLink>
-  );
+  const cta =
+    subscription.trialPlan === null ? (
+      <NeedHelpLink href="https://www.sentry.help" onClick={trackClickNeedHelp}>
+        {t('Need help?')}
+      </NeedHelpLink>
+    ) : (
+      <ActiveTrialWrapper
+        onClick={() => openUpsellModal({organization, source: 'targeted-onboarding'})}
+      >
+        <ActiveTrialHeader>{t('Trial is Active')}</ActiveTrialHeader>
+        <div>
+          {tn('%s Day Left', '%s Days Left', getTrialDaysLeft(subscription) || 0)}
+        </div>
+      </ActiveTrialWrapper>
+    );
 
   return (
     <HeaderActionBar gap="xl">

--- a/static/gsApp/overrides/targetedOnboardingHeader.tsx
+++ b/static/gsApp/overrides/targetedOnboardingHeader.tsx
@@ -12,7 +12,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {openUpsellModal} from 'getsentry/actionCreators/modal';
 import {withSubscription} from 'getsentry/components/withSubscription';
 import type {Subscription} from 'getsentry/types';
-import {getTrialDaysLeft} from 'getsentry/utils/billing';
+import {getTrialDaysLeft, isTrial} from 'getsentry/utils/billing';
 import {trackGetsentryAnalytics} from 'getsentry/utils/trackGetsentryAnalytics';
 
 type Props = {
@@ -37,21 +37,18 @@ function TargetedOnboardingHeader({source, subscription}: Props) {
 
   // if trial is active, show info on that
   // otherwise show help button
-  const cta =
-    subscription.trialPlan === null ? (
-      <NeedHelpLink href="https://www.sentry.help" onClick={trackClickNeedHelp}>
-        {t('Need help?')}
-      </NeedHelpLink>
-    ) : (
-      <ActiveTrialWrapper
-        onClick={() => openUpsellModal({organization, source: 'targeted-onboarding'})}
-      >
-        <ActiveTrialHeader>{t('Trial is Active')}</ActiveTrialHeader>
-        <div>
-          {tn('%s Day Left', '%s Days Left', getTrialDaysLeft(subscription) || 0)}
-        </div>
-      </ActiveTrialWrapper>
-    );
+  const cta = isTrial(subscription) ? (
+    <ActiveTrialWrapper
+      onClick={() => openUpsellModal({organization, source: 'targeted-onboarding'})}
+    >
+      <ActiveTrialHeader>{t('Trial is Active')}</ActiveTrialHeader>
+      <div>{tn('%s Day Left', '%s Days Left', getTrialDaysLeft(subscription) || 0)}</div>
+    </ActiveTrialWrapper>
+  ) : (
+    <NeedHelpLink href="https://www.sentry.help" onClick={trackClickNeedHelp}>
+      {t('Need help?')}
+    </NeedHelpLink>
+  );
 
   return (
     <HeaderActionBar gap="xl">

--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -326,7 +326,6 @@ export type Subscription = {
   isSponsored: boolean;
   isSuspended: boolean;
 
-  isTrial: boolean;
   lastTrialEnd: string | null;
   membersDeactivatedFromLimit: number;
   name: string;
@@ -609,8 +608,14 @@ type CamelToSnake<
         ? `${Prev extends '' ? '' : Prev extends 'lower' ? '_' : ''}${Lowercase<First>}`
         : Rest extends `${infer Next}${infer _Tail}`
           ? Next extends Lowercase<Next>
-            ? `${Prev extends '' ? '' : '_'}${Lowercase<First>}${CamelToSnake<Rest, 'upper'>}`
-            : `${Prev extends 'lower' ? '_' : ''}${Lowercase<First>}${CamelToSnake<Rest, 'upper'>}`
+            ? `${Prev extends '' ? '' : '_'}${Lowercase<First>}${CamelToSnake<
+                Rest,
+                'upper'
+              >}`
+            : `${Prev extends 'lower' ? '_' : ''}${Lowercase<First>}${CamelToSnake<
+                Rest,
+                'upper'
+              >}`
           : never
       : `${First}${CamelToSnake<Rest, Prev>}`
   : S;

--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -33,9 +33,6 @@ declare global {
   }
 
   namespace React {
-    // The type parameter name must match React's own DOMAttributes<T> for
-    // declaration merging to work, so it can't be renamed or prefixed with `_`.
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     interface DOMAttributes<T> {
       'data-test-id'?: string;
     }

--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -33,6 +33,9 @@ declare global {
   }
 
   namespace React {
+    // The type parameter name must match React's own DOMAttributes<T> for
+    // declaration merging to work, so it can't be renamed or prefixed with `_`.
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     interface DOMAttributes<T> {
       'data-test-id'?: string;
     }

--- a/static/gsApp/utils/billing.spec.tsx
+++ b/static/gsApp/utils/billing.spec.tsx
@@ -1002,7 +1002,7 @@ describe('isNewPayingCustomer', () => {
     const subscription = SubscriptionFixture({
       organization,
       plan: 'am3_team',
-      isTrial: true,
+      trialPlan: 'am3_team',
       isFree: false,
     });
     expect(isNewPayingCustomer(subscription, organization)).toBe(false);

--- a/static/gsApp/utils/billing.tsx
+++ b/static/gsApp/utils/billing.tsx
@@ -333,14 +333,14 @@ export const isTeamPlanFamily = (plan?: Plan) => plan?.name.includes(PlanName.TE
 
 export const isBusinessTrial = (subscription: Subscription) => {
   return (
-    subscription.isTrial &&
+    subscription.trialPlan !== null &&
     !subscription.isPerformancePlanTrial &&
     !subscription.isEnterpriseTrial
   );
 };
 
 export function hasJustStartedPlanTrial(subscription: Subscription) {
-  return subscription.isTrial && subscription.isTrialStarted;
+  return subscription.trialPlan !== null && subscription.isTrialStarted;
 }
 
 export const displayBudgetName = (

--- a/static/gsApp/utils/billing.tsx
+++ b/static/gsApp/utils/billing.tsx
@@ -1,11 +1,11 @@
-import type {PromptData} from 'sentry/actionCreators/prompts';
-import {IconBuilding, IconGroup, IconSeer, IconUser} from 'sentry/icons';
-import type {SVGIconProps} from 'sentry/icons/svgIcon';
-import {DataCategory} from 'sentry/types/core';
-import type {Organization} from 'sentry/types/organization';
-import {defined} from 'sentry/utils/defined';
-import {getDaysSinceDate} from 'sentry/utils/getDaysSinceDate';
-import {toTitleCase} from 'sentry/utils/string/toTitleCase';
+import type { PromptData } from "sentry/actionCreators/prompts";
+import { IconBuilding, IconGroup, IconSeer, IconUser } from "sentry/icons";
+import type { SVGIconProps } from "sentry/icons/svgIcon";
+import { DataCategory } from "sentry/types/core";
+import type { Organization } from "sentry/types/organization";
+import { defined } from "sentry/utils/defined";
+import { getDaysSinceDate } from "sentry/utils/getDaysSinceDate";
+import { toTitleCase } from "sentry/utils/string/toTitleCase";
 
 import {
   BILLION,
@@ -15,7 +15,7 @@ import {
   RESERVED_BUDGET_QUOTA,
   UNLIMITED,
   UNLIMITED_RESERVED,
-} from 'getsentry/constants';
+} from "getsentry/constants";
 import {
   AddOnCategory,
   CREDIT_INVOICE_ITEM_TYPES,
@@ -23,7 +23,7 @@ import {
   OnDemandBudgetMode,
   PlanName,
   ReservedBudgetCategoryType,
-} from 'getsentry/types';
+} from "getsentry/types";
 import type {
   BillingConfig,
   BillingDetails,
@@ -34,15 +34,15 @@ import type {
   Plan,
   ProductTrial,
   Subscription,
-} from 'getsentry/types';
-import {getCategoryInfoFromPlural} from 'getsentry/utils/dataCategory';
-import {titleCase} from 'getsentry/utils/titleCase';
-import {displayPriceWithCents} from 'getsentry/views/amCheckout/utils';
+} from "getsentry/types";
+import { getCategoryInfoFromPlural } from "getsentry/utils/dataCategory";
+import { titleCase } from "getsentry/utils/titleCase";
+import { displayPriceWithCents } from "getsentry/views/amCheckout/utils";
 
 export const MILLISECONDS_IN_HOUR = 3600_000;
 
 function isNum(val: unknown): val is number {
-  return typeof val === 'number';
+  return typeof val === "number";
 }
 
 // TODO(brendan): remove condition for 0 once -1 is the value we use to represent unlimited reserved quota
@@ -76,17 +76,20 @@ export const getSlot = (
   shouldMinimize = false
 ) => {
   let s = 0;
-  if (!slots?.length || (typeof events !== 'number' && typeof price !== 'number')) {
+  if (
+    !slots?.length ||
+    (typeof events !== "number" && typeof price !== "number")
+  ) {
     return 0;
   }
-  const byEvents = typeof events === 'number';
+  const byEvents = typeof events === "number";
 
   const value = isNum(events) ? events : isNum(price) ? price : null;
   if (value === null) {
     return 0;
   }
 
-  const slotKey = byEvents ? 'events' : 'price';
+  const slotKey = byEvents ? "events" : "price";
 
   while (value > slots[s]![slotKey]) {
     s++;
@@ -145,13 +148,13 @@ export function formatReservedWithUnits(
   isReservedBudget = false
 ): string {
   if (isReservedBudget) {
-    return displayPriceWithCents({cents: reservedQuantity ?? 0});
+    return displayPriceWithCents({ cents: reservedQuantity ?? 0 });
   }
 
   const categoryInfo = getCategoryInfoFromPlural(dataCategory);
-  const unitType = categoryInfo?.formatting.unitType ?? 'count';
+  const unitType = categoryInfo?.formatting.unitType ?? "count";
 
-  if (unitType !== 'bytes') {
+  if (unitType !== "bytes") {
     return formatReservedNumberToString(reservedQuantity, options);
   }
 
@@ -162,15 +165,18 @@ export function formatReservedWithUnits(
       ? reservedQuantity * GIGABYTE
       : reservedQuantity;
   if (isUnlimitedReserved(usageGb)) {
-    return options.isGifted ? '0 GB' : UNLIMITED;
+    return options.isGifted ? "0 GB" : UNLIMITED;
   }
 
   if (!options.useUnitScaling) {
     const byteOptions =
       dataCategory === DataCategory.LOG_BYTE
-        ? {...options, isAbbreviated: false}
+        ? { ...options, isAbbreviated: false }
         : options;
-    const formatted = formatReservedNumberToString(reservedQuantity, byteOptions);
+    const formatted = formatReservedNumberToString(
+      reservedQuantity,
+      byteOptions
+    );
     return `${formatted} GB`;
   }
 
@@ -186,12 +192,12 @@ export function formatReservedWithUnits(
 export function formatUsageWithUnits(
   usageQuantity = 0,
   dataCategory: DataCategory,
-  options: FormatOptions = {isAbbreviated: false, useUnitScaling: false}
+  options: FormatOptions = { isAbbreviated: false, useUnitScaling: false }
 ) {
   const categoryInfo = getCategoryInfoFromPlural(dataCategory);
-  const unitType = categoryInfo?.formatting.unitType ?? 'count';
+  const unitType = categoryInfo?.formatting.unitType ?? "count";
 
-  if (unitType === 'bytes') {
+  if (unitType === "bytes") {
     if (options.useUnitScaling) {
       return formatByteUnits(usageQuantity);
     }
@@ -199,16 +205,18 @@ export function formatUsageWithUnits(
     const usageGb = usageQuantity / GIGABYTE;
     return options.isAbbreviated
       ? `${displayNumber(usageGb)} GB`
-      : `${usageGb.toLocaleString(undefined, {maximumFractionDigits: 2})} GB`;
+      : `${usageGb.toLocaleString(undefined, { maximumFractionDigits: 2 })} GB`;
   }
-  if (unitType === 'durationHours') {
+  if (unitType === "durationHours") {
     const usageProfileHours = usageQuantity / MILLISECONDS_IN_HOUR;
     if (usageProfileHours === 0) {
-      return '0';
+      return "0";
     }
     return options.isAbbreviated
       ? displayNumber(usageProfileHours, 1)
-      : usageProfileHours.toLocaleString(undefined, {maximumFractionDigits: 1});
+      : usageProfileHours.toLocaleString(undefined, {
+          maximumFractionDigits: 1,
+        });
   }
   return options.isAbbreviated
     ? displayNumber(usageQuantity, 0)
@@ -220,12 +228,12 @@ export function convertUsageToReservedUnit(
   category: DataCategory | string
 ): number {
   const categoryInfo = getCategoryInfoFromPlural(category as DataCategory);
-  const unitType = categoryInfo?.formatting.unitType ?? 'count';
+  const unitType = categoryInfo?.formatting.unitType ?? "count";
 
-  if (unitType === 'bytes') {
+  if (unitType === "bytes") {
     return usage / GIGABYTE;
   }
-  if (unitType === 'durationHours') {
+  if (unitType === "durationHours") {
     return usage / MILLISECONDS_IN_HOUR;
   }
   return usage;
@@ -246,11 +254,11 @@ function formatReservedNumberToString(
 ): string {
   // "null" indicates that there's no quota for it.
   if (!defined(reservedQuantity)) {
-    return '0';
+    return "0";
   }
 
   if (reservedQuantity === RESERVED_BUDGET_QUOTA) {
-    return 'N/A';
+    return "N/A";
   }
 
   if (isUnlimitedReserved(reservedQuantity) && !options.isGifted) {
@@ -259,7 +267,7 @@ function formatReservedNumberToString(
 
   return options.isAbbreviated
     ? displayNumber(reservedQuantity, options.fractionDigits)
-    : reservedQuantity.toLocaleString(undefined, {maximumFractionDigits: 1});
+    : reservedQuantity.toLocaleString(undefined, { maximumFractionDigits: 1 });
 }
 
 /**
@@ -278,7 +286,7 @@ function formatReservedNumberToString(
  * sentry/utils/formatBytes.
  */
 function formatByteUnits(bytes: number, u = 0) {
-  const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+  const units = ["B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
   const threshold = 1000;
 
   while (bytes >= threshold) {
@@ -286,7 +294,11 @@ function formatByteUnits(bytes: number, u = 0) {
     u += 1;
   }
 
-  return bytes.toLocaleString(undefined, {maximumFractionDigits: 2}) + ' ' + units[u];
+  return (
+    bytes.toLocaleString(undefined, { maximumFractionDigits: 2 }) +
+    " " +
+    units[u]
+  );
 }
 
 /**
@@ -295,15 +307,21 @@ function formatByteUnits(bytes: number, u = 0) {
  */
 function displayNumber(n: number, fractionDigits = 0) {
   if (n >= BILLION) {
-    return (n / BILLION).toLocaleString(undefined, {maximumFractionDigits: 2}) + 'B';
+    return (
+      (n / BILLION).toLocaleString(undefined, { maximumFractionDigits: 2 }) +
+      "B"
+    );
   }
 
   if (n >= MILLION) {
-    return (n / MILLION).toLocaleString(undefined, {maximumFractionDigits: 1}) + 'M';
+    return (
+      (n / MILLION).toLocaleString(undefined, { maximumFractionDigits: 1 }) +
+      "M"
+    );
   }
 
   if (n >= 1000) {
-    return (n / 1000).toFixed().toLocaleString() + 'K';
+    return (n / 1000).toFixed().toLocaleString() + "K";
   }
 
   // Do not show decimals
@@ -320,27 +338,37 @@ export const hasPerformance = (plan?: Plan) => {
 };
 
 export const hasPartnerMigrationFeature = (organization: Organization) =>
-  organization.features.includes('partner-billing-migration');
+  organization.features.includes("partner-billing-migration");
 
 export const hasActiveVCFeature = (organization: Organization) =>
-  organization.features.includes('vc-marketplace-active-customer');
+  organization.features.includes("vc-marketplace-active-customer");
 
-export const isDeveloperPlan = (plan?: Plan) => plan?.name === PlanName.DEVELOPER;
+export const isDeveloperPlan = (plan?: Plan) =>
+  plan?.name === PlanName.DEVELOPER;
 
-export const isBizPlanFamily = (plan?: Plan) => plan?.name.includes(PlanName.BUSINESS);
+export const isBizPlanFamily = (plan?: Plan) =>
+  plan?.name.includes(PlanName.BUSINESS);
 
-export const isTeamPlanFamily = (plan?: Plan) => plan?.name.includes(PlanName.TEAM);
+export const isTeamPlanFamily = (plan?: Plan) =>
+  plan?.name.includes(PlanName.TEAM);
+
+/**
+ * Whether the subscription is currently on a trial, derived from `trialPlan`
+ * (non-null iff trialing).
+ */
+export const isTrial = (subscription: Subscription) =>
+  defined(subscription.trialPlan);
 
 export const isBusinessTrial = (subscription: Subscription) => {
   return (
-    subscription.trialPlan !== null &&
+    isTrial(subscription) &&
     !subscription.isPerformancePlanTrial &&
     !subscription.isEnterpriseTrial
   );
 };
 
 export function hasJustStartedPlanTrial(subscription: Subscription) {
-  return subscription.trialPlan !== null && subscription.isTrialStarted;
+  return isTrial(subscription) && subscription.isTrialStarted;
 }
 
 export const displayBudgetName = (
@@ -352,23 +380,23 @@ export const displayBudgetName = (
     withBudget?: boolean;
   } = {}
 ) => {
-  const budgetTerm = plan?.budgetTerm ?? 'pay-as-you-go';
-  const text = `${budgetTerm}${options.withBudget ? ' budget' : ''}`;
+  const budgetTerm = plan?.budgetTerm ?? "pay-as-you-go";
+  const text = `${budgetTerm}${options.withBudget ? " budget" : ""}`;
   if (options.abbreviated) {
-    if (budgetTerm === 'pay-as-you-go') {
-      return 'PAYG';
+    if (budgetTerm === "pay-as-you-go") {
+      return "PAYG";
     }
-    return 'OD';
+    return "OD";
   }
   if (options.title) {
-    if (budgetTerm === 'on-demand') {
+    if (budgetTerm === "on-demand") {
       if (options.withBudget) {
         if (options.pluralOndemand) {
-          return 'On-Demand Budgets';
+          return "On-Demand Budgets";
         }
-        return 'On-Demand Budget';
+        return "On-Demand Budget";
       }
-      return 'On-Demand';
+      return "On-Demand";
     }
     return titleCase(text);
   }
@@ -391,7 +419,7 @@ export const getOnDemandCategories = ({
   plan: Plan;
 }) => {
   if (budgetMode === OnDemandBudgetMode.PER_CATEGORY) {
-    return plan.onDemandCategories.filter(category => {
+    return plan.onDemandCategories.filter((category) => {
       const categoryInfo = getCategoryInfoFromPlural(category);
       if (!categoryInfo) {
         return false;
@@ -404,7 +432,7 @@ export const getOnDemandCategories = ({
 };
 
 export const displayPlanName = (plan?: Plan | null) => {
-  return plan?.isEnterprise ? 'Enterprise' : (plan?.name ?? '[unavailable]');
+  return plan?.isEnterprise ? "Enterprise" : plan?.name ?? "[unavailable]";
 };
 
 export const isNewPayingCustomer = (
@@ -420,7 +448,7 @@ export const isNewPayingCustomer = (
  */
 export function getTrialDaysLeft(subscription: Subscription): number {
   // trial end is in the future
-  return -1 * getDaysSinceDate(subscription.trialEnd ?? '');
+  return -1 * getDaysSinceDate(subscription.trialEnd ?? "");
 }
 
 /**
@@ -428,13 +456,19 @@ export function getTrialDaysLeft(subscription: Subscription): number {
  * Used to find the best plan for an org to upgrade to
  * based on a particular feature to unlock.
  */
-function sortPlansForUpgrade(billingConfig: BillingConfig, subscription: Subscription) {
+function sortPlansForUpgrade(
+  billingConfig: BillingConfig,
+  subscription: Subscription
+) {
   // Filter plans down to just user selectable plans types of the orgs current
   // contract interval. Sorted by price as features will become progressively
   // more available.
   let plans = billingConfig.planList
     .sort((a, b) => a.totalPrice - b.totalPrice)
-    .filter(p => p.userSelectable && p.billingInterval === subscription.billingInterval);
+    .filter(
+      (p) =>
+        p.userSelectable && p.billingInterval === subscription.billingInterval
+    );
 
   // If we're dealing with plans that are *not part of a tier* Then we can
   // assume special case that there is only one plan.
@@ -450,7 +484,7 @@ export function getBestPlanForUnlimitedMembers(
 ) {
   const plans = sortPlansForUpgrade(billingConfig, subscription);
   // the best plan is the first one that has unlimited members
-  return plans.find(p => p.maxMembers === null);
+  return plans.find((p) => p.maxMembers === null);
 }
 
 export function getTrialLength(_organization: Organization) {
@@ -460,16 +494,16 @@ export function getTrialLength(_organization: Organization) {
 
 export function formatBalance(value: number) {
   return value < 0
-    ? `${displayPriceWithCents({cents: 0 - value})} credit`
-    : `${displayPriceWithCents({cents: value})} owed`;
+    ? `${displayPriceWithCents({ cents: 0 - value })} credit`
+    : `${displayPriceWithCents({ cents: value })} owed`;
 }
 
 export enum UsageAction {
-  START_TRIAL = 'start_trial',
-  ADD_EVENTS = 'add_events',
-  REQUEST_ADD_EVENTS = 'request_add_events',
-  REQUEST_UPGRADE = 'request_upgrade',
-  SEND_TO_CHECKOUT = 'send_to_checkout',
+  START_TRIAL = "start_trial",
+  ADD_EVENTS = "add_events",
+  REQUEST_ADD_EVENTS = "request_add_events",
+  REQUEST_UPGRADE = "request_upgrade",
+  SEND_TO_CHECKOUT = "send_to_checkout",
 }
 
 /**
@@ -481,7 +515,7 @@ export function getBestActionToIncreaseEventLimits(
   subscription: Subscription
 ) {
   const isPaidPlan = subscription.planDetails?.totalPrice > 0;
-  const hasBillingPerms = organization.access?.includes('org:billing');
+  const hasBillingPerms = organization.access?.includes("org:billing");
 
   // free orgs can increase event limits by trialing
   if (!isPaidPlan && subscription.canTrial) {
@@ -489,26 +523,34 @@ export function getBestActionToIncreaseEventLimits(
   }
   // paid plans should add events without changing plans
   const hasAnyUsageExceeded = Object.values(subscription.categories).some(
-    category => category.usageExceeded
+    (category) => category.usageExceeded
   );
-  if (isPaidPlan && hasPerformance(subscription.planDetails) && hasAnyUsageExceeded) {
-    return hasBillingPerms ? UsageAction.ADD_EVENTS : UsageAction.REQUEST_ADD_EVENTS;
+  if (
+    isPaidPlan &&
+    hasPerformance(subscription.planDetails) &&
+    hasAnyUsageExceeded
+  ) {
+    return hasBillingPerms
+      ? UsageAction.ADD_EVENTS
+      : UsageAction.REQUEST_ADD_EVENTS;
   }
   // otherwise, we want them to upgrade to a different plan if they're not already on a Business plan
   if (!isBizPlanFamily(subscription.planDetails)) {
-    return hasBillingPerms ? UsageAction.SEND_TO_CHECKOUT : UsageAction.REQUEST_UPGRADE;
+    return hasBillingPerms
+      ? UsageAction.SEND_TO_CHECKOUT
+      : UsageAction.REQUEST_UPGRADE;
   }
-  return '';
+  return "";
 }
 
 /**
  * Returns a name for the plan that we can display to users
  */
 export function getFriendlyPlanName(subscription: Subscription) {
-  const {name} = subscription.planDetails;
+  const { name } = subscription.planDetails;
   switch (name) {
-    case 'Trial':
-      return 'Business Trial';
+    case "Trial":
+      return "Business Trial";
     default:
       return name;
   }
@@ -526,7 +568,10 @@ export function getPlanIcon(plan: Plan) {
   return <IconUser />;
 }
 
-export function getProductIcon(product: AddOnCategory, size?: SVGIconProps['size']) {
+export function getProductIcon(
+  product: AddOnCategory,
+  size?: SVGIconProps["size"]
+) {
   if ([AddOnCategory.LEGACY_SEER, AddOnCategory.SEER].includes(product)) {
     return <IconSeer size={size} />;
   }
@@ -537,7 +582,9 @@ export function getProductIcon(product: AddOnCategory, size?: SVGIconProps['size
  * Returns true if the subscription can use pay-as-you-go.
  */
 export function supportsPayg(subscription: Subscription) {
-  return subscription.planDetails.allowOnDemand && subscription.supportsOnDemand;
+  return (
+    subscription.planDetails.allowOnDemand && subscription.supportsOnDemand
+  );
 }
 
 /**
@@ -551,7 +598,9 @@ export function hasPaygBudgetForCategory(
   if (!subscription.onDemandBudgets) {
     return false;
   }
-  if (subscription.onDemandBudgets.budgetMode === OnDemandBudgetMode.PER_CATEGORY) {
+  if (
+    subscription.onDemandBudgets.budgetMode === OnDemandBudgetMode.PER_CATEGORY
+  ) {
     return (subscription.onDemandBudgets.budgets?.[category] ?? 0) > 0;
   }
   return subscription.onDemandBudgets.sharedMaxBudget > 0;
@@ -561,7 +610,7 @@ export function hasPaygBudgetForCategory(
  * Returns true if the current user has billing perms.
  */
 export function hasBillingAccess(organization: Organization) {
-  return organization.access.includes('org:billing');
+  return organization.access.includes("org:billing");
 }
 
 export function hasAccessToSubscriptionOverview(
@@ -575,11 +624,16 @@ export function hasAccessToSubscriptionOverview(
  * Returns the soft cap type for the given metric history category that can be
  * displayed to users if applicable. Returns null for if no soft cap type.
  */
-export function getSoftCapType(metricHistory: BillingMetricHistory): string | null {
+export function getSoftCapType(
+  metricHistory: BillingMetricHistory
+): string | null {
   if (metricHistory.softCapType) {
-    return toTitleCase(metricHistory.softCapType.replace(/_/g, ' ').toLowerCase(), {
-      allowInnerUpperCase: true,
-    }).replace(' ', metricHistory.softCapType === 'ON_DEMAND' ? '-' : ' ');
+    return toTitleCase(
+      metricHistory.softCapType.replace(/_/g, " ").toLowerCase(),
+      {
+        allowInnerUpperCase: true,
+      }
+    ).replace(" ", metricHistory.softCapType === "ON_DEMAND" ? "-" : " ");
   }
   return null;
 }
@@ -598,8 +652,8 @@ export function getProductTrial(
 ): ProductTrial | null {
   const trialsForCategory =
     productTrials
-      ?.filter(pt => pt.category === category)
-      .sort((a, b) => b.endDate?.localeCompare(a.endDate ?? '') || 0) ?? [];
+      ?.filter((pt) => pt.category === category)
+      .sort((a, b) => b.endDate?.localeCompare(a.endDate ?? "") || 0) ?? [];
 
   const activeProductTrial = getActiveProductTrial(trialsForCategory, category);
 
@@ -607,7 +661,10 @@ export function getProductTrial(
     return activeProductTrial;
   }
 
-  const longestAvailableTrial = getPotentialProductTrial(trialsForCategory, category);
+  const longestAvailableTrial = getPotentialProductTrial(
+    trialsForCategory,
+    category
+  );
 
   if (longestAvailableTrial) {
     return longestAvailableTrial;
@@ -629,13 +686,13 @@ export function getActiveProductTrial(
   }
   const currentTrials = productTrials
     .filter(
-      pt =>
+      (pt) =>
         pt.category === category &&
         pt.isStarted &&
-        getDaysSinceDate(pt.endDate ?? '') <= 0 &&
-        getDaysSinceDate(pt.startDate ?? '') >= 0
+        getDaysSinceDate(pt.endDate ?? "") <= 0 &&
+        getDaysSinceDate(pt.startDate ?? "") >= 0
     )
-    .sort((a, b) => b.endDate?.localeCompare(a.endDate ?? '') || 0);
+    .sort((a, b) => b.endDate?.localeCompare(a.endDate ?? "") || 0);
 
   return currentTrials[0] ?? null;
 }
@@ -653,10 +710,10 @@ export function getPotentialProductTrial(
   }
   const potentialTrials = productTrials
     .filter(
-      pt =>
+      (pt) =>
         pt.category === category &&
         !pt.isStarted &&
-        getDaysSinceDate(pt.endDate ?? '') <= 0
+        getDaysSinceDate(pt.endDate ?? "") <= 0
     )
     .sort((a, b) => (b.lengthDays ?? 0) - (a.lengthDays ?? 0));
 
@@ -683,8 +740,9 @@ export function getSeerTrialCategory(
   // For started trials, endDate is the expiration date
   // In both cases, endDate must not have passed
   const seerUserTrial = productTrials.find(
-    pt =>
-      pt.category === DataCategory.SEER_USER && getDaysSinceDate(pt.endDate ?? '') <= 0
+    (pt) =>
+      pt.category === DataCategory.SEER_USER &&
+      getDaysSinceDate(pt.endDate ?? "") <= 0
   );
   if (seerUserTrial) {
     return DataCategory.SEER_USER;
@@ -692,8 +750,9 @@ export function getSeerTrialCategory(
 
   // Fall back to SEER_AUTOFIX (legacy)
   const seerAutofixTrial = productTrials.find(
-    pt =>
-      pt.category === DataCategory.SEER_AUTOFIX && getDaysSinceDate(pt.endDate ?? '') <= 0
+    (pt) =>
+      pt.category === DataCategory.SEER_AUTOFIX &&
+      getDaysSinceDate(pt.endDate ?? "") <= 0
   );
   if (seerAutofixTrial) {
     return DataCategory.SEER_AUTOFIX;
@@ -702,8 +761,11 @@ export function getSeerTrialCategory(
   return null;
 }
 
-export function trialPromptIsDismissed(prompt: PromptData, subscription: Subscription) {
-  const {snoozedTime, dismissedTime} = prompt || {};
+export function trialPromptIsDismissed(
+  prompt: PromptData,
+  subscription: Subscription
+) {
+  const { snoozedTime, dismissedTime } = prompt || {};
   const time = snoozedTime || dismissedTime;
   if (!time) {
     return false;
@@ -713,7 +775,7 @@ export function trialPromptIsDismissed(prompt: PromptData, subscription: Subscri
 }
 
 export function getPercentage(quantity: number, total: number | null) {
-  if (typeof total === 'number' && total > 0) {
+  if (typeof total === "number" && total > 0) {
     return (Math.min(quantity, total) / total) * 100;
   }
   return 0;
@@ -721,13 +783,15 @@ export function getPercentage(quantity: number, total: number | null) {
 
 export function displayPercentage(quantity: number, total: number | null) {
   const percentage = getPercentage(quantity, total);
-  return percentage.toFixed(0) + '%';
+  return percentage.toFixed(0) + "%";
 }
 
 /**
  * Returns true if some billing details are set.
  */
-export function hasSomeBillingDetails(billingDetails: BillingDetails | undefined) {
+export function hasSomeBillingDetails(
+  billingDetails: BillingDetails | undefined
+) {
   if (!billingDetails) {
     return false;
   }
@@ -736,13 +800,15 @@ export function hasSomeBillingDetails(billingDetails: BillingDetails | undefined
     Object.entries(billingDetails)
       .filter(
         ([key, _]) =>
-          key !== 'billingEmail' && key !== 'companyName' && key !== 'taxNumber'
+          key !== "billingEmail" && key !== "companyName" && key !== "taxNumber"
       )
       .some(([_, value]) => defined(value))
   );
 }
 
-export function getReservedBudgetCategoryForAddOn(addOnCategory: AddOnCategory) {
+export function getReservedBudgetCategoryForAddOn(
+  addOnCategory: AddOnCategory
+) {
   if (addOnCategory === AddOnCategory.LEGACY_SEER) {
     return ReservedBudgetCategoryType.SEER;
   }
@@ -757,15 +823,13 @@ export const RETENTION_SETTINGS_CATEGORIES = new Set([
   DataCategory.TRANSACTIONS,
 ]);
 
-export function getCredits<T extends {amount: number; type: InvoiceItemType}>({
-  invoiceItems,
-}: {
-  invoiceItems: T[];
-}) {
+export function getCredits<
+  T extends { amount: number; type: InvoiceItemType }
+>({ invoiceItems }: { invoiceItems: T[] }) {
   return invoiceItems.filter(
-    item =>
+    (item) =>
       CREDIT_INVOICE_ITEM_TYPES.includes(item.type as any) ||
-      (item.type === 'balance_change' && item.amount < 0)
+      (item.type === "balance_change" && item.amount < 0)
   );
 }
 
@@ -779,10 +843,10 @@ export function getCreditApplied({
   invoiceItems,
 }: {
   creditApplied: number;
-  invoiceItems: Array<{amount: number; type: InvoiceItemType}>;
+  invoiceItems: Array<{ amount: number; type: InvoiceItemType }>;
 }) {
-  const credits = getCredits({invoiceItems});
-  if (credits.some(item => item.type === 'balance_change')) {
+  const credits = getCredits({ invoiceItems });
+  if (credits.some((item) => item.type === "balance_change")) {
     return 0;
   }
   return creditApplied;
@@ -792,27 +856,25 @@ export function getCreditApplied({
  * Returns extra fees included in the invoice or preview data, such as tax
  * or cancellation fees.
  */
-export function getFees<T extends {amount: number; type: InvoiceItemType}>({
+export function getFees<T extends { amount: number; type: InvoiceItemType }>({
   invoiceItems,
 }: {
   invoiceItems: T[];
 }) {
   return invoiceItems.filter(
-    item =>
+    (item) =>
       FEE_INVOICE_ITEM_TYPES.includes(item.type as any) ||
-      (item.type === 'balance_change' && item.amount > 0)
+      (item.type === "balance_change" && item.amount > 0)
   );
 }
 
 /**
  * Returns ondemand invoice items from the invoice or preview data.
  */
-export function getOnDemandItems<T extends {amount: number; type: InvoiceItemType}>({
-  invoiceItems,
-}: {
-  invoiceItems: T[];
-}) {
-  return invoiceItems.filter(item => item.type.startsWith('ondemand'));
+export function getOnDemandItems<
+  T extends { amount: number; type: InvoiceItemType }
+>({ invoiceItems }: { invoiceItems: T[] }) {
+  return invoiceItems.filter((item) => item.type.startsWith("ondemand"));
 }
 
 /**
@@ -822,8 +884,10 @@ export function formatOnDemandDescription(
   description: string,
   plan?: Plan | null
 ): string {
-  const budgetTerm = displayBudgetName(plan, {title: false}).toLowerCase();
-  return description.replace(new RegExp(`\\s*${budgetTerm}\\s*`, 'gi'), ' ').trim();
+  const budgetTerm = displayBudgetName(plan, { title: false }).toLowerCase();
+  return description
+    .replace(new RegExp(`\\s*${budgetTerm}\\s*`, "gi"), " ")
+    .trim();
 }
 
 /**
@@ -832,7 +896,9 @@ export function formatOnDemandDescription(
 export function checkIsAddOn(
   selectedProduct: DataCategory | AddOnCategory | string
 ): boolean {
-  return Object.values(AddOnCategory).includes(selectedProduct as AddOnCategory);
+  return Object.values(AddOnCategory).includes(
+    selectedProduct as AddOnCategory
+  );
 }
 
 /**
@@ -868,8 +934,8 @@ export function getParentAddOn(
     return null;
   }
   const parentAddOn = Object.values(subscription.addOns ?? {})
-    .filter(addOn => addOn.isAvailable)
-    .find(addOn => addOn.dataCategories.includes(category));
+    .filter((addOn) => addOn.isAvailable)
+    .find((addOn) => addOn.dataCategories.includes(category));
 
   if (!parentAddOn) {
     return null;
@@ -903,17 +969,17 @@ export function getBilledCategory(
       return null;
     }
 
-    const {dataCategories, apiName} = addOnInfo;
+    const { dataCategories, apiName } = addOnInfo;
     const reservedBudgetCategory = getReservedBudgetCategoryForAddOn(apiName);
     const reservedBudget = subscription.reservedBudgets?.find(
-      budget => budget.apiName === reservedBudgetCategory
+      (budget) => budget.apiName === reservedBudgetCategory
     );
     return reservedBudget
-      ? (dataCategories.find(dataCategory =>
+      ? dataCategories.find((dataCategory) =>
           subscription.planDetails.planCategories[dataCategory]?.find(
-            bucket => bucket.events === RESERVED_BUDGET_QUOTA
+            (bucket) => bucket.events === RESERVED_BUDGET_QUOTA
           )
-        ) ?? dataCategories[0]!)
+        ) ?? dataCategories[0]!
       : dataCategories[0]!;
   }
 

--- a/static/gsApp/utils/billing.tsx
+++ b/static/gsApp/utils/billing.tsx
@@ -1,11 +1,11 @@
-import type { PromptData } from "sentry/actionCreators/prompts";
-import { IconBuilding, IconGroup, IconSeer, IconUser } from "sentry/icons";
-import type { SVGIconProps } from "sentry/icons/svgIcon";
-import { DataCategory } from "sentry/types/core";
-import type { Organization } from "sentry/types/organization";
-import { defined } from "sentry/utils/defined";
-import { getDaysSinceDate } from "sentry/utils/getDaysSinceDate";
-import { toTitleCase } from "sentry/utils/string/toTitleCase";
+import type {PromptData} from 'sentry/actionCreators/prompts';
+import {IconBuilding, IconGroup, IconSeer, IconUser} from 'sentry/icons';
+import type {SVGIconProps} from 'sentry/icons/svgIcon';
+import {DataCategory} from 'sentry/types/core';
+import type {Organization} from 'sentry/types/organization';
+import {defined} from 'sentry/utils/defined';
+import {getDaysSinceDate} from 'sentry/utils/getDaysSinceDate';
+import {toTitleCase} from 'sentry/utils/string/toTitleCase';
 
 import {
   BILLION,
@@ -15,7 +15,7 @@ import {
   RESERVED_BUDGET_QUOTA,
   UNLIMITED,
   UNLIMITED_RESERVED,
-} from "getsentry/constants";
+} from 'getsentry/constants';
 import {
   AddOnCategory,
   CREDIT_INVOICE_ITEM_TYPES,
@@ -23,7 +23,7 @@ import {
   OnDemandBudgetMode,
   PlanName,
   ReservedBudgetCategoryType,
-} from "getsentry/types";
+} from 'getsentry/types';
 import type {
   BillingConfig,
   BillingDetails,
@@ -34,15 +34,15 @@ import type {
   Plan,
   ProductTrial,
   Subscription,
-} from "getsentry/types";
-import { getCategoryInfoFromPlural } from "getsentry/utils/dataCategory";
-import { titleCase } from "getsentry/utils/titleCase";
-import { displayPriceWithCents } from "getsentry/views/amCheckout/utils";
+} from 'getsentry/types';
+import {getCategoryInfoFromPlural} from 'getsentry/utils/dataCategory';
+import {titleCase} from 'getsentry/utils/titleCase';
+import {displayPriceWithCents} from 'getsentry/views/amCheckout/utils';
 
 export const MILLISECONDS_IN_HOUR = 3600_000;
 
 function isNum(val: unknown): val is number {
-  return typeof val === "number";
+  return typeof val === 'number';
 }
 
 // TODO(brendan): remove condition for 0 once -1 is the value we use to represent unlimited reserved quota
@@ -76,20 +76,17 @@ export const getSlot = (
   shouldMinimize = false
 ) => {
   let s = 0;
-  if (
-    !slots?.length ||
-    (typeof events !== "number" && typeof price !== "number")
-  ) {
+  if (!slots?.length || (typeof events !== 'number' && typeof price !== 'number')) {
     return 0;
   }
-  const byEvents = typeof events === "number";
+  const byEvents = typeof events === 'number';
 
   const value = isNum(events) ? events : isNum(price) ? price : null;
   if (value === null) {
     return 0;
   }
 
-  const slotKey = byEvents ? "events" : "price";
+  const slotKey = byEvents ? 'events' : 'price';
 
   while (value > slots[s]![slotKey]) {
     s++;
@@ -148,13 +145,13 @@ export function formatReservedWithUnits(
   isReservedBudget = false
 ): string {
   if (isReservedBudget) {
-    return displayPriceWithCents({ cents: reservedQuantity ?? 0 });
+    return displayPriceWithCents({cents: reservedQuantity ?? 0});
   }
 
   const categoryInfo = getCategoryInfoFromPlural(dataCategory);
-  const unitType = categoryInfo?.formatting.unitType ?? "count";
+  const unitType = categoryInfo?.formatting.unitType ?? 'count';
 
-  if (unitType !== "bytes") {
+  if (unitType !== 'bytes') {
     return formatReservedNumberToString(reservedQuantity, options);
   }
 
@@ -165,18 +162,15 @@ export function formatReservedWithUnits(
       ? reservedQuantity * GIGABYTE
       : reservedQuantity;
   if (isUnlimitedReserved(usageGb)) {
-    return options.isGifted ? "0 GB" : UNLIMITED;
+    return options.isGifted ? '0 GB' : UNLIMITED;
   }
 
   if (!options.useUnitScaling) {
     const byteOptions =
       dataCategory === DataCategory.LOG_BYTE
-        ? { ...options, isAbbreviated: false }
+        ? {...options, isAbbreviated: false}
         : options;
-    const formatted = formatReservedNumberToString(
-      reservedQuantity,
-      byteOptions
-    );
+    const formatted = formatReservedNumberToString(reservedQuantity, byteOptions);
     return `${formatted} GB`;
   }
 
@@ -192,12 +186,12 @@ export function formatReservedWithUnits(
 export function formatUsageWithUnits(
   usageQuantity = 0,
   dataCategory: DataCategory,
-  options: FormatOptions = { isAbbreviated: false, useUnitScaling: false }
+  options: FormatOptions = {isAbbreviated: false, useUnitScaling: false}
 ) {
   const categoryInfo = getCategoryInfoFromPlural(dataCategory);
-  const unitType = categoryInfo?.formatting.unitType ?? "count";
+  const unitType = categoryInfo?.formatting.unitType ?? 'count';
 
-  if (unitType === "bytes") {
+  if (unitType === 'bytes') {
     if (options.useUnitScaling) {
       return formatByteUnits(usageQuantity);
     }
@@ -205,12 +199,12 @@ export function formatUsageWithUnits(
     const usageGb = usageQuantity / GIGABYTE;
     return options.isAbbreviated
       ? `${displayNumber(usageGb)} GB`
-      : `${usageGb.toLocaleString(undefined, { maximumFractionDigits: 2 })} GB`;
+      : `${usageGb.toLocaleString(undefined, {maximumFractionDigits: 2})} GB`;
   }
-  if (unitType === "durationHours") {
+  if (unitType === 'durationHours') {
     const usageProfileHours = usageQuantity / MILLISECONDS_IN_HOUR;
     if (usageProfileHours === 0) {
-      return "0";
+      return '0';
     }
     return options.isAbbreviated
       ? displayNumber(usageProfileHours, 1)
@@ -228,12 +222,12 @@ export function convertUsageToReservedUnit(
   category: DataCategory | string
 ): number {
   const categoryInfo = getCategoryInfoFromPlural(category as DataCategory);
-  const unitType = categoryInfo?.formatting.unitType ?? "count";
+  const unitType = categoryInfo?.formatting.unitType ?? 'count';
 
-  if (unitType === "bytes") {
+  if (unitType === 'bytes') {
     return usage / GIGABYTE;
   }
-  if (unitType === "durationHours") {
+  if (unitType === 'durationHours') {
     return usage / MILLISECONDS_IN_HOUR;
   }
   return usage;
@@ -254,11 +248,11 @@ function formatReservedNumberToString(
 ): string {
   // "null" indicates that there's no quota for it.
   if (!defined(reservedQuantity)) {
-    return "0";
+    return '0';
   }
 
   if (reservedQuantity === RESERVED_BUDGET_QUOTA) {
-    return "N/A";
+    return 'N/A';
   }
 
   if (isUnlimitedReserved(reservedQuantity) && !options.isGifted) {
@@ -267,7 +261,7 @@ function formatReservedNumberToString(
 
   return options.isAbbreviated
     ? displayNumber(reservedQuantity, options.fractionDigits)
-    : reservedQuantity.toLocaleString(undefined, { maximumFractionDigits: 1 });
+    : reservedQuantity.toLocaleString(undefined, {maximumFractionDigits: 1});
 }
 
 /**
@@ -286,7 +280,7 @@ function formatReservedNumberToString(
  * sentry/utils/formatBytes.
  */
 function formatByteUnits(bytes: number, u = 0) {
-  const units = ["B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
+  const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
   const threshold = 1000;
 
   while (bytes >= threshold) {
@@ -294,11 +288,7 @@ function formatByteUnits(bytes: number, u = 0) {
     u += 1;
   }
 
-  return (
-    bytes.toLocaleString(undefined, { maximumFractionDigits: 2 }) +
-    " " +
-    units[u]
-  );
+  return bytes.toLocaleString(undefined, {maximumFractionDigits: 2}) + ' ' + units[u];
 }
 
 /**
@@ -307,21 +297,15 @@ function formatByteUnits(bytes: number, u = 0) {
  */
 function displayNumber(n: number, fractionDigits = 0) {
   if (n >= BILLION) {
-    return (
-      (n / BILLION).toLocaleString(undefined, { maximumFractionDigits: 2 }) +
-      "B"
-    );
+    return (n / BILLION).toLocaleString(undefined, {maximumFractionDigits: 2}) + 'B';
   }
 
   if (n >= MILLION) {
-    return (
-      (n / MILLION).toLocaleString(undefined, { maximumFractionDigits: 1 }) +
-      "M"
-    );
+    return (n / MILLION).toLocaleString(undefined, {maximumFractionDigits: 1}) + 'M';
   }
 
   if (n >= 1000) {
-    return (n / 1000).toFixed().toLocaleString() + "K";
+    return (n / 1000).toFixed().toLocaleString() + 'K';
   }
 
   // Do not show decimals
@@ -338,26 +322,22 @@ export const hasPerformance = (plan?: Plan) => {
 };
 
 export const hasPartnerMigrationFeature = (organization: Organization) =>
-  organization.features.includes("partner-billing-migration");
+  organization.features.includes('partner-billing-migration');
 
 export const hasActiveVCFeature = (organization: Organization) =>
-  organization.features.includes("vc-marketplace-active-customer");
+  organization.features.includes('vc-marketplace-active-customer');
 
-export const isDeveloperPlan = (plan?: Plan) =>
-  plan?.name === PlanName.DEVELOPER;
+export const isDeveloperPlan = (plan?: Plan) => plan?.name === PlanName.DEVELOPER;
 
-export const isBizPlanFamily = (plan?: Plan) =>
-  plan?.name.includes(PlanName.BUSINESS);
+export const isBizPlanFamily = (plan?: Plan) => plan?.name.includes(PlanName.BUSINESS);
 
-export const isTeamPlanFamily = (plan?: Plan) =>
-  plan?.name.includes(PlanName.TEAM);
+export const isTeamPlanFamily = (plan?: Plan) => plan?.name.includes(PlanName.TEAM);
 
 /**
  * Whether the subscription is currently on a trial, derived from `trialPlan`
  * (non-null iff trialing).
  */
-export const isTrial = (subscription: Subscription) =>
-  defined(subscription.trialPlan);
+export const isTrial = (subscription: Subscription) => defined(subscription.trialPlan);
 
 export const isBusinessTrial = (subscription: Subscription) => {
   return (
@@ -380,23 +360,23 @@ export const displayBudgetName = (
     withBudget?: boolean;
   } = {}
 ) => {
-  const budgetTerm = plan?.budgetTerm ?? "pay-as-you-go";
-  const text = `${budgetTerm}${options.withBudget ? " budget" : ""}`;
+  const budgetTerm = plan?.budgetTerm ?? 'pay-as-you-go';
+  const text = `${budgetTerm}${options.withBudget ? ' budget' : ''}`;
   if (options.abbreviated) {
-    if (budgetTerm === "pay-as-you-go") {
-      return "PAYG";
+    if (budgetTerm === 'pay-as-you-go') {
+      return 'PAYG';
     }
-    return "OD";
+    return 'OD';
   }
   if (options.title) {
-    if (budgetTerm === "on-demand") {
+    if (budgetTerm === 'on-demand') {
       if (options.withBudget) {
         if (options.pluralOndemand) {
-          return "On-Demand Budgets";
+          return 'On-Demand Budgets';
         }
-        return "On-Demand Budget";
+        return 'On-Demand Budget';
       }
-      return "On-Demand";
+      return 'On-Demand';
     }
     return titleCase(text);
   }
@@ -419,7 +399,7 @@ export const getOnDemandCategories = ({
   plan: Plan;
 }) => {
   if (budgetMode === OnDemandBudgetMode.PER_CATEGORY) {
-    return plan.onDemandCategories.filter((category) => {
+    return plan.onDemandCategories.filter(category => {
       const categoryInfo = getCategoryInfoFromPlural(category);
       if (!categoryInfo) {
         return false;
@@ -432,7 +412,7 @@ export const getOnDemandCategories = ({
 };
 
 export const displayPlanName = (plan?: Plan | null) => {
-  return plan?.isEnterprise ? "Enterprise" : plan?.name ?? "[unavailable]";
+  return plan?.isEnterprise ? 'Enterprise' : (plan?.name ?? '[unavailable]');
 };
 
 export const isNewPayingCustomer = (
@@ -448,7 +428,7 @@ export const isNewPayingCustomer = (
  */
 export function getTrialDaysLeft(subscription: Subscription): number {
   // trial end is in the future
-  return -1 * getDaysSinceDate(subscription.trialEnd ?? "");
+  return -1 * getDaysSinceDate(subscription.trialEnd ?? '');
 }
 
 /**
@@ -456,19 +436,13 @@ export function getTrialDaysLeft(subscription: Subscription): number {
  * Used to find the best plan for an org to upgrade to
  * based on a particular feature to unlock.
  */
-function sortPlansForUpgrade(
-  billingConfig: BillingConfig,
-  subscription: Subscription
-) {
+function sortPlansForUpgrade(billingConfig: BillingConfig, subscription: Subscription) {
   // Filter plans down to just user selectable plans types of the orgs current
   // contract interval. Sorted by price as features will become progressively
   // more available.
   let plans = billingConfig.planList
     .sort((a, b) => a.totalPrice - b.totalPrice)
-    .filter(
-      (p) =>
-        p.userSelectable && p.billingInterval === subscription.billingInterval
-    );
+    .filter(p => p.userSelectable && p.billingInterval === subscription.billingInterval);
 
   // If we're dealing with plans that are *not part of a tier* Then we can
   // assume special case that there is only one plan.
@@ -484,7 +458,7 @@ export function getBestPlanForUnlimitedMembers(
 ) {
   const plans = sortPlansForUpgrade(billingConfig, subscription);
   // the best plan is the first one that has unlimited members
-  return plans.find((p) => p.maxMembers === null);
+  return plans.find(p => p.maxMembers === null);
 }
 
 export function getTrialLength(_organization: Organization) {
@@ -494,16 +468,16 @@ export function getTrialLength(_organization: Organization) {
 
 export function formatBalance(value: number) {
   return value < 0
-    ? `${displayPriceWithCents({ cents: 0 - value })} credit`
-    : `${displayPriceWithCents({ cents: value })} owed`;
+    ? `${displayPriceWithCents({cents: 0 - value})} credit`
+    : `${displayPriceWithCents({cents: value})} owed`;
 }
 
 export enum UsageAction {
-  START_TRIAL = "start_trial",
-  ADD_EVENTS = "add_events",
-  REQUEST_ADD_EVENTS = "request_add_events",
-  REQUEST_UPGRADE = "request_upgrade",
-  SEND_TO_CHECKOUT = "send_to_checkout",
+  START_TRIAL = 'start_trial',
+  ADD_EVENTS = 'add_events',
+  REQUEST_ADD_EVENTS = 'request_add_events',
+  REQUEST_UPGRADE = 'request_upgrade',
+  SEND_TO_CHECKOUT = 'send_to_checkout',
 }
 
 /**
@@ -515,7 +489,7 @@ export function getBestActionToIncreaseEventLimits(
   subscription: Subscription
 ) {
   const isPaidPlan = subscription.planDetails?.totalPrice > 0;
-  const hasBillingPerms = organization.access?.includes("org:billing");
+  const hasBillingPerms = organization.access?.includes('org:billing');
 
   // free orgs can increase event limits by trialing
   if (!isPaidPlan && subscription.canTrial) {
@@ -523,34 +497,26 @@ export function getBestActionToIncreaseEventLimits(
   }
   // paid plans should add events without changing plans
   const hasAnyUsageExceeded = Object.values(subscription.categories).some(
-    (category) => category.usageExceeded
+    category => category.usageExceeded
   );
-  if (
-    isPaidPlan &&
-    hasPerformance(subscription.planDetails) &&
-    hasAnyUsageExceeded
-  ) {
-    return hasBillingPerms
-      ? UsageAction.ADD_EVENTS
-      : UsageAction.REQUEST_ADD_EVENTS;
+  if (isPaidPlan && hasPerformance(subscription.planDetails) && hasAnyUsageExceeded) {
+    return hasBillingPerms ? UsageAction.ADD_EVENTS : UsageAction.REQUEST_ADD_EVENTS;
   }
   // otherwise, we want them to upgrade to a different plan if they're not already on a Business plan
   if (!isBizPlanFamily(subscription.planDetails)) {
-    return hasBillingPerms
-      ? UsageAction.SEND_TO_CHECKOUT
-      : UsageAction.REQUEST_UPGRADE;
+    return hasBillingPerms ? UsageAction.SEND_TO_CHECKOUT : UsageAction.REQUEST_UPGRADE;
   }
-  return "";
+  return '';
 }
 
 /**
  * Returns a name for the plan that we can display to users
  */
 export function getFriendlyPlanName(subscription: Subscription) {
-  const { name } = subscription.planDetails;
+  const {name} = subscription.planDetails;
   switch (name) {
-    case "Trial":
-      return "Business Trial";
+    case 'Trial':
+      return 'Business Trial';
     default:
       return name;
   }
@@ -568,10 +534,7 @@ export function getPlanIcon(plan: Plan) {
   return <IconUser />;
 }
 
-export function getProductIcon(
-  product: AddOnCategory,
-  size?: SVGIconProps["size"]
-) {
+export function getProductIcon(product: AddOnCategory, size?: SVGIconProps['size']) {
   if ([AddOnCategory.LEGACY_SEER, AddOnCategory.SEER].includes(product)) {
     return <IconSeer size={size} />;
   }
@@ -582,9 +545,7 @@ export function getProductIcon(
  * Returns true if the subscription can use pay-as-you-go.
  */
 export function supportsPayg(subscription: Subscription) {
-  return (
-    subscription.planDetails.allowOnDemand && subscription.supportsOnDemand
-  );
+  return subscription.planDetails.allowOnDemand && subscription.supportsOnDemand;
 }
 
 /**
@@ -598,9 +559,7 @@ export function hasPaygBudgetForCategory(
   if (!subscription.onDemandBudgets) {
     return false;
   }
-  if (
-    subscription.onDemandBudgets.budgetMode === OnDemandBudgetMode.PER_CATEGORY
-  ) {
+  if (subscription.onDemandBudgets.budgetMode === OnDemandBudgetMode.PER_CATEGORY) {
     return (subscription.onDemandBudgets.budgets?.[category] ?? 0) > 0;
   }
   return subscription.onDemandBudgets.sharedMaxBudget > 0;
@@ -610,7 +569,7 @@ export function hasPaygBudgetForCategory(
  * Returns true if the current user has billing perms.
  */
 export function hasBillingAccess(organization: Organization) {
-  return organization.access.includes("org:billing");
+  return organization.access.includes('org:billing');
 }
 
 export function hasAccessToSubscriptionOverview(
@@ -624,16 +583,11 @@ export function hasAccessToSubscriptionOverview(
  * Returns the soft cap type for the given metric history category that can be
  * displayed to users if applicable. Returns null for if no soft cap type.
  */
-export function getSoftCapType(
-  metricHistory: BillingMetricHistory
-): string | null {
+export function getSoftCapType(metricHistory: BillingMetricHistory): string | null {
   if (metricHistory.softCapType) {
-    return toTitleCase(
-      metricHistory.softCapType.replace(/_/g, " ").toLowerCase(),
-      {
-        allowInnerUpperCase: true,
-      }
-    ).replace(" ", metricHistory.softCapType === "ON_DEMAND" ? "-" : " ");
+    return toTitleCase(metricHistory.softCapType.replace(/_/g, ' ').toLowerCase(), {
+      allowInnerUpperCase: true,
+    }).replace(' ', metricHistory.softCapType === 'ON_DEMAND' ? '-' : ' ');
   }
   return null;
 }
@@ -652,8 +606,8 @@ export function getProductTrial(
 ): ProductTrial | null {
   const trialsForCategory =
     productTrials
-      ?.filter((pt) => pt.category === category)
-      .sort((a, b) => b.endDate?.localeCompare(a.endDate ?? "") || 0) ?? [];
+      ?.filter(pt => pt.category === category)
+      .sort((a, b) => b.endDate?.localeCompare(a.endDate ?? '') || 0) ?? [];
 
   const activeProductTrial = getActiveProductTrial(trialsForCategory, category);
 
@@ -661,10 +615,7 @@ export function getProductTrial(
     return activeProductTrial;
   }
 
-  const longestAvailableTrial = getPotentialProductTrial(
-    trialsForCategory,
-    category
-  );
+  const longestAvailableTrial = getPotentialProductTrial(trialsForCategory, category);
 
   if (longestAvailableTrial) {
     return longestAvailableTrial;
@@ -686,13 +637,13 @@ export function getActiveProductTrial(
   }
   const currentTrials = productTrials
     .filter(
-      (pt) =>
+      pt =>
         pt.category === category &&
         pt.isStarted &&
-        getDaysSinceDate(pt.endDate ?? "") <= 0 &&
-        getDaysSinceDate(pt.startDate ?? "") >= 0
+        getDaysSinceDate(pt.endDate ?? '') <= 0 &&
+        getDaysSinceDate(pt.startDate ?? '') >= 0
     )
-    .sort((a, b) => b.endDate?.localeCompare(a.endDate ?? "") || 0);
+    .sort((a, b) => b.endDate?.localeCompare(a.endDate ?? '') || 0);
 
   return currentTrials[0] ?? null;
 }
@@ -710,10 +661,10 @@ export function getPotentialProductTrial(
   }
   const potentialTrials = productTrials
     .filter(
-      (pt) =>
+      pt =>
         pt.category === category &&
         !pt.isStarted &&
-        getDaysSinceDate(pt.endDate ?? "") <= 0
+        getDaysSinceDate(pt.endDate ?? '') <= 0
     )
     .sort((a, b) => (b.lengthDays ?? 0) - (a.lengthDays ?? 0));
 
@@ -740,9 +691,8 @@ export function getSeerTrialCategory(
   // For started trials, endDate is the expiration date
   // In both cases, endDate must not have passed
   const seerUserTrial = productTrials.find(
-    (pt) =>
-      pt.category === DataCategory.SEER_USER &&
-      getDaysSinceDate(pt.endDate ?? "") <= 0
+    pt =>
+      pt.category === DataCategory.SEER_USER && getDaysSinceDate(pt.endDate ?? '') <= 0
   );
   if (seerUserTrial) {
     return DataCategory.SEER_USER;
@@ -750,9 +700,8 @@ export function getSeerTrialCategory(
 
   // Fall back to SEER_AUTOFIX (legacy)
   const seerAutofixTrial = productTrials.find(
-    (pt) =>
-      pt.category === DataCategory.SEER_AUTOFIX &&
-      getDaysSinceDate(pt.endDate ?? "") <= 0
+    pt =>
+      pt.category === DataCategory.SEER_AUTOFIX && getDaysSinceDate(pt.endDate ?? '') <= 0
   );
   if (seerAutofixTrial) {
     return DataCategory.SEER_AUTOFIX;
@@ -761,11 +710,8 @@ export function getSeerTrialCategory(
   return null;
 }
 
-export function trialPromptIsDismissed(
-  prompt: PromptData,
-  subscription: Subscription
-) {
-  const { snoozedTime, dismissedTime } = prompt || {};
+export function trialPromptIsDismissed(prompt: PromptData, subscription: Subscription) {
+  const {snoozedTime, dismissedTime} = prompt || {};
   const time = snoozedTime || dismissedTime;
   if (!time) {
     return false;
@@ -775,7 +721,7 @@ export function trialPromptIsDismissed(
 }
 
 export function getPercentage(quantity: number, total: number | null) {
-  if (typeof total === "number" && total > 0) {
+  if (typeof total === 'number' && total > 0) {
     return (Math.min(quantity, total) / total) * 100;
   }
   return 0;
@@ -783,15 +729,13 @@ export function getPercentage(quantity: number, total: number | null) {
 
 export function displayPercentage(quantity: number, total: number | null) {
   const percentage = getPercentage(quantity, total);
-  return percentage.toFixed(0) + "%";
+  return percentage.toFixed(0) + '%';
 }
 
 /**
  * Returns true if some billing details are set.
  */
-export function hasSomeBillingDetails(
-  billingDetails: BillingDetails | undefined
-) {
+export function hasSomeBillingDetails(billingDetails: BillingDetails | undefined) {
   if (!billingDetails) {
     return false;
   }
@@ -800,15 +744,13 @@ export function hasSomeBillingDetails(
     Object.entries(billingDetails)
       .filter(
         ([key, _]) =>
-          key !== "billingEmail" && key !== "companyName" && key !== "taxNumber"
+          key !== 'billingEmail' && key !== 'companyName' && key !== 'taxNumber'
       )
       .some(([_, value]) => defined(value))
   );
 }
 
-export function getReservedBudgetCategoryForAddOn(
-  addOnCategory: AddOnCategory
-) {
+export function getReservedBudgetCategoryForAddOn(addOnCategory: AddOnCategory) {
   if (addOnCategory === AddOnCategory.LEGACY_SEER) {
     return ReservedBudgetCategoryType.SEER;
   }
@@ -823,13 +765,15 @@ export const RETENTION_SETTINGS_CATEGORIES = new Set([
   DataCategory.TRANSACTIONS,
 ]);
 
-export function getCredits<
-  T extends { amount: number; type: InvoiceItemType }
->({ invoiceItems }: { invoiceItems: T[] }) {
+export function getCredits<T extends {amount: number; type: InvoiceItemType}>({
+  invoiceItems,
+}: {
+  invoiceItems: T[];
+}) {
   return invoiceItems.filter(
-    (item) =>
+    item =>
       CREDIT_INVOICE_ITEM_TYPES.includes(item.type as any) ||
-      (item.type === "balance_change" && item.amount < 0)
+      (item.type === 'balance_change' && item.amount < 0)
   );
 }
 
@@ -843,10 +787,10 @@ export function getCreditApplied({
   invoiceItems,
 }: {
   creditApplied: number;
-  invoiceItems: Array<{ amount: number; type: InvoiceItemType }>;
+  invoiceItems: Array<{amount: number; type: InvoiceItemType}>;
 }) {
-  const credits = getCredits({ invoiceItems });
-  if (credits.some((item) => item.type === "balance_change")) {
+  const credits = getCredits({invoiceItems});
+  if (credits.some(item => item.type === 'balance_change')) {
     return 0;
   }
   return creditApplied;
@@ -856,25 +800,27 @@ export function getCreditApplied({
  * Returns extra fees included in the invoice or preview data, such as tax
  * or cancellation fees.
  */
-export function getFees<T extends { amount: number; type: InvoiceItemType }>({
+export function getFees<T extends {amount: number; type: InvoiceItemType}>({
   invoiceItems,
 }: {
   invoiceItems: T[];
 }) {
   return invoiceItems.filter(
-    (item) =>
+    item =>
       FEE_INVOICE_ITEM_TYPES.includes(item.type as any) ||
-      (item.type === "balance_change" && item.amount > 0)
+      (item.type === 'balance_change' && item.amount > 0)
   );
 }
 
 /**
  * Returns ondemand invoice items from the invoice or preview data.
  */
-export function getOnDemandItems<
-  T extends { amount: number; type: InvoiceItemType }
->({ invoiceItems }: { invoiceItems: T[] }) {
-  return invoiceItems.filter((item) => item.type.startsWith("ondemand"));
+export function getOnDemandItems<T extends {amount: number; type: InvoiceItemType}>({
+  invoiceItems,
+}: {
+  invoiceItems: T[];
+}) {
+  return invoiceItems.filter(item => item.type.startsWith('ondemand'));
 }
 
 /**
@@ -884,10 +830,8 @@ export function formatOnDemandDescription(
   description: string,
   plan?: Plan | null
 ): string {
-  const budgetTerm = displayBudgetName(plan, { title: false }).toLowerCase();
-  return description
-    .replace(new RegExp(`\\s*${budgetTerm}\\s*`, "gi"), " ")
-    .trim();
+  const budgetTerm = displayBudgetName(plan, {title: false}).toLowerCase();
+  return description.replace(new RegExp(`\\s*${budgetTerm}\\s*`, 'gi'), ' ').trim();
 }
 
 /**
@@ -896,9 +840,7 @@ export function formatOnDemandDescription(
 export function checkIsAddOn(
   selectedProduct: DataCategory | AddOnCategory | string
 ): boolean {
-  return Object.values(AddOnCategory).includes(
-    selectedProduct as AddOnCategory
-  );
+  return Object.values(AddOnCategory).includes(selectedProduct as AddOnCategory);
 }
 
 /**
@@ -934,8 +876,8 @@ export function getParentAddOn(
     return null;
   }
   const parentAddOn = Object.values(subscription.addOns ?? {})
-    .filter((addOn) => addOn.isAvailable)
-    .find((addOn) => addOn.dataCategories.includes(category));
+    .filter(addOn => addOn.isAvailable)
+    .find(addOn => addOn.dataCategories.includes(category));
 
   if (!parentAddOn) {
     return null;
@@ -969,17 +911,17 @@ export function getBilledCategory(
       return null;
     }
 
-    const { dataCategories, apiName } = addOnInfo;
+    const {dataCategories, apiName} = addOnInfo;
     const reservedBudgetCategory = getReservedBudgetCategoryForAddOn(apiName);
     const reservedBudget = subscription.reservedBudgets?.find(
-      (budget) => budget.apiName === reservedBudgetCategory
+      budget => budget.apiName === reservedBudgetCategory
     );
     return reservedBudget
-      ? dataCategories.find((dataCategory) =>
+      ? (dataCategories.find(dataCategory =>
           subscription.planDetails.planCategories[dataCategory]?.find(
-            (bucket) => bucket.events === RESERVED_BUDGET_QUOTA
+            bucket => bucket.events === RESERVED_BUDGET_QUOTA
           )
-        ) ?? dataCategories[0]!
+        ) ?? dataCategories[0]!)
       : dataCategories[0]!;
   }
 

--- a/static/gsApp/utils/pendo.tsx
+++ b/static/gsApp/utils/pendo.tsx
@@ -7,7 +7,7 @@ import {getOrganizationAge} from 'sentry/utils/getOrganizationAge';
 
 import type {PromotionClaimed, Subscription} from 'getsentry/types';
 
-import {getProductTrial, getTrialDaysLeft} from './billing';
+import {getProductTrial, getTrialDaysLeft, isTrial} from './billing';
 
 // we encode sizes for bucketing using roygbiv coloring
 const SIZES = {
@@ -108,7 +108,7 @@ export function getPendoAccountFields(
       'canSelfServe',
       'plan',
     ]),
-    isTrial: subscription.trialPlan !== null,
+    isTrial: isTrial(subscription),
     ...pick(organization, ['isEarlyAdopter']),
   };
   // for fields with bucketing, we need to encode the value so
@@ -277,7 +277,7 @@ function getAccountCredit(subscription: Subscription) {
 
 function getTrialDaysLeftFromSub(subscription: Subscription) {
   // only check if trial is active
-  if (subscription.trialPlan === null) {
+  if (!isTrial(subscription)) {
     return null;
   }
   return getTrialDaysLeft(subscription);

--- a/static/gsApp/utils/pendo.tsx
+++ b/static/gsApp/utils/pendo.tsx
@@ -101,7 +101,6 @@ export function getPendoAccountFields(
     ...pick(subscription, [
       'isFree',
       'isManaged',
-      'isTrial',
       'isEnterpriseTrial',
       'isPerformancePlanTrial',
       'isSuspended',
@@ -109,6 +108,7 @@ export function getPendoAccountFields(
       'canSelfServe',
       'plan',
     ]),
+    isTrial: subscription.trialPlan !== null,
     ...pick(organization, ['isEarlyAdopter']),
   };
   // for fields with bucketing, we need to encode the value so
@@ -277,7 +277,7 @@ function getAccountCredit(subscription: Subscription) {
 
 function getTrialDaysLeftFromSub(subscription: Subscription) {
   // only check if trial is active
-  if (!subscription.isTrial) {
+  if (subscription.trialPlan === null) {
     return null;
   }
   return getTrialDaysLeft(subscription);

--- a/static/gsApp/utils/rawTrackAnalyticsEvent.tsx
+++ b/static/gsApp/utils/rawTrackAnalyticsEvent.tsx
@@ -197,7 +197,7 @@ export function rawTrackAnalyticsEvent(
         data.can_trial = subscription.canTrial;
       }
       if (data.is_trial === undefined) {
-        data.is_trial = subscription.isTrial;
+        data.is_trial = subscription.trialPlan !== null;
       }
       // we can add more fields but we should be carefull about which ones to add
       // since Amplitude is an external vendor

--- a/static/gsApp/utils/rawTrackAnalyticsEvent.tsx
+++ b/static/gsApp/utils/rawTrackAnalyticsEvent.tsx
@@ -12,6 +12,7 @@ import {sessionStorageWrapper} from 'sentry/utils/sessionStorage';
 import {readStorageValue} from 'sentry/utils/useSessionStorage';
 
 import type {Subscription} from 'getsentry/types';
+import {isTrial} from 'getsentry/utils/billing';
 
 import {trackAmplitudeEvent} from './trackAmplitudeEvent';
 import {trackMarketingEvent} from './trackMarketingEvent';
@@ -197,7 +198,7 @@ export function rawTrackAnalyticsEvent(
         data.can_trial = subscription.canTrial;
       }
       if (data.is_trial === undefined) {
-        data.is_trial = subscription.trialPlan !== null;
+        data.is_trial = isTrial(subscription);
       }
       // we can add more fields but we should be carefull about which ones to add
       // since Amplitude is an external vendor

--- a/static/gsApp/views/amCheckout/index.spec.tsx
+++ b/static/gsApp/views/amCheckout/index.spec.tsx
@@ -503,7 +503,7 @@ describe('Default Tier Checkout', () => {
       onDemandMaxSpend: 2000,
       supportsOnDemand: true,
       isFree: false,
-      isTrial: true, // isTrial is true for both subscription trials and plan trials
+      trialPlan: 'am3_business', // trialPlan is set for both subscription trials and plan trials
     });
     sub.categories = {
       ...sub.categories,
@@ -690,14 +690,14 @@ describe('Default Tier Checkout', () => {
 
   it('does not use trial volumes for trial subscriptions', async () => {
     /**
-     * Test for the trial checkout slider fix in AM3 tier. When subscription.isTrial is true,
-     * the checkout should use default volumes instead of trial reserved volumes.
+     * Test for the trial checkout slider fix in AM3 tier. When the subscription is on a
+     * trial plan, the checkout should use default volumes instead of trial reserved volumes.
      */
 
     const trialSub = SubscriptionFixture({
       organization,
       plan: 'am3_t',
-      isTrial: true, // This is true for both subscription trials and plan trials
+      trialPlan: 'am3_t', // trialPlan is set for both subscription trials and plan trials
       categories: {
         // These are high trial volumes that should NOT be used in checkout
         errors: MetricHistoryFixture({reserved: 750_000}), // High trial volume

--- a/static/gsApp/views/amCheckout/index.tsx
+++ b/static/gsApp/views/amCheckout/index.tsx
@@ -178,8 +178,8 @@ function AMCheckout(props: Props) {
   const shouldDefaultToBusiness = useCallback(() => {
     const hasUpsell = referrer?.startsWith('upgrade') || referrer?.startsWith('upsell');
 
-    return hasUpsell || subscription.isFree || subscription.isTrial;
-  }, [referrer, subscription.isFree, subscription.isTrial]);
+    return hasUpsell || subscription.isFree || subscription.trialPlan !== null;
+  }, [referrer, subscription.isFree, subscription.trialPlan]);
 
   const getBusinessPlan = useCallback(
     (config: BillingConfig) => {

--- a/static/gsApp/views/amCheckout/index.tsx
+++ b/static/gsApp/views/amCheckout/index.tsx
@@ -53,6 +53,7 @@ import {
   hasPerformance,
   isBizPlanFamily,
   isNewPayingCustomer,
+  isTrial,
 } from 'getsentry/utils/billing';
 import {getCompletedOrActivePromotion} from 'getsentry/utils/promotions';
 import {trackGetsentryAnalytics} from 'getsentry/utils/trackGetsentryAnalytics';
@@ -175,11 +176,12 @@ function AMCheckout(props: Props) {
    * 2. The subscription is free
    * 3. Or, the subscription is on a free trial
    */
+  const subscriptionIsTrial = isTrial(subscription);
   const shouldDefaultToBusiness = useCallback(() => {
     const hasUpsell = referrer?.startsWith('upgrade') || referrer?.startsWith('upsell');
 
-    return hasUpsell || subscription.isFree || subscription.trialPlan !== null;
-  }, [referrer, subscription.isFree, subscription.trialPlan]);
+    return hasUpsell || subscription.isFree || subscriptionIsTrial;
+  }, [referrer, subscription.isFree, subscriptionIsTrial]);
 
   const getBusinessPlan = useCallback(
     (config: BillingConfig) => {

--- a/static/gsApp/views/amCheckout/steps/buildYourPlan.tsx
+++ b/static/gsApp/views/amCheckout/steps/buildYourPlan.tsx
@@ -13,6 +13,7 @@ import {
   isBizPlanFamily,
   isDeveloperPlan,
   isNewPayingCustomer,
+  isTrial,
 } from 'getsentry/utils/billing';
 import {PlanFeatures} from 'getsentry/views/amCheckout/components/planFeatures';
 import {PlanSelectCard} from 'getsentry/views/amCheckout/components/planSelectCard';
@@ -80,7 +81,7 @@ function PlanSubstep({
       const trialExpired = getDaysSinceDate(subscription.lastTrialEnd) > 0;
       return (
         <Tag variant="warning">
-          {subscription.trialPlan !== null && !trialExpired
+          {isTrial(subscription) && !trialExpired
             ? tct('Trial expires [lastTrialEnd]', {lastTrialEnd})
             : t('You trialed this plan')}
         </Tag>

--- a/static/gsApp/views/amCheckout/steps/buildYourPlan.tsx
+++ b/static/gsApp/views/amCheckout/steps/buildYourPlan.tsx
@@ -80,7 +80,7 @@ function PlanSubstep({
       const trialExpired = getDaysSinceDate(subscription.lastTrialEnd) > 0;
       return (
         <Tag variant="warning">
-          {subscription.isTrial && !trialExpired
+          {subscription.trialPlan !== null && !trialExpired
             ? tct('Trial expires [lastTrialEnd]', {lastTrialEnd})
             : t('You trialed this plan')}
         </Tag>

--- a/static/gsApp/views/amCheckout/steps/reserveAdditionalVolume.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/reserveAdditionalVolume.spec.tsx
@@ -300,7 +300,7 @@ describe('ReserveAdditionalVolume', () => {
       const trialSub = SubscriptionFixture({
         organization,
         plan: 'am3_t',
-        isTrial: true, // This is true for both subscription trials and plan trials
+        trialPlan: 'am3_t', // trialPlan is set for both subscription trials and plan trials
         categories: {
           // These are high trial volumes that should NOT be used in checkout
           errors: MetricHistoryFixture({reserved: 750_000}), // High trial volume

--- a/static/gsApp/views/subscriptionPage/subscriptionHeader.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/subscriptionHeader.spec.tsx
@@ -317,7 +317,7 @@ describe('SubscriptionHeader', () => {
     const subscription = SubscriptionFixture({
       organization,
       plan: 'am3_team',
-      isTrial: true,
+      trialPlan: 'am3_team',
     });
     SubscriptionStore.set(organization.slug, subscription);
     render(

--- a/static/gsApp/views/subscriptionPage/subscriptionUpsellBanner.tsx
+++ b/static/gsApp/views/subscriptionPage/subscriptionUpsellBanner.tsx
@@ -89,7 +89,7 @@ function useIsSubscriptionUpsellHidden(
     !subscription.canSelfServe ||
     (hasPerformance(subscription.planDetails) &&
       isBizPlanFamily(subscription.planDetails)) ||
-    subscription.isTrial ||
+    subscription.trialPlan !== null ||
     isLegacyUpsell ||
     hasEndingPartnerPlan ||
     isBizPlanFamily(subscription.pendingChanges?.planDetails)

--- a/static/gsApp/views/subscriptionPage/subscriptionUpsellBanner.tsx
+++ b/static/gsApp/views/subscriptionPage/subscriptionUpsellBanner.tsx
@@ -16,6 +16,7 @@ import {
   hasPartnerMigrationFeature,
   hasPerformance,
   isBizPlanFamily,
+  isTrial,
 } from 'getsentry/utils/billing';
 import {TrialBadge} from 'getsentry/views/subscriptionPage/trial/badge';
 
@@ -89,7 +90,7 @@ function useIsSubscriptionUpsellHidden(
     !subscription.canSelfServe ||
     (hasPerformance(subscription.planDetails) &&
       isBizPlanFamily(subscription.planDetails)) ||
-    subscription.trialPlan !== null ||
+    isTrial(subscription) ||
     isLegacyUpsell ||
     hasEndingPartnerPlan ||
     isBizPlanFamily(subscription.pendingChanges?.planDetails)

--- a/static/gsApp/views/subscriptionPage/trial/badge.tsx
+++ b/static/gsApp/views/subscriptionPage/trial/badge.tsx
@@ -14,7 +14,7 @@ type Props = {
 };
 
 export function TrialBadge({subscription, organization}: Props) {
-  if (subscription.isTrial) {
+  if (subscription.trialPlan !== null) {
     return (
       <Tag variant="promotion">
         <TrialText>

--- a/static/gsApp/views/subscriptionPage/trial/badge.tsx
+++ b/static/gsApp/views/subscriptionPage/trial/badge.tsx
@@ -6,7 +6,7 @@ import {t, tn} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 
 import type {Subscription} from 'getsentry/types';
-import {getTrialDaysLeft, getTrialLength} from 'getsentry/utils/billing';
+import {getTrialDaysLeft, getTrialLength, isTrial} from 'getsentry/utils/billing';
 
 type Props = {
   organization: Organization;
@@ -14,7 +14,7 @@ type Props = {
 };
 
 export function TrialBadge({subscription, organization}: Props) {
-  if (subscription.trialPlan !== null) {
+  if (isTrial(subscription)) {
     return (
       <Tag variant="promotion">
         <TrialText>

--- a/static/gsApp/views/subscriptionPage/trial/trialEnded.tsx
+++ b/static/gsApp/views/subscriptionPage/trial/trialEnded.tsx
@@ -9,6 +9,7 @@ import {showIntercom} from 'sentry/utils/intercom';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 import type {Subscription} from 'getsentry/types';
+import {isTrial} from 'getsentry/utils/billing';
 import {trackGetsentryAnalytics} from 'getsentry/utils/trackGetsentryAnalytics';
 
 type Props = {
@@ -20,7 +21,7 @@ export function TrialEnded({subscription}: Props) {
   const canRequestTrial =
     subscription.canSelfServe && subscription.planDetails?.trialPlan;
   const shouldRender = !(
-    subscription.trialPlan !== null ||
+    isTrial(subscription) ||
     subscription.canTrial ||
     !canRequestTrial
   );

--- a/static/gsApp/views/subscriptionPage/trial/trialEnded.tsx
+++ b/static/gsApp/views/subscriptionPage/trial/trialEnded.tsx
@@ -20,7 +20,7 @@ export function TrialEnded({subscription}: Props) {
   const canRequestTrial =
     subscription.canSelfServe && subscription.planDetails?.trialPlan;
   const shouldRender = !(
-    subscription.isTrial ||
+    subscription.trialPlan !== null ||
     subscription.canTrial ||
     !canRequestTrial
   );

--- a/static/gsApp/views/subscriptionPage/trialAlert.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/trialAlert.spec.tsx
@@ -21,7 +21,7 @@ describe('Subscription > TrialAlert', () => {
   it('does not render not on trial', () => {
     const sub = {
       ...subscription,
-      isTrial: false,
+      trialPlan: null,
       onDemandMaxSpend: 1000,
       onDemandSpendUsed: 0,
     };
@@ -32,7 +32,7 @@ describe('Subscription > TrialAlert', () => {
   it('renders 1 day left', () => {
     const sub = {
       ...subscription,
-      isTrial: true,
+      trialPlan: 'am1_business',
       onDemandMaxSpend: 1000,
       onDemandSpendUsed: 0,
       trialEnd: '2021-01-02',
@@ -45,7 +45,7 @@ describe('Subscription > TrialAlert', () => {
   it('renders 14 days left', () => {
     const sub = {
       ...subscription,
-      isTrial: true,
+      trialPlan: 'am1_business',
       onDemandMaxSpend: 1000,
       onDemandSpendUsed: 0,
       trialEnd: '2021-01-15',
@@ -58,7 +58,7 @@ describe('Subscription > TrialAlert', () => {
   it('does not render negative days left', () => {
     const sub = {
       ...subscription,
-      isTrial: true,
+      trialPlan: 'am1_business',
       onDemandMaxSpend: 1000,
       onDemandSpendUsed: 0,
       trialEnd: '2020-12-01',
@@ -70,7 +70,7 @@ describe('Subscription > TrialAlert', () => {
   it('renders enterprise trial', () => {
     const sub = {
       ...subscription,
-      isTrial: true,
+      trialPlan: 'am1_business',
       isEnterpriseTrial: true,
       onDemandMaxSpend: 1000,
       onDemandSpendUsed: 0,
@@ -88,7 +88,7 @@ describe('Subscription > TrialAlert', () => {
     const am3_sub = SubscriptionFixture({organization, plan: 'am3_f'});
     const sub = {
       ...am3_sub,
-      isTrial: true,
+      trialPlan: 'am1_business',
       isEnterpriseTrial: true,
       onDemandMaxSpend: 1000,
       onDemandSpendUsed: 0,
@@ -105,7 +105,7 @@ describe('Subscription > TrialAlert', () => {
   it('renders plan trial', () => {
     const sub = {
       ...subscription,
-      isTrial: true,
+      trialPlan: 'am1_business',
       isEnterpriseTrial: false,
       isPerformancePlanTrial: false,
       onDemandMaxSpend: 1000,
@@ -124,7 +124,7 @@ describe('Subscription > TrialAlert', () => {
   it('renders performance trial', () => {
     const sub = {
       ...subscription,
-      isTrial: true,
+      trialPlan: 'am1_business',
       isEnterpriseTrial: false,
       isPerformancePlanTrial: true,
       onDemandMaxSpend: 1000,

--- a/static/gsApp/views/subscriptionPage/trialAlert.tsx
+++ b/static/gsApp/views/subscriptionPage/trialAlert.tsx
@@ -20,7 +20,7 @@ type Props = {
 };
 
 export function TrialAlert({organization, subscription}: Props) {
-  if (!subscription.isTrial) {
+  if (subscription.trialPlan === null) {
     return null;
   }
 

--- a/static/gsApp/views/subscriptionPage/trialAlert.tsx
+++ b/static/gsApp/views/subscriptionPage/trialAlert.tsx
@@ -9,7 +9,7 @@ import {TextBlock} from 'sentry/views/settings/components/text/textBlock';
 
 import {openUpsellModal} from 'getsentry/actionCreators/modal';
 import type {Subscription} from 'getsentry/types';
-import {getTrialDaysLeft} from 'getsentry/utils/billing';
+import {getTrialDaysLeft, isTrial} from 'getsentry/utils/billing';
 
 import {TrialBadge} from './trial/badge';
 import {ButtonWrapper, SubscriptionBody} from './styles';
@@ -20,7 +20,7 @@ type Props = {
 };
 
 export function TrialAlert({organization, subscription}: Props) {
-  if (subscription.trialPlan === null) {
+  if (!isTrial(subscription)) {
     return null;
   }
 

--- a/tests/js/getsentry-test/fixtures/subscription.ts
+++ b/tests/js/getsentry-test/fixtures/subscription.ts
@@ -88,12 +88,11 @@ export function SubscriptionFixture(props: Props): TSubscription {
     spendAllocationEnabled: false,
     status: 'active',
     totalProjects: 0,
-    trialPlan: null,
+    trialPlan: isTrial ? planDetails.id : null,
     onDemandPeriodStart: '2018-09-25',
     trialEnd: null,
     countryCode: null,
     cancelAtPeriodEnd: false,
-    isTrial,
     onTrialPlan: isTrial,
     paymentSource: {
       last4: '4242',

--- a/tests/js/getsentry-test/fixtures/subscription.ts
+++ b/tests/js/getsentry-test/fixtures/subscription.ts
@@ -1,52 +1,70 @@
-import {MetricHistoryFixture} from 'getsentry-test/fixtures/metricHistory';
+import { MetricHistoryFixture } from "getsentry-test/fixtures/metricHistory";
 import {
   PlanDetailsLookupFixture,
   type PlanIds,
-} from 'getsentry-test/fixtures/planDetailsLookup';
-import {SeerReservedBudgetFixture} from 'getsentry-test/fixtures/reservedBudget';
+} from "getsentry-test/fixtures/planDetailsLookup";
+import { SeerReservedBudgetFixture } from "getsentry-test/fixtures/reservedBudget";
 
-import {DataCategory} from 'sentry/types/core';
-import type {Organization} from 'sentry/types/organization';
+import { DataCategory } from "sentry/types/core";
+import type { Organization } from "sentry/types/organization";
 
-import {RESERVED_BUDGET_QUOTA} from 'getsentry/constants';
-import type {Plan, Subscription as TSubscription} from 'getsentry/types';
-import {AddOnCategory, BillingType} from 'getsentry/types';
+import { RESERVED_BUDGET_QUOTA } from "getsentry/constants";
+import type { Plan, Subscription as TSubscription } from "getsentry/types";
+import { AddOnCategory, BillingType } from "getsentry/types";
 
-const TRIAL_PLANS = ['am1_t', 'am2_t', 'am3_t', 'am1_t_ent', 'am2_t_ent', 'am3_t_ent'];
+const TRIAL_PLANS = [
+  "am1_t",
+  "am2_t",
+  "am3_t",
+  "am1_t_ent",
+  "am2_t_ent",
+  "am3_t_ent",
+];
 
 // Derives whether a plan id is a trial plan, so the fixture can set the
 // trial-related fields the backend resolves from the subscription.
 const isTrialPlan = (plan: string) => TRIAL_PLANS.includes(plan);
 
-type Props = Partial<TSubscription> & {organization: Organization};
+type Props = Partial<TSubscription> & { organization: Organization };
 
 export function SubscriptionFixture(props: Props): TSubscription {
-  const {organization, ...params} = props;
-  const planData = {plan: 'am1_f', ...params};
+  const { organization, ...params } = props;
+  const planData = { plan: "am1_f", ...params };
 
   // Use planDetails from params if provided, otherwise look it up
   const planDetails = (planData.planDetails ||
     PlanDetailsLookupFixture(planData.plan as PlanIds)) as Plan;
 
-  const hasPerformance = planDetails?.categories?.includes(DataCategory.TRANSACTIONS);
+  const hasPerformance = planDetails?.categories?.includes(
+    DataCategory.TRANSACTIONS
+  );
   const hasReplays = planDetails?.categories?.includes(DataCategory.REPLAYS);
-  const hasMonitors = planDetails?.categories?.includes(DataCategory.MONITOR_SEATS);
+  const hasMonitors = planDetails?.categories?.includes(
+    DataCategory.MONITOR_SEATS
+  );
   const hasUptime = planDetails?.categories?.includes(DataCategory.UPTIME);
   const hasSpans = planDetails?.categories?.includes(DataCategory.SPANS);
-  const hasSpansIndexed = planDetails?.categories?.includes(DataCategory.SPANS_INDEXED);
+  const hasSpansIndexed = planDetails?.categories?.includes(
+    DataCategory.SPANS_INDEXED
+  );
   const hasProfileDuration = planDetails?.categories?.includes(
     DataCategory.PROFILE_DURATION
   );
   const hasProfileDurationUI = planDetails?.categories?.includes(
     DataCategory.PROFILE_DURATION_UI
   );
-  const hasAttachments = planDetails?.categories?.includes(DataCategory.ATTACHMENTS);
+  const hasAttachments = planDetails?.categories?.includes(
+    DataCategory.ATTACHMENTS
+  );
   const hasLogBytes = planDetails?.categories?.includes(DataCategory.LOG_BYTE);
-  const hasSizeAnalyses = planDetails?.categories?.includes(DataCategory.SIZE_ANALYSIS);
+  const hasSizeAnalyses = planDetails?.categories?.includes(
+    DataCategory.SIZE_ANALYSIS
+  );
   const hasInstallableBuilds = planDetails?.categories?.includes(
     DataCategory.INSTALLABLE_BUILD
   );
-  const hasLegacySeer = AddOnCategory.LEGACY_SEER in planDetails.addOnCategories;
+  const hasLegacySeer =
+    AddOnCategory.LEGACY_SEER in planDetails.addOnCategories;
   const hasSeer = AddOnCategory.SEER in planDetails.addOnCategories;
 
   // Create a safe default for planCategories if it doesn't exist
@@ -57,14 +75,16 @@ export function SubscriptionFixture(props: Props): TSubscription {
   const reservedBudgets = [];
   if (hasLegacySeer) {
     if (isTrial) {
-      reservedBudgets.push(SeerReservedBudgetFixture({reservedBudget: 150_00}));
+      reservedBudgets.push(
+        SeerReservedBudgetFixture({ reservedBudget: 150_00 })
+      );
     } else {
-      reservedBudgets.push(SeerReservedBudgetFixture({reservedBudget: 0}));
+      reservedBudgets.push(SeerReservedBudgetFixture({ reservedBudget: 0 }));
     }
   }
 
-  const addOns: TSubscription['addOns'] = {};
-  Object.values(planDetails.addOnCategories).forEach(addOnCategory => {
+  const addOns: TSubscription["addOns"] = {};
+  Object.values(planDetails.addOnCategories).forEach((addOnCategory) => {
     addOns[addOnCategory.apiName] = {
       ...addOnCategory,
       enabled: isTrial,
@@ -78,7 +98,7 @@ export function SubscriptionFixture(props: Props): TSubscription {
     hasDismissedTrialEndingNotice: false,
     hasMigratedToBillingPlatform: false,
     hadCustomDynamicSampling: false,
-    id: '',
+    id: "",
     isEnterpriseTrial,
     isOverMemberLimit: false,
     isPartner: false,
@@ -86,30 +106,30 @@ export function SubscriptionFixture(props: Props): TSubscription {
     isPerformancePlanTrial: false,
     lastTrialEnd: null,
     spendAllocationEnabled: false,
-    status: 'active',
+    status: "active",
     totalProjects: 0,
     trialPlan: isTrial ? planDetails.id : null,
-    onDemandPeriodStart: '2018-09-25',
+    onDemandPeriodStart: "2018-09-25",
     trialEnd: null,
     countryCode: null,
     cancelAtPeriodEnd: false,
     onTrialPlan: isTrial,
     paymentSource: {
-      last4: '4242',
-      countryCode: 'US',
-      zipCode: '94242',
+      last4: "4242",
+      countryCode: "US",
+      zipCode: "94242",
       expMonth: 12,
       expYear: 2077,
-      brand: 'Visa',
+      brand: "Visa",
     },
-    billingPeriodEnd: '2018-10-24',
+    billingPeriodEnd: "2018-10-24",
     onDemandSpendUsed: 0,
-    renewalDate: '2018-10-25',
+    renewalDate: "2018-10-25",
     partner: null,
     planDetails,
     totalMembers: 1,
     totalLicenses: 1,
-    billingPeriodStart: '2018-09-25',
+    billingPeriodStart: "2018-09-25",
     suspensionReason: null,
     accountBalance: -10000,
     companyName: null,
@@ -135,11 +155,11 @@ export function SubscriptionFixture(props: Props): TSubscription {
     slug: organization.slug,
     pendingChanges: null,
     name: organization.name,
-    billingInterval: planDetails.billingInterval || 'monthly',
-    dateJoined: '2018-09-10T23:58:10.167Z',
-    onDemandPeriodEnd: '2018-10-24',
+    billingInterval: planDetails.billingInterval || "monthly",
+    dateJoined: "2018-09-10T23:58:10.167Z",
+    onDemandPeriodEnd: "2018-10-24",
     msaUpdatedForDataConsent: false,
-    orgRetention: {standard: null, downsampled: null},
+    orgRetention: { standard: null, downsampled: null },
     addOns,
     reservedBudgets,
     categories: {
@@ -319,7 +339,7 @@ export function SubscriptionWithLegacySeerFixture(props: Props): TSubscription {
 }
 
 export function InvoicedSubscriptionFixture(props: Props): TSubscription {
-  const planData = {plan: 'am2_business_ent_auf', ...props};
+  const planData = { plan: "am2_business_ent_auf", ...props };
   const planDetails = PlanDetailsLookupFixture(planData.plan as PlanIds);
   const subscription = SubscriptionFixture({
     ...props,
@@ -327,7 +347,7 @@ export function InvoicedSubscriptionFixture(props: Props): TSubscription {
     plan: planDetails?.id,
     canSelfServe: false,
     type: BillingType.INVOICED,
-    channel: 'sales',
+    channel: "sales",
     accountBalance: 0,
     isFree: false,
   });

--- a/tests/js/getsentry-test/fixtures/subscription.ts
+++ b/tests/js/getsentry-test/fixtures/subscription.ts
@@ -1,70 +1,52 @@
-import { MetricHistoryFixture } from "getsentry-test/fixtures/metricHistory";
+import {MetricHistoryFixture} from 'getsentry-test/fixtures/metricHistory';
 import {
   PlanDetailsLookupFixture,
   type PlanIds,
-} from "getsentry-test/fixtures/planDetailsLookup";
-import { SeerReservedBudgetFixture } from "getsentry-test/fixtures/reservedBudget";
+} from 'getsentry-test/fixtures/planDetailsLookup';
+import {SeerReservedBudgetFixture} from 'getsentry-test/fixtures/reservedBudget';
 
-import { DataCategory } from "sentry/types/core";
-import type { Organization } from "sentry/types/organization";
+import {DataCategory} from 'sentry/types/core';
+import type {Organization} from 'sentry/types/organization';
 
-import { RESERVED_BUDGET_QUOTA } from "getsentry/constants";
-import type { Plan, Subscription as TSubscription } from "getsentry/types";
-import { AddOnCategory, BillingType } from "getsentry/types";
+import {RESERVED_BUDGET_QUOTA} from 'getsentry/constants';
+import type {Plan, Subscription as TSubscription} from 'getsentry/types';
+import {AddOnCategory, BillingType} from 'getsentry/types';
 
-const TRIAL_PLANS = [
-  "am1_t",
-  "am2_t",
-  "am3_t",
-  "am1_t_ent",
-  "am2_t_ent",
-  "am3_t_ent",
-];
+const TRIAL_PLANS = ['am1_t', 'am2_t', 'am3_t', 'am1_t_ent', 'am2_t_ent', 'am3_t_ent'];
 
 // Derives whether a plan id is a trial plan, so the fixture can set the
 // trial-related fields the backend resolves from the subscription.
 const isTrialPlan = (plan: string) => TRIAL_PLANS.includes(plan);
 
-type Props = Partial<TSubscription> & { organization: Organization };
+type Props = Partial<TSubscription> & {organization: Organization};
 
 export function SubscriptionFixture(props: Props): TSubscription {
-  const { organization, ...params } = props;
-  const planData = { plan: "am1_f", ...params };
+  const {organization, ...params} = props;
+  const planData = {plan: 'am1_f', ...params};
 
   // Use planDetails from params if provided, otherwise look it up
   const planDetails = (planData.planDetails ||
     PlanDetailsLookupFixture(planData.plan as PlanIds)) as Plan;
 
-  const hasPerformance = planDetails?.categories?.includes(
-    DataCategory.TRANSACTIONS
-  );
+  const hasPerformance = planDetails?.categories?.includes(DataCategory.TRANSACTIONS);
   const hasReplays = planDetails?.categories?.includes(DataCategory.REPLAYS);
-  const hasMonitors = planDetails?.categories?.includes(
-    DataCategory.MONITOR_SEATS
-  );
+  const hasMonitors = planDetails?.categories?.includes(DataCategory.MONITOR_SEATS);
   const hasUptime = planDetails?.categories?.includes(DataCategory.UPTIME);
   const hasSpans = planDetails?.categories?.includes(DataCategory.SPANS);
-  const hasSpansIndexed = planDetails?.categories?.includes(
-    DataCategory.SPANS_INDEXED
-  );
+  const hasSpansIndexed = planDetails?.categories?.includes(DataCategory.SPANS_INDEXED);
   const hasProfileDuration = planDetails?.categories?.includes(
     DataCategory.PROFILE_DURATION
   );
   const hasProfileDurationUI = planDetails?.categories?.includes(
     DataCategory.PROFILE_DURATION_UI
   );
-  const hasAttachments = planDetails?.categories?.includes(
-    DataCategory.ATTACHMENTS
-  );
+  const hasAttachments = planDetails?.categories?.includes(DataCategory.ATTACHMENTS);
   const hasLogBytes = planDetails?.categories?.includes(DataCategory.LOG_BYTE);
-  const hasSizeAnalyses = planDetails?.categories?.includes(
-    DataCategory.SIZE_ANALYSIS
-  );
+  const hasSizeAnalyses = planDetails?.categories?.includes(DataCategory.SIZE_ANALYSIS);
   const hasInstallableBuilds = planDetails?.categories?.includes(
     DataCategory.INSTALLABLE_BUILD
   );
-  const hasLegacySeer =
-    AddOnCategory.LEGACY_SEER in planDetails.addOnCategories;
+  const hasLegacySeer = AddOnCategory.LEGACY_SEER in planDetails.addOnCategories;
   const hasSeer = AddOnCategory.SEER in planDetails.addOnCategories;
 
   // Create a safe default for planCategories if it doesn't exist
@@ -75,16 +57,14 @@ export function SubscriptionFixture(props: Props): TSubscription {
   const reservedBudgets = [];
   if (hasLegacySeer) {
     if (isTrial) {
-      reservedBudgets.push(
-        SeerReservedBudgetFixture({ reservedBudget: 150_00 })
-      );
+      reservedBudgets.push(SeerReservedBudgetFixture({reservedBudget: 150_00}));
     } else {
-      reservedBudgets.push(SeerReservedBudgetFixture({ reservedBudget: 0 }));
+      reservedBudgets.push(SeerReservedBudgetFixture({reservedBudget: 0}));
     }
   }
 
-  const addOns: TSubscription["addOns"] = {};
-  Object.values(planDetails.addOnCategories).forEach((addOnCategory) => {
+  const addOns: TSubscription['addOns'] = {};
+  Object.values(planDetails.addOnCategories).forEach(addOnCategory => {
     addOns[addOnCategory.apiName] = {
       ...addOnCategory,
       enabled: isTrial,
@@ -98,7 +78,7 @@ export function SubscriptionFixture(props: Props): TSubscription {
     hasDismissedTrialEndingNotice: false,
     hasMigratedToBillingPlatform: false,
     hadCustomDynamicSampling: false,
-    id: "",
+    id: '',
     isEnterpriseTrial,
     isOverMemberLimit: false,
     isPartner: false,
@@ -106,30 +86,30 @@ export function SubscriptionFixture(props: Props): TSubscription {
     isPerformancePlanTrial: false,
     lastTrialEnd: null,
     spendAllocationEnabled: false,
-    status: "active",
+    status: 'active',
     totalProjects: 0,
     trialPlan: isTrial ? planDetails.id : null,
-    onDemandPeriodStart: "2018-09-25",
+    onDemandPeriodStart: '2018-09-25',
     trialEnd: null,
     countryCode: null,
     cancelAtPeriodEnd: false,
     onTrialPlan: isTrial,
     paymentSource: {
-      last4: "4242",
-      countryCode: "US",
-      zipCode: "94242",
+      last4: '4242',
+      countryCode: 'US',
+      zipCode: '94242',
       expMonth: 12,
       expYear: 2077,
-      brand: "Visa",
+      brand: 'Visa',
     },
-    billingPeriodEnd: "2018-10-24",
+    billingPeriodEnd: '2018-10-24',
     onDemandSpendUsed: 0,
-    renewalDate: "2018-10-25",
+    renewalDate: '2018-10-25',
     partner: null,
     planDetails,
     totalMembers: 1,
     totalLicenses: 1,
-    billingPeriodStart: "2018-09-25",
+    billingPeriodStart: '2018-09-25',
     suspensionReason: null,
     accountBalance: -10000,
     companyName: null,
@@ -155,11 +135,11 @@ export function SubscriptionFixture(props: Props): TSubscription {
     slug: organization.slug,
     pendingChanges: null,
     name: organization.name,
-    billingInterval: planDetails.billingInterval || "monthly",
-    dateJoined: "2018-09-10T23:58:10.167Z",
-    onDemandPeriodEnd: "2018-10-24",
+    billingInterval: planDetails.billingInterval || 'monthly',
+    dateJoined: '2018-09-10T23:58:10.167Z',
+    onDemandPeriodEnd: '2018-10-24',
     msaUpdatedForDataConsent: false,
-    orgRetention: { standard: null, downsampled: null },
+    orgRetention: {standard: null, downsampled: null},
     addOns,
     reservedBudgets,
     categories: {
@@ -339,7 +319,7 @@ export function SubscriptionWithLegacySeerFixture(props: Props): TSubscription {
 }
 
 export function InvoicedSubscriptionFixture(props: Props): TSubscription {
-  const planData = { plan: "am2_business_ent_auf", ...props };
+  const planData = {plan: 'am2_business_ent_auf', ...props};
   const planDetails = PlanDetailsLookupFixture(planData.plan as PlanIds);
   const subscription = SubscriptionFixture({
     ...props,
@@ -347,7 +327,7 @@ export function InvoicedSubscriptionFixture(props: Props): TSubscription {
     plan: planDetails?.id,
     canSelfServe: false,
     type: BillingType.INVOICED,
-    channel: "sales",
+    channel: 'sales',
     accountBalance: 0,
     isFree: false,
   });


### PR DESCRIPTION
`isTrial` is not needed. It's always true when `trialPlan` is provided and false when it is null.