### PR TITLE
ref(preprod): Remove `preprod-build-distribution-pr-comments` flag gate

### DIFF
--- a/static/app/views/settings/project/preprod/index.tsx
+++ b/static/app/views/settings/project/preprod/index.tsx
@@ -103,9 +103,7 @@ export default function PreprodSettings() {
               docsUrl="https://docs.sentry.io/product/build-distribution/"
               display={PreprodBuildsDisplay.DISTRIBUTION}
             />
-            <Feature features="organizations:preprod-build-distribution-pr-comments">
-              <PrCommentsToggle />
-            </Feature>
+            <PrCommentsToggle />
           </Fragment>
         )}
       </Stack>


### PR DESCRIPTION
Remove the `organizations:preprod-build-distribution-pr-comments` gate in the mobile builds settings. This flag has been fully rolled out to GA in the [automator](https://github.com/getsentry/sentry-options-automator/blob/main/options/default/flagpole.yaml) (rollout 100 for all orgs, created 2026-02-26) and hasn't been touched since, so the build-distribution PR comments toggle now always renders.

Split from the backend removal (#120632) per the frontend/backend deploy split.

---
_Generated by [Claude Code](https://claude.ai/code/session_015zfeAY16VD3vvxfnrqmVcQ)_