### PR TITLE
ref(dashboards): Remove `organizations:dashboards-ai-generate-edit` flag registration

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -79,8 +79,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:dashboards-details-widget", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Insights to Dashboards UI migration
     manager.add("organizations:insights-to-dashboards-ui-rollout", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable AI-powered dashboard editing via Seer
-    manager.add("organizations:dashboards-ai-generate-edit", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables starred dashboards functionality
     manager.add("organizations:dashboards-starred", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables per-user "last visited" tracking and sorting for dashboards

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -82,8 +82,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:dashboards-details-widget", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Insights to Dashboards UI migration
     manager.add("organizations:insights-to-dashboards-ui-rollout", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable AI-powered dashboard editing via Seer
-    manager.add("organizations:dashboards-ai-generate-edit", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables starred dashboards functionality
     manager.add("organizations:dashboards-starred", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables per-user "last visited" tracking and sorting for dashboards


### PR DESCRIPTION
Remove `organizations:dashboards-ai-generate-edit`. This flag was fully rolled out to GA in the automator in getsentry/sentry-options-automator#7292 on 4/16 and hasn't been touched since. The last code reference was removed in #120591.

Should land after #120591 (frontend/backend are not atomically deployed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQtVPKdj6SugtGgkJNSLhk

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQtVPKdj6SugtGgkJNSLhk)_