### PR TITLE
ref(split-panel): extract SplitDivider into DragHandle component

### DIFF
--- a/static/app/components/core/dragHandle/dragHandle.tsx
+++ b/static/app/components/core/dragHandle/dragHandle.tsx
@@ -1,0 +1,153 @@
+import styled from '@emotion/styled';
+
+import {Container} from '@sentry/scraps/layout';
+
+export type Orientation = 'horizontal' | 'vertical';
+
+// The handle renders as a 1px border; account for it when a consumer derives
+// layout sizes (e.g. the max size of a panel next to it).
+export const DRAG_HANDLE_SIZE = 1;
+
+// At a limit the handle can only travel one way, so point the cursor that way;
+// the grow/shrink direction flips when the sized pane sits after the handle.
+function getDragHandleCursor(
+  orientation: Orientation,
+  atMin: boolean,
+  atMax: boolean,
+  isSizedFirst: boolean
+): React.CSSProperties['cursor'] {
+  if (orientation === 'horizontal') {
+    if (atMin) {
+      return isSizedFirst ? 'e-resize' : 'w-resize';
+    }
+    if (atMax) {
+      return isSizedFirst ? 'w-resize' : 'e-resize';
+    }
+    return 'ew-resize';
+  }
+  if (atMin) {
+    return isSizedFirst ? 's-resize' : 'n-resize';
+  }
+  if (atMax) {
+    return isSizedFirst ? 'n-resize' : 's-resize';
+  }
+  return 'ns-resize';
+}
+
+export type DragHandleProps = {
+  isHeld: boolean;
+  isSizedFirst: boolean;
+  max: number;
+  min: number;
+  onDoubleClick: React.MouseEventHandler<HTMLElement>;
+  onKeyDown: React.KeyboardEventHandler<HTMLElement>;
+  onPointerDown: React.PointerEventHandler<HTMLElement>;
+  orientation: Orientation;
+  value: number;
+};
+
+export function DragHandle({
+  isHeld,
+  isSizedFirst,
+  max,
+  min,
+  orientation,
+  value,
+  onDoubleClick,
+  onKeyDown,
+  onPointerDown,
+}: DragHandleProps) {
+  const cursor = getDragHandleCursor(
+    orientation,
+    value <= min,
+    Number.isFinite(max) && value >= max,
+    isSizedFirst
+  );
+
+  return (
+    <Container position="relative" flexShrink={0}>
+      {containerProps => (
+        <DragHandleLine
+          {...containerProps}
+          $cursor={cursor}
+          aria-orientation={orientation === 'horizontal' ? 'vertical' : 'horizontal'}
+          aria-valuemax={Number.isFinite(max) ? max : undefined}
+          aria-valuemin={min}
+          aria-valuenow={value}
+          data-is-held={isHeld}
+          data-orientation={orientation}
+          onDoubleClick={onDoubleClick}
+          onKeyDown={onKeyDown}
+          onPointerDown={onPointerDown}
+          role="separator"
+          tabIndex={0}
+        />
+      )}
+    </Container>
+  );
+}
+
+const DragHandleLine = styled('div')<{$cursor: React.CSSProperties['cursor']}>`
+  user-select: none;
+  touch-action: none;
+  cursor: ${p => p.$cursor};
+
+  /* Invisible wider hit area for dragging */
+  &::before {
+    content: '';
+    position: absolute;
+    z-index: ${p => p.theme.zIndex.drawer};
+  }
+
+  /* Accent bar that lights up on hover/drag */
+  &::after {
+    content: '';
+    position: absolute;
+    z-index: ${p => p.theme.zIndex.drawer};
+    opacity: 0.8;
+    background: transparent;
+    transition: background ${p => p.theme.motion.smooth.slow} 0.1s;
+  }
+
+  &:hover::after,
+  &[data-is-held='true']::after {
+    background: ${p => p.theme.tokens.graphics.accent.vibrant};
+  }
+
+  &[data-orientation='horizontal'] {
+    width: 0;
+    height: auto;
+    align-self: stretch;
+    border-left: 1px solid ${p => p.theme.tokens.border.primary};
+
+    &::before {
+      inset: 0 auto 0 -5px;
+      width: 11px;
+    }
+
+    &::after {
+      inset: 0 auto 0 -2px;
+      width: 4px;
+    }
+  }
+
+  &[data-orientation='vertical'] {
+    width: 100%;
+    height: 0;
+    border-top: 1px solid ${p => p.theme.tokens.border.primary};
+
+    &::before {
+      inset: -5px 0 auto 0;
+      height: 11px;
+    }
+
+    &::after {
+      inset: -2px 0 auto 0;
+      height: 4px;
+    }
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${p => p.theme.tokens.focus.default};
+  }
+`;

--- a/static/app/components/core/dragHandle/index.tsx
+++ b/static/app/components/core/dragHandle/index.tsx
@@ -1,6 +1,1 @@
-export {
-  DragHandle,
-  DRAG_HANDLE_SIZE,
-  type DragHandleProps,
-  type Orientation,
-} from './dragHandle';
+export {DragHandle, DRAG_HANDLE_SIZE} from './dragHandle';

--- a/static/app/components/core/dragHandle/index.tsx
+++ b/static/app/components/core/dragHandle/index.tsx
@@ -1,0 +1,6 @@
+export {
+  DragHandle,
+  DRAG_HANDLE_SIZE,
+  type DragHandleProps,
+  type Orientation,
+} from './dragHandle';

--- a/static/app/components/core/splitPanel/splitPanel.tsx
+++ b/static/app/components/core/splitPanel/splitPanel.tsx
@@ -1,16 +1,12 @@
 import {useCallback, useImperativeHandle, useRef} from 'react';
 import styled from '@emotion/styled';
 
-import {Container, Flex, type Responsive, Stack} from '@sentry/scraps/layout';
+import {DRAG_HANDLE_SIZE, DragHandle} from '@sentry/scraps/dragHandle';
+import {Flex, type Responsive, Stack} from '@sentry/scraps/layout';
 import {useResponsivePropValue} from '@sentry/scraps/layout/styles';
 
 import {useDimensions} from 'sentry/utils/useDimensions';
 import {useResizableDrawer} from 'sentry/utils/useResizableDrawer';
-
-type Orientation = 'horizontal' | 'vertical';
-
-// The divider renders as a 1px border; account for it when deriving the max.
-const DIVIDER_SIZE = 1;
 
 export interface SplitPanelHandle {
   /**
@@ -50,32 +46,6 @@ interface SplitPanelProps {
   ref?: React.Ref<SplitPanelHandle>;
 }
 
-// At a limit the divider can only travel one way, so point the cursor that way;
-// the grow/shrink direction flips when the sized pane sits after the divider.
-function getDividerCursor(
-  orientation: Orientation,
-  atMin: boolean,
-  atMax: boolean,
-  isSizedFirst: boolean
-): React.CSSProperties['cursor'] {
-  if (orientation === 'horizontal') {
-    if (atMin) {
-      return isSizedFirst ? 'e-resize' : 'w-resize';
-    }
-    if (atMax) {
-      return isSizedFirst ? 'w-resize' : 'e-resize';
-    }
-    return 'ew-resize';
-  }
-  if (atMin) {
-    return isSizedFirst ? 's-resize' : 'n-resize';
-  }
-  if (atMax) {
-    return isSizedFirst ? 'n-resize' : 's-resize';
-  }
-  return 'ns-resize';
-}
-
 // `size === null` fills the remaining space; otherwise it takes a fixed basis.
 function Pane({size, children}: {children: React.ReactNode; size: number | null}) {
   const isFilling = size === null;
@@ -89,59 +59,6 @@ function Pane({size, children}: {children: React.ReactNode; size: number | null}
     >
       {children}
     </Stack>
-  );
-}
-
-type SplitDividerProps = {
-  isHeld: boolean;
-  isSizedFirst: boolean;
-  max: number;
-  min: number;
-  onDoubleClick: React.MouseEventHandler<HTMLElement>;
-  onKeyDown: React.KeyboardEventHandler<HTMLElement>;
-  onPointerDown: React.PointerEventHandler<HTMLElement>;
-  orientation: Orientation;
-  value: number;
-};
-
-function SplitDivider({
-  isHeld,
-  isSizedFirst,
-  max,
-  min,
-  orientation,
-  value,
-  onDoubleClick,
-  onKeyDown,
-  onPointerDown,
-}: SplitDividerProps) {
-  const cursor = getDividerCursor(
-    orientation,
-    value <= min,
-    Number.isFinite(max) && value >= max,
-    isSizedFirst
-  );
-
-  return (
-    <Container position="relative" flexShrink={0}>
-      {containerProps => (
-        <DividerLine
-          {...containerProps}
-          $cursor={cursor}
-          aria-orientation={orientation === 'horizontal' ? 'vertical' : 'horizontal'}
-          aria-valuemax={Number.isFinite(max) ? max : undefined}
-          aria-valuemin={min}
-          aria-valuenow={value}
-          data-is-held={isHeld}
-          data-orientation={orientation}
-          onDoubleClick={onDoubleClick}
-          onKeyDown={onKeyDown}
-          onPointerDown={onPointerDown}
-          role="separator"
-          tabIndex={0}
-        />
-      )}
-    </Container>
   );
 }
 
@@ -175,7 +92,10 @@ export function SplitPanel({
   // Floored at min; falls back to the explicit max until we've measured.
   const max =
     availableSize > 0
-      ? Math.max(min, Math.min(explicitMax, availableSize - fillMinSize - DIVIDER_SIZE))
+      ? Math.max(
+          min,
+          Math.min(explicitMax, availableSize - fillMinSize - DRAG_HANDLE_SIZE)
+        )
       : explicitMax;
 
   const handleResizeEnd = useCallback(
@@ -223,50 +143,47 @@ export function SplitPanel({
   // size rather than the raw (possibly out-of-range) containerSize.
   const visibleSize = Math.max(min, Math.min(containerSize, max));
 
-  const handleDoubleClick = useCallback(() => {
+  const handleDoubleClick = () => {
     const target = Math.max(min, Math.min(defaultSize, max));
     setSize(target, true);
     handleResizeEnd(visibleSize, target);
-  }, [visibleSize, max, min, defaultSize, setSize, handleResizeEnd]);
+  };
 
-  const handleKeyDown = useCallback(
-    (event: React.KeyboardEvent<HTMLElement>) => {
-      const step = event.shiftKey ? 50 : 10;
-      const isHorizontal = orientation === 'horizontal';
-      const towardStartKey = isHorizontal ? 'ArrowLeft' : 'ArrowUp';
-      const towardEndKey = isHorizontal ? 'ArrowRight' : 'ArrowDown';
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
+    const step = event.shiftKey ? 50 : 10;
+    const isHorizontal = orientation === 'horizontal';
+    const towardStartKey = isHorizontal ? 'ArrowLeft' : 'ArrowUp';
+    const towardEndKey = isHorizontal ? 'ArrowRight' : 'ArrowDown';
 
-      // Keys map to physical separator direction; moving it toward `end` grows
-      // the sized pane only when it sits first, and shrinks it otherwise.
-      const growKey = isSizedFirst ? towardEndKey : towardStartKey;
-      const shrinkKey = isSizedFirst ? towardStartKey : towardEndKey;
+    // Keys map to physical separator direction; moving it toward `end` grows
+    // the sized pane only when it sits first, and shrinks it otherwise.
+    const growKey = isSizedFirst ? towardEndKey : towardStartKey;
+    const shrinkKey = isSizedFirst ? towardStartKey : towardEndKey;
 
-      // Step from the visible size so it still moves after the container shrank.
-      const current = visibleSize;
+    // Step from the visible size so it still moves after the container shrank.
+    const current = visibleSize;
 
-      let newSize: number | null = null;
-      if (event.key === shrinkKey) {
-        newSize = Math.max(min, current - step);
-      } else if (event.key === growKey) {
-        newSize = Math.min(max, current + step);
-      } else if (event.key === 'Home') {
-        // Separator to the start edge.
-        newSize = isSizedFirst ? min : max;
-      } else if (event.key === 'End') {
-        // Separator to the end edge.
-        newSize = isSizedFirst ? max : min;
-      }
+    let newSize: number | null = null;
+    if (event.key === shrinkKey) {
+      newSize = Math.max(min, current - step);
+    } else if (event.key === growKey) {
+      newSize = Math.min(max, current + step);
+    } else if (event.key === 'Home') {
+      // Separator to the start edge.
+      newSize = isSizedFirst ? min : max;
+    } else if (event.key === 'End') {
+      // Separator to the end edge.
+      newSize = isSizedFirst ? max : min;
+    }
 
-      // Skip when the target is an unbounded max (not yet measured); min and
-      // stepped targets are always finite, so this only gates the edge keys.
-      if (newSize !== null && Number.isFinite(newSize)) {
-        event.preventDefault();
-        setSize(newSize, true);
-        handleResizeEnd(current, newSize);
-      }
-    },
-    [orientation, isSizedFirst, visibleSize, min, max, setSize, handleResizeEnd]
-  );
+    // Skip when the target is an unbounded max (not yet measured); min and
+    // stepped targets are always finite, so this only gates the edge keys.
+    if (newSize !== null && Number.isFinite(newSize)) {
+      event.preventDefault();
+      setSize(newSize, true);
+      handleResizeEnd(current, newSize);
+    }
+  };
 
   // Ordered sized -> divider -> fill; reversed for `placement="end"`. Keys keep
   // pane identity across the flip.
@@ -277,7 +194,7 @@ export function SplitPanel({
   ];
   if (hasFill) {
     panes.push(
-      <SplitDivider
+      <DragHandle
         key="divider"
         isHeld={isHeld}
         isSizedFirst={isSizedFirst}
@@ -331,70 +248,5 @@ const RootElement = styled('div')`
    */
   &&&[data-is-held='true'] iframe {
     pointer-events: none !important;
-  }
-`;
-
-const DividerLine = styled('div')<{$cursor: React.CSSProperties['cursor']}>`
-  user-select: none;
-  touch-action: none;
-  cursor: ${p => p.$cursor};
-
-  /* Invisible wider hit area for dragging */
-  &::before {
-    content: '';
-    position: absolute;
-    z-index: ${p => p.theme.zIndex.drawer};
-  }
-
-  /* Accent bar that lights up on hover/drag */
-  &::after {
-    content: '';
-    position: absolute;
-    z-index: ${p => p.theme.zIndex.drawer};
-    opacity: 0.8;
-    background: transparent;
-    transition: background ${p => p.theme.motion.smooth.slow} 0.1s;
-  }
-
-  &:hover::after,
-  &[data-is-held='true']::after {
-    background: ${p => p.theme.tokens.graphics.accent.vibrant};
-  }
-
-  &[data-orientation='horizontal'] {
-    width: 0;
-    height: auto;
-    align-self: stretch;
-    border-left: 1px solid ${p => p.theme.tokens.border.primary};
-
-    &::before {
-      inset: 0 auto 0 -5px;
-      width: 11px;
-    }
-
-    &::after {
-      inset: 0 auto 0 -2px;
-      width: 4px;
-    }
-  }
-
-  &[data-orientation='vertical'] {
-    width: 100%;
-    height: 0;
-    border-top: 1px solid ${p => p.theme.tokens.border.primary};
-
-    &::before {
-      inset: -5px 0 auto 0;
-      height: 11px;
-    }
-
-    &::after {
-      inset: -2px 0 auto 0;
-      height: 4px;
-    }
-  }
-
-  &:focus-visible {
-    outline: 2px solid ${p => p.theme.tokens.focus.default};
   }
 `;


### PR DESCRIPTION
## Summary

- Extracted the inline `SplitDivider` from `splitPanel.tsx` into a standalone `DragHandle` component at `static/app/components/core/dragHandle/`, exposed via the `@sentry/scraps/dragHandle` alias.
- `SplitPanel` now imports `DragHandle` and `DRAG_HANDLE_SIZE` instead of defining them inline.
- Pure refactor, no behavior changes, no new UI, no thumb. Prepares the ground for future PRs that can build on `DragHandle` (thumb, other consumers).
- Also removes two unnecessary `useCallback` wrappers flagged by `@sentry/no-unnecessary-use-callback` (they wrapped handlers passed to an unmemoized child, so they provided no benefit).

