### PR TITLE
style(performance): Rename trace waterfall AI tab

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -450,7 +450,7 @@ function Highlights({
                 },
               }}
             >
-              {t('Open in AI View')}
+              {t('Open Agent Timeline')}
             </OpenInAIFocusButton>
           )}
           {!hidePanelAndBreakdown && (

--- a/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.tsx
@@ -53,7 +53,7 @@ const TAB_DEFINITIONS: Record<TraceLayoutTabKeys, Tab> = {
   },
   [TraceLayoutTabKeys.AI_SPANS]: {
     slug: TraceLayoutTabKeys.AI_SPANS,
-    label: t('AI'),
+    label: t('Agent Timeline'),
   },
 };
 


### PR DESCRIPTION
The trace waterfall’s AI tab is now labeled “Agent Timeline”, and its action button is now labeled “Open Agent Timeline” to better describe the content it contains. This is a display-only copy change; the underlying tab key, routing, and analytics behavior remain unchanged.

Closes EXP-1087

Before:
<img width="401" height="53" alt="Screenshot 2026-07-31 at 13 07 50" src="https://github.com/user-attachments/assets/1909cf14-927d-4b08-82e5-3c79b933de2f" />

After:
<img width="483" height="59" alt="Screenshot 2026-07-31 at 13 07 36" src="https://github.com/user-attachments/assets/27ef9749-b95c-48dd-a589-a42cf7e17747" />
