### PR TITLE
chore: exclude bin/ from pre-push mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,6 +48,7 @@ repos:
         language: system
         stages: [pre-push]
         types: [python]
+        files: \.pyi?$
         require_serial: true
       - id: lint-requirements
         name: lint-requirements

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,7 @@ repos:
         language: system
         stages: [pre-push]
         types: [python]
-        files: \.pyi?$
+        exclude: ^bin/
         require_serial: true
       - id: lint-requirements
         name: lint-requirements

--- a/static/app/components/ai/chat/messageBlock.tsx
+++ b/static/app/components/ai/chat/messageBlock.tsx
@@ -66,18 +66,22 @@ export function AssistantMessageBlock({
   const bubbleCss = css`
     overflow-wrap: anywhere;
     background: ${theme.tokens.background.transparent.accent.muted};
-    ${onClick &&
-    css`
-      cursor: pointer;
-      &:hover {
-        opacity: 0.85;
-      }
-    `}
-    ${isSelected &&
-    css`
-      outline: 2px solid ${theme.tokens.focus.default};
-      outline-offset: -2px;
-    `}
+    ${
+      onClick &&
+      css`
+        cursor: pointer;
+        &:hover {
+          opacity: 0.85;
+        }
+      `
+    }
+    ${
+      isSelected &&
+      css`
+        outline: 2px solid ${theme.tokens.focus.default};
+        outline-offset: -2px;
+      `
+    }
   `;
 
   return (
@@ -90,6 +94,7 @@ export function AssistantMessageBlock({
           padding="md"
           radius="xs"
           css={bubbleCss}
+          data-selected={isSelected}
           onClick={onClick}
           role={onClick ? 'button' : undefined}
           tabIndex={onClick ? 0 : undefined}

--- a/static/app/components/core/input/inputGroup.tsx
+++ b/static/app/components/core/input/inputGroup.tsx
@@ -1,9 +1,11 @@
 import {
   createContext,
+  type Dispatch,
+  type SetStateAction,
+  useCallback,
   useContext,
   useLayoutEffect,
   useMemo,
-  useRef,
   useState,
 } from 'react';
 import {css} from '@emotion/react';
@@ -52,19 +54,23 @@ const inputStyles = ({
   size = 'md',
   theme,
 }: InputStyleProps & {theme: Theme}): StrictCSSObject => css`
-  ${leadingWidth &&
-  css`
-    padding-left: calc(
-      ${theme.form[size].paddingLeft}px + ${itemsPadding[size]}px + ${leadingWidth}px
-    );
-  `}
+  ${
+    leadingWidth &&
+    css`
+      padding-left: calc(
+        ${theme.form[size].paddingLeft}px + ${itemsPadding[size]}px + ${leadingWidth}px
+      );
+    `
+  }
 
-  ${trailingWidth &&
-  css`
-    padding-right: calc(
-      ${theme.form[size].paddingRight}px + ${itemsPadding[size]}px + ${trailingWidth}px
-    );
-  `}
+  ${
+    trailingWidth &&
+    css`
+      padding-right: calc(
+        ${theme.form[size].paddingRight}px + ${itemsPadding[size]}px + ${trailingWidth}px
+      );
+    `
+  }
 `;
 
 const StyledInput = styled(CoreInput)<InputStyleProps>`
@@ -102,8 +108,8 @@ interface InputContext {
    */
   leadingWidth?: number;
   setInputProps?: (props: Pick<InputProps, 'size' | 'disabled'>) => void;
-  setLeadingWidth?: (width: number) => void;
-  setTrailingWidth?: (width: number) => void;
+  setLeadingWidth?: Dispatch<SetStateAction<number | undefined>>;
+  setTrailingWidth?: Dispatch<SetStateAction<number | undefined>>;
   /**
    * Width of the trailing items wrap, to be added to `Input`'s padding.
    */
@@ -194,6 +200,36 @@ interface InputItemsProps extends React.HTMLAttributes<HTMLDivElement> {
   disablePointerEvents?: boolean;
 }
 
+function useInputItemsWidthRef(
+  setWidth: Dispatch<SetStateAction<number | undefined>> | undefined
+) {
+  return useCallback(
+    (node: HTMLDivElement | null) => {
+      if (!node || !setWidth) {
+        return;
+      }
+
+      const updateWidth = () => {
+        setWidth(node.offsetWidth);
+      };
+
+      // Measure synchronously when the node is mounted so the input padding is
+      // correct before the browser paints. The observer handles children that
+      // change size without replacing the items wrapper.
+      updateWidth();
+
+      const observer = new ResizeObserver(updateWidth);
+      observer.observe(node);
+
+      return () => {
+        observer.disconnect();
+        setWidth(undefined);
+      };
+    },
+    [setWidth]
+  );
+}
+
 /**
  * Container for leading input items (e.g. a search icon). To be wrapped
  * inside `InputGroup`:
@@ -203,18 +239,11 @@ interface InputItemsProps extends React.HTMLAttributes<HTMLDivElement> {
  *   </InputGroup>
  */
 function LeadingItems({children, disablePointerEvents, ...props}: InputItemsProps) {
-  const ref = useRef<HTMLDivElement | null>(null);
   const {
     inputProps: {size = 'md', disabled},
     setLeadingWidth,
   } = useContext(InputGroupContext);
-
-  useLayoutEffect(() => {
-    if (!ref.current) {
-      return;
-    }
-    setLeadingWidth?.(ref.current.offsetWidth);
-  }, [children, setLeadingWidth, size]);
+  const ref = useInputItemsWidthRef(setLeadingWidth);
 
   return (
     <StyledLeadingItemsWrap
@@ -238,18 +267,11 @@ function LeadingItems({children, disablePointerEvents, ...props}: InputItemsProp
  *   </InputGroup>
  */
 function TrailingItems({children, disablePointerEvents, ...props}: InputItemsProps) {
-  const ref = useRef<HTMLDivElement | null>(null);
   const {
     inputProps: {size = 'md', disabled},
     setTrailingWidth,
   } = useContext(InputGroupContext);
-
-  useLayoutEffect(() => {
-    if (!ref.current) {
-      return;
-    }
-    setTrailingWidth?.(ref.current.offsetWidth);
-  }, [children, setTrailingWidth, size]);
+  const ref = useInputItemsWidthRef(setTrailingWidth);
 
   return (
     <StyledTrailingItemsWrap

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
@@ -102,6 +102,7 @@ function FeedbackFooter({
         <OpenAskSeerButton ref={askSeerButtonRef} onTabForward={onAskSeerTabForward} />
       ) : null}
       <FeedbackButton
+        variant="secondary"
         size={hasAskSeerRework ? 'zero' : 'xs'}
         feedbackOptions={{
           messagePlaceholder: t('How can we make search better for you?'),
@@ -137,7 +138,12 @@ function RecentSearchFilterOption<T>({
   );
 
   return (
-    <RecentFilterPill key={key} data-test-id="recent-filter-key" {...optionProps}>
+    <RecentFilterPill
+      key={key}
+      ref={ref}
+      data-test-id="recent-filter-key"
+      {...optionProps}
+    >
       <InteractionStateLayer isHovered={isFocused} isPressed={isPressed} />
       <RecentFilterPillLabel {...labelProps}>
         {getKeyLabel(filter.key)}
@@ -475,15 +481,17 @@ const SectionedOverlay = styled(Overlay, {
             'tabs tabs'
             'list list'
             'footer footer';
-          ${p.fullWidth &&
-          css`
-            grid-template-areas:
-              'seer seer'
-              'recentFilters recentFilters'
-              'tabs tabs'
-              ${p.showDetailsPane ? "'list details'" : "'list list'"}
-              'footer footer';
-          `}
+          ${
+            p.fullWidth &&
+            css`
+              grid-template-areas:
+                'seer seer'
+                'recentFilters recentFilters'
+                'tabs tabs'
+                ${p.showDetailsPane ? "'list details'" : "'list list'"}
+                'footer footer';
+            `
+          }
         `
       : css`
           grid-template-rows: auto auto 1fr auto;
@@ -493,14 +501,16 @@ const SectionedOverlay = styled(Overlay, {
             'tabs tabs'
             'list list'
             'footer footer';
-          ${p.fullWidth &&
-          css`
-            grid-template-areas:
-              'recentFilters recentFilters'
-              'tabs tabs'
-              ${p.showDetailsPane ? "'list details'" : "'list list'"}
-              'footer footer';
-          `}
+          ${
+            p.fullWidth &&
+            css`
+              grid-template-areas:
+                'recentFilters recentFilters'
+                'tabs tabs'
+                ${p.showDetailsPane ? "'list details'" : "'list list'"}
+                'footer footer';
+            `
+          }
         `}
   overflow: hidden;
   height: 400px;

--- a/static/app/components/slider/index.tsx
+++ b/static/app/components/slider/index.tsx
@@ -164,9 +164,7 @@ export function Slider({
 
     if (ticks) {
       const range = max - min;
-      return [...Array.from({length: ticks})].map(
-        (_, i) => min + i * (range / (ticks - 1))
-      );
+      return Array.from({length: ticks}, (_, i) => min + i * (range / (ticks - 1)));
     }
 
     return [];
@@ -188,7 +186,7 @@ export function Slider({
       if (allowedValues) {
         return formatLabel
           ? formatLabel(allowedValues[val]!)
-          : state.getFormattedValue(allowedValues[val]!);
+          : state.getFormattedValue(allowedValues[val]);
       }
 
       return formatLabel ? formatLabel(val) : state.getFormattedValue(val);
@@ -269,7 +267,7 @@ export function Slider({
             </SliderTick>
           ))}
 
-          {[...Array.from({length: nThumbs})].map((_, index) => (
+          {Array.from(Array.from({length: nThumbs}), (_, index) => (
             <SliderThumb
               ref={node => {
                 if (!node) {
@@ -398,11 +396,13 @@ const SliderTick = styled('div')<{
     p.inSelection &&
     css`
       /* eslint-disable-next-line @sentry/scraps/use-semantic-token */
-      background: ${p.disabled
-        ? p.theme.tokens.content.disabled
-        : p.error
-          ? p.theme.tokens.content.danger
-          : p.theme.tokens.interactive.link.accent.active};
+      background: ${
+        p.disabled
+          ? p.theme.tokens.content.disabled
+          : p.error
+            ? p.theme.tokens.content.danger
+            : p.theme.tokens.interactive.link.accent.active
+      };
     `}
 `;
 

--- a/static/app/views/discover/table/columnEditCollection.tsx
+++ b/static/app/views/discover/table/columnEditCollection.tsx
@@ -5,7 +5,7 @@ import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
 import {Input} from '@sentry/scraps/input';
-import {Grid, type GridProps} from '@sentry/scraps/layout';
+import {Container, Grid, type GridProps} from '@sentry/scraps/layout';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {parseArithmetic} from 'sentry/components/arithmeticInput/parser';
@@ -533,7 +533,15 @@ function ColumnEditCollection({
             skipParameterPlaceholder={showAliasField}
           />
           {showAliasField && (
-            <AliasField singleColumn={singleColumn}>
+            <Container
+              marginTop={{zero: 'md', xl: '0'}}
+              marginLeft={{zero: '0', xl: 'md'}}
+              row={{zero: '2 / 2', xl: 'auto'}}
+              column={{
+                zero: singleColumn ? '1 / -1' : '2 / 2',
+                xl: 'auto',
+              }}
+            >
               <AliasInput
                 name="alias"
                 placeholder={t('Alias')}
@@ -545,7 +553,7 @@ function ColumnEditCollection({
                   });
                 }}
               />
-            </AliasField>
+            </Container>
           )}
           {canDelete || col.kind === 'equation' ? (
             showAliasField ? (
@@ -725,14 +733,16 @@ const RowContainer = styled('div')<{
     p.showAliasField &&
     css`
       align-items: flex-start;
-      grid-template-columns: ${p.singleColumn
-        ? '1fr'
-        : `${p.theme.space['2xl']} 1fr 40px 40px`};
+      grid-template-columns: ${
+        p.singleColumn ? '1fr' : `${p.theme.space['2xl']} 1fr 40px 40px`
+      };
 
-      @media (min-width: ${p.theme.breakpoints.sm}) {
-        grid-template-columns: ${p.singleColumn
-          ? `1fr calc(200px + ${p.theme.space.md})`
-          : `${p.theme.space['2xl']} 1fr calc(200px + ${p.theme.space.md}) 40px 40px`};
+      @container (min-width: ${p.theme.container.xl}) {
+        grid-template-columns: ${
+          p.singleColumn
+            ? `1fr calc(200px + ${p.theme.space.md})`
+            : `${p.theme.space['2xl']} 1fr calc(200px + ${p.theme.space.md}) 40px 40px`
+        };
       }
     `}
 `;
@@ -788,19 +798,6 @@ const StyledSectionHeading = styled(SectionHeading)`
 
 const AliasInput = styled(Input)`
   min-width: 50px;
-`;
-
-const AliasField = styled('div')<{singleColumn: boolean}>`
-  margin-top: ${p => p.theme.space.md};
-  @media (min-width: ${p => p.theme.breakpoints.sm}) {
-    margin-top: 0;
-    margin-left: ${p => p.theme.space.md};
-  }
-
-  @media (max-width: ${p => p.theme.breakpoints.sm}) {
-    grid-row: 2/2;
-    grid-column: ${p => (p.singleColumn ? '1/-1' : '2/2')};
-  }
 `;
 
 const RemoveButton = styled(Button)`

--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -23,6 +23,7 @@ import {SeverityLevel} from 'sentry/views/explore/logs/utils';
 export const LOGS_GRID_BODY_ROW_HEIGHT = GRID_BODY_ROW_HEIGHT - 16;
 
 interface LogTableRowProps {
+  error?: boolean;
   highlighted?: boolean;
   isClickable?: boolean;
   pinned?: boolean;
@@ -48,8 +49,9 @@ export const LogTableRow = styled(TableRow)<LogTableRowProps>`
       p.isClickable &&
       css`
         &:active {
-          background-color: ${p.theme.tokens.interactive.transparent.neutral.background
-            .active};
+          background-color: ${
+            p.theme.tokens.interactive.transparent.neutral.background.active
+          };
         }
       `}
 
@@ -77,14 +79,28 @@ export const LogTableRow = styled(TableRow)<LogTableRowProps>`
     `}
 
   ${p =>
+    p.error &&
+    css`
+      &:not(thead > &) {
+        background-color: ${p.theme.tokens.background.transparent.danger.muted};
+        color: ${p.theme.tokens.content.danger};
+
+        &:hover {
+          background-color: ${p.theme.tokens.background.transparent.danger.muted};
+        }
+      }
+    `}
+
+  ${p =>
     p.pinned &&
     css`
       &:not(thead > &) {
         background-color: ${p.theme.tokens.background.transparent.accent.muted};
 
         &:hover {
-          background-color: ${p.theme.tokens.interactive.transparent.accent.selected
-            .background.active};
+          background-color: ${
+            p.theme.tokens.interactive.transparent.accent.selected.background.active
+          };
         }
       }
     `}
@@ -159,6 +175,18 @@ export const LogTableBodyCell = styled(TableBodyCell)<{reservePinGutter?: boolea
     padding: 0
       ${p => (p.reservePinGutter ? 'var(--logsPinButtonArea)' : p.theme.space.md)} 0
       ${p => p.theme.space.md};
+  }
+`;
+
+export const LogErrorLabelCell = styled(LogTableBodyCell)`
+  grid-column: 2 / -1;
+  align-items: flex-start;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  &:last-child {
+    padding: 2px 0 2px ${p => p.theme.space['2xl']};
   }
 `;
 
@@ -403,12 +431,6 @@ export const AutoRefreshLabel = styled('label')`
   margin-bottom: 0;
 `;
 
-export const AutoRefreshText = styled('span')`
-  @media (max-width: ${p => p.theme.breakpoints.md}) {
-    display: none;
-  }
-`;
-
 export function getLogColors(level: SeverityLevel, theme: Theme) {
   switch (level) {
     case SeverityLevel.DEFAULT:
@@ -482,12 +504,6 @@ export function getLogColors(level: SeverityLevel, theme: Theme) {
 }
 
 export const LogsSidebarCollapseButton = styled(Button)<{sidebarOpen: boolean}>`
-  display: none;
-
-  @media (min-width: ${p => p.theme.breakpoints.lg}) {
-    display: inline-flex;
-  }
-
   ${p =>
     p.sidebarOpen &&
     css`
@@ -563,15 +579,6 @@ export const StyledPageFilterBar = styled(PageFilterBar)`
   width: auto;
 `;
 
-export const LogsFilterSection = styled('div')`
-  display: grid;
-  gap: ${p => p.theme.space.md};
-
-  @media (min-width: ${p => p.theme.breakpoints.md}) {
-    grid-template-columns: minmax(300px, auto) 1fr min-content;
-  }
-`;
-
 export const TraceIconStyleWrapper = styled(Flex)`
   width: 18px;
   height: 18px;
@@ -594,5 +601,24 @@ export const TraceIconStyleWrapper = styled(Flex)`
     width: 12px;
     height: 12px;
     fill: #ffffff;
+  }
+`;
+
+// The flame indicator is wider than the severity dot it replaces on log rows,
+// so pull the group left to line up the error row's project badge with them.
+export const ErrorRowIconGroup = styled(Flex)`
+  margin-left: -7px;
+
+  .TraceIcon.warning {
+    background-color: ${p => p.theme.tokens.dataviz.semantic.meh};
+  }
+
+  .TraceIcon.info,
+  .TraceIcon.sample {
+    background-color: ${p => p.theme.tokens.dataviz.semantic.accent};
+  }
+
+  .TraceIcon.unknown {
+    background-color: ${p => p.theme.tokens.dataviz.semantic.other};
   }
 `;


### PR DESCRIPTION
## Summary
- Exclude `bin/` from the pre-push mypy hook so extensionless scripts (and other `bin/` paths) are not passed to mypy.
- Avoids `__main__` collisions from shebang scripts that CI discovery never typechecks.

## Test plan
- [x] `SENTRY_MYPY_PRE_PUSH=1 .venv/bin/prek run mypy --files bin/mock-event --stage pre-push` → skipped
- [x] `SENTRY_MYPY_PRE_PUSH=1 .venv/bin/prek run mypy --files bin/__init__.py --stage pre-push` → skipped
- [x] `SENTRY_MYPY_PRE_PUSH=1 .venv/bin/prek run mypy --files src/sentry/__init__.py --stage pre-push` → mypy runs
- [ ] Pushing a branch that touches `bin/` scripts no longer fails mypy solely due to those paths