### PR TITLE
fix(replays): source member access from the org members endpoint

### DIFF
--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
@@ -478,5 +478,40 @@ describe('OrganizationSettingsForm', () => {
 
       expect(await screen.findByText('Paged Out Member')).toBeInTheDocument();
     });
+
+    it('keeps a newly selected member labeled when the search term changes', async () => {
+      const alice = UserFixture({id: '5', name: 'Alice Nguyen'});
+      const bob = UserFixture({id: '6', name: 'Bob Okafor'});
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/members/`,
+        body: [{user: alice}, {user: bob}],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/members/`,
+        body: [{user: bob}],
+        match: [MockApiClient.matchQuery({query: 'bob'})],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/members/`,
+        body: [{user: alice}],
+        match: [MockApiClient.matchQuery({query: 'user.id:5'})],
+      });
+      render(
+        <OrganizationSettingsForm initialData={OrganizationFixture()} onSave={onSave} />,
+        {organization: {...organization, hasGranularReplayPermissions: true}}
+      );
+
+      await userEvent.click(screen.getByRole('textbox', {name: 'Replay Access Members'}));
+      await userEvent.click(
+        await screen.findByRole('menuitemcheckbox', {name: 'Alice Nguyen'})
+      );
+      await userEvent.type(
+        screen.getByRole('textbox', {name: 'Replay Access Members'}),
+        'bob'
+      );
+      await screen.findByRole('menuitemcheckbox', {name: 'Bob Okafor'});
+
+      expect(screen.getByText('Alice Nguyen')).toBeInTheDocument();
+    });
   });
 });

--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
@@ -40,10 +40,6 @@ describe('OrganizationSettingsForm', () => {
       url: '/organizations/org-slug/members/',
       body: [{user: UserFixture()}],
     });
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/users/',
-      body: [{user: UserFixture()}],
-    });
     onSave.mockReset();
   });
 
@@ -411,11 +407,6 @@ describe('OrganizationSettingsForm', () => {
     });
 
     it('saves replayAccessMembers when a member is selected', async () => {
-      const user = UserFixture();
-      MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/users/`,
-        body: [{user}],
-      });
       const replayPutMock = MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/`,
         method: 'PUT',
@@ -445,6 +436,47 @@ describe('OrganizationSettingsForm', () => {
           expect.objectContaining({data: {replayAccessMembers: [1]}})
         );
       });
+    });
+
+    it('lists every organization member when the user shares no projects with them', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/users/`,
+        body: [],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/members/`,
+        body: [{user: UserFixture({id: '2', name: 'Teamless Member'})}],
+      });
+      render(
+        <OrganizationSettingsForm initialData={OrganizationFixture()} onSave={onSave} />,
+        {organization: {...organization, hasGranularReplayPermissions: true}}
+      );
+
+      await userEvent.click(screen.getByRole('textbox', {name: 'Replay Access Members'}));
+
+      expect(
+        await screen.findByRole('menuitemcheckbox', {name: 'Teamless Member'})
+      ).toBeInTheDocument();
+    });
+
+    it('labels an already selected member when they are missing from the default member list', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/members/`,
+        body: [{user: UserFixture({id: '404', name: 'Paged Out Member'})}],
+        match: [MockApiClient.matchQuery({query: 'user.id:404'})],
+      });
+      render(
+        <OrganizationSettingsForm initialData={OrganizationFixture()} onSave={onSave} />,
+        {
+          organization: {
+            ...organization,
+            hasGranularReplayPermissions: true,
+            replayAccessMembers: [404],
+          },
+        }
+      );
+
+      expect(await screen.findByText('Paged Out Member')).toBeInTheDocument();
     });
   });
 });

--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.tsx
@@ -90,10 +90,7 @@ export function ReplayAccessMembersField({
   organization: Organization;
 }) {
   const endpoint = `/organizations/${organization.slug}/`;
-  const initialValue = useMemo(
-    () => (organization.replayAccessMembers ?? []).map(String),
-    [organization.replayAccessMembers]
-  );
+  const initialValue = (organization.replayAccessMembers ?? []).map(String);
 
   const [selectedIds, setSelectedIds] = useState(initialValue);
   const {data: selectedMembers = []} = useMembers({ids: selectedIds});

--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useMemo} from 'react';
+import {Fragment, useMemo, useState} from 'react';
 import {mutationOptions, queryOptions} from '@tanstack/react-query';
 import {useMutation} from '@tanstack/react-query';
 import uniqBy from 'lodash/uniqBy';
@@ -90,10 +90,13 @@ export function ReplayAccessMembersField({
   organization: Organization;
 }) {
   const endpoint = `/organizations/${organization.slug}/`;
-  const selectedIds = useMemo(
+  const initialValue = useMemo(
     () => (organization.replayAccessMembers ?? []).map(String),
     [organization.replayAccessMembers]
   );
+  // Tracked separately from the form value so selected members can be resolved by
+  // id: a search that no longer returns them would otherwise drop their label.
+  const [selectedIds, setSelectedIds] = useState(initialValue);
   const {data: selectedMembers = []} = useMembers({ids: selectedIds});
 
   const replayMutationOpts = mutationOptions({
@@ -111,7 +114,7 @@ export function ReplayAccessMembersField({
       <AutoSaveForm
         name="replayAccessMembers"
         schema={membershipSchema}
-        initialValue={selectedIds}
+        initialValue={initialValue}
         mutationOptions={replayMutationOpts}
       >
         {field => (
@@ -132,7 +135,10 @@ export function ReplayAccessMembersField({
                 })
               }
               value={field.state.value}
-              onChange={field.handleChange}
+              onChange={next => {
+                setSelectedIds(next);
+                field.handleChange(next);
+              }}
               disabled={disabled}
             />
           </field.Layout.Row>

--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.tsx
@@ -1,6 +1,7 @@
 import {Fragment, useMemo} from 'react';
-import {mutationOptions, useQuery} from '@tanstack/react-query';
+import {mutationOptions, queryOptions} from '@tanstack/react-query';
 import {useMutation} from '@tanstack/react-query';
+import uniqBy from 'lodash/uniqBy';
 import {z} from 'zod';
 
 import {Alert} from '@sentry/scraps/alert';
@@ -28,8 +29,11 @@ import {
   getLocalityDataFromOrganization,
   shouldDisplayLocalities,
 } from 'sentry/utils/cells';
-import {useProjectMembersQueryOptions} from 'sentry/utils/members/projectMembers';
-import {selectUsersFromMembers} from 'sentry/utils/members/shared';
+import {
+  memberUsersQueryOptions,
+  selectUsersFromMembers,
+} from 'sentry/utils/members/shared';
+import {useMembers} from 'sentry/utils/members/useMembers';
 import {fetchMutation} from 'sentry/utils/queryClient';
 import {RequestError} from 'sentry/utils/requestError/requestError';
 import {slugify} from 'sentry/utils/slugify';
@@ -86,11 +90,11 @@ export function ReplayAccessMembersField({
   organization: Organization;
 }) {
   const endpoint = `/organizations/${organization.slug}/`;
-  const {data: members = [], isPending: fetching} = useQuery({
-    ...useProjectMembersQueryOptions(),
-    select: resp => selectUsersFromMembers(resp.json),
-  });
-  const memberOptions = members.map(m => ({value: m.id, label: m.name}));
+  const selectedIds = useMemo(
+    () => (organization.replayAccessMembers ?? []).map(String),
+    [organization.replayAccessMembers]
+  );
+  const {data: selectedMembers = []} = useMembers({ids: selectedIds});
 
   const replayMutationOpts = mutationOptions({
     mutationFn: (data: {replayAccessMembers: string[]}) =>
@@ -107,7 +111,7 @@ export function ReplayAccessMembersField({
       <AutoSaveForm
         name="replayAccessMembers"
         schema={membershipSchema}
-        initialValue={(organization.replayAccessMembers ?? []).map(String)}
+        initialValue={selectedIds}
         mutationOptions={replayMutationOpts}
       >
         {field => (
@@ -115,13 +119,21 @@ export function ReplayAccessMembersField({
             label={t('Replay Access Members')}
             hintText={t('Select the members who will have access to replay data.')}
           >
-            <field.Select
+            <field.SelectAsync
               multiple
-              options={memberOptions}
+              queryOptions={search =>
+                queryOptions({
+                  ...memberUsersQueryOptions({orgSlug: organization.slug, search}),
+                  select: ({json}) =>
+                    uniqBy(
+                      [...selectedMembers, ...selectUsersFromMembers(json)],
+                      member => member.id
+                    ).map(member => ({value: member.id, label: member.name})),
+                })
+              }
               value={field.state.value}
               onChange={field.handleChange}
               disabled={disabled}
-              isLoading={fetching}
             />
           </field.Layout.Row>
         )}

--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.tsx
@@ -94,8 +94,7 @@ export function ReplayAccessMembersField({
     () => (organization.replayAccessMembers ?? []).map(String),
     [organization.replayAccessMembers]
   );
-  // Tracked separately from the form value so selected members can be resolved by
-  // id: a search that no longer returns them would otherwise drop their label.
+
   const [selectedIds, setSelectedIds] = useState(initialValue);
   const {data: selectedMembers = []} = useMembers({ids: selectedIds});
 

--- a/static/gsApp/overrides/organizationMembershipSettingsForm.spec.tsx
+++ b/static/gsApp/overrides/organizationMembershipSettingsForm.spec.tsx
@@ -28,10 +28,6 @@ describe('OrganizationMembershipSettings', () => {
   beforeEach(() => {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/members/',
-      body: [],
-    });
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/users/',
       body: [{user: UserFixture()}],
     });
   });


### PR DESCRIPTION
The Replay Access Members selector loaded its options from `/organizations/{org}/users/`, which only returns users on teams attached to projects the requesting user is themselves a member of. An owner or manager who isn't on those teams got an empty list, while superusers bypass that filter and see everyone. That endpoint also omits members who are on no team at all, so those members could never be granted access.

This switches the field to `/organizations/{org}/members/` via `SelectAsync`, which lists every organization member and supports server-side search, so typing filters instead of doing nothing and orgs past the first page stay reachable. Members already saved to the setting are resolved by id and merged into the options.

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="2360" height="1724" alt="replay947-before" src="https://github.com/user-attachments/assets/fb93e599-1548-4f00-bddf-ef2b36c5fe71" />
</td>
<td>
<img width="2360" height="1724" alt="replay947-after" src="https://github.com/user-attachments/assets/421980ef-897d-4499-bf3a-015e041a0f03" />
</td>
</tr>
</tbody>
</table>

Closes REPLAY-947.
