### PR TITLE
ref(discover): Migrate layouts to container queries

### DIFF
--- a/static/app/views/discover/landing.tsx
+++ b/static/app/views/discover/landing.tsx
@@ -4,7 +4,7 @@ import {useQuery} from '@tanstack/react-query';
 import {Alert} from '@sentry/scraps/alert';
 import {LinkButton} from '@sentry/scraps/button';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
-import {Stack} from '@sentry/scraps/layout';
+import {Grid, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import type {SelectValue} from '@sentry/scraps/select';
@@ -206,7 +206,15 @@ function DiscoverLanding() {
           </TopBar.Slot>
           <Layout.Body>
             <Layout.Main width="full">
-              <StyledActions>
+              <Grid
+                columns={{
+                  zero: 'auto',
+                  xl: 'auto max-content min-content max-content',
+                }}
+                gap="xl"
+                align="center"
+                marginBottom="xl"
+              >
                 <StyledSearchBar
                   defaultQuery=""
                   query={savedSearchQuery}
@@ -243,7 +251,7 @@ function DiscoverLanding() {
                 >
                   {t('Build a new query')}
                 </LinkButton>
-              </StyledActions>
+              </Grid>
               {status === 'pending' ? (
                 <LoadingIndicator />
               ) : status === 'error' ? (
@@ -303,18 +311,6 @@ const PrebuiltSwitch = styled('label')`
 
 const StyledSearchBar = styled(SearchBar)`
   flex-grow: 1;
-`;
-
-const StyledActions = styled('div')`
-  display: grid;
-  gap: ${p => p.theme.space.xl};
-  grid-template-columns: auto max-content min-content max-content;
-  align-items: center;
-  margin-bottom: ${p => p.theme.space.xl};
-
-  @media (max-width: ${p => p.theme.breakpoints.sm}) {
-    grid-template-columns: auto;
-  }
 `;
 
 const QueriesContainer = styled('div')`

--- a/static/app/views/discover/queryList.tsx
+++ b/static/app/views/discover/queryList.tsx
@@ -4,6 +4,7 @@ import type {Location, Query} from 'history';
 import moment from 'moment-timezone';
 
 import {Button} from '@sentry/scraps/button';
+import {Grid} from '@sentry/scraps/layout';
 import {Pagination} from '@sentry/scraps/pagination';
 
 import type {Client} from 'sentry/api';
@@ -362,7 +363,16 @@ class QueryList extends Component<Props> {
     const {pageLinks} = this.props;
     return (
       <Fragment>
-        <QueryGrid>{this.renderQueries()}</QueryGrid>
+        <Grid
+          columns={{
+            zero: 'minmax(100px, 1fr)',
+            '3xl': 'repeat(2, minmax(100px, 1fr))',
+            '4xl': 'repeat(3, minmax(100px, 1fr))',
+          }}
+          gap="xl"
+        >
+          {this.renderQueries()}
+        </Grid>
         <PaginationRow
           pageLinks={pageLinks}
           onCursor={(cursor, path, query, direction) => {
@@ -388,20 +398,6 @@ class QueryList extends Component<Props> {
 
 const PaginationRow = styled(Pagination)`
   margin-bottom: 20px;
-`;
-
-const QueryGrid = styled('div')`
-  display: grid;
-  grid-template-columns: minmax(100px, 1fr);
-  gap: ${p => p.theme.space.xl};
-
-  @media (min-width: ${p => p.theme.breakpoints.md}) {
-    grid-template-columns: repeat(2, minmax(100px, 1fr));
-  }
-
-  @media (min-width: ${p => p.theme.breakpoints.lg}) {
-    grid-template-columns: repeat(3, minmax(100px, 1fr));
-  }
 `;
 
 const DropdownTrigger = styled(Button)`

--- a/static/app/views/discover/results.tsx
+++ b/static/app/views/discover/results.tsx
@@ -1012,7 +1012,12 @@ function SearchBar({
   }
 
   return (
-    <Wrapper>
+    <Flex
+      direction={{zero: 'column', xl: 'row'}}
+      justify="between"
+      gap="md"
+      marginBottom="xl"
+    >
       <ResultsSearchQueryBuilder
         projectIds={eventView.project}
         query={eventView.query}
@@ -1024,7 +1029,7 @@ function SearchBar({
         includeTransactions
         recentSearches={savedSearchType}
       />
-    </Wrapper>
+    </Flex>
   );
 }
 
@@ -1470,7 +1475,12 @@ function DiscoverPageFilters({
   }
 
   return (
-    <Wrapper>
+    <Flex
+      direction={{zero: 'column', xl: 'row'}}
+      justify="between"
+      gap="md"
+      marginBottom="xl"
+    >
       <PageFilterBar condensed>
         <ProjectPageFilter />
         <EnvironmentPageFilter />
@@ -1521,21 +1531,9 @@ function DiscoverPageFilters({
           errorCode={errorCode}
         />
       </Flex>
-    </Wrapper>
+    </Flex>
   );
 }
-
-const Wrapper = styled('div')`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  gap: ${p => p.theme.space.md};
-  margin-bottom: ${p => p.theme.space.xl};
-
-  @media (max-width: ${p => p.theme.breakpoints.sm}) {
-    flex-direction: column;
-  }
-`;
 
 const Top = styled(Layout.Main)`
   flex-grow: 0;

--- a/static/app/views/discover/results/resultsChart.tsx
+++ b/static/app/views/discover/results/resultsChart.tsx
@@ -296,7 +296,7 @@ class ResultsChartContainer extends Component<ContainerProps, ContainerState> {
 export default withApi(ResultsChartContainer);
 
 const StyledPanel = styled(Panel)`
-  @media (min-width: ${p => p.theme.breakpoints.lg}) {
+  @container (min-width: ${p => p.theme.container['4xl']}) {
     margin: 0;
   }
 `;

--- a/static/app/views/discover/savedQuery/index.tsx
+++ b/static/app/views/discover/savedQuery/index.tsx
@@ -7,7 +7,7 @@ import type {Location} from 'history';
 
 import {Button, LinkButton} from '@sentry/scraps/button';
 import {Input} from '@sentry/scraps/input';
-import {Stack, Grid, type GridProps} from '@sentry/scraps/layout';
+import {Grid, Stack} from '@sentry/scraps/layout';
 
 import type {Client} from 'sentry/api';
 import Feature from 'sentry/components/acl/feature';
@@ -168,19 +168,11 @@ const SavedQueryButtonGroup = memo(function SavedQueryButtonGroup({
   }
 
   return (
-    <ResponsiveButtonBar>
+    <Grid flow="column" align="center" gap="md">
       {renderQueryButton(isDisabled => renderButtonViewSaved(isDisabled))}
-    </ResponsiveButtonBar>
+    </Grid>
   );
 });
-
-const ResponsiveButtonBar = styled((props: GridProps) => (
-  <Grid flow="column" align="center" gap="md" {...props} />
-))`
-  @media (min-width: ${p => p.theme.breakpoints.md}) {
-    margin-top: 0;
-  }
-`;
 
 const StyledOverlay = styled(Overlay)`
   padding: ${p => p.theme.space.md};

--- a/static/app/views/discover/table/columnEditCollection.tsx
+++ b/static/app/views/discover/table/columnEditCollection.tsx
@@ -5,7 +5,7 @@ import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
 import {Input} from '@sentry/scraps/input';
-import {Grid, type GridProps} from '@sentry/scraps/layout';
+import {Container, Grid, type GridProps} from '@sentry/scraps/layout';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {parseArithmetic} from 'sentry/components/arithmeticInput/parser';
@@ -533,7 +533,15 @@ function ColumnEditCollection({
             skipParameterPlaceholder={showAliasField}
           />
           {showAliasField && (
-            <AliasField singleColumn={singleColumn}>
+            <Container
+              marginTop={{zero: 'md', xl: '0'}}
+              marginLeft={{zero: '0', xl: 'md'}}
+              row={{zero: '2 / 2', xl: 'auto'}}
+              column={{
+                zero: singleColumn ? '1 / -1' : '2 / 2',
+                xl: 'auto',
+              }}
+            >
               <AliasInput
                 name="alias"
                 placeholder={t('Alias')}
@@ -545,7 +553,7 @@ function ColumnEditCollection({
                   });
                 }}
               />
-            </AliasField>
+            </Container>
           )}
           {canDelete || col.kind === 'equation' ? (
             showAliasField ? (
@@ -729,7 +737,7 @@ const RowContainer = styled('div')<{
         ? '1fr'
         : `${p.theme.space['2xl']} 1fr 40px 40px`};
 
-      @media (min-width: ${p.theme.breakpoints.sm}) {
+      @container (min-width: ${p.theme.container.xl}) {
         grid-template-columns: ${p.singleColumn
           ? `1fr calc(200px + ${p.theme.space.md})`
           : `${p.theme.space['2xl']} 1fr calc(200px + ${p.theme.space.md}) 40px 40px`};
@@ -788,19 +796,6 @@ const StyledSectionHeading = styled(SectionHeading)`
 
 const AliasInput = styled(Input)`
   min-width: 50px;
-`;
-
-const AliasField = styled('div')<{singleColumn: boolean}>`
-  margin-top: ${p => p.theme.space.md};
-  @media (min-width: ${p => p.theme.breakpoints.sm}) {
-    margin-top: 0;
-    margin-left: ${p => p.theme.space.md};
-  }
-
-  @media (max-width: ${p => p.theme.breakpoints.sm}) {
-    grid-row: 2/2;
-    grid-column: ${p => (p.singleColumn ? '1/-1' : '2/2')};
-  }
 `;
 
 const RemoveButton = styled(Button)`

--- a/static/app/views/discover/table/columnEditModal.tsx
+++ b/static/app/views/discover/table/columnEditModal.tsx
@@ -190,7 +190,7 @@ const Instruction = styled('div')`
 `;
 
 const modalCss = (theme: Theme) => css`
-  @media (min-width: ${theme.breakpoints.md}) {
+  @container (min-width: ${theme.container['3xl']}) {
     width: auto;
     max-width: 900px;
   }


### PR DESCRIPTION
Migrates the Discover views (landing, query list, results, saved query, and column editor) from viewport media queries to container queries and layout primitives (`Grid`/`Flex`/`Container`). Responsive layout now adapts to the space actually available to each view rather than the browser viewport, so it reflows correctly when surrounding navigation or panels reduce its width.

The viewport and container breakpoint values compare as follows:

| Surface | Before: viewport value | After: container value |
| --- | --- | --- |
| Landing actions bar | Multi-column above `sm` (`>800px`) | Multi-column at `xl` (`≥768px`) |
| Saved query grid | 2 columns at `md` (`≥992px`), 3 at `lg` (`≥1200px`) | 2 columns at `3xl` (`≥1024px`), 3 at `4xl` (`≥1152px`) |
| Results search / page filter bars | Row above `sm` (`>800px`) | Row at `xl` (`≥768px`) |
| Results chart panel margin | `lg` (`≥1200px`) | `4xl` (`≥1152px`) |
| Column editor row + alias field | `sm` (`≥800px`) | `xl` (`≥768px`) |
| Column edit modal width | `md` (`≥992px`) | `3xl` (`≥1024px`) |

No behavior beyond the responsive breakpoints changes; the redundant `margin-top: 0` override on the saved-query button bar was dropped since the base layout no longer sets a top margin.

Refs #120315
