### PR TITLE
feat(snuba): enable response compression for json gated behind option…

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -941,6 +941,14 @@ register(
     type=Int,
 )
 
+# Fraction of JSON (SnQL/MQL) snuba queries that request zstd response compression via Accept-Encoding.
+register(
+    "snuba.json-response-compression.rollout",
+    type=Float,
+    default=0.0,
+    flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 
 # Refresh Bundle Indexes reported as used by symbolicator
 register(

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -40,6 +40,7 @@ from sentry.models.projectkey import ProjectKey
 from sentry.models.release import Release
 from sentry.models.releases.release_project import ReleaseProject
 from sentry.net.http import connection_from_url
+from sentry.options.rollout import in_random_rollout
 from sentry.services.eventstore.query_preprocessing import get_all_merged_group_ids
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.events import Columns
@@ -1415,6 +1416,9 @@ def _log_request_query(req: Request) -> None:
 RawResult = tuple[str, urllib3.response.HTTPResponse, Translator, Translator]
 
 
+SNUBA_JSON_RESP_COMPRESSION_ROLLOUT = "snuba.json-response-compression.rollout"
+
+
 def _snuba_query(
     params: tuple[
         sentry_sdk.Scope,
@@ -1427,8 +1431,15 @@ def _snuba_query(
     thread_isolation_scope, thread_current_scope, snuba_request = params
     with sentry_sdk.scope.use_isolation_scope(thread_isolation_scope):
         with sentry_sdk.scope.use_scope(thread_current_scope):
-            headers = snuba_request.headers
             request = snuba_request.request
+            headers = snuba_request.headers
+            # conditionally add compression encoding headers
+            should_compress = not isinstance(request.query, DeleteQuery) and in_random_rollout(
+                SNUBA_JSON_RESP_COMPRESSION_ROLLOUT
+            )
+            if should_compress:
+                headers = {**headers, "Accept-Encoding": "zstd"}
+
             try:
                 referrer = headers.get("referer", "unknown")
 

--- a/tests/sentry/billing/platform/services/usage/test_service.py
+++ b/tests/sentry/billing/platform/services/usage/test_service.py
@@ -16,6 +16,9 @@ from sentry.billing.platform.services.usage.service import (
     UsageService as UsageServiceDirect,
 )
 
+# TODO(EAP-627): remove once `snuba.json-response-compression.rollout` completes.
+pytestmark = [pytest.mark.django_db]
+
 
 class TestUsageService:
     """Tests for the UsageService."""

--- a/tests/sentry/replays/integration/test_data_export.py
+++ b/tests/sentry/replays/integration/test_data_export.py
@@ -13,6 +13,9 @@ from sentry.replays.data_export import (
 from sentry.replays.testutils import mock_replay
 from sentry.testutils.skips import requires_snuba
 
+# TODO(EAP-627): remove once `snuba.json-response-compression.rollout` completes.
+pytestmark = [pytest.mark.django_db]
+
 
 @pytest.mark.snuba
 @requires_snuba

--- a/tests/sentry/replays/test_query.py
+++ b/tests/sentry/replays/test_query.py
@@ -11,6 +11,9 @@ from sentry.replays.query import get_replay_range
 from sentry.replays.testutils import mock_replay
 from sentry.testutils.skips import requires_snuba
 
+# TODO(EAP-627): remove once `snuba.json-response-compression.rollout` completes.
+pytestmark = [pytest.mark.django_db]
+
 
 class ReplayStore:
     def save(self, data: Any) -> None:

--- a/tests/sentry/utils/test_snuba.py
+++ b/tests/sentry/utils/test_snuba.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from unittest import mock
 
 import pytest
+import sentry_sdk
 from django.utils import timezone
 from snuba_sdk import Column, Condition, Entity, Function, Op, Query, Request
 from urllib3 import HTTPConnectionPool
@@ -15,9 +16,12 @@ from sentry.models.project import Project
 from sentry.models.release import Release
 from sentry.snuba.dataset import Dataset
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers import override_options
 from sentry.utils import json
 from sentry.utils.snuba import (
     ROUND_UP,
+    SNUBA_JSON_RESP_COMPRESSION_ROLLOUT,
+    DeleteQuery,
     RateLimitExceeded,
     RetrySkipTimeout,
     SnubaQueryParams,
@@ -25,6 +29,7 @@ from sentry.utils.snuba import (
     UnqualifiedQueryError,
     _bulk_snuba_query,
     _prepare_query_params,
+    _snuba_query,
     get_json_type,
     get_query_params_to_update_for_projects,
     get_snuba_column_name,
@@ -754,3 +759,41 @@ class SnubaQueryRateLimitTest(TestCase):
             _bulk_snuba_query([make_request("ok"), make_request("rate_limited")])
 
         assert mock.call("allocation_policy.is_successful", True) not in mock_set_tag.call_args_list
+
+
+class SnubaResponseCompressionTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mock_pool = mock.patch("sentry.utils.snuba._snuba_pool").start()
+        self.addCleanup(mock.patch.stopall)
+        self.mock_pool.urlopen.return_value = mock.Mock(status=200, data=b'{"data": []}')
+
+    def _run_query(self, query) -> None:
+        req = mock.Mock(dataset="events", query=query)
+        req.serialize.return_value = b"{}"
+        _snuba_query(
+            (
+                sentry_sdk.get_isolation_scope(),
+                sentry_sdk.get_current_scope(),
+                SnubaRequest(
+                    request=req, referrer="test", forward=lambda x: x, reverse=lambda x: x
+                ),
+            )
+        )
+
+    @override_options({SNUBA_JSON_RESP_COMPRESSION_ROLLOUT: 1.0})
+    def test_compresses_read_query_if_ff_on(self) -> None:
+        self._run_query(mock.Mock(spec=Query))
+        headers = self.mock_pool.urlopen.call_args.kwargs["headers"]
+        assert headers["Accept-Encoding"] == "zstd"
+
+    @override_options({SNUBA_JSON_RESP_COMPRESSION_ROLLOUT: 0.0})
+    def test_does_not_compresses_read_query_if_ff_off(self) -> None:
+        self._run_query(mock.Mock(spec=Query))
+        headers = self.mock_pool.urlopen.call_args.kwargs["headers"]
+        assert "Accept-Encoding" not in headers
+
+    @override_options({SNUBA_JSON_RESP_COMPRESSION_ROLLOUT: 1.0})
+    def test_skips_delete_query(self) -> None:
+        self._run_query(mock.Mock(spec=DeleteQuery, storage_name="events"))
+        headers = self.mock_pool.urlopen.call_args.kwargs["headers"]
+        assert "Accept-Encoding" not in headers

--- a/tests/sentry/utils/test_snuba.py
+++ b/tests/sentry/utils/test_snuba.py
@@ -5,7 +5,7 @@ from unittest import mock
 import pytest
 import sentry_sdk
 from django.utils import timezone
-from snuba_sdk import Column, Condition, Entity, Function, Op, Query, Request
+from snuba_sdk import Column, Condition, DeleteQuery, Entity, Function, Op, Query, Request
 from urllib3 import HTTPConnectionPool
 from urllib3.exceptions import HTTPError, ReadTimeoutError
 from urllib3.response import HTTPResponse
@@ -21,7 +21,6 @@ from sentry.utils import json
 from sentry.utils.snuba import (
     ROUND_UP,
     SNUBA_JSON_RESP_COMPRESSION_ROLLOUT,
-    DeleteQuery,
     RateLimitExceeded,
     RetrySkipTimeout,
     SnubaQueryParams,


### PR DESCRIPTION
## What
Setups rollout of JSON compression for JSON responses from Snuba

## How
Conditionally adds `zstd` compression headers to Snuba queries

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
