### PR TITLE
style(weekly-report): Add x-axis to graph

### DIFF
--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -262,7 +262,7 @@
         {% endfor %}
       </tr>
       <tr>
-        <td class="axis" colspan="{{ trends.series|length }}" height="1" style="height: 1px; font-size: 0; line-height: 0; background-color: #F0F0F2; border-right: none;">&nbsp;</td>
+        <td class="axis" colspan="{{ trends.series|length }}" height="1" style="height: 1px; font-size: 0; line-height: 0; background-color: #C0BEC6; border-right: none;">&nbsp;</td>
       </tr>
       <tr>
         {% for timestamp, project_values in trends.series %}
@@ -304,7 +304,7 @@
         {% endfor %}
       </tr>
       <tr>
-        <td class="axis" colspan="{{ trends.series|length }}" height="1" style="height: 1px; font-size: 0; line-height: 0; background-color: #F0F0F2; border-right: none;">&nbsp;</td>
+        <td class="axis" colspan="{{ trends.series|length }}" height="1" style="height: 1px; font-size: 0; line-height: 0; background-color: #C0BEC6; border-right: none;">&nbsp;</td>
       </tr>
       <tr>
         {% for timestamp, project_values in trends.series %}

--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -107,6 +107,14 @@
         border-right: none;
     }
 
+    .project-breakdown .graph td.axis {
+      height: 1px;
+      font-size: 0;
+      line-height: 0;
+      background-color: #DEE7EB;
+      border-right: none;
+    }
+
     .project-breakdown .graph .label {
       font-size: 10px;
       color: #000;
@@ -254,6 +262,9 @@
         {% endfor %}
       </tr>
       <tr>
+        <td class="axis" colspan="{{ trends.series|length }}" height="1" style="height: 1px; font-size: 0; line-height: 0; background-color: #F0F0F2; border-right: none;">&nbsp;</td>
+      </tr>
+      <tr>
         {% for timestamp, project_values in trends.series %}
           <td class="label" style="width: {% widthratio 1 trends.series|length 100 %}%">
             {{ timestamp|day_initial }}
@@ -291,6 +302,9 @@
             </table>
           </td>
         {% endfor %}
+      </tr>
+      <tr>
+        <td class="axis" colspan="{{ trends.series|length }}" height="1" style="height: 1px; font-size: 0; line-height: 0; background-color: #F0F0F2; border-right: none;">&nbsp;</td>
       </tr>
       <tr>
         {% for timestamp, project_values in trends.series %}


### PR DESCRIPTION
Resolves [ID-1727](https://linear.app/getsentry/issue/ID-1727/add-horizontal-line-to-bar-graph)

Before: 
<img width="642" height="267" alt="Screenshot 2026-07-29 at 9 21 31 AM" src="https://github.com/user-attachments/assets/52d8b916-fa89-4a14-8e61-f8b6d6da0879" />

After: 
<img width="642" height="249" alt="Screenshot 2026-07-29 at 9 17 10 AM" src="https://github.com/user-attachments/assets/3bd07c07-f678-4263-afaa-ca86b0696df0" />