### PR TITLE
test(snuba): Loosen mobile vital test to unblock Snuba bugfix

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_trace.py
@@ -361,7 +361,14 @@ class OrganizationEventsTraceEndpointTest(
             "app.vitals.ttid.value": 1200.0,
             "app.vitals.ttfd.value": 2400.0,
         }
-        assert span["measurements"]["measurements.app_start_cold"] == 0.0
+        # TODO(mjq): This works around a chicken-and-egg problem where a Snuba
+        # fix causes this value to change, but we can't merge it because
+        # Sentry's assertion here would fail. Temporarily allow either value.
+        # Current buggy value: 0.0
+        # Fixed value after Snuba PR is merged: 1600.0
+        # Once https://github.com/getsentry/snuba/pull/8217 is merged, this can
+        # be updated to assert `== 1600.0` alone.
+        assert span["measurements"]["measurements.app_start_cold"] in (0.0, 1600.0)
 
     def test_with_mobile_frames_rate_vitals(self) -> None:
         self.load_trace()


### PR DESCRIPTION
A bugfix in Snuba (https://github.com/getsentry/snuba/pull/8217) is failing CI because of an assertion here in Sentry that asserts on the broken value (`0.0`).

Sentry's behaviour doesn't depend on the broken value (although we have [workarounds for it](https://github.com/getsentry/sentry/pull/118239) that should be made obsolete by this fix), so it's safe to just update the assertion to the new fixed value (`1600.0`).

But, it's a chicken-and-egg problem, since we can't update the assertion without updating Snuba and vice versa. Instead, loosen the assertion in Sentry to accept either the broken or fixed value, then we can merge Snuba, and then we can clean up the assertion to only check the fixed value.