### PR TITLE
ref: Claim CODEOWNERS ownership of src/sentry/pr_metrics

### DIFF
--- a/.codeowners-config.yml
+++ b/.codeowners-config.yml
@@ -7,13 +7,13 @@ codeowners_path: '.github/CODEOWNERS'
 baseline_path: '.github/codeowners-coverage-baseline.txt'
 
 team_allowlist:
+  - getsentry/agent-interfaces
+  - getsentry/agent-interfaces-sentry-backend
+  - getsentry/agent-interfaces-sentry-frontend
   - getsentry/alerts-create-issues
   - getsentry/alerts-notifications
   - getsentry/app-backend
   - getsentry/app-frontend
-  - getsentry/coding-workflows
-  - getsentry/coding-workflows-sentry-backend
-  - getsentry/coding-workflows-sentry-frontend
   - getsentry/crons
   - getsentry/dashboards
   - getsentry/data

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -474,10 +474,10 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /src/sentry/identity/                                                @getsentry/foundations
 
 /src/sentry/integrations/                                            @getsentry/integration-platform
-/src/sentry/integrations/api/endpoints/organization_code_mapping*.py                            @getsentry/coding-workflows-sentry-backend
+/src/sentry/integrations/api/endpoints/organization_code_mapping*.py                            @getsentry/agent-interfaces-sentry-backend
 /src/sentry/integrations/api/endpoints/organization_coding_agents.py                            @getsentry/machine-learning-ai
 /src/sentry/integrations/coding_agent/                                      @getsentry/machine-learning-ai
-/src/sentry/integrations/utils/stacktrace_link.py                            @getsentry/coding-workflows-sentry-backend
+/src/sentry/integrations/utils/stacktrace_link.py                            @getsentry/agent-interfaces-sentry-backend
 
 /src/sentry/mail/                                                    @getsentry/notifications
 /src/sentry/notifications/                                           @getsentry/notifications
@@ -633,8 +633,8 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /static/app/views/seerExplorer/                             @getsentry/machine-learning-ai
 /src/sentry/seer/                                           @getsentry/machine-learning-ai
 /tests/sentry/seer/                                         @getsentry/machine-learning-ai
-/src/sentry/seer/fetch_issues/                              @getsentry/machine-learning-ai @getsentry/coding-workflows-sentry-backend
-/tests/sentry/seer/fetch_issues/                            @getsentry/machine-learning-ai @getsentry/coding-workflows-sentry-backend
+/src/sentry/seer/fetch_issues/                              @getsentry/machine-learning-ai @getsentry/agent-interfaces-sentry-backend
+/tests/sentry/seer/fetch_issues/                            @getsentry/machine-learning-ai @getsentry/agent-interfaces-sentry-backend
 /src/sentry/tasks/seer/                                     @getsentry/machine-learning-ai
 /tests/sentry/tasks/seer/                                   @getsentry/machine-learning-ai
 /src/sentry/viewer_context.py                               @getsentry/machine-learning-ai
@@ -664,7 +664,7 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /src/sentry/event_manager.py                                @getsentry/issue-detection-backend
 /src/sentry/eventstore/models.py                            @getsentry/issue-detection-backend
 /src/sentry/grouping/                                       @getsentry/issue-detection-backend
-/src/sentry/issues/auto_source_code_config/                 @getsentry/coding-workflows-sentry-backend
+/src/sentry/issues/auto_source_code_config/                 @getsentry/agent-interfaces-sentry-backend
 /src/sentry/issues/endpoints/related_issues.py              @getsentry/issue-detection-backend
 /src/sentry/issues/ingest.py                                @getsentry/issue-detection-backend
 /src/sentry/issues/issue_occurrence.py                      @getsentry/issue-detection-backend
@@ -684,17 +684,17 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /src/sentry/tasks/auto_ongoing_issues.py                    @getsentry/issue-detection-backend
 /src/sentry/tasks/auto_remove_inbox.py                      @getsentry/issue-detection-backend
 /src/sentry/tasks/auto_resolve_issues.py                    @getsentry/issue-detection-backend
-/src/sentry/tasks/auto_source_code_config.py                @getsentry/coding-workflows-sentry-backend
+/src/sentry/tasks/auto_source_code_config.py                @getsentry/agent-interfaces-sentry-backend
 /src/sentry/tasks/check_new_issue_threshold_met.py          @getsentry/issue-detection-backend
 /src/sentry/tasks/clear_expired_resolutions.py              @getsentry/issue-detection-backend
 /src/sentry/tasks/clear_expired_rulesnoozes.py              @getsentry/issue-detection-backend
 /src/sentry/tasks/clear_expired_snoozes.py                  @getsentry/issue-detection-backend
-/src/sentry/tasks/codeowners/                               @getsentry/coding-workflows-sentry-backend
-/src/sentry/tasks/commits.py                                @getsentry/coding-workflows-sentry-backend
-/src/sentry/tasks/commit_context.py                         @getsentry/coding-workflows-sentry-backend
+/src/sentry/tasks/codeowners/                               @getsentry/agent-interfaces-sentry-backend
+/src/sentry/tasks/commits.py                                @getsentry/agent-interfaces-sentry-backend
+/src/sentry/tasks/commit_context.py                         @getsentry/agent-interfaces-sentry-backend
 /src/sentry/tasks/seer/delete_seer_grouping_records.py      @getsentry/issue-detection-backend
 /src/sentry/tasks/embeddings_grouping/                      @getsentry/issue-detection-backend
-/src/sentry/tasks/groupowner.py                             @getsentry/coding-workflows-sentry-backend
+/src/sentry/tasks/groupowner.py                             @getsentry/agent-interfaces-sentry-backend
 /src/sentry/tasks/merge.py                                  @getsentry/issue-detection-backend
 /src/sentry/tasks/unmerge.py                                @getsentry/issue-detection-backend
 /src/sentry/tasks/weekly_escalating_forecast.py             @getsentry/issue-detection-backend
@@ -712,7 +712,7 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /tests/sentry/deletions/test_group.py                       @getsentry/issue-detection-backend
 /tests/sentry/event_manager/                                @getsentry/issue-detection-backend
 /tests/sentry/grouping/                                     @getsentry/issue-detection-backend
-/tests/sentry/issues/auto_source_code_config/               @getsentry/coding-workflows-sentry-backend
+/tests/sentry/issues/auto_source_code_config/               @getsentry/agent-interfaces-sentry-backend
 /tests/sentry/issues/endpoints/                             @getsentry/issue-workflow
 /tests/sentry/issues/endpoints/test_related_issues.py       @getsentry/issue-detection-backend
 /tests/sentry/issues/test_ingest.py                         @getsentry/issue-detection-backend
@@ -735,9 +735,9 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /tests/sentry/tasks/test_clear_expired_resolutions.py       @getsentry/issue-detection-backend
 /tests/sentry/tasks/test_clear_expired_rulesnoozes.py       @getsentry/issue-detection-backend
 /tests/sentry/tasks/test_clear_expired_snoozes.py           @getsentry/issue-detection-backend
-/tests/sentry/tasks/test_code_owners.py                     @getsentry/coding-workflows-sentry-backend
-/tests/sentry/tasks/test_commit_context.py                  @getsentry/coding-workflows-sentry-backend
-/tests/sentry/tasks/test_groupowner.py                      @getsentry/coding-workflows-sentry-backend
+/tests/sentry/tasks/test_code_owners.py                     @getsentry/agent-interfaces-sentry-backend
+/tests/sentry/tasks/test_commit_context.py                  @getsentry/agent-interfaces-sentry-backend
+/tests/sentry/tasks/test_groupowner.py                      @getsentry/agent-interfaces-sentry-backend
 /tests/sentry/tasks/test_merge.py                           @getsentry/issue-detection-backend
 /tests/sentry/tasks/test_post_process.py                    @getsentry/issue-detection-backend
 /tests/sentry/tasks/test_weekly_escalating_forecast.py      @getsentry/issue-detection-backend
@@ -870,20 +870,20 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 ## End of Frontend Platform
 
 # Coding Workflows
-/static/app/components/prevent/                           @getsentry/coding-workflows-sentry-frontend
-/static/app/views/prevent/                                @getsentry/coding-workflows-sentry-frontend
-/static/app/views/nav/secondary/sections/prevent/         @getsentry/coding-workflows-sentry-frontend
-/static/gsApp/views/seerAutomation/                       @getsentry/coding-workflows-sentry-frontend
-/src/sentry/prevent/                                      @getsentry/coding-workflows-sentry-backend
-/src/sentry/integrations/api/endpoints/organization_repository_settings.py   @getsentry/coding-workflows-sentry-backend
-/src/sentry/seer/code_review/                                                @getsentry/coding-workflows-sentry-backend
-/tests/sentry/seer/code_review/                                              @getsentry/coding-workflows-sentry-backend
-/src/sentry/releases/                                     @getsentry/coding-workflows-sentry-backend
-/tests/sentry/releases/                                   @getsentry/coding-workflows-sentry-backend
+/static/app/components/prevent/                           @getsentry/agent-interfaces-sentry-frontend
+/static/app/views/prevent/                                @getsentry/agent-interfaces-sentry-frontend
+/static/app/views/nav/secondary/sections/prevent/         @getsentry/agent-interfaces-sentry-frontend
+/static/gsApp/views/seerAutomation/                       @getsentry/agent-interfaces-sentry-frontend
+/src/sentry/prevent/                                      @getsentry/agent-interfaces-sentry-backend
+/src/sentry/integrations/api/endpoints/organization_repository_settings.py   @getsentry/agent-interfaces-sentry-backend
+/src/sentry/seer/code_review/                                                @getsentry/agent-interfaces-sentry-backend
+/tests/sentry/seer/code_review/                                              @getsentry/agent-interfaces-sentry-backend
+/src/sentry/releases/                                     @getsentry/agent-interfaces-sentry-backend
+/tests/sentry/releases/                                   @getsentry/agent-interfaces-sentry-backend
 
 ## SCM
 /src/sentry/scm/                                                        @getsentry/scm
-/src/sentry/integrations/source_code_management/                        @getsentry/coding-workflows-sentry-backend @getsentry/scm
+/src/sentry/integrations/source_code_management/                        @getsentry/agent-interfaces-sentry-backend @getsentry/scm
 /src/sentry/integrations/repository/                                    @getsentry/scm
 /src/sentry/integrations/github_enterprise/                             @getsentry/scm
 /src/sentry/integrations/gitlab/                                        @getsentry/scm
@@ -892,7 +892,7 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /src/sentry/integrations/vsts/                                          @getsentry/scm
 /src/sentry/integrations/vsts_extension/                                @getsentry/scm
 /src/sentry/integrations/perforce/                                      @getsentry/scm @getsentry/gdx
-/tests/sentry/integrations/source_code_management/                      @getsentry/coding-workflows-sentry-backend @getsentry/scm
+/tests/sentry/integrations/source_code_management/                      @getsentry/agent-interfaces-sentry-backend @getsentry/scm
 /tests/sentry/integrations/repository/                                  @getsentry/scm
 /tests/sentry/integrations/github_enterprise/                           @getsentry/scm
 /tests/sentry/integrations/gitlab/                                      @getsentry/scm
@@ -905,7 +905,7 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 ## End of SCM
 
 ## SCM Frontend
-/static/app/components/repositories                                   @getsentry/coding-workflows-sentry-frontend @getsentry/scm
+/static/app/components/repositories                                   @getsentry/agent-interfaces-sentry-frontend @getsentry/scm
 ## End of SCM Frontend
 
 # End of Coding Workflows

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -880,6 +880,8 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /tests/sentry/seer/code_review/                                              @getsentry/agent-interfaces-sentry-backend
 /src/sentry/releases/                                     @getsentry/agent-interfaces-sentry-backend
 /tests/sentry/releases/                                   @getsentry/agent-interfaces-sentry-backend
+/src/sentry/pr_metrics/                                   @getsentry/agent-interfaces-sentry-backend
+/tests/sentry/pr_metrics/                                 @getsentry/agent-interfaces-sentry-backend
 
 ## SCM
 /src/sentry/scm/                                                        @getsentry/scm

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -869,7 +869,7 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /static/gsAdmin/views/sentryAppDetails.spec.tsx        @getsentry/design-engineering
 ## End of Frontend Platform
 
-# Coding Workflows
+# Agent Interfaces
 /static/app/components/prevent/                           @getsentry/agent-interfaces-sentry-frontend
 /static/app/views/prevent/                                @getsentry/agent-interfaces-sentry-frontend
 /static/app/views/nav/secondary/sections/prevent/         @getsentry/agent-interfaces-sentry-frontend
@@ -908,7 +908,7 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /static/app/components/repositories                                   @getsentry/agent-interfaces-sentry-frontend @getsentry/scm
 ## End of SCM Frontend
 
-# End of Coding Workflows
+# End of Agent Interfaces
 
 # Conduit
 /src/sentry/conduit/                                  @getsentry/sre-infrastructure-engineering

--- a/src/sentry/api/api_owners.py
+++ b/src/sentry/api/api_owners.py
@@ -9,7 +9,7 @@ class ApiOwner(Enum):
 
     ALERTS_MONITORS = "alerts-monitors"
     BILLING = "revenue"
-    CODING_WORKFLOWS = "coding-workflows-sentry-backend"
+    CODING_WORKFLOWS = "agent-interfaces-sentry-backend"
     COMMUNITY = "app-backend"
     CRONS = "crons"
     DASHBOARDS = "dashboards"


### PR DESCRIPTION
`src/sentry/pr_metrics/` and `tests/sentry/pr_metrics/` have **no CODEOWNERS entry at all** — no team is routed reviews for either.

This surfaced while auditing Agent Interfaces sub-team membership against the paths each sub-team owns: `pr_metrics` is one of the most actively developed areas by members of that team, and it's invisible to review routing.

Claiming it for `@getsentry/agent-interfaces-sentry-backend`, alongside the adjacent `releases/` and `seer/code_review/` entries it sits with.

## Stacked on #120867

Based on the rename branch rather than `master`, because `@getsentry/agent-interfaces-sentry-backend` doesn't exist until getsentry/security-as-code#3361 applies. GitHub will retarget this to `master` once #120867 merges.

## Notes

- The `codeowners-coverage` workflow is `workflow_dispatch`-only and runs with `--allow-dirty-baseline`, so `.github/codeowners-coverage-baseline.txt` needs no regeneration here.
- Adding coverage where there was none only ever adds reviewers; no existing assignment changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
