### PR TITLE
feat(snuba): tag query spans with request compression

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1455,8 +1455,6 @@ def _snuba_query(
                 sentry_sdk.set_attribute("query.referrer", referrer)
 
                 # Whether client asked snuba to zstd-compress the resp.
-                # Span-level so we can see per-query compression rate in traces.
-                sentry_sdk.set_tag("snuba.request_compressed", should_compress)
                 sentry_sdk.set_attribute("snuba.request_compressed", should_compress)
 
                 if isinstance(request.query, MetricsQuery):

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1454,6 +1454,11 @@ def _snuba_query(
                 sentry_sdk.set_tag("query.referrer", referrer)
                 sentry_sdk.set_attribute("query.referrer", referrer)
 
+                # Whether client asked snuba to zstd-compress the resp.
+                # Span-level so we can see per-query compression rate in traces.
+                sentry_sdk.set_tag("snuba.request_compressed", should_compress)
+                sentry_sdk.set_attribute("snuba.request_compressed", should_compress)
+
                 if isinstance(request.query, MetricsQuery):
                     return (
                         referrer,


### PR DESCRIPTION
  ## What
  Instrument whether we're setting compression headers as expected
  
  ## How
  Add `snuba.request_compressed` to snuba query spans (and scope) in `_snuba_query` 

  ## Links
  [EAP-627](https://linear.app/getsentry/issue/EAP-627/enable-compression-on-snuba-query-paths)