### PR TITLE
fix(issues): stop inventing a date range in the issue count endpoint

### DIFF
--- a/src/sentry/issues/endpoints/organization_issues_count.py
+++ b/src/sentry/issues/endpoints/organization_issues_count.py
@@ -74,7 +74,7 @@ class OrganizationIssuesCountEndpoint(OrganizationEndpoint):
 
     def get(self, request: Request, organization: Organization | RpcOrganization) -> Response:
         stats_period = request.GET.get("groupStatsPeriod")
-        start, end = get_date_range_from_params(request.GET)
+        start, end = get_date_range_from_params(request.GET, optional=True)
 
         if stats_period not in (None, "", "24h", "14d", "auto"):
             return Response({"detail": ERR_INVALID_STATS_PERIOD}, status=400)

--- a/tests/sentry/issues/endpoints/test_organization_issues_count.py
+++ b/tests/sentry/issues/endpoints/test_organization_issues_count.py
@@ -1,5 +1,8 @@
+from unittest import mock
+
 from django.urls import reverse
 
+from sentry import search
 from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now
 from tests.sentry.issues.test_utils import SearchIssueTestMixin
@@ -31,3 +34,21 @@ class OrganizationIssuesCountTest(APITestCase, SnubaTestCase, SearchIssueTestMix
         response = self.client.get(self.url + "?query=flags[test:flag]:true")
         assert response.status_code == 200
         assert response.json() == {"flags[test:flag]:true": 1}
+
+    def test_dateless_query_searches_without_a_date_range(self) -> None:
+        self.store_event(
+            data={"timestamp": before_now(seconds=1).isoformat()},
+            project_id=self.project.id,
+        )
+
+        with mock.patch(
+            "sentry.issues.endpoints.organization_issues_count.search.backend.query",
+            wraps=search.backend.query,
+        ) as mock_query:
+            response = self.get_success_response(
+                self.organization.slug, qs_params={"query": "is:unresolved"}
+            )
+
+        assert response.data == {"is:unresolved": 1}
+        assert mock_query.call_args.kwargs["date_from"] is None
+        assert mock_query.call_args.kwargs["date_to"] is None


### PR DESCRIPTION
For the `issue-count` endpoint, we don't typically send a date range when using it. However, `get_date_range_from_params` by default adds a date range. This becomes a problem since we always hit snuba when there is a date range in search, even when the rest of the query can be served by only postgres. Add `optional=True` so we won't pass a date range if the caller doesn't.