### PR TITLE
feat(conversations): Add project badge tooltip and fix pagination spacing

### DIFF
--- a/static/app/views/explore/conversations/components/conversationsTableRedesign.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTableRedesign.tsx
@@ -161,27 +161,34 @@ export function ConversationsTableRedesign() {
   return (
     <Fragment>
       {showMissingMessagesAlert && <ConversationMissingMessagesAlert />}
-      <FixedRowHeightGrid>
-        <GridEditable
-          isLoading={isFetching}
-          error={error}
-          data={data}
-          columnOrder={columnOrder}
-          columnSortBy={[]}
-          stickyHeader
-          grid={{
-            renderHeadCell,
-            renderBodyCell,
-            onResizeColumn: handleResizeColumn,
-          }}
-          onRowClick={handleRowClick}
-          isRowClickable={() => true}
-          onRowMouseOver={(_dataRow, key) => setHighlightedRowKey(key)}
-          onRowMouseOut={() => setHighlightedRowKey(undefined)}
-          highlightedRowKey={highlightedRowKey}
-        />
-      </FixedRowHeightGrid>
-      <Pagination pageLinks={pageLinks} onCursor={handlePaginate} />
+      <Stack gap="lg">
+        <FixedRowHeightGrid>
+          <GridEditable
+            isLoading={isFetching}
+            error={error}
+            data={data}
+            columnOrder={columnOrder}
+            columnSortBy={[]}
+            stickyHeader
+            // GridEditable's Panel body has a default bottom margin; drop it so
+            // the Stack's `lg` gap is the only spacing before the pagination.
+            bodyStyle={{marginBottom: 0}}
+            grid={{
+              renderHeadCell,
+              renderBodyCell,
+              onResizeColumn: handleResizeColumn,
+            }}
+            onRowClick={handleRowClick}
+            isRowClickable={() => true}
+            onRowMouseOver={(_dataRow, key) => setHighlightedRowKey(key)}
+            onRowMouseOut={() => setHighlightedRowKey(undefined)}
+            highlightedRowKey={highlightedRowKey}
+          />
+        </FixedRowHeightGrid>
+        {/* Zero Pagination's built-in top margin so the Stack's `lg` gap is the
+            only spacing between the table and the controls. */}
+        <TablePagination pageLinks={pageLinks} onCursor={handlePaginate} />
+      </Stack>
     </Fragment>
   );
 }
@@ -279,7 +286,14 @@ function ConversationCell({conversation}: {conversation: Conversation}) {
       </Text>
       <Flex align="center" gap="sm" minWidth={0}>
         <Flex align="center" gap="xs" minWidth={0}>
-          {project && <ProjectAvatar project={project} size={14} />}
+          {project && (
+            <ProjectAvatar
+              project={project}
+              size={14}
+              hasTooltip
+              tooltip={project.slug}
+            />
+          )}
           <Text size="sm" variant="muted" ellipsis>
             {getConversationIdLabel(conversation.conversationId)}
           </Text>
@@ -527,6 +541,10 @@ function ToolsCell({toolNames}: {toolNames: string[]}) {
     </ToolsContainer>
   );
 }
+
+const TablePagination = styled(Pagination)`
+  margin: 0;
+`;
 
 const FixedRowHeightGrid = styled('div')`
   /* Pin data rows to a fixed height by sizing their body cells. Head cells are


### PR DESCRIPTION
Two follow-ups to the redesigned conversations table:

- The project badge in each row now shows the project slug on hover.
- Tightens the space between the table and the pagination controls to a single `lg` gap. It was visibly too large because three spacings stacked up — the grid Panel's bottom margin, the pagination's own top margin, and the surrounding layout gap; the first two are now zeroed so the gap is the only spacing.

Both are behind the existing `gen-ai-conversations-redesign` flag.

Closes TET-2760
Closes TET-2758
