### PR TITLE
ref(seer): Remove legacy PR-created attribution/linking from process_autofix_updates (CW-1719 phase 2)

### DIFF
--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -9,7 +9,6 @@ from sentry.models.activity import Activity
 from sentry.models.group import Group
 from sentry.models.organization import Organization
 from sentry.organizations.services.organization import RpcOrganization
-from sentry.pr_metrics.attribution import attribute_seer_created_pull_requests
 from sentry.seer.agent.client import SeerAgentClient
 from sentry.seer.agent.client_models import CodingAgentState, SeerRunState
 from sentry.seer.agent.client_utils import fetch_run_status
@@ -31,7 +30,6 @@ from sentry.seer.entrypoints.types import (
     SeerEntrypointKey,
 )
 from sentry.seer.models import SeerPermissionError
-from sentry.seer.pull_requests import link_seer_run_pull_requests
 from sentry.seer.seer_setup import has_seer_access
 from sentry.sentry_apps.event_types import SentryAppEventType
 from sentry.tasks.base import instrumented_task
@@ -728,35 +726,6 @@ def process_autofix_updates(
                     "event_type": str(event_type),
                 },
             )
-
-        if event_type == SentryAppEventType.SEER_PR_CREATED:
-            pull_requests = event_payload.get("pull_requests", [])
-
-            if features.has("organizations:pr-metrics-attribution", organization):
-                try:
-                    attribute_seer_created_pull_requests(
-                        organization=organization,
-                        pull_requests=pull_requests,
-                        run_id=run_id,
-                        group_id=group_id,
-                    )
-                except Exception:
-                    logger.exception(
-                        "seer.pr_attribution.failed",
-                        extra={"group_id": group_id, "run_id": run_id},
-                    )
-
-            try:
-                link_seer_run_pull_requests(
-                    organization=organization,
-                    seer_run_state_id=run_id,
-                    pull_requests=pull_requests,
-                )
-            except Exception:
-                logger.exception(
-                    "seer.pr_link.failed",
-                    extra={"group_id": group_id, "run_id": run_id},
-                )
 
         for entrypoint_key, entrypoint_cls in autofix_entrypoint_registry.registrations.items():
             logging_ctx = {

--- a/tests/sentry/seer/entrypoints/test_operator.py
+++ b/tests/sentry/seer/entrypoints/test_operator.py
@@ -13,11 +13,6 @@ from sentry.issues.action_log.types import (
 )
 from sentry.models.activity import Activity
 from sentry.models.organization import Organization
-from sentry.models.pullrequest import (
-    PullRequest,
-    PullRequestAttribution,
-    PullRequestAttributionSignalType,
-)
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.seer.agent.client_models import (
     CodingAgentState,
@@ -46,7 +41,6 @@ from sentry.seer.entrypoints.types import (
     SeerEntrypointKey,
     SeerOperatorCacheResult,
 )
-from sentry.seer.models.run import SeerRunPullRequest, SeerRunType
 from sentry.sentry_apps.event_types import SentryAppEventType
 from sentry.testutils.asserts import assert_failure_metric
 from sentry.testutils.cases import TestCase
@@ -385,121 +379,6 @@ class SeerOperatorTest(TestCase):
             event_payload=event_payload,
             cache_payload=cache_payload,
         )
-
-    def _pr_created_event_payload(self) -> dict:
-        return {
-            "run_id": MOCK_RUN_ID,
-            "group_id": self.group.id,
-            "pull_requests": [
-                {
-                    "provider": "unknown",
-                    "repo_name": "getsentry/sentry",
-                    "pull_request": {"pr_id": 1, "pr_number": 99, "pr_url": "https://x/99"},
-                }
-            ],
-        }
-
-    @patch.object(SeerAutofixOperator, "has_access", return_value=True)
-    def test_process_autofix_updates_records_pr_attribution(self, _mock_has_access):
-        repo = self.create_repo(self.project, name="getsentry/sentry")
-
-        with (
-            self.feature("organizations:pr-metrics-attribution"),
-            override_options({"issues.record-seer-actions-as-activities": False}),
-            patch.dict(
-                "sentry.seer.entrypoints.operator.autofix_entrypoint_registry.registrations",
-                {},
-                clear=True,
-            ),
-        ):
-            process_autofix_updates(
-                event_type=SentryAppEventType.SEER_PR_CREATED,
-                event_payload=self._pr_created_event_payload(),
-                organization_id=self.organization.id,
-            )
-
-        pull_request = PullRequest.objects.get(repository_id=repo.id, key="99")
-        attribution = PullRequestAttribution.objects.get(pull_request=pull_request)
-        assert attribution.signal_type == PullRequestAttributionSignalType.SENTRY_APP
-        assert attribution.signal_details is not None
-        assert attribution.signal_details["run_id"] == MOCK_RUN_ID
-
-    @patch.object(SeerAutofixOperator, "has_access", return_value=True)
-    def test_process_autofix_updates_pr_attribution_disabled(self, _mock_has_access):
-        repo = self.create_repo(self.project, name="getsentry/sentry")
-
-        # Feature flag off (default) — the attribution block must not run.
-        with (
-            override_options({"issues.record-seer-actions-as-activities": False}),
-            patch.dict(
-                "sentry.seer.entrypoints.operator.autofix_entrypoint_registry.registrations",
-                {},
-                clear=True,
-            ),
-        ):
-            process_autofix_updates(
-                event_type=SentryAppEventType.SEER_PR_CREATED,
-                event_payload=self._pr_created_event_payload(),
-                organization_id=self.organization.id,
-            )
-
-        assert not PullRequest.objects.filter(repository_id=repo.id).exists()
-        assert not PullRequestAttribution.objects.exists()
-
-    @patch.object(SeerAutofixOperator, "has_access", return_value=True)
-    def test_process_autofix_updates_links_pull_requests(self, _mock_has_access):
-        repo = self.create_repo(self.project, name="getsentry/sentry")
-        seer_run = self.create_seer_run(
-            self.organization, type=SeerRunType.FEATURE_RUN, seer_run_state_id=MOCK_RUN_ID
-        )
-
-        with (
-            override_options({"issues.record-seer-actions-as-activities": False}),
-            patch.dict(
-                "sentry.seer.entrypoints.operator.autofix_entrypoint_registry.registrations",
-                {},
-                clear=True,
-            ),
-        ):
-            process_autofix_updates(
-                event_type=SentryAppEventType.SEER_PR_CREATED,
-                event_payload=self._pr_created_event_payload(),
-                organization_id=self.organization.id,
-            )
-
-        pull_request = PullRequest.objects.get(repository_id=repo.id, key="99")
-        link = SeerRunPullRequest.objects.get(pull_request=pull_request)
-        assert link.seer_run_id == seer_run.id
-        assert not PullRequestAttribution.objects.exists()
-
-    @patch.object(SeerAutofixOperator, "has_access", return_value=True)
-    def test_process_autofix_updates_link_killswitch(self, _mock_has_access):
-        repo = self.create_repo(self.project, name="getsentry/sentry")
-        self.create_seer_run(
-            self.organization, type=SeerRunType.FEATURE_RUN, seer_run_state_id=MOCK_RUN_ID
-        )
-
-        with (
-            override_options(
-                {
-                    "issues.record-seer-actions-as-activities": False,
-                    "seer.pull-request-linking.killswitch.enabled": True,
-                }
-            ),
-            patch.dict(
-                "sentry.seer.entrypoints.operator.autofix_entrypoint_registry.registrations",
-                {},
-                clear=True,
-            ),
-        ):
-            process_autofix_updates(
-                event_type=SentryAppEventType.SEER_PR_CREATED,
-                event_payload=self._pr_created_event_payload(),
-                organization_id=self.organization.id,
-            )
-
-        assert not SeerRunPullRequest.objects.exists()
-        assert not PullRequest.objects.filter(repository_id=repo.id).exists()
 
     def test_process_autofix_updates_no_operator_access(self) -> None:
         mock_entrypoint_cls = Mock(spec=SeerAutofixEntrypoint)


### PR DESCRIPTION
> **Draft / do not merge yet.** Stacked on #120583. This is the Phase-2 cleanup and is only safe to land **after** #120583 is deployed *and* Seer's PR writer is calling the new `notify_seer_pr_created` RPC. Until then, keep this draft.

## What

Removes the redundant PR **attribution** + **run↔PR link** write from the autofix completion-hook path (`process_autofix_updates`, the `SEER_PR_CREATED` branch).

Once the run-anchored `notify_seer_pr_created` RPC (#120583) records attribution and linking for **every** PR Seer creates — including PRs from group-less runs that the completion hook silently skipped — this second write is pure duplication (idempotent, but dead weight).

## Diff

- Delete the `attribute_seer_created_pull_requests(...)` and `link_seer_run_pull_requests(...)` calls (and their now-unused imports) from `process_autofix_updates`.
- **Kept, untouched:** the `Activity` creation for `SEER_PR_CREATED`, the entrypoint fan-out via `on_autofix_update`, all other event-type handling, and the GitHub-webhook backstop in `src/sentry/seer/autofix/webhooks.py`.
- The four `process_autofix_updates` attribution/link tests (`..._records_pr_attribution`, `..._pr_attribution_disabled`, `..._links_pull_requests`, `..._link_killswitch`) and their shared payload helper are removed — that behavior now lives in the `NotifySeerPrCreatedTest` suite added by #120583. The `test_create_seer_activity_pr_created_with_pull_requests` Activity test is kept.

## Why it's safe

Attribution and linking are idempotent and best-effort, so during the rolling deploy window both writers can coexist harmlessly (the second is a no-op). This PR only removes the second writer *after* the first is proven live — hence the draft gate.

## Tests run vs deferred

- `tests/sentry/seer/entrypoints/test_operator.py` — 50 passed (was 54; the 4 removed tests migrated to #120583).
- `mypy` on `operator.py` — passed.
- `prek run` (ruff, ruff-format, flake8, mypy) on the diff — passed.

Deferred to CI: the full backend suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)