### PR TITLE
fix(autofix): Prevent duplicate auto-triggered runs

### DIFF
--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -603,7 +603,11 @@ export function useExplorerAutofix(
     ]);
   }, []);
 
-  const {data: apiData, isPending} = useQuery({
+  const {
+    data: apiData,
+    isFetching,
+    isPending,
+  } = useQuery({
     ...explorerAutofixApiOptions(orgSlug, groupId),
     retry: false,
     enabled,
@@ -935,9 +939,11 @@ export function useExplorerAutofix(
      */
     runState,
     /**
-     * Whether the initial data fetch is pending.
+     * Whether we're fetching without an existing run to display.
+     * This includes background refetches of a cached null response so callers do not
+     * treat that stale response as confirmation that no run exists.
      */
-    isLoading: isPending,
+    isLoading: isPending || (isFetching && !runState),
     /**
      * Whether we're actively processing (used for UI indicators).
      */

--- a/static/app/components/events/autofix/v3/useAutoTriggerAutofix.spec.tsx
+++ b/static/app/components/events/autofix/v3/useAutoTriggerAutofix.spec.tsx
@@ -49,6 +49,44 @@ describe('useAutoTriggerAutofix', () => {
     expect(autofix.startStep).not.toHaveBeenCalled();
   });
 
+  it('does not start root_cause when an explorer autofix run already exists', () => {
+    const autofix = makeAutofix({
+      runState: {
+        run_id: 1,
+        blocks: [],
+        status: 'processing',
+        updated_at: '2024-01-02T00:00:00Z',
+      },
+    });
+    const group = GroupFixture({
+      seerAutofixLastTriggered: '2024-01-01T00:00:00Z',
+      seerExplorerAutofixLastTriggered: null,
+    });
+
+    renderHook(() => useAutoTriggerAutofix({autofix, group}));
+
+    expect(autofix.startStep).not.toHaveBeenCalled();
+  });
+
+  it('waits for explorer autofix state to load before triggering', () => {
+    const startStep = jest.fn();
+    let autofix = makeAutofix({isLoading: true, startStep});
+    const group = GroupFixture({
+      seerAutofixLastTriggered: '2024-01-01T00:00:00Z',
+      seerExplorerAutofixLastTriggered: null,
+    });
+
+    const {rerender} = renderHook(() => useAutoTriggerAutofix({autofix, group}));
+
+    expect(startStep).not.toHaveBeenCalled();
+
+    autofix = makeAutofix({isLoading: false, startStep});
+    rerender();
+
+    expect(startStep).toHaveBeenCalledWith('root_cause');
+    expect(startStep).toHaveBeenCalledTimes(1);
+  });
+
   it('does not trigger root_cause more than once on re-render', () => {
     const autofix = makeAutofix();
     const group = GroupFixture({

--- a/static/app/components/events/autofix/v3/useAutoTriggerAutofix.tsx
+++ b/static/app/components/events/autofix/v3/useAutoTriggerAutofix.tsx
@@ -11,11 +11,11 @@ interface UseAutoTriggerAutofixOptions {
 export function useAutoTriggerAutofix({autofix, group}: UseAutoTriggerAutofixOptions) {
   const alreadyTriggered = useRef(false);
 
-  // extract startStep first here so we can depend on it directly as `autofix` itself is unstable.
+  // Extract startStep so we don't depend on `autofix`, which is unstable.
   const startStep = autofix.startStep;
 
   useEffect(() => {
-    if (alreadyTriggered.current) {
+    if (alreadyTriggered.current || autofix.isLoading || autofix.runState) {
       return;
     }
 
@@ -30,5 +30,11 @@ export function useAutoTriggerAutofix({autofix, group}: UseAutoTriggerAutofixOpt
 
     alreadyTriggered.current = true;
     startStep('root_cause');
-  }, [group, startStep]);
+  }, [
+    autofix.isLoading,
+    autofix.runState,
+    group.seerAutofixLastTriggered,
+    group.seerExplorerAutofixLastTriggered,
+    startStep,
+  ]);
 }


### PR DESCRIPTION
Issue Details could kick off another Explorer Autofix run while an existing run was still loading because the migration hook only checked the group's completion timestamp.

Wait for fresh Explorer state and skip auto-triggering when a run already exists, including cached null responses being revalidated. Adds focused coverage for both cases.