### PR TITLE
fix(issues): Remove unsupported filters from inbox URLs

### DIFF
--- a/static/app/views/issueList/index.tsx
+++ b/static/app/views/issueList/index.tsx
@@ -23,6 +23,7 @@ import {useUpdateGroupSearchViewLastVisited} from 'sentry/views/navigation/secon
 
 type Props = {
   children: React.ReactNode;
+  disablePageFilters?: boolean;
   title?: string;
 };
 
@@ -68,11 +69,11 @@ function useHydrateIssueViewQueryParams({view}: {view: GroupSearchView | undefin
   }, [view, previousViewData, navigate, organization.slug]);
 }
 
-function StreamWrapper({children}: Props) {
+function StreamWrapper({children, disablePageFilters}: Props) {
   const organization = useOrganization();
   useRouteAnalyticsHookSetup();
   const {viewId} = useParams<{orgId?: string; viewId?: string}>();
-  const onIssuesFeed = !viewId;
+  const onIssuesFeed = !viewId && !disablePageFilters;
 
   return (
     <PageFiltersContainer
@@ -85,7 +86,7 @@ function StreamWrapper({children}: Props) {
   );
 }
 
-function IssueViewWrapper({children}: Props) {
+function IssueViewWrapper({children, disablePageFilters}: Props) {
   const organization = useOrganization();
   const {data: groupSearchView, isLoading, isError} = useSelectedGroupSearchView();
   useUpdateViewLastVisited({view: groupSearchView});
@@ -102,22 +103,30 @@ function IssueViewWrapper({children}: Props) {
   if (groupSearchView) {
     return (
       <SentryDocumentTitle title={groupSearchView.name} orgSlug={organization.slug}>
-        <StreamWrapper>{children}</StreamWrapper>
+        <StreamWrapper disablePageFilters={disablePageFilters}>{children}</StreamWrapper>
       </SentryDocumentTitle>
     );
   }
 
-  return <StreamWrapper>{children}</StreamWrapper>;
+  return (
+    <StreamWrapper disablePageFilters={disablePageFilters}>{children}</StreamWrapper>
+  );
 }
 
-export function IssueListContainer({children, title = t('Issues')}: Props) {
+export function IssueListContainer({
+  children,
+  disablePageFilters,
+  title = t('Issues'),
+}: Props) {
   const organization = useOrganization();
 
   return (
     <SentryDocumentTitle title={title} orgSlug={organization.slug}>
       <AnalyticsArea name="issue_list">
         <AiQueryProvider>
-          <IssueViewWrapper>{children}</IssueViewWrapper>
+          <IssueViewWrapper disablePageFilters={disablePageFilters}>
+            {children}
+          </IssueViewWrapper>
         </AiQueryProvider>
       </AnalyticsArea>
     </SentryDocumentTitle>

--- a/static/app/views/issueList/index.tsx
+++ b/static/app/views/issueList/index.tsx
@@ -12,6 +12,7 @@ import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import {useRouteAnalyticsHookSetup} from 'sentry/utils/routeAnalytics/useRouteAnalyticsHookSetup';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
+import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
@@ -23,7 +24,6 @@ import {useUpdateGroupSearchViewLastVisited} from 'sentry/views/navigation/secon
 
 type Props = {
   children: React.ReactNode;
-  disablePageFilters?: boolean;
   title?: string;
 };
 
@@ -69,11 +69,12 @@ function useHydrateIssueViewQueryParams({view}: {view: GroupSearchView | undefin
   }, [view, previousViewData, navigate, organization.slug]);
 }
 
-function StreamWrapper({children, disablePageFilters}: Props) {
+function StreamWrapper({children}: Props) {
   const organization = useOrganization();
+  const location = useLocation();
   useRouteAnalyticsHookSetup();
   const {viewId} = useParams<{orgId?: string; viewId?: string}>();
-  const onIssuesFeed = !viewId && !disablePageFilters;
+  const onIssuesFeed = !viewId && !location.pathname.endsWith('/issues/inbox/');
 
   return (
     <PageFiltersContainer
@@ -86,7 +87,7 @@ function StreamWrapper({children, disablePageFilters}: Props) {
   );
 }
 
-function IssueViewWrapper({children, disablePageFilters}: Props) {
+function IssueViewWrapper({children}: Props) {
   const organization = useOrganization();
   const {data: groupSearchView, isLoading, isError} = useSelectedGroupSearchView();
   useUpdateViewLastVisited({view: groupSearchView});
@@ -103,30 +104,22 @@ function IssueViewWrapper({children, disablePageFilters}: Props) {
   if (groupSearchView) {
     return (
       <SentryDocumentTitle title={groupSearchView.name} orgSlug={organization.slug}>
-        <StreamWrapper disablePageFilters={disablePageFilters}>{children}</StreamWrapper>
+        <StreamWrapper>{children}</StreamWrapper>
       </SentryDocumentTitle>
     );
   }
 
-  return (
-    <StreamWrapper disablePageFilters={disablePageFilters}>{children}</StreamWrapper>
-  );
+  return <StreamWrapper>{children}</StreamWrapper>;
 }
 
-export function IssueListContainer({
-  children,
-  disablePageFilters,
-  title = t('Issues'),
-}: Props) {
+export function IssueListContainer({children, title = t('Issues')}: Props) {
   const organization = useOrganization();
 
   return (
     <SentryDocumentTitle title={title} orgSlug={organization.slug}>
       <AnalyticsArea name="issue_list">
         <AiQueryProvider>
-          <IssueViewWrapper disablePageFilters={disablePageFilters}>
-            {children}
-          </IssueViewWrapper>
+          <IssueViewWrapper>{children}</IssueViewWrapper>
         </AiQueryProvider>
       </AnalyticsArea>
     </SentryDocumentTitle>

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -38,11 +38,7 @@ describe('InboxPage', () => {
   const initialRouterConfig = {
     location: {
       pathname: '/organizations/org-slug/issues/inbox/',
-      query: {
-        project: project.id,
-        environment: 'production',
-        statsPeriod: '7d',
-      },
+      query: {},
     },
   };
   const assignedUser = UserFixture({
@@ -327,6 +323,29 @@ describe('InboxPage', () => {
     expect(within(fixSection).queryByRole('checkbox')).not.toBeInTheDocument();
     expect(fixSection.querySelector('time')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', {name: '7D'})).not.toBeInTheDocument();
+  });
+
+  it('removes page filters from the URL', async () => {
+    mockSuccessfulSections();
+
+    const {router} = render(<InboxPage />, {
+      organization,
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/issues/inbox/',
+          query: {
+            end: '2026-07-28T00:00:00',
+            environment: 'production',
+            project: '1',
+            start: '2026-07-27T00:00:00',
+            statsPeriod: '24h',
+            utc: 'true',
+          },
+        },
+      },
+    });
+
+    await waitFor(() => expect(router.location.query).toEqual({}));
   });
 
   it('shows a plus sign when a section count reaches the API cap', async () => {

--- a/static/app/views/issueList/pages/inbox.tsx
+++ b/static/app/views/issueList/pages/inbox.tsx
@@ -95,7 +95,7 @@ export default function InboxPage() {
   }
 
   return (
-    <IssueListContainer title={TITLE} disablePageFilters>
+    <IssueListContainer title={TITLE}>
       <InboxContent />
     </IssueListContainer>
   );

--- a/static/app/views/issueList/pages/inbox.tsx
+++ b/static/app/views/issueList/pages/inbox.tsx
@@ -1,5 +1,7 @@
+import {Navigate} from 'react-router-dom';
 import styled from '@emotion/styled';
 import {useInfiniteQuery} from '@tanstack/react-query';
+import omit from 'lodash/omit';
 import {parseAsString, parseAsStringLiteral, useQueryState} from 'nuqs';
 
 import {ActorAvatar, ProjectAvatar, UserAvatar} from '@sentry/scraps/avatar';
@@ -17,6 +19,7 @@ import {NotFound} from 'sentry/components/errors/notFound';
 import {EventMessage} from 'sentry/components/events/eventMessage';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {LoadingError} from 'sentry/components/loadingError';
+import {URL_PARAM} from 'sentry/components/pageFilters/constants';
 import {Placeholder} from 'sentry/components/placeholder';
 import {QueryCount} from 'sentry/components/queryCount';
 import {IconArrow, IconChevron} from 'sentry/icons';
@@ -26,6 +29,7 @@ import type {User} from 'sentry/types/user';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {getMessage, getTitle} from 'sentry/utils/events';
 import {useMembers} from 'sentry/utils/members/useMembers';
+import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {IssuePreview} from 'sentry/views/issueDetails/issuePreview/issuePreview';
@@ -39,6 +43,7 @@ const ISSUE_LIMIT = 5;
 const SELECTED_ISSUE_QUERY_PARAM = 'preview';
 const ASSIGNMENT_QUERY_PARAM = 'assignment';
 const ASSIGNMENT_FILTERS = ['me', 'my_teams', 'all'] as const;
+const PAGE_FILTER_QUERY_PARAMS = Object.values(URL_PARAM);
 type AssignmentFilter = (typeof ASSIGNMENT_FILTERS)[number];
 export const ASSIGNMENT_QUERY_SUFFIXES: Record<AssignmentFilter, string> = {
   me: ' assigned:me',
@@ -90,13 +95,17 @@ export default function InboxPage() {
   }
 
   return (
-    <IssueListContainer title={TITLE}>
+    <IssueListContainer title={TITLE} disablePageFilters>
       <InboxContent />
     </IssueListContainer>
   );
 }
 
 function InboxContent() {
+  const location = useLocation();
+  const hasPageFilterQueryParams = PAGE_FILTER_QUERY_PARAMS.some(
+    key => location.query[key] !== undefined
+  );
   const [assignmentFilter, setAssignmentFilter] = useQueryState(
     ASSIGNMENT_QUERY_PARAM,
     parseAsStringLiteral(ASSIGNMENT_FILTERS)
@@ -107,6 +116,18 @@ function InboxContent() {
     SELECTED_ISSUE_QUERY_PARAM,
     parseAsString.withOptions({history: 'replace'})
   );
+
+  if (hasPageFilterQueryParams) {
+    return (
+      <Navigate
+        replace
+        to={normalizeUrl({
+          pathname: location.pathname,
+          query: omit(location.query, PAGE_FILTER_QUERY_PARAMS),
+        })}
+      />
+    );
+  }
 
   return (
     <Stack flex={1} minHeight={0} contain="size" overflow="hidden">


### PR DESCRIPTION
The issue inbox now removes shared project, environment, and date-range parameters from its URL because inbox sections intentionally span all projects, environments, and time ranges. This prevents a time range retained from the main issue stream from restricting the preview's recommended-event lookup and hiding event-dependent content for older issues.

The issue-list container now recognizes Inbox as a non-feed route, so shared page-filter state is neither initialized into its URL nor persisted from it. Inbox then canonicalizes existing links by removing only the shared page-filter keys; inbox-specific state remains in place, while the main issue stream keeps its separately persisted selection when users return.

Refs #120656
