### PR TITLE
feat(preprod): Show install groups in distribution table

### DIFF
--- a/static/app/components/preprod/preprodBuildsDistributionTable.tsx
+++ b/static/app/components/preprod/preprodBuildsDistributionTable.tsx
@@ -47,6 +47,7 @@ export function PreprodBuildsDistributionTable({
         <PreprodBuildsRowCells
           build={build}
           showInteraction={!isRowDisabled}
+          showInstallGroups
           showInstallabilityIndicator
           showProjectColumn={showProjectColumn}
         />

--- a/static/app/components/preprod/preprodBuildsTable.spec.tsx
+++ b/static/app/components/preprod/preprodBuildsTable.spec.tsx
@@ -93,6 +93,91 @@ describe('PreprodBuildsTable', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('renders install groups in distribution rows', () => {
+    const buildWithOneGroup = {
+      ...baseBuild,
+      distribution_info: {
+        ...baseBuild.distribution_info,
+        install_groups: ['internal'],
+      },
+    };
+    const buildWithThreeGroups = {
+      ...baseBuild,
+      id: 'build-2',
+      distribution_info: {
+        ...baseBuild.distribution_info,
+        install_groups: ['qa', 'beta', 'release-candidate'],
+      },
+    };
+
+    render(
+      <PreprodBuildsTable
+        builds={[buildWithOneGroup, buildWithThreeGroups]}
+        display={PreprodBuildsDisplay.DISTRIBUTION}
+        isLoading={false}
+        organizationSlug={organization.slug}
+      />,
+      {organization}
+    );
+
+    expect(screen.getByText('internal')).toBeInTheDocument();
+    expect(screen.getByText('qa')).toBeInTheDocument();
+    expect(screen.getByText('beta')).toBeInTheDocument();
+    expect(screen.getByText('release-candidate')).toBeInTheDocument();
+    expect(screen.queryByLabelText(/more install groups/)).not.toBeInTheDocument();
+  });
+
+  it('collapses install groups beyond the visible limit', () => {
+    const buildWithManyGroups = {
+      ...baseBuild,
+      distribution_info: {
+        ...baseBuild.distribution_info,
+        install_groups: ['internal', 'qa', 'beta', 'design-review', 'release-candidate'],
+      },
+    };
+
+    render(
+      <PreprodBuildsTable
+        builds={[buildWithManyGroups]}
+        display={PreprodBuildsDisplay.DISTRIBUTION}
+        isLoading={false}
+        organizationSlug={organization.slug}
+      />,
+      {organization}
+    );
+
+    expect(screen.getByText('internal')).toBeInTheDocument();
+    expect(screen.getByText('qa')).toBeInTheDocument();
+    expect(screen.getByText('beta')).toBeInTheDocument();
+    expect(screen.queryByText('design-review')).not.toBeInTheDocument();
+    expect(screen.queryByText('release-candidate')).not.toBeInTheDocument();
+
+    const overflow = screen.getByLabelText('2 more install groups');
+    expect(overflow).toHaveTextContent('+2');
+    expect(overflow).toHaveAttribute('title', 'design-review, release-candidate');
+  });
+
+  it('does not render install groups in the size view', () => {
+    const buildWithGroup = {
+      ...baseBuild,
+      distribution_info: {
+        ...baseBuild.distribution_info,
+        install_groups: ['internal'],
+      },
+    };
+
+    render(
+      <PreprodBuildsTable
+        builds={[buildWithGroup]}
+        isLoading={false}
+        organizationSlug={organization.slug}
+      />,
+      {organization}
+    );
+
+    expect(screen.queryByText('internal')).not.toBeInTheDocument();
+  });
+
   it('prefers build_number_raw over the synthesized build_number', () => {
     const buildWithRawNumber = {
       ...baseBuild,

--- a/static/app/components/preprod/preprodBuildsTable.spec.tsx
+++ b/static/app/components/preprod/preprodBuildsTable.spec.tsx
@@ -1,6 +1,6 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {PreprodBuildsDisplay} from 'sentry/components/preprod/preprodBuildsDisplay';
 import {PreprodBuildsTable} from 'sentry/components/preprod/preprodBuildsTable';
@@ -127,7 +127,7 @@ describe('PreprodBuildsTable', () => {
     expect(screen.queryByLabelText(/more install groups/)).not.toBeInTheDocument();
   });
 
-  it('collapses install groups beyond the visible limit', () => {
+  it('collapses install groups beyond the visible limit', async () => {
     const buildWithManyGroups = {
       ...baseBuild,
       distribution_info: {
@@ -154,7 +154,11 @@ describe('PreprodBuildsTable', () => {
 
     const overflow = screen.getByLabelText('2 more install groups');
     expect(overflow).toHaveTextContent('+2');
-    expect(overflow).toHaveAttribute('title', 'design-review, release-candidate');
+
+    await userEvent.hover(overflow);
+    expect(
+      await screen.findByText('design-review, release-candidate')
+    ).toBeInTheDocument();
   });
 
   it('does not render install groups in the size view', () => {

--- a/static/app/components/preprod/preprodBuildsTableCommon.tsx
+++ b/static/app/components/preprod/preprodBuildsTableCommon.tsx
@@ -192,22 +192,30 @@ export function PreprodBuildsRowCells({
           {visibleInstallGroups.length > 0 && (
             <Flex align="center" gap="xs" minWidth={0} width="100%" wrap="wrap">
               {visibleInstallGroups.map(group => (
-                <Tag key={group} style={{maxWidth: '100%'}} title={group} variant="muted">
-                  {group}
+                <Tag
+                  key={group}
+                  style={{maxWidth: '100%', minWidth: 0}}
+                  title={group}
+                  variant="muted"
+                >
+                  <Text ellipsis variant="inherit">
+                    {group}
+                  </Text>
                 </Tag>
               ))}
               {hiddenInstallGroups.length > 0 && (
-                <Tag
-                  aria-label={tn(
-                    '%s more install group',
-                    '%s more install groups',
-                    hiddenInstallGroups.length
-                  )}
-                  title={hiddenInstallGroups.join(', ')}
-                  variant="muted"
-                >
-                  +{hiddenInstallGroups.length}
-                </Tag>
+                <Tooltip title={hiddenInstallGroups.join(', ')}>
+                  <Tag
+                    aria-label={tn(
+                      '%s more install group',
+                      '%s more install groups',
+                      hiddenInstallGroups.length
+                    )}
+                    variant="muted"
+                  >
+                    +{hiddenInstallGroups.length}
+                  </Tag>
+                </Tooltip>
               )}
             </Flex>
           )}

--- a/static/app/components/preprod/preprodBuildsTableCommon.tsx
+++ b/static/app/components/preprod/preprodBuildsTableCommon.tsx
@@ -190,7 +190,7 @@ export function PreprodBuildsRowCells({
             )}
           </Flex>
           {visibleInstallGroups.length > 0 && (
-            <Flex align="center" gap="xs" minWidth={0} width="100%" wrap="wrap">
+            <Flex align="center" gap="xs" wrap="wrap">
               {visibleInstallGroups.map(group => (
                 <Tag
                   key={group}

--- a/static/app/components/preprod/preprodBuildsTableCommon.tsx
+++ b/static/app/components/preprod/preprodBuildsTableCommon.tsx
@@ -2,6 +2,7 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 import {PlatformIcon} from 'platformicons';
 
+import {Tag} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
 import {InfoText} from '@sentry/scraps/info';
 import InteractionStateLayer from '@sentry/scraps/interactionStateLayer';
@@ -13,7 +14,7 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {TimeSince} from 'sentry/components/timeSince';
 import {IconCheckmark, IconCommit, IconNot} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tn} from 'sentry/locale';
 import {InstallAppButton} from 'sentry/views/preprod/components/installAppButton';
 import {getDistributionErrorTooltip} from 'sentry/views/preprod/components/installDetailsContent';
 import {
@@ -45,16 +46,25 @@ interface PreprodBuildsRowCellsProps {
   build: BuildDetailsApiResponse;
   showInteraction: boolean;
   showProjectColumn: boolean;
+  showInstallGroups?: boolean;
   showInstallabilityIndicator?: boolean;
 }
+
+const MAX_VISIBLE_INSTALL_GROUPS = 3;
 
 export function PreprodBuildsRowCells({
   build,
   showInteraction,
   showProjectColumn,
+  showInstallGroups = false,
   showInstallabilityIndicator = false,
 }: PreprodBuildsRowCellsProps) {
   const buildNumber = getBuildNumber(build.app_info);
+  const installGroups = showInstallGroups
+    ? (build.distribution_info?.install_groups ?? [])
+    : [];
+  const visibleInstallGroups = installGroups.slice(0, MAX_VISIBLE_INSTALL_GROUPS);
+  const hiddenInstallGroups = installGroups.slice(MAX_VISIBLE_INSTALL_GROUPS);
 
   return (
     <Fragment>
@@ -179,6 +189,28 @@ export function PreprodBuildsRowCells({
               </Fragment>
             )}
           </Flex>
+          {visibleInstallGroups.length > 0 && (
+            <Flex align="center" gap="xs" minWidth={0} width="100%" wrap="wrap">
+              {visibleInstallGroups.map(group => (
+                <Tag key={group} style={{maxWidth: '100%'}} title={group} variant="muted">
+                  {group}
+                </Tag>
+              ))}
+              {hiddenInstallGroups.length > 0 && (
+                <Tag
+                  aria-label={tn(
+                    '%s more install group',
+                    '%s more install groups',
+                    hiddenInstallGroups.length
+                  )}
+                  title={hiddenInstallGroups.join(', ')}
+                  variant="muted"
+                >
+                  +{hiddenInstallGroups.length}
+                </Tag>
+              )}
+            </Flex>
+          )}
         </Stack>
       </SimpleTable.RowCell>
     </Fragment>


### PR DESCRIPTION
The Mobile Builds Distribution view now shows install-group "tags" beneath each build. Up to three groups are shown inline; additional groups collapse into a `+N` indicator that exposes the hidden values on hover. Size and Snapshot views remain unchanged.

Refs [EME-1281](https://linear.app/getsentry/issue/EME-1281/expose-install-group-data-on-distribution-table-view).

Looks like:

<img width="50%" alt="install-grp-tags" src="https://github.com/user-attachments/assets/438edec9-cca9-4a07-b943-47815fa4019d" />

