### PR TITLE
fix(issues): Show placeholder in issue preview header while loading

### DIFF
--- a/static/app/views/issueDetails/issuePreview/issuePreview.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreview.tsx
@@ -10,6 +10,7 @@ import {ErrorBoundary} from 'sentry/components/errorBoundary';
 import {EventMessage} from 'sentry/components/events/eventMessage';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {Placeholder} from 'sentry/components/placeholder';
 import {IconOpen} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {getMessage, getTitle} from 'sentry/utils/events';
@@ -54,7 +55,14 @@ export function IssuePreview({groupId}: IssuePreviewProps) {
     <Fragment>
       <Container padding="xs 2xl" borderBottom="muted">
         <Flex align="center" flex="1" gap="md">
-          {group && project && <IssueIdBreadcrumb group={group} project={project} />}
+          {group && project ? (
+            <IssueIdBreadcrumb group={group} project={project} />
+          ) : isPending ? (
+            <Flex align="center" gap="md" height="36px">
+              <Placeholder width="16px" height="16px" shape="rect" />
+              <Placeholder width="80px" height="16px" shape="rect" />
+            </Flex>
+          ) : null}
         </Flex>
       </Container>
       <Container flexGrow={1} minHeight={0} overflowY="auto" padding="lg 2xl">


### PR DESCRIPTION
While an issue is loading, the preview header rendered as an empty bordered rectangle: the header container mounted, but the breadcrumb inside was gated on the group and project, which weren't loaded yet.

Keep the header section mounted throughout and render a placeholder in place of the breadcrumb while loading — a small avatar square plus a short bar for the issue ID — so the header stays put and the real breadcrumb swaps in once the issue is ready.
