### PR TITLE
ref(autofix): Use Literal instead of StrEnum for fixability assessment

### DIFF
--- a/src/sentry/seer/autofix/artifact_schemas.py
+++ b/src/sentry/seer/autofix/artifact_schemas.py
@@ -1,4 +1,4 @@
-from enum import StrEnum
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
@@ -12,14 +12,8 @@ class SolutionStep(BaseModel):
     )
 
 
-class Fixability(StrEnum):
-    FIXABLE = "fixable"
-    NEEDS_MORE_CONTEXT = "needs_more_context"
-    NOT_ACTIONABLE = "not_actionable"
-
-
 class FixabilityAssessment(BaseModel):
-    assessment: Fixability = Field(
+    assessment: Literal["fixable", "needs_more_context", "not_actionable"] = Field(
         description="Whether the root cause is fixable through code changes"
     )
     reason: str = Field(description="Brief explanation for the assessment")

--- a/src/sentry/seer/autofix/on_completion_hook.py
+++ b/src/sentry/seer/autofix/on_completion_hook.py
@@ -629,37 +629,15 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
             stopping_step = STOPPING_POINT_TO_STEP.get(stopping_point)
             reached_stopping_point = current_step == stopping_step
 
-        fixability = cls.determine_fixability(
-            organization,
-            state,
-            current_step,
+        cls.determine_fixability(
+            organization=organization,
+            group=group,
+            run_id=run_id,
+            state=state,
+            step=current_step,
+            referrer=referrer,
+            reached_stopping_point=reached_stopping_point,
         )
-        if fixability is not None:
-            analytics.record(
-                AiAutofixIntrospectionEvent(
-                    organization_id=organization.id,
-                    project_id=group.project_id,
-                    group_id=group.id,
-                    run_id=run_id,
-                    referrer=referrer.value,
-                    step=current_step.value,
-                    action=fixability.assessment.value,
-                    reached_stopping_point=reached_stopping_point,
-                )
-            )
-            logger.info(
-                "autofix.on_completion_hook.introspection",
-                extra={
-                    "organization_id": organization.id,
-                    "project_id": group.project_id,
-                    "group_id": group.id,
-                    "referrer": referrer.value,
-                    "step": current_step.value,
-                    "action": fixability.assessment.value,
-                    "reason": fixability.reason,
-                    "reached_stopping_point": reached_stopping_point,
-                },
-            )
 
         # PR iteration runs against an existing PR rather than the automated
         # pipeline. Once the agent finishes iterating, push the new changes to
@@ -753,9 +731,14 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
     @classmethod
     def determine_fixability(
         cls,
+        *,
         organization: Organization,
+        group: Group,
+        run_id: int,
         state: SeerRunState,
         step: AutofixStep,
+        referrer: AutofixReferrer,
+        reached_stopping_point: bool,
     ) -> FixabilityAssessment | None:
         if step != AutofixStep.ROOT_CAUSE:
             return None
@@ -769,7 +752,35 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
         if artifact is None:
             return None
 
-        return artifact.fixability
+        fixability = artifact.fixability
+
+        analytics.record(
+            AiAutofixIntrospectionEvent(
+                organization_id=organization.id,
+                project_id=group.project_id,
+                group_id=group.id,
+                run_id=run_id,
+                referrer=referrer.value,
+                step=step.value,
+                action=fixability.assessment,
+                reached_stopping_point=reached_stopping_point,
+            )
+        )
+        logger.info(
+            "autofix.on_completion_hook.introspection",
+            extra={
+                "organization_id": organization.id,
+                "project_id": group.project_id,
+                "group_id": group.id,
+                "referrer": referrer.value,
+                "step": step.value,
+                "action": fixability.assessment,
+                "reason": fixability.reason,
+                "reached_stopping_point": reached_stopping_point,
+            },
+        )
+
+        return fixability
 
     @classmethod
     def _iteration_terminal_errored_repos(cls, state: SeerRunState) -> list[str]:

--- a/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
+++ b/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
@@ -229,12 +229,18 @@ class TestAutofixOnCompletionHookHelpers(TestCase):
 
     def test_determine_fixability_returns_none_for_non_root_cause(self) -> None:
         organization = self.create_organization()
+        project = self.create_project(organization=organization)
+        group = self.create_group(project=project)
         state = run_state(blocks=[pr_iteration_memory_block()])
 
         result = AutofixOnCompletionHook.determine_fixability(
-            organization,
-            state,
-            AutofixStep.PR_ITERATION,
+            organization=organization,
+            group=group,
+            run_id=1,
+            state=state,
+            step=AutofixStep.PR_ITERATION,
+            referrer=AutofixReferrer.GROUP_AUTOFIX_ENDPOINT,
+            reached_stopping_point=False,
         )
 
         assert result is None


### PR DESCRIPTION
There's weird cases of the LLM generating an artifact that do not conform to the expected schema. Let's try and see if a literal improves this over a str enum.