### PR TITLE
ref(issues): Share secondary navigation count styles

### DIFF
--- a/static/app/views/issueList/queries/useInboxIssueCount.tsx
+++ b/static/app/views/issueList/queries/useInboxIssueCount.tsx
@@ -4,9 +4,6 @@ import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {ASSIGNMENT_QUERY_SUFFIXES, SECTIONS} from 'sentry/views/issueList/pages/inbox';
 
-/** The endpoint stops counting at 100, so anything higher is a floor. */
-export const INBOX_COUNT_MAX = 99;
-
 const PROGRESS_STATES = SECTIONS.map(section => section.progress).join(', ');
 
 // A separate Snuba search runs per `query` param, so all the states travel as one.

--- a/static/app/views/navigation/secondary/sections/issues/issueCount.tsx
+++ b/static/app/views/navigation/secondary/sections/issues/issueCount.tsx
@@ -1,0 +1,39 @@
+import styled from '@emotion/styled';
+
+import {Tag} from '@sentry/scraps/badge';
+import {Text} from '@sentry/scraps/text';
+
+const MAX_COUNT = 99;
+
+export function IssueCount({count}: {count: number}) {
+  return (
+    <StyledTag variant="muted">
+      <Text variant="muted" size="xs" align="center" tabular>
+        {count > MAX_COUNT ? `${MAX_COUNT}+` : count}
+      </Text>
+    </StyledTag>
+  );
+}
+
+const StyledTag = styled(Tag)`
+  border: 1px solid ${p => p.theme.tokens.border.neutral.muted};
+  background-color: ${p => p.theme.tokens.background.primary};
+  padding: 0 ${p => p.theme.space.xs};
+  justify-content: end;
+
+  opacity: 0;
+  transform: scale(0.95);
+
+  @keyframes fadeIn {
+    from {
+      opacity: 0;
+      transform: scale(0.95);
+    }
+    to {
+      opacity: 1;
+      transform: scale(1);
+    }
+  }
+
+  animation: fadeIn 0.1s ease-in-out forwards;
+`;

--- a/static/app/views/navigation/secondary/sections/issues/issueViews/issueViewQueryCount.tsx
+++ b/static/app/views/navigation/secondary/sections/issues/issueViews/issueViewQueryCount.tsx
@@ -1,17 +1,11 @@
-import styled from '@emotion/styled';
-
-import {Tag} from '@sentry/scraps/badge';
-import {Text} from '@sentry/scraps/text';
-
 import type {PageFilters} from 'sentry/types/core';
 import {getUtcDateString} from 'sentry/utils/dates';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {createIssueViewFromUrl} from 'sentry/views/issueList/issueViews/createIssueViewFromUrl';
 import {useFetchIssueCounts} from 'sentry/views/issueList/queries/useFetchIssueCounts';
+import {IssueCount} from 'sentry/views/navigation/secondary/sections/issues/issueCount';
 import type {IssueView} from 'sentry/views/navigation/secondary/sections/issues/issueViews/issueViews';
-
-const TAB_MAX_COUNT = 99;
 
 const constructCountTimeFrame = (
   timeFilters: PageFilters['datetime']
@@ -71,33 +65,5 @@ export function IssueViewQueryCount({view, isActive}: IssueViewQueryCountProps) 
     return null;
   }
 
-  return (
-    <StyledTag variant="muted" data-issue-view-query-count>
-      <Text variant="muted" size="xs" align="center" tabular>
-        {count > TAB_MAX_COUNT ? `${TAB_MAX_COUNT}+` : count}
-      </Text>
-    </StyledTag>
-  );
+  return <IssueCount count={count} />;
 }
-const StyledTag = styled(Tag)`
-  border: 1px solid ${p => p.theme.tokens.border.neutral.muted};
-  background-color: ${p => p.theme.tokens.background.primary};
-  padding: 0 ${p => p.theme.space.xs};
-  justify-content: end;
-
-  opacity: 0;
-  transform: scale(0.95);
-
-  @keyframes fadeIn {
-    from {
-      opacity: 0;
-      transform: scale(0.95);
-    }
-    to {
-      opacity: 1;
-      transform: scale(1);
-    }
-  }
-
-  animation: fadeIn 0.1s ease-in-out forwards;
-`;

--- a/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.tsx
@@ -10,13 +10,11 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 import {t, tct} from 'sentry/locale';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {makeAutomationBasePathname} from 'sentry/views/automations/pathnames';
-import {
-  INBOX_COUNT_MAX,
-  useInboxIssueCount,
-} from 'sentry/views/issueList/queries/useInboxIssueCount';
+import {useInboxIssueCount} from 'sentry/views/issueList/queries/useInboxIssueCount';
 import {ISSUE_TAXONOMY_CONFIG} from 'sentry/views/issueList/taxonomies';
 import {usePrimaryNavigation} from 'sentry/views/navigation/primaryNavigationContext';
 import {SecondaryNavigation} from 'sentry/views/navigation/secondary/components';
+import {IssueCount} from 'sentry/views/navigation/secondary/sections/issues/issueCount';
 import {IssueViews} from 'sentry/views/navigation/secondary/sections/issues/issueViews/issueViews';
 
 function InboxCountBadge() {
@@ -26,11 +24,7 @@ function InboxCountBadge() {
     return null;
   }
 
-  return (
-    <Badge variant="muted">
-      {count > INBOX_COUNT_MAX ? `${INBOX_COUNT_MAX}+` : count}
-    </Badge>
-  );
+  return <IssueCount count={count} />;
 }
 
 export function IssuesSecondaryNavigation() {


### PR DESCRIPTION
The Inbox count now uses the same bordered tag, muted tabular text, 99+ cap, and fade-in behavior as saved Issue View counts in secondary navigation. Both surfaces render through a shared `IssueCount` component so their presentation and count formatting cannot drift, while existing loading and zero-count behavior remains unchanged.

Resolves: ISWF-3137
