### PR TITLE
chore: Bump sentry-protos to 0.55.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ dependencies = [
   "sentry-ophio>=1.1.3",
   # sentry-options is only used in getsentry for now
   "sentry-options>=1.1.2",
-  "sentry-protos>=0.53.1",
+  "sentry-protos>=0.55.0",
   "sentry-redis-tools>=0.5.0",
   "sentry-relay>=0.9.27",
   "sentry-scm>=1.3.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2411,7 +2411,7 @@ requires-dist = [
     { name = "sentry-kafka-schemas", specifier = ">=2.2.0" },
     { name = "sentry-ophio", specifier = ">=1.1.3" },
     { name = "sentry-options", specifier = ">=1.1.2" },
-    { name = "sentry-protos", specifier = ">=0.53.1" },
+    { name = "sentry-protos", specifier = ">=0.55.0" },
     { name = "sentry-redis-tools", specifier = ">=0.5.0" },
     { name = "sentry-relay", specifier = ">=0.9.27" },
     { name = "sentry-scm", specifier = ">=1.3.0" },
@@ -2595,7 +2595,7 @@ wheels = [
 
 [[package]]
 name = "sentry-protos"
-version = "0.53.1"
+version = "0.55.0"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 dependencies = [
     { name = "grpc-stubs" },
@@ -2603,7 +2603,7 @@ dependencies = [
     { name = "protobuf" },
 ]
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_protos-0.53.1-py3-none-any.whl", hash = "sha256:c8f33021e11a1a4e2816a719f7b3c33f875e946c57fd0f77484c3b880a297728" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_protos-0.55.0-py3-none-any.whl", hash = "sha256:4bf9fad4d51f05a907138c8e8f5e2f5b73b58a8ea77d501e5a5c1c84e0bfc548" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bumps `sentry-protos` from `0.53.1` to `0.55.0` for `has_remaining_capacity` on usage pricer summaries (needed by getsentry quota-unblock work).

## Test plan
- [ ] CI installs `sentry-protos==0.55.0`
- [ ] No unrelated lockfile churn


Made with [Cursor](https://cursor.com)