### PR TITLE
perf(global-selection): Speed up environment selector for many envs

### DIFF
--- a/static/app/components/core/compactSelect/compactSelect.spec.tsx
+++ b/static/app/components/core/compactSelect/compactSelect.spec.tsx
@@ -1532,6 +1532,35 @@ describe('CompactSelect', () => {
       expect(screen.getByRole('row', {name: 'Option Three'})).toBeInTheDocument();
     });
 
+    it('preserves selected values outside the size limit', async () => {
+      const onChange = jest.fn();
+      render(
+        <CompactSelect
+          mode="grid"
+          multiple
+          search
+          sizeLimit={2}
+          options={[
+            {value: 'opt_one', label: 'Option One'},
+            {value: 'opt_two', label: 'Option Two'},
+            {value: 'opt_three', label: 'Option Three'},
+          ]}
+          value={['opt_one', 'opt_two', 'opt_three']}
+          onChange={onChange}
+        />
+      );
+
+      await userEvent.click(screen.getByRole('button'));
+      expect(screen.queryByRole('row', {name: 'Option Three'})).not.toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('row', {name: 'Option One'}));
+
+      expect(onChange).toHaveBeenCalledWith([
+        {value: 'opt_two', label: 'Option Two'},
+        {value: 'opt_three', label: 'Option Three'},
+      ]);
+    });
+
     it('can toggle sections', async () => {
       const mock = jest.fn();
 

--- a/static/app/components/core/compactSelect/compactSelect.spec.tsx
+++ b/static/app/components/core/compactSelect/compactSelect.spec.tsx
@@ -7,7 +7,15 @@ import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 
 import {DropdownButton} from 'sentry/components/dropdownButton';
 
-import {CompactSelect, type SelectOption} from './';
+import {CompactSelect, getEscapedKey, type SelectOption} from './';
+
+describe('getEscapedKey', () => {
+  it('only escapes values that need it', () => {
+    expect(getEscapedKey('environment-123')).toBe('environment-123');
+    expect(getEscapedKey('release.version')).toBe('release\\.version');
+    expect(getEscapedKey(123)).toBe('\\31 23');
+  });
+});
 
 describe('CompactSelect', () => {
   describe('types', () => {

--- a/static/app/components/core/compactSelect/list.tsx
+++ b/static/app/components/core/compactSelect/list.tsx
@@ -171,9 +171,22 @@ export function List<Value extends SelectKey>({
   const {overlayState, search, searchable, overlayIsOpen, searchMatcher} =
     useContext(ControlContext);
 
+  const hasSections = useMemo(() => items.some(item => 'options' in item), [items]);
+  // Searchable flat menus can build their initial React Aria collection from only the
+  // visible items. Once a query is entered, use the existing search path unchanged.
+  const isFlatCollectionTruncated =
+    searchable &&
+    !hasSections &&
+    !search &&
+    sizeLimit !== undefined &&
+    items.length > sizeLimit;
+
   const {hidden: hiddenOptions, scores} = useMemo(
-    () => getHiddenOptions(items, search, sizeLimit, searchMatcher),
-    [items, search, sizeLimit, searchMatcher]
+    () =>
+      isFlatCollectionTruncated
+        ? {hidden: new Set<SelectKey>(), scores: new Map<SelectKey, number>()}
+        : getHiddenOptions(items, search, sizeLimit, searchMatcher),
+    [isFlatCollectionTruncated, items, search, sizeLimit, searchMatcher]
   );
 
   const sortedItems = useMemo(
@@ -181,12 +194,16 @@ export function List<Value extends SelectKey>({
     [items, scores]
   );
 
+  const collectionItems = useMemo(
+    () => (isFlatCollectionTruncated ? sortedItems.slice(0, sizeLimit) : sortedItems),
+    [isFlatCollectionTruncated, sizeLimit, sortedItems]
+  );
   /**
    * Props to be passed into useListState()
    */
   const listStateProps = useMemo<Partial<ListProps<ListItemBase>>>(() => {
     const disabledKeys = [
-      ...getDisabledOptions(items, isOptionDisabled),
+      ...getDisabledOptions(collectionItems, isOptionDisabled),
       ...hiddenOptions,
     ];
 
@@ -239,6 +256,7 @@ export function List<Value extends SelectKey>({
     value,
     onChange,
     items,
+    collectionItems,
     isOptionDisabled,
     hiddenOptions,
     multiple,
@@ -250,7 +268,7 @@ export function List<Value extends SelectKey>({
   const listState = useListState({
     ...props,
     ...listStateProps,
-    items: sortedItems,
+    items: collectionItems,
   });
 
   // In composite selects, focus should seamlessly move from one region (list) to

--- a/static/app/components/core/compactSelect/utils.tsx
+++ b/static/app/components/core/compactSelect/utils.tsx
@@ -22,6 +22,10 @@ import type {
   SelectSectionWithKey,
 } from './types';
 
+// Avoid the relatively expensive CSS.escape call for common keys while preserving
+// full escaping for values that are not already simple CSS identifiers.
+const SIMPLE_CSS_IDENTIFIER = /^-?(?!\d)\w[-\w]*$/;
+
 /**
  * Normalises the `search` prop into a plain config object (or `undefined` if
  * search is disabled). Accepts `true` as shorthand for `{}` and treats
@@ -40,7 +44,8 @@ export function getSearchConfig<Value extends SelectKey>(
 }
 
 export function getEscapedKey(value: SelectKey): string {
-  return CSS.escape(String(value));
+  const stringValue = String(value);
+  return SIMPLE_CSS_IDENTIFIER.test(stringValue) ? stringValue : CSS.escape(stringValue);
 }
 
 export function getItemsWithKeys<Value extends SelectKey>(

--- a/static/app/components/pageFilters/environment/environmentPageFilter.tsx
+++ b/static/app/components/pageFilters/environment/environmentPageFilter.tsx
@@ -2,8 +2,6 @@ import {useCallback, useMemo, useRef} from 'react';
 import {useMatches} from 'react-router-dom';
 import {isAppleDevice} from '@react-aria/utils';
 import isEqual from 'lodash/isEqual';
-import sortBy from 'lodash/sortBy';
-import xor from 'lodash/xor';
 
 import {CompactSelect, MenuComponents} from '@sentry/scraps/compactSelect';
 import type {MultipleSelectProps} from '@sentry/scraps/compactSelect';
@@ -80,10 +78,22 @@ export function EnvironmentPageFilter({
     isReady: pageFilterIsReady,
   } = usePageFilters();
 
-  const environments = useMemo<string[]>(() => {
-    const isSuperuser = isActiveSuperuser();
+  const projectSelection = useMemo(
+    () => new Set(projectPageFilterValue),
+    [projectPageFilterValue]
+  );
+  const selectedEnvironments = useMemo(
+    () => new Set(envPageFilterValue),
+    [envPageFilterValue]
+  );
 
-    const unsortedEnvironments = projects.flatMap(project => {
+  const environmentSet = useMemo(() => {
+    const isSuperuser = isActiveSuperuser();
+    const includeAllProjects = projectSelection.has(ALL_ACCESS_PROJECTS);
+    const includeMemberProjects = projectSelection.size === 0;
+    const result = new Set<string>();
+
+    for (const project of projects) {
       const projectId = parseInt(project.id, 10);
       // Include environments from:
       // - all projects if the user is a superuser
@@ -91,33 +101,37 @@ export function EnvironmentPageFilter({
       // - all member projects if 'my projects' (empty list) is selected.
       // - all projects if -1 is the only selected project.
       if (
-        (projectPageFilterValue.includes(ALL_ACCESS_PROJECTS) && project.hasAccess) ||
-        (projectPageFilterValue.length === 0 && (project.isMember || isSuperuser)) ||
-        projectPageFilterValue.includes(projectId)
+        (includeAllProjects && project.hasAccess) ||
+        (includeMemberProjects && (project.isMember || isSuperuser)) ||
+        projectSelection.has(projectId)
       ) {
-        return project.environments;
+        for (const environment of project.environments) {
+          result.add(environment);
+        }
       }
+    }
 
-      return [];
-    });
+    return result;
+  }, [projects, projectSelection]);
 
-    const uniqueUnsortedEnvironments = Array.from(new Set(unsortedEnvironments));
-
+  const environments = useMemo(() => {
     // Sort with the last selected environments at the top
-    return sortBy(uniqueUnsortedEnvironments, env => [
-      !envPageFilterValue.includes(env),
-      env,
-    ]);
-  }, [projects, projectPageFilterValue, envPageFilterValue]);
+    return [...environmentSet].toSorted((a, b) => {
+      const selectionOrder =
+        Number(selectedEnvironments.has(b)) - Number(selectedEnvironments.has(a));
+      return selectionOrder || (a < b ? -1 : a > b ? 1 : 0);
+    });
+  }, [environmentSet, selectedEnvironments]);
 
   /**
    * Validated values that only includes the currently available environments
    * (availability may change based on which projects are selected.)
    */
-  const value = useMemo(
-    () => envPageFilterValue.filter(env => environments.includes(env)),
-    [envPageFilterValue, environments]
+  const valueSet = useMemo(
+    () => selectedEnvironments.intersection(environmentSet),
+    [selectedEnvironments, environmentSet]
   );
+  const value = useMemo(() => [...valueSet], [valueSet]);
 
   const handleChange = useCallback(
     async (newValue: string[]) => {
@@ -222,7 +236,8 @@ export function EnvironmentPageFilter({
 
   const {dispatch} = stagedSelect;
 
-  const hasStagedChanges = xor(stagedSelect.value, value).length > 0;
+  const hasStagedChanges =
+    new Set(stagedSelect.value).symmetricDifference(valueSet).size > 0;
   const shouldShowReset = stagedSelect.value.length > 0;
 
   const handleReset = () => {

--- a/static/app/components/pageFilters/environment/environmentPageFilterTrigger.tsx
+++ b/static/app/components/pageFilters/environment/environmentPageFilterTrigger.tsx
@@ -1,3 +1,4 @@
+import {useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import {Badge} from '@sentry/scraps/badge';
@@ -20,8 +21,17 @@ export function EnvironmentPageFilterTrigger({
   label,
   ...props
 }: EnvironmentPageFilterTriggerProps) {
-  const isAllEnvironmentsSelected =
-    value.length === 0 || environments.every(env => value.includes(env));
+  const isAllEnvironmentsSelected = useMemo(() => {
+    if (value.length === 0) {
+      return true;
+    }
+    if (value.length !== environments.length) {
+      return false;
+    }
+
+    const selectedEnvironments = new Set(value);
+    return environments.every(env => selectedEnvironments.has(env));
+  }, [environments, value]);
 
   // Show 2 environments only if the combined string's length does not exceed 25.
   // Otherwise show only 1 environment.


### PR DESCRIPTION
Opening the environment selector in organizations with lots of projects and environments was doing duplicate array work and building a React Aria collection for every option before showing the first 25.

Build the environment list with Sets and cap the initial empty-query collection at the visible items. Once someone starts typing, search follows the existing path unchanged.

Testing in sentry org:
- Select my projects
- Select all projects
- Repeat

before (when switching from my projects to all projects in sentry org)

<img width="616" height="466" alt="image" src="https://github.com/user-attachments/assets/0c69bec3-546c-4075-9d5c-99d8f674e005" />

after

<img width="566" height="355" alt="image" src="https://github.com/user-attachments/assets/01212fe9-2e67-43a4-839f-0ee2203a6872" />
