### PR TITLE
feat(ai-monitoring): Gradual rollout for conversation title generation

### DIFF
--- a/src/sentry/ai_monitoring/tasks.py
+++ b/src/sentry/ai_monitoring/tasks.py
@@ -20,11 +20,14 @@ from sentry.ai_monitoring.utils import (
     span_source_timestamp,
 )
 from sentry.models.project import Project
+from sentry.options.rollout import in_rollout_group
 from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import ai_agent_monitoring_tasks
 from sentry.utils import metrics
+
+CONVERSATION_TITLE_ROLLOUT_RATE_OPTION = "ai-monitoring.conversation-title-generation.rollout-rate"
 
 
 def _is_earliest(source_ts: datetime) -> Q:
@@ -61,6 +64,9 @@ def generate_ai_conversation_title(
         return
     if organization.get_option("sentry:hide_ai_features"):
         metrics.incr("ai_monitoring.conversation_title.skip", tags={"reason": "hide_ai_features"})
+        return
+    if not in_rollout_group(CONVERSATION_TITLE_ROLLOUT_RATE_OPTION, conversation_id):
+        metrics.incr("ai_monitoring.conversation_title.skip", tags={"reason": "not_in_rollout"})
         return
 
     conv_hash = conversation_id_hash(conversation_id)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1240,6 +1240,16 @@ register(
     default=0.0,
     flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+# Deterministic % of gen_ai conversations that get Seer title generation, keyed
+# on conversation id. Requires organizations:gen-ai-conversation-title-generation.
+# 0.0 disables generation; 1.0 enables it for every conversation in flagged orgs.
+register(
+    "ai-monitoring.conversation-title-generation.rollout-rate",
+    type=Float,
+    default=0.0,
+    flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
+)
 register(
     "seer.night_shift.enable",
     type=Bool,

--- a/tests/sentry/ai_monitoring/test_tasks.py
+++ b/tests/sentry/ai_monitoring/test_tasks.py
@@ -9,6 +9,7 @@ from sentry_conventions.attributes import ATTRIBUTE_NAMES
 
 from sentry.ai_monitoring.models import AIConversationMetadata
 from sentry.ai_monitoring.tasks import (
+    CONVERSATION_TITLE_ROLLOUT_RATE_OPTION,
     generate_ai_conversation_title,
     spawn_conversation_title_generation,
 )
@@ -27,6 +28,7 @@ from sentry.ai_monitoring.utils import (
 from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.helpers.options import override_options
 from sentry.utils import json
 
 TS = 1609455600.0
@@ -237,6 +239,7 @@ class TitleHelpersTest(TestCase):
 class GenerateAIConversationTitleTaskTest(TestCase):
     def setUp(self) -> None:
         super().setUp()
+        self.enterContext(override_options({CONVERSATION_TITLE_ROLLOUT_RATE_OPTION: 1.0}))
         self.project = self.create_project()
 
     def _task_kwargs(self, **kwargs: Any) -> dict[str, Any]:
@@ -387,6 +390,13 @@ class GenerateAIConversationTitleTaskTest(TestCase):
     @patch("sentry.ai_monitoring.tasks.generate_conversation_title", return_value="Unused")
     def test_skips_when_feature_disabled(self, mock_generate: MagicMock) -> None:
         with self.feature({"organizations:gen-ai-conversation-title-generation": False}):
+            generate_ai_conversation_title(**self._task_kwargs())
+        assert AIConversationMetadata.objects.count() == 0
+        mock_generate.assert_not_called()
+
+    @patch("sentry.ai_monitoring.tasks.generate_conversation_title", return_value="Unused")
+    def test_skips_when_not_in_rollout(self, mock_generate: MagicMock) -> None:
+        with override_options({CONVERSATION_TITLE_ROLLOUT_RATE_OPTION: 0.0}):
             generate_ai_conversation_title(**self._task_kwargs())
         assert AIConversationMetadata.objects.count() == 0
         mock_generate.assert_not_called()


### PR DESCRIPTION
Conversation title generation can now be rolled out as a percentage of conversations, not whole orgs.

Today the feature flag is all-or-nothing for an org: once it's on, every conversation will call Seer. That is more load than we want at first. With this change, the flag still picks which orgs are in, and `ai-monitoring.conversation-title-generation.rollout-rate` (default `0.0`) picks what share of conversations in those orgs actually get a title. Selection is deterministic on conversation id via `in_rollout_group`, so the same conversations stay in as the rate rises.

The check lives only in the generation task — spawn still enqueues when the flag is on. Raise the option in automator while the flag is enabled; leave it at `0` until you are ready for Seer traffic.
