### PR TITLE
fix(contexts): Show `<redacted>` instead of "null" for scrubbed user context fields

### DIFF
--- a/static/app/components/events/contexts/knownContext/user.spec.tsx
+++ b/static/app/components/events/contexts/knownContext/user.spec.tsx
@@ -127,22 +127,22 @@ describe('UserContext', () => {
   });
 
   it('keeps scrubbed null fields that have direct meta annotations', () => {
-    const scrubbedUserContext: UserContext = {
-      id: null as any,
-      email: null as any,
-      username: null as any,
-      name: null as any,
-      ip_address: null as any,
+    const scrubbedUserContext = {
+      id: null,
+      email: null,
+      username: null,
+      name: null,
+      ip_address: null,
       geo: {
-        country_code: null as any,
-        city: null as any,
-        subdivision: null as any,
-        region: null as any,
+        country_code: null,
+        city: null,
+        subdivision: null,
+        region: null,
       },
     };
 
     const result = getUserContextData({
-      data: scrubbedUserContext,
+      data: scrubbedUserContext as unknown as UserContext,
       meta: MOCK_SCRUBBED_REDACTION,
     });
 

--- a/static/app/components/events/contexts/knownContext/user.spec.tsx
+++ b/static/app/components/events/contexts/knownContext/user.spec.tsx
@@ -34,6 +34,41 @@ const MOCK_REDACTION = {
   },
 };
 
+const MOCK_SCRUBBED_REDACTION = {
+  id: {
+    '': {
+      rem: [['project:2', 'x']],
+    },
+  },
+  email: {
+    '': {
+      rem: [['project:2', 'x']],
+    },
+  },
+  username: {
+    '': {
+      rem: [['project:2', 'x']],
+    },
+  },
+  name: {
+    '': {
+      rem: [['project:2', 'x']],
+    },
+  },
+  geo: {
+    city: {
+      '': {
+        rem: [['project:2', 'x']],
+      },
+    },
+    country_code: {
+      '': {
+        rem: [['project:2', 'x']],
+      },
+    },
+  },
+};
+
 describe('UserContext', () => {
   it('returns values and according to the parameters', () => {
     expect(getUserContextData({data: MOCK_USER_CONTEXT})).toEqual([
@@ -89,5 +124,61 @@ describe('UserContext', () => {
     ).toBeInTheDocument();
     expect(screen.getByText('Name')).toBeInTheDocument();
     expect(screen.getByText(/redacted/)).toBeInTheDocument();
+  });
+
+  it('keeps scrubbed null fields that have direct meta annotations', () => {
+    const scrubbedUserContext: UserContext = {
+      id: null as any,
+      email: null as any,
+      username: null as any,
+      name: null as any,
+      ip_address: null as any,
+      geo: {
+        country_code: null as any,
+        city: null as any,
+        subdivision: null as any,
+        region: null as any,
+      },
+    };
+
+    const result = getUserContextData({
+      data: scrubbedUserContext,
+      meta: MOCK_SCRUBBED_REDACTION,
+    });
+
+    expect(result.map(item => item.key)).toEqual(['id', 'email', 'username', 'name']);
+    expect(result.every(item => item.value === null)).toBe(true);
+  });
+
+  it('renders scrubbed null fields as redacted', () => {
+    const event = EventFixture({
+      _meta: {user: MOCK_SCRUBBED_REDACTION},
+    });
+
+    render(
+      <ContextCard
+        event={event}
+        type="user"
+        alias="user"
+        value={{
+          id: null,
+          email: null,
+          username: null,
+          name: null,
+          ip_address: null,
+          geo: {
+            country_code: null,
+            city: null,
+            subdivision: null,
+            region: null,
+          },
+        }}
+      />
+    );
+
+    expect(screen.getByText('User')).toBeInTheDocument();
+    expect(screen.getAllByText(/redacted/)).toHaveLength(4);
+    expect(screen.queryByText('null')).not.toBeInTheDocument();
+    expect(screen.queryByText('Geography')).not.toBeInTheDocument();
   });
 });

--- a/static/app/components/events/contexts/knownContext/user.tsx
+++ b/static/app/components/events/contexts/knownContext/user.tsx
@@ -55,7 +55,7 @@ function formatGeo(geoData: UserContext['geo'] = {}): string | undefined {
     );
   }
 
-  return geoStringArray.join(', ');
+  return geoStringArray.length > 0 ? geoStringArray.join(', ') : undefined;
 }
 
 export function getUserContextData({
@@ -120,8 +120,9 @@ export function getUserContextData({
             };
         }
       })
-      // Since user context is generated separately from the rest, it has all known keys with those
-      // unset appearing as `null`. We want to omit those unless they have annotations.
-      .filter(item => defined(item.value) || defined(meta?.[item.key]))
+      // User context includes all known keys even when unset (`null`). Omit those unless the
+      // field has a root-level meta annotation (the `['']` key), which indicates scrubbing or
+      // validation applied directly to this field — not to nested sub-fields (e.g. geo.city).
+      .filter(item => defined(item.value) || defined(meta?.[item.key]?.['']))
   );
 }

--- a/static/app/components/structuredEventData/index.spec.tsx
+++ b/static/app/components/structuredEventData/index.spec.tsx
@@ -97,6 +97,31 @@ describe('StructuredEventData', () => {
         within(screen.getByTestId('value-null')).getByText('null_value_output')
       ).toBeInTheDocument();
     });
+
+    it('renders scrubbed null values as redacted instead of "null"', () => {
+      const meta = {
+        '': {
+          rem: [['project:0', 'x']],
+        },
+      };
+      render(<StructuredEventData data={null} meta={meta} withAnnotatedText />);
+      expect(screen.getByText(/redacted/)).toBeInTheDocument();
+      expect(screen.queryByText('null')).not.toBeInTheDocument();
+    });
+
+    it('preserves renderNull when meta has no annotations', () => {
+      render(
+        <StructuredEventData
+          data={null}
+          config={{renderNull: () => 'None'}}
+          meta={{}}
+          withAnnotatedText
+        />
+      );
+      expect(
+        within(screen.getByTestId('value-null')).getByText('None')
+      ).toBeInTheDocument();
+    });
   });
 
   describe('collpasible values', () => {

--- a/static/app/components/structuredEventData/recursiveStructuredData.tsx
+++ b/static/app/components/structuredEventData/recursiveStructuredData.tsx
@@ -59,11 +59,12 @@ export function RecursiveStructuredData({
 
   if (config?.isNull?.(value) || value === null) {
     const nullValue = config?.renderNull?.(value) ?? String(value);
-    const metaEntry = meta?.[''] ?? meta;
-    const isRedacted =
+    const metaEntry: Record<string, any> | undefined = meta?.[''] ?? meta;
+    const isRedacted = !!(
       withAnnotatedText &&
       metaEntry &&
-      (metaEntry.rem?.length || metaEntry.err?.length || metaEntry.chunks?.length);
+      (metaEntry.rem?.length || metaEntry.err?.length || metaEntry.chunks?.length)
+    );
 
     return (
       <Fragment>

--- a/static/app/components/structuredEventData/recursiveStructuredData.tsx
+++ b/static/app/components/structuredEventData/recursiveStructuredData.tsx
@@ -59,13 +59,18 @@ export function RecursiveStructuredData({
 
   if (config?.isNull?.(value) || value === null) {
     const nullValue = config?.renderNull?.(value) ?? String(value);
+    const metaEntry = meta?.[''] ?? meta;
+    const isRedacted =
+      withAnnotatedText &&
+      metaEntry &&
+      (metaEntry.rem?.length || metaEntry.err?.length || metaEntry.chunks?.length);
 
     return (
       <Fragment>
         {formattedObjectKey}
         <ValueNull data-test-id="value-null">
           <AnnotatedValue
-            value={nullValue}
+            value={isRedacted ? null : nullValue}
             meta={meta}
             withAnnotatedText={withAnnotatedText}
             withOnlyFormattedText={withOnlyFormattedText}


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry/issues/120802.

When scrubbing rules replace user context values with `null`, the UI rendered the literal text "null" instead of showing `<redacted>` with a tooltip linking to the scrubbing rule. With these changes, when a null value has scrubbing annotations (`rem`/`err`/`chunks`), `null` (instead of "null") is passed to `AnnotatedValue` so that `<redacted>` is correctly rendered.