### PR TITLE
ref: Removed feature flag in test that was unused

### DIFF
--- a/static/gsApp/views/amCheckout/index.spec.tsx
+++ b/static/gsApp/views/amCheckout/index.spec.tsx
@@ -159,7 +159,7 @@ describe('Default Tier Checkout', () => {
   let mockBillingConfigResponse: any;
 
   beforeEach(() => {
-    organization.features = ['ondemand-budgets', 'am3-billing'];
+    organization.features = ['ondemand-budgets'];
     MockApiClient.clearMockResponses();
     mockBillingConfigResponse = MockApiClient.addMockResponse({
       url: `/customers/${organization.slug}/billing-config/`,

--- a/static/gsApp/views/amCheckout/steps/setSpendLimit.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/setSpendLimit.spec.tsx
@@ -14,7 +14,7 @@ import AMCheckout from 'getsentry/views/amCheckout';
 describe('SetSpendLimit', () => {
   let api: Client;
   const organization = OrganizationFixture({
-    features: ['ondemand-budgets', 'am3-billing'],
+    features: ['ondemand-budgets'],
   });
   const preAm3Organization = OrganizationFixture({
     features: ['ondemand-budgets'],


### PR DESCRIPTION
I'm removing this from the backend since it's only used by this frontend test (and has no effect)