### PR TITLE
perf(feedback): Stop expanding latest event attachments

### DIFF
--- a/static/app/components/feedback/list/feedbackListItem.tsx
+++ b/static/app/components/feedback/list/feedbackListItem.tsx
@@ -11,7 +11,7 @@ import {IssueTrackingSignals} from 'sentry/components/feedback/list/issueTrackin
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import {TextOverflow} from 'sentry/components/textOverflow';
 import {TimeSince} from 'sentry/components/timeSince';
-import {IconChat, IconFatal, IconImage, IconPlay} from 'sentry/icons';
+import {IconChat, IconFatal, IconPlay} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Group} from 'sentry/types/group';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -48,7 +48,6 @@ export function FeedbackListItem({feedbackItem, onItemSelect}: Props) {
   const location = useLocation();
 
   const hasLinkedError = feedbackHasLinkedError(feedbackItem);
-  const hasAttachments = feedbackItem.latestEventHasAttachments;
   const hasComments = feedbackItem.numComments > 0;
 
   return (
@@ -140,12 +139,6 @@ export function FeedbackListItem({feedbackItem, onItemSelect}: Props) {
             {hasReplayId && (
               <Tooltip title={t('Linked Replay')} containerDisplayMode="flex">
                 <IconPlay size="xs" variant="muted" />
-              </Tooltip>
-            )}
-
-            {hasAttachments && (
-              <Tooltip title={t('Has Screenshot')} containerDisplayMode="flex">
-                <IconImage size="xs" variant="muted" />
               </Tooltip>
             )}
 

--- a/static/app/components/feedback/useFeedbackListApiOptions.tsx
+++ b/static/app/components/feedback/useFeedbackListApiOptions.tsx
@@ -57,9 +57,7 @@ function buildQuery(params: {
 }) {
   return {
     ...params.fixedQueryView,
-    expand: params.prefetch
-      ? []
-      : ['integrationIssues', 'sentryAppIssues', 'latestEventHasAttachments'],
+    expand: params.prefetch ? [] : ['integrationIssues', 'sentryAppIssues'],
     shortIdLookup: 0,
     query: `issue.category:feedback status:${params.mailbox} ${params.fixedQueryView.query}`,
   };


### PR DESCRIPTION
Snuba latency has increased, and the "has screenshot" icon in the user feedback list causes a snuba request for the latest event for every feedback in the list, which has caused huge response times on the user feedback page.

See this [trace as an example](https://sentry.sentry.io/explore/traces/trace/1a4b40e50f2948cbb9035284b2dcc5c0/?aggregateField=%7B%22groupBy%22%3A%22%22%7D&aggregateField=%7B%22yAxes%22%3A%5B%22p99%28span.duration%29%22%5D%7D&end=2026-07-29T15%3A00%3A00&fov=1%2C158428.36694335938&mode=samples&node=span-852f90676f492f5d&pageEnd=2026-07-29T15%3A00%3A00.000&pageStart=2026-07-27T03%3A49%3A00.000&project=1&query=transaction%3A%2Fapi%2F0%2Forganizations%2F%7Borganization_id_or_slug%7D%2Fissues%2F%20span.op%3Ahttp.server&sort=-span.duration&source=traces&start=2026-07-27T03%3A49%3A00&targetId=852f90676f492f5d&timestamp=1785177349) - it shows that a request with `expand=latestEventHasAttachments` causes many sequential snuba queries

IMO showing the screenshot indicator isn't worth all the additional latency, even when snuba has more reasonable latency. We could also change the endpoint to bulk fetch all the latest events, but that too wouldn't be very quick. 