### PR TITLE
fix(issue-progress): heal null has_other_open_prs in PR lifecycle backfill

### DIFF
--- a/src/sentry/issues/action_log/backfill.py
+++ b/src/sentry/issues/action_log/backfill.py
@@ -231,30 +231,44 @@ def backfill_group_activities(
     return total_created
 
 
-def _latest_pr_lifecycle_action_types(*, group_id: int, project_id: int) -> dict[int, int]:
-    """Map pull request id to the type of its most recently logged lifecycle action.
+def _latest_pr_lifecycle_actions(
+    *, group_id: int, project_id: int
+) -> dict[int, GroupActionLogEntry]:
+    """Map pull request id to its most recently logged lifecycle action.
 
     Entries are scanned oldest first so the last write per pull request wins.
     """
-    latest_action_types: dict[int, int] = {}
-    logged_entries = (
-        GroupActionLogEntry.objects.filter(
-            group_id=group_id,
-            project_id=project_id,
-            type__in=_PR_LIFECYCLE_ACTION_TYPES,
-        )
-        .order_by("date_added", "id")
-        .values_list("type", "data")
-    )
-    for action_type, data in logged_entries:
+    latest_actions: dict[int, GroupActionLogEntry] = {}
+    logged_entries = GroupActionLogEntry.objects.filter(
+        group_id=group_id,
+        project_id=project_id,
+        type__in=_PR_LIFECYCLE_ACTION_TYPES,
+    ).order_by("date_added", "id")
+    for entry in logged_entries:
+        data = entry.data
         if not isinstance(data, dict):
             continue
         try:
             pull_request_id = int(data["pull_request"])
         except (KeyError, TypeError, ValueError):
             continue
-        latest_action_types[pull_request_id] = action_type
-    return latest_action_types
+        latest_actions[pull_request_id] = entry
+    return latest_actions
+
+
+def _heal_has_other_open_prs(
+    *,
+    entry: GroupActionLogEntry,
+    has_other_open_prs: bool,
+) -> bool:
+    """Heal the has_other_open_prs field on any action where it is present but null."""
+    if "has_other_open_prs" not in entry.data or entry.data["has_other_open_prs"] is not None:
+        return False
+
+    entry.data = {**entry.data, "has_other_open_prs": has_other_open_prs}
+    entry.save(update_fields=["data", "date_updated"])
+    invalidate_group_derived_data(entry.group_id, cursor=(entry.date_added, entry.id))
+    return True
 
 
 def _get_new_pr_lifecycle_action(
@@ -379,21 +393,25 @@ def backfill_group_pr_lifecycle(*, group_id: int, project_id: int) -> int:
         if is_open_pull_request_state(pull_request.state)
     }
 
-    latest_action_types = _latest_pr_lifecycle_action_types(
-        group_id=group_id, project_id=project_id
-    )
+    latest_actions = _latest_pr_lifecycle_actions(group_id=group_id, project_id=project_id)
 
     entries: list[BackfillEntry] = []
     for pull_request in pull_requests:
-        latest_action_type = latest_action_types.get(pull_request.id)
+        latest_action = latest_actions.get(pull_request.id)
+        has_other_open_prs = bool(open_pull_request_ids - {pull_request.id})
         action_and_date = _get_new_pr_lifecycle_action(
             pull_request=pull_request,
-            latest_action_type=latest_action_type,
-            has_other_open_prs=bool(open_pull_request_ids - {pull_request.id}),
+            latest_action_type=latest_action.type if latest_action is not None else None,
+            has_other_open_prs=has_other_open_prs,
             group_id=group_id,
             project_id=project_id,
         )
         if action_and_date is None:
+            if latest_action is not None:
+                _heal_has_other_open_prs(
+                    entry=latest_action,
+                    has_other_open_prs=has_other_open_prs,
+                )
             continue
         action, date_added = action_and_date
 

--- a/tests/sentry/issues/action_log/test_backfill.py
+++ b/tests/sentry/issues/action_log/test_backfill.py
@@ -466,6 +466,29 @@ class BackfillGroupPullRequestLifecycleTest(TestCase):
         assert self._backfill_pr_lifecycle() == 0
         assert GroupActionLogEntry.objects.filter(group_id=self.group.id).count() == 1
 
+    def test_heals_activity_backfill_with_unknown_open_pr_state(self) -> None:
+        pull_request = self._create_linked_pull_request(
+            state=PullRequestLifecycleState.MERGED,
+            merged_at=self.now - timedelta(minutes=1),
+        )
+        self._backfill_resolved_action(pull_request)
+        merged_entry = self.create_group_action_log_entry(
+            group=self.group,
+            type=GroupActionType.PULL_REQUEST_MERGED,
+            source=BACKFILL_ACTIVITY_SOURCE,
+            data={"pull_request": pull_request.id, "has_other_open_prs": None},
+            date_added=self.now - timedelta(minutes=1),
+        )
+
+        assert self._backfill_pr_lifecycle() == 0
+
+        merged_entry.refresh_from_db()
+        assert merged_entry.data["has_other_open_prs"] is False
+        derived = process_group_log(self.group.id)
+        assert derived.data["has_open_fix_pr"] is False
+        assert derived.progress != IssueProgressState.FIX_PROPOSED
+        assert self._backfill_pr_lifecycle() == 0
+
     def test_backfills_merge_after_stale_closed_action(self) -> None:
         merged_at = self.now - timedelta(minutes=1)
         pull_request = self._create_linked_pull_request(


### PR DESCRIPTION
Ref ISWF-3159

The PR lifecycle action logs have a property `has_other_open_prs` which is only captured on the action log, not in the activity entries. This caused an issue when backfilling the activities, because it ended up generating `has_other_open_prs: null`.

This PR updates the backfill so that we heal those null values with the proper state.