### PR TITLE
feat(onboarding): Register onboarding-scm-messaging-experiment flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -181,6 +181,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:onboarding-scm", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Experiment: SCM onboarding A/B test measuring conversion impact
     manager.add("organizations:onboarding-scm-experiment", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Experiment: SCM onboarding messaging step A/B test (treatment adds a messaging/alerting step before SDK setup)
+    manager.add("organizations:onboarding-scm-messaging-experiment", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable SCM-first project creation flow
     manager.add("organizations:onboarding-scm-project-creation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Experiment: SCM-first project creation wizard A/B test (project creation flow, not new-org onboarding)


### PR DESCRIPTION
## TLDR

Registers `organizations:onboarding-scm-messaging-experiment`, the distinct nested experiment key that will gate the treatment-only SCM messaging step. No behavior changes: nothing reads the flag yet.

## Details

VDY-140 adds a fifth, treatment-only messaging step between platform/features and SDK setup. The approved design runs it as its own nested experiment rather than reusing the parent `onboarding-scm-experiment` or the retired Project Details experiment, so control stays a four-step flow while treatment sees five steps from entry. Registration lands on its own and first because frontend and backend are not atomically deployed, and because `FeatureManager.add` is what auto-registers the backing `feature.organizations:onboarding-scm-messaging-experiment` option with `FLAG_AUTOMATOR_MODIFIABLE` — the FlagPole config in sentry-options-automator has nothing to write against until this deploys. This is the exact inverse of the VDY-139 removal order (#120625 then #120626), where the frontend consumer had to be removed and deployed before the registration.

The technical reference proposed `onboarding-scm-messaging-step-experiment` as a working key and left the final choice to implementation. This uses `onboarding-scm-messaging-experiment` instead, matching the shape of all three sibling keys — `onboarding-scm-experiment`, `onboarding-scm-project-creation-experiment`, and the removed `onboarding-scm-project-details-experiment`. None of them carry a `-step-` infix, and the step is the only thing the experiment varies, so the segment carried no information.

`api_expose=True` is required: `getsentry`'s `get_experiment_assignments` filters to features that are both flagpole-backed and in `exposed_features`, and the frontend `useExperiment` override reads the resulting assignment out of `organization.experiments` to decide whether to report exposure. Without the exposure flag the hook would still return an assignment but would never fire an exposure event, silently producing an unmeasurable experiment.

Verified against a locally generated region ConfigMap rather than a hand-written fixture: the flag registers as flagpole/entity/exposed with an automator-modifiable option key, and the generated `us` config parsed through `flagpole.Feature` resolves to `active` for the targeted developer alias and `control` for an arbitrary new org. Exercised through `FlagpoleFeatureHandler.get_experiment_assignments` and the organization details endpoint, the assignment surfaces on `organization.experiments` under the un-prefixed key that `useExperiment` reads.

The accompanying FlagPole config (getsentry/sentry-options-automator#9012) is deliberately scoped to a single throwaway developer alias, with no GA segment and no org-slug targeting. The treatment step has no forward navigation until VDY-141 lands shared project and alert creation, so any wider audience would resolve to `active` and reach a step it cannot advance past. Nothing reads this flag yet regardless; the narrow config is what keeps that true once the consumer lands.

Refs VDY-140

