### PR TITLE
chore(webhooks): Open the floodgates for all issue types to get issue.created webhooks

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3771,16 +3771,12 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Which issue categories should we send issue.created webhooks for
+# Which issue categories should we not send issue.created webhooks for
 register(
-    "sentry-apps.expanded-webhook-categories",
+    "sentry-apps.unsupported-webhook-categories",
     type=Sequence,
     default=[
-        1,  # ERROR
-        4,  # CRON
-        6,  # FEEDBACK
-        7,  # UPTIME
-        10,  # OUTAGE
+        9,  # TEST_NOTIFICATION
     ],
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1178,11 +1178,11 @@ def process_resource_change_bounds(job: PostProcessJob) -> None:
 def should_process_resource_change_bounds(job: PostProcessJob) -> bool:
     group_category = job["event"].group.issue_category
 
-    supported_group_categories = [
+    unsupported_group_categories = [
         GroupCategory(category)
-        for category in options.get("sentry-apps.expanded-webhook-categories")
+        for category in options.get("sentry-apps.unsupported-webhook-categories")
     ]
-    if group_category not in supported_group_categories:
+    if group_category in unsupported_group_categories:
         return False
 
     return True


### PR DESCRIPTION
Open the gates!!!!! I believe when we first added this option, we were more conservative on the rollout of what issue types to send webhooks for.

This PR basically does the reverse and say unless specified send a webhook for said issue category 