### PR TITLE
fix(seer): Some tweaks to Smart Assignment scoring, metrics (take 2)

### DIFF
--- a/src/sentry/seer/smart_assignment/scoring.py
+++ b/src/sentry/seer/smart_assignment/scoring.py
@@ -16,7 +16,7 @@ from sentry.seer.smart_assignment.models import (
     SmartAssignmentScore,
 )
 from sentry.seer.utils import latest_run_for_group
-from sentry.types.activity import ActivityIntegration, ActivityType
+from sentry.types.activity import ActivityType
 from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)

--- a/src/sentry/seer/smart_assignment/scoring.py
+++ b/src/sentry/seer/smart_assignment/scoring.py
@@ -16,7 +16,7 @@ from sentry.seer.smart_assignment.models import (
     SmartAssignmentScore,
 )
 from sentry.seer.utils import latest_run_for_group
-from sentry.types.activity import ActivityType
+from sentry.types.activity import ActivityIntegration, ActivityType
 from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
@@ -77,11 +77,6 @@ def _ground_truth_updates(
     when no explicit assignee has been recorded -- an assignment is better truth.
     """
     if activity_type == ActivityType.ASSIGNED:
-        if (
-            activity is not None
-            and (activity.data or {}).get("integration") == ActivityIntegration.SEER_SUGGESTED.value
-        ):
-            return None
         return _assignment_updates(group)
     if activity_type in RESOLUTION_ACTIVITIES:
         if activity is None or activity.user_id is None:
@@ -107,16 +102,35 @@ def _ground_truth_updates(
 
 
 def _assignment_updates(group: Group) -> RunUpdates | None:
-    """Mirror the current assignee (user and/or team), or ``None`` when the group
-    has no assignee."""
+    """Mirror the current assignee (user and/or team), or ``None`` when the group has
+    no assignee or the assignment is our own auto-assignment.
+    """
     assignee = GroupAssignee.objects.filter(group=group).first()
     if assignee is None:
+        return None
+    if _is_seer_auto_assignment(group):
         return None
     return {
         "actual_assignee_user_id": assignee.user_id,
         "actual_assignee_team_id": assignee.team_id,
         "ground_truth_source": ActivityType.ASSIGNED.name,
     }
+
+
+def _is_seer_auto_assignment(group: Group) -> bool:
+    """Whether the group's current assignment came from our own auto-assignment,
+    determined by the most recent ``ASSIGNED`` activity being tagged with the
+    ``SEER_SUGGESTED`` integration."""
+    latest_assignment = (
+        Activity.objects.filter(group=group, type=ActivityType.ASSIGNED.value)
+        .order_by("-datetime")
+        .first()
+    )
+    if latest_assignment is None:
+        return False
+    return (latest_assignment.data or {}).get(
+        "integration"
+    ) == ActivityIntegration.SEER_SUGGESTED.value
 
 
 def _apply(run_id: int, updates: RunUpdates) -> bool:

--- a/src/sentry/seer/smart_assignment/scoring.py
+++ b/src/sentry/seer/smart_assignment/scoring.py
@@ -58,7 +58,11 @@ def record_ground_truth(
         return
 
     if _apply(run.id, updates):
-        metrics.incr("smart_assignment.ground_truth.recorded", tags={"trigger": activity_type.name})
+        metrics.incr(
+            "smart_assignment.ground_truth.recorded",
+            tags={"trigger": activity_type.name},
+            sample_rate=1.0,
+        )
 
 
 def _ground_truth_updates(
@@ -172,6 +176,7 @@ def _apply(run_id: int, updates: RunUpdates) -> bool:
                 "hit_rank": hit_rank if hit_rank is not None else 0,
                 "trigger": extras.get("trigger"),
             },
+            sample_rate=1.0,
         )
     return True
 

--- a/src/sentry/seer/smart_assignment/trigger.py
+++ b/src/sentry/seer/smart_assignment/trigger.py
@@ -54,11 +54,14 @@ def trigger_smart_assignment(
     organization = group.organization
 
     if not features.has(FEATURE_FLAG, organization):
-        metrics.incr("smart_assignment.trigger.skipped", tags={"reason": "flag_disabled"})
         return
 
     if activity_type in RESOLUTION_ACTIVITIES and (activity is None or activity.user_id is None):
-        metrics.incr("smart_assignment.trigger.skipped", tags={"reason": "automatic_resolution"})
+        metrics.incr(
+            "smart_assignment.trigger.skipped",
+            tags={"reason": "automatic_resolution"},
+            sample_rate=1.0,
+        )
         return
 
     # Policy gate: today we predict at most once per issue, ever. This lives in app
@@ -94,7 +97,11 @@ def _dispatch_rate_limited(organization: Organization) -> bool:
         limit=options.get("seer.smart_assignment.max_dispatches_per_org_per_day"),
         window=_RATE_LIMIT_WINDOW,
     ):
-        metrics.incr("smart_assignment.trigger.skipped", tags={"reason": "org_rate_limited"})
+        metrics.incr(
+            "smart_assignment.trigger.skipped",
+            tags={"reason": "org_rate_limited"},
+            sample_rate=1.0,
+        )
         return True
 
     if ratelimiter.is_limited(
@@ -102,7 +109,11 @@ def _dispatch_rate_limited(organization: Organization) -> bool:
         limit=options.get("seer.smart_assignment.max_dispatches_per_day"),
         window=_RATE_LIMIT_WINDOW,
     ):
-        metrics.incr("smart_assignment.trigger.skipped", tags={"reason": "global_rate_limited"})
+        metrics.incr(
+            "smart_assignment.trigger.skipped",
+            tags={"reason": "global_rate_limited"},
+            sample_rate=1.0,
+        )
         return True
 
     return False
@@ -121,7 +132,11 @@ def _dispatch(group: Group, activity_type: ActivityType, activity: Activity | No
     try:
         client = SeerAgentClient(organization, project=group.project, group=group)
     except SeerPermissionError:
-        metrics.incr("smart_assignment.trigger.skipped", tags={"reason": "no_seer_access"})
+        metrics.incr(
+            "smart_assignment.trigger.skipped",
+            tags={"reason": "no_seer_access"},
+            sample_rate=1.0,
+        )
         return
 
     extras: dict[str, object] = {"trigger": activity_type.name}
@@ -145,7 +160,11 @@ def _dispatch(group: Group, activity_type: ActivityType, activity: Activity | No
     if activity is not None:
         _stamp_activity(activity, run, activity_type)
 
-    metrics.incr("smart_assignment.trigger.dispatched", tags={"trigger": activity_type.name})
+    metrics.incr(
+        "smart_assignment.trigger.dispatched",
+        tags={"trigger": activity_type.name},
+        sample_rate=1.0,
+    )
     logger.info(
         "smart_assignment.trigger.dispatched",
         extra={

--- a/tests/sentry/seer/smart_assignment/test_delivery.py
+++ b/tests/sentry/seer/smart_assignment/test_delivery.py
@@ -205,6 +205,7 @@ class DeliverSmartAssignmentResultTest(TestCase):
                 "hit_rank": 1,
                 "trigger": ActivityType.SEER_RCA_STARTED.name,
             },
+            sample_rate=1.0,
         )
 
     @patch(METRICS_PATH)

--- a/tests/sentry/seer/smart_assignment/test_scoring.py
+++ b/tests/sentry/seer/smart_assignment/test_scoring.py
@@ -12,7 +12,7 @@ from sentry.seer.smart_assignment.scoring import (
     record_prediction,
 )
 from sentry.testutils.cases import TestCase
-from sentry.types.activity import ActivityIntegration, ActivityType
+from sentry.types.activity import ActivityType
 
 METRICS_PATH = "sentry.seer.smart_assignment.scoring.metrics"
 

--- a/tests/sentry/seer/smart_assignment/test_scoring.py
+++ b/tests/sentry/seer/smart_assignment/test_scoring.py
@@ -47,6 +47,7 @@ class RecordPredictionScoringTest(ScoringTestBase):
         mock_metrics.incr.assert_called_once_with(
             "smart_assignment.scored",
             tags={"result": expected, "hit_rank": hit_rank, "trigger": STARTED.name},
+            sample_rate=1.0,
         )
 
     @patch(METRICS_PATH)
@@ -308,6 +309,7 @@ class RecordGroundTruthTest(ScoringTestBase):
         mock_metrics.incr.assert_any_call(
             "smart_assignment.scored",
             tags={"result": SmartAssignmentScore.EXACT, "hit_rank": 1, "trigger": STARTED.name},
+            sample_rate=1.0,
         )
 
     def test_resolution_does_not_overwrite_existing_assignee(self) -> None:

--- a/tests/sentry/seer/smart_assignment/test_scoring.py
+++ b/tests/sentry/seer/smart_assignment/test_scoring.py
@@ -12,7 +12,7 @@ from sentry.seer.smart_assignment.scoring import (
     record_prediction,
 )
 from sentry.testutils.cases import TestCase
-from sentry.types.activity import ActivityType
+from sentry.types.activity import ActivityIntegration, ActivityType
 
 METRICS_PATH = "sentry.seer.smart_assignment.scoring.metrics"
 
@@ -241,6 +241,57 @@ class RecordGroundTruthTest(ScoringTestBase):
         run.refresh_from_db()
         assert "actual_assignee_user_id" not in run.extras
         assert "ground_truth_source" not in run.extras
+
+    def _seer_auto_assign(self, assignee_id: int) -> Activity:
+        GroupAssignee.objects.create(
+            group=self.group, project=self.group.project, user_id=assignee_id
+        )
+        return self.create_group_activity(
+            group=self.group,
+            type=ActivityType.ASSIGNED.value,
+            data={
+                "assignee": str(assignee_id),
+                "assigneeType": "user",
+                "integration": ActivityIntegration.SEER_SUGGESTED.value,
+            },
+        )
+
+    def test_resolution_ignores_seer_auto_assignment(self) -> None:
+        # Seer auto-assigned (never reassigned by a human); a human resolves. The
+        # auto-assignment must not become ground truth -- that would score us against
+        # ourselves -- so the resolver is recorded as the fallback truth instead.
+        run = self._run()
+        seer_assignee = self.create_user()
+        self._seer_auto_assign(seer_assignee.id)
+        resolver = self.create_user()
+        record_ground_truth(
+            self.group, ActivityType.SET_RESOLVED, self._resolved_activity(resolver.id)
+        )
+
+        run.refresh_from_db()
+        assert run.extras["actual_assignee_user_id"] == resolver.id
+        assert run.extras["ground_truth_source"] == ActivityType.SET_RESOLVED.name
+
+    def test_resolution_records_human_reassignment_over_seer(self) -> None:
+        # A human reassigns after Seer auto-assigned (a new, untagged ASSIGNED
+        # activity), so on resolution the human assignee is honored as ground truth.
+        run = self._run()
+        seer_assignee = self.create_user()
+        self._seer_auto_assign(seer_assignee.id)
+        human_assignee = self.create_user()
+        GroupAssignee.objects.filter(group=self.group).update(user_id=human_assignee.id)
+        self.create_group_activity(
+            group=self.group,
+            type=ActivityType.ASSIGNED.value,
+            data={"assignee": str(human_assignee.id), "assigneeType": "user"},
+        )
+        record_ground_truth(
+            self.group, ActivityType.SET_RESOLVED, self._resolved_activity(self.create_user().id)
+        )
+
+        run.refresh_from_db()
+        assert run.extras["actual_assignee_user_id"] == human_assignee.id
+        assert run.extras["ground_truth_source"] == ActivityType.ASSIGNED.name
 
     @patch(METRICS_PATH)
     def test_records_ground_truth_scores_existing_prediction(self, mock_metrics: MagicMock) -> None:


### PR DESCRIPTION
Redo of #120537 with a fix to a test that was breaking CI post-merge. 


Bit of a catch-all; happy to split if desired:

- Don't score against our own assignment guess on resolution
  - If an issue resolves after it gets assigned via Smart Assignment, we
still grab the assignee and treat it as the ground truth, which would
mean we score against our own prediction -> we think we got it right.
So whatever the most recent ASSIGNED activity is, if it was us, don't
use the assignee as ground truth.
- Sample scoring metrics at 100%
  - I want all the stats!
- Sample trigger metrics at 100%
- Don't sample skipped: reason=flag_disabled
  - This will flood the metric for every single issue resolution etc. If the flag is off, clearly we don't care. But the other skip reasons are more useful. (Rate limits hit, it was an auto-resolution, Seer not available, etc.)