### PR TITLE
fix(sentry-apps): make routine templates alertable

### DIFF
--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.tsx
@@ -361,7 +361,7 @@ describe('Sentry Application Details', () => {
               ],
               events: ['issue.created'],
               scopes: ['event:read', 'event:write'],
-              isAlertable: false,
+              isAlertable: true,
               overview: '',
             }),
           })

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -445,6 +445,7 @@ function ClaudeRoutineTemplateForm() {
       token: '',
       scopes: CLAUDE_ROUTINE_SCOPES,
       events: CLAUDE_ROUTINE_EVENTS,
+      isAlertable: true,
     },
     validators: {
       onDynamic: claudeRoutineSchema,


### PR DESCRIPTION
We want claude routine templates to show up as an alert rule by default