### PR TITLE
ref(issues): Increase inbox pagination increment

### DIFF
--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -289,7 +289,7 @@ describe('InboxPage', () => {
               project: [-1],
               query,
               sort: 'progress',
-              limit: 5,
+              limit: 10,
               collapse: ['stats', 'unhandled'],
             },
           })
@@ -495,7 +495,7 @@ describe('InboxPage', () => {
       body: [fixProposedGroup],
       headers: {
         'X-Hits': '2',
-        Link: '<http://localhost/?cursor=0:5:0>; rel="next"; results="true"; cursor="0:5:0"',
+        Link: '<http://localhost/?cursor=0:10:0>; rel="next"; results="true"; cursor="0:10:0"',
       },
     });
     MockApiClient.addMockResponse({
@@ -503,8 +503,7 @@ describe('InboxPage', () => {
       match: [
         MockApiClient.matchQuery({
           query: 'issue.progress:fix_proposed assigned:[me,my_teams]',
-          cursor: '0:5:0',
-          limit: 10,
+          cursor: '0:10:0',
         }),
       ],
       body: [nextFixProposedGroup],

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -289,7 +289,7 @@ describe('InboxPage', () => {
               project: [-1],
               query,
               sort: 'progress',
-              limit: 5,
+              limit: 10,
               collapse: ['stats', 'unhandled'],
             },
           })
@@ -495,7 +495,7 @@ describe('InboxPage', () => {
       body: [fixProposedGroup],
       headers: {
         'X-Hits': '2',
-        Link: '<http://localhost/?cursor=0:5:0>; rel="next"; results="true"; cursor="0:5:0"',
+        Link: '<http://localhost/?cursor=0:10:0>; rel="next"; results="true"; cursor="0:10:0"',
       },
     });
     MockApiClient.addMockResponse({
@@ -503,7 +503,7 @@ describe('InboxPage', () => {
       match: [
         MockApiClient.matchQuery({
           query: 'issue.progress:fix_proposed assigned:[me,my_teams]',
-          cursor: '0:5:0',
+          cursor: '0:10:0',
         }),
       ],
       body: [nextFixProposedGroup],
@@ -518,7 +518,7 @@ describe('InboxPage', () => {
     const fixSection = screen.getByRole('region', {name: 'Fix Proposed'});
     expect(await within(fixSection).findByText('Fix proposed issue')).toBeInTheDocument();
     const loadMoreButton = within(fixSection).getByRole('button', {
-      name: 'Show 5 more',
+      name: 'Show 10 more',
     });
 
     await userEvent.click(loadMoreButton);
@@ -529,7 +529,7 @@ describe('InboxPage', () => {
     ).toBeInTheDocument();
     expect(within(fixSection).getByText('Fix proposed issue')).toBeInTheDocument();
     expect(
-      within(fixSection).queryByRole('button', {name: 'Show 5 more'})
+      within(fixSection).queryByRole('button', {name: 'Show 10 more'})
     ).not.toBeInTheDocument();
   });
 

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -289,7 +289,7 @@ describe('InboxPage', () => {
               project: [-1],
               query,
               sort: 'progress',
-              limit: 10,
+              limit: 5,
               collapse: ['stats', 'unhandled'],
             },
           })
@@ -495,7 +495,7 @@ describe('InboxPage', () => {
       body: [fixProposedGroup],
       headers: {
         'X-Hits': '2',
-        Link: '<http://localhost/?cursor=0:10:0>; rel="next"; results="true"; cursor="0:10:0"',
+        Link: '<http://localhost/?cursor=0:5:0>; rel="next"; results="true"; cursor="0:5:0"',
       },
     });
     MockApiClient.addMockResponse({
@@ -503,7 +503,8 @@ describe('InboxPage', () => {
       match: [
         MockApiClient.matchQuery({
           query: 'issue.progress:fix_proposed assigned:[me,my_teams]',
-          cursor: '0:10:0',
+          cursor: '0:5:0',
+          limit: 10,
         }),
       ],
       body: [nextFixProposedGroup],

--- a/static/app/views/issueList/pages/inbox.tsx
+++ b/static/app/views/issueList/pages/inbox.tsx
@@ -23,6 +23,7 @@ import {IconArrow, IconChevron} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import {ProgressState, type Group} from 'sentry/types/group';
 import type {User} from 'sentry/types/user';
+import {apiFetchInfinite} from 'sentry/utils/api/apiFetch';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {getMessage, getTitle} from 'sentry/utils/events';
 import {useMembers} from 'sentry/utils/members/useMembers';
@@ -35,7 +36,8 @@ import {IssueSortOptions} from 'sentry/views/issueList/utils';
 import {getProgressIcon} from 'sentry/views/issueList/utils/progress';
 
 const TITLE = t('Inbox');
-const ISSUE_LIMIT = 10;
+const INITIAL_ISSUE_LIMIT = 5;
+const PAGINATION_ISSUE_LIMIT = 10;
 const SELECTED_ISSUE_QUERY_PARAM = 'preview';
 const ASSIGNMENT_QUERY_PARAM = 'assignment';
 const ASSIGNMENT_FILTERS = ['me', 'my_teams', 'all'] as const;
@@ -208,11 +210,26 @@ function InboxSection({assignmentFilter, section, selectedIssueId}: InboxSection
         project: [-1],
         query: `${section.query}${ASSIGNMENT_QUERY_SUFFIXES[assignmentFilter]}`,
         sort: IssueSortOptions.PROGRESS,
-        limit: ISSUE_LIMIT,
+        limit: INITIAL_ISSUE_LIMIT,
         collapse: ['stats', 'unhandled'],
       },
       staleTime: 0,
     }),
+    queryFn: context =>
+      apiFetchInfinite<Group[]>({
+        ...context,
+        queryKey: [
+          context.queryKey[0],
+          {
+            ...context.queryKey[1],
+            query: {
+              ...context.queryKey[1].query,
+              limit: context.pageParam ? PAGINATION_ISSUE_LIMIT : INITIAL_ISSUE_LIMIT,
+            },
+          },
+          context.queryKey[2],
+        ],
+      }),
     refetchOnWindowFocus: true,
   });
   const groups = queryResult.data?.pages.flatMap(page => page.json) ?? [];
@@ -253,7 +270,7 @@ function InboxSection({assignmentFilter, section, selectedIssueId}: InboxSection
             gap="xs"
             padding="0 xs"
           >
-            {Array.from({length: ISSUE_LIMIT}).map((_, index) => (
+            {Array.from({length: INITIAL_ISSUE_LIMIT}).map((_, index) => (
               <Placeholder key={index} height="76px" />
             ))}
           </Stack>
@@ -293,7 +310,7 @@ function InboxSection({assignmentFilter, section, selectedIssueId}: InboxSection
                   onClick={() => void queryResult.fetchNextPage()}
                   icon={<IconChevron direction="down" />}
                 >
-                  {tn('Show %s more', 'Show %s more', ISSUE_LIMIT)}
+                  {tn('Show %s more', 'Show %s more', PAGINATION_ISSUE_LIMIT)}
                 </Button>
               </Flex>
             )}

--- a/static/app/views/issueList/pages/inbox.tsx
+++ b/static/app/views/issueList/pages/inbox.tsx
@@ -23,7 +23,6 @@ import {IconArrow, IconChevron} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import {ProgressState, type Group} from 'sentry/types/group';
 import type {User} from 'sentry/types/user';
-import {apiFetchInfinite} from 'sentry/utils/api/apiFetch';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {getMessage, getTitle} from 'sentry/utils/events';
 import {useMembers} from 'sentry/utils/members/useMembers';
@@ -36,8 +35,7 @@ import {IssueSortOptions} from 'sentry/views/issueList/utils';
 import {getProgressIcon} from 'sentry/views/issueList/utils/progress';
 
 const TITLE = t('Inbox');
-const INITIAL_ISSUE_LIMIT = 5;
-const PAGINATION_ISSUE_LIMIT = 10;
+const ISSUE_LIMIT = 10;
 const SELECTED_ISSUE_QUERY_PARAM = 'preview';
 const ASSIGNMENT_QUERY_PARAM = 'assignment';
 const ASSIGNMENT_FILTERS = ['me', 'my_teams', 'all'] as const;
@@ -210,26 +208,11 @@ function InboxSection({assignmentFilter, section, selectedIssueId}: InboxSection
         project: [-1],
         query: `${section.query}${ASSIGNMENT_QUERY_SUFFIXES[assignmentFilter]}`,
         sort: IssueSortOptions.PROGRESS,
-        limit: INITIAL_ISSUE_LIMIT,
+        limit: ISSUE_LIMIT,
         collapse: ['stats', 'unhandled'],
       },
       staleTime: 0,
     }),
-    queryFn: context =>
-      apiFetchInfinite<Group[]>({
-        ...context,
-        queryKey: [
-          context.queryKey[0],
-          {
-            ...context.queryKey[1],
-            query: {
-              ...context.queryKey[1].query,
-              limit: context.pageParam ? PAGINATION_ISSUE_LIMIT : INITIAL_ISSUE_LIMIT,
-            },
-          },
-          context.queryKey[2],
-        ],
-      }),
     refetchOnWindowFocus: true,
   });
   const groups = queryResult.data?.pages.flatMap(page => page.json) ?? [];
@@ -270,7 +253,7 @@ function InboxSection({assignmentFilter, section, selectedIssueId}: InboxSection
             gap="xs"
             padding="0 xs"
           >
-            {Array.from({length: INITIAL_ISSUE_LIMIT}).map((_, index) => (
+            {Array.from({length: ISSUE_LIMIT}).map((_, index) => (
               <Placeholder key={index} height="76px" />
             ))}
           </Stack>
@@ -310,7 +293,7 @@ function InboxSection({assignmentFilter, section, selectedIssueId}: InboxSection
                   onClick={() => void queryResult.fetchNextPage()}
                   icon={<IconChevron direction="down" />}
                 >
-                  {tn('Show %s more', 'Show %s more', PAGINATION_ISSUE_LIMIT)}
+                  {tn('Show %s more', 'Show %s more', ISSUE_LIMIT)}
                 </Button>
               </Flex>
             )}

--- a/static/app/views/issueList/pages/inbox.tsx
+++ b/static/app/views/issueList/pages/inbox.tsx
@@ -35,7 +35,7 @@ import {IssueSortOptions} from 'sentry/views/issueList/utils';
 import {getProgressIcon} from 'sentry/views/issueList/utils/progress';
 
 const TITLE = t('Inbox');
-const ISSUE_LIMIT = 5;
+const ISSUE_LIMIT = 10;
 const SELECTED_ISSUE_QUERY_PARAM = 'preview';
 const ASSIGNMENT_QUERY_PARAM = 'assignment';
 const ASSIGNMENT_FILTERS = ['me', 'my_teams', 'all'] as const;


### PR DESCRIPTION
Increase the Inbox pagination increment from 5 issues to 10 issues.

Updates the API page limit, loading state count, button label, and pagination test cursor expectations.

Closes ISWF-3149