### PR TITLE
ref(replays): Migrate layouts to container queries

### DIFF
--- a/static/app/views/explore/replays/detail/filtersGrid.tsx
+++ b/static/app/views/explore/replays/detail/filtersGrid.tsx
@@ -1,14 +1,17 @@
 import {Children} from 'react';
-import styled from '@emotion/styled';
 
-export const FiltersGrid = styled('div')`
-  display: grid;
-  gap: ${p => p.theme.space.md};
-  grid-template-columns:
-    repeat(${p => Children.toArray(p.children).length - 1}, max-content)
-    1fr;
-  margin-bottom: ${p => p.theme.space.md};
-  @media (max-width: ${p => p.theme.breakpoints.sm}) {
-    margin-top: ${p => p.theme.space.md};
-  }
-`;
+import {Grid, type GridProps} from '@sentry/scraps/layout';
+
+export function FiltersGrid({children, ...props}: GridProps) {
+  return (
+    <Grid
+      {...props}
+      columns={`repeat(${Children.toArray(children).length - 1}, max-content) 1fr`}
+      gap="md"
+      marginBottom="md"
+      marginTop={{zero: 'md', xl: '0'}}
+    >
+      {children}
+    </Grid>
+  );
+}

--- a/static/app/views/explore/replays/detail/layout/replayLayout.tsx
+++ b/static/app/views/explore/replays/detail/layout/replayLayout.tsx
@@ -1,8 +1,8 @@
-import {useLayoutEffect, useRef} from 'react';
+import {useRef} from 'react';
 import styled from '@emotion/styled';
 
 import {Stack, type Responsive, useResponsivePropValue} from '@sentry/scraps/layout';
-import {SplitPanel, type SplitPanelHandle} from '@sentry/scraps/splitPanel';
+import {SplitPanel} from '@sentry/scraps/splitPanel';
 import {TooltipContext} from '@sentry/scraps/tooltip';
 
 import {ErrorBoundary} from 'sentry/components/errorBoundary';
@@ -120,15 +120,6 @@ function ReplayLayoutBody({
   const splitPanelDefaultSize = isHorizontal
     ? width * 0.5
     : (height - DIVIDER_SIZE) * 0.5;
-  const splitPanelRef = useRef<SplitPanelHandle>(null);
-  const previousOrientation = useRef(isHorizontal);
-
-  useLayoutEffect(() => {
-    if (previousOrientation.current !== isHorizontal) {
-      splitPanelRef.current?.setSize(splitPanelDefaultSize);
-    }
-    previousOrientation.current = isHorizontal;
-  }, [isHorizontal, splitPanelDefaultSize]);
 
   if (layout === LayoutKey.NO_VIDEO) {
     return (
@@ -145,7 +136,6 @@ function ReplayLayoutBody({
       <Stack wrap="nowrap" minHeight="0" ref={measureRef}>
         {hasSize ? (
           <SplitPanel
-            ref={splitPanelRef}
             orientation={splitPanelOrientation}
             defaultSize={splitPanelDefaultSize}
             minSize={isHorizontal ? MIN_SIDEBAR_WIDTH : MIN_VIDEO_HEIGHT}

--- a/static/app/views/explore/replays/detail/layout/replayLayout.tsx
+++ b/static/app/views/explore/replays/detail/layout/replayLayout.tsx
@@ -1,7 +1,7 @@
 import {useRef} from 'react';
 import styled from '@emotion/styled';
 
-import {Stack, type Responsive, useResponsivePropValue} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {SplitPanel} from '@sentry/scraps/splitPanel';
 import {TooltipContext} from '@sentry/scraps/tooltip';
 
@@ -113,13 +113,6 @@ function ReplayLayoutBody({
   const isFocusAreaCollapsed = layout === LayoutKey.VIDEO_ONLY;
   const effectiveLayout = isFocusAreaCollapsed ? defaultLayout : layout;
   const isLeftRight = effectiveLayout === LayoutKey.SIDEBAR_LEFT;
-  const splitPanelOrientation: Responsive<'horizontal' | 'vertical'> = isLeftRight
-    ? {zero: 'vertical', xl: 'horizontal'}
-    : 'vertical';
-  const isHorizontal = useResponsivePropValue(splitPanelOrientation) === 'horizontal';
-  const splitPanelDefaultSize = isHorizontal
-    ? width * 0.5
-    : (height - DIVIDER_SIZE) * 0.5;
 
   if (layout === LayoutKey.NO_VIDEO) {
     return (
@@ -136,20 +129,20 @@ function ReplayLayoutBody({
       <Stack wrap="nowrap" minHeight="0" ref={measureRef}>
         {hasSize ? (
           <SplitPanel
-            orientation={splitPanelOrientation}
-            defaultSize={splitPanelDefaultSize}
-            minSize={isHorizontal ? MIN_SIDEBAR_WIDTH : MIN_VIDEO_HEIGHT}
-            fillMinSize={isHorizontal ? MIN_CONTENT_WIDTH : MIN_CONTENT_HEIGHT}
+            orientation={isLeftRight ? 'horizontal' : 'vertical'}
+            defaultSize={isLeftRight ? width * 0.5 : (height - DIVIDER_SIZE) * 0.5}
+            minSize={isLeftRight ? MIN_SIDEBAR_WIDTH : MIN_VIDEO_HEIGHT}
+            fillMinSize={isLeftRight ? MIN_CONTENT_WIDTH : MIN_CONTENT_HEIGHT}
             onResizeEnd={({direction}) =>
               trackAnalytics('replay.details-resized-panel', {
                 organization,
                 layout: effectiveLayout,
                 slide_motion:
                   direction === 'increase'
-                    ? isHorizontal
+                    ? isLeftRight
                       ? 'toRight'
                       : 'toBottom'
-                    : isHorizontal
+                    : isLeftRight
                       ? 'toLeft'
                       : 'toTop',
               })
@@ -159,8 +152,8 @@ function ReplayLayoutBody({
                 flex="1"
                 minHeight="0"
                 minWidth="0"
-                paddingRight={isHorizontal ? 'md' : undefined}
-                paddingBottom={isHorizontal ? undefined : 'md'}
+                paddingRight={isLeftRight ? 'md' : undefined}
+                paddingBottom={isLeftRight ? undefined : 'md'}
               >
                 <PanelContainer>{video}</PanelContainer>
               </Stack>
@@ -171,8 +164,8 @@ function ReplayLayoutBody({
                   flex="1"
                   minHeight="0"
                   minWidth="0"
-                  paddingLeft={isHorizontal ? 'md' : undefined}
-                  paddingTop={isHorizontal ? undefined : 'md'}
+                  paddingLeft={isLeftRight ? 'md' : undefined}
+                  paddingTop={isLeftRight ? undefined : 'md'}
                 >
                   {focusArea}
                 </Stack>

--- a/static/app/views/explore/replays/detail/layout/replayLayout.tsx
+++ b/static/app/views/explore/replays/detail/layout/replayLayout.tsx
@@ -1,8 +1,8 @@
-import {useRef} from 'react';
+import {useLayoutEffect, useRef} from 'react';
 import styled from '@emotion/styled';
 
-import {Stack} from '@sentry/scraps/layout';
-import {SplitPanel} from '@sentry/scraps/splitPanel';
+import {Stack, type Responsive, useResponsivePropValue} from '@sentry/scraps/layout';
+import {SplitPanel, type SplitPanelHandle} from '@sentry/scraps/splitPanel';
 import {TooltipContext} from '@sentry/scraps/tooltip';
 
 import {ErrorBoundary} from 'sentry/components/errorBoundary';
@@ -113,6 +113,22 @@ function ReplayLayoutBody({
   const isFocusAreaCollapsed = layout === LayoutKey.VIDEO_ONLY;
   const effectiveLayout = isFocusAreaCollapsed ? defaultLayout : layout;
   const isLeftRight = effectiveLayout === LayoutKey.SIDEBAR_LEFT;
+  const splitPanelOrientation: Responsive<'horizontal' | 'vertical'> = isLeftRight
+    ? {zero: 'vertical', xl: 'horizontal'}
+    : 'vertical';
+  const isHorizontal = useResponsivePropValue(splitPanelOrientation) === 'horizontal';
+  const splitPanelDefaultSize = isHorizontal
+    ? width * 0.5
+    : (height - DIVIDER_SIZE) * 0.5;
+  const splitPanelRef = useRef<SplitPanelHandle>(null);
+  const previousOrientation = useRef(isHorizontal);
+
+  useLayoutEffect(() => {
+    if (previousOrientation.current !== isHorizontal) {
+      splitPanelRef.current?.setSize(splitPanelDefaultSize);
+    }
+    previousOrientation.current = isHorizontal;
+  }, [isHorizontal, splitPanelDefaultSize]);
 
   if (layout === LayoutKey.NO_VIDEO) {
     return (
@@ -129,20 +145,21 @@ function ReplayLayoutBody({
       <Stack wrap="nowrap" minHeight="0" ref={measureRef}>
         {hasSize ? (
           <SplitPanel
-            orientation={isLeftRight ? 'horizontal' : 'vertical'}
-            defaultSize={isLeftRight ? width * 0.5 : (height - DIVIDER_SIZE) * 0.5}
-            minSize={isLeftRight ? MIN_SIDEBAR_WIDTH : MIN_VIDEO_HEIGHT}
-            fillMinSize={isLeftRight ? MIN_CONTENT_WIDTH : MIN_CONTENT_HEIGHT}
+            ref={splitPanelRef}
+            orientation={splitPanelOrientation}
+            defaultSize={splitPanelDefaultSize}
+            minSize={isHorizontal ? MIN_SIDEBAR_WIDTH : MIN_VIDEO_HEIGHT}
+            fillMinSize={isHorizontal ? MIN_CONTENT_WIDTH : MIN_CONTENT_HEIGHT}
             onResizeEnd={({direction}) =>
               trackAnalytics('replay.details-resized-panel', {
                 organization,
                 layout: effectiveLayout,
                 slide_motion:
                   direction === 'increase'
-                    ? isLeftRight
+                    ? isHorizontal
                       ? 'toRight'
                       : 'toBottom'
-                    : isLeftRight
+                    : isHorizontal
                       ? 'toLeft'
                       : 'toTop',
               })
@@ -152,8 +169,8 @@ function ReplayLayoutBody({
                 flex="1"
                 minHeight="0"
                 minWidth="0"
-                paddingRight={isLeftRight ? 'md' : undefined}
-                paddingBottom={isLeftRight ? undefined : 'md'}
+                paddingRight={isHorizontal ? 'md' : undefined}
+                paddingBottom={isHorizontal ? undefined : 'md'}
               >
                 <PanelContainer>{video}</PanelContainer>
               </Stack>
@@ -164,8 +181,8 @@ function ReplayLayoutBody({
                   flex="1"
                   minHeight="0"
                   minWidth="0"
-                  paddingLeft={isLeftRight ? 'md' : undefined}
-                  paddingTop={isLeftRight ? undefined : 'md'}
+                  paddingLeft={isHorizontal ? 'md' : undefined}
+                  paddingTop={isHorizontal ? undefined : 'md'}
                 >
                   {focusArea}
                 </Stack>

--- a/static/app/views/explore/replays/list/replayListControls.tsx
+++ b/static/app/views/explore/replays/list/replayListControls.tsx
@@ -1,4 +1,4 @@
-import {Flex} from '@sentry/scraps/layout';
+import {Container, Flex, Grid} from '@sentry/scraps/layout';
 
 import {ReplaysFilters} from 'sentry/views/explore/replays/list/filters';
 import {ReplayIndexTimestampPrefPicker} from 'sentry/views/explore/replays/list/replayIndexTimestampPrefPicker';
@@ -18,17 +18,43 @@ export function ReplayListControls({
   widgetIsOpen,
 }: Props) {
   return (
-    <Flex gap="md" wrap="wrap">
-      <ReplaysFilters />
-      <ReplaysSearch />
-      <ReplayIndexTimestampPrefPicker />
-      {showDeadRageClickCards ? (
-        <ReplayWidgetsToggleButton
-          onClick={onToggleWidgets}
-          widgetIsOpen={widgetIsOpen}
-        />
-      ) : null}
-      <SaveReplayQueryButton />
-    </Flex>
+    <Grid
+      areas={{
+        zero: `
+          "filters"
+          "search"
+          "actions"
+        `,
+        xl: `
+          "filters actions"
+          "search search"
+        `,
+        '4xl': '"filters search actions"',
+      }}
+      columns={{
+        zero: '100%',
+        xl: '1fr auto',
+        '4xl': 'auto 1fr auto',
+      }}
+      gap="md"
+      width="100%"
+    >
+      <Container area="filters">
+        <ReplaysFilters />
+      </Container>
+      <Container area="search">
+        <ReplaysSearch />
+      </Container>
+      <Flex area="actions" align="start" gap="md" justifySelf="end" wrap="wrap">
+        <ReplayIndexTimestampPrefPicker />
+        {showDeadRageClickCards ? (
+          <ReplayWidgetsToggleButton
+            onClick={onToggleWidgets}
+            widgetIsOpen={widgetIsOpen}
+          />
+        ) : null}
+        <SaveReplayQueryButton />
+      </Flex>
+    </Grid>
   );
 }

--- a/static/app/views/explore/replays/list/replayOnboardingPanel.tsx
+++ b/static/app/views/explore/replays/list/replayOnboardingPanel.tsx
@@ -278,34 +278,19 @@ export function SetupReplaysCTA({disabled, primaryAction}: SetupReplaysCTAProps)
 }
 
 const HeroImage = styled('img')`
+  display: block;
+  width: 100%;
+  max-width: 300px;
+  height: auto;
+  margin: 0 auto;
+  user-select: none;
+
   @container (min-width: ${p => p.theme.container.xl}) {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 50%;
     width: 220px;
-    margin-top: auto;
-    margin-bottom: auto;
-    user-select: none;
-    transform: translateX(-50%);
   }
 
   @container (min-width: ${p => p.theme.container['3xl']}) {
-    min-width: 300px;
     width: 300px;
-    transform: translateX(-55%);
-  }
-
-  @container (min-width: ${p => p.theme.container['4xl']}) {
-    min-width: 380px;
-    width: 380px;
-    transform: translateX(-60%);
-  }
-
-  @container (min-width: ${p => p.theme.container['5xl']}) {
-    min-width: 420px;
-    width: 420px;
-    transform: translateX(-65%);
   }
 `;
 

--- a/static/app/views/explore/replays/list/replayOnboardingPanel.tsx
+++ b/static/app/views/explore/replays/list/replayOnboardingPanel.tsx
@@ -25,15 +25,7 @@ import {
 } from 'sentry/views/explore/profiling/landing/styles';
 import {useAllMobileProj} from 'sentry/views/explore/replays/detail/useAllMobileProj';
 import {ReplayPanel} from 'sentry/views/explore/replays/list/replayPanel';
-import {useSecondaryNavigation} from 'sentry/views/navigation/secondaryNavigationContext';
 import {makeProjectsPathname} from 'sentry/views/projects/pathname';
-
-type Breakpoints = {
-  lg: string;
-  md: string;
-  sm: string;
-  xl: string;
-};
 
 const OnboardingCTAHook = OverrideOrDefault({
   overrideName: 'component:replay-onboarding-cta',
@@ -45,8 +37,6 @@ export function ReplayOnboardingPanel() {
   const projects = useProjects();
   const organization = useOrganization();
   const canUserCreateProject = useCanCreateProject();
-  const {view} = useSecondaryNavigation();
-  const isCollapsed = view !== 'expanded';
 
   const supportedPlatforms = replayPlatforms;
 
@@ -74,26 +64,12 @@ export function ReplayOnboardingPanel() {
       ? !canUserCreateProject
       : allSelectedProjectsUnsupported && hasSelectedProjects;
 
-  const breakpoints = isCollapsed
-    ? {
-        sm: '800px',
-        md: '992px',
-        lg: '1210px',
-        xl: '1450px',
-      }
-    : {
-        sm: '800px',
-        md: '1175px',
-        lg: '1375px',
-        xl: '1450px',
-      };
-
   return (
     <Fragment>
       {hasSelectedProjects && allSelectedProjectsUnsupported && (
         <ReplayUnsupportedAlert projectSlug={selectedProjects[0]!.slug} />
       )}
-      <ReplayPanel image={<HeroImage src={emptyStateImg} breakpoints={breakpoints} />}>
+      <ReplayPanel image={<HeroImage />}>
         <OnboardingCTAHook organization={organization}>
           <SetupReplaysCTA
             primaryAction={primaryAction}
@@ -301,35 +277,39 @@ export function SetupReplaysCTA({disabled, primaryAction}: SetupReplaysCTAProps)
   );
 }
 
-const HeroImage = styled('img')<{breakpoints: Breakpoints}>`
-  @media (min-width: ${p => p.breakpoints.sm}) {
-    user-select: none;
+function HeroImage() {
+  return <StyledHeroImage src={emptyStateImg} />;
+}
+
+const StyledHeroImage = styled('img')`
+  @container (min-width: ${p => p.theme.container.xl}) {
     position: absolute;
     top: 0;
     bottom: 0;
+    left: 50%;
     width: 220px;
     margin-top: auto;
     margin-bottom: auto;
+    user-select: none;
     transform: translateX(-50%);
-    left: 50%;
   }
 
-  @media (min-width: ${p => p.breakpoints.md}) {
-    transform: translateX(-55%);
-    width: 300px;
+  @container (min-width: ${p => p.theme.container['3xl']}) {
     min-width: 300px;
+    width: 300px;
+    transform: translateX(-55%);
   }
 
-  @media (min-width: ${p => p.breakpoints.lg}) {
-    transform: translateX(-60%);
-    width: 380px;
+  @container (min-width: ${p => p.theme.container['4xl']}) {
     min-width: 380px;
+    width: 380px;
+    transform: translateX(-60%);
   }
 
-  @media (min-width: ${p => p.breakpoints.xl}) {
-    transform: translateX(-65%);
-    width: 420px;
+  @container (min-width: ${p => p.theme.container['5xl']}) {
     min-width: 420px;
+    width: 420px;
+    transform: translateX(-65%);
   }
 `;
 

--- a/static/app/views/explore/replays/list/replayOnboardingPanel.tsx
+++ b/static/app/views/explore/replays/list/replayOnboardingPanel.tsx
@@ -69,7 +69,7 @@ export function ReplayOnboardingPanel() {
       {hasSelectedProjects && allSelectedProjectsUnsupported && (
         <ReplayUnsupportedAlert projectSlug={selectedProjects[0]!.slug} />
       )}
-      <ReplayPanel image={<HeroImage />}>
+      <ReplayPanel image={<HeroImage src={emptyStateImg} />}>
         <OnboardingCTAHook organization={organization}>
           <SetupReplaysCTA
             primaryAction={primaryAction}
@@ -277,11 +277,7 @@ export function SetupReplaysCTA({disabled, primaryAction}: SetupReplaysCTAProps)
   );
 }
 
-function HeroImage() {
-  return <StyledHeroImage src={emptyStateImg} />;
-}
-
-const StyledHeroImage = styled('img')`
+const HeroImage = styled('img')`
   @container (min-width: ${p => p.theme.container.xl}) {
     position: absolute;
     top: 0;

--- a/static/app/views/explore/replays/list/replayPanel.tsx
+++ b/static/app/views/explore/replays/list/replayPanel.tsx
@@ -26,11 +26,10 @@ export function ReplayPanel({image, noCenter, children, ...props}: Props) {
         {image ? (
           <Container
             flex={{xl: 1}}
-            margin={{zero: 'xl auto', xl: '120px 2xl 2xl'}}
+            margin={{zero: 'xl auto', xl: '2xl'}}
             maxWidth="300px"
             minHeight="100px"
             minWidth="150px"
-            position="relative"
           >
             {image}
           </Container>

--- a/static/app/views/explore/replays/list/replayPanel.tsx
+++ b/static/app/views/explore/replays/list/replayPanel.tsx
@@ -23,7 +23,7 @@ const Container = styled('div')`
   padding: ${p => p.theme.space['2xl']};
   position: relative;
 
-  @media (min-width: ${p => p.theme.breakpoints.sm}) {
+  @container (min-width: ${p => p.theme.container.xl}) {
     display: flex;
     align-items: flex-start;
     flex-direction: row;
@@ -34,7 +34,7 @@ const Container = styled('div')`
     margin: 0 auto;
   }
 
-  @media (min-width: ${p => p.theme.breakpoints.md}) {
+  @container (min-width: ${p => p.theme.container['3xl']}) {
     min-height: 350px;
   }
 `;
@@ -46,7 +46,7 @@ const StyledBox = styled('div')<{centered?: boolean}>`
   ${p => (p.centered ? 'text-align: center;' : '')}
   ${p => (p.centered ? 'max-width: 600px;' : '')}
 
-  @media (min-width: ${p => p.theme.breakpoints.sm}) {
+  @container (min-width: ${p => p.theme.container.xl}) {
     flex: 2;
   }
 `;
@@ -58,7 +58,7 @@ const IlloBox = styled(StyledBox)`
   min-width: 150px;
   margin: ${p => p.theme.space.xl} auto;
 
-  @media (min-width: ${p => p.theme.breakpoints.sm}) {
+  @container (min-width: ${p => p.theme.container.xl}) {
     flex: 1;
     margin: 120px ${p => p.theme.space['2xl']} ${p => p.theme.space['2xl']}
       ${p => p.theme.space['2xl']};

--- a/static/app/views/explore/replays/list/replayPanel.tsx
+++ b/static/app/views/explore/replays/list/replayPanel.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled';
+import {Container, Flex} from '@sentry/scraps/layout';
 
 import {Panel} from 'sentry/components/panels/panel';
 
@@ -11,57 +11,42 @@ interface Props extends React.ComponentProps<typeof Panel> {
 export function ReplayPanel({image, noCenter, children, ...props}: Props) {
   return (
     <Panel {...props}>
-      <Container>
-        {image ? <IlloBox>{image}</IlloBox> : null}
-        <StyledBox centered={!image && !noCenter}>{children}</StyledBox>
-      </Container>
+      <Flex
+        align="start"
+        direction="row"
+        display={{zero: 'block', xl: 'flex'}}
+        justify="center"
+        margin={{zero: '0', xl: '0 auto'}}
+        maxWidth={{xl: '1000px'}}
+        minHeight={{xl: '300px', '3xl': '350px'}}
+        padding="2xl"
+        position="relative"
+        wrap="wrap"
+      >
+        {image ? (
+          <Container
+            flex={{xl: 1}}
+            margin={{zero: 'xl auto', xl: '120px 2xl 2xl'}}
+            maxWidth="300px"
+            minHeight="100px"
+            minWidth="150px"
+            position="relative"
+          >
+            {image}
+          </Container>
+        ) : null}
+        <Container
+          flex={{xl: 2}}
+          minWidth="0"
+          style={
+            !image && !noCenter
+              ? {zIndex: 1, textAlign: 'center', maxWidth: '600px'}
+              : {zIndex: 1}
+          }
+        >
+          {children}
+        </Container>
+      </Flex>
     </Panel>
   );
 }
-
-const Container = styled('div')`
-  padding: ${p => p.theme.space['2xl']};
-  position: relative;
-
-  @container (min-width: ${p => p.theme.container.xl}) {
-    display: flex;
-    align-items: flex-start;
-    flex-direction: row;
-    justify-content: center;
-    flex-wrap: wrap;
-    min-height: 300px;
-    max-width: 1000px;
-    margin: 0 auto;
-  }
-
-  @container (min-width: ${p => p.theme.container['3xl']}) {
-    min-height: 350px;
-  }
-`;
-
-const StyledBox = styled('div')<{centered?: boolean}>`
-  min-width: 0;
-  z-index: 1;
-
-  ${p => (p.centered ? 'text-align: center;' : '')}
-  ${p => (p.centered ? 'max-width: 600px;' : '')}
-
-  @container (min-width: ${p => p.theme.container.xl}) {
-    flex: 2;
-  }
-`;
-
-const IlloBox = styled(StyledBox)`
-  position: relative;
-  min-height: 100px;
-  max-width: 300px;
-  min-width: 150px;
-  margin: ${p => p.theme.space.xl} auto;
-
-  @container (min-width: ${p => p.theme.container.xl}) {
-    flex: 1;
-    margin: 120px ${p => p.theme.space['2xl']} ${p => p.theme.space['2xl']}
-      ${p => p.theme.space['2xl']};
-    max-width: auto;
-  }
-`;

--- a/static/app/views/explore/replays/list/replayPanel.tsx
+++ b/static/app/views/explore/replays/list/replayPanel.tsx
@@ -12,9 +12,8 @@ export function ReplayPanel({image, noCenter, children, ...props}: Props) {
   return (
     <Panel {...props}>
       <Flex
-        align="start"
-        direction="row"
-        display={{zero: 'block', xl: 'flex'}}
+        align={{zero: 'stretch', xl: 'start'}}
+        direction={{zero: 'column', xl: 'row'}}
         justify="center"
         margin={{zero: '0', xl: '0 auto'}}
         maxWidth={{xl: '1000px'}}

--- a/static/app/views/explore/replays/list/search.tsx
+++ b/static/app/views/explore/replays/list/search.tsx
@@ -16,7 +16,12 @@ export function ReplaysSearch() {
   });
 
   return (
-    <Container flex="1" minWidth={{zero: 'auto', xl: 267}} maxWidth="100%" width="auto">
+    <Container
+      flex="1"
+      minWidth={{zero: 'auto', xl: '267px'}}
+      maxWidth="100%"
+      width="auto"
+    >
       <ReplaySearchBar
         organization={organization}
         pageFilters={selection}

--- a/static/app/views/explore/replays/list/search.tsx
+++ b/static/app/views/explore/replays/list/search.tsx
@@ -1,5 +1,6 @@
-import styled from '@emotion/styled';
 import {parseAsString, useQueryStates} from 'nuqs';
+
+import {Container} from '@sentry/scraps/layout';
 
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -15,7 +16,7 @@ export function ReplaysSearch() {
   });
 
   return (
-    <SearchContainer>
+    <Container flex="1" minWidth={{zero: 'auto', xl: 267}} maxWidth="100%" width="auto">
       <ReplaySearchBar
         organization={organization}
         pageFilters={selection}
@@ -28,17 +29,6 @@ export function ReplaysSearch() {
           });
         }}
       />
-    </SearchContainer>
+    </Container>
   );
 }
-
-const SearchContainer = styled('div')`
-  flex: 1;
-  min-width: 267px;
-  max-width: 100%;
-  width: auto;
-
-  @media (max-width: ${p => p.theme.breakpoints.sm}) {
-    min-width: auto;
-  }
-`;

--- a/static/app/views/explore/replays/selectors/deadRageSelectorCards.tsx
+++ b/static/app/views/explore/replays/selectors/deadRageSelectorCards.tsx
@@ -2,7 +2,7 @@ import type {ReactNode} from 'react';
 import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
-import {Container, Flex, Stack, type FlexProps} from '@sentry/scraps/layout';
+import {Container, Flex, Grid, Stack, type FlexProps} from '@sentry/scraps/layout';
 
 import {Accordion} from 'sentry/components/container/accordion';
 import {EmptyStateWarning} from 'sentry/components/emptyStateWarning';
@@ -222,14 +222,19 @@ function AccordionItemHeader({
   );
 }
 
-const SplitCardContainer = styled('div')`
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  grid-template-rows: max-content;
-  grid-auto-flow: column;
-  gap: 0 ${p => p.theme.space.xl};
-  align-items: stretch;
-`;
+function SplitCardContainer({children}: {children: ReactNode}) {
+  return (
+    <Grid
+      align="stretch"
+      columns={{zero: '1fr', xl: '1fr 1fr'}}
+      flow={{zero: 'row', xl: 'column'}}
+      gap={{zero: 'xl', xl: '0 xl'}}
+      rows="max-content"
+    >
+      {children}
+    </Grid>
+  );
+}
 
 const ClickCount = styled(TextOverflow)`
   color: ${p => p.theme.colors.gray500};


### PR DESCRIPTION
**Before**



https://github.com/user-attachments/assets/4639c205-60f4-443d-aaa7-d3f19a591356




**After**

https://github.com/user-attachments/assets/b7450954-24e3-40cf-a280-1ae99a7e5906


Refs #120315

## Breakpoint changes

Migrated from viewport `@media` queries (styled-components) to Scraps `@container` queries. Container breakpoints are generally narrower than the viewport ones they replace, since they resolve against the local container rather than the full viewport.

| Component | Before (viewport, `@media`) | After (container, `@container`) |
| --- | --- | --- |
| Search field min-width (`search.tsx`) | `max-width: sm` (800px) → `min-width: auto`; above → `267px` | `min-width: xl` (768px) → `auto` below, `267px` at/above |
| Replay panel layout (`replayPanel.tsx`) | `min-width: sm` (800px) → row layout, `min-height: 300px`; `min-width: md` (992px) → `min-height: 350px` | `min-width: xl` (768px) → row layout, `min-height: 300px`; `min-width: 3xl` (1024px) → `min-height: 350px` |
| Filters grid margin (`filtersGrid.tsx`) | `max-width: sm` (800px) → `margin-top: md` | `min-width: xl` (768px) → `margin-top: 0` (else `md`) |
| Dead/rage split cards (`deadRageSelectorCards.tsx`) | always 2-column grid (no breakpoint) | `min-width: xl` (768px) → 2-column; below → 1-column stacked |
| Replay list controls (`replayListControls.tsx`) | always single wrapped row (no breakpoint) | `min-width: xl` (768px) and `min-width: 4xl` (1152px) → grid-area layout changes |
| Onboarding hero image (`replayOnboardingPanel.tsx`) | `min-width` at sm/md/lg/xl (800px / 992–1175px / 1210–1375px / 1450px, varied by nav collapsed state) → width 220/300/380/420px | `min-width: xl` (768px) / `min-width: 3xl` (1024px) → width 220px / 300px |
