### PR TITLE
fix(metrics): Switch project details off of metricsEnhanced

### DIFF
--- a/static/app/views/projectDetail/charts/projectBaseEventsChart.spec.tsx
+++ b/static/app/views/projectDetail/charts/projectBaseEventsChart.spec.tsx
@@ -29,7 +29,7 @@ describe('ProjectBaseEventsChart', () => {
     yAxis: 'count()',
     query: '',
     field: ['count()'],
-    dataset: DiscoverDatasets.METRICS_ENHANCED,
+    dataset: DiscoverDatasets.SPANS,
     onTotalValuesChange: jest.fn(),
     location: {
       pathname: '/test',

--- a/static/app/views/projectDetail/charts/projectBaseEventsChart.tsx
+++ b/static/app/views/projectDetail/charts/projectBaseEventsChart.tsx
@@ -45,7 +45,7 @@ class ProjectBaseEventsChart extends Component<Props> {
       selection,
       onTotalValuesChange,
       query,
-      dataset = DiscoverDatasets.METRICS_ENHANCED,
+      dataset = DiscoverDatasets.SPANS,
     } = this.props;
     const {projects, environments, datetime} = selection;
 
@@ -76,7 +76,7 @@ class ProjectBaseEventsChart extends Component<Props> {
       field,
       title,
       help,
-      dataset = DiscoverDatasets.METRICS_ENHANCED,
+      dataset = DiscoverDatasets.SPANS,
       ...eventsChartProps
     } = this.props;
     const {projects, environments, datetime} = selection;

--- a/static/app/views/projectDetail/projectCharts.tsx
+++ b/static/app/views/projectDetail/projectCharts.tsx
@@ -326,11 +326,11 @@ export function ProjectCharts({
                 title={t('Apdex')}
                 help={getTermHelp(organization, PerformanceTerm.APDEX)}
                 query={new MutableSearch([
-                  'event.type:transaction',
+                  'is_transaction:true',
                   query ?? '',
                 ]).formatString()}
-                yAxis="apdex()"
-                field={['apdex()']}
+                yAxis="apdex(span.duration,300)"
+                field={['apdex(span.duration,300)']}
                 api={api}
                 location={location}
                 organization={organization}
@@ -346,7 +346,7 @@ export function ProjectCharts({
                 title={t('Failure Rate')}
                 help={getTermHelp(organization, PerformanceTerm.FAILURE_RATE)}
                 query={new MutableSearch([
-                  'event.type:transaction',
+                  'is_transaction:true',
                   query ?? '',
                 ]).formatString()}
                 yAxis="failure_rate()"
@@ -366,7 +366,7 @@ export function ProjectCharts({
                 title={t('Transactions Per Minute')}
                 help={getTermHelp(organization, PerformanceTerm.TPM)}
                 query={new MutableSearch([
-                  'event.type:transaction',
+                  'is_transaction:true',
                   query ?? '',
                 ]).formatString()}
                 yAxis="tpm()"
@@ -415,7 +415,7 @@ export function ProjectCharts({
               <ProjectBaseEventsChart
                 title={t('Number of Transactions')}
                 query={new MutableSearch([
-                  'event.type:transaction',
+                  'is_transaction:true',
                   query ?? '',
                 ]).formatString()}
                 yAxis="count()"

--- a/static/app/views/projectDetail/projectScoreCards/projectApdexScoreCard.spec.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectApdexScoreCard.spec.tsx
@@ -30,7 +30,7 @@ describe('ProjectDetail > ProjectApdex', () => {
       body: {
         data: [
           {
-            'apdex()': 0.678,
+            'apdex(span.duration,300)': 0.678,
           },
         ],
       },
@@ -43,7 +43,7 @@ describe('ProjectDetail > ProjectApdex', () => {
       body: {
         data: [
           {
-            'apdex()': 0.781,
+            'apdex(span.duration,300)': 0.781,
           },
         ],
       },
@@ -62,17 +62,18 @@ describe('ProjectDetail > ProjectApdex', () => {
 
     expect(await screen.findByText('Apdex')).toBeInTheDocument();
     expect(await screen.findByText('0.781')).toBeInTheDocument();
-    expect(await screen.findByText('0.102')).toBeInTheDocument();
+    expect(await screen.findByText('0.1029')).toBeInTheDocument();
 
     expect(currentDataEndpointMock).toHaveBeenNthCalledWith(
       1,
       `/organizations/${organization.slug}/events/`,
       expect.objectContaining({
         query: {
+          dataset: 'spans',
           environment: [],
-          field: ['apdex()'],
+          field: ['apdex(span.duration,300)'],
           project: ['1'],
-          query: 'event.type:transaction count():>0',
+          query: 'is_transaction:true count():>0',
           statsPeriod: '14d',
         },
       })
@@ -83,10 +84,11 @@ describe('ProjectDetail > ProjectApdex', () => {
       `/organizations/${organization.slug}/events/`,
       expect.objectContaining({
         query: {
+          dataset: 'spans',
           environment: [],
-          field: ['apdex()'],
+          field: ['apdex(span.duration,300)'],
           project: ['1'],
-          query: 'event.type:transaction count():>0',
+          query: 'is_transaction:true count():>0',
           statsPeriodStart: '28d',
           statsPeriodEnd: '14d',
         },

--- a/static/app/views/projectDetail/projectScoreCards/projectApdexScoreCard.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectApdexScoreCard.tsx
@@ -10,6 +10,7 @@ import type {Organization} from 'sentry/types/organization';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {defined} from 'sentry/utils/defined';
 import type {TableData} from 'sentry/utils/discover/discoverQuery';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {getPeriod} from 'sentry/utils/duration/getPeriod';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {BigNumberWidgetVisualization} from 'sentry/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization';
@@ -46,8 +47,9 @@ const useApdex = (props: Props) => {
   const commonQuery = {
     environment: environments,
     project: projects.map(String),
-    field: ['apdex()'],
-    query: ['event.type:transaction count():>0', query].join(' ').trim(),
+    field: ['apdex(span.duration,300)'],
+    query: ['is_transaction:true count():>0', query].join(' ').trim(),
+    dataset: DiscoverDatasets.SPANS,
   };
 
   const currentQuery = useApiQuery<TableData>(
@@ -108,9 +110,10 @@ export function ProjectApdexScoreCard(props: Props) {
 
   const {data, previousData, isLoading, error, refetch} = useApdex(props);
 
-  const apdex = Number(data?.data?.[0]?.['apdex()']) || undefined;
+  const apdex = Number(data?.data?.[0]?.['apdex(span.duration,300)']) || undefined;
 
-  const previousApdex = Number(previousData?.data?.[0]?.['apdex()']) || undefined;
+  const previousApdex =
+    Number(previousData?.data?.[0]?.['apdex(span.duration,300)']) || undefined;
 
   const cardTitle = t('Apdex');
 
@@ -172,7 +175,7 @@ export function ProjectApdexScoreCard(props: Props) {
         <BigNumberWidgetVisualization
           value={apdex}
           previousPeriodValue={previousApdex}
-          field="apdex()"
+          field="apdex(span.duration,300)"
           type="number"
           unit={null}
           preferredPolarity="+"

--- a/static/app/views/projectsDashboard/useProjectStats.spec.tsx
+++ b/static/app/views/projectsDashboard/useProjectStats.spec.tsx
@@ -12,7 +12,6 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 
 import type {ProjectStats} from 'sentry/types/project';
-import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {useProjectStats} from 'sentry/views/projectsDashboard/useProjectStats';
 
 describe('useProjectStats', () => {
@@ -62,7 +61,6 @@ describe('useProjectStats', () => {
       expect.anything(),
       expect.objectContaining({
         query: expect.objectContaining({
-          dataset: DiscoverDatasets.METRICS_ENHANCED,
           query: 'id:2 id:3',
           sessionStats: '1',
           statsPeriod: '24h',

--- a/static/app/views/projectsDashboard/useProjectStats.tsx
+++ b/static/app/views/projectsDashboard/useProjectStats.tsx
@@ -7,7 +7,6 @@ import type {Project, ProjectStats} from 'sentry/types/project';
 import type {ApiResponse} from 'sentry/utils/api/apiFetch';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {useAggregatedQueryKeys} from 'sentry/utils/api/useAggregatedQueryKeys';
-import {DiscoverDatasets} from 'sentry/utils/discover/types';
 
 const MAX_PROJECTS_TO_FETCH = 10;
 
@@ -66,7 +65,6 @@ export function useProjectStats({hasPerformance, organization}: Props) {
               statsPeriod: '24h',
               query: ids.map(id => `id:${id}`).join(' '),
               transactionStats: hasPerformance ? '1' : undefined,
-              dataset: DiscoverDatasets.METRICS_ENHANCED,
               sessionStats: '1',
             },
             staleTime: 0,


### PR DESCRIPTION
The metricsEnhanced dataset was using generic_metrics falling back to the transactions when queries are incompatible. Since we are moving away from collecting generic_metrics as well as transactions, these views have to be switched to 
spans.

Other:
- Also removed the metricsEnhanced dataset for useProjectStats after https://github.com/getsentry/sentry/pull/120743, this means the project list page will also be powered by spans 

Closes EXP-1115
Closes BROWSE-655
