### PR TITLE
fix(issues): Normalize the PR label in the issue stream

### DIFF
--- a/static/app/components/events/autofix/pullRequests.spec.ts
+++ b/static/app/components/events/autofix/pullRequests.spec.ts
@@ -1,0 +1,78 @@
+import {
+  getCodingAgentResultLink,
+  getRepoPullRequestLink,
+} from 'sentry/components/events/autofix/pullRequests';
+import type {
+  ExplorerCodingAgentState,
+  RepoPRState,
+} from 'sentry/views/seerExplorer/types';
+
+type CodingAgentResult = NonNullable<ExplorerCodingAgentState['results']>[number];
+
+function makeResult(result: Partial<CodingAgentResult> = {}): CodingAgentResult {
+  return {
+    description: 'Fixed',
+    repo_full_name: 'org/repo',
+    repo_provider: 'github',
+    pr_number: null,
+    pr_url: null,
+    ...result,
+  };
+}
+
+function makeRepoPRState(state: Partial<RepoPRState> = {}): RepoPRState {
+  return {
+    branch_name: 'seer/fix',
+    commit_sha: 'abc123',
+    pr_creation_error: null,
+    pr_creation_status: 'completed',
+    pr_id: 1,
+    pr_number: 7,
+    pr_url: 'https://github.com/org/repo/pull/7',
+    repo_name: 'org/repo',
+    title: 'Fix it',
+    ...state,
+  };
+}
+
+describe('getCodingAgentResultLink', () => {
+  it('names the PR when the result carries a number', () => {
+    expect(
+      getCodingAgentResultLink(
+        makeResult({pr_number: 99, pr_url: 'https://github.com/org/repo/pull/99'})
+      )
+    ).toEqual({label: 'View org/repo#99', url: 'https://github.com/org/repo/pull/99'});
+  });
+
+  it.each([
+    ['a pull request', 'https://github.com/org/repo/pull/99'],
+    ['a pushed branch', 'https://github.com/org/repo/tree/my-branch'],
+  ])('names the repo alone for %s recorded without a number', (_case, pr_url) => {
+    expect(getCodingAgentResultLink(makeResult({pr_url}))).toEqual({
+      label: 'View org/repo',
+      url: pr_url,
+    });
+  });
+
+  it('returns null when the agent reported no URL', () => {
+    expect(getCodingAgentResultLink(makeResult())).toBeNull();
+  });
+});
+
+describe('getRepoPullRequestLink', () => {
+  it('names the PR Seer opened', () => {
+    expect(getRepoPullRequestLink(makeRepoPRState())).toEqual({
+      label: 'View org/repo#7',
+      url: 'https://github.com/org/repo/pull/7',
+    });
+  });
+
+  it.each([
+    ['creation has not finished', {pr_creation_status: 'creating' as const}],
+    ['creation errored', {pr_creation_status: 'error' as const}],
+    ['there is no URL', {pr_url: null}],
+    ['there is no number', {pr_number: null}],
+  ])('returns null when %s', (_case, state) => {
+    expect(getRepoPullRequestLink(makeRepoPRState(state))).toBeNull();
+  });
+});

--- a/static/app/components/events/autofix/pullRequests.ts
+++ b/static/app/components/events/autofix/pullRequests.ts
@@ -1,4 +1,5 @@
 import {t} from 'sentry/locale';
+import {defined} from 'sentry/utils/defined';
 import type {
   ExplorerCodingAgentState,
   RepoPRState,
@@ -35,8 +36,8 @@ export function getRepoPullRequestLink(state: RepoPRState): AutofixResultLink | 
 /**
  * What a coding agent produced, or null if it reported no URL.
  *
- * `auto_create_pr=false` pushes a branch instead of opening a PR and `pr_url` holds
- * either, so the two are told apart by URL shape.
+ * `pr_url` holds a pushed branch rather than a PR when the agent ran with
+ * `auto_create_pr=false`, and results predating `pr_number` carry no number either way.
  */
 export function getCodingAgentResultLink(
   result: CodingAgentResult
@@ -46,7 +47,9 @@ export function getCodingAgentResultLink(
   }
 
   return {
-    label: result.pr_url.includes('/tree/') ? t('View Branch') : t('View Pull Request'),
+    label: defined(result.pr_number)
+      ? t('View %s#%s', result.repo_full_name, result.pr_number)
+      : t('View %s', result.repo_full_name),
     url: result.pr_url,
   };
 }

--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -1821,6 +1821,7 @@ describe('ArtifactCard', () => {
                     description: 'Fixed',
                     repo_full_name: 'org/repo',
                     repo_provider: 'github',
+                    pr_number: 99,
                     pr_url: 'https://github.com/org/repo/pull/99',
                   },
                 ],
@@ -1830,7 +1831,7 @@ describe('ArtifactCard', () => {
         />
       );
 
-      const link = screen.getByRole('button', {name: 'View Pull Request'});
+      const link = screen.getByRole('button', {name: 'View org/repo#99'});
       expect(link).toHaveAttribute('href', 'https://github.com/org/repo/pull/99');
     });
 

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -727,6 +727,48 @@ describe('InboxPage', () => {
     ).toHaveAttribute('href', 'https://github.com/org/repository/pull/10');
   });
 
+  it('labels a coding agent pull request like a Seer one', async () => {
+    // A delegated agent's PR arrives under coding_agents rather than repo_pr_states.
+    mockSuccessfulSections();
+    mockIssuePreview();
+    mockAutofixResponse(
+      ExplorerAutofixResponseFixture({
+        autofix: ExplorerAutofixStateFixture({
+          coding_agents: {
+            'agent-1': {
+              id: 'agent-1',
+              name: 'Cursor',
+              provider: 'cursor_background_agent',
+              started_at: '2024-01-01T00:00:00Z',
+              status: 'completed',
+              results: [
+                {
+                  description: 'Fixed',
+                  repo_full_name: 'org/repository',
+                  repo_provider: 'github',
+                  pr_number: 649,
+                  pr_url: 'https://github.com/org/repository/pull/649',
+                },
+              ],
+            },
+          },
+        }),
+      })
+    );
+
+    render(<InboxPage />, {
+      organization: seerOrganization,
+      initialRouterConfig,
+    });
+
+    const preview = await openFixProposedPreview();
+    expect(
+      await within(preview).findByRole('button', {
+        name: 'View org/repository#649',
+      })
+    ).toHaveAttribute('href', 'https://github.com/org/repository/pull/649');
+  });
+
   it('retries a failed Autofix pull request', async () => {
     mockSuccessfulSections();
     mockIssuePreview();


### PR DESCRIPTION
We had a discrepancy between our UI when showing seer-opened PRs vs coding agent handoff opened PRs. With `pr_number` now on coding agent responses, we can now put it on:
Before:
<img width="362" height="119" alt="Screenshot 2026-08-03 at 12 04 18 PM" src="https://github.com/user-attachments/assets/06e058d2-a957-4edf-b978-aa6dbe062c07" />
After:
<img width="335" height="123" alt="Screenshot 2026-08-03 at 12 04 25 PM" src="https://github.com/user-attachments/assets/07762e17-d14a-4d68-b2d6-ae4118b3428b" />

I don't plan to backfill old `pr_numbers`, but this will resolve the problem for new runs.
Fixes ISWF-3145.
