### PR TITLE
feat(ai-monitoring): Return conversation title behind apiVersion=2

### DIFF
--- a/src/sentry/ai_monitoring/utils.py
+++ b/src/sentry/ai_monitoring/utils.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
+from django.db.models import F
 from sentry_conventions.attributes import ATTRIBUTE_NAMES
 from sentry_sdk import trace
 
@@ -81,6 +82,32 @@ def clamp_conversation_id_for_storage(conversation_id: str) -> str:
     if len(conversation_id) <= CONVERSATION_ID_MAX_LENGTH:
         return conversation_id
     return conversation_id[:CONVERSATION_ID_TRUNCATE_TO] + "..."
+
+
+def fetch_conversation_title(
+    conversation_id: str,
+    project_ids: Collection[int],
+) -> AIConversationMetadata | None:
+    """Look up the titled metadata row for one conversation across the given projects.
+
+    A conversation id is only unique within a project, so the same id can be titled in
+    several projects. The earliest title wins: titles come from the first user message,
+    so the smallest ``title_source_timestamp`` is the one closest to the start of the
+    conversation. Ordering happens in the database; ``project_id`` only breaks ties.
+    """
+    if not project_ids:
+        return None
+
+    return (
+        AIConversationMetadata.objects.filter(
+            project_id__in=set(project_ids),
+            conversation_id_hash=conversation_id_hash(conversation_id),
+            title__isnull=False,
+        )
+        .exclude(title="")
+        .order_by(F("title_source_timestamp").asc(nulls_last=True), "project_id")
+        .first()
+    )
 
 
 def fetch_conversation_titles(

--- a/src/sentry/api/endpoints/organization_ai_conversation_details.py
+++ b/src/sentry/api/endpoints/organization_ai_conversation_details.py
@@ -79,7 +79,7 @@ class AIConversationDetailsResponse(TypedDict):
 
     conversationId: str
     title: str | None
-    data: list[dict[str, Any]]
+    spans: list[dict[str, Any]]
 
 
 @cell_silo_endpoint
@@ -138,7 +138,7 @@ class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
                 return {
                     "conversationId": conversation_id,
                     "title": self._resolve_title(conversation_id, spans, organization),
-                    "data": spans,
+                    "spans": spans,
                 }
 
             return self.paginate(

--- a/src/sentry/api/endpoints/organization_ai_conversation_details.py
+++ b/src/sentry/api/endpoints/organization_ai_conversation_details.py
@@ -1,17 +1,21 @@
 import logging
+from collections.abc import Mapping, Sequence
 from dataclasses import replace
 from datetime import datetime, timedelta
+from typing import Any, TypedDict
 
 from django.utils import timezone
 from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
+from sentry.ai_monitoring.utils import fetch_conversation_title
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
+from sentry.api.serializers.rest_framework import OrganizationAIConversationDetailsSerializer
 from sentry.api.utils import handle_query_errors
 from sentry.models.organization import Organization
 from sentry.search.eap.occurrences.query_utils import build_escaped_term_filter
@@ -70,6 +74,14 @@ AI_CONVERSATION_ATTRIBUTES = [
 ]
 
 
+class AIConversationDetailsResponse(TypedDict):
+    """Response body for ``apiVersion=2``: the span page plus conversation-level metadata."""
+
+    conversationId: str
+    title: str | None
+    data: list[dict[str, Any]]
+
+
 @cell_silo_endpoint
 class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
     publish_status = {"GET": ApiPublishStatus.PRIVATE}
@@ -78,6 +90,11 @@ class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
     def get(self, request: Request, organization: Organization, conversation_id: str) -> Response:
         if not features.has("organizations:gen-ai-conversations", organization, actor=request.user):
             return Response(status=404)
+
+        serializer = OrganizationAIConversationDetailsSerializer(data=request.GET)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=400)
+        use_envelope = serializer.validated_data["apiVersion"] >= 2
 
         try:
             snuba_params = self.get_snuba_params(request, organization)
@@ -113,9 +130,21 @@ class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
                 self._annotate_issues(spans, resolved_params, organization)
                 return spans
 
+            def on_results(
+                spans: list[dict[str, Any]],
+            ) -> list[dict[str, Any]] | AIConversationDetailsResponse:
+                if not use_envelope:
+                    return spans
+                return {
+                    "conversationId": conversation_id,
+                    "title": self._resolve_title(conversation_id, spans, organization),
+                    "data": spans,
+                }
+
             return self.paginate(
                 request=request,
                 paginator=GenericOffsetPaginator(data_fn=data_fn),
+                on_results=on_results,
                 default_per_page=100,
                 max_per_page=1000,
             )
@@ -150,6 +179,37 @@ class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
                 steps.append(step)
 
         return [replace(base_params, start=now - delta, end=now) for delta in steps]
+
+    @trace
+    def _resolve_title(
+        self,
+        conversation_id: str,
+        spans: Sequence[Mapping[str, Any]],
+        organization: Organization,
+    ) -> str | None:
+        """Stored title for this conversation, or None when there is none yet.
+
+        Titles are keyed per project, so they are looked up against the projects of the
+        spans on this page; a conversation id titled in several projects can therefore
+        report a different title on a later page. Best-effort: a failed lookup must not
+        break listing the spans.
+        """
+        project_ids = {
+            project_id for span in spans if isinstance(project_id := span.get("project.id"), int)
+        }
+        if not project_ids:
+            return None
+
+        try:
+            stored_title = fetch_conversation_title(conversation_id, project_ids)
+        except Exception:
+            logger.exception(
+                "Failed to resolve title for AI conversation",
+                extra={"organization_id": organization.id},
+            )
+            return None
+
+        return stored_title.title if stored_title else None
 
     @trace
     def _annotate_issues(

--- a/src/sentry/api/serializers/rest_framework/ai_conversations.py
+++ b/src/sentry/api/serializers/rest_framework/ai_conversations.py
@@ -1,6 +1,13 @@
 from rest_framework import serializers
 
 
+class OrganizationAIConversationDetailsSerializer(serializers.Serializer):
+    # Version 1 is the historical bare list of spans; version 2 wraps it in an object
+    # carrying conversation metadata. Once clients move to 2 it becomes the default and
+    # this field goes away.
+    apiVersion = serializers.ChoiceField(choices=[1, 2], required=False, default=1)
+
+
 class OrganizationAIConversationsSerializer(serializers.Serializer):
     sort = serializers.CharField(required=False, default="-timestamp")
     query = serializers.CharField(required=False, allow_blank=True)

--- a/tests/sentry/ai_monitoring/test_utils.py
+++ b/tests/sentry/ai_monitoring/test_utils.py
@@ -1,4 +1,6 @@
-from sentry.ai_monitoring.utils import fetch_conversation_titles
+from datetime import UTC, datetime
+
+from sentry.ai_monitoring.utils import fetch_conversation_title, fetch_conversation_titles
 from sentry.testutils.cases import TestCase
 
 
@@ -87,3 +89,135 @@ class FetchConversationTitlesTest(TestCase):
             ("conv-1", self.project.id): "Owned by project one",
             ("conv-1", other_project.id): "Owned by project two",
         }
+
+
+class FetchConversationTitleTest(TestCase):
+    def test_returns_none_without_projects(self) -> None:
+        assert fetch_conversation_title("conv-1", []) is None
+
+    def test_returns_none_when_conversation_is_unknown(self) -> None:
+        self.create_ai_conversation_metadata(
+            project=self.project,
+            conversation_id="conv-1",
+            title="Reset my password",
+        )
+
+        assert fetch_conversation_title("conv-2", [self.project.id]) is None
+
+    def test_returns_stored_title(self) -> None:
+        source_timestamp = datetime(2024, 5, 1, tzinfo=UTC)
+        self.create_ai_conversation_metadata(
+            project=self.project,
+            conversation_id="conv-1",
+            title="Reset my password",
+            title_source_timestamp=source_timestamp,
+        )
+
+        stored = fetch_conversation_title("conv-1", [self.project.id])
+
+        assert stored is not None
+        assert stored.project_id == self.project.id
+        assert stored.title == "Reset my password"
+        assert stored.title_source_timestamp == source_timestamp
+
+    def test_skips_untitled_rows(self) -> None:
+        self.create_ai_conversation_metadata(
+            project=self.project,
+            conversation_id="conv-1",
+            title=None,
+        )
+
+        assert fetch_conversation_title("conv-1", [self.project.id]) is None
+
+    def test_ignores_projects_that_were_not_requested(self) -> None:
+        other_project = self.create_project(organization=self.organization)
+        self.create_ai_conversation_metadata(
+            project=other_project,
+            conversation_id="conv-1",
+            title="Owned by project two",
+        )
+
+        assert fetch_conversation_title("conv-1", [self.project.id]) is None
+
+    def test_earliest_source_timestamp_wins(self) -> None:
+        other_project = self.create_project(organization=self.organization)
+        self.create_ai_conversation_metadata(
+            project=self.project,
+            conversation_id="conv-1",
+            title="Later half of the conversation",
+            title_source_timestamp=datetime(2024, 5, 1, 12, 0, tzinfo=UTC),
+        )
+        self.create_ai_conversation_metadata(
+            project=other_project,
+            conversation_id="conv-1",
+            title="Start of the conversation",
+            title_source_timestamp=datetime(2024, 5, 1, 11, 0, tzinfo=UTC),
+        )
+
+        stored = fetch_conversation_title("conv-1", [self.project.id, other_project.id])
+
+        assert stored is not None
+        assert stored.project_id == other_project.id
+        assert stored.title == "Start of the conversation"
+
+    def test_rows_without_source_timestamp_lose(self) -> None:
+        other_project = self.create_project(organization=self.organization)
+        self.create_ai_conversation_metadata(
+            project=self.project,
+            conversation_id="conv-1",
+            title="Unknown when this started",
+            title_source_timestamp=None,
+        )
+        self.create_ai_conversation_metadata(
+            project=other_project,
+            conversation_id="conv-1",
+            title="Start of the conversation",
+            title_source_timestamp=datetime(2024, 5, 1, 11, 0, tzinfo=UTC),
+        )
+
+        stored = fetch_conversation_title("conv-1", [self.project.id, other_project.id])
+
+        assert stored is not None
+        assert stored.title == "Start of the conversation"
+
+    def test_falls_back_to_row_without_source_timestamp(self) -> None:
+        row = self.create_ai_conversation_metadata(
+            project=self.project,
+            conversation_id="conv-1",
+            title="Unknown when this started",
+            title_source_timestamp=None,
+        )
+        assert row.title_source_timestamp is None
+
+        stored = fetch_conversation_title("conv-1", [self.project.id])
+
+        assert stored is not None
+        assert stored.title == "Unknown when this started"
+
+    def test_ties_break_on_project_id(self) -> None:
+        source_timestamp = datetime(2024, 5, 1, tzinfo=UTC)
+        lower_project, higher_project = sorted(
+            (
+                self.create_project(organization=self.organization),
+                self.create_project(organization=self.organization),
+            ),
+            key=lambda project: project.id,
+        )
+
+        self.create_ai_conversation_metadata(
+            project=lower_project,
+            conversation_id="conv-1",
+            title="Lower project id",
+            title_source_timestamp=source_timestamp,
+        )
+        self.create_ai_conversation_metadata(
+            project=higher_project,
+            conversation_id="conv-1",
+            title="Higher project id",
+            title_source_timestamp=source_timestamp,
+        )
+
+        stored = fetch_conversation_title("conv-1", [lower_project.id, higher_project.id])
+
+        assert stored is not None
+        assert stored.project_id == lower_project.id

--- a/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
@@ -40,6 +40,17 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
                 **kwargs,
             )
 
+    def _store_conversation_span(self, conversation_id, timestamp, project=None) -> None:
+        """One minimal span, enough for the conversation to resolve to a project."""
+        self.store_ai_span(
+            conversation_id=conversation_id,
+            timestamp=timestamp,
+            op="gen_ai.chat",
+            operation_type="ai_client",
+            trace_id=uuid4().hex,
+            project=project,
+        )
+
     def test_no_feature(self) -> None:
         conversation_id = uuid4().hex
         response = self.do_request(conversation_id, features=[])
@@ -690,3 +701,268 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         assert occurrence_issue["event_type"] == "occurrence"
         assert occurrence_issue["issue_id"] == group_info.group.id
         assert occurrence_issue["description"] == "File IO on Main Thread"
+
+    def test_default_and_api_version_1_return_a_bare_span_list(self) -> None:
+        now = before_now(days=5).replace(microsecond=0)
+        conversation_id = uuid4().hex
+
+        self._store_conversation_span(conversation_id, now)
+
+        query: dict[str, Any] = {
+            "project": [self.project.id],
+            "start": (now - timedelta(hours=1)).isoformat(),
+            "end": (now + timedelta(hours=1)).isoformat(),
+        }
+
+        default_response = self.do_request(conversation_id, query)
+        v1_response = self.do_request(conversation_id, {**query, "apiVersion": "1"})
+
+        assert default_response.status_code == 200
+        assert v1_response.status_code == 200
+        assert isinstance(default_response.data, list)
+        assert len(default_response.data) == 1
+        assert v1_response.data == default_response.data
+
+    def test_api_version_2_wraps_spans_under_data(self) -> None:
+        now = before_now(days=5).replace(microsecond=0)
+        conversation_id = uuid4().hex
+
+        self._store_conversation_span(conversation_id, now)
+
+        query: dict[str, Any] = {
+            "project": [self.project.id],
+            "start": (now - timedelta(hours=1)).isoformat(),
+            "end": (now + timedelta(hours=1)).isoformat(),
+        }
+
+        v1_response = self.do_request(conversation_id, query)
+        response = self.do_request(conversation_id, {**query, "apiVersion": "2"})
+
+        assert response.status_code == 200
+        assert set(response.data) == {"conversationId", "title", "data"}
+        assert response.data["conversationId"] == conversation_id
+        assert response.data["data"] == v1_response.data
+
+    def test_api_version_2_returns_stored_title(self) -> None:
+        now = before_now(days=5).replace(microsecond=0)
+        conversation_id = uuid4().hex
+
+        self._store_conversation_span(conversation_id, now)
+        self.create_ai_conversation_metadata(
+            project=self.project,
+            conversation_id=conversation_id,
+            title="Refund a duplicate charge",
+            title_source_timestamp=now,
+        )
+
+        query = {
+            "project": [self.project.id],
+            "apiVersion": "2",
+            "start": (now - timedelta(hours=1)).isoformat(),
+            "end": (now + timedelta(hours=1)).isoformat(),
+        }
+
+        response = self.do_request(conversation_id, query)
+        assert response.status_code == 200
+        assert response.data["title"] == "Refund a duplicate charge"
+        assert len(response.data["data"]) == 1
+
+    def test_api_version_2_title_is_null_without_metadata(self) -> None:
+        now = before_now(days=5).replace(microsecond=0)
+        conversation_id = uuid4().hex
+
+        self._store_conversation_span(conversation_id, now)
+
+        query = {
+            "project": [self.project.id],
+            "apiVersion": "2",
+            "start": (now - timedelta(hours=1)).isoformat(),
+            "end": (now + timedelta(hours=1)).isoformat(),
+        }
+
+        response = self.do_request(conversation_id, query)
+        assert response.status_code == 200
+        assert response.data["title"] is None
+
+    def test_api_version_2_title_is_null_when_row_is_untitled(self) -> None:
+        now = before_now(days=5).replace(microsecond=0)
+        conversation_id = uuid4().hex
+
+        self._store_conversation_span(conversation_id, now)
+        self.create_ai_conversation_metadata(
+            project=self.project,
+            conversation_id=conversation_id,
+            title=None,
+        )
+
+        query = {
+            "project": [self.project.id],
+            "apiVersion": "2",
+            "start": (now - timedelta(hours=1)).isoformat(),
+            "end": (now + timedelta(hours=1)).isoformat(),
+        }
+
+        response = self.do_request(conversation_id, query)
+        assert response.status_code == 200
+        assert response.data["title"] is None
+
+    def test_api_version_2_title_not_taken_from_unrelated_project(self) -> None:
+        """A same-named conversation in a project without spans must not supply the title."""
+        now = before_now(days=5).replace(microsecond=0)
+        conversation_id = uuid4().hex
+        other_project = self.create_project(organization=self.organization)
+
+        self._store_conversation_span(conversation_id, now)
+        self.create_ai_conversation_metadata(
+            project=other_project,
+            conversation_id=conversation_id,
+            title="Someone else's conversation",
+            title_source_timestamp=now,
+        )
+
+        query = {
+            "project": [self.project.id, other_project.id],
+            "apiVersion": "2",
+            "start": (now - timedelta(hours=1)).isoformat(),
+            "end": (now + timedelta(hours=1)).isoformat(),
+        }
+
+        response = self.do_request(conversation_id, query)
+        assert response.status_code == 200
+        assert response.data["title"] is None
+
+    def test_api_version_2_earliest_titled_project_wins(self) -> None:
+        """A conversation spanning projects is titled from the earliest title source."""
+        now = before_now(days=5).replace(microsecond=0)
+        conversation_id = uuid4().hex
+        other_project = self.create_project(organization=self.organization)
+
+        self._store_conversation_span(conversation_id, now - timedelta(seconds=2))
+        self._store_conversation_span(
+            conversation_id, now - timedelta(seconds=1), project=other_project
+        )
+
+        self.create_ai_conversation_metadata(
+            project=self.project,
+            conversation_id=conversation_id,
+            title="Started here",
+            title_source_timestamp=now - timedelta(seconds=2),
+        )
+        self.create_ai_conversation_metadata(
+            project=other_project,
+            conversation_id=conversation_id,
+            title="Continued here",
+            title_source_timestamp=now - timedelta(seconds=1),
+        )
+
+        query = {
+            "project": [self.project.id, other_project.id],
+            "apiVersion": "2",
+            "start": (now - timedelta(hours=1)).isoformat(),
+            "end": (now + timedelta(hours=1)).isoformat(),
+        }
+
+        response = self.do_request(conversation_id, query)
+        assert response.status_code == 200
+        assert len(response.data["data"]) == 2
+        assert response.data["title"] == "Started here"
+
+    def test_api_version_2_conversation_not_found(self) -> None:
+        now = before_now(days=5).replace(microsecond=0)
+        conversation_id = uuid4().hex
+
+        self._store_conversation_span(uuid4().hex, now)
+
+        query = {
+            "project": [self.project.id],
+            "apiVersion": "2",
+            "start": (now - timedelta(hours=1)).isoformat(),
+            "end": (now + timedelta(hours=1)).isoformat(),
+        }
+
+        response = self.do_request(conversation_id, query)
+        assert response.status_code == 200
+        assert response.data["conversationId"] == conversation_id
+        assert response.data["title"] is None
+        assert response.data["data"] == []
+
+    def test_api_version_2_paginates(self) -> None:
+        now = before_now(days=5).replace(microsecond=0)
+        conversation_id = uuid4().hex
+        trace_id = uuid4().hex
+
+        for i in range(3):
+            self.store_ai_span(
+                conversation_id=conversation_id,
+                timestamp=now - timedelta(seconds=i),
+                op="gen_ai.chat",
+                trace_id=trace_id,
+            )
+        self.create_ai_conversation_metadata(
+            project=self.project,
+            conversation_id=conversation_id,
+            title="Long conversation",
+            title_source_timestamp=now,
+        )
+
+        query: dict[str, Any] = {
+            "project": [self.project.id],
+            "apiVersion": "2",
+            "per_page": "2",
+            "start": (now - timedelta(hours=1)).isoformat(),
+            "end": (now + timedelta(hours=1)).isoformat(),
+        }
+
+        response = self.do_request(conversation_id, query)
+        assert response.status_code == 200
+        assert response.data["title"] == "Long conversation"
+        assert len(response.data["data"]) == 2
+
+        links = parse_link_header(response.headers["Link"])
+        next_link = next(link for link in links.values() if link["rel"] == "next")
+        assert next_link["results"] == "true"
+
+        query["cursor"] = next_link["cursor"]
+        response = self.do_request(conversation_id, query)
+        assert response.status_code == 200
+        assert response.data["title"] == "Long conversation"
+        assert len(response.data["data"]) == 1
+
+    @patch(
+        "sentry.api.endpoints.organization_ai_conversation_details.fetch_conversation_title",
+        side_effect=Exception("metadata unavailable"),
+    )
+    def test_api_version_2_survives_a_failing_title_lookup(
+        self, mock_fetch_conversation_title: MagicMock
+    ) -> None:
+        now = before_now(days=5).replace(microsecond=0)
+        conversation_id = uuid4().hex
+
+        self._store_conversation_span(conversation_id, now)
+
+        query = {
+            "project": [self.project.id],
+            "apiVersion": "2",
+            "start": (now - timedelta(hours=1)).isoformat(),
+            "end": (now + timedelta(hours=1)).isoformat(),
+        }
+
+        response = self.do_request(conversation_id, query)
+        assert response.status_code == 200
+        assert response.data["title"] is None
+        assert len(response.data["data"]) == 1
+        assert mock_fetch_conversation_title.call_count == 1
+
+    def test_unsupported_api_version_returns_400(self) -> None:
+        query = {"project": [self.project.id], "apiVersion": "3"}
+
+        response = self.do_request(uuid4().hex, query)
+        assert response.status_code == 400
+        assert "apiVersion" in response.data
+
+    def test_non_numeric_api_version_returns_400(self) -> None:
+        query = {"project": [self.project.id], "apiVersion": "v2"}
+
+        response = self.do_request(uuid4().hex, query)
+        assert response.status_code == 400
+        assert "apiVersion" in response.data

--- a/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
@@ -723,7 +723,7 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         assert len(default_response.data) == 1
         assert v1_response.data == default_response.data
 
-    def test_api_version_2_wraps_spans_under_data(self) -> None:
+    def test_api_version_2_wraps_spans_under_spans(self) -> None:
         now = before_now(days=5).replace(microsecond=0)
         conversation_id = uuid4().hex
 
@@ -739,9 +739,9 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         response = self.do_request(conversation_id, {**query, "apiVersion": "2"})
 
         assert response.status_code == 200
-        assert set(response.data) == {"conversationId", "title", "data"}
+        assert set(response.data) == {"conversationId", "title", "spans"}
         assert response.data["conversationId"] == conversation_id
-        assert response.data["data"] == v1_response.data
+        assert response.data["spans"] == v1_response.data
 
     def test_api_version_2_returns_stored_title(self) -> None:
         now = before_now(days=5).replace(microsecond=0)
@@ -765,7 +765,7 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         response = self.do_request(conversation_id, query)
         assert response.status_code == 200
         assert response.data["title"] == "Refund a duplicate charge"
-        assert len(response.data["data"]) == 1
+        assert len(response.data["spans"]) == 1
 
     def test_api_version_2_title_is_null_without_metadata(self) -> None:
         now = before_now(days=5).replace(microsecond=0)
@@ -864,7 +864,7 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
         response = self.do_request(conversation_id, query)
         assert response.status_code == 200
-        assert len(response.data["data"]) == 2
+        assert len(response.data["spans"]) == 2
         assert response.data["title"] == "Started here"
 
     def test_api_version_2_conversation_not_found(self) -> None:
@@ -884,7 +884,7 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         assert response.status_code == 200
         assert response.data["conversationId"] == conversation_id
         assert response.data["title"] is None
-        assert response.data["data"] == []
+        assert response.data["spans"] == []
 
     def test_api_version_2_paginates(self) -> None:
         now = before_now(days=5).replace(microsecond=0)
@@ -916,7 +916,7 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         response = self.do_request(conversation_id, query)
         assert response.status_code == 200
         assert response.data["title"] == "Long conversation"
-        assert len(response.data["data"]) == 2
+        assert len(response.data["spans"]) == 2
 
         links = parse_link_header(response.headers["Link"])
         next_link = next(link for link in links.values() if link["rel"] == "next")
@@ -926,7 +926,7 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         response = self.do_request(conversation_id, query)
         assert response.status_code == 200
         assert response.data["title"] == "Long conversation"
-        assert len(response.data["data"]) == 1
+        assert len(response.data["spans"]) == 1
 
     @patch(
         "sentry.api.endpoints.organization_ai_conversation_details.fetch_conversation_title",
@@ -950,7 +950,7 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         response = self.do_request(conversation_id, query)
         assert response.status_code == 200
         assert response.data["title"] is None
-        assert len(response.data["data"]) == 1
+        assert len(response.data["spans"]) == 1
         assert mock_fetch_conversation_title.call_count == 1
 
     def test_unsupported_api_version_returns_400(self) -> None:


### PR DESCRIPTION
Follow up to #120665, which added `title` to the conversations list and left the details endpoint alone because adding one there breaks its response shape.

That endpoint returns a bare array of spans, so there is nowhere to put a field that describes the conversation rather than a span. Passing `apiVersion=2` now returns an object instead, with the spans moved under `spans`:

```jsonc
// no apiVersion, or apiVersion=1 — unchanged
[ {span}, {span} ]

// apiVersion=2
{
  "conversationId": "abc",
  "title": "Refund a duplicate charge",  // null when nothing has been titled yet
  "spans": [ {span}, {span} ]
}
```

Requests that don't send the parameter keep the old array, so this lands without touching the UI. The frontend switches over in its own PR, and only once it pins `apiVersion=2` explicitly does flipping the default become safe for cached bundles. An unsupported value is a 400 rather than a silent fallback. Pagination is unaffected either way — cursors live in the `Link` header, not the body.
