### PR TITLE
chore(action log): Pass GALE to workflow engine functions to use in place of Activity

### DIFF
--- a/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
+++ b/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
@@ -1,10 +1,13 @@
 import logging
 
+from sentry import features
+from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
 from sentry.models.activity import Activity
 from sentry.models.group import Group
 from sentry.seer.smart_assignment.models import RESOLUTION_ACTIVITIES
 from sentry.types.activity import ActivityType
 from sentry.utils import metrics
+from sentry.utils.action_log.activity_translator import activity_action_idempotency_key
 from sentry.workflow_engine.models import Detector
 from sentry.workflow_engine.processors.detector import get_preferred_detector
 from sentry.workflow_engine.registry import workflow_activity_registry
@@ -12,6 +15,23 @@ from sentry.workflow_engine.tasks.workflows import process_workflow_activity
 from sentry.workflow_engine.types import DetectorId, WorkflowEventData
 
 logger = logging.getLogger(__name__)
+
+
+def _get_action_log_entry_id_for_activity(group: Group, activity: Activity) -> int | None:
+    """
+    Return the id of the GroupActionLogEntry corresponding to the activity, or None when
+    the `projects:issue-action-log-activity` feature is disabled for the project or no
+    matching entry exists.
+    """
+    if not features.has("projects:issue-action-log-activity", group.project):
+        return None
+
+    entry = GroupActionLogEntry.objects.filter(
+        group_id=group.id,
+        idempotency_key=activity_action_idempotency_key(activity),
+    ).first()
+    return entry.id if entry else None
+
 
 # Seer runs on an issue and reaches the stage...
 SEER_WORKFLOW_ACTIVITIES = [
@@ -89,6 +109,7 @@ def seer_activity_handler(
         activity_id=activity.id,
         group_id=group.id,
         detector_id=detector.id,
+        group_action_log_entry_id=_get_action_log_entry_id_for_activity(group, activity),
     )
     metrics.incr(
         "workflow_engine.seer_activity_handler.complete",
@@ -201,6 +222,7 @@ def activity_handler(
         activity_id=activity.id,
         group_id=group.id,
         detector_id=detector.id,
+        group_action_log_entry_id=_get_action_log_entry_id_for_activity(group, activity),
     )
 
     metrics.incr(

--- a/src/sentry/workflow_engine/tasks/actions.py
+++ b/src/sentry/workflow_engine/tasks/actions.py
@@ -43,12 +43,15 @@ def build_trigger_action_task_params(
     event_id = None
     activity_id = None
     occurrence_id = None
+    group_action_log_entry_id = None
 
     if isinstance(event_data.event, GroupEvent):
         event_id = event_data.event.event_id
         occurrence_id = event_data.event.occurrence_id
     elif isinstance(event_data.event, Activity):
         activity_id = event_data.event.id
+        if event_data.group_action_log_entry is not None:
+            group_action_log_entry_id = event_data.group_action_log_entry.id
 
     task_params = {
         "action_id": action.id,
@@ -60,6 +63,7 @@ def build_trigger_action_task_params(
         "group_state": event_data.group_state,
         "has_reappeared": False,  # TODO: remove when deployed trigger_action task doesn't expect it
         "has_escalated": event_data.has_escalated,
+        "group_action_log_entry_id": group_action_log_entry_id,
     }
 
     if workflow_id in workflow_uuid_map:
@@ -101,6 +105,7 @@ def trigger_action(
     group_state: GroupState,
     has_escalated: bool,
     notification_uuid: str | None = None,
+    group_action_log_entry_id: int | None = None,
     **kwargs: dict[str, object],
 ) -> None:
     import uuid
@@ -132,7 +137,9 @@ def trigger_action(
         )
     elif activity_id is not None:
         event_data = build_workflow_event_data_from_activity(
-            activity_id=activity_id, group_id=group_id
+            activity_id=activity_id,
+            group_id=group_id,
+            group_action_log_entry_id=group_action_log_entry_id,
         )
     else:
         # This should never happen, and if it does, need to investigate

--- a/src/sentry/workflow_engine/tasks/utils.py
+++ b/src/sentry/workflow_engine/tasks/utils.py
@@ -4,6 +4,7 @@ from sentry import nodestore
 from sentry.constants import ObjectStatus
 from sentry.eventstream.base import GroupState
 from sentry.issues.issue_occurrence import IssueOccurrence
+from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
 from sentry.models.activity import Activity
 from sentry.models.environment import Environment
 from sentry.models.group import Group
@@ -113,11 +114,19 @@ def build_workflow_event_data_from_event(
 def build_workflow_event_data_from_activity(
     activity_id: int,
     group_id: int,
+    group_action_log_entry_id: int | None = None,
 ) -> WorkflowEventData:
     activity = Activity.objects.get(id=activity_id)
     group = Group.objects.get(id=group_id)
 
+    group_action_log_entry = (
+        GroupActionLogEntry.objects.get(id=group_action_log_entry_id)
+        if group_action_log_entry_id is not None
+        else None
+    )
+
     return WorkflowEventData(
         event=activity,
         group=group,
+        group_action_log_entry=group_action_log_entry,
     )

--- a/src/sentry/workflow_engine/tasks/workflows.py
+++ b/src/sentry/workflow_engine/tasks/workflows.py
@@ -8,6 +8,7 @@ from google.api_core.exceptions import RetryError
 from taskbroker_client.retry import Retry, retry_task
 
 from sentry.eventstream.base import GroupState
+from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
 from sentry.locks import locks
 from sentry.models.activity import Activity
 from sentry.models.group import Group
@@ -40,12 +41,19 @@ logger = log_context.get_logger(__name__)
     retry=Retry(times=3, delay=5, on=(Exception,)),
     silo_mode=SiloMode.CELL,
 )
-def process_workflow_activity(activity_id: int, group_id: int, detector_id: DetectorId) -> None:
+def process_workflow_activity(
+    activity_id: int,
+    group_id: int,
+    detector_id: DetectorId,
+    group_action_log_entry_id: int | None = None,
+) -> None:
     """
     Process a workflow task identified by the given activity, group, and detector.
 
     The task will get the Activity from the database, create a WorkflowEventData object,
-    and then process the data in `process_workflows`.
+    and then process the data in `process_workflows`. When the caller passes a
+    `group_action_log_entry_id` (only when `projects:issue-action-log-activity` is
+    enabled), the corresponding GroupActionLogEntry is attached to the WorkflowEventData.
     """
     from sentry.workflow_engine.processors.workflow import process_workflows
 
@@ -54,13 +62,24 @@ def process_workflow_activity(activity_id: int, group_id: int, detector_id: Dete
             activity = Activity.objects.get(id=activity_id)
             group = Group.objects.get(id=group_id)
             detector = Detector.objects.get(id=detector_id)
-        except (Activity.DoesNotExist, Group.DoesNotExist, Detector.DoesNotExist):
+            group_action_log_entry = (
+                GroupActionLogEntry.objects.get(id=group_action_log_entry_id)
+                if group_action_log_entry_id is not None
+                else None
+            )
+        except (
+            Activity.DoesNotExist,
+            Group.DoesNotExist,
+            Detector.DoesNotExist,
+            GroupActionLogEntry.DoesNotExist,
+        ):
             logger.exception(
                 "Unable to fetch data to process workflow activity",
                 extra={
                     "activity_id": activity_id,
                     "group_id": group_id,
                     "detector_id": detector_id,
+                    "group_action_log_entry_id": group_action_log_entry_id,
                 },
             )
             return  # Exit execution that we cannot recover from
@@ -68,6 +87,7 @@ def process_workflow_activity(activity_id: int, group_id: int, detector_id: Dete
     event_data = WorkflowEventData(
         event=activity,
         group=group,
+        group_action_log_entry=group_action_log_entry,
     )
     with quiet_redis_noise():
         batch_client = DelayedWorkflowClient()

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from sentry.deletions.base import ModelRelation
     from sentry.eventstream.base import GroupState
     from sentry.issues.issue_occurrence import IssueOccurrence
+    from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
     from sentry.issues.status_change_message import StatusChangeMessage
     from sentry.models.activity import Activity
     from sentry.models.environment import Environment
@@ -105,6 +106,9 @@ class WorkflowEventData:
     # True when an issue transitions to the ESCALATING substatus for any reason.
     has_escalated: bool | None = None
     workflow_env: Environment | None = None
+    # The GroupActionLogEntry corresponding to the activity, set only when the
+    # `projects:issue-action-log-activity` feature is enabled for the project.
+    group_action_log_entry: GroupActionLogEntry | None = None
 
     # The cache field is used to deduplicate repeated work within the context
     # of a single event. This field violates the "frozen" requirement of the

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -345,6 +345,7 @@ class UpdateGroupsTest(TestCase):
             activity_id=activity.id,
             group_id=group.id,
             detector_id=detector.id,
+            group_action_log_entry_id=None,
         )
         # A plain resolve has no GroupResolution, so no ident is stamped.
         assert activity.ident is None
@@ -376,6 +377,7 @@ class UpdateGroupsTest(TestCase):
             activity_id=activity.id,
             group_id=group.id,
             detector_id=detector.id,
+            group_action_log_entry_id=None,
         )
         # The release resolution stamps the GroupResolution id onto the activity's ident.
         resolution = group.groupresolution_set.get()
@@ -410,6 +412,7 @@ class UpdateGroupsTest(TestCase):
             activity_id=activity.id,
             group_id=group.id,
             detector_id=detector.id,
+            group_action_log_entry_id=None,
         )
 
     @patch("sentry.signals.issue_ignored.send_robust")

--- a/tests/sentry/workflow_engine/handlers/workflow/test_workflow_activity_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/workflow/test_workflow_activity_handlers.py
@@ -3,8 +3,11 @@ from unittest.mock import MagicMock
 
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.incidents.grouptype import MetricIssue
+from sentry.models.activity import Activity
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.features import with_feature
 from sentry.types.activity import ActivityType
+from sentry.utils.action_log.activity_translator import activity_action_idempotency_key
 from sentry.workflow_engine.handlers.workflow.workflow_activity_handlers import (
     SEER_WORKFLOW_ACTIVITIES,
     SUPPORTED_ACTIVITIES,
@@ -127,6 +130,7 @@ class SeerActivityHandlerTest(TestCase):
                 activity_id=activity.id,
                 group_id=self.group.id,
                 detector_id=self.detector.id,
+                group_action_log_entry_id=None,
             )
 
     @mock.patch(
@@ -169,6 +173,7 @@ class SeerActivityHandlerTest(TestCase):
             activity_id=self.activity.id,
             group_id=self.group.id,
             detector_id=detector.id,
+            group_action_log_entry_id=None,
         )
 
     @mock.patch(
@@ -188,6 +193,44 @@ class SeerActivityHandlerTest(TestCase):
             activity_id=self.activity.id,
             group_id=self.group.id,
             detector_id=issue_stream_detector.id,
+            group_action_log_entry_id=None,
+        )
+
+    @with_feature("projects:issue-action-log-activity")
+    @mock.patch(
+        "sentry.workflow_engine.handlers.workflow.workflow_activity_handlers.process_workflow_activity"
+    )
+    def test_dispatches_group_action_log_entry(
+        self, mock_process_workflow_activity: MagicMock
+    ) -> None:
+        # With the feature on, the matching GroupActionLogEntry (keyed by the activity)
+        # is looked up and threaded through to the task.
+        entry = self.create_group_action_log_entry(
+            group=self.group,
+            idempotency_key=activity_action_idempotency_key(self.activity),
+        )
+        seer_activity_handler(self.group, self.activity, None)
+        mock_process_workflow_activity.delay.assert_called_once_with(
+            activity_id=self.activity.id,
+            group_id=self.group.id,
+            detector_id=self.detector.id,
+            group_action_log_entry_id=entry.id,
+        )
+
+        # An activity with no matching GroupActionLogEntry threads None.
+        mock_process_workflow_activity.reset_mock()
+        other_activity = Activity(
+            project=self.project,
+            group=self.group,
+            type=ActivityType.SEER_RCA_COMPLETED.value,
+        )
+        other_activity.save()
+        seer_activity_handler(self.group, other_activity, None)
+        mock_process_workflow_activity.delay.assert_called_once_with(
+            activity_id=other_activity.id,
+            group_id=self.group.id,
+            detector_id=self.detector.id,
+            group_action_log_entry_id=None,
         )
 
 
@@ -228,6 +271,7 @@ class GenericActivityHandlerTest(TestCase):
             activity_id=self.activity.id,
             group_id=self.group.id,
             detector_id=self.detector.id,
+            group_action_log_entry_id=None,
         )
 
     @mock.patch(
@@ -258,6 +302,7 @@ class GenericActivityHandlerTest(TestCase):
                 activity_id=activity.id,
                 group_id=self.group.id,
                 detector_id=self.detector.id,
+                group_action_log_entry_id=None,
             )
 
     @mock.patch(
@@ -273,6 +318,7 @@ class GenericActivityHandlerTest(TestCase):
             activity_id=self.activity.id,
             group_id=self.group.id,
             detector_id=self.detector.id,
+            group_action_log_entry_id=None,
         )
 
     @mock.patch(

--- a/tests/sentry/workflow_engine/tasks/test_actions.py
+++ b/tests/sentry/workflow_engine/tasks/test_actions.py
@@ -1,6 +1,7 @@
 import uuid
 from unittest.mock import Mock
 
+from sentry.models.activity import Activity
 from sentry.services.eventstore.models import GroupEvent
 from sentry.testutils.cases import TestCase
 from sentry.workflow_engine.models import Action
@@ -69,3 +70,28 @@ class TestBuildTriggerActionTaskParams(TestCase):
         assert params["action_id"] == 1
         assert params["workflow_id"] == 42
         assert "notification_uuid" not in params
+
+    def test_build_trigger_action_task_params_activity_with_group_action_log_entry(self) -> None:
+        mock_activity = Mock(spec=Activity)
+        mock_activity.id = 100
+        mock_activity.group_id = self.group.id
+
+        action = Action(id=1, type=Action.Type.SLACK)
+
+        # Without a GroupActionLogEntry on the event data, no id is threaded through.
+        event_data = WorkflowEventData(event=mock_activity, group=self.group)
+        params = build_trigger_action_task_params(action, event_data, {}, workflow_id=42)
+
+        assert params["activity_id"] == 100
+        assert params["event_id"] is None
+        assert params["group_action_log_entry_id"] is None
+
+        # When the event data carries a GroupActionLogEntry, its id is included.
+        entry = self.create_group_action_log_entry(group=self.group)
+        event_data = WorkflowEventData(
+            event=mock_activity, group=self.group, group_action_log_entry=entry
+        )
+        params = build_trigger_action_task_params(action, event_data, {}, workflow_id=42)
+
+        assert params["activity_id"] == 100
+        assert params["group_action_log_entry_id"] == entry.id

--- a/tests/sentry/workflow_engine/tasks/test_utils.py
+++ b/tests/sentry/workflow_engine/tasks/test_utils.py
@@ -3,11 +3,14 @@ from unittest import mock
 import pytest
 
 from sentry.constants import ObjectStatus
+from sentry.models.activity import Activity
 from sentry.services.eventstore.models import GroupEvent
 from sentry.testutils.cases import TestCase
+from sentry.types.activity import ActivityType
 from sentry.workflow_engine.tasks.utils import (
     EventNotFoundError,
     ProjectNotActiveError,
+    build_workflow_event_data_from_activity,
     build_workflow_event_data_from_event,
 )
 
@@ -72,3 +75,35 @@ class TestBuildWorkflowEventDataFromEvent(TestCase):
         assert isinstance(result.event, GroupEvent)
         assert result.event.event_id == "test-event-id"
         assert result.group.id == self.group.id
+
+
+class TestBuildWorkflowEventDataFromActivity(TestCase):
+    def setUp(self) -> None:
+        self.group = self.create_group(project=self.project)
+        self.activity = Activity(
+            project=self.project,
+            group=self.group,
+            type=ActivityType.SET_RESOLVED.value,
+        )
+        self.activity.save()
+
+    def test_returns_workflow_event_data(self) -> None:
+        # Without a GroupActionLogEntry, only the activity is attached.
+        result = build_workflow_event_data_from_activity(
+            activity_id=self.activity.id,
+            group_id=self.group.id,
+        )
+        assert result.event == self.activity
+        assert result.group == self.group
+        assert result.group_action_log_entry is None
+
+        # When a GroupActionLogEntry id is passed, the entry is attached too.
+        entry = self.create_group_action_log_entry(group=self.group)
+        result = build_workflow_event_data_from_activity(
+            activity_id=self.activity.id,
+            group_id=self.group.id,
+            group_action_log_entry_id=entry.id,
+        )
+        assert result.event == self.activity
+        assert result.group == self.group
+        assert result.group_action_log_entry == entry

--- a/tests/sentry/workflow_engine/test_task.py
+++ b/tests/sentry/workflow_engine/test_task.py
@@ -136,6 +136,68 @@ class TestProcessWorkflowActivity(TestCase):
         )
 
     @mock.patch(
+        "sentry.workflow_engine.processors.workflow.evaluate_workflows_action_filters",
+        return_value=(set(), {}, EvaluationStats(), {}),
+    )
+    @mock.patch(
+        "sentry.workflow_engine.processors.workflow.evaluate_workflow_triggers",
+        return_value=({}, {}, EvaluationStats(), {}),
+    )
+    def test_process_workflow_activity__group_action_log_entry(
+        self, mock_evaluate: mock.MagicMock, mock_eval_actions: mock.MagicMock
+    ) -> None:
+        self.workflow = self.create_workflow(organization=self.organization)
+        self.create_detector_workflow(detector=self.detector, workflow=self.workflow)
+
+        # Without a GroupActionLogEntry id, none is attached to the event data.
+        process_workflow_activity(
+            activity_id=self.activity.id,
+            group_id=self.group.id,
+            detector_id=self.detector.id,
+        )
+        expected_event_data = WorkflowEventData(event=self.activity, group=self.group)
+        mock_evaluate.assert_called_once_with({self.workflow}, expected_event_data, mock.ANY)
+
+        # With a GroupActionLogEntry id, the entry is attached to the event data.
+        mock_evaluate.reset_mock()
+        entry = self.create_group_action_log_entry(group=self.group)
+        process_workflow_activity(
+            activity_id=self.activity.id,
+            group_id=self.group.id,
+            detector_id=self.detector.id,
+            group_action_log_entry_id=entry.id,
+        )
+        expected_event_data = WorkflowEventData(
+            event=self.activity, group=self.group, group_action_log_entry=entry
+        )
+        mock_evaluate.assert_called_once_with({self.workflow}, expected_event_data, mock.ANY)
+
+    @mock.patch("sentry.workflow_engine.tasks.workflows.logger")
+    def test_process_workflow_activity__missing_group_action_log_entry(
+        self, mock_logger: mock.MagicMock
+    ) -> None:
+        with mock.patch(
+            "sentry.workflow_engine.processors.workflow.process_workflows"
+        ) as mock_process_workflows:
+            process_workflow_activity(
+                activity_id=self.activity.id,
+                group_id=self.group.id,
+                detector_id=self.detector.id,
+                group_action_log_entry_id=999999,
+            )
+
+        mock_process_workflows.assert_not_called()
+        mock_logger.exception.assert_called_once_with(
+            "Unable to fetch data to process workflow activity",
+            extra={
+                "activity_id": self.activity.id,
+                "group_id": self.group.id,
+                "detector_id": self.detector.id,
+                "group_action_log_entry_id": 999999,
+            },
+        )
+
+    @mock.patch(
         "sentry.workflow_engine.processors.action.filter_recently_fired_workflow_actions",
         return_value=([], {}),
     )


### PR DESCRIPTION
Updates `build_workflow_event_data_from_activity` and `process_workflow_activity` to be passed from `GALE` in addition to `Activity` if the flag is enabled.

Follow up PR(s) will actually use this data in place of `Activity`.