### PR TITLE
test(project-install): Stabilize notification refetch test

### DIFF
--- a/static/app/views/projectInstall/issueAlertNotificationOptions.spec.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.spec.tsx
@@ -239,9 +239,11 @@ describe('useCreateNotificationAction', () => {
 
     // Query resolved but integration list empty: setup CTA shown, guard not latched,
     // INTEGRATION must NOT be in actions (picker not half-applied).
-    await waitFor(() => expect(result.current.notificationProps.querySuccess).toBe(true));
+    await waitFor(() =>
+      expect(result.current.notificationProps.shouldRenderSetupButton).toBe(true)
+    );
+    expect(result.current.notificationProps.querySuccess).toBe(true);
     expect(result.current.notificationProps.provider).toBeUndefined();
-    expect(result.current.notificationProps.shouldRenderSetupButton).toBe(true);
     expect(result.current.notificationProps.actions).not.toContain(
       MultipleCheckboxOptions.INTEGRATION
     );


### PR DESCRIPTION
## TLDR

Stabilizes persisted notification-selection refetch coverage by waiting for the hook's initial setup state before triggering the focus refetch.

## Details

The test previously waited only for React Query's success flag and then synchronously asserted state set by a later effect, so slower CI runs could observe `shouldRenderSetupButton` before that effect committed. It now treats the setup button as the observable initial-state boundary, then preserves the existing assertions that the focus refetch restores the persisted provider, integration, channel, and action without changing production behavior.
