### PR TITLE
fix(codeowners): Ignore stale `organization_integration_id` input

### DIFF
--- a/src/sentry/issues/endpoints/serializers.py
+++ b/src/sentry/issues/endpoints/serializers.py
@@ -24,12 +24,11 @@ from sentry.utils.codeowners import MAX_RAW_LENGTH
 class ProjectCodeOwnerSerializer(CamelSnakeModelSerializer[ProjectCodeOwners]):
     code_mapping_id = serializers.IntegerField(required=True)
     raw = serializers.CharField(required=True)
-    organization_integration_id = serializers.IntegerField(required=False)
     date_updated = serializers.CharField(required=False)
 
     class Meta:
         model = ProjectCodeOwners
-        fields = ["raw", "code_mapping_id", "organization_integration_id", "date_updated"]
+        fields = ["raw", "code_mapping_id", "date_updated"]
 
     def get_max_length(self) -> int:
         return MAX_RAW_LENGTH


### PR DESCRIPTION
`organization_integration_id` was removed from `ProjectCodeOwners` in #24072, but #24033 added it back to the request serializer from a stale branch. Requests that include the legacy field validate successfully and then 500 when Django constructs the model.

Stop treating the obsolete field as serializer input so DRF ignores it.

fixes SENTRY-5S7V