### PR TITLE
feat(preprod): Add install group artifact search

### DIFF
--- a/src/sentry/preprod/artifact_search.py
+++ b/src/sentry/preprod/artifact_search.py
@@ -17,6 +17,7 @@ from sentry.api.event_search import (
 from sentry.db.models.fields.bounded import I64_MAX
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models.organization import Organization
+from sentry.preprod.build_distribution_utils import build_install_groups_q
 from sentry.preprod.models import (
     PreprodArtifact,
     PreprodArtifactQuerySet,
@@ -85,6 +86,7 @@ search_config = SearchConfig.create_from(
         "images_renamed",
         "images_skipped",
         "images_unchanged",
+        "install_groups",
         "install_size",
         "installable",
         "is",
@@ -333,6 +335,25 @@ def apply_filters(
                 queryset = queryset.exclude(q)
             else:
                 queryset = queryset.filter(q)
+            continue
+
+        if name == "install_groups":
+            if token.value.value == "":
+                raise InvalidSearchQuery("Enter at least one install group.")
+
+            groups = token.value.value if token.is_in_filter else [token.value.value]
+            install_groups_q = build_install_groups_q(groups)
+
+            if install_groups_q is None:
+                raise InvalidSearchQuery("Enter at least one install group.")
+
+            if token.is_negation:
+                # Missing JSON keys evaluate to SQL NULL, so include them explicitly.
+                queryset = queryset.filter(
+                    Q(extras__install_groups__isnull=True) | ~install_groups_q
+                )
+            else:
+                queryset = queryset.filter(install_groups_q)
             continue
 
         if name == "is_approved":

--- a/tests/sentry/preprod/test_artifact_search.py
+++ b/tests/sentry/preprod/test_artifact_search.py
@@ -1,9 +1,13 @@
 from datetime import timedelta
 
+import pytest
 from django.utils import timezone
 
+from sentry.api.event_search import SearchFilter, SearchKey, SearchValue
+from sentry.exceptions import InvalidSearchQuery
 from sentry.models.commitcomparison import CommitComparison
 from sentry.preprod.artifact_search import (
+    apply_filters,
     artifact_matches_query,
     get_sequential_base_artifact,
     queryset_for_query,
@@ -564,4 +568,98 @@ class ArtifactMatchesQuerySnapshotStatusFilterTest(TestCase):
         )
         assert not artifact_matches_query(
             success, "snapshot_status:[pending, failed]", self.organization
+        )
+
+
+class ArtifactMatchesQueryInstallGroupsFilterTest(TestCase):
+    def _create_artifact_with_install_groups(self, groups: list[str]) -> PreprodArtifact:
+        return self.create_preprod_artifact(project=self.project, extras={"install_groups": groups})
+
+    def test_single_value_match(self) -> None:
+        artifact = self._create_artifact_with_install_groups(["beta", "internal"])
+
+        assert artifact_matches_query(artifact, "install_groups:beta", self.organization)
+        assert artifact_matches_query(artifact, "install_groups:internal", self.organization)
+        assert not artifact_matches_query(artifact, "install_groups:production", self.organization)
+
+    def test_in_filter(self) -> None:
+        beta = self._create_artifact_with_install_groups(["beta"])
+        production = self._create_artifact_with_install_groups(["production"])
+
+        assert artifact_matches_query(beta, "install_groups:[beta, internal]", self.organization)
+        assert not artifact_matches_query(
+            production, "install_groups:[beta, internal]", self.organization
+        )
+
+    def test_negation_single(self) -> None:
+        artifact = self._create_artifact_with_install_groups(["beta"])
+
+        assert not artifact_matches_query(artifact, "!install_groups:beta", self.organization)
+        assert artifact_matches_query(artifact, "!install_groups:production", self.organization)
+
+    def test_negation_in_filter(self) -> None:
+        beta = self._create_artifact_with_install_groups(["beta"])
+        production = self._create_artifact_with_install_groups(["production"])
+
+        assert not artifact_matches_query(
+            beta, "!install_groups:[beta, internal]", self.organization
+        )
+        assert artifact_matches_query(
+            production, "!install_groups:[beta, internal]", self.organization
+        )
+
+    def test_null_extras(self) -> None:
+        artifact = self.create_preprod_artifact(project=self.project, extras=None)
+
+        assert not artifact_matches_query(artifact, "install_groups:beta", self.organization)
+        assert artifact_matches_query(artifact, "!install_groups:beta", self.organization)
+
+    def test_missing_key_in_extras(self) -> None:
+        artifact = self.create_preprod_artifact(
+            project=self.project, extras={"other_field": "value"}
+        )
+
+        assert not artifact_matches_query(artifact, "install_groups:beta", self.organization)
+        assert artifact_matches_query(artifact, "!install_groups:beta", self.organization)
+
+    def test_empty_array(self) -> None:
+        artifact = self._create_artifact_with_install_groups([])
+
+        assert not artifact_matches_query(artifact, "install_groups:beta", self.organization)
+
+    def test_has_filter_rejected(self) -> None:
+        artifact = self._create_artifact_with_install_groups(["beta"])
+
+        with pytest.raises(
+            InvalidSearchQuery,
+            match=r"Enter at least one install group\.",
+        ):
+            artifact_matches_query(artifact, "has:install_groups", self.organization)
+
+    def test_empty_quoted_value_rejected(self) -> None:
+        artifact = self._create_artifact_with_install_groups(["beta"])
+
+        with pytest.raises(
+            InvalidSearchQuery,
+            match=r"Enter at least one install group\.",
+        ):
+            artifact_matches_query(artifact, 'install_groups:""', self.organization)
+
+    def test_empty_in_filter_rejected(self) -> None:
+        empty_filter = SearchFilter(
+            key=SearchKey("install_groups"), operator="IN", value=SearchValue([])
+        )
+
+        with pytest.raises(InvalidSearchQuery, match=r"Enter at least one install group\."):
+            apply_filters(PreprodArtifact.objects.get_queryset(), [empty_filter], self.organization)
+
+    def test_multiple_groups_on_artifact(self) -> None:
+        artifact = self._create_artifact_with_install_groups(["beta", "internal", "qa"])
+
+        assert artifact_matches_query(artifact, "install_groups:internal", self.organization)
+        assert artifact_matches_query(
+            artifact, "install_groups:[qa, production]", self.organization
+        )
+        assert not artifact_matches_query(
+            artifact, "!install_groups:[beta, internal]", self.organization
         )


### PR DESCRIPTION
Preprod artifact search now accepts `install_groups` filters for individual values and lists, including negated searches. Empty filters return a consistent validation error, while artifacts with missing or empty install-group metadata retain the expected positive and negative matching behavior.

This provides the artifact-search support tracked by [EME-1180](https://linear.app/getsentry/issue/EME-1180/get-install-groups-artifact-search-over-the-finish-line).

Refs EME-1180
