### PR TITLE
fix(replays): stop bulk delete progress stalling and rewinding

### DIFF
--- a/src/sentry/replays/tasks.py
+++ b/src/sentry/replays/tasks.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from django.utils import timezone
 from google.cloud.exceptions import NotFound
 from taskbroker_client.constants import CompressionType
 from taskbroker_client.retry import Retry
+from taskbroker_client.state import current_task
+from taskbroker_client.worker.workerchild import ProcessingDeadlineExceeded
 
 from sentry.replays.consumers.recording import commit_message, process_message
 from sentry.replays.lib.kafka import PROCESS_REPLAY_RECORDING_TASK_NAME, publish_replay_event
@@ -215,11 +218,18 @@ def run_bulk_replay_delete_job(
 
     # If this is the first run of the task we set the model to in-progress.
     if job.status == DeletionJobStatus.PENDING:
+        _transition_status(job.id, DeletionJobStatus.PENDING, DeletionJobStatus.IN_PROGRESS)
         job.status = DeletionJobStatus.IN_PROGRESS
-        job.save()
 
     # Exit if the job status is failed or completed.
     if job.status != DeletionJobStatus.IN_PROGRESS:
+        return None
+
+    # Task delivery is at-least-once, so a job can end up with more than one live call chain: a
+    # redelivered activation re-enters at the offset it was given while the successor it already
+    # enqueued keeps going. The chain that fell behind the checkpoint stops here rather than
+    # re-deleting rows and rewinding the reported progress.
+    if offset < job.offset:
         return None
 
     try:
@@ -244,11 +254,19 @@ def run_bulk_replay_delete_job(
                     job.project_id,
                     [row["replay_id"] for row in results["rows"]],
                 )
+    except ProcessingDeadlineExceeded:
+        # A BaseException, so it escapes the handler below. Once retries run out the broker
+        # discards the activation, which leaves the job reporting "in-progress" forever with
+        # nothing left to advance it.
+        task = current_task()
+        if task is not None and not task.retries_remaining:
+            logger.warning("Bulk delete replays exhausted its processing deadline retries.")
+            _transition_status(job.id, DeletionJobStatus.IN_PROGRESS, DeletionJobStatus.FAILED)
+        raise
     except Exception:
         logger.exception("Bulk delete replays failed.")
 
-        job.status = DeletionJobStatus.FAILED
-        job.save()
+        _transition_status(job.id, DeletionJobStatus.IN_PROGRESS, DeletionJobStatus.FAILED)
         raise
 
     # Compute the next offset to start from. If no further processing is required then this serves
@@ -257,8 +275,7 @@ def run_bulk_replay_delete_job(
 
     if results["has_more"]:
         # Checkpoint before continuing.
-        job.offset = next_offset
-        job.save()
+        _advance_offset(job.id, next_offset)
         run_bulk_replay_delete_job.delay(
             job.id, next_offset, limit=limit, has_seer_data=has_seer_data
         )
@@ -266,7 +283,20 @@ def run_bulk_replay_delete_job(
     else:
         # If we've finished deleting all the replays for the selection. We can move the status to
         # completed and exit the call chain.
-        job.offset = next_offset
-        job.status = DeletionJobStatus.COMPLETED
-        job.save()
+        _advance_offset(job.id, next_offset)
+        _transition_status(job.id, DeletionJobStatus.IN_PROGRESS, DeletionJobStatus.COMPLETED)
         return None
+
+
+def _advance_offset(job_id: int, offset: int) -> None:
+    """Checkpoint progress, filtered so a lagging duplicate chain cannot rewind the counter."""
+    ReplayDeletionJobModel.objects.filter(id=job_id, offset__lt=offset).update(
+        offset=offset, date_updated=timezone.now()
+    )
+
+
+def _transition_status(job_id: int, expected: DeletionJobStatus, new: DeletionJobStatus) -> None:
+    """Transition status only from `expected`, and without `save()` rewriting the whole row."""
+    ReplayDeletionJobModel.objects.filter(id=job_id, status=expected).update(
+        status=new, date_updated=timezone.now()
+    )

--- a/src/sentry/replays/tasks.py
+++ b/src/sentry/replays/tasks.py
@@ -200,7 +200,7 @@ def _delete_if_exists(filename: str) -> None:
     # any activations that were enqueued before this deploy (with
     # namespace="replays") continue to resolve and execute.
     alias_namespace=replays_tasks,
-    retry=Retry(times=5),
+    retry=Retry(times=5, on=(ProcessingDeadlineExceeded,)),
     processing_deadline_duration=600,
     silo_mode=SiloMode.CELL,
 )

--- a/src/sentry/replays/tasks.py
+++ b/src/sentry/replays/tasks.py
@@ -225,13 +225,6 @@ def run_bulk_replay_delete_job(
     if job.status != DeletionJobStatus.IN_PROGRESS:
         return None
 
-    # Task delivery is at-least-once, so a job can end up with more than one live call chain: a
-    # redelivered activation re-enters at the offset it was given while the successor it already
-    # enqueued keeps going. The chain that fell behind the checkpoint stops here rather than
-    # re-deleting rows and rewinding the reported progress.
-    if offset < job.offset:
-        return None
-
     try:
         # Delete the replays within a limited range. If more replays exist an incremented offset value
         # is returned.

--- a/src/sentry/replays/usecases/delete.py
+++ b/src/sentry/replays/usecases/delete.py
@@ -72,8 +72,6 @@ def delete_replays(project_id: int, replay_ids: list[str]) -> None:
 
 
 def delete_replay_recordings(project_id: int, rows: list[MatchedRow]) -> None:
-    # One pool for the whole batch. A pool per replay serialized the batch behind whichever
-    # replay had the most segments, pushing large batches past the caller's processing deadline.
     filenames = [
         filename for row in rows for filename in _make_recording_filenames(project_id, row)
     ]

--- a/src/sentry/replays/usecases/delete.py
+++ b/src/sentry/replays/usecases/delete.py
@@ -60,9 +60,7 @@ def delete_matched_rows(project_id: int, rows: list[MatchedRow]) -> int | None:
     if not rows:
         return None
 
-    for row in rows:
-        delete_replay_recordings(project_id, row)
-
+    delete_replay_recordings(project_id, rows)
     delete_replays(project_id, [row["replay_id"] for row in rows])
     return None
 
@@ -73,9 +71,14 @@ def delete_replays(project_id: int, replay_ids: list[str]) -> None:
         publish_replay_event(archive_event(project_id, replay_id))
 
 
-def delete_replay_recordings(project_id: int, row: MatchedRow) -> None:
+def delete_replay_recordings(project_id: int, rows: list[MatchedRow]) -> None:
+    # One pool for the whole batch. A pool per replay serialized the batch behind whichever
+    # replay had the most segments, pushing large batches past the caller's processing deadline.
+    filenames = [
+        filename for row in rows for filename in _make_recording_filenames(project_id, row)
+    ]
     with ContextPropagatingThreadPoolExecutor(max_workers=100) as pool:
-        pool.map(_delete_if_exists, _make_recording_filenames(project_id, row))
+        pool.map(_delete_if_exists, filenames)
 
 
 def _delete_if_exists(filename: str) -> None:

--- a/tests/sentry/replays/tasks/test_delete_replays_bulk.py
+++ b/tests/sentry/replays/tasks/test_delete_replays_bulk.py
@@ -287,6 +287,13 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
         self.job.refresh_from_db()
         assert self.job.offset == 500
 
+    def test_run_bulk_replay_delete_job_retry_policy_covers_deadline(self) -> None:
+        """Test the deadline is retried, which is what the retries_remaining guard assumes"""
+        retry = run_bulk_replay_delete_job.retry
+        assert retry is not None
+
+        assert retry.should_retry(retry.initial_state(), ProcessingDeadlineExceeded())
+
     @patch("sentry.replays.tasks.fetch_rows_matching_pattern")
     def test_run_bulk_replay_delete_job_deadline_exceeded_with_retries(
         self, mock_fetch_rows: MagicMock

--- a/tests/sentry/replays/tasks/test_delete_replays_bulk.py
+++ b/tests/sentry/replays/tasks/test_delete_replays_bulk.py
@@ -5,6 +5,9 @@ import uuid
 from collections.abc import Generator
 from unittest.mock import MagicMock, Mock, patch
 
+import pytest
+from taskbroker_client.worker.workerchild import ProcessingDeadlineExceeded
+
 from sentry.replays.models import DeletionJobStatus, ReplayDeletionJobModel
 from sentry.replays.tasks import run_bulk_replay_delete_job
 from sentry.replays.testutils import mock_replay
@@ -216,6 +219,127 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
         self.job.refresh_from_db()
         assert self.job.status == "completed"
         assert self.job.offset == 0
+
+    @patch("sentry.replays.tasks.fetch_rows_matching_pattern")
+    @patch("sentry.replays.tasks.delete_matched_rows")
+    def test_run_bulk_replay_delete_job_stale_activation(
+        self, mock_delete_matched_rows: MagicMock, mock_fetch_rows: MagicMock
+    ) -> None:
+        """Test a duplicate activation behind the checkpoint does not rewind progress"""
+        self.job.status = DeletionJobStatus.IN_PROGRESS
+        self.job.offset = 300
+        self.job.save()
+
+        run_bulk_replay_delete_job(self.job.id, offset=100)
+
+        self.job.refresh_from_db()
+        assert self.job.status == "in-progress"
+        assert self.job.offset == 300
+        mock_fetch_rows.assert_not_called()
+        mock_delete_matched_rows.assert_not_called()
+
+    @patch("sentry.replays.tasks.fetch_rows_matching_pattern")
+    @patch("sentry.replays.tasks.delete_matched_rows")
+    def test_run_bulk_replay_delete_job_concurrent_checkpoint(
+        self, mock_delete_matched_rows: MagicMock, mock_fetch_rows: MagicMock
+    ) -> None:
+        """Test a checkpoint written by a further-along chain is not overwritten"""
+        mock_fetch_rows.return_value = {
+            "rows": [{"retention_days": 90, "replay_id": "a", "max_segment_id": 1}],
+            "has_more": True,
+        }
+
+        self.job.status = DeletionJobStatus.IN_PROGRESS
+        self.job.save()
+
+        def advance_checkpoint(*args: object, **kwargs: object) -> None:
+            ReplayDeletionJobModel.objects.filter(id=self.job.id).update(offset=500)
+
+        mock_delete_matched_rows.side_effect = advance_checkpoint
+
+        run_bulk_replay_delete_job(self.job.id, offset=0)
+
+        self.job.refresh_from_db()
+        assert self.job.offset == 500
+
+    @patch("sentry.replays.tasks.fetch_rows_matching_pattern")
+    def test_run_bulk_replay_delete_job_deadline_exceeded_with_retries(
+        self, mock_fetch_rows: MagicMock
+    ) -> None:
+        """Test the job stays in-progress while the activation can still be retried"""
+        mock_fetch_rows.side_effect = ProcessingDeadlineExceeded()
+
+        self.job.status = DeletionJobStatus.IN_PROGRESS
+        self.job.save()
+
+        with patch("sentry.replays.tasks.current_task", return_value=Mock(retries_remaining=2)):
+            with pytest.raises(ProcessingDeadlineExceeded):
+                run_bulk_replay_delete_job(self.job.id, offset=0)
+
+        self.job.refresh_from_db()
+        assert self.job.status == "in-progress"
+
+    @patch("sentry.replays.tasks.fetch_rows_matching_pattern")
+    def test_run_bulk_replay_delete_job_deadline_exceeded_without_retries(
+        self, mock_fetch_rows: MagicMock
+    ) -> None:
+        """Test the job is failed rather than stalled when deadline retries run out"""
+        mock_fetch_rows.side_effect = ProcessingDeadlineExceeded()
+
+        self.job.status = DeletionJobStatus.IN_PROGRESS
+        self.job.save()
+
+        with patch("sentry.replays.tasks.current_task", return_value=Mock(retries_remaining=0)):
+            with pytest.raises(ProcessingDeadlineExceeded):
+                run_bulk_replay_delete_job(self.job.id, offset=0)
+
+        self.job.refresh_from_db()
+        assert self.job.status == "failed"
+
+    @patch("sentry.replays.tasks.fetch_rows_matching_pattern")
+    def test_run_bulk_replay_delete_job_failure_preserves_offset(
+        self, mock_fetch_rows: MagicMock
+    ) -> None:
+        """Test a failure records the status without reverting the checkpoint"""
+        mock_fetch_rows.side_effect = ValueError("snuba is unhappy")
+
+        self.job.status = DeletionJobStatus.IN_PROGRESS
+        self.job.offset = 200
+        self.job.save()
+
+        with pytest.raises(ValueError):
+            run_bulk_replay_delete_job(self.job.id, offset=200)
+
+        self.job.refresh_from_db()
+        assert self.job.status == "failed"
+        assert self.job.offset == 200
+
+    @patch("sentry.replays.tasks.fetch_rows_matching_pattern")
+    @patch("sentry.replays.tasks.delete_matched_rows")
+    def test_run_bulk_replay_delete_job_does_not_resurrect_completed_job(
+        self, mock_delete_matched_rows: MagicMock, mock_fetch_rows: MagicMock
+    ) -> None:
+        """Test a chain finishing after another completed the job leaves it completed"""
+        mock_fetch_rows.return_value = {
+            "rows": [{"retention_days": 90, "replay_id": "a", "max_segment_id": 1}],
+            "has_more": True,
+        }
+
+        self.job.status = DeletionJobStatus.IN_PROGRESS
+        self.job.save()
+
+        def complete_job(*args: object, **kwargs: object) -> None:
+            ReplayDeletionJobModel.objects.filter(id=self.job.id).update(
+                status=DeletionJobStatus.COMPLETED
+            )
+
+        mock_delete_matched_rows.side_effect = complete_job
+
+        with patch.object(run_bulk_replay_delete_job, "delay"):
+            run_bulk_replay_delete_job(self.job.id, offset=0)
+
+        self.job.refresh_from_db()
+        assert self.job.status == "completed"
 
     def test_fetch_rows_matching_pattern(self) -> None:
         t1 = datetime.datetime.now() - datetime.timedelta(seconds=10)

--- a/tests/sentry/replays/tasks/test_delete_replays_bulk.py
+++ b/tests/sentry/replays/tasks/test_delete_replays_bulk.py
@@ -226,17 +226,42 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
         self, mock_delete_matched_rows: MagicMock, mock_fetch_rows: MagicMock
     ) -> None:
         """Test a duplicate activation behind the checkpoint does not rewind progress"""
+        mock_fetch_rows.return_value = {
+            "rows": [{"retention_days": 90, "replay_id": "a", "max_segment_id": 1}],
+            "has_more": True,
+        }
+
         self.job.status = DeletionJobStatus.IN_PROGRESS
         self.job.offset = 300
         self.job.save()
 
-        run_bulk_replay_delete_job(self.job.id, offset=100)
+        with patch.object(run_bulk_replay_delete_job, "delay"):
+            run_bulk_replay_delete_job(self.job.id, offset=100)
 
         self.job.refresh_from_db()
         assert self.job.status == "in-progress"
         assert self.job.offset == 300
-        mock_fetch_rows.assert_not_called()
-        mock_delete_matched_rows.assert_not_called()
+
+    @patch("sentry.replays.tasks.fetch_rows_matching_pattern")
+    @patch("sentry.replays.tasks.delete_matched_rows")
+    def test_run_bulk_replay_delete_job_redelivered_after_checkpoint(
+        self, mock_delete_matched_rows: MagicMock, mock_fetch_rows: MagicMock
+    ) -> None:
+        """Test an activation killed between checkpointing and enqueueing still finishes"""
+        mock_fetch_rows.return_value = {
+            "rows": [{"retention_days": 90, "replay_id": "a", "max_segment_id": 1}],
+            "has_more": False,
+        }
+
+        self.job.status = DeletionJobStatus.IN_PROGRESS
+        self.job.offset = 100
+        self.job.save()
+
+        run_bulk_replay_delete_job(self.job.id, offset=0)
+
+        self.job.refresh_from_db()
+        assert self.job.status == "completed"
+        assert self.job.offset == 100
 
     @patch("sentry.replays.tasks.fetch_rows_matching_pattern")
     @patch("sentry.replays.tasks.delete_matched_rows")


### PR DESCRIPTION
Bulk replay delete jobs showed two counter symptoms in production:

* `Count Deleted` frozen at a value for hours while the job still reported `in-progress`:  fixed by pooling recording deletes once per batch rather than per replay, and by marking the job as `'failed'` on the final attempt.
* Rotating between values while trending upward: fixed by switching *progress* and *status* saving to be independent, so writing one won't revert the other.

Closes getsentry/sentry#120413.