### PR TITLE
mypy(workflow-engine): Prepare for `detector.project` to be nullable

### DIFF
--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -392,7 +392,7 @@ class WorkflowEngineRuleSerializer(Serializer):
             workflow_id__in=[item.id for item in item_list]
         ).select_related("detector__project")
         for dw in detector_workflows:
-            workflow_to_projects[dw.workflow_id].add(dw.detector.project)
+            workflow_to_projects[dw.workflow_id].add(dw.detector.linked_project)
 
         return workflow_to_projects
 

--- a/src/sentry/explore/translation/alerts_translation.py
+++ b/src/sentry/explore/translation/alerts_translation.py
@@ -238,7 +238,7 @@ def translate_detector_and_update_subscription_in_snuba(
                         data_source,
                         data_condition,
                         snuba_query,
-                        detector.project,
+                        detector.linked_project,
                         SeerMethod.UPDATE,
                         event_types=[SnubaQueryEventType.EventType.TRACE_ITEM_SPAN],
                     )
@@ -342,7 +342,7 @@ def rollback_detector_query_and_update_subscription_in_snuba(
                         data_source,
                         data_condition,
                         snuba_query,
-                        detector.project,
+                        detector.linked_project,
                         SeerMethod.UPDATE,
                         event_types=[SnubaQueryEventType.EventType.TRANSACTION],
                     )

--- a/src/sentry/incidents/endpoints/serializers/workflow_engine_detector.py
+++ b/src/sentry/incidents/endpoints/serializers/workflow_engine_detector.py
@@ -145,7 +145,7 @@ class WorkflowEngineDetectorSerializer(Serializer):
     ) -> None:
         detector_projects = set()
         for detector in detectors.values():
-            detector_projects.add((detector.id, detector.project.slug))
+            detector_projects.add((detector.id, detector.linked_project.slug))
 
         for detector_id, project_slug in detector_projects:
             rule_result = result[detectors[detector_id]].setdefault(
@@ -268,7 +268,9 @@ class WorkflowEngineDetectorSerializer(Serializer):
         actions = [dcga.action for dcga in dcgas]
 
         # add sentry app data
-        organization_id = [detector.project.organization_id for detector in detectors.values()][0]
+        organization_id = [
+            detector.linked_project.organization_id for detector in detectors.values()
+        ][0]
         sentry_app_installations_by_sentry_app_id = (
             self.add_sentry_app_installations_by_sentry_app_id(actions, organization_id)
         )
@@ -430,7 +432,7 @@ class WorkflowEngineDetectorSerializer(Serializer):
         data: AlertRuleSerializerResponse = {
             "id": str(alert_rule_id),
             "name": obj.name,
-            "organizationId": str(obj.project.organization_id),
+            "organizationId": str(obj.linked_project.organization_id),
             "status": AlertRuleStatus.PENDING.value,
             "queryType": attrs.get("queryType"),
             "dataset": attrs.get("dataset"),

--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -236,7 +236,7 @@ class MetricIssueDetectorHandler(StatefulDetectorHandler[MetricUpdate, MetricRes
 
         try:
             owner = self.detector.owner.identifier if self.detector.owner else None
-            assignee = parse_and_validate_actor(owner, self.detector.project.organization_id)
+            assignee = parse_and_validate_actor(owner, self.detector.linked_project.organization_id)
         except Exception:
             logger.exception("Failed to parse assignee for detector id %s", self.detector.id)
             assignee = None
@@ -300,7 +300,7 @@ class MetricIssueDetectorHandler(StatefulDetectorHandler[MetricUpdate, MetricRes
             try:
                 dataset = Dataset(snuba_query.dataset)
                 alert_type = get_alert_type_from_aggregate_dataset(
-                    agg_display_key, dataset, self.detector.project.organization
+                    agg_display_key, dataset, self.detector.linked_project.organization
                 )
             except ValueError:
                 logger.exception(

--- a/src/sentry/incidents/metric_issue_detector.py
+++ b/src/sentry/incidents/metric_issue_detector.py
@@ -68,7 +68,7 @@ def schedule_update_project_config(detector: Detector) -> None:
     """
     If `should_use_on_demand`, then invalidate the project configs
     """
-    enabled_features = on_demand_metrics_feature_flags(detector.project.organization)
+    enabled_features = on_demand_metrics_feature_flags(detector.linked_project.organization)
     prefilling = "organizations:on-demand-metrics-prefill" in enabled_features
     if "organizations:on-demand-metrics-extraction" not in enabled_features and not prefilling:
         return
@@ -87,7 +87,7 @@ def schedule_update_project_config(detector: Detector) -> None:
     )
     if should_use_on_demand:
         schedule_invalidate_project_config(
-            trigger="alerts:create-on-demand-metric", project_id=detector.project.id
+            trigger="alerts:create-on-demand-metric", project_id=detector.linked_project.id
         )
 
 

--- a/src/sentry/notifications/notification_action/action_handler_registry/webhook_handler.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/webhook_handler.py
@@ -52,7 +52,7 @@ class WebhookActionHandler(ActionHandler):
     @staticmethod
     @override
     def execute(invocation: ActionInvocation) -> None:
-        organization = invocation.detector.project.organization
+        organization = invocation.detector.linked_project.organization
         target_identifier = invocation.action.config.get("target_identifier")
         if target_identifier == "webhooks":
             return _handle_legacy_webhooks(invocation)

--- a/src/sentry/notifications/notification_action/activity_registry/discord.py
+++ b/src/sentry/notifications/notification_action/activity_registry/discord.py
@@ -36,6 +36,6 @@ class DiscordActivityHandler(ActivityHandler):
                 resource_type=NotificationTargetResourceType.CHANNEL,
                 resource_id=require_config(invocation.action, "target_identifier"),
                 integration_id=require_integration_id(invocation.action),
-                organization_id=invocation.detector.project.organization.id,
+                organization_id=invocation.detector.linked_project.organization.id,
             )
             send_activity_notification(invocation, activity, target)

--- a/src/sentry/notifications/notification_action/activity_registry/msteams.py
+++ b/src/sentry/notifications/notification_action/activity_registry/msteams.py
@@ -36,6 +36,6 @@ class MSTeamsActivityHandler(ActivityHandler):
                 resource_type=NotificationTargetResourceType.CHANNEL,
                 resource_id=require_config(invocation.action, "target_identifier"),
                 integration_id=require_integration_id(invocation.action),
-                organization_id=invocation.detector.project.organization.id,
+                organization_id=invocation.detector.linked_project.organization.id,
             )
             send_activity_notification(invocation, activity, target)

--- a/src/sentry/notifications/notification_action/activity_registry/slack.py
+++ b/src/sentry/notifications/notification_action/activity_registry/slack.py
@@ -53,6 +53,6 @@ class SlackActivityHandler(ActivityHandler):
                 resource_type=resource_type,
                 resource_id=resource_id,
                 integration_id=require_integration_id(invocation.action),
-                organization_id=invocation.detector.project.organization.id,
+                organization_id=invocation.detector.linked_project.organization.id,
             )
             send_activity_notification(invocation, activity, target)

--- a/src/sentry/notifications/notification_action/types.py
+++ b/src/sentry/notifications/notification_action/types.py
@@ -218,7 +218,9 @@ class BaseIssueAlertHandler(ABC):
         environment_id = event_data.workflow_env.id if event_data.workflow_env else None
 
         data: RuleData = {
-            "actions": [cls.build_rule_action_blob(action, detector.project.organization.id)],
+            "actions": [
+                cls.build_rule_action_blob(action, detector.linked_project.organization.id)
+            ],
         }
         rule_id = None
 
@@ -253,7 +255,7 @@ class BaseIssueAlertHandler(ABC):
                 try:
                     label = Rule.objects.get(
                         id=alert_rule_workflow.rule_id,
-                        project__organization_id=detector.project.organization_id,
+                        project__organization_id=detector.linked_project.organization_id,
                     ).label
                     rule_id = alert_rule_workflow.rule_id
                 except Rule.DoesNotExist:
@@ -475,8 +477,8 @@ class BaseMetricAlertHandler(ABC):
             open_period_context=open_period_context,
             trigger_status=trigger_status,
             notification_uuid=invocation.notification_uuid,
-            organization=invocation.detector.project.organization,
-            project=invocation.detector.project,
+            organization=invocation.detector.linked_project.organization,
+            project=invocation.detector.linked_project,
         )
 
 

--- a/src/sentry/notifications/notification_action/types.py
+++ b/src/sentry/notifications/notification_action/types.py
@@ -276,7 +276,7 @@ class BaseIssueAlertHandler(ABC):
 
         rule = Rule(
             id=action.id,
-            project=detector.project,
+            project=detector.linked_project,
             environment_id=environment_id,
             label=label,
             data=dict(data),

--- a/src/sentry/notifications/notification_action/utils.py
+++ b/src/sentry/notifications/notification_action/utils.py
@@ -60,7 +60,7 @@ def execute_via_group_type_registry(invocation: ActionInvocation) -> None:
                 extra={
                     "action_id": invocation.action.id,
                     "detector_id": invocation.detector.id,
-                    "organization_id": invocation.detector.project.organization_id,
+                    "organization_id": invocation.detector.linked_project.organization_id,
                 },
             )
         return invocation.event_data.event.send_notification()

--- a/src/sentry/notifications/utils/issue_notification_context.py
+++ b/src/sentry/notifications/utils/issue_notification_context.py
@@ -114,7 +114,7 @@ class IssueNotificationContext:
 
     @cached_property
     def organization(self) -> Organization:
-        return self._invocation.detector.project.organization
+        return self._invocation.detector.linked_project.organization
 
     @cached_property
     def open_period(self) -> GroupOpenPeriod:

--- a/src/sentry/preprod/size_analysis/grouptype.py
+++ b/src/sentry/preprod/size_analysis/grouptype.py
@@ -205,7 +205,7 @@ class PreprodSizeAnalysisDetectorHandler(
             )
 
         artifact = metadata["head_artifact"]
-        organization = self.detector.project.organization
+        organization = self.detector.linked_project.organization
 
         try:
             return artifact_matches_query(artifact, query, organization)

--- a/src/sentry/seer/anomaly_detection/delete_rule.py
+++ b/src/sentry/seer/anomaly_detection/delete_rule.py
@@ -53,7 +53,7 @@ def delete_data_in_seer_for_detector(detector: Detector):
         )
         return
 
-    organization = detector.project.organization
+    organization = detector.linked_project.organization
 
     if detector.config.get("detection_type") == AlertRuleDetectionType.DYNAMIC:
         success = delete_rule_in_seer(

--- a/src/sentry/seer/anomaly_detection/store_data_workflow_engine.py
+++ b/src/sentry/seer/anomaly_detection/store_data_workflow_engine.py
@@ -123,7 +123,7 @@ def update_detector_data(
             data_source,
             data_condition,
             snuba_query,
-            detector.project,
+            detector.linked_project,
             SeerMethod.UPDATE,
             event_types,
         )
@@ -147,7 +147,12 @@ def send_new_detector_data(detector: Detector) -> None:
 
     try:
         handle_send_historical_data_to_seer(
-            detector, data_source, data_condition, snuba_query, detector.project, SeerMethod.CREATE
+            detector,
+            data_source,
+            data_condition,
+            snuba_query,
+            detector.linked_project,
+            SeerMethod.CREATE,
         )
     except (TimeoutError, MaxRetryError, ParseError, ValidationError):
         raise ValidationError("Couldn't send data to Seer, unable to create detector")

--- a/src/sentry/sentry_apps/services/legacy_webhook/service.py
+++ b/src/sentry/sentry_apps/services/legacy_webhook/service.py
@@ -134,7 +134,7 @@ def send_legacy_webhooks_for_invocation(invocation: ActionInvocation) -> None:
     # Delayed import to avoid circular dependency (tasks imports LegacyWebhookPayload from here)
     from sentry.sentry_apps.services.legacy_webhook.tasks import send_legacy_webhook_task
 
-    project = invocation.detector.project
+    project = invocation.detector.linked_project
     enabled = ProjectOption.objects.get_value(project, "webhooks:enabled", default=False)
     if not enabled:
         return

--- a/src/sentry/uptime/autodetect/result_handler.py
+++ b/src/sentry/uptime/autodetect/result_handler.py
@@ -115,7 +115,7 @@ def handle_onboarding_result(
                 )
                 return
             create_system_audit_entry(
-                organization=detector.project.organization,
+                organization=detector.linked_project.organization,
                 target_object=detector.id,
                 event=audit_log.get_event_id("UPTIME_MONITOR_ADD"),
                 data=get_audit_log_data(detector),

--- a/src/sentry/uptime/consumers/eap_producer.py
+++ b/src/sentry/uptime/consumers/eap_producer.py
@@ -65,7 +65,7 @@ def produce_eap_uptime_result(
             incident_status = IncidentStatus.NO_INCIDENT
 
         trace_items = convert_uptime_result_to_trace_items(
-            detector.project, result, incident_status
+            detector.linked_project, result, incident_status
         )
         topic = get_topic_definition(Topic.SNUBA_ITEMS)["real_topic_name"]
         producer = _get_producer()
@@ -86,7 +86,7 @@ def produce_eap_uptime_result(
                 "subscription_id": result["subscription_id"],
                 "check_status": result["status"],
                 "region": result["region"],
-                "project_id": detector.project.id,
+                "project_id": detector.linked_project.id,
                 "trace_item_count": len(trace_items),
                 "incident_status": incident_status.value,
             },

--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -646,7 +646,7 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
             delete_uptime_subscription(subscription)
             return
 
-        organization = detector.project.organization
+        organization = detector.linked_project.organization
 
         # Nothing to do if this subscription is disabled.
         if not detector.enabled:

--- a/src/sentry/uptime/endpoints/serializers.py
+++ b/src/sentry/uptime/endpoints/serializers.py
@@ -131,7 +131,7 @@ class UptimeDetectorSerializer(Serializer[UptimeDetectorSerializerResponse]):
 
         return {
             "id": str(obj.id),
-            "projectSlug": obj.project.slug,
+            "projectSlug": obj.linked_project.slug,
             "environment": obj.config.get("environment"),
             "name": obj.name or f"Uptime Monitoring for {uptime_subscription.url}",
             "status": "active" if obj.enabled else "disabled",

--- a/src/sentry/uptime/models.py
+++ b/src/sentry/uptime/models.py
@@ -153,7 +153,7 @@ class UptimeSubscriptionRegion(DefaultFieldsModel):
 
 
 def get_org_from_detector(detector: Detector) -> tuple[Organization]:
-    return (detector.project.organization,)
+    return (detector.linked_project.organization,)
 
 
 @cache_func_for_models([(Detector, get_org_from_detector)])

--- a/src/sentry/uptime/subscriptions/subscriptions.py
+++ b/src/sentry/uptime/subscriptions/subscriptions.py
@@ -435,7 +435,7 @@ def update_uptime_detector(
 
         current_env = detector.config.get("environment")
         if current_env:
-            current_env_obj = Environment.get_or_create(detector.project, current_env)
+            current_env_obj = Environment.get_or_create(detector.linked_project, current_env)
         else:
             current_env_obj = None
         env = default_if_not_set(current_env_obj, environment)

--- a/src/sentry/uptime/subscriptions/tasks.py
+++ b/src/sentry/uptime/subscriptions/tasks.py
@@ -219,7 +219,7 @@ def broken_monitor_checker(**kwargs):
             disable_uptime_detector(detector)
 
             create_system_audit_entry(
-                organization=detector.project.organization,
+                organization=detector.linked_project.organization,
                 target_object=detector.id,
                 event=audit_log.get_event_id("UPTIME_MONITOR_DISABLE_BROKEN"),
                 data={

--- a/src/sentry/workflow_engine/endpoints/organization_detector_details.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_details.py
@@ -81,7 +81,9 @@ def remove_detector(
     if not can_delete_detector(detector, request):
         raise PermissionDenied
 
-    validator = get_detector_validator(request, detector.project, detector.type, instance=detector)
+    validator = get_detector_validator(
+        request, detector.linked_project, detector.type, instance=detector
+    )
     validator.delete()
 
     if detector.type == MetricIssue.slug:
@@ -89,7 +91,7 @@ def remove_detector(
 
     create_audit_entry(
         request=request,
-        organization=detector.project.organization,
+        organization=detector.linked_project.organization,
         target_object=detector.id,
         event=audit_log.get_event_id("DETECTOR_REMOVE"),
         data=detector.get_audit_log_data(),
@@ -148,7 +150,7 @@ class OrganizationDetectorDetailsEndpoint(OrganizationEndpoint):
             raise ResourceDoesNotExist
 
         # Verify user has access to the detector's project (respects Open Membership setting)
-        if not request.access.has_project_access(detector.project):
+        if not request.access.has_project_access(detector.linked_project):
             raise PermissionDenied
 
         return args, kwargs
@@ -222,7 +224,7 @@ class OrganizationDetectorDetailsEndpoint(OrganizationEndpoint):
 
         group_type = request.data.get("type") or detector.group_type.slug
         validator = get_detector_validator(
-            request, detector.project, group_type, detector, partial=True
+            request, detector.linked_project, group_type, detector, partial=True
         )
 
         if not validator.is_valid():

--- a/src/sentry/workflow_engine/endpoints/organization_open_periods.py
+++ b/src/sentry/workflow_engine/endpoints/organization_open_periods.py
@@ -86,7 +86,7 @@ class OrganizationOpenPeriodsEndpoint(OrganizationEndpoint):
     ) -> Group | None:
         if detector_id:
             detector = self.get_detector_from_detector_id(detector_id, organization)
-            if not request.access.has_project_access(detector.project):
+            if not request.access.has_project_access(detector.linked_project):
                 raise ValidationError({"detectorId": "Detector not found"})
             return self.get_group_from_detector(detector)
 

--- a/src/sentry/workflow_engine/endpoints/organization_open_periods.py
+++ b/src/sentry/workflow_engine/endpoints/organization_open_periods.py
@@ -53,7 +53,7 @@ class OrganizationOpenPeriodsEndpoint(OrganizationEndpoint):
         except Detector.DoesNotExist:
             raise ValidationError({"detectorId": "Detector not found"})
 
-        if detector.project.organization_id != organization.id:
+        if detector.linked_project.organization_id != organization.id:
             raise ValidationError({"detectorId": "Detector not found"})
 
         return detector

--- a/src/sentry/workflow_engine/endpoints/validators/error_detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/error_detector.py
@@ -77,7 +77,7 @@ class ErrorDetectorValidator(BaseDetectorTypeValidator):
 
             super().update(instance, validated_data)
 
-            project = instance.project
+            project = instance.linked_project
             # update configs, which are project options. continue using them
             for config in validated_data:
                 if config in Detector.error_detector_project_options:

--- a/src/sentry/workflow_engine/endpoints/validators/utils.py
+++ b/src/sentry/workflow_engine/endpoints/validators/utils.py
@@ -117,7 +117,7 @@ def can_edit_detector_workflow_connections(detector: Detector, request: Request)
     which is slightly different from full edit access which differs by detector type.
     """
     return request.access.has_any_project_scope(
-        detector.project, USER_CREATED_DETECTOR_REQUIRED_SCOPES
+        detector.linked_project, USER_CREATED_DETECTOR_REQUIRED_SCOPES
     )
 
 

--- a/src/sentry/workflow_engine/endpoints/validators/utils.py
+++ b/src/sentry/workflow_engine/endpoints/validators/utils.py
@@ -79,11 +79,11 @@ def can_edit_detector(detector: Detector, request: Request) -> bool:
     in their request.
     """
     if is_system_created_detector(detector) and not can_edit_system_created_detectors(
-        request, detector.project
+        request, detector.linked_project
     ):
         return False
 
-    return can_edit_user_created_detectors(request, detector.project)
+    return can_edit_user_created_detectors(request, detector.linked_project)
 
 
 def can_delete_detectors(detectors: QuerySet[Detector], request: Request) -> bool:
@@ -108,7 +108,7 @@ def can_delete_detector(detector: Detector, request: Request) -> bool:
     if is_system_created_detector(detector):
         return False
 
-    return can_edit_user_created_detectors(request, detector.project)
+    return can_edit_user_created_detectors(request, detector.linked_project)
 
 
 def can_edit_detector_workflow_connections(detector: Detector, request: Request) -> bool:

--- a/src/sentry/workflow_engine/models/detector.py
+++ b/src/sentry/workflow_engine/models/detector.py
@@ -26,6 +26,7 @@ from sentry.workflow_engine.types import DetectorSettings
 from .json_config import JSONConfigBase
 
 if TYPE_CHECKING:
+    from sentry.models.project import Project
     from sentry.workflow_engine.handlers.detector import DetectorHandler
     from sentry.workflow_engine.models.data_condition_group import DataConditionGroupSnapshot
 
@@ -116,6 +117,12 @@ class Detector(DefaultFieldsModel, OwnerModel, JSONConfigBase):
     }
 
     CACHE_TTL = 60 * 10
+
+    @property
+    def linked_project(self) -> Project:
+        if self.project is None:
+            raise ValueError("Detector is not project-scoped")
+        return self.project
 
     @classmethod
     def get_default_detector_for_project(cls, project_id: int, detector_type: str) -> Detector:

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -198,7 +198,7 @@ class ProjectRuleDetailsBaseTestCase(APITestCase, BaseWorkflowTest):
         self.workflow_triggers = self.create_data_condition_group()
         self.workflow = self.create_workflow(
             when_condition_group=self.workflow_triggers,
-            organization=self.detector.project.organization,
+            organization=self.detector.linked_project.organization,
             config={"frequency": 30},
         )
         self.detector_workflow = self.create_detector_workflow(

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -85,7 +85,7 @@ class ProjectRuleBaseTestCase(APITestCase, BaseWorkflowTest):
         self.workflow_triggers = self.create_data_condition_group()
         self.workflow = self.create_workflow(
             when_condition_group=self.workflow_triggers,
-            organization=self.detector.project.organization,
+            organization=self.detector.linked_project.organization,
         )
         self.detector_workflow = self.create_detector_workflow(
             detector=self.detector, workflow=self.workflow
@@ -133,7 +133,7 @@ class ProjectRuleListTest(ProjectRuleBaseTestCase):
         workflow_triggers = self.create_data_condition_group()
         workflow = self.create_workflow(
             when_condition_group=workflow_triggers,
-            organization=detector.project.organization,
+            organization=detector.linked_project.organization,
             name="Issue resolved trigger workflow",
         )
         self.create_detector_workflow(detector=detector, workflow=workflow)
@@ -194,7 +194,7 @@ class ProjectRuleListTest(ProjectRuleBaseTestCase):
         workflow_triggers = self.create_data_condition_group()
         workflow = self.create_workflow(
             when_condition_group=workflow_triggers,
-            organization=detector.project.organization,
+            organization=detector.linked_project.organization,
             name="Issue resolved trigger workflow",
         )
         self.create_detector_workflow(detector=detector, workflow=workflow)

--- a/tests/sentry/incidents/endpoints/validators/test_validators.py
+++ b/tests/sentry/incidents/endpoints/validators/test_validators.py
@@ -1530,7 +1530,7 @@ class TestMetricAlertsUpdateDetectorValidator(TestMetricAlertsDetectorValidator)
             data_source,
             data_condition,
             snuba_query,
-            detector.project,
+            detector.linked_project,
             "update",
             [SnubaQueryEventType.EventType.TRANSACTION],
         )

--- a/tests/sentry/incidents/handlers/condition/test_anomaly_detection_handler.py
+++ b/tests/sentry/incidents/handlers/condition/test_anomaly_detection_handler.py
@@ -96,7 +96,7 @@ class TestAnomalyDetectionHandler(ConditionTestCase):
         }
 
     def assert_seer_call(self, deserialized_body: dict[str, Any]) -> None:
-        assert deserialized_body["organization_id"] == self.detector.project.organization.id
+        assert deserialized_body["organization_id"] == self.detector.linked_project.organization.id
         assert deserialized_body["project_id"] == self.detector.project_id
         assert deserialized_body["config"]["time_period"] == self.snuba_query.time_window / 60
         assert (

--- a/tests/sentry/incidents/serializers/test_workflow_engine_base.py
+++ b/tests/sentry/incidents/serializers/test_workflow_engine_base.py
@@ -180,7 +180,7 @@ class TestWorkflowEngineSerializer(TestCase):
             action=self.critical_action, group=self.group, workflow=workflow
         )
         self.group_open_period = GroupOpenPeriod.objects.get(
-            group=self.group, project=self.detector.project
+            group=self.group, project=self.detector.linked_project
         )
         self.group_open_period.update(date_started=self.incident.date_started)
         self.incident_group_open_period = IncidentGroupOpenPeriod.objects.create(

--- a/tests/sentry/incidents/serializers/test_workflow_engine_base.py
+++ b/tests/sentry/incidents/serializers/test_workflow_engine_base.py
@@ -94,7 +94,7 @@ class TestWorkflowEngineSerializer(TestCase):
         self.expected = {
             "id": str(self.alert_rule.id),
             "name": self.detector.name,
-            "organizationId": str(self.detector.project.organization_id),
+            "organizationId": str(self.detector.linked_project.organization_id),
             "status": AlertRuleStatus.PENDING.value,
             "queryType": self.alert_rule.snuba_query.type,
             "dataset": self.alert_rule.snuba_query.dataset,

--- a/tests/sentry/incidents/subscription_processor/test_subscription_processor_base.py
+++ b/tests/sentry/incidents/subscription_processor/test_subscription_processor_base.py
@@ -74,7 +74,7 @@ class ProcessUpdateBaseClass(TestCase, SpanTestCase, SnubaTestCase):
                 ],
             )
             query_subscription = create_snuba_subscription(
-                project=detector.project,
+                project=detector.linked_project,
                 subscription_type=INCIDENTS_SNUBA_SUBSCRIPTION_TYPE,
                 snuba_query=snuba_query,
             )

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -2249,7 +2249,7 @@ class EnableDisableDetectorTest(TestCase, BaseIncidentsTest):
                 event_types=([SnubaQueryEventType.EventType.ERROR]),
             )
             self.query_subscription = create_snuba_subscription(
-                project=self.detector.project,
+                project=self.detector.linked_project,
                 subscription_type=INCIDENTS_SNUBA_SUBSCRIPTION_TYPE,
                 snuba_query=self.snuba_query,
             )
@@ -2305,7 +2305,7 @@ class EnableDisableDetectorTest(TestCase, BaseIncidentsTest):
                 event_types=([SnubaQueryEventType.EventType.ERROR]),
             )
             self.query_subscription = create_snuba_subscription(
-                project=self.detector.project,
+                project=self.detector.linked_project,
                 subscription_type=INCIDENTS_SNUBA_SUBSCRIPTION_TYPE,
                 snuba_query=self.snuba_query,
             )

--- a/tests/sentry/incidents/utils/test_metric_issue_base.py
+++ b/tests/sentry/incidents/utils/test_metric_issue_base.py
@@ -61,7 +61,7 @@ class BaseMetricIssueTest(TestCase):
                 event_types=[SnubaQueryEventType.EventType.ERROR],
             )
             self.query_subscription = create_snuba_subscription(
-                project=self.detector.project,
+                project=self.detector.linked_project,
                 subscription_type=INCIDENTS_SNUBA_SUBSCRIPTION_TYPE,
                 snuba_query=self.snuba_query,
             )

--- a/tests/sentry/issues/test_ingest_incident_integration.py
+++ b/tests/sentry/issues/test_ingest_incident_integration.py
@@ -58,7 +58,7 @@ class IncidentGroupOpenPeriodIntegrationTest(TestCase):
                 event_types=[SnubaQueryEventType.EventType.ERROR],
             )
             self.query_subscription = create_snuba_subscription(
-                project=self.detector.project,
+                project=self.detector.linked_project,
                 subscription_type=INCIDENTS_SNUBA_SUBSCRIPTION_TYPE,
                 snuba_query=self.snuba_query,
             )

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_discord_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_discord_metric_alert_handler.py
@@ -65,13 +65,13 @@ class TestDiscordMetricAlertHandler(MetricAlertHandlerBase):
             metric_issue_context=metric_issue_context,
             open_period_context=open_period_context,
             trigger_status=TriggerStatus.ACTIVE,
-            project=self.detector.project,
-            organization=self.detector.project.organization,
+            project=self.detector.linked_project,
+            organization=self.detector.linked_project.organization,
             notification_uuid=notification_uuid,
         )
 
         mock_send_incident_alert_notification.assert_called_once_with(
-            organization=self.detector.project.organization,
+            organization=self.detector.linked_project.organization,
             alert_context=alert_context,
             notification_context=notification_context,
             metric_issue_context=metric_issue_context,
@@ -144,7 +144,7 @@ class TestDiscordMetricAlertHandler(MetricAlertHandlerBase):
             date_closed=None,
         )
 
-        assert organization == self.detector.project.organization
+        assert organization == self.detector.linked_project.organization
         assert isinstance(notification_uuid, str)
 
     @mock.patch(
@@ -230,5 +230,5 @@ class TestDiscordMetricAlertHandler(MetricAlertHandlerBase):
             date_closed=None,
         )
 
-        assert organization == self.detector.project.organization
+        assert organization == self.detector.linked_project.organization
         assert isinstance(notification_uuid, str)

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_email_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_email_metric_alert_handler.py
@@ -44,7 +44,7 @@ class TestEmailMetricAlertHandler(MetricAlertHandlerBase):
         self.handler = EmailMetricAlertHandler()
 
     def test_get_target_team_in_org(self) -> None:
-        organization = self.detector.project.organization
+        organization = self.detector.linked_project.organization
         team = self.create_team(organization=organization)
         notification_context = NotificationContext(
             id=self.action.id,
@@ -54,7 +54,7 @@ class TestEmailMetricAlertHandler(MetricAlertHandlerBase):
         assert get_target(organization, notification_context) == team
 
     def test_get_target_team_foreign_org(self) -> None:
-        organization = self.detector.project.organization
+        organization = self.detector.linked_project.organization
         other_org = self.create_organization()
         other_team = self.create_team(organization=other_org)
         notification_context = NotificationContext(
@@ -94,8 +94,8 @@ class TestEmailMetricAlertHandler(MetricAlertHandlerBase):
             metric_issue_context=metric_issue_context,
             open_period_context=open_period_context,
             trigger_status=TriggerStatus.ACTIVE,
-            project=self.detector.project,
-            organization=self.detector.project.organization,
+            project=self.detector.linked_project,
+            organization=self.detector.linked_project.organization,
             notification_uuid=notification_uuid,
         )
 
@@ -106,7 +106,7 @@ class TestEmailMetricAlertHandler(MetricAlertHandlerBase):
             detector_serialized_response=get_detector_serializer(self.detector),
             trigger_status=TriggerStatus.ACTIVE,
             targets=[(self.user.id, self.user.email)],
-            project=self.detector.project,
+            project=self.detector.linked_project,
             notification_uuid=notification_uuid,
         )
 
@@ -175,7 +175,7 @@ class TestEmailMetricAlertHandler(MetricAlertHandlerBase):
             date_closed=None,
         )
 
-        assert organization == self.detector.project.organization
+        assert organization == self.detector.linked_project.organization
         assert isinstance(notification_uuid, str)
 
     @mock.patch(
@@ -262,5 +262,5 @@ class TestEmailMetricAlertHandler(MetricAlertHandlerBase):
             date_closed=None,
         )
 
-        assert organization == self.detector.project.organization
+        assert organization == self.detector.linked_project.organization
         assert isinstance(notification_uuid, str)

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_msteams_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_msteams_metric_alert_handler.py
@@ -63,13 +63,13 @@ class TestMsteamsMetricAlertHandler(MetricAlertHandlerBase):
             metric_issue_context=metric_issue_context,
             open_period_context=open_period_context,
             trigger_status=TriggerStatus.ACTIVE,
-            project=self.detector.project,
-            organization=self.detector.project.organization,
+            project=self.detector.linked_project,
+            organization=self.detector.linked_project.organization,
             notification_uuid=notification_uuid,
         )
 
         mock_send_incident_alert_notification.assert_called_once_with(
-            organization=self.detector.project.organization,
+            organization=self.detector.linked_project.organization,
             alert_context=alert_context,
             notification_context=notification_context,
             metric_issue_context=metric_issue_context,
@@ -141,7 +141,7 @@ class TestMsteamsMetricAlertHandler(MetricAlertHandlerBase):
             date_closed=None,
         )
 
-        assert organization == self.detector.project.organization
+        assert organization == self.detector.linked_project.organization
         assert isinstance(notification_uuid, str)
 
     @mock.patch(
@@ -227,5 +227,5 @@ class TestMsteamsMetricAlertHandler(MetricAlertHandlerBase):
             date_closed=None,
         )
 
-        assert organization == self.detector.project.organization
+        assert organization == self.detector.linked_project.organization
         assert isinstance(notification_uuid, str)

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_opsgenie_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_opsgenie_metric_alert_handler.py
@@ -62,8 +62,8 @@ class TestOpsgenieMetricAlertHandler(MetricAlertHandlerBase):
             metric_issue_context=metric_issue_context,
             open_period_context=open_period_context,
             trigger_status=TriggerStatus.ACTIVE,
-            project=self.detector.project,
-            organization=self.detector.project.organization,
+            project=self.detector.linked_project,
+            organization=self.detector.linked_project.organization,
             notification_uuid=notification_uuid,
         )
 
@@ -71,7 +71,7 @@ class TestOpsgenieMetricAlertHandler(MetricAlertHandlerBase):
             notification_context=notification_context,
             alert_context=alert_context,
             metric_issue_context=metric_issue_context,
-            organization=self.detector.project.organization,
+            organization=self.detector.linked_project.organization,
             notification_uuid=notification_uuid,
         )
 
@@ -141,7 +141,7 @@ class TestOpsgenieMetricAlertHandler(MetricAlertHandlerBase):
             date_closed=None,
         )
 
-        assert organization == self.detector.project.organization
+        assert organization == self.detector.linked_project.organization
         assert isinstance(notification_uuid, str)
 
     @mock.patch(
@@ -226,5 +226,5 @@ class TestOpsgenieMetricAlertHandler(MetricAlertHandlerBase):
             date_closed=None,
         )
 
-        assert organization == self.detector.project.organization
+        assert organization == self.detector.linked_project.organization
         assert isinstance(notification_uuid, str)

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_pagerduty_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_pagerduty_metric_alert_handler.py
@@ -60,8 +60,8 @@ class TestPagerDutyMetricAlertHandler(MetricAlertHandlerBase):
             metric_issue_context=metric_issue_context,
             open_period_context=open_period_context,
             trigger_status=TriggerStatus.ACTIVE,
-            project=self.detector.project,
-            organization=self.detector.project.organization,
+            project=self.detector.linked_project,
+            organization=self.detector.linked_project.organization,
             notification_uuid=notification_uuid,
         )
 
@@ -69,7 +69,7 @@ class TestPagerDutyMetricAlertHandler(MetricAlertHandlerBase):
             notification_context=notification_context,
             alert_context=alert_context,
             metric_issue_context=metric_issue_context,
-            organization=self.detector.project.organization,
+            organization=self.detector.linked_project.organization,
             notification_uuid=notification_uuid,
         )
 
@@ -99,7 +99,7 @@ class TestPagerDutyMetricAlertHandler(MetricAlertHandlerBase):
             notification_uuid,
         ) = self.unpack_kwargs(mock_send_alert)
 
-        assert organization == self.detector.project.organization
+        assert organization == self.detector.linked_project.organization
         assert isinstance(notification_uuid, str)
 
         self.assert_notification_context(
@@ -139,7 +139,7 @@ class TestPagerDutyMetricAlertHandler(MetricAlertHandlerBase):
             date_closed=None,
         )
 
-        assert organization == self.detector.project.organization
+        assert organization == self.detector.linked_project.organization
         assert isinstance(notification_uuid, str)
 
     @mock.patch(
@@ -224,5 +224,5 @@ class TestPagerDutyMetricAlertHandler(MetricAlertHandlerBase):
             date_closed=None,
         )
 
-        assert organization == self.detector.project.organization
+        assert organization == self.detector.linked_project.organization
         assert isinstance(notification_uuid, str)

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_sentry_app_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_sentry_app_metric_alert_handler.py
@@ -75,8 +75,8 @@ class TestSentryAppMetricAlertHandler(MetricAlertHandlerBase):
             metric_issue_context=metric_issue_context,
             open_period_context=open_period_context,
             trigger_status=TriggerStatus.ACTIVE,
-            project=self.detector.project,
-            organization=self.detector.project.organization,
+            project=self.detector.linked_project,
+            organization=self.detector.linked_project.organization,
             notification_uuid=notification_uuid,
         )
 
@@ -84,8 +84,8 @@ class TestSentryAppMetricAlertHandler(MetricAlertHandlerBase):
             notification_context=notification_context,
             alert_context=alert_context,
             metric_issue_context=metric_issue_context,
-            organization=self.detector.project.organization,
-            project_id=self.detector.project.id,
+            organization=self.detector.linked_project.organization,
+            project_id=self.detector.linked_project.id,
             notification_uuid=notification_uuid,
             incident_serialized_response=get_incident_serializer(self.open_period),
         )
@@ -153,7 +153,7 @@ class TestSentryAppMetricAlertHandler(MetricAlertHandlerBase):
             date_closed=None,
         )
 
-        assert organization == self.detector.project.organization
+        assert organization == self.detector.linked_project.organization
         assert isinstance(notification_uuid, str)
 
     @mock.patch(
@@ -239,5 +239,5 @@ class TestSentryAppMetricAlertHandler(MetricAlertHandlerBase):
             date_closed=None,
         )
 
-        assert organization == self.detector.project.organization
+        assert organization == self.detector.linked_project.organization
         assert isinstance(notification_uuid, str)

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_slack_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_slack_metric_alert_handler.py
@@ -75,8 +75,8 @@ class TestSlackMetricAlertHandlerSendAlert(MetricAlertHandlerBase):
             ),
             open_period_context=OpenPeriodContext.from_group(self.group),
             trigger_status=TriggerStatus.ACTIVE,
-            project=self.detector.project,
-            organization=self.detector.project.organization,
+            project=self.detector.linked_project,
+            organization=self.detector.linked_project.organization,
             notification_uuid=str(uuid.uuid4()),
         )
 
@@ -211,7 +211,7 @@ class TestSlackMetricAlertHandlerInvokeRegistry(MetricAlertHandlerBase):
             date_closed=None,
         )
 
-        assert organization == self.detector.project.organization
+        assert organization == self.detector.linked_project.organization
         assert isinstance(notification_uuid, str)
 
     @mock.patch(
@@ -290,5 +290,5 @@ class TestSlackMetricAlertHandlerInvokeRegistry(MetricAlertHandlerBase):
             date_closed=None,
         )
 
-        assert organization == self.detector.project.organization
+        assert organization == self.detector.linked_project.organization
         assert isinstance(notification_uuid, str)

--- a/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
@@ -443,7 +443,7 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
             group=self.group_event.group,
             subscription=self.subscription,
         )
-        assert organization == self.detector.project.organization
+        assert organization == self.detector.linked_project.organization
         assert isinstance(notification_uuid, str)
 
     def test_send_alert_not_implemented(self) -> None:
@@ -529,7 +529,7 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
             group=self.group,
             subscription=self.subscription,
         )
-        assert organization == self.detector.project.organization
+        assert organization == self.detector.linked_project.organization
         assert isinstance(notification_uuid, str)
 
     @mock.patch.object(TestHandler, "send_alert")
@@ -605,7 +605,7 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
             group=self.group,
             subscription=self.subscription,
         )
-        assert organization == self.detector.project.organization
+        assert organization == self.detector.linked_project.organization
         assert isinstance(notification_uuid, str)
 
     def test_invoke_legacy_registry_activity_missing_data(self) -> None:

--- a/tests/sentry/notifications/utils/test_issue_notification_context.py
+++ b/tests/sentry/notifications/utils/test_issue_notification_context.py
@@ -203,7 +203,7 @@ class TestIssueNotificationContext(MetricAlertHandlerBase):
 
     def test_organization(self) -> None:
         ctx = self._make_context()
-        assert ctx.organization == self.detector.project.organization
+        assert ctx.organization == self.detector.linked_project.organization
 
     def test_open_period(self) -> None:
         ctx = self._make_context()

--- a/tests/sentry/uptime/endpoints/test_project_uptime_alert_details.py
+++ b/tests/sentry/uptime/endpoints/test_project_uptime_alert_details.py
@@ -19,7 +19,9 @@ class ProjectUptimeAlertDetailsGetEndpointTest(ProjectUptimeAlertDetailsBaseEndp
     def test_simple(self) -> None:
         detector = self.create_uptime_detector()
 
-        resp = self.get_success_response(self.organization.slug, detector.project.slug, detector.id)
+        resp = self.get_success_response(
+            self.organization.slug, detector.linked_project.slug, detector.id
+        )
         assert resp.data == serialize(detector, self.user, UptimeDetectorSerializer())
 
     def test_not_found(self) -> None:
@@ -34,7 +36,7 @@ class ProjectUptimeAlertDetailsGetEndpointTest(ProjectUptimeAlertDetailsBaseEndp
         )
 
         resp = self.get_error_response(
-            self.organization.slug, onboarding_detector.project.slug, onboarding_detector.id
+            self.organization.slug, onboarding_detector.linked_project.slug, onboarding_detector.id
         )
         assert resp.status_code == 404
 
@@ -43,7 +45,9 @@ class ProjectUptimeAlertDetailsGetEndpointTest(ProjectUptimeAlertDetailsBaseEndp
         detector = self.create_uptime_detector()
         detector.update(status=ObjectStatus.DISABLED, enabled=False)
 
-        resp = self.get_success_response(self.organization.slug, detector.project.slug, detector.id)
+        resp = self.get_success_response(
+            self.organization.slug, detector.linked_project.slug, detector.id
+        )
         assert resp.data == serialize(detector, self.user, UptimeDetectorSerializer())
 
 
@@ -55,7 +59,7 @@ class ProjectUptimeAlertDetailsPutEndpointTest(ProjectUptimeAlertDetailsBaseEndp
         uptime_sub = get_uptime_subscription(detector)
         resp = self.get_success_response(
             self.organization.slug,
-            detector.project.slug,
+            detector.linked_project.slug,
             detector.id,
             environment="uptime-prod",
             name="test",
@@ -83,7 +87,7 @@ class ProjectUptimeAlertDetailsPutEndpointTest(ProjectUptimeAlertDetailsBaseEndp
 
         resp = self.get_success_response(
             self.organization.slug,
-            detector.project.slug,
+            detector.linked_project.slug,
             detector.id,
             name="test",
             owner=f"user:{self.user.id}",
@@ -111,7 +115,7 @@ class ProjectUptimeAlertDetailsPutEndpointTest(ProjectUptimeAlertDetailsBaseEndp
 
         resp = self.get_success_response(
             self.organization.slug,
-            detector.project.slug,
+            detector.linked_project.slug,
             detector.id,
             name="test",
             environment="uptime-prod",
@@ -126,7 +130,7 @@ class ProjectUptimeAlertDetailsPutEndpointTest(ProjectUptimeAlertDetailsBaseEndp
 
         resp = self.get_success_response(
             self.organization.slug,
-            detector.project.slug,
+            detector.linked_project.slug,
             detector.id,
             name="test",
             owner=f"user:{self.user.id}",
@@ -141,7 +145,7 @@ class ProjectUptimeAlertDetailsPutEndpointTest(ProjectUptimeAlertDetailsBaseEndp
         detector = self.create_uptime_detector()
         resp = self.get_success_response(
             self.organization.slug,
-            detector.project.slug,
+            detector.linked_project.slug,
             detector.id,
             name="test_2",
             owner=f"team:{self.team.id}",
@@ -158,7 +162,7 @@ class ProjectUptimeAlertDetailsPutEndpointTest(ProjectUptimeAlertDetailsBaseEndp
 
         resp = self.get_error_response(
             self.organization.slug,
-            detector.project.slug,
+            detector.linked_project.slug,
             detector.id,
             owner=f"user:{bad_user.id}",
         )
@@ -172,7 +176,7 @@ class ProjectUptimeAlertDetailsPutEndpointTest(ProjectUptimeAlertDetailsBaseEndp
 
         resp = self.get_error_response(
             self.organization.slug,
-            detector.project.slug,
+            detector.linked_project.slug,
             detector.id,
             owner=f"team:{bad_team.id}",
         )
@@ -202,7 +206,7 @@ class ProjectUptimeAlertDetailsPutEndpointTest(ProjectUptimeAlertDetailsBaseEndp
         detector = self.create_uptime_detector()
         resp = self.get_error_response(
             self.organization.slug,
-            detector.project.slug,
+            detector.linked_project.slug,
             detector.id,
             status_code=400,
             url="https://test-two.example.com",
@@ -216,7 +220,7 @@ class ProjectUptimeAlertDetailsPutEndpointTest(ProjectUptimeAlertDetailsBaseEndp
         detector = self.create_uptime_detector()
         resp = self.get_success_response(
             self.organization.slug,
-            detector.project.slug,
+            detector.linked_project.slug,
             detector.id,
             name="test_2",
             status="disabled",
@@ -230,7 +234,7 @@ class ProjectUptimeAlertDetailsPutEndpointTest(ProjectUptimeAlertDetailsBaseEndp
         detector = self.create_uptime_detector(enabled=False)
         resp = self.get_success_response(
             self.organization.slug,
-            detector.project.slug,
+            detector.linked_project.slug,
             detector.id,
             name="test_2",
             status="active",
@@ -246,7 +250,7 @@ class ProjectUptimeAlertDetailsPutEndpointTest(ProjectUptimeAlertDetailsBaseEndp
 
         resp = self.get_success_response(
             self.organization.slug,
-            detector.project.slug,
+            detector.linked_project.slug,
             detector.id,
             name="test",
             response_capture_enabled=False,
@@ -258,7 +262,7 @@ class ProjectUptimeAlertDetailsPutEndpointTest(ProjectUptimeAlertDetailsBaseEndp
 
         resp = self.get_success_response(
             self.organization.slug,
-            detector.project.slug,
+            detector.linked_project.slug,
             detector.id,
             name="test",
             response_capture_enabled=True,
@@ -276,7 +280,7 @@ class ProjectUptimeAlertDetailsPutEndpointTest(ProjectUptimeAlertDetailsBaseEndp
 
         self.get_success_response(
             self.organization.slug,
-            detector.project.slug,
+            detector.linked_project.slug,
             detector.id,
             name="test",
             response_capture_enabled=False,
@@ -301,7 +305,7 @@ class ProjectUptimeAlertDetailsPutEndpointTest(ProjectUptimeAlertDetailsBaseEndp
         detector = self.create_uptime_detector(enabled=False)
         resp = self.get_error_response(
             self.organization.slug,
-            detector.project.slug,
+            detector.linked_project.slug,
             detector.id,
             name="test_2",
             status="active",
@@ -321,7 +325,7 @@ class ProjectUptimeAlertDetailsDeleteEndpointTest(ProjectUptimeAlertDetailsBaseE
         with self.tasks():
             self.get_success_response(
                 self.organization.slug,
-                detector.project.slug,
+                detector.linked_project.slug,
                 detector.id,
                 status_code=202,
             )

--- a/tests/sentry/uptime/endpoints/test_validators.py
+++ b/tests/sentry/uptime/endpoints/test_validators.py
@@ -158,7 +158,7 @@ class UptimeDomainCheckFailureValidatorTest(UptimeTestCase):
         condition_group = detector.workflow_condition_group
         assert condition_group is not None
         assert condition_group.logic_type == "any"
-        assert condition_group.organization_id == detector.project.organization_id
+        assert condition_group.organization_id == detector.linked_project.organization_id
 
         conditions = sorted(condition_group.conditions.all(), key=lambda c: c.comparison)
         assert len(conditions) == 2

--- a/tests/sentry/workflow_engine/models/test_incident_groupopenperiod.py
+++ b/tests/sentry/workflow_engine/models/test_incident_groupopenperiod.py
@@ -53,7 +53,7 @@ class IncidentGroupOpenPeriodTest(TestCase):
                 event_types=[SnubaQueryEventType.EventType.ERROR],
             )
             self.query_subscription = create_snuba_subscription(
-                project=self.detector.project,
+                project=self.detector.linked_project,
                 subscription_type=INCIDENTS_SNUBA_SUBSCRIPTION_TYPE,
                 snuba_query=self.snuba_query,
             )

--- a/tests/sentry/workflow_engine/test_base.py
+++ b/tests/sentry/workflow_engine/test_base.py
@@ -274,7 +274,7 @@ class BaseWorkflowTest(TestCase, OccurrenceTestMixin):
                 event_types=[SnubaQueryEventType.EventType.ERROR],
             )
             query_subscription = create_snuba_subscription(
-                project=detector.project,
+                project=detector.linked_project,
                 subscription_type=INCIDENTS_SNUBA_SUBSCRIPTION_TYPE,
                 snuba_query=snuba_query,
             )


### PR DESCRIPTION
sorry for all the codeowners pings 🙏 

we're looking to support a new detector for All Projects, but the current model (`Detector`) has a FK to Project. We can't use a random project without having issues with things like cascade deletions and project transfers so we're opting to make the column nullable.

That will introduce a lot of mypy issues though, so before that migration we're addressing those here.

Tech Spec - https://app.notion.com/p/sentry/Spec-All-Projects-Default-Alert-Migration-8e48b10e4b5d821fb1c581cc65e65c32?source=copy_link
Linear Ticket - https://linear.app/getsentry/issue/ISWF-3123/create-migration-to-support-all-projects

