### PR TITLE
fix(ourlogs): cancel the log row hover prefetch on unmount

### DIFF
--- a/static/app/views/explore/hooks/useTraceItemDetails.spec.tsx
+++ b/static/app/views/explore/hooks/useTraceItemDetails.spec.tsx
@@ -1,7 +1,14 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
-import {act, renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+import {
+  act,
+  render,
+  renderHookWithProviders,
+  screen,
+  userEvent,
+  waitFor,
+} from 'sentry-test/reactTestingLibrary';
 
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
@@ -12,9 +19,30 @@ import {
 } from 'sentry/views/explore/hooks/useTraceItemDetails';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 
+const HOVER_TIMEOUT = 150;
+
 describe('useTraceItemDetails', () => {
   const organization = OrganizationFixture();
   const project = ProjectFixture({id: '1', slug: 'project-slug'});
+
+  function HoverPrefetchTarget({
+    sharedHoverTimeoutRef,
+  }: {
+    sharedHoverTimeoutRef: React.MutableRefObject<NodeJS.Timeout | null>;
+  }) {
+    const {hoverProps} = usePrefetchTraceItemDetailsOnHover({
+      projectId: project.id,
+      traceItemId: 'item-id',
+      traceId: '1234567890abcdef1234567890abcdef',
+      traceItemType: TraceItemDataset.LOGS,
+      referrer: 'api.explore.log-item-details',
+      timestamp: 123,
+      sharedHoverTimeoutRef,
+      timeout: HOVER_TIMEOUT,
+    });
+
+    return <div {...hoverProps} data-test-id="hover-prefetch-target" />;
+  }
 
   function initializePageFilters(
     datetime: Parameters<typeof PageFiltersStore.onInitializeUrlState>[0]['datetime']
@@ -226,6 +254,61 @@ describe('useTraceItemDetails', () => {
     act(() => result.current.prefetch());
 
     await waitFor(() => expect(traceItemDetailsMock).toHaveBeenCalledTimes(1));
+  });
+
+  it('does not fetch details when the hovered element unmounts before the hover timeout elapses', async () => {
+    jest.useFakeTimers();
+    initializePageFilters({
+      period: '14d',
+      start: null,
+      end: null,
+      utc: false,
+    });
+    const traceItemDetailsMock = addTraceItemDetailsMock();
+    const sharedHoverTimeoutRef: React.MutableRefObject<NodeJS.Timeout | null> = {
+      current: null,
+    };
+
+    const {unmount} = render(
+      <HoverPrefetchTarget sharedHoverTimeoutRef={sharedHoverTimeoutRef} />,
+      {organization}
+    );
+
+    await userEvent.hover(screen.getByTestId('hover-prefetch-target'), {delay: null});
+    unmount();
+    act(() => {
+      jest.advanceTimersByTime(HOVER_TIMEOUT * 10);
+    });
+
+    expect(traceItemDetailsMock).not.toHaveBeenCalled();
+    expect(sharedHoverTimeoutRef.current).toBeNull();
+    jest.useRealTimers();
+  });
+
+  it('fetches details when the hovered element stays mounted past the hover timeout', async () => {
+    jest.useFakeTimers();
+    initializePageFilters({
+      period: '14d',
+      start: null,
+      end: null,
+      utc: false,
+    });
+    const traceItemDetailsMock = addTraceItemDetailsMock();
+
+    render(<HoverPrefetchTarget sharedHoverTimeoutRef={{current: null}} />, {
+      organization,
+    });
+
+    await waitFor(() => expect(ProjectsStore.getState().projects).toHaveLength(1));
+    await userEvent.hover(screen.getByTestId('hover-prefetch-target'), {delay: null});
+    act(() => {
+      jest.advanceTimersByTime(HOVER_TIMEOUT + 1);
+    });
+
+    await waitFor(() => expect(traceItemDetailsMock).toHaveBeenCalledTimes(1));
+    // Flush the .then() callback that reads cached data after prefetch
+    await act(async () => {});
+    jest.useRealTimers();
   });
 
   it('runs the prefetch on mount when enabled and the project is ready', () => {

--- a/static/app/views/explore/hooks/useTraceItemDetails.tsx
+++ b/static/app/views/explore/hooks/useTraceItemDetails.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useRef, useState} from 'react';
+import {useCallback, useEffect, useRef, useState} from 'react';
 import {useHover} from '@react-aria/interactions';
 import {captureException} from '@sentry/react';
 import {skipToken, useQuery, useQueryClient} from '@tanstack/react-query';
@@ -288,20 +288,41 @@ export function usePrefetchTraceItemDetailsOnHover({
       timestamp,
     });
 
+  const ownHoverTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const clearSharedHoverTimeout = useCallback(() => {
+    if (sharedHoverTimeoutRef.current) {
+      clearTimeout(sharedHoverTimeoutRef.current);
+      sharedHoverTimeoutRef.current = null;
+    }
+    ownHoverTimeoutRef.current = null;
+  }, [sharedHoverTimeoutRef]);
+
   const {hoverProps} = useHover({
     onHoverStart: () => {
-      if (sharedHoverTimeoutRef.current) {
-        clearTimeout(sharedHoverTimeoutRef.current);
-      }
-      sharedHoverTimeoutRef.current = setTimeout(prefetch, timeout);
+      clearSharedHoverTimeout();
+      const timeoutId = setTimeout(prefetch, timeout);
+      sharedHoverTimeoutRef.current = timeoutId;
+      ownHoverTimeoutRef.current = timeoutId;
     },
-    onHoverEnd: () => {
-      if (sharedHoverTimeoutRef.current) {
-        clearTimeout(sharedHoverTimeoutRef.current);
-      }
-    },
+    onHoverEnd: clearSharedHoverTimeout,
     isDisabled: hoverPrefetchDisabled,
   });
+
+  // Rows sharing the ref unmount independently (virtual scrolling), so an
+  // unmounting row must cancel only the prefetch it scheduled itself.
+  useEffect(
+    () => () => {
+      if (ownHoverTimeoutRef.current === null) {
+        return;
+      }
+      clearTimeout(ownHoverTimeoutRef.current);
+      if (sharedHoverTimeoutRef.current === ownHoverTimeoutRef.current) {
+        sharedHoverTimeoutRef.current = null;
+      }
+    },
+    [sharedHoverTimeoutRef]
+  );
 
   return {
     hoverProps,

--- a/static/app/views/explore/hooks/useTraceItemDetails.tsx
+++ b/static/app/views/explore/hooks/useTraceItemDetails.tsx
@@ -309,8 +309,6 @@ export function usePrefetchTraceItemDetailsOnHover({
     isDisabled: hoverPrefetchDisabled,
   });
 
-  // Rows sharing the ref unmount independently (virtual scrolling), so an
-  // unmounting row must cancel only the prefetch it scheduled itself.
   useEffect(
     () => () => {
       if (ownHoverTimeoutRef.current === null) {

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
@@ -799,19 +799,6 @@ describe('LogsInfiniteTable', () => {
         meta: {fields: {}, units: {}},
       },
     });
-    for (const log of mockLogsData) {
-      MockApiClient.addMockResponse({
-        url: `/projects/${organization.slug}/${project.slug}/trace-items/${log[OurLogKnownFieldKey.ID]}/`,
-        method: 'GET',
-        body: {
-          itemId: log[OurLogKnownFieldKey.ID],
-          links: null,
-          meta: {},
-          timestamp: log[OurLogKnownFieldKey.TIMESTAMP],
-          attributes: [],
-        },
-      });
-    }
 
     const traceError: TraceTree.TraceError = {
       event_id: 'abc123def456',
@@ -844,19 +831,6 @@ describe('LogsInfiniteTable', () => {
       method: 'GET',
       statusCode: 500,
     });
-    for (const log of mockLogsData) {
-      MockApiClient.addMockResponse({
-        url: `/projects/${organization.slug}/${project.slug}/trace-items/${log[OurLogKnownFieldKey.ID]}/`,
-        method: 'GET',
-        body: {
-          itemId: log[OurLogKnownFieldKey.ID],
-          links: null,
-          meta: {},
-          timestamp: log[OurLogKnownFieldKey.TIMESTAMP],
-          attributes: [],
-        },
-      });
-    }
 
     const traceError: TraceTree.TraceError = {
       event_id: 'abc123def456',


### PR DESCRIPTION
`usePrefetchTraceItemDetailsOnHover` scheduled a trace-item prefetch on hover start and cleared it only on hover end. Nothing cleared it on unmount, so a log row that unmounted while its timer was pending still issued `GET /trace-items/{id}/`. In the app that is a wasted fetch after the table is gone. 

Closes LOGS-936.
