### PR TITLE
ref(profiling): Migrate layouts to container queries

### DIFF
--- a/static/app/views/explore/profiling/content.tsx
+++ b/static/app/views/explore/profiling/content.tsx
@@ -4,7 +4,7 @@ import {useQuery} from '@tanstack/react-query';
 import type {Location} from 'history';
 
 import {Alert} from '@sentry/scraps/alert';
-import {Stack} from '@sentry/scraps/layout';
+import {Container, Grid, Stack} from '@sentry/scraps/layout';
 import {Pagination} from '@sentry/scraps/pagination';
 import {TabList, Tabs} from '@sentry/scraps/tabs';
 
@@ -172,14 +172,16 @@ function ProfilingContentInner() {
           <ProfilingContentPageHeader />
           <ExploreBodySearch>
             <Layout.Main width="full">
-              <PageFilterBar condensed>
-                <ProjectPageFilter resetParamsOnChange={CURSOR_PARAMS} />
-                <EnvironmentPageFilter resetParamsOnChange={CURSOR_PARAMS} />
-                <DatePageFilter
-                  {...datePageFilterProps}
-                  resetParamsOnChange={CURSOR_PARAMS}
-                />
-              </PageFilterBar>
+              <Container display="inline-flex" maxWidth="100%">
+                <PageFilterBar condensed>
+                  <ProjectPageFilter resetParamsOnChange={CURSOR_PARAMS} />
+                  <EnvironmentPageFilter resetParamsOnChange={CURSOR_PARAMS} />
+                  <DatePageFilter
+                    {...datePageFilterProps}
+                    resetParamsOnChange={CURSOR_PARAMS}
+                  />
+                </PageFilterBar>
+              </Container>
             </Layout.Main>
           </ExploreBodySearch>
           <ExploreBodyContent>
@@ -191,7 +193,7 @@ function ProfilingContentInner() {
                   {organization.features.includes(
                     'profiling-global-suspect-functions'
                   ) && (
-                    <WidgetsContainer>
+                    <Grid columns={{zero: '1fr', xl: '1fr 1fr'}} gap="xl">
                       <LandingWidgetSelector
                         cursorName={LEFT_WIDGET_CURSOR}
                         widgetHeight="410px"
@@ -210,7 +212,7 @@ function ProfilingContentInner() {
                         storageKey="profiling-landing-widget-1"
                         onDataState={updateWidget2DataState}
                       />
-                    </WidgetsContainer>
+                    </Grid>
                   )}
                   <Stack gap="lg">
                     <Tabs value={tab} onChange={onTabChange}>
@@ -436,15 +438,6 @@ const LandingAggregateFlamegraphContainer = styled('div')`
   position: relative;
   border: 1px solid ${p => p.theme.tokens.border.primary};
   border-radius: ${p => p.theme.radius.md};
-`;
-
-const WidgetsContainer = styled('div')`
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: ${p => p.theme.space.xl};
-  @media (max-width: ${p => p.theme.breakpoints.sm}) {
-    grid-template-columns: 1fr;
-  }
 `;
 
 const StyledPagination = styled(Pagination)`

--- a/static/app/views/explore/profiling/content.tsx
+++ b/static/app/views/explore/profiling/content.tsx
@@ -4,7 +4,7 @@ import {useQuery} from '@tanstack/react-query';
 import type {Location} from 'history';
 
 import {Alert} from '@sentry/scraps/alert';
-import {Container, Grid, Stack} from '@sentry/scraps/layout';
+import {Grid, Stack} from '@sentry/scraps/layout';
 import {Pagination} from '@sentry/scraps/pagination';
 import {TabList, Tabs} from '@sentry/scraps/tabs';
 
@@ -172,16 +172,14 @@ function ProfilingContentInner() {
           <ProfilingContentPageHeader />
           <ExploreBodySearch>
             <Layout.Main width="full">
-              <Container display="inline-flex" maxWidth="100%">
-                <PageFilterBar condensed>
-                  <ProjectPageFilter resetParamsOnChange={CURSOR_PARAMS} />
-                  <EnvironmentPageFilter resetParamsOnChange={CURSOR_PARAMS} />
-                  <DatePageFilter
-                    {...datePageFilterProps}
-                    resetParamsOnChange={CURSOR_PARAMS}
-                  />
-                </PageFilterBar>
-              </Container>
+              <PageFilterBar condensed>
+                <ProjectPageFilter resetParamsOnChange={CURSOR_PARAMS} />
+                <EnvironmentPageFilter resetParamsOnChange={CURSOR_PARAMS} />
+                <DatePageFilter
+                  {...datePageFilterProps}
+                  resetParamsOnChange={CURSOR_PARAMS}
+                />
+              </PageFilterBar>
             </Layout.Main>
           </ExploreBodySearch>
           <ExploreBodyContent>

--- a/static/app/views/explore/profiling/onboarding.tsx
+++ b/static/app/views/explore/profiling/onboarding.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import emptyTraceImg from 'sentry-images/spot/profiling-empty-state.svg';
 
 import {LinkButton} from '@sentry/scraps/button';
+import {Container, Flex} from '@sentry/scraps/layout';
 
 import {GuidedSteps} from 'sentry/components/guidedSteps/guidedSteps';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
@@ -147,8 +148,8 @@ function OnboardingPanel({
         <AuthTokenGeneratorProvider projectSlug={project?.slug}>
           <TabSelectionScope>
             <div>
-              <HeaderWrapper>
-                <HeaderText>
+              <Flex justify="between" gap="2xl" radius="md" padding="3xl">
+                <Container flex={{zero: 1, xl: 0.65}}>
                   <Title>{t('Find Slow Code')}</Title>
                   <SubTitle>
                     {t(
@@ -172,9 +173,11 @@ function OnboardingPanel({
                       )}
                     </li>
                   </BulletList>
-                </HeaderText>
-                <Image src={emptyTraceImg} />
-              </HeaderWrapper>
+                </Container>
+                <Container display={{zero: 'none', xl: 'block'}}>
+                  {imageProps => <Image {...imageProps} src={emptyTraceImg} />}
+                </Container>
+              </Flex>
               <Divider />
               <Body>
                 <Setup>{children}</Setup>
@@ -377,22 +380,6 @@ const BulletList = styled('ul')`
   }
 `;
 
-const HeaderWrapper = styled('div')`
-  display: flex;
-  justify-content: space-between;
-  gap: ${p => p.theme.space['2xl']};
-  border-radius: ${p => p.theme.radius.md};
-  padding: ${p => p.theme.space['3xl']};
-`;
-
-const HeaderText = styled('div')`
-  flex: 0.65;
-
-  @media (max-width: ${p => p.theme.breakpoints.sm}) {
-    flex: 1;
-  }
-`;
-
 const Setup = styled('div')`
   padding: ${p => p.theme.space['3xl']};
 
@@ -422,14 +409,9 @@ const Body = styled('div')`
 `;
 
 const Image = styled('img')`
-  display: block;
   pointer-events: none;
   height: 120px;
   overflow: hidden;
-
-  @media (max-width: ${p => p.theme.breakpoints.sm}) {
-    display: none;
-  }
 `;
 
 const Divider = styled('hr')`

--- a/static/app/views/performance/transactionSummary/transactionProfiles/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionProfiles/index.tsx
@@ -1,6 +1,8 @@
 import {useCallback, useMemo} from 'react';
 import styled from '@emotion/styled';
 
+import {Grid} from '@sentry/scraps/layout';
+
 import * as Layout from 'sentry/components/layouts/thirds';
 import {DatePageFilter} from 'sentry/components/pageFilters/date/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/pageFilters/environment/environmentPageFilter';
@@ -98,7 +100,7 @@ function Profiles({transaction}: ProfilesProps) {
 
   return (
     <StyledMain width="full">
-      <FilterActions>
+      <Grid columns={{zero: '1fr', xl: 'auto 1fr'}} gap="xl" marginBottom="xl">
         <PageFilterBar condensed>
           <EnvironmentPageFilter />
           <DatePageFilter {...datePageFilterProps} />
@@ -108,18 +110,11 @@ function Profiles({transaction}: ProfilesProps) {
           initialQuery={rawQuery}
           onSearch={handleSearch}
         />
-      </FilterActions>
+      </Grid>
       <TransactionProfilesContent query={query} />
     </StyledMain>
   );
 }
-
-const FilterActions = styled('div')`
-  margin-bottom: ${p => p.theme.space.xl};
-  gap: ${p => p.theme.space.xl};
-  display: grid;
-  grid-template-columns: min-content 1fr;
-`;
 
 const StyledMain = styled(Layout.Main)`
   display: flex;


### PR DESCRIPTION
Migrates Profiling landing and onboarding layouts to container-responsive primitives. The page filters retain their intrinsic width while staying constrained by narrow containers.

| Location | Before (viewport media query) | After (container query) |
| --- | --- | --- |
| `content.tsx` widgets grid (`WidgetsContainer`) | `max-width: ${theme.breakpoints.sm}` (800px) → 1 column | `Grid columns={{zero: '1fr', xl: '1fr 1fr'}}` (768px) |
| `onboarding.tsx` header text (`HeaderText`) | `max-width: ${theme.breakpoints.sm}` (800px) → `flex: 1` | `Container flex={{zero: 1, xl: 0.65}}` (768px) |
| `onboarding.tsx` header image (`Image`) | `max-width: ${theme.breakpoints.sm}` (800px) → `display: none` | `Container display={{zero: 'none', xl: 'block'}}` (768px) |

**Before**


https://github.com/user-attachments/assets/5cc31967-cbd3-4c66-ad1e-83e5cefaf163




**After**


https://github.com/user-attachments/assets/6c6122fd-23ed-400e-99c5-20ec95cefcb9




Refs #120315