### PR TITLE
ref(pr-metrics): promote the PR lifecycle mappers out of the webhooks

### DIFF
--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -8,7 +8,7 @@ import time
 from abc import ABC
 from collections.abc import Mapping, MutableMapping, Sequence
 from contextlib import nullcontext
-from datetime import datetime, timezone
+from datetime import timezone
 from typing import Any, Protocol
 
 import orjson
@@ -70,6 +70,10 @@ from sentry.organizations.services.organization.serial import serialize_rpc_orga
 from sentry.plugins.providers.integration_repository import (
     RepoExistsError,
     get_integration_repository_provider,
+)
+from sentry.pr_metrics.lifecycle_mapping import (
+    parse_scm_timestamp,
+    pull_request_lifecycle_state_from_github,
 )
 from sentry.pr_metrics.webhooks import handle_activity as pr_metrics_handle_activity
 from sentry.pr_metrics.webhooks import handle_attribution as pr_metrics_handle_attribution
@@ -1073,27 +1077,6 @@ class IssuesEventWebhook(GitHubWebhook):
         return f"{repo_full_name}#{issue_number}"
 
 
-def _parse_github_timestamp(value: str | None) -> datetime | None:
-    """Parse a GitHub ISO-8601 timestamp into a UTC datetime, or None if absent."""
-    if not value:
-        return None
-    return parse_date(value).astimezone(timezone.utc)
-
-
-def _pull_request_lifecycle_state(pull_request: Mapping[str, Any]) -> str:
-    """Map a GitHub PR payload to a ``PullRequestLifecycleState`` value.
-
-    GitHub reports ``state`` as only "open"/"closed" alongside a separate
-    ``merged`` flag; we fold the two into the richer lifecycle enum so a merged
-    PR is stored as "merged" rather than an ambiguous "closed".
-    """
-    if pull_request.get("merged"):
-        return PullRequestLifecycleState.MERGED
-    if pull_request.get("state") == "closed":
-        return PullRequestLifecycleState.CLOSED
-    return PullRequestLifecycleState.OPEN
-
-
 class PullRequestEventWebhook(GitHubWebhook):
     """https://developer.github.com/v3/activity/events/types/#pullrequestevent"""
 
@@ -1146,10 +1129,10 @@ class PullRequestEventWebhook(GitHubWebhook):
 
         # Lifecycle facts kept current for the PR metrics pipeline.
         head_commit_sha = pull_request["head"]["sha"]
-        opened_at = _parse_github_timestamp(pull_request.get("created_at"))
-        closed_at = _parse_github_timestamp(pull_request.get("closed_at"))
-        merged_at = _parse_github_timestamp(pull_request.get("merged_at"))
-        state = _pull_request_lifecycle_state(pull_request)
+        opened_at = parse_scm_timestamp(pull_request.get("created_at"))
+        closed_at = parse_scm_timestamp(pull_request.get("closed_at"))
+        merged_at = parse_scm_timestamp(pull_request.get("merged_at"))
+        state = pull_request_lifecycle_state_from_github(pull_request)
         draft = pull_request.get("draft")
 
         author_email = "{}@localhost".format(user["login"][:65])

--- a/src/sentry/integrations/gitlab/webhooks.py
+++ b/src/sentry/integrations/gitlab/webhooks.py
@@ -34,11 +34,12 @@ from sentry.integrations.utils.webhook_viewer_context import webhook_viewer_cont
 from sentry.issues.action_log import ActionSource, action_context_scope, resolve_action_actor
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
-from sentry.models.pullrequest import PullRequest, PullRequestLifecycleState
+from sentry.models.pullrequest import PullRequest
 from sentry.models.repository import Repository
 from sentry.organizations.services.organization import organization_service
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.plugins.providers import IntegrationRepositoryProvider
+from sentry.pr_metrics.lifecycle_mapping import map_gitlab_state_to_pullrequest_lifecycle
 from sentry.seer.code_review.webhooks.logging import debug_log
 from sentry.seer.code_review.webhooks.merge_request import (
     handle_merge_request_event,
@@ -382,15 +383,6 @@ class IssuesEventWebhook(GitlabWebhook):
         return f"{integration.metadata['domain_name']}:{path_with_namespace}#{issue_iid}"
 
 
-def _map_gitlab_state_to_pullrequest_lifecycle(gitlab_state: str | None) -> str | None:
-    return {
-        "opened": PullRequestLifecycleState.OPEN,
-        "closed": PullRequestLifecycleState.CLOSED,
-        "merged": PullRequestLifecycleState.MERGED,
-        "locked": PullRequestLifecycleState.LOCKED,
-    }.get(gitlab_state or "")
-
-
 class MergeEventWebhook(GitlabWebhook):
     """
     Handle Merge Request Hook
@@ -463,7 +455,7 @@ class MergeEventWebhook(GitlabWebhook):
 
             updated_at = event["object_attributes"].get("updated_at")
             merged_at = event["object_attributes"].get("merged_at")
-            state = _map_gitlab_state_to_pullrequest_lifecycle(
+            state = map_gitlab_state_to_pullrequest_lifecycle(
                 event["object_attributes"].get("state")
             )
             action = event["object_attributes"].get("action")

--- a/src/sentry/pr_metrics/lifecycle_mapping.py
+++ b/src/sentry/pr_metrics/lifecycle_mapping.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from typing import Any
+
+from dateutil.parser import parse as parse_date
+
+from sentry.models.pullrequest import PullRequestLifecycleState
+
+
+def parse_scm_timestamp(value: str | None) -> datetime | None:
+    """Parse a provider's ISO-8601 timestamp into a UTC datetime, or None if absent."""
+    if not value:
+        return None
+    return parse_date(value).astimezone(timezone.utc)
+
+
+def pull_request_lifecycle_state_from_github(pull_request: Mapping[str, Any]) -> str:
+    """Map a GitHub PR payload to a ``PullRequestLifecycleState`` value.
+
+    GitHub reports ``state`` as only "open"/"closed" alongside a separate
+    ``merged`` flag; we fold the two into the richer lifecycle enum so a merged
+    PR is stored as "merged" rather than an ambiguous "closed".
+    """
+    if pull_request.get("merged"):
+        return PullRequestLifecycleState.MERGED
+    if pull_request.get("state") == "closed":
+        return PullRequestLifecycleState.CLOSED
+    return PullRequestLifecycleState.OPEN
+
+
+def map_gitlab_state_to_pullrequest_lifecycle(gitlab_state: str | None) -> str | None:
+    return {
+        "opened": PullRequestLifecycleState.OPEN,
+        "closed": PullRequestLifecycleState.CLOSED,
+        "merged": PullRequestLifecycleState.MERGED,
+        "locked": PullRequestLifecycleState.LOCKED,
+    }.get(gitlab_state or "")

--- a/tests/sentry/pr_metrics/test_lifecycle_mapping.py
+++ b/tests/sentry/pr_metrics/test_lifecycle_mapping.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sentry.models.pullrequest import PullRequestLifecycleState
+from sentry.pr_metrics.lifecycle_mapping import (
+    map_gitlab_state_to_pullrequest_lifecycle,
+    parse_scm_timestamp,
+    pull_request_lifecycle_state_from_github,
+)
+
+
+def test_parse_scm_timestamp_to_utc() -> None:
+    assert parse_scm_timestamp("2026-07-01T12:30:00Z") == datetime(
+        2026, 7, 1, 12, 30, tzinfo=timezone.utc
+    )
+
+
+def test_parse_scm_timestamp_converts_offset() -> None:
+    assert parse_scm_timestamp("2026-07-01T14:30:00+02:00") == datetime(
+        2026, 7, 1, 12, 30, tzinfo=timezone.utc
+    )
+
+
+def test_parse_scm_timestamp_absent() -> None:
+    assert parse_scm_timestamp(None) is None
+    assert parse_scm_timestamp("") is None
+
+
+def test_github_state_merged_wins_over_closed() -> None:
+    # GitHub reports a merged PR as state "closed" plus merged=True; the merged flag must
+    # win so the row isn't stored as an ambiguous "closed".
+    assert (
+        pull_request_lifecycle_state_from_github({"state": "closed", "merged": True})
+        == PullRequestLifecycleState.MERGED
+    )
+
+
+def test_github_state_closed_unmerged() -> None:
+    assert (
+        pull_request_lifecycle_state_from_github({"state": "closed", "merged": False})
+        == PullRequestLifecycleState.CLOSED
+    )
+
+
+def test_github_state_open() -> None:
+    assert (
+        pull_request_lifecycle_state_from_github({"state": "open", "merged": False})
+        == PullRequestLifecycleState.OPEN
+    )
+
+
+def test_gitlab_state_known_values() -> None:
+    assert map_gitlab_state_to_pullrequest_lifecycle("opened") == PullRequestLifecycleState.OPEN
+    assert map_gitlab_state_to_pullrequest_lifecycle("closed") == PullRequestLifecycleState.CLOSED
+    assert map_gitlab_state_to_pullrequest_lifecycle("merged") == PullRequestLifecycleState.MERGED
+    assert map_gitlab_state_to_pullrequest_lifecycle("locked") == PullRequestLifecycleState.LOCKED
+
+
+def test_gitlab_state_unknown_values() -> None:
+    assert map_gitlab_state_to_pullrequest_lifecycle(None) is None
+    assert map_gitlab_state_to_pullrequest_lifecycle("") is None
+    assert map_gitlab_state_to_pullrequest_lifecycle("something_new") is None
+    # Casing is not normalized; GitLab reports lowercase.
+    assert map_gitlab_state_to_pullrequest_lifecycle("OPENED") is None


### PR DESCRIPTION
Refs https://linear.app/getsentry/issue/ISWF-3158/backfill-missing-pullrequest-data-using-scm-integrations

Modularize some Github + Gitlab helpers so we can use them for a backfill in getsentry.