### PR TITLE
ref(sentry-apps): require webhookEvents and drop the pre-granular fallbacks

### DIFF
--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -257,6 +257,9 @@ export type SentryApp = {
   status: SentryAppStatus;
   uuid: string;
   verifyInstall: boolean;
+  // The stored subscriptions as exact event tokens, where `events` consolidates
+  // them to resource names.
+  webhookEvents: string[];
   webhookUrl: string | null;
   allowedOrigins?: string[];
   avatars?: SentryAppAvatar[];
@@ -268,9 +271,6 @@ export type SentryApp = {
     id: number;
     slug: string;
   };
-  // The stored subscriptions as exact event tokens, where `events` consolidates
-  // them to resource names. Absent on older API responses.
-  webhookEvents?: string[];
   // Each entry is a "Header-Name: value" line. Saved values are masked by the API
   webhookHeaders?: string[];
 };

--- a/static/app/views/settings/organizationDeveloperSettings/constants.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/constants.tsx
@@ -9,11 +9,8 @@ export const EVENT_CHOICES = [
   'preprod_artifact',
 ] as const satisfies readonly WebhookEvent[];
 
-// The subscribable webhook vocabulary, mirroring EVENT_EXPANSION on the
-// backend (sentry_apps/utils/webhooks.py). A subscription is a whole resource
-// ("issue") or, with granular events enabled, an individual event
-// ("issue.created"). Needs to be backwards compatible with old stored
-// subscriptions.
+// The webhook subscription vocabulary, mirroring EVENT_EXPANSION in
+// sentry_apps/utils/webhooks.py.
 export const RESOURCE_EVENTS = {
   issue: [
     'issue.created',
@@ -41,11 +38,9 @@ export const RESOURCE_EVENTS = {
   ],
 } as const satisfies Record<WebhookEvent, readonly string[]>;
 
-export type WebhookGranularEvent = (typeof RESOURCE_EVENTS)[WebhookEvent][number];
+export type WebhookSubscription = (typeof RESOURCE_EVENTS)[WebhookEvent][number];
 
-export type WebhookSubscription = WebhookEvent | WebhookGranularEvent;
-
-export const WEBHOOK_GRANULAR_EVENT_CHOICES = [
+export const WEBHOOK_SUBSCRIPTION_CHOICES = [
   ...RESOURCE_EVENTS.issue,
   ...RESOURCE_EVENTS.error,
   ...RESOURCE_EVENTS.comment,
@@ -53,12 +48,12 @@ export const WEBHOOK_GRANULAR_EVENT_CHOICES = [
   ...RESOURCE_EVENTS.preprod_artifact,
 ] as const;
 
-const LEGACY_EVENT_ALIASES: Record<string, WebhookGranularEvent> = {
+const LEGACY_EVENT_ALIASES: Record<string, WebhookSubscription> = {
   'issue.archived': 'issue.ignored',
 };
 
 /** The granular events an app's stored subscriptions cover, whether stored as exact events or whole resources. */
-export function granularWebhookEvents(subscriptions: string[]): WebhookGranularEvent[] {
+export function granularWebhookEvents(subscriptions: string[]): WebhookSubscription[] {
   const stored = new Set<string>(
     subscriptions.map(subscription => LEGACY_EVENT_ALIASES[subscription] ?? subscription)
   );
@@ -69,16 +64,16 @@ export function granularWebhookEvents(subscriptions: string[]): WebhookGranularE
       }
     }
   }
-  return WEBHOOK_GRANULAR_EVENT_CHOICES.filter(event => stored.has(event));
+  return WEBHOOK_SUBSCRIPTION_CHOICES.filter(event => stored.has(event));
 }
 
-const EVENT_LABEL_OVERRIDES: Partial<Record<WebhookGranularEvent, string>> = {
+const EVENT_LABEL_OVERRIDES: Partial<Record<WebhookSubscription, string>> = {
   'issue.ignored': 'Archived', // the product renamed ignore → archive
   'comment.updated': 'Edited', // the product renamed update → edit
   'seer.pr_created': 'PR created', // the transform below would render "Pr created"
 };
 
-export function webhookEventLabel(event: WebhookGranularEvent): string {
+export function webhookEventLabel(event: WebhookSubscription): string {
   return (
     EVENT_LABEL_OVERRIDES[event] ??
     capitalize(event.slice(event.indexOf('.') + 1).replaceAll('_', ' '))

--- a/static/app/views/settings/organizationDeveloperSettings/permissionsObserver.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/permissionsObserver.spec.tsx
@@ -10,7 +10,7 @@ describe('PermissionsObserver', () => {
     render(
       <PermissionsObserver
         scopes={['project:read', 'project:write', 'project:releases', 'org:admin']}
-        events={['issue']}
+        events={['issue.created']}
         newApp={false}
         onScopesChange={onScopesChange}
         onEventsChange={noop}
@@ -32,7 +32,7 @@ describe('PermissionsObserver', () => {
           'org:admin',
           'org:ci',
         ]}
-        events={['issue']}
+        events={['issue.created']}
         newApp={false}
         onScopesChange={onScopesChange}
         onEventsChange={noop}

--- a/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.spec.tsx
@@ -141,7 +141,7 @@ describe('Resource Subscriptions', () => {
       render(
         <Form>
           <Subscriptions
-            events={['issue']}
+            events={['issue.created']}
             permissions={basePermissions}
             onChange={jest.fn()}
           />
@@ -157,7 +157,7 @@ describe('Resource Subscriptions', () => {
       render(
         <Form>
           <Subscriptions
-            events={['issue']}
+            events={['issue.created']}
             permissions={{...basePermissions, Event: 'no-access'}}
             onChange={jest.fn()}
           />

--- a/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.tsx
@@ -7,10 +7,7 @@ import {Text} from '@sentry/scraps/text';
 
 import {tct} from 'sentry/locale';
 import type {Permissions} from 'sentry/types/integrations';
-import type {
-  WebhookGranularEvent,
-  WebhookSubscription,
-} from 'sentry/views/settings/organizationDeveloperSettings/constants';
+import type {WebhookSubscription} from 'sentry/views/settings/organizationDeveloperSettings/constants';
 import {
   EVENT_CHOICES,
   PERMISSIONS_MAP,
@@ -51,7 +48,7 @@ export function Subscriptions({events, onChange, permissions}: Props) {
     onChange([...others, ...RESOURCE_EVENTS[resource]]);
   };
 
-  const handleEventChange = (event: WebhookGranularEvent, checked: boolean) => {
+  const handleEventChange = (event: WebhookSubscription, checked: boolean) => {
     const newEvents = new Set(events);
     if (checked) {
       newEvents.add(event);

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.tsx
@@ -997,22 +997,6 @@ describe('Sentry Application Details', () => {
         })
       );
     });
-
-    it('expands the consolidated events when webhookEvents is absent', async () => {
-      sentryApp.webhookEvents = undefined;
-      MockApiClient.addMockResponse({
-        url: `/sentry-apps/${sentryApp.slug}/`,
-        body: sentryApp,
-      });
-
-      renderComponent();
-      await screen.findByRole('button', {name: 'Save Changes'});
-
-      expect(screen.getByRole('checkbox', {name: 'issue'})).toBeChecked();
-      expect(screen.getByRole('checkbox', {name: 'issue.created'})).toBeChecked();
-      expect(screen.getByRole('checkbox', {name: 'issue.unresolved'})).toBeChecked();
-      expect(screen.getByRole('checkbox', {name: 'comment.created'})).not.toBeChecked();
-    });
   });
 
   describe('Editing an existing public Sentry App with a scope error', () => {

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -64,9 +64,8 @@ import {displayNewToken} from 'sentry/views/settings/components/newTokenHandler'
 import {BreadcrumbTitle} from 'sentry/views/settings/components/settingsBreadcrumb/breadcrumbTitle';
 import type {WebhookSubscription} from 'sentry/views/settings/organizationDeveloperSettings/constants';
 import {
-  EVENT_CHOICES,
   granularWebhookEvents,
-  WEBHOOK_GRANULAR_EVENT_CHOICES,
+  WEBHOOK_SUBSCRIPTION_CHOICES,
 } from 'sentry/views/settings/organizationDeveloperSettings/constants';
 import {
   getSentryAppTemplates,
@@ -120,9 +119,7 @@ const sentryAppBaseSchema = z.object({
   organization: z.string(),
   isInternal: z.boolean(),
   scopes: z.array(z.enum(ALLOWED_SCOPES)),
-  events: z.array(
-    z.union([z.enum(EVENT_CHOICES), z.enum(WEBHOOK_GRANULAR_EVENT_CHOICES)])
-  ),
+  events: z.array(z.enum(WEBHOOK_SUBSCRIPTION_CHOICES)),
 });
 
 type SentryAppFormValues = z.infer<typeof sentryAppBaseSchema>;
@@ -845,10 +842,7 @@ function SentryAppEditForm({
       }),
   });
 
-  // Older API responses only send the consolidated resource list
-  const initialEvents: WebhookSubscription[] = granularWebhookEvents(
-    app.webhookEvents ?? app.events
-  );
+  const initialEvents = granularWebhookEvents(app.webhookEvents);
 
   const hasTokenAccess = () => {
     return organization.access.includes('org:write');

--- a/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
@@ -10,7 +10,7 @@ import {t} from 'sentry/locale';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import type {
   EVENT_CHOICES,
-  WebhookGranularEvent,
+  WebhookSubscription,
 } from 'sentry/views/settings/organizationDeveloperSettings/constants';
 import {
   PERMISSIONS_MAP,
@@ -26,9 +26,9 @@ type Props = {
   disabledFromPermissions: boolean;
   isNew: boolean;
   onChange: (resource: Resource, checked: boolean) => void;
-  onEventChange: (event: WebhookGranularEvent, checked: boolean) => void;
+  onEventChange: (event: WebhookSubscription, checked: boolean) => void;
   resource: Resource;
-  selectedEvents: WebhookGranularEvent[];
+  selectedEvents: WebhookSubscription[];
 };
 
 export function SubscriptionBox({

--- a/tests/js/fixtures/integrationListDirectory.ts
+++ b/tests/js/fixtures/integrationListDirectory.ts
@@ -96,6 +96,7 @@ export function OrgOwnedAppsFixture(): SentryApp[] {
       status: 'internal',
       uuid: 'a806ab10-9608-4a4f-8dd9-ca6d6c09f9f5',
       verifyInstall: false,
+      webhookEvents: [],
       webhookUrl: 'https://myheadbandwasher.com',
       featureData: [],
       popularity: null,
@@ -118,6 +119,7 @@ export function OrgOwnedAppsFixture(): SentryApp[] {
       status: 'unpublished',
       uuid: 'a59c8fcc-2f27-49f8-af9e-02661fc3e8d7',
       verifyInstall: false,
+      webhookEvents: [],
       webhookUrl: 'https://lacroix.com',
       featureData: [
         {
@@ -145,6 +147,7 @@ export function OrgOwnedAppsFixture(): SentryApp[] {
       status: 'published',
       uuid: '5d547ecb-7eb8-4ed2-853b-40256177d526',
       verifyInstall: false,
+      webhookEvents: [],
       webhookUrl: 'http://localhost:7000',
       featureData: [
         {
@@ -178,6 +181,7 @@ export function PublishedAppsFixture(): SentryApp[] {
       popularity: 9,
       uuid: '5d547ecb-7eb8-4ed2-853b-40256177d526',
       verifyInstall: false,
+      webhookEvents: [],
       webhookUrl: 'http://localhost:7000',
       featureData: [
         {


### PR DESCRIPTION
Since we GAed granular webhooks, we can treat them as required in the frontend, which lets us clean up a few fallbacks we introduced when rolling them out.