### PR TITLE
chore(crons): When deleting checkins, skip marking them as pending deletion.

### DIFF
--- a/src/sentry/deletions/base.py
+++ b/src/sentry/deletions/base.py
@@ -67,8 +67,11 @@ class ModelRelation(BaseRelation):
         model: type[ModelT],
         query: Mapping[str, Any],
         task: type[BaseDeletionTask[Any]] | None = None,
+        mark_in_progress: bool | None = None,
     ) -> None:
-        params = {"model": model, "query": query}
+        params: dict[str, Any] = {"model": model, "query": query}
+        if mark_in_progress is not None:
+            params["mark_in_progress"] = mark_in_progress
 
         super().__init__(params=params, task=task)
 
@@ -81,6 +84,10 @@ class BaseDeletionTask(Generic[ModelT]):
 
     DEFAULT_CHUNK_SIZE = 100
 
+    # Whether to mark instances as ``ObjectStatus.DELETION_IN_PROGRESS`` before
+    # deleting them.
+    mark_in_progress_default = True
+
     def __init__(
         self,
         manager: DeletionTaskManager,
@@ -88,12 +95,16 @@ class BaseDeletionTask(Generic[ModelT]):
         transaction_id: str | None = None,
         actor_id: int | None = None,
         chunk_size: int | None = None,
+        mark_in_progress: bool | None = None,
     ):
         self.manager = manager
         self.skip_models = set(skip_models) if skip_models else None
         self.transaction_id = transaction_id
         self.actor_id = actor_id
         self.chunk_size = chunk_size if chunk_size is not None else self.DEFAULT_CHUNK_SIZE
+        self.mark_in_progress = (
+            mark_in_progress if mark_in_progress is not None else self.mark_in_progress_default
+        )
 
     def __repr__(self) -> str:
         return f"<{type(self)}: skip_models={self.skip_models} transaction_id={self.transaction_id} actor_id={self.actor_id}>"
@@ -139,7 +150,8 @@ class BaseDeletionTask(Generic[ModelT]):
         This **should** not be called with arbitrary types, but rather should
         be used for only the base type this task was instantiated against.
         """
-        self.mark_deletion_in_progress(instance_list)
+        if self.mark_in_progress:
+            self.mark_deletion_in_progress(instance_list)
 
         child_relations = self.get_child_relations_bulk(instance_list)
         child_relations = self.filter_relations(child_relations)

--- a/src/sentry/deletions/defaults/monitor.py
+++ b/src/sentry/deletions/defaults/monitor.py
@@ -12,6 +12,12 @@ class MonitorDeletionTask(ModelDeletionTask[Monitor]):
 
         return [
             ModelRelation(models.MonitorIncident, {"monitor_id": instance.id}),
-            ModelRelation(models.MonitorCheckIn, {"monitor_id": instance.id}, ModelDeletionTask),
+            ModelRelation(
+                models.MonitorCheckIn,
+                {"monitor_id": instance.id},
+                ModelDeletionTask,
+                # Skip marking as in progress for deletion since this can be a high volume delete
+                mark_in_progress=False,
+            ),
             ModelRelation(models.MonitorEnvironment, {"monitor_id": instance.id}),
         ]

--- a/src/sentry/deletions/defaults/monitor_checkin.py
+++ b/src/sentry/deletions/defaults/monitor_checkin.py
@@ -3,6 +3,8 @@ from sentry.monitors.models import MonitorCheckIn
 
 
 class MonitorCheckInDeletionTask(ModelDeletionTask[MonitorCheckIn]):
+    mark_in_progress_default = False
+
     def get_child_relations(self, instance: MonitorCheckIn) -> list[BaseRelation]:
         from sentry.monitors import models
 

--- a/tests/sentry/deletions/test_monitor_checkin.py
+++ b/tests/sentry/deletions/test_monitor_checkin.py
@@ -1,3 +1,6 @@
+from unittest import mock
+
+from sentry.deletions.base import ModelDeletionTask
 from sentry.deletions.tasks.scheduled import run_scheduled_deletions
 from sentry.models.environment import Environment
 from sentry.monitors.models import (
@@ -14,6 +17,96 @@ from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 
 
 class DeleteMonitorCheckInTest(APITestCase, TransactionTestCase, HybridCloudTestMixin):
+    def _spy_marked_models(self) -> tuple[mock._patch, list[str]]:
+        marked_models: list[str] = []
+        original = ModelDeletionTask.mark_deletion_in_progress
+
+        def spy(task: ModelDeletionTask, instance_list: object) -> None:
+            marked_models.append(task.model.__name__)
+            original(task, instance_list)  # type: ignore[arg-type]
+
+        patcher = mock.patch.object(
+            ModelDeletionTask, "mark_deletion_in_progress", autospec=True, side_effect=spy
+        )
+        return patcher, marked_models
+
+    def test_delete_monitor_does_not_mark_checkins_in_progress(self) -> None:
+        """
+        Deleting a Monitor should not mark its check-ins as
+        DELETION_IN_PROGRESS (an UPDATE per row) since the interim status is
+        meaningless for rows that are about to be deleted. Other models should
+        still be marked.
+        """
+        project = self.create_project(name="test")
+        env = Environment.objects.create(organization_id=project.organization_id, name="prod")
+
+        monitor = Monitor.objects.create(
+            organization_id=project.organization.id,
+            project_id=project.id,
+            config={"schedule": "* * * * *", "schedule_type": ScheduleType.CRONTAB},
+        )
+        monitor_env = MonitorEnvironment.objects.create(
+            monitor=monitor,
+            environment_id=env.id,
+        )
+        for status in (CheckInStatus.OK, CheckInStatus.ERROR, CheckInStatus.OK):
+            MonitorCheckIn.objects.create(
+                monitor=monitor,
+                monitor_environment=monitor_env,
+                project_id=project.id,
+                status=status,
+            )
+
+        self.ScheduledDeletion.schedule(instance=monitor, days=0)
+
+        patcher, marked_models = self._spy_marked_models()
+        with patcher, self.tasks():
+            run_scheduled_deletions()
+
+        assert not MonitorCheckIn.objects.filter(monitor_id=monitor.id).exists()
+        assert "MonitorCheckIn" not in marked_models
+        assert "Monitor" in marked_models
+
+    def test_delete_checkin_directly_does_not_mark_in_progress(self) -> None:
+        """
+        Deleting a MonitorCheckIn directly should also skip marking it as
+        DELETION_IN_PROGRESS.
+        """
+        project = self.create_project(name="test")
+        env = Environment.objects.create(organization_id=project.organization_id, name="prod")
+
+        monitor = Monitor.objects.create(
+            organization_id=project.organization.id,
+            project_id=project.id,
+            config={"schedule": "* * * * *", "schedule_type": ScheduleType.CRONTAB},
+        )
+        monitor_env = MonitorEnvironment.objects.create(
+            monitor=monitor,
+            environment_id=env.id,
+        )
+        checkin = MonitorCheckIn.objects.create(
+            monitor=monitor,
+            monitor_environment=monitor_env,
+            project_id=project.id,
+            status=CheckInStatus.ERROR,
+        )
+        incident = MonitorIncident.objects.create(
+            monitor=monitor,
+            monitor_environment=monitor_env,
+            starting_checkin=checkin,
+        )
+
+        self.ScheduledDeletion.schedule(instance=checkin, days=0)
+
+        patcher, marked_models = self._spy_marked_models()
+        with patcher, self.tasks():
+            run_scheduled_deletions()
+
+        assert not MonitorCheckIn.objects.filter(id=checkin.id).exists()
+        assert not MonitorIncident.objects.filter(id=incident.id).exists()
+        assert "MonitorCheckIn" not in marked_models
+        assert "MonitorIncident" in marked_models
+
     def test_delete_checkin_directly(self) -> None:
         """
         Test that deleting a MonitorCheckIn directly (not via Monitor deletion)

--- a/tests/sentry/deletions/test_monitor_checkin.py
+++ b/tests/sentry/deletions/test_monitor_checkin.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+from typing import Any
 from unittest import mock
 
 from sentry.deletions.base import ModelDeletionTask
@@ -17,11 +20,11 @@ from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 
 
 class DeleteMonitorCheckInTest(APITestCase, TransactionTestCase, HybridCloudTestMixin):
-    def _spy_marked_models(self) -> tuple[mock._patch, list[str]]:
+    def _spy_marked_models(self) -> tuple[mock._patch[mock.MagicMock], list[str]]:
         marked_models: list[str] = []
         original = ModelDeletionTask.mark_deletion_in_progress
 
-        def spy(task: ModelDeletionTask, instance_list: object) -> None:
+        def spy(task: ModelDeletionTask[Any], instance_list: object) -> None:
             marked_models.append(task.model.__name__)
             original(task, instance_list)  # type: ignore[arg-type]
 


### PR DESCRIPTION
We often delete a lot of checkins in a short period of time when deleting monitors (whether directly, via deleting a project or an org). Before deletions, we mark all the rows as deletion in progress. This doubles the number of mutations we perform when deleting a cron, and there's no real need to do it in this case.

Ideally we'd also throttle these, but this is a simple way to cut the load of deletions by half.

<!-- Describe your PR here. -->