### PR TITLE
perf(grouping): Avoid redundant match frame work

### DIFF
--- a/src/sentry/grouping/enhancer/matchers.py
+++ b/src/sentry/grouping/enhancer/matchers.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from typing import Any, Literal, TypedDict
 
 from sentry.grouping.utils import bool_from_string
@@ -104,40 +104,38 @@ def _get_function_name(frame_data: dict[str, Any], platform: str | None) -> str:
     return function_name or "<unknown>"
 
 
+def _encode_if_str(value: str | bytes | None) -> bytes | None:
+    return value.encode("utf-8") if isinstance(value, str) else value
+
+
 def create_match_frame(frame_data: dict[str, Any], platform: str | None) -> MatchFrame:
     """Create flat dict of values relevant to matchers"""
-    match_frame = dict(
-        category=get_path(frame_data, "data", "category"),
-        family=get_behavior_family_for_platform(frame_data.get("platform") or platform),
-        function=_get_function_name(frame_data, platform),
-        in_app=frame_data.get("in_app"),
-        orig_in_app=get_path(frame_data, "data", "orig_in_app"),
-        module=get_path(frame_data, "module"),
-        package=frame_data.get("package"),
-        path=frame_data.get("abs_path") or frame_data.get("filename"),
-    )
+    frame_metadata = frame_data.get("data")
+    if not isinstance(frame_metadata, Mapping):
+        frame_metadata = {}
 
-    for key in list(match_frame.keys()):
-        value = match_frame[key]
-        if isinstance(value, (bytes, str)):
-            if isinstance(value, str):
-                value = match_frame[key] = value.encode("utf-8")
+    category = _encode_if_str(frame_metadata.get("category"))
+    module = _encode_if_str(frame_data.get("module"))
 
-            if key in ("package", "path"):
-                # NOTE: path-like matchers are case insensitive, and normalize
-                # file-system separators to `/`.
-                # We do this here in a central place instead of in each matcher separately.
-                value = match_frame[key] = value.lower().replace(b"\\", b"/")
+    package = _encode_if_str(frame_data.get("package"))
+    if isinstance(package, bytes):
+        package = package.lower().replace(b"\\", b"/")
+
+    path = _encode_if_str(frame_data.get("abs_path") or frame_data.get("filename"))
+    if isinstance(path, bytes):
+        path = path.lower().replace(b"\\", b"/")
 
     return MatchFrame(
-        category=match_frame["category"],
-        family=match_frame["family"],
-        function=match_frame["function"],
-        in_app=match_frame["in_app"],
-        orig_in_app=match_frame["orig_in_app"],
-        module=match_frame["module"],
-        package=match_frame["package"],
-        path=match_frame["path"],
+        category=category,
+        family=get_behavior_family_for_platform(frame_data.get("platform") or platform).encode(
+            "utf-8"
+        ),
+        function=_get_function_name(frame_data, platform).encode("utf-8"),
+        in_app=frame_data.get("in_app"),
+        orig_in_app=frame_metadata.get("orig_in_app"),
+        module=module,
+        package=package,
+        path=path,
     )
 
 

--- a/src/sentry/grouping/enhancer/matchers.py
+++ b/src/sentry/grouping/enhancer/matchers.py
@@ -108,6 +108,14 @@ def _encode_if_str(value: str | bytes | None) -> bytes | None:
     return value.encode("utf-8") if isinstance(value, str) else value
 
 
+def _normalize_path(value: str | bytes | None) -> bytes | None:
+    # Path-like matchers are case-insensitive and use `/` as the file-system separator.
+    encoded_value = _encode_if_str(value)
+    if isinstance(encoded_value, bytes):
+        return encoded_value.lower().replace(b"\\", b"/")
+    return encoded_value
+
+
 def create_match_frame(frame_data: dict[str, Any], platform: str | None) -> MatchFrame:
     """Create flat dict of values relevant to matchers"""
     frame_metadata = frame_data.get("data")
@@ -117,14 +125,8 @@ def create_match_frame(frame_data: dict[str, Any], platform: str | None) -> Matc
     category = _encode_if_str(frame_metadata.get("category"))
     module = _encode_if_str(frame_data.get("module"))
 
-    # Path-like matchers are case-insensitive and normalize file-system separators to `/`.
-    package = _encode_if_str(frame_data.get("package"))
-    if isinstance(package, bytes):
-        package = package.lower().replace(b"\\", b"/")
-
-    path = _encode_if_str(frame_data.get("abs_path") or frame_data.get("filename"))
-    if isinstance(path, bytes):
-        path = path.lower().replace(b"\\", b"/")
+    package = _normalize_path(frame_data.get("package"))
+    path = _normalize_path(frame_data.get("abs_path") or frame_data.get("filename"))
 
     return MatchFrame(
         category=category,

--- a/src/sentry/grouping/enhancer/matchers.py
+++ b/src/sentry/grouping/enhancer/matchers.py
@@ -117,6 +117,7 @@ def create_match_frame(frame_data: dict[str, Any], platform: str | None) -> Matc
     category = _encode_if_str(frame_metadata.get("category"))
     module = _encode_if_str(frame_data.get("module"))
 
+    # Path-like matchers are case-insensitive and normalize file-system separators to `/`.
     package = _encode_if_str(frame_data.get("package"))
     if isinstance(package, bytes):
         package = package.lower().replace(b"\\", b"/")

--- a/tests/sentry/grouping/test_benchmark.py
+++ b/tests/sentry/grouping/test_benchmark.py
@@ -1,5 +1,6 @@
 from types import ModuleType
 from typing import Any
+from unittest import mock
 
 import pytest
 
@@ -36,13 +37,11 @@ def test_benchmark_grouping(config_name: str, benchmark: ModuleType) -> None:
     def setup() -> tuple[tuple[GroupingInput, str], dict[str, Any]]:
         return (next(input_iter), config_name), {}
 
-    benchmark.pedantic(run_configuration, setup=setup, rounds=len(GROUPING_INPUTS))
+    with mock.patch("sentry.grouping.context.in_rollout_group", return_value=False):
+        benchmark.pedantic(run_configuration, setup=setup, rounds=len(GROUPING_INPUTS))
 
 
 def run_configuration(grouping_input: GroupingInput, config_name: str) -> None:
     event = grouping_input.create_event(config_name, use_full_ingest_pipeline=False)
-
-    # This ensures we won't try to touch the DB when getting event hashes
-    event.project = None  # type: ignore[assignment]
 
     event.get_hashes()


### PR DESCRIPTION
Every stack frame used by grouping enhancements was copied into an intermediate dictionary, scanned to encode and normalize its fields, then copied again into the final match frame. This builds the final values directly and avoids that repeated work on every frame.

## Grouping benchmark

| Grouping config | Before | After | Improvement |
|---|---:|---:|---:|
| 2023-01-11 | 205.03 ms | 191.67 ms | 6.5% faster |
| 2026-01-20 | 203.58 ms | 191.22 ms | 6.1% faster |

Ran each version 10 times, alternating before and after. Each run processes all 193 grouping fixtures. Larger stack traces should benefit more because this work runs per frame.

Also fixes the benchmark so it runs without counting database option lookups.