### PR TITLE
Remove organizations:seer-night-shift-settings

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -262,8 +262,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-smart-assignment-run", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Auto-assign the top Seer smart assignment pick when a verdict is delivered
     manager.add("organizations:seer-smart-assignment-assign", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Display nightshift settings
-    manager.add("organizations:seer-night-shift-settings", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Display the Seer Night Shift UI
     manager.add("organizations:seer-night-shift-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Route autofix RCA through the Seer autofix_rca feature


### PR DESCRIPTION
Remove `organizations:seer-night-shift-settings`. All code references were removed in #118753 (2026-06-30), which deleted the Night Shift settings UI. The flag has had zero code/frontend/test usage since, so this removes the now-orphaned flagpole registration. Owner: ml-ai.

---
_Generated by [Claude Code](https://claude.ai/code/session_0155rBnboyBuBCgXS6VynZ9X)_