### PR TITLE
ref(api): add `event.type` Sentry attribute to all event endpoints

### DIFF
--- a/src/sentry/api/endpoints/event_apple_crash_report.py
+++ b/src/sentry/api/endpoints/event_apple_crash_report.py
@@ -1,3 +1,4 @@
+import sentry_sdk
 from django.http import HttpResponse, StreamingHttpResponse
 from django.http.response import HttpResponseBase
 from rest_framework.request import Request
@@ -30,6 +31,8 @@ class EventAppleCrashReportEndpoint(ProjectEndpoint):
         event = eventstore.backend.get_event_by_id(project.id, event_id)
         if event is None:
             raise ResourceDoesNotExist
+
+        sentry_sdk.set_attribute("event.type", event.get_event_type())
 
         if event.platform not in ("cocoa", "native"):
             return HttpResponse(

--- a/src/sentry/api/endpoints/event_attachment_details.py
+++ b/src/sentry/api/endpoints/event_attachment_details.py
@@ -1,5 +1,6 @@
 import posixpath
 
+import sentry_sdk
 from django.http import StreamingHttpResponse
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.request import Request
@@ -146,6 +147,8 @@ class EventAttachmentDetailsEndpoint(ProjectEndpoint):
         event = eventstore.backend.get_event_by_id(project.id, event_id)
         if event is None:
             return self.respond({"detail": "Event not found"}, status=404)
+
+        sentry_sdk.set_attribute("event.type", event.get_event_type())
 
         try:
             attachment = EventAttachment.objects.filter(

--- a/src/sentry/api/endpoints/event_attachments.py
+++ b/src/sentry/api/endpoints/event_attachments.py
@@ -1,3 +1,4 @@
+import sentry_sdk
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -74,6 +75,8 @@ class EventAttachmentsEndpoint(ProjectEndpoint):
         event = eventstore.backend.get_event_by_id(project.id, event_id)
         if event is None:
             return self.respond({"detail": "Event not found"}, status=404)
+
+        sentry_sdk.set_attribute("event.type", event.get_event_type())
 
         queryset = EventAttachment.objects.filter(project_id=project.id, event_id=event.event_id)
 

--- a/src/sentry/api/endpoints/event_file_committers.py
+++ b/src/sentry/api/endpoints/event_file_committers.py
@@ -1,3 +1,4 @@
+import sentry_sdk
 from rest_framework.exceptions import NotFound
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -35,6 +36,8 @@ class EventFileCommittersEndpoint(ProjectEndpoint):
             raise NotFound(detail="Event not found")
         elif event.group_id is None:
             raise NotFound(detail="Issue not found")
+
+        sentry_sdk.set_attribute("event.type", event.get_event_type())
 
         committers = get_serialized_event_file_committers(project, event)
 

--- a/src/sentry/api/endpoints/source_map_debug.py
+++ b/src/sentry/api/endpoints/source_map_debug.py
@@ -164,6 +164,8 @@ class SourceMapDebugEndpoint(ProjectEndpoint):
         if event is None:
             raise NotFound(detail="Event not found")
 
+        sentry_sdk.set_attribute("event.type", event.get_event_type())
+
         event_data = event.data
 
         release = None

--- a/src/sentry/issues/endpoints/actionable_items.py
+++ b/src/sentry/issues/endpoints/actionable_items.py
@@ -1,3 +1,4 @@
+import sentry_sdk
 from rest_framework.exceptions import NotFound
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -36,6 +37,8 @@ class ActionableItemsEndpoint(ProjectEndpoint):
         event = eventstore.backend.get_event_by_id(project.id, event_id)
         if event is None:
             raise NotFound(detail="Event not found")
+
+        sentry_sdk.set_attribute("event.type", event.get_event_type())
 
         actions = []
         event_errors = event.data.get("errors", [])

--- a/src/sentry/issues/endpoints/event_grouping_info.py
+++ b/src/sentry/issues/endpoints/event_grouping_info.py
@@ -1,4 +1,5 @@
 import orjson
+import sentry_sdk
 from django.http import HttpRequest, HttpResponse
 
 from sentry.api.api_owners import ApiOwner
@@ -32,6 +33,8 @@ class EventGroupingInfoEndpoint(ProjectEndpoint):
         event = eventstore.backend.get_event_by_id(project.id, event_id)
         if event is None:
             raise ResourceDoesNotExist
+
+        sentry_sdk.set_attribute("event.type", event.get_event_type())
 
         grouping_config = load_grouping_config(event.get_grouping_config())
 

--- a/src/sentry/issues/endpoints/event_owners.py
+++ b/src/sentry/issues/endpoints/event_owners.py
@@ -1,5 +1,6 @@
 from typing import Literal
 
+import sentry_sdk
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -34,6 +35,8 @@ class EventOwnersEndpoint(ProjectEndpoint):
         event = eventstore.backend.get_event_by_id(project.id, event_id)
         if event is None:
             return Response({"detail": "Event not found"}, status=404)
+
+        sentry_sdk.set_attribute("event.type", event.get_event_type())
 
         owners, rules = ProjectOwnership.get_owners(project.id, event.data)
 

--- a/src/sentry/issues/endpoints/group_event_details.py
+++ b/src/sentry/issues/endpoints/group_event_details.py
@@ -5,6 +5,7 @@ import logging
 from collections.abc import Sequence
 from typing import Any
 
+import sentry_sdk
 from django.contrib.auth.models import AnonymousUser
 from drf_spectacular.utils import extend_schema
 from rest_framework.exceptions import ParseError
@@ -253,6 +254,8 @@ class GroupEventDetailsEndpoint(GroupEndpoint):
                 else "No matching event found. Try changing the environments, date range, or query."
             )
             return Response({"detail": error_text}, status=404)
+
+        sentry_sdk.set_attribute("event.type", event.get_event_type())
 
         collapse = request.GET.getlist("collapse", [])
         if "stacktraceOnly" in collapse:

--- a/src/sentry/issues/endpoints/organization_event_details.py
+++ b/src/sentry/issues/endpoints/organization_event_details.py
@@ -147,6 +147,8 @@ class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):
         if event is None:
             return Response({"detail": "Event not found"}, status=404)
 
+        sentry_sdk.set_attribute("event.type", event.get_event_type())
+
         average_columns = request.GET.getlist("averageColumn", [])
         if (
             all(col in VALID_AVERAGE_COLUMNS for col in average_columns)

--- a/src/sentry/issues/endpoints/organization_eventid.py
+++ b/src/sentry/issues/endpoints/organization_eventid.py
@@ -1,5 +1,6 @@
 from typing import TypedDict
 
+import sentry_sdk
 from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -106,6 +107,7 @@ class EventIdLookupEndpoint(OrganizationEndpoint):
         except IndexError:
             raise ResourceDoesNotExist()
         else:
+            sentry_sdk.set_attribute("event.type", event.get_event_type())
             return Response(
                 {
                     "organizationSlug": organization.slug,

--- a/src/sentry/issues/endpoints/project_event_details.py
+++ b/src/sentry/issues/endpoints/project_event_details.py
@@ -157,6 +157,8 @@ class ProjectEventDetailsEndpoint(ProjectEndpoint):
         if event is None:
             return Response({"detail": "Event not found"}, status=404)
 
+        sentry_sdk.set_attribute("event.type", event.get_event_type())
+
         environments = set(request.GET.getlist("environment"))
 
         # TODO: Remove `for_group` check once performance issues are moved to the issue platform
@@ -192,6 +194,8 @@ class EventJsonEndpoint(ProjectEndpoint):
 
         if not event:
             return Response({"detail": "Event not found"}, status=404)
+
+        sentry_sdk.set_attribute("event.type", event.get_event_type())
 
         event_dict = event.as_dict()
         if isinstance(event_dict["datetime"], datetime):


### PR DESCRIPTION
For all endpoints targeting a single event, record the event type in the `event.type` Sentry attribute. We're trying to track all uses of transaction events (so that they can be removed), and this will allow us to do so.

Closes BROWSE-662.