### PR TITLE
fix(hybridcloud): Drain deep mailboxes in parallel on push trigger

### DIFF
--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -55,9 +55,8 @@ PARALLEL_DRAIN_THRESHOLD = int(MAX_MAILBOX_DRAIN / 5)
 """
 Mailbox depth at which delivery switches from sequential to parallel.
 
-A mailbox holding this many undelivered records is behind, and the throughput of
-`hybridcloud.webhookpayload.worker_threads` concurrent requests is worth the loss
-of strict ordering that parallel delivery implies.
+Past this depth a mailbox is behind, and parallel throughput is worth its loss of
+strict ordering.
 """
 
 
@@ -132,14 +131,11 @@ def _mailbox_needs_parallel_drain(mailbox_name: str) -> bool:
     """
     Whether this mailbox is deep enough to be drained in parallel.
 
-    Mirrors the depth check the scheduler makes on `updated_count`. The count is
-    capped at PARALLEL_DRAIN_THRESHOLD, so it reads at most that many entries of
-    the (mailbox_name, id) index no matter how deep the mailbox is. Mailboxes can
-    hold millions of records, so an unbounded COUNT(*) is not viable on this path.
-
-    Deliberately reads the primary. The replica lags exactly when it matters most
-    — during an inbound burst — and a stale read would under-report depth and
-    keep a hot mailbox on the sequential drain.
+    The count is capped at the threshold so it stays an index-only scan of that
+    many (mailbox_name, id) entries; mailboxes can hold millions of records, so an
+    unbounded COUNT(*) is not viable here. Reads the primary because the replica
+    lags during the inbound bursts that make a mailbox deep, and a stale read would
+    under-report depth.
     """
     depth = (
         WebhookPayload.objects.filter(mailbox_name=mailbox_name)
@@ -157,11 +153,9 @@ def maybe_trigger_drain(mailbox_name: str) -> None:
     Only the first webhook to an idle mailbox triggers a drain; subsequent webhooks
     within the TTL window are picked up by the already-enqueued drain task.
 
-    Deep mailboxes are drained in parallel, matching the choice the scheduler makes.
-    The drain holds the lock for its whole run and the scheduler skips locked
-    mailboxes, so dispatching the sequential drain here would pin the mailbox to a
-    single in-flight request until the drain finished — and the busier a mailbox is,
-    the more often this trigger fires.
+    Deep mailboxes go to the parallel drain: the drain holds the lock for its whole
+    run and the scheduler skips locked mailboxes, so a sequential drain here would
+    pin the mailbox to one in-flight request until it finished.
 
     Falls back gracefully if the cache backend is unavailable — the scheduler handles delivery.
     """

--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -107,6 +107,18 @@ class DeliveryFailed(Exception):
     pass
 
 
+DRAIN_LOCK_TTL = 90
+"""
+Seconds a mailbox drain lock survives without a refresh.
+
+A drain releases its lock explicitly when it finishes, so this TTL only fires when
+one dies without reaching that release (worker kill, OOM). It must outlast the
+longest a live drain can go between refreshes — a single delivery, which the cell
+client bounds at its 30s connect plus 30s read. A shorter TTL lets the lock expire
+under a running drain, and a second drain then starts on the same mailbox.
+"""
+
+
 def _drain_lock_key(mailbox_name: str) -> str:
     return f"wh:drain_active:{mailbox_name}"
 
@@ -114,7 +126,7 @@ def _drain_lock_key(mailbox_name: str) -> str:
 def _refresh_drain_lock(mailbox_name: str) -> None:
     """Refresh the drain lock TTL to signal the drain task is still active."""
     try:
-        cache.set(_drain_lock_key(mailbox_name), 1, timeout=15)
+        cache.set(_drain_lock_key(mailbox_name), 1, timeout=DRAIN_LOCK_TTL)
     except Exception:
         pass
 
@@ -149,9 +161,9 @@ def _mailbox_needs_parallel_drain(mailbox_name: str) -> bool:
 def maybe_trigger_drain(mailbox_name: str) -> None:
     """Trigger an immediate drain if one isn't already in-flight for this mailbox.
 
-    Uses cache.add (atomic SETNX-style) with a 15-second TTL for deduplication.
-    Only the first webhook to an idle mailbox triggers a drain; subsequent webhooks
-    within the TTL window are picked up by the already-enqueued drain task.
+    Uses cache.add (atomic SETNX-style) with DRAIN_LOCK_TTL for deduplication. Only
+    the first webhook to an idle mailbox triggers a drain; subsequent webhooks within
+    the TTL window are picked up by the already-enqueued drain task.
 
     Deep mailboxes go to the parallel drain: the drain holds the lock for its whole
     run and the scheduler skips locked mailboxes, so a sequential drain here would
@@ -165,7 +177,7 @@ def maybe_trigger_drain(mailbox_name: str) -> None:
     lock_key = _drain_lock_key(mailbox_name)
     lock_acquired = False
     try:
-        if cache.add(lock_key, 1, timeout=15):
+        if cache.add(lock_key, 1, timeout=DRAIN_LOCK_TTL):
             lock_acquired = True
             # Only drain if the true mailbox head (lowest ID) is ready to deliver.
             # We must check the head specifically — filtering by schedule_for first
@@ -594,6 +606,10 @@ def drain_mailbox_parallel(payload_id: int, mailbox_name: str | None = None) -> 
         return
 
     _set_webhook_delivery_sentry_context(payload)
+    if mailbox_name and options.get("hybridcloud.webhookpayload.push_drain_trigger"):
+        # The discard sweep deletes up to 10k rows before the loop's first refresh,
+        # and the lock has been unrefreshed since the trigger enqueued this task.
+        _refresh_drain_lock(payload.mailbox_name)
     _discard_stale_mailbox_payloads(payload)
 
     skip_on_failure_providers = frozenset(

--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -51,6 +51,16 @@ slow forwarding yields to other tasks
 """
 
 
+PARALLEL_DRAIN_THRESHOLD = int(MAX_MAILBOX_DRAIN / 5)
+"""
+Mailbox depth at which delivery switches from sequential to parallel.
+
+A mailbox holding this many undelivered records is behind, and the throughput of
+`hybridcloud.webhookpayload.worker_threads` concurrent requests is worth the loss
+of strict ordering that parallel delivery implies.
+"""
+
+
 BATCH_SCHEDULE_OFFSET = datetime.timedelta(minutes=BACKOFF_INTERVAL)
 """
 The time that batches are scheduled into the future when work starts.
@@ -118,12 +128,40 @@ def _release_drain_lock(mailbox_name: str) -> None:
         pass
 
 
+def _mailbox_needs_parallel_drain(mailbox_name: str) -> bool:
+    """
+    Whether this mailbox is deep enough to be drained in parallel.
+
+    Mirrors the depth check the scheduler makes on `updated_count`. The count is
+    capped at PARALLEL_DRAIN_THRESHOLD, so it reads at most that many entries of
+    the (mailbox_name, id) index no matter how deep the mailbox is. Mailboxes can
+    hold millions of records, so an unbounded COUNT(*) is not viable on this path.
+
+    Deliberately reads the primary. The replica lags exactly when it matters most
+    — during an inbound burst — and a stale read would under-report depth and
+    keep a hot mailbox on the sequential drain.
+    """
+    depth = (
+        WebhookPayload.objects.filter(mailbox_name=mailbox_name)
+        .order_by("id")
+        .values("id")[:PARALLEL_DRAIN_THRESHOLD]
+        .count()
+    )
+    return depth >= PARALLEL_DRAIN_THRESHOLD
+
+
 def maybe_trigger_drain(mailbox_name: str) -> None:
     """Trigger an immediate drain if one isn't already in-flight for this mailbox.
 
     Uses cache.add (atomic SETNX-style) with a 15-second TTL for deduplication.
     Only the first webhook to an idle mailbox triggers a drain; subsequent webhooks
     within the TTL window are picked up by the already-enqueued drain task.
+
+    Deep mailboxes are drained in parallel, matching the choice the scheduler makes.
+    The drain holds the lock for its whole run and the scheduler skips locked
+    mailboxes, so dispatching the sequential drain here would pin the mailbox to a
+    single in-flight request until the drain finished — and the busier a mailbox is,
+    the more often this trigger fires.
 
     Falls back gracefully if the cache backend is unavailable — the scheduler handles delivery.
     """
@@ -152,8 +190,15 @@ def maybe_trigger_drain(mailbox_name: str) -> None:
                 metrics.incr("hybridcloud.deliver_webhooks.push_trigger.backoff")
                 return
             head_id = head[0]
-            drain_mailbox.delay(head_id, mailbox_name=mailbox_name)
-            metrics.incr("hybridcloud.deliver_webhooks.push_trigger.success")
+            if _mailbox_needs_parallel_drain(mailbox_name):
+                drain_mailbox_parallel.delay(head_id, mailbox_name=mailbox_name)
+                drain_mode = "parallel"
+            else:
+                drain_mailbox.delay(head_id, mailbox_name=mailbox_name)
+                drain_mode = "sequential"
+            metrics.incr(
+                "hybridcloud.deliver_webhooks.push_trigger.success", tags={"drain": drain_mode}
+            )
         else:
             metrics.incr("hybridcloud.deliver_webhooks.push_trigger.skipped")
     except Exception:
@@ -239,7 +284,7 @@ def schedule_webhook_delivery() -> None:
             schedule_for=timezone.now() + BATCH_SCHEDULE_OFFSET
         )
         # If we have 1/5 or more in a mailbox we should process in parallel as we're likely behind.
-        if updated_count >= int(MAX_MAILBOX_DRAIN / 5):
+        if updated_count >= PARALLEL_DRAIN_THRESHOLD:
             drain_mailbox_parallel.delay(record["id"])
         else:
             drain_mailbox.delay(record["id"])

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -6,6 +6,8 @@ import orjson
 import pytest
 import responses
 from django.core.cache import cache
+from django.db import connections, router
+from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 from requests.exceptions import ConnectionError, ReadTimeout
 
@@ -16,6 +18,7 @@ from sentry.hybridcloud.tasks.deliver_webhooks import (
     MAX_MAILBOX_DRAIN,
     PARALLEL_DRAIN_THRESHOLD,
     SLOW_DELIVERY_THRESHOLD,
+    _mailbox_needs_parallel_drain,
     drain_mailbox,
     drain_mailbox_parallel,
     maybe_trigger_drain,
@@ -1244,6 +1247,18 @@ class PushTriggerTest(TestCase):
 
         # Lock must be released so new webhooks and the scheduler can reach this mailbox
         assert cache.get(f"wh:drain_active:{mailbox}") is None
+
+    def test_depth_probe_query_is_bounded(self) -> None:
+        create_payloads(PARALLEL_DRAIN_THRESHOLD + 5, "github:123")
+        connection = connections[router.db_for_read(WebhookPayload)]
+
+        with CaptureQueriesContext(connection) as queries:
+            assert _mailbox_needs_parallel_drain("github:123") is True
+
+        # Mailboxes reach millions of rows, so the probe must stop at the threshold
+        # rather than counting the mailbox.
+        assert len(queries.captured_queries) == 1
+        assert f"LIMIT {PARALLEL_DRAIN_THRESHOLD}" in queries.captured_queries[0]["sql"]
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox_parallel")
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -15,6 +15,7 @@ from sentry import options
 from sentry.hybridcloud.models.webhookpayload import MAX_ATTEMPTS, WebhookPayload
 from sentry.hybridcloud.tasks import deliver_webhooks
 from sentry.hybridcloud.tasks.deliver_webhooks import (
+    DRAIN_LOCK_TTL,
     MAX_MAILBOX_DRAIN,
     PARALLEL_DRAIN_THRESHOLD,
     SLOW_DELIVERY_THRESHOLD,
@@ -24,6 +25,7 @@ from sentry.hybridcloud.tasks.deliver_webhooks import (
     maybe_trigger_drain,
     schedule_webhook_delivery,
 )
+from sentry.silo.client import CellSiloClient
 from sentry.testutils.cases import TestCase
 from sentry.testutils.cell import override_cells
 from sentry.testutils.factories import Factories
@@ -1247,6 +1249,42 @@ class PushTriggerTest(TestCase):
 
         # Lock must be released so new webhooks and the scheduler can reach this mailbox
         assert cache.get(f"wh:drain_active:{mailbox}") is None
+
+    def test_drain_lock_ttl_outlives_a_single_delivery(self) -> None:
+        # The lock must not expire under a running drain, or a second drain starts on
+        # the same mailbox. The parallel drain refreshes once per batch and a batch
+        # runs its requests concurrently, so the widest gap between refreshes is one
+        # delivery: the cell client's connect timeout plus its read timeout.
+        assert DRAIN_LOCK_TTL > 2 * CellSiloClient.timeout
+
+    @responses.activate
+    @override_cells(cell_config)
+    @override_options({"hybridcloud.webhookpayload.push_drain_trigger": True})
+    def test_parallel_drain_refreshes_lock_before_stale_discard(self) -> None:
+        responses.add(
+            responses.POST,
+            "http://us.testserver/extensions/github/webhook/",
+            status=200,
+            body="",
+        )
+        webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
+        lock_key = f"wh:drain_active:{webhook.mailbox_name}"
+        # Nothing has refreshed the lock since the trigger enqueued this task, so treat
+        # it as already gone. The discard sweep deletes up to 10k rows, and the loop's
+        # first refresh only happens after it.
+        cache.delete(lock_key)
+        lock_during_discard = []
+
+        def record_lock(payload: WebhookPayload) -> None:
+            lock_during_discard.append(cache.get(lock_key))
+
+        with patch(
+            "sentry.hybridcloud.tasks.deliver_webhooks._discard_stale_mailbox_payloads",
+            side_effect=record_lock,
+        ):
+            drain_mailbox_parallel(webhook.id, mailbox_name=webhook.mailbox_name)
+
+        assert lock_during_discard == [1]
 
     def test_depth_probe_query_is_bounded(self) -> None:
         create_payloads(PARALLEL_DRAIN_THRESHOLD + 5, "github:123")

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -1255,9 +1255,6 @@ class PushTriggerTest(TestCase):
 
         maybe_trigger_drain("github:123")
 
-        # A mailbox this deep is behind. The sequential drain would hold the lock —
-        # and so keep the scheduler out — for a full batch window at one request
-        # at a time.
         mock_drain_parallel.delay.assert_called_once_with(records[0].id, mailbox_name="github:123")
         mock_drain.delay.assert_not_called()
 
@@ -1271,7 +1268,7 @@ class PushTriggerTest(TestCase):
 
         maybe_trigger_drain("github:123")
 
-        # One record short of the threshold keeps strict ordering.
+        # One short of the threshold keeps strict ordering.
         mock_drain.delay.assert_called_once_with(records[0].id, mailbox_name="github:123")
         mock_drain_parallel.delay.assert_not_called()
 
@@ -1286,8 +1283,7 @@ class PushTriggerTest(TestCase):
         maybe_trigger_drain("github:123")
         maybe_trigger_drain("github:123")
 
-        # Only one drain per mailbox may be in flight, regardless of which drain
-        # the depth check selects.
+        # One drain per mailbox, whichever drain the depth check selects.
         assert mock_drain_parallel.delay.call_count == 1
         assert mock_drain.delay.call_count == 0
 
@@ -1321,8 +1317,7 @@ class PushTriggerTest(TestCase):
         webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
         cache.add(f"wh:drain_active:{webhook.mailbox_name}", 1, timeout=15)
 
-        # Scheduler-triggered drains pass no mailbox_name and must not release a lock
-        # that a concurrent push-triggered drain owns.
+        # No mailbox_name: must not release a lock a concurrent push-triggered drain owns.
         drain_mailbox_parallel(webhook.id)
 
         assert cache.get(f"wh:drain_active:{webhook.mailbox_name}") == 1

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, PropertyMock, patch
 import orjson
 import pytest
 import responses
+from django.core.cache import cache
 from django.utils import timezone
 from requests.exceptions import ConnectionError, ReadTimeout
 
@@ -13,6 +14,7 @@ from sentry.hybridcloud.models.webhookpayload import MAX_ATTEMPTS, WebhookPayloa
 from sentry.hybridcloud.tasks import deliver_webhooks
 from sentry.hybridcloud.tasks.deliver_webhooks import (
     MAX_MAILBOX_DRAIN,
+    PARALLEL_DRAIN_THRESHOLD,
     SLOW_DELIVERY_THRESHOLD,
     drain_mailbox,
     drain_mailbox_parallel,
@@ -1231,8 +1233,6 @@ class PushTriggerTest(TestCase):
 
     @override_options({"hybridcloud.webhookpayload.push_drain_trigger": True})
     def test_drain_releases_lock_on_replica_doesnotexist(self) -> None:
-        from django.core.cache import cache
-
         mailbox = "github:123"
         # Simulate the lock held by maybe_trigger_drain
         cache.add(f"wh:drain_active:{mailbox}", 1, timeout=15)
@@ -1243,4 +1243,112 @@ class PushTriggerTest(TestCase):
         drain_mailbox(999999, mailbox_name=mailbox)
 
         # Lock must be released so new webhooks and the scheduler can reach this mailbox
+        assert cache.get(f"wh:drain_active:{mailbox}") is None
+
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox_parallel")
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    @override_options({"hybridcloud.webhookpayload.push_drain_trigger": True})
+    def test_push_trigger_uses_parallel_drain_for_deep_mailbox(
+        self, mock_drain: MagicMock, mock_drain_parallel: MagicMock
+    ) -> None:
+        records = create_payloads(PARALLEL_DRAIN_THRESHOLD, "github:123")
+
+        maybe_trigger_drain("github:123")
+
+        # A mailbox this deep is behind. The sequential drain would hold the lock —
+        # and so keep the scheduler out — for a full batch window at one request
+        # at a time.
+        mock_drain_parallel.delay.assert_called_once_with(records[0].id, mailbox_name="github:123")
+        mock_drain.delay.assert_not_called()
+
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox_parallel")
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    @override_options({"hybridcloud.webhookpayload.push_drain_trigger": True})
+    def test_push_trigger_uses_sequential_drain_for_shallow_mailbox(
+        self, mock_drain: MagicMock, mock_drain_parallel: MagicMock
+    ) -> None:
+        records = create_payloads(PARALLEL_DRAIN_THRESHOLD - 1, "github:123")
+
+        maybe_trigger_drain("github:123")
+
+        # One record short of the threshold keeps strict ordering.
+        mock_drain.delay.assert_called_once_with(records[0].id, mailbox_name="github:123")
+        mock_drain_parallel.delay.assert_not_called()
+
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox_parallel")
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    @override_options({"hybridcloud.webhookpayload.push_drain_trigger": True})
+    def test_push_trigger_deduplicates_deep_mailbox(
+        self, mock_drain: MagicMock, mock_drain_parallel: MagicMock
+    ) -> None:
+        create_payloads(PARALLEL_DRAIN_THRESHOLD, "github:123")
+
+        maybe_trigger_drain("github:123")
+        maybe_trigger_drain("github:123")
+
+        # Only one drain per mailbox may be in flight, regardless of which drain
+        # the depth check selects.
+        assert mock_drain_parallel.delay.call_count == 1
+        assert mock_drain.delay.call_count == 0
+
+    @responses.activate
+    @override_cells(cell_config)
+    @override_options({"hybridcloud.webhookpayload.push_drain_trigger": True})
+    def test_parallel_drain_clears_lock_when_push_triggered(self) -> None:
+        responses.add(
+            responses.POST,
+            "http://us.testserver/extensions/github/webhook/",
+            status=200,
+            body="",
+        )
+        webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
+        cache.add(f"wh:drain_active:{webhook.mailbox_name}", 1, timeout=15)
+
+        drain_mailbox_parallel(webhook.id, mailbox_name=webhook.mailbox_name)
+
+        assert cache.get(f"wh:drain_active:{webhook.mailbox_name}") is None
+
+    @responses.activate
+    @override_cells(cell_config)
+    @override_options({"hybridcloud.webhookpayload.push_drain_trigger": True})
+    def test_parallel_drain_keeps_lock_when_scheduler_triggered(self) -> None:
+        responses.add(
+            responses.POST,
+            "http://us.testserver/extensions/github/webhook/",
+            status=200,
+            body="",
+        )
+        webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
+        cache.add(f"wh:drain_active:{webhook.mailbox_name}", 1, timeout=15)
+
+        # Scheduler-triggered drains pass no mailbox_name and must not release a lock
+        # that a concurrent push-triggered drain owns.
+        drain_mailbox_parallel(webhook.id)
+
+        assert cache.get(f"wh:drain_active:{webhook.mailbox_name}") == 1
+
+    @responses.activate
+    @override_cells(cell_config)
+    @override_options({"hybridcloud.webhookpayload.push_drain_trigger": True})
+    def test_sequential_drain_keeps_lock_when_scheduler_triggered(self) -> None:
+        responses.add(
+            responses.POST,
+            "http://us.testserver/extensions/github/webhook/",
+            status=200,
+            body="",
+        )
+        webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
+        cache.add(f"wh:drain_active:{webhook.mailbox_name}", 1, timeout=15)
+
+        drain_mailbox(webhook.id)
+
+        assert cache.get(f"wh:drain_active:{webhook.mailbox_name}") == 1
+
+    @override_options({"hybridcloud.webhookpayload.push_drain_trigger": True})
+    def test_parallel_drain_releases_lock_on_doesnotexist(self) -> None:
+        mailbox = "github:123"
+        cache.add(f"wh:drain_active:{mailbox}", 1, timeout=15)
+
+        drain_mailbox_parallel(999999, mailbox_name=mailbox)
+
         assert cache.get(f"wh:drain_active:{mailbox}") is None


### PR DESCRIPTION
`maybe_trigger_drain` always dispatched the sequential `drain_mailbox`, so push-triggered drains delivered one webhook at a time however far behind the mailbox was. It now picks parallel vs sequential using the same depth threshold as the scheduler, via a count capped at that threshold — an index-only scan whose cost is the same on a 60-row mailbox as on a 1M-row one.

The dispatch choice was sticky because the drain refreshes the trigger's cache lock on every record it delivers, holding it for the whole run (up to 3 minutes), and `schedule_webhook_delivery` skips any mailbox holding that lock. So the scheduler never got to upgrade the mailbox to the parallel drain. The trigger fires on every webhook to an idle mailbox, so the busier a mailbox was, the more reliably it stayed pinned to the slow path.

**Throughput: 1 vs 16.** Sequential delivery keeps one request in flight; `drain_mailbox_parallel` runs `hybridcloud.webhookpayload.worker_threads` concurrent requests, which is 16 in production.

**Evidence.** One GitHub `check_run` mailbox holds \~1.35M undelivered rows with its oldest at exactly `MAX_DELIVERY_AGE`, discarding \~1.5M payloads/week on age at a \~99.99% delivery success rate — it is not failing, it is under-drained. Over 7 days it logged 1,336 `deliver_webhook.delivery_deadline` (sequential) against 648 `deliver_webhook_parallel.delivery_deadline`. A mailbox that deep always clears the scheduler's `>= 60` threshold, so those 1,336 sequential drains can only have come from the push trigger: two thirds of the drain-minutes on our most backed-up mailbox ran at 1/16th speed.

**Why the scheduler's lock skip is untouched.** Letting the scheduler dispatch a parallel drain into a mailbox that already holds a sequential drain's lock needs lock-upgrade semantics — the running drain would have to notice it has been superseded and bail mid-flight. That is racy and puts the one-drain-per-mailbox invariant at risk. Fixing the dispatch choice at the source means a hot mailbox's lock is held by a parallel drain, so the skip becomes correct rather than harmful.

One behavioural consequence worth flagging: `_discard_stale_mailbox_payloads` only runs in the parallel drain, so deep push-triggered mailboxes now also expunge rows older than `MAX_DELIVERY_AGE`.

Part of [CW-1830](https://linear.app/getsentry/issue/CW-1830)