### PR TITLE
fix(explore): Block transactions from Explore > Errors

### DIFF
--- a/static/app/views/discover/results.spec.tsx
+++ b/static/app/views/discover/results.spec.tsx
@@ -1535,4 +1535,92 @@ describe('Results', () => {
       ).toBeInTheDocument();
     });
   });
+
+  describe('transactions deprecation', () => {
+    const deprecationFeatures = [
+      'discover-basic',
+      'deprecate-discover',
+      'discover-saved-queries-deprecation',
+    ];
+
+    it('blocks the transactions dataset and points users to Explore', async () => {
+      const organization = OrganizationFixture({features: deprecationFeatures});
+
+      const mockRequests = renderMockRequests();
+
+      ProjectsStore.loadInitialData([ProjectFixture()]);
+
+      render(<Results />, {
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/explore/errors/results/`,
+            query: {...generateFields(), queryDataset: 'transaction-like'},
+          },
+          route: '/organizations/:orgId/explore/errors/results/',
+        },
+        organization,
+      });
+
+      const link = await screen.findByRole('link', {name: 'Explore Queries'});
+      expect(link).toHaveAttribute('href', '/explore/saved-queries/');
+
+      expect(mockRequests.eventsResultsMock).not.toHaveBeenCalled();
+      expect(mockRequests.eventsStatsMock).not.toHaveBeenCalled();
+      expect(mockRequests.eventsMetaMock).not.toHaveBeenCalled();
+    });
+
+    it('still renders the table for the errors dataset', async () => {
+      const organization = OrganizationFixture({features: deprecationFeatures});
+
+      const mockRequests = renderMockRequests();
+
+      ProjectsStore.loadInitialData([ProjectFixture()]);
+
+      render(<Results />, {
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/explore/errors/results/`,
+            query: {...generateFields(), queryDataset: 'error-events'},
+          },
+          route: '/organizations/:orgId/explore/errors/results/',
+        },
+        organization,
+      });
+
+      expect(await screen.findByText(eventTitle)).toBeInTheDocument();
+      expect(mockRequests.eventsResultsMock).toHaveBeenCalled();
+      expect(mockRequests.eventsStatsMock).toHaveBeenCalled();
+      await waitFor(() => expect(mockRequests.eventsMetaMock).toHaveBeenCalled());
+      expect(
+        screen.queryByRole('link', {name: 'Explore Queries'})
+      ).not.toBeInTheDocument();
+    });
+
+    it('does not block transactions when the deprecation is disabled', async () => {
+      const organization = OrganizationFixture({features: ['discover-basic']});
+
+      const mockRequests = renderMockRequests();
+
+      ProjectsStore.loadInitialData([ProjectFixture()]);
+
+      render(<Results />, {
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/explore/discover/results/`,
+            query: {...generateFields(), queryDataset: 'transaction-like'},
+          },
+          route: '/organizations/:orgId/explore/discover/results/',
+        },
+        organization,
+      });
+
+      expect(await screen.findByText(eventTitle)).toBeInTheDocument();
+      expect(mockRequests.eventsResultsMock).toHaveBeenCalled();
+      expect(mockRequests.eventsStatsMock).toHaveBeenCalled();
+      await waitFor(() => expect(mockRequests.eventsMetaMock).toHaveBeenCalled());
+      expect(
+        screen.queryByRole('link', {name: 'Explore Queries'})
+      ).not.toBeInTheDocument();
+    });
+  });
 });

--- a/static/app/views/discover/results.tsx
+++ b/static/app/views/discover/results.tsx
@@ -768,7 +768,9 @@ export class Results extends Component<Props, State> {
                   </MetricsCardinalityProvider>
                 )}
               </Top>
-              <Layout.Main width={showTags ? 'twothirds' : 'full'}>
+              <Layout.Main
+                width={showTags && !transactionsUnsupported ? 'twothirds' : 'full'}
+              >
                 {transactionsUnsupported ? (
                   <Alert.Container>
                     <Alert variant="info">

--- a/static/app/views/discover/results.tsx
+++ b/static/app/views/discover/results.tsx
@@ -107,6 +107,7 @@ import {
 import Table from 'sentry/views/discover/table';
 import {
   generateTitle,
+  getDiscoverDeprecation,
   getDiscoverDeprecationEnabled,
   getTransactionsDeprecation,
   handleAddQueryToDashboard,
@@ -371,11 +372,25 @@ export class Results extends Component<Props, State> {
     this.setState({needConfirmation: false, confirmedQuery: false});
   };
 
+  // Transactions are no longer supported in Discover once the deprecation is
+  // fully enabled. A bookmarked saved transactions query can still land directly
+  // on this results page, so hard-block every transactions query (table, chart,
+  // total count, and tags) and point users to their migrated queries instead.
+  isTransactionsUnsupported() {
+    const {organization, location} = this.props;
+    const {savedQueryDataset} = this.state;
+    return (
+      getDiscoverDeprecation(organization) &&
+      getDatasetFromLocationOrSavedQueryDataset(location, savedQueryDataset) ===
+        DiscoverDatasets.TRANSACTIONS
+    );
+  }
+
   async fetchTotalCount() {
     const {api, organization, location, getAiQueryRunId} = this.props;
     const {eventView, confirmedQuery} = this.state;
 
-    if (!confirmedQuery || !eventView.isValid()) {
+    if (!confirmedQuery || !eventView.isValid() || this.isTransactionsUnsupported()) {
       return;
     }
 
@@ -651,6 +666,8 @@ export class Results extends Component<Props, State> {
     } = this.state;
     const hasDatasetSelectorFeature = hasDatasetSelector(organization);
 
+    const transactionsUnsupported = this.isTransactionsUnsupported();
+
     const query = eventView.query;
     const title = this.getDocumentTitle();
     const yAxisArray = getYAxis(location, eventView, savedQuery);
@@ -730,52 +747,67 @@ export class Results extends Component<Props, State> {
                     />
                   )}
                 </CustomMeasurementsContext.Consumer>
-                <MetricsCardinalityProvider
-                  organization={organization}
-                  location={location}
-                >
-                  <ResultsChart
-                    api={api}
+                {!transactionsUnsupported && (
+                  <MetricsCardinalityProvider
+                    organization={organization}
+                    location={location}
+                  >
+                    <ResultsChart
+                      api={api}
+                      organization={organization}
+                      eventView={eventView}
+                      location={location}
+                      onAxisChange={this.handleYAxisChange}
+                      onDisplayChange={this.handleDisplayChange}
+                      onTopEventsChange={this.handleTopEventsChange}
+                      onIntervalChange={this.handleIntervalChange}
+                      total={totalValues}
+                      confirmedQuery={confirmedQuery}
+                      yAxis={yAxisArray}
+                    />
+                  </MetricsCardinalityProvider>
+                )}
+              </Top>
+              <Layout.Main width={showTags ? 'twothirds' : 'full'}>
+                {transactionsUnsupported ? (
+                  <Alert.Container>
+                    <Alert variant="info">
+                      {tct(
+                        'Your saved transactions queries are no longer available in this UI. Try them out in the [exploreLink:Explore Queries] page instead.',
+                        {
+                          exploreLink: <Link to="/explore/saved-queries/" />,
+                        }
+                      )}
+                    </Alert>
+                  </Alert.Container>
+                ) : (
+                  <Table
                     organization={organization}
                     eventView={eventView}
                     location={location}
-                    onAxisChange={this.handleYAxisChange}
-                    onDisplayChange={this.handleDisplayChange}
-                    onTopEventsChange={this.handleTopEventsChange}
-                    onIntervalChange={this.handleIntervalChange}
-                    total={totalValues}
+                    title={title}
+                    setError={this.setError}
+                    onChangeShowTags={this.handleChangeShowTags}
+                    showTags={showTags}
                     confirmedQuery={confirmedQuery}
-                    yAxis={yAxisArray}
+                    onCursor={this.handleCursor}
+                    isHomepage={isHomepage}
+                    setTips={this.setTips}
+                    queryDataset={savedQueryDataset}
+                    setSplitDecision={(value?: SavedQueryDatasets) => {
+                      if (
+                        hasDatasetSelectorFeature &&
+                        value !== SavedQueryDatasets.DISCOVER &&
+                        value !== savedQuery?.dataset
+                      ) {
+                        this.setSplitDecision(value);
+                      }
+                    }}
+                    dataset={hasDatasetSelectorFeature ? eventView.dataset : undefined}
                   />
-                </MetricsCardinalityProvider>
-              </Top>
-              <Layout.Main width={showTags ? 'twothirds' : 'full'}>
-                <Table
-                  organization={organization}
-                  eventView={eventView}
-                  location={location}
-                  title={title}
-                  setError={this.setError}
-                  onChangeShowTags={this.handleChangeShowTags}
-                  showTags={showTags}
-                  confirmedQuery={confirmedQuery}
-                  onCursor={this.handleCursor}
-                  isHomepage={isHomepage}
-                  setTips={this.setTips}
-                  queryDataset={savedQueryDataset}
-                  setSplitDecision={(value?: SavedQueryDatasets) => {
-                    if (
-                      hasDatasetSelectorFeature &&
-                      value !== SavedQueryDatasets.DISCOVER &&
-                      value !== savedQuery?.dataset
-                    ) {
-                      this.setSplitDecision(value);
-                    }
-                  }}
-                  dataset={hasDatasetSelectorFeature ? eventView.dataset : undefined}
-                />
+                )}
               </Layout.Main>
-              {showTags ? (
+              {showTags && !transactionsUnsupported ? (
                 <TagsTable
                   confirmedQuery={confirmedQuery}
                   eventView={eventView}


### PR DESCRIPTION
Some users were still querying transactions via bookmarked Discover queries/saved queries. Now this blocks them with a similar message to the one we have at the top of the Saved Queries screen, directing them to Explore -> Traces.

All Discover saved queries have already been split (always either `errors` or `transactions`, no `discover` - thanks @nikkikapadia!) so no need to handle that case.

Fixes BROWSE-668.

<img width="928" height="411" alt="Screenshot 2026-07-30 at 14 13 47" src="https://github.com/user-attachments/assets/23da3fc7-6117-4158-9110-3dd98174e748" />
