### PR TITLE
fix(issues): Use since first seen for more issue types

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -649,6 +649,7 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /static/**/issues/**                                        @getsentry/issue-detection-frontend @getsentry/issue-workflow
 /static/**/group/**                                         @getsentry/issue-detection-frontend @getsentry/issue-workflow
 /static/app/components/activity/                            @getsentry/issue-detection-frontend @getsentry/issue-workflow
+/static/app/utils/issueTypeConfig/                          @getsentry/issue-detection-frontend @getsentry/issue-workflow
 /tests/sentry/issues/**                                     @getsentry/issue-detection-backend @getsentry/issue-workflow
 # Overrides
 /src/sentry/api/helpers/actionable_items_helper.py          @getsentry/issue-workflow

--- a/static/app/utils/issueTypeConfig/frontendConfig.tsx
+++ b/static/app/utils/issueTypeConfig/frontendConfig.tsx
@@ -48,6 +48,7 @@ export const frontendConfig: IssueCategoryConfigMapping = {
     issueSummary: {enabled: false},
   },
   [IssueType.PERFORMANCE_UNCOMPRESSED_ASSET]: {
+    defaultTimePeriod: {sinceFirstSeen: true},
     spanEvidence: {enabled: true},
     evidence: null,
     resources: {
@@ -61,6 +62,7 @@ export const frontendConfig: IssueCategoryConfigMapping = {
     autofix: true,
   },
   [IssueType.PERFORMANCE_RENDER_BLOCKING_ASSET]: {
+    defaultTimePeriod: {sinceFirstSeen: true},
     spanEvidence: {enabled: true},
     evidence: null,
     resources: {
@@ -79,6 +81,7 @@ export const frontendConfig: IssueCategoryConfigMapping = {
     autofix: true,
   },
   [IssueType.WEB_VITALS]: {
+    defaultTimePeriod: {sinceFirstSeen: true},
     issueSummary: {enabled: true},
     autofix: true,
   },


### PR DESCRIPTION
Web Vitals and asset issues can have no events in the default 14-day window, leaving issue details basically empty.

Default these issue types to their available history instead.

fixes [this issue](https://sentry.sentry.io/issues/7585650905/?project=11276) from having nothing on the chart after loading