### PR TITLE
fix(replays): restore to-be-deleted count in delete_replays logs

### DIFF
--- a/src/sentry/replays/scripts/delete_replays.py
+++ b/src/sentry/replays/scripts/delete_replays.py
@@ -45,6 +45,9 @@ def delete_replays(
     # Keyset (seek) pagination cursor - page by the last replay_id we saw
     last_replay_id = None
 
+    # Running tally of replays to be deleted, accumulated across pages
+    total_replays = 0
+
     has_more = True
     while has_more:
         replays, has_more, last_replay_id = _get_rows_matching_deletion_pattern(
@@ -61,6 +64,8 @@ def delete_replays(
         if not replays:
             return None
 
+        total_replays += len(replays)
+
         logging_context = {
             "project_id": project_id,
             "dry_run": dry_run,
@@ -69,22 +74,26 @@ def delete_replays(
             "start_utc": start_utc,
             "end_utc": end_utc,
             "has_more": has_more,
+            "total_replays": total_replays,
         }
         if dry_run:
             logger.info(f"Replays to be deleted (dry run): {len(replays)}", extra=logging_context)
         else:
-            delete_replay_ids(project_id, replays)
+            delete_replay_ids(project_id, replays, total_replays=total_replays)
 
 
 def translate_cli_tags_param_to_snuba_tag_param(tags: list[str]) -> Sequence[QueryToken]:
     return parse_search_query(" AND ".join(tags), config=replay_url_parser_config)
 
 
-def delete_replay_ids(project_id: int, rows: list[tuple[int, str, int]]) -> None:
+def delete_replay_ids(
+    project_id: int, rows: list[tuple[int, str, int]], total_replays: int
+) -> None:
     """Delete a set of replay-ids for a specific project."""
     logging_context = {
         "project_id": project_id,
         "num_replays": len(rows),
+        "total_replays": total_replays,
     }
     logger.info("Archiving %d replays.", len(rows), extra=logging_context)
 


### PR DESCRIPTION
Problem: the keyset-pagination switch in #121027 dropped the overall count of replays to be deleted. The old offset paging incremented `offset += len(replays)` each page, so `offset` doubled as a running tally that landed in the log context. Keyset paging cursors on `last_replay_id` instead, so that number disappeared and the logs no longer report how many replays a run is working through.

Fix: track an explicit `total_replays` tally in `delete_replays`, incremented by `len(replays)` each page, and thread it into the log context on both paths:
- dry-run: added to the existing `logging_context`, so `Replays to be deleted (dry run)` carries `total_replays`.
- real delete: passed into `delete_replay_ids(...)` as a required arg and added to its `logging_context`, so all four of its lines (`Archiving`, `Scheduling`, `successfully deleted`, and the customer-access notice) carry the running total.

The count is cumulative and matches the old `offset` semantics (a running "processed so far", not a grand total known up front). Because keyset paging discovers replays page by page, the complete count only appears on the final log line of a run. Example with 3123 replays at `batch_size=1000` (4 pages): `total_replays` climbs 1000 → 2000 → 3000 → 3123, and the last line holds 3123. A distinct up-front grand total would need a separate count query before the loop; deliberately out of scope here.