### PR TITLE
feat(pr-metrics): Dedupe scm.pr.closed across a shared multi-org repo

### DIFF
--- a/src/sentry/models/pullrequest.py
+++ b/src/sentry/models/pullrequest.py
@@ -219,21 +219,14 @@ class PullRequestManager(BaseManager["PullRequest"]):
         """Every ``PullRequest`` row for one provider-side PR, across all orgs
         sharing the repository.
 
-        A repository connected to multiple Sentry orgs (a shared GitHub App
-        installation) has one active ``Repository`` row per org, all carrying the
-        provider's ``external_id`` (e.g. GitHub's repo id). A single provider PR —
-        the same ``(external_id, key)`` — therefore fans out to one ``PullRequest``
-        row per org. This returns every such row so callers can treat the provider
-        PR as the unit rather than the per-org row (e.g. emission dedupe, so a
-        single provider PR emits one ``scm.pr.closed`` instead of one per org).
+        A repo connected to N orgs has one active ``Repository`` per org, all
+        sharing the provider's ``external_id``, so one provider PR — the same
+        ``(external_id, key)`` — fans out to one row per org. Returns them all so
+        callers can treat the provider PR as the unit rather than the per-org row.
 
-        ``provider`` is the bare, normalized slug (e.g. ``github``) and scopes the
-        match so a numeric ``external_id`` can't collide across providers.
-
-        Cell-local: ``Repository`` and ``PullRequest`` are cell models, so rows in
-        other cells aren't visible here — consistent with every other cross-org
-        query in these paths. Returns ``[]`` when ``external_id`` matches no active
-        repository.
+        ``provider`` (bare slug, e.g. ``github``) scopes the match so a numeric
+        ``external_id`` can't collide across providers. Cell-local — rows in other
+        cells aren't visible. ``[]`` when no active repo matches.
         """
         repos = Repository.objects.filter(
             external_id=external_id, status=ObjectStatus.ACTIVE

--- a/src/sentry/models/pullrequest.py
+++ b/src/sentry/models/pullrequest.py
@@ -219,18 +219,22 @@ class PullRequestManager(BaseManager["PullRequest"]):
         """Every ``PullRequest`` row for one provider-side PR, across all orgs
         sharing the repository.
 
-        A repo connected to N orgs has one active ``Repository`` per org, all
-        sharing the provider's ``external_id``, so one provider PR — the same
-        ``(external_id, key)`` — fans out to one row per org. Returns them all so
-        callers can treat the provider PR as the unit rather than the per-org row.
+        A repo connected to N orgs has one ``Repository`` per org, all sharing the
+        provider's ``external_id``, so one provider PR — the same ``(external_id,
+        key)`` — fans out to one row per org. Returns them all so callers treat the
+        provider PR as the unit, not the per-org row.
 
-        ``provider`` (bare slug, e.g. ``github``) scopes the match so a numeric
-        ``external_id`` can't collide across providers. Cell-local — rows in other
-        cells aren't visible. ``[]`` when no active repo matches.
+        Filters repos like the SCM webhook does (all but ``HIDDEN``), not ``ACTIVE``
+        only, so the set is the rows that can emit and always includes the caller's
+        own PR (whose repo is read status-agnostically elsewhere). ``provider`` (bare
+        slug) keeps a numeric ``external_id`` from colliding across providers.
+        Cell-local. ``[]`` when no repo matches.
         """
-        repos = Repository.objects.filter(
-            external_id=external_id, status=ObjectStatus.ACTIVE
-        ).filter(Repository.objects.provider_match(provider))
+        repos = (
+            Repository.objects.exclude(status=ObjectStatus.HIDDEN)
+            .filter(external_id=external_id)
+            .filter(Repository.objects.provider_match(provider))
+        )
         repo_ids = list(repos.values_list("id", flat=True))
         if not repo_ids:
             return []

--- a/src/sentry/models/pullrequest.py
+++ b/src/sentry/models/pullrequest.py
@@ -12,6 +12,7 @@ from django.db.models.signals import post_save
 from django.utils import timezone
 
 from sentry.backup.scopes import RelocationScope
+from sentry.constants import ObjectStatus
 from sentry.db.models import (
     BoundedBigIntegerField,
     BoundedPositiveIntegerField,
@@ -25,6 +26,7 @@ from sentry.db.models.fields.jsonfield import LegacyTextJSONField
 from sentry.db.models.manager.base import BaseManager
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.group import Group
+from sentry.models.repository import Repository
 from sentry.utils.groupreference import find_referenced_groups
 
 if TYPE_CHECKING:
@@ -189,8 +191,6 @@ class PullRequestManager(BaseManager["PullRequest"]):
         rather than through an SCM installation (e.g. Seer-created and delegated-agent
         attribution).
         """
-        from sentry.models.repository import Repository
-
         normalized_provider = normalize_scm_provider(provider)
         provider_unmappable = (
             normalized_provider is not None and normalized_provider not in _KNOWN_SCM_PROVIDERS
@@ -212,6 +212,36 @@ class PullRequestManager(BaseManager["PullRequest"]):
             key=str(key),
         )
         return ResolvedPullRequest(pull_request, "resolved", provider_unmappable)
+
+    def for_provider_pr(
+        self, *, external_id: str, provider: str, key: int | str
+    ) -> list[PullRequest]:
+        """Every ``PullRequest`` row for one provider-side PR, across all orgs
+        sharing the repository.
+
+        A repository connected to multiple Sentry orgs (a shared GitHub App
+        installation) has one active ``Repository`` row per org, all carrying the
+        provider's ``external_id`` (e.g. GitHub's repo id). A single provider PR —
+        the same ``(external_id, key)`` — therefore fans out to one ``PullRequest``
+        row per org. This returns every such row so callers can treat the provider
+        PR as the unit rather than the per-org row (e.g. emission dedupe, so a
+        single provider PR emits one ``scm.pr.closed`` instead of one per org).
+
+        ``provider`` is the bare, normalized slug (e.g. ``github``) and scopes the
+        match so a numeric ``external_id`` can't collide across providers.
+
+        Cell-local: ``Repository`` and ``PullRequest`` are cell models, so rows in
+        other cells aren't visible here — consistent with every other cross-org
+        query in these paths. Returns ``[]`` when ``external_id`` matches no active
+        repository.
+        """
+        repos = Repository.objects.filter(
+            external_id=external_id, status=ObjectStatus.ACTIVE
+        ).filter(Repository.objects.provider_match(provider))
+        repo_ids = list(repos.values_list("id", flat=True))
+        if not repo_ids:
+            return []
+        return list(self.filter(repository_id__in=repo_ids, key=str(key)))
 
 
 @cell_silo_model
@@ -260,7 +290,6 @@ class PullRequest(Model):
         return find_referenced_groups(text, self.organization_id)
 
     def get_external_url(self) -> str | None:
-        from sentry.models.repository import Repository
         from sentry.plugins.base import bindings
 
         repository = Repository.objects.get(id=self.repository_id)

--- a/src/sentry/models/pullrequest.py
+++ b/src/sentry/models/pullrequest.py
@@ -214,28 +214,27 @@ class PullRequestManager(BaseManager["PullRequest"]):
         return ResolvedPullRequest(pull_request, "resolved", provider_unmappable)
 
     def for_provider_pr(
-        self, *, external_id: str, provider: str, key: int | str
+        self, *, external_id: str, integration_id: int, key: int | str
     ) -> list[PullRequest]:
         """Every ``PullRequest`` row for one provider-side PR, across all orgs
         sharing the repository.
 
-        A repo connected to N orgs has one ``Repository`` per org, all sharing the
-        provider's ``external_id``, so one provider PR — the same ``(external_id,
-        key)`` — fans out to one row per org. Returns them all so callers treat the
+        A repo connected to N orgs via one shared installation has one ``Repository``
+        per org, all with the same ``integration_id`` and ``external_id``, so one
+        provider PR fans out to one row per org. Returns them all so callers treat the
         provider PR as the unit, not the per-org row.
 
-        Filters repos like the SCM webhook does (all but ``HIDDEN``), not ``ACTIVE``
-        only, so the set is the rows that can emit and always includes the caller's
-        own PR (whose repo is read status-agnostically elsewhere). ``provider`` (bare
-        slug) keeps a numeric ``external_id`` from colliding across providers.
-        Cell-local. ``[]`` when no repo matches.
+        Keyed on ``integration_id`` (the shared installation) rather than provider, so
+        a numeric ``external_id`` reused across provider hosts — e.g. two GitHub
+        Enterprise instances — doesn't over-match. Filters repos like the SCM webhook
+        (all but ``HIDDEN``), so the set is the rows that can emit and includes the
+        caller's own PR. Cell-local. ``[]`` when no repo matches.
         """
-        repos = (
+        repo_ids = list(
             Repository.objects.exclude(status=ObjectStatus.HIDDEN)
-            .filter(external_id=external_id)
-            .filter(Repository.objects.provider_match(provider))
+            .filter(external_id=external_id, integration_id=integration_id)
+            .values_list("id", flat=True)
         )
-        repo_ids = list(repos.values_list("id", flat=True))
         if not repo_ids:
             return []
         return list(self.filter(repository_id__in=repo_ids, key=str(key)))

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -570,7 +570,25 @@ def _canonical_sibling(siblings: list[PullRequest]) -> PullRequest:
     for pull_request in sorted(siblings, key=lambda pr: pr.id):
         if run_org_by_pr.get(pull_request.id) == pull_request.organization_id:
             return pull_request
-    return min(siblings, key=lambda pr: pr.id)
+
+    canonical = min(siblings, key=lambda pr: pr.id)
+    if len(siblings) > 1:
+        # ≥2 orgs' rows emit for one provider PR but none is linked to a run in its
+        # own org — an app-authored PR that fanned out with no run link anywhere
+        # (e.g. a delegated coding-agent PR whose handoff link dropped). We still
+        # dedupe deterministically to the lowest-id row; surface it so the link loss
+        # is visible rather than silent.
+        logger.warning(
+            "pr_metrics.emit.dedup_no_run_org_row",
+            extra={
+                "pr_key": canonical.key,
+                "canonical_pull_request_id": canonical.id,
+                "sibling_pull_request_ids": sorted(pr.id for pr in siblings),
+                "organization_ids": sorted({pr.organization_id for pr in siblings}),
+            },
+        )
+        metrics.incr("pr_metrics.emit.dedup_no_run_org_row")
+    return canonical
 
 
 def active_attributions(pull_request: PullRequest) -> list[dict[str, Any]]:

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -16,7 +16,7 @@ from typing import Any, NamedTuple, cast
 from django.db.models import Count, Q
 from django.utils import timezone as dj_timezone
 
-from sentry import analytics
+from sentry import analytics, features
 from sentry.analytics.events.pr_metrics_events import PrCloseMetricsEvent
 from sentry.models.commit import Commit
 from sentry.models.organization import Organization
@@ -514,27 +514,41 @@ def is_canonical_github_pr_row(pull_request: PullRequest) -> bool:
     siblings = PullRequest.objects.for_provider_pr(
         external_id=external_id, provider=provider, key=pull_request.key
     )
-    # Only rows that actually emit (≥1 valid attribution) can be canonical, else an
-    # untracked shadow could suppress a tracked sibling — e.g. a run-less MCP PR
-    # whose attribution feature is on in only one org.
-    tracked = _tracked_rows(siblings)
-    if len(tracked) <= 1:
+    # Only rows that would actually emit can be canonical (see _emitting_rows), else
+    # a non-emitting shadow could win and suppress the sibling that would emit.
+    emitting = _emitting_rows(siblings)
+    if len(emitting) <= 1:
         return True
-    return _canonical_sibling(tracked).id == pull_request.id
+    return _canonical_sibling(emitting).id == pull_request.id
 
 
-def _tracked_rows(pull_requests: list[PullRequest]) -> list[PullRequest]:
-    """The subset with ≥1 valid attribution — the rows that actually emit.
+def _emitting_rows(pull_requests: list[PullRequest]) -> list[PullRequest]:
+    """The subset that would actually emit: a valid attribution *and* the row's org
+    with ``pr-metrics-emit`` on — the two gates every emission path applies.
 
-    Canonical selection runs over these only: an untracked sibling never emits, so
-    letting it win canonical would suppress a tracked row and drop the PR entirely.
+    Canonical selection runs over these so a row that can't emit — untracked (e.g. a
+    run-less MCP PR whose attribution feature is on in only one org), or emit-gated
+    off for its org mid-rollout — never wins canonical and drops the PR by
+    suppressing a sibling that would emit.
     """
     tracked_ids = set(
         PullRequestAttribution.objects.filter(pull_request__in=pull_requests, is_valid=True)
         .values_list("pull_request_id", flat=True)
         .distinct()
     )
-    return [pull_request for pull_request in pull_requests if pull_request.id in tracked_ids]
+    tracked = [pr for pr in pull_requests if pr.id in tracked_ids]
+    if not tracked:
+        return []
+    orgs = {
+        org.id: org
+        for org in Organization.objects.filter(id__in={pr.organization_id for pr in tracked})
+    }
+    return [
+        pr
+        for pr in tracked
+        if (org := orgs.get(pr.organization_id)) is not None
+        and features.has("organizations:pr-metrics-emit", org)
+    ]
 
 
 def _canonical_sibling(siblings: list[PullRequest]) -> PullRequest:

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -514,10 +514,13 @@ def is_canonical_github_pr_row(pull_request: PullRequest) -> bool:
     siblings = PullRequest.objects.for_provider_pr(
         external_id=external_id, provider=provider, key=pull_request.key
     )
-    # Only rows that would actually emit can be canonical (see _emitting_rows), else
-    # a non-emitting shadow could win and suppress the sibling that would emit.
+    # Canonical is the winner among only the rows that would actually emit (see
+    # _emitting_rows); comparing its id to this row's — rather than short-circuiting
+    # on a count — means a row that can't emit (e.g. it lost the emit flag after the
+    # cooldown was claimed) defers instead of emitting a duplicate alongside the real
+    # one. Emit when nothing would qualify, so the PR is never dropped entirely.
     emitting = _emitting_rows(siblings)
-    if len(emitting) <= 1:
+    if not emitting:
         return True
     return _canonical_sibling(emitting).id == pull_request.id
 

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -502,19 +502,11 @@ def _deduplication_key(
 def is_canonical_github_pr_row(pull_request: PullRequest) -> bool:
     """Whether this row is the one that should emit for its provider-side PR.
 
-    A provider PR shared across orgs (a multi-org GitHub App installation) fans
-    out to one ``PullRequest`` row per org, each independently passing the
-    tracking gate — so without dedupe a single provider PR emits one
-    ``scm.pr.closed`` per org. This picks exactly one canonical row:
-
-      - the row in the org of the Seer run that opened the PR (its
-        ``SeerRunPullRequest`` link), when one exists — the org with the real
-        signal;
-      - else the lowest-id row among the siblings (a stable, arbitrary pick when
-        no run link ties the PR to a specific org).
-
-    Returns True for that canonical row, and for any PR with no resolvable
-    siblings — the common single-org case, one repo lookup and out.
+    A repo shared across orgs fans a PR out to one row per org, each passing the
+    tracking gate — so one PR would emit one ``scm.pr.closed`` per org. Pick a
+    single canonical row: the Seer run's-org row (its ``SeerRunPullRequest`` link)
+    if any, else the lowest-id sibling. True also when there are no resolvable
+    siblings — the common single-org case.
     """
     external_id, provider = _repo_external_identity(pull_request)
     if external_id is None or provider is None:
@@ -522,10 +514,9 @@ def is_canonical_github_pr_row(pull_request: PullRequest) -> bool:
     siblings = PullRequest.objects.for_provider_pr(
         external_id=external_id, provider=provider, key=pull_request.key
     )
-    # Dedupe only among rows that actually emit (≥1 valid attribution). An untracked
-    # shadow must never win canonical and suppress a tracked sibling — e.g. an
-    # attribution feature (MCP issue-view) enabled in one org but not another leaves
-    # the sibling untracked, and a run-less MCP PR would otherwise emit nothing.
+    # Only rows that actually emit (≥1 valid attribution) can be canonical, else an
+    # untracked shadow could suppress a tracked sibling — e.g. a run-less MCP PR
+    # whose attribution feature is on in only one org.
     tracked = _tracked_rows(siblings)
     if len(tracked) <= 1:
         return True

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -44,7 +44,7 @@ from sentry.pr_metrics.utils import (
     load_activity_document,
     resolved_group_ids,
 )
-from sentry.seer.models.run import SeerRun
+from sentry.seer.models.run import SeerRun, SeerRunPullRequest
 from sentry.utils import json, metrics
 
 logger = logging.getLogger(__name__)
@@ -499,6 +499,72 @@ def _deduplication_key(
     return sha1(identity.encode()).hexdigest()
 
 
+def is_canonical_github_pr_row(pull_request: PullRequest) -> bool:
+    """Whether this row is the one that should emit for its provider-side PR.
+
+    A provider PR shared across orgs (a multi-org GitHub App installation) fans
+    out to one ``PullRequest`` row per org, each independently passing the
+    tracking gate — so without dedupe a single provider PR emits one
+    ``scm.pr.closed`` per org. This picks exactly one canonical row:
+
+      - the row in the org of the Seer run that opened the PR (its
+        ``SeerRunPullRequest`` link), when one exists — the org with the real
+        signal;
+      - else the lowest-id row among the siblings (a stable, arbitrary pick when
+        no run link ties the PR to a specific org).
+
+    Returns True for that canonical row, and for any PR with no resolvable
+    siblings — the common single-org case, one repo lookup and out.
+    """
+    external_id, provider = _repo_external_identity(pull_request)
+    if external_id is None or provider is None:
+        return True
+    siblings = PullRequest.objects.for_provider_pr(
+        external_id=external_id, provider=provider, key=pull_request.key
+    )
+    # Dedupe only among rows that actually emit (≥1 valid attribution). An untracked
+    # shadow must never win canonical and suppress a tracked sibling — e.g. an
+    # attribution feature (MCP issue-view) enabled in one org but not another leaves
+    # the sibling untracked, and a run-less MCP PR would otherwise emit nothing.
+    tracked = _tracked_rows(siblings)
+    if len(tracked) <= 1:
+        return True
+    return _canonical_sibling(tracked).id == pull_request.id
+
+
+def _tracked_rows(pull_requests: list[PullRequest]) -> list[PullRequest]:
+    """The subset with ≥1 valid attribution — the rows that actually emit.
+
+    Canonical selection runs over these only: an untracked sibling never emits, so
+    letting it win canonical would suppress a tracked row and drop the PR entirely.
+    """
+    tracked_ids = set(
+        PullRequestAttribution.objects.filter(pull_request__in=pull_requests, is_valid=True)
+        .values_list("pull_request_id", flat=True)
+        .distinct()
+    )
+    return [pull_request for pull_request in pull_requests if pull_request.id in tracked_ids]
+
+
+def _canonical_sibling(siblings: list[PullRequest]) -> PullRequest:
+    """The single row that emits for a provider PR fanned out across orgs.
+
+    Prefer the row whose org owns the Seer run linked to it (the run's-org row,
+    the one with real signal); fall back to the lowest-id row when no link ties a
+    row to its own org. Deterministic either way, so concurrent per-org emissions
+    all agree on the same winner.
+    """
+    run_org_by_pr = dict(
+        SeerRunPullRequest.objects.filter(pull_request__in=siblings).values_list(
+            "pull_request_id", "seer_run__organization_id"
+        )
+    )
+    for pull_request in sorted(siblings, key=lambda pr: pr.id):
+        if run_org_by_pr.get(pull_request.id) == pull_request.organization_id:
+            return pull_request
+    return min(siblings, key=lambda pr: pr.id)
+
+
 def active_attributions(pull_request: PullRequest) -> list[dict[str, Any]]:
     """The PR's valid attribution signals — all of them, unranked.
 
@@ -909,6 +975,13 @@ def emit_pr_metrics_row(
     attributions = active_attributions(pull_request)
     if not attributions:
         metrics.incr("pr_metrics.emit.skipped", tags={"reason": "untracked"})
+        return False
+
+    # A provider PR shared across orgs fans out to one row per org, each tracked
+    # and each otherwise emitting — dedupe to a single canonical row so counts
+    # aren't inflated by sibling-org duplicates.
+    if not is_canonical_github_pr_row(pull_request):
+        metrics.incr("pr_metrics.emit.skipped", tags={"reason": "duplicate_github_pr"})
         return False
 
     # Derive the activity-sourced counters at the terminal event — before the

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -508,11 +508,11 @@ def is_canonical_github_pr_row(pull_request: PullRequest) -> bool:
     if any, else the lowest-id sibling. True also when there are no resolvable
     siblings — the common single-org case.
     """
-    external_id, provider = _repo_external_identity(pull_request)
-    if external_id is None or provider is None:
+    external_id, _, integration_id = _repo_external_identity(pull_request)
+    if external_id is None or integration_id is None:
         return True
     siblings = PullRequest.objects.for_provider_pr(
-        external_id=external_id, provider=provider, key=pull_request.key
+        external_id=external_id, integration_id=integration_id, key=pull_request.key
     )
     # Canonical is the winner among only the rows that would actually emit (see
     # _emitting_rows); comparing its id to this row's — rather than short-circuiting

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -554,13 +554,35 @@ def _emitting_rows(pull_requests: list[PullRequest]) -> list[PullRequest]:
     ]
 
 
+def _attribution_completeness(siblings: list[PullRequest]) -> dict[int, tuple[bool, bool, int]]:
+    """Per-sibling completeness of the emitted event, from valid attributions in one
+    query: whether any carries a run id, whether any carries group ids, and how many
+    there are. The fallback prefers the fullest of these — the org whose issues the PR
+    resolves stamps run id / group ids into its attribution signal_details, while
+    shadow rows carry only the bare author signal.
+    """
+    by_pr: dict[int, tuple[bool, bool, int]] = {}
+    for pr_id, details in PullRequestAttribution.objects.filter(
+        pull_request__in=siblings, is_valid=True
+    ).values_list("pull_request_id", "signal_details"):
+        has_run_id, has_group_ids, count = by_pr.get(pr_id, (False, False, 0))
+        details = details or {}
+        by_pr[pr_id] = (
+            has_run_id or details.get("run_id") is not None,
+            has_group_ids or bool(details.get("group_ids")),
+            count + 1,
+        )
+    return by_pr
+
+
 def _canonical_sibling(siblings: list[PullRequest]) -> PullRequest:
     """The single row that emits for a provider PR fanned out across orgs.
 
-    Prefer the row whose org owns the Seer run linked to it (the run's-org row,
-    the one with real signal); fall back to the lowest-id row when no link ties a
-    row to its own org. Deterministic either way, so concurrent per-org emissions
-    all agree on the same winner.
+    Prefer the row whose org owns the Seer run linked to it (the run's-org row). With
+    no such link, pick the row whose emitted event would be most complete — the org
+    whose issues the PR resolves carries the run id / group ids / richer attributions,
+    while shadow rows have only the bare author signal. Ties (and the common
+    single-row case) break on lowest id, so concurrent per-org emissions all agree.
     """
     run_org_by_pr = dict(
         SeerRunPullRequest.objects.filter(pull_request__in=siblings).values_list(
@@ -571,13 +593,14 @@ def _canonical_sibling(siblings: list[PullRequest]) -> PullRequest:
         if run_org_by_pr.get(pull_request.id) == pull_request.organization_id:
             return pull_request
 
-    canonical = min(siblings, key=lambda pr: pr.id)
+    completeness = _attribution_completeness(siblings)
+    # Fullest event wins; lowest id is the deterministic final tiebreak.
+    canonical = max(siblings, key=lambda pr: (*completeness.get(pr.id, (False, False, 0)), -pr.id))
     if len(siblings) > 1:
         # ≥2 orgs' rows emit for one provider PR but none is linked to a run in its
         # own org — an app-authored PR that fanned out with no run link anywhere
-        # (e.g. a delegated coding-agent PR whose handoff link dropped). We still
-        # dedupe deterministically to the lowest-id row; surface it so the link loss
-        # is visible rather than silent.
+        # (e.g. a delegated coding-agent PR whose handoff link dropped). Surface it so
+        # the link loss is visible rather than silent.
         logger.warning(
             "pr_metrics.emit.dedup_no_run_org_row",
             extra={

--- a/tests/sentry/models/test_pullrequest.py
+++ b/tests/sentry/models/test_pullrequest.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 from django.utils import timezone
 
 from sentry.api.serializers import serialize
+from sentry.constants import ObjectStatus
 from sentry.models.activity import Activity
 from sentry.models.commit import Commit
 from sentry.models.group import GroupStatus
@@ -596,6 +597,59 @@ class GetOrCreateFromReferenceTest(TestCase):
         assert resolved.pull_request is not None
         assert resolved.pull_request.repository_id == other_repo.id
         assert not PullRequest.objects.filter(repository_id=self.repo.id).exists()
+
+
+class ForProviderPrTest(TestCase):
+    def setUp(self) -> None:
+        self.external_id = "556677"
+        self.repo = self.create_repo(
+            self.project,
+            name="getsentry/sentry",
+            provider="integrations:github",
+            external_id=self.external_id,
+        )
+        self.pull_request = self.create_pull_request(
+            organization_id=self.organization.id, repository_id=self.repo.id, key="42"
+        )
+
+    def _for_provider_pr(self, *, provider: str = "github", key: int | str = 42):
+        return PullRequest.objects.for_provider_pr(
+            external_id=self.external_id, provider=provider, key=key
+        )
+
+    def test_resolves_row_in_own_org(self) -> None:
+        assert [pr.id for pr in self._for_provider_pr()] == [self.pull_request.id]
+
+    def test_fans_across_orgs_sharing_external_id(self) -> None:
+        other_org = self.create_organization()
+        other_project = self.create_project(organization=other_org)
+        other_repo = self.create_repo(
+            other_project,
+            name="getsentry/sentry",
+            provider="integrations:github",
+            external_id=self.external_id,
+        )
+        other_pr = self.create_pull_request(
+            organization_id=other_org.id, repository_id=other_repo.id, key="42"
+        )
+
+        assert {pr.id for pr in self._for_provider_pr()} == {self.pull_request.id, other_pr.id}
+
+    def test_coerces_integer_key_to_string(self) -> None:
+        assert [pr.id for pr in self._for_provider_pr(key=42)] == [self.pull_request.id]
+
+    def test_excludes_other_pr_numbers(self) -> None:
+        self.create_pull_request(
+            organization_id=self.organization.id, repository_id=self.repo.id, key="99"
+        )
+        assert [pr.id for pr in self._for_provider_pr()] == [self.pull_request.id]
+
+    def test_excludes_inactive_repositories(self) -> None:
+        self.repo.update(status=ObjectStatus.HIDDEN)
+        assert self._for_provider_pr() == []
+
+    def test_excludes_mismatched_provider(self) -> None:
+        assert self._for_provider_pr(provider="gitlab") == []
 
 
 class ParsePullRequestNumberTest(TestCase):

--- a/tests/sentry/models/test_pullrequest.py
+++ b/tests/sentry/models/test_pullrequest.py
@@ -644,9 +644,16 @@ class ForProviderPrTest(TestCase):
         )
         assert [pr.id for pr in self._for_provider_pr()] == [self.pull_request.id]
 
-    def test_excludes_inactive_repositories(self) -> None:
+    def test_excludes_hidden_repositories(self) -> None:
         self.repo.update(status=ObjectStatus.HIDDEN)
         assert self._for_provider_pr() == []
+
+    def test_includes_non_hidden_inactive_repositories(self) -> None:
+        # A pending-deletion repo still gets webhooks (the fan-out only excludes
+        # HIDDEN), so its PR can emit and must stay in its own sibling set — matching
+        # how _repo_external_identity reads the repo regardless of status.
+        self.repo.update(status=ObjectStatus.PENDING_DELETION)
+        assert [pr.id for pr in self._for_provider_pr()] == [self.pull_request.id]
 
     def test_excludes_mismatched_provider(self) -> None:
         assert self._for_provider_pr(provider="gitlab") == []

--- a/tests/sentry/models/test_pullrequest.py
+++ b/tests/sentry/models/test_pullrequest.py
@@ -602,32 +602,36 @@ class GetOrCreateFromReferenceTest(TestCase):
 class ForProviderPrTest(TestCase):
     def setUp(self) -> None:
         self.external_id = "556677"
+        self.integration_id = 909
         self.repo = self.create_repo(
             self.project,
             name="getsentry/sentry",
             provider="integrations:github",
             external_id=self.external_id,
+            integration_id=self.integration_id,
         )
         self.pull_request = self.create_pull_request(
             organization_id=self.organization.id, repository_id=self.repo.id, key="42"
         )
 
-    def _for_provider_pr(self, *, provider: str = "github", key: int | str = 42):
+    def _for_provider_pr(self, *, integration_id: int | None = None, key: int | str = 42):
         return PullRequest.objects.for_provider_pr(
-            external_id=self.external_id, provider=provider, key=key
+            external_id=self.external_id,
+            integration_id=self.integration_id if integration_id is None else integration_id,
+            key=key,
         )
 
     def test_resolves_row_in_own_org(self) -> None:
         assert [pr.id for pr in self._for_provider_pr()] == [self.pull_request.id]
 
-    def test_fans_across_orgs_sharing_external_id(self) -> None:
+    def test_fans_across_orgs_sharing_installation(self) -> None:
         other_org = self.create_organization()
-        other_project = self.create_project(organization=other_org)
         other_repo = self.create_repo(
-            other_project,
+            self.create_project(organization=other_org),
             name="getsentry/sentry",
             provider="integrations:github",
             external_id=self.external_id,
+            integration_id=self.integration_id,
         )
         other_pr = self.create_pull_request(
             organization_id=other_org.id, repository_id=other_repo.id, key="42"
@@ -655,8 +659,10 @@ class ForProviderPrTest(TestCase):
         self.repo.update(status=ObjectStatus.PENDING_DELETION)
         assert [pr.id for pr in self._for_provider_pr()] == [self.pull_request.id]
 
-    def test_excludes_mismatched_provider(self) -> None:
-        assert self._for_provider_pr(provider="gitlab") == []
+    def test_excludes_other_installations(self) -> None:
+        # Same external_id under a different installation (e.g. a second GHE host,
+        # where repo ids can collide) must not be treated as a sibling.
+        assert self._for_provider_pr(integration_id=self.integration_id + 1) == []
 
 
 class ParsePullRequestNumberTest(TestCase):

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -1538,6 +1538,19 @@ class MultiOrgEmissionDedupeTest(TestCase):
         )
 
     @patch("sentry.analytics.record")
+    def test_fallback_prefers_more_complete_row(self, mock_record: Any) -> None:
+        # No run link on either row (the fallback). The higher-id sibling carries the
+        # richer attribution (run_id + group_ids in signal_details), so it — not the
+        # lower-id row — is canonical and emits the fuller event.
+        SeerRunPullRequest.objects.all().delete()
+        PullRequestAttribution.objects.filter(pull_request=self.sibling_pull_request).update(
+            signal_details={"run_id": 777, "group_ids": [1]}
+        )
+        assert emit_pr_metrics_row(pull_request=self.sibling_pull_request) is True
+        assert emit_pr_metrics_row(pull_request=self.pull_request) is False
+        assert mock_record.call_count == 1
+
+    @patch("sentry.analytics.record")
     def test_tracked_sibling_emits_when_lower_id_row_untracked(self, mock_record: Any) -> None:
         # No run link, and the lower-id row is an untracked shadow (its attribution
         # feature was off in that org) — as happens for a run-less MCP-attributed PR.

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -1509,6 +1509,34 @@ class MultiOrgEmissionDedupeTest(TestCase):
         assert emit_pr_metrics_row(pull_request=self.sibling_pull_request) is False
         assert mock_record.call_count == 1
 
+    @patch("sentry.pr_metrics.emit.logger")
+    @patch("sentry.analytics.record")
+    def test_warns_when_no_run_org_row_among_emitting_siblings(
+        self, mock_record: Any, mock_logger: Any
+    ) -> None:
+        # Two emitting rows for one provider PR, neither linked to a run in its own
+        # org (e.g. a delegated PR whose handoff link dropped) — dedupe still picks
+        # the lowest id, but the link loss is surfaced.
+        SeerRunPullRequest.objects.all().delete()
+        emit_pr_metrics_row(pull_request=self.pull_request)
+        warned = [
+            call
+            for call in mock_logger.warning.call_args_list
+            if call.args and call.args[0] == "pr_metrics.emit.dedup_no_run_org_row"
+        ]
+        assert len(warned) == 1
+
+    @patch("sentry.pr_metrics.emit.logger")
+    @patch("sentry.analytics.record")
+    def test_no_warning_when_run_org_row_present(self, mock_record: Any, mock_logger: Any) -> None:
+        # setUp links the run's-org row, so the canonical is found via the link, not
+        # the lowest-id fallback — no warning.
+        emit_pr_metrics_row(pull_request=self.pull_request)
+        assert not any(
+            call.args and call.args[0] == "pr_metrics.emit.dedup_no_run_org_row"
+            for call in mock_logger.warning.call_args_list
+        )
+
     @patch("sentry.analytics.record")
     def test_tracked_sibling_emits_when_lower_id_row_untracked(self, mock_record: Any) -> None:
         # No run link, and the lower-id row is an untracked shadow (its attribution

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -1467,11 +1467,14 @@ class MultiOrgEmissionDedupeTest(TestCase):
             )
 
     def _repo(self, project: Any) -> Any:
+        # Same integration_id across orgs = one shared installation, so the rows are
+        # siblings of one provider PR.
         return self.create_repo(
             project,
             name="getsentry/sentry",
             provider="integrations:github",
             external_id=EXTERNAL_ID,
+            integration_id=909,
         )
 
     def _mergeable_pr(self, repo: Any, organization: Any) -> Any:

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -1447,10 +1447,10 @@ class MultiOrgEmissionDedupeTest(TestCase):
         # Run's org (org A): the canonical row, linked to the run.
         self.repo = self._repo(self.project)
         self.pull_request = self._mergeable_pr(self.repo, self.organization)
-        self.run = self.create_seer_run(
+        run = self.create_seer_run(
             self.organization, type=SeerRunType.FEATURE_RUN, seer_run_state_id=777
         )
-        self.create_seer_run_pull_request(self.run, self.pull_request)
+        self.create_seer_run_pull_request(run, self.pull_request)
 
         # Sibling org (org B): a shadow row for the same provider PR.
         self.sibling_org = self.create_organization()

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -1532,6 +1532,20 @@ class MultiOrgEmissionDedupeTest(TestCase):
             assert emit_pr_metrics_row(pull_request=self.sibling_pull_request) is True
         assert mock_record.call_count == 1
 
+    @patch("sentry.analytics.record")
+    def test_emit_disabled_row_defers_rather_than_duplicating(self, mock_record: Any) -> None:
+        # The mirror of the above: the run's-org row that lost pr-metrics-emit after
+        # its cooldown was claimed must defer to the enabled sibling, not emit a
+        # duplicate alongside it.
+        with patch(
+            "sentry.pr_metrics.emit.features.has",
+            side_effect=lambda name, org, **kw: not (
+                name == "organizations:pr-metrics-emit" and org.id == self.organization.id
+            ),
+        ):
+            assert emit_pr_metrics_row(pull_request=self.pull_request) is False
+        assert mock_record.call_count == 0
+
 
 @cell_silo_test
 @with_feature(["organizations:pr-metrics-activity", "organizations:gen-ai-features"])

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -1432,7 +1432,13 @@ EXTERNAL_ID = "556677"
 
 
 @cell_silo_test
-@with_feature(["organizations:pr-metrics-activity", "organizations:gen-ai-features"])
+@with_feature(
+    [
+        "organizations:pr-metrics-activity",
+        "organizations:gen-ai-features",
+        "organizations:pr-metrics-emit",
+    ]
+)
 class MultiOrgEmissionDedupeTest(TestCase):
     """A provider PR shared across orgs fans out to one tracked row per org; only
     the canonical (run's-org) row should emit."""
@@ -1508,6 +1514,22 @@ class MultiOrgEmissionDedupeTest(TestCase):
         SeerRunPullRequest.objects.all().delete()
         PullRequestAttribution.objects.filter(pull_request=self.pull_request).delete()
         assert emit_pr_metrics_row(pull_request=self.sibling_pull_request) is True
+        assert mock_record.call_count == 1
+
+    @patch("sentry.analytics.record")
+    def test_emit_disabled_canonical_does_not_suppress_enabled_sibling(
+        self, mock_record: Any
+    ) -> None:
+        # Mid-rollout: the run's-org row (canonical via its link) has pr-metrics-emit
+        # off, the sibling has it on. The sibling must still emit rather than defer to
+        # a canonical that its own emit gate will never let through.
+        with patch(
+            "sentry.pr_metrics.emit.features.has",
+            side_effect=lambda name, org, **kw: not (
+                name == "organizations:pr-metrics-emit" and org.id == self.organization.id
+            ),
+        ):
+            assert emit_pr_metrics_row(pull_request=self.sibling_pull_request) is True
         assert mock_record.call_count == 1
 
 

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -34,6 +34,7 @@ from sentry.pr_metrics.emit import (
     select_verdict,
 )
 from sentry.pr_metrics.utils import _commit_shas_from_activity, resolved_group_ids
+from sentry.seer.models.run import SeerRunPullRequest, SeerRunType
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.analytics import assert_last_analytics_event
@@ -1428,6 +1429,86 @@ class PrMetricsEmissionTest(TestCase):
 
 
 EXTERNAL_ID = "556677"
+
+
+@cell_silo_test
+@with_feature(["organizations:pr-metrics-activity", "organizations:gen-ai-features"])
+class MultiOrgEmissionDedupeTest(TestCase):
+    """A provider PR shared across orgs fans out to one tracked row per org; only
+    the canonical (run's-org) row should emit."""
+
+    def setUp(self) -> None:
+        # Run's org (org A): the canonical row, linked to the run.
+        self.repo = self._repo(self.project)
+        self.pull_request = self._mergeable_pr(self.repo, self.organization)
+        self.run = self.create_seer_run(
+            self.organization, type=SeerRunType.FEATURE_RUN, seer_run_state_id=777
+        )
+        self.create_seer_run_pull_request(self.run, self.pull_request)
+
+        # Sibling org (org B): a shadow row for the same provider PR.
+        self.sibling_org = self.create_organization()
+        self.sibling_repo = self._repo(self.create_project(organization=self.sibling_org))
+        self.sibling_pull_request = self._mergeable_pr(self.sibling_repo, self.sibling_org)
+
+        # Both rows carry the naive webhook attribution, so both pass the gate.
+        for pull_request in (self.pull_request, self.sibling_pull_request):
+            PullRequestAttribution.objects.create(
+                pull_request=pull_request,
+                signal_type=PullRequestAttributionSignalType.SENTRY_APP,
+                source=PullRequestAttributionSource.WEBHOOK_DATA,
+                is_valid=True,
+            )
+
+    def _repo(self, project: Any) -> Any:
+        return self.create_repo(
+            project,
+            name="getsentry/sentry",
+            provider="integrations:github",
+            external_id=EXTERNAL_ID,
+        )
+
+    def _mergeable_pr(self, repo: Any, organization: Any) -> Any:
+        pull_request = self.create_pull_request(
+            repository_id=repo.id, organization_id=organization.id, key="42"
+        )
+        pull_request.head_commit_sha = HEAD_SHA
+        pull_request.merge_commit_sha = MERGE_SHA
+        pull_request.opened_at = OPENED_AT
+        pull_request.closed_at = CLOSED_AT
+        pull_request.merged_at = CLOSED_AT
+        pull_request.draft = False
+        pull_request.save()
+        return pull_request
+
+    @patch("sentry.analytics.record")
+    def test_canonical_run_org_row_emits(self, mock_record: Any) -> None:
+        assert emit_pr_metrics_row(pull_request=self.pull_request) is True
+        assert mock_record.call_count == 1
+
+    @patch("sentry.analytics.record")
+    def test_sibling_row_skipped(self, mock_record: Any) -> None:
+        assert emit_pr_metrics_row(pull_request=self.sibling_pull_request) is False
+        assert mock_record.call_count == 0
+
+    @patch("sentry.analytics.record")
+    def test_lowest_id_row_emits_when_no_run_link(self, mock_record: Any) -> None:
+        # No link ties either row to its own org — the lowest-id row (created
+        # first, the run's-org row here) is the stable canonical pick.
+        SeerRunPullRequest.objects.all().delete()
+        assert emit_pr_metrics_row(pull_request=self.pull_request) is True
+        assert emit_pr_metrics_row(pull_request=self.sibling_pull_request) is False
+        assert mock_record.call_count == 1
+
+    @patch("sentry.analytics.record")
+    def test_tracked_sibling_emits_when_lower_id_row_untracked(self, mock_record: Any) -> None:
+        # No run link, and the lower-id row is an untracked shadow (its attribution
+        # feature was off in that org) — as happens for a run-less MCP-attributed PR.
+        # The tracked higher-id row must still emit, not defer to the untracked row.
+        SeerRunPullRequest.objects.all().delete()
+        PullRequestAttribution.objects.filter(pull_request=self.pull_request).delete()
+        assert emit_pr_metrics_row(pull_request=self.sibling_pull_request) is True
+        assert mock_record.call_count == 1
 
 
 @cell_silo_test


### PR DESCRIPTION
## Problem

A GitHub App installation shared across multiple Sentry orgs fans each PR webhook out to one `PullRequest` row per org. Each org's row independently passes the tracking gate and emits `scm.pr.closed`, so a single provider-side PR is counted once per org — inflating verdict/judge stats and every downstream pr-metrics number.

## Approach

Emit from a single **canonical row** per provider PR, resolved by repo `external_id` + PR number within a cell (`PullRequest.objects.for_provider_pr`):

- the row owned by the Seer run that opened the PR (its `SeerRunPullRequest` link), else the lowest-id row;
- chosen **only among rows that actually emit** (≥1 valid attribution), so an untracked shadow — e.g. a run-less MCP PR whose `mcp-issue-view-attribution` is enabled in one org but not another — can never win canonical and suppress a real emitter.

Non-canonical rows skip with `pr_metrics.emit.skipped{reason: duplicate_github_pr}` for observability. It runs unconditionally: the blast radius is bounded (single-org PRs are always canonical; a bug can at most emit the wrong org's row, never zero rows), and it's a pure runtime change with no deploy ordering.

Cell-local by construction — the remaining cross-cell duplicates are collapsed downstream via the `deduplication_key` from the base PR.

## Stacked

Stacked on #120561 (they share the `_repo_external_identity` helper). **Merge #120561 first.**

## Testing

- `MultiOrgEmissionDedupeTest`: canonical run-org row emits, sibling skipped, lowest-id fallback with no run link, and the MCP untracked-shadow case (tracked sibling still emits).
- `ForProviderPrTest`: cross-org resolution by `external_id`, provider scoping, active-repo and PR-number filters.
