### PR TITLE
feat(issues): Show Seer avatar for created pull requests

### DIFF
--- a/static/app/views/issueDetails/activitySection/activityLineItem/activityFeedItem.ts
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/activityFeedItem.ts
@@ -29,6 +29,7 @@ export type ActivityFeedItem =
   | {
       activity: GroupActivity;
       type: 'activity';
+      actorActivity?: GroupActivity;
     }
   | CollapsedSeerActivity;
 

--- a/static/app/views/issueDetails/activitySection/activityLineItem/index.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/index.tsx
@@ -33,10 +33,12 @@ export function ActivityLine({item, group, timestampUnitStyle}: ActivityLineProp
   const timestamp = (
     <TimeSince date={activity.dateCreated} unitStyle={timestampUnitStyle} />
   );
-  const actorActivity =
-    item.type === GroupActivityType.SEER_ITERATION_COMPLETED
-      ? item.startedActivity
-      : activity;
+  let actorActivity = activity;
+  if (item.type === GroupActivityType.SEER_ITERATION_COMPLETED) {
+    actorActivity = item.startedActivity;
+  } else if (item.type === 'activity' && item.actorActivity) {
+    actorActivity = item.actorActivity;
+  }
 
   return (
     <ActivityLineRow>

--- a/static/app/views/issueDetails/activitySection/index.spec.tsx
+++ b/static/app/views/issueDetails/activitySection/index.spec.tsx
@@ -1609,6 +1609,7 @@ describe('ActivitySection', () => {
     );
 
     expect(await screen.findByText('Referenced in pull request')).toBeInTheDocument();
+    expect(screen.getByRole('img', {name: 'Seer activity'})).toBeInTheDocument();
     expect(screen.getAllByRole('link', {name: `#${pullRequest.id}`})).toHaveLength(1);
   });
 

--- a/static/app/views/issueDetails/activitySection/index.tsx
+++ b/static/app/views/issueDetails/activitySection/index.tsx
@@ -137,14 +137,24 @@ function isDuplicatePullRequestActivity(
   }
 }
 
-function removeAdjacentDuplicatePullRequestActivities(
-  activities: GroupActivity[]
-): GroupActivity[] {
-  return activities.filter(
-    (activity, index) =>
-      !isDuplicatePullRequestActivity(activity, activities[index - 1]) &&
-      !isDuplicatePullRequestActivity(activity, activities[index + 1])
-  );
+function removeAdjacentDuplicatePullRequestActivities(activities: GroupActivity[]): {
+  activities: GroupActivity[];
+  actorActivityById: Map<string, GroupActivity>;
+} {
+  const actorActivityById = new Map<string, GroupActivity>();
+  const filteredActivities = activities.filter((activity, index) => {
+    const duplicateActivity = [activities[index - 1], activities[index + 1]].find(
+      adjacentActivity => isDuplicatePullRequestActivity(activity, adjacentActivity)
+    );
+
+    if (activity.type === GroupActivityType.SEER_PR_CREATED && duplicateActivity) {
+      actorActivityById.set(duplicateActivity.id, activity);
+    }
+
+    return !duplicateActivity;
+  });
+
+  return {activities: filteredActivities, actorActivityById};
 }
 
 export function ActivitySection({
@@ -203,10 +213,15 @@ export function ActivitySection({
     ? group.activity
     : group.activity.filter(item => !SEER_ACTIVITY_TYPES.has(item.type));
 
-  const filteredActivities = removeAdjacentDuplicatePullRequestActivities(
-    visibleActivities
-  ).filter(item => !filterComments || item.type === GroupActivityType.NOTE);
-  const displayedActivities = collapseSeerActivityPairs(filteredActivities);
+  const {activities: deduplicatedActivities, actorActivityById} =
+    removeAdjacentDuplicatePullRequestActivities(visibleActivities);
+  const filteredActivities = deduplicatedActivities.filter(
+    item => !filterComments || item.type === GroupActivityType.NOTE
+  );
+  const displayedActivities = collapseSeerActivityPairs(filteredActivities).map(item => {
+    const actorActivity = actorActivityById.get(item.activity.id);
+    return item.type === 'activity' && actorActivity ? {...item, actorActivity} : item;
+  });
   const inputVariant = variant === 'sidebar' ? 'compact' : 'full';
   const timestampUnitStyle = variant === 'sidebar' ? 'short' : undefined;
 


### PR DESCRIPTION
seer avatar is shown for referenced in pr activity

<img width="518" height="196" alt="image" src="https://github.com/user-attachments/assets/26bae666-6c15-43e0-a8dc-4b835ec9f544" />
