### PR TITLE
perf(issues): Use progress search for Inbox count

### DIFF
--- a/static/app/views/issueList/queries/useInboxIssueCount.tsx
+++ b/static/app/views/issueList/queries/useInboxIssueCount.tsx
@@ -1,15 +1,16 @@
 import {keepPreviousData, useQuery} from '@tanstack/react-query';
 
-import {apiOptions} from 'sentry/utils/api/apiOptions';
+import type {Group} from 'sentry/types/group';
+import {apiOptions, selectJsonWithHeaders} from 'sentry/utils/api/apiOptions';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {ASSIGNMENT_QUERY_SUFFIXES, SECTIONS} from 'sentry/views/issueList/pages/inbox';
+import {IssueSortOptions} from 'sentry/views/issueList/utils';
 
-/** The endpoint stops counting at 100, so anything higher is a floor. */
+/** The navigation displays anything higher as a floor. */
 export const INBOX_COUNT_MAX = 99;
 
 const PROGRESS_STATES = SECTIONS.map(section => section.progress).join(', ');
 
-// A separate Snuba search runs per `query` param, so all the states travel as one.
 const INBOX_COUNT_QUERY = `issue.progress:[${PROGRESS_STATES}]${ASSIGNMENT_QUERY_SUFFIXES.my_teams}`;
 
 /** Number of issues waiting in the inbox, for the nav badge. */
@@ -17,16 +18,20 @@ export function useInboxIssueCount() {
   const organization = useOrganization();
 
   const {data} = useQuery({
-    ...apiOptions.as<Record<string, number>>()(
-      '/organizations/$organizationIdOrSlug/issues-count/',
-      {
-        path: {organizationIdOrSlug: organization.slug},
-        query: {query: [INBOX_COUNT_QUERY], project: [-1]},
-        staleTime: 180_000,
-      }
-    ),
+    ...apiOptions.as<Group[]>()('/organizations/$organizationIdOrSlug/issues/', {
+      path: {organizationIdOrSlug: organization.slug},
+      query: {
+        collapse: ['stats', 'unhandled'],
+        limit: 1,
+        project: [-1],
+        query: INBOX_COUNT_QUERY,
+        sort: IssueSortOptions.PROGRESS,
+      },
+      staleTime: 180_000,
+    }),
     placeholderData: keepPreviousData,
+    select: selectJsonWithHeaders,
   });
 
-  return data?.[INBOX_COUNT_QUERY] ?? null;
+  return data?.headers['X-Hits'] ?? null;
 }

--- a/static/app/views/navigation/index.desktop.spec.tsx
+++ b/static/app/views/navigation/index.desktop.spec.tsx
@@ -132,6 +132,11 @@ function setupMocks() {
     body: {},
   });
   MockApiClient.addMockResponse({
+    url: '/organizations/org-slug/issues/',
+    body: [],
+    headers: {'X-Hits': '0'},
+  });
+  MockApiClient.addMockResponse({
     url: '/organizations/org-slug/explore/saved/',
     body: [],
   });

--- a/static/app/views/navigation/index.mobile.spec.tsx
+++ b/static/app/views/navigation/index.mobile.spec.tsx
@@ -78,6 +78,11 @@ function setupMocks() {
     body: {},
   });
   MockApiClient.addMockResponse({
+    url: '/organizations/org-slug/issues/',
+    body: [],
+    headers: {'X-Hits': '0'},
+  });
+  MockApiClient.addMockResponse({
     url: '/organizations/org-slug/explore/saved/',
     body: [],
   });

--- a/static/app/views/navigation/secondary/components.spec.tsx
+++ b/static/app/views/navigation/secondary/components.spec.tsx
@@ -52,6 +52,11 @@ function setupMocks() {
     body: {},
   });
   MockApiClient.addMockResponse({
+    url: '/organizations/org-slug/issues/',
+    body: [],
+    headers: {'X-Hits': '0'},
+  });
+  MockApiClient.addMockResponse({
     url: '/organizations/org-slug/explore/saved/',
     body: [],
   });

--- a/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.spec.tsx
+++ b/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.spec.tsx
@@ -17,10 +17,11 @@ describe('IssuesSecondaryNavigation', () => {
     });
   });
 
-  function mockInboxCount(body: Record<string, number>) {
+  function mockInboxCount(count?: number) {
     return MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/issues-count/',
-      body,
+      url: '/organizations/org-slug/issues/',
+      body: [],
+      headers: count === undefined ? {} : {'X-Hits': String(count)},
     });
   }
 
@@ -34,28 +35,30 @@ describe('IssuesSecondaryNavigation', () => {
   }
 
   it('shows the inbox count for every progress section and the user and their teams', async () => {
-    const request = mockInboxCount({
-      'issue.progress:[fix_proposed, diagnosed, assigned] assigned:[me,my_teams]': 12,
-    });
+    const request = mockInboxCount(12);
 
     renderNavigation();
 
     expect(await screen.findByText('12')).toBeInTheDocument();
 
-    // One query, since a separate Snuba search runs per `query` param.
     const [[, options]] = request.mock.calls;
-    expect(options.query.query).toHaveLength(1);
-    const [query] = options.query.query;
+    const {query} = options.query;
     expect(query).toContain('fix_proposed');
     expect(query).toContain('diagnosed');
     expect(query).toContain('assigned');
     expect(query).toContain('assigned:[me,my_teams]');
+    expect(options.query).toEqual(
+      expect.objectContaining({
+        collapse: ['stats', 'unhandled'],
+        limit: 1,
+        project: [-1],
+        sort: 'progress',
+      })
+    );
   });
 
-  it('caps the count at 99+ since the endpoint stops counting at 100', async () => {
-    mockInboxCount({
-      'issue.progress:[fix_proposed, diagnosed, assigned] assigned:[me,my_teams]': 100,
-    });
+  it('caps the count at 99+', async () => {
+    mockInboxCount(100);
 
     renderNavigation();
 
@@ -63,9 +66,16 @@ describe('IssuesSecondaryNavigation', () => {
   });
 
   it('renders no badge when nothing is waiting', async () => {
-    mockInboxCount({
-      'issue.progress:[fix_proposed, diagnosed, assigned] assigned:[me,my_teams]': 0,
-    });
+    mockInboxCount(0);
+
+    renderNavigation();
+
+    expect(await screen.findByRole('link', {name: 'Inbox'})).toBeInTheDocument();
+    expect(screen.queryByText('0')).not.toBeInTheDocument();
+  });
+
+  it('renders no badge when the response has no count header', async () => {
+    mockInboxCount();
 
     renderNavigation();
 


### PR DESCRIPTION
The Inbox navigation count now reads `X-Hits` from a one-row, progress-sorted `/issues/` request instead of using the generic `/issues-count/` search path. It keeps the existing combined progress and assignment scope, `99+` display behavior, and three-minute cache while aligning the badge with the faster Postgres-backed query used by Inbox sections.


#### Issues

* Resolves: ISWF-3136
