### PR TITLE
fix(preprod): Recognize installable as a boolean filter

### DIFF
--- a/static/app/views/explore/constants.tsx
+++ b/static/app/views/explore/constants.tsx
@@ -134,7 +134,7 @@ export const SENTRY_PREPROD_NUMBER_TAGS: string[] = [
   ...PREPROD_IMAGE_FIELDS,
 ];
 
-export const SENTRY_PREPROD_BOOLEAN_TAGS: string[] = [];
+export const SENTRY_PREPROD_BOOLEAN_TAGS: string[] = ['installable'];
 
 export const HIDDEN_PREPROD_ATTRIBUTES = [
   'min_install_size',

--- a/static/app/views/explore/releases/list/index.spec.tsx
+++ b/static/app/views/explore/releases/list/index.spec.tsx
@@ -633,6 +633,17 @@ describe('ReleasesList', () => {
     expect(router.location.query.query).toBeFalsy();
   });
 
+  it('recognizes installable as a boolean filter without fetched attributes', async () => {
+    renderMobileBuildsTab({
+      display: 'distribution',
+      query: 'installable:true',
+    });
+
+    expect(
+      await screen.findByRole('row', {name: 'installable:true'})
+    ).not.toHaveAttribute('aria-invalid', 'true');
+  });
+
   it('shows the Download CSV button on the distribution display', async () => {
     renderMobileBuildsTab({display: 'distribution'});
     expect(await screen.findByRole('button', {name: 'Download CSV'})).toBeInTheDocument();


### PR DESCRIPTION
Mobile Builds now treats `installable` as a built-in boolean attribute even when
trace-item attribute discovery returns no values, so `installable:true` remains a
valid search token. Regression coverage exercises the empty discovery response that
previously exposed the invalid-token state.

| Before | After |
| --- | --- |
|<img width="380" height="261" alt="installable-before" src="https://github.com/user-attachments/assets/7a07cdf2-773d-4023-a506-a4e717851be1" />|<img width="864" height="427" alt="installable-after" src="https://github.com/user-attachments/assets/4b5eaf06-aa6f-48c9-b275-cb626ec99294" />|
