### PR TITLE
feat(issues): recommended event attempts to verify replay's existence

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -246,6 +246,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:replay-details-eap-query", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable using the events replays dataset
     manager.add("organizations:events-use-replays-dataset", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Verify a recommended event's replay exists in the replays dataset before it is surfaced on issue details
+    manager.add("organizations:issue-details-verify-recommended-replay", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable using the events api with a sql interface
     manager.add("organizations:events-sql-grammar-api", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Block transactions/discover dataset usage of the events endpoints for external API requests

--- a/src/sentry/issues/endpoints/group_event_details.py
+++ b/src/sentry/issues/endpoints/group_event_details.py
@@ -14,6 +14,7 @@ from rest_framework.response import Response
 from snuba_sdk import Column, Condition, Op, Or
 from snuba_sdk.legacy import is_condition, parse_condition
 
+from sentry import features
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.helpers.deprecation import deprecated
@@ -233,9 +234,19 @@ class GroupEventDetailsEndpoint(GroupEndpoint):
                     return Response(error_response, status=400)
 
         elif event_id == "recommended":
+            verify_replay_exists = features.has(
+                "organizations:issue-details-verify-recommended-replay",
+                organization,
+                actor=request.user,
+            )
             with metrics.timer(metric, tags={"type": "helpful", "query": bool(query)}):
                 try:
-                    event = group.get_recommended_event(conditions=conditions, start=start, end=end)
+                    event = group.get_recommended_event(
+                        conditions=conditions,
+                        start=start,
+                        end=end,
+                        verify_replay_exists=verify_replay_exists,
+                    )
                 except ValueError:
                     return Response(error_response, status=400)
 

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -447,7 +447,7 @@ def _normalize_replay_id(replay_id: str | None) -> str | None:
     if not replay_id:
         return None
     try:
-        return uuid.UUID(hex=replay_id, version=4).hex
+        return uuid.UUID(hex=replay_id).hex
     except ValueError:
         return None
 
@@ -462,6 +462,7 @@ def _select_event_with_existing_replay(
     Select an event with a replay id after it has been verified to exist in the replays dataset.
     """
     from sentry.replays.usecases.replay_existence import filter_existing_replay_ids
+    from sentry.utils.snuba import SnubaError
 
     replay_id_to_event: dict[str, Event] = {}
     for event in events:
@@ -477,14 +478,22 @@ def _select_event_with_existing_replay(
         )
         return events[0]
 
-    with metrics.timer("issue_details.recommended_event.replay_verify_duration"):
-        existing_replay_ids = filter_existing_replay_ids(
-            project_ids=[group.project.id],
-            start=start,
-            end=end,
-            replay_ids=list(replay_id_to_event.keys()),
-            tenant_ids={"organization_id": group.project.organization_id},
+    try:
+        with metrics.timer("issue_details.recommended_event.replay_verify_duration"):
+            existing_replay_ids = filter_existing_replay_ids(
+                project_ids=[group.project.id],
+                start=start,
+                end=end,
+                replay_ids=list(replay_id_to_event.keys()),
+                tenant_ids={"organization_id": group.project.organization_id},
+            )
+    except SnubaError:
+        logger.exception("issue_details.recommended_event.replay_verify_error")
+        metrics.incr(
+            "issue_details.recommended_event.replay_verify",
+            tags={"outcome": "query_error"},
         )
+        return events[0]
 
     for replay_id, event in replay_id_to_event.items():
         if replay_id in existing_replay_ids:

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import re
+import uuid
 from collections import defaultdict, namedtuple
 from collections.abc import Collection, Iterable, Mapping, Sequence
 from datetime import datetime, timedelta
@@ -53,7 +54,7 @@ from sentry.models.grouphistory import record_group_history, record_group_histor
 from sentry.models.organization import Organization
 from sentry.search.eap.occurrences.query_utils import build_event_id_in_filter
 from sentry.search.eap.rpc_utils import and_trace_item_filters
-from sentry.services.eventstore.models import GroupEvent
+from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.referrer import Referrer
 from sentry.types.activity import ActivityType
@@ -66,6 +67,7 @@ from sentry.types.group import (
 from sentry.utils import metrics
 from sentry.utils.dates import outside_retention_with_modified_start
 from sentry.utils.numbers import base32_decode, base32_encode
+from sentry.utils.safe import get_path
 from sentry.utils.strings import strip, truncatechars
 
 if TYPE_CHECKING:
@@ -366,11 +368,17 @@ def get_oldest_or_latest_event(
     return None
 
 
+# Arbitrary number of candidate events to consider when we need to pick a
+# recommended event whose session replay is verified to exist.
+RECOMMENDED_EVENT_REPLAY_CANDIDATES = 10
+
+
 def get_recommended_event(
     group: Group,
     conditions: Sequence[Condition] | None = None,
     start: datetime | None = None,
     end: datetime | None = None,
+    verify_replay_exists: bool = False,
 ) -> GroupEvent | None:
     if group.issue_category == GroupCategory.ERROR:
         dataset = Dataset.Events
@@ -388,22 +396,27 @@ def get_recommended_event(
     default_end = group.last_seen + timedelta(minutes=1)
     default_start = default_end - timedelta(days=7)
 
+    resolved_start = start if start else default_start
+    resolved_end = end if end else default_end
+
     expired, _ = outside_retention_with_modified_start(
-        start=start if start else default_start,
-        end=end if end else default_end,
+        start=resolved_start,
+        end=resolved_end,
         organization=Organization(group.project.organization_id),
     )
 
     if expired:
         return None
 
+    limit = RECOMMENDED_EVENT_REPLAY_CANDIDATES if verify_replay_exists else 1
+
     events = eventstore.backend.get_events_snql(
         organization_id=group.project.organization_id,
         group_id=group.id,
-        start=start if start else default_start,
-        end=end if end else default_end,
+        start=resolved_start,
+        end=resolved_end,
         conditions=all_conditions,
-        limit=1,
+        limit=limit,
         orderby=EventOrdering.RECOMMENDED.value,
         referrer="Group.get_helpful",
         dataset=dataset,
@@ -411,10 +424,81 @@ def get_recommended_event(
         inner_limit=1000,
     )
 
-    if events:
-        return events[0].for_group(group)
+    if not events:
+        return None
 
-    return None
+    if verify_replay_exists:
+        event = _select_event_with_existing_replay(group, events, resolved_start, resolved_end)
+    else:
+        event = events[0]
+
+    return event.for_group(group)
+
+
+def _get_replay_id_from_event(event: Event) -> str | None:
+    replay_id = get_path(event.data, "contexts", "replay", "replay_id")
+    if replay_id:
+        return replay_id
+    return event.get_tag("replayId")
+
+
+def _normalize_replay_id(replay_id: str | None) -> str | None:
+    """Normalize a replay id to the 32 char dashless hex used by the replays dataset."""
+    if not replay_id:
+        return None
+    try:
+        return uuid.UUID(hex=replay_id, version=4).hex
+    except ValueError:
+        return None
+
+
+def _select_event_with_existing_replay(
+    group: Group,
+    events: Sequence[Event],
+    start: datetime,
+    end: datetime,
+) -> Event:
+    """
+    Select an event with a replay id after it has been verified to exist in the replays dataset.
+    """
+    from sentry.replays.usecases.replay_existence import filter_existing_replay_ids
+
+    replay_id_to_event: dict[str, Event] = {}
+    for event in events:
+        # Replays store ids as dash-less hex strings.
+        normalized = _normalize_replay_id(_get_replay_id_from_event(event))
+        if normalized is not None and normalized not in replay_id_to_event:
+            replay_id_to_event[normalized] = event
+
+    if not replay_id_to_event:
+        metrics.incr(
+            "issue_details.recommended_event.replay_verify",
+            tags={"outcome": "no_candidates"},
+        )
+        return events[0]
+
+    with metrics.timer("issue_details.recommended_event.replay_verify_duration"):
+        existing_replay_ids = filter_existing_replay_ids(
+            project_ids=[group.project.id],
+            start=start,
+            end=end,
+            replay_ids=list(replay_id_to_event.keys()),
+            tenant_ids={"organization_id": group.project.organization_id},
+        )
+
+    for replay_id, event in replay_id_to_event.items():
+        if replay_id in existing_replay_ids:
+            metrics.incr(
+                "issue_details.recommended_event.replay_verify",
+                tags={"outcome": "verified"},
+            )
+            return event
+
+    metrics.incr(
+        "issue_details.recommended_event.replay_verify",
+        tags={"outcome": "fell_back"},
+    )
+    return events[0]
 
 
 class GroupManager(BaseManager["Group"]):
@@ -1057,17 +1141,23 @@ class Group(Model):
         conditions: Sequence[Condition] | None = None,
         start: datetime | None = None,
         end: datetime | None = None,
+        verify_replay_exists: bool = False,
     ) -> GroupEvent | None:
         """
         Returns a recommended event given the conditions and time range.
         If a helpful recommendation is not found, it will fallback to the latest event.
         If neither are found, returns None.
+
+        When ``verify_replay_exists`` is set, the recommendation prefers the
+        highest-ranked event whose session replay is verified to exist in the
+        replays dataset, falling back to the normal recommendation otherwise.
         """
         maybe_event = get_recommended_event(
             group=self,
             conditions=conditions,
             start=start,
             end=end,
+            verify_replay_exists=verify_replay_exists,
         )
         return (
             maybe_event

--- a/src/sentry/replays/usecases/replay_existence.py
+++ b/src/sentry/replays/usecases/replay_existence.py
@@ -50,7 +50,9 @@ def filter_existing_replay_ids(
                 Condition(Column("replay_id"), Op.IN, list(replay_ids)),
             ],
             having=[
+                # Must include the first sequence otherwise the replay is too old.
                 Condition(Function("min", parameters=[Column("segment_id")]), Op.EQ, 0),
+                # Require non-archived replays.
                 Condition(Column("is_archived"), Op.EQ, 0),
             ],
             groupby=[Column("replay_id")],

--- a/src/sentry/replays/usecases/replay_existence.py
+++ b/src/sentry/replays/usecases/replay_existence.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import datetime
+from typing import Any
+
+from snuba_sdk import Column, Condition, Entity, Function, Granularity, Op, Query, Request
+
+from sentry.snuba.referrer import Referrer
+from sentry.utils.snuba import raw_snql_query
+
+
+def filter_existing_replay_ids(
+    project_ids: Sequence[int],
+    start: datetime,
+    end: datetime,
+    replay_ids: Sequence[str],
+    tenant_ids: dict[str, Any],
+) -> set[str]:
+    """
+    Return the subset of replays provided a sequence of replay_ids.
+
+    ``replay_ids`` must be 32 character hex strings (dashes stripped). The returned
+    set uses that same dash-less hex representation.
+    """
+    if not replay_ids:
+        return set()
+
+    snuba_request = Request(
+        dataset="replays",
+        app_id="replay-backend-web",
+        query=Query(
+            match=Entity("replays"),
+            select=[
+                Function(
+                    "replaceAll",
+                    parameters=[Function("toString", parameters=[Column("replay_id")]), "-", ""],
+                    alias="rid",
+                ),
+                Function(
+                    "ifNull",
+                    parameters=[Function("max", parameters=[Column("is_archived")]), 0],
+                    alias="is_archived",
+                ),
+            ],
+            where=[
+                Condition(Column("project_id"), Op.IN, list(project_ids)),
+                Condition(Column("timestamp"), Op.LT, end),
+                Condition(Column("timestamp"), Op.GTE, start),
+                Condition(Column("replay_id"), Op.IN, list(replay_ids)),
+            ],
+            having=[
+                Condition(Function("min", parameters=[Column("segment_id")]), Op.EQ, 0),
+                Condition(Column("is_archived"), Op.EQ, 0),
+            ],
+            groupby=[Column("replay_id")],
+            granularity=Granularity(3600),
+        ),
+        tenant_ids=tenant_ids,
+    )
+
+    response = raw_snql_query(
+        snuba_request,
+        referrer=Referrer.API_ISSUE_DETAILS_VERIFY_RECOMMENDED_REPLAY.value,
+        use_cache=True,
+    )
+    return {row["rid"] for row in response["data"]}

--- a/src/sentry/replays/usecases/replay_existence.py
+++ b/src/sentry/replays/usecases/replay_existence.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any
 
 from snuba_sdk import Column, Condition, Entity, Function, Granularity, Op, Query, Request
 
+from sentry.replays.query import MAX_REPLAY_LENGTH_HOURS
 from sentry.snuba.referrer import Referrer
 from sentry.utils.snuba import raw_snql_query
 
@@ -26,6 +27,10 @@ def filter_existing_replay_ids(
     if not replay_ids:
         return set()
 
+    # Padding start/end time to up the chances of seeing a segment with an error.
+    padded_start = start - timedelta(hours=MAX_REPLAY_LENGTH_HOURS)
+    padded_end = end + timedelta(hours=MAX_REPLAY_LENGTH_HOURS)
+
     snuba_request = Request(
         dataset="replays",
         app_id="replay-backend-web",
@@ -45,8 +50,8 @@ def filter_existing_replay_ids(
             ],
             where=[
                 Condition(Column("project_id"), Op.IN, list(project_ids)),
-                Condition(Column("timestamp"), Op.LT, end),
-                Condition(Column("timestamp"), Op.GTE, start),
+                Condition(Column("timestamp"), Op.LT, padded_end),
+                Condition(Column("timestamp"), Op.GTE, padded_start),
                 Condition(Column("replay_id"), Op.IN, list(replay_ids)),
             ],
             having=[

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -497,6 +497,7 @@ class Referrer(StrEnum):
     API_ORGANIZATION_METRICS_EAP_QUERY = "api.organization.metrics-eap-query"
     API_ORGANIZATION_ISSUES_COUNT = "api.organization-issues-count"
     API_ORGANIZATION_ISSUE_REPLAY_COUNT = "api.organization-issue-replay-count"
+    API_ISSUE_DETAILS_VERIFY_RECOMMENDED_REPLAY = "api.issue-details-verify-recommended-replay"
     API_ORGANIZATION_SDK_UPDATES = "api.organization-sdk-updates"
     API_ORGANIZATION_SPAN_REPLAY_COUNT = "api.organization-span-replay-count"
     API_ORGANIZATION_VITALS_PER_PROJECT = "api.organization-vitals-per-project"

--- a/tests/sentry/replays/unit/usecases/test_replay_existence.py
+++ b/tests/sentry/replays/unit/usecases/test_replay_existence.py
@@ -1,0 +1,39 @@
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+from sentry.replays.query import MAX_REPLAY_LENGTH_HOURS
+from sentry.replays.usecases.replay_existence import filter_existing_replay_ids
+
+
+@patch("sentry.replays.usecases.replay_existence.raw_snql_query")
+def test_filter_existing_replay_ids_pads_time_window(mock_raw_snql_query: MagicMock) -> None:
+    mock_raw_snql_query.return_value = {"data": [{"rid": "a" * 32}]}
+    start = datetime(2024, 1, 15, 12, 0, tzinfo=UTC)
+    end = datetime(2024, 1, 15, 13, 0, tzinfo=UTC)
+
+    result = filter_existing_replay_ids(
+        project_ids=[1],
+        start=start,
+        end=end,
+        replay_ids=["a" * 32],
+        tenant_ids={"organization_id": 1},
+    )
+
+    assert result == {"a" * 32}
+    request = mock_raw_snql_query.call_args.args[0]
+    where = request.query.where
+    assert where[1].rhs == end + timedelta(hours=MAX_REPLAY_LENGTH_HOURS)
+    assert where[2].rhs == start - timedelta(hours=MAX_REPLAY_LENGTH_HOURS)
+
+
+def test_filter_existing_replay_ids_empty_input() -> None:
+    assert (
+        filter_existing_replay_ids(
+            project_ids=[1],
+            start=datetime(2024, 1, 15, tzinfo=UTC),
+            end=datetime(2024, 1, 16, tzinfo=UTC),
+            replay_ids=[],
+            tenant_ids={"organization_id": 1},
+        )
+        == set()
+    )

--- a/tests/snuba/models/test_group.py
+++ b/tests/snuba/models/test_group.py
@@ -13,12 +13,12 @@ from sentry.issues.grouptype import (
     PerformanceNPlusOneGroupType,
     ProfileFileIOGroupType,
 )
-from sentry.models.group import Group, bulk_get_latest_event_ids
+from sentry.models.group import Group, _normalize_replay_id, bulk_get_latest_event_ids
 from sentry.services.eventstore.models import GroupEvent
 from sentry.testutils.cases import PerformanceIssueTestCase, SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.utils.samples import load_data
-from sentry.utils.snuba import bulk_snuba_queries
+from sentry.utils.snuba import SnubaError, bulk_snuba_queries
 from tests.sentry.issues.test_utils import OccurrenceTestMixin, SearchIssueTestMixin
 
 
@@ -418,6 +418,28 @@ class GroupTestSnubaErrorIssue(TestCase, SnubaTestCase):
         assert (
             _get_recommended(self.group, verify_replay_exists=True).event_id == lower_event.event_id
         )
+
+    @patch(VERIFY_REPLAY_FILTER)
+    def test_recommended_event_verify_replay_query_error_falls_back(
+        self, mock_filter: MagicMock
+    ) -> None:
+        mock_filter.side_effect = SnubaError("boom")
+        assert (
+            _get_recommended(self.group, verify_replay_exists=True).event_id
+            == self.event_b.event_id
+        )
+
+    def test_normalize_replay_id_handles_dashed_and_dashless(self) -> None:
+        assert (
+            _normalize_replay_id("550e8400-e29b-41d4-a716-446655440000")
+            == "550e8400e29b41d4a716446655440000"
+        )
+        assert (
+            _normalize_replay_id("550e8400e29b41d4a716446655440000")
+            == "550e8400e29b41d4a716446655440000"
+        )
+        assert _normalize_replay_id(None) is None
+        assert _normalize_replay_id("not-a-uuid") is None
 
     def test_latest_event(self) -> None:
         # No filter

--- a/tests/snuba/models/test_group.py
+++ b/tests/snuba/models/test_group.py
@@ -262,8 +262,14 @@ def _get_recommended(
     conditions: Sequence[Condition] | None = None,
     start: datetime | None = None,
     end: datetime | None = None,
+    verify_replay_exists: bool = False,
 ) -> GroupEvent:
-    ret = g.get_recommended_event(conditions=conditions, start=start, end=end)
+    ret = g.get_recommended_event(
+        conditions=conditions,
+        start=start,
+        end=end,
+        verify_replay_exists=verify_replay_exists,
+    )
     assert ret is not None
     return ret
 
@@ -375,6 +381,42 @@ class GroupTestSnubaErrorIssue(TestCase, SnubaTestCase):
                 self.group, start=before_now(hours=1), end=before_now(seconds=90)
             ).event_id
             == self.event_b.event_id
+        )
+
+    VERIFY_REPLAY_FILTER = "sentry.replays.usecases.replay_existence.filter_existing_replay_ids"
+
+    @patch(VERIFY_REPLAY_FILTER)
+    def test_recommended_event_verify_replay_missing_falls_back(
+        self, mock_filter: MagicMock
+    ) -> None:
+        # No replay exists -> fall back to the top-ranked event (current behavior).
+        mock_filter.return_value = set()
+        assert (
+            _get_recommended(self.group, verify_replay_exists=True).event_id
+            == self.event_b.event_id
+        )
+
+    @patch(VERIFY_REPLAY_FILTER)
+    def test_recommended_event_verify_replay_prefers_existing(self, mock_filter: MagicMock) -> None:
+        # A lower-ranked event (replay + processing errors) whose replay exists is
+        # preferred over the top-ranked event whose replay is missing.
+        lower_replay_id = uuid.uuid4().hex
+        lower_event = self.store_event(
+            data={
+                "event_id": "d" * 32,
+                "timestamp": before_now(minutes=4).isoformat(),
+                "fingerprint": ["group-1"],
+                "environment": "production",
+                "contexts": {"replay": {"replay_id": lower_replay_id}},
+                "errors": [{"type": "one"}, {"type": "two"}],
+                "message": "Error: Division by zero",
+            },
+            project_id=self.project.id,
+            assert_no_errors=False,
+        )
+        mock_filter.return_value = {lower_replay_id}
+        assert (
+            _get_recommended(self.group, verify_replay_exists=True).event_id == lower_event.event_id
         )
 
     def test_latest_event(self) -> None:


### PR DESCRIPTION
This PR is in an effort to better surface events to the issue detail page that have working replays. It's related, but tangential, to [this PR](https://github.com/getsentry/sentry/pull/120916).

The issues detail page is populated by a recommended event. Amongst the criteria to show this event is the existence of a replay - we currently show this by finding an event that has a `replay_id`. While seemingly sufficient, it's not :[. Due to many reasons explored in the attached PR, a replay_id doesn't guarantee a replay exists, and we'd like to up the odds to have one. Therefore, this PR adjusts the logic to determine a recommended event to go and see if a replay exists, provided a replay_id. This mainly involves:
- Adjusting the amount of candidate recommended events from 1 to 10 (arbitrarily chosen)
- A query to Snuba (`replay_existence.py`)

This PR also adds metrics to observe the frequency we don't get replays, how often we return an event with a replay within those 10 events, and when we don't. All of this is currently feature flagged. 

Closes REPLAY-946