### PR TITLE
feat(ourlogs): add `level` as a secondary alias for `severity`

### DIFF
--- a/src/sentry/search/eap/ourlogs/attributes.py
+++ b/src/sentry/search/eap/ourlogs/attributes.py
@@ -42,6 +42,12 @@ OURLOG_ATTRIBUTE_DEFINITIONS = {
             ),
         ),
         ResolvedAttribute(
+            public_alias="level",
+            internal_name="sentry.severity_text",
+            search_type="string",
+            secondary_alias=True,
+        ),
+        ResolvedAttribute(
             public_alias="message",
             internal_name="sentry.body",
             search_type="string",

--- a/tests/sentry/api/endpoints/test_organization_events_validate.py
+++ b/tests/sentry/api/endpoints/test_organization_events_validate.py
@@ -117,6 +117,27 @@ class OrganizationEventsValidateEndpointTest(APITestCase, SnubaTestCase, SpanTes
             {"error": None, "name": "project", "valid": True, "attrType": "string"}
         ]
 
+    def test_logs_level_is_a_known_attribute(self) -> None:
+        response = self.do_request(
+            {
+                "project": [self.project.id],
+                "dataset": "logs",
+                "field": ["level"],
+                "query": "level:error",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        assert response.data["valid"]
+        assert response.data["field"] == [
+            {"error": None, "name": "level", "valid": True, "attrType": "string"}
+        ]
+        assert response.data["query"] == {
+            "valid": True,
+            "error": None,
+            "fields": [{"error": None, "name": "level", "valid": True, "attrType": "string"}],
+        }
+
     def test_user_tags_in_storage_for_fields(self) -> None:
         self.store_spans(
             [

--- a/tests/sentry/search/eap/test_ourlogs.py
+++ b/tests/sentry/search/eap/test_ourlogs.py
@@ -51,6 +51,17 @@ class SearchResolverQueryTest(TestCase):
         )
         assert having is None
 
+    def test_level_alias_query(self) -> None:
+        where, having, _ = self.resolver.resolve_query("level:error")
+        assert where == TraceItemFilter(
+            comparison_filter=ComparisonFilter(
+                key=AttributeKey(name="sentry.severity_text", type=AttributeKey.Type.TYPE_STRING),
+                op=ComparisonFilter.OP_EQUALS,
+                value=AttributeValue(val_str="error"),
+            )
+        )
+        assert having is None
+
     def test_negation(self) -> None:
         where, having, _ = self.resolver.resolve_query("!message:foo")
         assert where == TraceItemFilter(

--- a/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
@@ -64,6 +64,29 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase, 
         ]
         assert meta["dataset"] == self.dataset
 
+    def test_level_is_an_alias_for_severity(self) -> None:
+        logs = [
+            self.create_ourlog(
+                {"body": "foo", "severity_text": "error"},
+                timestamp=self.ten_mins_ago,
+            ),
+            self.create_ourlog(
+                {"body": "bar", "severity_text": "info"},
+                timestamp=self.nine_mins_ago,
+            ),
+        ]
+        self.store_eap_items(logs)
+        response = self.do_request(
+            {
+                "field": ["message", "level"],
+                "query": "level:error",
+                "project": self.project.id,
+                "dataset": self.dataset,
+            }
+        )
+        assert response.status_code == 200, response.content
+        assert response.data["data"] == [{"message": "foo", "level": "error"}]
+
     @pytest.mark.querybuilder
     def test_timestamp_order(self) -> None:
         logs = [

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -330,7 +330,7 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
                 "attributeSource": {
                     "source_type": "sentry",
                 },
-                "secondaryAliases": ["log.severity_text", "severity_text"],
+                "secondaryAliases": ["level", "log.severity_text", "severity_text"],
                 "attributeType": "string",
             },
         ]

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -203,6 +203,34 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
         assert "test.attribute2" in keys
         assert "severity" in keys
 
+    def test_user_sent_level_attribute_is_escaped(self) -> None:
+        logs = [
+            self.create_ourlog(
+                extra_data={"body": "log message", "severity_text": "info"},
+                organization=self.organization,
+                project=self.project,
+                attributes={"level": {"string_value": "CRITICAL-CUSTOM"}},
+            ),
+        ]
+        self.store_eap_items(logs)
+
+        response = self.do_request(query={"attributeType": "string"})
+
+        assert response.status_code == 200, response.content
+        by_key = {item["key"]: item for item in response.data}
+        assert by_key["tags[level,string]"] == {
+            "key": "tags[level,string]",
+            "name": "level",
+            "attributeSource": {"source_type": "user"},
+            "attributeType": "string",
+        }
+        assert "level" not in by_key
+        assert by_key["severity"]["secondaryAliases"] == [
+            "level",
+            "log.severity_text",
+            "severity_text",
+        ]
+
     def test_body_attribute(self) -> None:
         logs = [
             self.create_ourlog(


### PR DESCRIPTION
This registers `level` as a `secondary_alias=True` for `sentry.severity_text` on logs.

Note this is the same shadowing that already applies to `environment`, `release`, `origin`, `sdk.name` and friends, which are all `simple_sentry_field(...)` public aliases today.

Closes LOGS-219