### PR TITLE
style(ui): Remove bottom margin from tables

### DIFF
--- a/static/app/stories/apiReference.tsx
+++ b/static/app/stories/apiReference.tsx
@@ -352,7 +352,6 @@ const StoryTableContainer = styled('div')`
 const StoryTypesTable = styled('table')`
   width: 100%;
   border-collapse: collapse;
-  margin-bottom: 0;
   border-radius: ${p => p.theme.radius.md};
   word-break: normal;
   table-layout: fixed;

--- a/static/app/styles/text.tsx
+++ b/static/app/styles/text.tsx
@@ -21,7 +21,6 @@ export const textStyles = () => css`
     [data-panel-body-text-styles='ignore']
   ),
   ol:not([role='listbox'], [role='grid'], [role='menu']),
-  table,
   dl,
   blockquote,
   form,

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -218,8 +218,6 @@ const TitleOpText = styled('div')`
 `;
 
 const Table = styled('table')`
-  margin-bottom: 0 !important;
-
   td {
     overflow: hidden;
   }

--- a/static/less/base.less
+++ b/static/less/base.less
@@ -581,7 +581,6 @@ table {
   background-color: @table-bg;
   border-collapse: collapse;
   border-spacing: 0;
-  margin: 0 0 20px;
 
   col[class*='col-'] {
     position: static; // Prevent border hiding in Firefox and IE9-11 (see https://github.com/twbs/bootstrap/issues/11623)


### PR DESCRIPTION
The table by default shouldn't have a margin-bottom. Removing this and the overwrites.