### PR TITLE
fix(seer): Restrict chat continuations to run owners

### DIFF
--- a/src/sentry/seer/endpoints/organization_seer_agent_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_agent_chat.py
@@ -26,7 +26,7 @@ from sentry.seer.agent.client_utils import (
     has_seer_agent_access_with_detail,
     snapshot_to_markdown,
 )
-from sentry.seer.endpoints.utils import resolve_seer_run
+from sentry.seer.endpoints.utils import ResolvedSeerRun, resolve_seer_run
 from sentry.seer.models import SeerApiError, SeerPermissionError
 from sentry.seer.seer_setup import has_seer_access_with_detail
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
@@ -267,6 +267,14 @@ class OrganizationSeerAgentChatEndpoint(OrganizationEndpoint):
                     on_page_context = snapshot_to_markdown(snapshot)
             except (json.JSONDecodeError, TypeError, AttributeError):
                 pass
+        resolved: ResolvedSeerRun | None = None
+        if run_id:
+            result = resolve_seer_run(
+                run_id, organization, for_continue=True, user_id=request.user.id
+            )
+            if isinstance(result, Response):
+                return result
+            resolved = result
 
         try:
             enable_coding = organization.get_option(
@@ -294,10 +302,7 @@ class OrganizationSeerAgentChatEndpoint(OrganizationEndpoint):
                 enable_code_mode_tools=enable_code_mode_tools,
                 reasoning_effort="medium",
             )
-            if run_id:
-                resolved = resolve_seer_run(run_id, organization, for_continue=True)
-                if isinstance(resolved, Response):
-                    return resolved
+            if resolved is not None:
                 # Continue existing conversation
                 client.continue_run(
                     run_id=resolved.seer_run_state_id,

--- a/src/sentry/seer/endpoints/organization_seer_agent_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_agent_chat.py
@@ -269,9 +269,10 @@ class OrganizationSeerAgentChatEndpoint(OrganizationEndpoint):
                 pass
         resolved: ResolvedSeerRun | None = None
         if run_id:
-            result = resolve_seer_run(
-                run_id, organization, for_continue=True, user_id=request.user.id
-            )
+            user_id = request.user.id
+            if user_id is None:
+                raise PermissionDenied("A user account is required to continue a conversation.")
+            result = resolve_seer_run(run_id, organization, for_continue=True, user_id=user_id)
             if isinstance(result, Response):
                 return result
             resolved = result

--- a/src/sentry/seer/endpoints/utils.py
+++ b/src/sentry/seer/endpoints/utils.py
@@ -14,13 +14,6 @@ if TYPE_CHECKING:
     from sentry.models.organization import Organization
 
 
-class _UnsetUserId:
-    pass
-
-
-_UNSET_USER_ID = _UnsetUserId()
-
-
 class ResolvedSeerRun(NamedTuple):
     seer_run_state_id: int
     # None for legacy runs created before SeerRun mirroring, which have no row.
@@ -40,14 +33,14 @@ def resolve_seer_run(
     organization: Organization,
     *,
     for_continue: bool = False,
-    user_id: int | None | _UnsetUserId = _UNSET_USER_ID,
+    user_id: int | None = None,
 ) -> ResolvedSeerRun | Response:
     """Resolve a client-facing run id (numeric ``seer_run_state_id`` or
     ``SeerRun.uuid``) to a :class:`ResolvedSeerRun`, or an error ``Response``
     (narrow with ``isinstance``). When ``user_id`` is supplied, the mirrored run
-    must belong to that user; omitting it keeps resolution organization-scoped.
-    For a not-ready run, a poll gets the 200 ``{"session": {"status": ...}}``
-    shape; ``for_continue`` instead gets 409 (still mirroring) or 422 (mirror failed).
+    must belong to that user. For a not-ready run, a poll gets the 200
+    ``{"session": {"status": ...}}`` shape; ``for_continue`` instead gets 409
+    (still mirroring) or 422 (mirror failed).
     """
     try:
         seer_run_state_id = int(run_id)
@@ -58,9 +51,7 @@ def resolve_seer_run(
         if not validate_bigint(seer_run_state_id):
             return Response({"detail": "Invalid run_id"}, status=status.HTTP_400_BAD_REQUEST)
         run = get_seer_run(seer_run_state_id, organization)
-        if not isinstance(user_id, _UnsetUserId) and (
-            user_id is None or run is None or run.user_id != user_id
-        ):
+        if user_id is not None and (run is None or run.user_id != user_id):
             return Response(
                 {"detail": "This conversation belongs to another user and is read-only."},
                 status=status.HTTP_403_FORBIDDEN,
@@ -75,7 +66,7 @@ def resolve_seer_run(
     run = SeerRun.objects.filter(uuid=run_uuid, organization=organization).first()
     if run is None:
         return Response({"session": None}, status=status.HTTP_404_NOT_FOUND)
-    if not isinstance(user_id, _UnsetUserId) and (user_id is None or run.user_id != user_id):
+    if user_id is not None and run.user_id != user_id:
         return Response(
             {"detail": "This conversation belongs to another user and is read-only."},
             status=status.HTTP_403_FORBIDDEN,

--- a/src/sentry/seer/endpoints/utils.py
+++ b/src/sentry/seer/endpoints/utils.py
@@ -14,6 +14,13 @@ if TYPE_CHECKING:
     from sentry.models.organization import Organization
 
 
+class _UnsetUserId:
+    pass
+
+
+_UNSET_USER_ID = _UnsetUserId()
+
+
 class ResolvedSeerRun(NamedTuple):
     seer_run_state_id: int
     # None for legacy runs created before SeerRun mirroring, which have no row.
@@ -33,12 +40,14 @@ def resolve_seer_run(
     organization: Organization,
     *,
     for_continue: bool = False,
+    user_id: int | None | _UnsetUserId = _UNSET_USER_ID,
 ) -> ResolvedSeerRun | Response:
     """Resolve a client-facing run id (numeric ``seer_run_state_id`` or
     ``SeerRun.uuid``) to a :class:`ResolvedSeerRun`, or an error ``Response``
-    (narrow with ``isinstance``). For a not-ready run, a poll gets the 200
-    ``{"session": {"status": ...}}`` shape; ``for_continue`` instead gets 409
-    (still mirroring) or 422 (mirror failed).
+    (narrow with ``isinstance``). When ``user_id`` is supplied, the mirrored run
+    must belong to that user; omitting it keeps resolution organization-scoped.
+    For a not-ready run, a poll gets the 200 ``{"session": {"status": ...}}``
+    shape; ``for_continue`` instead gets 409 (still mirroring) or 422 (mirror failed).
     """
     try:
         seer_run_state_id = int(run_id)
@@ -49,6 +58,13 @@ def resolve_seer_run(
         if not validate_bigint(seer_run_state_id):
             return Response({"detail": "Invalid run_id"}, status=status.HTTP_400_BAD_REQUEST)
         run = get_seer_run(seer_run_state_id, organization)
+        if not isinstance(user_id, _UnsetUserId) and (
+            user_id is None or run is None or run.user_id != user_id
+        ):
+            return Response(
+                {"detail": "This conversation belongs to another user and is read-only."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
         return ResolvedSeerRun(seer_run_state_id, str(run.uuid) if run else None)
 
     try:
@@ -59,6 +75,11 @@ def resolve_seer_run(
     run = SeerRun.objects.filter(uuid=run_uuid, organization=organization).first()
     if run is None:
         return Response({"session": None}, status=status.HTTP_404_NOT_FOUND)
+    if not isinstance(user_id, _UnsetUserId) and (user_id is None or run.user_id != user_id):
+        return Response(
+            {"detail": "This conversation belongs to another user and is read-only."},
+            status=status.HTTP_403_FORBIDDEN,
+        )
     if run.mirror_status == SeerRunMirrorStatus.FAILED:
         if for_continue:
             return Response(

--- a/tests/sentry/seer/endpoints/test_organization_seer_agent_chat.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_agent_chat.py
@@ -164,6 +164,9 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
 
     @patch("sentry.seer.endpoints.organization_seer_agent_chat.SeerAgentClient")
     def test_post_continue_conversation_calls_client(self, mock_client_class: MagicMock) -> None:
+        run = self.create_seer_run(
+            organization=self.organization, seer_run_state_id=789, user_id=self.user.id
+        )
         mock_client = MagicMock()
         mock_client.continue_run.return_value = 789
         mock_client_class.return_value = mock_client
@@ -172,10 +175,10 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
             "query": "Follow up question",
             "insert_index": 2,
         }
-        response = self.client.post(f"{self.url}789/", data, format="json")
+        response = self.client.post(f"{self.url}{run.seer_run_state_id}/", data, format="json")
 
         assert response.status_code == 200
-        assert response.data == {"run_id": 789, "sentry_run_id": None}
+        assert response.data == {"run_id": 789, "sentry_run_id": str(run.uuid)}
         mock_client_class.assert_called_once_with(
             self.organization,
             ANY,
@@ -216,6 +219,30 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
         mock_client.get_run.assert_called_once_with(run_id=555)
 
     @patch("sentry.seer.endpoints.organization_seer_agent_chat.SeerAgentClient")
+    def test_get_allows_reading_another_users_conversation(
+        self, mock_client_class: MagicMock
+    ) -> None:
+        run = self.create_seer_run(
+            organization=self.organization, seer_run_state_id=555, user_id=self.user.id
+        )
+        member = self.create_user()
+        self.create_member(user=member, organization=self.organization, role="member")
+        self.login_as(user=member)
+        mock_client = MagicMock()
+        mock_client.get_run.return_value = SeerRunState(
+            run_id=555,
+            blocks=[],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+        )
+        mock_client_class.return_value = mock_client
+
+        response = self.client.get(f"{self.url}{run.uuid}/")
+
+        assert response.status_code == 200
+        mock_client.get_run.assert_called_once_with(run_id=555)
+
+    @patch("sentry.seer.endpoints.organization_seer_agent_chat.SeerAgentClient")
     def test_get_with_unknown_uuid_returns_null_session(self, mock_client_class: MagicMock) -> None:
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
@@ -243,7 +270,9 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
 
     @patch("sentry.seer.endpoints.organization_seer_agent_chat.SeerAgentClient")
     def test_post_continue_with_uuid_resolves(self, mock_client_class: MagicMock) -> None:
-        run = self.create_seer_run(organization=self.organization, seer_run_state_id=555)
+        run = self.create_seer_run(
+            organization=self.organization, seer_run_state_id=555, user_id=self.user.id
+        )
         mock_client = MagicMock()
         mock_client.continue_run.return_value = 555
         mock_client_class.return_value = mock_client
@@ -253,6 +282,27 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
         assert response.status_code == 200
         assert response.data == {"run_id": 555, "sentry_run_id": str(run.uuid)}
         assert mock_client.continue_run.call_args.kwargs["run_id"] == 555
+
+    @patch("sentry.seer.endpoints.organization_seer_agent_chat.SeerAgentClient")
+    def test_post_continuing_another_users_conversation_is_denied(
+        self, mock_client_class: MagicMock
+    ) -> None:
+        run = self.create_seer_run(
+            organization=self.organization, seer_run_state_id=555, user_id=self.user.id
+        )
+        member = self.create_user()
+        self.create_member(user=member, organization=self.organization, role="member")
+        self.login_as(user=member)
+
+        response = self.client.post(
+            f"{self.url}{run.seer_run_state_id}/", {"query": "More"}, format="json"
+        )
+
+        assert response.status_code == 403
+        assert response.data == {
+            "detail": "This conversation belongs to another user and is read-only."
+        }
+        mock_client_class.assert_not_called()
 
     @patch("sentry.seer.endpoints.organization_seer_agent_chat.SeerAgentClient")
     def test_post_continue_with_unknown_uuid_returns_404(
@@ -281,6 +331,9 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
 
     @patch("sentry.seer.endpoints.organization_seer_agent_chat.SeerAgentClient")
     def test_post_continue_conversation_enable_coding(self, mock_client_class: MagicMock) -> None:
+        run = self.create_seer_run(
+            organization=self.organization, seer_run_state_id=789, user_id=self.user.id
+        )
         for i, (feature_enabled, option_enabled) in enumerate(
             [(True, True), (True, False), (False, True), (False, False)]
         ):
@@ -291,7 +344,9 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
             data = {"query": "Follow up question", "insert_index": 2}
             self.organization.update_option("sentry:enable_seer_coding", option_enabled)
             with self.feature({"organizations:seer-explorer-chat-coding": feature_enabled}):
-                response = self.client.post(f"{self.url}789/", data, format="json")
+                response = self.client.post(
+                    f"{self.url}{run.seer_run_state_id}/", data, format="json"
+                )
 
             assert response.status_code == 200
             assert mock_client_class.call_count == i + 1
@@ -331,16 +386,19 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
         self, mock_client_class: MagicMock
     ) -> None:
         """POST with run_id should succeed for orgs with Seer access even without seer-explorer."""
+        run = self.create_seer_run(
+            organization=self.organization, seer_run_state_id=789, user_id=self.user.id
+        )
         mock_client = MagicMock()
         mock_client.continue_run.return_value = 789
         mock_client_class.return_value = mock_client
 
         data = {"query": "Follow up question"}
         with self.feature({"organizations:seer-explorer": False}):
-            response = self.client.post(f"{self.url}789/", data, format="json")
+            response = self.client.post(f"{self.url}{run.seer_run_state_id}/", data, format="json")
 
         assert response.status_code == 200
-        assert response.data == {"run_id": 789, "sentry_run_id": None}
+        assert response.data == {"run_id": 789, "sentry_run_id": str(run.uuid)}
 
     def test_new_run_denied_without_seer_explorer_flag(self) -> None:
         """POST without run_id should be denied for orgs without seer-explorer, even with Seer access."""

--- a/tests/sentry/seer/endpoints/test_organization_seer_agent_chat.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_agent_chat.py
@@ -16,6 +16,7 @@ from sentry.seer.models.run import SeerAgentRun, SeerRun, SeerRunMirrorStatus, S
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.utils import json
+from sentry.utils.security.orgauthtoken_token import generate_token, hash_token
 
 
 @with_feature("organizations:seer-explorer")
@@ -302,6 +303,32 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
         assert response.data == {
             "detail": "This conversation belongs to another user and is read-only."
         }
+        mock_client_class.assert_not_called()
+
+    @patch("sentry.seer.endpoints.organization_seer_agent_chat.SeerAgentClient")
+    def test_post_continue_with_org_auth_token_is_denied(
+        self, mock_client_class: MagicMock
+    ) -> None:
+        run = self.create_seer_run(
+            organization=self.organization, seer_run_state_id=555, user_id=self.user.id
+        )
+        token = generate_token(self.organization.slug, "")
+        self.create_org_auth_token(
+            name="org-auth-token",
+            token_hashed=hash_token(token),
+            organization_id=self.organization.id,
+            scope_list=["org:read"],
+        )
+
+        response = self.client.post(
+            f"{self.url}{run.seer_run_state_id}/",
+            {"query": "More"},
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        assert response.status_code == 403
+        assert response.data == {"detail": "A user account is required to continue a conversation."}
         mock_client_class.assert_not_called()
 
     @patch("sentry.seer.endpoints.organization_seer_agent_chat.SeerAgentClient")

--- a/tests/sentry/seer/endpoints/test_utils.py
+++ b/tests/sentry/seer/endpoints/test_utils.py
@@ -84,21 +84,6 @@ class ResolveSeerRunTest(TestCase):
             "detail": "This conversation belongs to another user and is read-only."
         }
 
-    def test_user_scope_rejects_userless_numeric_run(self) -> None:
-        run = self.create_seer_run(
-            organization=self.organization, seer_run_state_id=555, user_id=self.user.id
-        )
-
-        result = resolve_seer_run(
-            str(run.seer_run_state_id), self.organization, for_continue=True, user_id=None
-        )
-
-        assert isinstance(result, Response)
-        assert result.status_code == status.HTTP_403_FORBIDDEN
-        assert result.data == {
-            "detail": "This conversation belongs to another user and is read-only."
-        }
-
     def test_uuid_with_failed_mirror_returns_error_session(self) -> None:
         run = self.create_seer_run(
             organization=self.organization,

--- a/tests/sentry/seer/endpoints/test_utils.py
+++ b/tests/sentry/seer/endpoints/test_utils.py
@@ -52,6 +52,53 @@ class ResolveSeerRunTest(TestCase):
 
         assert result == ResolvedSeerRun(555, str(run.uuid))
 
+    def test_user_scope_rejects_another_users_numeric_run(self) -> None:
+        run = self.create_seer_run(
+            organization=self.organization, seer_run_state_id=555, user_id=self.user.id
+        )
+        other_user = self.create_user()
+
+        result = resolve_seer_run(
+            str(run.seer_run_state_id), self.organization, for_continue=True, user_id=other_user.id
+        )
+
+        assert isinstance(result, Response)
+        assert result.status_code == status.HTTP_403_FORBIDDEN
+        assert result.data == {
+            "detail": "This conversation belongs to another user and is read-only."
+        }
+
+    def test_user_scope_rejects_another_users_uuid_run(self) -> None:
+        run = self.create_seer_run(
+            organization=self.organization, seer_run_state_id=555, user_id=self.user.id
+        )
+        other_user = self.create_user()
+
+        result = resolve_seer_run(
+            str(run.uuid), self.organization, for_continue=True, user_id=other_user.id
+        )
+
+        assert isinstance(result, Response)
+        assert result.status_code == status.HTTP_403_FORBIDDEN
+        assert result.data == {
+            "detail": "This conversation belongs to another user and is read-only."
+        }
+
+    def test_user_scope_rejects_userless_numeric_run(self) -> None:
+        run = self.create_seer_run(
+            organization=self.organization, seer_run_state_id=555, user_id=self.user.id
+        )
+
+        result = resolve_seer_run(
+            str(run.seer_run_state_id), self.organization, for_continue=True, user_id=None
+        )
+
+        assert isinstance(result, Response)
+        assert result.status_code == status.HTTP_403_FORBIDDEN
+        assert result.data == {
+            "detail": "This conversation belongs to another user and is read-only."
+        }
+
     def test_uuid_with_failed_mirror_returns_error_session(self) -> None:
         run = self.create_seer_run(
             organization=self.organization,


### PR DESCRIPTION
Explorer conversations remain readable to organization members, but only the user who started a conversation can append to it.

The chat endpoint now resolves the mirrored run owner before dispatching to Seer and rejects non-owner continuations. Server-side continuations are unchanged because they do not use this endpoint.

Refs VULN-2165
