### PR TITLE
feat(issues): adjusts replay error message in issue details page

### DIFF
--- a/static/app/components/events/eventReplay/replayClipPreview.spec.tsx
+++ b/static/app/components/events/eventReplay/replayClipPreview.spec.tsx
@@ -154,15 +154,15 @@ describe('ReplayClipPreview', () => {
     expect(screen.getByTestId('replay-loading-placeholder')).toBeInTheDocument();
   });
 
-  it('Should throw error when there is a fetch error', () => {
+  it('Should throw an error when server did not find the replay', () => {
     // Change the mocked hook to return a fetch error
     mockUseLoadReplayReader.mockImplementationOnce(() => {
       return {
         attachmentError: undefined,
         attachments: [],
         errors: [],
-        fetchError: new RequestError('GET', '/replay/', new Error('bad request'), {
-          status: 400,
+        fetchError: new RequestError('GET', '/replay/', new Error('server error'), {
+          status: 500,
         } as ResponseMeta),
         isError: true,
         isPending: false,
@@ -178,6 +178,45 @@ describe('ReplayClipPreview', () => {
     render(<ReplayClipPreview {...defaultProps} />);
 
     expect(screen.getByTestId('replay-error')).toBeVisible();
+    expect(
+      screen.getByText('There was an error loading the replay.')
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Retry'})).toBeInTheDocument();
+  });
+
+  it('Should show a missing replay alert for 404 fetch errors', () => {
+    mockUseLoadReplayReader.mockImplementationOnce(() => {
+      return {
+        attachmentError: undefined,
+        attachments: [],
+        errors: [],
+        fetchError: new RequestError('GET', '/replay/', new Error('not found'), {
+          status: 404,
+        } as ResponseMeta),
+        isError: true,
+        isPending: false,
+        onRetry: jest.fn(),
+        projectSlug: ProjectFixture().slug,
+        replay: null,
+        replayId: mockReplayId,
+        replayRecord: ReplayRecordFixture(),
+        status: 'error' as const,
+      };
+    });
+
+    render(<ReplayClipPreview {...defaultProps} />);
+
+    expect(
+      screen.getByText(/A replay isn't available for this event/)
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'check your replay usage'})).toHaveAttribute(
+      'href',
+      `/settings/${mockOrgSlug}/stats/?dataCategory=replays`
+    );
+    expect(
+      screen.queryByText('There was an error loading the replay.')
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Retry'})).not.toBeInTheDocument();
   });
 
   it('Should throw throttled error when fetch returns 429', () => {

--- a/static/app/components/events/eventReplay/replayClipPreviewPlayer.tsx
+++ b/static/app/components/events/eventReplay/replayClipPreviewPlayer.tsx
@@ -9,6 +9,7 @@ import {ReplayPreviewPlayer} from 'sentry/components/events/eventReplay/replayPr
 import {StaticReplayPreview} from 'sentry/components/events/eventReplay/staticReplayPreview';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {ArchivedReplayAlert} from 'sentry/components/replays/alerts/archivedReplayAlert';
+import {MissingReplayAlert} from 'sentry/components/replays/alerts/missingReplayAlert';
 import {ReplayLoadingState} from 'sentry/components/replays/player/replayLoadingState';
 import {t} from 'sentry/locale';
 import type {useLoadReplayReader} from 'sentry/utils/replays/hooks/useLoadReplayReader';
@@ -16,6 +17,8 @@ import {useLogEventReplayStatus} from 'sentry/utils/replays/hooks/useLogEventRep
 import {ReplayPlayerPluginsContextProvider} from 'sentry/utils/replays/playback/providers/replayPlayerPluginsContext';
 import {ReplayPlayerStateContextProvider} from 'sentry/utils/replays/playback/providers/replayPlayerStateContext';
 import {ReplayReaderProvider} from 'sentry/utils/replays/playback/providers/replayReaderProvider';
+import {isNotFoundError} from 'sentry/utils/requestError/requestError';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {FluidHeight} from 'sentry/views/explore/replays/detail/layout/fluidHeight';
 
 interface Props {
@@ -31,6 +34,8 @@ export function ReplayClipPreviewPlayer({
   replayReaderResult,
   overlayContent,
 }: Props) {
+  const organization = useOrganization();
+
   useLogEventReplayStatus({
     readerResult: replayReaderResult,
   });
@@ -41,21 +46,28 @@ export function ReplayClipPreviewPlayer({
       renderArchived={() => (
         <ArchivedReplayAlert message={t('The replay for this event has been deleted.')} />
       )}
-      renderError={({onRetry}) => (
-        <Alert.Container>
-          <Alert
-            variant="danger"
-            data-test-id="replay-error"
-            trailingItems={
-              <Button size="xs" onClick={onRetry}>
-                {t('Retry')}
-              </Button>
-            }
-          >
-            {t('There was an error loading the replay.')}
-          </Alert>
-        </Alert.Container>
-      )}
+      renderError={({fetchError, attachmentError, onRetry}) => {
+        // 404s capture most common reasons for a replay not being available
+        if (isNotFoundError(fetchError) || attachmentError?.some(isNotFoundError)) {
+          return <MissingReplayAlert orgSlug={organization.slug} />;
+        }
+
+        return (
+          <Alert.Container>
+            <Alert
+              variant="danger"
+              data-test-id="replay-error"
+              trailingItems={
+                <Button size="xs" onClick={onRetry}>
+                  {t('Retry')}
+                </Button>
+              }
+            >
+              {t('There was an error loading the replay.')}
+            </Alert>
+          </Alert.Container>
+        );
+      }}
       renderLoading={() => (
         <StyledNegativeSpaceContainer data-test-id="replay-loading-placeholder">
           <LoadingIndicator />

--- a/static/app/components/replays/alerts/missingReplayAlert.tsx
+++ b/static/app/components/replays/alerts/missingReplayAlert.tsx
@@ -52,10 +52,12 @@ export function MissingReplayAlert({orgSlug}: Props) {
         }
       >
         {tct(
-          "The replay associated with this event cannot be found. In most cases, the replay wasn't accepted because your replay quota was exceeded at the time. To learn more, [link:read our docs].",
+          "A replay isn't available for this event. To learn more, [statsLink:check your replay usage].",
           {
-            link: (
-              <ExternalLink href="https://docs.sentry.io/platforms/javascript/session-replay/#error-linking" />
+            statsLink: (
+              <Link
+                to={normalizeUrl(`/settings/${orgSlug}/stats/?dataCategory=replays`)}
+              />
             ),
           }
         )}

--- a/static/app/utils/requestError/requestError.tsx
+++ b/static/app/utils/requestError/requestError.tsx
@@ -104,3 +104,11 @@ export interface RateLimitError extends RequestError {
 export function isRateLimitError(error: unknown): error is RateLimitError {
   return error instanceof RequestError && error.status === 429;
 }
+
+export interface NotFoundError extends RequestError {
+  status: 404;
+}
+
+export function isNotFoundError(error: unknown): error is NotFoundError {
+  return error instanceof RequestError && error.status === 404;
+}


### PR DESCRIPTION
This PR adjusts the replay error message displayed in the issues details page when a replay isn't found.

Replays can fail to exist in a database for many reasons: never recorded, recorded but was never delivered, fail to save after recorded, stored but stale, side-effects of rate limits, etc. This can happen for a lot of reasons. A tailored message explaining the situation better without the loud red colour would probably be a better experience.

This PR adds + adjusts that tailored message, pointing the customer to the replays stats page for further information. We do retain the error message when we experience legit 500's.

Before
<img width="1499" height="139" alt="Screenshot 2026-07-30 at 7 29 31 PM" src="https://github.com/user-attachments/assets/97179198-5a57-4fb7-89a1-7a8dfbaa910b" />

After
<img width="873" height="248" alt="Screenshot 2026-07-30 at 7 29 46 PM" src="https://github.com/user-attachments/assets/19a22e70-468a-4074-bf6f-449649cf5c03" />

Closes REPLAY-945