### PR TITLE
chore(ACI): Remove workflow-engine-ui flag from create alert entry points

### DIFF
--- a/static/app/components/createAlertButton.spec.tsx
+++ b/static/app/components/createAlertButton.spec.tsx
@@ -38,7 +38,7 @@ describe('CreateAlertFromViewButton', () => {
         onClick={onClickMock}
       />
     );
-    await userEvent.click(screen.getByRole('button', {name: 'Create Alert'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Create Monitor'}));
     expect(onClickMock).toHaveBeenCalledTimes(1);
   });
 
@@ -70,7 +70,7 @@ describe('CreateAlertFromViewButton', () => {
       }
     );
 
-    expect(screen.getByRole('button', {name: 'Create Alert'})).toHaveAttribute(
+    expect(screen.getByRole('button', {name: 'Create Monitor'})).toHaveAttribute(
       'aria-disabled',
       'true'
     );
@@ -100,7 +100,7 @@ describe('CreateAlertFromViewButton', () => {
       }
     );
 
-    expect(screen.getByRole('button', {name: 'Create Alert'})).toBeEnabled();
+    expect(screen.getByRole('button', {name: 'Create Monitor'})).toBeEnabled();
   });
 
   it('enables the button for team-admin', () => {
@@ -139,12 +139,12 @@ describe('CreateAlertFromViewButton', () => {
       }
     );
 
-    expect(screen.getByRole('button', {name: 'Create Alert'})).toBeEnabled();
+    expect(screen.getByRole('button', {name: 'Create Monitor'})).toBeEnabled();
   });
 
-  it('redirects to alert wizard with no project', async () => {
+  it('redirects to monitor creation with no project', async () => {
     const {router} = render(
-      <CreateAlertButton aria-label="Create Alert" organization={organization} />,
+      <CreateAlertButton aria-label="Create Monitor" organization={organization} />,
       {
         organization,
         initialRouterConfig: {
@@ -158,16 +158,16 @@ describe('CreateAlertFromViewButton', () => {
     await userEvent.click(screen.getByRole('button'));
     expect(router.location).toEqual(
       expect.objectContaining({
-        pathname: '/organizations/org-slug/issues/alerts/wizard/',
+        pathname: '/organizations/org-slug/monitors/new/',
         query: {},
       })
     );
   });
 
-  it('redirects to alert wizard with a project', () => {
+  it('redirects to monitor creation with a project', () => {
     render(
       <CreateAlertButton
-        aria-label="Create Alert"
+        aria-label="Create Monitor"
         organization={organization}
         projectSlug="proj-slug"
       />,
@@ -178,7 +178,7 @@ describe('CreateAlertFromViewButton', () => {
 
     expect(screen.getByRole('button')).toHaveAttribute(
       'href',
-      '/organizations/org-slug/issues/alerts/wizard/?project=proj-slug'
+      '/organizations/org-slug/monitors/new/?project=proj-slug'
     );
   });
 
@@ -202,71 +202,12 @@ describe('CreateAlertFromViewButton', () => {
     await userEvent.click(screen.getByRole('button'));
     expect(router.location).toEqual(
       expect.objectContaining({
-        pathname: '/organizations/org-slug/issues/alerts/new/metric/',
+        pathname: '/organizations/org-slug/monitors/new/settings',
         query: expect.objectContaining({
+          detectorType: 'metric_issue',
           query: 'event.type:error ',
-          project: 'project-slug',
+          project: '2',
         }),
-      })
-    );
-  });
-
-  it('shows monitor label and link when workflow engine is enabled', () => {
-    const workflowOrg = OrganizationFixture({
-      ...organization,
-      features: ['workflow-engine-ui'],
-    });
-
-    render(<CreateAlertButton organization={workflowOrg} projectSlug="proj-slug" />, {
-      organization: workflowOrg,
-    });
-
-    const button = screen.getByRole('button', {name: 'Create Monitor'});
-    expect(button).toHaveTextContent('Create Monitor');
-    expect(button).toHaveAttribute(
-      'href',
-      '/organizations/org-slug/monitors/new/?project=proj-slug'
-    );
-  });
-
-  it('deep links to monitor creation from discover when workflow engine is enabled', async () => {
-    const workflowOrg = OrganizationFixture({
-      ...organization,
-      features: ['workflow-engine-ui'],
-    });
-    const projects = [
-      ProjectFixture({
-        id: '2',
-        slug: 'project-slug',
-      }),
-    ];
-    ProjectsStore.loadInitialData(projects);
-
-    const eventView = EventView.fromSavedQuery({
-      ...DEFAULT_EVENT_VIEW,
-      query: 'event.type:error',
-      projects: [2],
-    });
-    const {router} = render(
-      <CreateAlertFromViewButton
-        organization={workflowOrg}
-        eventView={eventView}
-        projects={projects}
-        onClick={onClickMock}
-      />,
-      {
-        organization: workflowOrg,
-      }
-    );
-
-    await userEvent.click(screen.getByRole('button', {name: 'Create Monitor'}));
-    expect(router.location.pathname).toBe(
-      '/organizations/org-slug/monitors/new/settings'
-    );
-    expect(router.location.query).toEqual(
-      expect.objectContaining({
-        project: '2',
-        detectorType: 'metric_issue',
       })
     );
   });

--- a/static/app/components/createAlertButton.tsx
+++ b/static/app/components/createAlertButton.tsx
@@ -17,8 +17,7 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useProjects} from 'sentry/utils/useProjects';
-import {makeAlertsPathname} from 'sentry/views/alerts/pathnames';
-import type {AlertType, AlertWizardAlertNames} from 'sentry/views/alerts/wizard/options';
+import type {AlertType} from 'sentry/views/alerts/wizard/options';
 import {
   AlertWizardRuleTemplates,
   DEFAULT_WIZARD_TEMPLATE,
@@ -35,11 +34,6 @@ type CreateAlertFromViewButtonProps = Omit<LinkButtonProps, 'aria-label' | 'to'>
   projects: Project[];
   alertType?: AlertType;
   className?: string;
-  /**
-   * Passed in value to override any metrics decision and switch back to transactions dataset.
-   * We currently do a few checks on metrics data on performance pages and this passes the decision onward to alerts.
-   */
-  disableMetricDataset?: boolean;
 
   /**
    * Called when the user is redirected to the alert builder
@@ -59,7 +53,6 @@ export function CreateAlertFromViewButton({
   referrer,
   onClick,
   alertType,
-  disableMetricDataset,
   ...buttonProps
 }: CreateAlertFromViewButtonProps) {
   const project = projects.find(p => p.id === `${eventView.project[0]}`);
@@ -76,49 +69,27 @@ export function CreateAlertFromViewButton({
       AlertWizardRuleTemplates[alertType]
     : DEFAULT_WIZARD_TEMPLATE;
 
-  const shouldDirectToMonitors = organization.features.includes('workflow-engine-ui');
-
-  const to = shouldDirectToMonitors
-    ? getMetricMonitorUrl({
-        project,
-        environment: queryParams.environment,
-        aggregate: queryParams.yAxis ?? alertTemplate.aggregate,
-        dataset: alertTemplate.dataset,
-        organization,
-        query: decodeScalar(queryParams.query),
-        referrer,
-        eventTypes: alertTemplate.eventTypes,
-      })
-    : {
-        pathname: makeAlertsPathname({
-          path: '/new/metric/',
-          organization,
-        }),
-        query: {
-          ...queryParams,
-          createFromDiscover: true,
-          disableMetricDataset,
-          referrer,
-          ...alertTemplate,
-          project: project?.slug,
-          aggregate: queryParams.yAxis ?? alertTemplate.aggregate,
-        },
-      };
+  const to = getMetricMonitorUrl({
+    project,
+    environment: queryParams.environment,
+    aggregate: queryParams.yAxis ?? alertTemplate.aggregate,
+    dataset: alertTemplate.dataset,
+    organization,
+    query: decodeScalar(queryParams.query),
+    referrer,
+    eventTypes: alertTemplate.eventTypes,
+  });
 
   const handleClick = () => {
     onClick?.();
   };
-
-  const createButtonLabel = shouldDirectToMonitors
-    ? t('Create Monitor')
-    : t('Create Alert');
 
   return (
     <CreateAlertButton
       organization={organization}
       onClick={handleClick}
       to={to}
-      aria-label={createButtonLabel}
+      aria-label={t('Create Monitor')}
       {...buttonProps}
     />
   );
@@ -126,7 +97,6 @@ export function CreateAlertFromViewButton({
 
 type CreateAlertButtonProps = {
   organization: Organization;
-  alertOption?: keyof typeof AlertWizardAlertNames;
   hideIcon?: boolean;
   iconProps?: SVGIconProps;
   /**
@@ -146,7 +116,6 @@ export function CreateAlertButton({
   iconProps,
   referrer,
   hideIcon,
-  alertOption,
   onEnter,
   to,
   ...buttonProps
@@ -154,10 +123,6 @@ export function CreateAlertButton({
   const navigate = useNavigate();
   const location = useLocation();
   const {projects} = useProjects();
-  const shouldDirectToMonitors = organization.features.includes('workflow-engine-ui');
-  const defaultButtonLabel = shouldDirectToMonitors
-    ? t('Create Monitor')
-    : t('Create Alert');
   const createAlertUrl = (providedProj: string): string => {
     const params = new URLSearchParams();
     if (referrer) {
@@ -166,20 +131,9 @@ export function CreateAlertButton({
     if (providedProj !== ':projectId') {
       params.append('project', providedProj);
     }
-    if (alertOption && !shouldDirectToMonitors) {
-      params.append('alert_option', alertOption);
-    }
     const queryString = params.toString();
-    if (shouldDirectToMonitors) {
-      const basePath = makeMonitorCreatePathname(organization.slug);
-      return queryString ? `${basePath}?${queryString}` : basePath;
-    }
-    return (
-      makeAlertsPathname({
-        path: '/wizard/',
-        organization,
-      }) + (queryString ? `?${queryString}` : '')
-    );
+    const basePath = makeMonitorCreatePathname(organization.slug);
+    return queryString ? `${basePath}?${queryString}` : basePath;
   };
 
   function handleClickWithoutProject(event: React.MouseEvent) {
@@ -215,7 +169,7 @@ export function CreateAlertButton({
       onClick={projectSlug ? onEnter : handleClickWithoutProject}
       {...buttonProps}
     >
-      {buttonProps.children ?? defaultButtonLabel}
+      {buttonProps.children ?? t('Create Monitor')}
     </LinkButton>
   );
 }

--- a/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
@@ -274,9 +274,7 @@ export function getMenuOptions(
     usesTimeSeriesData(widget.displayType) &&
     timeseriesResults?.length
   ) {
-    const newAlertLabel = organization.features.includes('workflow-engine-ui')
-      ? t('Create a Monitor for')
-      : t('Create an Alert for');
+    const newAlertLabel = t('Create a Monitor for');
 
     const alertMenuOptions = timeseriesResults
       .map((series, index) => {

--- a/static/app/views/explore/components/chartContextMenu.tsx
+++ b/static/app/views/explore/components/chartContextMenu.tsx
@@ -100,7 +100,7 @@ export function ChartContextMenu({
           organization,
           alertsUrls,
           submenu: true,
-          label: getCreateAlertForLabel(organization),
+          label: getCreateAlertForLabel(),
         })
       );
     }

--- a/static/app/views/explore/conversations/components/conversationsChart.spec.tsx
+++ b/static/app/views/explore/conversations/components/conversationsChart.spec.tsx
@@ -184,29 +184,19 @@ describe('ConversationsChart', () => {
     expect(screen.queryByRole('button', {name: 'Expand chart'})).not.toBeInTheDocument();
   });
 
-  it('links to the metric alert builder for the current visualization', async () => {
+  it('links to the metric monitor builder for the current visualization', async () => {
     render(<ConversationsChart />, {organization});
 
     await userEvent.click(screen.getByRole('button', {name: 'Chart actions'}));
 
-    const alertItem = await screen.findByRole('menuitemradio', {name: 'Create an Alert'});
+    const alertItem = await screen.findByRole('menuitemradio', {
+      name: 'Create a Monitor',
+    });
     const href = alertItem.getAttribute('href') ?? '';
-    expect(href).toContain('/alerts/new/metric/');
+    expect(href).toContain('/monitors/new/settings');
+    expect(href).toContain('detectorType=metric_issue');
     expect(href).toContain('aggregate=sum');
     expect(href).toContain('gen_ai.cost.total_tokens');
-    expect(href).toContain('dataset=events_analytics_platform');
-  });
-
-  it('shows "Create a Monitor" with the workflow-engine-ui feature', async () => {
-    render(<ConversationsChart />, {
-      organization: OrganizationFixture({features: ['workflow-engine-ui']}),
-    });
-
-    await userEvent.click(screen.getByRole('button', {name: 'Chart actions'}));
-
-    expect(
-      await screen.findByRole('menuitemradio', {name: 'Create a Monitor'})
-    ).toBeInTheDocument();
   });
 
   it('disables "Add to Dashboard" without the dashboards-edit feature', async () => {

--- a/static/app/views/explore/conversations/components/conversationsChart.tsx
+++ b/static/app/views/explore/conversations/components/conversationsChart.tsx
@@ -281,9 +281,7 @@ function ContextMenu({
 
     const disableAddToDashboard = !organization.features.includes('dashboards-edit');
 
-    const newAlertLabel = organization.features.includes('workflow-engine-ui')
-      ? t('Create a Monitor')
-      : t('Create an Alert');
+    const newAlertLabel = t('Create a Monitor');
 
     return [
       {

--- a/static/app/views/explore/errors/charts/chartContextMenu.spec.tsx
+++ b/static/app/views/explore/errors/charts/chartContextMenu.spec.tsx
@@ -5,20 +5,9 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {ChartContextMenu} from './chartContextMenu';
 
 describe('ChartContextMenu', () => {
-  it('shows "Create an Alert" by default', async () => {
+  it('shows "Create a Monitor"', async () => {
     render(<ChartContextMenu visible setVisible={jest.fn()} />, {
       organization: OrganizationFixture(),
-    });
-
-    await userEvent.click(screen.getByRole('button'));
-    expect(
-      screen.getByRole('menuitemradio', {name: 'Create an Alert'})
-    ).toBeInTheDocument();
-  });
-
-  it('shows "Create a Monitor" with workflow-engine-ui feature', async () => {
-    render(<ChartContextMenu visible setVisible={jest.fn()} />, {
-      organization: OrganizationFixture({features: ['workflow-engine-ui']}),
     });
 
     await userEvent.click(screen.getByRole('button'));

--- a/static/app/views/explore/errors/charts/chartContextMenu.tsx
+++ b/static/app/views/explore/errors/charts/chartContextMenu.tsx
@@ -17,9 +17,7 @@ export function ChartContextMenu({visible, setVisible}: ChartContextMenuProps) {
   const items: MenuItemProps[] = useMemo(() => {
     const menuItems = [];
 
-    const newAlertLabel = organization.features.includes('workflow-engine-ui')
-      ? t('Create a Monitor')
-      : t('Create an Alert');
+    const newAlertLabel = t('Create a Monitor');
 
     menuItems.push({
       key: 'create-alert',

--- a/static/app/views/explore/logs/useSaveAsItems.spec.tsx
+++ b/static/app/views/explore/logs/useSaveAsItems.spec.tsx
@@ -229,7 +229,7 @@ describe('useSaveAsItems', () => {
       | undefined;
 
     expect(alertItem?.disabled).toBe(true);
-    expect(alertItem?.tooltip).toBe('Alerts are not available on your current plan.');
+    expect(alertItem?.tooltip).toBe('Monitors are not available on your current plan.');
     expect(alertItem?.children).toEqual([]);
   });
 

--- a/static/app/views/explore/metrics/useSaveAsMetricItems.spec.tsx
+++ b/static/app/views/explore/metrics/useSaveAsMetricItems.spec.tsx
@@ -333,7 +333,7 @@ describe('useSaveAsMetricItems', () => {
       | undefined;
 
     expect(alertItem?.disabled).toBe(true);
-    expect(alertItem?.tooltip).toBe('Alerts are not available on your current plan.');
+    expect(alertItem?.tooltip).toBe('Monitors are not available on your current plan.');
     expect(alertItem?.children).toEqual([]);
   });
 

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -960,21 +960,20 @@ describe('ExploreToolbar', () => {
 
     await userEvent.click(within(section).getByRole('button', {name: /save as/i}));
     await userEvent.hover(
-      within(section).getByRole('menuitemradio', {name: 'Alert for'})
+      within(section).getByRole('menuitemradio', {name: 'Monitor for'})
     );
     await userEvent.click(
       await within(section).findByRole('menuitemradio', {name: 'count(spans)'})
     );
     expect(router.location.pathname).toBe(
-      '/organizations/org-slug/issues/alerts/new/metric/'
+      '/organizations/org-slug/monitors/new/settings'
     );
     expect(router.location.query).toEqual({
       aggregate: 'count(span.duration)',
-      dataset: 'events_analytics_platform',
-      interval: '1h',
-      project: 'proj-slug',
+      dataset: 'spans',
+      detectorType: 'metric_issue',
+      project: '1',
       query: '',
-      statsPeriod: '7d',
     });
   });
 
@@ -1003,7 +1002,7 @@ describe('ExploreToolbar', () => {
     await userEvent.click(within(section).getByRole('button', {name: /save as/i}));
 
     expect(
-      within(section).getByRole('menuitemradio', {name: 'Alert for'})
+      within(section).getByRole('menuitemradio', {name: 'Monitor for'})
     ).toHaveAttribute('aria-disabled', 'true');
   });
 

--- a/static/app/views/explore/utils/saveAsAlertMenuItem.spec.tsx
+++ b/static/app/views/explore/utils/saveAsAlertMenuItem.spec.tsx
@@ -13,16 +13,8 @@ describe('getMetricAlertsUpsellTooltip', () => {
     expect(getMetricAlertsUpsellTooltip(organization)).toBeUndefined();
   });
 
-  it('returns an alert upsell message when metric alerts are unavailable', () => {
+  it('returns a monitor upsell message when metric alerts are unavailable', () => {
     const organization = OrganizationFixture({features: []});
-
-    expect(getMetricAlertsUpsellTooltip(organization)).toBe(
-      'Alerts are not available on your current plan.'
-    );
-  });
-
-  it('returns a monitor upsell message when workflow engine is enabled', () => {
-    const organization = OrganizationFixture({features: ['workflow-engine-ui']});
 
     expect(getMetricAlertsUpsellTooltip(organization)).toBe(
       'Monitors are not available on your current plan.'
@@ -31,16 +23,8 @@ describe('getMetricAlertsUpsellTooltip', () => {
 });
 
 describe('getCreateAlertLabel', () => {
-  it('returns the alert label when workflow engine is disabled', () => {
-    const organization = OrganizationFixture({features: []});
-
-    expect(getCreateAlertLabel(organization)).toBe('Create an Alert');
-  });
-
-  it('returns the monitor label when workflow engine is enabled', () => {
-    const organization = OrganizationFixture({features: ['workflow-engine-ui']});
-
-    expect(getCreateAlertLabel(organization)).toBe('Create a Monitor');
+  it('returns the monitor label', () => {
+    expect(getCreateAlertLabel()).toBe('Create a Monitor');
   });
 });
 
@@ -54,7 +38,7 @@ describe('getSaveAsAlertMenuItem', () => {
 
     expect(item).toEqual(
       expect.objectContaining({
-        label: 'Alert for',
+        label: 'Monitor for',
         disabled: false,
         tooltip: undefined,
         children: alertsUrls,
@@ -70,7 +54,7 @@ describe('getSaveAsAlertMenuItem', () => {
     expect(item).toEqual(
       expect.objectContaining({
         disabled: true,
-        tooltip: 'Alerts are not available on your current plan.',
+        tooltip: 'Monitors are not available on your current plan.',
         children: [],
       })
     );
@@ -85,16 +69,6 @@ describe('getSaveAsAlertMenuItem', () => {
     expect(item.tooltip).toBeUndefined();
   });
 
-  it('uses the monitor label when workflow engine is enabled', () => {
-    const organization = OrganizationFixture({
-      features: ['incidents', 'workflow-engine-ui'],
-    });
-
-    const item = getSaveAsAlertMenuItem({organization, alertsUrls, submenu: true});
-
-    expect(item.label).toBe('Monitor for');
-  });
-
   it('uses the given label when one is provided', () => {
     const organization = OrganizationFixture({features: ['incidents']});
 
@@ -102,10 +76,10 @@ describe('getSaveAsAlertMenuItem', () => {
       organization,
       alertsUrls,
       submenu: true,
-      label: 'Create an Alert for',
+      label: 'Create a Monitor for',
     });
 
-    expect(item.label).toBe('Create an Alert for');
+    expect(item.label).toBe('Create a Monitor for');
   });
 
   it('returns an actionable item with no children when not a submenu', () => {
@@ -116,7 +90,7 @@ describe('getSaveAsAlertMenuItem', () => {
 
     expect(item).toEqual(
       expect.objectContaining({
-        label: 'Create an Alert',
+        label: 'Create a Monitor',
         disabled: false,
         tooltip: undefined,
         to: '/alert/',
@@ -136,7 +110,7 @@ describe('getSaveAsAlertMenuItem', () => {
     });
 
     expect(item.disabled).toBe(true);
-    expect(item.tooltip).toBe('Alerts are not available on your current plan.');
+    expect(item.tooltip).toBe('Monitors are not available on your current plan.');
   });
 
   it('is disabled when the caller disables it for an unrelated reason', () => {

--- a/static/app/views/explore/utils/saveAsAlertMenuItem.tsx
+++ b/static/app/views/explore/utils/saveAsAlertMenuItem.tsx
@@ -24,29 +24,21 @@ interface SaveAsAlertActionOptions extends SaveAsAlertMenuItemBaseOptions {
 
 type SaveAsAlertMenuItemOptions = SaveAsAlertSubmenuOptions | SaveAsAlertActionOptions;
 
-function isMonitorOrg(organization: Organization): boolean {
-  return organization.features.includes('workflow-engine-ui');
-}
-
 export function getMetricAlertsUpsellTooltip(
   organization: Organization
 ): string | undefined {
   if (hasMetricAlerts(organization)) {
     return undefined;
   }
-  return isMonitorOrg(organization)
-    ? t('Monitors are not available on your current plan.')
-    : t('Alerts are not available on your current plan.');
+  return t('Monitors are not available on your current plan.');
 }
 
-export function getCreateAlertLabel(organization: Organization): string {
-  return isMonitorOrg(organization) ? t('Create a Monitor') : t('Create an Alert');
+export function getCreateAlertLabel(): string {
+  return t('Create a Monitor');
 }
 
-export function getCreateAlertForLabel(organization: Organization): string {
-  return isMonitorOrg(organization)
-    ? t('Create a Monitor for')
-    : t('Create an Alert for');
+export function getCreateAlertForLabel(): string {
+  return t('Create a Monitor for');
 }
 
 export function getSaveAsAlertMenuItem(
@@ -58,8 +50,7 @@ export function getSaveAsAlertMenuItem(
 
   if (options.submenu) {
     const {alertsUrls} = options;
-    const label =
-      options.label ?? (isMonitorOrg(organization) ? t('Monitor for') : t('Alert for'));
+    const label = options.label ?? t('Monitor for');
 
     return {
       key: 'create-alert',
@@ -72,7 +63,7 @@ export function getSaveAsAlertMenuItem(
     };
   }
 
-  const label = getCreateAlertLabel(organization);
+  const label = getCreateAlertLabel();
 
   return {
     key: 'create-alert',

--- a/static/app/views/insights/common/components/chartActionDropdown.tsx
+++ b/static/app/views/insights/common/components/chartActionDropdown.tsx
@@ -172,9 +172,7 @@ export function BaseChartActionDropdown({
     menuOptions.push(menuOption);
   }
 
-  const newAlertLabel = organization.features.includes('workflow-engine-ui')
-    ? t('Create a Monitor for')
-    : t('Create an Alert for');
+  const newAlertLabel = t('Create a Monitor for');
 
   if (alertMenuOptions.length > 0) {
     menuOptions.push({

--- a/static/app/views/insights/common/utils/getAlertsUrl.spec.tsx
+++ b/static/app/views/insights/common/utils/getAlertsUrl.spec.tsx
@@ -21,7 +21,7 @@ describe('getAlertsUrl', () => {
       pageFilters,
     });
     expect(url).toBe(
-      '/organizations/orgSlug/issues/alerts/new/metric/?aggregate=avg%28d%3Aspans%2Fduration%40millisecond%29&dataset=generic_metrics&interval=1h&project=project-slug&query=span.category%3Adb&statsPeriod=7d'
+      '/organizations/orgSlug/monitors/new/settings?aggregate=avg%28d%3Aspans%2Fduration%40millisecond%29&dataset=transactions&detectorType=metric_issue&project=2&query=span.category%3Adb'
     );
   });
   it('should return a url to an EAP alert rule', () => {
@@ -37,7 +37,7 @@ describe('getAlertsUrl', () => {
       dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
     });
     expect(url).toBe(
-      '/organizations/orgSlug/issues/alerts/new/metric/?aggregate=count%28span.duration%29&dataset=events_analytics_platform&interval=1h&project=project-slug&query=span.op%3Ahttp.client&statsPeriod=7d'
+      '/organizations/orgSlug/monitors/new/settings?aggregate=count%28span.duration%29&dataset=spans&detectorType=metric_issue&project=2&query=span.op%3Ahttp.client'
     );
   });
 });

--- a/static/app/views/insights/common/utils/getAlertsUrl.tsx
+++ b/static/app/views/insights/common/utils/getAlertsUrl.tsx
@@ -3,7 +3,6 @@ import * as qs from 'query-string';
 import type {PageFilters} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
-import {makeAlertsPathname} from 'sentry/views/alerts/pathnames';
 import {Dataset, EventTypes} from 'sentry/views/alerts/rules/metric/types';
 import {getMetricMonitorUrl} from 'sentry/views/insights/common/utils/getMetricMonitorUrl';
 
@@ -14,7 +13,6 @@ export function getAlertsUrl({
   organization,
   pageFilters,
   name,
-  interval,
   dataset = Dataset.GENERIC_METRICS,
   eventTypes,
   referrer,
@@ -30,74 +28,17 @@ export function getAlertsUrl({
   query?: string;
   referrer?: string;
 }) {
-  const statsPeriod = getStatsPeriod(pageFilters);
   const environment = pageFilters.environments;
-  const supportedInterval = getInterval(interval);
-  const queryParams = {
+  const loc = getMetricMonitorUrl({
+    project,
+    environment,
     aggregate,
     dataset,
-    project: project?.slug,
-    eventTypes,
-    query,
-    statsPeriod,
-    environment,
+    organization,
     name,
-    interval: supportedInterval,
+    query,
     referrer,
-  };
-  // If workflow engine UI is enabled, deep-link to the new monitor flow instead
-  if (organization.features?.includes('workflow-engine-ui')) {
-    const loc = getMetricMonitorUrl({
-      project,
-      environment,
-      aggregate,
-      dataset,
-      organization,
-      name,
-      query,
-      referrer,
-      eventTypes,
-    });
-    return `${loc.pathname}?${qs.stringify(loc.query)}`;
-  }
-
-  return (
-    makeAlertsPathname({
-      path: '/new/metric/',
-      organization,
-    }) + `?${qs.stringify(queryParams)}`
-  );
-}
-
-// Alert rules only support 24h, 3d, 7d, 14d periods
-function getStatsPeriod(pageFilters: PageFilters) {
-  const {period} = pageFilters.datetime;
-  switch (period) {
-    case '24h':
-    case '3d':
-    case '7d':
-      return period;
-    case '1h':
-      return '24h'; // Explore allows 1h, but alerts only allows 24h minimum
-    default:
-      return '7d';
-  }
-}
-
-function getInterval(interval?: string) {
-  switch (interval) {
-    case '5m':
-    case '15m':
-    case '30m':
-    case '1h':
-    case '3h':
-    case '4h':
-    case '6h':
-    case '24h':
-      return interval;
-    case '1m':
-      return '5m'; // Explore allows 1m, but alerts only allows 5m minimum
-    default:
-      return '1h';
-  }
+    eventTypes,
+  });
+  return `${loc.pathname}?${qs.stringify(loc.query)}`;
 }

--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -215,9 +215,6 @@ export function TransactionHeader({
                   referrer="performance"
                   alertType="trans_duration"
                   aria-label={t('Create Alert')}
-                  disableMetricDataset={
-                    metricsCardinality?.outcome?.forceTransactionsOnly
-                  }
                 />
               ) : null
             }
@@ -290,7 +287,6 @@ export function TransactionHeader({
                 referrer="performance"
                 alertType="trans_duration"
                 aria-label={t('Create Alert')}
-                disableMetricDataset={metricsCardinality?.outcome?.forceTransactionsOnly}
               />
             ) : null
           }

--- a/static/app/views/projectDetail/projectLatestAlerts.spec.tsx
+++ b/static/app/views/projectDetail/projectLatestAlerts.spec.tsx
@@ -116,7 +116,7 @@ describe('ProjectDetail > ProjectLatestAlerts', () => {
 
     expect(await screen.findByRole('button', {name: 'Create Alert'})).toHaveAttribute(
       'href',
-      `/organizations/${organization.slug}/issues/alerts/wizard/?referrer=project_detail&project=project-slug`
+      `/organizations/${organization.slug}/monitors/new/?referrer=project_detail&project=project-slug`
     );
 
     expect(screen.getByRole('button', {name: 'Learn More'})).toHaveAttribute(


### PR DESCRIPTION
Another piece to removing the legacy alert UI - removing the flag from alert creation. 