### PR TITLE
fix: widen select-all header in session replays view

### DIFF
--- a/static/app/components/tables/sortableHeaderCell.tsx
+++ b/static/app/components/tables/sortableHeaderCell.tsx
@@ -57,6 +57,7 @@ export function SortableHeaderCell({
 }
 
 const Label = styled('div')`
+  min-width: 22px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;


### PR DESCRIPTION
## Summary
- reserve 22px for sortable-header labels so the replay select-all checkbox is not clipped

Before:
<img width="88" height="104" alt="Screenshot 2026-08-02 at 7 59 15 AM" src="https://github.com/user-attachments/assets/9188d09a-62f0-46c1-aa58-b93ab7e4a48e" />

After:
<img width="443" height="126" alt="Screenshot 2026-08-02 at 8 07 24 AM" src="https://github.com/user-attachments/assets/17023ff0-117a-46d5-8e48-a5d62a74b6a4" />

## Testing
- `git diff --check`
- Not run: frontend dependencies are absent in this checkout (`node_modules` / ESLint unavailable)