### PR TITLE
ref(seer): remove `organizations:seer-explorer-ui-tools`

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -292,8 +292,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-slack-code-mode", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable the thinking blocks toggle in the Seer Agent top bar
     manager.add("organizations:seer-explorer-thinking-blocks", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable client-side UI tools for Seer Agent
-    manager.add("organizations:seer-explorer-ui-tools", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Seer Explorer to generate rich component embeds from an adjusted prompt
     manager.add("organizations:seer-explorer-embeds", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable thinking + tool-call summaries in Seer Agent

--- a/src/sentry/seer/endpoints/organization_seer_agent_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_agent_chat.py
@@ -251,13 +251,7 @@ class OrganizationSeerAgentChatEndpoint(OrganizationEndpoint):
         override_bash_mode_enabled = validated_data["override_bash_mode_enabled"]
         override_ce_enable = validated_data["override_ce_enable"]
         override_code_mode_enable = validated_data.get("override_code_mode_enable")
-        ui_tools = (
-            validated_data.get("ui_tools")
-            if features.has(
-                "organizations:seer-explorer-ui-tools", organization, actor=request.user
-            )
-            else None
-        )
+        ui_tools = validated_data.get("ui_tools")
 
         # If the frontend sent a structured LLMContext JSON snapshot, convert to markdown.
         if on_page_context:


### PR DESCRIPTION
Remove `organizations:seer-explorer-ui-tools`. This flag was fully rolled out to GA (100%, no conditions) in the automator in getsentry/sentry-options-automator#7652 on 5/4, and hasn't been touched since.

`ui_tools` is now always passed through in `OrganizationSeerAgentChatEndpoint`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bcx87sDFKyQ3hspFg73Tp8)_