### PR TITLE
ref(seer): remove SeerViewerContext from task and consumer paths

### DIFF
--- a/src/sentry/ai_monitoring/tasks.py
+++ b/src/sentry/ai_monitoring/tasks.py
@@ -21,7 +21,6 @@ from sentry.ai_monitoring.utils import (
 )
 from sentry.models.project import Project
 from sentry.options.rollout import in_rollout_group
-from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import ai_agent_monitoring_tasks
@@ -85,9 +84,7 @@ def generate_ai_conversation_title(
         metrics.incr("ai_monitoring.conversation_title.skip", tags={"reason": "later_or_equal_ts"})
         return
 
-    title = generate_conversation_title(
-        first_user_message, viewer_context=SeerViewerContext(organization_id=organization.id)
-    )
+    title = generate_conversation_title(first_user_message)
     stored_conversation_id = clamp_conversation_id_for_storage(conversation_id)
 
     # Update an existing row only if this span is still the earliest.

--- a/src/sentry/deletions/tasks/seer.py
+++ b/src/sentry/deletions/tasks/seer.py
@@ -4,7 +4,6 @@ from typing import Any
 from taskbroker_client.retry import Retry
 from urllib3.exceptions import HTTPError
 
-from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import deletion_tasks
@@ -36,7 +35,6 @@ def notify_seer_repository_deleted(
     # imported here to avoid circular imports
     from sentry.seer.code_review.utils import SeerEndpoint, make_seer_request
 
-    viewer_context = SeerViewerContext(organization_id=organization_id)
     make_seer_request(
         path=SeerEndpoint.REPOSITORY_OFFBOARD.value,
         payload={
@@ -45,7 +43,6 @@ def notify_seer_repository_deleted(
             "provider": provider,
             "repository_name": repository_name,
         },
-        viewer_context=viewer_context,
     )
     logger.info(
         "seer.forward_repository_delete.success",

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -120,7 +120,7 @@ from sentry.receivers.features import record_event_processed
 from sentry.receivers.onboarding import record_release_received
 from sentry.releases.auto_creation import should_auto_create_releases
 from sentry.reprocessing2 import is_reprocessed_event
-from sentry.seer.signed_seer_api import SeerViewerContext, make_signed_seer_api_request
+from sentry.seer.signed_seer_api import make_signed_seer_api_request
 from sentry.services.eventstore.processing import event_processing_store
 from sentry.signals import (
     first_event_received,
@@ -1978,7 +1978,6 @@ def make_severity_score_request(
     body: SeverityScoreRequest,
     connection_pool: HTTPConnectionPool | None = None,
     timeout: int | float | None = None,
-    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     payload: SeverityScoreRequest = {**body}
     if options.get("processing.severity-backlog-test.timeout"):
@@ -1990,7 +1989,6 @@ def make_severity_score_request(
         "/v0/issues/severity-score",
         body=orjson.dumps(payload),
         timeout=timeout,
-        viewer_context=viewer_context,
     )
 
 
@@ -2211,12 +2209,10 @@ def _get_severity_score(event: Event) -> tuple[float, str]:
                     "issues.severity.seer-timeout",
                     settings.SEER_SEVERITY_TIMEOUT,
                 )
-                viewer_context = SeerViewerContext(organization_id=event.project.organization_id)
                 response = make_severity_score_request(
                     payload,
                     connection_pool=severity_connection_pool,
                     timeout=timeout,
-                    viewer_context=viewer_context,
                 )
                 severity = orjson.loads(response.data).get("severity")
                 reason = "ml"

--- a/src/sentry/feedback/usecases/ingest/create_feedback.py
+++ b/src/sentry/feedback/usecases/ingest/create_feedback.py
@@ -27,7 +27,6 @@ from sentry.issues.status_change_message import StatusChangeMessage
 from sentry.models.group import GroupStatus
 from sentry.models.project import Project
 from sentry.seer.seer_setup import has_seer_access
-from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.signals import first_feedback_received, first_new_feedback_received
 from sentry.types.group import GroupSubStatus
 from sentry.utils import json, metrics
@@ -275,7 +274,6 @@ def create_feedback_issue(
     _seer_vc = ViewerContext(
         organization_id=project.organization_id, project_id=project.id, actor_type=ActorType.SYSTEM
     )
-    viewer_context = SeerViewerContext(organization_id=project.organization_id)
 
     # Spam detection.
     is_message_spam = None
@@ -283,9 +281,7 @@ def create_feedback_issue(
     if is_spam_enabled:
         # Will be None if the request fails
         with viewer_context_scope(_seer_vc):
-            is_message_spam = is_spam_seer(
-                feedback_message, project.organization_id, viewer_context=viewer_context
-            )
+            is_message_spam = is_spam_seer(feedback_message, project.organization_id)
 
         metrics.incr(
             "feedback.create_feedback_issue.seer_spam_detection",
@@ -315,7 +311,6 @@ def create_feedback_issue(
                 feedback_message,
                 project.organization_id,
                 use_ai_title,
-                viewer_context=viewer_context,
             )
         )
 
@@ -352,9 +347,7 @@ def create_feedback_issue(
     if should_query_seer:
         try:
             with viewer_context_scope(_seer_vc):
-                labels = generate_labels(
-                    feedback_message, project.organization_id, viewer_context=viewer_context
-                )
+                labels = generate_labels(feedback_message, project.organization_id)
             # This will rarely happen unless the user writes a really long feedback message
             if len(labels) > MAX_AI_LABELS:
                 logger.info(

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -17,7 +17,6 @@ from sentry.grouping.ingest.grouphash_metadata import (
 from sentry.grouping.variants import BaseVariant
 from sentry.models.grouphash import GroupHash
 from sentry.models.project import Project
-from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.seer.similarity.config import (
     get_grouping_model_version,
     should_send_to_seer_for_training,
@@ -362,11 +361,9 @@ def get_seer_similar_issues(
 
     request_data, seer_request_metric_tags = _build_seer_request(event, variants)
 
-    viewer_context = SeerViewerContext(organization_id=event.project.organization_id)
     seer_results, model_used = get_similarity_data_from_seer(
         request_data,
         {**seer_request_metric_tags, "hybrid_fingerprint": event_has_hybrid_fingerprint},
-        viewer_context=viewer_context,
     )
 
     # All of these will get overridden if we find a usable match
@@ -434,9 +431,7 @@ def get_seer_similar_issues(
 
         # We only want this for the side effect, and we know it'll return no matches, so we don't
         # bother to capture the return value.
-        get_similarity_data_from_seer(
-            request_data, seer_request_metric_tags, viewer_context=viewer_context
-        )
+        get_similarity_data_from_seer(request_data, seer_request_metric_tags)
 
     is_hybrid_fingerprint_case = (
         event_has_hybrid_fingerprint
@@ -726,11 +721,8 @@ def maybe_send_seer_for_new_model_training(
 
     request_data, metric_tags = _build_seer_request(event, variants, training_mode=True)
 
-    viewer_context = SeerViewerContext(organization_id=event.project.organization_id)
     try:
-        get_similarity_data_from_seer(
-            request_data, metric_tags, raise_on_error=True, viewer_context=viewer_context
-        )
+        get_similarity_data_from_seer(request_data, metric_tags, raise_on_error=True)
     except Exception as e:
         sentry_sdk.capture_exception(
             e,

--- a/src/sentry/pr_metrics/judge.py
+++ b/src/sentry/pr_metrics/judge.py
@@ -57,7 +57,7 @@ from sentry.seer.sentry_data_models import (
     UpdatePrMetricsErrorResponse,
     UpdatePrMetricsSuccessResponse,
 )
-from sentry.seer.signed_seer_api import SeerViewerContext, make_signed_seer_api_request
+from sentry.seer.signed_seer_api import make_signed_seer_api_request
 from sentry.utils import json, metrics
 
 logger = logging.getLogger(__name__)
@@ -235,7 +235,6 @@ def forward_pr_to_seer_judge(pull_request: PullRequest, repository: Repository) 
         connection_pool=seer_pr_metrics_connection_pool,
         path=SEER_PR_METRICS_JUDGE_PATH,
         body=payload.json().encode("utf-8"),
-        viewer_context=SeerViewerContext(organization_id=pull_request.organization_id),
     )
     if response.status >= 500 or response.status == 429:
         raise HTTPError(f"Seer judge forward returned retryable status {response.status}")

--- a/src/sentry/replays/usecases/delete.py
+++ b/src/sentry/replays/usecases/delete.py
@@ -34,7 +34,6 @@ from sentry.replays.query import replay_url_parser_config
 from sentry.replays.usecases.events import archive_event
 from sentry.replays.usecases.query import execute_query, handle_search_filters
 from sentry.replays.usecases.query.configs.aggregate import search_config as agg_search_config
-from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 from sentry.utils.retries import ConditionalRetryPolicy, exponential_delay
 from sentry.utils.snuba import (
@@ -201,14 +200,11 @@ def delete_seer_replay_data(organization_id: int, project_id: int, replay_ids: l
         project_id=project_id,
     )
 
-    viewer_context = SeerViewerContext(organization_id=organization_id)
-
     try:
         response = make_replay_delete_request(
             seer_request,
             timeout=5,
             retries=Retry(total=1, backoff_factor=3),  # 1 retry after a 3 second delay.
-            viewer_context=viewer_context,
         )
     except Exception:
         logger.exception(

--- a/src/sentry/seer/agent/snapshot_indexes.py
+++ b/src/sentry/seer/agent/snapshot_indexes.py
@@ -6,7 +6,6 @@ from sentry.seer.models import SeerApiError
 from sentry.seer.sentry_data_models import AgentExportIndexesResponse
 from sentry.seer.signed_seer_api import (
     AgentExportIndexesRequest,
-    SeerViewerContext,
     make_agent_export_indexes_request,
 )
 from sentry.utils.json import JSONDecodeError
@@ -20,9 +19,8 @@ def export_agent_indexes(*, org_id: int) -> AgentExportIndexesResponse:
     Intended for local eval DB seeding — calls the Seer export endpoint and
     returns the serialized table data.
     """
-    viewer_context = SeerViewerContext(organization_id=org_id)
     body = AgentExportIndexesRequest(org_id=org_id)
-    response = make_agent_export_indexes_request(body, viewer_context=viewer_context)
+    response = make_agent_export_indexes_request(body)
     if response.status >= 400:
         raise SeerApiError("Seer export-indexes request failed", response.status)
 

--- a/src/sentry/seer/anomaly_detection/delete_rule.py
+++ b/src/sentry/seer/anomaly_detection/delete_rule.py
@@ -11,7 +11,7 @@ from sentry.conf.server import SEER_ALERT_DELETION_URL
 from sentry.models.organization import Organization
 from sentry.net.http import connection_from_url
 from sentry.seer.anomaly_detection.types import AlertInSeer, DataSourceType, DeleteAlertDataRequest
-from sentry.seer.signed_seer_api import SeerViewerContext, make_signed_seer_api_request
+from sentry.seer.signed_seer_api import make_signed_seer_api_request
 from sentry.utils import json
 from sentry.utils.json import JSONDecodeError
 
@@ -25,13 +25,11 @@ seer_anomaly_detection_connection_pool = connection_from_url(
 def make_delete_alert_data_request(
     body: DeleteAlertDataRequest,
     connection_pool: HTTPConnectionPool | None = None,
-    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         connection_pool or seer_anomaly_detection_connection_pool,
         SEER_ALERT_DELETION_URL,
         body=json.dumps(body).encode("utf-8"),
-        viewer_context=viewer_context,
     )
 
 
@@ -81,9 +79,8 @@ def delete_rule_in_seer(source_id: int, organization: Organization) -> bool:
     extra_data = {
         "source_id": source_id,
     }
-    viewer_context = SeerViewerContext(organization_id=organization.id)
     try:
-        response = make_delete_alert_data_request(body, viewer_context=viewer_context)
+        response = make_delete_alert_data_request(body)
     except (TimeoutError, MaxRetryError):
         logger.warning(
             "Timeout error when hitting Seer delete rule data endpoint",

--- a/src/sentry/seer/anomaly_detection/get_anomaly_data.py
+++ b/src/sentry/seer/anomaly_detection/get_anomaly_data.py
@@ -25,7 +25,7 @@ from sentry.seer.anomaly_detection.types import (
     TimeSeriesPoint,
 )
 from sentry.seer.anomaly_detection.utils import get_aggregate_type, translate_direction
-from sentry.seer.signed_seer_api import SeerViewerContext, make_signed_seer_api_request
+from sentry.seer.signed_seer_api import make_signed_seer_api_request
 from sentry.snuba.models import QuerySubscription, SnubaQuery
 from sentry.utils import json
 from sentry.utils.json import JSONDecodeError
@@ -67,28 +67,24 @@ SEER_RETRIES = Retry(
 def make_detect_anomalies_request(
     body: DetectAnomaliesRequest,
     connection_pool: HTTPConnectionPool | None = None,
-    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         connection_pool or SEER_ANOMALY_DETECTION_CONNECTION_POOL,
         SEER_ANOMALY_DETECTION_ENDPOINT_URL,
         body=json.dumps(body).encode("utf-8"),
         retries=SEER_RETRIES,
-        viewer_context=viewer_context,
     )
 
 
 def make_get_anomaly_threshold_data_request(
     body: GetAnomalyThresholdDataRequest,
     connection_pool: HTTPConnectionPool | None = None,
-    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         connection_pool or SEER_ANOMALY_DETECTION_CONNECTION_POOL,
         SEER_ANOMALY_DETECTION_ALERT_DATA_URL,
         body=json.dumps(body).encode("utf-8"),
         retries=SEER_RETRIES,
-        viewer_context=viewer_context,
     )
 
 
@@ -143,10 +139,7 @@ def get_anomaly_data_from_seer(
     extra_data["dataset"] = snuba_query.dataset
     try:
         logger.info("Sending subscription update data to Seer", extra=extra_data)
-        viewer_context = SeerViewerContext(organization_id=subscription.project.organization_id)
-        response = make_detect_anomalies_request(
-            detect_anomalies_request, viewer_context=viewer_context
-        )
+        response = make_detect_anomalies_request(detect_anomalies_request)
     except (TimeoutError, MaxRetryError):
         logger.warning("Timeout error when hitting anomaly detection endpoint", extra=extra_data)
         return None
@@ -229,9 +222,8 @@ def get_anomaly_threshold_data_from_seer(
         start=start,
         end=end,
     )
-    viewer_context = SeerViewerContext(organization_id=subscription.project.organization_id)
     try:
-        response = make_get_anomaly_threshold_data_request(body, viewer_context=viewer_context)
+        response = make_get_anomaly_threshold_data_request(body)
     except (TimeoutError, MaxRetryError):
         logger.warning("anomaly_threshold.timeout_error_hitting_seer_endpoint")
         return None

--- a/src/sentry/seer/anomaly_detection/get_historical_anomalies.py
+++ b/src/sentry/seer/anomaly_detection/get_historical_anomalies.py
@@ -15,7 +15,7 @@ from sentry.seer.anomaly_detection.types import (
     DetectHistoricalAnomaliesRequest,
     TimeSeriesPoint,
 )
-from sentry.seer.signed_seer_api import SeerViewerContext, make_signed_seer_api_request
+from sentry.seer.signed_seer_api import make_signed_seer_api_request
 from sentry.utils import json
 from sentry.utils.json import JSONDecodeError
 
@@ -37,14 +37,12 @@ SEER_RETRIES = Retry(
 def make_detect_historical_anomalies_request(
     body: DetectHistoricalAnomaliesRequest,
     connection_pool: HTTPConnectionPool | None = None,
-    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         connection_pool or seer_anomaly_detection_connection_pool,
         SEER_ANOMALY_DETECTION_ENDPOINT_URL,
         body=json.dumps(body).encode("utf-8"),
         retries=SEER_RETRIES,
-        viewer_context=viewer_context,
     )
 
 
@@ -136,9 +134,8 @@ def get_historical_anomaly_data_from_seer_preview(
         "config": config,
         "context": context,
     }
-    viewer_context = SeerViewerContext(organization_id=organization_id)
     try:
-        response = make_detect_historical_anomalies_request(body, viewer_context=viewer_context)
+        response = make_detect_historical_anomalies_request(body)
     except (TimeoutError, MaxRetryError):
         logger.warning("Timeout error when hitting anomaly detection endpoint", extra=extra_data)
         return None

--- a/src/sentry/seer/anomaly_detection/store_data.py
+++ b/src/sentry/seer/anomaly_detection/store_data.py
@@ -31,7 +31,7 @@ from sentry.seer.anomaly_detection.utils import (
     get_event_types,
     translate_direction,
 )
-from sentry.seer.signed_seer_api import SeerViewerContext, make_signed_seer_api_request
+from sentry.seer.signed_seer_api import make_signed_seer_api_request
 from sentry.snuba.models import SnubaQuery, SnubaQueryEventType
 from sentry.utils import json, metrics
 from sentry.utils.json import JSONDecodeError
@@ -48,13 +48,11 @@ MIN_DAYS = 7
 def make_store_data_request(
     body: StoreDataRequest,
     connection_pool: HTTPConnectionPool | None = None,
-    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         connection_pool or seer_anomaly_detection_connection_pool,
         SEER_ANOMALY_DETECTION_STORE_DATA_URL,
         body=json.dumps(body).encode("utf-8"),
-        viewer_context=viewer_context,
     )
 
 
@@ -243,9 +241,8 @@ def send_historical_data_to_seer_legacy(
             "meta": json.dumps(historical_data.data.get("meta", {}).get("fields", {})),
         },
     )
-    viewer_context = SeerViewerContext(organization_id=alert_rule.organization.id)
     try:
-        response = make_store_data_request(body, viewer_context=viewer_context)
+        response = make_store_data_request(body)
     # See SEER_ANOMALY_DETECTION_TIMEOUT in sentry.conf.server.py
     except (TimeoutError, MaxRetryError):
         logger.warning(

--- a/src/sentry/seer/anomaly_detection/store_data_workflow_engine.py
+++ b/src/sentry/seer/anomaly_detection/store_data_workflow_engine.py
@@ -24,7 +24,6 @@ from sentry.seer.anomaly_detection.utils import (
     get_event_types,
     translate_direction,
 )
-from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.snuba.models import QuerySubscription, SnubaQuery, SnubaQueryEventType
 from sentry.utils import json, metrics
 from sentry.utils.json import JSONDecodeError
@@ -255,9 +254,8 @@ def send_historical_data_to_seer(
             "meta": json.dumps(historical_data.data.get("meta", {}).get("fields", {})),
         },
     )
-    viewer_context = SeerViewerContext(organization_id=project.organization.id)
     try:
-        response = make_store_data_request(body, viewer_context=viewer_context)
+        response = make_store_data_request(body)
     # See SEER_ANOMALY_DETECTION_TIMEOUT in sentry.conf.server.py
     except (TimeoutError, MaxRetryError):
         logger.warning(

--- a/src/sentry/seer/autofix/coding_agent.py
+++ b/src/sentry/seer/autofix/coding_agent.py
@@ -34,7 +34,6 @@ from sentry.seer.autofix.utils import (
     make_store_coding_agent_states_request,
 )
 from sentry.seer.models import SeerApiError
-from sentry.seer.signed_seer_api import SeerViewerContext
 
 logger = logging.getLogger(__name__)
 
@@ -87,12 +86,7 @@ def store_coding_agent_states_to_seer(
         run_id=run_id,
         coding_agent_states=[state.dict() for state in coding_agent_states],
     )
-    viewer_context: SeerViewerContext | None = None
-    if organization_id is not None:
-        viewer_context = SeerViewerContext(organization_id=organization_id)
-    response = make_store_coding_agent_states_request(
-        body, timeout=30, viewer_context=viewer_context
-    )
+    response = make_store_coding_agent_states_request(body, timeout=30)
 
     if response.status >= 400:
         raise SeerApiError(response.data.decode("utf-8"), response.status)

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -45,7 +45,6 @@ from sentry.seer.entrypoints.operator import SeerAutofixOperator
 from sentry.seer.models import SummarizeIssueResponse
 from sentry.seer.models.run import SeerRun
 from sentry.seer.signed_seer_api import (
-    SeerViewerContext,
     SummarizeIssueRequest,
     make_signed_seer_api_request,
     make_summarize_issue_request,
@@ -258,8 +257,7 @@ def _call_seer(
         project_id=group.project.id,
         experiment_variant=experiment_variant,
     )
-    viewer_context = SeerViewerContext(organization_id=group.organization.id)
-    response = make_summarize_issue_request(body, timeout=30, viewer_context=viewer_context)
+    response = make_summarize_issue_request(body, timeout=30)
 
     if response.status >= 400:
         raise Exception(f"Seer request failed with status {response.status}")
@@ -285,14 +283,12 @@ def make_fixability_score_request(
     body: FixabilityScoreRequest,
     connection_pool: HTTPConnectionPool | None = None,
     timeout: int | float | None = None,
-    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         connection_pool or fixability_connection_pool,
         "/v1/automation/summarize/fixability",
         body=orjson.dumps(body, option=orjson.OPT_NON_STR_KEYS),
         timeout=timeout,
-        viewer_context=viewer_context,
     )
 
 
@@ -308,12 +304,10 @@ def _generate_fixability_score(
     )
     if summary is not None:
         body["summary"] = summary
-    viewer_context = SeerViewerContext(organization_id=group.organization.id)
     response = make_fixability_score_request(
         body,
         connection_pool=fixability_connection_pool,
         timeout=settings.SEER_FIXABILITY_TIMEOUT,
-        viewer_context=viewer_context,
     )
     if response.status >= 400:
         raise Exception(f"Seer API error: {response.status}")

--- a/src/sentry/seer/code_review/webhooks/task.py
+++ b/src/sentry/seer/code_review/webhooks/task.py
@@ -16,7 +16,6 @@ from sentry.seer.code_review.models import (
     SeerCodeReviewTaskRequestForPrReview,
 )
 from sentry.seer.code_review.utils import transform_webhook_to_codegen_request
-from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import seer_code_review_tasks
@@ -116,11 +115,8 @@ def process_github_webhook_event(
     status = "success"
     try:
         sentry_sdk.set_tags(tags)
-        viewer_context: SeerViewerContext | None = None
-        if org_id := tags.get("sentry_organization_id"):
-            viewer_context = SeerViewerContext(organization_id=int(org_id))
 
-        make_seer_request(path=seer_path, payload=event_payload, viewer_context=viewer_context)
+        make_seer_request(path=seer_path, payload=event_payload)
     except Exception as e:
         status = e.__class__.__name__
         raise

--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -361,7 +361,7 @@ def make_remove_handoffs_for_integration_request(
 
 def make_agent_export_indexes_request(
     body: AgentExportIndexesRequest,
-    viewer_context: SeerViewerContext,
+    viewer_context: SeerViewerContext | None = None,
     timeout: int | float | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(

--- a/src/sentry/seer/supergroups/lightweight_rca_cluster.py
+++ b/src/sentry/seer/supergroups/lightweight_rca_cluster.py
@@ -8,7 +8,6 @@ from sentry.models.group import Group
 from sentry.seer.models import SeerApiError
 from sentry.seer.signed_seer_api import (
     LightweightRCAClusterRequest,
-    SeerViewerContext,
     make_lightweight_rca_cluster_request,
 )
 from sentry.seer.similarity.utils import (
@@ -83,9 +82,7 @@ def trigger_lightweight_rca_cluster(group: Group) -> None:
         organization_id=group.organization.id,
         project_id=group.project.id,
     )
-    viewer_context = SeerViewerContext(organization_id=group.organization.id)
-
-    response = make_lightweight_rca_cluster_request(body, timeout=30, viewer_context=viewer_context)
+    response = make_lightweight_rca_cluster_request(body, timeout=30)
     if response.status >= 400:
         raise SeerApiError("Lightweight RCA cluster request failed", response.status)
 

--- a/src/sentry/tasks/llm_issue_detection/detection.py
+++ b/src/sentry/tasks/llm_issue_detection/detection.py
@@ -29,7 +29,7 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.net.http import connection_from_url
 from sentry.seer.agent.utils import normalize_description
-from sentry.seer.signed_seer_api import SeerViewerContext, make_signed_seer_api_request
+from sentry.seer.signed_seer_api import make_signed_seer_api_request
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import issues_tasks
 from sentry.utils import json
@@ -86,7 +86,6 @@ def make_issue_detection_request(
     request: IssueDetectionRequest,
     timeout: int | float | None = None,
     retries: int | None = None,
-    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     extra_kwargs: dict[str, Any] = {}
     if timeout is not None:
@@ -97,7 +96,6 @@ def make_issue_detection_request(
         seer_issue_detection_connection_pool,
         SEER_ANALYZE_ISSUE_ENDPOINT_PATH,
         body=orjson.dumps(request.dict()),
-        viewer_context=viewer_context,
         **extra_kwargs,
     )
 
@@ -362,12 +360,10 @@ def detect_llm_issues_for_org(org_id: int, plan_tier: str = "business") -> None:
     with viewer_context_scope(
         ViewerContext(organization_id=org_id, project_id=project_id, actor_type=ActorType.SYSTEM)
     ):
-        viewer_context = SeerViewerContext(organization_id=org_id)
         response = make_issue_detection_request(
             seer_request,
             timeout=SEER_TIMEOUT_S,
             retries=0,
-            viewer_context=viewer_context,
         )
 
     if response.status == 202:

--- a/src/sentry/tasks/seer/backfill_supergroups_lightweight.py
+++ b/src/sentry/tasks/seer/backfill_supergroups_lightweight.py
@@ -13,7 +13,6 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.seer.signed_seer_api import (
     LightweightRCAClusterRequest,
-    SeerViewerContext,
     make_lightweight_rca_cluster_request,
 )
 from sentry.seer.similarity.utils import (
@@ -164,8 +163,6 @@ def _backfill_org(
     failure_count = 0
     success_count = 0
     last_processed_group_id = last_group_id
-    viewer_context = SeerViewerContext(organization_id=organization_id)
-
     for group, serialized_event in group_event_pairs:
         try:
             body = LightweightRCAClusterRequest(
@@ -180,9 +177,7 @@ def _backfill_org(
                 organization_id=organization_id,
                 project_id=group.project_id,
             )
-            response = make_lightweight_rca_cluster_request(
-                body, timeout=30, viewer_context=viewer_context
-            )
+            response = make_lightweight_rca_cluster_request(body, timeout=30)
             if response.status >= 400:
                 logger.warning(
                     "supergroups_backfill_lightweight.seer_error",

--- a/tests/sentry/ai_monitoring/test_tasks.py
+++ b/tests/sentry/ai_monitoring/test_tasks.py
@@ -282,10 +282,7 @@ class GenerateAIConversationTitleTaskTest(TestCase):
         assert row.conversation_id_hash == conversation_id_hash("conv-1")
         assert row.title == "AI Title"
         assert row.title_source_timestamp == _ts()
-        mock_generate.assert_called_once_with(
-            "How do I reset my password?",
-            viewer_context={"organization_id": self.project.organization_id},
-        )
+        mock_generate.assert_called_once_with("How do I reset my password?")
 
     @patch("sentry.ai_monitoring.tasks.generate_conversation_title", return_value="AI Title")
     def test_stores_clamped_conversation_id_and_hashes_full(self, mock_generate: MagicMock) -> None:


### PR DESCRIPTION
## Summary

Stacked on #121021. Removes `SeerViewerContext` from task and consumer call sites:

- **Tasks dispatched from endpoints/webhooks** (~11 files): `ViewerContextHook` already propagates VC from the dispatcher. The explicit `SeerViewerContext` was redundant.
- **Consumer/ingest paths** (~4 files): `feedback/usecases/ingest/create_feedback.py` already had `viewer_context_scope` — just removed the redundant `SeerViewerContext` alongside it. Other consumer paths (`event_manager`, `grouping/ingest/seer`) removed `SeerViewerContext` and rely on the chokepoint `viewer_context.missing` warning to flag the gap.
- **Mixed paths** (endpoint + consumer-dispatched task): Removed `SeerViewerContext` — endpoint callers have VC via middleware, consumer-dispatched task callers will be covered by adding `viewer_context_scope` in the task body (future work for tasks like `generate_summary_and_run_automation`).

### What's left (future PR)
- Cron-dispatched tasks (`statistical_detectors`, `context_engine_index`, `explorer_index`, `service_map_utils`) still use `SeerViewerContext`
- Adding `viewer_context_scope` at task entry points for tasks dispatched from consumer pipeline

## Test plan

- [x] mypy passes on all changed files
- [x] ruff passes
- [x] 129+ targeted tests pass
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)