### PR TITLE
feat(workflow-engine): Allow for creating all-project workflows

### DIFF
--- a/static/app/types/workflowEngine/detectors.tsx
+++ b/static/app/types/workflowEngine/detectors.tsx
@@ -235,7 +235,8 @@ interface UpdateUptimeDataSourcePayload {
 export interface BaseDetectorUpdatePayload {
   name: string;
   owner: string | null;
-  projectId: Detector['projectId'];
+  // Note: projectId is null for the AllProjectsDetector, but it cannot be updated.
+  projectId: string;
   type: Detector['type'];
   workflowIds: string[];
   description?: string | null;

--- a/static/app/types/workflowEngine/detectors.tsx
+++ b/static/app/types/workflowEngine/detectors.tsx
@@ -127,7 +127,7 @@ interface UptimeDetectorConfig {
   recoveryThreshold: number;
 }
 
-interface IssueStreamDetectorConfig {
+interface AllProjectsDetectorConfig {
   organizationId: number;
 }
 
@@ -170,10 +170,14 @@ export interface ErrorDetector extends BaseDetector {
   // TODO: Add error detector type fields
   readonly type: 'error';
 }
+export interface IssueStreamDetector extends BaseDetector {
+  // TODO: Add issue stream detector type fields
+  readonly type: 'issue_stream';
+}
 
-export interface IssueStreamDetector extends Omit<BaseDetector, 'projectId'> {
-  config: IssueStreamDetectorConfig | null;
-  projectId: string | null;
+export interface AllProjectsDetector extends Omit<BaseDetector, 'projectId'> {
+  config: AllProjectsDetectorConfig;
+  projectId: null;
   readonly type: 'issue_stream';
 }
 
@@ -198,6 +202,7 @@ export type Detector =
   | CronDetector
   | ErrorDetector
   | IssueStreamDetector
+  | AllProjectsDetector
   | PreprodDetector;
 
 interface UpdateConditionGroupPayload {
@@ -230,7 +235,7 @@ interface UpdateUptimeDataSourcePayload {
 export interface BaseDetectorUpdatePayload {
   name: string;
   owner: string | null;
-  projectId: string;
+  projectId: Detector['projectId'];
   type: Detector['type'];
   workflowIds: string[];
   description?: string | null;

--- a/static/app/types/workflowEngine/detectors.tsx
+++ b/static/app/types/workflowEngine/detectors.tsx
@@ -230,7 +230,7 @@ interface UpdateUptimeDataSourcePayload {
 export interface BaseDetectorUpdatePayload {
   name: string;
   owner: string | null;
-  projectId: Detector['projectId'];
+  projectId: string;
   type: Detector['type'];
   workflowIds: string[];
   description?: string | null;

--- a/static/app/types/workflowEngine/detectors.tsx
+++ b/static/app/types/workflowEngine/detectors.tsx
@@ -128,7 +128,7 @@ interface UptimeDetectorConfig {
 }
 
 interface IssueStreamDetectorConfig {
-  organization_id: number;
+  organizationId: number;
 }
 
 type BaseDetector = Readonly<{

--- a/static/app/types/workflowEngine/detectors.tsx
+++ b/static/app/types/workflowEngine/detectors.tsx
@@ -127,6 +127,10 @@ interface UptimeDetectorConfig {
   recoveryThreshold: number;
 }
 
+interface IssueStreamDetectorConfig {
+  organization_id: number;
+}
+
 type BaseDetector = Readonly<{
   createdBy: string | null;
   dateCreated: string;
@@ -167,8 +171,9 @@ export interface ErrorDetector extends BaseDetector {
   readonly type: 'error';
 }
 
-export interface IssueStreamDetector extends BaseDetector {
-  // TODO: Add issue stream detector type fields
+export interface IssueStreamDetector extends Omit<BaseDetector, 'projectId'> {
+  config: IssueStreamDetectorConfig | null;
+  projectId: string | null;
   readonly type: 'issue_stream';
 }
 

--- a/static/app/utils/useProjectFromId.tsx
+++ b/static/app/utils/useProjectFromId.tsx
@@ -1,7 +1,7 @@
 import {useProjects} from 'sentry/utils/useProjects';
 
 interface Props {
-  project_id: string | undefined;
+  project_id: string | null | undefined;
 }
 
 export function useProjectFromId({project_id}: Props) {

--- a/static/app/utils/useProjectFromId.tsx
+++ b/static/app/utils/useProjectFromId.tsx
@@ -1,7 +1,7 @@
 import {useProjects} from 'sentry/utils/useProjects';
 
 interface Props {
-  project_id: string | null | undefined;
+  project_id: string | undefined;
 }
 
 export function useProjectFromId({project_id}: Props) {

--- a/static/app/views/automations/components/automationBuilderDrawerForm.tsx
+++ b/static/app/views/automations/components/automationBuilderDrawerForm.tsx
@@ -40,6 +40,7 @@ import {useAutomationBuilderErrors} from 'sentry/views/automations/hooks/useAuto
 import {resolveDetectorIdsForProjects} from 'sentry/views/automations/utils/resolveDetectorIdsForProjects';
 
 const DEFAULT_INITIAL_DATA = {
+  allProjects: false,
   name: '',
   environment: null,
   frequency: 0,

--- a/static/app/views/automations/components/automationFormData.spec.tsx
+++ b/static/app/views/automations/components/automationFormData.spec.tsx
@@ -1,0 +1,34 @@
+import {DataConditionGroupLogicType} from 'sentry/types/workflowEngine/dataConditions';
+import type {AutomationBuilderState} from 'sentry/views/automations/components/automationBuilderContext';
+import {
+  type AutomationFormData,
+  validateAutomationBuilderState,
+} from 'sentry/views/automations/components/automationFormData';
+import {CONNECTED_MONITORS_ERROR_ID} from 'sentry/views/automations/components/editConnectedMonitors';
+
+describe('validateAutomationBuilderState', () => {
+  const state: AutomationBuilderState = {
+    triggers: {
+      id: 'when',
+      logicType: DataConditionGroupLogicType.ANY,
+      conditions: [],
+    },
+    actionFilters: [],
+  };
+
+  it('allows all projects without project or detector IDs', () => {
+    const data: AutomationFormData = {
+      allProjects: true,
+      detectorIds: [],
+      enabled: true,
+      environment: null,
+      frequency: 0,
+      name: 'All projects alert',
+      projectIds: [],
+    };
+
+    expect(validateAutomationBuilderState(state, data)).not.toHaveProperty(
+      CONNECTED_MONITORS_ERROR_ID
+    );
+  });
+});

--- a/static/app/views/automations/components/automationFormData.tsx
+++ b/static/app/views/automations/components/automationFormData.tsx
@@ -15,6 +15,7 @@ import {dataConditionNodesMap} from 'sentry/views/automations/components/dataCon
 import {CONNECTED_MONITORS_ERROR_ID} from 'sentry/views/automations/components/editConnectedMonitors';
 
 export interface AutomationFormData {
+  allProjects: boolean;
   detectorIds: string[];
   enabled: boolean;
   environment: string | null;
@@ -94,6 +95,7 @@ export function getAutomationFormData(
   automation: Automation
 ): Record<string, FieldValue> {
   return {
+    allProjects: false,
     detectorIds: automation.detectorIds,
     environment: automation.environment,
     frequency: automation.config.frequency ?? 0,
@@ -116,6 +118,7 @@ export function validateAutomationBuilderState(
 
   if (
     validateConnectedMonitors &&
+    !data.allProjects &&
     !data.detectorIds?.length &&
     !data.projectIds?.length
   ) {

--- a/static/app/views/automations/components/automationListTable/projectsCell.tsx
+++ b/static/app/views/automations/components/automationListTable/projectsCell.tsx
@@ -1,6 +1,9 @@
+import {Text} from '@sentry/scraps/text';
+
 import {Placeholder} from 'sentry/components/placeholder';
 import {ProjectList} from 'sentry/components/projectList';
 import {EmptyCell} from 'sentry/components/workflowEngine/gridCell/emptyCell';
+import {t} from 'sentry/locale';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import type {Automation} from 'sentry/types/workflowEngine/automations';
 import {defined} from 'sentry/utils/defined';
@@ -15,6 +18,10 @@ export function ProjectsCell({automation}: {automation: Automation}) {
 
   if (isLoading) {
     return <Placeholder height="20px" />;
+  }
+
+  if (automation.detectorIds.some(id => detectorsById.get(id)?.projectId === null)) {
+    return <Text>{t('All Projects')}</Text>;
   }
 
   const projectIds = [

--- a/static/app/views/automations/components/connectedProjectsList.tsx
+++ b/static/app/views/automations/components/connectedProjectsList.tsx
@@ -3,6 +3,7 @@ import {useQuery} from '@tanstack/react-query';
 
 import {Container} from '@sentry/scraps/layout';
 import {getPaginationCaption, Pagination} from '@sentry/scraps/pagination';
+import {Text} from '@sentry/scraps/text';
 
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import {LoadingError} from 'sentry/components/loadingError';
@@ -20,9 +21,19 @@ interface Props {
   automationId: string;
 }
 
-function ConnectedProjectRow({projectId}: {projectId: string}) {
+function ConnectedProjectRow({projectId}: {projectId: string | null}) {
   const organization = useOrganization();
-  const project = useProjectFromId({project_id: projectId});
+  const project = useProjectFromId({project_id: projectId ?? undefined});
+
+  if (projectId === null) {
+    return (
+      <SimpleTable.Row>
+        <SimpleTable.RowCell>
+          <Text>{t('All Projects')}</Text>
+        </SimpleTable.RowCell>
+      </SimpleTable.Row>
+    );
+  }
 
   if (!project) {
     return null;

--- a/static/app/views/automations/components/editConnectedMonitors.spec.tsx
+++ b/static/app/views/automations/components/editConnectedMonitors.spec.tsx
@@ -1,4 +1,5 @@
 import {
+  AllProjectsDetectorFixture,
   IssueStreamDetectorFixture,
   MetricDetectorFixture,
 } from 'sentry-fixture/detectors';
@@ -67,6 +68,28 @@ describe('EditConnectedMonitors', () => {
     ).toBeInTheDocument();
     expect(
       screen.getByRole('radio', {name: 'Alert on specific monitors'})
+    ).toBeInTheDocument();
+  });
+
+  it('disables the all projects option with a message when the user cannot edit', async () => {
+    render(<EditConnectedMonitors connectedIds={[]} setConnectedIds={jest.fn()} />, {
+      organization: OrganizationFixture({
+        features: ['workflow-engine-all-projects-detector'],
+        access: [],
+      }),
+    });
+
+    const allProjectsRadio = await screen.findByRole('radio', {
+      name: 'Alert on all issues in all projects',
+    });
+
+    expect(allProjectsRadio).toBeDisabled();
+
+    await userEvent.hover(allProjectsRadio);
+    expect(
+      await screen.findByText(
+        'Only organization owners and managers can create global issue monitors.'
+      )
     ).toBeInTheDocument();
   });
 
@@ -223,11 +246,7 @@ describe('EditConnectedMonitors', () => {
   });
 
   it('shows all projects mode when connected to the all-projects detector', async () => {
-    const allProjectsDetector = IssueStreamDetectorFixture({
-      id: '101',
-      projectId: null,
-      config: {organization_id: 1},
-    });
+    const allProjectsDetector = AllProjectsDetectorFixture({id: '101'});
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/detectors/',
       method: 'GET',

--- a/static/app/views/automations/components/editConnectedMonitors.spec.tsx
+++ b/static/app/views/automations/components/editConnectedMonitors.spec.tsx
@@ -2,6 +2,7 @@ import {
   IssueStreamDetectorFixture,
   MetricDetectorFixture,
 } from 'sentry-fixture/detectors';
+import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 
@@ -67,6 +68,30 @@ describe('EditConnectedMonitors', () => {
     expect(
       screen.getByRole('radio', {name: 'Alert on specific monitors'})
     ).toBeInTheDocument();
+  });
+
+  it('selects all projects', async () => {
+    const model = new FormModel();
+    model.setInitialData({allProjects: false, projectIds: [], detectorIds: []});
+
+    render(
+      <Form model={model}>
+        <EditConnectedMonitors connectedIds={[]} setConnectedIds={jest.fn()} />
+      </Form>,
+      {
+        organization: OrganizationFixture({
+          features: ['workflow-engine-all-projects-detector'],
+        }),
+      }
+    );
+
+    await userEvent.click(
+      await screen.findByRole('radio', {name: 'Alert on all issues in all projects'})
+    );
+
+    expect(model.getValue('allProjects')).toBe(true);
+    expect(model.getValue('projectIds')).toBeFalsy();
+    expect(screen.queryByText('Select projects')).not.toBeInTheDocument();
   });
 
   it('defaults to "all project issues" mode when no monitors are connected', async () => {
@@ -195,6 +220,41 @@ describe('EditConnectedMonitors', () => {
         screen.getByRole('radio', {name: 'Alert on all issues in selected projects'})
       ).toBeChecked();
     });
+  });
+
+  it('shows all projects mode when connected to the all-projects detector', async () => {
+    const allProjectsDetector = IssueStreamDetectorFixture({
+      id: '101',
+      projectId: null,
+      config: {organization_id: 1},
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/detectors/',
+      method: 'GET',
+      body: [allProjectsDetector],
+      match: [MockApiClient.matchQuery({id: [allProjectsDetector.id]})],
+    });
+    const model = new FormModel();
+    model.setInitialData({allProjects: false, projectIds: [], detectorIds: ['101']});
+
+    render(
+      <Form model={model}>
+        <EditConnectedMonitors
+          connectedIds={[allProjectsDetector.id]}
+          setConnectedIds={jest.fn()}
+        />
+      </Form>,
+      {
+        organization: OrganizationFixture({
+          features: ['workflow-engine-all-projects-detector'],
+        }),
+      }
+    );
+
+    expect(
+      await screen.findByRole('radio', {name: 'Alert on all issues in all projects'})
+    ).toBeChecked();
+    await waitFor(() => expect(model.getValue('allProjects')).toBe(true));
   });
 
   it('switches between modes correctly', async () => {

--- a/static/app/views/automations/components/editConnectedMonitors.tsx
+++ b/static/app/views/automations/components/editConnectedMonitors.tsx
@@ -8,7 +8,7 @@ import {useDrawer} from '@sentry/scraps/drawer';
 import {DrawerHeader} from '@sentry/scraps/drawer';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 
-import {RadioGroup} from 'sentry/components/forms/controls/radioGroup';
+import {RadioGroup, type RadioOption} from 'sentry/components/forms/controls/radioGroup';
 import {SentryProjectSelectorField} from 'sentry/components/forms/fields/sentryProjectSelectorField';
 import {FormContext} from 'sentry/components/forms/formContext';
 import {PageFiltersContainer} from 'sentry/components/pageFilters/container';
@@ -21,6 +21,7 @@ import {IconAdd, IconEdit} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Automation} from 'sentry/types/workflowEngine/automations';
 import type {Detector} from 'sentry/types/workflowEngine/detectors';
+import {defined} from 'sentry/utils/defined';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
 import {AutomationBuilderErrorContext} from 'sentry/views/automations/components/automationBuilderErrorContext';
@@ -35,7 +36,7 @@ const PROJECT_GROUPS = [
   {key: 'all', label: t('Other')},
 ];
 
-type MonitorMode = 'project' | 'specific';
+type MonitorMode = 'allProjects' | 'project' | 'specific';
 
 interface Props {
   connectedIds: Automation['detectorIds'];
@@ -47,6 +48,10 @@ interface ContentProps extends Props {
 }
 
 function getInitialMonitorMode(connectedDetectors: Detector[]): MonitorMode {
+  if (connectedDetectors.some(d => d.type === 'issue_stream' && d.projectId === null)) {
+    return 'allProjects';
+  }
+
   if (
     !connectedDetectors.length ||
     connectedDetectors.every(d => d.type === 'issue_stream')
@@ -295,14 +300,19 @@ function EditConnectedMonitorsContent({
   const [monitorMode, setMonitorMode] = useState<MonitorMode>(initialMode);
   const {form} = useContext(FormContext);
   const errorContext = useContext(AutomationBuilderErrorContext);
+  const organization = useOrganization();
 
   const handleModeChange = useCallback(
     (newMode: MonitorMode) => {
       setMonitorMode(newMode);
       setConnectedIds([]);
       form?.setValue('projectIds', []);
+      form?.setValue('allProjects', newMode === 'allProjects');
+      if (newMode === 'allProjects') {
+        errorContext?.removeError(CONNECTED_MONITORS_ERROR_ID);
+      }
     },
-    [form, setConnectedIds]
+    [errorContext, form, setConnectedIds]
   );
   const handleProjectChange = useCallback(
     (projectIds: string[]) => {
@@ -325,6 +335,14 @@ function EditConnectedMonitorsContent({
     [setConnectedIds, errorContext]
   );
 
+  const monitorModeChoices: Array<RadioOption<MonitorMode>> = [
+    ['project', t('Alert on all issues in selected projects')],
+    ['specific', t('Alert on specific monitors')],
+  ];
+  if (organization.features.includes('workflow-engine-all-projects-detector')) {
+    monitorModeChoices.push(['allProjects', t('Alert on all issues in all projects')]);
+  }
+
   return (
     <WorkflowEngineContainer>
       <FormSection
@@ -337,20 +355,17 @@ function EditConnectedMonitorsContent({
           <RadioGroup
             label={t('Connected monitors mode')}
             value={monitorMode}
-            choices={[
-              ['project', t('Alert on all issues in selected projects')],
-              ['specific', t('Alert on specific monitors')],
-            ]}
+            choices={monitorModeChoices}
             onChange={handleModeChange}
           />
           {monitorMode === 'project' ? (
             <AllProjectIssuesSection onProjectChange={handleProjectChange} />
-          ) : (
+          ) : monitorMode === 'specific' ? (
             <SpecificMonitorsSection
               connectedIds={connectedIds}
               setConnectedIds={handleSetConnectedIds}
             />
-          )}
+          ) : null}
           {errorContext?.errors[CONNECTED_MONITORS_ERROR_ID] && (
             <Alert variant="danger">
               {errorContext.errors[CONNECTED_MONITORS_ERROR_ID]}
@@ -374,6 +389,11 @@ export function EditConnectedMonitors({connectedIds, setConnectedIds}: Props) {
     }
     setFirstLoad(false);
 
+    if (initialMode === 'allProjects') {
+      form?.setValue('allProjects', true);
+      return;
+    }
+
     if (initialMode !== 'project') {
       return;
     }
@@ -382,7 +402,8 @@ export function EditConnectedMonitors({connectedIds, setConnectedIds}: Props) {
     const selectedProjectIds =
       connectedDetectors
         ?.filter(detector => connectedIds.includes(detector.id))
-        .map(d => d.projectId) ?? [];
+        .map(d => d.projectId)
+        .filter(defined) ?? [];
     if (form && selectedProjectIds.length > 0) {
       form.setValue('projectIds', selectedProjectIds);
     }

--- a/static/app/views/automations/components/editConnectedMonitors.tsx
+++ b/static/app/views/automations/components/editConnectedMonitors.tsx
@@ -30,6 +30,7 @@ import {useConnectedDetectors} from 'sentry/views/automations/hooks/useConnected
 import {DetectorSearch} from 'sentry/views/detectors/components/detectorSearch';
 import {detectorListApiOptions} from 'sentry/views/detectors/hooks';
 import {makeMonitorCreatePathname} from 'sentry/views/detectors/pathnames';
+import {useCanEditDetectorWorkflowConnections} from 'sentry/views/detectors/utils/useCanEditDetector';
 
 const PROJECT_GROUPS = [
   {key: 'member', label: t('My Projects')},
@@ -335,12 +336,23 @@ function EditConnectedMonitorsContent({
     [setConnectedIds, errorContext]
   );
 
+  const canEditAllProjects = useCanEditDetectorWorkflowConnections({projectId: null});
+
   const monitorModeChoices: Array<RadioOption<MonitorMode>> = [
     ['project', t('Alert on all issues in selected projects')],
     ['specific', t('Alert on specific monitors')],
   ];
+
+  const disabledChoices: Array<[MonitorMode, React.ReactNode?]> = [];
   if (organization.features.includes('workflow-engine-all-projects-detector')) {
     monitorModeChoices.push(['allProjects', t('Alert on all issues in all projects')]);
+
+    if (!canEditAllProjects) {
+      disabledChoices.push([
+        'allProjects',
+        t('Only organization owners and managers can create global issue monitors.'),
+      ]);
+    }
   }
 
   return (
@@ -356,6 +368,7 @@ function EditConnectedMonitorsContent({
             label={t('Connected monitors mode')}
             value={monitorMode}
             choices={monitorModeChoices}
+            disabledChoices={disabledChoices}
             onChange={handleModeChange}
           />
           {monitorMode === 'project' ? (

--- a/static/app/views/automations/constants.tsx
+++ b/static/app/views/automations/constants.tsx
@@ -1,1 +1,2 @@
 export const AUTOMATION_LIST_PAGE_LIMIT = 20;
+export const ALL_PROJECTS_DETECTOR_NAME = 'Issue Stream: All Projects';

--- a/static/app/views/automations/detail.spec.tsx
+++ b/static/app/views/automations/detail.spec.tsx
@@ -4,6 +4,7 @@ import {
   AutomationFixture,
 } from 'sentry-fixture/automations';
 import {
+  AllProjectsDetectorFixture,
   IssueStreamDetectorFixture,
   MetricDetectorFixture,
 } from 'sentry-fixture/detectors';
@@ -103,13 +104,7 @@ describe('AutomationDetail', () => {
   it('shows all projects for an all-projects detector', async () => {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/detectors/',
-      body: [
-        IssueStreamDetectorFixture({
-          id: '10',
-          projectId: null,
-          config: {organization_id: 1},
-        }),
-      ],
+      body: [AllProjectsDetectorFixture({id: '10'})],
       match: [MockApiClient.matchQuery({query: 'type:issue_stream workflow:123'})],
     });
 

--- a/static/app/views/automations/detail.spec.tsx
+++ b/static/app/views/automations/detail.spec.tsx
@@ -100,6 +100,30 @@ describe('AutomationDetail', () => {
     expect(screen.getByRole('heading', {name: 'Details'})).toBeInTheDocument();
   });
 
+  it('shows all projects for an all-projects detector', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/detectors/',
+      body: [
+        IssueStreamDetectorFixture({
+          id: '10',
+          projectId: null,
+          config: {organization_id: 1},
+        }),
+      ],
+      match: [MockApiClient.matchQuery({query: 'type:issue_stream workflow:123'})],
+    });
+
+    render(<AutomationDetail />, {
+      organization,
+      initialRouterConfig: {
+        route: '/alerts/:automationId/',
+        location: {pathname: '/alerts/123/'},
+      },
+    });
+
+    expect(await screen.findByText('All Projects')).toBeInTheDocument();
+  });
+
   it('can disable an enabled automation', async () => {
     const disabledAutomation = AutomationFixture({
       ...automation,

--- a/static/app/views/automations/hooks/useCanEditAutomation.tsx
+++ b/static/app/views/automations/hooks/useCanEditAutomation.tsx
@@ -8,6 +8,10 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 
 export function useCanEditAutomation(): boolean {
   const organization = useOrganization();
+  // TODO(Leander): Workflows connected to the all-projects detector require elevated permissions
+  // (org:write) but at the moment, not every callsite for this hook has the context to determine
+  // whether that applies. The backend still gates the mutations correctly, but this means some
+  // buttons don't appear disabled when they should.
   return hasEveryAccess(['alerts:write'], {organization});
 }
 

--- a/static/app/views/automations/list.spec.tsx
+++ b/static/app/views/automations/list.spec.tsx
@@ -4,7 +4,7 @@ import {
   AutomationFixture,
 } from 'sentry-fixture/automations';
 import {
-  IssueStreamDetectorFixture,
+  AllProjectsDetectorFixture,
   MetricDetectorFixture,
 } from 'sentry-fixture/detectors';
 import {OrganizationFixture} from 'sentry-fixture/organization';
@@ -146,11 +146,7 @@ describe('AutomationsList', () => {
   });
 
   it('shows all projects for an all-projects detector', async () => {
-    const allProjectsDetector = IssueStreamDetectorFixture({
-      id: '10',
-      projectId: null,
-      config: {organization_id: 1},
-    });
+    const allProjectsDetector = AllProjectsDetectorFixture({id: '10'});
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/workflows/',
       body: [AutomationFixture({id: '100', detectorIds: [allProjectsDetector.id]})],

--- a/static/app/views/automations/list.spec.tsx
+++ b/static/app/views/automations/list.spec.tsx
@@ -3,7 +3,10 @@ import {
   ActionFixture,
   AutomationFixture,
 } from 'sentry-fixture/automations';
-import {MetricDetectorFixture} from 'sentry-fixture/detectors';
+import {
+  IssueStreamDetectorFixture,
+  MetricDetectorFixture,
+} from 'sentry-fixture/detectors';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
@@ -140,6 +143,31 @@ describe('AutomationsList', () => {
     // Projects column should show em dash for automation with no detectors
     const projectsColumn = row.querySelector('[data-column-name="projects"]')!;
     expect(within(projectsColumn as HTMLElement).getByText('—')).toBeInTheDocument();
+  });
+
+  it('shows all projects for an all-projects detector', async () => {
+    const allProjectsDetector = IssueStreamDetectorFixture({
+      id: '10',
+      projectId: null,
+      config: {organization_id: 1},
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/workflows/',
+      body: [AutomationFixture({id: '100', detectorIds: [allProjectsDetector.id]})],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/detectors/',
+      body: [allProjectsDetector],
+      match: [MockApiClient.matchQuery({id: [allProjectsDetector.id]})],
+    });
+
+    render(<AutomationsList />, {organization});
+
+    const row = await screen.findByTestId('automation-list-row');
+    const projectsColumn = row.querySelector('[data-column-name="projects"]')!;
+    expect(
+      await within(projectsColumn as HTMLElement).findByText('All Projects')
+    ).toBeInTheDocument();
   });
 
   it('can filter by project', async () => {

--- a/static/app/views/automations/new.tsx
+++ b/static/app/views/automations/new.tsx
@@ -71,6 +71,7 @@ function AutomationBreadcrumbs() {
 }
 
 const INITIAL_FORM_DATA_DEFAULTS = {
+  allProjects: false,
   name: '',
   environment: null,
   frequency: 0,

--- a/static/app/views/automations/utils/fetchIssueStreamDetectorIds.ts
+++ b/static/app/views/automations/utils/fetchIssueStreamDetectorIds.ts
@@ -29,3 +29,20 @@ export async function fetchIssueStreamDetectorIdsForProjects({
     .map(projectId => detectors.find(detector => detector.projectId === projectId)?.id)
     .filter(defined);
 }
+
+export async function fetchAllProjectsDetectorId({
+  queryClient,
+  organization,
+}: {
+  organization: Organization;
+  queryClient: QueryClient;
+}): Promise<string | undefined> {
+  const {json: detectors} = await queryClient.fetchQuery(
+    detectorListApiOptions(organization, {
+      query: 'type:issue_stream',
+      includeIssueStreamDetectors: true,
+    })
+  );
+
+  return detectors.find(detector => detector.projectId === null)?.id;
+}

--- a/static/app/views/automations/utils/fetchIssueStreamDetectorIds.ts
+++ b/static/app/views/automations/utils/fetchIssueStreamDetectorIds.ts
@@ -2,6 +2,7 @@ import type {QueryClient} from '@tanstack/react-query';
 
 import type {Organization} from 'sentry/types/organization';
 import {defined} from 'sentry/utils/defined';
+import {ALL_PROJECTS_DETECTOR_NAME} from 'sentry/views/automations/constants';
 import {detectorListApiOptions} from 'sentry/views/detectors/hooks';
 
 export async function fetchIssueStreamDetectorIdsForProjects({
@@ -40,7 +41,7 @@ export async function fetchAllProjectsDetectorId({
   const {json: detectors} = await queryClient.fetchQuery(
     detectorListApiOptions(organization, {
       type: 'issue_stream',
-      query: 'name:"All Projects"',
+      query: `name:"${ALL_PROJECTS_DETECTOR_NAME}"`,
       includeIssueStreamDetectors: true,
       limit: 1,
     })

--- a/static/app/views/automations/utils/fetchIssueStreamDetectorIds.ts
+++ b/static/app/views/automations/utils/fetchIssueStreamDetectorIds.ts
@@ -39,8 +39,10 @@ export async function fetchAllProjectsDetectorId({
 }): Promise<string | undefined> {
   const {json: detectors} = await queryClient.fetchQuery(
     detectorListApiOptions(organization, {
-      query: 'type:issue_stream',
+      type: 'issue_stream',
+      query: 'name:"All Projects"',
       includeIssueStreamDetectors: true,
+      limit: 1,
     })
   );
 

--- a/static/app/views/automations/utils/resolveDetectorIdsForProjects.spec.ts
+++ b/static/app/views/automations/utils/resolveDetectorIdsForProjects.spec.ts
@@ -1,4 +1,7 @@
-import {IssueStreamDetectorFixture} from 'sentry-fixture/detectors';
+import {
+  AllProjectsDetectorFixture,
+  IssueStreamDetectorFixture,
+} from 'sentry-fixture/detectors';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {makeTestQueryClient} from 'sentry-test/queryClient';
@@ -13,10 +16,9 @@ describe('resolveDetectorIdsForProjects', () => {
 
   it('resolves the all-projects detector', async () => {
     const organization = OrganizationFixture();
-    const allProjectsDetector = IssueStreamDetectorFixture({
+    const allProjectsDetector = AllProjectsDetectorFixture({
       id: '10',
-      projectId: null,
-      config: {organization_id: Number(organization.id)},
+      config: {organizationId: Number(organization.id)},
     });
     const formData: AutomationFormData = {
       allProjects: true,

--- a/static/app/views/automations/utils/resolveDetectorIdsForProjects.spec.ts
+++ b/static/app/views/automations/utils/resolveDetectorIdsForProjects.spec.ts
@@ -1,0 +1,43 @@
+import {IssueStreamDetectorFixture} from 'sentry-fixture/detectors';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {makeTestQueryClient} from 'sentry-test/queryClient';
+
+import type {AutomationFormData} from 'sentry/views/automations/components/automationFormData';
+import {resolveDetectorIdsForProjects} from 'sentry/views/automations/utils/resolveDetectorIdsForProjects';
+
+describe('resolveDetectorIdsForProjects', () => {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('resolves the all-projects detector', async () => {
+    const organization = OrganizationFixture();
+    const allProjectsDetector = IssueStreamDetectorFixture({
+      id: '10',
+      projectId: null,
+      config: {organization_id: Number(organization.id)},
+    });
+    const formData: AutomationFormData = {
+      allProjects: true,
+      detectorIds: [],
+      enabled: true,
+      environment: null,
+      frequency: 0,
+      name: 'All projects alert',
+      projectIds: [],
+    };
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/detectors/`,
+      body: [IssueStreamDetectorFixture({id: '11', projectId: '1'}), allProjectsDetector],
+    });
+
+    const result = await resolveDetectorIdsForProjects({
+      formData,
+      organization,
+      queryClient: makeTestQueryClient(),
+    });
+
+    expect(result?.detectorIds).toEqual([allProjectsDetector.id]);
+  });
+});

--- a/static/app/views/automations/utils/resolveDetectorIdsForProjects.ts
+++ b/static/app/views/automations/utils/resolveDetectorIdsForProjects.ts
@@ -5,7 +5,10 @@ import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import type {AutomationFormData} from 'sentry/views/automations/components/automationFormData';
-import {fetchIssueStreamDetectorIdsForProjects} from 'sentry/views/automations/utils/fetchIssueStreamDetectorIdsForProjects';
+import {
+  fetchIssueStreamDetectorIdsForProjects,
+  fetchAllProjectsDetectorId,
+} from 'sentry/views/automations/utils/fetchIssueStreamDetectorIds';
 
 type ResolveDetectorIdsForProjectsParams = {
   formData: AutomationFormData;
@@ -27,6 +30,21 @@ export async function resolveDetectorIdsForProjects({
   projectIds,
   queryClient,
 }: ResolveDetectorIdsForProjectsParams): Promise<AutomationFormData | null> {
+  if (formData.allProjects) {
+    try {
+      const detectorId = await fetchAllProjectsDetectorId({queryClient, organization});
+      if (!detectorId) {
+        throw new Error('All Projects detector not available');
+      }
+      return {...formData, detectorIds: [detectorId]};
+    } catch (error) {
+      Sentry.captureException(error);
+      onSubmitError?.(error);
+      addErrorMessage(t('Something went wrong while saving to all projects'));
+      return null;
+    }
+  }
+
   if (!projectIds?.length) {
     return formData;
   }

--- a/static/app/views/detectors/components/details/common/automations.spec.tsx
+++ b/static/app/views/detectors/components/details/common/automations.spec.tsx
@@ -428,6 +428,22 @@ describe('DetectorDetailsAutomations', () => {
   });
 
   describe('permissions', () => {
+    it('allows org:write users to edit connections for a detector without a project', async () => {
+      const detector = IssueStreamDetectorFixture({projectId: null, workflowIds: []});
+
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/workflows/',
+        method: 'GET',
+        body: [],
+      });
+
+      render(<DetectorDetailsAutomations detector={detector} />, {
+        organization: OrganizationFixture({access: ['org:write']}),
+      });
+
+      expect(await screen.findByRole('button', {name: 'Edit Alerts'})).toBeEnabled();
+    });
+
     it('disables edit button when user lacks alerts:write permission', async () => {
       const orgWithoutAlertsWrite = OrganizationFixture({
         access: [],

--- a/static/app/views/detectors/components/details/common/automations.spec.tsx
+++ b/static/app/views/detectors/components/details/common/automations.spec.tsx
@@ -1,5 +1,6 @@
 import {AutomationFixture} from 'sentry-fixture/automations';
 import {
+  AllProjectsDetectorFixture,
   IssueStreamDetectorFixture,
   UptimeDetectorFixture,
 } from 'sentry-fixture/detectors';
@@ -429,7 +430,7 @@ describe('DetectorDetailsAutomations', () => {
 
   describe('permissions', () => {
     it('allows org:write users to edit connections for a detector without a project', async () => {
-      const detector = IssueStreamDetectorFixture({projectId: null, workflowIds: []});
+      const detector = AllProjectsDetectorFixture({workflowIds: []});
 
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/workflows/',

--- a/static/app/views/detectors/components/details/common/automations.tsx
+++ b/static/app/views/detectors/components/details/common/automations.tsx
@@ -150,7 +150,7 @@ export function DetectorDetailsAutomations({detector}: Props) {
   const queryClient = useQueryClient();
   const {openDrawer, closeDrawer, isDrawerOpen} = useDrawer();
   const {mutate: updateDetector} = useUpdateDetector();
-  const project = useProjectFromId({project_id: detector.projectId});
+  const project = useProjectFromId({project_id: detector.projectId ?? undefined});
   const canEditWorkflowConnections = useCanEditDetectorWorkflowConnections({
     projectId: detector.projectId,
   });

--- a/static/app/views/detectors/components/detectorLink.spec.tsx
+++ b/static/app/views/detectors/components/detectorLink.spec.tsx
@@ -1,3 +1,4 @@
+import {IssueStreamDetectorFixture} from 'sentry-fixture/detectors';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -101,10 +102,11 @@ describe('DetectorLink', () => {
   });
 
   it('renders disabled detector without link for issue_stream type', () => {
-    const issueStreamDetector = {
-      ...mockDetector,
-      type: 'issue_stream' as const,
-    };
+    const issueStreamDetector = IssueStreamDetectorFixture({
+      id: mockDetector.id,
+      name: mockDetector.name,
+      projectId: mockDetector.projectId,
+    });
 
     render(<DetectorLink detector={issueStreamDetector} />, {
       organization,

--- a/static/app/views/detectors/components/detectorLink.tsx
+++ b/static/app/views/detectors/components/detectorLink.tsx
@@ -250,12 +250,14 @@ function Details({detector}: {detector: Detector}) {
 
 export function DetectorLink({detector, className, openInNewTab}: DetectorLinkProps) {
   const org = useOrganization();
-  const project = useProjectFromId({project_id: detector.projectId});
+  const project = useProjectFromId({project_id: detector.projectId ?? undefined});
   const location = useLocation();
 
   const detectorName =
     detector.type === 'issue_stream'
-      ? t('All Issues in %s', project?.slug || 'project')
+      ? detector.projectId === null
+        ? t('All Projects')
+        : t('All Issues in %s', project?.slug || 'project')
       : detector.name;
 
   // Preserve page filters when navigating to detector details

--- a/static/app/views/detectors/components/detectorListTable/detectorListRow.tsx
+++ b/static/app/views/detectors/components/detectorListTable/detectorListRow.tsx
@@ -51,12 +51,14 @@ export function DetectorListRow({detector, selected, onSelect}: DetectorListRowP
       <SimpleTable.RowCell data-column-name="assignee">
         <DetectorAssigneeCell assignee={detector.owner} />
       </SimpleTable.RowCell>
-      <SimpleTable.RowCell data-column-name="connected-automations">
-        <DetectorListConnectedAutomations
-          automationIds={detector.workflowIds}
-          projectId={detector.projectId}
-        />
-      </SimpleTable.RowCell>
+      {detector.projectId && (
+        <SimpleTable.RowCell data-column-name="connected-automations">
+          <DetectorListConnectedAutomations
+            automationIds={detector.workflowIds}
+            projectId={detector.projectId}
+          />
+        </SimpleTable.RowCell>
+      )}
       {additionalColumns.map(col => (
         <Fragment key={col.id}>{col.renderCell(detector)}</Fragment>
       ))}

--- a/static/app/views/detectors/components/detectorListTable/detectorListRow.tsx
+++ b/static/app/views/detectors/components/detectorListTable/detectorListRow.tsx
@@ -51,14 +51,14 @@ export function DetectorListRow({detector, selected, onSelect}: DetectorListRowP
       <SimpleTable.RowCell data-column-name="assignee">
         <DetectorAssigneeCell assignee={detector.owner} />
       </SimpleTable.RowCell>
-      {detector.projectId && (
-        <SimpleTable.RowCell data-column-name="connected-automations">
+      <SimpleTable.RowCell data-column-name="connected-automations">
+        {detector.projectId && (
           <DetectorListConnectedAutomations
             automationIds={detector.workflowIds}
             projectId={detector.projectId}
           />
-        </SimpleTable.RowCell>
-      )}
+        )}
+      </SimpleTable.RowCell>
       {additionalColumns.map(col => (
         <Fragment key={col.id}>{col.renderCell(detector)}</Fragment>
       ))}

--- a/static/app/views/detectors/components/detectorListTable/index.tsx
+++ b/static/app/views/detectors/components/detectorListTable/index.tsx
@@ -137,7 +137,7 @@ export function DetectorListTable({
   );
 
   const uniqueProjectIds = useMemo(
-    () => [...new Set(detectors.map(d => d.projectId))],
+    () => [...new Set(detectors.map(d => d.projectId).filter(defined))],
     [detectors]
   );
 

--- a/static/app/views/detectors/components/detectorListTable/issueStreamDetectorContext.tsx
+++ b/static/app/views/detectors/components/detectorListTable/issueStreamDetectorContext.tsx
@@ -2,6 +2,7 @@ import {createContext, useContext, useMemo} from 'react';
 import {useQuery} from '@tanstack/react-query';
 
 import type {Detector} from 'sentry/types/workflowEngine/detectors';
+import {defined} from 'sentry/utils/defined';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {detectorListApiOptions} from 'sentry/views/detectors/hooks';
 
@@ -42,6 +43,9 @@ export function IssueStreamDetectorContextProvider({
       return map;
     }
     for (const detector of data) {
+      if (!defined(detector.projectId)) {
+        continue;
+      }
       const existing = map.get(detector.projectId);
       if (existing) {
         existing.push(detector);

--- a/static/app/views/detectors/hooks/index.ts
+++ b/static/app/views/detectors/hooks/index.ts
@@ -6,6 +6,7 @@ import type {Organization} from 'sentry/types/organization';
 import {
   type BaseDetectorUpdatePayload,
   type Detector,
+  type IssueStreamDetector,
   type UptimeDetector,
 } from 'sentry/types/workflowEngine/detectors';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
@@ -17,6 +18,7 @@ import {useApi} from 'sentry/utils/useApi';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 interface DetectorTypeMap {
+  issue_stream: IssueStreamDetector;
   uptime: UptimeDetector;
 }
 

--- a/static/app/views/detectors/utils/useCanEditDetector.tsx
+++ b/static/app/views/detectors/utils/useCanEditDetector.tsx
@@ -1,14 +1,23 @@
 import {hasEveryAccess} from 'sentry/components/acl/access';
 import type {Detector, DetectorType} from 'sentry/types/workflowEngine/detectors';
+import {defined} from 'sentry/utils/defined';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjectFromId} from 'sentry/utils/useProjectFromId';
 import {useProjects} from 'sentry/utils/useProjects';
 import {detectorTypeIsUserCreateable} from 'sentry/views/detectors/utils/detectorTypeConfig';
 
-export function useCanEditDetectorWorkflowConnections({projectId}: {projectId: string}) {
+export function useCanEditDetectorWorkflowConnections({
+  projectId,
+}: {
+  projectId: string | null;
+}) {
   const organization = useOrganization();
   const project = useProjectFromId({project_id: projectId});
-  return hasEveryAccess(['alerts:write'], {organization, project});
+
+  return (
+    hasEveryAccess(['org:write'], {organization, project}) ||
+    hasEveryAccess(['alerts:write'], {organization, project})
+  );
 }
 
 export function useCanEditDetector({
@@ -16,7 +25,7 @@ export function useCanEditDetector({
   detectorType,
 }: {
   detectorType: DetectorType;
-  projectId: string;
+  projectId: string | null;
 }) {
   const organization = useOrganization();
   const project = useProjectFromId({project_id: projectId});
@@ -50,6 +59,9 @@ export function useCanEditDetectors({detectors}: {detectors: Detector[]}) {
 
   for (const detector of detectors) {
     const projectId = detector.projectId;
+    if (!defined(projectId)) {
+      return false;
+    }
     if (!projectToDetectors[projectId]) {
       projectToDetectors[projectId] = [];
     }

--- a/static/app/views/detectors/utils/useCanEditDetector.tsx
+++ b/static/app/views/detectors/utils/useCanEditDetector.tsx
@@ -9,10 +9,14 @@ import {detectorTypeIsUserCreateable} from 'sentry/views/detectors/utils/detecto
 export function useCanEditDetectorWorkflowConnections({
   projectId,
 }: {
-  projectId: string | null;
+  projectId: Detector['projectId'];
 }) {
   const organization = useOrganization();
   const project = useProjectFromId({project_id: projectId});
+  if (!projectId) {
+    // Workflows connected to all project detector do not allow alerts:write updates.
+    return hasEveryAccess(['org:write'], {organization});
+  }
 
   return (
     hasEveryAccess(['org:write'], {organization, project}) ||
@@ -25,7 +29,7 @@ export function useCanEditDetector({
   detectorType,
 }: {
   detectorType: DetectorType;
-  projectId: string | null;
+  projectId: Detector['projectId'];
 }) {
   const organization = useOrganization();
   const project = useProjectFromId({project_id: projectId});

--- a/static/app/views/detectors/utils/useCanEditDetector.tsx
+++ b/static/app/views/detectors/utils/useCanEditDetector.tsx
@@ -12,7 +12,7 @@ export function useCanEditDetectorWorkflowConnections({
   projectId: Detector['projectId'];
 }) {
   const organization = useOrganization();
-  const project = useProjectFromId({project_id: projectId});
+  const project = useProjectFromId({project_id: projectId ?? undefined});
   if (!projectId) {
     // Workflows connected to all project detector do not allow alerts:write updates.
     return hasEveryAccess(['org:write'], {organization});
@@ -32,7 +32,7 @@ export function useCanEditDetector({
   projectId: Detector['projectId'];
 }) {
   const organization = useOrganization();
-  const project = useProjectFromId({project_id: projectId});
+  const project = useProjectFromId({project_id: projectId ?? undefined});
 
   if (!project) {
     return false;

--- a/static/app/views/detectors/utils/useIssueStreamDetectorsForProject.tsx
+++ b/static/app/views/detectors/utils/useIssueStreamDetectorsForProject.tsx
@@ -1,5 +1,6 @@
 import {useQuery} from '@tanstack/react-query';
 
+import {defined} from 'sentry/utils/defined';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {detectorListApiOptions} from 'sentry/views/detectors/hooks';
 
@@ -7,15 +8,16 @@ import {detectorListApiOptions} from 'sentry/views/detectors/hooks';
  * Returns the ID of the issue stream detector for a given project.
  * Issue stream detectors are used to connect automations to "all issues in a project".
  */
-export function useIssueStreamDetectorsForProject(projectId: string | undefined) {
+export function useIssueStreamDetectorsForProject(projectId: string | null | undefined) {
   const organization = useOrganization();
+  const hasProject = defined(projectId);
   return useQuery({
     ...detectorListApiOptions(organization, {
       query: 'type:issue_stream',
-      projects: [Number(projectId)],
+      projects: hasProject ? [Number(projectId)] : [],
       includeIssueStreamDetectors: true,
     }),
     staleTime: Infinity,
-    enabled: projectId !== undefined,
+    enabled: hasProject,
   });
 }

--- a/tests/js/fixtures/detectors.ts
+++ b/tests/js/fixtures/detectors.ts
@@ -132,6 +132,7 @@ export function IssueStreamDetectorFixture(
 ): IssueStreamDetector {
   return {
     ...BASE_DETECTOR,
+    config: null,
     name: 'Issue Stream Detector',
     id: '4',
     type: 'issue_stream',

--- a/tests/js/fixtures/detectors.ts
+++ b/tests/js/fixtures/detectors.ts
@@ -9,6 +9,7 @@ import {
   DetectorPriorityLevel,
 } from 'sentry/types/workflowEngine/dataConditions';
 import type {
+  AllProjectsDetector,
   CronDetector,
   CronMonitorDataSource,
   ErrorDetector,
@@ -132,8 +133,21 @@ export function IssueStreamDetectorFixture(
 ): IssueStreamDetector {
   return {
     ...BASE_DETECTOR,
-    config: null,
     name: 'Issue Stream Detector',
+    id: '4',
+    type: 'issue_stream',
+    ...params,
+  } as IssueStreamDetector;
+}
+
+export function AllProjectsDetectorFixture(
+  params: Partial<AllProjectsDetector> = {}
+): AllProjectsDetector {
+  return {
+    ...BASE_DETECTOR,
+    projectId: null,
+    config: {organizationId: 1},
+    name: 'All Projects Detector',
     id: '4',
     type: 'issue_stream',
     ...params,

--- a/tests/js/fixtures/detectors.ts
+++ b/tests/js/fixtures/detectors.ts
@@ -137,7 +137,7 @@ export function IssueStreamDetectorFixture(
     id: '4',
     type: 'issue_stream',
     ...params,
-  } as IssueStreamDetector;
+  };
 }
 
 export function AllProjectsDetectorFixture(


### PR DESCRIPTION
Adds the frontend UI for selecting all projects and validating the form and all that. It needed a different fetch method but most of the other changes are pretty straight forward.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>