### PR TITLE
fix(action log): Handle stranded derived status

### DIFF
--- a/src/sentry/issues/derived/processing.py
+++ b/src/sentry/issues/derived/processing.py
@@ -12,7 +12,7 @@ from django.utils import timezone
 from sentry.issues.derived.aggregators import AGGREGATORS
 from sentry.issues.derived.framework import Pipeline
 from sentry.issues.derived.store import GroupDerivedDataStore
-from sentry.issues.derived.tasks import process_group_log_task
+from sentry.issues.derived.tasks import generate_group_derived_data, process_group_log_task
 from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
 from sentry.issues.models.groupderiveddata import EPOCH, GroupDerivedData
 from sentry.models.group import Group
@@ -475,26 +475,33 @@ def invalidate_group_derived_data(
     group_id: int,
     cursor: tuple[datetime, int] | None = None,
 ) -> None:
-    """Delete derived state so it is rebuilt from scratch on the next pass,
-    then kicks off an async task to regenerate the derived data.
+    """Force derived state to be rebuilt from scratch via a full regeneration.
+
+    Uses ``generate_group_derived_data`` (a full rebuild from EPOCH that
+    promotes over the current row via a ``generated_at`` CAS) rather than
+    incremental processing: the entries prompting invalidation may be *behind*
+    the row's cursor (e.g. backfilled with a historical ``date_added``), and
+    incremental processing only reads entries ahead of the cursor, so it would
+    never pick them up.
 
     If *cursor* is ``(date_added, id)`` of the earliest affected entry, the
-    row is only deleted when its cursor is at or past that point; otherwise
-    the mutation is still ahead of processing and no invalidation is needed.
-    Without a cursor the invalidation is unconditional.
+    rebuild is only scheduled when the row has already processed past that
+    point; otherwise the entries are still ahead of the cursor and normal
+    incremental processing will pick them up. Without a cursor the row is
+    deleted first (the log may have shrunk, e.g. via merge) and rebuilt
+    unconditionally.
     """
     if cursor is None:
         GroupDerivedData.objects.filter(group_id=group_id).delete()
-        process_group_log_task.delay(group_id)
+        generate_group_derived_data.delay(group_id)
         return
 
-    # Only invalidate if the row has already processed past the affected point.
     cursor_date, cursor_id = cursor
-    deleted, _ = GroupDerivedData.objects.filter(
+    needs_rebuild = GroupDerivedData.objects.filter(
         Q(group_id=group_id)
         & (Q(cursor_date__gt=cursor_date) | Q(cursor_date=cursor_date, cursor_id__gte=cursor_id)),
-    ).delete()
-    if deleted:
+    ).exists()
+    if needs_rebuild:
         logger.info(
             "issues.derived.invalidated",
             extra={
@@ -503,4 +510,4 @@ def invalidate_group_derived_data(
                 "cursor_id": cursor_id,
             },
         )
-        process_group_log_task.delay(group_id)
+        generate_group_derived_data.delay(group_id)

--- a/tests/sentry/issues/derived/test_processing.py
+++ b/tests/sentry/issues/derived/test_processing.py
@@ -287,14 +287,17 @@ class ProcessGroupLogTest(TestCase):
         invalidate_group_derived_data(group.id)
         assert not GroupDerivedData.objects.filter(group_id=group.id).exists()
 
-    def test_invalidate_with_cursor_deletes_if_past(self) -> None:
+    def test_invalidate_with_cursor_rebuilds_if_past(self) -> None:
         group = self.create_group()
         _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
         derived = process_group_log(group.id)
 
-        # Cursor at the processed entry — row should be deleted.
-        invalidate_group_derived_data(group.id, cursor=(derived.cursor_date, derived.cursor_id))
-        assert not GroupDerivedData.objects.filter(group_id=group.id).exists()
+        # Cursor at the processed entry — a full rebuild is scheduled (the row is
+        # left in place; the rebuild promotes over it).
+        with patch("sentry.issues.derived.processing.generate_group_derived_data") as mock_generate:
+            invalidate_group_derived_data(group.id, cursor=(derived.cursor_date, derived.cursor_id))
+        mock_generate.delay.assert_called_once_with(group.id)
+        assert GroupDerivedData.objects.filter(group_id=group.id).exists()
 
     def test_invalidate_with_cursor_noop_if_not_reached(self) -> None:
         group = self.create_group()


### PR DESCRIPTION
While looking at the logs for [reconciliation divergence](https://github.com/getsentry/sentry/blob/master/src/sentry/issues/endpoints/group_details.py#L158) I found an issue that is closed but the derived data suggests it's open. In this case it was because the cursor was ahead from the view actions and we weren't ever replaying the history to determine the issue status. This PR addresses that by updating the backfill task's invalidation to regenerate the group derived data.