### PR TITLE
fix(agent-monitoring): Keep tool-error select outline purple in transcript

### DIFF
--- a/static/app/views/explore/conversations/components/messageToolCalls.tsx
+++ b/static/app/views/explore/conversations/components/messageToolCalls.tsx
@@ -146,9 +146,7 @@ function ToolCallRow({tool, node, isSelected, onSelectNode}: ToolCallRowProps) {
       style={
         isSelected
           ? {
-              outline: `2px solid ${
-                tool.hasError ? theme.tokens.content.danger : theme.tokens.focus.default
-              }`,
+              outline: `2px solid ${theme.tokens.focus.default}`,
               outlineOffset: '-2px',
             }
           : undefined


### PR DESCRIPTION
Selecting a tool call that errored used to draw a red selection outline, conflating the error state with selection. The selected outline now always uses the purple focus token, so selection reads consistently regardless of error state — matching how message blocks already behave. The tag, status icon, and error count stay red, so errors remain clearly communicated.

Refs TET-2785