### PR TITLE
ref(auth): Unify SAML and OAuth identity-confirmation flows on the shared SSO pipeline

### DIFF
--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -148,7 +148,7 @@ class AuthIdentityHandler:
             skip_internal=False,
         )
 
-        after_2fa_url = absolute_uri(reverse("sentry-auth-sso"))
+        after_2fa_url = self.request.build_absolute_uri(reverse("sentry-auth-sso"))
 
         user_was_logged_in = auth.login(
             self.request,

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -148,13 +148,7 @@ class AuthIdentityHandler:
             skip_internal=False,
         )
 
-        # Use the user's original destination (from _next) for 2FA redirect,
-        # falling back to current URL if not set or invalid
-        after_2fa_url = self.request.session.get("_next")
-        if not after_2fa_url or not auth.is_valid_redirect(
-            after_2fa_url, allowed_hosts=(self.request.get_host(),)
-        ):
-            after_2fa_url = self.request.build_absolute_uri()
+        after_2fa_url = absolute_uri(reverse("sentry-auth-sso"))
 
         user_was_logged_in = auth.login(
             self.request,
@@ -511,12 +505,14 @@ class AuthIdentityHandler:
 
     def _build_confirmation_response(self, is_new_account: bool) -> HttpResponse:
         existing_user, template = self._dispatch_to_confirmation(is_new_account)
+
         context = {
             "identity": self.identity,
             "provider": self.provider_name,
             "identity_display_name": self.identity.get("name") or self.identity.get("email"),
             "identity_identifier": self.identity.get("email") or self.identity.get("id"),
             "existing_user": existing_user,
+            "confirmation_url": reverse("sentry-auth-sso"),
         }
         if not self._logged_in_user:
             context["login_form"] = self._login_form
@@ -534,8 +530,7 @@ class AuthIdentityHandler:
         - Unauthenticated user who proved email ownership via verification link: auto-link.
         - Otherwise: show a confirmation page to merge, create, or log in.
         """
-        # IdP POST includes SAMLResponse; op only comes from Sentry's own confirmation form.
-        op = self.request.POST.get("op") if "SAMLResponse" not in self.request.POST else None
+        op = self.request.POST.get("op")
 
         # we don't trust all IDP email verification, so users can also confirm via one time email link
         is_account_verified = False

--- a/src/sentry/auth/providers/saml2/provider.py
+++ b/src/sentry/auth/providers/saml2/provider.py
@@ -39,6 +39,14 @@ ERR_NO_SAML_SSO = _("The organization does not exist or does not have SAML SSO e
 ERR_SAML_FAILED = _("SAML SSO failed, {reason}")
 
 
+def strip_op_from_post(request: HttpRequest) -> None:
+    # op is only meaningful at /auth/sso/; strip it here.
+    if "op" in request.POST:
+        post = request.POST.copy()
+        del post["op"]
+        request.POST = post  # type: ignore[assignment]
+
+
 def get_provider(organization_slug: str) -> SAML2Provider | None:
     try:
         mapping = OrganizationMapping.objects.get(slug=organization_slug)
@@ -98,17 +106,12 @@ class SAML2AcceptACSView(BaseView):
     def dispatch(self, request: HttpRequest, organization_slug: str) -> HttpResponseBase:
         from sentry.auth.helper import AuthHelper
 
+        strip_op_from_post(request)
+
         pipeline = AuthHelper.get_for_request(request)
 
         # SP initiated authentication, request helper is provided
         if pipeline:
-            # When an IdP POSTs a SAMLResponse, strip op — it's not part of
-            # the SAML spec and only comes from Sentry's own confirmation form.
-            if "SAMLResponse" in request.POST and "op" in request.POST:
-                post = request.POST.copy()
-                del post["op"]
-                request.POST = post  # type: ignore[assignment]
-
             from sentry.web.frontend.auth_provider_login import AuthProviderLoginView
 
             sso_login = AuthProviderLoginView()
@@ -145,12 +148,7 @@ class SAML2AcceptACSView(BaseView):
 class SAML2ACSView(AuthView):
     @method_decorator(csrf_exempt)
     def dispatch(self, request: HttpRequest, pipeline: AuthHelper) -> HttpResponseBase:
-        # When an IdP POSTs a SAMLResponse, strip op — it's not part of
-        # the SAML spec and only comes from Sentry's own confirmation form.
-        if "SAMLResponse" in request.POST and "op" in request.POST:
-            post = request.POST.copy()
-            del post["op"]
-            request.POST = post  # type: ignore[assignment]
+        strip_op_from_post(request)
 
         provider = pipeline.provider
 

--- a/src/sentry/templates/sentry/auth-confirm-identity.html
+++ b/src/sentry/templates/sentry/auth-confirm-identity.html
@@ -39,7 +39,7 @@
       <p>We found an existing Sentry account for {{ identity.email }}. Please confirm your credentials:</p>
     </div>
 
-    <form class="form-stacked" action="" method="post" autocomplete="off">
+    <form class="form-stacked" action="{{ confirmation_url }}" method="post" autocomplete="off">
       {% csrf_token %}
 
       {{ login_form|as_crispy_errors }}
@@ -54,7 +54,7 @@
       </fieldset>
     </form>
   {% else %}
-    <form class="form-stacked" action="" method="post">
+    <form class="form-stacked" action="{{ confirmation_url }}" method="post">
       {% csrf_token %}
       <div class="sso-link">
         <div class="sso-grid flex">

--- a/src/sentry/templates/sentry/auth-confirm-link.html
+++ b/src/sentry/templates/sentry/auth-confirm-link.html
@@ -7,7 +7,7 @@
 {% block title %}{% trans "Confirm Identity" %} | {{ block.super }}{% endblock %}
 
 {% block auth_main %}
-  <form class="form-stacked" action="" method="post">
+  <form class="form-stacked" action="{{ confirmation_url }}" method="post">
     {% csrf_token %}
 
     <div class="sso-link">

--- a/tests/sentry/auth/test_helper.py
+++ b/tests/sentry/auth/test_helper.py
@@ -12,6 +12,7 @@ from django.test import Client, RequestFactory
 
 from sentry import audit_log
 from sentry.analytics.events.user_signup import UserSignUpEvent
+from sentry.auth.authenticators.totp import TotpInterface
 from sentry.auth.exceptions import AuthIdentityUserMismatch
 from sentry.auth.helper import (
     ERR_IDENTITY_CONFLICT,
@@ -819,6 +820,23 @@ class HandleUnknownIdentityTest(AuthIdentityHandlerTest):
 
         assert response is mock_render.return_value
         mock_auth.log_auth_failure.assert_called_once()
+
+    def test_login_2fa_redirect_uses_request_host(self) -> None:
+        """The post-2FA redirect must resume the pipeline on the host the request
+        arrived on (e.g. a customer subdomain), not the system url-prefix host —
+        otherwise the pipeline session cookie isn't sent to the redirect target."""
+        user = self.create_user()
+        TotpInterface().enroll(user)
+
+        self.request = RequestFactory().post("/auth/sso/", SERVER_NAME="acme.testserver")
+        self.request.user = AnonymousUser()
+        self.request.session = Client().session
+
+        with override_options({"system.url-prefix": "https://system.example.com"}):
+            with pytest.raises(AuthIdentityHandler._NotCompletedSecurityChecks):
+                self.handler._login(user)
+
+        assert self.request.session["_after_2fa"] == "http://acme.testserver/auth/sso/"
 
 
 @control_silo_test

--- a/tests/sentry/auth/test_helper.py
+++ b/tests/sentry/auth/test_helper.py
@@ -683,22 +683,6 @@ class HandleUnknownIdentityTest(AuthIdentityHandlerTest):
         assert auth_identity.user_id == session_user.id
 
     @mock.patch("sentry.auth.helper.messages")
-    def test_saml_response_in_post_ignores_op(self, mock_messages: mock.MagicMock) -> None:
-        """When SAMLResponse is in POST, op from the POST body should be
-        ignored — op is only valid from Sentry's own confirmation form."""
-        session_user = self.create_user(email="session@example.com")
-        self.request.user = session_user
-        # No org membership — user is authenticated but not a member of this org.
-
-        self.request.POST = {"op": "confirm", "SAMLResponse": "fake-saml-data"}
-        response = self.handler.handle_unknown_identity(self.state)
-
-        assert not AuthIdentity.objects.filter(
-            auth_provider=self.auth_provider_inst, ident=self.identity["id"]
-        ).exists()
-        assert response.status_code == 200
-
-    @mock.patch("sentry.auth.helper.messages")
     @mock.patch("sentry.auth.helper.auth")
     def test_is_account_verified_auto_links_unauthenticated_user(
         self, mock_auth: mock.MagicMock, mock_messages: mock.MagicMock

--- a/tests/sentry/web/frontend/test_auth_oauth2.py
+++ b/tests/sentry/web/frontend/test_auth_oauth2.py
@@ -125,7 +125,7 @@ class AuthOAuth2Test(AuthProviderTestCase):
                     assert resp.status_code == 302
                     resp = self.client.post(reverse("sentry-2fa-dialog"), {"otp": "something"})
                     assert resp.status_code == 302
-                    assert resp["Location"].startswith("http://testserver/auth/sso/?")
+                    assert resp["Location"] == "http://testserver/auth/sso/"
                     resp = self.client.get(resp["Location"])
 
             assert resp.status_code == 302

--- a/tests/sentry/web/frontend/test_auth_saml2.py
+++ b/tests/sentry/web/frontend/test_auth_saml2.py
@@ -304,7 +304,8 @@ class AuthSAML2Test(AuthProviderTestCase):
         response = self.accept_auth()
         assert response.status_code == 200
 
-        response = self.client.post(self.acs_path, {"op": "confirm"})
+        sso_path = reverse("sentry-auth-sso")
+        response = self.client.post(sso_path, {"op": "confirm"})
 
         # expect no linking before verification
         assert AuthIdentity.objects.filter(user_id=self.user.id).count() == 0
@@ -329,7 +330,7 @@ class AuthSAML2Test(AuthProviderTestCase):
 
     def test_sp_initiated_new_user_can_complete_confirmation(self) -> None:
         """op from Sentry's own confirmation form (no SAMLResponse) must survive
-        the ACS endpoint so first-time SSO signup can complete."""
+        so first-time SSO signup can complete via /auth/sso/."""
         saml_response = self._saml_response_for_email("newperson@example.com")
         is_valid = "onelogin.saml2.response.OneLogin_Saml2_Response.is_valid"
 
@@ -338,13 +339,16 @@ class AuthSAML2Test(AuthProviderTestCase):
             resp = self.client.post(self.acs_path, {"SAMLResponse": saml_response})
         assert resp.status_code == 200
 
-        self.client.post(self.acs_path, {"op": "newuser"})
+        sso_path = reverse("sentry-auth-sso")
+        self.client.post(sso_path, {"op": "newuser"})
 
         assert AuthIdentity.objects.filter(auth_provider=self.auth_provider_inst).exists()
 
     def test_sp_initiated_existing_user_can_login_and_confirm(self) -> None:
         """An unauthenticated user can log in and confirm identity linking
-        through the ACS endpoint — op=login and op=confirm must survive."""
+        via /auth/sso/ — op=login and op=confirm must work."""
+        sso_path = reverse("sentry-auth-sso")
+
         # Start SP-initiated auth and complete SAML round-trip
         self.client.post(self.login_path, {"init": True})
         resp = self.accept_auth()
@@ -352,19 +356,23 @@ class AuthSAML2Test(AuthProviderTestCase):
 
         # Login step — authenticate as the existing user
         resp = self.client.post(
-            self.acs_path,
-            {"op": "login", "username": self.user.username, "password": "admin"},
+            sso_path,
+            {
+                "op": "login",
+                "username": self.user.username,
+                "password": "admin",
+            },
         )
 
         # Confirm step — link identity to this user
-        resp = self.client.post(self.acs_path, {"op": "confirm"}, follow=True)
+        resp = self.client.post(sso_path, {"op": "confirm"}, follow=True)
         assert AuthIdentity.objects.filter(
             auth_provider=self.auth_provider_inst, user_id=self.user.id
         ).exists()
 
     def test_acs_pipeline_step_strips_op_from_post(self) -> None:
         """When SAMLResponse and op are both in the POST body, op should be
-        ignored — only Sentry's own confirmation form should set op."""
+        stripped — the ACS endpoint only processes SAMLResponse payloads."""
         saml_response = self.load_fixture("saml2_auth_response.xml")
         saml_response = base64.b64encode(saml_response).decode("utf-8")
 
@@ -380,6 +388,42 @@ class AuthSAML2Test(AuthProviderTestCase):
         # Should show confirmation page, not auto-link
         assert resp.status_code == 200
         assert AuthIdentity.objects.filter(user_id=self.user.id).count() == 0
+
+    def test_confirmation_page_includes_sso_url_in_context(self) -> None:
+        """Confirmation page must include confirmation_url pointing to /auth/sso/."""
+        self.client.post(self.login_path, {"init": True})
+        resp = self.accept_auth()
+        assert resp.status_code == 200
+        assert resp.context["confirmation_url"] == reverse("sentry-auth-sso")
+
+    def test_acs_strips_op_without_saml_response(self) -> None:
+        """POST to the ACS endpoint must have op stripped."""
+        # Start SP-initiated auth and complete SAML round-trip to establish pipeline
+        self.client.post(self.login_path, {"init": True})
+        self.accept_auth()
+
+        # POSTing only op=confirm to the ACS endpoint should be stripped
+        resp = self.client.post(self.acs_path, {"op": "confirm"})
+        assert resp.status_code == 200
+        assert AuthIdentity.objects.filter(user_id=self.user.id).count() == 0
+
+    def test_idp_initiated_new_user_confirms_via_sso_endpoint(self) -> None:
+        """IdP-initiated flow: confirmation form should POST to /auth/sso/
+        and successfully complete identity linking."""
+        saml_response = self._saml_response_for_email("idp-newuser@example.com")
+        is_valid = "onelogin.saml2.response.OneLogin_Saml2_Response.is_valid"
+
+        # IdP-initiated: no prior login_path POST, SAMLResponse goes directly to ACS
+        with mock.patch(is_valid, return_value=True):
+            resp = self.client.post(self.acs_path, {"SAMLResponse": saml_response})
+        assert resp.status_code == 200
+        assert resp.context["confirmation_url"] == reverse("sentry-auth-sso")
+
+        # Confirm via /auth/sso/
+        sso_path = reverse("sentry-auth-sso")
+        self.client.post(sso_path, {"op": "newuser"})
+
+        assert AuthIdentity.objects.filter(auth_provider=self.auth_provider_inst).exists()
 
     def test_idp_initiated_without_relay_state_continues(self) -> None:
         """Test that IdP-initiated SAML without RelayState continues normally (backward compat)."""


### PR DESCRIPTION
## Summary

Consolidates the SSO identity-confirmation step so SAML uses the same pipeline as the OAuth providers.

Historically, SAML rendered the "confirm / create / link" step from the ACS endpoint, so the confirmation `op` was processed on the same URL that receives IdP assertions. OAuth already routes confirmation through the shared `sentry-auth-sso` endpoint (`/auth/sso/`). This PR brings SAML onto that same path.

## Changes

- SAML confirmation templates now submit to `confirmation_url` (`reverse("sentry-auth-sso")`) instead of the ACS url.
- The ACS views (`SAML2AcceptACSView`, `SAML2ACSView`) now only handle `SAMLResponse` assertions and no longer interpret `op`.
- `op` is read in the shared pipeline (`handle_unknown_identity`), reached via `/auth/sso/` for both SP- and IdP-initiated flows.
- The post-2FA redirect resumes the pipeline at `/auth/sso/` so the flow completes consistently for both provider types.
- Tests updated to exercise confirmation through the shared endpoint.

## Why

Removes SAML-specific special-casing on the ACS endpoint and gives both provider families a single, consistent confirmation code path, which is easier to reason about and maintain.