### PR TITLE
feat(sentry-apps): add external-issue webhook events

### DIFF
--- a/src/sentry/issues/endpoints/group_integration_details.py
+++ b/src/sentry/issues/endpoints/group_integration_details.py
@@ -64,7 +64,12 @@ from sentry.shared_integrations.exceptions import (
     IntegrationFormError,
     IntegrationProviderError,
 )
-from sentry.signals import integration_issue_created, integration_issue_linked
+from sentry.signals import (
+    external_issue_created,
+    external_issue_linked,
+    integration_issue_created,
+    integration_issue_linked,
+)
 from sentry.types.activity import ActivityType
 from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
@@ -363,6 +368,14 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
             actor=actor,
         )
 
+        external_issue_created.send_robust(
+            project=group.project,
+            group=group,
+            user=request.user,
+            external_issue=external_issue,
+            sender=self.__class__,
+        )
+
         # TODO(jess): return serialized issue
         url = data.get("url") or installation.get_issue_url(external_issue.key)
         context = {
@@ -519,6 +532,14 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
             group_id=group.id,
             project=group.project,
             actor=actor,
+        )
+
+        external_issue_linked.send_robust(
+            project=group.project,
+            group=group,
+            user=request.user,
+            external_issue=external_issue,
+            sender=self.__class__,
         )
 
         # TODO(jess): would be helpful to return serialized external issue

--- a/src/sentry/receivers/sentry_apps.py
+++ b/src/sentry/receivers/sentry_apps.py
@@ -1,21 +1,37 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping
 from typing import Any
 
+from django.core.exceptions import ObjectDoesNotExist
+
+from sentry.api.serializers import serialize
 from sentry.hybridcloud.rpc import coerce_id_from
+from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.models.group import Group
 from sentry.models.groupassignee import GroupAssignee
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.team import Team
+from sentry.sentry_apps.event_types import SentryAppEventType
+from sentry.sentry_apps.external_issues.kinds import ExternalIssueKind
+from sentry.sentry_apps.external_issues.types import ExternalIssueTrigger
+from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
 from sentry.sentry_apps.services.app import RpcSentryAppInstallation, app_service
-from sentry.sentry_apps.tasks.sentry_apps import build_comment_webhook, workflow_notification
+from sentry.sentry_apps.tasks.sentry_apps import (
+    build_comment_webhook,
+    build_external_issue_webhook,
+    is_project_allowed,
+    workflow_notification,
+)
 from sentry.sentry_apps.utils.webhooks import is_subscribed
 from sentry.signals import (
     comment_created,
     comment_deleted,
     comment_updated,
+    external_issue_created,
+    external_issue_linked,
     issue_assigned,
     issue_escalating,
     issue_ignored,
@@ -24,6 +40,8 @@ from sentry.signals import (
 )
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
+
+logger = logging.getLogger(__name__)
 
 
 @issue_assigned.connect(weak=False)
@@ -111,6 +129,66 @@ def send_comment_updated_webhook(project, user, group, data, **kwargs):
 @comment_deleted.connect(weak=False)
 def send_comment_deleted_webhook(project, user, group, data, **kwargs):
     send_comment_webhooks(project.organization, group, user, "comment.deleted", data=data)
+
+
+@external_issue_created.connect(weak=False)
+def send_external_issue_created_webhook(
+    project, group, user, external_issue, triggered_by=None, **kwargs
+):
+    event = SentryAppEventType.ISSUE_EXTERNAL_ISSUE_CREATED
+    send_external_issue_webhooks(project, group, user, external_issue, event, triggered_by)
+
+
+@external_issue_linked.connect(weak=False)
+def send_external_issue_linked_webhook(
+    project, group, user, external_issue, triggered_by=None, **kwargs
+):
+    event = SentryAppEventType.ISSUE_EXTERNAL_ISSUE_LINKED
+    send_external_issue_webhooks(project, group, user, external_issue, event, triggered_by)
+
+
+def send_external_issue_webhooks(
+    project: Project,
+    issue: Group,
+    user: User | RpcUser | None,
+    external_issue: ExternalIssue | PlatformExternalIssue,
+    event: SentryAppEventType,
+    triggered_by: ExternalIssueTrigger | None,
+) -> None:
+    installations = [
+        install
+        for install in installations_to_notify(project.organization, event)
+        if is_project_allowed(install, project.id)
+    ]
+    if not installations:
+        return
+
+    external_issue_kind = ExternalIssueKind.of(external_issue)
+    try:
+        external_issue = external_issue_kind.fetch(external_issue_id=external_issue.id, group=issue)
+    except ObjectDoesNotExist:
+        logger.info(
+            "sentry_app.external_issue_webhook.missing_external_issue",
+            extra={
+                "external_issue_id": external_issue.id,
+                "external_issue_kind": external_issue_kind,
+                "group_id": issue.id,
+                "project_id": project.id,
+            },
+        )
+        return
+
+    external_issue_data: dict[str, Any] = serialize(external_issue)
+    for install in installations:
+        build_external_issue_webhook.delay(
+            installation_id=install.id,
+            issue_id=issue.id,
+            type=event,
+            user_id=coerce_id_from(user),
+            external_issue=external_issue_data,
+            external_issue_kind=external_issue_kind,
+            triggered_by=triggered_by,
+        )
 
 
 def send_comment_webhooks(organization, issue, user, event, data=None):

--- a/src/sentry/receivers/sentry_apps.py
+++ b/src/sentry/receivers/sentry_apps.py
@@ -3,19 +3,32 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
+from sentry.api.serializers import serialize
 from sentry.hybridcloud.rpc import coerce_id_from
+from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.models.group import Group
 from sentry.models.groupassignee import GroupAssignee
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.team import Team
+from sentry.sentry_apps.event_types import SentryAppEventType
+from sentry.sentry_apps.external_issues.kinds import ExternalIssueKind
+from sentry.sentry_apps.external_issues.types import ExternalIssueTrigger
+from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
 from sentry.sentry_apps.services.app import RpcSentryAppInstallation, app_service
-from sentry.sentry_apps.tasks.sentry_apps import build_comment_webhook, workflow_notification
+from sentry.sentry_apps.tasks.sentry_apps import (
+    build_comment_webhook,
+    build_external_issue_webhook,
+    is_project_allowed,
+    workflow_notification,
+)
 from sentry.sentry_apps.utils.webhooks import is_subscribed
 from sentry.signals import (
     comment_created,
     comment_deleted,
     comment_updated,
+    external_issue_created,
+    external_issue_linked,
     issue_assigned,
     issue_escalating,
     issue_ignored,
@@ -111,6 +124,53 @@ def send_comment_updated_webhook(project, user, group, data, **kwargs):
 @comment_deleted.connect(weak=False)
 def send_comment_deleted_webhook(project, user, group, data, **kwargs):
     send_comment_webhooks(project.organization, group, user, "comment.deleted", data=data)
+
+
+@external_issue_created.connect(weak=False)
+def send_external_issue_created_webhook(
+    project, group, user, external_issue, triggered_by=None, **kwargs
+):
+    event = SentryAppEventType.ISSUE_EXTERNAL_ISSUE_CREATED
+    send_external_issue_webhooks(project, group, user, external_issue, event, triggered_by)
+
+
+@external_issue_linked.connect(weak=False)
+def send_external_issue_linked_webhook(
+    project, group, user, external_issue, triggered_by=None, **kwargs
+):
+    event = SentryAppEventType.ISSUE_EXTERNAL_ISSUE_LINKED
+    send_external_issue_webhooks(project, group, user, external_issue, event, triggered_by)
+
+
+def send_external_issue_webhooks(
+    project: Project,
+    issue: Group,
+    user: User | RpcUser | None,
+    external_issue: ExternalIssue | PlatformExternalIssue,
+    event: SentryAppEventType,
+    triggered_by: ExternalIssueTrigger | None,
+) -> None:
+    installations = [
+        install
+        for install in installations_to_notify(project.organization, event)
+        if is_project_allowed(install, project.id)
+    ]
+    if not installations:
+        return
+
+    external_issue_kind = ExternalIssueKind.of(external_issue)
+    external_issue = external_issue_kind.fetch(external_issue.id, group=issue)
+    external_issue_data: dict[str, Any] = serialize(external_issue)
+    for install in installations:
+        build_external_issue_webhook.delay(
+            installation_id=install.id,
+            issue_id=issue.id,
+            type=event,
+            user_id=coerce_id_from(user),
+            external_issue=external_issue_data,
+            external_issue_kind=external_issue_kind,
+            triggered_by=triggered_by,
+        )
 
 
 def send_comment_webhooks(organization, issue, user, event, data=None):

--- a/src/sentry/rules/actions/integrations/create_ticket/utils.py
+++ b/src/sentry/rules/actions/integrations/create_ticket/utils.py
@@ -21,6 +21,7 @@ from sentry.issues.action_log.types import SYSTEM_ACTOR, ActionSource, CreateExt
 from sentry.models.activity import Activity
 from sentry.models.grouplink import GroupLink
 from sentry.notifications.utils.links import create_link_to_workflow
+from sentry.sentry_apps.external_issues.types import ExternalIssueTrigger
 from sentry.services.eventstore.models import GroupEvent
 from sentry.shared_integrations.exceptions import (
     ApiUnauthorized,
@@ -29,11 +30,27 @@ from sentry.shared_integrations.exceptions import (
     IntegrationProviderError,
     IntegrationResourceNotFoundError,
 )
+from sentry.signals import external_issue_created
 from sentry.silo.base import cell_silo_function
 from sentry.types.activity import ActivityType
 from sentry.types.rules import RuleFuture
 
 logger = logging.getLogger("sentry.rules")
+
+
+def _get_external_issue_trigger(future: RuleFuture) -> ExternalIssueTrigger:
+    action_data = future.kwargs["data"]
+    legacy_rule_id = action_data.get("legacy_rule_id")
+    if legacy_rule_id is not None:
+        return ExternalIssueTrigger(
+            type="issue_alert", id=str(legacy_rule_id), name=future.rule.label
+        )
+
+    workflow_id = action_data.get("workflow_id")
+    if workflow_id is not None:
+        return ExternalIssueTrigger(type="workflow", id=str(workflow_id), name=future.rule.label)
+
+    return ExternalIssueTrigger(type="issue_alert", id=str(future.rule.id), name=future.rule.label)
 
 
 @cell_silo_function
@@ -42,6 +59,7 @@ def create_link(
     installation: IntegrationInstallation,
     event: GroupEvent,
     response: Response,
+    triggered_by: ExternalIssueTrigger,
 ) -> None:
     """
     After creating the event on a third-party service, create a link to the
@@ -52,6 +70,7 @@ def create_link(
     :param response: The API response from creating the new resource.
         - key: String. The unique ID of the external resource
         - metadata: Optional Object. Can contain `display_name`.
+    :param triggered_by: Rule or workflow that fired this action.
     """
 
     assert isinstance(installation, IssueBasicIntegration), (
@@ -97,6 +116,14 @@ def create_link(
         group_id=event.group.id,
         project=event.group.project,
         actor=SYSTEM_ACTOR,
+    )
+    external_issue_created.send_robust(
+        project=event.group.project,
+        group=event.group,
+        user=None,
+        external_issue=external_issue,
+        triggered_by=triggered_by,
+        sender=create_link,
     )
 
 
@@ -150,6 +177,7 @@ def create_issue(event: GroupEvent, futures: Sequence[RuleFuture]) -> None:
         # In the Notification Action, we store the rule_id in the action_id field
         action_id = rule_id
         rule_id = data.get("legacy_rule_id")
+        triggered_by = _get_external_issue_trigger(future)
 
         integration = integration_service.get_integration(
             integration_id=integration_id,
@@ -218,4 +246,4 @@ def create_issue(event: GroupEvent, futures: Sequence[RuleFuture]) -> None:
                 raise
             # If we successfully created the issue, we want to create the link
             else:
-                create_link(integration, installation, event, response)
+                create_link(integration, installation, event, response, triggered_by)

--- a/src/sentry/sentry_apps/api/serializers/app_platform_event.py
+++ b/src/sentry/sentry_apps/api/serializers/app_platform_event.py
@@ -6,7 +6,7 @@ from typing import Any, TypedDict
 from uuid import uuid4
 
 from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallation
-from sentry.sentry_apps.services.app.model import RpcSentryAppInstallation
+from sentry.sentry_apps.services.app.model import RpcSentryApp, RpcSentryAppInstallation
 from sentry.sentry_apps.utils.headers import mask_header_values, parse_custom_headers
 from sentry.sentry_apps.utils.webhooks import SentryAppActionType, SentryAppResourceType
 from sentry.users.models.user import User
@@ -50,7 +50,7 @@ class AppPlatformEvent[T: Mapping[str, Any]]:
         action: SentryAppActionType,
         install: RpcSentryAppInstallation | SentryAppInstallation,
         data: T,
-        actor: RpcUser | User | None = None,
+        actor: RpcSentryApp | RpcUser | User | None = None,
     ):
         self.resource = resource
         self.action = action
@@ -59,7 +59,8 @@ class AppPlatformEvent[T: Mapping[str, Any]]:
         self.actor = actor
         self.include_text_summary = False
 
-    def get_actor(self) -> AppPlatformEventActor:
+    @property
+    def actor_payload(self) -> AppPlatformEventActor:
         # when sentry auto assigns, auto resolves, etc.
         # or when an alert rule is triggered
         if not self.actor:
@@ -67,6 +68,13 @@ class AppPlatformEvent[T: Mapping[str, Any]]:
                 type=AppPlatformEventActorType.APPLICATION,
                 id="sentry",
                 name="Sentry",
+            )
+
+        if isinstance(self.actor, RpcSentryApp):
+            return AppPlatformEventActor(
+                type=AppPlatformEventActorType.APPLICATION,
+                id=self.actor.uuid,
+                name=self.actor.name,
             )
 
         if self.actor.is_sentry_app:
@@ -101,7 +109,7 @@ class AppPlatformEvent[T: Mapping[str, Any]]:
             action=self.action,
             installation=AppPlatformEventInstallation(uuid=self.install.uuid),
             data=self.data,
-            actor=self.get_actor(),
+            actor=self.actor_payload,
         )
         if self.include_text_summary:
             return json.dumps({**body, "text": self.get_text_summary()})

--- a/src/sentry/sentry_apps/api/serializers/app_platform_event.py
+++ b/src/sentry/sentry_apps/api/serializers/app_platform_event.py
@@ -6,7 +6,7 @@ from typing import Any, TypedDict
 from uuid import uuid4
 
 from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallation
-from sentry.sentry_apps.services.app.model import RpcSentryAppInstallation
+from sentry.sentry_apps.services.app.model import RpcSentryApp, RpcSentryAppInstallation
 from sentry.sentry_apps.utils.headers import mask_header_values, parse_custom_headers
 from sentry.sentry_apps.utils.webhooks import SentryAppActionType, SentryAppResourceType
 from sentry.users.models.user import User
@@ -50,7 +50,7 @@ class AppPlatformEvent[T: Mapping[str, Any]]:
         action: SentryAppActionType,
         install: RpcSentryAppInstallation | SentryAppInstallation,
         data: T,
-        actor: RpcUser | User | None = None,
+        actor: RpcSentryApp | RpcUser | User | None = None,
     ):
         self.resource = resource
         self.action = action
@@ -59,7 +59,8 @@ class AppPlatformEvent[T: Mapping[str, Any]]:
         self.actor = actor
         self.include_text_summary = False
 
-    def get_actor(self) -> AppPlatformEventActor:
+    @property
+    def actor_payload(self) -> AppPlatformEventActor:
         # when sentry auto assigns, auto resolves, etc.
         # or when an alert rule is triggered
         if not self.actor:
@@ -69,12 +70,15 @@ class AppPlatformEvent[T: Mapping[str, Any]]:
                 name="Sentry",
             )
 
-        if self.actor.is_sentry_app:
+        if isinstance(self.actor, RpcSentryApp):
             return AppPlatformEventActor(
                 type=AppPlatformEventActorType.APPLICATION,
-                id=self.install.sentry_app.uuid,
-                name=self.install.sentry_app.name,
+                id=self.actor.uuid,
+                name=self.actor.name,
             )
+
+        if self.actor.is_sentry_app:
+            raise ValueError("Sentry App actors must be resolved before serialization")
 
         return AppPlatformEventActor(
             type=AppPlatformEventActorType.USER,
@@ -101,7 +105,7 @@ class AppPlatformEvent[T: Mapping[str, Any]]:
             action=self.action,
             installation=AppPlatformEventInstallation(uuid=self.install.uuid),
             data=self.data,
-            actor=self.get_actor(),
+            actor=self.actor_payload,
         )
         if self.include_text_summary:
             return json.dumps({**body, "text": self.get_text_summary()})

--- a/src/sentry/sentry_apps/event_types.py
+++ b/src/sentry/sentry_apps/event_types.py
@@ -39,6 +39,9 @@ class SentryAppEventType(StrEnum):
     ISSUE_UNRESOLVED = "issue.unresolved"
     ISSUE_RESOLVED = "issue.resolved"
     ISSUE_ASSIGNED = "issue.assigned"
+    # Distinct from `external_issue.*` above, which are outbound requests to an app.
+    ISSUE_EXTERNAL_ISSUE_CREATED = "issue.external_issue_created"
+    ISSUE_EXTERNAL_ISSUE_LINKED = "issue.external_issue_linked"
 
     # authorizations
     GRANT_EXCHANGER = "grant_exchanger"

--- a/src/sentry/sentry_apps/external_issues/kinds.py
+++ b/src/sentry/sentry_apps/external_issues/kinds.py
@@ -1,0 +1,36 @@
+from enum import StrEnum
+
+from sentry.integrations.models.external_issue import ExternalIssue
+from sentry.models.group import Group
+from sentry.models.grouplink import GroupLink
+from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
+
+
+class ExternalIssueKind(StrEnum):
+    """Which kind of integration manages an external issue."""
+
+    INTEGRATION = "integration"
+    CUSTOM_INTEGRATION = "custom_integration"
+
+    @classmethod
+    def of(cls, external_issue: ExternalIssue | PlatformExternalIssue) -> "ExternalIssueKind":
+        return (
+            cls.INTEGRATION if isinstance(external_issue, ExternalIssue) else cls.CUSTOM_INTEGRATION
+        )
+
+    def fetch(
+        self, *, external_issue_id: int, group: Group
+    ) -> ExternalIssue | PlatformExternalIssue:
+        """Load an external issue only when it is linked to `group`."""
+        if self is ExternalIssueKind.CUSTOM_INTEGRATION:
+            return PlatformExternalIssue.objects.get(id=external_issue_id, group_id=group.id)
+
+        return ExternalIssue.objects.get(
+            id__in=GroupLink.objects.filter(
+                group_id=group.id,
+                project_id=group.project_id,
+                linked_type=GroupLink.LinkedType.issue,
+            ).values_list("linked_id", flat=True),
+            id=external_issue_id,
+            organization_id=group.project.organization_id,
+        )

--- a/src/sentry/sentry_apps/external_issues/kinds.py
+++ b/src/sentry/sentry_apps/external_issues/kinds.py
@@ -1,0 +1,36 @@
+from enum import StrEnum
+
+from sentry.integrations.models.external_issue import ExternalIssue
+from sentry.models.group import Group
+from sentry.models.grouplink import GroupLink
+from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
+
+
+class ExternalIssueKind(StrEnum):
+    """Which kind of integration manages an external issue."""
+
+    INTEGRATION = "integration"
+    CUSTOM_INTEGRATION = "custom_integration"
+
+    @classmethod
+    def of(cls, external_issue: ExternalIssue | PlatformExternalIssue) -> "ExternalIssueKind":
+        return (
+            cls.INTEGRATION if isinstance(external_issue, ExternalIssue) else cls.CUSTOM_INTEGRATION
+        )
+
+    def fetch(
+        self, external_issue_id: int, *, group: Group
+    ) -> ExternalIssue | PlatformExternalIssue:
+        """Load an external issue only when it is linked to `group`."""
+        if self is ExternalIssueKind.CUSTOM_INTEGRATION:
+            return PlatformExternalIssue.objects.get(id=external_issue_id, group_id=group.id)
+
+        return ExternalIssue.objects.get(
+            id__in=GroupLink.objects.filter(
+                group_id=group.id,
+                project_id=group.project_id,
+                linked_type=GroupLink.LinkedType.issue,
+            ).values_list("linked_id", flat=True),
+            id=external_issue_id,
+            organization_id=group.project.organization_id,
+        )

--- a/src/sentry/sentry_apps/external_issues/types.py
+++ b/src/sentry/sentry_apps/external_issues/types.py
@@ -1,0 +1,7 @@
+from typing import Literal, TypedDict
+
+
+class ExternalIssueTrigger(TypedDict):
+    type: Literal["issue_alert", "workflow"]
+    id: str
+    name: str

--- a/src/sentry/sentry_apps/external_requests/utils.py
+++ b/src/sentry/sentry_apps/external_requests/utils.py
@@ -84,7 +84,8 @@ SELECT_OPTIONS_SCHEMA = {
 ISSUE_LINKER_SCHEMA = {
     "type": "object",
     "properties": {
-        "webUrl": {"type": "string"},
+        # Require an HTTP(S) URL before storing it and including it in webhook payloads.
+        "webUrl": {"type": "string", "pattern": "^https?://"},
         "identifier": {"type": "string"},
         "project": {"type": "string"},
     },

--- a/src/sentry/sentry_apps/services/cell/impl.py
+++ b/src/sentry/sentry_apps/services/cell/impl.py
@@ -22,6 +22,7 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.sentry_apps.external_issues.external_issue_creator import ExternalIssueCreator
 from sentry.sentry_apps.external_issues.issue_link_creator import IssueLinkCreator
+from sentry.sentry_apps.external_requests.issue_link_requester import IssueRequestActionType
 from sentry.sentry_apps.external_requests.select_requester import SelectRequester
 from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
 from sentry.sentry_apps.models.servicehook import ServiceHook, ServiceHookProject
@@ -42,6 +43,7 @@ from sentry.sentry_apps.services.cell.serial import (
 )
 from sentry.sentry_apps.services.cell.service import SentryAppCellService
 from sentry.sentry_apps.utils.errors import SentryAppIntegratorError, SentryAppSentryError
+from sentry.signals import external_issue_created, external_issue_linked
 from sentry.tsdb.base import TSDBModel
 from sentry.users.services.user import RpcUser
 
@@ -172,10 +174,9 @@ class DatabaseBackedSentryAppCellService(SentryAppCellService):
         except (SentryAppIntegratorError, SentryAppSentryError) as e:
             return RpcPlatformExternalIssueResult(error=RpcSentryAppError.from_exc(e))
 
+        is_create = action == IssueRequestActionType.CREATE
         action_cls = (
-            CreatePlatformExternalIssueAction
-            if action == "create"
-            else LinkPlatformExternalIssueAction
+            CreatePlatformExternalIssueAction if is_create else LinkPlatformExternalIssueAction
         )
         publish_action(
             action_cls(
@@ -187,6 +188,15 @@ class DatabaseBackedSentryAppCellService(SentryAppCellService):
             group_id=group.id,
             project=group.project,
             actor=actor,
+        )
+
+        signal = external_issue_created if is_create else external_issue_linked
+        signal.send_robust(
+            project=group.project,
+            group=group,
+            user=user,
+            external_issue=external_issue,
+            sender=self.__class__,
         )
 
         return RpcPlatformExternalIssueResult(
@@ -270,6 +280,15 @@ class DatabaseBackedSentryAppCellService(SentryAppCellService):
             project=group.project,
             actor=actor,
         )
+
+        if created:
+            external_issue_created.send_robust(
+                project=group.project,
+                group=group,
+                user=user,
+                external_issue=external_issue,
+                sender=self.__class__,
+            )
 
         return RpcPlatformExternalIssueResult(
             external_issue=serialize_platform_external_issue(external_issue)

--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -47,6 +47,8 @@ from sentry.models.project import Project
 from sentry.notifications.utils.rules import get_rule_or_workflow_id
 from sentry.sentry_apps.api.serializers.app_platform_event import AppPlatformEvent
 from sentry.sentry_apps.event_types import SentryAppEventType
+from sentry.sentry_apps.external_issues.kinds import ExternalIssueKind
+from sentry.sentry_apps.external_issues.types import ExternalIssueTrigger
 from sentry.sentry_apps.metrics import (
     SentryAppInteractionEvent,
     SentryAppInteractionType,
@@ -80,6 +82,7 @@ from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import sentryapp_control_tasks, sentryapp_tasks
 from sentry.taskworker.timeout import InnerTimeoutError
 from sentry.types.rules import RuleFuture
+from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
 from sentry.users.services.user.service import user_service
 from sentry.utils import json, metrics
@@ -371,14 +374,14 @@ def _process_resource_change(
                     data[name][date_key] = data[name][date_key].isoformat()
 
             for installation in installations:
-                if _is_project_allowed(installation, instance.project_id):
+                if is_project_allowed(installation, instance.project_id):
                     # Trigger a new task for each webhook
                     send_resource_change_webhook.delay(
                         installation_id=installation.id, event=str(event), data=data
                     )
 
 
-def _is_project_allowed(installation: RpcSentryAppInstallation, project_id: int) -> bool:
+def is_project_allowed(installation: RpcSentryAppInstallation, project_id: int) -> bool:
     service_hook = _load_service_hook(installation.organization_id, installation.id)
     if not service_hook:
         logger.info("send_webhooks.missing_servicehook", extra={"installation_id": installation.id})
@@ -605,6 +608,48 @@ def workflow_notification(
 
 
 @instrumented_task(
+    name="sentry.sentry_apps.tasks.sentry_apps.build_external_issue_webhook",
+    namespace=sentryapp_tasks,
+    retry=Retry(
+        times=3,
+        delay=60 * 5,
+        on=_SENTRY_APP_WEBHOOK_RETRY_ON,
+        ignore=_SENTRY_APP_WEBHOOK_RETRY_IGNORE,
+    ),
+    processing_deadline_duration=15,
+    silo_mode=SiloMode.CELL,
+    silenced_exceptions=_SENTRY_APP_WEBHOOK_SILENCED,
+)
+def build_external_issue_webhook(
+    installation_id: int,
+    issue_id: int,
+    type: str,
+    user_id: int | None,
+    external_issue: dict[str, Any],
+    external_issue_kind: str,
+    triggered_by: ExternalIssueTrigger | None = None,
+    **kwargs: Any,
+) -> None:
+    event = SentryAppEventType(type)
+    with SentryAppInteractionEvent(
+        operation_type=SentryAppInteractionType.PREPARE_WEBHOOK,
+        event_type=event,
+    ).capture():
+        install, issue, user = get_webhook_data(installation_id, issue_id, user_id)
+
+        kind = ExternalIssueKind(external_issue_kind)
+        data: dict[str, Any] = {
+            "issue": _webhook_issue_data(group=issue, serialized_group=serialize(issue)),
+            "external_issue": external_issue,
+            "external_issue_kind": kind.value,
+        }
+        if triggered_by is not None:
+            data["triggered_by"] = triggered_by
+
+    send_webhooks(installation=install, event=event, data=data, actor=user)
+
+
+@instrumented_task(
     name="sentry.sentry_apps.tasks.sentry_apps.build_comment_webhook",
     namespace=sentryapp_tasks,
     retry=Retry(
@@ -783,6 +828,21 @@ def _is_sentry_app_disabled_for_webhooks(sentry_app: RpcSentryApp) -> bool:
     return sentry_app.is_disabled
 
 
+def _resolve_webhook_actor(
+    actor: RpcSentryApp | RpcUser | User | None,
+) -> RpcSentryApp | RpcUser | User | None:
+    if actor is None or isinstance(actor, RpcSentryApp) or not actor.is_sentry_app:
+        return actor
+
+    sentry_apps = app_service.get_sentry_apps_by_proxy_users(proxy_user_ids=[actor.id])
+    sentry_app = next(iter(sentry_apps), None)
+    if sentry_app is None:
+        raise SentryAppSentryError(
+            message=f"send_webhooks.{SentryAppWebhookFailureReason.MISSING_SENTRY_APP}"
+        )
+    return sentry_app
+
+
 def send_webhooks(installation: RpcSentryAppInstallation, event: str, **kwargs: Any) -> None:
     with SentryAppInteractionEvent(
         operation_type=SentryAppInteractionType.SEND_WEBHOOK,
@@ -842,6 +902,7 @@ def send_webhooks(installation: RpcSentryAppInstallation, event: str, **kwargs: 
         kwargs["resource"] = resource
         kwargs["action"] = action
         kwargs["install"] = installation
+        kwargs["actor"] = _resolve_webhook_actor(kwargs.get("actor"))
 
         request_data = AppPlatformEvent(**kwargs)
 

--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -47,6 +47,8 @@ from sentry.models.project import Project
 from sentry.notifications.utils.rules import get_rule_or_workflow_id
 from sentry.sentry_apps.api.serializers.app_platform_event import AppPlatformEvent
 from sentry.sentry_apps.event_types import SentryAppEventType
+from sentry.sentry_apps.external_issues.kinds import ExternalIssueKind
+from sentry.sentry_apps.external_issues.types import ExternalIssueTrigger
 from sentry.sentry_apps.metrics import (
     SentryAppInteractionEvent,
     SentryAppInteractionType,
@@ -80,6 +82,7 @@ from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import sentryapp_control_tasks, sentryapp_tasks
 from sentry.taskworker.timeout import InnerTimeoutError
 from sentry.types.rules import RuleFuture
+from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
 from sentry.users.services.user.service import user_service
 from sentry.utils import json, metrics
@@ -371,14 +374,14 @@ def _process_resource_change(
                     data[name][date_key] = data[name][date_key].isoformat()
 
             for installation in installations:
-                if _is_project_allowed(installation, instance.project_id):
+                if is_project_allowed(installation, instance.project_id):
                     # Trigger a new task for each webhook
                     send_resource_change_webhook.delay(
                         installation_id=installation.id, event=str(event), data=data
                     )
 
 
-def _is_project_allowed(installation: RpcSentryAppInstallation, project_id: int) -> bool:
+def is_project_allowed(installation: RpcSentryAppInstallation, project_id: int) -> bool:
     service_hook = _load_service_hook(installation.organization_id, installation.id)
     if not service_hook:
         logger.info("send_webhooks.missing_servicehook", extra={"installation_id": installation.id})
@@ -605,6 +608,48 @@ def workflow_notification(
 
 
 @instrumented_task(
+    name="sentry.sentry_apps.tasks.sentry_apps.build_external_issue_webhook",
+    namespace=sentryapp_tasks,
+    retry=Retry(
+        times=3,
+        delay=60 * 5,
+        on=_SENTRY_APP_WEBHOOK_RETRY_ON,
+        ignore=_SENTRY_APP_WEBHOOK_RETRY_IGNORE,
+    ),
+    processing_deadline_duration=15,
+    silo_mode=SiloMode.CELL,
+    silenced_exceptions=_SENTRY_APP_WEBHOOK_SILENCED,
+)
+def build_external_issue_webhook(
+    installation_id: int,
+    issue_id: int,
+    type: str,
+    user_id: int | None,
+    external_issue: dict[str, Any],
+    external_issue_kind: str,
+    triggered_by: ExternalIssueTrigger | None = None,
+    **kwargs: Any,
+) -> None:
+    event = SentryAppEventType(type)
+    with SentryAppInteractionEvent(
+        operation_type=SentryAppInteractionType.PREPARE_WEBHOOK,
+        event_type=event,
+    ).capture():
+        install, issue, user = get_webhook_data(installation_id, issue_id, user_id)
+
+        kind = ExternalIssueKind(external_issue_kind)
+        data: dict[str, Any] = {
+            "issue": _webhook_issue_data(group=issue, serialized_group=serialize(issue)),
+            "external_issue": external_issue,
+            "external_issue_kind": kind.value,
+        }
+        if triggered_by is not None:
+            data["triggered_by"] = triggered_by
+
+    send_webhooks(installation=install, event=event, data=data, actor=user)
+
+
+@instrumented_task(
     name="sentry.sentry_apps.tasks.sentry_apps.build_comment_webhook",
     namespace=sentryapp_tasks,
     retry=Retry(
@@ -783,6 +828,29 @@ def _is_sentry_app_disabled_for_webhooks(sentry_app: RpcSentryApp) -> bool:
     return sentry_app.is_disabled
 
 
+def _resolve_webhook_actor(
+    actor: RpcSentryApp | RpcUser | User | None,
+    *,
+    installation: RpcSentryAppInstallation,
+) -> RpcSentryApp | RpcUser | User | None:
+    if actor is None or isinstance(actor, RpcSentryApp) or not actor.is_sentry_app:
+        return actor
+
+    # App actions are fanned out to every subscribed installation, so the recipient may not be
+    # the app whose proxy user performed the action. Keep the existing direct path when they do
+    # match, but resolve cross-app actors so the payload identifies the originating app.
+    if actor.id == installation.sentry_app.proxy_user_id:
+        return installation.sentry_app
+
+    sentry_apps = app_service.get_sentry_apps_by_proxy_users(proxy_user_ids=[actor.id])
+    sentry_app = next(iter(sentry_apps), None)
+    if sentry_app is None:
+        raise SentryAppSentryError(
+            message=f"send_webhooks.{SentryAppWebhookFailureReason.MISSING_SENTRY_APP}"
+        )
+    return sentry_app
+
+
 def send_webhooks(installation: RpcSentryAppInstallation, event: str, **kwargs: Any) -> None:
     with SentryAppInteractionEvent(
         operation_type=SentryAppInteractionType.SEND_WEBHOOK,
@@ -842,6 +910,7 @@ def send_webhooks(installation: RpcSentryAppInstallation, event: str, **kwargs: 
         kwargs["resource"] = resource
         kwargs["action"] = action
         kwargs["install"] = installation
+        kwargs["actor"] = _resolve_webhook_actor(kwargs.get("actor"), installation=installation)
 
         request_data = AppPlatformEvent(**kwargs)
 

--- a/src/sentry/sentry_apps/utils/webhooks.py
+++ b/src/sentry/sentry_apps/utils/webhooks.py
@@ -90,6 +90,8 @@ EVENT_EXPANSION: Final[dict[SentryAppResourceType, list[SentryAppEventType]]] = 
     SentryAppResourceType.ISSUE: [
         SentryAppEventType.ISSUE_ASSIGNED,
         SentryAppEventType.ISSUE_CREATED,
+        SentryAppEventType.ISSUE_EXTERNAL_ISSUE_CREATED,
+        SentryAppEventType.ISSUE_EXTERNAL_ISSUE_LINKED,
         SentryAppEventType.ISSUE_IGNORED,
         SentryAppEventType.ISSUE_RESOLVED,
         SentryAppEventType.ISSUE_UNRESOLVED,

--- a/src/sentry/signals.py
+++ b/src/sentry/signals.py
@@ -170,6 +170,9 @@ team_created = (
 integration_added = BetterSignal()  # ["integration_id", "organization_id", "user_id"]
 integration_issue_created = BetterSignal()  # ["integration", "organization", "user"]
 integration_issue_linked = BetterSignal()  # ["integration", "organization", "user"]
+# ["project", "group", "user", "external_issue", "triggered_by"]
+external_issue_created = BetterSignal()
+external_issue_linked = BetterSignal()
 
 monitor_environment_failed = BetterSignal()  # ["monitor"]
 

--- a/tests/sentry/integrations/github/test_ticket_action.py
+++ b/tests/sentry/integrations/github/test_ticket_action.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import responses
@@ -13,6 +13,7 @@ from sentry.issues.action_log.types import SYSTEM_ACTOR, ActionSource, CreateExt
 from sentry.models.activity import Activity
 from sentry.models.repository import Repository
 from sentry.models.rule import Rule
+from sentry.rules.actions.integrations.create_ticket.utils import _get_external_issue_trigger
 from sentry.services.eventstore.models import GroupEvent
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import RuleTestCase
@@ -51,6 +52,7 @@ class GitHubTicketRulesTestCase(RuleTestCase, BaseAPITestCase):
         )
 
         self.login_as(user=self.user)
+
         responses.add(
             method=responses.POST,
             url="https://api.github.com/app/installations/1/access_tokens",
@@ -79,10 +81,41 @@ class GitHubTicketRulesTestCase(RuleTestCase, BaseAPITestCase):
         )[0]
 
     @responses.activate()
-    def test_ticket_rules(self) -> None:
+    def test_trigger_reference_prefers_the_legacy_issue_alert(self) -> None:
+        rule = Rule(id=789, label="Escalating issues")
+        future = RuleFuture(
+            rule=rule,
+            kwargs={"data": {"legacy_rule_id": 123, "workflow_id": 456}},
+        )
+
+        assert _get_external_issue_trigger(future) == {
+            "type": "issue_alert",
+            "id": "123",
+            "name": "Escalating issues",
+        }
+
+    @responses.activate()
+    def test_trigger_reference_uses_the_workflow_without_a_legacy_alert(self) -> None:
+        rule = Rule(id=789, label="Escalating issues")
+        future = RuleFuture(rule=rule, kwargs={"data": {"workflow_id": 456}})
+
+        assert _get_external_issue_trigger(future) == {
+            "type": "workflow",
+            "id": "456",
+            "name": "Escalating issues",
+        }
+
+    @responses.activate()
+    @patch("sentry.sentry_apps.tasks.sentry_apps.build_external_issue_webhook.delay")
+    def test_ticket_rules(self, build_external_issue_webhook: MagicMock) -> None:
         title = "sample title"
         sample_description = "sample bug report"
         html_url = f"https://github.com/foo/bar/issues/{self.issue_num}"
+
+        sentry_app = self.create_sentry_app(
+            organization=self.organization, events=["issue.external_issue_created"]
+        )
+        self.create_sentry_app_installation(organization=self.organization, slug=sentry_app.slug)
 
         with assume_test_silo_mode(SiloMode.CELL):
             Repository.objects.create(
@@ -162,6 +195,17 @@ class GitHubTicketRulesTestCase(RuleTestCase, BaseAPITestCase):
             provider="github",
         )
 
+        build_external_issue_webhook.assert_called_once()
+        sentry_app_call = build_external_issue_webhook.call_args
+        assert sentry_app_call.kwargs["type"] == "issue.external_issue_created"
+        assert sentry_app_call.kwargs["issue_id"] == event.group_id
+        assert sentry_app_call.kwargs["user_id"] is None
+        assert sentry_app_call.kwargs["triggered_by"] == {
+            "type": "issue_alert",
+            "id": str(rule_object.id),
+            "name": rule_object.label,
+        }
+
         # assert ticket created in DB
         key = self.get_key(event)
         assert key == f"{self.repo}#{self.issue_num}"
@@ -192,6 +236,7 @@ class GitHubTicketRulesTestCase(RuleTestCase, BaseAPITestCase):
         self.trigger(event, rule_object)
 
         # assert new ticket NOT created in DB
+        build_external_issue_webhook.assert_called_once()
         assert ExternalIssue.objects.count() == external_issue_count
         assert (
             Activity.objects.filter(

--- a/tests/sentry/issues/endpoints/test_group_integration_details.py
+++ b/tests/sentry/issues/endpoints/test_group_integration_details.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 from django.db.utils import IntegrityError
 
+from sentry.api.serializers import serialize
 from sentry.integrations.example.integration import ExampleIntegration
 from sentry.integrations.models import Integration
 from sentry.integrations.models.external_issue import ExternalIssue
@@ -11,6 +12,7 @@ from sentry.models.activity import Activity
 from sentry.models.group import Group
 from sentry.models.grouplink import GroupLink
 from sentry.models.organization import Organization
+from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallation
 from sentry.shared_integrations.exceptions import (
     IntegrationConfigurationError,
     IntegrationError,
@@ -613,3 +615,63 @@ class GroupIntegrationDetailsTest(APITestCase):
         with self.feature("organizations:integrations-issue-basic"):
             assert_default_project(create_path, "create", project_field)
             assert_default_project(link_path, "link", project_field)
+
+    def setup_subscribed_sentry_app(
+        self, event: str
+    ) -> tuple[Group, Integration, SentryAppInstallation]:
+        self.login_as(user=self.user)
+        group = self.create_group()
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="example",
+            name="Example",
+            external_id="example:1",
+        )
+        sentry_app = self.create_sentry_app(organization=self.organization, events=[event])
+        install = self.create_sentry_app_installation(
+            organization=self.organization, slug=sentry_app.slug
+        )
+        return group, integration, install
+
+    def assert_notified(
+        self,
+        delay: mock.MagicMock,
+        install: SentryAppInstallation,
+        group: Group,
+        integration: Integration,
+        event: str,
+    ) -> None:
+        external_issue = ExternalIssue.objects.get(
+            key="APP-123", integration_id=integration.id, organization_id=self.organization.id
+        )
+        delay.assert_called_once_with(
+            installation_id=install.id,
+            issue_id=group.id,
+            type=event,
+            user_id=self.user.id,
+            external_issue=serialize(external_issue),
+            external_issue_kind="integration",
+            triggered_by=None,
+        )
+
+    @mock.patch("sentry.sentry_apps.tasks.sentry_apps.build_external_issue_webhook.delay")
+    def test_post_notifies_subscribed_sentry_apps(self, delay: mock.MagicMock) -> None:
+        event = "issue.external_issue_created"
+        group, integration, install = self.setup_subscribed_sentry_app(event)
+
+        path = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/integrations/{integration.id}/"
+        with self.feature("organizations:integrations-issue-basic"):
+            assert self.client.post(path, data={"assignee": "foo@sentry.io"}).status_code == 201
+
+        self.assert_notified(delay, install, group, integration, event)
+
+    @mock.patch("sentry.sentry_apps.tasks.sentry_apps.build_external_issue_webhook.delay")
+    def test_put_notifies_subscribed_sentry_apps(self, delay: mock.MagicMock) -> None:
+        event = "issue.external_issue_linked"
+        group, integration, install = self.setup_subscribed_sentry_app(event)
+
+        path = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/integrations/{integration.id}/"
+        with self.feature("organizations:integrations-issue-basic"):
+            assert self.client.put(path, data={"externalIssue": "APP-123"}).status_code == 201
+
+        self.assert_notified(delay, install, group, integration, event)

--- a/tests/sentry/receivers/test_sentry_apps.py
+++ b/tests/sentry/receivers/test_sentry_apps.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+from sentry.api.serializers import serialize
 from sentry.constants import SentryAppInstallationStatus
+from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.issues.escalating.escalating import manage_issue_states
 from sentry.issues.ongoing import bulk_transition_group_to_ongoing
 from sentry.models.activity import Activity
@@ -13,6 +15,15 @@ from sentry.models.groupinbox import GroupInboxReason
 from sentry.models.grouplink import GroupLink
 from sentry.models.release import Release
 from sentry.models.repository import Repository
+from sentry.sentry_apps.external_issues.types import ExternalIssueTrigger
+from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
+from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallation
+from sentry.signals import (
+    BetterSignal,
+    external_issue_created,
+    external_issue_linked,
+    receivers_raise_on_send,
+)
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode
@@ -21,6 +32,7 @@ from sentry.testutils.silo import assume_test_silo_mode
 # Issues and kick off side effects are just chillin in the endpoint code -_-
 from sentry.types.activity import ActivityType
 from sentry.types.group import GroupSubStatus
+from sentry.users.models.user import User
 
 
 @patch("sentry.sentry_apps.tasks.sentry_apps.workflow_notification.delay")
@@ -397,3 +409,160 @@ class TestIssueWorkflowNotificationsForExactSubscription(APITestCase):
             user_id=self.user.id,
             data={},
         )
+
+
+@patch("sentry.sentry_apps.tasks.sentry_apps.build_external_issue_webhook.delay")
+class TestExternalIssueWebhooks(APITestCase):
+    def setUp(self) -> None:
+        self.issue = self.create_group(project=self.project)
+        self.integration = self.create_integration(
+            organization=self.organization, provider="example", external_id="123"
+        )
+        self.external_issue = self.create_integration_external_issue(
+            group=self.issue, integration=self.integration, key="APP-123"
+        )
+
+    def install_app(self, events: list[str]) -> SentryAppInstallation:
+        sentry_app = self.create_sentry_app(organization=self.organization, events=events)
+        return self.create_sentry_app_installation(
+            organization=self.organization, slug=sentry_app.slug
+        )
+
+    def fire(
+        self,
+        signal: BetterSignal,
+        external_issue: ExternalIssue | PlatformExternalIssue,
+        user: User | None = None,
+        triggered_by: ExternalIssueTrigger | None = None,
+    ) -> None:
+        with receivers_raise_on_send():
+            signal.send_robust(
+                project=self.project,
+                group=self.issue,
+                user=user,
+                external_issue=external_issue,
+                triggered_by=triggered_by,
+                sender=self.__class__,
+            )
+
+    def test_notifies_on_created(self, delay: MagicMock) -> None:
+        install = self.install_app(["issue.external_issue_created"])
+
+        self.fire(external_issue_created, self.external_issue, user=self.user)
+
+        delay.assert_called_once_with(
+            installation_id=install.id,
+            issue_id=self.issue.id,
+            type="issue.external_issue_created",
+            user_id=self.user.id,
+            external_issue=serialize(self.external_issue),
+            external_issue_kind="integration",
+            triggered_by=None,
+        )
+
+    def test_notifies_on_linked(self, delay: MagicMock) -> None:
+        install = self.install_app(["issue.external_issue_linked"])
+
+        self.fire(external_issue_linked, self.external_issue, user=self.user)
+
+        delay.assert_called_once_with(
+            installation_id=install.id,
+            issue_id=self.issue.id,
+            type="issue.external_issue_linked",
+            user_id=self.user.id,
+            external_issue=serialize(self.external_issue),
+            external_issue_kind="integration",
+            triggered_by=None,
+        )
+
+    def test_subscribing_to_the_issue_resource_covers_both_events(self, delay: MagicMock) -> None:
+        install = self.install_app(["issue"])
+
+        for signal in (external_issue_created, external_issue_linked):
+            self.fire(signal, self.external_issue, user=self.user)
+
+        assert [c.kwargs["type"] for c in delay.call_args_list] == [
+            "issue.external_issue_created",
+            "issue.external_issue_linked",
+        ]
+        assert {c.kwargs["installation_id"] for c in delay.call_args_list} == {install.id}
+
+    def test_skips_app_subscribed_to_other_issue_events(self, delay: MagicMock) -> None:
+        self.install_app(["issue.resolved"])
+
+        self.fire(external_issue_created, self.external_issue, user=self.user)
+
+        assert not delay.called
+
+    def test_passes_the_trigger_reference(self, delay: MagicMock) -> None:
+        install = self.install_app(["issue.external_issue_created"])
+        triggered_by = ExternalIssueTrigger(type="workflow", id="123", name="Escalating issues")
+
+        self.fire(external_issue_created, self.external_issue, triggered_by=triggered_by)
+
+        delay.assert_called_once_with(
+            installation_id=install.id,
+            issue_id=self.issue.id,
+            type="issue.external_issue_created",
+            user_id=None,
+            external_issue=serialize(self.external_issue),
+            external_issue_kind="integration",
+            triggered_by=triggered_by,
+        )
+
+    def test_marks_a_custom_integration_issue_as_custom_integration(self, delay: MagicMock) -> None:
+        install = self.install_app(["issue.external_issue_created"])
+        platform_issue = self.create_platform_external_issue(
+            group=self.issue,
+            service_type="my-app",
+            display_name="app#123",
+            web_url="https://example.com/issues/123",
+        )
+
+        self.fire(external_issue_created, platform_issue, user=self.user)
+
+        delay.assert_called_once_with(
+            installation_id=install.id,
+            issue_id=self.issue.id,
+            type="issue.external_issue_created",
+            user_id=self.user.id,
+            external_issue=serialize(platform_issue),
+            external_issue_kind="custom_integration",
+            triggered_by=None,
+        )
+
+    def test_does_not_queue_an_integration_issue_from_another_group(self, delay: MagicMock) -> None:
+        other_issue = self.create_group(project=self.project)
+        unrelated = self.create_integration_external_issue(
+            group=other_issue, integration=self.integration, key="APP-456"
+        )
+
+        self.fire(external_issue_created, unrelated, user=self.user)
+
+        delay.assert_not_called()
+
+    def test_does_not_queue_a_custom_integration_issue_from_another_group(
+        self, delay: MagicMock
+    ) -> None:
+        other_issue = self.create_group(project=self.project)
+        unrelated = self.create_platform_external_issue(
+            group=other_issue,
+            service_type="my-app",
+            display_name="app#456",
+            web_url="https://example.com/issues/456",
+        )
+
+        self.fire(external_issue_created, unrelated, user=self.user)
+
+        delay.assert_not_called()
+
+    def test_respects_the_installation_project_filter(self, delay: MagicMock) -> None:
+        install = self.install_app(["issue.external_issue_created"])
+        other_project = self.create_project(organization=self.organization)
+        self.create_service_hook_project_for_installation(
+            installation_id=install.id, project_id=other_project.id
+        )
+
+        self.fire(external_issue_created, self.external_issue, user=self.user)
+
+        delay.assert_not_called()

--- a/tests/sentry/receivers/test_sentry_apps.py
+++ b/tests/sentry/receivers/test_sentry_apps.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+from sentry.api.serializers import serialize
 from sentry.constants import SentryAppInstallationStatus
+from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.issues.escalating.escalating import manage_issue_states
 from sentry.issues.ongoing import bulk_transition_group_to_ongoing
 from sentry.models.activity import Activity
@@ -13,6 +15,10 @@ from sentry.models.groupinbox import GroupInboxReason
 from sentry.models.grouplink import GroupLink
 from sentry.models.release import Release
 from sentry.models.repository import Repository
+from sentry.sentry_apps.external_issues.types import ExternalIssueTrigger
+from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
+from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallation
+from sentry.signals import BetterSignal, external_issue_created, external_issue_linked
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode
@@ -21,6 +27,7 @@ from sentry.testutils.silo import assume_test_silo_mode
 # Issues and kick off side effects are just chillin in the endpoint code -_-
 from sentry.types.activity import ActivityType
 from sentry.types.group import GroupSubStatus
+from sentry.users.models.user import User
 
 
 @patch("sentry.sentry_apps.tasks.sentry_apps.workflow_notification.delay")
@@ -397,3 +404,159 @@ class TestIssueWorkflowNotificationsForExactSubscription(APITestCase):
             user_id=self.user.id,
             data={},
         )
+
+
+@patch("sentry.sentry_apps.tasks.sentry_apps.build_external_issue_webhook.delay")
+class TestExternalIssueWebhooks(APITestCase):
+    def setUp(self) -> None:
+        self.issue = self.create_group(project=self.project)
+        self.integration = self.create_integration(
+            organization=self.organization, provider="example", external_id="123"
+        )
+        self.external_issue = self.create_integration_external_issue(
+            group=self.issue, integration=self.integration, key="APP-123"
+        )
+
+    def install_app(self, events: list[str]) -> SentryAppInstallation:
+        sentry_app = self.create_sentry_app(organization=self.organization, events=events)
+        return self.create_sentry_app_installation(
+            organization=self.organization, slug=sentry_app.slug
+        )
+
+    def fire(
+        self,
+        signal: BetterSignal,
+        external_issue: ExternalIssue | PlatformExternalIssue,
+        user: User | None = None,
+        triggered_by: ExternalIssueTrigger | None = None,
+    ) -> None:
+        signal.send_robust(
+            project=self.project,
+            group=self.issue,
+            user=user,
+            external_issue=external_issue,
+            triggered_by=triggered_by,
+            sender=self.__class__,
+        )
+
+    def test_notifies_on_created(self, delay: MagicMock) -> None:
+        install = self.install_app(["issue.external_issue_created"])
+
+        self.fire(external_issue_created, self.external_issue, user=self.user)
+
+        delay.assert_called_once_with(
+            installation_id=install.id,
+            issue_id=self.issue.id,
+            type="issue.external_issue_created",
+            user_id=self.user.id,
+            external_issue=serialize(self.external_issue),
+            external_issue_kind="integration",
+            triggered_by=None,
+        )
+
+    def test_notifies_on_linked(self, delay: MagicMock) -> None:
+        install = self.install_app(["issue.external_issue_linked"])
+
+        self.fire(external_issue_linked, self.external_issue, user=self.user)
+
+        delay.assert_called_once_with(
+            installation_id=install.id,
+            issue_id=self.issue.id,
+            type="issue.external_issue_linked",
+            user_id=self.user.id,
+            external_issue=serialize(self.external_issue),
+            external_issue_kind="integration",
+            triggered_by=None,
+        )
+
+    def test_subscribing_to_the_issue_resource_covers_both_events(self, delay: MagicMock) -> None:
+        install = self.install_app(["issue"])
+
+        for signal in (external_issue_created, external_issue_linked):
+            self.fire(signal, self.external_issue, user=self.user)
+
+        assert [c.kwargs["type"] for c in delay.call_args_list] == [
+            "issue.external_issue_created",
+            "issue.external_issue_linked",
+        ]
+        assert {c.kwargs["installation_id"] for c in delay.call_args_list} == {install.id}
+
+    def test_skips_app_subscribed_to_other_issue_events(self, delay: MagicMock) -> None:
+        self.install_app(["issue.resolved"])
+
+        self.fire(external_issue_created, self.external_issue, user=self.user)
+
+        assert not delay.called
+
+    def test_passes_the_trigger_reference(self, delay: MagicMock) -> None:
+        install = self.install_app(["issue.external_issue_created"])
+        triggered_by = ExternalIssueTrigger(type="workflow", id="123", name="Escalating issues")
+
+        self.fire(external_issue_created, self.external_issue, triggered_by=triggered_by)
+
+        delay.assert_called_once_with(
+            installation_id=install.id,
+            issue_id=self.issue.id,
+            type="issue.external_issue_created",
+            user_id=None,
+            external_issue=serialize(self.external_issue),
+            external_issue_kind="integration",
+            triggered_by=triggered_by,
+        )
+
+    def test_marks_a_custom_integration_issue_as_custom_integration(self, delay: MagicMock) -> None:
+        install = self.install_app(["issue.external_issue_created"])
+        platform_issue = self.create_platform_external_issue(
+            group=self.issue,
+            service_type="my-app",
+            display_name="app#123",
+            web_url="https://example.com/issues/123",
+        )
+
+        self.fire(external_issue_created, platform_issue, user=self.user)
+
+        delay.assert_called_once_with(
+            installation_id=install.id,
+            issue_id=self.issue.id,
+            type="issue.external_issue_created",
+            user_id=self.user.id,
+            external_issue=serialize(platform_issue),
+            external_issue_kind="custom_integration",
+            triggered_by=None,
+        )
+
+    def test_does_not_queue_an_integration_issue_from_another_group(self, delay: MagicMock) -> None:
+        other_issue = self.create_group(project=self.project)
+        unrelated = self.create_integration_external_issue(
+            group=other_issue, integration=self.integration, key="APP-456"
+        )
+
+        self.fire(external_issue_created, unrelated, user=self.user)
+
+        delay.assert_not_called()
+
+    def test_does_not_queue_a_custom_integration_issue_from_another_group(
+        self, delay: MagicMock
+    ) -> None:
+        other_issue = self.create_group(project=self.project)
+        unrelated = self.create_platform_external_issue(
+            group=other_issue,
+            service_type="my-app",
+            display_name="app#456",
+            web_url="https://example.com/issues/456",
+        )
+
+        self.fire(external_issue_created, unrelated, user=self.user)
+
+        delay.assert_not_called()
+
+    def test_respects_the_installation_project_filter(self, delay: MagicMock) -> None:
+        install = self.install_app(["issue.external_issue_created"])
+        other_project = self.create_project(organization=self.organization)
+        self.create_service_hook_project_for_installation(
+            installation_id=install.id, project_id=other_project.id
+        )
+
+        self.fire(external_issue_created, self.external_issue, user=self.user)
+
+        delay.assert_not_called()

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_details.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_details.py
@@ -259,6 +259,8 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
         assert set(hook.events) == {
             "issue.assigned",
             "issue.created",
+            "issue.external_issue_created",
+            "issue.external_issue_linked",
             "issue.ignored",
             "issue.resolved",
             "issue.unresolved",
@@ -369,6 +371,8 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
             assert set(hook.events) == {
                 "issue.assigned",
                 "issue.created",
+                "issue.external_issue_created",
+                "issue.external_issue_linked",
                 "issue.ignored",
                 "issue.resolved",
                 "issue.unresolved",
@@ -383,6 +387,8 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
             assert set(hook.events) == {
                 "issue.assigned",
                 "issue.created",
+                "issue.external_issue_created",
+                "issue.external_issue_linked",
                 "issue.ignored",
                 "issue.resolved",
                 "issue.unresolved",
@@ -456,6 +462,8 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
             assert set(hook.events) == {
                 "issue.assigned",
                 "issue.created",
+                "issue.external_issue_created",
+                "issue.external_issue_linked",
                 "issue.ignored",
                 "issue.resolved",
                 "issue.unresolved",
@@ -470,6 +478,8 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
             assert set(hook.events) == {
                 "issue.assigned",
                 "issue.created",
+                "issue.external_issue_created",
+                "issue.external_issue_linked",
                 "issue.ignored",
                 "issue.resolved",
                 "issue.unresolved",

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_installation_external_issue_actions.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_installation_external_issue_actions.py
@@ -1,11 +1,16 @@
+from unittest.mock import MagicMock, patch
+
 import responses
 from django.urls import reverse
 
+from sentry.api.serializers import serialize
 from sentry.models.apitoken import ApiToken
 from sentry.models.organization import Organization
 from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
+from sentry.sentry_apps.tasks.sentry_apps import build_external_issue_webhook
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.silo import assume_test_silo_mode_of, control_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, assume_test_silo_mode_of, control_silo_test
 
 
 @control_silo_test
@@ -62,6 +67,136 @@ class SentryAppInstallationExternalIssuesEndpointTest(APITestCase):
             "displayName": "ProjectName#issue-1",
             "webUrl": "https://example.com/project/issue-id",
         }
+
+    @responses.activate
+    @patch("sentry.sentry_apps.tasks.sentry_apps.build_external_issue_webhook.delay")
+    def test_notifies_subscribed_sentry_apps_on_link(self, delay: MagicMock) -> None:
+        self.login_as(user=self.user)
+        subscriber = self.create_sentry_app(
+            organization=self.org, events=["issue.external_issue_linked"]
+        )
+        subscriber_install = self.create_sentry_app_installation(
+            organization=self.org, slug=subscriber.slug
+        )
+        responses.add(
+            method=responses.POST,
+            url="https://example.com/link-issues",
+            json={
+                "project": "ProjectName",
+                "webUrl": "https://example.com/project/issue-id",
+                "identifier": "issue-1",
+            },
+            status=200,
+            content_type="application/json",
+        )
+
+        response = self.client.post(
+            self.url,
+            data={
+                "groupId": self.group.id,
+                "action": "link",
+                "fields": {"title": "Hello"},
+                "uri": "/link-issues",
+            },
+            format="json",
+        )
+        assert response.status_code == 200
+
+        with assume_test_silo_mode_of(PlatformExternalIssue):
+            external_issue = PlatformExternalIssue.objects.get()
+
+        delay.assert_called_once_with(
+            installation_id=subscriber_install.id,
+            issue_id=self.group.id,
+            type="issue.external_issue_linked",
+            user_id=self.user.id,
+            external_issue=serialize(external_issue),
+            external_issue_kind="custom_integration",
+            triggered_by=None,
+        )
+
+    @responses.activate
+    @patch("sentry.sentry_apps.tasks.sentry_apps.build_external_issue_webhook.delay")
+    def test_queued_webhook_preserves_a_replaced_external_issue(self, delay: MagicMock) -> None:
+        self.login_as(user=self.user)
+        subscriber = self.create_sentry_app(
+            organization=self.org, events=["issue.external_issue_linked"]
+        )
+        self.create_sentry_app_installation(organization=self.org, slug=subscriber.slug)
+        for identifier in ("issue-1", "issue-2"):
+            responses.add(
+                method=responses.POST,
+                url="https://example.com/link-issues",
+                json={
+                    "project": "ProjectName",
+                    "webUrl": f"https://example.com/project/{identifier}",
+                    "identifier": identifier,
+                },
+                status=200,
+                content_type="application/json",
+            )
+
+        request_data = {
+            "groupId": self.group.id,
+            "action": "link",
+            "fields": {"title": "Hello"},
+            "uri": "/link-issues",
+        }
+        for _ in range(2):
+            response = self.client.post(self.url, data=request_data, format="json")
+            assert response.status_code == 200
+
+        with assume_test_silo_mode_of(PlatformExternalIssue):
+            external_issue = PlatformExternalIssue.objects.get()
+        assert external_issue.web_url == "https://example.com/project/issue-2"
+        assert delay.call_count == 2
+
+        first_webhook_kwargs = delay.call_args_list[0].kwargs
+        with (
+            assume_test_silo_mode(SiloMode.CELL),
+            patch("sentry.sentry_apps.tasks.sentry_apps.send_webhooks") as send_webhooks,
+        ):
+            build_external_issue_webhook(**first_webhook_kwargs)
+
+        send_webhooks.assert_called_once()
+        assert send_webhooks.call_args.kwargs["data"]["external_issue"] == {
+            "id": str(external_issue.id),
+            "issueId": str(self.group.id),
+            "serviceType": self.sentry_app.slug,
+            "displayName": "ProjectName#issue-1",
+            "webUrl": "https://example.com/project/issue-1",
+        }
+
+    @responses.activate
+    def test_rejects_a_web_url_the_app_returns_with_a_bad_scheme(self) -> None:
+        self.login_as(user=self.user)
+        responses.add(
+            method=responses.POST,
+            url="https://example.com/create-issues",
+            json={
+                "project": "ProjectName",
+                "webUrl": "javascript:alert(1)",
+                "identifier": "issue-1",
+            },
+            status=200,
+            content_type="application/json",
+        )
+
+        response = self.client.post(
+            self.url,
+            data={
+                "groupId": self.group.id,
+                "action": "create",
+                "fields": {"title": "Hello"},
+                "uri": "/create-issues",
+            },
+            format="json",
+        )
+
+        # Treated like any other malformed response from the app.
+        assert response.status_code == 500
+        with assume_test_silo_mode_of(PlatformExternalIssue):
+            assert not PlatformExternalIssue.objects.exists()
 
     @responses.activate
     def test_external_issue_doesnt_get_created(self) -> None:

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_installation_external_issues.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_installation_external_issues.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock, patch
 
 from django.urls import reverse
 
+from sentry.api.serializers import serialize
 from sentry.models.organization import Organization
 from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
 from sentry.testutils.cases import APITestCase
@@ -129,6 +130,55 @@ class SentryAppInstallationExternalIssuesEndpointTest(APITestCase):
             HTTP_AUTHORIZATION=f"Bearer {new_api_token.token}",
         )
         assert response.status_code == 403
+
+    @patch("sentry.sentry_apps.tasks.sentry_apps.build_external_issue_webhook.delay")
+    def test_notifies_subscribed_sentry_apps(self, delay: MagicMock) -> None:
+        self._set_up_sentry_app("Testin", ["event:write"])
+        subscriber = self.create_sentry_app(
+            organization=self.org, events=["issue.external_issue_created"]
+        )
+        subscriber_install = self.create_sentry_app_installation(
+            organization=self.org, slug=subscriber.slug
+        )
+
+        response = self.client.post(
+            self.url, data=self._post_data(), HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}"
+        )
+        assert response.status_code == 200
+
+        with assume_test_silo_mode_of(PlatformExternalIssue):
+            external_issue = PlatformExternalIssue.objects.get()
+
+        delay.assert_called_once_with(
+            installation_id=subscriber_install.id,
+            issue_id=self.group.id,
+            type="issue.external_issue_created",
+            user_id=self.sentry_app.proxy_user_id,
+            external_issue=serialize(external_issue),
+            external_issue_kind="custom_integration",
+            triggered_by=None,
+        )
+
+    @patch("sentry.sentry_apps.tasks.sentry_apps.build_external_issue_webhook.delay")
+    def test_does_not_notify_again_when_the_link_already_exists(self, delay: MagicMock) -> None:
+        self._set_up_sentry_app("Testin", ["event:write"])
+        subscriber = self.create_sentry_app(
+            organization=self.org, events=["issue.external_issue_created"]
+        )
+        self.create_sentry_app_installation(organization=self.org, slug=subscriber.slug)
+
+        for _ in range(2):
+            response = self.client.post(
+                self.url,
+                data=self._post_data(),
+                HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}",
+            )
+            assert response.status_code == 200
+
+        # The second POST upserts the same row, so it is not a new external issue.
+        with assume_test_silo_mode_of(PlatformExternalIssue):
+            assert PlatformExternalIssue.objects.count() == 1
+        assert delay.call_count == 1
 
     @patch(
         "sentry.sentry_apps.external_issues.external_issue_creator.PlatformExternalIssue.objects.update_or_create"

--- a/tests/sentry/sentry_apps/api/serializers/test_app_platform_event.py
+++ b/tests/sentry/sentry_apps/api/serializers/test_app_platform_event.py
@@ -2,9 +2,11 @@ import datetime
 from typing import Any
 
 import orjson
+import pytest
 
 from sentry.sentry_apps.api.serializers.app_platform_event import AppPlatformEvent
 from sentry.sentry_apps.models.sentry_app import MASKED_VALUE, SentryApp
+from sentry.sentry_apps.services.app import app_service
 from sentry.sentry_apps.utils.webhooks import (
     ErrorActionType,
     InstallationActionType,
@@ -55,12 +57,14 @@ class AppPlatformEventSerializerTest(TestCase):
         assert result.headers["Sentry-Hook-Signature"] == signature
 
     def test_sentry_app_actor(self) -> None:
+        actor = app_service.get_sentry_app_by_id(id=self.sentry_app.id)
+        assert actor is not None
         result = AppPlatformEvent[dict[str, Any]](
             resource=SentryAppResourceType.ISSUE,
             action=IssueActionType.ASSIGNED,
             install=self.install,
             data={},
-            actor=self.sentry_app.proxy_user,
+            actor=actor,
         )
 
         assert orjson.loads(result.body)["actor"] == {
@@ -95,6 +99,20 @@ class AppPlatformEventSerializerTest(TestCase):
         assert result.headers["Content-Type"] == "application/json"
         assert result.headers["Sentry-Hook-Resource"] == "installation"
         assert result.headers["Sentry-Hook-Signature"] == signature
+
+    def test_unresolved_sentry_app_actor(self) -> None:
+        result = AppPlatformEvent[dict[str, Any]](
+            resource=SentryAppResourceType.ISSUE,
+            action=IssueActionType.ASSIGNED,
+            install=self.install,
+            data={},
+            actor=self.sentry_app.proxy_user,
+        )
+
+        with pytest.raises(
+            ValueError, match="Sentry App actors must be resolved before serialization"
+        ):
+            result.body
 
     def _event_for_app_with_headers(
         self, headers: list[str]

--- a/tests/sentry/sentry_apps/services/test_hook_service.py
+++ b/tests/sentry/sentry_apps/services/test_hook_service.py
@@ -59,6 +59,8 @@ class TestHookService(TestCase):
             "comment.updated",
             "issue.assigned",
             "issue.created",
+            "issue.external_issue_created",
+            "issue.external_issue_linked",
             "issue.ignored",
             "issue.resolved",
             "issue.unresolved",

--- a/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
@@ -20,12 +20,15 @@ from sentry.incidents.models.incident import IncidentStatus
 from sentry.integrations.types import EventLifecycleOutcome
 from sentry.issues.ingest import save_issue_occurrence
 from sentry.models.activity import Activity
+from sentry.sentry_apps.external_issues.types import ExternalIssueTrigger
 from sentry.sentry_apps.metrics import SentryAppWebhookFailureReason, SentryAppWebhookHaltReason
 from sentry.sentry_apps.models.sentry_app import SentryApp
 from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallation
 from sentry.sentry_apps.models.servicehook import ServiceHook, ServiceHookProject
+from sentry.sentry_apps.services.app import app_service
 from sentry.sentry_apps.tasks.sentry_apps import (
     build_comment_webhook,
+    build_external_issue_webhook,
     installation_webhook,
     notify_sentry_app,
     process_resource_change_bound,
@@ -2228,3 +2231,181 @@ class TestDisabledSentryAppWebhooks(TestCase):
         disable_app(self.sentry_app)
         workflow_notification(self.install.id, self.issue.id, "resolved", self.user.id)
         assert safe_urlopen.called
+
+
+@patch("sentry.utils.sentry_apps.webhooks.safe_urlopen", return_value=MockResponseInstance)
+class TestExternalIssueWebhook(TestCase):
+    def setUp(self) -> None:
+        self.project = self.create_project()
+        self.user = self.create_user()
+        self.issue = self.create_group(project=self.project)
+
+        self.sentry_app = self.create_sentry_app(
+            organization=self.project.organization,
+            events=["issue.external_issue_created", "issue.external_issue_linked"],
+        )
+        self.install = self.create_sentry_app_installation(
+            organization=self.project.organization, slug=self.sentry_app.slug
+        )
+        self.integration = self.create_integration(
+            organization=self.project.organization, provider="example", external_id="123"
+        )
+        self.external_issue = self.create_integration_external_issue(
+            group=self.issue, integration=self.integration, key="APP-123"
+        )
+
+    def run_task(
+        self,
+        event: str,
+        user_id: int | None = None,
+        triggered_by: ExternalIssueTrigger | None = None,
+        external_issue: dict | None = None,
+        external_issue_kind: str = "integration",
+    ) -> None:
+        if external_issue is None:
+            external_issue = serialize(self.external_issue)
+        build_external_issue_webhook(
+            installation_id=self.install.id,
+            issue_id=self.issue.id,
+            type=event,
+            user_id=user_id,
+            external_issue=external_issue,
+            external_issue_kind=external_issue_kind,
+            triggered_by=triggered_by,
+        )
+
+    def test_sends_created_webhook(self, safe_urlopen: MagicMock) -> None:
+        self.run_task("issue.external_issue_created", user_id=self.user.id)
+
+        ((_, kwargs),) = safe_urlopen.call_args_list
+        data = json.loads(kwargs["data"])
+        assert data["action"] == "external_issue_created"
+        assert data["data"]["issue"]["id"] == str(self.issue.id)
+        assert data["data"]["external_issue"]["key"] == "APP-123"
+        assert data["data"]["external_issue_kind"] == "integration"
+        assert kwargs["headers"]["Sentry-Hook-Resource"] == "issue"
+
+    def test_sends_linked_webhook(self, safe_urlopen: MagicMock) -> None:
+        self.run_task("issue.external_issue_linked", user_id=self.user.id)
+
+        ((_, kwargs),) = safe_urlopen.call_args_list
+        data = json.loads(kwargs["data"])
+        assert data["action"] == "external_issue_linked"
+        assert data["data"]["external_issue"]["key"] == "APP-123"
+
+    def test_attributes_to_sentry_when_no_user(self, safe_urlopen: MagicMock) -> None:
+        self.run_task("issue.external_issue_created")
+
+        ((_, kwargs),) = safe_urlopen.call_args_list
+        data = json.loads(kwargs["data"])
+        assert data["actor"] == {
+            "type": "application",
+            "id": "sentry",
+            "name": "Sentry",
+        }
+
+    @patch.object(app_service, "get_sentry_apps_by_proxy_users")
+    def test_uses_recipient_app_for_its_own_proxy_user(
+        self, get_sentry_apps: MagicMock, safe_urlopen: MagicMock
+    ) -> None:
+        self.run_task(
+            "issue.external_issue_created",
+            user_id=self.sentry_app.proxy_user_id,
+        )
+
+        ((_, kwargs),) = safe_urlopen.call_args_list
+        data = json.loads(kwargs["data"])
+        assert data["actor"] == {
+            "type": "application",
+            "id": self.sentry_app.uuid,
+            "name": self.sentry_app.name,
+        }
+        get_sentry_apps.assert_not_called()
+
+    def test_resolves_an_originating_app_for_another_recipient(
+        self, safe_urlopen: MagicMock
+    ) -> None:
+        actor_app = self.create_sentry_app(organization=self.project.organization)
+        self.run_task(
+            "issue.external_issue_created",
+            user_id=actor_app.proxy_user_id,
+        )
+
+        ((_, kwargs),) = safe_urlopen.call_args_list
+        data = json.loads(kwargs["data"])
+        assert data["actor"] == {
+            "type": "application",
+            "id": actor_app.uuid,
+            "name": actor_app.name,
+        }
+
+    @patch.object(app_service, "get_sentry_apps_by_proxy_users", return_value=[])
+    def test_does_not_send_an_unresolved_app_actor(
+        self, get_sentry_apps: MagicMock, safe_urlopen: MagicMock
+    ) -> None:
+        actor_app = self.create_sentry_app(organization=self.project.organization)
+
+        with pytest.raises(SentryAppSentryError) as exc_info:
+            self.run_task(
+                "issue.external_issue_created",
+                user_id=actor_app.proxy_user_id,
+            )
+
+        assert exc_info.value.message == "send_webhooks.missing_sentry_app"
+        get_sentry_apps.assert_called_once_with(proxy_user_ids=[actor_app.proxy_user_id])
+        safe_urlopen.assert_not_called()
+
+    def test_includes_the_trigger_reference(self, safe_urlopen: MagicMock) -> None:
+        triggered_by = ExternalIssueTrigger(type="workflow", id="123", name="Escalating issues")
+        self.run_task("issue.external_issue_created", triggered_by=triggered_by)
+
+        ((_, kwargs),) = safe_urlopen.call_args_list
+        data = json.loads(kwargs["data"])
+        assert data["data"]["triggered_by"] == triggered_by
+
+    def test_omits_triggered_by_without_a_trigger(self, safe_urlopen: MagicMock) -> None:
+        self.run_task("issue.external_issue_created", user_id=self.user.id)
+
+        ((_, kwargs),) = safe_urlopen.call_args_list
+        data = json.loads(kwargs["data"])
+        assert "triggered_by" not in data["data"]
+
+    def test_sends_snapshot_after_external_issue_is_deleted(self, safe_urlopen: MagicMock) -> None:
+        external_issue = serialize(self.external_issue)
+        self.external_issue.delete()
+
+        self.run_task(
+            "issue.external_issue_created",
+            user_id=self.user.id,
+            external_issue=external_issue,
+        )
+
+        ((_, kwargs),) = safe_urlopen.call_args_list
+        data = json.loads(kwargs["data"])
+        assert data["data"]["external_issue"]["key"] == "APP-123"
+
+    def test_sends_the_custom_integration_shape(self, safe_urlopen: MagicMock) -> None:
+        platform_issue = self.create_platform_external_issue(
+            group=self.issue,
+            service_type=self.sentry_app.slug,
+            display_name="app#123",
+            web_url="https://example.com/issues/123",
+        )
+
+        self.run_task(
+            "issue.external_issue_created",
+            user_id=self.user.id,
+            external_issue=serialize(platform_issue),
+            external_issue_kind="custom_integration",
+        )
+
+        ((_, kwargs),) = safe_urlopen.call_args_list
+        data = json.loads(kwargs["data"])
+        assert data["data"]["external_issue_kind"] == "custom_integration"
+        assert data["data"]["external_issue"] == {
+            "id": str(platform_issue.id),
+            "issueId": str(self.issue.id),
+            "serviceType": self.sentry_app.slug,
+            "displayName": "app#123",
+            "webUrl": "https://example.com/issues/123",
+        }

--- a/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
@@ -20,12 +20,15 @@ from sentry.incidents.models.incident import IncidentStatus
 from sentry.integrations.types import EventLifecycleOutcome
 from sentry.issues.ingest import save_issue_occurrence
 from sentry.models.activity import Activity
+from sentry.sentry_apps.external_issues.types import ExternalIssueTrigger
 from sentry.sentry_apps.metrics import SentryAppWebhookFailureReason, SentryAppWebhookHaltReason
 from sentry.sentry_apps.models.sentry_app import SentryApp
 from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallation
 from sentry.sentry_apps.models.servicehook import ServiceHook, ServiceHookProject
+from sentry.sentry_apps.services.app import app_service
 from sentry.sentry_apps.tasks.sentry_apps import (
     build_comment_webhook,
+    build_external_issue_webhook,
     installation_webhook,
     notify_sentry_app,
     process_resource_change_bound,
@@ -2228,3 +2231,161 @@ class TestDisabledSentryAppWebhooks(TestCase):
         disable_app(self.sentry_app)
         workflow_notification(self.install.id, self.issue.id, "resolved", self.user.id)
         assert safe_urlopen.called
+
+
+@patch("sentry.utils.sentry_apps.webhooks.safe_urlopen", return_value=MockResponseInstance)
+class TestExternalIssueWebhook(TestCase):
+    def setUp(self) -> None:
+        self.project = self.create_project()
+        self.user = self.create_user()
+        self.issue = self.create_group(project=self.project)
+
+        self.sentry_app = self.create_sentry_app(
+            organization=self.project.organization,
+            events=["issue.external_issue_created", "issue.external_issue_linked"],
+        )
+        self.install = self.create_sentry_app_installation(
+            organization=self.project.organization, slug=self.sentry_app.slug
+        )
+        self.integration = self.create_integration(
+            organization=self.project.organization, provider="example", external_id="123"
+        )
+        self.external_issue = self.create_integration_external_issue(
+            group=self.issue, integration=self.integration, key="APP-123"
+        )
+
+    def run_task(
+        self,
+        event: str,
+        user_id: int | None = None,
+        triggered_by: ExternalIssueTrigger | None = None,
+        external_issue: dict | None = None,
+        external_issue_kind: str = "integration",
+    ) -> None:
+        if external_issue is None:
+            external_issue = serialize(self.external_issue)
+        build_external_issue_webhook(
+            installation_id=self.install.id,
+            issue_id=self.issue.id,
+            type=event,
+            user_id=user_id,
+            external_issue=external_issue,
+            external_issue_kind=external_issue_kind,
+            triggered_by=triggered_by,
+        )
+
+    def test_sends_created_webhook(self, safe_urlopen: MagicMock) -> None:
+        self.run_task("issue.external_issue_created", user_id=self.user.id)
+
+        ((_, kwargs),) = safe_urlopen.call_args_list
+        data = json.loads(kwargs["data"])
+        assert data["action"] == "external_issue_created"
+        assert data["data"]["issue"]["id"] == str(self.issue.id)
+        assert data["data"]["external_issue"]["key"] == "APP-123"
+        assert data["data"]["external_issue_kind"] == "integration"
+        assert kwargs["headers"]["Sentry-Hook-Resource"] == "issue"
+
+    def test_sends_linked_webhook(self, safe_urlopen: MagicMock) -> None:
+        self.run_task("issue.external_issue_linked", user_id=self.user.id)
+
+        ((_, kwargs),) = safe_urlopen.call_args_list
+        data = json.loads(kwargs["data"])
+        assert data["action"] == "external_issue_linked"
+        assert data["data"]["external_issue"]["key"] == "APP-123"
+
+    def test_attributes_to_sentry_when_no_user(self, safe_urlopen: MagicMock) -> None:
+        self.run_task("issue.external_issue_created")
+
+        ((_, kwargs),) = safe_urlopen.call_args_list
+        data = json.loads(kwargs["data"])
+        assert data["actor"] == {
+            "type": "application",
+            "id": "sentry",
+            "name": "Sentry",
+        }
+
+    def test_preserves_an_originating_app_actor(self, safe_urlopen: MagicMock) -> None:
+        actor_app = self.create_sentry_app(organization=self.project.organization)
+        self.run_task(
+            "issue.external_issue_created",
+            user_id=actor_app.proxy_user_id,
+        )
+
+        ((_, kwargs),) = safe_urlopen.call_args_list
+        data = json.loads(kwargs["data"])
+        assert data["actor"] == {
+            "type": "application",
+            "id": actor_app.uuid,
+            "name": actor_app.name,
+        }
+
+    @patch.object(app_service, "get_sentry_apps_by_proxy_users", return_value=[])
+    def test_does_not_send_an_unresolved_app_actor(
+        self, get_sentry_apps: MagicMock, safe_urlopen: MagicMock
+    ) -> None:
+        actor_app = self.create_sentry_app(organization=self.project.organization)
+
+        with pytest.raises(SentryAppSentryError) as exc_info:
+            self.run_task(
+                "issue.external_issue_created",
+                user_id=actor_app.proxy_user_id,
+            )
+
+        assert exc_info.value.message == "send_webhooks.missing_sentry_app"
+        get_sentry_apps.assert_called_once_with(proxy_user_ids=[actor_app.proxy_user_id])
+        safe_urlopen.assert_not_called()
+
+    def test_includes_the_trigger_reference(self, safe_urlopen: MagicMock) -> None:
+        triggered_by = ExternalIssueTrigger(type="workflow", id="123", name="Escalating issues")
+        self.run_task("issue.external_issue_created", triggered_by=triggered_by)
+
+        ((_, kwargs),) = safe_urlopen.call_args_list
+        data = json.loads(kwargs["data"])
+        assert data["data"]["triggered_by"] == triggered_by
+
+    def test_omits_triggered_by_without_a_trigger(self, safe_urlopen: MagicMock) -> None:
+        self.run_task("issue.external_issue_created", user_id=self.user.id)
+
+        ((_, kwargs),) = safe_urlopen.call_args_list
+        data = json.loads(kwargs["data"])
+        assert "triggered_by" not in data["data"]
+
+    def test_sends_snapshot_after_external_issue_is_deleted(self, safe_urlopen: MagicMock) -> None:
+        external_issue = serialize(self.external_issue)
+        self.external_issue.delete()
+
+        self.run_task(
+            "issue.external_issue_created",
+            user_id=self.user.id,
+            external_issue=external_issue,
+        )
+
+        ((_, kwargs),) = safe_urlopen.call_args_list
+        data = json.loads(kwargs["data"])
+        assert data["data"]["external_issue"]["key"] == "APP-123"
+
+    def test_sends_the_custom_integration_shape(self, safe_urlopen: MagicMock) -> None:
+        platform_issue = self.create_platform_external_issue(
+            group=self.issue,
+            service_type=self.sentry_app.slug,
+            display_name="app#123",
+            web_url="https://example.com/issues/123",
+        )
+
+        self.run_task(
+            "issue.external_issue_created",
+            user_id=self.user.id,
+            external_issue=serialize(platform_issue),
+            external_issue_kind="custom_integration",
+        )
+
+        ((_, kwargs),) = safe_urlopen.call_args_list
+        data = json.loads(kwargs["data"])
+        assert data["data"]["external_issue_kind"] == "custom_integration"
+        assert data["data"]["external_issue"] == {
+            "id": str(platform_issue.id),
+            "issueId": str(self.issue.id),
+            "serviceType": self.sentry_app.slug,
+            "displayName": "app#123",
+            "webUrl": "https://example.com/issues/123",
+        }


### PR DESCRIPTION
Support webhooks for external issue creation + linking. Will need a follow up frontend PR so users can actually subscribe to these.