### PR TITLE
feat(seer): Prefer sentry_run_id over legacy run_id in autofix UI

### DIFF
--- a/static/app/components/events/autofix/autofixRunId.ts
+++ b/static/app/components/events/autofix/autofixRunId.ts
@@ -1,0 +1,17 @@
+import type {SeerExplorerRunId} from 'sentry/views/seerExplorer/types';
+
+// Shim for the run_id -> sentry_run_id migration. The autofix endpoint still
+// accepts the deprecated integer `run_id` but prefers the UUID `sentry_run_id`
+// when present. Delete this file once the integer path is retired server-side.
+
+export function getAutofixRunId(
+  runState: {run_id: number; sentry_run_id?: string | null} | null | undefined
+): SeerExplorerRunId | undefined {
+  return runState?.sentry_run_id ?? runState?.run_id;
+}
+
+export function continueRunData(
+  runId: SeerExplorerRunId
+): Record<string, string | number> {
+  return typeof runId === 'string' ? {sentry_run_id: runId} : {run_id: runId};
+}

--- a/static/app/components/events/autofix/useExplorerAutofix.spec.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.spec.tsx
@@ -756,6 +756,31 @@ describe('useExplorerAutofix - createPR', () => {
     );
   });
 
+  it('sends sentry_run_id instead of run_id when given a UUID', async () => {
+    const mockPost = MockApiClient.addMockResponse({
+      url: AUTOFIX_URL,
+      method: 'POST',
+      body: {},
+    });
+
+    const {result} = renderHookWithProviders(() => useExplorerAutofix(MOCK_GROUP));
+
+    await act(() => result.current.createPR('f00dcafe-0000-0000-0000-000000000000'));
+
+    expect(mockPost).toHaveBeenCalledWith(
+      AUTOFIX_URL,
+      expect.objectContaining({
+        method: 'POST',
+        query: {mode: 'explorer'},
+        data: {
+          step: 'open_pr',
+          sentry_run_id: 'f00dcafe-0000-0000-0000-000000000000',
+          referrer: 'api.web',
+        },
+      })
+    );
+  });
+
   it('calls addErrorMessage and throws on API error', async () => {
     MockApiClient.addMockResponse({
       url: AUTOFIX_URL,
@@ -813,6 +838,37 @@ describe('useExplorerAutofix - startStep pr_iteration', () => {
         data: {
           step: 'pr_iteration',
           run_id: 42,
+          user_context: 'make it blue',
+          referrer: 'api.web',
+        },
+      })
+    );
+  });
+
+  it('continues via sentry_run_id when given a UUID', async () => {
+    const mockPost = MockApiClient.addMockResponse({
+      url: AUTOFIX_URL,
+      method: 'POST',
+      body: {run_id: 42},
+    });
+
+    const {result} = renderHookWithProviders(() => useExplorerAutofix(MOCK_GROUP));
+
+    await act(() =>
+      result.current.startStep('pr_iteration', {
+        runId: 'f00dcafe-0000-0000-0000-000000000000',
+        userContext: 'make it blue',
+      })
+    );
+
+    expect(mockPost).toHaveBeenCalledWith(
+      AUTOFIX_URL,
+      expect.objectContaining({
+        method: 'POST',
+        query: {mode: 'explorer'},
+        data: {
+          step: 'pr_iteration',
+          sentry_run_id: 'f00dcafe-0000-0000-0000-000000000000',
           user_context: 'make it blue',
           referrer: 'api.web',
         },
@@ -924,6 +980,59 @@ describe('useExplorerAutofix - codingAgentErrors', () => {
     await waitFor(() => {
       expect(result.current.codingAgentErrors.map(e => e.message)).toEqual(['boom']);
     });
+  });
+
+  it('sends the legacy run_id for an integer run', async () => {
+    const mockPost = MockApiClient.addMockResponse({
+      url: AUTOFIX_URL,
+      method: 'POST',
+      body: {successes: [], failures: []},
+    });
+
+    const {result} = renderHookWithProviders(() => useExplorerAutofix(MOCK_GROUP));
+
+    await act(() => result.current.triggerCodingAgentHandoff(1, integration));
+
+    expect(mockPost).toHaveBeenCalledWith(
+      AUTOFIX_URL,
+      expect.objectContaining({
+        data: expect.objectContaining({
+          step: 'coding_agent_handoff',
+          run_id: 1,
+          integration_id: 42,
+        }),
+      })
+    );
+    expect(mockPost.mock.calls[0][1].data.sentry_run_id).toBeUndefined();
+  });
+
+  it('sends sentry_run_id for a UUID run', async () => {
+    const mockPost = MockApiClient.addMockResponse({
+      url: AUTOFIX_URL,
+      method: 'POST',
+      body: {successes: [], failures: []},
+    });
+
+    const {result} = renderHookWithProviders(() => useExplorerAutofix(MOCK_GROUP));
+
+    await act(() =>
+      result.current.triggerCodingAgentHandoff(
+        'f00dcafe-0000-0000-0000-000000000000',
+        integration
+      )
+    );
+
+    expect(mockPost).toHaveBeenCalledWith(
+      AUTOFIX_URL,
+      expect.objectContaining({
+        data: expect.objectContaining({
+          step: 'coding_agent_handoff',
+          sentry_run_id: 'f00dcafe-0000-0000-0000-000000000000',
+          integration_id: 42,
+        }),
+      })
+    );
+    expect(mockPost.mock.calls[0][1].data.run_id).toBeUndefined();
   });
 
   it('dismissCodingAgentError removes the error with the given id', async () => {

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -11,6 +11,10 @@ import {
 import {AutofixCursorGithubAccessModal} from 'sentry/components/events/autofix/autofixCursorGithubAccessModal';
 import {AutofixGithubAppPermissionsModal} from 'sentry/components/events/autofix/autofixGithubAppPermissionsModal';
 import {AutofixGithubCopilotPurchaseModal} from 'sentry/components/events/autofix/autofixGithubCopilotPurchaseModal';
+import {
+  continueRunData,
+  getAutofixRunId,
+} from 'sentry/components/events/autofix/autofixRunId';
 import {CodingAgentStatus} from 'sentry/components/events/autofix/types';
 import {
   needsGitHubAuth,
@@ -40,6 +44,7 @@ import {
   type ExplorerCodingAgentState,
   type ExplorerFilePatch,
   type RepoPRState,
+  type SeerExplorerRunId,
 } from 'sentry/views/seerExplorer/types';
 
 /**
@@ -195,6 +200,7 @@ export interface ExplorerAutofixState {
   } | null;
   queued_feedback?: RawFeedback[];
   repo_pr_states?: Record<string, RepoPRState>;
+  sentry_run_id?: string | null;
   warnings?: Array<{
     warning_type: string;
     installation_id?: string;
@@ -611,7 +617,7 @@ export function useExplorerAutofix(
         /**
          * The run id where we want to start the step. If not specified, a new run is created
          */
-        runId?: number;
+        runId?: SeerExplorerRunId;
         /**
          * Additional context from the user. If specified, it is added to the builtin prompt
          */
@@ -628,7 +634,7 @@ export function useExplorerAutofix(
         }
 
         if (defined(startStepOptions?.runId)) {
-          data.run_id = startStepOptions.runId;
+          Object.assign(data, continueRunData(startStepOptions.runId));
         }
 
         if (startStepOptions?.userContext) {
@@ -696,7 +702,7 @@ export function useExplorerAutofix(
             });
         }
 
-        return response.run_id as number;
+        return getAutofixRunId(response)!;
       } catch (e: any) {
         setWaitingForResponse(false);
         queryClient.setQueryData(
@@ -729,12 +735,12 @@ export function useExplorerAutofix(
    * @param repoName - Optional specific repo to create PR for
    */
   const createPR = useCallback(
-    async (runId: number, repoName?: string) => {
+    async (runId: SeerExplorerRunId, repoName?: string) => {
       try {
         const data: Record<string, any> = {
           step: 'open_pr',
-          run_id: runId,
           referrer: 'api.web',
+          ...continueRunData(runId),
         };
         if (repoName) {
           data.repo_name = repoName;
@@ -778,7 +784,7 @@ export function useExplorerAutofix(
    * Trigger coding agent handoff for an existing run.
    */
   const triggerCodingAgentHandoff = useCallback(
-    async (runId: number, integration: CodingAgentIntegration) => {
+    async (runId: SeerExplorerRunId, integration: CodingAgentIntegration) => {
       setWaitingForCodingAgent(true);
 
       trackAnalytics('coding_integration.send_to_agent_clicked', {
@@ -793,8 +799,8 @@ export function useExplorerAutofix(
 
       const data: Record<string, string | number> = {
         step: 'coding_agent_handoff',
-        run_id: runId,
         referrer: 'api.web',
+        ...continueRunData(runId),
       };
 
       if (integration.id === null) {

--- a/static/app/components/events/autofix/v3/codeChangesCard.tsx
+++ b/static/app/components/events/autofix/v3/codeChangesCard.tsx
@@ -6,6 +6,7 @@ import {Flex, Stack} from '@sentry/scraps/layout';
 import {Markdown} from '@sentry/scraps/markdown';
 import {Text} from '@sentry/scraps/text';
 
+import {getAutofixRunId} from 'sentry/components/events/autofix/autofixRunId';
 import {
   collectPatches,
   getAutofixArtifactFromSection,
@@ -141,7 +142,7 @@ export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProp
     <PrIterationFeedbackForm
       autofix={autofix}
       groupId={groupId}
-      runId={autofix.runState?.run_id}
+      runId={getAutofixRunId(autofix.runState)}
       referrer="code_changes_card_reset"
       onClose={() => setShouldShowReset(false)}
     />

--- a/static/app/components/events/autofix/v3/nextStep.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.tsx
@@ -10,6 +10,7 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {DropdownMenuFooter} from 'sentry/components/dropdownMenu/footer';
+import {getAutofixRunId} from 'sentry/components/events/autofix/autofixRunId';
 import {
   organizationIntegrationsCodingAgents,
   type CodingAgentIntegration,
@@ -42,6 +43,7 @@ import {
   isGitHubProvider,
 } from 'sentry/utils/seer/seerProjectRepos';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import type {SeerExplorerRunId} from 'sentry/views/seerExplorer/types';
 import {getProviderPermissionsUrl} from 'sentry/views/settings/organizationRepositories/getProviderConfigUrl';
 
 interface SeerDrawerNextStepProps {
@@ -51,7 +53,7 @@ interface SeerDrawerNextStepProps {
 }
 
 export function SeerDrawerNextStep({sections, group, autofix}: SeerDrawerNextStepProps) {
-  const runId = autofix.runState?.run_id;
+  const runId = getAutofixRunId(autofix.runState);
   const section = sections[sections.length - 1];
   const referrer = autofix.runState?.blocks?.[0]?.message?.metadata?.referrer;
 
@@ -140,7 +142,7 @@ function PullRequestNextStep({autofix, group, runId, referrer}: NextStepProps) {
 interface NextStepProps {
   autofix: ReturnType<typeof useExplorerAutofix>;
   group: Group;
-  runId: number;
+  runId: SeerExplorerRunId;
   section: AutofixSection;
   referrer?: string;
 }
@@ -602,7 +604,7 @@ interface UseCodingAgentsOptions {
   autofix: ReturnType<typeof useExplorerAutofix>;
   group: Group;
   referrer: string | undefined;
-  runId: number;
+  runId: SeerExplorerRunId;
   step: 'root_cause' | 'solution';
 }
 

--- a/static/app/components/events/autofix/v3/prIterationFeedbackForm.tsx
+++ b/static/app/components/events/autofix/v3/prIterationFeedbackForm.tsx
@@ -14,13 +14,14 @@ import {IconReturn} from 'sentry/icons/iconReturn';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import type {SeerExplorerRunId} from 'sentry/views/seerExplorer/types';
 
 interface PrIterationFeedbackFormProps {
   autofix: ReturnType<typeof useExplorerAutofix>;
   groupId: string;
   onClose?: () => void;
   referrer?: string;
-  runId?: number;
+  runId?: SeerExplorerRunId;
 }
 
 export function PrIterationFeedbackForm({

--- a/static/app/components/events/autofix/v3/pullRequestsCard.tsx
+++ b/static/app/components/events/autofix/v3/pullRequestsCard.tsx
@@ -3,6 +3,7 @@ import {useMemo} from 'react';
 import {Button, LinkButton} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
 
+import {getAutofixRunId} from 'sentry/components/events/autofix/autofixRunId';
 import {
   getAutofixArtifactFromSection,
   isPullRequestsArtifact,
@@ -24,7 +25,7 @@ interface PullRequestsCardProps {
 }
 
 export function PullRequestsCard({autofix, section}: PullRequestsCardProps) {
-  const runId = autofix.runState?.run_id;
+  const runId = getAutofixRunId(autofix.runState);
   const {createPR} = autofix;
   const artifact = useMemo(() => {
     const sectionArtifact = getAutofixArtifactFromSection(section);

--- a/static/app/components/events/autofix/v3/useResetAutofixStep.tsx
+++ b/static/app/components/events/autofix/v3/useResetAutofixStep.tsx
@@ -1,6 +1,7 @@
 import {useMemo, useState} from 'react';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
+import {getAutofixRunId} from 'sentry/components/events/autofix/autofixRunId';
 import {
   type AutofixExplorerStep,
   type AutofixSection,
@@ -24,7 +25,7 @@ export function useResetAutofixStep({
   const [shouldShowReset, setShouldShowReset] = useState(false);
 
   const {runState, startStep} = autofix;
-  const runId = runState?.run_id;
+  const runId = getAutofixRunId(runState);
   const notProcessing = autofix.runState?.status !== 'processing';
   const noPRs = Object.values(autofix.runState?.repo_pr_states ?? {}).length === 0;
   const noCodingAgents =

--- a/static/app/serviceWorker/worker/handleAutofixStartStep.ts
+++ b/static/app/serviceWorker/worker/handleAutofixStartStep.ts
@@ -28,7 +28,7 @@ export interface AutofixStartStepData {
   step: AutofixExplorerStep;
   stepOptions: {
     insertIndex?: number;
-    runId?: number;
+    runId?: number | string;
     userContext?: string;
   };
 }

--- a/static/app/serviceWorker/worker/handleAutofixStartStep.ts
+++ b/static/app/serviceWorker/worker/handleAutofixStartStep.ts
@@ -28,7 +28,7 @@ export interface AutofixStartStepData {
   step: AutofixExplorerStep;
   stepOptions: {
     insertIndex?: number;
-    runId?: number | string; // SeerExplorerRunId, cloned per the note above
+    runId?: number | string;
     userContext?: string;
   };
 }

--- a/static/app/serviceWorker/worker/handleAutofixStartStep.ts
+++ b/static/app/serviceWorker/worker/handleAutofixStartStep.ts
@@ -28,7 +28,7 @@ export interface AutofixStartStepData {
   step: AutofixExplorerStep;
   stepOptions: {
     insertIndex?: number;
-    runId?: number | string;
+    runId?: number | string; // SeerExplorerRunId, cloned per the note above
     userContext?: string;
   };
 }

--- a/static/app/views/issueDetails/actions/seerCommandPaletteActions.tsx
+++ b/static/app/views/issueDetails/actions/seerCommandPaletteActions.tsx
@@ -2,6 +2,7 @@ import {Fragment, useMemo} from 'react';
 import {useQuery} from '@tanstack/react-query';
 
 import {CMDKAction} from 'sentry/components/commandPalette/ui/cmdk';
+import {getAutofixRunId} from 'sentry/components/events/autofix/autofixRunId';
 import {
   organizationIntegrationsCodingAgents,
   type CodingAgentIntegration,
@@ -98,7 +99,7 @@ export function SeerCommandPaletteActions({
   }
 
   const {runState, isPolling} = autofix;
-  const runId = runState?.run_id;
+  const runId = getAutofixRunId(runState);
 
   const canContinue = !isPolling && defined(runId);
 


### PR DESCRIPTION
The group autofix endpoint accepts a deprecated integer `run_id` and a preferred UUID `sentry_run_id`, but the Explorer autofix hook (`useExplorerAutofix`) only tracked `run_id` — so every continue / open-PR / coding-agent-handoff triggered from the web UI sent the legacy field, keeping the `group_ai_autofix.legacy_integer_run_id` server log warm with first-party traffic. This captures `sentry_run_id` from the run state and sends it when present, falling back to `run_id` only for legacy runs without a SeerRun mirror. No behavior change for those legacy runs — the fallback path is byte-identical to today.

The run-id shim — the state collapse (`getAutofixRunId`) and the POST-body builder (`continueRunData`) — lives in one file, `autofixRunId.ts`, so the whole legacy path can be deleted in one step once the integer `run_id` is retired server-side. Callers import from there rather than repeating the `sentry_run_id ?? run_id` read.

Split out from the backend logging change (#120519) per the frontend/backend atomic-deploy rule.