### PR TITLE
fix(conversations): stop loading after reaching the pagination cap

### DIFF
--- a/static/app/views/explore/conversations/hooks/useConversation.spec.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversation.spec.tsx
@@ -42,6 +42,34 @@ describe('useConversation', () => {
     expect(result.current.isLoading).toBe(false);
   });
 
+  it('stops loading after reaching the pagination cap', async () => {
+    const url = `/organizations/${organization.slug}/ai-conversations/conv-123/`;
+    const requests = Array.from({length: 10}, (_, index) =>
+      MockApiClient.addMockResponse({
+        url,
+        match: [MockApiClient.matchQuery({cursor: index === 0 ? undefined : `${index}`})],
+        body: [{...BASE_SPAN, span_id: `span-${index}`}],
+        headers: {
+          Link: `<${url}?cursor=${index + 1}>; rel="next"; results="true"; cursor="${index + 1}"`,
+        },
+      })
+    );
+
+    const {result} = renderHookWithProviders(
+      () => useConversation({conversationId: 'conv-123'}),
+      {organization}
+    );
+
+    await waitFor(() => {
+      expect(requests.map(request => request.mock.calls.length)).toEqual(
+        Array.from({length: 10}, () => 1)
+      );
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.nodes).toHaveLength(10);
+  });
+
   it('maps gen_ai.input.messages to node attributes', async () => {
     const inputMessages = JSON.stringify([{role: 'user', content: 'Hello from input'}]);
 

--- a/static/app/views/explore/conversations/hooks/useConversation.spec.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversation.spec.tsx
@@ -90,12 +90,12 @@ describe('useConversation', () => {
   });
 
   it('stops loading after reaching the pagination cap', async () => {
-    const url = `/organizations/${organization.slug}/ai-conversations/conv-123/`;
+    const url = `/organizations/${organization.slug}/agents/conversations/conv-123/`;
     const requests = Array.from({length: 10}, (_, index) =>
       MockApiClient.addMockResponse({
         url,
         match: [MockApiClient.matchQuery({cursor: index === 0 ? undefined : `${index}`})],
-        body: [{...BASE_SPAN, span_id: `span-${index}`}],
+        body: envelope([{...BASE_SPAN, span_id: `span-${index}`}]),
         headers: {
           Link: `<${url}?cursor=${index + 1}>; rel="next"; results="true"; cursor="${index + 1}"`,
         },

--- a/static/app/views/explore/conversations/hooks/useConversation.spec.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversation.spec.tsx
@@ -89,6 +89,34 @@ describe('useConversation', () => {
     expect(result.current.title).toBeNull();
   });
 
+  it('stops loading after reaching the pagination cap', async () => {
+    const url = `/organizations/${organization.slug}/ai-conversations/conv-123/`;
+    const requests = Array.from({length: 10}, (_, index) =>
+      MockApiClient.addMockResponse({
+        url,
+        match: [MockApiClient.matchQuery({cursor: index === 0 ? undefined : `${index}`})],
+        body: [{...BASE_SPAN, span_id: `span-${index}`}],
+        headers: {
+          Link: `<${url}?cursor=${index + 1}>; rel="next"; results="true"; cursor="${index + 1}"`,
+        },
+      })
+    );
+
+    const {result} = renderHookWithProviders(
+      () => useConversation({conversationId: 'conv-123'}),
+      {organization}
+    );
+
+    await waitFor(() => {
+      expect(requests.map(request => request.mock.calls.length)).toEqual(
+        Array.from({length: 10}, () => 1)
+      );
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.nodes).toHaveLength(10);
+  });
+
   it('maps gen_ai.input.messages to node attributes', async () => {
     const inputMessages = JSON.stringify([{role: 'user', content: 'Hello from input'}]);
 

--- a/static/app/views/explore/conversations/hooks/useConversation.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversation.tsx
@@ -262,12 +262,13 @@ export function useConversation(
   );
 
   const currentNumberPages = data?.pages.length ?? 0;
+  const canFetchNextPage = Boolean(hasNextPage && currentNumberPages < MAX_PAGES);
 
   useEffect(() => {
-    if (!isFetching && hasNextPage && currentNumberPages < MAX_PAGES) {
+    if (!isFetching && canFetchNextPage) {
       fetchNextPage();
     }
-  }, [isFetching, hasNextPage, fetchNextPage, currentNumberPages]);
+  }, [isFetching, canFetchNextPage, fetchNextPage, currentNumberPages]);
 
   const allSpans = useMemo(() => data?.pages.flatMap(page => page.json) ?? [], [data]);
 
@@ -304,7 +305,7 @@ export function useConversation(
   return {
     nodes,
     nodeTraceMap,
-    isLoading: isLoading || isFetchingNextPage || hasNextPage,
+    isLoading: isLoading || isFetchingNextPage || canFetchNextPage,
     error: isError,
   };
 }

--- a/static/app/views/explore/conversations/hooks/useConversation.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversation.tsx
@@ -354,7 +354,7 @@ export function useConversation(
     if (!isFetching && canFetchNextPage) {
       fetchNextPage();
     }
-  }, [isFetching, canFetchNextPage, fetchNextPage, currentNumberPages]);
+  }, [data, isFetching, canFetchNextPage, fetchNextPage]);
 
   const allSpans = useMemo(
     () => data?.pages.flatMap(page => page.json.spans ?? []) ?? [],

--- a/static/app/views/explore/conversations/hooks/useConversation.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversation.tsx
@@ -348,12 +348,13 @@ export function useConversation(
   );
 
   const currentNumberPages = data?.pages.length ?? 0;
+  const canFetchNextPage = Boolean(hasNextPage && currentNumberPages < MAX_PAGES);
 
   useEffect(() => {
-    if (!isFetching && hasNextPage && currentNumberPages < MAX_PAGES) {
+    if (!isFetching && canFetchNextPage) {
       fetchNextPage();
     }
-  }, [isFetching, hasNextPage, fetchNextPage, currentNumberPages]);
+  }, [isFetching, canFetchNextPage, fetchNextPage, currentNumberPages]);
 
   const allSpans = useMemo(
     () => data?.pages.flatMap(page => page.json.spans ?? []) ?? [],
@@ -396,7 +397,7 @@ export function useConversation(
   return {
     nodes,
     nodeTraceMap,
-    isLoading: isLoading || isFetchingNextPage || hasNextPage,
+    isLoading: isLoading || isFetchingNextPage || canFetchNextPage,
     error: isError,
     title,
   };

--- a/static/app/views/explore/conversations/hooks/useConversation.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversation.tsx
@@ -268,7 +268,7 @@ export function useConversation(
     if (!isFetching && canFetchNextPage) {
       fetchNextPage();
     }
-  }, [isFetching, canFetchNextPage, fetchNextPage, currentNumberPages]);
+  }, [data, isFetching, canFetchNextPage, fetchNextPage]);
 
   const allSpans = useMemo(() => data?.pages.flatMap(page => page.json) ?? [], [data]);
 


### PR DESCRIPTION
## Summary

- use the pagination cap when deciding whether conversation details are still loading
- stop reporting a loading state after ten pages even when the API returns another cursor
- cover the capped case with ten paginated responses

## Why

Conversation details automatically fetch at most ten pages. Previously, the returned loading state used the raw `hasNextPage` value, so conversations with more than 10,000 spans stayed in a loading state forever after page ten.

## Testing

- `pnpm exec jest static/app/views/explore/conversations/hooks/useConversation.spec.tsx --runInBand`
- `pnpm exec oxfmt --check static/app/views/explore/conversations/hooks/useConversation.tsx static/app/views/explore/conversations/hooks/useConversation.spec.tsx`
- `pnpm exec eslint static/app/views/explore/conversations/hooks/useConversation.tsx static/app/views/explore/conversations/hooks/useConversation.spec.tsx`