### PR TITLE
feat(logs): Add a stored-replays-only filter to Explore Logs

### DIFF
--- a/static/app/utils/api/useAggregatedQueryKeys.spec.tsx
+++ b/static/app/utils/api/useAggregatedQueryKeys.spec.tsx
@@ -2,7 +2,7 @@ import type {ReactNode} from 'react';
 import {QueryClientProvider, type QueryClient} from '@tanstack/react-query';
 
 import {makeTestQueryClient} from 'sentry-test/queryClient';
-import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+import {act, renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import type {ApiResponse} from 'sentry/utils/api/apiFetch';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
@@ -81,7 +81,9 @@ describe('useAggregatedQueryKeys', () => {
     );
   });
 
-  it('should send a fetch request immediatly if the buffer is full', async () => {
+  it('should skip the debounce and fetch on the next tick when the buffer is full', async () => {
+    jest.useFakeTimers();
+
     const mockRequest = MockApiClient.addMockResponse({
       url: '/api-tokens/',
     });
@@ -91,15 +93,62 @@ describe('useAggregatedQueryKeys', () => {
       initialProps: {...initialProps, bufferLimit: 2},
     });
 
+    // Buffered aggregates flush on the next tick rather than during render, so let
+    // that run before asserting. One of two slots is filled, so this is still waiting
+    // on the debounce.
     result.current.buffer(['1111']);
+    await act(async () => {
+      jest.advanceTimersByTime(0);
+      await Promise.resolve();
+    });
     expect(mockRequest).not.toHaveBeenCalled();
 
     result.current.buffer(['2222', '3333']);
+    await act(async () => {
+      jest.advanceTimersByTime(0);
+      await Promise.resolve();
+    });
+
     expect(mockRequest).toHaveBeenCalled();
 
-    await waitFor(() => {
-      expect(responseReducer).toHaveBeenCalled();
+    await act(async () => {
+      jest.runOnlyPendingTimers();
+      await Promise.resolve();
     });
+    jest.useRealTimers();
+  });
+
+  it('should fetch after the debounce when the buffer never fills', async () => {
+    jest.useFakeTimers();
+
+    const mockRequest = MockApiClient.addMockResponse({
+      url: '/api-tokens/',
+    });
+
+    const {result} = renderHook(useAggregatedQueryKeys, {
+      wrapper: makeWrapper(makeTestQueryClient()),
+      initialProps: {...initialProps, bufferLimit: 50},
+    });
+
+    result.current.buffer(['1111']);
+    await act(async () => {
+      jest.advanceTimersByTime(0);
+      await Promise.resolve();
+    });
+    expect(mockRequest).not.toHaveBeenCalled();
+
+    await act(async () => {
+      jest.advanceTimersByTime(20);
+      await Promise.resolve();
+    });
+
+    expect(mockRequest).toHaveBeenCalled();
+
+    await act(async () => {
+      jest.runOnlyPendingTimers();
+      await Promise.resolve();
+    });
+    jest.useRealTimers();
   });
 
   it('should return cached data right away, if it exists in the cache', async () => {

--- a/static/app/utils/api/useAggregatedQueryKeys.tsx
+++ b/static/app/utils/api/useAggregatedQueryKeys.tsx
@@ -182,57 +182,95 @@ export function useAggregatedQueryKeys<AggregatableQueryKey, Data, ResponseData 
     }, BUFFER_WAIT_MS);
   }, [clearTimer, fetchData]);
 
+  const pendingAggregates = useRef<AggregatableQueryKey[]>([]);
+  const flushTimer = useRef<null | NodeJS.Timeout>(null);
+
+  const flushBuffer = useCallback(() => {
+    const aggregates = pendingAggregates.current;
+    pendingAggregates.current = [];
+
+    // Track AggregatableQueryKey that we care about in this hook instance
+    const queryKeys = uniq([...prevQueryKeys.current, ...aggregates]);
+    if (queryKeys.length === prevQueryKeys.current.length) {
+      return;
+    }
+    prevQueryKeys.current = queryKeys;
+
+    // Get queryKeys for any cached data related to these aggregates.
+    const existingQueryKeys = cache
+      .findAll({
+        queryKey: ['aggregate', cacheKey, url],
+        predicate: isQueryKeyInList(prevQueryKeys.current),
+      })
+      .map(({queryKey}) => queryKey[4] as AggregatableQueryKey);
+
+    // Don't request aggregates multiple times.
+    const newQueryKeys = queryKeys.filter(agg => !existingQueryKeys.includes(agg));
+
+    // Cache sentinel data for the new cacheKeys
+    newQueryKeys
+      .map(agg => ['aggregate', cacheKey, url, 'queued', agg])
+      .forEach(queryKey => queryClient.setQueryData(queryKey, true));
+
+    if (newQueryKeys.length) {
+      setData(readCache(queryKeys));
+      // Grab anything in the queue, including the newQueryKeys
+      const existingQueuedQueries = cache.findAll({
+        queryKey: ['aggregate', cacheKey, url, 'queued'],
+      });
+      if (existingQueuedQueries.length >= bufferLimit) {
+        clearTimer();
+        fetchData();
+      } else {
+        setTimer();
+      }
+    }
+  }, [
+    bufferLimit,
+    cache,
+    cacheKey,
+    clearTimer,
+    fetchData,
+    url,
+    queryClient,
+    readCache,
+    setTimer,
+  ]);
+
+  /**
+   * Callers invoke this while rendering, so it must stay free of state updates and
+   * query-client writes. Doing either here updates every other hook instance sharing
+   * the cache mid-render, which React rejects when the other instance lives in a
+   * different component. The real work is deferred to `flushBuffer`.
+   */
   const buffer = useCallback(
     (aggregates: readonly AggregatableQueryKey[]) => {
-      // Track AggregatableQueryKey that we care about in this hook instance
-      const queryKeys = uniq([...prevQueryKeys.current, ...aggregates]);
-      if (queryKeys.length === prevQueryKeys.current.length) {
+      const unseen = aggregates.filter(
+        agg =>
+          !prevQueryKeys.current.includes(agg) && !pendingAggregates.current.includes(agg)
+      );
+      if (!unseen.length) {
         return;
       }
-      prevQueryKeys.current = queryKeys;
 
-      // Get queryKeys for any cached data related to these aggregates.
-      const existingQueryKeys = cache
-        .findAll({
-          queryKey: ['aggregate', cacheKey, url],
-          predicate: isQueryKeyInList(prevQueryKeys.current),
-        })
-        .map(({queryKey}) => queryKey[4] as AggregatableQueryKey);
+      pendingAggregates.current = [...pendingAggregates.current, ...unseen];
 
-      // Don't request aggregates multiple times.
-      const newQueryKeys = queryKeys.filter(agg => !existingQueryKeys.includes(agg));
-
-      // Cache sentinel data for the new cacheKeys
-      newQueryKeys
-        .map(agg => ['aggregate', cacheKey, url, 'queued', agg])
-        .forEach(queryKey => queryClient.setQueryData(queryKey, true));
-
-      if (newQueryKeys.length) {
-        setData(readCache(queryKeys));
-        // Grab anything in the queue, including the newQueryKeys
-        const existingQueuedQueries = cache.findAll({
-          queryKey: ['aggregate', cacheKey, url, 'queued'],
-        });
-        if (existingQueuedQueries.length >= bufferLimit) {
-          clearTimer();
-          fetchData();
-        } else {
-          setTimer();
-        }
-      }
+      flushTimer.current ??= setTimeout(() => {
+        flushTimer.current = null;
+        flushBuffer();
+      }, 0);
     },
-    [
-      bufferLimit,
-      cache,
-      cacheKey,
-      clearTimer,
-      fetchData,
-      url,
-      queryClient,
-      readCache,
-      setTimer,
-    ]
+    [flushBuffer]
   );
+
+  useEffect(() => {
+    return () => {
+      if (flushTimer.current) {
+        clearTimeout(flushTimer.current);
+        flushTimer.current = null;
+      }
+    };
+  }, []);
 
   useEffect(() => {
     return cache.subscribe(result => {

--- a/static/app/utils/discover/viewReplayLink.tsx
+++ b/static/app/utils/discover/viewReplayLink.tsx
@@ -25,7 +25,7 @@ export function ViewReplayLink({
     return (
       <Tooltip
         title={t(
-          'This replay may have been rate-limited, deleted, or not stored due to the error-based replay sampling rate.'
+          'A replay ID was recorded, but the replay itself was never stored. It may have been sampled out, rate-limited, or deleted.'
         )}
       >
         <EmptyValueContainer>{t('(missing)')}</EmptyValueContainer>

--- a/static/app/utils/replayCount/useReplayExists.tsx
+++ b/static/app/utils/replayCount/useReplayExists.tsx
@@ -8,7 +8,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
  */
 export function useReplayExists({start, end}: {end?: string; start?: string} = {}) {
   const organization = useOrganization();
-  const {hasOne, hasMany} = useReplayCount({
+  const {hasOne, hasMany, getMany} = useReplayCount({
     bufferLimit: 100,
     // The dataSource doesn't matter here - queries on `replay_id` skip the
     // given dataSource and go straight to `replays`.
@@ -24,7 +24,8 @@ export function useReplayExists({start, end}: {end?: string; start?: string} = {
     () => ({
       replayExists: hasOne,
       replaysExist: hasMany,
+      getReplayCounts: getMany,
     }),
-    [hasMany, hasOne]
+    [getMany, hasMany, hasOne]
   );
 }

--- a/static/app/views/explore/logs/logsAutoRefresh.tsx
+++ b/static/app/views/explore/logs/logsAutoRefresh.tsx
@@ -18,7 +18,7 @@ import {
 } from 'sentry/views/explore/contexts/logs/logsAutoRefreshContext';
 import {useLogsPageData} from 'sentry/views/explore/contexts/logs/logsPageData';
 import {useLogsAnalyticsPageSource} from 'sentry/views/explore/logs/logsQueryParamsProvider';
-import {AutoRefreshLabel, AutoRefreshText} from 'sentry/views/explore/logs/styles';
+import {TableToggleLabel, TableToggleText} from 'sentry/views/explore/logs/styles';
 import {useLogsAutoRefreshInterval} from 'sentry/views/explore/logs/useLogsAutoRefreshInterval';
 import {checkSortIsTimeBasedDescending} from 'sentry/views/explore/logs/utils';
 import {
@@ -109,7 +109,7 @@ export function AutorefreshToggle({averageLogsPerSecond = 0}: AutorefreshToggleP
 
   return (
     <Fragment>
-      <AutoRefreshLabel>
+      <TableToggleLabel>
         <Tooltip
           title={getTooltipMessage(tooltipReason)}
           disabled={!tooltipReason}
@@ -136,8 +136,8 @@ export function AutorefreshToggle({averageLogsPerSecond = 0}: AutorefreshToggleP
             }}
           />
         </Tooltip>
-        <AutoRefreshText>{t('Auto-refresh')}</AutoRefreshText>
-      </AutoRefreshLabel>
+        <TableToggleText>{t('Auto-refresh')}</TableToggleText>
+      </TableToggleLabel>
     </Fragment>
   );
 }

--- a/static/app/views/explore/logs/logsTab.spec.tsx
+++ b/static/app/views/explore/logs/logsTab.spec.tsx
@@ -23,6 +23,7 @@ import {LOGS_AGGREGATE_FIELD_KEY} from 'sentry/views/explore/logs/logsQueryParam
 import {LogsQueryParamsProvider} from 'sentry/views/explore/logs/logsQueryParamsProvider';
 import {LogsTabContent} from 'sentry/views/explore/logs/logsTab';
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
+import {LOGS_STORED_REPLAYS_ONLY_KEY} from 'sentry/views/explore/logs/useLogsStoredReplaysOnly';
 import * as QueryParamsContext from 'sentry/views/explore/queryParams/context';
 import type {EventValidationData} from 'sentry/views/explore/utils/validateEventParamsOptions';
 
@@ -590,5 +591,123 @@ describe('LogsTabContent', () => {
     });
     const refreshButton = await screen.findByRole('button', {name: 'Refresh'});
     expect(refreshButton).toBeDisabled();
+  });
+
+  describe('stored replays only toggle', () => {
+    const storedReplayId = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    const missingReplayId = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+    function renderWithReplayLogs({
+      query,
+      replayCounts,
+    }: {
+      query: string;
+      replayCounts: Record<string, number>;
+    }) {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/replay-count/`,
+        method: 'GET',
+        body: replayCounts,
+      });
+
+      return render(<LogsTabContentHarness datePageFilterProps={datePageFilterProps} />, {
+        initialRouterConfig: {
+          ...initialRouterConfig,
+          location: {
+            ...initialRouterConfig.location,
+            query: {
+              ...initialRouterConfig.location.query,
+              [LOGS_QUERY_KEY]: query,
+              [LOGS_STORED_REPLAYS_ONLY_KEY]: '1',
+            },
+          },
+        },
+        organization,
+        additionalWrapper: ProviderWrapper,
+      });
+    }
+
+    beforeEach(() => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/events/`,
+        method: 'GET',
+        body: {
+          data: [
+            {
+              [OurLogKnownFieldKey.ID]: '019621262d117e03bce898cb8f4f6ff7',
+              [OurLogKnownFieldKey.PROJECT_ID]: 1,
+              [OurLogKnownFieldKey.TRACE_ID]: '17cc0bae407042eaa4bf6d798c37d026',
+              [OurLogKnownFieldKey.SEVERITY_NUMBER]: 9,
+              [OurLogKnownFieldKey.SEVERITY]: 'info',
+              [OurLogKnownFieldKey.TIMESTAMP]: '2025-04-10T19:21:12+00:00',
+              [OurLogKnownFieldKey.MESSAGE]: 'log with stored replay',
+              [OurLogKnownFieldKey.TIMESTAMP_PRECISE]: 1.7443128722090732e18,
+              [OurLogKnownFieldKey.REPLAY_ID]: storedReplayId,
+            },
+            {
+              [OurLogKnownFieldKey.ID]: '0196212624a17144aa392d01420256a2',
+              [OurLogKnownFieldKey.PROJECT_ID]: 1,
+              [OurLogKnownFieldKey.TRACE_ID]: 'c331c2df93d846f5a2134203416d40bb',
+              [OurLogKnownFieldKey.SEVERITY_NUMBER]: 9,
+              [OurLogKnownFieldKey.SEVERITY]: 'info',
+              [OurLogKnownFieldKey.TIMESTAMP]: '2025-04-10T19:21:10+00:00',
+              [OurLogKnownFieldKey.MESSAGE]: 'log with missing replay',
+              [OurLogKnownFieldKey.TIMESTAMP_PRECISE]: 1.744312870049196e18,
+              [OurLogKnownFieldKey.REPLAY_ID]: missingReplayId,
+            },
+          ],
+          meta: {
+            fields: {
+              [OurLogKnownFieldKey.ID]: 'string',
+              [OurLogKnownFieldKey.PROJECT_ID]: 'string',
+              [OurLogKnownFieldKey.TRACE_ID]: 'string',
+              [OurLogKnownFieldKey.SEVERITY_NUMBER]: 'integer',
+              [OurLogKnownFieldKey.SEVERITY]: 'string',
+              [OurLogKnownFieldKey.TIMESTAMP]: 'string',
+              [OurLogKnownFieldKey.MESSAGE]: 'string',
+              [OurLogKnownFieldKey.TIMESTAMP_PRECISE]: 'number',
+              [OurLogKnownFieldKey.REPLAY_ID]: 'string',
+            },
+            units: {},
+          },
+        },
+      });
+    });
+
+    it('reports how many logs it hid when a replay is missing', async () => {
+      renderWithReplayLogs({
+        query: 'has:replay_id',
+        replayCounts: {[storedReplayId]: 1, [missingReplayId]: 0},
+      });
+
+      expect(await screen.findByText('1 hidden')).toBeInTheDocument();
+    });
+
+    it('does not render the toggle when the query does not reference replays', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/replay-count/`,
+        method: 'GET',
+        body: {},
+      });
+
+      render(<LogsTabContentHarness datePageFilterProps={datePageFilterProps} />, {
+        initialRouterConfig,
+        organization,
+        additionalWrapper: ProviderWrapper,
+      });
+
+      await screen.findByRole('button', {name: 'Refresh'});
+
+      expect(screen.queryByText('Stored replays only')).not.toBeInTheDocument();
+    });
+
+    it('renders the toggle when the query references replays', async () => {
+      renderWithReplayLogs({
+        query: 'has:replay_id',
+        replayCounts: {[storedReplayId]: 1, [missingReplayId]: 1},
+      });
+
+      expect(await screen.findByText('Stored replays only')).toBeInTheDocument();
+    });
   });
 });

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -58,6 +58,7 @@ import {LogsGraph} from 'sentry/views/explore/logs/logsGraph';
 import {LogsSidebarProvider} from 'sentry/views/explore/logs/logsSidebarContext';
 import {LogsTabSeerComboBox} from 'sentry/views/explore/logs/logsTabSeerComboBox';
 import {LogsToolbar} from 'sentry/views/explore/logs/logsToolbar';
+import {StoredReplaysOnlyToggle} from 'sentry/views/explore/logs/storedReplaysOnlyToggle';
 import {
   LogsFilterSection,
   LogsGraphContainer,
@@ -72,6 +73,7 @@ import {LogsInfiniteTable} from 'sentry/views/explore/logs/tables/logsInfiniteTa
 import {useLogsAggregatesTable} from 'sentry/views/explore/logs/useLogsAggregatesTable';
 import {getMaxIngestDelayTimestamp} from 'sentry/views/explore/logs/useLogsQuery';
 import {useLogsSearchQueryBuilderProps} from 'sentry/views/explore/logs/useLogsSearchQueryBuilderProps';
+import {useLogsStoredReplaysOnlyAvailable} from 'sentry/views/explore/logs/useLogsStoredReplaysOnly';
 import {useLogsTimeseries} from 'sentry/views/explore/logs/useLogsTimeseries';
 import {usePersistentLogsPageParameters} from 'sentry/views/explore/logs/usePersistentLogsPageParameters';
 import {useSaveAsItems} from 'sentry/views/explore/logs/useSaveAsItems';
@@ -227,6 +229,7 @@ function LogsTabContentInner({datePageFilterProps}: LogsTabProps) {
   const tableData = useLogsPageDataQueryResult();
   const autorefreshEnabled = useLogsAutoRefreshEnabled();
   const searchQuery = useQueryParamsSearch().formatString();
+  const showStoredReplaysOnlyToggle = useLogsStoredReplaysOnlyAvailable();
   const visualizes = useQueryParamsVisualizes();
 
   useLLMContext({
@@ -464,6 +467,7 @@ function LogsTabContentInner({datePageFilterProps}: LogsTabProps) {
               </Tabs>
               {tableTab === 'logs' && (
                 <TableActionsContainer>
+                  {showStoredReplaysOnlyToggle && <StoredReplaysOnlyToggle />}
                   <AutorefreshToggle averageLogsPerSecond={averageLogsPerSecond} />
                   <Tooltip
                     title={manualRefreshDisabledReason}

--- a/static/app/views/explore/logs/storedReplaysOnlyToggle.tsx
+++ b/static/app/views/explore/logs/storedReplaysOnlyToggle.tsx
@@ -1,0 +1,39 @@
+import {Switch} from '@sentry/scraps/switch';
+import {Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import {t, tn} from 'sentry/locale';
+import {useLogsPageDataQueryResult} from 'sentry/views/explore/contexts/logs/logsPageData';
+import {TableToggleLabel, TableToggleText} from 'sentry/views/explore/logs/styles';
+import {
+  useLogsStoredReplaysOnly,
+  useSetLogsStoredReplaysOnly,
+} from 'sentry/views/explore/logs/useLogsStoredReplaysOnly';
+
+export function StoredReplaysOnlyToggle() {
+  const storedReplaysOnly = useLogsStoredReplaysOnly();
+  const setStoredReplaysOnly = useSetLogsStoredReplaysOnly();
+  const {hiddenMissingReplayCount} = useLogsPageDataQueryResult();
+
+  return (
+    <TableToggleLabel>
+      <Tooltip
+        title={t(
+          "A replay ID is recorded on a log whether or not the replay itself was stored, so most of them don't resolve. This hides the logs whose replay is missing."
+        )}
+        skipWrapper
+      >
+        <Switch
+          checked={storedReplaysOnly}
+          onChange={() => setStoredReplaysOnly(!storedReplaysOnly)}
+        />
+      </Tooltip>
+      <TableToggleText>{t('Stored replays only')}</TableToggleText>
+      {hiddenMissingReplayCount > 0 && (
+        <Text size="sm" variant="muted">
+          {tn('%s hidden', '%s hidden', hiddenMissingReplayCount)}
+        </Text>
+      )}
+    </TableToggleLabel>
+  );
+}

--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -422,14 +422,14 @@ export function LogsGraphContainer(props: FlexProps) {
   return <Stack flex="0 0 auto" overflow="visible" gap="md" {...props} />;
 }
 
-export const AutoRefreshLabel = styled('label')`
+export const TableToggleLabel = styled('label')`
   display: flex;
   align-items: center;
   gap: ${p => p.theme.space.xs};
   margin-bottom: 0;
 `;
 
-export const AutoRefreshText = styled('span')`
+export const TableToggleText = styled('span')`
   @media (max-width: ${p => p.theme.breakpoints.md}) {
     display: none;
   }

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
@@ -33,6 +33,7 @@ import {
   LogsInfiniteTable,
 } from 'sentry/views/explore/logs/tables/logsInfiniteTable';
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
+import {LOGS_STORED_REPLAYS_ONLY_KEY} from 'sentry/views/explore/logs/useLogsStoredReplaysOnly';
 import {createErrorLogRow} from 'sentry/views/explore/logs/utils';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 
@@ -216,6 +217,13 @@ describe('LogsInfiniteTable', () => {
 
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/releases/stats/`,
+      method: 'GET',
+      body: {},
+    });
+
+    // Any row carrying a `replay_id` triggers a buffered existence lookup.
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/replay-count/`,
       method: 'GET',
       body: {},
     });
@@ -545,6 +553,211 @@ describe('LogsInfiniteTable', () => {
 
     await screen.findByText('abc123de');
     await screen.findByText('abc123ee');
+  });
+
+  describe('stored replays only', () => {
+    const storedReplayId = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    const missingReplayId = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+    const logsWithReplays = [
+      LogFixture({
+        [OurLogKnownFieldKey.ORGANIZATION_ID]: Number(organization.id),
+        [OurLogKnownFieldKey.PROJECT_ID]: String(project.id),
+        [OurLogKnownFieldKey.ID]: '1',
+        [OurLogKnownFieldKey.MESSAGE]: 'log with stored replay',
+        [OurLogKnownFieldKey.REPLAY_ID]: storedReplayId,
+      }),
+      LogFixture({
+        [OurLogKnownFieldKey.ORGANIZATION_ID]: Number(organization.id),
+        [OurLogKnownFieldKey.PROJECT_ID]: String(project.id),
+        [OurLogKnownFieldKey.ID]: '2',
+        [OurLogKnownFieldKey.MESSAGE]: 'log with missing replay',
+        [OurLogKnownFieldKey.REPLAY_ID]: missingReplayId,
+      }),
+    ];
+
+    const routerConfig = {
+      location: {
+        pathname: `/organizations/${organization.slug}/explore/logs/`,
+        query: {
+          [LOGS_FIELDS_KEY]: visibleColumnFields,
+          [LOGS_SORT_BYS_KEY]: '-timestamp',
+          [LOGS_QUERY_KEY]: 'has:replay_id',
+          [LOGS_STORED_REPLAYS_ONLY_KEY]: '1',
+        },
+      },
+    };
+
+    function mockLogs(data: typeof logsWithReplays) {
+      return MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/events/`,
+        method: 'GET',
+        body: {
+          data,
+          meta: {
+            fields: {
+              [OurLogKnownFieldKey.ID]: 'string',
+              [OurLogKnownFieldKey.PROJECT_ID]: 'string',
+              [OurLogKnownFieldKey.MESSAGE]: 'string',
+              [OurLogKnownFieldKey.SEVERITY_NUMBER]: 'integer',
+              [OurLogKnownFieldKey.SEVERITY]: 'string',
+              [OurLogKnownFieldKey.TIMESTAMP]: 'string',
+              [OurLogKnownFieldKey.TRACE_ID]: 'string',
+              [OurLogKnownFieldKey.TIMESTAMP_PRECISE]: 'number',
+              [OurLogKnownFieldKey.REPLAY_ID]: 'string',
+            },
+            units: {},
+          },
+        },
+      });
+    }
+
+    beforeEach(() => {
+      MockApiClient.clearMockResponses();
+      mockLogs(logsWithReplays);
+    });
+
+    it('keeps a log when its replay was stored', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/replay-count/`,
+        method: 'GET',
+        body: {[storedReplayId]: 1, [missingReplayId]: 0},
+      });
+
+      renderWithProviders(
+        <LogsInfiniteTable analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS} />,
+        {initialRouterConfig: routerConfig}
+      );
+
+      expect(await screen.findByText('log with stored replay')).toBeInTheDocument();
+    });
+
+    it('hides a log when its replay was never stored', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/replay-count/`,
+        method: 'GET',
+        body: {[storedReplayId]: 1, [missingReplayId]: 0},
+      });
+
+      renderWithProviders(
+        <LogsInfiniteTable analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS} />,
+        {initialRouterConfig: routerConfig}
+      );
+
+      await screen.findByText('log with stored replay');
+
+      await waitFor(() => {
+        expect(screen.queryByText('log with missing replay')).not.toBeInTheDocument();
+      });
+    });
+
+    it('keeps a log while its replay existence is still unresolved', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/replay-count/`,
+        method: 'GET',
+        body: {},
+      });
+
+      renderWithProviders(
+        <LogsInfiniteTable analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS} />,
+        {initialRouterConfig: routerConfig}
+      );
+
+      expect(await screen.findByText('log with missing replay')).toBeInTheDocument();
+    });
+
+    it('falls through to the empty state when every loaded log is missing its replay', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/replay-count/`,
+        method: 'GET',
+        body: {[storedReplayId]: 0, [missingReplayId]: 0},
+      });
+
+      renderWithProviders(
+        <LogsInfiniteTable analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS} />,
+        {initialRouterConfig: routerConfig}
+      );
+
+      expect(await screen.findByText('No logs found')).toBeInTheDocument();
+    });
+
+    it('requests replay_id even when the column is not selected', async () => {
+      const eventsMock = mockLogs(logsWithReplays);
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/replay-count/`,
+        method: 'GET',
+        body: {[storedReplayId]: 1, [missingReplayId]: 0},
+      });
+
+      renderWithProviders(
+        <LogsInfiniteTable analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS} />,
+        {initialRouterConfig: routerConfig}
+      );
+
+      await screen.findByText('log with stored replay');
+
+      expect(eventsMock).toHaveBeenCalledWith(
+        `/organizations/${organization.slug}/events/`,
+        expect.objectContaining({
+          query: expect.objectContaining({
+            field: expect.arrayContaining([OurLogKnownFieldKey.REPLAY_ID]),
+          }),
+        })
+      );
+    });
+
+    it('leaves every log visible when the query no longer references replays', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/replay-count/`,
+        method: 'GET',
+        body: {[storedReplayId]: 1, [missingReplayId]: 0},
+      });
+
+      renderWithProviders(
+        <LogsInfiniteTable analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS} />,
+        {
+          initialRouterConfig: {
+            location: {
+              ...routerConfig.location,
+              query: {
+                [LOGS_FIELDS_KEY]: visibleColumnFields,
+                [LOGS_SORT_BYS_KEY]: '-timestamp',
+                [LOGS_QUERY_KEY]: 'severity:error',
+                [LOGS_STORED_REPLAYS_ONLY_KEY]: '1',
+              },
+            },
+          },
+        }
+      );
+
+      expect(await screen.findByText('log with missing replay')).toBeInTheDocument();
+    });
+
+    it('leaves every log visible when the filter is off', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/replay-count/`,
+        method: 'GET',
+        body: {[storedReplayId]: 1, [missingReplayId]: 0},
+      });
+
+      renderWithProviders(
+        <LogsInfiniteTable analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS} />,
+        {
+          initialRouterConfig: {
+            location: {
+              ...routerConfig.location,
+              query: {
+                [LOGS_FIELDS_KEY]: visibleColumnFields,
+                [LOGS_SORT_BYS_KEY]: '-timestamp',
+                [LOGS_QUERY_KEY]: 'has:replay_id',
+              },
+            },
+          },
+        }
+      );
+
+      expect(await screen.findByText('log with missing replay')).toBeInTheDocument();
+    });
   });
 
   it('renders a pin button on a row when hovering', async () => {

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
@@ -51,10 +51,7 @@ import {useLogsAutoRefreshEnabled} from 'sentry/views/explore/contexts/logs/logs
 import {useLogsPageDataQueryResult} from 'sentry/views/explore/contexts/logs/logsPageData';
 import {LOGS_ROW_ID_KEY} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {logsTimestampDescendingSortBy} from 'sentry/views/explore/contexts/logs/sortBys';
-import {
-  MINIMUM_INFINITE_SCROLL_FETCH_COOLDOWN_MS,
-  QUANTIZE_MINUTES,
-} from 'sentry/views/explore/logs/constants';
+import {MINIMUM_INFINITE_SCROLL_FETCH_COOLDOWN_MS} from 'sentry/views/explore/logs/constants';
 import {getDisplayTotalPayloadBytes} from 'sentry/views/explore/logs/getDisplayTotalPayloadBytes';
 import {PinnedLogs} from 'sentry/views/explore/logs/pinning/PinnedLogs';
 import {useLogsPinning} from 'sentry/views/explore/logs/pinning/useLogsPinning';
@@ -84,12 +81,12 @@ import {
   getDynamicLogsNextFetchThreshold,
   getLogBodySearchTerms,
   getLogRowTimestampMillis,
+  getQuantizedLogTimeRange,
   getTableHeaderLabel,
   isErrorLogRow,
   isRegularLogResponseItem,
   logsFieldAlignment,
   mergeRowsByTimestampDescending,
-  quantizeTimestampToMinutes,
   type ErrorLogRowItem,
   type LogTableRowItem,
 } from 'sentry/views/explore/logs/utils';
@@ -257,31 +254,10 @@ export function LogsInfiniteTable({
 
   const isEmptyWithoutInjectedErrors = isEmpty && !hasInjectedErrorRows;
 
-  // Calculate quantized start and end times for replay links
-  const {logStart, logEnd} = useMemo(() => {
-    if (!baseData || baseData.length === 0) {
-      return {logStart: undefined, logEnd: undefined};
-    }
-
-    const timestamps = baseData.map(row => getLogRowTimestampMillis(row)).filter(Boolean);
-    if (timestamps.length === 0) {
-      return {logStart: undefined, logEnd: undefined};
-    }
-
-    const firstTimestamp = Math.min(...timestamps);
-    const lastTimestamp = Math.max(...timestamps);
-
-    const quantizedStart = quantizeTimestampToMinutes(firstTimestamp, QUANTIZE_MINUTES);
-    const quantizedEnd = quantizeTimestampToMinutes(
-      lastTimestamp + QUANTIZE_MINUTES * 60 * 1000,
-      QUANTIZE_MINUTES
-    );
-
-    return {
-      logStart: new Date(quantizedStart).toISOString(),
-      logEnd: new Date(quantizedEnd).toISOString(),
-    };
-  }, [baseData]);
+  const {start: logStart, end: logEnd} = useMemo(
+    () => getQuantizedLogTimeRange(baseData),
+    [baseData]
+  );
 
   const tableRef = useRef<HTMLTableElement>(null);
   const tableBodyRef = useRef<HTMLTableSectionElement>(null);

--- a/static/app/views/explore/logs/useLogsQuery.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.tsx
@@ -25,6 +25,7 @@ import {useTraceItemDetails} from 'sentry/views/explore/hooks/useTraceItemDetail
 import {
   AlwaysPresentLogFields,
   LOCAL_LOG_ROWS_FOR_EXPANDED_INFINITE_PAGES,
+  LOGS_GRID_SCROLL_MIN_ITEM_THRESHOLD,
   LOGS_HIGH_FIDELITY_INITIAL_AUTO_FETCH_WINDOW_MS,
   LOGS_HIGH_FIDELITY_RESUMED_AUTO_FETCH_WINDOW_MS,
   MAX_LOG_INGEST_DELAY,
@@ -44,11 +45,16 @@ import {
   type EventsLogsResult,
 } from 'sentry/views/explore/logs/types';
 import {useLogsQueryTruncate} from 'sentry/views/explore/logs/useLogsQueryTruncate';
+import {useLogsStoredReplaysOnly} from 'sentry/views/explore/logs/useLogsStoredReplaysOnly';
+import {useStoredReplayFilter} from 'sentry/views/explore/logs/useStoredReplayFilter';
 import {
   isRowVisibleInVirtualStream,
   useVirtualStreaming,
 } from 'sentry/views/explore/logs/useVirtualStreaming';
-import {getTimeBasedSortBy} from 'sentry/views/explore/logs/utils';
+import {
+  getQuantizedLogTimeRange,
+  getTimeBasedSortBy,
+} from 'sentry/views/explore/logs/utils';
 import {
   useQueryParamsCursor,
   useQueryParamsFields,
@@ -102,13 +108,19 @@ function useLogsApiOptions({
   const groupBys = useQueryParamsGroupBys();
   const [caseInsensitive] = useCaseInsensitivity();
   const truncate = useLogsQueryTruncate();
+  const storedReplaysOnly = useLogsStoredReplaysOnly();
 
   const search = baseSearch ? _search.copy() : _search;
   if (baseSearch) {
     search.tokens.push(...baseSearch.tokens);
   }
   const fields = Array.from(
-    new Set([...AlwaysPresentLogFields, ..._fields, ...groupBys.filter(Boolean)])
+    new Set([
+      ...AlwaysPresentLogFields,
+      ..._fields,
+      ...groupBys.filter(Boolean),
+      ...(storedReplaysOnly ? [OurLogKnownFieldKey.REPLAY_ID] : []),
+    ])
   );
   const sorts = sortBys ?? [];
   const pageFilters = selection;
@@ -450,6 +462,8 @@ export function useInfiniteLogsQuery({
   const queryKeyWithInfinite = infiniteApiOptions.queryKey;
   const queryClient = useQueryClient();
 
+  const storedReplaysOnly = useLogsStoredReplaysOnly();
+
   const sortBys = useQueryParamsSortBys();
 
   const getPreviousPageParam = useCallback(
@@ -632,7 +646,7 @@ export function useInfiniteLogsQuery({
     setTotalBytesScanned(previousBytesScanned => previousBytesScanned + bytesScanned);
   }, [lastPage]);
 
-  const _data = useMemo(() => {
+  const visibleData = useMemo(() => {
     const usedRowIds = new Set();
     return (
       data?.pages.flatMap(page =>
@@ -651,6 +665,19 @@ export function useInfiniteLogsQuery({
       ) ?? []
     );
   }, [data, virtualStreamedTimestamp]);
+
+  const replayTimeRange = getQuantizedLogTimeRange(visibleData);
+
+  const {
+    items: _data,
+    hiddenCount: hiddenMissingReplayCount,
+    isResolving: isResolvingReplays,
+  } = useStoredReplayFilter({
+    items: visibleData,
+    start: replayTimeRange.start,
+    end: replayTimeRange.end,
+    enabled: storedReplaysOnly,
+  });
 
   const pageCount = data?.pages?.length;
   const _meta = useMemo<EventsMetaType>(() => {
@@ -713,6 +740,18 @@ export function useInfiniteLogsQuery({
     fetchNextPage: _fetchNextPage,
   });
 
+  const shouldFillFilteredPage = useFillFilteredPages({
+    queryKey: queryKeyWithInfinite,
+    canFill:
+      storedReplaysOnly &&
+      !isResolvingReplays &&
+      hasNextPage &&
+      nextPageHasData &&
+      !isFetching &&
+      _data.length < LOGS_GRID_SCROLL_MIN_ITEM_THRESHOLD,
+    fetchNextPage: _fetchNextPage,
+  });
+
   return {
     error,
     isError,
@@ -721,7 +760,11 @@ export function useInfiniteLogsQuery({
       // query is still pending
       queryResult.isPending ||
       // started auto fetching the next page
-      (_data.length === 0 && (isFetchingNextPage || shouldAutoFetchNextPage)),
+      (_data.length === 0 &&
+        (isFetchingNextPage ||
+          shouldAutoFetchNextPage ||
+          shouldFillFilteredPage ||
+          isResolvingReplays)),
     data: _data,
     meta: _meta,
     isRefetching: queryResult.isRefetching,
@@ -731,7 +774,9 @@ export function useInfiniteLogsQuery({
       !isFetchingNextPage &&
       !isError &&
       _data.length === 0 &&
-      !shouldAutoFetchNextPage,
+      !shouldAutoFetchNextPage &&
+      !shouldFillFilteredPage &&
+      !isResolvingReplays,
     fetchNextPage: _fetchNextPage,
     fetchPreviousPage: _fetchPreviousPage,
     refetch,
@@ -745,6 +790,7 @@ export function useInfiniteLogsQuery({
     resumeAutoFetch,
     dataScanned,
     bytesScanned: totalBytesScanned,
+    hiddenMissingReplayCount,
   };
 }
 
@@ -848,6 +894,50 @@ function useAutoFetchWindow({
     canAutoFetchNextPage && (!deadlineMs || Date.now() < deadlineMs);
 
   return {shouldAutoFetchNextPage, resumeAutoFetch};
+}
+
+const MAX_STORED_REPLAY_FILL_FETCHES = 10;
+
+/**
+ * Hiding missing-replay rows can leave a page too short to scroll, which stalls the
+ * table's scroll-driven paging. Fetches a bounded number of extra pages until there are
+ * enough rows to scroll with.
+ *
+ * The cap matters: once the query hits `maxPages` React Query evicts old pages, so a
+ * query whose replays are nearly all missing would otherwise never reach the threshold
+ * and would page forever. Kept separate from the high fidelity auto-fetch, which is
+ * time-bounded and reports its own metrics.
+ */
+function useFillFilteredPages({
+  queryKey,
+  canFill,
+  fetchNextPage,
+}: {
+  canFill: boolean;
+  fetchNextPage: () => unknown;
+  queryKey: QueryKey;
+}) {
+  const timesFetched = useRef(0);
+
+  const queryKeyHash = useMemo(() => {
+    const {url, options} = parseQueryKey(queryKey);
+    return JSON.stringify([url, options?.query]);
+  }, [queryKey]);
+
+  useEffect(() => {
+    timesFetched.current = 0;
+  }, [queryKeyHash]);
+
+  const shouldFill = canFill && timesFetched.current < MAX_STORED_REPLAY_FILL_FETCHES;
+
+  useEffect(() => {
+    if (shouldFill) {
+      timesFetched.current += 1;
+      fetchNextPage();
+    }
+  }, [fetchNextPage, shouldFill]);
+
+  return shouldFill;
 }
 
 export function useLogsQueryHighFidelity() {

--- a/static/app/views/explore/logs/useLogsStoredReplaysOnly.spec.tsx
+++ b/static/app/views/explore/logs/useLogsStoredReplaysOnly.spec.tsx
@@ -1,0 +1,20 @@
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {searchReferencesReplayId} from 'sentry/views/explore/logs/useLogsStoredReplaysOnly';
+
+describe('searchReferencesReplayId', () => {
+  it('returns true when the query uses has:replay_id', () => {
+    expect(searchReferencesReplayId(new MutableSearch('has:replay_id'))).toBe(true);
+  });
+
+  it('returns true when the query filters on a replay_id value', () => {
+    expect(searchReferencesReplayId(new MutableSearch('replay_id:abc123'))).toBe(true);
+  });
+
+  it('returns false when the query does not mention replays', () => {
+    expect(searchReferencesReplayId(new MutableSearch('severity:error'))).toBe(false);
+  });
+
+  it('returns false when the query only has other has: filters', () => {
+    expect(searchReferencesReplayId(new MutableSearch('has:trace'))).toBe(false);
+  });
+});

--- a/static/app/views/explore/logs/useLogsStoredReplaysOnly.tsx
+++ b/static/app/views/explore/logs/useLogsStoredReplaysOnly.tsx
@@ -1,0 +1,67 @@
+import {useCallback} from 'react';
+import type {Location} from 'history';
+
+import {navigateIfQueryChanged} from 'sentry/utils/navigateIfQueryChanged';
+import {decodeScalar} from 'sentry/utils/queryString';
+import {useHasReplayAccess} from 'sentry/utils/replays/hooks/useHasReplayAccess';
+import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import {useLogsFrozenIsFrozen} from 'sentry/views/explore/logs/logsFrozenContext';
+import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
+import {useQueryParamsSearch} from 'sentry/views/explore/queryParams/context';
+
+export const LOGS_STORED_REPLAYS_ONLY_KEY = 'storedReplaysOnly';
+
+/**
+ * `has:replay_id` tokenizes under the `has` key rather than `replay_id`, so both
+ * shapes have to be checked to know whether the query talks about replays at all.
+ */
+export function searchReferencesReplayId(search: MutableSearch) {
+  return (
+    search.hasFilter(OurLogKnownFieldKey.REPLAY_ID) ||
+    search.getFilterValues('has').includes(OurLogKnownFieldKey.REPLAY_ID)
+  );
+}
+
+/**
+ * Whether the filter can do anything: the table isn't already scoped to a replay or
+ * trace that exists, the query is about replays, and we're allowed to look replays up.
+ */
+export function useLogsStoredReplaysOnlyAvailable() {
+  const search = useQueryParamsSearch();
+  const isFrozen = useLogsFrozenIsFrozen();
+  const hasReplayAccess = useHasReplayAccess();
+  return !isFrozen && hasReplayAccess && searchReferencesReplayId(search);
+}
+
+/**
+ * Deliberately gated on availability. Otherwise editing the replay filter out of the
+ * query would hide the toggle while the URL param kept silently dropping rows, leaving
+ * no control to turn it back off.
+ */
+export function useLogsStoredReplaysOnly() {
+  const location = useLocation();
+  const isAvailable = useLogsStoredReplaysOnlyAvailable();
+  return (
+    isAvailable && decodeScalar(location.query[LOGS_STORED_REPLAYS_ONLY_KEY]) === '1'
+  );
+}
+
+export function useSetLogsStoredReplaysOnly() {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  return useCallback(
+    (storedReplaysOnly: boolean) => {
+      const target: Location = {...location, query: {...location.query}};
+      if (storedReplaysOnly) {
+        target.query[LOGS_STORED_REPLAYS_ONLY_KEY] = '1';
+      } else {
+        delete target.query[LOGS_STORED_REPLAYS_ONLY_KEY];
+      }
+      navigateIfQueryChanged(navigate, location, target);
+    },
+    [location, navigate]
+  );
+}

--- a/static/app/views/explore/logs/useLogsTimeseries.spec.tsx
+++ b/static/app/views/explore/logs/useLogsTimeseries.spec.tsx
@@ -103,6 +103,7 @@ describe('useLogsTimeseries', () => {
             dataScanned: undefined,
             canResumeAutoFetch: false,
             resumeAutoFetch: () => {},
+            hiddenMissingReplayCount: 0,
           },
         }),
       {additionalWrapper: Wrapper}

--- a/static/app/views/explore/logs/useStoredReplayFilter.tsx
+++ b/static/app/views/explore/logs/useStoredReplayFilter.tsx
@@ -1,0 +1,72 @@
+import {useMemo} from 'react';
+
+import {defined} from 'sentry/utils/defined';
+import {useReplayExists} from 'sentry/utils/replayCount/useReplayExists';
+import {
+  OurLogKnownFieldKey,
+  type OurLogsResponseItem,
+} from 'sentry/views/explore/logs/types';
+
+interface Props {
+  enabled: boolean;
+  items: OurLogsResponseItem[];
+  end?: string;
+  start?: string;
+}
+
+interface Result {
+  hiddenCount: number;
+  isResolving: boolean;
+  items: OurLogsResponseItem[];
+}
+
+function getReplayId(item: OurLogsResponseItem) {
+  const replayId = item[OurLogKnownFieldKey.REPLAY_ID];
+  return typeof replayId === 'string' && replayId ? replayId : undefined;
+}
+
+/**
+ * Drops logs whose `replay_id` points at a replay that was never stored.
+ *
+ * Relay stamps `replay_id` from the DSC whether or not the replay was sampled, so the
+ * attribute is present on most logs and resolves for few of them. This checks each id
+ * against `/replay-count/` and hides the ones that resolve to nothing.
+ *
+ * Scoped to the logs already loaded into the table — counts, graphs and aggregates are
+ * unaffected.
+ */
+export function useStoredReplayFilter({items, start, end, enabled}: Props): Result {
+  const {getReplayCounts} = useReplayExists({start, end});
+
+  const replayIds = enabled ? [...new Set(items.map(getReplayId).filter(defined))] : [];
+
+  // Buffers the ids into the shared `/replay-count/` cache as a side effect, so it has
+  // to run even before anything can be filtered.
+  const counts = getReplayCounts(replayIds);
+
+  // A count of `undefined` means we haven't heard back about that id yet. Keeping those
+  // rows visible avoids flickering them out and back in as each batch resolves.
+  const missingIdsKey = replayIds.filter(replayId => counts[replayId] === 0).join(',');
+  const unresolvedCount = replayIds.filter(
+    replayId => counts[replayId] === undefined
+  ).length;
+
+  // Memoized because callers key rendering off the identity of `items`.
+  return useMemo(() => {
+    if (!enabled) {
+      return {items, hiddenCount: 0, isResolving: false};
+    }
+
+    const missingIds = new Set(missingIdsKey ? missingIdsKey.split(',') : []);
+    const kept = items.filter(item => {
+      const replayId = getReplayId(item);
+      return defined(replayId) && !missingIds.has(replayId);
+    });
+
+    return {
+      items: kept,
+      hiddenCount: items.length - kept.length,
+      isResolving: unresolvedCount > 0,
+    };
+  }, [enabled, items, missingIdsKey, unresolvedCount]);
+}

--- a/static/app/views/explore/logs/utils.tsx
+++ b/static/app/views/explore/logs/utils.tsx
@@ -41,6 +41,7 @@ import {
   DeprecatedLogDetailFields,
   LogAttributesHumanLabel,
   LOGS_GRID_SCROLL_MIN_ITEM_THRESHOLD,
+  QUANTIZE_MINUTES,
 } from 'sentry/views/explore/logs/constants';
 import {
   getTargetWithReadableQueryParams,
@@ -331,6 +332,34 @@ export function quantizeTimestampToMinutes(
 ): number {
   const quantizeMs = quantizeMinutes * 60 * 1000;
   return Math.floor(timestampMs / quantizeMs) * quantizeMs;
+}
+
+/**
+ * Quantized so the window stays stable as rows stream in, keeping downstream replay
+ * lookups on one cache key instead of refetching on every new row.
+ */
+export function getQuantizedLogTimeRange(rows: LogTableRowItem[]): {
+  end: string | undefined;
+  start: string | undefined;
+} {
+  const timestamps = rows.map(row => getLogRowTimestampMillis(row)).filter(Boolean);
+  if (timestamps.length === 0) {
+    return {start: undefined, end: undefined};
+  }
+
+  const quantizedStart = quantizeTimestampToMinutes(
+    Math.min(...timestamps),
+    QUANTIZE_MINUTES
+  );
+  const quantizedEnd = quantizeTimestampToMinutes(
+    Math.max(...timestamps) + QUANTIZE_MINUTES * 60 * 1000,
+    QUANTIZE_MINUTES
+  );
+
+  return {
+    start: new Date(quantizedStart).toISOString(),
+    end: new Date(quantizedEnd).toISOString(),
+  };
 }
 
 export function getLogTimestampBucketIndex(


### PR DESCRIPTION
Problem: `useStoredReplayFilter` treated `counts[id] === undefined` as _"still loading, keep the row"_ and `=== 0` as _"replay missing, hide it"_. But `useReplayCount`'s reducer backfills `0` for every id the hook tracks on every response, and `readCache()` passes all tracked ids. So the moment the first batch of ~100 replays lands, all remaining ids read as `0`. 😬 

Fix: `useAggregatedQueryKeys` now exposes `isPending(aggregate)`, read from the `queued`/`inFlight` "sentinel" query keys. Aside: this is the first time I've seen "sentinel" as a term in code in, like, years. Cool.

Bonus fix: logs with no `replay_id` are kept rather than hidden. They're reachable via `has:replay_id OR level:error`, and `replay_id:""` would have hidden everything.

Closes LOGS-580
