### PR TITLE
fix(issues): Query `errors` dataset for timeline

### DIFF
--- a/static/app/views/issueDetails/traceDataSection.spec.tsx
+++ b/static/app/views/issueDetails/traceDataSection.spec.tsx
@@ -106,7 +106,7 @@ describe('TraceDataSection', () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
       body: twoIssuesBody,
-      match: [MockApiClient.matchQuery({dataset: 'discover', project: -1})],
+      match: [MockApiClient.matchQuery({dataset: 'errors', project: -1})],
     });
     render(<TraceDataSection event={event} />, {organization});
     expect(await screen.findByLabelText('Current Event')).toBeInTheDocument();
@@ -127,7 +127,7 @@ describe('TraceDataSection', () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
       body: discoverBody,
-      match: [MockApiClient.matchQuery({dataset: 'discover', project: -1})],
+      match: [MockApiClient.matchQuery({dataset: 'errors', project: -1})],
     });
     const {container} = render(<TraceTimeline event={event} />, {organization});
     await waitFor(() =>
@@ -147,7 +147,7 @@ describe('TraceDataSection', () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
       body: emptyBody,
-      match: [MockApiClient.matchQuery({dataset: 'discover', project: -1})],
+      match: [MockApiClient.matchQuery({dataset: 'errors', project: -1})],
     });
     const {container} = render(<TraceTimeline event={event} />, {organization});
     await waitFor(() =>
@@ -167,7 +167,7 @@ describe('TraceDataSection', () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
       body: twoIssuesBody,
-      match: [MockApiClient.matchQuery({dataset: 'discover', project: -1})],
+      match: [MockApiClient.matchQuery({dataset: 'errors', project: -1})],
     });
     render(<TraceDataSection event={event} />, {organization});
     // Checking for the presence of seconds
@@ -187,7 +187,7 @@ describe('TraceDataSection', () => {
         // The event for the mainError is missing, thus, it will get added
         data: [secondError],
       },
-      match: [MockApiClient.matchQuery({dataset: 'discover', project: -1})],
+      match: [MockApiClient.matchQuery({dataset: 'errors', project: -1})],
     });
     render(<TraceDataSection event={event} />, {organization});
     expect(await screen.findByLabelText('Current Event')).toBeInTheDocument();
@@ -202,7 +202,7 @@ describe('TraceDataSection', () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
       body: discoverBody,
-      match: [MockApiClient.matchQuery({dataset: 'discover', project: -1})],
+      match: [MockApiClient.matchQuery({dataset: 'errors', project: -1})],
     });
     // Used to determine the project badge
     MockApiClient.addMockResponse({
@@ -261,7 +261,7 @@ describe('TraceDataSection', () => {
       url: `/organizations/${organization.slug}/events/`,
       // Only 1 issue
       body: discoverBody,
-      match: [MockApiClient.matchQuery({dataset: 'discover', project: -1})],
+      match: [MockApiClient.matchQuery({dataset: 'errors', project: -1})],
     });
     // Used to determine the project badge
     MockApiClient.addMockResponse({

--- a/static/app/views/issueDetails/traceTimeline/traceLink.spec.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceLink.spec.tsx
@@ -70,7 +70,7 @@ describe('TraceLink', () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
       body: discoverBody,
-      match: [MockApiClient.matchQuery({dataset: 'discover'})],
+      match: [MockApiClient.matchQuery({dataset: 'errors'})],
     });
     render(<TraceLink event={event} />, {organization});
     expect(await screen.findByText('View Full Trace')).toBeInTheDocument();

--- a/static/app/views/issueDetails/traceTimeline/useTraceTimelineEvents.tsx
+++ b/static/app/views/issueDetails/traceTimeline/useTraceTimelineEvents.tsx
@@ -111,7 +111,7 @@ export function useTraceTimelineEvents({event}: UseTraceTimelineEventsOptions): 
       {
         query: {
           // Other events
-          dataset: DiscoverDatasets.DISCOVER,
+          dataset: DiscoverDatasets.ERRORS,
           field: [
             'title',
             'project',


### PR DESCRIPTION
Explicitly query the `errors` dataset instead of `discover` in the issue details trace timeline query.

`discover` is deprecated (because `transactions` is deprecated, and `discover` queries both `errors` and `transactions`).

I traced the use of this hook and:

- The return type does not expect transactions:
```ts
export type TimelineEvent =
  | TimelineDefaultEvent
  | TimelineErrorEvent
  | TimelineIssuePlatformEvent;
```
- transactions are ignored for the `oneOtherIssueEvent` return value, which is the main UI driver from this hook
- The returned `traceEvents` property is only rendered on the feedback details screen, and in a context where a list of errors would be more expected than a mixed errors/transaction list

So, this seems safe to me, and helps us get rid of two deprecated datasets. (This call site is the largest internal user of `discover` remaining.) Thanks!

Fixes BROWSE-669.