### PR TITLE
fix(search): Preserve Ask Seer combobox sizing

### DIFF
--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.spec.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.spec.tsx
@@ -113,6 +113,25 @@ describe('AskSeerComboBox', () => {
     expect(input).toHaveValue('test ');
   });
 
+  it('applies a class name to the combobox wrapper', async () => {
+    render(
+      <SearchQueryBuilderProvider {...defaultProps}>
+        <AskSeerComboBox
+          className="search-grid-item"
+          initialQuery="test"
+          askSeerMutationOptions={askSeerMutationOptions}
+          applySeerSearchQuery={() => {}}
+        />
+      </SearchQueryBuilderProvider>,
+      {organization}
+    );
+
+    const input = await screen.findByRole('combobox', {
+      name: 'Ask Seer with Natural Language',
+    });
+    expect(input.closest('.search-grid-item')).toBeInTheDocument();
+  });
+
   it('sets the passed initial query as the input value', async () => {
     render(
       <SearchQueryBuilderProvider {...defaultProps}>

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
@@ -30,6 +30,7 @@ export interface AskSeerComboBoxProps<T extends QueryTokensProps> extends Omit<
   applySeerSearchQuery: (item: T) => void;
   askSeerMutationOptions: MutationOptions<AskSeerMutationResult<T>, Error, string>;
   initialQuery: string;
+  className?: string;
 }
 
 export function AskSeerComboBox<T extends QueryTokensProps>({

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
@@ -29,6 +29,7 @@ interface AskSeerPollingComboBoxProps<T extends QueryTokensProps> extends Omit<
   initialQuery: string;
   projectIds: number[];
   strategy: string;
+  className?: string;
   /**
    * Fallback mutation options to use if the polling endpoint fails.
    * If provided, the component will fall back to AskSeerComboBox on start failure.
@@ -118,6 +119,7 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
   if (startFailed && fallbackMutationOptions) {
     return (
       <AskSeerComboBox
+        {...props}
         initialQuery={initialQuery}
         askSeerMutationOptions={fallbackMutationOptions}
         applySeerSearchQuery={applySeerSearchQuery}

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/baseAskSeerComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/baseAskSeerComboBox.tsx
@@ -96,12 +96,14 @@ export interface BaseAskSeerComboBoxProps<T extends QueryTokensProps> extends Om
   queries: T[];
   searchQuery: string;
   submitQuery: (query: string) => void;
+  className?: string;
   onReset?: () => void;
   unsupportedReason?: string | null;
 }
 
 export function BaseAskSeerComboBox<T extends QueryTokensProps>({
   applySeerSearchQuery,
+  className,
   emptyTitle,
   errorTitle,
   isError,
@@ -440,7 +442,7 @@ export function BaseAskSeerComboBox<T extends QueryTokensProps>({
     : Boolean(openForm);
 
   return (
-    <Wrapper ref={containerRef} isDropdownOpen={state.isOpen}>
+    <Wrapper className={className} ref={containerRef} isDropdownOpen={state.isOpen}>
       <PositionedSearchIconContainer>
         <SearchIcon size="sm" />
       </PositionedSearchIconContainer>

--- a/static/app/views/issueList/issueListSeerComboBox.tsx
+++ b/static/app/views/issueList/issueListSeerComboBox.tsx
@@ -28,7 +28,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
-export function IssueListSeerComboBox() {
+export function IssueListSeerComboBox({className}: {className?: string}) {
   const organization = useOrganization();
   const location = useLocation();
   const navigate = useNavigate();
@@ -143,6 +143,7 @@ export function IssueListSeerComboBox() {
 
   return (
     <AskSeerPollingComboBox<AskSeerSearchQuery>
+      className={className}
       initialQuery={initialSeerQuery}
       projectIds={selectedProjectIds}
       strategy="Issues"

--- a/static/app/views/issueList/issueSearch.tsx
+++ b/static/app/views/issueList/issueSearch.tsx
@@ -21,7 +21,7 @@ function IssueSearchBar({query, onSearch, className}: IssueSearchProps) {
   const {displayAskSeer} = useSearchQueryBuilderAI();
 
   if (displayAskSeer) {
-    return <IssueListSeerComboBox />;
+    return <IssueListSeerComboBox className={className} />;
   }
 
   return (


### PR DESCRIPTION
The Issues search bar now preserves its layout class when switching from the regular query builder to Ask Seer, so the natural-language combobox keeps the intended grid placement and expands across the available search area.

The shared Ask Seer combobox and polling fallback now accept and forward `className`, with a regression test covering application of the class to the combobox wrapper.

Closes BROWSE-663

Before:
<img width="1106" height="142" alt="Screenshot 2026-07-30 at 09 18 31" src="https://github.com/user-attachments/assets/a1c2a0d3-9dfa-4cd6-b713-08f82768f5fa" />

After:
<img width="1102" height="145" alt="Screenshot 2026-07-30 at 09 18 17" src="https://github.com/user-attachments/assets/64e6172b-a837-47bc-8192-ea38ed0c5aa4" />