### PR TITLE
feat(issues): Add profiler.id FieldKey for continuous profile search

### DIFF
--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -55,7 +55,6 @@ export enum FieldKey {
   DIST = 'dist',
   ENVIRONMENT = 'environment',
   ERROR_HANDLED = 'error.handled',
-  ERROR_HAS_CONTINUOUS_PROFILE = 'error.has_continuous_profile',
   ERROR_MECHANISM = 'error.mechanism',
   ERROR_TYPE = 'error.type',
   ERROR_UNHANDLED = 'error.unhandled',
@@ -182,7 +181,6 @@ type ErrorFieldKey =
   | FieldKey.BOOKMARKS
   | FieldKey.CULPRIT
   | FieldKey.ERROR_HANDLED
-  | FieldKey.ERROR_HAS_CONTINUOUS_PROFILE
   | FieldKey.ERROR_MECHANISM
   | FieldKey.ERROR_TYPE
   | FieldKey.ERROR_UNHANDLED
@@ -1996,11 +1994,6 @@ const ERROR_FIELD_DEFINITION: Record<ErrorFieldKey, FieldDefinition> = {
     kind: FieldKind.FIELD,
     valueType: FieldValueType.BOOLEAN,
   },
-  [FieldKey.ERROR_HAS_CONTINUOUS_PROFILE]: {
-    desc: t('Errors with an associated continuous profile'),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.BOOLEAN,
-  },
   [FieldKey.ERROR_MECHANISM]: {
     desc: t('The mechanism that created the error'),
     kind: FieldKind.FIELD,
@@ -2858,7 +2851,6 @@ export const ISSUE_EVENT_PROPERTY_FIELDS: FieldKey[] = [
   FieldKey.DEVICE_UUID,
   FieldKey.DIST,
   FieldKey.ERROR_HANDLED,
-  FieldKey.ERROR_HAS_CONTINUOUS_PROFILE,
   FieldKey.ERROR_MAIN_THREAD,
   FieldKey.ERROR_MECHANISM,
   FieldKey.ERROR_TYPE,
@@ -2934,7 +2926,6 @@ export const ISSUE_EVENT_FIELDS_THAT_MAY_CONFLICT_WITH_TAGS = new Set<FieldKey>(
   FieldKey.DEVICE_ORIENTATION,
   FieldKey.DEVICE_UUID,
   FieldKey.ERROR_HANDLED,
-  FieldKey.ERROR_HAS_CONTINUOUS_PROFILE,
   FieldKey.ERROR_MAIN_THREAD,
   FieldKey.ERROR_MECHANISM,
   FieldKey.ERROR_TYPE,

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -55,6 +55,7 @@ export enum FieldKey {
   DIST = 'dist',
   ENVIRONMENT = 'environment',
   ERROR_HANDLED = 'error.handled',
+  ERROR_HAS_CONTINUOUS_PROFILE = 'error.has_continuous_profile',
   ERROR_MECHANISM = 'error.mechanism',
   ERROR_TYPE = 'error.type',
   ERROR_UNHANDLED = 'error.unhandled',
@@ -181,6 +182,7 @@ type ErrorFieldKey =
   | FieldKey.BOOKMARKS
   | FieldKey.CULPRIT
   | FieldKey.ERROR_HANDLED
+  | FieldKey.ERROR_HAS_CONTINUOUS_PROFILE
   | FieldKey.ERROR_MECHANISM
   | FieldKey.ERROR_TYPE
   | FieldKey.ERROR_UNHANDLED
@@ -1994,6 +1996,11 @@ const ERROR_FIELD_DEFINITION: Record<ErrorFieldKey, FieldDefinition> = {
     kind: FieldKind.FIELD,
     valueType: FieldValueType.BOOLEAN,
   },
+  [FieldKey.ERROR_HAS_CONTINUOUS_PROFILE]: {
+    desc: t('Errors with an associated continuous profile'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.BOOLEAN,
+  },
   [FieldKey.ERROR_MECHANISM]: {
     desc: t('The mechanism that created the error'),
     kind: FieldKind.FIELD,
@@ -2851,6 +2858,7 @@ export const ISSUE_EVENT_PROPERTY_FIELDS: FieldKey[] = [
   FieldKey.DEVICE_UUID,
   FieldKey.DIST,
   FieldKey.ERROR_HANDLED,
+  FieldKey.ERROR_HAS_CONTINUOUS_PROFILE,
   FieldKey.ERROR_MAIN_THREAD,
   FieldKey.ERROR_MECHANISM,
   FieldKey.ERROR_TYPE,
@@ -2926,6 +2934,7 @@ export const ISSUE_EVENT_FIELDS_THAT_MAY_CONFLICT_WITH_TAGS = new Set<FieldKey>(
   FieldKey.DEVICE_ORIENTATION,
   FieldKey.DEVICE_UUID,
   FieldKey.ERROR_HANDLED,
+  FieldKey.ERROR_HAS_CONTINUOUS_PROFILE,
   FieldKey.ERROR_MAIN_THREAD,
   FieldKey.ERROR_MECHANISM,
   FieldKey.ERROR_TYPE,

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -97,6 +97,7 @@ export enum FieldKey {
   PLATFORM = 'platform',
   PLATFORM_NAME = 'platform.name',
   PROFILE_ID = 'profile.id',
+  PROFILER_ID = 'profiler.id',
   PROJECT = 'project',
   RELEASE = 'release',
   RELEASE_BUILD = 'release.build',
@@ -164,6 +165,7 @@ type SharedFieldKey =
   | FieldKey.PLATFORM
   | FieldKey.PLATFORM_NAME
   | FieldKey.PROFILE_ID
+  | FieldKey.PROFILER_ID
   | FieldKey.PROJECT
   | FieldKey.REPLAY_ID
   | FieldKey.TIMESTAMP
@@ -1903,6 +1905,12 @@ const SHARED_FIELD_KEY: Record<SharedFieldKey, FieldDefinition> = {
     valueType: FieldValueType.STRING,
     allowWildcard: false,
   },
+  [FieldKey.PROFILER_ID]: {
+    desc: t('The ID of an associated continuous profile'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+    allowWildcard: false,
+  },
   [FieldKey.PROJECT]: {
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
@@ -2874,6 +2882,7 @@ export const ISSUE_EVENT_PROPERTY_FIELDS: FieldKey[] = [
   FieldKey.OS_DISTRIBUTION_NAME,
   FieldKey.OS_DISTRIBUTION_VERSION,
   FieldKey.PLATFORM_NAME,
+  FieldKey.PROFILER_ID,
   FieldKey.RELEASE_BUILD,
   FieldKey.RELEASE_PACKAGE,
   FieldKey.RELEASE_VERSION,
@@ -2948,6 +2957,7 @@ export const ISSUE_EVENT_FIELDS_THAT_MAY_CONFLICT_WITH_TAGS = new Set<FieldKey>(
   FieldKey.OS_DISTRIBUTION_NAME,
   FieldKey.OS_DISTRIBUTION_VERSION,
   FieldKey.PLATFORM_NAME,
+  FieldKey.PROFILER_ID,
   FieldKey.RELEASE_BUILD,
   FieldKey.RELEASE_PACKAGE,
   FieldKey.RELEASE_VERSION,
@@ -3069,6 +3079,7 @@ export const DISCOVER_FIELDS = [
   FieldKey.TRACE_CLIENT_SAMPLE_RATE,
 
   FieldKey.PROFILE_ID,
+  FieldKey.PROFILER_ID,
 
   // Meta field that returns total count, usually for equations
   FieldKey.TOTAL_COUNT,

--- a/static/app/views/issueDetails/hooks/useEventQuery.tsx
+++ b/static/app/views/issueDetails/hooks/useEventQuery.tsx
@@ -1,5 +1,5 @@
 import {MutableSearch} from 'sentry/components/searchSyntax/mutableSearch';
-import {ISSUE_PROPERTY_FIELDS} from 'sentry/utils/fields';
+import {FieldKey, ISSUE_PROPERTY_FIELDS} from 'sentry/utils/fields';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 
@@ -8,6 +8,8 @@ export const ALL_EVENTS_EXCLUDED_TAGS = [
   'performance.issue_ids',
   'transaction.op',
   'transaction.status',
+  // Only resolves on the issue search backend, not the event-level Discover datasets.
+  FieldKey.ERROR_HAS_CONTINUOUS_PROFILE,
   ...ISSUE_PROPERTY_FIELDS,
 ];
 

--- a/static/app/views/issueDetails/hooks/useEventQuery.tsx
+++ b/static/app/views/issueDetails/hooks/useEventQuery.tsx
@@ -1,5 +1,5 @@
 import {MutableSearch} from 'sentry/components/searchSyntax/mutableSearch';
-import {FieldKey, ISSUE_PROPERTY_FIELDS} from 'sentry/utils/fields';
+import {ISSUE_PROPERTY_FIELDS} from 'sentry/utils/fields';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 
@@ -8,8 +8,6 @@ export const ALL_EVENTS_EXCLUDED_TAGS = [
   'performance.issue_ids',
   'transaction.op',
   'transaction.status',
-  // Only resolves on the issue search backend, not the event-level Discover datasets.
-  FieldKey.ERROR_HAS_CONTINUOUS_PROFILE,
   ...ISSUE_PROPERTY_FIELDS,
 ];
 


### PR DESCRIPTION
### Description

Adds the `profiler.id` `FieldKey` definition to the issue search bar, so it renders nicely as a field with autocomplete.

<img width="1752" height="512" alt="image" src="https://github.com/user-attachments/assets/7d5b4b01-9083-4ce8-9664-3bc25c9f842d" />

### Motivation

Filter performance issues like ANRs to event instances which have a profile attached, making it easier to understand and debug those issues.

Fixes https://github.com/getsentry/sentry-java/issues/5512
Backend PR: https://github.com/getsentry/sentry/pull/120808

Note: this PR previously added support for a boolean-only `error.has_continuous_profile` filter. Following review, the backend switched to reusing the existing `profiler.id` alias (already used for transactions) instead of introducing a new filter. See backend PR for details.