### PR TITLE
feat(agent-monitoring): Add size and time totals to collapsed tool calls

### DIFF
--- a/static/app/views/explore/conversations/components/messageToolCalls.tsx
+++ b/static/app/views/explore/conversations/components/messageToolCalls.tsx
@@ -1,3 +1,4 @@
+import type {ReactNode} from 'react';
 import {css, useTheme} from '@emotion/react';
 
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
@@ -38,10 +39,10 @@ const COLLAPSE_THRESHOLD = 5;
 /**
  * Tool-call list for the redesigned transcript. Runs of at least
  * `COLLAPSE_THRESHOLD` calls collapse behind a `N tool calls` summary (with an
- * error count) that is collapsed by default, to keep tool-heavy turns compact;
- * shorter runs render inline. Each row is an accent wrench + `ToolTag` capped
- * at the message width, with the duration right-aligned. Selection shows an
- * outline.
+ * error count, plus the combined output size and time across the run) that is
+ * collapsed by default, to keep tool-heavy turns compact; shorter runs render
+ * inline. Each row is an accent wrench + `ToolTag` capped at the message width,
+ * with the size and duration right-aligned. Selection shows an outline.
  */
 export function MessageToolCalls({
   toolCalls,
@@ -72,21 +73,58 @@ export function MessageToolCalls({
 
   const errorCount = toolCalls.filter(tool => tool.hasError).length;
 
+  // Aggregate the same per-row values into a run-level total so the summary
+  // hints at how heavy the collapsed group is. Duration is the sum of each
+  // call's own duration (parallel calls are counted separately), matching the
+  // numbers on the rows rather than wall-clock elapsed time.
+  const totalDuration = toolCalls.reduce(
+    (sum, tool) => sum + (tool.duration && tool.duration > 0 ? tool.duration : 0),
+    0
+  );
+  const totalBytes = toolCalls.reduce((sum, tool) => {
+    const node = nodeMap.get(tool.nodeId);
+    return sum + (node ? getToolOutputBytes(node) : 0);
+  }, 0);
+
   return (
     <CollapsibleContent
       // Keep the group open when one of its calls is the current selection so a
       // deep-linked/timeline-selected row stays visible instead of hidden.
       defaultOpen={selectedToolCallId !== null}
       title={
-        <Flex align="center" gap="sm">
-          <Text size="sm" variant="muted">
-            {tn('%s tool call', '%s tool calls', toolCalls.length)}
-          </Text>
-          {errorCount > 0 && (
-            <Text size="sm" variant="danger">
-              {tn('%s error', '%s errors', errorCount)}
+        // Match the rows' vertical padding so the toggle shares their line
+        // height, and mirror their layout: label on the left, the same fixed
+        // meta column on the right so the totals line up over the per-row values.
+        <Flex
+          flex="1"
+          align="center"
+          justify="between"
+          gap="md"
+          minWidth={0}
+          padding="sm 0"
+        >
+          <Flex align="center" gap="sm" minWidth={0}>
+            <Text size="sm" variant="muted">
+              {tn('%s tool call', '%s tool calls', toolCalls.length)}
             </Text>
-          )}
+            {errorCount > 0 && (
+              <Text size="sm" variant="danger">
+                {tn('%s error', '%s errors', errorCount)}
+              </Text>
+            )}
+          </Flex>
+          <TurnMeta
+            metric={
+              totalBytes > 0 ? (
+                <MetaValue>{formatBytesBase10(totalBytes)}</MetaValue>
+              ) : null
+            }
+            duration={
+              totalDuration > 0 ? (
+                <MetaValue>{getDuration(totalDuration, 2, true)}</MetaValue>
+              ) : null
+            }
+          />
         </Flex>
       }
       onToggle={open =>
@@ -175,9 +213,7 @@ function ToolCallRow({tool, node, isSelected, onSelectNode}: ToolCallRowProps) {
           metric={node ? <ToolOutputSize node={node} /> : null}
           duration={
             tool.duration === undefined || tool.duration <= 0 ? null : (
-              <Text size="xs" variant="muted" tabular align="right">
-                {getDuration(tool.duration, 2, true)}
-              </Text>
+              <MetaValue>{getDuration(tool.duration, 2, true)}</MetaValue>
             )
           }
         />
@@ -186,13 +222,18 @@ function ToolCallRow({tool, node, isSelected, onSelectNode}: ToolCallRowProps) {
   );
 }
 
-function ToolOutputSize({node}: {node: AITraceSpanNode}) {
-  const bytes = getToolOutputBytes(node);
+/** Shared right-aligned styling for the size/duration values in the meta column. */
+function MetaValue({children}: {children: ReactNode}) {
   return (
     <Text size="xs" variant="muted" tabular align="right">
-      {formatBytesBase10(bytes)}
+      {children}
     </Text>
   );
+}
+
+function ToolOutputSize({node}: {node: AITraceSpanNode}) {
+  const bytes = getToolOutputBytes(node);
+  return <MetaValue>{formatBytesBase10(bytes)}</MetaValue>;
 }
 
 function ToolInputPreview({node}: {node: AITraceSpanNode}) {

--- a/static/app/views/explore/conversations/components/messagesPanel.spec.tsx
+++ b/static/app/views/explore/conversations/components/messagesPanel.spec.tsx
@@ -31,11 +31,20 @@ function createMockNode(overrides: {
 function createMockToolNode(overrides: {
   id: string;
   toolName: string;
+  endTimestamp?: number;
   hasError?: boolean;
+  output?: string;
   startTimestamp?: number;
 }) {
-  const {id, toolName, startTimestamp = 1000, hasError = false} = overrides;
-  const end = startTimestamp + 100;
+  const {
+    id,
+    toolName,
+    startTimestamp = 1000,
+    hasError = false,
+    output,
+    endTimestamp,
+  } = overrides;
+  const end = endTimestamp ?? startTimestamp + 100;
   return {
     id,
     type: 'span' as const,
@@ -47,6 +56,7 @@ function createMockToolNode(overrides: {
       [SpanFields.GEN_AI_OPERATION_TYPE]: 'tool',
       [SpanFields.GEN_AI_TOOL_NAME]: toolName,
       ...(hasError ? {[SpanFields.SPAN_STATUS]: 'internal_error'} : {}),
+      ...(output === undefined ? {} : {'gen_ai.tool.call.result': output}),
     },
     errors: new Set(),
   };
@@ -307,6 +317,50 @@ describe('MessagesPanel', () => {
 
     expect(screen.getByText('5 tool calls')).toBeInTheDocument();
     expect(screen.getByText('2 errors')).toBeInTheDocument();
+  });
+
+  it('summarizes the combined output size and time in the tool call summary', () => {
+    const requestMessages = JSON.stringify([{role: 'user', content: 'Question?'}]);
+    const firstGeneration = createMockNode({
+      id: 'span-1',
+      startTimestamp: 1000,
+      attributes: {
+        [SpanFields.GEN_AI_REQUEST_MESSAGES]: requestMessages,
+        [SpanFields.GEN_AI_RESPONSE_TEXT]: 'Let me check',
+      },
+    });
+    // Five calls, each 30 bytes of output over 0.1s, so the summary totals
+    // 150 B across 500.00ms — distinct from every per-row "30 B" / "100.00ms".
+    const toolNodes = Array.from({length: 5}, (_, index) => {
+      const start = 1500 + index * 100;
+      return createMockToolNode({
+        id: `tool-${index}`,
+        toolName: `t${index}`,
+        startTimestamp: start,
+        endTimestamp: start + 0.1,
+        output: 'x'.repeat(30),
+      });
+    });
+    const secondGeneration = createMockNode({
+      id: 'span-2',
+      startTimestamp: 3000,
+      attributes: {
+        [SpanFields.GEN_AI_REQUEST_MESSAGES]: requestMessages,
+        [SpanFields.GEN_AI_RESPONSE_TEXT]: 'Here is the answer',
+      },
+    });
+
+    render(
+      <MessagesPanel
+        nodes={[firstGeneration, ...toolNodes, secondGeneration] as any}
+        selectedNodeId={null}
+        onSelectNode={mockOnSelectNode}
+      />
+    );
+
+    expect(screen.getByText('5 tool calls')).toBeInTheDocument();
+    expect(screen.getByText('150 B')).toBeInTheDocument();
+    expect(screen.getByText('500.00ms')).toBeInTheDocument();
   });
 
   it('expands the tool call group when one of its calls is selected', () => {


### PR DESCRIPTION
The collapsed "N tool calls" toggle in the Conversations transcript now surfaces the combined output size and total time for the run, so you can tell how heavy a group is before deciding whether to expand it. The totals sit in the same fixed meta column the individual rows use, lining up over the per-call values.

The toggle row also picks up the tool rows' vertical padding so its line height matches the calls beneath it, instead of reading tighter as it did before.

Total time is the sum of each call's own duration (parallel calls counted separately), matching the numbers shown on the rows rather than wall-clock elapsed time.

Refs TET-2789