### PR TITLE
fix(ui): Avoid mutating AvatarList tooltip props

### DIFF
--- a/static/app/components/core/avatar/avatarList.spec.tsx
+++ b/static/app/components/core/avatar/avatarList.spec.tsx
@@ -31,6 +31,14 @@ describe('AvatarList', () => {
     expect(screen.queryByTestId('avatarList-collapsedavatars')).not.toBeInTheDocument();
   });
 
+  it('does not mutate tooltip options', () => {
+    const tooltipOptions = {};
+
+    render(<AvatarList users={[user]} tooltipOptions={tooltipOptions} />);
+
+    expect(tooltipOptions).toEqual({});
+  });
+
   it('renders with all avatars if count is max + 1 users', () => {
     const users = [
       {...user, id: '1', name: 'AB'},

--- a/static/app/components/core/avatar/avatarList.spec.tsx
+++ b/static/app/components/core/avatar/avatarList.spec.tsx
@@ -31,14 +31,6 @@ describe('AvatarList', () => {
     expect(screen.queryByTestId('avatarList-collapsedavatars')).not.toBeInTheDocument();
   });
 
-  it('does not mutate tooltip options', () => {
-    const tooltipOptions = {};
-
-    render(<AvatarList users={[user]} tooltipOptions={tooltipOptions} />);
-
-    expect(tooltipOptions).toEqual({});
-  });
-
   it('renders with all avatars if count is max + 1 users', () => {
     const users = [
       {...user, id: '1', name: 'AB'},

--- a/static/app/components/core/avatar/avatarList.tsx
+++ b/static/app/components/core/avatar/avatarList.tsx
@@ -75,9 +75,7 @@ export function AvatarList({
     numCollapsedAvatars = 0;
   }
 
-  if (!tooltipOptions.position) {
-    tooltipOptions.position = 'top';
-  }
+  const resolvedTooltipOptions = {position: 'top' as const, ...tooltipOptions};
 
   return (
     <AvatarListWrapper className={className}>
@@ -99,7 +97,7 @@ export function AvatarList({
               key={`${team.id}-${team.name}`}
               team={team}
               size={avatarSize}
-              tooltipOptions={tooltipOptions}
+              tooltipOptions={resolvedTooltipOptions}
               hasTooltip
             />
           ))
@@ -108,7 +106,7 @@ export function AvatarList({
               key={user.id}
               user={user}
               size={avatarSize}
-              tooltipOptions={tooltipOptions}
+              tooltipOptions={resolvedTooltipOptions}
               renderTooltip={renderTooltip}
               hasTooltip
             />
@@ -120,7 +118,7 @@ export function AvatarList({
               key={user.id}
               user={user}
               size={avatarSize}
-              tooltipOptions={tooltipOptions}
+              tooltipOptions={resolvedTooltipOptions}
               renderTooltip={renderTooltip}
               hasTooltip
             />
@@ -130,7 +128,7 @@ export function AvatarList({
               key={`${team.id}-${team.name}`}
               team={team}
               size={avatarSize}
-              tooltipOptions={tooltipOptions}
+              tooltipOptions={resolvedTooltipOptions}
               hasTooltip
             />
           ))}


### PR DESCRIPTION
AvatarList filled its default tooltip position by changing the object passed in by its caller.

Merge the default into a new object instead.