### PR TITLE
ref(relay): Add drop-transaction-metrics2 to drop metric extraction configs

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1462,6 +1462,9 @@ register("relay.allow_internal_ip_auth", default=True, flags=FLAG_AUTOMATOR_MODI
 # Example value: [{"project_id": 42}, {"project_id": 123}]
 register("relay.drop-transaction-metrics", default=[], flags=FLAG_AUTOMATOR_MODIFIABLE)
 
+# Tell Relay to stop extracting metrics from transaction payloads for all projects.
+register("relay.drop-transaction-metrics2", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
+
 # Relay should emit a usage metric to track total spans.
 register("relay.span-usage-metric", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -1115,8 +1115,10 @@ def _filter_option_to_config_setting(flt: _FilterSpec, setting: str) -> Mapping[
 
 
 def _should_extract_transaction_metrics(project: Project) -> bool:
-    return features.has(
-        "organizations:transaction-metrics-extraction", project.organization
-    ) and not killswitches.killswitch_matches_context(
-        "relay.drop-transaction-metrics", {"project_id": project.id}
+    return (
+        features.has("organizations:transaction-metrics-extraction", project.organization)
+        and not options.get("relay.drop-transaction-metrics2")
+        and not killswitches.killswitch_matches_context(
+            "relay.drop-transaction-metrics", {"project_id": project.id}
+        )
     )


### PR DESCRIPTION
Because the killswitch doesn't work ...