### PR TITLE
feat(workflow-engine): Extend issue stream detector to support all projects

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3408,6 +3408,12 @@ register(
     default=[8001],  # MetricIssue.type_id
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "workflow_engine.all_projects_detectors_enabled",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 register(
     "workflow_engine.group.type_id.open_periods_type_denylist",

--- a/src/sentry/workflow_engine/defaults/detectors.py
+++ b/src/sentry/workflow_engine/defaults/detectors.py
@@ -16,6 +16,7 @@ from sentry.incidents.utils.types import DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION
 from sentry.issue_detection.performance_detection import PERFORMANCE_DETECTOR_CONFIG_MAPPINGS
 from sentry.issues import grouptype
 from sentry.locks import locks
+from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.projectoptions.defaults import DEFAULT_PROJECT_PERFORMANCE_DETECTION_SETTINGS
 from sentry.seer.anomaly_detection.store_data_workflow_engine import send_new_detector_data
@@ -329,12 +330,17 @@ def ensure_default_all_projects_detector(organization_id: int) -> Detector:
         raise UnableToAcquireLockApiError
 
 
+def ensure_default_organization_detectors(organization: Organization) -> dict[str, Detector]:
+    detectors: dict[str, Detector] = {}
+    detectors[IssueStreamGroupType.slug] = ensure_default_all_projects_detector(
+        organization_id=organization.id
+    )
+    return detectors
+
+
 def ensure_default_detectors(project: Project) -> dict[str, Detector]:
     detectors: dict[str, Detector] = {}
     detectors[ErrorGroupType.slug] = _ensure_detector(project, ErrorGroupType.slug)
     detectors[IssueStreamGroupType.slug] = _ensure_detector(project, IssueStreamGroupType.slug)
     detectors.update(ensure_performance_detectors(project))
-    organization = project.organization
-    if features.has("organizations:workflow-engine-all-projects-detector", organization):
-        ensure_default_all_projects_detector(organization_id=project.organization_id)
     return detectors

--- a/src/sentry/workflow_engine/defaults/detectors.py
+++ b/src/sentry/workflow_engine/defaults/detectors.py
@@ -37,6 +37,7 @@ from sentry.workflow_engine.models import (
 )
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.types import (
+    ALL_PROJECTS_DETECTOR_NAME,
     ERROR_DETECTOR_NAME,
     ISSUE_STREAM_DETECTOR_NAME,
     DetectorPriorityLevel,
@@ -278,9 +279,62 @@ def ensure_performance_detectors(project: Project) -> dict[str, Detector]:
     return detectors
 
 
+def ensure_default_all_projects_detector(organization_id: int) -> Detector:
+    """
+    Ensure that an org-scoped all-project detector exists for the organization.
+    This detector has project=NULL and config={"organization_id": org_id}.
+    """
+    existing = (
+        Detector.objects.filter(
+            type=IssueStreamGroupType.slug,
+            project__isnull=True,
+            config__organization_id=organization_id,
+        )
+        .order_by("id")
+        .first()
+    )
+    if existing:
+        return existing
+
+    lock = locks.get(
+        f"workflow-engine-org-{IssueStreamGroupType.slug}-detector:{organization_id}",
+        duration=2,
+        name=f"workflow_engine_all_project_{IssueStreamGroupType.slug}_detector",
+    )
+    try:
+        with (
+            lock.blocking_acquire(initial_delay=0.1, timeout=3),
+            transaction.atomic(router.db_for_write(Detector)),
+        ):
+            existing = (
+                Detector.objects.filter(
+                    type=IssueStreamGroupType.slug,
+                    project__isnull=True,
+                    config__organization_id=organization_id,
+                )
+                .order_by("id")
+                .first()
+            )
+            if existing:
+                return existing
+
+            return Detector.objects.create(
+                type=IssueStreamGroupType.slug,
+                project=None,
+                config={"organization_id": organization_id},
+                name=ALL_PROJECTS_DETECTOR_NAME,
+                enabled=True,
+            )
+    except UnableToAcquireLock:
+        raise UnableToAcquireLockApiError
+
+
 def ensure_default_detectors(project: Project) -> dict[str, Detector]:
     detectors: dict[str, Detector] = {}
     detectors[ErrorGroupType.slug] = _ensure_detector(project, ErrorGroupType.slug)
     detectors[IssueStreamGroupType.slug] = _ensure_detector(project, IssueStreamGroupType.slug)
     detectors.update(ensure_performance_detectors(project))
+    organization = project.organization
+    if features.has("organizations:workflow-engine-all-projects-detector", organization):
+        ensure_default_all_projects_detector(organization_id=project.organization_id)
     return detectors

--- a/src/sentry/workflow_engine/models/detector.py
+++ b/src/sentry/workflow_engine/models/detector.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import builtins
 import logging
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, ClassVar, TypedDict
+from typing import TYPE_CHECKING, Any, ClassVar, Self, TypedDict
 
 from django.conf import settings
 from django.db import models
+from django.db.models import Q
 from jsonschema import ValidationError
 
 from sentry.backup.scopes import RelocationScope
@@ -46,15 +47,8 @@ class DetectorSnapshot(TypedDict):
     trigger_condition: DataConditionGroupSnapshot | None
 
 
-class DetectorManager(BaseManager["Detector"]):
-    def get_queryset(self) -> BaseQuerySet[Detector]:
-        return (
-            super()
-            .get_queryset()
-            .exclude(status__in=(ObjectStatus.PENDING_DELETION, ObjectStatus.DELETION_IN_PROGRESS))
-        )
-
-    def with_type_filters(self) -> BaseQuerySet[Detector]:
+class DetectorQuerySet(BaseQuerySet["Detector"]):
+    def with_type_filters(self) -> Self:
         """
         Returns a queryset with detector type-specific filters applied. This
         filters out detectors based on their type settings
@@ -63,7 +57,37 @@ class DetectorManager(BaseManager["Detector"]):
         code to ensure filtered detectors are hidden. This is the recommended
         way to query detectors.
         """
-        return self.get_queryset().filter(grouptype.registry.get_detector_type_filters())
+        return self.filter(grouptype.registry.get_detector_type_filters())
+
+    def by_organization(self, organization_id: int) -> Self:
+        """
+        Returns a queryset of detectors scoped to the given organization.
+        Project-scoped detectors are matched via project__organization.
+        Null-project (all-projects) detectors are matched via config__organization_id.
+        """
+        from sentry.workflow_engine.typings.grouptype import IssueStreamGroupType
+
+        return self.filter(
+            Q(project__organization_id=organization_id)
+            | Q(
+                project__isnull=True,
+                type=IssueStreamGroupType.slug,
+                config__organization_id=organization_id,
+            )
+        )
+
+
+class DetectorManager(BaseManager["Detector"]):
+    def get_queryset(self) -> DetectorQuerySet:
+        return DetectorQuerySet(self.model, using=self._db).exclude(
+            status__in=(ObjectStatus.PENDING_DELETION, ObjectStatus.DELETION_IN_PROGRESS)
+        )
+
+    def with_type_filters(self) -> DetectorQuerySet:
+        return self.get_queryset().with_type_filters()
+
+    def by_organization(self, organization_id: int) -> DetectorQuerySet:
+        return self.get_queryset().by_organization(organization_id)
 
 
 @cell_silo_model

--- a/src/sentry/workflow_engine/models/detector.py
+++ b/src/sentry/workflow_engine/models/detector.py
@@ -138,7 +138,7 @@ class Detector(DefaultFieldsModel, OwnerModel, JSONConfigBase):
         return detector
 
     @classmethod
-    def get_all_project_detector_for_org(cls, organization_id: int) -> Detector:
+    def get_all_projects_detector_for_org(cls, organization_id: int) -> Detector:
         from sentry.workflow_engine.typings.grouptype import IssueStreamGroupType
 
         cache_key = get_all_projects_detector_cache_key(organization_id)

--- a/src/sentry/workflow_engine/models/detector.py
+++ b/src/sentry/workflow_engine/models/detector.py
@@ -38,6 +38,10 @@ def get_detector_project_type_cache_key(project_id: int, detector_type: str) -> 
     return f"detector:by_proj_type:{project_id}:{detector_type}"
 
 
+def get_all_projects_detector_cache_key(organization_id: int) -> str:
+    return f"detector:all_projects:{organization_id}"
+
+
 class DetectorSnapshot(TypedDict):
     id: int
     type: str
@@ -130,6 +134,21 @@ class Detector(DefaultFieldsModel, OwnerModel, JSONConfigBase):
         detector = cache.get(cache_key)
         if detector is None:
             detector = cls.objects.get(project_id=project_id, type=detector_type)
+            cache.set(cache_key, detector, cls.CACHE_TTL)
+        return detector
+
+    @classmethod
+    def get_all_project_detector_for_org(cls, organization_id: int) -> Detector:
+        from sentry.workflow_engine.typings.grouptype import IssueStreamGroupType
+
+        cache_key = get_all_projects_detector_cache_key(organization_id)
+        detector = cache.get(cache_key)
+        if detector is None:
+            detector = cls.objects.get(
+                project__isnull=True,
+                type=IssueStreamGroupType.slug,
+                config__organization_id=organization_id,
+            )
             cache.set(cache_key, detector, cls.CACHE_TTL)
         return detector
 

--- a/src/sentry/workflow_engine/models/detector.py
+++ b/src/sentry/workflow_engine/models/detector.py
@@ -38,10 +38,6 @@ def get_detector_project_type_cache_key(project_id: int, detector_type: str) -> 
     return f"detector:by_proj_type:{project_id}:{detector_type}"
 
 
-def get_all_projects_detector_cache_key(organization_id: int) -> str:
-    return f"detector:all_projects:{organization_id}"
-
-
 class DetectorSnapshot(TypedDict):
     id: int
     type: str
@@ -134,21 +130,6 @@ class Detector(DefaultFieldsModel, OwnerModel, JSONConfigBase):
         detector = cache.get(cache_key)
         if detector is None:
             detector = cls.objects.get(project_id=project_id, type=detector_type)
-            cache.set(cache_key, detector, cls.CACHE_TTL)
-        return detector
-
-    @classmethod
-    def get_all_projects_detector_for_org(cls, organization_id: int) -> Detector:
-        from sentry.workflow_engine.typings.grouptype import IssueStreamGroupType
-
-        cache_key = get_all_projects_detector_cache_key(organization_id)
-        detector = cache.get(cache_key)
-        if detector is None:
-            detector = cls.objects.get(
-                project__isnull=True,
-                type=IssueStreamGroupType.slug,
-                config__organization_id=organization_id,
-            )
             cache.set(cache_key, detector, cls.CACHE_TTL)
         return detector
 

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -35,12 +35,12 @@ logger = logging.getLogger(__name__)
 _DETECTOR_SENTINEL = object()
 
 
-def get_all_projects_detector_cache_key(organization_id: int) -> str:
+def _get_all_projects_detector_cache_key(organization_id: int) -> str:
     return f"detector:all_projects:{organization_id}"
 
 
-def get_all_projects_detector_for_org(organization_id: int) -> Detector | None:
-    cache_key = get_all_projects_detector_cache_key(organization_id)
+def get_all_projects_detector(organization_id: int) -> Detector | None:
+    cache_key = _get_all_projects_detector_cache_key(organization_id)
     cached = cache.get(cache_key, default=_DETECTOR_SENTINEL)
     if cached is not _DETECTOR_SENTINEL:
         return cached
@@ -57,7 +57,7 @@ def invalidate_all_projects_detector_cache(instance: Detector) -> None:
     if instance.project_id is None:
         organization_id = instance.config.get("organization_id")
         if organization_id is not None:
-            cache_key = get_all_projects_detector_cache_key(organization_id)
+            cache_key = _get_all_projects_detector_cache_key(organization_id)
             cache.delete(cache_key)
 
 
@@ -154,7 +154,7 @@ def get_detectors_for_event_data(
 
     if options.get("workflow_engine.all_projects_detectors_enabled"):
         organization_id = event_data.event.project.organization_id
-        all_projects_detector = get_all_projects_detector_for_org(organization_id)
+        all_projects_detector = get_all_projects_detector(organization_id)
         if all_projects_detector:
             issue_stream_detectors.append(all_projects_detector)
 

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 class EventDetectors:
     issue_stream_detector: Detector | None = None
     event_detector: Detector | None = None
-    all_project_detector: Detector | None = None
+    all_projects_detector: Detector | None = None
 
     def __post_init__(self) -> None:
         if not self.has_detectors:
@@ -49,7 +49,7 @@ class EventDetectors:
         return (
             self.issue_stream_detector is not None
             or self.event_detector is not None
-            or self.all_project_detector is not None
+            or self.all_projects_detector is not None
         )
 
     @property
@@ -58,11 +58,8 @@ class EventDetectors:
         The preferred detector is the one that should be used for the event,
         if we need to use a singular detector (for example, in logging).
         The class will not initialize if no detectors are found.
-
-        The all_project_detector is deliberately excluded — it has no project,
-        so downstream code that calls detector.linked_project would break.
         """
-        detector = self.event_detector or self.issue_stream_detector
+        detector = self.event_detector or self.issue_stream_detector or self.all_projects_detector
         assert detector is not None, "At least one detector must exist"
         return detector
 
@@ -70,7 +67,7 @@ class EventDetectors:
     def detectors(self) -> set[Detector]:
         return {
             d
-            for d in [self.issue_stream_detector, self.event_detector, self.all_project_detector]
+            for d in [self.issue_stream_detector, self.event_detector, self.all_projects_detector]
             if d is not None
         }
 
@@ -114,7 +111,7 @@ def get_detectors_for_event_data(
     We expect a detector to be passed in for Activity updates.
     """
     issue_stream_detector: Detector | None = None
-    all_project_detector: Detector | None = None
+    all_projects_detector: Detector | None = None
 
     try:
         if _is_issue_stream_detector_enabled(event_data):
@@ -131,7 +128,7 @@ def get_detectors_for_event_data(
     organization = event_data.event.project.organization
     if features.has("organizations:workflow-engine-all-projects-detector", organization):
         try:
-            all_project_detector = Detector.get_all_project_detector_for_org(organization.id)
+            all_projects_detector = Detector.get_all_projects_detector_for_org(organization.id)
         except Detector.DoesNotExist:
             metrics.incr("workflow_engine.detectors.error", tags={"detector_type": "all_projects"})
             logger.exception(
@@ -145,7 +142,7 @@ def get_detectors_for_event_data(
         return EventDetectors(
             issue_stream_detector=issue_stream_detector,
             event_detector=detector,
-            all_project_detector=all_project_detector,
+            all_projects_detector=all_projects_detector,
         )
     except ValueError:
         return None

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -32,21 +32,25 @@ from sentry.workflow_engine.typings.grouptype import IssueStreamGroupType
 logger = logging.getLogger(__name__)
 
 
+_DETECTOR_SENTINEL = object()
+
+
 def get_all_projects_detector_cache_key(organization_id: int) -> str:
     return f"detector:all_projects:{organization_id}"
 
 
-def get_all_projects_detector_for_org(organization_id: int) -> Detector:
+def get_all_projects_detector_for_org(organization_id: int) -> Detector | None:
     cache_key = get_all_projects_detector_cache_key(organization_id)
-    detector = cache.get(cache_key)
-    if detector is None:
-        detector = Detector.objects.get(
-            project__isnull=True,
-            type=IssueStreamGroupType.slug,
-            config__organization_id=organization_id,
-        )
-        cache.set(cache_key, detector, Detector.CACHE_TTL)
-    return detector
+    cached = cache.get(cache_key, default=_DETECTOR_SENTINEL)
+    if cached is not _DETECTOR_SENTINEL:
+        return cached
+    result = Detector.objects.filter(
+        project__isnull=True,
+        type=IssueStreamGroupType.slug,
+        config__organization_id=organization_id,
+    ).first()
+    cache.set(cache_key, result, Detector.CACHE_TTL)
+    return result
 
 
 def invalidate_all_projects_detector_cache(instance: Detector) -> None:
@@ -148,17 +152,11 @@ def get_detectors_for_event_data(
             extra={"project_id": event_data.group.project_id, "group_id": event_data.group.id},
         )
 
-    organization = event_data.event.project.organization
-    try:
-        issue_stream_detectors.append(get_all_projects_detector_for_org(organization.id))
-    except (Detector.DoesNotExist, Detector.MultipleObjectsReturned) as exc:
-        metrics.incr("workflow_engine.detectors.error", tags={"detector_type": "all_projects"})
-        # TODO(Leander): Convert to exception once this detector has been rolled out
-        logger.warning(
-            "Single all projects detector not found for event",
-            extra={"organization_id": organization.id, "group_id": event_data.group.id},
-            exc_info=exc,
-        )
+    if options.get("workflow_engine.all_projects_detectors_enabled"):
+        organization_id = event_data.event.project.organization_id
+        all_projects_detector = get_all_projects_detector_for_org(organization_id)
+        if all_projects_detector:
+            issue_stream_detectors.append(all_projects_detector)
 
     if detector is None and isinstance(event_data.event, GroupEvent):
         detector = _get_detector_for_event(event_data.event)

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -35,6 +35,7 @@ logger = logging.getLogger(__name__)
 class EventDetectors:
     issue_stream_detector: Detector | None = None
     event_detector: Detector | None = None
+    all_project_detector: Detector | None = None
 
     def __post_init__(self) -> None:
         if not self.has_detectors:
@@ -45,7 +46,11 @@ class EventDetectors:
         """
         Returns True if at least one detector exists.
         """
-        return self.issue_stream_detector is not None or self.event_detector is not None
+        return (
+            self.issue_stream_detector is not None
+            or self.event_detector is not None
+            or self.all_project_detector is not None
+        )
 
     @property
     def preferred_detector(self) -> Detector:
@@ -53,6 +58,9 @@ class EventDetectors:
         The preferred detector is the one that should be used for the event,
         if we need to use a singular detector (for example, in logging).
         The class will not initialize if no detectors are found.
+
+        The all_project_detector is deliberately excluded — it has no project,
+        so downstream code that calls detector.linked_project would break.
         """
         detector = self.event_detector or self.issue_stream_detector
         assert detector is not None, "At least one detector must exist"
@@ -60,7 +68,11 @@ class EventDetectors:
 
     @property
     def detectors(self) -> set[Detector]:
-        return {d for d in [self.issue_stream_detector, self.event_detector] if d is not None}
+        return {
+            d
+            for d in [self.issue_stream_detector, self.event_detector, self.all_project_detector]
+            if d is not None
+        }
 
 
 # TODO - Delete this once the issue stream is fully rolled out.
@@ -97,10 +109,12 @@ def get_detectors_for_event_data(
 
     We always return at least the issue stream detector, unless excluded via option or feature flag.
     If the event has an associated detector, we return it too.
+    If an org-scoped all-project detector exists, we include it for workflow lookup.
 
     We expect a detector to be passed in for Activity updates.
     """
     issue_stream_detector: Detector | None = None
+    all_project_detector: Detector | None = None
 
     try:
         if _is_issue_stream_detector_enabled(event_data):
@@ -108,19 +122,31 @@ def get_detectors_for_event_data(
                 event_data.group.project_id
             )
     except Detector.DoesNotExist:
-        metrics.incr("workflow_engine.detectors.error")
+        metrics.incr("workflow_engine.detectors.error", tags={"detector_type": "issue_stream"})
         logger.exception(
             "Issue stream detector not found for event",
-            extra={
-                "project_id": event_data.group.project_id,
-                "group_id": event_data.group.id,
-            },
+            extra={"project_id": event_data.group.project_id, "group_id": event_data.group.id},
         )
+
+    organization = event_data.event.project.organization
+    if features.has("organizations:workflow-engine-all-projects-detector", organization):
+        try:
+            all_project_detector = Detector.get_all_project_detector_for_org(organization.id)
+        except Detector.DoesNotExist:
+            metrics.incr("workflow_engine.detectors.error", tags={"detector_type": "all_projects"})
+            logger.exception(
+                "All projects detector not found for event",
+                extra={"organization_id": organization.id, "group_id": event_data.group.id},
+            )
 
     if detector is None and isinstance(event_data.event, GroupEvent):
         detector = _get_detector_for_event(event_data.event)
     try:
-        return EventDetectors(issue_stream_detector=issue_stream_detector, event_detector=detector)
+        return EventDetectors(
+            issue_stream_detector=issue_stream_detector,
+            event_detector=detector,
+            all_project_detector=all_project_detector,
+        )
     except ValueError:
         return None
 

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from sentry import features, options
 from sentry.grouping.grouptype import ErrorGroupType
@@ -12,6 +12,7 @@ from sentry.models.activity import Activity
 from sentry.models.group import Group
 from sentry.services.eventstore.models import GroupEvent
 from sentry.utils import metrics
+from sentry.utils.cache import cache
 from sentry.utils.tracing import trace
 
 # TODO - remove this import once getsentry can be updated
@@ -31,11 +32,38 @@ from sentry.workflow_engine.typings.grouptype import IssueStreamGroupType
 logger = logging.getLogger(__name__)
 
 
+def get_all_projects_detector_cache_key(organization_id: int) -> str:
+    return f"detector:all_projects:{organization_id}"
+
+
+def get_all_projects_detector_for_org(organization_id: int) -> Detector:
+    cache_key = get_all_projects_detector_cache_key(organization_id)
+    detector = cache.get(cache_key)
+    if detector is None:
+        detector = Detector.objects.get(
+            project__isnull=True,
+            type=IssueStreamGroupType.slug,
+            config__organization_id=organization_id,
+        )
+        cache.set(cache_key, detector, Detector.CACHE_TTL)
+    return detector
+
+
+def invalidate_all_projects_detector_cache(instance: Detector) -> None:
+    if instance.project_id is None:
+        organization_id = instance.config.get("organization_id")
+        if organization_id is not None:
+            cache_key = get_all_projects_detector_cache_key(organization_id)
+            cache.delete(cache_key)
+
+
 @dataclass(frozen=True)
 class EventDetectors:
-    issue_stream_detector: Detector | None = None
+    issue_stream_detectors: list[Detector] = field(default_factory=list)
+    """
+    Assumed to be in priority order, since this is leveraged by preferred_detector.
+    """
     event_detector: Detector | None = None
-    all_projects_detector: Detector | None = None
 
     def __post_init__(self) -> None:
         if not self.has_detectors:
@@ -46,11 +74,7 @@ class EventDetectors:
         """
         Returns True if at least one detector exists.
         """
-        return (
-            self.issue_stream_detector is not None
-            or self.event_detector is not None
-            or self.all_projects_detector is not None
-        )
+        return bool(self.issue_stream_detectors) or self.event_detector is not None
 
     @property
     def preferred_detector(self) -> Detector:
@@ -59,17 +83,16 @@ class EventDetectors:
         if we need to use a singular detector (for example, in logging).
         The class will not initialize if no detectors are found.
         """
-        detector = self.event_detector or self.issue_stream_detector or self.all_projects_detector
+        detector = self.event_detector or next(iter(self.issue_stream_detectors), None)
         assert detector is not None, "At least one detector must exist"
         return detector
 
     @property
     def detectors(self) -> set[Detector]:
-        return {
-            d
-            for d in [self.issue_stream_detector, self.event_detector, self.all_projects_detector]
-            if d is not None
-        }
+        result = set(self.issue_stream_detectors)
+        if self.event_detector is not None:
+            result.add(self.event_detector)
+        return result
 
 
 # TODO - Delete this once the issue stream is fully rolled out.
@@ -110,13 +133,13 @@ def get_detectors_for_event_data(
 
     We expect a detector to be passed in for Activity updates.
     """
-    issue_stream_detector: Detector | None = None
-    all_projects_detector: Detector | None = None
+    # NOTE: Order determines priority: project-scoped first, then fall back to all-projects
+    issue_stream_detectors: list[Detector] = []
 
     try:
         if _is_issue_stream_detector_enabled(event_data):
-            issue_stream_detector = Detector.get_issue_stream_detector_for_project(
-                event_data.group.project_id
+            issue_stream_detectors.append(
+                Detector.get_issue_stream_detector_for_project(event_data.group.project_id)
             )
     except Detector.DoesNotExist:
         metrics.incr("workflow_engine.detectors.error", tags={"detector_type": "issue_stream"})
@@ -126,23 +149,23 @@ def get_detectors_for_event_data(
         )
 
     organization = event_data.event.project.organization
-    if features.has("organizations:workflow-engine-all-projects-detector", organization):
-        try:
-            all_projects_detector = Detector.get_all_projects_detector_for_org(organization.id)
-        except (Detector.DoesNotExist, Detector.MultipleObjectsReturned):
-            metrics.incr("workflow_engine.detectors.error", tags={"detector_type": "all_projects"})
-            logger.exception(
-                "Single all projects detector not found for event",
-                extra={"organization_id": organization.id, "group_id": event_data.group.id},
-            )
+    try:
+        issue_stream_detectors.append(get_all_projects_detector_for_org(organization.id))
+    except (Detector.DoesNotExist, Detector.MultipleObjectsReturned) as exc:
+        metrics.incr("workflow_engine.detectors.error", tags={"detector_type": "all_projects"})
+        # TODO(Leander): Convert to exception once this detector has been rolled out
+        logger.warning(
+            "Single all projects detector not found for event",
+            extra={"organization_id": organization.id, "group_id": event_data.group.id},
+            exc_info=exc,
+        )
 
     if detector is None and isinstance(event_data.event, GroupEvent):
         detector = _get_detector_for_event(event_data.event)
     try:
         return EventDetectors(
-            issue_stream_detector=issue_stream_detector,
+            issue_stream_detectors=issue_stream_detectors,
             event_detector=detector,
-            all_projects_detector=all_projects_detector,
         )
     except ValueError:
         return None

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -129,10 +129,10 @@ def get_detectors_for_event_data(
     if features.has("organizations:workflow-engine-all-projects-detector", organization):
         try:
             all_projects_detector = Detector.get_all_projects_detector_for_org(organization.id)
-        except Detector.DoesNotExist:
+        except (Detector.DoesNotExist, Detector.MultipleObjectsReturned):
             metrics.incr("workflow_engine.detectors.error", tags={"detector_type": "all_projects"})
             logger.exception(
-                "All projects detector not found for event",
+                "Single all projects detector not found for event",
                 extra={"organization_id": organization.id, "group_id": event_data.group.id},
             )
 

--- a/src/sentry/workflow_engine/receivers/detector.py
+++ b/src/sentry/workflow_engine/receivers/detector.py
@@ -33,7 +33,7 @@ def enforce_config_schema_signal(sender: type[Detector], instance: Detector, **k
 @receiver(post_save, sender=Detector)
 @receiver(pre_delete, sender=Detector)
 def invalidate_detector_cache(sender: type[Detector], instance: Detector, **kwargs: Any) -> None:
-    if kwargs.get("created") or not instance.id:
+    if not instance.id:
         return
 
     data_sources = list(instance.data_sources.values_list("source_id", "type"))

--- a/src/sentry/workflow_engine/receivers/detector.py
+++ b/src/sentry/workflow_engine/receivers/detector.py
@@ -4,19 +4,10 @@ from django.db import router, transaction
 from django.db.models.signals import post_save, pre_delete, pre_save
 from django.dispatch import receiver
 
-from sentry.utils.cache import cache
 from sentry.workflow_engine.caches.detector import invalidate_detectors_by_data_source_cache
 from sentry.workflow_engine.caches.workflow import invalidate_processing_workflows
 from sentry.workflow_engine.models import Detector
-from sentry.workflow_engine.models.detector import get_all_projects_detector_cache_key
-
-
-def _invalidate_all_projects_detector_cache(instance: Detector) -> None:
-    if instance.project_id is None:
-        organization_id = instance.config.get("organization_id")
-        if organization_id is not None:
-            cache_key = get_all_projects_detector_cache_key(organization_id)
-            cache.delete(cache_key)
+from sentry.workflow_engine.processors.detector import invalidate_all_projects_detector_cache
 
 
 @receiver(post_save, sender=Detector)
@@ -29,7 +20,6 @@ def invalidate_processing_workflows_cache(
         return
 
     invalidate_processing_workflows(instance.id)
-    _invalidate_all_projects_detector_cache(instance)
 
 
 @receiver(pre_save, sender=Detector)
@@ -46,11 +36,10 @@ def invalidate_detector_cache(sender: type[Detector], instance: Detector, **kwar
     if kwargs.get("created") or not instance.id:
         return
 
-    _invalidate_all_projects_detector_cache(instance)
-
     data_sources = list(instance.data_sources.values_list("source_id", "type"))
 
     def invalidate_cache() -> None:
+        invalidate_all_projects_detector_cache(instance)
         for source_id, source_type in data_sources:
             invalidate_detectors_by_data_source_cache(source_id, source_type)
 

--- a/src/sentry/workflow_engine/receivers/detector.py
+++ b/src/sentry/workflow_engine/receivers/detector.py
@@ -4,9 +4,19 @@ from django.db import router, transaction
 from django.db.models.signals import post_save, pre_delete, pre_save
 from django.dispatch import receiver
 
+from sentry.utils.cache import cache
 from sentry.workflow_engine.caches.detector import invalidate_detectors_by_data_source_cache
 from sentry.workflow_engine.caches.workflow import invalidate_processing_workflows
 from sentry.workflow_engine.models import Detector
+from sentry.workflow_engine.models.detector import get_all_projects_detector_cache_key
+
+
+def _invalidate_all_projects_detector_cache(instance: Detector) -> None:
+    if instance.project_id is None:
+        organization_id = instance.config.get("organization_id")
+        if organization_id is not None:
+            cache_key = get_all_projects_detector_cache_key(organization_id)
+            cache.delete(cache_key)
 
 
 @receiver(post_save, sender=Detector)
@@ -19,6 +29,7 @@ def invalidate_processing_workflows_cache(
         return
 
     invalidate_processing_workflows(instance.id)
+    _invalidate_all_projects_detector_cache(instance)
 
 
 @receiver(pre_save, sender=Detector)
@@ -34,6 +45,8 @@ def enforce_config_schema_signal(sender: type[Detector], instance: Detector, **k
 def invalidate_detector_cache(sender: type[Detector], instance: Detector, **kwargs: Any) -> None:
     if kwargs.get("created") or not instance.id:
         return
+
+    _invalidate_all_projects_detector_cache(instance)
 
     data_sources = list(instance.data_sources.values_list("source_id", "type"))
 

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -43,6 +43,7 @@ T = TypeVar("T")
 
 ERROR_DETECTOR_NAME = "Error Monitor"
 ISSUE_STREAM_DETECTOR_NAME = "Issue Stream"
+ALL_PROJECTS_DETECTOR_NAME = "All Projects"
 
 ActionId: TypeAlias = int
 DataConditionGroupId: TypeAlias = int

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -43,7 +43,7 @@ T = TypeVar("T")
 
 ERROR_DETECTOR_NAME = "Error Monitor"
 ISSUE_STREAM_DETECTOR_NAME = "Issue Stream"
-ALL_PROJECTS_DETECTOR_NAME = "All Projects"
+ALL_PROJECTS_DETECTOR_NAME = "Issue Stream: All Projects"
 
 ActionId: TypeAlias = int
 DataConditionGroupId: TypeAlias = int

--- a/src/sentry/workflow_engine/typings/grouptype.py
+++ b/src/sentry/workflow_engine/typings/grouptype.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 
 from sentry.issues.grouptype import GroupCategory, GroupType
+from sentry.workflow_engine.types import DetectorSettings
 
 
 # hidden group type, used for issue stream detector
@@ -17,3 +18,11 @@ class IssueStreamGroupType(GroupType):
     enable_status_change_workflow_notifications = False
     enable_workflow_notifications = False
     enable_user_status_and_priority_changes = False
+    detector_settings = DetectorSettings(
+        config_schema={
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {"organization_id": {"type": "integer"}},
+            "additionalProperties": False,
+        },
+    )

--- a/tests/sentry/workflow_engine/defaults/test_detectors.py
+++ b/tests/sentry/workflow_engine/defaults/test_detectors.py
@@ -9,6 +9,7 @@ from sentry.workflow_engine.defaults.detectors import (
     UnableToAcquireLockApiError,
     ensure_default_all_projects_detector,
     ensure_default_detectors,
+    ensure_default_organization_detectors,
 )
 from sentry.workflow_engine.models import Detector
 from sentry.workflow_engine.types import (
@@ -58,7 +59,7 @@ class TestEnsureDefaultDetectors(TestCase):
     def test_ensure_default_detectors__creates_all_projects_detector_when_flag_on(self) -> None:
         project = self.create_project()
         with self.feature("organizations:workflow-engine-all-projects-detector"):
-            ensure_default_detectors(project)
+            ensure_default_organization_detectors(project.organization)
 
         all_projects = Detector.objects.filter(
             type=IssueStreamGroupType.slug,

--- a/tests/sentry/workflow_engine/defaults/test_detectors.py
+++ b/tests/sentry/workflow_engine/defaults/test_detectors.py
@@ -7,10 +7,15 @@ from sentry.testutils.cases import TestCase
 from sentry.utils.locking import UnableToAcquireLock
 from sentry.workflow_engine.defaults.detectors import (
     UnableToAcquireLockApiError,
+    ensure_default_all_projects_detector,
     ensure_default_detectors,
 )
 from sentry.workflow_engine.models import Detector
-from sentry.workflow_engine.types import ERROR_DETECTOR_NAME, ISSUE_STREAM_DETECTOR_NAME
+from sentry.workflow_engine.types import (
+    ALL_PROJECTS_DETECTOR_NAME,
+    ERROR_DETECTOR_NAME,
+    ISSUE_STREAM_DETECTOR_NAME,
+)
 from sentry.workflow_engine.typings.grouptype import IssueStreamGroupType
 
 
@@ -49,3 +54,65 @@ class TestEnsureDefaultDetectors(TestCase):
             with pytest.raises(UnableToAcquireLockApiError):
                 project = self.create_project()
                 ensure_default_detectors(project)
+
+    def test_ensure_default_detectors__creates_all_projects_detector_when_flag_on(self) -> None:
+        project = self.create_project()
+        with self.feature("organizations:workflow-engine-all-projects-detector"):
+            ensure_default_detectors(project)
+
+        all_projects = Detector.objects.filter(
+            type=IssueStreamGroupType.slug,
+            project__isnull=True,
+            config__organization_id=project.organization_id,
+        )
+        assert all_projects.count() == 1
+
+    def test_ensure_default_detectors__no_all_projects_detector_when_flag_off(self) -> None:
+        project = self.create_project()
+        ensure_default_detectors(project)
+
+        assert not Detector.objects.filter(
+            type=IssueStreamGroupType.slug,
+            project__isnull=True,
+        ).exists()
+
+
+class TestEnsureDefaultAllProjectsDetector(TestCase):
+    def test_creates_detector(self) -> None:
+        org = self.create_organization()
+        detector = ensure_default_all_projects_detector(org.id)
+
+        assert detector.type == IssueStreamGroupType.slug
+        assert detector.project is None
+        assert detector.config == {"organization_id": org.id}
+        assert detector.name == ALL_PROJECTS_DETECTOR_NAME
+        assert detector.enabled is True
+
+    def test_idempotent(self) -> None:
+        org = self.create_organization()
+        first = ensure_default_all_projects_detector(org.id)
+        second = ensure_default_all_projects_detector(org.id)
+        assert first.id == second.id
+        assert (
+            Detector.objects.filter(
+                type=IssueStreamGroupType.slug,
+                project__isnull=True,
+                config__organization_id=org.id,
+            ).count()
+            == 1
+        )
+
+    def test_separate_orgs(self) -> None:
+        org1 = self.create_organization()
+        org2 = self.create_organization()
+        d1 = ensure_default_all_projects_detector(org1.id)
+        d2 = ensure_default_all_projects_detector(org2.id)
+        assert d1.id != d2.id
+        assert d1.config["organization_id"] == org1.id
+        assert d2.config["organization_id"] == org2.id
+
+    def test_lock_failure(self) -> None:
+        with patch("sentry.workflow_engine.defaults.detectors.locks.get") as mock_lock:
+            mock_lock.return_value.blocking_acquire.side_effect = UnableToAcquireLock
+            with pytest.raises(UnableToAcquireLockApiError):
+                ensure_default_all_projects_detector(self.organization.id)

--- a/tests/sentry/workflow_engine/defaults/test_detectors.py
+++ b/tests/sentry/workflow_engine/defaults/test_detectors.py
@@ -56,25 +56,23 @@ class TestEnsureDefaultDetectors(TestCase):
                 project = self.create_project()
                 ensure_default_detectors(project)
 
-    def test_ensure_default_detectors__creates_all_projects_detector_when_flag_on(self) -> None:
-        project = self.create_project()
-        with self.feature("organizations:workflow-engine-all-projects-detector"):
-            ensure_default_organization_detectors(project.organization)
+    def test_ensure_default_organization_detectors_creates_all_projects(self) -> None:
+        ensure_default_organization_detectors(self.organization)
 
         all_projects = Detector.objects.filter(
             type=IssueStreamGroupType.slug,
+            name=ALL_PROJECTS_DETECTOR_NAME,
             project__isnull=True,
-            config__organization_id=project.organization_id,
+            config__organization_id=self.organization.id,
         )
         assert all_projects.count() == 1
 
-    def test_ensure_default_detectors__no_all_projects_detector_when_flag_off(self) -> None:
+    def test_ensure_default_detectors_does_not_create_all_projects(self) -> None:
         project = self.create_project()
         ensure_default_detectors(project)
 
         assert not Detector.objects.filter(
-            type=IssueStreamGroupType.slug,
-            project__isnull=True,
+            type=IssueStreamGroupType.slug, project__isnull=True
         ).exists()
 
 

--- a/tests/sentry/workflow_engine/models/test_detector.py
+++ b/tests/sentry/workflow_engine/models/test_detector.py
@@ -4,6 +4,7 @@ import pytest
 
 from sentry.constants import ObjectStatus
 from sentry.grouping.grouptype import ErrorGroupType
+from sentry.workflow_engine.defaults.detectors import ensure_default_all_projects_detector
 from sentry.workflow_engine.models import Detector
 from sentry.workflow_engine.models.detector import get_detector_project_type_cache_key
 from sentry.workflow_engine.types import DetectorPriorityLevel
@@ -26,6 +27,22 @@ class DetectorTest(BaseWorkflowTest):
         self.detector.status = ObjectStatus.DELETION_IN_PROGRESS
         self.detector.save()
         assert not Detector.objects.filter(id=self.detector.id).exists()
+
+    def test_detectors_by_organization(self) -> None:
+        project_detector = self.create_detector(project=self.project)
+        all_projects_detector = ensure_default_all_projects_detector(self.organization.id)
+        result = list(Detector.objects.by_organization(self.organization.id))
+        assert project_detector in result
+        assert all_projects_detector in result
+
+    def test_excludes_other_organizations(self) -> None:
+        other_org = self.create_organization()
+        other_project = self.create_project(organization=other_org)
+        other_project_detector = self.create_detector(project=other_project)
+        other_all_projects_detector = ensure_default_all_projects_detector(other_org.id)
+        result = list(Detector.objects.by_organization(self.organization.id))
+        assert other_project_detector not in result
+        assert other_all_projects_detector not in result
 
     def test_get_conditions__cached(self) -> None:
         self.detector.workflow_condition_group = self.create_data_condition_group()

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -1012,33 +1012,31 @@ class TestEventDetectorsAllProject(TestCase):
         self.issue_stream_detector = self.create_detector(
             project=self.project, type=IssueStreamGroupType.slug
         )
+        self.all_projects_detector = ensure_default_all_projects_detector(self.organization.id)
 
-        self.all_project_detector = ensure_default_all_projects_detector(self.organization.id)
-
-    def test_preferred_detector_excludes_all_project(self) -> None:
+    def test_preferred_detector_prefers_project_scoped(self) -> None:
         ed = EventDetectors(
             issue_stream_detector=self.issue_stream_detector,
-            all_project_detector=self.all_project_detector,
+            all_projects_detector=self.all_projects_detector,
         )
         assert ed.preferred_detector == self.issue_stream_detector
 
-    def test_detectors_includes_all_project(self) -> None:
+    def test_detectors_includes_all_projects(self) -> None:
         ed = EventDetectors(
             issue_stream_detector=self.issue_stream_detector,
-            all_project_detector=self.all_project_detector,
+            all_projects_detector=self.all_projects_detector,
         )
-        assert self.all_project_detector in ed.detectors
+        assert self.all_projects_detector in ed.detectors
         assert self.issue_stream_detector in ed.detectors
 
-    def test_only_all_project_detector_raises_on_preferred(self) -> None:
-        ed = EventDetectors(all_project_detector=self.all_project_detector)
-        with pytest.raises(AssertionError, match="At least one detector must exist"):
-            ed.preferred_detector
+    def test_only_all_projects_detector_falls_back_to_preferred(self) -> None:
+        ed = EventDetectors(all_projects_detector=self.all_projects_detector)
+        assert ed.preferred_detector == self.all_projects_detector
 
-    def test_only_all_project_has_detectors(self) -> None:
-        ed = EventDetectors(all_project_detector=self.all_project_detector)
+    def test_only_all_projects_has_detectors(self) -> None:
+        ed = EventDetectors(all_projects_detector=self.all_projects_detector)
         assert ed.has_detectors is True
-        assert ed.detectors == {self.all_project_detector}
+        assert ed.detectors == {self.all_projects_detector}
 
 
 class TestGetDetectorsForEventAllProject(TestCase):
@@ -1052,35 +1050,35 @@ class TestGetDetectorsForEventAllProject(TestCase):
         )
         from sentry.workflow_engine.defaults.detectors import ensure_default_all_projects_detector
 
-        self.all_project_detector = ensure_default_all_projects_detector(
+        self.all_projects_detector = ensure_default_all_projects_detector(
             self.project.organization_id
         )
         self.event = self.store_event(project_id=self.project.id, data={})
         self.group_event = GroupEvent.from_event(self.event, self.group)
 
-    def test_includes_all_project_detector_with_flag(self) -> None:
+    def test_includes_all_projects_detector_with_flag(self) -> None:
         event_data = WorkflowEventData(event=self.group_event, group=self.group)
         with self.feature("organizations:workflow-engine-all-projects-detector"):
             result = get_detectors_for_event_data(event_data)
         assert result is not None
-        assert self.all_project_detector in result.detectors
-        assert result.all_project_detector == self.all_project_detector
+        assert self.all_projects_detector in result.detectors
+        assert result.all_projects_detector == self.all_projects_detector
         assert result.preferred_detector == self.error_detector
 
-    def test_excludes_all_project_detector_without_flag(self) -> None:
+    def test_excludes_all_projects_detector_without_flag(self) -> None:
         event_data = WorkflowEventData(event=self.group_event, group=self.group)
         result = get_detectors_for_event_data(event_data)
         assert result is not None
-        assert result.all_project_detector is None
-        assert self.all_project_detector not in result.detectors
+        assert result.all_projects_detector is None
+        assert self.all_projects_detector not in result.detectors
 
-    def test_no_all_project_detector_exists(self) -> None:
-        self.all_project_detector.delete()
+    def test_no_all_projects_detector_exists(self) -> None:
+        self.all_projects_detector.delete()
         event_data = WorkflowEventData(event=self.group_event, group=self.group)
         with self.feature("organizations:workflow-engine-all-projects-detector"):
             result = get_detectors_for_event_data(event_data)
         assert result is not None
-        assert result.all_project_detector is None
+        assert result.all_projects_detector is None
         assert result.preferred_detector == self.error_detector
 
 

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -32,6 +32,7 @@ from sentry.workflow_engine.processors.detector import (
     EventDetectors,
     associate_new_group_with_detector,
     ensure_association_with_detector,
+    get_all_projects_detector,
     get_detectors_for_event_data,
     get_preferred_detector,
     process_detectors,
@@ -1036,6 +1037,21 @@ class TestEventDetectorsAllProject(TestCase):
         ed = EventDetectors(issue_stream_detectors=[self.all_projects_detector])
         assert ed.has_detectors is True
         assert ed.detectors == {self.all_projects_detector}
+
+    def test_cached_miss_is_invalidated_when_detector_is_created(self) -> None:
+        self.all_projects_detector.delete()
+        cache.clear()
+        assert get_all_projects_detector(self.organization.id) is None
+
+        with self.captureOnCommitCallbacks(execute=True):
+            detector = Detector.objects.create(
+                project=None,
+                type=IssueStreamGroupType.slug,
+                config={"organization_id": self.organization.id},
+                name="All Projects Detector",
+            )
+
+        assert get_all_projects_detector(self.organization.id) == detector
 
 
 class TestGetDetectorsForEventAllProject(TestCase):

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -22,11 +22,13 @@ from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.types.activity import ActivityType
 from sentry.types.group import PriorityLevel
 from sentry.utils.cache import cache
+from sentry.workflow_engine.defaults.detectors import ensure_default_all_projects_detector
 from sentry.workflow_engine.handlers.detector import DetectorStateData
 from sentry.workflow_engine.handlers.detector.stateful import get_redis_client
 from sentry.workflow_engine.models import DataPacket, Detector, DetectorState
 from sentry.workflow_engine.models.detector_group import DetectorGroup
 from sentry.workflow_engine.processors.detector import (
+    EventDetectors,
     associate_new_group_with_detector,
     ensure_association_with_detector,
     get_detectors_for_event_data,
@@ -1003,6 +1005,83 @@ class TestGetDetectorsForEvent(TestCase):
         event_data = WorkflowEventData(event=self.group_event, group=self.group)
         result = get_detectors_for_event_data(event_data)
         assert result is None
+
+
+class TestEventDetectorsAllProject(TestCase):
+    def setUp(self) -> None:
+        self.issue_stream_detector = self.create_detector(
+            project=self.project, type=IssueStreamGroupType.slug
+        )
+
+        self.all_project_detector = ensure_default_all_projects_detector(self.organization.id)
+
+    def test_preferred_detector_excludes_all_project(self) -> None:
+        ed = EventDetectors(
+            issue_stream_detector=self.issue_stream_detector,
+            all_project_detector=self.all_project_detector,
+        )
+        assert ed.preferred_detector == self.issue_stream_detector
+
+    def test_detectors_includes_all_project(self) -> None:
+        ed = EventDetectors(
+            issue_stream_detector=self.issue_stream_detector,
+            all_project_detector=self.all_project_detector,
+        )
+        assert self.all_project_detector in ed.detectors
+        assert self.issue_stream_detector in ed.detectors
+
+    def test_only_all_project_detector_raises_on_preferred(self) -> None:
+        ed = EventDetectors(all_project_detector=self.all_project_detector)
+        with pytest.raises(Detector.DoesNotExist):
+            ed.preferred_detector
+
+    def test_only_all_project_has_detectors(self) -> None:
+        ed = EventDetectors(all_project_detector=self.all_project_detector)
+        assert ed.has_detectors is True
+        assert ed.detectors == {self.all_project_detector}
+
+
+class TestGetDetectorsForEventAllProject(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.project = self.create_project()
+        self.group = self.create_group(project=self.project, type=ErrorGroupType.type_id)
+        self.error_detector = self.create_detector(project=self.project, type=ErrorGroupType.slug)
+        self.issue_stream_detector = self.create_detector(
+            project=self.project, type=IssueStreamGroupType.slug
+        )
+        from sentry.workflow_engine.defaults.detectors import ensure_default_all_projects_detector
+
+        self.all_project_detector = ensure_default_all_projects_detector(
+            self.project.organization_id
+        )
+        self.event = self.store_event(project_id=self.project.id, data={})
+        self.group_event = GroupEvent.from_event(self.event, self.group)
+
+    def test_includes_all_project_detector_with_flag(self) -> None:
+        event_data = WorkflowEventData(event=self.group_event, group=self.group)
+        with self.feature("organizations:workflow-engine-all-projects-detector"):
+            result = get_detectors_for_event_data(event_data)
+        assert result is not None
+        assert self.all_project_detector in result.detectors
+        assert result.all_project_detector == self.all_project_detector
+        assert result.preferred_detector == self.error_detector
+
+    def test_excludes_all_project_detector_without_flag(self) -> None:
+        event_data = WorkflowEventData(event=self.group_event, group=self.group)
+        result = get_detectors_for_event_data(event_data)
+        assert result is not None
+        assert result.all_project_detector is None
+        assert self.all_project_detector not in result.detectors
+
+    def test_no_all_project_detector_exists(self) -> None:
+        self.all_project_detector.delete()
+        event_data = WorkflowEventData(event=self.group_event, group=self.group)
+        with self.feature("organizations:workflow-engine-all-projects-detector"):
+            result = get_detectors_for_event_data(event_data)
+        assert result is not None
+        assert result.all_project_detector is None
+        assert result.preferred_detector == self.error_detector
 
 
 class TestGetPreferredDetector(TestCase):

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -1032,7 +1032,7 @@ class TestEventDetectorsAllProject(TestCase):
 
     def test_only_all_project_detector_raises_on_preferred(self) -> None:
         ed = EventDetectors(all_project_detector=self.all_project_detector)
-        with pytest.raises(Detector.DoesNotExist):
+        with pytest.raises(AssertionError, match="At least one detector must exist"):
             ed.preferred_detector
 
     def test_only_all_project_has_detectors(self) -> None:

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -1016,25 +1016,23 @@ class TestEventDetectorsAllProject(TestCase):
 
     def test_preferred_detector_prefers_project_scoped(self) -> None:
         ed = EventDetectors(
-            issue_stream_detector=self.issue_stream_detector,
-            all_projects_detector=self.all_projects_detector,
+            issue_stream_detectors=[self.issue_stream_detector, self.all_projects_detector],
         )
         assert ed.preferred_detector == self.issue_stream_detector
 
     def test_detectors_includes_all_projects(self) -> None:
         ed = EventDetectors(
-            issue_stream_detector=self.issue_stream_detector,
-            all_projects_detector=self.all_projects_detector,
+            issue_stream_detectors=[self.issue_stream_detector, self.all_projects_detector],
         )
         assert self.all_projects_detector in ed.detectors
         assert self.issue_stream_detector in ed.detectors
 
     def test_only_all_projects_detector_falls_back_to_preferred(self) -> None:
-        ed = EventDetectors(all_projects_detector=self.all_projects_detector)
+        ed = EventDetectors(issue_stream_detectors=[self.all_projects_detector])
         assert ed.preferred_detector == self.all_projects_detector
 
     def test_only_all_projects_has_detectors(self) -> None:
-        ed = EventDetectors(all_projects_detector=self.all_projects_detector)
+        ed = EventDetectors(issue_stream_detectors=[self.all_projects_detector])
         assert ed.has_detectors is True
         assert ed.detectors == {self.all_projects_detector}
 
@@ -1056,29 +1054,19 @@ class TestGetDetectorsForEventAllProject(TestCase):
         self.event = self.store_event(project_id=self.project.id, data={})
         self.group_event = GroupEvent.from_event(self.event, self.group)
 
-    def test_includes_all_projects_detector_with_flag(self) -> None:
-        event_data = WorkflowEventData(event=self.group_event, group=self.group)
-        with self.feature("organizations:workflow-engine-all-projects-detector"):
-            result = get_detectors_for_event_data(event_data)
-        assert result is not None
-        assert self.all_projects_detector in result.detectors
-        assert result.all_projects_detector == self.all_projects_detector
-        assert result.preferred_detector == self.error_detector
-
-    def test_excludes_all_projects_detector_without_flag(self) -> None:
+    def test_includes_all_projects_detector(self) -> None:
         event_data = WorkflowEventData(event=self.group_event, group=self.group)
         result = get_detectors_for_event_data(event_data)
         assert result is not None
-        assert result.all_projects_detector is None
-        assert self.all_projects_detector not in result.detectors
+        assert self.all_projects_detector in result.detectors
+        assert result.preferred_detector == self.error_detector
 
     def test_no_all_projects_detector_exists(self) -> None:
         self.all_projects_detector.delete()
         event_data = WorkflowEventData(event=self.group_event, group=self.group)
-        with self.feature("organizations:workflow-engine-all-projects-detector"):
-            result = get_detectors_for_event_data(event_data)
+        result = get_detectors_for_event_data(event_data)
         assert result is not None
-        assert result.all_projects_detector is None
+        assert self.all_projects_detector not in result.detectors
         assert result.preferred_detector == self.error_detector
 
 

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -18,6 +18,7 @@ from sentry.models.group import GroupStatus
 from sentry.services.eventstore.models import GroupEvent
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.types.activity import ActivityType
 from sentry.types.group import PriorityLevel
@@ -1054,14 +1055,23 @@ class TestGetDetectorsForEventAllProject(TestCase):
         self.event = self.store_event(project_id=self.project.id, data={})
         self.group_event = GroupEvent.from_event(self.event, self.group)
 
-    def test_includes_all_projects_detector(self) -> None:
+    def test_omits_all_projects_detector_by_default(self) -> None:
+        event_data = WorkflowEventData(event=self.group_event, group=self.group)
+        result = get_detectors_for_event_data(event_data)
+        assert result is not None
+        assert self.all_projects_detector not in result.detectors
+        assert result.preferred_detector == self.error_detector
+
+    @override_options({"workflow_engine.all_projects_detectors_enabled": True})
+    def test_includes_all_projects_detector_with_option(self) -> None:
         event_data = WorkflowEventData(event=self.group_event, group=self.group)
         result = get_detectors_for_event_data(event_data)
         assert result is not None
         assert self.all_projects_detector in result.detectors
         assert result.preferred_detector == self.error_detector
 
-    def test_no_all_projects_detector_exists(self) -> None:
+    @override_options({"workflow_engine.all_projects_detectors_enabled": True})
+    def test_missing_all_projects_detector_no_effect(self) -> None:
         self.all_projects_detector.delete()
         event_data = WorkflowEventData(event=self.group_event, group=self.group)
         result = get_detectors_for_event_data(event_data)

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -377,7 +377,9 @@ class TestProcessWorkflows(BaseWorkflowTest):
 
         process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
 
-        mock_incr.assert_any_call("workflow_engine.detectors.error")
+        mock_incr.assert_any_call(
+            "workflow_engine.detectors.error", tags={"detector_type": "issue_stream"}
+        )
         mock_logger.exception.assert_called_once_with(
             "Issue stream detector not found for event",
             extra={
@@ -409,7 +411,9 @@ class TestProcessWorkflows(BaseWorkflowTest):
         self.issue_stream_detector.delete()
 
         process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
-        mock_incr.assert_called_with("workflow_engine.detectors.error")  # called twice
+        mock_incr.assert_any_call(
+            "workflow_engine.detectors.error", tags={"detector_type": "issue_stream"}
+        )
         mock_logger.exception.assert_called()  # called twice
 
     @patch("sentry.utils.metrics.incr")

--- a/tests/sentry/workflow_engine/receivers/test_detector.py
+++ b/tests/sentry/workflow_engine/receivers/test_detector.py
@@ -3,11 +3,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 from jsonschema import ValidationError
 
-from sentry.grouping.grouptype import ErrorGroupType
 from sentry.incidents.grouptype import MetricIssue
 from sentry.testutils.cases import TestCase
 from sentry.workflow_engine.models.detector import Detector
 from sentry.workflow_engine.processors.data_source import bulk_fetch_enabled_detectors
+from sentry.workflow_engine.typings.grouptype import IssueStreamGroupType
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 
@@ -25,22 +25,31 @@ class DetectorSignalCacheInvalidationTests(TestCase):
         self.dw = self.create_detector_workflow(detector=self.detector, workflow=self.workflow)
 
     @patch("sentry.workflow_engine.receivers.detector.invalidate_processing_workflows")
-    def test_cache_invalidate__create_detector(self, mock_invalidate: MagicMock) -> None:
+    @patch("sentry.workflow_engine.receivers.detector.invalidate_all_projects_detector_cache")
+    def test_cache_invalidate__create_detector(
+        self, mock_all_projects_invalidate: MagicMock, mock_workflows_invalidate: MagicMock
+    ) -> None:
         detector = Detector.objects.create(
-            project=self.project, type=ErrorGroupType.slug, config={}
+            project=None,
+            type=IssueStreamGroupType.slug,
+            config={"organization_id": self.organization.id},
         )
 
-        # new detectors have nothing to invalidate
-        mock_invalidate.assert_not_called()
+        mock_all_projects_invalidate.assert_called_once_with(detector)
+        mock_workflows_invalidate.assert_not_called()
         assert detector
 
     @patch("sentry.workflow_engine.receivers.detector.invalidate_processing_workflows")
-    def test_cache_invalidate__modify_detector(self, mock_invalidate: MagicMock) -> None:
+    @patch("sentry.workflow_engine.receivers.detector.invalidate_all_projects_detector_cache")
+    def test_cache_invalidate__modify_detector(
+        self, mock_all_projects_invalidate: MagicMock, mock_workflows_invalidate: MagicMock
+    ) -> None:
         self.detector.enabled = False
         self.detector.save()
 
         # Ensure the modified detector clears the workflow cache
-        mock_invalidate.assert_called_with(self.detector.id)
+        mock_all_projects_invalidate.assert_called_once_with(self.detector)
+        mock_workflows_invalidate.assert_called_with(self.detector.id)
 
 
 class TestDetectorCacheInvalidationSignals(BaseWorkflowTest):


### PR DESCRIPTION
Extends the current issue stream detector to support all projects if it has an `organization_id` in its config + no `Project` association.

These rows don't exist yet, but we'll migrate users to have them. For example, Acme, with frontend + backend project:

- Issue Stream for `backend`: Project -> Backend, Config -> null
- Issue Stream for `frontend`: Project -> Backend, Config -> null
- All Projects for Acme : Project -> Null, Config -> {"organization_id": ... }

So each organization receives one Issue Stream per project, and one All Projects for the organization.