### PR TITLE
fix(conversations): Keep user icon from shrinking

### DIFF
--- a/static/app/views/explore/conversations/components/conversationsTableRedesign.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTableRedesign.tsx
@@ -311,7 +311,7 @@ function ConversationUserLabel({user}: {user: Conversation['user']}) {
   if (displayName) {
     return (
       <Flex align="center" gap="xs" minWidth={0}>
-        <IconUser size="xs" />
+        <UserIcon size="xs" />
         <Text size="sm" variant="muted" ellipsis>
           {displayName}
         </Text>
@@ -322,7 +322,7 @@ function ConversationUserLabel({user}: {user: Conversation['user']}) {
   return (
     <Tooltip title={<UserNotInstrumentedTooltip />} isHoverable skipWrapper>
       <Flex align="center" gap="xs">
-        <IconUser size="xs" />
+        <UserIcon size="xs" />
         <Text size="sm" variant="muted">
           &mdash;
         </Text>
@@ -559,6 +559,11 @@ const FixedRowHeightGrid = styled('div')`
 // reads as a small inline divider between the id and the user. Override its
 // `align-self: stretch` so the fixed height stays centered in the row instead
 // of pinning to the top.
+// Keep the user icon from shrinking when the display name is long.
+const UserIcon = styled(IconUser)`
+  flex-shrink: 0;
+`;
+
 const CellDivider = styled(Separator)`
   align-self: center;
   height: 12px;


### PR DESCRIPTION
The user icon in each conversation row now keeps its size when the display name is long, instead of being squeezed by the adjacent ellipsized text. Adds `flex-shrink: 0` to the icon.
