### PR TITLE
fix(issues): Keep external links in place while the event loads

### DIFF
--- a/static/app/components/group/externalIssuesList/hooks/useGroupExternalIssues.tsx
+++ b/static/app/components/group/externalIssuesList/hooks/useGroupExternalIssues.tsx
@@ -7,7 +7,7 @@ import {useIntegrationExternalIssues} from './useIntegrationExternalIssues';
 import {useSentryAppExternalIssues} from './useSentryAppExternalIssues';
 
 interface Props {
-  event: Event;
+  event: Event | null;
   group: Group;
 }
 

--- a/static/app/components/group/externalIssuesList/hooks/useSentryAppExternalIssues.tsx
+++ b/static/app/components/group/externalIssuesList/hooks/useSentryAppExternalIssues.tsx
@@ -17,7 +17,7 @@ export function useSentryAppExternalIssues({
   group,
   event,
 }: {
-  event: Event;
+  event: Event | null;
   group: Group;
 }): GroupIntegrationIssueResult {
   const api = useApi();
@@ -86,13 +86,18 @@ export function useSentryAppExternalIssues({
         key: `sentryapp-${component.sentryApp.slug}`,
         displayName: appDisplayName,
         displayIcon,
-        disabled: Boolean(component.error),
-        disabledText: t('Unable to connect to %s', appDisplayName),
+        disabled: Boolean(component.error) || !event,
+        disabledText: component.error
+          ? t('Unable to connect to %s', appDisplayName)
+          : t('Loading\u2026'),
         actions: [
           {
             id: component.sentryApp.slug,
             name: 'Create Issue',
             onClick: () => {
+              if (!event) {
+                return;
+              }
               openSentryAppIssueModal({
                 organization,
                 group,

--- a/static/app/views/issueDetails/issuePreview/issuePreview.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreview.tsx
@@ -210,11 +210,9 @@ function IssuePreviewContent() {
             <TabPanels.Item key="activity">
               <Container paddingTop="md" paddingLeft="md" paddingRight="md">
                 <IssueDetailsContextProvider>
-                  {event && (
-                    <ErrorBoundary mini>
-                      <ExternalIssueSidebarList group={group} event={event} />
-                    </ErrorBoundary>
-                  )}
+                  <ErrorBoundary mini>
+                    <ExternalIssueSidebarList group={group} event={event ?? null} />
+                  </ErrorBoundary>
                   <ErrorBoundary mini>
                     <SidebarFoldSection
                       title={

--- a/static/app/views/issueDetails/sidebar/externalIssueSidebarList.tsx
+++ b/static/app/views/issueDetails/sidebar/externalIssueSidebarList.tsx
@@ -17,7 +17,7 @@ import {SectionKey} from 'sentry/views/issueDetails/context';
 import {SidebarFoldSection} from 'sentry/views/issueDetails/foldSection';
 
 interface Props {
-  event: Event;
+  event: Event | null;
   group: Group;
 }
 

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -457,6 +457,28 @@ describe('InboxPage', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('reserves the external links section before the event loads', async () => {
+    mockSuccessfulSections();
+    mockIssuePreview();
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${fixProposedGroup.id}/events/recommended/`,
+      body: EventFixture(),
+      asyncDelay: 200,
+    });
+
+    render(<InboxPage />, {organization, initialRouterConfig});
+
+    const preview = await openFixProposedPreview();
+
+    // Present while the event is still in flight, so its arrival doesn't push
+    // the activity feed down. Asserted against the activity heading, which is
+    // group-only, so the event cannot have resolved yet.
+    await within(preview).findByRole('heading', {name: 'Activity'});
+    expect(
+      within(preview).getByRole('heading', {name: 'External Links'})
+    ).toBeInTheDocument();
+  });
+
   it('stores selection in the URL, renders the embedded preview, and clears it', async () => {
     mockSuccessfulSections();
     mockIssuePreview();


### PR DESCRIPTION
The preview gated External Links on the recommended event — a second request that can't start until the group resolves. The preview paints as soon as the group lands, so the section appeared afterwards and shoved the activity feed down.

**Why issue details doesn't have this problem despite the identical `{event && ...}` guard:** it blocks the entire page on the event. `groupEventDetails.tsx` returns `<GroupEventDetailsLoading />` while `isLoadingEvent`, so when the page paints, group and event are both present and the section is there on the first frame. There's no intermediate state to shift out of. The preview deliberately doesn't block — that's what makes it feel fast — so it has that intermediate state.

The section already handles loading: `ExternalIssueListContent` renders a `Placeholder` while its integration and external-issue requests are in flight, and those are keyed on the group rather than the event. So making `event` nullable lets the section mount immediately and fill in place, using machinery that already exists.

One consequence: the Sentry app "Create Issue" action passes the event to `openSentryAppIssueModal`, so it's disabled with a loading label until the event arrives. Everything else in the section — linked issues, integrations, linked PRs — never needed the event.

The test asserts the section is present at the same moment the activity heading is, which renders from group data alone, so it can only pass if the section mounted before the event resolved. Verified by restoring the guard: it fails.
