### PR TITLE
ref: Remove performance plan trial

### DIFF
--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -321,7 +321,6 @@ export type Subscription = {
 
   isPartner: boolean;
   isPastDue: boolean;
-  isPerformancePlanTrial: boolean;
   isSelfServePartner: boolean;
   isSponsored: boolean;
   isSuspended: boolean;

--- a/static/gsApp/utils/billing.tsx
+++ b/static/gsApp/utils/billing.tsx
@@ -340,11 +340,7 @@ export const isTeamPlanFamily = (plan?: Plan) => plan?.name.includes(PlanName.TE
 export const isTrial = (subscription: Subscription) => defined(subscription.trialPlan);
 
 export const isBusinessTrial = (subscription: Subscription) => {
-  return (
-    isTrial(subscription) &&
-    !subscription.isPerformancePlanTrial &&
-    !subscription.isEnterpriseTrial
-  );
+  return isTrial(subscription) && !subscription.isEnterpriseTrial;
 };
 
 export function hasJustStartedPlanTrial(subscription: Subscription) {

--- a/static/gsApp/utils/pendo.tsx
+++ b/static/gsApp/utils/pendo.tsx
@@ -102,7 +102,6 @@ export function getPendoAccountFields(
       'isFree',
       'isManaged',
       'isEnterpriseTrial',
-      'isPerformancePlanTrial',
       'isSuspended',
       'canTrial',
       'canSelfServe',

--- a/static/gsApp/views/subscriptionPage/trialAlert.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/trialAlert.spec.tsx
@@ -107,7 +107,6 @@ describe('Subscription > TrialAlert', () => {
       ...subscription,
       trialPlan: 'am1_business',
       isEnterpriseTrial: false,
-      isPerformancePlanTrial: false,
       onDemandMaxSpend: 1000,
       onDemandSpendUsed: 0,
     };
@@ -119,23 +118,5 @@ describe('Subscription > TrialAlert', () => {
       )
     ).toBeInTheDocument();
     expect(screen.queryByText(/unlimited errors/)).not.toBeInTheDocument();
-  });
-
-  it('renders performance trial', () => {
-    const sub = {
-      ...subscription,
-      trialPlan: 'am1_business',
-      isEnterpriseTrial: false,
-      isPerformancePlanTrial: true,
-      onDemandMaxSpend: 1000,
-      onDemandSpendUsed: 0,
-    };
-    render(<TrialAlert subscription={sub} organization={organization} />);
-    expect(screen.getByText('Performance Trial')).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        "With your trial you have access to Sentry's performance features."
-      )
-    ).toBeInTheDocument();
   });
 });

--- a/static/gsApp/views/subscriptionPage/trialAlert.tsx
+++ b/static/gsApp/views/subscriptionPage/trialAlert.tsx
@@ -32,13 +32,9 @@ export function TrialAlert({organization, subscription}: Props) {
 
   const trialName = subscription.isEnterpriseTrial
     ? t('Enterprise Trial')
-    : subscription.isPerformancePlanTrial
-      ? t('Performance Trial')
-      : t('Business Plan Trial');
+    : t('Business Plan Trial');
 
-  const featuresName = subscription.isPerformancePlanTrial
-    ? 'performance'
-    : 'business plan';
+  const featuresName = 'business plan';
 
   return (
     <Container

--- a/tests/js/getsentry-test/fixtures/subscription.ts
+++ b/tests/js/getsentry-test/fixtures/subscription.ts
@@ -83,7 +83,6 @@ export function SubscriptionFixture(props: Props): TSubscription {
     isOverMemberLimit: false,
     isPartner: false,
     isSelfServePartner: false,
-    isPerformancePlanTrial: false,
     lastTrialEnd: null,
     spendAllocationEnabled: false,
     status: 'active',


### PR DESCRIPTION
legacy plans never start trials anymore (they are all partner accounts) so this can be removed