### PR TITLE
test(explore): Mock trace-item prefetch in logs table tests

### DIFF
--- a/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
@@ -799,6 +799,19 @@ describe('LogsInfiniteTable', () => {
         meta: {fields: {}, units: {}},
       },
     });
+    for (const log of mockLogsData) {
+      MockApiClient.addMockResponse({
+        url: `/projects/${organization.slug}/${project.slug}/trace-items/${log[OurLogKnownFieldKey.ID]}/`,
+        method: 'GET',
+        body: {
+          itemId: log[OurLogKnownFieldKey.ID],
+          links: null,
+          meta: {},
+          timestamp: log[OurLogKnownFieldKey.TIMESTAMP],
+          attributes: [],
+        },
+      });
+    }
 
     const traceError: TraceTree.TraceError = {
       event_id: 'abc123def456',
@@ -831,6 +844,19 @@ describe('LogsInfiniteTable', () => {
       method: 'GET',
       statusCode: 500,
     });
+    for (const log of mockLogsData) {
+      MockApiClient.addMockResponse({
+        url: `/projects/${organization.slug}/${project.slug}/trace-items/${log[OurLogKnownFieldKey.ID]}/`,
+        method: 'GET',
+        body: {
+          itemId: log[OurLogKnownFieldKey.ID],
+          links: null,
+          meta: {},
+          timestamp: log[OurLogKnownFieldKey.TIMESTAMP],
+          attributes: [],
+        },
+      });
+    }
 
     const traceError: TraceTree.TraceError = {
       event_id: 'abc123def456',


### PR DESCRIPTION
Injected-error-row cases in `LogsInfiniteTable` clear all API mocks and only re-stub the events endpoint. Leftover hover-prefetch timers from earlier tests in the file can still fire afterward and request `/trace-items/{id}/`, which then fails with `console.error` and flakes the suite.

These tests now re-add the standard log detail mocks after clearing so residual prefetch requests resolve cleanly.
