### PR TITLE
ref(spans): Replace TaskProducer with FutureTrackingProducer for segments

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3996,6 +3996,14 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Rolls out FutureTrackingProducer to spans process-segments tasks
+register(
+    "tasks.producer.process-segments.rollout",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # If False, TaskWorkers will wait for a task's producer futures to complete
 # before marking a task as complete
 register(

--- a/src/sentry/spans/consumers/process_segments/tasks.py
+++ b/src/sentry/spans/consumers/process_segments/tasks.py
@@ -34,9 +34,13 @@ _snuba_items_task_producer = get_task_producer(
     producer_name=_snuba_items_task_producer_name,
     producer_factory=partial(_get_snuba_items_producer, name=_snuba_items_task_producer_name),
 )
+
+_snuba_items_future_tracking_producer_name = "sentry.spans.process_segments.snuba_items_ftp"
 _snuba_items_future_tracking_producer = get_producer(
-    producer_name=_snuba_items_task_producer_name,
-    producer_factory=partial(_get_snuba_items_producer, name=_snuba_items_task_producer_name),
+    producer_name=_snuba_items_future_tracking_producer_name,
+    producer_factory=partial(
+        _get_snuba_items_producer, name=_snuba_items_future_tracking_producer_name
+    ),
 )
 _snuba_items_topic = ArroyoTopic(get_topic_definition(Topic.SNUBA_ITEMS)["real_topic_name"])
 

--- a/src/sentry/spans/consumers/process_segments/tasks.py
+++ b/src/sentry/spans/consumers/process_segments/tasks.py
@@ -9,13 +9,14 @@ from taskbroker_client.constants import CompressionType
 from taskbroker_client.retry import Retry
 from taskbroker_client.worker.workerchild import ProcessingDeadlineExceeded
 
+from sentry import options
 from sentry.conf.types.kafka_definition import Topic
 from sentry.silo.base import SiloMode
 from sentry.spans.consumers.process_segments.factory import _process_segment_bytes
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import spans_process_segments_tasks
 from sentry.taskworker.producer import get_task_producer
-from sentry.utils.arroyo_producer import get_arroyo_producer
+from sentry.utils.arroyo_producer import get_arroyo_producer, get_producer
 from sentry.utils.kafka_config import get_topic_definition
 
 
@@ -33,6 +34,10 @@ _snuba_items_task_producer = get_task_producer(
     producer_name=_snuba_items_task_producer_name,
     producer_factory=partial(_get_snuba_items_producer, name=_snuba_items_task_producer_name),
 )
+_snuba_items_future_tracking_producer = get_producer(
+    producer_name=_snuba_items_task_producer_name,
+    producer_factory=partial(_get_snuba_items_producer, name=_snuba_items_task_producer_name),
+)
 _snuba_items_topic = ArroyoTopic(get_topic_definition(Topic.SNUBA_ITEMS)["real_topic_name"])
 
 
@@ -45,5 +50,10 @@ _snuba_items_topic = ArroyoTopic(get_topic_definition(Topic.SNUBA_ITEMS)["real_t
     silo_mode=SiloMode.CELL,
 )
 def process_segment_task(segment_bytes: bytes) -> None:
+    producer = (
+        _snuba_items_future_tracking_producer
+        if options.get("tasks.producer.process-segments.rollout")
+        else _snuba_items_task_producer
+    )
     for payload in _process_segment_bytes(segment_bytes, start_new_transaction=False):
-        _snuba_items_task_producer.produce(_snuba_items_topic, payload)
+        producer.produce(_snuba_items_topic, payload)

--- a/tests/sentry/spans/consumers/process_segments/test_factory.py
+++ b/tests/sentry/spans/consumers/process_segments/test_factory.py
@@ -118,6 +118,7 @@ def test_segment_deserialized_correctly(mock_process_segment: mock.MagicMock) ->
         assert headers["project_id"] == b"1"
 
 
+@override_options({"tasks.producer.process-segments.rollout": False})
 @mock.patch(
     "sentry.spans.consumers.process_segments.factory._check_span_duplicates",
     side_effect=lambda spans: spans,
@@ -172,6 +173,31 @@ def test_process_segment_task_matches_consumer_output(
     assert headers["project_id"] == b"1"
 
 
+@override_options({"tasks.producer.process-segments.rollout": True})
+@mock.patch("sentry.spans.consumers.process_segments.tasks._snuba_items_task_producer")
+@mock.patch("sentry.spans.consumers.process_segments.tasks._snuba_items_future_tracking_producer")
+@mock.patch(
+    "sentry.spans.consumers.process_segments.tasks._process_segment_bytes",
+    return_value=[mock.sentinel.payload],
+)
+def test_process_segment_task_uses_future_tracking_producer(
+    mock_process_segment_bytes: mock.MagicMock,
+    mock_future_tracking_producer: mock.MagicMock,
+    mock_task_producer: mock.MagicMock,
+) -> None:
+    segment_bytes = b"segment"
+
+    process_segment_task(segment_bytes)
+
+    mock_process_segment_bytes.assert_called_once_with(segment_bytes, start_new_transaction=False)
+    mock_task_producer.produce.assert_not_called()
+    mock_future_tracking_producer.produce.assert_called_once_with(
+        ArroyoTopic("snuba-items"),
+        mock.sentinel.payload,
+    )
+
+
+@override_options({"tasks.producer.process-segments.rollout": False})
 @mock.patch("sentry.spans.consumers.process_segments.tasks._process_segment_bytes", return_value=[])
 def test_process_segment_task_does_not_start_new_transaction(
     mock_process_segment_bytes: mock.MagicMock,


### PR DESCRIPTION
Replaces TaskProducer with FutureTrackingProducer for process segments tasks.

The rollout will be done each region with the `tasks.producer.process-segments.rollout` flag.