### PR TITLE
fix(devserver): Reap daemons orphaned by an unclean shutdown

### DIFF
--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import getpass
 import os
 import threading
 from collections.abc import MutableSequence, Sequence
@@ -7,6 +8,7 @@ from pathlib import Path
 from typing import NoReturn
 
 import click
+import psutil
 import sentry_sdk
 
 from sentry.runner.commands.devservices import get_docker_client
@@ -37,6 +39,121 @@ def add_daemon(name: str, command: list[str]) -> None:
 
 def _get_daemon(name: str) -> tuple[str, list[str]]:
     return name, _DEFAULT_DAEMONS[name]
+
+
+_REAP_TERM_TIMEOUT = 3
+
+
+def _daemon_matches(argv: Sequence[str], cmd: Sequence[str]) -> bool:
+    """
+    Whether `argv` looks like a process honcho launched from `cmd`.
+
+    The daemon's own arguments must be the exact trailing portion of `argv`, and
+    the entry right before them must be its executable. We compare basenames
+    because the recorded command uses bare names (`sentry`) while the running
+    process shows resolved paths, often behind an interpreter:
+    `[.../python3, .../bin/sentry, run, consumer, ...]`.
+    """
+    exe_name = os.path.basename(cmd[0])
+    tail = list(cmd[1:])
+    if not tail:
+        return bool(argv) and os.path.basename(argv[-1]) == exe_name
+    if len(argv) <= len(tail) or list(argv[-len(tail) :]) != tail:
+        return False
+    return os.path.basename(argv[-len(tail) - 1]) == exe_name
+
+
+def _find_orphaned_daemons(
+    daemons: Sequence[tuple[str, Sequence[str]]], cwd: str
+) -> list[tuple[str, psutil.Process]]:
+    """
+    Find leaked daemons from a previous devserver in this checkout.
+
+    Only processes reparented to init are considered, so a daemon belonging to a
+    running devserver is never a candidate. Matches are additionally confined to
+    `cwd` -- the directory honcho launches every daemon in -- so a devserver in
+    another checkout is left alone.
+    """
+    expected_cwd = os.path.realpath(cwd)
+    own_pid = os.getpid()
+    username = getpass.getuser()
+
+    orphans = []
+    for proc in psutil.process_iter():
+        # Any of these can race with the process exiting, or be denied outright.
+        # Losing one candidate is fine; failing to start the devserver is not.
+        try:
+            if proc.pid == own_pid or proc.ppid() != 1:
+                continue
+            if proc.username() != username:
+                continue
+            argv = proc.cmdline()
+            if not argv:
+                continue
+
+            name = next((name for name, cmd in daemons if _daemon_matches(argv, cmd)), None)
+            if name is None:
+                continue
+
+            # Checked last so the cheap filters above reject most processes first.
+            if os.path.realpath(proc.cwd()) != expected_cwd:
+                continue
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            continue
+
+        orphans.append((name, proc))
+
+    return orphans
+
+
+def _reap_orphaned_daemons(daemons: Sequence[tuple[str, Sequence[str]]], cwd: str) -> None:
+    """
+    Terminate daemons leaked by a previous devserver in this checkout.
+
+    Honcho terminates its children on a clean exit, but when the devserver dies to
+    SIGKILL, a hard terminal close, or a crash they reparent to init and keep
+    running. Consumers are the worst of these: they spin forever failing to rejoin
+    their consumer group, respawning a multiprocessing worker every few seconds
+    that each pays a full Django import, and they hammer the Kafka group
+    coordinator while doing it. Nothing noticed them on the next startup, so they
+    accumulated across runs and burned several cores indefinitely.
+    """
+    orphans = _find_orphaned_daemons(daemons, cwd)
+    if not orphans:
+        return
+
+    click.secho(
+        f"Reaping {len(orphans)} orphaned daemon(s) leaked by a previous devserver:",
+        err=True,
+        fg="yellow",
+    )
+
+    victims = []
+    for name, proc in orphans:
+        click.secho(f"  {name} (pid {proc.pid})", err=True, fg="yellow")
+        try:
+            # Collect children before signalling the parent, otherwise the
+            # respawn loop leaves workers behind with no one to attribute them to.
+            victims.extend(proc.children(recursive=True))
+            victims.append(proc)
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            continue
+
+    for proc in victims:
+        try:
+            proc.terminate()
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            pass
+
+    # Wedged consumers do not honor SIGTERM -- their shutdown never completes --
+    # so escalating here is the step that actually reclaims the machine.
+    _, alive = psutil.wait_procs(victims, timeout=_REAP_TERM_TIMEOUT)
+    for proc in alive:
+        try:
+            proc.kill()
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            pass
+    psutil.wait_procs(alive, timeout=_REAP_TERM_TIMEOUT)
 
 
 @click.command()
@@ -129,6 +246,11 @@ def _get_daemon(name: str) -> tuple[str, list[str]]:
     default=False,
     help="Run task scheduler for periodically scheduled tasks.",
 )
+@click.option(
+    "--reap-orphans/--no-reap-orphans",
+    default=True,
+    help="Terminate orphaned daemons leaked by a previous devserver that did not shut down cleanly.",
+)
 @click.argument(
     "bind",
     default=None,
@@ -158,6 +280,7 @@ def devserver(
     apigw: bool,
     workers: bool,
     task_scheduler: bool,
+    reap_orphans: bool,
 ) -> NoReturn:
     "Starts a lightweight web server for development."
     sentry_sdk.init(
@@ -466,6 +589,9 @@ def devserver(
         )
 
         manager = Manager(honcho_printer)
+        # Mirrors everything handed to honcho, so the reaper below only ever
+        # targets the daemons this invocation is about to start.
+        reap_targets: list[tuple[str, Sequence[str]]] = list(daemons)
         for name, cmd in daemons:
             quiet = bool(
                 name not in (settings.DEVSERVER_LOGS_ALLOWLIST or ())
@@ -509,6 +635,10 @@ def devserver(
                     and settings.DEVSERVER_LOGS_ALLOWLIST
                 )
                 manager.add_process(name, list2cmdline(cmd), quiet=quiet, cwd=cwd, env=merged_env)
+                reap_targets.append((name, cmd))
+
+        if reap_orphans:
+            _reap_orphaned_daemons(reap_targets, cwd)
 
         manager.loop()
         sys.exit(manager.returncode)

--- a/tests/sentry/runner/commands/test_devserver.py
+++ b/tests/sentry/runner/commands/test_devserver.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import getpass
+import os
+from collections.abc import Generator, Sequence
+from contextlib import contextmanager
+from pathlib import Path
+from unittest import mock
+
+import psutil
+import pytest
+
+from sentry.runner.commands.devserver import (
+    _daemon_matches,
+    _find_orphaned_daemons,
+    _reap_orphaned_daemons,
+)
+
+CWD = "/repo/sentry"
+# Use the real user so the same-user guard can be exercised without patching
+# anything on the shared psutil module -- tests/conftest.py calls
+# psutil.Process() itself for an open-files leak check.
+USER = getpass.getuser()
+
+CONSUMER_CMD = [
+    "sentry",
+    "run",
+    "consumer",
+    "getsentry-outcomes",
+    "--consumer-group=sentry-consumer",
+    "--auto-offset-reset=latest",
+    "--no-strict-offset-reset",
+]
+CONSUMER_ARGV = [
+    "/repo/sentry/.venv/bin/python3",
+    "/repo/sentry/.venv/bin/sentry",
+    *CONSUMER_CMD[1:],
+]
+
+SERVER_CMD = ["sentry", "run", "web"]
+WATCHER_CMD = [
+    "/repo/sentry/node_modules/.bin/rspack",
+    "serve",
+    "--config=/repo/sentry/rspack.config.ts",
+]
+
+
+class FakeProcess:
+    def __init__(
+        self,
+        pid: int,
+        ppid: int,
+        cmdline: Sequence[str],
+        cwd: str = CWD,
+        username: str = USER,
+        cwd_exc: BaseException | None = None,
+        children: Sequence[FakeProcess] = (),
+    ) -> None:
+        self.pid = pid
+        self._ppid = ppid
+        self._cmdline = list(cmdline)
+        self._username = username
+        self._cwd = cwd
+        self._cwd_exc = cwd_exc
+        self._children = list(children)
+        self.terminated = False
+        self.killed = False
+
+    def ppid(self) -> int:
+        return self._ppid
+
+    def cmdline(self) -> list[str]:
+        return list(self._cmdline)
+
+    def username(self) -> str:
+        return self._username
+
+    def cwd(self) -> str:
+        if self._cwd_exc is not None:
+            raise self._cwd_exc
+        return self._cwd
+
+    def children(self, recursive: bool = False) -> list[FakeProcess]:
+        return list(self._children)
+
+    def terminate(self) -> None:
+        self.terminated = True
+
+    def kill(self) -> None:
+        self.killed = True
+
+
+@contextmanager
+def process_table(procs: Sequence[FakeProcess]) -> Generator[None]:
+    """Drive the reaper against an explicit process table."""
+    with mock.patch(
+        "sentry.runner.commands.devserver.psutil.process_iter",
+        side_effect=lambda *a, **kw: iter(list(procs)),
+    ):
+        yield
+
+
+@contextmanager
+def sigterm_works(honored: bool) -> Generator[mock.MagicMock]:
+    """Stub wait_procs to report whether SIGTERM actually reaped the victims."""
+
+    def _wait(
+        procs: Sequence[FakeProcess], timeout: float | None = None
+    ) -> tuple[list[FakeProcess], list[FakeProcess]]:
+        return (list(procs), []) if honored else ([], list(procs))
+
+    with mock.patch(
+        "sentry.runner.commands.devserver.psutil.wait_procs", side_effect=_wait
+    ) as waited:
+        yield waited
+
+
+class TestDaemonMatches:
+    def test_matches_through_interpreter_indirection(self) -> None:
+        assert _daemon_matches(CONSUMER_ARGV, CONSUMER_CMD)
+
+    def test_matches_bare_executable(self) -> None:
+        assert _daemon_matches(["/repo/sentry/.venv/bin/sentry", "run", "web"], SERVER_CMD)
+
+    def test_matches_node_watcher(self) -> None:
+        assert _daemon_matches(["node", *WATCHER_CMD], WATCHER_CMD)
+
+    def test_different_consumer_does_not_match(self) -> None:
+        argv = [
+            "/repo/sentry/.venv/bin/python3",
+            "/repo/sentry/.venv/bin/sentry",
+            "run",
+            "consumer",
+            "ingest-events",
+            "--consumer-group=sentry-consumer",
+            "--auto-offset-reset=latest",
+            "--no-strict-offset-reset",
+        ]
+        assert not _daemon_matches(argv, CONSUMER_CMD)
+
+    def test_extra_trailing_args_do_not_match(self) -> None:
+        """The daemon's args must be the exact trailing portion, not a prefix."""
+        argv = [
+            "/repo/sentry/.venv/bin/python3",
+            "/repo/sentry/.venv/bin/sentry",
+            "run",
+            "web",
+            "-x",
+        ]
+        assert not _daemon_matches(argv, SERVER_CMD)
+
+    def test_wrong_executable_does_not_match(self) -> None:
+        argv = ["/repo/sentry/.venv/bin/python3", "/usr/bin/other", "run", "web"]
+        assert not _daemon_matches(argv, SERVER_CMD)
+
+    def test_args_without_preceding_executable_do_not_match(self) -> None:
+        assert not _daemon_matches(["run", "web"], SERVER_CMD)
+
+    def test_empty_argv(self) -> None:
+        assert not _daemon_matches([], SERVER_CMD)
+
+    def test_single_element_command(self) -> None:
+        assert _daemon_matches(["/usr/local/bin/taskbroker"], ["taskbroker"])
+        assert not _daemon_matches(["/usr/local/bin/other"], ["taskbroker"])
+
+
+class TestFindOrphanedDaemons:
+    daemons: list[tuple[str, Sequence[str]]] = [
+        ("getsentry-outcomes", CONSUMER_CMD),
+        ("server", SERVER_CMD),
+    ]
+
+    def test_finds_orphan(self) -> None:
+        with process_table([FakeProcess(100, 1, CONSUMER_ARGV)]):
+            found = _find_orphaned_daemons(self.daemons, CWD)
+
+        assert [(name, p.pid) for name, p in found] == [("getsentry-outcomes", 100)]
+
+    def test_ignores_live_child_of_running_devserver(self) -> None:
+        """The critical guard: an identical cmdline still owned by honcho is left alone."""
+        with process_table([FakeProcess(100, 55, CONSUMER_ARGV)]):
+            assert _find_orphaned_daemons(self.daemons, CWD) == []
+
+    def test_ignores_other_checkout(self) -> None:
+        with process_table([FakeProcess(100, 1, CONSUMER_ARGV, cwd="/repo/sentry-other")]):
+            assert _find_orphaned_daemons(self.daemons, CWD) == []
+
+    def test_ignores_daemon_not_being_started(self) -> None:
+        with process_table([FakeProcess(100, 1, CONSUMER_ARGV)]):
+            assert _find_orphaned_daemons([("server", SERVER_CMD)], CWD) == []
+
+    def test_ignores_other_user(self) -> None:
+        with process_table([FakeProcess(100, 1, CONSUMER_ARGV, username="someone-else")]):
+            assert _find_orphaned_daemons(self.daemons, CWD) == []
+
+    def test_ignores_own_pid(self) -> None:
+        with process_table([FakeProcess(os.getpid(), 1, CONSUMER_ARGV)]):
+            assert _find_orphaned_daemons(self.daemons, CWD) == []
+
+    def test_ignores_empty_cmdline(self) -> None:
+        with process_table([FakeProcess(100, 1, [])]):
+            assert _find_orphaned_daemons(self.daemons, CWD) == []
+
+    @pytest.mark.parametrize("exc", [psutil.NoSuchProcess(100), psutil.AccessDenied(100)])
+    def test_cwd_errors_do_not_propagate(self, exc: BaseException) -> None:
+        """A process exiting or denying access mid-scan must not abort startup."""
+        with process_table([FakeProcess(100, 1, CONSUMER_ARGV, cwd_exc=exc)]):
+            assert _find_orphaned_daemons(self.daemons, CWD) == []
+
+    def test_resolves_symlinked_cwd(self, tmp_path: Path) -> None:
+        """
+        psutil reports a resolved cwd (macOS gives /private/tmp for /tmp), so both
+        sides need realpath or the reaper silently matches nothing.
+        """
+        real = tmp_path / "checkout"
+        real.mkdir()
+        link = tmp_path / "link"
+        link.symlink_to(real)
+
+        with process_table([FakeProcess(100, 1, CONSUMER_ARGV, cwd=str(real))]):
+            found = _find_orphaned_daemons(self.daemons, str(link))
+
+        assert [p.pid for _, p in found] == [100]
+
+
+class TestReapOrphanedDaemons:
+    daemons: list[tuple[str, Sequence[str]]] = [("getsentry-outcomes", CONSUMER_CMD)]
+
+    def test_terminates_orphan_and_children(self) -> None:
+        child = FakeProcess(101, 100, CONSUMER_ARGV)
+        orphan = FakeProcess(100, 1, CONSUMER_ARGV, children=[child])
+
+        with process_table([orphan]), sigterm_works(True):
+            _reap_orphaned_daemons(self.daemons, CWD)
+
+        assert orphan.terminated and child.terminated
+        assert not orphan.killed and not child.killed
+
+    def test_escalates_to_kill_when_sigterm_ignored(self) -> None:
+        """Wedged consumers do not honor SIGTERM, so the SIGKILL escalation matters."""
+        orphan = FakeProcess(100, 1, CONSUMER_ARGV)
+
+        with process_table([orphan]), sigterm_works(False):
+            _reap_orphaned_daemons(self.daemons, CWD)
+
+        assert orphan.terminated and orphan.killed
+
+    def test_no_orphans_is_a_noop(self) -> None:
+        with process_table([FakeProcess(100, 55, CONSUMER_ARGV)]), sigterm_works(True) as waited:
+            _reap_orphaned_daemons(self.daemons, CWD)
+
+        assert not waited.called


### PR DESCRIPTION
Starting a devserver now terminates daemons that a previous devserver leaked, so they no longer pile up across runs.

Honcho terminates its children on a clean exit, but when the devserver dies to SIGKILL, a hard terminal close, or a crash they reparent to init and keep running. Nothing noticed them on the next startup, so every unclean shutdown left another set behind.

Leaked consumers are by far the worst of these. They never rejoin their consumer group, so they respawn a `multiprocessing` worker every few seconds — each paying a full Django import — and hammer the Kafka group coordinator while doing it. On one laptop 16 leaked `getsentry-outcomes` consumers had accumulated over a week of normal work. With no devserver running at all, they held an idle Kafka container at **185% CPU** and burned about **2.7 cores** in total; killing them dropped Kafka to **1.3%** and total container CPU from ~231% to ~27%.

Before daemons are handed to honcho, a process is reaped only when all of these hold:

- it is reparented to init, so a daemon owned by a *running* devserver is never a candidate;
- its argv matches a daemon this invocation is about to start, as an exact trailing match with the executable basename immediately before it;
- its working directory is this checkout's, so a devserver in another checkout is untouched;
- it belongs to the current user.

Worth a look during review: the ppid and working-directory guards are what keep this from touching a live devserver or a second checkout, and `_daemon_matches` is deliberately strict about the argv tail so that `run consumer ingest-events` cannot be mistaken for `run consumer getsentry-outcomes`.

Two details that are easy to get wrong here, both verified against real processes rather than assumed:

- **SIGKILL escalation is load-bearing, not defensive.** Wedged consumers never complete their SIGTERM shutdown — `pkill` on all 16 left every one alive and unchanged. Without the escalation this fix would do nothing for exactly the case that motivates it.
- **Matching on the executable path does not work.** In a venv, `psutil.Process.exe()` resolves to the real interpreter (for example a uv-managed CPython), not the venv, so scoping by `sys.prefix` would have silently matched nothing. Working directory is used instead, which also covers the node-based watchers. The cwd comparison needs `realpath` on both sides, since psutil reports an already-resolved path.

Reaping is on by default and can be skipped with `--no-reap-orphans`.
