### PR TITLE
fix(ourlogs): use the right range operator when paginating ascending logs

### DIFF
--- a/static/app/views/explore/logs/useLogsQuery.spec.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.spec.tsx
@@ -172,6 +172,80 @@ describe('useInfiniteLogsQuery', () => {
     );
   });
 
+  it('keeps the first row first when fetching the previous page in ascending sort order', async () => {
+    const eventsEndpoint = `/organizations/${organization.slug}/events/`;
+    mockLocation.mockReturnValue(
+      LocationFixture({query: {[LOGS_SORT_BYS_KEY]: 'timestamp'}})
+    );
+
+    MockApiClient.addMockResponse({
+      url: eventsEndpoint,
+      body: createMockLogsData([
+        {id: '1', timestamp_precise: '100', timestamp: '100'},
+        {id: '2', timestamp_precise: '200', timestamp: '200'},
+        {id: '3', timestamp_precise: '300', timestamp: '300'},
+      ]),
+      match: [
+        (_, options) => {
+          const query = options?.query || {};
+          return query.query.length === 0;
+        },
+      ],
+      headers: linkHeaders,
+    });
+
+    const olderRowsMock = MockApiClient.addMockResponse({
+      url: eventsEndpoint,
+      body: createMockLogsData([]),
+      match: [
+        (_, options) => {
+          const query = options?.query || {};
+          return query.query.startsWith(
+            `${OurLogKnownFieldKey.TIMESTAMP_PRECISE}:<=100 !${OurLogKnownFieldKey.ID}:1`
+          );
+        },
+      ],
+      headers: linkHeaders,
+    });
+
+    const newerRowsMock = MockApiClient.addMockResponse({
+      url: eventsEndpoint,
+      body: createMockLogsData([
+        {id: '3', timestamp_precise: '300', timestamp: '300'},
+        {id: '2', timestamp_precise: '200', timestamp: '200'},
+      ]),
+      match: [
+        (_, options) => {
+          const query = options?.query || {};
+          return query.query.startsWith(
+            `${OurLogKnownFieldKey.TIMESTAMP_PRECISE}:>=100 !${OurLogKnownFieldKey.ID}:1`
+          );
+        },
+      ],
+      headers: linkHeaders,
+    });
+
+    const {result, rerender} = renderHookWithProviders(() => useInfiniteLogsQuery(), {
+      additionalWrapper: createWrapper(),
+      organization,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isPending).toBe(false);
+    });
+
+    await result.current.fetchPreviousPage();
+    rerender();
+
+    expect(olderRowsMock).toHaveBeenCalled();
+    expect(newerRowsMock).not.toHaveBeenCalled();
+    expect(result.current.data.map(datum => datum[OurLogKnownFieldKey.ID])).toEqual([
+      '1',
+      '2',
+      '3',
+    ]);
+  });
+
   it('should remove empty pages but maintain hasNextPage', async () => {
     const eventsEndpoint = `/organizations/${organization.slug}/events/`;
 
@@ -735,7 +809,7 @@ function createAscendingMocks(organization: Organization) {
         const query = options?.query || {};
         return (
           query.query.startsWith(
-            `${OurLogKnownFieldKey.TIMESTAMP_PRECISE}:>=400 !${OurLogKnownFieldKey.ID}:4`
+            `${OurLogKnownFieldKey.TIMESTAMP_PRECISE}:<=400 !${OurLogKnownFieldKey.ID}:4`
           ) && query.sort === '-timestamp' // DESC. Timestamp is aliased to sort both timestamp_precise and timestamp
         );
       },

--- a/static/app/views/explore/logs/useLogsQuery.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.tsx
@@ -354,7 +354,9 @@ function getParamBasedQuery(
   }
 
   const comparison =
-    (pageParam.querySortDirection ?? pageParam.sortByDirection === 'asc') ? '>=' : '<=';
+    (pageParam.querySortDirection?.kind ?? pageParam.sortByDirection) === 'asc'
+      ? '>='
+      : '<=';
 
   const filter = pageParam.timestampPrecise
     ? `${OurLogKnownFieldKey.TIMESTAMP_PRECISE}:${comparison}${pageParam.timestampPrecise}`


### PR DESCRIPTION
With the logs table sorted by timestamp ascending, scrolling back to the top fetched the *newest* rows instead of older ones and prepended them above the oldest. When the result set already fit in one page, deduplication then left the previously-first row alone at the end of the list.

Closes LOGS-932.