### PR TITLE
feat(issue-inbox): replace issue actions with Seer CTAs

### DIFF
--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -205,7 +205,7 @@ export interface ExplorerAutofixState {
 /**
  * Response from the autofix endpoint.
  */
-interface ExplorerAutofixResponse {
+export interface ExplorerAutofixResponse {
   autofix: ExplorerAutofixState | null;
 }
 

--- a/static/app/views/issueDetails/issuePreview/issuePreview.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreview.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import {Fragment, useState} from 'react';
 
 import {LinkButton} from '@sentry/scraps/button';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
@@ -7,6 +7,7 @@ import {Heading, Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {ErrorBoundary} from 'sentry/components/errorBoundary';
+import {useExplorerAutofix} from 'sentry/components/events/autofix/useExplorerAutofix';
 import {EventMessage} from 'sentry/components/events/eventMessage';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
@@ -30,6 +31,7 @@ import {GroupStatusSubtitle} from 'sentry/views/issueDetails/header/groupStatusS
 import {IssueIdBreadcrumb} from 'sentry/views/issueDetails/header/issueIdBreadcrumb';
 import {useAiConfig} from 'sentry/views/issueDetails/hooks/useAiConfig';
 import {IssuePreviewAutofix} from 'sentry/views/issueDetails/issuePreview/issuePreviewAutofix';
+import {IssuePreviewSeerActions} from 'sentry/views/issueDetails/issuePreview/issuePreviewSeerActions';
 import {ExternalIssueSidebarList} from 'sentry/views/issueDetails/sidebar/externalIssueSidebarList';
 import {useGroup} from 'sentry/views/issueDetails/useGroup';
 import {useGroupEvent} from 'sentry/views/issueDetails/useGroupEvent';
@@ -79,9 +81,15 @@ export function IssuePreview({groupId}: IssuePreviewProps) {
   );
 }
 
+type IssuePreviewTab = 'activity' | 'autofix';
+
 function IssuePreviewContent() {
   const {group, project} = useGroupData();
   const {hasAutofix} = useAiConfig(group, project);
+  const [selectedTab, setSelectedTab] = useState<IssuePreviewTab>('activity');
+  const autofix = useExplorerAutofix(group, {
+    enabled: hasAutofix,
+  });
   const {data: event} = useGroupEvent({
     groupId: group.id,
     eventId: 'recommended',
@@ -128,12 +136,21 @@ function IssuePreviewContent() {
         wrap="wrap"
         gap="md"
       >
-        <GroupActions
-          group={group}
-          project={project}
-          disabled={disableActions}
-          event={null}
-        />
+        {hasAutofix ? (
+          <IssuePreviewSeerActions
+            autofix={autofix}
+            group={group}
+            disabled={disableActions}
+            onOpenAutofix={() => setSelectedTab('autofix')}
+          />
+        ) : (
+          <GroupActions
+            group={group}
+            project={project}
+            disabled={disableActions}
+            event={null}
+          />
+        )}
         <Flex align="center" wrap="wrap" gap="lg">
           <Flex align="center" gap="xs">
             <Text size="sm" variant="muted">
@@ -150,7 +167,7 @@ function IssuePreviewContent() {
         </Flex>
       </Flex>
       <Container paddingTop="md">
-        <Tabs>
+        <Tabs value={selectedTab} onChange={setSelectedTab}>
           <Container paddingBottom="md" borderBottom="muted">
             <TabList variant="floating">
               <TabList.Item key="activity">{t('Activity')}</TabList.Item>
@@ -193,7 +210,11 @@ function IssuePreviewContent() {
             {hasAutofix ? (
               <TabPanels.Item key="autofix">
                 <Container paddingTop="md">
-                  <IssuePreviewAutofix group={group} project={project} />
+                  <IssuePreviewAutofix
+                    autofix={autofix}
+                    group={group}
+                    project={project}
+                  />
                 </Container>
               </TabPanels.Item>
             ) : null}

--- a/static/app/views/issueDetails/issuePreview/issuePreviewAutofix.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewAutofix.tsx
@@ -22,13 +22,13 @@ import type {Project} from 'sentry/types/project';
 import {useAiConfig} from 'sentry/views/issueDetails/hooks/useAiConfig';
 
 interface IssuePreviewAutofixProps {
+  autofix: ReturnType<typeof useExplorerAutofix>;
   group: Group;
   project: Project;
 }
 
-export function IssuePreviewAutofix({group, project}: IssuePreviewAutofixProps) {
+export function IssuePreviewAutofix({autofix, group, project}: IssuePreviewAutofixProps) {
   const aiConfig = useAiConfig(group, project);
-  const autofix = useExplorerAutofix(group);
 
   const handleCopyMarkdown = useHandleCopyMarkdown({aiAutofix: autofix});
   const handleRestart = useHandleRestart({aiAutofix: autofix});

--- a/static/app/views/issueDetails/issuePreview/issuePreviewSeerActions.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewSeerActions.tsx
@@ -273,7 +273,7 @@ function IssuePreviewSeerButton({
     }
   };
 
-  if (action.href && !busy) {
+  if (action.href) {
     return (
       <LinkButton
         external

--- a/static/app/views/issueDetails/issuePreview/issuePreviewSeerActions.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewSeerActions.tsx
@@ -1,0 +1,311 @@
+import {useState} from 'react';
+
+import {Button, LinkButton} from '@sentry/scraps/button';
+
+import {
+  getCodingAgentName,
+  getResultButtonLabel,
+} from 'sentry/components/events/autofix/types';
+import {
+  getOrderedAutofixSections,
+  type ExplorerAutofixState,
+  type useExplorerAutofix,
+} from 'sentry/components/events/autofix/useExplorerAutofix';
+import {Placeholder} from 'sentry/components/placeholder';
+import {IconOpen, IconRefresh, IconSeer} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import type {Group} from 'sentry/types/group';
+
+type ExplorerAutofix = ReturnType<typeof useExplorerAutofix>;
+
+type SeerActionKind =
+  | 'code_changes'
+  | 'create_pr'
+  | 'link'
+  | 'root_cause'
+  | 'solution'
+  | 'view_autofix';
+
+interface SeerAction {
+  analyticsEventKey: string;
+  analyticsEventName: string;
+  kind: SeerActionKind;
+  label: string;
+  href?: string;
+  repoName?: string;
+  tooltip?: string | null;
+}
+
+interface IssuePreviewSeerActionsProps {
+  autofix: ExplorerAutofix;
+  group: Group;
+  onOpenAutofix: () => void;
+  disabled?: boolean;
+}
+
+const AUTOFIX_ANALYTICS = {
+  code_changes: {
+    analyticsEventKey: 'autofix.solution.code',
+    analyticsEventName: 'Autofix: Code It Up',
+  },
+  create_pr: {
+    analyticsEventKey: 'autofix.create_pr_clicked',
+    analyticsEventName: 'Autofix: Create PR Setup Clicked',
+  },
+  root_cause: {
+    analyticsEventKey: 'autofix.start_fix_clicked',
+    analyticsEventName: 'Autofix: Start Fix Clicked',
+  },
+  solution: {
+    analyticsEventKey: 'autofix.root_cause.find_solution',
+    analyticsEventName: 'Autofix: Root Cause Find Solution',
+  },
+  view: {
+    analyticsEventKey: 'issue_inbox.seer_cta_clicked',
+    analyticsEventName: 'Issue Inbox: Seer CTA Clicked',
+  },
+} as const;
+
+export function getAutofixPrimaryAction(
+  runState: ExplorerAutofixState | null
+): SeerAction | null {
+  const sections = getOrderedAutofixSections(runState);
+  const lastCompletedSection = sections.findLast(
+    section => section.status === 'completed'
+  );
+
+  if (!runState || !lastCompletedSection) {
+    return {
+      ...AUTOFIX_ANALYTICS.root_cause,
+      kind: 'root_cause',
+      label: t('Find Root Cause'),
+    };
+  }
+
+  const pullRequests = Object.values(runState.repo_pr_states ?? {});
+  const completedPullRequest = pullRequests.find(
+    pullRequest =>
+      pullRequest.pr_creation_status === 'completed' &&
+      pullRequest.pr_url &&
+      pullRequest.pr_number &&
+      pullRequest.repo_name
+  );
+  const failedPullRequest = pullRequests.find(
+    pullRequest => pullRequest.pr_creation_status === 'error'
+  );
+
+  // A pull request was created and completed
+  // Show the view pull request button
+  if (completedPullRequest?.pr_url && completedPullRequest.pr_number) {
+    return {
+      ...AUTOFIX_ANALYTICS.view,
+      kind: 'link',
+      label: t(
+        'View %s#%s',
+        completedPullRequest.repo_name,
+        completedPullRequest.pr_number
+      ),
+      href: completedPullRequest.pr_url,
+    };
+  }
+
+  // A pull request was created but failed
+  // Show the retry button
+  if (failedPullRequest) {
+    return {
+      ...AUTOFIX_ANALYTICS.create_pr,
+      kind: 'create_pr',
+      label: t('Retry PR in %s', failedPullRequest.repo_name),
+      repoName: failedPullRequest.repo_name,
+      tooltip: failedPullRequest.pr_creation_error,
+    };
+  }
+
+  // The run is paused waiting on the user
+  // For now open the autofix tab, but in the future open an explorer side panel
+  if (runState.status === 'awaiting_user_input') {
+    return {
+      ...AUTOFIX_ANALYTICS.view,
+      kind: 'view_autofix',
+      label:
+        runState.pending_user_input?.input_type === 'file_change_approval'
+          ? t('Review Changes')
+          : t('Continue in Seer'),
+    };
+  }
+
+  switch (lastCompletedSection.step) {
+    case 'pull_request': {
+      const pullRequest = pullRequests[0];
+      if (!pullRequest) {
+        return null;
+      }
+
+      return {
+        ...AUTOFIX_ANALYTICS.create_pr,
+        kind: 'create_pr',
+        label: t('Retry PR in %s', pullRequest.repo_name),
+        repoName: pullRequest.repo_name,
+        tooltip: pullRequest.pr_creation_error,
+      };
+    }
+
+    case 'coding_agents': {
+      const codingAgents = Object.values(runState.coding_agents ?? {});
+      const result = codingAgents
+        .flatMap(codingAgent => codingAgent.results ?? [])
+        .find(item => item.pr_url);
+
+      if (result?.pr_url) {
+        return {
+          ...AUTOFIX_ANALYTICS.view,
+          kind: 'link',
+          label: getResultButtonLabel(result.pr_url),
+          href: result.pr_url,
+        };
+      }
+
+      const codingAgent = codingAgents.find(agent => agent.agent_url);
+      if (codingAgent?.agent_url) {
+        return {
+          ...AUTOFIX_ANALYTICS.view,
+          kind: 'link',
+          label: t('Open in %s', getCodingAgentName(codingAgent.provider)),
+          href: codingAgent.agent_url,
+        };
+      }
+
+      return null;
+    }
+
+    case 'code_changes':
+      return {
+        ...AUTOFIX_ANALYTICS.create_pr,
+        kind: 'create_pr',
+        label: t('Draft a PR'),
+      };
+
+    case 'solution':
+      return {
+        ...AUTOFIX_ANALYTICS.code_changes,
+        kind: 'code_changes',
+        label: t('Write a Code Fix'),
+      };
+
+    case 'root_cause':
+      return {
+        ...AUTOFIX_ANALYTICS.solution,
+        kind: 'solution',
+        label: t('Make a Plan'),
+      };
+
+    default:
+      return {
+        ...AUTOFIX_ANALYTICS.root_cause,
+        kind: 'root_cause',
+        label: t('Find Root Cause'),
+      };
+  }
+}
+
+export function IssuePreviewSeerActions({
+  autofix,
+  disabled,
+  group,
+  onOpenAutofix,
+}: IssuePreviewSeerActionsProps) {
+  if (autofix.isLoading) {
+    return <Placeholder width="120px" height="32px" />;
+  }
+
+  return (
+    <IssuePreviewSeerButton
+      autofix={autofix}
+      disabled={disabled}
+      group={group}
+      onOpenAutofix={onOpenAutofix}
+    />
+  );
+}
+
+function IssuePreviewSeerButton({
+  autofix,
+  disabled,
+  group,
+  onOpenAutofix,
+}: IssuePreviewSeerActionsProps) {
+  const [isStartingAction, setIsStartingAction] = useState(false);
+  const action = getAutofixPrimaryAction(autofix.runState);
+  const runId = autofix.runState?.run_id;
+  const busy = autofix.isPolling || isStartingAction;
+
+  if (!action) {
+    return null;
+  }
+
+  const analyticsParams = {
+    group_id: group.id,
+    referrer: 'issue_inbox',
+  };
+
+  const handleClick = async () => {
+    onOpenAutofix();
+
+    if (action.kind === 'view_autofix') {
+      return;
+    }
+
+    setIsStartingAction(true);
+    try {
+      if (action.kind === 'root_cause') {
+        await autofix.startStep('root_cause');
+      } else if (action.kind === 'solution' && runId !== undefined) {
+        await autofix.startStep('solution', {runId});
+      } else if (action.kind === 'code_changes' && runId !== undefined) {
+        await autofix.startStep('code_changes', {runId});
+      } else if (action.kind === 'create_pr' && runId !== undefined) {
+        await autofix.createPR(runId, action.repoName);
+      }
+    } catch {
+      // Errors are handled in the caller and shown in the autofix panel
+    } finally {
+      setIsStartingAction(false);
+    }
+  };
+
+  if (action.href && !busy) {
+    return (
+      <LinkButton
+        external
+        variant="primary"
+        size="sm"
+        icon={<IconOpen />}
+        href={action.href}
+        disabled={disabled}
+        tooltipProps={action.tooltip ? {title: action.tooltip} : undefined}
+        analyticsEventKey={action.analyticsEventKey}
+        analyticsEventName={action.analyticsEventName}
+        analyticsParams={analyticsParams}
+      >
+        {action.label}
+      </LinkButton>
+    );
+  }
+
+  return (
+    <Button
+      variant="primary"
+      size="sm"
+      icon={action.repoName ? <IconRefresh /> : <IconSeer />}
+      busy={busy}
+      disabled={disabled || busy}
+      onClick={handleClick}
+      tooltipProps={action.tooltip ? {title: action.tooltip} : undefined}
+      analyticsEventKey={action.analyticsEventKey}
+      analyticsEventName={action.analyticsEventName}
+      analyticsParams={analyticsParams}
+    >
+      {action.label}
+    </Button>
+  );
+}

--- a/static/app/views/issueDetails/issuePreview/issuePreviewSeerActions.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewSeerActions.tsx
@@ -82,6 +82,19 @@ function getAutofixPrimaryAction(
     };
   }
 
+  // The run is paused waiting on the user
+  // For now open the autofix tab, but in the future open an explorer side panel
+  if (runState.status === 'awaiting_user_input') {
+    return {
+      ...AUTOFIX_ANALYTICS.view,
+      kind: 'view_autofix',
+      label:
+        runState.pending_user_input?.input_type === 'file_change_approval'
+          ? t('Review Changes')
+          : t('Continue in Seer'),
+    };
+  }
+
   const pullRequests = Object.values(runState.repo_pr_states ?? {});
   const completedPullRequest = pullRequests.find(
     pullRequest =>
@@ -118,19 +131,6 @@ function getAutofixPrimaryAction(
       label: t('Retry PR in %s', failedPullRequest.repo_name),
       repoName: failedPullRequest.repo_name,
       tooltip: failedPullRequest.pr_creation_error,
-    };
-  }
-
-  // The run is paused waiting on the user
-  // For now open the autofix tab, but in the future open an explorer side panel
-  if (runState.status === 'awaiting_user_input') {
-    return {
-      ...AUTOFIX_ANALYTICS.view,
-      kind: 'view_autofix',
-      label:
-        runState.pending_user_input?.input_type === 'file_change_approval'
-          ? t('Review Changes')
-          : t('Continue in Seer'),
     };
   }
 

--- a/static/app/views/issueDetails/issuePreview/issuePreviewSeerActions.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewSeerActions.tsx
@@ -66,7 +66,7 @@ const AUTOFIX_ANALYTICS = {
   },
 } as const;
 
-export function getAutofixPrimaryAction(
+function getAutofixPrimaryAction(
   runState: ExplorerAutofixState | null
 ): SeerAction | null {
   const sections = getOrderedAutofixSections(runState);

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -1,3 +1,8 @@
+import {
+  AutofixRepoPRStateFixture,
+  ExplorerAutofixResponseFixture,
+  ExplorerAutofixStateFixture,
+} from 'sentry-fixture/autofix';
 import {EventFixture} from 'sentry-fixture/event';
 import {GroupFixture} from 'sentry-fixture/group';
 import {MemberFixture} from 'sentry-fixture/member';
@@ -22,6 +27,9 @@ import InboxPage from './inbox';
 describe('InboxPage', () => {
   const organization = OrganizationFixture({
     features: ['issue-stream-progress-ui'],
+  });
+  const seerOrganization = OrganizationFixture({
+    features: ['issue-stream-progress-ui', 'gen-ai-features'],
   });
   const project = ProjectFixture({
     id: '1',
@@ -77,7 +85,11 @@ describe('InboxPage', () => {
     shortId: 'PROJECT-102',
     project,
     hasSeen: true,
-    metadata: {type: 'Error', title: 'Diagnosed issue', value: 'Diagnosed message'},
+    metadata: {
+      type: 'Error',
+      title: 'Diagnosed issue',
+      value: 'Diagnosed message',
+    },
     derivedData: {
       progress: ProgressState.DIAGNOSED,
       status: 'open',
@@ -93,7 +105,11 @@ describe('InboxPage', () => {
     shortId: 'PROJECT-103',
     project,
     hasSeen: true,
-    metadata: {type: 'Error', title: 'Assigned issue', value: 'Assigned message'},
+    metadata: {
+      type: 'Error',
+      title: 'Assigned issue',
+      value: 'Assigned message',
+    },
     derivedData: {
       progress: ProgressState.ASSIGNED,
       status: 'open',
@@ -195,6 +211,26 @@ describe('InboxPage', () => {
     });
   }
 
+  function mockAutofixResponse(body: ReturnType<typeof ExplorerAutofixResponseFixture>) {
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${fixProposedGroup.id}/autofix/`,
+      body,
+    });
+  }
+
+  async function openFixProposedPreview() {
+    const preview = screen.getByRole('complementary', {
+      name: 'Issue preview',
+    });
+    const issueLink = await within(
+      screen.getByRole('region', {name: 'Fix Proposed'})
+    ).findByRole('link', {name: /Fix proposed issue/});
+
+    await userEvent.click(issueLink);
+
+    return preview;
+  }
+
   it('loads and renders the three progress sections with filtered issue metadata', async () => {
     const requests = mockSuccessfulSections();
 
@@ -240,10 +276,16 @@ describe('InboxPage', () => {
     const diagnosedSection = screen.getByRole('region', {name: 'Diagnosed'});
     const assignedSection = screen.getByRole('region', {name: 'Assigned'});
     expect(
-      within(fixSection).getByRole('heading', {name: 'Fix Proposed', level: 3})
+      within(fixSection).getByRole('heading', {
+        name: 'Fix Proposed',
+        level: 3,
+      })
     ).toBeInTheDocument();
     expect(
-      within(fixSection).getByRole('heading', {name: 'Fix proposed issue', level: 4})
+      within(fixSection).getByRole('heading', {
+        name: 'Fix proposed issue',
+        level: 4,
+      })
     ).toBeInTheDocument();
     expect(within(fixSection).getByText('2')).toBeInTheDocument();
     expect(within(diagnosedSection).getByText('2')).toBeInTheDocument();
@@ -265,7 +307,9 @@ describe('InboxPage', () => {
 
     render(<InboxPage />, {organization, initialRouterConfig});
 
-    const fixProposedButton = screen.getByRole('button', {name: 'Fix Proposed'});
+    const fixProposedButton = screen.getByRole('button', {
+      name: 'Fix Proposed',
+    });
     const assignedButton = screen.getByRole('button', {name: 'Assigned'});
     const fixProposedIssue = await screen.findByText('Fix proposed issue');
     const assignedIssue = screen.getByText('Assigned issue');
@@ -292,7 +336,10 @@ describe('InboxPage', () => {
       mockSection('issue.progress:assigned assigned:my_teams', [assignedGroup]),
     ];
 
-    const {router} = render(<InboxPage />, {organization, initialRouterConfig});
+    const {router} = render(<InboxPage />, {
+      organization,
+      initialRouterConfig,
+    });
 
     const meFilter = screen.getByRole('radio', {name: 'Me'});
     const myTeamsFilter = screen.getByRole('radio', {name: 'My Teams'});
@@ -323,7 +370,9 @@ describe('InboxPage', () => {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/issues/',
       match: [
-        MockApiClient.matchQuery({query: 'issue.progress:fix_proposed assigned:me'}),
+        MockApiClient.matchQuery({
+          query: 'issue.progress:fix_proposed assigned:me',
+        }),
       ],
       body: [fixProposedGroup],
       headers: {
@@ -370,8 +419,13 @@ describe('InboxPage', () => {
     mockSuccessfulSections();
     mockIssuePreview();
 
-    const {router} = render(<InboxPage />, {organization, initialRouterConfig});
-    const preview = screen.getByRole('complementary', {name: 'Issue preview'});
+    const {router} = render(<InboxPage />, {
+      organization,
+      initialRouterConfig,
+    });
+    const preview = screen.getByRole('complementary', {
+      name: 'Issue preview',
+    });
     expect(
       within(preview).queryByRole('button', {name: 'Open Issue'})
     ).not.toBeInTheDocument();
@@ -385,7 +439,9 @@ describe('InboxPage', () => {
     expect(router.location.query.preview).toBe(fixProposedGroup.id);
     expect(issueLink).toHaveAttribute('aria-current', 'true');
     expect(
-      await within(preview).findByRole('heading', {name: 'Fix proposed issue'})
+      await within(preview).findByRole('heading', {
+        name: 'Fix proposed issue',
+      })
     ).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole('button', {name: '7D', expanded: false}));
@@ -402,6 +458,223 @@ describe('InboxPage', () => {
     await userEvent.click(updatedIssueLink);
     await userEvent.click(await screen.findByRole('button', {name: 'Back to inbox'}));
     expect(router.location.query.preview).toBeUndefined();
+  });
+
+  it('starts finding the root cause in Autofix when there is no Autofix state', async () => {
+    mockSuccessfulSections();
+    mockIssuePreview();
+    mockAutofixResponse(ExplorerAutofixResponseFixture({autofix: null}));
+    const startAutofixRequest = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${fixProposedGroup.id}/autofix/`,
+      method: 'POST',
+      body: {run_id: 42},
+      asyncDelay: 100,
+    });
+
+    render(<InboxPage />, {
+      organization: seerOrganization,
+      initialRouterConfig,
+    });
+
+    const preview = await openFixProposedPreview();
+
+    const seerButton = await within(preview).findByRole('button', {
+      name: 'Find Root Cause',
+    });
+    expect(
+      within(preview).queryByRole('button', {name: 'Resolve'})
+    ).not.toBeInTheDocument();
+    expect(
+      within(preview).queryByRole('button', {name: 'Archive'})
+    ).not.toBeInTheDocument();
+    expect(
+      within(preview).queryByRole('button', {name: 'Share'})
+    ).not.toBeInTheDocument();
+    expect(
+      within(preview).queryByRole('button', {name: 'Subscribe'})
+    ).not.toBeInTheDocument();
+    expect(
+      within(preview).queryByRole('button', {name: 'More Actions'})
+    ).not.toBeInTheDocument();
+    expect(within(preview).getByText('Priority')).toBeInTheDocument();
+    expect(within(preview).getByText('Assignee')).toBeInTheDocument();
+
+    await userEvent.click(seerButton);
+
+    expect(within(preview).getByRole('tab', {name: 'Autofix'})).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+    expect(within(preview).getByRole('button', {name: 'Find Root Cause'})).toBeDisabled();
+    await waitFor(() =>
+      expect(startAutofixRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          data: {step: 'root_cause', referrer: 'api.web'},
+          method: 'POST',
+          query: {mode: 'explorer'},
+        })
+      )
+    );
+  });
+
+  it('starts making a plan in Autofix when the root cause is complete', async () => {
+    mockSuccessfulSections();
+    mockIssuePreview();
+    mockAutofixResponse(ExplorerAutofixResponseFixture());
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/coding-agents/',
+      body: {integrations: []},
+    });
+    MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/seer/repos/',
+      body: [],
+    });
+    const startAutofixRequest = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${fixProposedGroup.id}/autofix/`,
+      method: 'POST',
+      body: {run_id: 42},
+      asyncDelay: 100,
+    });
+
+    render(<InboxPage />, {
+      organization: seerOrganization,
+      initialRouterConfig,
+    });
+
+    const preview = await openFixProposedPreview();
+    const seerButton = await within(preview).findByRole('button', {
+      name: 'Make a Plan',
+    });
+
+    await userEvent.click(seerButton);
+
+    expect(within(preview).getByRole('tab', {name: 'Autofix'})).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+    expect(within(preview).getByRole('button', {name: 'Make a Plan'})).toBeDisabled();
+    await waitFor(() =>
+      expect(startAutofixRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          data: {step: 'solution', referrer: 'api.web', run_id: 42},
+          method: 'POST',
+          query: {mode: 'explorer'},
+        })
+      )
+    );
+  });
+
+  it('links to a completed Autofix pull request', async () => {
+    mockSuccessfulSections();
+    mockIssuePreview();
+    mockAutofixResponse(
+      ExplorerAutofixResponseFixture({
+        autofix: ExplorerAutofixStateFixture({
+          repo_pr_states: {
+            'org/repository': AutofixRepoPRStateFixture(),
+          },
+        }),
+      })
+    );
+
+    render(<InboxPage />, {
+      organization: seerOrganization,
+      initialRouterConfig,
+    });
+
+    const preview = await openFixProposedPreview();
+    expect(
+      await within(preview).findByRole('button', {
+        name: 'View org/repository#10',
+      })
+    ).toHaveAttribute('href', 'https://github.com/org/repository/pull/10');
+  });
+
+  it('retries a failed Autofix pull request', async () => {
+    mockSuccessfulSections();
+    mockIssuePreview();
+    mockAutofixResponse(
+      ExplorerAutofixResponseFixture({
+        autofix: ExplorerAutofixStateFixture({
+          repo_pr_states: {
+            'org/repository': AutofixRepoPRStateFixture({
+              pr_creation_error: 'Unable to create PR',
+              pr_creation_status: 'error',
+              pr_id: null,
+              pr_number: null,
+              pr_url: null,
+            }),
+          },
+        }),
+      })
+    );
+    const retryPullRequest = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${fixProposedGroup.id}/autofix/`,
+      method: 'POST',
+      body: {},
+      asyncDelay: 100,
+    });
+
+    render(<InboxPage />, {
+      organization: seerOrganization,
+      initialRouterConfig,
+    });
+
+    const preview = await openFixProposedPreview();
+    const retryButton = await within(preview).findByRole('button', {
+      name: 'Retry PR in org/repository',
+    });
+
+    await userEvent.hover(retryButton);
+    expect(await screen.findByText('Unable to create PR')).toBeInTheDocument();
+
+    await userEvent.click(retryButton);
+
+    expect(within(preview).getByRole('tab', {name: 'Autofix'})).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+    expect(retryButton).toBeDisabled();
+    await waitFor(() =>
+      expect(retryPullRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          data: {
+            step: 'open_pr',
+            run_id: 42,
+            repo_name: 'org/repository',
+            referrer: 'api.web',
+          },
+          method: 'POST',
+          query: {mode: 'explorer'},
+        })
+      )
+    );
+  });
+
+  it('retains issue actions when Seer Autofix is unavailable', async () => {
+    mockSuccessfulSections();
+    mockIssuePreview();
+
+    render(<InboxPage />, {organization, initialRouterConfig});
+
+    const preview = screen.getByRole('complementary', {
+      name: 'Issue preview',
+    });
+    const issueLink = await within(
+      screen.getByRole('region', {name: 'Fix Proposed'})
+    ).findByRole('link', {name: /Fix proposed issue/});
+    await userEvent.click(issueLink);
+
+    expect(
+      await within(preview).findByRole('button', {name: 'Resolve'})
+    ).toBeInTheDocument();
+    expect(within(preview).getByRole('button', {name: 'Archive'})).toBeInTheDocument();
+    expect(
+      within(preview).queryByRole('button', {name: 'Find Root Cause'})
+    ).not.toBeInTheDocument();
   });
 
   it('does not render without the progress UI feature', () => {

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -481,24 +481,6 @@ describe('InboxPage', () => {
     const seerButton = await within(preview).findByRole('button', {
       name: 'Find Root Cause',
     });
-    expect(
-      within(preview).queryByRole('button', {name: 'Resolve'})
-    ).not.toBeInTheDocument();
-    expect(
-      within(preview).queryByRole('button', {name: 'Archive'})
-    ).not.toBeInTheDocument();
-    expect(
-      within(preview).queryByRole('button', {name: 'Share'})
-    ).not.toBeInTheDocument();
-    expect(
-      within(preview).queryByRole('button', {name: 'Subscribe'})
-    ).not.toBeInTheDocument();
-    expect(
-      within(preview).queryByRole('button', {name: 'More Actions'})
-    ).not.toBeInTheDocument();
-    expect(within(preview).getByText('Priority')).toBeInTheDocument();
-    expect(within(preview).getByText('Assignee')).toBeInTheDocument();
-
     await userEvent.click(seerButton);
 
     expect(within(preview).getByRole('tab', {name: 'Autofix'})).toHaveAttribute(

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -548,12 +548,13 @@ describe('InboxPage', () => {
     );
   });
 
-  it('links to a completed Autofix pull request', async () => {
+  it('links to a completed Autofix pull request while polling', async () => {
     mockSuccessfulSections();
     mockIssuePreview();
     mockAutofixResponse(
       ExplorerAutofixResponseFixture({
         autofix: ExplorerAutofixStateFixture({
+          queued_feedback: [{text: 'Please revise the fix'}],
           repo_pr_states: {
             'org/repository': AutofixRepoPRStateFixture(),
           },

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -529,13 +529,22 @@ describe('InboxPage', () => {
       name: 'Make a Plan',
     });
 
+    // After starting the step, the refetch will see a processing state
+    mockAutofixResponse(
+      ExplorerAutofixResponseFixture({
+        autofix: ExplorerAutofixStateFixture({status: 'processing'}),
+      })
+    );
+
     await userEvent.click(seerButton);
 
     expect(within(preview).getByRole('tab', {name: 'Autofix'})).toHaveAttribute(
       'aria-selected',
       'true'
     );
-    expect(within(preview).getByRole('button', {name: 'Make a Plan'})).toBeDisabled();
+    await waitFor(() =>
+      expect(within(preview).getByRole('button', {name: 'Make a Plan'})).toBeDisabled()
+    );
     await waitFor(() =>
       expect(startAutofixRequest).toHaveBeenCalledWith(
         expect.anything(),
@@ -613,13 +622,31 @@ describe('InboxPage', () => {
     await userEvent.hover(retryButton);
     expect(await screen.findByText('Unable to create PR')).toBeInTheDocument();
 
+    // After retrying, the refetch will see a processing state.
+    mockAutofixResponse(
+      ExplorerAutofixResponseFixture({
+        autofix: ExplorerAutofixStateFixture({
+          status: 'processing',
+          repo_pr_states: {
+            'org/repository': AutofixRepoPRStateFixture({
+              pr_creation_error: 'Unable to create PR',
+              pr_creation_status: 'error',
+              pr_id: null,
+              pr_number: null,
+              pr_url: null,
+            }),
+          },
+        }),
+      })
+    );
+
     await userEvent.click(retryButton);
 
     expect(within(preview).getByRole('tab', {name: 'Autofix'})).toHaveAttribute(
       'aria-selected',
       'true'
     );
-    expect(retryButton).toBeDisabled();
+    await waitFor(() => expect(retryButton).toBeDisabled());
     await waitFor(() =>
       expect(retryPullRequest).toHaveBeenCalledWith(
         expect.anything(),

--- a/tests/js/fixtures/autofix.ts
+++ b/tests/js/fixtures/autofix.ts
@@ -1,0 +1,64 @@
+import type {
+  ExplorerAutofixResponse,
+  ExplorerAutofixState,
+} from 'sentry/components/events/autofix/useExplorerAutofix';
+import type {RepoPRState} from 'sentry/views/seerExplorer/types';
+
+export function ExplorerAutofixStateFixture(
+  params: Partial<ExplorerAutofixState> = {}
+): ExplorerAutofixState {
+  return {
+    blocks: [
+      {
+        id: 'root-cause',
+        artifacts: [
+          {
+            data: {
+              five_whys: ['The faulty code did not handle an unexpected value.'],
+              one_line_description: 'The issue was caused by an unexpected value.',
+            },
+            key: 'root_cause',
+            reason: 'Found the root cause',
+          },
+        ],
+        loading: false,
+        message: {
+          content: 'Root cause complete',
+          metadata: {step: 'root_cause'},
+          role: 'assistant',
+        },
+        timestamp: '2024-01-01T00:00:00Z',
+      },
+    ],
+    run_id: 42,
+    status: 'completed',
+    updated_at: '2024-01-01T00:00:00Z',
+    ...params,
+  };
+}
+
+export function ExplorerAutofixResponseFixture(
+  params: Partial<ExplorerAutofixResponse> = {}
+): ExplorerAutofixResponse {
+  return {
+    autofix: ExplorerAutofixStateFixture(),
+    ...params,
+  };
+}
+
+export function AutofixRepoPRStateFixture(
+  params: Partial<RepoPRState> = {}
+): RepoPRState {
+  return {
+    branch_name: 'seer/fix',
+    commit_sha: 'abc123',
+    pr_creation_error: null,
+    pr_creation_status: 'completed',
+    pr_id: 1,
+    pr_number: 10,
+    pr_url: 'https://github.com/org/repository/pull/10',
+    repo_name: 'org/repository',
+    title: 'Fix issue',
+    ...params,
+  };
+}


### PR DESCRIPTION
Ref ISWF-3075

This is the initial work to place Seer CTAs where the workflow actions (resolve/archive) normally reside.

In this PR I'm mostly mirroring the primary actions which are displayed in the autofix drawer (things like "find root cause", "view PR", "create plan"). It kicks off the action and navigates to the autofix tab. Soon, the autofix tab will be gone and there will be a condensed summary instead, so this will integrate more closely with the autofix UI once that is completed.

<img width="385" height="190" alt="CleanShot 2026-07-23 at 11 29 10" src="https://github.com/user-attachments/assets/3000c660-8700-4508-9f6b-765a21cad1b4" />
<img width="338" height="201" alt="CleanShot 2026-07-23 at 11 29 02" src="https://github.com/user-attachments/assets/ea2ddcaf-7921-498b-aecd-c0af9ec29128" />
