### PR TITLE
fix(dashboards): Improve Y-axis when fitting Y-axis range to data

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
@@ -421,8 +421,10 @@ export default Storybook.story('TimeSeriesWidgetVisualization', story => {
           A common issue with Y axes is data ranges. Some time series, like crash rates
           tend to hover very close to 100%. In these cases, starting the Y axis at 0 can
           make it difficult to see the actual values. You can set the{' '}
-          <code>axisRange</code> prop to <code>"dataMin"</code> to start the Y axis at the
-          minimum value of the data.
+          <code>axisRange</code> prop to <code>"dataMin"</code> to start the Y axis near
+          the minimum value of the data, instead of at 0. The exact starting value is the
+          nearest round tick value at or below the data minimum, so the axis labels stay
+          legible.
         </p>
 
         <p>

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -73,7 +73,7 @@ export interface TimeSeriesWidgetVisualizationProps extends Partial<LoadableChar
    * Sets the range of the Y axis.
    *
    * - `auto`: The Y axis starts at 0, and ends at the maximum value of the data.
-   * - `dataMin`: The Y axis starts at the minimum value of the data, and ends at the maximum value of the data.
+   * - `dataMin`: The Y axis starts at a round tick value at or just below the minimum value of the data, and ends at the maximum value of the data.
    * Default: `auto`
    */
   axisRange?: AxisRange;

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetYAxis.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetYAxis.tsx
@@ -27,7 +27,10 @@ export function TimeSeriesWidgetYAxis(
           show: false,
         },
       },
-      min: yAxisRange === 'auto' ? null : 'dataMin',
+      // "Zooms" the Y-axis to start at the minimum (approximate) of the data
+      // range. Better than using `min: "dataMin"` because `scale` ensure that
+      // the first tick is on a round value, which prevents bad axis margins.
+      scale: yAxisRange !== 'auto',
       // @ts-expect-error ECharts types are wrong here. Returning `undefined` from the `max` function is 100% allowed and is listed in the documentation. See https://github.com/apache/echarts/pull/12215/
       max: value => {
         // Handle a very specific edge case with percentage formatting.


### PR DESCRIPTION
**Before:**
<img width="413" height="261" alt="Screenshot 2026-07-30 at 4 32 57 PM" src="https://github.com/user-attachments/assets/fb636770-8874-4480-b6de-487b5be425c5" />

**After:**
<img width="271" height="315" alt="Screenshot 2026-07-30 at 4 33 16 PM" src="https://github.com/user-attachments/assets/e65252c5-d04a-471f-86a5-4497bf245a54" />

ECharts' `scale` option uses smarter logic, and does better tick placement in these situations.

Fixes DAIN-1734