### PR TITLE
ref(autofix): Resolve PR link labels in one place

### DIFF
--- a/static/app/components/events/autofix/pullRequests.ts
+++ b/static/app/components/events/autofix/pullRequests.ts
@@ -1,0 +1,66 @@
+import {t} from 'sentry/locale';
+import type {
+  ExplorerCodingAgentState,
+  RepoPRState,
+} from 'sentry/views/seerExplorer/types';
+
+type CodingAgentResult = NonNullable<ExplorerCodingAgentState['results']>[number];
+
+/**
+ * A link to a pull request an autofix run produced, resolved from either of the two
+ * shapes Seer reports one in so that every surface renders the same label.
+ */
+interface AutofixResultLink {
+  label: string;
+  url: string;
+}
+
+/** The PR Seer opened for this repo, or null if there isn't a finished one. */
+export function getRepoPullRequestLink(state: RepoPRState): AutofixResultLink | null {
+  if (
+    state.pr_creation_status !== 'completed' ||
+    !state.pr_url ||
+    !state.pr_number ||
+    !state.repo_name
+  ) {
+    return null;
+  }
+
+  return {
+    label: t('View %s#%s', state.repo_name, state.pr_number),
+    url: state.pr_url,
+  };
+}
+
+/**
+ * What a coding agent produced, or null if it reported no URL.
+ *
+ * `auto_create_pr=false` pushes a branch instead of opening a PR and `pr_url` holds
+ * either, so the two are told apart by URL shape.
+ */
+export function getCodingAgentResultLink(
+  result: CodingAgentResult
+): AutofixResultLink | null {
+  if (!result.pr_url) {
+    return null;
+  }
+
+  return {
+    label: result.pr_url.includes('/tree/') ? t('View Branch') : t('View Pull Request'),
+    url: result.pr_url,
+  };
+}
+
+/** The first result any of these agents reported a URL for. */
+export function findCodingAgentResultLink(
+  codingAgents: ExplorerCodingAgentState[]
+): AutofixResultLink | null {
+  for (const result of codingAgents.flatMap(codingAgent => codingAgent.results ?? [])) {
+    const link = getCodingAgentResultLink(result);
+    if (link) {
+      return link;
+    }
+  }
+
+  return null;
+}

--- a/static/app/components/events/autofix/types.ts
+++ b/static/app/components/events/autofix/types.ts
@@ -49,13 +49,6 @@ export enum CodingAgentProvider {
   GITHUB_COPILOT_AGENT = 'github_copilot_agent',
 }
 
-export function getResultButtonLabel(url: string | null | undefined): string {
-  if (url?.includes('/tree/')) {
-    return t('View Branch');
-  }
-  return t('View Pull Request');
-}
-
 export type FilePatch = {
   added: number;
   hunks: Hunk[];

--- a/static/app/components/events/autofix/v3/codingAgentsCard.tsx
+++ b/static/app/components/events/autofix/v3/codingAgentsCard.tsx
@@ -6,10 +6,10 @@ import {Flex} from '@sentry/scraps/layout';
 import {Markdown} from '@sentry/scraps/markdown';
 import {Text} from '@sentry/scraps/text';
 
+import {getCodingAgentResultLink} from 'sentry/components/events/autofix/pullRequests';
 import {
   CodingAgentStatus,
   getCodingAgentName,
-  getResultButtonLabel,
 } from 'sentry/components/events/autofix/types';
 import {
   getAutofixArtifactFromSection,
@@ -91,18 +91,14 @@ export function CodingAgentsCard({section}: CodingAgentsCardProps) {
                 </LinkButton>
               ) : null}
               {codingAgent.results?.map(result => {
-                if (!result.pr_url) {
+                const link = getCodingAgentResultLink(result);
+                if (!link) {
                   return null;
                 }
 
                 return (
-                  <LinkButton
-                    key={result.pr_url}
-                    href={result.pr_url}
-                    external
-                    icon={<IconOpen />}
-                  >
-                    {getResultButtonLabel(result.pr_url)}
+                  <LinkButton key={link.url} href={link.url} external icon={<IconOpen />}>
+                    {link.label}
                   </LinkButton>
                 );
               })}

--- a/static/app/components/events/autofix/v3/pullRequestsCard.tsx
+++ b/static/app/components/events/autofix/v3/pullRequestsCard.tsx
@@ -4,6 +4,7 @@ import {Button, LinkButton} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
 
 import {getAutofixRunId} from 'sentry/components/events/autofix/autofixRunId';
+import {getRepoPullRequestLink} from 'sentry/components/events/autofix/pullRequests';
 import {
   getAutofixArtifactFromSection,
   isPullRequestsArtifact,
@@ -62,20 +63,12 @@ export function PullRequestsCard({autofix, section}: PullRequestsCardProps) {
           );
         }
 
-        if (
-          pullRequest.pr_creation_status === 'completed' &&
-          pullRequest.pr_url &&
-          pullRequest.pr_number
-        ) {
+        const link = getRepoPullRequestLink(pullRequest);
+        if (link) {
           return (
             <Flex key={pullRequest.repo_name} gap="xs" align="center">
-              <LinkButton
-                external
-                href={pullRequest.pr_url}
-                variant="primary"
-                icon={<IconOpen />}
-              >
-                {t('View %s#%s', pullRequest.repo_name, pullRequest.pr_number)}
+              <LinkButton external href={link.url} variant="primary" icon={<IconOpen />}>
+                {link.label}
               </LinkButton>
               <Button
                 variant="primary"
@@ -83,7 +76,7 @@ export function PullRequestsCard({autofix, section}: PullRequestsCardProps) {
                 aria-label={t('Copy PR URL')}
                 tooltipProps={{title: t('Copy PR URL')}}
                 onClick={() =>
-                  copy(pullRequest.pr_url!, {
+                  copy(link.url, {
                     successMessage: t('PR URL copied to clipboard.'),
                   })
                 }

--- a/static/app/views/issueDetails/issuePreview/issuePreviewSeerActions.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewSeerActions.tsx
@@ -3,9 +3,10 @@ import {useState} from 'react';
 import {Button, LinkButton} from '@sentry/scraps/button';
 
 import {
-  getCodingAgentName,
-  getResultButtonLabel,
-} from 'sentry/components/events/autofix/types';
+  findCodingAgentResultLink,
+  getRepoPullRequestLink,
+} from 'sentry/components/events/autofix/pullRequests';
+import {getCodingAgentName} from 'sentry/components/events/autofix/types';
 import {
   getOrderedAutofixSections,
   type ExplorerAutofixState,
@@ -15,6 +16,7 @@ import {Placeholder} from 'sentry/components/placeholder';
 import {IconOpen, IconRefresh, IconSeer} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Group} from 'sentry/types/group';
+import {defined} from 'sentry/utils/defined';
 
 type ExplorerAutofix = ReturnType<typeof useExplorerAutofix>;
 
@@ -96,29 +98,19 @@ function getAutofixPrimaryAction(
   }
 
   const pullRequests = Object.values(runState.repo_pr_states ?? {});
-  const completedPullRequest = pullRequests.find(
-    pullRequest =>
-      pullRequest.pr_creation_status === 'completed' &&
-      pullRequest.pr_url &&
-      pullRequest.pr_number &&
-      pullRequest.repo_name
-  );
+  const completedPullRequestLink = pullRequests.map(getRepoPullRequestLink).find(defined);
   const failedPullRequest = pullRequests.find(
     pullRequest => pullRequest.pr_creation_status === 'error'
   );
 
   // A pull request was created and completed
   // Show the view pull request button
-  if (completedPullRequest?.pr_url && completedPullRequest.pr_number) {
+  if (completedPullRequestLink) {
     return {
       ...AUTOFIX_ANALYTICS.view,
       kind: 'link',
-      label: t(
-        'View %s#%s',
-        completedPullRequest.repo_name,
-        completedPullRequest.pr_number
-      ),
-      href: completedPullRequest.pr_url,
+      label: completedPullRequestLink.label,
+      href: completedPullRequestLink.url,
     };
   }
 
@@ -152,16 +144,14 @@ function getAutofixPrimaryAction(
 
     case 'coding_agents': {
       const codingAgents = Object.values(runState.coding_agents ?? {});
-      const result = codingAgents
-        .flatMap(codingAgent => codingAgent.results ?? [])
-        .find(item => item.pr_url);
+      const resultLink = findCodingAgentResultLink(codingAgents);
 
-      if (result?.pr_url) {
+      if (resultLink) {
         return {
           ...AUTOFIX_ANALYTICS.view,
           kind: 'link',
-          label: getResultButtonLabel(result.pr_url),
-          href: result.pr_url,
+          label: resultLink.label,
+          href: resultLink.url,
         };
       }
 

--- a/static/app/views/seerExplorer/types.tsx
+++ b/static/app/views/seerExplorer/types.tsx
@@ -46,6 +46,7 @@ const codingAgentResultSchema = z.object({
   description: z.string(),
   repo_full_name: z.string(),
   repo_provider: z.string(),
+  pr_number: z.number().nullable().optional(),
   pr_url: z.string().nullable().optional(),
 });
 


### PR DESCRIPTION
Refs https://linear.app/getsentry/issue/ISWF-3145/normalize-pr-cta-label-in-issue-stream

We show a 'View PR' button in a few places in the UI. PRs either come from Seer or coding agent handoffs. Ref the logic so it's all in one place to decide what exactly to show in the button, which sets up to always show 'View repo_name/#PR-number'. No functional changes yet.

See https://github.com/getsentry/seer/pull/7551