### PR TITLE
ref(navigation): Unify top offset behind a single hook

### DIFF
--- a/static/app/components/core/slideOverPanel/slideOverPanel.tsx
+++ b/static/app/components/core/slideOverPanel/slideOverPanel.tsx
@@ -73,7 +73,7 @@ export function SlideOverPanel({
   // is displayed.
   // Subsequent updates of the `children` are not deferred.
   const [isContentVisible, setIsContentVisible] = useState(false);
-  const {contentTop} = useTopOffset();
+  const {stickyContentTop} = useTopOffset();
   useEffect(() => {
     startTransition(() => {
       setIsContentVisible(true);
@@ -96,7 +96,7 @@ export function SlideOverPanel({
         ref={ref}
         id={id}
         mode={mode}
-        top={contentTop}
+        top={stickyContentTop}
         initial={collapsedStyle}
         animate={openStyle}
         exit={collapsedStyle}

--- a/static/app/components/sticky.tsx
+++ b/static/app/components/sticky.tsx
@@ -14,10 +14,10 @@ import {useTopOffset} from 'sentry/views/navigation/useTopOffset';
  */
 function TaggedSticky(props: React.ComponentProps<'div'>) {
   const elementRef = useRef<HTMLDivElement>(null);
-  const {contentTop} = useTopOffset();
+  const {stickyContentTop} = useTopOffset();
 
   const isStuck = useIsStuck(elementRef.current, {
-    offset: Number.parseInt(contentTop, 10) ?? 0,
+    offset: Number.parseInt(stickyContentTop, 10) ?? 0,
   });
 
   const stuckProps = isStuck ? {'data-stuck': ''} : {};

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -106,7 +106,7 @@ export function WidgetBuilderV2({
     }
   }, []);
 
-  const {contentTop} = useTopOffset();
+  const {stickyContentTop} = useTopOffset();
 
   const dimensions = useDimensions({elementRef: navigationElementRef});
 
@@ -172,12 +172,12 @@ export function WidgetBuilderV2({
                     ? isMediumScreen
                       ? {
                           left: 0,
-                          top: contentTop,
+                          top: stickyContentTop,
                           willChange: 'top',
                         }
                       : {
                           left: `${dimensions.width ?? 0}px`,
-                          top: contentTop,
+                          top: stickyContentTop,
                           willChange: 'left',
                         }
                     : undefined

--- a/static/app/views/issueDetails/eventDetails.tsx
+++ b/static/app/views/issueDetails/eventDetails.tsx
@@ -41,8 +41,8 @@ export function EventDetails({group, event, project}: EventDetailsContentProps) 
 function StickyEventNav({event, group}: {event: Event; group: Group}) {
   const [nav, setNav] = useState<HTMLDivElement | null>(null);
   const {dispatch} = useIssueDetails();
-  const {contentTop} = useTopOffset();
-  const stickyTopOffset = Number.parseInt(contentTop, 10);
+  const {stickyContentTop} = useTopOffset();
+  const stickyTopOffset = Number.parseInt(stickyContentTop, 10);
 
   useLayoutEffect(() => {
     if (!nav) {

--- a/static/app/views/navigation/index.tsx
+++ b/static/app/views/navigation/index.tsx
@@ -51,7 +51,7 @@ function CommandPaletteSlotOutlets() {
   );
 }
 
-function UserAndOrganizationNavigation({pageBannerHeight}: NavigationProps) {
+function UserAndOrganizationNavigation() {
   const {layout} = usePrimaryNavigation();
   const {visible} = useModal();
   const {view, setView} = useSecondaryNavigation();
@@ -68,7 +68,7 @@ function UserAndOrganizationNavigation({pageBannerHeight}: NavigationProps) {
   );
 
   return (
-    <NavigationLayout pageBannerHeight={pageBannerHeight}>
+    <NavigationLayout>
       <CommandPaletteHotkeys />
       <CommandPaletteSlotOutlets />
       <GlobalCommandPaletteActions />
@@ -91,33 +91,26 @@ function UserOnlyNavigation() {
   );
 }
 
-interface NavigationProps {
-  pageBannerHeight?: number;
-}
-
-function NavigationLayout({
-  children,
-  pageBannerHeight = 0,
-}: NavigationProps & {children: React.ReactNode}) {
+function NavigationLayout({children}: {children: React.ReactNode}) {
   const theme = useTheme();
   const {layout} = usePrimaryNavigation();
   const {currentStepId} = useNavigationTour();
   const hoverProps = useResetActiveNavigationGroup();
-  const {barTop} = useTopOffset();
+  const {stickyNavTop, bannerHeight} = useTopOffset();
 
   return (
     <Flex
-      top={barTop}
+      top={stickyNavTop}
       left={0}
       position={currentStepId ? undefined : 'sticky'}
       bottom={layout === 'mobile' ? undefined : 0}
       height={
         layout === 'mobile'
           ? undefined
-          : // barTop (marquee) and pageBannerHeight (marquee + alerts) overlap, so
-            // max not sum; barTop also floors the height while pageBannerHeight's
+          : // stickyNavTop (marquee) and bannerHeight (marquee + alerts) overlap, so
+            // max not sum; stickyNavTop also floors the height while bannerHeight's
             // ResizeObserver still reports 0 on first paint.
-            `calc(100dvh - max(${barTop}, ${pageBannerHeight}px))`
+            `calc(100dvh - max(${stickyNavTop}, ${bannerHeight}px))`
       }
       style={{
         zIndex: currentStepId ? undefined : theme.zIndex.sidebarPanel,
@@ -130,7 +123,7 @@ function NavigationLayout({
   );
 }
 
-export function Navigation({pageBannerHeight = 0}: NavigationProps) {
+export function Navigation() {
   const organization = useOrganization({allowNull: true});
 
   if (!organization) {
@@ -146,7 +139,7 @@ export function Navigation({pageBannerHeight = 0}: NavigationProps) {
     <HoverOverlayGroupProvider>
       <NavigationTourProvider>
         <SkipLink />
-        <UserAndOrganizationNavigation pageBannerHeight={pageBannerHeight} />
+        <UserAndOrganizationNavigation />
       </NavigationTourProvider>
     </HoverOverlayGroupProvider>
   );

--- a/static/app/views/navigation/topBar.tsx
+++ b/static/app/views/navigation/topBar.tsx
@@ -30,16 +30,16 @@ const Slot = slot(['breadcrumbs', 'title', 'search', 'actions', 'feedback'] as c
 
 function TopBarContent() {
   const theme = useTheme();
-  const {contentTop} = useTopOffset();
+  const {stickyContentTop} = useTopOffset();
 
   const organization = useOrganization({allowNull: true});
 
   useEffect(() => {
-    document.documentElement.style.setProperty(TOP_BAR_HEIGHT_CSS_VAR, contentTop);
+    document.documentElement.style.setProperty(TOP_BAR_HEIGHT_CSS_VAR, stickyContentTop);
     return () => {
       document.documentElement.style.removeProperty(TOP_BAR_HEIGHT_CSS_VAR);
     };
-  }, [contentTop]);
+  }, [stickyContentTop]);
 
   const {isOpen: isSeerExplorerOpen} = useSeerExplorerContext();
   const {runId: seerExplorerRunId} = useSeerExplorerChatState();

--- a/static/app/views/navigation/useTopOffset.tsx
+++ b/static/app/views/navigation/useTopOffset.tsx
@@ -1,3 +1,4 @@
+import {createContext, useContext} from 'react';
 import {useTheme} from '@emotion/react';
 
 import {getOverride} from 'sentry/overrideRegistry';
@@ -11,17 +12,42 @@ import {
   SUPERUSER_MARQUEE_HEIGHT,
 } from 'sentry/views/navigation/constants';
 
+/**
+ * Measured height of the global banner region (superuser marquee + in-flow
+ * SystemAlerts) that sits above the nav + content row. Only AppLayout can
+ * measure it, so it flows down through context. Defaults to 0 outside the
+ * provider (tests, Storybook, standalone primitives) — those trees have no
+ * banner, so the fallback is correct rather than merely safe.
+ */
+const BannerHeightContext = createContext(0);
+
+export function BannerHeightProvider({
+  height,
+  children,
+}: {
+  children: React.ReactNode;
+  height: number;
+}) {
+  return <BannerHeightContext value={height}>{children}</BannerHeightContext>;
+}
+
 interface TopOffset {
-  /** The `top` CSS value for the sticky bar itself */
-  barTop: string;
-  /** Offset where content below the bar starts (marquee + header only, excludes in-flow SystemAlerts) */
-  contentTop: string;
+  /**
+   * Measured banner region height (marquee + SystemAlerts), for sizing the nav
+   * against the viewport. 0 outside the provider.
+   */
+  bannerHeight: number;
+  /** `top` where sticky page content starts: below the marquee and the header. */
+  stickyContentTop: string;
+  /** `top` where the nav sidebar sticks: below the marquee only. */
+  stickyNavTop: string;
 }
 
 export function useTopOffset(): TopOffset {
   const theme = useTheme();
   const organization = useOrganization({allowNull: true});
   const isMobile = !useMedia(`(min-width: ${theme.breakpoints.md})`);
+  const bannerHeight = useContext(BannerHeightContext);
   const showSuperuserWarning =
     isActiveSuperuser() &&
     !ConfigStore.get('isSelfHosted') &&
@@ -33,7 +59,8 @@ export function useTopOffset(): TopOffset {
     : PRIMARY_HEADER_HEIGHT;
 
   return {
-    barTop: `${superuserOffset}px`,
-    contentTop: `${superuserOffset + headerHeight}px`,
+    bannerHeight,
+    stickyNavTop: `${superuserOffset}px`,
+    stickyContentTop: `${superuserOffset + headerHeight}px`,
   };
 }

--- a/static/app/views/organizationLayout/index.tsx
+++ b/static/app/views/organizationLayout/index.tsx
@@ -30,6 +30,7 @@ import {useRegisterDomainViewUsage} from 'sentry/views/insights/common/utils/dom
 import {Navigation} from 'sentry/views/navigation';
 import {PrimaryNavigationContextProvider} from 'sentry/views/navigation/primaryNavigationContext';
 import {TopBar} from 'sentry/views/navigation/topBar';
+import {BannerHeightProvider} from 'sentry/views/navigation/useTopOffset';
 import {OrganizationContainer} from 'sentry/views/organizationContainer';
 import {SeerExplorerSidebarLayout} from 'sentry/views/seerExplorer/components/sidebar/seerExplorerSidebarLayout';
 import {useSeerExplorerDocumentTitle} from 'sentry/views/seerExplorer/components/useSeerExplorerDocumentTitle';
@@ -100,46 +101,48 @@ function AppLayout({organization}: LayoutProps) {
 
   return (
     <PrimaryNavigationContextProvider>
-      <Stack flex="1" minWidth="0" minHeight="100dvh">
-        <Container ref={pageBannerRef}>
-          {showSuperuserWarning && (
-            <Override name="component:superuser-warning" organization={organization} />
-          )}
-          <SystemAlerts className="messages-container" />
-        </Container>
-        <Flex
-          flex="1"
-          minWidth="0"
-          minHeight="0"
-          direction={{'screen:sm': 'column', 'screen:md': 'row'}}
-          position="relative"
-        >
-          <Navigation pageBannerHeight={pageBannerHeight} />
-          <SeerExplorerSidebarLayout>
-            {/* The `#main` selector is used to make the app content `inert` when an overlay is active */}
-            <ContentStack
-              id="main"
-              tabIndex={-1}
-              flex="1"
-              minWidth="0"
-              background="secondary"
-              containerType="inline-size"
-            >
-              <DemoHeader />
-              {organization && <OrganizationHeader organization={organization} />}
-              <OrganizationDetailsBody>
-                <TopBar.Slot.Provider>
-                  <TopBar />
-                  <Layout.Page>
-                    <Outlet />
-                  </Layout.Page>
-                </TopBar.Slot.Provider>
-              </OrganizationDetailsBody>
-            </ContentStack>
-          </SeerExplorerSidebarLayout>
-        </Flex>
-      </Stack>
-      {organization ? <AppDrawers /> : null}
+      <BannerHeightProvider height={pageBannerHeight}>
+        <Stack flex="1" minWidth="0" minHeight="100dvh">
+          <Container ref={pageBannerRef}>
+            {showSuperuserWarning && (
+              <Override name="component:superuser-warning" organization={organization} />
+            )}
+            <SystemAlerts className="messages-container" />
+          </Container>
+          <Flex
+            flex="1"
+            minWidth="0"
+            minHeight="0"
+            direction={{'screen:sm': 'column', 'screen:md': 'row'}}
+            position="relative"
+          >
+            <Navigation />
+            <SeerExplorerSidebarLayout>
+              {/* The `#main` selector is used to make the app content `inert` when an overlay is active */}
+              <ContentStack
+                id="main"
+                tabIndex={-1}
+                flex="1"
+                minWidth="0"
+                background="secondary"
+                containerType="inline-size"
+              >
+                <DemoHeader />
+                {organization && <OrganizationHeader organization={organization} />}
+                <OrganizationDetailsBody>
+                  <TopBar.Slot.Provider>
+                    <TopBar />
+                    <Layout.Page>
+                      <Outlet />
+                    </Layout.Page>
+                  </TopBar.Slot.Provider>
+                </OrganizationDetailsBody>
+              </ContentStack>
+            </SeerExplorerSidebarLayout>
+          </Flex>
+        </Stack>
+        {organization ? <AppDrawers /> : null}
+      </BannerHeightProvider>
     </PrimaryNavigationContextProvider>
   );
 }


### PR DESCRIPTION


### Why
`useTopOffset` and a measured `pageBannerHeight` prop were two overlapping mechanisms for "the size of the top", reconciled with a `max()` in `NavigationLayout`. The prop was threaded `AppLayout → Navigation → UserAndOrganizationNavigation → NavigationLayout` purely to reach one consumer. Confusing to follow.

### What
- Route the measured banner height through a `BannerHeightProvider` (mounted in `AppLayout`, where the ref lives). `useTopOffset` reads it via context and returns it alongside the derived offsets — one hook, everything about "the top" in one place.
- Provider defaults to `0`, so the 20+ specs, the Storybook playground, and standalone `@sentry/scraps` primitives (`SlideOverPanel`, `Sticky`) that render outside `AppLayout` keep working — those trees have no banner, so the fallback is correct, not merely safe.
- Drop the `pageBannerHeight` prop threading entirely.
- Rename offsets to say what they position: `barTop → stickyNavTop`, `contentTop → stickyContentTop`. `bannerHeight` is the measured region.

No behavior change. The `max()` (first-paint floor while the `ResizeObserver` warms up) is preserved and documented.

### Test
- `pnpm typecheck` clean
- Affected suites pass: `organizationLayout`, `newWidgetBuilder`, `widgetBuilderSlideout`, `slideOverPanel`, `topBar`

🤖 Generated with [Claude Code](https://claude.com/claude-code)