### PR TITLE
fix(metrics): Align attribute queries with metric time range

### DIFF
--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
@@ -19,6 +19,7 @@ import {useGetTraceItemAttributeTagKeys} from 'sentry/views/explore/hooks/useGet
 import {useGetTraceItemAttributeValues} from 'sentry/views/explore/hooks/useGetTraceItemAttributeValues';
 import {LOGS_FILTER_KEY_SECTIONS} from 'sentry/views/explore/logs/constants';
 import {TRACEMETRICS_FILTER_KEY_SECTIONS} from 'sentry/views/explore/metrics/constants';
+import type {MetricsRelativePeriod} from 'sentry/views/explore/metrics/hooks/metricPeriod';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import {SPANS_FILTER_KEY_SECTIONS} from 'sentry/views/insights/constants';
 
@@ -45,6 +46,7 @@ export type TraceItemSearchQueryBuilderProps = {
   matchKeySuggestions?: Array<{key: string; valuePattern: RegExp}>;
   namespace?: string;
   onCaseInsensitiveClick?: SearchQueryBuilderProps['onCaseInsensitiveClick'];
+  relativePeriod?: MetricsRelativePeriod;
   replaceRawSearchKeys?: string[];
 } & Omit<SpanSearchQueryBuilderProps, 'numberTags' | 'stringTags'>;
 
@@ -103,6 +105,7 @@ export function useTraceItemSearchQueryBuilderProps({
   portalTarget,
   projects,
   datetime,
+  relativePeriod,
   supportedAggregates = [],
   namespace,
   replaceRawSearchKeys,
@@ -143,6 +146,7 @@ export function useTraceItemSearchQueryBuilderProps({
     projectIds: projects,
     datetime,
     query: attributeQuery,
+    relativePeriod,
   });
 
   const getSuggestedAttribute = useExploreSuggestedAttribute({
@@ -158,6 +162,7 @@ export function useTraceItemSearchQueryBuilderProps({
     query: attributeQuery,
     hiddenKeys: hiddenAttributeKeys,
     datetime,
+    relativePeriod,
   });
   // When an allowlist is in effect, the static filterKeys are already curated to
   // it. Skip the dynamic EAP fetch so typed-key autocomplete only matches against
@@ -172,6 +177,7 @@ export function useTraceItemSearchQueryBuilderProps({
       effectiveDatetime,
       attributeQuery,
       hiddenAttributeKeys,
+      relativePeriod,
       allowedAttributeKeys,
     ],
     [
@@ -181,6 +187,7 @@ export function useTraceItemSearchQueryBuilderProps({
       effectiveProjects,
       hiddenAttributeKeys,
       itemType,
+      relativePeriod,
       selection.environments,
     ]
   );
@@ -303,6 +310,7 @@ export function TraceItemSearchQueryBuilder({
   allowedAttributeKeys,
   placeholder,
   invalidFilterKeys,
+  relativePeriod,
 }: TraceItemSearchQueryBuilderProps) {
   const searchQueryBuilderProps = useTraceItemSearchQueryBuilderProps({
     itemType,
@@ -338,6 +346,7 @@ export function TraceItemSearchQueryBuilder({
     hiddenAttributeKeys,
     allowedAttributeKeys,
     datetime,
+    relativePeriod,
     invalidFilterKeys,
   });
 

--- a/static/app/views/explore/hooks/useGetTraceItemAttributeKeys.tsx
+++ b/static/app/views/explore/hooks/useGetTraceItemAttributeKeys.tsx
@@ -6,6 +6,7 @@ import type {PageFilters} from 'sentry/types/core';
 import type {TagCollection} from 'sentry/types/group';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {EXPLORE_FIVE_MIN_STALE_TIME} from 'sentry/views/explore/constants';
+import type {MetricsRelativePeriod} from 'sentry/views/explore/metrics/hooks/metricPeriod';
 import type {UseTraceItemAttributeBaseProps} from 'sentry/views/explore/types';
 import {
   getTraceItemTagCollection,
@@ -19,6 +20,7 @@ interface UseGetTraceItemAttributeKeysProps extends Omit<
   datetime?: PageFilters['datetime'];
   projectIds?: Array<string | number>;
   query?: string;
+  relativePeriod?: MetricsRelativePeriod;
 }
 
 export function useGetTraceItemAttributeKeys({
@@ -26,6 +28,7 @@ export function useGetTraceItemAttributeKeys({
   projectIds,
   query,
   datetime,
+  relativePeriod,
 }: UseGetTraceItemAttributeKeysProps) {
   const {selection} = usePageFilters();
   const organization = useOrganization();
@@ -48,6 +51,7 @@ export function useGetTraceItemAttributeKeys({
             projectIds: projectIds ?? selection.projects,
             search: queryString,
             query,
+            relativePeriod,
             staleTime: EXPLORE_FIVE_MIN_STALE_TIME,
           })
         );
@@ -56,6 +60,15 @@ export function useGetTraceItemAttributeKeys({
         throw new Error(`Unable to fetch trace item attribute keys: ${e}`);
       }
     },
-    [datetime, organization, projectIds, query, queryClient, selection, traceItemType]
+    [
+      datetime,
+      organization,
+      projectIds,
+      query,
+      queryClient,
+      relativePeriod,
+      selection,
+      traceItemType,
+    ]
   );
 }

--- a/static/app/views/explore/hooks/useGetTraceItemAttributeTagKeys.tsx
+++ b/static/app/views/explore/hooks/useGetTraceItemAttributeTagKeys.tsx
@@ -4,6 +4,7 @@ import type {GetTagKeys} from 'sentry/components/searchQueryBuilder';
 import type {PageFilters} from 'sentry/types/core';
 import type {Tag, TagCollection} from 'sentry/types/group';
 import {useGetTraceItemAttributeKeys} from 'sentry/views/explore/hooks/useGetTraceItemAttributeKeys';
+import type {MetricsRelativePeriod} from 'sentry/views/explore/metrics/hooks/metricPeriod';
 import type {TraceItemDataset} from 'sentry/views/explore/types';
 import {isHiddenAttribute} from 'sentry/views/explore/utils';
 
@@ -14,6 +15,7 @@ export function useGetTraceItemAttributeTagKeys({
   query,
   hiddenKeys,
   datetime,
+  relativePeriod,
 }: {
   itemType: TraceItemDataset;
   datetime?: PageFilters['datetime'];
@@ -21,12 +23,14 @@ export function useGetTraceItemAttributeTagKeys({
   hiddenKeys?: string[];
   projects?: PageFilters['projects'];
   query?: string;
+  relativePeriod?: MetricsRelativePeriod;
 }): GetTagKeys {
   const getTraceItemAttributeKeys = useGetTraceItemAttributeKeys({
     traceItemType: itemType,
     projectIds: projects,
     query,
     datetime,
+    relativePeriod,
   });
 
   return useCallback(

--- a/static/app/views/explore/hooks/useGetTraceItemAttributeValues.spec.tsx
+++ b/static/app/views/explore/hooks/useGetTraceItemAttributeValues.spec.tsx
@@ -142,6 +142,32 @@ describe('useGetTraceItemAttributeValues', () => {
     expect(searchResults).toEqual([{value: 'search-result', count: 1234}]);
   });
 
+  it('uses the metrics relative period when provided', async () => {
+    const request = addAttributeValuesMock({
+      substringMatch: 'search-query',
+      body: [makeAttributeValue('search-result')],
+      query: {
+        statsPeriodStart: '14d',
+        statsPeriodEnd: '120s',
+        statsPeriod: undefined,
+        start: undefined,
+        end: undefined,
+      },
+    });
+
+    const {result} = renderValuesHook({
+      relativePeriod: {statsPeriodStart: '14d', statsPeriodEnd: '120s'},
+    });
+
+    let searchResults: ValueResult = [];
+    await act(async () => {
+      searchResults = await result.current({tag, searchQuery: 'search-query'});
+    });
+
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(searchResults).toEqual([{value: 'search-result'}]);
+  });
+
   it('getTraceItemAttributeValues returns empty array for number type', async () => {
     const searchQueryMock = MockApiClient.addMockResponse({
       url: `/organizations/org-slug/trace-items/attributes/${attributeKey}/values/`,

--- a/static/app/views/explore/hooks/useGetTraceItemAttributeValues.tsx
+++ b/static/app/views/explore/hooks/useGetTraceItemAttributeValues.tsx
@@ -18,6 +18,7 @@ import {defined} from 'sentry/utils/defined';
 import {FieldKind} from 'sentry/utils/fields';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {EXPLORE_FIVE_MIN_STALE_TIME} from 'sentry/views/explore/constants';
+import type {MetricsRelativePeriod} from 'sentry/views/explore/metrics/hooks/metricPeriod';
 import type {UseTraceItemAttributeBaseProps} from 'sentry/views/explore/types';
 import {findFreshEmptyPrefixSearchCacheMatch} from 'sentry/views/explore/utils/findFreshEmptyPrefixSearchCacheMatch';
 
@@ -34,6 +35,7 @@ interface UseGetTraceItemAttributeValuesProps extends UseTraceItemAttributeBaseP
   datetime?: PageFilters['datetime'];
   projectIds?: PageFilters['projects'];
   query?: string;
+  relativePeriod?: MetricsRelativePeriod;
 }
 
 /**
@@ -46,6 +48,7 @@ export function useGetTraceItemAttributeValues({
   datetime,
   type,
   query: filterQuery,
+  relativePeriod,
 }: UseGetTraceItemAttributeValuesProps) {
   const organization = useOrganization();
   const {selection} = usePageFilters();
@@ -78,6 +81,14 @@ export function useGetTraceItemAttributeValues({
             substringMatch: searchQuery || undefined,
             project,
             ...datetimeParams,
+            ...(relativePeriod
+              ? {
+                  start: undefined,
+                  end: undefined,
+                  statsPeriod: undefined,
+                  ...relativePeriod,
+                }
+              : {}),
           },
         }
       );
@@ -112,6 +123,7 @@ export function useGetTraceItemAttributeValues({
       organization.slug,
       projectIds,
       queryClient,
+      relativePeriod,
       selection.datetime,
       selection.projects,
       traceItemType,

--- a/static/app/views/explore/hooks/useTraceItemAttributes.tsx
+++ b/static/app/views/explore/hooks/useTraceItemAttributes.tsx
@@ -21,6 +21,7 @@ import {
   SENTRY_TRACEMETRIC_NUMBER_TAGS,
   SENTRY_TRACEMETRIC_STRING_TAGS,
 } from 'sentry/views/explore/constants';
+import type {MetricsRelativePeriod} from 'sentry/views/explore/metrics/hooks/metricPeriod';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import {removeHiddenKeys} from 'sentry/views/explore/utils';
 import {
@@ -59,6 +60,7 @@ export type TraceItemAttributeConfig = {
   traceItemType: TraceItemDataset;
   projects?: Project[] | Array<string | number>;
   query?: string;
+  relativePeriod?: MetricsRelativePeriod;
   search?: string;
   staleTime?: number;
 };
@@ -77,6 +79,7 @@ function useTraceItemAttributeConfig({
   projects: rawProjects,
   search,
   query,
+  relativePeriod,
   staleTime,
 }: TraceItemAttributeConfig): TypedTraceItemAttributesResult {
   const {selection} = usePageFilters();
@@ -94,6 +97,7 @@ function useTraceItemAttributeConfig({
       projects,
       search,
       query,
+      relativePeriod,
       staleTime,
     }),
     enabled,

--- a/static/app/views/explore/metrics/hooks/metricPeriod.ts
+++ b/static/app/views/explore/metrics/hooks/metricPeriod.ts
@@ -1,0 +1,56 @@
+import {useMemo} from 'react';
+
+import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import type {PageFilters} from 'sentry/types/core';
+import {intervalToMilliseconds} from 'sentry/utils/duration/intervalToMilliseconds';
+import {useMetricsFrozenTracePeriod} from 'sentry/views/explore/metrics/metricsFrozenContext';
+import {INGESTION_DELAY} from 'sentry/views/insights/settings';
+
+const MILLISECONDS_PER_SECOND = 1000;
+
+export type MetricsRelativePeriod = {
+  statsPeriodEnd: string;
+  statsPeriodStart: string;
+};
+
+export function getMetricsRelativePeriod(
+  datetime: PageFilters['datetime'],
+  ingestionDelaySeconds = INGESTION_DELAY
+): MetricsRelativePeriod | undefined {
+  const {end, period} = datetime;
+  const periodMs = period ? intervalToMilliseconds(period) : 0;
+
+  if (period && periodMs > ingestionDelaySeconds * MILLISECONDS_PER_SECOND && !end) {
+    return {
+      statsPeriodStart: period,
+      statsPeriodEnd: `${ingestionDelaySeconds}s`,
+    };
+  }
+
+  return undefined;
+}
+
+export function useMetricsRelativePeriod(
+  ingestionDelaySeconds = INGESTION_DELAY
+): MetricsRelativePeriod | undefined {
+  const {selection} = usePageFilters();
+  const frozenTracePeriod = useMetricsFrozenTracePeriod();
+
+  const datetime = useMemo(
+    () =>
+      frozenTracePeriod
+        ? {
+            start: frozenTracePeriod.start ?? null,
+            end: frozenTracePeriod.end ?? null,
+            period: frozenTracePeriod.period ?? null,
+            utc: selection.datetime.utc,
+          }
+        : selection.datetime,
+    [selection.datetime, frozenTracePeriod]
+  );
+
+  return useMemo(
+    () => getMetricsRelativePeriod(datetime, ingestionDelaySeconds),
+    [datetime, ingestionDelaySeconds]
+  );
+}

--- a/static/app/views/explore/metrics/hooks/useMetricSamplesTable.tsx
+++ b/static/app/views/explore/metrics/hooks/useMetricSamplesTable.tsx
@@ -6,7 +6,6 @@ import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {defined} from 'sentry/utils/defined';
 import type {EventsMetaType, EventView} from 'sentry/utils/discover/eventView';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
-import {intervalToMilliseconds} from 'sentry/utils/duration/intervalToMilliseconds';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -20,6 +19,7 @@ import {
   AlwaysPresentTraceMetricFields,
   NONE_UNIT,
 } from 'sentry/views/explore/metrics/constants';
+import {getMetricsRelativePeriod} from 'sentry/views/explore/metrics/hooks/metricPeriod';
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 import {
   useMetricsFrozenSearch,
@@ -36,8 +36,6 @@ import {
 import {getEventView} from 'sentry/views/insights/common/queries/useDiscover';
 import {getStaleTimeForEventView} from 'sentry/views/insights/common/queries/useSpansQuery';
 import {INGESTION_DELAY} from 'sentry/views/insights/settings';
-
-const MILLISECONDS_PER_SECOND = 1000;
 
 interface UseMetricSamplesTableOptions {
   fields: string[];
@@ -133,19 +131,10 @@ function useMetricsQueryKey({
     return datetime;
   }, [selection.datetime, frozenTracePeriod]);
 
-  const delayedRelativePeriod = useMemo(() => {
-    const {end, period} = baseDatetime;
-    const periodMs = period ? intervalToMilliseconds(period) : 0;
-
-    if (period && periodMs > ingestionDelaySeconds * MILLISECONDS_PER_SECOND && !end) {
-      return {
-        statsPeriodStart: period,
-        statsPeriodEnd: `${ingestionDelaySeconds}s`,
-      };
-    }
-
-    return;
-  }, [baseDatetime, ingestionDelaySeconds]);
+  const delayedRelativePeriod = useMemo(
+    () => getMetricsRelativePeriod(baseDatetime, ingestionDelaySeconds),
+    [baseDatetime, ingestionDelaySeconds]
+  );
 
   const pageFilters = {
     ...selection,
@@ -254,7 +243,9 @@ function useMetricSamplesTableImpl({
   ingestionDelaySeconds = INGESTION_DELAY,
   queryExtras,
   staleTime,
-}: UseMetricSamplesTableOptions & {enabled: boolean}): MetricSamplesTableResult {
+}: UseMetricSamplesTableOptions & {
+  enabled: boolean;
+}): MetricSamplesTableResult {
   const {queryKey, other} = useMetricsQueryKey({
     limit,
     traceMetric,

--- a/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
@@ -19,6 +19,7 @@ import type {TableColumn} from 'sentry/views/discover/table/types';
 import {decodeColumnOrder} from 'sentry/views/discover/utils';
 import {EXPLORE_FIVE_MIN_STALE_TIME} from 'sentry/views/explore/constants';
 import {useTopEvents} from 'sentry/views/explore/hooks/useTopEvents';
+import {useMetricsRelativePeriod} from 'sentry/views/explore/metrics/hooks/metricPeriod';
 import {useMetricAggregatesTable} from 'sentry/views/explore/metrics/hooks/useMetricAggregatesTable';
 import {
   StyledSimpleTable,
@@ -86,6 +87,7 @@ export function AggregatesTab({traceMetric, isMetricOptionsEmpty}: AggregatesTab
   const organization = useOrganization();
   const topEvents = useTopEvents();
   const visualize = useMetricVisualize();
+  const relativePeriod = useMetricsRelativePeriod();
 
   const {result, eventView, fields} = useMetricAggregatesTable({
     enabled: isVisualizeFunction(visualize)
@@ -112,6 +114,7 @@ export function AggregatesTab({traceMetric, isMetricOptionsEmpty}: AggregatesTab
       selection,
       traceItemType: TraceItemDataset.TRACEMETRICS,
       query: traceMetricFilter,
+      relativePeriod,
       staleTime: EXPLORE_FIVE_MIN_STALE_TIME,
     }),
     enabled: Boolean(traceMetricFilter),
@@ -243,7 +246,10 @@ export function AggregatesTab({traceMetric, isMetricOptionsEmpty}: AggregatesTab
           result.data.map((row, i) => {
             const displayRow =
               groupBys.length === 0
-                ? {...row, [TraceMetricKnownFieldKey.METRIC_NAME]: traceMetric.name}
+                ? {
+                    ...row,
+                    [TraceMetricKnownFieldKey.METRIC_NAME]: traceMetric.name,
+                  }
                 : row;
 
             return (

--- a/static/app/views/explore/metrics/metricToolbar/filter.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/filter.tsx
@@ -21,6 +21,7 @@ import {
   SENTRY_TRACEMETRIC_STRING_TAGS,
 } from 'sentry/views/explore/constants';
 import {HiddenTraceMetricSearchFields} from 'sentry/views/explore/metrics/constants';
+import {useMetricsRelativePeriod} from 'sentry/views/explore/metrics/hooks/metricPeriod';
 import {useValidateMetricsTab} from 'sentry/views/explore/metrics/hooks/useValidateMetricsTab';
 import {type TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 import {MetricsTabSeerComboBox} from 'sentry/views/explore/metrics/metricsTabSeerComboBox';
@@ -78,6 +79,7 @@ export function Filter({
   const setQuery = useSetQueryParamsQuery();
   const organization = useOrganization();
   const {selection} = usePageFilters();
+  const relativePeriod = useMetricsRelativePeriod();
 
   const hasTranslateEndpoint = organization.features.includes(
     'gen-ai-search-agent-translate'
@@ -95,6 +97,7 @@ export function Filter({
       selection,
       traceItemType: TraceItemDataset.TRACEMETRICS,
       query: attributeQuery,
+      relativePeriod,
       projectIds,
       environments,
     }),
@@ -256,6 +259,7 @@ export function Filter({
         hiddenAttributeKeys: HiddenTraceMetricSearchFields,
         projects: projectIds,
         environments,
+        relativePeriod,
         disabled: isSearchBarDisabled,
         portalTarget,
         invalidFilterKeys,
@@ -272,6 +276,7 @@ export function Filter({
       portalTarget,
       projectIds,
       query,
+      relativePeriod,
       setQuery,
       skipTraceMetricFilter,
       traceMetric.name,

--- a/static/app/views/explore/metrics/metricToolbar/groupBySelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/groupBySelector.tsx
@@ -11,6 +11,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {useGroupByFields} from 'sentry/views/explore/hooks/useGroupByFields';
 import {HiddenTraceMetricGroupByFields} from 'sentry/views/explore/metrics/constants';
+import {useMetricsRelativePeriod} from 'sentry/views/explore/metrics/hooks/metricPeriod';
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 import {createTraceMetricFilter} from 'sentry/views/explore/metrics/utils';
 import {
@@ -56,6 +57,7 @@ export function GroupBySelector({
   const organization = useOrganization();
   const groupBys = useQueryParamsGroupBys();
   const setGroupBys = useSetQueryParamsGroupBys();
+  const relativePeriod = useMetricsRelativePeriod();
   const isDisabled = disabledReason !== undefined;
 
   const traceMetricFilter = createTraceMetricFilter(traceMetric);
@@ -66,6 +68,7 @@ export function GroupBySelector({
       selection,
       traceItemType: TraceItemDataset.TRACEMETRICS,
       query: skipTraceMetricFilter ? undefined : traceMetricFilter,
+      relativePeriod,
     }),
     select: selectTraceItemTagCollection(),
     enabled: skipTraceMetricFilter || Boolean(traceMetricFilter),

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector/metricDetailPanel.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector/metricDetailPanel.tsx
@@ -11,6 +11,7 @@ import {prettifyTagKey} from 'sentry/utils/fields';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {useTraceMetricItemAttributes} from 'sentry/views/explore/hooks/useTraceItemAttributes';
 import {HIDDEN_TRACEMETRIC_GROUP_BY_FIELDS_SET} from 'sentry/views/explore/metrics/constants';
+import {useMetricsRelativePeriod} from 'sentry/views/explore/metrics/hooks/metricPeriod';
 import {MetricTypeBadge} from 'sentry/views/explore/metrics/metricToolbar/metricOptionLabel';
 import type {MetricSelectorOption} from 'sentry/views/explore/metrics/metricToolbar/metricSelector/types';
 import {
@@ -94,10 +95,12 @@ function MetricAttributesSection({
     traceMetricFilter,
     METRIC_ATTRIBUTES_DEBOUNCE_DURATION
   );
+  const relativePeriod = useMetricsRelativePeriod();
 
   const isDebouncingAttributes = debouncedTraceMetricFilter !== traceMetricFilter;
   const metricAttributeQuery = {
     enabled: Boolean(debouncedTraceMetricFilter),
+    relativePeriod,
     query: debouncedTraceMetricFilter,
     staleTime: Infinity,
   };

--- a/static/app/views/explore/utils/traceItemAttributeKeysOptions.spec.tsx
+++ b/static/app/views/explore/utils/traceItemAttributeKeysOptions.spec.tsx
@@ -114,6 +114,33 @@ describe('traceItemAttributeKeysOptions', () => {
     expect(longerRequest).not.toHaveBeenCalled();
   });
 
+  it('uses the metrics relative period when provided', async () => {
+    const request = MockApiClient.addMockResponse({
+      url: endpoint,
+      method: 'GET',
+      body: [],
+      match: [
+        (_url, options) => {
+          const query = options?.query || {};
+          return (
+            query.statsPeriodStart === '7d' &&
+            query.statsPeriodEnd === '120s' &&
+            query.statsPeriod === undefined &&
+            query.start === undefined &&
+            query.end === undefined
+          );
+        },
+      ],
+    });
+
+    await fetchAttributeKeys({
+      search: 'foo',
+      relativePeriod: {statsPeriodStart: '7d', statsPeriodEnd: '120s'},
+    });
+
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
   it('does not reuse non-empty cached prefix results', async () => {
     const prefixBody = [makeAttribute('foo')];
     const longerBody = [makeAttribute('foo.bar')];

--- a/static/app/views/explore/utils/traceItemAttributeKeysOptions.tsx
+++ b/static/app/views/explore/utils/traceItemAttributeKeysOptions.tsx
@@ -10,6 +10,7 @@ import {apiOptions, selectJsonWithHeaders} from 'sentry/utils/api/apiOptions';
 import type {ApiQueryKey} from 'sentry/utils/api/apiQueryKey';
 import {defined} from 'sentry/utils/defined';
 import {FieldKind} from 'sentry/utils/fields';
+import type {MetricsRelativePeriod} from 'sentry/views/explore/metrics/hooks/metricPeriod';
 import type {TraceItemDataset} from 'sentry/views/explore/types';
 import {findFreshEmptyPrefixSearchCacheMatch} from 'sentry/views/explore/utils/findFreshEmptyPrefixSearchCacheMatch';
 
@@ -45,6 +46,7 @@ interface TraceItemAttributeKeysOptions {
   projectIds?: Array<string | number>;
   projects?: Project[];
   query?: string;
+  relativePeriod?: MetricsRelativePeriod;
   search?: string;
   staleTime?: number;
   type?: TraceItemAttributeType | TraceItemAttributeType[];
@@ -60,6 +62,7 @@ export function traceItemAttributeKeysOptions({
   projectIds: explicitProjectIds,
   environments,
   query,
+  relativePeriod,
   search,
 }: TraceItemAttributeKeysOptions) {
   const projectIds =
@@ -74,6 +77,14 @@ export function traceItemAttributeKeysOptions({
     environment: environments ?? selection.environments,
     query,
     ...normalizeDateTimeParams(selection.datetime),
+    ...(relativePeriod
+      ? {
+          start: undefined,
+          end: undefined,
+          statsPeriod: undefined,
+          ...relativePeriod,
+        }
+      : {}),
     ...(substringMatch === undefined ? {} : {substringMatch}),
   };
 


### PR DESCRIPTION
Metric attribute discovery and value autocomplete now use the same ingestion-delayed relative time window as the metrics events request. This keeps group-by/filter attributes, metric detail attributes, typed-key autocomplete, and attribute values aligned with the data that was fetched by replacing `statsPeriod` with `statsPeriodStart`/`statsPeriodEnd` when appropriate. Absolute time ranges remain unchanged.

Closes LOGS-915
