### PR TITLE
fix(issues): Show linked PRs without a current event

### DIFF
--- a/static/app/components/group/externalIssuesList/hooks/useGroupExternalIssues.tsx
+++ b/static/app/components/group/externalIssuesList/hooks/useGroupExternalIssues.tsx
@@ -7,7 +7,9 @@ import {useIntegrationExternalIssues} from './useIntegrationExternalIssues';
 import {useSentryAppExternalIssues} from './useSentryAppExternalIssues';
 
 interface Props {
-  /** Used to include stack trace content in Sentry App issue descriptions. */
+  /**
+   * Adds stack trace content to Sentry App issue descriptions when available.
+   */
   event: Event | undefined;
   group: Group;
 }

--- a/static/app/components/group/externalIssuesList/hooks/useGroupExternalIssues.tsx
+++ b/static/app/components/group/externalIssuesList/hooks/useGroupExternalIssues.tsx
@@ -7,6 +7,7 @@ import {useIntegrationExternalIssues} from './useIntegrationExternalIssues';
 import {useSentryAppExternalIssues} from './useSentryAppExternalIssues';
 
 interface Props {
+  /** Used to include stack trace content in Sentry App issue descriptions. */
   event: Event | undefined;
   group: Group;
 }

--- a/static/app/components/group/externalIssuesList/hooks/useGroupExternalIssues.tsx
+++ b/static/app/components/group/externalIssuesList/hooks/useGroupExternalIssues.tsx
@@ -7,7 +7,7 @@ import {useIntegrationExternalIssues} from './useIntegrationExternalIssues';
 import {useSentryAppExternalIssues} from './useSentryAppExternalIssues';
 
 interface Props {
-  event: Event;
+  event: Event | undefined;
   group: Group;
 }
 

--- a/static/app/components/group/externalIssuesList/hooks/useSentryAppExternalIssues.tsx
+++ b/static/app/components/group/externalIssuesList/hooks/useSentryAppExternalIssues.tsx
@@ -17,7 +17,7 @@ export function useSentryAppExternalIssues({
   group,
   event,
 }: {
-  event: Event;
+  event: Event | undefined;
   group: Group;
 }): GroupIntegrationIssueResult {
   const api = useApi();

--- a/static/app/components/group/sentryAppExternalIssueForm.spec.tsx
+++ b/static/app/components/group/sentryAppExternalIssueForm.spec.tsx
@@ -119,6 +119,27 @@ describe('SentryAppExternalIssueForm', () => {
         `Sentry Issue: [${group.shortId}](${url})`
       );
     });
+
+    it('renders without an event', async () => {
+      render(
+        <SentryAppExternalIssueForm
+          event={undefined}
+          onSubmitSuccess={jest.fn()}
+          group={group}
+          sentryAppInstallation={sentryAppInstallation}
+          appName={sentryApp.name}
+          config={component.schema.create}
+          action="create"
+        />
+      );
+
+      const url = addQueryParamsToExistingUrl(group.permalink, {
+        referrer: sentryApp.name,
+      });
+      expect(await screen.findByRole('textbox', {name: 'Description'})).toHaveValue(
+        `Sentry Issue: [${group.shortId}](${url})`
+      );
+    });
   });
 
   describe('link', () => {

--- a/static/app/components/group/sentryAppExternalIssueForm.tsx
+++ b/static/app/components/group/sentryAppExternalIssueForm.tsx
@@ -19,7 +19,7 @@ type Props = {
   action: 'create' | 'link';
   appName: string;
   config: SchemaFormConfig;
-  event: Event;
+  event: Event | undefined;
   group: Group;
   onSubmitSuccess: (externalIssue: PlatformExternalIssue) => void;
   sentryAppInstallation: SentryAppInstallation;

--- a/static/app/components/group/sentryAppExternalIssueForm.tsx
+++ b/static/app/components/group/sentryAppExternalIssueForm.tsx
@@ -19,6 +19,9 @@ type Props = {
   action: 'create' | 'link';
   appName: string;
   config: SchemaFormConfig;
+  /**
+   * Adds stack trace content to the default issue description when available.
+   */
   event: Event | undefined;
   group: Group;
   onSubmitSuccess: (externalIssue: PlatformExternalIssue) => void;

--- a/static/app/components/group/sentryAppExternalIssueModal.spec.tsx
+++ b/static/app/components/group/sentryAppExternalIssueModal.spec.tsx
@@ -77,6 +77,20 @@ describe('openSentryAppIssueModal', () => {
     }
   });
 
+  it('renders without an event', async () => {
+    openSentryAppIssueModal({
+      organization,
+      group,
+      event: undefined,
+      sentryAppComponent: component,
+      sentryAppInstallation: install,
+    });
+
+    renderGlobalModal();
+
+    expect(await screen.findByRole('textbox', {name: 'Title'})).toHaveValue(group.title);
+  });
+
   it('can link an existing Issue', async () => {
     const request = MockApiClient.addMockResponse({
       url: submitUrl,

--- a/static/app/components/group/sentryAppExternalIssueModal.tsx
+++ b/static/app/components/group/sentryAppExternalIssueModal.tsx
@@ -55,7 +55,7 @@ export const openSentryAppIssueModal = ({
 };
 
 type Props = ModalRenderProps & {
-  event: Event;
+  event: Event | undefined;
   group: Group;
   sentryAppComponent: SentryAppComponent;
   sentryAppInstallation: SentryAppInstallation;

--- a/static/app/utils/getStacktraceBody.tsx
+++ b/static/app/utils/getStacktraceBody.tsx
@@ -3,7 +3,7 @@ import type {Event} from 'sentry/types/event';
 
 type GetStacktraceBodyArgs = {
   /** The Sentry event containing stack trace data. */
-  event: Event;
+  event: Event | undefined;
   /** Whether the similarity embeddings feature is enabled. */
   hasSimilarityEmbeddingsFeature?: boolean;
   /** Whether to include source code context in stack trace frames for JavaScript. */

--- a/static/app/utils/getStacktraceBody.tsx
+++ b/static/app/utils/getStacktraceBody.tsx
@@ -2,7 +2,9 @@ import {displayRawContent as rawStacktraceContent} from 'sentry/components/event
 import type {Event} from 'sentry/types/event';
 
 type GetStacktraceBodyArgs = {
-  /** The Sentry event containing stack trace data. */
+  /**
+   * The Sentry event containing stack trace data. Returns no content when omitted.
+   */
   event: Event | undefined;
   /** Whether the similarity embeddings feature is enabled. */
   hasSimilarityEmbeddingsFeature?: boolean;

--- a/static/app/views/issueDetails/sidebar/externalIssueSidebarList.tsx
+++ b/static/app/views/issueDetails/sidebar/externalIssueSidebarList.tsx
@@ -17,7 +17,7 @@ import {SectionKey} from 'sentry/views/issueDetails/context';
 import {SidebarFoldSection} from 'sentry/views/issueDetails/foldSection';
 
 interface Props {
-  event: Event;
+  event: Event | undefined;
   group: Group;
 }
 

--- a/static/app/views/issueDetails/sidebar/sidebar.spec.tsx
+++ b/static/app/views/issueDetails/sidebar/sidebar.spec.tsx
@@ -4,6 +4,8 @@ import {GitHubIntegrationFixture} from 'sentry-fixture/githubIntegration';
 import {GroupFixture} from 'sentry-fixture/group';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
+import {PullRequestFixture} from 'sentry-fixture/pullRequest';
+import {RepositoryFixture} from 'sentry-fixture/repository';
 import {UserFixture} from 'sentry-fixture/user';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -147,5 +149,43 @@ describe('IssueDetailsSidebar', () => {
     expect(screen.getByRole('button', {name: 'View Similar Issues'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Merged Issues'})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'View Merged Issues'})).toBeInTheDocument();
+  });
+
+  it('renders linked pull requests without a current event', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${group.id}/pull-requests/`,
+      body: {
+        pullRequests: [
+          {
+            ...PullRequestFixture({
+              id: '123',
+              repository: RepositoryFixture({
+                id: '42',
+                name: 'example/widget-app',
+                provider: {id: 'integrations:github', name: 'GitHub'},
+              }),
+              externalUrl: 'https://github.com/example/widget-app/pull/123',
+            }),
+            attribution: null,
+            dateLinked: '2026-06-08T23:11:32.000000Z',
+            status: 'open',
+          },
+        ],
+      },
+    });
+
+    render(
+      <GroupDataContextProvider group={group} project={group.project}>
+        <IssueDetailsSidebar group={group} project={project} />
+      </GroupDataContextProvider>,
+      {organization}
+    );
+
+    expect(await screen.findByText('External Links')).toBeInTheDocument();
+    expect(
+      await screen.findByRole('link', {
+        name: /Pull request #123 in example\/widget-app/,
+      })
+    ).toBeInTheDocument();
   });
 });

--- a/static/app/views/issueDetails/sidebar/sidebar.tsx
+++ b/static/app/views/issueDetails/sidebar/sidebar.tsx
@@ -101,11 +101,9 @@ export function IssueDetailsSidebar({group, event, project}: Props) {
               <AutofixSection group={group} project={project} />
             </ErrorBoundary>
           )}
-          {event && (
-            <ErrorBoundary mini>
-              <ExternalIssueSidebarList group={group} event={event} />
-            </ErrorBoundary>
-          )}
+          <ErrorBoundary mini>
+            <ExternalIssueSidebarList group={group} event={event} />
+          </ErrorBoundary>
           <ErrorBoundary mini>
             <ActivitySection group={group} />
           </ErrorBoundary>


### PR DESCRIPTION
The External Links sidebar was hidden whenever issue details did not have a current event, which also hid linked pull requests.

Keep the section rendered and make the event optional for Sentry App issue creation. Without an event, generated issue descriptions just skip stack trace content.