### PR TITLE
fix(releases): Stop using discover dataset for release comparison

### DIFF
--- a/static/app/views/explore/releases/detail/overview/releaseComparisonChart/index.tsx
+++ b/static/app/views/explore/releases/detail/overview/releaseComparisonChart/index.tsx
@@ -210,7 +210,10 @@ export function ReleaseComparisonChart({
         api.requestPromise(url, {
           query: {
             field: ['count()'],
-            query: new MutableSearch([`release:${release.version}`]).formatString(),
+            query: new MutableSearch([
+              'event.type:error',
+              `release:${release.version}`,
+            ]).formatString(),
             dataset: DiscoverDatasets.ERRORS,
             ...commonQuery,
           },
@@ -218,7 +221,7 @@ export function ReleaseComparisonChart({
         api.requestPromise(url, {
           query: {
             field: ['count()'],
-            query: '',
+            query: new MutableSearch(['event.type:error']).formatString(),
             dataset: DiscoverDatasets.ERRORS,
             ...commonQuery,
           },

--- a/static/app/views/explore/releases/detail/overview/releaseComparisonChart/index.tsx
+++ b/static/app/views/explore/releases/detail/overview/releaseComparisonChart/index.tsx
@@ -210,17 +210,16 @@ export function ReleaseComparisonChart({
         api.requestPromise(url, {
           query: {
             field: ['count()'],
-            query: new MutableSearch([
-              'event.type:error',
-              `release:${release.version}`,
-            ]).formatString(),
+            query: new MutableSearch(`release:${release.version}`).formatString(),
+            dataset: DiscoverDatasets.ERRORS,
             ...commonQuery,
           },
         }),
         api.requestPromise(url, {
           query: {
             field: ['count()'],
-            query: new MutableSearch(['event.type:error']).formatString(),
+            query: '',
+            dataset: DiscoverDatasets.ERRORS,
             ...commonQuery,
           },
         }),

--- a/static/app/views/explore/releases/detail/overview/releaseComparisonChart/index.tsx
+++ b/static/app/views/explore/releases/detail/overview/releaseComparisonChart/index.tsx
@@ -210,7 +210,7 @@ export function ReleaseComparisonChart({
         api.requestPromise(url, {
           query: {
             field: ['count()'],
-            query: new MutableSearch(`release:${release.version}`).formatString(),
+            query: new MutableSearch([`release:${release.version}`]).formatString(),
             dataset: DiscoverDatasets.ERRORS,
             ...commonQuery,
           },


### PR DESCRIPTION
Replace queries to `discover` with `event.type:error`. Explicitly query the `errors` dataset instead.

See BROWSE-676.