### PR TITLE
feat(issues): fetch PR checks status from the provider

### DIFF
--- a/src/sentry/api/serializers/models/pullrequest.py
+++ b/src/sentry/api/serializers/models/pullrequest.py
@@ -8,6 +8,10 @@ from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.release import get_users_for_authors
 from sentry.api.serializers.models.repository import RepositorySerializerResponse
 from sentry.api.serializers.release_details_types import Author
+from sentry.integrations.source_code_management.status_check import (
+    AggregateChecksStatus,
+    PullRequestStatusResult,
+)
 from sentry.models.commitauthor import CommitAuthor
 from sentry.models.pullrequest import (
     PullRequest,
@@ -57,6 +61,7 @@ LinkedPullRequestAttributionResponse = LinkedPullRequestSeerAttributionResponse
 class LinkedPullRequestResponse(PullRequestSerializerResponse):
     attribution: LinkedPullRequestAttributionResponse | None
     dateLinked: datetime
+    checksStatus: AggregateChecksStatus | None
 
 
 def get_users_for_pull_requests(item_list, user=None):
@@ -122,8 +127,9 @@ def _serialize_attribution(
 class LinkedPullRequestSerializer(PullRequestSerializer):
     """Serialize a pull request linked to a group.
 
-    The caller passes in the linked-at timestamp and PR status; this serializer
-    maps them, along with the PR's Seer attribution, into the response shape.
+    The caller passes in the linked-at timestamp, status, and provider-reported checks;
+    this serializer maps them, along with the PR's Seer attribution, into the response
+    shape.
     """
 
     def __init__(
@@ -131,9 +137,11 @@ class LinkedPullRequestSerializer(PullRequestSerializer):
         *,
         date_linked_by_pr_id: Mapping[int, datetime],
         status_by_pr_id: Mapping[int, PullRequestStatus],
+        checks_and_review_by_pr_id: Mapping[int, PullRequestStatusResult],
     ) -> None:
         self.date_linked_by_pr_id = date_linked_by_pr_id
         self.status_by_pr_id = status_by_pr_id
+        self.checks_and_review_by_pr_id = checks_and_review_by_pr_id
 
     def get_attrs(self, item_list, user, **kwargs):
         attrs = super().get_attrs(item_list, user)
@@ -150,9 +158,11 @@ class LinkedPullRequestSerializer(PullRequestSerializer):
         return attrs
 
     def serialize(self, obj: PullRequest, attrs, user, **kwargs) -> LinkedPullRequestResponse:
+        checks_and_review = self.checks_and_review_by_pr_id.get(obj.id, PullRequestStatusResult())
         return {
             **super().serialize(obj, attrs, user, **kwargs),
             "attribution": attrs["attribution"],
             "dateLinked": self.date_linked_by_pr_id[obj.id],
             "status": self.status_by_pr_id[obj.id],
+            "checksStatus": checks_and_review.checks,
         }

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -351,6 +351,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:hard-delete-derived-data-invalidation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable double-reading from EAP for issue feed search queries
     manager.add("organizations:issue-feed.eap-search", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Fetch CI check status from the provider for pull requests linked to an issue
+    manager.add("organizations:issue-pr-checks-status", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Batch latest-event attachment lookups in the issue stream
     manager.add("organizations:issue-stream-batched-latest-event-attachments", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Remove trace and breadcrumbs from issue summary input

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -22,6 +22,10 @@ from sentry.integrations.github.blame import (
     is_graphql_response,
 )
 from sentry.integrations.github.constants import GITHUB_API_ACCEPT_HEADER
+from sentry.integrations.github.pull_request_status import (
+    create_pull_request_status_query,
+    extract_pull_request_statuses_from_response,
+)
 from sentry.integrations.github.utils import get_jwt, get_last_page_number, get_next_link
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.integration import RpcIntegration, integration_service
@@ -36,7 +40,12 @@ from sentry.integrations.source_code_management.metrics import (
 )
 from sentry.integrations.source_code_management.repo_trees import RepoTreesClient
 from sentry.integrations.source_code_management.repository import RepositoryClient
-from sentry.integrations.source_code_management.status_check import StatusCheckClient
+from sentry.integrations.source_code_management.status_check import (
+    PullRequestStatusClient,
+    PullRequestStatusRequest,
+    PullRequestStatusResult,
+    StatusCheckClient,
+)
 from sentry.integrations.types import EXTERNAL_PROVIDERS, ExternalProviders, IntegrationProviderSlug
 from sentry.models.pullrequest import PullRequest, PullRequestComment
 from sentry.models.repository import Repository
@@ -156,6 +165,7 @@ class GitHubApiRequestType(StrEnum):
     GET_PULL_REQUEST_COMMENTS = "get_pull_request_comments"
     GET_PULL_REQUEST_FILES = "get_pull_request_files"
     GET_PULL_REQUEST_FROM_COMMIT = "get_pull_request_from_commit"
+    GET_PULL_REQUEST_STATUS = "get_pull_request_status"
     GET_RATE_LIMIT = "get_rate_limit"
     GET_REPO = "get_repo"
     GET_REPO_TREE = "get_repo_tree"
@@ -445,7 +455,12 @@ class GithubProxyClient(IntegrationProxyClient):
 
 
 class GitHubBaseClient(
-    GithubProxyClient, RepositoryClient, CommitContextClient, RepoTreesClient, StatusCheckClient
+    GithubProxyClient,
+    RepositoryClient,
+    CommitContextClient,
+    RepoTreesClient,
+    StatusCheckClient,
+    PullRequestStatusClient,
 ):
     allow_redirects = True
 
@@ -1214,6 +1229,63 @@ class GitHubBaseClient(
                 "organization_integration_id": self.org_integration_id,
             },
         )
+
+    def _get_pull_request_status_cache_key(self, pull_request: PullRequestStatusRequest) -> str:
+        cache_data = orjson.dumps(
+            {"repo": pull_request.repo, "pull_number": pull_request.pull_number}
+        ).decode()
+        return self.get_cache_key("/graphql/pull-request-status", "", cache_data)
+
+    def get_pull_request_statuses(
+        self, pull_requests: Sequence[PullRequestStatusRequest]
+    ) -> dict[PullRequestStatusRequest, PullRequestStatusResult]:
+        """Return checks and review state, fetching all cache misses in one query."""
+        results: dict[PullRequestStatusRequest, PullRequestStatusResult] = {}
+        cache_keys: dict[PullRequestStatusRequest, str] = {}
+        uncached_pull_requests: list[PullRequestStatusRequest] = []
+
+        for pull_request in dict.fromkeys(pull_requests):
+            cache_key = self._get_pull_request_status_cache_key(pull_request)
+            cache_keys[pull_request] = cache_key
+            cached_result = self.check_cache(cache_key)
+            if isinstance(cached_result, PullRequestStatusResult):
+                results[pull_request] = cached_result
+            else:
+                uncached_pull_requests.append(pull_request)
+
+        if not uncached_pull_requests:
+            return results
+
+        data = create_pull_request_status_query(uncached_pull_requests)
+        response = self.post(
+            path="/graphql",
+            data=data,
+            allow_text=False,
+            api_request_type=GitHubApiRequestType.GET_PULL_REQUEST_STATUS,
+        )
+
+        if not is_graphql_response(response):
+            raise ApiError("Response is not JSON")
+
+        errors = response.get("errors", [])
+        if errors:
+            if any(error.get("type") == "RATE_LIMITED" for error in errors):
+                raise ApiRateLimitedError("GitHub rate limit exceeded")
+            if not response.get("data"):
+                raise ApiError("\n".join(error.get("message", "") for error in errors))
+            logger.info(
+                "github.get_pull_request_statuses.partial_errors",
+                extra={"error_count": len(errors)},
+            )
+
+        fetched_results = extract_pull_request_statuses_from_response(
+            response, uncached_pull_requests
+        )
+        for pull_request, result in fetched_results.items():
+            # Short enough that checks still appear to advance while CI runs.
+            self.set_cache(cache_keys[pull_request], result, 60)
+        results.update(fetched_results)
+        return results
 
     def create_check_run(self, repo: str, data: dict[str, Any]) -> Any:
         """

--- a/src/sentry/integrations/github/pull_request_status.py
+++ b/src/sentry/integrations/github/pull_request_status.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from sentry.integrations.source_code_management.status_check import (
+    AggregateChecksStatus,
+    PullRequestStatusRequest,
+    PullRequestStatusResult,
+)
+from sentry.utils.safe import get_path
+
+PULL_REQUEST_STATUS_FRAGMENT = """
+fragment PullRequestStatusFields on PullRequest {
+  commits(last: 1) {
+    nodes {
+      commit {
+        statusCheckRollup {
+          state
+        }
+      }
+    }
+  }
+}
+"""
+
+_CHECKS_STATUS_BY_STATE: dict[str, AggregateChecksStatus] = {
+    "SUCCESS": AggregateChecksStatus.SUCCESS,
+    "FAILURE": AggregateChecksStatus.FAILURE,
+    "ERROR": AggregateChecksStatus.FAILURE,
+    "PENDING": AggregateChecksStatus.PENDING,
+    "EXPECTED": AggregateChecksStatus.PENDING,
+}
+
+
+def create_pull_request_status_query(
+    pull_requests: Sequence[PullRequestStatusRequest],
+) -> dict[str, Any]:
+    """Create one GraphQL query for several pull requests."""
+    if not pull_requests:
+        raise ValueError("At least one pull request is required")
+
+    variable_definitions: list[str] = []
+    repository_queries: list[str] = []
+    variables: dict[str, str | int] = {}
+
+    for index, pull_request in enumerate(pull_requests):
+        owner, separator, name = pull_request.repo.partition("/")
+        if not separator or not owner or not name:
+            raise ValueError(f"Invalid GitHub repository name: {pull_request.repo!r}")
+
+        variable_definitions.extend(
+            (
+                f"$owner{index}: String!",
+                f"$name{index}: String!",
+                f"$number{index}: Int!",
+            )
+        )
+        variables.update(
+            {
+                f"owner{index}": owner,
+                f"name{index}": name,
+                f"number{index}": int(pull_request.pull_number),
+            }
+        )
+        repository_queries.append(
+            f"""  repository{index}: repository(owner: $owner{index}, name: $name{index}) {{
+    pullRequest(number: $number{index}) {{
+      ...PullRequestStatusFields
+    }}
+  }}"""
+        )
+
+    repository_query = "\n".join(repository_queries)
+    query = (
+        f"query pullRequestStatuses({', '.join(variable_definitions)}) {{\n"
+        f"{repository_query}\n"
+        f"}}\n{PULL_REQUEST_STATUS_FRAGMENT}"
+    )
+    return {"query": query, "variables": variables}
+
+
+def _extract_pull_request_status(pull_request: Any) -> PullRequestStatusResult:
+    state = get_path(pull_request, "commits", "nodes", 0, "commit", "statusCheckRollup", "state")
+    return PullRequestStatusResult(checks=_CHECKS_STATUS_BY_STATE.get(state))
+
+
+def extract_pull_request_status_from_response(response: Any) -> PullRequestStatusResult:
+    """
+    Read checks state from the legacy single-repository response shape.
+
+    Every level of the response is nullable and unrecognized values map to no state, so
+    a repository without CI, or a value GitHub adds later, reports nothing rather than
+    something wrong.
+    """
+    return _extract_pull_request_status(get_path(response, "data", "repository", "pullRequest"))
+
+
+def extract_pull_request_statuses_from_response(
+    response: Any, pull_requests: Sequence[PullRequestStatusRequest]
+) -> dict[PullRequestStatusRequest, PullRequestStatusResult]:
+    return {
+        pull_request: _extract_pull_request_status(
+            get_path(response, "data", f"repository{index}", "pullRequest")
+        )
+        for index, pull_request in enumerate(pull_requests)
+    }

--- a/src/sentry/integrations/source_code_management/status_check.py
+++ b/src/sentry/integrations/source_code_management/status_check.py
@@ -1,5 +1,7 @@
 import enum
 from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from dataclasses import dataclass
 from typing import Any
 
 
@@ -27,3 +29,43 @@ class StatusCheckClient(ABC):
     @abstractmethod
     def get_check_runs(self, repo: str, sha: str) -> Any:
         raise NotImplementedError
+
+
+class AggregateChecksStatus(enum.StrEnum):
+    """
+    The provider's roll-up of every check on a pull request into one state.
+    StatusCheckStatus above is the state of a single check Sentry writes; this is
+    every check read back.
+
+    A repository without CI has no state at all rather than a member here, so
+    that it does not read as perpetually pending.
+    """
+
+    SUCCESS = "success"
+    FAILURE = "failure"
+    PENDING = "pending"
+
+
+@dataclass(frozen=True)
+class PullRequestStatusResult:
+    """A pull request's checks state, as far as the provider reports it."""
+
+    checks: AggregateChecksStatus | None = None
+
+
+@dataclass(frozen=True)
+class PullRequestStatusRequest:
+    repo: str
+    pull_number: str
+
+
+class PullRequestStatusClient(ABC):
+    @abstractmethod
+    def get_pull_request_statuses(
+        self, pull_requests: Sequence[PullRequestStatusRequest]
+    ) -> dict[PullRequestStatusRequest, PullRequestStatusResult]:
+        raise NotImplementedError
+
+    def get_pull_request_status(self, repo: str, pull_number: str) -> PullRequestStatusResult:
+        request = PullRequestStatusRequest(repo=repo, pull_number=pull_number)
+        return self.get_pull_request_statuses([request]).get(request, PullRequestStatusResult())

--- a/src/sentry/issues/endpoints/group_pull_requests.py
+++ b/src/sentry/issues/endpoints/group_pull_requests.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
 from typing import TypedDict, cast
 
 from django.db.models import Exists, OuterRef
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -19,7 +21,13 @@ from sentry.api.serializers.models.pullrequest import (
     get_stored_pull_request_status,
 )
 from sentry.constants import ObjectStatus
+from sentry.integrations.base import IntegrationInstallation
 from sentry.integrations.services.integration import integration_service
+from sentry.integrations.source_code_management.status_check import (
+    PullRequestStatusClient,
+    PullRequestStatusRequest,
+    PullRequestStatusResult,
+)
 from sentry.issues.endpoints.bases.group import GroupEndpoint
 from sentry.models.group import Group
 from sentry.models.grouplink import GroupLink
@@ -72,9 +80,10 @@ def _get_pull_request_repo_name(repository: Repository) -> str:
     return repository.name
 
 
-def _fetch_pull_request_status_response(
+def _get_provider_installation(
     pull_request: PullRequest, repository: Repository
-) -> ProviderPullRequestResponse | None:
+) -> IntegrationInstallation | None:
+    """The repository's active integration, installed for the pull request's organization."""
     if repository.integration_id is None:
         return None
 
@@ -86,9 +95,17 @@ def _fetch_pull_request_status_response(
     if integration is None:
         return None
 
-    installation = integration.get_installation(organization_id=pull_request.organization_id)
-    client = installation.get_client()
-    get_pull_request = getattr(client, "get_pull_request", None)
+    return integration.get_installation(organization_id=pull_request.organization_id)
+
+
+def _fetch_pull_request_status_response(
+    pull_request: PullRequest, repository: Repository
+) -> ProviderPullRequestResponse | None:
+    installation = _get_provider_installation(pull_request, repository)
+    if installation is None:
+        return None
+
+    get_pull_request = getattr(installation.get_client(), "get_pull_request", None)
     if not callable(get_pull_request):
         return None
 
@@ -152,6 +169,69 @@ def _get_pull_request_status(
     return _get_provider_pull_request_status(pull_request, repository)
 
 
+def _get_checks_and_review(
+    pull_requests: Sequence[PullRequest],
+    repositories_by_id: Mapping[int, Repository],
+    lifecycle_status_by_pr_id: Mapping[int, PullRequestStatus],
+) -> dict[int, PullRequestStatusResult]:
+    """Fetch open pull requests in one provider request per integration."""
+    requests_by_integration_id: dict[
+        int, list[tuple[PullRequest, Repository, PullRequestStatusRequest]]
+    ] = defaultdict(list)
+
+    for pull_request in pull_requests:
+        repository = repositories_by_id.get(pull_request.repository_id)
+        if (
+            repository is None
+            or repository.integration_id is None
+            or lifecycle_status_by_pr_id[pull_request.id] not in ("open", "draft")
+        ):
+            continue
+
+        request = PullRequestStatusRequest(
+            repo=_get_pull_request_repo_name(repository), pull_number=pull_request.key
+        )
+        requests_by_integration_id[repository.integration_id].append(
+            (pull_request, repository, request)
+        )
+
+    results_by_pr_id: dict[int, PullRequestStatusResult] = {}
+    for integration_id, request_items in requests_by_integration_id.items():
+        representative_pull_request, representative_repository, _ = request_items[0]
+        try:
+            installation = _get_provider_installation(
+                representative_pull_request, representative_repository
+            )
+            if installation is None:
+                continue
+
+            client = installation.get_client()
+            if not isinstance(client, PullRequestStatusClient):
+                continue
+
+            status_by_request = client.get_pull_request_statuses(
+                [request for _, _, request in request_items]
+            )
+        except Exception:
+            logger.info(
+                "group_pull_requests.checks_and_review_fetch_failed",
+                exc_info=True,
+                extra={
+                    "organization_id": representative_pull_request.organization_id,
+                    "integration_id": integration_id,
+                    "pull_request_ids": [pull_request.id for pull_request, _, _ in request_items],
+                },
+            )
+            continue
+
+        for pull_request, _, request in request_items:
+            results_by_pr_id[pull_request.id] = status_by_request.get(
+                request, PullRequestStatusResult()
+            )
+
+    return results_by_pr_id
+
+
 @cell_silo_endpoint
 class GroupPullRequestsEndpoint(GroupEndpoint):
     owner = ApiOwner.ISSUES
@@ -195,6 +275,14 @@ class GroupPullRequestsEndpoint(GroupEndpoint):
             for pull_request in pull_requests
         }
 
+        checks_and_review_by_pr_id: dict[int, PullRequestStatusResult] = {}
+        if "checksAndReview" in request.GET.getlist("expand") and features.has(
+            "organizations:issue-pr-checks-status", group.project.organization
+        ):
+            checks_and_review_by_pr_id = _get_checks_and_review(
+                pull_requests, repositories_by_id, status_by_pr_id
+            )
+
         # serialize() infers the base PullRequestSerializerResponse from the
         # parent's generic; LinkedPullRequestSerializer returns the narrower type.
         pull_request_responses = cast(
@@ -205,6 +293,7 @@ class GroupPullRequestsEndpoint(GroupEndpoint):
                 serializer=LinkedPullRequestSerializer(
                     date_linked_by_pr_id=date_linked_by_pr_id,
                     status_by_pr_id=status_by_pr_id,
+                    checks_and_review_by_pr_id=checks_and_review_by_pr_id,
                 ),
             ),
         )

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -1,6 +1,7 @@
 import re
 from dataclasses import asdict
 from datetime import UTC, datetime, timedelta
+from typing import Any
 from unittest import mock
 
 import orjson
@@ -16,10 +17,16 @@ from sentry.integrations.github.blame import create_blame_query, generate_file_p
 from sentry.integrations.github.client import GitHubApiClient, GitHubApiRequestType, GitHubReaction
 from sentry.integrations.github.constants import GITHUB_API_ACCEPT_HEADER
 from sentry.integrations.github.integration import GitHubIntegration
+from sentry.integrations.github.pull_request_status import PULL_REQUEST_STATUS_FRAGMENT
 from sentry.integrations.source_code_management.commit_context import (
     CommitInfo,
     FileBlameInfo,
     SourceLineInfo,
+)
+from sentry.integrations.source_code_management.status_check import (
+    AggregateChecksStatus,
+    PullRequestStatusRequest,
+    PullRequestStatusResult,
 )
 from sentry.integrations.types import EventLifecycleOutcome
 from sentry.models.pullrequest import PullRequest, PullRequestComment
@@ -1061,6 +1068,133 @@ class GitHubApiClientTest(TestCase):
         assert result["state"] == "open"
         assert result["head"]["sha"] == "abc123def456"
         assert result["base"]["ref"] == "main"
+
+    def add_graphql_response(self, json: dict[str, Any]) -> None:
+        responses.add(
+            responses.POST,
+            "https://api.github.com/graphql",
+            json=json,
+            content_type="application/json",
+        )
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
+    def test_get_pull_request_status(self, get_jwt) -> None:
+        self.add_graphql_response(
+            {
+                "data": {
+                    "repository0": {
+                        "pullRequest": {
+                            "commits": {
+                                "nodes": [{"commit": {"statusCheckRollup": {"state": "SUCCESS"}}}]
+                            }
+                        }
+                    }
+                }
+            }
+        )
+
+        assert self.github_client.get_pull_request_status(
+            repo=self.repo.name, pull_number="42"
+        ) == PullRequestStatusResult(checks=AggregateChecksStatus.SUCCESS)
+
+        body = orjson.loads(responses.calls[-1].request.body)
+        assert PULL_REQUEST_STATUS_FRAGMENT in body["query"]
+        assert body["variables"] == {
+            "owner0": "Test-Organization",
+            "name0": "foo",
+            "number0": 42,
+        }
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
+    def test_get_pull_request_statuses_batches_cache_misses(self, get_jwt) -> None:
+        self.add_graphql_response(
+            {
+                "data": {
+                    "repository0": {
+                        "pullRequest": {
+                            "commits": {
+                                "nodes": [{"commit": {"statusCheckRollup": {"state": "SUCCESS"}}}]
+                            },
+                        }
+                    },
+                    "repository1": {
+                        "pullRequest": {
+                            "commits": {
+                                "nodes": [{"commit": {"statusCheckRollup": {"state": "FAILURE"}}}]
+                            },
+                        }
+                    },
+                }
+            }
+        )
+        first = PullRequestStatusRequest(repo=self.repo.name, pull_number="41")
+        second = PullRequestStatusRequest(repo=self.repo.name, pull_number="42")
+
+        assert self.github_client.get_pull_request_statuses([first, second]) == {
+            first: PullRequestStatusResult(checks=AggregateChecksStatus.SUCCESS),
+            second: PullRequestStatusResult(checks=AggregateChecksStatus.FAILURE),
+        }
+        assert len(responses.calls) == 1
+
+        body = orjson.loads(responses.calls[-1].request.body)
+        assert body["variables"] == {
+            "owner0": "Test-Organization",
+            "name0": "foo",
+            "number0": 41,
+            "owner1": "Test-Organization",
+            "name1": "foo",
+            "number1": 42,
+        }
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
+    def test_get_pull_request_status_caches_the_response(self, get_jwt) -> None:
+        # One provider request per pull request per window: the endpoint fetches for
+        # every linked pull request, so a repeat view must not re-query GitHub.
+        self.add_graphql_response(
+            {
+                "data": {
+                    "repository0": {
+                        "pullRequest": {
+                            "commits": {
+                                "nodes": [{"commit": {"statusCheckRollup": {"state": "SUCCESS"}}}]
+                            }
+                        }
+                    }
+                }
+            }
+        )
+        expected = PullRequestStatusResult(checks=AggregateChecksStatus.SUCCESS)
+
+        first = self.github_client.get_pull_request_status(repo=self.repo.name, pull_number="45")
+        second = self.github_client.get_pull_request_status(repo=self.repo.name, pull_number="45")
+
+        assert first == second == expected
+        assert len(responses.calls) == 1
+
+        # A different pull request keys separately, so it still reaches GitHub.
+        self.github_client.get_pull_request_status(repo=self.repo.name, pull_number="46")
+        assert len(responses.calls) == 2
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
+    def test_get_pull_request_status_query_errors(self, get_jwt) -> None:
+        self.add_graphql_response(
+            {"data": None, "errors": [{"message": "Field 'statusCheckRollup' doesn't exist"}]}
+        )
+
+        with pytest.raises(ApiError, match="Field 'statusCheckRollup' doesn't exist"):
+            self.github_client.get_pull_request_status(repo=self.repo.name, pull_number="43")
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
+    def test_get_pull_request_status_rate_limited(self, get_jwt) -> None:
+        self.add_graphql_response({"data": None, "errors": [{"type": "RATE_LIMITED"}]})
+
+        with pytest.raises(ApiRateLimitedError):
+            self.github_client.get_pull_request_status(repo=self.repo.name, pull_number="44")
 
 
 @control_silo_test

--- a/tests/sentry/integrations/github/test_pull_request_status.py
+++ b/tests/sentry/integrations/github/test_pull_request_status.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from sentry.integrations.github.pull_request_status import (
+    PULL_REQUEST_STATUS_FRAGMENT,
+    create_pull_request_status_query,
+    extract_pull_request_status_from_response,
+    extract_pull_request_statuses_from_response,
+)
+from sentry.integrations.source_code_management.status_check import (
+    AggregateChecksStatus,
+    PullRequestStatusRequest,
+    PullRequestStatusResult,
+)
+
+
+def response(rollup: dict[str, Any] | None = None) -> dict[str, Any]:
+    return {
+        "data": {
+            "repository": {
+                "pullRequest": {"commits": {"nodes": [{"commit": {"statusCheckRollup": rollup}}]}}
+            }
+        }
+    }
+
+
+def test_create_pull_request_status_query() -> None:
+    query = create_pull_request_status_query(
+        [
+            PullRequestStatusRequest(repo="getsentry/sentry", pull_number="42"),
+            PullRequestStatusRequest(repo="getsentry/snuba", pull_number="7"),
+        ]
+    )
+
+    assert query["variables"] == {
+        "owner0": "getsentry",
+        "name0": "sentry",
+        "number0": 42,
+        "owner1": "getsentry",
+        "name1": "snuba",
+        "number1": 7,
+    }
+    assert "repository0: repository(owner: $owner0, name: $name0)" in query["query"]
+    assert "repository1: repository(owner: $owner1, name: $name1)" in query["query"]
+    assert query["query"].count("...PullRequestStatusFields") == 2
+
+
+def test_create_pull_request_status_query_requires_a_pull_request() -> None:
+    with pytest.raises(ValueError, match="At least one pull request"):
+        create_pull_request_status_query([])
+
+
+def test_query_reads_the_head_commit() -> None:
+    # Checks belong to the newest commit; reading any other one reports stale CI forever.
+    assert "commits(last: 1)" in PULL_REQUEST_STATUS_FRAGMENT
+
+
+def test_extract_pull_request_statuses() -> None:
+    first = PullRequestStatusRequest(repo="getsentry/sentry", pull_number="42")
+    second = PullRequestStatusRequest(repo="getsentry/snuba", pull_number="7")
+    batch_response = {
+        "data": {
+            "repository0": response({"state": "SUCCESS"})["data"]["repository"],
+            "repository1": response({"state": "FAILURE"})["data"]["repository"],
+        }
+    }
+
+    assert extract_pull_request_statuses_from_response(batch_response, [first, second]) == {
+        first: PullRequestStatusResult(checks=AggregateChecksStatus.SUCCESS),
+        second: PullRequestStatusResult(checks=AggregateChecksStatus.FAILURE),
+    }
+
+
+@pytest.mark.parametrize(
+    ("state", "expected"),
+    (
+        ("SUCCESS", AggregateChecksStatus.SUCCESS),
+        ("FAILURE", AggregateChecksStatus.FAILURE),
+        ("PENDING", AggregateChecksStatus.PENDING),
+        # ERROR and EXPECTED have no member of their own.
+        ("ERROR", AggregateChecksStatus.FAILURE),
+        ("EXPECTED", AggregateChecksStatus.PENDING),
+        # A state GitHub adds later.
+        ("SOMETHING_NEW", None),
+    ),
+)
+def test_extract_checks(state: str, expected: AggregateChecksStatus | None) -> None:
+    assert extract_pull_request_status_from_response(response({"state": state})).checks == expected
+
+
+def test_extract_without_ci() -> None:
+    # No CI is an absent state, not a pending one.
+    assert extract_pull_request_status_from_response(response()) == PullRequestStatusResult()
+
+
+@pytest.mark.parametrize(
+    "data",
+    (
+        {"repository": {"pullRequest": {"commits": {"nodes": []}}}},
+        {"repository": {"pullRequest": None}},
+        {"repository": None},
+        None,
+    ),
+    ids=("no_commits", "no_pull_request", "no_repository", "no_data"),
+)
+def test_extract_nullable_levels(data: dict[str, Any] | None) -> None:
+    # An inaccessible repository or a deleted pull request nulls a level of the
+    # response rather than erroring.
+    assert extract_pull_request_status_from_response({"data": data}) == PullRequestStatusResult()

--- a/tests/sentry/issues/endpoints/test_group_pull_requests.py
+++ b/tests/sentry/issues/endpoints/test_group_pull_requests.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from datetime import datetime, timedelta
 from unittest.mock import Mock, patch
 
 from django.utils import timezone
 
 from sentry.constants import ObjectStatus
+from sentry.integrations.source_code_management.status_check import (
+    AggregateChecksStatus,
+    PullRequestStatusClient,
+    PullRequestStatusRequest,
+    PullRequestStatusResult,
+)
 from sentry.models.activity import Activity
 from sentry.models.group import Group
 from sentry.models.grouplink import GroupLink
@@ -18,7 +25,40 @@ from sentry.models.pullrequest import (
 )
 from sentry.models.repository import Repository
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.features import with_feature
 from sentry.types.activity import ActivityType
+
+
+class PullRequestStatusClientFake(PullRequestStatusClient):
+    """A client reporting checks state per pull request key."""
+
+    def __init__(
+        self,
+        status_by_key: dict[str, PullRequestStatusResult] | None = None,
+        error: Exception | None = None,
+    ) -> None:
+        self.status_by_key = status_by_key or {}
+        self.error = error
+        self.requested_keys: list[str] = []
+        self.request_count = 0
+
+    def get_pull_request_statuses(
+        self, pull_requests: Sequence[PullRequestStatusRequest]
+    ) -> dict[PullRequestStatusRequest, PullRequestStatusResult]:
+        self.request_count += 1
+        self.requested_keys.extend(pull_request.pull_number for pull_request in pull_requests)
+        if self.error is not None:
+            raise self.error
+        return {
+            pull_request: self.status_by_key.get(
+                pull_request.pull_number, PullRequestStatusResult()
+            )
+            for pull_request in pull_requests
+        }
+
+
+class UnsupportedClient:
+    """A client that cannot report checks state, like the non-GitHub providers."""
 
 
 class GroupPullRequestsEndpointTest(APITestCase):
@@ -36,6 +76,7 @@ class GroupPullRequestsEndpointTest(APITestCase):
         self.path = (
             f"/api/0/organizations/{self.organization.slug}/issues/{self.group.id}/pull-requests/"
         )
+        self.expanded_path = f"{self.path}?expand=checksAndReview"
 
     def create_linked_pull_request(
         self,
@@ -81,17 +122,26 @@ class GroupPullRequestsEndpointTest(APITestCase):
         )
         return pull_request, link
 
-    def set_provider_pull_request_response(
-        self, mock_get_integration: Mock, response: dict[str, object]
-    ) -> Mock:
-        client = Mock()
-        client.get_pull_request.return_value = response
+    def set_provider_client[T](self, mock_get_integration: Mock, client: T) -> T:
         installation = Mock()
         installation.get_client.return_value = client
         integration = Mock()
         integration.get_installation.return_value = installation
         mock_get_integration.return_value = integration
         return client
+
+    def set_provider_pull_request_response(
+        self, mock_get_integration: Mock, response: dict[str, object]
+    ) -> Mock:
+        client = Mock()
+        client.get_pull_request.return_value = response
+        return self.set_provider_client(mock_get_integration, client)
+
+    def get_checks(self, *, expand: bool = True) -> list[str | None]:
+        """The checksStatus of each pull request, in response order."""
+        response = self.client.get(self.expanded_path if expand else self.path)
+        assert response.status_code == 200
+        return [item["checksStatus"] for item in response.data["pullRequests"]]
 
     def test_empty_response(self) -> None:
         response = self.client.get(self.path)
@@ -362,3 +412,121 @@ class GroupPullRequestsEndpointTest(APITestCase):
 
         assert response.status_code == 200
         assert response.data["pullRequests"][0]["status"] == "unknown"
+
+    def test_checks_absent_without_feature(self) -> None:
+        self.create_linked_pull_request(key="1", state=PullRequestLifecycleState.OPEN, draft=False)
+
+        with patch(
+            "sentry.issues.endpoints.group_pull_requests.integration_service.get_integration"
+        ) as mock_get_integration:
+            assert self.get_checks() == [None]
+
+        # Both gates skip the provider request itself, not just the response field.
+        mock_get_integration.assert_not_called()
+
+    @with_feature("organizations:issue-pr-checks-status")
+    def test_checks_absent_without_expand(self) -> None:
+        self.create_linked_pull_request(key="1", state=PullRequestLifecycleState.OPEN, draft=False)
+
+        with patch(
+            "sentry.issues.endpoints.group_pull_requests.integration_service.get_integration"
+        ) as mock_get_integration:
+            assert self.get_checks(expand=False) == [None]
+
+        mock_get_integration.assert_not_called()
+
+    @with_feature("organizations:issue-pr-checks-status")
+    @patch("sentry.issues.endpoints.group_pull_requests.integration_service.get_integration")
+    def test_checks_for_open_pull_requests(self, mock_get_integration: Mock) -> None:
+        self.create_linked_pull_request(
+            key="1",
+            linked_delta=timedelta(days=2),
+            state=PullRequestLifecycleState.OPEN,
+            draft=False,
+        )
+        self.create_linked_pull_request(
+            key="2",
+            linked_delta=timedelta(days=1),
+            state=PullRequestLifecycleState.OPEN,
+            draft=True,
+        )
+        # "3" has no entry, standing in for a repository with no CI configured.
+        self.create_linked_pull_request(
+            key="3",
+            linked_delta=timedelta(hours=1),
+            state=PullRequestLifecycleState.OPEN,
+            draft=False,
+        )
+        client = self.set_provider_client(
+            mock_get_integration,
+            PullRequestStatusClientFake(
+                {
+                    "1": PullRequestStatusResult(checks=AggregateChecksStatus.FAILURE),
+                    "2": PullRequestStatusResult(checks=AggregateChecksStatus.SUCCESS),
+                }
+            ),
+        )
+
+        assert self.get_checks() == [None, "success", "failure"]
+        assert set(client.requested_keys) == {"1", "2", "3"}
+        assert client.request_count == 1
+        assert mock_get_integration.call_count == 1
+
+    @with_feature("organizations:issue-pr-checks-status")
+    @patch("sentry.issues.endpoints.group_pull_requests.integration_service.get_integration")
+    def test_checks_skipped_for_finished_pull_requests(self, mock_get_integration: Mock) -> None:
+        self.create_linked_pull_request(
+            key="1",
+            linked_delta=timedelta(days=2),
+            state=PullRequestLifecycleState.MERGED,
+            merged_at=timezone.now(),
+        )
+        self.create_linked_pull_request(
+            key="2",
+            linked_delta=timedelta(days=1),
+            state=PullRequestLifecycleState.CLOSED,
+        )
+        client = self.set_provider_client(mock_get_integration, PullRequestStatusClientFake())
+
+        assert self.get_checks() == [None, None]
+        assert client.requested_keys == []
+
+    @with_feature("organizations:issue-pr-checks-status")
+    @patch("sentry.issues.endpoints.group_pull_requests.integration_service.get_integration")
+    def test_checks_fetch_failure_is_not_fatal(self, mock_get_integration: Mock) -> None:
+        pull_request, _ = self.create_linked_pull_request(
+            key="1", state=PullRequestLifecycleState.OPEN, draft=False
+        )
+        self.set_provider_client(
+            mock_get_integration, PullRequestStatusClientFake(error=RuntimeError("nope"))
+        )
+
+        response = self.client.get(self.expanded_path)
+
+        assert response.status_code == 200
+        assert response.data["pullRequests"][0]["checksStatus"] is None
+        # The rest of the pull request still serializes.
+        assert response.data["pullRequests"][0]["id"] == pull_request.key
+        assert response.data["pullRequests"][0]["status"] == "open"
+
+    @with_feature("organizations:issue-pr-checks-status")
+    @patch("sentry.issues.endpoints.group_pull_requests.logger")
+    @patch("sentry.issues.endpoints.group_pull_requests.integration_service.get_integration")
+    def test_checks_without_client_support(
+        self, mock_get_integration: Mock, mock_logger: Mock
+    ) -> None:
+        self.create_linked_pull_request(key="1", state=PullRequestLifecycleState.OPEN, draft=False)
+        self.set_provider_client(mock_get_integration, UnsupportedClient())
+
+        assert self.get_checks() == [None]
+        # Nothing logged, so the capability check produced the None rather than a
+        # swallowed AttributeError.
+        mock_logger.info.assert_not_called()
+
+    @with_feature("organizations:issue-pr-checks-status")
+    @patch("sentry.issues.endpoints.group_pull_requests.integration_service.get_integration")
+    def test_checks_without_integration(self, mock_get_integration: Mock) -> None:
+        self.create_linked_pull_request(key="1", state=PullRequestLifecycleState.OPEN, draft=False)
+        mock_get_integration.return_value = None
+
+        assert self.get_checks() == [None]


### PR DESCRIPTION
Refs https://linear.app/getsentry/issue/ISWF-3140/fetch-pr-checks-and-review-status-from-integration-providers
<img width="1848" height="899" alt="image" src="https://github.com/user-attachments/assets/9fe61c62-6450-4b74-bec8-a20c0f5fe494" />
For PRs linked to issues, we'd like to show the mergability of a PR. Github exposes a `statusCheckRollup` state that we can query for — add the functionality in the Github integration to get this, and add it to the group pull request endpoint (gated behind a feature flag).