### PR TITLE
fix(issue-stream): wait to hide actions until the the screen is as the small breakpoint

### DIFF
--- a/static/app/views/issueList/actions/index.tsx
+++ b/static/app/views/issueList/actions/index.tsx
@@ -189,7 +189,7 @@ export function IssueListActions({
     return uniqProjects.length === 1 ? uniqProjects[0] : undefined;
   }, [selectedIdsSet]);
   const theme = useTheme();
-  const disableActions = useMedia(`(width < ${theme.breakpoints.md})`);
+  const disableActions = useMedia(`(width < ${theme.breakpoints.sm})`);
   const area = useAnalyticsArea();
   const numIssues = selectedIdsSet.size;
 

--- a/static/app/views/issueList/groupListBody.tsx
+++ b/static/app/views/issueList/groupListBody.tsx
@@ -183,7 +183,7 @@ function GroupList({
   const theme = useTheme();
   const organization = useOrganization();
   const topIssue = groupIds[0];
-  const selectDisabled = useMedia(`(width < ${theme.breakpoints.md})`);
+  const selectDisabled = useMedia(`(width < ${theme.breakpoints.sm})`);
 
   const showProgress = withColumns.includes('progress');
 


### PR DESCRIPTION
The existing `md` breakpoint is too large and will hide the checkboxes when it is not necessary.