### PR TITLE
feat(issue-progress): Add backfill task for new PR lifecycle log types

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -963,6 +963,7 @@ TASKWORKER_IMPORTS: tuple[str, ...] = (
     "sentry.tasks.auth.cleanup_pending_users",
     "sentry.tasks.auto_ongoing_issues",
     "sentry.tasks.backfill_group_action_log",
+    "sentry.tasks.backfill_pr_lifecycle_action_log",
     "sentry.tasks.auto_remove_inbox",
     "sentry.tasks.auto_resolve_issues",
     "sentry.tasks.auto_source_code_config",

--- a/src/sentry/issues/action_log/backfill.py
+++ b/src/sentry/issues/action_log/backfill.py
@@ -12,6 +12,7 @@ import logging
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime
+from typing import NamedTuple
 
 from django.db import connections, router, transaction
 from django.utils import timezone
@@ -49,14 +50,6 @@ _PR_LIFECYCLE_ACTION_TYPES = (
     GroupActionType.PULL_REQUEST_UNLINKED,
 )
 
-# Lifecycle actions that leave a pull request finished as far as the log is concerned.
-# When one of these is the last action logged for a pull request that is open, the
-# reopen went unlogged and is reconstructed by the backfill.
-_TERMINAL_PR_LIFECYCLE_ACTION_TYPES = (
-    GroupActionType.PULL_REQUEST_CLOSED,
-    GroupActionType.PULL_REQUEST_MERGED,
-)
-
 
 @dataclass(frozen=True)
 class BackfillEntry:
@@ -67,6 +60,13 @@ class BackfillEntry:
     source: str
     date_added: datetime
     idempotency_key: str
+
+
+class _PullRequestLifecycleDetails(NamedTuple):
+    id: int
+    state: str | None
+    closed_at: datetime | None
+    merged_at: datetime | None
 
 
 def bulk_insert_action_log_entries(params: list[int | str | datetime], num_rows: int) -> int:
@@ -257,6 +257,96 @@ def _latest_pr_lifecycle_action_types(*, group_id: int, project_id: int) -> dict
     return latest_action_types
 
 
+def _get_new_pr_lifecycle_action(
+    *,
+    pull_request: _PullRequestLifecycleDetails,
+    latest_action_type: int | None,
+    has_other_open_prs: bool,
+    group_id: int,
+    project_id: int,
+) -> (
+    tuple[
+        PullRequestClosedAction | PullRequestMergedAction | PullRequestReopenedAction,
+        datetime | None,
+    ]
+    | None
+):
+    """Return the lifecycle action and timestamp missing from a pull request's log."""
+    match pull_request.state:
+        case PullRequestLifecycleState.MERGED:
+            if latest_action_type == GroupActionType.PULL_REQUEST_MERGED:
+                return None
+            logger.info(
+                "backfill_group_pr_lifecycle.merged",
+                extra={
+                    "group_id": group_id,
+                    "project_id": project_id,
+                    "pull_request_id": pull_request.id,
+                    "state": pull_request.state,
+                    "latest_action_type": latest_action_type,
+                },
+            )
+            return (
+                PullRequestMergedAction(
+                    pull_request=pull_request.id,
+                    has_other_open_prs=has_other_open_prs,
+                ),
+                pull_request.merged_at,
+            )
+        case PullRequestLifecycleState.CLOSED | PullRequestLifecycleState.SUPERSEDED:
+            if latest_action_type == GroupActionType.PULL_REQUEST_CLOSED:
+                return None
+            logger.info(
+                "backfill_group_pr_lifecycle.closed",
+                extra={
+                    "group_id": group_id,
+                    "project_id": project_id,
+                    "pull_request_id": pull_request.id,
+                    "state": pull_request.state,
+                    "latest_action_type": latest_action_type,
+                },
+            )
+            return (
+                PullRequestClosedAction(
+                    pull_request=pull_request.id,
+                    has_other_open_prs=has_other_open_prs,
+                ),
+                pull_request.closed_at,
+            )
+        case PullRequestLifecycleState.OPEN | PullRequestLifecycleState.LOCKED:
+            if latest_action_type not in (
+                GroupActionType.PULL_REQUEST_CLOSED,
+                GroupActionType.PULL_REQUEST_MERGED,
+            ):
+                return None
+            # PullRequest does not store a reopened timestamp, so use the current time.
+            date_added = timezone.now()
+            logger.info(
+                "backfill_group_pr_lifecycle.reopen",
+                extra={
+                    "group_id": group_id,
+                    "project_id": project_id,
+                    "pull_request_id": pull_request.id,
+                    "state": pull_request.state,
+                    "latest_action_type": latest_action_type,
+                },
+            )
+            return PullRequestReopenedAction(pull_request=pull_request.id), date_added
+        case _:
+            # A null state is a legacy/unsynced pull request whose real state is unknown.
+            logger.info(
+                "backfill_group_pr_lifecycle.unknown_state",
+                extra={
+                    "group_id": group_id,
+                    "project_id": project_id,
+                    "pull_request_id": pull_request.id,
+                    "state": pull_request.state,
+                    "latest_action_type": latest_action_type,
+                },
+            )
+            return None
+
+
 def backfill_group_pr_lifecycle(*, group_id: int, project_id: int) -> int:
     """Backfill missing pull request lifecycle actions for a group.
 
@@ -276,15 +366,16 @@ def backfill_group_pr_lifecycle(*, group_id: int, project_id: int) -> int:
     if not pull_request_ids:
         return 0
 
-    pull_requests = list(
-        PullRequest.objects.filter(id__in=pull_request_ids).values_list(
+    pull_requests = [
+        _PullRequestLifecycleDetails(*pull_request)
+        for pull_request in PullRequest.objects.filter(id__in=pull_request_ids).values_list(
             "id", "state", "closed_at", "merged_at"
         )
-    )
+    ]
     open_pull_request_ids = {
-        pull_request_id
-        for pull_request_id, state, _, _ in pull_requests
-        if is_open_pull_request_state(state)
+        pull_request.id
+        for pull_request in pull_requests
+        if is_open_pull_request_state(pull_request.state)
     }
 
     latest_action_types = _latest_pr_lifecycle_action_types(
@@ -292,62 +383,18 @@ def backfill_group_pr_lifecycle(*, group_id: int, project_id: int) -> int:
     )
 
     entries: list[BackfillEntry] = []
-    for pull_request_id, state, closed_at, merged_at in pull_requests:
-        latest_action_type = latest_action_types.get(pull_request_id)
-
-        action: PullRequestClosedAction | PullRequestMergedAction | PullRequestReopenedAction
-        date_added: datetime | None
-        has_other_open_prs = bool(open_pull_request_ids - {pull_request_id})
-        match state:
-            case PullRequestLifecycleState.MERGED:
-                action = PullRequestMergedAction(
-                    pull_request=pull_request_id,
-                    has_other_open_prs=has_other_open_prs,
-                )
-                date_added = merged_at
-            case PullRequestLifecycleState.CLOSED | PullRequestLifecycleState.SUPERSEDED:
-                action = PullRequestClosedAction(
-                    pull_request=pull_request_id,
-                    has_other_open_prs=has_other_open_prs,
-                )
-                date_added = closed_at
-            case PullRequestLifecycleState.OPEN | PullRequestLifecycleState.LOCKED:
-                # The pull request is open, so a terminal action being the last thing
-                # logged means its reopen was never recorded. There is no reopened
-                # timestamp to recover, so use the current time
-                if latest_action_type not in _TERMINAL_PR_LIFECYCLE_ACTION_TYPES:
-                    continue
-                action = PullRequestReopenedAction(pull_request=pull_request_id)
-                date_added = timezone.now()
-                logger.info(
-                    "backfill_group_pr_lifecycle.synthetic_reopen",
-                    extra={
-                        "group_id": group_id,
-                        "project_id": project_id,
-                        "pull_request_id": pull_request_id,
-                        "state": state,
-                        "latest_action_type": latest_action_type,
-                    },
-                )
-            case _:
-                # A null state is a legacy/unsynced pull request whose real state we
-                # don't know, so we can't tell a stale terminal action from a correct
-                # one. Leave the log alone rather than inventing a reopen.
-                logger.info(
-                    "backfill_group_pr_lifecycle.unknown_state",
-                    extra={
-                        "group_id": group_id,
-                        "project_id": project_id,
-                        "pull_request_id": pull_request_id,
-                        "state": state,
-                        "latest_action_type": latest_action_type,
-                    },
-                )
-                continue
-
-        action_type = action.get_type()
-        if latest_action_type == action_type:
+    for pull_request in pull_requests:
+        latest_action_type = latest_action_types.get(pull_request.id)
+        action_and_date = _get_new_pr_lifecycle_action(
+            pull_request=pull_request,
+            latest_action_type=latest_action_type,
+            has_other_open_prs=bool(open_pull_request_ids - {pull_request.id}),
+            group_id=group_id,
+            project_id=project_id,
+        )
+        if action_and_date is None:
             continue
+        action, date_added = action_and_date
 
         if date_added is None:
             logger.info(
@@ -355,8 +402,8 @@ def backfill_group_pr_lifecycle(*, group_id: int, project_id: int) -> int:
                 extra={
                     "group_id": group_id,
                     "project_id": project_id,
-                    "pull_request_id": pull_request_id,
-                    "state": state,
+                    "pull_request_id": pull_request.id,
+                    "state": pull_request.state,
                 },
             )
             continue
@@ -367,7 +414,7 @@ def backfill_group_pr_lifecycle(*, group_id: int, project_id: int) -> int:
                 actor=SYSTEM_ACTOR,
                 source=BACKFILL_PR_LIFECYCLE_SOURCE,
                 date_added=date_added,
-                idempotency_key=f"pr-lifecycle:{pull_request_id}:{action_type.value}",
+                idempotency_key=f"pr-lifecycle:{pull_request.id}:{action.get_type().value}",
             )
         )
 

--- a/src/sentry/issues/action_log/backfill.py
+++ b/src/sentry/issues/action_log/backfill.py
@@ -23,6 +23,7 @@ from sentry.issues.action_log.types import (
     GroupActionType,
     PullRequestClosedAction,
     PullRequestMergedAction,
+    PullRequestReopenedAction,
 )
 from sentry.issues.derived.processing import invalidate_group_derived_data
 from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
@@ -46,6 +47,14 @@ _PR_LIFECYCLE_ACTION_TYPES = (
     GroupActionType.PULL_REQUEST_REOPENED,
     GroupActionType.PULL_REQUEST_MERGED,
     GroupActionType.PULL_REQUEST_UNLINKED,
+)
+
+# Lifecycle actions that leave a pull request finished as far as the log is concerned.
+# When one of these is the last action logged for a pull request that is open, the
+# reopen went unlogged and is reconstructed by the backfill.
+_TERMINAL_PR_LIFECYCLE_ACTION_TYPES = (
+    GroupActionType.PULL_REQUEST_CLOSED,
+    GroupActionType.PULL_REQUEST_MERGED,
 )
 
 
@@ -222,12 +231,39 @@ def backfill_group_activities(
     return total_created
 
 
-def backfill_group_pr_lifecycle(*, group_id: int, project_id: int) -> int:
-    """Backfill terminal lifecycle actions for pull requests that resolve a group.
+def _latest_pr_lifecycle_action_types(*, group_id: int, project_id: int) -> dict[int, int]:
+    """Map pull request id to the type of its most recently logged lifecycle action.
 
-    Only current terminal states with reliable timestamps can be reconstructed. A
-    pull request with any existing lifecycle action is skipped so this backfill
-    does not duplicate actions emitted by the live signal path.
+    Entries are scanned oldest first so the last write per pull request wins.
+    """
+    latest_action_types: dict[int, int] = {}
+    logged_entries = (
+        GroupActionLogEntry.objects.filter(
+            group_id=group_id,
+            project_id=project_id,
+            type__in=_PR_LIFECYCLE_ACTION_TYPES,
+        )
+        .order_by("date_added", "id")
+        .values_list("type", "data")
+    )
+    for action_type, data in logged_entries:
+        if not isinstance(data, dict):
+            continue
+        try:
+            pull_request_id = int(data["pull_request"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        latest_action_types[pull_request_id] = action_type
+    return latest_action_types
+
+
+def backfill_group_pr_lifecycle(*, group_id: int, project_id: int) -> int:
+    """Backfill missing pull request lifecycle actions for a group.
+
+    Each resolving pull request's current state is compared with its latest logged
+    lifecycle action. Closed and merged actions use their persisted timestamps. An
+    open pull request with a stale terminal action gets a synthetic reopen dated
+    now because pull requests do not store a reopened timestamp.
     """
     pull_request_ids = list(
         GroupLink.objects.filter(
@@ -251,26 +287,15 @@ def backfill_group_pr_lifecycle(*, group_id: int, project_id: int) -> int:
         if is_open_pull_request_state(state)
     }
 
-    already_logged_pull_request_ids: set[int] = set()
-    existing_data = GroupActionLogEntry.objects.filter(
-        group_id=group_id,
-        project_id=project_id,
-        type__in=_PR_LIFECYCLE_ACTION_TYPES,
-    ).values_list("data", flat=True)
-    for data in existing_data:
-        if not isinstance(data, dict):
-            continue
-        try:
-            already_logged_pull_request_ids.add(int(data["pull_request"]))
-        except (KeyError, TypeError, ValueError):
-            continue
+    latest_action_types = _latest_pr_lifecycle_action_types(
+        group_id=group_id, project_id=project_id
+    )
 
     entries: list[BackfillEntry] = []
     for pull_request_id, state, closed_at, merged_at in pull_requests:
-        if pull_request_id in already_logged_pull_request_ids:
-            continue
+        latest_action_type = latest_action_types.get(pull_request_id)
 
-        action: PullRequestClosedAction | PullRequestMergedAction
+        action: PullRequestClosedAction | PullRequestMergedAction | PullRequestReopenedAction
         date_added: datetime | None
         has_other_open_prs = bool(open_pull_request_ids - {pull_request_id})
         match state:
@@ -286,8 +311,43 @@ def backfill_group_pr_lifecycle(*, group_id: int, project_id: int) -> int:
                     has_other_open_prs=has_other_open_prs,
                 )
                 date_added = closed_at
+            case PullRequestLifecycleState.OPEN | PullRequestLifecycleState.LOCKED:
+                # The pull request is open, so a terminal action being the last thing
+                # logged means its reopen was never recorded. There is no reopened
+                # timestamp to recover, so use the current time
+                if latest_action_type not in _TERMINAL_PR_LIFECYCLE_ACTION_TYPES:
+                    continue
+                action = PullRequestReopenedAction(pull_request=pull_request_id)
+                date_added = timezone.now()
+                logger.info(
+                    "backfill_group_pr_lifecycle.synthetic_reopen",
+                    extra={
+                        "group_id": group_id,
+                        "project_id": project_id,
+                        "pull_request_id": pull_request_id,
+                        "state": state,
+                        "latest_action_type": latest_action_type,
+                    },
+                )
             case _:
+                # A null state is a legacy/unsynced pull request whose real state we
+                # don't know, so we can't tell a stale terminal action from a correct
+                # one. Leave the log alone rather than inventing a reopen.
+                logger.info(
+                    "backfill_group_pr_lifecycle.unknown_state",
+                    extra={
+                        "group_id": group_id,
+                        "project_id": project_id,
+                        "pull_request_id": pull_request_id,
+                        "state": state,
+                        "latest_action_type": latest_action_type,
+                    },
+                )
                 continue
+
+        action_type = action.get_type()
+        if latest_action_type == action_type:
+            continue
 
         if date_added is None:
             logger.info(
@@ -299,10 +359,6 @@ def backfill_group_pr_lifecycle(*, group_id: int, project_id: int) -> int:
                     "state": state,
                 },
             )
-            metrics.incr(
-                "issues.action_log.backfill_pr_lifecycle.skipped",
-                tags={"reason": "missing_timestamp"},
-            )
             continue
 
         entries.append(
@@ -311,7 +367,7 @@ def backfill_group_pr_lifecycle(*, group_id: int, project_id: int) -> int:
                 actor=SYSTEM_ACTOR,
                 source=BACKFILL_PR_LIFECYCLE_SOURCE,
                 date_added=date_added,
-                idempotency_key=f"pr-lifecycle:{pull_request_id}:{action.get_type().value}",
+                idempotency_key=f"pr-lifecycle:{pull_request_id}:{action_type.value}",
             )
         )
 

--- a/src/sentry/issues/action_log/backfill.py
+++ b/src/sentry/issues/action_log/backfill.py
@@ -20,16 +20,33 @@ from sentry.issues.action_log.types import (
     SYSTEM_ACTOR,
     GroupAction,
     GroupActionActor,
+    GroupActionType,
+    PullRequestClosedAction,
+    PullRequestMergedAction,
 )
 from sentry.issues.derived.processing import invalidate_group_derived_data
 from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
 from sentry.models.activity import Activity
+from sentry.models.grouplink import GroupLink
+from sentry.models.pullrequest import (
+    PullRequest,
+    PullRequestLifecycleState,
+    is_open_pull_request_state,
+)
 from sentry.utils import json, metrics
 from sentry.utils.action_log.activity_translator import activity_to_action
 
 logger = logging.getLogger(__name__)
 
 BACKFILL_ACTIVITY_SOURCE = "backfill:activity"
+BACKFILL_PR_LIFECYCLE_SOURCE = "backfill:pr-lifecycle"
+
+_PR_LIFECYCLE_ACTION_TYPES = (
+    GroupActionType.PULL_REQUEST_CLOSED,
+    GroupActionType.PULL_REQUEST_REOPENED,
+    GroupActionType.PULL_REQUEST_MERGED,
+    GroupActionType.PULL_REQUEST_UNLINKED,
+)
 
 
 @dataclass(frozen=True)
@@ -203,3 +220,100 @@ def backfill_group_activities(
         )
 
     return total_created
+
+
+def backfill_group_pr_lifecycle(*, group_id: int, project_id: int) -> int:
+    """Backfill terminal lifecycle actions for pull requests that resolve a group.
+
+    Only current terminal states with reliable timestamps can be reconstructed. A
+    pull request with any existing lifecycle action is skipped so this backfill
+    does not duplicate actions emitted by the live signal path.
+    """
+    pull_request_ids = list(
+        GroupLink.objects.filter(
+            group_id=group_id,
+            project_id=project_id,
+            linked_type=GroupLink.LinkedType.pull_request,
+            relationship=GroupLink.Relationship.resolves,
+        ).values_list("linked_id", flat=True)
+    )
+    if not pull_request_ids:
+        return 0
+
+    pull_requests = list(
+        PullRequest.objects.filter(id__in=pull_request_ids).values_list(
+            "id", "state", "closed_at", "merged_at"
+        )
+    )
+    open_pull_request_ids = {
+        pull_request_id
+        for pull_request_id, state, _, _ in pull_requests
+        if is_open_pull_request_state(state)
+    }
+
+    already_logged_pull_request_ids: set[int] = set()
+    existing_data = GroupActionLogEntry.objects.filter(
+        group_id=group_id,
+        project_id=project_id,
+        type__in=_PR_LIFECYCLE_ACTION_TYPES,
+    ).values_list("data", flat=True)
+    for data in existing_data:
+        if not isinstance(data, dict):
+            continue
+        try:
+            already_logged_pull_request_ids.add(int(data["pull_request"]))
+        except (KeyError, TypeError, ValueError):
+            continue
+
+    entries: list[BackfillEntry] = []
+    for pull_request_id, state, closed_at, merged_at in pull_requests:
+        if pull_request_id in already_logged_pull_request_ids:
+            continue
+
+        action: PullRequestClosedAction | PullRequestMergedAction
+        date_added: datetime | None
+        has_other_open_prs = bool(open_pull_request_ids - {pull_request_id})
+        match state:
+            case PullRequestLifecycleState.MERGED:
+                action = PullRequestMergedAction(
+                    pull_request=pull_request_id,
+                    has_other_open_prs=has_other_open_prs,
+                )
+                date_added = merged_at
+            case PullRequestLifecycleState.CLOSED | PullRequestLifecycleState.SUPERSEDED:
+                action = PullRequestClosedAction(
+                    pull_request=pull_request_id,
+                    has_other_open_prs=has_other_open_prs,
+                )
+                date_added = closed_at
+            case _:
+                continue
+
+        if date_added is None:
+            logger.info(
+                "backfill_group_pr_lifecycle.missing_timestamp",
+                extra={
+                    "group_id": group_id,
+                    "project_id": project_id,
+                    "pull_request_id": pull_request_id,
+                    "state": state,
+                },
+            )
+            metrics.incr(
+                "issues.action_log.backfill_pr_lifecycle.skipped",
+                tags={"reason": "missing_timestamp"},
+            )
+            continue
+
+        entries.append(
+            BackfillEntry(
+                action=action,
+                actor=SYSTEM_ACTOR,
+                source=BACKFILL_PR_LIFECYCLE_SOURCE,
+                date_added=date_added,
+                idempotency_key=f"pr-lifecycle:{pull_request_id}:{action.get_type().value}",
+            )
+        )
+
+    entries.sort(key=lambda entry: entry.date_added)
+    return backfill_actions(entries=entries, group_id=group_id, project_id=project_id)

--- a/src/sentry/issues/action_log/backfill.py
+++ b/src/sentry/issues/action_log/backfill.py
@@ -314,6 +314,7 @@ def _get_new_pr_lifecycle_action(
                 pull_request.closed_at,
             )
         case PullRequestLifecycleState.OPEN | PullRequestLifecycleState.LOCKED:
+            # Reopen actions only make sense if we have previously logged a closed/merged action
             if latest_action_type not in (
                 GroupActionType.PULL_REQUEST_CLOSED,
                 GroupActionType.PULL_REQUEST_MERGED,

--- a/src/sentry/models/pullrequest.py
+++ b/src/sentry/models/pullrequest.py
@@ -39,6 +39,13 @@ class PullRequestLifecycleState(models.TextChoices):
     SUPERSEDED = "superseded"
 
 
+def is_open_pull_request_state(state: str | None) -> bool:
+    return state is None or state in (
+        PullRequestLifecycleState.OPEN,
+        PullRequestLifecycleState.LOCKED,
+    )
+
+
 class PullRequestAttributionSignalType(models.TextChoices):
     SENTRY_APP = "sentry_app"
     SEER_DELEGATED_CURSOR = "seer_delegated:cursor"

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1293,6 +1293,24 @@ register(
     default=1,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "issues.backfill_pr_lifecycle_action_log.killswitch",
+    type=Bool,
+    default=False,
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "issues.backfill_pr_lifecycle_action_log.batch_size",
+    type=Int,
+    default=500,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "issues.backfill_pr_lifecycle_action_log.inter_batch_delay_s",
+    type=Int,
+    default=1,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 register(
     "seer.supergroups_backfill_lightweight.killswitch",

--- a/src/sentry/receivers/releases.py
+++ b/src/sentry/receivers/releases.py
@@ -29,7 +29,11 @@ from sentry.models.grouphistory import (
 from sentry.models.grouplink import GroupLink
 from sentry.models.groupsubscription import GroupSubscription
 from sentry.models.project import Project
-from sentry.models.pullrequest import PullRequest, PullRequestLifecycleState
+from sentry.models.pullrequest import (
+    PullRequest,
+    PullRequestLifecycleState,
+    is_open_pull_request_state,
+)
 from sentry.models.release import Release
 from sentry.models.releases.release_project import ReleaseProject
 from sentry.models.repository import Repository
@@ -283,13 +287,6 @@ def resolved_in_pull_request(instance: PullRequest, created, **kwargs):
                 )
 
 
-def _is_open_pull_request_state(state: str | None) -> bool:
-    return state is None or state in (
-        PullRequestLifecycleState.OPEN,
-        PullRequestLifecycleState.LOCKED,
-    )
-
-
 def _groups_with_other_open_prs(group_ids: Sequence[int], *, pull_request_id: int) -> set[int]:
     """
     Return the subset of `group_ids` that still have at least one linked PR
@@ -316,7 +313,7 @@ def _groups_with_other_open_prs(group_ids: Sequence[int], *, pull_request_id: in
         for pr_id, state in PullRequest.objects.filter(id__in=sibling_pr_ids).values_list(
             "id", "state"
         )
-        if _is_open_pull_request_state(state)
+        if is_open_pull_request_state(state)
     }
     return {group_id for group_id, linked_id in sibling_links if linked_id in open_pr_ids}
 
@@ -372,7 +369,7 @@ def _create_pull_request_activities(
 def _get_pull_request_activity_type_from_state(
     state: str | None,
 ) -> ActivityType | None:
-    if _is_open_pull_request_state(state):
+    if is_open_pull_request_state(state):
         return ActivityType.PULL_REQUEST_REOPENED
 
     match state:
@@ -393,8 +390,8 @@ def pull_request_state_changing(instance: PullRequest, **kwargs: object) -> None
         old_state = (
             PullRequest.objects.filter(pk=instance.pk).values_list("state", flat=True).first()
         )
-        previous_is_open = _is_open_pull_request_state(old_state)
-        is_open = _is_open_pull_request_state(instance.state)
+        previous_is_open = is_open_pull_request_state(old_state)
+        is_open = is_open_pull_request_state(instance.state)
         if previous_is_open == is_open:
             return
 

--- a/src/sentry/tasks/backfill_group_action_log.py
+++ b/src/sentry/tasks/backfill_group_action_log.py
@@ -122,6 +122,7 @@ def backfill_group_action_log_for_project(
     reset: bool = False,
     cursor_datetime: str | None = None,
     cursor_id: int = 0,
+    chain_pr_lifecycle: bool = False,
     **kwargs: object,
 ) -> None:
     task_state = current_task()
@@ -149,7 +150,13 @@ def backfill_group_action_log_for_project(
     parsed_cursor = datetime.fromisoformat(cursor_datetime) if cursor_datetime else None
 
     try:
-        _backfill_project(project, parsed_cursor, cursor_id, activation_id)
+        _backfill_project(
+            project,
+            parsed_cursor,
+            cursor_id,
+            activation_id,
+            chain_pr_lifecycle,
+        )
     except Exception:
         logger.exception(
             "backfill_group_action_log.task_failed",
@@ -190,9 +197,8 @@ def _backfill_project(
     cursor_dt: datetime | None,
     cursor_id: int = 0,
     activation_id: str | None = None,
+    chain_pr_lifecycle: bool = False,
 ) -> None:
-    from sentry.issues.derived.tasks import process_project_derived_data
-
     batch_size: int = options.get("issues.backfill_group_action_log.batch_size")
     inter_batch_delay_s: int = options.get("issues.backfill_group_action_log.inter_batch_delay_s")
 
@@ -219,7 +225,7 @@ def _backfill_project(
             "backfill_group_action_log.project_completed",
             extra={"project_id": project.id},
         )
-        process_project_derived_data.delay(project_id=project.id)
+        _complete_project_backfill(project, chain_pr_lifecycle)
         return
 
     logger.info(
@@ -310,6 +316,7 @@ def _backfill_project(
                 "project_id": project.id,
                 "cursor_datetime": last_activity.datetime.isoformat(),
                 "cursor_id": last_activity.id,
+                "chain_pr_lifecycle": chain_pr_lifecycle,
             },
             countdown=inter_batch_delay_s,
             headers={"sentry-propagate-traces": False},
@@ -321,4 +328,17 @@ def _backfill_project(
             "backfill_group_action_log.project_completed",
             extra={"project_id": project.id},
         )
+        _complete_project_backfill(project, chain_pr_lifecycle)
+
+
+def _complete_project_backfill(project: Project, chain_pr_lifecycle: bool) -> None:
+    if chain_pr_lifecycle:
+        from sentry.tasks.backfill_pr_lifecycle_action_log import (
+            backfill_pr_lifecycle_action_log_for_project,
+        )
+
+        backfill_pr_lifecycle_action_log_for_project.delay(project_id=project.id)
+    else:
+        from sentry.issues.derived.tasks import process_project_derived_data
+
         process_project_derived_data.delay(project_id=project.id)

--- a/src/sentry/tasks/backfill_pr_lifecycle_action_log.py
+++ b/src/sentry/tasks/backfill_pr_lifecycle_action_log.py
@@ -1,0 +1,205 @@
+import logging
+
+from taskbroker_client.state import current_task
+
+from sentry import options
+from sentry.issues.action_log.backfill import BACKFILL_PR_LIFECYCLE_SOURCE
+from sentry.models.group import Group
+from sentry.models.grouplink import GroupLink
+from sentry.models.project import Project
+from sentry.silo.base import SiloMode
+from sentry.tasks.base import instrumented_task
+from sentry.taskworker.namespaces import issues_tasks
+from sentry.taskworker.selfchain_idempotency import already_spawned, mark_spawned
+from sentry.utils import metrics
+
+logger = logging.getLogger(__name__)
+
+_TASK_KEY = "backfill_pr_lifecycle_action_log_for_project"
+
+
+@instrumented_task(
+    name=(
+        "sentry.tasks.backfill_pr_lifecycle_action_log.backfill_pr_lifecycle_action_log_for_group"
+    ),
+    namespace=issues_tasks,
+    silo_mode=SiloMode.CELL,
+)
+def backfill_pr_lifecycle_action_log_for_group(
+    group_id: int,
+    **kwargs: object,
+) -> None:
+    from sentry.issues.action_log.backfill import backfill_group_pr_lifecycle
+
+    try:
+        group = Group.objects.get(id=group_id)
+    except Group.DoesNotExist:
+        logger.warning(
+            "backfill_pr_lifecycle_action_log.group_not_found",
+            extra={"group_id": group_id},
+        )
+        return
+
+    try:
+        total = backfill_group_pr_lifecycle(
+            group_id=group.id,
+            project_id=group.project_id,
+        )
+    except Exception:
+        logger.exception(
+            "backfill_pr_lifecycle_action_log.group_failed",
+            extra={"group_id": group.id, "project_id": group.project_id},
+        )
+        raise
+
+    logger.info(
+        "backfill_pr_lifecycle_action_log.group_completed",
+        extra={
+            "group_id": group.id,
+            "project_id": group.project_id,
+            "total_created": total,
+        },
+    )
+
+
+@instrumented_task(
+    name=(
+        "sentry.tasks.backfill_pr_lifecycle_action_log.backfill_pr_lifecycle_action_log_for_project"
+    ),
+    namespace=issues_tasks,
+    processing_deadline_duration=15 * 60,
+    silo_mode=SiloMode.CELL,
+)
+def backfill_pr_lifecycle_action_log_for_project(
+    project_id: int,
+    cursor_group_id: int = 0,
+    reset: bool = False,
+    **kwargs: object,
+) -> None:
+    task_state = current_task()
+    activation_id = task_state.id if task_state else None
+    if activation_id and already_spawned(_TASK_KEY, activation_id):
+        logger.info(
+            "backfill_pr_lifecycle_action_log.duplicate_redelivery.skipped",
+            extra={"project_id": project_id, "activation_id": activation_id},
+        )
+        metrics.incr("taskworker.selfchain.duplicate_skipped", tags={"task": _TASK_KEY})
+        return
+
+    if options.get("issues.backfill_pr_lifecycle_action_log.killswitch"):
+        logger.info("backfill_pr_lifecycle_action_log.killswitch_enabled")
+        return
+
+    try:
+        project = Project.objects.get(id=project_id)
+    except Project.DoesNotExist:
+        return
+
+    if reset and cursor_group_id == 0:
+        _reset_project(project)
+
+    try:
+        _backfill_project(project, cursor_group_id, activation_id)
+    except Exception:
+        logger.exception(
+            "backfill_pr_lifecycle_action_log.task_failed",
+            extra={"project_id": project.id, "cursor_group_id": cursor_group_id},
+        )
+        raise
+
+
+def _reset_project(project: Project) -> None:
+    from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
+    from sentry.issues.models.groupderiveddata import GroupDerivedData
+
+    deleted_derived, _ = GroupDerivedData.objects.filter(group__project_id=project.id).delete()
+    deleted_entries, _ = GroupActionLogEntry.objects.filter(
+        project_id=project.id,
+        source=BACKFILL_PR_LIFECYCLE_SOURCE,
+    ).delete()
+
+    logger.info(
+        "backfill_pr_lifecycle_action_log.project_reset_completed",
+        extra={
+            "project_id": project.id,
+            "deleted_entries": deleted_entries,
+            "deleted_derived": deleted_derived,
+        },
+    )
+
+
+def _backfill_project(
+    project: Project,
+    cursor_group_id: int,
+    activation_id: str | None = None,
+) -> None:
+    from sentry.issues.action_log.backfill import backfill_group_pr_lifecycle
+    from sentry.issues.derived.tasks import process_project_derived_data
+
+    batch_size: int = options.get("issues.backfill_pr_lifecycle_action_log.batch_size")
+    inter_batch_delay_s: int = options.get(
+        "issues.backfill_pr_lifecycle_action_log.inter_batch_delay_s"
+    )
+
+    if batch_size <= 0:
+        logger.error(
+            "backfill_pr_lifecycle_action_log.invalid_batch_size",
+            extra={"project_id": project.id, "batch_size": batch_size},
+        )
+        return
+
+    group_ids = list(
+        GroupLink.objects.filter(
+            project_id=project.id,
+            group_id__gt=cursor_group_id,
+            linked_type=GroupLink.LinkedType.pull_request,
+            relationship=GroupLink.Relationship.resolves,
+        )
+        .order_by("group_id")
+        .values_list("group_id", flat=True)
+        .distinct()[:batch_size]
+    )
+
+    if not group_ids:
+        logger.info(
+            "backfill_pr_lifecycle_action_log.project_completed",
+            extra={"project_id": project.id},
+        )
+        process_project_derived_data.delay(project_id=project.id)
+        return
+
+    total_created = 0
+    for group_id in group_ids:
+        total_created += backfill_group_pr_lifecycle(
+            group_id=group_id,
+            project_id=project.id,
+        )
+
+    next_cursor_group_id = group_ids[-1]
+    logger.info(
+        "backfill_pr_lifecycle_action_log.batch_complete",
+        extra={
+            "project_id": project.id,
+            "group_count": len(group_ids),
+            "total_created": total_created,
+            "next_cursor_group_id": next_cursor_group_id,
+        },
+    )
+
+    if len(group_ids) == batch_size:
+        backfill_pr_lifecycle_action_log_for_project.apply_async(
+            kwargs={
+                "project_id": project.id,
+                "cursor_group_id": next_cursor_group_id,
+            },
+            countdown=inter_batch_delay_s,
+            headers={"sentry-propagate-traces": False},
+        )
+        if activation_id:
+            mark_spawned(_TASK_KEY, activation_id)
+    else:
+        logger.info(
+            "backfill_pr_lifecycle_action_log.project_completed",
+            extra={"project_id": project.id},
+        )
+        process_project_derived_data.delay(project_id=project.id)

--- a/tests/sentry/issues/action_log/test_backfill.py
+++ b/tests/sentry/issues/action_log/test_backfill.py
@@ -355,6 +355,12 @@ class BackfillGroupPullRequestLifecycleTest(TestCase):
             project_id=self.project.id,
         )
 
+    def _backfill_pr_lifecycle(self) -> int:
+        return backfill_group_pr_lifecycle(
+            group_id=self.group.id,
+            project_id=self.project.id,
+        )
+
     def test_backfills_merged_pull_request(self) -> None:
         merged_at = self.now - timedelta(minutes=1)
         pull_request = self._create_linked_pull_request(
@@ -362,13 +368,7 @@ class BackfillGroupPullRequestLifecycleTest(TestCase):
             merged_at=merged_at,
         )
 
-        assert (
-            backfill_group_pr_lifecycle(
-                group_id=self.group.id,
-                project_id=self.project.id,
-            )
-            == 1
-        )
+        assert self._backfill_pr_lifecycle() == 1
 
         entry = GroupActionLogEntry.objects.get(group_id=self.group.id)
         assert entry.type == GroupActionType.PULL_REQUEST_MERGED
@@ -395,13 +395,7 @@ class BackfillGroupPullRequestLifecycleTest(TestCase):
             closed_at=closed_at,
         )
 
-        assert (
-            backfill_group_pr_lifecycle(
-                group_id=self.group.id,
-                project_id=self.project.id,
-            )
-            == 2
-        )
+        assert self._backfill_pr_lifecycle() == 2
 
         entries = list(GroupActionLogEntry.objects.filter(group_id=self.group.id))
         assert {entry.type for entry in entries} == {GroupActionType.PULL_REQUEST_CLOSED}
@@ -416,13 +410,7 @@ class BackfillGroupPullRequestLifecycleTest(TestCase):
         self._create_linked_pull_request(state=PullRequestLifecycleState.OPEN)
         self._create_linked_pull_request(state=PullRequestLifecycleState.LOCKED)
 
-        assert (
-            backfill_group_pr_lifecycle(
-                group_id=self.group.id,
-                project_id=self.project.id,
-            )
-            == 0
-        )
+        assert self._backfill_pr_lifecycle() == 0
         assert not GroupActionLogEntry.objects.filter(group_id=self.group.id).exists()
 
     def test_open_sibling_keeps_fix_pr_open(self) -> None:
@@ -433,10 +421,7 @@ class BackfillGroupPullRequestLifecycleTest(TestCase):
         self._create_linked_pull_request(state=PullRequestLifecycleState.OPEN)
         self._backfill_resolved_action(closed_pull_request)
 
-        backfill_group_pr_lifecycle(
-            group_id=self.group.id,
-            project_id=self.project.id,
-        )
+        self._backfill_pr_lifecycle()
         derived = process_group_log(self.group.id)
 
         closed_entry = GroupActionLogEntry.objects.get(
@@ -454,10 +439,7 @@ class BackfillGroupPullRequestLifecycleTest(TestCase):
         )
         self._backfill_resolved_action(pull_request)
 
-        backfill_group_pr_lifecycle(
-            group_id=self.group.id,
-            project_id=self.project.id,
-        )
+        self._backfill_pr_lifecycle()
         derived = process_group_log(self.group.id)
 
         assert derived.data["has_open_fix_pr"] is False
@@ -466,33 +448,145 @@ class BackfillGroupPullRequestLifecycleTest(TestCase):
     def test_skips_terminal_pull_request_without_timestamp(self) -> None:
         self._create_linked_pull_request(state=PullRequestLifecycleState.MERGED)
 
-        assert (
-            backfill_group_pr_lifecycle(
-                group_id=self.group.id,
-                project_id=self.project.id,
-            )
-            == 0
-        )
+        assert self._backfill_pr_lifecycle() == 0
         assert not GroupActionLogEntry.objects.filter(group_id=self.group.id).exists()
 
-    def test_skips_pull_request_with_existing_lifecycle_entry(self) -> None:
+    def test_skips_pull_request_whose_latest_action_matches_state(self) -> None:
         pull_request = self._create_linked_pull_request(
             state=PullRequestLifecycleState.CLOSED,
             closed_at=self.now - timedelta(minutes=1),
         )
         self.create_group_action_log_entry(
             group=self.group,
-            type=GroupActionType.PULL_REQUEST_REOPENED,
-            data={"pull_request": str(pull_request.id)},
+            type=GroupActionType.PULL_REQUEST_CLOSED,
+            data={"pull_request": str(pull_request.id), "has_other_open_prs": False},
+            date_added=self.now - timedelta(minutes=1),
         )
 
-        assert (
-            backfill_group_pr_lifecycle(
-                group_id=self.group.id,
-                project_id=self.project.id,
-            )
-            == 0
+        assert self._backfill_pr_lifecycle() == 0
+        assert GroupActionLogEntry.objects.filter(group_id=self.group.id).count() == 1
+
+    def test_backfills_merge_after_stale_closed_action(self) -> None:
+        merged_at = self.now - timedelta(minutes=1)
+        pull_request = self._create_linked_pull_request(
+            state=PullRequestLifecycleState.MERGED,
+            closed_at=merged_at,
+            merged_at=merged_at,
         )
+        # PULL_REQUEST_CLOSED was logged before the other lifecycle actions existed,
+        # so the log's last word on this pull request is a stale close.
+        self.create_group_action_log_entry(
+            group=self.group,
+            type=GroupActionType.PULL_REQUEST_CLOSED,
+            data={"pull_request": pull_request.id, "has_other_open_prs": False},
+            date_added=self.now - timedelta(minutes=30),
+        )
+
+        assert self._backfill_pr_lifecycle() == 1
+
+        merged_entry = GroupActionLogEntry.objects.get(
+            group_id=self.group.id,
+            type=GroupActionType.PULL_REQUEST_MERGED,
+        )
+        assert merged_entry.data == {
+            "pull_request": pull_request.id,
+            "has_other_open_prs": False,
+        }
+        assert merged_entry.date_added == merged_at
+        assert self._backfill_pr_lifecycle() == 0
+
+    def test_backfills_close_after_stale_reopened_action(self) -> None:
+        closed_at = self.now - timedelta(minutes=1)
+        pull_request = self._create_linked_pull_request(
+            state=PullRequestLifecycleState.CLOSED,
+            closed_at=closed_at,
+        )
+        self._backfill_resolved_action(pull_request)
+        # The pull request was closed, reopened, then closed again — only the reopen
+        # made it into the log, so derived data still sees an open fix pull request.
+        self.create_group_action_log_entry(
+            group=self.group,
+            type=GroupActionType.PULL_REQUEST_REOPENED,
+            data={"pull_request": pull_request.id},
+            date_added=self.now - timedelta(seconds=90),
+        )
+
+        assert self._backfill_pr_lifecycle() == 1
+
+        closed_entry = GroupActionLogEntry.objects.get(
+            group_id=self.group.id,
+            type=GroupActionType.PULL_REQUEST_CLOSED,
+        )
+        assert closed_entry.date_added == closed_at
+        derived = process_group_log(self.group.id)
+        assert derived.data["has_open_fix_pr"] is False
+
+    def test_backfills_reopen_after_stale_closed_action(self) -> None:
+        pull_request = self._create_linked_pull_request(state=PullRequestLifecycleState.OPEN)
+        self._backfill_resolved_action(pull_request)
+        # The pull request was closed and later reopened, but only the close was logged,
+        # so derived data no longer sees the open fix pull request.
+        self.create_group_action_log_entry(
+            group=self.group,
+            type=GroupActionType.PULL_REQUEST_CLOSED,
+            data={"pull_request": pull_request.id, "has_other_open_prs": False},
+            date_added=self.now - timedelta(seconds=90),
+        )
+
+        assert self._backfill_pr_lifecycle() == 1
+
+        # PullRequest has no reopened timestamp, so the entry is dated now.
+        reopened_entry = GroupActionLogEntry.objects.get(
+            group_id=self.group.id,
+            type=GroupActionType.PULL_REQUEST_REOPENED,
+        )
+        assert reopened_entry.data == {"pull_request": pull_request.id}
+        assert reopened_entry.date_added >= self.now
+        assert reopened_entry.source == BACKFILL_PR_LIFECYCLE_SOURCE
+
+        derived = process_group_log(self.group.id)
+        assert derived.data["has_open_fix_pr"] is True
+        assert derived.progress == IssueProgressState.FIX_PROPOSED
+
+        assert self._backfill_pr_lifecycle() == 0
+
+    def test_backfills_reopen_for_locked_pull_request(self) -> None:
+        pull_request = self._create_linked_pull_request(state=PullRequestLifecycleState.LOCKED)
+        self.create_group_action_log_entry(
+            group=self.group,
+            type=GroupActionType.PULL_REQUEST_CLOSED,
+            data={"pull_request": str(pull_request.id), "has_other_open_prs": False},
+            date_added=self.now - timedelta(seconds=90),
+        )
+
+        assert self._backfill_pr_lifecycle() == 1
+        assert GroupActionLogEntry.objects.filter(
+            group_id=self.group.id,
+            type=GroupActionType.PULL_REQUEST_REOPENED,
+        ).exists()
+
+    def test_skips_reopen_for_open_pull_request_without_terminal_action(self) -> None:
+        pull_request = self._create_linked_pull_request(state=PullRequestLifecycleState.OPEN)
+        self.create_group_action_log_entry(
+            group=self.group,
+            type=GroupActionType.PULL_REQUEST_REOPENED,
+            data={"pull_request": pull_request.id},
+            date_added=self.now - timedelta(minutes=1),
+        )
+
+        assert self._backfill_pr_lifecycle() == 0
+        assert GroupActionLogEntry.objects.filter(group_id=self.group.id).count() == 1
+
+    def test_skips_reopen_for_pull_request_with_unknown_state(self) -> None:
+        pull_request = self._create_linked_pull_request(state=None)
+        self.create_group_action_log_entry(
+            group=self.group,
+            type=GroupActionType.PULL_REQUEST_CLOSED,
+            data={"pull_request": pull_request.id, "has_other_open_prs": False},
+            date_added=self.now - timedelta(minutes=1),
+        )
+
+        assert self._backfill_pr_lifecycle() == 0
         assert GroupActionLogEntry.objects.filter(group_id=self.group.id).count() == 1
 
     def test_idempotent_on_rerun(self) -> None:
@@ -501,14 +595,8 @@ class BackfillGroupPullRequestLifecycleTest(TestCase):
             merged_at=self.now - timedelta(minutes=1),
         )
 
-        first_count = backfill_group_pr_lifecycle(
-            group_id=self.group.id,
-            project_id=self.project.id,
-        )
-        second_count = backfill_group_pr_lifecycle(
-            group_id=self.group.id,
-            project_id=self.project.id,
-        )
+        first_count = self._backfill_pr_lifecycle()
+        second_count = self._backfill_pr_lifecycle()
 
         assert first_count == 1
         assert second_count == 0
@@ -521,10 +609,4 @@ class BackfillGroupPullRequestLifecycleTest(TestCase):
             merged_at=self.now - timedelta(minutes=1),
         )
 
-        assert (
-            backfill_group_pr_lifecycle(
-                group_id=self.group.id,
-                project_id=self.project.id,
-            )
-            == 0
-        )
+        assert self._backfill_pr_lifecycle() == 0

--- a/tests/sentry/issues/action_log/test_backfill.py
+++ b/tests/sentry/issues/action_log/test_backfill.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -6,9 +6,11 @@ from django.utils import timezone
 
 from sentry.issues.action_log.backfill import (
     BACKFILL_ACTIVITY_SOURCE,
+    BACKFILL_PR_LIFECYCLE_SOURCE,
     BackfillEntry,
     backfill_actions,
     backfill_group_activities,
+    backfill_group_pr_lifecycle,
 )
 from sentry.issues.action_log.types import (
     SYSTEM_ACTOR,
@@ -17,9 +19,15 @@ from sentry.issues.action_log.types import (
     GroupActionType,
     GroupActorType,
     ResolveAction,
+    ResolvedInPullRequestAction,
     ViewAction,
 )
+from sentry.issues.derived.processing import process_group_log
 from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
+from sentry.issues.progress_state import IssueProgressState
+from sentry.models.group import Group
+from sentry.models.grouplink import GroupLink
+from sentry.models.pullrequest import PullRequest, PullRequestLifecycleState
 from sentry.testutils.cases import TestCase
 from sentry.types.activity import ActivityType
 
@@ -294,3 +302,229 @@ class BackfillGroupActivitiesTest(TestCase):
         backfill_group_activities(group_id=self.group.id, project_id=self.project.id)
         entry = GroupActionLogEntry.objects.get(group_id=self.group.id)
         assert entry.date_added == ts
+
+
+class BackfillGroupPullRequestLifecycleTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.group = self.create_group()
+        self.repository = self.create_repo(project=self.project)
+        self.now = timezone.now()
+
+    def _create_linked_pull_request(
+        self,
+        *,
+        state: str | None,
+        group: Group | None = None,
+        relationship: int = GroupLink.Relationship.resolves,
+        closed_at: datetime | None = None,
+        merged_at: datetime | None = None,
+    ) -> PullRequest:
+        group = group or self.group
+        pull_request = self.create_pull_request(
+            repository_id=self.repository.id,
+            organization_id=self.organization.id,
+        )
+        PullRequest.objects.filter(id=pull_request.id).update(
+            state=state,
+            closed_at=closed_at,
+            merged_at=merged_at,
+        )
+        pull_request.refresh_from_db()
+        GroupLink.objects.create(
+            group_id=group.id,
+            project_id=group.project_id,
+            linked_type=GroupLink.LinkedType.pull_request,
+            relationship=relationship,
+            linked_id=pull_request.id,
+        )
+        return pull_request
+
+    def _backfill_resolved_action(self, pull_request: PullRequest) -> None:
+        backfill_actions(
+            entries=[
+                BackfillEntry(
+                    action=ResolvedInPullRequestAction(pull_request=pull_request.id),
+                    actor=SYSTEM_ACTOR,
+                    source="test",
+                    date_added=self.now - timedelta(minutes=2),
+                    idempotency_key=f"test-resolved-pr:{pull_request.id}",
+                )
+            ],
+            group_id=self.group.id,
+            project_id=self.project.id,
+        )
+
+    def test_backfills_merged_pull_request(self) -> None:
+        merged_at = self.now - timedelta(minutes=1)
+        pull_request = self._create_linked_pull_request(
+            state=PullRequestLifecycleState.MERGED,
+            merged_at=merged_at,
+        )
+
+        assert (
+            backfill_group_pr_lifecycle(
+                group_id=self.group.id,
+                project_id=self.project.id,
+            )
+            == 1
+        )
+
+        entry = GroupActionLogEntry.objects.get(group_id=self.group.id)
+        assert entry.type == GroupActionType.PULL_REQUEST_MERGED
+        assert entry.data == {
+            "pull_request": pull_request.id,
+            "has_other_open_prs": False,
+        }
+        assert entry.date_added == merged_at
+        assert entry.actor_type == GroupActorType.SYSTEM
+        assert entry.actor_id == SYSTEM_ACTOR.actor_id
+        assert entry.source == BACKFILL_PR_LIFECYCLE_SOURCE
+        assert entry.idempotency_key == (
+            f"pr-lifecycle:{pull_request.id}:{GroupActionType.PULL_REQUEST_MERGED.value}"
+        )
+
+    def test_backfills_closed_and_superseded_pull_requests(self) -> None:
+        closed_at = self.now - timedelta(minutes=1)
+        closed_pull_request = self._create_linked_pull_request(
+            state=PullRequestLifecycleState.CLOSED,
+            closed_at=closed_at,
+        )
+        superseded_pull_request = self._create_linked_pull_request(
+            state=PullRequestLifecycleState.SUPERSEDED,
+            closed_at=closed_at,
+        )
+
+        assert (
+            backfill_group_pr_lifecycle(
+                group_id=self.group.id,
+                project_id=self.project.id,
+            )
+            == 2
+        )
+
+        entries = list(GroupActionLogEntry.objects.filter(group_id=self.group.id))
+        assert {entry.type for entry in entries} == {GroupActionType.PULL_REQUEST_CLOSED}
+        assert {entry.data["pull_request"] for entry in entries} == {
+            closed_pull_request.id,
+            superseded_pull_request.id,
+        }
+        assert {entry.date_added for entry in entries} == {closed_at}
+
+    def test_skips_open_pull_requests(self) -> None:
+        self._create_linked_pull_request(state=None)
+        self._create_linked_pull_request(state=PullRequestLifecycleState.OPEN)
+        self._create_linked_pull_request(state=PullRequestLifecycleState.LOCKED)
+
+        assert (
+            backfill_group_pr_lifecycle(
+                group_id=self.group.id,
+                project_id=self.project.id,
+            )
+            == 0
+        )
+        assert not GroupActionLogEntry.objects.filter(group_id=self.group.id).exists()
+
+    def test_open_sibling_keeps_fix_pr_open(self) -> None:
+        closed_pull_request = self._create_linked_pull_request(
+            state=PullRequestLifecycleState.CLOSED,
+            closed_at=self.now - timedelta(minutes=1),
+        )
+        self._create_linked_pull_request(state=PullRequestLifecycleState.OPEN)
+        self._backfill_resolved_action(closed_pull_request)
+
+        backfill_group_pr_lifecycle(
+            group_id=self.group.id,
+            project_id=self.project.id,
+        )
+        derived = process_group_log(self.group.id)
+
+        closed_entry = GroupActionLogEntry.objects.get(
+            group_id=self.group.id,
+            type=GroupActionType.PULL_REQUEST_CLOSED,
+        )
+        assert closed_entry.data["has_other_open_prs"] is True
+        assert derived.data["has_open_fix_pr"] is True
+        assert derived.progress == IssueProgressState.FIX_PROPOSED
+
+    def test_all_terminal_pull_requests_clear_fix_proposed(self) -> None:
+        pull_request = self._create_linked_pull_request(
+            state=PullRequestLifecycleState.MERGED,
+            merged_at=self.now - timedelta(minutes=1),
+        )
+        self._backfill_resolved_action(pull_request)
+
+        backfill_group_pr_lifecycle(
+            group_id=self.group.id,
+            project_id=self.project.id,
+        )
+        derived = process_group_log(self.group.id)
+
+        assert derived.data["has_open_fix_pr"] is False
+        assert derived.progress != IssueProgressState.FIX_PROPOSED
+
+    def test_skips_terminal_pull_request_without_timestamp(self) -> None:
+        self._create_linked_pull_request(state=PullRequestLifecycleState.MERGED)
+
+        assert (
+            backfill_group_pr_lifecycle(
+                group_id=self.group.id,
+                project_id=self.project.id,
+            )
+            == 0
+        )
+        assert not GroupActionLogEntry.objects.filter(group_id=self.group.id).exists()
+
+    def test_skips_pull_request_with_existing_lifecycle_entry(self) -> None:
+        pull_request = self._create_linked_pull_request(
+            state=PullRequestLifecycleState.CLOSED,
+            closed_at=self.now - timedelta(minutes=1),
+        )
+        self.create_group_action_log_entry(
+            group=self.group,
+            type=GroupActionType.PULL_REQUEST_REOPENED,
+            data={"pull_request": str(pull_request.id)},
+        )
+
+        assert (
+            backfill_group_pr_lifecycle(
+                group_id=self.group.id,
+                project_id=self.project.id,
+            )
+            == 0
+        )
+        assert GroupActionLogEntry.objects.filter(group_id=self.group.id).count() == 1
+
+    def test_idempotent_on_rerun(self) -> None:
+        self._create_linked_pull_request(
+            state=PullRequestLifecycleState.MERGED,
+            merged_at=self.now - timedelta(minutes=1),
+        )
+
+        first_count = backfill_group_pr_lifecycle(
+            group_id=self.group.id,
+            project_id=self.project.id,
+        )
+        second_count = backfill_group_pr_lifecycle(
+            group_id=self.group.id,
+            project_id=self.project.id,
+        )
+
+        assert first_count == 1
+        assert second_count == 0
+        assert GroupActionLogEntry.objects.filter(group_id=self.group.id).count() == 1
+
+    def test_skips_non_resolving_pull_request_link(self) -> None:
+        self._create_linked_pull_request(
+            state=PullRequestLifecycleState.MERGED,
+            relationship=GroupLink.Relationship.references,
+            merged_at=self.now - timedelta(minutes=1),
+        )
+
+        assert (
+            backfill_group_pr_lifecycle(
+                group_id=self.group.id,
+                project_id=self.project.id,
+            )
+            == 0
+        )

--- a/tests/sentry/tasks/test_backfill_group_action_log.py
+++ b/tests/sentry/tasks/test_backfill_group_action_log.py
@@ -327,6 +327,22 @@ class BackfillGroupActionLogForProjectTest(TestCase):
         assert call_kwargs["cursor_datetime"] is not None
         assert call_kwargs["cursor_id"] > 0
 
+    def test_self_chain_propagates_pr_lifecycle_handoff(self) -> None:
+        for _ in range(3):
+            self._create_activity(ActivityType.SET_RESOLVED, user_id=self.user.id)
+
+        with (
+            self._options(batch_size=2),
+            patch.object(backfill_group_action_log_for_project, "apply_async") as mock_apply,
+        ):
+            backfill_group_action_log_for_project(
+                self.project.id,
+                chain_pr_lifecycle=True,
+            )
+
+        call_kwargs = mock_apply.call_args.kwargs["kwargs"]
+        assert call_kwargs["chain_pr_lifecycle"] is True
+
     def test_completes_when_no_activities(self) -> None:
         with (
             self._options(),
@@ -465,3 +481,40 @@ class BackfillGroupActionLogForProjectTest(TestCase):
             backfill_group_action_log_for_project(self.project.id)
 
         mock_derived.assert_called_once_with(project_id=self.project.id)
+
+    def test_chains_pr_lifecycle_instead_of_derived_data_on_completion(self) -> None:
+        with (
+            self._options(),
+            patch(
+                "sentry.tasks.backfill_pr_lifecycle_action_log."
+                "backfill_pr_lifecycle_action_log_for_project.delay"
+            ) as mock_pr_lifecycle,
+            patch("sentry.issues.derived.tasks.process_project_derived_data.delay") as mock_derived,
+        ):
+            backfill_group_action_log_for_project(
+                self.project.id,
+                chain_pr_lifecycle=True,
+            )
+
+        mock_pr_lifecycle.assert_called_once_with(project_id=self.project.id)
+        mock_derived.assert_not_called()
+
+    def test_chains_pr_lifecycle_after_final_activity_batch(self) -> None:
+        self._create_activity(ActivityType.SET_RESOLVED, user_id=self.user.id)
+
+        with (
+            self._options(),
+            patch(
+                "sentry.tasks.backfill_pr_lifecycle_action_log."
+                "backfill_pr_lifecycle_action_log_for_project.delay"
+            ) as mock_pr_lifecycle,
+            patch("sentry.issues.derived.tasks.process_project_derived_data.delay") as mock_derived,
+        ):
+            backfill_group_action_log_for_project(
+                self.project.id,
+                chain_pr_lifecycle=True,
+            )
+
+        assert GroupActionLogEntry.objects.filter(group_id=self.group.id).count() == 1
+        mock_pr_lifecycle.assert_called_once_with(project_id=self.project.id)
+        mock_derived.assert_not_called()

--- a/tests/sentry/tasks/test_backfill_pr_lifecycle_action_log.py
+++ b/tests/sentry/tasks/test_backfill_pr_lifecycle_action_log.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+from django.utils import timezone
+
+from sentry import options as real_options
+from sentry.issues.action_log.backfill import BACKFILL_PR_LIFECYCLE_SOURCE
+from sentry.issues.action_log.types import GroupActionType
+from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
+from sentry.issues.models.groupderiveddata import GroupDerivedData
+from sentry.models.group import Group
+from sentry.models.grouplink import GroupLink
+from sentry.models.pullrequest import PullRequest, PullRequestLifecycleState
+from sentry.tasks.backfill_pr_lifecycle_action_log import (
+    backfill_pr_lifecycle_action_log_for_group,
+    backfill_pr_lifecycle_action_log_for_project,
+)
+from sentry.testutils.cases import TestCase
+
+TEST_BATCH_SIZE = 5
+
+
+class BackfillPullRequestLifecycleActionLogTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.repository = self.create_repo(project=self.project)
+        self.now = timezone.now()
+
+    def _options(
+        self,
+        *,
+        killswitch: bool = False,
+        batch_size: int = TEST_BATCH_SIZE,
+        delay: int = 0,
+    ) -> Any:
+        overrides = {
+            "issues.backfill_pr_lifecycle_action_log.killswitch": killswitch,
+            "issues.backfill_pr_lifecycle_action_log.batch_size": batch_size,
+            "issues.backfill_pr_lifecycle_action_log.inter_batch_delay_s": delay,
+        }
+        original_get = real_options.get
+
+        def side_effect(key: str, *args: Any, **kwargs: Any) -> Any:
+            if key in overrides:
+                return overrides[key]
+            return original_get(key, *args, **kwargs)
+
+        return patch(
+            "sentry.tasks.backfill_pr_lifecycle_action_log.options.get",
+            side_effect=side_effect,
+        )
+
+    def _create_linked_pull_request(self, group: Group) -> PullRequest:
+        pull_request = self.create_pull_request(
+            repository_id=self.repository.id,
+            organization_id=self.organization.id,
+        )
+        PullRequest.objects.filter(id=pull_request.id).update(
+            state=PullRequestLifecycleState.MERGED,
+            merged_at=self.now,
+        )
+        pull_request.refresh_from_db()
+        GroupLink.objects.create(
+            group_id=group.id,
+            project_id=group.project_id,
+            linked_type=GroupLink.LinkedType.pull_request,
+            relationship=GroupLink.Relationship.resolves,
+            linked_id=pull_request.id,
+        )
+        return pull_request
+
+    def test_group_task_backfills_lifecycle_entry(self) -> None:
+        group = self.create_group()
+        self._create_linked_pull_request(group)
+
+        backfill_pr_lifecycle_action_log_for_group(group.id)
+
+        assert GroupActionLogEntry.objects.filter(
+            group_id=group.id,
+            type=GroupActionType.PULL_REQUEST_MERGED,
+        ).exists()
+
+    def test_project_task_backfills_each_linked_group(self) -> None:
+        groups = [self.create_group(), self.create_group()]
+        for group in groups:
+            self._create_linked_pull_request(group)
+
+        with (
+            self._options(),
+            patch.object(backfill_pr_lifecycle_action_log_for_project, "apply_async"),
+            patch("sentry.issues.derived.tasks.process_project_derived_data.delay") as mock_derived,
+        ):
+            backfill_pr_lifecycle_action_log_for_project(self.project.id)
+
+        assert GroupActionLogEntry.objects.filter(
+            project_id=self.project.id,
+            type=GroupActionType.PULL_REQUEST_MERGED,
+        ).count() == len(groups)
+        mock_derived.assert_called_once_with(project_id=self.project.id)
+
+    def test_project_task_respects_killswitch(self) -> None:
+        group = self.create_group()
+        self._create_linked_pull_request(group)
+
+        with self._options(killswitch=True):
+            backfill_pr_lifecycle_action_log_for_project(self.project.id)
+
+        assert not GroupActionLogEntry.objects.filter(project_id=self.project.id).exists()
+
+    def test_project_task_self_chains_with_group_cursor(self) -> None:
+        groups = [self.create_group(), self.create_group(), self.create_group()]
+        for group in groups:
+            self._create_linked_pull_request(group)
+
+        with (
+            self._options(batch_size=2, delay=3),
+            patch.object(
+                backfill_pr_lifecycle_action_log_for_project,
+                "apply_async",
+            ) as mock_apply,
+            patch("sentry.issues.derived.tasks.process_project_derived_data.delay") as mock_derived,
+        ):
+            backfill_pr_lifecycle_action_log_for_project(self.project.id)
+
+        mock_apply.assert_called_once_with(
+            kwargs={
+                "project_id": self.project.id,
+                "cursor_group_id": sorted(group.id for group in groups)[1],
+            },
+            countdown=3,
+            headers={"sentry-propagate-traces": False},
+        )
+        mock_derived.assert_not_called()
+        assert GroupActionLogEntry.objects.filter(project_id=self.project.id).count() == 2
+
+    def test_project_task_processes_derived_data_when_complete(self) -> None:
+        with (
+            self._options(),
+            patch("sentry.issues.derived.tasks.process_project_derived_data.delay") as mock_derived,
+        ):
+            backfill_pr_lifecycle_action_log_for_project(self.project.id)
+
+        mock_derived.assert_called_once_with(project_id=self.project.id)
+
+    def test_reset_deletes_backfilled_entries_and_derived_data(self) -> None:
+        group = self.create_group()
+        self.create_group_action_log_entry(
+            group=group,
+            type=GroupActionType.PULL_REQUEST_MERGED,
+            source=BACKFILL_PR_LIFECYCLE_SOURCE,
+            data={"pull_request": 1, "has_other_open_prs": False},
+        )
+        self.create_group_derived_data(group=group)
+
+        with (
+            self._options(),
+            patch("sentry.issues.derived.tasks.process_project_derived_data.delay"),
+        ):
+            backfill_pr_lifecycle_action_log_for_project(self.project.id, reset=True)
+
+        assert not GroupActionLogEntry.objects.filter(
+            project_id=self.project.id,
+            source=BACKFILL_PR_LIFECYCLE_SOURCE,
+        ).exists()
+        assert not GroupDerivedData.objects.filter(group_id=group.id).exists()


### PR DESCRIPTION
Ref ISWF-3068

See ticket for the full details, but the tl;dr is that we recently added some action logs and we need to ensure that we've backfilled historical pull request actions like `PULL_REQUEST_CLOSED` so that we can properly calculate the progress.

This PR adds a task to do this which compares the current `PullRequest` model to the existing action log entries and decides if we need to add new entries. This task can be run independently if needed, but I also added a param to chain it on top of the existing activity log backfill task. This task is dependent on the activity logs already being backfilled, so it probably makes sense in most cases to do the full activity backfill and pr lifecycle backfill one after another.

I will need to follow this up with a getsentry PR to update the custom jobs to point at this task and run it for internal orgs.