### PR TITLE
feat(profiling): Show qualified java frame names in continuous profile flamegraphs

### DIFF
--- a/static/app/utils/profiling/frame.spec.tsx
+++ b/static/app/utils/profiling/frame.spec.tsx
@@ -94,6 +94,51 @@ describe('Frame', () => {
     });
   });
 
+  describe('java frames', () => {
+    it('qualifies name with module', () => {
+      expect(
+        new Frame(
+          {
+            key: 0,
+            name: 'call',
+            module: 'rx.internal.util.ScalarSynchronousObservable$ScalarAsyncOnSubscribe',
+            platform: 'java',
+          },
+          'mobile'
+        ).name
+      ).toBe('rx.internal.util.ScalarSynchronousObservable$ScalarAsyncOnSubscribe.call');
+    });
+
+    it('shows only module for constructors', () => {
+      expect(
+        new Frame(
+          {
+            key: 0,
+            name: '<init>',
+            module: 'com.example.Foo',
+            platform: 'java',
+          },
+          'mobile'
+        ).name
+      ).toBe('com.example.Foo');
+    });
+
+    it('keeps bare name when module is missing', () => {
+      expect(
+        new Frame({key: 0, name: 'art_jni_trampoline', platform: 'java'}, 'mobile').name
+      ).toBe('art_jni_trampoline');
+    });
+
+    it('does not qualify non-java frames', () => {
+      expect(
+        new Frame(
+          {key: 0, name: 'memcpy', module: 'libc.so', platform: 'native'},
+          'mobile'
+        ).name
+      ).toBe('memcpy');
+    });
+  });
+
   it('formats getSourceLocation', () => {
     const frame = new Frame(
       {

--- a/static/app/utils/profiling/frame.tsx
+++ b/static/app/utils/profiling/frame.tsx
@@ -72,6 +72,12 @@ export class Frame {
           : 0
         : undefined;
 
+    // Java frames are shown fully qualified as <module>.<function>.
+    // For constructors ("<init>") the class name alone is more readable.
+    if (this.platform === 'java' && this.module) {
+      this.name = this.name === '<init>' ? this.module : `${this.module}.${this.name}`;
+    }
+
     // We are remapping some of the keys as they differ between platforms.
     // This is a temporary solution until we adopt a unified format.
     if (frame.columnNumber && this.column === undefined) {

--- a/static/app/utils/profiling/profile/utils.tsx
+++ b/static/app/utils/profiling/profile/utils.tsx
@@ -17,9 +17,9 @@ export function createContinuousProfileFrameIndex(
 
   for (let i = 0; i < frames.length; i++) {
     const frame = frames[i]!;
-    const frameKey = `${frame.filename ?? ''}:${frame.function ?? 'unknown'}:${String(
-      frame.lineno
-    )}:${frame.instruction_addr ?? ''}`;
+    const frameKey = `${frame.filename ?? ''}:${frame.module ?? ''}:${
+      frame.function ?? 'unknown'
+    }:${String(frame.lineno)}:${frame.instruction_addr ?? ''}`;
 
     const existing = insertionCache[frameKey];
     if (existing) {
@@ -42,6 +42,7 @@ export function createContinuousProfileFrameIndex(
         symbol: frame.symbol,
         symbolAddr: frame.sym_addr,
         symbolicatorStatus: frame.status,
+        platform: frame.platform,
       },
       platform
     );

--- a/static/app/views/explore/profiling/landing/slowestFunctionsWidget.spec.tsx
+++ b/static/app/views/explore/profiling/landing/slowestFunctionsWidget.spec.tsx
@@ -45,7 +45,15 @@ describe('SlowestFunctionsWidget', () => {
       match: [
         MockApiClient.matchQuery({
           dataset: 'profileFunctions',
-          field: ['project.id', 'fingerprint', 'package', 'function', 'count()', 'sum()'],
+          field: [
+            'project.id',
+            'fingerprint',
+            'package',
+            'function',
+            'platform.name',
+            'count()',
+            'sum()',
+          ],
         }),
       ],
     });
@@ -84,7 +92,15 @@ describe('SlowestFunctionsWidget', () => {
       match: [
         MockApiClient.matchQuery({
           dataset: 'profileFunctions',
-          field: ['project.id', 'fingerprint', 'package', 'function', 'count()', 'sum()'],
+          field: [
+            'project.id',
+            'fingerprint',
+            'package',
+            'function',
+            'platform.name',
+            'count()',
+            'sum()',
+          ],
         }),
       ],
     });
@@ -251,5 +267,79 @@ describe('SlowestFunctionsWidget', () => {
     // Check items in example profiles dropdown
     expect(screen.getByText('1'.repeat(8))).toBeInTheDocument();
     expect(screen.getByText('2'.repeat(8))).toBeInTheDocument();
+  });
+
+  it('qualifies java function names with the class name', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {
+        data: [
+          {
+            'project.id': 1,
+            fingerprint: 123,
+            package: 'com.example.Foo',
+            function: 'bar',
+            'platform.name': 'android',
+            'sum()': 150,
+          },
+          {
+            'project.id': 1,
+            fingerprint: 456,
+            package: 'com.example.legacy',
+            function: 'com.example.legacy.Baz.qux()',
+            'platform.name': 'android',
+            'sum()': 100,
+          },
+          {
+            'project.id': 1,
+            fingerprint: 789,
+            package: 'libhwui',
+            function: 'memcpy',
+            'platform.name': 'android',
+            'sum()': 50,
+          },
+        ],
+      },
+      match: [
+        MockApiClient.matchQuery({
+          dataset: 'profileFunctions',
+          field: [
+            'project.id',
+            'fingerprint',
+            'package',
+            'function',
+            'platform.name',
+            'count()',
+            'sum()',
+          ],
+        }),
+      ],
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {data: [{'project.id': 1, 'sum()': 2500000}]},
+      match: [
+        MockApiClient.matchQuery({
+          dataset: 'profileFunctions',
+          field: ['project.id', 'sum()'],
+          project: [1],
+        }),
+      ],
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      body: {},
+    });
+
+    render(<SlowestFunctionsWidget widgetHeight="100px" breakdownFunction="p75()" />);
+
+    // continuous profile frames are qualified with the class name
+    expect(await screen.findByText('com.example.Foo.bar')).toBeInTheDocument();
+    // legacy android frames are already fully qualified
+    expect(screen.getByText('com.example.legacy.Baz.qux()')).toBeInTheDocument();
+    // native frames are left untouched
+    expect(screen.getByText('memcpy')).toBeInTheDocument();
   });
 });

--- a/static/app/views/explore/profiling/landing/slowestFunctionsWidget.tsx
+++ b/static/app/views/explore/profiling/landing/slowestFunctionsWidget.tsx
@@ -340,11 +340,14 @@ function SlowestFunctionEntry<F extends BreakdownFunction>({
   const palette = Array.from<[string]>({length: BARS}).fill([colors[0]]);
 
   const frame = useMemo(() => {
+    const module = qualifiedJavaFrameModule(func);
     return new Frame(
       {
         key: 0,
         name: func.function as string,
         package: func.package as string,
+        module,
+        platform: module ? 'java' : undefined,
       },
       // Ensures that the frame runs through the normalization code path
       project?.platform && /node|javascript/.test(project.platform)
@@ -565,11 +568,38 @@ const functionsFields = [
   'fingerprint',
   'package',
   'function',
+  'platform.name',
   'count()',
   'sum()',
 ] as const;
 
 type FunctionsField = (typeof functionsFields)[number] | SortOption;
+
+// For java frames from continuous profiles, `function` is the bare method
+// name and `package` the fully qualified class name. Passing the class name
+// as the frame module lets the Frame model qualify the display name.
+// Legacy android profiles already ship fully qualified function names and
+// native frames carry a binary name (no dots) as package - both are skipped.
+function qualifiedJavaFrameModule(
+  func: EventsResultsDataRow<FunctionsField>
+): string | undefined {
+  const platform = String(func['platform.name'] ?? '');
+  if (platform !== 'android' && !platform.startsWith('java')) {
+    return undefined;
+  }
+
+  const pkg = func.package;
+  const fn = func.function;
+  if (typeof pkg !== 'string' || typeof fn !== 'string' || !pkg.includes('.')) {
+    return undefined;
+  }
+
+  if (fn === pkg || fn.startsWith(`${pkg}.`)) {
+    return undefined;
+  }
+
+  return pkg;
+}
 
 const totalsFields = ['project.id', 'sum()'] as const;
 


### PR DESCRIPTION
For continuous (sample-v2) Android chunks, java frames carry the fully qualified class name in `module` and the bare method name in `function`, so the flamegraph and frame search only showed e.g. `call` instead of `rx.internal.util.ScalarSynchronousObservable$ScalarAsyncOnSubscribe.call`.

The legacy Android format doesn't have this problem because vroom pre-joins class and method name backend-side. This applies the same display logic in the frontend `Frame` model: java frames with a `module` are shown as `<module>.<function>`, with constructors (`<init>`) shown as just the class name.

Also passes the per-frame `platform` through in `createContinuousProfileFrameIndex` and includes `module` in the frame dedup key so same-named methods from different classes aren't merged.

The Slowest Functions widget gets the same treatment: for java rows from continuous profiles (where `package` is the fully qualified class name), the class name is passed as the frame module so the displayed name and the example-profile deep links (`frameName`/`framePackage`) match the now-qualified flamegraph frame names. Legacy android rows (already qualified) and native frames are left untouched.