### PR TITLE
fix(replay): use org members endpoint for replay access selector

### DIFF
--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
@@ -40,10 +40,6 @@ describe('OrganizationSettingsForm', () => {
       url: '/organizations/org-slug/members/',
       body: [{user: UserFixture()}],
     });
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/users/',
-      body: [{user: UserFixture()}],
-    });
     onSave.mockReset();
   });
 
@@ -413,7 +409,7 @@ describe('OrganizationSettingsForm', () => {
     it('saves replayAccessMembers when a member is selected', async () => {
       const user = UserFixture();
       MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/users/`,
+        url: `/organizations/${organization.slug}/members/`,
         body: [{user}],
       });
       const replayPutMock = MockApiClient.addMockResponse({

--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.tsx
@@ -28,8 +28,7 @@ import {
   getLocalityDataFromOrganization,
   shouldDisplayLocalities,
 } from 'sentry/utils/cells';
-import {useProjectMembersQueryOptions} from 'sentry/utils/members/projectMembers';
-import {selectUsersFromMembers} from 'sentry/utils/members/shared';
+import {memberUsersQueryOptions} from 'sentry/utils/members/shared';
 import {fetchMutation} from 'sentry/utils/queryClient';
 import {RequestError} from 'sentry/utils/requestError/requestError';
 import {slugify} from 'sentry/utils/slugify';
@@ -86,10 +85,9 @@ export function ReplayAccessMembersField({
   organization: Organization;
 }) {
   const endpoint = `/organizations/${organization.slug}/`;
-  const {data: members = [], isPending: fetching} = useQuery({
-    ...useProjectMembersQueryOptions(),
-    select: resp => selectUsersFromMembers(resp.json),
-  });
+  const {data: members = [], isPending: fetching} = useQuery(
+    memberUsersQueryOptions({orgSlug: organization.slug})
+  );
   const memberOptions = members.map(m => ({value: m.id, label: m.name}));
 
   const replayMutationOpts = mutationOptions({


### PR DESCRIPTION
Fixes [REPLAY-947](https://linear.app/getsentry/issue/REPLAY-947).

## Problem

When "Restrict Replay Access" is enabled in **Settings → General**, the **Replay Access Members** selector was stuck loading / showed no members for regular org owners and managers. It only worked for superusers, which is why the reporter couldn't reproduce it as a superuser.

## Root cause

The field fetched its member list from `GET /organizations/{org}/users/` (`OrganizationUsersEndpoint`). That endpoint doesn't return org members — it returns *users who share a project the requester can access*, and it builds that project list via `get_projects()`, which for **non-superusers** filters by the requester's project **membership** (`has_project_membership`).

An owner/manager who isn't on the relevant teams therefore resolves to zero projects → zero members → an empty selector. Superusers hit the `has_project_access` branch instead and see every member.

## Fix

Swap the selector to the existing `memberUsersQueryOptions` helper, which hits `GET /organizations/{org}/members/` and lists **all** org members regardless of the requester's team membership. Spec mocks updated from `/users/` to `/members/` accordingly.
