### PR TITLE
fix(bootstrap): Handle failed org preload requests

### DIFF
--- a/static/app/bootstrap/index.tsx
+++ b/static/app/bootstrap/index.tsx
@@ -67,11 +67,9 @@ async function promiseRequest(url: string) {
       };
       return [json, response.statusText, responseMeta];
     }
-    // eslint-disable-next-line @typescript-eslint/only-throw-error
-    throw [response.status, response.statusText];
-  } catch (error: any) {
-    // eslint-disable-next-line @typescript-eslint/only-throw-error
-    throw [error.status, error.statusText];
+    return null;
+  } catch {
+    return null;
   }
 }
 

--- a/static/app/bootstrap/initializeSdk.spec.tsx
+++ b/static/app/bootstrap/initializeSdk.spec.tsx
@@ -44,40 +44,6 @@ describe('initializeSdk', () => {
       })
     );
   });
-
-  it('filters malformed [null,null] unhandled rejections', () => {
-    initializeSdk({
-      ...window.__initialData,
-      apmSampling: 1,
-      sentryConfig: {
-        allowUrls: [],
-        dsn: '',
-        release: '',
-        tracePropagationTargets: [],
-      },
-    });
-
-    const initConfig = jest.mocked(Sentry.init).mock.calls.slice(-1)[0]?.[0];
-    expect(initConfig?.beforeSend).toBeDefined();
-
-    const event = {
-      // The SDK has not normalized this to the stored `[null,null]` string yet.
-      message: [null, null] as unknown as string,
-      exception: {
-        values: [
-          {
-            type: 'Error',
-            value: ',',
-            mechanism: {
-              type: 'auto.browser.global_handlers.onunhandledrejection',
-            },
-          },
-        ],
-      },
-    } as Sentry.ErrorEvent;
-
-    expect(initConfig?.beforeSend?.(event, {originalException: [null, null]})).toBeNull();
-  });
 });
 
 describe('isFilteredRequestErrorEvent', () => {

--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -185,11 +185,7 @@ export function initializeSdk(config: Config) {
     },
 
     beforeSend(event, hint) {
-      if (
-        isFilteredRequestErrorEvent(event) ||
-        isEventWithFileUrl(event) ||
-        isNullTupleUnhandledRejectionEvent(hint)
-      ) {
+      if (isFilteredRequestErrorEvent(event) || isEventWithFileUrl(event)) {
         return null;
       }
 
@@ -277,21 +273,6 @@ export function isFilteredRequestErrorEvent(event: Event): boolean {
 
 export function isEventWithFileUrl(event: Event): boolean {
   return !!event.request?.url?.startsWith('file://');
-}
-
-/**
- * Ignore unhandled rejections of `[null, null]`. The SDK keeps the original
- * array in the hint until after `beforeSend`, then normalizes it to the
- * `[null,null]` message shown in the stored event.
- */
-function isNullTupleUnhandledRejectionEvent(hint: Sentry.EventHint): boolean {
-  const originalException = hint.originalException;
-
-  return (
-    Array.isArray(originalException) &&
-    originalException.length === 2 &&
-    originalException.every(value => value === null)
-  );
 }
 
 /** Tag and set fingerprint for UndefinedResponseBodyError events */

--- a/static/app/types/system.tsx
+++ b/static/app/types/system.tsx
@@ -93,11 +93,11 @@ declare global {
      */
     __sentry_preload?: {
       orgSlug?: string;
-      organization?: Promise<ApiResult>;
+      organization?: Promise<ApiResult | null>;
       organization_fallback?: Promise<ApiResult>;
-      projects?: Promise<ApiResult>;
+      projects?: Promise<ApiResult | null>;
       projects_fallback?: Promise<ApiResult>;
-      teams?: Promise<ApiResult>;
+      teams?: Promise<ApiResult | null>;
       teams_fallback?: Promise<ApiResult>;
     };
     /**


### PR DESCRIPTION
Standalone SPA preload failures reject with an undefined tuple that gets reported as noisy frontend errors.

Resolve null at the source and remove the null-tuple SDK filter that was trying to hide these events.

Refs #109588
fixes JAVASCRIPT-2XH0
