### PR TITLE
fix(seer): Don't treat resolution by bots as a ground truth to score Smart Assignment

### DIFF
--- a/src/sentry/seer/smart_assignment/scoring.py
+++ b/src/sentry/seer/smart_assignment/scoring.py
@@ -103,6 +103,7 @@ def _ground_truth_updates(
     if activity_type in RESOLUTION_ACTIVITIES:
         resolver_id = resolver_user_id(activity)
         if resolver_id is None:
+            # If we don't have a resolver user ID, we can't score the prediction.
             return None
         extras = run.extras or {}
         if (

--- a/src/sentry/seer/smart_assignment/scoring.py
+++ b/src/sentry/seer/smart_assignment/scoring.py
@@ -17,6 +17,7 @@ from sentry.seer.smart_assignment.models import (
 )
 from sentry.seer.utils import latest_run_for_group
 from sentry.types.activity import ActivityType
+from sentry.users.services.user.service import user_service
 from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
@@ -65,6 +66,23 @@ def record_ground_truth(
         )
 
 
+def resolver_user_id(activity: Activity | None) -> int | None:
+    """The user a resolution can be credited to, or ``None`` when it names no one who
+    could have owned the issue.
+
+    Automatic resolutions (auto-resolve, resolve-in-next-release) have no acting user.
+    A resolution driven through an integration -- a Linear ticket moving to Done, say --
+    acts as the Sentry App's proxy user (``is_sentry_app``), which identifies the app
+    rather than a person.
+    """
+    if activity is None or activity.user_id is None:
+        return None
+    user = user_service.get_user(user_id=activity.user_id)
+    if user is None or user.is_sentry_app:
+        return None
+    return user.id
+
+
 def _ground_truth_updates(
     run: SeerAgentRun,
     group: Group,
@@ -83,7 +101,8 @@ def _ground_truth_updates(
     if activity_type == ActivityType.ASSIGNED:
         return _assignment_updates(group)
     if activity_type in RESOLUTION_ACTIVITIES:
-        if activity is None or activity.user_id is None:
+        resolver_id = resolver_user_id(activity)
+        if resolver_id is None:
             return None
         extras = run.extras or {}
         if (
@@ -99,7 +118,7 @@ def _ground_truth_updates(
         if assignment is not None:
             return assignment
         return {
-            "actual_assignee_user_id": activity.user_id,
+            "actual_assignee_user_id": resolver_id,
             "ground_truth_source": activity_type.name,
         }
     return None

--- a/src/sentry/seer/smart_assignment/scoring.py
+++ b/src/sentry/seer/smart_assignment/scoring.py
@@ -43,7 +43,7 @@ def record_prediction(run: SeerAgentRun, predicted_assignee_user_ids: list[int |
 def record_ground_truth(
     group: Group,
     activity_type: ActivityType,
-    activity: Activity | None = None,
+    activity: Activity,
 ) -> None:
     """Record who the issue actually belonged to, then score the prediction.
 
@@ -66,7 +66,7 @@ def record_ground_truth(
         )
 
 
-def resolver_user_id(activity: Activity | None) -> int | None:
+def resolver_user_id(activity: Activity) -> int | None:
     """The user a resolution can be credited to, or ``None`` when it names no one who
     could have owned the issue.
 
@@ -75,7 +75,7 @@ def resolver_user_id(activity: Activity | None) -> int | None:
     acts as the Sentry App's proxy user (``is_sentry_app``), which identifies the app
     rather than a person.
     """
-    if activity is None or activity.user_id is None:
+    if activity.user_id is None:
         return None
     user = user_service.get_user(user_id=activity.user_id)
     if user is None or user.is_sentry_app:
@@ -87,7 +87,7 @@ def _ground_truth_updates(
     run: SeerAgentRun,
     group: Group,
     activity_type: ActivityType,
-    activity: Activity | None,
+    activity: Activity,
 ) -> RunUpdates | None:
     """Build the ground-truth mirror updates for an activity, or ``None`` when it
     carries no useful signal.

--- a/src/sentry/seer/smart_assignment/trigger.py
+++ b/src/sentry/seer/smart_assignment/trigger.py
@@ -15,7 +15,7 @@ from sentry.seer.smart_assignment.models import (
     SEER_FEATURE_ID,
     SmartAssignmentPayload,
 )
-from sentry.seer.smart_assignment.scoring import record_ground_truth
+from sentry.seer.smart_assignment.scoring import record_ground_truth, resolver_user_id
 from sentry.seer.utils import runs_for_group
 from sentry.types.activity import ActivityType
 from sentry.utils import metrics
@@ -56,7 +56,7 @@ def trigger_smart_assignment(
     if not features.has(FEATURE_FLAG, organization):
         return
 
-    if activity_type in RESOLUTION_ACTIVITIES and (activity is None or activity.user_id is None):
+    if activity_type in RESOLUTION_ACTIVITIES and resolver_user_id(activity) is None:
         metrics.incr(
             "smart_assignment.trigger.skipped",
             tags={"reason": "automatic_resolution"},

--- a/src/sentry/seer/smart_assignment/trigger.py
+++ b/src/sentry/seer/smart_assignment/trigger.py
@@ -31,7 +31,7 @@ _RATE_LIMIT_WINDOW = 86400
 def trigger_smart_assignment(
     group: Group,
     activity_type: ActivityType,
-    activity: Activity | None = None,
+    activity: Activity,
 ) -> None:
     """Trigger and/or score a Smart Assignment run for an issue.
 
@@ -119,7 +119,7 @@ def _dispatch_rate_limited(organization: Organization) -> bool:
     return False
 
 
-def _dispatch(group: Group, activity_type: ActivityType, activity: Activity | None) -> None:
+def _dispatch(group: Group, activity_type: ActivityType, activity: Activity) -> None:
     """Dispatch a Seer smart-assignment run and stamp the triggering activity.
 
     The run's Sentry-side mirror (`SeerAgentRun`) is created inside `start_feature_run`
@@ -139,9 +139,10 @@ def _dispatch(group: Group, activity_type: ActivityType, activity: Activity | No
         )
         return
 
-    extras: dict[str, object] = {"trigger": activity_type.name}
-    if activity is not None:
-        extras["triggering_activity_id"] = activity.id
+    extras: dict[str, object] = {
+        "trigger": activity_type.name,
+        "triggering_activity_id": activity.id,
+    }
 
     payload = SmartAssignmentPayload(group_id=group.id, project_slug=group.project.slug)
     title = f"Smart assignment for {group.qualified_short_id or group.id}"
@@ -157,8 +158,7 @@ def _dispatch(group: Group, activity_type: ActivityType, activity: Activity | No
         logger.exception("smart_assignment.trigger.dispatch_failed", extra={"group_id": group.id})
         return
 
-    if activity is not None:
-        _stamp_activity(activity, run, activity_type)
+    _stamp_activity(activity, run, activity_type)
 
     metrics.incr(
         "smart_assignment.trigger.dispatched",

--- a/tests/sentry/seer/smart_assignment/test_scoring.py
+++ b/tests/sentry/seer/smart_assignment/test_scoring.py
@@ -219,9 +219,7 @@ class RecordGroundTruthTest(ScoringTestBase):
         assert "actual_assignee_user_id" not in run.extras
         assert "ground_truth_source" not in run.extras
 
-    def test_integration_resolution_is_noop(self) -> None:
-        # An integration resolving through the API (a Linear ticket moving to Done)
-        # acts as the Sentry App's proxy user, which owns nothing.
+    def test_resolution_by_sentry_app_proxy_user_is_noop(self) -> None:
         run = self._run()
         proxy_user = self.create_user(is_sentry_app=True)
         record_ground_truth(

--- a/tests/sentry/seer/smart_assignment/test_scoring.py
+++ b/tests/sentry/seer/smart_assignment/test_scoring.py
@@ -169,9 +169,13 @@ class RecordPredictionScoringTest(ScoringTestBase):
 
 
 class RecordGroundTruthTest(ScoringTestBase):
-    def _resolved_activity(self, user_id: int | None = None) -> Activity:
+    def _resolved_activity(
+        self,
+        user_id: int | None = None,
+        activity_type: ActivityType = ActivityType.SET_RESOLVED,
+    ) -> Activity:
         return self.create_group_activity(
-            group=self.group, type=ActivityType.SET_RESOLVED.value, user_id=user_id
+            group=self.group, type=activity_type.value, user_id=user_id
         )
 
     def test_noop_without_run(self) -> None:
@@ -210,6 +214,21 @@ class RecordGroundTruthTest(ScoringTestBase):
     def test_automatic_resolution_is_noop(self) -> None:
         run = self._run()
         record_ground_truth(self.group, ActivityType.SET_RESOLVED, self._resolved_activity(None))
+
+        run.refresh_from_db()
+        assert "actual_assignee_user_id" not in run.extras
+        assert "ground_truth_source" not in run.extras
+
+    def test_integration_resolution_is_noop(self) -> None:
+        # An integration resolving through the API (a Linear ticket moving to Done)
+        # acts as the Sentry App's proxy user, which owns nothing.
+        run = self._run()
+        proxy_user = self.create_user(is_sentry_app=True)
+        record_ground_truth(
+            self.group,
+            ActivityType.SET_RESOLVED_IN_RELEASE,
+            self._resolved_activity(proxy_user.id, ActivityType.SET_RESOLVED_IN_RELEASE),
+        )
 
         run.refresh_from_db()
         assert "actual_assignee_user_id" not in run.extras

--- a/tests/sentry/seer/smart_assignment/test_scoring.py
+++ b/tests/sentry/seer/smart_assignment/test_scoring.py
@@ -169,18 +169,24 @@ class RecordPredictionScoringTest(ScoringTestBase):
 
 
 class RecordGroundTruthTest(ScoringTestBase):
-    def _resolved_activity(
-        self,
-        user_id: int | None = None,
-        activity_type: ActivityType = ActivityType.SET_RESOLVED,
-    ) -> Activity:
+    def _activity(self, activity_type: ActivityType, user_id: int | None = None) -> Activity:
         return self.create_group_activity(
             group=self.group, type=activity_type.value, user_id=user_id
         )
 
+    def _assigned_activity(self, assignee_id: int, integration: str | None = None) -> Activity:
+        data = {"assignee": str(assignee_id), "assigneeType": "user"}
+        if integration is not None:
+            data["integration"] = integration
+        return self.create_group_activity(
+            group=self.group, type=ActivityType.ASSIGNED.value, data=data
+        )
+
     def test_noop_without_run(self) -> None:
         record_ground_truth(
-            self.group, ActivityType.SET_RESOLVED, self._resolved_activity(self.user.id)
+            self.group,
+            ActivityType.SET_RESOLVED,
+            self._activity(ActivityType.SET_RESOLVED, self.user.id),
         )
         assert not SeerAgentRun.objects.filter(
             group_id=self.group.id, source=SEER_FEATURE_ID
@@ -192,7 +198,7 @@ class RecordGroundTruthTest(ScoringTestBase):
         GroupAssignee.objects.create(
             group=self.group, project=self.group.project, user_id=assignee.id
         )
-        record_ground_truth(self.group, ActivityType.ASSIGNED)
+        record_ground_truth(self.group, ActivityType.ASSIGNED, self._assigned_activity(assignee.id))
 
         run.refresh_from_db()
         assert run.extras["actual_assignee_user_id"] == assignee.id
@@ -203,7 +209,9 @@ class RecordGroundTruthTest(ScoringTestBase):
         run = self._run(actual_assignee_team_id=team.id)
         resolver = self.create_user()
         record_ground_truth(
-            self.group, ActivityType.SET_RESOLVED, self._resolved_activity(resolver.id)
+            self.group,
+            ActivityType.SET_RESOLVED,
+            self._activity(ActivityType.SET_RESOLVED, resolver.id),
         )
 
         run.refresh_from_db()
@@ -213,7 +221,9 @@ class RecordGroundTruthTest(ScoringTestBase):
 
     def test_automatic_resolution_is_noop(self) -> None:
         run = self._run()
-        record_ground_truth(self.group, ActivityType.SET_RESOLVED, self._resolved_activity(None))
+        record_ground_truth(
+            self.group, ActivityType.SET_RESOLVED, self._activity(ActivityType.SET_RESOLVED)
+        )
 
         run.refresh_from_db()
         assert "actual_assignee_user_id" not in run.extras
@@ -225,7 +235,7 @@ class RecordGroundTruthTest(ScoringTestBase):
         record_ground_truth(
             self.group,
             ActivityType.SET_RESOLVED_IN_RELEASE,
-            self._resolved_activity(proxy_user.id, ActivityType.SET_RESOLVED_IN_RELEASE),
+            self._activity(ActivityType.SET_RESOLVED_IN_RELEASE, proxy_user.id),
         )
 
         run.refresh_from_db()
@@ -234,7 +244,9 @@ class RecordGroundTruthTest(ScoringTestBase):
 
     def test_seer_start_is_noop(self) -> None:
         run = self._run()
-        record_ground_truth(self.group, ActivityType.SEER_RCA_STARTED)
+        record_ground_truth(
+            self.group, ActivityType.SEER_RCA_STARTED, self._activity(ActivityType.SEER_RCA_STARTED)
+        )
 
         run.refresh_from_db()
         assert "ground_truth_source" not in run.extras
@@ -245,14 +257,8 @@ class RecordGroundTruthTest(ScoringTestBase):
         GroupAssignee.objects.create(
             group=self.group, project=self.group.project, user_id=assignee.id
         )
-        activity = self.create_group_activity(
-            group=self.group,
-            type=ActivityType.ASSIGNED.value,
-            data={
-                "assignee": str(assignee.id),
-                "assigneeType": "user",
-                "integration": ActivityIntegration.SEER_SUGGESTED.value,
-            },
+        activity = self._assigned_activity(
+            assignee.id, integration=ActivityIntegration.SEER_SUGGESTED.value
         )
         record_ground_truth(self.group, ActivityType.ASSIGNED, activity)
 
@@ -264,14 +270,8 @@ class RecordGroundTruthTest(ScoringTestBase):
         GroupAssignee.objects.create(
             group=self.group, project=self.group.project, user_id=assignee_id
         )
-        return self.create_group_activity(
-            group=self.group,
-            type=ActivityType.ASSIGNED.value,
-            data={
-                "assignee": str(assignee_id),
-                "assigneeType": "user",
-                "integration": ActivityIntegration.SEER_SUGGESTED.value,
-            },
+        return self._assigned_activity(
+            assignee_id, integration=ActivityIntegration.SEER_SUGGESTED.value
         )
 
     def test_resolution_ignores_seer_auto_assignment(self) -> None:
@@ -283,7 +283,9 @@ class RecordGroundTruthTest(ScoringTestBase):
         self._seer_auto_assign(seer_assignee.id)
         resolver = self.create_user()
         record_ground_truth(
-            self.group, ActivityType.SET_RESOLVED, self._resolved_activity(resolver.id)
+            self.group,
+            ActivityType.SET_RESOLVED,
+            self._activity(ActivityType.SET_RESOLVED, resolver.id),
         )
 
         run.refresh_from_db()
@@ -298,13 +300,11 @@ class RecordGroundTruthTest(ScoringTestBase):
         self._seer_auto_assign(seer_assignee.id)
         human_assignee = self.create_user()
         GroupAssignee.objects.filter(group=self.group).update(user_id=human_assignee.id)
-        self.create_group_activity(
-            group=self.group,
-            type=ActivityType.ASSIGNED.value,
-            data={"assignee": str(human_assignee.id), "assigneeType": "user"},
-        )
+        self._assigned_activity(human_assignee.id)
         record_ground_truth(
-            self.group, ActivityType.SET_RESOLVED, self._resolved_activity(self.create_user().id)
+            self.group,
+            ActivityType.SET_RESOLVED,
+            self._activity(ActivityType.SET_RESOLVED, self.create_user().id),
         )
 
         run.refresh_from_db()
@@ -321,7 +321,7 @@ class RecordGroundTruthTest(ScoringTestBase):
         GroupAssignee.objects.create(
             group=self.group, project=self.group.project, user_id=assignee.id
         )
-        record_ground_truth(self.group, ActivityType.ASSIGNED)
+        record_ground_truth(self.group, ActivityType.ASSIGNED, self._assigned_activity(assignee.id))
 
         mock_metrics.incr.assert_any_call(
             "smart_assignment.scored",
@@ -337,7 +337,9 @@ class RecordGroundTruthTest(ScoringTestBase):
         )
         resolver = self.create_user()
         record_ground_truth(
-            self.group, ActivityType.SET_RESOLVED, self._resolved_activity(resolver.id)
+            self.group,
+            ActivityType.SET_RESOLVED,
+            self._activity(ActivityType.SET_RESOLVED, resolver.id),
         )
 
         run.refresh_from_db()

--- a/tests/sentry/seer/smart_assignment/test_trigger.py
+++ b/tests/sentry/seer/smart_assignment/test_trigger.py
@@ -207,3 +207,21 @@ class TriggerSmartAssignmentTest(TestCase):
         # No acting user -> not a signal, so we don't even dispatch a prediction.
         assert self._mirrors() == []
         mock_client_cls.return_value.start_feature_run.assert_not_called()
+
+    @patch(CLIENT_PATH)
+    def test_integration_resolution_is_skipped(self, mock_client_cls: MagicMock) -> None:
+        self._wire_client(mock_client_cls)
+        proxy_user = self.create_user(is_sentry_app=True)
+        with self.feature("organizations:seer-smart-assignment-run"):
+            trigger_smart_assignment(
+                self.group,
+                ActivityType.SET_RESOLVED_IN_RELEASE,
+                self.create_group_activity(
+                    group=self.group,
+                    type=ActivityType.SET_RESOLVED_IN_RELEASE.value,
+                    user_id=proxy_user.id,
+                ),
+            )
+
+        assert self._mirrors() == []
+        mock_client_cls.return_value.start_feature_run.assert_not_called()

--- a/tests/sentry/seer/smart_assignment/test_trigger.py
+++ b/tests/sentry/seer/smart_assignment/test_trigger.py
@@ -107,7 +107,7 @@ class TriggerSmartAssignmentTest(TestCase):
         )
         with self.feature("organizations:seer-smart-assignment-run"):
             trigger_smart_assignment(
-                self.group, ActivityType.ASSIGNED, self._activity(ActivityType.ASSIGNED)
+                self.group, ActivityType.ASSIGNED, self._assigned_activity(assignee.id)
             )
 
         mirrors = self._mirrors()
@@ -125,7 +125,7 @@ class TriggerSmartAssignmentTest(TestCase):
         GroupAssignee.objects.create(group=self.group, project=self.group.project, team=team)
         with self.feature("organizations:seer-smart-assignment-run"):
             trigger_smart_assignment(
-                self.group, ActivityType.ASSIGNED, self._activity(ActivityType.ASSIGNED)
+                self.group, ActivityType.ASSIGNED, self._assigned_activity(team.id, "team")
             )
 
         extras = self._mirrors()[0].extras
@@ -211,7 +211,7 @@ class TriggerSmartAssignmentTest(TestCase):
             ),
         ):
             trigger_smart_assignment(
-                self.group, ActivityType.ASSIGNED, self._activity(ActivityType.ASSIGNED)
+                self.group, ActivityType.ASSIGNED, self._assigned_activity(assignee.id)
             )
 
         extras = self._mirrors()[0].extras

--- a/tests/sentry/seer/smart_assignment/test_trigger.py
+++ b/tests/sentry/seer/smart_assignment/test_trigger.py
@@ -53,28 +53,39 @@ class TriggerSmartAssignmentTest(TestCase):
     def _mirrors(self) -> list[SeerAgentRun]:
         return list(SeerAgentRun.objects.filter(group_id=self.group.id, source=SEER_FEATURE_ID))
 
-    def _resolved_activity(self, user_id: int | None = None) -> Activity:
+    def _activity(self, activity_type: ActivityType, user_id: int | None = None) -> Activity:
         return self.create_group_activity(
-            group=self.group, type=ActivityType.SET_RESOLVED.value, user_id=user_id
+            group=self.group, type=activity_type.value, user_id=user_id
+        )
+
+    def _seer_started(self) -> Activity:
+        return self._activity(ActivityType.SEER_RCA_STARTED)
+
+    def _assigned_activity(self, assignee_id: int, assignee_type: str = "user") -> Activity:
+        return self.create_group_activity(
+            group=self.group,
+            type=ActivityType.ASSIGNED.value,
+            data={"assignee": str(assignee_id), "assigneeType": assignee_type},
         )
 
     @patch(CLIENT_PATH)
     def test_dispatch_creates_run_mirror(self, mock_client_cls: MagicMock) -> None:
         self._wire_client(mock_client_cls)
         with self.feature("organizations:seer-smart-assignment-run"):
-            trigger_smart_assignment(self.group, ActivityType.SEER_RCA_STARTED)
+            trigger_smart_assignment(
+                self.group, ActivityType.SEER_RCA_STARTED, self._seer_started()
+            )
 
         mirrors = self._mirrors()
         assert len(mirrors) == 1
         # The dispatch trigger (raw ActivityType name) is seeded on the extras for scoring.
         assert mirrors[0].extras["trigger"] == ActivityType.SEER_RCA_STARTED.name
-        # A Seer AI-step start carries no ground truth (and no activity was passed to stamp).
+        # A Seer AI-step start carries no ground truth.
         assert "actual_assignee_user_id" not in mirrors[0].extras
-        assert "triggering_activity_id" not in mirrors[0].extras
 
     @patch(CLIENT_PATH)
     def test_flag_disabled_is_noop(self, mock_client_cls: MagicMock) -> None:
-        trigger_smart_assignment(self.group, ActivityType.SEER_RCA_STARTED)
+        trigger_smart_assignment(self.group, ActivityType.SEER_RCA_STARTED, self._seer_started())
         assert self._mirrors() == []
         mock_client_cls.return_value.start_feature_run.assert_not_called()
 
@@ -82,7 +93,9 @@ class TriggerSmartAssignmentTest(TestCase):
     def test_dedup_skips_second_dispatch(self, mock_client_cls: MagicMock) -> None:
         self._mirror(trigger=ActivityType.SEER_RCA_STARTED.name)
         with self.feature("organizations:seer-smart-assignment-run"):
-            trigger_smart_assignment(self.group, ActivityType.SEER_RCA_STARTED)
+            trigger_smart_assignment(
+                self.group, ActivityType.SEER_RCA_STARTED, self._seer_started()
+            )
         mock_client_cls.return_value.start_feature_run.assert_not_called()
 
     @patch(CLIENT_PATH)
@@ -93,7 +106,9 @@ class TriggerSmartAssignmentTest(TestCase):
             group=self.group, project=self.group.project, user_id=assignee.id
         )
         with self.feature("organizations:seer-smart-assignment-run"):
-            trigger_smart_assignment(self.group, ActivityType.ASSIGNED)
+            trigger_smart_assignment(
+                self.group, ActivityType.ASSIGNED, self._activity(ActivityType.ASSIGNED)
+            )
 
         mirrors = self._mirrors()
         assert len(mirrors) == 1
@@ -109,7 +124,9 @@ class TriggerSmartAssignmentTest(TestCase):
         team = self.create_team(organization=self.organization)
         GroupAssignee.objects.create(group=self.group, project=self.group.project, team=team)
         with self.feature("organizations:seer-smart-assignment-run"):
-            trigger_smart_assignment(self.group, ActivityType.ASSIGNED)
+            trigger_smart_assignment(
+                self.group, ActivityType.ASSIGNED, self._activity(ActivityType.ASSIGNED)
+            )
 
         extras = self._mirrors()[0].extras
         assert extras["actual_assignee_team_id"] == team.id
@@ -121,7 +138,9 @@ class TriggerSmartAssignmentTest(TestCase):
         resolver = self.create_user()
         with self.feature("organizations:seer-smart-assignment-run"):
             trigger_smart_assignment(
-                self.group, ActivityType.SET_RESOLVED, self._resolved_activity(resolver.id)
+                self.group,
+                ActivityType.SET_RESOLVED,
+                self._activity(ActivityType.SET_RESOLVED, resolver.id),
             )
 
         extras = self._mirrors()[0].extras
@@ -132,9 +151,7 @@ class TriggerSmartAssignmentTest(TestCase):
     @patch(CLIENT_PATH)
     def test_dispatch_stamps_triggering_activity(self, mock_client_cls: MagicMock) -> None:
         self._wire_client(mock_client_cls)
-        activity = self.create_group_activity(
-            group=self.group, type=ActivityType.SEER_RCA_STARTED.value
-        )
+        activity = self._seer_started()
         with self.feature("organizations:seer-smart-assignment-run"):
             trigger_smart_assignment(self.group, ActivityType.SEER_RCA_STARTED, activity)
 
@@ -153,7 +170,9 @@ class TriggerSmartAssignmentTest(TestCase):
             self.feature("organizations:seer-smart-assignment-run"),
             self.options({"seer.smart_assignment.max_dispatches_per_org_per_day": 0}),
         ):
-            trigger_smart_assignment(self.group, ActivityType.SEER_RCA_STARTED)
+            trigger_smart_assignment(
+                self.group, ActivityType.SEER_RCA_STARTED, self._seer_started()
+            )
 
         assert self._mirrors() == []
         mock_client_cls.return_value.start_feature_run.assert_not_called()
@@ -166,7 +185,9 @@ class TriggerSmartAssignmentTest(TestCase):
             self.feature("organizations:seer-smart-assignment-run"),
             self.options({"seer.smart_assignment.max_dispatches_per_day": 0}),
         ):
-            trigger_smart_assignment(self.group, ActivityType.SEER_RCA_STARTED)
+            trigger_smart_assignment(
+                self.group, ActivityType.SEER_RCA_STARTED, self._seer_started()
+            )
 
         assert self._mirrors() == []
         mock_client_cls.return_value.start_feature_run.assert_not_called()
@@ -189,7 +210,9 @@ class TriggerSmartAssignmentTest(TestCase):
                 }
             ),
         ):
-            trigger_smart_assignment(self.group, ActivityType.ASSIGNED)
+            trigger_smart_assignment(
+                self.group, ActivityType.ASSIGNED, self._activity(ActivityType.ASSIGNED)
+            )
 
         extras = self._mirrors()[0].extras
         assert extras["actual_assignee_user_id"] == assignee.id
@@ -201,7 +224,7 @@ class TriggerSmartAssignmentTest(TestCase):
         self._wire_client(mock_client_cls)
         with self.feature("organizations:seer-smart-assignment-run"):
             trigger_smart_assignment(
-                self.group, ActivityType.SET_RESOLVED, self._resolved_activity(None)
+                self.group, ActivityType.SET_RESOLVED, self._activity(ActivityType.SET_RESOLVED)
             )
 
         # No acting user -> not a signal, so we don't even dispatch a prediction.
@@ -216,11 +239,7 @@ class TriggerSmartAssignmentTest(TestCase):
             trigger_smart_assignment(
                 self.group,
                 ActivityType.SET_RESOLVED_IN_RELEASE,
-                self.create_group_activity(
-                    group=self.group,
-                    type=ActivityType.SET_RESOLVED_IN_RELEASE.value,
-                    user_id=proxy_user.id,
-                ),
+                self._activity(ActivityType.SET_RESOLVED_IN_RELEASE, proxy_user.id),
             )
 
         assert self._mirrors() == []


### PR DESCRIPTION
I noticed a situation where we scored a Smart Assignment prediction as wrong because we guessed a very-plausible suspect-commit author, but we counted the actual user as the Linear bot that auto-resolved the issue. Use `is_sentry_user` to disqualify these users from scoring as actual.

Resolves ISWF-3163