### PR TITLE
fix(replays): stop polling bulk delete jobs that are not running

### DIFF
--- a/static/app/components/replays/bulkDelete/replayBulkDeleteAuditLog.spec.tsx
+++ b/static/app/components/replays/bulkDelete/replayBulkDeleteAuditLog.spec.tsx
@@ -1,0 +1,72 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {act, render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {ReplayBulkDeleteAuditLog} from 'sentry/components/replays/bulkDelete/replayBulkDeleteAuditLog';
+import type {ReplayBulkDeleteAuditLog as ReplayBulkDeleteAuditLogJob} from 'sentry/components/replays/bulkDelete/types';
+
+describe('ReplayBulkDeleteAuditLog', () => {
+  const organization = OrganizationFixture();
+  const url = `/projects/${organization.slug}/project-slug/replays/jobs/delete/`;
+
+  function jobFixture(
+    params: Partial<ReplayBulkDeleteAuditLogJob> = {}
+  ): ReplayBulkDeleteAuditLogJob {
+    return {
+      id: 1,
+      countDeleted: 100,
+      dateCreated: '2026-07-28T00:00:00Z',
+      dateUpdated: '2026-07-28T00:00:00Z',
+      environments: ['prod'],
+      query: '',
+      rangeEnd: '2026-07-27T00:00:00Z',
+      rangeStart: '2026-07-26T00:00:00Z',
+      status: 'in-progress',
+      ...params,
+    };
+  }
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('polls for progress while a job is running', async () => {
+    const mock = MockApiClient.addMockResponse({
+      url,
+      body: {data: [jobFixture({status: 'in-progress'})]},
+    });
+
+    render(<ReplayBulkDeleteAuditLog projectSlug="project-slug" />, {organization});
+
+    await waitFor(() => expect(mock).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      jest.advanceTimersByTime(5_000);
+    });
+
+    await waitFor(() => expect(mock).toHaveBeenCalledTimes(2));
+  });
+
+  it('stops polling once no job is running', async () => {
+    const mock = MockApiClient.addMockResponse({
+      url,
+      body: {data: [jobFixture({status: 'completed'})]},
+    });
+
+    render(<ReplayBulkDeleteAuditLog projectSlug="project-slug" />, {organization});
+
+    await waitFor(() => expect(mock).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText('completed')).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(60_000);
+    });
+
+    expect(mock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/static/app/components/replays/bulkDelete/replayBulkDeleteAuditLogApiOptions.tsx
+++ b/static/app/components/replays/bulkDelete/replayBulkDeleteAuditLogApiOptions.tsx
@@ -10,6 +10,12 @@ type Query = {
   per_page?: number;
 };
 
+const POLL_INTERVAL_MS = 5_000;
+
+export function isBulkDeleteJobRunning(job: ReplayBulkDeleteAuditLog) {
+  return job.status === 'pending' || job.status === 'in-progress';
+}
+
 export function replayBulkDeleteAuditLogApiOptions(
   organization: Organization,
   {
@@ -29,7 +35,8 @@ export function replayBulkDeleteAuditLogApiOptions(
         staleTime: 0,
       }
     ),
-    refetchInterval: 1_000,
+    refetchInterval: ({state}) =>
+      state.data?.json.data.some(isBulkDeleteJobRunning) ? POLL_INTERVAL_MS : false,
     retry: false,
   });
 }

--- a/static/app/components/replays/bulkDelete/types.tsx
+++ b/static/app/components/replays/bulkDelete/types.tsx
@@ -7,5 +7,5 @@ export type ReplayBulkDeleteAuditLog = {
   query: string;
   rangeEnd: string;
   rangeStart: string;
-  status: 'pending' | 'in-progress' | 'completed';
+  status: 'pending' | 'in-progress' | 'completed' | 'failed';
 };

--- a/static/app/views/explore/replays/list/bulkDeleteAlert.tsx
+++ b/static/app/views/explore/replays/list/bulkDeleteAlert.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useRef} from 'react';
+import {useEffect} from 'react';
 import {useQuery} from '@tanstack/react-query';
 
 import {Alert} from '@sentry/scraps/alert';
@@ -6,7 +6,10 @@ import {LinkButton} from '@sentry/scraps/button';
 
 import {hasEveryAccess} from 'sentry/components/acl/access';
 import {useAnalyticsArea} from 'sentry/components/analyticsArea';
-import {replayBulkDeleteAuditLogApiOptions} from 'sentry/components/replays/bulkDelete/replayBulkDeleteAuditLogApiOptions';
+import {
+  isBulkDeleteJobRunning,
+  replayBulkDeleteAuditLogApiOptions,
+} from 'sentry/components/replays/bulkDelete/replayBulkDeleteAuditLogApiOptions';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
@@ -47,30 +50,21 @@ function useShouldRenderBulkDeleteAlert({
   const hasWriteAccess = hasEveryAccess(['project:write'], {organization, project});
   const hasAdminAccess = hasEveryAccess(['project:admin'], {organization, project});
 
-  const hasAnyInProgressRef = useRef(false);
-
   const {data} = useQuery({
     ...replayBulkDeleteAuditLogApiOptions(organization, {
       projectSlug: project?.slug ?? '',
       query: {per_page: 10, offset: 0, referrer: analyticsArea},
     }),
     enabled: Boolean(project && (hasWriteAccess || hasAdminAccess)),
-    refetchInterval: hasAnyInProgressRef.current ? 1_000 : 60_000,
   });
-
-  useEffect(() => {
-    // TODO: This only looks at the first page of results.
-    // It would be better to be able to search for jobs in progress to be sure.
-    // The expectation is that only one job is running at a time.
-    hasAnyInProgressRef.current = Boolean(
-      data?.data?.some(job => ['pending', 'in-progress'].includes(job?.status ?? ''))
-    );
-  }, [data?.data]);
 
   if ((!hasWriteAccess && !hasAdminAccess) || !project) {
     return false;
   }
-  return hasAnyInProgressRef.current;
+  // TODO: This only looks at the first page of results.
+  // It would be better to be able to search for jobs in progress to be sure.
+  // The expectation is that only one job is running at a time.
+  return Boolean(data?.data.some(isBulkDeleteJobRunning));
 }
 
 function DeleteInProgressAlert({

--- a/static/app/views/settings/project/projectReplays.spec.tsx
+++ b/static/app/views/settings/project/projectReplays.spec.tsx
@@ -30,6 +30,52 @@ describe('ProjectReplays', () => {
     });
   });
 
+  it('renders the bulk delete tab when the user has write access', async () => {
+    const deleteJobsMock = MockApiClient.addMockResponse({
+      url: `${getProjectEndpoint}replays/jobs/delete/`,
+      body: {data: []},
+    });
+
+    render(<ProjectReplays />, {
+      organization,
+      outletContext: {project},
+      initialRouterConfig,
+    });
+
+    await userEvent.click(await screen.findByRole('tab', {name: 'Bulk Delete'}));
+
+    expect(await screen.findByText('No deletes found')).toBeInTheDocument();
+    expect(deleteJobsMock).toHaveBeenCalled();
+  });
+
+  it('hides the bulk delete tab when the user lacks write access', async () => {
+    const deleteJobsMock = MockApiClient.addMockResponse({
+      url: `${getProjectEndpoint}replays/jobs/delete/`,
+      body: {data: []},
+    });
+    const {organization: readOnlyOrganization} = initializeOrg({
+      organization: {access: ['org:read', 'project:read']},
+    });
+
+    render(<ProjectReplays />, {
+      organization: readOnlyOrganization,
+      outletContext: {project},
+      initialRouterConfig: {
+        ...initialRouterConfig,
+        location: {
+          ...initialRouterConfig.location,
+          query: {replaySettingsTab: 'bulk-delete'},
+        },
+      },
+    });
+
+    expect(await screen.findByRole('tab', {name: 'Replay Issues'})).toBeInTheDocument();
+    expect(screen.queryByRole('tab', {name: 'Bulk Delete'})).not.toBeInTheDocument();
+    expect(screen.queryByText('Count Deleted')).not.toBeInTheDocument();
+    expect(screen.getByText('Create Rage Click Issues')).toBeInTheDocument();
+    expect(deleteJobsMock).not.toHaveBeenCalled();
+  });
+
   it('renders both replay issue fields', async () => {
     render(<ProjectReplays />, {
       organization,

--- a/static/app/views/settings/project/projectReplays.tsx
+++ b/static/app/views/settings/project/projectReplays.tsx
@@ -62,12 +62,14 @@ export default function ProjectReplaySettings() {
       <SentryDocumentTitle title={t('Replays')} projectSlug={project.slug}>
         <SettingsPageHeader title={t('Replays')} />
         <TabsWithGap
-          value={tab}
+          value={hasAccess ? tab : 'replay-issues'}
           onChange={value => setTab(value as 'replay-issues' | 'bulk-delete')}
         >
           <TabList>
             <TabList.Item key="replay-issues">{t('Replay Issues')}</TabList.Item>
-            <TabList.Item key="bulk-delete">{t('Bulk Delete')}</TabList.Item>
+            {hasAccess ? (
+              <TabList.Item key="bulk-delete">{t('Bulk Delete')}</TabList.Item>
+            ) : null}
           </TabList>
           <TabPanels>
             <TabPanels.Item key="replay-issues">
@@ -129,14 +131,16 @@ export default function ProjectReplaySettings() {
                 </AutoSaveForm>
               </FieldGroup>
             </TabPanels.Item>
-            <TabPanels.Item key="bulk-delete">
-              <p>
-                {t(
-                  'Deleting replays requires us to remove data from multiple storage locations which can take some time. You can monitor progress and audit requests here.'
-                )}
-              </p>
-              <ReplayBulkDeleteAuditLog projectSlug={project.slug} />
-            </TabPanels.Item>
+            {hasAccess ? (
+              <TabPanels.Item key="bulk-delete">
+                <p>
+                  {t(
+                    'Deleting replays requires us to remove data from multiple storage locations which can take some time. You can monitor progress and audit requests here.'
+                  )}
+                </p>
+                <ReplayBulkDeleteAuditLog projectSlug={project.slug} />
+              </TabPanels.Item>
+            ) : null}
           </TabPanels>
         </TabsWithGap>
       </SentryDocumentTitle>


### PR DESCRIPTION
Frontend half of the bulk replay delete report. Backend changes are in getsentry/sentry#120772.

This has three general areas fixed:

* Endless polling: `replayBulkDeleteAuditLogApiOptions` set `refetchInterval: 1_000` unconditionally, so the Bulk Delete settings tab requested the endpoint once a second for as long as it stayed open, whether or not any job was running.
* Tab visibility: *Bulk Delete* always was rendered  in project settings, even though you can't use it without `project:write`/`project:admin`. That's a recipe for 403s.
* Alert visibility:  `useShouldRenderBulkDeleteAlert` derived its return value from a `useRef` *(aside: this is why AIs defaulting to so many refs irks me!)*, so the in-progress banner on the replay list did not appear or disappear until some unrelated re-render happened.

Part of getsentry/sentry#120413.