### PR TITLE
fix(dashboards): show an empty state for out-of-retention errors widgets

### DIFF
--- a/static/app/views/dashboards/utils/isQueryOutsideRetentionError.tsx
+++ b/static/app/views/dashboards/utils/isQueryOutsideRetentionError.tsx
@@ -1,0 +1,27 @@
+import {RequestError} from 'sentry/utils/requestError/requestError';
+
+/**
+ * Raised by the backend when the whole queried range predates the org's
+ * retention window. See `QueryOutsideRetentionError` in `src/sentry/utils/snuba.py`,
+ * surfaced as a 400 `ParseError` by `handle_query_errors` in `src/sentry/api/utils.py`.
+ *
+ * The response carries no error code, so the message is the only thing to match
+ * on. If it ever grows a `detail.code`, switch this over to that.
+ */
+const QUERY_OUTSIDE_RETENTION_DETAIL =
+  'Invalid date range. Please try a more recent date range.';
+
+/**
+ * Whether a failed widget query was rejected for querying outside of retention,
+ * as opposed to actually failing. Callers should treat this as an empty result
+ * rather than an error.
+ */
+export function isQueryOutsideRetentionError(error: unknown): boolean {
+  if (!(error instanceof RequestError) || error.status !== 400) {
+    return false;
+  }
+
+  const detail = error.responseJSON?.detail;
+
+  return typeof detail === 'string' && detail === QUERY_OUTSIDE_RETENTION_DETAIL;
+}

--- a/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
@@ -62,6 +62,11 @@ export type GenericWidgetQueriesResult = {
   dataScanned?: 'full' | 'partial';
   errorMessage?: string;
   heatmapResults?: HeatMapSeries;
+  /**
+   * The query was rejected for reaching outside of retention. Render an empty
+   * state rather than surfacing `errorMessage` as a failure.
+   */
+  isOutsideRetention?: boolean;
   isProgressivelyLoading?: boolean;
   isSampled?: boolean | null;
   pageLinks?: string;

--- a/static/app/views/dashboards/widgetCard/hooks/useErrorsWidgetQuery.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useErrorsWidgetQuery.spec.tsx
@@ -244,6 +244,49 @@ describe('useErrorsSeriesQuery', () => {
     });
     expect(mockRequest2).toHaveBeenCalled();
   });
+
+  it('flags a query rejected for reaching outside of retention', async () => {
+    const widget = WidgetFixture({displayType: DisplayType.LINE});
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      statusCode: 400,
+      body: {detail: 'Invalid date range. Please try a more recent date range.'},
+    });
+
+    const {result} = renderHookWithProviders(() =>
+      useErrorsSeriesQuery({widget, organization, pageFilters, enabled: true})
+    );
+
+    await waitFor(() => {
+      expect(result.current.isOutsideRetention).toBe(true);
+    });
+
+    // `errorMessage` has to stay set, otherwise `loading` never resolves
+    expect(result.current.errorMessage).toBeDefined();
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('does not flag other 400s as outside of retention', async () => {
+    const widget = WidgetFixture({displayType: DisplayType.LINE});
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      statusCode: 400,
+      body: {detail: 'Invalid query. Argument to function is wrong type.'},
+    });
+
+    const {result} = renderHookWithProviders(() =>
+      useErrorsSeriesQuery({widget, organization, pageFilters, enabled: true})
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.isOutsideRetention).toBe(false);
+    expect(result.current.errorMessage).toBeDefined();
+  });
 });
 
 describe('useErrorsTableQuery', () => {

--- a/static/app/views/dashboards/widgetCard/hooks/useErrorsWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useErrorsWidgetQuery.tsx
@@ -24,6 +24,7 @@ import {ErrorsConfig} from 'sentry/views/dashboards/datasetConfig/errors';
 import {getSeriesRequestData} from 'sentry/views/dashboards/datasetConfig/utils/getSeriesRequestData';
 import {eventViewFromWidget} from 'sentry/views/dashboards/utils';
 import {getSeriesQueryPrefix} from 'sentry/views/dashboards/utils/getSeriesQueryPrefix';
+import {isQueryOutsideRetentionError} from 'sentry/views/dashboards/utils/isQueryOutsideRetentionError';
 import {useWidgetQueryQueue} from 'sentry/views/dashboards/utils/widgetQueryQueue';
 import type {HookWidgetQueryResult} from 'sentry/views/dashboards/widgetCard/genericWidgetQueries';
 import {
@@ -129,13 +130,15 @@ export function useErrorsSeriesQuery(
   const transformedData = (() => {
     const isFetching = queryResults.some(q => q?.isFetching);
     const allHaveData = queryResults.every(q => q?.data);
-    const errorMessage = queryResults.find(q => q?.error)?.error?.message;
+    const error = queryResults.find(q => q?.error)?.error;
+    const errorMessage = error?.message;
 
     if (!allHaveData || isFetching) {
       const loading = isFetching || !errorMessage;
       return {
         loading,
         errorMessage,
+        isOutsideRetention: isQueryOutsideRetentionError(error),
         rawData: EMPTY_ARRAY,
       };
     }
@@ -287,13 +290,15 @@ export function useErrorsTableQuery(
   const transformedData = (() => {
     const isFetching = queryResults.some(q => q?.isFetching);
     const allHaveData = queryResults.every(q => q?.data?.json);
-    const errorMessage = queryResults.find(q => q?.error)?.error?.message;
+    const error = queryResults.find(q => q?.error)?.error;
+    const errorMessage = error?.message;
 
     if (!allHaveData || isFetching) {
       const loading = isFetching || !errorMessage;
       return {
         loading,
         errorMessage,
+        isOutsideRetention: isQueryOutsideRetentionError(error),
         rawData: EMPTY_ARRAY,
       };
     }

--- a/static/app/views/dashboards/widgetCard/index.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/index.spec.tsx
@@ -800,4 +800,73 @@ describe('Dashboards > WidgetCard', () => {
       expect(screen.queryByLabelText('Widget warnings')).not.toBeInTheDocument();
     });
   });
+
+  describe('queries outside of retention', () => {
+    const outsideRetentionResponse = {
+      statusCode: 400,
+      body: {detail: 'Invalid date range. Please try a more recent date range.'},
+    };
+
+    const renderErrorsWidget = (displayType: DisplayType) =>
+      renderWithProviders(
+        <WidgetCard
+          api={api}
+          widget={{
+            ...multipleQueryWidget,
+            displayType,
+            queries: [multipleQueryWidget.queries[0]!],
+          }}
+          selection={selection}
+          onDelete={() => {}}
+          onEdit={() => {}}
+          onDuplicate={() => {}}
+          showContextMenu
+          widgetLimitReached={false}
+          widgetLegendState={widgetLegendState}
+        />
+      );
+
+    it('renders an empty state instead of an error for a timeseries widget', async () => {
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/events-stats/',
+        ...outsideRetentionResponse,
+      });
+
+      renderErrorsWidget(DisplayType.LINE);
+
+      expect(await screen.findByText('No data to plot.')).toBeInTheDocument();
+      expect(
+        screen.getByText('Events from this date range are outside your retention period.')
+      ).toBeInTheDocument();
+      expect(screen.queryByText('Try adjusting the filters.')).not.toBeInTheDocument();
+    });
+
+    it('renders an empty state instead of an error for a table widget', async () => {
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/events/',
+        ...outsideRetentionResponse,
+      });
+
+      renderErrorsWidget(DisplayType.TABLE);
+
+      expect(await screen.findByText('No data to plot.')).toBeInTheDocument();
+      expect(
+        screen.getByText('Events from this date range are outside your retention period.')
+      ).toBeInTheDocument();
+    });
+
+    it('still renders an error for other failures', async () => {
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/events-stats/',
+        statusCode: 400,
+        body: {detail: 'Invalid query. Argument to function is wrong type.'},
+      });
+
+      renderErrorsWidget(DisplayType.LINE);
+
+      await waitFor(() => {
+        expect(screen.queryByText('No data to plot.')).not.toBeInTheDocument();
+      });
+    });
+  });
 });

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -37,6 +37,7 @@ import type {
   TimeSeries,
   TimeSeriesGroupBy,
 } from 'sentry/views/dashboards/widgets/common/types';
+import {OUTSIDE_RETENTION_DESCRIPTION} from 'sentry/views/dashboards/widgets/common/widgetNoDataPanel';
 import {plottablesCanBeVisualized} from 'sentry/views/dashboards/widgets/plottablesCanBeVisualized';
 import {formatBreakdownLegendValue} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatBreakdownLegendValue';
 import {createPlottableFromTimeSeriesAndWidget} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/createPlottableFromTimeSeries';
@@ -138,13 +139,14 @@ export function VisualizationWidget({
         timeseriesResultsUnits,
         tableResults,
         errorMessage,
+        isOutsideRetention,
         loading,
         confidence,
         dataScanned,
         isSampled,
         sampleCount,
       }) => {
-        if (errorMessage && onWidgetError) {
+        if (errorMessage && !isOutsideRetention && onWidgetError) {
           onWidgetError(widget, errorMessage);
         }
 
@@ -156,6 +158,7 @@ export function VisualizationWidget({
             timeseriesResultsUnits={timeseriesResultsUnits}
             tableResults={tableResults}
             errorMessage={errorMessage}
+            isOutsideRetention={isOutsideRetention}
             loading={loading}
             releases={releases}
             showReleaseAs={showReleaseAs}
@@ -187,6 +190,7 @@ interface VisualizationWidgetContentProps {
   dataScanned?: 'full' | 'partial';
   errorMessage?: string;
   isFullScreen?: boolean;
+  isOutsideRetention?: boolean;
   isSampled?: boolean | null;
   legendSelection?: LegendSelection;
   onLegendSelectionChange?: (selection: LegendSelection) => void;
@@ -205,6 +209,7 @@ function VisualizationWidgetContent({
   timeseriesResultsUnits,
   tableResults,
   errorMessage,
+  isOutsideRetention,
   loading,
   releases,
   showReleaseAs,
@@ -387,6 +392,14 @@ function VisualizationWidgetContent({
 
   if (loading) {
     return <TimeSeriesWidgetVisualization.LoadingPlaceholder />;
+  }
+
+  // The range predates retention, so there is genuinely nothing to plot. Check
+  // this before `errorMessage`, which is set for this case too.
+  if (isOutsideRetention) {
+    return (
+      <TimeSeriesWidgetVisualization.NoData description={OUTSIDE_RETENTION_DESCRIPTION} />
+    );
   }
 
   if (errorMessage) {

--- a/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
@@ -28,6 +28,10 @@ import type {
   HeatMapSeries,
   TabularColumn,
 } from 'sentry/views/dashboards/widgets/common/types';
+import {
+  OUTSIDE_RETENTION_DESCRIPTION,
+  WidgetNoDataPanel,
+} from 'sentry/views/dashboards/widgets/common/widgetNoDataPanel';
 import {HEATMAP_RESIZE_DEBOUNCE_MS} from 'sentry/views/dashboards/widgets/heatMapWidget/settings';
 import {calculateHeatMapBucketDimensions} from 'sentry/views/dashboards/widgets/heatMapWidget/utils/calculateHeatMapBucketDimensions';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
@@ -161,6 +165,7 @@ export function WidgetCardChartContainer({
         timeseriesResults,
         heatmapResults,
         errorMessage,
+        isOutsideRetention,
         loading,
         timeseriesResultsTypes,
         timeseriesResultsUnits,
@@ -172,6 +177,12 @@ export function WidgetCardChartContainer({
         // Bind timeseries to widget for ability to control each widget's legend individually
         const modifiedTimeseriesResults =
           WidgetLegendNameEncoderDecoder.modifyTimeseriesNames(widget, timeseriesResults);
+
+        // The range predates retention, so there is genuinely nothing to show.
+        // Check this before the error message, which is set for this case too.
+        if (!loading && isOutsideRetention) {
+          return <WidgetNoDataPanel description={OUTSIDE_RETENTION_DESCRIPTION} />;
+        }
 
         const errorOrEmptyMessage = loading
           ? errorMessage

--- a/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
@@ -25,6 +25,7 @@ type Results = {
   dataScanned?: 'full' | 'partial';
   errorMessage?: string;
   heatmapResults?: HeatMapSeries;
+  isOutsideRetention?: boolean;
   isProgressivelyLoading?: boolean;
   isSampled?: boolean | null;
   pageLinks?: string;
@@ -210,6 +211,7 @@ export function WidgetCardDataLoader({
         tableResults,
         timeseriesResults,
         errorMessage,
+        isOutsideRetention,
         loading,
         timeseriesResultsTypes,
         timeseriesResultsUnits,
@@ -220,6 +222,7 @@ export function WidgetCardDataLoader({
             tableResults,
             timeseriesResults,
             errorMessage,
+            isOutsideRetention,
             loading,
             timeseriesResultsTypes,
             timeseriesResultsUnits,

--- a/static/app/views/dashboards/widgets/common/widgetNoDataPanel.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetNoDataPanel.tsx
@@ -2,11 +2,23 @@ import {EmptyState} from '@sentry/scraps/emptyState';
 
 import {t} from 'sentry/locale';
 
-export function WidgetNoDataPanel() {
+/**
+ * Shown when a widget's query reached outside of retention. The data is gone
+ * rather than missing, so the default "adjust the filters" hint doesn't apply.
+ */
+export const OUTSIDE_RETENTION_DESCRIPTION = t(
+  'Events from this date range are outside your retention period.'
+);
+
+interface WidgetNoDataPanelProps {
+  description?: string;
+}
+
+export function WidgetNoDataPanel({description}: WidgetNoDataPanelProps = {}) {
   return (
     <EmptyState
       title={t('No data to plot.')}
-      description={t('Try adjusting the filters.')}
+      description={description ?? t('Try adjusting the filters.')}
     />
   );
 }


### PR DESCRIPTION
An errors widget queried over a date range that predates the org's retention window gets a 400 (`{"detail": "Invalid date range. Please try a more recent date range."}`) and renders an error panel. The data is gone rather than missing, so it should read as an empty state.

The message it showed wasn't even the backend's. `useErrorsWidgetQuery` reads `error.message`, which `RequestError` builds as `` `${method} ${path} ${status}` `` — so the widget displayed *"GET /organizations/…/events-stats/ 400"*.

## Changes

- `isQueryOutsideRetentionError` matches the 400 + `detail` string. The response carries no error code, so the message is the only signal; it's isolated in one helper so it can be swapped for a `detail.code` check if the backend ever grows one.
- Detection happens in the query hook, where the raw `RequestError` is still available — the type boundary flattens to `errorMessage?: string` before any render layer sees it. A separate `isOutsideRetention` flag carries it through. `errorMessage` deliberately stays set, since `loading` is derived from it (`loading = isFetching || !errorMessage`) and clearing it would leave the widget spinning.
- Both render pipelines handle it, since errors widgets can be either: `VisualizationWidget` (line/area/bar/top-n) and `WidgetCardChartContainer` (table/big number/categorical bar). Both also skip reporting it to the Seer widget-error callback.
- `WidgetNoDataPanel` takes an optional `description`, defaulting to today's copy. The default "Try adjusting the filters." is wrong here — only moving the date range helps.

Frontend only.

## Scope

Errors dataset only. Transactions, discover, issues and releases raise the same 400 and would need the same treatment. EAP-backed datasets (spans, logs, trace metrics) never raise it — they return 200 with empty data.

Related to #120974, which makes this more visible: dashboards containing span widgets can select ranges beyond 90 days, and errors widgets on those dashboards then 400.