### PR TITLE
fix(conversations): Hide misleading span value counts in search

### DIFF
--- a/static/app/views/explore/conversations/overview.tsx
+++ b/static/app/views/explore/conversations/overview.tsx
@@ -13,6 +13,7 @@ import {
   useSpanSearchQueryBuilderProps,
   type UseSpanSearchQueryBuilderProps,
 } from 'sentry/components/performance/spanSearchQueryBuilder';
+import type {GetTagValues} from 'sentry/components/searchQueryBuilder';
 import {SearchQueryBuilderProvider} from 'sentry/components/searchQueryBuilder/context';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -106,8 +107,24 @@ function ConversationsOverviewPage() {
   const {spanSearchQueryBuilderProviderProps, spanSearchQueryBuilderProps} =
     useSpanSearchQueryBuilderProps(searchQueryBuilderProps);
 
+  // Value counts are span-level and can imply conversation results that the list
+  // will not return. Strip them so autocomplete only shows attribute values.
+  const searchQueryBuilderProviderProps = useMemo(() => {
+    const getTagValuesWithoutCounts: GetTagValues = async params => {
+      const values = await spanSearchQueryBuilderProviderProps.getTagValues(params);
+      return values.map(value =>
+        typeof value === 'string' ? value : {value: value.value}
+      );
+    };
+
+    return {
+      ...spanSearchQueryBuilderProviderProps,
+      getTagValues: getTagValuesWithoutCounts,
+    };
+  }, [spanSearchQueryBuilderProviderProps]);
+
   return (
-    <SearchQueryBuilderProvider {...spanSearchQueryBuilderProviderProps}>
+    <SearchQueryBuilderProvider {...searchQueryBuilderProviderProps}>
       <ExploreBodySearch>
         <Layout.Main width="full">
           <Stack gap="md">


### PR DESCRIPTION
Conversations search autocomplete currently shows span-level occurrence counts next to attribute values. Those counts come from generic spans, not from conversation-matching spans, so a value can look popular and still return no conversations after search.

This PR strips those counts from the conversations search bar only, so suggestions no longer imply guaranteed results. Attribute keys/values themselves are unchanged.


Closes [TET-2749: Conversations UI search dropdown shows matches but yields no results](https://linear.app/getsentry/issue/TET-2749/conversations-ui-search-dropdown-shows-matches-but-yields-no-results)