### PR TITLE
feat(issues): Collapse Seer activity phases

### DIFF
--- a/static/app/views/issueDetails/activitySection/activityLineItem.stories.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem.stories.tsx
@@ -16,6 +16,10 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {useUser} from 'sentry/utils/useUser';
 import {ActivityLine} from 'sentry/views/issueDetails/activitySection/activityLineItem';
 import {
+  collapseSeerActivityPairs,
+  type ActivityFeedItem,
+} from 'sentry/views/issueDetails/activitySection/activityLineItem/activityFeedItem';
+import {
   ActivityLineNote,
   isActivityNote,
 } from 'sentry/views/issueDetails/activitySection/activityLineItem/note';
@@ -319,6 +323,38 @@ const seerActivities = [
   }),
 ];
 
+const collapsedSeerActivities = collapseSeerActivityPairs([
+  seerActivityAt(GroupActivityType.SEER_RCA_COMPLETED, '2025-01-01T00:12:00Z', {
+    run_id: 1,
+  }),
+  seerActivityAt(GroupActivityType.SEER_RCA_STARTED, '2025-01-01T00:00:00Z', {
+    run_id: 1,
+  }),
+  seerActivityAt(GroupActivityType.SEER_SOLUTION_COMPLETED, '2025-01-01T00:22:00Z', {
+    run_id: 2,
+  }),
+  seerActivityAt(GroupActivityType.SEER_SOLUTION_STARTED, '2025-01-01T00:12:00Z', {
+    run_id: 2,
+  }),
+  seerActivityAt(GroupActivityType.SEER_CODING_COMPLETED, '2025-01-01T00:30:00Z', {
+    run_id: 3,
+  }),
+  seerActivityAt(GroupActivityType.SEER_CODING_STARTED, '2025-01-01T00:22:00Z', {
+    run_id: 3,
+  }),
+  seerActivityAt(GroupActivityType.SEER_ITERATION_COMPLETED, '2025-01-01T00:37:00Z', {
+    pull_requests: [seerPullRequest],
+    run_id: 4,
+  }),
+  {
+    ...seerActivityAt(GroupActivityType.SEER_ITERATION_STARTED, '2025-01-01T00:30:00Z', {
+      referrer: 'github.check_suite',
+      run_id: 4,
+    }),
+    user,
+  },
+]);
+
 export default Storybook.story('Issue Activity', story => {
   const activityStory = (name: string, render: () => ReactNode) =>
     story(name, () => <ActivityStory>{render()}</ActivityStory>);
@@ -335,6 +371,9 @@ export default Storybook.story('Issue Activity', story => {
   activityStory('Issue changes', () => <ActivityExamples items={issueActivities} />);
   activityStory('Comments', () => <CommentExample />);
   activityStory('Seer', () => <ActivityExamples items={seerActivities} />);
+  activityStory('Collapsed Seer', () => (
+    <ActivityFeedExamples items={collapsedSeerActivities} />
+  ));
 });
 
 function ActivityStory({children}: {children: ReactNode}) {
@@ -398,6 +437,14 @@ function seerActivity(type: GroupActivityType, data: Record<string, unknown> = {
   return activity(type, data, null);
 }
 
+function seerActivityAt(
+  type: GroupActivityType,
+  dateCreated: string,
+  data: Record<string, unknown>
+) {
+  return {...seerActivity(type, data), dateCreated};
+}
+
 function sentryAppActivity(
   type: GroupActivityType,
   data: Record<string, unknown>,
@@ -412,21 +459,29 @@ function release(version: string, dateReleased: string) {
 
 function ActivityExamples({items}: {items: GroupActivity[]}) {
   return (
+    <ActivityFeedExamples
+      items={items.map(item => ({type: 'activity', activity: item}))}
+    />
+  );
+}
+
+function ActivityFeedExamples({items}: {items: ActivityFeedItem[]}) {
+  return (
     <ActivityList gap="md">
       {items.map((item, index) =>
-        isActivityNote(item) ? (
+        item.type === 'activity' && isActivityNote(item.activity) ? (
           <ActivityLineNote
-            key={`${item.id}-${index}`}
-            activity={item}
+            key={`${item.activity.id}-${index}`}
+            activity={item.activity}
             group={group}
             inputVariant="compact"
             onDelete={async () => {}}
           />
         ) : (
           <ActivityLine
-            key={`${item.id}-${index}`}
+            key={`${item.activity.id}-${index}`}
             group={group}
-            item={{type: 'activity', activity: item}}
+            item={item}
             timestampUnitStyle="short"
           />
         )

--- a/static/app/views/issueDetails/activitySection/activityLineItem.stories.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem.stories.tsx
@@ -426,7 +426,7 @@ function ActivityExamples({items}: {items: GroupActivity[]}) {
           <ActivityLine
             key={`${item.id}-${index}`}
             group={group}
-            item={{kind: 'activity', activity: item}}
+            item={{type: 'activity', activity: item}}
             timestampUnitStyle="short"
           />
         )

--- a/static/app/views/issueDetails/activitySection/activityLineItem.stories.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem.stories.tsx
@@ -426,7 +426,7 @@ function ActivityExamples({items}: {items: GroupActivity[]}) {
           <ActivityLine
             key={`${item.id}-${index}`}
             group={group}
-            item={item}
+            item={{kind: 'activity', activity: item}}
             timestampUnitStyle="short"
           />
         )

--- a/static/app/views/issueDetails/activitySection/activityLineItem/activityFeedItem.ts
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/activityFeedItem.ts
@@ -1,0 +1,174 @@
+import type {GroupActivity} from 'sentry/types/group';
+import {GroupActivityType, SEER_ACTIVITY_TYPES} from 'sentry/types/group';
+
+type ActivityOfType<Type extends GroupActivityType> = Extract<
+  GroupActivity,
+  {type: Type}
+>;
+
+type CollapsibleSeerCompletionActivity = ActivityOfType<
+  | GroupActivityType.SEER_RCA_COMPLETED
+  | GroupActivityType.SEER_SOLUTION_COMPLETED
+  | GroupActivityType.SEER_CODING_COMPLETED
+  | GroupActivityType.SEER_ITERATION_COMPLETED
+>;
+
+export type CollapsedSeerActivity =
+  | {
+      activity: ActivityOfType<GroupActivityType.SEER_RCA_COMPLETED>;
+      kind: 'collapsed-seer';
+      phase: 'root-cause';
+      startedActivity: ActivityOfType<GroupActivityType.SEER_RCA_STARTED>;
+    }
+  | {
+      activity: ActivityOfType<GroupActivityType.SEER_SOLUTION_COMPLETED>;
+      kind: 'collapsed-seer';
+      phase: 'planning';
+      startedActivity: ActivityOfType<GroupActivityType.SEER_SOLUTION_STARTED>;
+    }
+  | {
+      activity: ActivityOfType<GroupActivityType.SEER_CODING_COMPLETED>;
+      kind: 'collapsed-seer';
+      phase: 'coding';
+      startedActivity: ActivityOfType<GroupActivityType.SEER_CODING_STARTED>;
+    }
+  | {
+      activity: ActivityOfType<GroupActivityType.SEER_ITERATION_COMPLETED>;
+      kind: 'collapsed-seer';
+      phase: 'iteration';
+      startedActivity: ActivityOfType<GroupActivityType.SEER_ITERATION_STARTED>;
+    };
+
+export type ActivityFeedItem =
+  | {
+      activity: GroupActivity;
+      kind: 'activity';
+    }
+  | CollapsedSeerActivity;
+
+function getSeerRunId(activity: GroupActivity): number | undefined {
+  if (!('run_id' in activity.data)) {
+    return undefined;
+  }
+
+  return typeof activity.data.run_id === 'number' ? activity.data.run_id : undefined;
+}
+
+function isCollapsibleSeerCompletionActivity(
+  activity: GroupActivity
+): activity is CollapsibleSeerCompletionActivity {
+  return (
+    activity.type === GroupActivityType.SEER_RCA_COMPLETED ||
+    activity.type === GroupActivityType.SEER_SOLUTION_COMPLETED ||
+    activity.type === GroupActivityType.SEER_CODING_COMPLETED ||
+    activity.type === GroupActivityType.SEER_ITERATION_COMPLETED
+  );
+}
+
+function collapseSeerActivityPair(
+  completedActivity: CollapsibleSeerCompletionActivity,
+  startedActivity: GroupActivity
+): CollapsedSeerActivity | null {
+  const completedRunId = getSeerRunId(completedActivity);
+  if (completedRunId === undefined || completedRunId !== getSeerRunId(startedActivity)) {
+    return null;
+  }
+
+  switch (completedActivity.type) {
+    case GroupActivityType.SEER_RCA_COMPLETED:
+      return startedActivity.type === GroupActivityType.SEER_RCA_STARTED
+        ? {
+            kind: 'collapsed-seer',
+            phase: 'root-cause',
+            activity: completedActivity,
+            startedActivity,
+          }
+        : null;
+    case GroupActivityType.SEER_SOLUTION_COMPLETED:
+      return startedActivity.type === GroupActivityType.SEER_SOLUTION_STARTED
+        ? {
+            kind: 'collapsed-seer',
+            phase: 'planning',
+            activity: completedActivity,
+            startedActivity,
+          }
+        : null;
+    case GroupActivityType.SEER_CODING_COMPLETED:
+      return startedActivity.type === GroupActivityType.SEER_CODING_STARTED
+        ? {
+            kind: 'collapsed-seer',
+            phase: 'coding',
+            activity: completedActivity,
+            startedActivity,
+          }
+        : null;
+    case GroupActivityType.SEER_ITERATION_COMPLETED:
+      return startedActivity.type === GroupActivityType.SEER_ITERATION_STARTED
+        ? {
+            kind: 'collapsed-seer',
+            phase: 'iteration',
+            activity: completedActivity,
+            startedActivity,
+          }
+        : null;
+  }
+
+  return null;
+}
+
+function findCollapsedSeerActivity(
+  activities: GroupActivity[],
+  completedActivity: CollapsibleSeerCompletionActivity,
+  completedActivityIndex: number
+): {activity: CollapsedSeerActivity; startedActivityIndex: number} | null {
+  for (let index = completedActivityIndex + 1; index < activities.length; index += 1) {
+    const activity = activities[index];
+    if (!activity || !SEER_ACTIVITY_TYPES.has(activity.type)) {
+      continue;
+    }
+
+    const collapsedActivity = collapseSeerActivityPair(completedActivity, activity);
+    return collapsedActivity
+      ? {activity: collapsedActivity, startedActivityIndex: index}
+      : null;
+  }
+
+  return null;
+}
+
+/**
+ * Issue activity is ordered newest first. Collapse a completed Seer activity with the next
+ * Seer activity when it is the corresponding start event, allowing unrelated activity to
+ * remain between them. Keep the completed activity as the representative item so its marker,
+ * actor, timestamp, and result details are preserved.
+ */
+export function collapseSeerActivityPairs(
+  activities: GroupActivity[]
+): ActivityFeedItem[] {
+  const collapsedActivities: ActivityFeedItem[] = [];
+  const collapsedStartedActivityIndexes = new Set<number>();
+
+  for (let index = 0; index < activities.length; index += 1) {
+    if (collapsedStartedActivityIndexes.has(index)) {
+      continue;
+    }
+
+    const activity = activities[index];
+    if (!activity) {
+      break;
+    }
+
+    const collapsedActivity = isCollapsibleSeerCompletionActivity(activity)
+      ? findCollapsedSeerActivity(activities, activity, index)
+      : null;
+
+    if (collapsedActivity) {
+      collapsedActivities.push(collapsedActivity.activity);
+      collapsedStartedActivityIndexes.add(collapsedActivity.startedActivityIndex);
+    } else {
+      collapsedActivities.push({kind: 'activity', activity});
+    }
+  }
+
+  return collapsedActivities;
+}

--- a/static/app/views/issueDetails/activitySection/activityLineItem/activityFeedItem.ts
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/activityFeedItem.ts
@@ -6,43 +6,28 @@ type ActivityOfType<Type extends GroupActivityType> = Extract<
   {type: Type}
 >;
 
-type CollapsibleSeerCompletionActivity = ActivityOfType<
-  | GroupActivityType.SEER_RCA_COMPLETED
-  | GroupActivityType.SEER_SOLUTION_COMPLETED
-  | GroupActivityType.SEER_CODING_COMPLETED
-  | GroupActivityType.SEER_ITERATION_COMPLETED
->;
+type SeerActivityPair = {
+  [GroupActivityType.SEER_RCA_COMPLETED]: GroupActivityType.SEER_RCA_STARTED;
+  [GroupActivityType.SEER_SOLUTION_COMPLETED]: GroupActivityType.SEER_SOLUTION_STARTED;
+  [GroupActivityType.SEER_CODING_COMPLETED]: GroupActivityType.SEER_CODING_STARTED;
+  [GroupActivityType.SEER_ITERATION_COMPLETED]: GroupActivityType.SEER_ITERATION_STARTED;
+};
 
-export type CollapsedSeerActivity =
-  | {
-      activity: ActivityOfType<GroupActivityType.SEER_RCA_COMPLETED>;
-      kind: 'collapsed-seer';
-      phase: 'root-cause';
-      startedActivity: ActivityOfType<GroupActivityType.SEER_RCA_STARTED>;
-    }
-  | {
-      activity: ActivityOfType<GroupActivityType.SEER_SOLUTION_COMPLETED>;
-      kind: 'collapsed-seer';
-      phase: 'planning';
-      startedActivity: ActivityOfType<GroupActivityType.SEER_SOLUTION_STARTED>;
-    }
-  | {
-      activity: ActivityOfType<GroupActivityType.SEER_CODING_COMPLETED>;
-      kind: 'collapsed-seer';
-      phase: 'coding';
-      startedActivity: ActivityOfType<GroupActivityType.SEER_CODING_STARTED>;
-    }
-  | {
-      activity: ActivityOfType<GroupActivityType.SEER_ITERATION_COMPLETED>;
-      kind: 'collapsed-seer';
-      phase: 'iteration';
-      startedActivity: ActivityOfType<GroupActivityType.SEER_ITERATION_STARTED>;
-    };
+type CollapsedSeerActivityType = keyof SeerActivityPair;
+type CollapsibleSeerCompletionActivity = ActivityOfType<CollapsedSeerActivityType>;
+
+export type CollapsedSeerActivity = {
+  [Type in CollapsedSeerActivityType]: {
+    activity: ActivityOfType<Type>;
+    startedActivity: ActivityOfType<SeerActivityPair[Type]>;
+    type: Type;
+  };
+}[CollapsedSeerActivityType];
 
 export type ActivityFeedItem =
   | {
       activity: GroupActivity;
-      kind: 'activity';
+      type: 'activity';
     }
   | CollapsedSeerActivity;
 
@@ -78,37 +63,33 @@ function collapseSeerActivityPair(
     case GroupActivityType.SEER_RCA_COMPLETED:
       return startedActivity.type === GroupActivityType.SEER_RCA_STARTED
         ? {
-            kind: 'collapsed-seer',
-            phase: 'root-cause',
             activity: completedActivity,
             startedActivity,
+            type: completedActivity.type,
           }
         : null;
     case GroupActivityType.SEER_SOLUTION_COMPLETED:
       return startedActivity.type === GroupActivityType.SEER_SOLUTION_STARTED
         ? {
-            kind: 'collapsed-seer',
-            phase: 'planning',
             activity: completedActivity,
             startedActivity,
+            type: completedActivity.type,
           }
         : null;
     case GroupActivityType.SEER_CODING_COMPLETED:
       return startedActivity.type === GroupActivityType.SEER_CODING_STARTED
         ? {
-            kind: 'collapsed-seer',
-            phase: 'coding',
             activity: completedActivity,
             startedActivity,
+            type: completedActivity.type,
           }
         : null;
     case GroupActivityType.SEER_ITERATION_COMPLETED:
       return startedActivity.type === GroupActivityType.SEER_ITERATION_STARTED
         ? {
-            kind: 'collapsed-seer',
-            phase: 'iteration',
             activity: completedActivity,
             startedActivity,
+            type: completedActivity.type,
           }
         : null;
   }
@@ -166,7 +147,7 @@ export function collapseSeerActivityPairs(
       collapsedActivities.push(collapsedActivity.activity);
       collapsedStartedActivityIndexes.add(collapsedActivity.startedActivityIndex);
     } else {
-      collapsedActivities.push({kind: 'activity', activity});
+      collapsedActivities.push({type: 'activity', activity});
     }
   }
 

--- a/static/app/views/issueDetails/activitySection/activityLineItem/activityFeedItem.ts
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/activityFeedItem.ts
@@ -6,14 +6,15 @@ type ActivityOfType<Type extends GroupActivityType> = Extract<
   {type: Type}
 >;
 
-type SeerActivityPair = {
-  [GroupActivityType.SEER_RCA_COMPLETED]: GroupActivityType.SEER_RCA_STARTED;
-  [GroupActivityType.SEER_SOLUTION_COMPLETED]: GroupActivityType.SEER_SOLUTION_STARTED;
-  [GroupActivityType.SEER_CODING_COMPLETED]: GroupActivityType.SEER_CODING_STARTED;
-  [GroupActivityType.SEER_ITERATION_COMPLETED]: GroupActivityType.SEER_ITERATION_STARTED;
-};
+const SEER_ACTIVITY_PAIRS = {
+  [GroupActivityType.SEER_RCA_COMPLETED]: GroupActivityType.SEER_RCA_STARTED,
+  [GroupActivityType.SEER_SOLUTION_COMPLETED]: GroupActivityType.SEER_SOLUTION_STARTED,
+  [GroupActivityType.SEER_CODING_COMPLETED]: GroupActivityType.SEER_CODING_STARTED,
+  [GroupActivityType.SEER_ITERATION_COMPLETED]: GroupActivityType.SEER_ITERATION_STARTED,
+} as const;
 
-type CollapsedSeerActivityType = keyof SeerActivityPair;
+type SeerActivityPair = typeof SEER_ACTIVITY_PAIRS;
+type CollapsedSeerActivityType = keyof typeof SEER_ACTIVITY_PAIRS;
 type CollapsibleSeerCompletionActivity = ActivityOfType<CollapsedSeerActivityType>;
 
 export type CollapsedSeerActivity = {
@@ -42,12 +43,7 @@ function getSeerRunId(activity: GroupActivity): number | undefined {
 function isCollapsibleSeerCompletionActivity(
   activity: GroupActivity
 ): activity is CollapsibleSeerCompletionActivity {
-  return (
-    activity.type === GroupActivityType.SEER_RCA_COMPLETED ||
-    activity.type === GroupActivityType.SEER_SOLUTION_COMPLETED ||
-    activity.type === GroupActivityType.SEER_CODING_COMPLETED ||
-    activity.type === GroupActivityType.SEER_ITERATION_COMPLETED
-  );
+  return activity.type in SEER_ACTIVITY_PAIRS;
 }
 
 function collapseSeerActivityPair(
@@ -121,7 +117,7 @@ function findCollapsedSeerActivity(
  * Issue activity is ordered newest first. Collapse a completed Seer activity with the next
  * Seer activity when it is the corresponding start event, allowing unrelated activity to
  * remain between them. Keep the completed activity as the representative item so its marker,
- * actor, timestamp, and result details are preserved.
+ * timestamp, and result details are preserved.
  */
 export function collapseSeerActivityPairs(
   activities: GroupActivity[]

--- a/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem.tsx
@@ -158,7 +158,7 @@ export function getCompactGroupActivityItem({
   const issuesLink = `/organizations/${organization.slug}/issues/`;
   const activityContext = {id: activity.id, type: activity.type};
   const seerActivityDuration =
-    item.kind === 'collapsed-seer' ? getSeerActivityDuration(item) : null;
+    item.type === 'activity' ? null : getSeerActivityDuration(item);
 
   switch (activity.type) {
     case GroupActivityType.NOTE:

--- a/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem.tsx
@@ -148,6 +148,22 @@ function getSeerActivityDuration(
   ) : null;
 }
 
+function getSeerIterationReferrer(referrer: string | undefined) {
+  if (referrer === 'github.check_suite') {
+    return t('after CI failed');
+  }
+
+  return referrer?.startsWith('github.') ? t('from GitHub') : null;
+}
+
+function getCollapsedSeerIterationReferrer(item: ActivityFeedItem) {
+  if (item.type !== GroupActivityType.SEER_ITERATION_COMPLETED) {
+    return null;
+  }
+
+  return getSeerIterationReferrer(item.startedActivity.data.referrer);
+}
+
 export function getCompactGroupActivityItem({
   item,
   organization,
@@ -519,28 +535,25 @@ export function getCompactGroupActivityItem({
       const {referrer} = activity.data;
       return {
         title: t('Pull request iteration started'),
-        details:
-          referrer === 'github.check_suite'
-            ? t('after CI failed')
-            : referrer?.startsWith('github.')
-              ? t('from GitHub')
-              : null,
+        details: getSeerIterationReferrer(referrer),
       };
     }
     case GroupActivityType.SEER_ITERATION_COMPLETED: {
       const pullRequest = activity.data.pull_requests?.[0];
       const provider = pullRequest ? getProviderName(pullRequest.provider) : null;
-      let details: React.ReactNode = null;
+      const referrer = getCollapsedSeerIterationReferrer(item);
+      let details: React.ReactNode = referrer;
 
-      if (provider && seerActivityDuration) {
-        details = tct('on [provider] in [duration]', {
-          provider,
-          duration: seerActivityDuration,
-        });
-      } else if (provider) {
+      if (!details && provider) {
         details = tct('on [provider]', {provider});
-      } else if (seerActivityDuration) {
-        details = tct('in [duration]', {duration: seerActivityDuration});
+      }
+      if (seerActivityDuration) {
+        details = details
+          ? tct('[details] in [duration]', {
+              details,
+              duration: seerActivityDuration,
+            })
+          : tct('in [duration]', {duration: seerActivityDuration});
       }
 
       return {

--- a/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem.tsx
@@ -28,6 +28,7 @@ import {getResolvedInCommitDetails} from './compactActivityItem/commitDetails';
 import {getProviderName} from './compactActivityItem/provider';
 import {getResolvedInReleaseDetails} from './compactActivityItem/releaseDetails';
 import type {CompactGroupActivityItem} from './compactActivityItem/types';
+import type {ActivityFeedItem, CollapsedSeerActivity} from './activityFeedItem';
 import {getArchiveDetails} from './archiveDetails';
 
 export type {CompactGroupActivityItem} from './compactActivityItem/types';
@@ -125,20 +126,39 @@ function getPriorityDetails(
 }
 
 interface GetCompactGroupActivityItemParams {
-  activity: GroupActivity;
   issueCategory: IssueCategory;
+  item: ActivityFeedItem;
   organization: Organization;
   project: Project;
 }
 
+const MINIMUM_SEER_ACTIVITY_DURATION_SECONDS = 5 * 60;
+
+function getSeerActivityDuration(
+  activity: CollapsedSeerActivity
+): React.ReactNode | null {
+  const durationSeconds =
+    (new Date(activity.activity.dateCreated).getTime() -
+      new Date(activity.startedActivity.dateCreated).getTime()) /
+    1000;
+
+  return Number.isFinite(durationSeconds) &&
+    durationSeconds >= MINIMUM_SEER_ACTIVITY_DURATION_SECONDS ? (
+    <Duration seconds={durationSeconds} />
+  ) : null;
+}
+
 export function getCompactGroupActivityItem({
-  activity,
+  item,
   organization,
   project,
   issueCategory,
 }: GetCompactGroupActivityItemParams): CompactGroupActivityItem {
+  const {activity} = item;
   const issuesLink = `/organizations/${organization.slug}/issues/`;
   const activityContext = {id: activity.id, type: activity.type};
+  const seerActivityDuration =
+    item.kind === 'collapsed-seer' ? getSeerActivityDuration(item) : null;
 
   switch (activity.type) {
     case GroupActivityType.NOTE:
@@ -454,6 +474,9 @@ export function getCompactGroupActivityItem({
     case GroupActivityType.SEER_RCA_COMPLETED:
       return {
         title: t('Root cause found'),
+        details: seerActivityDuration
+          ? tct('in [duration]', {duration: seerActivityDuration})
+          : null,
       };
     case GroupActivityType.SEER_SOLUTION_STARTED:
       return {
@@ -462,6 +485,9 @@ export function getCompactGroupActivityItem({
     case GroupActivityType.SEER_SOLUTION_COMPLETED:
       return {
         title: t('Plan created'),
+        details: seerActivityDuration
+          ? tct('in [duration]', {duration: seerActivityDuration})
+          : null,
       };
     case GroupActivityType.SEER_CODING_STARTED:
       return {
@@ -470,6 +496,9 @@ export function getCompactGroupActivityItem({
     case GroupActivityType.SEER_CODING_COMPLETED:
       return {
         title: t('Code changes suggested'),
+        details: seerActivityDuration
+          ? tct('in [duration]', {duration: seerActivityDuration})
+          : null,
       };
     case GroupActivityType.SEER_PR_CREATED: {
       const pullRequest = activity.data.pull_requests?.[0];
@@ -500,17 +529,27 @@ export function getCompactGroupActivityItem({
     }
     case GroupActivityType.SEER_ITERATION_COMPLETED: {
       const pullRequest = activity.data.pull_requests?.[0];
+      const provider = pullRequest ? getProviderName(pullRequest.provider) : null;
+      let details: React.ReactNode = null;
+
+      if (provider && seerActivityDuration) {
+        details = tct('on [provider] in [duration]', {
+          provider,
+          duration: seerActivityDuration,
+        });
+      } else if (provider) {
+        details = tct('on [provider]', {provider});
+      } else if (seerActivityDuration) {
+        details = tct('in [duration]', {duration: seerActivityDuration});
+      }
+
       return {
         title: pullRequest
           ? tct('Pull request [pullRequest] updated', {
               pullRequest: <SeerPullRequestChip pullRequest={pullRequest} />,
             })
           : t('Pull request updated'),
-        details: pullRequest
-          ? tct('on [provider]', {
-              provider: getProviderName(pullRequest.provider),
-            })
-          : null,
+        details,
       };
     }
     case GroupActivityType.TRIGGER_AUTOFIX:

--- a/static/app/views/issueDetails/activitySection/activityLineItem/index.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/index.tsx
@@ -1,9 +1,10 @@
 import {useMemo} from 'react';
 
 import {TimeSince} from 'sentry/components/timeSince';
-import type {Group, GroupActivity} from 'sentry/types/group';
+import type {Group} from 'sentry/types/group';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
+import type {ActivityFeedItem} from './activityFeedItem';
 import {ActivityLineBody} from './body';
 import {getCompactGroupActivityItem} from './compactActivityItem';
 import {ActivityLineHeadline, ActivityLineRow} from './layout';
@@ -11,7 +12,7 @@ import {ActivityLineMarker} from './progressMarker';
 
 interface ActivityLineProps {
   group: Group;
-  item: GroupActivity;
+  item: ActivityFeedItem;
   timestampUnitStyle?: React.ComponentProps<typeof TimeSince>['unitStyle'];
 }
 
@@ -19,21 +20,24 @@ export function ActivityLine({item, group, timestampUnitStyle}: ActivityLineProp
   const organization = useOrganization();
   const showProgress = organization.features.includes('issue-activity-progress');
   const {issueCategory, project} = group;
+  const {activity} = item;
   const compactItem = useMemo(
     () =>
       getCompactGroupActivityItem({
-        activity: item,
+        item,
         organization,
         project,
         issueCategory,
       }),
     [item, issueCategory, organization, project]
   );
-  const timestamp = <TimeSince date={item.dateCreated} unitStyle={timestampUnitStyle} />;
+  const timestamp = (
+    <TimeSince date={activity.dateCreated} unitStyle={timestampUnitStyle} />
+  );
 
   return (
     <ActivityLineRow>
-      <ActivityLineMarker item={item} showProgress={showProgress} />
+      <ActivityLineMarker item={activity} showProgress={showProgress} />
       <ActivityLineHeadline
         title={compactItem.title}
         details={compactItem.details}

--- a/static/app/views/issueDetails/activitySection/activityLineItem/index.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/index.tsx
@@ -1,7 +1,7 @@
 import {useMemo} from 'react';
 
 import {TimeSince} from 'sentry/components/timeSince';
-import type {Group} from 'sentry/types/group';
+import {GroupActivityType, type Group} from 'sentry/types/group';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 import type {ActivityFeedItem} from './activityFeedItem';
@@ -34,10 +34,18 @@ export function ActivityLine({item, group, timestampUnitStyle}: ActivityLineProp
   const timestamp = (
     <TimeSince date={activity.dateCreated} unitStyle={timestampUnitStyle} />
   );
+  const actorActivity =
+    item.type === GroupActivityType.SEER_ITERATION_COMPLETED
+      ? item.startedActivity
+      : activity;
 
   return (
     <ActivityLineRow>
-      <ActivityLineMarker item={activity} showProgress={showProgress} />
+      <ActivityLineMarker
+        actorItem={actorActivity}
+        item={activity}
+        showProgress={showProgress}
+      />
       <ActivityLineHeadline
         title={compactItem.title}
         details={compactItem.details}

--- a/static/app/views/issueDetails/activitySection/activityLineItem/progressMarker/index.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/progressMarker/index.tsx
@@ -11,22 +11,26 @@ import {ActivityProgressMarker} from './progressMarker';
 import {getActivityMarkerState} from './variant';
 
 export function ActivityLineMarker({
+  actorItem,
   item,
   showProgress,
 }: {
   item: GroupActivity;
   showProgress: boolean;
+  actorItem?: GroupActivity;
 }) {
+  const activityActor = actorItem ?? item;
+
   return (
     <LeadingCells>
       <MarkerCell>
         {showProgress ? (
           <ActivityProgressMarker state={getActivityMarkerState(item)} />
         ) : (
-          (renderActivityLineActor(item) ?? <ActivityLineDot />)
+          (renderActivityLineActor(activityActor) ?? <ActivityLineDot />)
         )}
       </MarkerCell>
-      {showProgress ? <ActivityLineActor item={item} /> : null}
+      {showProgress ? <ActivityLineActor item={activityActor} /> : null}
     </LeadingCells>
   );
 }

--- a/static/app/views/issueDetails/activitySection/index.spec.tsx
+++ b/static/app/views/issueDetails/activitySection/index.spec.tsx
@@ -1605,6 +1605,62 @@ describe('ActivitySection', () => {
     expect(await screen.findByText('f7f395d')).toBeInTheDocument();
   });
 
+  it('hides an adjacent Seer creation activity for the same pull request', async () => {
+    const repository = RepositoryFixture({name: 'example/repository'});
+    const pullRequest = PullRequestFixture({
+      externalUrl: 'https://github.com/example/repository/pull/1234',
+      repository,
+    });
+    const activityGroup = GroupFixture({
+      activity: [
+        {
+          type: GroupActivityType.SET_RESOLVED_IN_PULL_REQUEST,
+          id: 'referenced-in-pull-request',
+          dateCreated: '2020-01-01T00:00:03Z',
+          data: {pullRequest},
+          user: null,
+        },
+        {
+          type: GroupActivityType.SEER_PR_CREATED,
+          id: 'seer-pull-request-created',
+          dateCreated: '2020-01-01T00:00:00Z',
+          data: {
+            run_id: 123,
+            pull_requests: [
+              {
+                provider: 'github',
+                repo_name: repository.name,
+                pull_request: {
+                  pr_number: 1234,
+                  pr_url: pullRequest.externalUrl,
+                },
+              },
+            ],
+          },
+          user: null,
+        },
+      ],
+      project,
+    });
+
+    render(
+      <GroupDataContextProvider group={activityGroup} project={activityGroup.project}>
+        <ActivitySection group={activityGroup} />
+      </GroupDataContextProvider>,
+      {
+        organization: OrganizationFixture({
+          features: [
+            'display-seer-actions-as-issue-activities',
+            'issue-activity-feed-v2',
+          ],
+        }),
+      }
+    );
+
+    expect(await screen.findByText('Referenced in pull request')).toBeInTheDocument();
+    expect(screen.getAllByRole('link', {name: `#${pullRequest.id}`})).toHaveLength(1);
+  });
+
   it('prefers commit repository details for resolved commit activity line items', async () => {
     const commitRepository = RepositoryFixture({
       name: 'getsentry/sentry',
@@ -2055,7 +2111,7 @@ describe('ActivitySection', () => {
             iteration_index: 1,
             referrer: 'github.check_suite',
           },
-          user: null,
+          user,
         },
       ],
       project,
@@ -2075,8 +2131,9 @@ describe('ActivitySection', () => {
       {organization: org}
     );
     expect(await screen.findByTestId('activity-timeline')).toHaveTextContent(
-      'Pull request #42 updated on GitHub'
+      'Pull request #42 updated after CI failed'
     );
+    expect(screen.getByTestId('user-activity-actor')).toBeInTheDocument();
     expect(screen.queryByText('1 second')).not.toBeInTheDocument();
     expect(screen.queryByText('Pull request iteration started')).not.toBeInTheDocument();
     expect(screen.getByRole('link', {name: '#42'})).toHaveAttribute(

--- a/static/app/views/issueDetails/activitySection/index.spec.tsx
+++ b/static/app/views/issueDetails/activitySection/index.spec.tsx
@@ -1783,6 +1783,135 @@ describe('ActivitySection', () => {
     expect(screen.getByText('Autofix was triggered from Slack')).toBeInTheDocument();
   });
 
+  it('collapses Seer activity pairs across other activity in the v2 feed', async () => {
+    const seerGroup = GroupFixture({
+      id: '1343',
+      activity: [
+        {
+          type: GroupActivityType.SEER_CODING_COMPLETED,
+          id: 'seer-coding-completed',
+          dateCreated: '2020-01-01T00:30:00Z',
+          data: {run_id: 123},
+          user: null,
+        },
+        {
+          type: GroupActivityType.SEER_CODING_STARTED,
+          id: 'seer-coding-started',
+          dateCreated: '2020-01-01T00:20:00Z',
+          data: {run_id: 123},
+          user: null,
+        },
+        {
+          type: GroupActivityType.SEER_SOLUTION_COMPLETED,
+          id: 'seer-solution-completed',
+          dateCreated: '2020-01-01T00:15:00Z',
+          data: {run_id: 123},
+          user: null,
+        },
+        {
+          type: GroupActivityType.SEER_SOLUTION_STARTED,
+          id: 'seer-solution-started',
+          dateCreated: '2020-01-01T00:09:00Z',
+          data: {run_id: 123},
+          user: null,
+        },
+        {
+          type: GroupActivityType.SEER_RCA_COMPLETED,
+          id: 'seer-rca-completed',
+          dateCreated: '2020-01-01T00:05:00Z',
+          data: {run_id: 123},
+          user: null,
+        },
+        {
+          type: GroupActivityType.NOTE,
+          id: 'activity-during-rca',
+          dateCreated: '2020-01-01T00:02:00Z',
+          data: {text: 'Checked during analysis'},
+          user,
+        },
+        {
+          type: GroupActivityType.SEER_RCA_STARTED,
+          id: 'seer-rca-started',
+          dateCreated: '2020-01-01T00:00:00Z',
+          data: {run_id: 123},
+          user: null,
+        },
+      ],
+      project,
+    });
+
+    render(
+      <GroupDataContextProvider group={seerGroup} project={seerGroup.project}>
+        <ActivitySection group={seerGroup} variant="standalone" />
+      </GroupDataContextProvider>,
+      {
+        organization: OrganizationFixture({
+          features: [
+            'display-seer-actions-as-issue-activities',
+            'issue-activity-feed-v2',
+          ],
+        }),
+      }
+    );
+
+    const timeline = await screen.findByTestId('activity-timeline');
+    expect(timeline).toHaveTextContent('Root cause found in 5 minutes');
+    expect(timeline).toHaveTextContent('Plan created in 6 minutes');
+    expect(timeline).toHaveTextContent('Code changes suggested in 10 minutes');
+    expect(timeline).toHaveTextContent('Checked during analysis');
+    expect(screen.queryByText('Root cause analysis started')).not.toBeInTheDocument();
+    expect(screen.queryByText('Plan started')).not.toBeInTheDocument();
+    expect(screen.queryByText('Code changes started')).not.toBeInTheDocument();
+  });
+
+  it('does not collapse a Seer pair across another Seer activity', async () => {
+    const seerGroup = GroupFixture({
+      id: '1343',
+      activity: [
+        {
+          type: GroupActivityType.SEER_RCA_COMPLETED,
+          id: 'seer-rca-completed',
+          dateCreated: '2020-01-01T00:10:00Z',
+          data: {run_id: 123},
+          user: null,
+        },
+        {
+          type: GroupActivityType.SEER_SOLUTION_STARTED,
+          id: 'seer-solution-started',
+          dateCreated: '2020-01-01T00:06:00Z',
+          data: {run_id: 123},
+          user: null,
+        },
+        {
+          type: GroupActivityType.SEER_RCA_STARTED,
+          id: 'seer-rca-started',
+          dateCreated: '2020-01-01T00:00:00Z',
+          data: {run_id: 123},
+          user: null,
+        },
+      ],
+      project,
+    });
+
+    render(
+      <GroupDataContextProvider group={seerGroup} project={seerGroup.project}>
+        <ActivitySection group={seerGroup} variant="standalone" />
+      </GroupDataContextProvider>,
+      {
+        organization: OrganizationFixture({
+          features: [
+            'display-seer-actions-as-issue-activities',
+            'issue-activity-feed-v2',
+          ],
+        }),
+      }
+    );
+
+    expect(await screen.findByText('Root cause found')).toBeInTheDocument();
+    expect(screen.getByText('Root cause analysis started')).toBeInTheDocument();
+    expect(screen.getByText('Plan started')).toBeInTheDocument();
+  });
+
   it('hides Seer activity when feature flag is disabled', () => {
     const seerGroup = GroupFixture({
       id: '1343',
@@ -1816,6 +1945,41 @@ describe('ActivitySection', () => {
     ).not.toBeInTheDocument();
     expect(screen.queryByText('Autofix')).not.toBeInTheDocument();
     expect(screen.queryByText('Autofix was triggered')).not.toBeInTheDocument();
+  });
+
+  it('does not collapse hidden Seer activities in the v2 feed', () => {
+    const seerGroup = GroupFixture({
+      id: '1343',
+      activity: [
+        {
+          type: GroupActivityType.SEER_RCA_COMPLETED,
+          id: 'hidden-seer-rca-completed',
+          dateCreated: '2020-01-01T00:00:15Z',
+          data: {run_id: 123},
+          user: null,
+        },
+        {
+          type: GroupActivityType.SEER_RCA_STARTED,
+          id: 'hidden-seer-rca-started',
+          dateCreated: '2020-01-01T00:00:00Z',
+          data: {run_id: 123},
+          user: null,
+        },
+      ],
+      project,
+    });
+
+    render(
+      <GroupDataContextProvider group={seerGroup} project={seerGroup.project}>
+        <ActivitySection group={seerGroup} />
+      </GroupDataContextProvider>,
+      {
+        organization: OrganizationFixture({features: ['issue-activity-feed-v2']}),
+      }
+    );
+
+    expect(screen.queryByText('Root cause found')).not.toBeInTheDocument();
+    expect(screen.queryByText('Root cause analysis started')).not.toBeInTheDocument();
   });
 
   it('does not render Seer PR created activity in timeline', () => {
@@ -1858,7 +2022,7 @@ describe('ActivitySection', () => {
     expect(screen.queryByText('Pull Request Created')).not.toBeInTheDocument();
   });
 
-  it('renders Seer PR iteration activity when feature flag is enabled', async () => {
+  it('collapses Seer PR iteration activity when feature flag is enabled', async () => {
     const seerIterationGroup = GroupFixture({
       id: '1346',
       activity: [
@@ -1910,8 +2074,11 @@ describe('ActivitySection', () => {
       </GroupDataContextProvider>,
       {organization: org}
     );
-    expect(await screen.findByText('Pull request iteration started')).toBeInTheDocument();
-    expect(screen.getByText('after CI failed')).toBeInTheDocument();
+    expect(await screen.findByTestId('activity-timeline')).toHaveTextContent(
+      'Pull request #42 updated on GitHub'
+    );
+    expect(screen.queryByText('1 second')).not.toBeInTheDocument();
+    expect(screen.queryByText('Pull request iteration started')).not.toBeInTheDocument();
     expect(screen.getByRole('link', {name: '#42'})).toHaveAttribute(
       'href',
       'https://github.com/org/repo/pull/42'

--- a/static/app/views/issueDetails/activitySection/index.tsx
+++ b/static/app/views/issueDetails/activitySection/index.tsx
@@ -316,7 +316,7 @@ export function ActivitySection({
   ).filter(item => !filterComments || item.type === GroupActivityType.NOTE);
   const displayedActivities: ActivityFeedItem[] = useActivityLineItems
     ? collapseSeerActivityPairs(filteredActivities)
-    : filteredActivities.map(activity => ({kind: 'activity', activity}));
+    : filteredActivities.map(activity => ({type: 'activity', activity}));
   const inputVariant = variant === 'sidebar' ? 'compact' : 'full';
   const timestampUnitStyle = variant === 'sidebar' ? 'short' : undefined;
 

--- a/static/app/views/issueDetails/activitySection/index.tsx
+++ b/static/app/views/issueDetails/activitySection/index.tsx
@@ -22,6 +22,8 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useTeamsById} from 'sentry/utils/useTeamsById';
 import {ActivityLine} from 'sentry/views/issueDetails/activitySection/activityLineItem';
+import type {ActivityFeedItem} from 'sentry/views/issueDetails/activitySection/activityLineItem/activityFeedItem';
+import {collapseSeerActivityPairs} from 'sentry/views/issueDetails/activitySection/activityLineItem/activityFeedItem';
 import {
   ActivityLineNote,
   isActivityNote,
@@ -41,7 +43,7 @@ interface TimelineItemProps {
   group: Group;
   handleDelete: (item: GroupActivity) => Promise<void>;
   inputVariant: 'compact' | 'full';
-  item: GroupActivity;
+  item: ActivityFeedItem;
   size: 'sm' | 'md';
   teams: Team[];
   onCommentEdited?: (activity: GroupActivity[]) => void;
@@ -60,16 +62,17 @@ function TimelineItem({
 }: TimelineItemProps) {
   const organization = useOrganization();
   const useActivityLineItems = organization.features.includes('issue-activity-feed-v2');
+  const {activity} = item;
 
   if (useActivityLineItems) {
-    if (isActivityNote(item)) {
+    if (isActivityNote(activity)) {
       // Keep note mutations wired from ActivitySection until the v2 note API settles.
       return (
         <ActivityLineNote
-          activity={item}
+          activity={activity}
           group={group}
           inputVariant={inputVariant}
-          onDelete={() => handleDelete(item)}
+          onDelete={() => handleDelete(activity)}
           onCommentEdited={onCommentEdited}
           timestampUnitStyle={timestampUnitStyle}
         />
@@ -83,7 +86,7 @@ function TimelineItem({
 
   return (
     <LegacyTimelineItemWithEditing
-      item={item}
+      item={activity}
       handleDelete={handleDelete}
       onCommentEdited={onCommentEdited}
       group={group}
@@ -95,7 +98,9 @@ function TimelineItem({
   );
 }
 
-function LegacyTimelineItemWithEditing(props: TimelineItemProps) {
+type LegacyTimelineItemProps = Omit<TimelineItemProps, 'item'> & {item: GroupActivity};
+
+function LegacyTimelineItemWithEditing(props: LegacyTimelineItemProps) {
   const [editing, setEditing] = useState(false);
 
   return <LegacyTimelineItem {...props} editing={editing} setEditing={setEditing} />;
@@ -112,17 +117,9 @@ function LegacyTimelineItem({
   timestampUnitStyle,
   editing,
   setEditing,
-}: {
+}: LegacyTimelineItemProps & {
   editing: boolean;
-  group: Group;
-  handleDelete: (item: GroupActivity) => Promise<void>;
-  inputVariant: 'compact' | 'full';
-  item: GroupActivity;
   setEditing: (editing: boolean) => void;
-  size: 'sm' | 'md';
-  teams: Team[];
-  onCommentEdited?: (activity: GroupActivity[]) => void;
-  timestampUnitStyle?: React.ComponentProps<typeof TimeSince>['unitStyle'];
 }) {
   const organization = useOrganization();
   const {title, message} = getGroupActivityItem(
@@ -317,17 +314,20 @@ export function ActivitySection({
   const filteredActivities = removeAdjacentDuplicatePullRequestActivities(
     visibleActivities
   ).filter(item => !filterComments || item.type === GroupActivityType.NOTE);
+  const displayedActivities: ActivityFeedItem[] = useActivityLineItems
+    ? collapseSeerActivityPairs(filteredActivities)
+    : filteredActivities.map(activity => ({kind: 'activity', activity}));
   const inputVariant = variant === 'sidebar' ? 'compact' : 'full';
   const timestampUnitStyle = variant === 'sidebar' ? 'short' : undefined;
 
-  const renderActivityItem = (item: GroupActivity) => (
+  const renderActivityItem = (item: ActivityFeedItem) => (
     <TimelineItem
       item={item}
       handleDelete={handleDelete}
       onCommentEdited={onCommentEdited}
       group={group}
       teams={teams}
-      key={item.id}
+      key={item.activity.id}
       size={size}
       inputVariant={inputVariant}
       timestampUnitStyle={timestampUnitStyle}
@@ -354,11 +354,11 @@ export function ActivitySection({
     />
   );
 
-  const timeline = renderActivityList(filteredActivities.map(renderActivityItem));
+  const timeline = renderActivityList(displayedActivities.map(renderActivityItem));
   const hiddenActivityCount =
-    filteredActivities.length >= 5 ? filteredActivities.length - 3 : 0;
+    displayedActivities.length >= 5 ? displayedActivities.length - 3 : 0;
   const sidebarVisibleActivities =
-    hiddenActivityCount > 0 ? filteredActivities.slice(0, 3) : filteredActivities;
+    hiddenActivityCount > 0 ? displayedActivities.slice(0, 3) : displayedActivities;
   const sidebarActivityItems = (
     <Fragment>
       {sidebarVisibleActivities.map(renderActivityItem)}

--- a/static/app/views/issueDetails/activitySection/index.tsx
+++ b/static/app/views/issueDetails/activitySection/index.tsx
@@ -13,8 +13,12 @@ import {Timeline} from 'sentry/components/timeline';
 import {TimeSince} from 'sentry/components/timeSince';
 import {IconEllipsis} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import type {Group, GroupActivity} from 'sentry/types/group';
-import {GroupActivityType, SEER_ACTIVITY_TYPES} from 'sentry/types/group';
+import {
+  GroupActivityType,
+  SEER_ACTIVITY_TYPES,
+  type Group,
+  type GroupActivity,
+} from 'sentry/types/group';
 import type {Team} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {uniqueId} from 'sentry/utils/guid';
@@ -22,8 +26,10 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useTeamsById} from 'sentry/utils/useTeamsById';
 import {ActivityLine} from 'sentry/views/issueDetails/activitySection/activityLineItem';
-import type {ActivityFeedItem} from 'sentry/views/issueDetails/activitySection/activityLineItem/activityFeedItem';
-import {collapseSeerActivityPairs} from 'sentry/views/issueDetails/activitySection/activityLineItem/activityFeedItem';
+import {
+  collapseSeerActivityPairs,
+  type ActivityFeedItem,
+} from 'sentry/views/issueDetails/activitySection/activityLineItem/activityFeedItem';
 import {
   ActivityLineNote,
   isActivityNote,
@@ -233,6 +239,23 @@ function isDuplicatePullRequestActivity(
       return (
         pullRequest.id === adjacentPullRequest.id &&
         pullRequest.repository.id === adjacentPullRequest.repository.id
+      );
+    }
+    case GroupActivityType.SEER_PR_CREATED: {
+      if (adjacentActivity?.type !== GroupActivityType.SET_RESOLVED_IN_PULL_REQUEST) {
+        return false;
+      }
+
+      const adjacentPullRequest = adjacentActivity.data.pullRequest;
+      if (!adjacentPullRequest) {
+        return false;
+      }
+
+      return Boolean(
+        activity.data.pull_requests?.some(
+          pullRequest =>
+            pullRequest.pull_request.pr_url === adjacentPullRequest.externalUrl
+        )
       );
     }
     default:


### PR DESCRIPTION
Collapse matching Seer start/completion events into one compact activity

before

<img width="650" height="375" alt="image" src="https://github.com/user-attachments/assets/52ef5ab6-f894-460f-bdda-78f0ce95a41b" />


after

<img width="539" height="231" alt="image" src="https://github.com/user-attachments/assets/a2325406-962a-4db4-be43-b94c961581c0" />

was testing with [this issue](https://sentry.sentry.io/issues/7322664106/activity/)