### PR TITLE
feat(scm-project-creation-flow): Storing decoded notification selecti…

### DIFF
--- a/static/app/components/onboarding/onboardingContext.tsx
+++ b/static/app/components/onboarding/onboardingContext.tsx
@@ -1,10 +1,10 @@
 import {createContext, useContext, useEffect, useMemo, useRef} from 'react';
 
 import type {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
-import type {IntegrationAction} from 'sentry/types/alerts';
 import type {Integration, Repository} from 'sentry/types/integrations';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import {useSessionStorage} from 'sentry/utils/useSessionStorage';
+import type {NotificationSelection} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 import type {AlertRuleOptions} from 'sentry/views/projectInstall/issueAlertOptions';
 
 /**
@@ -15,7 +15,7 @@ import type {AlertRuleOptions} from 'sentry/views/projectInstall/issueAlertOptio
  */
 export interface ProjectDetailsFormState {
   alertRuleConfig?: AlertRuleOptions;
-  notificationAction?: IntegrationAction;
+  notificationSelection?: NotificationSelection;
   projectName?: string;
   teamSlug?: string;
 }

--- a/static/app/components/onboarding/scm/useScmProjectDetails.spec.tsx
+++ b/static/app/components/onboarding/scm/useScmProjectDetails.spec.tsx
@@ -7,7 +7,6 @@ import {act, renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLib
 
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {TeamStore} from 'sentry/stores/teamStore';
-import {IssueAlertActionType} from 'sentry/types/alerts';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import {MultipleCheckboxOptions} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 import {
@@ -207,7 +206,7 @@ describe('useScmProjectDetails', () => {
       ProjectsStore.loadInitialData([]);
     });
 
-    it('includes notificationAction in the submittedForm passed to onComplete', async () => {
+    it('includes notificationSelection in the submittedForm passed to onComplete', async () => {
       const createdProject = ProjectFixture({slug: 'my-project', platform: 'python'});
 
       MockApiClient.addMockResponse({
@@ -254,14 +253,14 @@ describe('useScmProjectDetails', () => {
       await waitFor(() => expect(onComplete).toHaveBeenCalled());
 
       const {projectDetailsForm: submittedForm} = onComplete.mock.calls[0][0];
-      expect(submittedForm.notificationAction).toEqual({
-        id: IssueAlertActionType.SLACK,
-        workspace: slackIntegration.id,
+      expect(submittedForm.notificationSelection).toEqual({
+        provider: 'slack',
+        integrationId: slackIntegration.id,
         channel: '#eng',
       });
     });
 
-    it('does not persist a notificationAction when alerts are turned off', async () => {
+    it('does not persist a notificationSelection when alerts are turned off', async () => {
       const createdProject = ProjectFixture({slug: 'my-project', platform: 'python'});
 
       MockApiClient.addMockResponse({
@@ -302,44 +301,19 @@ describe('useScmProjectDetails', () => {
 
       await waitFor(() => expect(onComplete).toHaveBeenCalled());
 
-      // No notification UI was shown, so the snapshot must not carry an action
-      // (it would otherwise force the restore gate on a later visit).
+      // No notification UI was shown, so the snapshot must not carry a
+      // selection (it would otherwise force the restore gate on a later visit).
       const {projectDetailsForm: submittedForm} = onComplete.mock.calls[0][0];
-      expect(submittedForm.notificationAction).toBeUndefined();
-    });
-
-    it('restores provider/integration/channel from a persisted notificationAction', async () => {
-      const persistedAction = {
-        id: IssueAlertActionType.SLACK as const,
-        workspace: slackIntegration.id,
-        channel: '#restored',
-      };
-
-      const {result} = renderDetails({
-        projectDetailsForm: {
-          projectName: 'my-project',
-          teamSlug: adminTeam.slug,
-          notificationAction: persistedAction,
-        },
-      });
-
-      await waitFor(() =>
-        expect(result.current.notificationProps.provider).toBe('slack')
-      );
-      expect(result.current.notificationProps.integration?.id).toBe(slackIntegration.id);
-      expect(result.current.notificationProps.channel?.value).toBe('#restored');
-      expect(result.current.notificationProps.actions).toContain(
-        MultipleCheckboxOptions.INTEGRATION
-      );
+      expect(submittedForm.notificationSelection).toBeUndefined();
     });
 
     it('reuses the project when the user returns with the same notification action', async () => {
       const existingProject = ProjectFixture({slug: 'my-project', platform: 'python'});
       ProjectsStore.loadInitialData([existingProject]);
 
-      const persistedAction = {
-        id: IssueAlertActionType.SLACK as const,
-        workspace: slackIntegration.id,
+      const persistedSelection = {
+        provider: 'slack',
+        integrationId: slackIntegration.id,
         channel: '#eng',
       };
 
@@ -350,7 +324,7 @@ describe('useScmProjectDetails', () => {
           teamSlug: adminTeam.slug,
           // alertRuleConfig must match the in-use defaults so nothingChanged is true.
           alertRuleConfig: DEFAULT_ISSUE_ALERT_OPTIONS_VALUES,
-          notificationAction: persistedAction,
+          notificationSelection: persistedSelection,
         },
         createdProjectSlug: existingProject.slug,
         selectedPlatform: pythonPlatform,
@@ -374,9 +348,9 @@ describe('useScmProjectDetails', () => {
       const existingProject = ProjectFixture({slug: 'my-project', platform: 'python'});
       ProjectsStore.loadInitialData([existingProject]);
 
-      const persistedAction = {
-        id: IssueAlertActionType.SLACK as const,
-        workspace: slackIntegration.id,
+      const persistedSelection = {
+        provider: 'slack',
+        integrationId: slackIntegration.id,
         channel: '#eng',
       };
 
@@ -392,7 +366,7 @@ describe('useScmProjectDetails', () => {
           projectName: 'my-project',
           teamSlug: adminTeam.slug,
           alertRuleConfig: DEFAULT_ISSUE_ALERT_OPTIONS_VALUES,
-          notificationAction: persistedAction,
+          notificationSelection: persistedSelection,
         },
         createdProjectSlug: existingProject.slug,
         selectedPlatform: pythonPlatform,
@@ -431,9 +405,9 @@ describe('useScmProjectDetails', () => {
       const existingProject = ProjectFixture({slug: 'my-project', platform: 'python'});
       ProjectsStore.loadInitialData([existingProject]);
 
-      const persistedAction = {
-        id: IssueAlertActionType.SLACK as const,
-        workspace: slackIntegration.id,
+      const persistedSelection = {
+        provider: 'slack',
+        integrationId: slackIntegration.id,
         channel: '#eng',
       };
 
@@ -442,7 +416,7 @@ describe('useScmProjectDetails', () => {
           projectName: 'my-project',
           teamSlug: adminTeam.slug,
           alertRuleConfig: DEFAULT_ISSUE_ALERT_OPTIONS_VALUES,
-          notificationAction: persistedAction,
+          notificationSelection: persistedSelection,
         },
         createdProjectSlug: existingProject.slug,
         selectedPlatform: pythonPlatform,
@@ -482,9 +456,9 @@ describe('useScmProjectDetails', () => {
         body: [],
       });
 
-      const persistedAction = {
-        id: IssueAlertActionType.SLACK as const,
-        workspace: slackIntegration.id,
+      const persistedSelection = {
+        provider: 'slack',
+        integrationId: slackIntegration.id,
         channel: '#eng',
       };
 
@@ -493,7 +467,7 @@ describe('useScmProjectDetails', () => {
           projectName: 'my-project',
           teamSlug: adminTeam.slug,
           alertRuleConfig: DEFAULT_ISSUE_ALERT_OPTIONS_VALUES,
-          notificationAction: persistedAction,
+          notificationSelection: persistedSelection,
         },
         selectedPlatform: pythonPlatform,
       });
@@ -507,12 +481,13 @@ describe('useScmProjectDetails', () => {
     });
 
     it('unblocks submit and falls back to email-only when saved integration is deleted', async () => {
-      // The saved action points to workspace '999', which is not in the current
-      // integration list (only slackIntegration with id '10' is present). This
-      // simulates the integration being deleted after the form was first submitted.
-      const persistedAction = {
-        id: IssueAlertActionType.SLACK as const,
-        workspace: '999',
+      // The saved selection points to integrationId '999', which is not in the
+      // current integration list (only slackIntegration with id '10' is
+      // present). This simulates the integration being deleted after the form
+      // was first submitted.
+      const persistedSelection = {
+        provider: 'slack',
+        integrationId: '999',
         channel: '#eng',
       };
 
@@ -529,7 +504,7 @@ describe('useScmProjectDetails', () => {
           projectName: 'my-project',
           teamSlug: adminTeam.slug,
           alertRuleConfig: DEFAULT_ISSUE_ALERT_OPTIONS_VALUES,
-          notificationAction: persistedAction,
+          notificationSelection: persistedSelection,
         },
         selectedPlatform: pythonPlatform,
         onComplete,
@@ -546,7 +521,7 @@ describe('useScmProjectDetails', () => {
       expect(result.current.canSubmit).toBe(true);
 
       // Submitting falls back to email-only: no messaging rule is created and
-      // onComplete receives notificationAction === undefined.
+      // onComplete receives notificationSelection === undefined.
       act(() => {
         result.current.submit();
       });
@@ -554,16 +529,16 @@ describe('useScmProjectDetails', () => {
       await waitFor(() => expect(onComplete).toHaveBeenCalled());
       expect(createMock).toHaveBeenCalled();
       const {projectDetailsForm: submittedForm} = onComplete.mock.calls[0][0];
-      expect(submittedForm.notificationAction).toBeUndefined();
+      expect(submittedForm.notificationSelection).toBeUndefined();
     });
 
     it('creates a new project when the notification channel changes on return', async () => {
       const existingProject = ProjectFixture({slug: 'my-project', platform: 'python'});
       ProjectsStore.loadInitialData([existingProject]);
 
-      const persistedAction = {
-        id: IssueAlertActionType.SLACK as const,
-        workspace: slackIntegration.id,
+      const persistedSelection = {
+        provider: 'slack',
+        integrationId: slackIntegration.id,
         channel: '#eng',
       };
 
@@ -585,7 +560,7 @@ describe('useScmProjectDetails', () => {
           projectName: 'my-project',
           teamSlug: adminTeam.slug,
           alertRuleConfig: DEFAULT_ISSUE_ALERT_OPTIONS_VALUES,
-          notificationAction: persistedAction,
+          notificationSelection: persistedSelection,
         },
         createdProjectSlug: existingProject.slug,
         selectedPlatform: pythonPlatform,

--- a/static/app/components/onboarding/scm/useScmProjectDetails.ts
+++ b/static/app/components/onboarding/scm/useScmProjectDetails.ts
@@ -194,11 +194,9 @@ export function useScmProjectDetails({
   // Provides the messaging-integration notification picker (notificationProps,
   // rendered in ScmAlertFrequencySection) and the side-effect that creates the
   // chosen notification rule at project creation.
-  const {createNotificationAction, notificationProps} = useScmNotificationAction({
-    provider: restoredNotificationSelectionRef.current?.provider,
-    integrationId: restoredNotificationSelectionRef.current?.integrationId,
-    channel: restoredNotificationSelectionRef.current?.channel,
-  });
+  const {createNotificationAction, notificationProps} = useScmNotificationAction(
+    restoredNotificationSelectionRef.current
+  );
 
   const accessTeams = teams.filter((team: Team) => team.access.includes('team:admin'));
   const firstAdminTeam = accessTeams[0];

--- a/static/app/components/onboarding/scm/useScmProjectDetails.ts
+++ b/static/app/components/onboarding/scm/useScmProjectDetails.ts
@@ -19,10 +19,10 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
 import {useTeams} from 'sentry/utils/useTeams';
 import {
-  buildIntegrationAction,
+  buildNotificationSelection,
   type IssueAlertNotificationProps,
   MultipleCheckboxOptions,
-  useCreateNotificationAction,
+  useScmNotificationAction,
 } from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 import {
   DEFAULT_ISSUE_ALERT_OPTIONS_VALUES,
@@ -187,18 +187,20 @@ export function useScmProjectDetails({
   const {projects, initiallyLoaded: projectsLoaded} = useProjects();
   const createProjectAndRules = useCreateProjectAndRules();
 
-  const restoredNotificationOptionsRef = useRef(
-    projectDetailsForm?.notificationAction
-      ? {actions: [projectDetailsForm.notificationAction]}
-      : undefined
+  const restoredNotificationSelectionRef = useRef(
+    projectDetailsForm?.notificationSelection
   );
 
   // Provides the messaging-integration notification picker (notificationProps,
   // rendered in ScmAlertFrequencySection) and the side-effect that creates the
-  // chosen notification rule at project creation.
-  const {createNotificationAction, notificationProps} = useCreateNotificationAction(
-    restoredNotificationOptionsRef.current
-  );
+  // chosen notification rule at project creation. Restores directly from the
+  // raw provider/integrationId/channel fields stored in the wizard's form
+  // state, with no decoding step.
+  const {createNotificationAction, notificationProps} = useScmNotificationAction({
+    provider: restoredNotificationSelectionRef.current?.provider,
+    integrationId: restoredNotificationSelectionRef.current?.integrationId,
+    channel: restoredNotificationSelectionRef.current?.channel,
+  });
 
   const accessTeams = teams.filter((team: Team) => team.access.includes('team:admin'));
   const firstAdminTeam = accessTeams[0];
@@ -312,7 +314,9 @@ export function useScmProjectDetails({
 
   const submitTooltipText = getSubmitTooltipText(missingFields);
 
-  const notificationRestoreCompleteRef = useRef(!projectDetailsForm?.notificationAction);
+  const notificationRestoreCompleteRef = useRef(
+    !projectDetailsForm?.notificationSelection
+  );
 
   // Blocks canSubmit until a persisted notification selection settles, then latches open
   // so later edits don't re-block. No-op when there's no saved action.
@@ -364,8 +368,8 @@ export function useScmProjectDetails({
     alertRuleConfig.metric === savedAlert?.metric &&
     alertRuleConfig.threshold === savedAlert?.threshold &&
     isEqual(
-      hasNotificationAction ? buildIntegrationAction(notificationProps) : undefined,
-      savedForm?.notificationAction
+      hasNotificationAction ? buildNotificationSelection(notificationProps) : undefined,
+      savedForm?.notificationSelection
     );
 
   const submit = useCallback(async () => {
@@ -377,14 +381,14 @@ export function useScmProjectDetails({
 
     trackAnalytics(CREATE_CLICKED_EVENT[analyticsFlow], {organization});
 
-    const notificationAction = hasNotificationAction
-      ? buildIntegrationAction(notificationProps)
+    const notificationSelection = hasNotificationAction
+      ? buildNotificationSelection(notificationProps)
       : undefined;
     const submittedForm = {
       projectName: projectNameResolved,
       teamSlug: teamSlugResolved,
       alertRuleConfig,
-      notificationAction,
+      notificationSelection,
     };
 
     try {

--- a/static/app/components/onboarding/scm/useScmProjectDetails.ts
+++ b/static/app/components/onboarding/scm/useScmProjectDetails.ts
@@ -193,9 +193,7 @@ export function useScmProjectDetails({
 
   // Provides the messaging-integration notification picker (notificationProps,
   // rendered in ScmAlertFrequencySection) and the side-effect that creates the
-  // chosen notification rule at project creation. Restores directly from the
-  // raw provider/integrationId/channel fields stored in the wizard's form
-  // state, with no decoding step.
+  // chosen notification rule at project creation.
   const {createNotificationAction, notificationProps} = useScmNotificationAction({
     provider: restoredNotificationSelectionRef.current?.provider,
     integrationId: restoredNotificationSelectionRef.current?.integrationId,

--- a/static/app/views/projectInstall/issueAlertNotificationOptions.spec.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.spec.tsx
@@ -501,12 +501,34 @@ describe('useScmNotificationAction', () => {
     addIntegrationsResponse([]);
 
     const {result} = renderHookWithProviders(
-      () => useScmNotificationAction({provider: 'slack', channel: '#eng'}),
+      () =>
+        useScmNotificationAction({
+          provider: 'slack',
+          integrationId: slackIntegration.id,
+          channel: '#eng',
+        }),
       {organization}
     );
 
     await waitFor(() => expect(result.current.notificationProps.querySuccess).toBe(true));
     expect(result.current.notificationProps.shouldRenderSetupButton).toBe(true);
+    expect(result.current.notificationProps.actions).not.toContain(
+      MultipleCheckboxOptions.INTEGRATION
+    );
+  });
+
+  it('falls back to auto-select when no integrationId is given', async () => {
+    addIntegrationsResponse([slackIntegration]);
+
+    const {result} = renderHookWithProviders(
+      () => useScmNotificationAction({provider: 'slack'}),
+      {organization}
+    );
+
+    // No integrationId means the hook treats the input as no stored selection
+    // and auto-selects the first available integration instead.
+    await waitFor(() => expect(result.current.notificationProps.provider).toBe('slack'));
+    expect(result.current.notificationProps.integration?.id).toBe(slackIntegration.id);
     expect(result.current.notificationProps.actions).not.toContain(
       MultipleCheckboxOptions.INTEGRATION
     );
@@ -519,6 +541,17 @@ describe('buildNotificationSelection', () => {
       buildNotificationSelection({
         provider: undefined,
         integration: undefined,
+        channel: undefined,
+      })
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when provider and integration are set but channel is absent', () => {
+    const integration = OrganizationIntegrationsFixture({id: '5'});
+    expect(
+      buildNotificationSelection({
+        provider: 'slack',
+        integration,
         channel: undefined,
       })
     ).toBeUndefined();

--- a/static/app/views/projectInstall/issueAlertNotificationOptions.spec.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.spec.tsx
@@ -15,10 +15,12 @@ import {
 import {IssueAlertActionType} from 'sentry/types/alerts';
 import type {OrganizationIntegration} from 'sentry/types/integrations';
 import {
+  buildNotificationSelection,
   IssueAlertNotificationOptions,
   type IssueAlertNotificationProps,
   MultipleCheckboxOptions,
   useCreateNotificationAction,
+  useScmNotificationAction,
 } from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 
 describe('MessagingIntegrationAlertRule', () => {
@@ -359,5 +361,177 @@ describe('useCreateNotificationAction', () => {
       expect(result.current.notificationProps.provider).toBe('discord')
     );
     expect(result.current.notificationProps.channel?.value).toBe('2');
+  });
+});
+
+describe('useScmNotificationAction', () => {
+  const organization = OrganizationFixture();
+
+  const slackIntegration = OrganizationIntegrationsFixture({
+    id: '1',
+    name: 'my-workspace',
+    status: 'active',
+    provider: {
+      key: 'slack',
+      slug: 'slack',
+      name: 'Slack',
+      canAdd: true,
+      canDisable: false,
+      features: [],
+      aspects: {},
+    },
+  });
+
+  function addIntegrationsResponse(body: OrganizationIntegration[]) {
+    return MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/`,
+      body,
+      match: [MockApiClient.matchQuery({integrationType: 'messaging'})],
+    });
+  }
+
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('auto-selects the first integration when no selection is given', async () => {
+    addIntegrationsResponse([slackIntegration]);
+
+    const {result} = renderHookWithProviders(() => useScmNotificationAction(), {
+      organization,
+    });
+
+    await waitFor(() => expect(result.current.notificationProps.provider).toBe('slack'));
+    expect(result.current.notificationProps.integration?.id).toBe(slackIntegration.id);
+    expect(result.current.notificationProps.actions).not.toContain(
+      MultipleCheckboxOptions.INTEGRATION
+    );
+  });
+
+  it('applies a selection directly, with no decoding, when the integration is already loaded', async () => {
+    addIntegrationsResponse([slackIntegration]);
+
+    const {result} = renderHookWithProviders(
+      () =>
+        useScmNotificationAction({
+          provider: 'slack',
+          integrationId: slackIntegration.id,
+          channel: '#eng',
+        }),
+      {organization}
+    );
+
+    await waitFor(() => expect(result.current.notificationProps.provider).toBe('slack'));
+    expect(result.current.notificationProps.integration?.id).toBe(slackIntegration.id);
+    expect(result.current.notificationProps.channel?.value).toBe('#eng');
+    expect(result.current.notificationProps.actions).toContain(
+      MultipleCheckboxOptions.INTEGRATION
+    );
+    expect(result.current.notificationProps.shouldRenderSetupButton).toBe(false);
+  });
+
+  it('picks the selected integration over the first in the list', async () => {
+    const secondSlack = OrganizationIntegrationsFixture({
+      id: '2',
+      name: 'second-workspace',
+      status: 'active',
+      provider: slackIntegration.provider,
+    });
+    addIntegrationsResponse([slackIntegration, secondSlack]);
+
+    const {result} = renderHookWithProviders(
+      () =>
+        useScmNotificationAction({
+          provider: 'slack',
+          integrationId: secondSlack.id,
+          channel: '#team',
+        }),
+      {organization}
+    );
+
+    await waitFor(() => expect(result.current.notificationProps.provider).toBe('slack'));
+    expect(result.current.notificationProps.integration?.id).toBe(secondSlack.id);
+    expect(result.current.notificationProps.channel?.value).toBe('#team');
+  });
+
+  it('waits for a refetch when the selected integration is not loaded yet', async () => {
+    // First fetch returns nothing (integration not yet visible / mid-load).
+    addIntegrationsResponse([]);
+
+    const {result} = renderHookWithProviders(
+      () =>
+        useScmNotificationAction({
+          provider: 'slack',
+          integrationId: slackIntegration.id,
+          channel: '#eng',
+        }),
+      {organization}
+    );
+
+    // Query resolved but integration list empty: setup CTA shown, guard not
+    // latched, INTEGRATION must NOT be in actions (picker not half-applied).
+    await waitFor(() => expect(result.current.notificationProps.querySuccess).toBe(true));
+    expect(result.current.notificationProps.provider).toBeUndefined();
+    expect(result.current.notificationProps.shouldRenderSetupButton).toBe(true);
+    expect(result.current.notificationProps.actions).not.toContain(
+      MultipleCheckboxOptions.INTEGRATION
+    );
+
+    // Refetch delivers the Slack integration.
+    MockApiClient.clearMockResponses();
+    addIntegrationsResponse([slackIntegration]);
+    act(() => {
+      focusManager.setFocused(false);
+    });
+    act(() => {
+      focusManager.setFocused(true);
+    });
+
+    // Full restore completes: provider, integration, channel, and actions are set.
+    await waitFor(() => expect(result.current.notificationProps.provider).toBe('slack'));
+    expect(result.current.notificationProps.integration?.id).toBe(slackIntegration.id);
+    expect(result.current.notificationProps.channel?.value).toBe('#eng');
+    expect(result.current.notificationProps.actions).toContain(
+      MultipleCheckboxOptions.INTEGRATION
+    );
+    expect(result.current.notificationProps.shouldRenderSetupButton).toBe(false);
+  });
+
+  it('shows the setup CTA without latching when there are no integrations at all', async () => {
+    addIntegrationsResponse([]);
+
+    const {result} = renderHookWithProviders(
+      () => useScmNotificationAction({provider: 'slack', channel: '#eng'}),
+      {organization}
+    );
+
+    await waitFor(() => expect(result.current.notificationProps.querySuccess).toBe(true));
+    expect(result.current.notificationProps.shouldRenderSetupButton).toBe(true);
+    expect(result.current.notificationProps.actions).not.toContain(
+      MultipleCheckboxOptions.INTEGRATION
+    );
+  });
+});
+
+describe('buildNotificationSelection', () => {
+  it('returns undefined when there is no provider or integration selected', () => {
+    expect(
+      buildNotificationSelection({
+        provider: undefined,
+        integration: undefined,
+        channel: undefined,
+      })
+    ).toBeUndefined();
+  });
+
+  it('maps provider, integration id, and channel into a raw selection', () => {
+    const integration = OrganizationIntegrationsFixture({id: '5'});
+    expect(
+      buildNotificationSelection({
+        provider: 'slack',
+        integration,
+        channel: {label: '#eng', value: '#eng'},
+      })
+    ).toEqual({provider: 'slack', integrationId: '5', channel: '#eng'});
   });
 });

--- a/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
@@ -101,8 +101,6 @@ export type IssueAlertNotificationProps = {
 /**
  * Builds the serializable IntegrationAction for the current messaging
  * selection. Returns undefined if the provider is unrecognised or unset.
- * Exported so callers can persist the action snapshot and use it as
- * `defaultActions` on the next mount to restore the selection.
  */
 function buildIntegrationAction({
   provider,
@@ -136,14 +134,14 @@ function buildIntegrationAction({
 }
 
 export type NotificationSelection = {
+  channel: string;
+  integrationId: string;
   provider: string;
-  channel?: string;
-  integrationId?: string;
 };
 
 /**
  * Builds the raw {provider, integrationId, channel} snapshot of the current
- * messaging selection. Returns undefined if there's no provider/integration selected.
+ * messaging selection. Returns undefined if any of the three fields are absent.
  */
 export function buildNotificationSelection({
   provider,
@@ -152,10 +150,10 @@ export function buildNotificationSelection({
 }: Pick<IssueAlertNotificationProps, 'provider' | 'integration' | 'channel'>):
   | NotificationSelection
   | undefined {
-  if (!provider || !integration) {
+  if (!provider || !integration || !channel?.value) {
     return undefined;
   }
-  return {provider, integrationId: integration.id, channel: channel?.value};
+  return {provider, integrationId: integration.id, channel: channel.value};
 }
 
 /**
@@ -405,25 +403,22 @@ export function useScmNotificationAction({
   provider,
   integrationId,
   channel,
-}: {
-  channel?: string;
-  integrationId?: string;
-  provider?: string;
-} = {}) {
+}: Partial<NotificationSelection> = {}) {
   const resolveRestore = useCallback<RestoreResolver>(
     providersToIntegrations => {
-      if (!provider) {
+      // A stored selection always carries an integrationId (the encoder bails
+      // without one); anything less is treated as no selection at all.
+      if (!provider || !integrationId) {
         return {kind: 'auto'};
       }
 
-      const matchedIntegration = integrationId
-        ? (providersToIntegrations[provider] ?? []).find(i => i.id === integrationId)
-        : providersToIntegrations[provider]?.[0];
+      const matchedIntegration = providersToIntegrations[provider]?.find(
+        i => i.id === integrationId
+      );
 
-      // Whether the selection names a specific integration or just a provider,
-      // an unresolved integration means the picker can't be safely applied yet:
-      // show the setup CTA and don't latch, so this re-resolves after a
-      // refetch (mirrors the classic decode resolver's guard).
+      // Named integration not (yet) in the query response: show the setup CTA
+      // and don't latch, so this re-resolves after a refetch delivers it
+      // (mirrors the classic decode resolver's guard).
       if (!matchedIntegration) {
         return {kind: 'wait'};
       }

--- a/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
@@ -104,7 +104,7 @@ export type IssueAlertNotificationProps = {
  * Exported so callers can persist the action snapshot and use it as
  * `defaultActions` on the next mount to restore the selection.
  */
-export function buildIntegrationAction({
+function buildIntegrationAction({
   provider,
   integration,
   channel,

--- a/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
@@ -135,9 +135,62 @@ export function buildIntegrationAction({
   }
 }
 
-export function useCreateNotificationAction({
-  actions: defaultActions,
-}: Partial<Pick<RequestDataFragment, 'actions'>> = {}) {
+export type NotificationSelection = {
+  provider: string;
+  channel?: string;
+  integrationId?: string;
+};
+
+/**
+ * Builds the raw {provider, integrationId, channel} snapshot of the current
+ * messaging selection. For callers (the SCM wizard) that persist their own
+ * selection directly rather than a flattened `IntegrationAction`. Returns
+ * undefined if there's no provider/integration selected.
+ */
+export function buildNotificationSelection({
+  provider,
+  integration,
+  channel,
+}: Pick<IssueAlertNotificationProps, 'provider' | 'integration' | 'channel'>):
+  | NotificationSelection
+  | undefined {
+  if (!provider || !integration) {
+    return undefined;
+  }
+  return {provider, integrationId: integration.id, channel: channel?.value};
+}
+
+/**
+ * Result of resolving the initial notification-picker selection, computed
+ * from whatever restore source a caller-specific hook uses (a persisted
+ * rule action, a raw stored selection, etc). `useNotificationPicker` applies
+ * this uniformly so the restore logic itself can differ per caller.
+ */
+type RestoreOutcome =
+  | {kind: 'auto'}
+  | {kind: 'wait'}
+  | {
+      actions: MultipleCheckboxOptions[];
+      channel: IntegrationChannel | undefined;
+      integration: OrganizationIntegration | undefined;
+      kind: 'apply';
+      provider: string | undefined;
+      shouldRenderSetupButton: boolean;
+    };
+
+type RestoreResolver = (
+  providersToIntegrations: Record<string, OrganizationIntegration[]>
+) => RestoreOutcome;
+
+/**
+ * Flow-agnostic base for the messaging-integration notification picker: owns
+ * the integrations query, picker state, the once-only restore/auto-select
+ * effect, and the create-rule side effect. Callers only supply how to
+ * resolve the initial selection via `resolveRestore` — see
+ * `useCreateNotificationAction` (restores from a persisted rule action) and
+ * `useScmNotificationAction` (restores from a raw stored selection).
+ */
+function useNotificationPicker(resolveRestore: RestoreResolver) {
   const organization = useOrganization();
   const createProjectRules = useCreateProjectRules();
 
@@ -177,75 +230,40 @@ export function useCreateNotificationAction({
 
   const hasInitializedSelection = useRef(false);
 
-  function getIntegrationId(action: IssueAlertRuleAction): string | undefined {
-    switch (action.id) {
-      case IssueAlertActionType.SLACK:
-        return action.workspace;
-      case IssueAlertActionType.DISCORD:
-        return action.server;
-      case IssueAlertActionType.MS_TEAMS:
-        return action.team;
-      default:
-        return undefined;
-    }
-  }
-
   // Seeds the notification picker once, after the integrations query resolves:
-  // restores the provider/integration/channel from a default action when one is
-  // present, otherwise auto-selects the first available integration. Guarded by
-  // a ref so it runs a single time and never overwrites later user edits.
+  // restores the selection via `resolveRestore` when it can, otherwise
+  // auto-selects the first available integration. Guarded by a ref so it runs
+  // a single time and never overwrites later user edits.
   useEffect(() => {
     if (!messagingIntegrationsQuery.isSuccess || hasInitializedSelection.current) {
       return;
     }
 
-    const firstAction = defaultActions?.[0];
-    if (firstAction) {
-      // Restore from a persisted/default action (e.g. back-nav). Provider key is
-      // derived from the action's id; integration is matched by integrationId if
-      // present, falling back to the first in the list.
-      const matchedProviderKey = Object.keys(providerDetails).find(
-        key =>
-          providerDetails[key as keyof typeof providerDetails].action === firstAction.id
-      );
-      const integrationId = getIntegrationId(firstAction);
-      const integrationList = matchedProviderKey
-        ? (providersToIntegrations[matchedProviderKey] ?? [])
-        : [];
-      const matchedIntegration = integrationId
-        ? integrationList.find(i => i.id === integrationId)
-        : integrationList[0];
+    const outcome = resolveRestore(providersToIntegrations);
 
-      // Integration action whose integration hasn't loaded yet: show the setup CTA
-      // and wait for a refetch to deliver it. Don't latch or half-apply the
-      // restore, so the picker can't look submittable with an unresolved integration.
-      const isIntegrationAction = firstAction.id !== IssueAlertActionType.NOTIFY_EMAIL;
-      if (isIntegrationAction && !matchedIntegration) {
-        setShouldRenderSetupButton(true);
-        return;
+    if (outcome.kind === 'wait') {
+      // The restore source names an integration that hasn't loaded yet: show
+      // the setup CTA and do NOT latch, so this effect re-runs after a
+      // refetch delivers it. Don't half-apply the restore, so the picker
+      // can't look submittable with an unresolved integration.
+      setShouldRenderSetupButton(true);
+      return;
+    }
+
+    if (outcome.kind === 'apply') {
+      setProvider(outcome.provider);
+      setIntegration(outcome.integration);
+      // eslint-disable-next-line react-you-might-not-need-an-effect/no-derived-state
+      setActions(outcome.actions);
+      setShouldRenderSetupButton(outcome.shouldRenderSetupButton);
+      if (outcome.channel) {
+        setChannel(outcome.channel);
       }
-
-      setProvider(matchedProviderKey);
-      setIntegration(matchedIntegration);
-      setShouldRenderSetupButton(!matchedIntegration);
-
-      const newActions =
-        firstAction.id === IssueAlertActionType.NOTIFY_EMAIL
-          ? [MultipleCheckboxOptions.EMAIL]
-          : [MultipleCheckboxOptions.EMAIL, MultipleCheckboxOptions.INTEGRATION];
-      setActions(newActions);
-
-      const restoredChannel = firstAction.channel ?? firstAction.channel_id;
-      if (restoredChannel) {
-        // eslint-disable-next-line react-you-might-not-need-an-effect/no-derived-state
-        setChannel({label: restoredChannel, value: restoredChannel});
-      }
-
       hasInitializedSelection.current = true;
       return;
     }
 
-    // No persisted action: auto-select the first available provider/integration.
+    // No restore source: auto-select the first available provider/integration.
     const providerKeys = Object.keys(providersToIntegrations);
     const firstProvider = providerKeys[0];
     if (!firstProvider) {
@@ -260,7 +278,7 @@ export function useCreateNotificationAction({
     setIntegration(firstIntegration);
     setChannel(undefined);
     setShouldRenderSetupButton(false);
-  }, [messagingIntegrationsQuery.isSuccess, providersToIntegrations, defaultActions]);
+  }, [messagingIntegrationsQuery.isSuccess, providersToIntegrations, resolveRestore]);
 
   const createNotificationAction = useCallback(
     ({
@@ -312,6 +330,122 @@ export function useCreateNotificationAction({
       shouldRenderSetupButton,
     },
   };
+}
+
+function getIntegrationId(action: IssueAlertRuleAction): string | undefined {
+  switch (action.id) {
+    case IssueAlertActionType.SLACK:
+      return action.workspace;
+    case IssueAlertActionType.DISCORD:
+      return action.server;
+    case IssueAlertActionType.MS_TEAMS:
+      return action.team;
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Classic notification-picker adapter: restores the selection by decoding a
+ * persisted `IssueAlertRuleAction` (e.g. from a previously created rule, in
+ * the API's flattened action shape). Used by the standalone Create Project
+ * page, whose only restore source is a real created rule.
+ */
+export function useCreateNotificationAction({
+  actions: defaultActions,
+}: Partial<Pick<RequestDataFragment, 'actions'>> = {}) {
+  const resolveRestore = useCallback<RestoreResolver>(
+    providersToIntegrations => {
+      const firstAction = defaultActions?.[0];
+      if (!firstAction) {
+        return {kind: 'auto'};
+      }
+
+      // Provider key is derived from the action's id; integration is matched
+      // by integrationId if present, falling back to the first in the list.
+      const matchedProviderKey = Object.keys(providerDetails).find(
+        key =>
+          providerDetails[key as keyof typeof providerDetails].action === firstAction.id
+      );
+      const integrationId = getIntegrationId(firstAction);
+      const integrationList = matchedProviderKey
+        ? (providersToIntegrations[matchedProviderKey] ?? [])
+        : [];
+      const matchedIntegration = integrationId
+        ? integrationList.find(i => i.id === integrationId)
+        : integrationList[0];
+
+      const isIntegrationAction = firstAction.id !== IssueAlertActionType.NOTIFY_EMAIL;
+      if (isIntegrationAction && !matchedIntegration) {
+        return {kind: 'wait'};
+      }
+
+      const restoredChannel = firstAction.channel ?? firstAction.channel_id;
+
+      return {
+        kind: 'apply',
+        provider: matchedProviderKey,
+        integration: matchedIntegration,
+        channel: restoredChannel
+          ? {label: restoredChannel, value: restoredChannel}
+          : undefined,
+        actions: isIntegrationAction
+          ? [MultipleCheckboxOptions.EMAIL, MultipleCheckboxOptions.INTEGRATION]
+          : [MultipleCheckboxOptions.EMAIL],
+        shouldRenderSetupButton: !matchedIntegration,
+      };
+    },
+    [defaultActions]
+  );
+
+  return useNotificationPicker(resolveRestore);
+}
+
+/**
+ * SCM notification-picker adapter: restores the selection directly from raw
+ * `provider`/`integrationId`/`channel` fields (e.g. persisted in the SCM
+ * wizard's own session storage), with no decoding step.
+ */
+export function useScmNotificationAction({
+  provider,
+  integrationId,
+  channel,
+}: {
+  channel?: string;
+  integrationId?: string;
+  provider?: string;
+} = {}) {
+  const resolveRestore = useCallback<RestoreResolver>(
+    providersToIntegrations => {
+      if (!provider) {
+        return {kind: 'auto'};
+      }
+
+      const matchedIntegration = integrationId
+        ? (providersToIntegrations[provider] ?? []).find(i => i.id === integrationId)
+        : providersToIntegrations[provider]?.[0];
+
+      // Whether the selection names a specific integration or just a provider,
+      // an unresolved integration means the picker can't be safely applied yet:
+      // show the setup CTA and don't latch, so this re-resolves after a
+      // refetch (mirrors the classic decode resolver's guard).
+      if (!matchedIntegration) {
+        return {kind: 'wait'};
+      }
+
+      return {
+        kind: 'apply',
+        provider,
+        integration: matchedIntegration,
+        channel: channel ? {label: channel, value: channel} : undefined,
+        actions: [MultipleCheckboxOptions.EMAIL, MultipleCheckboxOptions.INTEGRATION],
+        shouldRenderSetupButton: false,
+      };
+    },
+    [provider, integrationId, channel]
+  );
+
+  return useNotificationPicker(resolveRestore);
 }
 
 /**

--- a/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
@@ -143,9 +143,7 @@ export type NotificationSelection = {
 
 /**
  * Builds the raw {provider, integrationId, channel} snapshot of the current
- * messaging selection. For callers (the SCM wizard) that persist their own
- * selection directly rather than a flattened `IntegrationAction`. Returns
- * undefined if there's no provider/integration selected.
+ * messaging selection. Returns undefined if there's no provider/integration selected.
  */
 export function buildNotificationSelection({
   provider,
@@ -163,8 +161,7 @@ export function buildNotificationSelection({
 /**
  * Result of resolving the initial notification-picker selection, computed
  * from whatever restore source a caller-specific hook uses (a persisted
- * rule action, a raw stored selection, etc). `useNotificationPicker` applies
- * this uniformly so the restore logic itself can differ per caller.
+ * rule action, a raw stored selection, etc).
  */
 type RestoreOutcome =
   | {kind: 'auto'}
@@ -186,9 +183,7 @@ type RestoreResolver = (
  * Flow-agnostic base for the messaging-integration notification picker: owns
  * the integrations query, picker state, the once-only restore/auto-select
  * effect, and the create-rule side effect. Callers only supply how to
- * resolve the initial selection via `resolveRestore` — see
- * `useCreateNotificationAction` (restores from a persisted rule action) and
- * `useScmNotificationAction` (restores from a raw stored selection).
+ * resolve the initial selection via `resolveRestore`.
  */
 function useNotificationPicker(resolveRestore: RestoreResolver) {
   const organization = useOrganization();


### PR DESCRIPTION
**Problem:**

The SCM wizard stored its messaging notification choice as a flattened `IssueAlertRuleAction` and then reverse-engineered `provider/integration/channel` back out of it on restore. That decode logic sat in a hook shared with the classic Create Project page, but only the classic page needs it (its restore source is a real server rule in that shape). The SCM wizard owns its storage and could just save/read the fields directly.

**Refactor:**

Went with a shared base hook plus thin per-flow adapters rather than forking the hook or branching inside it, because the two flows share nearly everything — the integrations query, picker state, and rule creation — and diverge only in how they decode the initial selection. So only that one piece gets specialized.

`useNotificationPicker` owns the shared logic and runs a per-flow restore resolver. `useCreateNotificationAction` keeps the decode path with an unchanged signature, so the classic page is untouched; a new `useScmNotificationAction` restores directly from raw `{provider, integrationId, channel}`. The SCM wizard now persists notificationSelection instead of notificationAction, via a small `buildNotificationSelection` encoder.

**Tests:**

Legacy `useCreateNotificationAction` suite left untouched and passing as the regression net. SCM hook spec converted to the new `notificationSelection` shape (one duplicate removed). Added coverage for the new code paths the legacy tests don't touch: a `useScmNotificationAction` suite and unit tests for `buildNotificationSelection`.