### PR TITLE
ref(chat): Use MessageRow gutter in ToolUseBlock, drop redundant spinner slot

### DIFF
--- a/static/app/views/seerExplorer/components/chat/shared.tsx
+++ b/static/app/views/seerExplorer/components/chat/shared.tsx
@@ -68,16 +68,7 @@ export function MessagePlaceholder({content}: {content?: string}) {
   return (
     <MessageRow from="assistant">
       <Flex align="center" gap="md">
-        <Flex
-          display="inline-flex"
-          align="center"
-          justify="center"
-          width="12px"
-          height="12px"
-          flexShrink={0}
-        >
-          <Spinner role="status" aria-label={t('Loading')} />
-        </Flex>
+        <Spinner role="status" aria-label={t('Loading')} />
         {hasValidContent(content) && <SeerMarkdown raw={content} />}
       </Flex>
     </MessageRow>

--- a/static/app/views/seerExplorer/components/chat/toolUse.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.tsx
@@ -1,7 +1,7 @@
 import {useMemo} from 'react';
 import styled from '@emotion/styled';
 
-import {ToolCallIndicator, type ToolCallStatus} from '@sentry/scraps/chat';
+import {MessageRow, ToolCallIndicator, type ToolCallStatus} from '@sentry/scraps/chat';
 import {Checkbox} from '@sentry/scraps/checkbox';
 import {Disclosure} from '@sentry/scraps/disclosure';
 import {Flex, Stack} from '@sentry/scraps/layout';
@@ -36,23 +36,25 @@ export function ToolUseBlock({
   }
 
   return (
-    <Stack padding="md xl" gap="md" minWidth={0} overflow="hidden">
-      {showThinking && hasValidContent(block.message.thinking_content) && (
-        <Disclosure size="sm">
-          <Disclosure.Title>
-            <Text size="sm" variant="muted" monospace>
-              {t('Thinking')}
-            </Text>
-          </Disclosure.Title>
-          <Disclosure.Content>
-            <SeerMarkdown raw={block.message.thinking_content} />
-          </Disclosure.Content>
-        </Disclosure>
-      )}
-      {block.message.tool_calls ? (
-        <ToolCallList block={block} blocks={blocks} getPageReferrer={getPageReferrer} />
-      ) : null}
-    </Stack>
+    <MessageRow from="assistant" density="compact">
+      <Stack gap="md" width="100%" minWidth={0} overflow="hidden">
+        {showThinking && hasValidContent(block.message.thinking_content) && (
+          <Disclosure size="sm">
+            <Disclosure.Title>
+              <Text size="sm" variant="muted" monospace>
+                {t('Thinking')}
+              </Text>
+            </Disclosure.Title>
+            <Disclosure.Content>
+              <SeerMarkdown raw={block.message.thinking_content} />
+            </Disclosure.Content>
+          </Disclosure>
+        )}
+        {block.message.tool_calls ? (
+          <ToolCallList block={block} blocks={blocks} getPageReferrer={getPageReferrer} />
+        ) : null}
+      </Stack>
+    </MessageRow>
   );
 }
 


### PR DESCRIPTION
`ToolUseBlock` set its own `md xl` padding, which is exactly what `MessageRow`'s `compact` density already means, so the gutter now comes from the row primitive instead of being repeated inline.

`MessagePlaceholder` also wrapped its `Spinner` in a 12px centering `Flex` that did nothing — `Spinner` at `xs` is already 12px and does not shrink — so that wrapper is gone.