### PR TITLE
ref(breadcrumbs): add useHasNewBreadcrumbs hook

### DIFF
--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -79,6 +79,7 @@ import {getDefaultWidget} from 'sentry/views/dashboards/widgetBuilder/utils/getD
 import {getDefaultWidgets} from 'sentry/views/dashboards/widgetLibrary/data';
 import {ReleasesDrawerFields} from 'sentry/views/explore/releases/drawer/utils';
 import {TopBar} from 'sentry/views/navigation/topBar';
+import {useHasNewBreadcrumbs} from 'sentry/views/navigation/useHasNewBreadcrumbs';
 import {generatePerformanceEventView} from 'sentry/views/performance/data';
 import {MetricsDataSwitcher} from 'sentry/views/performance/landing/metricsDataSwitcher';
 
@@ -135,6 +136,7 @@ type RouteParams = {
 type Props = {
   api: Client;
   dashboard: DashboardDetails;
+  hasNewBreadcrumbs: boolean;
   initialState: DashboardState;
   location: Location;
   navigate: ReactRouter3Navigate;
@@ -1182,6 +1184,7 @@ class DashboardDetail extends Component<Props, State> {
       navigate,
       organization,
       dashboard,
+      hasNewBreadcrumbs,
       location,
       onDashboardUpdate,
       pageAlerts,
@@ -1201,7 +1204,6 @@ class DashboardDetail extends Component<Props, State> {
       hasUnsavedFilterChanges(dashboard, location);
 
     const eventView = generatePerformanceEventView(location, projects, {});
-    const hasNewBreadcrumbs = organization.features.includes('ui-migration-breadcrumbs');
 
     const pageContent = (
       <Stack flex={1}>
@@ -1560,6 +1562,7 @@ interface DashboardDetailWithInjectedPropsProps extends Omit<
   | 'location'
   | 'params'
   | 'queryClient'
+  | 'hasNewBreadcrumbs'
 > {}
 
 export function DashboardDetailWithInjectedProps(
@@ -1574,6 +1577,7 @@ export function DashboardDetailWithInjectedProps(
   const params = useParams<RouteParams>();
   const [chartInterval] = useDashboardChartInterval();
   const queryClient = useQueryClient();
+  const hasNewBreadcrumbs = useHasNewBreadcrumbs();
   // Always use the validated chart interval so the UI dropdown and widget
   // requests stay in sync. chartInterval is validated against the current page
   // filter period (e.g. won't return 1m for a 30d range) and always has a value.
@@ -1591,6 +1595,7 @@ export function DashboardDetailWithInjectedProps(
       params={params}
       widgetInterval={widgetInterval}
       queryClient={queryClient}
+      hasNewBreadcrumbs={hasNewBreadcrumbs}
     />
   );
 }

--- a/static/app/views/detectors/components/details/common/header.tsx
+++ b/static/app/views/detectors/components/details/common/header.tsx
@@ -17,6 +17,7 @@ import {
 } from 'sentry/views/detectors/pathnames';
 import {getDetectorTypeLabel} from 'sentry/views/detectors/utils/detectorTypeConfig';
 import {TopBar} from 'sentry/views/navigation/topBar';
+import {useHasNewBreadcrumbs} from 'sentry/views/navigation/useHasNewBreadcrumbs';
 
 type DetectorDetailsHeaderProps = {
   detector: Detector;
@@ -25,8 +26,9 @@ type DetectorDetailsHeaderProps = {
 
 function DetectorDetailsBreadcrumbs({detector}: {detector: Detector}) {
   const organization = useOrganization();
+  const hasNewBreadcrumbs = useHasNewBreadcrumbs();
 
-  if (!organization.features.includes('ui-migration-breadcrumbs')) {
+  if (!hasNewBreadcrumbs) {
     return (
       <Breadcrumbs
         crumbs={[
@@ -63,9 +65,9 @@ function DetectorDetailsBreadcrumbs({detector}: {detector: Detector}) {
 }
 
 function DetectorDetailsDefaultHeaderContent({detector}: {detector: Detector}) {
-  const organization = useOrganization();
+  const hasNewBreadcrumbs = useHasNewBreadcrumbs();
 
-  if (organization.features.includes('ui-migration-breadcrumbs')) {
+  if (hasNewBreadcrumbs) {
     return (
       <Fragment>
         <TopBar.Slot name="breadcrumbs">

--- a/static/app/views/explore/conversations/components/conversationsBreadcrumbs.tsx
+++ b/static/app/views/explore/conversations/components/conversationsBreadcrumbs.tsx
@@ -21,6 +21,7 @@ import {
   CONVERSATIONS_SIDEBAR_LABEL,
 } from 'sentry/views/explore/conversations/settings';
 import {TopBar} from 'sentry/views/navigation/topBar';
+import {useHasNewBreadcrumbs} from 'sentry/views/navigation/useHasNewBreadcrumbs';
 
 const COPY_ID_LABEL = t('Copy conversation ID');
 
@@ -51,6 +52,7 @@ export function ConversationsBreadcrumbs({
   project,
 }: ConversationsBreadcrumbsProps) {
   const organization = useOrganization();
+  const hasNewBreadcrumbs = useHasNewBreadcrumbs();
   const location = useLocation();
   const conversationsBaseUrl = normalizeUrl(
     `/organizations/${organization.slug}/explore/${CONVERSATIONS_LANDING_SUB_PATH}/`
@@ -67,7 +69,7 @@ export function ConversationsBreadcrumbs({
     referrer: 'conversations-breadcrumb',
   };
 
-  if (organization.features.includes('ui-migration-breadcrumbs')) {
+  if (hasNewBreadcrumbs) {
     return (
       <Fragment>
         <TopBar.Slot name="breadcrumbs">

--- a/static/app/views/explore/conversations/layout.tsx
+++ b/static/app/views/explore/conversations/layout.tsx
@@ -26,6 +26,7 @@ import {
   MAX_PICKABLE_DAYS,
 } from 'sentry/views/explore/conversations/settings';
 import {TopBar} from 'sentry/views/navigation/topBar';
+import {useHasNewBreadcrumbs} from 'sentry/views/navigation/useHasNewBreadcrumbs';
 
 function ConversationsLayout() {
   const organization = useOrganization();
@@ -90,6 +91,7 @@ function ConversationsHeader() {
 
 function ConversationsLandingHeader() {
   const organization = useOrganization();
+  const hasNewBreadcrumbs = useHasNewBreadcrumbs();
   const location = useLocation();
   const savedQueryTitle = decodeScalar(location.query.title);
   const savedQueryId = decodeScalar(location.query.id);
@@ -108,7 +110,7 @@ function ConversationsLandingHeader() {
     );
   }
 
-  if (organization.features.includes('ui-migration-breadcrumbs')) {
+  if (hasNewBreadcrumbs) {
     return (
       <Fragment>
         <TopBar.Slot name="breadcrumbs">

--- a/static/app/views/explore/replays/detail/header/replayDetailsPageBreadcrumbs.tsx
+++ b/static/app/views/explore/replays/detail/header/replayDetailsPageBreadcrumbs.tsx
@@ -26,6 +26,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjectFromId} from 'sentry/utils/useProjectFromId';
 import {makeReplaysPathname} from 'sentry/views/explore/replays/pathnames';
 import {TopBar} from 'sentry/views/navigation/topBar';
+import {useHasNewBreadcrumbs} from 'sentry/views/navigation/useHasNewBreadcrumbs';
 
 interface Props {
   readerResult: ReturnType<typeof useLoadReplayReader>;
@@ -34,6 +35,7 @@ interface Props {
 export function ReplayDetailsPageBreadcrumbs({readerResult}: Props) {
   const replayRecord = readerResult.replayRecord;
   const organization = useOrganization();
+  const hasNewBreadcrumbs = useHasNewBreadcrumbs();
   const location = useLocation();
   const eventView = EventView.fromLocation(location);
   const project = useProjectFromId({
@@ -74,7 +76,7 @@ export function ReplayDetailsPageBreadcrumbs({readerResult}: Props) {
 
   const {copy} = useCopyToClipboard();
 
-  if (organization.features.includes('ui-migration-breadcrumbs')) {
+  if (hasNewBreadcrumbs) {
     return (
       <Fragment>
         <TopBar.Slot name="breadcrumbs">

--- a/static/app/views/explore/replays/details.tsx
+++ b/static/app/views/explore/replays/details.tsx
@@ -27,6 +27,7 @@ import {ReplayDetailsPageBreadcrumbs} from 'sentry/views/explore/replays/detail/
 import {ReplayDetailsUserBadge} from 'sentry/views/explore/replays/detail/header/replayDetailsUserBadge';
 import {ReplayDetailsPage} from 'sentry/views/explore/replays/detail/page';
 import {TopBar} from 'sentry/views/navigation/topBar';
+import {useHasNewBreadcrumbs} from 'sentry/views/navigation/useHasNewBreadcrumbs';
 import {useLLMContext} from 'sentry/views/seerExplorer/contexts/llmContext';
 import {registerLLMContext} from 'sentry/views/seerExplorer/contexts/registerLLMContext';
 
@@ -62,6 +63,7 @@ function ReplayDetailsContent() {
   const user = useUser();
   const location = useLocation();
   const organization = useOrganization();
+  const hasNewBreadcrumbs = useHasNewBreadcrumbs();
   const {replaySlug} = useParams();
   invariant(replaySlug, '`replaySlug` is required as part of the route params');
 
@@ -109,7 +111,7 @@ function ReplayDetailsContent() {
 
   const pageContent = (
     <Fragment>
-      {organization.features.includes('ui-migration-breadcrumbs') ? (
+      {hasNewBreadcrumbs ? (
         <ReplayDetailsPageBreadcrumbs readerResult={readerResult} />
       ) : (
         <TopBar.Slot name="title">

--- a/static/app/views/issueDetails/header/header.tsx
+++ b/static/app/views/issueDetails/header/header.tsx
@@ -45,6 +45,7 @@ import {
   ReprocessingStatus,
 } from 'sentry/views/issueDetails/utils';
 import {TopBar} from 'sentry/views/navigation/topBar';
+import {useHasNewBreadcrumbs} from 'sentry/views/navigation/useHasNewBreadcrumbs';
 
 interface GroupHeaderProps {
   event: Event | null;
@@ -78,7 +79,7 @@ export function GroupHeader({event, group, project}: GroupHeaderProps) {
 
   const issueTypeConfig = getConfigForIssueType(group, project);
 
-  const hasNewBreadcrumbs = organization.features.includes('ui-migration-breadcrumbs');
+  const hasNewBreadcrumbs = useHasNewBreadcrumbs();
   const issueItem = useIssueIdBreadcrumbItem({project, group});
 
   return (

--- a/static/app/views/navigation/useHasNewBreadcrumbs.tsx
+++ b/static/app/views/navigation/useHasNewBreadcrumbs.tsx
@@ -1,0 +1,6 @@
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+export function useHasNewBreadcrumbs() {
+  const organization = useOrganization();
+  return organization.features.includes('ui-migration-breadcrumbs');
+}


### PR DESCRIPTION
Just created a hook for the feature flag, so we don't need to always do this check `organization.features.includes('ui-migration-breadcrumbs');`