### PR TITLE
feat(seer): Carry structuredContent on the ToolResult client model

### DIFF
--- a/src/sentry/seer/agent/client_models.py
+++ b/src/sentry/seer/agent/client_models.py
@@ -146,6 +146,11 @@ class ToolResult(BaseModel):
     tool_call_id: str
     tool_call_function: str
     content: str | None = None
+    # Standard MCP-style structured payload carried from seer (openspec:
+    # code-mode-effects-registry). Opaque pass-through: frontend-only effects like
+    # `navigation` (RENDERED) ride this to the client. Additive/optional — absent on old
+    # seer responses, ignored by old clients.
+    structuredContent: dict[str, Any] | None = None
 
     class Config:
         extra = "ignore"

--- a/tests/sentry/seer/agent/test_client_models_structured_content.py
+++ b/tests/sentry/seer/agent/test_client_models_structured_content.py
@@ -1,0 +1,42 @@
+"""ToolResult.structuredContent pass-through (openspec: code-mode-effects-registry).
+
+seer carries frontend-only effects (e.g. `navigation`, RENDERED) on a tool result's
+`structuredContent`. The sentry client model must parse it from seer and serialize it back out to
+the frontend; it is additive/optional so old seer responses (no field) still parse.
+"""
+
+from __future__ import annotations
+
+from sentry.seer.agent.client_models import ToolResult
+
+
+def test_structured_content_is_parsed_from_seer():
+    result = ToolResult(
+        tool_call_id="t1",
+        tool_call_function="sentry_api_execute",
+        content="ran",
+        structuredContent={
+            "navigation": [{"kind": "get_issue_details", "params": {"issue_id": "123"}}]
+        },
+    )
+    assert result.structuredContent == {
+        "navigation": [{"kind": "get_issue_details", "params": {"issue_id": "123"}}]
+    }
+
+
+def test_structured_content_defaults_to_none_for_old_seer():
+    result = ToolResult(tool_call_id="t1", tool_call_function="todo_write", content="{}")
+    assert result.structuredContent is None
+
+
+def test_structured_content_round_trips_to_the_frontend_dict():
+    payload = {"navigation": [{"kind": "get_trace_waterfall", "params": {"trace_id": "abc"}}]}
+    result = ToolResult(
+        tool_call_id="t1",
+        tool_call_function="sentry_api_execute",
+        content="ran",
+        structuredContent=payload,
+    )
+    # The chat endpoint serializes the run state via .dict(); the field must survive with its
+    # camelCase name so the frontend can read tool_result.structuredContent.
+    assert result.dict()["structuredContent"] == payload


### PR DESCRIPTION
seer emits frontend-only effects (deep-links) on a tool result's structuredContent, but the ToolResult client model dropped it (extra=ignore), so it never reached the Explorer frontend. Add an additive optional structuredContent pass-through so the chat endpoint's .dict() serialization carries it to the client.

Absent on old seer responses and ignored by old clients — no behavior change on its own and no required deploy order.

Backend half of the links bus (getsentry/seer#7507); the frontend render lands separately in #120570 and depends on this.