### PR TITLE
ref(scm): return the parsed parts of a pull-request URL

### DIFF
--- a/src/sentry/models/pullrequest.py
+++ b/src/sentry/models/pullrequest.py
@@ -4,6 +4,7 @@ import re
 from collections.abc import Mapping, Sequence
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple
+from urllib.parse import urlsplit
 
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
@@ -117,15 +118,41 @@ class ResolvedPullRequest(NamedTuple):
     provider_unmappable: bool
 
 
-def parse_pull_request_number(url: str) -> int | None:
-    """Extract the PR/MR number from a pull-request URL, or None if there isn't one.
+class ParsedPullRequestUrl(NamedTuple):
+    """The parts of a pull-request URL a caller can act on."""
 
-    Matches the number after a ``/pull/`` (GitHub) or ``/merge_requests/`` (GitLab)
-    segment specifically — a source can report a branch/``tree`` URL as its result, and
-    we must not mistake a trailing branch-name segment for a PR number.
+    number: int
+    host: str
+    repo_full_name: str
+
+
+def parse_pull_request_url(url: str) -> ParsedPullRequestUrl | None:
+    """Parse an https pull-request URL, or None if it isn't one.
+
+    The number must follow a ``/pull/`` (GitHub) or ``/merge_requests/`` (GitLab) segment and
+    end it, so a branch/``tree`` URL is never mistaken for a pull request. ``repo_full_name``
+    spans every segment above that one, keeping GitLab's nested subgroups
+    (``group/subgroup/project``) intact and dropping its ``/-/`` separator.
     """
-    match = re.search(r"/(?:pull|pulls|merge_requests)/(\d+)", url)
-    return int(match.group(1)) if match else None
+    try:
+        parsed = urlsplit(url)
+    except ValueError:  # e.g. an unclosed IPv6 bracket
+        return None
+    if parsed.scheme != "https" or not parsed.hostname:
+        return None
+
+    # Against the path alone, so a PR link in a query string isn't read as this URL's own.
+    match = re.search(r"/(?:pull|pulls|merge_requests)/(\d+)(?=/|$)", parsed.path)
+    if match is None:
+        return None
+    repo_full_name = parsed.path[: match.start()].strip("/").removesuffix("/-")
+    if "/" not in repo_full_name:
+        return None
+    return ParsedPullRequestUrl(
+        number=int(match.group(1)),
+        host=parsed.hostname,
+        repo_full_name=repo_full_name,
+    )
 
 
 def normalize_scm_provider(provider: str | None) -> str | None:

--- a/src/sentry/pr_metrics/attribution.py
+++ b/src/sentry/pr_metrics/attribution.py
@@ -25,7 +25,7 @@ from sentry.models.pullrequest import (
     PullRequestAttributionSignalType,
     PullRequestAttributionSource,
     ResolvedPullRequest,
-    parse_pull_request_number,
+    parse_pull_request_url,
 )
 
 logger = logging.getLogger(__name__)
@@ -310,7 +310,8 @@ def attribute_delegated_agent_pull_request(
     if not features.has("organizations:pr-metrics-attribution", organization):
         return
 
-    pr_number = parse_pull_request_number(pr_url)
+    parsed_pr = parse_pull_request_url(pr_url)
+    pr_number = parsed_pr.number if parsed_pr else None
 
     log_context = {
         "organization_id": organization_id,

--- a/src/sentry/seer/autofix/coding_agent_handoffs.py
+++ b/src/sentry/seer/autofix/coding_agent_handoffs.py
@@ -9,7 +9,7 @@ import logging
 from typing import NamedTuple
 
 from sentry.models.organization import Organization
-from sentry.models.pullrequest import parse_pull_request_number
+from sentry.models.pullrequest import parse_pull_request_url
 from sentry.seer.autofix.constants import CodingAgentStatus
 from sentry.seer.autofix.utils import (
     CodingAgentProviderType,
@@ -122,7 +122,8 @@ def sync_coding_agent_status(
                 return CodingAgentSyncResult(known_to_seer=False, run_id=run_id, group_id=group_id)
 
         if result and result.pr_url:
-            pr_number = parse_pull_request_number(result.pr_url)
+            parsed_pr = parse_pull_request_url(result.pr_url)
+            pr_number = parsed_pr.number if parsed_pr else None
             link_log_context = {
                 **log_context,
                 "repo_name": result.repo_full_name,

--- a/tests/sentry/models/test_pullrequest.py
+++ b/tests/sentry/models/test_pullrequest.py
@@ -16,7 +16,7 @@ from sentry.models.pullrequest import (
     CommentType,
     PullRequest,
     PullRequestCommit,
-    parse_pull_request_number,
+    parse_pull_request_url,
 )
 from sentry.models.releasecommit import ReleaseCommit
 from sentry.models.releaseheadcommit import ReleaseHeadCommit
@@ -665,23 +665,58 @@ class ForProviderPrTest(TestCase):
         assert self._for_provider_pr(integration_id=self.integration_id + 1) == []
 
 
-class ParsePullRequestNumberTest(TestCase):
-    def test_extracts_number_from_supported_url_shapes(self) -> None:
-        # Each provider segment the regex recognizes must yield the trailing number.
-        cases = [
-            ("https://github.com/getsentry/sentry/pull/42", 42),
-            ("https://github.com/getsentry/sentry/pulls/7", 7),
-            ("https://gitlab.com/getsentry/sentry/merge_requests/13", 13),
-        ]
-        for url, expected in cases:
-            assert parse_pull_request_number(url) == expected
+class ParsePullRequestUrlTest(TestCase):
+    def test_parses_each_provider_url_shape(self) -> None:
+        cases = {
+            "https://github.com/getsentry/sentry/pull/42": (42, "github.com", "getsentry/sentry"),
+            "https://github.com/getsentry/sentry/pulls/7": (7, "github.com", "getsentry/sentry"),
+            "https://gitlab.com/gs/sentry/merge_requests/13": (13, "gitlab.com", "gs/sentry"),
+            # GitLab nests projects under subgroups and separates the MR path with "/-/", so
+            # the repo name spans the subgroups but excludes the separator.
+            "https://gitlab.com/grp/sub/proj/-/merge_requests/3": (3, "gitlab.com", "grp/sub/proj"),
+            "https://gitlab.com/grp/sub/proj/merge_requests/3": (3, "gitlab.com", "grp/sub/proj"),
+        }
+        for url, expected in cases.items():
+            assert parse_pull_request_url(url) == expected, url
 
-    def test_returns_none_when_no_pr_segment(self) -> None:
-        # A branch/tree URL or a number-less path must not be mistaken for a PR.
+    def test_parses_past_trailing_url_segments(self) -> None:
+        # A PR URL stays a PR URL with a subpath, query, or fragment appended.
+        for url in [
+            "https://github.com/o/r/pull/5/files",
+            "https://github.com/o/r/pull/5?w=1",
+            "https://github.com/o/r/pull/5#issuecomment-1",
+        ]:
+            assert parse_pull_request_url(url) == (5, "github.com", "o/r"), url
+
+    def test_normalizes_the_host(self) -> None:
+        # Callers compare host to a known value, so casing, port and userinfo must not survive.
+        cases = {
+            "https://GitHub.com/o/r/pull/5": (5, "github.com", "o/r"),
+            "https://github.com:443/o/r/pull/5": (5, "github.com", "o/r"),
+            "https://user@github.com/o/r/pull/5": (5, "github.com", "o/r"),
+            # The real host is what follows the userinfo, not what precedes it.
+            "https://github.com@evil.com/o/r/pull/5": (5, "evil.com", "o/r"),
+        }
+        for url, expected in cases.items():
+            assert parse_pull_request_url(url) == expected, url
+
+    def test_returns_none_when_not_a_pr_url(self) -> None:
         cases = [
+            # A branch/tree URL or a number-less path must not be mistaken for a PR.
             "https://github.com/getsentry/sentry/tree/123",
             "https://github.com/getsentry/sentry/pulls",
             "https://github.com/getsentry/sentry",
+            # The number must end its path segment, not merely start it.
+            "https://github.com/o/r/pull/12x",
+            # Only https, so a parsed host can be trusted.
+            "http://github.com/o/r/pull/5",
+            # A PR URL smuggled into another URL's query string is not this URL's PR.
+            "https://evil.com/x?u=https://github.com/o/r/pull/5",
+            # A PR segment needs a repo above it; "pull" alone is not an owner/repo.
+            "https://github.com/pull/5",
+            # Malformed authority — urlsplit raises rather than returning a host.
+            "https://[::1/o/r/pull/5",
+            "",
         ]
         for url in cases:
-            assert parse_pull_request_number(url) is None
+            assert parse_pull_request_url(url) is None, url


### PR DESCRIPTION
`parse_pull_request_number` matched the repo in its regex and then discarded it, so any caller needing to know which repo a URL pointed at had to re-parse the string itself. Return the number, host, and repo together instead.