### PR TITLE
fix(inbox): expand the topmost autofix summary section by default

### DIFF
--- a/static/app/views/issueDetails/issuePreview/issuePreview.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreview.tsx
@@ -213,7 +213,7 @@ function IssuePreviewContent() {
         <Dividers>
           <LinkedPullRequests group={group} showEmptyState={false} />
           {hasAutofix ? (
-            <IssuePreviewAutofixSummary key={groupId} runState={autofix.runState} />
+            <IssuePreviewAutofixSummary key={group.id} runState={autofix.runState} />
           ) : null}
           <Container>
             <ErrorBoundary mini>

--- a/static/app/views/issueDetails/issuePreview/issuePreview.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreview.tsx
@@ -212,7 +212,9 @@ function IssuePreviewContent() {
       ) : (
         <Dividers>
           <LinkedPullRequests group={group} showEmptyState={false} />
-          {hasAutofix ? <IssuePreviewAutofixSummary runState={autofix.runState} /> : null}
+          {hasAutofix ? (
+            <IssuePreviewAutofixSummary key={groupId} runState={autofix.runState} />
+          ) : null}
           <Container>
             <ErrorBoundary mini>
               <FoldSection

--- a/static/app/views/issueDetails/issuePreview/issuePreviewAutofixSummary.spec.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewAutofixSummary.spec.tsx
@@ -56,7 +56,7 @@ const solutionArtifact = AutofixSolutionArtifactFixture({
 });
 
 describe('IssuePreviewAutofixSummary', () => {
-  it('renders collapsed summaries in the requested order and expands full details', async () => {
+  it('renders summaries in the requested order with the first section expanded', async () => {
     const runState = ExplorerAutofixStateFixture({
       blocks: [
         ExplorerAutofixBlockFixture({artifacts: [rootCauseArtifact]}),
@@ -115,7 +115,7 @@ describe('IssuePreviewAutofixSummary', () => {
 
     expect(within(proposal).getByRole('button', {name: 'Proposal'})).toHaveAttribute(
       'aria-expanded',
-      'false'
+      'true'
     );
     expect(
       within(plan).getByRole('button', {name: 'Implementation Plan'})
@@ -133,7 +133,7 @@ describe('IssuePreviewAutofixSummary', () => {
       within(rootCause).getByText('An unexpected null value reached the user handler.')
     ).toBeVisible();
 
-    expect(within(proposal).getByText('org/frontend:src/user.ts')).not.toBeVisible();
+    expect(within(proposal).getByText('org/frontend:src/user.ts')).toBeVisible();
     expect(within(plan).getByText('Add a null guard')).not.toBeVisible();
     expect(
       within(rootCause).getByText(
@@ -141,8 +141,6 @@ describe('IssuePreviewAutofixSummary', () => {
       )
     ).not.toBeVisible();
 
-    await userEvent.click(within(proposal).getByRole('button', {name: 'Proposal'}));
-    expect(within(proposal).getByText('org/frontend:src/user.ts')).toBeVisible();
     expect(within(proposal).getByText('org/backend:tests/test_user.py')).toBeVisible();
 
     await userEvent.click(
@@ -175,6 +173,10 @@ describe('IssuePreviewAutofixSummary', () => {
     );
 
     expect(screen.getByRole('region', {name: 'Root Cause'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Root Cause'})).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    );
     expect(
       screen.queryByRole('region', {name: 'Implementation Plan'})
     ).not.toBeInTheDocument();

--- a/static/app/views/issueDetails/issuePreview/issuePreviewAutofixSummary.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewAutofixSummary.tsx
@@ -59,10 +59,10 @@ export function IssuePreviewAutofixSummary({runState}: IssuePreviewAutofixSummar
     return null;
   }
 
-  const hasProposal = patchesByRepo.size > 0;
   const isProposalProcessing = proposalSection?.status === 'processing';
   const isPlanProcessing = planSection?.status === 'processing';
   const isRootCauseProcessing = rootCauseSection?.status === 'processing';
+  const hasProposal = patchesByRepo.size > 0;
   if (
     !hasProposal &&
     !isProposalProcessing &&
@@ -82,12 +82,22 @@ export function IssuePreviewAutofixSummary({runState}: IssuePreviewAutofixSummar
     patchesByRepo.size === 1
       ? tn('%s file changed in 1 repo', '%s files changed in 1 repo', filesChanged)
       : t('%s files changed in %s repos', filesChanged, patchesByRepo.size);
+  const defaultExpandedSection = hasProposal
+    ? 'proposal'
+    : planArtifact || isPlanProcessing
+      ? 'plan'
+      : 'rootCause';
 
   return (
     <Dividers>
       {hasProposal || isProposalProcessing ? (
         <Container>
-          <Disclosure as="section" aria-label={t('Proposal')} size="md">
+          <Disclosure
+            as="section"
+            aria-label={t('Proposal')}
+            size="md"
+            defaultExpanded={defaultExpandedSection === 'proposal'}
+          >
             <Disclosure.Title>
               <Heading as="h3" size="md">
                 {t('Proposal')}
@@ -125,7 +135,12 @@ export function IssuePreviewAutofixSummary({runState}: IssuePreviewAutofixSummar
 
       {planArtifact || isPlanProcessing ? (
         <Container>
-          <Disclosure as="section" aria-label={t('Implementation Plan')} size="md">
+          <Disclosure
+            as="section"
+            aria-label={t('Implementation Plan')}
+            size="md"
+            defaultExpanded={defaultExpandedSection === 'plan'}
+          >
             <Disclosure.Title>
               <Heading as="h3" size="md">
                 {t('Implementation Plan')}
@@ -165,7 +180,12 @@ export function IssuePreviewAutofixSummary({runState}: IssuePreviewAutofixSummar
 
       {rootCauseArtifact || isRootCauseProcessing ? (
         <Container>
-          <Disclosure as="section" aria-label={t('Root Cause')} size="md">
+          <Disclosure
+            as="section"
+            aria-label={t('Root Cause')}
+            size="md"
+            defaultExpanded={defaultExpandedSection === 'rootCause'}
+          >
             <Disclosure.Title>
               <Heading as="h3" size="md">
                 {t('Root Cause')}


### PR DESCRIPTION
Closes ISWF-3152

The top section of the autofix summary is now expanded when you open the preview, allowing you to quickly skim to most relevant info and progress the issue forward.