### PR TITLE
fix(integrations): Chunk the repo-activity RPC in sync_repos_for_org

### DIFF
--- a/src/sentry/integrations/source_code_management/sync_repos.py
+++ b/src/sentry/integrations/source_code_management/sync_repos.py
@@ -67,6 +67,12 @@ SCM_SYNC_PROVIDERS = [
 
 SYNC_BATCH_SIZE = 100
 
+# Chunk size for the `find_recently_active_repo_external_ids` cross-silo RPC.
+# The whole removed-repo set can be tens of thousands of external ids for large
+# GitHub orgs, which would be sent as a single unbounded request body. Kept
+# larger than SYNC_BATCH_SIZE because each chunk is one blocking round trip.
+ACTIVITY_LOOKUP_BATCH_SIZE = 500
+
 # Final safety guard before auto-disabling a repo: if it has any commit, PR,
 # or code review event row in the last DISABLE_ACTIVITY_CUTOFF_DAYS days, we
 # skip the disable even if the provider isn't returning the repo right now.
@@ -293,38 +299,41 @@ def _sync_repos_for_org(organization_integration_id: int) -> None:
             )
 
         # Filter out any repo with recent activity (commits, PRs, code review
-        # events) before disable.
-        removed_id_list = list(removed_ids)
+        # events) before disable. The lookup is chunked because it's a cross-silo
+        # RPC and the candidate set is unbounded — one request per chunk keeps the
+        # payload small instead of shipping every removed external id at once.
+        removed_id_list = sorted(eid for eid in removed_ids if eid is not None)
         active_skipped: set[str] = set()
-        if removed_id_list:
-            active_skipped = set(
+        for candidate_batch in chunked(removed_id_list, ACTIVITY_LOOKUP_BATCH_SIZE):
+            active_skipped.update(
                 repository_service.find_recently_active_repo_external_ids(
                     organization_id=rpc_org.id,
                     integration_id=integration.id,
                     provider=provider,
-                    external_ids=removed_id_list,
+                    external_ids=candidate_batch,
                     cutoff_days=DISABLE_ACTIVITY_CUTOFF_DAYS,
                 )
             )
-            if active_skipped:
-                logger.info(
-                    "scm.repo_sync.disable_skipped_due_to_activity",
-                    extra={
-                        "provider": provider_key,
-                        "integration_id": integration.id,
-                        "organization_id": rpc_org.id,
-                        "candidate_count": len(removed_id_list),
-                        "skipped_count": len(active_skipped),
-                        "skipped_ids": list(active_skipped),
-                        "cutoff_days": DISABLE_ACTIVITY_CUTOFF_DAYS,
-                    },
-                )
-                metrics.distribution(
-                    "scm.repo_sync.disable_skipped_due_to_activity",
-                    len(active_skipped),
-                    tags={"provider": provider_key},
-                    sample_rate=1.0,
-                )
+
+        if active_skipped:
+            logger.info(
+                "scm.repo_sync.disable_skipped_due_to_activity",
+                extra={
+                    "provider": provider_key,
+                    "integration_id": integration.id,
+                    "organization_id": rpc_org.id,
+                    "candidate_count": len(removed_id_list),
+                    "skipped_count": len(active_skipped),
+                    "skipped_ids": list(active_skipped),
+                    "cutoff_days": DISABLE_ACTIVITY_CUTOFF_DAYS,
+                },
+            )
+            metrics.distribution(
+                "scm.repo_sync.disable_skipped_due_to_activity",
+                len(active_skipped),
+                tags={"provider": provider_key},
+                sample_rate=1.0,
+            )
 
         safe_to_disable = [eid for eid in removed_id_list if eid not in active_skipped]
         bump_org_integration_last_sync(

--- a/tests/sentry/integrations/source_code_management/test_sync_repos.py
+++ b/tests/sentry/integrations/source_code_management/test_sync_repos.py
@@ -13,6 +13,7 @@ from sentry.integrations.github_enterprise.integration import GitHubEnterpriseIn
 from sentry.integrations.gitlab.integration import GitlabIntegration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.perforce.integration import PerforceIntegrationProvider
+from sentry.integrations.services.repository.service import repository_service
 from sentry.integrations.source_code_management.sync_repos import (
     sync_repos_for_org,
 )
@@ -181,6 +182,93 @@ class SyncReposForOrgTestCase(IntegrationTestCase):
         with assume_test_silo_mode(SiloMode.CELL):
             still_active_repo.refresh_from_db()
             assert still_active_repo.status == ObjectStatus.ACTIVE
+
+    @responses.activate
+    @patch(
+        "sentry.integrations.source_code_management.sync_repos.ACTIVITY_LOOKUP_BATCH_SIZE",
+        2,
+    )
+    def test_activity_lookup_is_chunked(self, _: MagicMock) -> None:
+        # The activity lookup is a cross-silo RPC, so the removed-repo candidate
+        # list must be split into bounded batches instead of shipping every
+        # external id in a single request body.
+        with assume_test_silo_mode(SiloMode.CELL):
+            for external_id in ("90", "91", "92", "93", "94"):
+                repo = Repository.objects.create(
+                    organization_id=self.organization.id,
+                    name=f"getsentry/old-repo-{external_id}",
+                    external_id=external_id,
+                    provider="integrations:github",
+                    integration_id=self.integration.id,
+                    status=ObjectStatus.ACTIVE,
+                )
+                if external_id == "93":
+                    Commit.objects.create(
+                        organization_id=self.organization.id,
+                        repository_id=repo.id,
+                        key="abc123",
+                    )
+
+        # Provider no longer returns any of them
+        self._add_repos_response([{"id": 1, "full_name": "getsentry/sentry", "name": "sentry"}])
+
+        real_find = repository_service.find_recently_active_repo_external_ids
+        batches: list[list[str]] = []
+
+        def spy(
+            *,
+            organization_id: int,
+            integration_id: int,
+            provider: str,
+            external_ids: list[str],
+            cutoff_days: int,
+        ) -> list[str]:
+            batches.append(external_ids)
+            return real_find(
+                organization_id=organization_id,
+                integration_id=integration_id,
+                provider=provider,
+                external_ids=external_ids,
+                cutoff_days=cutoff_days,
+            )
+
+        with (
+            patch.object(
+                repository_service,
+                "find_recently_active_repo_external_ids",
+                side_effect=spy,
+            ),
+            self.tasks(),
+        ):
+            sync_repos_for_org(self.oi.id)
+
+        # 5 candidates at a batch size of 2 => 3 requests, none oversized
+        assert len(batches) == 3
+        assert all(len(batch) <= 2 for batch in batches)
+        assert sorted(eid for batch in batches for eid in batch) == [
+            "90",
+            "91",
+            "92",
+            "93",
+            "94",
+        ]
+
+        # Results are accumulated across batches: the repo with recent activity
+        # stays active, everything else is disabled.
+        with assume_test_silo_mode(SiloMode.CELL):
+            statuses = dict(
+                Repository.objects.filter(
+                    organization_id=self.organization.id,
+                    external_id__in=["90", "91", "92", "93", "94"],
+                ).values_list("external_id", "status")
+            )
+        assert statuses == {
+            "90": ObjectStatus.DISABLED,
+            "91": ObjectStatus.DISABLED,
+            "92": ObjectStatus.DISABLED,
+            "93": ObjectStatus.ACTIVE,
+            "94": ObjectStatus.DISABLED,
+        }
 
     @responses.activate
     def test_re_enables_restored_repos(self, _: MagicMock) -> None:


### PR DESCRIPTION
Fixes an unbounded cross-silo RPC payload in the periodic SCM repo sync.

- Sentry event: `1986a344223545f0af045736530b1efb`
- Transaction: `sentry.integrations.source_code_management.sync_repos.sync_repos_for_org` (env `control`)
- Triage session: https://claude.ai/code/session_017YpUohVVykHZnEEdAS77dw

### Root cause

`_sync_repos_for_org` diffs the provider's repo list against Sentry's `Repository` rows, then — before disabling anything — asks the cell silo which of the removed repos still have recent commit/PR/code-review activity:

```python
removed_id_list = list(removed_ids)
if removed_id_list:
    active_skipped = set(
        repository_service.find_recently_active_repo_external_ids(
            ...,
            external_ids=removed_id_list,   # entire set, one request
            cutoff_days=DISABLE_ACTIVITY_CUTOFF_DAYS,
        )
    )
```

`removed_ids` is unbounded — it is `sentry_active_ids - provider_external_ids`. For a GitHub org with ~10K repos (99+ pages of `/installation/repositories`), that single call serializes every removed external id into one RPC POST body (~72KB on the failing event). Nothing caps it, so at scale the call dies on request-size limit / timeout / cell-side memory before a single repo is disabled, and the task never converges — every scheduled run re-does the same doomed request. The task's `processing_deadline_duration=120` plus `Retry(times=3)` means it just burns retries.

Everything else in this task already batches through `chunked(...)` (`create_repos_batch`, `disable_repos_batch`, `restore_repos_batch` all dispatch in `SYNC_BATCH_SIZE` slices). This activity lookup was the one remaining unbounded payload on the path.

### Fix

Chunk the candidate list and accumulate the results:

```python
removed_id_list = sorted(eid for eid in removed_ids if eid is not None)
active_skipped: set[str] = set()
for candidate_batch in chunked(removed_id_list, ACTIVITY_LOOKUP_BATCH_SIZE):
    active_skipped.update(
        repository_service.find_recently_active_repo_external_ids(
            ..., external_ids=candidate_batch, ...
        )
    )
```

Notes on the shape of the change:

- **New `ACTIVITY_LOOKUP_BATCH_SIZE = 500` rather than reusing `SYNC_BATCH_SIZE = 100`.** `SYNC_BATCH_SIZE` sizes async task dispatch, where extra batches are cheap. This lookup is a *blocking* round trip inside a task with a 120s processing deadline, so 100 would mean ~99 sequential RPCs for a 9.9K-repo org. 500 keeps each body around 4KB while holding the worst case to ~20 calls.
- **`sorted(...)` instead of `list(...)`** makes batch boundaries deterministic (easier to correlate logs/retries) and narrows the element type to `str` — `RpcRepository.external_id` is `str | None`, and the `if eid is not None` filter is a no-op at runtime since `removed_ids` is built only from repos with a truthy `external_id`.
- The `if removed_id_list:` guard is gone because the loop body simply doesn't execute for an empty set; the `find_recently_active_repo_external_ids` impl also already short-circuits on an empty list. The logging/metrics block moved out one level, which is behaviour-preserving (`active_skipped` is empty whenever there were no candidates).

### Ruled out

- **`querybuilder.name: UnresolvedQuery` on the event is a red herring** — scope contamination from a previous task in the same worker process. No query-builder code is reachable from this task.
- **Not the provider fetch.** `installation.get_repositories(raise_on_page_limit=True)` already has a pagination cap and its `ApiPaginationTruncated` path is handled (partial results are used for create/restore and the disable path is skipped). That's the path that would produce a *provider* failure, and the event isn't it.
- **Not a broken integration.** Expired-token / suspended-install cases are already funnelled into `_halt_broken_integration` and halt without an issue, so this error is a genuine failure, not a known terminal state.
- **Not fixed by a guard at the crash site.** Skipping or truncating the lookup when the list is long would silently disable repos that still have activity — the opposite of what `DISABLE_ACTIVITY_CUTOFF_DAYS` exists to prevent. Chunking preserves the exact result set.

### Known remaining risk (not addressed here)

`repository_service.get_repositories(organization_id=..., integration_id=..., providers=[...])` has **no limit or pagination** (`src/sentry/integrations/services/repository/impl.py`) — it serializes every matching `Repository` row into the RPC *response* (~78KB for the org in this event). It's a read, so it doesn't have the same failure mode as the oversized request body, but it will keep growing with repo count, and `disable_repos_batch` / `restore_repos_batch` each call it again per batch. Fixing it properly means a paginated or `external_ids`-filtered variant of the RPC method, which is a bigger change than this hotfix and is deliberately out of scope.

### Tests

Added `test_activity_lookup_is_chunked` to `tests/sentry/integrations/source_code_management/test_sync_repos.py`. It patches `ACTIVITY_LOOKUP_BATCH_SIZE` down to 2, removes 5 repos from the provider listing (one of which has a recent commit), spies on the RPC while delegating to the real implementation, and asserts:

- 3 requests are made and no request carries more than 2 external ids,
- the union of the batches is the full candidate set (nothing dropped),
- results accumulate across batches — the repo with recent activity stays `ACTIVE`, the other four end up `DISABLED`.

⚠️ **Not run locally**: this environment has no Python virtualenv (no `.venv`, no `devenv`, no Django installed), so `pytest` and `prek` could not be executed. What was verified locally: `ruff check` and `ruff format --check` clean on both files, `py_compile` clean, and the chunk/accumulate logic exercised standalone against a 9,900-id set (20 calls, max 500 ids per call, correct skip/disable partition). CI needs to confirm the pytest run.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017YpUohVVykHZnEEdAS77dw


---
_Generated by [Claude Code](https://claude.ai/code/session_017YpUohVVykHZnEEdAS77dw)_