### PR TITLE
fix(preprod): Disallow wildcards for snapshot status

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -4511,29 +4511,6 @@ describe('SearchQueryBuilder', () => {
         expect(doesNotEndWithOption).toBeInTheDocument();
       });
 
-      it('does not allow wildcard operators for snapshot statuses', async () => {
-        render(
-          <SearchQueryBuilder
-            {...defaultProps}
-            initialQuery="snapshot_status:failed"
-            fieldDefinitionGetter={key => getFieldDefinition(key, 'preprod')}
-          />
-        );
-
-        await userEvent.click(
-          screen.getByRole('button', {
-            name: 'Edit operator for filter: snapshot_status',
-          })
-        );
-
-        expect(await screen.findByRole('option', {name: 'is'})).toBeInTheDocument();
-        expect(screen.queryByRole('option', {name: 'contains'})).not.toBeInTheDocument();
-        expect(
-          screen.queryByRole('option', {name: 'starts with'})
-        ).not.toBeInTheDocument();
-        expect(screen.queryByRole('option', {name: 'ends with'})).not.toBeInTheDocument();
-      });
-
       it('default-string filters have wildcard operator options', async () => {
         render(
           <SearchQueryBuilder {...defaultProps} initialQuery="custom_tag_name:hello" />

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -4511,6 +4511,29 @@ describe('SearchQueryBuilder', () => {
         expect(doesNotEndWithOption).toBeInTheDocument();
       });
 
+      it('does not allow wildcard operators for snapshot statuses', async () => {
+        render(
+          <SearchQueryBuilder
+            {...defaultProps}
+            initialQuery="snapshot_status:failed"
+            fieldDefinitionGetter={key => getFieldDefinition(key, 'preprod')}
+          />
+        );
+
+        await userEvent.click(
+          screen.getByRole('button', {
+            name: 'Edit operator for filter: snapshot_status',
+          })
+        );
+
+        expect(await screen.findByRole('option', {name: 'is'})).toBeInTheDocument();
+        expect(screen.queryByRole('option', {name: 'contains'})).not.toBeInTheDocument();
+        expect(
+          screen.queryByRole('option', {name: 'starts with'})
+        ).not.toBeInTheDocument();
+        expect(screen.queryByRole('option', {name: 'ends with'})).not.toBeInTheDocument();
+      });
+
       it('default-string filters have wildcard operator options', async () => {
         render(
           <SearchQueryBuilder {...defaultProps} initialQuery="custom_tag_name:hello" />

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -2712,6 +2712,7 @@ const PREPROD_FIELD_DEFINITIONS: Record<string, FieldDefinition> = {
     desc: t('Status of the snapshot in the comparison pipeline'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
+    allowWildcard: false,
     values: [
       'approved',
       'auto_approved',


### PR DESCRIPTION
Snapshot status filters now offer only exact-match operators, preventing the search builder from generating wildcard values that the preprod API rejects.
Fixes EME-1252

| Before | After |
| --- | --- |
| <img width="443" height="409" alt="1252-before" src="https://github.com/user-attachments/assets/d455568b-f14f-41c7-a442-db7f4a22a768" /> | <img width="391" height="359" alt="1252-after" src="https://github.com/user-attachments/assets/1bcb55d4-2ef4-443f-9fa6-8e94fae024d5" /> |
