### PR TITLE
fix(ai-monitoring): Stop title generation from joining AI conversations

### DIFF
--- a/src/sentry/ai_monitoring/utils.py
+++ b/src/sentry/ai_monitoring/utils.py
@@ -243,6 +243,10 @@ def generate_title_with_seer(
         max_tokens=64,
         response_schema=TITLE_RESPONSE_SCHEMA,
         reasoning="off",  # force thinking_budget=0 on Gemini 2.x flash-lite
+        # Never attach this call to a conversation: its own gen_ai spans would be
+        # ingested as a conversation, which would enqueue another title
+        # generation, and so on forever.
+        conversation_id=None,
     )
     try:
         response = make_llm_generate_request(body, timeout=20, viewer_context=viewer_context)

--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -242,11 +242,12 @@ class LlmGenerateRequest(TypedDict):
     timeout: NotRequired[float | None]
     reasoning: NotRequired[Literal["off", "low", "med", "high"] | None]
     # Groups this call's gen_ai spans into a Sentry AI Monitoring conversation.
-    # Seer cannot infer identity for a proxied call, so omitting this means "not
-    # part of any conversation" and the spans carry no conversation id. Prefer a
-    # stable subject key (e.g. f"autofix_{run_id}"); omit for calls that are not
-    # conversations, such as classification, scoring, or telemetry processing.
-    conversation_id: NotRequired[str]
+    # Seer cannot infer identity for a proxied call, so omitting this (or passing
+    # None) means "not part of any conversation" and the spans carry no
+    # conversation id. Prefer a stable subject key (e.g. f"autofix_{run_id}");
+    # pass None for calls that are not conversations, such as classification,
+    # scoring, or telemetry processing.
+    conversation_id: NotRequired[str | None]
 
 
 class OneShotRunRequest(TypedDict):


### PR DESCRIPTION
Conversation title generation now calls the Seer LLM proxy with `conversation_id=None`, so those proxy spans are not treated as part of an AI Monitoring conversation.

If this call is grouped into a conversation, its spans get ingested as a conversation and re-enqueue title generation, which can loop forever. `LlmGenerateRequest.conversation_id` also accepts `None` so callers can state that opt-out explicitly.