### PR TITLE
feat(dashboards): adjust dashboards columns

### DIFF
--- a/static/app/views/dashboards/manage/dashboardTable.spec.tsx
+++ b/static/app/views/dashboards/manage/dashboardTable.spec.tsx
@@ -305,4 +305,75 @@ describe('Dashboards - DashboardTable', () => {
     await userEvent.click(screen.queryAllByLabelText('Star')[0]!);
     expect(screen.queryAllByLabelText('Unstar')).toHaveLength(2);
   });
+
+  describe('with dashboards-user-last-visited feature flag', () => {
+    const organizationWithLastVisited = OrganizationFixture({
+      features: [
+        'dashboards-basic',
+        'dashboards-edit',
+        'discover-query',
+        'dashboards-user-last-visited',
+      ],
+    });
+
+    let lastVisitedDashboards: DashboardListItem[];
+
+    beforeEach(() => {
+      lastVisitedDashboards = [
+        DashboardListItemFixture({
+          id: '1',
+          title: 'Dashboard With Description',
+          description: 'Some accurate description about this dashboard.',
+          lastVisited: '2021-04-19T13:13:23.962105Z',
+          createdBy: UserFixture({id: '1'}),
+        }),
+        DashboardListItemFixture({
+          id: '2',
+          title: 'Dashboard Without Description',
+          createdBy: UserFixture({id: '1'}),
+        }),
+      ];
+    });
+
+    it('renders the reordered columns', async () => {
+      render(
+        <DashboardTable
+          onDashboardsChange={jest.fn()}
+          organization={organizationWithLastVisited}
+          dashboards={lastVisitedDashboards}
+          location={location}
+        />,
+        {organization: organizationWithLastVisited}
+      );
+
+      const headers = await screen.findAllByTestId('grid-head-cell');
+      expect(headers).toHaveLength(5);
+      expect(headers[0]).toHaveTextContent('Name');
+      expect(headers[1]).toHaveTextContent('Description');
+      expect(headers[2]).toHaveTextContent('Access');
+      expect(headers[3]).toHaveTextContent('Widgets');
+      expect(headers[4]).toHaveTextContent('Last Visited');
+
+      // Owner and Created columns are removed when the flag is on
+      // TODO: these can be removed once FF is cleaned up
+      expect(screen.queryByText('Owner')).not.toBeInTheDocument();
+      expect(screen.queryByText('Created')).not.toBeInTheDocument();
+    });
+
+    it('renders the description column', async () => {
+      render(
+        <DashboardTable
+          onDashboardsChange={jest.fn()}
+          organization={organizationWithLastVisited}
+          dashboards={lastVisitedDashboards}
+          location={location}
+        />,
+        {organization: organizationWithLastVisited}
+      );
+
+      expect(
+        await screen.findByText('Some accurate description about this dashboard.')
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/static/app/views/dashboards/manage/dashboardTable.spec.tsx
+++ b/static/app/views/dashboards/manage/dashboardTable.spec.tsx
@@ -385,15 +385,16 @@ describe('Dashboards - DashboardTable', () => {
       );
 
       const headers = await screen.findAllByTestId('grid-head-cell');
-      expect(headers).toHaveLength(5);
+      expect(headers).toHaveLength(4);
       expect(headers[0]).toHaveTextContent('Name');
       expect(headers[1]).toHaveTextContent('Description');
       expect(headers[2]).toHaveTextContent('Widgets');
-      expect(headers[3]).toHaveTextContent('Access');
-      expect(headers[4]).toHaveTextContent('Last Visited');
+      expect(headers[3]).toHaveTextContent('Last Visited');
 
+      // Owner, Created, and Access are omitted from the Sentry Built view
       expect(screen.queryByText('Owner')).not.toBeInTheDocument();
       expect(screen.queryByText('Created')).not.toBeInTheDocument();
+      expect(screen.queryByText('Access')).not.toBeInTheDocument();
     });
 
     it('renders the description column', async () => {

--- a/static/app/views/dashboards/manage/dashboardTable.spec.tsx
+++ b/static/app/views/dashboards/manage/dashboardTable.spec.tsx
@@ -111,6 +111,7 @@ describe('Dashboards - DashboardTable', () => {
         organization={organization}
         dashboards={[]}
         location={location}
+        isOnlyPrebuilt={false}
       />
     );
 
@@ -127,6 +128,7 @@ describe('Dashboards - DashboardTable', () => {
         organization={organization}
         dashboards={dashboards}
         location={location}
+        isOnlyPrebuilt={false}
       />
     );
 
@@ -141,6 +143,7 @@ describe('Dashboards - DashboardTable', () => {
         organization={organization}
         dashboards={dashboards}
         location={location}
+        isOnlyPrebuilt={false}
       />
     );
 
@@ -164,6 +167,7 @@ describe('Dashboards - DashboardTable', () => {
           ...LocationFixture(),
           query: {sort: 'title', query: 'agent', statsPeriod: '7d'},
         }}
+        isOnlyPrebuilt={false}
       />
     );
 
@@ -180,6 +184,7 @@ describe('Dashboards - DashboardTable', () => {
         dashboards={dashboards}
         location={{...LocationFixture(), query: {}}}
         onDashboardsChange={dashboardUpdateMock}
+        isOnlyPrebuilt={false}
       />
     );
     renderGlobalModal();
@@ -205,6 +210,7 @@ describe('Dashboards - DashboardTable', () => {
         dashboards={dashboards}
         location={{...LocationFixture(), query: {}}}
         onDashboardsChange={dashboardUpdateMock}
+        isOnlyPrebuilt={false}
       />
     );
     renderGlobalModal();
@@ -236,6 +242,7 @@ describe('Dashboards - DashboardTable', () => {
         dashboards={dashboards}
         location={{...LocationFixture(), query: {}}}
         onDashboardsChange={dashboardUpdateMock}
+        isOnlyPrebuilt={false}
       />
     );
     renderGlobalModal();
@@ -266,6 +273,7 @@ describe('Dashboards - DashboardTable', () => {
         organization={organizationWithEditAccess}
         dashboards={dashboards}
         location={location}
+        isOnlyPrebuilt={false}
       />
     );
 
@@ -292,6 +300,7 @@ describe('Dashboards - DashboardTable', () => {
         organization={organizationWithFavorite}
         dashboards={dashboards}
         location={location}
+        isOnlyPrebuilt={false}
       />,
       {
         organization: organizationWithFavorite,
@@ -335,13 +344,42 @@ describe('Dashboards - DashboardTable', () => {
       ];
     });
 
-    it('renders the reordered columns', async () => {
+    it('renders all columns in the default view', async () => {
       render(
         <DashboardTable
           onDashboardsChange={jest.fn()}
           organization={organizationWithLastVisited}
           dashboards={lastVisitedDashboards}
           location={location}
+          isOnlyPrebuilt={false}
+        />,
+        {organization: organizationWithLastVisited}
+      );
+
+      const headers = await screen.findAllByTestId('grid-head-cell');
+      expect(headers).toHaveLength(6);
+      expect(headers[0]).toHaveTextContent('Name');
+      expect(headers[1]).toHaveTextContent('Widgets');
+      expect(headers[2]).toHaveTextContent('Owner');
+      expect(headers[3]).toHaveTextContent('Access');
+      expect(headers[4]).toHaveTextContent('Created');
+      expect(headers[5]).toHaveTextContent('Last Visited');
+      // Description is only shown in the Sentry Built view
+      expect(screen.queryByText('Description')).not.toBeInTheDocument();
+
+      expect(screen.getAllByTestId('dashboard-delete')).toHaveLength(
+        lastVisitedDashboards.length
+      );
+    });
+
+    it('renders Sentry Built columns with Description instead of Owner/Created', async () => {
+      render(
+        <DashboardTable
+          onDashboardsChange={jest.fn()}
+          organization={organizationWithLastVisited}
+          dashboards={lastVisitedDashboards}
+          location={location}
+          isOnlyPrebuilt
         />,
         {organization: organizationWithLastVisited}
       );
@@ -350,12 +388,10 @@ describe('Dashboards - DashboardTable', () => {
       expect(headers).toHaveLength(5);
       expect(headers[0]).toHaveTextContent('Name');
       expect(headers[1]).toHaveTextContent('Description');
-      expect(headers[2]).toHaveTextContent('Access');
-      expect(headers[3]).toHaveTextContent('Widgets');
+      expect(headers[2]).toHaveTextContent('Widgets');
+      expect(headers[3]).toHaveTextContent('Access');
       expect(headers[4]).toHaveTextContent('Last Visited');
 
-      // Owner and Created columns are removed when the flag is on
-      // TODO: these can be removed once FF is cleaned up
       expect(screen.queryByText('Owner')).not.toBeInTheDocument();
       expect(screen.queryByText('Created')).not.toBeInTheDocument();
     });
@@ -367,6 +403,7 @@ describe('Dashboards - DashboardTable', () => {
           organization={organizationWithLastVisited}
           dashboards={lastVisitedDashboards}
           location={location}
+          isOnlyPrebuilt
         />,
         {organization: organizationWithLastVisited}
       );

--- a/static/app/views/dashboards/manage/dashboardTable.tsx
+++ b/static/app/views/dashboards/manage/dashboardTable.tsx
@@ -165,7 +165,9 @@ function DashboardTable({
         ...(isOnlyPrebuilt
           ? []
           : [{key: ResponseKeys.OWNER, name: t('Owner'), width: COL_WIDTH_UNDEFINED}]),
-        {key: ResponseKeys.ACCESS, name: t('Access'), width: COL_WIDTH_UNDEFINED},
+        ...(isOnlyPrebuilt
+          ? []
+          : [{key: ResponseKeys.ACCESS, name: t('Access'), width: COL_WIDTH_UNDEFINED}]),
         ...(isOnlyPrebuilt
           ? []
           : [

--- a/static/app/views/dashboards/manage/dashboardTable.tsx
+++ b/static/app/views/dashboards/manage/dashboardTable.tsx
@@ -69,7 +69,7 @@ const SortKeys = {
   title: {asc: 'title', desc: '-title'},
   dateCreated: {asc: 'dateCreated', desc: '-dateCreated'},
   createdBy: {asc: 'mydashboards', desc: 'mydashboards'},
-  lastVisited: {asc: 'recentlyViewed', desc: '-recentlyViewed'},
+  lastVisited: {asc: '-recentlyViewed', desc: 'recentlyViewed'},
 };
 
 type FavoriteButtonProps = {
@@ -145,6 +145,9 @@ function DashboardTable({
     'dashboards-user-last-visited'
   );
 
+  // TODO: When `dashboards-user-last-visited` is fully rolled out, delete the
+  // flag-off `columnOrder` branch below, the `createdBy` SortKeys entry and its
+  // special case in `renderHeadCell`, and the `mydashboards` default/fallback.
   const columnOrder: Array<GridColumnOrder<ResponseKeys>> = hasUserLastVisited
     ? [
         {key: ResponseKeys.NAME, name: t('Name'), width: COL_WIDTH_UNDEFINED},
@@ -228,19 +231,16 @@ function DashboardTable({
 
   function renderHeadCell(column: GridColumnOrder<string>) {
     if (column.key in SortKeys) {
+      const sortKey = SortKeys[column.key as keyof typeof SortKeys];
       const urlSort = decodeScalar(
         location.query.sort,
         hasUserLastVisited ? 'recentlyViewed' : 'mydashboards'
       );
-      const isCurrentSort =
-        // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-        urlSort === SortKeys[column.key].asc || urlSort === SortKeys[column.key].desc;
+      const currentDirection =
+        urlSort === sortKey.asc ? 'asc' : urlSort === sortKey.desc ? 'desc' : undefined;
+      const isCurrentSort = currentDirection !== undefined;
       const sortDirection =
-        !isCurrentSort || column.key === 'createdBy'
-          ? undefined
-          : urlSort.startsWith('-')
-            ? 'desc'
-            : 'asc';
+        !isCurrentSort || column.key === 'createdBy' ? undefined : currentDirection;
 
       return (
         <SortLink
@@ -249,14 +249,8 @@ function DashboardTable({
           direction={sortDirection}
           canSort
           generateSortLink={() => {
-            const newSort = isCurrentSort
-              ? sortDirection === 'asc'
-                ? // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-                  SortKeys[column.key].desc
-                : // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-                  SortKeys[column.key].asc
-              : // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-                SortKeys[column.key].asc;
+            const newSort =
+              isCurrentSort && currentDirection === 'asc' ? sortKey.desc : sortKey.asc;
             return {
               ...location,
               query: {...location.query, sort: newSort},

--- a/static/app/views/dashboards/manage/dashboardTable.tsx
+++ b/static/app/views/dashboards/manage/dashboardTable.tsx
@@ -48,6 +48,7 @@ import {PREBUILT_DASHBOARD_LABEL} from 'sentry/views/dashboards/types';
 type Props = {
   api: Client;
   dashboards: DashboardListItem[] | undefined;
+  isOnlyPrebuilt: boolean;
   location: Location;
   onDashboardsChange: () => void;
   organization: Organization;
@@ -69,7 +70,6 @@ const SortKeys = {
   title: {asc: 'title', desc: '-title'},
   dateCreated: {asc: 'dateCreated', desc: '-dateCreated'},
   createdBy: {asc: 'mydashboards', desc: 'mydashboards'},
-  lastVisited: {asc: '-recentlyViewed', desc: 'recentlyViewed'},
 };
 
 type FavoriteButtonProps = {
@@ -134,6 +134,7 @@ function DashboardTable({
   dashboards,
   onDashboardsChange,
   isLoading,
+  isOnlyPrebuilt,
 }: Props) {
   const handleDuplicateDashboard = useDuplicateDashboard({
     onSuccess: onDashboardsChange,
@@ -151,13 +152,25 @@ function DashboardTable({
   const columnOrder: Array<GridColumnOrder<ResponseKeys>> = hasUserLastVisited
     ? [
         {key: ResponseKeys.NAME, name: t('Name'), width: COL_WIDTH_UNDEFINED},
-        {
-          key: ResponseKeys.DESCRIPTION,
-          name: t('Description'),
-          width: COL_WIDTH_UNDEFINED,
-        },
-        {key: ResponseKeys.ACCESS, name: t('Access'), width: COL_WIDTH_UNDEFINED},
+        ...(isOnlyPrebuilt
+          ? [
+              {
+                key: ResponseKeys.DESCRIPTION,
+                name: t('Description'),
+                width: COL_WIDTH_UNDEFINED,
+              },
+            ]
+          : []),
         {key: ResponseKeys.WIDGETS, name: t('Widgets'), width: COL_WIDTH_UNDEFINED},
+        ...(isOnlyPrebuilt
+          ? []
+          : [{key: ResponseKeys.OWNER, name: t('Owner'), width: COL_WIDTH_UNDEFINED}]),
+        {key: ResponseKeys.ACCESS, name: t('Access'), width: COL_WIDTH_UNDEFINED},
+        ...(isOnlyPrebuilt
+          ? []
+          : [
+              {key: ResponseKeys.CREATED, name: t('Created'), width: COL_WIDTH_UNDEFINED},
+            ]),
         {
           key: ResponseKeys.LAST_VISITED,
           name: t('Last Visited'),
@@ -165,6 +178,7 @@ function DashboardTable({
         },
       ]
     : [
+        // Legacy layout; delete this when hasUserLastVisited is cleaned up
         {key: ResponseKeys.NAME, name: t('Name'), width: COL_WIDTH_UNDEFINED},
         {key: ResponseKeys.WIDGETS, name: t('Widgets'), width: COL_WIDTH_UNDEFINED},
         {key: ResponseKeys.OWNER, name: t('Owner'), width: COL_WIDTH_UNDEFINED},
@@ -332,6 +346,8 @@ function DashboardTable({
       );
     }
 
+    // TODO: only last visited will show renderActions. Delete ternary below
+    // when hasUserLastVisited is cleaned up.
     if (column.key === ResponseKeys.CREATED) {
       return (
         <Flex justify="between" align="center" gap="3xl">
@@ -344,13 +360,11 @@ function DashboardTable({
               <DateStatus />
             )}
           </DateSelected>
-          {renderActions(dataRow)}
+          {hasUserLastVisited ? undefined : renderActions(dataRow)}
         </Flex>
       );
     }
 
-    // TODO: last visited and description will replace created and owner. Delete
-    // fields after FF is cleaned up.
     if (column.key === ResponseKeys.LAST_VISITED && hasUserLastVisited) {
       return (
         <Flex justify="between" align="center" gap="3xl">

--- a/static/app/views/dashboards/manage/dashboardTable.tsx
+++ b/static/app/views/dashboards/manage/dashboardTable.tsx
@@ -61,12 +61,15 @@ enum ResponseKeys {
   ACCESS = 'permissions',
   CREATED = 'dateCreated',
   FAVORITE = 'isFavorited',
+  DESCRIPTION = 'description',
+  LAST_VISITED = 'lastVisited',
 }
 
 const SortKeys = {
   title: {asc: 'title', desc: '-title'},
   dateCreated: {asc: 'dateCreated', desc: '-dateCreated'},
   createdBy: {asc: 'mydashboards', desc: 'mydashboards'},
+  lastVisited: {asc: 'recentlyViewed', desc: '-recentlyViewed'},
 };
 
 type FavoriteButtonProps = {
@@ -138,17 +141,97 @@ function DashboardTable({
   const handleDeleteDashboard = useDeleteDashboard({
     onSuccess: onDashboardsChange,
   });
-  const columnOrder: Array<GridColumnOrder<ResponseKeys>> = [
-    {key: ResponseKeys.NAME, name: t('Name'), width: COL_WIDTH_UNDEFINED},
-    {key: ResponseKeys.WIDGETS, name: t('Widgets'), width: COL_WIDTH_UNDEFINED},
-    {key: ResponseKeys.OWNER, name: t('Owner'), width: COL_WIDTH_UNDEFINED},
-    {key: ResponseKeys.ACCESS, name: t('Access'), width: COL_WIDTH_UNDEFINED},
-    {key: ResponseKeys.CREATED, name: t('Created'), width: COL_WIDTH_UNDEFINED},
-  ];
+  const hasUserLastVisited = organization.features.includes(
+    'dashboards-user-last-visited'
+  );
+
+  const columnOrder: Array<GridColumnOrder<ResponseKeys>> = hasUserLastVisited
+    ? [
+        {key: ResponseKeys.NAME, name: t('Name'), width: COL_WIDTH_UNDEFINED},
+        {
+          key: ResponseKeys.DESCRIPTION,
+          name: t('Description'),
+          width: COL_WIDTH_UNDEFINED,
+        },
+        {key: ResponseKeys.ACCESS, name: t('Access'), width: COL_WIDTH_UNDEFINED},
+        {key: ResponseKeys.WIDGETS, name: t('Widgets'), width: COL_WIDTH_UNDEFINED},
+        {
+          key: ResponseKeys.LAST_VISITED,
+          name: t('Last Visited'),
+          width: COL_WIDTH_UNDEFINED,
+        },
+      ]
+    : [
+        {key: ResponseKeys.NAME, name: t('Name'), width: COL_WIDTH_UNDEFINED},
+        {key: ResponseKeys.WIDGETS, name: t('Widgets'), width: COL_WIDTH_UNDEFINED},
+        {key: ResponseKeys.OWNER, name: t('Owner'), width: COL_WIDTH_UNDEFINED},
+        {key: ResponseKeys.ACCESS, name: t('Access'), width: COL_WIDTH_UNDEFINED},
+        {key: ResponseKeys.CREATED, name: t('Created'), width: COL_WIDTH_UNDEFINED},
+      ];
+
+  const renderActions = (dataRow: DashboardListItem) => {
+    return (
+      <Flex gap="xs">
+        <DashboardCreateLimitWrapper>
+          {({
+            hasReachedDashboardLimit,
+            isLoading: isLoadingDashboardsLimit,
+            limitMessage,
+          }) => (
+            <StyledButton
+              onClick={e => {
+                e.stopPropagation();
+                openConfirmModal({
+                  message: t('Are you sure you want to duplicate this dashboard?'),
+                  priority: 'primary',
+                  onConfirm: () => handleDuplicateDashboard(dataRow, 'table'),
+                });
+              }}
+              variant="transparent"
+              aria-label={t('Duplicate Dashboard')}
+              data-test-id="dashboard-duplicate"
+              icon={<IconCopy />}
+              size="sm"
+              disabled={hasReachedDashboardLimit || isLoadingDashboardsLimit}
+              tooltipProps={{
+                title: limitMessage,
+              }}
+            />
+          )}
+        </DashboardCreateLimitWrapper>
+        <StyledButton
+          onClick={e => {
+            e.stopPropagation();
+            openConfirmModal({
+              message: t('Are you sure you want to delete this dashboard?'),
+              priority: 'danger',
+              onConfirm: () => handleDeleteDashboard(dataRow, 'table'),
+            });
+          }}
+          variant="transparent"
+          aria-label={t('Delete Dashboard')}
+          data-test-id="dashboard-delete"
+          icon={<IconDelete />}
+          size="sm"
+          disabled={defined(dataRow.prebuiltId)}
+          tooltipProps={{
+            title: defined(dataRow.prebuiltId)
+              ? tct('[label] dashboards cannot be deleted', {
+                  label: PREBUILT_DASHBOARD_LABEL,
+                })
+              : undefined,
+          }}
+        />
+      </Flex>
+    );
+  };
 
   function renderHeadCell(column: GridColumnOrder<string>) {
     if (column.key in SortKeys) {
-      const urlSort = decodeScalar(location.query.sort, 'mydashboards');
+      const urlSort = decodeScalar(
+        location.query.sort,
+        hasUserLastVisited ? 'recentlyViewed' : 'mydashboards'
+      );
       const isCurrentSort =
         // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
         urlSort === SortKeys[column.key].asc || urlSort === SortKeys[column.key].desc;
@@ -267,60 +350,32 @@ function DashboardTable({
               <DateStatus />
             )}
           </DateSelected>
-          <Flex gap="xs">
-            <DashboardCreateLimitWrapper>
-              {({
-                hasReachedDashboardLimit,
-                isLoading: isLoadingDashboardsLimit,
-                limitMessage,
-              }) => (
-                <StyledButton
-                  onClick={e => {
-                    e.stopPropagation();
-                    openConfirmModal({
-                      message: t('Are you sure you want to duplicate this dashboard?'),
-                      priority: 'primary',
-                      onConfirm: () => handleDuplicateDashboard(dataRow, 'table'),
-                    });
-                  }}
-                  variant="transparent"
-                  aria-label={t('Duplicate Dashboard')}
-                  data-test-id="dashboard-duplicate"
-                  icon={<IconCopy />}
-                  size="sm"
-                  disabled={hasReachedDashboardLimit || isLoadingDashboardsLimit}
-                  tooltipProps={{
-                    title: limitMessage,
-                  }}
-                />
-              )}
-            </DashboardCreateLimitWrapper>
-            <StyledButton
-              onClick={e => {
-                e.stopPropagation();
-                openConfirmModal({
-                  message: t('Are you sure you want to delete this dashboard?'),
-                  priority: 'danger',
-                  onConfirm: () => handleDeleteDashboard(dataRow, 'table'),
-                });
-              }}
-              variant="transparent"
-              aria-label={t('Delete Dashboard')}
-              data-test-id="dashboard-delete"
-              icon={<IconDelete />}
-              size="sm"
-              disabled={defined(dataRow.prebuiltId)}
-              tooltipProps={{
-                title: defined(dataRow.prebuiltId)
-                  ? tct('[label] dashboards cannot be deleted', {
-                      label: PREBUILT_DASHBOARD_LABEL,
-                    })
-                  : undefined,
-              }}
-            />
-          </Flex>
+          {renderActions(dataRow)}
         </Flex>
       );
+    }
+
+    // TODO: last visited and description will replace created and owner. Delete
+    // fields after FF is cleaned up.
+    if (column.key === ResponseKeys.LAST_VISITED && hasUserLastVisited) {
+      return (
+        <Flex justify="between" align="center" gap="3xl">
+          <DateSelected>
+            {dataRow[ResponseKeys.LAST_VISITED] ? (
+              <DateStatus>
+                <TimeSince date={dataRow[ResponseKeys.LAST_VISITED]} />
+              </DateStatus>
+            ) : (
+              <DateStatus />
+            )}
+          </DateSelected>
+          {renderActions(dataRow)}
+        </Flex>
+      );
+    }
+
+    if (column.key === ResponseKeys.DESCRIPTION && hasUserLastVisited) {
+      return <Text ellipsis>{dataRow.description}</Text>;
     }
 
     // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message

--- a/static/app/views/dashboards/manage/index.spec.tsx
+++ b/static/app/views/dashboards/manage/index.spec.tsx
@@ -165,6 +165,30 @@ describe('Dashboards > Detail', () => {
     );
   });
 
+  it('defaults to recently viewed sort with dashboards-user-last-visited', async () => {
+    const org = OrganizationFixture({
+      features: [...FEATURES, 'dashboards-user-last-visited'],
+    });
+    mockUseNavigate.mockReturnValue(jest.fn());
+
+    const request = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/dashboards/',
+      body: [DashboardListItemFixture({title: 'Test Dashboard'})],
+    });
+
+    render(<ManageDashboards />, {
+      organization: org,
+    });
+
+    expect(await screen.findByText('Test Dashboard')).toBeInTheDocument();
+    expect(request).toHaveBeenCalledWith(
+      '/organizations/org-slug/dashboards/',
+      expect.objectContaining({
+        query: expect.objectContaining({sort: 'recentlyViewed'}),
+      })
+    );
+  });
+
   it('can search', async () => {
     const org = OrganizationFixture({features: FEATURES});
     const mockNavigate = jest.fn();

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -44,31 +44,49 @@ import {RouteError} from 'sentry/views/routeError';
 
 import {DASHBOARD_TABLE_NUM_ROWS, DEFAULT_PREBUILT_SORT} from './settings';
 
-function getSortOptions({isOnlyPrebuilt}: {isOnlyPrebuilt: boolean}) {
+function getSortOptions({
+  isOnlyPrebuilt,
+  hasUserLastVisited,
+}: {
+  hasUserLastVisited: boolean;
+  isOnlyPrebuilt: boolean;
+}) {
   const options = [];
 
   if (!isOnlyPrebuilt) {
     options.push({label: t('My Dashboards'), value: 'mydashboards'});
   }
-
   options.push(
     {label: t('Dashboard Name (A-Z)'), value: 'title'},
-    {label: t('Dashboard Name (Z-A)'), value: '-title'},
-    {label: t('Date Created (Newest)'), value: '-dateCreated'},
-    {label: t('Date Created (Oldest)'), value: 'dateCreated'},
+    {label: t('Dashboard Name (Z-A)'), value: '-title'}
+  );
+  if (!hasUserLastVisited) {
+    options.push(
+      {label: t('Date Created (Newest)'), value: '-dateCreated'},
+      {label: t('Date Created (Oldest)'), value: 'dateCreated'}
+    );
+  }
+  options.push(
     {label: t('Most Popular'), value: 'mostPopular'},
-    {label: t('Recently Viewed'), value: 'recentlyViewed'}
+    {label: t('Recently Viewed (Newest)'), value: 'recentlyViewed'},
+    {label: t('Recently Viewed (Oldest)'), value: '-recentlyViewed'}
   );
 
   return options;
 }
 
-function getDefaultSort({isOnlyPrebuilt}: {isOnlyPrebuilt: boolean}) {
-  if (isOnlyPrebuilt) {
+function getDefaultSort({
+  isOnlyPrebuilt,
+  hasUserLastVisited,
+}: {
+  hasUserLastVisited: boolean;
+  isOnlyPrebuilt: boolean;
+}) {
+  if (isOnlyPrebuilt && !hasUserLastVisited) {
     return DEFAULT_PREBUILT_SORT;
   }
 
-  return 'mydashboards';
+  return hasUserLastVisited ? 'recentlyViewed' : 'mydashboards';
 }
 
 function ManageDashboards() {
@@ -89,7 +107,10 @@ function ManageDashboards() {
 
   const {hasProjectAccess, projectsLoaded} = useHasProjectAccess();
 
-  const sortOptions = getSortOptions({isOnlyPrebuilt});
+  const hasUserLastVisited = organization.features.includes(
+    'dashboards-user-last-visited'
+  );
+  const sortOptions = getSortOptions({isOnlyPrebuilt, hasUserLastVisited});
 
   const {
     data: dashboardsResponse,
@@ -130,6 +151,7 @@ function ManageDashboards() {
                 layout: widget.layout ?? null,
               })
             ),
+            description: PREBUILT_DASHBOARDS[dashboard.prebuiltId].description,
             projects: [],
           };
         }
@@ -142,7 +164,7 @@ function ManageDashboards() {
 
   useEffect(() => {
     const urlSort = decodeScalar(location.query.sort);
-    const defaultSort = getDefaultSort({isOnlyPrebuilt});
+    const defaultSort = getDefaultSort({isOnlyPrebuilt, hasUserLastVisited});
     if (urlSort && !sortOptions.some(option => option.value === urlSort)) {
       // The sort option is not valid, so we need to set the default sort
       // in the URL
@@ -158,10 +180,11 @@ function ManageDashboards() {
     navigate,
     organization,
     sortOptions,
+    hasUserLastVisited,
   ]);
 
   function getActiveSort() {
-    const defaultSort = getDefaultSort({isOnlyPrebuilt});
+    const defaultSort = getDefaultSort({isOnlyPrebuilt, hasUserLastVisited});
     const urlSort = decodeScalar(location.query.sort, defaultSort);
 
     if (urlSort) {

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -60,7 +60,7 @@ function getSortOptions({
     {label: t('Dashboard Name (A-Z)'), value: 'title'},
     {label: t('Dashboard Name (Z-A)'), value: '-title'}
   );
-  if (!hasUserLastVisited) {
+  if (!hasUserLastVisited || !isOnlyPrebuilt) {
     options.push(
       {label: t('Date Created (Newest)'), value: '-dateCreated'},
       {label: t('Date Created (Oldest)'), value: 'dateCreated'}

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -68,8 +68,7 @@ function getSortOptions({
   }
   options.push(
     {label: t('Most Popular'), value: 'mostPopular'},
-    {label: t('Recently Viewed (Newest)'), value: 'recentlyViewed'},
-    {label: t('Recently Viewed (Oldest)'), value: '-recentlyViewed'}
+    {label: t('Recently Viewed'), value: 'recentlyViewed'}
   );
 
   return options;
@@ -345,6 +344,7 @@ function ManageDashboards() {
         location={location}
         onDashboardsChange={invalidateDashboards}
         isLoading={isLoading}
+        isOnlyPrebuilt={isOnlyPrebuilt}
       />
     );
   }

--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -205,6 +205,7 @@ export type DashboardListItem = {
   widgetPreview: WidgetPreview[];
   createdBy?: User;
   dateCreated?: string;
+  description?: string;
   isFavorited?: boolean;
   lastVisited?: string;
   permissions?: DashboardPermissions;

--- a/static/app/views/navigation/secondary/sections/dashboards/dashboardsSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/dashboards/dashboardsSecondaryNavigation.tsx
@@ -30,6 +30,9 @@ export function DashboardsSecondaryNavigation() {
   const hasPrebuiltDashboards = organization.features.includes(
     'dashboards-prebuilt-insights-dashboards'
   );
+  const hasUserLastVisited = organization.features.includes(
+    'dashboards-user-last-visited'
+  );
   const urlFilter = decodeScalar(location.query.filter) as DashboardFilter | undefined;
   const isOnlyPrebuilt = getIsOnlyPrebuilt(hasPrebuiltDashboards, urlFilter);
   const isOnDashboardsList = isPrimaryNavigationLinkActive(
@@ -59,7 +62,11 @@ export function DashboardsSecondaryNavigation() {
             {hasPrebuiltDashboards ? (
               <SecondaryNavigation.ListItem>
                 <SecondaryNavigation.Link
-                  to={`${baseUrl}/?filter=${DashboardFilter.ONLY_PREBUILT}&sort=${DEFAULT_PREBUILT_SORT}`}
+                  to={
+                    hasUserLastVisited
+                      ? `${baseUrl}/?filter=${DashboardFilter.ONLY_PREBUILT}`
+                      : `${baseUrl}/?filter=${DashboardFilter.ONLY_PREBUILT}&sort=${DEFAULT_PREBUILT_SORT}`
+                  }
                   isActive={isOnDashboardsList && isOnlyPrebuilt}
                   analyticsItemName="dashboards_sentry_built"
                 >


### PR DESCRIPTION
This PR adjusts the columns of the tables shown in the dashboards tabs. Specifically, we're adding the `last visited` column to both all and sentry built dashboard tables, `description` only on sentry built, and removing `access` to sentry built. The descriptions were added in a [previous PR](https://github.com/getsentry/sentry/pull/120540) but not implemented in the tables themselves. The `last visited` backend logic was adjusted in a [previous pr](https://github.com/getsentry/sentry/pull/120286) to be a last visited by user, instead of by org. As well, the sorting has been defaulted to recently visited (by person). All of this is currently feature flagged.

Before
<img width="1431" height="366" alt="Screenshot 2026-07-27 at 1 59 06 PM" src="https://github.com/user-attachments/assets/06b06681-6765-4192-b27c-7be9d7922197" />

After
<img width="1423" height="345" alt="Screenshot 2026-07-28 at 7 18 14 PM" src="https://github.com/user-attachments/assets/a875f33b-5f21-4c76-88c9-705824513288" />

<img width="1427" height="495" alt="Screenshot 2026-07-27 at 5 42 10 PM" src="https://github.com/user-attachments/assets/c9e8562c-0b2a-47f3-9d21-52030d80e207" />

* As noted in previous PRs: a) at the moment, custom dashboards don't have a description, only prebuilt dashboards, hence that column only shows in the sentry built page - that may change in the future, and b) the starred dashboards take sorting precedence over non-starred ones.

Closes BROWSE-634 and BROWSE-636