### PR TITLE
ref(seer): Return the SeerRun from trigger_autofix_agent, not a bare int

### DIFF
--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -49,7 +49,12 @@ from sentry.seer.agent.on_completion_hook import (
     AgentOnCompletionHook,
     extract_hook_definition,
 )
-from sentry.seer.models import SeerApiError, SeerPermissionError, SeerRepoDefinition
+from sentry.seer.models import (
+    UNKNOWN_RUN_ID_FOR_GROUP,
+    SeerApiError,
+    SeerPermissionError,
+    SeerRepoDefinition,
+)
 from sentry.seer.models.run import SeerAgentRun, SeerRun, SeerRunType
 from sentry.seer.seer_setup import has_seer_access_with_detail
 from sentry.seer.signed_seer_api import SeerViewerContext
@@ -648,7 +653,7 @@ class SeerAgentClient:
         artifact_schema: type[BaseModel] | None = None,
         ui_tools: str | None = None,
         request: Request | None = None,
-    ) -> int:
+    ) -> SeerRun:
         """
         Continue an existing Seer Agent session. This allows you to add follow-up queries to an ongoing conversation.
 
@@ -661,10 +666,11 @@ class SeerAgentClient:
             artifact_schema: Optional Pydantic model for the new artifact (required if artifact_key is provided)
 
         Returns:
-            int: The run ID (same as input)
+            SeerRun: The run's mirror row.
 
         Raises:
             SeerApiError: If the Seer API request fails
+            SeerPermissionError: If no SeerRun mirror exists for run_id
             ValueError: If artifact_schema is provided without artifact_key
         """
         if bool(artifact_schema) != bool(artifact_key):
@@ -765,11 +771,15 @@ class SeerAgentClient:
 
         if response.status >= 400:
             raise SeerApiError("Seer request failed", response.status)
-        result = response.json()
 
-        SeerRun.objects.filter(seer_run_state_id=run_id).update(last_triggered_at=now())
+        run = SeerRun.objects.filter(
+            organization_id=self.organization.id, seer_run_state_id=run_id
+        ).first()
+        if run is None:
+            raise SeerPermissionError(UNKNOWN_RUN_ID_FOR_GROUP)
+        run.update(last_triggered_at=now())
 
-        return result["run_id"]
+        return run
 
     def get_run(
         self,

--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -676,6 +676,14 @@ class SeerAgentClient:
         if bool(artifact_schema) != bool(artifact_key):
             raise ValueError("artifact_key and artifact_schema must be provided together")
 
+        # Resolve the mirror before calling Seer so a missing run never advances
+        # the remote run (fail closed).
+        run = SeerRun.objects.filter(
+            organization_id=self.organization.id, seer_run_state_id=run_id
+        ).first()
+        if run is None:
+            raise SeerPermissionError(UNKNOWN_RUN_ID_FOR_GROUP)
+
         agent_run_options: dict[str, Any] = {
             "enable_coding": self.enable_coding,
             "enable_code_mode_tools": self.enable_code_mode_tools,
@@ -772,11 +780,6 @@ class SeerAgentClient:
         if response.status >= 400:
             raise SeerApiError("Seer request failed", response.status)
 
-        run = SeerRun.objects.filter(
-            organization_id=self.organization.id, seer_run_state_id=run_id
-        ).first()
-        if run is None:
-            raise SeerPermissionError(UNKNOWN_RUN_ID_FOR_GROUP)
         run.update(last_triggered_at=now())
 
         return run

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -385,7 +385,7 @@ def trigger_autofix_agent(
     feedback: Sequence[Feedback] | None = None,
     user: User | RpcUser | AnonymousUser | None = None,
     enable_bash_tools: bool = False,
-) -> SeerRun | None:
+) -> SeerRun:
     """
     Start or continue an agent-based autofix run.
 
@@ -456,7 +456,7 @@ def trigger_autofix_agent(
     artifact_key = step.value if config.artifact_schema else None
     artifact_schema = config.artifact_schema
 
-    run: SeerRun | None = None
+    run: SeerRun
     if run_id is None:
         metadata: dict[str, Any] = {
             "group_id": group.id,
@@ -478,6 +478,15 @@ def trigger_autofix_agent(
             group.organization.id, group.project.id, DataCategory.SEER_AUTOFIX
         )
     else:
+        # Resolve the mirror before touching Seer so a missing run fails without
+        # advancing it.
+        existing = SeerRun.objects.filter(
+            organization_id=group.organization.id,
+            seer_run_state_id=run_id,
+        ).first()
+        if existing is None:
+            raise SeerPermissionError(UNKNOWN_RUN_ID_FOR_GROUP)
+        run = existing
         client.continue_run(
             run_id=run_id,
             prompt=prompt,
@@ -486,12 +495,6 @@ def trigger_autofix_agent(
             artifact_schema=artifact_schema,
             insert_index=insert_index,
         )
-
-    if run is None:
-        run = SeerRun.objects.filter(
-            organization_id=group.organization.id,
-            seer_run_state_id=run_id,
-        ).first()
 
     # Emit the started event after run_id is resolved so it can be joined to
     # downstream completed/PR events.
@@ -509,7 +512,7 @@ def trigger_autofix_agent(
 
     payload: dict[str, Any] = {
         "run_id": run_id,
-        "sentry_run_id": str(run.uuid) if run is not None else None,
+        "sentry_run_id": str(run.uuid),
         "group_id": group.id,
     }
     if iteration_index is not None:

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -385,7 +385,7 @@ def trigger_autofix_agent(
     feedback: Sequence[Feedback] | None = None,
     user: User | RpcUser | AnonymousUser | None = None,
     enable_bash_tools: bool = False,
-) -> int:
+) -> SeerRun | None:
     """
     Start or continue an agent-based autofix run.
 
@@ -396,7 +396,8 @@ def trigger_autofix_agent(
         stopping_point: Where to stop the automated pipeline (only used for new runs)
 
     Returns:
-        The run ID
+        The run's SeerRun mirror (carrying both seer_run_state_id and uuid). None
+        only when continuing a legacy run that predates SeerRun mirroring.
     """
     # check billing quota for triggering a new autofix run
     if run_id is None:
@@ -568,7 +569,7 @@ def trigger_autofix_agent(
         },
     )
 
-    return run_id
+    return run
 
 
 def get_autofix_agent_state(organization: Organization, group_id: int):

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -478,8 +478,7 @@ def trigger_autofix_agent(
             group.organization.id, group.project.id, DataCategory.SEER_AUTOFIX
         )
     else:
-        # Resolve the mirror before touching Seer so a missing run fails without
-        # advancing it.
+        # Resolve before continue_run so a missing run fails without advancing it.
         existing = SeerRun.objects.filter(
             organization_id=group.organization.id,
             seer_run_state_id=run_id,

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -394,11 +394,6 @@ def trigger_autofix_agent(
         step: Which autofix step to run
         run_id: Existing run ID to continue, or None for new run
         stopping_point: Where to stop the automated pipeline (only used for new runs)
-
-    Returns:
-        The run's SeerRun mirror (carrying both seer_run_state_id and uuid). A
-        kickoff (run_id is None) always returns a freshly created mirror; a
-        continue returns None if no SeerRun row matches the given run_id.
     """
     # check billing quota for triggering a new autofix run
     if run_id is None:

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -396,8 +396,9 @@ def trigger_autofix_agent(
         stopping_point: Where to stop the automated pipeline (only used for new runs)
 
     Returns:
-        The run's SeerRun mirror (carrying both seer_run_state_id and uuid). None
-        only when continuing a legacy run that predates SeerRun mirroring.
+        The run's SeerRun mirror (carrying both seer_run_state_id and uuid). A
+        kickoff (run_id is None) always returns a freshly created mirror; a
+        continue returns None if no SeerRun row matches the given run_id.
     """
     # check billing quota for triggering a new autofix run
     if run_id is None:

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -52,7 +52,7 @@ from sentry.seer.autofix.utils import (
 from sentry.seer.entrypoints.operator import SeerAutofixOperator, process_autofix_updates
 from sentry.seer.models import SeerRepoDefinition
 from sentry.seer.models.run import SeerRun
-from sentry.seer.models.seer_api_models import SeerPermissionError
+from sentry.seer.models.seer_api_models import UNKNOWN_RUN_ID_FOR_GROUP, SeerPermissionError
 from sentry.sentry_apps.event_types import SentryAppEventType
 from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
 from sentry.sentry_apps.tasks.sentry_apps import broadcast_webhooks_for_organization
@@ -69,8 +69,6 @@ if TYPE_CHECKING:
     from sentry.users.services.user import RpcUser
 
 logger = logging.getLogger(__name__)
-
-UNKNOWN_RUN_ID_FOR_GROUP = "Unknown run id for group"
 
 
 class NoSeerQuotaException(Exception):
@@ -478,15 +476,7 @@ def trigger_autofix_agent(
             group.organization.id, group.project.id, DataCategory.SEER_AUTOFIX
         )
     else:
-        # Resolve before continue_run so a missing run fails without advancing it.
-        existing = SeerRun.objects.filter(
-            organization_id=group.organization.id,
-            seer_run_state_id=run_id,
-        ).first()
-        if existing is None:
-            raise SeerPermissionError(UNKNOWN_RUN_ID_FOR_GROUP)
-        run = existing
-        client.continue_run(
+        run = client.continue_run(
             run_id=run_id,
             prompt=prompt,
             prompt_metadata=prompt_metadata,

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -41,6 +41,7 @@ from sentry.seer.autofix.utils import (
 from sentry.seer.entrypoints.cache import SeerOperatorAutofixCache
 from sentry.seer.entrypoints.operator import SeerAutofixOperator
 from sentry.seer.models import SummarizeIssueResponse
+from sentry.seer.models.run import SeerRun
 from sentry.seer.signed_seer_api import (
     SeerViewerContext,
     SummarizeIssueRequest,
@@ -177,9 +178,9 @@ def _trigger_autofix_task(
             }
         )
 
-        run_id: int | None = None
+        run: SeerRun | None = None
         try:
-            run_id = trigger_autofix_agent(
+            run = trigger_autofix_agent(
                 group=group,
                 step=AutofixStep.ROOT_CAUSE,
                 referrer=referrer,
@@ -189,8 +190,10 @@ def _trigger_autofix_task(
         except NoSeerQuotaException:
             pass
 
-        if run_id and SeerAutofixOperator.has_access(organization=group.project.organization):
-            SeerOperatorAutofixCache.migrate(from_group_id=group_id, to_run_id=run_id)
+        if run and SeerAutofixOperator.has_access(organization=group.project.organization):
+            SeerOperatorAutofixCache.migrate(
+                from_group_id=group_id, to_run_id=run.seer_run_state_id
+            )
 
 
 def _get_event(

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -432,8 +432,6 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                         return Response(status=status.HTTP_404_NOT_FOUND)
                     raise PermissionDenied(SEER_PERMISSION_DENIED)
 
-                # Kickoff always yields a fresh run; continue always has a
-                # resolved_run_id (a legacy run with no mirror leaves run None).
                 triggered_run_id = run.seer_run_state_id if run is not None else resolved_run_id
                 assert triggered_run_id is not None
                 run_id = triggered_run_id

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -410,7 +410,7 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
 
             case _:
                 try:
-                    run_id = trigger_autofix_agent(
+                    run = trigger_autofix_agent(
                         group=group,
                         step=AutofixStep(step),
                         referrer=referrer,
@@ -432,6 +432,12 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                         return Response(status=status.HTTP_404_NOT_FOUND)
                     raise PermissionDenied(SEER_PERMISSION_DENIED)
 
+                # Kickoff always yields a fresh run; continue always has a
+                # resolved_run_id (a legacy run with no mirror leaves run None).
+                triggered_run_id = run.seer_run_state_id if run is not None else resolved_run_id
+                assert triggered_run_id is not None
+                run_id = triggered_run_id
+
                 if is_autofix_kickoff:
                     actor = resolve_action_actor(request)
                     with action_context_scope(
@@ -447,7 +453,6 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                             data={"referrer": referrer.value},
                             send_notification=False,
                         )
-                    run = get_seer_run(run_id, group.organization)
                     sentry_run_id = str(run.uuid) if run else None
                 else:
                     sentry_run_id = resolved_sentry_run_id

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -42,7 +42,6 @@ from sentry.models.activity import Activity
 from sentry.models.group import Group
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.seer.autofix.autofix_agent import (
-    UNKNOWN_RUN_ID_FOR_GROUP,
     AutofixStep,
     NoSeerQuotaException,
     get_autofix_agent_state,
@@ -76,7 +75,7 @@ from sentry.seer.autofix.utils import (
     CodingAgentProviderType,
 )
 from sentry.seer.endpoints.utils import get_seer_run, resolve_seer_run
-from sentry.seer.models import SeerPermissionError
+from sentry.seer.models import UNKNOWN_RUN_ID_FOR_GROUP, SeerPermissionError
 from sentry.tasks.seer.pr_iteration import consume_queued_autofix_feedback
 from sentry.types.activity import ActivityType
 from sentry.types.ratelimit import RateLimit, RateLimitCategory

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -432,9 +432,7 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                         return Response(status=status.HTTP_404_NOT_FOUND)
                     raise PermissionDenied(SEER_PERMISSION_DENIED)
 
-                triggered_run_id = run.seer_run_state_id if run is not None else resolved_run_id
-                assert triggered_run_id is not None
-                run_id = triggered_run_id
+                run_id = run.seer_run_state_id
 
                 if is_autofix_kickoff:
                     actor = resolve_action_actor(request)
@@ -451,7 +449,7 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                             data={"referrer": referrer.value},
                             send_notification=False,
                         )
-                    sentry_run_id = str(run.uuid) if run else None
+                    sentry_run_id = str(run.uuid)
                 else:
                     sentry_run_id = resolved_sentry_run_id
 

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -525,7 +525,7 @@ class SeerAgentOperator[CachePayloadT]:
                         run_id=existing_runs[0].run_id,
                         prompt=prompt,
                         on_page_context=on_page_context,
-                    )
+                    ).seer_run_state_id
                     lifecycle.add_extra("continued", "true")
                 else:
                     run_id = client.start_run(

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -222,7 +222,6 @@ class SeerAutofixOperator[CachePayloadT]:
                         run_id=None,
                         user=user,
                     )
-                    assert run is not None
                     run_id = run.seer_run_state_id
                 elif stopping_point == AutofixStoppingPoint.OPEN_PR:
                     trigger_push_changes(

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -222,7 +222,6 @@ class SeerAutofixOperator[CachePayloadT]:
                         run_id=None,
                         user=user,
                     )
-                    # A fresh kickoff always mirrors, so run is never None here.
                     assert run is not None
                     run_id = run.seer_run_state_id
                 elif stopping_point == AutofixStoppingPoint.OPEN_PR:

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -215,13 +215,16 @@ class SeerAutofixOperator[CachePayloadT]:
 
             try:
                 if not run_id:
-                    run_id = trigger_autofix_agent(
+                    run = trigger_autofix_agent(
                         group=group,
                         step=AutofixStep.ROOT_CAUSE,
                         referrer=AutofixReferrer.SLACK,
                         run_id=None,
                         user=user,
                     )
+                    # A fresh kickoff always mirrors, so run is never None here.
+                    assert run is not None
+                    run_id = run.seer_run_state_id
                 elif stopping_point == AutofixStoppingPoint.OPEN_PR:
                     trigger_push_changes(
                         group,

--- a/src/sentry/seer/models/seer_api_models.py
+++ b/src/sentry/seer/models/seer_api_models.py
@@ -134,3 +134,6 @@ class SeerPermissionError(Exception):
 
     def __str__(self):
         return f"Seer permission error: {self.message}"
+
+
+UNKNOWN_RUN_ID_FOR_GROUP = "Unknown run id for group"

--- a/src/sentry/seer/night_shift/delivery.py
+++ b/src/sentry/seer/night_shift/delivery.py
@@ -180,7 +180,7 @@ def _process_verdicts(
         )
 
     reason_by_group_id = {v.group_id: v.reason for v in verdicts}
-    state_id_by_group: dict[int, int] = {}
+    run_by_group: dict[int, SeerRun] = {}
     rate_limited_group_ids: set[int] = set()
     if not dry_run and fixable_groups:
         # Cache organization on each group's project to avoid N+1 queries
@@ -219,20 +219,22 @@ def _process_verdicts(
                 else None
             )
             try:
-                state_id_by_group[group.id] = trigger_autofix_agent(
+                autofix_run = trigger_autofix_agent(
                     group=group,
                     step=AutofixStep.ROOT_CAUSE,
                     referrer=referrer,
                     stopping_point=stopping_point_by_project_id[group.project_id],
                     user_context=user_context,
                 )
+                if autofix_run is not None:
+                    run_by_group[group.id] = autofix_run
             except Exception:
                 logger.exception(
                     "night_shift.autofix_trigger_failed",
                     extra={**log_extra, "group_id": group.id},
                 )
 
-        sentry_sdk.metrics.count("night_shift.autofix_triggered", len(state_id_by_group))
+        sentry_sdk.metrics.count("night_shift.autofix_triggered", len(run_by_group))
         if rate_limited_group_ids:
             sentry_sdk.metrics.count(
                 "night_shift.autofix_rate_limited", len(rate_limited_group_ids)
@@ -241,12 +243,6 @@ def _process_verdicts(
                 "night_shift.autofix_rate_limited",
                 extra={**log_extra, "num_rate_limited": len(rate_limited_group_ids)},
             )
-
-    # TODO: have trigger_autofix_agent return the SeerRun directly to avoid this lookup.
-    seer_run_by_state_id = {
-        sr.seer_run_state_id: sr
-        for sr in SeerRun.objects.filter(seer_run_state_id__in=state_id_by_group.values())
-    }
 
     rows: list[SeerNightShiftRunResult] = []
     for v in verdicts:
@@ -258,15 +254,14 @@ def _process_verdicts(
         seer_run_id: str | None = None
         result_seer_run: SeerRun | None = None
         if v.action == TriageAction.AUTOFIX and not dry_run:
-            state_id = state_id_by_group.get(v.group_id)
-            if state_id is None:
+            result_seer_run = run_by_group.get(v.group_id)
+            if result_seer_run is None:
                 if v.group_id in rate_limited_group_ids:
                     extras["rate_limited"] = True
                 else:
                     extras["trigger_error"] = True
             else:
-                seer_run_id = str(state_id)
-                result_seer_run = seer_run_by_state_id.get(state_id)
+                seer_run_id = str(result_seer_run.seer_run_state_id)
         rows.append(
             SeerNightShiftRunResult(
                 run=run,
@@ -293,8 +288,8 @@ def _process_verdicts(
                     "group_id": v.group_id,
                     "action": v.action,
                     "seer_run_id": (
-                        str(state_id)
-                        if (state_id := state_id_by_group.get(v.group_id)) is not None
+                        str(r.seer_run_state_id)
+                        if (r := run_by_group.get(v.group_id)) is not None
                         else None
                     ),
                 }

--- a/src/sentry/seer/night_shift/delivery.py
+++ b/src/sentry/seer/night_shift/delivery.py
@@ -219,15 +219,13 @@ def _process_verdicts(
                 else None
             )
             try:
-                autofix_run = trigger_autofix_agent(
+                run_by_group[group.id] = trigger_autofix_agent(
                     group=group,
                     step=AutofixStep.ROOT_CAUSE,
                     referrer=referrer,
                     stopping_point=stopping_point_by_project_id[group.project_id],
                     user_context=user_context,
                 )
-                if autofix_run is not None:
-                    run_by_group[group.id] = autofix_run
             except Exception:
                 logger.exception(
                     "night_shift.autofix_trigger_failed",

--- a/tests/sentry/seer/agent/test_agent_client.py
+++ b/tests/sentry/seer/agent/test_agent_client.py
@@ -503,6 +503,7 @@ class TestSeerAgentClient(TestCase):
         """Test that HTTP errors are propagated"""
         mock_access.return_value = (True, None)
         mock_post.return_value.status = 500
+        self.create_seer_run(organization=self.organization, seer_run_state_id=123)
 
         client = SeerAgentClient(self.organization, self.user)
         with pytest.raises(SeerApiError):
@@ -517,6 +518,9 @@ class TestSeerAgentClient(TestCase):
         client = SeerAgentClient(self.organization, self.user)
         with pytest.raises(SeerPermissionError):
             client.continue_run(999, "Follow up query")
+
+        # Fail closed: a missing mirror must not advance the run on Seer's side.
+        mock_post.assert_not_called()
 
     @patch("sentry.seer.agent.client.has_seer_access_with_detail")
     @patch("sentry.seer.agent.client.make_agent_chat_request")

--- a/tests/sentry/seer/agent/test_agent_client.py
+++ b/tests/sentry/seer/agent/test_agent_client.py
@@ -296,6 +296,7 @@ class TestSeerAgentClient(TestCase):
     def test_continue_run_includes_embed_widgets_by_default(self, mock_post, mock_access):
         mock_access.return_value = (True, None)
         mock_post.return_value = self._mock_run_response()
+        self.create_seer_run(organization=self.organization, seer_run_state_id=123)
 
         client = SeerAgentClient(self.organization, self.user)
         client.continue_run(123, "Follow-up query")
@@ -309,6 +310,7 @@ class TestSeerAgentClient(TestCase):
     def test_continue_run_excludes_embed_widgets_when_disabled(self, mock_post, mock_access):
         mock_access.return_value = (True, None)
         mock_post.return_value = self._mock_run_response()
+        self.create_seer_run(organization=self.organization, seer_run_state_id=123)
 
         client = SeerAgentClient(self.organization, self.user, enable_embeds=False)
         client.continue_run(123, "Follow-up query")
@@ -426,11 +428,12 @@ class TestSeerAgentClient(TestCase):
         """Test continuing an existing run"""
         mock_access.return_value = (True, None)
         mock_post.return_value = self._mock_run_response(run_id=456)
+        self.create_seer_run(organization=self.organization, seer_run_state_id=456)
 
         client = SeerAgentClient(self.organization, self.user)
-        run_id = client.continue_run(456, "Follow up query")
+        run = client.continue_run(456, "Follow up query")
 
-        assert run_id == 456
+        assert run.seer_run_state_id == 456
         assert mock_post.called
         body = mock_post.call_args[0][0]
         assert "enable_frontend_code_search" not in body["agent_run_options"]
@@ -455,6 +458,7 @@ class TestSeerAgentClient(TestCase):
             )
         ]
 
+        self.create_seer_run(organization=self.organization, seer_run_state_id=1)
         client = SeerAgentClient(self.organization, user=None)
         client.continue_run(1, "Follow up")
 
@@ -469,14 +473,13 @@ class TestSeerAgentClient(TestCase):
         """Test continuing a run with all optional parameters"""
         mock_access.return_value = (True, None)
         mock_post.return_value = self._mock_run_response(run_id=789)
+        self.create_seer_run(organization=self.organization, seer_run_state_id=789)
 
         client = SeerAgentClient(self.organization, self.user)
         with self.feature("organizations:seer-agent-source-code-search"):
-            run_id = client.continue_run(
-                789, "Follow up", insert_index=2, on_page_context="context"
-            )
+            run = client.continue_run(789, "Follow up", insert_index=2, on_page_context="context")
 
-        assert run_id == 789
+        assert run.seer_run_state_id == 789
         body = mock_post.call_args[0][0]
         assert body["agent_run_options"]["enable_frontend_code_search"] is True
 
@@ -486,6 +489,7 @@ class TestSeerAgentClient(TestCase):
     def test_continue_run_passes_enable_pr_context_tools(self, mock_post, mock_access):
         mock_access.return_value = (True, None)
         mock_post.return_value = self._mock_run_response(run_id=789)
+        self.create_seer_run(organization=self.organization, seer_run_state_id=789)
 
         client = SeerAgentClient(self.organization, self.user, enable_pr_context_tools=True)
         client.continue_run(789, "Follow up")
@@ -503,6 +507,16 @@ class TestSeerAgentClient(TestCase):
         client = SeerAgentClient(self.organization, self.user)
         with pytest.raises(SeerApiError):
             client.continue_run(123, "Test query")
+
+    @patch("sentry.seer.agent.client.has_seer_access_with_detail")
+    @patch("sentry.seer.agent.client.make_agent_chat_request")
+    def test_continue_run_missing_mirror_raises(self, mock_post, mock_access):
+        mock_access.return_value = (True, None)
+        mock_post.return_value = self._mock_run_response(run_id=999)
+
+        client = SeerAgentClient(self.organization, self.user)
+        with pytest.raises(SeerPermissionError):
+            client.continue_run(999, "Follow up query")
 
     @patch("sentry.seer.agent.client.has_seer_access_with_detail")
     @patch("sentry.seer.agent.client.make_agent_chat_request")
@@ -670,17 +684,18 @@ class TestSeerAgentClientArtifacts(TestCase):
         mock_response.json.return_value = {"run_id": 123}
         mock_response.status = 200
         mock_post.return_value = mock_response
+        self.create_seer_run(organization=self.organization, seer_run_state_id=123)
 
         class Solution(BaseModel):
             description: str
             steps: list[str]
 
         client = SeerAgentClient(self.organization, self.user)
-        run_id = client.continue_run(
+        run = client.continue_run(
             123, "Propose a fix", artifact_key="solution", artifact_schema=Solution
         )
 
-        assert run_id == 123
+        assert run.seer_run_state_id == 123
 
         body = mock_post.call_args[0][0]
         assert body["artifact_key"] == "solution"

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -423,7 +423,6 @@ class TestTriggerAutofixAgent(TestCase):
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
         mock_client.start_run.return_value = MagicMock(seer_run_state_id=12345)
-        mock_client.continue_run.return_value = 12345
 
         step_to_action = {
             AutofixStep.ROOT_CAUSE: SeerActionType.ROOT_CAUSE_STARTED,
@@ -454,10 +453,10 @@ class TestTriggerAutofixAgent(TestCase):
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
         mock_client.get_run.return_value = self._make_run_state()
-        mock_client.continue_run.return_value = 67890
         seer_run = self.create_seer_run(
             organization=self.group.organization, seer_run_state_id=67890
         )
+        mock_client.continue_run.return_value = seer_run
 
         result = trigger_autofix_agent(
             group=self.group,
@@ -543,8 +542,9 @@ class TestTriggerAutofixAgent(TestCase):
                 )
             },
         )
-        mock_client.continue_run.return_value = 67890
-        self.create_seer_run(organization=self.group.organization, seer_run_state_id=67890)
+        mock_client.continue_run.return_value = self.create_seer_run(
+            organization=self.group.organization, seer_run_state_id=67890
+        )
 
         with self.feature("organizations:autofix-pr-iteration"):
             trigger_autofix_agent(
@@ -627,8 +627,9 @@ class TestTriggerAutofixAgent(TestCase):
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
         mock_client.get_run.return_value = self._make_run_state()
-        mock_client.continue_run.return_value = 67890
-        self.create_seer_run(organization=self.group.organization, seer_run_state_id=67890)
+        mock_client.continue_run.return_value = self.create_seer_run(
+            organization=self.group.organization, seer_run_state_id=67890
+        )
 
         trigger_autofix_agent(
             group=self.group,
@@ -649,10 +650,10 @@ class TestTriggerAutofixAgent(TestCase):
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
         mock_client.get_run.return_value = self._make_run_state()
-        mock_client.continue_run.return_value = 67890
         seer_run = self.create_seer_run(
             organization=self.group.organization, seer_run_state_id=67890
         )
+        mock_client.continue_run.return_value = seer_run
 
         run = trigger_autofix_agent(
             group=self.group,
@@ -662,26 +663,6 @@ class TestTriggerAutofixAgent(TestCase):
         )
 
         assert run == seer_run
-
-    @patch("sentry.quotas.backend.record_seer_run")
-    @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
-    @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
-    def test_continue_with_missing_mirror_raises_without_touching_seer(
-        self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
-    ):
-        mock_client = MagicMock()
-        mock_client_class.return_value = mock_client
-
-        with pytest.raises(SeerPermissionError):
-            trigger_autofix_agent(
-                group=self.group,
-                step=AutofixStep.SOLUTION,
-                referrer=AutofixReferrer.UNKNOWN,
-                run_id=99999,
-            )
-
-        mock_client.continue_run.assert_not_called()
 
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
     @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
@@ -760,8 +741,9 @@ class TestTriggerAutofixAgent(TestCase):
                 )
             },
         )
-        mock_client.continue_run.return_value = 67890
-        self.create_seer_run(organization=self.group.organization, seer_run_state_id=67890)
+        mock_client.continue_run.return_value = self.create_seer_run(
+            organization=self.group.organization, seer_run_state_id=67890
+        )
 
         with self.feature("organizations:autofix-pr-iteration"):
             trigger_autofix_agent(

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -681,8 +681,6 @@ class TestTriggerAutofixAgent(TestCase):
                 run_id=99999,
             )
 
-        # The run is resolved before Seer is called, so a missing mirror fails
-        # without advancing the run.
         mock_client.continue_run.assert_not_called()
 
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -544,6 +544,7 @@ class TestTriggerAutofixAgent(TestCase):
             },
         )
         mock_client.continue_run.return_value = 67890
+        self.create_seer_run(organization=self.group.organization, seer_run_state_id=67890)
 
         with self.feature("organizations:autofix-pr-iteration"):
             trigger_autofix_agent(
@@ -627,6 +628,7 @@ class TestTriggerAutofixAgent(TestCase):
         mock_client_class.return_value = mock_client
         mock_client.get_run.return_value = self._make_run_state()
         mock_client.continue_run.return_value = 67890
+        self.create_seer_run(organization=self.group.organization, seer_run_state_id=67890)
 
         trigger_autofix_agent(
             group=self.group,
@@ -660,9 +662,28 @@ class TestTriggerAutofixAgent(TestCase):
         )
 
         assert run == seer_run
-        mock_client.continue_run.assert_called_once()
-        mock_check_quota.assert_not_called()
-        mock_record_run.assert_not_called()
+
+    @patch("sentry.quotas.backend.record_seer_run")
+    @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
+    @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
+    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    def test_continue_with_missing_mirror_raises_without_touching_seer(
+        self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
+    ):
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+
+        with pytest.raises(SeerPermissionError):
+            trigger_autofix_agent(
+                group=self.group,
+                step=AutofixStep.SOLUTION,
+                referrer=AutofixReferrer.UNKNOWN,
+                run_id=99999,
+            )
+
+        # The run is resolved before Seer is called, so a missing mirror fails
+        # without advancing the run.
+        mock_client.continue_run.assert_not_called()
 
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
     @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
@@ -742,6 +763,7 @@ class TestTriggerAutofixAgent(TestCase):
             },
         )
         mock_client.continue_run.return_value = 67890
+        self.create_seer_run(organization=self.group.organization, seer_run_state_id=67890)
 
         with self.feature("organizations:autofix-pr-iteration"):
             trigger_autofix_agent(

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -466,7 +466,7 @@ class TestTriggerAutofixAgent(TestCase):
             run_id=67890,
         )
 
-        assert result == 67890
+        assert result == seer_run
         # Verify started webhook was sent with the existing run_id and uuid
         mock_broadcast.assert_called_once()
         call_kwargs = mock_broadcast.call_args.kwargs
@@ -648,15 +648,18 @@ class TestTriggerAutofixAgent(TestCase):
         mock_client_class.return_value = mock_client
         mock_client.get_run.return_value = self._make_run_state()
         mock_client.continue_run.return_value = 67890
+        seer_run = self.create_seer_run(
+            organization=self.group.organization, seer_run_state_id=67890
+        )
 
-        run_id = trigger_autofix_agent(
+        run = trigger_autofix_agent(
             group=self.group,
             step=AutofixStep.SOLUTION,
             referrer=AutofixReferrer.UNKNOWN,
             run_id=67890,
         )
 
-        assert run_id == 67890
+        assert run == seer_run
         mock_client.continue_run.assert_called_once()
         mock_check_quota.assert_not_called()
         mock_record_run.assert_not_called()

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -145,7 +145,8 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
     @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
     def test_post_triggers_autofix_agent(self, mock_trigger_explorer):
         group = self.create_group()
-        mock_trigger_explorer.return_value = 123
+        run = self.create_seer_run(organization=self.organization, seer_run_state_id=123)
+        mock_trigger_explorer.return_value = run
 
         self.login_as(user=self.user)
         response = self.client.post(
@@ -162,7 +163,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
     def test_post_kickoff_returns_sentry_run_id(self, mock_trigger_explorer):
         group = self.create_group()
         run = self.create_seer_run(organization=self.organization, seer_run_state_id=777)
-        mock_trigger_explorer.return_value = 777
+        mock_trigger_explorer.return_value = run
 
         self.login_as(user=self.user)
         response = self.client.post(
@@ -176,7 +177,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
     def test_post_continue_with_sentry_run_id_resolves_to_numeric_id(self, mock_trigger_explorer):
         group = self.create_group()
         run = self.create_seer_run(organization=self.organization, seer_run_state_id=555)
-        mock_trigger_explorer.return_value = 555
+        mock_trigger_explorer.return_value = run
 
         self.login_as(user=self.user)
         response = self.client.post(
@@ -194,7 +195,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         """The legacy numeric run_id field keeps working unchanged."""
         group = self.create_group()
         run = self.create_seer_run(organization=self.organization, seer_run_state_id=321)
-        mock_trigger_explorer.return_value = 321
+        mock_trigger_explorer.return_value = run
 
         self.login_as(user=self.user)
         response = self.client.post(
@@ -239,7 +240,8 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
     def test_post_from_mcp_defaults_referrer_to_mcp(self, mock_trigger_explorer):
         """A request from the Sentry MCP server defaults the referrer to api.mcp."""
         group = self.create_group()
-        mock_trigger_explorer.return_value = 123
+        run = self.create_seer_run(organization=self.organization, seer_run_state_id=123)
+        mock_trigger_explorer.return_value = run
 
         self.login_as(user=self.user)
         response = self.client.post(
@@ -259,7 +261,8 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
     def test_post_explicit_referrer_overrides_mcp_default(self, mock_trigger_explorer):
         """An explicitly supplied referrer takes precedence over the MCP default."""
         group = self.create_group()
-        mock_trigger_explorer.return_value = 123
+        run = self.create_seer_run(organization=self.organization, seer_run_state_id=123)
+        mock_trigger_explorer.return_value = run
 
         self.login_as(user=self.user)
         response = self.client.post(
@@ -276,7 +279,8 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
     def test_stopping_point(self, mock_trigger_explorer):
         """Stopping point forces the step to be root_cause"""
         group = self.create_group()
-        mock_trigger_explorer.return_value = 123
+        run = self.create_seer_run(organization=self.organization, seer_run_state_id=123)
+        mock_trigger_explorer.return_value = run
 
         self.login_as(user=self.user)
         response = self.client.post(
@@ -303,7 +307,8 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
     def test_insert_index_passed_through(self, mock_trigger_explorer):
         """POST passes insert_index to trigger_autofix_agent for retry-from-step."""
         group = self.create_group()
-        mock_trigger_explorer.return_value = 123
+        run = self.create_seer_run(organization=self.organization, seer_run_state_id=123)
+        mock_trigger_explorer.return_value = run
 
         self.login_as(user=self.user)
         response = self.client.post(
@@ -329,7 +334,9 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
     def test_kickoff_emits_trigger_autofix_action(self, mock_trigger):
         # A kickoff (no run_id) records the action.
         group = self.create_group()
-        mock_trigger.return_value = 123
+        mock_trigger.return_value = self.create_seer_run(
+            organization=self.organization, seer_run_state_id=123
+        )
 
         self.login_as(user=self.user)
         with capture_action_log() as action_log:
@@ -350,7 +357,9 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
     @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
     def test_kickoff_creates_trigger_autofix_activity(self, mock_trigger):
         group = self.create_group()
-        mock_trigger.return_value = 123
+        mock_trigger.return_value = self.create_seer_run(
+            organization=self.organization, seer_run_state_id=123
+        )
 
         self.login_as(user=self.user)
         response = self.client.post(
@@ -368,7 +377,9 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
     def test_advancing_existing_run_skips_action(self, mock_trigger):
         # Advancing an existing run (run_id provided) is steering, not a new trigger.
         group = self.create_group()
-        mock_trigger.return_value = 42
+        mock_trigger.return_value = self.create_seer_run(
+            organization=self.organization, seer_run_state_id=42
+        )
 
         self.login_as(user=self.user)
         with capture_action_log() as action_log:

--- a/tests/sentry/seer/night_shift/test_delivery.py
+++ b/tests/sentry/seer/night_shift/test_delivery.py
@@ -40,7 +40,6 @@ class TestDeliverNightShiftResult(TestCase):
         return seer_run.uuid
 
     def _triggered_run(self, seer_run_state_id: int, organization: Organization) -> SeerRun:
-        """A SeerRun standing in for trigger_autofix_agent's return value."""
         return self.create_seer_run(organization=organization, seer_run_state_id=seer_run_state_id)
 
     def test_missing_run_logs_warning(self) -> None:

--- a/tests/sentry/seer/night_shift/test_delivery.py
+++ b/tests/sentry/seer/night_shift/test_delivery.py
@@ -10,6 +10,7 @@ from sentry.seer.models.night_shift import (
     SeerNightShiftRunResult,
     SeerNightShiftRunShard,
 )
+from sentry.seer.models.run import SeerRun
 from sentry.seer.night_shift.delivery import REASON_MAX_CHARS, deliver_night_shift_result
 from sentry.tasks.seer.night_shift.models import TriageAction
 from sentry.tasks.seer.night_shift.skip_cache import key as skip_cache_key
@@ -37,6 +38,10 @@ class TestDeliverNightShiftResult(TestCase):
         seer_run = run.shards.get().seer_run
         assert seer_run is not None
         return seer_run.uuid
+
+    def _triggered_run(self, seer_run_state_id: int, organization: Organization) -> SeerRun:
+        """A SeerRun standing in for trigger_autofix_agent's return value."""
+        return self.create_seer_run(organization=organization, seer_run_state_id=seer_run_state_id)
 
     def test_missing_run_logs_warning(self) -> None:
         """When run_uuid doesn't match any SeerNightShiftRun, log and return."""
@@ -93,7 +98,10 @@ class TestDeliverNightShiftResult(TestCase):
             result=None,
             error="shard failed",
         )
-        with patch("sentry.seer.night_shift.delivery.trigger_autofix_agent", return_value=1):
+        with patch(
+            "sentry.seer.night_shift.delivery.trigger_autofix_agent",
+            return_value=self._triggered_run(1, org),
+        ):
             deliver_night_shift_result(
                 organization_id=org.id,
                 run_uuid=ok_seer_run.uuid,
@@ -184,7 +192,8 @@ class TestDeliverNightShiftResult(TestCase):
         }
 
         with patch(
-            "sentry.seer.night_shift.delivery.trigger_autofix_agent", return_value=42
+            "sentry.seer.night_shift.delivery.trigger_autofix_agent",
+            return_value=self._triggered_run(42, org),
         ) as mock_trigger:
             deliver_night_shift_result(
                 organization_id=org.id,
@@ -404,10 +413,12 @@ class TestDeliverNightShiftResult(TestCase):
             ]
         }
 
-        def trigger_side_effect(**kwargs: Any) -> int:
+        ok_run = self._triggered_run(7, org)
+
+        def trigger_side_effect(**kwargs: Any) -> SeerRun:
             if kwargs["group"].id == failing_group.id:
                 raise RuntimeError("trigger failed")
-            return 7
+            return ok_run
 
         with (
             patch(
@@ -470,7 +481,8 @@ class TestDeliverNightShiftResult(TestCase):
                 side_effect=rate_limited_side_effect,
             ),
             patch(
-                "sentry.seer.night_shift.delivery.trigger_autofix_agent", return_value=7
+                "sentry.seer.night_shift.delivery.trigger_autofix_agent",
+                return_value=self._triggered_run(7, org),
             ) as mock_trigger,
         ):
             deliver_night_shift_result(
@@ -514,7 +526,8 @@ class TestDeliverNightShiftResult(TestCase):
                 return_value=True,
             ),
             patch(
-                "sentry.seer.night_shift.delivery.trigger_autofix_agent", return_value=1
+                "sentry.seer.night_shift.delivery.trigger_autofix_agent",
+                return_value=self._triggered_run(1, org),
             ) as mock_trigger,
         ):
             deliver_night_shift_result(
@@ -586,7 +599,8 @@ class TestDeliverNightShiftResult(TestCase):
         }
 
         with patch(
-            "sentry.seer.night_shift.delivery.trigger_autofix_agent", return_value=1
+            "sentry.seer.night_shift.delivery.trigger_autofix_agent",
+            return_value=self._triggered_run(1, org),
         ) as mock_trigger:
             deliver_night_shift_result(
                 organization_id=org.id,
@@ -613,7 +627,10 @@ class TestDeliverNightShiftResult(TestCase):
             ]
         }
 
-        with patch("sentry.seer.night_shift.delivery.trigger_autofix_agent", return_value=1):
+        with patch(
+            "sentry.seer.night_shift.delivery.trigger_autofix_agent",
+            return_value=self._triggered_run(1, org),
+        ):
             deliver_night_shift_result(
                 organization_id=org.id,
                 run_uuid=self._run_uuid(run),
@@ -640,7 +657,8 @@ class TestDeliverNightShiftResult(TestCase):
         }
 
         with patch(
-            "sentry.seer.night_shift.delivery.trigger_autofix_agent", return_value=11
+            "sentry.seer.night_shift.delivery.trigger_autofix_agent",
+            return_value=self._triggered_run(11, org),
         ) as mock_trigger:
             for _ in range(2):
                 deliver_night_shift_result(
@@ -704,7 +722,10 @@ class TestDeliverNightShiftResult(TestCase):
             ]
         }
 
-        with patch("sentry.seer.night_shift.delivery.trigger_autofix_agent", return_value=99):
+        with patch(
+            "sentry.seer.night_shift.delivery.trigger_autofix_agent",
+            return_value=autofix_seer_run,
+        ):
             deliver_night_shift_result(
                 organization_id=org.id,
                 run_uuid=self._run_uuid(run),
@@ -760,7 +781,8 @@ class TestDeliverNightShiftResult(TestCase):
         }
 
         with patch(
-            "sentry.seer.night_shift.delivery.trigger_autofix_agent", return_value=1
+            "sentry.seer.night_shift.delivery.trigger_autofix_agent",
+            return_value=self._triggered_run(1, org),
         ) as mock_trigger:
             deliver_night_shift_result(
                 organization_id=org.id,


### PR DESCRIPTION
`trigger_autofix_agent` and the `SeerAgentClient` returned Seer's integer run id. But callers usually want the run's UUID, so they re-queried the `SeerRun` mirror the code had effectively just touched — `get_seer_run()` in the autofix endpoint, a `SeerRun.objects.filter()` in night-shift delivery (with a `# TODO` for exactly this), and `continue_run` itself, which already loaded the row to bump `last_triggered_at`. The int is also the wrong handle to pass around: it's nullable until Seer's create round-trips, whereas `SeerRun.uuid` exists from row creation.

Both client entry points now return the `SeerRun` (`start_run` already did; `continue_run` now does too), and `trigger_autofix_agent` returns it as well. Callers read `.seer_run_state_id` / `.uuid` off it and drop their re-queries.

Reviewer-relevant details:

- **New failure mode:** continuing a run whose mirror doesn't exist is now a **404** (`SeerPermissionError`) instead of silently proceeding with a null `sentry_run_id`.
- **Fail-closed:** `continue_run` resolves the mirror *before* calling Seer, so a missing run never advances the remote run.
- **Incidental fix:** that lookup is now org-scoped (the old `last_triggered_at` filter wasn't).
- **Happy path unchanged:** response bodies, webhook payloads, and persisted rows are identical.