### PR TITLE
feat(issues): Record PR iteration sources in issue activity

### DIFF
--- a/src/sentry/issues/action_log/types.py
+++ b/src/sentry/issues/action_log/types.py
@@ -777,6 +777,8 @@ class SeerPRCreatedAction(GroupAction):
 
 class SeerIterationStartedAction(GroupAction):
     user_visible = True
+    run_id: Optional[int] = None
+    referrer: Optional[str] = None
 
     @classmethod
     def get_type(cls) -> GroupActionType:

--- a/src/sentry/issues/action_log/types.py
+++ b/src/sentry/issues/action_log/types.py
@@ -11,6 +11,8 @@ from typing import Any, ClassVar, Literal, NotRequired, Optional, TypedDict
 
 from pydantic import BaseModel
 
+from sentry.seer.autofix.constants import AutofixReferrer
+
 
 class GroupActorType(IntEnum):
     SYSTEM = 0
@@ -778,7 +780,7 @@ class SeerPRCreatedAction(GroupAction):
 class SeerIterationStartedAction(GroupAction):
     user_visible = True
     run_id: Optional[int] = None
-    referrer: Optional[str] = None
+    referrer: Optional[AutofixReferrer] = None
 
     @classmethod
     def get_type(cls) -> GroupActionType:

--- a/src/sentry/issues/action_log/types.py
+++ b/src/sentry/issues/action_log/types.py
@@ -11,8 +11,6 @@ from typing import Any, ClassVar, Literal, NotRequired, Optional, TypedDict
 
 from pydantic import BaseModel
 
-from sentry.seer.autofix.constants import AutofixReferrer
-
 
 class GroupActorType(IntEnum):
     SYSTEM = 0
@@ -780,7 +778,7 @@ class SeerPRCreatedAction(GroupAction):
 class SeerIterationStartedAction(GroupAction):
     user_visible = True
     run_id: Optional[int] = None
-    referrer: Optional[AutofixReferrer] = None
+    referrer: Optional[str] = None
 
     @classmethod
     def get_type(cls) -> GroupActionType:

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -525,7 +525,7 @@ def trigger_autofix_agent(
             }
             if is_iteration_step:
                 activity_attribution: SeerActivityAttribution = {
-                    "referrer": referrer.value,
+                    "referrer": referrer,
                 }
                 task_kwargs["activity_attribution"] = activity_attribution
             process_autofix_updates.apply_async(kwargs=task_kwargs)

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -49,7 +49,11 @@ from sentry.seer.autofix.utils import (
     AutofixStoppingPoint,
     read_preference_from_sentry_db,
 )
-from sentry.seer.entrypoints.operator import SeerAutofixOperator, process_autofix_updates
+from sentry.seer.entrypoints.operator import (
+    SeerActivityAttribution,
+    SeerAutofixOperator,
+    process_autofix_updates,
+)
 from sentry.seer.models import SeerRepoDefinition
 from sentry.seer.models.run import SeerRun
 from sentry.seer.models.seer_api_models import UNKNOWN_RUN_ID_FOR_GROUP, SeerPermissionError
@@ -520,7 +524,10 @@ def trigger_autofix_agent(
                 "organization_id": group.organization.id,
             }
             if is_iteration_step:
-                task_kwargs["activity_referrer"] = referrer.value
+                activity_attribution: SeerActivityAttribution = {
+                    "referrer": referrer.value,
+                }
+                task_kwargs["activity_attribution"] = activity_attribution
             process_autofix_updates.apply_async(kwargs=task_kwargs)
     except ValueError:
         logger.exception(

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -514,13 +514,14 @@ def trigger_autofix_agent(
     try:
         sentry_app_event_type = SentryAppEventType(event_type)
         if SeerAutofixOperator.has_access(organization=group.organization):
-            process_autofix_updates.apply_async(
-                kwargs={
-                    "event_type": sentry_app_event_type,
-                    "event_payload": payload,
-                    "organization_id": group.organization.id,
-                }
-            )
+            task_kwargs: dict[str, Any] = {
+                "event_type": sentry_app_event_type,
+                "event_payload": payload,
+                "organization_id": group.organization.id,
+            }
+            if is_iteration_step:
+                task_kwargs["activity_referrer"] = referrer.value
+            process_autofix_updates.apply_async(kwargs=task_kwargs)
     except ValueError:
         logger.exception(
             "autofix.trigger.webhook_invalid_event_type",

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -52,6 +52,17 @@ SEER_EVENT_TO_ACTIVITY_TYPE: dict[SentryAppEventType, ActivityType] = {
     SentryAppEventType.SEER_ITERATION_COMPLETED: ActivityType.SEER_ITERATION_COMPLETED,
 }
 
+ITERATION_REFERRER_TO_ACTION_SOURCE: dict[AutofixReferrer, ActionSource] = {
+    AutofixReferrer.GROUP_AUTOFIX_ENDPOINT: ActionSource.API,
+    AutofixReferrer.CLI: ActionSource.SENTRY_CLI,
+    AutofixReferrer.LINEAR_AGENT: ActionSource.API,
+    AutofixReferrer.MCP: ActionSource.MCP,
+    AutofixReferrer.WEB: ActionSource.WEB,
+    AutofixReferrer.GITHUB_PR_COMMENT: ActionSource.GITHUB,
+    AutofixReferrer.GITHUB_PR_REVIEW: ActionSource.GITHUB,
+    AutofixReferrer.GITHUB_CHECK_SUITE: ActionSource.GITHUB,
+}
+
 logger = logging.getLogger(__name__)
 
 
@@ -577,6 +588,7 @@ def _create_seer_activity(
     group: Group,
     event_type: SentryAppEventType,
     event_payload: dict[str, Any],
+    activity_referrer: str | None = None,
 ) -> None:
     activity_type = SEER_EVENT_TO_ACTIVITY_TYPE.get(event_type)
     if not activity_type:
@@ -591,7 +603,9 @@ def _create_seer_activity(
     if run_id is not None:
         activity_data["run_id"] = run_id
 
-    if event_type == SentryAppEventType.SEER_ROOT_CAUSE_COMPLETED:
+    if event_type == SentryAppEventType.SEER_ITERATION_STARTED and activity_referrer is not None:
+        activity_data["referrer"] = activity_referrer
+    elif event_type == SentryAppEventType.SEER_ROOT_CAUSE_COMPLETED:
         root_cause = event_payload.get("root_cause")
         if root_cause:
             activity_data["summary"] = root_cause.get("one_line_description")
@@ -633,6 +647,7 @@ def process_autofix_updates(
     event_type: SentryAppEventType,
     event_payload: dict[str, Any],
     organization_id: int,
+    activity_referrer: str | None = None,
 ) -> None:
     """
     Use the registry to iterate over all entrypoints and check if this payload's run_id or group_id
@@ -672,9 +687,23 @@ def process_autofix_updates(
             lifecycle.record_halt(halt_reason="no_operator_access")
             return
 
+        action_source = ActionSource.SEER_EXPLORER
+        if (
+            event_type == SentryAppEventType.SEER_ITERATION_STARTED
+            and activity_referrer is not None
+        ):
+            try:
+                referrer = AutofixReferrer(activity_referrer)
+            except ValueError:
+                pass
+            else:
+                action_source = ITERATION_REFERRER_TO_ACTION_SOURCE.get(
+                    referrer, ActionSource.SEER_EXPLORER
+                )
+
         try:
-            with action_context_scope(ActionSource.SEER_EXPLORER, SYSTEM_ACTOR):
-                _create_seer_activity(group, event_type, event_payload)
+            with action_context_scope(action_source, SYSTEM_ACTOR):
+                _create_seer_activity(group, event_type, event_payload, activity_referrer)
         except Exception:
             logger.exception(
                 "seer.activity_creation_failed",

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -609,7 +609,9 @@ def _create_seer_activity(
         activity_data["run_id"] = run_id
 
     if event_type == SentryAppEventType.SEER_ITERATION_STARTED and activity_attribution is not None:
-        activity_data["referrer"] = activity_attribution["referrer"].value
+        # ``referrer`` arrives as a plain string once the task payload is
+        # serialized; ``str()`` covers both that and the enum member.
+        activity_data["referrer"] = str(activity_attribution["referrer"])
     elif event_type == SentryAppEventType.SEER_ROOT_CAUSE_COMPLETED:
         root_cause = event_payload.get("root_cause")
         if root_cause:
@@ -694,12 +696,7 @@ def process_autofix_updates(
 
         iteration_attribution: SeerActivityAttribution | None = None
         if event_type == SentryAppEventType.SEER_ITERATION_STARTED and activity_attribution:
-            try:
-                activity_attribution["referrer"] = AutofixReferrer(activity_attribution["referrer"])
-            except ValueError:
-                pass
-            else:
-                iteration_attribution = activity_attribution
+            iteration_attribution = activity_attribution
 
         action_source = ActionSource.SEER_EXPLORER
         if iteration_attribution is not None:

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -609,8 +609,6 @@ def _create_seer_activity(
         activity_data["run_id"] = run_id
 
     if event_type == SentryAppEventType.SEER_ITERATION_STARTED and activity_attribution is not None:
-        # ``referrer`` arrives as a plain string once the task payload is
-        # serialized; ``str()`` covers both that and the enum member.
         activity_data["referrer"] = str(activity_attribution["referrer"])
     elif event_type == SentryAppEventType.SEER_ROOT_CAUSE_COMPLETED:
         root_cause = event_payload.get("root_cause")

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any
+from typing import Any, TypedDict
 
 from sentry import features, options
 from sentry.constants import DataCategory
@@ -51,6 +51,11 @@ SEER_EVENT_TO_ACTIVITY_TYPE: dict[SentryAppEventType, ActivityType] = {
     SentryAppEventType.SEER_ITERATION_STARTED: ActivityType.SEER_ITERATION_STARTED,
     SentryAppEventType.SEER_ITERATION_COMPLETED: ActivityType.SEER_ITERATION_COMPLETED,
 }
+
+
+class SeerActivityAttribution(TypedDict):
+    referrer: str
+
 
 ITERATION_REFERRER_TO_ACTION_SOURCE: dict[AutofixReferrer, ActionSource] = {
     AutofixReferrer.GROUP_AUTOFIX_ENDPOINT: ActionSource.API,
@@ -588,7 +593,7 @@ def _create_seer_activity(
     group: Group,
     event_type: SentryAppEventType,
     event_payload: dict[str, Any],
-    activity_referrer: str | None = None,
+    activity_attribution: SeerActivityAttribution | None = None,
 ) -> None:
     activity_type = SEER_EVENT_TO_ACTIVITY_TYPE.get(event_type)
     if not activity_type:
@@ -603,8 +608,8 @@ def _create_seer_activity(
     if run_id is not None:
         activity_data["run_id"] = run_id
 
-    if event_type == SentryAppEventType.SEER_ITERATION_STARTED and activity_referrer is not None:
-        activity_data["referrer"] = activity_referrer
+    if event_type == SentryAppEventType.SEER_ITERATION_STARTED and activity_attribution is not None:
+        activity_data["referrer"] = activity_attribution["referrer"]
     elif event_type == SentryAppEventType.SEER_ROOT_CAUSE_COMPLETED:
         root_cause = event_payload.get("root_cause")
         if root_cause:
@@ -647,7 +652,7 @@ def process_autofix_updates(
     event_type: SentryAppEventType,
     event_payload: dict[str, Any],
     organization_id: int,
-    activity_referrer: str | None = None,
+    activity_attribution: SeerActivityAttribution | None = None,
 ) -> None:
     """
     Use the registry to iterate over all entrypoints and check if this payload's run_id or group_id
@@ -688,12 +693,9 @@ def process_autofix_updates(
             return
 
         action_source = ActionSource.SEER_EXPLORER
-        if (
-            event_type == SentryAppEventType.SEER_ITERATION_STARTED
-            and activity_referrer is not None
-        ):
+        if event_type == SentryAppEventType.SEER_ITERATION_STARTED and activity_attribution:
             try:
-                referrer = AutofixReferrer(activity_referrer)
+                referrer = AutofixReferrer(activity_attribution["referrer"])
             except ValueError:
                 pass
             else:
@@ -703,7 +705,7 @@ def process_autofix_updates(
 
         try:
             with action_context_scope(action_source, SYSTEM_ACTOR):
-                _create_seer_activity(group, event_type, event_payload, activity_referrer)
+                _create_seer_activity(group, event_type, event_payload, activity_attribution)
         except Exception:
             logger.exception(
                 "seer.activity_creation_failed",

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -66,6 +66,7 @@ ITERATION_REFERRER_TO_ACTION_SOURCE: dict[AutofixReferrer, ActionSource] = {
     AutofixReferrer.GITHUB_PR_COMMENT: ActionSource.GITHUB,
     AutofixReferrer.GITHUB_PR_REVIEW: ActionSource.GITHUB,
     AutofixReferrer.GITHUB_CHECK_SUITE: ActionSource.GITHUB,
+    AutofixReferrer.UNKNOWN: ActionSource.UNKNOWN,
 }
 
 logger = logging.getLogger(__name__)

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -54,7 +54,7 @@ SEER_EVENT_TO_ACTIVITY_TYPE: dict[SentryAppEventType, ActivityType] = {
 
 
 class SeerActivityAttribution(TypedDict):
-    referrer: str
+    referrer: AutofixReferrer
 
 
 ITERATION_REFERRER_TO_ACTION_SOURCE: dict[AutofixReferrer, ActionSource] = {
@@ -609,7 +609,7 @@ def _create_seer_activity(
         activity_data["run_id"] = run_id
 
     if event_type == SentryAppEventType.SEER_ITERATION_STARTED and activity_attribution is not None:
-        activity_data["referrer"] = activity_attribution["referrer"]
+        activity_data["referrer"] = activity_attribution["referrer"].value
     elif event_type == SentryAppEventType.SEER_ROOT_CAUSE_COMPLETED:
         root_cause = event_payload.get("root_cause")
         if root_cause:
@@ -692,20 +692,24 @@ def process_autofix_updates(
             lifecycle.record_halt(halt_reason="no_operator_access")
             return
 
-        action_source = ActionSource.SEER_EXPLORER
+        iteration_attribution: SeerActivityAttribution | None = None
         if event_type == SentryAppEventType.SEER_ITERATION_STARTED and activity_attribution:
             try:
-                referrer = AutofixReferrer(activity_attribution["referrer"])
+                activity_attribution["referrer"] = AutofixReferrer(activity_attribution["referrer"])
             except ValueError:
                 pass
             else:
-                action_source = ITERATION_REFERRER_TO_ACTION_SOURCE.get(
-                    referrer, ActionSource.SEER_EXPLORER
-                )
+                iteration_attribution = activity_attribution
+
+        action_source = ActionSource.SEER_EXPLORER
+        if iteration_attribution is not None:
+            action_source = ITERATION_REFERRER_TO_ACTION_SOURCE.get(
+                iteration_attribution["referrer"], ActionSource.SEER_EXPLORER
+            )
 
         try:
             with action_context_scope(action_source, SYSTEM_ACTOR):
-                _create_seer_activity(group, event_type, event_payload, activity_attribution)
+                _create_seer_activity(group, event_type, event_payload, iteration_attribution)
         except Exception:
             logger.exception(
                 "seer.activity_creation_failed",

--- a/src/sentry/tasks/seer/pr_iteration.py
+++ b/src/sentry/tasks/seer/pr_iteration.py
@@ -185,6 +185,7 @@ def consume_queued_autofix_feedback(
         if not queued_items:
             return
 
+        consumable_items: list[QueuedAutofixFeedback] = []
         feedback_items = []
         # Keyed by (source class, id): issue-comment, review-comment, and review
         # (body) ids come from separate GitHub namespaces, so dedupe within each
@@ -226,6 +227,7 @@ def consume_queued_autofix_feedback(
                     continue
                 seen_check_suite_keys.add(suite_key)
 
+            consumable_items.append(item)
             feedback_items.append(item.feedback)
 
         if not feedback_items:
@@ -239,7 +241,7 @@ def consume_queued_autofix_feedback(
             trigger_autofix_agent(
                 group=group,
                 step=AutofixStep.PR_ITERATION,
-                referrer=_get_feedback_referrer(queued_items),
+                referrer=_get_feedback_referrer(consumable_items),
                 run_id=run_id,
                 user_context="\n\n".join(item.text for item in feedback_items),
                 feedback=feedback_items,

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -28,6 +28,7 @@ from sentry.seer.autofix.autofix_agent import (
 )
 from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.models import SeerPermissionError
+from sentry.sentry_apps.event_types import SentryAppEventType
 from sentry.sentry_apps.utils.webhooks import SeerActionType
 from sentry.testutils.cases import TestCase
 from sentry.utils import json
@@ -546,17 +547,33 @@ class TestTriggerAutofixAgent(TestCase):
             organization=self.group.organization, seer_run_state_id=67890
         )
 
-        with self.feature("organizations:autofix-pr-iteration"):
+        with (
+            self.feature("organizations:autofix-pr-iteration"),
+            patch(
+                "sentry.seer.autofix.autofix_agent.SeerAutofixOperator.has_access",
+                return_value=True,
+            ),
+            patch(
+                "sentry.seer.autofix.autofix_agent.process_autofix_updates.apply_async"
+            ) as mock_process_updates,
+        ):
             trigger_autofix_agent(
                 group=self.group,
                 step=AutofixStep.PR_ITERATION,
-                referrer=AutofixReferrer.UNKNOWN,
+                referrer=AutofixReferrer.GITHUB_PR_COMMENT,
                 run_id=67890,
             )
 
         call_kwargs = mock_broadcast.call_args.kwargs
         assert call_kwargs["event_name"] == SeerActionType.ITERATION_STARTED.value
         assert call_kwargs["payload"]["iteration_index"] == 2
+        assert "referrer" not in call_kwargs["payload"]
+        assert mock_process_updates.call_args.kwargs["kwargs"] == {
+            "event_type": SentryAppEventType.SEER_ITERATION_STARTED,
+            "event_payload": call_kwargs["payload"],
+            "organization_id": self.group.organization.id,
+            "activity_referrer": AutofixReferrer.GITHUB_PR_COMMENT.value,
+        }
 
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
     @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -28,7 +28,6 @@ from sentry.seer.autofix.autofix_agent import (
 )
 from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.models import SeerPermissionError
-from sentry.sentry_apps.event_types import SentryAppEventType
 from sentry.sentry_apps.utils.webhooks import SeerActionType
 from sentry.testutils.cases import TestCase
 from sentry.utils import json
@@ -547,16 +546,7 @@ class TestTriggerAutofixAgent(TestCase):
             organization=self.group.organization, seer_run_state_id=67890
         )
 
-        with (
-            self.feature("organizations:autofix-pr-iteration"),
-            patch(
-                "sentry.seer.autofix.autofix_agent.SeerAutofixOperator.has_access",
-                return_value=True,
-            ),
-            patch(
-                "sentry.seer.autofix.autofix_agent.process_autofix_updates.apply_async"
-            ) as mock_process_updates,
-        ):
+        with self.feature("organizations:autofix-pr-iteration"):
             trigger_autofix_agent(
                 group=self.group,
                 step=AutofixStep.PR_ITERATION,
@@ -568,12 +558,6 @@ class TestTriggerAutofixAgent(TestCase):
         assert call_kwargs["event_name"] == SeerActionType.ITERATION_STARTED.value
         assert call_kwargs["payload"]["iteration_index"] == 2
         assert "referrer" not in call_kwargs["payload"]
-        assert mock_process_updates.call_args.kwargs["kwargs"] == {
-            "event_type": SentryAppEventType.SEER_ITERATION_STARTED,
-            "event_payload": call_kwargs["payload"],
-            "organization_id": self.group.organization.id,
-            "activity_referrer": AutofixReferrer.GITHUB_PR_COMMENT.value,
-        }
 
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
     @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")

--- a/tests/sentry/seer/entrypoints/test_operator.py
+++ b/tests/sentry/seer/entrypoints/test_operator.py
@@ -4,7 +4,13 @@ from typing import Any, TypedDict, cast
 from unittest.mock import Mock, patch
 
 from fixtures.seer.webhooks import MOCK_RUN_ID
-from sentry.issues.action_log.types import ActionSource, GroupActionActor, TriggerAutofixAction
+from sentry.issues.action_log.types import (
+    SYSTEM_ACTOR,
+    ActionSource,
+    GroupActionActor,
+    SeerIterationStartedAction,
+    TriggerAutofixAction,
+)
 from sentry.models.activity import Activity
 from sentry.models.organization import Organization
 from sentry.models.pullrequest import (
@@ -759,6 +765,46 @@ class SeerOperatorTest(TestCase):
         )
         assert activity.data["pull_requests"][0]["repo_name"] == "owner/repo"
         assert activity.data["code_changes"]["owner/repo"][0]["path"] == "foo.py"
+
+    def _assert_iteration_started_referrer(
+        self,
+        referrer: AutofixReferrer,
+        expected_source: ActionSource,
+    ) -> None:
+        with (
+            patch.object(SeerAutofixOperator, "has_access", return_value=True),
+            capture_action_log() as action_log,
+        ):
+            process_autofix_updates(
+                event_type=SentryAppEventType.SEER_ITERATION_STARTED,
+                event_payload={"run_id": MOCK_RUN_ID, "group_id": self.group.id},
+                organization_id=self.organization.id,
+                activity_referrer=referrer.value,
+            )
+
+        activity = Activity.objects.get(
+            group=self.group, type=ActivityType.SEER_ITERATION_STARTED.value
+        )
+        assert activity.data == {
+            "run_id": MOCK_RUN_ID,
+            "referrer": referrer.value,
+        }
+        action_log.assert_logged(
+            SeerIterationStartedAction,
+            group_id=self.group.id,
+            source=expected_source,
+            actor=SYSTEM_ACTOR,
+            run_id=MOCK_RUN_ID,
+            referrer=referrer.value,
+        )
+
+    def test_create_seer_iteration_started_activity_records_github_referrer(self) -> None:
+        self._assert_iteration_started_referrer(
+            AutofixReferrer.GITHUB_PR_COMMENT, ActionSource.GITHUB
+        )
+
+    def test_create_seer_iteration_started_activity_records_web_referrer(self) -> None:
+        self._assert_iteration_started_referrer(AutofixReferrer.WEB, ActionSource.WEB)
 
     @patch("sentry.models.activity.invoke_workflow_activity_handlers")
     @patch.object(SeerAutofixOperator, "has_access", return_value=True)

--- a/tests/sentry/seer/entrypoints/test_operator.py
+++ b/tests/sentry/seer/entrypoints/test_operator.py
@@ -675,7 +675,7 @@ class SeerOperatorTest(TestCase):
                     event_type=seer_event,
                     event_payload=event_payload,
                     organization_id=self.organization.id,
-                    activity_referrer=AutofixReferrer.GITHUB_PR_COMMENT.value,
+                    activity_attribution={"referrer": AutofixReferrer.GITHUB_PR_COMMENT.value},
                 )
                 assert Activity.objects.filter(
                     group=self.group, type=expected_activity_type.value

--- a/tests/sentry/seer/entrypoints/test_operator.py
+++ b/tests/sentry/seer/entrypoints/test_operator.py
@@ -668,16 +668,27 @@ class SeerOperatorTest(TestCase):
 
     @patch.object(SeerAutofixOperator, "has_access", return_value=True)
     def test_create_seer_activity_all_mapped_event_types(self, _mock_has_access):
-        for seer_event, expected_activity_type in SEER_EVENT_TO_ACTIVITY_TYPE.items():
-            event_payload = {"run_id": MOCK_RUN_ID, "group_id": self.group.id}
-            process_autofix_updates(
-                event_type=seer_event,
-                event_payload=event_payload,
-                organization_id=self.organization.id,
-            )
-            assert Activity.objects.filter(
-                group=self.group, type=expected_activity_type.value
-            ).exists(), f"Activity not created for {seer_event}"
+        with capture_action_log() as action_log:
+            for seer_event, expected_activity_type in SEER_EVENT_TO_ACTIVITY_TYPE.items():
+                event_payload = {"run_id": MOCK_RUN_ID, "group_id": self.group.id}
+                process_autofix_updates(
+                    event_type=seer_event,
+                    event_payload=event_payload,
+                    organization_id=self.organization.id,
+                    activity_referrer=AutofixReferrer.GITHUB_PR_COMMENT.value,
+                )
+                assert Activity.objects.filter(
+                    group=self.group, type=expected_activity_type.value
+                ).exists(), f"Activity not created for {seer_event}"
+
+        action_log.assert_logged(
+            SeerIterationStartedAction,
+            group_id=self.group.id,
+            source=ActionSource.GITHUB,
+            actor=SYSTEM_ACTOR,
+            run_id=MOCK_RUN_ID,
+            referrer=AutofixReferrer.GITHUB_PR_COMMENT.value,
+        )
 
     @patch.object(SeerAutofixOperator, "has_access", return_value=True)
     def test_create_seer_activity_skips_non_seer_events(self, _mock_has_access):
@@ -765,46 +776,6 @@ class SeerOperatorTest(TestCase):
         )
         assert activity.data["pull_requests"][0]["repo_name"] == "owner/repo"
         assert activity.data["code_changes"]["owner/repo"][0]["path"] == "foo.py"
-
-    def _assert_iteration_started_referrer(
-        self,
-        referrer: AutofixReferrer,
-        expected_source: ActionSource,
-    ) -> None:
-        with (
-            patch.object(SeerAutofixOperator, "has_access", return_value=True),
-            capture_action_log() as action_log,
-        ):
-            process_autofix_updates(
-                event_type=SentryAppEventType.SEER_ITERATION_STARTED,
-                event_payload={"run_id": MOCK_RUN_ID, "group_id": self.group.id},
-                organization_id=self.organization.id,
-                activity_referrer=referrer.value,
-            )
-
-        activity = Activity.objects.get(
-            group=self.group, type=ActivityType.SEER_ITERATION_STARTED.value
-        )
-        assert activity.data == {
-            "run_id": MOCK_RUN_ID,
-            "referrer": referrer.value,
-        }
-        action_log.assert_logged(
-            SeerIterationStartedAction,
-            group_id=self.group.id,
-            source=expected_source,
-            actor=SYSTEM_ACTOR,
-            run_id=MOCK_RUN_ID,
-            referrer=referrer.value,
-        )
-
-    def test_create_seer_iteration_started_activity_records_github_referrer(self) -> None:
-        self._assert_iteration_started_referrer(
-            AutofixReferrer.GITHUB_PR_COMMENT, ActionSource.GITHUB
-        )
-
-    def test_create_seer_iteration_started_activity_records_web_referrer(self) -> None:
-        self._assert_iteration_started_referrer(AutofixReferrer.WEB, ActionSource.WEB)
 
     @patch("sentry.models.activity.invoke_workflow_activity_handlers")
     @patch.object(SeerAutofixOperator, "has_access", return_value=True)

--- a/tests/sentry/seer/entrypoints/test_operator.py
+++ b/tests/sentry/seer/entrypoints/test_operator.py
@@ -681,6 +681,13 @@ class SeerOperatorTest(TestCase):
                     group=self.group, type=expected_activity_type.value
                 ).exists(), f"Activity not created for {seer_event}"
 
+            process_autofix_updates(
+                event_type=SentryAppEventType.SEER_ITERATION_STARTED,
+                event_payload={"run_id": MOCK_RUN_ID, "group_id": self.group.id},
+                organization_id=self.organization.id,
+                activity_attribution={"referrer": AutofixReferrer.UNKNOWN},
+            )
+
         action_log.assert_logged(
             SeerIterationStartedAction,
             group_id=self.group.id,
@@ -688,6 +695,14 @@ class SeerOperatorTest(TestCase):
             actor=SYSTEM_ACTOR,
             run_id=MOCK_RUN_ID,
             referrer=AutofixReferrer.GITHUB_PR_COMMENT.value,
+        )
+        action_log.assert_logged(
+            SeerIterationStartedAction,
+            group_id=self.group.id,
+            source=ActionSource.UNKNOWN,
+            actor=SYSTEM_ACTOR,
+            run_id=MOCK_RUN_ID,
+            referrer=AutofixReferrer.UNKNOWN.value,
         )
 
     @patch.object(SeerAutofixOperator, "has_access", return_value=True)

--- a/tests/sentry/seer/entrypoints/test_operator.py
+++ b/tests/sentry/seer/entrypoints/test_operator.py
@@ -675,7 +675,7 @@ class SeerOperatorTest(TestCase):
                     event_type=seer_event,
                     event_payload=event_payload,
                     organization_id=self.organization.id,
-                    activity_attribution={"referrer": AutofixReferrer.GITHUB_PR_COMMENT.value},
+                    activity_attribution={"referrer": AutofixReferrer.GITHUB_PR_COMMENT},
                 )
                 assert Activity.objects.filter(
                     group=self.group, type=expected_activity_type.value

--- a/tests/sentry/tasks/seer/test_pr_iteration.py
+++ b/tests/sentry/tasks/seer/test_pr_iteration.py
@@ -385,12 +385,16 @@ class ConsumeQueuedAutofixFeedbackTest(TestCase):
             metadata={"group_id": self.group.id} if metadata is None else metadata,
         )
 
-    def _queued(self, feedback: Feedback) -> QueuedAutofixFeedback:
+    def _queued(
+        self,
+        feedback: Feedback,
+        referrer: AutofixReferrer = AutofixReferrer.GITHUB_PR_COMMENT,
+    ) -> QueuedAutofixFeedback:
         return QueuedAutofixFeedback(
             organization_id=self.organization.id,
             group_id=self.group.id,
             feedback=feedback,
-            referrer=AutofixReferrer.GITHUB_PR_COMMENT,
+            referrer=referrer,
         )
 
     def _iteration_block(self, idx: int) -> MemoryBlock:
@@ -545,13 +549,47 @@ class ConsumeQueuedAutofixFeedbackTest(TestCase):
         fresh = Feedback(
             source=GithubPrCommentFeedbackSource(comment={"id": 777, "body": "@sentry fresh"})
         )
-        mock_pop.return_value = [self._queued(stale), self._queued(fresh)]
+        mock_pop.return_value = [
+            self._queued(stale, AutofixReferrer.GITHUB_PR_REVIEW),
+            self._queued(fresh, AutofixReferrer.GITHUB_PR_COMMENT),
+        ]
 
         self._call()
 
         mock_trigger.assert_called_once()
         _, kwargs = mock_trigger.call_args
         assert [f.text for f in kwargs["feedback"]] == ["fresh"]
+        assert kwargs["referrer"] == AutofixReferrer.GITHUB_PR_COMMENT
+
+    @patch(f"{TASK_PATH}.trigger_autofix_agent")
+    @patch(f"{TASK_PATH}.pop_queued_autofix_feedback")
+    @patch(f"{TASK_PATH}.fetch_run_status")
+    def test_mixed_consumable_feedback_uses_unknown_referrer(
+        self,
+        mock_fetch: MagicMock,
+        mock_pop: MagicMock,
+        mock_trigger: MagicMock,
+    ) -> None:
+        mock_fetch.return_value = self._state()
+        mock_pop.return_value = [
+            self._queued(
+                Feedback(source=UserUIFeedbackSource(user_id=1, user_feedback="from sentry")),
+                AutofixReferrer.WEB,
+            ),
+            self._queued(
+                Feedback(
+                    source=GithubPrCommentFeedbackSource(
+                        comment={"id": 777, "body": "@sentry from github"}
+                    )
+                ),
+                AutofixReferrer.GITHUB_PR_COMMENT,
+            ),
+        ]
+
+        self._call()
+
+        mock_trigger.assert_called_once()
+        assert mock_trigger.call_args.kwargs["referrer"] == AutofixReferrer.UNKNOWN
 
     @patch(f"{TASK_PATH}.trigger_autofix_agent")
     @patch(f"{TASK_PATH}.pop_queued_autofix_feedback")

--- a/tests/sentry/tasks/seer/test_pr_iteration.py
+++ b/tests/sentry/tasks/seer/test_pr_iteration.py
@@ -564,36 +564,6 @@ class ConsumeQueuedAutofixFeedbackTest(TestCase):
     @patch(f"{TASK_PATH}.trigger_autofix_agent")
     @patch(f"{TASK_PATH}.pop_queued_autofix_feedback")
     @patch(f"{TASK_PATH}.fetch_run_status")
-    def test_mixed_consumable_feedback_uses_unknown_referrer(
-        self,
-        mock_fetch: MagicMock,
-        mock_pop: MagicMock,
-        mock_trigger: MagicMock,
-    ) -> None:
-        mock_fetch.return_value = self._state()
-        mock_pop.return_value = [
-            self._queued(
-                Feedback(source=UserUIFeedbackSource(user_id=1, user_feedback="from sentry")),
-                AutofixReferrer.WEB,
-            ),
-            self._queued(
-                Feedback(
-                    source=GithubPrCommentFeedbackSource(
-                        comment={"id": 777, "body": "@sentry from github"}
-                    )
-                ),
-                AutofixReferrer.GITHUB_PR_COMMENT,
-            ),
-        ]
-
-        self._call()
-
-        mock_trigger.assert_called_once()
-        assert mock_trigger.call_args.kwargs["referrer"] == AutofixReferrer.UNKNOWN
-
-    @patch(f"{TASK_PATH}.trigger_autofix_agent")
-    @patch(f"{TASK_PATH}.pop_queued_autofix_feedback")
-    @patch(f"{TASK_PATH}.fetch_run_status")
     def test_does_not_trigger_when_all_feedback_stale(
         self,
         mock_fetch: MagicMock,


### PR DESCRIPTION
PR iteration starts currently lose where the feedback came from once it leaves the queue, so the activity and action log cannot distinguish Sentry from GitHub.

This carries the resolved referrer through the internal activity task and maps it to the action-log source. Mixed-source batches remain unknown, and the public Seer webhook payload stays unchanged.

This is intentionally only source attribution. User mapping and UI copy can land separately.