### PR TITLE
Require RpcUser for select option, create and delete external issue

### DIFF
--- a/src/sentry/sentry_apps/api/endpoints/installation_external_issues.py
+++ b/src/sentry/sentry_apps/api/endpoints/installation_external_issues.py
@@ -94,7 +94,6 @@ class SentryAppInstallationExternalIssuesEndpoint(ExternalIssueBaseEndpoint):
         if rpc_user is None:
             return Response({"detail": "Authentication credentials were not provided."}, status=401)
 
-        # Do not pass `user` until cells accept the new RPC arg everywhere (deploy phase 2).
         result = sentry_app_cell_service.create_external_issue(
             organization_id=installation.organization_id,
             installation=installation,

--- a/src/sentry/sentry_apps/services/cell/impl.py
+++ b/src/sentry/sentry_apps/services/cell/impl.py
@@ -7,7 +7,6 @@ from sentry import deletions, tsdb
 from sentry.auth.access import Access, OrganizationGlobalMembership, from_user
 from sentry.auth.services.auth.model import AuthenticationContext
 from sentry.issues.action_log import (
-    SYSTEM_ACTOR,
     ActionSource,
     GroupActionActor,
     action_context_scope,
@@ -56,7 +55,7 @@ class DatabaseBackedSentryAppCellService(SentryAppCellService):
         organization_id: int,
         installation: RpcSentryAppInstallation,
         uri: str,
-        user: RpcUser | None = None,
+        user: RpcUser,
         project_id: int | None = None,
         query: str | None = None,
         dependent_data: str | None = None,
@@ -79,19 +78,18 @@ class DatabaseBackedSentryAppCellService(SentryAppCellService):
                         status_code=404,
                     )
                 )
-            if user is not None:
-                access = self._access_for_installation_user(
-                    organization=project.organization,
-                    installation=installation,
-                    user=user,
-                )
-                if not access.has_project_access(project):
-                    return RpcSelectRequesterResult(
-                        error=RpcSentryAppError(
-                            message="You do not have permission to access this project.",
-                            status_code=403,
-                        )
+            access = self._access_for_installation_user(
+                organization=project.organization,
+                installation=installation,
+                user=user,
+            )
+            if not access.has_project_access(project):
+                return RpcSelectRequesterResult(
+                    error=RpcSentryAppError(
+                        message="You do not have permission to access this project.",
+                        status_code=403,
                     )
+                )
             project_slug = project.slug
 
         try:
@@ -204,7 +202,7 @@ class DatabaseBackedSentryAppCellService(SentryAppCellService):
         web_url: str,
         project: str,
         identifier: str,
-        user: RpcUser | None = None,
+        user: RpcUser,
     ) -> RpcPlatformExternalIssueResult:
         """
         Matches: src/sentry/sentry_apps/api/endpoints/installation_external_issues.py @ POST
@@ -230,21 +228,20 @@ class DatabaseBackedSentryAppCellService(SentryAppCellService):
                 )
             )
 
-        if user is not None:
-            access = self._access_for_installation_user(
-                organization=group.project.organization,
-                installation=installation,
-                user=user,
-            )
-            if not access.has_project_access(group.project):
-                return RpcPlatformExternalIssueResult(
-                    error=RpcSentryAppError(
-                        message="You do not have permission to create an external issue for this issue.",
-                        status_code=403,
-                    )
+        access = self._access_for_installation_user(
+            organization=group.project.organization,
+            installation=installation,
+            user=user,
+        )
+        if not access.has_project_access(group.project):
+            return RpcPlatformExternalIssueResult(
+                error=RpcSentryAppError(
+                    message="You do not have permission to create an external issue for this issue.",
+                    status_code=403,
                 )
+            )
 
-        actor = GroupActionActor.user(user.id) if user is not None else SYSTEM_ACTOR
+        actor = GroupActionActor.user(user.id)
         try:
             external_issue_creator = ExternalIssueCreator(
                 install=installation,
@@ -252,7 +249,7 @@ class DatabaseBackedSentryAppCellService(SentryAppCellService):
                 web_url=web_url,
                 project=project,
                 identifier=identifier,
-                user_id=user.id if user is not None else None,
+                user_id=user.id,
             )
             external_issue, created = external_issue_creator.run()
         except SentryAppSentryError as e:
@@ -284,7 +281,7 @@ class DatabaseBackedSentryAppCellService(SentryAppCellService):
         organization_id: int,
         installation: RpcSentryAppInstallation,
         external_issue_id: int,
-        user: RpcUser | None = None,
+        user: RpcUser,
     ) -> RpcEmptyResult:
         """
         Matches: src/sentry/sentry_apps/api/endpoints/installation_external_issue_details.py @ DELETE
@@ -321,20 +318,19 @@ class DatabaseBackedSentryAppCellService(SentryAppCellService):
             )
         organization = issue_project.organization
 
-        if user is not None:
-            access = self._access_for_installation_user(
-                organization=organization,
-                installation=installation,
-                user=user,
+        access = self._access_for_installation_user(
+            organization=organization,
+            installation=installation,
+            user=user,
+        )
+        if not access.has_project_access(issue_project):
+            return RpcEmptyResult(
+                success=False,
+                error=RpcSentryAppError(
+                    message="You do not have permission to delete this external issue.",
+                    status_code=403,
+                ),
             )
-            if not access.has_project_access(issue_project):
-                return RpcEmptyResult(
-                    success=False,
-                    error=RpcSentryAppError(
-                        message="You do not have permission to delete this external issue.",
-                        status_code=403,
-                    ),
-                )
 
         publish_action(
             UnlinkPlatformExternalIssueAction(
@@ -345,7 +341,7 @@ class DatabaseBackedSentryAppCellService(SentryAppCellService):
             source=ActionSource.API,
             group_id=platform_external_issue.group_id,
             project=issue_project,
-            actor=GroupActionActor.user(user.id) if user is not None else SYSTEM_ACTOR,
+            actor=GroupActionActor.user(user.id),
         )
 
         deletions.exec_sync(platform_external_issue)

--- a/src/sentry/sentry_apps/services/cell/service.py
+++ b/src/sentry/sentry_apps/services/cell/service.py
@@ -51,7 +51,7 @@ class SentryAppCellService(RpcService):
         organization_id: int,
         installation: RpcSentryAppInstallation,
         uri: str,
-        user: RpcUser | None = None,
+        user: RpcUser,
         project_id: int | None = None,
         query: str | None = None,
         dependent_data: str | None = None,
@@ -86,7 +86,7 @@ class SentryAppCellService(RpcService):
         web_url: str,
         project: str,
         identifier: str,
-        user: RpcUser | None = None,
+        user: RpcUser,
     ) -> RpcPlatformExternalIssueResult:
         """Invokes ExternalIssueCreator to create an external issue."""
         pass
@@ -99,7 +99,7 @@ class SentryAppCellService(RpcService):
         organization_id: int,
         installation: RpcSentryAppInstallation,
         external_issue_id: int,
-        user: RpcUser | None = None,
+        user: RpcUser,
     ) -> RpcEmptyResult:
         """Deletes a PlatformExternalIssue."""
         pass

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_installation_external_issue_details.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_installation_external_issue_details.py
@@ -1,3 +1,4 @@
+from sentry.models.organization import Organization
 from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode_of, control_silo_test
@@ -60,6 +61,26 @@ class SentryAppInstallationExternalIssueDetailsEndpointTest(APITestCase):
         )
 
         self.get_error_response(evil_install.uuid, self.external_issue.id, status_code=404)
+        with assume_test_silo_mode_of(PlatformExternalIssue):
+            assert PlatformExternalIssue.objects.filter(id=self.external_issue.id).exists()
+
+    def test_handles_member_without_project_access(self) -> None:
+        """
+        Ensure that a member fenced out of the issue's project cannot delete its external issue
+        """
+        with assume_test_silo_mode_of(Organization):
+            self.org.flags.allow_joinleave = False
+            self.org.save()
+
+        member_team = self.create_team(organization=self.org)
+        self.create_project(organization=self.org, teams=[member_team])
+        restricted_member = self.create_user(email="restricted@example.com")
+        self.create_member(
+            organization=self.org, user=restricted_member, role="member", teams=[member_team]
+        )
+        self.login_as(restricted_member)
+
+        self.get_error_response(self.install.uuid, self.external_issue.id, status_code=403)
         with assume_test_silo_mode_of(PlatformExternalIssue):
             assert PlatformExternalIssue.objects.filter(id=self.external_issue.id).exists()
 

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_installation_external_issues.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_installation_external_issues.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock, patch
 
 from django.urls import reverse
 
+from sentry.models.organization import Organization
 from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode_of, control_silo_test
@@ -75,6 +76,26 @@ class SentryAppInstallationExternalIssuesEndpointTest(APITestCase):
         )
 
         assert response.status_code == 404
+
+    def test_member_without_project_access(self) -> None:
+        self._set_up_sentry_app("Testin", ["event:write"])
+        with assume_test_silo_mode_of(Organization):
+            self.org.flags.allow_joinleave = False
+            self.org.save()
+
+        member_team = self.create_team(organization=self.org)
+        self.create_project(organization=self.org, teams=[member_team])
+        restricted_member = self.create_user(email="restricted@example.com")
+        self.create_member(
+            organization=self.org, user=restricted_member, role="member", teams=[member_team]
+        )
+        self.login_as(restricted_member)
+
+        response = self.client.post(self.url, data=self._post_data())
+
+        assert response.status_code == 403
+        with assume_test_silo_mode_of(PlatformExternalIssue):
+            assert not PlatformExternalIssue.objects.exists()
 
     def test_invalid_scopes(self) -> None:
         self._set_up_sentry_app("Testin", ["project:read"])

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_installation_external_requests.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_installation_external_requests.py
@@ -4,8 +4,9 @@ from django.urls import reverse
 from django.utils.http import urlencode
 from responses.matchers import query_string_matcher
 
+from sentry.models.organization import Organization
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.silo import control_silo_test
+from sentry.testutils.silo import assume_test_silo_mode_of, control_silo_test
 
 
 @control_silo_test
@@ -101,6 +102,23 @@ class SentryAppInstallationExternalRequestsEndpointTest(APITestCase):
         response = self.client.get(url, format="json")
         assert response.status_code == 400
         assert "projectId" in response.data
+
+    def test_member_without_project_access(self) -> None:
+        with assume_test_silo_mode_of(Organization):
+            self.org.flags.allow_joinleave = False
+            self.org.save()
+
+        member_team = self.create_team(organization=self.org)
+        self.create_project(organization=self.org, teams=[member_team])
+        restricted_member = self.create_user(email="restricted@example.com")
+        self.create_member(
+            organization=self.org, user=restricted_member, role="member", teams=[member_team]
+        )
+        self.login_as(restricted_member)
+
+        url = self.url + f"?projectId={self.project.id}&uri=/get-projects&query=proj"
+        response = self.client.get(url, format="json")
+        assert response.status_code == 403
 
     def test_rejects_uri_with_userinfo_injection(self) -> None:
         self.login_as(user=self.user)

--- a/tests/sentry/sentry_apps/services/test_cell_service.py
+++ b/tests/sentry/sentry_apps/services/test_cell_service.py
@@ -498,24 +498,6 @@ class TestSentryAppCellService(TestCase):
         assert getattr(records[0], "actor_type") == "user"
         assert getattr(records[0], "actor_id") == str(self.user.id)
 
-    def test_create_external_issue_without_user_records_system_actor(self) -> None:
-        with self.assertLogs("sentry.issues.action_log", level="INFO") as logs:
-            result = sentry_app_cell_service.create_external_issue(
-                organization_id=self.org.id,
-                installation=self.rpc_installation,
-                group_id=self.group.id,
-                web_url="https://example.com/project/issue-1",
-                project="ProjectName",
-                identifier="issue-1",
-                user=None,
-            )
-
-        assert result.error is None
-        records = self._action_log_records(logs.records, "create_platform_external_issue")
-        assert len(records) == 1
-        assert getattr(records[0], "actor_type") == "system"
-        assert getattr(records[0], "actor_id") == "0"
-
     def test_delete_external_issue_records_action_log(self) -> None:
         with assume_test_silo_mode_of(PlatformExternalIssue):
             external_issue = PlatformExternalIssue.objects.create(
@@ -583,46 +565,6 @@ class TestSentryAppCellService(TestCase):
         assert result.error.status_code == 403
         assert result.external_issue is None
 
-    def test_create_external_issue_legacy_skips_project_access_without_user(self) -> None:
-        """RPC user is optional during rollout; None skips has_project_access (temporary)."""
-        with assume_test_silo_mode_of(Organization):
-            self.org.flags.allow_joinleave = False
-            self.org.save()
-
-        other_team = self.create_team(organization=self.org, name="cei-legacy-other-team")
-        other_project = self.create_project(
-            organization=self.org, teams=[other_team], name="cei-legacy-other-proj"
-        )
-        other_group = self.create_group(project=other_project)
-
-        result = sentry_app_cell_service.create_external_issue(
-            organization_id=self.org.id,
-            installation=self.rpc_installation,
-            group_id=other_group.id,
-            web_url="https://example.com/p/i",
-            project="P",
-            identifier="1",
-            user=None,
-        )
-
-        assert result.error is None
-        assert result.external_issue is not None
-
-        with assume_test_silo_mode_of(Activity):
-            activity = Activity.objects.get(
-                group_id=other_group.id,
-                type=ActivityType.CREATE_ISSUE.value,
-            )
-        assert activity.project_id == other_project.id
-        assert activity.user_id is None
-        assert activity.data == {
-            "title": "P#1",
-            "provider": self.sentry_app.name,
-            "location": "https://example.com/p/i",
-            "label": "P#1",
-            "new": True,
-        }
-
     def test_get_select_options_denied_without_project_access(self) -> None:
         with assume_test_silo_mode_of(Organization):
             self.org.flags.allow_joinleave = False
@@ -655,47 +597,6 @@ class TestSentryAppCellService(TestCase):
 
         assert result.error is not None
         assert result.error.status_code == 403
-
-    @responses.activate
-    def test_get_select_options_legacy_skips_project_access_without_user(self) -> None:
-        """RPC user is optional during rollout; None skips has_project_access (temporary)."""
-        with assume_test_silo_mode_of(Organization):
-            self.org.flags.allow_joinleave = False
-            self.org.save()
-
-        other_team = self.create_team(organization=self.org, name="gso-legacy-other-team")
-        other_project = self.create_project(
-            organization=self.org, teams=[other_team], name="gso-legacy-other-proj"
-        )
-
-        options = [{"label": "Other", "value": "99"}]
-        qs = urlencode(
-            {
-                "projectSlug": other_project.slug,
-                "installationId": self.install.uuid,
-                "query": "q",
-            }
-        )
-        responses.add(
-            method=responses.GET,
-            url="https://example.com/get-projects",
-            match=[query_string_matcher(qs)],
-            json=options,
-            status=200,
-            content_type="application/json",
-        )
-
-        result = sentry_app_cell_service.get_select_options(
-            organization_id=self.org.id,
-            installation=self.rpc_installation,
-            uri="/get-projects",
-            user=None,
-            project_id=other_project.id,
-            query="q",
-        )
-
-        assert result.error is None
-        assert result.choices == [["99", "Other"]]
 
     def test_get_select_options_unknown_project_id_returns_404(self) -> None:
         result = sentry_app_cell_service.get_select_options(
@@ -753,39 +654,6 @@ class TestSentryAppCellService(TestCase):
         assert result.error.status_code == 403
         with assume_test_silo_mode_of(PlatformExternalIssue):
             assert PlatformExternalIssue.objects.filter(id=external_issue.id).exists()
-
-    def test_delete_external_issue_legacy_skips_project_access_without_user(self) -> None:
-        """RPC user is optional during rollout; None skips has_project_access (temporary)."""
-        with assume_test_silo_mode_of(Organization):
-            self.org.flags.allow_joinleave = False
-            self.org.save()
-
-        other_team = self.create_team(organization=self.org, name="dei-legacy-other-team")
-        other_project = self.create_project(
-            organization=self.org, teams=[other_team], name="dei-legacy-other-proj"
-        )
-        other_group = self.create_group(project=other_project)
-
-        with assume_test_silo_mode_of(PlatformExternalIssue):
-            external_issue = PlatformExternalIssue.objects.create(
-                group_id=other_group.id,
-                project_id=other_project.id,
-                service_type=self.sentry_app.slug,
-                display_name="X#1",
-                web_url="https://example.com/issue/1",
-            )
-
-        result = sentry_app_cell_service.delete_external_issue(
-            organization_id=self.org.id,
-            installation=self.rpc_installation,
-            external_issue_id=external_issue.id,
-            user=None,
-        )
-
-        assert result.success is True
-        assert result.error is None
-        with assume_test_silo_mode_of(PlatformExternalIssue):
-            assert not PlatformExternalIssue.objects.filter(id=external_issue.id).exists()
 
     def test_get_service_hook_projects(self) -> None:
         project2 = self.create_project(organization=self.org)


### PR DESCRIPTION
Follow ups to https://github.com/getsentry/sentry/pull/112709 & https://github.com/getsentry/sentry/pull/120268 we're now making user a required RPC arg and removing the SYSTEM_ACTOR fallback. Affects get_select_options, create_external_issue, and delete_external_issue
