### PR TITLE
fix(issues): Truncate status subtitle so it doesn't overlap progress tag

### DIFF
--- a/static/app/views/issueDetails/header/groupStatusSubtitle.tsx
+++ b/static/app/views/issueDetails/header/groupStatusSubtitle.tsx
@@ -28,7 +28,7 @@ export function GroupStatusSubtitle({group, project}: GroupStatusSubtitleProps) 
   const statusProps = getBadgeProperties(group.status, group.substatus);
 
   return (
-    <Flex gap="md" align="center">
+    <Flex gap="md" align="center" minWidth={0}>
       {group.isUnhandled && (
         <Fragment>
           <UnhandledTag />


### PR DESCRIPTION
Long culprit paths in the issue preview overlapped the progress tag instead of truncating. The status row already wrapped `GroupStatusSubtitle` in a `minWidth={0}` flex, but the component's own root `Flex` kept the default `min-width: auto`, so it never shrank and its inner text ellipsis never fired. Setting `minWidth={0}` on that root lets the subtitle shrink and truncate as intended. This also improves the issue-details header, where the same subtitle previously stretched its grid on long culprits.
