### PR TITLE
feat(agent-monitoring): Display thinking in span details output tab

### DIFF
--- a/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
+++ b/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
@@ -337,6 +337,12 @@ function OutputTab({
   );
   const toolOutput = getAIToolOutput(node, attributes);
 
+  // Reasoning is supplementary to the actual output, so clip it when there is
+  // other content; when it is the only output, show it in full.
+  const clipReasoning = Boolean(
+    responseText || responseObject || toolCalls || toolOutput
+  );
+
   if (!reasoningText && !responseText && !responseObject && !toolCalls && !toolOutput) {
     return <EmptyTab message={t('No output for this span')} />;
   }
@@ -353,7 +359,7 @@ function OutputTab({
             text={reasoningText}
             maxJsonDepth={AI_SPAN_OUTPUT_JSON_MAX_DEFAULT_DEPTH}
             autoCollapseLimit={AI_SPAN_JSON_AUTO_COLLAPSE_LIMIT}
-            clip={false}
+            clip={clipReasoning}
           />
         </Fragment>
       ) : null}

--- a/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
+++ b/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
@@ -331,15 +331,32 @@ function OutputTab({
   attributes: SpanAttributes;
   node: AITraceSpanNode;
 }) {
-  const {responseText, responseObject, toolCalls} = getAIOutputData(node, attributes);
+  const {reasoningText, responseText, responseObject, toolCalls} = getAIOutputData(
+    node,
+    attributes
+  );
   const toolOutput = getAIToolOutput(node, attributes);
 
-  if (!responseText && !responseObject && !toolCalls && !toolOutput) {
+  if (!reasoningText && !responseText && !responseObject && !toolCalls && !toolOutput) {
     return <EmptyTab message={t('No output for this span')} />;
   }
 
   return (
     <Fragment>
+      {reasoningText ? (
+        <Fragment>
+          <TraceDrawerComponents.MultilineTextLabel>
+            {t('Thinking')}
+          </TraceDrawerComponents.MultilineTextLabel>
+          <AIContentRenderer
+            key={`${node.id}:reasoning-text`}
+            text={reasoningText}
+            maxJsonDepth={AI_SPAN_OUTPUT_JSON_MAX_DEFAULT_DEPTH}
+            autoCollapseLimit={AI_SPAN_JSON_AUTO_COLLAPSE_LIMIT}
+            clip={false}
+          />
+        </Fragment>
+      ) : null}
       {responseText ? (
         <Fragment>
           <TraceDrawerComponents.MultilineTextLabel>

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput.spec.tsx
@@ -1,0 +1,77 @@
+import type {ComponentProps} from 'react';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {AIOutputSection} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput';
+
+function makeAiNodeWithAttributes(
+  attributes: Record<string, unknown>
+): ComponentProps<typeof AIOutputSection>['node'] {
+  return {
+    id: 'span-id',
+    attributes: {
+      'gen_ai.operation.type': 'chat',
+      ...attributes,
+    },
+    value: {},
+  } as unknown as ComponentProps<typeof AIOutputSection>['node'];
+}
+
+function makeAiNode(
+  messages: Array<{role: string; content?: unknown; parts?: unknown[]}>
+): ComponentProps<typeof AIOutputSection>['node'] {
+  return makeAiNodeWithAttributes({
+    'gen_ai.output.messages': JSON.stringify(messages),
+  });
+}
+
+describe('AIOutputSection', () => {
+  it('renders reasoning output under a Thinking label', () => {
+    render(
+      <AIOutputSection
+        node={makeAiNode([
+          {
+            role: 'assistant',
+            parts: [
+              {type: 'reasoning', content: 'Let me think step by step...'},
+              {type: 'text', content: 'The answer is 42'},
+            ],
+          },
+        ])}
+      />
+    );
+
+    expect(screen.getByText('Thinking')).toBeInTheDocument();
+    expect(screen.getByText('Let me think step by step...')).toBeVisible();
+    expect(screen.getByText('Response')).toBeInTheDocument();
+    expect(screen.getByText('The answer is 42')).toBeVisible();
+  });
+
+  it('renders reasoning even when there is no response text', () => {
+    render(
+      <AIOutputSection
+        node={makeAiNode([
+          {
+            role: 'assistant',
+            parts: [{type: 'reasoning', content: 'Thinking only...'}],
+          },
+        ])}
+      />
+    );
+
+    expect(screen.getByText('Thinking')).toBeInTheDocument();
+    expect(screen.getByText('Thinking only...')).toBeVisible();
+    expect(screen.queryByText('Response')).not.toBeInTheDocument();
+  });
+
+  it('does not render a Thinking label when there is no reasoning', () => {
+    render(
+      <AIOutputSection
+        node={makeAiNode([{role: 'assistant', content: 'Just a response'}])}
+      />
+    );
+
+    expect(screen.getByText('Just a response')).toBeVisible();
+    expect(screen.queryByText('Thinking')).not.toBeInTheDocument();
+  });
+});

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput.spec.tsx
@@ -47,6 +47,30 @@ describe('AIOutputSection', () => {
     expect(screen.getByText('The answer is 42')).toBeVisible();
   });
 
+  it('renders reasoning from a realistic payload with braces and code', () => {
+    const reasoning =
+      'Let me analyze this error. The issue is ALTITUDE-69 with title "Error: {" which is a bit cryptic.\n\nThe actual error is an `AbortError` serialized as `{"name": "AbortError", "message": "Aborted"}`.';
+    const response =
+      'This is an **`AbortError`** being incorrectly captured by the logger.';
+
+    render(
+      <AIOutputSection
+        node={makeAiNode([
+          {
+            role: 'assistant',
+            parts: [
+              {type: 'reasoning', content: reasoning},
+              {type: 'text', content: response},
+            ],
+          },
+        ])}
+      />
+    );
+
+    expect(screen.getByText('Thinking')).toBeInTheDocument();
+    expect(screen.getByText(/Let me analyze this error/)).toBeVisible();
+  });
+
   it('renders reasoning even when there is no response text', () => {
     render(
       <AIOutputSection

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput.tsx
@@ -17,6 +17,7 @@ import type {SpanNode} from 'sentry/views/performance/newTraceDetails/traceModel
 import type {TransactionNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/transactionNode';
 
 interface AIOutputData {
+  reasoningText: string | null;
   responseObject: string | null;
   responseText: string | null;
   toolCalls: string | null;
@@ -47,14 +48,14 @@ export function AIOutputSection({
     return null;
   }
 
-  const {responseText, responseObject, toolCalls} = getAIOutputData(
+  const {reasoningText, responseText, responseObject, toolCalls} = getAIOutputData(
     node,
     attributes,
     event
   );
   const toolOutput = getAIToolOutput(node, attributes, event);
 
-  if (!responseText && !responseObject && !toolCalls && !toolOutput) {
+  if (!reasoningText && !responseText && !responseObject && !toolCalls && !toolOutput) {
     return null;
   }
 
@@ -66,6 +67,14 @@ export function AIOutputSection({
       disableCollapsePersistence
       initialCollapse={initialCollapse}
     >
+      {reasoningText && (
+        <Fragment>
+          <TraceDrawerComponents.MultilineTextLabel>
+            {t('Thinking')}
+          </TraceDrawerComponents.MultilineTextLabel>
+          <AIContentRenderer text={reasoningText} />
+        </Fragment>
+      )}
       {responseText && (
         <Fragment>
           <TraceDrawerComponents.MultilineTextLabel>
@@ -130,8 +139,14 @@ export function getAIOutputData(
     const extracted = extractAssistantOutput(raw.toString(), {
       defaultRole: 'assistant',
     });
-    if (extracted.responseText || extracted.responseObject || extracted.toolCalls) {
+    if (
+      extracted.reasoningText ||
+      extracted.responseText ||
+      extracted.responseObject ||
+      extracted.toolCalls
+    ) {
       return {
+        reasoningText: extracted.reasoningText,
         responseText: extracted.responseText,
         responseObject: extracted.responseObject,
         toolCalls: extracted.toolCalls,
@@ -153,6 +168,7 @@ export function getAIOutputData(
   );
 
   return {
+    reasoningText: null,
     responseText: null,
     responseObject: responseObject?.toString() ?? null,
     toolCalls: toolCalls?.toString() ?? null,


### PR DESCRIPTION
Surface model reasoning in the AI span details Output tab.

The output normalizer already extracted `reasoning`-type parts into `reasoningText`, but the component discarded the value, so a model's thinking never appeared in the tab. This renders it as a "Thinking" section alongside Response, Response Object, and Tool Calls, and keeps the tab visible for reasoning-only spans. The label matches the "Thinking" wording already used for the same data in the Conversations view.

Refs TET-2765