### PR TITLE
ref(logs): Migrate layouts to container queries

### DIFF
--- a/static/app/views/explore/logs/logsAutoRefresh.tsx
+++ b/static/app/views/explore/logs/logsAutoRefresh.tsx
@@ -1,5 +1,6 @@
 import {Fragment, useEffect, type ReactNode} from 'react';
 
+import {Container} from '@sentry/scraps/layout';
 import {Switch} from '@sentry/scraps/switch';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -18,7 +19,7 @@ import {
 } from 'sentry/views/explore/contexts/logs/logsAutoRefreshContext';
 import {useLogsPageData} from 'sentry/views/explore/contexts/logs/logsPageData';
 import {useLogsAnalyticsPageSource} from 'sentry/views/explore/logs/logsQueryParamsProvider';
-import {AutoRefreshLabel, AutoRefreshText} from 'sentry/views/explore/logs/styles';
+import {AutoRefreshLabel} from 'sentry/views/explore/logs/styles';
 import {useLogsAutoRefreshInterval} from 'sentry/views/explore/logs/useLogsAutoRefreshInterval';
 import {checkSortIsTimeBasedDescending} from 'sentry/views/explore/logs/utils';
 import {
@@ -136,7 +137,9 @@ export function AutorefreshToggle({averageLogsPerSecond = 0}: AutorefreshToggleP
             }}
           />
         </Tooltip>
-        <AutoRefreshText>{t('Auto-refresh')}</AutoRefreshText>
+        <Container as="span" display={{zero: 'none', '3xl': 'inline'}}>
+          {t('Auto-refresh')}
+        </Container>
       </AutoRefreshLabel>
     </Fragment>
   );

--- a/static/app/views/explore/logs/logsOnboarding.tsx
+++ b/static/app/views/explore/logs/logsOnboarding.tsx
@@ -156,8 +156,8 @@ function OnboardingPanel({
         <AuthTokenGeneratorProvider projectSlug={project?.slug}>
           <TabSelectionScope>
             <div>
-              <HeaderWrapper>
-                <HeaderText>
+              <Flex justify="between" gap="2xl" radius="md" padding="3xl">
+                <Container flex={{zero: 1, xl: 0.65}}>
                   <Title>{t('Logs in Sentry')}</Title>
                   <SubTitle>
                     {t('Search and visualize application logs at scale.')}
@@ -169,9 +169,11 @@ function OnboardingPanel({
                       {t('Build alerts and dashboard widgets based on log queries')}
                     </li>
                   </BulletList>
-                </HeaderText>
-                <Image src={connectDotsImg} />
-              </HeaderWrapper>
+                </Container>
+                <Container display={{zero: 'none', xl: 'block'}}>
+                  {imageProps => <Image {...imageProps} src={connectDotsImg} />}
+                </Container>
+              </Flex>
               <Divider />
               <Body>
                 <Setup>
@@ -502,22 +504,6 @@ const BulletList = styled('ul')`
   }
 `;
 
-const HeaderWrapper = styled('div')`
-  display: flex;
-  justify-content: space-between;
-  gap: ${p => p.theme.space['2xl']};
-  border-radius: ${p => p.theme.radius.md};
-  padding: ${p => p.theme.space['3xl']};
-`;
-
-const HeaderText = styled('div')`
-  flex: 0.65;
-
-  @media (max-width: ${p => p.theme.breakpoints.sm}) {
-    flex: 1;
-  }
-`;
-
 const Setup = styled('div')`
   padding: ${p => p.theme.space['3xl']};
 
@@ -563,14 +549,9 @@ const Body = styled('div')`
 `;
 
 const Image = styled('img')`
-  display: block;
   pointer-events: none;
   height: 120px;
   overflow: hidden;
-
-  @media (max-width: ${p => p.theme.breakpoints.sm}) {
-    display: none;
-  }
 `;
 
 const Divider = styled('hr')`

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -454,24 +454,21 @@ function LogsTabContentInner({datePageFilterProps}: LogsTabProps) {
           <ExploreContentSection gap="md">
             <OverChartButtonGroup>
               <Container display={{zero: 'none', '4xl': 'inline-flex'}}>
-                {buttonProps => (
-                  <LogsSidebarCollapseButton
-                    {...buttonProps}
-                    sidebarOpen={sidebarOpen}
-                    aria-label={sidebarOpen ? t('Collapse sidebar') : t('Expand sidebar')}
-                    size="xs"
-                    icon={
-                      <IconChevron
-                        isDouble
-                        direction={sidebarOpen ? 'left' : 'right'}
-                        size="xs"
-                      />
-                    }
-                    onClick={() => setSidebarOpen(!sidebarOpen)}
-                  >
-                    {sidebarOpen ? null : t('Advanced')}
-                  </LogsSidebarCollapseButton>
-                )}
+                <LogsSidebarCollapseButton
+                  sidebarOpen={sidebarOpen}
+                  aria-label={sidebarOpen ? t('Collapse sidebar') : t('Expand sidebar')}
+                  size="xs"
+                  icon={
+                    <IconChevron
+                      isDouble
+                      direction={sidebarOpen ? 'left' : 'right'}
+                      size="xs"
+                    />
+                  }
+                  onClick={() => setSidebarOpen(!sidebarOpen)}
+                >
+                  {sidebarOpen ? null : t('Advanced')}
+                </LogsSidebarCollapseButton>
               </Container>
               {mode === Mode.AGGREGATE ? (
                 <LogsAggregateExportModalButton

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import {useQueryClient} from '@tanstack/react-query';
 
 import {Button} from '@sentry/scraps/button';
+import {Container, Flex, Grid} from '@sentry/scraps/layout';
 import {useModal} from '@sentry/scraps/modal';
 import {TabList, Tabs} from '@sentry/scraps/tabs';
 import {Tooltip} from '@sentry/scraps/tooltip';
@@ -59,7 +60,6 @@ import {LogsSidebarProvider} from 'sentry/views/explore/logs/logsSidebarContext'
 import {LogsTabSeerComboBox} from 'sentry/views/explore/logs/logsTabSeerComboBox';
 import {LogsToolbar} from 'sentry/views/explore/logs/logsToolbar';
 import {
-  LogsFilterSection,
   LogsGraphContainer,
   LogsItemContainer,
   LogsSidebarCollapseButton,
@@ -172,39 +172,65 @@ const LogsSearchSection = memo(function LogsSearchSection({
     >
       <ExploreBodySearch>
         <Layout.Main width="full">
-          <LogsFilterSection>
-            <StyledPageFilterBar condensed>
-              <ProjectPageFilter />
-              <EnvironmentPageFilter />
-              <DatePageFilter
-                {...datePageFilterProps}
-                searchPlaceholder={t('Custom range: 2h, 4d, 3w')}
+          <Grid
+            areas={{
+              zero: `
+                "filters"
+                "search"
+                "actions"
+              `,
+              xl: `
+                "filters actions"
+                "search search"
+              `,
+              '3xl': '"filters search actions"',
+            }}
+            columns={{
+              zero: '100%',
+              xl: '1fr auto',
+              '3xl': 'minmax(300px, auto) 1fr min-content',
+            }}
+            gap="md"
+            width="100%"
+          >
+            <Container area="filters" justifySelf="start">
+              <StyledPageFilterBar condensed>
+                <ProjectPageFilter />
+                <EnvironmentPageFilter />
+                <DatePageFilter
+                  {...datePageFilterProps}
+                  searchPlaceholder={t('Custom range: 2h, 4d, 3w')}
+                />
+              </StyledPageFilterBar>
+            </Container>
+            <Container area="search">
+              <LogsSearchBar
+                tracesItemSearchQueryBuilderProps={tracesItemSearchQueryBuilderProps}
               />
-            </StyledPageFilterBar>
-            <LogsSearchBar
-              tracesItemSearchQueryBuilderProps={tracesItemSearchQueryBuilderProps}
-            />
+            </Container>
             {saveAsItems.length > 0 && (
-              <DropdownMenu
-                items={saveAsItems}
-                trigger={triggerProps => (
-                  <Button
-                    {...triggerProps}
-                    variant="primary"
-                    aria-label={t('Save as')}
-                    onClick={e => {
-                      e.stopPropagation();
-                      e.preventDefault();
+              <Flex area="actions" align="start" justifySelf="end">
+                <DropdownMenu
+                  items={saveAsItems}
+                  trigger={triggerProps => (
+                    <Button
+                      {...triggerProps}
+                      variant="primary"
+                      aria-label={t('Save as')}
+                      onClick={e => {
+                        e.stopPropagation();
+                        e.preventDefault();
 
-                      triggerProps.onClick?.(e);
-                    }}
-                  >
-                    {t('Save as')}
-                  </Button>
-                )}
-              />
+                        triggerProps.onClick?.(e);
+                      }}
+                    >
+                      {t('Save as')}
+                    </Button>
+                  )}
+                />
+              </Flex>
             )}
-          </LogsFilterSection>
+          </Grid>
         </Layout.Main>
       </ExploreBodySearch>
     </SearchQueryBuilderProvider>
@@ -409,26 +435,35 @@ function LogsTabContentInner({datePageFilterProps}: LogsTabProps) {
       <LogsSearchSection datePageFilterProps={datePageFilterProps} />
       <ViewportConstrainedPage constrained={mode === Mode.SAMPLES} hideFooter>
         <ViewportConstrainedBody>
-          <LogsControlSection expanded={sidebarOpen}>
-            {sidebarOpen ? <LogsToolbar /> : null}
-          </LogsControlSection>
+          <Container display={{zero: 'none', '3xl': 'block'}}>
+            {controlProps => (
+              <ExploreControlSection {...controlProps} expanded={sidebarOpen}>
+                {sidebarOpen ? <LogsToolbar /> : null}
+              </ExploreControlSection>
+            )}
+          </Container>
           <ExploreContentSection gap="md">
             <OverChartButtonGroup>
-              <LogsSidebarCollapseButton
-                sidebarOpen={sidebarOpen}
-                aria-label={sidebarOpen ? t('Collapse sidebar') : t('Expand sidebar')}
-                size="xs"
-                icon={
-                  <IconChevron
-                    isDouble
-                    direction={sidebarOpen ? 'left' : 'right'}
+              <Container display={{zero: 'none', '4xl': 'inline-flex'}}>
+                {buttonProps => (
+                  <LogsSidebarCollapseButton
+                    {...buttonProps}
+                    sidebarOpen={sidebarOpen}
+                    aria-label={sidebarOpen ? t('Collapse sidebar') : t('Expand sidebar')}
                     size="xs"
-                  />
-                }
-                onClick={() => setSidebarOpen(!sidebarOpen)}
-              >
-                {sidebarOpen ? null : t('Advanced')}
-              </LogsSidebarCollapseButton>
+                    icon={
+                      <IconChevron
+                        isDouble
+                        direction={sidebarOpen ? 'left' : 'right'}
+                        size="xs"
+                      />
+                    }
+                    onClick={() => setSidebarOpen(!sidebarOpen)}
+                  >
+                    {sidebarOpen ? null : t('Advanced')}
+                  </LogsSidebarCollapseButton>
+                )}
+              </Container>
               {mode === Mode.AGGREGATE ? (
                 <LogsAggregateExportModalButton
                   isLoading={aggregatesTableResult.isPending}
@@ -531,10 +566,4 @@ export const LogsTabContent = registerLLMContext('logs-explorer', LogsTabContent
 const ViewportConstrainedBody = styled(ExploreBodyContent)`
   flex-direction: row;
   min-height: 0;
-`;
-
-const LogsControlSection = styled(ExploreControlSection)`
-  @media (max-width: ${p => p.theme.breakpoints.md}) {
-    display: none;
-  }
 `;

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -193,7 +193,7 @@ const LogsSearchSection = memo(function LogsSearchSection({
             gap="md"
             width="100%"
           >
-            <Container area="filters" justifySelf="start">
+            <Container area="filters" justifySelf={{zero: 'stretch', xl: 'start'}}>
               <StyledPageFilterBar condensed>
                 <ProjectPageFilter />
                 <EnvironmentPageFilter />
@@ -209,23 +209,32 @@ const LogsSearchSection = memo(function LogsSearchSection({
               />
             </Container>
             {saveAsItems.length > 0 && (
-              <Flex area="actions" align="start" justifySelf="end">
+              <Flex
+                area="actions"
+                align="start"
+                justifySelf={{zero: 'stretch', xl: 'end'}}
+              >
                 <DropdownMenu
                   items={saveAsItems}
                   trigger={triggerProps => (
-                    <Button
-                      {...triggerProps}
-                      variant="primary"
-                      aria-label={t('Save as')}
-                      onClick={e => {
-                        e.stopPropagation();
-                        e.preventDefault();
+                    <Container width={{zero: '100%', xl: 'auto'}}>
+                      {buttonProps => (
+                        <Button
+                          {...buttonProps}
+                          {...triggerProps}
+                          variant="primary"
+                          aria-label={t('Save as')}
+                          onClick={e => {
+                            e.stopPropagation();
+                            e.preventDefault();
 
-                        triggerProps.onClick?.(e);
-                      }}
-                    >
-                      {t('Save as')}
-                    </Button>
+                            triggerProps.onClick?.(e);
+                          }}
+                        >
+                          {t('Save as')}
+                        </Button>
+                      )}
+                    </Container>
                   )}
                 />
               </Flex>

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -193,7 +193,7 @@ const LogsSearchSection = memo(function LogsSearchSection({
             gap="md"
             width="100%"
           >
-            <Container area="filters" justifySelf={{zero: 'stretch', xl: 'start'}}>
+            <Container area="filters" justifySelf={{zero: 'stretch', sm: 'start'}}>
               <StyledPageFilterBar condensed>
                 <ProjectPageFilter />
                 <EnvironmentPageFilter />
@@ -212,12 +212,12 @@ const LogsSearchSection = memo(function LogsSearchSection({
               <Flex
                 area="actions"
                 align="start"
-                justifySelf={{zero: 'stretch', xl: 'end'}}
+                justifySelf={{zero: 'stretch', sm: 'end'}}
               >
                 <DropdownMenu
                   items={saveAsItems}
                   trigger={triggerProps => (
-                    <Container width={{zero: '100%', xl: 'auto'}}>
+                    <Container width={{zero: '100%', sm: 'auto'}}>
                       {buttonProps => (
                         <Button
                           {...buttonProps}

--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -429,12 +429,6 @@ export const AutoRefreshLabel = styled('label')`
   margin-bottom: 0;
 `;
 
-export const AutoRefreshText = styled('span')`
-  @media (max-width: ${p => p.theme.breakpoints.md}) {
-    display: none;
-  }
-`;
-
 export function getLogColors(level: SeverityLevel, theme: Theme) {
   switch (level) {
     case SeverityLevel.DEFAULT:
@@ -508,12 +502,6 @@ export function getLogColors(level: SeverityLevel, theme: Theme) {
 }
 
 export const LogsSidebarCollapseButton = styled(Button)<{sidebarOpen: boolean}>`
-  display: none;
-
-  @media (min-width: ${p => p.theme.breakpoints.lg}) {
-    display: inline-flex;
-  }
-
   ${p =>
     p.sidebarOpen &&
     css`
@@ -587,15 +575,6 @@ export const HoveringRowLoadingRendererContainer = styled('div')<{
 
 export const StyledPageFilterBar = styled(PageFilterBar)`
   width: auto;
-`;
-
-export const LogsFilterSection = styled('div')`
-  display: grid;
-  gap: ${p => p.theme.space.md};
-
-  @media (min-width: ${p => p.theme.breakpoints.md}) {
-    grid-template-columns: minmax(300px, auto) 1fr min-content;
-  }
 `;
 
 export const TraceIconStyleWrapper = styled(Flex)`


### PR DESCRIPTION
Migrates Logs layout behavior to container-responsive primitives. Header filters, search, and actions now adapt to the space available to the Logs view, including when surrounding navigation or panels reduce its width.

The viewport and container breakpoint values compare as follows:

| Surface | Before: viewport value | After: container value |
| --- | --- | --- |
| Search controls | Single row at `md` (`≥992px`) | Two rows at `xl` (`≥768px`); single row at `3xl` (`≥1024px`) |
| Auto-refresh label | Visible above `md` (`>992px`) | Visible at `3xl` (`≥1024px`) |
| Onboarding illustration | Visible above `sm` (`>800px`) | Visible at `xl` (`≥768px`) |
| Advanced sidebar | Visible above `md` (`>992px`) | Visible at `3xl` (`≥1024px`) |
| Advanced toggle | Visible at `lg` (`≥1200px`) | Visible at `4xl` (`≥1152px`) |


**Before**



https://github.com/user-attachments/assets/4314ca9d-12a7-4e08-9667-befc0cb37b37






**After**

https://github.com/user-attachments/assets/f7dbf317-8c87-479f-a138-f82ba2a6be23

Refs #120315
