### PR TITLE
Drop weekly-reports from plan fixtures

### DIFF
--- a/tests/js/getsentry-test/fixtures/am1Plans.ts
+++ b/tests/js/getsentry-test/fixtures/am1Plans.ts
@@ -75,7 +75,6 @@ const AM1_TEAM_FEATURES = [
   'integrations-chat-unfurl',
   'integrations-incident-management',
   'sso-basic',
-  'weekly-reports',
   'on-demand-metrics-prefill',
   'seer-billing',
 ];

--- a/tests/js/getsentry-test/fixtures/am2Plans.ts
+++ b/tests/js/getsentry-test/fixtures/am2Plans.ts
@@ -85,7 +85,6 @@ const AM2_TEAM_FEATURES = [
   'integrations-chat-unfurl',
   'integrations-incident-management',
   'sso-basic',
-  'weekly-reports',
   'on-demand-metrics-prefill',
   'seer-billing',
 ];

--- a/tests/js/getsentry-test/fixtures/am3Plans.ts
+++ b/tests/js/getsentry-test/fixtures/am3Plans.ts
@@ -80,7 +80,6 @@ const AM3_TEAM_FEATURES = [
   'integrations-chat-unfurl',
   'integrations-incident-management',
   'sso-basic',
-  'weekly-reports',
   'seer-billing',
 ];
 

--- a/tests/js/getsentry-test/fixtures/featureList.ts
+++ b/tests/js/getsentry-test/fixtures/featureList.ts
@@ -62,10 +62,6 @@ export function FeatureListFixture(): Record<string, Feature> {
       description:
         'Automatically forward processed Sentry events into third party tools such as Amazon SQS, Segment, and Splunk.',
     },
-    'weekly-reports': {
-      name: 'Weekly Reports',
-      description: "A weekly email summary of your organization's health.",
-    },
     'discover-basic': {
       name: 'Discover',
       description: 'Browse raw event data outside of Issues.',

--- a/tests/js/getsentry-test/fixtures/mm1Plans.ts
+++ b/tests/js/getsentry-test/fixtures/mm1Plans.ts
@@ -40,7 +40,6 @@ export const MM1_PLANS = {
     features: [
       'sso-basic',
       'sso-saml2',
-      'weekly-reports',
       'data-forwarding',
       'rate-limits',
       'custom-inbound-filters',
@@ -74,7 +73,6 @@ export const MM1_PLANS = {
     features: [
       'sso-basic',
       'sso-saml2',
-      'weekly-reports',
       'data-forwarding',
       'rate-limits',
       'custom-inbound-filters',
@@ -136,7 +134,6 @@ export const MM1_PLANS = {
     retentionDays: 90,
     features: [
       'sso-basic',
-      'weekly-reports',
       'data-forwarding',
       'rate-limits',
       'custom-inbound-filters',
@@ -171,7 +168,6 @@ export const MM1_PLANS = {
     retentionDays: 90,
     features: [
       'sso-basic',
-      'weekly-reports',
       'data-forwarding',
       'rate-limits',
       'custom-inbound-filters',
@@ -206,7 +202,6 @@ export const MM1_PLANS = {
     retentionDays: 90,
     features: [
       'sso-basic',
-      'weekly-reports',
       'data-forwarding',
       'rate-limits',
       'custom-inbound-filters',
@@ -241,7 +236,6 @@ export const MM1_PLANS = {
     retentionDays: 90,
     features: [
       'sso-basic',
-      'weekly-reports',
       'discard-groups',
       'integrations-issue-basic',
       'integrations-issue-sync',
@@ -273,7 +267,6 @@ export const MM1_PLANS = {
     retentionDays: 90,
     features: [
       'sso-basic',
-      'weekly-reports',
       'discard-groups',
       'integrations-issue-basic',
       'integrations-issue-sync',
@@ -305,7 +298,6 @@ export const MM1_PLANS = {
     retentionDays: 90,
     features: [
       'sso-basic',
-      'weekly-reports',
       'discard-groups',
       'integrations-issue-basic',
       'integrations-issue-sync',
@@ -335,12 +327,7 @@ export const MM1_PLANS = {
     billingInterval: 'monthly',
     allowOnDemand: true,
     retentionDays: 90,
-    features: [
-      'sso-basic',
-      'weekly-reports',
-      'integrations-issue-basic',
-      'extended-data-retention',
-    ],
+    features: ['sso-basic', 'integrations-issue-basic', 'extended-data-retention'],
     dashboardLimit: 0,
     metricDetectorLimit: 0,
   },
@@ -365,12 +352,7 @@ export const MM1_PLANS = {
     billingInterval: 'monthly',
     allowOnDemand: true,
     retentionDays: 90,
-    features: [
-      'sso-basic',
-      'weekly-reports',
-      'integrations-issue-basic',
-      'extended-data-retention',
-    ],
+    features: ['sso-basic', 'integrations-issue-basic', 'extended-data-retention'],
     dashboardLimit: 0,
     metricDetectorLimit: 0,
   },

--- a/tests/js/getsentry-test/fixtures/mm2Plans.ts
+++ b/tests/js/getsentry-test/fixtures/mm2Plans.ts
@@ -48,7 +48,6 @@ export const MM2_PLANS = {
     features: [
       'advanced-search',
       'sso-basic',
-      'weekly-reports',
       'integrations-issue-basic',
       'integrations-issue-sync',
       'events',
@@ -92,7 +91,6 @@ export const MM2_PLANS = {
     features: [
       'advanced-search',
       'sso-basic',
-      'weekly-reports',
       'integrations-issue-basic',
       'integrations-issue-sync',
       'events',
@@ -136,7 +134,6 @@ export const MM2_PLANS = {
     features: [
       'advanced-search',
       'sso-basic',
-      'weekly-reports',
       'integrations-issue-basic',
       'integrations-issue-sync',
       'events',
@@ -180,7 +177,6 @@ export const MM2_PLANS = {
     features: [
       'advanced-search',
       'sso-basic',
-      'weekly-reports',
       'integrations-issue-basic',
       'integrations-issue-sync',
       'events',
@@ -224,7 +220,6 @@ export const MM2_PLANS = {
     features: [
       'advanced-search',
       'sso-basic',
-      'weekly-reports',
       'integrations-issue-basic',
       'integrations-issue-sync',
       'events',
@@ -268,7 +263,6 @@ export const MM2_PLANS = {
     features: [
       'advanced-search',
       'sso-basic',
-      'weekly-reports',
       'integrations-issue-basic',
       'integrations-issue-sync',
       'events',
@@ -312,7 +306,6 @@ export const MM2_PLANS = {
     features: [
       'advanced-search',
       'sso-basic',
-      'weekly-reports',
       'integrations-issue-basic',
       'integrations-issue-sync',
       'events',
@@ -346,7 +339,6 @@ export const MM2_PLANS = {
     features: [
       'advanced-search',
       'sso-basic',
-      'weekly-reports',
       'integrations-issue-basic',
       'integrations-issue-sync',
       'events',
@@ -380,7 +372,6 @@ export const MM2_PLANS = {
     features: [
       'advanced-search',
       'sso-basic',
-      'weekly-reports',
       'integrations-issue-basic',
       'integrations-issue-sync',
       'events',
@@ -415,7 +406,6 @@ export const MM2_PLANS = {
     features: [
       'advanced-search',
       'sso-basic',
-      'weekly-reports',
       'integrations-issue-basic',
       'integrations-issue-sync',
       'events',
@@ -449,7 +439,6 @@ export const MM2_PLANS = {
     features: [
       'advanced-search',
       'sso-basic',
-      'weekly-reports',
       'integrations-issue-basic',
       'integrations-issue-sync',
       'events',
@@ -483,7 +472,6 @@ export const MM2_PLANS = {
     features: [
       'advanced-search',
       'sso-basic',
-      'weekly-reports',
       'integrations-issue-basic',
       'integrations-issue-sync',
       'events',
@@ -539,7 +527,6 @@ export const MM2_PLANS = {
       'integrations-issue-basic',
       'integrations-issue-sync',
       'sso-basic',
-      'weekly-reports',
       'custom-inbound-filters',
       'custom-symbol-sources',
       'data-forwarding',


### PR DESCRIPTION
The getsentry plan definitions no longer grant weekly-reports: it was registered with no feature handler, so nothing could ever read it