### PR TITLE
PRODENG-1946 Reserve the self-healing slug

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -194,6 +194,7 @@ RESERVED_ORGANIZATION_SLUGS = frozenset(
         "sales",
         "security",
         "securityportal",
+        "self-healing",
         "sentry-apps",
         "services",
         "settings",


### PR DESCRIPTION
Add "self-healing" to RESERVED_ORGANIZATION_SLUGS so no customer org can claim the slug now routed to the marketing site.

Pairs with: https://github.com/getsentry/ops/pull/22433