### PR TITLE
ref(input): switch from effect + setState to callback-ref + resizeObserver

### DIFF
--- a/static/app/components/core/input/inputGroup.spec.tsx
+++ b/static/app/components/core/input/inputGroup.spec.tsx
@@ -66,4 +66,29 @@ describe('InputGroup', () => {
     await userEvent.tab();
     expect(screen.getByRole('button', {name: 'Trailing Button'})).toHaveFocus();
   });
+
+  it('does not remeasure items when their parent rerenders', () => {
+    const offsetWidthSpy = jest
+      .spyOn(HTMLElement.prototype, 'offsetWidth', 'get')
+      .mockReturnValue(24);
+
+    const renderGroup = (label: string) => (
+      <InputGroup>
+        <InputGroup.LeadingItems>
+          <Button>{label}</Button>
+        </InputGroup.LeadingItems>
+        <InputGroup.Input />
+      </InputGroup>
+    );
+
+    try {
+      const {rerender} = render(renderGroup('initial'));
+      expect(offsetWidthSpy).toHaveBeenCalledTimes(1);
+
+      rerender(renderGroup('updated'));
+      expect(offsetWidthSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      offsetWidthSpy.mockRestore();
+    }
+  });
 });

--- a/static/app/components/core/input/inputGroup.tsx
+++ b/static/app/components/core/input/inputGroup.tsx
@@ -1,5 +1,7 @@
 import {
   createContext,
+  type Dispatch,
+  type SetStateAction,
   useCallback,
   useContext,
   useLayoutEffect,
@@ -102,8 +104,8 @@ interface InputContext {
    */
   leadingWidth?: number;
   setInputProps?: (props: Pick<InputProps, 'size' | 'disabled'>) => void;
-  setLeadingWidth?: (width: number) => void;
-  setTrailingWidth?: (width: number) => void;
+  setLeadingWidth?: Dispatch<SetStateAction<number | undefined>>;
+  setTrailingWidth?: Dispatch<SetStateAction<number | undefined>>;
   /**
    * Width of the trailing items wrap, to be added to `Input`'s padding.
    */
@@ -194,7 +196,9 @@ interface InputItemsProps extends React.HTMLAttributes<HTMLDivElement> {
   disablePointerEvents?: boolean;
 }
 
-function useInputItemsWidthRef(setWidth: ((width: number) => void) | undefined) {
+function useInputItemsWidthRef(
+  setWidth: Dispatch<SetStateAction<number | undefined>> | undefined
+) {
   return useCallback(
     (node: HTMLDivElement | null) => {
       if (!node || !setWidth) {
@@ -213,7 +217,10 @@ function useInputItemsWidthRef(setWidth: ((width: number) => void) | undefined) 
       const observer = new ResizeObserver(updateWidth);
       observer.observe(node);
 
-      return () => observer.disconnect();
+      return () => {
+        observer.disconnect();
+        setWidth(undefined);
+      };
     },
     [setWidth]
   );

--- a/static/app/components/core/input/inputGroup.tsx
+++ b/static/app/components/core/input/inputGroup.tsx
@@ -1,9 +1,9 @@
 import {
   createContext,
+  useCallback,
   useContext,
   useLayoutEffect,
   useMemo,
-  useRef,
   useState,
 } from 'react';
 import {css} from '@emotion/react';
@@ -194,6 +194,31 @@ interface InputItemsProps extends React.HTMLAttributes<HTMLDivElement> {
   disablePointerEvents?: boolean;
 }
 
+function useInputItemsWidthRef(setWidth: ((width: number) => void) | undefined) {
+  return useCallback(
+    (node: HTMLDivElement | null) => {
+      if (!node || !setWidth) {
+        return;
+      }
+
+      const updateWidth = () => {
+        setWidth(node.offsetWidth);
+      };
+
+      // Measure synchronously when the node is mounted so the input padding is
+      // correct before the browser paints. The observer handles children that
+      // change size without replacing the items wrapper.
+      updateWidth();
+
+      const observer = new ResizeObserver(updateWidth);
+      observer.observe(node);
+
+      return () => observer.disconnect();
+    },
+    [setWidth]
+  );
+}
+
 /**
  * Container for leading input items (e.g. a search icon). To be wrapped
  * inside `InputGroup`:
@@ -203,18 +228,11 @@ interface InputItemsProps extends React.HTMLAttributes<HTMLDivElement> {
  *   </InputGroup>
  */
 function LeadingItems({children, disablePointerEvents, ...props}: InputItemsProps) {
-  const ref = useRef<HTMLDivElement | null>(null);
   const {
     inputProps: {size = 'md', disabled},
     setLeadingWidth,
   } = useContext(InputGroupContext);
-
-  useLayoutEffect(() => {
-    if (!ref.current) {
-      return;
-    }
-    setLeadingWidth?.(ref.current.offsetWidth);
-  }, [children, setLeadingWidth, size]);
+  const ref = useInputItemsWidthRef(setLeadingWidth);
 
   return (
     <StyledLeadingItemsWrap
@@ -238,18 +256,11 @@ function LeadingItems({children, disablePointerEvents, ...props}: InputItemsProp
  *   </InputGroup>
  */
 function TrailingItems({children, disablePointerEvents, ...props}: InputItemsProps) {
-  const ref = useRef<HTMLDivElement | null>(null);
   const {
     inputProps: {size = 'md', disabled},
     setTrailingWidth,
   } = useContext(InputGroupContext);
-
-  useLayoutEffect(() => {
-    if (!ref.current) {
-      return;
-    }
-    setTrailingWidth?.(ref.current.offsetWidth);
-  }, [children, setTrailingWidth, size]);
+  const ref = useInputItemsWidthRef(setTrailingWidth);
 
   return (
     <StyledTrailingItemsWrap


### PR DESCRIPTION
this fixes "Maximum update depth exceeded" observed in production. The effect was continuously firing because it had `children` in the dependency array, which is always a new identity on each render.