### PR TITLE
fix(seer): Prefer lower-ranked assignment candidates that actually resolve

### DIFF
--- a/src/sentry/seer/smart_assignment/completion.py
+++ b/src/sentry/seer/smart_assignment/completion.py
@@ -48,8 +48,13 @@ def _apply_prediction(
 
     # We need someone who actually resolves to a Sentry user, so pick one further
     # down the list of suggestions if necessary.
-    top_user_id = next(
-        (user_id for user_id in predicted_assignee_user_ids if user_id is not None), None
+    top_user_id, used_rank = next(
+        (
+            (user_id, rank)
+            for rank, user_id in enumerate(predicted_assignee_user_ids)
+            if user_id is not None
+        ),
+        (None, None),
     )
     if top_user_id is None:
         # Agent abstained, or none of its candidates mapped to an org user.
@@ -64,7 +69,7 @@ def _apply_prediction(
         # The top pick doesn't resolve to an org user.
         metrics.incr(
             "smart_assignment.apply_prediction",
-            tags={"outcome": "user_missing"},
+            tags={"outcome": "user_missing", "used_rank": used_rank},
             sample_rate=1.0,
         )
         return
@@ -88,8 +93,12 @@ def _apply_prediction(
     # ground-truth capture skips our own assignment (see scoring.record_ground_truth).
     ProjectOwnership.handle_auto_assignment(project_id=group.project_id, group=group)
 
-    metrics.incr("smart_assignment.apply_prediction", tags={"outcome": "applied"}, sample_rate=1.0)
+    metrics.incr(
+        "smart_assignment.apply_prediction",
+        tags={"outcome": "applied", "used_rank": used_rank},
+        sample_rate=1.0,
+    )
     logger.info(
         "smart_assignment.apply_prediction.applied",
-        extra={"group_id": group.id, "user_id": top_user_id},
+        extra={"group_id": group.id, "user_id": top_user_id, "used_rank": used_rank},
     )

--- a/src/sentry/seer/smart_assignment/completion.py
+++ b/src/sentry/seer/smart_assignment/completion.py
@@ -42,13 +42,21 @@ def _apply_prediction(
 ) -> None:
     """If the feature flag is enabled and we predicted an acutal org user,
     create a (suggested) GroupOwner for them. Then promote the suggestion to an
-    assignment iff the project auto-assigns to owners."""
+    assignment iff the project auto-assigns to owners.
+
+    Suggests the best-ranked candidate we could resolve, which need not be the agent's
+    first choice: only a resolvable user can own anything, so a linked alternate is worth
+    more here than a top pick Sentry can't map. The ranking as the agent gave it stays
+    untouched on the activity and the run mirror.
+    """
     if not features.has(AUTO_ASSIGN_FEATURE_FLAG, group.organization):
         return
 
-    top_user_id = predicted_assignee_user_ids[0] if predicted_assignee_user_ids else None
+    top_user_id = next(
+        (user_id for user_id in predicted_assignee_user_ids if user_id is not None), None
+    )
     if top_user_id is None:
-        # Agent abstained or named someone we couldn't map to an org user.
+        # Agent abstained, or none of its candidates mapped to an org user.
         metrics.incr(
             "smart_assignment.apply_prediction",
             tags={"outcome": "no_candidate"},

--- a/src/sentry/seer/smart_assignment/completion.py
+++ b/src/sentry/seer/smart_assignment/completion.py
@@ -42,16 +42,12 @@ def _apply_prediction(
 ) -> None:
     """If the feature flag is enabled and we predicted an acutal org user,
     create a (suggested) GroupOwner for them. Then promote the suggestion to an
-    assignment iff the project auto-assigns to owners.
-
-    Suggests the best-ranked candidate we could resolve, which need not be the agent's
-    first choice: only a resolvable user can own anything, so a linked alternate is worth
-    more here than a top pick Sentry can't map. The ranking as the agent gave it stays
-    untouched on the activity and the run mirror.
-    """
+    assignment iff the project auto-assigns to owners."""
     if not features.has(AUTO_ASSIGN_FEATURE_FLAG, group.organization):
         return
 
+    # We need someone who actually resolves to a Sentry user, so pick one further
+    # down the list of suggestions if necessary.
     top_user_id = next(
         (user_id for user_id in predicted_assignee_user_ids if user_id is not None), None
     )

--- a/tests/sentry/seer/smart_assignment/test_completion.py
+++ b/tests/sentry/seer/smart_assignment/test_completion.py
@@ -135,6 +135,20 @@ class ProcessSmartAssignmentCompletionTest(TestCase):
         assert len(self._suggested_owners()) == 1
         assert GroupAssignee.objects.get(group=self.group).user_id == existing.id
 
+    def test_suggests_resolvable_alternate_when_top_pick_unlinked(self) -> None:
+        # The agent's first choice mapped to nobody (an unlinked commit author), so the
+        # alternate behind them is the one that can actually own the issue.
+        alice = self._member()
+        self._set_project_auto_assignment(False)
+        with self.feature(AUTO_ASSIGN_FLAG):
+            process_smart_assignment_completion(self.group, self._activity([None, alice.id]))
+
+        owners = self._suggested_owners()
+        assert len(owners) == 1
+        assert owners[0].user_id == alice.id
+        # The agent's ranking is preserved as delivered; only the suggestion skips ahead.
+        assert self._extras()["predicted_assignee_user_ids"] == [None, alice.id]
+
     def test_no_writes_when_top_pick_unlinked(self) -> None:
         with self.feature(AUTO_ASSIGN_FLAG):
             process_smart_assignment_completion(self.group, self._activity([None]))


### PR DESCRIPTION
We really just need to assign issues to someone. If the top choice from a Smart Assignment doesn't resolve, but a lower choice does, just go with that one. We do this at the very end of the process to preserve the list of predictions as long as possible.

Resolves ISWF-3166