### PR TITLE
feat(inbox): Add "all" option and include "me" in "my teams"

### DIFF
--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -158,9 +158,24 @@ describe('InboxPage', () => {
 
   function mockSuccessfulSections() {
     return [
-      mockSection('issue.progress:fix_proposed assigned:me', [fixProposedGroup], 200, 2),
-      mockSection('issue.progress:diagnosed assigned:me', [diagnosedGroup], 200, 2),
-      mockSection('issue.progress:assigned assigned:me', [assignedGroup], 200, 12),
+      mockSection(
+        'issue.progress:fix_proposed assigned:[me,my_teams]',
+        [fixProposedGroup],
+        200,
+        2
+      ),
+      mockSection(
+        'issue.progress:diagnosed assigned:[me,my_teams]',
+        [diagnosedGroup],
+        200,
+        2
+      ),
+      mockSection(
+        'issue.progress:assigned assigned:[me,my_teams]',
+        [assignedGroup],
+        200,
+        12
+      ),
     ];
   }
 
@@ -248,9 +263,9 @@ describe('InboxPage', () => {
     expect(screen.getByRole('heading', {name: 'Issues', level: 2})).toBeInTheDocument();
 
     for (const [index, query] of [
-      'issue.progress:fix_proposed assigned:me',
-      'issue.progress:diagnosed assigned:me',
-      'issue.progress:assigned assigned:me',
+      'issue.progress:fix_proposed assigned:[me,my_teams]',
+      'issue.progress:diagnosed assigned:[me,my_teams]',
+      'issue.progress:assigned assigned:[me,my_teams]',
     ].entries()) {
       await waitFor(() =>
         expect(requests[index]).toHaveBeenCalledWith(
@@ -302,6 +317,26 @@ describe('InboxPage', () => {
     expect(fixSection.querySelectorAll('time')).toHaveLength(2);
   });
 
+  it('shows a plus sign when a section count reaches the API cap', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/',
+      match: [
+        MockApiClient.matchQuery({
+          query: 'issue.progress:fix_proposed assigned:[me,my_teams]',
+        }),
+      ],
+      body: [fixProposedGroup],
+      headers: {'X-Hits': '1000', 'X-Max-Hits': '1000'},
+    });
+    mockSection('issue.progress:diagnosed assigned:[me,my_teams]', [diagnosedGroup]);
+    mockSection('issue.progress:assigned assigned:[me,my_teams]', [assignedGroup]);
+
+    render(<InboxPage />, {organization, initialRouterConfig});
+
+    const fixSection = screen.getByRole('region', {name: 'Fix Proposed'});
+    expect(await within(fixSection).findByText('1000+')).toBeInTheDocument();
+  });
+
   it('expands and collapses progress sections', async () => {
     mockSuccessfulSections();
 
@@ -330,10 +365,15 @@ describe('InboxPage', () => {
 
   it('filters sections by the selected assignee', async () => {
     mockSuccessfulSections();
-    const myTeamsRequests = [
-      mockSection('issue.progress:fix_proposed assigned:my_teams', [fixProposedGroup]),
-      mockSection('issue.progress:diagnosed assigned:my_teams', [diagnosedGroup]),
-      mockSection('issue.progress:assigned assigned:my_teams', [assignedGroup]),
+    const meRequests = [
+      mockSection('issue.progress:fix_proposed assigned:me', [fixProposedGroup]),
+      mockSection('issue.progress:diagnosed assigned:me', [diagnosedGroup]),
+      mockSection('issue.progress:assigned assigned:me', [assignedGroup]),
+    ];
+    const allRequests = [
+      mockSection('issue.progress:fix_proposed', [fixProposedGroup]),
+      mockSection('issue.progress:diagnosed', [diagnosedGroup]),
+      mockSection('issue.progress:assigned', [assignedGroup]),
     ];
 
     const {router} = render(<InboxPage />, {
@@ -343,15 +383,25 @@ describe('InboxPage', () => {
 
     const meFilter = screen.getByRole('radio', {name: 'Me'});
     const myTeamsFilter = screen.getByRole('radio', {name: 'My Teams'});
-    expect(meFilter).toBeChecked();
-    expect(myTeamsFilter).not.toBeChecked();
+    const allFilter = screen.getByRole('radio', {name: 'All'});
+    expect(meFilter).not.toBeChecked();
+    expect(myTeamsFilter).toBeChecked();
+    expect(allFilter).not.toBeChecked();
     expect(await screen.findByText('Fix proposed issue')).toBeInTheDocument();
 
-    await userEvent.click(myTeamsFilter);
+    await userEvent.click(meFilter);
 
-    expect(myTeamsFilter).toBeChecked();
-    expect(router.location.query.assignment).toBe('my_teams');
-    for (const request of myTeamsRequests) {
+    expect(meFilter).toBeChecked();
+    expect(router.location.query.assignment).toBe('me');
+    for (const request of meRequests) {
+      await waitFor(() => expect(request).toHaveBeenCalledTimes(1));
+    }
+
+    await userEvent.click(allFilter);
+
+    expect(allFilter).toBeChecked();
+    expect(router.location.query.assignment).toBe('all');
+    for (const request of allRequests) {
       await waitFor(() => expect(request).toHaveBeenCalledTimes(1));
     }
   });
@@ -371,7 +421,7 @@ describe('InboxPage', () => {
       url: '/organizations/org-slug/issues/',
       match: [
         MockApiClient.matchQuery({
-          query: 'issue.progress:fix_proposed assigned:me',
+          query: 'issue.progress:fix_proposed assigned:[me,my_teams]',
         }),
       ],
       body: [fixProposedGroup],
@@ -384,7 +434,7 @@ describe('InboxPage', () => {
       url: '/organizations/org-slug/issues/',
       match: [
         MockApiClient.matchQuery({
-          query: 'issue.progress:fix_proposed assigned:me',
+          query: 'issue.progress:fix_proposed assigned:[me,my_teams]',
           cursor: '0:5:0',
         }),
       ],
@@ -392,8 +442,8 @@ describe('InboxPage', () => {
       headers: {'X-Hits': '2'},
       asyncDelay: 100,
     });
-    mockSection('issue.progress:diagnosed assigned:me', [diagnosedGroup]);
-    mockSection('issue.progress:assigned assigned:me', [assignedGroup]);
+    mockSection('issue.progress:diagnosed assigned:[me,my_teams]', [diagnosedGroup]);
+    mockSection('issue.progress:assigned assigned:[me,my_teams]', [assignedGroup]);
 
     render(<InboxPage />, {organization, initialRouterConfig});
 

--- a/static/app/views/issueList/pages/inbox.tsx
+++ b/static/app/views/issueList/pages/inbox.tsx
@@ -25,6 +25,7 @@ import {PageFilterBar} from 'sentry/components/pageFilters/pageFilterBar';
 import {ProjectPageFilter} from 'sentry/components/pageFilters/project/projectPageFilter';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {Placeholder} from 'sentry/components/placeholder';
+import {QueryCount} from 'sentry/components/queryCount';
 import {IconArrow, IconChevron} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import {ProgressState, type Group} from 'sentry/types/group';
@@ -45,8 +46,13 @@ const TITLE = t('Inbox');
 const ISSUE_LIMIT = 5;
 const SELECTED_ISSUE_QUERY_PARAM = 'preview';
 const ASSIGNMENT_QUERY_PARAM = 'assignment';
-const ASSIGNMENT_FILTERS = ['me', 'my_teams'] as const;
+const ASSIGNMENT_FILTERS = ['me', 'my_teams', 'all'] as const;
 type AssignmentFilter = (typeof ASSIGNMENT_FILTERS)[number];
+const ASSIGNMENT_QUERY_SUFFIXES: Record<AssignmentFilter, string> = {
+  me: ' assigned:me',
+  my_teams: ' assigned:[me,my_teams]',
+  all: '',
+};
 
 interface InboxSectionConfig {
   defaultExpanded: boolean;
@@ -107,7 +113,7 @@ function InboxContent() {
   const [assignmentFilter, setAssignmentFilter] = useQueryState(
     ASSIGNMENT_QUERY_PARAM,
     parseAsStringLiteral(ASSIGNMENT_FILTERS)
-      .withDefault('me')
+      .withDefault('my_teams')
       .withOptions({history: 'replace'})
   );
   const [selectedIssueId, setSelectedIssueId] = useQueryState(
@@ -163,6 +169,7 @@ function InboxContent() {
               <SegmentedControl.Item key="my_teams">
                 {t('My Teams')}
               </SegmentedControl.Item>
+              <SegmentedControl.Item key="all">{t('All')}</SegmentedControl.Item>
             </SegmentedControl>
           </Flex>
           <Stack flex={1} minHeight={0} overflowY="auto">
@@ -231,7 +238,7 @@ function InboxSection({
       query: {
         project: selection.projects,
         environment: selection.environments,
-        query: `${section.query} assigned:${assignmentFilter}`,
+        query: `${section.query}${ASSIGNMENT_QUERY_SUFFIXES[assignmentFilter]}`,
         sort: IssueSortOptions.PROGRESS,
         limit: ISSUE_LIMIT,
         expand: ['owners', 'derivedData'],
@@ -247,6 +254,7 @@ function InboxSection({
   });
   const groups = queryResult.data?.pages.flatMap(page => page.json) ?? [];
   const count = queryResult.data?.pages[0]?.headers['X-Hits'] ?? groups.length;
+  const maxCount = queryResult.data?.pages[0]?.headers['X-Max-Hits'];
   const {data: members = []} = useMembers();
   const membersById = new Map(members.map(member => [member.id, member]));
 
@@ -259,7 +267,13 @@ function InboxSection({
     >
       <Container padding="xs" width="100%">
         <Container width="100%" padding="sm" background="secondary" radius="sm">
-          <Disclosure.Title trailingItems={<Badge variant="muted">{count}</Badge>}>
+          <Disclosure.Title
+            trailingItems={
+              <Badge variant="muted">
+                <QueryCount count={count} max={maxCount} hideIfEmpty={false} hideParens />
+              </Badge>
+            }
+          >
             <Flex align="center" gap="sm">
               {getProgressIcon(section.progress)}
               <Heading as="h3" size="md">


### PR DESCRIPTION
Closes ISWF-3124

- adds "all" option to query across the whole org
- "My Teams" now includes "me,my_teams"
- "My Teams" is the default selection