### PR TITLE
fix(seer): Serialize Sentry user @mentions in Seer tools

### DIFF
--- a/src/sentry/api/serializers/models/activity.py
+++ b/src/sentry/api/serializers/models/activity.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, TypedDict
+from typing import Any, TypeAlias, TypedDict
 
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.commit import CommitWithReleaseSerializer
@@ -17,12 +17,21 @@ from sentry.types.activity import ActivityType
 from sentry.users.services.user.serial import serialize_generic_user
 from sentry.users.services.user.service import user_service
 
+ActivityId: TypeAlias = int
+
 
 class _ActivitySentryAppEmbed(TypedDict):
     id: str
     name: str
     slug: str
     avatars: list[SentryAppAvatarSerializerResponse]
+
+
+class ResolvedMention(TypedDict):
+    """A Sentry user @mentioned by an activity, resolved from the stored id ref."""
+
+    name: str
+    email: str
 
 
 class ActivitySerializerResponse(TypedDict):
@@ -59,9 +68,10 @@ PULL_REQUEST_ACTIVITY_TYPES = {
 }
 
 
-def _resolve_mentioned_users(activities: list[Activity]) -> dict[int, list[dict[str, str]]]:
-    """The Sentry users each activity @mentions, as ``{"name", "email"}`` keyed by activity
-    id, resolved in one batch.
+def _resolve_mentioned_users(
+    activities: list[Activity],
+) -> dict[ActivityId, list[ResolvedMention]]:
+    """The Sentry users each activity @mentions, keyed by activity id, resolved in one batch.
 
     Mentions are stored as ``{"id", "actor_type"}`` refs; a team ref, or a row that embedded
     a whole serialized user instead of a ref, is skipped.
@@ -177,7 +187,9 @@ class ActivitySerializer(Serializer):
             ).items()
         }
 
-        mentions = _resolve_mentioned_users(item_list) if self.resolve_mentions else {}
+        mentions: dict[ActivityId, list[ResolvedMention]] = (
+            _resolve_mentioned_users(item_list) if self.resolve_mentions else {}
+        )
 
         return {
             item: {

--- a/src/sentry/api/serializers/models/activity.py
+++ b/src/sentry/api/serializers/models/activity.py
@@ -81,7 +81,7 @@ def _resolve_mentioned_users(activities: list[Activity]) -> dict[int, list[dict[
     users = {u.id: u for u in user_service.get_many_by_id(ids=list(all_user_ids))}
     return {
         activity_id: [
-            {"name": user.name, "email": user.email}
+            {"name": user.get_display_name(), "email": user.email}
             for user_id in user_ids
             if (user := users.get(user_id))
         ]

--- a/src/sentry/api/serializers/models/activity.py
+++ b/src/sentry/api/serializers/models/activity.py
@@ -59,10 +59,46 @@ PULL_REQUEST_ACTIVITY_TYPES = {
 }
 
 
+def _resolve_mentioned_users(item_list: list[Activity]) -> dict[int, list[dict[str, str]]]:
+    """The Sentry users each activity @mentions, as ``{"name", "email"}`` keyed by activity
+    id, resolved in one batch.
+
+    Mentions are stored as ``{"id", "actor_type"}`` refs; a team ref, or a row that embedded
+    a whole serialized user instead of a ref, is skipped.
+    """
+    user_ids_by_activity = {
+        item.id: [
+            mention["id"]
+            for mention in (item.data or {}).get("mentions") or []
+            if isinstance(mention, dict) and mention.get("actor_type") == "User"
+        ]
+        for item in item_list
+    }
+    all_user_ids = {user_id for ids in user_ids_by_activity.values() for user_id in ids}
+    if not all_user_ids:
+        return {}
+
+    users = {u.id: u for u in user_service.get_many_by_id(ids=list(all_user_ids))}
+    return {
+        activity_id: [
+            {"name": user.name, "email": user.email}
+            for user_id in user_ids
+            if (user := users.get(user_id))
+        ]
+        for activity_id, user_ids in user_ids_by_activity.items()
+    }
+
+
 @register(Activity)
 class ActivitySerializer(Serializer):
-    def __init__(self, environment_func=None):
+    def __init__(self, environment_func=None, resolve_mentions: bool = False):
+        """
+        Args:
+            environment_func: A function that returns the environment for the activity.
+            resolve_mentions: Whether to resolve the mentions to the users' ``{"name", "email"}``.
+        """
         self.environment_func = environment_func
+        self.resolve_mentions = resolve_mentions
 
     def get_attrs(self, item_list, user, **kwargs):
         from sentry.api.serializers.models.group import GroupSerializer
@@ -146,10 +182,13 @@ class ActivitySerializer(Serializer):
             ).items()
         }
 
+        mentions = _resolve_mentioned_users(item_list) if self.resolve_mentions else {}
+
         return {
             item: {
                 "user": users.get(str(item.user_id)) if item.user_id else None,
                 "sentry_app": sentry_apps.get(str(item.user_id)) if item.user_id else None,
+                "mentions": mentions.get(item.id) or [],
                 "source": (
                     groups.get(item.data["source_id"])
                     if item.type == ActivityType.UNMERGE_DESTINATION.value
@@ -182,12 +221,16 @@ class ActivitySerializer(Serializer):
         elif obj.type == ActivityType.UNMERGE_SOURCE.value:
             data = {"fingerprints": obj.data["fingerprints"], "destination": attrs["destination"]}
         else:
-            data = obj.data or {}
+            # Copied because the mention handling below rewrites the key: mutating
+            # obj.data risks persisting serialized users back onto the row.
+            data = dict(obj.data or {})
             # XXX: We had a problem where Users were embedded into the mentions
             # attribute of group notes which needs to be removed
             # While group_note update has been fixed there are still many skunky comments
             # in the database.
             data.pop("mentions", None)
+            if attrs["mentions"]:
+                data["mentions"] = attrs["mentions"]
 
         return {
             "id": str(obj.id),

--- a/src/sentry/api/serializers/models/activity.py
+++ b/src/sentry/api/serializers/models/activity.py
@@ -73,8 +73,7 @@ def _resolve_mentioned_users(
 ) -> dict[ActivityId, list[ResolvedMention]]:
     """The Sentry users each activity @mentions, keyed by activity id, resolved in one batch.
 
-    Mentions are stored as ``{"id", "actor_type"}`` refs; a team ref, or a row that embedded
-    a whole serialized user instead of a ref, is skipped.
+    Returns shape: { activity.id: [{ "name": "David Cramer", "email": "david@sentry.io"}] }
     """
     activity_to_user_ids = {
         activity.id: [
@@ -83,6 +82,7 @@ def _resolve_mentioned_users(
             if isinstance(mention, dict) and mention.get("actor_type") == "User"
         ]
         for activity in activities
+        if activity.type == ActivityType.NOTE.value
     }
     all_user_ids = {user_id for ids in activity_to_user_ids.values() for user_id in ids}
     if not all_user_ids:
@@ -227,19 +227,17 @@ class ActivitySerializer(Serializer):
             data = {"fingerprints": obj.data["fingerprints"], "source": attrs["source"]}
         elif obj.type == ActivityType.UNMERGE_SOURCE.value:
             data = {"fingerprints": obj.data["fingerprints"], "destination": attrs["destination"]}
-        else:
-            # Copied because the mention handling below rewrites the key: mutating
-            # obj.data risks persisting serialized users back onto the row.
+        elif obj.type == ActivityType.NOTE.value:
             data = dict(obj.data or {})
             # XXX: We had a problem where Users were embedded into the mentions
             # attribute of group notes which needs to be removed
             # While group_note update has been fixed there are still many skunky comments
             # in the database.
             data.pop("mentions", None)
-
-            # Unrelated to the above, if we resolved mentions, add them to the data.
             if attrs["mentions"]:
                 data["mentions"] = attrs["mentions"]
+        else:
+            data = obj.data or {}
 
         return {
             "id": str(obj.id),

--- a/src/sentry/api/serializers/models/activity.py
+++ b/src/sentry/api/serializers/models/activity.py
@@ -59,22 +59,22 @@ PULL_REQUEST_ACTIVITY_TYPES = {
 }
 
 
-def _resolve_mentioned_users(item_list: list[Activity]) -> dict[int, list[dict[str, str]]]:
+def _resolve_mentioned_users(activities: list[Activity]) -> dict[int, list[dict[str, str]]]:
     """The Sentry users each activity @mentions, as ``{"name", "email"}`` keyed by activity
     id, resolved in one batch.
 
     Mentions are stored as ``{"id", "actor_type"}`` refs; a team ref, or a row that embedded
     a whole serialized user instead of a ref, is skipped.
     """
-    user_ids_by_activity = {
-        item.id: [
+    activity_to_user_ids = {
+        activity.id: [
             mention["id"]
-            for mention in (item.data or {}).get("mentions") or []
+            for mention in (activity.data or {}).get("mentions") or []
             if isinstance(mention, dict) and mention.get("actor_type") == "User"
         ]
-        for item in item_list
+        for activity in activities
     }
-    all_user_ids = {user_id for ids in user_ids_by_activity.values() for user_id in ids}
+    all_user_ids = {user_id for ids in activity_to_user_ids.values() for user_id in ids}
     if not all_user_ids:
         return {}
 
@@ -85,18 +85,13 @@ def _resolve_mentioned_users(item_list: list[Activity]) -> dict[int, list[dict[s
             for user_id in user_ids
             if (user := users.get(user_id))
         ]
-        for activity_id, user_ids in user_ids_by_activity.items()
+        for activity_id, user_ids in activity_to_user_ids.items()
     }
 
 
 @register(Activity)
 class ActivitySerializer(Serializer):
     def __init__(self, environment_func=None, resolve_mentions: bool = False):
-        """
-        Args:
-            environment_func: A function that returns the environment for the activity.
-            resolve_mentions: Whether to resolve the mentions to the users' ``{"name", "email"}``.
-        """
         self.environment_func = environment_func
         self.resolve_mentions = resolve_mentions
 
@@ -229,6 +224,8 @@ class ActivitySerializer(Serializer):
             # While group_note update has been fixed there are still many skunky comments
             # in the database.
             data.pop("mentions", None)
+
+            # Unrelated to the above, if we resolved mentions, add them to the data.
             if attrs["mentions"]:
                 data["mentions"] = attrs["mentions"]
 

--- a/src/sentry/seer/agent/tools.py
+++ b/src/sentry/seer/agent/tools.py
@@ -1515,7 +1515,7 @@ def get_issue_details(
             type__in=_SEER_EXPLORER_ACTIVITY_TYPES,
         ).order_by("-datetime")[:50]
         serialized_activities = serialize(
-            list(activities), user=None, serializer=ActivitySerializer()
+            list(activities), user=None, serializer=ActivitySerializer(resolve_mentions=True)
         )
     except Exception:
         logger.exception(

--- a/tests/sentry/api/serializers/test_activity.py
+++ b/tests/sentry/api/serializers/test_activity.py
@@ -1,4 +1,5 @@
 from sentry.api.serializers import serialize
+from sentry.api.serializers.models.activity import ActivitySerializer
 from sentry.models.activity import Activity
 from sentry.models.commit import Commit
 from sentry.models.group import GroupStatus
@@ -205,6 +206,46 @@ class GroupActivityTestCase(TestCase):
         serialized = serialize(act)
 
         assert "firstSeen" not in serialized["data"]["source"]
+
+    def _create_note(self, mentions):
+        group = self.create_group()
+        return Activity.objects.create(
+            project_id=group.project_id,
+            group=group,
+            type=ActivityType.NOTE.value,
+            user_id=self.user.id,
+            data={"text": "hi **@Jane Doe**", "mentions": mentions},
+        )
+
+    def test_note_mentions_dropped_by_default(self) -> None:
+        note = self._create_note([{"id": self.user.id, "actor_type": "User", "slug": None}])
+
+        assert serialize([note], self.user)[0]["data"] == {"text": "hi **@Jane Doe**"}
+
+    def test_note_mentions_resolved_to_users(self) -> None:
+        mentioned = self.create_user(email="jane@example.com", name="Jane Doe")
+        team = self.create_team(organization=self.organization, slug="payments")
+        note = self._create_note(
+            [
+                {"id": mentioned.id, "actor_type": "User", "slug": None},
+                # A team isn't assignable, and a stale user ref resolves to nobody.
+                {"id": team.id, "actor_type": "Team", "slug": "payments"},
+                {"id": 1234567890, "actor_type": "User", "slug": None},
+            ]
+        )
+
+        data = serialize([note], self.user, serializer=ActivitySerializer(resolve_mentions=True))[
+            0
+        ]["data"]
+
+        assert data["text"] == "hi **@Jane Doe**"
+        assert data["mentions"] == [{"name": "Jane Doe", "email": "jane@example.com"}]
+        # The row keeps its actor refs; resolved users must not be written back onto it.
+        assert note.data["mentions"][0] == {
+            "id": mentioned.id,
+            "actor_type": "User",
+            "slug": None,
+        }
 
     def test_get_activities_for_group_proxy_user(self) -> None:
         project = self.create_project(name="test_activities_group")

--- a/tests/sentry/api/serializers/test_activity.py
+++ b/tests/sentry/api/serializers/test_activity.py
@@ -224,10 +224,13 @@ class GroupActivityTestCase(TestCase):
 
     def test_note_mentions_resolved_to_users(self) -> None:
         mentioned = self.create_user(email="jane@example.com", name="Jane Doe")
+        # ``name`` is optional, and falls back to something identifiable.
+        nameless = self.create_user(email="john@example.com", name="")
         team = self.create_team(organization=self.organization, slug="payments")
         note = self._create_note(
             [
                 {"id": mentioned.id, "actor_type": "User", "slug": None},
+                {"id": nameless.id, "actor_type": "User", "slug": None},
                 # A team isn't assignable, and a stale user ref resolves to nobody.
                 {"id": team.id, "actor_type": "Team", "slug": "payments"},
                 {"id": 1234567890, "actor_type": "User", "slug": None},
@@ -239,7 +242,10 @@ class GroupActivityTestCase(TestCase):
         ]["data"]
 
         assert data["text"] == "hi **@Jane Doe**"
-        assert data["mentions"] == [{"name": "Jane Doe", "email": "jane@example.com"}]
+        assert data["mentions"] == [
+            {"name": "Jane Doe", "email": "jane@example.com"},
+            {"name": "john@example.com", "email": "john@example.com"},
+        ]
         # The row keeps its actor refs; resolved users must not be written back onto it.
         assert note.data["mentions"][0] == {
             "id": mentioned.id,


### PR DESCRIPTION
Smart Assignment wants to read user `@mention`s from comments, but the current serializer behavior just displays them as users' names. This is fine/desirable for user-facing stuff, but Smart Assignment needs email addresses that are cross-referenced with actual Sentry users. Here, we add a `resolve_mentions` flag to `ActivitySerializer`, which adds the email etc. metadata we need to the serializer output. Turn this on when fetching comment data for Seer tools.

Relates to ISWF-3164

Is a dependency of https://github.com/getsentry/seer/pull/7569