### PR TITLE
feat: Pass variable extraction flag to Symbolicator

### DIFF
--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -310,7 +310,7 @@ class Symbolicator:
             "scraping": orjson.dumps(scraping_config).decode(),
             "options": orjson.dumps(
                 {"dif_candidates": True, "extract_variables": self._should_extract_variables()}
-            ),
+            ).decode(),
         }
         files = {"apple_crash_report": report.load_data(self.project)}
 

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -234,9 +234,6 @@ class Symbolicator:
     ):
         (sources, process_response) = sources_for_symbolication(self.project)
         scraping_config = get_scraping_config(self.project)
-        extract_variables = features.has(
-            "organizations:native-variable-extraction", self.project.organization
-        )
 
         if minidump.stored_id:
             stored_id = minidump.stored_id
@@ -245,7 +242,10 @@ class Symbolicator:
                 "platform": platform,
                 "sources": sources,
                 "scraping": scraping_config,
-                "options": {"dif_candidates": True, "extract_variables": extract_variables},
+                "options": {
+                    "dif_candidates": True,
+                    "extract_variables": self._should_extract_variables(),
+                },
                 "symbolicate": {
                     "type": "minidump",
                     "rewrite_first_module": rewrite_first_module,
@@ -266,7 +266,7 @@ class Symbolicator:
             "sources": orjson.dumps(sources).decode(),
             "scraping": orjson.dumps(scraping_config).decode(),
             "options": orjson.dumps(
-                {"dif_candidates": True, "extract_variables": extract_variables}
+                {"dif_candidates": True, "extract_variables": self._should_extract_variables()}
             ).decode(),
             "rewrite_first_module": orjson.dumps(rewrite_first_module).decode(),
         }
@@ -286,7 +286,10 @@ class Symbolicator:
                 "platform": platform,
                 "sources": sources,
                 "scraping": scraping_config,
-                "options": {"dif_candidates": True},
+                "options": {
+                    "dif_candidates": True,
+                    "extract_variables": self._should_extract_variables(),
+                },
                 "symbolicate": {
                     "type": "applecrashreport",
                 },
@@ -305,7 +308,9 @@ class Symbolicator:
             "platform": orjson.dumps(platform).decode(),
             "sources": orjson.dumps(sources).decode(),
             "scraping": orjson.dumps(scraping_config).decode(),
-            "options": '{"dif_candidates": true}',
+            "options": orjson.dumps(
+                {"dif_candidates": True, "extract_variables": self._should_extract_variables()}
+            ),
         }
         files = {"apple_crash_report": report.load_data(self.project)}
 
@@ -336,6 +341,7 @@ class Symbolicator:
                 "dif_candidates": True,
                 "apply_source_context": apply_source_context,
                 "frame_order": frame_order.value,
+                "extract_variables": self._should_extract_variables(),
             },
             "stacktraces": stacktraces,
             "modules": modules,
@@ -375,6 +381,7 @@ class Symbolicator:
             "options": {
                 "apply_source_context": apply_source_context,
                 "frame_order": frame_order.value,
+                "extract_variables": self._should_extract_variables(),
             },
             "scraping": scraping_config,
         }
@@ -424,6 +431,7 @@ class Symbolicator:
             "options": {
                 "apply_source_context": apply_source_context,
                 "frame_order": frame_order.value,
+                "extract_variables": self._should_extract_variables(),
             },
         }
 
@@ -431,6 +439,13 @@ class Symbolicator:
             json["release_package"] = release_package
 
         return self._process("symbolicate_jvm_stacktraces", "symbolicate-jvm", json=json)
+
+    def _should_extract_variables(self) -> bool:
+        """Helper for determining whether to extract variables.
+
+        This just reads the "organizations:native-variable-extraction" feature flag.
+        """
+        return features.has("organizations:native-variable-extraction", self.project.organization)
 
 
 class TaskIdNotFound(Exception):

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -16,7 +16,7 @@ import sentry_sdk
 from django.conf import settings
 from requests.exceptions import RequestException
 
-from sentry import options
+from sentry import features, options
 from sentry.attachments.base import CachedAttachment
 from sentry.lang.native.sources import (
     get_internal_artifact_lookup_source,
@@ -234,6 +234,9 @@ class Symbolicator:
     ):
         (sources, process_response) = sources_for_symbolication(self.project)
         scraping_config = get_scraping_config(self.project)
+        extract_variables = features.has(
+            "organizations:native-variable-extraction", self.project.organization
+        )
 
         if minidump.stored_id:
             stored_id = minidump.stored_id
@@ -242,7 +245,7 @@ class Symbolicator:
                 "platform": platform,
                 "sources": sources,
                 "scraping": scraping_config,
-                "options": {"dif_candidates": True},
+                "options": {"dif_candidates": True, "extract_variables": extract_variables},
                 "symbolicate": {
                     "type": "minidump",
                     "rewrite_first_module": rewrite_first_module,
@@ -262,7 +265,9 @@ class Symbolicator:
             "platform": orjson.dumps(platform).decode(),
             "sources": orjson.dumps(sources).decode(),
             "scraping": orjson.dumps(scraping_config).decode(),
-            "options": '{"dif_candidates": true}',
+            "options": orjson.dumps(
+                {"dif_candidates": True, "extract_variables": extract_variables}
+            ).decode(),
             "rewrite_first_module": orjson.dumps(rewrite_first_module).decode(),
         }
         files = {"upload_file_minidump": minidump.load_data(self.project)}

--- a/tests/sentry/lang/native/test_symbolicator.py
+++ b/tests/sentry/lang/native/test_symbolicator.py
@@ -1,18 +1,14 @@
 import copy
-from unittest import mock
 
 import pytest
 
-from sentry.attachments.base import CachedAttachment
 from sentry.lang.native.sources import (
     get_sources_for_project,
     redact_internal_sources,
     reverse_aliases_map,
 )
-from sentry.lang.native.symbolicator import Symbolicator
 from sentry.testutils.helpers import Feature
 from sentry.testutils.pytest.fixtures import django_db_all
-from sentry.utils import json
 
 CUSTOM_SOURCE_CONFIG = """
 [{
@@ -32,62 +28,6 @@ CUSTOM_SOURCE_CONFIG = """
     "bundleId": "test"
 }]
 """
-
-
-@django_db_all
-@pytest.mark.parametrize("enabled", [False, True])
-def test_minidump_object_store_extract_variables(default_project, enabled) -> None:
-    symbolicator = object.__new__(Symbolicator)
-    symbolicator.project = default_project
-    symbolicator.event_id = "event-id"
-
-    session = mock.Mock()
-    session.mint_token.return_value = "token"
-    response = {"status": "completed"}
-    attachment = CachedAttachment(stored_id="attachment-id")
-
-    with (
-        Feature({"organizations:native-variable-extraction": enabled}),
-        mock.patch(
-            "sentry.lang.native.symbolicator.sources_for_symbolication",
-            return_value=([], lambda result: result),
-        ),
-        mock.patch("sentry.lang.native.symbolicator.get_scraping_config", return_value={}),
-        mock.patch("sentry.lang.native.symbolicator.get_attachments_session", return_value=session),
-        mock.patch(
-            "sentry.lang.native.symbolicator.get_symbolicator_url", return_value="storage-url"
-        ),
-        mock.patch.object(symbolicator, "_process", return_value=response) as process,
-    ):
-        symbolicator.process_minidump("native", attachment, [])
-
-    request = process.call_args.kwargs["kwargs_cb"]()["json"]
-    assert request["options"]["extract_variables"] is enabled
-
-
-@django_db_all
-@pytest.mark.parametrize("enabled", [False, True])
-def test_minidump_multipart_extract_variables(default_project, enabled) -> None:
-    symbolicator = object.__new__(Symbolicator)
-    symbolicator.project = default_project
-    symbolicator.event_id = "event-id"
-
-    response = {"status": "completed"}
-    attachment = CachedAttachment(data=b"minidump")
-
-    with (
-        Feature({"organizations:native-variable-extraction": enabled}),
-        mock.patch(
-            "sentry.lang.native.symbolicator.sources_for_symbolication",
-            return_value=([], lambda result: result),
-        ),
-        mock.patch("sentry.lang.native.symbolicator.get_scraping_config", return_value={}),
-        mock.patch.object(symbolicator, "_process", return_value=response) as process,
-    ):
-        symbolicator.process_minidump("native", attachment, [])
-
-    options = json.loads(process.call_args.kwargs["data"]["options"])
-    assert options["extract_variables"] is enabled
 
 
 @django_db_all

--- a/tests/sentry/lang/native/test_symbolicator.py
+++ b/tests/sentry/lang/native/test_symbolicator.py
@@ -1,14 +1,18 @@
 import copy
+from unittest import mock
 
 import pytest
 
+from sentry.attachments.base import CachedAttachment
 from sentry.lang.native.sources import (
     get_sources_for_project,
     redact_internal_sources,
     reverse_aliases_map,
 )
+from sentry.lang.native.symbolicator import Symbolicator
 from sentry.testutils.helpers import Feature
 from sentry.testutils.pytest.fixtures import django_db_all
+from sentry.utils import json
 
 CUSTOM_SOURCE_CONFIG = """
 [{
@@ -28,6 +32,62 @@ CUSTOM_SOURCE_CONFIG = """
     "bundleId": "test"
 }]
 """
+
+
+@django_db_all
+@pytest.mark.parametrize("enabled", [False, True])
+def test_minidump_object_store_extract_variables(default_project, enabled) -> None:
+    symbolicator = object.__new__(Symbolicator)
+    symbolicator.project = default_project
+    symbolicator.event_id = "event-id"
+
+    session = mock.Mock()
+    session.mint_token.return_value = "token"
+    response = {"status": "completed"}
+    attachment = CachedAttachment(stored_id="attachment-id")
+
+    with (
+        Feature({"organizations:native-variable-extraction": enabled}),
+        mock.patch(
+            "sentry.lang.native.symbolicator.sources_for_symbolication",
+            return_value=([], lambda result: result),
+        ),
+        mock.patch("sentry.lang.native.symbolicator.get_scraping_config", return_value={}),
+        mock.patch("sentry.lang.native.symbolicator.get_attachments_session", return_value=session),
+        mock.patch(
+            "sentry.lang.native.symbolicator.get_symbolicator_url", return_value="storage-url"
+        ),
+        mock.patch.object(symbolicator, "_process", return_value=response) as process,
+    ):
+        symbolicator.process_minidump("native", attachment, [])
+
+    request = process.call_args.kwargs["kwargs_cb"]()["json"]
+    assert request["options"]["extract_variables"] is enabled
+
+
+@django_db_all
+@pytest.mark.parametrize("enabled", [False, True])
+def test_minidump_multipart_extract_variables(default_project, enabled) -> None:
+    symbolicator = object.__new__(Symbolicator)
+    symbolicator.project = default_project
+    symbolicator.event_id = "event-id"
+
+    response = {"status": "completed"}
+    attachment = CachedAttachment(data=b"minidump")
+
+    with (
+        Feature({"organizations:native-variable-extraction": enabled}),
+        mock.patch(
+            "sentry.lang.native.symbolicator.sources_for_symbolication",
+            return_value=([], lambda result: result),
+        ),
+        mock.patch("sentry.lang.native.symbolicator.get_scraping_config", return_value={}),
+        mock.patch.object(symbolicator, "_process", return_value=response) as process,
+    ):
+        symbolicator.process_minidump("native", attachment, [])
+
+    options = json.loads(process.call_args.kwargs["data"]["options"])
+    assert options["extract_variables"] is enabled
 
 
 @django_db_all


### PR DESCRIPTION
Send the variable extraction flag in all Symbolicator requests.

The flag will only affect a subset of Symbolicator operations, but all requests should accept this option, so there is no harm in passing it consistently.

Resolves [INGEST-1103](https://linear.app/getsentry/issue/INGEST-1103/include-variable-extraction-flag-in-symbolication-request)