### PR TITLE
perf(issues): Batch external issue serialization

### DIFF
--- a/src/sentry/api/serializers/models/group_stream.py
+++ b/src/sentry/api/serializers/models/group_stream.py
@@ -436,7 +436,8 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
         if self._expand("integrationIssues"):
             group_ids_by_external_issue_id: dict[int, list[int]] = defaultdict(list)
             for group_id, linked_id in GroupLink.objects.filter(
-                group_id__in=[item.id for item in item_list]
+                group_id__in=[item.id for item in item_list],
+                linked_type=GroupLink.LinkedType.issue,
             ).values_list("group_id", "linked_id"):
                 group_ids_by_external_issue_id[linked_id].append(group_id)
 

--- a/src/sentry/api/serializers/models/group_stream.py
+++ b/src/sentry/api/serializers/models/group_stream.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import functools
 from abc import abstractmethod
+from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta
 from typing import Any, NamedTuple, NotRequired, Protocol, TypedDict
@@ -40,6 +41,7 @@ from sentry.models.groupowner import OwnersSerialized, get_owner_details
 from sentry.notifications.helpers import SubscriptionDetails
 from sentry.sentry_apps.api.serializers.platform_external_issue import (
     PlatformExternalIssueSerializer,
+    PlatformExternalIssueSerializerResponse,
 )
 from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
 from sentry.snuba.dataset import Dataset
@@ -432,24 +434,47 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
                 attrs[item]["owners"] = owner_details.get(item.id)
 
         if self._expand("integrationIssues"):
+            group_ids_by_external_issue_id: dict[int, list[int]] = defaultdict(list)
+            for group_id, linked_id in GroupLink.objects.filter(
+                group_id__in=[item.id for item in item_list]
+            ).values_list("group_id", "linked_id"):
+                group_ids_by_external_issue_id[linked_id].append(group_id)
+
+            external_issues = list(
+                ExternalIssue.objects.filter(id__in=group_ids_by_external_issue_id)
+            )
+            serialized_external_issues = serialize(
+                external_issues, serializer=ExternalIssueSerializer()
+            )
+            integration_issues_by_group_id: dict[int, list[dict[str, Any]]] = defaultdict(list)
+            for external_issue, serialized_external_issue in zip(
+                external_issues, serialized_external_issues
+            ):
+                for group_id in group_ids_by_external_issue_id[external_issue.id]:
+                    integration_issues_by_group_id[group_id].append(serialized_external_issue)
+
             for item in item_list:
-                external_issues = ExternalIssue.objects.filter(
-                    id__in=GroupLink.objects.filter(group_id__in=[item.id]).values_list(
-                        "linked_id", flat=True
-                    ),
-                )
-                integration_issues = serialize(
-                    list(external_issues), serializer=ExternalIssueSerializer()
-                )
-                attrs[item]["integrationIssues"] = integration_issues
+                attrs[item]["integrationIssues"] = integration_issues_by_group_id[item.id]
 
         if self._expand("sentryAppIssues"):
-            for item in item_list:
-                platform_external_issues = PlatformExternalIssue.objects.filter(group_id=item.id)
-                sentry_app_issues = serialize(
-                    list(platform_external_issues), serializer=PlatformExternalIssueSerializer()
+            platform_external_issues = list(
+                PlatformExternalIssue.objects.filter(group_id__in=[item.id for item in item_list])
+            )
+            serialized_sentry_app_issues = serialize(
+                platform_external_issues, serializer=PlatformExternalIssueSerializer()
+            )
+            sentry_app_issues_by_group_id: dict[
+                int, list[PlatformExternalIssueSerializerResponse]
+            ] = defaultdict(list)
+            for platform_external_issue, serialized_sentry_app_issue in zip(
+                platform_external_issues, serialized_sentry_app_issues
+            ):
+                sentry_app_issues_by_group_id[platform_external_issue.group_id].append(
+                    serialized_sentry_app_issue
                 )
-                attrs[item]["sentryAppIssues"] = sentry_app_issues
+
+            for item in item_list:
+                attrs[item]["sentryAppIssues"] = sentry_app_issues_by_group_id[item.id]
 
         if (
             self._expand("latestEventHasAttachments")

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -2111,8 +2111,6 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
             )
             for index, event in enumerate(events[:2])
         ]
-        self.create_group_link(group=events[0].group, linked_id=issues[0].id)
-        self.create_group_link(group=events[2].group, linked_id=issues[0].id)
         self.login_as(user=self.user)
 
         with CaptureQueriesContext(connection) as queries:
@@ -2126,12 +2124,62 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
 
         assert response.status_code == 200
         issues_by_group = {int(group["id"]): group["integrationIssues"] for group in response.data}
-        assert len(issues_by_group[events[0].group.id]) == 1
         assert issues_by_group[events[0].group.id][0]["title"] == issues[0].title
         assert issues_by_group[events[1].group.id][0]["title"] == issues[1].title
         assert issues_by_group[events[2].group.id] == []
         assert len([query for query in queries if "sentry_grouplink" in query["sql"]]) == 1
         assert len([query for query in queries if "sentry_externalissue" in query["sql"]]) == 1
+
+    def test_expand_integration_issues_ignores_non_issue_group_links(self) -> None:
+        events = [
+            self.store_event(
+                data={
+                    "timestamp": before_now(seconds=500 - index).isoformat(),
+                    "fingerprint": [f"group-{index}"],
+                },
+                project_id=self.project.id,
+            )
+            for index in range(2)
+        ]
+        integration = self.create_integration(
+            organization=events[0].group.organization,
+            provider="jira",
+            external_id="jira_external_id",
+            name="Jira",
+            metadata={"base_url": "https://example.com", "domain_name": "test/"},
+        )
+        issue = self.create_integration_external_issue(
+            group=events[0].group,
+            integration=integration,
+            key="APP-1",
+            title="jira issue",
+            description="this is an example description",
+        )
+        self.create_group_link(
+            group=events[0].group,
+            linked_id=issue.id,
+            linked_type=GroupLink.LinkedType.commit,
+        )
+        self.create_group_link(
+            group=events[1].group,
+            linked_id=issue.id,
+            linked_type=GroupLink.LinkedType.commit,
+        )
+        self.login_as(user=self.user)
+
+        response = self.get_response(
+            sort_by="date",
+            limit=10,
+            query="status:unresolved",
+            collapse=["base"],
+            expand=["integrationIssues"],
+        )
+
+        assert response.status_code == 200
+        issues_by_group = {int(group["id"]): group["integrationIssues"] for group in response.data}
+        assert len(issues_by_group[events[0].group.id]) == 1
+        assert issues_by_group[events[0].group.id][0]["title"] == issue.title
+        assert issues_by_group[events[1].group.id] == []
 
     def test_expand_sentry_app_issues(self) -> None:
         event = self.store_event(

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -2083,7 +2083,9 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         assert response.data[0]["integrationIssues"][0]["title"] == external_issue_1.title
         assert response.data[0]["integrationIssues"][1]["title"] == external_issue_2.title
 
-    def test_expand_integration_issues_is_batched(self) -> None:
+    def test_expand_integration_issues_resolves_group_links_in_two_batched_queries(
+        self,
+    ) -> None:
         events = [
             self.store_event(
                 data={
@@ -2130,7 +2132,7 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         assert len([query for query in queries if "sentry_grouplink" in query["sql"]]) == 1
         assert len([query for query in queries if "sentry_externalissue" in query["sql"]]) == 1
 
-    def test_expand_integration_issues_ignores_non_issue_group_links(self) -> None:
+    def test_expand_integration_issues_only_associates_issue_type_group_links(self) -> None:
         events = [
             self.store_event(
                 data={
@@ -2235,7 +2237,7 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         assert response.data[0]["sentryAppIssues"][0]["displayName"] == issue_1.display_name
         assert response.data[0]["sentryAppIssues"][1]["displayName"] == issue_2.display_name
 
-    def test_expand_sentry_app_issues_is_batched(self) -> None:
+    def test_expand_sentry_app_issues_loads_direct_group_relations_in_one_query(self) -> None:
         events = [
             self.store_event(
                 data={

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -2111,6 +2111,8 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
             )
             for index, event in enumerate(events[:2])
         ]
+        self.create_group_link(group=events[0].group, linked_id=issues[0].id)
+        self.create_group_link(group=events[2].group, linked_id=issues[0].id)
         self.login_as(user=self.user)
 
         with CaptureQueriesContext(connection) as queries:
@@ -2124,6 +2126,7 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
 
         assert response.status_code == 200
         issues_by_group = {int(group["id"]): group["integrationIssues"] for group in response.data}
+        assert len(issues_by_group[events[0].group.id]) == 1
         assert issues_by_group[events[0].group.id][0]["title"] == issues[0].title
         assert issues_by_group[events[1].group.id][0]["title"] == issues[1].title
         assert issues_by_group[events[2].group.id] == []

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -2083,6 +2083,53 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         assert response.data[0]["integrationIssues"][0]["title"] == external_issue_1.title
         assert response.data[0]["integrationIssues"][1]["title"] == external_issue_2.title
 
+    def test_expand_integration_issues_is_batched(self) -> None:
+        events = [
+            self.store_event(
+                data={
+                    "timestamp": before_now(seconds=500 - index).isoformat(),
+                    "fingerprint": [f"group-{index}"],
+                },
+                project_id=self.project.id,
+            )
+            for index in range(3)
+        ]
+        integration = self.create_integration(
+            organization=events[0].group.organization,
+            provider="jira",
+            external_id="jira_external_id",
+            name="Jira",
+            metadata={"base_url": "https://example.com", "domain_name": "test/"},
+        )
+        issues = [
+            self.create_integration_external_issue(
+                group=event.group,
+                integration=integration,
+                key=f"APP-{index}",
+                title=f"jira issue {index}",
+                description="this is an example description",
+            )
+            for index, event in enumerate(events[:2])
+        ]
+        self.login_as(user=self.user)
+
+        with CaptureQueriesContext(connection) as queries:
+            response = self.get_response(
+                sort_by="date",
+                limit=10,
+                query="status:unresolved",
+                collapse=["base"],
+                expand=["integrationIssues"],
+            )
+
+        assert response.status_code == 200
+        issues_by_group = {int(group["id"]): group["integrationIssues"] for group in response.data}
+        assert issues_by_group[events[0].group.id][0]["title"] == issues[0].title
+        assert issues_by_group[events[1].group.id][0]["title"] == issues[1].title
+        assert issues_by_group[events[2].group.id] == []
+        assert len([query for query in queries if "sentry_grouplink" in query["sql"]]) == 1
+        assert len([query for query in queries if "sentry_externalissue" in query["sql"]]) == 1
+
     def test_expand_sentry_app_issues(self) -> None:
         event = self.store_event(
             data={"timestamp": before_now(seconds=500).isoformat(), "fingerprint": ["group-1"]},
@@ -2136,6 +2183,48 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         assert response.data[0]["sentryAppIssues"][1]["issueId"] == str(issue_2.group_id)
         assert response.data[0]["sentryAppIssues"][0]["displayName"] == issue_1.display_name
         assert response.data[0]["sentryAppIssues"][1]["displayName"] == issue_2.display_name
+
+    def test_expand_sentry_app_issues_is_batched(self) -> None:
+        events = [
+            self.store_event(
+                data={
+                    "timestamp": before_now(seconds=500 - index).isoformat(),
+                    "fingerprint": [f"group-{index}"],
+                },
+                project_id=self.project.id,
+            )
+            for index in range(3)
+        ]
+        issues = [
+            PlatformExternalIssue.objects.create(
+                group_id=event.group.id,
+                project_id=event.group.project.id,
+                service_type=f"sentry-app-{index}",
+                display_name=f"App#issue-{index}",
+                web_url=f"https://example.com/app/issues/{index}",
+            )
+            for index, event in enumerate(events[:2])
+        ]
+        self.login_as(user=self.user)
+
+        with CaptureQueriesContext(connection) as queries:
+            response = self.get_response(
+                sort_by="date",
+                limit=10,
+                query="status:unresolved",
+                collapse=["base"],
+                expand=["sentryAppIssues"],
+            )
+
+        assert response.status_code == 200
+        issues_by_group = {int(group["id"]): group["sentryAppIssues"] for group in response.data}
+        assert issues_by_group[events[0].group.id][0]["displayName"] == issues[0].display_name
+        assert issues_by_group[events[1].group.id][0]["displayName"] == issues[1].display_name
+        assert issues_by_group[events[2].group.id] == []
+        platform_issue_queries = [
+            query for query in queries if "sentry_platformexternalissue" in query["sql"]
+        ]
+        assert len(platform_issue_queries) == 1
 
     @with_feature(
         {


### PR DESCRIPTION
The issue-list serializer now loads linked integration issues and Sentry App issues in a fixed number of database queries instead of querying once per group. It fetches links and external issues in bulk, serializes each collection once, and groups the responses in memory while preserving empty lists for groups without links.

This PR is stacked on #120834 and addresses the remaining relational N+1 queries triggered by the Feedback list expansions.