### PR TITLE
fix(replays): Handle click nodes without attributes

### DIFF
--- a/static/app/components/replays/breadcrumbs/selectorList.spec.tsx
+++ b/static/app/components/replays/breadcrumbs/selectorList.spec.tsx
@@ -5,6 +5,7 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {SelectorList} from 'sentry/components/replays/breadcrumbs/selectorList';
 import {hydrateBreadcrumbs} from 'sentry/utils/replays/hydrateBreadcrumbs';
+import type {ClickFrame} from 'sentry/utils/replays/types';
 
 describe('SelectorList', () => {
   it('renders malformed click breadcrumbs without attributes', () => {
@@ -17,14 +18,15 @@ describe('SelectorList', () => {
             id: 1,
             tagName: 'button',
             textContent: 'Save',
-            attributes: {},
-          },
+            // `attributes` is intentionally omitted to represent a malformed breadcrumb.
+          } as any,
         },
       }),
     ]);
-    Reflect.deleteProperty(frame.data.node, 'attributes');
-
-    render(<SelectorList frame={frame} />);
+    if (!frame) {
+      throw new Error('Expected click breadcrumb to hydrate');
+    }
+    render(<SelectorList frame={frame as ClickFrame} />);
 
     expect(screen.getByText('button#save')).toBeInTheDocument();
   });

--- a/static/app/components/replays/breadcrumbs/selectorList.spec.tsx
+++ b/static/app/components/replays/breadcrumbs/selectorList.spec.tsx
@@ -23,9 +23,6 @@ describe('SelectorList', () => {
         },
       }),
     ]);
-    if (!frame) {
-      throw new Error('Expected click breadcrumb to hydrate');
-    }
     render(<SelectorList frame={frame as ClickFrame} />);
 
     expect(screen.getByText('button#save')).toBeInTheDocument();

--- a/static/app/components/replays/breadcrumbs/selectorList.spec.tsx
+++ b/static/app/components/replays/breadcrumbs/selectorList.spec.tsx
@@ -1,0 +1,31 @@
+import {ReplayClickFrameFixture} from 'sentry-fixture/replay/replayBreadcrumbFrameData';
+import {ReplayRecordFixture} from 'sentry-fixture/replayRecord';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {SelectorList} from 'sentry/components/replays/breadcrumbs/selectorList';
+import {hydrateBreadcrumbs} from 'sentry/utils/replays/hydrateBreadcrumbs';
+
+describe('SelectorList', () => {
+  it('renders malformed click breadcrumbs without attributes', () => {
+    const [frame] = hydrateBreadcrumbs(ReplayRecordFixture(), [
+      ReplayClickFrameFixture({
+        timestamp: new Date('2024/06/21'),
+        message: 'button#save',
+        data: {
+          node: {
+            id: 1,
+            tagName: 'button',
+            textContent: 'Save',
+            attributes: {},
+          },
+        },
+      }),
+    ]);
+    Reflect.deleteProperty(frame.data.node, 'attributes');
+
+    render(<SelectorList frame={frame} />);
+
+    expect(screen.getByText('button#save')).toBeInTheDocument();
+  });
+});

--- a/static/app/components/replays/breadcrumbs/selectorList.spec.tsx
+++ b/static/app/components/replays/breadcrumbs/selectorList.spec.tsx
@@ -8,6 +8,26 @@ import {hydrateBreadcrumbs} from 'sentry/utils/replays/hydrateBreadcrumbs';
 import type {ClickFrame} from 'sentry/utils/replays/types';
 
 describe('SelectorList', () => {
+  it('links annotated components to replay search', () => {
+    const [frame] = hydrateBreadcrumbs(ReplayRecordFixture(), [
+      ReplayClickFrameFixture({
+        timestamp: new Date('2024/06/21'),
+        message: 'button > SaveButton',
+        data: {
+          node: {
+            id: 1,
+            tagName: 'button',
+            textContent: 'Save',
+            attributes: {'data-sentry-component': 'SaveButton'},
+          },
+        },
+      }),
+    ]);
+    render(<SelectorList frame={frame as ClickFrame} />);
+
+    expect(screen.getByRole('link', {name: 'SaveButton'})).toBeInTheDocument();
+  });
+
   it('renders malformed click breadcrumbs without attributes', () => {
     const [frame] = hydrateBreadcrumbs(ReplayRecordFixture(), [
       ReplayClickFrameFixture({

--- a/static/app/components/replays/breadcrumbs/selectorList.tsx
+++ b/static/app/components/replays/breadcrumbs/selectorList.tsx
@@ -13,15 +13,20 @@ export function SelectorList({frame}: {frame: ClickFrame}) {
   const location = useLocation();
   const organization = useOrganization();
 
-  // There's a rare case where `frame.data` is undefined, either SDK error or
-  // user creating bad breadcrumbs
-  const componentName = frame.data?.node?.attributes['data-sentry-component'];
-  const indexOfArrow = frame.message?.lastIndexOf('>') ?? -1;
-  const lastComponentIndex = indexOfArrow === -1 ? 0 : indexOfArrow + 2;
+  // These fields can be missing when an SDK emits a malformed breadcrumb.
+  const componentName = frame.data?.node?.attributes?.['data-sentry-component'];
 
-  return componentName ? (
+  if (!componentName) {
+    return frame.message;
+  }
+
+  const lastSeparatorIndex = frame.message?.lastIndexOf('>') ?? -1;
+  const selectorPrefix =
+    lastSeparatorIndex < 0 ? '' : frame.message?.slice(0, lastSeparatorIndex + 2);
+
+  return (
     <Fragment>
-      <span>{frame.message?.substring(0, lastComponentIndex)}</span>
+      <span>{selectorPrefix}</span>
       <Tooltip
         title={t('Search by this component')}
         containerDisplayMode="inline"
@@ -43,7 +48,5 @@ export function SelectorList({frame}: {frame: ClickFrame}) {
         </Link>
       </Tooltip>
     </Fragment>
-  ) : (
-    frame.message
   );
 }


### PR DESCRIPTION
fixes an issue where replay breadcrumbs crash when a click node is missing its attributes.

keeps rendering the original selector when component metadata is unavailable and adds a small regression test.

fixes JAVASCRIPT-3B5M