### PR TITLE
fix(apigateway): restore cell tag on async proxy_request counter

### DIFF
--- a/src/sentry/hybridcloud/apigateway_async/apigateway.py
+++ b/src/sentry/hybridcloud/apigateway_async/apigateway.py
@@ -73,14 +73,8 @@ async def proxy_request_if_needed(
         org_id_or_slug = str(
             view_kwargs.get("organization_slug") or view_kwargs.get("organization_id_or_slug", "")
         )
-
-        metrics.incr(
-            "apigateway.proxy_request",
-            tags={
-                **shared_metric_tags,
-                "kind": "orgslug",
-            },
-        )
+        # The orgslug counter is emitted inside proxy_request, after the cell is
+        # resolved, so it can carry the destination_cell tag.
         return await proxy_request(request, org_id_or_slug, url_name)
 
     resolver = _get_view_cell_resolver(view_func)
@@ -90,7 +84,11 @@ async def proxy_request_if_needed(
         if cell:
             metrics.incr(
                 "apigateway.proxy_request",
-                tags={**shared_metric_tags, "kind": "cell_resolver"},
+                tags={
+                    **shared_metric_tags,
+                    "kind": "cell_resolver",
+                    "destination_cell": cell.name,
+                },
             )
             return await proxy_cell_request(request, cell, url_name)
         # If no cell resolved, we drop through to the default resolution method
@@ -105,6 +103,7 @@ async def proxy_request_if_needed(
             tags={
                 **shared_metric_tags,
                 "kind": "regionpin",
+                "destination_cell": cell.name,
             },
         )
 

--- a/src/sentry/hybridcloud/apigateway_async/proxy.py
+++ b/src/sentry/hybridcloud/apigateway_async/proxy.py
@@ -108,6 +108,15 @@ async def proxy_request(
         logger.info("region_resolution_error", extra={"org_slug": org_id_or_slug, "error": str(e)})
         return HttpResponse(status=404)
 
+    metrics.incr(
+        "apigateway.proxy_request",
+        tags={
+            "url_name": url_name,
+            "kind": "orgslug",
+            "destination_cell": cell.name,
+            "request_method": request.method,
+        },
+    )
     return await proxy_cell_request(request, cell, url_name)
 
 
@@ -173,6 +182,8 @@ async def proxy_cell_request(
                     if resp.status_code >= 502:
                         metrics.incr("apigateway.proxy.request_failed", tags=metric_tags)
                         circuitbreaker.incr_failures()
+                    else:
+                        metrics.incr("apigateway.proxy.request_succeeded", tags=metric_tags)
                     return _adapt_response(resp, target_url)
             except asyncio.CancelledError:
                 metrics.incr("apigateway.proxy.request_aborted", tags=metric_tags)

--- a/tests/sentry/hybridcloud/apigateway/test_apigateway.py
+++ b/tests/sentry/hybridcloud/apigateway/test_apigateway.py
@@ -1,3 +1,4 @@
+from unittest.mock import Mock, patch
 from urllib.parse import urlencode
 
 import pytest
@@ -172,7 +173,8 @@ class ApiGatewayTest(ApiGatewayTestCase):
             assert resp.status_code == 200
             assert resp.data["proxy"] is False
 
-    def test_proxy_check_region_pinned_url(self) -> None:
+    @patch("sentry.hybridcloud.apigateway_async.apigateway.metrics")
+    def test_proxy_check_region_pinned_url(self, mock_metrics: Mock) -> None:
         project_key = self.create_project_key(self.project)
         self.httpx_router.add(
             "GET",
@@ -198,6 +200,20 @@ class ApiGatewayTest(ApiGatewayTestCase):
             assert resp.status_code == 200
             assert resp.data["proxy"] is False
 
+        # The js-sdk-loader endpoint resolves its cell via a cell resolver, so
+        # this proxied request goes through the cell_resolver branch.
+        cell_resolver_calls = [
+            c
+            for c in mock_metrics.incr.mock_calls
+            if c.args
+            and c.args[0] == "apigateway.proxy_request"
+            and c.kwargs.get("tags", {}).get("kind") == "cell_resolver"
+        ]
+        assert cell_resolver_calls
+        assert all(
+            c.kwargs["tags"]["destination_cell"] == self.CELL.name for c in cell_resolver_calls
+        )
+
     def test_proxy_check_cell_pinned_url_with_params(self) -> None:
         self.httpx_router.add(
             "GET",
@@ -222,7 +238,8 @@ class ApiGatewayTest(ApiGatewayTestCase):
             assert resp_json["proxy"] is True
             assert resp_json["details"] is True
 
-    def test_proxy_check_cell_pinned_issue_urls(self) -> None:
+    @patch("sentry.hybridcloud.apigateway_async.apigateway.metrics")
+    def test_proxy_check_cell_pinned_issue_urls(self, mock_metrics: Mock) -> None:
         issue = self.create_group()
         self.httpx_router.add(
             "GET",
@@ -252,6 +269,18 @@ class ApiGatewayTest(ApiGatewayTestCase):
             resp_json = json.loads(close_streaming_response(resp))
             assert resp_json["proxy"] is True
             assert resp_json["events"]
+
+        # Issue URLs are region-pinned without a cell resolver, so these proxied
+        # requests go through the regionpin branch.
+        regionpin_calls = [
+            c
+            for c in mock_metrics.incr.mock_calls
+            if c.args
+            and c.args[0] == "apigateway.proxy_request"
+            and c.kwargs.get("tags", {}).get("kind") == "regionpin"
+        ]
+        assert regionpin_calls
+        assert all(c.kwargs["tags"]["destination_cell"] == self.CELL.name for c in regionpin_calls)
 
     def test_proxy_error_embed_dsn(self) -> None:
         self.httpx_router.add(

--- a/tests/sentry/hybridcloud/apigateway/test_proxy.py
+++ b/tests/sentry/hybridcloud/apigateway/test_proxy.py
@@ -1,6 +1,6 @@
 from collections.abc import Generator
 from typing import NoReturn
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 from urllib.parse import urlencode
 
 import httpx
@@ -526,6 +526,62 @@ class ProxyTestCase(ApiGatewayTestCase):
         resp = proxy_request(request, self.organization.slug, url_name)
         close_streaming_response(resp)
         assert captured["content_encoding"] is None
+
+    @patch("sentry.hybridcloud.apigateway_async.proxy.metrics")
+    def test_async_orgslug_metrics_tagged_with_cell_on_success(self, mock_metrics: Mock) -> None:
+        request = RequestFactory().get("http://sentry.io/get")
+        resp = proxy_request(request, self.organization.slug, url_name)
+        close_streaming_response(resp)
+        assert resp.status_code == 200
+
+        mock_metrics.incr.assert_any_call(
+            "apigateway.proxy_request",
+            tags={
+                "url_name": url_name,
+                "kind": "orgslug",
+                "destination_cell": "us",
+                "request_method": "GET",
+            },
+        )
+        mock_metrics.incr.assert_any_call(
+            "apigateway.proxy.request_succeeded",
+            tags={
+                "destination_cell": "us",
+                "url_name": url_name,
+                "destination_host": "http://us.internal.sentry.io",
+                "request_method": "GET",
+            },
+        )
+
+    @patch("sentry.hybridcloud.apigateway_async.proxy.metrics")
+    def test_async_unresolved_org_does_not_emit_proxy_request(self, mock_metrics: Mock) -> None:
+        request = RequestFactory().get("http://sentry.io/get")
+        resp = proxy_request(request, "doesnotexist", url_name)
+        assert resp.status_code == 404
+
+        emitted = [c.args[0] for c in mock_metrics.incr.mock_calls]
+        assert "apigateway.proxy_request" not in emitted
+        assert "apigateway.proxy.request_succeeded" not in emitted
+
+    @patch("sentry.hybridcloud.apigateway_async.proxy.metrics")
+    def test_async_upstream_failure_emits_request_failed_not_succeeded(
+        self, mock_metrics: Mock
+    ) -> None:
+        def bad_gateway(request: httpx.Request) -> tuple[int, dict[str, str], bytes]:
+            return (503, {}, b"{}")
+
+        self.httpx_router.add_callback(
+            "GET", "http://us.internal.sentry.io/bad-gateway", bad_gateway
+        )
+
+        request = RequestFactory().get("http://sentry.io/bad-gateway")
+        resp = proxy_request(request, self.organization.slug, url_name)
+        close_streaming_response(resp)
+        assert resp.status_code == 503
+
+        emitted = [c.args[0] for c in mock_metrics.incr.mock_calls]
+        assert "apigateway.proxy.request_failed" in emitted
+        assert "apigateway.proxy.request_succeeded" not in emitted
 
 
 api_gateway_address_cell = Cell(

--- a/tests/sentry/web/frontend/test_js_sdk_loader.py
+++ b/tests/sentry/web/frontend/test_js_sdk_loader.py
@@ -793,7 +793,6 @@ class JavaScriptSdkLoaderProxyTest(ApiGatewayTestCase):
             assert (
                 "apigateway.proxy_request",
                 (
-                    ("destination_cell", "us"),
                     ("kind", "cell_resolver"),
                     ("request_method", "GET"),
                     ("url_name", "sentry-js-sdk-loader"),
@@ -819,7 +818,6 @@ class JavaScriptSdkLoaderProxyTest(ApiGatewayTestCase):
             assert (
                 "apigateway.proxy_request",
                 (
-                    ("destination_cell", "us"),
                     ("kind", "cell_resolver"),
                     ("request_method", "GET"),
                     ("url_name", "sentry-js-sdk-loader"),

--- a/tests/sentry/web/frontend/test_js_sdk_loader.py
+++ b/tests/sentry/web/frontend/test_js_sdk_loader.py
@@ -734,6 +734,7 @@ class JavaScriptSdkLoaderProxyTest(ApiGatewayTestCase):
                     "url_name": "sentry-js-sdk-loader",
                     "kind": "cell_resolver",
                     "request_method": "GET",
+                    "destination_cell": "us",
                 },
             )
 
@@ -758,6 +759,7 @@ class JavaScriptSdkLoaderProxyTest(ApiGatewayTestCase):
                     "url_name": "sentry-js-sdk-loader",
                     "kind": "cell_resolver",
                     "request_method": "GET",
+                    "destination_cell": "us",
                 },
             )
 
@@ -782,6 +784,7 @@ class JavaScriptSdkLoaderProxyTest(ApiGatewayTestCase):
             assert (
                 "apigateway.proxy_request",
                 (
+                    ("destination_cell", "us"),
                     ("kind", "regionpin"),
                     ("request_method", "GET"),
                     ("url_name", "sentry-js-sdk-loader"),
@@ -790,6 +793,7 @@ class JavaScriptSdkLoaderProxyTest(ApiGatewayTestCase):
             assert (
                 "apigateway.proxy_request",
                 (
+                    ("destination_cell", "us"),
                     ("kind", "cell_resolver"),
                     ("request_method", "GET"),
                     ("url_name", "sentry-js-sdk-loader"),
@@ -815,6 +819,7 @@ class JavaScriptSdkLoaderProxyTest(ApiGatewayTestCase):
             assert (
                 "apigateway.proxy_request",
                 (
+                    ("destination_cell", "us"),
                     ("kind", "cell_resolver"),
                     ("request_method", "GET"),
                     ("url_name", "sentry-js-sdk-loader"),
@@ -823,6 +828,7 @@ class JavaScriptSdkLoaderProxyTest(ApiGatewayTestCase):
             assert (
                 "apigateway.proxy_request",
                 (
+                    ("destination_cell", "us"),
                     ("kind", "regionpin"),
                     ("request_method", "GET"),
                     ("url_name", "sentry-js-sdk-loader"),


### PR DESCRIPTION
The async gateway rollout moved the `apigateway.proxy_request` emission into the dispatcher, before cell resolution, so the `org-slug` path lost its destination-cell tag and the Proxied URL names widget lost its by-cell granularity.

Emit the `org-slug` counter after the cell resolves (mirroring the sync path) and tag the `cell_resolver` and `regionpin` branches too, so every proxied path carries destination_cell — standardized to match the duration, failure, and circuit-breaker metrics. Add an explicit `apigateway.proxy.request_succeeded` counter as a robust SLO numerator.
