### PR TITLE
fix: do not run the react compiler on node_modules

### DIFF
--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -198,7 +198,7 @@ const DEFINED_ENV_VARS = {
   'process.env.ENABLE_SENTRY_TOOLBAR': JSON.stringify(ENABLE_SENTRY_TOOLBAR),
 };
 
-const swcReactLoaderConfig: SwcLoaderOptions = {
+const swcReactLoaderConfig = (options: {reactCompiler: boolean}): SwcLoaderOptions => ({
   env: {
     mode: 'usage',
     // https://rspack.rs/guide/features/builtin-swc-loader#polyfill-injection
@@ -244,7 +244,9 @@ const swcReactLoaderConfig: SwcLoaderOptions = {
     },
     transform: {
       // TODO: Enable in production
-      reactCompiler: IS_DEPLOY_PREVIEW || IS_ACCEPTANCE_TEST || IS_UI_DEV_ONLY,
+      reactCompiler:
+        options.reactCompiler &&
+        (IS_DEPLOY_PREVIEW || IS_ACCEPTANCE_TEST || IS_UI_DEV_ONLY),
       react: {
         runtime: 'automatic',
         development: DEV_MODE,
@@ -254,7 +256,7 @@ const swcReactLoaderConfig: SwcLoaderOptions = {
     },
   },
   isModule: 'unknown',
-};
+});
 
 /**
  * Main Webpack config for Sentry React SPA.
@@ -320,20 +322,31 @@ const appConfig: Configuration = {
     rules: [
       {
         test: /\.(?:tsx?|jsx?)$/,
-        // core-js: Avoids recompiling core-js based on usage imports
-        // react-select: Ships pre-compiled ESM with emotion's keyframes already
-        // compiled via swc. Re-processing with @swc/plugin-emotion causes
-        // "illegal escape sequence" warnings in dev mode.
-        exclude: /node_modules[\\/](core-js|react-select)/,
-        loader: 'builtin:swc-loader',
-        options: swcReactLoaderConfig,
+        oneOf: [
+          {
+            include: /node_modules/,
+            // core-js: Avoids recompiling core-js based on usage imports
+            // react-select: Ships pre-compiled ESM with emotion's keyframes already
+            // compiled via swc. Re-processing with @swc/plugin-emotion causes
+            // "illegal escape sequence" warnings in dev mode.
+            exclude: /node_modules[\\/](core-js|react-select)/,
+            loader: 'builtin:swc-loader',
+            options: swcReactLoaderConfig({reactCompiler: false}),
+          },
+          {
+            // Application code only.
+            exclude: /node_modules/,
+            loader: 'builtin:swc-loader',
+            options: swcReactLoaderConfig({reactCompiler: true}),
+          },
+        ],
       },
       {
         test: /\.mdx?$/,
         use: [
           {
             loader: 'builtin:swc-loader',
-            options: swcReactLoaderConfig,
+            options: swcReactLoaderConfig({reactCompiler: false}),
           },
           {
             loader: '@mdx-js/loader',


### PR DESCRIPTION
some 3rd party integrations break with it, and we mainly want to optimize our own code
