### PR TITLE
feat(issues): Add ProGuard Mapping section to issue details

### DIFF
--- a/static/app/components/events/interfaces/debugMeta/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta/index.tsx
@@ -42,20 +42,6 @@ import {combineStatus, getFileName, normalizeId} from './utils';
 const ROW_HEIGHT = 45;
 const MAX_HEIGHT = 400;
 
-function shouldSkipSection(
-  filteredImages: Image[],
-  images: EntryDebugMeta['data']['images']
-) {
-  if (filteredImages.length) {
-    return false;
-  }
-  const definedImages = images?.filter(image => defined(image));
-  if (!definedImages?.length) {
-    return true;
-  }
-  return definedImages.every(image => image.type === 'proguard');
-}
-
 function filterImages(
   images: ImageWithCombinedStatus[],
   filterSelections: Array<SelectOption<string>>,
@@ -214,7 +200,7 @@ export function DebugMeta({data, projectSlug, groupId, event}: DebugMetaProps) {
     [event, groupId, organization, projectSlug, theme, openModal]
   );
 
-  if (shouldSkipSection(filteredImages, data.images)) {
+  if (!allImages.length) {
     return null;
   }
 

--- a/static/app/components/events/interfaces/debugMeta/proguardSection.spec.tsx
+++ b/static/app/components/events/interfaces/debugMeta/proguardSection.spec.tsx
@@ -29,7 +29,7 @@ describe('ProguardSection', () => {
     const link = screen.getByRole('button', {name: 'Open in Settings'});
     expect(link).toHaveAttribute(
       'href',
-      `/settings/${organization.slug}/projects/${project.slug}/proguard/?query=${uuid}`
+      `/settings/${organization.slug}/projects/${project.slug}/debug-symbols/?query=${uuid}`
     );
   });
 

--- a/static/app/components/events/interfaces/debugMeta/proguardSection.spec.tsx
+++ b/static/app/components/events/interfaces/debugMeta/proguardSection.spec.tsx
@@ -1,0 +1,46 @@
+import {EntryDebugMetaFixture} from 'sentry-fixture/eventEntry';
+import {ImageFixture} from 'sentry-fixture/image';
+
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {ProguardSection} from 'sentry/components/events/interfaces/debugMeta/proguardSection';
+
+describe('ProguardSection', () => {
+  const {organization, project} = initializeOrg();
+  const uuid = '9d2e35ba-c1c1-4b7a-9575-8f3b0c1b4a12';
+
+  it('links the proguard uuid to the project proguard settings', async () => {
+    const entry = {
+      ...EntryDebugMetaFixture(),
+      data: {images: [ImageFixture({type: 'proguard', uuid})]},
+    };
+
+    render(<ProguardSection data={entry.data} projectSlug={project.slug} />, {
+      organization,
+    });
+
+    expect(screen.getByText('ProGuard Mapping')).toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole('button', {name: 'View ProGuard Mapping Section'})
+    );
+    expect(screen.getByText('UUID')).toBeInTheDocument();
+    expect(screen.getByText(uuid)).toBeInTheDocument();
+    const link = screen.getByRole('button', {name: 'Open in Settings'});
+    expect(link).toHaveAttribute(
+      'href',
+      `/settings/${organization.slug}/projects/${project.slug}/proguard/?query=${uuid}`
+    );
+  });
+
+  it('renders nothing without a proguard image', () => {
+    const entry = EntryDebugMetaFixture();
+
+    const {container} = render(
+      <ProguardSection data={entry.data} projectSlug={project.slug} />,
+      {organization}
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/static/app/components/events/interfaces/debugMeta/proguardSection.tsx
+++ b/static/app/components/events/interfaces/debugMeta/proguardSection.tsx
@@ -48,7 +48,7 @@ export function ProguardSection({data, projectSlug}: ProguardSectionProps) {
                 }}
                 aria-label={t('Open in Settings')}
                 to={{
-                  pathname: `/settings/${organization.slug}/projects/${projectSlug}/proguard/`,
+                  pathname: `/settings/${organization.slug}/projects/${projectSlug}/debug-symbols/`,
                   query: {query: uuid},
                 }}
               />

--- a/static/app/components/events/interfaces/debugMeta/proguardSection.tsx
+++ b/static/app/components/events/interfaces/debugMeta/proguardSection.tsx
@@ -40,10 +40,12 @@ export function ProguardSection({data, projectSlug}: ProguardSectionProps) {
               <LinkButton
                 size="xs"
                 icon={<IconOpen />}
-                title={t(
-                  'Search for this mapping file in the %s project settings',
-                  projectSlug
-                )}
+                tooltipProps={{
+                  title: t(
+                    'Search for this mapping file in the %s project settings',
+                    projectSlug
+                  ),
+                }}
                 aria-label={t('Open in Settings')}
                 to={{
                   pathname: `/settings/${organization.slug}/projects/${projectSlug}/proguard/`,

--- a/static/app/components/events/interfaces/debugMeta/proguardSection.tsx
+++ b/static/app/components/events/interfaces/debugMeta/proguardSection.tsx
@@ -1,4 +1,7 @@
+import styled from '@emotion/styled';
+
 import {LinkButton} from '@sentry/scraps/button';
+import {Flex} from '@sentry/scraps/layout';
 
 import {KeyValueList} from 'sentry/components/events/interfaces/keyValueList';
 import {IconOpen} from 'sentry/icons';
@@ -35,23 +38,25 @@ export function ProguardSection({data, projectSlug}: ProguardSectionProps) {
           {
             key: 'uuid',
             subject: t('UUID'),
-            value: <pre className="val-string">{uuid}</pre>,
-            actionButton: (
-              <LinkButton
-                size="xs"
-                icon={<IconOpen />}
-                tooltipProps={{
-                  title: t(
-                    'Search for this mapping file in the %s project settings',
-                    projectSlug
-                  ),
-                }}
-                aria-label={t('Open in Settings')}
-                to={{
-                  pathname: `/settings/${organization.slug}/projects/${projectSlug}/debug-symbols/`,
-                  query: {query: uuid},
-                }}
-              />
+            value: (
+              <Flex align="center" gap="md">
+                <UuidValue className="val-string">{uuid}</UuidValue>
+                <LinkButton
+                  size="xs"
+                  icon={<IconOpen />}
+                  tooltipProps={{
+                    title: t(
+                      'Search for this mapping file in the %s project settings',
+                      projectSlug
+                    ),
+                  }}
+                  aria-label={t('Open in Settings')}
+                  to={{
+                    pathname: `/settings/${organization.slug}/projects/${projectSlug}/debug-symbols/`,
+                    query: {query: uuid},
+                  }}
+                />
+              </Flex>
             ),
           },
         ]}
@@ -59,3 +64,7 @@ export function ProguardSection({data, projectSlug}: ProguardSectionProps) {
     </FoldSection>
   );
 }
+
+const UuidValue = styled('pre')`
+  flex-grow: 1;
+`;

--- a/static/app/components/events/interfaces/debugMeta/proguardSection.tsx
+++ b/static/app/components/events/interfaces/debugMeta/proguardSection.tsx
@@ -1,0 +1,59 @@
+import {LinkButton} from '@sentry/scraps/button';
+
+import {KeyValueList} from 'sentry/components/events/interfaces/keyValueList';
+import {IconOpen} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import type {EntryDebugMeta} from 'sentry/types/event';
+import type {Project} from 'sentry/types/project';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {SectionKey} from 'sentry/views/issueDetails/context';
+import {FoldSection} from 'sentry/views/issueDetails/foldSection';
+
+interface ProguardSectionProps {
+  data: EntryDebugMeta['data'];
+  projectSlug: Project['slug'];
+}
+
+export function ProguardSection({data, projectSlug}: ProguardSectionProps) {
+  const organization = useOrganization();
+
+  const proguardImage = data.images?.find(image => image?.type === 'proguard');
+  const uuid = proguardImage?.uuid;
+
+  if (!uuid) {
+    return null;
+  }
+
+  return (
+    <FoldSection
+      title={t('ProGuard Mapping')}
+      sectionKey={SectionKey.PROGUARD}
+      initialCollapse
+    >
+      <KeyValueList
+        data={[
+          {
+            key: 'uuid',
+            subject: t('UUID'),
+            value: <pre className="val-string">{uuid}</pre>,
+            actionButton: (
+              <LinkButton
+                size="xs"
+                icon={<IconOpen />}
+                title={t(
+                  'Search for this mapping file in the %s project settings',
+                  projectSlug
+                )}
+                aria-label={t('Open in Settings')}
+                to={{
+                  pathname: `/settings/${organization.slug}/projects/${projectSlug}/proguard/`,
+                  query: {query: uuid},
+                }}
+              />
+            ),
+          },
+        ]}
+      />
+    </FoldSection>
+  );
+}

--- a/static/app/views/issueDetails/context.tsx
+++ b/static/app/views/issueDetails/context.tsx
@@ -54,6 +54,7 @@ export const enum SectionKey {
    * Also called images loaded
    */
   DEBUGMETA = 'debugmeta',
+  PROGUARD = 'proguard',
   REQUEST = 'request',
 
   TAGS = 'tags',

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -35,6 +35,7 @@ import {
 import {Csp} from 'sentry/components/events/interfaces/csp';
 import {DebugMeta} from 'sentry/components/events/interfaces/debugMeta';
 import {DebugMetaSearchProvider} from 'sentry/components/events/interfaces/debugMeta/debugMetaSearchContext';
+import {ProguardSection} from 'sentry/components/events/interfaces/debugMeta/proguardSection';
 import {Exception} from 'sentry/components/events/interfaces/exception';
 import {Message} from 'sentry/components/events/interfaces/message';
 import {AnrRootCause} from 'sentry/components/events/interfaces/performance/anrRootCause';
@@ -356,6 +357,10 @@ export function EventDetailsContent({
               projectSlug={projectSlug}
               groupId={group?.id}
               data={eventEntries[EntryType.DEBUGMETA].data}
+            />
+            <ProguardSection
+              data={eventEntries[EntryType.DEBUGMETA].data}
+              projectSlug={projectSlug}
             />
           </EntryErrorBoundary>
         )}


### PR DESCRIPTION
## Why

Proguard debug images have been filtered out of the *Images Loaded* section since 2017 (7fc2b29bc64) because they carry no `code_file` or address range — a proguard entry only contains `{type: 'proguard', uuid}`. As a result the proguard mapping uuid of an event is not visible anywhere in the issue details UI, even though it is the key needed to locate the matching mapping file in project settings.

## What

- **New _ProGuard Mapping_ section** on issue details (Android/Java events with a proguard debug image). It shows the mapping uuid as a key/value row — same look as the SDK section — with an icon button linking to the project's debug files settings page pre-filtered by that uuid (`/settings/<org>/projects/<project>/debug-symbols/?query=<uuid>`), matching the existing debug-symbols/source-maps settings link patterns.
- **Hide _Images Loaded_ when empty**: previously an event whose debug images were all irrelevant (e.g. proguard-only) still rendered the section with an empty-state message; the section is now omitted entirely.

## Screenshots
<img width="1146" height="856" alt="Screenshot 2026-07-24 at 12 14 04" src="https://github.com/user-attachments/assets/6485e045-9c05-4421-8702-b2cc1c8ddb60" />

