### PR TITLE
fix(tracemetrics): Restore cell actions to aggregates table

### DIFF
--- a/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.spec.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.spec.tsx
@@ -5,13 +5,14 @@ import {
   initializeTraceMetricsTest,
 } from 'sentry-fixture/tracemetrics';
 
-import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {AggregatesTab} from 'sentry/views/explore/metrics/metricInfoTabs/aggregatesTab';
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 import {MetricsQueryParamsProvider} from 'sentry/views/explore/metrics/metricsQueryParams';
 import {MultiMetricsQueryParamsProvider} from 'sentry/views/explore/metrics/multiMetricsQueryParams';
+import {TraceMetricKnownFieldKey} from 'sentry/views/explore/metrics/types';
 import type {GroupBy} from 'sentry/views/explore/queryParams/groupBy';
 import {Mode} from 'sentry/views/explore/queryParams/mode';
 import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
@@ -248,5 +249,70 @@ describe('AggregatesTab', () => {
     await waitFor(() => {
       expect(screen.getByTestId('error-indicator')).toBeInTheDocument();
     });
+  });
+
+  it('restricts actions on metric name', async () => {
+    const traceMetric: TraceMetric = {
+      name: 'foo',
+      type: 'distribution',
+      unit: 'millisecond',
+    };
+    const visualize = new VisualizeFunction('avg(value,foo,distribution,millisecond)');
+
+    const queryParams = new ReadableQueryParams({
+      extrapolate: true,
+      mode: Mode.AGGREGATE,
+      query: '',
+      cursor: '',
+      fields: ['metric.name', 'environment'],
+      sortBys: [{field: 'metric.name', kind: 'desc'}],
+      aggregateCursor: '',
+      aggregateFields: [{groupBy: 'metric.name'}, {groupBy: 'environment'}, visualize],
+      aggregateSortBys: [
+        {field: 'avg(value,foo,distribution,millisecond)', kind: 'desc'},
+      ],
+    });
+
+    const metricFixtures = createTraceMetricFixtures(organization, project, new Date(), {
+      baseFields: ['metric.name'],
+    });
+    setupEventsMock(
+      metricFixtures.baseFixtures
+        .filter(f => f[TraceMetricKnownFieldKey.METRIC_NAME] === 'foo')
+        .map(f => ({
+          ...f,
+          [TraceMetricKnownFieldKey.METRIC_NAME]: 'foo',
+          environment: 'production',
+        })),
+      [
+        MockApiClient.matchQuery({
+          dataset: 'tracemetrics',
+          referrer: 'api.explore.metric-aggregates-table',
+        }),
+      ]
+    );
+
+    render(<AggregatesTab traceMetric={traceMetric} />, {
+      organization,
+      additionalWrapper: createWrapper({queryParams, traceMetric}),
+    });
+
+    expect(await screen.findByRole('cell', {name: 'foo'})).toBeInTheDocument();
+
+    const fooCellButton = screen.getAllByRole('button')[0]!;
+    expect(fooCellButton).toHaveTextContent('foo');
+    await userEvent.click(fooCellButton);
+
+    expect(await screen.findAllByRole('menuitemradio')).toHaveLength(1);
+    expect(screen.getByText('Copy to clipboard')).toBeInTheDocument();
+
+    const envCellButton = screen.getAllByRole('button')[1]!;
+    expect(envCellButton).toHaveTextContent('production');
+    await userEvent.click(envCellButton);
+
+    expect(await screen.findAllByRole('menuitemradio')).toHaveLength(3);
+    expect(screen.getByText('Copy to clipboard')).toBeInTheDocument();
+    expect(screen.getByText('Add to filter')).toBeInTheDocument();
+    expect(screen.getByText('Exclude from filter')).toBeInTheDocument();
   });
 });

--- a/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
@@ -263,7 +263,11 @@ export function AggregatesTab({traceMetric, isMetricOptionsEmpty}: AggregatesTab
                       data={displayRow}
                       unit={getMetricsUnit(meta, field)}
                       meta={meta}
-                      allowActions={METRICS_AGGREGATES_CELL_ACTIONS}
+                      allowActions={
+                        field === TraceMetricKnownFieldKey.METRIC_NAME
+                          ? METRICS_AGGREGATES_CELL_ACTIONS
+                          : undefined
+                      }
                       usePortalOnDropdown
                     />
                   </AggregatesStyledRowCell>


### PR DESCRIPTION
Only restricts the access to "Copy" if it's the metric name. Since the metric panel makes all results the same metric name, adding or excluding filters doesn't make sense for that column

Before:
<img width="366" height="209" alt="Screenshot 2026-07-29 at 2 57 45 PM" src="https://github.com/user-attachments/assets/77c8954a-bfb8-4494-8fcd-fb9c5efedda7" />


After:
<img width="728" height="302" alt="Screenshot 2026-07-29 at 2 57 18 PM" src="https://github.com/user-attachments/assets/17cc0ea2-384e-40b4-9b46-6c0165e6489a" />
