### PR TITLE
feat(disclosure): Add preview prop to Disclosure.Title

### DIFF
--- a/static/app/components/core/disclosure/disclosure.mdx
+++ b/static/app/components/core/disclosure/disclosure.mdx
@@ -105,6 +105,43 @@ The disclosure can be sized by setting the `size` prop.
 </Disclosure>
 ```
 
+### Preview
+
+Use the `preview` prop to summarize the collapsed content inline, after the
+title. It truncates to the space left over and is hidden once expanded, where
+the content itself takes over.
+
+The preview sits outside the toggle button, so it is not part of the button's
+accessible name and clicking it does not expand the disclosure. Keep it to a
+short summary of what is inside — never put information there that is only
+available while collapsed.
+
+<Storybook.Demo>
+  <Flex width="100%">
+    <Disclosure size="sm">
+      <Disclosure.Title preview="The user is asking about their error rate, so I should start by...">
+        Thinking
+      </Disclosure.Title>
+      <Disclosure.Content>
+        The user is asking about their error rate, so I should start by looking at the
+        issues that regressed in the last 24 hours.
+      </Disclosure.Content>
+    </Disclosure>
+  </Flex>
+</Storybook.Demo>
+
+```jsx
+<Disclosure size="sm">
+  <Disclosure.Title preview="The user is asking about their error rate, so I should start by...">
+    Thinking
+  </Disclosure.Title>
+  <Disclosure.Content>
+    The user is asking about their error rate, so I should start by looking at the issues
+    that regressed in the last 24 hours.
+  </Disclosure.Content>
+</Disclosure>
+```
+
 ### Trailing Items
 
 Add interactive elements like buttons, links or badges to the right side of disclosures using the `trailingItems` prop.

--- a/static/app/components/core/disclosure/disclosure.spec.tsx
+++ b/static/app/components/core/disclosure/disclosure.spec.tsx
@@ -45,6 +45,21 @@ describe('Disclosure', () => {
     expect(screen.queryByText('This is the content of the disclosure')).not.toBeVisible();
   });
 
+  it('shows the preview only while collapsed, and keeps it out of the button name', async () => {
+    render(
+      <Disclosure defaultExpanded={false}>
+        <Disclosure.Title preview="a short summary">Thinking</Disclosure.Title>
+        <Disclosure.Content>This is the content of the disclosure</Disclosure.Content>
+      </Disclosure>
+    );
+
+    expect(screen.getByText('a short summary')).toBeVisible();
+    expect(screen.getByRole('button', {name: 'Thinking'})).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Thinking'}));
+    expect(screen.queryByText('a short summary')).not.toBeInTheDocument();
+  });
+
   it('toggling a disclosure triggers the onExpandedChange callback', async () => {
     const onExpandedChange = jest.fn();
     render(

--- a/static/app/components/core/disclosure/disclosure.tsx
+++ b/static/app/components/core/disclosure/disclosure.tsx
@@ -77,14 +77,23 @@ function DisclosureComponent({
 
 interface DisclosureTitleProps extends React.HTMLAttributes<HTMLButtonElement> {
   children?: NonNullable<React.ReactNode>;
+  /**
+   * A single-line summary of the collapsed content, shown after the title and
+   * truncated to the space left over. Hidden once expanded, where the content
+   * itself takes over. Sits outside the toggle button so it stays out of the
+   * button's accessible name — it is a visual affordance, not a label.
+   */
+  preview?: React.ReactNode;
   trailingItems?: React.ReactNode;
 }
 
-function Title({children, trailingItems, ...rest}: DisclosureTitleProps) {
+function Title({children, preview, trailingItems, ...rest}: DisclosureTitleProps) {
   const {buttonProps, state, context} = useDisclosureContext();
 
   const {isDisabled, ...restProps} = buttonProps;
   const {pressProps} = usePress({...restProps});
+
+  const showPreview = preview !== undefined && !state.isExpanded;
 
   return (
     <Flex
@@ -95,23 +104,36 @@ function Title({children, trailingItems, ...rest}: DisclosureTitleProps) {
       paddingRight="xs"
       radius="md"
     >
-      <StretchedButton
+      <TitleButton
         icon={<IconChevron direction={state.isExpanded ? 'down' : 'right'} />}
         disabled={isDisabled}
         size={context.size}
         variant="transparent"
+        $stretch={!showPreview}
         {...pressProps}
         {...rest}
       >
         {children}
-      </StretchedButton>
+      </TitleButton>
+      {showPreview ? (
+        // Shrinks before trailingItems do, so a long preview truncates instead
+        // of squeezing them out.
+        <Flex flex="1" minWidth={0} aria-hidden>
+          <Text size={context.size} variant="muted" ellipsis>
+            {preview}
+          </Text>
+        </Flex>
+      ) : null}
       {trailingItems ?? null}
     </Flex>
   );
 }
 
-const StretchedButton = styled(Button)`
-  flex-grow: 1;
+const TitleButton = styled(Button)<{$stretch: boolean}>`
+  /* Without a preview the button owns the row; with one it hugs its label so
+   * the preview takes the remaining space. */
+  flex-grow: ${p => (p.$stretch ? 1 : 0)};
+  flex-shrink: 0;
   justify-content: flex-start;
   padding-left: ${p => p.theme.space.xs};
 `;

--- a/static/app/views/explore/conversations/components/messagesPanel.spec.tsx
+++ b/static/app/views/explore/conversations/components/messagesPanel.spec.tsx
@@ -354,7 +354,7 @@ describe('MessagesPanel', () => {
     ).toBeInTheDocument();
   });
 
-  it('keeps reasoning text in the DOM inside a collapsed details element', () => {
+  it('keeps reasoning text in the DOM while collapsed', () => {
     const node = createMockNode({
       id: 'span-1',
       attributes: {
@@ -382,10 +382,10 @@ describe('MessagesPanel', () => {
     );
 
     // The reasoning appears both as the collapsed preview and the full content.
-    const matches = screen.getAllByText('My secret thinking text');
-    expect(matches.length).toBeGreaterThan(0);
-    const details = matches[0]!.closest('details');
-    expect(details).not.toBeNull();
-    expect(details).not.toHaveAttribute('open');
+    // The content stays in the DOM but hidden, so find-in-page can reveal it.
+    const [preview, content] = screen.getAllByText('My secret thinking text');
+    expect(preview).toBeVisible();
+    expect(content).toBeInTheDocument();
+    expect(content).not.toBeVisible();
   });
 });

--- a/static/app/views/explore/conversations/components/messagesPanel.tsx
+++ b/static/app/views/explore/conversations/components/messagesPanel.tsx
@@ -4,11 +4,11 @@ import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
 import {MessageRow} from '@sentry/scraps/chat';
+import {Disclosure} from '@sentry/scraps/disclosure';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 
-import {CollapsibleContent} from 'sentry/components/ai/chat/collapsibleContent';
 import {
   AssistantMessageBlock,
   UserMessageBlock,
@@ -283,30 +283,26 @@ function ReasoningSection({reasoning}: {reasoning: string}) {
   const organization = useOrganization();
 
   return (
-    <CollapsibleContent
-      title={
-        <Text size="sm" variant="muted" monospace>
-          {t('Thinking...')}
-        </Text>
-      }
-      preview={
-        <Text size="sm" variant="muted" monospace>
-          {reasoning}
-        </Text>
-      }
-      onToggle={open =>
+    <Disclosure
+      size="sm"
+      onExpandedChange={expanded =>
         trackAnalytics('conversations.detail.expand-thinking', {
           organization,
-          expanded: open,
+          expanded,
         })
       }
     >
-      <Container padding="xs md">
+      <Disclosure.Title preview={reasoning}>
+        <Text size="sm" variant="muted" monospace>
+          {t('Thinking...')}
+        </Text>
+      </Disclosure.Title>
+      <Disclosure.Content>
         <MessageText size="sm" align="left" variant="muted" monospace>
           <AIContentRenderer text={reasoning} inline autoCollapseLimit={10} />
         </MessageText>
-      </Container>
-    </CollapsibleContent>
+      </Disclosure.Content>
+    </Disclosure>
   );
 }
 


### PR DESCRIPTION
Adds a `preview` prop to `Disclosure.Title` that shows a single-line summary of the collapsed content inline, after the title. It truncates to whatever space is left over and is hidden once expanded, where the content itself takes over.

### Accessibility

The preview renders outside the toggle button and is marked `aria-hidden`, so it stays out of the button's accessible name and clicking it does not expand the disclosure. It is a visual affordance only — never put information there that is unavailable while collapsed.

### Layout

Previously the title button always stretched to fill the row. It now hugs its label when a preview is present, so the preview claims the remaining space and truncates before `trailingItems` get squeezed out. Without a preview the behavior is unchanged.

### Conversations

Migrates the reasoning ("Thinking...") section in `messagesPanel` off `CollapsibleContent` onto `Disclosure` with the new prop. The reasoning text still stays in the DOM while collapsed so find-in-page can reveal it. `CollapsibleContent` remains in use elsewhere and is untouched.

Docs added to `disclosure.mdx`.