### PR TITLE
ref(onboarding): Remove SCM Project Details registration

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -181,8 +181,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:onboarding-scm-experiment", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable SCM-first project creation flow
     manager.add("organizations:onboarding-scm-project-creation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Experiment: SCM onboarding project details A/B test
-    manager.add("organizations:onboarding-scm-project-details-experiment", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Experiment: SCM-first project creation wizard A/B test (project creation flow, not new-org onboarding)
     manager.add("organizations:onboarding-scm-project-creation-experiment", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Double-write newly created debug files to Objectstore.


### PR DESCRIPTION
## TLDR

Sentry stops registering and API-exposing the retired `organizations:onboarding-scm-project-details-experiment` feature. The PR contains no frontend or acceptance-test changes.

## Details

This is the registration-only remainder of #120626 after its acceptance coverage moved to a separate test-only PR. Removing the registration is intentionally last in the runtime chain: #120625 must remove and deploy the frontend consumer, then getsentry/sentry-options-automator#8888 must remove and deploy the FlagPole key before this PR merges.

The two-line deletion removes the feature comment and `manager.add` call from `register_temporary_features`. The acceptance split only updates tests to match the existing control path and must land before #120625.

Refs VDY-139
