### PR TITLE
fix(dashboards): Correct filter legend names with group by

### DIFF
--- a/static/app/views/dashboards/widgetCard/transformWidgetSeriesToTimeSeries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/transformWidgetSeriesToTimeSeries.spec.tsx
@@ -129,6 +129,47 @@ describe('transformWidgetSeriesToTimeSeries', () => {
       expect(result?.label).toBe('browser:Chrome : prod');
     });
 
+    it('matches the correct query by alias prefix when there is a group by (DAIN-1784)', () => {
+      const dbQuery = WidgetQueryFixture({
+        name: 'db',
+        conditions: 'span.op:db',
+        aggregates: ['count(span.duration)', 'avg(span.duration)'],
+        columns: ['project_id'],
+        fields: ['project_id', 'count(span.duration)', 'avg(span.duration)'],
+      });
+      const httpQuery = WidgetQueryFixture({
+        name: 'http',
+        conditions: 'span.op:http.client',
+        aggregates: ['count(span.duration)', 'avg(span.duration)'],
+        columns: ['project_id'],
+        fields: ['project_id', 'count(span.duration)', 'avg(span.duration)'],
+      });
+      const widget = WidgetFixture({queries: [dbQuery, httpQuery]});
+
+      // Alias with a group-by uses ' > ' to separate the alias from the
+      // group-by value (from transformEventsResponseToSeries).
+      const dbCount = transformWidgetSeriesToTimeSeries(
+        makeSeries('db > (no value) : count(span.duration)'),
+        widget
+      );
+      expect(dbCount?.widgetQuery).toBe(dbQuery);
+      expect(dbCount?.label).toBe('db : (no value) : count(span.duration)');
+
+      const httpCount = transformWidgetSeriesToTimeSeries(
+        makeSeries('http > (no value) : count(span.duration)'),
+        widget
+      );
+      expect(httpCount?.widgetQuery).toBe(httpQuery);
+      expect(httpCount?.label).toBe('http : (no value) : count(span.duration)');
+
+      const httpAvg = transformWidgetSeriesToTimeSeries(
+        makeSeries('http > (no value) : avg(span.duration)'),
+        widget
+      );
+      expect(httpAvg?.widgetQuery).toBe(httpQuery);
+      expect(httpAvg?.label).toBe('http : (no value) : avg(span.duration)');
+    });
+
     it('uses query alias from the : delimited series name when available', () => {
       const widget = WidgetFixture({
         queries: [

--- a/static/app/views/dashboards/widgetCard/transformWidgetSeriesToTimeSeries.tsx
+++ b/static/app/views/dashboards/widgetCard/transformWidgetSeriesToTimeSeries.tsx
@@ -57,6 +57,12 @@ export function transformWidgetSeriesToTimeSeries(
       : splitSeriesName;
   const widgetQuery =
     widget.queries.find(({conditions}) => conditions && queryName === conditions) ??
+    // When there's a group-by, an alias prefix is glued to the group-by value
+    // with the ' > ' delimiter (e.g., "http > (no value) : count()"), so the
+    // bare alias never appears as a ' : ' delimited part. Match the extracted
+    // prefix against the query name directly to avoid falling back to the first
+    // query and mislabeling every series with its name.
+    widget.queries.find(({name}) => name && queryName === name) ??
     widget.queries.find(({name}) => name && splitSeriesName.includes(name)) ??
     firstQuery;
   const effectiveQueryName = queryName ?? (widgetQuery?.name || undefined);


### PR DESCRIPTION
Fixes [DAIN-1784](https://linear.app/getsentry/issue/DAIN-1784/fix-incorrect-filter-legend-names-in-dashboards).

### Before
<img width="624" height="445" alt="image" src="https://github.com/user-attachments/assets/83be6d12-6c81-4109-a164-dba46af77f89" />

### After
<img width="627" height="487" alt="image" src="https://github.com/user-attachments/assets/314ae5b3-a4f9-4602-a34e-2027675234b9" />


## Problem

In a widget with multiple named filter queries (e.g. `db` and `http`), multiple aggregates, **and** a group-by, every series in the chart legend/tooltip was labeled with the *first* filter's name. Instead of `db : (no value) : count(...)` and `http : (no value) : count(...)`, all series showed `db`. The breakdown legend table also duplicated the first query's values.

## Root cause

When a series has a group-by, the upstream series-name builder joins the query alias to the group-by value with the ` > ` delimiter (e.g. `http > (no value) : count(span.duration)`). `transformWidgetSeriesToTimeSeries` correctly extracted `queryName = "http"`, but the lookup that maps a series back to its `WidgetQuery` only matched against ` : `-delimited parts via `splitSeriesName.includes(name)` — which saw `"http > (no value)"` and never matched the bare `"http"`. It fell back to the first query, which then drove both the (wrong) legend label and the breakdown table's value lookup.

## Fix

Match the extracted ` > ` prefix against the query `name` directly, before the existing `splitSeriesName.includes` fallback. The change is additive and only fires when the prefix exactly equals a query name, so the conditions-prefix and no-group-by paths are unchanged. Added a regression test covering the alias-with-group-by scenario.
