### PR TITLE
feat(issues): Prefetch the inbox preview on hover

### DIFF
--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -475,8 +475,8 @@ describe('InboxPage', () => {
 
     await waitFor(() => expect(groupRequest).toHaveBeenCalledTimes(1));
 
-    // Clicking reads the warmed cache rather than fetching the group again,
-    // which only holds if the prefetch used the same query key as the preview.
+    // Reads the warmed cache, which only holds if the prefetch used the same
+    // query key as the preview.
     await userEvent.click(issueLink);
 
     const preview = screen.getByRole('complementary', {name: 'Issue preview'});

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -457,6 +457,40 @@ describe('InboxPage', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('prefetches the preview on hover so opening it needs no new request', async () => {
+    mockSuccessfulSections();
+    mockIssuePreview();
+    const groupRequest = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${fixProposedGroup.id}/`,
+      body: fixProposedGroup,
+    });
+    const eventRequest = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${fixProposedGroup.id}/events/recommended/`,
+      body: EventFixture(),
+    });
+
+    render(<InboxPage />, {organization, initialRouterConfig});
+
+    const issueLink = await within(
+      screen.getByRole('region', {name: 'Fix Proposed'})
+    ).findByRole('link', {name: /Fix proposed issue/});
+
+    await userEvent.hover(issueLink);
+
+    await waitFor(() => expect(groupRequest).toHaveBeenCalledTimes(1));
+    expect(eventRequest).toHaveBeenCalledTimes(1);
+
+    // Clicking reads the warmed cache rather than issuing the requests again.
+    await userEvent.click(issueLink);
+
+    const preview = screen.getByRole('complementary', {name: 'Issue preview'});
+    expect(
+      await within(preview).findByRole('heading', {name: 'Fix proposed issue'})
+    ).toBeInTheDocument();
+    expect(groupRequest).toHaveBeenCalledTimes(1);
+    expect(eventRequest).toHaveBeenCalledTimes(1);
+  });
+
   it('stores selection in the URL, renders the embedded preview, and clears it', async () => {
     mockSuccessfulSections();
     mockIssuePreview();

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -457,12 +457,16 @@ describe('InboxPage', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('prefetches the group on hover so opening the preview needs no new request', async () => {
+  it('prefetches the preview on hover so opening it needs no new request', async () => {
     mockSuccessfulSections();
     mockIssuePreview();
     const groupRequest = MockApiClient.addMockResponse({
       url: `/organizations/org-slug/issues/${fixProposedGroup.id}/`,
       body: fixProposedGroup,
+    });
+    const eventRequest = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${fixProposedGroup.id}/events/recommended/`,
+      body: EventFixture(),
     });
 
     render(<InboxPage />, {organization, initialRouterConfig});
@@ -474,16 +478,17 @@ describe('InboxPage', () => {
     await userEvent.hover(issueLink);
 
     await waitFor(() => expect(groupRequest).toHaveBeenCalledTimes(1));
+    expect(eventRequest).toHaveBeenCalledTimes(1);
 
-    // Reads the warmed cache, which only holds if the prefetch used the same
-    // query key as the preview.
+    // Reads the warmed cache, which only holds if the query keys match.
     await userEvent.click(issueLink);
 
     const preview = screen.getByRole('complementary', {name: 'Issue preview'});
     expect(
-      await within(preview).findByRole('heading', {name: 'Fix proposed issue'})
+      await within(preview).findByRole('heading', {name: 'External Links'})
     ).toBeInTheDocument();
     expect(groupRequest).toHaveBeenCalledTimes(1);
+    expect(eventRequest).toHaveBeenCalledTimes(1);
   });
 
   it('stores selection in the URL, renders the embedded preview, and clears it', async () => {

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -457,16 +457,12 @@ describe('InboxPage', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('prefetches the preview on hover so opening it needs no new request', async () => {
+  it('prefetches the group on hover so opening the preview needs no new request', async () => {
     mockSuccessfulSections();
     mockIssuePreview();
     const groupRequest = MockApiClient.addMockResponse({
       url: `/organizations/org-slug/issues/${fixProposedGroup.id}/`,
       body: fixProposedGroup,
-    });
-    const eventRequest = MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/issues/${fixProposedGroup.id}/events/recommended/`,
-      body: EventFixture(),
     });
 
     render(<InboxPage />, {organization, initialRouterConfig});
@@ -478,9 +474,9 @@ describe('InboxPage', () => {
     await userEvent.hover(issueLink);
 
     await waitFor(() => expect(groupRequest).toHaveBeenCalledTimes(1));
-    expect(eventRequest).toHaveBeenCalledTimes(1);
 
-    // Clicking reads the warmed cache rather than issuing the requests again.
+    // Clicking reads the warmed cache rather than fetching the group again,
+    // which only holds if the prefetch used the same query key as the preview.
     await userEvent.click(issueLink);
 
     const preview = screen.getByRole('complementary', {name: 'Issue preview'});
@@ -488,7 +484,6 @@ describe('InboxPage', () => {
       await within(preview).findByRole('heading', {name: 'Fix proposed issue'})
     ).toBeInTheDocument();
     expect(groupRequest).toHaveBeenCalledTimes(1);
-    expect(eventRequest).toHaveBeenCalledTimes(1);
   });
 
   it('stores selection in the URL, renders the embedded preview, and clears it', async () => {

--- a/static/app/views/issueList/pages/inbox.tsx
+++ b/static/app/views/issueList/pages/inbox.tsx
@@ -30,6 +30,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {IssuePreview} from 'sentry/views/issueDetails/issuePreview/issuePreview';
 import {IssueListContainer} from 'sentry/views/issueList';
+import {useInboxPreviewPrefetch} from 'sentry/views/issueList/pages/useInboxPreviewPrefetch';
 import {IssueSortOptions} from 'sentry/views/issueList/utils';
 import {getProgressIcon} from 'sentry/views/issueList/utils/progress';
 
@@ -315,9 +316,11 @@ function InboxIssueCard({
   const location = useLocation();
   const {title} = getTitle(group);
   const message = getMessage(group);
+  const prefetchHoverProps = useInboxPreviewPrefetch(group.id);
 
   return (
     <IssueCardLink
+      {...prefetchHoverProps}
       aria-current={selected ? 'true' : undefined}
       data-selected={selected}
       to={{

--- a/static/app/views/issueList/pages/useInboxPreviewPrefetch.tsx
+++ b/static/app/views/issueList/pages/useInboxPreviewPrefetch.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useRef} from 'react';
+import {useRef} from 'react';
 import {useHover} from '@react-aria/interactions';
 import {useQueryClient} from '@tanstack/react-query';
 
@@ -26,8 +26,6 @@ export function useInboxPreviewPrefetch(groupId: string) {
   const environments = useEnvironmentsFromUrl();
   const eventQuery = useEventQuery();
   const timeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
-
-  useEffect(() => () => clearTimeout(timeoutRef.current), []);
 
   const {hoverProps} = useHover({
     onHoverStart: () => {

--- a/static/app/views/issueList/pages/useInboxPreviewPrefetch.tsx
+++ b/static/app/views/issueList/pages/useInboxPreviewPrefetch.tsx
@@ -1,0 +1,74 @@
+import {useCallback, useEffect, useRef} from 'react';
+import {useHover} from '@react-aria/interactions';
+import {useQueryClient} from '@tanstack/react-query';
+
+import {decodeScalar} from 'sentry/utils/queryString';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {useEventQuery} from 'sentry/views/issueDetails/hooks/useEventQuery';
+import {groupApiOptions} from 'sentry/views/issueDetails/useGroup';
+import {
+  groupEventApiOptions,
+  useEnvironmentsFromUrl,
+} from 'sentry/views/issueDetails/utils';
+
+// Long enough that scrolling the list doesn't fire a request per row.
+const PREFETCH_DELAY_MS = 300;
+
+/**
+ * Warms the preview's requests while hovering an inbox row, so clicking renders
+ * from cache instead of waiting on the network.
+ *
+ * Both the group and its recommended event are prefetched: the event request
+ * can't start until the group resolves, so warming only the group would leave
+ * the second round trip on the critical path.
+ *
+ * The options factories are shared with the preview's own hooks, so the query
+ * keys match and the prefetched entries are the ones it reads.
+ */
+export function useInboxPreviewPrefetch(groupId: string) {
+  const organization = useOrganization();
+  const queryClient = useQueryClient();
+  const location = useLocation();
+  const environments = useEnvironmentsFromUrl();
+  const eventQuery = useEventQuery();
+  const timeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
+
+  useEffect(() => () => clearTimeout(timeoutRef.current), []);
+
+  const prefetch = useCallback(() => {
+    queryClient.prefetchQuery(
+      groupApiOptions({
+        groupId,
+        organizationSlug: organization.slug,
+        environments,
+        // Must match useGroup, or this warms a different cache key and the
+        // click refetches anyway.
+        expandDerivedData: organization.features.includes('issue-stream-progress-ui'),
+      })
+    );
+    queryClient.prefetchQuery(
+      groupEventApiOptions({
+        orgSlug: organization.slug,
+        groupId,
+        eventId: 'recommended',
+        environments,
+        query: eventQuery,
+        statsPeriod: decodeScalar(location.query.statsPeriod),
+        start: decodeScalar(location.query.start),
+        end: decodeScalar(location.query.end),
+      })
+    );
+  }, [queryClient, groupId, organization, environments, eventQuery, location.query]);
+
+  const {hoverProps} = useHover({
+    onHoverStart: () => {
+      timeoutRef.current = setTimeout(prefetch, PREFETCH_DELAY_MS);
+    },
+    onHoverEnd: () => {
+      clearTimeout(timeoutRef.current);
+    },
+  });
+
+  return hoverProps;
+}

--- a/static/app/views/issueList/pages/useInboxPreviewPrefetch.tsx
+++ b/static/app/views/issueList/pages/useInboxPreviewPrefetch.tsx
@@ -1,69 +1,42 @@
-import {useCallback, useEffect, useRef} from 'react';
+import {useEffect, useRef} from 'react';
 import {useHover} from '@react-aria/interactions';
 import {useQueryClient} from '@tanstack/react-query';
 
-import {decodeScalar} from 'sentry/utils/queryString';
-import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {useEventQuery} from 'sentry/views/issueDetails/hooks/useEventQuery';
 import {groupApiOptions} from 'sentry/views/issueDetails/useGroup';
-import {
-  groupEventApiOptions,
-  useEnvironmentsFromUrl,
-} from 'sentry/views/issueDetails/utils';
+import {useEnvironmentsFromUrl} from 'sentry/views/issueDetails/utils';
 
 // Long enough that scrolling the list doesn't fire a request per row.
 const PREFETCH_DELAY_MS = 300;
 
 /**
- * Warms the preview's requests while hovering an inbox row, so clicking renders
- * from cache instead of waiting on the network.
+ * Warms the group request while hovering an inbox row, so clicking renders the
+ * preview from cache instead of waiting on the network.
  *
- * Both the group and its recommended event are prefetched: the event request
- * can't start until the group resolves, so warming only the group would leave
- * the second round trip on the critical path.
- *
- * The options factories are shared with the preview's own hooks, so the query
- * keys match and the prefetched entries are the ones it reads.
+ * Uses the same options factory as `useGroup` so the query keys match — notably
+ * `expandDerivedData`, which is part of the key, so building the request by hand
+ * would warm an entry the preview never reads.
  */
 export function useInboxPreviewPrefetch(groupId: string) {
   const organization = useOrganization();
   const queryClient = useQueryClient();
-  const location = useLocation();
   const environments = useEnvironmentsFromUrl();
-  const eventQuery = useEventQuery();
   const timeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
 
   useEffect(() => () => clearTimeout(timeoutRef.current), []);
 
-  const prefetch = useCallback(() => {
-    queryClient.prefetchQuery(
-      groupApiOptions({
-        groupId,
-        organizationSlug: organization.slug,
-        environments,
-        // Must match useGroup, or this warms a different cache key and the
-        // click refetches anyway.
-        expandDerivedData: organization.features.includes('issue-stream-progress-ui'),
-      })
-    );
-    queryClient.prefetchQuery(
-      groupEventApiOptions({
-        orgSlug: organization.slug,
-        groupId,
-        eventId: 'recommended',
-        environments,
-        query: eventQuery,
-        statsPeriod: decodeScalar(location.query.statsPeriod),
-        start: decodeScalar(location.query.start),
-        end: decodeScalar(location.query.end),
-      })
-    );
-  }, [queryClient, groupId, organization, environments, eventQuery, location.query]);
-
   const {hoverProps} = useHover({
     onHoverStart: () => {
-      timeoutRef.current = setTimeout(prefetch, PREFETCH_DELAY_MS);
+      timeoutRef.current = setTimeout(() => {
+        queryClient.prefetchQuery(
+          groupApiOptions({
+            groupId,
+            organizationSlug: organization.slug,
+            environments,
+            expandDerivedData: organization.features.includes('issue-stream-progress-ui'),
+          })
+        );
+      }, PREFETCH_DELAY_MS);
     },
     onHoverEnd: () => {
       clearTimeout(timeoutRef.current);

--- a/static/app/views/issueList/pages/useInboxPreviewPrefetch.tsx
+++ b/static/app/views/issueList/pages/useInboxPreviewPrefetch.tsx
@@ -6,16 +6,12 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {groupApiOptions} from 'sentry/views/issueDetails/useGroup';
 import {useEnvironmentsFromUrl} from 'sentry/views/issueDetails/utils';
 
-// Long enough that scrolling the list doesn't fire a request per row.
 const PREFETCH_DELAY_MS = 300;
 
 /**
  * Warms the group request while hovering an inbox row, so clicking renders the
- * preview from cache instead of waiting on the network.
- *
- * Uses the same options factory as `useGroup` so the query keys match — notably
- * `expandDerivedData`, which is part of the key, so building the request by hand
- * would warm an entry the preview never reads.
+ * preview from cache. Reuses `useGroup`'s options factory so the query keys
+ * match; `expandDerivedData` is part of the key.
  */
 export function useInboxPreviewPrefetch(groupId: string) {
   const organization = useOrganization();

--- a/static/app/views/issueList/pages/useInboxPreviewPrefetch.tsx
+++ b/static/app/views/issueList/pages/useInboxPreviewPrefetch.tsx
@@ -2,21 +2,29 @@ import {useEffect, useRef} from 'react';
 import {useHover} from '@react-aria/interactions';
 import {useQueryClient} from '@tanstack/react-query';
 
+import {decodeScalar} from 'sentry/utils/queryString';
+import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {useEventQuery} from 'sentry/views/issueDetails/hooks/useEventQuery';
 import {groupApiOptions} from 'sentry/views/issueDetails/useGroup';
-import {useEnvironmentsFromUrl} from 'sentry/views/issueDetails/utils';
+import {
+  groupEventApiOptions,
+  useEnvironmentsFromUrl,
+} from 'sentry/views/issueDetails/utils';
 
 const PREFETCH_DELAY_MS = 300;
 
 /**
- * Warms the group request while hovering an inbox row, so clicking renders the
- * preview from cache. Reuses `useGroup`'s options factory so the query keys
- * match; `expandDerivedData` is part of the key.
+ * Warms the preview's requests on hover so clicking renders from cache. Reuses
+ * the preview's own options factories so the query keys match. The event is
+ * included because External Links is gated on it and sits above the feed.
  */
 export function useInboxPreviewPrefetch(groupId: string) {
   const organization = useOrganization();
   const queryClient = useQueryClient();
+  const location = useLocation();
   const environments = useEnvironmentsFromUrl();
+  const eventQuery = useEventQuery();
   const timeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
 
   useEffect(() => () => clearTimeout(timeoutRef.current), []);
@@ -30,6 +38,18 @@ export function useInboxPreviewPrefetch(groupId: string) {
             organizationSlug: organization.slug,
             environments,
             expandDerivedData: organization.features.includes('issue-stream-progress-ui'),
+          })
+        );
+        queryClient.prefetchQuery(
+          groupEventApiOptions({
+            orgSlug: organization.slug,
+            groupId,
+            eventId: 'recommended',
+            environments,
+            query: eventQuery,
+            statsPeriod: decodeScalar(location.query.statsPeriod),
+            start: decodeScalar(location.query.start),
+            end: decodeScalar(location.query.end),
           })
         );
       }, PREFETCH_DELAY_MS);


### PR DESCRIPTION
Hovering an inbox row for 300ms warms the preview's requests, so clicking renders from cache instead of waiting on the network.

This ports the pattern the issue stream already uses for issue details (`usePreloadGroupOnHover` in `groupHeaderRow.tsx`) — `useHover` with a delay so scrolling the list doesn't fire a request per row, cancelled on hover-end.

Both the group and the recommended event are warmed. The event only feeds External Links, but that section is gated on it and sits above the activity feed, so it lands after the feed has painted and shoves it down. Prefetching both means they arrive together.

The subtle part is cache-key alignment: the prefetch reuses the same options factories the preview's own hooks call rather than rebuilding the requests. That matters for `expandDerivedData`, which is part of the group query key — prefetching without it would warm an entry the preview never reads, so the whole thing would look wired up while doing nothing.

The test asserts both request counts stay at 1 after clicking, so it fails if the prefetched entries aren't the ones the preview reads. Verified by unwiring the hover props: it fails without them.


Refs ISWF-3133
Refs ISWF-3132
