### PR TITLE
fix(pr-metrics): merge attribution-carried group_ids into scm.pr.closed

### DIFF
--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -37,6 +37,7 @@ from sentry.pr_metrics.contracts import (
     PrConversationAnalysis,
 )
 from sentry.pr_metrics.utils import (
+    group_ids_from_attributions,
     is_activity_tracking_enabled,
     iso_or_none,
     load_activity_document,
@@ -741,11 +742,18 @@ def emit_pr_metrics_row(
     close_action: CloseAction = (
         CLOSE_ACTION_MERGED if pull_request.merged_at is not None else CLOSE_ACTION_CLOSED
     )
+    # Union the GroupLink-derived ids with whatever attribution rows carry in
+    # their signal_details, so a group id attributed only through Seer data
+    # (never exposed back via a GitHub-parseable "Fixes #123" reference) isn't
+    # dropped from the emitted row.
+    group_ids = sorted(
+        set(resolved_group_ids(pull_request)) | set(group_ids_from_attributions(attributions))
+    )
     row = build_pr_metrics_row(
         pull_request=pull_request,
         close_action=close_action,
         attributions=attributions,
-        group_ids=resolved_group_ids(pull_request),
+        group_ids=group_ids,
         conversation_analysis=conversation_analysis,
         diagnosis_labels=diagnosis_labels,
     )

--- a/src/sentry/pr_metrics/utils.py
+++ b/src/sentry/pr_metrics/utils.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import logging
+from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta
-from typing import cast
+from typing import Any, cast
 
 from django.db.models import Q
 from django.utils import timezone
@@ -26,6 +28,8 @@ from sentry.models.pullrequest import (
 )
 from sentry.pr_metrics.activity_doc import ActivityDoc, commit_shas_from_doc
 from sentry.seer.models import SeerAgentRun, SeerRunPullRequest
+
+logger = logging.getLogger(__name__)
 
 _PR_ACTIVITY_ATTRIBUTION_BUFFER = timedelta(hours=30)
 
@@ -252,6 +256,50 @@ def resolved_group_ids(pull_request: PullRequest) -> list[int]:
         combined = pr_filter
 
     return sorted(GroupLink.objects.filter(combined).values_list("group_id", flat=True).distinct())
+
+
+def group_ids_from_attributions(attributions: Sequence[Mapping[str, Any]]) -> list[int]:
+    """Group IDs carried in the PR's attribution ``signal_details``.
+
+    ``signal_details["group_ids"]`` is a ``list[int]`` for ``SENTRY_APP`` and
+    ``SEER_DELEGATED_*`` signals (see ``SentryAppSignalDetails`` /
+    ``DelegatedAgentSignalDetails``), but the ``MCP`` signal instead stores a
+    ``dict[str, str]`` mapping group id (as a string key) to client family (see
+    ``_write_mcp_attribution``). Both shapes are read here so a group id
+    attributed only through MCP isn't dropped.
+
+    This exists because attribution can be written from data GitHub never
+    exposes back to us (e.g. a Seer run's target group), so the high-level
+    ``resolved_group_ids`` GroupLink lookup alone can miss it.
+
+    ``signal_details`` is an unstructured, nullable JSONField, and one producer
+    (the Seer judge RPC callback) merges in caller-supplied data — so a
+    malformed entry is tolerated (skipped) rather than raising and aborting
+    emission for the whole PR.
+    """
+    group_ids: set[int] = set()
+    for attribution in attributions:
+        details = attribution.get("signal_details")
+        if not details:
+            continue
+        raw_group_ids = details.get("group_ids")
+        if not raw_group_ids:
+            continue
+        # A dict (MCP) iterates its string keys; a list (everything else)
+        # iterates its int elements. Either way, coerce to int.
+        for group_id in raw_group_ids:
+            try:
+                group_ids.add(int(group_id))
+            except (TypeError, ValueError):
+                logger.warning(
+                    "pr_metrics.group_ids_from_attributions.malformed_group_id",
+                    extra={
+                        "signal_type": attribution.get("signal_type"),
+                        "source": attribution.get("source"),
+                        "group_id": group_id,
+                    },
+                )
+    return sorted(group_ids)
 
 
 def seer_run_link_for_pull_request(pull_request: PullRequest) -> tuple[list[int], int | None]:

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -30,7 +30,11 @@ from sentry.pr_metrics.emit import (
     select_fallback_verdict,
     select_verdict,
 )
-from sentry.pr_metrics.utils import _commit_shas_from_activity, resolved_group_ids
+from sentry.pr_metrics.utils import (
+    _commit_shas_from_activity,
+    group_ids_from_attributions,
+    resolved_group_ids,
+)
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.analytics import assert_last_analytics_event
@@ -763,6 +767,45 @@ class PrMetricsEmissionTest(TestCase):
     def test_resolved_group_ids_empty_when_pr_resolves_nothing(self) -> None:
         assert resolved_group_ids(self.pull_request) == []
 
+    def test_group_ids_from_attributions_dedupes_and_sorts_across_rows(self) -> None:
+        attributions = [
+            {
+                "signal_type": "sentry_app",
+                "source": "seer_data",
+                "signal_details": {"group_ids": [9, 10]},
+            },
+            {
+                "signal_type": "mcp",
+                "source": "webhook_data",
+                "signal_details": {"group_ids": {"7": "claude", "9": "cursor"}},
+            },
+        ]
+        assert group_ids_from_attributions(attributions) == [7, 9, 10]
+
+    def test_group_ids_from_attributions_empty_when_no_signal_details(self) -> None:
+        attributions = [
+            {"signal_type": "sentry_app", "source": "seer_data", "signal_details": None},
+            {
+                "signal_type": "sentry_app",
+                "source": "webhook_data",
+                "signal_details": {"pr_url": "https://github.com/owner/repo/pulls/123"},
+            },
+        ]
+        assert group_ids_from_attributions(attributions) == []
+
+    def test_group_ids_from_attributions_skips_malformed_entries(self) -> None:
+        # signal_details is an unstructured JSONField that one producer (the
+        # Seer judge RPC callback) populates from caller-supplied data — a
+        # non-numeric entry should be dropped, not raise and abort emission.
+        attributions = [
+            {
+                "signal_type": "seer_delegated:claude_code",
+                "source": "webhook_data",
+                "signal_details": {"group_ids": ["not-a-number", 9]},
+            }
+        ]
+        assert group_ids_from_attributions(attributions) == [9]
+
     def test_build_row_carries_group_ids(self) -> None:
         row = build_pr_metrics_row(
             pull_request=self.pull_request,
@@ -1264,6 +1307,33 @@ class PrMetricsEmissionTest(TestCase):
         self._sync_activity(after_sha="a" * 40, before_sha="b" * 40, webhook_id="s1")
         emit_pr_metrics_row(pull_request=self.pull_request)
         assert mock_record.call_args[0][0].group_ids == [group_id]
+
+    @patch("sentry.analytics.record")
+    def test_emit_merges_group_ids_carried_only_by_attribution(self, mock_record: Any) -> None:
+        # A group id attributed via Seer data (e.g. the run's target group) may
+        # never surface as a resolving GroupLink — the PR text never referenced
+        # it. It should still make it into the emitted row's group_ids.
+        linked_group_id = self._link_group()
+        self._track(
+            PullRequestAttributionSignalType.SEER_DELEGATED_CLAUDE_CODE,
+            source=PullRequestAttributionSource.WEBHOOK_DATA,
+            signal_details={"group_ids": [linked_group_id + 1000]},
+        )
+        emit_pr_metrics_row(pull_request=self.pull_request)
+        assert mock_record.call_args[0][0].group_ids == sorted(
+            [linked_group_id, linked_group_id + 1000]
+        )
+
+    @patch("sentry.analytics.record")
+    def test_emit_merges_mcp_dict_shaped_attribution_group_ids(self, mock_record: Any) -> None:
+        self._track()
+        self._track(
+            PullRequestAttributionSignalType.MCP,
+            source=PullRequestAttributionSource.WEBHOOK_DATA,
+            signal_details={"group_ids": {"321": "claude_code"}},
+        )
+        emit_pr_metrics_row(pull_request=self.pull_request)
+        assert mock_record.call_args[0][0].group_ids == [321]
 
     @patch("sentry.pr_metrics.tasks.cleanup_pr_activity_task")
     @patch("sentry.analytics.record")


### PR DESCRIPTION
`resolved_group_ids()` only finds groups linked via a `GroupLink` row, which is written by parsing GitHub-style `Fixes/Closes/Resolves #123` references out of the PR title/body/commit messages at open/sync time. If the PR description changes after that (or never included such a reference), the `GroupLink` can be missing or stale, so the high-level `group_ids` on the emitted `scm.pr.closed` event comes back empty or incomplete.

We have a HEX dashboard showing a non-trivial number of `scm.pr.closed` rows where the high-level `group_ids` is empty/missing but a `group_id`/`group_ids` value is still present in the row's `attributions` (`signal_details`). This is exactly that gap: `PullRequestAttribution.signal_details` is written from other sources (e.g. a Seer delegated agent run, or MCP) that know the PR's target group independently of the PR text, and those values are persisted once at attribution time rather than being re-derived from the (mutable) PR description like `GroupLink` is.

This PR adds `group_ids_from_attributions()` in `pr_metrics/utils.py`, which reads `signal_details["group_ids"]` across both shapes producers use today (`list[int]` for `SENTRY_APP`/`SEER_DELEGATED_*`, a `{group_id: client_family}` dict for `MCP`), and unions it with `resolved_group_ids()` in `emit_pr_metrics_row`. So a group id known only through attribution — never expressed as a GitHub-parseable reference — now makes it into the emitted `group_ids`, closing the gap visible on the dashboard.

Since `signal_details` is an unstructured, nullable JSONField and one producer (the Seer judge RPC callback) merges in caller-supplied data, malformed entries are skipped with a `logger.warning` rather than raising and aborting emission for the whole PR.