### PR TITLE
feat(inbox): Remove page filters

### DIFF
--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -18,7 +18,6 @@ import {
   within,
 } from 'sentry-test/reactTestingLibrary';
 
-import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {ProgressState} from 'sentry/types/group';
 
@@ -124,12 +123,6 @@ describe('InboxPage', () => {
   beforeEach(() => {
     ProjectsStore.reset();
     ProjectsStore.loadInitialData([project]);
-    PageFiltersStore.init();
-    PageFiltersStore.onInitializeUrlState({
-      projects: [Number(project.id)],
-      environments: ['production'],
-      datetime: {period: '7d', start: null, end: null, utc: false},
-    });
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/members/',
       body: [MemberFixture({id: assignedUser.id, user: assignedUser})],
@@ -257,15 +250,13 @@ describe('InboxPage', () => {
           expect.anything(),
           expect.objectContaining({
             method: 'GET',
-            query: expect.objectContaining({
-              project: [1],
-              environment: ['production'],
-              statsPeriod: '7d',
+            query: {
+              project: [-1],
               query,
               sort: 'progress',
               limit: 5,
-              expand: ['owners', 'derivedData'],
-            }),
+              collapse: ['stats', 'unhandled'],
+            },
           })
         )
       );
@@ -299,7 +290,8 @@ describe('InboxPage', () => {
     );
     expect(within(fixSection).getByLabelText('Unread issue')).toBeInTheDocument();
     expect(within(fixSection).queryByRole('checkbox')).not.toBeInTheDocument();
-    expect(fixSection.querySelectorAll('time')).toHaveLength(2);
+    expect(fixSection.querySelector('time')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: '7D'})).not.toBeInTheDocument();
   });
 
   it('expands and collapses progress sections', async () => {
@@ -444,20 +436,11 @@ describe('InboxPage', () => {
       })
     ).toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole('button', {name: '7D', expanded: false}));
-    await userEvent.click(screen.getByRole('option', {name: 'Last 30 days'}));
-
+    await userEvent.click(await screen.findByRole('button', {name: 'Back to inbox'}));
     expect(router.location.query.preview).toBeUndefined();
     expect(
       within(preview).queryByRole('heading', {name: 'Fix proposed issue'})
     ).not.toBeInTheDocument();
-
-    const updatedIssueLink = within(
-      screen.getByRole('region', {name: 'Fix Proposed'})
-    ).getByRole('link', {name: /Fix proposed issue/});
-    await userEvent.click(updatedIssueLink);
-    await userEvent.click(await screen.findByRole('button', {name: 'Back to inbox'}));
-    expect(router.location.query.preview).toBeUndefined();
   });
 
   it('starts finding the root cause in Autofix when there is no Autofix state', async () => {

--- a/static/app/views/issueList/pages/inbox.tsx
+++ b/static/app/views/issueList/pages/inbox.tsx
@@ -17,27 +17,18 @@ import {NotFound} from 'sentry/components/errors/notFound';
 import {EventMessage} from 'sentry/components/events/eventMessage';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {LoadingError} from 'sentry/components/loadingError';
-import {NoProjectMessage} from 'sentry/components/noProjectMessage';
-import {PageFiltersContainer} from 'sentry/components/pageFilters/container';
-import {DatePageFilter} from 'sentry/components/pageFilters/date/datePageFilter';
-import {EnvironmentPageFilter} from 'sentry/components/pageFilters/environment/environmentPageFilter';
-import {PageFilterBar} from 'sentry/components/pageFilters/pageFilterBar';
-import {ProjectPageFilter} from 'sentry/components/pageFilters/project/projectPageFilter';
-import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {Placeholder} from 'sentry/components/placeholder';
 import {IconArrow, IconChevron} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import {ProgressState, type Group} from 'sentry/types/group';
 import type {User} from 'sentry/types/user';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
-import {getUtcDateString} from 'sentry/utils/dates';
 import {getMessage, getTitle} from 'sentry/utils/events';
 import {useMembers} from 'sentry/utils/members/useMembers';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {IssuePreview} from 'sentry/views/issueDetails/issuePreview/issuePreview';
 import {IssueListContainer} from 'sentry/views/issueList';
-import {IssueSeenTimes} from 'sentry/views/issueList/pages/issueSeenTimes';
 import {IssueSortOptions} from 'sentry/views/issueList/utils';
 import {getProgressIcon} from 'sentry/views/issueList/utils/progress';
 
@@ -93,17 +84,12 @@ export default function InboxPage() {
 
   return (
     <IssueListContainer title={TITLE}>
-      <PageFiltersContainer>
-        <NoProjectMessage organization={organization}>
-          <InboxContent />
-        </NoProjectMessage>
-      </PageFiltersContainer>
+      <InboxContent />
     </IssueListContainer>
   );
 }
 
 function InboxContent() {
-  const {selection, isReady} = usePageFilters();
   const [assignmentFilter, setAssignmentFilter] = useQueryState(
     ASSIGNMENT_QUERY_PARAM,
     parseAsStringLiteral(ASSIGNMENT_FILTERS)
@@ -118,13 +104,6 @@ function InboxContent() {
   return (
     <Stack flex={1} minHeight={0} contain="size" overflow="hidden">
       <Layout.Title>{TITLE}</Layout.Title>
-      <Container padding="lg xl" borderBottom="muted">
-        <PageFilterBar condensed>
-          <ProjectPageFilter resetParamsOnChange={[SELECTED_ISSUE_QUERY_PARAM]} />
-          <EnvironmentPageFilter resetParamsOnChange={[SELECTED_ISSUE_QUERY_PARAM]} />
-          <DatePageFilter resetParamsOnChange={[SELECTED_ISSUE_QUERY_PARAM]} />
-        </PageFilterBar>
-      </Container>
       <Grid
         flex={1}
         minHeight={0}
@@ -171,8 +150,6 @@ function InboxContent() {
                 key={section.key}
                 section={section}
                 assignmentFilter={assignmentFilter}
-                selection={selection}
-                isReady={isReady}
                 selectedIssueId={selectedIssueId}
               />
             ))}
@@ -210,39 +187,24 @@ function InboxContent() {
 
 interface InboxSectionProps {
   assignmentFilter: AssignmentFilter;
-  isReady: boolean;
   section: InboxSectionConfig;
   selectedIssueId: string | null;
-  selection: ReturnType<typeof usePageFilters>['selection'];
 }
 
-function InboxSection({
-  assignmentFilter,
-  isReady,
-  section,
-  selection,
-  selectedIssueId,
-}: InboxSectionProps) {
+function InboxSection({assignmentFilter, section, selectedIssueId}: InboxSectionProps) {
   const organization = useOrganization();
-  const {start, end, period, utc} = selection.datetime;
   const queryResult = useInfiniteQuery({
     ...apiOptions.asInfinite<Group[]>()('/organizations/$organizationIdOrSlug/issues/', {
       path: {organizationIdOrSlug: organization.slug},
       query: {
-        project: selection.projects,
-        environment: selection.environments,
+        project: [-1],
         query: `${section.query} assigned:${assignmentFilter}`,
         sort: IssueSortOptions.PROGRESS,
         limit: ISSUE_LIMIT,
-        expand: ['owners', 'derivedData'],
-        ...(period ? {statsPeriod: period} : {}),
-        ...(start ? {start: getUtcDateString(start)} : {}),
-        ...(end ? {end: getUtcDateString(end)} : {}),
-        ...(utc === null ? {} : {utc}),
+        collapse: ['stats', 'unhandled'],
       },
       staleTime: 0,
     }),
-    enabled: isReady,
     refetchOnWindowFocus: true,
   });
   const groups = queryResult.data?.pages.flatMap(page => page.json) ?? [];
@@ -372,8 +334,7 @@ function InboxIssueCard({
             </Text>
           </Flex>
         </Stack>
-        <Stack align="end" justify="between" gap="sm">
-          <IssueSeenTimes group={group} />
+        <Flex align="center">
           {group.assignedTo &&
             (group.assignedTo.type === 'user' ? (
               <UserAvatar
@@ -390,7 +351,7 @@ function InboxIssueCard({
                 title={group.assignedTo.name}
               />
             ))}
-        </Stack>
+        </Flex>
       </Grid>
     </IssueCardLink>
   );


### PR DESCRIPTION
Closes ISWF-3094

Removes page filters to match the design and queries across all projects and time ranges. The endpoints already make progress queries a postgres-only request, so results return quickly.