### PR TITLE
feat(issues): Show PR iteration sources in issue activity

### DIFF
--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -1033,6 +1033,7 @@ interface GroupActivitySeerPrCreated extends GroupActivityBase {
 interface GroupActivitySeerIterationStarted extends GroupActivityBase {
   data: {
     iteration_index?: number;
+    referrer?: AutofixReferrer;
     run_id?: number;
   };
   type: GroupActivityType.SEER_ITERATION_STARTED;

--- a/static/app/views/issueDetails/activitySection/activityLineItem.stories.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem.stories.tsx
@@ -308,6 +308,12 @@ const seerActivities = [
     pull_requests: [seerPullRequest],
   }),
   seerActivity(GroupActivityType.SEER_ITERATION_STARTED),
+  seerActivity(GroupActivityType.SEER_ITERATION_STARTED, {
+    referrer: 'github.pr_comment',
+  }),
+  seerActivity(GroupActivityType.SEER_ITERATION_STARTED, {
+    referrer: 'github.check_suite',
+  }),
   seerActivity(GroupActivityType.SEER_ITERATION_COMPLETED, {
     pull_requests: [seerPullRequest],
   }),

--- a/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem.tsx
@@ -486,11 +486,18 @@ export function getCompactGroupActivityItem({
           : null,
       };
     }
-    case GroupActivityType.SEER_ITERATION_STARTED:
+    case GroupActivityType.SEER_ITERATION_STARTED: {
+      const {referrer} = activity.data;
       return {
         title: t('Pull request iteration started'),
-        details: activity.data.referrer?.startsWith('github.') ? t('from GitHub') : null,
+        details:
+          referrer === 'github.check_suite'
+            ? t('after CI failed')
+            : referrer?.startsWith('github.')
+              ? t('from GitHub')
+              : null,
       };
+    }
     case GroupActivityType.SEER_ITERATION_COMPLETED: {
       const pullRequest = activity.data.pull_requests?.[0];
       return {

--- a/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem.tsx
@@ -489,6 +489,7 @@ export function getCompactGroupActivityItem({
     case GroupActivityType.SEER_ITERATION_STARTED:
       return {
         title: t('Pull request iteration started'),
+        details: activity.data.referrer?.startsWith('github.') ? t('from GitHub') : null,
       };
     case GroupActivityType.SEER_ITERATION_COMPLETED: {
       const pullRequest = activity.data.pull_requests?.[0];

--- a/static/app/views/issueDetails/activitySection/groupActivityItem.tsx
+++ b/static/app/views/issueDetails/activitySection/groupActivityItem.tsx
@@ -860,9 +860,7 @@ export function getGroupActivityItem(
       case GroupActivityType.SEER_ITERATION_STARTED:
         return {
           title: t('PR Iteration'),
-          message: activity.data.referrer?.startsWith('github.')
-            ? t('Seer started iterating from GitHub')
-            : t('Seer started iterating on the pull request'),
+          message: t('Seer started iterating on the pull request'),
         };
       case GroupActivityType.SEER_ITERATION_COMPLETED: {
         const {data: iterationData} = activity;

--- a/static/app/views/issueDetails/activitySection/groupActivityItem.tsx
+++ b/static/app/views/issueDetails/activitySection/groupActivityItem.tsx
@@ -860,7 +860,9 @@ export function getGroupActivityItem(
       case GroupActivityType.SEER_ITERATION_STARTED:
         return {
           title: t('PR Iteration'),
-          message: t('Seer started iterating on the pull request'),
+          message: activity.data.referrer?.startsWith('github.')
+            ? t('Seer started iterating from GitHub')
+            : t('Seer started iterating on the pull request'),
         };
       case GroupActivityType.SEER_ITERATION_COMPLETED: {
         const {data: iterationData} = activity;

--- a/static/app/views/issueDetails/activitySection/index.spec.tsx
+++ b/static/app/views/issueDetails/activitySection/index.spec.tsx
@@ -1889,7 +1889,7 @@ describe('ActivitySection', () => {
           data: {
             run_id: 456,
             iteration_index: 1,
-            referrer: 'github.pr_comment',
+            referrer: 'github.check_suite',
           },
           user: null,
         },
@@ -1898,7 +1898,7 @@ describe('ActivitySection', () => {
     });
 
     const org = OrganizationFixture({
-      features: ['display-seer-actions-as-issue-activities'],
+      features: ['display-seer-actions-as-issue-activities', 'issue-activity-feed-v2'],
     });
 
     render(
@@ -1910,9 +1910,9 @@ describe('ActivitySection', () => {
       </GroupDataContextProvider>,
       {organization: org}
     );
-    expect(await screen.findAllByText('PR Iteration')).toHaveLength(2);
-    expect(screen.getByText('Seer started iterating from GitHub')).toBeInTheDocument();
-    expect(screen.getByRole('link', {name: 'pull request'})).toHaveAttribute(
+    expect(await screen.findByText('Pull request iteration started')).toBeInTheDocument();
+    expect(screen.getByText('after CI failed')).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: '#42'})).toHaveAttribute(
       'href',
       'https://github.com/org/repo/pull/42'
     );

--- a/static/app/views/issueDetails/activitySection/index.spec.tsx
+++ b/static/app/views/issueDetails/activitySection/index.spec.tsx
@@ -1886,7 +1886,11 @@ describe('ActivitySection', () => {
           type: GroupActivityType.SEER_ITERATION_STARTED,
           id: 'seer-iteration-1',
           dateCreated: '2020-01-01T00:00:00',
-          data: {run_id: 456, iteration_index: 1},
+          data: {
+            run_id: 456,
+            iteration_index: 1,
+            referrer: 'github.pr_comment',
+          },
           user: null,
         },
       ],
@@ -1907,9 +1911,7 @@ describe('ActivitySection', () => {
       {organization: org}
     );
     expect(await screen.findAllByText('PR Iteration')).toHaveLength(2);
-    expect(
-      screen.getByText('Seer started iterating on the pull request')
-    ).toBeInTheDocument();
+    expect(screen.getByText('Seer started iterating from GitHub')).toBeInTheDocument();
     expect(screen.getByRole('link', {name: 'pull request'})).toHaveAttribute(
       'href',
       'https://github.com/org/repo/pull/42'


### PR DESCRIPTION
Adds a small source label to compact PR iteration activity: `after CI failed` for failed check suite starts and `from GitHub` for comment/review starts. Sentry UI and unknown starts keep the existing copy.

Adds each state to the activity story. Uses the referrer recorded by #120695.