### PR TITLE
ref: Move subscription flags to flagpole

### DIFF
--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -48,9 +48,6 @@ def register_permanent_features(manager: FeatureManager) -> None:
         # Enable integration functionality to work with alert rules (specifically incident
         # management integrations)
         "organizations:integrations-incident-management": True,
-        # Enable integration functionality to create and link groups to issues on
-        # external services.
-        "organizations:integrations-issue-basic": True,
         # Enable interface functionality to synchronize groups between sentry and
         # issues on external services.
         "organizations:integrations-issue-sync": True,
@@ -66,10 +63,6 @@ def register_permanent_features(manager: FeatureManager) -> None:
         "organizations:session-replay": False,
         # Measure usage by spans instead of transactions
         "organizations:spans-usage-tracking": False,
-        # Enable basic SSO functionality, providing configurable single sign on
-        # using services like GitHub / Google. This is *not* the same as the signup
-        # and login with Github / Azure DevOps that sentry.io provides.
-        "organizations:sso-basic": True,
         # Enable SAML2 based SSO functionality. getsentry/sentry-auth-saml2 plugin
         # must be installed to use this functionality.
         "organizations:sso-saml2": True,
@@ -154,6 +147,13 @@ def register_permanent_features(manager: FeatureManager) -> None:
         "organizations:team-insights": FlagpoleFeature(default=True, api_expose=True),
         # Enable setting team-level roles and receiving permissions from them
         "organizations:team-roles": FlagpoleFeature(default=True, api_expose=True),
+        # Enable integration functionality to create and link groups to issues on
+        # external services.
+        "organizations:integrations-issue-basic": FlagpoleFeature(default=True, api_expose=True),
+        # Enable basic SSO functionality, providing configurable single sign on
+        # using services like GitHub / Google. This is *not* the same as the signup
+        # and login with Github / Azure DevOps that sentry.io provides.
+        "organizations:sso-basic": FlagpoleFeature(default=True, api_expose=True),
     }
 
     # Flagpole cannot control system-scoped flags — keep these as INTERNAL.


### PR DESCRIPTION
These flags can be moved to flagpole using the is-free property