### PR TITLE
fix(traces): Avoid sorting issue nodes in place

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issues.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issues.tsx
@@ -189,7 +189,7 @@ export function IssueList({
   className,
 }: IssueListProps) {
   const uniqueIssues = [
-    ...node.uniqueErrorIssues.sort(sortIssuesByLevel),
+    ...node.uniqueErrorIssues.toSorted(sortIssuesByLevel),
     ...node.uniqueOccurrenceIssues,
   ].filter(issue => issue.issue_id);
 


### PR DESCRIPTION
The trace issue list sorted unique error issues directly on the trace node while rendering.

use toSorted so display ordering does not change the trace model.