### PR TITLE
fix(search): Require two words before defaulting to Ask Seer

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -7380,24 +7380,54 @@ describe('SearchQueryBuilder', () => {
         );
 
         await userEvent.click(getLastInput());
-        await userEvent.type(getLastInput(), 'find slow spans{enter}');
+        await userEvent.type(getLastInput(), 'slow spans{enter}');
 
         expect(
           await screen.findByRole('combobox', {
             name: 'Ask Seer with Natural Language',
           })
-        ).toHaveValue('find slow spans ');
+        ).toHaveValue('slow spans ');
         await waitFor(() => {
-          expect(mockAskSeer).toHaveBeenCalledWith('find slow spans', expect.anything());
+          expect(mockAskSeer).toHaveBeenCalledWith('slow spans', expect.anything());
         });
         expect(mockOnSearch).not.toHaveBeenCalled();
 
         await userEvent.click(screen.getByRole('button', {name: 'Close Seer Search'}));
 
-        expect(
-          screen.queryByRole('row', {name: 'find slow spans'})
-        ).not.toBeInTheDocument();
-        expect(screen.queryByDisplayValue('find slow spans')).not.toBeInTheDocument();
+        expect(screen.queryByRole('row', {name: 'slow spans'})).not.toBeInTheDocument();
+        expect(screen.queryByDisplayValue('slow spans')).not.toBeInTheDocument();
+      });
+
+      it('submits a single word as a regular search when defaulting to ask seer', async () => {
+        const mockOnSearch = jest.fn();
+        const mockAskSeer = makeMockAskSeer();
+        const props = {
+          ...defaultProps,
+          defaultToAskSeerOnFreeTextSearch: true,
+          enableAISearch: true,
+          onSearch: mockOnSearch,
+        };
+
+        render(
+          <SearchQueryBuilderProvider {...props}>
+            <AskSeerAutoSubmitTestComponent mockAskSeer={mockAskSeer}>
+              <SearchQueryBuilder {...props} />
+            </AskSeerAutoSubmitTestComponent>
+          </SearchQueryBuilderProvider>,
+          {
+            organization: {
+              features: ['gen-ai-features', 'gen-ai-default-to-ask-seer'],
+            },
+          }
+        );
+
+        await userEvent.click(getLastInput());
+        await userEvent.type(getLastInput(), 'error{enter}');
+
+        await waitFor(() => {
+          expect(mockOnSearch).toHaveBeenCalledWith('error', expect.anything());
+        });
+        expect(mockAskSeer).not.toHaveBeenCalled();
       });
 
       it('does not duplicate committed free text when defaulting to ask seer', async () => {

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -89,9 +89,9 @@ export interface SearchQueryBuilderProps {
   caseInsensitive?: CaseInsensitive;
   className?: string;
   /**
-   * When true, submitting free text will open Ask Seer and submit the full query.
-   * Requires AI search to be enabled and the organization to have the
-   * gen-ai-default-to-ask-seer feature.
+   * When true, submitting free text containing at least two words will open Ask Seer
+   * and submit the full query. Requires AI search to be enabled and the organization
+   * to have the gen-ai-default-to-ask-seer feature.
    */
   defaultToAskSeerOnFreeTextSearch?: boolean;
   disabled?: boolean;

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -716,7 +716,11 @@ function SearchQueryBuilderInputInternal({
           resetInputValue();
         }}
         onCustomValueCommitted={value => {
-          if (defaultToAskSeerOnFreeTextSearch && value.trim() && !hasFilter) {
+          if (
+            defaultToAskSeerOnFreeTextSearch &&
+            value.trim().split(/\s+/).length >= 2 &&
+            !hasFilter
+          ) {
             setAutoSubmitFromCurrentQuery(true);
             setAutoSubmitSeer(true);
             setDisplayAskSeer(true);


### PR DESCRIPTION
Free-text searches now auto-switch to Ask Seer only when the submitted input contains at least two words. Single-word input continues through the existing query replacement and search flow, while multi-word behavior and filter handling remain unchanged.
