### PR TITLE
fix(seer-settings): Fix agent handoff dropdown selection not persisting

### DIFF
--- a/static/app/components/seer/projectTable/seerProjectTable.spec.tsx
+++ b/static/app/components/seer/projectTable/seerProjectTable.spec.tsx
@@ -171,6 +171,10 @@ describe('SeerProjectTable', () => {
 
   it('allows coding-agent handoff for a GitHub-only project', async () => {
     mockProjectRepos('github');
+    const settingsPut = MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/seer/settings/`,
+      method: 'PUT',
+    });
     const errorSpy = jest.spyOn(indicators, 'addErrorMessage');
 
     renderTable();
@@ -180,9 +184,8 @@ describe('SeerProjectTable', () => {
       await screen.findByRole('menuitemradio', {name: 'Cursor Cloud Agent'})
     );
 
-    // The check passes, so the selection is committed (left to the existing
-    // blur-to-save flow to persist) and no warning is shown.
-    expect(await screen.findByText('Cursor Cloud Agent')).toBeInTheDocument();
+    // The check passes, so the selection is persisted and no warning is shown.
+    await waitFor(() => expect(settingsPut).toHaveBeenCalled());
     expect(errorSpy).not.toHaveBeenCalled();
   });
 });

--- a/static/app/components/seer/projectTable/seerProjectTable.tsx
+++ b/static/app/components/seer/projectTable/seerProjectTable.tsx
@@ -382,6 +382,10 @@ function AgentSelectCell({
               }
             }
             field.handleChange(newValue);
+            // AutoSaveForm only persists on blur, but the select's blur fires
+            // before this async handler resolves, so trigger the save
+            // explicitly now that the value is set.
+            field.handleBlur();
           }}
           options={agentSelectOptions}
           // @ts-expect-error: Select component does not have a size prop defined

--- a/static/app/components/seer/projectTable/seerProjectTable.tsx
+++ b/static/app/components/seer/projectTable/seerProjectTable.tsx
@@ -382,9 +382,6 @@ function AgentSelectCell({
               }
             }
             field.handleChange(newValue);
-            // AutoSaveForm only persists on blur, but the select's blur fires
-            // before this async handler resolves, so trigger the save
-            // explicitly now that the value is set.
             field.handleBlur();
           }}
           options={agentSelectOptions}


### PR DESCRIPTION
Fixes AIML-3211

The Seer project settings table's agent dropdown had an async `onChange` that awaited a repo check, so the select blurred before `field.handleChange` ran — and since `AutoSaveForm` only saves on blur, the PUT was never sent (intermittent, depending on repo-check cache hits). Fix by calling `field.handleBlur()` after `handleChange` to trigger the save explicitly. 

Before (notice no green check mark after selecting):

https://github.com/user-attachments/assets/40acef48-b3b7-400a-b71d-848bf72725b5

After:

https://github.com/user-attachments/assets/86402930-e0f6-48ae-82ba-e43549e0066b
