### PR TITLE
fix(replays): make delete_replays script mirror the bulk delete path so its Snuba finder stops timing out

### DIFF
--- a/src/sentry/replays/scripts/delete_replays.py
+++ b/src/sentry/replays/scripts/delete_replays.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import functools
 import logging
+import uuid
 from collections.abc import Sequence
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from snuba_sdk import (
     Column,
@@ -17,12 +19,16 @@ from snuba_sdk import (
     Query,
 )
 
+from sentry import features, options
 from sentry.api.event_search import QueryToken, parse_search_query
 from sentry.models.organization import Organization
 from sentry.replays.query import replay_url_parser_config
 from sentry.replays.tasks import archive_replay, delete_replays_script_async
+from sentry.replays.usecases.delete import SNUBA_RETRY_EXCEPTIONS, delete_seer_replay_data
 from sentry.replays.usecases.query import execute_query, handle_search_filters
 from sentry.replays.usecases.query.configs.scalar import scalar_search_config
+from sentry.snuba.referrer import Referrer
+from sentry.utils.retries import ConditionalRetryPolicy, exponential_delay
 
 logger = logging.getLogger()
 
@@ -42,44 +48,66 @@ def delete_replays(
     start_utc = start_utc.replace(tzinfo=timezone.utc)
     end_utc = end_utc.replace(tzinfo=timezone.utc)
 
-    # Keyset (seek) pagination cursor - page by the last replay_id we saw
-    last_replay_id = None
+    organization = Organization.objects.filter(project__id=project_id).get()
+    has_seer_data = features.has("organizations:replay-ai-summaries", organization)
 
-    # Running tally of replays to be deleted, accumulated across pages
+    # Running tally of replays to be deleted, accumulated across windows and pages
     total_replays = 0
 
-    has_more = True
-    while has_more:
-        replays, has_more, last_replay_id = _get_rows_matching_deletion_pattern(
-            project_id=project_id,
-            start=start_utc,
-            end=end_utc,
-            limit=batch_size,
-            after_replay_id=last_replay_id,
-            search_filters=search_filters,
-            environment=environment,
-        )
+    # Chunk the range into fixed-size windows
+    chunk_size_days = options.get("replay.bulk_delete_job.chunk_size_days") or 7
 
-        # Exit early if no replays were found.
-        if not replays:
-            return None
+    window_offset_days = 0
+    while True:
+        window_start = start_utc + timedelta(days=window_offset_days)
+        if window_start >= end_utc:
+            break
+        window_end = min(window_start + timedelta(days=chunk_size_days), end_utc)
 
-        total_replays += len(replays)
+        # Reset per window because the cursor space is scoped to the window's result set
+        last_replay_id = None
 
-        logging_context = {
-            "project_id": project_id,
-            "dry_run": dry_run,
-            "batch_size": batch_size,
-            "tags": tags,
-            "start_utc": start_utc,
-            "end_utc": end_utc,
-            "has_more": has_more,
-            "total_replays": total_replays,
-        }
-        if dry_run:
-            logger.info(f"Replays to be deleted (dry run): {len(replays)}", extra=logging_context)
-        else:
-            delete_replay_ids(project_id, replays, total_replays=total_replays)
+        has_more = True
+        while has_more:
+            replays, has_more, last_replay_id = _get_rows_matching_deletion_pattern(
+                project_id=project_id,
+                organization_id=organization.id,
+                start=window_start,
+                end=window_end,
+                limit=batch_size,
+                after_replay_id=last_replay_id,
+                search_filters=search_filters,
+                environment=environment,
+            )
+
+            # Pages can filter to nothing, so use `has_more` to determine termination rather than single empty
+            if replays:
+                total_replays += len(replays)
+
+                logging_context = {
+                    "project_id": project_id,
+                    "dry_run": dry_run,
+                    "batch_size": batch_size,
+                    "tags": tags,
+                    "window_start": window_start,
+                    "window_end": window_end,
+                    "has_more": has_more,
+                    "total_replays": total_replays,
+                }
+                if dry_run:
+                    logger.info(
+                        f"Replays to be deleted (dry run): {len(replays)}", extra=logging_context
+                    )
+                else:
+                    delete_replay_ids(
+                        project_id,
+                        organization_id=organization.id,
+                        rows=replays,
+                        has_seer_data=has_seer_data,
+                        total_replays=total_replays,
+                    )
+
+        window_offset_days += chunk_size_days
 
 
 def translate_cli_tags_param_to_snuba_tag_param(tags: list[str]) -> Sequence[QueryToken]:
@@ -87,7 +115,11 @@ def translate_cli_tags_param_to_snuba_tag_param(tags: list[str]) -> Sequence[Que
 
 
 def delete_replay_ids(
-    project_id: int, rows: list[tuple[int, str, int]], total_replays: int
+    project_id: int,
+    organization_id: int,
+    rows: list[tuple[int, str, int]],
+    has_seer_data: bool,
+    total_replays: int,
 ) -> None:
     """Delete a set of replay-ids for a specific project."""
     logging_context = {
@@ -111,6 +143,11 @@ def delete_replay_ids(
     for _, replay_id, _ in rows:
         archive_replay(project_id, replay_id)
 
+    if has_seer_data:
+        # The finder strips dashes from `replay_id`; Seer keys on the dashed UUID
+        replay_ids = [str(uuid.UUID(replay_id)) for _, replay_id, _ in rows]
+        delete_seer_replay_data(organization_id, project_id, replay_ids)
+
     logger.info("Scheduling %d replays for deletion.", len(rows), extra=logging_context)
 
     # Asynchronously delete RRWeb recording data.
@@ -131,6 +168,7 @@ def delete_replay_ids(
 
 def _get_rows_matching_deletion_pattern(
     project_id: int,
+    organization_id: int,
     limit: int,
     after_replay_id: str | None,
     end: datetime,
@@ -158,6 +196,7 @@ def _get_rows_matching_deletion_pattern(
             Condition(Column("project_id"), Op.EQ, project_id),
             Condition(Column("timestamp"), Op.LT, end),
             Condition(Column("timestamp"), Op.GTE, start),
+            Condition(Column("segment_id"), Op.IS_NOT_NULL),
             *where,
         ],
         groupby=[Column("replay_id")],
@@ -166,10 +205,17 @@ def _get_rows_matching_deletion_pattern(
         limit=Limit(limit),
     )
 
-    response = execute_query(
-        query,
-        {"tenant_id": Organization.objects.filter(project__id=project_id).get().id},
-        "replays.scripts.delete_replays",
+    policy = ConditionalRetryPolicy(
+        test_function=lambda a, e: a < 5 and isinstance(e, SNUBA_RETRY_EXCEPTIONS),
+        delay_function=exponential_delay(1.0),
+    )
+    response = policy(
+        functools.partial(
+            execute_query,
+            query,
+            {"organization_id": organization_id},
+            Referrer.REPLAYS_SCRIPTS_DELETE_REPLAYS.value,
+        )
     )
 
     data = response.get("data", [])
@@ -182,6 +228,7 @@ def _get_rows_matching_deletion_pattern(
         [
             (item["retention_days"], item["replay_id"].replace("-", ""), item["max_segment_id"])
             for item in data
+            if item["max_segment_id"] is not None
         ],
         has_more,
         next_cursor,

--- a/src/sentry/replays/tasks.py
+++ b/src/sentry/replays/tasks.py
@@ -107,8 +107,11 @@ def delete_replays_script_async(
     retention_days: int,
     project_id: int,
     replay_id: str,
-    max_segment_id: int,
+    max_segment_id: int | None,
 ) -> None:
+    if max_segment_id is None:
+        return None
+
     segments = [
         RecordingSegmentStorageMeta(
             project_id=project_id,
@@ -116,7 +119,7 @@ def delete_replays_script_async(
             segment_id=i,
             retention_days=retention_days,
         )
-        for i in range(0, max_segment_id)
+        for i in range(max_segment_id + 1)
     ]
 
     rrweb_filenames = []

--- a/src/sentry/replays/usecases/delete.py
+++ b/src/sentry/replays/usecases/delete.py
@@ -163,7 +163,7 @@ def fetch_rows_matching_pattern(
         functools.partial(
             execute_query,
             query,
-            {"tenant_id": Organization.objects.filter(project__id=project_id).get().id},
+            {"organization_id": Organization.objects.filter(project__id=project_id).get().id},
             Referrer.REPLAYS_DELETE_REPLAYS_BULK.value,
         )
     )

--- a/tests/sentry/replays/scripts/test_delete_replays.py
+++ b/tests/sentry/replays/scripts/test_delete_replays.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime
 from io import BytesIO
+from unittest.mock import patch
 from uuid import uuid4
 from zlib import compress
 
@@ -325,3 +326,87 @@ class TestDeleteReplays(ReplaysSnubaTestCase):
             self.assert_recording_deleted(replay_id)
         self.assert_recording_not_deleted(replay_id_other_project)
         self.assert_recording_not_deleted(replay_id_outside_timerange)
+
+    def test_deletion_replays_multiple_time_windows(self) -> None:
+        # Store replays spread across a range wider than the chunk size so the finder has to walk
+        # more than one time window. Each must still be deleted.
+        old_replay = uuid4().hex
+        self.store_replay_segments(
+            old_replay,
+            self.project.id,
+            datetime.datetime.now() - datetime.timedelta(days=20),
+        )
+        mid_replay = uuid4().hex
+        self.store_replay_segments(
+            mid_replay,
+            self.project.id,
+            datetime.datetime.now() - datetime.timedelta(days=10),
+        )
+        recent_replay = uuid4().hex
+        self.store_replay_segments(
+            recent_replay,
+            self.project.id,
+            datetime.datetime.now() - datetime.timedelta(seconds=10),
+        )
+
+        # A 3-day chunk over a ~30-day range forces roughly ten windows, so each replay lands in a
+        # different window from the others.
+        with self.options({"replay.bulk_delete_job.chunk_size_days": 3}), TaskRunner():
+            delete_replays(
+                project_id=self.project.id,
+                batch_size=self.small_batch_size,
+                environment=[],
+                tags=[],
+                start_utc=datetime.datetime.utcnow() - datetime.timedelta(days=30),
+                end_utc=self.default_end_time,
+                dry_run=False,
+            )
+
+        self.assert_recording_deleted(old_replay)
+        self.assert_recording_deleted(mid_replay)
+        self.assert_recording_deleted(recent_replay)
+
+    @patch("sentry.replays.scripts.delete_replays.delete_seer_replay_data")
+    def test_deletion_replays_seer_delete_gated(self, mock_delete_seer: object) -> None:
+        to_delete = uuid4().hex
+        self.store_replay_segments(
+            to_delete,
+            self.project.id,
+            datetime.datetime.now() - datetime.timedelta(seconds=10),
+        )
+
+        # Without the feature flag Seer deletion is not attempted.
+        with TaskRunner():
+            delete_replays(
+                project_id=self.project.id,
+                batch_size=self.small_batch_size,
+                environment=[],
+                tags=[],
+                start_utc=self.default_start_time,
+                end_utc=self.default_end_time,
+                dry_run=False,
+            )
+        assert mock_delete_seer.call_count == 0  # type: ignore[attr-defined]
+
+        # With the feature flag we call Seer with the canonical dashed replay ids.
+        deletable = uuid4().hex
+        self.store_replay_segments(
+            deletable,
+            self.project.id,
+            datetime.datetime.now() - datetime.timedelta(seconds=10),
+        )
+        with self.feature("organizations:replay-ai-summaries"), TaskRunner():
+            delete_replays(
+                project_id=self.project.id,
+                batch_size=self.small_batch_size,
+                environment=[],
+                tags=[],
+                start_utc=self.default_start_time,
+                end_utc=self.default_end_time,
+                dry_run=False,
+            )
+        assert mock_delete_seer.call_count >= 1  # type: ignore[attr-defined]
+        # The replay ids passed to Seer are canonical dashed UUIDs.
+        _, _, passed_ids = mock_delete_seer.call_args[0]  # type: ignore[attr-defined]
+        for replay_id in passed_ids:
+            assert "-" in replay_id

--- a/tests/sentry/replays/tasks/test_delete_replays_script_async.py
+++ b/tests/sentry/replays/tasks/test_delete_replays_script_async.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+from uuid import uuid4
+
+from sentry.replays.tasks import delete_replays_script_async
+from sentry.testutils.cases import TestCase
+
+
+class TestDeleteReplaysScriptAsync(TestCase):
+    @patch("sentry.replays.tasks._delete_if_exists")
+    def test_deletes_inclusive_of_top_segment(self, mock_delete: object) -> None:
+        replay_id = uuid4().hex
+
+        with patch("sentry.replays.tasks.make_recording_filename", side_effect=lambda s: str(s)):
+            delete_replays_script_async(
+                retention_days=90,
+                project_id=self.project.id,
+                replay_id=replay_id,
+                max_segment_id=3,
+            )
+
+        # Segments 0, 1, 2, and 3 must all be scheduled for deletion. An exclusive range would
+        # leave segment 3 (the top segment) behind.
+        assert mock_delete.call_count == 4  # type: ignore[attr-defined]
+
+    @patch("sentry.replays.tasks._delete_if_exists")
+    def test_null_max_segment_id_is_a_no_op(self, mock_delete: object) -> None:
+        replay_id = uuid4().hex
+
+        delete_replays_script_async(
+            retention_days=90,
+            project_id=self.project.id,
+            replay_id=replay_id,
+            max_segment_id=None,
+        )
+
+        assert mock_delete.call_count == 0  # type: ignore[attr-defined]


### PR DESCRIPTION
 ## Why
The `delete_replays` operational script still times out its Snuba finder with `SnubaError: Read timed out. (read timeout=30)` even after the keyset pagination fix shipped.

fix tldr; 
The production bulk delete path (`run_bulk_replay_delete_job` + `fetch_rows_matching_pattern`) already solved this and carries several other optimizations the script was missing. This PR just brings the script in line with the API endpoint.

Claude's summary about the investigation:
`system.query_log` from the replays ClickHouse cluster showed why keyset alone couldn't fix it: every finder page read a flat ~240.5M rows and ~940MB, on 90+ pages, and never dropped as paging advanced. The `replay_id > cursor` predicate doesn't prune granules because the physical sort key holds `cityHash64(replay_id)` in third position, not the raw value, so every page re-scans the whole project window and filters after the read. Per-page ClickHouse time was only 3–13s, but it climbed under load: the script fires a 940MB scan every few seconds at the same cluster serving live replay traffic, so it degrades itself, and a bad page crosses the 30s client HTTP read timeout (a different clock from `query_duration_ms`).

## Notes

- The `segment_id IS NOT NULL` filter and the null-`max_segment_id` guard are equivalent on the output set; both are kept, the filter for cheaper paging and bulk-path parity, the guard so the blob-range math never sees a null.
- Keyset paging is intentionally kept inside each window rather than the bulk path's `LIMIT`/`OFFSET`: inside a small window it's strictly cheaper and the script already had it working.