### PR TITLE
docs: discourage `make test-selective`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ If a hook fails, fix the issues, stage changes, then re-run until it passes.
 
 #### Testing
 
-For backend-scoped changes, always try `make test-selective` first. It detects which tests are affected by your local diff and runs only those, making the feedback loop much faster. Fall back to `pytest` when you need to run a specific file or `test-selective` doesn't cover your case.
+For backend-scoped changes, prioritize running the individual relevant pytest files or nodeids locally. `make test-selective` is not optimized for routine local development, so use it only when it is useful for a particular investigation. If a PR's backend CI fails, inspect the `select-tests` job in `.github/workflows/backend.yml` and its selected-test output to identify the exact nodeids CI ran, then run those nodeids locally.
 
 ```bash
 # Run a specific test file.


### PR DESCRIPTION
locally running test-selective works but most of eng doesn't have gcloud setup and authed; "always try `make test-selective`" is tripping up agents

we'd need to rethink the current selective testing architecture as it's optimized for CI only, but in the meantime it's quite feasible to just:

- prioritize focused pytest files/nodeids locally
- if backend ci fails, simply reference ci `select-tests` for said nodeids
