### PR TITLE
feat(explore): Serve custom attribute context from postgres

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -201,13 +201,10 @@ EXPAND_QUERY_PARAM = OpenApiParameter(
     type=str,
     enum=["context"],
     # Internal-only for now, so exclude it from the public OpenAPI spec.
-    # Promoting it is tracked separately.
     exclude=True,
     description=(
         "Optional fields to expand. Pass `context` to include attribute metadata "
-        "(brief, examples, deprecation, etc.), sourced from the sentry "
-        "conventions, Sentry's own attribute definitions, or the organization's "
-        "authored context for custom attributes."
+        "(brief, examples, deprecation, etc.)."
     ),
 )
 
@@ -440,11 +437,8 @@ def build_custom_attribute_context(
 ) -> TraceItemAttributeContext:
     """
     Build context for a custom (user-authored) attribute from its stored row.
-
-    Unlike conventions and Sentry column definitions, this metadata is authored
-    by the organization, so it's marked ``isCustom`` to let clients tell the two
-    apart. ``brief`` is required by the write endpoint, and deprecation isn't
-    modeled for custom attributes, so ``isDeprecated`` is omitted.
+    Marked ``isCustom`` so clients can tell it from convention and Sentry-defined
+    context. Deprecation isn't modeled for custom attributes.
     """
     context: TraceItemAttributeContext = {"isCustom": True}
     if row.brief is not None:
@@ -463,28 +457,16 @@ def attach_custom_attribute_context(
     project_ids: Sequence[int],
 ) -> None:
     """
-    Attach user-authored context to the attributes that don't already have any,
-    with a single lookup for the whole page (no N+1).
+    Attach user-authored context to attributes that don't already have any, with a
+    single lookup for the whole page (no N+1). Skipping attributes that resolved
+    convention or Sentry-defined context keeps those sources winning, and bounds
+    the query to names in the response.
 
-    Only attributes left without context are considered: conventions and
-    Sentry-defined attributes already resolved theirs, and the write endpoint
-    rejects Sentry-owned names, so nothing here can shadow them. That also keeps
-    the query bounded to names actually present in the response rather than
-    every row the organization has authored.
-
-    Rows are stored against an attribute's internal name, which for a custom
-    attribute is also its ``name`` (only Sentry-owned attributes get a public
-    alias that differs, and those are excluded above).
-
-    Context is authored either for a single project or org-wide (see the PUT
-    endpoint), so reads mirror that: with exactly one project in scope its rows
-    take precedence over the org-wide ones, and with any other selection only
-    org-wide context applies (a per-project brief would otherwise be ambiguous
-    across a multi-project query).
+    Mirrors the write endpoint's scoping: with exactly one project in scope its
+    rows beat the org-wide ones, otherwise only org-wide context applies.
     """
-    # Keyed by (name, type), the identity rows are stored under: one name can
-    # appear twice in a page when a custom attribute was sent as both a string
-    # and a number, and each variant takes its own context.
+    # Keyed by (name, type) since a custom attribute sent as both a string and a
+    # number appears twice, and each variant takes its own context.
     describable = {
         (attribute["name"], attribute["attributeType"]): attribute
         for attribute in attributes
@@ -505,11 +487,8 @@ def attach_custom_attribute_context(
         attribute_key__in={name for name, _ in describable},
     )
 
-    # Apply org-wide rows (project_id None) first so a project-scoped row for the
-    # same attribute takes precedence.
+    # Org-wide rows first, so a project-scoped row overwrites them.
     for row in sorted(rows, key=lambda row: row.project_id is not None):
-        # A row whose type matches no variant of that name is simply not applied,
-        # so context authored for `number` can't attach to a `string` attribute.
         attribute = describable.get(
             (row.attribute_key, TraceItemAttributeTypes.get_type_name(row.attribute_type))
         )
@@ -592,9 +571,8 @@ def as_attribute_key(
         # `http.route` -- is missing from it and resolves as a `user` source
         # attribute. A Sentry-defined attribute that isn't a convention (e.g.
         # `span.description`) instead carries its context on the definition.
-        # Attributes left without a match get an empty context here; custom ones
-        # may still have user-authored context attached afterwards (see
-        # attach_custom_attribute_context).
+        # Custom attributes get an empty context here; see
+        # attach_custom_attribute_context.
         context = build_sentry_convention_context(
             public_name, name, attr_type
         ) or build_sentry_attribute_context(public_name, attr_type, item_type)
@@ -782,8 +760,7 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
                 attributes.extend(result_attributes)
                 if result_debug_info is not None:
                     debug_infos.append(result_debug_info)
-            # Attach authored context once all types are in, so the lookup covers
-            # the whole page in one query.
+            # Attach once all types are in, so the lookup is one query per page.
             if include_custom_context:
                 attach_custom_attribute_context(
                     attributes,

--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -482,8 +482,13 @@ def attach_custom_attribute_context(
     org-wide context applies (a per-project brief would otherwise be ambiguous
     across a multi-project query).
     """
+    # Keyed by (name, type), the identity rows are stored under: one name can
+    # appear twice in a page when a custom attribute was sent as both a string
+    # and a number, and each variant takes its own context.
     describable = {
-        attribute["name"]: attribute for attribute in attributes if not attribute.get("context")
+        (attribute["name"], attribute["attributeType"]): attribute
+        for attribute in attributes
+        if not attribute.get("context")
     }
     if not describable:
         return
@@ -497,18 +502,18 @@ def attach_custom_attribute_context(
         project_scope,
         organization=organization,
         item_type=TraceItemTypes.get_id_for_type_name(item_type.value),
-        attribute_key__in=list(describable),
+        attribute_key__in={name for name, _ in describable},
     )
 
     # Apply org-wide rows (project_id None) first so a project-scoped row for the
     # same attribute takes precedence.
     for row in sorted(rows, key=lambda row: row.project_id is not None):
-        attribute = describable.get(row.attribute_key)
-        # The stored type must match the attribute's own, so context authored for
-        # `number` doesn't attach to a same-named `string` attribute.
-        if attribute is None or attribute["attributeType"] != TraceItemAttributeTypes.get_type_name(
-            row.attribute_type
-        ):
+        # A row whose type matches no variant of that name is simply not applied,
+        # so context authored for `number` can't attach to a `string` attribute.
+        attribute = describable.get(
+            (row.attribute_key, TraceItemAttributeTypes.get_type_name(row.attribute_type))
+        )
+        if attribute is None:
             continue
         attribute["context"] = build_custom_attribute_context(row)
 

--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -456,15 +456,25 @@ def build_custom_attribute_context(
     return context
 
 
-def get_custom_attribute_contexts(
+def attach_custom_attribute_context(
+    attributes: list[TraceItemAttributeKey],
     organization: Organization,
     item_type: SupportedTraceItemType,
     project_ids: Sequence[int],
-) -> dict[tuple[str, str], TraceItemAttributeContext]:
+) -> None:
     """
-    Load user-authored attribute context for an organization, keyed by
-    ``(internal attribute name, attribute type)`` — the identity the write
-    endpoint stores rows under.
+    Attach user-authored context to the attributes that don't already have any,
+    with a single lookup for the whole page (no N+1).
+
+    Only attributes left without context are considered: conventions and
+    Sentry-defined attributes already resolved theirs, and the write endpoint
+    rejects Sentry-owned names, so nothing here can shadow them. That also keeps
+    the query bounded to names actually present in the response rather than
+    every row the organization has authored.
+
+    Rows are stored against an attribute's internal name, which for a custom
+    attribute is also its ``name`` (only Sentry-owned attributes get a public
+    alias that differs, and those are excluded above).
 
     Context is authored either for a single project or org-wide (see the PUT
     endpoint), so reads mirror that: with exactly one project in scope its rows
@@ -472,8 +482,13 @@ def get_custom_attribute_contexts(
     org-wide context applies (a per-project brief would otherwise be ambiguous
     across a multi-project query).
     """
-    scoped_project_id = project_ids[0] if len(project_ids) == 1 else None
+    describable = {
+        attribute["name"]: attribute for attribute in attributes if not attribute.get("context")
+    }
+    if not describable:
+        return
 
+    scoped_project_id = project_ids[0] if len(project_ids) == 1 else None
     project_scope = Q(project_id__isnull=True)
     if scoped_project_id is not None:
         project_scope |= Q(project_id=scoped_project_id)
@@ -482,18 +497,20 @@ def get_custom_attribute_contexts(
         project_scope,
         organization=organization,
         item_type=TraceItemTypes.get_id_for_type_name(item_type.value),
+        attribute_key__in=list(describable),
     )
 
-    contexts: dict[tuple[str, str], TraceItemAttributeContext] = {}
-    # Sort org-wide rows (project_id None) first so a project-scoped row for the
-    # same attribute overwrites them.
+    # Apply org-wide rows (project_id None) first so a project-scoped row for the
+    # same attribute takes precedence.
     for row in sorted(rows, key=lambda row: row.project_id is not None):
-        attribute_type = TraceItemAttributeTypes.get_type_name(row.attribute_type)
-        if attribute_type is None:
+        attribute = describable.get(row.attribute_key)
+        # The stored type must match the attribute's own, so context authored for
+        # `number` doesn't attach to a same-named `string` attribute.
+        if attribute is None or attribute["attributeType"] != TraceItemAttributeTypes.get_type_name(
+            row.attribute_type
+        ):
             continue
-        contexts[(row.attribute_key, attribute_type)] = build_custom_attribute_context(row)
-
-    return contexts
+        attribute["context"] = build_custom_attribute_context(row)
 
 
 def is_known_attribute(name: str, definitions: ColumnDefinitions) -> bool:
@@ -516,7 +533,6 @@ def as_attribute_key(
     item_type: SupportedTraceItemType,
     is_proxy: bool = False,
     include_context: bool = False,
-    custom_contexts: dict[tuple[str, str], TraceItemAttributeContext] | None = None,
 ) -> TraceItemAttributeKey:
     public_key, public_name, attribute_source = translate_internal_to_public_alias(
         name, attr_type, item_type
@@ -571,15 +587,12 @@ def as_attribute_key(
         # `http.route` -- is missing from it and resolves as a `user` source
         # attribute. A Sentry-defined attribute that isn't a convention (e.g.
         # `span.description`) instead carries its context on the definition.
-        # Anything left over is a custom attribute, which may have
-        # user-authored context stored against its internal name; the write
-        # endpoint rejects Sentry-owned names, so the sources can't collide.
-        # Attributes with no match at all get an empty context.
-        context = (
-            build_sentry_convention_context(public_name, name, attr_type)
-            or build_sentry_attribute_context(public_name, attr_type, item_type)
-            or (custom_contexts or {}).get((name, attr_type))
-        )
+        # Attributes left without a match get an empty context here; custom ones
+        # may still have user-authored context attached afterwards (see
+        # attach_custom_attribute_context).
+        context = build_sentry_convention_context(
+            public_name, name, attr_type
+        ) or build_sentry_attribute_context(public_name, attr_type, item_type)
         attribute_key["context"] = context or {}
 
     return attribute_key
@@ -730,17 +743,10 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
         include_context = "context" in serialized.get("expand", set())
 
         # Custom (user-authored) context is gated behind the
-        # data-browsing-attribute-context feature. Loaded once per request rather
-        # than per attribute, so serialization stays free of queries.
-        custom_contexts: dict[tuple[str, str], TraceItemAttributeContext] = {}
-        if include_context and features.has(
+        # data-browsing-attribute-context feature, unlike conventions context.
+        include_custom_context = include_context and features.has(
             "organizations:data-browsing-attribute-context", organization, actor=request.user
-        ):
-            custom_contexts = get_custom_attribute_contexts(
-                organization,
-                trace_item_type,
-                [project.id for project in snuba_params.projects],
-            )
+        )
 
         def data_fn(offset: int, limit: int) -> list[TraceItemAttributeKey]:
             futures = []
@@ -762,7 +768,6 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
                             trace_item_type,
                             include_internal,
                             include_context,
-                            custom_contexts,
                             debug=debug,
                         )
                     )
@@ -772,6 +777,15 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
                 attributes.extend(result_attributes)
                 if result_debug_info is not None:
                     debug_infos.append(result_debug_info)
+            # Attach authored context once all types are in, so the lookup covers
+            # the whole page in one query.
+            if include_custom_context:
+                attach_custom_attribute_context(
+                    attributes,
+                    organization,
+                    trace_item_type,
+                    [project.id for project in snuba_params.projects],
+                )
             return attributes
 
         response = self.paginate(
@@ -797,7 +811,6 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
         trace_item_type: SupportedTraceItemType,
         include_internal: bool,
         include_context: bool = False,
-        custom_contexts: dict[tuple[str, str], TraceItemAttributeContext] | None = None,
         debug: str | bool = False,
     ) -> tuple[list[TraceItemAttributeKey], dict | None]:
         debug_info: dict | None = None
@@ -904,7 +917,6 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
                 aliased_attributes,
                 all_aliased_attributes,
                 include_context,
-                custom_contexts,
             )
 
             sentry_sdk.set_context("api_response", {"attributes": attributes})
@@ -923,7 +935,6 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
         aliased_attributes: list[ResolvedAttribute | ProxyResolvedAttribute],
         exclude_attributes: list[ResolvedAttribute | ProxyResolvedAttribute],
         include_context: bool = False,
-        custom_contexts: dict[tuple[str, str], TraceItemAttributeContext] | None = None,
     ) -> list[TraceItemAttributeKey]:
         attribute_keys = {}
         for attribute in rpc_response.attributes:
@@ -934,7 +945,6 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
                 attribute_type,
                 trace_item_type,
                 include_context=include_context,
-                custom_contexts=custom_contexts,
             )
             if (
                 _can_expose_data_attribute_to_api(

--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from typing import Any, Literal
 
 import sentry_sdk
+from django.db.models import Q
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from google.protobuf.json_format import MessageToDict
 from google.protobuf.timestamp_pb2 import Timestamp
@@ -51,6 +52,8 @@ from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.auth.staff import is_active_staff
 from sentry.auth.superuser import is_active_superuser
 from sentry.exceptions import InvalidSearchQuery
+from sentry.explore.models import TraceItemAttributeContext as TraceItemAttributeContextModel
+from sentry.explore.models import TraceItemAttributeTypes, TraceItemTypes
 from sentry.models.organization import Organization
 from sentry.models.release import Release
 from sentry.models.releaseenvironment import ReleaseEnvironment
@@ -197,14 +200,14 @@ EXPAND_QUERY_PARAM = OpenApiParameter(
     many=True,
     type=str,
     enum=["context"],
-    # Internal-only for now (context is currently limited to sentry conventions;
-    # custom attribute context is still to come), so exclude it from the public
-    # OpenAPI spec.
+    # Internal-only for now, so exclude it from the public OpenAPI spec.
+    # Promoting it is tracked separately.
     exclude=True,
     description=(
-        "Optional fields to expand. Pass `context` to include the sentry "
-        "conventions metadata (brief, examples, deprecation, etc.) for "
-        "attributes that map to a known convention."
+        "Optional fields to expand. Pass `context` to include attribute metadata "
+        "(brief, examples, deprecation, etc.), sourced from the sentry "
+        "conventions, Sentry's own attribute definitions, or the organization's "
+        "authored context for custom attributes."
     ),
 )
 
@@ -432,6 +435,67 @@ def build_sentry_attribute_context(
     return result
 
 
+def build_custom_attribute_context(
+    row: TraceItemAttributeContextModel,
+) -> TraceItemAttributeContext:
+    """
+    Build context for a custom (user-authored) attribute from its stored row.
+
+    Unlike conventions and Sentry column definitions, this metadata is authored
+    by the organization, so it's marked ``isCustom`` to let clients tell the two
+    apart. ``brief`` is required by the write endpoint, and deprecation isn't
+    modeled for custom attributes, so ``isDeprecated`` is omitted.
+    """
+    context: TraceItemAttributeContext = {"isCustom": True}
+    if row.brief is not None:
+        context["brief"] = row.brief
+    if row.additional_context:
+        context["details"] = [row.additional_context]
+    if row.examples:
+        context["examples"] = list(row.examples)
+    return context
+
+
+def get_custom_attribute_contexts(
+    organization: Organization,
+    item_type: SupportedTraceItemType,
+    project_ids: Sequence[int],
+) -> dict[tuple[str, str], TraceItemAttributeContext]:
+    """
+    Load user-authored attribute context for an organization, keyed by
+    ``(internal attribute name, attribute type)`` — the identity the write
+    endpoint stores rows under.
+
+    Context is authored either for a single project or org-wide (see the PUT
+    endpoint), so reads mirror that: with exactly one project in scope its rows
+    take precedence over the org-wide ones, and with any other selection only
+    org-wide context applies (a per-project brief would otherwise be ambiguous
+    across a multi-project query).
+    """
+    scoped_project_id = project_ids[0] if len(project_ids) == 1 else None
+
+    project_scope = Q(project_id__isnull=True)
+    if scoped_project_id is not None:
+        project_scope |= Q(project_id=scoped_project_id)
+
+    rows = TraceItemAttributeContextModel.objects.filter(
+        project_scope,
+        organization=organization,
+        item_type=TraceItemTypes.get_id_for_type_name(item_type.value),
+    )
+
+    contexts: dict[tuple[str, str], TraceItemAttributeContext] = {}
+    # Sort org-wide rows (project_id None) first so a project-scoped row for the
+    # same attribute overwrites them.
+    for row in sorted(rows, key=lambda row: row.project_id is not None):
+        attribute_type = TraceItemAttributeTypes.get_type_name(row.attribute_type)
+        if attribute_type is None:
+            continue
+        contexts[(row.attribute_key, attribute_type)] = build_custom_attribute_context(row)
+
+    return contexts
+
+
 def is_known_attribute(name: str, definitions: ColumnDefinitions) -> bool:
     """
     Whether ``name`` is an attribute Sentry defines — a column public/secondary
@@ -452,6 +516,7 @@ def as_attribute_key(
     item_type: SupportedTraceItemType,
     is_proxy: bool = False,
     include_context: bool = False,
+    custom_contexts: dict[tuple[str, str], TraceItemAttributeContext] | None = None,
 ) -> TraceItemAttributeKey:
     public_key, public_name, attribute_source = translate_internal_to_public_alias(
         name, attr_type, item_type
@@ -505,11 +570,16 @@ def as_attribute_key(
         # convention whose name is already the same internally -- e.g.
         # `http.route` -- is missing from it and resolves as a `user` source
         # attribute. A Sentry-defined attribute that isn't a convention (e.g.
-        # `span.description`) instead carries its context on the definition. User
-        # attributes with no match get an empty context.
-        context = build_sentry_convention_context(
-            public_name, name, attr_type
-        ) or build_sentry_attribute_context(public_name, attr_type, item_type)
+        # `span.description`) instead carries its context on the definition.
+        # Anything left over is a custom attribute, which may have
+        # user-authored context stored against its internal name; the write
+        # endpoint rejects Sentry-owned names, so the sources can't collide.
+        # Attributes with no match at all get an empty context.
+        context = (
+            build_sentry_convention_context(public_name, name, attr_type)
+            or build_sentry_attribute_context(public_name, attr_type, item_type)
+            or (custom_contexts or {}).get((name, attr_type))
+        )
         attribute_key["context"] = context or {}
 
     return attribute_key
@@ -656,10 +726,21 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
 
         # Expand the sentry conventions context when explicitly requested via
         # `expand=context`. The conventions metadata is static with no data
-        # implications, so it isn't gated. (Custom attribute context, planned
-        # later, will be gated behind the data-browsing-attribute-context
-        # feature.)
+        # implications, so it isn't gated.
         include_context = "context" in serialized.get("expand", set())
+
+        # Custom (user-authored) context is gated behind the
+        # data-browsing-attribute-context feature. Loaded once per request rather
+        # than per attribute, so serialization stays free of queries.
+        custom_contexts: dict[tuple[str, str], TraceItemAttributeContext] = {}
+        if include_context and features.has(
+            "organizations:data-browsing-attribute-context", organization, actor=request.user
+        ):
+            custom_contexts = get_custom_attribute_contexts(
+                organization,
+                trace_item_type,
+                [project.id for project in snuba_params.projects],
+            )
 
         def data_fn(offset: int, limit: int) -> list[TraceItemAttributeKey]:
             futures = []
@@ -681,6 +762,7 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
                             trace_item_type,
                             include_internal,
                             include_context,
+                            custom_contexts,
                             debug=debug,
                         )
                     )
@@ -715,6 +797,7 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
         trace_item_type: SupportedTraceItemType,
         include_internal: bool,
         include_context: bool = False,
+        custom_contexts: dict[tuple[str, str], TraceItemAttributeContext] | None = None,
         debug: str | bool = False,
     ) -> tuple[list[TraceItemAttributeKey], dict | None]:
         debug_info: dict | None = None
@@ -821,6 +904,7 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
                 aliased_attributes,
                 all_aliased_attributes,
                 include_context,
+                custom_contexts,
             )
 
             sentry_sdk.set_context("api_response", {"attributes": attributes})
@@ -839,6 +923,7 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
         aliased_attributes: list[ResolvedAttribute | ProxyResolvedAttribute],
         exclude_attributes: list[ResolvedAttribute | ProxyResolvedAttribute],
         include_context: bool = False,
+        custom_contexts: dict[tuple[str, str], TraceItemAttributeContext] | None = None,
     ) -> list[TraceItemAttributeKey]:
         attribute_keys = {}
         for attribute in rpc_response.attributes:
@@ -849,6 +934,7 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
                 attribute_type,
                 trace_item_type,
                 include_context=include_context,
+                custom_contexts=custom_contexts,
             )
             if (
                 _can_expose_data_attribute_to_api(

--- a/src/sentry/api/endpoints/organization_trace_item_attributes_types.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes_types.py
@@ -11,29 +11,34 @@ class TraceItemAttributeContext(TypedDict):
     Additional, mostly-static metadata about an attribute.
 
     When ``expand=context`` is requested, context is attached to every
-    attribute. Today the metadata is sourced from the sentry conventions
-    (``sentry_conventions.attributes.ATTRIBUTE_METADATA``), matched by attribute
-    name (and type when known) regardless of the attribute's source, so any
-    attribute that maps to a known convention carries that metadata (only the
-    fields actually present are included) while the rest get an empty context.
-    Serving context for custom attributes is planned (gated behind the
-    ``data-browsing-attribute-context`` feature), at which point the empty
-    contexts will start to be populated.
+    attribute. Metadata comes from three sources, in precedence order: the
+    sentry conventions (``sentry_conventions.attributes.ATTRIBUTE_METADATA``,
+    matched by attribute name and type regardless of the attribute's source),
+    Sentry's own column definitions (e.g. ``span.description``), and
+    user-authored context stored in ``TraceItemAttributeContext`` (gated behind
+    the ``data-browsing-attribute-context`` feature). Only the fields actually
+    available for an attribute are included; an attribute with no metadata from
+    any source gets an empty context.
     """
 
     # Whether this context comes from a known sentry convention. Present (and
     # True) for a known convention. Lets clients distinguish sentry-convention
-    # context from custom (user-authored) context once the latter is served.
+    # context from Sentry-defined and custom (user-authored) context.
     isConvention: NotRequired[bool]
+    # Whether this context was authored by a user (as opposed to sourced from
+    # the sentry conventions or a Sentry column definition). Present (and True)
+    # only for user-authored context. Sentry-owned attributes are never
+    # user-describable, so this is mutually exclusive with ``isConvention``.
+    isCustom: NotRequired[bool]
     # A short, human-readable description of the attribute. Present for a known
-    # convention.
+    # convention, and for user-authored context (where it is required).
     brief: NotRequired[str]
     # Whether the convention has been deprecated. Present for a known
-    # convention.
+    # convention. User-authored context has no notion of deprecation.
     isDeprecated: NotRequired[bool]
     # Longer-form notes that add nuance beyond the brief (e.g. caveats,
     # double-counting warnings). Sourced from the convention's
-    # ``additional_context``.
+    # ``additional_context``, or from user-authored ``additional_context``.
     details: NotRequired[list[str]]
     # Example value(s) for the attribute, normalized to a list.
     examples: NotRequired[list[Any]]
@@ -47,8 +52,7 @@ class TraceItemAttributeKey(TypedDict):
     secondaryAliases: NotRequired[list[str]]
     attributeSource: TraceItemAttributeSource
     attributeType: Literal["string", "number", "boolean"]
-    # Attribute context, only present when requested via ``expand=context`` (and
-    # gated behind the feature flag). Attached to every attribute when
-    # requested; currently empty for custom (non-convention) attributes, which
-    # will be populated once custom attribute context is served.
+    # Attribute context, only present when requested via ``expand=context``.
+    # Attached to every attribute when requested, and empty for attributes with
+    # no metadata from any source.
     context: NotRequired[TraceItemAttributeContext]

--- a/src/sentry/api/endpoints/organization_trace_item_attributes_types.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes_types.py
@@ -10,35 +10,27 @@ class TraceItemAttributeContext(TypedDict):
     """
     Additional, mostly-static metadata about an attribute.
 
-    When ``expand=context`` is requested, context is attached to every
-    attribute. Metadata comes from three sources, in precedence order: the
-    sentry conventions (``sentry_conventions.attributes.ATTRIBUTE_METADATA``,
-    matched by attribute name and type regardless of the attribute's source),
-    Sentry's own column definitions (e.g. ``span.description``), and
-    user-authored context stored in ``TraceItemAttributeContext`` (gated behind
-    the ``data-browsing-attribute-context`` feature). Only the fields actually
-    available for an attribute are included; an attribute with no metadata from
-    any source gets an empty context.
+    When ``expand=context`` is requested, context is attached to every attribute.
+    Metadata comes from the sentry conventions, Sentry's own column definitions,
+    or user-authored context (gated behind ``data-browsing-attribute-context``),
+    in that precedence order. Only the fields available are included, so an
+    attribute with no metadata gets an empty context.
     """
 
     # Whether this context comes from a known sentry convention. Present (and
-    # True) for a known convention. Lets clients distinguish sentry-convention
-    # context from Sentry-defined and custom (user-authored) context.
+    # True) for a known convention.
     isConvention: NotRequired[bool]
-    # Whether this context was authored by a user (as opposed to sourced from
-    # the sentry conventions or a Sentry column definition). Present (and True)
-    # only for user-authored context. Sentry-owned attributes are never
-    # user-describable, so this is mutually exclusive with ``isConvention``.
+    # Whether this context was authored by a user. Present (and True) only for
+    # user-authored context, so mutually exclusive with ``isConvention``.
     isCustom: NotRequired[bool]
     # A short, human-readable description of the attribute. Present for a known
     # convention, and for user-authored context (where it is required).
     brief: NotRequired[str]
     # Whether the convention has been deprecated. Present for a known
-    # convention. User-authored context has no notion of deprecation.
+    # convention; not modeled for user-authored context.
     isDeprecated: NotRequired[bool]
     # Longer-form notes that add nuance beyond the brief (e.g. caveats,
-    # double-counting warnings). Sourced from the convention's
-    # ``additional_context``, or from user-authored ``additional_context``.
+    # double-counting warnings). Sourced from ``additional_context``.
     details: NotRequired[list[str]]
     # Example value(s) for the attribute, normalized to a list.
     examples: NotRequired[list[Any]]
@@ -53,6 +45,5 @@ class TraceItemAttributeKey(TypedDict):
     attributeSource: TraceItemAttributeSource
     attributeType: Literal["string", "number", "boolean"]
     # Attribute context, only present when requested via ``expand=context``.
-    # Attached to every attribute when requested, and empty for attributes with
-    # no metadata from any source.
+    # Attached to every attribute, and empty when it has no metadata.
     context: NotRequired[TraceItemAttributeContext]

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -769,6 +769,50 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
             "brief": "Value of the cart in cents",
         }
 
+    def test_expand_context_custom_attribute_same_name_both_types(self) -> None:
+        # A custom attribute sent as a string on one span and a number on another
+        # appears twice in an all-types response, under one name. Each variant
+        # must resolve its own context rather than one clobbering the other.
+        self.store_segment(
+            self.project.id,
+            uuid4().hex,
+            uuid4().hex,
+            organization_id=self.organization.id,
+            timestamp=before_now(days=0, minutes=10).replace(microsecond=0),
+            tags={"cart_total": "free"},
+        )
+        self.store_segment(
+            self.project.id,
+            uuid4().hex,
+            uuid4().hex,
+            organization_id=self.organization.id,
+            timestamp=before_now(days=0, minutes=9).replace(microsecond=0),
+            measurements={"cart_total": 42.0},
+        )
+        self.create_context(
+            "cart_total",
+            attribute_type=TraceItemAttributeTypes.STRING,
+            brief="Cart tier label",
+        )
+
+        response = self.do_request(
+            query={"expand": "context"},
+            features={
+                **self.feature_flags,
+                "organizations:data-browsing-attribute-context": True,
+            },
+        )
+        assert response.status_code == 200, response.data
+
+        attributes = {item["key"]: item for item in response.data}
+        assert attributes["cart_total"]["attributeType"] == "string"
+        assert attributes["cart_total"]["context"] == {
+            "isCustom": True,
+            "brief": "Cart tier label",
+        }
+        # The number variant has no context authored for its type.
+        assert attributes["tags[cart_total,number]"]["context"] == {}
+
     def test_expand_context_custom_attribute_requires_feature(self) -> None:
         self._store_basic_segment()
         self.create_context("foo")

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -693,9 +693,8 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         assert response.status_code == 200, response.data
 
         attributes = {item["key"]: item for item in response.data}
-        # User-authored context is marked isCustom so clients can tell it apart
-        # from convention/Sentry-defined context. Deprecation isn't modeled for
-        # custom attributes, so isDeprecated is absent.
+        # Marked isCustom, and no isDeprecated since deprecation isn't modeled
+        # for custom attributes.
         assert attributes["foo"]["context"] == {
             "isCustom": True,
             "brief": "How foo is used here",
@@ -708,8 +707,7 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
     def test_expand_context_custom_attribute_single_bounded_query(self) -> None:
         self._store_basic_segment()
         self.create_context("foo")
-        # Authored rows for attributes that aren't in the response must not be
-        # fetched: the lookup is bounded to the names actually being serialized.
+        # Rows for attributes not in the response must not be fetched.
         for i in range(10):
             self.create_context(f"not_in_response_{i}")
 
@@ -745,9 +743,8 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
             timestamp=before_now(days=0, minutes=10).replace(microsecond=0),
             measurements={"cart_total": 42.0},
         )
-        # Number attributes are exposed under a `tags[...]` key but context is
-        # keyed by the attribute's internal name, which is what the write
-        # endpoint stores.
+        # Number attributes are exposed under a `tags[...]` key, but context is
+        # matched on the internal name the write endpoint stores.
         self.create_context(
             "cart_total",
             attribute_type=TraceItemAttributeTypes.NUMBER,
@@ -770,9 +767,8 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         }
 
     def test_expand_context_custom_attribute_same_name_both_types(self) -> None:
-        # A custom attribute sent as a string on one span and a number on another
-        # appears twice in an all-types response, under one name. Each variant
-        # must resolve its own context rather than one clobbering the other.
+        # Sent as a string on one span and a number on another, so it appears
+        # twice under one name; each variant resolves its own context.
         self.store_segment(
             self.project.id,
             uuid4().hex,
@@ -877,8 +873,7 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
 
     def test_expand_context_custom_attribute_type_must_match(self) -> None:
         self._store_basic_segment()
-        # `foo` is a string attribute; context authored for the number type must
-        # not attach to it.
+        # `foo` is a string attribute, so number-typed context must not attach.
         self.create_context("foo", attribute_type=TraceItemAttributeTypes.NUMBER)
 
         response = self.do_request(

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -3,6 +3,8 @@ from unittest import mock
 from uuid import uuid4
 
 import pytest
+from django.db import connections
+from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from rest_framework.exceptions import ErrorDetail
 from sentry_conventions.attributes import ATTRIBUTE_METADATA
@@ -702,6 +704,37 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         }
         # A custom attribute with no authored context still gets an empty one.
         assert attributes["http.route"]["context"]["isConvention"] is True
+
+    def test_expand_context_custom_attribute_single_bounded_query(self) -> None:
+        self._store_basic_segment()
+        self.create_context("foo")
+        # Authored rows for attributes that aren't in the response must not be
+        # fetched: the lookup is bounded to the names actually being serialized.
+        for i in range(10):
+            self.create_context(f"not_in_response_{i}")
+
+        with CaptureQueriesContext(connections["default"]) as captured:
+            response = self.do_request(
+                query={"attributeType": "string", "expand": "context"},
+                features={
+                    **self.feature_flags,
+                    "organizations:data-browsing-attribute-context": True,
+                },
+            )
+        assert response.status_code == 200, response.data
+
+        context_queries = [
+            query["sql"]
+            for query in captured.captured_queries
+            if "explore_traceitemattributecontext" in (query["sql"] or "")
+        ]
+        # One query for the whole page, regardless of how many attributes it has.
+        assert len(context_queries) == 1
+        assert "IN (" in context_queries[0]
+        assert "not_in_response_0" not in context_queries[0]
+
+        attributes = {item["key"]: item for item in response.data}
+        assert attributes["foo"]["context"]["isCustom"] is True
 
     def test_expand_context_custom_number_attribute(self) -> None:
         self.store_segment(

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -13,6 +13,11 @@ from sentry.api.endpoints.organization_trace_item_attributes_types import (
     TraceItemAttributeKey,
 )
 from sentry.exceptions import InvalidSearchQuery
+from sentry.explore.models import (
+    TraceItemAttributeContext,
+    TraceItemAttributeTypes,
+    TraceItemTypes,
+)
 from sentry.search.eap import constants
 from sentry.search.eap.spans.definitions import SPAN_DEFINITIONS
 from sentry.search.eap.types import SupportedTraceItemType
@@ -648,11 +653,191 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         assert message["name"] == "message"
         assert message["context"] == {}
 
+    def create_context(
+        self,
+        attribute_key,
+        project=None,
+        item_type=TraceItemTypes.SPANS,
+        attribute_type=TraceItemAttributeTypes.STRING,
+        **kwargs,
+    ):
+        kwargs.setdefault("brief", f"Authored brief for {attribute_key}")
+        return TraceItemAttributeContext.objects.create(
+            organization=self.organization,
+            project=project,
+            attribute_key=attribute_key,
+            item_type=item_type,
+            attribute_type=attribute_type,
+            created_by_id=self.user.id,
+            **kwargs,
+        )
+
+    def test_expand_context_custom_attribute(self) -> None:
+        self._store_basic_segment()
+        self.create_context(
+            "foo",
+            brief="How foo is used here",
+            additional_context="Only set by the checkout service.",
+            examples=["a", "b"],
+        )
+
+        response = self.do_request(
+            query={"attributeType": "string", "expand": "context"},
+            features={
+                **self.feature_flags,
+                "organizations:data-browsing-attribute-context": True,
+            },
+        )
+        assert response.status_code == 200, response.data
+
+        attributes = {item["key"]: item for item in response.data}
+        # User-authored context is marked isCustom so clients can tell it apart
+        # from convention/Sentry-defined context. Deprecation isn't modeled for
+        # custom attributes, so isDeprecated is absent.
+        assert attributes["foo"]["context"] == {
+            "isCustom": True,
+            "brief": "How foo is used here",
+            "details": ["Only set by the checkout service."],
+            "examples": ["a", "b"],
+        }
+        # A custom attribute with no authored context still gets an empty one.
+        assert attributes["http.route"]["context"]["isConvention"] is True
+
+    def test_expand_context_custom_number_attribute(self) -> None:
+        self.store_segment(
+            self.project.id,
+            uuid4().hex,
+            uuid4().hex,
+            organization_id=self.organization.id,
+            timestamp=before_now(days=0, minutes=10).replace(microsecond=0),
+            measurements={"cart_total": 42.0},
+        )
+        # Number attributes are exposed under a `tags[...]` key but context is
+        # keyed by the attribute's internal name, which is what the write
+        # endpoint stores.
+        self.create_context(
+            "cart_total",
+            attribute_type=TraceItemAttributeTypes.NUMBER,
+            brief="Value of the cart in cents",
+        )
+
+        response = self.do_request(
+            query={"attributeType": "number", "expand": "context"},
+            features={
+                **self.feature_flags,
+                "organizations:data-browsing-attribute-context": True,
+            },
+        )
+        assert response.status_code == 200, response.data
+
+        attributes = {item["key"]: item for item in response.data}
+        assert attributes["tags[cart_total,number]"]["context"] == {
+            "isCustom": True,
+            "brief": "Value of the cart in cents",
+        }
+
+    def test_expand_context_custom_attribute_requires_feature(self) -> None:
+        self._store_basic_segment()
+        self.create_context("foo")
+
+        # Custom context is gated, unlike conventions context.
+        response = self.do_request(
+            query={"attributeType": "string", "expand": "context"},
+            features={
+                **self.feature_flags,
+                "organizations:data-browsing-attribute-context": False,
+            },
+        )
+        assert response.status_code == 200, response.data
+
+        attributes = {item["key"]: item for item in response.data}
+        assert attributes["foo"]["context"] == {}
+        assert attributes["device.class"]["context"]["isConvention"] is True
+
+    def test_expand_context_custom_attribute_project_scoped(self) -> None:
+        self._store_basic_segment()
+        other_project = self.create_project(organization=self.organization)
+        # Context authored against a different project must not leak into this
+        # project's response.
+        self.create_context("foo", project=other_project, brief="Other project brief")
+
+        response = self.do_request(
+            query={
+                "attributeType": "string",
+                "expand": "context",
+                "project": self.project.id,
+            },
+            features={
+                **self.feature_flags,
+                "organizations:data-browsing-attribute-context": True,
+            },
+        )
+        assert response.status_code == 200, response.data
+
+        attributes = {item["key"]: item for item in response.data}
+        assert attributes["foo"]["context"] == {}
+
+    def test_expand_context_custom_attribute_project_overrides_org_wide(self) -> None:
+        self._store_basic_segment()
+        self.create_context("foo", brief="Org-wide brief")
+        self.create_context("foo", project=self.project, brief="Project brief")
+
+        response = self.do_request(
+            query={
+                "attributeType": "string",
+                "expand": "context",
+                "project": self.project.id,
+            },
+            features={
+                **self.feature_flags,
+                "organizations:data-browsing-attribute-context": True,
+            },
+        )
+        assert response.status_code == 200, response.data
+
+        attributes = {item["key"]: item for item in response.data}
+        assert attributes["foo"]["context"]["brief"] == "Project brief"
+
+    def test_expand_context_custom_attribute_type_must_match(self) -> None:
+        self._store_basic_segment()
+        # `foo` is a string attribute; context authored for the number type must
+        # not attach to it.
+        self.create_context("foo", attribute_type=TraceItemAttributeTypes.NUMBER)
+
+        response = self.do_request(
+            query={"attributeType": "string", "expand": "context"},
+            features={
+                **self.feature_flags,
+                "organizations:data-browsing-attribute-context": True,
+            },
+        )
+        assert response.status_code == 200, response.data
+
+        attributes = {item["key"]: item for item in response.data}
+        assert attributes["foo"]["context"] == {}
+
+    def test_expand_context_custom_attribute_item_type_must_match(self) -> None:
+        self._store_basic_segment()
+        # Context authored for logs must not attach to a span attribute.
+        self.create_context("foo", item_type=TraceItemTypes.LOGS)
+
+        response = self.do_request(
+            query={"attributeType": "string", "expand": "context"},
+            features={
+                **self.feature_flags,
+                "organizations:data-browsing-attribute-context": True,
+            },
+        )
+        assert response.status_code == 200, response.data
+
+        attributes = {item["key"]: item for item in response.data}
+        assert attributes["foo"]["context"] == {}
+
     def test_expand_context_without_feature_flag(self) -> None:
         self._store_basic_segment()
 
-        # Context is no longer gated by a feature flag: expand=context alone is
-        # enough, even with the data-browsing-attribute-context flag disabled.
+        # Conventions context is not gated by a feature flag: expand=context alone
+        # is enough, even with the data-browsing-attribute-context flag disabled.
         response = self.do_request(
             query={"attributeType": "string", "expand": "context"},
             features={


### PR DESCRIPTION
The `/trace-items/attributes/` endpoint only built attribute context from the
sentry conventions and Sentry's own column definitions, so custom attributes
always came back with an empty context. Rows written by the
`/trace-items/attributes/context/` PUT endpoint (BROWSE-509) were never read
back anywhere.

This adds the read side: user-authored context is looked up for the attributes
in a response and attached, marked `isCustom` so clients can distinguish it from
convention and Sentry-defined context.

```json
{
  "key": "tags[cart_total,number]",
  "name": "cart_total",
  "attributeType": "number",
  "context": {
    "isCustom": true,
    "brief": "Value of the cart in cents",
    "details": ["Only present on payment spans."],
    "examples": ["visa", "amex"]
  }
}
```

### Notes

- **One bounded lookup per page**, not per attribute — mirrors `_attach_context`
  in the trace-items metrics endpoint, which already does this for metric
  context. Context is attached after the per-type queries resolve, so the query
  is restricted to the attribute names actually being serialized rather than
  every row the organization has authored.
- **Only attributes still without context** are considered. Conventions and
  Sentry-defined attributes have already resolved theirs by that point, and the
  write endpoint rejects Sentry-owned names, so nothing custom can shadow a
  convention — precedence holds by construction rather than by the ordering of a
  fallback chain.
- **Matched on internal attribute name and type**, the identity the write
  endpoint stores rows under. Type is part of the match so context authored for
  `number` doesn't attach to a same-named `string` attribute.
- **Project scoping** mirrors the write endpoint: with exactly one project in
  scope its rows take precedence over org-wide ones; with any other selection
  only org-wide context applies, since a per-project brief would be ambiguous
  across a multi-project query.
- **Gated** behind `data-browsing-attribute-context`. Conventions context stays
  ungated, as before.

### Response shape

`isCustom` is a new field on `context`. `expand=context` is still `exclude=True`
in the OpenAPI spec, so the published spec doesn't change (promoting it is
BROWSE-593).

### Tests

Eight new cases: context attached, feature gating, project scoping,
project-overrides-org-wide, non-matching attribute type, non-matching item type,
number-typed attributes (which take the `tags[…,number]` key path), and one
asserting the lookup is a single query bounded to the names in the response.

Refs BROWSE-595
