### PR TITLE
feat(pr-metrics): Emit an opaque deduplication_key on scm.pr.closed

### DIFF
--- a/src/sentry/analytics/events/pr_metrics_events.py
+++ b/src/sentry/analytics/events/pr_metrics_events.py
@@ -16,6 +16,16 @@ class PrCloseMetricsEvent(analytics.Event):
 
     organization_id: int
     repository_id: int
+    # Opaque key identifying the provider-side PR, for deduping emitted rows.
+    # Emission already dedupes a shared multi-org installation's per-org rows to one
+    # canonical row, but only within a cell (Repository/PullRequest are cell-local),
+    # so a PR spanning cells still emits once per cell — the same PR yields the same
+    # key in every cell, letting a cross-cell consumer collapse those (and guarding
+    # against a duplicate slipping through in-cell). Treat as opaque: dedupe by
+    # equality only, never parse, so the identity composition can change in code
+    # without a schema change. "" is only the dataclass default; an emitted row
+    # always carries a real key (see emit._deduplication_key).
+    deduplication_key: str = ""
     # Normalized SCM slug (e.g. "github", "gitlab"), read off Repository.provider
     # at emit time. Null when the Repository row is gone or its provider is unset.
     repository_provider: str | None = None

--- a/src/sentry/analytics/events/pr_metrics_events.py
+++ b/src/sentry/analytics/events/pr_metrics_events.py
@@ -16,15 +16,11 @@ class PrCloseMetricsEvent(analytics.Event):
 
     organization_id: int
     repository_id: int
-    # Opaque key identifying the provider-side PR, for deduping emitted rows.
-    # Emission already dedupes a shared multi-org installation's per-org rows to one
-    # canonical row, but only within a cell (Repository/PullRequest are cell-local),
-    # so a PR spanning cells still emits once per cell — the same PR yields the same
-    # key in every cell, letting a cross-cell consumer collapse those (and guarding
-    # against a duplicate slipping through in-cell). Treat as opaque: dedupe by
-    # equality only, never parse, so the identity composition can change in code
-    # without a schema change. "" is only the dataclass default; an emitted row
-    # always carries a real key (see emit._deduplication_key).
+    # Opaque key identifying the provider-side PR. A repo shared across orgs emits one
+    # scm.pr.closed per org, all with the same key, so a consumer can collapse the
+    # duplicates by grouping on it. Opaque by contract -- dedupe by equality only,
+    # never parse -- so the identity composition can change in code without a schema
+    # change. "" is only the dataclass default; an emitted row always carries a key.
     deduplication_key: str = ""
     # Normalized SCM slug (e.g. "github", "gitlab"), read off Repository.provider
     # at emit time. Null when the Repository row is gone or its provider is unset.

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Sequence
 from enum import Enum
+from hashlib import sha1
 from typing import Any, NamedTuple, cast
 
 from django.db.models import Count, Q
@@ -322,6 +323,42 @@ def is_pr_tracked(pull_request: PullRequest) -> bool:
     return PullRequestAttribution.objects.filter(pull_request=pull_request, is_valid=True).exists()
 
 
+def _repo_external_identity(pull_request: PullRequest) -> tuple[str | None, str | None]:
+    """The PR repo's provider ``external_id`` (GitHub repo id) and normalized
+    provider slug. ``external_id`` is None when the repo row is gone or never had
+    one — the PR then can't be identified by its provider-side identity.
+    """
+    repo = (
+        Repository.objects.filter(id=pull_request.repository_id)
+        .values_list("external_id", "provider")
+        .first()
+    )
+    if repo is None:
+        return None, None
+    external_id, provider = repo
+    return external_id, normalize_scm_provider(provider)
+
+
+def _deduplication_key(
+    pull_request: PullRequest, external_id: str | None, provider: str | None
+) -> str:
+    """Opaque key identifying this row's provider-side PR, for deduping emitted rows.
+
+    The same provider PR hashes to the same key in every cell, so a cross-cell
+    consumer can collapse the one-row-per-cell duplicates the cell-local in-Sentry
+    dedupe can't reach. Opaque by contract: consumers dedupe by equality only and
+    must not parse it, so the identity composition here can change without a
+    pipeline/schema change. When the repo has no external id the PR can't be
+    identified globally (nor fanned out across orgs), so the key falls back to the
+    row's own globally-unique identity — it forms its own group instead of merging.
+    """
+    if external_id is not None:
+        identity = f"pr:{provider or ''}:{external_id}:{pull_request.key}"
+    else:
+        identity = f"row:{pull_request.organization_id}:{pull_request.id}"
+    return sha1(identity.encode()).hexdigest()
+
+
 def active_attributions(pull_request: PullRequest) -> list[dict[str, Any]]:
     """The PR's valid attribution signals, highest-confidence first.
 
@@ -452,17 +489,6 @@ def _repo_is_public(pull_request: PullRequest) -> bool | None:
     return None if is_private is None else not is_private
 
 
-def _repo_provider(pull_request: PullRequest) -> str | None:
-    """Normalized SCM slug for the PR's repo (e.g. "github"), or ``None`` if the
-    ``Repository`` row is gone or its provider is unset."""
-    provider = (
-        Repository.objects.filter(id=pull_request.repository_id)
-        .values_list("provider", flat=True)
-        .first()
-    )
-    return normalize_scm_provider(provider)
-
-
 def build_pr_metrics_row(
     *,
     pull_request: PullRequest,
@@ -503,10 +529,14 @@ def build_pr_metrics_row(
     # same activity snapshot rather than two separate reads.
     review = review_activity(pull_request)
 
+    # One repo read serves both the provider slug and the dedup key's identity.
+    repo_external_id, repo_provider = _repo_external_identity(pull_request)
+
     return PrCloseMetricsEvent(
         organization_id=pull_request.organization_id,
         repository_id=pull_request.repository_id,
-        repository_provider=_repo_provider(pull_request),
+        deduplication_key=_deduplication_key(pull_request, repo_external_id, repo_provider),
+        repository_provider=repo_provider,
         repository_is_public=_repo_is_public(pull_request),
         pull_request_id=pull_request.id,
         pr_key=pull_request.key,

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -323,35 +323,40 @@ def is_pr_tracked(pull_request: PullRequest) -> bool:
     return PullRequestAttribution.objects.filter(pull_request=pull_request, is_valid=True).exists()
 
 
-def _repo_external_identity(pull_request: PullRequest) -> tuple[str | None, str | None]:
-    """The PR repo's provider ``external_id`` (GitHub repo id) and normalized
-    provider slug. ``external_id`` is None when the repo row is gone or never had
-    one — the PR then can't be identified by its provider-side identity.
+def _repo_external_identity(
+    pull_request: PullRequest,
+) -> tuple[str | None, str | None, int | None]:
+    """The PR repo's provider ``external_id`` (repo id), normalized provider slug, and
+    ``integration_id``. ``external_id``/``integration_id`` are None when the repo row
+    is gone or lacks them. ``integration_id`` (the shared installation) distinguishes
+    the same numeric ``external_id`` across different provider hosts.
     """
     repo = (
         Repository.objects.filter(id=pull_request.repository_id)
-        .values_list("external_id", "provider")
+        .values_list("external_id", "provider", "integration_id")
         .first()
     )
     if repo is None:
-        return None, None
-    external_id, provider = repo
-    return external_id, normalize_scm_provider(provider)
+        return None, None, None
+    external_id, provider, integration_id = repo
+    return external_id, normalize_scm_provider(provider), integration_id
 
 
 def _deduplication_key(
-    pull_request: PullRequest, external_id: str | None, provider: str | None
+    pull_request: PullRequest, external_id: str | None, integration_id: int | None
 ) -> str:
     """Opaque key identifying this row's provider-side PR, for deduping emitted rows.
 
     A repo shared across orgs emits one row per org, all hashing to the same key, so
-    a consumer can collapse the duplicates by grouping on it. Opaque by contract --
-    dedupe by equality only, never parse -- so the identity composition can change
-    without a schema change. With no external id the PR can't be identified globally,
-    so the key falls back to the row's own identity (its own group, never merged).
+    a consumer can collapse the duplicates by grouping on it. Keyed on the shared
+    ``integration_id`` (not provider) so a numeric ``external_id`` reused across
+    provider hosts -- e.g. two GitHub Enterprise instances -- can't collide. Opaque by
+    contract -- dedupe by equality only, never parse -- so the identity composition
+    can change without a schema change. When the repo has no external id or
+    integration, the key falls back to the row's own identity (its own group).
     """
-    if external_id is not None:
-        identity = f"pr:{provider or ''}:{external_id}:{pull_request.key}"
+    if external_id is not None and integration_id is not None:
+        identity = f"pr:{integration_id}:{external_id}:{pull_request.key}"
     else:
         identity = f"row:{pull_request.organization_id}:{pull_request.id}"
     return sha1(identity.encode()).hexdigest()
@@ -528,12 +533,12 @@ def build_pr_metrics_row(
     review = review_activity(pull_request)
 
     # One repo read serves both the provider slug and the dedup key's identity.
-    repo_external_id, repo_provider = _repo_external_identity(pull_request)
+    repo_external_id, repo_provider, integration_id = _repo_external_identity(pull_request)
 
     return PrCloseMetricsEvent(
         organization_id=pull_request.organization_id,
         repository_id=pull_request.repository_id,
-        deduplication_key=_deduplication_key(pull_request, repo_external_id, repo_provider),
+        deduplication_key=_deduplication_key(pull_request, repo_external_id, integration_id),
         repository_provider=repo_provider,
         repository_is_public=_repo_is_public(pull_request),
         pull_request_id=pull_request.id,

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -344,13 +344,11 @@ def _deduplication_key(
 ) -> str:
     """Opaque key identifying this row's provider-side PR, for deduping emitted rows.
 
-    The same provider PR hashes to the same key in every cell, so a cross-cell
-    consumer can collapse the one-row-per-cell duplicates the cell-local in-Sentry
-    dedupe can't reach. Opaque by contract: consumers dedupe by equality only and
-    must not parse it, so the identity composition here can change without a
-    pipeline/schema change. When the repo has no external id the PR can't be
-    identified globally (nor fanned out across orgs), so the key falls back to the
-    row's own globally-unique identity — it forms its own group instead of merging.
+    A repo shared across orgs emits one row per org, all hashing to the same key, so
+    a consumer can collapse the duplicates by grouping on it. Opaque by contract --
+    dedupe by equality only, never parse -- so the identity composition can change
+    without a schema change. With no external id the PR can't be identified globally,
+    so the key falls back to the row's own identity (its own group, never merged).
     """
     if external_id is not None:
         identity = f"pr:{provider or ''}:{external_id}:{pull_request.key}"

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -894,6 +894,8 @@ class PrMetricsEmissionTest(TestCase):
                 attributions=json.dumps([SENTRY_APP_ATTRIBUTION]),
                 review_results=json.dumps({"approved": 0, "changes_requested": 0, "commented": 0}),
             ),
+            # Opaque hash, asserted on its own in MultiOrgEmissionDedupeTest.
+            exclude_fields=["deduplication_key"],
         )
 
     @patch("sentry.analytics.record")
@@ -1281,3 +1283,52 @@ class PrMetricsEmissionTest(TestCase):
         result = emit_pr_metrics_row(pull_request=self.pull_request)
         assert result is False
         mock_cleanup.delay.assert_not_called()
+
+
+EXTERNAL_ID = "556677"
+
+
+@cell_silo_test
+@with_feature(["organizations:pr-metrics-activity", "organizations:gen-ai-features"])
+class DeduplicationKeyTest(TestCase):
+    """The same provider PR, fanned out to one row per org, must build the same
+    opaque deduplication_key so a cross-cell consumer can collapse them."""
+
+    def setUp(self) -> None:
+        self.pull_request = self._mergeable_pr(self._repo(self.project), self.organization)
+        sibling_org = self.create_organization()
+        self.sibling_pull_request = self._mergeable_pr(
+            self._repo(self.create_project(organization=sibling_org)), sibling_org
+        )
+
+    def _repo(self, project: Any) -> Any:
+        return self.create_repo(
+            project,
+            name="getsentry/sentry",
+            provider="integrations:github",
+            external_id=EXTERNAL_ID,
+        )
+
+    def _mergeable_pr(self, repo: Any, organization: Any) -> Any:
+        pull_request = self.create_pull_request(
+            repository_id=repo.id, organization_id=organization.id, key="42"
+        )
+        pull_request.head_commit_sha = HEAD_SHA
+        pull_request.closed_at = CLOSED_AT
+        pull_request.save()
+        return pull_request
+
+    def test_deduplication_key_shared_across_sibling_rows(self) -> None:
+        # Build each sibling's row directly: the same provider PR must yield one
+        # identical, non-empty opaque key so a cross-cell consumer can collapse the
+        # one-row-per-cell duplicates.
+        key_a = build_pr_metrics_row(
+            pull_request=self.pull_request, close_action="merged", attributions=[], group_ids=[]
+        ).deduplication_key
+        key_b = build_pr_metrics_row(
+            pull_request=self.sibling_pull_request,
+            close_action="merged",
+            attributions=[],
+            group_ids=[],
+        ).deduplication_key
+        assert key_a == key_b != ""

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -1292,7 +1292,7 @@ EXTERNAL_ID = "556677"
 @with_feature(["organizations:pr-metrics-activity", "organizations:gen-ai-features"])
 class DeduplicationKeyTest(TestCase):
     """The same provider PR, fanned out to one row per org, must build the same
-    opaque deduplication_key so a cross-cell consumer can collapse them."""
+    opaque deduplication_key so a consumer can collapse them."""
 
     def setUp(self) -> None:
         self.pull_request = self._mergeable_pr(self._repo(self.project), self.organization)

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -1295,18 +1295,27 @@ class DeduplicationKeyTest(TestCase):
     opaque deduplication_key so a consumer can collapse them."""
 
     def setUp(self) -> None:
-        self.pull_request = self._mergeable_pr(self._repo(self.project), self.organization)
+        # One shared installation across both orgs -> both rows carry the same
+        # integration_id, so the same provider PR keys identically.
+        self.integration = self.create_integration(
+            organization=self.organization, external_id="shared-install", provider="github"
+        )
+        self.pull_request = self._mergeable_pr(
+            self._repo(self.project, self.integration.id), self.organization
+        )
         sibling_org = self.create_organization()
         self.sibling_pull_request = self._mergeable_pr(
-            self._repo(self.create_project(organization=sibling_org)), sibling_org
+            self._repo(self.create_project(organization=sibling_org), self.integration.id),
+            sibling_org,
         )
 
-    def _repo(self, project: Any) -> Any:
+    def _repo(self, project: Any, integration_id: int) -> Any:
         return self.create_repo(
             project,
             name="getsentry/sentry",
             provider="integrations:github",
             external_id=EXTERNAL_ID,
+            integration_id=integration_id,
         )
 
     def _mergeable_pr(self, repo: Any, organization: Any) -> Any:
@@ -1318,17 +1327,24 @@ class DeduplicationKeyTest(TestCase):
         pull_request.save()
         return pull_request
 
+    def _key_for(self, pull_request: Any) -> str:
+        return build_pr_metrics_row(
+            pull_request=pull_request, close_action="merged", attributions=[], group_ids=[]
+        ).deduplication_key
+
     def test_deduplication_key_shared_across_sibling_rows(self) -> None:
-        # Build each sibling's row directly: the same provider PR must yield one
-        # identical, non-empty opaque key so a cross-cell consumer can collapse the
-        # one-row-per-cell duplicates.
-        key_a = build_pr_metrics_row(
-            pull_request=self.pull_request, close_action="merged", attributions=[], group_ids=[]
-        ).deduplication_key
-        key_b = build_pr_metrics_row(
-            pull_request=self.sibling_pull_request,
-            close_action="merged",
-            attributions=[],
-            group_ids=[],
-        ).deduplication_key
-        assert key_a == key_b != ""
+        # The same provider PR must yield one identical, non-empty opaque key so a
+        # cross-cell consumer can collapse the one-row-per-cell duplicates.
+        assert self._key_for(self.pull_request) == self._key_for(self.sibling_pull_request) != ""
+
+    def test_deduplication_key_differs_across_installations(self) -> None:
+        # Same external_id + PR number under a *different* installation (e.g. a second
+        # GitHub Enterprise host, where repo ids can collide) must not share a key.
+        other_integration = self.create_integration(
+            organization=self.organization, external_id="other-install", provider="github"
+        )
+        other_org = self.create_organization()
+        other_pr = self._mergeable_pr(
+            self._repo(self.create_project(organization=other_org), other_integration.id), other_org
+        )
+        assert self._key_for(self.pull_request) != self._key_for(other_pr)


### PR DESCRIPTION
## Problem

A GitHub App installation shared across multiple Sentry orgs fans each PR webhook out to one `PullRequest` row per org, so a single provider-side PR emits one `scm.pr.closed` per org. Those rows are cell-local (`Repository`/`PullRequest` are cell models), so a consumer that aggregates across cells can't tell the rows describe the same PR.

## Approach

Add an opaque `deduplication_key` to `scm.pr.closed` — a hash of the provider-global identity (`provider`, repo `external_id`, PR number). The same provider PR yields the same key in every cell, so a cross-cell consumer can collapse the duplicates by grouping on it (e.g. `QUALIFY ROW_NUMBER() OVER (PARTITION BY deduplication_key ORDER BY closed_at DESC) = 1`).

It's **opaque by contract** — consumers dedupe by equality only, never parse — so the identity composition can change in code without a schema or pipeline change. When a repo has no `external_id`, the key falls back to the row's own globally-unique identity, so it forms its own group instead of wrongly merging.

This is the cross-cell safety net. Suppressing the same-cell duplicates inside Sentry is the follow-up (stacked on top of this PR).

## Testing

- `DeduplicationKeyTest`: the same provider PR fanned out to two orgs builds one identical, non-empty key.
- The existing full `scm.pr.closed` assertion excludes the opaque hash (asserted on its own instead).

---

Follow-up that suppresses the same-cell duplicates inside Sentry: #120562
