### PR TITLE
ref: Update feature flags to use flagpole

### DIFF
--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -29,16 +29,10 @@ def register_permanent_features(manager: FeatureManager) -> None:
     permanent_organization_features = {
         # Enable advanced search features, like negation and wildcard matching.
         "organizations:advanced-search": True,
-        # Denotes organizations on the AM3 billing tier
-        "organizations:am3-tier": False,
         # Enable discover 2 basic functions
         "organizations:discover-basic": True,
         # Enable discover 2 custom queries and saved queries
         "organizations:discover-query": True,
-        # Enable the new opinionated dynamic sampling
-        "organizations:dynamic-sampling": False,
-        # Enable attaching arbitrary files to events.
-        "organizations:event-attachments": True,
         # Enable incidents feature
         "organizations:incidents": False,
         # Enable integration functionality to work with alert rules
@@ -55,14 +49,6 @@ def register_permanent_features(manager: FeatureManager) -> None:
         "organizations:integrations-stacktrace-link": True,
         # Enable metric alert charts in email/slack
         "organizations:metric-alert-chartcuterie": False,
-        # Enable Performance view
-        "organizations:performance-view": True,
-        # Enable profiling view
-        "organizations:profiling-view": False,
-        # Enable core Session Replay backend APIs
-        "organizations:session-replay": False,
-        # Measure usage by spans instead of transactions
-        "organizations:spans-usage-tracking": False,
         # Enable SAML2 based SSO functionality. getsentry/sentry-auth-saml2 plugin
         # must be installed to use this functionality.
         "organizations:sso-saml2": True,
@@ -148,6 +134,20 @@ def register_permanent_features(manager: FeatureManager) -> None:
         # using services like GitHub / Google. This is *not* the same as the signup
         # and login with Github / Azure DevOps that sentry.io provides.
         "organizations:sso-basic": FlagpoleFeature(default=True, api_expose=True),
+        # Denotes organizations on the AM3 billing tier
+        "organizations:am3-tier": FlagpoleFeature(default=False, api_expose=True),
+        # Measure usage by spans instead of transactions
+        "organizations:spans-usage-tracking": FlagpoleFeature(default=False, api_expose=True),
+        # Enable the new opinionated dynamic sampling
+        "organizations:dynamic-sampling": FlagpoleFeature(default=False, api_expose=True),
+        # Enable attaching arbitrary files to events.
+        "organizations:event-attachments": FlagpoleFeature(default=True, api_expose=True),
+        # Enable Performance view
+        "organizations:performance-view": FlagpoleFeature(default=True, api_expose=True),
+        # Enable core Session Replay backend APIs
+        "organizations:session-replay": FlagpoleFeature(default=False, api_expose=True),
+        # Enable profiling view
+        "organizations:profiling-view": FlagpoleFeature(default=False, api_expose=True),
     }
 
     # Permanent project features that are controlled via flagpole. These are

--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -27,21 +27,6 @@ def register_permanent_features(manager: FeatureManager) -> None:
     self-hosted and single-tenant are aligned with sentry.io.
     """
     permanent_organization_features = {
-        # Enable advanced search features, like negation and wildcard matching.
-        "organizations:advanced-search": True,
-        # Enable discover 2 basic functions
-        "organizations:discover-basic": True,
-        # Enable discover 2 custom queries and saved queries
-        "organizations:discover-query": True,
-        # Enable incidents feature
-        "organizations:incidents": False,
-        # Enable integration functionality to work with alert rules
-        "organizations:integrations-alert-rule": True,
-        # Enable integration functionality to work with alert rules (specifically chat integrations)
-        "organizations:integrations-chat-unfurl": True,
-        # Enable integration functionality to work with alert rules (specifically incident
-        # management integrations)
-        "organizations:integrations-incident-management": True,
         # Enable interface functionality to synchronize groups between sentry and
         # issues on external services.
         "organizations:integrations-issue-sync": True,
@@ -52,13 +37,8 @@ def register_permanent_features(manager: FeatureManager) -> None:
         # Enable SAML2 based SSO functionality. getsentry/sentry-auth-saml2 plugin
         # must be installed to use this functionality.
         "organizations:sso-saml2": True,
-        # Enable 'spans' category on the stats page
-        "organizations:span-stats": False,
         # Enable the uptime monitoring features
         "organizations:uptime": True,
-        # Feature flag for continuous profiling billing-related features.
-        # Separate from organizations:continuous-profiling feature flag.
-        "organizations:continuous-profiling-billing": False,
         # Signals that the organization supports the on demand metrics prefill.
         "organizations:on-demand-metrics-prefill": False,
         # Metrics: Enable ingestion and storage of custom metrics. See custom-metrics for UI.
@@ -148,6 +128,25 @@ def register_permanent_features(manager: FeatureManager) -> None:
         "organizations:session-replay": FlagpoleFeature(default=False, api_expose=True),
         # Enable profiling view
         "organizations:profiling-view": FlagpoleFeature(default=False, api_expose=True),
+        # Enable advanced search features, like negation and wildcard matching.
+        "organizations:advanced-search": FlagpoleFeature(default=True, api_expose=True),
+        # Enable discover 2 basic functions
+        "organizations:discover-basic": FlagpoleFeature(default=True, api_expose=True),
+        # Enable discover 2 custom queries and saved queries
+        "organizations:discover-query": FlagpoleFeature(default=True, api_expose=True),
+        # Enable 'spans' category on the stats page
+        "organizations:span-stats": FlagpoleFeature(default=False, api_expose=True),
+        # Enable incidents feature
+        "organizations:incidents": FlagpoleFeature(default=False, api_expose=True),
+        # Enable integration functionality to work with alert rules
+        "organizations:integrations-alert-rule": FlagpoleFeature(default=True, api_expose=True),
+        # Enable integration functionality to work with alert rules (specifically chat integrations)
+        "organizations:integrations-chat-unfurl": FlagpoleFeature(default=True, api_expose=True),
+        # Enable integration functionality to work with alert rules (specifically incident
+        # management integrations)
+        "organizations:integrations-incident-management": FlagpoleFeature(
+            default=True, api_expose=True
+        ),
     }
 
     # Permanent project features that are controlled via flagpole. These are


### PR DESCRIPTION
Move a few Subscription based feature flags to flagpole. continuous-profiling-billing was deleted since it is not used anymore