### PR TITLE
ref(auth): Extract reusable methods from SSO identity handler

### DIFF
--- a/src/sentry/auth/email_verification.py
+++ b/src/sentry/auth/email_verification.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import binascii
 import logging
 import time
+from collections.abc import Mapping
 from typing import Any
 
 from django.conf import settings
@@ -17,6 +18,8 @@ from sentry.utils.http import absolute_uri
 from sentry.utils.signing import sign, unsign
 
 logger = logging.getLogger("sentry.auth.email_verification")
+TRUSTED_EMAIL_VERIFIED_PROVIDERS = frozenset(("github", "google"))
+DEFAULT_MAX_AGE_MINUTES = 120
 
 
 class SignupLinkExpired(SignatureExpired):
@@ -30,7 +33,13 @@ def hash_email(email: str) -> str:
     return sha256_text(email.lower()).hexdigest()
 
 
-DEFAULT_MAX_AGE_MINUTES = 120
+def is_email_verified_by_trusted_provider(provider_key: str, identity: Mapping[str, Any]) -> bool:
+    """If True: the provider's email_verified claim can be trusted, and they certify that the email is verified.
+    If False: the identity requires our own verification step.
+    """
+    return (
+        provider_key in TRUSTED_EMAIL_VERIFIED_PROVIDERS and identity.get("email_verified") is True
+    )
 
 
 def send_signup_verification_email(

--- a/src/sentry/auth/email_verification.py
+++ b/src/sentry/auth/email_verification.py
@@ -36,6 +36,10 @@ def hash_email(email: str) -> str:
 def is_email_verified_by_trusted_provider(provider_key: str, identity: Mapping[str, Any]) -> bool:
     """If True: the provider's email_verified claim can be trusted, and they certify that the email is verified.
     If False: the identity requires our own verification step.
+
+    Expects a freshly built identity, where email_verified has been normalized to a
+    bool (see normalize_email_verified). The strict `is True` check does not handle
+    legacy persisted values, which may be the string "true".
     """
     return (
         provider_key in TRUSTED_EMAIL_VERIFIED_PROVIDERS and identity.get("email_verified") is True

--- a/src/sentry/auth/email_verification.py
+++ b/src/sentry/auth/email_verification.py
@@ -18,7 +18,7 @@ from sentry.utils.http import absolute_uri
 from sentry.utils.signing import sign, unsign
 
 logger = logging.getLogger("sentry.auth.email_verification")
-TRUSTED_EMAIL_VERIFIED_PROVIDERS = frozenset(("github", "google"))
+TRUSTED_EMAIL_VERIFIED_PROVIDERS = frozenset({"google"})
 DEFAULT_MAX_AGE_MINUTES = 120
 
 

--- a/src/sentry/auth/exceptions.py
+++ b/src/sentry/auth/exceptions.py
@@ -13,3 +13,14 @@ class IdentityNotValid(Exception):
 
 class AuthIdentityUserMismatch(Exception):
     pass
+
+
+class PipelineStateExpired(Exception):
+    pass
+
+
+class ProviderMismatch(Exception):
+    def __init__(self, actual: str, expected: str) -> None:
+        self.actual = actual
+        self.expected = expected
+        super().__init__(f"Expected provider {expected}, got {actual}")

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -866,8 +866,8 @@ class AuthHelper(Pipeline[AuthProvider, AuthHelperSessionStore]):
         if not data:
             raise PipelineStateExpired()
 
-        # Check for provider mismatch — user authenticated with a different
-        # provider than what the organization requires.  Can happen when a user
+        # Check for provider mismatch - user authenticated with a different
+        # provider than what the organization requires. Can happen when a user
         # has multiple SSO sessions in different tabs.
         provider_key = data.get("provider_key")
         if (

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -25,7 +25,12 @@ from sentry import audit_log, features
 from sentry.api.invite_helper import ApiInviteHelper, remove_invite_details_from_session
 from sentry.audit_log.services.log import AuditLogEvent, log_service
 from sentry.auth.email import AmbiguousUserFromEmail, resolve_email_to_user
-from sentry.auth.exceptions import AuthIdentityUserMismatch, IdentityNotValid
+from sentry.auth.exceptions import (
+    AuthIdentityUserMismatch,
+    IdentityNotValid,
+    PipelineStateExpired,
+    ProviderMismatch,
+)
 from sentry.auth.idpmigration import (
     SSO_VERIFICATION_KEY,
     get_verification_value_from_key,
@@ -850,17 +855,20 @@ class AuthHelper(Pipeline[AuthProvider, AuthHelperSessionStore]):
         state.update({"flow": self.flow, "referrer": self.referrer})
         return state
 
-    def finish_pipeline(self) -> HttpResponseBase:
-        data = self.fetch_state()
+    def resolve_identity(self) -> Mapping[str, Any]:
+        """Fetch pipeline state, validate provider, and build identity.
 
-        # The state data may have expired, in which case the state data will
-        # simply be None.
+        Raises PipelineStateExpired if state is missing/expired,
+        ProviderMismatch if the pipeline provider doesn't match the org's auth provider,
+        IdentityNotValid if the provider can't build a valid identity.
+        """
+        data: Mapping[str, Any] | None = self.fetch_state()
         if not data:
-            return self.error(ERR_INVALID_IDENTITY)
+            raise PipelineStateExpired()
 
-        # Check for provider mismatch - user authenticated with a different provider
-        # than what the organization requires. This can happen when a user has multiple
-        # SSO sessions in different tabs and completes the wrong one.
+        # Check for provider mismatch — user authenticated with a different
+        # provider than what the organization requires.  Can happen when a user
+        # has multiple SSO sessions in different tabs.
         provider_key = data.get("provider_key")
         if (
             self.state.flow == FLOW_LOGIN
@@ -868,13 +876,20 @@ class AuthHelper(Pipeline[AuthProvider, AuthHelperSessionStore]):
             and provider_key
             and provider_key != self.provider_model.provider
         ):
-            return self._handle_provider_mismatch(
-                provider_key=provider_key,
-                expected_provider_key=self.provider_model.provider,
-            )
+            raise ProviderMismatch(actual=provider_key, expected=self.provider_model.provider)
 
+        return self.provider.build_identity(data)
+
+    def finish_pipeline(self) -> HttpResponseBase:
         try:
-            identity = self.provider.build_identity(data)
+            identity = self.resolve_identity()
+        except PipelineStateExpired:
+            return self.error(ERR_INVALID_IDENTITY)
+        except ProviderMismatch as e:
+            return self._handle_provider_mismatch(
+                provider_key=e.actual,
+                expected_provider_key=e.expected,
+            )
         except IdentityNotValid as error:
             return self.error(str(error) or ERR_INVALID_IDENTITY)
 

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -454,9 +454,11 @@ class AuthIdentityHandler:
 
         return render_to_response(template, default_context, self.request, status=status)
 
-    def _post_login_redirect(self) -> HttpResponseRedirect:
+    def _post_login_redirect(self, is_new_user: bool | None = None) -> HttpResponseRedirect:
         url = auth.get_login_redirect(self.request)
-        if self.request.POST.get("op") == "newuser":
+        if is_new_user is None:
+            is_new_user = self.request.POST.get("op") == "newuser"
+        if is_new_user:
             # add events that we can handle on the front end
             provider = self.auth_provider.provider if self.auth_provider else None
             params = {
@@ -654,20 +656,28 @@ class AuthIdentityHandler:
             )
             return self._build_confirmation_response(is_new_account)
 
+        return self.complete_and_login(auth_identity, state, is_new_user=(op == "newuser"))
+
+    def complete_and_login(
+        self,
+        auth_identity: AuthIdentity,
+        state: AuthHelperSessionStore,
+        is_new_user: bool = False,
+    ) -> HttpResponseRedirect:
+        """Log in a user after identity resolution and clean up pipeline state."""
         user = auth_identity.user
         user.backend = settings.AUTHENTICATION_BACKENDS[0]
 
-        # XXX(dcramer): this is repeated from above
         try:
             self._login(user)
         except self._NotCompletedSecurityChecks:
-            return self._post_login_redirect()
+            return self._post_login_redirect(is_new_user=is_new_user)
 
         state.clear()
 
         if not is_active_superuser(self.request):
             auth.set_active_org(self.request, self.organization.slug)
-        return self._post_login_redirect()
+        return self._post_login_redirect(is_new_user=is_new_user)
 
     @property
     def provider_name(self) -> str:
@@ -696,7 +706,7 @@ class AuthIdentityHandler:
         self.request.session.set_test_cookie()
         return None if is_new_account else self.user, "auth-confirm-identity"
 
-    def handle_new_user(self) -> AuthIdentity:
+    def handle_new_user(self, skip_confirm_emails: bool = False) -> AuthIdentity:
         user = User.objects.create(
             username=uuid4().hex,
             email=self.identity["email"],
@@ -720,7 +730,8 @@ class AuthIdentityHandler:
             )
             auth_identity.update(user=user, data=self.identity.get("data", {}))
 
-        user.send_confirm_emails(is_new_user=True)
+        if not skip_confirm_emails:
+            user.send_confirm_emails(is_new_user=True)
         provider = self.auth_provider.provider if self.auth_provider else None
         user_signup.send_robust(
             sender=self.handle_new_user,

--- a/src/sentry/auth/providers/google/provider.py
+++ b/src/sentry/auth/providers/google/provider.py
@@ -10,6 +10,7 @@ from sentry.auth.provider import MigratingIdentityId
 from sentry.auth.providers.oauth2 import OAuth2Callback, OAuth2Login, OAuth2Provider
 from sentry.auth.services.auth.model import RpcAuthProvider
 from sentry.auth.view import AuthView
+from sentry.identity.google.provider import normalize_email_verified
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.plugins.base.response import DeferredResponse
 
@@ -118,5 +119,5 @@ class GoogleOAuth2Provider(OAuth2Provider):
             "email": user_data["email"],
             "name": user_data["email"],
             "data": self.get_oauth_data(data),
-            "email_verified": user_data["email_verified"],
+            "email_verified": normalize_email_verified(user_data["email_verified"]),
         }

--- a/src/sentry/identity/google/provider.py
+++ b/src/sentry/identity/google/provider.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import orjson
 
 from sentry import options
@@ -11,6 +13,15 @@ from sentry.utils.signing import urlsafe_b64decode
 # account (you can register a google account with any email), but it is not a
 # gsuite account, which we want to differentiate on.
 DEFAULT_GOOGLE_DOMAIN = "gmail.com"
+
+
+def normalize_email_verified(value: Any) -> bool:
+    """Coerce Google's email_verified claim to a bool.
+
+    Google's docs define this as a bool but their example (and the tokeninfo endpoint) show the string "true".
+    Only True or "true" counts as verified.
+    """
+    return value is True or (isinstance(value, str) and value.strip().lower() == "true")
 
 
 class GoogleIdentityProvider(OAuth2Provider):
@@ -56,7 +67,7 @@ class GoogleIdentityProvider(OAuth2Provider):
             "type": "google",
             "id": user_id,
             "email": user_data["email"],
-            "email_verified": user_data["email_verified"],
+            "email_verified": normalize_email_verified(user_data["email_verified"]),
             "name": user_data["email"],
             "domain": user_data.get("hd", DEFAULT_GOOGLE_DOMAIN),
             "scopes": sorted(self.oauth_scopes),

--- a/tests/sentry/auth/test_email_verification.py
+++ b/tests/sentry/auth/test_email_verification.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.core.signing import BadSignature, SignatureExpired
 
 from sentry.auth.email_verification import (
+    is_email_verified_by_trusted_provider,
     send_signup_verification_email,
     verify_signup_link,
 )
@@ -88,3 +89,20 @@ class UnsignSignupVerificationTest(TestCase):
         signed = sign(salt="wrong-salt", email="a@b.com", expires_at=exp)
         with pytest.raises(BadSignature):
             verify_signup_link(signed)
+
+
+@control_silo_test
+class IsEmailVerifiedByTrustedProviderTest(TestCase):
+    def test_trusted_check(self) -> None:
+        cases = [
+            ("google", {"email_verified": True}, True),
+            ("github", {"email_verified": True}, True),
+            ("google", {"email_verified": False}, False),
+            ("google", {}, False),
+            ("saml2", {"email_verified": True}, False),
+            ("okta", {"email_verified": False}, False),
+        ]
+        for provider_key, identity, expected in cases:
+            assert is_email_verified_by_trusted_provider(provider_key, identity) is expected, (
+                f"{provider_key=} {identity=}"
+            )

--- a/tests/sentry/auth/test_email_verification.py
+++ b/tests/sentry/auth/test_email_verification.py
@@ -96,7 +96,7 @@ class IsEmailVerifiedByTrustedProviderTest(TestCase):
     def test_trusted_check(self) -> None:
         cases = [
             ("google", {"email_verified": True}, True),
-            ("github", {"email_verified": True}, True),
+            ("github", {"email_verified": True}, False),
             ("google", {"email_verified": False}, False),
             ("google", {}, False),
             ("saml2", {"email_verified": True}, False),

--- a/tests/sentry/auth/test_helper.py
+++ b/tests/sentry/auth/test_helper.py
@@ -172,11 +172,15 @@ class UserResolutionTest(AuthIdentityHandlerTest):
 
 @control_silo_test
 class HandleNewUserTest(AuthIdentityHandlerTest, HybridCloudTestMixin):
-    @mock.patch("sentry.analytics.record")
-    def test_skip_confirm_emails_suppresses_email(self, mock_record: mock.MagicMock) -> None:
+    def test_skip_confirm_emails_suppresses_email(self) -> None:
         with mock.patch.object(User, "send_confirm_emails") as mock_send:
             self.handler.handle_new_user(skip_confirm_emails=True)
         mock_send.assert_not_called()
+
+    def test_confirm_emails_sent_by_default(self) -> None:
+        with mock.patch.object(User, "send_confirm_emails") as mock_send:
+            self.handler.handle_new_user()
+        mock_send.assert_called_once()
 
     @mock.patch("sentry.analytics.record")
     def test_simple(self, mock_record: mock.MagicMock) -> None:

--- a/tests/sentry/auth/test_helper.py
+++ b/tests/sentry/auth/test_helper.py
@@ -37,6 +37,7 @@ from sentry.testutils.helpers.analytics import assert_last_analytics_event
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
+from sentry.users.models.user import User
 from sentry.utils import json
 from sentry.utils.redis import clusters
 
@@ -171,6 +172,12 @@ class UserResolutionTest(AuthIdentityHandlerTest):
 
 @control_silo_test
 class HandleNewUserTest(AuthIdentityHandlerTest, HybridCloudTestMixin):
+    @mock.patch("sentry.analytics.record")
+    def test_skip_confirm_emails_suppresses_email(self, mock_record: mock.MagicMock) -> None:
+        with mock.patch.object(User, "send_confirm_emails") as mock_send:
+            self.handler.handle_new_user(skip_confirm_emails=True)
+        mock_send.assert_not_called()
+
     @mock.patch("sentry.analytics.record")
     def test_simple(self, mock_record: mock.MagicMock) -> None:
         auth_identity = self.handler.handle_new_user()


### PR DESCRIPTION
## Summary
Preparatory refactors for the upcoming SSO email verification at signup feature. No behavior changes.

- Add `is_email_verified_by_trusted_provider()` utility to `email_verification.py` — centralizes the trust check for Google/GitHub `email_verified` claims so both `sentry` and `getsentry` can share it
- Extract `complete_and_login()` from `handle_unknown_identity()` — the login + state cleanup tail is now callable independently (needed by the future verification view)
- Add `skip_confirm_emails` param to `handle_new_user()` — allows skipping the advisory confirmation email when the address has already been verified
- Update `_post_login_redirect()` to accept an explicit `is_new_user` flag, falling back to the existing `request.POST` check when `None`