### PR TITLE
ref: Support lists in flagpole conditions

### DIFF
--- a/src/flagpole/conditions.py
+++ b/src/flagpole/conditions.py
@@ -9,9 +9,18 @@ from flagpole.evaluation_context import EvaluationContext
 
 class ConditionOperatorKind(str, Enum):
     IN = "in"
-    """Provided a list of values, check if the property value is in the list ov values"""
+    """
+    Provided a list of values, check if the property value is in the list of values.
+
+    When the property is itself a list, the condition matches if any of its
+    entries appears in the list of values.
+    """
 
     NOT_IN = "not_in"
+    """
+    The negation of IN: true when the property value is absent from the list of
+    values. A list-valued property must have no entry in common with it.
+    """
 
     CONTAINS = "contains"
     """Provided a single value, check if the property (a list) is included"""
@@ -87,15 +96,28 @@ class ConditionBase:
                 f"'In' condition value must be a list, but was provided a '{get_type_name(self.value)}'"
                 + f" of segment {segment_name}"
             )
-        if isinstance(condition_property, (list, dict)):
+        if isinstance(condition_property, dict):
             raise ConditionTypeMismatchException(
-                "'In' condition property value must be str | int | float | bool | None, but was provided a"
-                + f"'{get_type_name(self.value)}' of segment {segment_name}"
+                "'In' condition property value must be str | int | float | bool | None, or a list"
+                + f" thereof, but was provided a '{get_type_name(condition_property)}'"
+                + f" of segment {segment_name}"
             )
+
+        candidate_values = create_case_insensitive_set_from_list(self.value)
+
+        # A list-valued property holds several names for one entity, so the
+        # condition matches when the two sets overlap. Plan families use this:
+        # an enterprise subscription reports both "enterprise business" and
+        # "business", letting a config name either one.
+        if isinstance(condition_property, list):
+            return bool(
+                create_case_insensitive_set_from_list(condition_property) & candidate_values
+            )
+
         if isinstance(condition_property, str):
             condition_property = condition_property.lower()
 
-        return condition_property in create_case_insensitive_set_from_list(self.value)
+        return condition_property in candidate_values
 
     def _evaluate_contains(self, condition_property: Any, segment_name: str) -> bool:
         if not isinstance(condition_property, list):

--- a/tests/flagpole/test_conditions.py
+++ b/tests/flagpole/test_conditions.py
@@ -76,17 +76,53 @@ class TestInConditions:
         values = ["bar", "baz"]
         condition = InCondition(property="foo", value=values)
 
-        bad_context = ([1], {"k": "v"})
-        for attr_val in bad_context:
-            with pytest.raises(ConditionTypeMismatchException):
-                condition.match(context=EvaluationContext({"foo": attr_val}), segment_name="test")
+        with pytest.raises(ConditionTypeMismatchException):
+            condition.match(context=EvaluationContext({"foo": {"k": "v"}}), segment_name="test")
 
         not_condition = NotInCondition(property="foo", value=values)
-        for attr_val in bad_context:
-            with pytest.raises(ConditionTypeMismatchException):
-                not_condition.match(
-                    context=EvaluationContext({"foo": attr_val}), segment_name="test"
-                )
+        with pytest.raises(ConditionTypeMismatchException):
+            not_condition.match(context=EvaluationContext({"foo": {"k": "v"}}), segment_name="test")
+
+    def test_is_in_list_property_matches_on_overlap(self) -> None:
+        """A list-valued property carries several names for one entity.
+
+        Used by plan families: an enterprise subscription reports both
+        "enterprise business" and "business", so a config may name either.
+        """
+        values = ["bar", "baz"]
+        condition = InCondition(property="foo", value=values)
+
+        assert condition.match(
+            context=EvaluationContext({"foo": ["bar", "unrelated"]}), segment_name="test"
+        )
+        assert not condition.match(
+            context=EvaluationContext({"foo": ["unrelated", "other"]}), segment_name="test"
+        )
+        assert not condition.match(context=EvaluationContext({"foo": []}), segment_name="test")
+
+    def test_is_not_in_list_property_requires_no_overlap(self) -> None:
+        values = ["bar", "baz"]
+        not_condition = NotInCondition(property="foo", value=values)
+
+        assert not not_condition.match(
+            context=EvaluationContext({"foo": ["bar", "unrelated"]}), segment_name="test"
+        )
+        assert not_condition.match(
+            context=EvaluationContext({"foo": ["unrelated", "other"]}), segment_name="test"
+        )
+        assert not_condition.match(context=EvaluationContext({"foo": []}), segment_name="test")
+
+    def test_is_in_list_property_case_insensitivity(self) -> None:
+        condition = InCondition(property="foo", value=["bAr"])
+        assert condition.match(context=EvaluationContext({"foo": ["BaR"]}), segment_name="test")
+
+    def test_is_in_list_property_no_type_coercion(self) -> None:
+        """Overlap must not coerce, matching the scalar path's behaviour."""
+        condition = InCondition(property="foo", value=["123"])
+        assert not condition.match(context=EvaluationContext({"foo": [123]}), segment_name="test")
+
+        int_condition = InCondition(property="foo", value=[123])
+        assert int_condition.match(context=EvaluationContext({"foo": [123]}), segment_name="test")
 
     def test_missing_context_property(self) -> None:
         values = ["bar", "baz"]


### PR DESCRIPTION
When launching a feature to only business you currently have to write:
```
          - operator: in
            property: subscription_plan-family
            value:
              - business
              - enterprise business
```

This is very error prone, with this change we'll be able to have an enterprise business org in both "business" and "business enterprise" so that both conditions don't have to be listed in the flagpole config

The getsentry PR that will use this list support is here: https://github.com/getsentry/getsentry/pull/21232