### PR TITLE
feat(agent-monitoring): Add collapse, alert, and dashboard actions to conversations chart

### DIFF
--- a/static/app/utils/analytics/conversationsAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/conversationsAnalyticsEvents.tsx
@@ -15,6 +15,9 @@ export type ConversationsEventParameters = {
   'conversations.message.click-tool-call': Record<string, unknown>;
   'conversations.onboarding.page-view': Record<string, unknown>;
   'conversations.page-view': Record<string, unknown>;
+  'conversations.save_as': {
+    save_type: 'alert' | 'dashboard';
+  };
   'conversations.save_query_modal': {
     action: 'open' | 'submit';
     save_type?: 'save_new_query' | 'rename_query';
@@ -29,6 +32,7 @@ export type ConversationsEventParameters = {
 export const conversationsEventMap: Record<keyof ConversationsEventParameters, string> = {
   'conversations.onboarding.page-view': 'Conversations: Onboarding Page View',
   'conversations.page-view': 'Conversations: Page View',
+  'conversations.save_as': 'Conversations: Save As',
   'conversations.save_query_modal': 'Conversations: Save Query Modal',
   'conversations.table.page-view': 'Conversations: Table Page View',
   'conversations.table.paginate': 'Conversations: Table Paginate',

--- a/static/app/views/explore/conversations/components/conversationsChart.spec.tsx
+++ b/static/app/views/explore/conversations/components/conversationsChart.spec.tsx
@@ -3,7 +3,11 @@ import {TimeSeriesFixture} from 'sentry-fixture/timeSeries';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import {openAddToDashboardModal} from 'sentry/actionCreators/modal';
+import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import {ConversationsChart} from 'sentry/views/explore/conversations/components/conversationsChart';
+
+jest.mock('sentry/actionCreators/modal');
 
 describe('ConversationsChart', () => {
   const organization = OrganizationFixture();
@@ -150,5 +154,98 @@ describe('ConversationsChart', () => {
     render(<ConversationsChart />, {organization});
 
     expect(await screen.findByText('Internal Error')).toBeInTheDocument();
+  });
+
+  it('collapses and expands the chart', async () => {
+    const {router} = render(<ConversationsChart />, {organization});
+
+    await userEvent.click(screen.getByRole('button', {name: 'Collapse chart'}));
+
+    await waitFor(() => {
+      expect(router.location.query.chartCollapsed).toBe('true');
+    });
+
+    // Collapsing hides the chart-type/interval controls and reveals the expander.
+    const expandButton = await screen.findByRole('button', {name: 'Expand chart'});
+    expect(
+      screen.queryByRole('button', {name: 'Collapse chart'})
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Bar'})).not.toBeInTheDocument();
+
+    await userEvent.click(expandButton);
+
+    // Expanding resets to the default, which nuqs strips from the URL.
+    await waitFor(() => {
+      expect(router.location.query.chartCollapsed).toBeUndefined();
+    });
+    expect(
+      await screen.findByRole('button', {name: 'Collapse chart'})
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Expand chart'})).not.toBeInTheDocument();
+  });
+
+  it('links to the metric alert builder for the current visualization', async () => {
+    render(<ConversationsChart />, {organization});
+
+    await userEvent.click(screen.getByRole('button', {name: 'Chart actions'}));
+
+    const alertItem = await screen.findByRole('menuitemradio', {name: 'Create an Alert'});
+    const href = alertItem.getAttribute('href') ?? '';
+    expect(href).toContain('/alerts/new/metric/');
+    expect(href).toContain('aggregate=sum');
+    expect(href).toContain('gen_ai.cost.total_tokens');
+    expect(href).toContain('dataset=events_analytics_platform');
+  });
+
+  it('shows "Create a Monitor" with the workflow-engine-ui feature', async () => {
+    render(<ConversationsChart />, {
+      organization: OrganizationFixture({features: ['workflow-engine-ui']}),
+    });
+
+    await userEvent.click(screen.getByRole('button', {name: 'Chart actions'}));
+
+    expect(
+      await screen.findByRole('menuitemradio', {name: 'Create a Monitor'})
+    ).toBeInTheDocument();
+  });
+
+  it('disables "Add to Dashboard" without the dashboards-edit feature', async () => {
+    render(<ConversationsChart />, {
+      organization: OrganizationFixture({features: []}),
+    });
+
+    await userEvent.click(screen.getByRole('button', {name: 'Chart actions'}));
+
+    expect(
+      await screen.findByRole('menuitemradio', {name: 'Add to Dashboard'})
+    ).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('opens the add-to-dashboard modal with the dashboards-edit feature', async () => {
+    render(<ConversationsChart />, {
+      organization: OrganizationFixture({features: ['dashboards-edit']}),
+    });
+
+    await userEvent.click(screen.getByRole('button', {name: 'Chart actions'}));
+    await userEvent.click(
+      await screen.findByRole('menuitemradio', {name: 'Add to Dashboard'})
+    );
+
+    expect(openAddToDashboardModal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        widgets: [
+          expect.objectContaining({
+            displayType: DisplayType.BAR,
+            widgetType: WidgetType.SPANS,
+            queries: [
+              expect.objectContaining({
+                aggregates: ['sum(gen_ai.cost.total_tokens)'],
+                conditions: 'has:gen_ai.conversation.id gen_ai.operation.type:ai_client',
+              }),
+            ],
+          }),
+        ],
+      })
+    );
   });
 });

--- a/static/app/views/explore/conversations/components/conversationsChart.tsx
+++ b/static/app/views/explore/conversations/components/conversationsChart.tsx
@@ -1,27 +1,48 @@
 import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
-import {parseAsStringLiteral, useQueryState} from 'nuqs';
+import {parseAsBoolean, parseAsStringLiteral, useQueryState} from 'nuqs';
 
+import {Button} from '@sentry/scraps/button';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {Container} from '@sentry/scraps/layout';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
-import {Heading} from '@sentry/scraps/text';
+import {Heading, Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import {IconClock, IconGraph} from 'sentry/icons';
+import Feature from 'sentry/components/acl/feature';
+import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
+import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {IconClock, IconContract, IconEllipsis, IconExpand, IconGraph} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import type {NewQuery} from 'sentry/types/organization';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {EventView} from 'sentry/utils/discover/eventView';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {markDelayedData} from 'sentry/utils/timeSeries/markDelayedData';
 import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import {
   ChartIntervalUnspecifiedStrategy,
   useChartInterval,
 } from 'sentry/utils/useChartInterval';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {useProjects} from 'sentry/utils/useProjects';
+import {Dataset} from 'sentry/views/alerts/rules/metric/types';
+import {
+  DashboardWidgetSource,
+  DEFAULT_WIDGET_NAME,
+  DisplayType,
+  WidgetType,
+} from 'sentry/views/dashboards/types';
 import {MISSING_DATA_MESSAGE} from 'sentry/views/dashboards/widgets/common/settings';
+import {plottablesCanBeVisualized} from 'sentry/views/dashboards/widgets/plottablesCanBeVisualized';
 import {Bars} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/bars';
 import {Line} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/line';
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
+import {handleAddQueryToDashboard} from 'sentry/views/discover/utils';
 import {Referrer} from 'sentry/views/explore/conversations/utils/referrers';
+import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
 import {useCombinedQuery} from 'sentry/views/insights/pages/agents/hooks/useCombinedQuery';
 import {INGESTION_DELAY} from 'sentry/views/insights/settings';
 import {SpanFields} from 'sentry/views/insights/types';
@@ -49,6 +70,8 @@ const CHART_VISUALIZATIONS = {
 
 type ChartVisualizationKey = keyof typeof CHART_VISUALIZATIONS;
 
+type ChartTypeKey = 'line' | 'bar';
+
 const VISUALIZATION_OPTIONS = Object.entries(CHART_VISUALIZATIONS).map(
   ([value, {label}]) => ({value: value as ChartVisualizationKey, label})
 );
@@ -58,11 +81,18 @@ const CHART_TYPE_OPTIONS = [
   {value: 'bar' as const, label: t('Bar')},
 ];
 
+const CHART_TYPE_TO_DISPLAY_TYPE: Record<ChartTypeKey, DisplayType> = {
+  line: DisplayType.LINE,
+  bar: DisplayType.BAR,
+};
+
 const visualizationParser = parseAsStringLiteral(
   Object.keys(CHART_VISUALIZATIONS) as ChartVisualizationKey[]
 ).withDefault('cost');
 
 const chartTypeParser = parseAsStringLiteral(['line', 'bar'] as const).withDefault('bar');
+
+const collapsedParser = parseAsBoolean.withDefault(false);
 
 export function ConversationsChart() {
   const [visualization, setVisualization] = useQueryState(
@@ -70,6 +100,7 @@ export function ConversationsChart() {
     visualizationParser
   );
   const [chartType, setChartType] = useQueryState('chartType', chartTypeParser);
+  const [collapsed, setCollapsed] = useQueryState('chartCollapsed', collapsedParser);
   const [interval, setInterval, intervalOptions] = useChartInterval({
     unspecifiedStrategy: ChartIntervalUnspecifiedStrategy.USE_BIGGEST,
   });
@@ -105,7 +136,7 @@ export function ConversationsChart() {
   const intervalLabel =
     intervalOptions.find(option => option.value === interval)?.label ?? interval;
 
-  const Title = (
+  const visualizationSelect = (
     <CompactSelect
       trigger={triggerProps => (
         <TitleTrigger {...triggerProps} variant="transparent" size="xs">
@@ -120,7 +151,35 @@ export function ConversationsChart() {
     />
   );
 
-  const Actions = (
+  // When collapsed, drop the interactive dropdown for a compact title and keep
+  // the trend visible as a mini sparkline that fits the header, mirroring the
+  // logs chart.
+  const Title = collapsed ? (
+    <Widget.WidgetTitle
+      title={label}
+      summary={
+        plottablesCanBeVisualized(plottables) ? (
+          <TimeSeriesWidgetVisualization
+            plottables={plottables}
+            showLegend="never"
+            showXAxis="never"
+            showYAxis="never"
+          />
+        ) : null
+      }
+    />
+  ) : (
+    visualizationSelect
+  );
+
+  const Actions = collapsed ? (
+    <Button
+      aria-label={t('Expand chart')}
+      icon={<IconExpand />}
+      onClick={() => setCollapsed(false)}
+      size="xs"
+    />
+  ) : (
     <Fragment>
       <Tooltip title={t('Type of chart displayed in this visualization (ex. line)')}>
         <CompactSelect
@@ -158,6 +217,18 @@ export function ConversationsChart() {
           onChange={option => setInterval(option.value)}
         />
       </Tooltip>
+      <ContextMenu
+        yAxis={yAxis}
+        chartType={chartType}
+        query={query}
+        interval={interval}
+      />
+      <Button
+        aria-label={t('Collapse chart')}
+        icon={<IconContract />}
+        onClick={() => setCollapsed(true)}
+        size="xs"
+      />
     </Fragment>
   );
 
@@ -179,9 +250,124 @@ export function ConversationsChart() {
     <Widget
       Title={Title}
       Actions={Actions}
-      Visualization={Visualization}
-      height={195}
+      Visualization={collapsed ? null : Visualization}
+      height={collapsed ? 50 : 195}
       revealActions="always"
+    />
+  );
+}
+
+function ContextMenu({
+  yAxis,
+  chartType,
+  query,
+  interval,
+}: {
+  chartType: ChartTypeKey;
+  interval: string;
+  query: string;
+  yAxis: string;
+}) {
+  const location = useLocation();
+  const organization = useOrganization();
+  const {projects} = useProjects();
+  const pageFilters = usePageFilters();
+
+  const items: MenuItemProps[] = useMemo(() => {
+    const project =
+      projects.length === 1
+        ? projects[0]
+        : projects.find(p => p.id === `${pageFilters.selection.projects[0]}`);
+
+    const disableAddToDashboard = !organization.features.includes('dashboards-edit');
+
+    const newAlertLabel = organization.features.includes('workflow-engine-ui')
+      ? t('Create a Monitor')
+      : t('Create an Alert');
+
+    return [
+      {
+        key: 'create-alert',
+        textValue: newAlertLabel,
+        label: newAlertLabel,
+        to: getAlertsUrl({
+          project,
+          query,
+          pageFilters: pageFilters.selection,
+          aggregate: yAxis,
+          organization,
+          dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
+          interval,
+        }),
+        onAction: () => {
+          trackAnalytics('conversations.save_as', {
+            save_type: 'alert',
+            organization,
+          });
+        },
+      },
+      {
+        key: 'add-to-dashboard',
+        textValue: t('Add to Dashboard'),
+        label: (
+          <Feature
+            overrideName="feature-disabled:dashboards-edit"
+            features="organizations:dashboards-edit"
+            renderDisabled={() => <Text variant="muted">{t('Add to Dashboard')}</Text>}
+          >
+            {t('Add to Dashboard')}
+          </Feature>
+        ),
+        disabled: disableAddToDashboard,
+        onAction: () => {
+          if (disableAddToDashboard) {
+            return;
+          }
+          trackAnalytics('conversations.save_as', {
+            save_type: 'dashboard',
+            organization,
+          });
+
+          const discoverQuery: NewQuery = {
+            name: DEFAULT_WIDGET_NAME,
+            fields: [yAxis],
+            query,
+            version: 2,
+            dataset: DiscoverDatasets.SPANS,
+            yAxis: [yAxis],
+          };
+
+          const eventView = EventView.fromNewQueryWithPageFilters(
+            discoverQuery,
+            pageFilters.selection
+          );
+          eventView.dataset = DiscoverDatasets.SPANS;
+          eventView.display = CHART_TYPE_TO_DISPLAY_TYPE[chartType];
+
+          handleAddQueryToDashboard({
+            organization,
+            location,
+            eventView,
+            yAxis: eventView.yAxis,
+            widgetType: WidgetType.SPANS,
+            source: DashboardWidgetSource.INSIGHTS,
+          });
+        },
+      },
+    ];
+  }, [chartType, interval, location, organization, pageFilters, projects, query, yAxis]);
+
+  return (
+    <DropdownMenu
+      triggerProps={{
+        'aria-label': t('Chart actions'),
+        size: 'xs',
+        variant: 'transparent',
+        showChevron: false,
+        icon: <IconEllipsis />,
+      }}
+      position="bottom-end"
+      items={items}
     />
   );
 }


### PR DESCRIPTION
The conversations chart in agent monitoring now offers the same actions as the logs chart, exposed through a new "…" menu and a collapse control in the chart header.

- **Collapse/expand** the chart. The state is stored in the URL, so it survives reloads and is shareable; when collapsed, the header keeps a mini sparkline of the current visualization.
- **Create an alert** — or a monitor, under `workflow-engine-ui` — for the selected visualization, opening the metric alert builder against the spans dataset.
- **Add to dashboard**, gated on `dashboards-edit`, which opens the add-to-dashboard modal with a spans widget for the current visualization.

A new `conversations.save_as` Amplitude event fires when either save action is used, with `save_type` set to `alert` or `dashboard`.

Fixes TET-2775
