### PR TITLE
feat(spans): Add new conditional if syntax

### DIFF
--- a/src/sentry/search/eap/aggregate_utils.py
+++ b/src/sentry/search/eap/aggregate_utils.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import Callable, cast
 
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey, AttributeValue
 from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
@@ -10,6 +10,7 @@ from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
 from sentry.exceptions import InvalidSearchQuery
 from sentry.search.eap import constants
 from sentry.search.eap.columns import (
+    AggregateDefinition,
     ResolvedArguments,
 )
 from sentry.search.eap.normalizer import unquote_literal
@@ -125,3 +126,23 @@ def resolve_key_eq_value_filter(args: ResolvedArguments) -> tuple[AttributeKey, 
             )
         )
     return aggregate_key, trace_filter
+
+
+def if_query_validator(term: str) -> bool:
+    if not term.startswith("`") or not term.endswith("`"):
+        return False
+    return True
+
+
+def apply_combinators(
+    combinators: dict[str, Callable[[AggregateDefinition], AggregateDefinition]],
+    definitions: dict[str, AggregateDefinition],
+) -> None:
+    combinator_aggregate_definitions: dict[str, AggregateDefinition] = {}
+    for combinator, apply_combinator in combinators.items():
+        for function, definition in definitions.items():
+            if not function.endswith(f"_{combinator}"):
+                function_label = f"{function}_{combinator}"
+                if function_label not in definitions:
+                    combinator_aggregate_definitions[function_label] = apply_combinator(definition)
+    definitions.update(combinator_aggregate_definitions)

--- a/src/sentry/search/eap/aggregate_utils.py
+++ b/src/sentry/search/eap/aggregate_utils.py
@@ -142,9 +142,7 @@ def apply_combinators(
     combinator_aggregate_definitions: dict[str, AggregateDefinition] = {}
     for combinator, apply_combinator in combinators.items():
         for function, definition in definitions.items():
-            if not isinstance(function, ConditionalAggregateDefinition) and not function.endswith(
-                f"_{combinator}"
-            ):
+            if not isinstance(definition, ConditionalAggregateDefinition):
                 function_label = f"{function}_{combinator}"
                 if function_label not in definitions:
                     combinator_aggregate_definitions[function_label] = apply_combinator(definition)

--- a/src/sentry/search/eap/aggregate_utils.py
+++ b/src/sentry/search/eap/aggregate_utils.py
@@ -11,6 +11,7 @@ from sentry.exceptions import InvalidSearchQuery
 from sentry.search.eap import constants
 from sentry.search.eap.columns import (
     AggregateDefinition,
+    ConditionalAggregateDefinition,
     ResolvedArguments,
 )
 from sentry.search.eap.normalizer import unquote_literal
@@ -141,7 +142,9 @@ def apply_combinators(
     combinator_aggregate_definitions: dict[str, AggregateDefinition] = {}
     for combinator, apply_combinator in combinators.items():
         for function, definition in definitions.items():
-            if not function.endswith(f"_{combinator}"):
+            if not isinstance(function, ConditionalAggregateDefinition) and not function.endswith(
+                f"_{combinator}"
+            ):
                 function_label = f"{function}_{combinator}"
                 if function_label not in definitions:
                     combinator_aggregate_definitions[function_label] = apply_combinator(definition)

--- a/src/sentry/search/eap/columns.py
+++ b/src/sentry/search/eap/columns.py
@@ -500,32 +500,56 @@ class AggregateDefinition(FunctionDefinition):
         search_config: SearchResolverConfig,
         default_value: float | None = None,
     ) -> ResolvedFunction:
-        if len(resolved_arguments) > 1:
+        if len(resolved_arguments) > len(self.arguments):
             raise InvalidSearchQuery(
-                f"Aggregates expects exactly 1 argument, got {len(resolved_arguments)}"
+                f"Aggregates expects exactly {len(self.arguments)} argument, got {len(resolved_arguments)}"
             )
 
         resolved_attribute = None
+        trace_filter = None
 
-        if len(resolved_arguments) == 1:
-            if not isinstance(resolved_arguments[0], AttributeKey):
-                raise InvalidSearchQuery("Aggregates accept attribute keys only")
-            resolved_attribute = resolved_arguments[0]
-            if self.attribute_resolver is not None:
-                resolved_attribute = self.attribute_resolver(resolved_attribute)
+        for index, arg_definition in enumerate(self.arguments):
+            resolved_argument = resolved_arguments[index]
+            # Current assumption is that there should only be 1 attribute per aggregate
+            if isinstance(arg_definition, AttributeArgumentDefinition):
+                if not isinstance(resolved_argument, AttributeKey):
+                    raise InvalidSearchQuery("Aggregates accept attribute keys only")
+                if self.attribute_resolver is not None:
+                    resolved_attribute = self.attribute_resolver(resolved_argument)
+                else:
+                    resolved_attribute = resolved_argument
+            elif isinstance(resolved_argument, TraceItemFilter):
+                trace_filter = resolved_argument
 
-        return ResolvedAggregate(
-            public_alias=alias,
-            internal_name=self.internal_function,
-            search_type=search_type,
-            internal_type=self.internal_type,
-            processor=self.processor,
-            extrapolation_mode=resolve_extrapolation_mode(
-                search_config, self.extrapolation_mode_override
-            ),
-            argument=resolved_attribute,
-            default_value=default_value,
-        )
+        if trace_filter is not None:
+            if resolved_attribute is None:
+                raise InvalidSearchQuery(f"{alias} requires an attribute to aggregate on")
+            return ResolvedConditionalAggregate(
+                public_alias=alias,
+                internal_name=self.internal_function,
+                search_type=search_type,
+                internal_type=self.internal_type,
+                processor=self.processor,
+                trace_filter=trace_filter,
+                extrapolation_mode=resolve_extrapolation_mode(
+                    search_config, self.extrapolation_mode_override
+                ),
+                key=resolved_attribute,
+                default_value=default_value,
+            )
+        else:
+            return ResolvedAggregate(
+                public_alias=alias,
+                internal_name=self.internal_function,
+                search_type=search_type,
+                internal_type=self.internal_type,
+                processor=self.processor,
+                extrapolation_mode=resolve_extrapolation_mode(
+                    search_config, self.extrapolation_mode_override
+                ),
+                argument=resolved_attribute,
+                default_value=default_value,
+            )
 
 
 @dataclass(kw_only=True)
@@ -809,6 +833,7 @@ class ColumnDefinitions:
     filter_aliases: Mapping[str, Callable[[SnubaParams, SearchFilter, Any], list[SearchFilter]]]
     alias_to_column: Callable[[str], str | None] | None
     column_to_alias: Callable[[str], str | None] | None
+    aggregate_deprecations: dict[str, AggregateDefinition] | None = None
 
 
 def attribute_key_to_tuple(

--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -1237,6 +1237,37 @@ class SearchResolver:
         # Check if the column looks like a function (matches a pattern), parse the function name and args out
 
         function_definition = self.get_function_definition(function_name)
+        if (
+            self.definitions.aggregate_deprecations
+            and function_name in self.definitions.aggregate_deprecations
+        ):
+            deprecated_definition = self.definitions.aggregate_deprecations[function_name]
+        else:
+            deprecated_definition = None
+
+        # Temporary while we get rid of the old _if combinators
+        if deprecated_definition:
+            try:
+                return self._resolve_function(
+                    function_definition, function_name, alias, columns, default_value
+                )
+            except Exception:
+                return self._resolve_function(
+                    deprecated_definition, function_name, alias, columns, default_value
+                )
+        else:
+            return self._resolve_function(
+                function_definition, function_name, alias, columns, default_value
+            )
+
+    def _resolve_function(
+        self,
+        function_definition: FormulaDefinition | AggregateDefinition,
+        function_name: str,
+        alias: str,
+        columns: str,
+        default_value: float | None = None,
+    ) -> tuple[ResolvedFunction, VirtualColumnDefinition | None]:
         if function_definition.private and function_name not in self.config.fields_acl.functions:
             raise InvalidSearchQuery(f"The function {function_name} is not allowed for this query")
 

--- a/src/sentry/search/eap/spans/aggregates.py
+++ b/src/sentry/search/eap/spans/aggregates.py
@@ -1,4 +1,4 @@
-from typing import Literal, cast
+from typing import Callable, Literal, cast
 
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
     AttributeKey,
@@ -16,7 +16,9 @@ from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
 
 from sentry.search.eap import constants
 from sentry.search.eap.aggregate_utils import (
+    apply_combinators,
     count_processor,
+    if_query_validator,
     resolve_key_eq_value_filter,
 )
 from sentry.search.eap.columns import (
@@ -135,220 +137,6 @@ SPAN_AGGREGATE_DEFINITIONS = {
         default_search_type="integer",
         arguments=[ValueArgumentDefinition(argument_types={"string"})],
         aggregate_resolver=resolve_count_op,
-    ),
-    "count_if": ConditionalAggregateDefinition(
-        internal_function=Function.FUNCTION_COUNT,
-        infer_search_type_from_arguments=False,
-        default_search_type="integer",
-        arguments=[
-            AttributeArgumentDefinition(
-                attribute_types={
-                    "duration",
-                    "number",
-                    "percentage",
-                    "currency",
-                    "boolean",
-                    *constants.SIZE_TYPE,
-                    *constants.DURATION_TYPE,
-                },
-                default_arg="span.self_time",
-                field_allowlist={"is_transaction"},
-            ),
-            AttributeArgumentDefinition(
-                attribute_types={
-                    "string",
-                    "duration",
-                    "number",
-                    "integer",
-                    "percentage",
-                    "currency",
-                    "boolean",
-                    *constants.SIZE_TYPE,
-                    *constants.DURATION_TYPE,
-                }
-            ),
-            ValueArgumentDefinition(
-                argument_types={"string"},
-                validator=literal_validator(
-                    [
-                        "equals",
-                        "notEquals",
-                        "lessOrEquals",
-                        "greaterOrEquals",
-                        "less",
-                        "greater",
-                        "between",
-                    ]
-                ),
-            ),
-            ValueArgumentDefinition(argument_types={"string"}),
-            ValueArgumentDefinition(
-                argument_types={"string"}, default_arg="", validator=number_validator
-            ),  # Second value is only for between, so it must be a number
-        ],
-        aggregate_resolver=resolve_key_eq_value_filter,
-    ),
-    "avg_if": ConditionalAggregateDefinition(
-        internal_function=Function.FUNCTION_AVG,
-        default_search_type="duration",
-        arguments=[
-            AttributeArgumentDefinition(
-                attribute_types={
-                    "duration",
-                    "number",
-                    "percentage",
-                    "currency",
-                    *constants.SIZE_TYPE,
-                    *constants.DURATION_TYPE,
-                },
-            ),
-            AttributeArgumentDefinition(attribute_types={"string"}),
-            ValueArgumentDefinition(
-                argument_types={"string"},
-                validator=literal_validator(["equals", "notEquals"]),
-            ),
-            ValueArgumentDefinition(argument_types={"string"}),
-        ],
-        aggregate_resolver=resolve_key_eq_value_filter,
-    ),
-    "p50_if": ConditionalAggregateDefinition(
-        internal_function=Function.FUNCTION_P50,
-        default_search_type="duration",
-        arguments=[
-            AttributeArgumentDefinition(
-                attribute_types={
-                    "duration",
-                    "number",
-                    "percentage",
-                    "currency",
-                    *constants.SIZE_TYPE,
-                    *constants.DURATION_TYPE,
-                },
-            ),
-            AttributeArgumentDefinition(attribute_types={"string", "boolean"}),
-            ValueArgumentDefinition(
-                argument_types={"string"},
-                validator=literal_validator(["equals", "notEquals"]),
-            ),
-            ValueArgumentDefinition(argument_types={"string"}),
-        ],
-        aggregate_resolver=resolve_key_eq_value_filter,
-    ),
-    "p75_if": ConditionalAggregateDefinition(
-        internal_function=Function.FUNCTION_P75,
-        default_search_type="duration",
-        arguments=[
-            AttributeArgumentDefinition(
-                attribute_types={
-                    "duration",
-                    "number",
-                    "percentage",
-                    "currency",
-                    *constants.SIZE_TYPE,
-                    *constants.DURATION_TYPE,
-                },
-            ),
-            AttributeArgumentDefinition(attribute_types={"string", "boolean"}),
-            ValueArgumentDefinition(
-                argument_types={"string"},
-                validator=literal_validator(["equals", "notEquals"]),
-            ),
-            ValueArgumentDefinition(argument_types={"string"}),
-        ],
-        aggregate_resolver=resolve_key_eq_value_filter,
-    ),
-    "p90_if": ConditionalAggregateDefinition(
-        internal_function=Function.FUNCTION_P90,
-        default_search_type="duration",
-        arguments=[
-            AttributeArgumentDefinition(
-                attribute_types={
-                    "duration",
-                    "number",
-                    "percentage",
-                    "currency",
-                    *constants.SIZE_TYPE,
-                    *constants.DURATION_TYPE,
-                },
-            ),
-            AttributeArgumentDefinition(attribute_types={"string", "boolean"}),
-            ValueArgumentDefinition(
-                argument_types={"string"},
-                validator=literal_validator(["equals", "notEquals"]),
-            ),
-            ValueArgumentDefinition(argument_types={"string"}),
-        ],
-        aggregate_resolver=resolve_key_eq_value_filter,
-    ),
-    "p95_if": ConditionalAggregateDefinition(
-        internal_function=Function.FUNCTION_P95,
-        default_search_type="duration",
-        arguments=[
-            AttributeArgumentDefinition(
-                attribute_types={
-                    "duration",
-                    "number",
-                    "percentage",
-                    "currency",
-                    *constants.SIZE_TYPE,
-                    *constants.DURATION_TYPE,
-                },
-            ),
-            AttributeArgumentDefinition(attribute_types={"string", "boolean"}),
-            ValueArgumentDefinition(
-                argument_types={"string"},
-                validator=literal_validator(["equals", "notEquals"]),
-            ),
-            ValueArgumentDefinition(argument_types={"string"}),
-        ],
-        aggregate_resolver=resolve_key_eq_value_filter,
-    ),
-    "p99_if": ConditionalAggregateDefinition(
-        internal_function=Function.FUNCTION_P99,
-        default_search_type="duration",
-        arguments=[
-            AttributeArgumentDefinition(
-                attribute_types={
-                    "duration",
-                    "number",
-                    "percentage",
-                    "currency",
-                    *constants.SIZE_TYPE,
-                    *constants.DURATION_TYPE,
-                },
-            ),
-            AttributeArgumentDefinition(attribute_types={"string", "boolean"}),
-            ValueArgumentDefinition(
-                argument_types={"string"},
-                validator=literal_validator(["equals", "notEquals"]),
-            ),
-            ValueArgumentDefinition(argument_types={"string"}),
-        ],
-        aggregate_resolver=resolve_key_eq_value_filter,
-    ),
-    "sum_if": ConditionalAggregateDefinition(
-        internal_function=Function.FUNCTION_SUM,
-        default_search_type="duration",
-        arguments=[
-            AttributeArgumentDefinition(
-                attribute_types={
-                    "duration",
-                    "number",
-                    "integer",
-                    "percentage",
-                    "currency",
-                    *constants.SIZE_TYPE,
-                    *constants.DURATION_TYPE,
-                },
-            ),
-            AttributeArgumentDefinition(attribute_types={"string", "boolean"}),
-            ValueArgumentDefinition(
-                argument_types={"string"},
-                validator=literal_validator(["equals", "notEquals"]),
-            ),
-            ValueArgumentDefinition(argument_types={"string"}),
-        ],
-        aggregate_resolver=resolve_key_eq_value_filter,
     ),
     "count_scores": ConditionalAggregateDefinition(
         internal_function=Function.FUNCTION_COUNT,
@@ -693,3 +481,244 @@ SPAN_AGGREGATE_DEFINITIONS = {
     ),
     "count_unique": count_unique_aggregate_definition(),
 }
+
+DEPRECATED_SPAN_AGGREGATE_DEFINITIONS: dict[str, AggregateDefinition] = {
+    "count_if": ConditionalAggregateDefinition(
+        internal_function=Function.FUNCTION_COUNT,
+        infer_search_type_from_arguments=False,
+        default_search_type="integer",
+        arguments=[
+            AttributeArgumentDefinition(
+                attribute_types={
+                    "duration",
+                    "number",
+                    "percentage",
+                    "currency",
+                    "boolean",
+                    *constants.SIZE_TYPE,
+                    *constants.DURATION_TYPE,
+                },
+                default_arg="span.self_time",
+                field_allowlist={"is_transaction"},
+            ),
+            AttributeArgumentDefinition(
+                attribute_types={
+                    "string",
+                    "duration",
+                    "number",
+                    "integer",
+                    "percentage",
+                    "currency",
+                    "boolean",
+                    *constants.SIZE_TYPE,
+                    *constants.DURATION_TYPE,
+                }
+            ),
+            ValueArgumentDefinition(
+                argument_types={"string"},
+                validator=literal_validator(
+                    [
+                        "equals",
+                        "notEquals",
+                        "lessOrEquals",
+                        "greaterOrEquals",
+                        "less",
+                        "greater",
+                        "between",
+                    ]
+                ),
+            ),
+            ValueArgumentDefinition(argument_types={"string"}),
+            ValueArgumentDefinition(
+                argument_types={"string"}, default_arg="", validator=number_validator
+            ),  # Second value is only for between, so it must be a number
+        ],
+        aggregate_resolver=resolve_key_eq_value_filter,
+    ),
+    "avg_if": ConditionalAggregateDefinition(
+        internal_function=Function.FUNCTION_AVG,
+        default_search_type="duration",
+        arguments=[
+            AttributeArgumentDefinition(
+                attribute_types={
+                    "duration",
+                    "number",
+                    "percentage",
+                    "currency",
+                    *constants.SIZE_TYPE,
+                    *constants.DURATION_TYPE,
+                },
+            ),
+            AttributeArgumentDefinition(attribute_types={"string"}),
+            ValueArgumentDefinition(
+                argument_types={"string"},
+                validator=literal_validator(["equals", "notEquals"]),
+            ),
+            ValueArgumentDefinition(argument_types={"string"}),
+        ],
+        aggregate_resolver=resolve_key_eq_value_filter,
+    ),
+    "p50_if": ConditionalAggregateDefinition(
+        internal_function=Function.FUNCTION_P50,
+        default_search_type="duration",
+        arguments=[
+            AttributeArgumentDefinition(
+                attribute_types={
+                    "duration",
+                    "number",
+                    "percentage",
+                    "currency",
+                    *constants.SIZE_TYPE,
+                    *constants.DURATION_TYPE,
+                },
+            ),
+            AttributeArgumentDefinition(attribute_types={"string", "boolean"}),
+            ValueArgumentDefinition(
+                argument_types={"string"},
+                validator=literal_validator(["equals", "notEquals"]),
+            ),
+            ValueArgumentDefinition(argument_types={"string"}),
+        ],
+        aggregate_resolver=resolve_key_eq_value_filter,
+    ),
+    "p75_if": ConditionalAggregateDefinition(
+        internal_function=Function.FUNCTION_P75,
+        default_search_type="duration",
+        arguments=[
+            AttributeArgumentDefinition(
+                attribute_types={
+                    "duration",
+                    "number",
+                    "percentage",
+                    "currency",
+                    *constants.SIZE_TYPE,
+                    *constants.DURATION_TYPE,
+                },
+            ),
+            AttributeArgumentDefinition(attribute_types={"string", "boolean"}),
+            ValueArgumentDefinition(
+                argument_types={"string"},
+                validator=literal_validator(["equals", "notEquals"]),
+            ),
+            ValueArgumentDefinition(argument_types={"string"}),
+        ],
+        aggregate_resolver=resolve_key_eq_value_filter,
+    ),
+    "p90_if": ConditionalAggregateDefinition(
+        internal_function=Function.FUNCTION_P90,
+        default_search_type="duration",
+        arguments=[
+            AttributeArgumentDefinition(
+                attribute_types={
+                    "duration",
+                    "number",
+                    "percentage",
+                    "currency",
+                    *constants.SIZE_TYPE,
+                    *constants.DURATION_TYPE,
+                },
+            ),
+            AttributeArgumentDefinition(attribute_types={"string", "boolean"}),
+            ValueArgumentDefinition(
+                argument_types={"string"},
+                validator=literal_validator(["equals", "notEquals"]),
+            ),
+            ValueArgumentDefinition(argument_types={"string"}),
+        ],
+        aggregate_resolver=resolve_key_eq_value_filter,
+    ),
+    "p95_if": ConditionalAggregateDefinition(
+        internal_function=Function.FUNCTION_P95,
+        default_search_type="duration",
+        arguments=[
+            AttributeArgumentDefinition(
+                attribute_types={
+                    "duration",
+                    "number",
+                    "percentage",
+                    "currency",
+                    *constants.SIZE_TYPE,
+                    *constants.DURATION_TYPE,
+                },
+            ),
+            AttributeArgumentDefinition(attribute_types={"string", "boolean"}),
+            ValueArgumentDefinition(
+                argument_types={"string"},
+                validator=literal_validator(["equals", "notEquals"]),
+            ),
+            ValueArgumentDefinition(argument_types={"string"}),
+        ],
+        aggregate_resolver=resolve_key_eq_value_filter,
+    ),
+    "p99_if": ConditionalAggregateDefinition(
+        internal_function=Function.FUNCTION_P99,
+        default_search_type="duration",
+        arguments=[
+            AttributeArgumentDefinition(
+                attribute_types={
+                    "duration",
+                    "number",
+                    "percentage",
+                    "currency",
+                    *constants.SIZE_TYPE,
+                    *constants.DURATION_TYPE,
+                },
+            ),
+            AttributeArgumentDefinition(attribute_types={"string", "boolean"}),
+            ValueArgumentDefinition(
+                argument_types={"string"},
+                validator=literal_validator(["equals", "notEquals"]),
+            ),
+            ValueArgumentDefinition(argument_types={"string"}),
+        ],
+        aggregate_resolver=resolve_key_eq_value_filter,
+    ),
+    "sum_if": ConditionalAggregateDefinition(
+        internal_function=Function.FUNCTION_SUM,
+        default_search_type="duration",
+        arguments=[
+            AttributeArgumentDefinition(
+                attribute_types={
+                    "duration",
+                    "number",
+                    "integer",
+                    "percentage",
+                    "currency",
+                    *constants.SIZE_TYPE,
+                    *constants.DURATION_TYPE,
+                },
+            ),
+            AttributeArgumentDefinition(attribute_types={"string", "boolean"}),
+            ValueArgumentDefinition(
+                argument_types={"string"},
+                validator=literal_validator(["equals", "notEquals"]),
+            ),
+            ValueArgumentDefinition(argument_types={"string"}),
+        ],
+        aggregate_resolver=resolve_key_eq_value_filter,
+    ),
+}
+
+
+def if_combinator(definition: AggregateDefinition) -> AggregateDefinition:
+    return AggregateDefinition(
+        internal_function=definition.internal_function,
+        default_search_type=definition.default_search_type,
+        infer_search_type_from_arguments=definition.infer_search_type_from_arguments,
+        internal_type=definition.internal_type,
+        extrapolation_mode_override=definition.extrapolation_mode_override,
+        processor=definition.processor,
+        private=definition.private,
+        attribute_resolver=definition.attribute_resolver,
+        arguments=[
+            ValueArgumentDefinition(argument_types={"query"}, validator=if_query_validator),
+            *definition.arguments,
+        ],
+    )
+
+
+SPAN_AGGREGATE_COMBINATORS: dict[str, Callable[[AggregateDefinition], AggregateDefinition]] = {
+    "if": if_combinator,
+}
+
+apply_combinators(SPAN_AGGREGATE_COMBINATORS, SPAN_AGGREGATE_DEFINITIONS)

--- a/src/sentry/search/eap/spans/definitions.py
+++ b/src/sentry/search/eap/spans/definitions.py
@@ -1,7 +1,10 @@
 from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
 
 from sentry.search.eap.columns import ColumnDefinitions
-from sentry.search.eap.spans.aggregates import SPAN_AGGREGATE_DEFINITIONS
+from sentry.search.eap.spans.aggregates import (
+    DEPRECATED_SPAN_AGGREGATE_DEFINITIONS,
+    SPAN_AGGREGATE_DEFINITIONS,
+)
 from sentry.search.eap.spans.attributes import SPAN_ATTRIBUTE_DEFINITIONS, SPAN_VIRTUAL_CONTEXTS
 from sentry.search.eap.spans.filter_aliases import SPAN_FILTER_ALIAS_DEFINITIONS
 from sentry.search.eap.spans.formulas import SPAN_FORMULA_DEFINITIONS
@@ -15,4 +18,5 @@ SPAN_DEFINITIONS = ColumnDefinitions(
     filter_aliases=SPAN_FILTER_ALIAS_DEFINITIONS,
     column_to_alias=None,
     alias_to_column=None,
+    aggregate_deprecations=DEPRECATED_SPAN_AGGREGATE_DEFINITIONS,
 )

--- a/src/sentry/search/eap/trace_metrics/aggregates.py
+++ b/src/sentry/search/eap/trace_metrics/aggregates.py
@@ -3,7 +3,7 @@ from typing import Callable
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey, Function
 
 from sentry.search.eap import constants
-from sentry.search.eap.aggregate_utils import count_processor
+from sentry.search.eap.aggregate_utils import apply_combinators, count_processor, if_query_validator
 from sentry.search.eap.columns import (
     AggregateDefinition,
     AttributeArgumentDefinition,
@@ -368,12 +368,6 @@ TRACE_METRICS_AGGREGATE_DEFINITIONS: dict[str, AggregateDefinition] = {
 }
 
 
-def if_query_validator(term: str) -> bool:
-    if not term.startswith("`") or not term.endswith("`"):
-        return False
-    return True
-
-
 def if_combinator(definition: AggregateDefinition) -> AggregateDefinition:
     # Copy the TraceMetricAggregateDefinition but make it Conditional
     return ConditionalTraceMetricAggregateDefinition(
@@ -398,9 +392,4 @@ TRACE_METRICS_AGGREGATE_COMBINATORS: dict[
     "if": if_combinator,
 }
 
-combinator_aggregate_definitions: dict[str, AggregateDefinition] = {}
-for combinator, apply_combinator in TRACE_METRICS_AGGREGATE_COMBINATORS.items():
-    for function, definition in TRACE_METRICS_AGGREGATE_DEFINITIONS.items():
-        combinator_aggregate_definitions[f"{function}_{combinator}"] = apply_combinator(definition)
-
-TRACE_METRICS_AGGREGATE_DEFINITIONS.update(combinator_aggregate_definitions)
+apply_combinators(TRACE_METRICS_AGGREGATE_COMBINATORS, TRACE_METRICS_AGGREGATE_DEFINITIONS)

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -3327,7 +3327,7 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
 
         assert meta["dataset"] == "spans"
 
-    def test_avg_if(self) -> None:
+    def test_avg_if_old_syntax(self) -> None:
         self.store_spans(
             [
                 self.create_span(
@@ -3365,6 +3365,46 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
         assert len(data) == 1
         assert data[0]["avg_if(span.duration, span.op, equals, queue.process)"] == 1500.0
         assert data[0]["avg_if(span.duration, span.op, equals, queue.publish)"] == 3000.0
+        assert meta["dataset"] == "spans"
+
+    def test_avg_if_new_syntax(self) -> None:
+        self.store_spans(
+            [
+                self.create_span(
+                    {"op": "queue.process", "sentry_tags": {"op": "queue.process"}},
+                    duration=1000,
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {"op": "queue.process", "sentry_tags": {"op": "queue.process"}},
+                    duration=2000,
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {"op": "queue.publish", "sentry_tags": {"op": "queue.publish"}},
+                    duration=3000,
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+        )
+
+        response = self.do_request(
+            {
+                "field": [
+                    "avg_if(`span.op:queue.process`, span.duration)",
+                    "avg_if(`span.op:queue.publish`, span.duration)",
+                ],
+                "project": self.project.id,
+                "dataset": "spans",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        assert data[0]["avg_if(`span.op:queue.process`, span.duration)"] == 1500.0
+        assert data[0]["avg_if(`span.op:queue.publish`, span.duration)"] == 3000.0
         assert meta["dataset"] == "spans"
 
     def test_avg_compare(self) -> None:
@@ -3444,6 +3484,35 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
 
         assert response.status_code == 400, response.content
         assert "Invalid parameter snequals" in response.data["detail"]
+
+    def test_any_if_combinator(self) -> None:
+        self.store_spans(
+            [
+                self.create_span(
+                    {"description": "foo_test", "tags": {"condition": "bad"}},
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {"description": "test_foo", "tags": {"condition": "good"}},
+                    start_ts=self.ten_mins_ago,
+                ),
+            ]
+        )
+
+        response = self.do_request(
+            {
+                "field": [
+                    "any_if(`span.description:*test`, condition)",
+                ],
+                "project": self.project.id,
+                "dataset": "spans",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        assert len(response.data["data"]) == 1
+        data = response.data["data"][0]
+        assert data["any_if(`span.description:*test`, condition)"] == "bad"
 
     def test_ttif_ttfd_contribution_rate(self) -> None:
         spans = []


### PR DESCRIPTION
- This adds a new -if combinator to all the span functions that will deprecate the old 3 parameter style functions in favour of one that just accepts an arbitarary search string
- This will need a follow up to remove all the instances of the old syntax both in the frontend and in saved queries before we can delete the old functions but for now this allows both syntax to be used
- BROWSE-559