### PR TITLE
feat(agent-monitoring): Add Cloudflare deployment target to agent onboarding

### DIFF
--- a/static/app/components/onboarding/platformOptionDropdown.tsx
+++ b/static/app/components/onboarding/platformOptionDropdown.tsx
@@ -24,6 +24,12 @@ type PlatformOptionsControlProps = {
    */
   platformOptions: Record<string, PlatformOption>;
   /**
+   * Optional connector word rendered before a given option's control, keyed by
+   * option key. Lets callers compose a readable sentence, e.g. rendering "on"
+   * between two selectors so it reads "with <integration> on <runtime>".
+   */
+  connectors?: Record<string, string>;
+  /**
    * Whether the option is disabled
    */
   disabled?: boolean;
@@ -53,6 +59,7 @@ function OptionControl({option, value, onChange, disabled}: OptionControlProps) 
 export function PlatformOptionDropdown({
   platformOptions,
   disabled,
+  connectors,
 }: PlatformOptionsControlProps) {
   const navigate = useNavigate();
   const location = useLocation();
@@ -79,13 +86,15 @@ export function PlatformOptionDropdown({
     <Fragment>
       {t('with')}
       {Object.keys(platformOptions).map(key => (
-        <OptionControl
-          key={key}
-          option={platformOptions[key]!}
-          value={urlOptionValues[key]!}
-          onChange={v => handleChange(key, v.value)}
-          disabled={disabled}
-        />
+        <Fragment key={key}>
+          {connectors?.[key]}
+          <OptionControl
+            option={platformOptions[key]!}
+            value={urlOptionValues[key]!}
+            onChange={v => handleChange(key, v.value)}
+            disabled={disabled}
+          />
+        </Fragment>
       ))}
     </Fragment>
   );

--- a/static/app/gettingStartedDocs/node/agentMonitoring.spec.tsx
+++ b/static/app/gettingStartedDocs/node/agentMonitoring.spec.tsx
@@ -1,0 +1,173 @@
+import type {
+  ContentBlock,
+  DocsParams,
+  OnboardingStep,
+} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {agentMonitoring} from 'sentry/gettingStartedDocs/node/agentMonitoring';
+
+function makeParams(platformOptions: Record<string, string> = {}): DocsParams {
+  return {
+    dsn: {public: 'https://public@o1.ingest.sentry.io/1'},
+    platformOptions,
+    project: {id: '1', slug: 'project-slug', platform: 'node'},
+    isProfilingSelected: false,
+    isLogsSelected: false,
+    isFeedbackSelected: false,
+    isMetricsSelected: false,
+    isPerformanceSelected: true,
+    isReplaySelected: false,
+    sourcePackageRegistries: {isLoading: false, data: undefined},
+  } as unknown as DocsParams;
+}
+
+function collectCode(steps: OnboardingStep[]): string {
+  return steps
+    .flatMap(step => step.content ?? [])
+    .filter((block): block is Extract<ContentBlock, {type: 'code'}> => {
+      return block.type === 'code';
+    })
+    .flatMap(block => block.tabs?.map(tab => tab.code) ?? [])
+    .join('\n\n');
+}
+
+describe('node agentMonitoring onboarding', () => {
+  const config = agentMonitoring();
+
+  describe('Node deployment target', () => {
+    it('initializes the SDK with Sentry.init', () => {
+      const code = collectCode(
+        config.configure(makeParams({integration: 'openai', deploymentTarget: 'node'}))
+      );
+
+      expect(code).toContain('Sentry.init({');
+      expect(code).toContain('@sentry/node');
+      expect(code).not.toContain('Sentry.withSentry');
+    });
+
+    it('defaults to the Node target when no deployment target is selected', () => {
+      const code = collectCode(config.configure(makeParams({integration: 'openai'})));
+
+      expect(code).toContain('Sentry.init({');
+      expect(code).not.toContain('Sentry.withSentry');
+    });
+
+    it('installs @sentry/node', () => {
+      const code = collectCode(config.install(makeParams({integration: 'openai'})));
+
+      expect(code).toContain('npm install @sentry/node');
+      expect(code).not.toContain('@sentry/cloudflare');
+    });
+
+    it('uses Sentry.init for manual instrumentation', () => {
+      const code = collectCode(config.configure(makeParams({integration: 'manual'})));
+
+      expect(code).toContain('Sentry.init({');
+      expect(code).not.toContain('Sentry.withSentry');
+    });
+
+    it('shows a raw-SDK verify snippet (auto-instrumented on Node)', () => {
+      const code = collectCode(config.verify(makeParams({integration: 'openai'})));
+
+      expect(code).toContain('responses.create');
+    });
+  });
+
+  describe('Cloudflare deployment target', () => {
+    it('bootstraps the SDK with Sentry.withSentry instead of Sentry.init', () => {
+      const code = collectCode(
+        config.configure(
+          makeParams({integration: 'anthropic', deploymentTarget: 'cloudflare'})
+        )
+      );
+
+      expect(code).toContain('Sentry.withSentry(');
+      expect(code).toContain('import * as Sentry from "@sentry/cloudflare"');
+      expect(code).not.toContain('Sentry.init(');
+      expect(code).not.toContain('nodejs_compat');
+      expect(code).not.toContain('vercelAIIntegration');
+    });
+
+    it('wraps the client explicitly for non-Vercel integrations (not auto-instrumented on Cloudflare)', () => {
+      const code = collectCode(
+        config.configure(
+          makeParams({integration: 'openai', deploymentTarget: 'cloudflare'})
+        )
+      );
+
+      // Worker is wrapped, and the client must be instrumented explicitly
+      expect(code).toContain('Sentry.withSentry(');
+      expect(code).toContain('Sentry.instrumentOpenAiClient(');
+      // These integrations don't use the nodejs_compat entrypoint (that's Vercel AI)
+      expect(code).not.toContain('nodejs_compat');
+    });
+
+    it('does not show a raw-SDK verify snippet for wrapped Cloudflare integrations', () => {
+      const code = collectCode(
+        config.verify(makeParams({integration: 'openai', deploymentTarget: 'cloudflare'}))
+      );
+
+      // The wrapped-client call is shown in the Configure step instead
+      expect(code).toBe('');
+    });
+
+    it('treats Workers AI as auto-instrumented (no client wrapping)', () => {
+      const configureCode = collectCode(
+        config.configure(
+          makeParams({integration: 'workers_ai', deploymentTarget: 'cloudflare'})
+        )
+      );
+
+      expect(configureCode).toContain('Sentry.withSentry(');
+      expect(configureCode).toContain('import * as Sentry from "@sentry/cloudflare"');
+      expect(configureCode).not.toContain('instrument');
+      expect(configureCode).not.toContain('nodejs_compat');
+      expect(configureCode).not.toContain('vercelAIIntegration');
+    });
+
+    it('verifies Workers AI via the env.AI binding', () => {
+      const verifyCode = collectCode(
+        config.verify(
+          makeParams({integration: 'workers_ai', deploymentTarget: 'cloudflare'})
+        )
+      );
+
+      expect(verifyCode).toContain('env.AI.run(');
+    });
+
+    it('uses the nodejs_compat entrypoint and registers the Vercel AI integration', () => {
+      const code = collectCode(
+        config.configure(
+          makeParams({integration: 'vercel_ai', deploymentTarget: 'cloudflare'})
+        )
+      );
+
+      expect(code).toContain('Sentry.withSentry(');
+      expect(code).toContain(
+        'import * as Sentry from "@sentry/cloudflare/nodejs_compat"'
+      );
+      expect(code).toContain('integrations: [Sentry.vercelAIIntegration()]');
+    });
+
+    it('installs @sentry/cloudflare', () => {
+      const code = collectCode(
+        config.install(
+          makeParams({integration: 'openai', deploymentTarget: 'cloudflare'})
+        )
+      );
+
+      expect(code).toContain('npm install @sentry/cloudflare');
+      expect(code).not.toContain('@sentry/node');
+    });
+
+    it('uses Sentry.withSentry for manual instrumentation', () => {
+      const code = collectCode(
+        config.configure(
+          makeParams({integration: 'manual', deploymentTarget: 'cloudflare'})
+        )
+      );
+
+      expect(code).toContain('Sentry.withSentry(');
+      expect(code).not.toContain('Sentry.init(');
+    });
+  });
+});

--- a/static/app/gettingStartedDocs/node/agentMonitoring.spec.tsx
+++ b/static/app/gettingStartedDocs/node/agentMonitoring.spec.tsx
@@ -1,5 +1,4 @@
 import type {
-  ContentBlock,
   DocsParams,
   OnboardingStep,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
@@ -21,13 +20,20 @@ function makeParams(platformOptions: Record<string, string> = {}): DocsParams {
 }
 
 function collectCode(steps: OnboardingStep[]): string {
-  return steps
-    .flatMap(step => step.content ?? [])
-    .filter((block): block is Extract<ContentBlock, {type: 'code'}> => {
-      return block.type === 'code';
-    })
-    .flatMap(block => block.tabs?.map(tab => tab.code) ?? [])
-    .join('\n\n');
+  const codes: string[] = [];
+  for (const step of steps) {
+    for (const block of step.content ?? []) {
+      if (block.type !== 'code') {
+        continue;
+      }
+      if ('tabs' in block) {
+        block.tabs.forEach(tab => codes.push(tab.code));
+      } else {
+        codes.push(block.code);
+      }
+    }
+  }
+  return codes.join('\n\n');
 }
 
 describe('node agentMonitoring onboarding', () => {

--- a/static/app/gettingStartedDocs/node/agentMonitoring.tsx
+++ b/static/app/gettingStartedDocs/node/agentMonitoring.tsx
@@ -197,19 +197,32 @@ const response = await chatModel.invoke(
   { callbacks: [callbackHandler] }
 );`,
   [AgentIntegration.LANGGRAPH]: `import * as Sentry from "@sentry/cloudflare";
-import { createReactAgent } from "@langchain/langgraph/prebuilt";
 import { ChatOpenAI } from "@langchain/openai";
+import { StateGraph, MessagesAnnotation, START, END } from "@langchain/langgraph";
+import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 
-const model = new ChatOpenAI({ modelName: "gpt-5.4" });
+const llm = new ChatOpenAI({ modelName: "gpt-5.4" });
 
-// Setting the agent name helps Sentry identify and group agent activity
-const agent = createReactAgent({ llm: model, tools: [], name: "joke_agent" });
+async function callLLM(state) {
+  const response = await llm.invoke(state.messages);
+  return { messages: [...state.messages, response] };
+}
 
-// Wrap the agent so its calls are captured as AI spans
+const agent = new StateGraph(MessagesAnnotation)
+  .addNode("agent", callLLM)
+  .addEdge(START, "agent")
+  .addEdge("agent", END);
+
+// Instrument the graph BEFORE compiling so its calls are captured as AI spans
 Sentry.instrumentLangGraph(agent);
 
-const result = await agent.invoke({
-  messages: [{ role: "user", content: "Tell me a joke" }],
+const graph = agent.compile({ name: "joke_agent" });
+
+const result = await graph.invoke({
+  messages: [
+    new SystemMessage("You are a helpful assistant."),
+    new HumanMessage("Tell me a joke"),
+  ],
 });`,
 };
 

--- a/static/app/gettingStartedDocs/node/agentMonitoring.tsx
+++ b/static/app/gettingStartedDocs/node/agentMonitoring.tsx
@@ -14,13 +14,229 @@ import {ManualInstrumentationNote} from 'sentry/views/insights/pages/agents/llmO
 import {
   AGENT_INTEGRATION_LABELS,
   AgentIntegration,
+  DeploymentTarget,
 } from 'sentry/views/insights/pages/agents/utils/agentIntegrations';
 
 export const MIN_REQUIRED_VERSION = '10.61.0';
 
+const CLOUDFLARE_AGENT_TRACING_DOCS =
+  'https://docs.sentry.io/platforms/javascript/guides/cloudflare/agent-tracing/';
+const CLOUDFLARE_DURABLE_OBJECTS_DOCS =
+  'https://docs.sentry.io/platforms/javascript/guides/cloudflare/features/durableobject/';
+const CLOUDFLARE_AGENTS_SDK_DOCS =
+  'https://docs.sentry.io/platforms/javascript/guides/cloudflare/features/agents-sdk/';
+
 export function getAgentIntegration(params: DocsParams): AgentIntegration {
   return (params.platformOptions?.integration ??
     AgentIntegration.VERCEL_AI) as AgentIntegration;
+}
+
+export function getDeploymentTarget(params: DocsParams): DeploymentTarget {
+  return (params.platformOptions?.deploymentTarget ??
+    DeploymentTarget.NODE) as DeploymentTarget;
+}
+
+/**
+ * Cloudflare Workers don't expose the public `Sentry.init()` API. Instead the
+ * SDK is bootstrapped by wrapping the worker with `Sentry.withSentry`. The
+ * Vercel AI SDK additionally requires the `nodejs_compat` entrypoint and its
+ * integration to be registered explicitly.
+ *
+ * @see https://docs.sentry.io/platforms/javascript/guides/cloudflare/agent-tracing/
+ */
+function getCloudflareConfigureSnippet({
+  dsn,
+  integration,
+}: {
+  dsn: string;
+  integration?: AgentIntegration;
+}): string {
+  const isVercelAi = integration === AgentIntegration.VERCEL_AI;
+  const importPath = isVercelAi
+    ? '@sentry/cloudflare/nodejs_compat'
+    : '@sentry/cloudflare';
+  const integrationsLine = isVercelAi
+    ? '\n    integrations: [Sentry.vercelAIIntegration()],'
+    : '';
+
+  return `import * as Sentry from "${importPath}";
+
+export default Sentry.withSentry(
+  (env) => ({
+    dsn: "${dsn}",
+    // Tracing must be enabled for agent monitoring to work
+    tracesSampleRate: 1.0,
+    dataCollection: {
+      // Control data collection of LLMs and tools.
+      // For more info visit: https://docs.sentry.io/platforms/javascript/data-management/data-collected/
+      // genAI: { inputs: false, outputs: false },
+    },${integrationsLine}
+  }),
+  {
+    async fetch(request, env, ctx) {
+      // Your worker logic goes here
+      return new Response("Hello World!");
+    },
+  }
+);`;
+}
+
+const WORKERS_AI_DOCS =
+  'https://docs.sentry.io/platforms/javascript/guides/cloudflare/features/workers-ai/';
+const WORKERS_AI_MIN_VERSION = '10.67.0';
+
+/**
+ * `instrumentDurableObjectWithSentry` is the Durable-Object / Agents-SDK
+ * equivalent of `withSentry` - a bootstrapping concern that is independent of
+ * the chosen AI SDK, so this note is shown for every Cloudflare integration.
+ */
+function getDurableObjectsNote(): ContentBlock {
+  return {
+    type: 'text',
+    text: tct(
+      'If your AI calls run inside a [durableObjectsLink:Durable Object] or [agentsSdkLink:Agents SDK] agent rather than the fetch handler, bootstrap Sentry there too with [code:instrumentDurableObjectWithSentry] - it takes the same options as [code:withSentry].',
+      {
+        code: <code />,
+        durableObjectsLink: <ExternalLink href={CLOUDFLARE_DURABLE_OBJECTS_DOCS} />,
+        agentsSdkLink: <ExternalLink href={CLOUDFLARE_AGENTS_SDK_DOCS} />,
+      }
+    ),
+  };
+}
+
+/**
+ * Workers AI (`env.AI`) is Cloudflare-native and auto-instruments once the
+ * Worker is wrapped with `withSentry` - no client wrapping required.
+ *
+ * @see https://docs.sentry.io/platforms/javascript/guides/cloudflare/features/workers-ai/
+ */
+function getWorkersAiNote(): ContentBlock {
+  return {
+    type: 'text',
+    text: tct(
+      "Sentry automatically instruments the [link:Workers AI binding] ([code:env.AI]) once your Worker is wrapped - there's no extra setup. Requires SDK [version] or later.",
+      {
+        code: <code />,
+        link: <ExternalLink href={WORKERS_AI_DOCS} />,
+        version: <code>{WORKERS_AI_MIN_VERSION}</code>,
+      }
+    ),
+  };
+}
+
+/**
+ * Unlike Node's OpenTelemetry-based auto-instrumentation, these SDKs are NOT
+ * auto-instrumented on Cloudflare Workers - the client has to be wrapped
+ * explicitly for AI spans to be captured. Vercel AI (enabled via
+ * `vercelAIIntegration()`) and Workers AI (native `env.AI` binding) are
+ * excluded because they don't require client wrapping.
+ *
+ * @see https://docs.sentry.io/platforms/javascript/guides/cloudflare/agent-tracing/#instrumentation
+ */
+const CLOUDFLARE_WRAP_INTEGRATIONS: readonly AgentIntegration[] = [
+  AgentIntegration.OPENAI,
+  AgentIntegration.ANTHROPIC,
+  AgentIntegration.GOOGLE_GENAI,
+  AgentIntegration.LANGCHAIN,
+  AgentIntegration.LANGGRAPH,
+];
+
+const CLOUDFLARE_WRAP_HELPERS: Partial<Record<AgentIntegration, string>> = {
+  [AgentIntegration.OPENAI]: 'instrumentOpenAiClient',
+  [AgentIntegration.ANTHROPIC]: 'instrumentAnthropicAiClient',
+  [AgentIntegration.GOOGLE_GENAI]: 'instrumentGoogleGenAIClient',
+  [AgentIntegration.LANGCHAIN]: 'createLangChainCallbackHandler',
+  [AgentIntegration.LANGGRAPH]: 'instrumentLangGraph',
+};
+
+const CLOUDFLARE_WRAP_SNIPPETS: Partial<Record<AgentIntegration, string>> = {
+  [AgentIntegration.OPENAI]: `import * as Sentry from "@sentry/cloudflare";
+import OpenAI from "openai";
+
+// Wrap the client so its calls are captured as AI spans
+const client = Sentry.instrumentOpenAiClient(new OpenAI());
+
+const response = await client.responses.create({
+  model: "gpt-5.4",
+  input: "Tell me a joke",
+});`,
+  [AgentIntegration.ANTHROPIC]: `import * as Sentry from "@sentry/cloudflare";
+import Anthropic from "@anthropic-ai/sdk";
+
+// Wrap the client so its calls are captured as AI spans
+const client = Sentry.instrumentAnthropicAiClient(new Anthropic());
+
+const msg = await client.messages.create({
+  model: "claude-sonnet-4-6",
+  messages: [{ role: "user", content: "Tell me a joke" }],
+});`,
+  [AgentIntegration.GOOGLE_GENAI]: `import * as Sentry from "@sentry/cloudflare";
+import { GoogleGenAI } from "@google/genai";
+
+// Wrap the client so its calls are captured as AI spans
+const client = Sentry.instrumentGoogleGenAIClient(new GoogleGenAI());
+
+const response = await client.models.generateContent({
+  model: "gemini-3-flash-preview",
+  contents: "Why is the sky blue?",
+});`,
+  [AgentIntegration.LANGCHAIN]: `import * as Sentry from "@sentry/cloudflare";
+import { ChatOpenAI } from "@langchain/openai";
+import { HumanMessage, SystemMessage } from "@langchain/core/messages";
+
+// Pass the callback handler so LangChain calls are captured as AI spans
+const callbackHandler = Sentry.createLangChainCallbackHandler();
+
+const chatModel = new ChatOpenAI({ modelName: "gpt-5.4" });
+
+const response = await chatModel.invoke(
+  [
+    new SystemMessage("You are a helpful assistant."),
+    new HumanMessage("Tell me a joke"),
+  ],
+  { callbacks: [callbackHandler] }
+);`,
+  [AgentIntegration.LANGGRAPH]: `import * as Sentry from "@sentry/cloudflare";
+import { createReactAgent } from "@langchain/langgraph/prebuilt";
+import { ChatOpenAI } from "@langchain/openai";
+
+const model = new ChatOpenAI({ modelName: "gpt-5.4" });
+
+// Setting the agent name helps Sentry identify and group agent activity
+const agent = createReactAgent({ llm: model, tools: [], name: "joke_agent" });
+
+// Wrap the agent so its calls are captured as AI spans
+Sentry.instrumentLangGraph(agent);
+
+const result = await agent.invoke({
+  messages: [{ role: "user", content: "Tell me a joke" }],
+});`,
+};
+
+function getCloudflareWrapBlocks(integration: AgentIntegration): ContentBlock[] {
+  const helper = CLOUDFLARE_WRAP_HELPERS[integration];
+  const code = CLOUDFLARE_WRAP_SNIPPETS[integration];
+
+  if (!helper || !code) {
+    return [];
+  }
+
+  return [
+    {
+      type: 'text',
+      text: tct(
+        "On Cloudflare, [label] isn't auto-instrumented. Wrap your client with [helper] so its calls are captured as AI spans:",
+        {
+          label: AGENT_INTEGRATION_LABELS[integration] ?? integration,
+          helper: <code>{helper}</code>,
+        }
+      ),
+    },
+    {
+      type: 'code',
+      tabs: [{label: 'JavaScript', language: 'javascript', code}],
+    },
+  ];
 }
 
 export const mastraOnboarding: OnboardingConfig = {
@@ -155,7 +371,23 @@ export function getManualConfigureStep(
     sentryImport?: string;
   } = {}
 ): OnboardingStep[] {
+  const isCloudflare = getDeploymentTarget(params) === DeploymentTarget.CLOUDFLARE;
   const importStatement = sentryImport ?? getImport(packageName, importMode).join('\n');
+
+  const code = isCloudflare
+    ? getCloudflareConfigureSnippet({dsn: params.dsn.public})
+    : `${importStatement}
+
+Sentry.init({
+  dsn: "${params.dsn.public}",
+  // Tracing must be enabled for agent monitoring to work
+  tracesSampleRate: 1.0,
+  dataCollection: {
+    // Control data collection of LLMs and tools.
+    // For more info visit: https://docs.sentry.io/platforms/javascript/data-management/data-collected/
+    // genAI: { inputs: false, outputs: false },
+  },
+});`;
 
   return [
     {
@@ -171,25 +403,21 @@ export function getManualConfigureStep(
             {
               label: configFileName ?? 'JavaScript',
               language: 'javascript',
-              code: `${importStatement}
-
-Sentry.init({
-  dsn: "${params.dsn.public}",
-  // Tracing must be enabled for agent monitoring to work
-  tracesSampleRate: 1.0,
-  dataCollection: {
-    // Control data collection of LLMs and tools.
-    // For more info visit: https://docs.sentry.io/platforms/javascript/data-management/data-collected/
-    // genAI: { inputs: false, outputs: false },
-  },
-});`,
+              code,
             },
           ],
         },
+        ...(isCloudflare ? [getDurableObjectsNote()] : []),
         {
           type: 'custom',
           content: (
-            <ManualInstrumentationNote docsLink={<ExternalLink href={docUrl} />} />
+            <ManualInstrumentationNote
+              docsLink={
+                <ExternalLink
+                  href={isCloudflare ? CLOUDFLARE_AGENT_TRACING_DOCS : docUrl}
+                />
+              }
+            />
           ),
         },
       ],
@@ -213,6 +441,11 @@ export function getInstallStep(
     return mastraOnboarding.install(params);
   }
 
+  const resolvedPackageName =
+    getDeploymentTarget(params) === DeploymentTarget.CLOUDFLARE
+      ? '@sentry/cloudflare'
+      : packageName;
+
   return [
     {
       type: StepType.INSTALL,
@@ -227,7 +460,7 @@ export function getInstallStep(
           ),
         },
         getInstallCodeBlock(params, {
-          packageName,
+          packageName: resolvedPackageName,
         }),
       ],
     },
@@ -320,29 +553,15 @@ const result = await agent.generate({
         ]
       : [];
 
-  return [
-    {
-      title: t('Configure'),
-      content:
-        integration === AgentIntegration.MASTRA
-          ? (mastraOnboarding.configure(params)[0]?.content ?? [])
-          : [
-              {
-                type: 'text',
-                text: tct(
-                  'Import and initialize the Sentry SDK - the [integration] will be enabled automatically:',
-                  {
-                    integration: AGENT_INTEGRATION_LABELS[integration] ?? integration,
-                  }
-                ),
-              },
-              {
-                type: 'code',
-                tabs: [
-                  {
-                    label: configFileName ?? 'JavaScript',
-                    language: 'javascript',
-                    code: `${getImport(packageName).join('\n')}
+  const isCloudflare = getDeploymentTarget(params) === DeploymentTarget.CLOUDFLARE;
+  const isCloudflareWrap =
+    isCloudflare && CLOUDFLARE_WRAP_INTEGRATIONS.includes(integration);
+  const isCloudflareWorkersAi =
+    isCloudflare && integration === AgentIntegration.WORKERS_AI;
+
+  const configureCode = isCloudflare
+    ? getCloudflareConfigureSnippet({dsn: params.dsn.public, integration})
+    : `${getImport(packageName).join('\n')}
 
 Sentry.init({
   dsn: "${params.dsn.public}",
@@ -353,10 +572,43 @@ Sentry.init({
     // For more info visit: https://docs.sentry.io/platforms/javascript/data-management/data-collected/
     // genAI: { inputs: false, outputs: false },
   },
-});`,
+});`;
+
+  // On Node the SDK auto-instruments the integration; on Cloudflare the worker is
+  // wrapped and (for most SDKs) the client is instrumented explicitly below.
+  const introText = isCloudflare
+    ? t('Wrap your Worker with the Sentry SDK:')
+    : tct(
+        'Import and initialize the Sentry SDK - the [integration] will be enabled automatically:',
+        {
+          integration: AGENT_INTEGRATION_LABELS[integration] ?? integration,
+        }
+      );
+
+  return [
+    {
+      title: t('Configure'),
+      content:
+        integration === AgentIntegration.MASTRA
+          ? (mastraOnboarding.configure(params)[0]?.content ?? [])
+          : [
+              {
+                type: 'text',
+                text: introText,
+              },
+              {
+                type: 'code',
+                tabs: [
+                  {
+                    label: configFileName ?? 'JavaScript',
+                    language: 'javascript',
+                    code: configureCode,
                   },
                 ],
               },
+              ...(isCloudflareWorkersAi ? [getWorkersAiNote()] : []),
+              ...(isCloudflare ? [getDurableObjectsNote()] : []),
+              ...(isCloudflareWrap ? getCloudflareWrapBlocks(integration) : []),
               ...vercelAiExtraInstrumentation,
             ],
     },
@@ -370,12 +622,31 @@ function getVerifyStep(params: DocsParams): OnboardingStep[] {
     return mastraOnboarding.verify(params);
   }
 
+  // On Cloudflare these SDKs only produce spans through the wrapped client shown
+  // in the Configure step, so the raw-SDK verify snippets below don't apply.
+  const isCloudflareWrap =
+    getDeploymentTarget(params) === DeploymentTarget.CLOUDFLARE &&
+    CLOUDFLARE_WRAP_INTEGRATIONS.includes(selected);
+
   const content: ContentBlock[] = [
     {
       type: 'text',
-      text: t('Verify that your instrumentation works by simply calling your LLM.'),
+      text: isCloudflareWrap
+        ? t(
+            'Trigger your Worker so it makes an AI call through the wrapped client, then confirm the agent spans show up in Sentry.'
+          )
+        : t('Verify that your instrumentation works by simply calling your LLM.'),
     },
   ];
+
+  if (isCloudflareWrap) {
+    return [
+      {
+        type: StepType.VERIFY,
+        content,
+      },
+    ];
+  }
 
   if (selected === AgentIntegration.ANTHROPIC) {
     content.push({
@@ -409,6 +680,22 @@ const client = new OpenAI();
 const response = await client.responses.create({
   model: "gpt-5.4",
   input: "Tell me a joke",
+});`,
+        },
+      ],
+    });
+  }
+
+  if (selected === AgentIntegration.WORKERS_AI) {
+    content.push({
+      type: 'code',
+      tabs: [
+        {
+          label: 'JavaScript',
+          language: 'javascript',
+          code: `// Inside your withSentry fetch handler, call the AI binding:
+const result = await env.AI.run("@cf/meta/llama-3.1-8b-instruct", {
+  messages: [{ role: "user", content: "What is the capital of France?" }],
 });`,
         },
       ],

--- a/static/app/gettingStartedDocs/node/agentMonitoring.tsx
+++ b/static/app/gettingStartedDocs/node/agentMonitoring.tsx
@@ -17,7 +17,9 @@ import {
   DeploymentTarget,
 } from 'sentry/views/insights/pages/agents/utils/agentIntegrations';
 
-export const MIN_REQUIRED_VERSION = '10.61.0';
+// Bumped to 10.67.0 so the install step also satisfies Workers AI, which
+// auto-instruments the `env.AI` binding only from that version.
+export const MIN_REQUIRED_VERSION = '10.67.0';
 
 const CLOUDFLARE_AGENT_TRACING_DOCS =
   'https://docs.sentry.io/platforms/javascript/guides/cloudflare/agent-tracing/';
@@ -83,7 +85,6 @@ export default Sentry.withSentry(
 
 const WORKERS_AI_DOCS =
   'https://docs.sentry.io/platforms/javascript/guides/cloudflare/features/workers-ai/';
-const WORKERS_AI_MIN_VERSION = '10.67.0';
 
 /**
  * `instrumentDurableObjectWithSentry` is the Durable-Object / Agents-SDK
@@ -114,11 +115,10 @@ function getWorkersAiNote(): ContentBlock {
   return {
     type: 'text',
     text: tct(
-      "Sentry automatically instruments the [link:Workers AI binding] ([code:env.AI]) once your Worker is wrapped - there's no extra setup. Requires SDK [version] or later.",
+      "Sentry automatically instruments the [link:Workers AI binding] ([code:env.AI]) once your Worker is wrapped - there's no extra setup.",
       {
         code: <code />,
         link: <ExternalLink href={WORKERS_AI_DOCS} />,
-        version: <code>{WORKERS_AI_MIN_VERSION}</code>,
       }
     ),
   };

--- a/static/app/views/explore/conversations/onboarding.spec.tsx
+++ b/static/app/views/explore/conversations/onboarding.spec.tsx
@@ -1,0 +1,100 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
+import {ProjectFixture} from 'sentry-fixture/project';
+import {ProjectKeysFixture} from 'sentry-fixture/projectKeys';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {textWithMarkupMatcher} from 'sentry-test/utils';
+
+import {PageFiltersStore} from 'sentry/components/pageFilters/store';
+import {ProjectsStore} from 'sentry/stores/projectsStore';
+
+import {ConversationOnboarding} from './onboarding';
+
+describe('ConversationOnboarding deployment target', () => {
+  function setupProject(platform: string) {
+    const organization = OrganizationFixture();
+    const project = ProjectFixture({platform, firstTransactionEvent: false});
+
+    ProjectsStore.loadInitialData([project]);
+    PageFiltersStore.onInitializeUrlState(
+      PageFiltersFixture({projects: [Number(project.id)]}),
+      false
+    );
+
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/keys/`,
+      body: ProjectKeysFixture(),
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/sdks/`,
+      body: {},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/sdk-updates/`,
+      body: [],
+    });
+    // The last onboarding step waits for the first conversation span.
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      body: {data: []},
+    });
+
+    return {organization, project};
+  }
+
+  afterEach(() => {
+    ProjectsStore.reset();
+    MockApiClient.clearMockResponses();
+  });
+
+  it('defaults a Node project to the Node target and installs @sentry/node', async () => {
+    const {organization} = setupProject('node');
+
+    render(<ConversationOnboarding onDismiss={jest.fn()} />, {organization});
+
+    expect(await screen.findByRole('button', {name: 'Node'})).toBeInTheDocument();
+    expect(
+      (await screen.findAllByText(textWithMarkupMatcher(/npm install @sentry\/node/)))
+        .length
+    ).toBeGreaterThan(0);
+  });
+
+  it('pins Cloudflare projects to the Cloudflare runtime with no Node toggle', async () => {
+    const {organization} = setupProject('node-cloudflare-workers');
+
+    render(<ConversationOnboarding onDismiss={jest.fn()} />, {organization});
+
+    expect(
+      (
+        await screen.findAllByText(
+          textWithMarkupMatcher(/npm install @sentry\/cloudflare/)
+        )
+      ).length
+    ).toBeGreaterThan(0);
+    expect(screen.queryByRole('button', {name: 'Node'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Cloudflare'})).not.toBeInTheDocument();
+  });
+
+  it('switches instructions when the deployment target changes', async () => {
+    const {organization} = setupProject('node');
+
+    render(<ConversationOnboarding onDismiss={jest.fn()} />, {organization});
+
+    expect(
+      (await screen.findAllByText(textWithMarkupMatcher(/npm install @sentry\/node/)))
+        .length
+    ).toBeGreaterThan(0);
+
+    await userEvent.click(screen.getByRole('button', {name: 'Node'}));
+    await userEvent.click(await screen.findByRole('option', {name: 'Cloudflare'}));
+
+    expect(
+      (
+        await screen.findAllByText(
+          textWithMarkupMatcher(/npm install @sentry\/cloudflare/)
+        )
+      ).length
+    ).toBeGreaterThan(0);
+  });
+});

--- a/static/app/views/explore/conversations/onboarding.spec.tsx
+++ b/static/app/views/explore/conversations/onboarding.spec.tsx
@@ -8,11 +8,12 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
+import type {PlatformKey} from 'sentry/types/platform';
 
 import {ConversationOnboarding} from './onboarding';
 
 describe('ConversationOnboarding deployment target', () => {
-  function setupProject(platform: string) {
+  function setupProject(platform: PlatformKey) {
     const organization = OrganizationFixture();
     const project = ProjectFixture({platform, firstTransactionEvent: false});
 

--- a/static/app/views/explore/conversations/onboarding.tsx
+++ b/static/app/views/explore/conversations/onboarding.tsx
@@ -404,12 +404,13 @@ export function ConversationOnboarding({onDismiss}: {onDismiss: () => void}) {
   // Node-based platforms can deploy to either the Node runtime or Cloudflare
   // Workers, so we let the user pick a target that tailors the instructions.
   const isNodePlatform = (project?.platform ?? '').startsWith('node');
-  const isCloudflarePlatform =
-    project?.platform === 'node-cloudflare-workers' ||
-    project?.platform === 'node-cloudflare-pages';
-  // Cloudflare projects always run on Cloudflare - there's no Node runtime to
-  // switch to - so we only offer the selector for other Node platforms.
-  const showDeploymentTarget = isNodePlatform && !isCloudflarePlatform;
+  // Cloudflare Workers projects are pinned to the Cloudflare (withSentry) setup.
+  // Cloudflare Pages bootstraps via `sentryPagesPlugin` instead, so it's left out
+  // of this selector for now and keeps its existing onboarding.
+  const isCloudflareWorkers = project?.platform === 'node-cloudflare-workers';
+  const isCloudflarePages = project?.platform === 'node-cloudflare-pages';
+  const showDeploymentTarget =
+    isNodePlatform && !isCloudflareWorkers && !isCloudflarePages;
 
   const deploymentTargetOptions: BasePlatformOptions = showDeploymentTarget
     ? {
@@ -429,9 +430,9 @@ export function ConversationOnboarding({onDismiss}: {onDismiss: () => void}) {
 
   const selectedDeploymentTarget = useUrlPlatformOptions(deploymentTargetOptions)
     .deploymentTarget as DeploymentTarget | undefined;
-  // Cloudflare projects are pinned to the Cloudflare runtime; other Node projects
-  // follow the selector (defaulting to Node).
-  const deploymentTarget = isCloudflarePlatform
+  // Cloudflare Workers projects are pinned to the Cloudflare runtime; other Node
+  // projects follow the selector (defaulting to Node).
+  const deploymentTarget = isCloudflareWorkers
     ? DeploymentTarget.CLOUDFLARE
     : selectedDeploymentTarget;
   const isCloudflareTarget =

--- a/static/app/views/explore/conversations/onboarding.tsx
+++ b/static/app/views/explore/conversations/onboarding.tsx
@@ -519,7 +519,8 @@ export function ConversationOnboarding({onDismiss}: {onDismiss: () => void}) {
     isSelfHosted,
   };
 
-  const selectedIntegration = selectedPlatformOptions.integration;
+  const selectedIntegration =
+    selectedPlatformOptions.integration ?? AgentIntegration.VERCEL_AI;
   const jsPackageName = isCloudflareTarget ? '@sentry/cloudflare' : '@sentry/node';
 
   const steps: OnboardingStep[] = [

--- a/static/app/views/explore/conversations/onboarding.tsx
+++ b/static/app/views/explore/conversations/onboarding.tsx
@@ -57,6 +57,10 @@ import {
   AGENT_INTEGRATION_ICONS,
   AGENT_INTEGRATION_LABELS,
   AgentIntegration,
+  CLOUDFLARE_AGENT_INTEGRATIONS,
+  DEPLOYMENT_TARGET_ICONS,
+  DEPLOYMENT_TARGET_LABELS,
+  DeploymentTarget,
   NODE_AGENT_INTEGRATIONS,
   PHP_AGENT_INTEGRATIONS,
   PYTHON_AGENT_INTEGRATIONS,
@@ -228,7 +232,8 @@ function ConversationOnboardingPanel({
 
 function getConversationIdStep(
   integration: string,
-  platform: 'javascript' | 'php' | 'python'
+  platform: 'javascript' | 'php' | 'python',
+  jsPackageName = '@sentry/node'
 ): OnboardingStep {
   const isOpenAI =
     integration === AgentIntegration.OPENAI ||
@@ -280,7 +285,7 @@ sentry_sdk.ai.set_conversation_id("my-conversation-123")`,
       : {
           type: 'code',
           language: 'javascript',
-          code: `import * as Sentry from "@sentry/node";
+          code: `import * as Sentry from "${jsPackageName}";
 
 // Call this at the start of each conversation
 Sentry.setConversationId("my-conversation-123");`,
@@ -313,7 +318,10 @@ Sentry.setConversationId("my-conversation-123");`,
   };
 }
 
-function getSetUserStep(isPython: boolean): OnboardingStep {
+function getSetUserStep(
+  isPython: boolean,
+  jsPackageName = '@sentry/node'
+): OnboardingStep {
   const content: ContentBlock[] = [
     {
       type: 'text',
@@ -333,7 +341,7 @@ sentry_sdk.set_user({"id": "user_123", "email": "jane@example.com", "username": 
       : {
           type: 'code' as const,
           language: 'javascript',
-          code: `import * as Sentry from "@sentry/node";
+          code: `import * as Sentry from "${jsPackageName}";
 
 // Call this once per request / session, before any AI calls
 Sentry.setUser({ id: "user_123", email: "jane@example.com", username: "jane" });`,
@@ -392,14 +400,54 @@ export function ConversationOnboarding({onDismiss}: {onDismiss: () => void}) {
 
   const isPythonPlatform = (project?.platform ?? '').startsWith('python');
   const isPhpPlatform = (project?.platform ?? '').startsWith('php');
+  // Node-based platforms can deploy to either the Node runtime or Cloudflare
+  // Workers, so we let the user pick a target that tailors the instructions.
+  const isNodePlatform = (project?.platform ?? '').startsWith('node');
+  const isCloudflarePlatform =
+    project?.platform === 'node-cloudflare-workers' ||
+    project?.platform === 'node-cloudflare-pages';
+  // Cloudflare projects always run on Cloudflare - there's no Node runtime to
+  // switch to - so we only offer the selector for other Node platforms.
+  const showDeploymentTarget = isNodePlatform && !isCloudflarePlatform;
+
+  const deploymentTargetOptions = showDeploymentTarget
+    ? {
+        deploymentTarget: {
+          label: t('Deployment'),
+          defaultValue: DeploymentTarget.NODE,
+          items: [DeploymentTarget.NODE, DeploymentTarget.CLOUDFLARE].map(target => ({
+            label: DEPLOYMENT_TARGET_LABELS[target],
+            value: target,
+            leadingItems: (
+              <PlatformIcon platform={DEPLOYMENT_TARGET_ICONS[target]} size={16} />
+            ),
+          })),
+        },
+      }
+    : {};
+
+  const selectedDeploymentTarget = (
+    useUrlPlatformOptions(deploymentTargetOptions) as {
+      deploymentTarget?: DeploymentTarget;
+    }
+  ).deploymentTarget;
+  // Cloudflare projects are pinned to the Cloudflare runtime; other Node projects
+  // follow the selector (defaulting to Node).
+  const deploymentTarget = isCloudflarePlatform
+    ? DeploymentTarget.CLOUDFLARE
+    : selectedDeploymentTarget;
+  const isCloudflareTarget =
+    isNodePlatform && deploymentTarget === DeploymentTarget.CLOUDFLARE;
 
   const integrations = isPythonPlatform
     ? PYTHON_AGENT_INTEGRATIONS
     : isPhpPlatform
       ? PHP_AGENT_INTEGRATIONS
-      : NODE_AGENT_INTEGRATIONS;
+      : isCloudflareTarget
+        ? CLOUDFLARE_AGENT_INTEGRATIONS
+        : NODE_AGENT_INTEGRATIONS;
 
-  const integrationOptions = {
+  const platformOptions = {
     integration: {
       label: t('Integration'),
       items: integrations.map(integration => ({
@@ -419,9 +467,10 @@ export function ConversationOnboarding({onDismiss}: {onDismiss: () => void}) {
         ),
       })),
     },
+    ...deploymentTargetOptions,
   };
 
-  const selectedPlatformOptions = useUrlPlatformOptions(integrationOptions);
+  const selectedPlatformOptions = useUrlPlatformOptions(platformOptions);
 
   const {isPending: isLoadingRegistry, data: registryData} =
     useSourcePackageRegistries(organization);
@@ -466,22 +515,24 @@ export function ConversationOnboarding({onDismiss}: {onDismiss: () => void}) {
       isLoading: isLoadingRegistry,
       data: registryData,
     },
-    platformOptions: selectedPlatformOptions,
+    platformOptions: {...selectedPlatformOptions, deploymentTarget},
     docsLocation: DocsPageLocation.PROFILING_PAGE,
     urlPrefix,
     isSelfHosted,
   };
 
   const selectedIntegration = selectedPlatformOptions.integration;
+  const jsPackageName = isCloudflareTarget ? '@sentry/cloudflare' : '@sentry/node';
 
   const steps: OnboardingStep[] = [
     ...(agentMonitoringDocs.install?.(docParams) || []),
     ...(agentMonitoringDocs.configure?.(docParams) || []),
     getConversationIdStep(
       selectedIntegration,
-      isPythonPlatform ? 'python' : isPhpPlatform ? 'php' : 'javascript'
+      isPythonPlatform ? 'python' : isPhpPlatform ? 'php' : 'javascript',
+      jsPackageName
     ),
-    ...(isPhpPlatform ? [] : [getSetUserStep(isPythonPlatform)]),
+    ...(isPhpPlatform ? [] : [getSetUserStep(isPythonPlatform, jsPackageName)]),
     ...(isPhpPlatform
       ? [getPhpConversationVerifyStep()]
       : agentMonitoringDocs.verify?.(docParams) || []),
@@ -494,7 +545,10 @@ export function ConversationOnboarding({onDismiss}: {onDismiss: () => void}) {
       <SetupTitle project={project} />
       <Stack gap="md">
         <Flex gap="md" align="center" wrap="wrap">
-          <PlatformOptionDropdown platformOptions={integrationOptions} />
+          <PlatformOptionDropdown
+            platformOptions={platformOptions}
+            connectors={{deploymentTarget: t('on')}}
+          />
         </Flex>
         {introduction && <Prose>{introduction}</Prose>}
         <GuidedSteps

--- a/static/app/views/explore/conversations/onboarding.tsx
+++ b/static/app/views/explore/conversations/onboarding.tsx
@@ -24,6 +24,7 @@ import {
 } from 'sentry/components/onboarding/gettingStartedDoc/selectedCodeTabContext';
 import {StepTitles} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import type {
+  BasePlatformOptions,
   DocsParams,
   OnboardingStep,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
@@ -410,7 +411,7 @@ export function ConversationOnboarding({onDismiss}: {onDismiss: () => void}) {
   // switch to - so we only offer the selector for other Node platforms.
   const showDeploymentTarget = isNodePlatform && !isCloudflarePlatform;
 
-  const deploymentTargetOptions = showDeploymentTarget
+  const deploymentTargetOptions: BasePlatformOptions = showDeploymentTarget
     ? {
         deploymentTarget: {
           label: t('Deployment'),
@@ -426,11 +427,8 @@ export function ConversationOnboarding({onDismiss}: {onDismiss: () => void}) {
       }
     : {};
 
-  const selectedDeploymentTarget = (
-    useUrlPlatformOptions(deploymentTargetOptions) as {
-      deploymentTarget?: DeploymentTarget;
-    }
-  ).deploymentTarget;
+  const selectedDeploymentTarget = useUrlPlatformOptions(deploymentTargetOptions)
+    .deploymentTarget as DeploymentTarget | undefined;
   // Cloudflare projects are pinned to the Cloudflare runtime; other Node projects
   // follow the selector (defaulting to Node).
   const deploymentTarget = isCloudflarePlatform
@@ -447,7 +445,7 @@ export function ConversationOnboarding({onDismiss}: {onDismiss: () => void}) {
         ? CLOUDFLARE_AGENT_INTEGRATIONS
         : NODE_AGENT_INTEGRATIONS;
 
-  const platformOptions = {
+  const platformOptions: BasePlatformOptions = {
     integration: {
       label: t('Integration'),
       items: integrations.map(integration => ({

--- a/static/app/views/insights/pages/agents/onboarding.spec.tsx
+++ b/static/app/views/insights/pages/agents/onboarding.spec.tsx
@@ -1,10 +1,15 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
+import {ProjectKeysFixture} from 'sentry-fixture/projectKeys';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
-import {NoDocsOnboarding, UnsupportedPlatformOnboarding} from './onboarding';
+import {PageFiltersStore} from 'sentry/components/pageFilters/store';
+import {ProjectsStore} from 'sentry/stores/projectsStore';
+
+import {NoDocsOnboarding, Onboarding, UnsupportedPlatformOnboarding} from './onboarding';
 
 describe('UnsupportedPlatformOnboarding', () => {
   const project = ProjectFixture();
@@ -47,6 +52,118 @@ describe('UnsupportedPlatformOnboarding', () => {
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
       expect.stringContaining('Instrument Sentry AI Agent Monitoring')
     );
+  });
+});
+
+describe('Onboarding deployment target', () => {
+  function setupProject(platform: string) {
+    const organization = OrganizationFixture();
+    const project = ProjectFixture({platform, firstTransactionEvent: false});
+
+    ProjectsStore.loadInitialData([project]);
+    PageFiltersStore.onInitializeUrlState(
+      PageFiltersFixture({projects: [Number(project.id)]}),
+      false
+    );
+
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/keys/`,
+      body: ProjectKeysFixture(),
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/sdks/`,
+      body: {},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/sdk-updates/`,
+      body: [],
+    });
+    // The last onboarding step waits for the first AI span via a spans query.
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      body: {data: []},
+    });
+
+    return {organization, project};
+  }
+
+  afterEach(() => {
+    ProjectsStore.reset();
+    MockApiClient.clearMockResponses();
+  });
+
+  it('defaults a Node project to the Node target and installs @sentry/node', async () => {
+    const {organization} = setupProject('node');
+
+    render(<Onboarding />, {organization});
+
+    // The deployment-target selector renders alongside the integration selector
+    expect(await screen.findByRole('button', {name: 'Node'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Vercel AI SDK'})).toBeInTheDocument();
+    expect(
+      (await screen.findAllByText(textWithMarkupMatcher(/npm install @sentry\/node/)))
+        .length
+    ).toBeGreaterThan(0);
+  });
+
+  it('pins Cloudflare projects to the Cloudflare runtime with no Node toggle', async () => {
+    const {organization} = setupProject('node-cloudflare-workers');
+
+    render(<Onboarding />, {organization});
+
+    // Cloudflare install instructions render...
+    expect(
+      (
+        await screen.findAllByText(
+          textWithMarkupMatcher(/npm install @sentry\/cloudflare/)
+        )
+      ).length
+    ).toBeGreaterThan(0);
+    // ...but there is no Node/Cloudflare deployment selector (it's always Cloudflare)
+    expect(screen.queryByRole('button', {name: 'Node'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Cloudflare'})).not.toBeInTheDocument();
+  });
+
+  it('offers Workers AI as an integration only on the Cloudflare target', async () => {
+    const {organization} = setupProject('node');
+
+    render(<Onboarding />, {organization});
+
+    // Node target: Workers AI is not in the integration list
+    await userEvent.click(await screen.findByRole('button', {name: 'Vercel AI SDK'}));
+    expect(screen.queryByRole('option', {name: 'Workers AI'})).not.toBeInTheDocument();
+    await userEvent.keyboard('{Escape}');
+
+    // Switch to the Cloudflare target
+    await userEvent.click(screen.getByRole('button', {name: 'Node'}));
+    await userEvent.click(await screen.findByRole('option', {name: 'Cloudflare'}));
+
+    // Cloudflare target: Workers AI is now offered
+    await userEvent.click(await screen.findByRole('button', {name: 'Vercel AI SDK'}));
+    expect(await screen.findByRole('option', {name: 'Workers AI'})).toBeInTheDocument();
+  });
+
+  it('switches instructions when the deployment target changes', async () => {
+    const {organization} = setupProject('node');
+
+    render(<Onboarding />, {organization});
+
+    // Starts on the Node target
+    expect(
+      (await screen.findAllByText(textWithMarkupMatcher(/npm install @sentry\/node/)))
+        .length
+    ).toBeGreaterThan(0);
+
+    await userEvent.click(screen.getByRole('button', {name: 'Node'}));
+    await userEvent.click(await screen.findByRole('option', {name: 'Cloudflare'}));
+
+    expect(
+      (
+        await screen.findAllByText(
+          textWithMarkupMatcher(/npm install @sentry\/cloudflare/)
+        )
+      ).length
+    ).toBeGreaterThan(0);
   });
 });
 

--- a/static/app/views/insights/pages/agents/onboarding.spec.tsx
+++ b/static/app/views/insights/pages/agents/onboarding.spec.tsx
@@ -8,6 +8,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
+import type {PlatformKey} from 'sentry/types/platform';
 
 import {NoDocsOnboarding, Onboarding, UnsupportedPlatformOnboarding} from './onboarding';
 
@@ -56,7 +57,7 @@ describe('UnsupportedPlatformOnboarding', () => {
 });
 
 describe('Onboarding deployment target', () => {
-  function setupProject(platform: string) {
+  function setupProject(platform: PlatformKey) {
     const organization = OrganizationFixture();
     const project = ProjectFixture({platform, firstTransactionEvent: false});
 

--- a/static/app/views/insights/pages/agents/onboarding.spec.tsx
+++ b/static/app/views/insights/pages/agents/onboarding.spec.tsx
@@ -107,7 +107,7 @@ describe('Onboarding deployment target', () => {
     ).toBeGreaterThan(0);
   });
 
-  it('pins Cloudflare projects to the Cloudflare runtime with no Node toggle', async () => {
+  it('pins Cloudflare Workers projects to the Cloudflare runtime with no Node toggle', async () => {
     const {organization} = setupProject('node-cloudflare-workers');
 
     render(<Onboarding />, {organization});
@@ -121,6 +121,19 @@ describe('Onboarding deployment target', () => {
       ).length
     ).toBeGreaterThan(0);
     // ...but there is no Node/Cloudflare deployment selector (it's always Cloudflare)
+    expect(screen.queryByRole('button', {name: 'Node'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Cloudflare'})).not.toBeInTheDocument();
+  });
+
+  it('does not show the deployment selector for Cloudflare Pages', async () => {
+    const {organization} = setupProject('node-cloudflare-pages');
+
+    render(<Onboarding />, {organization});
+
+    // Pages keeps its existing onboarding and is left out of the runtime selector
+    expect(
+      await screen.findByRole('button', {name: 'Vercel AI SDK'})
+    ).toBeInTheDocument();
     expect(screen.queryByRole('button', {name: 'Node'})).not.toBeInTheDocument();
     expect(screen.queryByRole('button', {name: 'Cloudflare'})).not.toBeInTheDocument();
   });

--- a/static/app/views/insights/pages/agents/onboarding.tsx
+++ b/static/app/views/insights/pages/agents/onboarding.tsx
@@ -250,12 +250,13 @@ export function Onboarding() {
   // Node-based platforms can deploy their agents to either the Node runtime or
   // Cloudflare Workers, so we let the user pick a target that tailors the setup.
   const isNodePlatform = (project?.platform ?? '').startsWith('node');
-  const isCloudflarePlatform =
-    project?.platform === 'node-cloudflare-workers' ||
-    project?.platform === 'node-cloudflare-pages';
-  // Cloudflare projects always run on Cloudflare - there's no Node runtime to
-  // switch to - so we only offer the selector for other Node platforms.
-  const showDeploymentTarget = isNodePlatform && !isCloudflarePlatform;
+  // Cloudflare Workers projects are pinned to the Cloudflare (withSentry) setup.
+  // Cloudflare Pages bootstraps via `sentryPagesPlugin` instead, so it's left out
+  // of this selector for now and keeps its existing onboarding.
+  const isCloudflareWorkers = project?.platform === 'node-cloudflare-workers';
+  const isCloudflarePages = project?.platform === 'node-cloudflare-pages';
+  const showDeploymentTarget =
+    isNodePlatform && !isCloudflareWorkers && !isCloudflarePages;
 
   const deploymentTargetOptions: BasePlatformOptions = showDeploymentTarget
     ? {
@@ -275,9 +276,9 @@ export function Onboarding() {
 
   const selectedDeploymentTarget = useUrlPlatformOptions(deploymentTargetOptions)
     .deploymentTarget as DeploymentTarget | undefined;
-  // Cloudflare projects are pinned to the Cloudflare runtime; other Node projects
-  // follow the selector (defaulting to Node).
-  const deploymentTarget = isCloudflarePlatform
+  // Cloudflare Workers projects are pinned to the Cloudflare runtime; other Node
+  // projects follow the selector (defaulting to Node).
+  const deploymentTarget = isCloudflareWorkers
     ? DeploymentTarget.CLOUDFLARE
     : selectedDeploymentTarget;
   const isCloudflareTarget =

--- a/static/app/views/insights/pages/agents/onboarding.tsx
+++ b/static/app/views/insights/pages/agents/onboarding.tsx
@@ -22,6 +22,7 @@ import {
 } from 'sentry/components/onboarding/gettingStartedDoc/selectedCodeTabContext';
 import {StepTitles} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import type {
+  BasePlatformOptions,
   DocsParams,
   OnboardingStep,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
@@ -256,7 +257,7 @@ export function Onboarding() {
   // switch to - so we only offer the selector for other Node platforms.
   const showDeploymentTarget = isNodePlatform && !isCloudflarePlatform;
 
-  const deploymentTargetOptions = showDeploymentTarget
+  const deploymentTargetOptions: BasePlatformOptions = showDeploymentTarget
     ? {
         deploymentTarget: {
           label: t('Deployment'),
@@ -272,11 +273,8 @@ export function Onboarding() {
       }
     : {};
 
-  const selectedDeploymentTarget = (
-    useUrlPlatformOptions(deploymentTargetOptions) as {
-      deploymentTarget?: DeploymentTarget;
-    }
-  ).deploymentTarget;
+  const selectedDeploymentTarget = useUrlPlatformOptions(deploymentTargetOptions)
+    .deploymentTarget as DeploymentTarget | undefined;
   // Cloudflare projects are pinned to the Cloudflare runtime; other Node projects
   // follow the selector (defaulting to Node).
   const deploymentTarget = isCloudflarePlatform
@@ -295,7 +293,7 @@ export function Onboarding() {
           ? CLOUDFLARE_AGENT_INTEGRATIONS
           : NODE_AGENT_INTEGRATIONS;
 
-  const platformOptions = {
+  const platformOptions: BasePlatformOptions = {
     integration: {
       label: t('Integration'),
       items: integrations.map(integration => ({

--- a/static/app/views/insights/pages/agents/onboarding.tsx
+++ b/static/app/views/insights/pages/agents/onboarding.tsx
@@ -400,6 +400,9 @@ export function Onboarding() {
         </p>
       </DescriptionWrapper>
       <GuidedSteps
+        // Remount when the integration or runtime changes so the stepper doesn't
+        // carry over stale per-step state from the previous selection.
+        key={`${selectedPlatformOptions.integration}-${deploymentTarget}`}
         initialStep={decodeInteger(location.query.guidedStep)}
         onStepChange={step => {
           navigate({

--- a/static/app/views/insights/pages/agents/onboarding.tsx
+++ b/static/app/views/insights/pages/agents/onboarding.tsx
@@ -52,7 +52,11 @@ import {LLM_ONBOARDING_COPY_MARKDOWN} from 'sentry/views/insights/pages/agents/l
 import {
   AGENT_INTEGRATION_ICONS,
   AGENT_INTEGRATION_LABELS,
+  CLOUDFLARE_AGENT_INTEGRATIONS,
   DENO_AGENT_INTEGRATIONS,
+  DEPLOYMENT_TARGET_ICONS,
+  DEPLOYMENT_TARGET_LABELS,
+  DeploymentTarget,
   NODE_AGENT_INTEGRATIONS,
   PHP_AGENT_INTEGRATIONS,
   PYTHON_AGENT_INTEGRATIONS,
@@ -242,6 +246,44 @@ export function Onboarding() {
   const isPythonPlatform = (project?.platform ?? '').startsWith('python');
   const isDenoPlatform = project?.platform === 'deno';
   const isPhpPlatform = (project?.platform ?? '').startsWith('php');
+  // Node-based platforms can deploy their agents to either the Node runtime or
+  // Cloudflare Workers, so we let the user pick a target that tailors the setup.
+  const isNodePlatform = (project?.platform ?? '').startsWith('node');
+  const isCloudflarePlatform =
+    project?.platform === 'node-cloudflare-workers' ||
+    project?.platform === 'node-cloudflare-pages';
+  // Cloudflare projects always run on Cloudflare - there's no Node runtime to
+  // switch to - so we only offer the selector for other Node platforms.
+  const showDeploymentTarget = isNodePlatform && !isCloudflarePlatform;
+
+  const deploymentTargetOptions = showDeploymentTarget
+    ? {
+        deploymentTarget: {
+          label: t('Deployment'),
+          defaultValue: DeploymentTarget.NODE,
+          items: [DeploymentTarget.NODE, DeploymentTarget.CLOUDFLARE].map(target => ({
+            label: DEPLOYMENT_TARGET_LABELS[target],
+            value: target,
+            leadingItems: (
+              <PlatformIcon platform={DEPLOYMENT_TARGET_ICONS[target]} size={16} />
+            ),
+          })),
+        },
+      }
+    : {};
+
+  const selectedDeploymentTarget = (
+    useUrlPlatformOptions(deploymentTargetOptions) as {
+      deploymentTarget?: DeploymentTarget;
+    }
+  ).deploymentTarget;
+  // Cloudflare projects are pinned to the Cloudflare runtime; other Node projects
+  // follow the selector (defaulting to Node).
+  const deploymentTarget = isCloudflarePlatform
+    ? DeploymentTarget.CLOUDFLARE
+    : selectedDeploymentTarget;
+  const isCloudflareTarget =
+    isNodePlatform && deploymentTarget === DeploymentTarget.CLOUDFLARE;
 
   const integrations = isPythonPlatform
     ? PYTHON_AGENT_INTEGRATIONS
@@ -249,9 +291,11 @@ export function Onboarding() {
       ? DENO_AGENT_INTEGRATIONS
       : isPhpPlatform
         ? PHP_AGENT_INTEGRATIONS
-        : NODE_AGENT_INTEGRATIONS;
+        : isCloudflareTarget
+          ? CLOUDFLARE_AGENT_INTEGRATIONS
+          : NODE_AGENT_INTEGRATIONS;
 
-  const integrationOptions = {
+  const platformOptions = {
     integration: {
       label: t('Integration'),
       items: integrations.map(integration => ({
@@ -271,9 +315,10 @@ export function Onboarding() {
         ),
       })),
     },
+    ...deploymentTargetOptions,
   };
 
-  const selectedPlatformOptions = useUrlPlatformOptions(integrationOptions);
+  const selectedPlatformOptions = useUrlPlatformOptions(platformOptions);
 
   const {isPending: isLoadingRegistry, data: registryData} =
     useSourcePackageRegistries(organization);
@@ -318,7 +363,7 @@ export function Onboarding() {
       isLoading: isLoadingRegistry,
       data: registryData,
     },
-    platformOptions: selectedPlatformOptions,
+    platformOptions: {...selectedPlatformOptions, deploymentTarget},
     docsLocation: DocsPageLocation.PROFILING_PAGE,
     urlPrefix,
     isSelfHosted,
@@ -336,7 +381,10 @@ export function Onboarding() {
     <OnboardingPanel project={project}>
       <SetupTitle project={project} />
       <OptionsWrapper>
-        <PlatformOptionDropdown platformOptions={integrationOptions} />
+        <PlatformOptionDropdown
+          platformOptions={platformOptions}
+          connectors={{deploymentTarget: t('on')}}
+        />
       </OptionsWrapper>
       {introduction && <DescriptionWrapper>{introduction}</DescriptionWrapper>}
       <DescriptionWrapper>

--- a/static/app/views/insights/pages/agents/utils/agentIntegrations.tsx
+++ b/static/app/views/insights/pages/agents/utils/agentIntegrations.tsx
@@ -9,6 +9,9 @@ export enum AgentIntegration {
   MASTRA = 'mastra',
   PYDANTIC_AI = 'pydantic_ai',
   VERCEL_AI = 'vercel_ai',
+  // Cloudflare-only: the Workers AI binding (env.AI) auto-instruments once the
+  // Worker is wrapped with Sentry.
+  WORKERS_AI = 'workers_ai',
   MANUAL = 'manual',
 }
 
@@ -23,6 +26,7 @@ export const AGENT_INTEGRATION_LABELS = {
   [AgentIntegration.MASTRA]: 'Mastra',
   [AgentIntegration.PYDANTIC_AI]: 'Pydantic AI',
   [AgentIntegration.VERCEL_AI]: 'Vercel AI SDK',
+  [AgentIntegration.WORKERS_AI]: 'Workers AI',
   [AgentIntegration.MANUAL]: 'Other',
 };
 
@@ -37,6 +41,7 @@ export const AGENT_INTEGRATION_ICONS: Record<AgentIntegration, string> = {
   [AgentIntegration.MASTRA]: 'mastra',
   [AgentIntegration.PYDANTIC_AI]: 'pydantic-ai',
   [AgentIntegration.VERCEL_AI]: 'vercel',
+  [AgentIntegration.WORKERS_AI]: 'cloudflare',
   [AgentIntegration.MANUAL]: 'default',
 };
 
@@ -69,3 +74,41 @@ export const DENO_AGENT_INTEGRATIONS = [
 ];
 
 export const PHP_AGENT_INTEGRATIONS = [AgentIntegration.MANUAL];
+
+/**
+ * Where a Node-based project deploys its AI agents. This drives which setup
+ * instructions we render in the onboarding empty state (Node runtime vs. the
+ * Cloudflare `withSentry` flow).
+ */
+export enum DeploymentTarget {
+  NODE = 'node',
+  CLOUDFLARE = 'cloudflare',
+}
+
+export const DEPLOYMENT_TARGET_LABELS = {
+  [DeploymentTarget.NODE]: 'Node',
+  [DeploymentTarget.CLOUDFLARE]: 'Cloudflare',
+};
+
+export const DEPLOYMENT_TARGET_ICONS: Record<DeploymentTarget, string> = {
+  [DeploymentTarget.NODE]: 'node',
+  [DeploymentTarget.CLOUDFLARE]: 'cloudflare',
+};
+
+/**
+ * Integrations documented for the Cloudflare deployment target. Mirrors the
+ * Node list minus Mastra, whose `@mastra/sentry` exporter is not part of the
+ * Cloudflare `withSentry` flow.
+ *
+ * @see https://docs.sentry.io/platforms/javascript/guides/cloudflare/agent-tracing/
+ */
+export const CLOUDFLARE_AGENT_INTEGRATIONS = [
+  AgentIntegration.VERCEL_AI,
+  AgentIntegration.WORKERS_AI,
+  AgentIntegration.ANTHROPIC,
+  AgentIntegration.GOOGLE_GENAI,
+  AgentIntegration.LANGCHAIN,
+  AgentIntegration.LANGGRAPH,
+  AgentIntegration.OPENAI,
+  AgentIntegration.MANUAL,
+];


### PR DESCRIPTION
Developers setting up AI agent monitoring get instructions that match where their agent actually runs. The AI Agents and Conversations onboarding empty states now let Node projects choose between the **Node** and **Cloudflare** runtimes, and render setup steps tailored to that choice. Cloudflare Workers/Pages projects are pinned to Cloudflare (no meaningless "Node" option); every other Node project defaults to Node and can switch.

This also corrects Cloudflare instructions that previously wouldn't have worked: Cloudflare Workers don't expose `Sentry.init()`, and most AI SDKs aren't auto-instrumented there.

## What a developer sees now

The onboarding reads `with <integration> on <runtime>`. Picking a runtime changes the install package, the SDK bootstrapping, and which integrations are offered.

**Base setup**

|  | Node | Cloudflare |
|---|---|---|
| Install | `@sentry/node` (or framework package) | `@sentry/cloudflare` |
| Init | `Sentry.init({ …, dataCollection })` | `Sentry.withSentry((env) => ({ …dataCollection }), { fetch })` |
| Extra note | — | Durable Objects / Agents SDK → `instrumentDurableObjectWithSentry` |

**Per integration** — *auto* = works from init alone · *wrap* = instrument the client explicitly · *integration + telemetry* = register the integration and enable `experimental_telemetry` per call.

| Integration | Node | Cloudflare |
|---|---|---|
| Vercel AI SDK | auto + `experimental_telemetry` | `@sentry/cloudflare/nodejs_compat` + `vercelAIIntegration()` + `experimental_telemetry` |
| Workers AI | *(not offered)* | auto via `env.AI` (SDK ≥ 10.67.0) |
| OpenAI | auto | wrap: `Sentry.instrumentOpenAiClient()` |
| Anthropic | auto | wrap: `Sentry.instrumentAnthropicAiClient()` |
| Google GenAI | auto | wrap: `Sentry.instrumentGoogleGenAIClient()` |
| LangChain | auto | wrap: `Sentry.createLangChainCallbackHandler()` |
| LangGraph | auto | wrap: `Sentry.instrumentLangGraph()` |
| Mastra | `@mastra/sentry` exporter | *(not offered)* |
| Other (manual) | `Sentry.init` + manual note | `withSentry` + manual note |

The Conversations onboarding additionally tailors its `setConversationId` / `setUser` snippets to the selected runtime's package.

The runtime selector is only shown for server-side Node platforms (`node`, `node-express`, `node-fastify`, …) plus the Cloudflare platforms. Meta-frameworks (Next.js, Nuxt, SvelteKit, …), Python, PHP, and Deno are unchanged.

