### PR TITLE
feat(ai-monitoring): show conversation title on the details page

### DIFF
--- a/static/app/views/explore/conversations/components/conversationSummary.tsx
+++ b/static/app/views/explore/conversations/components/conversationSummary.tsx
@@ -48,6 +48,8 @@ interface ConversationSummaryProps {
   nodes: AITraceSpanNode[];
   isLoading?: boolean;
   nodeTraceMap?: Map<string, string>;
+  /** Conversation title when Sentry has one; falls back to the id when null. */
+  title?: string | null;
 }
 
 const VISIBLE_TOOL_COUNT = 6;
@@ -55,6 +57,7 @@ const VISIBLE_TOOL_COUNT = 6;
 export function ConversationSummary({
   nodes,
   conversationId,
+  title,
   isLoading,
   nodeTraceMap,
 }: ConversationSummaryProps) {
@@ -66,6 +69,12 @@ export function ConversationSummary({
   const userDisplayName = user ? getUserDisplayName(user) : null;
 
   const displayId = isUUID(conversationId) ? conversationId.slice(0, 8) : conversationId;
+  // Prefer the human-readable title; fall back to the (possibly truncated) id.
+  const headingText = title || displayId;
+  const headingTooltip = title || conversationId;
+  // A UUID id is truncated to 8 chars, so it always needs the tooltip to reveal
+  // the full value; a title or non-UUID id only needs it when it overflows.
+  const headingTooltipOnlyOnOverflow = title ? true : !isUUID(conversationId);
 
   const errorsUrl = getExploreUrl({
     organization,
@@ -111,11 +120,20 @@ export function ConversationSummary({
     >
       <Stack gap="md" minWidth={0} flex={1}>
         <Container minWidth={0}>
-          <Tooltip title={conversationId} showOnlyOnOverflow={!isUUID(conversationId)}>
-            <Heading as="h2" ellipsis>
-              {displayId}
-            </Heading>
-          </Tooltip>
+          {isLoading ? (
+            // The title is only known once the conversation loads, so show a
+            // skeleton rather than briefly flashing the id and swapping it out.
+            <Placeholder width="240px" height="28px" />
+          ) : (
+            <Tooltip
+              title={headingTooltip}
+              showOnlyOnOverflow={headingTooltipOnlyOnOverflow}
+            >
+              <Heading as="h2" ellipsis>
+                {headingText}
+              </Heading>
+            </Tooltip>
+          )}
         </Container>
         <Flex align="center" gap="xl" minWidth={0} wrap="wrap">
           {isLoading ? (

--- a/static/app/views/explore/conversations/components/conversationView.spec.tsx
+++ b/static/app/views/explore/conversations/components/conversationView.spec.tsx
@@ -44,7 +44,7 @@ const CONVERSATION_BODY = [
 function mockConversation() {
   MockApiClient.addMockResponse({
     url: `/organizations/org-slug/ai-conversations/${CONVERSATION_ID}/`,
-    body: CONVERSATION_BODY,
+    body: {conversationId: CONVERSATION_ID, title: null, spans: CONVERSATION_BODY},
   });
   // The detail pane fetches full attributes per span; keep it empty.
   MockApiClient.addMockResponse({

--- a/static/app/views/explore/conversations/conversationDetail.spec.tsx
+++ b/static/app/views/explore/conversations/conversationDetail.spec.tsx
@@ -48,10 +48,10 @@ const CONVERSATION_BODY = [
   }),
 ];
 
-function mockApis() {
+function mockApis(title: string | null = null) {
   MockApiClient.addMockResponse({
     url: `/organizations/org-slug/ai-conversations/${CONVERSATION_ID}/`,
-    body: CONVERSATION_BODY,
+    body: {conversationId: CONVERSATION_ID, title, spans: CONVERSATION_BODY},
   });
   MockApiClient.addMockResponse({
     url: '/organizations/org-slug/trace-items/attributes/',
@@ -145,12 +145,43 @@ describe('ConversationDetailPage breadcrumbs', () => {
     expect(
       await within(topBar).findByRole('link', {name: 'Conversations'})
     ).toBeInTheDocument();
-    // The conversation id is the page heading, owned by the TopBar title slot.
+    // The conversation id is the top-bar identifier, owned by the TopBar title
+    // slot, alongside the copy affordance.
     expect(
       within(topBar).getByRole('heading', {name: new RegExp(CONVERSATION_ID)})
     ).toBeInTheDocument();
     expect(
       within(topBar).getByRole('button', {name: 'Copy conversation ID'})
+    ).toBeInTheDocument();
+  });
+});
+
+describe('ConversationDetailPage title', () => {
+  beforeEach(() => {
+    Element.prototype.scrollTo = jest.fn();
+    MockApiClient.clearMockResponses();
+    act(() => {
+      PageFiltersStore.reset();
+      PageFiltersStore.init();
+    });
+  });
+
+  it('shows the conversation title as the heading when present', async () => {
+    mockApis('Trip planning assistant');
+    renderPage();
+
+    expect(
+      await screen.findByRole('heading', {name: 'Trip planning assistant'})
+    ).toBeInTheDocument();
+  });
+
+  it('falls back to the conversation id heading when there is no title', async () => {
+    mockApis(null);
+    renderPage();
+
+    // Once loaded, the summary heading shows the id (no title available).
+    expect(
+      await screen.findByRole('heading', {name: new RegExp(CONVERSATION_ID)})
     ).toBeInTheDocument();
   });
 });

--- a/static/app/views/explore/conversations/conversationDetail.tsx
+++ b/static/app/views/explore/conversations/conversationDetail.tsx
@@ -43,7 +43,7 @@ function ConversationDetailPage() {
 
   const conversation = useMemo(() => ({conversationId}), [conversationId]);
 
-  const {nodes, nodeTraceMap, isLoading} = useConversation(conversation);
+  const {nodes, nodeTraceMap, isLoading, title} = useConversation(conversation);
 
   const messages = useMemo(() => extractMessagesFromNodes(nodes), [nodes]);
 
@@ -85,6 +85,7 @@ function ConversationDetailPage() {
           nodes={nodes}
           nodeTraceMap={nodeTraceMap}
           conversationId={conversationId}
+          title={title}
           isLoading={isLoading}
         />
       </Container>

--- a/static/app/views/explore/conversations/hooks/useConversation.spec.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversation.spec.tsx
@@ -21,6 +21,17 @@ const BASE_SPAN = {
   'gen_ai.operation.type': 'ai_client',
 };
 
+function envelope(
+  spans: Array<Record<string, unknown>>,
+  title: string | null = null
+): Record<string, unknown> {
+  return {
+    conversationId: (spans[0]?.['gen_ai.conversation.id'] as string) ?? '',
+    title,
+    spans,
+  };
+}
+
 describe('useConversation', () => {
   const organization = OrganizationFixture();
 
@@ -40,6 +51,42 @@ describe('useConversation', () => {
 
     expect(result.current.nodes).toEqual([]);
     expect(result.current.isLoading).toBe(false);
+    expect(result.current.title).toBeNull();
+  });
+
+  it('returns the conversation title from the envelope', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/ai-conversations/conv-title/`,
+      body: envelope(
+        [{...BASE_SPAN, 'gen_ai.conversation.id': 'conv-title', span_id: 'span-title'}],
+        'My great conversation'
+      ),
+    });
+
+    const {result} = renderHookWithProviders(
+      () => useConversation({conversationId: 'conv-title'}),
+      {organization}
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.title).toBe('My great conversation');
+  });
+
+  it('returns a null title when the envelope has none', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/ai-conversations/conv-123/`,
+      body: envelope([BASE_SPAN]),
+    });
+
+    const {result} = renderHookWithProviders(
+      () => useConversation({conversationId: 'conv-123'}),
+      {organization}
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.title).toBeNull();
   });
 
   it('maps gen_ai.input.messages to node attributes', async () => {
@@ -47,7 +94,7 @@ describe('useConversation', () => {
 
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/ai-conversations/conv-123/`,
-      body: [
+      body: envelope([
         {
           'gen_ai.conversation.id': 'conv-123',
           parent_span: 'parent-1',
@@ -65,7 +112,7 @@ describe('useConversation', () => {
             {role: 'user', content: 'Fallback message'},
           ]),
         },
-      ],
+      ]),
     });
 
     const {result} = renderHookWithProviders(
@@ -91,7 +138,7 @@ describe('useConversation', () => {
 
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/ai-conversations/conv-output/`,
-      body: [
+      body: envelope([
         {
           'gen_ai.conversation.id': 'conv-output',
           parent_span: 'parent-1',
@@ -106,7 +153,7 @@ describe('useConversation', () => {
           'gen_ai.operation.type': 'ai_client',
           'gen_ai.output.messages': outputMessages,
         },
-      ],
+      ]),
     });
 
     const {result} = renderHookWithProviders(
@@ -132,7 +179,7 @@ describe('useConversation', () => {
 
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/ai-conversations/conv-456/`,
-      body: [
+      body: envelope([
         {
           'gen_ai.conversation.id': 'conv-456',
           parent_span: 'parent-1',
@@ -147,7 +194,7 @@ describe('useConversation', () => {
           'gen_ai.operation.type': 'ai_client',
           'gen_ai.request.messages': requestMessages,
         },
-      ],
+      ]),
     });
 
     const {result} = renderHookWithProviders(
@@ -169,7 +216,7 @@ describe('useConversation', () => {
   it('uses empty string for missing optional fields', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/ai-conversations/conv-789/`,
-      body: [
+      body: envelope([
         {
           'gen_ai.conversation.id': 'conv-789',
           parent_span: 'parent-1',
@@ -184,7 +231,7 @@ describe('useConversation', () => {
           'gen_ai.operation.type': 'ai_client',
           // No input or request messages provided
         },
-      ],
+      ]),
     });
 
     const {result} = renderHookWithProviders(
@@ -208,7 +255,7 @@ describe('useConversation', () => {
   it('uses conversation timestamps when provided', async () => {
     const mockRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/ai-conversations/conv-timestamps/`,
-      body: [
+      body: envelope([
         {
           'gen_ai.conversation.id': 'conv-timestamps',
           parent_span: 'parent-1',
@@ -222,7 +269,7 @@ describe('useConversation', () => {
           trace: 'trace-ts',
           'gen_ai.operation.type': 'ai_client',
         },
-      ],
+      ]),
     });
 
     const startTimestamp = 1700000000000; // Nov 14, 2023
@@ -263,7 +310,7 @@ describe('useConversation', () => {
   it('uses span.name for description and name fields', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/ai-conversations/conv-name/`,
-      body: [
+      body: envelope([
         {
           'gen_ai.conversation.id': 'conv-name',
           parent_span: 'parent-1',
@@ -277,7 +324,7 @@ describe('useConversation', () => {
           trace: 'trace-name',
           'gen_ai.operation.type': 'ai_client',
         },
-      ],
+      ]),
     });
 
     const {result} = renderHookWithProviders(
@@ -299,7 +346,7 @@ describe('useConversation', () => {
   it('sorts nodes by start timestamp for AI spans list', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/ai-conversations/conv-sort/`,
-      body: [
+      body: envelope([
         {
           'gen_ai.conversation.id': 'conv-sort',
           parent_span: 'parent-1',
@@ -326,7 +373,7 @@ describe('useConversation', () => {
           trace: 'trace-sort',
           'gen_ai.operation.type': 'ai_client',
         },
-      ],
+      ]),
     });
 
     const {result} = renderHookWithProviders(
@@ -349,7 +396,7 @@ describe('useConversation', () => {
 
     const mockRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/ai-conversations/conv-123/`,
-      body: [BASE_SPAN],
+      body: envelope([BASE_SPAN]),
     });
 
     const {result} = renderHookWithProviders(
@@ -379,7 +426,7 @@ describe('useConversation', () => {
 
     const mockRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/ai-conversations/conv-123/`,
-      body: [BASE_SPAN],
+      body: envelope([BASE_SPAN]),
     });
 
     const {result} = renderHookWithProviders(
@@ -406,7 +453,7 @@ describe('useConversation', () => {
   it('falls back to ALL_ACCESS_PROJECTS with no time params when no filters are set', async () => {
     const mockRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/ai-conversations/conv-123/`,
-      body: [BASE_SPAN],
+      body: envelope([BASE_SPAN]),
     });
 
     const {result} = renderHookWithProviders(
@@ -443,7 +490,7 @@ describe('useConversation', () => {
 
     const mockRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/ai-conversations/conv-123/`,
-      body: [BASE_SPAN],
+      body: envelope([BASE_SPAN]),
     });
 
     const {result} = renderHookWithProviders(
@@ -469,7 +516,7 @@ describe('useConversation', () => {
   it('filters to only gen_ai spans', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/ai-conversations/conv-filter/`,
-      body: [
+      body: envelope([
         {
           'gen_ai.conversation.id': 'conv-filter',
           parent_span: 'parent-1',
@@ -496,7 +543,7 @@ describe('useConversation', () => {
           trace: 'trace-1',
           // No gen_ai.operation.type - should be filtered out
         },
-      ],
+      ]),
     });
 
     const {result} = renderHookWithProviders(
@@ -516,7 +563,7 @@ describe('useConversation', () => {
   it('maps errors and occurrences from the response onto the node', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/ai-conversations/conv-issues/`,
-      body: [
+      body: envelope([
         {
           ...BASE_SPAN,
           'gen_ai.conversation.id': 'conv-issues',
@@ -549,7 +596,7 @@ describe('useConversation', () => {
             },
           ],
         },
-      ],
+      ]),
     });
 
     const {result} = renderHookWithProviders(
@@ -570,9 +617,9 @@ describe('useConversation', () => {
   it('defaults to no issues when the response omits errors and occurrences', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/ai-conversations/conv-no-issues/`,
-      body: [
+      body: envelope([
         {...BASE_SPAN, 'gen_ai.conversation.id': 'conv-no-issues', span_id: 'span-x'},
-      ],
+      ]),
     });
 
     const {result} = renderHookWithProviders(

--- a/static/app/views/explore/conversations/hooks/useConversation.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversation.tsx
@@ -62,6 +62,12 @@ interface ConversationApiSpan {
   'user.username'?: string;
 }
 
+interface ConversationApiResponse {
+  conversationId: string;
+  spans: ConversationApiSpan[];
+  title: string | null;
+}
+
 function isGenAiSpan(span: ConversationApiSpan): boolean {
   if (span['gen_ai.operation.type']) {
     return true;
@@ -74,6 +80,7 @@ interface UseConversationResult {
   isLoading: boolean;
   nodeTraceMap: Map<string, string>;
   nodes: AITraceSpanNode[];
+  title: string | null;
 }
 
 /**
@@ -234,6 +241,7 @@ export function useConversation(
   const queryParams = {
     project,
     per_page: 1000,
+    apiVersion: 2,
     ...datetimeParams,
   };
 
@@ -246,7 +254,7 @@ export function useConversation(
     isLoading,
     isError,
   } = useInfiniteQuery(
-    apiOptions.asInfinite<ConversationApiSpan[]>()(
+    apiOptions.asInfinite<ConversationApiResponse>()(
       '/organizations/$organizationIdOrSlug/ai-conversations/$conversationId/',
       {
         path: conversation.conversationId
@@ -269,7 +277,14 @@ export function useConversation(
     }
   }, [isFetching, hasNextPage, fetchNextPage, currentNumberPages]);
 
-  const allSpans = useMemo(() => data?.pages.flatMap(page => page.json) ?? [], [data]);
+  const allSpans = useMemo(
+    () => data?.pages.flatMap(page => page.json.spans ?? []) ?? [],
+    [data]
+  );
+
+  // The title is conversation-level, so it is identical across pages; read it
+  // off the first page.
+  const title = data?.pages[0]?.json.title ?? null;
 
   const {nodes, nodeTraceMap} = useMemo(() => {
     if (allSpans.length === 0) {
@@ -298,6 +313,7 @@ export function useConversation(
       nodeTraceMap: new Map(),
       isLoading: false,
       error: false,
+      title: null,
     };
   }
 
@@ -306,5 +322,6 @@ export function useConversation(
     nodeTraceMap,
     isLoading: isLoading || isFetchingNextPage || hasNextPage,
     error: isError,
+    title,
   };
 }


### PR DESCRIPTION
The conversation details page showed a raw conversation id as its heading, which tells a user nothing about what the conversation was. Now that the endpoint can return a human-readable title, show that title as the heading and fall back to the id only when no title exists yet.

The top-bar breadcrumb keeps the id as the stable identifier (with its copy affordance), mirroring how issue pages pair a short id with a human title.

Closes TET-2762
