### PR TITLE
fix(projects): honor custom slug in organization project creation

### DIFF
--- a/src/sentry/core/endpoints/organization_projects.py
+++ b/src/sentry/core/endpoints/organization_projects.py
@@ -381,7 +381,7 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint):
                 )
                 project = Project.objects.create(
                     name=project_name,
-                    # slug is *not* set so we get an automatic one
+                    slug=result.get("slug"),
                     organization=organization,
                     platform=result.get("platform"),
                 )

--- a/src/sentry/core/endpoints/organization_projects.py
+++ b/src/sentry/core/endpoints/organization_projects.py
@@ -93,6 +93,7 @@ DATASETS = {
 }
 
 CONFLICTING_TEAM_SLUG_ERROR = "A team with this slug already exists."
+CONFLICTING_PROJECT_SLUG_ERROR = "A project with this slug already exists."
 MISSING_PERMISSION_ERROR_STRING = "You do not have permission to join a new team as a Team Admin."
 DISABLED_FEATURE_ERROR_STRING = "Your organization has disabled this feature for members."
 
@@ -379,12 +380,21 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint):
                     organizationmember=member,
                     role="admin",
                 )
-                project = Project.objects.create(
-                    name=project_name,
-                    slug=result.get("slug"),
-                    organization=organization,
-                    platform=result.get("platform"),
-                )
+                try:
+                    with transaction.atomic(router.db_for_write(Project)):
+                        project = Project.objects.create(
+                            name=project_name,
+                            slug=result.get("slug"),
+                            organization=organization,
+                            platform=result.get("platform"),
+                        )
+                except (IntegrityError, MaxSnowflakeRetryError):
+                    raise ConflictError(
+                        {
+                            "non_field_errors": [CONFLICTING_PROJECT_SLUG_ERROR],
+                            "detail": CONFLICTING_PROJECT_SLUG_ERROR,
+                        }
+                    )
                 project.add_team(team)
         except (IntegrityError, MaxSnowflakeRetryError):
             raise ConflictError(

--- a/tests/sentry/core/endpoints/test_organization_projects_create.py
+++ b/tests/sentry/core/endpoints/test_organization_projects_create.py
@@ -129,6 +129,19 @@ class OrganizationProjectsCreateTest(APITestCase):
         assert response.data["teams"][0]["id"] == str(team.id)
 
     @with_feature(["organizations:team-roles"])
+    def test_custom_project_slug(self) -> None:
+        response = self.get_success_response(
+            self.organization.slug,
+            name="My Display Name",
+            slug="exact-custom-slug",
+            status_code=201,
+        )
+
+        project = Project.objects.get(id=response.data["id"])
+        assert response.data["slug"] == "exact-custom-slug"
+        assert project.slug == "exact-custom-slug"
+
+    @with_feature(["organizations:team-roles"])
     def test_project_slug_is_slugified(self) -> None:
         unslugified_name = "not_slugged_$!@#$"
         response = self.get_success_response(

--- a/tests/sentry/core/endpoints/test_organization_projects_create.py
+++ b/tests/sentry/core/endpoints/test_organization_projects_create.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, Mock, patch
 from django.utils.text import slugify
 
 from sentry.core.endpoints.organization_projects import (
+    CONFLICTING_PROJECT_SLUG_ERROR,
     DISABLED_FEATURE_ERROR_STRING,
     OrganizationProjectsEndpoint,
     fetch_slugifed_email_username,
@@ -140,6 +141,22 @@ class OrganizationProjectsCreateTest(APITestCase):
         project = Project.objects.get(id=response.data["id"])
         assert response.data["slug"] == "exact-custom-slug"
         assert project.slug == "exact-custom-slug"
+
+    @with_feature(["organizations:team-roles"])
+    def test_duplicate_custom_project_slug(self) -> None:
+        self.create_project(organization=self.organization, slug="exact-custom-slug")
+
+        response = self.get_error_response(
+            self.organization.slug,
+            name="My Display Name",
+            slug="exact-custom-slug",
+            status_code=409,
+        )
+
+        assert response.data == {
+            "non_field_errors": [CONFLICTING_PROJECT_SLUG_ERROR],
+            "detail": CONFLICTING_PROJECT_SLUG_ERROR,
+        }
 
     @with_feature(["organizations:team-roles"])
     def test_project_slug_is_slugified(self) -> None:


### PR DESCRIPTION
## Summary

- pass the validated project slug through the organization-level creation endpoint
- preserve automatic slug generation when no slug is supplied
- cover custom slugs in both the API response and persisted project

## Why

The organization-level endpoint validates an optional slug but previously discarded it during project creation. This made its behavior inconsistent with the team-level endpoint and silently replaced caller-supplied slugs with generated ones.

## Testing

- repository Python pre-commit checks
- mypy pre-push check
- focused ruff check