### PR TITLE
feat(aci): Add button to leave alert edit window

### DIFF
--- a/static/app/views/automations/components/editAutomationActions.tsx
+++ b/static/app/views/automations/components/editAutomationActions.tsx
@@ -1,7 +1,8 @@
 import {Observer} from 'mobx-react-lite';
 
-import {Button} from '@sentry/scraps/button';
+import {Button, LinkButton} from '@sentry/scraps/button';
 import {Grid} from '@sentry/scraps/layout';
+import {Separator} from '@sentry/scraps/separator';
 
 import {addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {openConfirmModal} from 'sentry/components/confirm';
@@ -18,7 +19,10 @@ import {
   getNoAlertWritePermissionTooltip,
   useCanEditAutomation,
 } from 'sentry/views/automations/hooks/useCanEditAutomation';
-import {makeAutomationBasePathname} from 'sentry/views/automations/pathnames';
+import {
+  makeAutomationBasePathname,
+  makeAutomationDetailsPathname,
+} from 'sentry/views/automations/pathnames';
 
 interface EditAutomationActionsProps {
   automation: Automation;
@@ -83,6 +87,14 @@ export function EditAutomationActions({automation, form}: EditAutomationActionsP
         >
           {t('Delete')}
         </Button>
+        <Separator orientation="vertical" />
+        <LinkButton
+          variant="secondary"
+          size="sm"
+          to={makeAutomationDetailsPathname(organization.slug, automation.id)}
+        >
+          {t('Cancel')}
+        </LinkButton>
         <Observer>
           {() => (
             <Button


### PR DESCRIPTION
Add a button to leave the alert edit window for the monitors route

Currently if you go it is just 3 buttons that say disable, delete, and save. If you make a change to any of the triggers there isn't a clean way to undo what you did. You have to navigate back in the browser. This PR adds a button to do that.

The other thing is that since the words disable, delete, and cancel are all negative actions, there is a separator to make it clear that cancel is the opposite of saving aka not saving your changes

Before

<img width="1281" height="708" alt="image" src="https://github.com/user-attachments/assets/03f5db9d-950a-46c4-9468-c12ffd254e41" />

After

<img width="1241" height="948" alt="image" src="https://github.com/user-attachments/assets/212e0999-18e8-4fdd-a7da-295b3c9907d8" />
