### PR TITLE
ref(api): Remove unused organization option features

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable, Mapping, MutableMapping, Sequence
+from collections.abc import Mapping, MutableMapping, Sequence
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, ClassVar, TypedDict, cast
 
@@ -103,16 +103,6 @@ START_DATE_FOR_CHECKING_ONBOARDING_COMPLETION = datetime(2024, 10, 30, tzinfo=ti
 _ORGANIZATION_SCOPE_PREFIX = "organizations:"
 
 logger = logging.getLogger(__name__)
-
-# A mapping of OrganizationOption keys to a list of frontend features, and functions to apply the feature.
-# Enabling feature-flagging frontend components without an extra API call/endpoint to verify
-# the OrganizationOption.
-OptionFeature = tuple[str, Callable[[OrganizationOption], bool]]
-ORGANIZATION_OPTIONS_AS_FEATURES: Mapping[str, list[OptionFeature]] = {
-    "quotas:new-spike-protection": [
-        ("spike-projections", lambda opt: bool(opt.value)),
-    ],
-}
 
 
 class _Status(TypedDict):
@@ -518,15 +508,6 @@ class OrganizationSummarySerializer(Serializer[OrganizationSummarySerializerResp
         # Include api-keys feature if they previously had any api-keys
         if "api-keys" not in feature_set and attrs["has_api_key"]:
             feature_set.add("api-keys")
-
-        # Organization flag features (not provided through the features module)
-        options_as_features = OrganizationOption.objects.filter(
-            organization=obj, key__in=ORGANIZATION_OPTIONS_AS_FEATURES.keys()
-        )
-        for option in options_as_features:
-            for option_feature, option_function in ORGANIZATION_OPTIONS_AS_FEATURES[option.key]:
-                if option_function(option):
-                    feature_set.add(option_feature)
 
         if getattr(obj.flags, "allow_joinleave"):
             feature_set.add("open-membership")

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -11,7 +11,6 @@ from sentry.api.serializers import (
     OrganizationWithProjectsAndTeamsSerializer,
     serialize,
 )
-from sentry.api.serializers.models.organization import ORGANIZATION_OPTIONS_AS_FEATURES
 from sentry.auth import access
 from sentry.features.base import OrganizationFeature
 from sentry.models.deploy import Deploy
@@ -33,25 +32,6 @@ non_default_owner_scopes = ["org:ci", "openid", "email", "profile", "project:dis
 default_owner_scopes = frozenset(
     filter(lambda scope: scope not in non_default_owner_scopes, settings.SENTRY_SCOPES)
 )
-
-mock_options_as_features = {
-    "sentry:set_no_value": [
-        ("frontend-flag-1-1", lambda opt: True),
-        ("frontend-flag-1-2", lambda opt: True),
-    ],
-    "sentry:unset_no_value": [
-        ("frontend-flag-2-1", lambda opt: True),
-        ("frontend-flag-2-2", lambda opt: True),
-    ],
-    "sentry:set_with_func_pass": [
-        ("frontend-flag-3-1", lambda opt: bool(opt.value)),
-        ("frontend-flag-3-2", lambda opt: bool(opt.value)),
-    ],
-    "sentry:set_with_func_fail": [
-        ("frontend-flag-4-1", lambda opt: bool(opt.value)),
-        ("frontend-flag-4-2", lambda opt: bool(opt.value)),
-    ],
-}
 
 
 class OrganizationSummarySerializerTest(TestCase):
@@ -117,30 +97,6 @@ class OrganizationSummarySerializerTest(TestCase):
         result = serialize(organization, user)
         assert "test-feature" in result["features"]
         assert "disabled-feature" not in result["features"]
-
-    @mock.patch.dict(ORGANIZATION_OPTIONS_AS_FEATURES, mock_options_as_features)
-    def test_organization_options_as_features(self) -> None:
-        user = self.create_user()
-        organization = self.create_organization(owner=user)
-
-        OrganizationOption.objects.set_value(organization, "sentry:set_no_value", {})
-        OrganizationOption.objects.set_value(organization, "sentry:set_with_func_pass", 1)
-        OrganizationOption.objects.set_value(organization, "sentry:set_with_func_fail", 0)
-
-        features = serialize(organization, user)["features"]
-
-        # Setting a flag with no function checks for option, regardless of value
-        for feature, _func in mock_options_as_features["sentry:set_no_value"]:
-            assert feature in features
-        # If the option isn't set, it doesn't appear in features
-        for feature, _func in mock_options_as_features["sentry:unset_no_value"]:
-            assert feature not in features
-        # With a function, run it against the value
-        for feature, _func in mock_options_as_features["sentry:set_with_func_pass"]:
-            assert feature in features
-        # If it returns False, it doesn't appear in features
-        for feature, _func in mock_options_as_features["sentry:set_with_func_fail"]:
-            assert feature not in features
 
 
 class OrganizationSerializerTest(TestCase):


### PR DESCRIPTION
OrganizationSummarySerializer runs one OrganizationOption query per organization to translate quotas:new-spike-protection into spike-projections. That feature no longer has a consumer in Sentry or GetSentry, so remove the mapping and query instead of batching dead code.