### PR TITLE
fix: only hide issueList actions on narrow viewPorts, not containers

### DIFF
--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -1036,7 +1036,6 @@ const GroupSummary = styled('div')<{canSelect: boolean}>`
 const GroupCheckBoxWrapper = styled('div')`
   align-self: flex-start;
   width: 32px;
-  flex-shrink: 0;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -1036,6 +1036,7 @@ const GroupSummary = styled('div')<{canSelect: boolean}>`
 const GroupCheckBoxWrapper = styled('div')`
   align-self: flex-start;
   width: 32px;
+  flex-shrink: 0;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/static/app/views/issueList/actions/index.tsx
+++ b/static/app/views/issueList/actions/index.tsx
@@ -6,7 +6,7 @@ import {AnimatePresence, motion, type MotionNodeAnimationOptions} from 'framer-m
 
 import {Alert} from '@sentry/scraps/alert';
 import {Checkbox} from '@sentry/scraps/checkbox';
-import {Flex, Grid, useHasContainerQuery} from '@sentry/scraps/layout';
+import {Flex, Grid} from '@sentry/scraps/layout';
 
 import {bulkDelete, mergeGroups} from 'sentry/actionCreators/group';
 import {useAnalyticsArea} from 'sentry/components/analyticsArea';
@@ -29,7 +29,6 @@ import {
   useIssueSelectionSummary,
 } from 'sentry/views/issueList/issueSelectionContext';
 import type {IssueUpdateData} from 'sentry/views/issueList/types';
-import {useIsIssueListContainerNarrow} from 'sentry/views/issueList/utils';
 import {SAVED_SEARCHES_SIDEBAR_OPEN_LOCALSTORAGE_KEY} from 'sentry/views/issueList/utils';
 
 import {ActionSet} from './actionSet';
@@ -65,6 +64,7 @@ const animationProps: MotionNodeAnimationOptions = {
 
 function ActionsBarPriority({
   anySelected,
+  narrowViewport,
   displayReprocessingActions,
   pageSelected,
   queryCount,
@@ -80,7 +80,6 @@ function ActionsBarPriority({
   onSelectStatsPeriod,
   statsPeriod,
   selection,
-  isSavedSearchesOpen,
   withColumns,
 }: {
   allInQuerySelected: boolean;
@@ -89,8 +88,8 @@ function ActionsBarPriority({
   handleDelete: () => void;
   handleMerge: () => void;
   handleUpdate: (data: IssueUpdateData) => void;
-  isSavedSearchesOpen: boolean;
   multiSelected: boolean;
+  narrowViewport: boolean;
   onSelectStatsPeriod: (period: string) => void;
   pageSelected: boolean;
   query: string;
@@ -102,15 +101,6 @@ function ActionsBarPriority({
   toggleSelectAllVisible: () => void;
   withColumns?: GroupListColumn[];
 }) {
-  const theme = useTheme();
-  const hasContainerQuery = useHasContainerQuery();
-  const disableActionsInContainer = useIsIssueListContainerNarrow(isSavedSearchesOpen);
-  const disableActionsInViewport = useMedia(
-    `(width < ${isSavedSearchesOpen ? theme.container['5xl'] : theme.container['3xl']})`
-  );
-  const narrowViewport = hasContainerQuery
-    ? disableActionsInContainer
-    : disableActionsInViewport;
   const shouldDisplayActions = anySelected && !narrowViewport;
 
   return (
@@ -203,6 +193,10 @@ export function IssueListActions({
   const [isSavedSearchesOpen] = useSyncedLocalStorageState(
     SAVED_SEARCHES_SIDEBAR_OPEN_LOCALSTORAGE_KEY,
     false
+  );
+  const theme = useTheme();
+  const disableActions = useMedia(
+    `(width < ${isSavedSearchesOpen ? theme.breakpoints.xl : theme.breakpoints.md})`
   );
   const area = useAnalyticsArea();
   const numIssues = selectedIdsSet.size;
@@ -306,7 +300,7 @@ export function IssueListActions({
         handleUpdate={handleUpdate}
         toggleSelectAllVisible={toggleSelectAllVisible}
         multiSelected={multiSelected}
-        isSavedSearchesOpen={isSavedSearchesOpen}
+        narrowViewport={disableActions}
         selectedProjectSlug={selectedProjectSlug}
         anySelected={anySelected}
         onSelectStatsPeriod={onSelectStatsPeriod}

--- a/static/app/views/issueList/groupListBody.tsx
+++ b/static/app/views/issueList/groupListBody.tsx
@@ -1,8 +1,6 @@
 import {useMemo} from 'react';
 import {useTheme} from '@emotion/react';
 
-import {useHasContainerQuery} from '@sentry/scraps/layout';
-
 import type {GroupListColumn} from 'sentry/components/issues/groupList';
 import {LoadingError} from 'sentry/components/loadingError';
 import {PanelBody} from 'sentry/components/panels/panelBody';
@@ -20,10 +18,7 @@ import type {SupergroupLookup} from 'sentry/views/issueList/supergroups/useSuper
 import type {IssueUpdateData} from 'sentry/views/issueList/types';
 
 import {NoGroupsHandler} from './noGroupsHandler';
-import {
-  SAVED_SEARCHES_SIDEBAR_OPEN_LOCALSTORAGE_KEY,
-  useIsIssueListContainerNarrow,
-} from './utils';
+import {SAVED_SEARCHES_SIDEBAR_OPEN_LOCALSTORAGE_KEY} from './utils';
 
 type GroupListBodyProps = {
   displayReprocessingLayout: boolean;
@@ -194,13 +189,9 @@ function GroupList({
     false
   );
   const topIssue = groupIds[0];
-  const selectDisabledInContainer = useIsIssueListContainerNarrow(isSavedSearchesOpen);
-  const selectDisabledInViewport = useMedia(
-    `(width < ${isSavedSearchesOpen ? theme.container['5xl'] : theme.container['3xl']})`
+  const selectDisabled = useMedia(
+    `(width < ${isSavedSearchesOpen ? theme.breakpoints.xl : theme.breakpoints.md})`
   );
-  const selectDisabled = useHasContainerQuery()
-    ? selectDisabledInContainer
-    : selectDisabledInViewport;
 
   const showProgress = withColumns.includes('progress');
 

--- a/static/app/views/issueList/utils.tsx
+++ b/static/app/views/issueList/utils.tsx
@@ -1,7 +1,5 @@
 import type {Location, LocationDescriptorObject} from 'history';
 
-import {useContainerBreakpoint} from '@sentry/scraps/layout';
-
 import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
@@ -94,16 +92,6 @@ export const FOR_REVIEW_QUERIES: string[] = [Query.FOR_REVIEW];
 
 export const SAVED_SEARCHES_SIDEBAR_OPEN_LOCALSTORAGE_KEY =
   'issue-stream-saved-searches-sidebar-open';
-
-export function useIsIssueListContainerNarrow(isSavedSearchesOpen: boolean) {
-  const breakpoint = useContainerBreakpoint();
-
-  if (isSavedSearchesOpen) {
-    return breakpoint !== '5xl';
-  }
-
-  return breakpoint !== '3xl' && breakpoint !== '4xl' && breakpoint !== '5xl';
-}
 
 const ISSUE_STREAM_SORT_LOCALSTORAGE_KEY = 'issue-stream-sort';
 


### PR DESCRIPTION
this fixes a regression from
- #120321

where we switched everything to container queries, but it seems the fact that we want to hide the issue action column should still be dependent on media queries (browser size).

tbh I don’t know why we even hide this column at all but 🤷 