### PR TITLE
feat(explore): Register conversations list chart referrer

### DIFF
--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -120,6 +120,8 @@ class Referrer(StrEnum):
 
     # ** Explore **
     API_EXPLORE_CONVERSATIONS_LIST_CHART = "api.explore.conversations.list.chart"
+    API_EXPLORE_CONVERSATIONS_ONBOARDING = "api.explore.conversations.onboarding"
+    API_EXPLORE_CONVERSATIONS_GET_AGENT_NAMES = "api.explore.conversations.get-agent-names"
     API_EXPLORE_SPANS_TIMESERIES = "api.explore.spans-timeseries"
     API_EXPLORE_OURLOGS_TIMESERIES = "api.explore.ourlogs-timeseries"
     API_EXPLORE_TRACEMETRICS_TIMESERIES = "api.explore.tracemetrics-timeseries"

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -119,6 +119,7 @@ class Referrer(StrEnum):
     API_GROUP_HASHES = "api.group-hashes"
 
     # ** Explore **
+    API_EXPLORE_CONVERSATIONS_LIST_CHART = "api.explore.conversations.list.chart"
     API_EXPLORE_SPANS_TIMESERIES = "api.explore.spans-timeseries"
     API_EXPLORE_OURLOGS_TIMESERIES = "api.explore.ourlogs-timeseries"
     API_EXPLORE_TRACEMETRICS_TIMESERIES = "api.explore.tracemetrics-timeseries"


### PR DESCRIPTION
Register three AI Conversations referrers in the `Referrer` enum:

- `api.explore.conversations.list.chart`
- `api.explore.conversations.onboarding`
- `api.explore.conversations.get-agent-names`

The frontend (`static/app/views/explore/conversations/`) will send these to the `events-timeseries` and `events` endpoints