### PR TITLE
feat(issues): Add a detector for redundant agent tool calls

### DIFF
--- a/src/sentry/issue_detection/base.py
+++ b/src/sentry/issue_detection/base.py
@@ -29,6 +29,7 @@ class DetectorType(Enum):
     HTTP_OVERHEAD = "http_overhead"
     SQL_INJECTION = "sql_injection"
     QUERY_INJECTION = "query_injection"
+    AGENT_REDUNDANT_TOOL_CALLS = "agent_redundant_tool_calls"
 
 
 # Detector and the corresponding system option must be added to this list to have issues created.
@@ -47,6 +48,7 @@ DETECTOR_TYPE_ISSUE_CREATION_TO_SYSTEM_OPTION = {
     DetectorType.HTTP_OVERHEAD: "performance.issues.http_overhead.problem-creation",
     DetectorType.SQL_INJECTION: "performance.issues.sql_injection.problem-creation",
     DetectorType.QUERY_INJECTION: "performance.issues.query_injection.problem-creation",
+    DetectorType.AGENT_REDUNDANT_TOOL_CALLS: "performance.issues.agent_redundant_tool_calls.problem-creation",
 }
 
 

--- a/src/sentry/issue_detection/detectors/agent_redundant_tool_calls_detector.py
+++ b/src/sentry/issue_detection/detectors/agent_redundant_tool_calls_detector.py
@@ -392,7 +392,11 @@ def _first_string(data: dict[str, Any], keys: tuple[str, ...]) -> str:
             return value
         if value is not None and not isinstance(value, str):
             # Some SDKs attach the raw object rather than a serialized payload.
-            return json.dumps(value)
+            try:
+                return json.dumps(value)
+            except Exception:
+                # Nothing comparable to work with, so the call is skipped.
+                return ""
     return ""
 
 

--- a/src/sentry/issue_detection/detectors/agent_redundant_tool_calls_detector.py
+++ b/src/sentry/issue_detection/detectors/agent_redundant_tool_calls_detector.py
@@ -1,0 +1,488 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from bisect import bisect_left
+from dataclasses import dataclass, field
+from typing import Any
+
+from sentry.issue_detection.base import DetectorType, PerformanceDetector
+from sentry.issue_detection.detectors.utils import (
+    get_notification_attachment_body,
+    total_span_time,
+)
+from sentry.issue_detection.performance_problem import PerformanceProblem
+from sentry.issue_detection.types import Span
+from sentry.issues.grouptype import AgentRedundantToolCallsGroupType
+from sentry.issues.issue_occurrence import IssueEvidence
+from sentry.models.project import Project
+from sentry.utils import json
+
+TOOL_OP = "gen_ai.execute_tool"
+# `gen_ai` ops that wrap other spans rather than doing work themselves. Their duration and
+# token usage already covers their children, so they're neither tool nor model calls.
+AGENT_WRAPPER_OPS = frozenset(("gen_ai.invoke_agent", "gen_ai.create_agent", "gen_ai.handoff"))
+
+# Argument/result payloads can be enormous, and this runs on every ingested event, so at most
+# this many characters of one are ever inspected.
+MAX_PAYLOAD_LENGTH = 4096
+# Those characters are taken as evenly spaced chunks rather than as a prefix. Tool results
+# routinely open with a schema, preamble, or citation block, and comparing openings alone would
+# call any two results from the same tool identical.
+PAYLOAD_SAMPLE_CHUNKS = 8
+# Above this length a payload isn't worth trying to parse as JSON.
+MAX_CANONICALIZE_LENGTH = 16_384
+# Guards against pathological runs. Beyond these caps we stop clustering, which can only
+# cause us to miss a problem, never to invent one.
+MAX_TOOL_CALLS = 200
+MAX_CLUSTERS_PER_TOOL = 20
+
+MAX_EVIDENCE_VALUE_LENGTH = 1_000
+
+# Two results overlapping by at least this much are treated as the same information.
+RESULT_SIMILARITY_THRESHOLD = 0.8
+# Once at least this share of the repeated calls returns a result overlapping the first
+# call's result, the loop is considered to be making no progress.
+MIN_RESULT_SIMILARITY_RATIO = 0.5
+# Repeated calls further apart than this aren't a loop. An agent re-reading a tool minutes
+# later is usually after fresh data, not stuck.
+MAX_DURATION_BETWEEN_CALLS = 60_000  # ms
+
+_TOKEN_SPLIT_RE = re.compile(r"[^a-z0-9]+")
+
+# `gen_ai.tool.input`/`gen_ai.tool.output` are what the SDKs emit; the `call.arguments`/
+# `call.result` spellings come from other gen_ai instrumentation and appear in the wild too.
+_ARGUMENT_KEYS = ("gen_ai.tool.input", "gen_ai.tool.call.arguments")
+_RESULT_KEYS = ("gen_ai.tool.output", "gen_ai.tool.call.result")
+_TOKEN_USAGE_KEYS = ("gen_ai.usage.input_tokens", "gen_ai.usage.output_tokens")
+
+# SDKs name tool spans `execute_tool <name>`, so the description is only a fallback for the
+# tool name once this prefix is removed.
+_TOOL_DESCRIPTION_PREFIX = "execute_tool "
+
+# Span statuses that don't indicate the tool failed. Anything else means the agent was
+# retrying after an error, which is not the same problem as a redundant loop.
+_NON_ERROR_STATUSES = frozenset(("ok", "unknown", "unset", ""))
+
+# Spans that likely changed state the agent can observe, which makes repeating a tool call
+# with the same arguments a reasonable thing to do.
+_MUTATING_HTTP_METHODS = ("POST", "PUT", "PATCH", "DELETE")
+_MUTATING_DB_KEYWORDS = ("INSERT", "UPDATE", "DELETE", "REPLACE", "UPSERT", "MERGE")
+
+
+@dataclass
+class ToolCall:
+    span: Span
+    name: str
+    argument_tokens: frozenset[str]
+    arguments: str
+    result_tokens: frozenset[str]
+
+
+@dataclass
+class ModelCall:
+    start_timestamp: float
+    tokens: int
+
+
+@dataclass
+class ToolCallCluster:
+    """
+    Repeated calls to one tool whose arguments are all equivalent to the first call's, ordered
+    by start time.
+    """
+
+    calls: list[ToolCall] = field(default_factory=list)
+
+    @property
+    def name(self) -> str:
+        return self.calls[0].name
+
+    @property
+    def start_timestamp(self) -> float:
+        return self.calls[0].span.get("start_timestamp", 0)
+
+    @property
+    def end_timestamp(self) -> float:
+        return max(call.span.get("timestamp", 0) for call in self.calls)
+
+    def sort_calls(self) -> None:
+        self.calls.sort(key=lambda call: call.span.get("start_timestamp", 0))
+
+    def max_gap_between_calls(self) -> float:
+        """Largest gap in ms between the end of one call and the start of the next."""
+        gaps = [
+            self.calls[index].span.get("start_timestamp", 0)
+            - self.calls[index - 1].span.get("timestamp", 0)
+            for index in range(1, len(self.calls))
+        ]
+        return max(gaps, default=0.0) * 1000
+
+    def result_similarity_ratio(self) -> float:
+        """
+        The share of repeat calls whose result overlaps the first call's result. Returns 0 when
+        results weren't recorded, so callers must treat missing results separately.
+        """
+        first, *repeats = self.calls
+        if not first.result_tokens:
+            return 0.0
+
+        overlapping = sum(
+            1
+            for call in repeats
+            if call.result_tokens
+            and _jaccard_similarity(first.result_tokens, call.result_tokens)
+            >= RESULT_SIMILARITY_THRESHOLD
+        )
+        return overlapping / len(repeats)
+
+    def last_call_returned_new_information(self) -> bool:
+        """
+        Whether the loop ended on a result the first call didn't already have. A polling tool
+        looks identical to a redundant one until its last call comes back changed, which is
+        exactly the agent making progress and waiting correctly.
+        """
+        first, last = self.calls[0], self.calls[-1]
+        if not first.result_tokens or not last.result_tokens:
+            return False
+        return (
+            _jaccard_similarity(first.result_tokens, last.result_tokens)
+            < RESULT_SIMILARITY_THRESHOLD
+        )
+
+    def has_results(self) -> bool:
+        return any(call.result_tokens for call in self.calls)
+
+
+class AgentRedundantToolCallsDetector(PerformanceDetector):
+    """
+    Detects an agent burning latency and tokens by calling the same tool over and over without
+    learning anything new.
+
+    A problem is reported when all of the following hold for one tool:
+      - it succeeded at least `count_threshold` times with equivalent arguments,
+      - those calls took at least `total_duration_threshold` in aggregate,
+      - no two consecutive calls were more than `MAX_DURATION_BETWEEN_CALLS` apart,
+      - the calls returned overlapping results, including the last one (when results were
+        recorded),
+      - nothing between the first and last call changed state the agent could observe.
+
+    Requires the tool's arguments, which SDKs only send when `send_default_pii` is enabled, so
+    this stays silent for agents that don't report them.
+    """
+
+    type = DetectorType.AGENT_REDUNDANT_TOOL_CALLS
+    settings_key = DetectorType.AGENT_REDUNDANT_TOOL_CALLS
+
+    def __init__(
+        self,
+        settings: dict[str, Any],
+        event: dict[str, Any],
+        detector_id: int | None = None,
+    ) -> None:
+        super().__init__(settings, event, detector_id)
+
+        self.tool_calls: list[ToolCall] = []
+        self.model_calls: list[ModelCall] = []
+        # Sorted in `on_complete`; spans are visited in tree order, not time order.
+        self.mutation_timestamps: list[float] = []
+        self.run_start_timestamp: float | None = None
+        self.run_end_timestamp: float | None = None
+
+    @classmethod
+    def is_event_eligible(cls, event: dict[str, Any], project: Project | None = None) -> bool:
+        return any(
+            (span.get("op") or "").startswith("gen_ai.") for span in event.get("spans") or []
+        )
+
+    def visit_span(self, span: Span) -> None:
+        self._track_run_bounds(span)
+
+        op = span.get("op") or ""
+        if op == TOOL_OP:
+            self._visit_tool_span(span)
+        elif op.startswith("gen_ai.") and op not in AGENT_WRAPPER_OPS:
+            self.model_calls.append(
+                ModelCall(
+                    start_timestamp=span.get("start_timestamp", 0),
+                    tokens=_get_token_usage(span),
+                )
+            )
+        elif _is_mutating_span(span):
+            self.mutation_timestamps.append(span.get("start_timestamp", 0))
+
+    def on_complete(self) -> None:
+        self.mutation_timestamps.sort()
+        for cluster in self._cluster_tool_calls():
+            self._maybe_store_problem(cluster)
+
+    def is_creation_allowed(self) -> bool:
+        return self.settings["detection_enabled"]
+
+    def _track_run_bounds(self, span: Span) -> None:
+        start = span.get("start_timestamp", 0)
+        end = span.get("timestamp", 0)
+        if self.run_start_timestamp is None or start < self.run_start_timestamp:
+            self.run_start_timestamp = start
+        if self.run_end_timestamp is None or end > self.run_end_timestamp:
+            self.run_end_timestamp = end
+
+    def _visit_tool_span(self, span: Span) -> None:
+        if len(self.tool_calls) >= MAX_TOOL_CALLS:
+            return
+
+        if (span.get("status") or "").lower() not in _NON_ERROR_STATUSES:
+            # The agent was retrying a failing tool. Repeating a call that errored is a
+            # different problem, and treating it as a loop would blame the wrong thing.
+            return
+
+        data = span.get("data") or {}
+        name = data.get("gen_ai.tool.name") or _name_from_description(span)
+        arguments = _first_string(data, _ARGUMENT_KEYS)
+        if not name or not arguments:
+            # Without a tool name and arguments there's nothing to compare calls on.
+            return
+
+        self.tool_calls.append(
+            ToolCall(
+                span=span,
+                name=str(name),
+                argument_tokens=_tokenize(_canonicalize(arguments)),
+                arguments=arguments[:MAX_EVIDENCE_VALUE_LENGTH],
+                result_tokens=_tokenize(_first_string(data, _RESULT_KEYS)),
+            )
+        )
+
+    def _cluster_tool_calls(self) -> list[ToolCallCluster]:
+        """
+        Group calls by tool name, then greedily cluster them by argument similarity. The first
+        call in a cluster is the representative, so a cluster means "these calls all asked the
+        same question", not "these calls resemble each other transitively".
+        """
+        clusters_by_tool: dict[str, list[ToolCallCluster]] = {}
+        similarity_threshold = self.settings["argument_similarity_threshold"]
+
+        for call in self.tool_calls:
+            clusters = clusters_by_tool.setdefault(call.name, [])
+            for cluster in clusters:
+                if (
+                    _jaccard_similarity(cluster.calls[0].argument_tokens, call.argument_tokens)
+                    >= similarity_threshold
+                ):
+                    cluster.calls.append(call)
+                    break
+            else:
+                if len(clusters) < MAX_CLUSTERS_PER_TOOL:
+                    clusters.append(ToolCallCluster(calls=[call]))
+
+        clusters = [cluster for clusters in clusters_by_tool.values() for cluster in clusters]
+        for cluster in clusters:
+            cluster.sort_calls()
+        return clusters
+
+    def _maybe_store_problem(self, cluster: ToolCallCluster) -> None:
+        if len(cluster.calls) < self.settings["count_threshold"]:
+            return
+
+        spans = [call.span for call in cluster.calls]
+        duplicate_duration = total_span_time(spans)
+        if duplicate_duration < self.settings["total_duration_threshold"]:
+            return
+
+        if cluster.max_gap_between_calls() > MAX_DURATION_BETWEEN_CALLS:
+            return
+
+        # When results were recorded, they have to actually overlap, and the loop has to end
+        # without turning anything up. Repeated calls that keep returning something different,
+        # or that end on a changed result, are gathering information rather than spinning.
+        result_similarity = cluster.result_similarity_ratio()
+        if cluster.has_results() and (
+            result_similarity < MIN_RESULT_SIMILARITY_RATIO
+            or cluster.last_call_returned_new_information()
+        ):
+            return
+
+        if self._state_changed_during(cluster):
+            return
+
+        fingerprint = self._fingerprint(cluster.name)
+        offender_span_ids = [span["span_id"] for span in spans]
+        interleaved_model_calls, interleaved_tokens = self._model_usage_during(cluster)
+        run_duration = self._run_duration()
+
+        evidence_data: dict[str, Any] = {
+            "op": TOOL_OP,
+            "cause_span_ids": [],
+            "parent_span_ids": _parent_span_ids(spans),
+            "offender_span_ids": offender_span_ids,
+            "transaction_name": self._event.get("transaction", ""),
+            "tool_name": cluster.name,
+            "num_redundant_calls": len(cluster.calls),
+            "redundant_call_duration": duplicate_duration,
+            "run_duration": run_duration,
+            # How much of the run these calls account for. The most useful number for deciding
+            # whether the loop is worth fixing.
+            "redundant_duration_ratio": (
+                duplicate_duration / run_duration if run_duration else None
+            ),
+            # Model/tool cycles: each interleaved model call re-fed the same tool output back
+            # into the model.
+            "interleaved_model_calls": interleaved_model_calls,
+            "interleaved_model_tokens": interleaved_tokens,
+            "result_similarity_ratio": result_similarity if cluster.has_results() else None,
+            "sample_arguments": cluster.calls[0].arguments[:MAX_EVIDENCE_VALUE_LENGTH],
+        }
+        if self.detector_id is not None:
+            evidence_data["detector_id"] = self.detector_id
+
+        desc = f"{cluster.name} called {len(cluster.calls)} times with equivalent arguments"
+
+        self.stored_problems[fingerprint] = PerformanceProblem(
+            fingerprint=fingerprint,
+            op=TOOL_OP,
+            desc=desc,
+            type=AgentRedundantToolCallsGroupType,
+            cause_span_ids=[],
+            parent_span_ids=evidence_data["parent_span_ids"],
+            offender_span_ids=offender_span_ids,
+            evidence_display=[
+                IssueEvidence(
+                    name="Offending Spans",
+                    value=get_notification_attachment_body(TOOL_OP, desc)[
+                        :MAX_EVIDENCE_VALUE_LENGTH
+                    ],
+                    # Has to be marked important to be displayed in the notifications
+                    important=True,
+                )
+            ],
+            evidence_data=evidence_data,
+        )
+
+    def _state_changed_during(self, cluster: ToolCallCluster) -> bool:
+        start, end = cluster.start_timestamp, cluster.end_timestamp
+        index = bisect_left(self.mutation_timestamps, start)
+        return index < len(self.mutation_timestamps) and self.mutation_timestamps[index] <= end
+
+    def _model_usage_during(self, cluster: ToolCallCluster) -> tuple[int, int]:
+        start, end = cluster.start_timestamp, cluster.end_timestamp
+        interleaved = [
+            model_call
+            for model_call in self.model_calls
+            if start <= model_call.start_timestamp <= end
+        ]
+        return len(interleaved), sum(model_call.tokens for model_call in interleaved)
+
+    def _run_duration(self) -> float:
+        if self.run_start_timestamp is None or self.run_end_timestamp is None:
+            return 0.0
+        return (self.run_end_timestamp - self.run_start_timestamp) * 1000
+
+    def _fingerprint(self, tool_name: str) -> str:
+        # Fingerprint on the tool, not the arguments: the fix is to the tool or the loop around
+        # it, and arguments carry user input, which would shatter the issue into one group per
+        # distinct question the agent was asked.
+        signature = hashlib.sha1(tool_name.encode("utf-8")).hexdigest()
+        return f"1-{AgentRedundantToolCallsGroupType.type_id}-{signature}"
+
+
+def _first_string(data: dict[str, Any], keys: tuple[str, ...]) -> str:
+    for key in keys:
+        value = data.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+        if value is not None and not isinstance(value, str):
+            # Some SDKs attach the raw object rather than a serialized payload.
+            return json.dumps(value)
+    return ""
+
+
+def _canonicalize(arguments: str) -> str:
+    """
+    Reduce an argument payload to a form where irrelevant differences (key order, formatting)
+    disappear. Semantic equivalence beyond that is left to token comparison.
+    """
+    if len(arguments) > MAX_CANONICALIZE_LENGTH:
+        return arguments
+    try:
+        parsed = json.loads(arguments)
+    except Exception:
+        return arguments
+    try:
+        return json.dumps(parsed, sort_keys=True)
+    except Exception:
+        return arguments
+
+
+def _sample_payload(payload: str) -> str:
+    """
+    Bound a payload to `MAX_PAYLOAD_LENGTH` characters taken as evenly spaced chunks, so that
+    the middle and tail of a long result weigh as much as its opening.
+    """
+    if len(payload) <= MAX_PAYLOAD_LENGTH:
+        return payload
+
+    chunk_length = MAX_PAYLOAD_LENGTH // PAYLOAD_SAMPLE_CHUNKS
+    stride = len(payload) // PAYLOAD_SAMPLE_CHUNKS
+    return "".join(
+        payload[index * stride : index * stride + chunk_length]
+        for index in range(PAYLOAD_SAMPLE_CHUNKS)
+    )
+
+
+def _tokenize(payload: str) -> frozenset[str]:
+    if not payload:
+        return frozenset()
+    return frozenset(
+        token for token in _TOKEN_SPLIT_RE.split(_sample_payload(payload).lower()) if token
+    )
+
+
+def _name_from_description(span: Span) -> str:
+    description = (span.get("description") or "").strip()
+    if description.startswith(_TOOL_DESCRIPTION_PREFIX):
+        return description[len(_TOOL_DESCRIPTION_PREFIX) :]
+    return description
+
+
+def _jaccard_similarity(left: frozenset[str], right: frozenset[str]) -> float:
+    if not left or not right:
+        return 0.0
+    union = len(left | right)
+    return len(left & right) / union if union else 0.0
+
+
+def _get_token_usage(span: Span) -> int:
+    data = span.get("data") or {}
+    total = data.get("gen_ai.usage.total_tokens")
+    if isinstance(total, (int, float)):
+        return int(total)
+
+    tokens = 0
+    for key in _TOKEN_USAGE_KEYS:
+        value = data.get(key)
+        if isinstance(value, (int, float)):
+            tokens += int(value)
+    return tokens
+
+
+def _is_mutating_span(span: Span) -> bool:
+    op = span.get("op") or ""
+    description = (span.get("description") or "").strip().upper()
+    if not description:
+        return False
+
+    if op.startswith("http.client"):
+        return description.startswith(_MUTATING_HTTP_METHODS)
+    if op.startswith("db") and not op.startswith("db.redis"):
+        return description.startswith(_MUTATING_DB_KEYWORDS)
+    return False
+
+
+def _parent_span_ids(spans: list[Span]) -> list[str]:
+    """The agent span(s) the repeated calls hang off of, when the SDK recorded a parent."""
+    parent_ids = []
+    for span in spans:
+        parent_id = span.get("parent_span_id")
+        if parent_id and parent_id not in parent_ids:
+            parent_ids.append(parent_id)
+    return parent_ids

--- a/src/sentry/issue_detection/performance_detection.py
+++ b/src/sentry/issue_detection/performance_detection.py
@@ -24,6 +24,7 @@ from sentry.utils.tracing import set_span_tag, start_span
 from sentry.workflow_engine.models import Detector
 
 from .base import DetectorType, PerformanceDetector
+from .detectors.agent_redundant_tool_calls_detector import AgentRedundantToolCallsDetector
 from .detectors.consecutive_db_detector import ConsecutiveDBSpanDetector
 from .detectors.consecutive_http_detector import ConsecutiveHTTPSpanDetector
 from .detectors.http_overhead_detector import HTTPOverheadDetector
@@ -236,6 +237,12 @@ def get_merged_settings(
             "performance.issues.sql_injection.query_value_length_threshold"
         ),
         "web_vitals_count": options.get("performance.issues.web_vitals.count_threshold"),
+        "agent_redundant_tool_calls_count_threshold": options.get(
+            "performance.issues.agent_redundant_tool_calls.count_threshold"
+        ),
+        "agent_redundant_tool_calls_total_duration_threshold": options.get(
+            "performance.issues.agent_redundant_tool_calls.total_duration_threshold"
+        ),
     }
 
     default_project_settings = (
@@ -656,6 +663,16 @@ def get_detection_settings(
         DetectorType.QUERY_INJECTION: {
             "detection_enabled": settings["db_query_injection_detection_enabled"]
         },
+        DetectorType.AGENT_REDUNDANT_TOOL_CALLS: {
+            "count_threshold": settings["agent_redundant_tool_calls_count_threshold"],
+            "total_duration_threshold": settings[
+                "agent_redundant_tool_calls_total_duration_threshold"
+            ],  # ms
+            # Jaccard similarity over argument tokens, above which two calls are treated as
+            # asking the same question.
+            "argument_similarity_threshold": 0.9,
+            "detection_enabled": settings["agent_redundant_tool_calls_detection_enabled"],
+        },
     }
 
 
@@ -674,6 +691,7 @@ DETECTOR_CLASSES: list[type[PerformanceDetector]] = [
     HTTPOverheadDetector,
     SQLInjectionDetector,
     QueryInjectionDetector,
+    AgentRedundantToolCallsDetector,
 ]
 
 

--- a/src/sentry/issue_detection/types.py
+++ b/src/sentry/issue_detection/types.py
@@ -21,6 +21,7 @@ class Span(TypedDict, total=False):
     op: str
     description: str
     hash: str
+    status: str
     parent_span_id: str
     data: dict[str, Any] | None
     tags: dict[str, Any] | None

--- a/src/sentry/issues/endpoints/project_performance_issue_settings.py
+++ b/src/sentry/issues/endpoints/project_performance_issue_settings.py
@@ -18,6 +18,7 @@ from sentry.issue_detection.performance_detection import (
     update_performance_settings,
 )
 from sentry.issues.grouptype import (
+    AgentRedundantToolCallsGroupType,
     AIDetectedGeneralGroupType,
     GroupType,
     PerformanceConsecutiveDBQueriesGroupType,
@@ -93,6 +94,9 @@ class ConfigurableThresholds(Enum):
     AI_DETECTED_SECURITY = "ai_detected_security_enabled"
     AI_DETECTED_CODE_HEALTH = "ai_detected_code_health_enabled"
     AI_DETECTED_GENERAL = "ai_detected_general_enabled"
+    AGENT_REDUNDANT_TOOL_CALLS = "agent_redundant_tool_calls_detection_enabled"
+    AGENT_REDUNDANT_TOOL_CALLS_COUNT = "agent_redundant_tool_calls_count_threshold"
+    AGENT_REDUNDANT_TOOL_CALLS_DURATION = "agent_redundant_tool_calls_total_duration_threshold"
 
 
 project_settings_to_group_map: dict[str, type[GroupType]] = {
@@ -112,6 +116,7 @@ project_settings_to_group_map: dict[str, type[GroupType]] = {
     ConfigurableThresholds.DB_QUERY_INJECTION.value: QueryInjectionVulnerabilityGroupType,
     ConfigurableThresholds.WEB_VITALS.value: WebVitalsGroup,
     ConfigurableThresholds.AI_ISSUE_DETECTION.value: AIDetectedGeneralGroupType,
+    ConfigurableThresholds.AGENT_REDUNDANT_TOOL_CALLS.value: AgentRedundantToolCallsGroupType,
 }
 """
 A mapping of the management settings to the group type that the detector spawns.
@@ -140,6 +145,8 @@ thresholds_to_manage_map: dict[str, str] = {
     ConfigurableThresholds.AI_DETECTED_SECURITY.value: ConfigurableThresholds.AI_ISSUE_DETECTION.value,
     ConfigurableThresholds.AI_DETECTED_CODE_HEALTH.value: ConfigurableThresholds.AI_ISSUE_DETECTION.value,
     ConfigurableThresholds.AI_DETECTED_GENERAL.value: ConfigurableThresholds.AI_ISSUE_DETECTION.value,
+    ConfigurableThresholds.AGENT_REDUNDANT_TOOL_CALLS_COUNT.value: ConfigurableThresholds.AGENT_REDUNDANT_TOOL_CALLS.value,
+    ConfigurableThresholds.AGENT_REDUNDANT_TOOL_CALLS_DURATION.value: ConfigurableThresholds.AGENT_REDUNDANT_TOOL_CALLS.value,
 }
 """
 A mapping of threshold setting to the parent setting that manages it's detection.
@@ -221,6 +228,15 @@ class ProjectPerformanceIssueSettingsSerializer(serializers.Serializer):
     ai_detected_security_enabled = serializers.BooleanField(required=False)
     ai_detected_code_health_enabled = serializers.BooleanField(required=False)
     ai_detected_general_enabled = serializers.BooleanField(required=False)
+    agent_redundant_tool_calls_detection_enabled = serializers.BooleanField(required=False)
+    agent_redundant_tool_calls_count_threshold = serializers.IntegerField(
+        required=False, min_value=2, max_value=50
+    )
+    agent_redundant_tool_calls_total_duration_threshold = serializers.IntegerField(
+        required=False,
+        min_value=100,
+        max_value=TEN_SECONDS,  # ms
+    )
     sql_injection_query_value_length_threshold = serializers.IntegerField(
         required=False, min_value=3, max_value=10
     )

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -737,6 +737,25 @@ class AIDetectedGeneralGroupType(GroupType):
 
 
 @dataclass(frozen=True)
+class AgentRedundantToolCallsGroupType(GroupType):
+    """
+    An agent called the same tool repeatedly with equivalent arguments without making
+    progress. Detected deterministically from gen_ai spans, not by an LLM, but it shares
+    the AI_DETECTED category since that's where agent issues surface today.
+    """
+
+    type_id = 3509
+    slug = "agent_redundant_tool_calls"
+    description = "Redundant Agent Tool Calls"
+    category = GroupCategory.AI_DETECTED.value
+    noise_config = NoiseConfig(ignore_limit=5)
+    default_priority = PriorityLevel.MEDIUM
+    released = False
+    enable_auto_resolve = False
+    enable_escalation_detection = False
+
+
+@dataclass(frozen=True)
 class ReplayRageClickType(ReplayGroupTypeDefaults, GroupType):
     type_id = 5002
     slug = "replay_click_rage"

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1957,6 +1957,11 @@ register(
     default=0.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "performance.issues.agent_redundant_tool_calls.problem-creation",
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # System-wide options for default performance detection settings for any org opted into the performance-issues-ingest feature. Meant for rollout.
 register(
@@ -2069,6 +2074,16 @@ register(
     default=10,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "performance.issues.agent_redundant_tool_calls.count_threshold",
+    default=3,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "performance.issues.agent_redundant_tool_calls.total_duration_threshold",
+    default=1000,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)  # ms
 
 # Adjusting some time buffers in the trace endpoint
 register(

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -108,6 +108,7 @@ DEFAULT_PROJECT_PERFORMANCE_DETECTION_SETTINGS = {
     "transaction_duration_regression_detection_enabled": True,
     "function_duration_regression_detection_enabled": True,
     "db_query_injection_detection_enabled": False,
+    "agent_redundant_tool_calls_detection_enabled": False,
     "web_vitals_detection_enabled": True,
     "ai_issue_detection_enabled": True,
 }

--- a/tests/sentry/issue_detection/test_agent_redundant_tool_calls_detector.py
+++ b/tests/sentry/issue_detection/test_agent_redundant_tool_calls_detector.py
@@ -362,6 +362,24 @@ class AgentRedundantToolCallsDetectorTest(TestCase):
 
         assert self.find_problems(create_event(spans)) == []
 
+    def test_skips_tool_input_that_cannot_be_serialized(self) -> None:
+        spans = [agent_span()]
+        for index, span_id in enumerate(("b", "c", "d")):
+            span = create_span(
+                "gen_ai.execute_tool",
+                1000.0,
+                "execute_tool searchDocumentation",
+                "hash1",
+                data={
+                    "gen_ai.tool.name": "searchDocumentation",
+                    "gen_ai.tool.input": object(),
+                },
+            )
+            span["span_id"] = span_id * 16
+            spans.append(modify_span_start(span, index * 1000))
+
+        assert self.find_problems(create_event(spans)) == []
+
     def test_ignores_events_without_agent_spans(self) -> None:
         spans = [create_span("db", 2000.0, "SELECT * FROM users", "hash3")]
 

--- a/tests/sentry/issue_detection/test_agent_redundant_tool_calls_detector.py
+++ b/tests/sentry/issue_detection/test_agent_redundant_tool_calls_detector.py
@@ -1,0 +1,377 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from sentry.issue_detection.detectors.agent_redundant_tool_calls_detector import (
+    AgentRedundantToolCallsDetector,
+)
+from sentry.issue_detection.performance_detection import (
+    get_detection_settings,
+    run_detector_on_data,
+)
+from sentry.issue_detection.performance_problem import PerformanceProblem
+from sentry.issues.grouptype import AgentRedundantToolCallsGroupType
+from sentry.testutils.cases import TestCase
+from sentry.testutils.issue_detection.event_generators import (
+    create_event,
+    create_span,
+    modify_span_start,
+)
+
+AGENT_SPAN_ID = "a" * 16
+DOCS_RESULT = "Authentication is configured with the auth middleware. See the auth guide."
+
+
+def agent_span(duration: float = 4000.0) -> dict[str, Any]:
+    """The `gen_ai.invoke_agent` span the SDKs wrap a whole agent run in."""
+    span = create_span(
+        "gen_ai.invoke_agent",
+        duration,
+        "invoke_agent research-agent",
+        "hash0",
+        data={"gen_ai.operation.name": "invoke_agent", "gen_ai.agent.name": "research-agent"},
+    )
+    span["span_id"] = AGENT_SPAN_ID
+    return modify_span_start(span, 0)
+
+
+def tool_span(
+    span_id: str,
+    start: float,
+    tool_input: str,
+    output: str = DOCS_RESULT,
+    duration: float = 1000.0,
+    name: str = "searchDocumentation",
+    status: str = "ok",
+) -> dict[str, Any]:
+    """
+    A `gen_ai.execute_tool` span shaped the way the SDKs emit it: the tool name always present,
+    the input and output only there when `send_default_pii` is on, and the description prefixed
+    with the operation.
+    """
+    span = create_span(
+        "gen_ai.execute_tool",
+        duration,
+        f"execute_tool {name}",
+        "hash1",
+        data={
+            "gen_ai.operation.name": "execute_tool",
+            "gen_ai.tool.name": name,
+            "gen_ai.tool.input": tool_input,
+            "gen_ai.tool.output": output,
+        },
+    )
+    span["span_id"] = span_id
+    span["status"] = status
+    return modify_span_start(span, start)
+
+
+def model_span(span_id: str, start: float, duration: float = 200.0) -> dict[str, Any]:
+    span = create_span(
+        "gen_ai.chat",
+        duration,
+        "chat gpt-4o",
+        "hash2",
+        data={
+            "gen_ai.request.model": "gpt-4o",
+            "gen_ai.usage.input_tokens": 1800,
+            "gen_ai.usage.output_tokens": 200,
+            "gen_ai.usage.total_tokens": 2000,
+        },
+    )
+    span["span_id"] = span_id
+    return modify_span_start(span, start)
+
+
+@pytest.mark.django_db
+class AgentRedundantToolCallsDetectorTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self._settings = get_detection_settings()
+
+    def find_problems(self, event: dict[str, Any]) -> list[PerformanceProblem]:
+        detector = AgentRedundantToolCallsDetector(
+            self._settings[AgentRedundantToolCallsDetector.settings_key], event
+        )
+        run_detector_on_data(detector, event)
+        return list(detector.stored_problems.values())
+
+    def test_detects_a_tool_loop_that_returns_the_same_documents(self) -> None:
+        spans = [
+            agent_span(),
+            model_span("b" * 16, 0),
+            tool_span("c" * 16, 200, '{"query": "how do I configure auth"}'),
+            model_span("d" * 16, 1200),
+            tool_span("e" * 16, 1400, '{"query": "how do I configure auth"}'),
+            model_span("f" * 16, 2400),
+            tool_span("1" * 16, 2600, '{"query": "how do I configure auth"}'),
+        ]
+
+        problems = self.find_problems(create_event(spans))
+        assert len(problems) == 1
+        problem = problems[0]
+
+        assert problem.type == AgentRedundantToolCallsGroupType
+        assert problem.op == "gen_ai.execute_tool"
+        assert problem.desc == "searchDocumentation called 3 times with equivalent arguments"
+        assert problem.offender_span_ids == ["c" * 16, "e" * 16, "1" * 16]
+        # The tool spans hang off the agent span, which is what the issue points at.
+        assert problem.parent_span_ids == [AGENT_SPAN_ID]
+
+        assert problem.evidence_data is not None
+        assert problem.evidence_data["tool_name"] == "searchDocumentation"
+        assert problem.evidence_data["num_redundant_calls"] == 3
+        assert problem.evidence_data["redundant_call_duration"] == 3000
+        assert problem.evidence_data["result_similarity_ratio"] == 1.0
+        # The two model calls between the first and last tool call re-fed the same tool output
+        # back into the model.
+        assert problem.evidence_data["interleaved_model_calls"] == 2
+        assert problem.evidence_data["interleaved_model_tokens"] == 4000
+
+    def test_reports_the_share_of_the_run_the_loop_consumed(self) -> None:
+        db_span = create_span("db", 2000.0, "SELECT * FROM users", "hash3")
+        db_span["span_id"] = "d" * 16
+
+        spans = [
+            agent_span(duration=8000.0),
+            tool_span("a1" * 8, 0, '{"query": "auth"}', duration=2000.0),
+            tool_span("b" * 16, 2000, '{"query": "auth"}', duration=2000.0),
+            tool_span("c" * 16, 4000, '{"query": "auth"}', duration=2000.0),
+            modify_span_start(db_span, 6000),
+        ]
+
+        problems = self.find_problems(create_event(spans))
+        assert len(problems) == 1
+        assert problems[0].evidence_data["run_duration"] == 8000
+        assert problems[0].evidence_data["redundant_duration_ratio"] == 0.75
+
+    def test_treats_reformatted_and_recased_arguments_as_equivalent(self) -> None:
+        spans = [
+            agent_span(),
+            tool_span("b" * 16, 0, '{"query": "Configure Auth", "limit": 5}'),
+            tool_span("c" * 16, 1000, '{"limit": 5, "query": "configure auth"}'),
+            tool_span("d" * 16, 2000, '{"query":"configure   auth","limit":5}'),
+        ]
+
+        assert len(self.find_problems(create_event(spans))) == 1
+
+    def test_reads_the_alternate_tool_call_attribute_spelling(self) -> None:
+        spans = [agent_span()]
+        for index, span_id in enumerate(("b", "c", "d")):
+            span = create_span(
+                "gen_ai.execute_tool",
+                1000.0,
+                "execute_tool searchDocumentation",
+                "hash1",
+                data={
+                    "gen_ai.tool.name": "searchDocumentation",
+                    "gen_ai.tool.call.arguments": '{"query": "auth"}',
+                    "gen_ai.tool.call.result": DOCS_RESULT,
+                },
+            )
+            span["span_id"] = span_id * 16
+            spans.append(modify_span_start(span, index * 1000))
+
+        assert len(self.find_problems(create_event(spans))) == 1
+
+    def test_falls_back_to_the_span_description_for_the_tool_name(self) -> None:
+        spans = [agent_span()]
+        for index, span_id in enumerate(("b", "c", "d")):
+            span = create_span(
+                "gen_ai.execute_tool",
+                1000.0,
+                "execute_tool searchDocumentation",
+                "hash1",
+                data={"gen_ai.tool.input": '{"query": "auth"}', "gen_ai.tool.output": DOCS_RESULT},
+            )
+            span["span_id"] = span_id * 16
+            spans.append(modify_span_start(span, index * 1000))
+
+        problems = self.find_problems(create_event(spans))
+        assert len(problems) == 1
+        assert problems[0].evidence_data["tool_name"] == "searchDocumentation"
+
+    def test_ignores_calls_asking_different_questions(self) -> None:
+        spans = [
+            agent_span(),
+            tool_span("b" * 16, 0, '{"query": "how do I configure auth"}'),
+            tool_span("c" * 16, 1000, '{"query": "which database drivers ship by default"}'),
+            tool_span("d" * 16, 2000, '{"query": "what does the rate limiter do"}'),
+        ]
+
+        assert self.find_problems(create_event(spans)) == []
+
+    def test_ignores_repeated_calls_that_keep_returning_new_information(self) -> None:
+        spans = [
+            agent_span(),
+            tool_span("b" * 16, 0, '{"query": "auth"}', output="the auth middleware guide"),
+            tool_span("c" * 16, 1000, '{"query": "auth"}', output="oauth provider setup steps"),
+            tool_span("d" * 16, 2000, '{"query": "auth"}', output="session cookie reference"),
+        ]
+
+        assert self.find_problems(create_event(spans)) == []
+
+    def test_ignores_a_polling_loop_that_ends_on_a_changed_result(self) -> None:
+        spans = [
+            agent_span(),
+            tool_span("b" * 16, 0, '{"job": "build-42"}', output='{"status": "running"}'),
+            tool_span("c" * 16, 1000, '{"job": "build-42"}', output='{"status": "running"}'),
+            tool_span("d" * 16, 2000, '{"job": "build-42"}', output='{"status": "running"}'),
+            tool_span("e" * 16, 3000, '{"job": "build-42"}', output='{"finished": "success"}'),
+        ]
+
+        assert self.find_problems(create_event(spans)) == []
+
+    def test_ignores_retries_of_a_failing_tool(self) -> None:
+        spans = [
+            agent_span(),
+            tool_span("b" * 16, 0, '{"query": "auth"}', status="internal_error"),
+            tool_span("c" * 16, 1000, '{"query": "auth"}', status="internal_error"),
+            tool_span("d" * 16, 2000, '{"query": "auth"}', status="internal_error"),
+        ]
+
+        assert self.find_problems(create_event(spans)) == []
+
+    def test_counts_only_the_successful_calls_of_a_partly_failing_tool(self) -> None:
+        spans = [
+            agent_span(),
+            tool_span("b" * 16, 0, '{"query": "auth"}', status="internal_error"),
+            tool_span("c" * 16, 1000, '{"query": "auth"}'),
+            tool_span("d" * 16, 2000, '{"query": "auth"}'),
+            tool_span("e" * 16, 3000, '{"query": "auth"}'),
+        ]
+
+        problems = self.find_problems(create_event(spans))
+        assert len(problems) == 1
+        assert problems[0].evidence_data["num_redundant_calls"] == 3
+        assert problems[0].offender_span_ids == ["c" * 16, "d" * 16, "e" * 16]
+
+    def test_ignores_repeated_calls_spread_across_a_long_running_segment(self) -> None:
+        spans = [
+            agent_span(duration=200_000.0),
+            tool_span("b" * 16, 0, '{"query": "auth"}'),
+            tool_span("c" * 16, 1000, '{"query": "auth"}'),
+            # Minutes later, so the agent is after fresh data rather than stuck in a loop.
+            tool_span("d" * 16, 150_000, '{"query": "auth"}'),
+        ]
+
+        assert self.find_problems(create_event(spans)) == []
+
+    def test_ignores_repeated_calls_around_a_state_change(self) -> None:
+        write_span = create_span("http.client", 100.0, "POST /api/0/documents/", "hash4")
+        write_span["span_id"] = "e" * 16
+
+        spans = [
+            agent_span(),
+            tool_span("b" * 16, 0, '{"query": "auth"}'),
+            tool_span("c" * 16, 1000, '{"query": "auth"}'),
+            modify_span_start(write_span, 1500),
+            tool_span("d" * 16, 2000, '{"query": "auth"}'),
+        ]
+
+        assert self.find_problems(create_event(spans)) == []
+
+    def test_ignores_long_results_that_differ_past_a_shared_header(self) -> None:
+        """
+        Tool results commonly open with the same schema or preamble and only diverge further in.
+        The shared header here is longer than the sample budget, so comparing openings alone
+        would call these three documents identical.
+        """
+        header = " ".join(f"header-field-{index}" for index in range(400))
+        bodies = [
+            " ".join(f"{topic}-passage-{index}" for index in range(600))
+            for topic in ("middleware", "oauth", "cookies")
+        ]
+        spans = [
+            agent_span(),
+            tool_span("b" * 16, 0, '{"query": "auth"}', output=f"{header} {bodies[0]}"),
+            tool_span("c" * 16, 1000, '{"query": "auth"}', output=f"{header} {bodies[1]}"),
+            tool_span("d" * 16, 2000, '{"query": "auth"}', output=f"{header} {bodies[2]}"),
+        ]
+
+        assert self.find_problems(create_event(spans)) == []
+
+    def test_detects_a_loop_returning_identical_long_results(self) -> None:
+        document = " ".join(f"auth-guide-passage-{index}" for index in range(1000))
+        spans = [
+            agent_span(),
+            tool_span("b" * 16, 0, '{"query": "auth"}', output=document),
+            tool_span("c" * 16, 1000, '{"query": "auth"}', output=document),
+            tool_span("d" * 16, 2000, '{"query": "auth"}', output=document),
+        ]
+
+        problems = self.find_problems(create_event(spans))
+        assert len(problems) == 1
+        assert problems[0].evidence_data["result_similarity_ratio"] == 1.0
+
+    def test_ignores_a_loop_below_the_count_threshold(self) -> None:
+        spans = [
+            agent_span(),
+            tool_span("b" * 16, 0, '{"query": "auth"}'),
+            tool_span("c" * 16, 1000, '{"query": "auth"}'),
+        ]
+
+        assert self.find_problems(create_event(spans)) == []
+
+    def test_ignores_a_loop_of_cheap_calls(self) -> None:
+        spans = [
+            agent_span(),
+            tool_span("b" * 16, 0, '{"query": "auth"}', duration=50.0),
+            tool_span("c" * 16, 100, '{"query": "auth"}', duration=50.0),
+            tool_span("d" * 16, 200, '{"query": "auth"}', duration=50.0),
+        ]
+
+        assert self.find_problems(create_event(spans)) == []
+
+    def test_separates_loops_by_tool(self) -> None:
+        spans = [
+            agent_span(duration=6000.0),
+            tool_span("b" * 16, 0, '{"query": "auth"}'),
+            tool_span("c" * 16, 1000, '{"query": "auth"}'),
+            tool_span("d" * 16, 2000, '{"query": "auth"}'),
+            tool_span("e" * 16, 3000, '{"path": "src/auth.py"}', name="readFile"),
+            tool_span("f" * 16, 4000, '{"path": "src/auth.py"}', name="readFile"),
+            tool_span("1" * 16, 5000, '{"path": "src/auth.py"}', name="readFile"),
+        ]
+
+        problems = self.find_problems(create_event(spans))
+        assert sorted(problem.evidence_data["tool_name"] for problem in problems) == [
+            "readFile",
+            "searchDocumentation",
+        ]
+        assert len({problem.fingerprint for problem in problems}) == 2
+
+    def test_stays_silent_when_the_sdk_reports_no_tool_input(self) -> None:
+        """Tool input and output are only sent with `send_default_pii`, so this is the default."""
+        spans = [agent_span()]
+        for index, span_id in enumerate(("b", "c", "d")):
+            span = create_span(
+                "gen_ai.execute_tool",
+                1000.0,
+                "execute_tool searchDocumentation",
+                "hash1",
+                data={
+                    "gen_ai.operation.name": "execute_tool",
+                    "gen_ai.tool.name": "searchDocumentation",
+                },
+            )
+            span["span_id"] = span_id * 16
+            spans.append(modify_span_start(span, index * 1000))
+
+        assert self.find_problems(create_event(spans)) == []
+
+    def test_ignores_events_without_agent_spans(self) -> None:
+        spans = [create_span("db", 2000.0, "SELECT * FROM users", "hash3")]
+
+        assert self.find_problems(create_event(spans)) == []
+
+    def test_detection_is_gated_by_the_project_setting(self) -> None:
+        detector = AgentRedundantToolCallsDetector(
+            {**self._settings[AgentRedundantToolCallsDetector.settings_key]}, create_event([])
+        )
+        assert detector.is_creation_allowed() is False
+
+        detector.settings["detection_enabled"] = True
+        assert detector.is_creation_allowed() is True


### PR DESCRIPTION
Adds an issue detector for agent tool loops, built on the `gen_ai.execute_tool` spans we already ingest. It fires when one tool is called repeatedly with equivalent arguments, the results overlap, and nothing in between changed state the agent could see.

```
gen_ai.invoke_agent   research-agent                                       12.4s
├─ gen_ai.chat        gpt-4o                        0.9s   2.1k tokens
├─ gen_ai.execute_tool searchDocumentation          1.4s   {"query": "how do I configure auth"}
├─ gen_ai.chat        gpt-4o                        1.1s   2.4k tokens     <- counted
├─ gen_ai.execute_tool searchDocumentation          1.3s   {"query": "configure auth"}        same docs
├─ gen_ai.chat        gpt-4o                        1.0s   2.6k tokens     <- counted
└─ gen_ai.execute_tool searchDocumentation          1.5s   {"query": "auth configuration"}    same docs

issue: searchDocumentation called 3 times with equivalent arguments
       4.2s of 12.4s (34% of the run), 5.0k tokens on the model calls in between
```

Useful because this is the expensive agent bug and nothing surfaces it today. The trace has the evidence but someone has to read it and count. Fingerprint is the tool name, so it's one issue per broken tool, not one per question a user asked.

Skips retries after a tool errored, polling loops where the last call returned something new, and repeat calls minutes apart.

Needs `gen_ai.tool.input`, which SDKs only send when `send_default_pii` is on. Off by default at both the system rate and the project setting, group type unreleased, frontend toggle is a follow-up.