### PR TITLE
fix(settings): Close member dropdown before invite modal

### DIFF
--- a/static/app/views/settings/organizationTeams/teamMembers.spec.tsx
+++ b/static/app/views/settings/organizationTeams/teamMembers.spec.tsx
@@ -166,6 +166,7 @@ describe('TeamMembers', () => {
     await userEvent.click(screen.getByTestId('invite-member'));
 
     expect(openInviteMembersModal).toHaveBeenCalled();
+    expect(screen.queryByTestId('invite-member')).not.toBeInTheDocument();
   });
 
   it('can invite member from team dropdown with access and `Open Membership` enabled', async () => {

--- a/static/app/views/settings/organizationTeams/teamMembers.tsx
+++ b/static/app/views/settings/organizationTeams/teamMembers.tsx
@@ -155,14 +155,17 @@ function AddMemberDropdown({
                 memberId: selection.value,
               })
       }
-      menuFooter={
+      menuFooter={({closeOverlay}) => (
         <MenuComponents.CTAButton
-          onClick={() => openInviteMembersModal({source: 'teams'})}
+          onClick={() => {
+            closeOverlay();
+            openInviteMembersModal({source: 'teams'});
+          }}
           data-test-id="invite-member"
         >
           {t('Invite Member')}
         </MenuComponents.CTAButton>
-      }
+      )}
       data-test-id="add-member-menu"
       disabled={isDropdownDisabled}
       menuTitle={t('Members')}


### PR DESCRIPTION
Opening Invite Member from the Add Member menu left the menu's contained focus scope active while the modal created a second focus trap. They could bounce focus between each other and freeze the page.

Close the menu before opening the modal and cover the behavior in the team members test.

steps to reproduce:
- go to team settings page and open "Add member" dropdown
- click invite member

fixes JAVASCRIPT-3B6A