### PR TITLE
fix(crons): Throttle max deletion rate

### DIFF
--- a/src/sentry/deletions/base.py
+++ b/src/sentry/deletions/base.py
@@ -2,14 +2,17 @@ from __future__ import annotations
 
 import logging
 import re
+import time
 from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from django.db import router
 from django.db.models import Q
 
+from sentry import options
 from sentry.constants import ObjectStatus
 from sentry.db.models.base import Model
+from sentry.ratelimits.leaky_bucket import LeakyBucketRateLimiter
 from sentry.silo.safety import unguarded_write
 from sentry.users.services.user.model import RpcUser
 from sentry.users.services.user.service import user_service
@@ -20,6 +23,7 @@ logger = logging.getLogger(__name__)
 
 _leaf_re = re.compile(r"^(UserReport|Event|Group)(.+)")
 
+_MAX_RATE_LIMIT_SLEEP = 1.0
 
 if TYPE_CHECKING:
     from sentry.deletions.manager import DeletionTaskManager
@@ -68,10 +72,13 @@ class ModelRelation(BaseRelation):
         query: Mapping[str, Any],
         task: type[BaseDeletionTask[Any]] | None = None,
         mark_in_progress: bool | None = None,
+        rate_limit_option: str | None = None,
     ) -> None:
         params: dict[str, Any] = {"model": model, "query": query}
         if mark_in_progress is not None:
             params["mark_in_progress"] = mark_in_progress
+        if rate_limit_option is not None:
+            params["rate_limit_option"] = rate_limit_option
 
         super().__init__(params=params, task=task)
 
@@ -88,6 +95,10 @@ class BaseDeletionTask(Generic[ModelT]):
     # deleting them.
     mark_in_progress_default = True
 
+    # Name of an int option used to rate limit the aggregate deletion throughput
+    # for this task's model across all concurrent deletions. None disables throttling.
+    rate_limit_option_default: str | None = None
+
     def __init__(
         self,
         manager: DeletionTaskManager,
@@ -96,6 +107,7 @@ class BaseDeletionTask(Generic[ModelT]):
         actor_id: int | None = None,
         chunk_size: int | None = None,
         mark_in_progress: bool | None = None,
+        rate_limit_option: str | None = None,
     ):
         self.manager = manager
         self.skip_models = set(skip_models) if skip_models else None
@@ -104,6 +116,9 @@ class BaseDeletionTask(Generic[ModelT]):
         self.chunk_size = chunk_size if chunk_size is not None else self.DEFAULT_CHUNK_SIZE
         self.mark_in_progress = (
             mark_in_progress if mark_in_progress is not None else self.mark_in_progress_default
+        )
+        self.rate_limit_option = (
+            rate_limit_option if rate_limit_option is not None else self.rate_limit_option_default
         )
 
     def __repr__(self) -> str:
@@ -239,11 +254,40 @@ class ModelDeletionTask(BaseDeletionTask[ModelT]):
             if not queryset:
                 return False
 
+            self._throttle_deletes(len(queryset))
             self.delete_bulk(queryset)
             remaining = remaining - len(queryset)
 
         # We have more work to do as we didn't run out of rows to delete.
         return True
+
+    def _throttle_deletes(self, num_rows: int) -> None:
+        """
+        Rate limit deletion throughput for this model across all concurrent deletion tasks.
+        """
+        option_name = self.rate_limit_option
+        if not option_name or num_rows <= 0:
+            return
+
+        rate = options.get(option_name)
+        if not rate or rate <= 0:
+            return
+
+        limiter = LeakyBucketRateLimiter(
+            burst_limit=max(rate, self.query_limit),
+            drip_rate=rate,
+            key=f"deletions.rate_limit:{option_name}",
+        )
+        waited = False
+        while True:
+            info = limiter.use_and_get_info(incr_by=num_rows)
+            if info.wait_time <= 0:
+                break
+            waited = True
+            time.sleep(min(info.wait_time, _MAX_RATE_LIMIT_SLEEP))
+
+        if waited:
+            metrics.incr("deletions.rate_limited", tags={"model": self.model.__name__})
 
     def delete_instance(self, instance: ModelT) -> None:
         instance_id = instance.id

--- a/src/sentry/deletions/defaults/monitor.py
+++ b/src/sentry/deletions/defaults/monitor.py
@@ -18,6 +18,8 @@ class MonitorDeletionTask(ModelDeletionTask[Monitor]):
                 ModelDeletionTask,
                 # Skip marking as in progress for deletion since this can be a high volume delete
                 mark_in_progress=False,
+                # Rate limit check-in deletions so a large delete doesn't spike DB load
+                rate_limit_option="deletions.monitor-check-in.rate-limit",
             ),
             ModelRelation(models.MonitorEnvironment, {"monitor_id": instance.id}),
         ]

--- a/src/sentry/deletions/defaults/monitor_checkin.py
+++ b/src/sentry/deletions/defaults/monitor_checkin.py
@@ -4,6 +4,8 @@ from sentry.monitors.models import MonitorCheckIn
 
 class MonitorCheckInDeletionTask(ModelDeletionTask[MonitorCheckIn]):
     mark_in_progress_default = False
+    # Rate limit check-in deletions so a large delete doesn't spike DB load
+    rate_limit_option_default = "deletions.monitor-check-in.rate-limit"
 
     def get_child_relations(self, instance: MonitorCheckIn) -> list[BaseRelation]:
         from sentry.monitors import models

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -324,6 +324,14 @@ register(
     type=Int,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+# Aggregate rows/sec ceiling for MonitorCheckIn deletions across all concurrent
+# deletion tasks. 0 disables rate limiting.
+register(
+    "deletions.monitor-check-in.rate-limit",
+    default=1000,
+    type=Int,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 register(
     "unmerge.killswitch-projects",

--- a/tests/sentry/deletions/test_monitor_checkin.py
+++ b/tests/sentry/deletions/test_monitor_checkin.py
@@ -33,6 +33,75 @@ class DeleteMonitorCheckInTest(APITestCase, TransactionTestCase, HybridCloudTest
         )
         return patcher, marked_models
 
+    def _create_monitor_with_checkins(self, num_checkins: int) -> tuple[Monitor, int]:
+        project = self.create_project(name="test")
+        env = Environment.objects.create(organization_id=project.organization_id, name="prod")
+        monitor = Monitor.objects.create(
+            organization_id=project.organization.id,
+            project_id=project.id,
+            config={"schedule": "* * * * *", "schedule_type": ScheduleType.CRONTAB},
+        )
+        monitor_env = MonitorEnvironment.objects.create(monitor=monitor, environment_id=env.id)
+        for _ in range(num_checkins):
+            MonitorCheckIn.objects.create(
+                monitor=monitor,
+                monitor_environment=monitor_env,
+                project_id=project.id,
+                status=CheckInStatus.OK,
+            )
+        return monitor, num_checkins
+
+    def test_checkin_deletion_is_rate_limited(self) -> None:
+        monitor, num_checkins = self._create_monitor_with_checkins(5)
+        self.ScheduledDeletion.schedule(instance=monitor, days=0)
+
+        with mock.patch("sentry.deletions.base.LeakyBucketRateLimiter") as mock_limiter_cls:
+            mock_limiter_cls.return_value.use_and_get_info.return_value = mock.Mock(wait_time=0)
+            with self.tasks():
+                run_scheduled_deletions()
+
+        assert not MonitorCheckIn.objects.filter(monitor_id=monitor.id).exists()
+        mock_limiter_cls.assert_called_with(
+            burst_limit=800,
+            drip_rate=800,
+            key="deletions.rate_limit:deletions.monitor-check-in.rate-limit",
+        )
+        # Every deleted check-in is charged to the bucket exactly once.
+        limiter = mock_limiter_cls.return_value
+        total_charged = sum(
+            call.kwargs["incr_by"] for call in limiter.use_and_get_info.call_args_list
+        )
+        assert total_charged == num_checkins
+
+    def test_checkin_deletion_rate_limit_disabled(self) -> None:
+        """A rate of 0 disables throttling entirely (limiter is never built)."""
+        monitor, _ = self._create_monitor_with_checkins(3)
+        self.ScheduledDeletion.schedule(instance=monitor, days=0)
+
+        with self.options({"deletions.monitor-check-in.rate-limit": 0}):
+            with mock.patch("sentry.deletions.base.LeakyBucketRateLimiter") as mock_limiter_cls:
+                with self.tasks():
+                    run_scheduled_deletions()
+
+        assert not MonitorCheckIn.objects.filter(monitor_id=monitor.id).exists()
+        mock_limiter_cls.assert_not_called()
+
+    def test_checkin_deletion_sleeps_when_throttled(self) -> None:
+        """When the bucket reports a wait, we sleep for it before retrying."""
+        monitor, _ = self._create_monitor_with_checkins(2)
+        self.ScheduledDeletion.schedule(instance=monitor, days=0)
+
+        # First reservation is throttled (wait 0.2s), second is admitted.
+        infos = [mock.Mock(wait_time=0.2), mock.Mock(wait_time=0)]
+        with mock.patch("sentry.deletions.base.LeakyBucketRateLimiter") as mock_limiter_cls:
+            mock_limiter_cls.return_value.use_and_get_info.side_effect = infos
+            with mock.patch("sentry.deletions.base.time.sleep") as mock_sleep:
+                with self.tasks():
+                    run_scheduled_deletions()
+
+        mock_sleep.assert_called_once_with(0.2)
+        assert not MonitorCheckIn.objects.filter(monitor_id=monitor.id).exists()
+
     def test_delete_monitor_does_not_mark_checkins_in_progress(self) -> None:
         """
         Deleting a Monitor should not mark its check-ins as

--- a/tests/sentry/deletions/test_monitor_checkin.py
+++ b/tests/sentry/deletions/test_monitor_checkin.py
@@ -62,8 +62,8 @@ class DeleteMonitorCheckInTest(APITestCase, TransactionTestCase, HybridCloudTest
 
         assert not MonitorCheckIn.objects.filter(monitor_id=monitor.id).exists()
         mock_limiter_cls.assert_called_with(
-            burst_limit=800,
-            drip_rate=800,
+            burst_limit=1000,
+            drip_rate=1000,
             key="deletions.rate_limit:deletions.monitor-check-in.rate-limit",
         )
         # Every deleted check-in is charged to the bucket exactly once.


### PR DESCRIPTION
We sometimes see large spikes in deletions from crons, which cause cpu spikes and pages. We don't need to delete these at full speed, so throttle how quickly we delete them.

The downside of this method is that we'll keep the task hanging for longer. It's a simpler approach though that rewriting the deletions abstraction to be able to stop/start mid way through a whole delete, and should solve our problem.

Related to https://github.com/getsentry/sentry/pull/120670. We removed updates from the deletions process here, which should also significantly improve load.

<!-- Describe your PR here. -->