### PR TITLE
fix(issues): Reduce issue preview header height

### DIFF
--- a/static/app/views/issueDetails/issuePreview/issuePreview.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreview.tsx
@@ -52,7 +52,7 @@ export function IssuePreview({groupId}: IssuePreviewProps) {
 
   return (
     <Fragment>
-      <Container padding="md 2xl" borderBottom="muted">
+      <Container padding="xs 2xl" borderBottom="muted">
         <Flex align="center" flex="1" gap="md">
           {group && project && <IssueIdBreadcrumb group={group} project={project} />}
         </Flex>


### PR DESCRIPTION
Reduces the issue preview header height by dropping its vertical padding from `md` (8px) to `xs` (4px), matching the smaller header in the design.
before:
<img width="176" height="63" alt="Screenshot 2026-07-24 at 2 12 18 PM" src="https://github.com/user-attachments/assets/07fd2a88-93e0-446d-8922-02583f71ff48" />

after:
<img width="73" height="63" alt="Screenshot 2026-07-24 at 2 12 28 PM" src="https://github.com/user-attachments/assets/94746880-897c-4c56-847b-616fc5ec2bf3" />

