### PR TITLE
ref(issues): Rename progress state display labels

### DIFF
--- a/static/app/views/issueDetails/actions/statusBanner.spec.tsx
+++ b/static/app/views/issueDetails/actions/statusBanner.spec.tsx
@@ -27,7 +27,7 @@ describe('StatusBanner', () => {
     );
 
     expect(screen.getByText('Resolved')).toBeInTheDocument();
-    expect(screen.getByRole('img', {name: 'Fix Applied'})).toBeInTheDocument();
+    expect(screen.getByRole('img', {name: 'PR Merged'})).toBeInTheDocument();
     expect(screen.queryByTestId('icon-check-mark')).not.toBeInTheDocument();
   });
 

--- a/static/app/views/issueDetails/activitySection/index.spec.tsx
+++ b/static/app/views/issueDetails/activitySection/index.spec.tsx
@@ -1178,7 +1178,7 @@ describe('ActivitySection', () => {
       }
     );
 
-    expect(screen.getByRole('img', {name: 'Fix Applied'})).toBeInTheDocument();
+    expect(screen.getByRole('img', {name: 'PR Merged'})).toBeInTheDocument();
     expect(screen.getByTestId('user-activity-actor')).toBeInTheDocument();
   });
 

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -216,7 +216,7 @@ describe('InboxPage', () => {
       name: 'Issue preview',
     });
     const issueLink = await within(
-      screen.getByRole('region', {name: 'Fix Proposed'})
+      screen.getByRole('region', {name: 'PR Created'})
     ).findByRole('link', {name: /Fix proposed issue/});
 
     await userEvent.click(issueLink);
@@ -229,9 +229,9 @@ describe('InboxPage', () => {
 
     render(<InboxPage />, {organization, initialRouterConfig});
 
-    expect(screen.getByLabelText('Loading Fix Proposed issues')).toBeInTheDocument();
+    expect(screen.getByLabelText('Loading PR Created issues')).toBeInTheDocument();
     expect(screen.getByLabelText('Loading Diagnosed issues')).toBeInTheDocument();
-    expect(screen.getByLabelText('Loading Assigned issues')).toBeInTheDocument();
+    expect(screen.getByLabelText('Loading Triaged issues')).toBeInTheDocument();
 
     expect(await screen.findByText('Fix proposed issue')).toBeInTheDocument();
     expect(await screen.findByText('Diagnosed issue')).toBeInTheDocument();
@@ -263,12 +263,12 @@ describe('InboxPage', () => {
       expect(requests[index]).toHaveBeenCalledTimes(1);
     }
 
-    const fixSection = screen.getByRole('region', {name: 'Fix Proposed'});
+    const fixSection = screen.getByRole('region', {name: 'PR Created'});
     const diagnosedSection = screen.getByRole('region', {name: 'Diagnosed'});
-    const assignedSection = screen.getByRole('region', {name: 'Assigned'});
+    const assignedSection = screen.getByRole('region', {name: 'Triaged'});
     expect(
       within(fixSection).getByRole('heading', {
-        name: 'Fix Proposed',
+        name: 'PR Created',
         level: 3,
       })
     ).toBeInTheDocument();
@@ -300,9 +300,9 @@ describe('InboxPage', () => {
     render(<InboxPage />, {organization, initialRouterConfig});
 
     const fixProposedButton = screen.getByRole('button', {
-      name: 'Fix Proposed',
+      name: 'PR Created',
     });
-    const assignedButton = screen.getByRole('button', {name: 'Assigned'});
+    const assignedButton = screen.getByRole('button', {name: 'Triaged'});
     const fixProposedIssue = await screen.findByText('Fix proposed issue');
     const assignedIssue = screen.getByText('Assigned issue');
 
@@ -389,7 +389,7 @@ describe('InboxPage', () => {
 
     render(<InboxPage />, {organization, initialRouterConfig});
 
-    const fixSection = screen.getByRole('region', {name: 'Fix Proposed'});
+    const fixSection = screen.getByRole('region', {name: 'PR Created'});
     expect(await within(fixSection).findByText('Fix proposed issue')).toBeInTheDocument();
     const loadMoreButton = within(fixSection).getByRole('button', {
       name: 'Show 5 more',
@@ -422,7 +422,7 @@ describe('InboxPage', () => {
       within(preview).queryByRole('button', {name: 'Open Issue'})
     ).not.toBeInTheDocument();
 
-    const fixSection = screen.getByRole('region', {name: 'Fix Proposed'});
+    const fixSection = screen.getByRole('region', {name: 'PR Created'});
     const issueLink = await within(fixSection).findByRole('link', {
       name: /Fix proposed issue/,
     });
@@ -657,7 +657,7 @@ describe('InboxPage', () => {
       name: 'Issue preview',
     });
     const issueLink = await within(
-      screen.getByRole('region', {name: 'Fix Proposed'})
+      screen.getByRole('region', {name: 'PR Created'})
     ).findByRole('link', {name: /Fix proposed issue/});
     await userEvent.click(issueLink);
 

--- a/static/app/views/issueList/pages/inbox.tsx
+++ b/static/app/views/issueList/pages/inbox.tsx
@@ -30,7 +30,10 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {IssuePreview} from 'sentry/views/issueDetails/issuePreview/issuePreview';
 import {IssueListContainer} from 'sentry/views/issueList';
 import {IssueSortOptions} from 'sentry/views/issueList/utils';
-import {getProgressIcon} from 'sentry/views/issueList/utils/progress';
+import {
+  formatProgressState,
+  getProgressIcon,
+} from 'sentry/views/issueList/utils/progress';
 
 const TITLE = t('Inbox');
 const ISSUE_LIMIT = 5;
@@ -43,7 +46,6 @@ interface InboxSectionConfig {
   defaultExpanded: boolean;
   emptyMessage: string;
   key: string;
-  label: string;
   progress: ProgressState;
   query: string;
 }
@@ -51,7 +53,6 @@ interface InboxSectionConfig {
 const SECTIONS: InboxSectionConfig[] = [
   {
     key: 'fix-proposed',
-    label: t('Fix Proposed'),
     query: 'issue.progress:fix_proposed',
     emptyMessage: t('No issues with a proposed fix'),
     progress: ProgressState.FIX_PROPOSED,
@@ -59,7 +60,6 @@ const SECTIONS: InboxSectionConfig[] = [
   },
   {
     key: 'diagnosed',
-    label: t('Diagnosed'),
     query: 'issue.progress:diagnosed',
     emptyMessage: t('No diagnosed issues'),
     progress: ProgressState.DIAGNOSED,
@@ -67,7 +67,6 @@ const SECTIONS: InboxSectionConfig[] = [
   },
   {
     key: 'assigned',
-    label: t('Assigned'),
     query: 'issue.progress:assigned',
     emptyMessage: t('No assigned issues'),
     progress: ProgressState.ASSIGNED,
@@ -211,11 +210,12 @@ function InboxSection({assignmentFilter, section, selectedIssueId}: InboxSection
   const count = queryResult.data?.pages[0]?.headers['X-Hits'] ?? groups.length;
   const {data: members = []} = useMembers();
   const membersById = new Map(members.map(member => [member.id, member]));
+  const label = formatProgressState(section.progress);
 
   return (
     <Disclosure
       as="section"
-      aria-label={section.label}
+      aria-label={label}
       defaultExpanded={section.defaultExpanded}
       size="sm"
     >
@@ -225,7 +225,7 @@ function InboxSection({assignmentFilter, section, selectedIssueId}: InboxSection
             <Flex align="center" gap="sm">
               {getProgressIcon(section.progress)}
               <Heading as="h3" size="md">
-                {section.label}
+                {label}
               </Heading>
             </Flex>
           </Disclosure.Title>
@@ -233,11 +233,7 @@ function InboxSection({assignmentFilter, section, selectedIssueId}: InboxSection
       </Container>
       <InboxSectionContent>
         {queryResult.isPending ? (
-          <Stack
-            aria-label={t('Loading %s issues', section.label)}
-            gap="xs"
-            padding="0 xs"
-          >
+          <Stack aria-label={t('Loading %s issues', label)} gap="xs" padding="0 xs">
             {Array.from({length: ISSUE_LIMIT}).map((_, index) => (
               <Placeholder key={index} height="76px" />
             ))}

--- a/static/app/views/issueList/utils/progress.tsx
+++ b/static/app/views/issueList/utils/progress.tsx
@@ -8,12 +8,18 @@ import {ProgressState} from 'sentry/types/group';
 import type {TagVariant} from 'sentry/utils/theme';
 import type {IconSize} from 'sentry/utils/theme/types';
 
+/**
+ * Display names only — the underlying `ProgressState` values are persisted in
+ * `GroupDerivedData` and are the public `issue.progress:` search values, so they
+ * intentionally keep their original names. Expect labels and values to read
+ * differently (e.g. `fix_proposed` displays as "PR Created").
+ */
 const PROGRESS_STATE_LABELS: Record<ProgressState, string> = {
   [ProgressState.IDENTIFIED]: t('Identified'),
-  [ProgressState.ASSIGNED]: t('Assigned'),
+  [ProgressState.ASSIGNED]: t('Triaged'),
   [ProgressState.DIAGNOSED]: t('Diagnosed'),
-  [ProgressState.FIX_PROPOSED]: t('Fix Proposed'),
-  [ProgressState.FIX_APPLIED]: t('Fix Applied'),
+  [ProgressState.FIX_PROPOSED]: t('PR Created'),
+  [ProgressState.FIX_APPLIED]: t('PR Merged'),
 };
 
 export function formatProgressState(state: ProgressState | null): string {
@@ -47,7 +53,7 @@ const PROGRESS_STATE_TAG_VARIANTS: Record<ProgressState, TagVariant> = {
   [ProgressState.FIX_APPLIED]: 'success',
 };
 
-/** Progress state as a colored tag with a leading icon (e.g. a green "Fix Proposed"). */
+/** Progress state as a colored tag with a leading icon (e.g. a green "PR Created"). */
 export function IssueProgressTag({state}: {state: ProgressState | null}) {
   if (!state) {
     return null;


### PR DESCRIPTION
Renames the user-facing progress state labels:

| Value (unchanged) | Was | Now |
|---|---|---|
| `identified` | Identified | Identified |
| `assigned` | Assigned | **Triaged** |
| `diagnosed` | Diagnosed | Diagnosed |
| `fix_proposed` | Fix Proposed | **PR Created** |
| `fix_applied` | Fix Applied | **PR Merged** |

Display names only. The `ProgressState` values are persisted in `GroupDerivedData` and are the public `issue.progress:` search values, so they keep their existing names — no migration, and existing saved searches and bookmarks keep working. The tradeoff is that labels and values now read differently (`issue.progress:fix_proposed` shows as "PR Created"); the label map documents this so the next reader doesn't assume it's a bug.

Everything routes through `PROGRESS_STATE_LABELS`, so the inbox section headers, the issue stream progress column, the progress tag, and the activity timeline markers all pick this up together. The inbox sections were carrying duplicate copies of these strings in their config — they now derive from `formatProgressState`, so a future rename only needs to touch one place.

This is a 1:1 label move; how the states are derived is untouched (`track_progress` in `aggregators.py`).
