### PR TITLE
fix(browse): Ignore time range filters in context PUT endpoints

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_item_attribute_context.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attribute_context.py
@@ -18,7 +18,7 @@ from sentry.api.endpoints.organization_trace_item_attributes import (
     POSSIBLE_ATTRIBUTE_TYPES,
     SUPPORTED_DATASETS,
     OrganizationTraceItemAttributesEndpointBase,
-    adjust_start_end_window,
+    full_retention_window,
     get_column_definitions,
     is_known_attribute,
     resolve_attribute_referrer,
@@ -128,9 +128,10 @@ class OrganizationTraceItemAttributeContextEndpoint(OrganizationTraceItemAttribu
                 status=400,
             )
 
-        adjusted_start, adjusted_end = adjust_start_end_window(
-            snuba_params.start_date, snuba_params.end_date
-        )
+        # Existence is a property of all the org's data, so always check against
+        # the full retention window and ignore any time range filters
+        # (`statsPeriod`/`start`/`end`) on the request.
+        adjusted_start, adjusted_end = full_retention_window()
         snuba_params.start = adjusted_start
         snuba_params.end = adjusted_end
 

--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -42,7 +42,7 @@ from sentry.api.endpoints.organization_trace_item_attributes_types import (
 from sentry.api.event_search import translate_escape_sequences
 from sentry.api.paginator import ChainPaginator, GenericOffsetPaginator
 from sentry.api.serializers import serialize
-from sentry.api.utils import handle_query_errors
+from sentry.api.utils import default_start_end_dates, handle_query_errors
 from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
 from sentry.apidocs.examples.trace_item_attribute_examples import TraceItemAttributeExamples
 from sentry.apidocs.parameters import CursorQueryParam, GlobalParams
@@ -1236,6 +1236,17 @@ def adjust_start_end_window(start_date: datetime, end_date: datetime) -> tuple[d
     start_date = start_date.replace(hour=0, minute=0, second=0, microsecond=0)
     end_date = end_date.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1)
     return start_date, end_date
+
+
+def full_retention_window() -> tuple[datetime, datetime]:
+    """
+    The widest window we can query, used by context existence checks that must
+    always look at all of an org's data regardless of any `statsPeriod`/`start`/
+    `end` filters passed on the request. Anchored to the default (max) stats
+    period so a narrow user-supplied range can't cause a false negative.
+    """
+    start_date, end_date = default_start_end_dates()
+    return adjust_start_end_window(start_date, end_date)
 
 
 class OrganizationTraceItemAttributeValidateQuerySerializer(serializers.Serializer):

--- a/src/sentry/api/endpoints/organization_trace_item_metric_context.py
+++ b/src/sentry/api/endpoints/organization_trace_item_metric_context.py
@@ -12,7 +12,7 @@ from sentry.api.bases import NoProjects
 from sentry.api.bases.organization import OrganizationEventPermission
 from sentry.api.endpoints.organization_trace_item_attributes import (
     OrganizationTraceItemAttributesEndpointBase,
-    adjust_start_end_window,
+    full_retention_window,
     resolve_attribute_values_referrer,
 )
 from sentry.api.serializers import serialize
@@ -103,9 +103,10 @@ class OrganizationTraceItemMetricContextEndpoint(OrganizationTraceItemAttributes
         except NoProjects:
             return Response({"detail": "No projects available."}, status=400)
 
-        adjusted_start, adjusted_end = adjust_start_end_window(
-            snuba_params.start_date, snuba_params.end_date
-        )
+        # Existence is a property of all the org's data, so always check against
+        # the full retention window and ignore any time range filters
+        # (`statsPeriod`/`start`/`end`) on the request.
+        adjusted_start, adjusted_end = full_retention_window()
         snuba_params.start = adjusted_start
         snuba_params.end = adjusted_end
 

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attribute_context.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attribute_context.py
@@ -273,6 +273,31 @@ class OrganizationTraceItemAttributeContextEndpointTest(
         assert response.status_code == 400, response.data
         assert "not found" in response.data["detail"]
 
+    def test_ignores_time_range_filter(self) -> None:
+        # The attribute was last seen well outside the narrow requested window.
+        # Existence must be checked against all data, so a `statsPeriod` filter
+        # that would exclude it is ignored and the request still succeeds.
+        self.store_segment(
+            self.project.id,
+            uuid4().hex,
+            uuid4().hex,
+            organization_id=self.organization.id,
+            timestamp=before_now(days=5).replace(microsecond=0),
+            tags={"my_custom_attr": "value"},
+        )
+
+        response = self.do_request(
+            "my_custom_attr",
+            {
+                "dataset": "spans",
+                "attributeType": "string",
+                "brief": "My custom attribute",
+            },
+            query={"project": self.project.id, "statsPeriod": "1h"},
+        )
+
+        assert response.status_code == 201, response.data
+
     def test_requires_feature_flag(self) -> None:
         self.store_attribute(my_custom_attr="value")
 

--- a/tests/snuba/api/endpoints/test_organization_trace_item_metric_context.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_metric_context.py
@@ -275,6 +275,32 @@ class OrganizationTraceItemMetricContextEndpointTest(
         assert response.status_code == 400, response.data
         assert "not found" in response.data["detail"]
 
+    def test_ignores_time_range_filter(self) -> None:
+        # The metric was last seen well outside the narrow requested window.
+        # Existence must be checked against all data, so a `statsPeriod` filter
+        # that would exclude it is ignored and the request still succeeds.
+        self.store_eap_items(
+            [
+                self.create_trace_metric(
+                    "checkout.requests",
+                    1,
+                    "counter",
+                    timestamp=before_now(days=5),
+                )
+            ]
+        )
+
+        response = self.do_request(
+            "checkout.requests",
+            {
+                "metricType": "counter",
+                "brief": "Checkout requests",
+            },
+            query={"project": self.project.id, "statsPeriod": "1h"},
+        )
+
+        assert response.status_code == 201, response.data
+
     def test_requires_feature_flag(self) -> None:
         self.store_metric("checkout.requests")
 


### PR DESCRIPTION
## Summary

The metrics and attribute context `PUT` endpoints (`/trace-items/attributes/{key}/context/` and `/trace-items/metrics/{metric}/context/`) gate context authoring on an existence check that confirms the attribute/metric has actually been seen in storage. That check was honoring the request's time range filters (`statsPeriod`/`start`/`end`), so a narrow window could produce a false "not found" even when the attribute or metric exists in the org's data.

Existence is a property of *all* of an org's data, so both endpoints now always run the existence check against the full retention window and ignore any time range filters on the request.

## Changes

- Add a shared `full_retention_window()` helper (anchored to the default/max stats period, normalized through the existing `adjust_start_end_window`) in `organization_trace_item_attributes.py`.
- Both context `PUT` endpoints use it instead of deriving the window from the request's `snuba_params`; project scoping is unchanged.
- Add a regression test to each endpoint's suite covering data seen outside a narrow requested window.

Fixes BROWSE-622