### PR TITLE
fix(eap): stop `has:trace` erroring on UUID-backed attributes

### DIFF
--- a/src/sentry/search/eap/columns.py
+++ b/src/sentry/search/eap/columns.py
@@ -114,6 +114,13 @@ class ResolvedColumn:
                     return
             raise InvalidSearchQuery(f"{value} is an invalid value for {self.public_alias}")
 
+    def allows_value(self, value: Any) -> bool:
+        try:
+            self.validate(value)
+        except InvalidSearchQuery:
+            return False
+        return True
+
     @property
     def proto_type(self) -> AttributeKey.Type.ValueType:
         """The proto's AttributeKey type for this column"""

--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -707,9 +707,15 @@ class SearchResolver:
                     key=resolved_column.proto_definition,
                 )
             )
+            # Attributes that reject the empty string can never hold it, and comparing against it
+            # fails in snuba for the ones backed by a typed column (eg. trace id parsed as a UUID).
+            compare_to_empty_string = (
+                resolved_column.proto_definition.type == constants.STRING
+                and resolved_column.allows_value(value)
+            )
             if term.operator == "!=":
                 filters = [exists_filter]
-                if resolved_column.proto_definition.type == constants.STRING:
+                if compare_to_empty_string:
                     filters.append(
                         TraceItemFilter(
                             comparison_filter=ComparisonFilter(
@@ -725,7 +731,7 @@ class SearchResolver:
                 )
             elif term.operator == "=":
                 filters = [TraceItemFilter(not_filter=NotFilter(filters=[exists_filter]))]
-                if resolved_column.proto_definition.type == constants.STRING:
+                if compare_to_empty_string:
                     filters.append(
                         TraceItemFilter(
                             comparison_filter=ComparisonFilter(

--- a/tests/sentry/search/eap/test_spans.py
+++ b/tests/sentry/search/eap/test_spans.py
@@ -812,13 +812,6 @@ class SearchResolverQueryTest(TestCase):
                     TraceItemFilter(
                         exists_filter=ExistsFilter(key=trace_key),
                     ),
-                    TraceItemFilter(
-                        comparison_filter=ComparisonFilter(
-                            key=trace_key,
-                            op=ComparisonFilter.OP_NOT_EQUALS,
-                            value=AttributeValue(val_str=""),
-                        )
-                    ),
                 ]
             )
         )
@@ -839,10 +832,26 @@ class SearchResolverQueryTest(TestCase):
                             ]
                         )
                     ),
+                ]
+            )
+        )
+        assert having is None
+
+    def test_has_parent_span(self) -> None:
+        where, having, _ = self.resolver.resolve_query("has:parent_span")
+        parent_span_key = AttributeKey(
+            name="sentry.parent_span_id", type=AttributeKey.Type.TYPE_STRING
+        )
+        assert where == TraceItemFilter(
+            and_filter=AndFilter(
+                filters=[
+                    TraceItemFilter(
+                        exists_filter=ExistsFilter(key=parent_span_key),
+                    ),
                     TraceItemFilter(
                         comparison_filter=ComparisonFilter(
-                            key=trace_key,
-                            op=ComparisonFilter.OP_EQUALS,
+                            key=parent_span_key,
+                            op=ComparisonFilter.OP_NOT_EQUALS,
                             value=AttributeValue(val_str=""),
                         )
                     ),

--- a/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
@@ -233,6 +233,27 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase, 
         ]
         assert meta["dataset"] == self.dataset
 
+    def test_has_trace_filter(self) -> None:
+        trace_id = "1" * 32
+        logs = [
+            self.create_ourlog(
+                {"body": "foo", "trace_id": trace_id},
+                timestamp=self.ten_mins_ago,
+            ),
+        ]
+        self.store_eap_items(logs)
+        response = self.do_request(
+            {
+                "field": ["message", "trace"],
+                "query": "has:trace",
+                "project": self.project.id,
+                "dataset": self.dataset,
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        assert response.data["data"] == [{"message": "foo", "trace": trace_id}]
+
     def test_filter_timestamp(self) -> None:
         one_day_ago = before_now(days=1).replace(microsecond=0)
         three_days_ago = before_now(days=3).replace(microsecond=0)


### PR DESCRIPTION
`has:X` is desugared into `X != ""`. Snuba cannot evaluate that for an attribute stored as a UUID column: resolving `sentry.trace_id` against the empty string fails with `Not a valid UUID string` and the request 500s. `has:origin` works because `origin` is a plain string attribute.

Skip the empty-string comparison when the attribute's validator rejects the empty string. Such an attribute can never hold `""`, so the comparison never matched anything and the exists check alone is equivalent. Attributes that explicitly allow the empty string, such as `parent_span`, keep the comparison.

Also fixes `has:id` and `!has:trace`.

Closes LOGS-935.