### PR TITLE
fix(discover): Avoid sorting field option inputs in place

### DIFF
--- a/static/app/views/discover/utils.spec.tsx
+++ b/static/app/views/discover/utils.spec.tsx
@@ -779,32 +779,6 @@ describe('eventViewToWidgetQuery', () => {
 });
 
 describe('generateFieldOptions', () => {
-  it('does not sort input arrays in place', () => {
-    const tagKeys = ['z-tag', 'a-tag'];
-    const measurementKeys = ['measurements.z', 'measurements.a'];
-    const spanOperationBreakdownKeys = ['spans.z', 'spans.a'];
-    const customMeasurements = [
-      {functions: ['p99'], key: 'measurements.z'},
-      {functions: ['p99'], key: 'measurements.a'},
-    ];
-
-    generateFieldOptions({
-      organization: initializeOrg().organization,
-      tagKeys,
-      measurementKeys,
-      spanOperationBreakdownKeys,
-      customMeasurements,
-    });
-
-    expect(tagKeys).toEqual(['z-tag', 'a-tag']);
-    expect(measurementKeys).toEqual(['measurements.z', 'measurements.a']);
-    expect(spanOperationBreakdownKeys).toEqual(['spans.z', 'spans.a']);
-    expect(customMeasurements).toEqual([
-      {functions: ['p99'], key: 'measurements.z'},
-      {functions: ['p99'], key: 'measurements.a'},
-    ]);
-  });
-
   it('generates custom measurement field options', () => {
     expect(
       generateFieldOptions({

--- a/static/app/views/discover/utils.spec.tsx
+++ b/static/app/views/discover/utils.spec.tsx
@@ -779,6 +779,32 @@ describe('eventViewToWidgetQuery', () => {
 });
 
 describe('generateFieldOptions', () => {
+  it('does not sort input arrays in place', () => {
+    const tagKeys = ['z-tag', 'a-tag'];
+    const measurementKeys = ['measurements.z', 'measurements.a'];
+    const spanOperationBreakdownKeys = ['spans.z', 'spans.a'];
+    const customMeasurements = [
+      {functions: ['p99'], key: 'measurements.z'},
+      {functions: ['p99'], key: 'measurements.a'},
+    ];
+
+    generateFieldOptions({
+      organization: initializeOrg().organization,
+      tagKeys,
+      measurementKeys,
+      spanOperationBreakdownKeys,
+      customMeasurements,
+    });
+
+    expect(tagKeys).toEqual(['z-tag', 'a-tag']);
+    expect(measurementKeys).toEqual(['measurements.z', 'measurements.a']);
+    expect(spanOperationBreakdownKeys).toEqual(['spans.z', 'spans.a']);
+    expect(customMeasurements).toEqual([
+      {functions: ['p99'], key: 'measurements.z'},
+      {functions: ['p99'], key: 'measurements.a'},
+    ]);
+  });
+
   it('generates custom measurement field options', () => {
     expect(
       generateFieldOptions({

--- a/static/app/views/discover/utils.tsx
+++ b/static/app/views/discover/utils.tsx
@@ -463,11 +463,11 @@ function generateExpandedConditions(
 type FieldGeneratorOpts = {
   organization: Organization;
   aggregations?: Record<string, Aggregation>;
-  customMeasurements?: Array<{functions: string[]; key: string}> | null;
-  fieldKeys?: string[];
-  measurementKeys?: string[] | null;
-  spanOperationBreakdownKeys?: string[];
-  tagKeys?: string[] | null;
+  customMeasurements?: ReadonlyArray<{functions: string[]; key: string}> | null;
+  fieldKeys?: readonly string[];
+  measurementKeys?: readonly string[] | null;
+  spanOperationBreakdownKeys?: readonly string[];
+  tagKeys?: readonly string[] | null;
 };
 
 export function generateFieldOptions({

--- a/static/app/views/discover/utils.tsx
+++ b/static/app/views/discover/utils.tsx
@@ -537,8 +537,7 @@ export function generateFieldOptions({
   });
 
   if (measurementKeys !== undefined && measurementKeys !== null) {
-    measurementKeys.sort();
-    measurementKeys.forEach(measurement => {
+    measurementKeys.toSorted().forEach(measurement => {
       fieldOptions[`measurement:${measurement}`] = {
         label: measurement,
         value: {
@@ -550,27 +549,27 @@ export function generateFieldOptions({
   }
 
   if (customMeasurements !== undefined && customMeasurements !== null) {
-    customMeasurements.sort(({key: currentKey}, {key: nextKey}) =>
-      currentKey > nextKey ? 1 : currentKey === nextKey ? 0 : -1
-    );
-    customMeasurements.forEach(({key, functions: supportedFunctions}) => {
-      fieldOptions[`measurement:${key}`] = {
-        label: key,
-        value: {
-          kind: FieldValueKind.CUSTOM_MEASUREMENT,
-          meta: {
-            name: key,
-            dataType: measurementType(key),
-            functions: supportedFunctions,
+    customMeasurements
+      .toSorted(({key: currentKey}, {key: nextKey}) =>
+        currentKey > nextKey ? 1 : currentKey === nextKey ? 0 : -1
+      )
+      .forEach(({key, functions: supportedFunctions}) => {
+        fieldOptions[`measurement:${key}`] = {
+          label: key,
+          value: {
+            kind: FieldValueKind.CUSTOM_MEASUREMENT,
+            meta: {
+              name: key,
+              dataType: measurementType(key),
+              functions: supportedFunctions,
+            },
           },
-        },
-      };
-    });
+        };
+      });
   }
 
   if (Array.isArray(spanOperationBreakdownKeys)) {
-    spanOperationBreakdownKeys.sort();
-    spanOperationBreakdownKeys.forEach(breakdownField => {
+    spanOperationBreakdownKeys.toSorted().forEach(breakdownField => {
       if (!fieldKeys.includes(breakdownField)) {
         // These span op breakdowns are sometimes included in the fieldKeys
         // so check before we add them, or else we surface duplicates
@@ -586,8 +585,7 @@ export function generateFieldOptions({
   }
 
   if (tagKeys !== undefined && tagKeys !== null) {
-    tagKeys.sort();
-    tagKeys.forEach(tag => {
+    tagKeys.toSorted().forEach(tag => {
       const tagValue =
         fieldKeys.includes(tag) || Object.hasOwn(aggregations, tag)
           ? `tags[${tag}]`


### PR DESCRIPTION
generateFieldOptions sorted four arrays owned by its callers.

Use copied sorting for each input and mark the arrays readonly so the ownership contract is enforced by the types.