### PR TITLE
fix(issues): Prevent scroll chaining to the page in inbox and feedback

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -202,6 +202,7 @@ function FeedbackItemContexts({
 
 const OverflowPanelItem = styled(PanelItem)`
   overflow: auto;
+  overscroll-behavior: contain;
 
   flex-direction: column;
   flex-grow: 1;

--- a/static/app/views/feedback/feedbackListPage.tsx
+++ b/static/app/views/feedback/feedbackListPage.tsx
@@ -229,7 +229,7 @@ export default function FeedbackListPage() {
 
   return (
     <SentryDocumentTitle title={t('User Feedback')} orgSlug={organization.slug}>
-      <Stack flex={1} contain="size">
+      <Stack flex={1} minHeight={0} contain="size" overflow="hidden">
         <FeedbackApiOptions organization={organization}>
           <TopBar.Slot name="title">{titleContent}</TopBar.Slot>
           <TopBar.Slot name="feedback">

--- a/static/app/views/issueDetails/issuePreview/issuePreview.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreview.tsx
@@ -67,7 +67,13 @@ export function IssuePreview({groupId}: IssuePreviewProps) {
           ) : null}
         </Flex>
       </Container>
-      <Container flexGrow={1} minHeight={0} overflowY="auto" padding="lg 2xl">
+      <Container
+        flexGrow={1}
+        minHeight={0}
+        overflowY="auto"
+        overscrollBehavior="contain"
+        padding="lg 2xl"
+      >
         {isPending && <LoadingIndicator />}
         {isError && <LoadingError />}
         {group && project && (

--- a/static/app/views/issueList/pages/inbox.tsx
+++ b/static/app/views/issueList/pages/inbox.tsx
@@ -144,7 +144,7 @@ function InboxContent() {
               </SegmentedControl.Item>
             </SegmentedControl>
           </Flex>
-          <Stack flex={1} minHeight={0} overflowY="auto">
+          <Stack flex={1} minHeight={0} overflowY="auto" overscrollBehavior="contain">
             {SECTIONS.map(section => (
               <InboxSection
                 key={section.key}


### PR DESCRIPTION
Scrolling inside either pane of the inbox could shift the whole page down. Both the inbox and the feedback list lock themselves to the viewport with `contain: size`, but their inner scroll panes allowed scroll chaining — once a pane reached its scroll end, further wheel events propagated to the document, which still has `min-height: 100vh` and a small residual scrollable height. The issue preview pane hits this most easily since its activity feed is long.

`overscroll-behavior: contain` now stops that propagation on the inbox issue list, the issue preview pane, and the feedback item detail pane. The feedback list's own scroller already had it, which is why only its detail side leaked.

The feedback page root also picks up the `min-height: 0` and `overflow: hidden` that the inbox root already has. Without `min-height: 0` a `contain: size` flex child can't shrink below its flex base size, so it can overhang the viewport independently of scroll chaining.

fixes ISWF-3122
