### PR TITLE
feat(onboarding): Add SCM messaging treatment route

### DIFF
--- a/static/app/components/onboarding/onboardingContext.spec.tsx
+++ b/static/app/components/onboarding/onboardingContext.spec.tsx
@@ -8,6 +8,7 @@ import {
   OnboardingContextProvider,
   useOnboardingContext,
 } from 'sentry/components/onboarding/onboardingContext';
+import type {ScmMessagingSetup} from 'sentry/components/onboarding/scm/scmMessagingSetup';
 
 const platform = {
   key: 'javascript-nextjs' as const,
@@ -17,6 +18,13 @@ const platform = {
   link: null,
   category: 'browser' as const,
 };
+
+const selectedMessagingSetup = {
+  mode: 'selected',
+  providerKey: 'slack',
+  integrationId: '15',
+  channelId: 'C123',
+} as const satisfies ScmMessagingSetup;
 
 function StateConsumer() {
   const {
@@ -108,12 +116,7 @@ describe('OnboardingContextProvider', () => {
           selectedRepository: RepositoryFixture({id: '42'}),
           selectedPlatform: platform,
           selectedFeatures: [ProductSolution.ERROR_MONITORING],
-          messagingSetup: {
-            mode: 'selected',
-            providerKey: 'slack',
-            integrationId: '15',
-            channelId: 'C123',
-          },
+          messagingSetup: selectedMessagingSetup,
         }}
       >
         <StateConsumer />
@@ -168,12 +171,7 @@ describe('OnboardingContextProvider session semantics', () => {
         initialValue={{
           selectedRepository: RepositoryFixture({id: '42'}),
           selectedPlatform: platform,
-          messagingSetup: {
-            mode: 'selected',
-            providerKey: 'slack',
-            integrationId: '15',
-            channelId: 'C123',
-          },
+          messagingSetup: selectedMessagingSetup,
         }}
       >
         <StateConsumer />
@@ -191,12 +189,7 @@ describe('OnboardingContextProvider session semantics', () => {
     expect(screen.getByText('messaging:selected')).toBeInTheDocument();
     expect(JSON.parse(sessionStorage.getItem('onboarding') ?? '{}')).toMatchObject({
       selectedRepository: {id: '42'},
-      messagingSetup: {
-        mode: 'selected',
-        providerKey: 'slack',
-        integrationId: '15',
-        channelId: 'C123',
-      },
+      messagingSetup: selectedMessagingSetup,
     });
   });
 

--- a/static/app/components/onboarding/onboardingContext.spec.tsx
+++ b/static/app/components/onboarding/onboardingContext.spec.tsx
@@ -19,6 +19,7 @@ const platform = {
 
 function StateConsumer() {
   const {
+    messagingSetup,
     selectedRepository,
     selectedPlatform,
     selectedFeatures,
@@ -32,6 +33,7 @@ function StateConsumer() {
       <div>
         {selectedFeatures ? `features:${selectedFeatures.length}` : 'no-features'}
       </div>
+      <div>{`messaging:${messagingSetup.mode}`}</div>
       <button onClick={() => setSelectedPlatform(undefined)}>Clear platform</button>
       <button onClick={() => resetOnboarding()}>Reset onboarding</button>
     </div>
@@ -62,6 +64,7 @@ describe('OnboardingContextProvider', () => {
     expect(await screen.findByText('no-repo')).toBeInTheDocument();
     expect(screen.getByText('no-platform')).toBeInTheDocument();
     expect(screen.getByText('no-features')).toBeInTheDocument();
+    expect(screen.getByText('messaging:unconfigured')).toBeInTheDocument();
   });
 
   it('keeps a resolved repository and its derived state on load', () => {
@@ -71,6 +74,12 @@ describe('OnboardingContextProvider', () => {
           selectedRepository: RepositoryFixture({id: '42'}),
           selectedPlatform: platform,
           selectedFeatures: [ProductSolution.ERROR_MONITORING],
+          messagingSetup: {
+            mode: 'selected',
+            providerKey: 'slack',
+            integrationId: '15',
+            channelId: 'C123',
+          },
         }}
       >
         <StateConsumer />
@@ -80,6 +89,37 @@ describe('OnboardingContextProvider', () => {
     expect(screen.getByText('repo:42')).toBeInTheDocument();
     expect(screen.getByText('platform:javascript-nextjs')).toBeInTheDocument();
     expect(screen.getByText('features:1')).toBeInTheDocument();
+    expect(screen.getByText('messaging:selected')).toBeInTheDocument();
+  });
+
+  it('restores messaging setup from session storage after a remount', () => {
+    sessionStorage.setItem(
+      'onboarding',
+      JSON.stringify({
+        messagingSetup: {
+          mode: 'selected',
+          providerKey: 'discord',
+          integrationId: '20',
+          channelId: '123456789',
+        },
+      })
+    );
+
+    const firstRender = render(
+      <OnboardingContextProvider>
+        <StateConsumer />
+      </OnboardingContextProvider>
+    );
+    expect(screen.getByText('messaging:selected')).toBeInTheDocument();
+
+    firstRender.unmount();
+    render(
+      <OnboardingContextProvider>
+        <StateConsumer />
+      </OnboardingContextProvider>
+    );
+
+    expect(screen.getByText('messaging:selected')).toBeInTheDocument();
   });
 });
 
@@ -94,6 +134,12 @@ describe('OnboardingContextProvider session semantics', () => {
         initialValue={{
           selectedRepository: RepositoryFixture({id: '42'}),
           selectedPlatform: platform,
+          messagingSetup: {
+            mode: 'selected',
+            providerKey: 'slack',
+            integrationId: '15',
+            channelId: 'C123',
+          },
         }}
       >
         <StateConsumer />
@@ -103,12 +149,20 @@ describe('OnboardingContextProvider session semantics', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Clear platform'}));
 
     // Clearing one field must stay local to that field. This previously routed
-    // through removeOnboarding and wiped the whole session, taking the
-    // connected repository with it.
+    // through removeOnboarding and wiped the whole session, taking the connected
+    // repository with it. Messaging destinations are organization-scoped, so they
+    // must survive a platform change too.
     expect(screen.getByText('no-platform')).toBeInTheDocument();
     expect(screen.getByText('repo:42')).toBeInTheDocument();
+    expect(screen.getByText('messaging:selected')).toBeInTheDocument();
     expect(JSON.parse(sessionStorage.getItem('onboarding') ?? '{}')).toMatchObject({
       selectedRepository: {id: '42'},
+      messagingSetup: {
+        mode: 'selected',
+        providerKey: 'slack',
+        integrationId: '15',
+        channelId: 'C123',
+      },
     });
   });
 

--- a/static/app/components/onboarding/onboardingContext.spec.tsx
+++ b/static/app/components/onboarding/onboardingContext.spec.tsx
@@ -1,3 +1,4 @@
+import {useState} from 'react';
 import {RepositoryFixture} from 'sentry-fixture/repository';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
@@ -37,6 +38,39 @@ function StateConsumer() {
       <button onClick={() => setSelectedPlatform(undefined)}>Clear platform</button>
       <button onClick={() => resetOnboarding()}>Reset onboarding</button>
     </div>
+  );
+}
+
+function ExitConsumer({onExit}: {onExit: () => void}) {
+  const {discardOnboardingSession} = useOnboardingContext();
+  return (
+    <button
+      onClick={() => {
+        discardOnboardingSession();
+        onExit();
+      }}
+    >
+      Leave flow
+    </button>
+  );
+}
+
+/**
+ * Mirrors leaving the onboarding flow: one click both clears the session and
+ * unmounts the provider, giving React no render in which to process a pending
+ * state update.
+ */
+function ExitFlowHarness() {
+  const [inFlow, setInFlow] = useState(true);
+
+  if (!inFlow) {
+    return <div>left the flow</div>;
+  }
+
+  return (
+    <OnboardingContextProvider>
+      <ExitConsumer onExit={() => setInFlow(false)} />
+    </OnboardingContextProvider>
   );
 }
 
@@ -190,6 +224,31 @@ describe('OnboardingContextProvider session semantics', () => {
 
     expect(screen.getByText('no-platform')).toBeInTheDocument();
     expect(screen.getByText('no-repo')).toBeInTheDocument();
+    expect(sessionStorage.getItem('onboarding')).toBeNull();
+  });
+
+  it('clears persisted session state when the provider unmounts in the same commit', async () => {
+    // Leaving the flow clears the session and navigates away in one click, so
+    // the provider unmounts in that same commit. resetOnboarding cannot be used
+    // for this: useSessionStorage's removeItem performs the storage removal
+    // inside a setState updater, and React drops the update — and the removal
+    // with it — when the owning subtree unmounts before the queue is processed.
+    // Verified in a browser: skipping from scm-platform-features and
+    // scm-messaging left the session behind, so the next /onboarding visit
+    // silently resumed from it.
+    sessionStorage.setItem(
+      'onboarding',
+      JSON.stringify({
+        selectedRepository: RepositoryFixture({id: '42'}),
+        selectedPlatform: platform,
+      })
+    );
+
+    render(<ExitFlowHarness />);
+
+    await userEvent.click(screen.getByRole('button', {name: 'Leave flow'}));
+
+    expect(screen.getByText('left the flow')).toBeInTheDocument();
     expect(sessionStorage.getItem('onboarding')).toBeNull();
   });
 });

--- a/static/app/components/onboarding/onboardingContext.tsx
+++ b/static/app/components/onboarding/onboardingContext.tsx
@@ -7,10 +7,11 @@ import {
 } from 'sentry/components/onboarding/scm/scmMessagingSetup';
 import type {Integration, Repository} from 'sentry/types/integrations';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
-import {useSessionStorage} from 'sentry/utils/useSessionStorage';
+import {removeStorageValue, useSessionStorage} from 'sentry/utils/useSessionStorage';
 
 type OnboardingContextProps = {
   clearDerivedState: () => void;
+  discardOnboardingSession: () => void;
   messagingSetup: ScmMessagingSetup;
   resetOnboarding: () => void;
   setCreatedProjectSlug: (slug?: string) => void;
@@ -25,6 +26,8 @@ type OnboardingContextProps = {
   selectedPlatform?: OnboardingSelectedSDK;
   selectedRepository?: Repository;
 };
+
+const ONBOARDING_SESSION_KEY = 'onboarding';
 
 type OnboardingSessionState = {
   createdProjectSlug?: string;
@@ -53,6 +56,7 @@ const OnboardingContext = createContext<OnboardingContextProps>({
   setMessagingSetup: () => {},
   clearDerivedState: () => {},
   resetOnboarding: () => {},
+  discardOnboardingSession: () => {},
 });
 
 type ProviderProps = {
@@ -66,7 +70,7 @@ type ProviderProps = {
 
 export function OnboardingContextProvider({children, initialValue}: ProviderProps) {
   const [onboarding, setOnboarding, removeOnboarding] = useSessionStorage(
-    'onboarding',
+    ONBOARDING_SESSION_KEY,
     initialValue
   );
 
@@ -133,6 +137,19 @@ export function OnboardingContextProvider({children, initialValue}: ProviderProp
       // a selected-platform reset for this: messaging setup is organization-
       // scoped and must survive local repository/platform changes.
       resetOnboarding: removeOnboarding,
+      // Drop the persisted session on the way out of the flow. Do not use
+      // resetOnboarding here: it goes through useSessionStorage's removeItem,
+      // which performs the removeStorageValue call inside a setState updater.
+      // React only runs an updater when it processes the queue during a render,
+      // so when leaving the flow — where the same click both clears state and
+      // navigates away — the provider unmounts first and the update, along with
+      // its storage write, is discarded. The session then survives and the next
+      // /onboarding visit silently resumes from it. Clearing storage directly
+      // does not depend on a render happening. The in-memory state needs no
+      // reset because the context unmounts with the flow.
+      discardOnboardingSession: () => {
+        removeStorageValue(ONBOARDING_SESSION_KEY);
+      },
     }),
     [onboarding, setOnboarding, removeOnboarding]
   );

--- a/static/app/components/onboarding/onboardingContext.tsx
+++ b/static/app/components/onboarding/onboardingContext.tsx
@@ -1,14 +1,20 @@
 import {createContext, useContext, useEffect, useMemo, useRef} from 'react';
 
 import type {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {
+  type ScmMessagingSetup,
+  UNCONFIGURED_SCM_MESSAGING_SETUP,
+} from 'sentry/components/onboarding/scm/scmMessagingSetup';
 import type {Integration, Repository} from 'sentry/types/integrations';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import {useSessionStorage} from 'sentry/utils/useSessionStorage';
 
 type OnboardingContextProps = {
   clearDerivedState: () => void;
+  messagingSetup: ScmMessagingSetup;
   resetOnboarding: () => void;
   setCreatedProjectSlug: (slug?: string) => void;
+  setMessagingSetup: (messagingSetup: ScmMessagingSetup) => void;
   setSelectedFeatures: (features?: ProductSolution[]) => void;
   setSelectedIntegration: (integration?: Integration) => void;
   setSelectedPlatform: (selectedSDK?: OnboardingSelectedSDK) => void;
@@ -22,6 +28,7 @@ type OnboardingContextProps = {
 
 type OnboardingSessionState = {
   createdProjectSlug?: string;
+  messagingSetup?: ScmMessagingSetup;
   selectedFeatures?: ProductSolution[];
   selectedIntegration?: Integration;
   selectedPlatform?: OnboardingSelectedSDK;
@@ -42,6 +49,8 @@ const OnboardingContext = createContext<OnboardingContextProps>({
   setSelectedFeatures: () => {},
   createdProjectSlug: undefined,
   setCreatedProjectSlug: () => {},
+  messagingSetup: UNCONFIGURED_SCM_MESSAGING_SETUP,
+  setMessagingSetup: () => {},
   clearDerivedState: () => {},
   resetOnboarding: () => {},
 });
@@ -105,6 +114,10 @@ export function OnboardingContextProvider({children, initialValue}: ProviderProp
       setCreatedProjectSlug: (createdProjectSlug?: string) => {
         setOnboarding(prev => ({...prev, createdProjectSlug}));
       },
+      messagingSetup: onboarding?.messagingSetup ?? UNCONFIGURED_SCM_MESSAGING_SETUP,
+      setMessagingSetup: (messagingSetup: ScmMessagingSetup) => {
+        setOnboarding(prev => ({...prev, messagingSetup}));
+      },
       // Clear state derived from the selected repository (platform, features,
       // created project) without wiping the entire session. Use this when the
       // repo changes so downstream steps start fresh.
@@ -116,10 +129,9 @@ export function OnboardingContextProvider({children, initialValue}: ProviderProp
           createdProjectSlug: undefined,
         }));
       },
-      // Full-flow exits should clear every staged choice explicitly. Do not
-      // reach for a selected-platform reset to do this: clearing one field must
-      // stay local to that field so organization-scoped state added later
-      // survives local repository and platform changes.
+      // Full-flow exits should clear every staged choice explicitly. Do not use
+      // a selected-platform reset for this: messaging setup is organization-
+      // scoped and must survive local repository/platform changes.
       resetOnboarding: removeOnboarding,
     }),
     [onboarding, setOnboarding, removeOnboarding]

--- a/static/app/components/onboarding/scm/scmMessagingSetup.ts
+++ b/static/app/components/onboarding/scm/scmMessagingSetup.ts
@@ -1,0 +1,16 @@
+type ScmMessagingProviderKey = 'discord' | 'msteams' | 'slack';
+
+export type ScmMessagingSetup =
+  | {mode: 'unconfigured'}
+  | {mode: 'skipped'}
+  | {
+      channelId: string;
+      integrationId: string;
+      mode: 'selected';
+      providerKey: ScmMessagingProviderKey;
+      channelName?: string;
+    };
+
+export const UNCONFIGURED_SCM_MESSAGING_SETUP = {
+  mode: 'unconfigured',
+} as const satisfies ScmMessagingSetup;

--- a/static/app/views/onboarding/components/onboardingSkipButton.spec.tsx
+++ b/static/app/views/onboarding/components/onboardingSkipButton.spec.tsx
@@ -30,6 +30,11 @@ const MAPPED_CASES: MappedCase[] = [
     referrer: 'onboarding-scm-platform-features-skip',
   },
   {
+    stepId: OnboardingStepId.SCM_MESSAGING,
+    sidebarSource: 'onboarding_sidebar',
+    referrer: 'onboarding-scm-messaging-skip',
+  },
+  {
     stepId: OnboardingStepId.SETUP_DOCS,
     sidebarSource: 'targeted_onboarding_first_event_footer_skip',
     referrer: 'onboarding-first-event-footer-skip',

--- a/static/app/views/onboarding/components/onboardingSkipButton.tsx
+++ b/static/app/views/onboarding/components/onboardingSkipButton.tsx
@@ -45,7 +45,7 @@ interface OnboardingSkipButtonProps {
 
 export function OnboardingSkipButton({stepId}: OnboardingSkipButtonProps) {
   const organization = useOrganization();
-  const {resetOnboarding} = useOnboardingContext();
+  const {discardOnboardingSession} = useOnboardingContext();
   const {activateSidebar} = useOnboardingSidebar();
 
   const config = SKIP_CONFIG_BY_STEP[stepId];
@@ -56,7 +56,7 @@ export function OnboardingSkipButton({stepId}: OnboardingSkipButtonProps) {
   const handleClick = () => {
     // Skipping exits the treatment and must not leave a half-staged session for
     // the next /onboarding visit to silently resume from.
-    resetOnboarding();
+    discardOnboardingSession();
     trackAnalytics('onboarding.scm_header_skip_clicked', {
       organization,
       step: stepId,

--- a/static/app/views/onboarding/components/onboardingSkipButton.tsx
+++ b/static/app/views/onboarding/components/onboardingSkipButton.tsx
@@ -54,9 +54,8 @@ export function OnboardingSkipButton({stepId}: OnboardingSkipButtonProps) {
   }
 
   const handleClick = () => {
-    // Treatment ends on scm-messaging, the last step before project creation.
-    // Skipping here must not leave a half-staged session for the next
-    // /onboarding visit to silently resume from.
+    // Skipping exits the treatment and must not leave a half-staged session for
+    // the next /onboarding visit to silently resume from.
     resetOnboarding();
     trackAnalytics('onboarding.scm_header_skip_clicked', {
       organization,

--- a/static/app/views/onboarding/components/onboardingSkipButton.tsx
+++ b/static/app/views/onboarding/components/onboardingSkipButton.tsx
@@ -1,5 +1,6 @@
 import {LinkButton} from '@sentry/scraps/button';
 
+import {useOnboardingContext} from 'sentry/components/onboarding/onboardingContext';
 import {useOnboardingSidebar} from 'sentry/components/onboarding/useOnboardingSidebar';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -27,6 +28,11 @@ const SKIP_CONFIG_BY_STEP: Partial<Record<OnboardingStepId, SkipAnalyticsConfig>
     sidebarSource: 'targeted_onboarding_scm_platform_features_skip',
     referrer: 'onboarding-scm-platform-features-skip',
   },
+  [OnboardingStepId.SCM_MESSAGING]: {
+    // VDY-146 will add treatment-specific interaction analytics.
+    sidebarSource: 'onboarding_sidebar',
+    referrer: 'onboarding-scm-messaging-skip',
+  },
   [OnboardingStepId.SETUP_DOCS]: {
     sidebarSource: 'targeted_onboarding_first_event_footer_skip',
     referrer: 'onboarding-first-event-footer-skip',
@@ -39,6 +45,7 @@ interface OnboardingSkipButtonProps {
 
 export function OnboardingSkipButton({stepId}: OnboardingSkipButtonProps) {
   const organization = useOrganization();
+  const {resetOnboarding} = useOnboardingContext();
   const {activateSidebar} = useOnboardingSidebar();
 
   const config = SKIP_CONFIG_BY_STEP[stepId];
@@ -47,6 +54,10 @@ export function OnboardingSkipButton({stepId}: OnboardingSkipButtonProps) {
   }
 
   const handleClick = () => {
+    // Treatment ends on scm-messaging, the last step before project creation.
+    // Skipping here must not leave a half-staged session for the next
+    // /onboarding visit to silently resume from.
+    resetOnboarding();
     trackAnalytics('onboarding.scm_header_skip_clicked', {
       organization,
       step: stepId,

--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -635,6 +635,19 @@ describe('Onboarding', () => {
       });
     });
 
+    it('redirects treatment off the messaging step when no platform is staged', async () => {
+      // The messaging step reads a platform it cannot render without. Bounce
+      // back one step rather than to the start of the flow, so a refresh with
+      // an empty session does not discard the repository connection.
+      const {router} = renderTreatmentOnboarding('scm-messaging');
+
+      await waitFor(() => {
+        expect(router.location.pathname).toBe(
+          `/onboarding/${messagingOrganization.slug}/scm-platform-features/`
+        );
+      });
+    });
+
     it('navigates from welcome to scm-connect', async () => {
       const {router} = renderOnboarding('welcome');
 

--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -591,12 +591,16 @@ describe('Onboarding', () => {
       );
     }
 
-    it('navigates from welcome to scm-connect', async () => {
-      const {router} = renderOnboarding('welcome');
+    it('reports four total steps for the control flow', () => {
+      renderOnboarding('welcome');
 
       expect(
         screen.getByRole('progressbar', {name: 'Onboarding progress'})
       ).toHaveAttribute('aria-valuemax', '4');
+    });
+
+    it('navigates from welcome to scm-connect', async () => {
+      const {router} = renderOnboarding('welcome');
 
       await userEvent.click(screen.getByTestId('onboarding-welcome-start'));
 
@@ -845,6 +849,31 @@ describe('Onboarding', () => {
       });
     });
 
+    it('reports five total steps for the treatment flow', () => {
+      const treatmentOrganization = OrganizationFixture({
+        features: ['onboarding-scm-experiment', 'onboarding-scm-messaging-experiment'],
+      });
+
+      render(
+        <OnboardingContextProvider initialValue={{selectedPlatform: nextJsPlatform}}>
+          <OnboardingWithoutContext />
+        </OnboardingContextProvider>,
+        {
+          organization: treatmentOrganization,
+          initialRouterConfig: {
+            location: {
+              pathname: `/onboarding/${treatmentOrganization.slug}/scm-messaging/`,
+            },
+            route: '/onboarding/:orgId/:step/',
+          },
+        }
+      );
+
+      expect(
+        screen.getByRole('progressbar', {name: 'Onboarding progress'})
+      ).toHaveAttribute('aria-valuemax', '5');
+    });
+
     it('adds the messaging route for treatment without creating a project', async () => {
       ProjectsStore.loadInitialData([]);
       const treatmentOrganization = OrganizationFixture({
@@ -884,9 +913,6 @@ describe('Onboarding', () => {
         }
       );
 
-      expect(
-        screen.getByRole('progressbar', {name: 'Onboarding progress'})
-      ).toHaveAttribute('aria-valuemax', '5');
       await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
 
       expect(

--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -950,8 +950,11 @@ describe('Onboarding', () => {
         body: ProjectFixture(),
       });
 
+      // Render the provider bare, like production does, so it hydrates from
+      // sessionStorage. Seeding `initialValue` instead makes a session clear
+      // restore that value rather than empty the context.
       render(
-        <OnboardingContextProvider initialValue={initialContext}>
+        <OnboardingContextProvider>
           <OnboardingWithoutContext />
         </OnboardingContextProvider>,
         {
@@ -969,6 +972,133 @@ describe('Onboarding', () => {
 
       expect(createRequest).not.toHaveBeenCalled();
       expect(sessionStorage.getItem('onboarding')).toBeNull();
+    });
+
+    describe('global Skip exit destination', () => {
+      // The skip button renders in the treatment header on every step, so each
+      // one has to leave the flow the same way: land on the issues stream and
+      // leave no session behind for the next /onboarding visit to resume from.
+      //
+      // Note on the failure mode these lock in: under jsdom, reverting to
+      // resetOnboarding fails the `setup-docs` and `scm-messaging` cases on the
+      // destination assertion, because clearing state re-renders the step, flips
+      // its validity guard and mounts a <Redirect> that beats the outbound
+      // navigation. That sequence does not occur in a real browser, where the
+      // click's state update and the router navigation land in one commit and
+      // the step unmounts without re-rendering. The bug that is real there is
+      // the session leak — see the unmount-in-same-commit test in
+      // onboardingContext.spec.tsx, which reproduces it directly.
+      it.each(['welcome', 'scm-connect', 'scm-platform-features'])(
+        'skip from %s lands on the issues stream',
+        async step => {
+          sessionStorage.setItem(
+            'onboarding',
+            JSON.stringify({
+              selectedPlatform: nextJsPlatform,
+              selectedFeatures: [ProductSolution.ERROR_MONITORING],
+              selectedRepository: RepositoryFixture(),
+            })
+          );
+
+          const {router} = renderOnboarding(step);
+
+          await userEvent.click(screen.getByRole('button', {name: 'Skip setup'}));
+
+          await waitFor(() => {
+            expect(router.location.pathname).toBe(
+              `/organizations/${scmOrganization.slug}/issues/`
+            );
+          });
+          expect(sessionStorage.getItem('onboarding')).toBeNull();
+        }
+      );
+
+      it('skip from scm-messaging lands on the issues stream', async () => {
+        const messagingOrganization = OrganizationFixture({
+          features: ['onboarding-scm-experiment', 'onboarding-scm-messaging-experiment'],
+        });
+        MockApiClient.addMockResponse({
+          url: `/organizations/${messagingOrganization.slug}/integrations/`,
+          body: [],
+        });
+        sessionStorage.setItem(
+          'onboarding',
+          JSON.stringify({selectedPlatform: nextJsPlatform})
+        );
+
+        const {router} = render(
+          <OnboardingContextProvider>
+            <OnboardingWithoutContext />
+          </OnboardingContextProvider>,
+          {
+            organization: messagingOrganization,
+            initialRouterConfig: {
+              location: {
+                pathname: `/onboarding/${messagingOrganization.slug}/scm-messaging/`,
+              },
+              route: '/onboarding/:orgId/:step/',
+            },
+          }
+        );
+
+        await userEvent.click(screen.getByRole('button', {name: 'Skip setup'}));
+
+        await waitFor(() => {
+          expect(router.location.pathname).toBe(
+            `/organizations/${messagingOrganization.slug}/issues/`
+          );
+        });
+        expect(sessionStorage.getItem('onboarding')).toBeNull();
+      });
+
+      it('skip from setup-docs lands on the issues stream', async () => {
+        const nextJsProject = ProjectFixture({
+          platform: 'javascript-nextjs',
+          id: '2',
+          slug: 'javascript-nextjs',
+        });
+
+        jest
+          .spyOn(useRecentCreatedProjectHook, 'useRecentCreatedProject')
+          .mockImplementation(() => ({
+            project: nextJsProject,
+            isProjectActive: true,
+          }));
+
+        MockApiClient.addMockResponse({
+          url: `/organizations/${scmOrganization.slug}/sdks/`,
+          body: {},
+        });
+        MockApiClient.addMockResponse({
+          url: `/projects/${scmOrganization.slug}/${nextJsProject.slug}/keys/`,
+          body: [ProjectKeysFixture()[0]],
+        });
+        MockApiClient.addMockResponse({
+          url: `/projects/${scmOrganization.slug}/${nextJsProject.slug}/issues/`,
+          body: [],
+        });
+
+        sessionStorage.setItem(
+          'onboarding',
+          JSON.stringify({
+            selectedPlatform: nextJsPlatform,
+            selectedFeatures: [ProductSolution.ERROR_MONITORING],
+            createdProjectSlug: nextJsProject.slug,
+          })
+        );
+
+        const {router} = renderOnboarding('setup-docs');
+
+        await userEvent.click(screen.getByRole('button', {name: 'Skip setup'}));
+
+        await waitFor(() => {
+          expect(router.location.pathname).toBe(
+            `/organizations/${scmOrganization.slug}/issues/`
+          );
+        });
+        expect(router.location.query.referrer).toBe('onboarding-first-event-footer-skip');
+        expect(sessionStorage.getItem('onboarding')).toBeNull();
+      });
     });
 
     it('preserves SCM context when going back from setup-docs', async () => {

--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -617,14 +617,6 @@ describe('Onboarding', () => {
       return renderFlow(messagingOrganization, step, options);
     }
 
-    it('reports four total steps for the control flow', () => {
-      renderOnboarding('welcome');
-
-      expect(
-        screen.getByRole('progressbar', {name: 'Onboarding progress'})
-      ).toHaveAttribute('aria-valuemax', '4');
-    });
-
     it('redirects an inactive messaging route to welcome without skipping SCM steps', async () => {
       const {router} = renderOnboarding('scm-messaging');
 
@@ -896,16 +888,6 @@ describe('Onboarding', () => {
           `/onboarding/${controlOrganization.slug}/setup-docs/`
         );
       });
-    });
-
-    it('reports five total steps for the treatment flow', () => {
-      renderTreatmentOnboarding('scm-messaging', {
-        initialContext: {selectedPlatform: nextJsPlatform},
-      });
-
-      expect(
-        screen.getByRole('progressbar', {name: 'Onboarding progress'})
-      ).toHaveAttribute('aria-valuemax', '5');
     });
 
     it('adds the messaging route for treatment without creating a project', async () => {

--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -21,10 +21,12 @@ import {
   OnboardingContextProvider,
   useOnboardingContext,
 } from 'sentry/components/onboarding/onboardingContext';
+import type {ScmMessagingSetup} from 'sentry/components/onboarding/scm/scmMessagingSetup';
 import * as useRecentCreatedProjectHook from 'sentry/components/onboarding/useRecentCreatedProject';
 import {OnboardingDrawerStore} from 'sentry/stores/onboardingDrawerStore';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {TeamStore} from 'sentry/stores/teamStore';
+import type {Organization} from 'sentry/types/organization';
 import type {PlatformKey} from 'sentry/types/platform';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {OnboardingWithoutContext} from 'sentry/views/onboarding/onboarding';
@@ -541,6 +543,12 @@ describe('Onboarding', () => {
       features: ['onboarding-scm-experiment'],
     });
 
+    // Shares scmOrganization's slug, so the mocks registered in beforeEach below
+    // cover both flows. Only the messaging experiment flag differs.
+    const messagingOrganization = OrganizationFixture({
+      features: ['onboarding-scm-experiment', 'onboarding-scm-messaging-experiment'],
+    });
+
     const githubProvider = GitHubIntegrationProviderFixture({
       features: ['commits'],
     });
@@ -553,6 +561,13 @@ describe('Onboarding', () => {
       name: 'Next.js',
       link: 'https://docs.sentry.io/platforms/javascript/guides/nextjs/',
     };
+
+    const selectedMessagingSetup = {
+      mode: 'selected',
+      providerKey: 'slack',
+      integrationId: '15',
+      channelId: 'C123',
+    } as const satisfies ScmMessagingSetup;
 
     beforeEach(() => {
       MockApiClient.addMockResponse({
@@ -569,26 +584,37 @@ describe('Onboarding', () => {
       });
     });
 
-    function renderOnboarding(
+    type RenderOptions = {
+      initialContext?: Parameters<typeof OnboardingContextProvider>[0]['initialValue'];
+    };
+
+    function renderFlow(
+      organization: Organization,
       step: string,
-      options?: {
-        initialContext?: Parameters<typeof OnboardingContextProvider>[0]['initialValue'];
-      }
+      options?: RenderOptions
     ) {
       return render(
         <OnboardingContextProvider initialValue={options?.initialContext}>
           <OnboardingWithoutContext />
         </OnboardingContextProvider>,
         {
-          organization: scmOrganization,
+          organization,
           initialRouterConfig: {
             location: {
-              pathname: `/onboarding/${scmOrganization.slug}/${step}/`,
+              pathname: `/onboarding/${organization.slug}/${step}/`,
             },
             route: '/onboarding/:orgId/:step/',
           },
         }
       );
+    }
+
+    function renderOnboarding(step: string, options?: RenderOptions) {
+      return renderFlow(scmOrganization, step, options);
+    }
+
+    function renderTreatmentOnboarding(step: string, options?: RenderOptions) {
+      return renderFlow(messagingOrganization, step, options);
     }
 
     it('reports four total steps for the control flow', () => {
@@ -638,18 +664,11 @@ describe('Onboarding', () => {
     });
 
     it('preserves messaging setup when returning to the welcome step', async () => {
-      const messagingSetup = {
-        mode: 'selected' as const,
-        providerKey: 'slack' as const,
-        integrationId: '15',
-        channelId: 'C123',
-      };
-
       renderOnboarding('welcome', {
         initialContext: {
           selectedPlatform: nextJsPlatform,
           selectedFeatures: [ProductSolution.ERROR_MONITORING],
-          messagingSetup,
+          messagingSetup: selectedMessagingSetup,
         },
       });
 
@@ -657,7 +676,7 @@ describe('Onboarding', () => {
         const stored = JSON.parse(sessionStorage.getItem('onboarding') ?? '{}');
         expect(stored.selectedPlatform).toBeUndefined();
         expect(stored.selectedFeatures).toBeUndefined();
-        expect(stored.messagingSetup).toEqual(messagingSetup);
+        expect(stored.messagingSetup).toEqual(selectedMessagingSetup);
       });
     });
 
@@ -860,24 +879,9 @@ describe('Onboarding', () => {
     });
 
     it('reports five total steps for the treatment flow', () => {
-      const treatmentOrganization = OrganizationFixture({
-        features: ['onboarding-scm-experiment', 'onboarding-scm-messaging-experiment'],
+      renderTreatmentOnboarding('scm-messaging', {
+        initialContext: {selectedPlatform: nextJsPlatform},
       });
-
-      render(
-        <OnboardingContextProvider initialValue={{selectedPlatform: nextJsPlatform}}>
-          <OnboardingWithoutContext />
-        </OnboardingContextProvider>,
-        {
-          organization: treatmentOrganization,
-          initialRouterConfig: {
-            location: {
-              pathname: `/onboarding/${treatmentOrganization.slug}/scm-messaging/`,
-            },
-            route: '/onboarding/:orgId/:step/',
-          },
-        }
-      );
 
       expect(
         screen.getByRole('progressbar', {name: 'Onboarding progress'})
@@ -886,42 +890,26 @@ describe('Onboarding', () => {
 
     it('adds the messaging route for treatment without creating a project', async () => {
       ProjectsStore.loadInitialData([]);
-      const treatmentOrganization = OrganizationFixture({
-        features: ['onboarding-scm-experiment', 'onboarding-scm-messaging-experiment'],
-      });
       MockApiClient.addMockResponse({
-        url: `/organizations/${treatmentOrganization.slug}/projects/`,
+        url: `/organizations/${messagingOrganization.slug}/projects/`,
         body: [],
       });
       MockApiClient.addMockResponse({
-        url: `/organizations/${treatmentOrganization.slug}/teams/`,
+        url: `/organizations/${messagingOrganization.slug}/teams/`,
         body: [],
       });
       const createRequest = MockApiClient.addMockResponse({
-        url: `/organizations/${treatmentOrganization.slug}/projects/`,
+        url: `/organizations/${messagingOrganization.slug}/projects/`,
         method: 'POST',
         body: ProjectFixture(),
       });
 
-      const {router} = render(
-        <OnboardingContextProvider
-          initialValue={{
-            selectedPlatform: nextJsPlatform,
-            selectedFeatures: [ProductSolution.ERROR_MONITORING],
-          }}
-        >
-          <OnboardingWithoutContext />
-        </OnboardingContextProvider>,
-        {
-          organization: treatmentOrganization,
-          initialRouterConfig: {
-            location: {
-              pathname: `/onboarding/${treatmentOrganization.slug}/scm-platform-features/`,
-            },
-            route: '/onboarding/:orgId/:step/',
-          },
-        }
-      );
+      const {router} = renderTreatmentOnboarding('scm-platform-features', {
+        initialContext: {
+          selectedPlatform: nextJsPlatform,
+          selectedFeatures: [ProductSolution.ERROR_MONITORING],
+        },
+      });
 
       await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
 
@@ -929,44 +917,30 @@ describe('Onboarding', () => {
         await screen.findByText('Get alerts where your team works')
       ).toBeInTheDocument();
       expect(router.location.pathname).toBe(
-        `/onboarding/${treatmentOrganization.slug}/scm-messaging/`
+        `/onboarding/${messagingOrganization.slug}/scm-messaging/`
       );
       expect(createRequest).not.toHaveBeenCalled();
     });
 
     it('global Skip exits treatment without creating a project and clears state', async () => {
-      const treatmentOrganization = OrganizationFixture({
-        features: ['onboarding-scm-experiment', 'onboarding-scm-messaging-experiment'],
-      });
-      const initialContext = {
-        selectedPlatform: nextJsPlatform,
-        selectedFeatures: [ProductSolution.ERROR_MONITORING],
-        messagingSetup: {mode: 'skipped' as const},
-      };
-      sessionStorage.setItem('onboarding', JSON.stringify(initialContext));
+      sessionStorage.setItem(
+        'onboarding',
+        JSON.stringify({
+          selectedPlatform: nextJsPlatform,
+          selectedFeatures: [ProductSolution.ERROR_MONITORING],
+          messagingSetup: {mode: 'skipped'},
+        })
+      );
       const createRequest = MockApiClient.addMockResponse({
-        url: `/organizations/${treatmentOrganization.slug}/projects/`,
+        url: `/organizations/${messagingOrganization.slug}/projects/`,
         method: 'POST',
         body: ProjectFixture(),
       });
 
       // Render the provider bare, like production does, so it hydrates from
-      // sessionStorage. Seeding `initialValue` instead makes a session clear
+      // sessionStorage. Seeding `initialContext` instead makes a session clear
       // restore that value rather than empty the context.
-      render(
-        <OnboardingContextProvider>
-          <OnboardingWithoutContext />
-        </OnboardingContextProvider>,
-        {
-          organization: treatmentOrganization,
-          initialRouterConfig: {
-            location: {
-              pathname: `/onboarding/${treatmentOrganization.slug}/scm-messaging/`,
-            },
-            route: '/onboarding/:orgId/:step/',
-          },
-        }
-      );
+      renderTreatmentOnboarding('scm-messaging');
 
       await userEvent.click(screen.getByRole('button', {name: 'Skip setup'}));
 
@@ -1014,32 +988,12 @@ describe('Onboarding', () => {
       );
 
       it('skip from scm-messaging lands on the issues stream', async () => {
-        const messagingOrganization = OrganizationFixture({
-          features: ['onboarding-scm-experiment', 'onboarding-scm-messaging-experiment'],
-        });
-        MockApiClient.addMockResponse({
-          url: `/organizations/${messagingOrganization.slug}/integrations/`,
-          body: [],
-        });
         sessionStorage.setItem(
           'onboarding',
           JSON.stringify({selectedPlatform: nextJsPlatform})
         );
 
-        const {router} = render(
-          <OnboardingContextProvider>
-            <OnboardingWithoutContext />
-          </OnboardingContextProvider>,
-          {
-            organization: messagingOrganization,
-            initialRouterConfig: {
-              location: {
-                pathname: `/onboarding/${messagingOrganization.slug}/scm-messaging/`,
-              },
-              route: '/onboarding/:orgId/:step/',
-            },
-          }
-        );
+        const {router} = renderTreatmentOnboarding('scm-messaging');
 
         await userEvent.click(screen.getByRole('button', {name: 'Skip setup'}));
 
@@ -1136,12 +1090,7 @@ describe('Onboarding', () => {
       const initialContext = {
         selectedPlatform: nextJsPlatform,
         selectedFeatures: [ProductSolution.ERROR_MONITORING],
-        messagingSetup: {
-          mode: 'selected' as const,
-          providerKey: 'slack' as const,
-          integrationId: '15',
-          channelId: 'C123',
-        },
+        messagingSetup: selectedMessagingSetup,
       };
 
       // Seed sessionStorage directly so we can verify it's preserved after back
@@ -1265,12 +1214,7 @@ describe('Onboarding', () => {
         selectedPlatform: nextJsPlatform,
         selectedFeatures: [ProductSolution.ERROR_MONITORING],
         createdProjectSlug: 'javascript-nextjs',
-        messagingSetup: {
-          mode: 'selected' as const,
-          providerKey: 'slack' as const,
-          integrationId: '15',
-          channelId: 'C123',
-        },
+        messagingSetup: selectedMessagingSetup,
       };
 
       sessionStorage.setItem('onboarding', JSON.stringify(initialContext));

--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -663,20 +663,27 @@ describe('Onboarding', () => {
       );
     });
 
-    it('preserves messaging setup when returning to the welcome step', async () => {
-      renderOnboarding('welcome', {
-        initialContext: {
+    it('clears the whole session when returning to the welcome step', async () => {
+      // Returning to welcome restarts the flow, so nothing is carried over —
+      // including messagingSetup, which only has to survive local repository
+      // and platform changes.
+      sessionStorage.setItem(
+        'onboarding',
+        JSON.stringify({
           selectedPlatform: nextJsPlatform,
           selectedFeatures: [ProductSolution.ERROR_MONITORING],
+          createdProjectSlug: 'javascript-nextjs',
           messagingSetup: selectedMessagingSetup,
-        },
-      });
+        })
+      );
+
+      // Render the provider bare, like production does, so it hydrates from
+      // sessionStorage. Seeding `initialContext` instead makes a session clear
+      // restore that value rather than empty the context.
+      renderOnboarding('welcome');
 
       await waitFor(() => {
-        const stored = JSON.parse(sessionStorage.getItem('onboarding') ?? '{}');
-        expect(stored.selectedPlatform).toBeUndefined();
-        expect(stored.selectedFeatures).toBeUndefined();
-        expect(stored.messagingSetup).toEqual(selectedMessagingSetup);
+        expect(sessionStorage.getItem('onboarding')).toBeNull();
       });
     });
 

--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -599,6 +599,16 @@ describe('Onboarding', () => {
       ).toHaveAttribute('aria-valuemax', '4');
     });
 
+    it('redirects an inactive messaging route to welcome without skipping SCM steps', async () => {
+      const {router} = renderOnboarding('scm-messaging');
+
+      await waitFor(() => {
+        expect(router.location.pathname).toBe(
+          `/onboarding/${scmOrganization.slug}/welcome/`
+        );
+      });
+    });
+
     it('navigates from welcome to scm-connect', async () => {
       const {router} = renderOnboarding('welcome');
 

--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -594,6 +594,10 @@ describe('Onboarding', () => {
     it('navigates from welcome to scm-connect', async () => {
       const {router} = renderOnboarding('welcome');
 
+      expect(
+        screen.getByRole('progressbar', {name: 'Onboarding progress'})
+      ).toHaveAttribute('aria-valuemax', '4');
+
       await userEvent.click(screen.getByTestId('onboarding-welcome-start'));
 
       // Wait for scm-connect to render and its queries to resolve so the
@@ -617,6 +621,30 @@ describe('Onboarding', () => {
         'growth.onboarding_start_onboarding',
         expect.anything()
       );
+    });
+
+    it('preserves messaging setup when returning to the welcome step', async () => {
+      const messagingSetup = {
+        mode: 'selected' as const,
+        providerKey: 'slack' as const,
+        integrationId: '15',
+        channelId: 'C123',
+      };
+
+      renderOnboarding('welcome', {
+        initialContext: {
+          selectedPlatform: nextJsPlatform,
+          selectedFeatures: [ProductSolution.ERROR_MONITORING],
+          messagingSetup,
+        },
+      });
+
+      await waitFor(() => {
+        const stored = JSON.parse(sessionStorage.getItem('onboarding') ?? '{}');
+        expect(stored.selectedPlatform).toBeUndefined();
+        expect(stored.selectedFeatures).toBeUndefined();
+        expect(stored.messagingSetup).toEqual(messagingSetup);
+      });
     });
 
     it('fires scm_welcome_continue_clicked on start click and not the legacy event', async () => {
@@ -817,6 +845,96 @@ describe('Onboarding', () => {
       });
     });
 
+    it('adds the messaging route for treatment without creating a project', async () => {
+      ProjectsStore.loadInitialData([]);
+      const treatmentOrganization = OrganizationFixture({
+        features: ['onboarding-scm-experiment', 'onboarding-scm-messaging-experiment'],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${treatmentOrganization.slug}/projects/`,
+        body: [],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${treatmentOrganization.slug}/teams/`,
+        body: [],
+      });
+      const createRequest = MockApiClient.addMockResponse({
+        url: `/organizations/${treatmentOrganization.slug}/projects/`,
+        method: 'POST',
+        body: ProjectFixture(),
+      });
+
+      const {router} = render(
+        <OnboardingContextProvider
+          initialValue={{
+            selectedPlatform: nextJsPlatform,
+            selectedFeatures: [ProductSolution.ERROR_MONITORING],
+          }}
+        >
+          <OnboardingWithoutContext />
+        </OnboardingContextProvider>,
+        {
+          organization: treatmentOrganization,
+          initialRouterConfig: {
+            location: {
+              pathname: `/onboarding/${treatmentOrganization.slug}/scm-platform-features/`,
+            },
+            route: '/onboarding/:orgId/:step/',
+          },
+        }
+      );
+
+      expect(
+        screen.getByRole('progressbar', {name: 'Onboarding progress'})
+      ).toHaveAttribute('aria-valuemax', '5');
+      await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
+
+      expect(
+        await screen.findByText('Get alerts where your team works')
+      ).toBeInTheDocument();
+      expect(router.location.pathname).toBe(
+        `/onboarding/${treatmentOrganization.slug}/scm-messaging/`
+      );
+      expect(createRequest).not.toHaveBeenCalled();
+    });
+
+    it('global Skip exits treatment without creating a project and clears state', async () => {
+      const treatmentOrganization = OrganizationFixture({
+        features: ['onboarding-scm-experiment', 'onboarding-scm-messaging-experiment'],
+      });
+      const initialContext = {
+        selectedPlatform: nextJsPlatform,
+        selectedFeatures: [ProductSolution.ERROR_MONITORING],
+        messagingSetup: {mode: 'skipped' as const},
+      };
+      sessionStorage.setItem('onboarding', JSON.stringify(initialContext));
+      const createRequest = MockApiClient.addMockResponse({
+        url: `/organizations/${treatmentOrganization.slug}/projects/`,
+        method: 'POST',
+        body: ProjectFixture(),
+      });
+
+      render(
+        <OnboardingContextProvider initialValue={initialContext}>
+          <OnboardingWithoutContext />
+        </OnboardingContextProvider>,
+        {
+          organization: treatmentOrganization,
+          initialRouterConfig: {
+            location: {
+              pathname: `/onboarding/${treatmentOrganization.slug}/scm-messaging/`,
+            },
+            route: '/onboarding/:orgId/:step/',
+          },
+        }
+      );
+
+      await userEvent.click(screen.getByRole('button', {name: 'Skip setup'}));
+
+      expect(createRequest).not.toHaveBeenCalled();
+      expect(sessionStorage.getItem('onboarding')).toBeNull();
+    });
+
     it('preserves SCM context when going back from setup-docs', async () => {
       const nextJsProject = ProjectFixture({
         platform: 'javascript-nextjs',
@@ -852,6 +970,12 @@ describe('Onboarding', () => {
       const initialContext = {
         selectedPlatform: nextJsPlatform,
         selectedFeatures: [ProductSolution.ERROR_MONITORING],
+        messagingSetup: {
+          mode: 'selected' as const,
+          providerKey: 'slack' as const,
+          integrationId: '15',
+          channelId: 'C123',
+        },
       };
 
       // Seed sessionStorage directly so we can verify it's preserved after back
@@ -884,6 +1008,7 @@ describe('Onboarding', () => {
       expect(stored.selectedFeatures).toBeDefined();
       // createdProjectSlug should be cleared so the user can re-create
       expect(stored.createdProjectSlug).toBeUndefined();
+      expect(stored.messagingSetup).toEqual(initialContext.messagingSetup);
     });
 
     describe('setup-docs analytics', () => {
@@ -974,6 +1099,12 @@ describe('Onboarding', () => {
         selectedPlatform: nextJsPlatform,
         selectedFeatures: [ProductSolution.ERROR_MONITORING],
         createdProjectSlug: 'javascript-nextjs',
+        messagingSetup: {
+          mode: 'selected' as const,
+          providerKey: 'slack' as const,
+          integrationId: '15',
+          channelId: 'C123',
+        },
       };
 
       sessionStorage.setItem('onboarding', JSON.stringify(initialContext));
@@ -999,6 +1130,8 @@ describe('Onboarding', () => {
       // Integration and repo should be preserved
       expect(stored.selectedIntegration).toBeDefined();
       expect(stored.selectedRepository).toBeDefined();
+      // Messaging destinations are organization-scoped, not repo-derived.
+      expect(stored.messagingSetup).toEqual(initialContext.messagingSetup);
     });
 
     it('navigates back from scm-connect to welcome', async () => {

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -40,7 +40,7 @@ import {NewWelcomeUI} from './components/newWelcome';
 import {OnboardingSkipButton} from './components/onboardingSkipButton';
 import {PlatformSelection} from './platformSelection';
 import {ScmConnect} from './scmConnect';
-import {ScmMessaging} from './scmMessaging';
+import {ScmMessaging, SCM_MESSAGING_TITLE} from './scmMessaging';
 import {ScmPlatformFeatures} from './scmPlatformFeatures';
 import {SetupDocs} from './setupDocs';
 import {OnboardingStepId, type StepDescriptor, type StepProps} from './types';
@@ -142,6 +142,9 @@ function ScmPlatformFeaturesTreatmentAdapter(props: StepProps) {
 function ScmMessagingAdapter({genBackButton}: StepProps) {
   const {selectedPlatform} = useOnboardingContext();
 
+  // Type-narrowing only. `isInvalidMessagingStep` below redirects away from
+  // this step before it renders without a platform, so this is unreachable —
+  // it is not an empty state and should not grow into one.
   if (!selectedPlatform) {
     return null;
   }
@@ -193,7 +196,7 @@ const scmMessagingOnboardingSteps: StepDescriptor[] = [
   },
   {
     id: OnboardingStepId.SCM_MESSAGING,
-    title: t('Get alerts where your team works'),
+    title: SCM_MESSAGING_TITLE,
     Component: ScmMessagingAdapter,
     cornerVariant: 'top-left',
   },

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -40,6 +40,7 @@ import {NewWelcomeUI} from './components/newWelcome';
 import {OnboardingSkipButton} from './components/onboardingSkipButton';
 import {PlatformSelection} from './platformSelection';
 import {ScmConnect} from './scmConnect';
+import {ScmMessaging} from './scmMessaging';
 import {ScmPlatformFeatures} from './scmPlatformFeatures';
 import {SetupDocs} from './setupDocs';
 import {OnboardingStepId, type StepDescriptor, type StepProps} from './types';
@@ -99,7 +100,11 @@ function ScmConnectAdapter({onComplete, genBackButton}: StepProps) {
   );
 }
 
-function ScmPlatformFeaturesAdapter({onComplete, genBackButton}: StepProps) {
+function ScmPlatformFeaturesAdapter({
+  deferProjectCreation,
+  genBackButton,
+  onComplete,
+}: StepProps & {deferProjectCreation: boolean}) {
   const {
     selectedRepository,
     selectedPlatform,
@@ -116,6 +121,7 @@ function ScmPlatformFeaturesAdapter({onComplete, genBackButton}: StepProps) {
       selectedPlatform={selectedPlatform}
       selectedFeatures={selectedFeatures}
       createdProjectSlug={createdProjectSlug}
+      deferProjectCreation={deferProjectCreation}
       onPlatformChange={setSelectedPlatform}
       onFeaturesChange={setSelectedFeatures}
       onProjectCreated={setCreatedProjectSlug}
@@ -125,7 +131,27 @@ function ScmPlatformFeaturesAdapter({onComplete, genBackButton}: StepProps) {
   );
 }
 
-const scmOnboardingSteps: StepDescriptor[] = [
+function ScmPlatformFeaturesControlAdapter(props: StepProps) {
+  return <ScmPlatformFeaturesAdapter {...props} deferProjectCreation={false} />;
+}
+
+function ScmPlatformFeaturesTreatmentAdapter(props: StepProps) {
+  return <ScmPlatformFeaturesAdapter {...props} deferProjectCreation />;
+}
+
+function ScmMessagingAdapter({genBackButton}: StepProps) {
+  const {selectedPlatform} = useOnboardingContext();
+
+  if (!selectedPlatform) {
+    return null;
+  }
+
+  return (
+    <ScmMessaging selectedPlatform={selectedPlatform} genBackButton={genBackButton} />
+  );
+}
+
+const scmOnboardingSharedSteps: StepDescriptor[] = [
   {
     id: OnboardingStepId.WELCOME,
     title: t('Welcome'),
@@ -138,10 +164,37 @@ const scmOnboardingSteps: StepDescriptor[] = [
     Component: ScmConnectAdapter,
     cornerVariant: 'top-left',
   },
+];
+
+const scmOnboardingSteps: StepDescriptor[] = [
+  ...scmOnboardingSharedSteps,
   {
     id: OnboardingStepId.SCM_PLATFORM_FEATURES,
     title: t('Create your first project'),
-    Component: ScmPlatformFeaturesAdapter,
+    Component: ScmPlatformFeaturesControlAdapter,
+    cornerVariant: 'top-left',
+  },
+  {
+    id: OnboardingStepId.SETUP_DOCS,
+    title: t('Install the Sentry SDK'),
+    Component: SetupDocs,
+    hasFooter: true,
+    cornerVariant: 'top-left',
+  },
+];
+
+const scmMessagingOnboardingSteps: StepDescriptor[] = [
+  ...scmOnboardingSharedSteps,
+  {
+    id: OnboardingStepId.SCM_PLATFORM_FEATURES,
+    title: t('Create your first project'),
+    Component: ScmPlatformFeaturesTreatmentAdapter,
+    cornerVariant: 'top-left',
+  },
+  {
+    id: OnboardingStepId.SCM_MESSAGING,
+    title: t('Get alerts where your team works'),
+    Component: ScmMessagingAdapter,
     cornerVariant: 'top-left',
   },
   {
@@ -232,7 +285,18 @@ export function OnboardingWithoutContext() {
     reportExposure: isNewOrgOnboarding,
   });
 
-  const onboardingSteps = hasScmOnboarding ? scmOnboardingSteps : legacyOnboardingSteps;
+  // VDY-146 owns treatment exposure and interaction analytics. For now the
+  // host consumes the nested assignment without reporting it.
+  const {inExperiment: hasScmMessaging} = useExperiment({
+    feature: 'onboarding-scm-messaging-experiment',
+    reportExposure: false,
+  });
+
+  const onboardingSteps = hasScmOnboarding
+    ? hasScmMessaging
+      ? scmMessagingOnboardingSteps
+      : scmOnboardingSteps
+    : legacyOnboardingSteps;
 
   useReplayForCriticalFlow({
     flowName: 'scm_onboarding',
@@ -388,12 +452,15 @@ export function OnboardingWithoutContext() {
   };
 
   // Redirect to the first step if we end up in an invalid state
-  const isInvalidDocsStep = stepId === 'setup-docs' && !projectSlug;
-  if (!stepObj || stepIndex === -1 || isInvalidDocsStep) {
+  const isInvalidDocsStep = stepId === OnboardingStepId.SETUP_DOCS && !projectSlug;
+  const isInvalidMessagingStep =
+    stepId === OnboardingStepId.SCM_MESSAGING && !onboardingContext.selectedPlatform;
+  if (!stepObj || stepIndex === -1 || isInvalidDocsStep || isInvalidMessagingStep) {
+    const fallbackStep = isInvalidMessagingStep
+      ? OnboardingStepId.SCM_PLATFORM_FEATURES
+      : onboardingSteps[0]!.id;
     return (
-      <Redirect
-        to={normalizeUrl(`/onboarding/${organization.slug}/${onboardingSteps[0]!.id}/`)}
-      />
+      <Redirect to={normalizeUrl(`/onboarding/${organization.slug}/${fallbackStep}/`)} />
     );
   }
 
@@ -416,6 +483,11 @@ export function OnboardingWithoutContext() {
             }}
           >
             <Stepper
+              aria-label={t('Onboarding progress')}
+              aria-valuemax={onboardingSteps.length}
+              aria-valuemin={1}
+              aria-valuenow={stepIndex + 1}
+              role="progressbar"
               numSteps={onboardingSteps.length}
               currentStepIndex={stepIndex}
               onClick={i => {

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -457,7 +457,9 @@ export function OnboardingWithoutContext() {
   // Redirect to the first step if we end up in an invalid state
   const isInvalidDocsStep = stepId === OnboardingStepId.SETUP_DOCS && !projectSlug;
   const isInvalidMessagingStep =
-    stepId === OnboardingStepId.SCM_MESSAGING && !onboardingContext.selectedPlatform;
+    hasScmMessaging &&
+    stepId === OnboardingStepId.SCM_MESSAGING &&
+    !onboardingContext.selectedPlatform;
   if (!stepObj || stepIndex === -1 || isInvalidDocsStep || isInvalidMessagingStep) {
     const fallbackStep = isInvalidMessagingStep
       ? OnboardingStepId.SCM_PLATFORM_FEATURES

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -209,6 +209,19 @@ const scmMessagingOnboardingSteps: StepDescriptor[] = [
   },
 ];
 
+function getOnboardingSteps({
+  hasScmOnboarding,
+  hasScmMessaging,
+}: {
+  hasScmMessaging: boolean;
+  hasScmOnboarding: boolean;
+}): StepDescriptor[] {
+  if (!hasScmOnboarding) {
+    return legacyOnboardingSteps;
+  }
+  return hasScmMessaging ? scmMessagingOnboardingSteps : scmOnboardingSteps;
+}
+
 interface ContainerVariableProps {
   hasFooter: boolean;
   hasScmOnboarding: boolean;
@@ -295,11 +308,7 @@ export function OnboardingWithoutContext() {
     reportExposure: false,
   });
 
-  const onboardingSteps = hasScmOnboarding
-    ? hasScmMessaging
-      ? scmMessagingOnboardingSteps
-      : scmOnboardingSteps
-    : legacyOnboardingSteps;
+  const onboardingSteps = getOnboardingSteps({hasScmOnboarding, hasScmMessaging});
 
   useReplayForCriticalFlow({
     flowName: 'scm_onboarding',

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -499,11 +499,6 @@ export function OnboardingWithoutContext() {
             }}
           >
             <Stepper
-              aria-label={t('Onboarding progress')}
-              aria-valuemax={onboardingSteps.length}
-              aria-valuemin={1}
-              aria-valuenow={stepIndex + 1}
-              role="progressbar"
               numSteps={onboardingSteps.length}
               currentStepIndex={stepIndex}
               onClick={i => {

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -465,10 +465,12 @@ export function OnboardingWithoutContext() {
 
   // Redirect to the first step if we end up in an invalid state
   const isInvalidDocsStep = stepId === OnboardingStepId.SETUP_DOCS && !projectSlug;
+  // Keyed off `stepObj` rather than the experiment flag so the fallback below is
+  // always a step in the active list: `scm-messaging` only exists alongside
+  // `scm-platform-features`. Testing the flag instead would send a flow whose
+  // step list has neither on a second redirect to reach the first step.
   const isInvalidMessagingStep =
-    hasScmMessaging &&
-    stepId === OnboardingStepId.SCM_MESSAGING &&
-    !onboardingContext.selectedPlatform;
+    stepObj?.id === OnboardingStepId.SCM_MESSAGING && !onboardingContext.selectedPlatform;
   if (!stepObj || stepIndex === -1 || isInvalidDocsStep || isInvalidMessagingStep) {
     const fallbackStep = isInvalidMessagingStep
       ? OnboardingStepId.SCM_PLATFORM_FEATURES

--- a/static/app/views/onboarding/scmMessaging.tsx
+++ b/static/app/views/onboarding/scmMessaging.tsx
@@ -1,0 +1,36 @@
+import {Stack} from '@sentry/scraps/layout';
+import {Heading, Text} from '@sentry/scraps/text';
+
+import {t} from 'sentry/locale';
+import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
+import {SCM_STEP_CONTENT_WIDTH} from 'sentry/views/onboarding/consts';
+
+import type {StepProps} from './types';
+
+interface ScmMessagingProps {
+  selectedPlatform: OnboardingSelectedSDK;
+  genBackButton?: StepProps['genBackButton'];
+}
+
+export function ScmMessaging({genBackButton, selectedPlatform}: ScmMessagingProps) {
+  return (
+    <Stack align="center" gap="2xl" flexGrow={1}>
+      <Stack gap="xl" maxWidth={`min(${SCM_STEP_CONTENT_WIDTH}, 100%)`} width="100%">
+        <Stack gap="md">
+          <Heading as="h2" size="4xl">
+            {t('Get alerts where your team works')}
+          </Heading>
+          <Text variant="muted" size="md" density="comfortable">
+            {t(
+              "Choose where to send alerts for your %s project. We'll create the project and its alert rules when you continue.",
+              selectedPlatform.name
+            )}
+          </Text>
+        </Stack>
+
+        <Text variant="muted">{t('Email alerts will be included by default')}</Text>
+        <Stack align="start">{genBackButton?.()}</Stack>
+      </Stack>
+    </Stack>
+  );
+}

--- a/static/app/views/onboarding/scmMessaging.tsx
+++ b/static/app/views/onboarding/scmMessaging.tsx
@@ -7,6 +7,12 @@ import {SCM_STEP_CONTENT_WIDTH} from 'sentry/views/onboarding/consts';
 
 import type {StepProps} from './types';
 
+/**
+ * Shared by the step descriptor's `title` (document title / stepper) and the
+ * step's own heading so the two cannot drift apart.
+ */
+export const SCM_MESSAGING_TITLE = t('Get alerts where your team works');
+
 interface ScmMessagingProps {
   selectedPlatform: OnboardingSelectedSDK;
   genBackButton?: StepProps['genBackButton'];
@@ -18,7 +24,7 @@ export function ScmMessaging({genBackButton, selectedPlatform}: ScmMessagingProp
       <Stack gap="xl" maxWidth={`min(${SCM_STEP_CONTENT_WIDTH}, 100%)`} width="100%">
         <Stack gap="md">
           <Heading as="h2" size="4xl">
-            {t('Get alerts where your team works')}
+            {SCM_MESSAGING_TITLE}
           </Heading>
           <Text variant="muted" size="md" density="comfortable">
             {t(

--- a/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
@@ -69,6 +69,7 @@ function defaultProps(state: StateOverrides = {}) {
     selectedPlatform: state.selectedPlatform,
     selectedFeatures: state.selectedFeatures,
     createdProjectSlug: state.createdProjectSlug,
+    deferProjectCreation: false,
     onPlatformChange: jest.fn(),
     onFeaturesChange: jest.fn(),
     onProjectCreated: jest.fn(),
@@ -623,6 +624,31 @@ describe('ScmPlatformFeatures', () => {
       MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/teams/`,
         body: [adminTeam],
+      });
+    });
+
+    it('defers project creation for the messaging treatment', async () => {
+      const createRequest = MockApiClient.addMockResponse({
+        url: `/teams/${organization.slug}/${adminTeam.slug}/projects/`,
+        method: 'POST',
+        body: ProjectFixture(),
+      });
+      const props = {
+        ...defaultProps({
+          selectedPlatform: nextJsPlatform,
+          selectedFeatures: [ProductSolution.ERROR_MONITORING],
+        }),
+        deferProjectCreation: true,
+      };
+
+      render(<ScmPlatformFeatures {...props} />, {organization});
+
+      await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
+
+      expect(createRequest).not.toHaveBeenCalled();
+      expect(props.onProjectCreated).not.toHaveBeenCalled();
+      expect(props.onComplete).toHaveBeenCalledWith(nextJsPlatform, {
+        product: [ProductSolution.ERROR_MONITORING],
       });
     });
 

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -32,6 +32,7 @@ import type {StepProps} from './types';
 
 interface ScmPlatformFeaturesProps {
   createdProjectSlug: string | undefined;
+  deferProjectCreation: boolean;
   onComplete: StepProps['onComplete'];
   onFeaturesChange: (features: ProductSolution[] | undefined) => void;
   onPlatformChange: (platform: OnboardingSelectedSDK | undefined) => void;
@@ -44,6 +45,7 @@ interface ScmPlatformFeaturesProps {
 
 export function ScmPlatformFeatures({
   createdProjectSlug,
+  deferProjectCreation,
   onComplete,
   onFeaturesChange,
   onPlatformChange,
@@ -91,9 +93,10 @@ export function ScmPlatformFeatures({
     ? projects.find(p => p.slug === createdProjectSlug)
     : undefined;
 
-  // Continue auto-creates the project, which needs the teams and projects
-  // stores loaded.
-  const autoCreateDataPending = isLoadingTeams || !projectsLoaded;
+  // Control auto-creates the project and needs both stores loaded. Treatment
+  // only stages platform/features here; its messaging step owns creation.
+  const autoCreateDataPending =
+    !deferProjectCreation && (isLoadingTeams || !projectsLoaded);
 
   async function handleContinue() {
     if (isCompletingRef.current) {
@@ -116,6 +119,11 @@ export function ScmPlatformFeatures({
       return;
     }
     const platform = selectedPlatform ?? toSelectedSdk(info);
+
+    if (deferProjectCreation) {
+      onComplete(platform, {product: currentFeatures});
+      return;
+    }
 
     // If a project was already created for this platform (e.g. the user
     // went back after the project received its first event), reuse it.

--- a/static/app/views/onboarding/types.ts
+++ b/static/app/views/onboarding/types.ts
@@ -26,6 +26,7 @@ export enum OnboardingStepId {
   SETUP_DOCS = 'setup-docs',
   // SCM-first onboarding flow
   SCM_CONNECT = 'scm-connect',
+  SCM_MESSAGING = 'scm-messaging',
   SCM_PLATFORM_FEATURES = 'scm-platform-features',
 }
 

--- a/static/app/views/onboarding/useWelcomeAnalyticsEffect.ts
+++ b/static/app/views/onboarding/useWelcomeAnalyticsEffect.ts
@@ -29,10 +29,10 @@ export function useWelcomeAnalyticsEffect() {
   }, [organization, hasScmOnboarding]);
 
   useEffect(() => {
+    // At this point the selectedSDK shall be undefined but just in case, cleaning this up here too
     if (onboardingContext.selectedPlatform) {
-      // At this point the selectedSDK shall be undefined but just in case, cleaning this up here too
       // messagingSetup is organization-scoped and must survive a return to
-      // welcome; only the repo-derived state belongs to the local selection.
+      // welcome, so the SCM flow clears only the repo-derived state.
       if (hasScmOnboarding) {
         onboardingContext.clearDerivedState();
       } else {

--- a/static/app/views/onboarding/useWelcomeAnalyticsEffect.ts
+++ b/static/app/views/onboarding/useWelcomeAnalyticsEffect.ts
@@ -31,7 +31,13 @@ export function useWelcomeAnalyticsEffect() {
   useEffect(() => {
     if (onboardingContext.selectedPlatform) {
       // At this point the selectedSDK shall be undefined but just in case, cleaning this up here too
-      onboardingContext.resetOnboarding();
+      // messagingSetup is organization-scoped and must survive a return to
+      // welcome; only the repo-derived state belongs to the local selection.
+      if (hasScmOnboarding) {
+        onboardingContext.clearDerivedState();
+      } else {
+        onboardingContext.resetOnboarding();
+      }
     }
   }, [onboardingContext]);
 }

--- a/static/app/views/onboarding/useWelcomeAnalyticsEffect.ts
+++ b/static/app/views/onboarding/useWelcomeAnalyticsEffect.ts
@@ -31,13 +31,7 @@ export function useWelcomeAnalyticsEffect() {
   useEffect(() => {
     // At this point the selectedSDK shall be undefined but just in case, cleaning this up here too
     if (onboardingContext.selectedPlatform) {
-      // messagingSetup is organization-scoped and must survive a return to
-      // welcome, so the SCM flow clears only the repo-derived state.
-      if (hasScmOnboarding) {
-        onboardingContext.clearDerivedState();
-      } else {
-        onboardingContext.resetOnboarding();
-      }
+      onboardingContext.resetOnboarding();
     }
-  }, [onboardingContext, hasScmOnboarding]);
+  }, [onboardingContext]);
 }

--- a/static/app/views/onboarding/useWelcomeAnalyticsEffect.ts
+++ b/static/app/views/onboarding/useWelcomeAnalyticsEffect.ts
@@ -39,5 +39,5 @@ export function useWelcomeAnalyticsEffect() {
         onboardingContext.resetOnboarding();
       }
     }
-  }, [onboardingContext]);
+  }, [onboardingContext, hasScmOnboarding]);
 }


### PR DESCRIPTION
## TLDR

Adds a treatment-only fifth SCM onboarding step, `scm-messaging`, between platform/features and SDK setup, leaving the four-step control flow unchanged. The messaging destination persists in the onboarding session and survives refresh, Back within the flow, and repository or platform changes.

## Details

This lands the route and session contract only, with no forward navigation on completion: VDY-141 owns project and alert-rule creation on final Continue, VDY-143 the destination picker, VDY-146 analytics. A placeholder `onComplete` would strand users on a blank `setup-docs`, which renders off `recentCreatedProject` and bails when absent, so the flag stays scoped to one throwaway developer alias (getsentry/sentry-options-automator#9012) until VDY-141 lands. Revalidation of a restored destination is stacked in #121187.

Skipping now clears the session, which it previously did not do at all, through a new `discardOnboardingSession` rather than `resetOnboarding`. The latter removes storage inside a `setState` updater, and React drops that update when the provider unmounts in the same commit as the click, so on `scm-platform-features` and `scm-messaging` nothing was cleared and the next `/onboarding` visit resumed from a stale session. VDY-152 tracks the one remaining call with that shape, in the legacy flow's skip link.

Refs VDY-140
