### PR TITLE
feat(coding-agents): Record the PR number on coding-agent results

### DIFF
--- a/src/sentry/integrations/cursor/webhooks/handler.py
+++ b/src/sentry/integrations/cursor/webhooks/handler.py
@@ -23,7 +23,7 @@ from sentry.api.utils import to_valid_int_id
 from sentry.integrations.cursor.integration import CursorAgentIntegration
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.utils.webhook_viewer_context import webhook_viewer_context
-from sentry.models.pullrequest import PullRequestAttributionSignalType
+from sentry.models.pullrequest import PullRequestAttributionSignalType, parse_pull_request_url
 from sentry.pr_metrics.attribution import attribute_delegated_agent_pull_request
 from sentry.seer.autofix.coding_agent_handoffs import sync_coding_agent_status
 from sentry.seer.autofix.constants import CodingAgentStatus
@@ -219,18 +219,28 @@ class CursorWebhookEndpoint(Endpoint):
             )
             return
 
-        if pr_url and not self._validate_pr_url(pr_url, repo_full_name):
+        # Cursor reports the repo separately from the PR URL, so a URL naming a different
+        # repo would attribute someone else's PR to this agent.
+        parsed_pr = parse_pull_request_url(pr_url) if pr_url else None
+        if parsed_pr is not None and (
+            parsed_pr.host != "github.com" or parsed_pr.repo_full_name != repo_full_name
+        ):
+            parsed_pr = None
+        if pr_url and parsed_pr is None:
             logger.warning(
                 "cursor_webhook.invalid_pr_url",
                 extra={"agent_id": agent_id, "pr_url": pr_url},
             )
             pr_url = None
 
+        # Only a completed agent has a result to point at.
+        is_completed = status == CodingAgentStatus.COMPLETED
         result = CodingAgentResult(
             repo_full_name=repo_full_name,
             repo_provider=repo_provider,
             description=summary or f"Agent {status.lower()}",
-            pr_url=pr_url if status == CodingAgentStatus.COMPLETED else None,
+            pr_number=parsed_pr.number if parsed_pr and is_completed else None,
+            pr_url=pr_url if is_completed else None,
             branch_name=branch_name,
         )
 
@@ -242,7 +252,7 @@ class CursorWebhookEndpoint(Endpoint):
             result=result,
         )
 
-        if sync_result.known_to_seer and status == CodingAgentStatus.COMPLETED and pr_url:
+        if sync_result.known_to_seer and is_completed and pr_url:
             try:
                 attribute_delegated_agent_pull_request(
                     organization_id=self.organization_id,
@@ -261,7 +271,7 @@ class CursorWebhookEndpoint(Endpoint):
                     "cursor_webhook.pr_attribution_failed",
                     extra={"agent_id": agent_id, "pr_url": pr_url},
                 )
-        elif status == CodingAgentStatus.COMPLETED:
+        elif is_completed:
             # A completed agent that we did not attribute is otherwise invisible: the
             # webhook arrived and the agent finished, but one of the remaining gates
             # dropped it silently, leaving no SEER_DELEGATED_CURSOR row and no trace of
@@ -276,7 +286,3 @@ class CursorWebhookEndpoint(Endpoint):
                     "has_pr_url": bool(pr_url),
                 },
             )
-
-    def _validate_pr_url(self, pr_url: str, repo_full_name: str) -> bool:
-        """Validates that the URL points to the expected repo."""
-        return pr_url.startswith(f"https://github.com/{repo_full_name}/pull/")

--- a/src/sentry/seer/agent/client_models.py
+++ b/src/sentry/seer/agent/client_models.py
@@ -186,11 +186,17 @@ class PendingUserInput(BaseModel):
 
 
 class CodingAgentResult(BaseModel):
-    """Result from a coding agent."""
+    """Result from a coding agent.
+
+    ``pr_url`` points at a pull request when ``pr_number`` is set and at a pushed branch
+    otherwise, except on results recorded before Seer reported the number -- so a missing
+    number does not by itself mean the URL is a branch.
+    """
 
     description: str
     repo_provider: str
     repo_full_name: str
+    pr_number: int | None = None
     pr_url: str | None = None
 
     class Config:

--- a/src/sentry/seer/autofix/coding_agent.py
+++ b/src/sentry/seer/autofix/coding_agent.py
@@ -4,7 +4,7 @@ import logging
 import re
 import secrets
 import string
-from typing import Any
+from typing import Any, NamedTuple
 
 from rest_framework.exceptions import NotFound, ValidationError
 
@@ -21,7 +21,7 @@ from sentry.integrations.coding_agent.utils import get_coding_agent_providers
 from sentry.integrations.github_copilot.client import GithubCopilotAgentClient
 from sentry.integrations.services.github_copilot_identity import github_copilot_identity_service
 from sentry.integrations.services.integration import integration_service
-from sentry.models.pullrequest import PullRequestAttributionSignalType
+from sentry.models.pullrequest import PullRequestAttributionSignalType, parse_pull_request_url
 from sentry.pr_metrics.attribution import attribute_delegated_agent_pull_request
 from sentry.seer.autofix.coding_agent_handoffs import sync_coding_agent_status
 from sentry.seer.autofix.constants import CodingAgentStatus
@@ -263,6 +263,7 @@ def poll_github_copilot_agents(
                         description=pr_info.title,
                         repo_provider="github",
                         repo_full_name=f"{owner}/{repo}",
+                        pr_number=pr_info.number,
                         pr_url=pr_url,
                         branch_name=branch_name,
                     )
@@ -480,15 +481,27 @@ def get_claude_code_client(clients, agent_id, org_id, integration_id: int | None
     return client
 
 
+class ExtractedAgentResult(NamedTuple):
+    """A GitHub PR or branch URL found in a Claude Code session, and what it identifies.
+
+    Exactly one of ``pr_number`` and ``branch_name`` is set whenever ``url`` is; a branch
+    URL means the agent ran with auto_create_pr=False.
+    """
+
+    url: str | None = None
+    text_block: str | None = None
+    branch_name: str | None = None
+    pr_number: int | None = None
+
+
 def extract_result_from_events(
     events: list[ClaudeSessionEvent],
-) -> tuple[str | None, str | None, str | None]:
+) -> ExtractedAgentResult:
     """Extract a GitHub PR or branch URL and its surrounding text block from session events.
 
-    Returns:
-        Tuple of (url, text_block, branch_name). branch_name is populated when the agent
-        returned a branch URL instead of a PR URL (i.e. auto_create_pr=False).
-        text_block is the full text content of the agent event block that contained the URL.
+    The patterns only locate a URL inside the agent's prose; what a PR URL means is left to
+    :func:`parse_pull_request_url`, which ``pr_pattern`` is strictly narrower than -- so
+    every URL it finds parses.
     """
     pr_pattern = re.compile(r"https://github\.com/[^/]+/[^/]+/pull/\d+")
     branch_pattern = re.compile(r"https://github\.com/[^/]+/[^/]+/tree/([-\w./]*[-\w])")
@@ -501,12 +514,23 @@ def extract_result_from_events(
                 text = block.get("text", "")
                 pr_match = pr_pattern.search(text)
                 if pr_match:
-                    return pr_match.group(0), text, None
+                    pr_url = pr_match.group(0)
+                    parsed_pr = parse_pull_request_url(pr_url)
+                    assert parsed_pr is not None  # pr_pattern only matches parseable URLs
+                    return ExtractedAgentResult(
+                        url=pr_url,
+                        text_block=text,
+                        pr_number=parsed_pr.number,
+                    )
                 branch_match = branch_pattern.search(text)
                 if branch_match:
-                    return branch_match.group(0), text, branch_match.group(1)
+                    return ExtractedAgentResult(
+                        url=branch_match.group(0),
+                        text_block=text,
+                        branch_name=branch_match.group(1),
+                    )
 
-    return None, None, None
+    return ExtractedAgentResult()
 
 
 def build_result_from_events(
@@ -517,12 +541,10 @@ def build_result_from_events(
     new_status: CodingAgentStatus,
 ) -> tuple[Any | None, CodingAgentStatus]:
     result = None
-    pr_url = None
-    branch_name = None
-    description: str | None = None
+    extracted = ExtractedAgentResult()
     if new_status == CodingAgentStatus.COMPLETED:
-        pr_url, description, branch_name = extract_result_from_events(events)
-        if not pr_url:
+        extracted = extract_result_from_events(events)
+        if not extracted.url:
             logger.warning(
                 "coding_agent.claude_code.no_result_url_in_response",
                 extra={"agent_id": agent_id},
@@ -532,11 +554,12 @@ def build_result_from_events(
     try:
         result = client.build_result_from_session(
             agent_name=agent_name,
-            pr_url=pr_url,
+            pr_url=extracted.url,
         )
         if result:
-            result.description = description or ""
-            result.branch_name = branch_name
+            result.description = extracted.text_block or ""
+            result.branch_name = extracted.branch_name
+            result.pr_number = extracted.pr_number
     except Exception:
         logger.exception(
             "coding_agent.claude_code.build_result_error",

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -134,6 +134,7 @@ class CodingAgentResult(BaseModel):
     description: str
     repo_provider: str
     repo_full_name: str
+    pr_number: int | None = None
     pr_url: str | None = None
     branch_name: str | None = None
 

--- a/tests/sentry/integrations/cursor/test_webhook.py
+++ b/tests/sentry/integrations/cursor/test_webhook.py
@@ -104,7 +104,40 @@ class TestCursorWebhook(APITestCase):
         assert result.repo_full_name == "testorg/testrepo"
         assert result.repo_provider == "github"
         assert result.pr_url == "https://github.com/testorg/testrepo/pull/1"
+        assert result.pr_number == 1
         assert result.branch_name == "cursor/fix-bug-1234"
+
+    @patch("sentry.integrations.cursor.webhooks.handler.sync_coding_agent_status")
+    def test_pr_number_parsed_past_trailing_url_segments(self, mock_update_state):
+        for pr_url in [
+            "https://github.com/testorg/testrepo/pull/649",
+            "https://github.com/testorg/testrepo/pull/649/files",
+            "https://github.com/testorg/testrepo/pull/649?w=1",
+            "https://github.com/testorg/testrepo/pull/649#issuecomment-1",
+        ]:
+            mock_update_state.reset_mock()
+            body = orjson.dumps(self._build_status_payload(status="FINISHED", pr_url=pr_url))
+            headers = self._signed_headers(body)
+
+            response = self._post_with_headers(body, headers)
+
+            assert response.status_code == 204, pr_url
+            result = mock_update_state.call_args[1]["result"]
+            assert result.pr_number == 649, pr_url
+            assert result.pr_url == pr_url, pr_url
+
+    @patch("sentry.integrations.cursor.webhooks.handler.sync_coding_agent_status")
+    def test_pr_number_withheld_when_not_completed(self, mock_update_state):
+        # Only a completed agent has a result to point at, so an errored one reports neither.
+        body = orjson.dumps(self._build_status_payload(status="ERROR"))
+        headers = self._signed_headers(body)
+
+        response = self._post_with_headers(body, headers)
+
+        assert response.status_code == 204
+        result = mock_update_state.call_args[1]["result"]
+        assert result.pr_url is None
+        assert result.pr_number is None
 
     @patch("sentry.integrations.cursor.webhooks.handler.sync_coding_agent_status")
     def test_branch_name_absent_is_none(self, mock_update_state):
@@ -374,7 +407,8 @@ class TestCursorWebhook(APITestCase):
 
     @patch("sentry.integrations.cursor.webhooks.handler.sync_coding_agent_status")
     def test_invalid_pr_url_is_dropped(self, mock_update_state):
-        # Non-https scheme must be rejected — the pr_url is nulled out so no attribution fires.
+        # Anything that isn't a PR URL in the reported repo is nulled out, so no attribution
+        # fires.
         mock_update_state.return_value = CodingAgentSyncResult(
             known_to_seer=True, run_id=None, group_id=None
         )
@@ -385,6 +419,8 @@ class TestCursorWebhook(APITestCase):
             "http://github.com/testorg/testrepo/pull/1",
             "https://github.com/otherorg/otherrepo/pull/1",
             "https://github.com/testorg/testrepo/tree/main",
+            "https://github.com/testorg/testrepo/pull/",
+            "https://github.com/testorg/testrepo/pull/abc",
         ]:
             mock_update_state.reset_mock()
             body = orjson.dumps(self._build_status_payload(status="FINISHED", pr_url=bad_url))
@@ -396,7 +432,9 @@ class TestCursorWebhook(APITestCase):
             assert response.status_code == 204, bad_url
             # The Seer state update still happens, but with no pr_url.
             assert mock_update_state.call_count == 1, bad_url
-            assert mock_update_state.call_args[1]["result"].pr_url is None, bad_url
+            result = mock_update_state.call_args[1]["result"]
+            assert result.pr_url is None, bad_url
+            assert result.pr_number is None, bad_url
             assert not PullRequestAttribution.objects.exists(), bad_url
 
     @patch("sentry.integrations.cursor.webhooks.handler.sync_coding_agent_status")

--- a/tests/sentry/seer/autofix/test_coding_agent.py
+++ b/tests/sentry/seer/autofix/test_coding_agent.py
@@ -220,6 +220,8 @@ class TestPollGithubCopilotAgents(TestCase):
             call_kwargs["agent_url"] == "https://github.com/getsentry/sentry/copilot/tasks/task-123"
         )
         assert call_kwargs["result"].pr_url == "https://github.com/getsentry/sentry/pull/12345"
+        # The fixture's number and URL disagree, pinning that we use the API's own field.
+        assert call_kwargs["result"].pr_number == 456
         assert call_kwargs["result"].description == "Fix the bug"
         assert call_kwargs["result"].repo_full_name == "getsentry/sentry"
 
@@ -670,42 +672,50 @@ class TestExtractResultFromEvents(TestCase):
     def test_extracts_pr_url(self) -> None:
         text = "PR created: https://github.com/org/repo/pull/123"
         events = [_make_agent_event(text)]
-        url, block, branch_name = extract_result_from_events(events)
-        assert url == "https://github.com/org/repo/pull/123"
-        assert block == text
-        assert branch_name is None
+        extracted = extract_result_from_events(events)
+        assert extracted.url == "https://github.com/org/repo/pull/123"
+        assert extracted.text_block == text
+        assert extracted.branch_name is None
+        assert extracted.pr_number == 123
+
+    def test_extracts_pr_number_past_a_trailing_segment(self) -> None:
+        events = [_make_agent_event("https://github.com/org/repo/pull/123/files")]
+        extracted = extract_result_from_events(events)
+        assert extracted.url == "https://github.com/org/repo/pull/123"
+        assert extracted.pr_number == 123
 
     def test_extracts_branch_url(self) -> None:
         text = "Pushed to https://github.com/org/repo/tree/my-branch"
         events = [_make_agent_event(text)]
-        url, block, branch_name = extract_result_from_events(events)
-        assert url == "https://github.com/org/repo/tree/my-branch"
-        assert block == text
-        assert branch_name == "my-branch"
+        extracted = extract_result_from_events(events)
+        assert extracted.url == "https://github.com/org/repo/tree/my-branch"
+        assert extracted.text_block == text
+        assert extracted.branch_name == "my-branch"
+        assert extracted.pr_number is None
 
     def test_strips_trailing_period(self) -> None:
         events = [_make_agent_event("See https://github.com/org/repo/tree/my-branch.")]
-        url, _, branch_name = extract_result_from_events(events)
-        assert url == "https://github.com/org/repo/tree/my-branch"
-        assert branch_name == "my-branch"
+        extracted = extract_result_from_events(events)
+        assert extracted.url == "https://github.com/org/repo/tree/my-branch"
+        assert extracted.branch_name == "my-branch"
 
     def test_strips_trailing_comma(self) -> None:
         events = [_make_agent_event("https://github.com/org/repo/tree/my-branch, ready")]
-        url, _, branch_name = extract_result_from_events(events)
-        assert url == "https://github.com/org/repo/tree/my-branch"
-        assert branch_name == "my-branch"
+        extracted = extract_result_from_events(events)
+        assert extracted.url == "https://github.com/org/repo/tree/my-branch"
+        assert extracted.branch_name == "my-branch"
 
     def test_branch_with_slashes(self) -> None:
         events = [_make_agent_event("https://github.com/org/repo/tree/feat/sub/thing")]
-        url, _, branch_name = extract_result_from_events(events)
-        assert url == "https://github.com/org/repo/tree/feat/sub/thing"
-        assert branch_name == "feat/sub/thing"
+        extracted = extract_result_from_events(events)
+        assert extracted.url == "https://github.com/org/repo/tree/feat/sub/thing"
+        assert extracted.branch_name == "feat/sub/thing"
 
     def test_branch_with_dots_in_name(self) -> None:
         events = [_make_agent_event("https://github.com/org/repo/tree/v1.2.3-fix")]
-        url, _, branch_name = extract_result_from_events(events)
-        assert url == "https://github.com/org/repo/tree/v1.2.3-fix"
-        assert branch_name == "v1.2.3-fix"
+        extracted = extract_result_from_events(events)
+        assert extracted.url == "https://github.com/org/repo/tree/v1.2.3-fix"
+        assert extracted.branch_name == "v1.2.3-fix"
 
     def test_pr_preferred_over_branch(self) -> None:
         events = [
@@ -714,31 +724,34 @@ class TestExtractResultFromEvents(TestCase):
                 "and PR https://github.com/org/repo/pull/42"
             )
         ]
-        url, _, branch_name = extract_result_from_events(events)
-        assert url == "https://github.com/org/repo/pull/42"
-        assert branch_name is None
+        extracted = extract_result_from_events(events)
+        assert extracted.url == "https://github.com/org/repo/pull/42"
+        assert extracted.branch_name is None
+        assert extracted.pr_number == 42
 
     def test_returns_none_when_no_url(self) -> None:
         events = [_make_agent_event("All done, no link.")]
-        url, block, branch_name = extract_result_from_events(events)
-        assert url is None
-        assert block is None
-        assert branch_name is None
+        extracted = extract_result_from_events(events)
+        assert extracted.url is None
+        assert extracted.text_block is None
+        assert extracted.branch_name is None
+        assert extracted.pr_number is None
 
     def test_returns_none_for_empty_events(self) -> None:
-        url, block, branch_name = extract_result_from_events([])
-        assert url is None
-        assert block is None
-        assert branch_name is None
+        extracted = extract_result_from_events([])
+        assert extracted.url is None
+        assert extracted.text_block is None
+        assert extracted.branch_name is None
+        assert extracted.pr_number is None
 
     def test_searches_most_recent_event_first(self) -> None:
         events = [
             _make_agent_event("https://github.com/org/repo/tree/old-branch"),
             _make_agent_event("https://github.com/org/repo/tree/new-branch"),
         ]
-        url, _, branch_name = extract_result_from_events(events)
-        assert url == "https://github.com/org/repo/tree/new-branch"
-        assert branch_name == "new-branch"
+        extracted = extract_result_from_events(events)
+        assert extracted.url == "https://github.com/org/repo/tree/new-branch"
+        assert extracted.branch_name == "new-branch"
 
     def test_skips_non_agent_events(self) -> None:
         events = [
@@ -748,10 +761,11 @@ class TestExtractResultFromEvents(TestCase):
             ),
             _make_agent_event("No URL here"),
         ]
-        url, block, branch_name = extract_result_from_events(events)
-        assert url is None
-        assert block is None
-        assert branch_name is None
+        extracted = extract_result_from_events(events)
+        assert extracted.url is None
+        assert extracted.text_block is None
+        assert extracted.branch_name is None
+        assert extracted.pr_number is None
 
 
 class TestPollClaudeCodeAgents(TestCase):
@@ -886,6 +900,8 @@ class TestPollClaudeCodeAgents(TestCase):
         assert call_kwargs["agent_id"] == "claude-session-123"
         assert call_kwargs["organization_id"] == self.organization.id
         assert call_kwargs["status"] == CodingAgentStatus.COMPLETED
+        # The client builds the result without a number; the session scrape supplies it.
+        assert call_kwargs["result"].pr_number == 999
 
     @patch("sentry.seer.autofix.coding_agent.attribute_delegated_agent_pull_request")
     @patch(MOCK_SYNC_STATUS_PATH)


### PR DESCRIPTION
Seer produces a pr number (e.g. #120909) when creating a new PR. For coding agent handoffs, they produce PR URLs, but no number. Track `pr_number` so we can be consistent.

Refs https://linear.app/getsentry/issue/ISWF-3145/normalize-pr-cta-label-in-issue-stream