### PR TITLE
feat(tracemetrics): Add search query assistant UI for equations

### DIFF
--- a/static/app/components/arithmeticBuilder/action.tsx
+++ b/static/app/components/arithmeticBuilder/action.tsx
@@ -67,6 +67,12 @@ export function useArithmeticBuilderAction({
   };
 } {
   const [expressionString, setExpressionString] = useState(initialExpression);
+  const [prevInitialExpression, setPrevInitialExpression] = useState(initialExpression);
+  if (prevInitialExpression !== initialExpression) {
+    // If the initial expression changes, we need to reset the internal state to reflect the new expression
+    setPrevInitialExpression(initialExpression);
+    setExpressionString(initialExpression);
+  }
   const [focusOverride, setFocusOverride] = useState<FocusOverride | null>(null);
 
   // Recreate the Expression when the string or references change because

--- a/static/app/views/explore/metrics/applySeerEquation.spec.tsx
+++ b/static/app/views/explore/metrics/applySeerEquation.spec.tsx
@@ -1,0 +1,422 @@
+import {EQUATION_PREFIX} from 'sentry/utils/discover/fields';
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+import {applySeerEquation} from 'sentry/views/explore/metrics/applySeerEquation';
+import type {BaseMetricQuery} from 'sentry/views/explore/metrics/metricQuery';
+import {decodeMetricsQueryParams} from 'sentry/views/explore/metrics/metricQuery';
+import {parseAggregateExpression} from 'sentry/views/explore/metrics/parseAggregateExpression';
+import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
+import {
+  isVisualizeEquation,
+  VisualizeEquation,
+  VisualizeFunction,
+} from 'sentry/views/explore/queryParams/visualize';
+
+function makeQueryParams(
+  overrides: Partial<{
+    aggregateFields: readonly unknown[];
+    mode: Mode;
+    query: string;
+  }> = {}
+): ReadableQueryParams {
+  return new ReadableQueryParams({
+    extrapolate: true,
+    mode: overrides.mode ?? Mode.SAMPLES,
+    query: overrides.query ?? '',
+    cursor: '',
+    fields: ['id', 'timestamp'],
+    sortBys: [{field: 'timestamp', kind: 'desc' as const}],
+    aggregateCursor: '',
+    aggregateFields: (overrides.aggregateFields ?? [
+      new VisualizeFunction('sum(value)'),
+    ]) as readonly never[],
+    aggregateSortBys: [],
+  });
+}
+
+function makeAggregate(
+  yAxis: string,
+  label: string,
+  opts?: {metric?: {name: string; type: string; unit?: string}; query?: string}
+): BaseMetricQuery {
+  const qp = makeQueryParams({
+    aggregateFields: [new VisualizeFunction(yAxis)],
+    query: opts?.query,
+  });
+  return {
+    label,
+    metric: opts?.metric ?? {name: '', type: ''},
+    queryParams: qp,
+  };
+}
+
+function makeEquation(
+  yAxis: string,
+  label: string,
+  internalExpression?: string
+): BaseMetricQuery {
+  const qp = makeQueryParams({
+    mode: Mode.AGGREGATE,
+    aggregateFields: [
+      new VisualizeEquation(`${EQUATION_PREFIX}${yAxis}`, {internalExpression}),
+    ],
+  });
+  return {label, metric: {name: '', type: ''}, queryParams: qp};
+}
+
+function runSeerEquationUpdate({
+  currentMetricQueries,
+  interactedQueryParams,
+  seerEquationYAxis,
+}: {
+  currentMetricQueries: BaseMetricQuery[];
+  interactedQueryParams: ReadableQueryParams;
+  seerEquationYAxis: string;
+}) {
+  const parsed = parseAggregateExpression(seerEquationYAxis);
+  const seerAggregates = parsed.metricQueries;
+  const seerEquations = parsed.equationRow ? [parsed.equationRow] : [];
+
+  return applySeerEquation({
+    metricQueries: currentMetricQueries,
+    interactedQueryParams,
+    seerAggregates,
+    seerEquations,
+  });
+}
+
+/**
+ * Decodes the final encoded metrics array into BaseMetricQuery objects and
+ * pulls out the yAxis and internalExpression for each visualization so tests
+ * can assert on the end result the caller navigates with.
+ */
+function decodeResults(encodedMetrics: string[]) {
+  return encodedMetrics.map(encoded => {
+    const decoded = decodeMetricsQueryParams(encoded);
+    const viz = decoded?.queryParams.visualizes[0];
+    return {
+      metric: decoded?.metric,
+      yAxis: viz?.yAxis,
+      isEquation: viz ? isVisualizeEquation(viz) : false,
+      internalExpression:
+        viz && isVisualizeEquation(viz) ? viz.internalExpression : undefined,
+    };
+  });
+}
+
+describe('applySeerEquation', () => {
+  it('replaces an aggregate row and splices equation components', () => {
+    const aggA = makeAggregate('sum(value,metricA,counter,none)', 'A', {
+      metric: {name: 'metricA', type: 'counter'},
+    });
+
+    const result = runSeerEquationUpdate({
+      currentMetricQueries: [aggA],
+      interactedQueryParams: aggA.queryParams,
+      seerEquationYAxis:
+        'equation|sum(value,metricX,counter,none) + avg(value,metricY,gauge,none)',
+    });
+
+    const decoded = decodeResults(result.encodedMetrics);
+    expect(decoded).toHaveLength(3);
+
+    // First two are aggregates, last is the equation
+    expect(decoded[0]!.isEquation).toBe(false);
+    expect(decoded[1]!.isEquation).toBe(false);
+    expect(decoded[2]!.isEquation).toBe(true);
+    // expect(decoded[2]!.internalExpression).toBe('A + B');
+  });
+
+  it('assigns letter label when replacing an equation panel (ƒ1)', () => {
+    const aggA = makeAggregate('sum(value,metricA,counter,none)', 'A', {
+      metric: {name: 'metricA', type: 'counter'},
+    });
+    const aggB = makeAggregate('avg(value,metricB,gauge,none)', 'B', {
+      metric: {name: 'metricB', type: 'gauge'},
+    });
+    const eqF1 = makeEquation(
+      'sum(value,metricA,counter,none) + avg(value,metricB,gauge,none)',
+      'ƒ1',
+      'A + B'
+    );
+    const seerEquationYAxis =
+      'equation|p50(value,metricC,distribution,none) * count(value,metricD,counter,none)';
+
+    const result = runSeerEquationUpdate({
+      currentMetricQueries: [aggA, aggB, eqF1],
+      interactedQueryParams: eqF1.queryParams,
+      seerEquationYAxis,
+    });
+
+    const decoded = decodeResults(result.encodedMetrics);
+
+    // ƒ1 was replaced by an aggregate, extra aggregate + equation spliced in
+    // Expect: [aggA, aggB, replacement(metricC), extra(metricD), newEquation]
+    expect(decoded).toHaveLength(5);
+
+    // The replacement row is an aggregate, not an equation
+    expect(decoded[2]!.isEquation).toBe(false);
+    expect(decoded[2]!.yAxis).toBe('p50(value,metricC,distribution,none)');
+
+    // The new equation references letter labels, not ƒ labels
+    const newEq = decoded.find(d => d.isEquation && d.yAxis === seerEquationYAxis);
+    // expect(newEq!.internalExpression).toBe('C * D');
+  });
+
+  it('preserves existing equation yAxis when replacing an aggregate', () => {
+    const aggA = makeAggregate('sum(value,metricA,counter,none)', 'A', {
+      metric: {name: 'metricA', type: 'counter'},
+    });
+    const aggB = makeAggregate('avg(value,metricB,gauge,none)', 'B', {
+      metric: {name: 'metricB', type: 'gauge'},
+    });
+    const existingEq = makeEquation(
+      'sum(value,metricA,counter,none) + avg(value,metricB,gauge,none)',
+      'ƒ1',
+      'A + B'
+    );
+    const seerEquationYAxis =
+      'equation|p75(value,metricX,distribution,none) - count(value,metricY,counter,none)';
+
+    const result = runSeerEquationUpdate({
+      currentMetricQueries: [aggA, aggB, existingEq],
+      interactedQueryParams: aggA.queryParams,
+      seerEquationYAxis,
+    });
+
+    const decoded = decodeResults(result.encodedMetrics);
+    const existingEqDecoded = decoded.find(
+      d => d.isEquation && d.yAxis !== seerEquationYAxis
+    );
+
+    // The existing equation's internalExpression and resolved yAxis should
+    // reference the updated A aggregate
+    expect(existingEqDecoded).toBeDefined();
+    expect(existingEqDecoded!.yAxis).toBe(
+      'equation|p75(value,metricX,distribution,none) + avg(value,metricB,gauge,none)'
+    );
+  });
+
+  it('handles equation with single aggregate (no extra aggregates)', () => {
+    const aggA = makeAggregate('sum(value,metricA,counter,none)', 'A', {
+      metric: {name: 'metricA', type: 'counter'},
+    });
+
+    const result = runSeerEquationUpdate({
+      currentMetricQueries: [aggA],
+      interactedQueryParams: aggA.queryParams,
+      seerEquationYAxis: 'equation|sum(value,metricX,counter,none) / 2',
+    });
+
+    const decoded = decodeResults(result.encodedMetrics);
+    expect(decoded).toHaveLength(2);
+
+    expect(decoded[0]!.yAxis).toBe('sum(value,metricX,counter,none)');
+
+    const eqn = decoded[1]!;
+    expect(eqn.yAxis).toBe('equation|sum(value,metricX,counter,none) / 2');
+    // expect(eqn.internalExpression).toBe('A / 2');
+  });
+
+  it('no ƒ labels leak when equation panel is the only row', () => {
+    const eqF1 = makeEquation('1 + 2', 'ƒ1', '1 + 2');
+
+    const result = runSeerEquationUpdate({
+      currentMetricQueries: [eqF1],
+      interactedQueryParams: eqF1.queryParams,
+      seerEquationYAxis:
+        'equation|sum(value,metricA,counter,none) + avg(value,metricB,gauge,none)',
+    });
+
+    const decoded = decodeResults(result.encodedMetrics);
+
+    expect(decoded[0]!.yAxis).toBe('sum(value,metricA,counter,none)');
+    expect(decoded[1]!.yAxis).toBe('avg(value,metricB,gauge,none)');
+
+    const eqn = decoded[2]!;
+    expect(eqn.yAxis).toBe(
+      'equation|sum(value,metricA,counter,none) + avg(value,metricB,gauge,none)'
+    );
+    // expect(eqn.internalExpression).toBe('A + B');
+  });
+
+  it('maps extra Seer aggregates to correct insertion positions', () => {
+    const aggA = makeAggregate('sum(value,metricA,counter,none)', 'A', {
+      metric: {name: 'metricA', type: 'counter'},
+    });
+    const aggB = makeAggregate('avg(value,metricB,gauge,none)', 'B', {
+      metric: {name: 'metricB', type: 'gauge'},
+    });
+
+    const result = runSeerEquationUpdate({
+      currentMetricQueries: [aggA, aggB],
+      interactedQueryParams: aggA.queryParams,
+      seerEquationYAxis:
+        'equation|p50(value,metricX,distribution,none) + p99(value,metricY,distribution,none) + count(value,metricZ,counter,none)',
+    });
+
+    const decoded = decodeResults(result.encodedMetrics);
+    expect(decoded[0]!.yAxis).toBe('p50(value,metricX,distribution,none)');
+    expect(decoded[1]!.yAxis).toBe('avg(value,metricB,gauge,none)');
+    expect(decoded[2]!.yAxis).toBe('p99(value,metricY,distribution,none)');
+    expect(decoded[3]!.yAxis).toBe('count(value,metricZ,counter,none)');
+    const eqn = decoded[4]!;
+    expect(eqn.yAxis).toBe(
+      'equation|p50(value,metricX,distribution,none) + p99(value,metricY,distribution,none) + count(value,metricZ,counter,none)'
+    );
+    // "B" was left untouched because it was not interacted with and preexisting
+    // expect(eqn.internalExpression).toBe('A + C + D');
+  });
+
+  it('never produces ƒ labels with mixed aggregates and equations', () => {
+    const aggA = makeAggregate('sum(value,m1,counter,none)', 'A', {
+      metric: {name: 'm1', type: 'counter'},
+    });
+    const aggB = makeAggregate('avg(value,m2,gauge,none)', 'B', {
+      metric: {name: 'm2', type: 'gauge'},
+    });
+    const aggC = makeAggregate('count(value,m3,counter,none)', 'C', {
+      metric: {name: 'm3', type: 'counter'},
+    });
+    const eqF1 = makeEquation(
+      'sum(value,m1,counter,none) + avg(value,m2,gauge,none)',
+      'ƒ1',
+      'A + B'
+    );
+    const eqF2 = makeEquation('count(value,m3,counter,none) * 100', 'ƒ2', 'C * 100');
+
+    const result = runSeerEquationUpdate({
+      currentMetricQueries: [aggA, aggB, aggC, eqF1, eqF2],
+      interactedQueryParams: eqF2.queryParams,
+      seerEquationYAxis:
+        'equation|p50(value,metricNew,distribution,none) / count(value,metricNew,distribution,none)',
+    });
+
+    const decoded = decodeResults(result.encodedMetrics);
+    expect(decoded).toHaveLength(7);
+
+    expect(decoded[0]!.yAxis).toBe('sum(value,m1,counter,none)');
+    expect(decoded[1]!.yAxis).toBe('avg(value,m2,gauge,none)');
+    expect(decoded[2]!.yAxis).toBe('count(value,m3,counter,none)');
+    expect(decoded[3]!.yAxis).toBe('count(value,metricNew,distribution,none)');
+    expect(decoded[4]!.yAxis).toBe(
+      'equation|sum(value,m1,counter,none) + avg(value,m2,gauge,none)'
+    );
+
+    // TODO: Should this be in the proper order by this point? Or is it aggregated downstream?
+    expect(decoded[5]!.yAxis).toBe('p50(value,metricNew,distribution,none)');
+    expect(decoded[6]!.yAxis).toBe(
+      'equation|p50(value,metricNew,distribution,none) / count(value,metricNew,distribution,none)'
+    );
+  });
+
+  it('deduped aggregates produce repeated label references', () => {
+    const aggA = makeAggregate('sum(value,metricA,counter,none)', 'A', {
+      metric: {name: 'metricA', type: 'counter'},
+    });
+    const seerEquationYAxis =
+      'equation|sum(value,metricX,counter,none) + sum(value,metricX,counter,none)';
+
+    const result = runSeerEquationUpdate({
+      currentMetricQueries: [aggA],
+      interactedQueryParams: aggA.queryParams,
+      seerEquationYAxis,
+    });
+
+    const decoded = decodeResults(result.encodedMetrics);
+    expect(decoded).toHaveLength(2);
+
+    expect(decoded[0]!.yAxis).toBe('sum(value,metricX,counter,none)');
+    expect(decoded[1]!.yAxis).toBe(seerEquationYAxis);
+    // expect(decoded[1]!.internalExpression).toBe('A + A');
+  });
+
+  // TODO: This is kind of clunky, maybe we can do something general and pass in a type of replacement to applySeerEquation?
+  it('nonEquationReplacement is applied when Seer returns no equation', () => {
+    const aggA = makeAggregate('sum(value,metricA,counter,none)', 'A', {
+      metric: {name: 'metricA', type: 'counter'},
+    });
+    const newQp = makeQueryParams({
+      aggregateFields: [new VisualizeFunction('avg(value,metricX,gauge,none)')],
+    });
+
+    const result = applySeerEquation({
+      metricQueries: [aggA],
+      interactedQueryParams: aggA.queryParams,
+      seerAggregates: [],
+      seerEquations: [],
+      nonEquationReplacement: {
+        metric: {name: 'metricX', type: 'gauge'},
+        queryParams: newQp,
+      },
+    });
+
+    const decoded = decodeResults(result.encodedMetrics);
+    expect(decoded).toHaveLength(1);
+    expect(decoded[0]!.yAxis).toBe('avg(value,metricX,gauge,none)');
+    expect(decoded[0]!.metric).toEqual({name: 'metricX', type: 'gauge'});
+  });
+
+  it('counts only aggregate rows when computing replacement label position', () => {
+    // Layout: [agg, eq, agg, eq, agg, eq(interacted)]
+    const queries: BaseMetricQuery[] = [
+      makeAggregate('sum(value,m1,counter,none)', 'A', {
+        metric: {name: 'm1', type: 'counter'},
+      }),
+      makeAggregate('avg(value,m2,gauge,none)', 'B', {
+        metric: {name: 'm2', type: 'gauge'},
+      }),
+      makeAggregate('count(value,m3,counter,none)', 'C', {
+        metric: {name: 'm3', type: 'counter'},
+      }),
+      makeEquation('sum(value,m1,counter,none) * 2', 'ƒ1', 'A * 2'),
+      makeEquation('avg(value,m2,gauge,none) * 3', 'ƒ2', 'B * 3'),
+      makeEquation('count(value,m3,counter,none) / 10', 'ƒ3', 'C / 10'),
+    ];
+
+    const result = runSeerEquationUpdate({
+      currentMetricQueries: queries,
+      interactedQueryParams: queries[2]!.queryParams,
+      seerEquationYAxis:
+        'equation|p50(value,metricNew,distribution,none) + p99(value,metricNew,distribution,none)',
+    });
+
+    const decoded = decodeResults(result.encodedMetrics);
+    expect(decoded).toHaveLength(8);
+
+    expect(decoded[0]!.yAxis).toBe('sum(value,m1,counter,none)');
+    expect(decoded[1]!.yAxis).toBe('avg(value,m2,gauge,none)');
+    expect(decoded[2]!.yAxis).toBe('p50(value,metricNew,distribution,none)');
+    expect(decoded[3]!.yAxis).toBe('p99(value,metricNew,distribution,none)');
+
+    // Every equation should use only letter labels
+    expect(decoded[4]!.yAxis).toBe('equation|sum(value,m1,counter,none) * 2');
+    // expect(decoded[4]!.internalExpression).toBe('A * 2');
+    expect(decoded[5]!.yAxis).toBe('equation|avg(value,m2,gauge,none) * 3');
+    // expect(decoded[5]!.internalExpression).toBe('B * 3');
+    expect(decoded[6]!.yAxis).toBe(
+      'equation|p50(value,metricNew,distribution,none) / 10'
+    );
+    // expect(decoded[6]!.internalExpression).toBe('C / 10');
+    expect(decoded[7]!.yAxis).toBe(
+      'equation|p50(value,metricNew,distribution,none) + p99(value,metricNew,distribution,none)'
+    );
+    // expect(decoded[7]!.internalExpression).toBe('C + D');
+  });
+
+  it('returns requires_clear when there are not enough slots', () => {
+    const queries = Array.from({length: 8}, (_, i) =>
+      makeAggregate(`sum(value,metric,counter,none)`, String.fromCharCode(65 + i), {
+        metric: {name: `metric${i}`, type: 'counter'},
+      })
+    );
+
+    const result = runSeerEquationUpdate({
+      currentMetricQueries: queries,
+      interactedQueryParams: queries[0]!.queryParams,
+      seerEquationYAxis:
+        'equation|sum(value,metricX,counter,none) + avg(value,metricY,gauge,none)',
+    });
+
+    expect(result.spliceResult).toBe('requires_clear');
+  });
+});

--- a/static/app/views/explore/metrics/applySeerEquation.spec.tsx
+++ b/static/app/views/explore/metrics/applySeerEquation.spec.tsx
@@ -292,16 +292,17 @@ describe('applySeerEquation', () => {
     const decoded = decodeResults(result.encodedMetrics);
     expect(decoded).toHaveLength(7);
 
+    // Aggregates: original A, B, C stay, plus two new seer aggregates spliced before equations
     expect(decoded[0]!.yAxis).toBe('sum(value,m1,counter,none)');
     expect(decoded[1]!.yAxis).toBe('avg(value,m2,gauge,none)');
     expect(decoded[2]!.yAxis).toBe('count(value,m3,counter,none)');
-    expect(decoded[3]!.yAxis).toBe('count(value,metricNew,distribution,none)');
-    expect(decoded[4]!.yAxis).toBe(
+    expect(decoded[3]!.yAxis).toBe('p50(value,metricNew,distribution,none)');
+    expect(decoded[4]!.yAxis).toBe('count(value,metricNew,distribution,none)');
+
+    // Equations: ƒ1 preserved, ƒ2 replaced in-place by new equation
+    expect(decoded[5]!.yAxis).toBe(
       'equation|sum(value,m1,counter,none) + avg(value,m2,gauge,none)'
     );
-
-    // TODO: Should this be in the proper order by this point? Or is it aggregated downstream?
-    expect(decoded[5]!.yAxis).toBe('p50(value,metricNew,distribution,none)');
     expect(decoded[6]!.yAxis).toBe(
       'equation|p50(value,metricNew,distribution,none) / count(value,metricNew,distribution,none)'
     );

--- a/static/app/views/explore/metrics/applySeerEquation.spec.tsx
+++ b/static/app/views/explore/metrics/applySeerEquation.spec.tsx
@@ -1,6 +1,6 @@
 import {EQUATION_PREFIX} from 'sentry/utils/discover/fields';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
-import {applySeerEquation} from 'sentry/views/explore/metrics/applySeerEquation';
+import {applySeerResultsToMetricQueries} from 'sentry/views/explore/metrics/applySeerEquation';
 import type {BaseMetricQuery} from 'sentry/views/explore/metrics/metricQuery';
 import {decodeMetricsQueryParams} from 'sentry/views/explore/metrics/metricQuery';
 import {parseAggregateExpression} from 'sentry/views/explore/metrics/parseAggregateExpression';
@@ -76,11 +76,10 @@ function runSeerEquationUpdate({
   const seerAggregates = parsed.metricQueries;
   const seerEquations = parsed.equationRow ? [parsed.equationRow] : [];
 
-  return applySeerEquation({
+  return applySeerResultsToMetricQueries({
     metricQueries: currentMetricQueries,
     interactedQueryParams,
-    seerAggregates,
-    seerEquations,
+    seerMetricQueries: [...seerAggregates, ...seerEquations],
   });
 }
 
@@ -123,7 +122,7 @@ describe('applySeerEquation', () => {
     expect(decoded[0]!.isEquation).toBe(false);
     expect(decoded[1]!.isEquation).toBe(false);
     expect(decoded[2]!.isEquation).toBe(true);
-    // expect(decoded[2]!.internalExpression).toBe('A + B');
+    expect(decoded[2]!.internalExpression).toBe('A + B');
   });
 
   it('assigns letter label when replacing an equation panel (ƒ1)', () => {
@@ -158,7 +157,8 @@ describe('applySeerEquation', () => {
     expect(decoded[2]!.yAxis).toBe('p50(value,metricC,distribution,none)');
 
     // The new equation references letter labels, not ƒ labels
-    const newEq = decoded.find(d => d.isEquation && d.yAxis === seerEquationYAxis);
+    // TODO: the new one should get the correct internalExpression, we can calculate that.
+    // const newEq = decoded.find(d => d.isEquation && d.yAxis === seerEquationYAxis);
     // expect(newEq!.internalExpression).toBe('C * D');
   });
 
@@ -214,7 +214,7 @@ describe('applySeerEquation', () => {
 
     const eqn = decoded[1]!;
     expect(eqn.yAxis).toBe('equation|sum(value,metricX,counter,none) / 2');
-    // expect(eqn.internalExpression).toBe('A / 2');
+    expect(eqn.internalExpression).toBe('A / 2');
   });
 
   it('no ƒ labels leak when equation panel is the only row', () => {
@@ -236,7 +236,7 @@ describe('applySeerEquation', () => {
     expect(eqn.yAxis).toBe(
       'equation|sum(value,metricA,counter,none) + avg(value,metricB,gauge,none)'
     );
-    // expect(eqn.internalExpression).toBe('A + B');
+    expect(eqn.internalExpression).toBe('A + B');
   });
 
   it('maps extra Seer aggregates to correct insertion positions', () => {
@@ -264,7 +264,7 @@ describe('applySeerEquation', () => {
       'equation|p50(value,metricX,distribution,none) + p99(value,metricY,distribution,none) + count(value,metricZ,counter,none)'
     );
     // "B" was left untouched because it was not interacted with and preexisting
-    // expect(eqn.internalExpression).toBe('A + C + D');
+    expect(eqn.internalExpression).toBe('A + C + D');
   });
 
   it('never produces ƒ labels with mixed aggregates and equations', () => {
@@ -327,7 +327,7 @@ describe('applySeerEquation', () => {
 
     expect(decoded[0]!.yAxis).toBe('sum(value,metricX,counter,none)');
     expect(decoded[1]!.yAxis).toBe(seerEquationYAxis);
-    // expect(decoded[1]!.internalExpression).toBe('A + A');
+    expect(decoded[1]!.internalExpression).toBe('A + A');
   });
 
   // TODO: This is kind of clunky, maybe we can do something general and pass in a type of replacement to applySeerEquation?
@@ -339,12 +339,11 @@ describe('applySeerEquation', () => {
       aggregateFields: [new VisualizeFunction('avg(value,metricX,gauge,none)')],
     });
 
-    const result = applySeerEquation({
+    const result = applySeerResultsToMetricQueries({
       metricQueries: [aggA],
       interactedQueryParams: aggA.queryParams,
-      seerAggregates: [],
-      seerEquations: [],
-      nonEquationReplacement: {
+      seerMetricQueries: [],
+      seerAggregateReplacement: {
         metric: {name: 'metricX', type: 'gauge'},
         queryParams: newQp,
       },
@@ -390,17 +389,17 @@ describe('applySeerEquation', () => {
 
     // Every equation should use only letter labels
     expect(decoded[4]!.yAxis).toBe('equation|sum(value,m1,counter,none) * 2');
-    // expect(decoded[4]!.internalExpression).toBe('A * 2');
+    expect(decoded[4]!.internalExpression).toBe('A * 2');
     expect(decoded[5]!.yAxis).toBe('equation|avg(value,m2,gauge,none) * 3');
-    // expect(decoded[5]!.internalExpression).toBe('B * 3');
+    expect(decoded[5]!.internalExpression).toBe('B * 3');
     expect(decoded[6]!.yAxis).toBe(
       'equation|p50(value,metricNew,distribution,none) / 10'
     );
-    // expect(decoded[6]!.internalExpression).toBe('C / 10');
+    expect(decoded[6]!.internalExpression).toBe('C / 10');
     expect(decoded[7]!.yAxis).toBe(
       'equation|p50(value,metricNew,distribution,none) + p99(value,metricNew,distribution,none)'
     );
-    // expect(decoded[7]!.internalExpression).toBe('C + D');
+    expect(decoded[7]!.internalExpression).toBe('C + D');
   });
 
   it('returns requires_clear when there are not enough slots', () => {

--- a/static/app/views/explore/metrics/applySeerEquation.spec.tsx
+++ b/static/app/views/explore/metrics/applySeerEquation.spec.tsx
@@ -417,4 +417,97 @@ describe('applySeerEquation', () => {
 
     expect(result.spliceResult).toBe('requires_clear');
   });
+
+  it('replaces a middle equation in-place while preserving sibling equations', () => {
+    const aggA = makeAggregate('sum(value,m1,counter,none)', 'A', {
+      metric: {name: 'm1', type: 'counter'},
+    });
+    const aggB = makeAggregate('avg(value,m2,gauge,none)', 'B', {
+      metric: {name: 'm2', type: 'gauge'},
+    });
+    const aggC = makeAggregate('count(value,m3,counter,none)', 'C', {
+      metric: {name: 'm3', type: 'counter'},
+    });
+    const eqF1 = makeEquation(
+      'sum(value,m1,counter,none) + avg(value,m2,gauge,none)',
+      'ƒ1',
+      'A + B'
+    );
+    const eqF2 = makeEquation('count(value,m3,counter,none) * 100', 'ƒ2', 'C * 100');
+    const eqF3 = makeEquation(
+      'sum(value,m1,counter,none) - count(value,m3,counter,none)',
+      'ƒ3',
+      'A - C'
+    );
+
+    const result = runSeerEquationUpdate({
+      currentMetricQueries: [aggA, aggB, aggC, eqF1, eqF2, eqF3],
+      interactedQueryParams: eqF2.queryParams,
+      seerEquationYAxis:
+        'equation|p50(value,metricNew,distribution,none) / count(value,metricNew2,counter,none)',
+    });
+
+    const decoded = decodeResults(result.encodedMetrics);
+    expect(decoded).toHaveLength(8);
+
+    // Original aggregates unchanged
+    expect(decoded[0]!.yAxis).toBe('sum(value,m1,counter,none)');
+    expect(decoded[1]!.yAxis).toBe('avg(value,m2,gauge,none)');
+    expect(decoded[2]!.yAxis).toBe('count(value,m3,counter,none)');
+
+    // New seer aggregates spliced before equations
+    expect(decoded[3]!.yAxis).toBe('p50(value,metricNew,distribution,none)');
+    expect(decoded[4]!.yAxis).toBe('count(value,metricNew2,counter,none)');
+
+    // ƒ1 and ƒ3 preserved, ƒ2 replaced in-place by new equation
+    expect(decoded[5]!.yAxis).toBe(
+      'equation|sum(value,m1,counter,none) + avg(value,m2,gauge,none)'
+    );
+    expect(decoded[5]!.internalExpression).toBe('A + B');
+    expect(decoded[6]!.yAxis).toBe(
+      'equation|p50(value,metricNew,distribution,none) / count(value,metricNew2,counter,none)'
+    );
+    expect(decoded[6]!.internalExpression).toBe('D / E');
+    expect(decoded[7]!.yAxis).toBe(
+      'equation|sum(value,m1,counter,none) - count(value,m3,counter,none)'
+    );
+    expect(decoded[7]!.internalExpression).toBe('A - C');
+  });
+
+  it('removes the equation and appends the aggregate when seer returns no equation', () => {
+    const aggA = makeAggregate('sum(value,m1,counter,none)', 'A', {
+      metric: {name: 'm1', type: 'counter'},
+    });
+    const aggB = makeAggregate('avg(value,m2,gauge,none)', 'B', {
+      metric: {name: 'm2', type: 'gauge'},
+    });
+    const eqF1 = makeEquation(
+      'sum(value,m1,counter,none) + avg(value,m2,gauge,none)',
+      'ƒ1',
+      'A + B'
+    );
+
+    const seerAggregate = makeAggregate(
+      'p99(value,metricNew,distribution,none)',
+      'ignored',
+      {metric: {name: 'metricNew', type: 'distribution'}}
+    );
+
+    const result = applySeerResultsToMetricQueries({
+      metricQueries: [aggA, aggB, eqF1],
+      interactedQueryParams: eqF1.queryParams,
+      seerMetricQueries: [seerAggregate],
+    });
+
+    const decoded = decodeResults(result.encodedMetrics);
+    expect(decoded).toHaveLength(3);
+
+    // Original aggregates unchanged
+    expect(decoded[0]!.yAxis).toBe('sum(value,m1,counter,none)');
+    expect(decoded[1]!.yAxis).toBe('avg(value,m2,gauge,none)');
+
+    // ƒ1 removed and replaced by the seer aggregate with a letter label
+    expect(decoded[2]!.yAxis).toBe('p99(value,metricNew,distribution,none)');
+    expect(decoded[2]!.isEquation).toBe(false);
+  });
 });

--- a/static/app/views/explore/metrics/applySeerEquation.spec.tsx
+++ b/static/app/views/explore/metrics/applySeerEquation.spec.tsx
@@ -474,7 +474,7 @@ describe('applySeerEquation', () => {
     expect(decoded[7]!.internalExpression).toBe('A - C');
   });
 
-  it('removes the equation and appends the aggregate when seer returns no equation', () => {
+  it('replaces the equation with an aggregate when seer returns no equation', () => {
     const aggA = makeAggregate('sum(value,m1,counter,none)', 'A', {
       metric: {name: 'm1', type: 'counter'},
     });
@@ -487,16 +487,18 @@ describe('applySeerEquation', () => {
       'A + B'
     );
 
-    const seerAggregate = makeAggregate(
-      'p99(value,metricNew,distribution,none)',
-      'ignored',
-      {metric: {name: 'metricNew', type: 'distribution'}}
-    );
+    const newQp = makeQueryParams({
+      aggregateFields: [new VisualizeFunction('p99(value,metricNew,distribution,none)')],
+    });
 
     const result = applySeerResultsToMetricQueries({
       metricQueries: [aggA, aggB, eqF1],
       interactedQueryParams: eqF1.queryParams,
-      seerMetricQueries: [seerAggregate],
+      seerMetricQueries: [],
+      seerAggregateReplacement: {
+        metric: {name: 'metricNew', type: 'distribution'},
+        queryParams: newQp,
+      },
     });
 
     const decoded = decodeResults(result.encodedMetrics);
@@ -506,8 +508,9 @@ describe('applySeerEquation', () => {
     expect(decoded[0]!.yAxis).toBe('sum(value,m1,counter,none)');
     expect(decoded[1]!.yAxis).toBe('avg(value,m2,gauge,none)');
 
-    // ƒ1 removed and replaced by the seer aggregate with a letter label
+    // ƒ1 replaced by the seer aggregate with a letter label (C, not ƒ)
     expect(decoded[2]!.yAxis).toBe('p99(value,metricNew,distribution,none)');
     expect(decoded[2]!.isEquation).toBe(false);
+    expect(decoded[2]!.metric).toEqual({name: 'metricNew', type: 'distribution'});
   });
 });

--- a/static/app/views/explore/metrics/applySeerEquation.spec.tsx
+++ b/static/app/views/explore/metrics/applySeerEquation.spec.tsx
@@ -149,7 +149,6 @@ describe('applySeerEquation', () => {
     const decoded = decodeResults(result.encodedMetrics);
 
     // ƒ1 was replaced by an aggregate, extra aggregate + equation spliced in
-    // Expect: [aggA, aggB, replacement(metricC), extra(metricD), newEquation]
     expect(decoded).toHaveLength(5);
 
     // The replacement row is an aggregate, not an equation
@@ -157,9 +156,8 @@ describe('applySeerEquation', () => {
     expect(decoded[2]!.yAxis).toBe('p50(value,metricC,distribution,none)');
 
     // The new equation references letter labels, not ƒ labels
-    // TODO: the new one should get the correct internalExpression, we can calculate that.
-    // const newEq = decoded.find(d => d.isEquation && d.yAxis === seerEquationYAxis);
-    // expect(newEq!.internalExpression).toBe('C * D');
+    const newEq = decoded.find(d => d.isEquation && d.yAxis === seerEquationYAxis);
+    expect(newEq!.internalExpression).toBe('C * D');
   });
 
   it('preserves existing equation yAxis when replacing an aggregate', () => {

--- a/static/app/views/explore/metrics/applySeerEquation.tsx
+++ b/static/app/views/explore/metrics/applySeerEquation.tsx
@@ -1,3 +1,4 @@
+import {defined} from 'sentry/utils/defined';
 import {EQUATION_PREFIX} from 'sentry/utils/discover/fields';
 import {syncEquationMetricQueries} from 'sentry/views/explore/metrics/equationBuilder/utils';
 import {getMetricReferences} from 'sentry/views/explore/metrics/hooks/useMetricReferences';
@@ -8,18 +9,14 @@ import {
 } from 'sentry/views/explore/metrics/metricQuery';
 import {spliceEquationQueries} from 'sentry/views/explore/metrics/utils';
 import type {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
-import {
-  isVisualize,
-  isVisualizeEquation,
-} from 'sentry/views/explore/queryParams/visualize';
+import {isVisualizeEquation} from 'sentry/views/explore/queryParams/visualize';
 import {getFunctionLabel} from 'sentry/views/explore/toolbar/toolbarVisualize';
 
 interface ApplySeerEquationParams {
   interactedQueryParams: ReadableQueryParams;
   metricQueries: BaseMetricQuery[];
-  seerAggregates: BaseMetricQuery[];
-  seerEquations: BaseMetricQuery[];
-  nonEquationReplacement?: {
+  seerMetricQueries: BaseMetricQuery[];
+  seerAggregateReplacement?: {
     metric: TraceMetric;
     queryParams: ReadableQueryParams;
   };
@@ -30,15 +27,48 @@ interface ApplySeerEquationResult {
   spliceResult: ReturnType<typeof spliceEquationQueries>;
 }
 
-export function applySeerEquation({
+/**
+ * Applies Seer-generated equations or aggregates to metric queries after a user interacts
+ * within the metrics explorer. The function is structured in logical steps (chunks)
+ * to clarify its operation and surface any redundant or decomposable work:
+ *
+ * **Main chunks of the process:**
+ * 1. **Detection:** Determines if Seer equation(s) or aggregate(s) are present, and identifies which metric query row was interacted with.
+ * 2. **Replacement Preparation:**
+ *    - Analyzes whether the interacted row is an equation or an aggregate.
+ *    - Calculates the correct label for a replacement aggregate if necessary (e.g., assigning a sequential label for aggregates within equations).
+ *    - Captures existing metric references for future synchronization.
+ * 3. **Replacement Application:** Builds a new metric query array:
+ *    - Replaces the interacted row either with a Seer-generated aggregate/equation or swaps in a non-equation replacement metric (if specified).
+ *    - Ensures label consistency for aggregates and equations to maintain correctness in equation evaluation.
+ * 4. **Encoding and Splicing:**
+ *    - Encodes the updated set of metric queries for further processing.
+ *    - Applies any required splicing of equation/aggregate sequences for proper visual and logical order.
+ *
+ * **Summary:**
+ * This function thus modularly:
+ *   - Swaps in aggregates/equations after interacting with a metric row.
+ *   - Maintains correct label assignment for equation parsing.
+ *   - Supports non-equation replacement if provided.
+ *   - Returns both the encoded metric queries and the splice operation result.
+ *
+ * @param params - Encapsulates the current metric queries, the row interacted with, Seer-provided aggregates and equations, and (optionally) details for a non-equation replacement.
+ * @returns An object with (a) an updated, encoded metrics list and (b) the result of the equation splicing operation.
+ */
+
+export function applySeerResultsToMetricQueries({
   metricQueries,
   interactedQueryParams,
-  seerAggregates,
-  seerEquations,
-  nonEquationReplacement,
+  seerMetricQueries,
+  seerAggregateReplacement,
 }: ApplySeerEquationParams): ApplySeerEquationResult {
-  const hasEquation = seerAggregates.length + seerEquations.length > 0;
-  const [replacementAggregate, ...extraAggregates] = seerAggregates;
+  const seerEquation = seerMetricQueries.find(
+    mq =>
+      mq.queryParams.visualizes[0] && isVisualizeEquation(mq.queryParams.visualizes[0])
+  );
+  const [replacementAggregate, ...extraAggregates] = seerMetricQueries.filter(
+    mq => !isVisualizeEquation(mq.queryParams.visualizes[0]!)
+  );
 
   const interactedRow = metricQueries.find(
     mq => mq.queryParams === interactedQueryParams
@@ -55,28 +85,32 @@ export function applySeerEquation({
   const isInteractedEquation =
     interactedRow && isVisualizeEquation(interactedRow.queryParams.visualizes[0]!);
   let replacementAggregateLabel: string | undefined;
-  if (hasEquation && isInteractedEquation && interactedIndex >= 0) {
+  if (seerEquation && isInteractedEquation && interactedIndex >= 0) {
     const aggregatesBefore = metricQueries
       .slice(0, interactedIndex)
       .filter(mq => !isVisualizeEquation(mq.queryParams.visualizes[0]!)).length;
     replacementAggregateLabel = getFunctionLabel(aggregatesBefore);
   }
 
-  const previousRefs = getMetricReferences(metricQueries);
+  const previousEquationReferences = getMetricReferences(metricQueries);
 
-  let updatedMetricQueries = metricQueries.map(mq => {
+  // Replaces the interacted row with the Seer-generated aggregate or the replacement metric from the equation.
+  // The other rows will be left
+  const updatedMetricQueries = metricQueries.map(mq => {
     if (mq.queryParams === interactedQueryParams) {
-      if (hasEquation && replacementAggregate) {
+      if (seerEquation && replacementAggregate) {
         return {
           ...replacementAggregate,
-          label: replacementAggregateLabel ?? mq.label,
+          label: mq.label,
         };
       }
-      if (nonEquationReplacement) {
+
+      if (seerAggregateReplacement) {
+        // For non-equation replacement
         return {
           ...mq,
-          metric: nonEquationReplacement.metric,
-          queryParams: nonEquationReplacement.queryParams,
+          metric: seerAggregateReplacement.metric,
+          queryParams: seerAggregateReplacement.queryParams,
         };
       }
     }
@@ -87,30 +121,18 @@ export function applySeerEquation({
   // map so charts query the new aggregate. Preserve the original
   // internalExpression exactly — syncEquationMetricQueries round-trips
   // it through unresolveExpression which can alter whitespace/ordering.
-  const nextRefs = getMetricReferences(updatedMetricQueries);
-  const synced = syncEquationMetricQueries(updatedMetricQueries, previousRefs, nextRefs);
-  updatedMetricQueries = synced.map((mq, i) => {
-    const original = updatedMetricQueries[i]!;
-    if (mq === original) {
-      return mq;
-    }
-    const origViz = original.queryParams.visualizes[0];
-    if (!origViz || !isVisualizeEquation(origViz)) {
-      return mq;
-    }
-    return {
-      ...mq,
-      queryParams: mq.queryParams.replace({
-        aggregateFields: mq.queryParams.aggregateFields.map(field =>
-          isVisualize(field) && isVisualizeEquation(field)
-            ? field.replace({internalExpression: origViz.internalExpression})
-            : field
-        ),
-      }),
-    };
-  });
+  const nextEquationReferences = getMetricReferences(updatedMetricQueries);
 
-  const encodedMetrics = updatedMetricQueries
+  // Update the metric queries to have the correct equation references
+  // e.g. handles when user interacts with a metric query that is used in a
+  // preexisting equation.
+  const syncedMetricQueries = syncEquationMetricQueries(
+    updatedMetricQueries,
+    previousEquationReferences,
+    nextEquationReferences
+  );
+
+  const encodedMetrics = syncedMetricQueries
     .map(mq => encodeMetricQueryParams(mq))
     .filter(Boolean);
 
@@ -124,17 +146,19 @@ export function applySeerEquation({
 
   const fullRemap: Record<string, string> = {};
   const remapLabel = replacementAggregateLabel ?? interactedRow?.label;
-  if (hasEquation && remapLabel) {
+  if (seerEquation && remapLabel) {
     fullRemap[getFunctionLabel(0)] = remapLabel;
   }
   for (let i = 0; i < extraAggregates.length; i++) {
     fullRemap[getFunctionLabel(i + 1)] = getFunctionLabel(insertionOffset + i);
   }
 
-  const allSeerQueries = [...extraAggregates, ...seerEquations];
-
-  // TODO: I was removing the relabelling and it seemed to have work but it still needs me to pass this along.
-  const spliceResult = spliceEquationQueries(encodedMetrics, allSeerQueries);
+  // TODO: See why this is actually the seer queries minus the replacement aggregate.
+  const allSeerQueries = [...extraAggregates, seerEquation];
+  const spliceResult = spliceEquationQueries(
+    encodedMetrics,
+    allSeerQueries.filter(defined)
+  );
 
   return {
     encodedMetrics,

--- a/static/app/views/explore/metrics/applySeerEquation.tsx
+++ b/static/app/views/explore/metrics/applySeerEquation.tsx
@@ -50,7 +50,8 @@ export function applySeerResultsToMetricQueries({
       mq.queryParams.visualizes[0] && isVisualizeEquation(mq.queryParams.visualizes[0])
   );
   const seerAggregates = seerMetricQueries.filter(
-    mq => !isVisualizeEquation(mq.queryParams.visualizes[0]!)
+    mq =>
+      mq.queryParams.visualizes[0] && !isVisualizeEquation(mq.queryParams.visualizes[0])
   );
   const [replacementAggregate, ...extraAggregates] = seerAggregates;
 

--- a/static/app/views/explore/metrics/applySeerEquation.tsx
+++ b/static/app/views/explore/metrics/applySeerEquation.tsx
@@ -47,25 +47,28 @@ export function applySeerResultsToMetricQueries({
     mq =>
       mq.queryParams.visualizes[0] && isVisualizeEquation(mq.queryParams.visualizes[0])
   );
-  const [replacementAggregate, ...extraAggregates] = seerMetricQueries.filter(
+  const seerAggregates = seerMetricQueries.filter(
     mq => !isVisualizeEquation(mq.queryParams.visualizes[0]!)
   );
+  const [replacementAggregate, ...extraAggregates] = seerAggregates;
+
+  const interactedViz = interactedQueryParams.visualizes[0];
+  const interactedIsEquation = interactedViz && isVisualizeEquation(interactedViz);
 
   const previousEquationReferences = getMetricReferences(metricQueries);
 
-  // Replaces the interacted row with the Seer-generated aggregate or the replacement metric from the equation.
-  // The other rows will be left
+  // Replace like with like: equations replace equations, aggregates replace aggregates.
   const updatedMetricQueries = metricQueries.map(mq => {
     if (mq.queryParams === interactedQueryParams) {
-      if (seerEquation && replacementAggregate) {
-        return {
-          ...replacementAggregate,
-          label: mq.label,
-        };
+      if (interactedIsEquation && seerEquation) {
+        return {...seerEquation, label: mq.label};
+      }
+
+      if (!interactedIsEquation && seerEquation && replacementAggregate) {
+        return {...replacementAggregate, label: mq.label};
       }
 
       if (seerAggregateReplacement) {
-        // For non-equation replacement
         return {
           ...mq,
           metric: seerAggregateReplacement.metric,
@@ -95,11 +98,10 @@ export function applySeerResultsToMetricQueries({
     .map(mq => encodeMetricQueryParams(mq))
     .filter(Boolean);
 
-  const remainingSeerAggregates = [...extraAggregates, seerEquation];
-  const spliceResult = spliceEquationQueries(
-    encodedMetrics,
-    remainingSeerAggregates.filter(defined)
-  );
+  const remainingToSplice = interactedIsEquation
+    ? seerAggregates
+    : [...extraAggregates, seerEquation].filter(defined);
+  const spliceResult = spliceEquationQueries(encodedMetrics, remainingToSplice);
 
   // After splicing, set internalExpression on equations that don't already
   // have one by unresolving against the final reference map.

--- a/static/app/views/explore/metrics/applySeerEquation.tsx
+++ b/static/app/views/explore/metrics/applySeerEquation.tsx
@@ -13,11 +13,13 @@ import {
 import {spliceEquationQueries} from 'sentry/views/explore/metrics/utils';
 import type {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
 import {isVisualizeEquation} from 'sentry/views/explore/queryParams/visualize';
+import {getFunctionLabel} from 'sentry/views/explore/toolbar/toolbarVisualize';
 
 interface ApplySeerEquationParams {
   interactedQueryParams: ReadableQueryParams;
   metricQueries: BaseMetricQuery[];
   seerMetricQueries: BaseMetricQuery[];
+  replaceLabel?: (position: number, label: string) => void;
   seerAggregateReplacement?: {
     metric: TraceMetric;
     queryParams: ReadableQueryParams;
@@ -42,6 +44,7 @@ export function applySeerResultsToMetricQueries({
   interactedQueryParams,
   seerMetricQueries,
   seerAggregateReplacement,
+  replaceLabel,
 }: ApplySeerEquationParams): ApplySeerEquationResult {
   const seerEquation = seerMetricQueries.find(
     mq =>
@@ -61,14 +64,26 @@ export function applySeerResultsToMetricQueries({
   // When seer returns no equation for an interacted equation, drop it — the
   // seer aggregates will be spliced in by spliceEquationQueries.
   const updatedMetricQueries = metricQueries
-    .map(mq => {
+    .map((mq, i) => {
       if (mq.queryParams === interactedQueryParams) {
         if (interactedIsEquation && seerEquation) {
           return {...seerEquation, label: mq.label};
         }
 
         if (interactedIsEquation && !seerEquation) {
-          return null;
+          if (seerAggregateReplacement) {
+            const aggregateCount = metricQueries.filter(
+              q => !isVisualizeEquation(q.queryParams.visualizes[0]!)
+            ).length;
+            const newLabel = getFunctionLabel(aggregateCount);
+            replaceLabel?.(i, newLabel);
+            return {
+              ...mq,
+              label: newLabel,
+              metric: seerAggregateReplacement.metric,
+              queryParams: seerAggregateReplacement.queryParams,
+            };
+          }
         }
 
         if (!interactedIsEquation && seerEquation && replacementAggregate) {

--- a/static/app/views/explore/metrics/applySeerEquation.tsx
+++ b/static/app/views/explore/metrics/applySeerEquation.tsx
@@ -38,7 +38,6 @@ interface ApplySeerEquationResult {
  * and optionally supports non-equation replacements. Returns updated, encoded metric queries and the result of equation splicing
  * in case there was not enough space to fit all the Seer-generated aggregates/equations.
  */
-
 export function applySeerResultsToMetricQueries({
   metricQueries,
   interactedQueryParams,

--- a/static/app/views/explore/metrics/applySeerEquation.tsx
+++ b/static/app/views/explore/metrics/applySeerEquation.tsx
@@ -1,8 +1,11 @@
 import {defined} from 'sentry/utils/defined';
-import {EQUATION_PREFIX} from 'sentry/utils/discover/fields';
-import {syncEquationMetricQueries} from 'sentry/views/explore/metrics/equationBuilder/utils';
+import {
+  syncEquationMetricQueries,
+  unresolveExpression,
+} from 'sentry/views/explore/metrics/equationBuilder/utils';
 import {getMetricReferences} from 'sentry/views/explore/metrics/hooks/useMetricReferences';
 import {
+  decodeMetricsQueryParams,
   encodeMetricQueryParams,
   type BaseMetricQuery,
   type TraceMetric,
@@ -10,7 +13,6 @@ import {
 import {spliceEquationQueries} from 'sentry/views/explore/metrics/utils';
 import type {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
 import {isVisualizeEquation} from 'sentry/views/explore/queryParams/visualize';
-import {getFunctionLabel} from 'sentry/views/explore/toolbar/toolbarVisualize';
 
 interface ApplySeerEquationParams {
   interactedQueryParams: ReadableQueryParams;
@@ -70,28 +72,6 @@ export function applySeerResultsToMetricQueries({
     mq => !isVisualizeEquation(mq.queryParams.visualizes[0]!)
   );
 
-  const interactedRow = metricQueries.find(
-    mq => mq.queryParams === interactedQueryParams
-  );
-  const interactedIndex = metricQueries.findIndex(
-    mq => mq.queryParams === interactedQueryParams
-  );
-
-  // When the interacted row is an equation, the replacement aggregate
-  // needs a letter label (A, B, C…) rather than inheriting the
-  // equation's ƒn label, because ƒn labels are reserved for equations
-  // and will break the equation's internalExpression after labels are
-  // reassigned sequentially on the next render.
-  const isInteractedEquation =
-    interactedRow && isVisualizeEquation(interactedRow.queryParams.visualizes[0]!);
-  let replacementAggregateLabel: string | undefined;
-  if (seerEquation && isInteractedEquation && interactedIndex >= 0) {
-    const aggregatesBefore = metricQueries
-      .slice(0, interactedIndex)
-      .filter(mq => !isVisualizeEquation(mq.queryParams.visualizes[0]!)).length;
-    replacementAggregateLabel = getFunctionLabel(aggregatesBefore);
-  }
-
   const previousEquationReferences = getMetricReferences(metricQueries);
 
   // Replaces the interacted row with the Seer-generated aggregate or the replacement metric from the equation.
@@ -123,9 +103,9 @@ export function applySeerResultsToMetricQueries({
   // it through unresolveExpression which can alter whitespace/ordering.
   const nextEquationReferences = getMetricReferences(updatedMetricQueries);
 
-  // Update the metric queries to have the correct equation references
-  // e.g. handles when user interacts with a metric query that is used in a
-  // preexisting equation.
+  // Update the metric queries to have the correct equation references.
+  // Mainly to ensure that preexisting equations now point to the correct aggregate
+  // if a referenced metric was replaced.
   const syncedMetricQueries = syncEquationMetricQueries(
     updatedMetricQueries,
     previousEquationReferences,
@@ -136,29 +116,33 @@ export function applySeerResultsToMetricQueries({
     .map(mq => encodeMetricQueryParams(mq))
     .filter(Boolean);
 
-  // Build a single remap table for ALL of Seer's aggregates so the
-  // equation's internalExpression references the correct final labels.
-  // The first aggregate (A) replaces the interacted row, so it maps to
-  // the interacted label. The remaining aggregates are spliced at the
-  // insertion offset, so they get sequential labels from there.
-  const eqStartIdx = encodedMetrics.findIndex(e => e.includes(EQUATION_PREFIX));
-  const insertionOffset = eqStartIdx === -1 ? encodedMetrics.length : eqStartIdx;
-
-  const fullRemap: Record<string, string> = {};
-  const remapLabel = replacementAggregateLabel ?? interactedRow?.label;
-  if (seerEquation && remapLabel) {
-    fullRemap[getFunctionLabel(0)] = remapLabel;
-  }
-  for (let i = 0; i < extraAggregates.length; i++) {
-    fullRemap[getFunctionLabel(i + 1)] = getFunctionLabel(insertionOffset + i);
-  }
-
-  // TODO: See why this is actually the seer queries minus the replacement aggregate.
-  const allSeerQueries = [...extraAggregates, seerEquation];
+  const remainingSeerAggregates = [...extraAggregates, seerEquation];
   const spliceResult = spliceEquationQueries(
     encodedMetrics,
-    allSeerQueries.filter(defined)
+    remainingSeerAggregates.filter(defined)
   );
+
+  // After splicing, set internalExpression on equations that don't already
+  // have one by unresolving against the final reference map.
+  if (spliceResult === 'applied') {
+    const finalQueries = encodedMetrics.map(decodeMetricsQueryParams).filter(defined);
+    const finalRefs = getMetricReferences(finalQueries);
+
+    for (let i = 0; i < encodedMetrics.length; i++) {
+      const decoded = finalQueries[i];
+      const viz = decoded?.queryParams.visualizes[0];
+      if (viz && isVisualizeEquation(viz) && !viz.internalExpression) {
+        const internal = unresolveExpression(viz.expression.text, finalRefs);
+        const updated = {
+          ...decoded,
+          queryParams: decoded.queryParams.replace({
+            aggregateFields: [viz.replace({internalExpression: internal})],
+          }),
+        };
+        encodedMetrics[i] = encodeMetricQueryParams(updated);
+      }
+    }
+  }
 
   return {
     encodedMetrics,

--- a/static/app/views/explore/metrics/applySeerEquation.tsx
+++ b/static/app/views/explore/metrics/applySeerEquation.tsx
@@ -4,6 +4,7 @@ import {
   unresolveExpression,
 } from 'sentry/views/explore/metrics/equationBuilder/utils';
 import {getMetricReferences} from 'sentry/views/explore/metrics/hooks/useMetricReferences';
+import {getNextLabel} from 'sentry/views/explore/metrics/hooks/useStableLabels';
 import {
   decodeMetricsQueryParams,
   encodeMetricQueryParams,
@@ -13,7 +14,6 @@ import {
 import {spliceEquationQueries} from 'sentry/views/explore/metrics/utils';
 import type {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
 import {isVisualizeEquation} from 'sentry/views/explore/queryParams/visualize';
-import {getFunctionLabel} from 'sentry/views/explore/toolbar/toolbarVisualize';
 
 interface ApplySeerEquationParams {
   interactedQueryParams: ReadableQueryParams;
@@ -71,10 +71,7 @@ export function applySeerResultsToMetricQueries({
 
         if (interactedIsEquation && !seerEquation) {
           if (seerAggregateReplacement) {
-            const aggregateCount = metricQueries.filter(
-              q => !isVisualizeEquation(q.queryParams.visualizes[0]!)
-            ).length;
-            const newLabel = getFunctionLabel(aggregateCount);
+            const newLabel = getNextLabel(metricQueries, 'aggregate');
             replaceLabel?.(i, newLabel);
             return {
               ...mq,

--- a/static/app/views/explore/metrics/applySeerEquation.tsx
+++ b/static/app/views/explore/metrics/applySeerEquation.tsx
@@ -30,32 +30,11 @@ interface ApplySeerEquationResult {
 }
 
 /**
- * Applies Seer-generated equations or aggregates to metric queries after a user interacts
- * within the metrics explorer. The function is structured in logical steps (chunks)
- * to clarify its operation and surface any redundant or decomposable work:
+ * Updates metric queries by applying Seer-generated aggregates or equations based on user interaction.
  *
- * **Main chunks of the process:**
- * 1. **Detection:** Determines if Seer equation(s) or aggregate(s) are present, and identifies which metric query row was interacted with.
- * 2. **Replacement Preparation:**
- *    - Analyzes whether the interacted row is an equation or an aggregate.
- *    - Calculates the correct label for a replacement aggregate if necessary (e.g., assigning a sequential label for aggregates within equations).
- *    - Captures existing metric references for future synchronization.
- * 3. **Replacement Application:** Builds a new metric query array:
- *    - Replaces the interacted row either with a Seer-generated aggregate/equation or swaps in a non-equation replacement metric (if specified).
- *    - Ensures label consistency for aggregates and equations to maintain correctness in equation evaluation.
- * 4. **Encoding and Splicing:**
- *    - Encodes the updated set of metric queries for further processing.
- *    - Applies any required splicing of equation/aggregate sequences for proper visual and logical order.
- *
- * **Summary:**
- * This function thus modularly:
- *   - Swaps in aggregates/equations after interacting with a metric row.
- *   - Maintains correct label assignment for equation parsing.
- *   - Supports non-equation replacement if provided.
- *   - Returns both the encoded metric queries and the splice operation result.
- *
- * @param params - Encapsulates the current metric queries, the row interacted with, Seer-provided aggregates and equations, and (optionally) details for a non-equation replacement.
- * @returns An object with (a) an updated, encoded metrics list and (b) the result of the equation splicing operation.
+ * Swaps in Seer aggregates/equations for the interacted row, updates label references for equations,
+ * and optionally supports non-equation replacements. Returns updated, encoded metric queries and the result of equation splicing
+ * in case there was not enough space to fit all the Seer-generated aggregates/equations.
  */
 
 export function applySeerResultsToMetricQueries({

--- a/static/app/views/explore/metrics/applySeerEquation.tsx
+++ b/static/app/views/explore/metrics/applySeerEquation.tsx
@@ -1,0 +1,143 @@
+import {EQUATION_PREFIX} from 'sentry/utils/discover/fields';
+import {syncEquationMetricQueries} from 'sentry/views/explore/metrics/equationBuilder/utils';
+import {getMetricReferences} from 'sentry/views/explore/metrics/hooks/useMetricReferences';
+import {
+  encodeMetricQueryParams,
+  type BaseMetricQuery,
+  type TraceMetric,
+} from 'sentry/views/explore/metrics/metricQuery';
+import {spliceEquationQueries} from 'sentry/views/explore/metrics/utils';
+import type {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
+import {
+  isVisualize,
+  isVisualizeEquation,
+} from 'sentry/views/explore/queryParams/visualize';
+import {getFunctionLabel} from 'sentry/views/explore/toolbar/toolbarVisualize';
+
+interface ApplySeerEquationParams {
+  interactedQueryParams: ReadableQueryParams;
+  metricQueries: BaseMetricQuery[];
+  seerAggregates: BaseMetricQuery[];
+  seerEquations: BaseMetricQuery[];
+  nonEquationReplacement?: {
+    metric: TraceMetric;
+    queryParams: ReadableQueryParams;
+  };
+}
+
+interface ApplySeerEquationResult {
+  encodedMetrics: string[];
+  spliceResult: ReturnType<typeof spliceEquationQueries>;
+}
+
+export function applySeerEquation({
+  metricQueries,
+  interactedQueryParams,
+  seerAggregates,
+  seerEquations,
+  nonEquationReplacement,
+}: ApplySeerEquationParams): ApplySeerEquationResult {
+  const hasEquation = seerAggregates.length + seerEquations.length > 0;
+  const [replacementAggregate, ...extraAggregates] = seerAggregates;
+
+  const interactedRow = metricQueries.find(
+    mq => mq.queryParams === interactedQueryParams
+  );
+  const interactedIndex = metricQueries.findIndex(
+    mq => mq.queryParams === interactedQueryParams
+  );
+
+  // When the interacted row is an equation, the replacement aggregate
+  // needs a letter label (A, B, C…) rather than inheriting the
+  // equation's ƒn label, because ƒn labels are reserved for equations
+  // and will break the equation's internalExpression after labels are
+  // reassigned sequentially on the next render.
+  const isInteractedEquation =
+    interactedRow && isVisualizeEquation(interactedRow.queryParams.visualizes[0]!);
+  let replacementAggregateLabel: string | undefined;
+  if (hasEquation && isInteractedEquation && interactedIndex >= 0) {
+    const aggregatesBefore = metricQueries
+      .slice(0, interactedIndex)
+      .filter(mq => !isVisualizeEquation(mq.queryParams.visualizes[0]!)).length;
+    replacementAggregateLabel = getFunctionLabel(aggregatesBefore);
+  }
+
+  const previousRefs = getMetricReferences(metricQueries);
+
+  let updatedMetricQueries = metricQueries.map(mq => {
+    if (mq.queryParams === interactedQueryParams) {
+      if (hasEquation && replacementAggregate) {
+        return {
+          ...replacementAggregate,
+          label: replacementAggregateLabel ?? mq.label,
+        };
+      }
+      if (nonEquationReplacement) {
+        return {
+          ...mq,
+          metric: nonEquationReplacement.metric,
+          queryParams: nonEquationReplacement.queryParams,
+        };
+      }
+    }
+    return mq;
+  });
+
+  // Re-resolve existing equations' yAxis against the updated reference
+  // map so charts query the new aggregate. Preserve the original
+  // internalExpression exactly — syncEquationMetricQueries round-trips
+  // it through unresolveExpression which can alter whitespace/ordering.
+  const nextRefs = getMetricReferences(updatedMetricQueries);
+  const synced = syncEquationMetricQueries(updatedMetricQueries, previousRefs, nextRefs);
+  updatedMetricQueries = synced.map((mq, i) => {
+    const original = updatedMetricQueries[i]!;
+    if (mq === original) {
+      return mq;
+    }
+    const origViz = original.queryParams.visualizes[0];
+    if (!origViz || !isVisualizeEquation(origViz)) {
+      return mq;
+    }
+    return {
+      ...mq,
+      queryParams: mq.queryParams.replace({
+        aggregateFields: mq.queryParams.aggregateFields.map(field =>
+          isVisualize(field) && isVisualizeEquation(field)
+            ? field.replace({internalExpression: origViz.internalExpression})
+            : field
+        ),
+      }),
+    };
+  });
+
+  const encodedMetrics = updatedMetricQueries
+    .map(mq => encodeMetricQueryParams(mq))
+    .filter(Boolean);
+
+  // Build a single remap table for ALL of Seer's aggregates so the
+  // equation's internalExpression references the correct final labels.
+  // The first aggregate (A) replaces the interacted row, so it maps to
+  // the interacted label. The remaining aggregates are spliced at the
+  // insertion offset, so they get sequential labels from there.
+  const eqStartIdx = encodedMetrics.findIndex(e => e.includes(EQUATION_PREFIX));
+  const insertionOffset = eqStartIdx === -1 ? encodedMetrics.length : eqStartIdx;
+
+  const fullRemap: Record<string, string> = {};
+  const remapLabel = replacementAggregateLabel ?? interactedRow?.label;
+  if (hasEquation && remapLabel) {
+    fullRemap[getFunctionLabel(0)] = remapLabel;
+  }
+  for (let i = 0; i < extraAggregates.length; i++) {
+    fullRemap[getFunctionLabel(i + 1)] = getFunctionLabel(insertionOffset + i);
+  }
+
+  const allSeerQueries = [...extraAggregates, ...seerEquations];
+
+  // TODO: I was removing the relabelling and it seemed to have work but it still needs me to pass this along.
+  const spliceResult = spliceEquationQueries(encodedMetrics, allSeerQueries);
+
+  return {
+    encodedMetrics,
+    spliceResult,
+  };
+}

--- a/static/app/views/explore/metrics/applySeerEquation.tsx
+++ b/static/app/views/explore/metrics/applySeerEquation.tsx
@@ -58,26 +58,34 @@ export function applySeerResultsToMetricQueries({
   const previousEquationReferences = getMetricReferences(metricQueries);
 
   // Replace like with like: equations replace equations, aggregates replace aggregates.
-  const updatedMetricQueries = metricQueries.map(mq => {
-    if (mq.queryParams === interactedQueryParams) {
-      if (interactedIsEquation && seerEquation) {
-        return {...seerEquation, label: mq.label};
-      }
+  // When seer returns no equation for an interacted equation, drop it — the
+  // seer aggregates will be spliced in by spliceEquationQueries.
+  const updatedMetricQueries = metricQueries
+    .map(mq => {
+      if (mq.queryParams === interactedQueryParams) {
+        if (interactedIsEquation && seerEquation) {
+          return {...seerEquation, label: mq.label};
+        }
 
-      if (!interactedIsEquation && seerEquation && replacementAggregate) {
-        return {...replacementAggregate, label: mq.label};
-      }
+        if (interactedIsEquation && !seerEquation) {
+          return null;
+        }
 
-      if (seerAggregateReplacement) {
-        return {
-          ...mq,
-          metric: seerAggregateReplacement.metric,
-          queryParams: seerAggregateReplacement.queryParams,
-        };
+        if (!interactedIsEquation && seerEquation && replacementAggregate) {
+          return {...replacementAggregate, label: mq.label};
+        }
+
+        if (seerAggregateReplacement) {
+          return {
+            ...mq,
+            metric: seerAggregateReplacement.metric,
+            queryParams: seerAggregateReplacement.queryParams,
+          };
+        }
       }
-    }
-    return mq;
-  });
+      return mq;
+    })
+    .filter(defined);
 
   // Re-resolve existing equations' yAxis against the updated reference
   // map so charts query the new aggregate. Preserve the original

--- a/static/app/views/explore/metrics/equationBuilder/utils.ts
+++ b/static/app/views/explore/metrics/equationBuilder/utils.ts
@@ -44,6 +44,7 @@ export function unresolveExpression(
       }
       return token.text;
     })
+    .filter(text => text.length > 0)
     .join(' ');
 }
 

--- a/static/app/views/explore/metrics/hooks/useStableLabels.tsx
+++ b/static/app/views/explore/metrics/hooks/useStableLabels.tsx
@@ -95,6 +95,9 @@ export function useStableLabels(queries: BaseMetricQuery[]) {
       remove(position: number) {
         labelsRef.current = labelsRef.current.filter((_, j) => j !== position);
       },
+      replace(position: number, label: string) {
+        labelsRef.current = labelsRef.current.with(position, label);
+      },
       move(from: number, to: number) {
         if (
           from === to ||

--- a/static/app/views/explore/metrics/metricPanel/index.tsx
+++ b/static/app/views/explore/metrics/metricPanel/index.tsx
@@ -1,4 +1,4 @@
-import {Activity, Fragment, useRef, useState} from 'react';
+import {Activity, Fragment, useEffect, useRef, useState} from 'react';
 import type {DraggableAttributes} from '@dnd-kit/core';
 import type {SyntheticListenerMap} from '@dnd-kit/core/dist/hooks/utilities';
 
@@ -35,8 +35,8 @@ import {useMetricHeatMapData} from 'sentry/views/explore/metrics/hooks/useMetric
 import {useMetricSamplesTable} from 'sentry/views/explore/metrics/hooks/useMetricSamplesTable';
 import {useMetricTimeseries} from 'sentry/views/explore/metrics/hooks/useMetricTimeseries';
 import {
-  MetricsGraph,
   getMetricsChartTypeOptions,
+  MetricsGraph,
 } from 'sentry/views/explore/metrics/metricGraph';
 import {MetricInfoTabs} from 'sentry/views/explore/metrics/metricInfoTabs';
 import {type TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
@@ -133,6 +133,15 @@ export function MetricPanel({
     }
     return;
   });
+
+  useEffect(() => {
+    if (isVisualizeEquation(visualize)) {
+      setTitle(
+        visualize.internalExpression ??
+          unresolveExpression(visualize.expression.text, referenceMap)
+      );
+    }
+  }, [visualize, referenceMap]);
 
   const areQueriesEnabled = isVisualizeFunction(visualize)
     ? Boolean(traceMetric.name) && !isMetricOptionsEmpty

--- a/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
+++ b/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
@@ -38,7 +38,10 @@ import {
   defaultAggregateSortBys,
   type TraceMetric,
 } from 'sentry/views/explore/metrics/metricQuery';
-import {useMultiMetricsQueryParams} from 'sentry/views/explore/metrics/multiMetricsQueryParams';
+import {
+  useMultiMetricsQueryParams,
+  useReplaceMetricLabel,
+} from 'sentry/views/explore/metrics/multiMetricsQueryParams';
 import {parseAggregateExpression} from 'sentry/views/explore/metrics/parseAggregateExpression';
 import {parseMetricAggregate} from 'sentry/views/explore/metrics/parseMetricsAggregate';
 import {isTraceMetricTypeValue} from 'sentry/views/explore/metrics/types';
@@ -66,6 +69,7 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
   const {projects} = useProjects();
   const queryParams = useQueryParams();
   const metricQueries = useMultiMetricsQueryParams();
+  const replaceLabel = useReplaceMetricLabel();
   const analyticsArea = useAnalyticsArea();
   const {askSeerSuggestedQueryRef, enableAISearch} = useSearchQueryBuilderAI();
 
@@ -258,6 +262,7 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
             metric: nextMetric,
             queryParams: newQueryParams,
           },
+          replaceLabel,
         });
 
       const selection = {
@@ -337,6 +342,7 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
       pageFilters.selection,
       projects,
       queryParams,
+      replaceLabel,
       setRunId,
       traceMetric,
     ]

--- a/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
+++ b/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
@@ -3,6 +3,7 @@ import {mutationOptions} from '@tanstack/react-query';
 import omit from 'lodash/omit';
 
 import {useAnalyticsArea} from 'sentry/components/analyticsArea';
+import {openConfirmModal} from 'sentry/components/confirm';
 import {ALL_DATE_TIME_QUERY_KEYS} from 'sentry/components/pageFilters/constants';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {useAiQueryContext} from 'sentry/components/searchQueryBuilder/askSeerCombobox/aiQueryContext';
@@ -22,24 +23,27 @@ import {
 } from 'sentry/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup';
 import {resolveSeerProjectSelection} from 'sentry/components/searchQueryBuilder/askSeerCombobox/utils';
 import {useSearchQueryBuilderAI} from 'sentry/components/searchQueryBuilder/context';
+import {t} from 'sentry/locale';
 import {ConfigStore} from 'sentry/stores/configStore';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {isEquation} from 'sentry/utils/discover/fields';
 import {fetchMutation} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
+import {applySeerEquation} from 'sentry/views/explore/metrics/applySeerEquation';
 import {DEFAULT_YAXIS_BY_TYPE, NONE_UNIT} from 'sentry/views/explore/metrics/constants';
 import {
   defaultAggregateSortBys,
-  encodeMetricQueryParams,
-  type BaseMetricQuery,
   type TraceMetric,
 } from 'sentry/views/explore/metrics/metricQuery';
 import {useMultiMetricsQueryParams} from 'sentry/views/explore/metrics/multiMetricsQueryParams';
+import {parseAggregateExpression} from 'sentry/views/explore/metrics/parseAggregateExpression';
 import {parseMetricAggregate} from 'sentry/views/explore/metrics/parseMetricsAggregate';
 import {isTraceMetricTypeValue} from 'sentry/views/explore/metrics/types';
 import {
+  encodeEquationMetricQueries,
   makeMetricsAggregate,
   parseTraceMetricFromQuery,
   stripTraceMetricTokens,
@@ -47,9 +51,12 @@ import {
 import type {AggregateField} from 'sentry/views/explore/queryParams/aggregateField';
 import {useQueryParams} from 'sentry/views/explore/queryParams/context';
 import {Mode} from 'sentry/views/explore/queryParams/mode';
-import {isVisualize, VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
+import {
+  isVisualize,
+  isVisualizeEquation,
+  VisualizeFunction,
+} from 'sentry/views/explore/queryParams/visualize';
 import {getSeerExploreQuery, getSeerSort} from 'sentry/views/explore/seerQuery';
-
 interface MetricsTabSeerComboBoxProps {
   traceMetric: TraceMetric;
 }
@@ -110,8 +117,23 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
         pageDatetime: pageFilters.selection.datetime,
       });
 
-      const seerVisualizes = (result.visualizations ?? []).flatMap(viz =>
-        viz.yAxes.map(yAxis => new VisualizeFunction(yAxis, {chartType: viz.chartType}))
+      // Seer responses only return equations or functions at the moment, but equations need special handling
+      // to generate its base metricQueries.
+      const seerVisualizeFunctions = (result.visualizations ?? []).flatMap(viz =>
+        viz.yAxes
+          .filter(yAxis => !isEquation(yAxis))
+          .map(yAxis => new VisualizeFunction(yAxis, {chartType: viz.chartType}))
+      );
+
+      // Parse out the metric queries required for equations.
+      const seerEquationMetricQueries = (result.visualizations ?? []).flatMap(viz =>
+        viz.yAxes.filter(isEquation).flatMap(yAxis => {
+          const parsed = parseAggregateExpression(yAxis);
+          return [
+            ...parsed.metricQueries,
+            ...(parsed.equationRow ? [parsed.equationRow] : []),
+          ];
+        })
       );
 
       // Move any `project:` filter Seer put in the query onto the page-level
@@ -173,8 +195,8 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
       // so build a default one from the metric's type. When Seer didn't resolve
       // a valid metric, leave the existing visualizes untouched so we don't
       // clobber a customized aggregate.
-      if (seerVisualizes.length > 0) {
-        for (const viz of seerVisualizes) {
+      if (seerVisualizeFunctions.length > 0) {
+        for (const viz of seerVisualizeFunctions) {
           const {aggregation, traceMetric: vizMetric} = parseMetricAggregate(viz.yAxis);
           const isQualified = Boolean(
             vizMetric.name && vizMetric.type && isTraceMetricTypeValue(vizMetric.type)
@@ -231,18 +253,24 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
       // Build encoded metric queries, updating the current metric's query params
       // and trace metric (the metric is parsed out of the agent's visualization
       // aggregate or query filters above so the panel matches what was queried).
-      const newEncodedMetrics = metricQueries
-        .map((mq: BaseMetricQuery) => {
-          if (mq.queryParams === queryParams) {
-            return encodeMetricQueryParams({
-              ...mq,
-              metric: nextMetric,
-              queryParams: newQueryParams,
-            });
-          }
-          return encodeMetricQueryParams(mq);
-        })
-        .filter(Boolean);
+      const seerAggregates = seerEquationMetricQueries.filter(
+        mq => !mq.queryParams.visualizes.some(isVisualizeEquation)
+      );
+      const seerEquations = seerEquationMetricQueries.filter(mq =>
+        mq.queryParams.visualizes.some(isVisualizeEquation)
+      );
+
+      // TODO I think we can drop the seerAggregates and seerEquations individual parts
+      const {encodedMetrics: newEncodedMetrics, spliceResult} = applySeerEquation({
+        metricQueries,
+        interactedQueryParams: queryParams,
+        seerAggregates,
+        seerEquations,
+        nonEquationReplacement: {
+          metric: nextMetric,
+          queryParams: newQueryParams,
+        },
+      });
 
       const selection = {
         ...pageFilters.selection,
@@ -269,27 +297,47 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
         setRunId(runId);
       }
 
-      // Single navigate with both metric params and datetime — previously
-      // setQueryParams and navigate were separate calls, and the second
-      // navigate overwrote the first with stale location.
-      navigate(
-        {
-          ...location,
-          query: {
-            ...omit(location.query, ALL_DATE_TIME_QUERY_KEYS),
-            ...(projectIds?.length ? {project: projectIds.map(String)} : {}),
-            metric: newEncodedMetrics,
-            start: seerQuery.datetime.start,
-            end: seerQuery.datetime.end,
-            statsPeriod: seerQuery.datetime.period,
-            utc: seerQuery.datetime.utc,
-            // Only override the interval when Seer suggested one, otherwise
-            // leave the user's current interval untouched.
-            ...(seerQuery.interval ? {interval: seerQuery.interval} : {}),
+      const navigateWithMetrics = (encodedMetrics: string[]) => {
+        // Single navigate with both metric params and datetime — previously
+        // setQueryParams and navigate were separate calls, and the second
+        // navigate overwrote the first with stale location.
+        navigate(
+          {
+            ...location,
+            query: {
+              ...omit(location.query, ALL_DATE_TIME_QUERY_KEYS),
+              ...(projectIds?.length ? {project: projectIds.map(String)} : {}),
+              metric: encodedMetrics,
+              start: seerQuery.datetime.start,
+              end: seerQuery.datetime.end,
+              statsPeriod: seerQuery.datetime.period,
+              utc: seerQuery.datetime.utc,
+              // Only override the interval when Seer suggested one, otherwise
+              // leave the user's current interval untouched.
+              ...(seerQuery.interval ? {interval: seerQuery.interval} : {}),
+            },
           },
-        },
-        {replace: true, preventScrollReset: true}
-      );
+          {replace: true, preventScrollReset: true}
+        );
+      };
+
+      if (spliceResult === 'requires_clear') {
+        openConfirmModal({
+          header: t('Clear Queries'),
+          message: t(
+            "This equation needs an additional %s queries but, there isn't enough room. Clear existing queries to make room?",
+            seerAggregates.length
+          ),
+          confirmText: t('Clear and apply'),
+          isDangerous: true,
+          onConfirm: () => {
+            navigateWithMetrics(encodeEquationMetricQueries(seerEquationMetricQueries));
+          },
+        });
+        return;
+      }
+
+      navigateWithMetrics(newEncodedMetrics);
     },
     [
       analyticsArea,

--- a/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
+++ b/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
@@ -56,6 +56,7 @@ import {useQueryParams} from 'sentry/views/explore/queryParams/context';
 import {Mode} from 'sentry/views/explore/queryParams/mode';
 import {isVisualize, VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
 import {getSeerExploreQuery, getSeerSort} from 'sentry/views/explore/seerQuery';
+
 interface MetricsTabSeerComboBoxProps {
   traceMetric: TraceMetric;
 }

--- a/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
+++ b/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
@@ -32,7 +32,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
-import {applySeerEquation} from 'sentry/views/explore/metrics/applySeerEquation';
+import {applySeerResultsToMetricQueries} from 'sentry/views/explore/metrics/applySeerEquation';
 import {DEFAULT_YAXIS_BY_TYPE, NONE_UNIT} from 'sentry/views/explore/metrics/constants';
 import {
   defaultAggregateSortBys,
@@ -51,11 +51,7 @@ import {
 import type {AggregateField} from 'sentry/views/explore/queryParams/aggregateField';
 import {useQueryParams} from 'sentry/views/explore/queryParams/context';
 import {Mode} from 'sentry/views/explore/queryParams/mode';
-import {
-  isVisualize,
-  isVisualizeEquation,
-  VisualizeFunction,
-} from 'sentry/views/explore/queryParams/visualize';
+import {isVisualize, VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
 import {getSeerExploreQuery, getSeerSort} from 'sentry/views/explore/seerQuery';
 interface MetricsTabSeerComboBoxProps {
   traceMetric: TraceMetric;
@@ -253,24 +249,16 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
       // Build encoded metric queries, updating the current metric's query params
       // and trace metric (the metric is parsed out of the agent's visualization
       // aggregate or query filters above so the panel matches what was queried).
-      const seerAggregates = seerEquationMetricQueries.filter(
-        mq => !mq.queryParams.visualizes.some(isVisualizeEquation)
-      );
-      const seerEquations = seerEquationMetricQueries.filter(mq =>
-        mq.queryParams.visualizes.some(isVisualizeEquation)
-      );
-
-      // TODO I think we can drop the seerAggregates and seerEquations individual parts
-      const {encodedMetrics: newEncodedMetrics, spliceResult} = applySeerEquation({
-        metricQueries,
-        interactedQueryParams: queryParams,
-        seerAggregates,
-        seerEquations,
-        nonEquationReplacement: {
-          metric: nextMetric,
-          queryParams: newQueryParams,
-        },
-      });
+      const {encodedMetrics: newEncodedMetrics, spliceResult} =
+        applySeerResultsToMetricQueries({
+          metricQueries,
+          interactedQueryParams: queryParams,
+          seerMetricQueries: seerEquationMetricQueries,
+          seerAggregateReplacement: {
+            metric: nextMetric,
+            queryParams: newQueryParams,
+          },
+        });
 
       const selection = {
         ...pageFilters.selection,
@@ -326,7 +314,7 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
           header: t('Clear Queries'),
           message: t(
             "This equation needs an additional %s queries but, there isn't enough room. Clear existing queries to make room?",
-            seerAggregates.length
+            seerEquationMetricQueries.length - 1 // -1 because the interacted row receives a replacement not an addition
           ),
           confirmText: t('Clear and apply'),
           isDangerous: true,

--- a/static/app/views/explore/metrics/multiMetricsQueryParams.tsx
+++ b/static/app/views/explore/metrics/multiMetricsQueryParams.tsx
@@ -154,3 +154,8 @@ export function useReorderMetricQueries() {
   const {reorderMetricQueries} = useMultiMetricsQueryParamsContext();
   return reorderMetricQueries;
 }
+
+export function useReplaceMetricLabel() {
+  const {replaceLabel} = useMultiMetricsQueryParamsContext();
+  return replaceLabel;
+}

--- a/static/app/views/explore/metrics/useMetricQueriesController.tsx
+++ b/static/app/views/explore/metrics/useMetricQueriesController.tsx
@@ -47,6 +47,7 @@ export interface MetricQueriesControllerValue {
     oldIndex: number,
     newIndex: number
   ) => void;
+  replaceLabel: (position: number, label: string) => void;
 }
 
 interface UseMetricQueriesControllerArgs {
@@ -202,6 +203,7 @@ export function useMetricQueriesController({
       })),
       addMetricQuery,
       reorderMetricQueries,
+      replaceLabel: labels.replace,
     };
   }, [queries, setQueries, labels]);
 }

--- a/static/app/views/explore/metrics/utils.spec.tsx
+++ b/static/app/views/explore/metrics/utils.spec.tsx
@@ -1,18 +1,27 @@
 import qs from 'query-string';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
+import {EQUATION_PREFIX} from 'sentry/utils/discover/fields';
 import {SavedQuery} from 'sentry/views/explore/hooks/useGetSavedQueries';
 import {NONE_UNIT} from 'sentry/views/explore/metrics/constants';
-import {decodeMetricsQueryParams} from 'sentry/views/explore/metrics/metricQuery';
+import {
+  type BaseMetricQuery,
+  decodeMetricsQueryParams,
+  defaultMetricQuery,
+  encodeMetricQueryParams,
+} from 'sentry/views/explore/metrics/metricQuery';
 import {
   createTraceMetricEventsFilter,
+  encodeEquationMetricQueries,
   getEquationMetricsTotalFilter,
   getMetricsUrlFromSavedQueryUrl,
   mapMetricUnitToFieldType,
   parseTraceMetricFromQuery,
+  spliceEquationQueries,
   stripTraceMetricTokens,
 } from 'sentry/views/explore/metrics/utils';
 import {Mode} from 'sentry/views/explore/queryParams/mode';
+import {VisualizeEquation} from 'sentry/views/explore/queryParams/visualize';
 
 describe('mapMetricUnitToFieldType', () => {
   it.each([
@@ -335,5 +344,105 @@ describe('createTraceMetricEventsFilter', () => {
     expect(result).toBe(
       '( metric.name:chat.message_sent metric.type:counter ( !has:metric.unit OR metric.unit:none ) )'
     );
+  });
+});
+
+function makeAggregateQuery(overrides?: Partial<BaseMetricQuery>): BaseMetricQuery {
+  return {
+    ...defaultMetricQuery(),
+    metric: {name: 'test_metric', type: 'counter'},
+    ...overrides,
+  };
+}
+
+function makeEquationQuery(equation: string): BaseMetricQuery {
+  return {
+    ...defaultMetricQuery({type: 'equation'}),
+    queryParams: defaultMetricQuery({type: 'equation'}).queryParams.replace({
+      aggregateFields: [new VisualizeEquation(`${EQUATION_PREFIX}${equation}`)],
+    }),
+  };
+}
+
+describe('spliceEquationQueries', () => {
+  it('returns noop when equationMetricQueries is empty', () => {
+    const encoded = ['a', 'b'];
+    const result = spliceEquationQueries(encoded, []);
+    expect(result).toBe('noop');
+    expect(encoded).toEqual(['a', 'b']);
+  });
+
+  it('returns requires_clear when there are not enough slots', () => {
+    const existingEncoded = Array.from({length: 8}, (_, i) => `metric_${i}`);
+    const equationQueries = [makeAggregateQuery(), makeEquationQuery('a + b')];
+
+    const result = spliceEquationQueries(existingEncoded, equationQueries);
+    expect(result).toBe('requires_clear');
+    expect(existingEncoded).toHaveLength(8);
+  });
+
+  it('splices aggregate rows before existing equations and appends equation rows', () => {
+    const existingAggregate = makeAggregateQuery();
+    const existingEquation = makeEquationQuery('a + b');
+
+    const existingMetrics = [existingAggregate, existingEquation];
+    const encodedMetrics = existingMetrics.map(mq => encodeMetricQueryParams(mq));
+
+    const newAgg = makeAggregateQuery({
+      metric: {name: 'new_agg', type: 'distribution'},
+    });
+    const newEqn = makeEquationQuery('c + d');
+
+    const result = spliceEquationQueries(encodedMetrics, [newAgg, newEqn]);
+
+    expect(result).toBe('applied');
+    expect(encodedMetrics).toHaveLength(4);
+    expect(encodedMetrics[1]).toBe(encodeMetricQueryParams(newAgg));
+    expect(encodedMetrics[3]).toBe(encodeMetricQueryParams(newEqn));
+  });
+
+  it('appends aggregates at the end when no existing equations', () => {
+    const existingAggregate = makeAggregateQuery();
+    const existingMetrics = [existingAggregate];
+    const encodedMetrics = existingMetrics.map(mq => encodeMetricQueryParams(mq));
+
+    const newAgg = makeAggregateQuery({
+      metric: {name: 'new_metric', type: 'gauge'},
+    });
+
+    const result = spliceEquationQueries(encodedMetrics, [newAgg]);
+
+    expect(result).toBe('applied');
+    expect(encodedMetrics).toHaveLength(2);
+    expect(encodedMetrics[1]).toBe(encodeMetricQueryParams(newAgg));
+  });
+});
+
+describe('encodeEquationMetricQueries', () => {
+  it('returns encoded aggregates before equations', () => {
+    const agg = makeAggregateQuery({metric: {name: 'metricA', type: 'counter'}});
+    const eqn = makeEquationQuery('metricA + metricB');
+
+    const result = encodeEquationMetricQueries([eqn, agg]);
+
+    expect(result).toEqual([encodeMetricQueryParams(agg), encodeMetricQueryParams(eqn)]);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(encodeEquationMetricQueries([])).toEqual([]);
+  });
+
+  it('handles multiple aggregates and one equation', () => {
+    const agg1 = makeAggregateQuery({metric: {name: 'metricA', type: 'counter'}});
+    const agg2 = makeAggregateQuery({metric: {name: 'metricB', type: 'distribution'}});
+    const eqn = makeEquationQuery('metricA / metricB');
+
+    const result = encodeEquationMetricQueries([eqn, agg1, agg2]);
+
+    expect(result).toEqual([
+      encodeMetricQueryParams(agg1),
+      encodeMetricQueryParams(agg2),
+      encodeMetricQueryParams(eqn),
+    ]);
   });
 });

--- a/static/app/views/explore/metrics/utils.tsx
+++ b/static/app/views/explore/metrics/utils.tsx
@@ -381,13 +381,14 @@ export function getEquationMetricsTotalFilter(equation: string) {
   return createTraceMetricEventsFilter(traceMetricsUsed);
 }
 
-function _isEquationQuery(mq: BaseMetricQuery): boolean {
-  if (mq.queryParams.visualizes.length > 1) {
+function _isEquationQuery(metricQuery: BaseMetricQuery): boolean {
+  if (metricQuery.queryParams.visualizes.length > 1) {
     // Only a single equation can be plotted in a metric query.
     return false;
   }
   return Boolean(
-    mq.queryParams.visualizes[0] && isVisualizeEquation(mq.queryParams.visualizes[0])
+    metricQuery.queryParams.visualizes[0] &&
+    isVisualizeEquation(metricQuery.queryParams.visualizes[0])
   );
 }
 

--- a/static/app/views/explore/metrics/utils.tsx
+++ b/static/app/views/explore/metrics/utils.tsx
@@ -9,6 +9,7 @@ import {defined} from 'sentry/utils/defined';
 import type {EventsMetaType, MetaType} from 'sentry/utils/discover/eventView';
 import {
   DurationUnit,
+  EQUATION_PREFIX,
   RateUnit,
   SizeUnit,
   stripEquationPrefix,
@@ -29,6 +30,7 @@ import {
   encodeMetricQueryParams,
   type BaseMetricQuery,
 } from 'sentry/views/explore/metrics/metricQuery';
+import {MAX_METRICS_ALLOWED} from 'sentry/views/explore/metrics/multiMetricsQueryParams';
 import {normalizeFunctionToken} from 'sentry/views/explore/metrics/parseAggregateExpression';
 import {parseMetricAggregate} from 'sentry/views/explore/metrics/parseMetricsAggregate';
 import {
@@ -38,7 +40,7 @@ import {
 } from 'sentry/views/explore/metrics/types';
 import {isGroupBy, type GroupBy} from 'sentry/views/explore/queryParams/groupBy';
 import type {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
-import {Visualize} from 'sentry/views/explore/queryParams/visualize';
+import {isVisualizeEquation, Visualize} from 'sentry/views/explore/queryParams/visualize';
 
 export function makeMetricsPathname({
   organizationSlug,
@@ -377,4 +379,77 @@ export function getEquationMetricsTotalFilter(equation: string) {
   });
 
   return createTraceMetricEventsFilter(traceMetricsUsed);
+}
+
+function _isEquationQuery(mq: BaseMetricQuery): boolean {
+  if (mq.queryParams.visualizes.length > 1) {
+    // Only a single equation can be plotted in a metric query.
+    return false;
+  }
+  return Boolean(
+    mq.queryParams.visualizes[0] && isVisualizeEquation(mq.queryParams.visualizes[0])
+  );
+}
+
+type SpliceResult = 'applied' | 'requires_clear' | 'noop';
+
+/**
+ * Splices equation sub-components into the encoded metrics array while
+ * respecting the 8-slot budget on the explore page and the
+ * aggregates-before-equations ordering.
+ *
+ * Returns a status so the caller can decide what to do when there isn't
+ * enough room (e.g. show a confirmation modal).
+ *
+ * Mutates `encodedMetrics` in place when applied.
+ */
+export function spliceEquationQueries(
+  encodedMetrics: string[],
+  equationMetricQueries: BaseMetricQuery[]
+): SpliceResult {
+  if (equationMetricQueries.length === 0) {
+    return 'noop';
+  }
+
+  const slotsAvailable = MAX_METRICS_ALLOWED - encodedMetrics.length;
+  if (equationMetricQueries.length > slotsAvailable) {
+    return 'requires_clear';
+  }
+
+  const equationStartIndex = encodedMetrics.findIndex(encoded =>
+    encoded.includes(EQUATION_PREFIX)
+  );
+
+  const aggregateRows = equationMetricQueries.filter(mq => !_isEquationQuery(mq));
+  const equationRows = equationMetricQueries.filter(_isEquationQuery);
+
+  const encodedAggregates = aggregateRows
+    .map(mq => encodeMetricQueryParams(mq))
+    .filter(Boolean);
+  const encodedEquations = equationRows
+    .map(mq => encodeMetricQueryParams(mq))
+    .filter(Boolean);
+
+  const insertAt = equationStartIndex === -1 ? encodedMetrics.length : equationStartIndex;
+  encodedMetrics.splice(insertAt, 0, ...encodedAggregates);
+  encodedMetrics.push(...encodedEquations);
+
+  return 'applied';
+}
+
+/**
+ * Builds an encoded metrics array containing only the equation's
+ * sub-components and equation row. Used when the user confirms clearing
+ * all existing queries to make room for an equation.
+ */
+export function encodeEquationMetricQueries(
+  equationMetricQueries: BaseMetricQuery[]
+): string[] {
+  const aggregateRows = equationMetricQueries.filter(mq => !_isEquationQuery(mq));
+  const equationRows = equationMetricQueries.filter(_isEquationQuery);
+
+  return [
+    ...aggregateRows.map(mq => encodeMetricQueryParams(mq)).filter(Boolean),
+    ...equationRows.map(mq => encodeMetricQueryParams(mq)).filter(Boolean),
+  ];
 }


### PR DESCRIPTION
Updates the behaviour after selecting an equation in the seer search query assistant in metrics explorer. Completing this work touched a number of different components to ensure that the label state, titles, and equations were always updating at the right time when invoked from either metric query or equation sources.

After this PR:

1. Seer equations are now applied. When Seer returns an equation, the interacted aggregate is replaced by the first component aggregate, and the remaining aggregates + equation row are spliced into the query list (aggregates before the equation boundary, equation at the end).
2. Equations replace equations. If the user triggers Seer from an equation panel and Seer returns a new equation, the equation is replaced in-place and the aggregates are pushed at the end of the preexisting aggregates
3. Equation-to-aggregate conversion. If the user triggers Seer from an equation panel but Seer returns only an aggregate (no equation), the equation is replaced by the aggregate and its label changes from an ƒ label (e.g. ƒ2) to the next available letter label (e.g. D).
4. Capacity overflow handling. If there aren't enough slots (max 8) to fit the new aggregates + equation, a confirmation modal asks the user to clear existing queries before applying.