### PR TITLE
chore(weekly-report): Remove "Resolved in PR" label

### DIFF
--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -671,10 +671,8 @@ def fetch_past_resolved_issue_links(ctx: OrganizationReportContext) -> None:
 
     resolution_labels: dict[int, str] = {}
 
-    # Ordered newest first so the most recent resolution wins per group
-    for gr in GroupResolution.objects.filter(group_id__in=all_group_ids).order_by("-datetime"):
-        if gr.group_id in resolution_labels:
-            continue
+    # GroupResolution.group is unique, so there is at most one row per group
+    for gr in GroupResolution.objects.filter(group_id__in=all_group_ids):
         if gr.current_release_version or gr.type in (
             None,
             GroupResolution.Type.in_next_release,

--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -23,7 +23,6 @@ from sentry.issues.grouptype import (
 )
 from sentry.models.group import DEFAULT_TYPE_ID, Group, GroupStatus
 from sentry.models.grouphistory import GroupHistory
-from sentry.models.grouplink import GroupLink
 from sentry.models.groupresolution import GroupResolution
 from sentry.models.organization import Organization
 from sentry.models.organizationmember import OrganizationMember
@@ -672,17 +671,8 @@ def fetch_past_resolved_issue_links(ctx: OrganizationReportContext) -> None:
 
     resolution_labels: dict[int, str] = {}
 
-    groups_with_pr = set(
-        GroupLink.objects.filter(
-            group_id__in=all_group_ids,
-            linked_type=GroupLink.LinkedType.pull_request,
-            relationship=GroupLink.Relationship.resolves,
-        ).values_list("group_id", flat=True)
-    )
-    for gid in groups_with_pr:
-        resolution_labels[gid] = "Resolved in PR"
-
-    for gr in GroupResolution.objects.filter(group_id__in=all_group_ids):
+    # Ordered newest first so the most recent resolution wins per group
+    for gr in GroupResolution.objects.filter(group_id__in=all_group_ids).order_by("-datetime"):
         if gr.group_id in resolution_labels:
             continue
         if gr.current_release_version or gr.type in (

--- a/src/sentry/web/frontend/debug/debug_weekly_report.py
+++ b/src/sentry/web/frontend/debug/debug_weekly_report.py
@@ -210,7 +210,6 @@ class DebugWeeklyReportView(MailPreviewView):
                     random.choice(
                         [
                             "Resolved",
-                            "Resolved in PR",
                             "Resolved in release",
                             "Resolved in next release",
                         ]

--- a/tests/sentry/tasks/test_weekly_report_utils.py
+++ b/tests/sentry/tasks/test_weekly_report_utils.py
@@ -666,7 +666,7 @@ class WeeklyReportUtilsTest(
         assert label_by_group[group2.id] == "Resolved"
 
     @freeze_time(before_now(days=2).replace(hour=0, minute=0, second=0, microsecond=0))
-    def test_fetch_resolution_label_pr(self) -> None:
+    def test_fetch_resolution_label_pr_link_ignored(self) -> None:
         self.project.first_event = self.now - timedelta(days=3)
         self.project.save()
         min_ago = (self.now - timedelta(minutes=1)).isoformat()
@@ -704,7 +704,7 @@ class WeeklyReportUtilsTest(
 
         updated = ctx.projects_context_map[self.project.id].past_resolved_issues
         assert len(updated) == 1
-        assert updated[0][2] == "Resolved in PR"
+        assert updated[0][2] == "Resolved"
 
     @freeze_time(before_now(days=2).replace(hour=0, minute=0, second=0, microsecond=0))
     def test_fetch_resolution_label_release(self) -> None:
@@ -791,7 +791,7 @@ class WeeklyReportUtilsTest(
         assert updated[0][2] == "Resolved in next release"
 
     @freeze_time(before_now(days=2).replace(hour=0, minute=0, second=0, microsecond=0))
-    def test_fetch_resolution_label_pr_priority_over_release(self) -> None:
+    def test_fetch_resolution_label_release_with_pr_link(self) -> None:
         self.project.first_event = self.now - timedelta(days=3)
         self.project.save()
         min_ago = (self.now - timedelta(minutes=1)).isoformat()
@@ -837,7 +837,7 @@ class WeeklyReportUtilsTest(
 
         updated = ctx.projects_context_map[self.project.id].past_resolved_issues
         assert len(updated) == 1
-        assert updated[0][2] == "Resolved in PR"
+        assert updated[0][2] == "Resolved in release"
 
     @freeze_time(before_now(days=2).replace(hour=0, minute=0, second=0, microsecond=0))
     def test_fetch_resolution_label_null_type(self) -> None:


### PR DESCRIPTION
Problem statement: "Resolved in PR" causes confusion ---> phasing out in favor of release

Goal: Only use "Resolved in release" and "Resolved in next release" labels