### PR TITLE
fix(hybridcloud): Allow skip-on-failure for Bitbucket, GHE and GitLab webhooks

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2419,10 +2419,13 @@ register(
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+# Providers whose mailbox drains skip a failed message and keep going instead of
+# aborting. Only safe for providers whose cell-side handlers tolerate reordering,
+# since a skipped message is retried after the ones behind it.
 register(
     "hybridcloud.webhookpayload.skip_on_failure_providers",
     type=Sequence,
-    default=["github"],
+    default=["github", "github_enterprise", "bitbucket", "bitbucket_server"],
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
 # Break glass controls

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2508,10 +2508,22 @@ register(
     default=0.0,
     flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
 )
+# Providers whose mailbox drains skip a failed message and keep going instead of
+# aborting. Only safe for providers whose cell-side handlers tolerate reordering,
+# since a skipped message is retried after the ones behind it. Aborting is not a
+# strict-ordering guarantee to begin with: drain_mailbox_parallel delivers a whole
+# batch concurrently before it consults this list, and dispatch to it is chosen on
+# backlog depth alone (PARALLEL_DRAIN_THRESHOLD), for every provider.
 register(
     "hybridcloud.webhookpayload.skip_on_failure_providers",
     type=Sequence,
-    default=["github"],
+    default=[
+        "github",
+        "github_enterprise",
+        "bitbucket",
+        "bitbucket_server",
+        "gitlab",
+    ],
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
 # Drops GitHub check webhooks that reference no pull request based in their own

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from datetime import timedelta
 from typing import Any
 from unittest.mock import MagicMock, PropertyMock, patch
@@ -369,6 +370,36 @@ def create_payloads(num: int, mailbox: str, provider: str | None = None) -> list
     return created
 
 
+def assert_drain_skips_failed_message(drain: Callable[[int], None], provider: str) -> None:
+    """
+    Drain a 5 message mailbox where the second delivery fails.
+
+    Asserts the provider is allowlisted in
+    `hybridcloud.webhookpayload.skip_on_failure_providers`: every message is
+    attempted and only the failed one is left behind for a later retry. The
+    provider string is used verbatim for `WebhookPayload.provider`, so a value
+    that doesn't match the registered default fails here instead of silently
+    behaving as a non-allowlisted provider.
+    """
+    url = f"http://us.testserver/extensions/{provider}/webhook/"
+    responses.add(responses.POST, url, status=200, body="")
+    responses.add(responses.POST, url, status=500, body="")
+    responses.add(responses.POST, url, status=200, body="")
+    responses.add(responses.POST, url, status=200, body="")
+    responses.add(responses.POST, url, status=200, body="")
+    records = create_payloads(5, f"{provider}:123", provider=provider)
+
+    drain(records[0].id)
+
+    assert len(responses.calls) == 5
+    assert WebhookPayload.objects.count() == 1
+
+    remaining = WebhookPayload.objects.get()
+    assert remaining.provider == provider
+    assert remaining.attempts == 1
+    assert remaining.schedule_for > timezone.now()
+
+
 @control_silo_test
 class DrainMailboxTest(TestCase):
     @responses.activate
@@ -472,6 +503,26 @@ class DrainMailboxTest(TestCase):
         assert first
         assert first.attempts == 1
         assert first.schedule_for > timezone.now()
+
+    @responses.activate
+    @override_cells(cell_config)
+    def test_drain_skip_on_failure_github_enterprise(self) -> None:
+        assert_drain_skips_failed_message(drain_mailbox, "github_enterprise")
+
+    @responses.activate
+    @override_cells(cell_config)
+    def test_drain_skip_on_failure_bitbucket(self) -> None:
+        assert_drain_skips_failed_message(drain_mailbox, "bitbucket")
+
+    @responses.activate
+    @override_cells(cell_config)
+    def test_drain_skip_on_failure_bitbucket_server(self) -> None:
+        assert_drain_skips_failed_message(drain_mailbox, "bitbucket_server")
+
+    @responses.activate
+    @override_cells(cell_config)
+    def test_drain_skip_on_failure_gitlab(self) -> None:
+        assert_drain_skips_failed_message(drain_mailbox, "gitlab")
 
     @responses.activate
     @override_cells(cell_config)
@@ -853,6 +904,26 @@ class DrainMailboxParallelTest(TestCase):
         assert first
         assert first.attempts == 1
         assert first.schedule_for > timezone.now()
+
+    @responses.activate
+    @override_cells(cell_config)
+    def test_drain_skip_on_failure_github_enterprise(self) -> None:
+        assert_drain_skips_failed_message(drain_mailbox_parallel, "github_enterprise")
+
+    @responses.activate
+    @override_cells(cell_config)
+    def test_drain_skip_on_failure_bitbucket(self) -> None:
+        assert_drain_skips_failed_message(drain_mailbox_parallel, "bitbucket")
+
+    @responses.activate
+    @override_cells(cell_config)
+    def test_drain_skip_on_failure_bitbucket_server(self) -> None:
+        assert_drain_skips_failed_message(drain_mailbox_parallel, "bitbucket_server")
+
+    @responses.activate
+    @override_cells(cell_config)
+    def test_drain_skip_on_failure_gitlab(self) -> None:
+        assert_drain_skips_failed_message(drain_mailbox_parallel, "gitlab")
 
     @responses.activate
     @override_cells(cell_config)

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from datetime import timedelta
 from typing import Any
 from unittest.mock import MagicMock, PropertyMock, patch
@@ -285,6 +286,36 @@ def create_payloads(num: int, mailbox: str, provider: str | None = None) -> list
     return created
 
 
+def assert_drain_skips_failed_message(drain: Callable[[int], None], provider: str) -> None:
+    """
+    Drain a 5 message mailbox where the second delivery fails.
+
+    Asserts the provider is allowlisted in
+    `hybridcloud.webhookpayload.skip_on_failure_providers`: every message is
+    attempted and only the failed one is left behind for a later retry. The
+    provider string is used verbatim for `WebhookPayload.provider`, so a value
+    that doesn't match the registered default fails here instead of silently
+    behaving as a non-allowlisted provider.
+    """
+    url = f"http://us.testserver/extensions/{provider}/webhook/"
+    responses.add(responses.POST, url, status=200, body="")
+    responses.add(responses.POST, url, status=500, body="")
+    responses.add(responses.POST, url, status=200, body="")
+    responses.add(responses.POST, url, status=200, body="")
+    responses.add(responses.POST, url, status=200, body="")
+    records = create_payloads(5, f"{provider}:123", provider=provider)
+
+    drain(records[0].id)
+
+    assert len(responses.calls) == 5
+    assert WebhookPayload.objects.count() == 1
+
+    remaining = WebhookPayload.objects.get()
+    assert remaining.provider == provider
+    assert remaining.attempts == 1
+    assert remaining.schedule_for > timezone.now()
+
+
 @control_silo_test
 class DrainMailboxTest(TestCase):
     @responses.activate
@@ -347,6 +378,21 @@ class DrainMailboxTest(TestCase):
         assert first
         assert first.attempts == 1
         assert first.schedule_for > timezone.now()
+
+    @responses.activate
+    @override_cells(cell_config)
+    def test_drain_skip_on_failure_github_enterprise(self) -> None:
+        assert_drain_skips_failed_message(drain_mailbox, "github_enterprise")
+
+    @responses.activate
+    @override_cells(cell_config)
+    def test_drain_skip_on_failure_bitbucket(self) -> None:
+        assert_drain_skips_failed_message(drain_mailbox, "bitbucket")
+
+    @responses.activate
+    @override_cells(cell_config)
+    def test_drain_skip_on_failure_bitbucket_server(self) -> None:
+        assert_drain_skips_failed_message(drain_mailbox, "bitbucket_server")
 
     @responses.activate
     @override_cells(cell_config)
@@ -685,6 +731,21 @@ class DrainMailboxParallelTest(TestCase):
         assert first
         assert first.attempts == 1
         assert first.schedule_for > timezone.now()
+
+    @responses.activate
+    @override_cells(cell_config)
+    def test_drain_skip_on_failure_github_enterprise(self) -> None:
+        assert_drain_skips_failed_message(drain_mailbox_parallel, "github_enterprise")
+
+    @responses.activate
+    @override_cells(cell_config)
+    def test_drain_skip_on_failure_bitbucket(self) -> None:
+        assert_drain_skips_failed_message(drain_mailbox_parallel, "bitbucket")
+
+    @responses.activate
+    @override_cells(cell_config)
+    def test_drain_skip_on_failure_bitbucket_server(self) -> None:
+        assert_drain_skips_failed_message(drain_mailbox_parallel, "bitbucket_server")
 
     @responses.activate
     @override_cells(cell_config)


### PR DESCRIPTION
Draining a webhook mailbox aborts on the first delivery failure unless the payload's provider is in `hybridcloud.webhookpayload.skip_on_failure_providers` (`deliver_webhooks.py:733`, `:1099`). Only `github` was listed, so a single wedged message blocks everything behind it for up to `MAX_DELIVERY_AGE` (3 days). This adds `github_enterprise`, `bitbucket`, `bitbucket_server` and `gitlab`.

### Aborting is not the ordering guarantee it looks like

The premise for keeping a provider off this list is that aborting preserves mailbox order. It does not, for anyone.

`drain_mailbox_parallel` submits a whole batch of `hybridcloud.webhookpayload.worker_threads` deliveries to a thread pool concurrently, and only consults the allowlist *after* the batch completes (`deliver_webhooks.py:967-981`, `:1099`). Dispatch to it is chosen on backlog depth alone — `claimed >= PARALLEL_DRAIN_THRESHOLD` (60) — with no provider gating (`:349`, `:581`). A non-allowlisted provider is therefore already reordered within every batch; the allowlist only widens the window from "within a batch" to "across a backoff".

This is not theoretical for GitLab. Over the last 7 days it took **5,706 parallel drains** (4,149 push-dispatched, 1,557 scheduler-dispatched), against a peak single-mailbox depth of **26,670** rows.

### Why GitLab is now included

The previous revision excluded GitLab because `IssuesEventWebhook._handle_status_change` (`gitlab/webhooks.py:325-349`) passes a delta, `{"action": action}`, into `sync_status_inbound`, and `get_resolve_sync_action` (`gitlab/issue_sync.py:262-277`) maps it straight through without re-reading the issue.

That reasoning does not survive comparison with GitHub, which has been draining under this option since it was introduced:

- `github/webhook.py:1020-1050` passes the **same** `{"action": action}` delta, and `github/issue_sync.py:193-202` maps `closed → RESOLVE` / `reopened → UNRESOLVE` with no state re-read. The two implementations are structurally identical; GitLab's only addition is a feature-flag check.
- `sync_status_inbound` dispatches via `apply_async` (`mixins/issues.py:481-489`) for both, so mailbox order is void before either handler runs — the same reason the previous revision gave for not clearing `jira`.

Every other GitLab handler matches a GitHub one already covered:

| | GitLab | GitHub (already allowlisted) |
|---|---|---|
| Push | idempotent `Commit.objects.create` under `except IntegrityError: pass` (`webhooks.py:650-666`) | same shape |
| MR / PR lifecycle | `update_pull_request_from_scm_snapshot` (`webhooks.py:524-531`) | same guard (`webhook.py:1221-1241`) |
| Assignment | full `assignees` snapshot (`webhooks.py:255-325`) | full `issue.assignees` snapshot |
| Repo metadata | `update_repo_data` | `update_repo_data` |
| Processor chain | 3 processors | 11 handlers, 8 with processor chains |

The PR-lifecycle guard that gated the previous revision — #121059 — merged on 2026-08-05, and covers GitLab's `MergeEventWebhook` on the same code path as GitHub's.

### The production case is strongest for GitLab

Over the last 7 days, GitLab holds the **worst oldest-pending-payload age of any provider**: peak 262,577s (3.04 days, i.e. rows aging out at the `MAX_DELIVERY_AGE` cliff), mean 213,581s (2.47 days) sustained across the whole window. Its transient-failure rate is ~3.6x GitHub's as a share of deliveries, and every one of those wedges a mailbox.

GitLab mailboxes are also **not split by event type** — `GitlabRequestParser` buckets on project id only (`parsers/gitlab.py:87-95`), where `GithubRequestParser` appends the event type (`parsers/github.py:98-108`); the backlog series confirms this, reporting `event_type:none` for GitLab. One wedged GitLab payload therefore blocks Push, Merge Request, Note and Issue hooks for that project simultaneously. The blast radius per wedged message is wider than GitHub's, not narrower.

### Why these three are safe

- **`github_enterprise`** — `GithubEnterpriseRequestParser` overrides only `provider` (`parsers/github_enterprise.py:20-21`) and runs literal subclasses of GitHub's handlers (`github_enterprise/webhook.py:144-183`). The allowlist is an exact string match, so GHE never matched `"github"` — an unintended exclusion, not a risk decision.
- **`bitbucket` / `bitbucket_server`** — one push-only handler each (`bitbucket/webhook.py:170`, `bitbucket_server/webhook.py:160`), commits inserted idempotently under `except IntegrityError: pass`, per-organization mailboxes. Bitbucket Server re-fetches each self-contained `fromHash..toHash` range from the API. No create/update/delete lifecycle to reorder.

### Known caveat

Both Bitbucket handlers and both GitLab SCM handlers call `update_repo_data`, a last-writer-wins refresh of the stored repo name and URL from the event body. A push carrying a pre-rename name, retried after a later push, can briefly write the stale name back. It self-heals on the next successful push and renames are rare. GitHub calls the same function (`webhook.py:362`) under this option today, so it is not a new exposure.

### Still excluded

`vsts` syncs assignees from a **delta** — the parsed `newValue` of an `assignedTo` field change (`vsts/webhooks.py:130-151`) — where GitHub and GitLab both read a full snapshot. That is an exposure neither allowlisted provider has, so the argument above does not extend to it. `jira_server`, `msteams` and `jira` were not assessed and remain follow-ups.

### No production effect on its own

The registered default only governs environments without an explicit override, and `sentry-options-automator` pins this fleet-wide. getsentry/sentry-options-automator#9018 is the change that actually takes effect in prod; merging this one alone changes nothing on sentry.io.

#121084 remains a real improvement to the status-sync path and is worth landing, but it is not a prerequisite for GitLab specifically: the hazard it fixes is already in production for GitHub under this same option.

Part of [INC-2424](https://linear.app/getsentry/issue/INC-2424)
