### PR TITLE
chore(ui): Clarify beta feature badge tooltip copy

### DIFF
--- a/static/app/components/core/badge/featureBadge.tsx
+++ b/static/app/components/core/badge/featureBadge.tsx
@@ -12,7 +12,7 @@ import {Tag, type TagProps} from './tag';
 
 const defaultTitles: Record<FeatureBadgeProps['type'], string> = {
   alpha: t('This feature is internal and available for QA purposes'),
-  beta: t('This feature is available for early adopters and may change'),
+  beta: t('This feature is in beta and may change'),
   new: t('This feature is new! Try it out and let us know what you think'),
   experimental: t(
     'This feature is experimental! Try it out and let us know what you think. No promises!'

--- a/static/app/views/seerExplorer/components/seerExplorerHeader.tsx
+++ b/static/app/views/seerExplorer/components/seerExplorerHeader.tsx
@@ -123,10 +123,7 @@ export function SeerExplorerHeader({
         <Text wrap="nowrap" size="md">
           {t('Seer Agent')}
         </Text>
-        <FeatureBadge
-          type="beta"
-          tooltipProps={{title: t('This feature is in beta and may change')}}
-        />
+        <FeatureBadge type="beta" />
       </Flex>
       <Flex flex="1" />
       <Flex gap="sm" align="center">


### PR DESCRIPTION
Beta feature badge tooltips now say the feature is in beta, instead of describing it as available for early adopters. The note that behavior may still change is unchanged.
