### PR TITLE
fix(preprod): Stop size comments and status checks hanging on filtered artifacts

### DIFF
--- a/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
@@ -28,6 +28,7 @@ from sentry.preprod.models import (
     PreprodArtifactSizeMetrics,
 )
 from sentry.preprod.quotas import PreprodFeature, should_run_distribution, should_run_size
+from sentry.preprod.vcs.pr_comments.size_tasks import create_preprod_size_pr_comment_task
 from sentry.preprod.vcs.status_checks.size.tasks import create_preprod_status_check_task
 
 logger = logging.getLogger(__name__)
@@ -394,13 +395,6 @@ class ProjectPreprodArtifactUpdateEndpoint(PreprodArtifactEndpoint):
                 },
             )
 
-            create_preprod_status_check_task.apply_async(
-                kwargs={
-                    "preprod_artifact_id": artifact_id_int,
-                    "caller": "artifact_update_endpoint",
-                }
-            )
-
         mobile_app_info = head_artifact.get_mobile_app_info()
         build_version = mobile_app_info.build_version if mobile_app_info else None
         build_number = mobile_app_info.build_number if mobile_app_info else None
@@ -468,6 +462,35 @@ class ProjectPreprodArtifactUpdateEndpoint(PreprodArtifactEndpoint):
                     "error_code": error_code,
                     "error_message": error_message,
                 },
+            )
+
+            # The summary can only account for this artifact once the metrics row
+            # above exists, and that happens after the comment for a sibling
+            # artifact may already have been created. Re-render so the comment
+            # stops showing it as perpetually processing: SKIPPED drops the
+            # artifact from the table, NO_QUOTA switches the summary to the quota
+            # message.
+            #
+            # Without a commit comparison there is no PR to comment on, and this
+            # branch runs on every upload for projects that filter size analysis,
+            # so gate rather than enqueue a task that can only no-op.
+            if head_artifact.commit_comparison_id:
+                create_preprod_size_pr_comment_task.apply_async(
+                    kwargs={
+                        "preprod_artifact_id": head_artifact.id,
+                        "caller": "artifact_update_endpoint_size_skipped",
+                    }
+                )
+
+        # Dispatch after the size filter has settled this artifact's metrics row:
+        # a filtered artifact whose row is still unwritten reads as unfinished, and
+        # nothing re-runs the check once the row lands, so it stays in progress.
+        if updated_fields:
+            create_preprod_status_check_task.apply_async(
+                kwargs={
+                    "preprod_artifact_id": artifact_id_int,
+                    "caller": "artifact_update_endpoint",
+                }
             )
 
         can_run_distro, distro_skip_reason = should_run_distribution(head_artifact)

--- a/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
@@ -476,13 +476,22 @@ class ProjectPreprodArtifactUpdateEndpoint(PreprodArtifactEndpoint):
             # artifact may already have been created. Re-render so the comment
             # stops showing it as perpetually processing: SKIPPED drops the
             # artifact from the table, NO_QUOTA switches the summary to the quota
-            # message. The status check gets the same treatment above.
-            create_preprod_size_pr_comment_task.apply_async(
-                kwargs={
-                    "preprod_artifact_id": head_artifact.id,
-                    "caller": "artifact_update_endpoint_size_skipped",
-                }
-            )
+            # message.
+            #
+            # The status check needs no equivalent dispatch: it already gets one
+            # above, though that happens before this row is written and so relies
+            # on task pickup latency to observe it.
+            #
+            # Without a commit comparison there is no PR to comment on, and this
+            # branch runs on every upload for projects that filter size analysis,
+            # so gate rather than enqueue a task that can only no-op.
+            if head_artifact.commit_comparison_id:
+                create_preprod_size_pr_comment_task.apply_async(
+                    kwargs={
+                        "preprod_artifact_id": head_artifact.id,
+                        "caller": "artifact_update_endpoint_size_skipped",
+                    }
+                )
 
         can_run_distro, distro_skip_reason = should_run_distribution(head_artifact)
         if can_run_distro:

--- a/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
@@ -28,6 +28,7 @@ from sentry.preprod.models import (
     PreprodArtifactSizeMetrics,
 )
 from sentry.preprod.quotas import PreprodFeature, should_run_distribution, should_run_size
+from sentry.preprod.vcs.pr_comments.size_tasks import create_preprod_size_pr_comment_task
 from sentry.preprod.vcs.status_checks.size.tasks import create_preprod_status_check_task
 
 logger = logging.getLogger(__name__)
@@ -468,6 +469,19 @@ class ProjectPreprodArtifactUpdateEndpoint(PreprodArtifactEndpoint):
                     "error_code": error_code,
                     "error_message": error_message,
                 },
+            )
+
+            # The summary can only account for this artifact once the metrics row
+            # above exists, and that happens after the comment for a sibling
+            # artifact may already have been created. Re-render so the comment
+            # stops showing it as perpetually processing: SKIPPED drops the
+            # artifact from the table, NO_QUOTA switches the summary to the quota
+            # message. The status check gets the same treatment above.
+            create_preprod_size_pr_comment_task.apply_async(
+                kwargs={
+                    "preprod_artifact_id": head_artifact.id,
+                    "caller": "artifact_update_endpoint_size_skipped",
+                }
             )
 
         can_run_distro, distro_skip_reason = should_run_distribution(head_artifact)

--- a/src/sentry/preprod/vcs/pr_comments/size_tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/size_tasks.py
@@ -67,16 +67,6 @@ def create_preprod_size_pr_comment_task(
     rules = get_status_check_rules(artifact.project, option_key=RULES_OPTION_KEY)
     evaluation = evaluate_size_and_format_messages(artifact.project, all_artifacts, rules)
 
-    # Unlike the status check (which posts a neutral "skipped" check regardless),
-    # a comment should only exist when there is size data to report. No evaluated
-    # artifacts means every sibling was skipped or had no size metrics.
-    if not evaluation.evaluated_artifacts:
-        logger.info(
-            "preprod.size_pr_comments.create.no_size_data",
-            extra={"preprod_artifact_id": artifact.id},
-        )
-        return
-
     triggered_rules = evaluation.triggered_rules
     comment_body = format_size_pr_comment(evaluation.title, evaluation.subtitle, evaluation.summary)
 
@@ -91,6 +81,19 @@ def create_preprod_size_pr_comment_task(
                 target_id=commit_comparison.id,
                 comment_type=COMMENT_TYPE,
             )
+
+            # Unlike the status check (which posts a neutral "skipped" check
+            # regardless), a comment should only be created when there is size data
+            # to report. No evaluated artifacts means every sibling was skipped or
+            # had no size metrics. An existing comment is still updated with the
+            # skipped summary, otherwise it keeps whatever it last said - e.g. a
+            # sibling rendered as processing before it was marked skipped.
+            if not existing_comment_id and not evaluation.evaluated_artifacts:
+                logger.info(
+                    "preprod.size_pr_comments.create.no_size_data",
+                    extra={"preprod_artifact_id": artifact.id},
+                )
+                return
 
             # The trigger check gates first creation only; once a comment exists it is
             # always updated to reflect current state. With no rules configured, post a

--- a/src/sentry/preprod/vcs/pr_comments/size_tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/size_tasks.py
@@ -10,6 +10,7 @@ from sentry.models.commitcomparison import CommitComparison
 from sentry.preprod.integration_utils import get_commit_context_client
 from sentry.preprod.vcs.pr_comments.size_templates import format_size_pr_comment
 from sentry.preprod.vcs.pr_comments.tasks import (
+    get_comment_id_for_comparison,
     lock_pr_comparisons_for_update,
     resolve_pr_comment_context,
     save_pr_comment_result,
@@ -59,17 +60,6 @@ def create_preprod_size_pr_comment_task(
         )
         return
 
-    # Compute rules, triggered rules, and the comment body BEFORE taking the lock
-    # so the (DB-heavy) size evaluation stays out of the locked transaction that
-    # holds the GitHub call. Only find-existing -> gate -> post -> save run under
-    # the lock.
-    all_artifacts = list(artifact.get_sibling_artifacts_for_commit())
-    rules = get_status_check_rules(artifact.project, option_key=RULES_OPTION_KEY)
-    evaluation = evaluate_size_and_format_messages(artifact.project, all_artifacts, rules)
-
-    triggered_rules = evaluation.triggered_rules
-    comment_body = format_size_pr_comment(evaluation.title, evaluation.subtitle, evaluation.summary)
-
     api_error: Exception | None = None
 
     try:
@@ -82,18 +72,41 @@ def create_preprod_size_pr_comment_task(
                 comment_type=COMMENT_TYPE,
             )
 
-            # Unlike the status check (which posts a neutral "skipped" check
-            # regardless), a comment should only be created when there is size data
-            # to report. No evaluated artifacts means every sibling was skipped or
-            # had no size metrics. An existing comment is still updated with the
-            # skipped summary, otherwise it keeps whatever it last said - e.g. a
-            # sibling rendered as processing before it was marked skipped.
-            if not existing_comment_id and not evaluation.evaluated_artifacts:
-                logger.info(
-                    "preprod.size_pr_comments.create.no_size_data",
-                    extra={"preprod_artifact_id": artifact.id},
-                )
-                return
+            # Evaluate under the lock. The lock serializes the GitHub writes, so an
+            # evaluation computed before acquiring it can already be stale when it
+            # is posted: a sibling-completion task that read a PENDING metrics row
+            # can block here while the skipped-artifact refresh writes the correct
+            # body, then take the lock and restore "Processing..." permanently.
+            # create_preprod_pr_comment_task formats its body under the lock for the
+            # same reason.
+            all_artifacts = list(artifact.get_sibling_artifacts_for_commit())
+            rules = get_status_check_rules(artifact.project, option_key=RULES_OPTION_KEY)
+            evaluation = evaluate_size_and_format_messages(artifact.project, all_artifacts, rules)
+
+            triggered_rules = evaluation.triggered_rules
+            comment_body = format_size_pr_comment(
+                evaluation.title, evaluation.subtitle, evaluation.summary
+            )
+
+            if not evaluation.evaluated_artifacts:
+                # Unlike the status check (which posts a neutral "skipped" check
+                # regardless), a comment should only be created when there is size
+                # data to report. No evaluated artifacts means every sibling was
+                # skipped or had no size metrics.
+                #
+                # A comment this commit already owns is still refreshed, so a sibling
+                # that rendered as processing before it was marked skipped does not
+                # stay that way for the life of the PR. A comment owned by a
+                # different commit is left alone: artifacts upload one at a time, so
+                # a newer commit whose first artifact is filtered would otherwise
+                # flap the comment to "skipped" before its real build lands.
+                own_comment_id = get_comment_id_for_comparison(cc, COMMENT_TYPE)
+                if not own_comment_id or own_comment_id != existing_comment_id:
+                    logger.info(
+                        "preprod.size_pr_comments.create.no_size_data",
+                        extra={"preprod_artifact_id": artifact.id},
+                    )
+                    return
 
             # The trigger check gates first creation only; once a comment exists it is
             # always updated to reflect current state. With no rules configured, post a

--- a/src/sentry/preprod/vcs/pr_comments/size_tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/size_tasks.py
@@ -8,14 +8,19 @@ from taskbroker_client.retry import Retry
 
 from sentry.models.commitcomparison import CommitComparison
 from sentry.preprod.integration_utils import get_commit_context_client
+from sentry.preprod.models import PreprodArtifact, PreprodArtifactSizeMetrics
 from sentry.preprod.vcs.pr_comments.size_templates import format_size_pr_comment
 from sentry.preprod.vcs.pr_comments.tasks import (
+    get_comment_id_for_comparison,
     lock_pr_comparisons_for_update,
     resolve_pr_comment_context,
     save_pr_comment_result,
 )
 from sentry.preprod.vcs.status_checks.size.rules import get_status_check_rules
-from sentry.preprod.vcs.status_checks.size.tasks import evaluate_size_and_format_messages
+from sentry.preprod.vcs.status_checks.size.tasks import (
+    evaluate_size_and_format_messages,
+    is_artifact_size_skipped,
+)
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
@@ -27,6 +32,28 @@ COMMENT_TYPE = "size"
 
 ENABLED_OPTION_KEY = "sentry:preprod_size_pr_comments_enabled"
 RULES_OPTION_KEY = "sentry:preprod_size_pr_comments_rules"
+
+
+def _commit_has_unskipped_size_metrics(artifact: PreprodArtifact) -> bool:
+    """Whether any artifact on this commit has size metrics that are not skipped.
+
+    ``get_sibling_artifacts_for_commit`` deduplicates by (app_id, artifact_type,
+    build_configuration_id) and resolves the caller's own key to the caller, so a
+    CI retry can substitute the skipped artifact that dispatched this task for the
+    analyzed one that the comment was rendered from. The evaluation then reports no
+    size data for a commit that has some, and refreshing on that would replace a
+    real size table with the all-skipped body. Consult the undeduplicated set,
+    reusing the evaluation's own predicate so the two cannot diverge.
+    """
+    metrics_by_artifact: dict[int, list[PreprodArtifactSizeMetrics]] = {}
+    for metrics in PreprodArtifactSizeMetrics.objects.filter(
+        preprod_artifact__commit_comparison_id=artifact.commit_comparison_id,
+        # Mirrors the organization filter get_sibling_artifacts_for_commit applies.
+        preprod_artifact__project__organization_id=artifact.project.organization_id,
+    ):
+        metrics_by_artifact.setdefault(metrics.preprod_artifact_id, []).append(metrics)
+
+    return any(not is_artifact_size_skipped(rows) for rows in metrics_by_artifact.values())
 
 
 @instrumented_task(
@@ -59,27 +86,6 @@ def create_preprod_size_pr_comment_task(
         )
         return
 
-    # Compute rules, triggered rules, and the comment body BEFORE taking the lock
-    # so the (DB-heavy) size evaluation stays out of the locked transaction that
-    # holds the GitHub call. Only find-existing -> gate -> post -> save run under
-    # the lock.
-    all_artifacts = list(artifact.get_sibling_artifacts_for_commit())
-    rules = get_status_check_rules(artifact.project, option_key=RULES_OPTION_KEY)
-    evaluation = evaluate_size_and_format_messages(artifact.project, all_artifacts, rules)
-
-    # Unlike the status check (which posts a neutral "skipped" check regardless),
-    # a comment should only exist when there is size data to report. No evaluated
-    # artifacts means every sibling was skipped or had no size metrics.
-    if not evaluation.evaluated_artifacts:
-        logger.info(
-            "preprod.size_pr_comments.create.no_size_data",
-            extra={"preprod_artifact_id": artifact.id},
-        )
-        return
-
-    triggered_rules = evaluation.triggered_rules
-    comment_body = format_size_pr_comment(evaluation.title, evaluation.subtitle, evaluation.summary)
-
     api_error: Exception | None = None
 
     try:
@@ -91,6 +97,52 @@ def create_preprod_size_pr_comment_task(
                 target_id=commit_comparison.id,
                 comment_type=COMMENT_TYPE,
             )
+
+            # Evaluate under the lock. The lock serializes the GitHub writes, so an
+            # evaluation computed before acquiring it can already be stale when it
+            # is posted: a sibling-completion task that read a PENDING metrics row
+            # can block here while the skipped-artifact refresh writes the correct
+            # body, then take the lock and restore "Processing..." permanently.
+            # create_preprod_pr_comment_task formats its body under the lock for the
+            # same reason.
+            all_artifacts = list(artifact.get_sibling_artifacts_for_commit())
+            rules = get_status_check_rules(artifact.project, option_key=RULES_OPTION_KEY)
+            evaluation = evaluate_size_and_format_messages(artifact.project, all_artifacts, rules)
+
+            triggered_rules = evaluation.triggered_rules
+            comment_body = format_size_pr_comment(
+                evaluation.title, evaluation.subtitle, evaluation.summary
+            )
+
+            if not evaluation.evaluated_artifacts:
+                # Unlike the status check (which posts a neutral "skipped" check
+                # regardless), a comment should only be created when there is size
+                # data to report. No evaluated artifacts means every sibling was
+                # skipped or had no size metrics.
+                #
+                # A comment this commit already owns is still refreshed, so a sibling
+                # that rendered as processing before it was marked skipped does not
+                # stay that way for the life of the PR. A comment owned by a
+                # different commit is left alone: artifacts upload one at a time, so
+                # a newer commit whose first artifact is filtered would otherwise
+                # flap the comment to "skipped" before its real build lands.
+                own_comment_id = get_comment_id_for_comparison(cc, COMMENT_TYPE)
+                if not own_comment_id or own_comment_id != existing_comment_id:
+                    logger.info(
+                        "preprod.size_pr_comments.create.no_size_data",
+                        extra={"preprod_artifact_id": artifact.id},
+                    )
+                    return
+
+                # An empty evaluation is only authoritative for the deduplicated
+                # sibling list it was computed from, so confirm against the raw set
+                # before overwriting a comment with the all-skipped body.
+                if _commit_has_unskipped_size_metrics(artifact):
+                    logger.info(
+                        "preprod.size_pr_comments.create.no_size_data_but_commit_has_metrics",
+                        extra={"preprod_artifact_id": artifact.id},
+                    )
+                    return
 
             # The trigger check gates first creation only; once a comment exists it is
             # always updated to reflect current state. With no rules configured, post a

--- a/src/sentry/preprod/vcs/pr_comments/tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/tasks.py
@@ -227,15 +227,30 @@ def create_preprod_pr_comment_task(
         raise api_error
 
 
+def get_comment_id_for_comparison(
+    commit_comparison: CommitComparison,
+    comment_type: str,
+) -> str | None:
+    """Return the comment id recorded on this specific comparison, if any.
+
+    Comments are keyed per PR, so a comment may belong to a different commit on
+    the same PR. Callers that need to know whether a given comparison is the one
+    that created the comment should use this rather than
+    ``find_existing_comment_id``, which searches the whole PR.
+    """
+    extras = commit_comparison.extras or {}
+    comment_id = extras.get("pr_comments", {}).get(comment_type, {}).get("comment_id")
+    return str(comment_id) if comment_id else None
+
+
 def find_existing_comment_id(
     comparisons: Sequence[CommitComparison],
     comment_type: str,
 ) -> str | None:
     for cc in comparisons:
-        extras = cc.extras or {}
-        comment_id = extras.get("pr_comments", {}).get(comment_type, {}).get("comment_id")
+        comment_id = get_comment_id_for_comparison(cc, comment_type)
         if comment_id:
-            return str(comment_id)
+            return comment_id
     return None
 
 

--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -162,7 +162,7 @@ def evaluate_size_and_format_messages(
     evaluated_artifacts = [
         a
         for a in evaluated_artifacts
-        if not _is_artifact_size_skipped(size_metrics_map.get(a.id, []))
+        if not is_artifact_size_skipped(size_metrics_map.get(a.id, []))
     ]
 
     triggered_rules: list[TriggeredRule] = []
@@ -429,7 +429,7 @@ def _fetch_base_size_metrics(
     return base_artifact_map, base_metrics_by_artifact
 
 
-def _is_artifact_size_skipped(
+def is_artifact_size_skipped(
     size_metrics_list: list[PreprodArtifactSizeMetrics],
 ) -> bool:
     """Check if artifact should be excluded because size analysis was skipped."""

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_update.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_update.py
@@ -5,8 +5,13 @@ import orjson
 from django.test import override_settings
 
 from sentry.preprod.api.endpoints.project_preprod_artifact_update import find_or_create_release
-from sentry.preprod.models import PreprodArtifact, PreprodArtifactMobileAppInfo
+from sentry.preprod.models import (
+    PreprodArtifact,
+    PreprodArtifactMobileAppInfo,
+    PreprodArtifactSizeMetrics,
+)
 from sentry.preprod.quotas import DISTRIBUTION_ENABLED_QUERY_KEY, SIZE_ENABLED_QUERY_KEY
+from sentry.preprod.vcs.status_checks.size.tasks import evaluate_size_and_format_messages
 from sentry.testutils.auth import generate_service_request_signature
 from sentry.testutils.cases import TestCase
 
@@ -18,6 +23,11 @@ class ProjectPreprodArtifactUpdateEndpointTest(TestCase):
         self.preprod_artifact = self.create_preprod_artifact(
             file_id=self.file.id,
             state=PreprodArtifact.ArtifactState.UPLOADING,
+        )
+
+    def _create_pr_commit_comparison(self):
+        return self.create_commit_comparison(
+            organization=self.organization, provider="github", pr_number=42
         )
 
     def _get_url(self, artifact_id=None):
@@ -590,6 +600,190 @@ class ProjectPreprodArtifactUpdateEndpointTest(TestCase):
         assert "requestedFeatures" in resp_data
         assert "size_analysis" not in resp_data["requestedFeatures"]
         assert "build_distribution" in resp_data["requestedFeatures"]
+
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=["test-secret-key"])
+    @patch(
+        "sentry.preprod.api.endpoints.project_preprod_artifact_update"
+        ".create_preprod_size_pr_comment_task"
+    )
+    def test_update_preprod_artifact_filtered_size_updates_pr_comment(
+        self, mock_pr_comment_task
+    ) -> None:
+        """Test that filtering size analysis re-renders the size PR comment.
+
+        Without this the comment keeps showing the filtered artifact as processing,
+        because it was rendered before the skipped metrics row existed.
+        """
+        self.preprod_artifact.app_id = "com.my.app"
+        self.preprod_artifact.commit_comparison = self._create_pr_commit_comparison()
+        self.preprod_artifact.save()
+
+        self.project.update_option(SIZE_ENABLED_QUERY_KEY, "app_id:com.other.app")
+
+        response = self._make_request({"artifact_type": 1})
+
+        assert response.status_code == 200
+        mock_pr_comment_task.apply_async.assert_called_once_with(
+            kwargs={
+                "preprod_artifact_id": self.preprod_artifact.id,
+                "caller": "artifact_update_endpoint_size_skipped",
+            }
+        )
+
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=["test-secret-key"])
+    @patch(
+        "sentry.preprod.api.endpoints.project_preprod_artifact_update"
+        ".create_preprod_size_pr_comment_task"
+    )
+    def test_update_preprod_artifact_filtered_size_without_pr_does_not_dispatch(
+        self, mock_pr_comment_task
+    ) -> None:
+        """Test that an artifact with no commit comparison enqueues nothing.
+
+        The task can only no-op without a PR, and this branch runs on every upload
+        for projects that filter size analysis.
+        """
+        self.preprod_artifact.app_id = "com.my.app"
+        self.preprod_artifact.save()
+        assert self.preprod_artifact.commit_comparison_id is None
+
+        self.project.update_option(SIZE_ENABLED_QUERY_KEY, "app_id:com.other.app")
+
+        response = self._make_request({"artifact_type": 1})
+
+        assert response.status_code == 200
+        resp_data = response.json()
+        assert "size_analysis" not in resp_data["requestedFeatures"]
+        mock_pr_comment_task.apply_async.assert_not_called()
+
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=["test-secret-key"])
+    @patch(
+        "sentry.preprod.api.endpoints.project_preprod_artifact_update"
+        ".create_preprod_size_pr_comment_task"
+    )
+    def test_update_preprod_artifact_unfiltered_size_does_not_update_pr_comment(
+        self, mock_pr_comment_task
+    ) -> None:
+        """Test that an artifact queued for size analysis does not re-render the comment."""
+        self.preprod_artifact.app_id = "com.my.app"
+        self.preprod_artifact.commit_comparison = self._create_pr_commit_comparison()
+        self.preprod_artifact.save()
+
+        self.project.update_option(SIZE_ENABLED_QUERY_KEY, "app_id:com.my.app")
+
+        response = self._make_request({"artifact_type": 1})
+
+        assert response.status_code == 200
+        mock_pr_comment_task.apply_async.assert_not_called()
+
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=["test-secret-key"])
+    @patch(
+        "sentry.preprod.api.endpoints.project_preprod_artifact_update"
+        ".create_preprod_size_pr_comment_task"
+    )
+    def test_update_preprod_artifact_filtered_size_drops_processing_row(
+        self, mock_pr_comment_task
+    ) -> None:
+        """Test that the re-render drops the filtered artifact from the summary.
+
+        This is the behavior the re-render exists for: a sibling artifact finishes
+        size analysis and the summary is rendered while the to-be-filtered artifact
+        still has a pending metrics row, so it renders as processing. Only after the
+        endpoint stamps that row skipped can it be excluded.
+        """
+        commit_comparison = self._create_pr_commit_comparison()
+
+        analyzed = self.create_preprod_artifact(
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.my.app",
+            commit_comparison=commit_comparison,
+            build_version="1.0.0",
+            build_number=1,
+        )
+        self.create_preprod_artifact_size_metrics(
+            analyzed,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+        )
+
+        self.preprod_artifact.app_id = "com.my.app.universal"
+        self.preprod_artifact.commit_comparison = commit_comparison
+        self.preprod_artifact.save()
+        self.create_preprod_artifact_size_metrics(
+            self.preprod_artifact,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.PENDING,
+        )
+
+        # Resolve siblings the way the comment task does, so the test covers the
+        # real lookup rather than a hand-built list.
+        siblings = analyzed.get_sibling_artifacts_for_commit()
+        assert {a.id for a in siblings} == {analyzed.id, self.preprod_artifact.id}
+
+        before = evaluate_size_and_format_messages(self.project, siblings, [])
+        assert {a.id for a in before.evaluated_artifacts} == {
+            analyzed.id,
+            self.preprod_artifact.id,
+        }
+        # The phantom row the bug leaves behind, identified by app_id rather than
+        # the translated "Processing..." cell so the assertion survives copy changes.
+        assert "com.my.app.universal" in before.summary
+
+        self.project.update_option(SIZE_ENABLED_QUERY_KEY, "app_id:com.my.app")
+
+        response = self._make_request({"artifact_type": 1})
+        assert response.status_code == 200
+        mock_pr_comment_task.apply_async.assert_called_once()
+
+        after = evaluate_size_and_format_messages(self.project, siblings, [])
+        assert [a.id for a in after.evaluated_artifacts] == [analyzed.id]
+        assert "com.my.app.universal" not in after.summary
+
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=["test-secret-key"])
+    @patch(
+        "sentry.preprod.api.endpoints.project_preprod_artifact_update"
+        ".create_preprod_status_check_task"
+    )
+    def test_update_preprod_artifact_dispatches_check_after_size_skip(
+        self, mock_status_check_task
+    ) -> None:
+        """Test that the status check is dispatched after the skipped row is written.
+
+        Dispatching before it lets the check read the filtered artifact as still
+        processing, and nothing re-runs the check once the row lands, so it stays
+        in progress for the life of the pull request.
+        """
+        observed = {}
+
+        def record_row_state(*args, **kwargs):
+            metrics = PreprodArtifactSizeMetrics.objects.get(
+                preprod_artifact=self.preprod_artifact,
+                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            )
+            observed["state"] = metrics.state
+            observed["error_code"] = metrics.error_code
+
+        mock_status_check_task.apply_async.side_effect = record_row_state
+
+        self.preprod_artifact.app_id = "com.my.app.universal"
+        self.preprod_artifact.commit_comparison = self._create_pr_commit_comparison()
+        self.preprod_artifact.save()
+        self.create_preprod_artifact_size_metrics(
+            self.preprod_artifact,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.PENDING,
+        )
+
+        self.project.update_option(SIZE_ENABLED_QUERY_KEY, "app_id:com.my.app")
+
+        response = self._make_request({"artifact_type": 1})
+
+        assert response.status_code == 200
+        mock_status_check_task.apply_async.assert_called_once_with(
+            kwargs={
+                "preprod_artifact_id": self.preprod_artifact.id,
+                "caller": "artifact_update_endpoint",
+            }
+        )
+        assert observed["state"] == PreprodArtifactSizeMetrics.SizeAnalysisState.NOT_RAN
+        assert observed["error_code"] == PreprodArtifactSizeMetrics.ErrorCode.SKIPPED
 
     @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=["test-secret-key"])
     def test_update_preprod_artifact_includes_size_when_query_matches(self) -> None:

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_update.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_update.py
@@ -25,6 +25,11 @@ class ProjectPreprodArtifactUpdateEndpointTest(TestCase):
             state=PreprodArtifact.ArtifactState.UPLOADING,
         )
 
+    def _create_pr_commit_comparison(self):
+        return self.create_commit_comparison(
+            organization=self.organization, provider="github", pr_number=42
+        )
+
     def _get_url(self, artifact_id=None):
         artifact_id = artifact_id or self.preprod_artifact.id
         return f"/api/0/internal/{self.organization.slug}/{self.project.slug}/files/preprodartifacts/{artifact_id}/update/"
@@ -610,6 +615,7 @@ class ProjectPreprodArtifactUpdateEndpointTest(TestCase):
         because it was rendered before the skipped metrics row existed.
         """
         self.preprod_artifact.app_id = "com.my.app"
+        self.preprod_artifact.commit_comparison = self._create_pr_commit_comparison()
         self.preprod_artifact.save()
 
         self.project.update_option(SIZE_ENABLED_QUERY_KEY, "app_id:com.other.app")
@@ -629,11 +635,38 @@ class ProjectPreprodArtifactUpdateEndpointTest(TestCase):
         "sentry.preprod.api.endpoints.project_preprod_artifact_update"
         ".create_preprod_size_pr_comment_task"
     )
+    def test_update_preprod_artifact_filtered_size_without_pr_does_not_dispatch(
+        self, mock_pr_comment_task
+    ) -> None:
+        """Test that an artifact with no commit comparison enqueues nothing.
+
+        The task can only no-op without a PR, and this branch runs on every upload
+        for projects that filter size analysis.
+        """
+        self.preprod_artifact.app_id = "com.my.app"
+        self.preprod_artifact.save()
+        assert self.preprod_artifact.commit_comparison_id is None
+
+        self.project.update_option(SIZE_ENABLED_QUERY_KEY, "app_id:com.other.app")
+
+        response = self._make_request({"artifact_type": 1})
+
+        assert response.status_code == 200
+        resp_data = response.json()
+        assert "size_analysis" not in resp_data["requestedFeatures"]
+        mock_pr_comment_task.apply_async.assert_not_called()
+
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=["test-secret-key"])
+    @patch(
+        "sentry.preprod.api.endpoints.project_preprod_artifact_update"
+        ".create_preprod_size_pr_comment_task"
+    )
     def test_update_preprod_artifact_unfiltered_size_does_not_update_pr_comment(
         self, mock_pr_comment_task
     ) -> None:
         """Test that an artifact queued for size analysis does not re-render the comment."""
         self.preprod_artifact.app_id = "com.my.app"
+        self.preprod_artifact.commit_comparison = self._create_pr_commit_comparison()
         self.preprod_artifact.save()
 
         self.project.update_option(SIZE_ENABLED_QUERY_KEY, "app_id:com.my.app")
@@ -658,9 +691,12 @@ class ProjectPreprodArtifactUpdateEndpointTest(TestCase):
         still has a pending metrics row, so it renders as processing. Only after the
         endpoint stamps that row skipped can it be excluded.
         """
+        commit_comparison = self._create_pr_commit_comparison()
+
         analyzed = self.create_preprod_artifact(
             state=PreprodArtifact.ArtifactState.PROCESSED,
             app_id="com.my.app",
+            commit_comparison=commit_comparison,
             build_version="1.0.0",
             build_number=1,
         )
@@ -670,21 +706,26 @@ class ProjectPreprodArtifactUpdateEndpointTest(TestCase):
         )
 
         self.preprod_artifact.app_id = "com.my.app.universal"
+        self.preprod_artifact.commit_comparison = commit_comparison
         self.preprod_artifact.save()
         self.create_preprod_artifact_size_metrics(
             self.preprod_artifact,
             state=PreprodArtifactSizeMetrics.SizeAnalysisState.PENDING,
-            min_download_size=None,
-            max_download_size=None,
-            min_install_size=None,
-            max_install_size=None,
         )
 
-        siblings = [analyzed, self.preprod_artifact]
+        # Resolve siblings the way the comment task does, so the test covers the
+        # real lookup rather than a hand-built list.
+        siblings = analyzed.get_sibling_artifacts_for_commit()
+        assert {a.id for a in siblings} == {analyzed.id, self.preprod_artifact.id}
 
         before = evaluate_size_and_format_messages(self.project, siblings, [])
-        assert "Processing..." in before.summary
-        assert before.evaluated_artifacts == siblings
+        assert {a.id for a in before.evaluated_artifacts} == {
+            analyzed.id,
+            self.preprod_artifact.id,
+        }
+        # The phantom row the bug leaves behind, identified by app_id rather than
+        # the translated "Processing..." cell so the assertion survives copy changes.
+        assert "com.my.app.universal" in before.summary
 
         self.project.update_option(SIZE_ENABLED_QUERY_KEY, "app_id:com.my.app")
 
@@ -693,8 +734,8 @@ class ProjectPreprodArtifactUpdateEndpointTest(TestCase):
         mock_pr_comment_task.apply_async.assert_called_once()
 
         after = evaluate_size_and_format_messages(self.project, siblings, [])
-        assert "Processing..." not in after.summary
-        assert after.evaluated_artifacts == [analyzed]
+        assert [a.id for a in after.evaluated_artifacts] == [analyzed.id]
+        assert "com.my.app.universal" not in after.summary
 
     @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=["test-secret-key"])
     def test_update_preprod_artifact_includes_size_when_query_matches(self) -> None:

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_update.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_update.py
@@ -5,8 +5,13 @@ import orjson
 from django.test import override_settings
 
 from sentry.preprod.api.endpoints.project_preprod_artifact_update import find_or_create_release
-from sentry.preprod.models import PreprodArtifact, PreprodArtifactMobileAppInfo
+from sentry.preprod.models import (
+    PreprodArtifact,
+    PreprodArtifactMobileAppInfo,
+    PreprodArtifactSizeMetrics,
+)
 from sentry.preprod.quotas import DISTRIBUTION_ENABLED_QUERY_KEY, SIZE_ENABLED_QUERY_KEY
+from sentry.preprod.vcs.status_checks.size.tasks import evaluate_size_and_format_messages
 from sentry.testutils.auth import generate_service_request_signature
 from sentry.testutils.cases import TestCase
 
@@ -590,6 +595,106 @@ class ProjectPreprodArtifactUpdateEndpointTest(TestCase):
         assert "requestedFeatures" in resp_data
         assert "size_analysis" not in resp_data["requestedFeatures"]
         assert "build_distribution" in resp_data["requestedFeatures"]
+
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=["test-secret-key"])
+    @patch(
+        "sentry.preprod.api.endpoints.project_preprod_artifact_update"
+        ".create_preprod_size_pr_comment_task"
+    )
+    def test_update_preprod_artifact_filtered_size_updates_pr_comment(
+        self, mock_pr_comment_task
+    ) -> None:
+        """Test that filtering size analysis re-renders the size PR comment.
+
+        Without this the comment keeps showing the filtered artifact as processing,
+        because it was rendered before the skipped metrics row existed.
+        """
+        self.preprod_artifact.app_id = "com.my.app"
+        self.preprod_artifact.save()
+
+        self.project.update_option(SIZE_ENABLED_QUERY_KEY, "app_id:com.other.app")
+
+        response = self._make_request({"artifact_type": 1})
+
+        assert response.status_code == 200
+        mock_pr_comment_task.apply_async.assert_called_once_with(
+            kwargs={
+                "preprod_artifact_id": self.preprod_artifact.id,
+                "caller": "artifact_update_endpoint_size_skipped",
+            }
+        )
+
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=["test-secret-key"])
+    @patch(
+        "sentry.preprod.api.endpoints.project_preprod_artifact_update"
+        ".create_preprod_size_pr_comment_task"
+    )
+    def test_update_preprod_artifact_unfiltered_size_does_not_update_pr_comment(
+        self, mock_pr_comment_task
+    ) -> None:
+        """Test that an artifact queued for size analysis does not re-render the comment."""
+        self.preprod_artifact.app_id = "com.my.app"
+        self.preprod_artifact.save()
+
+        self.project.update_option(SIZE_ENABLED_QUERY_KEY, "app_id:com.my.app")
+
+        response = self._make_request({"artifact_type": 1})
+
+        assert response.status_code == 200
+        mock_pr_comment_task.apply_async.assert_not_called()
+
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=["test-secret-key"])
+    @patch(
+        "sentry.preprod.api.endpoints.project_preprod_artifact_update"
+        ".create_preprod_size_pr_comment_task"
+    )
+    def test_update_preprod_artifact_filtered_size_drops_processing_row(
+        self, mock_pr_comment_task
+    ) -> None:
+        """Test that the re-render drops the filtered artifact from the summary.
+
+        This is the behavior the re-render exists for: a sibling artifact finishes
+        size analysis and the summary is rendered while the to-be-filtered artifact
+        still has a pending metrics row, so it renders as processing. Only after the
+        endpoint stamps that row skipped can it be excluded.
+        """
+        analyzed = self.create_preprod_artifact(
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.my.app",
+            build_version="1.0.0",
+            build_number=1,
+        )
+        self.create_preprod_artifact_size_metrics(
+            analyzed,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+        )
+
+        self.preprod_artifact.app_id = "com.my.app.universal"
+        self.preprod_artifact.save()
+        self.create_preprod_artifact_size_metrics(
+            self.preprod_artifact,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.PENDING,
+            min_download_size=None,
+            max_download_size=None,
+            min_install_size=None,
+            max_install_size=None,
+        )
+
+        siblings = [analyzed, self.preprod_artifact]
+
+        before = evaluate_size_and_format_messages(self.project, siblings, [])
+        assert "Processing..." in before.summary
+        assert before.evaluated_artifacts == siblings
+
+        self.project.update_option(SIZE_ENABLED_QUERY_KEY, "app_id:com.my.app")
+
+        response = self._make_request({"artifact_type": 1})
+        assert response.status_code == 200
+        mock_pr_comment_task.apply_async.assert_called_once()
+
+        after = evaluate_size_and_format_messages(self.project, siblings, [])
+        assert "Processing..." not in after.summary
+        assert after.evaluated_artifacts == [analyzed]
 
     @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=["test-secret-key"])
     def test_update_preprod_artifact_includes_size_when_query_matches(self) -> None:

--- a/tests/sentry/preprod/vcs/pr_comments/test_size_tasks.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_size_tasks.py
@@ -266,6 +266,52 @@ class CreatePreprodSizePrCommentTaskTest(TestCase):
         )
         mock_client.create_comment.assert_not_called()
 
+    @patch(_CLIENT_PATH)
+    @patch(_EVAL_PATH)
+    def test_no_size_artifacts_leaves_another_commits_comment_alone(
+        self, mock_eval, mock_get_client
+    ) -> None:
+        """An all-skipped commit must not clobber a comment owned by another commit.
+
+        Comments are keyed per PR but the evaluation covers one commit's siblings.
+        Artifacts upload one at a time, so a newer commit whose first artifact is
+        filtered would otherwise flap the PR comment to "skipped" before its real
+        build lands.
+        """
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        mock_eval.return_value = _eval_result(
+            triggered=False,
+            status=StatusCheckStatus.NEUTRAL,
+            subtitle="size analysis skipped",
+            evaluated_artifacts=[],
+        )
+
+        # Earlier commit on the same PR owns the comment.
+        older = self.create_commit_comparison(
+            organization=self.organization, provider="github", pr_number=42
+        )
+        older.extras = {"pr_comments": {"size": {"success": True, "comment_id": "existing_777"}}}
+        older.save(update_fields=["extras"])
+
+        newer = self.create_commit_comparison(
+            organization=self.organization, provider="github", pr_number=42
+        )
+
+        self._enable()
+        self._set_rules()
+        artifact = self._create_artifact(commit_comparison=newer)
+
+        self._import_task()(artifact.id)
+
+        mock_client.update_comment.assert_not_called()
+        mock_client.create_comment.assert_not_called()
+
+        older.refresh_from_db()
+        assert older.extras["pr_comments"]["size"]["comment_id"] == "existing_777"
+        newer.refresh_from_db()
+        assert (newer.extras or {}).get("pr_comments") is None
+
     # --- early-return skips ---------------------------------------------
 
     @patch(_CLIENT_PATH)
@@ -403,6 +449,9 @@ class CreatePreprodSizePrCommentTaskTest(TestCase):
         mock_lock.assert_called_once()
         mock_client.create_comment.assert_not_called()
         mock_client.update_comment.assert_not_called()
+        # Also pins the ordering: the evaluation runs under the lock, so a failure
+        # to acquire it means nothing was evaluated.
+        mock_eval.assert_not_called()
 
     # --- end-to-end (real evaluation, unpatched) ------------------------
 

--- a/tests/sentry/preprod/vcs/pr_comments/test_size_tasks.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_size_tasks.py
@@ -225,6 +225,47 @@ class CreatePreprodSizePrCommentTaskTest(TestCase):
         artifact.commit_comparison.refresh_from_db()
         assert (artifact.commit_comparison.extras or {}).get("pr_comments") is None
 
+    @patch(_CLIENT_PATH)
+    @patch(_EVAL_PATH)
+    def test_updates_existing_comment_when_no_size_artifacts(
+        self, mock_eval, mock_get_client
+    ) -> None:
+        """The last sibling becoming skipped must still update an existing comment.
+
+        Otherwise the comment keeps rendering whatever it last said, which is the
+        sibling that has since been skipped, shown as processing forever.
+        """
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        mock_eval.return_value = _eval_result(
+            triggered=False,
+            status=StatusCheckStatus.NEUTRAL,
+            subtitle="size analysis skipped",
+            evaluated_artifacts=[],
+        )
+
+        commit_comparison = self.create_commit_comparison(
+            organization=self.organization, provider="github", pr_number=42
+        )
+        commit_comparison.extras = {
+            "pr_comments": {"size": {"success": True, "comment_id": "existing_777"}}
+        }
+        commit_comparison.save(update_fields=["extras"])
+
+        self._enable()
+        self._set_rules()
+        artifact = self._create_artifact(commit_comparison=commit_comparison)
+
+        self._import_task()(artifact.id)
+
+        mock_client.update_comment.assert_called_once_with(
+            repo="owner/repo",
+            issue_id="42",
+            comment_id="existing_777",
+            data={"body": "## Size Analysis\n\nsize analysis skipped\n\nsize summary body"},
+        )
+        mock_client.create_comment.assert_not_called()
+
     # --- early-return skips ---------------------------------------------
 
     @patch(_CLIENT_PATH)

--- a/tests/sentry/preprod/vcs/pr_comments/test_size_tasks.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_size_tasks.py
@@ -7,8 +7,11 @@ import pytest
 
 from sentry.integrations.source_code_management.status_check import StatusCheckStatus
 from sentry.models.commitcomparison import CommitComparison
-from sentry.preprod.models import PreprodArtifact
-from sentry.preprod.vcs.status_checks.size.tasks import SizeEvaluation
+from sentry.preprod.models import PreprodArtifact, PreprodArtifactSizeMetrics
+from sentry.preprod.vcs.status_checks.size.tasks import (
+    SizeEvaluation,
+    evaluate_size_and_format_messages,
+)
 from sentry.preprod.vcs.status_checks.size.types import StatusCheckRule, TriggeredRule
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.testutils.cases import TestCase
@@ -225,6 +228,187 @@ class CreatePreprodSizePrCommentTaskTest(TestCase):
         artifact.commit_comparison.refresh_from_db()
         assert (artifact.commit_comparison.extras or {}).get("pr_comments") is None
 
+    @patch(_CLIENT_PATH)
+    @patch(_EVAL_PATH)
+    def test_updates_existing_comment_when_no_size_artifacts(
+        self, mock_eval, mock_get_client
+    ) -> None:
+        """The last sibling becoming skipped must still update an existing comment.
+
+        Otherwise the comment keeps rendering whatever it last said, which is the
+        sibling that has since been skipped, shown as processing forever.
+        """
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        mock_eval.return_value = _eval_result(
+            triggered=False,
+            status=StatusCheckStatus.NEUTRAL,
+            subtitle="size analysis skipped",
+            evaluated_artifacts=[],
+        )
+
+        commit_comparison = self.create_commit_comparison(
+            organization=self.organization, provider="github", pr_number=42
+        )
+        commit_comparison.extras = {
+            "pr_comments": {"size": {"success": True, "comment_id": "existing_777"}}
+        }
+        commit_comparison.save(update_fields=["extras"])
+
+        self._enable()
+        self._set_rules()
+        artifact = self._create_artifact(commit_comparison=commit_comparison)
+
+        self._import_task()(artifact.id)
+
+        mock_client.update_comment.assert_called_once_with(
+            repo="owner/repo",
+            issue_id="42",
+            comment_id="existing_777",
+            data={"body": "## Size Analysis\n\nsize analysis skipped\n\nsize summary body"},
+        )
+        mock_client.create_comment.assert_not_called()
+
+    @patch(_CLIENT_PATH)
+    @patch(_EVAL_PATH)
+    def test_no_size_artifacts_leaves_another_commits_comment_alone(
+        self, mock_eval, mock_get_client
+    ) -> None:
+        """An all-skipped commit must not clobber a comment owned by another commit.
+
+        Comments are keyed per PR but the evaluation covers one commit's siblings.
+        Artifacts upload one at a time, so a newer commit whose first artifact is
+        filtered would otherwise flap the PR comment to "skipped" before its real
+        build lands.
+        """
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        mock_eval.return_value = _eval_result(
+            triggered=False,
+            status=StatusCheckStatus.NEUTRAL,
+            subtitle="size analysis skipped",
+            evaluated_artifacts=[],
+        )
+
+        # Earlier commit on the same PR owns the comment.
+        older = self.create_commit_comparison(
+            organization=self.organization, provider="github", pr_number=42
+        )
+        older.extras = {"pr_comments": {"size": {"success": True, "comment_id": "existing_777"}}}
+        older.save(update_fields=["extras"])
+
+        newer = self.create_commit_comparison(
+            organization=self.organization, provider="github", pr_number=42
+        )
+
+        self._enable()
+        self._set_rules()
+        artifact = self._create_artifact(commit_comparison=newer)
+
+        self._import_task()(artifact.id)
+
+        mock_client.update_comment.assert_not_called()
+        mock_client.create_comment.assert_not_called()
+
+        older.refresh_from_db()
+        assert older.extras["pr_comments"]["size"]["comment_id"] == "existing_777"
+        newer.refresh_from_db()
+        assert (newer.extras or {}).get("pr_comments") is None
+
+    @patch(_CLIENT_PATH)
+    def test_no_size_artifacts_leaves_comment_alone_when_a_retry_displaced_analysis(
+        self, mock_get_client
+    ) -> None:
+        """A retried upload must not overwrite its own commit's real size table.
+
+        get_sibling_artifacts_for_commit deduplicates by (app_id, artifact_type,
+        build_configuration_id) and resolves the caller's own key to the caller, so
+        dispatching this task for the skipped retry substitutes it for the analyzed
+        first attempt. The evaluation then sees no size data even though the commit
+        has some, and refreshing on that would replace the real table with the
+        all-skipped body.
+
+        The evaluation is deliberately unpatched: the displacement happens inside
+        the sibling lookup, so mocking it out would mock out the bug.
+        """
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+
+        commit_comparison = self.create_commit_comparison(
+            organization=self.organization, provider="github", pr_number=42
+        )
+        commit_comparison.extras = {
+            "pr_comments": {"size": {"success": True, "comment_id": "existing_777"}}
+        }
+        commit_comparison.save(update_fields=["extras"])
+
+        self._enable()
+        self._set_rules()
+
+        # Attempt 1 analyzed. Attempt 2 shares its dedup key (the factory defaults
+        # app_id and artifact_type, and neither has a build configuration) and was
+        # filtered out of size analysis.
+        analyzed = self._create_artifact(commit_comparison=commit_comparison)
+        self.create_preprod_artifact_size_metrics(preprod_artifact=analyzed)
+
+        retried = self._create_artifact(commit_comparison=commit_comparison)
+        self.create_preprod_artifact_size_metrics(
+            preprod_artifact=retried,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.NOT_RAN,
+            error_code=PreprodArtifactSizeMetrics.ErrorCode.SKIPPED,
+        )
+
+        # Pin the displacement itself, so this test fails loudly rather than
+        # silently passing if the dedup rule ever stops substituting the caller.
+        siblings = retried.get_sibling_artifacts_for_commit()
+        assert [a.id for a in siblings] == [retried.id]
+        evaluation = evaluate_size_and_format_messages(self.project, siblings, [])
+        assert evaluation.evaluated_artifacts == []
+
+        self._import_task()(retried.id)
+
+        mock_client.update_comment.assert_not_called()
+        mock_client.create_comment.assert_not_called()
+
+        commit_comparison.refresh_from_db()
+        assert commit_comparison.extras["pr_comments"]["size"]["comment_id"] == "existing_777"
+
+    @patch(_CLIENT_PATH)
+    def test_no_size_artifacts_updates_comment_when_every_sibling_is_skipped(
+        self, mock_get_client
+    ) -> None:
+        """The guard above must not block the case the refresh exists for.
+
+        Every artifact on the commit is genuinely skipped, so there is no real size
+        table to protect and the stale "Processing..." row must still be cleared.
+        """
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+
+        commit_comparison = self.create_commit_comparison(
+            organization=self.organization, provider="github", pr_number=42
+        )
+        commit_comparison.extras = {
+            "pr_comments": {"size": {"success": True, "comment_id": "existing_777"}}
+        }
+        commit_comparison.save(update_fields=["extras"])
+
+        self._enable()
+        self._set_rules()
+
+        artifact = self._create_artifact(commit_comparison=commit_comparison)
+        self.create_preprod_artifact_size_metrics(
+            preprod_artifact=artifact,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.NOT_RAN,
+            error_code=PreprodArtifactSizeMetrics.ErrorCode.SKIPPED,
+        )
+
+        self._import_task()(artifact.id)
+
+        mock_client.update_comment.assert_called_once()
+        assert mock_client.update_comment.call_args.kwargs["comment_id"] == "existing_777"
+        mock_client.create_comment.assert_not_called()
+
     # --- early-return skips ---------------------------------------------
 
     @patch(_CLIENT_PATH)
@@ -362,6 +546,9 @@ class CreatePreprodSizePrCommentTaskTest(TestCase):
         mock_lock.assert_called_once()
         mock_client.create_comment.assert_not_called()
         mock_client.update_comment.assert_not_called()
+        # Also pins the ordering: the evaluation runs under the lock, so a failure
+        # to acquire it means nothing was evaluated.
+        mock_eval.assert_not_called()
 
     # --- end-to-end (real evaluation, unpatched) ------------------------
 


### PR DESCRIPTION
A size PR comment and its status check can both sit on `Processing...` for the life of a pull request, showing a phantom row for an artifact that will never be analyzed. The check never resolves, so it cannot be used as a required check.

This hits any project that uploads more than one artifact per build and filters some of them out of size analysis with `sentry:preprod_size_enabled_query` — for us, a thinned IPA for analysis plus a universal xcarchive for distribution. A filtered artifact's metrics row stays `PENDING`, and so renders as processing, until `project_preprod_artifact_update` stamps it `NOT_RAN`. If a sibling finishes size analysis inside that window, both surfaces render against the unstamped artifact and neither is rendered again, because no further event arrives for an artifact whose size analysis never runs.

The two need different fixes because they fail differently. The comment fails across requests, since a sibling's request can render it before this artifact's request has started, so it needs an explicit re-render once the row exists. The status check fails within a single request: it was dispatched immediately after the artifact was marked processed, well before the filter writes the row. Moving that one dispatch below the filter is enough, because each artifact's request then orders its own write before its own dispatch. No second dispatch and no reliance on task pickup latency.

The re-render is a no-op when size analysis runs normally, and is gated on the artifact having a commit comparison, since the branch runs on every upload for projects that filter size analysis and would otherwise enqueue a task that can only no-op. Filtering the table by `size_info.state` at render time in `templates.py` would make membership independent of ordering, but it also hides artifacts that are legitimately pending and leaves the asymmetry in place.

Three adjacent ordering bugs surfaced while fixing this, one commit each: the no-size-data guard ran before the lock, so an existing comment was never updated once every sibling became skippable; the evaluation was computed before the lock, letting an older sibling task restore `Processing...` permanently over a correct render; and the refresh could overwrite a comment belonging to a different commit on the same PR, since comments are keyed per PR while evaluation covers one commit's siblings.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
