### PR TITLE
chore(codeowners): Exclude auto-generated API urls file from ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -40,6 +40,7 @@
 
 /tests/js/sentry-test/                                  @getsentry/app-frontend
 /static/app/utils/                                      @getsentry/app-frontend
+# This file is auto-generated on endpoint changes
 /static/app/utils/api/knownSentryApiUrls.generated.ts
 /src/sentry/web/frontend/                               @getsentry/app-frontend
 /.agents/skills/sentry-javascript-bugs/                 @getsentry/app-frontend

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -40,6 +40,7 @@
 
 /tests/js/sentry-test/                                  @getsentry/app-frontend
 /static/app/utils/                                      @getsentry/app-frontend
+/static/app/utils/api/knownSentryApiUrls.generated.ts
 /src/sentry/web/frontend/                               @getsentry/app-frontend
 /.agents/skills/sentry-javascript-bugs/                 @getsentry/app-frontend
 /.agents/skills/generate-snapshot-tests/                @getsentry/app-frontend


### PR DESCRIPTION
`knownSentryApiUrls.generated.ts` is now explicitly excluded from CODEOWNERS so regenerated API URL changes do not request app-frontend review through the `/static/app/utils/` rule