### PR TITLE
fix(overrides): upsell footer not rendering in date filter

### DIFF
--- a/static/app/components/overrideOrDefault.tsx
+++ b/static/app/components/overrideOrDefault.tsx
@@ -62,22 +62,15 @@ export function OverrideOrDefault<H extends OverrideName>({
     return defaultComponent;
   }
 
-  // Overrides are registered asynchronously during app bootstrap;
-  // resolving too early can permanently miss them.
-  let ResolvedComponent: React.ComponentType<any> | undefined;
-  let isResolved = false;
-
   function OverrideOrDefaultComponent(props: Props) {
-    if (!isResolved) {
-      ResolvedComponent = getOverride(overrideName)?.() ?? getDefaultComponent();
-      isResolved = true;
-    }
+    // Defining the props here is unnecessary and slow for typescript
+    const OverrideComponent: React.ComponentType<any> =
+      getOverride(overrideName)?.() ?? getDefaultComponent();
 
-    if (!ResolvedComponent) {
+    if (!OverrideComponent) {
       return null;
     }
-
-    return <ResolvedComponent {...props} />;
+    return <OverrideComponent {...props} />;
   }
 
   OverrideOrDefaultComponent.displayName = `OverrideOrDefaultComponent(${overrideName})`;

--- a/static/app/components/overrideOrDefault.tsx
+++ b/static/app/components/overrideOrDefault.tsx
@@ -62,10 +62,17 @@ export function OverrideOrDefault<H extends OverrideName>({
     return defaultComponent;
   }
 
-  const ResolvedComponent: React.ComponentType<any> | undefined =
-    getOverride(overrideName)?.() ?? getDefaultComponent();
+  // Overrides are registered asynchronously during app bootstrap;
+  // resolving too early can permanently miss them.
+  let ResolvedComponent: React.ComponentType<any> | undefined;
+  let isResolved = false;
 
   function OverrideOrDefaultComponent(props: Props) {
+    if (!isResolved) {
+      ResolvedComponent = getOverride(overrideName)?.() ?? getDefaultComponent();
+      isResolved = true;
+    }
+
     if (!ResolvedComponent) {
       return null;
     }


### PR DESCRIPTION
Just fixing a bug i've noticed! I git blamed [this pr](https://github.com/getsentry/sentry/pull/120028) to being the culprit but basically the date filter upsell footer was not rendering because it was being forced to resolve before the async call could return the component. This change waits for that async call to return before deciding if it has been resolved or not.

| Before | After |
|--------|--------|
| <img width="620" alt="image" src="https://github.com/user-attachments/assets/21c8930b-9c55-4186-8409-2d3a84c21df2" /> | <img width="619" height="520" alt="Screenshot 2026-07-27 at 12 09 25 PM" src="https://github.com/user-attachments/assets/72edf5ab-945c-4d49-9252-a4c93bad0f3a" /> |  

EDIT: Talked to Ryan in DMs and decided to revert sentry's changes so i've just edited the code for that