### PR TITLE
fix(preprod): Correct snapshot status multi-select filters

### DIFF
--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -205,6 +205,7 @@ type MultiSelectFilterValueAction = {
   token: TokenResult<Token.FILTER>;
   type: 'TOGGLE_FILTER_VALUE';
   value: string;
+  op?: TermOperator;
 };
 
 type UpdateAggregateArgsAction = {
@@ -693,7 +694,8 @@ export function modifyFilterValue(
 function updateFilterMultipleValues(
   state: QueryBuilderState,
   token: TokenResult<Token.FILTER>,
-  values: string[]
+  values: string[],
+  op?: TermOperator
 ) {
   // Deduplicate by canonical form while preserving the original text of the
   // first occurrence (so the query string keeps the user's original formatting)
@@ -712,7 +714,7 @@ function updateFilterMultipleValues(
     return true;
   });
   if (uniqNonEmptyValues.length === 0) {
-    return {...state, query: replaceQueryToken(state.query, token.value, '""')};
+    return {...state, query: modifyFilterValue(state.query, token, '""', op)};
   }
 
   const newValue =
@@ -720,7 +722,7 @@ function updateFilterMultipleValues(
       ? `[${uniqNonEmptyValues.join(',')}]`
       : uniqNonEmptyValues[0]!;
 
-  return {...state, query: replaceQueryToken(state.query, token.value, newValue)};
+  return {...state, query: modifyFilterValue(state.query, token, newValue, op)};
 }
 
 // Normalizes a filter value so that different surface representations of the
@@ -803,10 +805,12 @@ export function multiSelectTokenValue(
       );
 
       if (!containsValue) {
-        return updateFilterMultipleValues(state, action.token, [
-          ...values.map(({text}) => text),
-          action.value,
-        ]);
+        return updateFilterMultipleValues(
+          state,
+          action.token,
+          [...values.map(({text}) => text), action.value],
+          action.op
+        );
       }
 
       // The selected value was already present, so this is a deselect. Filter it
@@ -820,18 +824,18 @@ export function multiSelectTokenValue(
         }
       }
 
-      return updateFilterMultipleValues(state, action.token, newValues);
+      return updateFilterMultipleValues(state, action.token, newValues, action.op);
     }
     default: {
       // Single values use the same toggle semantics as lists: if the canonical
       // value is already selected, clear it; otherwise expand it into a list.
       if (canonicalizeSearchValue(tokenValue.value ?? '') === normalizedActionValue) {
-        return updateFilterMultipleValues(state, action.token, ['']);
+        return updateFilterMultipleValues(state, action.token, [''], action.op);
       }
       const newValue = tokenValue.value
         ? [tokenValue.text, action.value]
         : [action.value];
-      return updateFilterMultipleValues(state, action.token, newValue);
+      return updateFilterMultipleValues(state, action.token, newValue, action.op);
     }
   }
 }

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -3831,6 +3831,26 @@ describe('SearchQueryBuilder', () => {
         expect(optionsAfterToggle).toEqual(initialOptions);
       });
 
+      it('switches from contains to is when selecting an initial value via checkbox', async () => {
+        render(
+          <SearchQueryBuilder
+            {...defaultProps}
+            initialQuery={`browser.name:${WildcardOperators.CONTAINS}""`}
+          />
+        );
+
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit value for filter: browser.name'})
+        );
+        await userEvent.click(
+          await screen.findByRole('checkbox', {name: 'Toggle Chrome'})
+        );
+
+        expect(
+          await screen.findByRole('row', {name: 'browser.name:Chrome'})
+        ).toBeInTheDocument();
+      });
+
       it('does not reset frozen order when predefined sections rebuild', async () => {
         render(
           <SearchQueryBuilder

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -588,6 +588,7 @@ function ItemCheckbox({disabled, value}: {disabled: boolean; value: string}) {
               type: 'TOGGLE_FILTER_VALUE',
               token,
               value: escapedValue,
+              op: getOperatorForSelectedValue(token),
             });
 
             const {selected: currentlySelected, selectedCount} = getMultiSelectValueState(
@@ -607,6 +608,20 @@ function ItemCheckbox({disabled, value}: {disabled: boolean; value: string}) {
       </CheckWrap>
     </TrailingWrap>
   );
+}
+
+function getOperatorForSelectedValue(
+  token: TokenResult<Token.FILTER>
+): TermOperator | undefined {
+  if (
+    token.operator === TermOperator.CONTAINS &&
+    token.value.type === Token.VALUE_TEXT &&
+    !token.value.value
+  ) {
+    return token.negated ? TermOperator.NOT_EQUAL : TermOperator.DEFAULT;
+  }
+
+  return undefined;
 }
 
 function ValueComboboxCustomMenu(
@@ -1103,16 +1118,9 @@ export function SearchQueryBuilderValueCombobox({
       }
 
       // When selecting from dropdown with no existing value, switch from "contains" to "is"
-      let newOp: TermOperator | undefined;
-      if (
-        token.operator === TermOperator.CONTAINS &&
-        token.value.type === Token.VALUE_TEXT &&
-        !token.value.value
-      ) {
-        newOp = token.negated ? TermOperator.NOT_EQUAL : TermOperator.DEFAULT;
-      }
-
-      updateFilterValue(value, newOp, {escapeSearchValue: true});
+      updateFilterValue(value, getOperatorForSelectedValue(token), {
+        escapeSearchValue: true,
+      });
       trackAnalytics('search.value_autocompleted', {
         ...analyticsData,
         filter_value: value,

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -2712,6 +2712,7 @@ const PREPROD_FIELD_DEFINITIONS: Record<string, FieldDefinition> = {
     desc: t('Status of the snapshot in the comparison pipeline'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
+    allowWildcard: false,
     values: [
       'approved',
       'auto_approved',


### PR DESCRIPTION
Snapshot status filters now use exact-match semantics, preventing checkbox-driven multi-selects from retaining `contains` and producing wildcard lists that the builds endpoint rejects. Checkbox selection now applies the same operator normalization as regular option selection, and the snapshot status field no longer exposes wildcard operators.

Regression coverage verifies that selecting an initial value via checkbox changes `contains` to `is`.

Fixes EME-1252
