### PR TITLE
feat(conversations): Add usage chart to the conversations list

### DIFF
--- a/static/app/views/explore/conversations/components/conversationsChart.spec.tsx
+++ b/static/app/views/explore/conversations/components/conversationsChart.spec.tsx
@@ -1,0 +1,154 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {TimeSeriesFixture} from 'sentry-fixture/timeSeries';
+
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {ConversationsChart} from 'sentry/views/explore/conversations/components/conversationsChart';
+
+describe('ConversationsChart', () => {
+  const organization = OrganizationFixture();
+
+  let timeseriesRequest: jest.Mock;
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+
+    timeseriesRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events-timeseries/`,
+      body: {
+        timeSeries: [
+          TimeSeriesFixture({
+            yAxis: 'sum(gen_ai.cost.total_tokens)',
+            meta: {valueType: 'number', valueUnit: null, interval: 1_800_000},
+          }),
+        ],
+      },
+    });
+  });
+
+  it('fetches the cost timeseries by default', async () => {
+    render(<ConversationsChart />, {organization});
+
+    await waitFor(() => {
+      expect(timeseriesRequest).toHaveBeenCalledWith(
+        `/organizations/${organization.slug}/events-timeseries/`,
+        expect.objectContaining({
+          query: expect.objectContaining({
+            yAxis: ['sum(gen_ai.cost.total_tokens)'],
+            query: 'has:gen_ai.conversation.id gen_ai.operation.type:ai_client',
+          }),
+        })
+      );
+    });
+
+    expect(screen.getByRole('button', {name: 'Cost'})).toBeInTheDocument();
+  });
+
+  it('switches the visualization via the title dropdown', async () => {
+    const {router} = render(<ConversationsChart />, {organization});
+
+    await userEvent.click(screen.getByRole('button', {name: 'Cost'}));
+    await userEvent.click(screen.getByRole('option', {name: 'Individual Chats'}));
+
+    await waitFor(() => {
+      expect(router.location.query.chartVisualization).toBe('chats');
+    });
+
+    expect(
+      await screen.findByRole('button', {name: 'Individual Chats'})
+    ).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(timeseriesRequest).toHaveBeenCalledWith(
+        `/organizations/${organization.slug}/events-timeseries/`,
+        expect.objectContaining({
+          query: expect.objectContaining({
+            yAxis: ['count_unique(gen_ai.conversation.id)'],
+            query: 'has:gen_ai.conversation.id',
+          }),
+        })
+      );
+    });
+  });
+
+  it('fetches the total messages timeseries', async () => {
+    render(<ConversationsChart />, {organization});
+
+    await userEvent.click(screen.getByRole('button', {name: 'Cost'}));
+    await userEvent.click(screen.getByRole('option', {name: 'Total Messages'}));
+
+    await waitFor(() => {
+      expect(timeseriesRequest).toHaveBeenCalledWith(
+        `/organizations/${organization.slug}/events-timeseries/`,
+        expect.objectContaining({
+          query: expect.objectContaining({
+            yAxis: ['count(span.duration)'],
+            query: 'has:gen_ai.conversation.id gen_ai.operation.type:ai_client',
+          }),
+        })
+      );
+    });
+  });
+
+  it('switches the chart type', async () => {
+    const {router} = render(<ConversationsChart />, {organization});
+
+    await userEvent.click(screen.getByRole('button', {name: 'Bar'}));
+    await userEvent.click(screen.getByRole('option', {name: 'Line'}));
+
+    await waitFor(() => {
+      expect(router.location.query.chartType).toBe('line');
+    });
+
+    expect(screen.getByRole('button', {name: 'Line'})).toBeInTheDocument();
+  });
+
+  it('applies the search query and agent filter to the timeseries request', async () => {
+    render(<ConversationsChart />, {
+      organization,
+      initialRouterConfig: {
+        location: {
+          pathname: '/',
+          query: {query: 'gen_ai.agent.name:my-agent'},
+        },
+      },
+    });
+
+    await waitFor(() => {
+      expect(timeseriesRequest).toHaveBeenCalledWith(
+        `/organizations/${organization.slug}/events-timeseries/`,
+        expect.objectContaining({
+          query: expect.objectContaining({
+            query:
+              '(has:gen_ai.conversation.id gen_ai.operation.type:ai_client) and (gen_ai.agent.name:my-agent)',
+          }),
+        })
+      );
+    });
+  });
+
+  it('shows an empty state when there is no data', async () => {
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events-timeseries/`,
+      body: {timeSeries: []},
+    });
+
+    render(<ConversationsChart />, {organization});
+
+    expect(await screen.findByText('No Data')).toBeInTheDocument();
+  });
+
+  it('shows an error state when the request fails', async () => {
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events-timeseries/`,
+      statusCode: 500,
+      body: {detail: 'Internal Error'},
+    });
+
+    render(<ConversationsChart />, {organization});
+
+    expect(await screen.findByText('Internal Error')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/explore/conversations/components/conversationsChart.tsx
+++ b/static/app/views/explore/conversations/components/conversationsChart.tsx
@@ -100,6 +100,11 @@ export function ConversationsChart() {
     ];
   }, [timeSeries, chartType, label]);
 
+  const chartTypeLabel =
+    CHART_TYPE_OPTIONS.find(option => option.value === chartType)?.label ?? '';
+  const intervalLabel =
+    intervalOptions.find(option => option.value === interval)?.label ?? interval;
+
   const Title = (
     <CompactSelect
       trigger={triggerProps => (
@@ -126,7 +131,7 @@ export function ConversationsChart() {
               variant="transparent"
               size="xs"
             >
-              {CHART_TYPE_OPTIONS.find(option => option.value === chartType)?.label}
+              {chartTypeLabel}
             </OverlayTrigger.Button>
           )}
           value={chartType}
@@ -144,7 +149,7 @@ export function ConversationsChart() {
               variant="transparent"
               size="xs"
             >
-              {intervalOptions.find(option => option.value === interval)?.label}
+              {intervalLabel}
             </OverlayTrigger.Button>
           )}
           value={interval}

--- a/static/app/views/explore/conversations/components/conversationsChart.tsx
+++ b/static/app/views/explore/conversations/components/conversationsChart.tsx
@@ -1,0 +1,188 @@
+import {Fragment, useMemo} from 'react';
+import styled from '@emotion/styled';
+import {parseAsStringLiteral, useQueryState} from 'nuqs';
+
+import {CompactSelect} from '@sentry/scraps/compactSelect';
+import {Container} from '@sentry/scraps/layout';
+import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
+import {Heading} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import {IconClock, IconGraph} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {markDelayedData} from 'sentry/utils/timeSeries/markDelayedData';
+import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
+import {
+  ChartIntervalUnspecifiedStrategy,
+  useChartInterval,
+} from 'sentry/utils/useChartInterval';
+import {MISSING_DATA_MESSAGE} from 'sentry/views/dashboards/widgets/common/settings';
+import {Bars} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/bars';
+import {Line} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/line';
+import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
+import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
+import {Referrer} from 'sentry/views/explore/conversations/utils/referrers';
+import {useCombinedQuery} from 'sentry/views/insights/pages/agents/hooks/useCombinedQuery';
+import {INGESTION_DELAY} from 'sentry/views/insights/settings';
+import {SpanFields} from 'sentry/views/insights/types';
+
+const CONVERSATION_SPANS_FILTER = `has:${SpanFields.GEN_AI_CONVERSATION_ID}`;
+const AI_CLIENT_FILTER = `${SpanFields.GEN_AI_OPERATION_TYPE}:ai_client`;
+
+const CHART_VISUALIZATIONS = {
+  cost: {
+    label: t('Cost'),
+    yAxis: `sum(${SpanFields.GEN_AI_COST_TOTAL_TOKENS})`,
+    filter: `${CONVERSATION_SPANS_FILTER} ${AI_CLIENT_FILTER}`,
+  },
+  messages: {
+    label: t('Total Messages'),
+    yAxis: `count(${SpanFields.SPAN_DURATION})`,
+    filter: `${CONVERSATION_SPANS_FILTER} ${AI_CLIENT_FILTER}`,
+  },
+  chats: {
+    label: t('Individual Chats'),
+    yAxis: `count_unique(${SpanFields.GEN_AI_CONVERSATION_ID})`,
+    filter: CONVERSATION_SPANS_FILTER,
+  },
+} as const satisfies Record<string, {filter: string; label: string; yAxis: string}>;
+
+type ChartVisualizationKey = keyof typeof CHART_VISUALIZATIONS;
+
+const VISUALIZATION_OPTIONS = Object.entries(CHART_VISUALIZATIONS).map(
+  ([value, {label}]) => ({value: value as ChartVisualizationKey, label})
+);
+
+const CHART_TYPE_OPTIONS = [
+  {value: 'line' as const, label: t('Line')},
+  {value: 'bar' as const, label: t('Bar')},
+];
+
+const visualizationParser = parseAsStringLiteral(
+  Object.keys(CHART_VISUALIZATIONS) as ChartVisualizationKey[]
+).withDefault('cost');
+
+const chartTypeParser = parseAsStringLiteral(['line', 'bar'] as const).withDefault('bar');
+
+export function ConversationsChart() {
+  const [visualization, setVisualization] = useQueryState(
+    'chartVisualization',
+    visualizationParser
+  );
+  const [chartType, setChartType] = useQueryState('chartType', chartTypeParser);
+  const [interval, setInterval, intervalOptions] = useChartInterval({
+    unspecifiedStrategy: ChartIntervalUnspecifiedStrategy.USE_BIGGEST,
+  });
+
+  const {label, yAxis, filter} = CHART_VISUALIZATIONS[visualization];
+  const query = useCombinedQuery(filter);
+
+  const {data, isPending, error} = useFetchSpanTimeSeries(
+    {
+      yAxis: [yAxis],
+      query,
+      interval,
+    },
+    Referrer.CHART
+  );
+
+  const timeSeries = data?.timeSeries[0];
+
+  const plottables = useMemo(() => {
+    if (!timeSeries) {
+      return [];
+    }
+    const PlottableConstructor = chartType === 'line' ? Line : Bars;
+    return [
+      new PlottableConstructor(markDelayedData(timeSeries, INGESTION_DELAY), {
+        alias: label,
+      }),
+    ];
+  }, [timeSeries, chartType, label]);
+
+  const Title = (
+    <CompactSelect
+      trigger={triggerProps => (
+        <TitleTrigger {...triggerProps} variant="transparent" size="xs">
+          <Heading as="h3" size="lg">
+            {label}
+          </Heading>
+        </TitleTrigger>
+      )}
+      value={visualization}
+      options={VISUALIZATION_OPTIONS}
+      onChange={option => setVisualization(option.value)}
+    />
+  );
+
+  const Actions = (
+    <Fragment>
+      <Tooltip title={t('Type of chart displayed in this visualization (ex. line)')}>
+        <CompactSelect
+          trigger={triggerProps => (
+            <OverlayTrigger.Button
+              {...triggerProps}
+              icon={<IconGraph type={chartType} />}
+              variant="transparent"
+              size="xs"
+            >
+              {CHART_TYPE_OPTIONS.find(option => option.value === chartType)?.label}
+            </OverlayTrigger.Button>
+          )}
+          value={chartType}
+          menuTitle={t('Type')}
+          options={CHART_TYPE_OPTIONS}
+          onChange={option => setChartType(option.value)}
+        />
+      </Tooltip>
+      <Tooltip title={t('Time interval displayed in this visualization (ex. 5m)')}>
+        <CompactSelect
+          trigger={triggerProps => (
+            <OverlayTrigger.Button
+              {...triggerProps}
+              icon={<IconClock />}
+              variant="transparent"
+              size="xs"
+            >
+              {intervalOptions.find(option => option.value === interval)?.label}
+            </OverlayTrigger.Button>
+          )}
+          value={interval}
+          menuTitle={t('Interval')}
+          options={intervalOptions}
+          onChange={option => setInterval(option.value)}
+        />
+      </Tooltip>
+    </Fragment>
+  );
+
+  const Visualization = isPending ? (
+    <TimeSeriesWidgetVisualization.LoadingPlaceholder />
+  ) : error ? (
+    <Container position="absolute" inset={0}>
+      <Widget.WidgetError error={error} />
+    </Container>
+  ) : plottables.length === 0 ? (
+    <Container position="absolute" inset={0}>
+      <Widget.WidgetError error={MISSING_DATA_MESSAGE} />
+    </Container>
+  ) : (
+    <TimeSeriesWidgetVisualization plottables={plottables} />
+  );
+
+  return (
+    <Widget
+      Title={Title}
+      Actions={Actions}
+      Visualization={Visualization}
+      height={195}
+      revealActions="always"
+    />
+  );
+}
+
+// Pull the trigger left so the label's text edge aligns with the chart's
+// left edge, rather than being indented by the button's own padding.
+const TitleTrigger = styled(OverlayTrigger.Button)`
+  margin-left: -${p => p.theme.space.xs};
+`;

--- a/static/app/views/explore/conversations/hooks/useShowConversationOnboarding.ts
+++ b/static/app/views/explore/conversations/hooks/useShowConversationOnboarding.ts
@@ -4,8 +4,8 @@ import {ALL_ACCESS_PROJECTS} from 'sentry/components/pageFilters/constants';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {Referrer} from 'sentry/views/explore/conversations/utils/referrers';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
-import {Referrer} from 'sentry/views/insights/pages/agents/utils/referrers';
 
 /**
  * Whether the current project selection represents "all projects" (-1 or empty).
@@ -44,7 +44,7 @@ export function useShowConversationOnboarding(): {
       limit: 1,
       pageFilters: selection,
     },
-    Referrer.CONVERSATIONS_ONBOARDING
+    Referrer.ONBOARDING
   );
 
   const hasData = !request.isLoading && (request.data?.length ?? 0) > 0;

--- a/static/app/views/explore/conversations/onboarding.tsx
+++ b/static/app/views/explore/conversations/onboarding.tsx
@@ -53,6 +53,7 @@ import {useApi} from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {Referrer} from 'sentry/views/explore/conversations/utils/referrers';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {CopyLLMPromptButton} from 'sentry/views/insights/pages/agents/llmOnboardingInstructions';
 import {
@@ -64,7 +65,6 @@ import {
   PYTHON_AGENT_INTEGRATIONS,
 } from 'sentry/views/insights/pages/agents/utils/agentIntegrations';
 import {AI_INSTRUMENTATION_DOCS_LINKS} from 'sentry/views/insights/pages/agents/utils/docsLinks';
-import {Referrer} from 'sentry/views/insights/pages/agents/utils/referrers';
 import {
   BulletList,
   HeaderText,
@@ -98,7 +98,7 @@ function useConversationSpanWaiter(project: Project) {
         },
       },
     },
-    Referrer.CONVERSATIONS_ONBOARDING
+    Referrer.ONBOARDING
   );
 
   const hasEvents = Boolean(request.data?.length);

--- a/static/app/views/explore/conversations/overview.tsx
+++ b/static/app/views/explore/conversations/overview.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useMemo} from 'react';
+import {Fragment, useEffect, useMemo} from 'react';
 import {parseAsString, useQueryState} from 'nuqs';
 
 import {Flex, Stack} from '@sentry/scraps/layout';
@@ -23,11 +23,14 @@ import {
   ExploreBodySearch,
 } from 'sentry/views/explore/components/styles';
 import {TraceItemSearchQueryBuilder} from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
+import {ConversationsChart} from 'sentry/views/explore/conversations/components/conversationsChart';
 import {ConversationsTable} from 'sentry/views/explore/conversations/components/conversationsTable';
 import {SaveConversationQueryButton} from 'sentry/views/explore/conversations/components/saveConversationQueryButton';
 import {useShowConversationOnboarding} from 'sentry/views/explore/conversations/hooks/useShowConversationOnboarding';
 import {ConversationOnboarding} from 'sentry/views/explore/conversations/onboarding';
 import {MAX_PICKABLE_DAYS} from 'sentry/views/explore/conversations/settings';
+import {hasGenAiConversationsRedesignFeature} from 'sentry/views/explore/conversations/utils/features';
+import {Referrer} from 'sentry/views/explore/conversations/utils/referrers';
 import {AgentSelector} from 'sentry/views/insights/common/components/agentSelector';
 import {useTableCursor} from 'sentry/views/insights/pages/agents/hooks/useTableCursor';
 import {
@@ -120,7 +123,7 @@ function ConversationsOverviewPage() {
                     resetParamsOnChange={[TableUrlParams.CURSOR]}
                   />
                 </PageFilterBar>
-                <AgentSelector referrer="api.insights.conversations.get-agent-names" />
+                <AgentSelector referrer={Referrer.AGENT_NAMES} />
               </Flex>
               {!showOnboarding && !isOnboardingLoading && (
                 <Flex flex={1} minWidth="300px">
@@ -142,7 +145,12 @@ function ConversationsOverviewPage() {
           ) : showOnboarding ? (
             <ConversationOnboarding onDismiss={refetchOnboarding} />
           ) : (
-            <ConversationsTable />
+            <Fragment>
+              {hasGenAiConversationsRedesignFeature(organization) && (
+                <ConversationsChart />
+              )}
+              <ConversationsTable />
+            </Fragment>
           )}
         </Stack>
       </ExploreBodyContent>

--- a/static/app/views/explore/conversations/utils/features.ts
+++ b/static/app/views/explore/conversations/utils/features.ts
@@ -3,3 +3,7 @@ import type {Organization} from 'sentry/types/organization';
 export function hasGenAiConversationsFeature(organization: Organization) {
   return organization.features.includes('gen-ai-conversations');
 }
+
+export function hasGenAiConversationsRedesignFeature(organization: Organization) {
+  return organization.features.includes('gen-ai-conversations-redesign');
+}

--- a/static/app/views/explore/conversations/utils/referrers.ts
+++ b/static/app/views/explore/conversations/utils/referrers.ts
@@ -1,0 +1,5 @@
+export enum Referrer {
+  CHART = 'api.explore.conversations.list.chart',
+  ONBOARDING = 'api.explore.conversations.onboarding',
+  AGENT_NAMES = 'api.explore.conversations.get-agent-names',
+}

--- a/static/app/views/insights/pages/agents/utils/referrers.tsx
+++ b/static/app/views/insights/pages/agents/utils/referrers.tsx
@@ -15,5 +15,4 @@ export enum Referrer {
   AGENT_DURATION_WIDGET = 'api.insights.agent-monitoring.agent-duration-widget',
   AGENT_SELECTOR = 'api.insights.agent-monitoring.agent-selector',
   ONBOARDING = 'api.insights.agent-monitoring.onboarding',
-  CONVERSATIONS_ONBOARDING = 'api.insights.conversations.onboarding',
 }


### PR DESCRIPTION
Add a chart above the conversations list showing cost, message volume, or
conversation count over time, so users can spot trends without opening
individual conversations.

The chart reuses the page's existing project, agent, and search filters, and
lets users switch the metric, toggle line/bar, and pick the time interval.

Gated behind the conversations redesign feature flag.

Depends on https://github.com/getsentry/sentry/pull/120551 registering the new `api.explore.conversations.*`
referrers

Closes TET-2739