### PR TITLE
ref(replays): Give spans path in replay counts its own referrer

### DIFF
--- a/src/sentry/replays/usecases/replay_counts.py
+++ b/src/sentry/replays/usecases/replay_counts.py
@@ -13,6 +13,7 @@ from sentry.search.eap.types import SearchResolverConfig, SupportedTraceItemType
 from sentry.search.events.types import EventsResponse, SnubaParams
 from sentry.snuba import discover, errors, issue_platform, transactions
 from sentry.snuba.dataset import Dataset
+from sentry.snuba.referrer import Referrer
 from sentry.snuba.spans_rpc import Spans
 
 MAX_REPLAY_COUNT = 51
@@ -196,7 +197,7 @@ def _query_eap_spans_for_replay_ids(
         # In buffer mode we'll often set IDs for replays that are never sent to
         # Sentry - load a lot of extra IDs to compensate.
         limit=MAX_REPLAY_COUNT * 10,
-        referrer="api.organization-issue-replay-count",
+        referrer=Referrer.API_ORGANIZATION_SPAN_REPLAY_COUNT,
         config=SearchResolverConfig(),
     )
 

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -498,6 +498,7 @@ class Referrer(StrEnum):
     API_ORGANIZATION_ISSUES_COUNT = "api.organization-issues-count"
     API_ORGANIZATION_ISSUE_REPLAY_COUNT = "api.organization-issue-replay-count"
     API_ORGANIZATION_SDK_UPDATES = "api.organization-sdk-updates"
+    API_ORGANIZATION_SPAN_REPLAY_COUNT = "api.organization-span-replay-count"
     API_ORGANIZATION_VITALS_PER_PROJECT = "api.organization-vitals-per-project"
     API_ORGANIZATION_VITALS = "api.organization-vitals"
     API_AI_CONVERSATIONS = "api.ai-conversations"


### PR DESCRIPTION
Give the spans path in the `/replay-counts/` endpoint its own referrer to separate it from the non-EAP path, for cleaner usage reporting:

https://github.com/getsentry/sentry/blob/b696e70f898ee743196d5600d32358bd1861600f/src/sentry/replays/usecases/replay_counts.py#L161-L169