### PR TITLE
fix(projects): Projects endpoint should use spans

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -31,7 +31,7 @@ from sentry.ingest.inbound_filters import FilterTypes
 from sentry.issues.highlights import HighlightPreset, get_highlight_preset_for_project
 from sentry.lang.native.sources import parse_sources, redact_source_secrets
 from sentry.lang.native.utils import convert_crashreport_count
-from sentry.models.environment import EnvironmentProject
+from sentry.models.environment import Environment, EnvironmentProject
 from sentry.models.options.project_option import OPTION_KEYS, ProjectOption
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.project import Project
@@ -42,9 +42,11 @@ from sentry.models.release import Release
 from sentry.models.userreport import UserReport
 from sentry.release_health.base import CurrentAndPreviousCrashFreeRate
 from sentry.roles import organization_roles
+from sentry.search.eap.types import SearchResolverConfig
 from sentry.search.events.types import SnubaParams
 from sentry.services.eventstore.models import DEFAULT_SUBJECT_TEMPLATE
 from sentry.snuba import discover
+from sentry.snuba.spans_rpc import Spans
 from sentry.tempest.utils import has_tempest_access
 from sentry.users.api.serializers.user import SerializedAvatarFields
 from sentry.users.models.user import User
@@ -71,6 +73,11 @@ STATS_PERIOD_CHOICES = {
 }
 
 _PROJECT_SCOPE_PREFIX = "projects:"
+
+# Transactions live in the spans dataset as 'segment' spans, so counting them means
+# counting spans matching `is_transaction:true` (might change later to is_segment)
+TRANSACTION_STATS_QUERY = "is_transaction:true"
+TRANSACTION_STATS_COUNT = "count(span.duration)"
 
 LATEST_DEPLOYS_KEY: Final = "latestDeploys"
 UNUSED_ON_FRONTEND_FEATURES: Final = "unusedFeatures"
@@ -393,7 +400,7 @@ class ProjectSerializer(Serializer):
             if self.stats_period:
                 stats = self.get_stats(item_list, "!event.type:transaction")
                 if self._expand("transaction_stats"):
-                    transaction_stats = self.get_stats(item_list, "event.type:transaction")
+                    transaction_stats = self.get_transaction_stats(item_list)
                 if self._expand("session_stats"):
                     session_stats = self.get_session_stats(project_ids)
 
@@ -474,6 +481,59 @@ class ProjectSerializer(Serializer):
                 for item in stats[str_id].data["data"]:
                     serialized.append((item["time"], item.get("count", 0)))
             results[project.id] = serialized
+        return results
+
+    def get_transaction_stats(
+        self, projects: Sequence[Project]
+    ) -> dict[int, list[tuple[int, int]]]:
+        """Transaction counts can only come from the spans dataset now with is_transaction:true"""
+        assert self.stats_period is not None
+        segments, interval = STATS_PERIOD_CHOICES[self.stats_period]
+        now = timezone.now()
+        rollup = int(interval.total_seconds())
+        start = now - ((segments - 1) * interval)
+
+        snuba_params = SnubaParams(
+            projects=projects,
+            environments=(
+                list(Environment.objects.filter(id=self.environment_id))
+                if self.environment_id
+                else []
+            ),
+            start=start,
+            end=now,
+            granularity_secs=rollup,
+        )
+
+        stats = Spans.run_top_events_timeseries_query(
+            params=snuba_params,
+            query_string=TRANSACTION_STATS_QUERY,
+            y_axes=[TRANSACTION_STATS_COUNT],
+            raw_groupby=["project.id"],
+            orderby=[f"-{TRANSACTION_STATS_COUNT}"],
+            limit=len(projects),
+            include_other=False,
+            referrer="api.serializer.projects.get_transaction_stats",
+            config=SearchResolverConfig(),
+            sampling_mode=None,
+        )
+
+        # The spans query drops projects without transactions entirely, but callers expect
+        # every project to come back with a full series.
+        empty_series = [
+            (item["time"], 0) for item in discover.zerofill([], start, now, rollup, ["time"])
+        ]
+
+        results = {}
+        for project in projects:
+            str_id = str(project.id)
+            if str_id in stats:
+                results[project.id] = [
+                    (item["time"], item.get(TRANSACTION_STATS_COUNT) or 0)
+                    for item in stats[str_id].data["data"]
+                ]
+            else:
+                results[project.id] = list(empty_series)
         return results
 
     def get_session_stats(

--- a/src/sentry/core/endpoints/organization_projects.py
+++ b/src/sentry/core/endpoints/organization_projects.py
@@ -82,6 +82,9 @@ class _OrganizationProjectCreateResponse(OrganizationProjectResponse):
     team_slug: str
 
 
+# Only applies to the error `stats`; `transactionStats` always queries spans. Kept for
+# now until we have the frontend stop sending it, though every option resolves to discover for the error query anyway since the
+# metrics datasets is not compatible with `!event.type:transaction`.
 DATASETS = {
     "": discover,  # in case they pass an empty query string fall back on default
     "discover": discover,

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -598,6 +598,7 @@ class Referrer(StrEnum):
     API_SPAN_SAMPLE_GET_SPAN_IDS = "api.spans.sample-get-span-ids"
     API_SPAN_SAMPLE_GET_SPAN_DATA = "api.spans.sample-get-span-data"
     API_SERIALIZER_PROJECTS_GET_STATS = "api.serializer.projects.get_stats"
+    API_SERIALIZER_PROJECTS_GET_TRANSACTION_STATS = "api.serializer.projects.get_transaction_stats"
     API_SERIALIZER_CHECKINS_TRACE_IDS = "api.serializer.checkins.trace-ids"
     API_TRACE_VIEW_ERRORS_VIEW = "api.trace-view.errors-view"
     API_TRACE_VIEW_GET_TIMESTAMP_PROJECTS = "api.trace-view.get-timestamp-projects"

--- a/tests/sentry/api/serializers/test_project.py
+++ b/tests/sentry/api/serializers/test_project.py
@@ -28,10 +28,10 @@ from sentry.models.project import Project
 from sentry.models.release import Release
 from sentry.models.releaseprojectenvironment import ReleaseProjectEnvironment
 from sentry.models.userreport import UserReport
-from sentry.testutils.cases import SnubaTestCase, TestCase
+from sentry.snuba import metrics_enhanced_performance
+from sentry.testutils.cases import SnubaTestCase, SpanTestCase, TestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.datetime import before_now
-from sentry.utils.samples import load_data
 
 TEAM_CONTRIBUTOR = settings.SENTRY_TEAM_ROLES[0]
 TEAM_ADMIN = settings.SENTRY_TEAM_ROLES[1]
@@ -307,7 +307,7 @@ class ProjectWithTeamSerializerTest(TestCase):
         }
 
 
-class ProjectSummarySerializerTest(SnubaTestCase, TestCase):
+class ProjectSummarySerializerTest(SnubaTestCase, SpanTestCase, TestCase):
     def setUp(self) -> None:
         super().setUp()
         self.date = datetime.datetime(2018, 1, 12, 3, 8, 25, tzinfo=UTC)
@@ -659,8 +659,9 @@ class ProjectSummarySerializerTest(SnubaTestCase, TestCase):
             data={"event_id": "d" * 32, "message": "oh no", "timestamp": two_min_ago.isoformat()},
             project_id=self.project.id,
         )
-        transaction = load_data("transaction", timestamp=two_min_ago)
-        self.store_event(data=transaction, project_id=self.project.id)
+        self.store_span(
+            self.create_span({"is_segment": True}, project=self.project, start_ts=two_min_ago)
+        )
         serializer = ProjectSummarySerializer(stats_period="24h", expand=["transaction_stats"])
         results = serialize([self.project], self.user, serializer)
         assert "stats" in results[0]
@@ -671,6 +672,28 @@ class ProjectSummarySerializerTest(SnubaTestCase, TestCase):
         assert "transactionStats" in results[0]
         assert 24 == len(results[0]["transactionStats"])
         assert [1] == [v[1] for v in results[0]["transactionStats"] if v[1] > 0]
+
+    def test_stats_with_transactions_ignores_dataset(self) -> None:
+        self.store_span(
+            self.create_span(
+                {"is_segment": True}, project=self.project, start_ts=before_now(minutes=2)
+            )
+        )
+        serializer = ProjectSummarySerializer(
+            stats_period="24h",
+            expand=["transaction_stats"],
+            dataset=metrics_enhanced_performance,
+        )
+        results = serialize([self.project], self.user, serializer)
+
+        assert [1] == [v[1] for v in results[0]["transactionStats"] if v[1] > 0]
+
+    def test_stats_with_transactions_no_spans(self) -> None:
+        serializer = ProjectSummarySerializer(stats_period="24h", expand=["transaction_stats"])
+        results = serialize([self.project], self.user, serializer)
+
+        assert 24 == len(results[0]["transactionStats"])
+        assert 0 == sum(v[1] for v in results[0]["transactionStats"])
 
     @mock.patch(
         "sentry.api.serializers.models.project.release_health.backend.check_has_health_data"


### PR DESCRIPTION
The stats for the project list page was still going through metricsEnhanced for txn count etc, and had no option to use spans. We're no longer writing transaction information to `generic_metrics` (where metricsEnhanced got the metrics from) so this needs to be switched over.

This PR gives the endpoint it's own spans query; `is_transaction:true` grouped by `project.id` and ignores `dataset` for it (we'll delete it in the frontend). Spans return had to be zerofilled to match existing behaviour, and returned empty projects since this is an exhaustive listing.
