### PR TITLE
style(ui): Show All Agents when no agent filter is selected

### DIFF
--- a/static/app/views/insights/common/components/agentSelector.tsx
+++ b/static/app/views/insights/common/components/agentSelector.tsx
@@ -101,7 +101,12 @@ export function AgentSelector({referrer}: AgentSelectorProps) {
         }
       }}
       trigger={triggerProps => (
-        <OverlayTrigger.Button {...triggerProps} prefix={t('Agent')} />
+        <OverlayTrigger.Button
+          {...triggerProps}
+          prefix={selectedAgents.length === 0 ? undefined : t('Agent')}
+        >
+          {selectedAgents.length === 0 ? t('All Agents') : triggerProps.children}
+        </OverlayTrigger.Button>
       )}
       onChange={newValue => {
         const values = newValue.map(v => v.value).filter(Boolean);


### PR DESCRIPTION
When nothing is selected, the conversations agent filter now shows **All Agents** instead of **Agent: None**, matching other page filters like **All Projects**. Selecting one or more agents still uses the **Agent:** prefix.