### PR TITLE
feat(conversations): Add error fire icon to conversation summary

### DIFF
--- a/static/app/views/explore/conversations/components/conversationSummary.tsx
+++ b/static/app/views/explore/conversations/components/conversationSummary.tsx
@@ -14,7 +14,7 @@ import {Count} from 'sentry/components/count';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {Placeholder} from 'sentry/components/placeholder';
 import {TimeSince} from 'sentry/components/timeSince';
-import {IconOpen, IconUser} from 'sentry/icons';
+import {IconFire, IconOpen, IconUser} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import {escapeDoubleQuotes} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -235,6 +235,15 @@ export function ConversationSummary({
         <Stat
           label={t('Errors')}
           value={<Count value={aggregates.errorCount} />}
+          icon={
+            aggregates.errorCount > 0 ? (
+              <IconFire
+                size="sm"
+                variant="danger"
+                data-test-id="conversation-error-icon"
+              />
+            ) : undefined
+          }
           to={aggregates.errorCount > 0 ? errorsUrl : undefined}
           onClick={
             aggregates.errorCount > 0
@@ -271,14 +280,30 @@ function Stat({
   isLoading,
   to,
   onClick,
+  icon,
 }: {
   label: string;
   value: React.ReactNode;
+  icon?: React.ReactNode;
   isLoading?: boolean;
   onClick?: () => void;
   to?: string;
 }) {
   const isInteractive = !!to && !isLoading;
+
+  const valueContent = (
+    <Flex align="center" gap="xs">
+      <Text
+        size="xl"
+        tabular
+        variant={isInteractive ? 'danger' : undefined}
+        wrap="nowrap"
+      >
+        {value}
+      </Text>
+      {icon}
+    </Flex>
+  );
 
   return (
     <Stack gap="xs" flexShrink={0}>
@@ -289,14 +314,10 @@ function Stat({
         <Placeholder width="32px" height="24px" />
       ) : isInteractive ? (
         <Link to={to} onClick={onClick}>
-          <Text size="xl" tabular variant="danger" wrap="nowrap">
-            {value}
-          </Text>
+          {valueContent}
         </Link>
       ) : (
-        <Text size="xl" tabular wrap="nowrap">
-          {value}
-        </Text>
+        valueContent
       )}
     </Stack>
   );

--- a/static/app/views/explore/conversations/conversationDetail.spec.tsx
+++ b/static/app/views/explore/conversations/conversationDetail.spec.tsx
@@ -48,10 +48,13 @@ const CONVERSATION_BODY = [
   }),
 ];
 
-function mockApis(title: string | null = null) {
+function mockApis(
+  title: string | null = null,
+  spans: Array<Record<string, unknown>> = CONVERSATION_BODY
+) {
   MockApiClient.addMockResponse({
     url: `/organizations/org-slug/ai-conversations/${CONVERSATION_ID}/`,
-    body: {conversationId: CONVERSATION_ID, title, spans: CONVERSATION_BODY},
+    body: {conversationId: CONVERSATION_ID, title, spans},
   });
   MockApiClient.addMockResponse({
     url: '/organizations/org-slug/trace-items/attributes/',
@@ -187,5 +190,43 @@ describe('ConversationDetailPage title', () => {
     expect(
       await screen.findByRole('heading', {name: new RegExp(CONVERSATION_ID)})
     ).toBeInTheDocument();
+  });
+});
+
+describe('ConversationDetailPage summary errors', () => {
+  beforeEach(() => {
+    Element.prototype.scrollTo = jest.fn();
+    Element.prototype.scrollIntoView = jest.fn();
+    MockApiClient.clearMockResponses();
+    act(() => {
+      PageFiltersStore.reset();
+      PageFiltersStore.init();
+    });
+  });
+
+  it('renders the fire icon in the summary when a span errored', async () => {
+    mockApis(null, [
+      ...CONVERSATION_BODY,
+      spanFixture({
+        span_id: 'span-error',
+        'span.name': 'failed turn',
+        'span.status': 'internal_error',
+        'precise.start_ts': 3000,
+        'precise.finish_ts': 3000.5,
+      }),
+    ]);
+    renderPage();
+
+    // The summary renders the fire icon once the conversation finishes loading.
+    expect(await screen.findByTestId('conversation-error-icon')).toBeInTheDocument();
+  });
+
+  it('omits the fire icon in the summary when there are no errors', async () => {
+    mockApis(null);
+    renderPage();
+
+    // Wait for the conversation to load before asserting the icon's absence.
+    expect(await screen.findByText('First answer')).toBeInTheDocument();
+    expect(screen.queryByTestId('conversation-error-icon')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
The conversation list already marks errored conversations with a fire icon next to the error count, but the conversation summary header showed only the count. This carries the same treatment into the summary's Errors stat so the error state reads consistently between the list and detail views. The icon shows only when the conversation has at least one error.

Refs TET-2786