### PR TITLE
feat(snuba): complete and remove option rollout for response compress…

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -949,14 +949,6 @@ register(
     type=Int,
 )
 
-# Fraction of JSON (SnQL/MQL) snuba queries that request zstd response compression via Accept-Encoding.
-register(
-    "snuba.json-response-compression.rollout",
-    type=Float,
-    default=0.0,
-    flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
-)
-
 
 # Refresh Bundle Indexes reported as used by symbolicator
 register(

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -40,7 +40,6 @@ from sentry.models.projectkey import ProjectKey
 from sentry.models.release import Release
 from sentry.models.releases.release_project import ReleaseProject
 from sentry.net.http import connection_from_url
-from sentry.options.rollout import in_random_rollout
 from sentry.services.eventstore.query_preprocessing import get_all_merged_group_ids
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.events import Columns
@@ -1416,9 +1415,6 @@ def _log_request_query(req: Request) -> None:
 RawResult = tuple[str, urllib3.response.HTTPResponse, Translator, Translator]
 
 
-SNUBA_JSON_RESP_COMPRESSION_ROLLOUT = "snuba.json-response-compression.rollout"
-
-
 def _snuba_query(
     params: tuple[
         sentry_sdk.Scope,
@@ -1433,10 +1429,8 @@ def _snuba_query(
         with sentry_sdk.scope.use_scope(thread_current_scope):
             request = snuba_request.request
             headers = snuba_request.headers
-            # conditionally add compression encoding headers
-            should_compress = not isinstance(request.query, DeleteQuery) and in_random_rollout(
-                SNUBA_JSON_RESP_COMPRESSION_ROLLOUT
-            )
+            # Delete queries do not benefit from compression
+            should_compress = not isinstance(request.query, DeleteQuery)
             if should_compress:
                 headers = {**headers, "Accept-Encoding": "zstd"}
 

--- a/tests/sentry/billing/platform/services/usage/test_service.py
+++ b/tests/sentry/billing/platform/services/usage/test_service.py
@@ -16,9 +16,6 @@ from sentry.billing.platform.services.usage.service import (
     UsageService as UsageServiceDirect,
 )
 
-# TODO(EAP-627): remove once `snuba.json-response-compression.rollout` completes.
-pytestmark = [pytest.mark.django_db]
-
 
 class TestUsageService:
     """Tests for the UsageService."""

--- a/tests/sentry/replays/integration/test_data_export.py
+++ b/tests/sentry/replays/integration/test_data_export.py
@@ -13,9 +13,6 @@ from sentry.replays.data_export import (
 from sentry.replays.testutils import mock_replay
 from sentry.testutils.skips import requires_snuba
 
-# TODO(EAP-627): remove once `snuba.json-response-compression.rollout` completes.
-pytestmark = [pytest.mark.django_db]
-
 
 @pytest.mark.snuba
 @requires_snuba

--- a/tests/sentry/replays/test_query.py
+++ b/tests/sentry/replays/test_query.py
@@ -11,9 +11,6 @@ from sentry.replays.query import get_replay_range
 from sentry.replays.testutils import mock_replay
 from sentry.testutils.skips import requires_snuba
 
-# TODO(EAP-627): remove once `snuba.json-response-compression.rollout` completes.
-pytestmark = [pytest.mark.django_db]
-
 
 class ReplayStore:
     def save(self, data: Any) -> None:

--- a/tests/sentry/utils/test_snuba.py
+++ b/tests/sentry/utils/test_snuba.py
@@ -16,11 +16,9 @@ from sentry.models.project import Project
 from sentry.models.release import Release
 from sentry.snuba.dataset import Dataset
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers import override_options
 from sentry.utils import json
 from sentry.utils.snuba import (
     ROUND_UP,
-    SNUBA_JSON_RESP_COMPRESSION_ROLLOUT,
     RateLimitExceeded,
     RetrySkipTimeout,
     SnubaQueryParams,
@@ -779,19 +777,11 @@ class SnubaResponseCompressionTest(unittest.TestCase):
             )
         )
 
-    @override_options({SNUBA_JSON_RESP_COMPRESSION_ROLLOUT: 1.0})
-    def test_compresses_read_query_if_ff_on(self) -> None:
+    def test_compresses_read_query(self) -> None:
         self._run_query(mock.Mock(spec=Query))
         headers = self.mock_pool.urlopen.call_args.kwargs["headers"]
         assert headers["Accept-Encoding"] == "zstd"
 
-    @override_options({SNUBA_JSON_RESP_COMPRESSION_ROLLOUT: 0.0})
-    def test_does_not_compresses_read_query_if_ff_off(self) -> None:
-        self._run_query(mock.Mock(spec=Query))
-        headers = self.mock_pool.urlopen.call_args.kwargs["headers"]
-        assert "Accept-Encoding" not in headers
-
-    @override_options({SNUBA_JSON_RESP_COMPRESSION_ROLLOUT: 1.0})
     def test_skips_delete_query(self) -> None:
         self._run_query(mock.Mock(spec=DeleteQuery, storage_name="events"))
         headers = self.mock_pool.urlopen.call_args.kwargs["headers"]


### PR DESCRIPTION
## What
Completes rollout of JSON compression for JSON responses from Snuba

## How
- Removes rollout option gate
- All Snuba JSON backed queries set `zstd` compression headers

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
