### PR TITLE
fix(integrations): Return 400 instead of 500 on partial code mapping PUT

### DIFF
--- a/src/sentry/integrations/api/endpoints/organization_code_mapping_details.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mapping_details.py
@@ -42,7 +42,6 @@ class OrganizationCodeMappingDetailsEndpoint(OrganizationEndpoint, OrganizationI
                 "project_repository__project"
             ).get(
                 id=config_id,
-                organization_id=kwargs["organization"].id,
                 organization_integration_id__in=[oi.id for oi in ois],
             )
         except (RepositoryProjectPathConfig.DoesNotExist, ValueError):

--- a/src/sentry/integrations/api/endpoints/organization_code_mapping_details.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mapping_details.py
@@ -42,19 +42,15 @@ class OrganizationCodeMappingDetailsEndpoint(OrganizationEndpoint, OrganizationI
                 "project_repository__project"
             ).get(
                 id=config_id,
+                organization_id=kwargs["organization"].id,
                 organization_integration_id__in=[oi.id for oi in ois],
             )
-        except RepositoryProjectPathConfig.DoesNotExist:
+        except (RepositoryProjectPathConfig.DoesNotExist, ValueError):
             raise Http404
-
-        if request.data.get("projectId"):
-            kwargs["new_project"] = super().get_project(
-                kwargs["organization"], request.data.get("projectId")
-            )
 
         return (args, kwargs)
 
-    def put(self, request: Request, config_id, organization, config, new_project) -> Response:
+    def put(self, request: Request, config_id, organization, config) -> Response:
         """
         Update a repository project path config
         ``````````````````
@@ -69,7 +65,7 @@ class OrganizationCodeMappingDetailsEndpoint(OrganizationEndpoint, OrganizationI
         :auth: required
         """
         project = config.project_repository.project
-        if not request.access.has_projects_access([project, new_project]):
+        if not request.access.has_project_access(project):
             return self.respond(status=status.HTTP_403_FORBIDDEN)
 
         try:
@@ -90,13 +86,18 @@ class OrganizationCodeMappingDetailsEndpoint(OrganizationEndpoint, OrganizationI
             instance=config,
             data=request.data,
         )
-        if serializer.is_valid():
-            repository_project_path_config = serializer.save()
-            return self.respond(
-                serialize(repository_project_path_config, request.user),
-                status=status.HTTP_200_OK,
-            )
-        return self.respond(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        if not serializer.is_valid():
+            return self.respond(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        new_project = self.get_project(organization, serializer.validated_data["project_id"])
+        if not request.access.has_project_access(new_project):
+            return self.respond(status=status.HTTP_403_FORBIDDEN)
+
+        repository_project_path_config = serializer.save()
+        return self.respond(
+            serialize(repository_project_path_config, request.user),
+            status=status.HTTP_200_OK,
+        )
 
     def delete(self, request: Request, config_id, organization, config) -> Response:
         """

--- a/src/sentry/integrations/api/endpoints/organization_code_mapping_details.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mapping_details.py
@@ -12,6 +12,7 @@ from sentry.api.bases.organization import (
     OrganizationIntegrationsLoosePermission,
 )
 from sentry.api.serializers import serialize
+from sentry.api.serializers.rest_framework.base import camel_to_snake_case, convert_dict_key_case
 from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.integrations.services.integration import integration_service
 
@@ -44,11 +45,12 @@ class OrganizationCodeMappingDetailsEndpoint(OrganizationEndpoint, OrganizationI
                 id=config_id,
                 organization_integration_id__in=[oi.id for oi in ois],
             )
-            # Only set when the request wants to move the mapping to another project
-            if request.data.get("projectId"):
-                kwargs["new_project"] = self.get_project(
-                    kwargs["organization"], request.data["projectId"]
-                )
+            # Only set when the request wants to move the mapping to another project.
+            # Normalize keys the way the serializer does first, otherwise a snake_case
+            # `project_id` skips the access check below but still moves the mapping.
+            data = convert_dict_key_case(request.data, camel_to_snake_case)
+            if data.get("project_id"):
+                kwargs["new_project"] = self.get_project(kwargs["organization"], data["project_id"])
         except (RepositoryProjectPathConfig.DoesNotExist, ValueError):
             raise Http404
 

--- a/src/sentry/integrations/api/endpoints/organization_code_mapping_details.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mapping_details.py
@@ -44,12 +44,17 @@ class OrganizationCodeMappingDetailsEndpoint(OrganizationEndpoint, OrganizationI
                 id=config_id,
                 organization_integration_id__in=[oi.id for oi in ois],
             )
+            # Only set when the request wants to move the mapping to another project
+            if request.data.get("projectId"):
+                kwargs["new_project"] = self.get_project(
+                    kwargs["organization"], request.data["projectId"]
+                )
         except (RepositoryProjectPathConfig.DoesNotExist, ValueError):
             raise Http404
 
         return (args, kwargs)
 
-    def put(self, request: Request, config_id, organization, config) -> Response:
+    def put(self, request: Request, config_id, organization, config, new_project=None) -> Response:
         """
         Update a repository project path config
         ``````````````````
@@ -63,8 +68,10 @@ class OrganizationCodeMappingDetailsEndpoint(OrganizationEndpoint, OrganizationI
         :param string default_branch:
         :auth: required
         """
-        project = config.project_repository.project
-        if not request.access.has_project_access(project):
+        projects = [config.project_repository.project]
+        if new_project is not None:
+            projects.append(new_project)
+        if not request.access.has_projects_access(projects):
             return self.respond(status=status.HTTP_403_FORBIDDEN)
 
         try:
@@ -85,18 +92,13 @@ class OrganizationCodeMappingDetailsEndpoint(OrganizationEndpoint, OrganizationI
             instance=config,
             data=request.data,
         )
-        if not serializer.is_valid():
-            return self.respond(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-
-        new_project = self.get_project(organization, serializer.validated_data["project_id"])
-        if not request.access.has_project_access(new_project):
-            return self.respond(status=status.HTTP_403_FORBIDDEN)
-
-        repository_project_path_config = serializer.save()
-        return self.respond(
-            serialize(repository_project_path_config, request.user),
-            status=status.HTTP_200_OK,
-        )
+        if serializer.is_valid():
+            repository_project_path_config = serializer.save()
+            return self.respond(
+                serialize(repository_project_path_config, request.user),
+                status=status.HTTP_200_OK,
+            )
+        return self.respond(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     def delete(self, request: Request, config_id, organization, config) -> Response:
         """

--- a/tests/sentry/integrations/api/endpoints/test_organization_code_mapping_details.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_code_mapping_details.py
@@ -140,16 +140,3 @@ class OrganizationCodeMappingDetailsTest(APITestCase):
         )
         resp = self.client.delete(url)
         assert resp.status_code == 404
-
-    def test_edit_another_orgs_code_mapping(self) -> None:
-        invalid_user = self.create_user()
-        invalid_organization = self.create_organization(owner=invalid_user)
-        self.login_as(user=invalid_user)
-        url = reverse(
-            self.endpoint,
-            args=[invalid_organization.slug, self.config.id],
-        )
-
-        resp = self.client.put(url, {})
-
-        assert resp.status_code == status.HTTP_404_NOT_FOUND

--- a/tests/sentry/integrations/api/endpoints/test_organization_code_mapping_details.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_code_mapping_details.py
@@ -71,6 +71,9 @@ class OrganizationCodeMappingDetailsTest(APITestCase):
         non_member_om = self.create_member(organization=self.org, user=non_member)
         self.login_as(user=non_member)
 
+        response = self.client.put(self.url, {"sourceRoot": ""})
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
         response = self.make_put({"sourceRoot": "newRoot"})
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
@@ -102,6 +105,16 @@ class OrganizationCodeMappingDetailsTest(APITestCase):
         assert resp.data["id"] == str(self.config.id)
         assert resp.data["sourceRoot"] == "newRoot"
 
+    def test_edit_rejects_missing_required_fields(self) -> None:
+        resp = self.client.put(self.url, {"sourceRoot": ""})
+
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        assert resp.data == {
+            "projectId": ["This field is required."],
+            "repositoryId": ["This field is required."],
+            "stackRoot": ["This field is required."],
+        }
+
     def test_basic_edit_from_member_permissions(self) -> None:
         self.login_as(user=self.user2)
         resp = self.make_put({"sourceRoot": "newRoot"})
@@ -127,3 +140,16 @@ class OrganizationCodeMappingDetailsTest(APITestCase):
         )
         resp = self.client.delete(url)
         assert resp.status_code == 404
+
+    def test_edit_another_orgs_code_mapping(self) -> None:
+        invalid_user = self.create_user()
+        invalid_organization = self.create_organization(owner=invalid_user)
+        self.login_as(user=invalid_user)
+        url = reverse(
+            self.endpoint,
+            args=[invalid_organization.slug, self.config.id],
+        )
+
+        resp = self.client.put(url, {})
+
+        assert resp.status_code == status.HTTP_404_NOT_FOUND

--- a/tests/sentry/integrations/api/endpoints/test_organization_code_mapping_details.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_code_mapping_details.py
@@ -115,6 +115,30 @@ class OrganizationCodeMappingDetailsTest(APITestCase):
             "stackRoot": ["This field is required."],
         }
 
+    def test_edit_snake_case_project_id_is_access_checked(self) -> None:
+        member = self.create_user()
+        self.create_member(
+            organization=self.org, user=member, has_global_access=False, teams=[self.team]
+        )
+        self.login_as(user=member)
+
+        # every key is snake_case so `projectId` never appears in the body, but the
+        # serializer still reads it as project_id and would move the mapping
+        resp = self.client.put(
+            self.url,
+            {
+                "repository_id": self.repo.id,
+                "project_id": self.project2.id,
+                "stack_root": "/stack/root",
+                "source_root": "/source/root",
+                "default_branch": "master",
+            },
+        )
+
+        assert resp.status_code == status.HTTP_403_FORBIDDEN
+        self.config.refresh_from_db()
+        assert self.config.project_repository.project_id == self.project.id
+
     def test_basic_edit_from_member_permissions(self) -> None:
         self.login_as(user=self.user2)
         resp = self.make_put({"sourceRoot": "newRoot"})


### PR DESCRIPTION
A PUT that left out `projectId`, e.g. `{"sourceRoot": ""}`, returned a 500. `put()` took `new_project` as a required arg but `convert_args` only set it when the body had a `projectId`, so the handler was called without it.

`new_project` is now optional and only included in the access check when the body actually asks to move the mapping. Missing required fields come back as a normal 400, and a garbage `projectId` or `config_id` 404s instead of blowing up on `int()`. Every other status code is unchanged.

fixes SENTRY-5ENF