### PR TITLE
ref(replays): Migrate responsive styles to container queries

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
@@ -126,7 +126,7 @@ function Event({
     max-width: ${tooltipWidth}px !important;
     width: ${tooltipWidth}px;
 
-    @media screen and (max-width: ${theme.breakpoints.sm}) {
+    @container (max-width: ${theme.container.xl}) {
       max-width: ${mobileMaxWidth}px !important;
     }
   `;

--- a/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
@@ -126,7 +126,8 @@ function Event({
     max-width: ${tooltipWidth}px !important;
     width: ${tooltipWidth}px;
 
-    @container (max-width: ${theme.container.xl}) {
+    /* Viewport-based: the tooltip is portaled to the body, so it has no query container. */
+    @media screen and (max-width: ${theme.breakpoints.sm}) {
       max-width: ${mobileMaxWidth}px !important;
     }
   `;

--- a/static/app/components/replays/header/replayMetaData.tsx
+++ b/static/app/components/replays/header/replayMetaData.tsx
@@ -119,10 +119,6 @@ const KeyMetrics = styled('dl')`
   align-items: center;
   color: ${p => p.theme.tokens.content.secondary};
   margin: 0;
-
-  @container (min-width: ${p => p.theme.container['3xl']}) {
-    justify-self: flex-end;
-  }
 `;
 
 const KeyMetricLabel = styled('dt')`

--- a/static/app/components/replays/header/replayMetaData.tsx
+++ b/static/app/components/replays/header/replayMetaData.tsx
@@ -120,7 +120,7 @@ const KeyMetrics = styled('dl')`
   color: ${p => p.theme.tokens.content.secondary};
   margin: 0;
 
-  @media (min-width: ${p => p.theme.breakpoints.md}) {
+  @container (min-width: ${p => p.theme.container['3xl']}) {
     justify-self: flex-end;
   }
 `;

--- a/static/app/components/replays/list/__stories__/replayList.tsx
+++ b/static/app/components/replays/list/__stories__/replayList.tsx
@@ -71,7 +71,7 @@ const NoReplaysWrapper = styled('div')`
   text-align: center;
   color: ${p => p.theme.tokens.content.secondary};
 
-  @media (max-width: ${p => p.theme.breakpoints.sm}) {
+  @container (max-width: ${p => p.theme.container.xl}) {
     font-size: ${p => p.theme.font.size.md};
   }
 `;
@@ -80,7 +80,7 @@ const NoReplaysMessage = styled('div')`
   font-weight: ${p => p.theme.font.weight.sans.medium};
   color: ${p => p.theme.colors.gray500};
 
-  @media (min-width: ${p => p.theme.breakpoints.sm}) {
+  @container (min-width: ${p => p.theme.container.xl}) {
     font-size: ${p => p.theme.font.size.xl};
   }
 `;

--- a/static/app/components/replays/list/__stories__/replayList.tsx
+++ b/static/app/components/replays/list/__stories__/replayList.tsx
@@ -59,14 +59,16 @@ export function ReplayList({onSelect, queryResult}: Props) {
 function NoReplays() {
   return (
     <Container padding="3xl">
-      <Stack align="center" gap="md">
+      <Stack align="center">
         <img src={waitingForEventImg} alt={t('A person waiting for a phone to ring')} />
-        <Text as="div" size={{zero: 'md', xl: 'xl'}} bold variant="secondary">
-          {t('Inbox Zero')}
-        </Text>
-        <Text as="p" size="md" variant="secondary">
-          {t('You have two options: take a nap or be productive.')}
-        </Text>
+        <Stack align="center" gap="md">
+          <Text as="div" size="xl" bold variant="secondary">
+            {t('Inbox Zero')}
+          </Text>
+          <Text as="p" size="md" variant="secondary">
+            {t('You have two options: take a nap or be productive.')}
+          </Text>
+        </Stack>
       </Stack>
     </Container>
   );

--- a/static/app/components/replays/list/__stories__/replayList.tsx
+++ b/static/app/components/replays/list/__stories__/replayList.tsx
@@ -1,10 +1,10 @@
-import styled from '@emotion/styled';
 import type {InfiniteData, UseInfiniteQueryResult} from '@tanstack/react-query';
 import uniqBy from 'lodash/uniqBy';
 
 import waitingForEventImg from 'sentry-images/spot/waiting-for-event.svg';
 
-import {Container} from '@sentry/scraps/layout';
+import {Container, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {ErrorBoundary} from 'sentry/components/errorBoundary';
@@ -58,29 +58,16 @@ export function ReplayList({onSelect, queryResult}: Props) {
 
 function NoReplays() {
   return (
-    <NoReplaysWrapper>
-      <img src={waitingForEventImg} alt={t('A person waiting for a phone to ring')} />
-      <NoReplaysMessage>{t('Inbox Zero')}</NoReplaysMessage>
-      <p>{t('You have two options: take a nap or be productive.')}</p>
-    </NoReplaysWrapper>
+    <Container padding="3xl">
+      <Stack align="center" gap="md">
+        <img src={waitingForEventImg} alt={t('A person waiting for a phone to ring')} />
+        <Text as="div" size={{zero: 'md', xl: 'xl'}} bold variant="secondary">
+          {t('Inbox Zero')}
+        </Text>
+        <Text as="p" size="md" variant="secondary">
+          {t('You have two options: take a nap or be productive.')}
+        </Text>
+      </Stack>
+    </Container>
   );
 }
-
-const NoReplaysWrapper = styled('div')`
-  padding: ${p => p.theme.space['3xl']};
-  text-align: center;
-  color: ${p => p.theme.tokens.content.secondary};
-
-  @container (max-width: ${p => p.theme.container.xl}) {
-    font-size: ${p => p.theme.font.size.md};
-  }
-`;
-
-const NoReplaysMessage = styled('div')`
-  font-weight: ${p => p.theme.font.weight.sans.medium};
-  color: ${p => p.theme.colors.gray500};
-
-  @container (min-width: ${p => p.theme.container.xl}) {
-    font-size: ${p => p.theme.font.size.xl};
-  }
-`;

--- a/static/app/components/replays/table/replayTableColumns.tsx
+++ b/static/app/components/replays/table/replayTableColumns.tsx
@@ -9,7 +9,7 @@ import {PlatformIcon} from 'platformicons';
 import {LinkButton} from '@sentry/scraps/button';
 import {Checkbox} from '@sentry/scraps/checkbox';
 import {InfoText} from '@sentry/scraps/info';
-import {Flex, useResponsivePropValue} from '@sentry/scraps/layout';
+import {Flex} from '@sentry/scraps/layout';
 import {ExternalLink, Link} from '@sentry/scraps/link';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -138,8 +138,6 @@ export const ReplayBrowserColumn: ReplayTableColumn = {
   interactive: false,
   sortKey: 'browser.name',
   Component: ({replay, showDropdownFilters}) => {
-    const isLargeContainer = useResponsivePropValue({zero: false, '4xl': true});
-
     if (replay.is_archived) {
       return null;
     }
@@ -156,10 +154,7 @@ export const ReplayBrowserColumn: ReplayTableColumn = {
       );
     }
 
-    const icon = generatePlatformIconName(
-      name ?? '',
-      version && isLargeContainer ? version : undefined
-    );
+    const icon = generatePlatformIconName(name ?? '', version ?? undefined);
 
     const nameOrUnknown = name ?? t('Unknown');
     const versionOrBlank = version ?? '';
@@ -363,16 +358,11 @@ export const ReplayOSColumn: ReplayTableColumn = {
   interactive: false,
   sortKey: 'os.name',
   Component: ({replay, showDropdownFilters}) => {
-    const isLargeContainer = useResponsivePropValue({zero: false, '4xl': true});
-
     if (replay.is_archived) {
       return null;
     }
     const {name, version} = replay.os;
-    const icon = generatePlatformIconName(
-      name ?? '',
-      version && isLargeContainer ? version : undefined
-    );
+    const icon = generatePlatformIconName(name ?? '', version ?? undefined);
 
     const nameOrUnknown = name ?? t('Unknown');
     const versionOrBlank = version ?? '';

--- a/static/app/components/replays/table/replayTableColumns.tsx
+++ b/static/app/components/replays/table/replayTableColumns.tsx
@@ -9,7 +9,7 @@ import {PlatformIcon} from 'platformicons';
 import {LinkButton} from '@sentry/scraps/button';
 import {Checkbox} from '@sentry/scraps/checkbox';
 import {InfoText} from '@sentry/scraps/info';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, useResponsivePropValue} from '@sentry/scraps/layout';
 import {ExternalLink, Link} from '@sentry/scraps/link';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -37,7 +37,6 @@ import {
 import {generatePlatformIconName} from 'sentry/utils/replays/generatePlatformIconName';
 import {MIN_DEAD_RAGE_CLICK_SDK} from 'sentry/utils/replays/sdkVersions';
 import {useLocation} from 'sentry/utils/useLocation';
-import {useMedia} from 'sentry/utils/useMedia';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjectFromId} from 'sentry/utils/useProjectFromId';
@@ -139,8 +138,7 @@ export const ReplayBrowserColumn: ReplayTableColumn = {
   interactive: false,
   sortKey: 'browser.name',
   Component: ({replay, showDropdownFilters}) => {
-    const theme = useTheme();
-    const isLargeBreakpoint = useMedia(`(min-width: ${theme.breakpoints.lg})`);
+    const isLargeContainer = useResponsivePropValue({zero: false, '4xl': true});
 
     if (replay.is_archived) {
       return null;
@@ -160,7 +158,7 @@ export const ReplayBrowserColumn: ReplayTableColumn = {
 
     const icon = generatePlatformIconName(
       name ?? '',
-      version && isLargeBreakpoint ? version : undefined
+      version && isLargeContainer ? version : undefined
     );
 
     const nameOrUnknown = name ?? t('Unknown');
@@ -365,8 +363,7 @@ export const ReplayOSColumn: ReplayTableColumn = {
   interactive: false,
   sortKey: 'os.name',
   Component: ({replay, showDropdownFilters}) => {
-    const theme = useTheme();
-    const isLargeBreakpoint = useMedia(`(min-width: ${theme.breakpoints.lg})`);
+    const isLargeContainer = useResponsivePropValue({zero: false, '4xl': true});
 
     if (replay.is_archived) {
       return null;
@@ -374,7 +371,7 @@ export const ReplayOSColumn: ReplayTableColumn = {
     const {name, version} = replay.os;
     const icon = generatePlatformIconName(
       name ?? '',
-      version && isLargeBreakpoint ? version : undefined
+      version && isLargeContainer ? version : undefined
     );
 
     const nameOrUnknown = name ?? t('Unknown');


### PR DESCRIPTION
Replay components now respond to the width of their containing surface instead of the viewport. Existing responsive thresholds are mapped to the nearest container-query tokens, and browser/OS icon selection uses the container-scoped responsive value hook.

The reduced-motion media query remains viewport-based because it represents a user media preference rather than available layout width.


