### PR TITLE
fix(explore): Require referrers when calling /events/

### DIFF
--- a/static/app/components/events/eventStatisticalDetector/eventComparison/eventDisplay.tsx
+++ b/static/app/components/events/eventStatisticalDetector/eventComparison/eventDisplay.tsx
@@ -103,6 +103,7 @@ function useFetchSampleEvents({
     location,
     orgSlug: organization.slug,
     limit: 20,
+    referrer: 'api.statistical-detector.event-comparison',
   });
 }
 

--- a/static/app/utils/api/apiOptions.ts
+++ b/static/app/utils/api/apiOptions.ts
@@ -14,6 +14,11 @@ type KnownApiUrls = KnownGetsentryApiUrls | KnownSentryApiUrls;
 
 type Options = QueryKeyEndpointOptions & {staleTime: number | 'static'};
 
+type RequiresReferrer<TApiPath extends string> =
+  TApiPath extends '/organizations/$organizationIdOrSlug/events/'
+    ? {query: {referrer: string} & Record<string, unknown>}
+    : {query?: Record<string, unknown>};
+
 type PathParamOptions<TApiPath extends string> =
   ExtractPathParams<TApiPath> extends never
     ? {path?: never}
@@ -157,7 +162,7 @@ export const apiOptions = {
     <TManualData>() =>
     <TApiPath extends KnownApiUrls = KnownApiUrls>(
       path: TApiPath,
-      options: Options & PathParamOptions<TApiPath>
+      options: Options & PathParamOptions<TApiPath> & RequiresReferrer<TApiPath>
     ) =>
       _apiOptions<TManualData>(path, options as never),
 
@@ -165,7 +170,7 @@ export const apiOptions = {
     <TManualData>() =>
     <TApiPath extends KnownApiUrls = KnownApiUrls>(
       path: TApiPath,
-      options: Options & PathParamOptions<TApiPath>
+      options: Options & PathParamOptions<TApiPath> & RequiresReferrer<TApiPath>
     ) =>
       _apiOptionsInfinite<TManualData>(path, options as never),
 };

--- a/static/app/utils/discover/discoverQuery.spec.tsx
+++ b/static/app/utils/discover/discoverQuery.spec.tsx
@@ -29,7 +29,12 @@ describe('DiscoverQuery', () => {
       },
     });
     render(
-      <DiscoverQuery orgSlug="test-org" location={location} eventView={eventView}>
+      <DiscoverQuery
+        orgSlug="test-org"
+        location={location}
+        eventView={eventView}
+        referrer="api.discover.test"
+      >
         {({tableData, isLoading}) => {
           if (isLoading) {
             return 'loading';
@@ -57,6 +62,7 @@ describe('DiscoverQuery', () => {
         orgSlug="test-org"
         location={location}
         eventView={eventView}
+        referrer="api.discover.test"
         limit={3}
         cursor="1:0:1"
       >
@@ -97,6 +103,7 @@ describe('DiscoverQuery', () => {
         orgSlug="test-org"
         location={location}
         eventView={eventView}
+        referrer="api.discover.test"
         setError={e => (errorValue = e)}
       >
         {({isLoading}) => {
@@ -130,6 +137,7 @@ describe('DiscoverQuery', () => {
         orgSlug="test-org"
         location={location}
         eventView={eventView}
+        referrer="api.discover.test"
         setError={e => (errorValue = e)}
       >
         {({isLoading}) => {

--- a/static/app/utils/discover/discoverQuery.tsx
+++ b/static/app/utils/discover/discoverQuery.tsx
@@ -31,6 +31,7 @@ export type EventsTableData = {
 export type TableDataWithTitle = TableData & {title: string};
 
 type DiscoverQueryPropsWithThresholds = DiscoverQueryProps & {
+  referrer: string;
   transactionName?: string;
   transactionThreshold?: number;
   transactionThresholdMetric?: TransactionThresholdMetric;

--- a/static/app/views/alerts/rules/metric/details/relatedTransactions.tsx
+++ b/static/app/views/alerts/rules/metric/details/relatedTransactions.tsx
@@ -121,6 +121,7 @@ export function RelatedTransactions({
       eventView={sortedEventView}
       orgSlug={organization.slug}
       location={location}
+      referrer="api.alerts.related-transactions"
     >
       {({isLoading, tableData}) => (
         <GridEditable

--- a/static/app/views/dashboards/widgetCard/hooks/useErrorsAndTransactionsWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useErrorsAndTransactionsWidgetQuery.tsx
@@ -376,7 +376,6 @@ export function useErrorsAndTransactionsTableQuery(
       const requestParams: DiscoverQueryRequestParams = {
         per_page: limit,
         cursor,
-        referrer: getReferrer(filteredWidget.displayType),
         dataset: isMEPEnabled
           ? DiscoverDatasets.METRICS_ENHANCED
           : DiscoverDatasets.DISCOVER,
@@ -391,6 +390,7 @@ export function useErrorsAndTransactionsTableQuery(
       const queryParams = {
         ...eventView.generateQueryStringObject(),
         ...requestParams,
+        referrer: getReferrer(filteredWidget.displayType),
       };
 
       return queryOptions({

--- a/static/app/views/dashboards/widgetCard/hooks/useErrorsWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useErrorsWidgetQuery.tsx
@@ -238,7 +238,6 @@ export function useErrorsTableQuery(
       const requestParams: DiscoverQueryRequestParams = {
         per_page: limit,
         cursor,
-        referrer: getReferrer(filteredWidget.displayType),
         dataset: DiscoverDatasets.ERRORS,
       };
 
@@ -252,6 +251,7 @@ export function useErrorsTableQuery(
       const queryParams = {
         ...eventView.generateQueryStringObject(),
         ...requestParams,
+        referrer: getReferrer(filteredWidget.displayType),
       };
 
       return queryOptions({

--- a/static/app/views/dashboards/widgetCard/hooks/useLogsWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useLogsWidgetQuery.tsx
@@ -229,7 +229,6 @@ export function useLogsTableQuery(
       const requestParams: DiscoverQueryRequestParams = {
         per_page: limit,
         cursor,
-        referrer: getReferrer(filteredWidget.displayType),
         dataset: DiscoverDatasets.OURLOGS,
       };
 
@@ -241,6 +240,7 @@ export function useLogsTableQuery(
         ...eventView.generateQueryStringObject(),
         ...requestParams,
         ...(samplingMode ? {sampling: samplingMode} : {}),
+        referrer: getReferrer(filteredWidget.displayType),
       };
 
       return queryOptions({

--- a/static/app/views/dashboards/widgetCard/hooks/useSpansWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useSpansWidgetQuery.tsx
@@ -280,7 +280,6 @@ export function useSpansTableQuery(
       const requestParams: DiscoverQueryRequestParams = {
         per_page: limit,
         cursor,
-        referrer: getReferrer(filteredWidget.displayType),
         dataset: DiscoverDatasets.SPANS,
       };
 
@@ -317,6 +316,7 @@ export function useSpansTableQuery(
         ...eventView.generateQueryStringObject(),
         ...requestParams,
         ...(samplingMode ? {sampling: samplingMode} : {}),
+        referrer: getReferrer(filteredWidget.displayType),
       };
 
       const baseOptions = apiOptions.as<SpansTableResponse>()(

--- a/static/app/views/dashboards/widgetCard/hooks/useTraceMetricsWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useTraceMetricsWidgetQuery.tsx
@@ -274,7 +274,6 @@ export function useTraceMetricsTableQuery(
       const requestParams: DiscoverQueryRequestParams = {
         per_page: limit,
         cursor,
-        referrer: getReferrer(filteredWidget.displayType),
         dataset: DiscoverDatasets.TRACEMETRICS,
       };
 
@@ -302,6 +301,7 @@ export function useTraceMetricsTableQuery(
         ...eventView.generateQueryStringObject(),
         ...requestParams,
         ...(samplingMode ? {sampling: samplingMode} : {}),
+        referrer: getReferrer(filteredWidget.displayType),
       };
 
       return queryOptions({

--- a/static/app/views/dashboards/widgetCard/hooks/useTransactionsWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useTransactionsWidgetQuery.tsx
@@ -335,7 +335,6 @@ export function useTransactionsTableQuery(
       const requestParams: DiscoverQueryRequestParams = {
         per_page: limit,
         cursor,
-        referrer: getReferrer(filteredWidget.displayType),
         dataset: isMEPEnabled
           ? DiscoverDatasets.METRICS_ENHANCED
           : DiscoverDatasets.TRANSACTIONS,
@@ -352,6 +351,7 @@ export function useTransactionsTableQuery(
       const queryParams = {
         ...eventView.generateQueryStringObject(),
         ...requestParams,
+        referrer: getReferrer(filteredWidget.displayType),
       };
 
       return queryOptions({

--- a/static/app/views/explore/components/attributeBreakdowns/attributeDistributionContent.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeDistributionContent.tsx
@@ -80,6 +80,7 @@ export function AttributeDistribution() {
           per_page: 1,
           disableAggregateExtrapolation: '1',
           sampling: SAMPLING_MODE.NORMAL,
+          referrer: 'api.explore.attribute-distribution',
         },
         staleTime: Infinity,
       }

--- a/static/app/views/explore/hooks/useMetricOptions.tsx
+++ b/static/app/views/explore/hooks/useMetricOptions.tsx
@@ -49,7 +49,10 @@ function metricOptionsQueryKey({
     searchValue.addContainsFilterValue(TraceMetricKnownFieldKey.METRIC_NAME, search);
   }
 
-  const query: Record<string, string | string[] | number[] | undefined> = {
+  const query: {referrer: string} & Record<
+    string,
+    string | string[] | number[] | undefined
+  > = {
     dataset: DiscoverDatasets.TRACEMETRICS,
     field: queryFields,
     referrer: 'api.explore.metric-options',

--- a/static/app/views/explore/releases/detail/overview/releaseComparisonChart/index.tsx
+++ b/static/app/views/explore/releases/detail/overview/releaseComparisonChart/index.tsx
@@ -177,6 +177,7 @@ export function ReleaseComparisonChart({
       start,
       end,
       ...(period ? {statsPeriod: period} : {}),
+      referrer: 'api.releases.release-comparison-chart',
     };
 
     setEventsLoading(true);

--- a/static/app/views/insights/common/queries/useSpansQuery.tsx
+++ b/static/app/views/insights/common/queries/useSpansQuery.tsx
@@ -32,6 +32,7 @@ const THIRTY_DAYS = 30 * 24 * 60 * 60 * 1000;
 const SIXTY_DAYS = 60 * 24 * 60 * 60 * 1000;
 
 type SpansQueryProps<T = any[]> = {
+  referrer: string;
   allowAggregateConditions?: boolean;
   cursor?: string;
   enabled?: boolean;
@@ -39,13 +40,12 @@ type SpansQueryProps<T = any[]> = {
   initialData?: T;
   limit?: number;
   queryExtras?: RPCQueryExtras;
-  referrer?: string;
   staleTime?: number;
   trackResponseAnalytics?: boolean;
 };
 
 export function useSpansQuery<T = any[]>({
-  referrer = 'use-spans-query',
+  referrer,
   trackResponseAnalytics = true,
   ...props
 }: SpansQueryProps<T>) {
@@ -60,7 +60,7 @@ export function useSpansQuery<T = any[]>({
 }
 
 export function useSpansQueryWithoutPageFilters<T = any[]>({
-  referrer = 'use-spans-query',
+  referrer,
   trackResponseAnalytics = true,
   ...props
 }: SpansQueryProps<T>) {
@@ -247,6 +247,7 @@ function useWrappedDiscoverTimeseriesQueryWithoutPageFilters<T>(
 
 type WrappedDiscoverQueryProps<T> = {
   eventView: EventView;
+  referrer: string;
   additionalQueryKey?: string[];
   allowAggregateConditions?: boolean;
   caseInsensitive?: CaseInsensitive;
@@ -260,7 +261,6 @@ type WrappedDiscoverQueryProps<T> = {
   logQuery?: string[];
   metricQuery?: string[];
   noPagination?: boolean;
-  referrer?: string;
   refetchInterval?: number;
   samplingMode?: SamplingMode;
   spanQuery?: string[];

--- a/static/app/views/organizationStats/teamInsights/teamMisery.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamMisery.tsx
@@ -256,12 +256,14 @@ export function TeamMiseryWrapper({
       eventView={periodEventView}
       orgSlug={organization.slug}
       location={location}
+      referrer="api.team-insights.team-misery"
     >
       {({isLoading, tableData: periodTableData, error}) => (
         <DiscoverQuery
           eventView={weekEventView}
           orgSlug={organization.slug}
           location={location}
+          referrer="api.team-insights.team-misery"
         >
           {({isLoading: isWeekLoading, tableData: weekTableData, error: weekError}) => (
             <TeamMisery

--- a/static/app/views/performance/landing/widgets/components/queryHandler.tsx
+++ b/static/app/views/performance/landing/widgets/components/queryHandler.tsx
@@ -37,7 +37,7 @@ export function QueryHandler<T extends WidgetDataConstraint>(
   );
 }
 
-function genericQueryReferrer(setting: PerformanceWidgetSetting) {
+export function genericQueryReferrer(setting: PerformanceWidgetSetting) {
   return `api.insights.generic-widget-chart.${setting.replace(/_/g, '-')}`;
 }
 

--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
@@ -43,6 +43,7 @@ import {Chart as DurationChart} from 'sentry/views/performance/charts/chart';
 import {excludeTransaction} from 'sentry/views/performance/landing/utils';
 import {Accordion} from 'sentry/views/performance/landing/widgets/components/accordion';
 import {GenericPerformanceWidget} from 'sentry/views/performance/landing/widgets/components/performanceWidget';
+import {genericQueryReferrer} from 'sentry/views/performance/landing/widgets/components/queryHandler';
 import {
   GrowLink,
   HighestCacheMissRateTransactionsWidgetEmptyStateWarning,
@@ -340,6 +341,7 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
             cursor="0:0:1"
             noPagination
             queryExtras={extraQueryParams}
+            referrer={genericQueryReferrer(props.chartSetting)}
           />
         );
       },

--- a/static/app/views/performance/landing/widgets/widgets/mobileReleaseComparisonListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/mobileReleaseComparisonListWidget.tsx
@@ -37,6 +37,7 @@ import type {TabKey} from 'sentry/views/insights/mobile/screens/views/screenDeta
 import {ModuleName} from 'sentry/views/insights/types';
 import {Accordion} from 'sentry/views/performance/landing/widgets/components/accordion';
 import {GenericPerformanceWidget} from 'sentry/views/performance/landing/widgets/components/performanceWidget';
+import {genericQueryReferrer} from 'sentry/views/performance/landing/widgets/components/queryHandler';
 import {
   GrowLink,
   WidgetEmptyStateWarning,
@@ -166,6 +167,7 @@ export function MobileReleaseComparisonListWidget(props: PerformanceWidgetProps)
             cursor="0:0:1"
             noPagination
             queryExtras={extraQueryParams}
+            referrer={genericQueryReferrer(props.chartSetting)}
           />
         );
       },

--- a/static/app/views/performance/landing/widgets/widgets/singleFieldAreaWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/singleFieldAreaWidget.tsx
@@ -15,6 +15,7 @@ import {withApi} from 'sentry/utils/withApi';
 import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
 import {Chart as DurationChart} from 'sentry/views/performance/charts/chart';
 import {GenericPerformanceWidget} from 'sentry/views/performance/landing/widgets/components/performanceWidget';
+import {genericQueryReferrer} from 'sentry/views/performance/landing/widgets/components/queryHandler';
 import {transformDiscoverToSingleValue} from 'sentry/views/performance/landing/widgets/transforms/transformDiscoverToSingleValue';
 import {transformEventsRequestToArea} from 'sentry/views/performance/landing/widgets/transforms/transformEventsToArea';
 import type {
@@ -103,6 +104,7 @@ export function SingleFieldAreaWidget(props: PerformanceWidgetProps) {
             eventView={eventView}
             location={location}
             queryExtras={queryExtras}
+            referrer={genericQueryReferrer(props.chartSetting)}
           />
         );
       },

--- a/static/app/views/performance/landing/widgets/widgets/stackedAreaChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/stackedAreaChartListWidget.tsx
@@ -25,6 +25,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {withApi} from 'sentry/utils/withApi';
 import {Accordion} from 'sentry/views/performance/landing/widgets/components/accordion';
 import {GenericPerformanceWidget} from 'sentry/views/performance/landing/widgets/components/performanceWidget';
+import {genericQueryReferrer} from 'sentry/views/performance/landing/widgets/components/queryHandler';
 import {
   GrowLink,
   RightAlignedCell,
@@ -110,6 +111,7 @@ export function StackedAreaChartListWidget(props: PerformanceWidgetProps) {
             cursor="0:0:1"
             noPagination
             queryExtras={getMEPParamsIfApplicable(mepSetting, props.chartSetting)}
+            referrer={genericQueryReferrer(props.chartSetting)}
           />
         );
       },

--- a/static/app/views/performance/newTraceDetails/traceApi/useTraceAverageTransactionDuration.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTraceAverageTransactionDuration.tsx
@@ -38,5 +38,6 @@ export const useTraceAverageTransactionDuration = ({
     eventView,
     location,
     orgSlug: organization.slug,
+    referrer: 'api.trace-details.average-transaction-duration',
   });
 };

--- a/static/app/views/performance/transactionSummary/transactionReplays/useReplaysFromTransaction.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/useReplaysFromTransaction.tsx
@@ -62,11 +62,14 @@ export function useReplaysFromTransaction({
       const [{data}, _textStatus, resp] = await doDiscoverQuery<{data: EventSpanData[]}>(
         api,
         `/organizations/${organization.slug}/events/`,
-        replayIdsEventView.getEventsAPIPayload({
-          query: {cursor},
-          // Will be fixed by https://github.com/typescript-eslint/typescript-eslint/pull/12206
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
-        } as Location<ReplayListLocationQuery>)
+        {
+          ...replayIdsEventView.getEventsAPIPayload({
+            query: {cursor},
+            // Will be fixed by https://github.com/typescript-eslint/typescript-eslint/pull/12206
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
+          } as Location<ReplayListLocationQuery>),
+          referrer: 'api.transaction-summary.replay-ids',
+        }
       );
 
       setResponse({

--- a/static/app/views/projectDetail/projectScoreCards/projectApdexScoreCard.spec.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectApdexScoreCard.spec.tsx
@@ -74,6 +74,7 @@ describe('ProjectDetail > ProjectApdex', () => {
           field: ['apdex(span.duration,300)'],
           project: ['1'],
           query: 'is_transaction:true count():>0',
+          referrer: 'api.project-detail.apdex-score-card',
           statsPeriod: '14d',
         },
       })
@@ -89,6 +90,7 @@ describe('ProjectDetail > ProjectApdex', () => {
           field: ['apdex(span.duration,300)'],
           project: ['1'],
           query: 'is_transaction:true count():>0',
+          referrer: 'api.project-detail.apdex-score-card',
           statsPeriodStart: '28d',
           statsPeriodEnd: '14d',
         },

--- a/static/app/views/projectDetail/projectScoreCards/projectApdexScoreCard.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectApdexScoreCard.tsx
@@ -50,6 +50,7 @@ const useApdex = (props: Props) => {
     field: ['apdex(span.duration,300)'],
     query: ['is_transaction:true count():>0', query].join(' ').trim(),
     dataset: DiscoverDatasets.SPANS,
+    referrer: 'api.project-detail.apdex-score-card',
   };
 
   const currentQuery = useApiQuery<TableData>(


### PR DESCRIPTION
In order to better track queries to Snuba (especially to deprecated datasets):
- make `referrer` required in common utility functions/hooks for calling `/events/`
- add referrers where missing (includes some callers that don't go through our standard utilities)

Note that every referrer must appear in `src/sentry/snuba/referrer.py` or it will be replaced with a default referrer by the backend. Those are added in #121000, which should be deployed first (just to avoid a bunch of extra warning logs about invalid referrers).