### PR TITLE
chore(issues): Remove GroupCategory.TEST_NOTIFICATION from defaults

### DIFF
--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -69,7 +69,12 @@ DEFAULT_GROUP_SEARCH_CATEGORY_IDS = frozenset(
     category.value
     for category in GroupCategory
     # Hide certain categories from the default issue stream
-    if category not in {GroupCategory.FEEDBACK, GroupCategory.CONFIGURATION}
+    if category
+    not in {
+        GroupCategory.FEEDBACK,
+        GroupCategory.TEST_NOTIFICATION,
+        GroupCategory.CONFIGURATION,
+    }
 )
 
 


### PR DESCRIPTION
This category is only used for sending notifications and occurrences are not stored. The snuba executor fans out on a request per item in the DEFAULT_GROUP_SEARCH_CATEGORY_IDS set, this results in no behavior change aside from removing a query which would never return results.

There are a number of additional improvements we can make to better align this with GroupType definitions but this is an easy and quick win for now.