### PR TITLE
feat(integrations): track clicks in the create integration modal

### DIFF
--- a/static/app/components/modals/createNewIntegrationModal.tsx
+++ b/static/app/components/modals/createNewIntegrationModal.tsx
@@ -101,7 +101,17 @@ function CreateNewIntegrationModal({Body, Header, Footer, closeModal}: ModalRend
             {tct(
               'Looking for MCP? Connect Sentry to AI-powered tools and your terminal from the [link:MCP & CLI] page.',
               {
-                link: <Link to={`/settings/${organization.slug}/mcp-cli/`} />,
+                link: (
+                  <Link
+                    to={`/settings/${organization.slug}/mcp-cli/`}
+                    onClick={() => {
+                      trackIntegrationAnalytics(PlatformEvents.MCP_CLI_HINT, {
+                        organization,
+                        view: analyticsView,
+                      });
+                    }}
+                  />
+                ),
               }
             )}
           </Alert>

--- a/static/app/utils/analytics/integrations/platformAnalyticsEvents.ts
+++ b/static/app/utils/analytics/integrations/platformAnalyticsEvents.ts
@@ -8,6 +8,7 @@ export enum PlatformEvents {
   INTERNAL_DOCS = 'integrations.platform_internal_docs_clicked',
   CHOSE_PUBLIC = 'integrations.platform_create_modal_public_clicked',
   PUBLIC_DOCS = 'integrations.platform_public_docs_clicked',
+  MCP_CLI_HINT = 'integrations.platform_mcp_cli_hint_clicked',
 }
 
 export type PlatformEventParameters = Record<PlatformEvents, {} & IntegrationView>;
@@ -23,6 +24,7 @@ export const platformEventMap: Record<PlatformEvents, string> = {
     'Integrations: Platform Internal Integration Docs Clicked',
   [PlatformEvents.CHOSE_PUBLIC]: 'Integrations: Platform Chose Public Integration',
   [PlatformEvents.PUBLIC_DOCS]: 'Integrations: Platform Public Integration Docs Clicked',
+  [PlatformEvents.MCP_CLI_HINT]: 'Integrations: Platform MCP & CLI Hint Clicked',
 };
 
 export const platformEventLinkMap: Partial<Record<PlatformEvents, string>> = {


### PR DESCRIPTION
Add an analytic event to the MCP/CLI hint in the create integration modal (this one):
<img width="580" height="103" alt="Screenshot 2026-07-27 at 4 42 17 PM" src="https://github.com/user-attachments/assets/57a795f6-1a5e-4f6e-ad94-f1e310f7304c" />

