### PR TITLE
fix(feedback): Avoid mutating event context data

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -168,22 +168,28 @@ function FeedbackItemContexts({
       return [name, value];
     }) ?? []
   );
-  eventData.contexts = eventData.contexts ?? {};
-  eventData.contexts.feedback = eventData.contexts.feedback ?? {};
-  eventData.contexts.feedback['auto_spam.detection_enabled'] =
-    evidenceObject.spam_detection_enabled;
-  if (evidenceObject.spam_detection_enabled) {
-    eventData.contexts.feedback['auto_spam.is_spam'] = evidenceObject.is_spam;
-  }
+  const eventDataWithSpamContext: Event = {
+    ...eventData,
+    contexts: {
+      ...eventData.contexts,
+      feedback: {
+        ...eventData.contexts?.feedback,
+        ['auto_spam.detection_enabled']: evidenceObject.spam_detection_enabled,
+        ...(evidenceObject.spam_detection_enabled
+          ? {['auto_spam.is_spam']: evidenceObject.is_spam}
+          : {}),
+      },
+    },
+  };
 
-  const cards = getOrderedContextItems(eventData).map(
+  const cards = getOrderedContextItems(eventDataWithSpamContext).map(
     ({alias, type, value: contextValue}) => (
       <ContextCard
         key={alias}
         type={type}
         alias={alias}
         value={contextValue}
-        event={eventData}
+        event={eventDataWithSpamContext}
         project={project}
       />
     )


### PR DESCRIPTION
The feedback context section added spam fields directly to the event from query data.

build a copied event and context for display instead, query cache data should not change while rendering.