### PR TITLE
fix(dashboards): keep custom date ranges beyond 90 days

### DIFF
--- a/static/app/views/dashboards/dashboardPageFilters.tsx
+++ b/static/app/views/dashboards/dashboardPageFilters.tsx
@@ -1,27 +1,34 @@
 import {PageFiltersContainer} from 'sentry/components/pageFilters/container';
+import {DataCategory} from 'sentry/types/core';
+import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
 import {DEFAULT_STATS_PERIOD} from 'sentry/views/dashboards/data';
-import {useDashboardMaxPickableDays} from 'sentry/views/dashboards/hooks/useDashboardMaxPickableDays';
-import type {Widget} from 'sentry/views/dashboards/types';
+
+const ALL_DASHBOARD_DATA_CATEGORIES = [
+  DataCategory.SPANS,
+  DataCategory.TRANSACTIONS,
+  DataCategory.ERRORS,
+  DataCategory.LOG_ITEM,
+  DataCategory.TRACE_METRICS,
+] as const;
 
 interface DashboardPageFiltersProps {
   children: React.ReactNode;
-  widgets: Widget[];
   skipLoadLastUsed?: boolean;
 }
 
 export function DashboardPageFilters({
   children,
-  widgets,
   skipLoadLastUsed,
 }: DashboardPageFiltersProps) {
-  const {maxPickableDays, maxDateRange} = useDashboardMaxPickableDays(widgets);
+  const {maxPickableDays} = useMaxPickableDays({
+    dataCategories: ALL_DASHBOARD_DATA_CATEGORIES,
+  });
 
   return (
     <PageFiltersContainer
       disablePersistence
       skipLoadLastUsed={skipLoadLastUsed}
       maxPickableDays={maxPickableDays}
-      maxDateRange={maxDateRange}
       defaultSelection={{
         datetime: {
           start: null,

--- a/static/app/views/dashboards/dashboardPageFilters.tsx
+++ b/static/app/views/dashboards/dashboardPageFilters.tsx
@@ -1,15 +1,7 @@
 import {PageFiltersContainer} from 'sentry/components/pageFilters/container';
-import {DataCategory} from 'sentry/types/core';
 import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
 import {DEFAULT_STATS_PERIOD} from 'sentry/views/dashboards/data';
-
-const ALL_DASHBOARD_DATA_CATEGORIES = [
-  DataCategory.SPANS,
-  DataCategory.TRANSACTIONS,
-  DataCategory.ERRORS,
-  DataCategory.LOG_ITEM,
-  DataCategory.TRACE_METRICS,
-] as const;
+import {ALL_DASHBOARD_DATA_CATEGORIES} from 'sentry/views/dashboards/hooks/useDashboardMaxPickableDays';
 
 interface DashboardPageFiltersProps {
   children: React.ReactNode;

--- a/static/app/views/dashboards/dashboardPageFilters.tsx
+++ b/static/app/views/dashboards/dashboardPageFilters.tsx
@@ -1,7 +1,15 @@
 import {PageFiltersContainer} from 'sentry/components/pageFilters/container';
+import {DataCategory} from 'sentry/types/core';
 import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
 import {DEFAULT_STATS_PERIOD} from 'sentry/views/dashboards/data';
-import {ALL_DASHBOARD_DATA_CATEGORIES} from 'sentry/views/dashboards/hooks/useDashboardMaxPickableDays';
+
+const ALL_DASHBOARD_DATA_CATEGORIES = [
+  DataCategory.SPANS,
+  DataCategory.TRANSACTIONS,
+  DataCategory.ERRORS,
+  DataCategory.LOG_ITEM,
+  DataCategory.TRACE_METRICS,
+] as const;
 
 interface DashboardPageFiltersProps {
   children: React.ReactNode;

--- a/static/app/views/dashboards/dashboardPageFilters.tsx
+++ b/static/app/views/dashboards/dashboardPageFilters.tsx
@@ -1,0 +1,37 @@
+import {PageFiltersContainer} from 'sentry/components/pageFilters/container';
+import {DEFAULT_STATS_PERIOD} from 'sentry/views/dashboards/data';
+import {useDashboardMaxPickableDays} from 'sentry/views/dashboards/hooks/useDashboardMaxPickableDays';
+import type {Widget} from 'sentry/views/dashboards/types';
+
+interface DashboardPageFiltersProps {
+  children: React.ReactNode;
+  widgets: Widget[];
+  skipLoadLastUsed?: boolean;
+}
+
+export function DashboardPageFilters({
+  children,
+  widgets,
+  skipLoadLastUsed,
+}: DashboardPageFiltersProps) {
+  const {maxPickableDays, maxDateRange} = useDashboardMaxPickableDays(widgets);
+
+  return (
+    <PageFiltersContainer
+      disablePersistence
+      skipLoadLastUsed={skipLoadLastUsed}
+      maxPickableDays={maxPickableDays}
+      maxDateRange={maxDateRange}
+      defaultSelection={{
+        datetime: {
+          start: null,
+          end: null,
+          utc: false,
+          period: DEFAULT_STATS_PERIOD,
+        },
+      }}
+    >
+      {children}
+    </PageFiltersContainer>
+  );
+}

--- a/static/app/views/dashboards/dashboardPageFilters.tsx
+++ b/static/app/views/dashboards/dashboardPageFilters.tsx
@@ -20,6 +20,11 @@ export function DashboardPageFilters({
   children,
   skipLoadLastUsed,
 }: DashboardPageFiltersProps) {
+  // This ceiling is derived from all dashboard data categories, not the current
+  // widgets, so it's always at least as high as the date picker's own limit (which
+  // `FiltersBar` derives per dashboard via `useDashboardMaxPickableDays`). A
+  // widget-derived ceiling here would move as the dashboard's contents change and
+  // reset a selection the picker had already allowed.
   const {maxPickableDays} = useMaxPickableDays({
     dataCategories: ALL_DASHBOARD_DATA_CATEGORIES,
   });

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -1082,7 +1082,7 @@ class DashboardDetail extends Component<Props, State> {
     const {pageAlerts, organization, dashboard, location} = this.props;
     const {modifiedDashboard, dashboardState, widgetLimitReached} = this.state;
     return (
-      <DashboardPageFilters widgets={dashboard.widgets}>
+      <DashboardPageFilters>
         <Stack flex={1} padding="2xl 3xl">
           <OnDemandControlProvider location={location}>
             <MetricsResultsMetaProvider>
@@ -1495,12 +1495,7 @@ class DashboardDetail extends Component<Props, State> {
         {this.isEmbedded ? (
           pageContent
         ) : (
-          <DashboardPageFilters
-            skipLoadLastUsed
-            widgets={(modifiedDashboard ?? dashboard).widgets}
-          >
-            {pageContent}
-          </DashboardPageFilters>
+          <DashboardPageFilters skipLoadLastUsed>{pageContent}</DashboardPageFilters>
         )}
       </SentryDocumentTitle>
     );

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -34,7 +34,6 @@ import {
 } from 'sentry/components/modals/widgetViewerModal/utils';
 import {NoProjectMessage} from 'sentry/components/noProjectMessage';
 import {OverrideOrDefault} from 'sentry/components/overrideOrDefault';
-import {PageFiltersContainer} from 'sentry/components/pageFilters/container';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {USING_CUSTOMER_DOMAIN} from 'sentry/constants';
 import {t} from 'sentry/locale';
@@ -87,7 +86,7 @@ import {Controls} from './controls';
 import {validateDashboardAndRecordMetrics} from './createFromSeerUtils';
 import {Dashboard} from './dashboard';
 import {DashboardEditSeerChat} from './dashboardEditSeerChat';
-import {DEFAULT_STATS_PERIOD} from './data';
+import {DashboardPageFilters} from './dashboardPageFilters';
 import {FiltersBar} from './filtersBar';
 import {
   assignDefaultLayout,
@@ -1083,17 +1082,7 @@ class DashboardDetail extends Component<Props, State> {
     const {pageAlerts, organization, dashboard, location} = this.props;
     const {modifiedDashboard, dashboardState, widgetLimitReached} = this.state;
     return (
-      <PageFiltersContainer
-        disablePersistence
-        defaultSelection={{
-          datetime: {
-            start: null,
-            end: null,
-            utc: false,
-            period: DEFAULT_STATS_PERIOD,
-          },
-        }}
-      >
+      <DashboardPageFilters widgets={dashboard.widgets}>
         <Stack flex={1} padding="2xl 3xl">
           <OnDemandControlProvider location={location}>
             <MetricsResultsMetaProvider>
@@ -1172,7 +1161,7 @@ class DashboardDetail extends Component<Props, State> {
             </MetricsResultsMetaProvider>
           </OnDemandControlProvider>
         </Stack>
-      </PageFiltersContainer>
+      </DashboardPageFilters>
     );
   }
 
@@ -1506,20 +1495,12 @@ class DashboardDetail extends Component<Props, State> {
         {this.isEmbedded ? (
           pageContent
         ) : (
-          <PageFiltersContainer
-            disablePersistence
+          <DashboardPageFilters
             skipLoadLastUsed
-            defaultSelection={{
-              datetime: {
-                start: null,
-                end: null,
-                utc: false,
-                period: DEFAULT_STATS_PERIOD,
-              },
-            }}
+            widgets={(modifiedDashboard ?? dashboard).widgets}
           >
             {pageContent}
-          </PageFiltersContainer>
+          </DashboardPageFilters>
         )}
       </SentryDocumentTitle>
     );

--- a/static/app/views/dashboards/filtersBar.tsx
+++ b/static/app/views/dashboards/filtersBar.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useMemo, useState} from 'react';
+import {useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
 import {createParser, useQueryState} from 'nuqs';
@@ -23,11 +23,9 @@ import {
 } from 'sentry/constants/releases';
 import {IconAdd, IconClock} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {DataCategory} from 'sentry/types/core';
 import type {User} from 'sentry/types/user';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {defined} from 'sentry/utils/defined';
-import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useUser} from 'sentry/utils/useUser';
 import {useUserTeams} from 'sentry/utils/useUserTeams';
@@ -39,6 +37,7 @@ import {
   mergeGlobalFilters,
 } from 'sentry/views/dashboards/globalFilter/utils';
 import {useDashboardChartInterval} from 'sentry/views/dashboards/hooks/useDashboardChartInterval';
+import {useDashboardMaxPickableDays} from 'sentry/views/dashboards/hooks/useDashboardMaxPickableDays';
 import {useDatasetSearchBarData} from 'sentry/views/dashboards/hooks/useDatasetSearchBarData';
 import {useInvalidateStarredDashboards} from 'sentry/views/dashboards/hooks/useInvalidateStarredDashboards';
 import {getDashboardFiltersFromURL} from 'sentry/views/dashboards/utils';
@@ -55,53 +54,8 @@ import type {
   DashboardFilters,
   DashboardPermissions,
   GlobalFilter,
-  Widget,
 } from './types';
-import {DashboardFilterKeys, WidgetType} from './types';
-
-/**
- * Maps widget types to data categories for determining max pickable days
- */
-function getDataCategoriesFromWidgets(
-  widgets: Widget[]
-): [DataCategory, ...DataCategory[]] {
-  const categories = new Set<DataCategory>();
-
-  for (const widget of widgets) {
-    const widgetType = widget.widgetType ?? WidgetType.DISCOVER;
-
-    switch (widgetType) {
-      case WidgetType.SPANS:
-        categories.add(DataCategory.SPANS);
-        break;
-      case WidgetType.TRANSACTIONS:
-        categories.add(DataCategory.TRANSACTIONS);
-        break;
-      case WidgetType.TRACEMETRICS:
-        categories.add(DataCategory.TRACE_METRICS);
-        break;
-      case WidgetType.LOGS:
-        categories.add(DataCategory.LOG_ITEM);
-        break;
-      case WidgetType.ERRORS:
-      case WidgetType.DISCOVER:
-      case WidgetType.ISSUE:
-      case WidgetType.RELEASE:
-      case WidgetType.METRICS:
-      default:
-        // For error-like widgets, use TRANSACTIONS as a safe default
-        // since it has the most permissive date range
-        categories.add(DataCategory.TRANSACTIONS);
-        break;
-    }
-  }
-
-  // Return as tuple with at least one element (required by useMaxPickableDays)
-  const categoriesArray = Array.from(categories);
-  return categoriesArray.length > 0
-    ? (categoriesArray as [DataCategory, ...DataCategory[]])
-    : [DataCategory.TRANSACTIONS];
-}
+import {DashboardFilterKeys} from './types';
 
 export type FiltersBarProps = {
   filters: DashboardFilters;
@@ -149,18 +103,7 @@ export function FiltersBar({
     ? (PREBUILT_DASHBOARDS[prebuiltDashboardId].filters.globalFilter ?? [])
     : [];
 
-  // Determine data categories based on widget types in the dashboard
-  const dataCategories = useMemo(() => {
-    if (!dashboard?.widgets || dashboard.widgets.length === 0) {
-      // Default to TRANSACTIONS if no widgets
-      return [DataCategory.TRANSACTIONS] as [DataCategory, ...DataCategory[]];
-    }
-
-    return getDataCategoriesFromWidgets(dashboard.widgets);
-  }, [dashboard?.widgets]);
-
-  // Calculate maxPickableDays based on the data categories
-  const maxPickableDaysOptions = useMaxPickableDays({dataCategories});
+  const maxPickableDaysOptions = useDashboardMaxPickableDays(dashboard?.widgets);
 
   // Release sort state - validates and defaults to DATE via custom parser
   const [releaseSort, setReleaseSort] = useQueryState('sortReleasesBy', parseReleaseSort);

--- a/static/app/views/dashboards/hooks/useDashboardMaxPickableDays.tsx
+++ b/static/app/views/dashboards/hooks/useDashboardMaxPickableDays.tsx
@@ -1,0 +1,68 @@
+import {useMemo} from 'react';
+
+import {DataCategory} from 'sentry/types/core';
+import {
+  useMaxPickableDays,
+  type MaxPickableDaysOptions,
+} from 'sentry/utils/useMaxPickableDays';
+import type {Widget} from 'sentry/views/dashboards/types';
+import {WidgetType} from 'sentry/views/dashboards/types';
+
+/**
+ * Maps widget types to data categories for determining max pickable days
+ */
+function getDataCategoriesFromWidgets(
+  widgets: Widget[]
+): [DataCategory, ...DataCategory[]] {
+  const categories = new Set<DataCategory>();
+
+  for (const widget of widgets) {
+    const widgetType = widget.widgetType ?? WidgetType.DISCOVER;
+
+    switch (widgetType) {
+      case WidgetType.SPANS:
+        categories.add(DataCategory.SPANS);
+        break;
+      case WidgetType.TRANSACTIONS:
+        categories.add(DataCategory.TRANSACTIONS);
+        break;
+      case WidgetType.TRACEMETRICS:
+        categories.add(DataCategory.TRACE_METRICS);
+        break;
+      case WidgetType.LOGS:
+        categories.add(DataCategory.LOG_ITEM);
+        break;
+      case WidgetType.ERRORS:
+      case WidgetType.DISCOVER:
+      case WidgetType.ISSUE:
+      case WidgetType.RELEASE:
+      case WidgetType.METRICS:
+      default:
+        // For error-like widgets, use TRANSACTIONS as a safe default
+        // since it has the most permissive date range
+        categories.add(DataCategory.TRANSACTIONS);
+        break;
+    }
+  }
+
+  // Return as tuple with at least one element (required by useMaxPickableDays)
+  const categoriesArray = Array.from(categories);
+  return categoriesArray.length > 0
+    ? (categoriesArray as [DataCategory, ...DataCategory[]])
+    : [DataCategory.TRANSACTIONS];
+}
+
+export function useDashboardMaxPickableDays(
+  widgets: Widget[] | undefined
+): MaxPickableDaysOptions {
+  const dataCategories = useMemo(() => {
+    if (!widgets || widgets.length === 0) {
+      // Default to TRANSACTIONS if no widgets
+      return [DataCategory.TRANSACTIONS] as [DataCategory, ...DataCategory[]];
+    }
+
+    return getDataCategoriesFromWidgets(widgets);
+  }, [widgets]);
+
+  return useMaxPickableDays({dataCategories});
+}

--- a/static/app/views/dashboards/hooks/useDashboardMaxPickableDays.tsx
+++ b/static/app/views/dashboards/hooks/useDashboardMaxPickableDays.tsx
@@ -11,45 +11,54 @@ import {WidgetType} from 'sentry/views/dashboards/types';
 /**
  * Maps widget types to data categories for determining max pickable days
  */
-function getDataCategoriesFromWidgets(
-  widgets: Widget[]
-): [DataCategory, ...DataCategory[]] {
-  const categories = new Set<DataCategory>();
-
-  for (const widget of widgets) {
-    const widgetType = widget.widgetType ?? WidgetType.DISCOVER;
-
-    switch (widgetType) {
-      case WidgetType.SPANS:
-        categories.add(DataCategory.SPANS);
-        break;
-      case WidgetType.TRANSACTIONS:
-        categories.add(DataCategory.TRANSACTIONS);
-        break;
-      case WidgetType.TRACEMETRICS:
-        categories.add(DataCategory.TRACE_METRICS);
-        break;
-      case WidgetType.LOGS:
-        categories.add(DataCategory.LOG_ITEM);
-        break;
-      case WidgetType.ERRORS:
-      case WidgetType.DISCOVER:
-      case WidgetType.ISSUE:
-      case WidgetType.RELEASE:
-      case WidgetType.METRICS:
-      default:
-        // For error-like widgets, use TRANSACTIONS as a safe default
-        // since it has the most permissive date range
-        categories.add(DataCategory.TRANSACTIONS);
-        break;
-    }
+function getDataCategoryFromWidgetType(widgetType: WidgetType): DataCategory {
+  switch (widgetType) {
+    case WidgetType.SPANS:
+      return DataCategory.SPANS;
+    case WidgetType.TRANSACTIONS:
+      return DataCategory.TRANSACTIONS;
+    case WidgetType.TRACEMETRICS:
+      return DataCategory.TRACE_METRICS;
+    case WidgetType.LOGS:
+      return DataCategory.LOG_ITEM;
+    case WidgetType.ERRORS:
+    case WidgetType.DISCOVER:
+    case WidgetType.ISSUE:
+    case WidgetType.RELEASE:
+    case WidgetType.METRICS:
+    default:
+      // For error-like widgets, use TRANSACTIONS as a safe default
+      // since it has the most permissive date range
+      return DataCategory.TRANSACTIONS;
   }
+}
 
+function toDataCategoryTuple(
+  categories: Iterable<DataCategory>
+): [DataCategory, ...DataCategory[]] {
   // Return as tuple with at least one element (required by useMaxPickableDays)
-  const categoriesArray = Array.from(categories);
+  const categoriesArray = Array.from(new Set(categories));
   return categoriesArray.length > 0
     ? (categoriesArray as [DataCategory, ...DataCategory[]])
     : [DataCategory.TRANSACTIONS];
+}
+
+/**
+ * Every data category a dashboard widget can query, so the ceiling covers any
+ * widget the dashboard could hold rather than the ones it holds right now.
+ */
+export const ALL_DASHBOARD_DATA_CATEGORIES = toDataCategoryTuple(
+  Object.values(WidgetType).map(getDataCategoryFromWidgetType)
+);
+
+function getDataCategoriesFromWidgets(
+  widgets: Widget[]
+): [DataCategory, ...DataCategory[]] {
+  return toDataCategoryTuple(
+    widgets.map(widget =>
+      getDataCategoryFromWidgetType(widget.widgetType ?? WidgetType.DISCOVER)
+    )
+  );
 }
 
 export function useDashboardMaxPickableDays(

--- a/static/app/views/dashboards/hooks/useDashboardMaxPickableDays.tsx
+++ b/static/app/views/dashboards/hooks/useDashboardMaxPickableDays.tsx
@@ -11,54 +11,45 @@ import {WidgetType} from 'sentry/views/dashboards/types';
 /**
  * Maps widget types to data categories for determining max pickable days
  */
-function getDataCategoryFromWidgetType(widgetType: WidgetType): DataCategory {
-  switch (widgetType) {
-    case WidgetType.SPANS:
-      return DataCategory.SPANS;
-    case WidgetType.TRANSACTIONS:
-      return DataCategory.TRANSACTIONS;
-    case WidgetType.TRACEMETRICS:
-      return DataCategory.TRACE_METRICS;
-    case WidgetType.LOGS:
-      return DataCategory.LOG_ITEM;
-    case WidgetType.ERRORS:
-    case WidgetType.DISCOVER:
-    case WidgetType.ISSUE:
-    case WidgetType.RELEASE:
-    case WidgetType.METRICS:
-    default:
-      // For error-like widgets, use TRANSACTIONS as a safe default
-      // since it has the most permissive date range
-      return DataCategory.TRANSACTIONS;
-  }
-}
-
-function toNonEmptyDataCategories(
-  categories: Iterable<DataCategory>
-): [DataCategory, ...DataCategory[]] {
-  // Return as tuple with at least one element (required by useMaxPickableDays)
-  const categoriesArray = Array.from(new Set(categories));
-  return categoriesArray.length > 0
-    ? (categoriesArray as [DataCategory, ...DataCategory[]])
-    : [DataCategory.TRANSACTIONS];
-}
-
-/**
- * Every data category a dashboard widget can query, so the ceiling covers any
- * widget the dashboard could hold rather than the ones it holds right now.
- */
-export const ALL_DASHBOARD_DATA_CATEGORIES = toNonEmptyDataCategories(
-  Object.values(WidgetType).map(getDataCategoryFromWidgetType)
-);
-
 function getDataCategoriesFromWidgets(
   widgets: Widget[]
 ): [DataCategory, ...DataCategory[]] {
-  return toNonEmptyDataCategories(
-    widgets.map(widget =>
-      getDataCategoryFromWidgetType(widget.widgetType ?? WidgetType.DISCOVER)
-    )
-  );
+  const categories = new Set<DataCategory>();
+
+  for (const widget of widgets) {
+    const widgetType = widget.widgetType ?? WidgetType.DISCOVER;
+
+    switch (widgetType) {
+      case WidgetType.SPANS:
+        categories.add(DataCategory.SPANS);
+        break;
+      case WidgetType.TRANSACTIONS:
+        categories.add(DataCategory.TRANSACTIONS);
+        break;
+      case WidgetType.TRACEMETRICS:
+        categories.add(DataCategory.TRACE_METRICS);
+        break;
+      case WidgetType.LOGS:
+        categories.add(DataCategory.LOG_ITEM);
+        break;
+      case WidgetType.ERRORS:
+      case WidgetType.DISCOVER:
+      case WidgetType.ISSUE:
+      case WidgetType.RELEASE:
+      case WidgetType.METRICS:
+      default:
+        // For error-like widgets, use TRANSACTIONS as a safe default
+        // since it has the most permissive date range
+        categories.add(DataCategory.TRANSACTIONS);
+        break;
+    }
+  }
+
+  // Return as tuple with at least one element (required by useMaxPickableDays)
+  const categoriesArray = Array.from(categories);
+  return categoriesArray.length > 0
+    ? (categoriesArray as [DataCategory, ...DataCategory[]])
+    : [DataCategory.TRANSACTIONS];
 }
 
 export function useDashboardMaxPickableDays(

--- a/static/app/views/dashboards/hooks/useDashboardMaxPickableDays.tsx
+++ b/static/app/views/dashboards/hooks/useDashboardMaxPickableDays.tsx
@@ -33,7 +33,7 @@ function getDataCategoryFromWidgetType(widgetType: WidgetType): DataCategory {
   }
 }
 
-function toDataCategoryTuple(
+function toNonEmptyDataCategories(
   categories: Iterable<DataCategory>
 ): [DataCategory, ...DataCategory[]] {
   // Return as tuple with at least one element (required by useMaxPickableDays)
@@ -47,14 +47,14 @@ function toDataCategoryTuple(
  * Every data category a dashboard widget can query, so the ceiling covers any
  * widget the dashboard could hold rather than the ones it holds right now.
  */
-export const ALL_DASHBOARD_DATA_CATEGORIES = toDataCategoryTuple(
+export const ALL_DASHBOARD_DATA_CATEGORIES = toNonEmptyDataCategories(
   Object.values(WidgetType).map(getDataCategoryFromWidgetType)
 );
 
 function getDataCategoriesFromWidgets(
   widgets: Widget[]
 ): [DataCategory, ...DataCategory[]] {
-  return toDataCategoryTuple(
+  return toNonEmptyDataCategories(
     widgets.map(widget =>
       getDataCategoryFromWidgetType(widget.widgetType ?? WidgetType.DISCOVER)
     )


### PR DESCRIPTION
Fixes [DAIN-1822](https://linear.app/getsentry/issue/DAIN-1822/keep-custom-date-range-selected-beyond-90-days).

The main issue here was that we were not passing through `maxPickableDays` in `PageFilters`, however this pr also refactors the code to share more functionality and updates maxPickableDays to be the ceiling for the org (vs ceiling for dashboard datasets to prevent weird issues where deleting a widget might change your date selection) 

`FiltersBar` derives the date picker's `maxPickableDays` from the dashboard's widget data categories, which can exceed 90 days for spans with downsampled retention. The `PageFiltersContainer` wrapping the dashboard passed no limit, so it fell back to the plan's `retentionDays` (90) and reset any custom range starting before that window back to `90d`.

A small `DashboardPageFilters` wrapper now gives the container a ceiling based on the org's most permissive data category, so it's always at least as high as anything the picker offers and can't undo a selection the picker just allowed. `getDataCategoriesFromWidgets` also moves into a shared `useDashboardMaxPickableDays` hook, which the picker keeps using to limit per dashboard. Frontend only.

### Selecting 100 days in the ui
Before (when selecting last 100 days, falls back to 90 days)
<img width="1422" height="752" alt="image" src="https://github.com/user-attachments/assets/fdd9e997-c127-4855-8199-872b719bb753" />

After (when selecting last 100 days)
<img width="1454" height="680" alt="image" src="https://github.com/user-attachments/assets/6c5dfec2-4da4-426f-a807-decd5f6231e0" />
