### PR TITLE
fix(explore): Show No Data state for empty attribute breakdown chart

### DIFF
--- a/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.spec.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.spec.tsx
@@ -170,7 +170,6 @@ describe('AttributeBreakdownViewerModal', () => {
 
       expect(screen.getByRole('heading', {name: 'empty.attribute'})).toBeInTheDocument();
       expect(screen.queryByText('echarts mock')).not.toBeInTheDocument();
-      // Shows the shared no-data state instead of a blank area or a thrown error
       expect(screen.getByText('No data to plot')).toBeInTheDocument();
     });
   });
@@ -319,7 +318,6 @@ describe('AttributeBreakdownViewerModal', () => {
 
       expect(screen.getByRole('heading', {name: 'empty.attribute'})).toBeInTheDocument();
       expect(screen.queryByText('echarts mock')).not.toBeInTheDocument();
-      // Shows the shared no-data state instead of a blank area or a thrown error
       expect(screen.getByText('No data to plot')).toBeInTheDocument();
     });
   });

--- a/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.spec.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.spec.tsx
@@ -170,6 +170,8 @@ describe('AttributeBreakdownViewerModal', () => {
 
       expect(screen.getByRole('heading', {name: 'empty.attribute'})).toBeInTheDocument();
       expect(screen.queryByText('echarts mock')).not.toBeInTheDocument();
+      // Shows the shared no-data state instead of a blank area or a thrown error
+      expect(screen.getByText('No data to plot')).toBeInTheDocument();
     });
   });
 
@@ -317,6 +319,8 @@ describe('AttributeBreakdownViewerModal', () => {
 
       expect(screen.getByRole('heading', {name: 'empty.attribute'})).toBeInTheDocument();
       expect(screen.queryByText('echarts mock')).not.toBeInTheDocument();
+      // Shows the shared no-data state instead of a blank area or a thrown error
+      expect(screen.getByText('No data to plot')).toBeInTheDocument();
     });
   });
 

--- a/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.tsx
@@ -19,6 +19,7 @@ import type {
   TabularColumn,
   TabularData,
 } from 'sentry/views/dashboards/widgets/common/types';
+import {plottablesCanBeVisualized} from 'sentry/views/dashboards/widgets/plottablesCanBeVisualized';
 import {TableWidgetVisualization} from 'sentry/views/dashboards/widgets/tableWidget/tableWidgetVisualization';
 import {Actions} from 'sentry/views/discover/table/cellAction';
 import type {AttributeBreakdownsComparison} from 'sentry/views/explore/hooks/useAttributeBreakdownComparison';
@@ -281,12 +282,24 @@ export default function AttributeBreakdownViewerModal(props: Props) {
     return transformTableToCategoricalSeries(chartQuery, slicedTableData);
   }, [computedData.tableData, computedData.mode]);
 
-  const hasPlottableValues = useMemo(() => {
-    return chartSeries.some(series => series.values.some(value => value.value !== null));
-  }, [chartSeries]);
-  const singleSeries = chartSeries[0];
-  const selectedSeries = chartSeries[0];
-  const baselineSeries = chartSeries[1];
+  const plottables = useMemo(() => {
+    if (computedData.mode === 'comparison') {
+      const [selectedSeries, baselineSeries] = chartSeries;
+      if (!selectedSeries || !baselineSeries) {
+        return [];
+      }
+      return [
+        new Bars(selectedSeries, {color: primaryColor, alias: 'selected'}),
+        new Bars(baselineSeries, {color: secondaryColor, alias: 'baseline'}),
+      ];
+    }
+
+    const [singleSeries] = chartSeries;
+    if (!singleSeries) {
+      return [];
+    }
+    return [new Bars(singleSeries, {color: primaryColor})];
+  }, [computedData.mode, chartSeries, primaryColor, secondaryColor]);
 
   return (
     <Fragment>
@@ -328,23 +341,14 @@ export default function AttributeBreakdownViewerModal(props: Props) {
         <Stack gap="2xl" height="600px">
           <Container height={`${MODAL_CHART_HEIGHT}px`}>
             <Container height={`${MODAL_CHART_HEIGHT}px`} position="relative">
-              {computedData.mode === 'single' && singleSeries && hasPlottableValues ? (
+              {plottablesCanBeVisualized(plottables) ? (
                 <CategoricalSeriesWidgetVisualization
-                  plottables={[new Bars(singleSeries, {color: primaryColor})]}
-                  showLegend="never"
+                  plottables={plottables}
+                  showLegend={computedData.mode === 'comparison' ? 'always' : 'never'}
                 />
-              ) : computedData.mode === 'comparison' &&
-                selectedSeries &&
-                baselineSeries &&
-                hasPlottableValues ? (
-                <CategoricalSeriesWidgetVisualization
-                  plottables={[
-                    new Bars(selectedSeries, {color: primaryColor, alias: 'selected'}),
-                    new Bars(baselineSeries, {color: secondaryColor, alias: 'baseline'}),
-                  ]}
-                  showLegend="always"
-                />
-              ) : null}
+              ) : (
+                <CategoricalSeriesWidgetVisualization.NoData />
+              )}
             </Container>
           </Container>
 


### PR DESCRIPTION
A bit of refactoring. I started doing this to close a Sentry bug but that bug was a red herring: someone on an old release. That said, I noticed that the "Attribute Breakdown" handling of empty data is a bit messy, and thought I'd just fix it to work like it does everywhere else now.

Refs DAIN-1812