### PR TITLE
feat(derived data): Add metric to reliably capture project regen

### DIFF
--- a/src/sentry/issues/derived/tasks.py
+++ b/src/sentry/issues/derived/tasks.py
@@ -394,6 +394,12 @@ def generate_project_derived_data(
     if not group_ids:
         return
 
+    metrics.incr(
+        "issues.derived.generate_project_scheduled",
+        sample_rate=1.0,
+        tags={"stale_only": str(stale_only)},
+    )
+
     if len(group_ids) >= _MAX_PROJECT_GROUPS:
         logger.error(
             "generate_project_derived_data.too_many_groups",


### PR DESCRIPTION
I want a graph for "we generated a project"; the top-level task metric is sampled and thus a bit imprecise, the batch task metrics don't count projects. This also ignores no-work regens, which is arguable, but I think is fine.