### PR TITLE
ref(dynamic-sampling): Remove the implicit sample rate floor

### DIFF
--- a/src/sentry/dynamic_sampling/per_org/calculations.py
+++ b/src/sentry/dynamic_sampling/per_org/calculations.py
@@ -11,10 +11,6 @@ import sentry_sdk
 
 from sentry import options
 from sentry.dynamic_sampling.models.common import RebalancedItem
-from sentry.dynamic_sampling.models.full_rebalancing import (
-    FullRebalancingInput,
-    FullRebalancingModel,
-)
 from sentry.dynamic_sampling.models.projects_rebalancing import (
     ProjectsRebalancingInput,
     ProjectsRebalancingModel,
@@ -23,10 +19,7 @@ from sentry.dynamic_sampling.models.transactions_rebalancing import (
     TransactionsRebalancingInput,
     TransactionsRebalancingModel,
 )
-from sentry.dynamic_sampling.per_org.gate import (
-    is_implicit_sample_rate_floor_enabled,
-    project_balancing_debug_project_ids,
-)
+from sentry.dynamic_sampling.per_org.gate import project_balancing_debug_project_ids
 from sentry.dynamic_sampling.per_org.queries import (
     ProjectTransactionCounts,
     ProjectVolume,
@@ -351,7 +344,6 @@ def run_transaction_balancing(
 ) -> dict[int, tuple[list[RebalancedItem], float]]:
     sample_rates = config.get_project_sample_rates()
     min_sample_rate = options.get("dynamic-sampling.prioritise_transactions.min_sample_rate")
-    apply_implicit_floor = is_implicit_sample_rate_floor_enabled()
     result: dict[int, tuple[list[RebalancedItem], float]] = {}
     project_volume_by_id = {
         project_volume.project_id: project_volume for project_volume in project_volumes
@@ -392,50 +384,8 @@ def run_transaction_balancing(
             )
         )
 
-        if apply_implicit_floor and implicit_rate < sample_rate:
-            named_rates, implicit_rate = _apply_implicit_sample_rate_floor(
-                named_rates=named_rates,
-                implicit_sample_rate=implicit_rate,
-                floor_sample_rate=sample_rate,
-                total_volume=project_volume.total,
-                min_sample_rate=min_sample_rate,
-            )
-
         result[project_id] = (named_rates, implicit_rate)
     return result
-
-
-def _apply_implicit_sample_rate_floor(
-    named_rates: list[RebalancedItem],
-    implicit_sample_rate: float,
-    floor_sample_rate: float,
-    total_volume: int,
-    min_sample_rate: float = 0.0,
-) -> tuple[list[RebalancedItem], float]:
-    total_explicit_volume = sum(item.count for item in named_rates)
-    total_implicit_volume = total_volume - total_explicit_volume
-    if total_explicit_volume <= 0 or total_implicit_volume <= 0:
-        return named_rates, floor_sample_rate
-
-    additional_implicit_volume = (floor_sample_rate - implicit_sample_rate) * total_implicit_volume
-    previously_used_explicit_volume = sum(item.count * item.new_sample_rate for item in named_rates)
-    new_explicit_volume = previously_used_explicit_volume - additional_implicit_volume
-
-    if new_explicit_volume <= 0:
-        return [], floor_sample_rate
-
-    new_explicit_sample_rate = new_explicit_volume / total_explicit_volume
-    new_rates, _ = FullRebalancingModel().run(
-        FullRebalancingInput(
-            classes=[RebalancedItem(id=item.id, count=item.count) for item in named_rates],
-            sample_rate=new_explicit_sample_rate,
-            intensity=REBALANCE_INTENSITY,
-            # keep the head floor here too, so reclaiming budget for the implicit tail can't push the
-            # explicit rates back below the floor. Clamp to the floor rate (the overall rate here).
-            min_sample_rate=min(min_sample_rate, floor_sample_rate),
-        )
-    )
-    return new_rates, floor_sample_rate
 
 
 def get_cached_rebalanced_transaction_sample_rates(

--- a/src/sentry/dynamic_sampling/per_org/gate.py
+++ b/src/sentry/dynamic_sampling/per_org/gate.py
@@ -20,9 +20,6 @@ SLIDING_WINDOW_COMPARISON_ORG_IDS_OPTION = (
 SAMPLE_RATES_SUMMARY_LOG_ROLLOUT_RATE_OPTION = (
     "dynamic-sampling.per_org.sample-rates-summary-log-rollout-rate"
 )
-APPLY_IMPLICIT_SAMPLE_RATE_FLOOR_OPTION = (
-    "dynamic-sampling.per_org.apply-implicit-sample-rate-floor"
-)
 
 
 def is_killswitch_engaged() -> bool:
@@ -47,10 +44,6 @@ def is_org_in_sample_rates_summary_log_rollout(org_id: int) -> bool:
 
 def metrics_sample_rate() -> float:
     return float(options.get(METRICS_SAMPLE_RATE_OPTION))
-
-
-def is_implicit_sample_rate_floor_enabled() -> bool:
-    return bool(options.get(APPLY_IMPLICIT_SAMPLE_RATE_FLOOR_OPTION))
 
 
 def project_balancing_debug_project_ids() -> set[int]:

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2247,17 +2247,6 @@ register(
     flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Applies the implicit sample rate floor in the per-org pipeline. The transaction rebalancing
-# model can return an implicit (tail) rate below the project's overall rate; the floor lifts it
-# back to that rate and pays for it by lowering the explicit rates. The legacy pipeline has no
-# such step, so with this enabled the two pipelines write different per-transaction rates for
-# identical input. Set to False to compare them like for like.
-register(
-    "dynamic-sampling.per_org.apply-implicit-sample-rate-floor",
-    default=True,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
 # Stops dynamic sampling rules from being emitted in relay config.
 # This is required for ST instances that have flakey flags as we want to be able kill DS ruining customer data if necessary.
 # It is only a killswitch for behaviour, it may actually increase infra load if flipped for a user currently being sampled.

--- a/tests/sentry/dynamic_sampling/per_org/test_calculations.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_calculations.py
@@ -505,108 +505,25 @@ class TransactionBalancingCalculationsTest(TestCase):
         assert extras[1]["is_equal"] is False
 
 
-def _branch3_project_volume(project_id: int) -> ProjectVolume:
-    """The full-project totals that drive TransactionsRebalancingModel into
-    branch 3 (explicit pool too small to absorb its budget share), producing an
-    implicit rate below the base sample rate."""
-    return ProjectVolume(
-        project_id=project_id, total=1000, keep=0, drop=0, num_distinct_transactions=10
-    )
-
-
-def _branch3_transactions(org_id: int, project_id: int) -> ProjectTransactionCounts:
-    return ProjectTransactionCounts(
-        org_id=org_id, project_id=project_id, transaction_counts=[("tiny", 5.0)]
-    )
-
-
-class TransactionBalancingImplicitFactorFloorTest(TestCase):
-    """Tests for the implicit factor floor that clamps the implicit factor
-    via budget redistribution from the explicit pool."""
-
-    def test_factor_one_lifts_implicit_rate_to_base(self) -> None:
+class TransactionBalancingModelOutputTest(TestCase):
+    def test_model_output_is_stored_as_is(self) -> None:
         org = self.create_organization()
         project = self.create_project(organization=org)
         config = Mock()
         config.organization = org
         config.get_project_sample_rates.return_value = {project.id: 0.1}
 
-        result = run_transaction_balancing(
-            config,
-            [_branch3_project_volume(project.id)],
-            [_branch3_transactions(org.id, project.id)],
-        )
-
-        named_rates, implicit_rate = result[project.id]
-        assert implicit_rate == pytest.approx(0.1)
-        # Explicit rate is reduced from 1.0 to absorb the extra implicit budget,
-        # so the overall budget remains at total * base_sample_rate = 100.
-        assert len(named_rates) == 1
-        new_explicit_rate = named_rates[0].new_sample_rate
-        total = 1000.0
-        total_explicit = 5.0
-        total_implicit = total - total_explicit
-        kept = new_explicit_rate * total_explicit + implicit_rate * total_implicit
-        assert kept == pytest.approx(total * 0.1, abs=1e-6)
-
-    def test_no_change_when_implicit_already_above_floor(self) -> None:
-        org = self.create_organization()
-        project = self.create_project(organization=org)
-        config = Mock()
-        config.organization = org
-        config.get_project_sample_rates.return_value = {project.id: 0.1}
-
-        # Branch 2 scenario: small long tail relative to its share → implicit_rate=1.0,
-        # which is already well above any factor floor we'd set.
+        # Branch 3 of TransactionsRebalancingModel: the explicit pool is too small to absorb
+        # its budget share, so the model returns an implicit rate below the project rate.
         project_volume = ProjectVolume(
-            project_id=project.id, total=1010, keep=0, drop=0, num_distinct_transactions=11
+            project_id=project.id, total=1000, keep=0, drop=0, num_distinct_transactions=10
         )
         project_transactions = ProjectTransactionCounts(
-            org_id=org.id, project_id=project.id, transaction_counts=[("heavy", 1000.0)]
+            org_id=org.id, project_id=project.id, transaction_counts=[("tiny", 5.0)]
         )
 
         result = run_transaction_balancing(config, [project_volume], [project_transactions])
 
-        _, implicit_rate = result[project.id]
-        assert implicit_rate == 1.0
-
-    @override_options({"dynamic-sampling.per_org.apply-implicit-sample-rate-floor": False})
-    def test_disabled_option_leaves_the_model_output_untouched(self) -> None:
-        org = self.create_organization()
-        project = self.create_project(organization=org)
-        config = Mock()
-        config.organization = org
-        config.get_project_sample_rates.return_value = {project.id: 0.1}
-
-        result = run_transaction_balancing(
-            config,
-            [_branch3_project_volume(project.id)],
-            [_branch3_transactions(org.id, project.id)],
-        )
-
         named_rates, implicit_rate = result[project.id]
-        # With the floor on, the implicit rate is lifted to 0.1 and the explicit rate drops
-        # below 1.0 to pay for it. Off, the model's own output is stored as-is, matching the
-        # legacy pipeline.
         assert implicit_rate == pytest.approx(0.09547738693467336)
         assert [item.new_sample_rate for item in named_rates] == [1.0]
-
-    @override_options({"dynamic-sampling.per_org.apply-implicit-sample-rate-floor": False})
-    def test_disabled_option_is_a_noop_when_the_floor_would_not_engage(self) -> None:
-        org = self.create_organization()
-        project = self.create_project(organization=org)
-        config = Mock()
-        config.organization = org
-        config.get_project_sample_rates.return_value = {project.id: 0.1}
-
-        project_volume = ProjectVolume(
-            project_id=project.id, total=1010, keep=0, drop=0, num_distinct_transactions=11
-        )
-        project_transactions = ProjectTransactionCounts(
-            org_id=org.id, project_id=project.id, transaction_counts=[("heavy", 1000.0)]
-        )
-
-        result = run_transaction_balancing(config, [project_volume], [project_transactions])
-
-        _, implicit_rate = result[project.id]
-        assert implicit_rate == 1.0


### PR DESCRIPTION
- Removes `_apply_implicit_sample_rate_floor` from the per-org transaction balancing. The rebalancing model output is now stored unmodified.
- Removes the `dynamic-sampling.per_org.apply-implicit-sample-rate-floor` option and its gate helper. The option is already off.