### PR TITLE
feat(aci): Rename alert option for regression events

### DIFF
--- a/static/app/views/automations/components/dataConditionNodes.tsx
+++ b/static/app/views/automations/components/dataConditionNodes.tsx
@@ -144,7 +144,7 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
   [
     DataConditionType.REGRESSION_EVENT,
     {
-      label: t('A resolved issue becomes unresolved'),
+      label: t('A resolved issue regresses'),
       validate: undefined,
     },
   ],


### PR DESCRIPTION
Updates the UI to be less misleading

See the image in the linear ticket for more context as to why this is helpful