### PR TITLE
feat(events): Soft block external legacy events API usage

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -58,10 +58,16 @@ from sentry.snuba.referrer import Referrer, is_valid_referrer
 from sentry.snuba.spans_rpc import Spans
 from sentry.snuba.trace_metrics import TraceMetrics
 from sentry.snuba.types import DatasetQuery
-from sentry.snuba.utils import RPC_DATASETS, dataset_split_decision_inferred_from_query, get_dataset
+from sentry.snuba.utils import (
+    DATASET_LABELS,
+    RPC_DATASETS,
+    dataset_split_decision_inferred_from_query,
+    get_dataset,
+)
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 from sentry.utils.cursors import Cursor, EAPPageTokenCursor
+from sentry.utils.sdk import sdk_logger
 from sentry.utils.snuba import SnubaError
 from sentry.utils.tracing import trace
 
@@ -132,6 +138,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
             "organizations:dynamic-sampling",
             "organizations:on-demand-metrics-extraction",
             "organizations:on-demand-metrics-extraction-widgets",
+            "organizations:events-endpoint-transactions-discover-blocked",
         ]
         batch_features = features.batch_has(
             feature_names,
@@ -204,6 +211,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
             )
 
         referrer = request.GET.get("referrer")
+        sentry_sdk.set_attribute("query.raw_referrer", referrer or "")
 
         try:
             snuba_params = self.get_snuba_params(
@@ -262,6 +270,29 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
         elif not is_valid_referrer(referrer):
             referrer = Referrer.API_ORGANIZATION_EVENTS.value
 
+        sentry_sdk.set_tag("query.referrer", referrer)
+        sentry_sdk.set_attribute("query.referrer", referrer)
+
+        # We are going to start ratcheting usage of this endpoint for legacy
+        # datasets. For now, log usage from blocked orgs but still permit the
+        # request.
+        is_external_api_request = request.auth and referrer == Referrer.API_AUTH_TOKEN_EVENTS
+        is_legacy_dataset = dataset in {transactions, discover, metrics_enhanced_performance}
+        is_blocked = batch_features.get(
+            "organizations:events-endpoint-transactions-discover-blocked", False
+        )
+        if is_external_api_request and is_legacy_dataset and is_blocked:
+            sdk_logger.warning(
+                "events endpoint called by blocked org",
+                attributes={
+                    "org_id": organization.id,
+                    "org_slug": organization.slug,
+                    "effective_dataset": DATASET_LABELS.get(dataset, ""),
+                    "requested_dataset": request.GET.get("dataset", ""),
+                    "endpoint_name": "organization-events",
+                },
+            )
+
         use_aggregate_conditions = request.GET.get("allowAggregateConditions", "1") in ("1", "true")
 
         max_string_length: int | None = None
@@ -290,7 +321,11 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                 )
                 if orderby:
                     orderby = transform_orderby_for_error_upsampling(orderby)
+
             query_source = self.get_request_source(request)
+            sentry_sdk.set_tag("query.query_source", query_source)
+            sentry_sdk.set_attribute("query.query_source", query_source)
+
             return dataset_query(
                 selected_columns=selected_columns,
                 query=query or "",

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -323,8 +323,8 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                     orderby = transform_orderby_for_error_upsampling(orderby)
 
             query_source = self.get_request_source(request)
-            sentry_sdk.set_tag("query.query_source", query_source)
-            sentry_sdk.set_attribute("query.query_source", query_source)
+            sentry_sdk.set_tag("query.query_source", query_source.value)
+            sentry_sdk.set_attribute("query.query_source", query_source.value)
 
             return dataset_query(
                 selected_columns=selected_columns,

--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -296,8 +296,8 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
         sentry_sdk.set_attribute("query.referrer", referrer)
 
         query_source = self.get_request_querysource(request, referrer)
-        sentry_sdk.set_tag("query.query_source", query_source)
-        sentry_sdk.set_attribute("query.query_source", query_source)
+        sentry_sdk.set_tag("query.query_source", query_source.value)
+        sentry_sdk.set_attribute("query.query_source", query_source.value)
 
         # We are going to start ratcheting usage of this endpoint for legacy
         # datasets. For now, log usage from blocked orgs but still permit the

--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -55,6 +55,7 @@ from sentry.snuba.spans_rpc import Spans
 from sentry.snuba.trace_metrics import TraceMetrics
 from sentry.snuba.utils import DATASET_LABELS, RPC_DATASETS
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
+from sentry.utils.sdk import sdk_logger
 from sentry.utils.snuba import SnubaTSResult
 from sentry.utils.tracing import set_span_data, start_span
 
@@ -282,6 +283,7 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
         allow_metric_aggregates = request.GET.get("preventMetricAggregates") != "1"
         include_other = request.GET.get("excludeOther") != "1"
         referrer = request.GET.get("referrer")
+        sentry_sdk.set_attribute("query.raw_referrer", referrer or "")
         # Force the referrer to "api.auth-token.events" for events requests authorized through a bearer token
         if request.auth:
             referrer = Referrer.API_AUTH_TOKEN_EVENTS.value
@@ -289,7 +291,35 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
             referrer = Referrer.API_ORGANIZATION_EVENTS.value
         elif not is_valid_referrer(referrer):
             referrer = Referrer.API_ORGANIZATION_EVENTS.value
+
+        sentry_sdk.set_tag("query.referrer", referrer)
+        sentry_sdk.set_attribute("query.referrer", referrer)
+
         query_source = self.get_request_querysource(request, referrer)
+        sentry_sdk.set_tag("query.query_source", query_source)
+        sentry_sdk.set_attribute("query.query_source", query_source)
+
+        # We are going to start ratcheting usage of this endpoint for legacy
+        # datasets. For now, log usage from blocked orgs but still permit the
+        # request.
+        is_external_api_request = request.auth and referrer == Referrer.API_AUTH_TOKEN_EVENTS
+        is_legacy_dataset = dataset in {transactions, discover, metrics_enhanced_performance}
+        is_blocked = features.has(
+            "organizations:events-endpoint-transactions-discover-blocked",
+            organization,
+            actor=request.user,
+        )
+        if is_external_api_request and is_legacy_dataset and is_blocked:
+            sdk_logger.warning(
+                "events endpoint called by blocked org",
+                attributes={
+                    "org_id": organization.id,
+                    "org_slug": organization.slug,
+                    "effective_dataset": DATASET_LABELS.get(dataset, ""),
+                    "requested_dataset": request.GET.get("dataset", ""),
+                    "endpoint_name": "organization-events-timeseries",
+                },
+            )
 
         self._emit_analytics_event(organization, referrer)
 

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -250,6 +250,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:events-use-replays-dataset", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable using the events api with a sql interface
     manager.add("organizations:events-sql-grammar-api", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Block transactions/discover dataset usage of the events endpoints for external API requests
+    manager.add("organizations:events-endpoint-transactions-discover-blocked", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable detecting SDK crashes during event processing
     manager.add("organizations:sdk-crash-detection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable Seer Agent panel for AI-powered data exploration

--- a/tests/sentry/api/test_organization_events.py
+++ b/tests/sentry/api/test_organization_events.py
@@ -177,3 +177,123 @@ class OrganizationEventsEndpointTest(APITestCase):
         self.do_request(query)
         _, kwargs = mock.call_args
         self.assertEqual(kwargs["referrer"], "api.insights.transaction-summary")
+
+    def _api_token_request(self, query, features):
+        """Issue an external API-token request, which forces the referrer to
+        `api.auth-token.events` (the "external API request" branch of the
+        blocked-org warning)."""
+        api_key = self.create_api_key(organization=self.organization, scope_list=["org:read"])
+        features.update(self.features)
+        url = self.reverse_url()
+        with self.feature(features):
+            return self.client_get(
+                url,
+                query,
+                format="json",
+                HTTP_AUTHORIZATION=self.create_basic_auth_header(api_key.key),
+            )
+
+    @mock.patch("sentry.api.endpoints.organization_events.sdk_logger")
+    @mock.patch("sentry.snuba.discover.query")
+    def test_blocked_org_log_fires_for_discover(
+        self, mock_query: mock.MagicMock, mock_sdk_logger: mock.MagicMock
+    ) -> None:
+        mock_query.return_value = {}
+
+        # discover is the default dataset when none is specified
+        query = {"field": ["user"], "project": [self.project.id]}
+        self._api_token_request(
+            query,
+            features={
+                "organizations:discover-basic": True,
+                "organizations:events-endpoint-transactions-discover-blocked": True,
+            },
+        )
+
+        mock_sdk_logger.warning.assert_called_once()
+        _, kwargs = mock_sdk_logger.warning.call_args
+        assert kwargs["attributes"] == {
+            "org_id": self.organization.id,
+            "org_slug": self.organization.slug,
+            # no dataset param was passed, so the requested value is empty
+            "requested_dataset": "",
+            # but the default dataset is used
+            "effective_dataset": "discover",
+            "endpoint_name": "organization-events",
+        }
+
+    @mock.patch("sentry.api.endpoints.organization_events.sdk_logger")
+    @mock.patch("sentry.snuba.transactions.query")
+    def test_blocked_org_log_fires_for_transactions(
+        self, mock_query: mock.MagicMock, mock_sdk_logger: mock.MagicMock
+    ) -> None:
+        mock_query.return_value = {}
+
+        query = {"field": ["user"], "project": [self.project.id], "dataset": "transactions"}
+        self._api_token_request(
+            query,
+            features={
+                "organizations:discover-basic": True,
+                "organizations:events-endpoint-transactions-discover-blocked": True,
+            },
+        )
+
+        mock_sdk_logger.warning.assert_called_once()
+        _, kwargs = mock_sdk_logger.warning.call_args
+        assert kwargs["attributes"]["effective_dataset"] == "transactions"
+        assert kwargs["attributes"]["requested_dataset"] == "transactions"
+
+    @mock.patch("sentry.api.endpoints.organization_events.sdk_logger")
+    @mock.patch("sentry.snuba.discover.query")
+    def test_blocked_org_log_not_fired_when_flag_off(
+        self, mock_query: mock.MagicMock, mock_sdk_logger: mock.MagicMock
+    ) -> None:
+        mock_query.return_value = {}
+
+        query = {"field": ["user"], "project": [self.project.id]}
+        self._api_token_request(
+            query,
+            features={
+                "organizations:discover-basic": True,
+                "organizations:events-endpoint-transactions-discover-blocked": False,
+            },
+        )
+
+        mock_sdk_logger.warning.assert_not_called()
+
+    @mock.patch("sentry.api.endpoints.organization_events.sdk_logger")
+    @mock.patch("sentry.snuba.discover.query")
+    def test_blocked_org_log_not_fired_for_non_external_request(
+        self, mock_query: mock.MagicMock, mock_sdk_logger: mock.MagicMock
+    ) -> None:
+        mock_query.return_value = {}
+
+        query = {"field": ["user"], "project": [self.project.id]}
+        # do_request uses a session login, not an API token
+        self.do_request(
+            query,
+            features={
+                "organizations:discover-basic": True,
+                "organizations:events-endpoint-transactions-discover-blocked": True,
+            },
+        )
+
+        mock_sdk_logger.warning.assert_not_called()
+
+    @mock.patch("sentry.api.endpoints.organization_events.sdk_logger")
+    @mock.patch("sentry.snuba.errors.query")
+    def test_blocked_org_log_not_fired_for_non_legacy_dataset(
+        self, mock_query: mock.MagicMock, mock_sdk_logger: mock.MagicMock
+    ) -> None:
+        mock_query.return_value = {}
+
+        query = {"field": ["user"], "project": [self.project.id], "dataset": "errors"}
+        self._api_token_request(
+            query,
+            features={
+                "organizations:discover-basic": True,
+                "organizations:events-endpoint-transactions-discover-blocked": True,
+            },
+        )
+
+        mock_sdk_logger.warning.assert_not_called()

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
+from unittest import mock
 
 import pytest
 from django.urls import reverse
@@ -390,3 +391,123 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
             "valueUnit": None,
             "interval": 3_600_000,
         }
+
+    def _api_token_request(self, data, features):
+        api_key = self.create_api_key(organization=self.organization, scope_list=["org:read"])
+        with self.feature(features):
+            return self.client.get(
+                self.url,
+                data=data,
+                format="json",
+                HTTP_AUTHORIZATION=self.create_basic_auth_header(api_key.key),
+            )
+
+    @mock.patch("sentry.api.endpoints.organization_events_timeseries.sdk_logger")
+    def test_blocked_org_log_fires_for_discover(self, mock_sdk_logger: mock.MagicMock) -> None:
+        data = {
+            "start": self.start,
+            "end": self.end,
+            "interval": "1h",
+            "project": [self.project.id],
+        }
+        self._api_token_request(
+            data,
+            features={
+                "organizations:discover-basic": True,
+                "organizations:events-endpoint-transactions-discover-blocked": True,
+            },
+        )
+
+        mock_sdk_logger.warning.assert_called_once()
+        _, kwargs = mock_sdk_logger.warning.call_args
+        assert kwargs["attributes"] == {
+            "org_id": self.organization.id,
+            "org_slug": self.organization.slug,
+            # no dataset param was passed, so the requested value is empty
+            "requested_dataset": "",
+            # but the default dataset is used
+            "effective_dataset": "discover",
+            "endpoint_name": "organization-events-timeseries",
+        }
+
+    @mock.patch("sentry.api.endpoints.organization_events_timeseries.sdk_logger")
+    def test_blocked_org_log_fires_for_transactions(self, mock_sdk_logger: mock.MagicMock) -> None:
+        data = {
+            "start": self.start,
+            "end": self.end,
+            "interval": "1h",
+            "project": [self.project.id],
+            "dataset": "transactions",
+        }
+        self._api_token_request(
+            data,
+            features={
+                "organizations:discover-basic": True,
+                "organizations:events-endpoint-transactions-discover-blocked": True,
+            },
+        )
+
+        mock_sdk_logger.warning.assert_called_once()
+        _, kwargs = mock_sdk_logger.warning.call_args
+        assert kwargs["attributes"]["effective_dataset"] == "transactions"
+        assert kwargs["attributes"]["requested_dataset"] == "transactions"
+
+    @mock.patch("sentry.api.endpoints.organization_events_timeseries.sdk_logger")
+    def test_blocked_org_log_not_fired_when_flag_off(self, mock_sdk_logger: mock.MagicMock) -> None:
+        data = {
+            "start": self.start,
+            "end": self.end,
+            "interval": "1h",
+            "project": [self.project.id],
+        }
+        self._api_token_request(
+            data,
+            features={
+                "organizations:discover-basic": True,
+                "organizations:events-endpoint-transactions-discover-blocked": False,
+            },
+        )
+
+        mock_sdk_logger.warning.assert_not_called()
+
+    @mock.patch("sentry.api.endpoints.organization_events_timeseries.sdk_logger")
+    def test_blocked_org_log_not_fired_for_non_external_request(
+        self, mock_sdk_logger: mock.MagicMock
+    ) -> None:
+        data = {
+            "start": self.start,
+            "end": self.end,
+            "interval": "1h",
+            "project": [self.project.id],
+        }
+        # do_request uses a session login, not an API token
+        self.do_request(
+            data,
+            features={
+                "organizations:discover-basic": True,
+                "organizations:events-endpoint-transactions-discover-blocked": True,
+            },
+        )
+
+        mock_sdk_logger.warning.assert_not_called()
+
+    @mock.patch("sentry.api.endpoints.organization_events_timeseries.sdk_logger")
+    def test_blocked_org_log_not_fired_for_non_legacy_dataset(
+        self, mock_sdk_logger: mock.MagicMock
+    ) -> None:
+        data = {
+            "start": self.start,
+            "end": self.end,
+            "interval": "1h",
+            "project": [self.project.id],
+            "dataset": "errors",
+        }
+        self._api_token_request(
+            data,
+            features={
+                "organizations:discover-basic": True,
+                "organizations:events-endpoint-transactions-discover-blocked": True,
+            },
+        )
+
+        mock_sdk_logger.warning.assert_not_called()


### PR DESCRIPTION
We found that external API users are still using deprecated datasets that query transactions: `transactions`, `discover` (a union of `errors` and `transactions`), and `metricsEnhanced` (`metrics` with a fallback to `transactions`).

Prepare to block these uses. To start we'll apply a ratchet: allowlist current users but block everyone else. This PR puts the code in place to start with a soft block, logging all access outside of the allowlist so we can tune it.

The duplication between the two endpoints is IMO fine - once the code evolves into an actual block I'll consolidate it at that time, if it makes sense to do so.

For the sake of investigating where requests are coming from, I also added the incoming `referrer`, the normalized `referrer`, and the `query_source` to tags/attributes so we can break down the usage of these endpoints in Sentry.

Fixes BROWSE-660. Fixes BROWSE-661.

---

🤖: Wrote the tests.