### PR TITLE
feat(issue-progress): Merged PRs should transition issue to fix applied

### DIFF
--- a/src/sentry/issues/derived/aggregators.py
+++ b/src/sentry/issues/derived/aggregators.py
@@ -97,7 +97,7 @@ def track_status(state: StateView, entry: GroupActionLogEntry) -> AggregatorResu
 
 # Progress for open issues (None when closed).
 #
-# Progress is dervived from a few features, which are tracked independently:
+# Progress is derived from a few features, which are tracked independently:
 #
 #   * IS_ASSIGNED     — issue has an assignee. Survives close/reopen.
 #   * HAS_ROOT_CAUSE  — a root cause has been identified (diagnosed). Cleared on
@@ -111,9 +111,12 @@ def track_status(state: StateView, entry: GroupActionLogEntry) -> AggregatorResu
 #   IS_ASSIGNED     → ASSIGNED
 #   (none)          → IDENTIFIED
 #
+# A merged fix PR advances progress to FIX_APPLIED, which remains sticky until
+# the issue closes.
+#
 #   IDENTIFIED → ASSIGNED → DIAGNOSED → FIX_PROPOSED → FIX_APPLIED
-#                                (RESOLVE / ARCHIVE)         → None (closed)
-#                                (UNRESOLVE / SET_REGRESSED) → Reopened
+#   (RESOLVE / ARCHIVE) → None (closed)
+#   (UNRESOLVE / SET_REGRESSED) → Reopen
 
 
 @aggregator(
@@ -194,6 +197,11 @@ def track_progress(state: StateView, entry: GroupActionLogEntry) -> AggregatorRe
 
     if state[STATUS] != IssueStatus.OPEN:
         new_progress = None
+    elif (
+        current_progress == IssueProgressState.FIX_APPLIED
+        or entry.type == PullRequestMergedAction.get_type()
+    ):
+        new_progress = IssueProgressState.FIX_APPLIED
     elif state[HAS_OPEN_FIX_PR]:
         new_progress = IssueProgressState.FIX_PROPOSED
     elif state[HAS_ROOT_CAUSE]:

--- a/src/sentry/issues/derived/features.py
+++ b/src/sentry/issues/derived/features.py
@@ -24,6 +24,7 @@ PROGRESS = Feature[IssueProgressState | None](
     "progress",
     default=IssueProgressState.IDENTIFIED,
     codec=OptionalCodec(EnumCodec(IssueProgressState)),
+    version=1,
 )
 
 # The last time the progress was advanced.

--- a/tests/sentry/issues/derived/test_aggregators.py
+++ b/tests/sentry/issues/derived/test_aggregators.py
@@ -709,14 +709,7 @@ def test_pr_close_with_remaining_keeps_fix_proposed() -> None:
     )
 
 
-@pytest.mark.parametrize(
-    "action_type",
-    [
-        GroupActionType.PULL_REQUEST_MERGED,
-        GroupActionType.PULL_REQUEST_UNLINKED,
-    ],
-)
-def test_pr_merged_or_unlinked_demotes_when_no_open_prs_remain(action_type: int) -> None:
+def test_pr_merged_advances_to_fix_applied() -> None:
     assert (
         _run_for_feature(
             PROGRESS,
@@ -727,23 +720,16 @@ def test_pr_merged_or_unlinked_demotes_when_no_open_prs_remain(action_type: int)
                     data=_resolved_pr_data(101),
                 ),
                 FakeEntry(
-                    type=action_type,
+                    type=GroupActionType.PULL_REQUEST_MERGED,
                     data={"pull_request": 101, "has_other_open_prs": False},
                 ),
             ],
         )
-        == IssueProgressState.DIAGNOSED
+        == IssueProgressState.FIX_APPLIED
     )
 
 
-@pytest.mark.parametrize(
-    "action_type",
-    [
-        GroupActionType.PULL_REQUEST_MERGED,
-        GroupActionType.PULL_REQUEST_UNLINKED,
-    ],
-)
-def test_pr_merged_or_unlinked_with_remaining_keeps_fix_proposed(action_type: int) -> None:
+def test_pr_unlinked_demotes_when_no_open_prs_remain() -> None:
     assert (
         _run_for_feature(
             PROGRESS,
@@ -753,13 +739,78 @@ def test_pr_merged_or_unlinked_with_remaining_keeps_fix_proposed(action_type: in
                     data=_resolved_pr_data(101),
                 ),
                 FakeEntry(
-                    type=action_type,
+                    type=GroupActionType.PULL_REQUEST_UNLINKED,
+                    data={"pull_request": 101, "has_other_open_prs": False},
+                ),
+            ],
+        )
+        == IssueProgressState.IDENTIFIED
+    )
+
+
+def test_pr_unlinked_with_remaining_keeps_fix_proposed() -> None:
+    assert (
+        _run_for_feature(
+            PROGRESS,
+            [
+                FakeEntry(
+                    type=GroupActionType.RESOLVED_IN_PULL_REQUEST,
+                    data=_resolved_pr_data(101),
+                ),
+                FakeEntry(
+                    type=GroupActionType.PULL_REQUEST_UNLINKED,
                     data={"pull_request": 101, "has_other_open_prs": True},
                 ),
             ],
         )
         == IssueProgressState.FIX_PROPOSED
     )
+
+
+def test_merged_fix_persists_across_unrelated_actions() -> None:
+    assert (
+        _run_for_feature(
+            PROGRESS,
+            [
+                FakeEntry(
+                    type=GroupActionType.RESOLVED_IN_PULL_REQUEST,
+                    data=_resolved_pr_data(101),
+                ),
+                FakeEntry(
+                    type=GroupActionType.PULL_REQUEST_MERGED,
+                    data={"pull_request": 101, "has_other_open_prs": False},
+                ),
+                FakeEntry(type=GroupActionType.ASSIGN),
+            ],
+        )
+        == IssueProgressState.FIX_APPLIED
+    )
+
+
+def test_merged_fix_resets_after_closed_issue_regresses() -> None:
+    p = _pipeline(targets=(PROGRESS,))
+    state = p.initial_state()
+    state = p.step(
+        state,
+        FakeEntry(
+            type=GroupActionType.RESOLVED_IN_PULL_REQUEST,
+            data=_resolved_pr_data(101),
+        ),
+    )
+    state = p.step(
+        state,
+        FakeEntry(
+            type=GroupActionType.PULL_REQUEST_MERGED,
+            data={"pull_request": 101, "has_other_open_prs": False},
+        ),
+    )
+    assert state[PROGRESS] == IssueProgressState.FIX_APPLIED
+
+    state = p.step(state, FakeEntry(type=GroupActionType.SET_RESOLVED_IN_COMMIT))
+    assert state[PROGRESS] is None
+
+    state = p.step(state, FakeEntry(type=GroupActionType.SET_REGRESSED))
+    assert state[PROGRESS] == IssueProgressState.IDENTIFIED
 
 
 def test_pr_reopened_restores_fix_proposed() -> None:


### PR DESCRIPTION
Closes ISWF-3182

A small change to the issue progress algorithm.

`PULL_REQUEST_MERGED` now transitions the issue progress to "Fix Applied". The issue will state in that progress state until the fix is deployed and the issue is resolved.