### PR TITLE
fix(ui): Ignore 402 request errors

### DIFF
--- a/static/app/bootstrap/initializeSdk.spec.tsx
+++ b/static/app/bootstrap/initializeSdk.spec.tsx
@@ -48,7 +48,7 @@ describe('initializeSdk', () => {
 
 describe('isFilteredRequestErrorEvent', () => {
   const methods = ['GET', 'POST', 'PUT', 'DELETE'];
-  const stati = [200, 400, 401, 403, 404, 429];
+  const stati = [200, 400, 401, 402, 403, 404, 429];
 
   describe('matching error type, matching message', () => {
     for (const method of methods) {

--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -29,7 +29,7 @@ export function getLastEventId(): string | undefined {
 
 // Each error type maps to the set of HTTP status codes it should be filtered for.
 const FILTERED_STATUSES_BY_ERROR_TYPE: Readonly<Record<string, ReadonlySet<string>>> = {
-  RequestError: new Set(['200', '400', '401', '403', '404', '429']),
+  RequestError: new Set(['200', '400', '401', '402', '403', '404', '429']),
   BadRequestError: new Set(['400']),
   UnauthorizedError: new Set(['401']),
   ForbiddenError: new Set(['403']),

--- a/static/app/utils/queryClient.spec.tsx
+++ b/static/app/utils/queryClient.spec.tsx
@@ -106,7 +106,7 @@ describe('queryClient', () => {
       return err;
     };
 
-    it.each([400, 401, 403, 404])('does not retry on %s status', status => {
+    it.each([400, 401, 402, 403, 404])('does not retry on %s status', status => {
       expect(retry(0, errorWithStatus(status))).toBe(false);
     });
 

--- a/static/app/utils/queryClient.tsx
+++ b/static/app/utils/queryClient.tsx
@@ -16,7 +16,7 @@ import {normalizeQueryKey} from 'sentry/utils/api/apiQueryKey';
 import type {ApiQueryKey, QueryKeyEndpointOptions} from 'sentry/utils/api/apiQueryKey';
 import {RequestError} from 'sentry/utils/requestError/requestError';
 
-const nonRetryCodes = new Set<number | undefined>([400, 401, 403, 404]);
+const nonRetryCodes = new Set<number | undefined>([400, 401, 402, 403, 404]);
 
 // Overrides to the default react-query options.
 // See https://tanstack.com/query/v5/docs/framework/react/guides/important-defaults


### PR DESCRIPTION
402 responses from Autofix are expected when payment is required, but the rejected RequestError can still be reported by the UI SDK.

Filter those events and treat 402 as non-retryable in the default React Query config.