### PR TITLE
feat(seer): Render tool links from the structuredContent links bus

### DIFF
--- a/static/app/views/seerExplorer/components/chat/toolUse.spec.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.spec.tsx
@@ -187,9 +187,37 @@ describe('ToolUseBlock', () => {
 
     render(<BlockComponent block={block} blockIndex={0} blocks={[block]} />);
 
-    // The row link renders (from the positional channel); no duplicate labeled link below.
+    // The row link renders (from the positional channel) and is the only link: a failed dedupe
+    // would add a second one below labeled with the raw kind (telemetry_live_search has no
+    // NAV_LINK_LABELS entry), so assert on the link count rather than an unrelated label.
     expect(screen.getByText(/Queried spans/)).toBeInTheDocument();
+    expect(screen.getAllByRole('link')).toHaveLength(1);
+    expect(screen.queryByText('telemetry_live_search')).not.toBeInTheDocument();
+  });
+
+  it('does not render bus links for errored results', () => {
+    // getValidToolLinks drops errored links from the positional channel; the bus applies the same
+    // rule, so a failed tool never surfaces a labeled nav link.
+    const block = createBlock({
+      tool_results: [
+        {
+          tool_call_id: 'call-1',
+          tool_call_function: 'telemetry_live_search',
+          content: '{}',
+          structuredContent: {
+            links: [
+              {kind: 'get_issue_details', params: {issue_id: '123', is_error: true}},
+              {kind: 'get_trace_waterfall', params: {trace_id: 'abc'}},
+            ],
+          },
+        },
+      ],
+    });
+
+    render(<BlockComponent block={block} blockIndex={0} blocks={[block]} />);
+
     expect(screen.queryByText('View issue')).not.toBeInTheDocument();
+    expect(screen.getByText('View trace')).toBeInTheDocument();
   });
 
   it('renders per-row channels in a mixed block (classic positional + Code Mode bus)', () => {

--- a/static/app/views/seerExplorer/components/chat/toolUse.spec.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.spec.tsx
@@ -135,6 +135,113 @@ describe('ToolUseBlock', () => {
     expect(screen.getByText('Propose a fix')).toBeInTheDocument();
   });
 
+  it('renders the links bus from a Code Mode execute (many links, one result)', () => {
+    // seer carries a result's deep-links on its structuredContent.links; a Code Mode execute can
+    // produce many, and each renders as a labeled link (code-mode-effects-registry).
+    const block = createBlock({
+      message: {
+        role: 'tool_use',
+        content: null,
+        tool_calls: [{id: 'call-1', function: 'sentry_api_execute', args: '{}'}],
+      },
+      tool_results: [
+        {
+          tool_call_id: 'call-1',
+          tool_call_function: 'sentry_api_execute',
+          content: 'ran',
+          structuredContent: {
+            links: [
+              {kind: 'get_issue_details', params: {issue_id: '123'}},
+              {kind: 'get_trace_waterfall', params: {trace_id: 'abc'}},
+            ],
+          },
+        },
+      ],
+    });
+
+    render(<BlockComponent block={block} blockIndex={0} blocks={[block]} />);
+
+    expect(screen.getByText('View issue')).toBeInTheDocument();
+    expect(screen.getByText('View trace')).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: /View issue/})).toHaveAttribute(
+      'href',
+      expect.stringContaining('/issues/123/')
+    );
+  });
+
+  it('does not double-render a classic link present in both channels', () => {
+    // A classic tool populates both the positional tool_links (row link) and structuredContent.links
+    // during migration; the bus entry that duplicates the row link is deduped, so it renders once.
+    const block = createBlock({
+      tool_results: [
+        {
+          tool_call_id: 'call-1',
+          tool_call_function: 'telemetry_live_search',
+          content: '{}',
+          structuredContent: {
+            links: [{kind: 'telemetry_live_search', params: {}}],
+          },
+        },
+      ],
+    });
+
+    render(<BlockComponent block={block} blockIndex={0} blocks={[block]} />);
+
+    // The row link renders (from the positional channel); no duplicate labeled link below.
+    expect(screen.getByText(/Queried spans/)).toBeInTheDocument();
+    expect(screen.queryByText('View issue')).not.toBeInTheDocument();
+  });
+
+  it('renders per-row channels in a mixed block (classic positional + Code Mode bus)', () => {
+    // One block, two tool calls: a classic tool renders via the positional tool_links row link,
+    // and a Code Mode execute renders its links from structuredContent — each row independent.
+    const block = createBlock({
+      message: {
+        role: 'tool_use',
+        content: null,
+        tool_calls: [
+          {id: 'call-1', function: 'telemetry_live_search', args: '{}'},
+          {id: 'call-2', function: 'sentry_api_execute', args: '{}'},
+        ],
+      },
+      tool_results: [
+        {
+          tool_call_id: 'call-1',
+          tool_call_function: 'telemetry_live_search',
+          content: '{}',
+        },
+        {
+          tool_call_id: 'call-2',
+          tool_call_function: 'sentry_api_execute',
+          content: 'ran',
+          structuredContent: {
+            links: [{kind: 'get_issue_details', params: {issue_id: '123'}}],
+          },
+        },
+      ],
+      // Positional link for the classic call only; the execute has none.
+      tool_links: [{kind: 'telemetry_live_search', params: {}}, null],
+    });
+
+    const blocks = [block];
+    render(<BlockComponent block={block} blockIndex={0} blocks={blocks} />);
+
+    // Classic row renders via the positional channel.
+    expect(screen.getByText(/Queried spans/)).toBeInTheDocument();
+    // Code Mode row renders its link from the bus.
+    expect(screen.getByRole('link', {name: /View issue/})).toHaveAttribute(
+      'href',
+      expect.stringContaining('/issues/123/')
+    );
+  });
+
+  it('falls back to the positional link when a result has no bus links', () => {
+    // No structuredContent on the result (older seer): the row renders from tool_links.
+    const block = createBlock(); // default: telemetry_live_search + positional tool_link, no bus
+    render(<BlockComponent block={block} blockIndex={0} blocks={[block]} />);
+    expect(screen.getByRole('link', {name: /Queried spans/})).toBeInTheDocument();
+  });
+
   it('does not render action bar', () => {
     render(<BlockComponent block={createBlock()} blockIndex={0} runId={123} />);
     expect(

--- a/static/app/views/seerExplorer/components/chat/toolUse.spec.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.spec.tsx
@@ -220,6 +220,178 @@ describe('ToolUseBlock', () => {
     expect(screen.getByText('View trace')).toBeInTheDocument();
   });
 
+  // The dedupe key is derived from the link's own params, and the bus drops errored links before
+  // deduping. These cases pin down the interaction between those two rules — in particular that an
+  // errored tool call never surfaces a link through either channel, which is the invariant the
+  // positional channel has always had (getValidToolLinks drops is_error links).
+  describe('errored links across both channels', () => {
+    it('renders no link when a classic tool errors (seer writes is_error to both channels)', () => {
+      // seer derives the positional ToolLink and the classic bus entry from the same `metadata`
+      // dict (explorer_agent lifts one into structuredContent["links"] and appends the other to
+      // block.tool_links), so is_error is present in both or neither. This is the shape a real
+      // errored classic tool produces.
+      const erroredParams = {query: 'errors', is_error: true};
+      const block = createBlock({
+        tool_links: [{kind: 'telemetry_live_search', params: erroredParams}],
+        tool_results: [
+          {
+            tool_call_id: 'call-1',
+            tool_call_function: 'telemetry_live_search',
+            content: '{}',
+            structuredContent: {
+              links: [{kind: 'telemetry_live_search', params: erroredParams}],
+            },
+          },
+        ],
+      });
+
+      render(<BlockComponent block={block} blockIndex={0} blocks={[block]} />);
+
+      // The row still describes the call, but nothing is clickable through either channel.
+      expect(screen.getByText(/Queried spans/)).toBeInTheDocument();
+      expect(screen.queryAllByRole('link')).toHaveLength(0);
+    });
+
+    it('renders no link when a Code Mode execute errors', () => {
+      // sentry_api_execute returns {is_error: True} metadata and never publishes the drained
+      // links on its failure path, so the only bus entry is the errored one seer appends.
+      const block = createBlock({
+        message: {
+          role: 'tool_use',
+          content: null,
+          tool_calls: [{id: 'call-1', function: 'sentry_api_execute', args: '{}'}],
+        },
+        tool_links: [{kind: 'sentry_api_execute', params: {is_error: true}}],
+        tool_results: [
+          {
+            tool_call_id: 'call-1',
+            tool_call_function: 'sentry_api_execute',
+            content: 'Error executing code:\nboom',
+            structuredContent: {
+              links: [{kind: 'sentry_api_execute', params: {is_error: true}}],
+            },
+          },
+        ],
+      });
+
+      render(<BlockComponent block={block} blockIndex={0} blocks={[block]} />);
+
+      expect(screen.queryAllByRole('link')).toHaveLength(0);
+    });
+
+    it('renders no link when only the positional channel carries is_error', () => {
+      // Defensive: if the two channels ever disagree about a link's error state (they cannot
+      // today — both read the same params dict), the errored tool must still not surface a link.
+      // The dedupe key ignores is_error so the twin is matched regardless of which side flags it.
+      const block = createBlock({
+        tool_links: [
+          {kind: 'get_issue_details', params: {issue_id: '123', is_error: true}},
+        ],
+        tool_results: [
+          {
+            tool_call_id: 'call-1',
+            tool_call_function: 'get_issue_details',
+            content: '{}',
+            structuredContent: {
+              links: [{kind: 'get_issue_details', params: {issue_id: '123'}}],
+            },
+          },
+        ],
+      });
+
+      render(<BlockComponent block={block} blockIndex={0} blocks={[block]} />);
+
+      expect(screen.queryByText('View issue')).not.toBeInTheDocument();
+      expect(screen.queryAllByRole('link')).toHaveLength(0);
+    });
+
+    it('renders the row link once when only the bus channel carries is_error', () => {
+      // The mirror of the case above. The positional channel is the source of truth for the row
+      // link, so a non-errored positional link still renders; the errored bus twin is dropped
+      // rather than added below it. Either way the link surfaces exactly once, never twice.
+      const block = createBlock({
+        tool_links: [{kind: 'get_issue_details', params: {issue_id: '123'}}],
+        tool_results: [
+          {
+            tool_call_id: 'call-1',
+            tool_call_function: 'get_issue_details',
+            content: '{}',
+            structuredContent: {
+              links: [
+                {kind: 'get_issue_details', params: {issue_id: '123', is_error: true}},
+              ],
+            },
+          },
+        ],
+      });
+
+      render(<BlockComponent block={block} blockIndex={0} blocks={[block]} />);
+
+      expect(screen.getAllByRole('link')).toHaveLength(1);
+    });
+
+    it('keeps unrelated bus links when one bus link is errored', () => {
+      // Dropping an errored link must not drop its siblings on the same result.
+      const block = createBlock({
+        message: {
+          role: 'tool_use',
+          content: null,
+          tool_calls: [{id: 'call-1', function: 'sentry_api_execute', args: '{}'}],
+        },
+        tool_links: [null],
+        tool_results: [
+          {
+            tool_call_id: 'call-1',
+            tool_call_function: 'sentry_api_execute',
+            content: 'ran',
+            structuredContent: {
+              links: [
+                {kind: 'get_issue_details', params: {issue_id: '123', is_error: true}},
+                {kind: 'get_trace_waterfall', params: {trace_id: 'abc'}},
+                {
+                  kind: 'get_replay_details',
+                  params: {replay_id: 'def', project_slug: 'p'},
+                },
+              ],
+            },
+          },
+        ],
+      });
+
+      render(<BlockComponent block={block} blockIndex={0} blocks={[block]} />);
+
+      expect(screen.queryByText('View issue')).not.toBeInTheDocument();
+      expect(screen.getByText('View trace')).toBeInTheDocument();
+      expect(screen.getByText('View replay')).toBeInTheDocument();
+    });
+
+    it('dedupes a twin whose params are in a different key order', () => {
+      // linkKey sorts params, so the dedupe does not depend on JSON key order across channels.
+      const block = createBlock({
+        tool_links: [
+          {kind: 'get_issue_details', params: {issue_id: '123', project_slug: 'p'}},
+        ],
+        tool_results: [
+          {
+            tool_call_id: 'call-1',
+            tool_call_function: 'get_issue_details',
+            content: '{}',
+            structuredContent: {
+              links: [
+                // Same link, keys declared in the opposite order.
+                {kind: 'get_issue_details', params: {project_slug: 'p', issue_id: '123'}},
+              ],
+            },
+          },
+        ],
+      });
+
+      render(<BlockComponent block={block} blockIndex={0} blocks={[block]} />);
+
+      expect(screen.getAllByRole('link')).toHaveLength(1);
+    });
+  });
+
   it('renders per-row channels in a mixed block (classic positional + Code Mode bus)', () => {
     // One block, two tool calls: a classic tool renders via the positional tool_links row link,
     // and a Code Mode execute renders its links from structuredContent — each row independent.

--- a/static/app/views/seerExplorer/components/chat/toolUse.stories.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.stories.tsx
@@ -1,0 +1,119 @@
+import {Fragment} from 'react';
+
+import * as Storybook from 'sentry/stories';
+import {BlockComponent} from 'sentry/views/seerExplorer/components/chat';
+import type {Block} from 'sentry/views/seerExplorer/types';
+
+// Minimal block fixtures for eyeballing the links-bus render (code-mode-effects-registry).
+// View at the dev `/stories` route. No backend/seer needed — BlockComponent is a pure function
+// of the block, so these exercise exactly the render path the links bus lands on.
+
+function block(overrides: Partial<Block>): Block {
+  return {
+    id: 'b1',
+    message: {
+      role: 'tool_use',
+      content: null,
+      tool_calls: [{id: 'call-1', function: 'sentry_api_execute', args: '{}'}],
+    },
+    timestamp: '2026-07-24T00:00:00Z',
+    loading: false,
+    tool_results: [
+      {tool_call_id: 'call-1', tool_call_function: 'sentry_api_execute', content: 'ran'},
+    ],
+    ...overrides,
+  };
+}
+
+const CODE_MODE_MANY_LINKS = block({
+  tool_results: [
+    {
+      tool_call_id: 'call-1',
+      tool_call_function: 'sentry_api_execute',
+      content: 'ran',
+      structuredContent: {
+        links: [
+          {kind: 'get_issue_details', params: {issue_id: '123'}},
+          {kind: 'get_trace_waterfall', params: {trace_id: 'abc'}},
+          {kind: 'get_replay_details', params: {replay_id: 'rep-9'}},
+        ],
+      },
+    },
+  ],
+});
+
+const CLASSIC_POSITIONAL = block({
+  message: {
+    role: 'tool_use',
+    content: null,
+    tool_calls: [{id: 'call-1', function: 'telemetry_live_search', args: '{}'}],
+  },
+  tool_results: [
+    {tool_call_id: 'call-1', tool_call_function: 'telemetry_live_search', content: '{}'},
+  ],
+  tool_links: [{kind: 'telemetry_live_search', params: {}}],
+});
+
+const MIXED = block({
+  message: {
+    role: 'tool_use',
+    content: null,
+    tool_calls: [
+      {id: 'call-1', function: 'telemetry_live_search', args: '{}'},
+      {id: 'call-2', function: 'sentry_api_execute', args: '{}'},
+    ],
+  },
+  tool_results: [
+    {tool_call_id: 'call-1', tool_call_function: 'telemetry_live_search', content: '{}'},
+    {
+      tool_call_id: 'call-2',
+      tool_call_function: 'sentry_api_execute',
+      content: 'ran',
+      structuredContent: {
+        links: [{kind: 'get_issue_details', params: {issue_id: '123'}}],
+      },
+    },
+  ],
+  tool_links: [{kind: 'telemetry_live_search', params: {}}, null],
+});
+
+export default Storybook.story('ToolUseBlock (links bus)', story => {
+  story('Code Mode execute — many links (bus)', () => (
+    <Fragment>
+      <p>
+        A single Code Mode execute produces several deep-links, carried on the tool
+        result's <Storybook.JSXNode name="structuredContent" />
+        .links. Each renders as a labeled link below the row — no index alignment.
+      </p>
+      <BlockComponent
+        block={CODE_MODE_MANY_LINKS}
+        blockIndex={0}
+        blocks={[CODE_MODE_MANY_LINKS]}
+      />
+    </Fragment>
+  ));
+
+  story('Classic tool — positional fallback', () => (
+    <Fragment>
+      <p>
+        No structuredContent on the result (older seer / classic tool): the row renders as
+        a link from the positional block.tool_links.
+      </p>
+      <BlockComponent
+        block={CLASSIC_POSITIONAL}
+        blockIndex={0}
+        blocks={[CLASSIC_POSITIONAL]}
+      />
+    </Fragment>
+  ));
+
+  story('Mixed block — classic row + Code Mode row', () => (
+    <Fragment>
+      <p>
+        One block with two tool calls: the classic tool renders via its positional row
+        link, the Code Mode execute renders its link from the bus — each row independent.
+      </p>
+      <BlockComponent block={MIXED} blockIndex={0} blocks={[MIXED]} />
+    </Fragment>
+  ));
+});

--- a/static/app/views/seerExplorer/components/chat/toolUse.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.tsx
@@ -15,7 +15,7 @@ import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
-import type {Block, TodoItem} from 'sentry/views/seerExplorer/types';
+import type {Block, TodoItem, ToolLink} from 'sentry/views/seerExplorer/types';
 import {
   buildToolLinkUrl,
   getToolsStringFromBlock,
@@ -88,10 +88,26 @@ function useToolLinks(block: Block) {
     return map;
   }, [block.tool_links, block.tool_results]);
 
+  // The links bus (code-mode-effects-registry): a tool result carries its own deep-links in
+  // structuredContent.links as a {kind, params} list. Keyed by tool_call_id, so a result can hold
+  // many with no index alignment. When present, this is the source of truth for that result's
+  // links; when absent, we fall back to the positional block.tool_links below.
+  const busLinksByCallId = useMemo(() => {
+    const map = new Map<string, ToolLink[]>();
+    (block.tool_results || []).forEach(result => {
+      const links = result?.structuredContent?.links;
+      if (result?.tool_call_id && links?.length) {
+        map.set(result.tool_call_id, links);
+      }
+    });
+    return map;
+  }, [block.tool_results]);
+
   return {
     sortedToolLinks,
     toolCallToLinkIndexMap,
     toolLinkByCallId,
+    busLinksByCallId,
     organization,
     projects,
   };
@@ -108,6 +124,7 @@ function ToolCallList({block, blocks, getPageReferrer}: ToolCallListProps) {
     sortedToolLinks,
     toolCallToLinkIndexMap,
     toolLinkByCallId,
+    busLinksByCallId,
     organization,
     projects,
   } = useToolLinks(block);
@@ -122,25 +139,21 @@ function ToolCallList({block, blocks, getPageReferrer}: ToolCallListProps) {
           ? toolLinkByCallId.get(toolCall.id)
           : undefined;
         const hasLink = correspondingLinkIndex !== undefined;
-        const toolUrl = hasLink
-          ? buildToolLinkUrl(
-              sortedToolLinks[correspondingLinkIndex],
-              organization,
-              projects
-            )
+        const positionalLink = hasLink
+          ? sortedToolLinks[correspondingLinkIndex]
+          : undefined;
+        const toolUrl = positionalLink
+          ? buildToolLinkUrl(positionalLink, organization, projects)
           : null;
 
-        const handleLinkClick = hasLink
+        const handleLinkClick = positionalLink
           ? (e: React.MouseEvent) => {
               e.stopPropagation();
-              const selectedLink = sortedToolLinks[correspondingLinkIndex];
-              if (selectedLink) {
-                trackAnalytics('seer.explorer.global_panel.tool_link_navigation', {
-                  referrer: getPageReferrer?.() ?? '',
-                  organization,
-                  tool_kind: selectedLink.kind,
-                });
-              }
+              trackAnalytics('seer.explorer.global_panel.tool_link_navigation', {
+                referrer: getPageReferrer?.() ?? '',
+                organization,
+                tool_kind: positionalLink.kind,
+              });
             }
           : undefined;
 
@@ -161,6 +174,23 @@ function ToolCallList({block, blocks, getPageReferrer}: ToolCallListProps) {
             ? t('Tool call returned empty results')
             : null;
 
+        // Links bus: render the result's own links (structuredContent.links) as labeled links
+        // below the row. Dedupe the one already shown as the positional row link (classic tools
+        // populate both channels during migration), so a Code Mode execute's many links surface
+        // while classic single-link rendering is unchanged.
+        const linkKey = (link: ToolLink) => `${link.kind}:${JSON.stringify(link.params)}`;
+        const positionalKey = positionalLink ? linkKey(positionalLink) : null;
+        const navItems = (toolCall.id ? (busLinksByCallId.get(toolCall.id) ?? []) : [])
+          .filter(link => linkKey(link) !== positionalKey)
+          .map(link => ({
+            kind: link.kind,
+            url: buildToolLinkUrl(link, organization, projects),
+          }))
+          .filter(
+            (item): item is {kind: string; url: NonNullable<typeof item.url>} =>
+              !!item.url
+          );
+
         return (
           <ToolCallRow
             key={toolCall.id ?? `${toolCall.function}-${idx}`}
@@ -170,11 +200,17 @@ function ToolCallList({block, blocks, getPageReferrer}: ToolCallListProps) {
             failureTooltip={failureTooltip}
             onLinkClick={handleLinkClick}
             todos={todos}
+            navItems={navItems}
           />
         );
       })}
     </Stack>
   );
+}
+
+interface NavItem {
+  kind: string;
+  url: NonNullable<ReturnType<typeof buildToolLinkUrl>>;
 }
 
 function ToolCallRow({
@@ -184,9 +220,11 @@ function ToolCallRow({
   failureTooltip,
   onLinkClick,
   todos,
+  navItems,
 }: {
   blockStatus: ToolCallStatus | undefined;
   failureTooltip: string | null;
+  navItems: NavItem[];
   todos: TodoItem[] | null;
   toolString: string;
   toolUrl: ReturnType<typeof buildToolLinkUrl>;
@@ -227,7 +265,34 @@ function ToolCallRow({
           <ToolCallPlainRow>{toolCallText}</ToolCallPlainRow>
         )}
       </Flex>
+      {navItems.length > 0 && <NavLinks navItems={navItems} />}
       {todos && <TodoList todos={todos} />}
+    </Stack>
+  );
+}
+
+const NAV_LINK_LABELS: Record<string, string> = {
+  get_issue_details: t('View issue'),
+  get_trace_waterfall: t('View trace'),
+  get_replay_details: t('View replay'),
+  get_profile_flamegraph: t('View profile'),
+};
+
+function NavLinks({navItems}: {navItems: NavItem[]}) {
+  return (
+    <Stack as="ul" gap="xs" padding="0">
+      {navItems.map((item, idx) => (
+        <Flex key={`${item.kind}-${idx}`} as="li" gap="sm" align="center">
+          <ToolCallLink to={item.url}>
+            <Text size="xs" monospace>
+              {NAV_LINK_LABELS[item.kind] ?? item.kind}
+            </Text>
+            <ToolCallLinkIconWrapper>
+              <ToolCallLinkIcon size="xs" />
+            </ToolCallLinkIconWrapper>
+          </ToolCallLink>
+        </Flex>
+      ))}
     </Stack>
   );
 }

--- a/static/app/views/seerExplorer/components/chat/toolUse.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.tsx
@@ -25,6 +25,18 @@ import {
 import type {ToolUseBlockProps} from './shared';
 import {MessagePlaceholder, getBlockStatus, hasValidContent} from './shared';
 
+// Identity for deduping a bus link against the positional row link. Params are sorted so the key
+// does not depend on object key order — today both channels derive params from the same object, but
+// this keeps the dedupe correct if that ever stops being true.
+function linkKey(link: ToolLink) {
+  const params = link.params ?? {};
+  const sorted = Object.keys(params)
+    .sort()
+    .map(k => `${k}=${JSON.stringify(params[k])}`)
+    .join(',');
+  return `${link.kind}:${sorted}`;
+}
+
 export function ToolUseBlock({
   block,
   showThinking,
@@ -146,15 +158,19 @@ function ToolCallList({block, blocks, getPageReferrer}: ToolCallListProps) {
           ? buildToolLinkUrl(positionalLink, organization, projects)
           : null;
 
+        // Both channels' links stop propagation (so the click doesn't reach the blocks
+        // container's handler) and report the same navigation analytics.
+        const trackLinkClick = (kind: string) => (e: React.MouseEvent) => {
+          e.stopPropagation();
+          trackAnalytics('seer.explorer.global_panel.tool_link_navigation', {
+            referrer: getPageReferrer?.() ?? '',
+            organization,
+            tool_kind: kind,
+          });
+        };
+
         const handleLinkClick = positionalLink
-          ? (e: React.MouseEvent) => {
-              e.stopPropagation();
-              trackAnalytics('seer.explorer.global_panel.tool_link_navigation', {
-                referrer: getPageReferrer?.() ?? '',
-                organization,
-                tool_kind: positionalLink.kind,
-              });
-            }
+          ? trackLinkClick(positionalLink.kind)
           : undefined;
 
         // Render the checklist once per block (on the last tool-call row), regardless of
@@ -177,10 +193,11 @@ function ToolCallList({block, blocks, getPageReferrer}: ToolCallListProps) {
         // Links bus: render the result's own links (structuredContent.links) as labeled links
         // below the row. Dedupe the one already shown as the positional row link (classic tools
         // populate both channels during migration), so a Code Mode execute's many links surface
-        // while classic single-link rendering is unchanged.
-        const linkKey = (link: ToolLink) => `${link.kind}:${JSON.stringify(link.params)}`;
+        // while classic single-link rendering is unchanged. Errored links are dropped here for
+        // the same reason getValidToolLinks drops them from the positional channel.
         const positionalKey = positionalLink ? linkKey(positionalLink) : null;
         const navItems = (toolCall.id ? (busLinksByCallId.get(toolCall.id) ?? []) : [])
+          .filter(link => link.params?.is_error !== true)
           .filter(link => linkKey(link) !== positionalKey)
           .map(link => ({
             kind: link.kind,
@@ -201,6 +218,7 @@ function ToolCallList({block, blocks, getPageReferrer}: ToolCallListProps) {
             onLinkClick={handleLinkClick}
             todos={todos}
             navItems={navItems}
+            onNavLinkClick={trackLinkClick}
           />
         );
       })}
@@ -221,6 +239,7 @@ function ToolCallRow({
   onLinkClick,
   todos,
   navItems,
+  onNavLinkClick,
 }: {
   blockStatus: ToolCallStatus | undefined;
   failureTooltip: string | null;
@@ -229,6 +248,7 @@ function ToolCallRow({
   toolString: string;
   toolUrl: ReturnType<typeof buildToolLinkUrl>;
   onLinkClick?: (e: React.MouseEvent) => void;
+  onNavLinkClick?: (kind: string) => (e: React.MouseEvent) => void;
 }) {
   const hasLink = toolUrl !== null;
 
@@ -265,7 +285,9 @@ function ToolCallRow({
           <ToolCallPlainRow>{toolCallText}</ToolCallPlainRow>
         )}
       </Flex>
-      {navItems.length > 0 && <NavLinks navItems={navItems} />}
+      {navItems.length > 0 && (
+        <NavLinks navItems={navItems} onNavLinkClick={onNavLinkClick} />
+      )}
       {todos && <TodoList todos={todos} />}
     </Stack>
   );
@@ -278,15 +300,23 @@ const NAV_LINK_LABELS: Record<string, string> = {
   get_profile_flamegraph: t('View profile'),
 };
 
-function NavLinks({navItems}: {navItems: NavItem[]}) {
+function NavLinks({
+  navItems,
+  onNavLinkClick,
+}: {
+  navItems: NavItem[];
+  onNavLinkClick?: (kind: string) => (e: React.MouseEvent) => void;
+}) {
   return (
     <Stack as="ul" gap="xs" padding="0">
       {navItems.map((item, idx) => (
         <Flex key={`${item.kind}-${idx}`} as="li" gap="sm" align="center">
-          <ToolCallLink to={item.url}>
-            <Text size="xs" monospace>
+          {/* ToolCallText (not plain Text) so ToolCallLink's hover rule, which targets it by
+              class, colors the label the same way it does the positional row link. */}
+          <ToolCallLink to={item.url} onClick={onNavLinkClick?.(item.kind)}>
+            <ToolCallText size="xs" monospace>
               {NAV_LINK_LABELS[item.kind] ?? item.kind}
-            </Text>
+            </ToolCallText>
             <ToolCallLinkIconWrapper>
               <ToolCallLinkIcon size="xs" />
             </ToolCallLinkIconWrapper>

--- a/static/app/views/seerExplorer/components/chat/toolUse.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.tsx
@@ -25,12 +25,18 @@ import {
 import type {ToolUseBlockProps} from './shared';
 import {MessagePlaceholder, getBlockStatus, hasValidContent} from './shared';
 
+// Result-status metadata rather than part of a link's identity: two entries pointing at the same
+// target are the same link whether or not one side also reports the call failed or came back empty.
+// Excluded from linkKey so the dedupe still matches a twin when only one channel carries them.
+const LINK_STATUS_PARAMS = new Set(['is_error', 'empty_results']);
+
 // Identity for deduping a bus link against the positional row link. Params are sorted so the key
 // does not depend on object key order — today both channels derive params from the same object, but
 // this keeps the dedupe correct if that ever stops being true.
 function linkKey(link: ToolLink) {
   const params = link.params ?? {};
   const sorted = Object.keys(params)
+    .filter(k => !LINK_STATUS_PARAMS.has(k))
     .sort()
     .map(k => `${k}=${JSON.stringify(params[k])}`)
     .join(',');
@@ -100,6 +106,20 @@ function useToolLinks(block: Block) {
     return map;
   }, [block.tool_links, block.tool_results]);
 
+  // The positional links as seer sent them, before getValidToolLinks drops errored/unbuildable
+  // ones. Used only to dedupe the bus against the positional channel: an errored link still has to
+  // suppress its bus twin even though it never renders as a row link itself.
+  const rawToolLinkByCallId = useMemo(() => {
+    const map = new Map<string, ToolLink>();
+    (block.tool_results || []).forEach((result, idx) => {
+      const link = block.tool_links?.[idx];
+      if (result?.tool_call_id && link) {
+        map.set(result.tool_call_id, link);
+      }
+    });
+    return map;
+  }, [block.tool_links, block.tool_results]);
+
   // The links bus (code-mode-effects-registry): a tool result carries its own deep-links in
   // structuredContent.links as a {kind, params} list. Keyed by tool_call_id, so a result can hold
   // many with no index alignment. When present, this is the source of truth for that result's
@@ -119,6 +139,7 @@ function useToolLinks(block: Block) {
     sortedToolLinks,
     toolCallToLinkIndexMap,
     toolLinkByCallId,
+    rawToolLinkByCallId,
     busLinksByCallId,
     organization,
     projects,
@@ -136,6 +157,7 @@ function ToolCallList({block, blocks, getPageReferrer}: ToolCallListProps) {
     sortedToolLinks,
     toolCallToLinkIndexMap,
     toolLinkByCallId,
+    rawToolLinkByCallId,
     busLinksByCallId,
     organization,
     projects,
@@ -195,7 +217,15 @@ function ToolCallList({block, blocks, getPageReferrer}: ToolCallListProps) {
         // populate both channels during migration), so a Code Mode execute's many links surface
         // while classic single-link rendering is unchanged. Errored links are dropped here for
         // the same reason getValidToolLinks drops them from the positional channel.
-        const positionalKey = positionalLink ? linkKey(positionalLink) : null;
+        //
+        // Dedupe against the *raw* positional link, not the filtered `positionalLink`:
+        // getValidToolLinks drops errored (and unbuildable) links, so a failed classic tool has no
+        // `positionalLink` at all. Keying off that would leave its bus twin unmatched and render it
+        // as a success link under a row that failed.
+        const rawPositionalLink = toolCall.id
+          ? rawToolLinkByCallId.get(toolCall.id)
+          : undefined;
+        const positionalKey = rawPositionalLink ? linkKey(rawPositionalLink) : null;
         const navItems = (toolCall.id ? (busLinksByCallId.get(toolCall.id) ?? []) : [])
           .filter(link => link.params?.is_error !== true)
           .filter(link => linkKey(link) !== positionalKey)

--- a/static/app/views/seerExplorer/types.tsx
+++ b/static/app/views/seerExplorer/types.tsx
@@ -80,6 +80,11 @@ export interface ToolResult {
   content: string;
   tool_call_function: string;
   tool_call_id: string;
+  // MCP-style structured payload carried from seer (code-mode-effects-registry).
+  // The links bus: a tool result's own deep-links as a {kind, params} list — one result can
+  // carry many, so there's no index alignment. Optional — absent on old seer responses, in
+  // which case the frontend falls back to the positional block.tool_links.
+  structuredContent?: {links?: ToolLink[]} | null;
 }
 
 export interface ToolCall {


### PR DESCRIPTION
Render a tool result's deep-links from its own structuredContent.links (a {kind, params} list) rather than only the positional block.tool_links. Because the links live on the result, a Code Mode execute — one tool call — can surface many; each renders as a labeled link below the row.

The positional row link is unchanged and the bus entry duplicating it is deduped, so classic single-link rendering is untouched. Falls back to positional tool_links when structuredContent.links is absent (older seer), so it degrades safely with no deploy order.

Frontend half of the links bus; depends on the backend structuredContent pass-through (#120569). seer side: getsentry/seer#7507.