### PR TITLE
feat(sentry-apps): send external-issue webhooks for custom integrations

### DIFF
--- a/src/sentry/sentry_apps/external_requests/utils.py
+++ b/src/sentry/sentry_apps/external_requests/utils.py
@@ -84,7 +84,9 @@ SELECT_OPTIONS_SCHEMA = {
 ISSUE_LINKER_SCHEMA = {
     "type": "object",
     "properties": {
-        "webUrl": {"type": "string"},
+        # We store this and hand it to other apps, so reject anything that isn't
+        # a plain http(s) link -- matching the `URLField` on the sibling endpoint.
+        "webUrl": {"type": "string", "pattern": "^https?://"},
         "identifier": {"type": "string"},
         "project": {"type": "string"},
     },

--- a/src/sentry/sentry_apps/services/cell/impl.py
+++ b/src/sentry/sentry_apps/services/cell/impl.py
@@ -23,6 +23,7 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.sentry_apps.external_issues.external_issue_creator import ExternalIssueCreator
 from sentry.sentry_apps.external_issues.issue_link_creator import IssueLinkCreator
+from sentry.sentry_apps.external_requests.issue_link_requester import IssueRequestActionType
 from sentry.sentry_apps.external_requests.select_requester import SelectRequester
 from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
 from sentry.sentry_apps.models.servicehook import ServiceHook, ServiceHookProject
@@ -43,6 +44,7 @@ from sentry.sentry_apps.services.cell.serial import (
 )
 from sentry.sentry_apps.services.cell.service import SentryAppCellService
 from sentry.sentry_apps.utils.errors import SentryAppIntegratorError, SentryAppSentryError
+from sentry.signals import external_issue_created, external_issue_linked
 from sentry.tsdb.base import TSDBModel
 from sentry.users.services.user import RpcUser
 
@@ -174,10 +176,9 @@ class DatabaseBackedSentryAppCellService(SentryAppCellService):
         except (SentryAppIntegratorError, SentryAppSentryError) as e:
             return RpcPlatformExternalIssueResult(error=RpcSentryAppError.from_exc(e))
 
+        is_create = action == IssueRequestActionType.CREATE
         action_cls = (
-            CreatePlatformExternalIssueAction
-            if action == "create"
-            else LinkPlatformExternalIssueAction
+            CreatePlatformExternalIssueAction if is_create else LinkPlatformExternalIssueAction
         )
         publish_action(
             action_cls(
@@ -189,6 +190,15 @@ class DatabaseBackedSentryAppCellService(SentryAppCellService):
             group_id=group.id,
             project=group.project,
             actor=actor,
+        )
+
+        signal = external_issue_created if is_create else external_issue_linked
+        signal.send_robust(
+            project=group.project,
+            group=group,
+            user=user,
+            external_issue=external_issue,
+            sender=self.__class__,
         )
 
         return RpcPlatformExternalIssueResult(
@@ -272,6 +282,14 @@ class DatabaseBackedSentryAppCellService(SentryAppCellService):
             group_id=group.id,
             project=group.project,
             actor=actor,
+        )
+
+        external_issue_created.send_robust(
+            project=group.project,
+            group=group,
+            user=user,
+            external_issue=external_issue,
+            sender=self.__class__,
         )
 
         return RpcPlatformExternalIssueResult(

--- a/tests/sentry/receivers/test_sentry_apps.py
+++ b/tests/sentry/receivers/test_sentry_apps.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 from sentry.constants import SentryAppInstallationStatus
+from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.issues.escalating.escalating import manage_issue_states
 from sentry.issues.ongoing import bulk_transition_group_to_ongoing
 from sentry.models.activity import Activity
@@ -13,6 +14,7 @@ from sentry.models.groupinbox import GroupInboxReason
 from sentry.models.grouplink import GroupLink
 from sentry.models.release import Release
 from sentry.models.repository import Repository
+from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
 from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallation
 from sentry.signals import BetterSignal, external_issue_created, external_issue_linked
 from sentry.silo.base import SiloMode
@@ -420,13 +422,17 @@ class TestExternalIssueWebhooks(APITestCase):
         )
 
     def fire(
-        self, signal: BetterSignal, user: User | None = None, rule_label: str | None = None
+        self,
+        signal: BetterSignal,
+        external_issue: ExternalIssue | PlatformExternalIssue,
+        user: User | None = None,
+        rule_label: str | None = None,
     ) -> None:
         signal.send_robust(
             project=self.project,
             group=self.issue,
             user=user,
-            external_issue=self.external_issue,
+            external_issue=external_issue,
             rule_label=rule_label,
             sender=self.__class__,
         )
@@ -493,4 +499,25 @@ class TestExternalIssueWebhooks(APITestCase):
             external_issue_id=self.external_issue.id,
             external_issue_kind="integration",
             rule_label="My rule",
+        )
+
+    def test_marks_a_custom_integrations_issue_as_platform(self, delay: MagicMock) -> None:
+        install = self.install_app(["issue.external_issue_created"])
+        platform_issue = self.create_platform_external_issue(
+            group=self.issue,
+            service_type="my-app",
+            display_name="app#123",
+            web_url="https://example.com/issues/123",
+        )
+
+        self.fire(external_issue_created, platform_issue, user=self.user)
+
+        delay.assert_called_once_with(
+            installation_id=install.id,
+            issue_id=self.issue.id,
+            type="issue.external_issue_created",
+            user_id=self.user.id,
+            external_issue_id=platform_issue.id,
+            external_issue_kind="platform",
+            rule_label=None,
         )

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_installation_external_issue_actions.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_installation_external_issue_actions.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock, patch
+
 import responses
 from django.urls import reverse
 
@@ -62,6 +64,84 @@ class SentryAppInstallationExternalIssuesEndpointTest(APITestCase):
             "displayName": "ProjectName#issue-1",
             "webUrl": "https://example.com/project/issue-id",
         }
+
+    @responses.activate
+    @patch("sentry.sentry_apps.tasks.sentry_apps.build_external_issue_webhook.delay")
+    def test_notifies_subscribed_sentry_apps_on_link(self, delay: MagicMock) -> None:
+        self.login_as(user=self.user)
+        subscriber = self.create_sentry_app(
+            organization=self.org, events=["issue.external_issue_linked"]
+        )
+        subscriber_install = self.create_sentry_app_installation(
+            organization=self.org, slug=subscriber.slug
+        )
+        responses.add(
+            method=responses.POST,
+            url="https://example.com/link-issues",
+            json={
+                "project": "ProjectName",
+                "webUrl": "https://example.com/project/issue-id",
+                "identifier": "issue-1",
+            },
+            status=200,
+            content_type="application/json",
+        )
+
+        response = self.client.post(
+            self.url,
+            data={
+                "groupId": self.group.id,
+                "action": "link",
+                "fields": {"title": "Hello"},
+                "uri": "/link-issues",
+            },
+            format="json",
+        )
+        assert response.status_code == 200
+
+        with assume_test_silo_mode_of(PlatformExternalIssue):
+            external_issue = PlatformExternalIssue.objects.get()
+
+        delay.assert_called_once_with(
+            installation_id=subscriber_install.id,
+            issue_id=self.group.id,
+            type="issue.external_issue_linked",
+            user_id=self.user.id,
+            external_issue_id=external_issue.id,
+            external_issue_kind="platform",
+            rule_label=None,
+        )
+
+    @responses.activate
+    def test_rejects_a_web_url_the_app_returns_with_a_bad_scheme(self) -> None:
+        self.login_as(user=self.user)
+        responses.add(
+            method=responses.POST,
+            url="https://example.com/create-issues",
+            json={
+                "project": "ProjectName",
+                "webUrl": "javascript:alert(1)",
+                "identifier": "issue-1",
+            },
+            status=200,
+            content_type="application/json",
+        )
+
+        response = self.client.post(
+            self.url,
+            data={
+                "groupId": self.group.id,
+                "action": "create",
+                "fields": {"title": "Hello"},
+                "uri": "/create-issues",
+            },
+            format="json",
+        )
+
+        # Treated like any other malformed response from the app.
+        assert response.status_code == 500
+        with assume_test_silo_mode_of(PlatformExternalIssue):
+            assert not PlatformExternalIssue.objects.exists()
 
     @responses.activate
     def test_external_issue_doesnt_get_created(self) -> None:

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_installation_external_issues.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_installation_external_issues.py
@@ -109,6 +109,34 @@ class SentryAppInstallationExternalIssuesEndpointTest(APITestCase):
         )
         assert response.status_code == 403
 
+    @patch("sentry.sentry_apps.tasks.sentry_apps.build_external_issue_webhook.delay")
+    def test_notifies_subscribed_sentry_apps(self, delay: MagicMock) -> None:
+        self._set_up_sentry_app("Testin", ["event:write"])
+        subscriber = self.create_sentry_app(
+            organization=self.org, events=["issue.external_issue_created"]
+        )
+        subscriber_install = self.create_sentry_app_installation(
+            organization=self.org, slug=subscriber.slug
+        )
+
+        response = self.client.post(
+            self.url, data=self._post_data(), HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}"
+        )
+        assert response.status_code == 200
+
+        with assume_test_silo_mode_of(PlatformExternalIssue):
+            external_issue = PlatformExternalIssue.objects.get()
+
+        delay.assert_called_once_with(
+            installation_id=subscriber_install.id,
+            issue_id=self.group.id,
+            type="issue.external_issue_created",
+            user_id=self.sentry_app.proxy_user_id,
+            external_issue_id=external_issue.id,
+            external_issue_kind="platform",
+            rule_label=None,
+        )
+
     @patch(
         "sentry.sentry_apps.external_issues.external_issue_creator.PlatformExternalIssue.objects.update_or_create"
     )

--- a/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
@@ -2253,7 +2253,12 @@ class TestExternalIssueWebhook(TestCase):
         )
 
     def run_task(
-        self, event: str, user_id: int | None = None, rule_label: str | None = None
+        self,
+        event: str,
+        user_id: int | None = None,
+        rule_label: str | None = None,
+        external_issue_id: int | None = None,
+        external_issue_kind: str = "integration",
     ) -> None:
         if external_issue_id is None:
             external_issue_id = self.external_issue.id
@@ -2262,7 +2267,8 @@ class TestExternalIssueWebhook(TestCase):
             issue_id=self.issue.id,
             type=event,
             user_id=user_id,
-            external_issue_id=self.external_issue.id,
+            external_issue_id=external_issue_id,
+            external_issue_kind=external_issue_kind,
             rule_label=rule_label,
         )
 
@@ -2328,5 +2334,54 @@ class TestExternalIssueWebhook(TestCase):
 
         with pytest.raises(SentryAppSentryError):
             self.run_task("issue.external_issue_created", user_id=self.user.id)
+
+        assert not safe_urlopen.called
+
+    def test_sends_the_platform_shape_for_a_custom_integration(
+        self, safe_urlopen: MagicMock
+    ) -> None:
+        platform_issue = self.create_platform_external_issue(
+            group=self.issue,
+            service_type=self.sentry_app.slug,
+            display_name="app#123",
+            web_url="https://example.com/issues/123",
+        )
+
+        self.run_task(
+            "issue.external_issue_created",
+            user_id=self.user.id,
+            external_issue_id=platform_issue.id,
+            external_issue_kind="platform",
+        )
+
+        ((_, kwargs),) = safe_urlopen.call_args_list
+        data = json.loads(kwargs["data"])
+        assert data["data"]["external_issue_kind"] == "platform"
+        assert data["data"]["external_issue"] == {
+            "id": str(platform_issue.id),
+            "issueId": str(self.issue.id),
+            "serviceType": self.sentry_app.slug,
+            "displayName": "app#123",
+            "webUrl": "https://example.com/issues/123",
+        }
+
+    def test_will_not_send_a_platform_issue_belonging_to_another_group(
+        self, safe_urlopen: MagicMock
+    ) -> None:
+        other_issue = self.create_group(project=self.project)
+        unrelated = self.create_platform_external_issue(
+            group=other_issue,
+            service_type=self.sentry_app.slug,
+            display_name="app#456",
+            web_url="https://example.com/issues/456",
+        )
+
+        with pytest.raises(SentryAppSentryError):
+            self.run_task(
+                "issue.external_issue_created",
+                user_id=self.user.id,
+                external_issue_id=unrelated.id,
+                external_issue_kind="platform",
+            )
 
         assert not safe_urlopen.called


### PR DESCRIPTION
Custom (platform) integrations create their own `PlatformExternalIssue` rows rather than the `ExternalIssue` rows that first-party integrations use. Fire the same two events for both, discriminated by `external_issue_kind` in the payload.