### PR TITLE
feat(ai-monitoring): restore scroll state and scroll to selected span

### DIFF
--- a/static/app/components/ai/chat/messageBlock.tsx
+++ b/static/app/components/ai/chat/messageBlock.tsx
@@ -90,6 +90,7 @@ export function AssistantMessageBlock({
           padding="md"
           radius="xs"
           css={bubbleCss}
+          data-selected={isSelected}
           onClick={onClick}
           role={onClick ? 'button' : undefined}
           tabIndex={onClick ? 0 : undefined}

--- a/static/app/views/explore/conversations/components/conversationLayout.tsx
+++ b/static/app/views/explore/conversations/components/conversationLayout.tsx
@@ -120,8 +120,10 @@ export function ConversationContentLayout({
   left,
   right,
   leftPadding = 'md',
+  contentRef,
 }: {
   left: React.ReactNode;
+  contentRef?: React.Ref<HTMLDivElement>;
   leftPadding?: React.ComponentProps<typeof Container>['padding'];
   right?: React.ReactNode;
 }) {
@@ -140,6 +142,7 @@ export function ConversationContentLayout({
               detail={right}
               content={
                 <Container
+                  ref={contentRef}
                   flex="1"
                   minWidth="0"
                   minHeight="0"

--- a/static/app/views/explore/conversations/components/conversationView.spec.tsx
+++ b/static/app/views/explore/conversations/components/conversationView.spec.tsx
@@ -73,8 +73,10 @@ function detailPane() {
 
 describe('ConversationViewContent', () => {
   beforeEach(() => {
-    // jsdom doesn't implement Element.scrollTo, which the detail pane calls.
+    // jsdom implements neither scroll API the view relies on: the detail pane
+    // calls scrollTo, and switching tabs reveals a selected span via scrollIntoView.
     Element.prototype.scrollTo = jest.fn();
+    Element.prototype.scrollIntoView = jest.fn();
     MockApiClient.clearMockResponses();
     act(() => {
       PageFiltersStore.reset();
@@ -120,6 +122,58 @@ describe('ConversationViewContent', () => {
     await userEvent.click(await screen.findByText('First answer'));
 
     expect(onSelectSpan).toHaveBeenCalledWith('span-a');
+  });
+
+  it('scrolls the selected span into view when switching tabs', async () => {
+    const {rerender} = renderView({
+      activeTab: 'transcript',
+      selectedSpanId: 'span-a',
+    });
+
+    // Wait for the deep-linked selection to render before asserting the switch.
+    expect(await screen.findByRole('button', {name: 'Close'})).toBeInTheDocument();
+
+    jest.mocked(Element.prototype.scrollIntoView).mockClear();
+
+    rerender(
+      <ConversationViewContent
+        conversation={{conversationId: CONVERSATION_ID}}
+        activeTab="timeline"
+        selectedSpanId="span-a"
+      />
+    );
+
+    await waitFor(() =>
+      expect(Element.prototype.scrollIntoView).toHaveBeenCalledWith({block: 'nearest'})
+    );
+  });
+
+  it('does not scroll into view when returning to a tab with no selection', async () => {
+    const {rerender} = renderView({activeTab: 'transcript'});
+    expect(await screen.findByText('First answer')).toBeInTheDocument();
+
+    // The timeline opens its default span, so leaving the transcript is fine to
+    // scroll; returning to the transcript (nothing selected) must restore the
+    // saved offset instead of scrolling.
+    rerender(
+      <ConversationViewContent
+        conversation={{conversationId: CONVERSATION_ID}}
+        activeTab="timeline"
+      />
+    );
+    expect(await screen.findByRole('button', {name: 'Close'})).toBeInTheDocument();
+
+    jest.mocked(Element.prototype.scrollIntoView).mockClear();
+
+    rerender(
+      <ConversationViewContent
+        conversation={{conversationId: CONVERSATION_ID}}
+        activeTab="transcript"
+      />
+    );
+
+    expect(await screen.findByText('First answer')).toBeInTheDocument();
+    expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled();
   });
 
   it('closes the timeline default and does not reopen it', async () => {

--- a/static/app/views/explore/conversations/components/conversationView.spec.tsx
+++ b/static/app/views/explore/conversations/components/conversationView.spec.tsx
@@ -148,13 +148,34 @@ describe('ConversationViewContent', () => {
     );
   });
 
+  it('does not snap to the timeline default when no span is selected', async () => {
+    // The timeline opens on a default span, but that view-local default is not a
+    // real selection: entering the timeline must restore its saved offset rather
+    // than scroll the default span into view.
+    const {rerender} = renderView({activeTab: 'transcript'});
+    expect(await screen.findByText('First answer')).toBeInTheDocument();
+
+    jest.mocked(Element.prototype.scrollIntoView).mockClear();
+
+    rerender(
+      <ConversationViewContent
+        conversation={{conversationId: CONVERSATION_ID}}
+        activeTab="timeline"
+      />
+    );
+
+    // The default span still opens the detail pane...
+    expect(await screen.findByRole('button', {name: 'Close'})).toBeInTheDocument();
+    // ...but nothing is scrolled into view, so the saved offset is restored.
+    expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled();
+  });
+
   it('does not scroll into view when returning to a tab with no selection', async () => {
     const {rerender} = renderView({activeTab: 'transcript'});
     expect(await screen.findByText('First answer')).toBeInTheDocument();
 
-    // The timeline opens its default span, so leaving the transcript is fine to
-    // scroll; returning to the transcript (nothing selected) must restore the
-    // saved offset instead of scrolling.
+    // Neither switch has a sticky selection, so both restore the saved offset
+    // rather than scroll a row into view.
     rerender(
       <ConversationViewContent
         conversation={{conversationId: CONVERSATION_ID}}

--- a/static/app/views/explore/conversations/components/conversationView.tsx
+++ b/static/app/views/explore/conversations/components/conversationView.tsx
@@ -94,10 +94,13 @@ export function ConversationViewContent({
   }, [selectedNode, isTimeline, timelineDefaultDismissed, defaultTimelineNode]);
 
   // Each tab keeps its own scroll position in the shared content container; a
-  // selected span is scrolled into view instead when switching tabs.
+  // selected span is scrolled into view instead when switching tabs. This keys
+  // off the sticky (URL) selection, not `displayedNode`: the timeline's
+  // view-local default span is not a real selection, so entering the timeline
+  // restores its saved offset rather than snapping to that default.
   const contentRef = useConversationScrollRestoration({
     activeTab,
-    selectedNodeId: displayedNode?.id ?? null,
+    selectedNodeId: selectedNode?.id ?? null,
   });
 
   const handleSelectAndOpenDetail = useCallback(

--- a/static/app/views/explore/conversations/components/conversationView.tsx
+++ b/static/app/views/explore/conversations/components/conversationView.tsx
@@ -14,6 +14,7 @@ import {
   useConversation,
   type UseConversationsOptions,
 } from 'sentry/views/explore/conversations/hooks/useConversation';
+import {useConversationScrollRestoration} from 'sentry/views/explore/conversations/hooks/useConversationScrollRestoration';
 import {useConversationSelection} from 'sentry/views/explore/conversations/hooks/useConversationSelection';
 import {AiSpanTimeline} from 'sentry/views/insights/pages/agents/components/aiSpanTimeline';
 import {getDefaultSelectedNode} from 'sentry/views/insights/pages/agents/utils/getDefaultSelectedNode';
@@ -92,6 +93,13 @@ export function ConversationViewContent({
     return;
   }, [selectedNode, isTimeline, timelineDefaultDismissed, defaultTimelineNode]);
 
+  // Each tab keeps its own scroll position in the shared content container; a
+  // selected span is scrolled into view instead when switching tabs.
+  const contentRef = useConversationScrollRestoration({
+    activeTab,
+    selectedNodeId: displayedNode?.id ?? null,
+  });
+
   const handleSelectAndOpenDetail = useCallback(
     (node: AITraceSpanNode) => {
       setTimelineDefaultDismissed(false);
@@ -129,6 +137,7 @@ export function ConversationViewContent({
   return (
     <TraceStateProvider initialPreferences={DEFAULT_TRACE_VIEW_PREFERENCES}>
       <ConversationContentLayout
+        contentRef={contentRef}
         leftPadding={isTranscript ? '0' : 'md'}
         left={
           isTranscript ? (

--- a/static/app/views/explore/conversations/components/messageToolCalls.tsx
+++ b/static/app/views/explore/conversations/components/messageToolCalls.tsx
@@ -142,6 +142,7 @@ function ToolCallRow({tool, node, isSelected, onSelectNode}: ToolCallRowProps) {
       padding="sm sm"
       cursor="pointer"
       css={rowCss}
+      data-selected={isSelected}
       style={
         isSelected
           ? {

--- a/static/app/views/explore/conversations/conversationDetail.spec.tsx
+++ b/static/app/views/explore/conversations/conversationDetail.spec.tsx
@@ -87,7 +87,9 @@ function detailPane() {
 
 describe('ConversationDetailPage span default selection', () => {
   beforeEach(() => {
+    // jsdom implements neither scroll API the view relies on.
     Element.prototype.scrollTo = jest.fn();
+    Element.prototype.scrollIntoView = jest.fn();
     MockApiClient.clearMockResponses();
     act(() => {
       PageFiltersStore.reset();
@@ -128,7 +130,9 @@ describe('ConversationDetailPage span default selection', () => {
 
 describe('ConversationDetailPage breadcrumbs', () => {
   beforeEach(() => {
+    // jsdom implements neither scroll API the view relies on.
     Element.prototype.scrollTo = jest.fn();
+    Element.prototype.scrollIntoView = jest.fn();
     MockApiClient.clearMockResponses();
     act(() => {
       PageFiltersStore.reset();

--- a/static/app/views/explore/conversations/hooks/useConversationScrollRestoration.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversationScrollRestoration.tsx
@@ -1,0 +1,77 @@
+import {useEffect, useLayoutEffect, useRef} from 'react';
+
+import type {ConversationViewTab} from 'sentry/views/explore/conversations/components/conversationView';
+
+interface UseConversationScrollRestorationOptions {
+  /** The currently visible tab. */
+  activeTab: ConversationViewTab;
+  /**
+   * The id of the currently selected span, or null when nothing is selected.
+   * When set, switching tabs reveals its row instead of restoring the offset.
+   */
+  selectedNodeId: string | null;
+}
+
+/**
+ * Keeps each tab's scroll position independent while the transcript and
+ * timeline share a single scroll container.
+ *
+ * Returning to a tab restores where the user left it. When a span is selected,
+ * switching tabs scrolls that span's row into view instead, so the selection
+ * stays visible across both views. The selected row is located by its
+ * `data-selected="true"` attribute, which both views set on the highlighted row.
+ */
+export function useConversationScrollRestoration({
+  activeTab,
+  selectedNodeId,
+}: UseConversationScrollRestorationOptions) {
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+
+  // Last-known scroll offset per tab. Written continuously from a scroll
+  // listener so the outgoing tab's offset is captured before swapping views
+  // clamps scrollTop against the other view's (usually shorter) height.
+  const offsetByTab = useRef({
+    transcript: 0,
+    timeline: 0,
+  });
+
+  // The scroll listener is attached once, so it reads the active tab from a ref
+  // to always record against the tab that is currently visible.
+  const activeTabRef = useRef(activeTab);
+  activeTabRef.current = activeTab;
+
+  useEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container) {
+      return;
+    }
+
+    const handleScroll = () => {
+      offsetByTab.current[activeTabRef.current] = container.scrollTop;
+    };
+
+    container.addEventListener('scroll', handleScroll, {passive: true});
+    return () => container.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  useLayoutEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container) {
+      return;
+    }
+
+    if (selectedNodeId) {
+      const selectedRow = container.querySelector<HTMLElement>('[data-selected="true"]');
+      if (selectedRow) {
+        selectedRow.scrollIntoView({block: 'nearest'});
+        // Keep the saved offset in sync so switching away and back lands here.
+        offsetByTab.current[activeTab] = container.scrollTop;
+        return;
+      }
+    }
+
+    container.scrollTop = offsetByTab.current[activeTab];
+  }, [activeTab, selectedNodeId]);
+
+  return scrollContainerRef;
+}


### PR DESCRIPTION
The transcript and timeline of a conversation share a single scroll container, so switching between the two tabs discarded wherever you had scrolled to. Each tab now remembers its own scroll position and restores it when you come back.

When a span is selected, switching tabs instead scrolls that span's row into view, so the selection stays on screen across both views rather than leaving you to hunt for it.

Closes TET-2766