### PR TITLE
fix(alerts): preserve selected projects beyond 100 monitors

### DIFF
--- a/static/app/views/automations/components/editConnectedMonitors.spec.tsx
+++ b/static/app/views/automations/components/editConnectedMonitors.spec.tsx
@@ -253,23 +253,77 @@ describe('EditConnectedMonitors', () => {
     model.setInitialData({allProjects: false, projectIds: [], detectorIds: ['101']});
 
     render(
-      <Form model={model}>
-        <EditConnectedMonitors
-          connectedIds={[allProjectsDetector.id]}
-          setConnectedIds={jest.fn()}
-        />
-      </Form>,
-      {
-        organization: OrganizationFixture({
-          features: ['workflow-engine-all-projects-detector'],
-        }),
-      }
+        <Form model={model}>
+          <EditConnectedMonitors
+              connectedIds={[allProjectsDetector.id]}
+              setConnectedIds={jest.fn()}
+          />
+        </Form>,
+        {
+          organization: OrganizationFixture({
+            features: ['workflow-engine-all-projects-detector'],
+          }),
+        }
     );
 
     expect(
-      await screen.findByRole('radio', {name: 'Alert on all issues in all projects'})
+        await screen.findByRole('radio', {name: 'Alert on all issues in all projects'})
     ).toBeChecked();
     await waitFor(() => expect(model.getValue('allProjects')).toBe(true));
+  });
+
+  it('loads every connected project when the alert has more than 100 monitors', async () => {
+    const connectedProjects = Array.from({length: 101}, (_, index) =>
+      ProjectFixture({id: String(index + 1), slug: `project-${index + 1}`})
+    );
+    const detectors = connectedProjects.map(connectedProject =>
+      IssueStreamDetectorFixture({
+        id: connectedProject.id,
+        projectId: connectedProject.id,
+      })
+    );
+    ProjectsStore.loadInitialData(connectedProjects);
+
+    const firstRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/detectors/',
+      method: 'GET',
+      body: detectors.slice(0, 100),
+      match: [
+        MockApiClient.matchQuery({
+          id: detectors.slice(0, 100).map(detector => detector.id),
+        }),
+      ],
+    });
+    const secondRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/detectors/',
+      method: 'GET',
+      body: detectors.slice(100),
+      match: [
+        MockApiClient.matchQuery({
+          id: detectors.slice(100).map(detector => detector.id),
+        }),
+      ],
+    });
+
+    const model = new FormModel();
+    model.setInitialData({detectorIds: detectors.map(detector => detector.id)});
+    render(
+      <Form model={model}>
+        <EditConnectedMonitors
+          connectedIds={detectors.map(detector => detector.id)}
+          setConnectedIds={jest.fn()}
+        />
+      </Form>
+    );
+
+    await waitFor(() => {
+      expect(model.getValue('projectIds')).toEqual(
+        connectedProjects.map(connectedProject => connectedProject.id)
+      );
+    });
+
+    expect(firstRequest).toHaveBeenCalledTimes(1);
+    expect(secondRequest).toHaveBeenCalledTimes(1);
   });
 
   it('switches between modes correctly', async () => {

--- a/static/app/views/automations/components/editConnectedMonitors.spec.tsx
+++ b/static/app/views/automations/components/editConnectedMonitors.spec.tsx
@@ -197,6 +197,60 @@ describe('EditConnectedMonitors', () => {
     });
   });
 
+  it('loads every connected project when the alert has more than 100 monitors', async () => {
+    const connectedProjects = Array.from({length: 101}, (_, index) =>
+      ProjectFixture({id: String(index + 1), slug: `project-${index + 1}`})
+    );
+    const detectors = connectedProjects.map(connectedProject =>
+      IssueStreamDetectorFixture({
+        id: connectedProject.id,
+        projectId: connectedProject.id,
+      })
+    );
+    ProjectsStore.loadInitialData(connectedProjects);
+
+    const firstRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/detectors/',
+      method: 'GET',
+      body: detectors.slice(0, 100),
+      match: [
+        MockApiClient.matchQuery({
+          id: detectors.slice(0, 100).map(detector => detector.id),
+        }),
+      ],
+    });
+    const secondRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/detectors/',
+      method: 'GET',
+      body: detectors.slice(100),
+      match: [
+        MockApiClient.matchQuery({
+          id: detectors.slice(100).map(detector => detector.id),
+        }),
+      ],
+    });
+
+    const model = new FormModel();
+    model.setInitialData({detectorIds: detectors.map(detector => detector.id)});
+    render(
+      <Form model={model}>
+        <EditConnectedMonitors
+          connectedIds={detectors.map(detector => detector.id)}
+          setConnectedIds={jest.fn()}
+        />
+      </Form>
+    );
+
+    await waitFor(() => {
+      expect(model.getValue('projectIds')).toEqual(
+        connectedProjects.map(connectedProject => connectedProject.id)
+      );
+    });
+
+    expect(firstRequest).toHaveBeenCalledTimes(1);
+    expect(secondRequest).toHaveBeenCalledTimes(1);
+  });
+
   it('switches between modes correctly', async () => {
     const setConnectedIds = jest.fn();
     render(<EditConnectedMonitors connectedIds={[]} setConnectedIds={setConnectedIds} />);

--- a/static/app/views/automations/hooks/useConnectedDetectors.tsx
+++ b/static/app/views/automations/hooks/useConnectedDetectors.tsx
@@ -1,20 +1,28 @@
-import {useQuery} from '@tanstack/react-query';
+import {useQueries} from '@tanstack/react-query';
+import chunk from 'lodash/chunk';
 
 import {useFormField} from 'sentry/components/workflowEngine/form/useFormField';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {detectorListApiOptions} from 'sentry/views/detectors/hooks';
 
+const MAX_DETECTORS_PER_REQUEST = 100;
+
 export function useConnectedDetectors() {
   const detectorIds = useFormField<string[]>('detectorIds') ?? [];
   const organization = useOrganization();
+  const detectorIdChunks = chunk(detectorIds, MAX_DETECTORS_PER_REQUEST);
 
-  const {data: connectedDetectors = [], isLoading} = useQuery({
-    ...detectorListApiOptions(organization, {
-      ids: detectorIds,
-      includeIssueStreamDetectors: true,
-    }),
-    enabled: detectorIds.length > 0,
+  const detectorQueries = useQueries({
+    queries: detectorIdChunks.map(ids =>
+      detectorListApiOptions(organization, {
+        ids,
+        includeIssueStreamDetectors: true,
+      })
+    ),
   });
+
+  const connectedDetectors = detectorQueries.flatMap(query => query.data ?? []);
+  const isLoading = detectorQueries.some(query => query.isLoading);
 
   return {connectedDetectors, isLoading};
 }

--- a/static/app/views/automations/utils/fetchIssueStreamDetectorIds.ts
+++ b/static/app/views/automations/utils/fetchIssueStreamDetectorIds.ts
@@ -1,9 +1,12 @@
 import type {QueryClient} from '@tanstack/react-query';
+import chunk from 'lodash/chunk';
 
 import type {Organization} from 'sentry/types/organization';
 import {defined} from 'sentry/utils/defined';
 import {ALL_PROJECTS_DETECTOR_NAME} from 'sentry/views/automations/constants';
 import {detectorListApiOptions} from 'sentry/views/detectors/hooks';
+
+const MAX_PROJECTS_PER_REQUEST = 100;
 
 export async function fetchIssueStreamDetectorIdsForProjects({
   queryClient,
@@ -18,13 +21,19 @@ export async function fetchIssueStreamDetectorIdsForProjects({
     return [];
   }
 
-  const {json: detectors} = await queryClient.fetchQuery(
-    detectorListApiOptions(organization, {
-      query: 'type:issue_stream',
-      includeIssueStreamDetectors: true,
-      projects: projectIds.map(Number),
-    })
+  const detectorPages = await Promise.all(
+    chunk(projectIds, MAX_PROJECTS_PER_REQUEST).map(projectIdChunk =>
+      queryClient.fetchQuery(
+        detectorListApiOptions(organization, {
+          query: 'type:issue_stream',
+          includeIssueStreamDetectors: true,
+          limit: MAX_PROJECTS_PER_REQUEST,
+          projects: projectIdChunk.map(Number),
+        })
+      )
+    )
   );
+  const detectors = detectorPages.flatMap(page => page.json);
 
   return projectIds
     .map(projectId => detectors.find(detector => detector.projectId === projectId)?.id)

--- a/static/app/views/automations/utils/fetchIssueStreamDetectorIdsForProjects.spec.ts
+++ b/static/app/views/automations/utils/fetchIssueStreamDetectorIdsForProjects.spec.ts
@@ -1,0 +1,57 @@
+import {IssueStreamDetectorFixture} from 'sentry-fixture/detectors';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {makeTestQueryClient} from 'sentry-test/queryClient';
+
+import {fetchIssueStreamDetectorIdsForProjects} from './fetchIssueStreamDetectorIdsForProjects';
+
+describe('fetchIssueStreamDetectorIdsForProjects', () => {
+  const organization = OrganizationFixture();
+  const endpoint = `/organizations/${organization.slug}/detectors/`;
+  const queryClient = makeTestQueryClient();
+
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+    queryClient.clear();
+  });
+
+  it('fetches every selected project when more than 100 are selected', async () => {
+    const projectIds = Array.from({length: 101}, (_, index) => String(index + 1));
+    const detectors = projectIds.map(projectId =>
+      IssueStreamDetectorFixture({id: projectId, projectId})
+    );
+
+    const firstRequest = MockApiClient.addMockResponse({
+      url: endpoint,
+      method: 'GET',
+      body: detectors.slice(0, 100),
+      match: [
+        MockApiClient.matchQuery({
+          project: projectIds.slice(0, 100).map(Number),
+          query: 'type:issue_stream',
+        }),
+      ],
+    });
+    const secondRequest = MockApiClient.addMockResponse({
+      url: endpoint,
+      method: 'GET',
+      body: detectors.slice(100),
+      match: [
+        MockApiClient.matchQuery({
+          project: projectIds.slice(100).map(Number),
+          query: 'type:issue_stream',
+        }),
+      ],
+    });
+
+    const detectorIds = await fetchIssueStreamDetectorIdsForProjects({
+      organization,
+      projectIds,
+      queryClient,
+    });
+
+    expect(detectorIds).toEqual(detectors.map(detector => detector.id));
+    expect(firstRequest).toHaveBeenCalledTimes(1);
+    expect(secondRequest).toHaveBeenCalledTimes(1);
+  });
+});

--- a/static/app/views/automations/utils/fetchIssueStreamDetectorIdsForProjects.ts
+++ b/static/app/views/automations/utils/fetchIssueStreamDetectorIdsForProjects.ts
@@ -1,8 +1,11 @@
 import type {QueryClient} from '@tanstack/react-query';
+import chunk from 'lodash/chunk';
 
 import type {Organization} from 'sentry/types/organization';
 import {defined} from 'sentry/utils/defined';
 import {detectorListApiOptions} from 'sentry/views/detectors/hooks';
+
+const MAX_PROJECTS_PER_REQUEST = 100;
 
 export async function fetchIssueStreamDetectorIdsForProjects({
   queryClient,
@@ -17,13 +20,19 @@ export async function fetchIssueStreamDetectorIdsForProjects({
     return [];
   }
 
-  const {json: detectors} = await queryClient.fetchQuery(
-    detectorListApiOptions(organization, {
-      query: 'type:issue_stream',
-      includeIssueStreamDetectors: true,
-      projects: projectIds.map(Number),
-    })
+  const detectorPages = await Promise.all(
+    chunk(projectIds, MAX_PROJECTS_PER_REQUEST).map(projectIdChunk =>
+      queryClient.fetchQuery(
+        detectorListApiOptions(organization, {
+          query: 'type:issue_stream',
+          includeIssueStreamDetectors: true,
+          limit: MAX_PROJECTS_PER_REQUEST,
+          projects: projectIdChunk.map(Number),
+        })
+      )
+    )
   );
+  const detectors = detectorPages.flatMap(page => page.json);
 
   return projectIds
     .map(projectId => detectors.find(detector => detector.projectId === projectId)?.id)


### PR DESCRIPTION
## Problem

Editing an alert connected to more than 100 issue-stream monitors only loaded the first page of connected detectors. The project selector derived its selection from that partial response, so saving the form removed every connection after the first 100.

The same pagination limit could also affect creation or editing of project-scoped alerts with more than 100 selected projects, because resolving selected projects to issue-stream detector IDs used a single paginated request.

<img width="3456" height="1776" alt="image" src="https://github.com/user-attachments/assets/248d6eb2-481b-4cb0-a623-892db78eeadf" />

<img width="3456" height="1776" alt="image" src="https://github.com/user-attachments/assets/e835e1e3-b2cb-45a2-acce-77bb5b1e2505" />

<img width="3456" height="1776" alt="image" src="https://github.com/user-attachments/assets/47087a27-3028-4dc3-9e01-35d16e258e85" />

## Solution

- Fetch connected detectors in batches of 100 IDs when initializing the alert edit form.
- Resolve selected projects in batches of 100 when saving a project-scoped alert.
- Add regression coverage for 101 connected monitors and 101 selected projects.

## Verification

- Focused Jest regression suites: 9 tests passed.
- Targeted ESLint passed for all changed files.

AI-created PR: this pull request was created by Codex (OpenAI) with human direction.