### PR TITLE
fix(seer): Keep persisted sidebar width stable across resizes

### DIFF
--- a/static/app/utils/useResizableDrawer.tsx
+++ b/static/app/utils/useResizableDrawer.tsx
@@ -180,6 +180,15 @@ export function useResizableDrawer(options: UseResizableDrawerOptions): {
     document.removeEventListener('pointermove', onDragMove);
     document.removeEventListener('pointerup', onDragEnd);
     document.removeEventListener('pointercancel', onDragEnd);
+    // Flush any frame still pending from the last move synchronously. sizeRef
+    // already holds the dragged size; committing it here keeps the React state
+    // (and thus the rendered layout) in step before setIsHeld re-renders and
+    // its effect cleanup cancels the frame that would otherwise commit it.
+    if (rafIdRef.current !== null) {
+      window.cancelAnimationFrame(rafIdRef.current);
+      rafIdRef.current = null;
+      updateSize(sizeRef.current, true);
+    }
     setIsHeld(false);
     if (dragStartSizeRef.current !== null) {
       options.onResizeEnd?.({
@@ -188,7 +197,7 @@ export function useResizableDrawer(options: UseResizableDrawerOptions): {
       });
       dragStartSizeRef.current = null;
     }
-  }, [onDragMove, options]);
+  }, [onDragMove, options, updateSize]);
 
   const startDrag = useCallback((clientX: number, clientY: number) => {
     // Re-clamp to the current [min, max] before the drag begins: bounds can

--- a/static/app/utils/useResizableDrawer.tsx
+++ b/static/app/utils/useResizableDrawer.tsx
@@ -130,36 +130,40 @@ export function useResizableDrawer(options: UseResizableDrawerOptions): {
       // applied to the root most element to work
       document.documentElement.style.cursor = isXAxis ? 'ew-resize' : 'ns-resize';
 
+      if (!currentMouseVectorRaf.current) {
+        return;
+      }
+
+      const newPositionVector: [number, number] = [event.clientX, event.clientY];
+      const newAxisPosition = isXAxis ? newPositionVector[0] : newPositionVector[1];
+
+      const currentAxisPosition = isXAxis
+        ? currentMouseVectorRaf.current[0]
+        : currentMouseVectorRaf.current[1];
+
+      const positionDelta = currentAxisPosition - newAxisPosition;
+
+      currentMouseVectorRaf.current = newPositionVector;
+
+      // Round to 1px precision. Clamp to [min, max]. Update sizeRef
+      // synchronously so a drag-end that races the pending frame (fast
+      // drag + release) still reports the size the user dragged to via
+      // onResizeEnd, rather than a stale value.
+      sizeRef.current = Math.round(
+        clampSize(
+          sizeRef.current + positionDelta * (isInverted ? -1 : 1),
+          options.min,
+          options.max
+        )
+      );
+
+      // Throttle the state update / side effects to one per frame.
       if (rafIdRef.current !== null) {
         window.cancelAnimationFrame(rafIdRef.current);
       }
-
       rafIdRef.current = window.requestAnimationFrame(() => {
-        if (!currentMouseVectorRaf.current) {
-          return;
-        }
-
-        const newPositionVector: [number, number] = [event.clientX, event.clientY];
-        const newAxisPosition = isXAxis ? newPositionVector[0] : newPositionVector[1];
-
-        const currentAxisPosition = isXAxis
-          ? currentMouseVectorRaf.current[0]
-          : currentMouseVectorRaf.current[1];
-
-        const positionDelta = currentAxisPosition - newAxisPosition;
-
-        currentMouseVectorRaf.current = newPositionVector;
-
-        // Round to 1px precision. Clamp to [min, max].
-        const newSize = Math.round(
-          clampSize(
-            sizeRef.current + positionDelta * (isInverted ? -1 : 1),
-            options.min,
-            options.max
-          )
-        );
-
-        updateSize(newSize, true);
+        rafIdRef.current = null;
+        updateSize(sizeRef.current, true);
       });
     },
     [options.direction, options.min, options.max, updateSize]

--- a/static/app/utils/useResizableDrawer.tsx
+++ b/static/app/utils/useResizableDrawer.tsx
@@ -79,6 +79,7 @@ export function useResizableDrawer(options: UseResizableDrawerOptions): {
 } {
   const rafIdRef = useRef<number | null>(null);
   const currentMouseVectorRaf = useRef<[number, number] | null>(null);
+  const isDraggingRef = useRef(false);
   const [size, setSize] = useState<number>(() => {
     const storedSize = options.sizeStorageKey
       ? parseInt(localStorage.getItem(options.sizeStorageKey) ?? '', 10)
@@ -114,7 +115,13 @@ export function useResizableDrawer(options: UseResizableDrawerOptions): {
   }, [options.direction]);
 
   const sizeRef = useRef(size);
-  sizeRef.current = size;
+  // During a drag, sizeRef is the authoritative accumulator that onDragMove
+  // steps from and commits. A re-render triggered mid-drag by something else
+  // (e.g. a ResizeObserver measuring the resizing panes) must NOT roll it back
+  // to the last-committed React state, or the in-progress drag delta is lost.
+  if (!isDraggingRef.current) {
+    sizeRef.current = size;
+  }
 
   const onDragMove = useCallback(
     (event: MouseEvent | PointerEvent) => {
@@ -197,6 +204,9 @@ export function useResizableDrawer(options: UseResizableDrawerOptions): {
       });
       dragStartSizeRef.current = null;
     }
+    // Drag is over: allow re-renders to sync sizeRef from React state again.
+    // Cleared last so the onResizeEnd above still reads the dragged size.
+    isDraggingRef.current = false;
   }, [onDragMove, options, updateSize]);
 
   const startDrag = useCallback((clientX: number, clientY: number) => {
@@ -211,6 +221,7 @@ export function useResizableDrawer(options: UseResizableDrawerOptions): {
     sizeRef.current = clamped;
     setSize(clamped);
     setIsHeld(true);
+    isDraggingRef.current = true;
     dragStartSizeRef.current = clamped;
     currentMouseVectorRaf.current = [clientX, clientY];
   }, []);

--- a/static/app/utils/useResizableDrawer.tsx
+++ b/static/app/utils/useResizableDrawer.tsx
@@ -79,7 +79,6 @@ export function useResizableDrawer(options: UseResizableDrawerOptions): {
 } {
   const rafIdRef = useRef<number | null>(null);
   const currentMouseVectorRaf = useRef<[number, number] | null>(null);
-  const isDraggingRef = useRef(false);
   const [size, setSize] = useState<number>(() => {
     const storedSize = options.sizeStorageKey
       ? parseInt(localStorage.getItem(options.sizeStorageKey) ?? '', 10)
@@ -89,6 +88,11 @@ export function useResizableDrawer(options: UseResizableDrawerOptions): {
     // never enters as the size; bounds are enforced from the very first render.
     return clampSize(storedSize || options.initialSize, options.min, options.max);
   });
+  // Mirrors the latest committed size for the drag math and imperative reads.
+  // Kept in sync by every path that changes `size` (updateSize, startDrag, and
+  // the direction-change effect below) — never written during render, so a
+  // re-render that lands mid-drag can't roll back an in-progress drag delta.
+  const sizeRef = useRef(size);
   const [isHeld, setIsHeld] = useState(false);
   const optionsRef = useRef(options);
   useLayoutEffect(() => {
@@ -110,18 +114,10 @@ export function useResizableDrawer(options: UseResizableDrawerOptions): {
   useLayoutEffect(() => {
     const clamped = clampSize(options.initialSize ?? 0, options.min, options.max);
     options.onResize(clamped, size, false);
+    sizeRef.current = clamped;
     setSize(clamped);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [options.direction]);
-
-  const sizeRef = useRef(size);
-  // During a drag, sizeRef is the authoritative accumulator that onDragMove
-  // steps from and commits. A re-render triggered mid-drag by something else
-  // (e.g. a ResizeObserver measuring the resizing panes) must NOT roll it back
-  // to the last-committed React state, or the in-progress drag delta is lost.
-  if (!isDraggingRef.current) {
-    sizeRef.current = size;
-  }
 
   const onDragMove = useCallback(
     (event: MouseEvent | PointerEvent) => {
@@ -204,9 +200,6 @@ export function useResizableDrawer(options: UseResizableDrawerOptions): {
       });
       dragStartSizeRef.current = null;
     }
-    // Drag is over: allow re-renders to sync sizeRef from React state again.
-    // Cleared last so the onResizeEnd above still reads the dragged size.
-    isDraggingRef.current = false;
   }, [onDragMove, options, updateSize]);
 
   const startDrag = useCallback((clientX: number, clientY: number) => {
@@ -221,7 +214,6 @@ export function useResizableDrawer(options: UseResizableDrawerOptions): {
     sizeRef.current = clamped;
     setSize(clamped);
     setIsHeld(true);
-    isDraggingRef.current = true;
     dragStartSizeRef.current = clamped;
     currentMouseVectorRaf.current = [clientX, clientY];
   }, []);

--- a/static/app/views/seerExplorer/components/sidebar/seerExplorerSidebarLayout.spec.tsx
+++ b/static/app/views/seerExplorer/components/sidebar/seerExplorerSidebarLayout.spec.tsx
@@ -1,7 +1,7 @@
 import {Fragment} from 'react';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {GlobalDrawer} from '@sentry/scraps/drawer';
 import {PictureInPictureProvider} from '@sentry/scraps/pictureInPicture';
@@ -318,6 +318,52 @@ describe('SeerExplorerSidebarLayout', () => {
     expect(await screen.findByTestId('seer-explorer-input')).toBeInTheDocument();
 
     expect(localStorage.getItem('seer-explorer-sidebar-seer-size:bottom')).toBe('700');
+  });
+
+  it('keeps the persisted Seer width when the available width changes', async () => {
+    mockWideScreen(true);
+    const dims = jest
+      .spyOn(useDimensionsModule, 'useDimensions')
+      .mockReturnValue({width: 1200, height: 800});
+    localStorage.setItem('seer-explorer-sidebar-seer-size:right', '500');
+
+    const pendingFrames: FrameRequestCallback[] = [];
+    jest.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
+      pendingFrames.push(callback);
+      return pendingFrames.length;
+    });
+    jest.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+
+    const {rerender} = render(sidebarTree(), {organization: orgWithSidebar});
+    await userEvent.click(screen.getByText('open-seer'));
+    const input = await screen.findByTestId('seer-explorer-input');
+    await waitFor(() => expect(input).toHaveFocus());
+
+    const separator = screen.getByRole('separator');
+    // Available width 1200 - persisted Seer width 500 = content width 700.
+    expect(separator).toHaveAttribute('aria-valuenow', '700');
+
+    // Move the divider 10px left. Keep the animation frame pending so the test
+    // covers the same event ordering as a fast pointer drag followed by release.
+    await userEvent.pointer([
+      {keys: '[MouseLeft>]', target: separator, coords: {x: 700, y: 0}},
+      {target: separator, coords: {x: 690, y: 0}},
+    ]);
+    act(() => {
+      document.dispatchEvent(new MouseEvent('pointerup', {bubbles: true}));
+      pendingFrames.forEach(callback => callback(0));
+    });
+
+    expect(separator).toHaveAttribute('aria-valuenow', '690');
+    expect(localStorage.getItem('seer-explorer-sidebar-seer-size:right')).toBe('510');
+
+    // Simulate a secondary navigation/window resize. The content pane should
+    // change size while Seer remains at its persisted 510px width.
+    dims.mockReturnValue({width: 1000, height: 800});
+    rerender(sidebarTree());
+
+    expect(screen.getByRole('separator')).toHaveAttribute('aria-valuenow', '490');
+    expect(localStorage.getItem('seer-explorer-sidebar-seer-size:right')).toBe('510');
   });
 
   it('switches to the run when opened with a runId (deep link / session picker)', async () => {

--- a/static/app/views/seerExplorer/components/sidebar/seerExplorerSidebarLayout.spec.tsx
+++ b/static/app/views/seerExplorer/components/sidebar/seerExplorerSidebarLayout.spec.tsx
@@ -327,12 +327,20 @@ describe('SeerExplorerSidebarLayout', () => {
       .mockReturnValue({width: 1200, height: 800});
     localStorage.setItem('seer-explorer-sidebar-seer-size:right', '500');
 
-    const pendingFrames: FrameRequestCallback[] = [];
+    // Model real requestAnimationFrame semantics: cancelAnimationFrame must
+    // actually drop the pending callback. This matters because drag end
+    // re-renders (setIsHeld) and the hook's cleanup cancels the in-flight
+    // frame — so the committed size can't rely on a frame that runs later.
+    const pendingFrames = new Map<number, FrameRequestCallback>();
+    let nextFrameId = 0;
     jest.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
-      pendingFrames.push(callback);
-      return pendingFrames.length;
+      nextFrameId += 1;
+      pendingFrames.set(nextFrameId, callback);
+      return nextFrameId;
     });
-    jest.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+    jest.spyOn(window, 'cancelAnimationFrame').mockImplementation(id => {
+      pendingFrames.delete(id);
+    });
 
     const {rerender} = render(sidebarTree(), {organization: orgWithSidebar});
     await userEvent.click(screen.getByText('open-seer'));
@@ -343,15 +351,21 @@ describe('SeerExplorerSidebarLayout', () => {
     // Available width 1200 - persisted Seer width 500 = content width 700.
     expect(separator).toHaveAttribute('aria-valuenow', '700');
 
-    // Move the divider 10px left. Keep the animation frame pending so the test
-    // covers the same event ordering as a fast pointer drag followed by release.
+    // Move the divider 10px left, then release while the frame is still pending
+    // — the same event ordering as a fast pointer drag followed by release.
     await userEvent.pointer([
       {keys: '[MouseLeft>]', target: separator, coords: {x: 700, y: 0}},
       {target: separator, coords: {x: 690, y: 0}},
     ]);
     act(() => {
       document.dispatchEvent(new MouseEvent('pointerup', {bubbles: true}));
+    });
+    // Flush only frames that survived drag end. On a fast drag + release the
+    // pending frame is cancelled, so the committed size must already reflect
+    // the drag rather than wait for a frame that never runs.
+    act(() => {
       pendingFrames.forEach(callback => callback(0));
+      pendingFrames.clear();
     });
 
     expect(separator).toHaveAttribute('aria-valuenow', '690');

--- a/static/app/views/seerExplorer/components/sidebar/seerExplorerSidebarLayout.spec.tsx
+++ b/static/app/views/seerExplorer/components/sidebar/seerExplorerSidebarLayout.spec.tsx
@@ -380,6 +380,72 @@ describe('SeerExplorerSidebarLayout', () => {
     expect(localStorage.getItem('seer-explorer-sidebar-seer-size:right')).toBe('510');
   });
 
+  it('keeps a mid-drag resize from discarding the dragged Seer width', async () => {
+    // Reproduces the "jumps back to default" report: the app re-renders *during*
+    // a drag (its ResizeObserver measures the resizing panes via useDimensions)
+    // while an animation frame is still pending. sizeRef must stay the drag's
+    // authoritative accumulator across that render, or the delta is lost and
+    // nothing is persisted — so a later resize falls back to the default size.
+    mockWideScreen(true);
+    const dims = jest
+      .spyOn(useDimensionsModule, 'useDimensions')
+      .mockReturnValue({width: 1200, height: 800});
+
+    // Hold animation frames pending so the mid-drag re-render happens before the
+    // move is committed to React state — the crux of the race.
+    const pendingFrames: FrameRequestCallback[] = [];
+    jest.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
+      pendingFrames.push(callback);
+      return pendingFrames.length;
+    });
+    jest.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+    const flushFrames = () =>
+      act(() => {
+        pendingFrames.splice(0, pendingFrames.length).forEach(callback => callback(0));
+      });
+
+    const {rerender} = render(sidebarTree(), {organization: orgWithSidebar});
+    await userEvent.click(screen.getByText('open-seer'));
+    const input = await screen.findByTestId('seer-explorer-input');
+    await waitFor(() => expect(input).toHaveFocus());
+
+    const separator = screen.getByRole('separator');
+    // Available 1200 − default Seer 420 = content 780.
+    expect(separator).toHaveAttribute('aria-valuenow', '780');
+
+    // Drag the content pane left to 600 (Seer grows to 600). Raw pointer events
+    // because the drag disables body pointer-events, which blocks userEvent.
+    await userEvent.pointer([
+      {keys: '[MouseLeft>]', target: separator, coords: {x: 780, y: 0}},
+    ]);
+    act(() => {
+      document.dispatchEvent(
+        new MouseEvent('pointermove', {bubbles: true, clientX: 600, clientY: 0})
+      );
+    });
+
+    // A foreign re-render lands mid-drag, before the pending frame commits.
+    dims.mockReturnValue({width: 1200, height: 801});
+    rerender(sidebarTree());
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent('pointerup', {bubbles: true}));
+    });
+    flushFrames();
+
+    // The dragged size survives and is persisted.
+    expect(screen.getByRole('separator')).toHaveAttribute('aria-valuenow', '600');
+    expect(localStorage.getItem('seer-explorer-sidebar-seer-size:right')).toBe('600');
+
+    // A later window/nav resize keeps Seer at its persisted 600 (content flexes
+    // to 1000 − 600 − divider), rather than snapping back to the default.
+    dims.mockReturnValue({width: 1000, height: 800});
+    rerender(sidebarTree());
+
+    expect(screen.getByRole('separator')).toHaveAttribute('aria-valuenow', '480');
+    expect(localStorage.getItem('seer-explorer-sidebar-seer-size:right')).toBe('600');
+  });
+
   it('switches to the run when opened with a runId (deep link / session picker)', async () => {
     mockWideScreen(true);
     MockApiClient.addMockResponse({


### PR DESCRIPTION
The Seer persistent sidebar no longer jumps to a different width after you resize it and then resize the window or the secondary navigation. The persisted width now matches what you actually dragged to.

Root cause: `useResizableDrawer` computed the drag delta *inside* the `requestAnimationFrame` callback, so `sizeRef` lagged one frame behind the pointer. On a fast drag-then-release, `pointerup` fired while the last frame was still pending, and `onResizeEnd` persisted a stale size to `localStorage`. The rendered and persisted widths then disagreed, so the next window/nav resize recomputed the content pane from the stale persisted value (`available − seerSize`) and the Seer pane jumped.

The fix computes the size synchronously in `onDragMove` so `sizeRef` is always current, and uses the animation frame only to throttle the React state update. `onResizeEnd` now always reports the size the user dragged to, so persistence stays in sync with the display.

The regression test drives a fast drag with a pending animation frame at `pointerup`, then simulates a viewport change and asserts the persisted Seer width stays fixed while the content pane flexes.
