### PR TITLE
feat(derived data): Make activity backfill trigger a targeted regeneration run

### DIFF
--- a/src/sentry/tasks/backfill_group_action_log.py
+++ b/src/sentry/tasks/backfill_group_action_log.py
@@ -10,6 +10,7 @@ from sentry.issues.action_log.backfill import (
     bulk_insert_action_log_entries,
 )
 from sentry.issues.action_log.types import SYSTEM_ACTOR, GroupActionActor
+from sentry.issues.models.groupderiveddata import GroupDerivedData
 from sentry.models.activity import Activity
 from sentry.models.group import Group
 from sentry.models.project import Project
@@ -243,6 +244,7 @@ def _backfill_project(
     skipped_count = 0
     error_count = 0
     num_entries = 0
+    backfilled_group_ids: set[int] = set()
 
     for activity in activities:
         try:
@@ -263,6 +265,7 @@ def _backfill_project(
         else:
             actor = SYSTEM_ACTOR
 
+        backfilled_group_ids.add(activity.group_id)
         params.extend(
             [
                 activity.group_id,
@@ -280,6 +283,11 @@ def _backfill_project(
         num_entries += 1
 
     converted_count = bulk_insert_action_log_entries(params, num_entries)
+
+    if backfilled_group_ids:
+        GroupDerivedData.objects.filter(group_id__in=backfilled_group_ids).update(
+            pipeline_hash=None
+        )
 
     metrics.incr(
         "issues.backfill_group_action_log.activities_converted",
@@ -339,6 +347,6 @@ def _complete_project_backfill(project: Project, chain_pr_lifecycle: bool) -> No
 
         backfill_pr_lifecycle_action_log_for_project.delay(project_id=project.id)
     else:
-        from sentry.issues.derived.tasks import process_project_derived_data
+        from sentry.issues.derived.tasks import generate_project_derived_data
 
-        process_project_derived_data.delay(project_id=project.id)
+        generate_project_derived_data.delay(project_id=project.id, stale_only=True)

--- a/tests/sentry/tasks/test_backfill_group_action_log.py
+++ b/tests/sentry/tasks/test_backfill_group_action_log.py
@@ -475,12 +475,47 @@ class BackfillGroupActionLogForProjectTest(TestCase):
 
         mock_reset.assert_not_called()
 
-    @patch("sentry.issues.derived.tasks.process_project_derived_data.delay")
+    @patch("sentry.issues.derived.tasks.generate_project_derived_data.delay")
     def test_triggers_derived_data_on_completion(self, mock_derived: Any) -> None:
         with self._options():
             backfill_group_action_log_for_project(self.project.id)
 
-        mock_derived.assert_called_once_with(project_id=self.project.id)
+        mock_derived.assert_called_once_with(project_id=self.project.id, stale_only=True)
+
+    def test_nulls_pipeline_hash_on_backfilled_groups(self) -> None:
+        from sentry.issues.models.groupderiveddata import GroupDerivedData
+
+        self._create_activity(ActivityType.SET_RESOLVED, user_id=self.user.id)
+
+        self.create_group_derived_data(
+            group=self.group,
+            pipeline_hash="old_hash",
+            data={},
+        )
+
+        with self._options(), patch.object(backfill_group_action_log_for_project, "apply_async"):
+            backfill_group_action_log_for_project(self.project.id)
+
+        derived = GroupDerivedData.objects.get(group=self.group)
+        assert derived.pipeline_hash is None
+
+    def test_does_not_null_pipeline_hash_for_untouched_groups(self) -> None:
+        from sentry.issues.models.groupderiveddata import GroupDerivedData
+
+        other_group = self.create_group(project=self.project)
+        self._create_activity(ActivityType.SET_RESOLVED, user_id=self.user.id)
+
+        self.create_group_derived_data(
+            group=other_group,
+            pipeline_hash="keep_me",
+            data={},
+        )
+
+        with self._options(), patch.object(backfill_group_action_log_for_project, "apply_async"):
+            backfill_group_action_log_for_project(self.project.id)
+
+        derived = GroupDerivedData.objects.get(group=other_group)
+        assert derived.pipeline_hash == "keep_me"
 
     def test_chains_pr_lifecycle_instead_of_derived_data_on_completion(self) -> None:
         with (
@@ -489,7 +524,9 @@ class BackfillGroupActionLogForProjectTest(TestCase):
                 "sentry.tasks.backfill_pr_lifecycle_action_log."
                 "backfill_pr_lifecycle_action_log_for_project.delay"
             ) as mock_pr_lifecycle,
-            patch("sentry.issues.derived.tasks.process_project_derived_data.delay") as mock_derived,
+            patch(
+                "sentry.issues.derived.tasks.generate_project_derived_data.delay"
+            ) as mock_derived,
         ):
             backfill_group_action_log_for_project(
                 self.project.id,
@@ -508,7 +545,9 @@ class BackfillGroupActionLogForProjectTest(TestCase):
                 "sentry.tasks.backfill_pr_lifecycle_action_log."
                 "backfill_pr_lifecycle_action_log_for_project.delay"
             ) as mock_pr_lifecycle,
-            patch("sentry.issues.derived.tasks.process_project_derived_data.delay") as mock_derived,
+            patch(
+                "sentry.issues.derived.tasks.generate_project_derived_data.delay"
+            ) as mock_derived,
         ):
             backfill_group_action_log_for_project(
                 self.project.id,


### PR DESCRIPTION
After backfill, invalidate affected groups by clearing out their GroupDerivedData.pipeline_hash,
then run a generate task for that project focused on stale/missing pipeline_hash afterward.

The end result of this is that (once writing is enabled) this makes triggering backfill for a project sufficient to get the data into full working order.