### PR TITLE
fix(dashboards): guard against null environment in saved page filters

### DIFF
--- a/static/app/views/dashboards/dashboardRevisionsDiff.ts
+++ b/static/app/views/dashboards/dashboardRevisionsDiff.ts
@@ -23,7 +23,7 @@ function formatTime(d: DashboardDetails): string | null {
   return null;
 }
 
-function formatList(items: string[] | undefined): string {
+function formatList(items: string[] | undefined | null): string {
   const filtered = items?.filter(Boolean) ?? [];
   return filtered.length ? filtered.join(', ') : t('(none)');
 }

--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -244,7 +244,7 @@ export type DashboardDetails = {
   widgets: Widget[];
   createdBy?: User;
   end?: string;
-  environment?: string[];
+  environment?: string[] | null;
   isFavorited?: boolean;
   period?: string;
   permissions?: DashboardPermissions;

--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -358,7 +358,7 @@ export function hasSavedPageFilters(
 ) {
   return !(
     (dashboard.projects === undefined || dashboard.projects.length === 0) &&
-    (dashboard.environment === undefined || dashboard.environment.length === 0) &&
+    (!defined(dashboard.environment) || dashboard.environment.length === 0) &&
     dashboard.start === undefined &&
     dashboard.end === undefined &&
     dashboard.period === undefined


### PR DESCRIPTION
A dashboard's `environment` field can arrive as `null` at runtime, but its type declared only `string[] | undefined`. `hasSavedPageFilters` guarded with `dashboard.environment === undefined`, which let `null` slip through to `dashboard.environment.length` and threw `TypeError: Cannot read properties of null (reading 'length')` while mounting the dashboard view.

This widens `DashboardDetails['environment']` to `string[] | null` to reflect what the API actually returns, and replaces the `=== undefined` check with `defined()` so both `null` and `undefined` are handled. `formatList` in `dashboardRevisionsDiff` is widened to accept `null` for the same field.

Fixes JAVASCRIPT-3B79
