### PR TITLE
fix(issues): Close assignee menu before invite modal

### DIFF
--- a/static/app/components/assigneeSelectorDropdown.spec.tsx
+++ b/static/app/components/assigneeSelectorDropdown.spec.tsx
@@ -669,6 +669,7 @@ describe('AssigneeSelectorDropdown', () => {
 
     await userEvent.click(await screen.findByRole('button', {name: 'Invite Member'}));
     expect(openInviteMembersModal).toHaveBeenCalled();
+    expect(screen.queryByRole('button', {name: 'Invite Member'})).not.toBeInTheDocument();
     jest.mocked(ConfigStore.get).mockRestore();
   });
 

--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -562,12 +562,13 @@ export function AssigneeSelectorDropdown({
         onChange={handleSelect}
         options={makeAllOptions()}
         trigger={trigger ?? makeTrigger}
-        menuFooter={
+        menuFooter={({closeOverlay}) => (
           <Flex gap="md">
             <MenuComponents.CTAButton
               disabled={loading}
               onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
                 event.preventDefault();
+                closeOverlay();
                 openInviteMembersModal({source: 'assignee_selector'});
               }}
               icon={<IconAdd />}
@@ -576,7 +577,7 @@ export function AssigneeSelectorDropdown({
             </MenuComponents.CTAButton>
             {additionalMenuFooterItems}
           </Flex>
-        }
+        )}
         sizeLimit={sizeLimit}
         sizeLimitMessage="Use search to find more users and teams..."
         strategy="fixed"


### PR DESCRIPTION
Opening Invite Member from the assignee selector left the menu's focus scope active while the global modal created a second focus trap. That can bounce focus between both overlays and freeze the page.

Close the assignee menu before launching the modal, matching #121005.