### PR TITLE
ref(deps): Bump sentry-protos to 0.53.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ dependencies = [
   "sentry-ophio>=1.1.3",
   # sentry-options is only used in getsentry for now
   "sentry-options>=1.1.2",
-  "sentry-protos>=0.51.0",
+  "sentry-protos>=0.53.0",
   "sentry-redis-tools>=0.5.0",
   "sentry-relay>=0.9.27",
   "sentry-scm>=1.3.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2411,7 +2411,7 @@ requires-dist = [
     { name = "sentry-kafka-schemas", specifier = ">=2.2.0" },
     { name = "sentry-ophio", specifier = ">=1.1.3" },
     { name = "sentry-options", specifier = ">=1.1.2" },
-    { name = "sentry-protos", specifier = ">=0.51.0" },
+    { name = "sentry-protos", specifier = ">=0.53.0" },
     { name = "sentry-redis-tools", specifier = ">=0.5.0" },
     { name = "sentry-relay", specifier = ">=0.9.27" },
     { name = "sentry-scm", specifier = ">=1.3.0" },
@@ -2595,7 +2595,7 @@ wheels = [
 
 [[package]]
 name = "sentry-protos"
-version = "0.51.0"
+version = "0.53.0"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 dependencies = [
     { name = "grpc-stubs" },
@@ -2603,7 +2603,7 @@ dependencies = [
     { name = "protobuf" },
 ]
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_protos-0.51.0-py3-none-any.whl", hash = "sha256:65ae6d0f662dd194c217e859b74f73507e192a0cf029287836e982b0a7604133" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_protos-0.53.0-py3-none-any.whl", hash = "sha256:cc7297d24c9f0d662c3b27340d062883c6936b365baa73c2d83e4d8b14798756" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bumps `sentry-protos` `0.51.0` → `0.53.0`.

`0.53.0` adds the target-plan re-pricing override fields (`override_package_uid` / `override_month_interval` on `GetRateCardRequest` and `GetPriceForContractRequest`) that the getsentry checkout PAYG-freeze work depends on (getsentry#21200, REVENG-356). Bumping here so getsentry can pin to a sentry commit that resolves the new proto version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)