### PR TITLE
fix(integrations): halt on connectivity errors instead of creating Sentry issues

### DIFF
--- a/src/sentry/integrations/utils/metrics.py
+++ b/src/sentry/integrations/utils/metrics.py
@@ -349,6 +349,38 @@ class EventLifecycle:
             )
 
 
+# OSError subtypes that represent network connectivity failures to external servers.
+# These are expected infrastructure errors (e.g., customer's server is unreachable)
+# and should be treated as halts rather than Sentry-issue-creating failures.
+_CONNECTIVITY_ERRORS: tuple[type[OSError], ...] = (TimeoutError, ConnectionError)
+
+
+def _has_connectivity_error_in_chain(exc: BaseException | None) -> bool:
+    """Return True if the exception chain contains a network connectivity failure.
+
+    Walks both explicit (__cause__) and implicit (__context__) exception chains
+    because integrations may use implicit re-raising (``raise X`` without
+    ``raise X from Y``), which sets ``__context__`` instead of ``__cause__``.
+    """
+    seen: set[int] = set()
+    stack: list[BaseException | None] = [exc]
+    while stack:
+        current = stack.pop()
+        if current is None:
+            continue
+        eid = id(current)
+        if eid in seen:
+            continue
+        seen.add(eid)
+        if isinstance(current, _CONNECTIVITY_ERRORS):
+            return True
+        if current.__cause__ is not None:
+            stack.append(current.__cause__)
+        if current.__context__ is not None:
+            stack.append(current.__context__)
+    return False
+
+
 class IntegrationEventLifecycle(EventLifecycle):
     def __exit__(
         self,
@@ -365,6 +397,16 @@ class IntegrationEventLifecycle(EventLifecycle):
             # ApiHostError is raised from RestrictedIPAddress
             self.record_halt(exc_value)
             return
+
+        if exc_value is not None and _has_connectivity_error_in_chain(exc_value):
+            # Network connectivity failures (TCP timeout, connection refused, etc.)
+            # to customer-managed external servers are expected infrastructure errors,
+            # not bugs. Halt rather than create a Sentry issue for each unreachable
+            # server. The exception chain may use implicit (__context__) chaining, so
+            # we walk both __cause__ and __context__.
+            self.record_halt(exc_value)
+            return
+
         super().__exit__(exc_type, exc_value, traceback)
 
 

--- a/tests/sentry/integrations/utils/test_lifecycle_metrics.py
+++ b/tests/sentry/integrations/utils/test_lifecycle_metrics.py
@@ -2,9 +2,13 @@ from unittest import TestCase, mock
 
 import pytest
 
+from sentry.exceptions import RestrictedIPAddress
 from sentry.integrations.base import IntegrationDomain
 from sentry.integrations.types import EventLifecycleOutcome
-from sentry.integrations.utils.metrics import IntegrationEventLifecycleMetric
+from sentry.integrations.utils.metrics import (
+    IntegrationEventLifecycleMetric,
+    _has_connectivity_error_in_chain,
+)
 from sentry.testutils.silo import no_silo_test
 
 
@@ -493,3 +497,152 @@ class IntegrationEventLifecycleMetricTest(TestCase):
 
         # Should log since default is 1.0
         mock_logger.warning.assert_called_once()
+
+
+class HasConnectivityErrorInChainTest(TestCase):
+    """Unit tests for the _has_connectivity_error_in_chain helper."""
+
+    def test_returns_false_for_none(self) -> None:
+        assert not _has_connectivity_error_in_chain(None)
+
+    def test_returns_false_for_unrelated_exception(self) -> None:
+        assert not _has_connectivity_error_in_chain(ValueError("unrelated"))
+
+    def test_detects_timeout_error_directly(self) -> None:
+        assert _has_connectivity_error_in_chain(TimeoutError("timed out"))
+
+    def test_detects_connection_refused_directly(self) -> None:
+        assert _has_connectivity_error_in_chain(ConnectionRefusedError("refused"))
+
+    def test_detects_connection_reset_directly(self) -> None:
+        assert _has_connectivity_error_in_chain(ConnectionResetError("reset"))
+
+    def test_detects_connection_error_subtype_via_explicit_cause(self) -> None:
+        """Explicit chaining: raise Wrapper() from TimeoutError()"""
+        inner = TimeoutError("timed out")
+        outer = RuntimeError("wrapper")
+        outer.__cause__ = inner
+        assert _has_connectivity_error_in_chain(outer)
+
+    def test_detects_timeout_via_implicit_context(self) -> None:
+        """Implicit chaining: raise Wrapper() inside except TimeoutError block."""
+        inner = TimeoutError("timed out")
+        outer = RuntimeError("wrapper")
+        outer.__context__ = inner
+        assert _has_connectivity_error_in_chain(outer)
+
+    def test_detects_connectivity_error_two_levels_deep(self) -> None:
+        """Chain: OuterError -> MiddleError -> TimeoutError (all implicit)."""
+        root = TimeoutError("TCP connect timed out")
+        middle = RuntimeError("P4Exception wrapping the OS error")
+        middle.__context__ = root
+        outer = RuntimeError("ApiError wrapping P4Exception")
+        outer.__context__ = middle
+        assert _has_connectivity_error_in_chain(outer)
+
+    def test_does_not_detect_unrelated_oserror_subtype(self) -> None:
+        """PermissionError is an OSError but not a connectivity error."""
+        assert not _has_connectivity_error_in_chain(PermissionError("permission denied"))
+
+    def test_handles_cycle_in_exception_chain(self) -> None:
+        """Guard against a cyclic __context__ chain (should not loop forever)."""
+        exc_a = RuntimeError("a")
+        exc_b = RuntimeError("b")
+        exc_a.__context__ = exc_b
+        exc_b.__context__ = exc_a  # cycle
+        # Neither is a connectivity error; must not infinite-loop.
+        assert not _has_connectivity_error_in_chain(exc_a)
+
+
+@no_silo_test
+class IntegrationEventLifecycleConnectivityHaltTest(TestCase):
+    """Tests that IntegrationEventLifecycle halts (not fails) on connectivity errors."""
+
+    class TestLifecycleMetric(IntegrationEventLifecycleMetric):
+        def get_integration_domain(self) -> IntegrationDomain:
+            return IntegrationDomain.SOURCE_CODE_MANAGEMENT
+
+        def get_integration_name(self) -> str:
+            return "perforce"
+
+        def get_interaction_type(self) -> str:
+            return "sync_repos"
+
+    def setUp(self) -> None:
+        patcher = mock.patch("sentry.integrations.utils.metrics.options.get", return_value=False)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    @mock.patch("sentry.integrations.utils.metrics.sentry_sdk")
+    @mock.patch("sentry.integrations.utils.metrics.metrics")
+    def test_timeout_error_in_chain_records_halt_not_failure(
+        self, mock_metrics: mock.MagicMock, mock_sentry_sdk: mock.MagicMock
+    ) -> None:
+        """A TimeoutError anywhere in the exception chain should halt, not fail."""
+        root = TimeoutError("TCP connect timed out")
+        middle = RuntimeError("P4Exception: connect to server failed")
+        middle.__context__ = root
+        outer = RuntimeError("ApiError: Failed to connect to Perforce")
+        outer.__context__ = middle
+
+        metric_obj = self.TestLifecycleMetric()
+        with pytest.raises(RuntimeError):
+            with metric_obj.capture():
+                raise outer
+
+        # Must record a halt, not a failure
+        assert mock_metrics.incr.call_args_list[-1][0][0] == "integrations.slo.halted"
+        # Must NOT call capture_exception (no Sentry issue created)
+        mock_sentry_sdk.capture_exception.assert_not_called()
+
+    @mock.patch("sentry.integrations.utils.metrics.sentry_sdk")
+    @mock.patch("sentry.integrations.utils.metrics.metrics")
+    def test_connection_refused_in_chain_records_halt(
+        self, mock_metrics: mock.MagicMock, mock_sentry_sdk: mock.MagicMock
+    ) -> None:
+        """A ConnectionRefusedError in the chain should halt, not fail."""
+        root = ConnectionRefusedError("Connection refused")
+        outer = RuntimeError("ApiError wrapping connection refusal")
+        outer.__context__ = root
+
+        metric_obj = self.TestLifecycleMetric()
+        with pytest.raises(RuntimeError):
+            with metric_obj.capture():
+                raise outer
+
+        assert mock_metrics.incr.call_args_list[-1][0][0] == "integrations.slo.halted"
+        mock_sentry_sdk.capture_exception.assert_not_called()
+
+    @mock.patch("sentry.integrations.utils.metrics.sentry_sdk")
+    @mock.patch("sentry.integrations.utils.metrics.metrics")
+    def test_unrelated_exception_still_records_failure(
+        self, mock_metrics: mock.MagicMock, mock_sentry_sdk: mock.MagicMock
+    ) -> None:
+        """Exceptions unrelated to connectivity must still create Sentry issues."""
+        mock_sentry_sdk.capture_exception.return_value = "test-event-id"
+
+        metric_obj = self.TestLifecycleMetric()
+        with pytest.raises(ValueError):
+            with metric_obj.capture():
+                raise ValueError("unexpected internal error")
+
+        assert mock_metrics.incr.call_args_list[-1][0][0] == "integrations.slo.failure"
+        mock_sentry_sdk.capture_exception.assert_called_once()
+
+    @mock.patch("sentry.integrations.utils.metrics.sentry_sdk")
+    @mock.patch("sentry.integrations.utils.metrics.metrics")
+    def test_restricted_ip_address_in_cause_records_halt(
+        self, mock_metrics: mock.MagicMock, mock_sentry_sdk: mock.MagicMock
+    ) -> None:
+        """RestrictedIPAddress via explicit __cause__ still records a halt (existing behavior)."""
+        inner = RestrictedIPAddress("blocked")
+        outer = RuntimeError("ApiHostError: restricted")
+        outer.__cause__ = inner  # explicit chaining
+
+        metric_obj = self.TestLifecycleMetric()
+        with pytest.raises(RuntimeError):
+            with metric_obj.capture():
+                raise outer
+
+        assert mock_metrics.incr.call_args_list[-1][0][0] == "integrations.slo.halted"
+        mock_sentry_sdk.capture_exception.assert_not_called()


### PR DESCRIPTION
## Root-cause analysis

**Triage session**: https://claude.ai/code
**Triggering event**: `b743844bbff94ba8a96ebab6d99e35c9`

### What was happening

`sync_repos_for_org` (a background task) failed to reach a customer's Perforce server. The TCP connection timed out, which propagated up as:

```
TimeoutError("timed out")
  → P4Exception("connect to server failed; check P4PORT. TCP connect to … failed: timed out")
  → ApiError("Failed to connect to Perforce: connect to server failed …")
```

`IntegrationEventLifecycle.__exit__` caught the `ApiError` as an unhandled exception and called `record_failure(exc_value, create_issue=True)`, which fired `sentry_sdk.capture_exception()` — creating a Sentry issue for what is an expected external-infrastructure failure (the customer's server is unreachable).

### Exception chaining detail

Both `P4Exception` and `ApiError` are raised with **implicit chaining** (`raise X` inside an `except Y` block, no `from Y`). This sets `__context__` on each exception, not `__cause__`. The existing `RestrictedIPAddress` check uses `exc_value.__cause__`, which works for that path (another integration raises `ApiHostError` explicitly with `raise ApiHostError from RestrictedIPAddress`). Walking only `__cause__` would miss the Perforce timeout chain entirely.

### Fix

1. Add `_has_connectivity_error_in_chain(exc)` — a BFS helper that walks both `__cause__` (explicit chaining) and `__context__` (implicit chaining), looking for `TimeoutError` or `ConnectionError` (the `OSError` subclasses that represent network-level connectivity failures). The seen-set guards against cycles.

2. In `IntegrationEventLifecycle.__exit__`, after the existing `RestrictedIPAddress` guard, add a parallel guard: if the chain contains a connectivity error, call `record_halt(exc_value)` instead of falling through to `super().__exit__()` which calls `record_failure(create_issue=True)`.

### Scope: general, not Perforce-specific

The fix lives in `IntegrationEventLifecycle` (shared across all integration providers) and targets the class of error (connectivity `OSError`) rather than anything Perforce-specific. Any integration that wraps a TCP timeout or connection refusal — whether the chain is explicit or implicit — will now halt instead of generating a Sentry issue.

### What was ruled out

- **Fixing only the Perforce client**: Would leave the same class of error unhandled in GitHub, GitLab, Bitbucket, Jira, and any other integration that can time out reaching an external server. The right place is the shared lifecycle.
- **Changing exception chaining in the Perforce client** (`raise ApiError(...) from e`): Would fix `__cause__` for Perforce but not other integrations, and would be a larger, riskier change in the integration code itself.
- **Just downgrading the log level**: The task specifically requires preventing `create_issue=True` calls, not suppressing logging.
- **Catching generic `OSError`**: Too broad — `PermissionError`, `FileNotFoundError`, etc. are `OSError` subclasses that are genuine bugs, not expected external-server failures. `TimeoutError` and `ConnectionError` (and its subtypes: `ConnectionRefusedError`, `ConnectionResetError`, `BrokenPipeError`, `ConnectionAbortedError`) are the right scope.

## Changes

- `src/sentry/integrations/utils/metrics.py` — add `_CONNECTIVITY_ERRORS`, `_has_connectivity_error_in_chain()`, and the guard in `IntegrationEventLifecycle.__exit__`.
- `tests/sentry/integrations/utils/test_lifecycle_metrics.py` — add `HasConnectivityErrorInChainTest` (unit tests for the helper) and `IntegrationEventLifecycleConnectivityHaltTest` (integration-level tests verifying halt vs. failure behaviour and that `capture_exception` is not called).

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Je2GtbKLzqG16rxh5Hj2zU)_