### PR TITLE
ref(seer): replace SeerViewerContext with ViewerContext contextvar

### DIFF
--- a/src/sentry/ai_monitoring/tasks.py
+++ b/src/sentry/ai_monitoring/tasks.py
@@ -20,11 +20,11 @@ from sentry.ai_monitoring.utils import (
     span_source_timestamp,
 )
 from sentry.models.project import Project
-from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import ai_agent_monitoring_tasks
 from sentry.utils import metrics
+from sentry.viewer_context import ViewerContext, viewer_context_scope
 
 
 def _is_earliest(source_ts: datetime) -> Q:
@@ -79,9 +79,10 @@ def generate_ai_conversation_title(
         metrics.incr("ai_monitoring.conversation_title.skip", tags={"reason": "later_or_equal_ts"})
         return
 
-    title = generate_conversation_title(
-        first_user_message, viewer_context=SeerViewerContext(organization_id=organization.id)
-    )
+    with viewer_context_scope(
+        ViewerContext(organization_id=organization.id, project_id=project_id)
+    ):
+        title = generate_conversation_title(first_user_message)
     stored_conversation_id = clamp_conversation_id_for_storage(conversation_id)
 
     # Update an existing row only if this span is still the earliest.

--- a/src/sentry/api/endpoints/organization_events_trends_v2.py
+++ b/src/sentry/api/endpoints/organization_events_trends_v2.py
@@ -1,5 +1,4 @@
 import logging
-from functools import partial
 
 import sentry_sdk
 from rest_framework.exceptions import ParseError
@@ -17,7 +16,6 @@ from sentry.models.organization import Organization
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.search.events.constants import METRICS_GRANULARITIES
 from sentry.seer.breakpoints import detect_breakpoints
-from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.snuba import metrics_performance
 from sentry.snuba.discover import create_result_key, zerofill
 from sentry.snuba.metrics_performance import query as metrics_query
@@ -26,6 +24,7 @@ from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 from sentry.utils.iterators import chunked
 from sentry.utils.snuba import SnubaTSResult
+from sentry.viewer_context import ViewerContext, viewer_context_scope
 
 logger = logging.getLogger(__name__)
 
@@ -69,8 +68,6 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsEndpointBase):
     )
 
     def get(self, request: Request, organization: Organization) -> Response:
-        viewer_context = SeerViewerContext(organization_id=organization.id, user_id=request.user.id)
-
         try:
             snuba_params = self.get_snuba_params(request, organization)
         except NoProjects:
@@ -279,15 +276,18 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsEndpointBase):
             ]
 
             # send the data to microservice
-            with ContextPropagatingThreadPoolExecutor(
-                thread_name_prefix=__name__
-            ) as query_thread_pool:
-                results = list(
-                    query_thread_pool.map(
-                        partial(detect_breakpoints, viewer_context=viewer_context),
-                        trends_requests,
+            with viewer_context_scope(
+                ViewerContext(organization_id=organization.id, user_id=request.user.id)
+            ):
+                with ContextPropagatingThreadPoolExecutor(
+                    thread_name_prefix=__name__
+                ) as query_thread_pool:
+                    results = list(
+                        query_thread_pool.map(
+                            detect_breakpoints,
+                            trends_requests,
+                        )
                     )
-                )
             trend_results = []
 
             # append all the results

--- a/src/sentry/api/endpoints/organization_profiling_functions.py
+++ b/src/sentry/api/endpoints/organization_profiling_functions.py
@@ -20,13 +20,13 @@ from sentry.models.organization import Organization
 from sentry.search.events.builder.profile_functions import ProfileTopFunctionsTimeseriesQueryBuilder
 from sentry.search.events.types import QueryBuilderConfig
 from sentry.seer.breakpoints import BreakpointData, BreakpointRequest, detect_breakpoints
-from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.snuba import functions
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.referrer import Referrer
 from sentry.utils.dates import parse_stats_period, validate_interval
 from sentry.utils.sdk import set_span_attribute
 from sentry.utils.snuba import bulk_snuba_queries
+from sentry.viewer_context import ViewerContext, viewer_context_scope
 
 TOP_FUNCTIONS_LIMIT = 50
 FUNCTIONS_PER_QUERY = 10
@@ -81,8 +81,6 @@ class OrganizationProfilingFunctionTrendsEndpoint(OrganizationEventsEndpointBase
     def get(self, request: Request, organization: Organization) -> Response:
         if not self.has_feature(organization, request):
             return Response(status=404)
-
-        viewer_context = SeerViewerContext(organization_id=organization.id, user_id=request.user.id)
 
         try:
             snuba_params = self.get_snuba_params(request, organization)
@@ -189,7 +187,7 @@ class OrganizationProfilingFunctionTrendsEndpoint(OrganizationEventsEndpointBase
                 "sort": data["trend"].as_sort(),
             }
 
-            return detect_breakpoints(trends_request, viewer_context=viewer_context)["data"]
+            return detect_breakpoints(trends_request)["data"]
 
         stats_data = self.get_event_stats_data(
             request,
@@ -202,7 +200,10 @@ class OrganizationProfilingFunctionTrendsEndpoint(OrganizationEventsEndpointBase
             query=data.get("query"),
         )
 
-        trending_functions = get_trends_data(stats_data)
+        with viewer_context_scope(
+            ViewerContext(organization_id=organization.id, user_id=request.user.id)
+        ):
+            trending_functions = get_trends_data(stats_data)
 
         all_trending_functions_count = len(trending_functions)
         set_span_attribute("profiling.top_functions", all_trending_functions_count)

--- a/src/sentry/api/endpoints/organization_trace_item_attributes_ranked.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes_ranked.py
@@ -29,12 +29,12 @@ from sentry.search.eap.types import SearchResolverConfig, SupportedTraceItemType
 from sentry.search.eap.utils import can_expose_attribute, translate_internal_to_public_alias
 from sentry.search.events import fields
 from sentry.seer.endpoints.compare import compare_distributions
-from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.snuba.referrer import Referrer
 from sentry.snuba.spans_rpc import Spans
 from sentry.utils import snuba_rpc
 from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 from sentry.utils.snuba_rpc import trace_item_stats_rpc
+from sentry.viewer_context import ViewerContext, viewer_context_scope
 
 logger = logging.getLogger(__name__)
 
@@ -105,21 +105,22 @@ class OrganizationTraceItemsAttributesRankedEndpoint(OrganizationEventsEndpointB
             {"referrer": Referrer.API_TRACE_EXPLORER_STATS.value},
         )
 
-        viewer_context = SeerViewerContext(organization_id=organization.id, user_id=request.user.id)
-        scored_attrs_rrr = compare_distributions(
-            baseline=cohort_2_distribution,
-            outliers=cohort_1_distribution,
-            total_outliers=total_outliers,
-            total_baseline=total_baseline,
-            config={
-                "topKAttributes": 75,
-                "topKBuckets": 75,
-            },
-            meta={
-                "referrer": Referrer.API_TRACE_EXPLORER_STATS.value,
-            },
-            viewer_context=viewer_context,
-        )
+        with viewer_context_scope(
+            ViewerContext(organization_id=organization.id, user_id=request.user.id)
+        ):
+            scored_attrs_rrr = compare_distributions(
+                baseline=cohort_2_distribution,
+                outliers=cohort_1_distribution,
+                total_outliers=total_outliers,
+                total_baseline=total_baseline,
+                config={
+                    "topKAttributes": 75,
+                    "topKBuckets": 75,
+                },
+                meta={
+                    "referrer": Referrer.API_TRACE_EXPLORER_STATS.value,
+                },
+            )
         logger.info("scored_attrs_rrr: %s", scored_attrs_rrr)
 
         rrr_results = scored_attrs_rrr.get("results", [])

--- a/src/sentry/deletions/tasks/seer.py
+++ b/src/sentry/deletions/tasks/seer.py
@@ -4,10 +4,10 @@ from typing import Any
 from taskbroker_client.retry import Retry
 from urllib3.exceptions import HTTPError
 
-from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import deletion_tasks
+from sentry.viewer_context import ViewerContext, viewer_context_scope
 
 logger = logging.getLogger(__name__)
 
@@ -36,17 +36,16 @@ def notify_seer_repository_deleted(
     # imported here to avoid circular imports
     from sentry.seer.code_review.utils import SeerEndpoint, make_seer_request
 
-    viewer_context = SeerViewerContext(organization_id=organization_id)
-    make_seer_request(
-        path=SeerEndpoint.REPOSITORY_OFFBOARD.value,
-        payload={
-            "organization_id": organization_id,
-            "repository_id": repository_id,
-            "provider": provider,
-            "repository_name": repository_name,
-        },
-        viewer_context=viewer_context,
-    )
+    with viewer_context_scope(ViewerContext(organization_id=organization_id)):
+        make_seer_request(
+            path=SeerEndpoint.REPOSITORY_OFFBOARD.value,
+            payload={
+                "organization_id": organization_id,
+                "repository_id": repository_id,
+                "provider": provider,
+                "repository_name": repository_name,
+            },
+        )
     logger.info(
         "seer.forward_repository_delete.success",
         extra={

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -120,7 +120,7 @@ from sentry.receivers.features import record_event_processed
 from sentry.receivers.onboarding import record_release_received
 from sentry.releases.auto_creation import should_auto_create_releases
 from sentry.reprocessing2 import is_reprocessed_event
-from sentry.seer.signed_seer_api import SeerViewerContext, make_signed_seer_api_request
+from sentry.seer.signed_seer_api import make_signed_seer_api_request
 from sentry.services.eventstore.processing import event_processing_store
 from sentry.signals import (
     first_event_received,
@@ -152,6 +152,7 @@ from sentry.utils.safe import get_path, safe_execute, setdefault_path, trim
 from sentry.utils.sdk import set_span_attribute
 from sentry.utils.tag_normalization import normalized_sdk_tag_from_event
 from sentry.utils.tracing import set_span_tag, start_span, trace
+from sentry.viewer_context import ViewerContext, viewer_context_scope
 from sentry.workflow_engine.processors.detector import (
     associate_new_group_with_detector,
     ensure_association_with_detector,
@@ -1978,7 +1979,6 @@ def make_severity_score_request(
     body: SeverityScoreRequest,
     connection_pool: HTTPConnectionPool | None = None,
     timeout: int | float | None = None,
-    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     payload: SeverityScoreRequest = {**body}
     if options.get("processing.severity-backlog-test.timeout"):
@@ -1990,7 +1990,6 @@ def make_severity_score_request(
         "/v0/issues/severity-score",
         body=orjson.dumps(payload),
         timeout=timeout,
-        viewer_context=viewer_context,
     )
 
 
@@ -2211,13 +2210,16 @@ def _get_severity_score(event: Event) -> tuple[float, str]:
                     "issues.severity.seer-timeout",
                     settings.SEER_SEVERITY_TIMEOUT,
                 )
-                viewer_context = SeerViewerContext(organization_id=event.project.organization_id)
-                response = make_severity_score_request(
-                    payload,
-                    connection_pool=severity_connection_pool,
-                    timeout=timeout,
-                    viewer_context=viewer_context,
-                )
+                with viewer_context_scope(
+                    ViewerContext(
+                        organization_id=event.project.organization_id, project_id=event.project_id
+                    )
+                ):
+                    response = make_severity_score_request(
+                        payload,
+                        connection_pool=severity_connection_pool,
+                        timeout=timeout,
+                    )
                 severity = orjson.loads(response.data).get("severity")
                 reason = "ml"
         except MaxRetryError:

--- a/src/sentry/feedback/endpoints/organization_feedback_categories.py
+++ b/src/sentry/feedback/endpoints/organization_feedback_categories.py
@@ -26,8 +26,8 @@ from sentry.feedback.lib.seer_api import (
 from sentry.grouping.utils import hash_from_values
 from sentry.models.organization import Organization
 from sentry.seer.seer_setup import has_seer_access
-from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.utils.cache import cache
+from sentry.viewer_context import ViewerContext, viewer_context_scope
 
 logger = logging.getLogger(__name__)
 
@@ -107,8 +107,6 @@ class OrganizationFeedbackCategoriesEndpoint(OrganizationEndpoint):
             return Response(
                 {"detail": "AI categorization is not available for this organization."}, status=403
             )
-
-        viewer_context = SeerViewerContext(organization_id=organization.id, user_id=request.user.id)
 
         try:
             start, end = get_date_range_from_stats_period(
@@ -190,27 +188,29 @@ class OrganizationFeedbackCategoriesEndpoint(OrganizationEndpoint):
         )
 
         if len(context_feedbacks) >= THRESHOLD_TO_GET_ASSOCIATED_LABELS:
-            try:
-                response = make_label_groups_request(
-                    seer_request,
-                    timeout=SEER_TIMEOUT_S,
-                    retries=SEER_RETRIES,
-                    viewer_context=viewer_context,
-                )
-            except Exception:
-                logger.exception("Seer failed to generate user feedback label groups")
-                return Response(
-                    {"detail": "Failed to generate user feedback label groups"}, status=500
-                )
-            if response.status < 200 or response.status >= 300:
-                logger.error(
-                    "Seer failed to generate user feedback label groups",
-                    extra={"status_code": response.status, "response_data": response.data},
-                )
-                return Response(
-                    {"detail": "Failed to generate user feedback label groups"}, status=500
-                )
-            label_groups = response.json()["data"]
+            with viewer_context_scope(
+                ViewerContext(organization_id=organization.id, user_id=request.user.id)
+            ):
+                try:
+                    response = make_label_groups_request(
+                        seer_request,
+                        timeout=SEER_TIMEOUT_S,
+                        retries=SEER_RETRIES,
+                    )
+                except Exception:
+                    logger.exception("Seer failed to generate user feedback label groups")
+                    return Response(
+                        {"detail": "Failed to generate user feedback label groups"}, status=500
+                    )
+                if response.status < 200 or response.status >= 300:
+                    logger.error(
+                        "Seer failed to generate user feedback label groups",
+                        extra={"status_code": response.status, "response_data": response.data},
+                    )
+                    return Response(
+                        {"detail": "Failed to generate user feedback label groups"}, status=500
+                    )
+                label_groups = response.json()["data"]
         else:
             # If there are less than THRESHOLD_TO_GET_ASSOCIATED_LABELS feedbacks, we don't ask for associated labels
             # The more feedbacks there are, the LLM does a better job of generating associated labels since it has more context

--- a/src/sentry/feedback/endpoints/organization_feedback_summary.py
+++ b/src/sentry/feedback/endpoints/organization_feedback_summary.py
@@ -18,9 +18,9 @@ from sentry.issues.grouptype import FeedbackGroup
 from sentry.models.group import Group, GroupStatus
 from sentry.models.organization import Organization
 from sentry.seer.seer_setup import has_seer_access
-from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.utils import metrics
 from sentry.utils.cache import cache
+from sentry.viewer_context import ViewerContext, viewer_context_scope
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +38,6 @@ SEER_RETRIES = Retry(total=1, backoff_factor=3)  # 1 retry after a 3 second dela
 
 def get_summary_from_seer(
     feedback_msgs: list[str],
-    viewer_context: SeerViewerContext | None = None,
 ) -> str | None:
     request_body = SummarizeFeedbacksRequest(feedbacks=feedback_msgs)
     try:
@@ -46,7 +45,6 @@ def get_summary_from_seer(
             request_body,
             timeout=SEER_TIMEOUT_S,
             retries=SEER_RETRIES,
-            viewer_context=viewer_context,
         )
     except Exception:
         logger.exception(
@@ -94,8 +92,6 @@ class OrganizationFeedbackSummaryEndpoint(OrganizationEndpoint):
             return Response(
                 {"detail": "AI summaries are not available for this organization."}, status=403
             )
-
-        viewer_context = SeerViewerContext(organization_id=organization.id, user_id=request.user.id)
 
         try:
             start, end = get_date_range_from_stats_period(
@@ -162,7 +158,10 @@ class OrganizationFeedbackSummaryEndpoint(OrganizationEndpoint):
         if len(feedback_msgs) < MIN_FEEDBACKS_TO_SUMMARIZE:
             logger.error("Too few feedbacks to summarize after enforcing the character limit")
 
-        summary = get_summary_from_seer(feedback_msgs, viewer_context=viewer_context)
+        with viewer_context_scope(
+            ViewerContext(organization_id=organization.id, user_id=request.user.id)
+        ):
+            summary = get_summary_from_seer(feedback_msgs)
         if summary is None:
             return Response(
                 {"detail": "Failed to generate a summary for a list of feedbacks"}, status=500

--- a/src/sentry/feedback/usecases/ingest/create_feedback.py
+++ b/src/sentry/feedback/usecases/ingest/create_feedback.py
@@ -27,7 +27,6 @@ from sentry.issues.status_change_message import StatusChangeMessage
 from sentry.models.group import GroupStatus
 from sentry.models.project import Project
 from sentry.seer.seer_setup import has_seer_access
-from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.signals import first_feedback_received, first_new_feedback_received
 from sentry.types.group import GroupSubStatus
 from sentry.utils import json, metrics
@@ -275,17 +274,13 @@ def create_feedback_issue(
     _seer_vc = ViewerContext(
         organization_id=project.organization_id, project_id=project.id, actor_type=ActorType.SYSTEM
     )
-    viewer_context = SeerViewerContext(organization_id=project.organization_id)
-
     # Spam detection.
     is_message_spam = None
     is_spam_enabled = spam_detection_enabled(project)
     if is_spam_enabled:
         # Will be None if the request fails
         with viewer_context_scope(_seer_vc):
-            is_message_spam = is_spam_seer(
-                feedback_message, project.organization_id, viewer_context=viewer_context
-            )
+            is_message_spam = is_spam_seer(feedback_message, project.organization_id)
 
         metrics.incr(
             "feedback.create_feedback_issue.seer_spam_detection",
@@ -315,7 +310,6 @@ def create_feedback_issue(
                 feedback_message,
                 project.organization_id,
                 use_ai_title,
-                viewer_context=viewer_context,
             )
         )
 
@@ -352,9 +346,7 @@ def create_feedback_issue(
     if should_query_seer:
         try:
             with viewer_context_scope(_seer_vc):
-                labels = generate_labels(
-                    feedback_message, project.organization_id, viewer_context=viewer_context
-                )
+                labels = generate_labels(feedback_message, project.organization_id)
             # This will rarely happen unless the user writes a really long feedback message
             if len(labels) > MAX_AI_LABELS:
                 logger.info(

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -17,7 +17,6 @@ from sentry.grouping.ingest.grouphash_metadata import (
 from sentry.grouping.variants import BaseVariant
 from sentry.models.grouphash import GroupHash
 from sentry.models.project import Project
-from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.seer.similarity.config import (
     get_grouping_model_version,
     should_send_to_seer_for_training,
@@ -43,6 +42,7 @@ from sentry.utils import metrics
 from sentry.utils.circuit_breaker2 import CircuitBreaker, CountBasedTripStrategy
 from sentry.utils.safe import get_path
 from sentry.utils.tracing import trace
+from sentry.viewer_context import ViewerContext, viewer_context_scope
 
 logger = logging.getLogger("sentry.events.grouping")
 
@@ -362,12 +362,13 @@ def get_seer_similar_issues(
 
     request_data, seer_request_metric_tags = _build_seer_request(event, variants)
 
-    viewer_context = SeerViewerContext(organization_id=event.project.organization_id)
-    seer_results, model_used = get_similarity_data_from_seer(
-        request_data,
-        {**seer_request_metric_tags, "hybrid_fingerprint": event_has_hybrid_fingerprint},
-        viewer_context=viewer_context,
-    )
+    with viewer_context_scope(
+        ViewerContext(organization_id=event.project.organization_id, project_id=event.project.id)
+    ):
+        seer_results, model_used = get_similarity_data_from_seer(
+            request_data,
+            {**seer_request_metric_tags, "hybrid_fingerprint": event_has_hybrid_fingerprint},
+        )
 
     # All of these will get overridden if we find a usable match
     matching_seer_result = None  # JSON of result data
@@ -434,9 +435,12 @@ def get_seer_similar_issues(
 
         # We only want this for the side effect, and we know it'll return no matches, so we don't
         # bother to capture the return value.
-        get_similarity_data_from_seer(
-            request_data, seer_request_metric_tags, viewer_context=viewer_context
-        )
+        with viewer_context_scope(
+            ViewerContext(
+                organization_id=event.project.organization_id, project_id=event.project.id
+            )
+        ):
+            get_similarity_data_from_seer(request_data, seer_request_metric_tags)
 
     is_hybrid_fingerprint_case = (
         event_has_hybrid_fingerprint
@@ -726,21 +730,21 @@ def maybe_send_seer_for_new_model_training(
 
     request_data, metric_tags = _build_seer_request(event, variants, training_mode=True)
 
-    viewer_context = SeerViewerContext(organization_id=event.project.organization_id)
-    try:
-        get_similarity_data_from_seer(
-            request_data, metric_tags, raise_on_error=True, viewer_context=viewer_context
-        )
-    except Exception as e:
-        sentry_sdk.capture_exception(
-            e,
-            tags={
-                "event": event.event_id,
-                "project": event.project.id,
-                "grouphash": existing_grouphash.hash,
-            },
-        )
-        return
+    with viewer_context_scope(
+        ViewerContext(organization_id=event.project.organization_id, project_id=event.project.id)
+    ):
+        try:
+            get_similarity_data_from_seer(request_data, metric_tags, raise_on_error=True)
+        except Exception as e:
+            sentry_sdk.capture_exception(
+                e,
+                tags={
+                    "event": event.event_id,
+                    "project": event.project.id,
+                    "grouphash": existing_grouphash.hash,
+                },
+            )
+            return
 
     metrics.incr(
         "grouping.similarity.get_seer_similar_issues",

--- a/src/sentry/integrations/utils/external_issues.py
+++ b/src/sentry/integrations/utils/external_issues.py
@@ -7,7 +7,6 @@ from sentry import features
 from sentry.models.group import Group
 from sentry.seer.signed_seer_api import (
     LlmGenerateRequest,
-    SeerViewerContext,
     make_llm_generate_request,
 )
 from sentry.services.eventstore.models import GroupEvent
@@ -15,6 +14,7 @@ from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
 from sentry.utils import json
 from sentry.utils.safe import safe_execute
+from sentry.viewer_context import ViewerContext, viewer_context_scope
 
 logger = logging.getLogger(__name__)
 
@@ -63,9 +63,9 @@ class GeneratedExternalIssueDetails(TypedDict):
 
 
 def _make_generate_external_issue_details_request(
-    group: Group, event: Any | None = None, viewer_context: SeerViewerContext | None = None
+    group: Group, event: Any | None = None
 ) -> GeneratedExternalIssueDetails | None:
-    logging_ctx: dict[str, Any] = {"group_id": group.id, "viewer_context": viewer_context}
+    logging_ctx: dict[str, Any] = {"group_id": group.id}
     context = _build_event_context(group, event=event)
 
     body = LlmGenerateRequest(
@@ -85,7 +85,7 @@ def _make_generate_external_issue_details_request(
             "required": ["title", "description"],
         },
     )
-    response = make_llm_generate_request(body, timeout=10, viewer_context=viewer_context)
+    response = make_llm_generate_request(body, timeout=10)
     logging_ctx["status_code"] = response.status
     if response.status >= 400:
         logger.warning("external_issues.seer_request_failed", extra=logging_ctx)
@@ -131,10 +131,8 @@ def maybe_generate_external_issue_details(
         return empty_result
 
     try:
-        viewer_context = SeerViewerContext(organization_id=organization.id, user_id=user.id)
-        result = _make_generate_external_issue_details_request(
-            group, event=event, viewer_context=viewer_context
-        )
+        with viewer_context_scope(ViewerContext(organization_id=organization.id, user_id=user.id)):
+            result = _make_generate_external_issue_details_request(group, event=event)
     except Exception:
         logger.error("external_issues.generate_issue_details_failed", exc_info=True)
         return empty_result

--- a/src/sentry/issues/endpoints/group_similar_issues_embeddings.py
+++ b/src/sentry/issues/endpoints/group_similar_issues_embeddings.py
@@ -18,7 +18,6 @@ from sentry.grouping.grouping_info import get_grouping_info_from_variants_legacy
 from sentry.issues.endpoints.bases.group import GroupEndpoint
 from sentry.models.group import Group
 from sentry.models.grouphash import GroupHash
-from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.seer.similarity.config import get_grouping_model_version, should_skip_seer_fallback
 from sentry.seer.similarity.similar_issues import get_similarity_data_from_seer
 from sentry.seer.similarity.types import SeerSimilarIssueData, SimilarIssuesEmbeddingsRequest
@@ -31,6 +30,7 @@ from sentry.seer.similarity.utils import (
 )
 from sentry.users.models.user import User
 from sentry.utils.safe import get_path
+from sentry.viewer_context import ViewerContext, viewer_context_scope
 
 logger = logging.getLogger(__name__)
 
@@ -136,12 +136,14 @@ class GroupSimilarIssuesEmbeddingsEndpoint(GroupEndpoint):
 
         logger.info("Similar issues embeddings parameters", extra=similar_issues_params)
 
-        viewer_context = SeerViewerContext(
-            organization_id=group.project.organization.id, user_id=request.user.id
-        )
-        results, _model_used = get_similarity_data_from_seer(
-            similar_issues_params, viewer_context=viewer_context
-        )
+        with viewer_context_scope(
+            ViewerContext(
+                organization_id=group.project.organization.id,
+                user_id=request.user.id,
+                project_id=group.project.id,
+            )
+        ):
+            results, _model_used = get_similarity_data_from_seer(similar_issues_params)
 
         analytics.record(
             GroupSimilarIssuesEmbeddingsCountEvent(

--- a/src/sentry/pr_metrics/judge.py
+++ b/src/sentry/pr_metrics/judge.py
@@ -57,8 +57,9 @@ from sentry.seer.sentry_data_models import (
     UpdatePrMetricsErrorResponse,
     UpdatePrMetricsSuccessResponse,
 )
-from sentry.seer.signed_seer_api import SeerViewerContext, make_signed_seer_api_request
+from sentry.seer.signed_seer_api import make_signed_seer_api_request
 from sentry.utils import json, metrics
+from sentry.viewer_context import ViewerContext, viewer_context_scope
 
 logger = logging.getLogger(__name__)
 
@@ -231,12 +232,12 @@ def forward_pr_to_seer_judge(pull_request: PullRequest, repository: Repository) 
         "repo_name": repository.name,
         "pull_request_id": pull_request.id,
     }
-    response = make_signed_seer_api_request(
-        connection_pool=seer_pr_metrics_connection_pool,
-        path=SEER_PR_METRICS_JUDGE_PATH,
-        body=payload.json().encode("utf-8"),
-        viewer_context=SeerViewerContext(organization_id=pull_request.organization_id),
-    )
+    with viewer_context_scope(ViewerContext(organization_id=pull_request.organization_id)):
+        response = make_signed_seer_api_request(
+            connection_pool=seer_pr_metrics_connection_pool,
+            path=SEER_PR_METRICS_JUDGE_PATH,
+            body=payload.json().encode("utf-8"),
+        )
     if response.status >= 500 or response.status == 429:
         raise HTTPError(f"Seer judge forward returned retryable status {response.status}")
     if response.status >= 400:

--- a/src/sentry/replays/endpoints/project_replay_summary.py
+++ b/src/sentry/replays/endpoints/project_replay_summary.py
@@ -23,8 +23,8 @@ from sentry.replays.lib.storage import storage
 from sentry.replays.post_process import process_raw_response
 from sentry.replays.query import query_replay_instance
 from sentry.seer.seer_setup import has_seer_access
-from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.utils.tracing import start_span
+from sentry.viewer_context import ViewerContext, viewer_context_scope
 
 logger = logging.getLogger(__name__)
 
@@ -68,7 +68,6 @@ class ProjectReplaySummaryEndpoint(ProjectReplayEndpoint):
     def _make_seer_start_request(
         self,
         body: ReplaySummaryStartRequest,
-        viewer_context: SeerViewerContext | None = None,
     ) -> Response:
         """Make a start-summary request to Seer with error handling."""
         serialized = orjson.dumps(body)
@@ -89,7 +88,6 @@ class ProjectReplaySummaryEndpoint(ProjectReplayEndpoint):
                 body,
                 timeout=5,
                 retries=0,
-                viewer_context=viewer_context,
             )
         except Exception:
             logger.exception(
@@ -114,7 +112,6 @@ class ProjectReplaySummaryEndpoint(ProjectReplayEndpoint):
     def _make_seer_state_request(
         self,
         body: ReplaySummaryStateRequest,
-        viewer_context: SeerViewerContext | None = None,
     ) -> Response:
         """Make a poll-state request to Seer with error handling."""
         try:
@@ -122,7 +119,6 @@ class ProjectReplaySummaryEndpoint(ProjectReplayEndpoint):
                 body,
                 timeout=5,
                 retries=0,
-                viewer_context=viewer_context,
             )
         except Exception:
             logger.exception(
@@ -177,19 +173,21 @@ class ProjectReplaySummaryEndpoint(ProjectReplayEndpoint):
             # Since this endpoint is polled, we skip checking Seer permissions here for performance.
             # Both the frontend and summary generation are gated by the same permissions.
 
-            viewer_context = SeerViewerContext(
-                organization_id=project.organization_id, user_id=request.user.id
-            )
-
             # Request Seer for the state of the summary task.
-            return self._make_seer_state_request(
-                ReplaySummaryStateRequest(
-                    replay_id=replay_id,
-                    organization_id=project.organization.id,
+            with viewer_context_scope(
+                ViewerContext(
+                    organization_id=project.organization_id,
+                    user_id=request.user.id,
                     project_id=project.id,
-                ),
-                viewer_context=viewer_context,
-            )
+                )
+            ):
+                return self._make_seer_state_request(
+                    ReplaySummaryStateRequest(
+                        replay_id=replay_id,
+                        organization_id=project.organization.id,
+                        project_id=project.id,
+                    ),
+                )
 
     def post(self, request: Request, project: Project, replay_id: str) -> Response:
         """Download replay segment data and parse it into logs. Then post to Seer to start a summary task."""
@@ -282,8 +280,11 @@ class ProjectReplaySummaryEndpoint(ProjectReplayEndpoint):
             if temperature is not None:
                 start_request["temperature"] = temperature
 
-            viewer_context = SeerViewerContext(
-                organization_id=project.organization_id, user_id=request.user.id
-            )
-
-            return self._make_seer_start_request(start_request, viewer_context=viewer_context)
+            with viewer_context_scope(
+                ViewerContext(
+                    organization_id=project.organization_id,
+                    user_id=request.user.id,
+                    project_id=project.id,
+                )
+            ):
+                return self._make_seer_start_request(start_request)

--- a/src/sentry/replays/usecases/delete.py
+++ b/src/sentry/replays/usecases/delete.py
@@ -34,7 +34,6 @@ from sentry.replays.query import replay_url_parser_config
 from sentry.replays.usecases.events import archive_event
 from sentry.replays.usecases.query import execute_query, handle_search_filters
 from sentry.replays.usecases.query.configs.aggregate import search_config as agg_search_config
-from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 from sentry.utils.retries import ConditionalRetryPolicy, exponential_delay
 from sentry.utils.snuba import (
@@ -44,6 +43,7 @@ from sentry.utils.snuba import (
     SnubaError,
     UnexpectedResponseError,
 )
+from sentry.viewer_context import ViewerContext, viewer_context_scope
 
 SNUBA_RETRY_EXCEPTIONS = (
     RateLimitExceeded,
@@ -200,15 +200,15 @@ def delete_seer_replay_data(organization_id: int, project_id: int, replay_ids: l
         project_id=project_id,
     )
 
-    viewer_context = SeerViewerContext(organization_id=organization_id)
-
     try:
-        response = make_replay_delete_request(
-            seer_request,
-            timeout=5,
-            retries=Retry(total=1, backoff_factor=3),  # 1 retry after a 3 second delay.
-            viewer_context=viewer_context,
-        )
+        with viewer_context_scope(
+            ViewerContext(organization_id=organization_id, project_id=project_id)
+        ):
+            response = make_replay_delete_request(
+                seer_request,
+                timeout=5,
+                retries=Retry(total=1, backoff_factor=3),  # 1 retry after a 3 second delay.
+            )
     except Exception:
         logger.exception(
             "Failed to delete replay data from Seer",

--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -57,7 +57,6 @@ from sentry.seer.models import (
 )
 from sentry.seer.models.run import SeerAgentRun, SeerRun, SeerRunType
 from sentry.seer.seer_setup import has_seer_access_with_detail
-from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.tasks.seer.context_engine_index import build_service_map, index_org_project_knowledge
 from sentry.tasks.seer.explorer_index import dispatch_explorer_index_projects
 from sentry.users.models.user import User
@@ -66,6 +65,7 @@ from sentry.utils.prompts import (
     get_prompt_activities_for_user,
     seer_monitoring_provider_dont_ask_feature,
 )
+from sentry.viewer_context import ViewerContext, viewer_context_scope
 
 logger = logging.getLogger(__name__)
 
@@ -373,11 +373,15 @@ class SeerAgentClient:
         if not has_access:
             raise SeerPermissionError(error or "Access denied")
 
-    def _build_viewer_context(self) -> SeerViewerContext:
-        context = SeerViewerContext(organization_id=self.organization.id)
+    def _build_viewer_context(self) -> ViewerContext:
+        user_id = None
         if self.user and hasattr(self.user, "id") and self.user.id is not None:
-            context["user_id"] = self.user.id
-        return context
+            user_id = self.user.id
+        return ViewerContext(
+            organization_id=self.organization.id,
+            user_id=user_id,
+            project_id=self.project.id if self.project else None,
+        )
 
     def start_run(
         self,
@@ -513,16 +517,16 @@ class SeerAgentClient:
                 extras=({"category_value": self.category_value} if self.category_value else {}),
             )
 
-        return enqueue_seer_run(
-            organization=self.organization,
-            run_type=SeerRunType.EXPLORER,
-            body=chat_body,
-            on_run_created=_create_agent_run,
-            viewer_context=self.viewer_context,
-            user_id=user_id,
-            referrer=metadata.get("referrer") if metadata else None,
-            flush=True,
-        )
+        with viewer_context_scope(self.viewer_context):
+            return enqueue_seer_run(
+                organization=self.organization,
+                run_type=SeerRunType.EXPLORER,
+                body=chat_body,
+                on_run_created=_create_agent_run,
+                user_id=user_id,
+                referrer=metadata.get("referrer") if metadata else None,
+                flush=True,
+            )
 
     def start_feature_run(
         self,
@@ -567,20 +571,20 @@ class SeerAgentClient:
             if on_run_created is not None:
                 on_run_created(run)
 
-        return enqueue_seer_run(
-            organization=self.organization,
-            run_type=SeerRunType.FEATURE_RUN,
-            on_run_created=_create_agent_run,
-            body=SeerFeatureRunRequest(
-                feature_id=feature_id,
-                payload=payload,
-                agent_run_options=self._build_agent_run_options(),
-            ),
-            viewer_context=self.viewer_context,
-            user_id=user_id,
-            referrer=feature_id,
-            flush=flush,
-        )
+        with viewer_context_scope(self.viewer_context):
+            return enqueue_seer_run(
+                organization=self.organization,
+                run_type=SeerRunType.FEATURE_RUN,
+                on_run_created=_create_agent_run,
+                body=SeerFeatureRunRequest(
+                    feature_id=feature_id,
+                    payload=payload,
+                    agent_run_options=self._build_agent_run_options(),
+                ),
+                user_id=user_id,
+                referrer=feature_id,
+                flush=flush,
+            )
 
     def _build_agent_run_options(self, *, override_ce_enable: bool = True) -> dict[str, Any]:
         """Resolve org-flag-driven agent run options, shared by start_run and start_feature_run."""
@@ -775,7 +779,8 @@ class SeerAgentClient:
         ):
             agent_run_options["enable_streaming"] = True
 
-        response = make_agent_chat_request(chat_body, viewer_context=self.viewer_context)
+        with viewer_context_scope(self.viewer_context):
+            response = make_agent_chat_request(chat_body)
 
         if response.status >= 400:
             raise SeerApiError("Seer request failed", response.status)
@@ -807,16 +812,16 @@ class SeerAgentClient:
             SeerApiError: If the Seer API request fails
             TimeoutError: If polling exceeds poll_timeout when blocking=True
         """
-        if blocking:
-            state = poll_until_done(
-                run_id,
-                self.organization,
-                poll_interval,
-                poll_timeout,
-                viewer_context=self.viewer_context,
-            )
-        else:
-            state = fetch_run_status(run_id, self.organization, viewer_context=self.viewer_context)
+        with viewer_context_scope(self.viewer_context):
+            if blocking:
+                state = poll_until_done(
+                    run_id,
+                    self.organization,
+                    poll_interval,
+                    poll_timeout,
+                )
+            else:
+                state = fetch_run_status(run_id, self.organization)
 
         return state
 
@@ -912,7 +917,8 @@ class SeerAgentClient:
         if query is not None:
             runs_body["query"] = query
 
-        response = make_agent_runs_request(runs_body, viewer_context=self.viewer_context)
+        with viewer_context_scope(self.viewer_context):
+            response = make_agent_runs_request(runs_body)
 
         if response.status >= 400:
             raise SeerApiError("Seer request failed", response.status)
@@ -927,7 +933,8 @@ class SeerAgentClient:
             run_id=run_id,
             organization_id=self.organization.id,
         )
-        return make_agent_repos_request(body, viewer_context=self.viewer_context)
+        with viewer_context_scope(self.viewer_context):
+            return make_agent_repos_request(body)
 
     def push_changes(
         self,
@@ -984,7 +991,8 @@ class SeerAgentClient:
             organization_id=self.organization.id,
             payload=payload,
         )
-        response = make_agent_update_request(update_body, viewer_context=self.viewer_context)
+        with viewer_context_scope(self.viewer_context):
+            response = make_agent_update_request(update_body)
         if response.status >= 400:
             raise SeerApiError("Seer request failed", response.status)
 
@@ -995,7 +1003,8 @@ class SeerAgentClient:
         start_time = time.time()
 
         while True:
-            state = fetch_run_status(run_id, self.organization, viewer_context=self.viewer_context)
+            with viewer_context_scope(self.viewer_context):
+                state = fetch_run_status(run_id, self.organization)
 
             # Check if any PRs are still being created
             any_creating = any(

--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -993,31 +993,30 @@ class SeerAgentClient:
         )
         with viewer_context_scope(self.viewer_context):
             response = make_agent_update_request(update_body)
-        if response.status >= 400:
-            raise SeerApiError("Seer request failed", response.status)
+            if response.status >= 400:
+                raise SeerApiError("Seer request failed", response.status)
 
-        if not blocking:
-            return None
+            if not blocking:
+                return None
 
-        # Poll until PR creation completes
-        start_time = time.time()
+            # Poll until PR creation completes
+            start_time = time.time()
 
-        while True:
-            with viewer_context_scope(self.viewer_context):
+            while True:
                 state = fetch_run_status(run_id, self.organization)
 
-            # Check if any PRs are still being created
-            any_creating = any(
-                pr.pr_creation_status == "creating" for pr in state.repo_pr_states.values()
-            )
+                # Check if any PRs are still being created
+                any_creating = any(
+                    pr.pr_creation_status == "creating" for pr in state.repo_pr_states.values()
+                )
 
-            if not any_creating:
-                return state
+                if not any_creating:
+                    return state
 
-            if time.time() - start_time > poll_timeout:
-                raise TimeoutError(f"PR creation timed out after {poll_timeout}s")
+                if time.time() - start_time > poll_timeout:
+                    raise TimeoutError(f"PR creation timed out after {poll_timeout}s")
 
-            time.sleep(poll_interval)
+                time.sleep(poll_interval)
 
     def launch_coding_agents(
         self,

--- a/src/sentry/seer/agent/client_utils.py
+++ b/src/sentry/seer/agent/client_utils.py
@@ -250,7 +250,7 @@ def enqueue_seer_run(
     organization: Organization,
     run_type: SeerRunType,
     body: Mapping[str, Any],
-    viewer_context: SeerViewerContext | None,
+    viewer_context: SeerViewerContext | None = None,
     user_id: int | None = None,
     referrer: str | None = None,
     flush: bool = True,

--- a/src/sentry/seer/agent/service_map_utils.py
+++ b/src/sentry/seer/agent/service_map_utils.py
@@ -21,13 +21,13 @@ from sentry.search.eap.types import SearchResolverConfig
 from sentry.search.events.types import SnubaParams
 from sentry.seer.models import SeerApiError
 from sentry.seer.signed_seer_api import (
-    SeerViewerContext,
     ServiceMapUpdateRequest,
     make_service_map_update_request,
 )
 from sentry.snuba.referrer import Referrer
 from sentry.snuba.spans_rpc import Spans
 from sentry.utils.tracing import set_span_data, start_span
+from sentry.viewer_context import ViewerContext, viewer_context_scope
 
 logger = logging.getLogger(__name__)
 
@@ -318,7 +318,7 @@ def _send_to_seer(org_id: int, nodes: list[dict], edges: list[dict]) -> None:
         },
     )
 
-    viewer_context = SeerViewerContext(organization_id=org_id)
-    response = make_service_map_update_request(body, timeout=30, viewer_context=viewer_context)
+    with viewer_context_scope(ViewerContext(organization_id=org_id)):
+        response = make_service_map_update_request(body, timeout=30)
     if response.status >= 400:
         raise SeerApiError("Seer service map update failed", response.status)

--- a/src/sentry/seer/agent/snapshot_indexes.py
+++ b/src/sentry/seer/agent/snapshot_indexes.py
@@ -6,10 +6,10 @@ from sentry.seer.models import SeerApiError
 from sentry.seer.sentry_data_models import AgentExportIndexesResponse
 from sentry.seer.signed_seer_api import (
     AgentExportIndexesRequest,
-    SeerViewerContext,
     make_agent_export_indexes_request,
 )
 from sentry.utils.json import JSONDecodeError
+from sentry.viewer_context import ViewerContext, viewer_context_scope
 
 logger = logging.getLogger(__name__)
 
@@ -20,9 +20,9 @@ def export_agent_indexes(*, org_id: int) -> AgentExportIndexesResponse:
     Intended for local eval DB seeding — calls the Seer export endpoint and
     returns the serialized table data.
     """
-    viewer_context = SeerViewerContext(organization_id=org_id)
     body = AgentExportIndexesRequest(org_id=org_id)
-    response = make_agent_export_indexes_request(body, viewer_context=viewer_context)
+    with viewer_context_scope(ViewerContext(organization_id=org_id)):
+        response = make_agent_export_indexes_request(body)
     if response.status >= 400:
         raise SeerApiError("Seer export-indexes request failed", response.status)
 

--- a/src/sentry/seer/anomaly_detection/delete_rule.py
+++ b/src/sentry/seer/anomaly_detection/delete_rule.py
@@ -11,9 +11,10 @@ from sentry.conf.server import SEER_ALERT_DELETION_URL
 from sentry.models.organization import Organization
 from sentry.net.http import connection_from_url
 from sentry.seer.anomaly_detection.types import AlertInSeer, DataSourceType, DeleteAlertDataRequest
-from sentry.seer.signed_seer_api import SeerViewerContext, make_signed_seer_api_request
+from sentry.seer.signed_seer_api import make_signed_seer_api_request
 from sentry.utils import json
 from sentry.utils.json import JSONDecodeError
+from sentry.viewer_context import ViewerContext, viewer_context_scope
 
 logger = logging.getLogger(__name__)
 
@@ -25,13 +26,11 @@ seer_anomaly_detection_connection_pool = connection_from_url(
 def make_delete_alert_data_request(
     body: DeleteAlertDataRequest,
     connection_pool: HTTPConnectionPool | None = None,
-    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         connection_pool or seer_anomaly_detection_connection_pool,
         SEER_ALERT_DELETION_URL,
         body=json.dumps(body).encode("utf-8"),
-        viewer_context=viewer_context,
     )
 
 
@@ -81,15 +80,15 @@ def delete_rule_in_seer(source_id: int, organization: Organization) -> bool:
     extra_data = {
         "source_id": source_id,
     }
-    viewer_context = SeerViewerContext(organization_id=organization.id)
-    try:
-        response = make_delete_alert_data_request(body, viewer_context=viewer_context)
-    except (TimeoutError, MaxRetryError):
-        logger.warning(
-            "Timeout error when hitting Seer delete rule data endpoint",
-            extra=extra_data,
-        )
-        return False
+    with viewer_context_scope(ViewerContext(organization_id=organization.id)):
+        try:
+            response = make_delete_alert_data_request(body)
+        except (TimeoutError, MaxRetryError):
+            logger.warning(
+                "Timeout error when hitting Seer delete rule data endpoint",
+                extra=extra_data,
+            )
+            return False
 
     if response.status >= 400:
         logger.error(

--- a/src/sentry/seer/anomaly_detection/get_anomaly_data.py
+++ b/src/sentry/seer/anomaly_detection/get_anomaly_data.py
@@ -25,10 +25,11 @@ from sentry.seer.anomaly_detection.types import (
     TimeSeriesPoint,
 )
 from sentry.seer.anomaly_detection.utils import get_aggregate_type, translate_direction
-from sentry.seer.signed_seer_api import SeerViewerContext, make_signed_seer_api_request
+from sentry.seer.signed_seer_api import make_signed_seer_api_request
 from sentry.snuba.models import QuerySubscription, SnubaQuery
 from sentry.utils import json
 from sentry.utils.json import JSONDecodeError
+from sentry.viewer_context import ViewerContext, viewer_context_scope
 
 logger = logging.getLogger(__name__)
 
@@ -67,28 +68,24 @@ SEER_RETRIES = Retry(
 def make_detect_anomalies_request(
     body: DetectAnomaliesRequest,
     connection_pool: HTTPConnectionPool | None = None,
-    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         connection_pool or SEER_ANOMALY_DETECTION_CONNECTION_POOL,
         SEER_ANOMALY_DETECTION_ENDPOINT_URL,
         body=json.dumps(body).encode("utf-8"),
         retries=SEER_RETRIES,
-        viewer_context=viewer_context,
     )
 
 
 def make_get_anomaly_threshold_data_request(
     body: GetAnomalyThresholdDataRequest,
     connection_pool: HTTPConnectionPool | None = None,
-    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         connection_pool or SEER_ANOMALY_DETECTION_CONNECTION_POOL,
         SEER_ANOMALY_DETECTION_ALERT_DATA_URL,
         body=json.dumps(body).encode("utf-8"),
         retries=SEER_RETRIES,
-        viewer_context=viewer_context,
     )
 
 
@@ -143,10 +140,13 @@ def get_anomaly_data_from_seer(
     extra_data["dataset"] = snuba_query.dataset
     try:
         logger.info("Sending subscription update data to Seer", extra=extra_data)
-        viewer_context = SeerViewerContext(organization_id=subscription.project.organization_id)
-        response = make_detect_anomalies_request(
-            detect_anomalies_request, viewer_context=viewer_context
-        )
+        with viewer_context_scope(
+            ViewerContext(
+                organization_id=subscription.project.organization_id,
+                project_id=subscription.project_id,
+            )
+        ):
+            response = make_detect_anomalies_request(detect_anomalies_request)
     except (TimeoutError, MaxRetryError):
         logger.warning("Timeout error when hitting anomaly detection endpoint", extra=extra_data)
         return None
@@ -229,12 +229,16 @@ def get_anomaly_threshold_data_from_seer(
         start=start,
         end=end,
     )
-    viewer_context = SeerViewerContext(organization_id=subscription.project.organization_id)
-    try:
-        response = make_get_anomaly_threshold_data_request(body, viewer_context=viewer_context)
-    except (TimeoutError, MaxRetryError):
-        logger.warning("anomaly_threshold.timeout_error_hitting_seer_endpoint")
-        return None
+    with viewer_context_scope(
+        ViewerContext(
+            organization_id=subscription.project.organization_id, project_id=subscription.project_id
+        )
+    ):
+        try:
+            response = make_get_anomaly_threshold_data_request(body)
+        except (TimeoutError, MaxRetryError):
+            logger.warning("anomaly_threshold.timeout_error_hitting_seer_endpoint")
+            return None
 
     if response.status >= 400:
         logger.error(

--- a/src/sentry/seer/anomaly_detection/get_historical_anomalies.py
+++ b/src/sentry/seer/anomaly_detection/get_historical_anomalies.py
@@ -15,9 +15,10 @@ from sentry.seer.anomaly_detection.types import (
     DetectHistoricalAnomaliesRequest,
     TimeSeriesPoint,
 )
-from sentry.seer.signed_seer_api import SeerViewerContext, make_signed_seer_api_request
+from sentry.seer.signed_seer_api import make_signed_seer_api_request
 from sentry.utils import json
 from sentry.utils.json import JSONDecodeError
+from sentry.viewer_context import ViewerContext, viewer_context_scope
 
 logger = logging.getLogger(__name__)
 
@@ -37,14 +38,12 @@ SEER_RETRIES = Retry(
 def make_detect_historical_anomalies_request(
     body: DetectHistoricalAnomaliesRequest,
     connection_pool: HTTPConnectionPool | None = None,
-    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         connection_pool or seer_anomaly_detection_connection_pool,
         SEER_ANOMALY_DETECTION_ENDPOINT_URL,
         body=json.dumps(body).encode("utf-8"),
         retries=SEER_RETRIES,
-        viewer_context=viewer_context,
     )
 
 
@@ -136,16 +135,20 @@ def get_historical_anomaly_data_from_seer_preview(
         "config": config,
         "context": context,
     }
-    viewer_context = SeerViewerContext(organization_id=organization_id)
-    try:
-        response = make_detect_historical_anomalies_request(body, viewer_context=viewer_context)
-    except (TimeoutError, MaxRetryError):
-        logger.warning("Timeout error when hitting anomaly detection endpoint", extra=extra_data)
-        return None
+    with viewer_context_scope(
+        ViewerContext(organization_id=organization_id, project_id=project_id)
+    ):
+        try:
+            response = make_detect_historical_anomalies_request(body)
+        except (TimeoutError, MaxRetryError):
+            logger.warning(
+                "Timeout error when hitting anomaly detection endpoint", extra=extra_data
+            )
+            return None
 
-    error = handle_seer_error_responses(response, config, context, extra_data)
-    if error:
-        return None
+        error = handle_seer_error_responses(response, config, context, extra_data)
+        if error:
+            return None
 
-    results: DetectAnomaliesResponse = json.loads(response.data.decode("utf-8"))
-    return results.get("timeseries")
+        results: DetectAnomaliesResponse = json.loads(response.data.decode("utf-8"))
+        return results.get("timeseries")

--- a/src/sentry/seer/anomaly_detection/store_data.py
+++ b/src/sentry/seer/anomaly_detection/store_data.py
@@ -31,10 +31,11 @@ from sentry.seer.anomaly_detection.utils import (
     get_event_types,
     translate_direction,
 )
-from sentry.seer.signed_seer_api import SeerViewerContext, make_signed_seer_api_request
+from sentry.seer.signed_seer_api import make_signed_seer_api_request
 from sentry.snuba.models import SnubaQuery, SnubaQueryEventType
 from sentry.utils import json, metrics
 from sentry.utils.json import JSONDecodeError
+from sentry.viewer_context import ViewerContext, viewer_context_scope
 
 logger = logging.getLogger(__name__)
 
@@ -48,13 +49,11 @@ MIN_DAYS = 7
 def make_store_data_request(
     body: StoreDataRequest,
     connection_pool: HTTPConnectionPool | None = None,
-    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         connection_pool or seer_anomaly_detection_connection_pool,
         SEER_ANOMALY_DETECTION_STORE_DATA_URL,
         body=json.dumps(body).encode("utf-8"),
-        viewer_context=viewer_context,
     )
 
 
@@ -243,19 +242,21 @@ def send_historical_data_to_seer_legacy(
             "meta": json.dumps(historical_data.data.get("meta", {}).get("fields", {})),
         },
     )
-    viewer_context = SeerViewerContext(organization_id=alert_rule.organization.id)
-    try:
-        response = make_store_data_request(body, viewer_context=viewer_context)
-    # See SEER_ANOMALY_DETECTION_TIMEOUT in sentry.conf.server.py
-    except (TimeoutError, MaxRetryError):
-        logger.warning(
-            "Timeout error when hitting Seer store data endpoint",
-            extra={
-                "rule_id": alert_rule.id,
-                "project_id": project.id,
-            },
-        )
-        raise TimeoutError
+    with viewer_context_scope(
+        ViewerContext(organization_id=alert_rule.organization.id, project_id=project.id)
+    ):
+        try:
+            response = make_store_data_request(body)
+        # See SEER_ANOMALY_DETECTION_TIMEOUT in sentry.conf.server.py
+        except (TimeoutError, MaxRetryError):
+            logger.warning(
+                "Timeout error when hitting Seer store data endpoint",
+                extra={
+                    "rule_id": alert_rule.id,
+                    "project_id": project.id,
+                },
+            )
+            raise TimeoutError
 
     if response.status > 400:
         logger.error(

--- a/src/sentry/seer/anomaly_detection/store_data_workflow_engine.py
+++ b/src/sentry/seer/anomaly_detection/store_data_workflow_engine.py
@@ -24,10 +24,10 @@ from sentry.seer.anomaly_detection.utils import (
     get_event_types,
     translate_direction,
 )
-from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.snuba.models import QuerySubscription, SnubaQuery, SnubaQueryEventType
 from sentry.utils import json, metrics
 from sentry.utils.json import JSONDecodeError
+from sentry.viewer_context import ViewerContext, viewer_context_scope
 from sentry.workflow_engine.models import DataCondition, DataSource, DataSourceDetector, Detector
 from sentry.workflow_engine.types import DetectorException, DetectorPriorityLevel
 
@@ -250,19 +250,21 @@ def send_historical_data_to_seer(
             "meta": json.dumps(historical_data.data.get("meta", {}).get("fields", {})),
         },
     )
-    viewer_context = SeerViewerContext(organization_id=project.organization.id)
-    try:
-        response = make_store_data_request(body, viewer_context=viewer_context)
-    # See SEER_ANOMALY_DETECTION_TIMEOUT in sentry.conf.server.py
-    except (TimeoutError, MaxRetryError):
-        logger.warning(
-            "Timeout error when hitting Seer store data endpoint",
-            extra={
-                "detector_id": detector.id,
-                "project_id": project.id,
-            },
-        )
-        raise TimeoutError
+    with viewer_context_scope(
+        ViewerContext(organization_id=project.organization.id, project_id=project.id)
+    ):
+        try:
+            response = make_store_data_request(body)
+        # See SEER_ANOMALY_DETECTION_TIMEOUT in sentry.conf.server.py
+        except (TimeoutError, MaxRetryError):
+            logger.warning(
+                "Timeout error when hitting Seer store data endpoint",
+                extra={
+                    "detector_id": detector.id,
+                    "project_id": project.id,
+                },
+            )
+            raise TimeoutError
 
     if response.status > 400:
         status_code_error_string = "Error when hitting Seer store data endpoint"

--- a/src/sentry/seer/autofix/coding_agent.py
+++ b/src/sentry/seer/autofix/coding_agent.py
@@ -34,7 +34,7 @@ from sentry.seer.autofix.utils import (
     make_store_coding_agent_states_request,
 )
 from sentry.seer.models import SeerApiError
-from sentry.seer.signed_seer_api import SeerViewerContext
+from sentry.viewer_context import ViewerContext, viewer_context_scope
 
 logger = logging.getLogger(__name__)
 
@@ -87,12 +87,11 @@ def store_coding_agent_states_to_seer(
         run_id=run_id,
         coding_agent_states=[state.dict() for state in coding_agent_states],
     )
-    viewer_context: SeerViewerContext | None = None
     if organization_id is not None:
-        viewer_context = SeerViewerContext(organization_id=organization_id)
-    response = make_store_coding_agent_states_request(
-        body, timeout=30, viewer_context=viewer_context
-    )
+        with viewer_context_scope(ViewerContext(organization_id=organization_id)):
+            response = make_store_coding_agent_states_request(body, timeout=30)
+    else:
+        response = make_store_coding_agent_states_request(body, timeout=30)
 
     if response.status >= 400:
         raise SeerApiError(response.data.decode("utf-8"), response.status)

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -45,7 +45,6 @@ from sentry.seer.entrypoints.operator import SeerAutofixOperator
 from sentry.seer.models import SummarizeIssueResponse
 from sentry.seer.models.run import SeerRun
 from sentry.seer.signed_seer_api import (
-    SeerViewerContext,
     SummarizeIssueRequest,
     make_signed_seer_api_request,
     make_summarize_issue_request,
@@ -60,6 +59,7 @@ from sentry.users.services.user.model import RpcUser
 from sentry.utils.cache import cache
 from sentry.utils.locking import UnableToAcquireLock
 from sentry.utils.tracing import start_span
+from sentry.viewer_context import ViewerContext, viewer_context_scope
 
 logger = logging.getLogger(__name__)
 
@@ -258,8 +258,10 @@ def _call_seer(
         project_id=group.project.id,
         experiment_variant=experiment_variant,
     )
-    viewer_context = SeerViewerContext(organization_id=group.organization.id)
-    response = make_summarize_issue_request(body, timeout=30, viewer_context=viewer_context)
+    with viewer_context_scope(
+        ViewerContext(organization_id=group.organization.id, project_id=group.project.id)
+    ):
+        response = make_summarize_issue_request(body, timeout=30)
 
     if response.status >= 400:
         raise Exception(f"Seer request failed with status {response.status}")
@@ -285,14 +287,12 @@ def make_fixability_score_request(
     body: FixabilityScoreRequest,
     connection_pool: HTTPConnectionPool | None = None,
     timeout: int | float | None = None,
-    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         connection_pool or fixability_connection_pool,
         "/v1/automation/summarize/fixability",
         body=orjson.dumps(body, option=orjson.OPT_NON_STR_KEYS),
         timeout=timeout,
-        viewer_context=viewer_context,
     )
 
 
@@ -308,13 +308,14 @@ def _generate_fixability_score(
     )
     if summary is not None:
         body["summary"] = summary
-    viewer_context = SeerViewerContext(organization_id=group.organization.id)
-    response = make_fixability_score_request(
-        body,
-        connection_pool=fixability_connection_pool,
-        timeout=settings.SEER_FIXABILITY_TIMEOUT,
-        viewer_context=viewer_context,
-    )
+    with viewer_context_scope(
+        ViewerContext(organization_id=group.organization.id, project_id=group.project.id)
+    ):
+        response = make_fixability_score_request(
+            body,
+            connection_pool=fixability_connection_pool,
+            timeout=settings.SEER_FIXABILITY_TIMEOUT,
+        )
     if response.status >= 400:
         raise Exception(f"Seer API error: {response.status}")
     response_data = orjson.loads(response.data)

--- a/src/sentry/seer/code_review/webhooks/task.py
+++ b/src/sentry/seer/code_review/webhooks/task.py
@@ -16,11 +16,11 @@ from sentry.seer.code_review.models import (
     SeerCodeReviewTaskRequestForPrReview,
 )
 from sentry.seer.code_review.utils import transform_webhook_to_codegen_request
-from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import seer_code_review_tasks
 from sentry.utils import json, metrics
+from sentry.viewer_context import ViewerContext, viewer_context_scope
 
 from ..metrics import WebhookFilteredReason, record_webhook_enqueued, record_webhook_filtered
 from ..utils import (
@@ -116,11 +116,12 @@ def process_github_webhook_event(
     status = "success"
     try:
         sentry_sdk.set_tags(tags)
-        viewer_context: SeerViewerContext | None = None
-        if org_id := tags.get("sentry_organization_id"):
-            viewer_context = SeerViewerContext(organization_id=int(org_id))
-
-        make_seer_request(path=seer_path, payload=event_payload, viewer_context=viewer_context)
+        org_id = tags.get("sentry_organization_id")
+        if org_id:
+            with viewer_context_scope(ViewerContext(organization_id=int(org_id))):
+                make_seer_request(path=seer_path, payload=event_payload)
+        else:
+            make_seer_request(path=seer_path, payload=event_payload)
     except Exception as e:
         status = e.__class__.__name__
         raise

--- a/src/sentry/seer/endpoints/issue_view_title_generate.py
+++ b/src/sentry/seer/endpoints/issue_view_title_generate.py
@@ -14,9 +14,9 @@ from sentry.models.organization import Organization
 from sentry.seer.models import SeerApiError
 from sentry.seer.signed_seer_api import (
     LlmGenerateRequest,
-    SeerViewerContext,
     make_llm_generate_request,
 )
+from sentry.viewer_context import ViewerContext, viewer_context_scope
 
 logger = logging.getLogger(__name__)
 
@@ -52,9 +52,7 @@ class IssueViewTitleGeneratePermission(OrganizationPermission):
     }
 
 
-def generate_title_from_query(
-    query: str, viewer_context: SeerViewerContext | None = None
-) -> str | None:
+def generate_title_from_query(query: str) -> str | None:
     truncated_query = query[:MAX_QUERY_LENGTH] if len(query) > MAX_QUERY_LENGTH else query
 
     body = LlmGenerateRequest(
@@ -68,7 +66,7 @@ def generate_title_from_query(
         temperature=0.2,
         max_tokens=100,
     )
-    response = make_llm_generate_request(body, timeout=10, viewer_context=viewer_context)
+    response = make_llm_generate_request(body, timeout=10)
     if response.status >= 400:
         raise SeerApiError("Seer request failed", response.status)
     data = response.json()
@@ -96,10 +94,10 @@ class IssueViewTitleGenerateEndpoint(OrganizationEndpoint):
             )
 
         try:
-            viewer_context = SeerViewerContext(
-                organization_id=organization.id, user_id=request.user.id
-            )
-            title = generate_title_from_query(query, viewer_context=viewer_context)
+            with viewer_context_scope(
+                ViewerContext(organization_id=organization.id, user_id=request.user.id)
+            ):
+                title = generate_title_from_query(query)
             if not title or not title.strip():
                 logger.error(
                     "No title returned from Seer",

--- a/src/sentry/seer/endpoints/search_agent_start.py
+++ b/src/sentry/seer/endpoints/search_agent_start.py
@@ -19,7 +19,8 @@ from sentry.seer.endpoints.trace_explorer_ai_setup import OrganizationTraceExplo
 from sentry.seer.models import SeerApiError
 from sentry.seer.models.run import SeerRun, SeerRunType
 from sentry.seer.seer_setup import has_seer_access_with_detail
-from sentry.seer.signed_seer_api import SearchAgentStartRequest, SeerViewerContext
+from sentry.seer.signed_seer_api import SearchAgentStartRequest
+from sentry.viewer_context import ViewerContext, viewer_context_scope
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +66,6 @@ def send_search_agent_start_request(
     timezone: str | None = None,
     model_name: str | None = None,
     metric_context: dict[str, Any] | None = None,
-    viewer_context: SeerViewerContext | None = None,
 ) -> SeerRun:
     """Create the SeerRun mirror and enqueue the outbox that starts the agent in Seer."""
     body = SearchAgentStartRequest(
@@ -91,7 +91,6 @@ def send_search_agent_start_request(
         organization=organization,
         run_type=SeerRunType.ASSISTED_QUERY,
         body=body,
-        viewer_context=viewer_context,
         user_id=user_id,
     )
 
@@ -175,21 +174,20 @@ class SearchAgentStartEndpoint(OrganizationEndpoint):
         user_email = user_org_context.get("user_email")
         timezone = user_org_context.get("user_timezone")
         try:
-            viewer_context = SeerViewerContext(
-                organization_id=organization.id, user_id=request.user.id
-            )
-            result = send_search_agent_start_request(
-                organization=organization,
-                user_id=request.user.id,
-                project_ids=project_ids,
-                natural_language_query=natural_language_query,
-                strategy=strategy,
-                user_email=user_email,
-                timezone=timezone,
-                model_name=model_name,
-                metric_context=metric_context,
-                viewer_context=viewer_context,
-            )
+            with viewer_context_scope(
+                ViewerContext(organization_id=organization.id, user_id=request.user.id)
+            ):
+                result = send_search_agent_start_request(
+                    organization=organization,
+                    user_id=request.user.id,
+                    project_ids=project_ids,
+                    natural_language_query=natural_language_query,
+                    strategy=strategy,
+                    user_email=user_email,
+                    timezone=timezone,
+                    model_name=model_name,
+                    metric_context=metric_context,
+                )
             return Response(
                 {
                     "run_id": result.seer_run_state_id,

--- a/src/sentry/seer/endpoints/search_agent_state.py
+++ b/src/sentry/seer/endpoints/search_agent_state.py
@@ -20,23 +20,21 @@ from sentry.seer.models import SeerApiError
 from sentry.seer.seer_setup import has_seer_access_with_detail
 from sentry.seer.signed_seer_api import (
     SearchAgentStateRequest,
-    SeerViewerContext,
     make_search_agent_state_request,
 )
+from sentry.viewer_context import ViewerContext, viewer_context_scope
 
 logger = logging.getLogger(__name__)
 
 
-def fetch_search_agent_state(
-    run_id: int, organization_id: int, viewer_context: SeerViewerContext | None = None
-) -> dict[str, Any]:
+def fetch_search_agent_state(run_id: int, organization_id: int) -> dict[str, Any]:
     """
     Fetch the current state of a search agent run from Seer.
 
     Calls POST /v1/assisted-query/state with the run_id and organization_id.
     """
     body = SearchAgentStateRequest(run_id=run_id, organization_id=organization_id)
-    response = make_search_agent_state_request(body, timeout=10, viewer_context=viewer_context)
+    response = make_search_agent_state_request(body, timeout=10)
     if response.status >= 400:
         raise SeerApiError("Seer request failed", response.status)
     return response.json()
@@ -110,12 +108,10 @@ class SearchAgentStateEndpoint(OrganizationEndpoint):
         seer_run_id = resolved.seer_run_state_id
 
         try:
-            viewer_context = SeerViewerContext(
-                organization_id=organization.id, user_id=request.user.id
-            )
-            data = fetch_search_agent_state(
-                seer_run_id, organization.id, viewer_context=viewer_context
-            )
+            with viewer_context_scope(
+                ViewerContext(organization_id=organization.id, user_id=request.user.id)
+            ):
+                data = fetch_search_agent_state(seer_run_id, organization.id)
             data["sentry_run_id"] = resolved.uuid
             return Response(data)
 

--- a/src/sentry/seer/endpoints/trace_explorer_ai_query.py
+++ b/src/sentry/seer/endpoints/trace_explorer_ai_query.py
@@ -17,10 +17,10 @@ from sentry.models.organization import Organization
 from sentry.seer.endpoints.trace_explorer_ai_setup import OrganizationTraceExplorerAIPermission
 from sentry.seer.models import SeerApiError
 from sentry.seer.signed_seer_api import (
-    SeerViewerContext,
     TranslateQueryRequest,
     make_translate_query_request,
 )
+from sentry.viewer_context import ViewerContext, viewer_context_scope
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +30,6 @@ def send_translate_request(
     org_slug: str,
     project_ids: list[int],
     natural_language_query: str,
-    viewer_context: SeerViewerContext | None = None,
 ) -> Any:
     """
     Sends a request to seer to create the initial cached prompt / setup the AI models
@@ -41,7 +40,7 @@ def send_translate_request(
         project_ids=project_ids,
         natural_language_query=natural_language_query,
     )
-    response = make_translate_query_request(body, timeout=30, viewer_context=viewer_context)
+    response = make_translate_query_request(body, timeout=30)
     if response.status >= 400:
         raise SeerApiError("Seer request failed", response.status)
     return response.json()
@@ -110,14 +109,15 @@ class TraceExplorerAIQuery(OrganizationEndpoint):
                 {"detail": "Seer is not properly configured."},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
-        viewer_context = SeerViewerContext(organization_id=organization.id, user_id=request.user.id)
-        data = send_translate_request(
-            organization.id,
-            organization.slug,
-            project_ids,
-            natural_language_query,
-            viewer_context=viewer_context,
-        )
+        with viewer_context_scope(
+            ViewerContext(organization_id=organization.id, user_id=request.user.id)
+        ):
+            data = send_translate_request(
+                organization.id,
+                organization.slug,
+                project_ids,
+                natural_language_query,
+            )
 
         responses = data.get("responses", [])[:limit]
         unsupported_reason = data.get("unsupported_reason")

--- a/src/sentry/seer/endpoints/trace_explorer_ai_setup.py
+++ b/src/sentry/seer/endpoints/trace_explorer_ai_setup.py
@@ -17,9 +17,9 @@ from sentry.models.organization import Organization
 from sentry.seer.models import SeerApiError
 from sentry.seer.signed_seer_api import (
     CreateCacheRequest,
-    SeerViewerContext,
     make_create_cache_request,
 )
+from sentry.viewer_context import ViewerContext, viewer_context_scope
 
 logger = logging.getLogger(__name__)
 
@@ -33,14 +33,12 @@ class OrganizationTraceExplorerAIPermission(OrganizationPermission):
     }
 
 
-def fire_setup_request(
-    org_id: int, project_ids: list[int], viewer_context: SeerViewerContext | None = None
-) -> None:
+def fire_setup_request(org_id: int, project_ids: list[int]) -> None:
     """
     Sends a request to seer to create the initial cached prompt / setup the AI models
     """
     body = CreateCacheRequest(org_id=org_id, project_ids=project_ids)
-    response = make_create_cache_request(body, viewer_context=viewer_context)
+    response = make_create_cache_request(body)
     if response.status >= 400:
         raise SeerApiError("Seer request failed", response.status)
 
@@ -97,7 +95,9 @@ class TraceExplorerAISetup(OrganizationEndpoint):
                 {"detail": "Seer is not properly configured."},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
-        viewer_context = SeerViewerContext(organization_id=organization.id, user_id=request.user.id)
-        fire_setup_request(organization.id, validated_project_ids, viewer_context=viewer_context)
+        with viewer_context_scope(
+            ViewerContext(organization_id=organization.id, user_id=request.user.id)
+        ):
+            fire_setup_request(organization.id, validated_project_ids)
 
         return Response({"status": "ok"})

--- a/src/sentry/seer/endpoints/trace_explorer_ai_translate_agentic.py
+++ b/src/sentry/seer/endpoints/trace_explorer_ai_translate_agentic.py
@@ -18,10 +18,10 @@ from sentry.seer.endpoints.trace_explorer_ai_setup import OrganizationTraceExplo
 from sentry.seer.models import SeerApiError
 from sentry.seer.seer_setup import has_seer_access_with_detail
 from sentry.seer.signed_seer_api import (
-    SeerViewerContext,
     TranslateAgenticRequest,
     make_translate_agentic_request,
 )
+from sentry.viewer_context import ViewerContext, viewer_context_scope
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +65,6 @@ def send_translate_agentic_request(
     strategy: str = "Traces",
     model_name: str | None = None,
     metric_context: dict[str, Any] | None = None,
-    viewer_context: SeerViewerContext | None = None,
 ) -> Any:
     """
     Sends a request to seer to translate a natural language query using the agentic search API.
@@ -84,7 +83,7 @@ def send_translate_agentic_request(
         options["metric_context"] = metric_context
     body["options"] = options
 
-    response = make_translate_agentic_request(body, timeout=10, viewer_context=viewer_context)
+    response = make_translate_agentic_request(body, timeout=10)
     if response.status >= 400:
         raise SeerApiError("Seer request failed", response.status)
     return response.json()
@@ -142,15 +141,16 @@ class SearchAgentTranslateEndpoint(OrganizationEndpoint):
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
-        viewer_context = SeerViewerContext(organization_id=organization.id, user_id=request.user.id)
-        data = send_translate_agentic_request(
-            organization.id,
-            organization.slug,
-            project_ids,
-            natural_language_query,
-            strategy=strategy,
-            model_name=model_name,
-            metric_context=metric_context,
-            viewer_context=viewer_context,
-        )
+        with viewer_context_scope(
+            ViewerContext(organization_id=organization.id, user_id=request.user.id)
+        ):
+            data = send_translate_agentic_request(
+                organization.id,
+                organization.slug,
+                project_ids,
+                natural_language_query,
+                strategy=strategy,
+                model_name=model_name,
+                metric_context=metric_context,
+            )
         return Response(data)

--- a/src/sentry/seer/oneshot.py
+++ b/src/sentry/seer/oneshot.py
@@ -21,10 +21,10 @@ from sentry.models.organization import Organization
 from sentry.seer.models.seer_api_models import SeerApiError
 from sentry.seer.signed_seer_api import (
     OneShotRunRequest,
-    SeerViewerContext,
     make_oneshot_request,
 )
 from sentry.utils import metrics
+from sentry.viewer_context import ViewerContext, viewer_context_scope
 
 logger = logging.getLogger(__name__)
 
@@ -56,15 +56,15 @@ def call_seer_oneshot(
     Seer task endpoints require viewer context with an organization, so
     ``organization`` is mandatory.
     """
-    viewer_context = SeerViewerContext(organization_id=organization.id)
+    vc_kwargs: dict[str, Any] = {"organization_id": organization.id}
     if user_id is not None:
-        viewer_context["user_id"] = user_id
+        vc_kwargs["user_id"] = user_id
 
-    response = make_request(
-        body,
-        timeout=timeout if timeout is not None else settings.SEER_DEFAULT_TIMEOUT,
-        viewer_context=viewer_context,
-    )
+    with viewer_context_scope(ViewerContext(**vc_kwargs)):
+        response = make_request(
+            body,
+            timeout=timeout if timeout is not None else settings.SEER_DEFAULT_TIMEOUT,
+        )
 
     if response.status >= 400:
         metrics.incr(

--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -352,7 +352,7 @@ def make_remove_handoffs_for_integration_request(
 
 def make_agent_export_indexes_request(
     body: AgentExportIndexesRequest,
-    viewer_context: SeerViewerContext,
+    viewer_context: SeerViewerContext | None = None,
     timeout: int | float | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
@@ -573,7 +573,7 @@ def make_lightweight_rca_cluster_request(
 
 def make_supergroups_get_request(
     body: SupergroupsGetRequest,
-    viewer_context: SeerViewerContext,
+    viewer_context: SeerViewerContext | None = None,
     timeout: int | float | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
@@ -587,7 +587,7 @@ def make_supergroups_get_request(
 
 def make_supergroups_get_by_group_ids_request(
     body: SupergroupsGetByGroupIdsRequest,
-    viewer_context: SeerViewerContext,
+    viewer_context: SeerViewerContext | None = None,
     timeout: int | float | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(

--- a/src/sentry/seer/supergroups/by_group.py
+++ b/src/sentry/seer/supergroups/by_group.py
@@ -7,10 +7,10 @@ import orjson
 from sentry.models.organization import Organization
 from sentry.seer.models import SeerApiError
 from sentry.seer.signed_seer_api import (
-    SeerViewerContext,
     SupergroupsByGroupIdsResponse,
     make_supergroups_get_by_group_ids_request,
 )
+from sentry.viewer_context import ViewerContext, viewer_context_scope
 
 
 def get_supergroups_by_group_ids(
@@ -19,14 +19,15 @@ def get_supergroups_by_group_ids(
     *,
     user_id: int | None = None,
 ) -> SupergroupsByGroupIdsResponse:
-    response = make_supergroups_get_by_group_ids_request(
-        {
-            "organization_id": organization.id,
-            "group_ids": list(group_ids),
-        },
-        SeerViewerContext(organization_id=organization.id, user_id=user_id),
-        timeout=10,
-    )
+    vc = ViewerContext(organization_id=organization.id, user_id=user_id)
+    with viewer_context_scope(vc):
+        response = make_supergroups_get_by_group_ids_request(
+            {
+                "organization_id": organization.id,
+                "group_ids": list(group_ids),
+            },
+            timeout=10,
+        )
     if response.status >= 400:
         raise SeerApiError("Seer request failed", response.status)
     return orjson.loads(response.data)

--- a/src/sentry/seer/supergroups/endpoints/organization_supergroup_details.py
+++ b/src/sentry/seer/supergroups/endpoints/organization_supergroup_details.py
@@ -12,7 +12,8 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.models.organization import Organization
-from sentry.seer.signed_seer_api import SeerViewerContext, make_supergroups_get_request
+from sentry.seer.signed_seer_api import make_supergroups_get_request
+from sentry.viewer_context import ViewerContext, viewer_context_scope
 
 logger = logging.getLogger(__name__)
 
@@ -35,14 +36,16 @@ class OrganizationSupergroupDetailsEndpoint(OrganizationEndpoint):
         if not features.has("organizations:top-issues-ui", organization, actor=request.user):
             return Response({"detail": "Feature not available"}, status=403)
 
-        response = make_supergroups_get_request(
-            {
-                "organization_id": organization.id,
-                "supergroup_id": supergroup_id,
-            },
-            SeerViewerContext(organization_id=organization.id, user_id=request.user.id),
-            timeout=10,
-        )
+        with viewer_context_scope(
+            ViewerContext(organization_id=organization.id, user_id=request.user.id)
+        ):
+            response = make_supergroups_get_request(
+                {
+                    "organization_id": organization.id,
+                    "supergroup_id": supergroup_id,
+                },
+                timeout=10,
+            )
 
         if response.status >= 400:
             return Response(

--- a/src/sentry/seer/supergroups/lightweight_rca_cluster.py
+++ b/src/sentry/seer/supergroups/lightweight_rca_cluster.py
@@ -8,7 +8,6 @@ from sentry.models.group import Group
 from sentry.seer.models import SeerApiError
 from sentry.seer.signed_seer_api import (
     LightweightRCAClusterRequest,
-    SeerViewerContext,
     make_lightweight_rca_cluster_request,
 )
 from sentry.seer.similarity.utils import (
@@ -16,6 +15,7 @@ from sentry.seer.similarity.utils import (
     event_content_has_stacktrace,
 )
 from sentry.utils import metrics
+from sentry.viewer_context import ViewerContext, viewer_context_scope
 
 logger = logging.getLogger(__name__)
 
@@ -83,9 +83,10 @@ def trigger_lightweight_rca_cluster(group: Group) -> None:
         organization_id=group.organization.id,
         project_id=group.project.id,
     )
-    viewer_context = SeerViewerContext(organization_id=group.organization.id)
-
-    response = make_lightweight_rca_cluster_request(body, timeout=30, viewer_context=viewer_context)
+    with viewer_context_scope(
+        ViewerContext(organization_id=group.organization.id, project_id=group.project.id)
+    ):
+        response = make_lightweight_rca_cluster_request(body, timeout=30)
     if response.status >= 400:
         raise SeerApiError("Lightweight RCA cluster request failed", response.status)
 

--- a/src/sentry/tasks/llm_issue_detection/detection.py
+++ b/src/sentry/tasks/llm_issue_detection/detection.py
@@ -29,7 +29,7 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.net.http import connection_from_url
 from sentry.seer.agent.utils import normalize_description
-from sentry.seer.signed_seer_api import SeerViewerContext, make_signed_seer_api_request
+from sentry.seer.signed_seer_api import make_signed_seer_api_request
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import issues_tasks
 from sentry.utils import json
@@ -86,7 +86,6 @@ def make_issue_detection_request(
     request: IssueDetectionRequest,
     timeout: int | float | None = None,
     retries: int | None = None,
-    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     extra_kwargs: dict[str, Any] = {}
     if timeout is not None:
@@ -97,7 +96,6 @@ def make_issue_detection_request(
         seer_issue_detection_connection_pool,
         SEER_ANALYZE_ISSUE_ENDPOINT_PATH,
         body=orjson.dumps(request.dict()),
-        viewer_context=viewer_context,
         **extra_kwargs,
     )
 
@@ -362,12 +360,10 @@ def detect_llm_issues_for_org(org_id: int, plan_tier: str = "business") -> None:
     with viewer_context_scope(
         ViewerContext(organization_id=org_id, project_id=project_id, actor_type=ActorType.SYSTEM)
     ):
-        viewer_context = SeerViewerContext(organization_id=org_id)
         response = make_issue_detection_request(
             seer_request,
             timeout=SEER_TIMEOUT_S,
             retries=0,
-            viewer_context=viewer_context,
         )
 
     if response.status == 202:

--- a/src/sentry/tasks/seer/autofix.py
+++ b/src/sentry/tasks/seer/autofix.py
@@ -31,6 +31,7 @@ from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import ingest_errors_tasks, issues_tasks
 from sentry.utils import metrics
 from sentry.utils.cache import cache
+from sentry.viewer_context import ViewerContext, viewer_context_scope
 
 logger = logging.getLogger(__name__)
 
@@ -76,7 +77,10 @@ def generate_summary_and_run_automation(group_id: int, **kwargs) -> None:
             )
         )
 
-    get_issue_summary(group=group, source=SeerAutomationSource.POST_PROCESS)
+    with viewer_context_scope(
+        ViewerContext(organization_id=organization.id, project_id=group.project_id)
+    ):
+        get_issue_summary(group=group, source=SeerAutomationSource.POST_PROCESS)
 
 
 @instrumented_task(
@@ -115,9 +119,12 @@ def generate_issue_summary_only(group_id: int) -> None:
         )
 
     # Generate and cache the summary
-    get_issue_summary(
-        group=group, source=SeerAutomationSource.POST_PROCESS, should_run_automation=False
-    )
+    with viewer_context_scope(
+        ViewerContext(organization_id=organization.id, project_id=group.project_id)
+    ):
+        get_issue_summary(
+            group=group, source=SeerAutomationSource.POST_PROCESS, should_run_automation=False
+        )
 
     get_and_update_group_fixability_score(group, force_generate=True)
 

--- a/src/sentry/tasks/seer/backfill_supergroups_lightweight.py
+++ b/src/sentry/tasks/seer/backfill_supergroups_lightweight.py
@@ -13,7 +13,6 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.seer.signed_seer_api import (
     LightweightRCAClusterRequest,
-    SeerViewerContext,
     make_lightweight_rca_cluster_request,
 )
 from sentry.seer.similarity.utils import (
@@ -29,6 +28,7 @@ from sentry.types.group import UNRESOLVED_SUBSTATUS_CHOICES
 from sentry.utils import metrics
 from sentry.utils.retries import ConditionalRetryPolicy, exponential_delay
 from sentry.utils.snuba import SnubaError, bulk_snuba_queries
+from sentry.viewer_context import ViewerContext, viewer_context_scope
 
 logger = logging.getLogger(__name__)
 
@@ -164,57 +164,57 @@ def _backfill_org(
     failure_count = 0
     success_count = 0
     last_processed_group_id = last_group_id
-    viewer_context = SeerViewerContext(organization_id=organization_id)
 
-    for group, serialized_event in group_event_pairs:
-        try:
-            body = LightweightRCAClusterRequest(
-                group_id=group.id,
-                issue={
-                    "id": group.id,
-                    "title": group.title,
-                    "short_id": group.qualified_short_id,
-                    "events": [serialized_event],
-                },
-                organization_slug=organization.slug,
-                organization_id=organization_id,
-                project_id=group.project_id,
-            )
-            response = make_lightweight_rca_cluster_request(
-                body, timeout=30, viewer_context=viewer_context
-            )
-            if response.status >= 400:
-                logger.warning(
-                    "supergroups_backfill_lightweight.seer_error",
-                    extra={
-                        "group_id": group.id,
-                        "project_id": group.project_id,
-                        "status": response.status,
+    with viewer_context_scope(
+        ViewerContext(organization_id=organization_id, project_id=project.id)
+    ):
+        for group, serialized_event in group_event_pairs:
+            try:
+                body = LightweightRCAClusterRequest(
+                    group_id=group.id,
+                    issue={
+                        "id": group.id,
+                        "title": group.title,
+                        "short_id": group.qualified_short_id,
+                        "events": [serialized_event],
                     },
+                    organization_slug=organization.slug,
+                    organization_id=organization_id,
+                    project_id=group.project_id,
+                )
+                response = make_lightweight_rca_cluster_request(body, timeout=30)
+                if response.status >= 400:
+                    logger.warning(
+                        "supergroups_backfill_lightweight.seer_error",
+                        extra={
+                            "group_id": group.id,
+                            "project_id": group.project_id,
+                            "status": response.status,
+                        },
+                    )
+                    failure_count += 1
+                else:
+                    success_count += 1
+            except Exception:
+                logger.exception(
+                    "supergroups_backfill_lightweight.group_failed",
+                    extra={"group_id": group.id, "project_id": group.project_id},
                 )
                 failure_count += 1
-            else:
-                success_count += 1
-        except Exception:
-            logger.exception(
-                "supergroups_backfill_lightweight.group_failed",
-                extra={"group_id": group.id, "project_id": group.project_id},
-            )
-            failure_count += 1
 
-        last_processed_group_id = group.id
+            last_processed_group_id = group.id
 
-        if max_failures_per_batch > 0 and failure_count >= max_failures_per_batch:
-            logger.error(
-                "supergroups_backfill_lightweight.max_failures_reached",
-                extra={
-                    "organization_id": organization_id,
-                    "project_id": project.id,
-                    "failure_count": failure_count,
-                    "last_processed_group_id": last_processed_group_id,
-                },
-            )
-            break
+            if max_failures_per_batch > 0 and failure_count >= max_failures_per_batch:
+                logger.error(
+                    "supergroups_backfill_lightweight.max_failures_reached",
+                    extra={
+                        "organization_id": organization_id,
+                        "project_id": project.id,
+                        "failure_count": failure_count,
+                        "last_processed_group_id": last_processed_group_id,
+                    },
+                )
+                break
 
     metrics.incr(
         "seer.supergroups_backfill_lightweight.groups_processed",

--- a/src/sentry/tasks/seer/context_engine_index.py
+++ b/src/sentry/tasks/seer/context_engine_index.py
@@ -39,7 +39,6 @@ from sentry.seer.signed_seer_api import (
     OrgProjectKnowledgeIndexRequest,
     OrgProjectKnowledgeProjectData,
     RepoDetails,
-    SeerViewerContext,
     make_index_sentry_knowledge_request,
     make_org_project_knowledge_index_request,
     make_org_repo_knowledge_index_request,
@@ -50,6 +49,7 @@ from sentry.utils.hashlib import md5_text
 from sentry.utils.query import RangeQuerySetWrapper
 from sentry.utils.snuba_rpc import SnubaRPCRateLimitExceeded
 from sentry.utils.tracing import start_span
+from sentry.viewer_context import ViewerContext, viewer_context_scope
 
 logger = logging.getLogger(__name__)
 
@@ -129,22 +129,20 @@ def index_org_project_knowledge(org_id: int) -> None:
 
     payload = OrgProjectKnowledgeIndexRequest(org_id=org_id, projects=project_data)
 
-    viewer_context = SeerViewerContext(organization_id=org_id)
-
-    try:
-        response = make_org_project_knowledge_index_request(
-            payload,
-            timeout=30,
-            viewer_context=viewer_context,
-        )
-        if response.status >= 400:
-            raise SeerApiError("Seer request failed", response.status)
-    except Exception:
-        logger.exception(
-            "Failed to call Seer org-project-knowledge endpoint",
-            extra={"org_id": org_id, "num_projects": len(project_data)},
-        )
-        raise
+    with viewer_context_scope(ViewerContext(organization_id=org_id)):
+        try:
+            response = make_org_project_knowledge_index_request(
+                payload,
+                timeout=30,
+            )
+            if response.status >= 400:
+                raise SeerApiError("Seer request failed", response.status)
+        except Exception:
+            logger.exception(
+                "Failed to call Seer org-project-knowledge endpoint",
+                extra={"org_id": org_id, "num_projects": len(project_data)},
+            )
+            raise
 
     logger.info(
         "Successfully called Seer org-project-knowledge endpoint",
@@ -298,12 +296,13 @@ def index_repos(organization_id: int, *args, **kwargs) -> None:
                     "integration_id": repo.integration_id,
                 }
 
-    viewer_context = SeerViewerContext(organization_id=organization_id)
-    response = make_org_repo_knowledge_index_request(
-        AgentIndexOrgRepoRequest(org_id=organization.id, repos=list(org_repo_definitions.values())),
-        timeout=30,
-        viewer_context=viewer_context,
-    )
+    with viewer_context_scope(ViewerContext(organization_id=organization_id)):
+        response = make_org_repo_knowledge_index_request(
+            AgentIndexOrgRepoRequest(
+                org_id=organization.id, repos=list(org_repo_definitions.values())
+            ),
+            timeout=30,
+        )
 
     if response.status >= 400:
         raise SeerApiError("Seer request failed", response.status)

--- a/src/sentry/tasks/seer/explorer_index.py
+++ b/src/sentry/tasks/seer/explorer_index.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import logging
 from collections.abc import Generator, Iterator
 from datetime import datetime, timedelta
@@ -13,7 +14,6 @@ from sentry.seer.models import SeerApiError
 from sentry.seer.signed_seer_api import (
     AgentIndexProject,
     AgentIndexRequest,
-    SeerViewerContext,
     make_agent_index_request,
 )
 from sentry.tasks.base import instrumented_task
@@ -21,6 +21,7 @@ from sentry.tasks.utils import compute_delay
 from sentry.taskworker.namespaces import seer_tasks
 from sentry.utils.query import RangeQuerySetWrapper
 from sentry.utils.tracing import start_span
+from sentry.viewer_context import ViewerContext, viewer_context_scope
 
 logger = logging.getLogger("sentry.tasks.seer_explorer_indexer")
 
@@ -226,30 +227,33 @@ def run_explorer_index_for_projects(
     ]
     payload = AgentIndexRequest(projects=project_list)
 
-    # Only set viewer_context when all projects in the batch share the same org
     org_ids = {org_id for _, org_id in projects}
-    viewer_context = SeerViewerContext(organization_id=org_ids.pop()) if len(org_ids) == 1 else None
+    _vc_scope = (
+        viewer_context_scope(ViewerContext(organization_id=org_ids.pop()))
+        if len(org_ids) == 1
+        else contextlib.nullcontext()
+    )
 
-    try:
-        response = make_agent_index_request(
-            payload,
-            timeout=30,
-            viewer_context=viewer_context,
-        )
-        if response.status >= 400:
-            raise SeerApiError("Seer request failed", response.status)
-    except Exception as e:
-        logger.exception(
-            "Failed to schedule explorer index tasks in seer",
-            extra={
-                "num_projects": len(projects),
-                "error": str(e),
-            },
-        )
-        raise
+    with _vc_scope:
+        try:
+            response = make_agent_index_request(
+                payload,
+                timeout=30,
+            )
+            if response.status >= 400:
+                raise SeerApiError("Seer request failed", response.status)
+        except Exception as e:
+            logger.exception(
+                "Failed to schedule explorer index tasks in seer",
+                extra={
+                    "num_projects": len(projects),
+                    "error": str(e),
+                },
+            )
+            raise
 
-    result = response.json()
-    scheduled_count = result.get("scheduled_count", 0)
+        result = response.json()
+        scheduled_count = result.get("scheduled_count", 0)
 
     logger.info(
         "Successfully scheduled explorer index tasks in seer",

--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import logging
 from collections.abc import Generator, Iterable
 from datetime import UTC, datetime, timedelta
@@ -37,7 +38,6 @@ from sentry.profiles.utils import get_from_profiling_service
 from sentry.search.events.fields import resolve_datetime64
 from sentry.search.events.types import SnubaParams
 from sentry.seer.breakpoints import BreakpointData
-from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.snuba import functions
@@ -65,6 +65,7 @@ from sentry.utils.iterators import chunked
 from sentry.utils.math import ExponentialMovingAverage
 from sentry.utils.query import RangeQuerySetWrapper
 from sentry.utils.snuba import SnubaTSResult, raw_snql_query
+from sentry.viewer_context import ViewerContext, viewer_context_scope
 
 logger = logging.getLogger("sentry.tasks.statistical_detectors")
 
@@ -370,18 +371,20 @@ def _detect_transaction_change_points(
         (projects_by_id[item[0]], item[1]) for item in transactions if item[0] in projects_by_id
     ]
 
-    viewer_context = None
+    _vc_scope = contextlib.nullcontext()
     if transaction_pairs:
         project = transaction_pairs[0][0]
-        viewer_context = SeerViewerContext(organization_id=project.organization_id)
+        _vc_scope = viewer_context_scope(
+            ViewerContext(organization_id=project.organization_id, project_id=project.id)
+        )
 
-    regressions = EndpointRegressionDetector.detect_regressions(
-        transaction_pairs,
-        start,
-        "p95(transaction.duration)",
-        TIMESERIES_PER_BATCH,
-        viewer_context=viewer_context,
-    )
+    with _vc_scope:
+        regressions = EndpointRegressionDetector.detect_regressions(
+            transaction_pairs,
+            start,
+            "p95(transaction.duration)",
+            TIMESERIES_PER_BATCH,
+        )
     regressions = EndpointRegressionDetector.save_regressions_with_versions(regressions)
 
     breakpoint_count = 0
@@ -469,14 +472,20 @@ def _detect_function_change_points(
         (projects_by_id[item[0]], item[1]) for item in functions_list if item[0] in projects_by_id
     ]
 
-    viewer_context = None
+    _vc_scope = contextlib.nullcontext()
     if function_pairs:
         project = function_pairs[0][0]
-        viewer_context = SeerViewerContext(organization_id=project.organization_id)
+        _vc_scope = viewer_context_scope(
+            ViewerContext(organization_id=project.organization_id, project_id=project.id)
+        )
 
-    regressions = FunctionRegressionDetector.detect_regressions(
-        function_pairs, start, "p95()", TIMESERIES_PER_BATCH, viewer_context=viewer_context
-    )
+    with _vc_scope:
+        regressions = FunctionRegressionDetector.detect_regressions(
+            function_pairs,
+            start,
+            "p95()",
+            TIMESERIES_PER_BATCH,
+        )
     regressions = FunctionRegressionDetector.save_regressions_with_versions(regressions)
 
     breakpoint_count = 0

--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -371,7 +371,7 @@ def _detect_transaction_change_points(
         (projects_by_id[item[0]], item[1]) for item in transactions if item[0] in projects_by_id
     ]
 
-    _vc_scope = contextlib.nullcontext()
+    _vc_scope: contextlib.AbstractContextManager[None] = contextlib.nullcontext()
     if transaction_pairs:
         project = transaction_pairs[0][0]
         _vc_scope = viewer_context_scope(ViewerContext(organization_id=project.organization_id))
@@ -470,7 +470,7 @@ def _detect_function_change_points(
         (projects_by_id[item[0]], item[1]) for item in functions_list if item[0] in projects_by_id
     ]
 
-    _vc_scope = contextlib.nullcontext()
+    _vc_scope: contextlib.AbstractContextManager[None] = contextlib.nullcontext()
     if function_pairs:
         project = function_pairs[0][0]
         _vc_scope = viewer_context_scope(ViewerContext(organization_id=project.organization_id))

--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -374,9 +374,7 @@ def _detect_transaction_change_points(
     _vc_scope = contextlib.nullcontext()
     if transaction_pairs:
         project = transaction_pairs[0][0]
-        _vc_scope = viewer_context_scope(
-            ViewerContext(organization_id=project.organization_id, project_id=project.id)
-        )
+        _vc_scope = viewer_context_scope(ViewerContext(organization_id=project.organization_id))
 
     with _vc_scope:
         regressions = EndpointRegressionDetector.detect_regressions(
@@ -385,13 +383,13 @@ def _detect_transaction_change_points(
             "p95(transaction.duration)",
             TIMESERIES_PER_BATCH,
         )
-    regressions = EndpointRegressionDetector.save_regressions_with_versions(regressions)
+        regressions = EndpointRegressionDetector.save_regressions_with_versions(regressions)
 
-    breakpoint_count = 0
+        breakpoint_count = 0
 
-    for regression in regressions:
-        breakpoint_count += 1
-        send_regression_to_platform(regression)
+        for regression in regressions:
+            breakpoint_count += 1
+            send_regression_to_platform(regression)
 
     metrics.incr(
         "statistical_detectors.breakpoint.emitted",
@@ -475,9 +473,7 @@ def _detect_function_change_points(
     _vc_scope = contextlib.nullcontext()
     if function_pairs:
         project = function_pairs[0][0]
-        _vc_scope = viewer_context_scope(
-            ViewerContext(organization_id=project.organization_id, project_id=project.id)
-        )
+        _vc_scope = viewer_context_scope(ViewerContext(organization_id=project.organization_id))
 
     with _vc_scope:
         regressions = FunctionRegressionDetector.detect_regressions(
@@ -486,14 +482,14 @@ def _detect_function_change_points(
             "p95()",
             TIMESERIES_PER_BATCH,
         )
-    regressions = FunctionRegressionDetector.save_regressions_with_versions(regressions)
+        regressions = FunctionRegressionDetector.save_regressions_with_versions(regressions)
 
-    breakpoint_count = 0
-    emitted_count = 0
+        breakpoint_count = 0
+        emitted_count = 0
 
-    for regression_chunk in chunked(regressions, 100):
-        breakpoint_count += len(regression_chunk)
-        emitted_count += emit_function_regression_issue(projects_by_id, regression_chunk, start)
+        for regression_chunk in chunked(regressions, 100):
+            breakpoint_count += len(regression_chunk)
+            emitted_count += emit_function_regression_issue(projects_by_id, regression_chunk, start)
 
     metrics.incr(
         "statistical_detectors.breakpoint.detected",

--- a/tests/sentry/ai_monitoring/test_tasks.py
+++ b/tests/sentry/ai_monitoring/test_tasks.py
@@ -279,10 +279,7 @@ class GenerateAIConversationTitleTaskTest(TestCase):
         assert row.conversation_id_hash == conversation_id_hash("conv-1")
         assert row.title == "AI Title"
         assert row.title_source_timestamp == _ts()
-        mock_generate.assert_called_once_with(
-            "How do I reset my password?",
-            viewer_context={"organization_id": self.project.organization_id},
-        )
+        mock_generate.assert_called_once_with("How do I reset my password?")
 
     @patch("sentry.ai_monitoring.tasks.generate_conversation_title", return_value="AI Title")
     def test_stores_clamped_conversation_id_and_hashes_full(self, mock_generate: MagicMock) -> None:

--- a/tests/sentry/deletions/tasks/test_seer_repository_deleted.py
+++ b/tests/sentry/deletions/tasks/test_seer_repository_deleted.py
@@ -6,6 +6,7 @@ import pytest
 from sentry.deletions.tasks.seer import notify_seer_repository_deleted
 from sentry.seer.code_review.utils import SeerEndpoint
 from sentry.testutils.cases import TestCase
+from sentry.viewer_context import get_viewer_context
 
 
 class NotifySeerRepositoryDeletedTest(TestCase):
@@ -18,7 +19,15 @@ class NotifySeerRepositoryDeletedTest(TestCase):
 
     @patch("sentry.seer.code_review.utils.make_seer_request")
     def test_notifies_seer_via_signed_endpoint(self, mock_make_seer_request: Any) -> None:
-        mock_make_seer_request.return_value = b"{}"
+        captured_organization_id = None
+
+        def _capture(*args: Any, **kwargs: Any) -> bytes:
+            nonlocal captured_organization_id
+            viewer_context = get_viewer_context()
+            captured_organization_id = viewer_context.organization_id if viewer_context else None
+            return b"{}"
+
+        mock_make_seer_request.side_effect = _capture
 
         notify_seer_repository_deleted(
             self.organization_id,
@@ -36,7 +45,7 @@ class NotifySeerRepositoryDeletedTest(TestCase):
             "provider": self.provider,
             "repository_name": self.repository_name,
         }
-        assert kwargs["viewer_context"]["organization_id"] == self.organization_id
+        assert captured_organization_id == self.organization_id
 
     @patch("sentry.seer.code_review.utils.make_seer_request")
     def test_propagates_seer_errors(self, mock_make_seer_request: Any) -> None:

--- a/tests/sentry/feedback/usecases/ingest/test_create_feedback.py
+++ b/tests/sentry/feedback/usecases/ingest/test_create_feedback.py
@@ -782,7 +782,6 @@ def test_create_feedback_issue_title(
         long_message,
         default_project.organization_id,
         False,
-        viewer_context={"organization_id": default_project.organization_id},
     )
     assert mock_produce_occurrence_to_kafka.call_count == 1
     call_args = mock_produce_occurrence_to_kafka.call_args
@@ -818,7 +817,6 @@ def test_create_feedback_issue_title_from_seer(
         "The login button is broken and the UI is slow",
         default_project.organization_id,
         True,
-        viewer_context={"organization_id": default_project.organization_id},
     )
 
     assert mock_produce_occurrence_to_kafka.call_count == 1

--- a/tests/sentry/grouping/seer_similarity/test_get_seer_similar_issues.py
+++ b/tests/sentry/grouping/seer_similarity/test_get_seer_similar_issues.py
@@ -120,7 +120,6 @@ class GetSeerSimilarIssuesTest(TestCase):
                 "training_mode": False,
                 "hybrid_fingerprint": False,
             },
-            viewer_context={"organization_id": self.project.organization_id},
         )
 
     @patch("sentry.grouping.ingest.seer.get_similarity_data_from_seer", return_value=([], "v1"))
@@ -154,7 +153,6 @@ class GetSeerSimilarIssuesTest(TestCase):
                 "training_mode": False,
                 "hybrid_fingerprint": False,
             },
-            viewer_context={"organization_id": self.project.organization_id},
         )
 
     @patch("sentry.grouping.ingest.seer.metrics.incr")
@@ -205,7 +203,6 @@ class GetSeerSimilarIssuesTest(TestCase):
                 "skip_fallback": False,
             }
 
-            viewer_ctx = {"organization_id": self.project.organization_id}
             assert mock_get_similarity_data.call_count == 2
             assert mock_get_similarity_data.mock_calls == [
                 # Initial call to Seer
@@ -221,7 +218,6 @@ class GetSeerSimilarIssuesTest(TestCase):
                         "training_mode": False,
                         "hybrid_fingerprint": False,
                     },
-                    viewer_context=viewer_ctx,
                 ),
                 # Second call to store the event's data since the match that came back from Seer
                 # wasn't usable
@@ -236,7 +232,6 @@ class GetSeerSimilarIssuesTest(TestCase):
                         "model_version": "v1",
                         "training_mode": False,
                     },
-                    viewer_context=viewer_ctx,
                 ),
             ]
 

--- a/tests/sentry/grouping/seer_similarity/test_seer.py
+++ b/tests/sentry/grouping/seer_similarity/test_seer.py
@@ -70,7 +70,6 @@ class MaybeCheckSeerForMatchingGroupHashTest(TestCase):
                 "training_mode": False,
                 "hybrid_fingerprint": False,
             },
-            viewer_context={"organization_id": self.project.organization_id},
         )
 
     @patch("sentry.grouping.ingest.seer.record_did_call_seer_metric")
@@ -209,5 +208,4 @@ class MaybeCheckSeerForMatchingGroupHashTest(TestCase):
                     "training_mode": False,
                     "hybrid_fingerprint": False,
                 },
-                viewer_context={"organization_id": self.project.organization_id},
             )

--- a/tests/sentry/seer/agent/test_agent_client.py
+++ b/tests/sentry/seer/agent/test_agent_client.py
@@ -555,9 +555,7 @@ class TestSeerAgentClient(TestCase):
 
         assert result.run_id == 123
         assert result.status == "processing"
-        mock_fetch.assert_called_once_with(
-            123, self.organization, viewer_context=client.viewer_context
-        )
+        mock_fetch.assert_called_once_with(123, self.organization)
 
     @patch("sentry.seer.agent.client.has_seer_access_with_detail")
     @patch("sentry.seer.agent.client.poll_until_done")
@@ -577,9 +575,7 @@ class TestSeerAgentClient(TestCase):
 
         assert result.run_id == 123
         assert result.status == "completed"
-        mock_poll.assert_called_once_with(
-            123, self.organization, 1.0, 30.0, viewer_context=client.viewer_context
-        )
+        mock_poll.assert_called_once_with(123, self.organization, 1.0, 30.0)
 
     @patch("sentry.seer.agent.client.has_seer_access_with_detail")
     @patch("sentry.seer.agent.client.fetch_run_status")
@@ -1376,7 +1372,7 @@ class TestStartFeatureRun(TestCase):
         assert body["feature_id"] == "night_shift"
         # ref/external_idempotency_key are stamped by the handler at dispatch, not enqueue.
         assert "ref" not in body
-        assert outbox.payload["viewer_context"]["organization_id"] == self.organization.id
+        assert outbox.payload["viewer_context"] is None
 
     @patch("sentry.seer.agent.client.has_seer_access_with_detail", return_value=(True, None))
     @patch("sentry.receivers.outbox.cell.make_feature_run_request")

--- a/tests/sentry/seer/endpoints/test_organization_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_rpc.py
@@ -225,10 +225,7 @@ class TestOrganizationSeerRpcEndpoint(APITestCase):
         assert response.data["org_id"] == self.organization.id
         assert "tables" in response.data
         # org_id injected from URL, not from caller-supplied args
-        mock_request.assert_called_once_with(
-            {"org_id": self.organization.id},
-            viewer_context={"organization_id": self.organization.id},
-        )
+        mock_request.assert_called_once_with({"org_id": self.organization.id})
 
     @with_feature("organizations:seer-public-rpc")
     @patch("sentry.seer.agent.snapshot_indexes.make_agent_export_indexes_request")
@@ -250,10 +247,7 @@ class TestOrganizationSeerRpcEndpoint(APITestCase):
         response = self.client.post(path, data={"args": {"org_id": 99999}}, format="json")
 
         assert response.status_code == 200
-        mock_request.assert_called_once_with(
-            {"org_id": self.organization.id},
-            viewer_context={"organization_id": self.organization.id},
-        )
+        mock_request.assert_called_once_with({"org_id": self.organization.id})
 
     @with_feature("organizations:seer-public-rpc")
     def test_get_issue_committers_with_project_access(self) -> None:

--- a/tests/sentry/seer/endpoints/test_search_agent_start.py
+++ b/tests/sentry/seer/endpoints/test_search_agent_start.py
@@ -5,26 +5,25 @@ import pytest
 from sentry.seer.endpoints.search_agent_start import send_search_agent_start_request
 from sentry.seer.models import SeerApiError
 from sentry.seer.models.run import SeerRun, SeerRunMirrorStatus, SeerRunType
-from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.testutils.cases import TestCase
+from sentry.viewer_context import ViewerContext, viewer_context_scope
 
 
 class SendSearchAgentStartRequestTest(TestCase):
     @patch("sentry.receivers.outbox.cell.make_search_agent_start_request")
     def test_outbox_path_creates_run_and_flushes(self, mock_request: Mock) -> None:
         mock_request.return_value = Mock(status=200, json=Mock(return_value={"run_id": 42}))
-        viewer_context = SeerViewerContext(
-            organization_id=self.organization.id, user_id=self.user.id
-        )
 
-        result = send_search_agent_start_request(
-            organization=self.organization,
-            user_id=self.user.id,
-            project_ids=[self.project.id],
-            natural_language_query="errors today",
-            strategy="Issues",
-            viewer_context=viewer_context,
-        )
+        with viewer_context_scope(
+            ViewerContext(organization_id=self.organization.id, user_id=self.user.id)
+        ):
+            result = send_search_agent_start_request(
+                organization=self.organization,
+                user_id=self.user.id,
+                project_ids=[self.project.id],
+                natural_language_query="errors today",
+                strategy="Issues",
+            )
 
         assert isinstance(result, SeerRun)
         assert result.type == SeerRunType.ASSISTED_QUERY
@@ -36,31 +35,32 @@ class SendSearchAgentStartRequestTest(TestCase):
         assert sent_body["natural_language_query"] == "errors today"
 
     def test_outbox_flush_error_raises(self) -> None:
-        viewer_context = SeerViewerContext(
-            organization_id=self.organization.id, user_id=self.user.id
-        )
-
-        with pytest.raises(SeerApiError):
+        with (
+            viewer_context_scope(
+                ViewerContext(organization_id=self.organization.id, user_id=self.user.id)
+            ),
+            pytest.raises(SeerApiError),
+        ):
             send_search_agent_start_request(
                 organization=self.organization,
                 user_id=self.user.id,
                 project_ids=[self.project.id],
                 natural_language_query="errors today",
-                viewer_context=viewer_context,
             )
 
     @patch("sentry.receivers.outbox.cell.make_search_agent_start_request")
     def test_terminal_seer_failure_raises(self, mock_request: Mock) -> None:
         mock_request.return_value = Mock(status=400, json=Mock(return_value={}))
-        viewer_context = SeerViewerContext(
-            organization_id=self.organization.id, user_id=self.user.id
-        )
 
-        with pytest.raises(SeerApiError):
+        with (
+            viewer_context_scope(
+                ViewerContext(organization_id=self.organization.id, user_id=self.user.id)
+            ),
+            pytest.raises(SeerApiError),
+        ):
             send_search_agent_start_request(
                 organization=self.organization,
                 user_id=self.user.id,
                 project_ids=[self.project.id],
                 natural_language_query="errors today",
-                viewer_context=viewer_context,
             )

--- a/tests/sentry/seer/endpoints/test_trace_explorer_ai_query.py
+++ b/tests/sentry/seer/endpoints/test_trace_explorer_ai_query.py
@@ -52,10 +52,6 @@ class TraceExplorerAIQueryTest(APITestCase):
             self.organization.slug,
             [self.project.id],
             "Find slow transactions",
-            viewer_context={
-                "organization_id": self.organization.id,
-                "user_id": self.user.id,
-            },
         )
 
     def test_query_missing_parameters(self) -> None:

--- a/tests/sentry/seer/endpoints/test_trace_explorer_ai_setup.py
+++ b/tests/sentry/seer/endpoints/test_trace_explorer_ai_setup.py
@@ -24,10 +24,6 @@ class TraceExplorerAISetupTest(APITestCase):
         mock_fire_setup_request.assert_called_once_with(
             self.organization.id,
             [self.project.id],
-            viewer_context={
-                "organization_id": self.organization.id,
-                "user_id": self.user.id,
-            },
         )
 
     @with_feature("organizations:gen-ai-features")
@@ -79,10 +75,6 @@ class TraceExplorerAISetupTest(APITestCase):
         mock_fire_setup_request.assert_called_once_with(
             self.organization.id,
             [],
-            viewer_context={
-                "organization_id": self.organization.id,
-                "user_id": self.user.id,
-            },
         )
 
     def test_requires_feature_flag(self) -> None:

--- a/tests/sentry/seer/endpoints/test_trace_explorer_ai_translate_agentic.py
+++ b/tests/sentry/seer/endpoints/test_trace_explorer_ai_translate_agentic.py
@@ -53,10 +53,6 @@ class SearchAgentTranslateEndpointTest(APITestCase):
             strategy="Traces",
             model_name=None,
             metric_context=None,
-            viewer_context={
-                "organization_id": self.organization.id,
-                "user_id": self.user.id,
-            },
         )
 
     @patch(

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -789,7 +789,7 @@ class TestRunNightShiftFeatureDelivery(NightShiftFixtures, TestCase, SnubaTestCa
             category=OutboxCategory.SEER_RUN_CREATE, object_identifier=seer_run.id
         )
         assert outbox.payload is not None
-        assert outbox.payload["viewer_context"] == {"organization_id": org.id}
+        assert outbox.payload["viewer_context"] is None
 
         assert seer_run.mirror_status == SeerRunMirrorStatus.PENDING
         assert seer_run.seer_run_state_id is None


### PR DESCRIPTION
## Summary

- Migrates all `SeerViewerContext` instantiations across callers to use `viewer_context_scope` with `ViewerContext`, setting the contextvar so `_resolve_viewer_context` picks up `org_id`, `project_id`, and `user_id` automatically without explicit parameter passing.
- Adds `project_id` to all call sites where a project context is available, enabling per-project cost attribution in the llm-proxy.
- Converts the last remaining caller in `ai_monitoring/tasks.py`.
- Fixes a bug where `viewer_context_scope` only wrapped generator *creation* (not consumption) in `statistical_detectors.py` — since `detect_regressions` uses `yield`, the contextvar was unset by the time the generator body ran.
- Drops `project_id` from multi-project batch scopes in `statistical_detectors.py` where a single project_id would be inaccurate.
- Wraps the full polling block in `wait_for_pr_creation` with a single scope instead of re-entering on every iteration.

After this PR, zero callers instantiate `SeerViewerContext` directly. A follow-up will remove the now-dead `viewer_context` parameter from function signatures and the `_resolve_viewer_context` bridge.