### PR TITLE
fix(dashboards): Avoid sorting access props in place

### DIFF
--- a/static/app/views/dashboards/editAccessSelector.tsx
+++ b/static/app/views/dashboards/editAccessSelector.tsx
@@ -353,7 +353,7 @@ export function EditAccessSelector({
               !userCanEditDashboardPermissions ||
               isEqual(getDashboardPermissions(), {
                 ...dashboard.permissions,
-                teamsWithEditAccess: dashboard.permissions?.teamsWithEditAccess?.sort(
+                teamsWithEditAccess: dashboard.permissions?.teamsWithEditAccess?.toSorted(
                   (a, b) => a - b
                 ),
               })


### PR DESCRIPTION
The edit access dirty check sorted dashboard team ids directly on permissions from props.

use toSorted for the comparison so checking for changes does not change the dashboard.