### PR TITLE
feat(issues): mark the issue inbox nav entry as experimental

### DIFF
--- a/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.spec.tsx
+++ b/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.spec.tsx
@@ -69,7 +69,9 @@ describe('IssuesSecondaryNavigation', () => {
 
     renderNavigation();
 
-    expect(await screen.findByRole('link', {name: 'Inbox'})).toBeInTheDocument();
+    expect(
+      await screen.findByRole('link', {name: 'Inbox experimental'})
+    ).toBeInTheDocument();
     expect(screen.queryByText('0')).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.tsx
@@ -51,7 +51,12 @@ export function IssuesSecondaryNavigation() {
                   to={`${baseUrl}/inbox/`}
                   end
                   analyticsItemName="issues_inbox"
-                  trailingItems={<InboxCountBadge />}
+                  trailingItems={
+                    <Fragment>
+                      <FeatureBadge type="experimental" />
+                      <InboxCountBadge />
+                    </Fragment>
+                  }
                 >
                   {t('Inbox')}
                 </SecondaryNavigation.Link>


### PR DESCRIPTION
Add the experimental badge to the inbox view:
<img width="185" height="122" alt="Screenshot 2026-07-28 at 5 08 20 PM" src="https://github.com/user-attachments/assets/f7af1705-fae4-4a12-9139-1b927a5735a2" />

unfortunately looks a bit cluttered with the count. we could also put it here:
<img width="353" height="142" alt="image" src="https://github.com/user-attachments/assets/e4b2994d-2c96-4924-9627-acc2077b0c41" />
