### PR TITLE
feat(data-browsing): adding backend id for deterministic sorting

### DIFF
--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -628,6 +628,11 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
         else:
             order_by = ["title"]
 
+        # Entries with null last visited need a deterministic tiebreaker,
+        # hence adding id to serve this purpose.
+        if use_user_last_visited:
+            order_by.append("-id")
+
         pin_by = request.query_params.get("pin")
         if pin_by == "favorites":
             favorited_by_subquery = DashboardFavoriteUser.objects.filter(

--- a/src/sentry/explore/endpoints/explore_saved_queries.py
+++ b/src/sentry/explore/endpoints/explore_saved_queries.py
@@ -499,6 +499,15 @@ class ExploreSavedQueriesEndpoint(OrganizationEndpoint):
             )
             order_by = ["position", "-date_added"]
 
+        # Entries with null last visited need a deterministic tiebreaker,
+        # hence adding id to serve this purpose.
+        if features.has(
+            "organizations:dashboards-user-last-visited",
+            organization,
+            actor=request.user,
+        ):
+            order_by.append("-id")
+
         queryset = queryset.order_by(*order_by)
 
         def data_fn(offset, limit):

--- a/src/sentry/explore/endpoints/explore_saved_queries.py
+++ b/src/sentry/explore/endpoints/explore_saved_queries.py
@@ -501,12 +501,7 @@ class ExploreSavedQueriesEndpoint(OrganizationEndpoint):
 
         # Entries with null last visited need a deterministic tiebreaker,
         # hence adding id to serve this purpose.
-        if features.has(
-            "organizations:dashboards-user-last-visited",
-            organization,
-            actor=request.user,
-        ):
-            order_by.append("-id")
+        order_by.append("-id")
 
         queryset = queryset.order_by(*order_by)
 

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
@@ -973,6 +973,32 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
         assert response.data[1]["title"] == never_visited.title
         assert response.data[1].get("lastVisited") is None
 
+    def test_recently_viewed_sort_unvisited_stable_order_with_flag(self) -> None:
+        Dashboard.objects.all().delete()
+
+        first = Dashboard.objects.create(
+            title="First",
+            organization=self.organization,
+            created_by_id=self.user.id,
+        )
+        second = Dashboard.objects.create(
+            title="Second",
+            organization=self.organization,
+            created_by_id=self.user.id,
+        )
+        third = Dashboard.objects.create(
+            title="Third",
+            organization=self.organization,
+            created_by_id=self.user.id,
+        )
+
+        with self.feature("organizations:dashboards-user-last-visited"):
+            response = self.client.get(self.url, data={"sort": "recentlyViewed"})
+
+        assert response.status_code == 200, response.content
+        ids = [row["id"] for row in response.data]
+        assert ids == [str(third.id), str(second.id), str(first.id)]
+
     def test_post(self) -> None:
         response = self.do_request("post", self.url, data={"title": "Dashboard from Post"})
         assert response.status_code == 201

--- a/tests/sentry/explore/endpoints/test_explore_saved_queries.py
+++ b/tests/sentry/explore/endpoints/test_explore_saved_queries.py
@@ -238,6 +238,33 @@ class ExploreSavedQueriesTest(APITestCase):
                 assert values[0] == expected[0]
                 assert values[1] == expected[1]
 
+    def test_get_sortby_recently_viewed_stable_order_with_flag(self) -> None:
+        query = {"range": "24h", "query": [{"fields": ["span.op"], "mode": "samples"}]}
+        same_date = before_now(minutes=1)
+        created = [
+            ExploreSavedQuery.objects.create(
+                organization=self.org,
+                created_by_id=self.user.id,
+                name=f"Unvisited {i}",
+                query=query,
+                date_added=same_date,
+                date_updated=same_date,
+            )
+            for i in range(3)
+        ]
+
+        features = {
+            **self.features,
+            "organizations:dashboards-user-last-visited": True,
+        }
+        with self.feature(features):
+            response = self.client.get(self.url, data={"sortBy": "recentlyViewed"})
+
+        assert response.status_code == 200, response.content
+        expected = [q.name for q in sorted(created, key=lambda q: q.id, reverse=True)]
+        returned = [row["name"] for row in response.data if row["name"].startswith("Unvisited ")]
+        assert returned == expected
+
     def test_get_sortby_myqueries(self) -> None:
         uhoh_user = self.create_user(username="uhoh")
         self.create_member(organization=self.org, user=uhoh_user)

--- a/tests/sentry/explore/endpoints/test_explore_saved_queries.py
+++ b/tests/sentry/explore/endpoints/test_explore_saved_queries.py
@@ -238,7 +238,7 @@ class ExploreSavedQueriesTest(APITestCase):
                 assert values[0] == expected[0]
                 assert values[1] == expected[1]
 
-    def test_get_sortby_recently_viewed_stable_order_with_flag(self) -> None:
+    def test_get_sortby_recently_viewed_stable_order(self) -> None:
         query = {"range": "24h", "query": [{"fields": ["span.op"], "mode": "samples"}]}
         same_date = before_now(minutes=1)
         created = [
@@ -253,11 +253,7 @@ class ExploreSavedQueriesTest(APITestCase):
             for i in range(3)
         ]
 
-        features = {
-            **self.features,
-            "organizations:dashboards-user-last-visited": True,
-        }
-        with self.feature(features):
+        with self.feature(self.features):
             response = self.client.get(self.url, data={"sortBy": "recentlyViewed"})
 
         assert response.status_code == 200, response.content


### PR DESCRIPTION
This PR adds an id to the explore/dashboard detail endpoints to have a deterministic tiebreaker where entries have null values for certain properties, like `last_visited`

Closes BROWSE-664