### PR TITLE
feat(ai-monitoring): Return stored conversation titles from the list endpoint

### DIFF
--- a/src/sentry/ai_monitoring/utils.py
+++ b/src/sentry/ai_monitoring/utils.py
@@ -1,7 +1,7 @@
 import hashlib
 import logging
 import re
-from collections.abc import Mapping
+from collections.abc import Collection, Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
@@ -9,6 +9,7 @@ from typing import Any
 from sentry_conventions.attributes import ATTRIBUTE_NAMES
 from sentry_sdk import trace
 
+from sentry.ai_monitoring.models import AIConversationMetadata
 from sentry.seer.signed_seer_api import (
     LlmGenerateRequest,
     SeerViewerContext,
@@ -80,6 +81,40 @@ def clamp_conversation_id_for_storage(conversation_id: str) -> str:
     if len(conversation_id) <= CONVERSATION_ID_MAX_LENGTH:
         return conversation_id
     return conversation_id[:CONVERSATION_ID_TRUNCATE_TO] + "..."
+
+
+def fetch_conversation_titles(
+    conversation_project_pairs: Collection[tuple[str, int]],
+) -> dict[tuple[str, int], str]:
+    """Look up stored titles for the given (conversation_id, project_id) pairs.
+
+    A conversation id is only unique within a project, so callers must key on the
+    pair. Pairs without a titled row are simply absent from the result.
+    """
+    if not conversation_project_pairs:
+        return {}
+
+    requested_pairs = set(conversation_project_pairs)
+    conversation_id_by_hash = {
+        conversation_id_hash(conversation_id): conversation_id
+        for conversation_id, _ in requested_pairs
+    }
+
+    rows = AIConversationMetadata.objects.filter(
+        project_id__in={project_id for _, project_id in requested_pairs},
+        conversation_id_hash__in=conversation_id_by_hash,
+        title__isnull=False,
+    ).values_list("conversation_id_hash", "project_id", "title")
+
+    # The filter matches the cross product of the hashes and the projects, so drop
+    # any (conversation, project) combination the caller did not ask about.
+    titles: dict[tuple[str, int], str] = {}
+    for row_hash, project_id, title in rows:
+        pair = (conversation_id_by_hash[row_hash], project_id)
+        if title and pair in requested_pairs:
+            titles[pair] = title
+
+    return titles
 
 
 def _extract_first_user_message(messages: Any) -> str | None:

--- a/src/sentry/api/endpoints/organization_ai_conversations.py
+++ b/src/sentry/api/endpoints/organization_ai_conversations.py
@@ -1,6 +1,7 @@
 import logging
 import re
 from collections import defaultdict
+from collections.abc import Mapping, Sequence
 from datetime import datetime
 from typing import Any, TypedDict
 
@@ -9,6 +10,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
+from sentry.ai_monitoring.utils import fetch_conversation_titles
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -76,6 +78,17 @@ def _to_timestamp_float(ts: Any) -> float:
 
 def _compute_timestamp_ms(finish_ts: float) -> int:
     return int(finish_ts * 1000) if finish_ts else 0
+
+
+def _first_title(
+    titles: Mapping[tuple[str, int], str], conv_id: str, project_ids: Sequence[int]
+) -> str | None:
+    """Lowest project id with a stored title wins, so results are stable across requests."""
+    for project_id in project_ids:
+        title = titles.get((conv_id, project_id))
+        if title is not None:
+            return title
+    return None
 
 
 def _extract_first_user_message(messages: Any) -> str | None:
@@ -175,9 +188,11 @@ def _build_conversation_response(
     user: dict[str, str | None] | None = None,
     tool_names: list[str] | None = None,
     tool_errors: int = 0,
+    title: str | None = None,
 ) -> dict[str, Any]:
     return {
         "conversationId": conv_id,
+        "title": title,
         "flow": flow,
         "errors": errors,
         "llmCalls": llm_calls,
@@ -313,8 +328,11 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
         # Process results
         with start_span(op="ai_conversations.process", name="Process query results"):
             conversations_map = self._build_conversations_from_aggregations(results["aggregations"])
-            self._apply_enrichment(conversations_map, results["enrichment"])
+            project_ids_by_conversation = self._apply_enrichment(
+                conversations_map, results["enrichment"]
+            )
             self._apply_first_last_io(conversations_map, results["first_last_io"])
+            self._apply_titles(conversations_map, project_ids_by_conversation)
 
         return [
             conversations_map[conv_id]
@@ -362,6 +380,7 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
                 "span.status",
                 "trace",
                 "timestamp",
+                "project.id",
                 "user.id",
                 "user.email",
                 "user.username",
@@ -452,7 +471,8 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
 
     def _apply_enrichment(
         self, conversations_map: dict[str, dict[str, Any]], enrichment_data: EAPResponse
-    ) -> None:
+    ) -> dict[str, set[int]]:
+        """Apply enrichment data, returning the project ids each conversation spans."""
         with start_span(
             op="ai_conversations.apply_enrichment",
             name="Apply enrichment data",
@@ -464,6 +484,7 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
             traces_by_conversation: dict[str, set[str]] = defaultdict(set)
             tool_names_by_conversation: dict[str, set[str]] = defaultdict(set)
             tool_errors_by_conversation: dict[str, int] = defaultdict(int)
+            project_ids_by_conversation: dict[str, set[int]] = defaultdict(set)
             # Track first user data per conversation (data is sorted by timestamp, so first occurrence wins)
             user_by_conversation: dict[str, UserResponse] = {}
 
@@ -471,6 +492,10 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
                 conv_id = row.get("gen_ai.conversation.id", "")
                 if not conv_id:
                     continue
+
+                project_id = row.get("project.id")
+                if isinstance(project_id, int):
+                    project_ids_by_conversation[conv_id].add(project_id)
 
                 trace_id = row.get("trace", "")
                 if trace_id:
@@ -509,6 +534,8 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
                 conversation["toolNames"] = sorted(tool_names_by_conversation.get(conv_id, set()))
                 conversation["toolErrors"] = tool_errors_by_conversation.get(conv_id, 0)
 
+            return project_ids_by_conversation
+
     def _apply_first_last_io(
         self, conversations_map: dict[str, dict[str, Any]], first_last_io_data: EAPResponse
     ) -> None:
@@ -545,3 +572,24 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
                 conversation["firstInput"] = first_input_by_conv.get(conv_id)
                 last_tuple = last_output_by_conv.get(conv_id)
                 conversation["lastOutput"] = last_tuple[1] if last_tuple else None
+
+    @trace
+    def _apply_titles(
+        self,
+        conversations_map: dict[str, dict[str, Any]],
+        project_ids_by_conversation: Mapping[str, set[int]],
+    ) -> None:
+        """Attach stored conversation titles, leaving `title` as None when we have none."""
+        sorted_project_ids = {
+            conv_id: sorted(project_ids_by_conversation.get(conv_id, ()))
+            for conv_id in conversations_map
+        }
+        titles = fetch_conversation_titles(
+            [
+                (conv_id, project_id)
+                for conv_id, project_ids in sorted_project_ids.items()
+                for project_id in project_ids
+            ]
+        )
+        for conv_id, conversation in conversations_map.items():
+            conversation["title"] = _first_title(titles, conv_id, sorted_project_ids[conv_id])

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -32,6 +32,8 @@ from google.protobuf.timestamp_pb2 import Timestamp
 from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
 from sentry_protos.snuba.v1.trace_item_pb2 import TraceItem
 
+from sentry.ai_monitoring.models import AIConversationMetadata
+from sentry.ai_monitoring.utils import clamp_conversation_id_for_storage, conversation_id_hash
 from sentry.auth.access import RpcBackedAccess
 from sentry.auth.services.auth.model import RpcAuthState, RpcMemberSsoState
 from sentry.constants import SentryAppInstallationStatus, SentryAppStatus
@@ -627,6 +629,22 @@ class Factories:
     @assume_test_silo_mode(SiloMode.CELL)
     def create_project_bookmark(project, user):
         return ProjectBookmark.objects.create(project_id=project.id, user_id=user.id)
+
+    @staticmethod
+    @assume_test_silo_mode(SiloMode.CELL)
+    def create_ai_conversation_metadata(
+        project: Project,
+        conversation_id: str,
+        title: str | None = None,
+        title_source_timestamp: datetime | None = None,
+    ) -> AIConversationMetadata:
+        return AIConversationMetadata.objects.create(
+            project_id=project.id,
+            conversation_id=clamp_conversation_id_for_storage(conversation_id),
+            conversation_id_hash=conversation_id_hash(conversation_id),
+            title=title,
+            title_source_timestamp=title_source_timestamp,
+        )
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.CELL)

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -228,6 +228,11 @@ class Fixtures:
             project = self.project
         return Factories.create_project_bookmark(project, *args, **kwargs)
 
+    def create_ai_conversation_metadata(self, project=None, *args, **kwargs):
+        if project is None:
+            project = self.project
+        return Factories.create_ai_conversation_metadata(project, *args, **kwargs)
+
     def create_project_key(self, project=None, *args, **kwargs):
         if project is None:
             project = self.project

--- a/tests/sentry/ai_monitoring/test_utils.py
+++ b/tests/sentry/ai_monitoring/test_utils.py
@@ -1,0 +1,89 @@
+from sentry.ai_monitoring.utils import fetch_conversation_titles
+from sentry.testutils.cases import TestCase
+
+
+class FetchConversationTitlesTest(TestCase):
+    def test_returns_empty_for_no_pairs(self) -> None:
+        assert fetch_conversation_titles([]) == {}
+
+    def test_returns_title_for_requested_pair(self) -> None:
+        self.create_ai_conversation_metadata(
+            project=self.project,
+            conversation_id="conv-1",
+            title="Reset my password",
+        )
+
+        titles = fetch_conversation_titles([("conv-1", self.project.id)])
+
+        assert titles == {("conv-1", self.project.id): "Reset my password"}
+
+    def test_skips_untitled_rows(self) -> None:
+        self.create_ai_conversation_metadata(
+            project=self.project,
+            conversation_id="conv-1",
+            title=None,
+        )
+
+        assert fetch_conversation_titles([("conv-1", self.project.id)]) == {}
+
+    def test_skips_unknown_conversations(self) -> None:
+        self.create_ai_conversation_metadata(
+            project=self.project,
+            conversation_id="conv-1",
+            title="Reset my password",
+        )
+
+        assert fetch_conversation_titles([("conv-2", self.project.id)]) == {}
+
+    def test_does_not_return_pairs_that_were_not_requested(self) -> None:
+        """A row matching the queried hashes and projects, but not as a requested pair."""
+        other_project = self.create_project(organization=self.organization)
+
+        self.create_ai_conversation_metadata(
+            project=self.project,
+            conversation_id="conv-1",
+            title="Owned by project one",
+        )
+        self.create_ai_conversation_metadata(
+            project=other_project,
+            conversation_id="conv-1",
+            title="Owned by project two",
+        )
+        self.create_ai_conversation_metadata(
+            project=other_project,
+            conversation_id="conv-2",
+            title="Second conversation",
+        )
+
+        # conv-1 is only asked about for self.project, conv-2 only for other_project.
+        titles = fetch_conversation_titles(
+            [("conv-1", self.project.id), ("conv-2", other_project.id)]
+        )
+
+        assert titles == {
+            ("conv-1", self.project.id): "Owned by project one",
+            ("conv-2", other_project.id): "Second conversation",
+        }
+
+    def test_returns_both_projects_when_both_requested(self) -> None:
+        other_project = self.create_project(organization=self.organization)
+
+        self.create_ai_conversation_metadata(
+            project=self.project,
+            conversation_id="conv-1",
+            title="Owned by project one",
+        )
+        self.create_ai_conversation_metadata(
+            project=other_project,
+            conversation_id="conv-1",
+            title="Owned by project two",
+        )
+
+        titles = fetch_conversation_titles(
+            [("conv-1", self.project.id), ("conv-1", other_project.id)]
+        )
+
+        assert titles == {
+            ("conv-1", self.project.id): "Owned by project one",
+            ("conv-1", other_project.id): "Owned by project two",
+        }

--- a/tests/sentry/api/endpoints/test_organization_ai_conversations.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversations.py
@@ -1420,3 +1420,178 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
         # Verify counts are correct
         assert conversation["llmCalls"] == 1
         assert conversation["flow"] == ["Test Agent"]
+
+    def _store_conversation_span(self, conversation_id, timestamp, project=None):
+        """Store one minimal ai_client span so a conversation shows up in the list."""
+        self.store_ai_span(
+            conversation_id=conversation_id,
+            timestamp=timestamp,
+            op="gen_ai.chat",
+            operation_type="ai_client",
+            trace_id=uuid4().hex,
+            messages=[{"role": "user", "content": "hello"}],
+            response_text="hi",
+            project=project,
+        )
+
+    def test_title_is_null_without_metadata(self) -> None:
+        """A conversation with no stored metadata still exposes a null title."""
+        now = before_now(days=25).replace(microsecond=0)
+        conversation_id = uuid4().hex
+
+        self._store_conversation_span(conversation_id, now)
+
+        query = {
+            "project": [self.project.id],
+            "start": (now - timedelta(hours=1)).isoformat(),
+            "end": (now + timedelta(hours=1)).isoformat(),
+        }
+
+        response = self.do_request(query)
+        assert response.status_code == 200, response.data
+        assert len(response.data) == 1
+        assert response.data[0]["title"] is None
+
+    def test_title_from_metadata(self) -> None:
+        """A stored title for this project is returned on the conversation."""
+        now = before_now(days=25).replace(microsecond=0)
+        conversation_id = uuid4().hex
+
+        self._store_conversation_span(conversation_id, now)
+        self.create_ai_conversation_metadata(
+            project=self.project,
+            conversation_id=conversation_id,
+            title="Refund a duplicate charge",
+            title_source_timestamp=now,
+        )
+
+        query = {
+            "project": [self.project.id],
+            "start": (now - timedelta(hours=1)).isoformat(),
+            "end": (now + timedelta(hours=1)).isoformat(),
+        }
+
+        response = self.do_request(query)
+        assert response.status_code == 200, response.data
+        assert len(response.data) == 1
+        assert response.data[0]["title"] == "Refund a duplicate charge"
+
+    def test_title_is_null_when_metadata_row_is_untitled(self) -> None:
+        """A metadata row that never got a title does not change the response."""
+        now = before_now(days=25).replace(microsecond=0)
+        conversation_id = uuid4().hex
+
+        self._store_conversation_span(conversation_id, now)
+        self.create_ai_conversation_metadata(
+            project=self.project,
+            conversation_id=conversation_id,
+            title=None,
+        )
+
+        query = {
+            "project": [self.project.id],
+            "start": (now - timedelta(hours=1)).isoformat(),
+            "end": (now + timedelta(hours=1)).isoformat(),
+        }
+
+        response = self.do_request(query)
+        assert response.status_code == 200, response.data
+        assert len(response.data) == 1
+        assert response.data[0]["title"] is None
+
+    def test_title_not_taken_from_unrelated_project(self) -> None:
+        """A same-named conversation in another project must not supply the title."""
+        now = before_now(days=25).replace(microsecond=0)
+        conversation_id = uuid4().hex
+        other_project = self.create_project(organization=self.organization)
+
+        self._store_conversation_span(conversation_id, now)
+        self.create_ai_conversation_metadata(
+            project=other_project,
+            conversation_id=conversation_id,
+            title="Someone else's conversation",
+            title_source_timestamp=now,
+        )
+
+        query = {
+            "project": [self.project.id, other_project.id],
+            "start": (now - timedelta(hours=1)).isoformat(),
+            "end": (now + timedelta(hours=1)).isoformat(),
+        }
+
+        response = self.do_request(query)
+        assert response.status_code == 200, response.data
+        assert len(response.data) == 1
+        assert response.data[0]["title"] is None
+
+    def test_title_for_conversation_spanning_projects(self) -> None:
+        """When a conversation spans projects, the lowest project id with a title wins."""
+        now = before_now(days=25).replace(microsecond=0)
+        conversation_id = uuid4().hex
+        lower_project = self.create_project(organization=self.organization)
+        higher_project = self.create_project(organization=self.organization)
+        assert lower_project.id < higher_project.id
+
+        self._store_conversation_span(
+            conversation_id, now - timedelta(seconds=2), project=lower_project
+        )
+        self._store_conversation_span(
+            conversation_id, now - timedelta(seconds=1), project=higher_project
+        )
+
+        self.create_ai_conversation_metadata(
+            project=lower_project,
+            conversation_id=conversation_id,
+            title="Lower project id title",
+            title_source_timestamp=now,
+        )
+        self.create_ai_conversation_metadata(
+            project=higher_project,
+            conversation_id=conversation_id,
+            title="Higher project id title",
+            title_source_timestamp=now,
+        )
+
+        query = {
+            "project": [lower_project.id, higher_project.id],
+            "start": (now - timedelta(hours=1)).isoformat(),
+            "end": (now + timedelta(hours=1)).isoformat(),
+        }
+
+        response = self.do_request(query)
+        assert response.status_code == 200, response.data
+        assert len(response.data) == 1
+        assert response.data[0]["title"] == "Lower project id title"
+
+    def test_title_found_when_only_higher_project_id_has_one(self) -> None:
+        """Every project the conversation spans is searched, not just the lowest."""
+        now = before_now(days=25).replace(microsecond=0)
+        conversation_id = uuid4().hex
+        lower_project = self.create_project(organization=self.organization)
+        higher_project = self.create_project(organization=self.organization)
+        assert lower_project.id < higher_project.id
+
+        self._store_conversation_span(
+            conversation_id, now - timedelta(seconds=2), project=lower_project
+        )
+        self._store_conversation_span(
+            conversation_id, now - timedelta(seconds=1), project=higher_project
+        )
+
+        self.create_ai_conversation_metadata(
+            project=higher_project,
+            conversation_id=conversation_id,
+            title="Higher project id title",
+            title_source_timestamp=now,
+        )
+
+        query = {
+            "project": [lower_project.id, higher_project.id],
+            "start": (now - timedelta(hours=1)).isoformat(),
+            "end": (now + timedelta(hours=1)).isoformat(),
+        }
+
+        response = self.do_request(query)
+        assert response.status_code == 200, response.data
+        assert len(response.data) == 1
+        assert response.data[0]["title"] == "Higher project id title"

--- a/tests/sentry/api/endpoints/test_organization_ai_conversations_base.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversations_base.py
@@ -44,6 +44,7 @@ class BaseAIConversationsTestCase(BaseSpansTestCase, SpanTestCase, APITestCase):
         output_messages=None,
         system_instructions=None,
         tool_definitions=None,
+        project=None,
         store=True,
     ):
         """Create and store an AI span with the given attributes.
@@ -74,6 +75,7 @@ class BaseAIConversationsTestCase(BaseSpansTestCase, SpanTestCase, APITestCase):
             output_messages: The gen_ai.output.messages (new format, will be JSON serialized)
             system_instructions: The gen_ai.system_instructions attribute
             tool_definitions: The gen_ai.tool.definitions (new format, will be JSON serialized)
+            project: The project to store the span under (default: self.project)
 
         Returns:
             The created span object
@@ -131,6 +133,7 @@ class BaseAIConversationsTestCase(BaseSpansTestCase, SpanTestCase, APITestCase):
 
         span = self.create_span(
             extra_data,
+            project=project,
             start_ts=timestamp,
         )
         if store:


### PR DESCRIPTION
Conversation titles have been written into `AIConversationMetadata` since title generation was hooked into the ingestion pipeline, but nothing ever read them back. The AI conversations list response now includes a `title` for each conversation.

The conversation details endpoint is deliberately untouched — adding a title there is a breaking change to its response shape and will be done as a follow up.

## Resolving a title
This is where it gets a bit tricky, so bear with me....

Metadata rows are keyed on `(project_id, sha256(conversation_id))`, but the list endpoint groups by `gen_ai.conversation.id` across every project in the request, so a conversation on its own doesn't identify a row. The enrichment span query now also selects `project.id`, which gives the set of projects each conversation actually has spans in, and titles are matched against exactly those pairs.

This matters because a conversation id is only unique within a project. Matching on the id alone would let an unrelated conversation that happens to share an id in another project supply the title. 

A conversation genuinely spanning several projects can have a row in each. The lowest project id with a stored title wins, so repeated requests return the same title rather than varying with row ordering. This is an edge case behavior, but we need to handle it :( 
