### PR TITLE
feat(slack): Add logging for Slack webhook retries and slow responses

### DIFF
--- a/src/sentry/middleware/integrations/parsers/slack.py
+++ b/src/sentry/middleware/integrations/parsers/slack.py
@@ -368,6 +368,7 @@ class SlackRequestParser(BaseRequestParser):
                 "url_name": self.match.url_name,
                 "status_code": status_code,
                 "event_type": self.slack_request.type,
+                "slack_event_id": self.slack_request.data.get("event_id"),
                 "retry_num": self.request.META.get("HTTP_X_SLACK_RETRY_NUM"),
                 "retry_reason": self.request.META.get("HTTP_X_SLACK_RETRY_REASON"),
             },

--- a/src/sentry/middleware/integrations/parsers/slack.py
+++ b/src/sentry/middleware/integrations/parsers/slack.py
@@ -14,6 +14,7 @@ from rest_framework import status
 from rest_framework.request import Request
 from slack_sdk.errors import SlackApiError
 
+from sentry import options
 from sentry.hybridcloud.outbox.category import WebhookProviderIdentifier
 from sentry.hybridcloud.services.organization_mapping.model import RpcOrganizationMapping
 from sentry.integrations.messaging import commands
@@ -361,7 +362,9 @@ class SlackRequestParser(BaseRequestParser):
             sample_rate=1.0,
         )
 
-        if elapsed > SLACK_RESPONSE_TIMEOUT_SECONDS:
+        if elapsed > SLACK_RESPONSE_TIMEOUT_SECONDS and options.get(
+            "slack.log-webhook-retry-diagnostics"
+        ):
             slack_event_id = self.slack_request.data.get("event_id") if self.slack_request else None
             logger.info(
                 "slack.control.response_time_exceeded",
@@ -376,6 +379,9 @@ class SlackRequestParser(BaseRequestParser):
             )
 
     def _log_seer_agent_retry_headers(self, status_code: int | str) -> None:
+        if not options.get("slack.log-webhook-retry-diagnostics"):
+            return
+
         if not self._is_seer_agent_request(self.slack_request):
             return
 

--- a/src/sentry/middleware/integrations/parsers/slack.py
+++ b/src/sentry/middleware/integrations/parsers/slack.py
@@ -362,7 +362,7 @@ class SlackRequestParser(BaseRequestParser):
         )
 
         if elapsed > SLACK_RESPONSE_TIMEOUT_SECONDS:
-            slack_request_data = getattr(self.slack_request, "data", {})
+            slack_event_id = self.slack_request.data.get("event_id") if self.slack_request else None
             logger.info(
                 "slack.control.response_time_exceeded",
                 extra={
@@ -370,7 +370,7 @@ class SlackRequestParser(BaseRequestParser):
                     "url_name": self.match.url_name,
                     "status_code": status_code,
                     "event_type": self._get_metric_event_type(),
-                    "slack_event_id": slack_request_data.get("event_id"),
+                    "slack_event_id": slack_event_id,
                     "elapsed": elapsed,
                 },
             )

--- a/src/sentry/middleware/integrations/parsers/slack.py
+++ b/src/sentry/middleware/integrations/parsers/slack.py
@@ -60,6 +60,9 @@ SLACK_WEBHOOK_METRIC_EVENT_TYPES = frozenset(
     ["app_mention", "assistant_thread_started", "link_shared", "message", "reaction_added"]
 )
 
+# Slack gives us 3 seconds to respond before it considers the delivery failed.
+SLACK_RESPONSE_TIMEOUT_SECONDS = 3
+
 
 class SlackRequestParser(BaseRequestParser):
     provider = EXTERNAL_PROVIDERS[ExternalProviders.SLACK]  # "slack"
@@ -344,9 +347,10 @@ class SlackRequestParser(BaseRequestParser):
             )
             return
 
+        elapsed = time.time() - sent_at
         metrics.timing(
             "hybrid_cloud.integration_control.slack.response_time",
-            time.time() - sent_at,
+            elapsed,
             tags={
                 # SlackStagingRequestParser inherits this, so keep the two apart.
                 "provider": self.provider,
@@ -356,6 +360,20 @@ class SlackRequestParser(BaseRequestParser):
             },
             sample_rate=1.0,
         )
+
+        if elapsed > SLACK_RESPONSE_TIMEOUT_SECONDS:
+            slack_request_data = getattr(self.slack_request, "data", {})
+            logger.info(
+                "slack.control.response_time_exceeded",
+                extra={
+                    "path": self.request.path,
+                    "url_name": self.match.url_name,
+                    "status_code": status_code,
+                    "event_type": self._get_metric_event_type(),
+                    "slack_event_id": slack_request_data.get("event_id"),
+                    "elapsed": elapsed,
+                },
+            )
 
     def _log_seer_agent_retry_headers(self, status_code: int | str) -> None:
         if not self._is_seer_agent_request(self.slack_request):

--- a/src/sentry/middleware/integrations/parsers/slack.py
+++ b/src/sentry/middleware/integrations/parsers/slack.py
@@ -357,15 +357,34 @@ class SlackRequestParser(BaseRequestParser):
             sample_rate=1.0,
         )
 
+    def _log_seer_agent_retry_headers(self, status_code: int | str) -> None:
+        if not self._is_seer_agent_request(self.slack_request):
+            return
+
+        logger.info(
+            "slack.control.webhook_retry_headers",
+            extra={
+                "path": self.request.path,
+                "url_name": self.match.url_name,
+                "status_code": status_code,
+                "event_type": self.slack_request.type,
+                "retry_num": self.request.META.get("HTTP_X_SLACK_RETRY_NUM"),
+                "retry_reason": self.request.META.get("HTTP_X_SLACK_RETRY_REASON"),
+            },
+        )
+
     def get_response(self) -> HttpResponseBase:
         try:
             response = self._get_response()
         except Exception:
             # The final status code is decided further up the stack.
             self._record_response_time("error")
+            self._log_seer_agent_retry_headers("error")
             raise
 
         self._record_response_time(response.status_code)
+        self._log_seer_agent_retry_headers(response.status_code)
+
         return response
 
     def _get_response(self) -> HttpResponseBase:

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -608,6 +608,8 @@ register("slack.debug-workspace", flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("slack.debug-channel", flags=FLAG_AUTOMATOR_MODIFIABLE)
 # Log unfurl payloads for debugging
 register("slack.log-unfurl-payload", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
+# Log Slack webhook retry headers and slow (>3s) responses for debugging
+register("slack.log-webhook-retry-diagnostics", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 # Frequency of slack nudge blocks on issue alerts (0.0 to 1.0, where 0.3 = 30%)
 register(
     "slack.nudge-frequency",


### PR DESCRIPTION
Slack considers a webhook delivery failed if we don't respond within 3 seconds, then retries it with `x-slack-retry-num` and `x-slack-retry-reason` set. We currently have no visibility into how often either side of that happens.

## Changes

**`slack.control.webhook_retry_headers`** — logs Slack's retry headers for Seer agent requests, from `get_response` on both the success and exception paths:

- `retry_num` / `retry_reason` — the two Slack retry headers
- `slack_event_id` — Slack reuses `event_id` across retries of the same event, so this ties a retry series back to one webhook
- `path`, `url_name`, `status_code`, `event_type`

Gated on `_is_seer_agent_request`, so it covers app mentions, assistant thread starts, and assistant-scoped DMs — not all Slack webhook traffic.

**`slack.control.response_time_exceeded`** — logs when the response time already tracked by `_record_response_time` crosses `SLACK_RESPONSE_TIMEOUT_SECONDS` (3s), i.e. when we've missed Slack's deadline. Includes `elapsed` and the same `slack_event_id`, so a slow response can be correlated with the retry it causes.

Unlike the retry log, this one covers all Slack webhook traffic, since `_record_response_time` is not Seer-specific. `slack_request` is `None` on django views, so the `event_id` lookup is guarded and logs as null there.

## Notes

Slack only sets the retry headers on a redelivery, so `retry_num` and `retry_reason` log as null on a first delivery rather than the log being skipped. That's deliberate: it makes the retry rate computable as a fraction of total Seer agent traffic, and the first delivery appears in the series alongside its retries under the same `slack_event_id`.

The tradeoff is volume on the retry log — roughly one INFO line per Seer Slack interaction. The retry fields are the discriminator to filter on if it gets noisy. The slow-response log is bounded by how often we actually miss the deadline.