### PR TITLE
ref(ui): Remove ui-migration-breadcrumbs checks from replays and detectors

### DIFF
--- a/static/app/views/detectors/components/details/common/header.tsx
+++ b/static/app/views/detectors/components/details/common/header.tsx
@@ -2,7 +2,6 @@ import {Fragment} from 'react';
 
 import {BreadcrumbList} from '@sentry/scraps/breadcrumbList';
 
-import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import {t} from 'sentry/locale';
 import type {Detector} from 'sentry/types/workflowEngine/detectors';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -26,24 +25,6 @@ type DetectorDetailsHeaderProps = {
 function DetectorDetailsBreadcrumbs({detector}: {detector: Detector}) {
   const organization = useOrganization();
 
-  if (!organization.features.includes('ui-migration-breadcrumbs')) {
-    return (
-      <Breadcrumbs
-        crumbs={[
-          {
-            label: t('Monitors'),
-            to: makeMonitorBasePathname(organization.slug),
-          },
-          {
-            label: getDetectorTypeLabel(detector.type),
-            to: makeMonitorTypePathname(organization.slug, detector.type),
-          },
-          {label: detector.name},
-        ]}
-      />
-    );
-  }
-
   return (
     <BreadcrumbList
       items={[
@@ -63,25 +44,15 @@ function DetectorDetailsBreadcrumbs({detector}: {detector: Detector}) {
 }
 
 function DetectorDetailsDefaultHeaderContent({detector}: {detector: Detector}) {
-  const organization = useOrganization();
-
-  if (organization.features.includes('ui-migration-breadcrumbs')) {
-    return (
-      <Fragment>
-        <TopBar.Slot name="breadcrumbs">
-          <DetectorDetailsBreadcrumbs detector={detector} />
-        </TopBar.Slot>
-        <TopBar.Slot name="title">
-          <BreadcrumbList.Title item={{type: 'page-title', label: detector.name}} />
-        </TopBar.Slot>
-      </Fragment>
-    );
-  }
-
   return (
-    <TopBar.Slot name="title">
-      <DetectorDetailsBreadcrumbs detector={detector} />
-    </TopBar.Slot>
+    <Fragment>
+      <TopBar.Slot name="breadcrumbs">
+        <DetectorDetailsBreadcrumbs detector={detector} />
+      </TopBar.Slot>
+      <TopBar.Slot name="title">
+        <BreadcrumbList.Title item={{type: 'page-title', label: detector.name}} />
+      </TopBar.Slot>
+    </Fragment>
   );
 }
 

--- a/static/app/views/explore/replays/detail/header/replayDetailsPageBreadcrumbs.tsx
+++ b/static/app/views/explore/replays/detail/header/replayDetailsPageBreadcrumbs.tsx
@@ -1,26 +1,20 @@
 import {Fragment, useMemo, useRef} from 'react';
-import styled from '@emotion/styled';
 
 import {BreadcrumbList} from '@sentry/scraps/breadcrumbList';
-import {Button, LinkButton} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Button} from '@sentry/scraps/button';
 import {Text} from '@sentry/scraps/text';
-import {Tooltip} from '@sentry/scraps/tooltip';
 
-import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import {Placeholder} from 'sentry/components/placeholder';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {useLiveRefresh} from 'sentry/components/replays/replayLiveIndicator';
-import {IconChevron, IconCopy, IconRefresh} from 'sentry/icons';
+import {IconRefresh} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {defined} from 'sentry/utils/defined';
 import {EventView} from 'sentry/utils/discover/eventView';
 import {getShortEventId} from 'sentry/utils/events';
 import type {useLoadReplayReader} from 'sentry/utils/replays/hooks/useLoadReplayReader';
 import {useReplayPlaylist} from 'sentry/utils/replays/playback/providers/replayPlaylistProvider';
-import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjectFromId} from 'sentry/utils/useProjectFromId';
@@ -72,269 +66,111 @@ export function ReplayDetailsPageBreadcrumbs({readerResult}: Props) {
       })()
     : '';
 
-  const {copy} = useCopyToClipboard();
-
-  if (organization.features.includes('ui-migration-breadcrumbs')) {
-    return (
-      <Fragment>
-        <TopBar.Slot name="breadcrumbs">
-          <BreadcrumbList
-            items={[
-              {
-                type: 'link',
-                label: t('Session Replay'),
-                to: {
-                  pathname: makeReplaysPathname({path: '/', organization}),
-                  query: {
-                    ...eventView.generateQueryStringObject(),
-                    project: replayRecord?.project_id,
-                  },
-                },
-              },
-            ]}
-          />
-        </TopBar.Slot>
-        <TopBar.Slot name="title">
-          <BreadcrumbList.Title
-            item={{
-              type: 'page-title',
-              label: replayRecord?.id
-                ? getShortEventId(replayRecord.id)
-                : t('Unknown Replay'),
-              leadingGraphic: project ? (
-                <ProjectBadge disableLink project={project} avatarSize={16} hideName />
-              ) : (
-                <Placeholder width="16px" height="16px" />
-              ),
-              pagination: {
-                previous: {
-                  ariaLabel: t('Previous replay based on search query'),
-                  tooltip: previousReplay
-                    ? t('Previous replay based on search query')
-                    : undefined,
-                  to: previousReplay
-                    ? {
-                        pathname: makeReplaysPathname({
-                          path: `/${previousReplay.id}/`,
-                          organization,
-                        }),
-                        query: initialLocation.current.query,
-                      }
-                    : undefined,
-                  onClick: () =>
-                    trackAnalytics('replay.details-playlist-clicked', {
-                      direction: 'previous',
-                      organization,
-                    }),
-                },
-                next: {
-                  ariaLabel: t('Next replay based on search query'),
-                  tooltip: nextReplay
-                    ? t('Next replay based on search query')
-                    : undefined,
-                  to: nextReplay
-                    ? {
-                        pathname: makeReplaysPathname({
-                          path: `/${nextReplay.id}/`,
-                          organization,
-                        }),
-                        query: initialLocation.current.query,
-                      }
-                    : undefined,
-                  onClick: () =>
-                    trackAnalytics('replay.details-playlist-clicked', {
-                      direction: 'next',
-                      organization,
-                    }),
-                },
-              },
-              trailingActions: [
-                replayRecord
-                  ? {
-                      type: 'copy',
-                      text: replayUrlWithTimestamp,
-                      label: t('Copy link to replay at current timestamp'),
-                      tooltip: t('Copy link to replay at current timestamp'),
-                    }
-                  : null,
-                shouldShowRefreshButton
-                  ? {
-                      type: 'button',
-                      element: (
-                        <Button
-                          tooltipProps={{
-                            title: t('Replay is outdated. Refresh for latest activity.'),
-                          }}
-                          data-test-id="refresh-button"
-                          size="zero"
-                          variant="link"
-                          onClick={doRefresh}
-                          icon={<IconRefresh size="xs" variant="accent" />}
-                        >
-                          <Text size="md" variant="accent">
-                            {t('Update')}
-                          </Text>
-                        </Button>
-                      ),
-                    }
-                  : null,
-              ],
-            }}
-          />
-        </TopBar.Slot>
-      </Fragment>
-    );
-  }
-
-  // Legacy breadcrumbs (flag off).
   return (
-    <StyledBreadcrumbs
-      crumbs={[
-        {
-          to: {
-            pathname: makeReplaysPathname({
-              path: '/',
-              organization,
-            }),
-            query: {
-              ...eventView.generateQueryStringObject(),
-              project: replayRecord?.project_id,
+    <Fragment>
+      <TopBar.Slot name="breadcrumbs">
+        <BreadcrumbList
+          items={[
+            {
+              type: 'link',
+              label: t('Session Replay'),
+              to: {
+                pathname: makeReplaysPathname({path: '/', organization}),
+                query: {
+                  ...eventView.generateQueryStringObject(),
+                  project: replayRecord?.project_id,
+                },
+              },
             },
-          },
-          label: t('Session Replay'),
-        },
-        replayRecord
-          ? {
-              label: (
-                <Flex align="center" gap="sm">
-                  <div>
-                    <Tooltip
-                      title={t('Previous replay based on search query')}
-                      disabled={!previousReplay}
-                    >
-                      <LinkButton
-                        size="zero"
-                        variant="transparent"
-                        icon={<IconChevron direction="left" size="xs" />}
-                        disabled={!previousReplay}
-                        aria-label={t('Previous replay based on search query')}
-                        to={{
-                          pathname: previousReplay
-                            ? makeReplaysPathname({
-                                path: `/${previousReplay.id}/`,
-                                organization,
-                              })
-                            : undefined,
-                          query: initialLocation.current.query,
+          ]}
+        />
+      </TopBar.Slot>
+      <TopBar.Slot name="title">
+        <BreadcrumbList.Title
+          item={{
+            type: 'page-title',
+            label: replayRecord?.id
+              ? getShortEventId(replayRecord.id)
+              : t('Unknown Replay'),
+            leadingGraphic: project ? (
+              <ProjectBadge disableLink project={project} avatarSize={16} hideName />
+            ) : (
+              <Placeholder width="16px" height="16px" />
+            ),
+            pagination: {
+              previous: {
+                ariaLabel: t('Previous replay based on search query'),
+                tooltip: previousReplay
+                  ? t('Previous replay based on search query')
+                  : undefined,
+                to: previousReplay
+                  ? {
+                      pathname: makeReplaysPathname({
+                        path: `/${previousReplay.id}/`,
+                        organization,
+                      }),
+                      query: initialLocation.current.query,
+                    }
+                  : undefined,
+                onClick: () =>
+                  trackAnalytics('replay.details-playlist-clicked', {
+                    direction: 'previous',
+                    organization,
+                  }),
+              },
+              next: {
+                ariaLabel: t('Next replay based on search query'),
+                tooltip: nextReplay ? t('Next replay based on search query') : undefined,
+                to: nextReplay
+                  ? {
+                      pathname: makeReplaysPathname({
+                        path: `/${nextReplay.id}/`,
+                        organization,
+                      }),
+                      query: initialLocation.current.query,
+                    }
+                  : undefined,
+                onClick: () =>
+                  trackAnalytics('replay.details-playlist-clicked', {
+                    direction: 'next',
+                    organization,
+                  }),
+              },
+            },
+            trailingActions: [
+              replayRecord
+                ? {
+                    type: 'copy',
+                    text: replayUrlWithTimestamp,
+                    label: t('Copy link to replay at current timestamp'),
+                    tooltip: t('Copy link to replay at current timestamp'),
+                  }
+                : null,
+              shouldShowRefreshButton
+                ? {
+                    type: 'button',
+                    element: (
+                      <Button
+                        tooltipProps={{
+                          title: t('Replay is outdated. Refresh for latest activity.'),
                         }}
-                        onClick={() =>
-                          trackAnalytics('replay.details-playlist-clicked', {
-                            direction: 'previous',
-                            organization,
-                          })
-                        }
-                      />
-                    </Tooltip>
-                    <Tooltip
-                      title={t('Next replay based on search query')}
-                      disabled={!nextReplay}
-                    >
-                      <LinkButton
+                        data-test-id="refresh-button"
                         size="zero"
-                        variant="transparent"
-                        icon={<IconChevron direction="right" size="xs" />}
-                        disabled={!nextReplay}
-                        aria-label={t('Next replay based on search query')}
-                        to={{
-                          pathname: nextReplay
-                            ? makeReplaysPathname({
-                                path: `/${nextReplay.id}/`,
-                                organization,
-                              })
-                            : undefined,
-                          query: initialLocation.current.query,
-                        }}
-                        onClick={() =>
-                          trackAnalytics('replay.details-playlist-clicked', {
-                            direction: 'next',
-                            organization,
-                          })
-                        }
-                      />
-                    </Tooltip>
-                  </div>
-                  <HoverArea align="center" gap="xs">
-                    {project ? (
-                      <ProjectBadge
-                        disableLink
-                        project={project}
-                        avatarSize={16}
-                        hideName
-                      />
-                    ) : (
-                      <Placeholder width="16px" height="16px" />
-                    )}
-                    <div
-                      onClick={() =>
-                        copy(replayUrlWithTimestamp, {
-                          successMessage: t('Copied replay link to clipboard'),
-                        })
-                      }
-                    >
-                      {getShortEventId(replayRecord?.id)}
-                    </div>
-                    <LinkCopyButton
-                      tooltipProps={{
-                        title: t('Copy link to replay at current timestamp'),
-                      }}
-                      aria-label={t('Copy link to replay at current timestamp')}
-                      onClick={() =>
-                        copy(replayUrlWithTimestamp, {
-                          successMessage: t('Copied replay link to clipboard'),
-                        })
-                      }
-                      size="zero"
-                      variant="transparent"
-                      icon={<IconCopy size="xs" variant="muted" />}
-                    />
-                  </HoverArea>
-                  {shouldShowRefreshButton ? (
-                    <Button
-                      tooltipProps={{
-                        title: t('Replay is outdated. Refresh for latest activity.'),
-                      }}
-                      data-test-id="refresh-button"
-                      size="zero"
-                      variant="link"
-                      onClick={doRefresh}
-                      icon={<IconRefresh size="xs" variant="accent" />}
-                    >
-                      <Text size="md" variant="accent">
-                        {t('Update')}
-                      </Text>
-                    </Button>
-                  ) : null}
-                </Flex>
-              ),
-            }
-          : null,
-      ].filter(defined)}
-    />
+                        variant="link"
+                        onClick={doRefresh}
+                        icon={<IconRefresh size="xs" variant="accent" />}
+                      >
+                        <Text size="md" variant="accent">
+                          {t('Update')}
+                        </Text>
+                      </Button>
+                    ),
+                  }
+                : null,
+            ],
+          }}
+        />
+      </TopBar.Slot>
+    </Fragment>
   );
 }
-
-const StyledBreadcrumbs = styled(Breadcrumbs)`
-  padding: 0;
-  height: 34px;
-`;
-
-const HoverArea = styled(Flex)``;
-
-const LinkCopyButton = styled(Button)`
-  opacity: 0;
-
-  ${HoverArea}:focus-within &,
-  ${HoverArea}:hover & {
-    opacity: 1;
-  }
-`;

--- a/static/app/views/explore/replays/details.spec.tsx
+++ b/static/app/views/explore/replays/details.spec.tsx
@@ -36,6 +36,9 @@ mockUseLoadReplayReader.mockReturnValue({
 function TopBarWrapper({children}: {children: ReactNode}) {
   return (
     <TopBar.Slot.Provider>
+      <TopBar.Slot.Outlet name="breadcrumbs">
+        {props => <div {...props} data-test-id="topbar-breadcrumbs-slot" />}
+      </TopBar.Slot.Outlet>
       <TopBar.Slot.Outlet name="title">
         {props => <div {...props} data-test-id="topbar-title-slot" />}
       </TopBar.Slot.Outlet>
@@ -90,9 +93,9 @@ describe('ReplayDetails', () => {
     expect(mockUseLoadReplayReader).toHaveBeenCalled();
   });
 
-  it('renders pagination chevrons and a copy action in the replay crumb (flag on)', () => {
+  it('renders pagination chevrons and a copy action in the replay crumb', () => {
     const organization = OrganizationFixture({
-      features: ['session-replay', 'ui-migration-breadcrumbs'],
+      features: ['session-replay'],
     });
 
     render(<ReplayDetails />, {

--- a/static/app/views/explore/replays/details.tsx
+++ b/static/app/views/explore/replays/details.tsx
@@ -26,7 +26,6 @@ import {ReplayDetailsMetadata} from 'sentry/views/explore/replays/detail/header/
 import {ReplayDetailsPageBreadcrumbs} from 'sentry/views/explore/replays/detail/header/replayDetailsPageBreadcrumbs';
 import {ReplayDetailsUserBadge} from 'sentry/views/explore/replays/detail/header/replayDetailsUserBadge';
 import {ReplayDetailsPage} from 'sentry/views/explore/replays/detail/page';
-import {TopBar} from 'sentry/views/navigation/topBar';
 import {useLLMContext} from 'sentry/views/seerExplorer/contexts/llmContext';
 import {registerLLMContext} from 'sentry/views/seerExplorer/contexts/registerLLMContext';
 
@@ -109,13 +108,7 @@ function ReplayDetailsContent() {
 
   const pageFrameContent = (
     <Fragment>
-      {organization.features.includes('ui-migration-breadcrumbs') ? (
-        <ReplayDetailsPageBreadcrumbs readerResult={readerResult} />
-      ) : (
-        <TopBar.Slot name="title">
-          <ReplayDetailsPageBreadcrumbs readerResult={readerResult} />
-        </TopBar.Slot>
-      )}
+      <ReplayDetailsPageBreadcrumbs readerResult={readerResult} />
       <ReplayDetailsHeaderActions readerResult={readerResult} />
       <Flex
         justify="between"


### PR DESCRIPTION
Removes the `ui-migration-breadcrumbs` feature-flag branches from two page headers, collapsing to the page-frame breadcrumb layout and deleting the legacy fallbacks.

## Changes

- **Detectors monitor detail header** (`detectors/components/details/common/header.tsx`): drop the flag-off branches in `DetectorDetailsBreadcrumbs` and `DetectorDetailsDefaultHeaderContent`; keep the `TopBar.Slot` + `BreadcrumbList` rendering. Remove the now-unused legacy `Breadcrumbs` import.
- **Replay details** (`explore/replays/details.tsx` + `explore/replays/detail/header/replayDetailsPageBreadcrumbs.tsx`): these gate the same page on one flag, so collapse both together. `ReplayDetailsPageBreadcrumbs` always renders bare into `TopBar.Slot`, and the legacy `StyledBreadcrumbs` block (plus its styled components and dead imports) is deleted.
- **Tests**: update `details.spec.tsx` to drop the flag from fixtures and add the `breadcrumbs` slot to the test `TopBar` wrapper (breadcrumb text moved out of the title slot).

The three remaining `ui-migration-breadcrumbs` usages (`issueDetails/header/header.tsx`, `dashboards/detail.tsx`, alerts) are left for follow-up PRs.

Net: -197 lines. Frontend-only.