### PR TITLE
perf(tests): Freeze the gc after pytest collection

### DIFF
--- a/src/sentry/testutils/pytest/sentry.py
+++ b/src/sentry/testutils/pytest/sentry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import collections
+import gc
 import os
 import random
 import shutil
@@ -415,6 +416,19 @@ def pytest_sessionstart(session: pytest.Session) -> None:
     # Tests use TaskRunner (TASKWORKER_ALWAYS_EAGER=True) or BurstTaskRunner
     # (_signal_send hook) which both operate before send_task in the call chain.
     TaskNamespace.send_task = lambda self, *args, **kwargs: None  # type: ignore[assignment,method-assign]
+
+
+def pytest_collection_finish(session: pytest.Session) -> None:
+    # Collection has imported Django, the app registry, and every selected test
+    # module. That is ~900k gc-tracked objects which live for the rest of the
+    # process and can never become garbage, yet every generation-2 collection
+    # walks all of them. Moving them to the permanent generation keeps those
+    # traversals proportional to what the tests themselves allocate.
+    #
+    # Objects created from here on (i.e. anything a test builds) are still
+    # tracked and collected normally, so this does not weaken test isolation or
+    # pytest's unraisable-exception detection.
+    gc.freeze()
 
 
 def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:


### PR DESCRIPTION
Running a single postgres test spends ~0.6s in garbage collection and none of that work can ever find any garbage. By the time the first test runs there are ~890k gc-tracked objects sitting in generation 2 - django's app registry, a few thousand model classes, the imported test modules - all of it alive for the life of the process. A gen-2 collection scans every generation, so each one walks all 890k just to re-confirm the framework isn't trash.

pytest's unraisableexception plugin then forces five `gc.collect()` passes at teardown, so the most expensive scans land on the biggest heap. That alone is 0.42s of the 0.6s.

`gc.freeze()` at collection finish moves the imported world into the permanent generation, which the collector never scans. It only affects objects that already exist, so anything a test allocates is still tracked and collected normally and isolation is unchanged.

| Scope | Before | After | Gain |
|---|---|---|---|
| single test | 7.007s | 5.730s | 18.2% |
| full file (61 tests) | 9.531s | 8.519s | 10.6% |
| full file (~16s) | 16.006s | 14.765s | 7.8% |

Works out to a flat ~1.2s per pytest process since it scales with imports, not test count. Mostly a local win - xdist workers each freeze independently but run concurrently, so a shard only gains one worker's worth, well under 1% of wall time. Those CI numbers are estimated, not measured.