### PR TITLE
ref(sentry-apps): gate webhook delivery on the app's own events

### DIFF
--- a/src/sentry/sentry_apps/metrics.py
+++ b/src/sentry/sentry_apps/metrics.py
@@ -57,7 +57,8 @@ class SentryAppWebhookFailureReason(StrEnum):
     MISSING_EVENT = "missing_event"
     INVALID_EVENT = "invalid_event"
     MISSING_SERVICEHOOK = "missing_servicehook"
-    EVENT_NOT_IN_SERVCEHOOK = "event_not_in_servicehook"
+    # Value differs from the member name: dashboards and alerts query the string.
+    EVENT_NOT_SUBSCRIBED = "event_not_in_servicehook"
     MISSING_ISSUE_OCCURRENCE = "missing_issue_occurrence"
     MISSING_USER = "missing_user"
     MULTIPLE_INSTALLATIONS = "multiple_installations"

--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -796,7 +796,6 @@ def send_webhooks(installation: RpcSentryAppInstallation, event: str, **kwargs: 
             installation.organization_id, installation.id
         )
         if not servicehook:
-            lifecycle.add_extra("events", installation.sentry_app.events)
             lifecycle.add_extras(
                 {
                     "installation_uuid": installation.uuid,
@@ -808,19 +807,16 @@ def send_webhooks(installation: RpcSentryAppInstallation, event: str, **kwargs: 
                 }
             )
             raise SentryAppSentryError(message=SentryAppWebhookFailureReason.MISSING_SERVICEHOOK)
-        if event not in servicehook.events:
+        if not is_subscribed(installation.sentry_app.events, event):
             lifecycle.add_extras(
                 {
-                    "events": servicehook.events,
                     "event": event,
                     "installation_id": installation.id,
-                    "sentry_app_id": installation.sentry_app.id,
-                    "sentry_app_events": installation.sentry_app.events,
+                    "sentry_app": installation.sentry_app.id,
+                    "events": installation.sentry_app.events,
                 }
             )
-            raise SentryAppSentryError(
-                message=SentryAppWebhookFailureReason.EVENT_NOT_IN_SERVCEHOOK
-            )
+            raise SentryAppSentryError(message=SentryAppWebhookFailureReason.EVENT_NOT_SUBSCRIBED)
 
         # TODO(nola): This is disabled for now, because it could potentially affect internal integrations w/ error.created
         # # If the event is error.created & the request is going out to the Org that owns the Sentry App,

--- a/src/sentry/sentry_apps/utils/webhooks.py
+++ b/src/sentry/sentry_apps/utils/webhooks.py
@@ -124,12 +124,6 @@ EVENT_TO_RESOURCE: Final[dict[str, SentryAppResourceType]] = {
     event: resource for resource, events in EVENT_EXPANSION.items() for event in events
 }
 
-# Renamed events were never migrated in stored subscriptions, so old and new
-# names are equivalent when matching an exact subscription.
-_LEGACY_EVENT_ALIASES: Final[dict[str, str]] = {
-    SentryAppEventType.ISSUE_IGNORED: SentryAppEventType.ISSUE_ARCHIVED,
-}
-
 
 def resource_of(event: str) -> SentryAppResourceType | None:
     """The resource a subscribable event belongs to ("issue.resolved" -> ISSUE), else None."""
@@ -148,15 +142,20 @@ def is_subscribed(stored_events: Collection[str], event: str) -> bool:
     """
     Whether a stored subscription covers a fired event.
 
-    Only the exact event matches (plus its legacy alias, for installs that
-    stored the pre-rename name). Subscribing to a whole resource stores every
-    event it expands to, so resource-level subscriptions match all of that
-    resource's events by construction.
+    Only the exact event matches, under either of its names. Subscribing to a whole
+    resource stores every event it expands to, so resource-level subscriptions match
+    all of that resource's events by construction.
     """
+    # issue.archived was added alongside issue.ignored rather than replacing it, and
+    # neither dispatch nor stored subscriptions were consolidated onto one name, so
+    # either name on either side means the same event.
+    aliases = (SentryAppEventType.ISSUE_IGNORED, SentryAppEventType.ISSUE_ARCHIVED)
+    if event in aliases:
+        return any(name in aliases for name in stored_events)
+
     if resource_of(event) is None:
         return False
-    alias = _LEGACY_EVENT_ALIASES.get(event)
-    return event in stored_events or (alias is not None and alias in stored_events)
+    return event in stored_events
 
 
 def find_alert_rule_action_ui_component(

--- a/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
@@ -1329,9 +1329,12 @@ class TestSendResourceChangeWebhook(TestCase):
             mock_record=mock_record, outcome=EventLifecycleOutcome.SUCCESS, outcome_count=13
         )
 
+    @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen", return_value=MockResponseInstance)
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @with_feature("organizations:integrations-event-hooks")
-    def test_sends_webhooks_with_send_webhook_sentry_failure(self, mock_record: MagicMock) -> None:
+    def test_sends_webhooks_with_stale_service_hook_events(
+        self, mock_record: MagicMock, safe_urlopen: MagicMock
+    ) -> None:
         self.project = self.create_project()
         self.sentry_app_1 = self.create_sentry_app(
             organization=self.project.organization,
@@ -1371,18 +1374,19 @@ class TestSendResourceChangeWebhook(TestCase):
                 eventstream_type=EventStreamEventType.Error.value,
             )
 
+        # ServiceHook.events is a denormalized copy that the outbox may not have
+        # caught up on yet; delivery follows the app's own subscriptions.
+        ((_, kwargs),) = safe_urlopen.call_args_list
+        assert kwargs["url"] == self.sentry_app_1.webhook_url
+
         assert_success_metric(mock_record)
         # APP_CREATE (success) -> UPDATE_WEBHOOK (success) -> GRANT_EXCHANGER (success) ->
-        # PREPARE_WEBHOOK (failure, exception propagates from send_resource_change_webhook) ->
-        # SEND_WEBHOOK (success) x 1 -> SEND_WEBHOOK (failure)
+        # PREPARE_WEBHOOK (success) -> SEND_WEBHOOK (success) x 3
         assert_count_of_metric(
-            mock_record=mock_record, outcome=EventLifecycleOutcome.STARTED, outcome_count=6
+            mock_record=mock_record, outcome=EventLifecycleOutcome.STARTED, outcome_count=7
         )
         assert_count_of_metric(
-            mock_record=mock_record, outcome=EventLifecycleOutcome.SUCCESS, outcome_count=4
-        )
-        assert_count_of_metric(
-            mock_record=mock_record, outcome=EventLifecycleOutcome.FAILURE, outcome_count=2
+            mock_record=mock_record, outcome=EventLifecycleOutcome.SUCCESS, outcome_count=7
         )
 
 
@@ -1695,7 +1699,7 @@ class TestWorkflowNotification(TestCase):
 
         # SLO assertions
         assert_failure_metric(
-            mock_record, SentryAppSentryError(SentryAppWebhookFailureReason.EVENT_NOT_IN_SERVCEHOOK)
+            mock_record, SentryAppSentryError(SentryAppWebhookFailureReason.EVENT_NOT_SUBSCRIBED)
         )
         # APP_CREATE (success) -> UPDATE_WEBHOOK (success) -> GRANT_EXCHANGER (success) -> PREPARE_WEBHOOK (success) -> SEND_WEBHOOK (failure)
         assert_count_of_metric(
@@ -1707,6 +1711,24 @@ class TestWorkflowNotification(TestCase):
         assert_count_of_metric(
             mock_record=mock_record, outcome=EventLifecycleOutcome.FAILURE, outcome_count=1
         )
+
+    def test_sends_webhook_to_install_subscribed_as_issue_archived(
+        self, safe_urlopen: MagicMock
+    ) -> None:
+        sentry_app = self.create_sentry_app(
+            name="Legacy App",
+            organization=self.project.organization,
+            events=["issue.archived"],
+        )
+        install = self.create_sentry_app_installation(
+            organization=self.project.organization, slug=sentry_app.slug
+        )
+
+        workflow_notification(install.id, self.issue.id, "archived", self.user.id)
+
+        ((_, kwargs),) = safe_urlopen.call_args_list
+        assert kwargs["url"] == sentry_app.webhook_url
+        assert json.loads(kwargs["data"])["action"] == "archived"
 
 
 class TestWebhookRequests(TestCase):

--- a/tests/sentry/sentry_apps/test_webhooks.py
+++ b/tests/sentry/sentry_apps/test_webhooks.py
@@ -25,9 +25,13 @@ def test_is_subscribed_matches_exact_event() -> None:
     assert not is_subscribed(["issue.ignored"], "issue.resolved")
     assert not is_subscribed(["error.created"], "issue.resolved")
     assert not is_subscribed([], "issue.resolved")
-    # Legacy installs that stored the pre-rename name still match issue.ignored.
+    # Legacy installs that stored the pre-rename name still match issue.ignored,
+    # and the legacy name matches when it is the one dispatched.
     assert is_subscribed(["issue.archived"], "issue.ignored")
+    assert is_subscribed(["issue.ignored"], "issue.archived")
+    assert is_subscribed(["issue.archived"], "issue.archived")
     assert not is_subscribed(["issue.archived"], "issue.resolved")
+    assert not is_subscribed(["issue.resolved"], "issue.archived")
     # Events whose resource has no subscribable events never match.
     assert not is_subscribed(["metric_alert.open"], "metric_alert.critical")
 


### PR DESCRIPTION
send_webhooks gated delivery on ServiceHook.events, a denormalized copy of SentryApp.events. Both are written by expand_events, which is idempotent, so the two lists are identical -- the copy only adds a way for delivery to disagree with the callers that already filtered on the app's events. Read the app's events directly so subscription state has one source of truth.

Keeps the raw membership test rather than reusing is_subscribed: that helper returns False for any event absent from EVENT_EXPANSION, which includes issue.archived, the name send_workflow_webhooks dispatches to installs still subscribed under it.

ServiceHook.events stays: the legacy project-servicehook path still reads it.

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
