### PR TITLE
feat(llm-proxy): Add conversation_id attribute to request

### DIFF
--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -241,6 +241,12 @@ class LlmGenerateRequest(TypedDict):
     response_schema: NotRequired[dict[str, Any]]
     timeout: NotRequired[float | None]
     reasoning: NotRequired[Literal["off", "low", "med", "high"] | None]
+    # Groups this call's gen_ai spans into a Sentry AI Monitoring conversation.
+    # Seer cannot infer identity for a proxied call, so omitting this means "not
+    # part of any conversation" and the spans carry no conversation id. Prefer a
+    # stable subject key (e.g. f"autofix:{run_id}"); omit for calls that are not
+    # conversations, such as classification, scoring, or telemetry processing.
+    conversation_id: NotRequired[str]
 
 
 class OneShotRunRequest(TypedDict):

--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -244,7 +244,7 @@ class LlmGenerateRequest(TypedDict):
     # Groups this call's gen_ai spans into a Sentry AI Monitoring conversation.
     # Seer cannot infer identity for a proxied call, so omitting this means "not
     # part of any conversation" and the spans carry no conversation id. Prefer a
-    # stable subject key (e.g. f"autofix:{run_id}"); omit for calls that are not
+    # stable subject key (e.g. f"autofix_{run_id}"); omit for calls that are not
     # conversations, such as classification, scoring, or telemetry processing.
     conversation_id: NotRequired[str]
 


### PR DESCRIPTION
After https://github.com/getsentry/seer/pull/7529 is merged, we can pass `conversation_id` as `None` to the LLM proxy to not have the request registered as a part of the conversation.
