### PR TITLE
fix(metrics): handle Contains filter on indexed tag in release health query builder

### DIFF
--- a/src/sentry/snuba/metrics/query_builder.py
+++ b/src/sentry/snuba/metrics/query_builder.py
@@ -22,7 +22,7 @@ from snuba_sdk import (
 from snuba_sdk.conditions import And, BooleanCondition, ConditionGroup
 from snuba_sdk.orderby import Direction, OrderBy
 
-from sentry.api.event_search import SearchFilter
+from sentry.api.event_search import ParenExpression, SearchFilter
 from sentry.api.utils import get_date_range_from_params
 from sentry.exceptions import InvalidParams, InvalidSearchQuery
 from sentry.models.project import Project
@@ -475,16 +475,23 @@ def parse_conditions(
 class ReleaseHealthQueryBuilder(UnresolvedQuery):
     config_class = SessionsDatasetConfig
 
-    def _contains_wildcard_in_query(self, query: str | None) -> bool:
-        parsed_terms = self.parse_query(query)
+    def _terms_contain_wildcard(self, parsed_terms: Sequence[Any]) -> bool:
         for parsed_term in parsed_terms:
             # Since wildcards search uses the clickhouse `match` operator that works on strings, we can't
             # use it for release health, since tags are stored as integers and converted through
-            # the indexer.
-            if isinstance(parsed_term, SearchFilter) and parsed_term.value.is_wildcard():
+            # the indexer. Wildcards can be nested inside a ParenExpression (which is how the UI
+            # combines filters, and how the `Contains`/`StartsWith`/`EndsWith` operators arrive), so
+            # we have to recurse rather than only inspecting the top-level terms.
+            if isinstance(parsed_term, ParenExpression):
+                if self._terms_contain_wildcard(parsed_term.children):
+                    return True
+            elif isinstance(parsed_term, SearchFilter) and parsed_term.value.is_wildcard():
                 return True
 
         return False
+
+    def _contains_wildcard_in_query(self, query: str | None) -> bool:
+        return self._terms_contain_wildcard(self.parse_query(query))
 
     def resolve_conditions(
         self,

--- a/tests/sentry/releases/endpoints/test_organization_release_health_data.py
+++ b/tests/sentry/releases/endpoints/test_organization_release_health_data.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 import pytest
 
+from sentry.search.events.constants import WILDCARD_OPERATOR_MAP
 from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.snuba.metrics.naming_layer.mri import ParsedMRI, SessionMRI, TransactionMRI
@@ -489,6 +490,44 @@ class OrganizationReleaseHealthDataTest(MetricsAPIBaseTestCase):
             groupBy="release",
             environment="Release",
             query='!release:"0.99.0 (*)"',
+            statsPeriod="14d",
+            interval="1h",
+            includeTotals="1",
+            includeSeries="0",
+            status_code=400,
+        )
+
+        assert (
+            response.data["detail"]
+            == "Failed to parse conditions: Release Health Queries don't support wildcards"
+        )
+
+    def test_query_with_contains_operator_on_environment(self) -> None:
+        """
+        Regression test for SENTRY-5PKE: a "Contains" (substring) filter on an
+        indexed tag such as ``environment`` is translated into a ClickHouse
+        ``match()`` regex condition. Release health tags are stored as UInt64
+        indexer values, so ``match()`` crashes Snuba with a code 43
+        (QueryIllegalTypeOfArgument) error.
+
+        The wildcard guard must reject these queries with a 400 even when the
+        filter is nested inside a parenthesized group (which is how the UI emits
+        combined filters and the ``Contains`` operator), instead of letting the
+        invalid query reach Snuba.
+        """
+        rh_indexer_record(self.organization.id, "session.crash_free_user_rate")
+        self.build_and_store_session(
+            project_id=self.project.id,
+        )
+        # WILDCARD_OPERATOR_MAP["contains"] is the internal "Contains" operator the
+        # search UI emits; it expands to a leading/trailing wildcard (*production*).
+        # Nest it in a parenthesized group to mirror how the UI combines filters.
+        contains_production = f"{WILDCARD_OPERATOR_MAP['contains']}production"
+        response = self.get_error_response(
+            self.organization.slug,
+            field="session.crash_free_user_rate",
+            groupBy="release",
+            query=f"(environment:{contains_production})",
             statsPeriod="14d",
             interval="1h",
             includeTotals="1",


### PR DESCRIPTION
## Summary

The release health metrics endpoint (`GET /api/0/organizations/{org}/metrics/data/`, handled by `OrganizationReleaseHealthDataEndpoint`) returned a 500 when a **"Contains"** (substring) filter was applied to an indexed tag such as `environment`.

- **Sentry issue:** https://sentry.sentry.io/issues/SENTRY-5PKE
- **Dispatching session:** https://claude.ai/code/session_01DATMfhjiSzSmzwsgvaDByq
- **Error:** `QueryIllegalTypeOfArgument: Received ClickHouse exception, code: 43 ... Illegal type UInt64 of argument of function match`

## Root cause

Release-health tag values (including `environment`) are stored in the `metrics_sets` ClickHouse table as **UInt64 indexer values**, not strings, so ClickHouse's `match()` (regex) function cannot be applied to them.

`ReleaseHealthQueryBuilder` already knows this and guards against wildcard searches via `_contains_wildcard_in_query`, converting them into a clean `400 ParseError` ("Release Health Queries don't support wildcards"). The bug is that the guard only inspected the **top-level** parsed terms:

```python
for parsed_term in parsed_terms:
    if isinstance(parsed_term, SearchFilter) and parsed_term.value.is_wildcard():
        return True
```

The `Contains` / `StartsWith` / `EndsWith` operators expand to a wildcard value (`Contains` + `production` -> `*production*`, `is_wildcard() == True`). When the filter arrives **nested inside a `ParenExpression`** — which is how the search UI combines filters — the term the loop sees is the `ParenExpression`, not the `SearchFilter`, so `isinstance(..., SearchFilter)` is `False` and the wildcard slips through. `_environment_filter_converter` (`src/sentry/search/events/builder/base.py`) then emits `Condition(Function("match", [environment, "(?i)^.*production.*$"]), Op.EQ, 1)`, `resolve_tags` passes the `match` function straight through to the metrics dataset, and Snuba rejects it with ClickHouse code 43.

## Fix

Make wildcard detection recurse into `ParenExpression` so a wildcard anywhere in the query (top-level, parenthesized, or nested) is rejected early with the existing `400 ParseError`, before the invalid `match()` condition is ever built.

This is a root-cause fix at the point of bad-query construction, not a catch of the downstream ClickHouse exception.

## What was ruled out

- **Catching `QueryIllegalTypeOfArgument` in the endpoint** — symptom-only; leaves the invalid query being sent to Snuba. Rejected in favor of fixing the guard.
- **The `?environment=` query parameter path (`resolve_params`)** — this path resolves environment values by looking up real `Environment` rows by name and never produces a wildcard `match()`, so it is not the source. The `match()` comes exclusively from the query-string path via `resolve_conditions`.
- **The single, top-level `environment:Contains…` case** — already correctly rejected by the existing guard (verified below); the gap is specifically nested (parenthesized) wildcards.

## Test evidence

Added `test_query_with_contains_operator_on_environment` to `tests/sentry/releases/endpoints/test_organization_release_health_data.py`, asserting a `Contains` filter on `environment` nested in a parenthesized group returns a 400 with the "don't support wildcards" detail.

Because this sandbox has no running Snuba/ClickHouse/Postgres services, the full `MetricsAPIBaseTestCase` integration test could not be executed here. The fix was instead verified at the unit level against the **real** parser and the **real** `ReleaseHealthQueryBuilder` guard method:

```
query case      current guard   fixed guard
single          True            True
paren           False   <-- BUG  True
paren-or        False   <-- BUG  True
nested-paren    False   <-- BUG  True
no-wildcard     False           False
literal-star    True            True
```

The `paren*` rows are the crash cases: the old guard returned `False` (wildcard slips through to Snuba -> 500); the fixed guard returns `True` (clean 400). Non-wildcard queries are unaffected.

`ruff check` and `ruff format --check` pass on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DATMfhjiSzSmzwsgvaDByq

---
_Generated by [Claude Code](https://claude.ai/code/session_01DATMfhjiSzSmzwsgvaDByq)_