### PR TITLE
fix(dashboards): Prettify typed EAP attribute keys in group by

### DIFF
--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -3767,3 +3767,12 @@ export function prettifyTagKey(key: string): string {
   const result = key.match(TYPED_TAG_KEY_RE);
   return result?.[1] ?? key;
 }
+
+/**
+ * Whether a key uses the explicit typed form, e.g. `tags[foo,number]`.
+ * Shares the same pattern as `classifyTagKey`/`prettifyTagKey` so callers
+ * don't reinvent the regex.
+ */
+export function isTypedTagKey(key: string): boolean {
+  return TYPED_TAG_KEY_RE.test(key);
+}

--- a/static/app/views/dashboards/widgetBuilder/components/groupBySelector.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/groupBySelector.spec.tsx
@@ -95,6 +95,55 @@ describe('WidgetBuilderGroupBySelector', () => {
     });
   });
 
+  it('renders explicitly-typed EAP attribute group by fields with prettified names', async () => {
+    const logsOrganization = OrganizationFixture({features: ['ourlogs-enabled']});
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/trace-items/attributes/',
+      body: [
+        {
+          key: 'tags[my_number,number]',
+          name: 'my_number',
+          attributeType: 'number',
+        },
+        {
+          key: 'tags[my_boolean,boolean]',
+          name: 'my_boolean',
+          attributeType: 'boolean',
+        },
+      ],
+    });
+
+    render(
+      <WidgetBuilderProvider>
+        <WidgetBuilderGroupBySelector validatedWidgetResponse={{} as any} />
+      </WidgetBuilderProvider>,
+      {
+        organization: logsOrganization,
+        initialRouterConfig: {
+          route: '/organizations/:orgId/dashboard/:dashboardId/',
+          location: {
+            pathname: '/organizations/org-slug/dashboard/1/',
+            query: {
+              dataset: WidgetType.LOGS,
+              displayType: DisplayType.LINE,
+              // Saved group by fields are stored with their explicit type, e.g.
+              // `tags[name,type]`.
+              field: ['tags[my_number,number]', 'tags[my_boolean,boolean]'],
+            },
+          },
+        },
+      }
+    );
+
+    // Saved group by fields should render with their prettified names rather
+    // than the raw `tags[name,type]` form (DAIN-1783).
+    expect(await screen.findByText('my_number')).toBeInTheDocument();
+    expect(await screen.findByText('my_boolean')).toBeInTheDocument();
+    expect(screen.queryByText('tags[my_number,number]')).not.toBeInTheDocument();
+    expect(screen.queryByText('tags[my_boolean,boolean]')).not.toBeInTheDocument();
+  });
+
   it('disables group by selector when transaction widget type and discover-saved-queries-deprecation feature flag', async () => {
     const organizationWithFeature = OrganizationFixture({
       features: ['discover-saved-queries-deprecation'],

--- a/static/app/views/discover/table/queryField.tsx
+++ b/static/app/views/discover/table/queryField.tsx
@@ -25,7 +25,7 @@ import type {
   ValidateColumnTypes,
 } from 'sentry/utils/discover/fields';
 import {AGGREGATIONS, DEPRECATED_FIELDS} from 'sentry/utils/discover/fields';
-import type {FieldValueType} from 'sentry/utils/fields';
+import {classifyTagKey, isTypedTagKey, type FieldValueType} from 'sentry/utils/fields';
 import {SESSIONS_OPERATIONS} from 'sentry/views/dashboards/widgetBuilder/releaseWidget/fields';
 import {TypeBadge} from 'sentry/views/explore/components/typeBadge';
 
@@ -317,6 +317,18 @@ class _QueryField extends Component<Props> {
     const equationName = `equation:${name}`;
     if (fieldOptions[equationName]) {
       return fieldOptions[equationName].value;
+    }
+
+    // EAP attributes are stored with an explicit type, e.g. `tags[foo,number]`
+    // or `tags[foo,boolean]`, and their options are keyed by the attribute's
+    // FieldKind (`measurement:`/`boolean:`/`tag:`). Classify the key to find the
+    // matching option instead of relying on the generic `tag:` lookup below,
+    // which would keep the `,type` suffix and fail to match.
+    if (isTypedTagKey(name)) {
+      const typedTagName = `${classifyTagKey(name)}:${name}`;
+      if (fieldOptions[typedTagName]) {
+        return fieldOptions[typedTagName].value;
+      }
     }
 
     const tagName =


### PR DESCRIPTION
Grouping by a custom **boolean** attribute in the dashboard widget query builder rendered the raw `tags[attribute_name,boolean]` string (with the type suffix) instead of the prettified attribute name. This was visible on logs widgets.

### Root cause
EAP attributes are stored with an explicit type key — the backend returns `key = tags[foo,boolean]` while `name` stays pretty (`foo`) — and group by options are keyed by `FieldKind` (`measurement:`, `boolean:`, `tag:`). The reverse lookup in `getFieldOrTagOrMeasurementValue` (`static/app/views/discover/table/queryField.tsx`) tried the `field:`, `measurement:`, `span_op_breakdown:`, `equation:`, and `tag:` prefixes but never `boolean:`. Numeric attributes resolved via the `measurement:` branch and rendered correctly, but booleans fell through to the unknown-tag fallback, which displays the raw `tags[...]` string.

### Fix
When the stored field is an explicit typed key (`tags[name,type]`), classify it with the existing `classifyTagKey` util and look it up under the correct `FieldKind` prefix. The change is additive (only matches an option that already exists) and lives in the shared query field component, so it covers logs, spans, trace-metrics, and preprod group by.

Fixes DAIN-1783.