### PR TITLE
fix(dashboards): Disambiguate Dashboard widget error and loading states

### DIFF
--- a/static/app/views/dashboards/utils/getWidgetConfigError.spec.tsx
+++ b/static/app/views/dashboards/utils/getWidgetConfigError.spec.tsx
@@ -118,11 +118,23 @@ describe('getWidgetConfigError', () => {
     );
   });
 
+  it('nudges to finish the equation when a blank equation is the only aggregate', () => {
+    const widget = WidgetFixture({
+      displayType: DisplayType.LINE,
+      widgetType: WidgetType.TRACEMETRICS,
+      // The blank equation was stripped during conversion, leaving no aggregates.
+      queries: [WidgetQueryFixture({aggregates: []})],
+    });
+
+    expect(getWidgetConfigError(widget, {hasBlankEquation: true})).toBe(
+      'Enter an equation to preview results'
+    );
+  });
+
   it('returns undefined for a trace metric widget with a resolvable metric', () => {
     const widget = WidgetFixture({
       displayType: DisplayType.LINE,
       widgetType: WidgetType.TRACEMETRICS,
-      // Encodes the metric as fn(value, name, type, unit).
       queries: [
         WidgetQueryFixture({aggregates: ['sum(value,test_metric,distribution,none)']}),
       ],

--- a/static/app/views/dashboards/utils/getWidgetConfigError.spec.tsx
+++ b/static/app/views/dashboards/utils/getWidgetConfigError.spec.tsx
@@ -104,4 +104,34 @@ describe('getWidgetConfigError', () => {
       'Heatmaps can only visualize distribution metrics.'
     );
   });
+
+  it.each([DisplayType.LINE, DisplayType.BAR, DisplayType.TABLE, DisplayType.BIG_NUMBER])(
+    'returns an error for %s trace metric widgets whose aggregate has no metric',
+    displayType => {
+      const widget = WidgetFixture({
+        displayType,
+        widgetType: WidgetType.TRACEMETRICS,
+        queries: [WidgetQueryFixture({aggregates: ['sum(value)']})],
+      });
+
+      expect(getWidgetConfigError(widget)).toBe(
+        'This widget is missing a metric to visualize.'
+      );
+    }
+  );
+
+  it('returns an error when any query in a trace metric widget is unresolvable', () => {
+    const widget = WidgetFixture({
+      displayType: DisplayType.LINE,
+      widgetType: WidgetType.TRACEMETRICS,
+      queries: [
+        WidgetQueryFixture({aggregates: ['sum(value,test_metric,distribution,none)']}),
+        WidgetQueryFixture({aggregates: ['sum(value)']}),
+      ],
+    });
+
+    expect(getWidgetConfigError(widget)).toBe(
+      'This widget is missing a metric to visualize.'
+    );
+  });
 });

--- a/static/app/views/dashboards/utils/getWidgetConfigError.spec.tsx
+++ b/static/app/views/dashboards/utils/getWidgetConfigError.spec.tsx
@@ -118,20 +118,16 @@ describe('getWidgetConfigError', () => {
     );
   });
 
-  it('returns an error when any query in a trace metric widget is unresolvable', () => {
+  it('returns undefined for a trace metric widget with a resolvable metric', () => {
     const widget = WidgetFixture({
       displayType: DisplayType.LINE,
       widgetType: WidgetType.TRACEMETRICS,
+      // Encodes the metric as fn(value, name, type, unit).
       queries: [
-        // Resolvable: encodes the metric as fn(value, name, type, unit).
         WidgetQueryFixture({aggregates: ['sum(value,test_metric,distribution,none)']}),
-        // Unresolvable: bare placeholder with no metric.
-        WidgetQueryFixture({aggregates: ['sum(value)']}),
       ],
     });
 
-    expect(getWidgetConfigError(widget)).toBe(
-      'This widget is missing a metric to visualize.'
-    );
+    expect(getWidgetConfigError(widget)).toBeUndefined();
   });
 });

--- a/static/app/views/dashboards/utils/getWidgetConfigError.spec.tsx
+++ b/static/app/views/dashboards/utils/getWidgetConfigError.spec.tsx
@@ -79,6 +79,18 @@ describe('getWidgetConfigError', () => {
     expect(getWidgetConfigError(widget)).toBeDefined();
   });
 
+  it('returns an error for heat map widgets with no aggregates', () => {
+    const widget = WidgetFixture({
+      displayType: DisplayType.HEATMAP,
+      widgetType: WidgetType.TRACEMETRICS,
+      queries: [WidgetQueryFixture({aggregates: []})],
+    });
+
+    expect(getWidgetConfigError(widget)).toBe(
+      'This widget is missing a metric to visualize.'
+    );
+  });
+
   it('returns undefined for heat map widgets with a resolvable metric', () => {
     const widget = WidgetFixture({
       displayType: DisplayType.HEATMAP,

--- a/static/app/views/dashboards/utils/getWidgetConfigError.spec.tsx
+++ b/static/app/views/dashboards/utils/getWidgetConfigError.spec.tsx
@@ -105,27 +105,27 @@ describe('getWidgetConfigError', () => {
     );
   });
 
-  it.each([DisplayType.LINE, DisplayType.BAR, DisplayType.TABLE, DisplayType.BIG_NUMBER])(
-    'returns an error for %s trace metric widgets whose aggregate has no metric',
-    displayType => {
-      const widget = WidgetFixture({
-        displayType,
-        widgetType: WidgetType.TRACEMETRICS,
-        queries: [WidgetQueryFixture({aggregates: ['sum(value)']})],
-      });
+  it('returns an error for trace metric widgets whose aggregate has no metric', () => {
+    const widget = WidgetFixture({
+      displayType: DisplayType.LINE,
+      widgetType: WidgetType.TRACEMETRICS,
+      // `sum(value)` is the placeholder aggregate — no metric name/type encoded.
+      queries: [WidgetQueryFixture({aggregates: ['sum(value)']})],
+    });
 
-      expect(getWidgetConfigError(widget)).toBe(
-        'This widget is missing a metric to visualize.'
-      );
-    }
-  );
+    expect(getWidgetConfigError(widget)).toBe(
+      'This widget is missing a metric to visualize.'
+    );
+  });
 
   it('returns an error when any query in a trace metric widget is unresolvable', () => {
     const widget = WidgetFixture({
       displayType: DisplayType.LINE,
       widgetType: WidgetType.TRACEMETRICS,
       queries: [
+        // Resolvable: encodes the metric as fn(value, name, type, unit).
         WidgetQueryFixture({aggregates: ['sum(value,test_metric,distribution,none)']}),
+        // Unresolvable: bare placeholder with no metric.
         WidgetQueryFixture({aggregates: ['sum(value)']}),
       ],
     });

--- a/static/app/views/dashboards/utils/getWidgetConfigError.tsx
+++ b/static/app/views/dashboards/utils/getWidgetConfigError.tsx
@@ -1,9 +1,9 @@
 import {t} from 'sentry/locale';
-import {explodeField, isEquation} from 'sentry/utils/discover/fields';
 import {DisplayType, WidgetType, type Widget} from 'sentry/views/dashboards/types';
 import {usesTimeSeriesData} from 'sentry/views/dashboards/utils';
 import {extractTraceMetricFromColumn} from 'sentry/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate';
 import {getSelectedAggregate} from 'sentry/views/dashboards/widgetBuilder/utils/getSelectedAggregate';
+import {hasUnresolvedTraceMetric} from 'sentry/views/dashboards/widgetBuilder/utils/hasUnresolvedTraceMetric';
 import {doesMetricSupportHeatMapVisualization} from 'sentry/views/explore/metrics/constants';
 
 /**
@@ -37,18 +37,4 @@ export function getWidgetConfigError(widget: Widget): string | undefined {
   }
 
   return undefined;
-}
-
-/**
- * Whether any of a trace-metric widget's aggregates fail to resolve to a metric
- * (`fn(value, name, type, unit)`). This is the same predicate the metric selector's
- * auto-select uses, so it also answers "is a metric about to be filled in?".
- * Equations carry no metric tuple and reference base aggregates validated on their
- * own, so they're skipped. Callers must confirm the trace-metrics dataset first.
- */
-export function hasUnresolvedTraceMetric(widget: Widget): boolean {
-  return widget.queries
-    .flatMap(query => query.aggregates)
-    .filter(aggregate => !isEquation(aggregate))
-    .some(aggregate => !extractTraceMetricFromColumn(explodeField({field: aggregate})));
 }

--- a/static/app/views/dashboards/utils/getWidgetConfigError.tsx
+++ b/static/app/views/dashboards/utils/getWidgetConfigError.tsx
@@ -10,13 +10,25 @@ import {doesMetricSupportHeatMapVisualization} from 'sentry/views/explore/metric
  * Returns a user-facing error message if the widget has a static config
  * problem that would prevent it from displaying data. Returns undefined
  * if the widget config is valid.
+ *
+ * `hasBlankEquation` is a builder-only signal: `convertBuilderStateToWidget`
+ * strips blank equations, so a widget whose only "Visualize" entry is an
+ * unfinished equation arrives here with no aggregates and is indistinguishable
+ * from an empty one. The builder passes this in to swap the generic
+ * missing-field error for a more specific nudge. Saved widgets never carry a
+ * blank equation, so callers without builder state can omit it.
  */
-export function getWidgetConfigError(widget: Widget): string | undefined {
+export function getWidgetConfigError(
+  widget: Widget,
+  {hasBlankEquation = false}: {hasBlankEquation?: boolean} = {}
+): string | undefined {
   if (
     usesTimeSeriesData(widget.displayType) &&
     widget.queries.every(q => q.aggregates.length === 0)
   ) {
-    return t('The widget configuration is not valid. Please add a "Visualize" field.');
+    return hasBlankEquation
+      ? t('Enter an equation to preview results')
+      : t('The widget configuration is not valid. Please add a "Visualize" field.');
   }
 
   // Trace-metric widgets encode the metric in the aggregate; if it doesn't resolve,

--- a/static/app/views/dashboards/utils/getWidgetConfigError.tsx
+++ b/static/app/views/dashboards/utils/getWidgetConfigError.tsx
@@ -43,7 +43,11 @@ export function getWidgetConfigError(
     }
     const aggregate = getSelectedAggregate(widget);
     const traceMetric = aggregate && extractTraceMetricFromColumn(aggregate);
-    if (traceMetric && !doesMetricSupportHeatMapVisualization(traceMetric)) {
+    if (!traceMetric) {
+      // No aggregate at all — a present-but-unresolved one is already caught above.
+      return t('This widget is missing a metric to visualize.');
+    }
+    if (!doesMetricSupportHeatMapVisualization(traceMetric)) {
       return t('Heatmaps can only visualize distribution metrics.');
     }
   }

--- a/static/app/views/dashboards/utils/getWidgetConfigError.tsx
+++ b/static/app/views/dashboards/utils/getWidgetConfigError.tsx
@@ -19,17 +19,9 @@ export function getWidgetConfigError(widget: Widget): string | undefined {
     return t('The widget configuration is not valid. Please add a "Visualize" field.');
   }
 
-  // Trace-metric widgets encode the metric in the aggregate (fn(value, name, type,
-  // unit)); if any non-equation aggregate doesn't resolve to a metric, nothing can
-  // render. Applies to every display type, including heat maps. Equations carry no
-  // metric tuple and reference base aggregates that are validated on their own.
-  const hasUnresolvedMetric =
-    widget.widgetType === WidgetType.TRACEMETRICS &&
-    widget.queries
-      .flatMap(query => query.aggregates)
-      .filter(aggregate => !isEquation(aggregate))
-      .some(aggregate => !extractTraceMetricFromColumn(explodeField({field: aggregate})));
-  if (hasUnresolvedMetric) {
+  // Trace-metric widgets encode the metric in the aggregate; if it doesn't resolve,
+  // nothing can render (applies to every display type, including heat maps).
+  if (widget.widgetType === WidgetType.TRACEMETRICS && hasUnresolvedTraceMetric(widget)) {
     return t('This widget is missing a metric to visualize.');
   }
 
@@ -45,4 +37,18 @@ export function getWidgetConfigError(widget: Widget): string | undefined {
   }
 
   return undefined;
+}
+
+/**
+ * Whether any of a trace-metric widget's aggregates fail to resolve to a metric
+ * (`fn(value, name, type, unit)`). This is the same predicate the metric selector's
+ * auto-select uses, so it also answers "is a metric about to be filled in?".
+ * Equations carry no metric tuple and reference base aggregates validated on their
+ * own, so they're skipped. Callers must confirm the trace-metrics dataset first.
+ */
+export function hasUnresolvedTraceMetric(widget: Widget): boolean {
+  return widget.queries
+    .flatMap(query => query.aggregates)
+    .filter(aggregate => !isEquation(aggregate))
+    .some(aggregate => !extractTraceMetricFromColumn(explodeField({field: aggregate})));
 }

--- a/static/app/views/dashboards/utils/getWidgetConfigError.tsx
+++ b/static/app/views/dashboards/utils/getWidgetConfigError.tsx
@@ -1,4 +1,5 @@
 import {t} from 'sentry/locale';
+import {explodeField, isEquation} from 'sentry/utils/discover/fields';
 import {DisplayType, WidgetType, type Widget} from 'sentry/views/dashboards/types';
 import {usesTimeSeriesData} from 'sentry/views/dashboards/utils';
 import {extractTraceMetricFromColumn} from 'sentry/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate';
@@ -18,19 +19,27 @@ export function getWidgetConfigError(widget: Widget): string | undefined {
     return t('The widget configuration is not valid. Please add a "Visualize" field.');
   }
 
-  // Heat maps are only offered on the trace-metrics dataset, and plot the metric
-  // from their selected "Visualize" aggregate. If they're on another dataset or
-  // that aggregate doesn't resolve to a metric, the widget can't render.
+  // Trace-metric widgets encode the metric in the aggregate (fn(value, name, type,
+  // unit)); if any non-equation aggregate doesn't resolve to a metric, nothing can
+  // render. Applies to every display type, including heat maps. Equations carry no
+  // metric tuple and reference base aggregates that are validated on their own.
+  const hasUnresolvedMetric =
+    widget.widgetType === WidgetType.TRACEMETRICS &&
+    widget.queries
+      .flatMap(query => query.aggregates)
+      .filter(aggregate => !isEquation(aggregate))
+      .some(aggregate => !extractTraceMetricFromColumn(explodeField({field: aggregate})));
+  if (hasUnresolvedMetric) {
+    return t('This widget is missing a metric to visualize.');
+  }
+
   if (widget.displayType === DisplayType.HEATMAP) {
     if (widget.widgetType !== WidgetType.TRACEMETRICS) {
       return t('This dataset does not support this visualization.');
     }
     const aggregate = getSelectedAggregate(widget);
     const traceMetric = aggregate && extractTraceMetricFromColumn(aggregate);
-    if (!traceMetric) {
-      return t('This widget is missing a metric to visualize.');
-    }
-    if (!doesMetricSupportHeatMapVisualization(traceMetric)) {
+    if (traceMetric && !doesMetricSupportHeatMapVisualization(traceMetric)) {
       return t('Heatmaps can only visualize distribution metrics.');
     }
   }

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -32,10 +32,7 @@ import {
   type DashboardFilters,
   type Widget,
 } from 'sentry/views/dashboards/types';
-import {
-  getWidgetConfigError,
-  hasUnresolvedTraceMetric,
-} from 'sentry/views/dashboards/utils/getWidgetConfigError';
+import {getWidgetConfigError} from 'sentry/views/dashboards/utils/getWidgetConfigError';
 import {animationTransitionSettings} from 'sentry/views/dashboards/widgetBuilder/components/common/animationSettings';
 import {
   DEFAULT_WIDGET_DRAG_POSITIONING,
@@ -58,6 +55,7 @@ import {
   WidgetBuilderProvider,
 } from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import {convertBuilderStateToWidget} from 'sentry/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget';
+import {hasUnresolvedTraceMetric} from 'sentry/views/dashboards/widgetBuilder/utils/hasUnresolvedTraceMetric';
 import type {OnDataFetchedParams} from 'sentry/views/dashboards/widgetCard';
 import {DashboardsMEPProvider} from 'sentry/views/dashboards/widgetCard/dashboardsMEPContext';
 import {useMetricOptions} from 'sentry/views/explore/hooks/useMetricOptions';

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -290,18 +290,21 @@ export function WidgetPreviewContainer({
     getWidgetConfigError(widget) ??
     (isQueryConditionInvalid ? t("This widget's query filter is invalid.") : undefined);
 
+  // A renderable widget always wins — `isResolving`/`hasNoMetrics` only decide how to
+  // present a widget that can't render yet (e.g. an equation-mode widget has no
+  // selected metric but is perfectly valid, so it must not get stuck loading).
   let previewStatus: WidgetPreviewStatus;
-  if (isResolving) {
+  if (!message) {
+    previewStatus = {status: 'ready'};
+  } else if (isResolving) {
     previewStatus = {status: 'loading'};
   } else if (hasNoMetrics) {
     previewStatus = {
       status: 'invalid',
       message: t('No metrics found for the selected projects.'),
     };
-  } else if (message) {
-    previewStatus = {status: 'invalid', message};
   } else {
-    previewStatus = {status: 'ready'};
+    previewStatus = {status: 'invalid', message};
   }
   const organization = useOrganization();
   const location = useLocation();

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -54,10 +54,12 @@ import {
   useWidgetBuilderContext,
   WidgetBuilderProvider,
 } from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
+import {getTraceMetricAggregateSource} from 'sentry/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate';
 import {convertBuilderStateToWidget} from 'sentry/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget';
 import {hasUnresolvedTraceMetric} from 'sentry/views/dashboards/widgetBuilder/utils/hasUnresolvedTraceMetric';
 import type {OnDataFetchedParams} from 'sentry/views/dashboards/widgetCard';
 import {DashboardsMEPProvider} from 'sentry/views/dashboards/widgetCard/dashboardsMEPContext';
+import {FieldValueKind} from 'sentry/views/discover/table/types';
 import {useMetricOptions} from 'sentry/views/explore/hooks/useMetricOptions';
 import {useTopOffset} from 'sentry/views/navigation/useTopOffset';
 import {MetricsDataSwitcher} from 'sentry/views/performance/landing/metricsDataSwitcher';
@@ -269,29 +271,40 @@ export function WidgetPreviewContainer({
   });
   const hasMetricOptions = (metricOptions?.data?.length ?? 0) > 0;
 
-  // Loading while the options fetch is in flight; once it settles with no options
-  // the metric can never auto-select, so fall through to the error.
   const isResolving = needsMetric && isFetchingMetricOptions;
   const hasNoMetrics = needsMetric && !isFetchingMetricOptions && !hasMetricOptions;
 
+  // `convertBuilderStateToWidget` strips blank equations, so one only matters when it's
+  // the *only* thing entered — otherwise the widget renders from its other aggregates.
+  // In that lone-equation case, nudge the user to finish it rather than showing the
+  // generic "add a field" error.
+  const hasOnlyBlankEquation =
+    widget.widgetType === WidgetType.TRACEMETRICS &&
+    widget.queries.every(query => query.aggregates.length === 0) &&
+    Boolean(
+      getTraceMetricAggregateSource(state.displayType, state.yAxis, state.fields)?.some(
+        aggregate =>
+          aggregate.kind === FieldValueKind.EQUATION && aggregate.field.trim() === ''
+      )
+    );
+
   const message =
+    (hasOnlyBlankEquation ? t('Enter an equation to preview results') : undefined) ??
     getWidgetConfigError(widget) ??
     (isQueryConditionInvalid ? t("This widget's query filter is invalid.") : undefined);
 
-  // A renderable widget always wins; `isResolving`/`hasNoMetrics` only decide how to
-  // present one that can't render yet.
   let previewStatus: WidgetPreviewStatus;
-  if (!message) {
-    previewStatus = {status: 'ready'};
-  } else if (isResolving) {
+  if (isResolving) {
     previewStatus = {status: 'loading'};
   } else if (hasNoMetrics) {
     previewStatus = {
       status: 'invalid',
       message: t('No metrics found for the selected projects.'),
     };
-  } else {
+  } else if (message) {
     previewStatus = {status: 'invalid', message};
+  } else {
+    previewStatus = {status: 'ready'};
   }
   const organization = useOrganization();
   const location = useLocation();

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -271,14 +271,12 @@ export function WidgetPreviewContainer({
     selectedAggregate && extractTraceMetricFromColumn(selectedAggregate)
   );
 
-  // A metric auto-selects once its options are available, so a metrics widget with
-  // none picked is still resolving while the options are fetching or already loaded
-  // with results — keying off `hasMetricOptions` too (not just the fetch state)
-  // avoids flashing the error for the frame before the cached auto-select runs.
-  const isResolving =
-    isMetricsDataset &&
-    !hasSelectedMetric &&
-    (isFetchingMetricOptions || hasMetricOptions);
+  // A metric auto-selects once its options load, so a metrics widget with none
+  // picked shows loading while that fetch is in flight. Once the fetch settles the
+  // widget either resolves or falls through to an error below, so one that can never
+  // resolve — e.g. a heat map in a project with no distribution metrics — surfaces
+  // the error instead of spinning forever.
+  const isResolving = isMetricsDataset && !hasSelectedMetric && isFetchingMetricOptions;
   // The options finished loading and the selected projects have no metrics to pick.
   const hasNoMetrics =
     isMetricsDataset &&

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -265,20 +265,26 @@ export function WidgetPreviewContainer({
   const {data: metricOptions, isFetching: isFetchingMetricOptions} = useMetricOptions({
     enabled: isMetricsDataset,
   });
+  const hasMetricOptions = (metricOptions?.data?.length ?? 0) > 0;
   const selectedAggregate = getSelectedAggregate(widget);
   const hasSelectedMetric = Boolean(
     selectedAggregate && extractTraceMetricFromColumn(selectedAggregate)
   );
 
-  // A metric auto-selects once its options load, so a metrics widget with none
-  // picked is just waiting on that fetch.
-  const isResolving = isMetricsDataset && !hasSelectedMetric && isFetchingMetricOptions;
+  // A metric auto-selects once its options are available, so a metrics widget with
+  // none picked is still resolving while the options are fetching or already loaded
+  // with results — keying off `hasMetricOptions` too (not just the fetch state)
+  // avoids flashing the error for the frame before the cached auto-select runs.
+  const isResolving =
+    isMetricsDataset &&
+    !hasSelectedMetric &&
+    (isFetchingMetricOptions || hasMetricOptions);
   // The options finished loading and the selected projects have no metrics to pick.
   const hasNoMetrics =
     isMetricsDataset &&
     !hasSelectedMetric &&
     !isFetchingMetricOptions &&
-    (metricOptions?.data?.length ?? 0) === 0;
+    !hasMetricOptions;
 
   const message =
     getWidgetConfigError(widget) ??

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -261,9 +261,14 @@ export function WidgetPreviewContainer({
   const {state} = useWidgetBuilderContext();
 
   const widget = convertBuilderStateToWidget(state);
-  // A trace-metric widget with an unresolved metric will auto-select one once its
-  // options load — the same predicate getWidgetConfigError uses — so only fetch the
-  // options when we actually need to, and gate the resolving/no-metrics states on it.
+
+  // `MetricSelector` loads available metrics, and if the current widget doesn't
+  // have a selected metric, `MetricSelect` might _force_ one, in a `useEffect`.
+  // To prevent showing an error state while it's fetching, fetch data here, if
+  // needed. Show a loading screen while it's fetching. NOTE: the default
+  // aggregate for trace metrics is `sum(value)` because we don't know available
+  // metrics at render time, so a default metrics widget is invalid, which is
+  // why we need to wait for the load.
   const needsMetric =
     widget.widgetType === WidgetType.TRACEMETRICS && hasUnresolvedTraceMetric(widget);
   const {data: metricOptions, isFetching: isFetchingMetricOptions} = useMetricOptions({

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -27,10 +27,12 @@ import {useMedia} from 'sentry/utils/useMedia';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {
   DisplayType,
+  WidgetType,
   type DashboardDetails,
   type DashboardFilters,
   type Widget,
 } from 'sentry/views/dashboards/types';
+import {getWidgetConfigError} from 'sentry/views/dashboards/utils/getWidgetConfigError';
 import {animationTransitionSettings} from 'sentry/views/dashboards/widgetBuilder/components/common/animationSettings';
 import {
   DEFAULT_WIDGET_DRAG_POSITIONING,
@@ -44,13 +46,20 @@ import {
 } from 'sentry/views/dashboards/widgetBuilder/components/common/draggableUtils';
 import {WidgetBuilderFilterBar} from 'sentry/views/dashboards/widgetBuilder/components/filtersBar';
 import {WidgetBuilderSlideout} from 'sentry/views/dashboards/widgetBuilder/components/widgetBuilderSlideout';
-import {WidgetPreview} from 'sentry/views/dashboards/widgetBuilder/components/widgetPreview';
+import {
+  WidgetPreview,
+  type WidgetPreviewStatus,
+} from 'sentry/views/dashboards/widgetBuilder/components/widgetPreview';
 import {
   useWidgetBuilderContext,
   WidgetBuilderProvider,
 } from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
+import {extractTraceMetricFromColumn} from 'sentry/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate';
+import {convertBuilderStateToWidget} from 'sentry/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget';
+import {getSelectedAggregate} from 'sentry/views/dashboards/widgetBuilder/utils/getSelectedAggregate';
 import type {OnDataFetchedParams} from 'sentry/views/dashboards/widgetCard';
 import {DashboardsMEPProvider} from 'sentry/views/dashboards/widgetCard/dashboardsMEPContext';
+import {useMetricOptions} from 'sentry/views/explore/hooks/useMetricOptions';
 import {useTopOffset} from 'sentry/views/navigation/useTopOffset';
 import {MetricsDataSwitcher} from 'sentry/views/performance/landing/metricsDataSwitcher';
 
@@ -249,6 +258,45 @@ export function WidgetPreviewContainer({
   openWidgetTemplates?: boolean;
 }) {
   const {state} = useWidgetBuilderContext();
+
+  // The builder owns the preview's validity/loading decision.
+  const widget = convertBuilderStateToWidget(state);
+  const isMetricsDataset = widget.widgetType === WidgetType.TRACEMETRICS;
+  const {data: metricOptions, isFetching: isFetchingMetricOptions} = useMetricOptions({
+    enabled: isMetricsDataset,
+  });
+  const selectedAggregate = getSelectedAggregate(widget);
+  const hasSelectedMetric = Boolean(
+    selectedAggregate && extractTraceMetricFromColumn(selectedAggregate)
+  );
+
+  // A metric auto-selects once its options load, so a metrics widget with none
+  // picked is just waiting on that fetch.
+  const isResolving = isMetricsDataset && !hasSelectedMetric && isFetchingMetricOptions;
+  // The options finished loading and the selected projects have no metrics to pick.
+  const hasNoMetrics =
+    isMetricsDataset &&
+    !hasSelectedMetric &&
+    !isFetchingMetricOptions &&
+    (metricOptions?.data?.length ?? 0) === 0;
+
+  const message =
+    getWidgetConfigError(widget) ??
+    (isQueryConditionInvalid ? t("This widget's query filter is invalid.") : undefined);
+
+  let previewStatus: WidgetPreviewStatus;
+  if (isResolving) {
+    previewStatus = {status: 'loading'};
+  } else if (hasNoMetrics) {
+    previewStatus = {
+      status: 'invalid',
+      message: t('No metrics found for the selected projects.'),
+    };
+  } else if (message) {
+    previewStatus = {status: 'invalid', message};
+  } else {
+    previewStatus = {status: 'ready'};
+  }
   const organization = useOrganization();
   const location = useLocation();
   const theme = useTheme();
@@ -365,7 +413,7 @@ export function WidgetPreviewContainer({
                     <WidgetPreview
                       dashboardFilters={dashboardFilters}
                       dashboard={dashboard}
-                      isQueryConditionInvalid={isQueryConditionInvalid}
+                      previewStatus={previewStatus}
                       onDataFetched={onDataFetched}
                       shouldForceDescriptionTooltip={!isSmallScreen}
                     />

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -259,7 +259,6 @@ export function WidgetPreviewContainer({
 }) {
   const {state} = useWidgetBuilderContext();
 
-  // The builder owns the preview's validity/loading decision.
   const widget = convertBuilderStateToWidget(state);
   const isMetricsDataset = widget.widgetType === WidgetType.TRACEMETRICS;
   const {data: metricOptions, isFetching: isFetchingMetricOptions} = useMetricOptions({
@@ -277,7 +276,6 @@ export function WidgetPreviewContainer({
   // resolve — e.g. a heat map in a project with no distribution metrics — surfaces
   // the error instead of spinning forever.
   const isResolving = isMetricsDataset && !hasSelectedMetric && isFetchingMetricOptions;
-  // The options finished loading and the selected projects have no metrics to pick.
   const hasNoMetrics =
     isMetricsDataset &&
     !hasSelectedMetric &&

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -32,7 +32,10 @@ import {
   type DashboardFilters,
   type Widget,
 } from 'sentry/views/dashboards/types';
-import {getWidgetConfigError} from 'sentry/views/dashboards/utils/getWidgetConfigError';
+import {
+  getWidgetConfigError,
+  hasUnresolvedTraceMetric,
+} from 'sentry/views/dashboards/utils/getWidgetConfigError';
 import {animationTransitionSettings} from 'sentry/views/dashboards/widgetBuilder/components/common/animationSettings';
 import {
   DEFAULT_WIDGET_DRAG_POSITIONING,
@@ -54,9 +57,7 @@ import {
   useWidgetBuilderContext,
   WidgetBuilderProvider,
 } from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
-import {extractTraceMetricFromColumn} from 'sentry/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate';
 import {convertBuilderStateToWidget} from 'sentry/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget';
-import {getSelectedAggregate} from 'sentry/views/dashboards/widgetBuilder/utils/getSelectedAggregate';
 import type {OnDataFetchedParams} from 'sentry/views/dashboards/widgetCard';
 import {DashboardsMEPProvider} from 'sentry/views/dashboards/widgetCard/dashboardsMEPContext';
 import {useMetricOptions} from 'sentry/views/explore/hooks/useMetricOptions';
@@ -260,35 +261,27 @@ export function WidgetPreviewContainer({
   const {state} = useWidgetBuilderContext();
 
   const widget = convertBuilderStateToWidget(state);
-  const isMetricsDataset = widget.widgetType === WidgetType.TRACEMETRICS;
+  // A trace-metric widget with an unresolved metric will auto-select one once its
+  // options load — the same predicate getWidgetConfigError uses — so only fetch the
+  // options when we actually need to, and gate the resolving/no-metrics states on it.
+  const needsMetric =
+    widget.widgetType === WidgetType.TRACEMETRICS && hasUnresolvedTraceMetric(widget);
   const {data: metricOptions, isFetching: isFetchingMetricOptions} = useMetricOptions({
-    enabled: isMetricsDataset,
+    enabled: needsMetric,
   });
   const hasMetricOptions = (metricOptions?.data?.length ?? 0) > 0;
-  const selectedAggregate = getSelectedAggregate(widget);
-  const hasSelectedMetric = Boolean(
-    selectedAggregate && extractTraceMetricFromColumn(selectedAggregate)
-  );
 
-  // A metric auto-selects once its options load, so a metrics widget with none
-  // picked shows loading while that fetch is in flight. Once the fetch settles the
-  // widget either resolves or falls through to an error below, so one that can never
-  // resolve — e.g. a heat map in a project with no distribution metrics — surfaces
-  // the error instead of spinning forever.
-  const isResolving = isMetricsDataset && !hasSelectedMetric && isFetchingMetricOptions;
-  const hasNoMetrics =
-    isMetricsDataset &&
-    !hasSelectedMetric &&
-    !isFetchingMetricOptions &&
-    !hasMetricOptions;
+  // Loading while the options fetch is in flight; once it settles with no options
+  // the metric can never auto-select, so fall through to the error.
+  const isResolving = needsMetric && isFetchingMetricOptions;
+  const hasNoMetrics = needsMetric && !isFetchingMetricOptions && !hasMetricOptions;
 
   const message =
     getWidgetConfigError(widget) ??
     (isQueryConditionInvalid ? t("This widget's query filter is invalid.") : undefined);
 
-  // A renderable widget always wins — `isResolving`/`hasNoMetrics` only decide how to
-  // present a widget that can't render yet (e.g. an equation-mode widget has no
-  // selected metric but is perfectly valid, so it must not get stuck loading).
+  // A renderable widget always wins; `isResolving`/`hasNoMetrics` only decide how to
+  // present one that can't render yet.
   let previewStatus: WidgetPreviewStatus;
   if (!message) {
     previewStatus = {status: 'ready'};

--- a/static/app/views/dashboards/widgetBuilder/components/widgetPreview.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetPreview.spec.tsx
@@ -2,7 +2,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
+import type {DashboardDetails} from 'sentry/views/dashboards/types';
 import {WidgetPreview} from 'sentry/views/dashboards/widgetBuilder/components/widgetPreview';
 import {WidgetBuilderProvider} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 
@@ -10,38 +10,42 @@ const DASHBOARD_WIDGET_BUILDER_PATHNAME =
   '/organizations/org-slug/dashboards/new/widget/new/';
 
 describe('WidgetPreview', () => {
-  it('shows a message when a trace metrics widget has a blank equation', async () => {
+  const dashboard: DashboardDetails = {
+    id: 'new',
+    title: 'Test Dashboard',
+    createdBy: undefined,
+    dateCreated: '',
+    widgets: [],
+    projects: [],
+    filters: {},
+  };
+
+  function renderPreview(
+    previewStatus: Parameters<typeof WidgetPreview>[0]['previewStatus']
+  ) {
     render(
       <WidgetPreview
-        dashboard={{
-          id: 'new',
-          title: 'Test Dashboard',
-          createdBy: undefined,
-          dateCreated: '',
-          widgets: [],
-          projects: [],
-          filters: {},
-        }}
+        dashboard={dashboard}
         dashboardFilters={{}}
+        previewStatus={previewStatus}
       />,
       {
         organization: OrganizationFixture(),
         additionalWrapper: WidgetBuilderProvider,
         initialRouterConfig: {
-          location: {
-            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
-            query: {
-              dataset: WidgetType.TRACEMETRICS,
-              displayType: DisplayType.LINE,
-              yAxis: ['equation|'],
-            },
-          },
+          location: {pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME},
         },
       }
     );
+  }
 
-    expect(
-      await screen.findByText('Enter an equation to preview results')
-    ).toBeInTheDocument();
+  it('renders a loading state when the preview status is loading', () => {
+    renderPreview({status: 'loading'});
+    expect(screen.getByTestId('loading-placeholder')).toBeInTheDocument();
+  });
+
+  it('renders the error message when the preview status is invalid', () => {
+    renderPreview({status: 'invalid', message: 'This widget is broken.'});
+    expect(screen.getByText('This widget is broken.')).toBeInTheDocument();
   });
 });

--- a/static/app/views/dashboards/widgetBuilder/components/widgetPreview.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetPreview.tsx
@@ -1,7 +1,7 @@
 import {useState} from 'react';
 
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
-import {t} from 'sentry/locale';
+import {Placeholder} from 'sentry/components/placeholder';
 import {dedupeArray} from 'sentry/utils/dedupeArray';
 import {type Sort} from 'sentry/utils/discover/fields';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -17,7 +17,6 @@ import {
 import {usesTimeSeriesData} from 'sentry/views/dashboards/utils';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
-import {getTraceMetricAggregateSource} from 'sentry/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate';
 import {convertBuilderStateToWidget} from 'sentry/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget';
 import type {OnDataFetchedParams} from 'sentry/views/dashboards/widgetCard';
 import WidgetCard from 'sentry/views/dashboards/widgetCard';
@@ -25,13 +24,17 @@ import {WidgetLegendNameEncoderDecoder} from 'sentry/views/dashboards/widgetLege
 import {WidgetLegendSelectionState} from 'sentry/views/dashboards/widgetLegendSelectionState';
 import type {TabularColumn} from 'sentry/views/dashboards/widgets/common/types';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
-import {FieldValueKind} from 'sentry/views/discover/table/types';
+
+export type WidgetPreviewStatus =
+  | {status: 'loading'}
+  | {message: string; status: 'invalid'}
+  | {status: 'ready'};
 
 interface WidgetPreviewProps {
   dashboard: DashboardDetails;
   dashboardFilters: DashboardFilters;
-  isQueryConditionInvalid?: boolean;
   onDataFetched?: (results: OnDataFetchedParams) => void;
+  previewStatus?: WidgetPreviewStatus;
   shouldForceDescriptionTooltip?: boolean;
 }
 
@@ -40,8 +43,8 @@ const MIN_TABLE_COLUMN_WIDTH_PX = 125;
 export function WidgetPreview({
   dashboard,
   dashboardFilters,
-  isQueryConditionInvalid,
   onDataFetched,
+  previewStatus = {status: 'ready'},
   shouldForceDescriptionTooltip,
 }: WidgetPreviewProps) {
   const organization = useOrganization();
@@ -97,35 +100,21 @@ export function WidgetPreview({
     setTableWidths(widths);
   }
 
-  if (widget.widgetType === WidgetType.TRACEMETRICS) {
-    const hasBlankEquation = getTraceMetricAggregateSource(
-      state.displayType,
-      state.yAxis,
-      state.fields
-    )?.some(
-      aggregate =>
-        aggregate.kind === FieldValueKind.EQUATION && aggregate.field.trim() === ''
-    );
-    if (hasBlankEquation) {
-      return (
-        <Widget
-          Title={<Widget.WidgetTitle title={widget.title} />}
-          Visualization={
-            <Widget.WidgetError error={t('Enter an equation to preview results')} />
-          }
-          noVisualizationPadding
-        />
-      );
-    }
-  }
-
-  if (isQueryConditionInvalid) {
+  if (previewStatus.status === 'loading') {
     return (
       <Widget
         Title={<Widget.WidgetTitle title={widget.title} />}
-        Visualization={
-          <Widget.WidgetError error={t('Widget query condition is invalid.')} />
-        }
+        Visualization={<Placeholder height="100%" />}
+        noVisualizationPadding
+      />
+    );
+  }
+
+  if (previewStatus.status === 'invalid') {
+    return (
+      <Widget
+        Title={<Widget.WidgetTitle title={widget.title} />}
+        Visualization={<Widget.WidgetError error={previewStatus.message} />}
         noVisualizationPadding
       />
     );

--- a/static/app/views/dashboards/widgetBuilder/utils/hasUnresolvedTraceMetric.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils/hasUnresolvedTraceMetric.spec.tsx
@@ -1,0 +1,48 @@
+import {WidgetFixture} from 'sentry-fixture/widget';
+import {WidgetQueryFixture} from 'sentry-fixture/widgetQuery';
+
+import {hasUnresolvedTraceMetric} from 'sentry/views/dashboards/widgetBuilder/utils/hasUnresolvedTraceMetric';
+
+describe('hasUnresolvedTraceMetric', () => {
+  it('is true when an aggregate carries no metric', () => {
+    // `sum(value)` is the placeholder aggregate — no metric name/type encoded.
+    const widget = WidgetFixture({
+      queries: [WidgetQueryFixture({aggregates: ['sum(value)']})],
+    });
+
+    expect(hasUnresolvedTraceMetric(widget)).toBe(true);
+  });
+
+  it('is false when every aggregate resolves to a metric', () => {
+    const widget = WidgetFixture({
+      queries: [
+        WidgetQueryFixture({aggregates: ['sum(value,test_metric,distribution,none)']}),
+      ],
+    });
+
+    expect(hasUnresolvedTraceMetric(widget)).toBe(false);
+  });
+
+  it('is true when any query has an unresolved aggregate', () => {
+    const widget = WidgetFixture({
+      queries: [
+        WidgetQueryFixture({aggregates: ['sum(value,test_metric,distribution,none)']}),
+        WidgetQueryFixture({aggregates: ['sum(value)']}),
+      ],
+    });
+
+    expect(hasUnresolvedTraceMetric(widget)).toBe(true);
+  });
+
+  it('ignores equations, which carry no metric tuple', () => {
+    const widget = WidgetFixture({
+      queries: [
+        WidgetQueryFixture({
+          aggregates: ['sum(value,test_metric,distribution,none)', 'equation|1 + 1'],
+        }),
+      ],
+    });
+
+    expect(hasUnresolvedTraceMetric(widget)).toBe(false);
+  });
+});

--- a/static/app/views/dashboards/widgetBuilder/utils/hasUnresolvedTraceMetric.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/hasUnresolvedTraceMetric.ts
@@ -1,0 +1,18 @@
+import {explodeField, isEquation} from 'sentry/utils/discover/fields';
+import type {Widget} from 'sentry/views/dashboards/types';
+import {extractTraceMetricFromColumn} from 'sentry/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate';
+
+/**
+ * Whether any of a trace-metric widget's aggregates fail to resolve to a metric
+ * (`fn(value, name, type, unit)`). This uses the same per-aggregate predicate the
+ * metric selector's auto-select keys off (`extractTraceMetricFromColumn`), so it
+ * also answers "is a metric about to be filled in?". Equations carry no metric
+ * tuple and reference base aggregates validated on their own, so they're skipped.
+ * Callers must confirm the trace-metrics dataset first.
+ */
+export function hasUnresolvedTraceMetric(widget: Widget): boolean {
+  return widget.queries
+    .flatMap(query => query.aggregates)
+    .filter(aggregate => !isEquation(aggregate))
+    .some(aggregate => !extractTraceMetricFromColumn(explodeField({field: aggregate})));
+}

--- a/static/app/views/dashboards/widgetBuilder/utils/hasUnresolvedTraceMetric.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/hasUnresolvedTraceMetric.ts
@@ -4,11 +4,8 @@ import {extractTraceMetricFromColumn} from 'sentry/views/dashboards/widgetBuilde
 
 /**
  * Whether any of a trace-metric widget's aggregates fail to resolve to a metric
- * (`fn(value, name, type, unit)`). This uses the same per-aggregate predicate the
- * metric selector's auto-select keys off (`extractTraceMetricFromColumn`), so it
- * also answers "is a metric about to be filled in?". Equations carry no metric
- * tuple and reference base aggregates validated on their own, so they're skipped.
- * Callers must confirm the trace-metrics dataset first.
+ * (`fn(value, name, type, unit)`). Equations carry no metric tuple and
+ * reference base aggregates validated on their own, so they're skipped.
  */
 export function hasUnresolvedTraceMetric(widget: Widget): boolean {
   return widget.queries

--- a/static/app/views/dashboards/widgetCard/traceMetricsWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/traceMetricsWidgetQueries.tsx
@@ -3,7 +3,6 @@ import {useCallback, useState} from 'react';
 import type {PageFilters} from 'sentry/types/core';
 import type {Confidence} from 'sentry/types/organization';
 import type {EventsTableData} from 'sentry/utils/discover/discoverQuery';
-import {EQUATION_PREFIX, isEquation, parseFunction} from 'sentry/utils/discover/fields';
 import {getDynamicText} from 'sentry/utils/getDynamicText';
 import type {EventsTimeSeriesResponse} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import {determineSeriesSampleCountAndIsSampled} from 'sentry/views/alerts/rules/metric/utils/determineSeriesSampleCount';
@@ -109,27 +108,6 @@ function TraceMetricsWidgetQueriesSingleRequestImpl({
     });
   };
 
-  // Trace metric aggregates encode the metric name and type in the function
-  // arguments: fn(value, metricName, metricType, unit). We must wait for
-  // the metric selector to load and populate these before firing the query.
-  const disabled = widget.queries.some(
-    q =>
-      q.aggregates.length === 0 ||
-      q.aggregates.some(agg => {
-        if (isEquation(agg)) {
-          // Disable if the aggregate is empty, i.e. just the equation prefix
-          return agg === EQUATION_PREFIX;
-        }
-        const parsed = parseFunction(agg);
-        if (!parsed) {
-          return true;
-        }
-        const metricName = parsed.arguments[1];
-        const metricType = parsed.arguments[2];
-        return !metricName || !metricType;
-      })
-  );
-
   const props = useGenericWidgetQueries<SeriesResult, TableResult>({
     config,
     widget,
@@ -140,8 +118,6 @@ function TraceMetricsWidgetQueriesSingleRequestImpl({
     onDataFetchStart,
     afterFetchSeriesData,
     samplingMode: SAMPLING_MODE.NORMAL,
-    disabled,
-    loading: disabled,
     selection,
     widgetInterval,
     yBuckets,

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector/metricSelector.tsx
@@ -268,6 +268,12 @@ export function MetricSelector({
   // param. Skip options the caller disables (e.g. counters for heat maps) so we
   // don't default into an invalid selection. If every option is disabled, leave
   // the slot empty rather than selecting a metric the caller marked invalid.
+  //
+  // TODO: This runs after paint, so when options are already cached the widget
+  // builder preview renders one frame with no metric selected — briefly flashing
+  // the "missing a metric" error before this fills it in. Worth resolving the
+  // default synchronously (or otherwise closing that gap) so the preview never
+  // flashes. See newWidgetBuilder's `isResolving`.
   useEffect(() => {
     if (traceMetric.name) {
       return;


### PR DESCRIPTION
In some cases, it's possible to make a widget that's invalid but it still attempts to load its data. e.g., if an Application Metrics widget has a bad aggregate, this passes UI validation and the widget renders, but then it gets stuck in a forever loading state, since the `useQuery` that fetches the data is not `enabled` due to it being invalid. This PR cleans things up

1. Puts more validation logic into widget validation. This prevents invalid widgets from rendering at all, they show an error state with a specific error. The query doesn't even fire
2. Removes that logic from the query, no point doing it twice in the UI code
3. Adds _one_ special workaround. In the Application Metrics UI, we need to also force a _loading_ state when we're trying to load available trace metrics for backfilling an empty widget configuration

Now, the widget builder checks for the various possible states, and then passes them to the preview. This accounts for cases where we're _waiting_ for something, and for errors. The Widget Card situation is simpler, we just run validation or loading, or the display.

Closes DAIN-1806