### PR TITLE
fix(ui): Stop the explore catch-all from renaming every transaction

### DIFF
--- a/static/app/router/routes.spec.tsx
+++ b/static/app/router/routes.spec.tsx
@@ -136,7 +136,7 @@ describe('buildRoutes()', () => {
         routes,
         '/organizations/test-org/explore/nonexistent-page/also-nonexistent-page/'
       );
-      expect(matchedPaths).toContain(':catchAll/*');
+      expect(matchedPaths).toContain('*');
     });
   });
 

--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -2298,14 +2298,22 @@ function buildRoutes(): RouteObject[] {
       path: 'saved-queries/',
       component: make(() => import('sentry/views/explore/savedQueries')),
     },
-    // These two routes have to be placed at the end of the exploreChildren
-    // array to avoid being overridden by the other routes.
+    // Unknown /explore/ subpaths redirect to the default explore view, rather
+    // than falling through to the `/:orgId/:projectId/` legacy redirect and
+    // rendering "The project you were looking for was not found".
+    //
+    // Real routes outrank these on specificity, so they win regardless of
+    // where they sit in this array. Keep these last anyway: order is the
+    // tiebreaker if a sibling ever scores the same.
     {
       path: ':catchAll/',
       component: make(() => import('sentry/views/explore/indexRedirect')),
     },
     {
-      path: ':catchAll/*',
+      // Same, for deeper paths. Not `:catchAll/*` — our SDK matches relative
+      // route paths against the full pathname, so that pattern would rename
+      // every transaction in the app to `/:catchAll/...`.
+      path: '*',
       component: make(() => import('sentry/views/explore/indexRedirect')),
     },
   ];


### PR DESCRIPTION
Every transaction in the app is reported as `/:catchAll/...`. `/dashboard/20788/` shows up as `/:catchAll/20788`.

<img width="290" height="76" alt="image" src="https://github.com/user-attachments/assets/74931ca9-68af-4a8a-af64-98a93db718d7" />

The explore catch-all from #116066 uses `:catchAll/*`. Our SDK matches relative route paths against the full pathname, so that pattern matches every URL in the app and overwrites the real route name. A bare `*` doesn't. Kept `:catchAll/` for the single-segment case since that's what outranks the `/:orgId/:projectId/` legacy redirect.

Unrelated but nearby: `/insights/typo/` and friends still hit that legacy redirect and render "project not found". Needs its own PR.