### PR TITLE
ref(onboarding): Make onboarding session exits explicit

### DIFF
--- a/static/app/components/onboarding/onboardingContext.spec.tsx
+++ b/static/app/components/onboarding/onboardingContext.spec.tsx
@@ -1,6 +1,6 @@
 import {RepositoryFixture} from 'sentry-fixture/repository';
 
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {
@@ -18,7 +18,13 @@ const platform = {
 };
 
 function StateConsumer() {
-  const {selectedRepository, selectedPlatform, selectedFeatures} = useOnboardingContext();
+  const {
+    selectedRepository,
+    selectedPlatform,
+    selectedFeatures,
+    setSelectedPlatform,
+    resetOnboarding,
+  } = useOnboardingContext();
   return (
     <div>
       <div>{selectedRepository ? `repo:${selectedRepository.id}` : 'no-repo'}</div>
@@ -26,6 +32,8 @@ function StateConsumer() {
       <div>
         {selectedFeatures ? `features:${selectedFeatures.length}` : 'no-features'}
       </div>
+      <button onClick={() => setSelectedPlatform(undefined)}>Clear platform</button>
+      <button onClick={() => resetOnboarding()}>Reset onboarding</button>
     </div>
   );
 }
@@ -72,5 +80,62 @@ describe('OnboardingContextProvider', () => {
     expect(screen.getByText('repo:42')).toBeInTheDocument();
     expect(screen.getByText('platform:javascript-nextjs')).toBeInTheDocument();
     expect(screen.getByText('features:1')).toBeInTheDocument();
+  });
+});
+
+describe('OnboardingContextProvider session semantics', () => {
+  afterEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it('keeps the rest of the session when clearing the selected platform', async () => {
+    render(
+      <OnboardingContextProvider
+        initialValue={{
+          selectedRepository: RepositoryFixture({id: '42'}),
+          selectedPlatform: platform,
+        }}
+      >
+        <StateConsumer />
+      </OnboardingContextProvider>
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Clear platform'}));
+
+    // Clearing one field must stay local to that field. This previously routed
+    // through removeOnboarding and wiped the whole session, taking the
+    // connected repository with it.
+    expect(screen.getByText('no-platform')).toBeInTheDocument();
+    expect(screen.getByText('repo:42')).toBeInTheDocument();
+    expect(JSON.parse(sessionStorage.getItem('onboarding') ?? '{}')).toMatchObject({
+      selectedRepository: {id: '42'},
+    });
+  });
+
+  it('clears persisted session state on resetOnboarding', async () => {
+    // Seeded through sessionStorage rather than the initialValue prop:
+    // useSessionStorage's removeItem resets in-memory state back to
+    // initialValue, so a seeded prop would be restored rather than cleared.
+    // The real provider passes no initialValue, so removal is total there.
+    sessionStorage.setItem(
+      'onboarding',
+      JSON.stringify({
+        selectedRepository: RepositoryFixture({id: '42'}),
+        selectedPlatform: platform,
+      })
+    );
+
+    render(
+      <OnboardingContextProvider>
+        <StateConsumer />
+      </OnboardingContextProvider>
+    );
+    expect(screen.getByText('platform:javascript-nextjs')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Reset onboarding'}));
+
+    expect(screen.getByText('no-platform')).toBeInTheDocument();
+    expect(screen.getByText('no-repo')).toBeInTheDocument();
+    expect(sessionStorage.getItem('onboarding')).toBeNull();
   });
 });

--- a/static/app/components/onboarding/onboardingContext.tsx
+++ b/static/app/components/onboarding/onboardingContext.tsx
@@ -7,6 +7,7 @@ import {useSessionStorage} from 'sentry/utils/useSessionStorage';
 
 type OnboardingContextProps = {
   clearDerivedState: () => void;
+  resetOnboarding: () => void;
   setCreatedProjectSlug: (slug?: string) => void;
   setSelectedFeatures: (features?: ProductSolution[]) => void;
   setSelectedIntegration: (integration?: Integration) => void;
@@ -42,6 +43,7 @@ const OnboardingContext = createContext<OnboardingContextProps>({
   createdProjectSlug: undefined,
   setCreatedProjectSlug: () => {},
   clearDerivedState: () => {},
+  resetOnboarding: () => {},
 });
 
 type ProviderProps = {
@@ -85,11 +87,7 @@ export function OnboardingContextProvider({children, initialValue}: ProviderProp
     () => ({
       selectedPlatform: onboarding?.selectedPlatform,
       setSelectedPlatform: (selectedPlatform?: OnboardingSelectedSDK) => {
-        if (selectedPlatform === undefined) {
-          removeOnboarding();
-        } else {
-          setOnboarding(prev => ({...prev, selectedPlatform}));
-        }
+        setOnboarding(prev => ({...prev, selectedPlatform}));
       },
       selectedIntegration: onboarding?.selectedIntegration,
       setSelectedIntegration: (selectedIntegration?: Integration) => {
@@ -118,6 +116,11 @@ export function OnboardingContextProvider({children, initialValue}: ProviderProp
           createdProjectSlug: undefined,
         }));
       },
+      // Full-flow exits should clear every staged choice explicitly. Do not
+      // reach for a selected-platform reset to do this: clearing one field must
+      // stay local to that field so organization-scoped state added later
+      // survives local repository and platform changes.
+      resetOnboarding: removeOnboarding,
     }),
     [onboarding, setOnboarding, removeOnboarding]
   );

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -370,7 +370,7 @@ export function OnboardingWithoutContext() {
             organization,
             source,
           });
-          onboardingContext.setSelectedPlatform(undefined);
+          onboardingContext.resetOnboarding();
           activateSidebar({
             userClicked: false,
             source: 'targeted_onboarding_select_platform_skip',

--- a/static/app/views/onboarding/useBackActions.tsx
+++ b/static/app/views/onboarding/useBackActions.tsx
@@ -49,7 +49,7 @@ export function useBackActions({
       if (preserveOnboardingState) {
         onboardingContext.setCreatedProjectSlug(undefined);
       } else {
-        onboardingContext.setSelectedPlatform(undefined);
+        onboardingContext.resetOnboarding();
       }
 
       try {
@@ -106,7 +106,7 @@ export function useBackActions({
 
       // from selected platform to welcome
       if (currentStep.id === 'select-platform') {
-        onboardingContext.setSelectedPlatform(undefined);
+        onboardingContext.resetOnboarding();
 
         if (!browserBackButton) {
           goToStep(prevStep);

--- a/static/app/views/onboarding/useConfigureSdk.tsx
+++ b/static/app/views/onboarding/useConfigureSdk.tsx
@@ -146,7 +146,7 @@ export function useConfigureSdk({
               platform: selectedPlatform.key,
               organization,
             });
-            onboardingContext.setSelectedPlatform(undefined);
+            onboardingContext.resetOnboarding();
           },
         }
       );

--- a/static/app/views/onboarding/useWelcomeAnalyticsEffect.ts
+++ b/static/app/views/onboarding/useWelcomeAnalyticsEffect.ts
@@ -26,7 +26,7 @@ export function useWelcomeAnalyticsEffect() {
 
     if (onboardingContext.selectedPlatform) {
       // At this point the selectedSDK shall be undefined but just in case, cleaning this up here too
-      onboardingContext.setSelectedPlatform(undefined);
+      onboardingContext.resetOnboarding();
     }
   }, [organization, onboardingContext, hasScmOnboarding]);
 }


### PR DESCRIPTION
## TLDR

Clearing the selected platform in SCM onboarding no longer discards the connected repository and every other staged choice. The four exits that genuinely want a clean slate now say so explicitly, with no change to their behavior.

## Details

`setSelectedPlatform(undefined)` was routed through `removeOnboarding()`, so a setter named after one field wiped the entire session. That coupling was invisible at every call site, and it made the setter unsafe for any state that should outlive a platform change — which is the blocker for the messaging destination VDY-140 stacks on top of this. The refactor lands on its own because it changes legacy onboarding behavior and deserves review on those terms, not buried in the experiment work.

`OnboardingContextProvider` now exposes `resetOnboarding` alongside the existing `clearDerivedState`, and `setSelectedPlatform` behaves like every sibling setter: it writes one field. The four full-flow exits that relied on the destructive overload call `resetOnboarding` directly — the global Skip Onboarding link in `onboarding.tsx`, back-from-`select-platform` and project deletion without state preservation in `useBackActions`, and the legacy cleanup in `useConfigureSdk`. Each of those is a 1-for-1 rename: behavior is unchanged, only the intent is now greppable.

Routing the exits through a named function rather than keeping the overload means the destructive call is greppable and each site states its intent. The alternative — leaving the setter destructive and adding a second non-destructive setter — preserves the trap for the next caller who reasonably assumes a field setter touches one field.

The one user-visible consequence is in `scmPlatformFeaturesCore`, whose clearable platform Select calls `onPlatformChange(undefined)`. That control previously destroyed the SCM integration and repository selection as a side effect of clearing a platform; it now leaves them intact. Reachable when no platform was detected and the manual picker is showing.

New coverage in `onboardingContext.spec.tsx` pins both halves: clearing a field preserves the rest of the session, and `resetOnboarding` clears persisted state. The reset test seeds `sessionStorage` directly rather than using the `initialValue` prop, because `useSessionStorage`'s `removeItem` restores in-memory state back to `initialValue` — a seeded prop would be restored rather than cleared, which the real provider never does since it passes no `initialValue`.

Two session-exit *behavior* changes that an earlier revision of this PR carried have moved to #120992, the messaging-route PR that actually requires them, so this PR is a pure refactor.

Refs VDY-140
