### PR TITLE
ref(symbolicator): Use pre-signed URLs for minidumps and apple crash reports

### DIFF
--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -236,6 +236,7 @@ class Symbolicator:
         scraping_config = get_scraping_config(self.project)
 
         if minidump.stored_id:
+            stored_id = minidump.stored_id
             session = get_attachments_session(self.project.organization_id, self.project.id)
             json: dict[str, Any] = {
                 "platform": platform,
@@ -250,7 +251,7 @@ class Symbolicator:
 
             def cb() -> dict[str, Any]:
                 json["symbolicate"]["storage_url"] = get_internal_download_url(
-                    session, minidump.stored_id, token_validity=TOKEN_VALIDITY
+                    session, stored_id, token_validity=TOKEN_VALIDITY
                 )
                 return {"json": json}
 
@@ -274,6 +275,7 @@ class Symbolicator:
         scraping_config = get_scraping_config(self.project)
 
         if report.stored_id:
+            stored_id = report.stored_id
             session = get_attachments_session(self.project.organization_id, self.project.id)
             json: dict[str, Any] = {
                 "platform": platform,
@@ -287,7 +289,7 @@ class Symbolicator:
 
             def cb() -> dict[str, Any]:
                 json["symbolicate"]["storage_url"] = get_internal_download_url(
-                    session, report.stored_id, token_validity=TOKEN_VALIDITY
+                    session, stored_id, token_validity=TOKEN_VALIDITY
                 )
                 return {"json": json}
 

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -6,6 +6,7 @@ import time
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import timedelta
 from enum import Enum
 from typing import Any
 from urllib.parse import urljoin
@@ -26,13 +27,19 @@ from sentry.lang.native.sources import (
 from sentry.lang.native.utils import Backoff
 from sentry.models.project import Project
 from sentry.net.http import Session
-from sentry.objectstore import get_attachments_session, get_symbolicator_url
+from sentry.objectstore import (
+    get_attachments_session,
+    get_download_redirect_url,
+)
 from sentry.utils import metrics
 
 MAX_ATTEMPTS = 3
 
 BACKOFF_INITIAL = 0.1
 BACKOFF_MAX = 5
+
+# Symbolicator runs up to 3 tries with 5 minute timeouts
+TOKEN_VALIDITY = timedelta(minutes=15)
 
 logger = logging.getLogger(__name__)
 
@@ -230,7 +237,6 @@ class Symbolicator:
 
         if minidump.stored_id:
             session = get_attachments_session(self.project.organization_id, self.project.id)
-            storage_url = get_symbolicator_url(session, minidump.stored_id)
             json: dict[str, Any] = {
                 "platform": platform,
                 "sources": sources,
@@ -238,13 +244,14 @@ class Symbolicator:
                 "options": {"dif_candidates": True},
                 "symbolicate": {
                     "type": "minidump",
-                    "storage_url": storage_url,
                     "rewrite_first_module": rewrite_first_module,
                 },
             }
 
             def cb() -> dict[str, Any]:
-                json["symbolicate"]["storage_token"] = session.mint_token()
+                json["symbolicate"]["storage_url"] = get_download_redirect_url(
+                    session, minidump.stored_id, token_validity=TOKEN_VALIDITY
+                )
                 return {"json": json}
 
             res = self._process("process_minidump", "symbolicate-any", kwargs_cb=cb)
@@ -268,7 +275,6 @@ class Symbolicator:
 
         if report.stored_id:
             session = get_attachments_session(self.project.organization_id, self.project.id)
-            storage_url = get_symbolicator_url(session, report.stored_id)
             json: dict[str, Any] = {
                 "platform": platform,
                 "sources": sources,
@@ -276,12 +282,13 @@ class Symbolicator:
                 "options": {"dif_candidates": True},
                 "symbolicate": {
                     "type": "applecrashreport",
-                    "storage_url": storage_url,
                 },
             }
 
             def cb() -> dict[str, Any]:
-                json["symbolicate"]["storage_token"] = session.mint_token()
+                json["symbolicate"]["storage_url"] = get_download_redirect_url(
+                    session, report.stored_id, token_validity=TOKEN_VALIDITY
+                )
                 return {"json": json}
 
             res = self._process("process_applecrashreport", "symbolicate-any", kwargs_cb=cb)

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -29,7 +29,7 @@ from sentry.models.project import Project
 from sentry.net.http import Session
 from sentry.objectstore import (
     get_attachments_session,
-    get_download_redirect_url,
+    get_internal_download_url,
 )
 from sentry.utils import metrics
 
@@ -249,7 +249,7 @@ class Symbolicator:
             }
 
             def cb() -> dict[str, Any]:
-                json["symbolicate"]["storage_url"] = get_download_redirect_url(
+                json["symbolicate"]["storage_url"] = get_internal_download_url(
                     session, minidump.stored_id, token_validity=TOKEN_VALIDITY
                 )
                 return {"json": json}
@@ -286,7 +286,7 @@ class Symbolicator:
             }
 
             def cb() -> dict[str, Any]:
-                json["symbolicate"]["storage_url"] = get_download_redirect_url(
+                json["symbolicate"]["storage_url"] = get_internal_download_url(
                     session, report.stored_id, token_validity=TOKEN_VALIDITY
                 )
                 return {"json": json}

--- a/src/sentry/objectstore/__init__.py
+++ b/src/sentry/objectstore/__init__.py
@@ -205,6 +205,11 @@ def get_internal_download_url(
     if token_validity is None:
         token_validity = REDIRECT_VALIDITY
 
+    # Redirect to a URL pointing to the internal Objectstore ip/hostname.
+    # In dev/test, we potentially need to rewrite this URL to point to the hostname in the docker network
+    # instead, so we need to additionally wrap this with `maybe_rewrite_url_for_symbolicator`.
+    # TODO(lcian): Find a more robust way to do this. Here we assume that the caller is Symbolicator,
+    # which is currently the case in practice, but in theory it could be any other service.
     return maybe_rewrite_url_for_symbolicator(
         session.object_url(key, token_validity=token_validity)
     )

--- a/src/sentry/objectstore/__init__.py
+++ b/src/sentry/objectstore/__init__.py
@@ -195,6 +195,21 @@ def maybe_rewrite_url_for_symbolicator(url: str) -> str:
     return urlunparse(updated)
 
 
+def get_internal_download_url(
+    session: Session, key: str, token_validity: timedelta | None = None
+) -> str:
+    """
+    Pre-signed URL to `key` for an INTERNAL service (e.g. Symbolicator, teapot): a direct link to
+    Objectstore that bypasses the cell proxy.
+    """
+    if token_validity is None:
+        token_validity = REDIRECT_VALIDITY
+
+    return maybe_rewrite_url_for_symbolicator(
+        session.object_url(key, token_validity=token_validity)
+    )
+
+
 def get_download_redirect_url(
     request: HttpRequest,
     session: Session,
@@ -212,17 +227,13 @@ def get_download_redirect_url(
     from sentry.api.utils import generate_locality_url
     from sentry.auth import system
 
+    if system.is_internal_ip(request):
+        return get_internal_download_url(session, key, token_validity)
+
     if token_validity is None:
         token_validity = REDIRECT_VALIDITY
-    presigned_url = session.object_url(key, token_validity=token_validity)
 
-    if system.is_internal_ip(request):
-        # Redirect to a URL pointing to the internal Objectstore ip/hostname.
-        # In dev/test, we potentially need to rewrite this URL to point to the hostname in the docker network
-        # instead, so we need to additionally wrap this with `maybe_rewrite_url_for_symbolicator`.
-        # TODO(lcian): Find a more robust way to do this. Here we assume that the caller is Symbolicator,
-        # which is currently the case in practice, but in theory it could be any other service.
-        return maybe_rewrite_url_for_symbolicator(presigned_url)
+    presigned_url = session.object_url(key, token_validity=token_validity)
 
     parts = urlsplit(presigned_url)
     proxy_path = reverse(

--- a/src/sentry/objectstore/__init__.py
+++ b/src/sentry/objectstore/__init__.py
@@ -25,6 +25,11 @@ from sentry.utils.env import in_test_environment
 __all__ = ["get_attachments_session", "get_debug_files_session", "parse_accept_encoding"]
 
 
+# Default validity of the token used for redirecting to Objectstore. This is a
+# short-lived token, as it is only used for a single request.
+REDIRECT_VALIDITY = timedelta(minutes=5)
+
+
 def default_attachment_retention() -> int:
     """
     Returns the default attachment retention in days, which is used if no
@@ -190,16 +195,13 @@ def maybe_rewrite_url_for_symbolicator(url: str) -> str:
     return urlunparse(updated)
 
 
-def get_symbolicator_url(session: Session, key: str) -> str:
-    """
-    Gets the URL that Symbolicator shall use to access the object at the given key in Objectstore.
-
-    The URL is only rewritten in dev/test mode. See `maybe_rewrite_url_for_symbolicator` for details.
-    """
-    return maybe_rewrite_url_for_symbolicator(session.object_url(key))
-
-
-def get_download_redirect_url(request: HttpRequest, session: Session, org: int, key: str) -> str:
+def get_download_redirect_url(
+    request: HttpRequest,
+    session: Session,
+    org: int,
+    key: str,
+    token_validity: timedelta | None = None,
+) -> str:
     """
     Returns the URL that `request` should be redirected to in order to download the object at `key`
     directly from Objectstore, bypassing Sentry.
@@ -210,7 +212,9 @@ def get_download_redirect_url(request: HttpRequest, session: Session, org: int, 
     from sentry.api.utils import generate_locality_url
     from sentry.auth import system
 
-    presigned_url = session.object_url(key, token_validity=timedelta(minutes=5))
+    if token_validity is None:
+        token_validity = REDIRECT_VALIDITY
+    presigned_url = session.object_url(key, token_validity=token_validity)
 
     if system.is_internal_ip(request):
         # Redirect to a URL pointing to the internal Objectstore ip/hostname.


### PR DESCRIPTION
Objectstore has pre-signed URLs now, so we no longer have to send the token explicitly.

After this has been rolled out, we can remove support for `storage_token` from symbolicator.