### PR TITLE
feat(action log): Update group index helper to read from GALE

### DIFF
--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -799,7 +799,6 @@ def prepare_response(
                             "group_index.groupactionlogentry.not_found",
                             extra={"group_id": group.id},
                         )
-                        return
 
                 else:
                     result["activity"] = serialize(

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -799,12 +799,8 @@ def prepare_response(
                             "group_index.groupactionlogentry.not_found",
                             extra={"group_id": group.id},
                         )
-                        result["activity"] = serialize(
-                            Activity.objects.get_activities_for_group(
-                                group=group, num=ACTIVITIES_COUNT
-                            ),
-                            acting_user,
-                        )
+                        return
+
                 else:
                     result["activity"] = serialize(
                         Activity.objects.get_activities_for_group(

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -787,7 +787,7 @@ def prepare_response(
                     "projects:issue-action-log-activity", group.project, actor=acting_user
                 ):
                     action_log = GroupActionLogEntry.objects.get_actions_for_group(
-                        group, ACTIVITIES_COUNT
+                        group, ACTIVITIES_COUNT - 1
                     )
                     if action_log:
                         result["activity"] = [

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -22,6 +22,7 @@ from sentry import analytics, features, options
 from sentry.analytics.events.manual_issue_assignment import ManualIssueAssignment
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.actor import ActorSerializer, ActorSerializerResponse
+from sentry.api.serializers.models.groupactionlogentry import serialize_first_seen_entry
 from sentry.hybridcloud.rpc import coerce_id_from
 from sentry.integrations.tasks.kick_off_status_syncs import kick_off_status_syncs
 from sentry.issues.action_log import (
@@ -35,6 +36,7 @@ from sentry.issues.action_log.types import MergeIntoOtherAction
 from sentry.issues.grouptype import GroupCategory
 from sentry.issues.ignored import handle_archived_until_escalating, handle_ignored
 from sentry.issues.merge import MergedGroup, handle_merge
+from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
 from sentry.issues.priority import update_priority
 from sentry.issues.status_change import handle_status_update, infer_substatus
 from sentry.issues.update_inbox import update_inbox
@@ -780,12 +782,36 @@ def prepare_response(
     try:
         if len(group_list) == 1:
             if res_type in (GroupResolution.Type.in_next_release, GroupResolution.Type.in_release):
-                result["activity"] = serialize(
-                    Activity.objects.get_activities_for_group(
-                        group=group_list[0], num=ACTIVITIES_COUNT
-                    ),
-                    acting_user,
-                )
+                group = group_list[0]
+                if features.has(
+                    "projects:issue-action-log-activity", group.project, actor=acting_user
+                ):
+                    action_log = GroupActionLogEntry.objects.get_actions_for_group(
+                        group, ACTIVITIES_COUNT
+                    )
+                    if action_log:
+                        result["activity"] = [
+                            *serialize(action_log, acting_user),
+                            serialize_first_seen_entry(group),
+                        ]
+                    else:
+                        logger.info(
+                            "group_index.groupactionlogentry.not_found",
+                            extra={"group_id": group.id},
+                        )
+                        result["activity"] = serialize(
+                            Activity.objects.get_activities_for_group(
+                                group=group, num=ACTIVITIES_COUNT
+                            ),
+                            acting_user,
+                        )
+                else:
+                    result["activity"] = serialize(
+                        Activity.objects.get_activities_for_group(
+                            group=group, num=ACTIVITIES_COUNT
+                        ),
+                        acting_user,
+                    )
     except UnboundLocalError:
         pass
 

--- a/src/sentry/api/serializers/models/groupactionlogentry.py
+++ b/src/sentry/api/serializers/models/groupactionlogentry.py
@@ -206,6 +206,12 @@ class GroupActionLogEntrySerializer(Serializer):
                 data = dict(raw_data)
             data.pop("mentions", None)
 
+        if (
+            obj.type == GroupActionType.SET_RESOLVED_IN_RELEASE.value
+            and data.get("current_release_version") is None
+        ):
+            data.pop("current_release_version", None)
+
         return {
             "id": str(obj.id),
             "type": type_display,

--- a/src/sentry/issues/action_log/types.py
+++ b/src/sentry/issues/action_log/types.py
@@ -585,6 +585,7 @@ class CreateIssueAction(GroupAction):
 class SetResolvedInReleaseAction(GroupAction):
     user_visible = True
     version: Optional[str] = None
+    current_release_version: Optional[str] = None
 
     @classmethod
     def get_type(cls) -> GroupActionType:

--- a/src/sentry/issues/action_log/types.py
+++ b/src/sentry/issues/action_log/types.py
@@ -585,7 +585,7 @@ class CreateIssueAction(GroupAction):
 class SetResolvedInReleaseAction(GroupAction):
     user_visible = True
     version: Optional[str] = None
-    current_release_version: Optional[str] = None
+    current_release_version: str
 
     @classmethod
     def get_type(cls) -> GroupActionType:

--- a/src/sentry/issues/action_log/types.py
+++ b/src/sentry/issues/action_log/types.py
@@ -585,7 +585,7 @@ class CreateIssueAction(GroupAction):
 class SetResolvedInReleaseAction(GroupAction):
     user_visible = True
     version: Optional[str] = None
-    current_release_version: str
+    current_release_version: Optional[str] = None
 
     @classmethod
     def get_type(cls) -> GroupActionType:

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -731,7 +731,7 @@ class UpdateGroupsTest(TestCase):
         assert [entry["type"] for entry in activity] == ["set_resolved", "first_seen"]
         assert activity[-1]["id"] == "0"
 
-    def test_resolve_in_next_release_activity_falls_back_without_action_log(self) -> None:
+    def test_resolve_in_next_release_no_activity_without_action_log(self) -> None:
         self.create_release(project=self.project, version="test@1.0.0.0")
         group = self.create_group(status=GroupStatus.UNRESOLVED)
 
@@ -749,8 +749,8 @@ class UpdateGroupsTest(TestCase):
         assert any(
             record.message == "group_index.groupactionlogentry.not_found" for record in logs.records
         )
-        activity = response.data["activity"]
-        assert activity[-1]["type"] == "first_seen"
+        assert response is not None
+        assert "activity" not in response.data
         assert GroupActionLogEntry.objects.filter(group_id=group.id).count() == 0
 
 

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -30,7 +30,9 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import GroupSerializer
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.issues.action_log import ActionSource, GroupActionActor, action_context_scope
+from sentry.issues.action_log.types import GroupActionType, GroupActorType
 from sentry.issues.issue_search import parse_search_query
+from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
 from sentry.models.activity import Activity
 from sentry.models.group import Group, GroupStatus
 from sentry.models.groupassignee import GroupAssignee
@@ -703,6 +705,53 @@ class UpdateGroupsTest(TestCase):
         assert group.status == GroupStatus.RESOLVED
         resolution = group.groupresolution_set.get()
         assert resolution.release == open_release
+
+    def test_resolve_in_next_release_activity_from_action_log(self) -> None:
+        self.create_release(project=self.project, version="test@1.0.0.0")
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
+        GroupActionLogEntry.objects.create(
+            group_id=group.id,
+            project_id=group.project_id,
+            type=GroupActionType.RESOLVE.value,
+            actor_type=GroupActorType.USER.value,
+            actor_id=self.user.id,
+            source="web",
+            data={},
+        )
+
+        http_request = self.make_request(user=self.user, method="GET")
+        http_request.GET = QueryDict(query_string=f"id={group.id}")
+        request = _wrap_request(http_request, data={"status": "resolvedInNextRelease"})
+
+        group_list = get_group_list(self.organization.id, [self.project], request.GET.getlist("id"))
+        with self.feature("projects:issue-action-log-activity"):
+            response = update_groups(request, group_list)
+
+        activity = response.data["activity"]
+        assert [entry["type"] for entry in activity] == ["set_resolved", "first_seen"]
+        assert activity[-1]["id"] == "0"
+
+    def test_resolve_in_next_release_activity_falls_back_without_action_log(self) -> None:
+        self.create_release(project=self.project, version="test@1.0.0.0")
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
+
+        http_request = self.make_request(user=self.user, method="GET")
+        http_request.GET = QueryDict(query_string=f"id={group.id}")
+        request = _wrap_request(http_request, data={"status": "resolvedInNextRelease"})
+
+        group_list = get_group_list(self.organization.id, [self.project], request.GET.getlist("id"))
+        with (
+            self.feature("projects:issue-action-log-activity"),
+            self.assertLogs("sentry.api.helpers.group_index.update", level="INFO") as logs,
+        ):
+            response = update_groups(request, group_list)
+
+        assert any(
+            record.message == "group_index.groupactionlogentry.not_found" for record in logs.records
+        )
+        activity = response.data["activity"]
+        assert activity[-1]["type"] == "first_seen"
+        assert GroupActionLogEntry.objects.filter(group_id=group.id).count() == 0
 
 
 class MergeGroupsTest(TestCase):


### PR DESCRIPTION
Update a helper in group index to read from `GroupActionLogEntry` instead of `Activity` if the flag is set.