### PR TITLE
fix(forms): make :project specific fields searchable

### DIFF
--- a/static/app/views/settings/settingsCommandPaletteActions.tsx
+++ b/static/app/views/settings/settingsCommandPaletteActions.tsx
@@ -51,9 +51,6 @@ function isSettingsRoute(route: string): boolean {
   if (!route.startsWith('/settings/')) {
     return false;
   }
-  if (route.includes(':projectId')) {
-    return false;
-  }
   if (route.includes(':teamId')) {
     return false;
   }


### PR DESCRIPTION
Project-scoped form fields (routes containing `:projectId`) are now included in
the settings command palette search. Previously `isSettingsRoute` dropped any
field whose route had a `:projectId` placeholder, so fields like the Seer
"Handoff to Agent" option never surfaced — searching for their label returned
nothing, even though the extracted registry entry was correct.

The `:projectId` exclusion existed because the generated `to` only resolves
`:orgId`, leaving `:projectId` literal in the path. That turns out to be fine:
navigating to such a route lands on `ProjectSettingsLayout`, which detects the
`:projectId` placeholder and opens the context picker for the user to choose a
project. `:teamId` and `:appId` remain excluded since their layouts don't have
that redirect.

Refs DE-1491
