### PR TITLE
feat(agent-monitoring): Add area chart type to conversations chart

### DIFF
--- a/static/app/views/explore/conversations/components/conversationsChart.spec.tsx
+++ b/static/app/views/explore/conversations/components/conversationsChart.spec.tsx
@@ -107,6 +107,19 @@ describe('ConversationsChart', () => {
     expect(screen.getByRole('button', {name: 'Line'})).toBeInTheDocument();
   });
 
+  it('switches the chart type to area', async () => {
+    const {router} = render(<ConversationsChart />, {organization});
+
+    await userEvent.click(screen.getByRole('button', {name: 'Bar'}));
+    await userEvent.click(screen.getByRole('option', {name: 'Area'}));
+
+    await waitFor(() => {
+      expect(router.location.query.chartType).toBe('area');
+    });
+
+    expect(screen.getByRole('button', {name: 'Area'})).toBeInTheDocument();
+  });
+
   it('applies the search query and agent filter to the timeseries request', async () => {
     render(<ConversationsChart />, {
       organization,
@@ -245,6 +258,26 @@ describe('ConversationsChart', () => {
             ],
           }),
         ],
+      })
+    );
+  });
+
+  it('maps the area chart type to the area dashboard display type', async () => {
+    render(<ConversationsChart />, {
+      organization: OrganizationFixture({features: ['dashboards-edit']}),
+      initialRouterConfig: {
+        location: {pathname: '/', query: {chartType: 'area'}},
+      },
+    });
+
+    await userEvent.click(screen.getByRole('button', {name: 'Chart actions'}));
+    await userEvent.click(
+      await screen.findByRole('menuitemradio', {name: 'Add to Dashboard'})
+    );
+
+    expect(openAddToDashboardModal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        widgets: [expect.objectContaining({displayType: DisplayType.AREA})],
       })
     );
   });

--- a/static/app/views/explore/conversations/components/conversationsChart.tsx
+++ b/static/app/views/explore/conversations/components/conversationsChart.tsx
@@ -36,6 +36,7 @@ import {
 } from 'sentry/views/dashboards/types';
 import {MISSING_DATA_MESSAGE} from 'sentry/views/dashboards/widgets/common/settings';
 import {plottablesCanBeVisualized} from 'sentry/views/dashboards/widgets/plottablesCanBeVisualized';
+import {Area} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/area';
 import {Bars} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/bars';
 import {Line} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/line';
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
@@ -70,7 +71,7 @@ const CHART_VISUALIZATIONS = {
 
 type ChartVisualizationKey = keyof typeof CHART_VISUALIZATIONS;
 
-type ChartTypeKey = 'line' | 'bar';
+type ChartTypeKey = 'line' | 'area' | 'bar';
 
 const VISUALIZATION_OPTIONS = Object.entries(CHART_VISUALIZATIONS).map(
   ([value, {label}]) => ({value: value as ChartVisualizationKey, label})
@@ -78,11 +79,13 @@ const VISUALIZATION_OPTIONS = Object.entries(CHART_VISUALIZATIONS).map(
 
 const CHART_TYPE_OPTIONS = [
   {value: 'line' as const, label: t('Line')},
+  {value: 'area' as const, label: t('Area')},
   {value: 'bar' as const, label: t('Bar')},
 ];
 
 const CHART_TYPE_TO_DISPLAY_TYPE: Record<ChartTypeKey, DisplayType> = {
   line: DisplayType.LINE,
+  area: DisplayType.AREA,
   bar: DisplayType.BAR,
 };
 
@@ -90,7 +93,11 @@ const visualizationParser = parseAsStringLiteral(
   Object.keys(CHART_VISUALIZATIONS) as ChartVisualizationKey[]
 ).withDefault('cost');
 
-const chartTypeParser = parseAsStringLiteral(['line', 'bar'] as const).withDefault('bar');
+const chartTypeParser = parseAsStringLiteral([
+  'line',
+  'area',
+  'bar',
+] as const).withDefault('bar');
 
 const collapsedParser = parseAsBoolean.withDefault(false);
 
@@ -123,7 +130,8 @@ export function ConversationsChart() {
     if (!timeSeries) {
       return [];
     }
-    const PlottableConstructor = chartType === 'line' ? Line : Bars;
+    const PlottableConstructor =
+      chartType === 'line' ? Line : chartType === 'area' ? Area : Bars;
     return [
       new PlottableConstructor(markDelayedData(timeSeries, INGESTION_DELAY), {
         alias: label,


### PR DESCRIPTION
Adds an "Area" (filled line) variant to the chart-type selector on the conversations overview chart. Explore already offers this option, so the two surfaces now match — the dropdown reads Line / Area / Bar. Selecting Area and adding the chart to a dashboard carries the area display type through.

The default chart type is unchanged (Bar).

Refs TET-2787