### PR TITLE
feat(billing): Wire trace-metric retention to the byte category

### DIFF
--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -71,10 +71,13 @@ class RetentionSettings:
 
 # This mirrors the Retentions struct in relay
 # https://github.com/getsentry/relay/blob/641e7f20cd/relay-dynamic-config/src/project.rs#L34-L45
+# On wire-name collisions (TRANSACTION/SPAN, TRACE_METRIC/TRACE_METRIC_BYTE) the
+# last entry wins, so list categories from least to most preferred.
 RETENTIONS_CONFIG_MAPPING = {
     DataCategory.LOG_BYTE: "log",
     DataCategory.TRANSACTION: "span",
     DataCategory.SPAN: "span",
+    DataCategory.TRACE_METRIC: "traceMetric",
     DataCategory.TRACE_METRIC_BYTE: "traceMetric",
 }
 

--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -75,7 +75,7 @@ RETENTIONS_CONFIG_MAPPING = {
     DataCategory.LOG_BYTE: "log",
     DataCategory.TRANSACTION: "span",
     DataCategory.SPAN: "span",
-    DataCategory.TRACE_METRIC: "traceMetric",
+    DataCategory.TRACE_METRIC_BYTE: "traceMetric",
 }
 
 

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -934,10 +934,12 @@ def _get_project_config(
             config["downsampledEventRetention"] = downsampled_event_retention
     with start_span(op="get_retentions", name="get_retentions"):
         retentions = quotas.backend.get_retentions(project.organization)
+        # Iterate the mapping (not the backend's dict) so that wire-name
+        # collisions resolve deterministically: the last mapping wins.
         retentions_config = {
-            RETENTIONS_CONFIG_MAPPING[c]: v.to_object()
-            for c, v in retentions.items()
-            if c in RETENTIONS_CONFIG_MAPPING
+            name: retentions[c].to_object()
+            for c, name in RETENTIONS_CONFIG_MAPPING.items()
+            if c in retentions
         }
         if retentions_config:
             config["retentions"] = retentions_config

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs.py
@@ -198,7 +198,7 @@ def test_parse_retentions(call_endpoint, default_project):
         assert safe.get_path(cfg, "config", "retentions") == {
             "span": {"standard": 12, "downsampled": 22},
             "log": {"standard": 13, "downsampled": 23},
-            "traceMetric": {"standard": 15, "downsampled": 25},
+            "traceMetric": {"standard": 14, "downsampled": 24},
         }
 
 

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs.py
@@ -183,6 +183,7 @@ def test_parse_retentions(call_endpoint, default_project):
             DataCategory.SPAN: RetentionSettings(standard=12, downsampled=22),
             DataCategory.LOG_BYTE: RetentionSettings(standard=13, downsampled=23),
             DataCategory.TRACE_METRIC_BYTE: RetentionSettings(standard=14, downsampled=24),
+            DataCategory.TRACE_METRIC: RetentionSettings(standard=15, downsampled=25),
         },
         get_event_retention=lambda x: 45,
         get_downsampled_event_retention=lambda x: 90,
@@ -197,7 +198,7 @@ def test_parse_retentions(call_endpoint, default_project):
         assert safe.get_path(cfg, "config", "retentions") == {
             "span": {"standard": 12, "downsampled": 22},
             "log": {"standard": 13, "downsampled": 23},
-            "traceMetric": {"standard": 14, "downsampled": 24},
+            "traceMetric": {"standard": 15, "downsampled": 25},
         }
 
 

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs.py
@@ -182,7 +182,7 @@ def test_parse_retentions(call_endpoint, default_project):
             DataCategory.REPLAY: RetentionSettings(standard=11, downsampled=21),
             DataCategory.SPAN: RetentionSettings(standard=12, downsampled=22),
             DataCategory.LOG_BYTE: RetentionSettings(standard=13, downsampled=23),
-            DataCategory.TRACE_METRIC: RetentionSettings(standard=14, downsampled=24),
+            DataCategory.TRACE_METRIC_BYTE: RetentionSettings(standard=14, downsampled=24),
         },
         get_event_retention=lambda x: 45,
         get_downsampled_event_retention=lambda x: 90,

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs_v2.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs_v2.py
@@ -113,9 +113,9 @@ def test_internal_relays_should_receive_full_configs(
 
     retentions = quotas.backend.get_retentions(default_project.organization)
     retentions_config = {
-        RETENTIONS_CONFIG_MAPPING[c]: v.to_object()
-        for c, v in retentions.items()
-        if c in RETENTIONS_CONFIG_MAPPING
+        name: retentions[c].to_object()
+        for c, name in RETENTIONS_CONFIG_MAPPING.items()
+        if c in retentions
     }
     if retentions_config:
         assert safe.get_path(cfg, "config", "retentions") == retentions_config


### PR DESCRIPTION
## What

`RETENTIONS_CONFIG_MAPPING` in `src/sentry/quotas/base.py` now maps `DataCategory.TRACE_METRIC_BYTE` (37) to the `"traceMetric"` wire key.

It previously mapped `DataCategory.TRACE_METRIC` (33).

The relay project-config test now feeds the byte category. It expects the same `"traceMetric"` payload as before.

## Why

Billing keys trace-metric retention by the byte category. This mirrors `LOG_BYTE` → `"log"`.

No quota backend returns the item category (33). Only a synthetic test mock fed it. The old entry was dead code.

## Impact

**This change activates legacy trace-metric retention emission.** Orgs whose quota backend returns a byte-keyed trace-metric retention will now emit a `retentions.traceMetric` block in Relay project configs. This is a real TTL behavior change for those orgs.

**Do not merge.** This PR is intentionally gated. It waits on two things:

1. The decision on the emitted retention values (standard 30 vs downsampled 396 days).
2. Product/ops sign-off on activating the emission.

## Verification

- `tests/sentry/api/endpoints/test_relay_projectconfigs{,_v2}.py`: 24 passed.
- `tests/sentry/relay/`: 193 passed.
- `tests/sentry/quotas/`: 27 passed.
- `prek` hooks on the diff: passed.
- Empirical check: the mapping is now `{24: 'log', 2: 'span', 12: 'span', 37: 'traceMetric'}`. A byte-keyed retention projects to `"traceMetric"`. The item category (33) projects nothing.
