### PR TITLE
fix(agent-monitoring): Show only model in agent span timeline secondary

### DIFF
--- a/static/app/views/insights/pages/agents/components/aiSpanTimeline.tsx
+++ b/static/app/views/insights/pages/agents/components/aiSpanTimeline.tsx
@@ -331,7 +331,7 @@ function getSpanPresentation(
         color,
         isTool: false,
         title: name || op,
-        secondary: model ? `${op} (${model})` : op,
+        secondary: model,
       };
     }
     case GenAiOperationType.AI_CLIENT: {


### PR DESCRIPTION
The secondary label on agent spans in the AI span timeline now shows just the model instead of pairing it with the raw span operation. The operation was too technical and left some users unsure what they were looking at, so it no longer appears here.
