### PR TITLE
fix(ci): Update tests to seed the correct column for ai_conversations

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -3434,10 +3434,13 @@ def span_to_trace_item(span) -> TraceItem:
 
     timestamp.FromMilliseconds(span["start_timestamp_ms"])
 
+    if "gen_ai.conversation.id" in span.get("data", {}) and "ai_conversation_id" not in span:
+        assert False, "gen_ai.conversation.id is deprecated.  Use the newer indexed on instead."
     return TraceItem(
         organization_id=span["organization_id"],
         project_id=span["project_id"],
         item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+        conversation_id=span.get("ai_conversation_id", ""),
         timestamp=timestamp,
         trace_id=span["trace_id"],
         item_id=hex_to_item_id(span["span_id"]),

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -3435,7 +3435,7 @@ def span_to_trace_item(span) -> TraceItem:
     timestamp.FromMilliseconds(span["start_timestamp_ms"])
 
     if "gen_ai.conversation.id" in span.get("data", {}) and "ai_conversation_id" not in span:
-        assert False, "gen_ai.conversation.id is deprecated.  Use the newer indexed on instead."
+        assert False, "gen_ai.conversation.id is deprecated.  Use the newer indexed one instead."
     return TraceItem(
         organization_id=span["organization_id"],
         project_id=span["project_id"],

--- a/tests/sentry/api/endpoints/test_organization_ai_conversations_base.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversations_base.py
@@ -49,7 +49,7 @@ class BaseAIConversationsTestCase(BaseSpansTestCase, SpanTestCase, APITestCase):
         """Create and store an AI span with the given attributes.
 
         Args:
-            conversation_id: The gen_ai.conversation.id attribute
+            conversation_id: The gen_ai.conversation.id(old), and ai_conversation_id(new), attribute
             timestamp: The span start timestamp
             op: The span operation (default: "gen_ai.chat")
             description: Span description
@@ -78,7 +78,10 @@ class BaseAIConversationsTestCase(BaseSpansTestCase, SpanTestCase, APITestCase):
         Returns:
             The created span object
         """
-        span_data = {"gen_ai.conversation.id": conversation_id}
+        span_data = {
+            # deprecated in favour of `ai_conversation_id` down below.
+            "gen_ai.conversation.id": conversation_id,
+        }
         if operation_type:
             span_data["gen_ai.operation.type"] = operation_type
         if tokens is not None:
@@ -125,6 +128,7 @@ class BaseAIConversationsTestCase(BaseSpansTestCase, SpanTestCase, APITestCase):
             "description": description or "default",
             "sentry_tags": {"status": status, "op": op},
             "data": span_data,
+            "ai_conversation_id": conversation_id,
         }
         if trace_id:
             extra_data["trace_id"] = trace_id


### PR DESCRIPTION
## Description

Tests were only seeding the un-indexed `gen_ai.conversation.id` field when running the tests.  After merging snuba side perf-improvements in https://github.com/getsentry/snuba/pull/8185; the CI started failing due to us not seeding the right field.

This now updates the tests so that we always seed the indexed column; and adds a useful error message if we end up forgetting this.


Original failing CI run: https://sentry.slack.com/archives/CUHS29QJ0/p1784920298033589
Snuba CI has been updated to use the failing test in https://github.com/getsentry/snuba/pull/8221, updating the CI to use this branch temporarily causes the CI to pass [in this run](https://github.com/getsentry/snuba/actions/runs/30134208696).


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.