### PR TITLE
fix(search): stop clipping single-value filter dropdowns

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -1444,6 +1444,8 @@ export function SearchQueryBuilderValueCombobox({
           gap="2xs"
           minWidth="0"
           height="100%"
+          overflowX={canSelectMultipleValues ? 'auto' : undefined}
+          overflowY={canSelectMultipleValues ? 'hidden' : undefined}
           ref={ref}
           data-test-id="filter-value-editing"
         >
@@ -1457,8 +1459,6 @@ export function SearchQueryBuilderValueCombobox({
 const ValueEditingChips = styled(Flex)`
   max-width: 100%;
   flex-wrap: nowrap;
-  overflow-x: auto;
-  overflow-y: hidden;
   scrollbar-width: none;
   &::-webkit-scrollbar {
     display: none;


### PR DESCRIPTION
Editing a `timestamp` filter value such as `24h ago` on the Issues page clipped the value dropdown to the value cell instead of letting it expand past it. Every option below the first row was invisible and unclickable, though still reachable by arrow key.

The value editing row became a horizontal scroll container in #118191 so a long chip row could scroll when it outgrew the cell. That also made it a clipping ancestor. The value dropdown renders inside that row unless the search bar is given a `portalTarget`, which the Issues page doesn't set, so the menu got clipped to a 54×22 window.

Multi-select filters were unaffected because they already portal their dropdown out to the top-level search bar wrapper. 

Only multi-value filters render chips, so the scroll container now applies only to them. This also covers the absolute-date picker, which renders inline with no portal at all and would have been clipped the same way once reached.

Fixes ISWF-3117