### PR TITLE
fix(issues): Use provider from PR state

### DIFF
--- a/src/sentry/seer/agent/client_models.py
+++ b/src/sentry/seer/agent/client_models.py
@@ -104,6 +104,7 @@ class RepoPRState(BaseModel):
     """PR state for a single repository."""
 
     repo_name: str
+    provider: str | None = None
     branch_name: str | None = None
     pr_number: int | None = None
     pr_url: str | None = None

--- a/src/sentry/seer/autofix/on_completion_hook.py
+++ b/src/sentry/seer/autofix/on_completion_hook.py
@@ -540,10 +540,13 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
         }
 
     @classmethod
-    def _format_pull_requests_payload(cls, state: SeerRunState) -> list[dict]:
+    def _format_pull_requests_payload(
+        cls,
+        state: SeerRunState,
+    ) -> list[dict]:
         return [
             {
-                "provider": "unknown",
+                "provider": pull_request.provider or "unknown",
                 "repo_name": pull_request.repo_name,
                 "pull_request": {
                     "pr_id": pull_request.pr_id,

--- a/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
+++ b/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
@@ -531,6 +531,7 @@ class TestAutofixOnCompletionHookWebhooks(TestCase):
         state.repo_pr_states = {
             "test-repo": RepoPRState(
                 repo_name="test-repo",
+                provider="github",
                 pr_id=77,
                 pr_number=7,
                 pr_url="https://example.com/pull/7",
@@ -545,6 +546,7 @@ class TestAutofixOnCompletionHookWebhooks(TestCase):
         call_kwargs = mock_broadcast.call_args.kwargs
         assert call_kwargs["event_name"] == SeerActionType.ITERATION_COMPLETED.value
         assert call_kwargs["payload"]["code_changes"]["test-repo"][0]["path"] == "test.py"
+        assert call_kwargs["payload"]["pull_requests"][0]["provider"] == "github"
         assert call_kwargs["payload"]["pull_requests"][0]["pull_request"]["pr_number"] == 7
         mock_process_autofix_updates.assert_called_once()
         assert (


### PR DESCRIPTION
Use the provider returned in Seer PR state for PR-created and iteration-completed activity payloads, with unknown as the fallback for older runs.

fixes https://linear.app/getsentry/issue/ID-1670/investigate-seer-pull-request-activity-behavior

refs https://github.com/getsentry/seer/pull/7533