### PR TITLE
fix(seer): Normalize anonymous users for user RPCs

### DIFF
--- a/src/sentry/core/endpoints/organization_user_details.py
+++ b/src/sentry/core/endpoints/organization_user_details.py
@@ -6,6 +6,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.bases.organizationmember import MemberPermission
+from sentry.users.services.user.serial import serialize_generic_user
 from sentry.users.services.user.service import user_service
 
 
@@ -23,7 +24,8 @@ class OrganizationUserDetailsEndpoint(OrganizationEndpoint):
             raise ValidationError(f"user_id({user_id}) must be an integer")
 
         users = user_service.serialize_many(
-            filter={"user_ids": [user_id], "organization_id": organization.id}, as_user=request.user
+            filter={"user_ids": [user_id], "organization_id": organization.id},
+            as_user=serialize_generic_user(request.user),
         )
         if len(users) == 0:
             return Response(status=404)

--- a/src/sentry/issues/endpoints/group_details.py
+++ b/src/sentry/issues/endpoints/group_details.py
@@ -74,6 +74,7 @@ from sentry.sentry_apps.api.serializers.platform_external_issue import (
 from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
 from sentry.tasks.post_process import fetch_buffered_group_stats
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
+from sentry.users.services.user.serial import serialize_generic_user
 from sentry.users.services.user.service import user_service
 from sentry.utils import metrics
 from sentry.utils.http import is_mcp_request
@@ -399,7 +400,7 @@ class GroupDetailsEndpoint(GroupEndpoint):
 
             participants = user_service.serialize_many(
                 filter={"user_ids": GroupSubscriptionManager.get_participating_user_ids(group)},
-                as_user=request.user,
+                as_user=serialize_generic_user(request.user),
             )
 
             for participant in participants:

--- a/tests/sentry/api/endpoints/test_rpc.py
+++ b/tests/sentry/api/endpoints/test_rpc.py
@@ -214,8 +214,8 @@ class RpcServiceEndpointTest(APITestCase):
         assert ctx.organization_id is None
         assert ctx.actor_type == ActorType.UNKNOWN
 
-    def test_viewer_context_roundtrip_through_meta(self) -> None:
-        """ViewerContext set on the sending side arrives on the receiving side."""
+    def test_agent_viewer_context_roundtrip_through_meta(self) -> None:
+        """Agent ViewerContext set on the sending side arrives on the receiving side."""
         organization = self.create_organization()
         captured_contexts: list[ViewerContext | None] = []
 
@@ -228,7 +228,7 @@ class RpcServiceEndpointTest(APITestCase):
             return original_dispatch(*args, **kwargs)
 
         # Simulate what _send_to_remote_silo builds when ViewerContext is set
-        ctx = ViewerContext(organization_id=organization.id, user_id=42, actor_type=ActorType.USER)
+        ctx = ViewerContext(organization_id=organization.id, user_id=42, actor_type=ActorType.AGENT)
         path = self._get_path("organization", "get_organization_by_id")
         data = {
             "args": {"id": organization.id},

--- a/tests/sentry/core/endpoints/test_organization_user_details.py
+++ b/tests/sentry/core/endpoints/test_organization_user_details.py
@@ -1,4 +1,11 @@
+from django.test import override_settings
+from rest_framework.test import APIClient
+
+from sentry.seer import agent_token
 from sentry.testutils.cases import APITestCase
+
+SECRET = "test-seer-api-shared-secret-thirty-two-bytes!"
+FLAG = "organizations:seer-agent-token-flow"
 
 
 class OrganizationUserDetailsTest(APITestCase):
@@ -16,6 +23,26 @@ class OrganizationUserDetailsTest(APITestCase):
     def test_gets_info_for_user_in_org(self) -> None:
         response = self.get_success_response(self.org.slug, self.user.id)
 
+        assert response.data["id"] == str(self.user.id)
+        assert response.data["email"] == self.user.email
+
+    @override_settings(SEER_API_SHARED_SECRET=SECRET)
+    def test_agent_token_gets_info_for_user_in_org(self) -> None:
+        token, _ = agent_token.encode_agent_token(
+            user_id=self.owner_user.id,
+            organization_id=self.org.id,
+            scopes=["member:read", "org:read"],
+            session_id="s1",
+        )
+        client = APIClient()
+
+        with self.feature(FLAG):
+            response = client.get(
+                f"/api/0/organizations/{self.org.slug}/users/{self.user.id}/",
+                HTTP_AUTHORIZATION=f"Bearer {token}",
+            )
+
+        assert response.status_code == 200, response.content
         assert response.data["id"] == str(self.user.id)
         assert response.data["email"] == self.user.email
 

--- a/tests/sentry/issues/endpoints/test_group_details.py
+++ b/tests/sentry/issues/endpoints/test_group_details.py
@@ -4,6 +4,7 @@ from unittest import mock
 from django.core.cache import cache
 from django.test import override_settings
 from django.utils import timezone
+from rest_framework.test import APIClient
 
 from sentry import audit_log, buffer, tsdb
 from sentry.analytics.events.issue_viewed import IssueViewedEvent
@@ -33,6 +34,7 @@ from sentry.models.groupsubscription import GroupSubscription
 from sentry.models.grouptombstone import GroupTombstone
 from sentry.models.project import Project
 from sentry.models.release import Release
+from sentry.seer import agent_token
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.action_log import capture_action_log
@@ -47,6 +49,9 @@ from sentry.types.group import GroupSubStatus
 
 pytestmark = [requires_snuba]
 
+SECRET = "test-seer-api-shared-secret-thirty-two-bytes!"
+FLAG = "organizations:seer-agent-token-flow"
+
 
 class GroupDetailsTest(APITestCase, SnubaTestCase):
     def test_with_numerical_id(self) -> None:
@@ -56,6 +61,26 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
 
         url = f"/api/0/organizations/{group.organization.slug}/issues/{group.id}/"
         response = self.client.get(url, format="json")
+
+        assert response.status_code == 200, response.content
+        assert response.data["id"] == str(group.id)
+
+    @override_settings(SEER_API_SHARED_SECRET=SECRET)
+    def test_agent_token_gets_issue_details(self) -> None:
+        group = self.create_group()
+        token, _ = agent_token.encode_agent_token(
+            user_id=self.user.id,
+            organization_id=group.organization.id,
+            scopes=["event:read", "org:read", "project:read"],
+            session_id="s1",
+        )
+        client = APIClient()
+
+        with self.feature(FLAG):
+            response = client.get(
+                f"/api/0/issues/{group.id}/",
+                HTTP_AUTHORIZATION=f"Bearer {token}",
+            )
 
         assert response.status_code == 200, response.content
         assert response.data["id"] == str(group.id)


### PR DESCRIPTION
Agent capability authentication intentionally leaves `request.user` anonymous. Issue details and organization user details passed that `AnonymousUser` directly into `UserService.serialize_many`; in split-silo deployments, the typed RPC rejects it because `as_user` must be an `RpcUser` or `None`, producing a 500 before the request is sent.

This normalizes `request.user` through the existing `serialize_generic_user` helper. Normal authenticated users retain their current field visibility, while agent requests pass `None` and receive anonymous-safe user serialization rather than implicitly gaining the delegated user’s self-only fields without the agent token scopes on the control side.

ViewerContext remains the independent agent-identity mechanism. Hybrid-cloud RPC includes it in signed metadata and restores it around receiver dispatch. Regression coverage proves `ActorType.AGENT`, delegated user ID, and organization survive that round trip, while endpoint tests cover both production-affected serialization paths.