### PR TITLE
ref(dashboards): Remove `organizations:dashboards-ai-generate-edit` flag check

### DIFF
--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -1444,15 +1444,12 @@ class DashboardDetail extends Component<Props, State> {
                               dashboard={modifiedDashboard ?? dashboard}
                               onSave={this.handleSaveWidget}
                             />
-                            {dashboardState === DashboardState.EDIT &&
-                              organization.features.includes(
-                                'dashboards-ai-generate-edit'
-                              ) && (
-                                <DashboardEditSeerChat
-                                  dashboard={modifiedDashboard ?? dashboard}
-                                  onDashboardUpdate={this.handleSeerDashboardUpdate}
-                                />
-                              )}
+                            {dashboardState === DashboardState.EDIT && (
+                              <DashboardEditSeerChat
+                                dashboard={modifiedDashboard ?? dashboard}
+                                onDashboardUpdate={this.handleSeerDashboardUpdate}
+                              />
+                            )}
                           </Fragment>
                         </MEPSettingProvider>
                       )}


### PR DESCRIPTION
Remove `organizations:dashboards-ai-generate-edit`. This flag was fully rolled out to GA in the automator in getsentry/sentry-options-automator#7292 on 4/16 and hasn't been touched since, so the edit-mode Seer chat panel now renders unconditionally.

Backend registration removal follows in a separate PR (frontend/backend are not atomically deployed; this frontend PR should land first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQtVPKdj6SugtGgkJNSLhk

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQtVPKdj6SugtGgkJNSLhk)_