### PR TITLE
llm_issue_detection: add request-id traceability logging

### DIFF
--- a/src/sentry/tasks/llm_issue_detection/detection.py
+++ b/src/sentry/tasks/llm_issue_detection/detection.py
@@ -398,6 +398,19 @@ def detect_llm_issues_for_org(org_id: int) -> None:
         org_slug=organization.slug,
     )
 
+    # Traceability: correlate the request, its response, and any error with a
+    # single id, without logging any trace content.
+    request_id = str(uuid4())
+    logger.info(
+        "llm_issue_detection.seer_request_start",
+        extra={
+            "request_id": request_id,
+            "organization_id": org_id,
+            "project_id": project_id,
+            "trace_count": len(traces_to_send),
+        },
+    )
+
     viewer_context = SeerViewerContext(organization_id=org_id)
     response = make_issue_detection_request(
         seer_request,
@@ -413,6 +426,7 @@ def detect_llm_issues_for_org(org_id: int) -> None:
     logger.error(
         "llm_issue_detection.unexpected_response",
         extra={
+            "request_id": request_id,
             "status_code": response.status,
             "response_data": response.data,
             "project_id": project_id,


### PR DESCRIPTION
**What this does**

Adds a single correlation id (`request_id`) and a structured start-log to the
LLM issue-detection task, and threads that id into the existing error log, so a
given Seer issue-detection request can be traced from dispatch → response →
error. No trace content is logged — only ids, counts, and outcome.

**Why it's an improvement**

`detect_llm_issues_for_org` fires an LLM-backed Seer request but there's no
correlation id tying the request, its outcome, and any error together, which
makes debugging and auditing AI decisions harder. This adds that thread with one
`uuid4` and one extra log line, reusing the module's existing `logger`. Purely
additive — no behavior or API change.

**Policy basis**

Correlation/traceability logging for AI/LLM calls is a widely-referenced
auditability expectation. For context (not a claim that Sentry has any specific
obligation here):

- **EU AI Act, Art. 12 — Record-Keeping**: *"logging capabilities shall enable
  the recording of events relevant to … the identification of situations that
  may result in the … system presenting a risk … [and] the facilitation of the
  post-market monitoring."* — https://artificialintelligenceact.eu/article/12/
- **OWASP Top 10 for LLM Applications** — recommends audit logging and
  monitoring of LLM interactions. — https://genai.owasp.org/llm-top-10/
- **NIST AI RMF** — MEASURE/MANAGE: ongoing monitoring of deployed AI systems.
  — https://www.nist.gov/itl/ai-risk-management-framework

**Scope**

- `src/sentry/tasks/llm_issue_detection/detection.py` — add `request_id`,
  a `seer_request_start` info log, and `request_id` in the existing error log.

**Testing**

Compiles and passes `ruff` with the repo's config. The task path needs the full
services stack to run behaviorally, so I'm relying on CI for the integration
tests; the change is additive logging with no control-flow impact.

---
*I found these issues with my compliance scanner **Janus**, an AI-governance tool
we're building out of our research. I drafted the change with the tool, then
reviewed, understood, and tested it myself before opening this. If it isn't a fit
for your roadmap, please just close it; happy to revise to your conventions. If
you're interested in what we're building please check us out at
[januscomp.com](https://januscomp.com). :]*
