### PR TITLE
fix(ci): replace invalid Actions pin with the commit SHA it resolves to

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -428,7 +428,7 @@ jobs:
 
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      - uses: astral-sh/setup-uv@884ad927a57e558e7a70b92f2bccf9198a4be546 # v6
+      - uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6
         with:
           version: '0.9.28'
 
@@ -576,7 +576,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      - uses: astral-sh/setup-uv@884ad927a57e558e7a70b92f2bccf9198a4be546 # v6
+      - uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6
         with:
           version: '0.9.28'
           # we just cache the venv-dir directly in action-setup-venv

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           token: ${{ secrets.BUMP_SENTRY_TOKEN }}
-      - uses: astral-sh/setup-uv@884ad927a57e558e7a70b92f2bccf9198a4be546 # v6
+      - uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6
         with:
           version: '0.9.28'
       - run: |

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      - uses: astral-sh/setup-uv@884ad927a57e558e7a70b92f2bccf9198a4be546 # v6
+      - uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6
         with:
           version: '0.9.28'
           # we just cache the venv-dir directly in action-setup-venv
@@ -55,7 +55,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      - uses: astral-sh/setup-uv@884ad927a57e558e7a70b92f2bccf9198a4be546 # v6
+      - uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6
         with:
           version: '0.9.28'
           # we just cache the venv-dir directly in action-setup-venv

--- a/.github/workflows/frontend-snapshots.yml
+++ b/.github/workflows/frontend-snapshots.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           node-version-file: '.node-version'
 
-      - uses: pnpm/action-setup@36de12bed180fa130ed56a35e7344f2fa7a820ab # v4
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
 
       - name: node_modules cache
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -55,7 +55,7 @@ jobs:
 
       - uses: ./.github/actions/setup-node-pnpm
 
-      - uses: astral-sh/setup-uv@884ad927a57e558e7a70b92f2bccf9198a4be546 # v6
+      - uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6
         with:
           version: '0.9.28'
           # we just cache the venv-dir directly in action-setup-venv

--- a/.github/workflows/react-to-product-owners-yml-changes.yml
+++ b/.github/workflows/react-to-product-owners-yml-changes.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      - uses: astral-sh/setup-uv@884ad927a57e558e7a70b92f2bccf9198a4be546 # v6
+      - uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6
         with:
           version: '0.9.28'
           # we just cache the venv-dir directly in action-setup-venv

--- a/.github/workflows/self-hosted.yml
+++ b/.github/workflows/self-hosted.yml
@@ -40,7 +40,7 @@ jobs:
           node-version-file: '.node-version'
 
       - uses: pnpm/action-setup@9b5745cdf0a2e8c2620f0746130f809adb911c19 # v4
-      - uses: astral-sh/setup-uv@884ad927a57e558e7a70b92f2bccf9198a4be546 # v6
+      - uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6
         with:
           version: '0.9.28'
 


### PR DESCRIPTION
## Problem

These workflow `uses:` pins are invalid as written. Each item below shows the current value, why it is wrong, and the correct ref that must be used instead.

### 1. `.github/workflows/backend.yml`

**Current (invalid):**

```yaml
uses: astral-sh/setup-uv@884ad927a57e558e7a70b92f2bccf9198a4be546 # v6
```

**Why this is wrong:**

- `884ad927a57e558e7a70b92f2bccf9198a4be546` is **not a commit SHA**. It is the Git object SHA of an **annotated tag** (`v6`).
- GitHub Actions does not accept annotated tag *object* SHAs in `uses:` pins (Commits API returns `No commit found for SHA`).
- The correct pin is the **commit SHA that tag `v6` points to**: `bd01e18f51369d5a26f1651c3cb451d3417e3bba`.

**Correct pin:**

```yaml
uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6
```

### 2. `.github/workflows/bump-version.yml`

**Current (invalid):**

```yaml
uses: astral-sh/setup-uv@884ad927a57e558e7a70b92f2bccf9198a4be546 # v6
```

**Why this is wrong:**

- `884ad927a57e558e7a70b92f2bccf9198a4be546` is **not a commit SHA**. It is the Git object SHA of an **annotated tag** (`v6`).
- GitHub Actions does not accept annotated tag *object* SHAs in `uses:` pins (Commits API returns `No commit found for SHA`).
- The correct pin is the **commit SHA that tag `v6` points to**: `bd01e18f51369d5a26f1651c3cb451d3417e3bba`.

**Correct pin:**

```yaml
uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6
```

### 3. `.github/workflows/development-environment.yml`

**Current (invalid):**

```yaml
uses: astral-sh/setup-uv@884ad927a57e558e7a70b92f2bccf9198a4be546 # v6
```

**Why this is wrong:**

- `884ad927a57e558e7a70b92f2bccf9198a4be546` is **not a commit SHA**. It is the Git object SHA of an **annotated tag** (`v6`).
- GitHub Actions does not accept annotated tag *object* SHAs in `uses:` pins (Commits API returns `No commit found for SHA`).
- The correct pin is the **commit SHA that tag `v6` points to**: `bd01e18f51369d5a26f1651c3cb451d3417e3bba`.

**Correct pin:**

```yaml
uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6
```

### 4. `.github/workflows/frontend-snapshots.yml`

**Current (invalid):**

```yaml
uses: pnpm/action-setup@36de12bed180fa130ed56a35e7344f2fa7a820ab # v4
```

**Why this is wrong:**

- `36de12bed180fa130ed56a35e7344f2fa7a820ab` is **not a commit SHA**. It is the Git object SHA of an **annotated tag** (`v4`).
- GitHub Actions does not accept annotated tag *object* SHAs in `uses:` pins (Commits API returns `No commit found for SHA`).
- The correct pin is the **commit SHA that tag `v4` points to**: `a7487c7e89a18df4991f7f222e4898a00d66ddda`.

**Correct pin:**

```yaml
uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
```

### 5. `.github/workflows/pre-commit.yml`

**Current (invalid):**

```yaml
uses: astral-sh/setup-uv@884ad927a57e558e7a70b92f2bccf9198a4be546 # v6
```

**Why this is wrong:**

- `884ad927a57e558e7a70b92f2bccf9198a4be546` is **not a commit SHA**. It is the Git object SHA of an **annotated tag** (`v6`).
- GitHub Actions does not accept annotated tag *object* SHAs in `uses:` pins (Commits API returns `No commit found for SHA`).
- The correct pin is the **commit SHA that tag `v6` points to**: `bd01e18f51369d5a26f1651c3cb451d3417e3bba`.

**Correct pin:**

```yaml
uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6
```

### 6. `.github/workflows/react-to-product-owners-yml-changes.yml`

**Current (invalid):**

```yaml
uses: astral-sh/setup-uv@884ad927a57e558e7a70b92f2bccf9198a4be546 # v6
```

**Why this is wrong:**

- `884ad927a57e558e7a70b92f2bccf9198a4be546` is **not a commit SHA**. It is the Git object SHA of an **annotated tag** (`v6`).
- GitHub Actions does not accept annotated tag *object* SHAs in `uses:` pins (Commits API returns `No commit found for SHA`).
- The correct pin is the **commit SHA that tag `v6` points to**: `bd01e18f51369d5a26f1651c3cb451d3417e3bba`.

**Correct pin:**

```yaml
uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6
```

### 7. `.github/workflows/self-hosted.yml`

**Current (invalid):**

```yaml
uses: astral-sh/setup-uv@884ad927a57e558e7a70b92f2bccf9198a4be546 # v6
```

**Why this is wrong:**

- `884ad927a57e558e7a70b92f2bccf9198a4be546` is **not a commit SHA**. It is the Git object SHA of an **annotated tag** (`v6`).
- GitHub Actions does not accept annotated tag *object* SHAs in `uses:` pins (Commits API returns `No commit found for SHA`).
- The correct pin is the **commit SHA that tag `v6` points to**: `bd01e18f51369d5a26f1651c3cb451d3417e3bba`.

**Correct pin:**

```yaml
uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6
```

## Test plan

- [ ] Each updated `uses:` ref resolves as a commit via the GitHub Commits API
- [ ] Relevant CI jobs on this branch look healthy
