### PR TITLE
fix(seer): Avoid mutating repository settings

### DIFF
--- a/static/app/components/seer/repoTable/seerRepoTableRow.tsx
+++ b/static/app/components/seer/repoTable/seerRepoTableRow.tsx
@@ -158,7 +158,7 @@ export function SeerRepoTableRow({
       <SimpleTable.RowCell justify="end">
         <Text size="sm">
           {repository.settings?.codeReviewTriggers
-            .sort()
+            .toSorted()
             .map(triggerToLabel)
             .map((label, index, array) => (
               <div key={label}>


### PR DESCRIPTION
The repository row sorted code review triggers directly on query data while rendering.

use toSorted so the labels stay ordered without changing the cached repository.