### PR TITLE
feat(admin): Add a Seer plan section to customer overview

### DIFF
--- a/static/gsAdmin/components/customers/customerOverview.spec.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.spec.tsx
@@ -404,13 +404,14 @@ describe('CustomerOverview', () => {
       />
     );
 
-    expect(screen.getByText('Seer Budget')).toBeInTheDocument();
-    expect(screen.getByText('Reserved Budget:')).toBeInTheDocument();
-    expect(screen.getByText('$25.00')).toBeInTheDocument();
-    expect(screen.getByText('Gifted Budget:')).toBeInTheDocument();
-    expect(screen.getByText('$15.00')).toBeInTheDocument();
-    expect(screen.getByText('Total Used:')).toBeInTheDocument();
-    expect(screen.getByText('$20.00 / $40.00 (50.00%)')).toBeInTheDocument();
+    const budgetSection = within(screen.getByTestId('reserved-budgets-data'));
+    expect(budgetSection.getByText('Seer Budget')).toBeInTheDocument();
+    expect(budgetSection.getByText('Reserved Budget:')).toBeInTheDocument();
+    expect(budgetSection.getByText('$25.00')).toBeInTheDocument();
+    expect(budgetSection.getByText('Gifted Budget:')).toBeInTheDocument();
+    expect(budgetSection.getByText('$15.00')).toBeInTheDocument();
+    expect(budgetSection.getByText('Total Used:')).toBeInTheDocument();
+    expect(budgetSection.getByText('$20.00 / $40.00 (50.00%)')).toBeInTheDocument();
     expect(screen.getByText('Reserved Issue fixes:')).toBeInTheDocument();
     expect(screen.getByText('Reserved Cost-Per-Event Issue fixes:')).toBeInTheDocument();
     expect(screen.getByText('$1.00000000')).toBeInTheDocument();
@@ -940,5 +941,95 @@ describe('CustomerOverview', () => {
     );
 
     expect(screen.getByText('90 days')).toBeInTheDocument();
+  });
+
+  describe('Seer plan section', () => {
+    it('renders seat-based Seer details', () => {
+      const organization = OrganizationFixture();
+      const subscription = SubscriptionFixture({organization, plan: 'am3_business'});
+      subscription.addOns = {
+        ...subscription.addOns,
+        [AddOnCategory.SEER]: {
+          ...subscription.addOns![AddOnCategory.SEER]!,
+          enabled: true,
+        },
+      };
+      subscription.categories.seerUsers = MetricHistoryFixture({
+        category: DataCategory.SEER_USER,
+        reserved: 5,
+        usage: 3,
+        free: 1,
+      });
+
+      render(
+        <CustomerOverview
+          customer={subscription}
+          onAction={jest.fn()}
+          organization={organization}
+        />
+      );
+
+      const seerSection = within(screen.getByTestId('seer-plan-summary'));
+      expect(seerSection.getByText('Seat-based')).toBeInTheDocument();
+      expect(seerSection.getByText('Reserved Seats:').nextSibling).toHaveTextContent('5');
+      expect(
+        seerSection.getByText('Active Contributors (billed this period):').nextSibling
+      ).toHaveTextContent('3');
+      expect(seerSection.getByText('Gifted Seats:')).toBeInTheDocument();
+    });
+
+    it('renders legacy budget-based Seer details', () => {
+      const organization = OrganizationFixture();
+      const subscription = SubscriptionWithLegacySeerFixture({
+        organization,
+        plan: 'am3_business',
+      });
+
+      render(
+        <CustomerOverview
+          customer={subscription}
+          onAction={jest.fn()}
+          organization={organization}
+        />
+      );
+
+      const seerSection = within(screen.getByTestId('seer-plan-summary'));
+      expect(seerSection.getByText('Legacy (budget)')).toBeInTheDocument();
+      expect(seerSection.getByText('Reserved Budget:')).toBeInTheDocument();
+      expect(seerSection.getByText('Budget Used:')).toBeInTheDocument();
+    });
+
+    it('renders None when the plan offers Seer but it is not enabled', () => {
+      const organization = OrganizationFixture();
+      const subscription = SubscriptionFixture({organization, plan: 'am3_business'});
+
+      render(
+        <CustomerOverview
+          customer={subscription}
+          onAction={jest.fn()}
+          organization={organization}
+        />
+      );
+
+      const seerSection = within(screen.getByTestId('seer-plan-summary'));
+      expect(seerSection.getByText('Plan:').nextSibling).toHaveTextContent('None');
+      expect(seerSection.queryByText('Reserved Seats:')).not.toBeInTheDocument();
+      expect(seerSection.queryByText('Reserved Budget:')).not.toBeInTheDocument();
+    });
+
+    it('omits the Seer section when the plan does not offer Seer', () => {
+      const organization = OrganizationFixture();
+      const subscription = SubscriptionFixture({organization, plan: 'mm2_a_100k'});
+
+      render(
+        <CustomerOverview
+          customer={subscription}
+          onAction={jest.fn()}
+          organization={organization}
+        />
+      );
+
+      expect(screen.queryByTestId('seer-plan-summary')).not.toBeInTheDocument();
+    });
   });
 });

--- a/static/gsAdmin/components/customers/customerOverview.spec.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.spec.tsx
@@ -1067,7 +1067,7 @@ describe('CustomerOverview', () => {
       expect(seerSection.queryByText('Reserved Budget:')).not.toBeInTheDocument();
     });
 
-    it('omits the Seer section when the plan does not offer Seer', () => {
+    it('shows Seer is unavailable when the plan does not offer it', () => {
       const organization = OrganizationFixture();
       const subscription = SubscriptionFixture({organization, plan: 'mm2_a_100k'});
 
@@ -1079,7 +1079,12 @@ describe('CustomerOverview', () => {
         />
       );
 
-      expect(screen.queryByTestId('seer-plan-summary')).not.toBeInTheDocument();
+      const seerSection = within(screen.getByTestId('seer-plan-summary'));
+      expect(seerSection.getByText('Plan:').nextSibling).toHaveTextContent(
+        `Not available on the ${subscription.planDetails.name} plan`
+      );
+      expect(seerSection.queryByText('Reserved Seats:')).not.toBeInTheDocument();
+      expect(seerSection.queryByText('Reserved Budget:')).not.toBeInTheDocument();
     });
   });
 });

--- a/static/gsAdmin/components/customers/customerOverview.spec.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.spec.tsx
@@ -999,7 +999,7 @@ describe('CustomerOverview', () => {
       expect(seerSection.getByText('Budget Used:')).toBeInTheDocument();
     });
 
-    it('flags a seat-based plan with no seat data instead of hiding it', () => {
+    it('shows zeroed seats when seat-based Seer is enabled before any usage', () => {
       const organization = OrganizationFixture();
       const subscription = SubscriptionFixture({organization, plan: 'am3_business'});
       subscription.addOns = {
@@ -1009,6 +1009,7 @@ describe('CustomerOverview', () => {
           enabled: true,
         },
       };
+      // Enabled via opt-in/trial before any seat usage accrues — no metric row.
       delete subscription.categories.seerUsers;
 
       render(
@@ -1021,9 +1022,11 @@ describe('CustomerOverview', () => {
 
       const seerSection = within(screen.getByTestId('seer-plan-summary'));
       expect(seerSection.getByText('Seat-based')).toBeInTheDocument();
+      expect(seerSection.getByText('Reserved Seats:').nextSibling).toHaveTextContent('0');
       expect(
-        seerSection.getByText('Seat plan enabled but no seat data found')
-      ).toBeInTheDocument();
+        seerSection.getByText('Active Contributors (billed this period):').nextSibling
+      ).toHaveTextContent('0');
+      expect(seerSection.queryByText(/no seat data found/)).not.toBeInTheDocument();
     });
 
     it('flags a legacy plan with no budget data instead of hiding it', () => {

--- a/static/gsAdmin/components/customers/customerOverview.spec.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.spec.tsx
@@ -964,7 +964,6 @@ describe('CustomerOverview', () => {
         usage: 3,
         free: 1,
       });
-      // A lingering trial record must not downgrade a purchased add-on to Trial.
       subscription.productTrials = [makeTrial(DataCategory.SEER_USER)];
 
       render(
@@ -1098,8 +1097,6 @@ describe('CustomerOverview', () => {
     it('does not show budget figures for an unpurchased legacy add-on', () => {
       const organization = OrganizationFixture();
       const subscription = SubscriptionFixture({organization, plan: 'am3_business'});
-      // The serializer surfaces a $0 budget entry for available-but-unpurchased
-      // reserved-budget categories; it must not render beside a non-active status.
       subscription.reservedBudgets = [SeerReservedBudgetFixture({})];
 
       render(
@@ -1163,8 +1160,6 @@ describe('CustomerOverview', () => {
         organization,
         plan: 'am3_business',
       });
-      // Purchased legacy alongside a seat trial: both surface with their own
-      // status; there is no precedence that suppresses one for the other.
       subscription.productTrials = [makeTrial(DataCategory.SEER_USER)];
 
       render(

--- a/static/gsAdmin/components/customers/customerOverview.spec.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.spec.tsx
@@ -999,6 +999,56 @@ describe('CustomerOverview', () => {
       expect(seerSection.getByText('Budget Used:')).toBeInTheDocument();
     });
 
+    it('flags a seat-based plan with no seat data instead of hiding it', () => {
+      const organization = OrganizationFixture();
+      const subscription = SubscriptionFixture({organization, plan: 'am3_business'});
+      subscription.addOns = {
+        ...subscription.addOns,
+        [AddOnCategory.SEER]: {
+          ...subscription.addOns![AddOnCategory.SEER]!,
+          enabled: true,
+        },
+      };
+      delete subscription.categories.seerUsers;
+
+      render(
+        <CustomerOverview
+          customer={subscription}
+          onAction={jest.fn()}
+          organization={organization}
+        />
+      );
+
+      const seerSection = within(screen.getByTestId('seer-plan-summary'));
+      expect(seerSection.getByText('Seat-based')).toBeInTheDocument();
+      expect(
+        seerSection.getByText('Seat plan enabled but no seat data found')
+      ).toBeInTheDocument();
+    });
+
+    it('flags a legacy plan with no budget data instead of hiding it', () => {
+      const organization = OrganizationFixture();
+      const subscription = SubscriptionWithLegacySeerFixture({
+        organization,
+        plan: 'am3_business',
+      });
+      subscription.reservedBudgets = [];
+
+      render(
+        <CustomerOverview
+          customer={subscription}
+          onAction={jest.fn()}
+          organization={organization}
+        />
+      );
+
+      const seerSection = within(screen.getByTestId('seer-plan-summary'));
+      expect(seerSection.getByText('Legacy (budget)')).toBeInTheDocument();
+      expect(
+        seerSection.getByText('Legacy plan enabled but no budget data found')
+      ).toBeInTheDocument();
+    });
+
     it('renders None when the plan offers Seer but it is not enabled', () => {
       const organization = OrganizationFixture();
       const subscription = SubscriptionFixture({organization, plan: 'am3_business'});

--- a/static/gsAdmin/components/customers/customerOverview.spec.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.spec.tsx
@@ -944,16 +944,20 @@ describe('CustomerOverview', () => {
   });
 
   describe('Seer plan section', () => {
-    it('renders seat-based Seer details', () => {
+    function makeTrial(category: DataCategory) {
+      return {
+        category,
+        isStarted: true,
+        reasonCode: 1001,
+        startDate: moment().utc().subtract(2, 'days').format(),
+        endDate: moment().utc().add(12, 'days').format(),
+      };
+    }
+
+    it('renders seat-based Seer status and figures when enabled', () => {
       const organization = OrganizationFixture();
       const subscription = SubscriptionFixture({organization, plan: 'am3_business'});
-      subscription.addOns = {
-        ...subscription.addOns,
-        [AddOnCategory.SEER]: {
-          ...subscription.addOns![AddOnCategory.SEER]!,
-          enabled: true,
-        },
-      };
+      subscription.addOns![AddOnCategory.SEER]!.enabled = true;
       subscription.categories.seerUsers = MetricHistoryFixture({
         category: DataCategory.SEER_USER,
         reserved: 5,
@@ -970,7 +974,9 @@ describe('CustomerOverview', () => {
       );
 
       const seerSection = within(screen.getByTestId('seer-plan-summary'));
-      expect(seerSection.getByText('Seat-based')).toBeInTheDocument();
+      expect(seerSection.getByText('Seat-based:').nextSibling).toHaveTextContent(
+        'Enabled'
+      );
       expect(seerSection.getByText('Reserved Seats:').nextSibling).toHaveTextContent('5');
       expect(
         seerSection.getByText('Active Contributors (billed this period):').nextSibling
@@ -978,7 +984,7 @@ describe('CustomerOverview', () => {
       expect(seerSection.getByText('Gifted Seats:')).toBeInTheDocument();
     });
 
-    it('renders legacy budget-based Seer details', () => {
+    it('renders legacy budget-based Seer status and figures', () => {
       const organization = OrganizationFixture();
       const subscription = SubscriptionWithLegacySeerFixture({
         organization,
@@ -994,7 +1000,9 @@ describe('CustomerOverview', () => {
       );
 
       const seerSection = within(screen.getByTestId('seer-plan-summary'));
-      expect(seerSection.getByText('Legacy (budget)')).toBeInTheDocument();
+      expect(seerSection.getByText('Legacy (budget):').nextSibling).toHaveTextContent(
+        'Enabled'
+      );
       expect(seerSection.getByText('Reserved Budget:')).toBeInTheDocument();
       expect(seerSection.getByText('Budget Used:')).toBeInTheDocument();
     });
@@ -1002,13 +1010,7 @@ describe('CustomerOverview', () => {
     it('shows zeroed seats when seat-based Seer is enabled before any usage', () => {
       const organization = OrganizationFixture();
       const subscription = SubscriptionFixture({organization, plan: 'am3_business'});
-      subscription.addOns = {
-        ...subscription.addOns,
-        [AddOnCategory.SEER]: {
-          ...subscription.addOns![AddOnCategory.SEER]!,
-          enabled: true,
-        },
-      };
+      subscription.addOns![AddOnCategory.SEER]!.enabled = true;
       // Enabled via opt-in/trial before any seat usage accrues — no metric row.
       delete subscription.categories.seerUsers;
 
@@ -1021,15 +1023,16 @@ describe('CustomerOverview', () => {
       );
 
       const seerSection = within(screen.getByTestId('seer-plan-summary'));
-      expect(seerSection.getByText('Seat-based')).toBeInTheDocument();
+      expect(seerSection.getByText('Seat-based:').nextSibling).toHaveTextContent(
+        'Enabled'
+      );
       expect(seerSection.getByText('Reserved Seats:').nextSibling).toHaveTextContent('0');
       expect(
         seerSection.getByText('Active Contributors (billed this period):').nextSibling
       ).toHaveTextContent('0');
-      expect(seerSection.queryByText(/no seat data found/)).not.toBeInTheDocument();
     });
 
-    it('flags a legacy plan with no budget data instead of hiding it', () => {
+    it('flags a paid legacy plan with no budget data', () => {
       const organization = OrganizationFixture();
       const subscription = SubscriptionWithLegacySeerFixture({
         organization,
@@ -1046,13 +1049,15 @@ describe('CustomerOverview', () => {
       );
 
       const seerSection = within(screen.getByTestId('seer-plan-summary'));
-      expect(seerSection.getByText('Legacy (budget)')).toBeInTheDocument();
+      expect(seerSection.getByText('Legacy (budget):').nextSibling).toHaveTextContent(
+        'Enabled'
+      );
       expect(
-        seerSection.getByText('Legacy plan enabled but no budget data found')
+        seerSection.getByText('Enabled but no budget data found')
       ).toBeInTheDocument();
     });
 
-    it('renders None when the plan offers Seer but it is not enabled', () => {
+    it('shows each available Seer add-on as Available when not enabled', () => {
       const organization = OrganizationFixture();
       const subscription = SubscriptionFixture({organization, plan: 'am3_business'});
 
@@ -1065,15 +1070,15 @@ describe('CustomerOverview', () => {
       );
 
       const seerSection = within(screen.getByTestId('seer-plan-summary'));
-      expect(seerSection.getByText('Plan:').nextSibling).toHaveTextContent('None');
+      expect(seerSection.getByText('Seat-based:').nextSibling).toHaveTextContent(
+        'Available'
+      );
       expect(seerSection.queryByText('Reserved Seats:')).not.toBeInTheDocument();
-      expect(seerSection.queryByText('Reserved Budget:')).not.toBeInTheDocument();
     });
 
-    it('treats unavailable Seer add-ons as unavailable, not None', () => {
+    it('marks an ineligible Seer add-on as Unavailable', () => {
       const organization = OrganizationFixture();
       const subscription = SubscriptionFixture({organization, plan: 'am3_business'});
-      // Add-on entries exist on the plan but the org is not eligible for them.
       Object.values(AddOnCategory).forEach(category => {
         if (subscription.addOns?.[category]) {
           subscription.addOns[category].enabled = false;
@@ -1090,10 +1095,9 @@ describe('CustomerOverview', () => {
       );
 
       const seerSection = within(screen.getByTestId('seer-plan-summary'));
-      expect(seerSection.getByText('Plan:').nextSibling).toHaveTextContent(
-        `Not available on the ${subscription.planDetails.name} plan`
+      expect(seerSection.getByText('Seat-based:').nextSibling).toHaveTextContent(
+        'Unavailable'
       );
-      expect(seerSection.queryByText('None')).not.toBeInTheDocument();
     });
 
     it('shows Seer is unavailable when the plan does not offer it', () => {
@@ -1112,24 +1116,15 @@ describe('CustomerOverview', () => {
       expect(seerSection.getByText('Plan:').nextSibling).toHaveTextContent(
         `Not available on the ${subscription.planDetails.name} plan`
       );
-      expect(seerSection.queryByText('Reserved Seats:')).not.toBeInTheDocument();
-      expect(seerSection.queryByText('Reserved Budget:')).not.toBeInTheDocument();
+      expect(seerSection.queryByText('Seat-based:')).not.toBeInTheDocument();
+      expect(seerSection.queryByText('Legacy (budget):')).not.toBeInTheDocument();
     });
 
-    it('detects an active seat-based Seer trial as seat-based', () => {
+    it('shows a seat-based Seer trial as Trial with seat figures', () => {
       const organization = OrganizationFixture();
       const subscription = SubscriptionFixture({organization, plan: 'am3_business'});
-      // Add-on unpurchased, but an active SEER_USER trial is in use.
       subscription.addOns![AddOnCategory.SEER]!.enabled = false;
-      subscription.productTrials = [
-        {
-          category: DataCategory.SEER_USER,
-          isStarted: true,
-          reasonCode: 1001,
-          startDate: moment().utc().subtract(2, 'days').format(),
-          endDate: moment().utc().add(12, 'days').format(),
-        },
-      ];
+      subscription.productTrials = [makeTrial(DataCategory.SEER_USER)];
 
       render(
         <CustomerOverview
@@ -1140,27 +1135,16 @@ describe('CustomerOverview', () => {
       );
 
       const seerSection = within(screen.getByTestId('seer-plan-summary'));
-      expect(seerSection.getByText('Plan:').nextSibling).toHaveTextContent(
-        'Seat-based (trial)'
-      );
+      expect(seerSection.getByText('Seat-based:').nextSibling).toHaveTextContent('Trial');
       expect(seerSection.getByText('Reserved Seats:')).toBeInTheDocument();
-      expect(seerSection.queryByText('None')).not.toBeInTheDocument();
     });
 
-    it('detects an active legacy Seer trial without flagging missing budget', () => {
+    it('shows a legacy Seer trial as Trial without flagging missing budget', () => {
       const organization = OrganizationFixture();
       const subscription = SubscriptionFixture({organization, plan: 'am3_business'});
       subscription.addOns![AddOnCategory.LEGACY_SEER]!.enabled = false;
       subscription.reservedBudgets = [];
-      subscription.productTrials = [
-        {
-          category: DataCategory.SEER_AUTOFIX,
-          isStarted: true,
-          reasonCode: 1002,
-          startDate: moment().utc().subtract(2, 'days').format(),
-          endDate: moment().utc().add(12, 'days').format(),
-        },
-      ];
+      subscription.productTrials = [makeTrial(DataCategory.SEER_AUTOFIX)];
 
       render(
         <CustomerOverview
@@ -1171,12 +1155,65 @@ describe('CustomerOverview', () => {
       );
 
       const seerSection = within(screen.getByTestId('seer-plan-summary'));
-      expect(seerSection.getByText('Plan:').nextSibling).toHaveTextContent(
-        'Legacy (budget) (trial)'
+      expect(seerSection.getByText('Legacy (budget):').nextSibling).toHaveTextContent(
+        'Trial'
       );
       expect(
-        seerSection.queryByText('Legacy plan enabled but no budget data found')
+        seerSection.queryByText('Enabled but no budget data found')
       ).not.toBeInTheDocument();
+    });
+
+    it('renders seat and legacy add-ons independently when both are present', () => {
+      const organization = OrganizationFixture();
+      const subscription = SubscriptionWithLegacySeerFixture({
+        organization,
+        plan: 'am3_business',
+      });
+      // Purchased legacy plus a lingering seat trial: both surface, neither hides
+      // the other and neither overrides the other's status.
+      subscription.productTrials = [makeTrial(DataCategory.SEER_USER)];
+
+      render(
+        <CustomerOverview
+          customer={subscription}
+          onAction={jest.fn()}
+          organization={organization}
+        />
+      );
+
+      const seerSection = within(screen.getByTestId('seer-plan-summary'));
+      expect(seerSection.getByText('Legacy (budget):').nextSibling).toHaveTextContent(
+        'Enabled'
+      );
+      expect(seerSection.getByText('Seat-based:').nextSibling).toHaveTextContent('Trial');
+      expect(seerSection.getByText('Reserved Budget:')).toBeInTheDocument();
+    });
+
+    it('does not mark a purchased add-on as Trial when a trial record lingers', () => {
+      const organization = OrganizationFixture();
+      const subscription = SubscriptionFixture({organization, plan: 'am3_business'});
+      subscription.addOns![AddOnCategory.SEER]!.enabled = true;
+      subscription.categories.seerUsers = MetricHistoryFixture({
+        category: DataCategory.SEER_USER,
+        reserved: 5,
+      });
+      subscription.productTrials = [makeTrial(DataCategory.SEER_USER)];
+
+      render(
+        <CustomerOverview
+          customer={subscription}
+          onAction={jest.fn()}
+          organization={organization}
+        />
+      );
+
+      const seerSection = within(screen.getByTestId('seer-plan-summary'));
+      expect(seerSection.getByText('Seat-based:').nextSibling).toHaveTextContent(
+        'Enabled'
+      );
+      expect(seerSection.getByText('Seat-based:').nextSibling).not.toHaveTextContent(
+        'Trial'
+      );
     });
   });
 });

--- a/static/gsAdmin/components/customers/customerOverview.spec.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.spec.tsx
@@ -954,7 +954,7 @@ describe('CustomerOverview', () => {
       };
     }
 
-    it('renders seat-based Seer status and figures when enabled', () => {
+    it('shows a purchased seat-based add-on as Enabled with its figures', () => {
       const organization = OrganizationFixture();
       const subscription = SubscriptionFixture({organization, plan: 'am3_business'});
       subscription.addOns![AddOnCategory.SEER]!.enabled = true;
@@ -964,6 +964,8 @@ describe('CustomerOverview', () => {
         usage: 3,
         free: 1,
       });
+      // A lingering trial record must not downgrade a purchased add-on to Trial.
+      subscription.productTrials = [makeTrial(DataCategory.SEER_USER)];
 
       render(
         <CustomerOverview
@@ -974,9 +976,9 @@ describe('CustomerOverview', () => {
       );
 
       const seerSection = within(screen.getByTestId('seer-plan-summary'));
-      expect(seerSection.getByText('Seat-based:').nextSibling).toHaveTextContent(
-        'Enabled'
-      );
+      const status = seerSection.getByText('Seat-based:').nextSibling;
+      expect(status).toHaveTextContent('Enabled');
+      expect(status).not.toHaveTextContent('Trial');
       expect(seerSection.getByText('Reserved Seats:').nextSibling).toHaveTextContent('5');
       expect(
         seerSection.getByText('Active Contributors (billed this period):').nextSibling
@@ -984,7 +986,28 @@ describe('CustomerOverview', () => {
       expect(seerSection.getByText('Gifted Seats:')).toBeInTheDocument();
     });
 
-    it('renders legacy budget-based Seer status and figures', () => {
+    it('shows zeroed seat figures when enabled before any usage accrues', () => {
+      const organization = OrganizationFixture();
+      const subscription = SubscriptionFixture({organization, plan: 'am3_business'});
+      subscription.addOns![AddOnCategory.SEER]!.enabled = true;
+      delete subscription.categories.seerUsers;
+
+      render(
+        <CustomerOverview
+          customer={subscription}
+          onAction={jest.fn()}
+          organization={organization}
+        />
+      );
+
+      const seerSection = within(screen.getByTestId('seer-plan-summary'));
+      expect(seerSection.getByText('Reserved Seats:').nextSibling).toHaveTextContent('0');
+      expect(
+        seerSection.getByText('Active Contributors (billed this period):').nextSibling
+      ).toHaveTextContent('0');
+    });
+
+    it('shows a purchased legacy add-on as Enabled with its budget', () => {
       const organization = OrganizationFixture();
       const subscription = SubscriptionWithLegacySeerFixture({
         organization,
@@ -1007,32 +1030,7 @@ describe('CustomerOverview', () => {
       expect(seerSection.getByText('Budget Used:')).toBeInTheDocument();
     });
 
-    it('shows zeroed seats when seat-based Seer is enabled before any usage', () => {
-      const organization = OrganizationFixture();
-      const subscription = SubscriptionFixture({organization, plan: 'am3_business'});
-      subscription.addOns![AddOnCategory.SEER]!.enabled = true;
-      // Enabled via opt-in/trial before any seat usage accrues — no metric row.
-      delete subscription.categories.seerUsers;
-
-      render(
-        <CustomerOverview
-          customer={subscription}
-          onAction={jest.fn()}
-          organization={organization}
-        />
-      );
-
-      const seerSection = within(screen.getByTestId('seer-plan-summary'));
-      expect(seerSection.getByText('Seat-based:').nextSibling).toHaveTextContent(
-        'Enabled'
-      );
-      expect(seerSection.getByText('Reserved Seats:').nextSibling).toHaveTextContent('0');
-      expect(
-        seerSection.getByText('Active Contributors (billed this period):').nextSibling
-      ).toHaveTextContent('0');
-    });
-
-    it('flags a paid legacy plan with no budget data', () => {
+    it('flags a purchased legacy add-on that is missing its budget', () => {
       const organization = OrganizationFixture();
       const subscription = SubscriptionWithLegacySeerFixture({
         organization,
@@ -1049,97 +1047,12 @@ describe('CustomerOverview', () => {
       );
 
       const seerSection = within(screen.getByTestId('seer-plan-summary'));
-      expect(seerSection.getByText('Legacy (budget):').nextSibling).toHaveTextContent(
-        'Enabled'
-      );
       expect(
         seerSection.getByText('Enabled but no budget data found')
       ).toBeInTheDocument();
     });
 
-    it('shows each available Seer add-on as Available when not enabled', () => {
-      const organization = OrganizationFixture();
-      const subscription = SubscriptionFixture({organization, plan: 'am3_business'});
-
-      render(
-        <CustomerOverview
-          customer={subscription}
-          onAction={jest.fn()}
-          organization={organization}
-        />
-      );
-
-      const seerSection = within(screen.getByTestId('seer-plan-summary'));
-      expect(seerSection.getByText('Seat-based:').nextSibling).toHaveTextContent(
-        'Available'
-      );
-      expect(seerSection.queryByText('Reserved Seats:')).not.toBeInTheDocument();
-    });
-
-    it('marks an ineligible Seer add-on as Unavailable', () => {
-      const organization = OrganizationFixture();
-      const subscription = SubscriptionFixture({organization, plan: 'am3_business'});
-      Object.values(AddOnCategory).forEach(category => {
-        if (subscription.addOns?.[category]) {
-          subscription.addOns[category].enabled = false;
-          subscription.addOns[category].isAvailable = false;
-        }
-      });
-
-      render(
-        <CustomerOverview
-          customer={subscription}
-          onAction={jest.fn()}
-          organization={organization}
-        />
-      );
-
-      const seerSection = within(screen.getByTestId('seer-plan-summary'));
-      expect(seerSection.getByText('Seat-based:').nextSibling).toHaveTextContent(
-        'Unavailable'
-      );
-    });
-
-    it('shows Seer is unavailable when the plan does not offer it', () => {
-      const organization = OrganizationFixture();
-      const subscription = SubscriptionFixture({organization, plan: 'mm2_a_100k'});
-
-      render(
-        <CustomerOverview
-          customer={subscription}
-          onAction={jest.fn()}
-          organization={organization}
-        />
-      );
-
-      const seerSection = within(screen.getByTestId('seer-plan-summary'));
-      expect(seerSection.getByText('Plan:').nextSibling).toHaveTextContent(
-        `Not available on the ${subscription.planDetails.name} plan`
-      );
-      expect(seerSection.queryByText('Seat-based:')).not.toBeInTheDocument();
-      expect(seerSection.queryByText('Legacy (budget):')).not.toBeInTheDocument();
-    });
-
-    it('shows a seat-based Seer trial as Trial with seat figures', () => {
-      const organization = OrganizationFixture();
-      const subscription = SubscriptionFixture({organization, plan: 'am3_business'});
-      subscription.addOns![AddOnCategory.SEER]!.enabled = false;
-      subscription.productTrials = [makeTrial(DataCategory.SEER_USER)];
-
-      render(
-        <CustomerOverview
-          customer={subscription}
-          onAction={jest.fn()}
-          organization={organization}
-        />
-      );
-
-      const seerSection = within(screen.getByTestId('seer-plan-summary'));
-      expect(seerSection.getByText('Seat-based:').nextSibling).toHaveTextContent('Trial');
-      expect(seerSection.getByText('Reserved Seats:')).toBeInTheDocument();
-    });
-
-    it('shows a legacy Seer trial as Trial without flagging missing budget', () => {
+    it('shows a legacy trial as Trial without flagging a missing budget', () => {
       const organization = OrganizationFixture();
       const subscription = SubscriptionFixture({organization, plan: 'am3_business'});
       subscription.addOns![AddOnCategory.LEGACY_SEER]!.enabled = false;
@@ -1163,14 +1076,72 @@ describe('CustomerOverview', () => {
       ).not.toBeInTheDocument();
     });
 
-    it('renders seat and legacy add-ons independently when both are present', () => {
+    it('shows an offered but unpurchased add-on as Available with no figures', () => {
+      const organization = OrganizationFixture();
+      const subscription = SubscriptionFixture({organization, plan: 'am3_business'});
+
+      render(
+        <CustomerOverview
+          customer={subscription}
+          onAction={jest.fn()}
+          organization={organization}
+        />
+      );
+
+      const seerSection = within(screen.getByTestId('seer-plan-summary'));
+      expect(seerSection.getByText('Seat-based:').nextSibling).toHaveTextContent(
+        'Available'
+      );
+      expect(seerSection.queryByText('Reserved Seats:')).not.toBeInTheDocument();
+    });
+
+    it('shows an ineligible add-on as Unavailable', () => {
+      const organization = OrganizationFixture();
+      const subscription = SubscriptionFixture({organization, plan: 'am3_business'});
+      subscription.addOns![AddOnCategory.SEER]!.isAvailable = false;
+
+      render(
+        <CustomerOverview
+          customer={subscription}
+          onAction={jest.fn()}
+          organization={organization}
+        />
+      );
+
+      const seerSection = within(screen.getByTestId('seer-plan-summary'));
+      expect(seerSection.getByText('Seat-based:').nextSibling).toHaveTextContent(
+        'Unavailable'
+      );
+    });
+
+    it('replaces the section with a note when the plan offers no Seer', () => {
+      const organization = OrganizationFixture();
+      const subscription = SubscriptionFixture({organization, plan: 'mm2_a_100k'});
+
+      render(
+        <CustomerOverview
+          customer={subscription}
+          onAction={jest.fn()}
+          organization={organization}
+        />
+      );
+
+      const seerSection = within(screen.getByTestId('seer-plan-summary'));
+      expect(seerSection.getByText('Plan:').nextSibling).toHaveTextContent(
+        `Not available on the ${subscription.planDetails.name} plan`
+      );
+      expect(seerSection.queryByText('Seat-based:')).not.toBeInTheDocument();
+      expect(seerSection.queryByText('Legacy (budget):')).not.toBeInTheDocument();
+    });
+
+    it('renders both add-ons independently, with neither hiding the other', () => {
       const organization = OrganizationFixture();
       const subscription = SubscriptionWithLegacySeerFixture({
         organization,
         plan: 'am3_business',
       });
-      // Purchased legacy plus a lingering seat trial: both surface, neither hides
-      // the other and neither overrides the other's status.
+      // Purchased legacy alongside a seat trial: both surface with their own
+      // status; there is no precedence that suppresses one for the other.
       subscription.productTrials = [makeTrial(DataCategory.SEER_USER)];
 
       render(
@@ -1187,33 +1158,7 @@ describe('CustomerOverview', () => {
       );
       expect(seerSection.getByText('Seat-based:').nextSibling).toHaveTextContent('Trial');
       expect(seerSection.getByText('Reserved Budget:')).toBeInTheDocument();
-    });
-
-    it('does not mark a purchased add-on as Trial when a trial record lingers', () => {
-      const organization = OrganizationFixture();
-      const subscription = SubscriptionFixture({organization, plan: 'am3_business'});
-      subscription.addOns![AddOnCategory.SEER]!.enabled = true;
-      subscription.categories.seerUsers = MetricHistoryFixture({
-        category: DataCategory.SEER_USER,
-        reserved: 5,
-      });
-      subscription.productTrials = [makeTrial(DataCategory.SEER_USER)];
-
-      render(
-        <CustomerOverview
-          customer={subscription}
-          onAction={jest.fn()}
-          organization={organization}
-        />
-      );
-
-      const seerSection = within(screen.getByTestId('seer-plan-summary'));
-      expect(seerSection.getByText('Seat-based:').nextSibling).toHaveTextContent(
-        'Enabled'
-      );
-      expect(seerSection.getByText('Seat-based:').nextSibling).not.toHaveTextContent(
-        'Trial'
-      );
+      expect(seerSection.getByText('Reserved Seats:')).toBeInTheDocument();
     });
   });
 });

--- a/static/gsAdmin/components/customers/customerOverview.spec.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.spec.tsx
@@ -1067,6 +1067,32 @@ describe('CustomerOverview', () => {
       expect(seerSection.queryByText('Reserved Budget:')).not.toBeInTheDocument();
     });
 
+    it('treats unavailable Seer add-ons as unavailable, not None', () => {
+      const organization = OrganizationFixture();
+      const subscription = SubscriptionFixture({organization, plan: 'am3_business'});
+      // Add-on entries exist on the plan but the org is not eligible for them.
+      Object.values(AddOnCategory).forEach(category => {
+        if (subscription.addOns?.[category]) {
+          subscription.addOns[category].enabled = false;
+          subscription.addOns[category].isAvailable = false;
+        }
+      });
+
+      render(
+        <CustomerOverview
+          customer={subscription}
+          onAction={jest.fn()}
+          organization={organization}
+        />
+      );
+
+      const seerSection = within(screen.getByTestId('seer-plan-summary'));
+      expect(seerSection.getByText('Plan:').nextSibling).toHaveTextContent(
+        `Not available on the ${subscription.planDetails.name} plan`
+      );
+      expect(seerSection.queryByText('None')).not.toBeInTheDocument();
+    });
+
     it('shows Seer is unavailable when the plan does not offer it', () => {
       const organization = OrganizationFixture();
       const subscription = SubscriptionFixture({organization, plan: 'mm2_a_100k'});

--- a/static/gsAdmin/components/customers/customerOverview.spec.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.spec.tsx
@@ -1095,6 +1095,29 @@ describe('CustomerOverview', () => {
       expect(seerSection.queryByText('Reserved Seats:')).not.toBeInTheDocument();
     });
 
+    it('does not show budget figures for an unpurchased legacy add-on', () => {
+      const organization = OrganizationFixture();
+      const subscription = SubscriptionFixture({organization, plan: 'am3_business'});
+      // The serializer surfaces a $0 budget entry for available-but-unpurchased
+      // reserved-budget categories; it must not render beside a non-active status.
+      subscription.reservedBudgets = [SeerReservedBudgetFixture({})];
+
+      render(
+        <CustomerOverview
+          customer={subscription}
+          onAction={jest.fn()}
+          organization={organization}
+        />
+      );
+
+      const seerSection = within(screen.getByTestId('seer-plan-summary'));
+      expect(seerSection.getByText('Legacy (budget):').nextSibling).toHaveTextContent(
+        'Available'
+      );
+      expect(seerSection.queryByText('Reserved Budget:')).not.toBeInTheDocument();
+      expect(seerSection.queryByText('Budget Used:')).not.toBeInTheDocument();
+    });
+
     it('shows an ineligible add-on as Unavailable', () => {
       const organization = OrganizationFixture();
       const subscription = SubscriptionFixture({organization, plan: 'am3_business'});

--- a/static/gsAdmin/components/customers/customerOverview.spec.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.spec.tsx
@@ -1115,5 +1115,68 @@ describe('CustomerOverview', () => {
       expect(seerSection.queryByText('Reserved Seats:')).not.toBeInTheDocument();
       expect(seerSection.queryByText('Reserved Budget:')).not.toBeInTheDocument();
     });
+
+    it('detects an active seat-based Seer trial as seat-based', () => {
+      const organization = OrganizationFixture();
+      const subscription = SubscriptionFixture({organization, plan: 'am3_business'});
+      // Add-on unpurchased, but an active SEER_USER trial is in use.
+      subscription.addOns![AddOnCategory.SEER]!.enabled = false;
+      subscription.productTrials = [
+        {
+          category: DataCategory.SEER_USER,
+          isStarted: true,
+          reasonCode: 1001,
+          startDate: moment().utc().subtract(2, 'days').format(),
+          endDate: moment().utc().add(12, 'days').format(),
+        },
+      ];
+
+      render(
+        <CustomerOverview
+          customer={subscription}
+          onAction={jest.fn()}
+          organization={organization}
+        />
+      );
+
+      const seerSection = within(screen.getByTestId('seer-plan-summary'));
+      expect(seerSection.getByText('Plan:').nextSibling).toHaveTextContent(
+        'Seat-based (trial)'
+      );
+      expect(seerSection.getByText('Reserved Seats:')).toBeInTheDocument();
+      expect(seerSection.queryByText('None')).not.toBeInTheDocument();
+    });
+
+    it('detects an active legacy Seer trial without flagging missing budget', () => {
+      const organization = OrganizationFixture();
+      const subscription = SubscriptionFixture({organization, plan: 'am3_business'});
+      subscription.addOns![AddOnCategory.LEGACY_SEER]!.enabled = false;
+      subscription.reservedBudgets = [];
+      subscription.productTrials = [
+        {
+          category: DataCategory.SEER_AUTOFIX,
+          isStarted: true,
+          reasonCode: 1002,
+          startDate: moment().utc().subtract(2, 'days').format(),
+          endDate: moment().utc().add(12, 'days').format(),
+        },
+      ];
+
+      render(
+        <CustomerOverview
+          customer={subscription}
+          onAction={jest.fn()}
+          organization={organization}
+        />
+      );
+
+      const seerSection = within(screen.getByTestId('seer-plan-summary'));
+      expect(seerSection.getByText('Plan:').nextSibling).toHaveTextContent(
+        'Legacy (budget) (trial)'
+      );
+      expect(
+        seerSection.queryByText('Legacy plan enabled but no budget data found')
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/static/gsAdmin/components/customers/customerOverview.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.tsx
@@ -49,6 +49,7 @@ import {
   getBilledCategory,
   getProductTrial,
   isTrial,
+  normalizeMetricHistory,
   RETENTION_SETTINGS_CATEGORIES,
 } from 'getsentry/utils/billing';
 import {
@@ -313,7 +314,12 @@ function SeerPlanSummary({customer}: {customer: Subscription}) {
   const isSeatBased = !!seerAddOn?.enabled;
   const isLegacy = !!legacySeerAddOn?.enabled;
 
-  const seerUsers = customer.categories?.[DataCategory.SEER_USER];
+  // A seat-based org can be enabled (via opt-in or trial) before any seat
+  // usage accrues, so a missing metric row is zero usage, not an error.
+  const seerUsers = normalizeMetricHistory(
+    DataCategory.SEER_USER,
+    customer.categories?.[DataCategory.SEER_USER]
+  );
   const legacyBudget = customer.reservedBudgets?.find(
     budget => budget.apiName === ReservedBudgetCategoryType.SEER
   );
@@ -337,31 +343,26 @@ function SeerPlanSummary({customer}: {customer: Subscription}) {
             </Tag>
           )}
         </DetailLabel>
-        {isSeatBased &&
-          (seerUsers ? (
-            <Fragment>
-              <DetailLabel title="Reserved Seats">
-                {formatReservedWithUnits(seerUsers.reserved, DataCategory.SEER_USER)}
-              </DetailLabel>
-              <DetailLabel title="Active Contributors (billed this period)">
-                {seerUsers.usage.toLocaleString()}
-              </DetailLabel>
-              <DetailLabel title="Gifted Seats">
-                {formatReservedWithUnits(seerUsers.free, DataCategory.SEER_USER, {
-                  isGifted: true,
-                })}
-              </DetailLabel>
-              {typeof seerUsers.customPrice === 'number' && (
-                <DetailLabel title="Custom Price">
-                  {displayPriceWithCents({cents: seerUsers.customPrice})}
-                </DetailLabel>
-              )}
-            </Fragment>
-          ) : (
-            <DetailLabel title="Seats">
-              <Tag variant="danger">Seat plan enabled but no seat data found</Tag>
+        {isSeatBased && (
+          <Fragment>
+            <DetailLabel title="Reserved Seats">
+              {formatReservedWithUnits(seerUsers.reserved, DataCategory.SEER_USER)}
             </DetailLabel>
-          ))}
+            <DetailLabel title="Active Contributors (billed this period)">
+              {seerUsers.usage.toLocaleString()}
+            </DetailLabel>
+            <DetailLabel title="Gifted Seats">
+              {formatReservedWithUnits(seerUsers.free, DataCategory.SEER_USER, {
+                isGifted: true,
+              })}
+            </DetailLabel>
+            {typeof seerUsers.customPrice === 'number' && (
+              <DetailLabel title="Custom Price">
+                {displayPriceWithCents({cents: seerUsers.customPrice})}
+              </DetailLabel>
+            )}
+          </Fragment>
+        )}
         {isLegacy &&
           (legacyBudget ? (
             <Fragment>

--- a/static/gsAdmin/components/customers/customerOverview.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.tsx
@@ -311,8 +311,15 @@ function SeerPlanSummary({customer}: {customer: Subscription}) {
   const legacySeerAddOn = customer.addOns?.[AddOnCategory.LEGACY_SEER];
   const isOffered = !!seerAddOn?.isAvailable || !!legacySeerAddOn?.isAvailable;
 
-  const isSeatBased = !!seerAddOn?.enabled;
-  const isLegacy = !!legacySeerAddOn?.enabled;
+  // An active product trial counts as the plan being in use even when the
+  // add-on hasn't been purchased, matching productIsEnabled. Seat-based and
+  // legacy Seer trial on different billed categories.
+  const trials = customer.productTrials ?? null;
+  const onSeatTrial = !!getActiveProductTrial(trials, DataCategory.SEER_USER);
+  const onLegacyTrial = !!getActiveProductTrial(trials, DataCategory.SEER_AUTOFIX);
+
+  const isSeatBased = !!seerAddOn?.enabled || onSeatTrial;
+  const isLegacy = !!legacySeerAddOn?.enabled || onLegacyTrial;
 
   // A seat-based org can be enabled (via opt-in or trial) before any seat
   // usage accrues, so a missing metric row is zero usage, not an error.
@@ -330,9 +337,9 @@ function SeerPlanSummary({customer}: {customer: Subscription}) {
       <DetailList>
         <DetailLabel title="Plan">
           {isSeatBased ? (
-            <Tag variant="success">Seat-based</Tag>
+            <Tag variant="success">Seat-based{onSeatTrial ? ' (trial)' : ''}</Tag>
           ) : isLegacy ? (
-            <Tag variant="warning">Legacy (budget)</Tag>
+            <Tag variant="warning">Legacy (budget){onLegacyTrial ? ' (trial)' : ''}</Tag>
           ) : isOffered ? (
             <Tag variant="muted">None</Tag>
           ) : (
@@ -377,11 +384,12 @@ function SeerPlanSummary({customer}: {customer: Subscription}) {
                 ({(legacyBudget.percentUsed * 100).toFixed(2)}%)
               </DetailLabel>
             </Fragment>
-          ) : (
+          ) : legacySeerAddOn?.enabled ? (
+            // A paid legacy plan is backed by a reserved budget; a trial is not.
             <DetailLabel title="Budget">
               <Tag variant="danger">Legacy plan enabled but no budget data found</Tag>
             </DetailLabel>
-          ))}
+          ) : null)}
       </DetailList>
     </div>
   );

--- a/static/gsAdmin/components/customers/customerOverview.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.tsx
@@ -348,6 +348,7 @@ function SeerPlanSummary({customer}: {customer: Subscription}) {
     budget => budget.apiName === ReservedBudgetCategoryType.SEER
   );
   const showSeatData = !!seerAddOn?.enabled || onSeatTrial;
+  const showLegacyData = !!legacySeerAddOn?.enabled || onLegacyTrial;
 
   return (
     <div data-test-id="seer-plan-summary">
@@ -394,25 +395,26 @@ function SeerPlanSummary({customer}: {customer: Subscription}) {
             <DetailLabel title="Legacy (budget)">
               <Tag variant={legacyStatus.variant}>{legacyStatus.label}</Tag>
             </DetailLabel>
-            {legacyBudget ? (
-              <Fragment>
-                <DetailLabel title="Reserved Budget">
-                  {displayPriceWithCents({cents: legacyBudget.reservedBudget})}
+            {showLegacyData &&
+              (legacyBudget ? (
+                <Fragment>
+                  <DetailLabel title="Reserved Budget">
+                    {displayPriceWithCents({cents: legacyBudget.reservedBudget})}
+                  </DetailLabel>
+                  <DetailLabel title="Budget Used">
+                    {displayPriceWithCents({cents: legacyBudget.totalReservedSpend})} /{' '}
+                    {displayPriceWithCents({
+                      cents: legacyBudget.reservedBudget + legacyBudget.freeBudget,
+                    })}{' '}
+                    ({(legacyBudget.percentUsed * 100).toFixed(2)}%)
+                  </DetailLabel>
+                </Fragment>
+              ) : legacySeerAddOn?.enabled ? (
+                // A paid legacy plan is backed by a reserved budget; a trial is not.
+                <DetailLabel title="Budget">
+                  <Tag variant="danger">Enabled but no budget data found</Tag>
                 </DetailLabel>
-                <DetailLabel title="Budget Used">
-                  {displayPriceWithCents({cents: legacyBudget.totalReservedSpend})} /{' '}
-                  {displayPriceWithCents({
-                    cents: legacyBudget.reservedBudget + legacyBudget.freeBudget,
-                  })}{' '}
-                  ({(legacyBudget.percentUsed * 100).toFixed(2)}%)
-                </DetailLabel>
-              </Fragment>
-            ) : legacySeerAddOn?.enabled ? (
-              // A paid legacy plan is backed by a reserved budget; a trial is not.
-              <DetailLabel title="Budget">
-                <Tag variant="danger">Enabled but no budget data found</Tag>
-              </DetailLabel>
-            ) : null}
+              ) : null)}
           </Fragment>
         )}
       </DetailList>

--- a/static/gsAdmin/components/customers/customerOverview.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.tsx
@@ -308,10 +308,7 @@ function ReservedBudgetData({
 function SeerPlanSummary({customer}: {customer: Subscription}) {
   const seerAddOn = customer.addOns?.[AddOnCategory.SEER];
   const legacySeerAddOn = customer.addOns?.[AddOnCategory.LEGACY_SEER];
-
-  if (!seerAddOn && !legacySeerAddOn) {
-    return null;
-  }
+  const isOffered = !!seerAddOn || !!legacySeerAddOn;
 
   const isSeatBased = !!seerAddOn?.enabled;
   const isLegacy = !!legacySeerAddOn?.enabled;
@@ -330,8 +327,12 @@ function SeerPlanSummary({customer}: {customer: Subscription}) {
             <Tag variant="success">Seat-based</Tag>
           ) : isLegacy ? (
             <Tag variant="warning">Legacy (budget)</Tag>
-          ) : (
+          ) : isOffered ? (
             <Tag variant="muted">None</Tag>
+          ) : (
+            <Tag variant="muted">
+              Not available on the {customer.planDetails.name} plan
+            </Tag>
           )}
         </DetailLabel>
         {isSeatBased &&

--- a/static/gsAdmin/components/customers/customerOverview.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.tsx
@@ -331,7 +331,9 @@ function SeerPlanSummary({customer}: {customer: Subscription}) {
             <Tag variant="muted">None</Tag>
           ) : (
             <Tag variant="muted">
-              Not available on the {customer.planDetails.name} plan
+              {customer.planDetails?.name
+                ? `Not available on the ${customer.planDetails.name} plan`
+                : 'Not available on this plan'}
             </Tag>
           )}
         </DetailLabel>

--- a/static/gsAdmin/components/customers/customerOverview.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.tsx
@@ -35,7 +35,12 @@ import type {
   ReservedBudgetMetricHistory,
   Subscription,
 } from 'getsentry/types';
-import {AddOnCategory, BillingType, OnDemandBudgetMode} from 'getsentry/types';
+import {
+  AddOnCategory,
+  BillingType,
+  OnDemandBudgetMode,
+  ReservedBudgetCategoryType,
+} from 'getsentry/types';
 import {
   displayBudgetName,
   formatBalance,
@@ -247,7 +252,7 @@ function ReservedBudgetsData({customer}: ReservedDataProps) {
   }
 
   return (
-    <Fragment>
+    <div data-test-id="reserved-budgets-data">
       {customer.reservedBudgets.map(reservedBudget => {
         return (
           <Fragment key={reservedBudget.id}>
@@ -255,7 +260,7 @@ function ReservedBudgetsData({customer}: ReservedDataProps) {
           </Fragment>
         );
       })}
-    </Fragment>
+    </div>
   );
 }
 
@@ -292,6 +297,81 @@ function ReservedBudgetData({
         </DetailLabel>
       </DetailList>
     </Fragment>
+  );
+}
+
+/**
+ * A clearly-labeled summary of the org's Seer plan. All of this data already
+ * lives on the subscription payload, but it's otherwise scattered as anonymous
+ * rows across ReservedData / ReservedBudgetsData, which makes it hard to tell
+ * at a glance which Seer plan an org is on and how many seats they pay for.
+ */
+function SeerPlanSummary({customer}: {customer: Subscription}) {
+  const seerAddOn = customer.addOns?.[AddOnCategory.SEER];
+  const legacySeerAddOn = customer.addOns?.[AddOnCategory.LEGACY_SEER];
+
+  // Seer isn't offered on this subscription's plan at all — nothing to show.
+  if (!seerAddOn && !legacySeerAddOn) {
+    return null;
+  }
+
+  const isSeatBased = !!seerAddOn?.enabled;
+  const isLegacy = !!legacySeerAddOn?.enabled;
+
+  const seerUsers = customer.categories?.[DataCategory.SEER_USER];
+  const legacyBudget = customer.reservedBudgets?.find(
+    budget => budget.apiName === ReservedBudgetCategoryType.SEER
+  );
+
+  return (
+    <div data-test-id="seer-plan-summary">
+      <h6>Seer</h6>
+      <DetailList>
+        <DetailLabel title="Plan">
+          {isSeatBased ? (
+            <Tag variant="success">Seat-based</Tag>
+          ) : isLegacy ? (
+            <Tag variant="warning">Legacy (budget)</Tag>
+          ) : (
+            <Tag variant="muted">None</Tag>
+          )}
+        </DetailLabel>
+        {isSeatBased && seerUsers && (
+          <Fragment>
+            <DetailLabel title="Reserved Seats">
+              {formatReservedWithUnits(seerUsers.reserved, DataCategory.SEER_USER)}
+            </DetailLabel>
+            <DetailLabel title="Active Contributors (billed this period)">
+              {seerUsers.usage.toLocaleString()}
+            </DetailLabel>
+            <DetailLabel title="Gifted Seats">
+              {formatReservedWithUnits(seerUsers.free, DataCategory.SEER_USER, {
+                isGifted: true,
+              })}
+            </DetailLabel>
+            {typeof seerUsers.customPrice === 'number' && (
+              <DetailLabel title="Custom Price">
+                {displayPriceWithCents({cents: seerUsers.customPrice})}
+              </DetailLabel>
+            )}
+          </Fragment>
+        )}
+        {isLegacy && legacyBudget && (
+          <Fragment>
+            <DetailLabel title="Reserved Budget">
+              {displayPriceWithCents({cents: legacyBudget.reservedBudget})}
+            </DetailLabel>
+            <DetailLabel title="Budget Used">
+              {displayPriceWithCents({cents: legacyBudget.totalReservedSpend})} /{' '}
+              {displayPriceWithCents({
+                cents: legacyBudget.reservedBudget + legacyBudget.freeBudget,
+              })}{' '}
+              ({(legacyBudget.percentUsed * 100).toFixed(2)}%)
+            </DetailLabel>
+          </Fragment>
+        )}
+      </DetailList>
+    </div>
   );
 }
 
@@ -917,6 +997,7 @@ export function CustomerOverview({customer, onAction, organization}: Props) {
             </tbody>
           </table>
         </Fragment>
+        <SeerPlanSummary customer={customer} />
       </div>
     </DetailsContainer>
   );

--- a/static/gsAdmin/components/customers/customerOverview.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.tsx
@@ -305,17 +305,21 @@ function ReservedBudgetData({
 function seerAddOnStatus(
   addOn: AddOn | undefined,
   onTrial: boolean
-): {label: string; variant: 'success' | 'warning' | 'muted'} | null {
+): {active: boolean; label: string; variant: 'success' | 'warning' | 'muted'} | null {
   if (!addOn) {
     return null;
   }
   if (addOn.enabled) {
-    return {label: 'Enabled', variant: 'success'};
+    return {label: 'Enabled', variant: 'success', active: true};
   }
   if (onTrial) {
-    return {label: 'Trial', variant: 'warning'};
+    return {label: 'Trial', variant: 'warning', active: true};
   }
-  return {label: addOn.isAvailable ? 'Available' : 'Unavailable', variant: 'muted'};
+  return {
+    label: addOn.isAvailable ? 'Available' : 'Unavailable',
+    variant: 'muted',
+    active: false,
+  };
 }
 
 function SeerPlanSummary({customer}: {customer: Subscription}) {
@@ -335,8 +339,6 @@ function SeerPlanSummary({customer}: {customer: Subscription}) {
   const legacyBudget = customer.reservedBudgets?.find(
     budget => budget.apiName === ReservedBudgetCategoryType.SEER
   );
-  const showSeatData = !!seerAddOn?.enabled || onSeatTrial;
-  const showLegacyData = !!legacySeerAddOn?.enabled || onLegacyTrial;
 
   return (
     <div data-test-id="seer-plan-summary">
@@ -356,7 +358,7 @@ function SeerPlanSummary({customer}: {customer: Subscription}) {
             <DetailLabel title="Seat-based">
               <Tag variant={seatStatus.variant}>{seatStatus.label}</Tag>
             </DetailLabel>
-            {showSeatData && (
+            {seatStatus.active && (
               <Fragment>
                 <DetailLabel title="Reserved Seats">
                   {formatReservedWithUnits(seerUsers.reserved, DataCategory.SEER_USER)}
@@ -383,7 +385,7 @@ function SeerPlanSummary({customer}: {customer: Subscription}) {
             <DetailLabel title="Legacy (budget)">
               <Tag variant={legacyStatus.variant}>{legacyStatus.label}</Tag>
             </DetailLabel>
-            {showLegacyData &&
+            {legacyStatus.active &&
               (legacyBudget ? (
                 <Fragment>
                   <DetailLabel title="Reserved Budget">

--- a/static/gsAdmin/components/customers/customerOverview.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.tsx
@@ -302,9 +302,8 @@ function ReservedBudgetData({
 }
 
 /**
- * Surfaces the org's Seer plan in one labeled place. The same numbers are
- * otherwise scattered as anonymous rows across ReservedData /
- * ReservedBudgetsData.
+ * The same numbers otherwise appear only as anonymous rows across ReservedData
+ * / ReservedBudgetsData; this surfaces the Seer plan in one labeled place.
  */
 function SeerPlanSummary({customer}: {customer: Subscription}) {
   const seerAddOn = customer.addOns?.[AddOnCategory.SEER];
@@ -312,8 +311,7 @@ function SeerPlanSummary({customer}: {customer: Subscription}) {
   const isOffered = !!seerAddOn?.isAvailable || !!legacySeerAddOn?.isAvailable;
 
   // An active product trial counts as the plan being in use even when the
-  // add-on hasn't been purchased, matching productIsEnabled. Seat-based and
-  // legacy Seer trial on different billed categories.
+  // add-on hasn't been purchased, matching productIsEnabled.
   const trials = customer.productTrials ?? null;
   const onSeatTrial = !!getActiveProductTrial(trials, DataCategory.SEER_USER);
   const onLegacyTrial = !!getActiveProductTrial(trials, DataCategory.SEER_AUTOFIX);

--- a/static/gsAdmin/components/customers/customerOverview.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.tsx
@@ -301,16 +301,14 @@ function ReservedBudgetData({
 }
 
 /**
- * A clearly-labeled summary of the org's Seer plan. All of this data already
- * lives on the subscription payload, but it's otherwise scattered as anonymous
- * rows across ReservedData / ReservedBudgetsData, which makes it hard to tell
- * at a glance which Seer plan an org is on and how many seats they pay for.
+ * Surfaces the org's Seer plan in one labeled place. The same numbers are
+ * otherwise scattered as anonymous rows across ReservedData /
+ * ReservedBudgetsData.
  */
 function SeerPlanSummary({customer}: {customer: Subscription}) {
   const seerAddOn = customer.addOns?.[AddOnCategory.SEER];
   const legacySeerAddOn = customer.addOns?.[AddOnCategory.LEGACY_SEER];
 
-  // Seer isn't offered on this subscription's plan at all — nothing to show.
   if (!seerAddOn && !legacySeerAddOn) {
     return null;
   }
@@ -336,40 +334,50 @@ function SeerPlanSummary({customer}: {customer: Subscription}) {
             <Tag variant="muted">None</Tag>
           )}
         </DetailLabel>
-        {isSeatBased && seerUsers && (
-          <Fragment>
-            <DetailLabel title="Reserved Seats">
-              {formatReservedWithUnits(seerUsers.reserved, DataCategory.SEER_USER)}
-            </DetailLabel>
-            <DetailLabel title="Active Contributors (billed this period)">
-              {seerUsers.usage.toLocaleString()}
-            </DetailLabel>
-            <DetailLabel title="Gifted Seats">
-              {formatReservedWithUnits(seerUsers.free, DataCategory.SEER_USER, {
-                isGifted: true,
-              })}
-            </DetailLabel>
-            {typeof seerUsers.customPrice === 'number' && (
-              <DetailLabel title="Custom Price">
-                {displayPriceWithCents({cents: seerUsers.customPrice})}
+        {isSeatBased &&
+          (seerUsers ? (
+            <Fragment>
+              <DetailLabel title="Reserved Seats">
+                {formatReservedWithUnits(seerUsers.reserved, DataCategory.SEER_USER)}
               </DetailLabel>
-            )}
-          </Fragment>
-        )}
-        {isLegacy && legacyBudget && (
-          <Fragment>
-            <DetailLabel title="Reserved Budget">
-              {displayPriceWithCents({cents: legacyBudget.reservedBudget})}
+              <DetailLabel title="Active Contributors (billed this period)">
+                {seerUsers.usage.toLocaleString()}
+              </DetailLabel>
+              <DetailLabel title="Gifted Seats">
+                {formatReservedWithUnits(seerUsers.free, DataCategory.SEER_USER, {
+                  isGifted: true,
+                })}
+              </DetailLabel>
+              {typeof seerUsers.customPrice === 'number' && (
+                <DetailLabel title="Custom Price">
+                  {displayPriceWithCents({cents: seerUsers.customPrice})}
+                </DetailLabel>
+              )}
+            </Fragment>
+          ) : (
+            <DetailLabel title="Seats">
+              <Tag variant="danger">Seat plan enabled but no seat data found</Tag>
             </DetailLabel>
-            <DetailLabel title="Budget Used">
-              {displayPriceWithCents({cents: legacyBudget.totalReservedSpend})} /{' '}
-              {displayPriceWithCents({
-                cents: legacyBudget.reservedBudget + legacyBudget.freeBudget,
-              })}{' '}
-              ({(legacyBudget.percentUsed * 100).toFixed(2)}%)
+          ))}
+        {isLegacy &&
+          (legacyBudget ? (
+            <Fragment>
+              <DetailLabel title="Reserved Budget">
+                {displayPriceWithCents({cents: legacyBudget.reservedBudget})}
+              </DetailLabel>
+              <DetailLabel title="Budget Used">
+                {displayPriceWithCents({cents: legacyBudget.totalReservedSpend})} /{' '}
+                {displayPriceWithCents({
+                  cents: legacyBudget.reservedBudget + legacyBudget.freeBudget,
+                })}{' '}
+                ({(legacyBudget.percentUsed * 100).toFixed(2)}%)
+              </DetailLabel>
+            </Fragment>
+          ) : (
+            <DetailLabel title="Budget">
+              <Tag variant="danger">Legacy plan enabled but no budget data found</Tag>
             </DetailLabel>
-          </Fragment>
-        )}
+          ))}
       </DetailList>
     </div>
   );

--- a/static/gsAdmin/components/customers/customerOverview.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.tsx
@@ -308,7 +308,7 @@ function ReservedBudgetData({
 function SeerPlanSummary({customer}: {customer: Subscription}) {
   const seerAddOn = customer.addOns?.[AddOnCategory.SEER];
   const legacySeerAddOn = customer.addOns?.[AddOnCategory.LEGACY_SEER];
-  const isOffered = !!seerAddOn || !!legacySeerAddOn;
+  const isOffered = !!seerAddOn?.isAvailable || !!legacySeerAddOn?.isAvailable;
 
   const isSeatBased = !!seerAddOn?.enabled;
   const isLegacy = !!legacySeerAddOn?.enabled;

--- a/static/gsAdmin/components/customers/customerOverview.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.tsx
@@ -30,6 +30,7 @@ import {ExtendProductTrialAction} from 'admin/components/extendProductTrialActio
 import {getLogQuery} from 'admin/utils';
 import {BILLED_DATA_CATEGORY_INFO, UNLIMITED} from 'getsentry/constants';
 import type {
+  AddOn,
   Plan,
   ReservedBudget,
   ReservedBudgetMetricHistory,
@@ -302,25 +303,43 @@ function ReservedBudgetData({
 }
 
 /**
+ * The status of one Seer add-on, derived only from that add-on's own signals.
+ * There is deliberately no cross-add-on resolution: each renders independently
+ * so the display can't produce a contradictory combined verdict.
+ */
+function seerAddOnStatus(
+  addOn: AddOn | undefined,
+  onTrial: boolean
+): {label: string; variant: 'success' | 'warning' | 'muted'} | null {
+  if (!addOn) {
+    return null;
+  }
+  if (addOn.enabled) {
+    return {label: 'Enabled', variant: 'success'};
+  }
+  if (onTrial) {
+    return {label: 'Trial', variant: 'warning'};
+  }
+  return {label: addOn.isAvailable ? 'Available' : 'Unavailable', variant: 'muted'};
+}
+
+/**
  * The same numbers otherwise appear only as anonymous rows across ReservedData
- * / ReservedBudgetsData; this surfaces the Seer plan in one labeled place.
+ * / ReservedBudgetsData; this surfaces each Seer add-on's status and figures in
+ * one labeled place.
  */
 function SeerPlanSummary({customer}: {customer: Subscription}) {
   const seerAddOn = customer.addOns?.[AddOnCategory.SEER];
   const legacySeerAddOn = customer.addOns?.[AddOnCategory.LEGACY_SEER];
-  const isOffered = !!seerAddOn?.isAvailable || !!legacySeerAddOn?.isAvailable;
-
-  // An active product trial counts as the plan being in use even when the
-  // add-on hasn't been purchased, matching productIsEnabled.
   const trials = customer.productTrials ?? null;
+
   const onSeatTrial = !!getActiveProductTrial(trials, DataCategory.SEER_USER);
   const onLegacyTrial = !!getActiveProductTrial(trials, DataCategory.SEER_AUTOFIX);
+  const seatStatus = seerAddOnStatus(seerAddOn, onSeatTrial);
+  const legacyStatus = seerAddOnStatus(legacySeerAddOn, onLegacyTrial);
 
-  const isSeatBased = !!seerAddOn?.enabled || onSeatTrial;
-  const isLegacy = !!legacySeerAddOn?.enabled || onLegacyTrial;
-
-  // A seat-based org can be enabled (via opt-in or trial) before any seat
-  // usage accrues, so a missing metric row is zero usage, not an error.
+  // A seat-based org can be active before any seat usage accrues, so a missing
+  // metric row is zero usage, not an error.
   const seerUsers = normalizeMetricHistory(
     DataCategory.SEER_USER,
     customer.categories?.[DataCategory.SEER_USER]
@@ -328,66 +347,74 @@ function SeerPlanSummary({customer}: {customer: Subscription}) {
   const legacyBudget = customer.reservedBudgets?.find(
     budget => budget.apiName === ReservedBudgetCategoryType.SEER
   );
+  const showSeatData = !!seerAddOn?.enabled || onSeatTrial;
 
   return (
     <div data-test-id="seer-plan-summary">
       <h6>Seer</h6>
       <DetailList>
-        <DetailLabel title="Plan">
-          {isSeatBased ? (
-            <Tag variant="success">Seat-based{onSeatTrial ? ' (trial)' : ''}</Tag>
-          ) : isLegacy ? (
-            <Tag variant="warning">Legacy (budget){onLegacyTrial ? ' (trial)' : ''}</Tag>
-          ) : isOffered ? (
-            <Tag variant="muted">None</Tag>
-          ) : (
+        {!seatStatus && !legacyStatus && (
+          <DetailLabel title="Plan">
             <Tag variant="muted">
               {customer.planDetails?.name
                 ? `Not available on the ${customer.planDetails.name} plan`
                 : 'Not available on this plan'}
             </Tag>
-          )}
-        </DetailLabel>
-        {isSeatBased && (
+          </DetailLabel>
+        )}
+        {seatStatus && (
           <Fragment>
-            <DetailLabel title="Reserved Seats">
-              {formatReservedWithUnits(seerUsers.reserved, DataCategory.SEER_USER)}
+            <DetailLabel title="Seat-based">
+              <Tag variant={seatStatus.variant}>{seatStatus.label}</Tag>
             </DetailLabel>
-            <DetailLabel title="Active Contributors (billed this period)">
-              {seerUsers.usage.toLocaleString()}
-            </DetailLabel>
-            <DetailLabel title="Gifted Seats">
-              {formatReservedWithUnits(seerUsers.free, DataCategory.SEER_USER, {
-                isGifted: true,
-              })}
-            </DetailLabel>
-            {typeof seerUsers.customPrice === 'number' && (
-              <DetailLabel title="Custom Price">
-                {displayPriceWithCents({cents: seerUsers.customPrice})}
-              </DetailLabel>
+            {showSeatData && (
+              <Fragment>
+                <DetailLabel title="Reserved Seats">
+                  {formatReservedWithUnits(seerUsers.reserved, DataCategory.SEER_USER)}
+                </DetailLabel>
+                <DetailLabel title="Active Contributors (billed this period)">
+                  {seerUsers.usage.toLocaleString()}
+                </DetailLabel>
+                <DetailLabel title="Gifted Seats">
+                  {formatReservedWithUnits(seerUsers.free, DataCategory.SEER_USER, {
+                    isGifted: true,
+                  })}
+                </DetailLabel>
+                {typeof seerUsers.customPrice === 'number' && (
+                  <DetailLabel title="Custom Price">
+                    {displayPriceWithCents({cents: seerUsers.customPrice})}
+                  </DetailLabel>
+                )}
+              </Fragment>
             )}
           </Fragment>
         )}
-        {isLegacy &&
-          (legacyBudget ? (
-            <Fragment>
-              <DetailLabel title="Reserved Budget">
-                {displayPriceWithCents({cents: legacyBudget.reservedBudget})}
-              </DetailLabel>
-              <DetailLabel title="Budget Used">
-                {displayPriceWithCents({cents: legacyBudget.totalReservedSpend})} /{' '}
-                {displayPriceWithCents({
-                  cents: legacyBudget.reservedBudget + legacyBudget.freeBudget,
-                })}{' '}
-                ({(legacyBudget.percentUsed * 100).toFixed(2)}%)
-              </DetailLabel>
-            </Fragment>
-          ) : legacySeerAddOn?.enabled ? (
-            // A paid legacy plan is backed by a reserved budget; a trial is not.
-            <DetailLabel title="Budget">
-              <Tag variant="danger">Legacy plan enabled but no budget data found</Tag>
+        {legacyStatus && (
+          <Fragment>
+            <DetailLabel title="Legacy (budget)">
+              <Tag variant={legacyStatus.variant}>{legacyStatus.label}</Tag>
             </DetailLabel>
-          ) : null)}
+            {legacyBudget ? (
+              <Fragment>
+                <DetailLabel title="Reserved Budget">
+                  {displayPriceWithCents({cents: legacyBudget.reservedBudget})}
+                </DetailLabel>
+                <DetailLabel title="Budget Used">
+                  {displayPriceWithCents({cents: legacyBudget.totalReservedSpend})} /{' '}
+                  {displayPriceWithCents({
+                    cents: legacyBudget.reservedBudget + legacyBudget.freeBudget,
+                  })}{' '}
+                  ({(legacyBudget.percentUsed * 100).toFixed(2)}%)
+                </DetailLabel>
+              </Fragment>
+            ) : legacySeerAddOn?.enabled ? (
+              // A paid legacy plan is backed by a reserved budget; a trial is not.
+              <DetailLabel title="Budget">
+                <Tag variant="danger">Enabled but no budget data found</Tag>
+              </DetailLabel>
+            ) : null}
+          </Fragment>
+        )}
       </DetailList>
     </div>
   );

--- a/static/gsAdmin/components/customers/customerOverview.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.tsx
@@ -302,11 +302,6 @@ function ReservedBudgetData({
   );
 }
 
-/**
- * The status of one Seer add-on, derived only from that add-on's own signals.
- * There is deliberately no cross-add-on resolution: each renders independently
- * so the display can't produce a contradictory combined verdict.
- */
 function seerAddOnStatus(
   addOn: AddOn | undefined,
   onTrial: boolean
@@ -323,11 +318,6 @@ function seerAddOnStatus(
   return {label: addOn.isAvailable ? 'Available' : 'Unavailable', variant: 'muted'};
 }
 
-/**
- * The same numbers otherwise appear only as anonymous rows across ReservedData
- * / ReservedBudgetsData; this surfaces each Seer add-on's status and figures in
- * one labeled place.
- */
 function SeerPlanSummary({customer}: {customer: Subscription}) {
   const seerAddOn = customer.addOns?.[AddOnCategory.SEER];
   const legacySeerAddOn = customer.addOns?.[AddOnCategory.LEGACY_SEER];
@@ -338,8 +328,6 @@ function SeerPlanSummary({customer}: {customer: Subscription}) {
   const seatStatus = seerAddOnStatus(seerAddOn, onSeatTrial);
   const legacyStatus = seerAddOnStatus(legacySeerAddOn, onLegacyTrial);
 
-  // A seat-based org can be active before any seat usage accrues, so a missing
-  // metric row is zero usage, not an error.
   const seerUsers = normalizeMetricHistory(
     DataCategory.SEER_USER,
     customer.categories?.[DataCategory.SEER_USER]
@@ -410,7 +398,6 @@ function SeerPlanSummary({customer}: {customer: Subscription}) {
                   </DetailLabel>
                 </Fragment>
               ) : legacySeerAddOn?.enabled ? (
-                // A paid legacy plan is backed by a reserved budget; a trial is not.
                 <DetailLabel title="Budget">
                   <Tag variant="danger">Enabled but no budget data found</Tag>
                 </DetailLabel>


### PR DESCRIPTION
It's hard to tell from the admin customer page whether an org is on Seer, and if so whether it's the newer seat-based plan or the legacy budget-based one. Everything needed already ships on the subscription payload, but it's scattered as anonymous rows across the reserved-data and reserved-budget lists.

This adds a labeled **Seer** section to the right column of the customer overview, under Retention Settings. Each Seer add-on (seat-based and legacy) is rendered independently: its own status — `Enabled`, `Trial`, `Available`, or `Unavailable` — derived only from that add-on's own signals, followed by its own figures (reserved seats / active contributors / gifted for seat-based; reserved budget / spend for legacy). There is deliberately no cross-add-on "which plan wins" resolution, so the display can't produce a contradictory verdict and an org mid-migration with both simply shows both. The section as a whole is replaced with a "Not available on the <plan> plan" note when the plan offers no Seer add-on. Frontend-only — the pre-existing per-category and reserved-budget rows are untouched, and no serializer change is needed.