### PR TITLE
chore(ACI): Remove workflow-engine-ui flag from some more places

### DIFF
--- a/static/app/views/issueDetails/sidebar/detectorSection.spec.tsx
+++ b/static/app/views/issueDetails/sidebar/detectorSection.spec.tsx
@@ -15,7 +15,7 @@ import {
 
 describe('DetectorSection', () => {
   const detectorId = '123';
-  const organization = OrganizationFixture({features: ['workflow-engine-ui']});
+  const organization = OrganizationFixture();
   const project = ProjectFixture();
   const issueDetailsContext = {
     sectionData: {},
@@ -184,49 +184,5 @@ describe('DetectorSection', () => {
     expect(
       screen.getByText('This issue was created by an uptime monitoring alert rule.')
     ).toBeInTheDocument();
-  });
-
-  it('links to metric alert rule details when workflow engine UI is disabled', async () => {
-    const alertRuleId = 456;
-    const event = EventFixture({
-      occurrence: {
-        evidenceData: {
-          detectorId,
-        },
-        type: 8001,
-      },
-    });
-    const group = GroupFixture({
-      issueCategory: IssueCategory.METRIC,
-      issueType: IssueType.METRIC_ISSUE,
-    });
-    const orgWithOnlyMetricIssues = OrganizationFixture();
-    const metricDetector = MetricDetectorFixture({
-      id: detectorId,
-      alertRuleId,
-    });
-    const detectorDetails = getDetectorDetails({
-      event,
-      organization: orgWithOnlyMetricIssues,
-      project,
-    });
-
-    MockApiClient.addMockResponse({
-      url: `/organizations/${orgWithOnlyMetricIssues.slug}/detectors/${detectorId}/`,
-      body: metricDetector,
-    });
-
-    render(
-      <IssueDetailsContext value={{...issueDetailsContext, detectorDetails}}>
-        <DetectorSection group={group} project={project} />
-      </IssueDetailsContext>,
-      {organization: orgWithOnlyMetricIssues}
-    );
-
-    const link = await screen.findByRole('button', {name: 'View metric alert details'});
-    expect(link).toHaveAttribute(
-      'href',
-      `/organizations/${orgWithOnlyMetricIssues.slug}/issues/alerts/rules/details/${alertRuleId}/`
-    );
   });
 });

--- a/static/app/views/issueDetails/sidebar/detectorSection.tsx
+++ b/static/app/views/issueDetails/sidebar/detectorSection.tsx
@@ -2,18 +2,13 @@ import styled from '@emotion/styled';
 
 import {LinkButton} from '@sentry/scraps/button';
 
-import {LoadingError} from 'sentry/components/loadingError';
 import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
-import type {MetricDetector} from 'sentry/types/workflowEngine/detectors';
-import {defined} from 'sentry/utils/defined';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
-import {useOrganization} from 'sentry/utils/useOrganization';
 import {makeAlertsPathname} from 'sentry/views/alerts/pathnames';
-import {useDetectorQuery} from 'sentry/views/detectors/hooks';
 import {makeMonitorDetailsPathname} from 'sentry/views/detectors/pathnames';
 import {useIssueDetails} from 'sentry/views/issueDetails/context';
 import type {DetectorDetails} from 'sentry/views/issueDetails/sidebar/detectorDetails';
@@ -100,18 +95,10 @@ export function getDetectorDetails({
 
 export function DetectorSection({group, project}: {group: Group; project: Project}) {
   const issueConfig = getConfigForIssueType(group, project);
-  const organization = useOrganization();
   const {detectorDetails} = useIssueDetails();
-  const {detectorPath, description, detectorId, detectorType} = detectorDetails;
+  const {detectorPath, description} = detectorDetails;
   const detectorCtaText = issueConfig.detector.ctaText ?? t('View detector details');
   const title = issueConfig.detector.title ?? t('Detector');
-
-  const hasWorkflowEngineUi = organization.features.includes('workflow-engine-ui');
-  const shouldUseMetricRuleLink = detectorType === 'metric_alert' && !hasWorkflowEngineUi;
-
-  if (shouldUseMetricRuleLink) {
-    return <MetricAlertSection detectorId={detectorId} />;
-  }
 
   return (
     <DetectorSectionContent
@@ -119,42 +106,6 @@ export function DetectorSection({group, project}: {group: Group; project: Projec
       description={description}
       title={title}
       to={detectorPath}
-    />
-  );
-}
-
-// This section is only shown when metric issues are enabled, but the full workflow engine UI is not.
-// Remove this section once the new Monitors/Alerts UI is fully rolled out.
-function MetricAlertSection({detectorId}: {detectorId: string | undefined}) {
-  const organization = useOrganization();
-  const {data: metricDetector, isLoading} = useDetectorQuery<MetricDetector>(
-    detectorId ?? '',
-    {
-      enabled: Boolean(detectorId),
-    }
-  );
-  const metricRuleId = metricDetector?.alertRuleId
-    ? String(metricDetector.alertRuleId)
-    : null;
-  const metricRulePath = metricRuleId
-    ? makeAlertsPathname({
-        path: `/rules/details/${metricRuleId}/`,
-        organization,
-      })
-    : undefined;
-
-  if (!defined(detectorId) || (!isLoading && !metricDetector?.alertRuleId)) {
-    return <LoadingError message={t('Corresponding metric alert not found')} />;
-  }
-
-  return (
-    <DetectorSectionContent
-      ctaText={t('View metric alert details')}
-      description={t(
-        'This issue was created by a metric alert. View the alert details to learn more.'
-      )}
-      title={t('Metric Alert')}
-      to={metricRulePath}
     />
   );
 }

--- a/static/gsApp/overrides/useMetricDetectorLimit.tsx
+++ b/static/gsApp/overrides/useMetricDetectorLimit.tsx
@@ -1,6 +1,5 @@
 import {useQuery} from '@tanstack/react-query';
 
-import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {detectorListApiOptions} from 'sentry/views/detectors/hooks/index';
 
@@ -22,7 +21,6 @@ export function useMetricDetectorLimit(): MetricDetectorLimitResponse {
   const subscription = useSubscription();
   const detectorLimit = subscription?.planDetails?.metricDetectorLimit ?? UNLIMITED_QUOTA;
 
-  const isWorkflowEngine = organization.features.includes('workflow-engine-ui');
   const hasFlag = organization.features.includes('workflow-engine-metric-detector-limit');
 
   const {
@@ -34,28 +32,14 @@ export function useMetricDetectorLimit(): MetricDetectorLimitResponse {
       query: 'type:metric',
       limit: 1,
     }),
-    enabled: hasFlag && isWorkflowEngine && detectorLimit !== UNLIMITED_QUOTA,
+    enabled: hasFlag && detectorLimit !== UNLIMITED_QUOTA,
     staleTime: 5 * 1000, // Set stale time to 5 sec to avoid unnecessary re-fetching
     select: data => data.headers['X-Hits'],
   });
 
-  const {
-    data: alertRulesXHits = NO_COUNT,
-    isLoading: isMetricRulesLoading,
-    isError: isMetricRulesError,
-  } = useQuery({
-    ...apiOptions.as<unknown[]>()('/organizations/$organizationIdOrSlug/alert-rules/', {
-      path: {organizationIdOrSlug: organization.slug},
-      staleTime: 5 * 1000, // Set stale time to 5 sec to avoid unnecessary re-fetching
-      query: {limit: 1},
-    }),
-    enabled: hasFlag && !isWorkflowEngine && detectorLimit !== UNLIMITED_QUOTA,
-    select: data => data.headers['X-Hits'],
-  });
-
-  const isLoading = isWorkflowEngine ? isDetectorsLoading : isMetricRulesLoading;
-  const isError = isWorkflowEngine ? isDetectorsError : isMetricRulesError;
-  const detectorCount = isWorkflowEngine ? detectorXHits : alertRulesXHits;
+  const isLoading = isDetectorsLoading;
+  const isError = isDetectorsError;
+  const detectorCount = detectorXHits;
 
   if (!hasFlag || detectorLimit === UNLIMITED_QUOTA) {
     return {


### PR DESCRIPTION
Remove the ACI UI flag from the command palette, detector sidebar, and metric detector limit. 
