### PR TITLE
feat(conversations): Return generation duration and primary project

### DIFF
--- a/src/sentry/api/endpoints/organization_ai_conversations.py
+++ b/src/sentry/api/endpoints/organization_ai_conversations.py
@@ -189,10 +189,13 @@ def _build_conversation_response(
     tool_names: list[str] | None = None,
     tool_errors: int = 0,
     title: str | None = None,
+    generation_duration: float = 0,
+    project_id: int | None = None,
 ) -> dict[str, Any]:
     return {
         "conversationId": conv_id,
         "title": title,
+        "projectId": project_id,
         "flow": flow,
         "errors": errors,
         "llmCalls": llm_calls,
@@ -201,6 +204,7 @@ def _build_conversation_response(
         "inputTokens": input_tokens,
         "outputTokens": output_tokens,
         "totalCost": total_cost,
+        "generationDuration": generation_duration,
         "startTimestamp": start_timestamp,
         "endTimestamp": end_timestamp,
         "traceCount": len(trace_ids),
@@ -355,6 +359,7 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
                 "sum_if(gen_ai.usage.input_tokens,gen_ai.operation.type,equals,ai_client)",
                 "sum_if(gen_ai.usage.output_tokens,gen_ai.operation.type,equals,ai_client)",
                 "sum_if(gen_ai.cost.total_tokens,gen_ai.operation.type,equals,ai_client)",
+                "sum_if(span.duration,gen_ai.operation.type,equals,ai_client)",
                 "min(precise.start_ts)",
                 "max(precise.finish_ts)",
             ],
@@ -461,6 +466,9 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
                         )
                         or 0
                     ),
+                    generation_duration=float(
+                        row.get("sum_if(span.duration,gen_ai.operation.type,equals,ai_client)") or 0
+                    ),
                     trace_ids=[],
                     flow=[],
                     first_input=None,
@@ -485,8 +493,10 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
             tool_names_by_conversation: dict[str, set[str]] = defaultdict(set)
             tool_errors_by_conversation: dict[str, int] = defaultdict(int)
             project_ids_by_conversation: dict[str, set[int]] = defaultdict(set)
-            # Track first user data per conversation (data is sorted by timestamp, so first occurrence wins)
+            # Rows are sorted by timestamp, so the first occurrence per conversation
+            # is the earliest span. Track the first span's user and project.
             user_by_conversation: dict[str, UserResponse] = {}
+            first_project_by_conversation: dict[str, int] = {}
 
             for row in enrichment_rows:
                 conv_id = row.get("gen_ai.conversation.id", "")
@@ -496,6 +506,8 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
                 project_id = row.get("project.id")
                 if isinstance(project_id, int):
                     project_ids_by_conversation[conv_id].add(project_id)
+                    if conv_id not in first_project_by_conversation:
+                        first_project_by_conversation[conv_id] = project_id
 
                 trace_id = row.get("trace", "")
                 if trace_id:
@@ -533,6 +545,7 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
                 conversation["user"] = user_by_conversation.get(conv_id)
                 conversation["toolNames"] = sorted(tool_names_by_conversation.get(conv_id, set()))
                 conversation["toolErrors"] = tool_errors_by_conversation.get(conv_id, 0)
+                conversation["projectId"] = first_project_by_conversation.get(conv_id)
 
             return project_ids_by_conversation
 

--- a/tests/sentry/api/endpoints/test_organization_ai_conversations.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversations.py
@@ -243,6 +243,8 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
         assert conversation["inputTokens"] == LLM_INPUT_TOKENS * 2
         assert conversation["outputTokens"] == LLM_OUTPUT_TOKENS * 2
         assert conversation["totalCost"] == LLM_COST * 2
+        assert conversation["projectId"] == self.project.id
+        assert conversation["generationDuration"] > 0
         assert conversation["traceCount"] == 1
         assert conversation["startTimestamp"] > 0
         assert conversation["endTimestamp"] > 0


### PR DESCRIPTION
Adds two fields to the AI conversations list response so the redesigned conversations table can display them without a request per row:

- `generationDuration`: summed duration of the conversation's generation (`ai_client`) spans.
- `projectId`: the project the conversation's first span belongs to.

`generationDuration` extends the existing aggregation query and `projectId` is derived from enrichment rows already fetched, so neither adds a round trip. The frontend consumer ships separately.

Refs TET-2738
