### PR TITLE
feat(preprod): Add install group search to mobile builds

### DIFF
--- a/static/app/components/preprod/constants.ts
+++ b/static/app/components/preprod/constants.ts
@@ -28,6 +28,11 @@ export const MOBILE_BUILDS_ALLOWED_KEYS = [
   'platform_name',
 ];
 
+export const MOBILE_BUILDS_DISTRIBUTION_ALLOWED_KEYS = [
+  ...MOBILE_BUILDS_ALLOWED_KEYS,
+  'install_groups',
+];
+
 export const SNAPSHOT_ALLOWED_KEYS = [
   'app_id',
   'git_base_ref',

--- a/static/app/components/preprod/preprodBuildsSearchControls.tsx
+++ b/static/app/components/preprod/preprodBuildsSearchControls.tsx
@@ -3,7 +3,11 @@ import {CompactSelect, type SelectOption} from '@sentry/scraps/compactSelect';
 import {Container, Flex} from '@sentry/scraps/layout';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 
-import {MOBILE_BUILDS_ALLOWED_KEYS} from 'sentry/components/preprod/constants';
+import {
+  MOBILE_BUILDS_ALLOWED_KEYS,
+  MOBILE_BUILDS_DISTRIBUTION_ALLOWED_KEYS,
+  SNAPSHOT_ALLOWED_KEYS,
+} from 'sentry/components/preprod/constants';
 import {PreprodBuildsDisplay} from 'sentry/components/preprod/preprodBuildsDisplay';
 import {PreprodSearchBar} from 'sentry/components/preprod/preprodSearchBar';
 import {IconDownload} from 'sentry/icons';
@@ -13,6 +17,8 @@ const displaySelectOptions: Array<SelectOption<PreprodBuildsDisplay>> = [
   {value: PreprodBuildsDisplay.SIZE, label: t('Size')},
   {value: PreprodBuildsDisplay.DISTRIBUTION, label: t('Distribution')},
 ];
+
+const DISTRIBUTION_FREEFORM_KEYS = ['install_groups'];
 
 interface PreprodBuildsSearchControlsProps {
   /**
@@ -32,11 +38,14 @@ interface PreprodBuildsSearchControlsProps {
    */
   projects: number[];
   /**
-   * List of attribute keys to show in the search bar. When provided, only these
-   * keys will be available. When omitted, all keys except HIDDEN_PREPROD_ATTRIBUTES
-   * are shown.
+   * Overrides the display-specific list of attribute keys shown in the search bar.
    */
   allowedKeys?: string[];
+  /**
+   * Overrides the display-specific list of attributes whose values are entered
+   * as free text.
+   */
+  freeformKeys?: string[];
   /**
    * Hide the display mode toggle
    */
@@ -63,13 +72,25 @@ export function PreprodBuildsSearchControls({
   initialQuery,
   display,
   projects,
-  allowedKeys = MOBILE_BUILDS_ALLOWED_KEYS,
+  allowedKeys,
+  freeformKeys,
   hideDisplayToggle,
   onChange,
   onSearch,
   onDisplayChange,
   onExportCsv,
 }: PreprodBuildsSearchControlsProps) {
+  const displayAllowedKeys =
+    display === PreprodBuildsDisplay.SNAPSHOT
+      ? SNAPSHOT_ALLOWED_KEYS
+      : display === PreprodBuildsDisplay.DISTRIBUTION
+        ? MOBILE_BUILDS_DISTRIBUTION_ALLOWED_KEYS
+        : MOBILE_BUILDS_ALLOWED_KEYS;
+  const displayFreeformKeys =
+    display === PreprodBuildsDisplay.DISTRIBUTION
+      ? DISTRIBUTION_FREEFORM_KEYS
+      : undefined;
+
   return (
     <Flex
       align={{'screen:xs': 'stretch', 'screen:sm': 'center'}}
@@ -80,7 +101,8 @@ export function PreprodBuildsSearchControls({
       <Container flex="1">
         <PreprodSearchBar
           initialQuery={initialQuery}
-          allowedKeys={allowedKeys}
+          allowedKeys={allowedKeys ?? displayAllowedKeys}
+          freeformKeys={freeformKeys ?? displayFreeformKeys}
           onChange={onChange}
           onSearch={onSearch}
           projects={projects}

--- a/static/app/components/preprod/preprodSearchBar.tsx
+++ b/static/app/components/preprod/preprodSearchBar.tsx
@@ -28,13 +28,16 @@ interface PreprodSearchBarProps {
    * When true, parens and logical operators (AND, OR) will be marked as invalid.
    */
   disallowLogicalOperators?: boolean;
+  /**
+   * List of attribute keys whose values should be entered as free text instead
+   * of fetched from the trace item attribute values endpoint.
+   */
+  freeformKeys?: string[];
   onChange?: (query: string, state: {queryIsValid: boolean}) => void;
   onSearch?: (query: string) => void;
   portalTarget?: HTMLElement | null;
   searchSource?: string;
 }
-
-const FREEFORM_SEARCH_KEYS = new Set(['install_groups']);
 
 function filterToAllowedKeys(
   attributes: TagCollection,
@@ -50,14 +53,18 @@ function filterToAllowedKeys(
   return result;
 }
 
-function markFreeformKeys(attributes: TagCollection): TagCollection {
+function markFreeformKeys(
+  attributes: TagCollection,
+  freeformKeys?: string[]
+): TagCollection {
+  const freeformKeySet = new Set(freeformKeys);
   const result: TagCollection = {};
   for (const key in attributes) {
     const tag = attributes[key];
     if (!tag) {
       continue;
     }
-    result[key] = FREEFORM_SEARCH_KEYS.has(key) ? {...tag, predefined: true} : tag;
+    result[key] = freeformKeySet.has(key) ? {...tag, predefined: true} : tag;
   }
   return result;
 }
@@ -73,6 +80,7 @@ export function PreprodSearchBar({
   initialQuery,
   projects,
   allowedKeys,
+  freeformKeys,
   onChange,
   onSearch,
   portalTarget,
@@ -97,9 +105,10 @@ export function PreprodSearchBar({
       markFreeformKeys(
         allowedKeys
           ? filterToAllowedKeys(rawStringAttributes, allowedKeys)
-          : rawStringAttributes
+          : rawStringAttributes,
+        freeformKeys
       ),
-    [allowedKeys, rawStringAttributes]
+    [allowedKeys, freeformKeys, rawStringAttributes]
   );
 
   const stringSecondaryAliases = useMemo(

--- a/static/app/components/preprod/preprodSearchBar.tsx
+++ b/static/app/components/preprod/preprodSearchBar.tsx
@@ -34,6 +34,8 @@ interface PreprodSearchBarProps {
   searchSource?: string;
 }
 
+const FREEFORM_SEARCH_KEYS = new Set(['install_groups']);
+
 function filterToAllowedKeys(
   attributes: TagCollection,
   allowedKeys: string[]
@@ -44,6 +46,18 @@ function filterToAllowedKeys(
     if (allowedSet.has(key) && attributes[key]) {
       result[key] = attributes[key];
     }
+  }
+  return result;
+}
+
+function markFreeformKeys(attributes: TagCollection): TagCollection {
+  const result: TagCollection = {};
+  for (const key in attributes) {
+    const tag = attributes[key];
+    if (!tag) {
+      continue;
+    }
+    result[key] = FREEFORM_SEARCH_KEYS.has(key) ? {...tag, predefined: true} : tag;
   }
   return result;
 }
@@ -80,9 +94,11 @@ export function PreprodSearchBar({
 
   const stringAttributes = useMemo(
     () =>
-      allowedKeys
-        ? filterToAllowedKeys(rawStringAttributes, allowedKeys)
-        : rawStringAttributes,
+      markFreeformKeys(
+        allowedKeys
+          ? filterToAllowedKeys(rawStringAttributes, allowedKeys)
+          : rawStringAttributes
+      ),
     [allowedKeys, rawStringAttributes]
   );
 

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -2708,6 +2708,12 @@ const PREPROD_FIELD_DEFINITIONS: Record<string, FieldDefinition> = {
     kind: FieldKind.FIELD,
     valueType: FieldValueType.INTEGER,
   },
+  install_groups: {
+    desc: t('The install groups this build belongs to'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+    allowWildcard: false,
+  },
   snapshot_status: {
     desc: t('Status of the snapshot in the comparison pipeline'),
     kind: FieldKind.FIELD,

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -2709,7 +2709,7 @@ const PREPROD_FIELD_DEFINITIONS: Record<string, FieldDefinition> = {
     valueType: FieldValueType.INTEGER,
   },
   install_groups: {
-    desc: t('The install groups this build belongs to'),
+    desc: t('The install groups this build distribution belongs to'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
     allowWildcard: false,

--- a/static/app/views/explore/constants.tsx
+++ b/static/app/views/explore/constants.tsx
@@ -115,6 +115,7 @@ export const SENTRY_PREPROD_STRING_TAGS: string[] = [
   'git_base_sha',
   'git_head_ref',
   'git_head_sha',
+  'install_groups',
   'platform_name',
   'snapshot_status',
 ];
@@ -158,6 +159,8 @@ export const HIDDEN_PREPROD_ATTRIBUTES = [
   'tags[metrics_artifact_type,number]',
   'tags[artifact_type,number]',
   ...PREPROD_IMAGE_FIELDS,
+  // Distribution-only; explicitly allowlisted by the Mobile Builds distribution views.
+  'install_groups',
   'snapshot_status',
 ];
 

--- a/static/app/views/explore/releases/detail/commitsAndFiles/preprodBuilds.tsx
+++ b/static/app/views/explore/releases/detail/commitsAndFiles/preprodBuilds.tsx
@@ -6,6 +6,11 @@ import {Container} from '@sentry/scraps/layout';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {LoadingError} from 'sentry/components/loadingError';
 import {
+  MOBILE_BUILDS_ALLOWED_KEYS,
+  MOBILE_BUILDS_DISTRIBUTION_ALLOWED_KEYS,
+  SNAPSHOT_ALLOWED_KEYS,
+} from 'sentry/components/preprod/constants';
+import {
   getPreprodBuildsDisplay,
   PreprodBuildsDisplay,
 } from 'sentry/components/preprod/preprodBuildsDisplay';
@@ -188,6 +193,13 @@ export default function PreprodBuilds() {
             initialQuery={localSearchQuery}
             display={activeDisplay}
             projects={[Number(projectId)]}
+            allowedKeys={
+              activeDisplay === PreprodBuildsDisplay.SNAPSHOT
+                ? SNAPSHOT_ALLOWED_KEYS
+                : activeDisplay === PreprodBuildsDisplay.DISTRIBUTION
+                  ? MOBILE_BUILDS_DISTRIBUTION_ALLOWED_KEYS
+                  : MOBILE_BUILDS_ALLOWED_KEYS
+            }
             onChange={handleSearch}
             onDisplayChange={handleDisplayChange}
           />

--- a/static/app/views/explore/releases/detail/commitsAndFiles/preprodBuilds.tsx
+++ b/static/app/views/explore/releases/detail/commitsAndFiles/preprodBuilds.tsx
@@ -6,11 +6,6 @@ import {Container} from '@sentry/scraps/layout';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {LoadingError} from 'sentry/components/loadingError';
 import {
-  MOBILE_BUILDS_ALLOWED_KEYS,
-  MOBILE_BUILDS_DISTRIBUTION_ALLOWED_KEYS,
-  SNAPSHOT_ALLOWED_KEYS,
-} from 'sentry/components/preprod/constants';
-import {
   getPreprodBuildsDisplay,
   PreprodBuildsDisplay,
 } from 'sentry/components/preprod/preprodBuildsDisplay';
@@ -193,13 +188,6 @@ export default function PreprodBuilds() {
             initialQuery={localSearchQuery}
             display={activeDisplay}
             projects={[Number(projectId)]}
-            allowedKeys={
-              activeDisplay === PreprodBuildsDisplay.SNAPSHOT
-                ? SNAPSHOT_ALLOWED_KEYS
-                : activeDisplay === PreprodBuildsDisplay.DISTRIBUTION
-                  ? MOBILE_BUILDS_DISTRIBUTION_ALLOWED_KEYS
-                  : MOBILE_BUILDS_ALLOWED_KEYS
-            }
             onChange={handleSearch}
             onDisplayChange={handleDisplayChange}
           />

--- a/static/app/views/explore/releases/list/index.spec.tsx
+++ b/static/app/views/explore/releases/list/index.spec.tsx
@@ -645,6 +645,22 @@ describe('ReleasesList', () => {
     expect(screen.queryByRole('button', {name: 'Download CSV'})).not.toBeInTheDocument();
   });
 
+  it('searches distribution builds by install group without fetching values', async () => {
+    const installGroupValuesMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/trace-items/attributes/install_groups/values/`,
+      body: [],
+    });
+    const {router} = renderMobileBuildsTab({display: 'distribution'});
+
+    const searchInput = await screen.findByTestId('query-builder-input');
+    await userEvent.type(searchInput, 'install_groups:alpha{enter}');
+
+    await waitFor(() => {
+      expect(router.location.query.query).toBe('install_groups:alpha');
+    });
+    expect(installGroupValuesMock).not.toHaveBeenCalled();
+  });
+
   it('allows searching within the mobile-builds tab', async () => {
     const mobileProject = ProjectFixture({
       id: '13',

--- a/static/app/views/explore/releases/list/mobileBuilds.tsx
+++ b/static/app/views/explore/releases/list/mobileBuilds.tsx
@@ -9,11 +9,6 @@ import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {ALL_ACCESS_PROJECTS} from 'sentry/components/pageFilters/constants';
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {
-  MOBILE_BUILDS_ALLOWED_KEYS,
-  MOBILE_BUILDS_DISTRIBUTION_ALLOWED_KEYS,
-  SNAPSHOT_ALLOWED_KEYS,
-} from 'sentry/components/preprod/constants';
-import {
   getPreprodBuildsDisplay,
   PreprodBuildsDisplay,
 } from 'sentry/components/preprod/preprodBuildsDisplay';
@@ -217,13 +212,6 @@ export function MobileBuilds({
         initialQuery={searchQuery ?? ''}
         display={activeDisplay}
         projects={selectedProjectIds.map(Number)}
-        allowedKeys={
-          activeDisplay === PreprodBuildsDisplay.SNAPSHOT
-            ? SNAPSHOT_ALLOWED_KEYS
-            : activeDisplay === PreprodBuildsDisplay.DISTRIBUTION
-              ? MOBILE_BUILDS_DISTRIBUTION_ALLOWED_KEYS
-              : MOBILE_BUILDS_ALLOWED_KEYS
-        }
         hideDisplayToggle={hideDisplayToggle}
         onSearch={handleSearch}
         onDisplayChange={handleDisplayChange}

--- a/static/app/views/explore/releases/list/mobileBuilds.tsx
+++ b/static/app/views/explore/releases/list/mobileBuilds.tsx
@@ -10,6 +10,7 @@ import {ALL_ACCESS_PROJECTS} from 'sentry/components/pageFilters/constants';
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {
   MOBILE_BUILDS_ALLOWED_KEYS,
+  MOBILE_BUILDS_DISTRIBUTION_ALLOWED_KEYS,
   SNAPSHOT_ALLOWED_KEYS,
 } from 'sentry/components/preprod/constants';
 import {
@@ -219,7 +220,9 @@ export function MobileBuilds({
         allowedKeys={
           activeDisplay === PreprodBuildsDisplay.SNAPSHOT
             ? SNAPSHOT_ALLOWED_KEYS
-            : MOBILE_BUILDS_ALLOWED_KEYS
+            : activeDisplay === PreprodBuildsDisplay.DISTRIBUTION
+              ? MOBILE_BUILDS_DISTRIBUTION_ALLOWED_KEYS
+              : MOBILE_BUILDS_ALLOWED_KEYS
         }
         hideDisplayToggle={hideDisplayToggle}
         onSearch={handleSearch}


### PR DESCRIPTION
Mobile Builds distribution search now exposes `install_groups` as a free-form search field without attempting to fetch predefined values. The field remains hidden from generic EAP-backed dashboard search and excluded from the Size and Snapshot views, keeping unsupported consumers unchanged.

Refs EME-1181

| Before | After |
| --- | --- |
|<img width="390" height="265" alt="install-grp-before" src="https://github.com/user-attachments/assets/a28e96b4-f442-46c0-bafe-89655a876735" />|<img width="521" height="196" alt="install-grp-after" src="https://github.com/user-attachments/assets/ef5f4a10-65ea-420e-975e-f1a8a0a820c0" />|
