### PR TITLE
chore(workflow-engine): Modify cache utils to fix failing tests 

### DIFF
--- a/src/sentry/uptime/models.py
+++ b/src/sentry/uptime/models.py
@@ -162,11 +162,7 @@ def get_org_from_detector(detector: Detector) -> tuple[Organization] | None:
         return None
 
 
-def get_org_from_project(project: Project) -> tuple[Organization]:
-    return (project.organization,)
-
-
-@cache_func_for_models([(Detector, get_org_from_detector), (Project, get_org_from_project)])
+@cache_func_for_models([(Detector, get_org_from_detector)])
 def get_active_auto_monitor_count_for_org(organization: Organization) -> int:
     return Detector.objects.filter(
         status=ObjectStatus.ACTIVE,

--- a/src/sentry/uptime/models.py
+++ b/src/sentry/uptime/models.py
@@ -162,7 +162,11 @@ def get_org_from_detector(detector: Detector) -> tuple[Organization] | None:
         return None
 
 
-@cache_func_for_models([(Detector, get_org_from_detector)])
+def get_org_from_project(project: Project) -> tuple[Organization]:
+    return (project.organization,)
+
+
+@cache_func_for_models([(Detector, get_org_from_detector), (Project, get_org_from_project)])
 def get_active_auto_monitor_count_for_org(organization: Organization) -> int:
     return Detector.objects.filter(
         status=ObjectStatus.ACTIVE,

--- a/src/sentry/uptime/models.py
+++ b/src/sentry/uptime/models.py
@@ -19,6 +19,7 @@ from sentry.db.models.manager.base import BaseManager
 from sentry.deletions.base import ModelRelation
 from sentry.models.files.file import File
 from sentry.models.organization import Organization
+from sentry.models.project import Project
 from sentry.remote_subscriptions.models import BaseRemoteSubscription
 from sentry.uptime.types import (
     DATA_SOURCE_UPTIME_SUBSCRIPTION,
@@ -152,8 +153,13 @@ class UptimeSubscriptionRegion(DefaultFieldsModel):
         ]
 
 
-def get_org_from_detector(detector: Detector) -> tuple[Organization]:
-    return (detector.linked_project.organization,)
+def get_org_from_detector(detector: Detector) -> tuple[Organization] | None:
+    if detector.project_id is None:
+        return None
+    try:
+        return (detector.linked_project.organization,)
+    except Project.DoesNotExist:
+        return None
 
 
 @cache_func_for_models([(Detector, get_org_from_detector)])

--- a/src/sentry/utils/function_cache.py
+++ b/src/sentry/utils/function_cache.py
@@ -50,6 +50,8 @@ def clear_cache_for_cached_func(
     **kwargs: object,
 ) -> None:
     func_args = arg_getter(instance)
+    if func_args is None:
+        return
     cache_key = cache_key_for_cached_func(cached_func, *func_args)
     if recalculate:
         try:

--- a/src/sentry/utils/function_cache.py
+++ b/src/sentry/utils/function_cache.py
@@ -43,7 +43,7 @@ def cache_key_for_cached_func(cached_func: Callable[[*Ts], R], *args: *Ts) -> st
 
 def clear_cache_for_cached_func(
     cached_func: Callable[[*Ts], R],
-    arg_getter: Callable[[S], tuple[*Ts]],
+    arg_getter: Callable[[S], tuple[*Ts] | None],
     recalculate: bool,
     instance: S,
     *args: object,
@@ -66,7 +66,7 @@ def clear_cache_for_cached_func(
 
 
 def cache_func_for_models(
-    cache_invalidators: list[tuple[type[S], Callable[[S], tuple[*Ts]]]],
+    cache_invalidators: list[tuple[type[S], Callable[[S], tuple[*Ts] | None]]],
     cache_ttl: None | timedelta = None,
     recalculate: bool = True,
 ) -> Callable[[Callable[[*Ts], R]], CachedFunction[*Ts, R]]:

--- a/tests/sentry/uptime/test_models.py
+++ b/tests/sentry/uptime/test_models.py
@@ -2,8 +2,11 @@ from io import BytesIO
 from unittest import mock
 
 import pytest
+from django.core.cache import cache as django_cache
+from django.db.models.signals import post_delete
 
 from sentry.models.files.file import File
+from sentry.models.project import Project
 from sentry.testutils.cases import UptimeTestCase
 from sentry.uptime.models import (
     UptimeResponseCapture,
@@ -13,6 +16,7 @@ from sentry.uptime.models import (
     get_top_hosting_provider_names,
 )
 from sentry.uptime.types import DATA_SOURCE_UPTIME_SUBSCRIPTION, UptimeMonitorMode
+from sentry.utils.function_cache import cache_key_for_cached_func
 from sentry.workflow_engine.models.detector import Detector
 
 
@@ -32,6 +36,23 @@ class GetActiveMonitorCountForOrgTest(UptimeTestCase):
         self.create_uptime_detector(uptime_subscription=other_org_sub, project=other_proj)
         assert get_active_auto_monitor_count_for_org(self.organization) == 2
         assert get_active_auto_monitor_count_for_org(other_org) == 1
+
+    def test_cache_invalidated_on_project_delete(self) -> None:
+        # Note: This test adds fake data to django's cache to ensure some upcoming behaviour when we
+        # migrate Detector's Project FK to be nullable. We can't just test it normally at the moment
+        # because the cascade deletion order hasn't changed yet.
+        # See https://github.com/getsentry/sentry/pull/120747 for details.
+        self.create_uptime_detector()
+        assert get_active_auto_monitor_count_for_org(self.organization) == 1
+
+        cache_key = cache_key_for_cached_func(
+            get_active_auto_monitor_count_for_org.func, self.organization
+        )
+        django_cache.set(cache_key, 999)
+        assert get_active_auto_monitor_count_for_org(self.organization) == 999
+
+        post_delete.send(sender=Project, instance=self.project)
+        assert get_active_auto_monitor_count_for_org(self.organization) != 999
 
 
 class GetTopHostingProviderNamesTest(UptimeTestCase):

--- a/tests/sentry/uptime/test_models.py
+++ b/tests/sentry/uptime/test_models.py
@@ -2,11 +2,8 @@ from io import BytesIO
 from unittest import mock
 
 import pytest
-from django.core.cache import cache as django_cache
-from django.db.models.signals import post_delete
 
 from sentry.models.files.file import File
-from sentry.models.project import Project
 from sentry.testutils.cases import UptimeTestCase
 from sentry.uptime.models import (
     UptimeResponseCapture,
@@ -16,7 +13,6 @@ from sentry.uptime.models import (
     get_top_hosting_provider_names,
 )
 from sentry.uptime.types import DATA_SOURCE_UPTIME_SUBSCRIPTION, UptimeMonitorMode
-from sentry.utils.function_cache import cache_key_for_cached_func
 from sentry.workflow_engine.models.detector import Detector
 
 
@@ -36,23 +32,6 @@ class GetActiveMonitorCountForOrgTest(UptimeTestCase):
         self.create_uptime_detector(uptime_subscription=other_org_sub, project=other_proj)
         assert get_active_auto_monitor_count_for_org(self.organization) == 2
         assert get_active_auto_monitor_count_for_org(other_org) == 1
-
-    def test_cache_invalidated_on_project_delete(self) -> None:
-        # Note: This test adds fake data to django's cache to ensure some upcoming behaviour when we
-        # migrate Detector's Project FK to be nullable. We can't just test it normally at the moment
-        # because the cascade deletion order hasn't changed yet.
-        # See https://github.com/getsentry/sentry/pull/120747 for details.
-        self.create_uptime_detector()
-        assert get_active_auto_monitor_count_for_org(self.organization) == 1
-
-        cache_key = cache_key_for_cached_func(
-            get_active_auto_monitor_count_for_org.func, self.organization
-        )
-        django_cache.set(cache_key, 999)
-        assert get_active_auto_monitor_count_for_org(self.organization) == 999
-
-        post_delete.send(sender=Project, instance=self.project)
-        assert get_active_auto_monitor_count_for_org(self.organization) != 999
 
 
 class GetTopHostingProviderNamesTest(UptimeTestCase):


### PR DESCRIPTION
The cascade deletions cause issues with these caching functions. The test failures can be [seen in the migration PR](https://github.com/getsentry/sentry/pull/120687#issuecomment-5106116900). I'm not too familiar with these utilities but from my understanding:
- It's causing failures because the cascade deletion order has changed
- with the NOT NULL key to Project: the Detector was always deleted before the Project, meaning Detector's post_delete fires, and that Project is still in the DB, so detector.project.organization (on the in-memory Detector) still works.
- with the nulllable FK to Project: Django does not ensure that Detector's post_delete happens before the Project row is removed. When the Project is removed first, the caching function hits the DoesNotExist error.

I consulted claude about this ordering change, who added:
> the reason the ordering changes is specific to how Django's cascade collector works. It tracks dependencies between models to determine deletion order, but it only registers a dependency when the FK is NOT NULL (line 136 of django/db/models/deletion.py: if source is not None and not nullable). And the CASCADE handler passes nullable=field.null (line 27). So making the FK nullable literally removes the ordering constraint that kept Detector-before-Project, and the deletion order becomes arbitrary.

Previous PR: https://github.com/getsentry/sentry/pull/120744
Next PR: https://github.com/getsentry/sentry/pull/120687