### PR TITLE
fix(issues): Hide Diagnosed inbox section without Seer

### DIFF
--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -29,6 +29,10 @@ describe('InboxPage', () => {
   const seerOrganization = OrganizationFixture({
     features: ['issue-stream-progress-ui', 'gen-ai-features'],
   });
+  const seerDisabledOrganization = OrganizationFixture({
+    features: ['issue-stream-progress-ui', 'gen-ai-features'],
+    hideAiFeatures: true,
+  });
   const project = ProjectFixture({
     id: '1',
     slug: 'project-slug',
@@ -257,7 +261,7 @@ describe('InboxPage', () => {
   it('loads and renders the three progress sections with filtered issue metadata', async () => {
     const requests = mockSuccessfulSections();
 
-    render(<InboxPage />, {organization, initialRouterConfig});
+    render(<InboxPage />, {organization: seerOrganization, initialRouterConfig});
 
     expect(screen.getByLabelText('Loading Fix Proposed issues')).toBeInTheDocument();
     expect(screen.getByLabelText('Loading Diagnosed issues')).toBeInTheDocument();
@@ -324,6 +328,26 @@ describe('InboxPage', () => {
     expect(screen.queryByRole('button', {name: '7D'})).not.toBeInTheDocument();
   });
 
+  it.each([
+    ['without Seer access', organization],
+    ['when AI features are disabled', seerDisabledOrganization],
+  ])('hides the Diagnosed section %s', async (_description, testOrganization) => {
+    const requests = mockSuccessfulSections();
+
+    render(<InboxPage />, {
+      organization: testOrganization,
+      initialRouterConfig,
+    });
+
+    expect(screen.queryByRole('region', {name: 'Diagnosed'})).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Loading Diagnosed issues')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(requests[0]).toHaveBeenCalledTimes(1);
+      expect(requests[2]).toHaveBeenCalledTimes(1);
+    });
+    expect(requests[1]).not.toHaveBeenCalled();
+  });
+
   it('shows a plus sign when a section count reaches the API cap', async () => {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/issues/',
@@ -384,7 +408,7 @@ describe('InboxPage', () => {
     ];
 
     const {router} = render(<InboxPage />, {
-      organization,
+      organization: seerOrganization,
       initialRouterConfig,
     });
 

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -27,10 +27,16 @@ describe('InboxPage', () => {
     features: ['issue-stream-progress-ui'],
   });
   const seerOrganization = OrganizationFixture({
+    features: ['issue-stream-progress-ui', 'gen-ai-features', 'seat-based-seer-enabled'],
+  });
+  const legacySeerOrganization = OrganizationFixture({
+    features: ['issue-stream-progress-ui', 'gen-ai-features', 'seer-added'],
+  });
+  const aiOnlyOrganization = OrganizationFixture({
     features: ['issue-stream-progress-ui', 'gen-ai-features'],
   });
   const seerDisabledOrganization = OrganizationFixture({
-    features: ['issue-stream-progress-ui', 'gen-ai-features'],
+    features: ['issue-stream-progress-ui', 'gen-ai-features', 'seat-based-seer-enabled'],
     hideAiFeatures: true,
   });
   const project = ProjectFixture({
@@ -330,7 +336,8 @@ describe('InboxPage', () => {
 
   it.each([
     ['without Seer access', organization],
-    ['when AI features are disabled', seerDisabledOrganization],
+    ['with AI access but no Seer plan', aiOnlyOrganization],
+    ['when AI features are disabled for a Seer customer', seerDisabledOrganization],
   ])('hides the Diagnosed section %s', async (_description, testOrganization) => {
     const requests = mockSuccessfulSections();
 
@@ -346,6 +353,18 @@ describe('InboxPage', () => {
       expect(requests[2]).toHaveBeenCalledTimes(1);
     });
     expect(requests[1]).not.toHaveBeenCalled();
+  });
+
+  it('shows the Diagnosed section for legacy Seer customers', async () => {
+    const requests = mockSuccessfulSections();
+
+    render(<InboxPage />, {
+      organization: legacySeerOrganization,
+      initialRouterConfig,
+    });
+
+    expect(await screen.findByRole('region', {name: 'Diagnosed'})).toBeInTheDocument();
+    expect(requests[1]).toHaveBeenCalledTimes(1);
   });
 
   it('shows a plus sign when a section count reaches the API cap', async () => {

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -29,15 +29,8 @@ describe('InboxPage', () => {
   const seerOrganization = OrganizationFixture({
     features: ['issue-stream-progress-ui', 'gen-ai-features', 'seat-based-seer-enabled'],
   });
-  const legacySeerOrganization = OrganizationFixture({
-    features: ['issue-stream-progress-ui', 'gen-ai-features', 'seer-added'],
-  });
   const aiOnlyOrganization = OrganizationFixture({
     features: ['issue-stream-progress-ui', 'gen-ai-features'],
-  });
-  const seerDisabledOrganization = OrganizationFixture({
-    features: ['issue-stream-progress-ui', 'gen-ai-features', 'seat-based-seer-enabled'],
-    hideAiFeatures: true,
   });
   const project = ProjectFixture({
     id: '1',
@@ -334,15 +327,11 @@ describe('InboxPage', () => {
     expect(screen.queryByRole('button', {name: '7D'})).not.toBeInTheDocument();
   });
 
-  it.each([
-    ['without Seer access', organization],
-    ['with AI access but no Seer plan', aiOnlyOrganization],
-    ['when AI features are disabled for a Seer customer', seerDisabledOrganization],
-  ])('hides the Diagnosed section %s', async (_description, testOrganization) => {
+  it('hides the Diagnosed section without a paid Seer plan', async () => {
     const requests = mockSuccessfulSections();
 
     render(<InboxPage />, {
-      organization: testOrganization,
+      organization: aiOnlyOrganization,
       initialRouterConfig,
     });
 
@@ -353,18 +342,6 @@ describe('InboxPage', () => {
       expect(requests[2]).toHaveBeenCalledTimes(1);
     });
     expect(requests[1]).not.toHaveBeenCalled();
-  });
-
-  it('shows the Diagnosed section for legacy Seer customers', async () => {
-    const requests = mockSuccessfulSections();
-
-    render(<InboxPage />, {
-      organization: legacySeerOrganization,
-      initialRouterConfig,
-    });
-
-    expect(await screen.findByRole('region', {name: 'Diagnosed'})).toBeInTheDocument();
-    expect(requests[1]).toHaveBeenCalledTimes(1);
   });
 
   it('shows a plus sign when a section count reaches the API cap', async () => {

--- a/static/app/views/issueList/pages/inbox.tsx
+++ b/static/app/views/issueList/pages/inbox.tsx
@@ -97,6 +97,9 @@ export default function InboxPage() {
 }
 
 function InboxContent() {
+  const organization = useOrganization();
+  const hasSeer =
+    organization.features.includes('gen-ai-features') && !organization.hideAiFeatures;
   const [assignmentFilter, setAssignmentFilter] = useQueryState(
     ASSIGNMENT_QUERY_PARAM,
     parseAsStringLiteral(ASSIGNMENT_FILTERS)
@@ -153,7 +156,9 @@ function InboxContent() {
             </SegmentedControl>
           </Flex>
           <Stack flex={1} minHeight={0} overflowY="auto" overscrollBehavior="contain">
-            {SECTIONS.map(section => (
+            {SECTIONS.filter(
+              section => hasSeer || section.progress !== ProgressState.DIAGNOSED
+            ).map(section => (
               <InboxSection
                 key={section.key}
                 section={section}

--- a/static/app/views/issueList/pages/inbox.tsx
+++ b/static/app/views/issueList/pages/inbox.tsx
@@ -99,7 +99,9 @@ export default function InboxPage() {
 function InboxContent() {
   const organization = useOrganization();
   const hasSeer =
-    organization.features.includes('gen-ai-features') && !organization.hideAiFeatures;
+    !organization.hideAiFeatures &&
+    (organization.features.includes('seat-based-seer-enabled') ||
+      organization.features.includes('seer-added'));
   const [assignmentFilter, setAssignmentFilter] = useQueryState(
     ASSIGNMENT_QUERY_PARAM,
     parseAsStringLiteral(ASSIGNMENT_FILTERS)


### PR DESCRIPTION
Hide the Diagnosed Inbox section unless the organization is on the current seat-based Seer plan or legacy usage-based Seer plan. The section also remains hidden when the organization has disabled AI features. Filtering before rendering avoids issuing a diagnosed-issues request for ineligible organizations.

Closes ISWF-3142