### PR TITLE
fix(seer): Preserve activity event timestamps

### DIFF
--- a/src/sentry/issues/action_log/publish.py
+++ b/src/sentry/issues/action_log/publish.py
@@ -10,6 +10,7 @@ from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
+from datetime import datetime
 from typing import TYPE_CHECKING, Optional, Sequence
 
 from sentry.hybridcloud.models.outbox import outbox_context
@@ -81,6 +82,7 @@ def publish_action(
     actor: GroupActionActor = SYSTEM_ACTOR,
     force_async_derived: bool = False,
     idempotency_key: str | None = None,
+    date_added: datetime | None = None,
 ) -> None:
     """
     Record an issue action.
@@ -94,6 +96,9 @@ def publish_action(
 
     If *idempotency_key* is set, the GroupActionLogEntry is created if and only if there
     does not already exist a GALE with that group id & idempotency key; else it's a no-op.
+
+    If *date_added* is set, it records when the action occurred instead of when the outbox
+    receiver processed it.
 
     Log publishing is managed by an outbox that flushes on commit by
     default. Wrap in ``outbox_context(flush=False)`` to defer the drain.
@@ -151,6 +156,8 @@ def publish_action(
 
     if idempotency_key is not None:
         payload["idempotency_key"] = idempotency_key
+    if date_added is not None:
+        payload["date_added"] = date_added.isoformat()
 
     outbox = CellOutbox(
         shard_scope=OutboxScope.GROUP_SCOPE,
@@ -171,6 +178,7 @@ def publish_action_from_context(
     project: Project,
     force_async_derived: bool = False,
     idempotency_key: Optional[str] = None,
+    date_added: datetime | None = None,
 ) -> None:
     """
     Record an issue action using the current ActionContext. This is the primary API
@@ -198,6 +206,7 @@ def publish_action_from_context(
         actor=actor,
         force_async_derived=force_async_derived,
         idempotency_key=idempotency_key,
+        date_added=date_added,
     )
 
 

--- a/src/sentry/issues/action_log/types.py
+++ b/src/sentry/issues/action_log/types.py
@@ -552,6 +552,7 @@ class GroupActionLogPayload(TypedDict):
     data: dict[str, Any]
     force_async_derived: bool
     idempotency_key: NotRequired[str]
+    date_added: NotRequired[str]
 
 
 class SetPublicAction(GroupAction):

--- a/src/sentry/models/activity.py
+++ b/src/sentry/models/activity.py
@@ -151,6 +151,7 @@ class ActivityManager(BaseManager["Activity"]):
                         group_id=group_id,
                         project=activity.project,
                         idempotency_key=activity_action_idempotency_key(activity),
+                        date_added=activity.datetime,
                     )
             except Exception:
                 _default_logger.info("Failed to translate activity %d to GALE", activity.id)

--- a/src/sentry/receivers/outbox/cell.py
+++ b/src/sentry/receivers/outbox/cell.py
@@ -10,10 +10,12 @@ from __future__ import annotations
 
 import json  # noqa: S003 - urllib3 raises stdlib JSONDecodeError, not simplejson's
 import logging
+from datetime import datetime
 from typing import Any, assert_never, cast
 
 from django.db import IntegrityError, router, transaction
 from django.dispatch import receiver
+from django.utils import timezone
 
 from sentry.audit_log.services.log import AuditLogEvent, UserIpEvent, log_rpc_service
 from sentry.auth.services.auth import auth_service
@@ -351,6 +353,7 @@ def process_group_action_log_event(payload: GroupActionLogPayload, **kwds: Any) 
 
         group_id = payload["group_id"]
         force_async_derived = payload["force_async_derived"]
+        date_added = payload.get("date_added")
 
         try:
             with transaction.atomic(using=using):
@@ -363,6 +366,9 @@ def process_group_action_log_event(payload: GroupActionLogPayload, **kwds: Any) 
                     source=payload["source"],
                     data=payload["data"],
                     idempotency_key=payload.get("idempotency_key"),
+                    date_added=(
+                        datetime.fromisoformat(date_added) if date_added else timezone.now()
+                    ),
                 )
         except IntegrityError:
             # Idempotency conflict; we treat this as a no-op.

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -8,6 +8,7 @@ from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 import sentry_sdk
+from django.utils import timezone
 from pydantic import BaseModel
 from rest_framework.exceptions import PermissionDenied
 from scm.types import GetBranchProtocol, GetRepositoryProtocol
@@ -490,6 +491,8 @@ def trigger_autofix_agent(
             insert_index=insert_index,
         )
 
+    activity_datetime = timezone.now().isoformat()
+
     # Emit the started event after run_id is resolved so it can be joined to
     # downstream completed/PR events.
     if config.started_event is not None:
@@ -523,6 +526,7 @@ def trigger_autofix_agent(
                 "event_type": sentry_app_event_type,
                 "event_payload": payload,
                 "organization_id": group.organization.id,
+                "activity_datetime": activity_datetime,
             }
             if is_iteration_step:
                 activity_attribution: SeerActivityAttribution = {

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -8,6 +8,7 @@ import orjson
 import sentry_sdk
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
+from django.utils import timezone
 from taskbroker_client.retry import Retry
 from urllib3 import BaseHTTPResponse
 from urllib3.connectionpool import HTTPConnectionPool
@@ -182,6 +183,7 @@ def _trigger_autofix_task(
         )
 
         run: SeerRun | None = None
+        triggered_at = timezone.now()
         try:
             run = trigger_autofix_agent(
                 group=group,
@@ -196,6 +198,7 @@ def _trigger_autofix_task(
                     ActivityType.TRIGGER_AUTOFIX,
                     data={"referrer": referrer.value},
                     send_notification=False,
+                    datetime=triggered_at,
                 )
         except NoSeerQuotaException:
             pass

--- a/src/sentry/seer/autofix/on_completion_hook.py
+++ b/src/sentry/seer/autofix/on_completion_hook.py
@@ -468,6 +468,7 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
                         "event_type": sentry_app_event_type,
                         "event_payload": webhook_payload,
                         "organization_id": organization.id,
+                        "activity_datetime": state.updated_at,
                     }
                 )
         except ValueError:

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -4,6 +4,7 @@ import logging
 import uuid
 from typing import Any
 
+from django.utils import timezone
 from drf_spectacular.utils import extend_schema
 from rest_framework import serializers, status
 from rest_framework.exceptions import PermissionDenied
@@ -409,6 +410,7 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                 run_id, sentry_run_id = resolved_run_id, resolved_sentry_run_id
 
             case _:
+                triggered_at = timezone.now() if is_autofix_kickoff else None
                 try:
                     run = trigger_autofix_agent(
                         group=group,
@@ -448,6 +450,7 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                             ),
                             data={"referrer": referrer.value},
                             send_notification=False,
+                            datetime=triggered_at,
                         )
                     sentry_run_id = str(run.uuid)
                 else:

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -1,5 +1,8 @@
 import logging
+from datetime import datetime
 from typing import Any, NotRequired, TypedDict
+
+from django.utils import timezone
 
 from sentry import features, options
 from sentry.constants import DataCategory
@@ -231,6 +234,7 @@ class SeerAutofixOperator[CachePayloadT]:
 
             try:
                 if not run_id:
+                    triggered_at = timezone.now()
                     with action_context_scope(ActionSource.SLACK, GroupActionActor.user(user.id)):
                         run = trigger_autofix_agent(
                             group=group,
@@ -246,6 +250,7 @@ class SeerAutofixOperator[CachePayloadT]:
                             user_id=user.id,
                             data={"referrer": AutofixReferrer.SLACK.value},
                             send_notification=False,
+                            datetime=triggered_at,
                         )
                 elif stopping_point == AutofixStoppingPoint.OPEN_PR:
                     trigger_push_changes(
@@ -594,6 +599,7 @@ def _create_seer_activity(
     event_type: SentryAppEventType,
     event_payload: dict[str, Any],
     activity_attribution: SeerActivityAttribution | None = None,
+    activity_datetime: datetime | None = None,
 ) -> None:
     activity_type = SEER_EVENT_TO_ACTIVITY_TYPE.get(event_type)
     if not activity_type:
@@ -641,6 +647,7 @@ def _create_seer_activity(
         user_id=actor_user_id,
         data=activity_data if activity_data else None,
         send_notification=False,
+        datetime=activity_datetime,
     )
 
 
@@ -656,6 +663,7 @@ def process_autofix_updates(
     event_payload: dict[str, Any],
     organization_id: int,
     activity_attribution: SeerActivityAttribution | None = None,
+    activity_datetime: str | None = None,
 ) -> None:
     """
     Use the registry to iterate over all entrypoints and check if this payload's run_id or group_id
@@ -716,7 +724,15 @@ def process_autofix_updates(
 
         try:
             with action_context_scope(action_source, action_actor):
-                _create_seer_activity(group, event_type, event_payload, iteration_attribution)
+                _create_seer_activity(
+                    group,
+                    event_type,
+                    event_payload,
+                    activity_attribution=iteration_attribution,
+                    activity_datetime=(
+                        datetime.fromisoformat(activity_datetime) if activity_datetime else None
+                    ),
+                )
         except Exception:
             logger.exception(
                 "seer.activity_creation_failed",

--- a/src/sentry/seer/night_shift/delivery.py
+++ b/src/sentry/seer/night_shift/delivery.py
@@ -8,6 +8,7 @@ from typing import Any
 from uuid import UUID
 
 import sentry_sdk
+from django.utils import timezone
 
 from sentry.constants import SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT, ObjectStatus
 from sentry.issues.action_log import SYSTEM_ACTOR, ActionSource, action_context_scope
@@ -221,6 +222,7 @@ def _process_verdicts(
                 if reason
                 else None
             )
+            triggered_at = timezone.now()
             try:
                 triggered_run = trigger_autofix_agent(
                     group=group,
@@ -243,6 +245,7 @@ def _process_verdicts(
                     ActivityType.TRIGGER_AUTOFIX,
                     data={"referrer": referrer.value},
                     send_notification=False,
+                    datetime=triggered_at,
                 )
 
         sentry_sdk.metrics.count("night_shift.autofix_triggered", len(run_by_group))

--- a/tests/sentry/models/test_activity.py
+++ b/tests/sentry/models/test_activity.py
@@ -4,8 +4,10 @@ from unittest.mock import MagicMock, patch
 
 from sentry.event_manager import EventManager
 from sentry.incidents.grouptype import MetricIssue
+from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
 from sentry.models.activity import Activity
 from sentry.testutils.cases import TestCase
+from sentry.testutils.outbox import outbox_runner
 from sentry.types.activity import ActivityType
 from sentry.types.group import PriorityLevel
 from sentry.utils.iterators import chunked
@@ -412,18 +414,20 @@ class ActivityTest(TestCase):
 
         custom_datetime = datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
 
-        activity = Activity.objects.create_group_activity(
-            group=group,
-            type=ActivityType.SET_RESOLVED,
-            user=user,
-            data={"reason": "test"},
-            send_notification=False,
-            datetime=custom_datetime,
-        )
+        with self.feature("projects:issue-action-log-write-to-db"), outbox_runner():
+            activity = Activity.objects.create_group_activity(
+                group=group,
+                type=ActivityType.SET_RESOLVED,
+                user=user,
+                data={"reason": "test"},
+                send_notification=False,
+                datetime=custom_datetime,
+            )
 
         assert activity.datetime == custom_datetime
         assert activity.type == ActivityType.SET_RESOLVED.value
         assert activity.user_id == user.id
+        assert GroupActionLogEntry.objects.get(group_id=group.id).date_added == custom_datetime
 
     def test_create_group_activity_without_custom_datetime(self) -> None:
         project = self.create_project(name="test_default_datetime")

--- a/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
+++ b/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
@@ -558,6 +558,10 @@ class TestAutofixOnCompletionHookWebhooks(TestCase):
         assert call_kwargs["payload"]["pull_requests"][0]["pull_request"]["pr_number"] == 7
         mock_process_autofix_updates.assert_called_once()
         assert (
+            mock_process_autofix_updates.call_args.kwargs["kwargs"]["activity_datetime"]
+            == state.updated_at
+        )
+        assert (
             mock_analytics.call_args.args[0].referrer
             == AutofixReferrer.GROUP_AUTOFIX_ENDPOINT.value
         )

--- a/tests/sentry/seer/entrypoints/test_operator.py
+++ b/tests/sentry/seer/entrypoints/test_operator.py
@@ -501,6 +501,7 @@ class SeerOperatorTest(TestCase):
 
     @patch.object(SeerAutofixOperator, "has_access", return_value=True)
     def test_seer_event_creates_activity_solution_completed(self, _mock_has_access):
+        activity_datetime = datetime.fromisoformat("2024-01-15T10:30:00+00:00")
         event_payload = {
             "run_id": MOCK_RUN_ID,
             "group_id": self.group.id,
@@ -514,6 +515,7 @@ class SeerOperatorTest(TestCase):
             event_type=SentryAppEventType.SEER_SOLUTION_COMPLETED,
             event_payload=event_payload,
             organization_id=self.organization.id,
+            activity_datetime=activity_datetime.isoformat(),
         )
 
         activity = Activity.objects.get(
@@ -523,6 +525,7 @@ class SeerOperatorTest(TestCase):
         assert activity.data["summary"] == "Test solution summary"
         assert "solution" not in activity.data
         assert "steps" not in activity.data
+        assert activity.datetime == activity_datetime
 
     @patch.object(SeerAutofixOperator, "has_access", return_value=True)
     def test_seer_event_creates_activity_coding_completed(self, _mock_has_access):


### PR DESCRIPTION
Seer issue activities were timestamped when async workers created their rows, so a completed step could appear after the next step had already started.

Record when each transition actually happens and carry that timestamp through both Activity and action log writes. Autofix trigger activities also keep the time captured before starting the run.