### PR TITLE
chore(ACI): Remove workflow-engine-ui flag from even more places

### DIFF
--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
@@ -324,7 +324,6 @@ export function GlobalCommandPaletteActions() {
   const hasInsightsRollout = organization.features.includes(
     'insights-to-dashboards-ui-rollout'
   );
-  const hasWorkflowEngineUI = organization.features.includes('workflow-engine-ui');
   const hasPrebuiltDashboards = organization.features.includes(
     'dashboards-prebuilt-insights-dashboards'
   );
@@ -494,110 +493,88 @@ export function GlobalCommandPaletteActions() {
           </CMDKAction>
         </CMDKAction>
 
-        {/* Hide the entire Insights section only when both migrations are active.
-            During partial rollout, individual items are gated: domain links
-            (Frontend, Backend, etc.) by insights-to-dashboards-ui-rollout,
-            and Crons/Uptime by workflow-engine-ui. */}
-        {organization.features.includes('performance-view') &&
-          !(hasInsightsRollout && hasWorkflowEngineUI) && (
-            <CMDKAction
-              display={{
-                label: t('Insights'),
-                icon: <IconGraph type="area" />,
-              }}
-              limit={4}
-            >
-              {!hasInsightsRollout && (
-                <CMDKAction
-                  display={{label: t('Frontend')}}
-                  keywords={[t('apdex'), t('web vitals'), t('performance score')]}
-                  to={`${prefix}/insights/${FRONTEND_LANDING_SUB_PATH}/`}
-                />
-              )}
-              {!hasInsightsRollout && (
-                <CMDKAction
-                  display={{label: t('Backend')}}
-                  to={`${prefix}/insights/${BACKEND_LANDING_SUB_PATH}/`}
-                />
-              )}
-              {!hasInsightsRollout && (
-                <CMDKAction
-                  display={{label: t('Mobile')}}
-                  to={`${prefix}/insights/${MOBILE_LANDING_SUB_PATH}/`}
-                />
-              )}
-              {!hasInsightsRollout && (
-                <CMDKAction
-                  display={{label: t('Agents')}}
-                  to={`${prefix}/insights/${AGENTS_LANDING_SUB_PATH}/`}
-                />
-              )}
-              {!hasInsightsRollout && (
-                <CMDKAction
-                  display={{label: t('MCP')}}
-                  to={`${prefix}/insights/${MCP_LANDING_SUB_PATH}/`}
-                />
-              )}
-              {!hasWorkflowEngineUI && (
-                <CMDKAction
-                  display={{label: t('Crons')}}
-                  keywords={[t('jobs'), t('cron jobs')]}
-                  to={`${prefix}/insights/crons/`}
-                />
-              )}
-              {organization.features.includes('uptime') && !hasWorkflowEngineUI && (
-                <CMDKAction
-                  display={{label: t('Uptime')}}
-                  keywords={[t('uptime monitors')]}
-                  to={`${prefix}/insights/uptime/`}
-                />
-              )}
-              {!hasInsightsRollout && (
-                <CMDKAction
-                  display={{label: t('Projects')}}
-                  to={`${prefix}/insights/projects/`}
-                />
-              )}
-            </CMDKAction>
-          )}
-
-        {hasWorkflowEngineUI && (
-          <CMDKAction display={{label: t('Monitors'), icon: <IconSiren />}} limit={4}>
-            <CMDKAction display={{label: t('All Monitors')}} to={`${prefix}/monitors/`} />
-            <CMDKAction
-              display={{label: t('My Monitors')}}
-              to={`${prefix}/monitors/my-monitors/`}
-            />
-            <CMDKAction display={{label: t('Error')}} to={`${prefix}/monitors/errors/`} />
-            <CMDKAction
-              display={{label: t('Metric')}}
-              to={`${prefix}/monitors/metrics/`}
-            />
-            <CMDKAction
-              display={{label: t('Cron')}}
-              keywords={[t('jobs'), t('cron jobs')]}
-              to={`${prefix}/monitors/crons/`}
-            />
-            {organization.features.includes('uptime') && (
+        {/* Hide the Insights section once the insights-to-dashboards migration
+            is active; Crons and Uptime now live under the Monitors section. */}
+        {organization.features.includes('performance-view') && !hasInsightsRollout && (
+          <CMDKAction
+            display={{
+              label: t('Insights'),
+              icon: <IconGraph type="area" />,
+            }}
+            limit={4}
+          >
+            {!hasInsightsRollout && (
               <CMDKAction
-                display={{label: t('Uptime')}}
-                keywords={[t('uptime monitors'), t('monitors')]}
-                to={`${prefix}/monitors/uptime/`}
+                display={{label: t('Frontend')}}
+                keywords={[t('apdex'), t('web vitals'), t('performance score')]}
+                to={`${prefix}/insights/${FRONTEND_LANDING_SUB_PATH}/`}
               />
             )}
-            {organization.features.includes('preprod-size-monitors-frontend') && (
+            {!hasInsightsRollout && (
               <CMDKAction
-                display={{label: t('Mobile Build')}}
-                to={`${prefix}/monitors/mobile-builds/`}
+                display={{label: t('Backend')}}
+                to={`${prefix}/insights/${BACKEND_LANDING_SUB_PATH}/`}
               />
             )}
-            <CMDKAction
-              display={{label: t('Alerts')}}
-              keywords={[t('alert rules'), t('issue alert')]}
-              to={`${prefix}/monitors/alerts/`}
-            />
+            {!hasInsightsRollout && (
+              <CMDKAction
+                display={{label: t('Mobile')}}
+                to={`${prefix}/insights/${MOBILE_LANDING_SUB_PATH}/`}
+              />
+            )}
+            {!hasInsightsRollout && (
+              <CMDKAction
+                display={{label: t('Agents')}}
+                to={`${prefix}/insights/${AGENTS_LANDING_SUB_PATH}/`}
+              />
+            )}
+            {!hasInsightsRollout && (
+              <CMDKAction
+                display={{label: t('MCP')}}
+                to={`${prefix}/insights/${MCP_LANDING_SUB_PATH}/`}
+              />
+            )}
+            {!hasInsightsRollout && (
+              <CMDKAction
+                display={{label: t('Projects')}}
+                to={`${prefix}/insights/projects/`}
+              />
+            )}
           </CMDKAction>
         )}
+
+        <CMDKAction display={{label: t('Monitors'), icon: <IconSiren />}} limit={4}>
+          <CMDKAction display={{label: t('All Monitors')}} to={`${prefix}/monitors/`} />
+          <CMDKAction
+            display={{label: t('My Monitors')}}
+            to={`${prefix}/monitors/my-monitors/`}
+          />
+          <CMDKAction display={{label: t('Error')}} to={`${prefix}/monitors/errors/`} />
+          <CMDKAction display={{label: t('Metric')}} to={`${prefix}/monitors/metrics/`} />
+          <CMDKAction
+            display={{label: t('Cron')}}
+            keywords={[t('jobs'), t('cron jobs')]}
+            to={`${prefix}/monitors/crons/`}
+          />
+          {organization.features.includes('uptime') && (
+            <CMDKAction
+              display={{label: t('Uptime')}}
+              keywords={[t('uptime monitors'), t('monitors')]}
+              to={`${prefix}/monitors/uptime/`}
+            />
+          )}
+          {organization.features.includes('preprod-size-monitors-frontend') && (
+            <CMDKAction
+              display={{label: t('Mobile Build')}}
+              to={`${prefix}/monitors/mobile-builds/`}
+            />
+          )}
+          <CMDKAction
+            display={{label: t('Alerts')}}
+            keywords={[t('alert rules'), t('issue alert')]}
+            to={`${prefix}/monitors/alerts/`}
+          />
+        </CMDKAction>
 
         <CMDKAction display={{label: t('Settings'), icon: <IconSettings />}} limit={4}>
           {visibleOrgSettingsNavItems.map(item => (

--- a/static/app/views/navigation/index.desktop.spec.tsx
+++ b/static/app/views/navigation/index.desktop.spec.tsx
@@ -32,7 +32,6 @@ const ALL_AVAILABLE_FEATURES = [
   'performance-view',
   'profiling',
   'visibility-explore-view',
-  'workflow-engine-ui',
 ];
 
 const mockUsingCustomerDomain = jest.fn();
@@ -200,7 +199,7 @@ describe('desktop navigation', () => {
           <Navigation />
         </PrimaryNavigationContextProvider>,
         navigationContext({
-          organization: {features: [...ALL_AVAILABLE_FEATURES, 'workflow-engine-ui']},
+          organization: {features: [...ALL_AVAILABLE_FEATURES]},
         })
       );
 

--- a/static/app/views/navigation/index.mobile.spec.tsx
+++ b/static/app/views/navigation/index.mobile.spec.tsx
@@ -27,7 +27,6 @@ const ALL_AVAILABLE_FEATURES = [
   'performance-view',
   'profiling',
   'visibility-explore-view',
-  'workflow-engine-ui',
 ];
 
 function navigationContext({

--- a/static/app/views/navigation/navigation.tsx
+++ b/static/app/views/navigation/navigation.tsx
@@ -243,18 +243,16 @@ export function PrimaryNavigationItems({listRef}: PrimaryNavigationItemsProps) {
         </Feature>
       )}
 
-      <Feature features={['workflow-engine-ui']}>
-        <PrimaryNavigation.ListItem>
-          <PrimaryNavigation.Link
-            to={`/${prefix}/monitors/`}
-            analyticsKey="monitors"
-            label={t('Monitors')}
-            {...makeNavigationItemProps('monitors', `/${prefix}/monitors/`)}
-          >
-            <IconSiren />
-          </PrimaryNavigation.Link>
-        </PrimaryNavigation.ListItem>
-      </Feature>
+      <PrimaryNavigation.ListItem>
+        <PrimaryNavigation.Link
+          to={`/${prefix}/monitors/`}
+          analyticsKey="monitors"
+          label={t('Monitors')}
+          {...makeNavigationItemProps('monitors', `/${prefix}/monitors/`)}
+        >
+          <IconSiren />
+        </PrimaryNavigation.Link>
+      </PrimaryNavigation.ListItem>
 
       <NavigationTourElement id={NavigationTour.SETTINGS} title={null} description={null}>
         {tourProps => (

--- a/static/app/views/navigation/secondary/components.spec.tsx
+++ b/static/app/views/navigation/secondary/components.spec.tsx
@@ -25,7 +25,6 @@ const ALL_AVAILABLE_FEATURES = [
   'performance-view',
   'profiling',
   'visibility-explore-view',
-  'workflow-engine-ui',
 ];
 
 function setupMocks() {

--- a/static/app/views/navigation/secondary/sections/insights/insightsSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/insights/insightsSecondaryNavigation.tsx
@@ -37,7 +37,6 @@ export function InsightsSecondaryNavigation() {
   const organization = useOrganization();
   const baseUrl = `/organizations/${organization.slug}/${DOMAIN_VIEW_BASE_URL}`;
 
-  const hasWorkflowEngineUI = organization.features.includes('workflow-engine-ui');
   const hasInsightsToDashboards = organization.features.includes(
     'insights-to-dashboards-ui-rollout'
   );
@@ -100,24 +99,49 @@ export function InsightsSecondaryNavigation() {
           <SecondaryNavigation.List>
             <SecondaryNavigation.ListItem>
               <SecondaryNavigation.Link
-                to={
-                  hasWorkflowEngineUI
-                    ? `${makeMonitorBasePathname(organization.slug)}crons/?insightsRedirect=true`
-                    : `${baseUrl}/crons/`
-                }
+                to={`${makeMonitorBasePathname(organization.slug)}crons/?insightsRedirect=true`}
                 analyticsItemName="insights_crons"
                 trailingItems={
-                  hasWorkflowEngineUI ? (
+                  <Tooltip
+                    isHoverable
+                    title={
+                      <Fragment>
+                        <Text as="p">{t('Crons now live under Monitors.')}</Text>
+                        <Text as="p">
+                          {tct('See the [link:new Crons page here.]', {
+                            link: (
+                              <Link
+                                to={`${makeMonitorBasePathname(organization.slug)}crons/`}
+                              />
+                            ),
+                          })}
+                        </Text>
+                      </Fragment>
+                    }
+                  >
+                    <Badge variant="muted">{t('Moved')}</Badge>
+                  </Tooltip>
+                }
+              >
+                {t('Crons')}
+              </SecondaryNavigation.Link>
+            </SecondaryNavigation.ListItem>
+            <Feature features={['uptime']}>
+              <SecondaryNavigation.ListItem>
+                <SecondaryNavigation.Link
+                  to={`${makeMonitorBasePathname(organization.slug)}uptime/?insightsRedirect=true`}
+                  analyticsItemName="insights_uptime"
+                  trailingItems={
                     <Tooltip
                       isHoverable
                       title={
                         <Fragment>
-                          <Text as="p">{t('Crons now live under Monitors.')}</Text>
+                          <Text as="p">{t('Uptime now lives under Monitors.')}</Text>
                           <Text as="p">
-                            {tct('See the [link:new Crons page here.]', {
+                            {tct('See the [link:new Uptime page here.]', {
                               link: (
                                 <Link
-                                  to={`${makeMonitorBasePathname(organization.slug)}crons/`}
+                                  to={`${makeMonitorBasePathname(organization.slug)}uptime/`}
                                 />
                               ),
                             })}
@@ -127,43 +151,6 @@ export function InsightsSecondaryNavigation() {
                     >
                       <Badge variant="muted">{t('Moved')}</Badge>
                     </Tooltip>
-                  ) : null
-                }
-              >
-                {t('Crons')}
-              </SecondaryNavigation.Link>
-            </SecondaryNavigation.ListItem>
-            <Feature features={['uptime']}>
-              <SecondaryNavigation.ListItem>
-                <SecondaryNavigation.Link
-                  to={
-                    hasWorkflowEngineUI
-                      ? `${makeMonitorBasePathname(organization.slug)}uptime/?insightsRedirect=true`
-                      : `${baseUrl}/uptime/`
-                  }
-                  analyticsItemName="insights_uptime"
-                  trailingItems={
-                    hasWorkflowEngineUI ? (
-                      <Tooltip
-                        isHoverable
-                        title={
-                          <Fragment>
-                            <Text as="p">{t('Uptime now lives under Monitors.')}</Text>
-                            <Text as="p">
-                              {tct('See the [link:new Uptime page here.]', {
-                                link: (
-                                  <Link
-                                    to={`${makeMonitorBasePathname(organization.slug)}uptime/`}
-                                  />
-                                ),
-                              })}
-                            </Text>
-                          </Fragment>
-                        }
-                      >
-                        <Badge variant="muted">{t('Moved')}</Badge>
-                      </Tooltip>
-                    ) : null
                   }
                 >
                   {t('Uptime')}

--- a/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.tsx
@@ -124,23 +124,18 @@ export function IssuesSecondaryNavigation() {
           </SecondaryNavigation.List>
         </SecondaryNavigation.Section>
         <IssueViews />
-        <ConfigureSection baseUrl={baseUrl} />
+        <ConfigureSection />
       </SecondaryNavigation.Body>
     </Fragment>
   );
 }
 
-function ConfigureSection({baseUrl}: {baseUrl: string}) {
+function ConfigureSection() {
   const organization = useOrganization();
   const {layout} = usePrimaryNavigation();
   const isSticky = layout === 'sidebar';
 
-  const hasWorkflowEngineUI = organization.features.includes('workflow-engine-ui');
-  const shouldRedirectToWorkflowEngineUI = hasWorkflowEngineUI;
-
-  const alertsLink = shouldRedirectToWorkflowEngineUI
-    ? makeAutomationBasePathname(organization.slug)
-    : `${baseUrl}/alerts/rules/`;
+  const alertsLink = makeAutomationBasePathname(organization.slug);
 
   return (
     <Fragment>
@@ -155,30 +150,27 @@ function ConfigureSection({baseUrl}: {baseUrl: string}) {
           <SecondaryNavigation.ListItem>
             <SecondaryNavigation.Link
               to={alertsLink}
-              {...(!shouldRedirectToWorkflowEngineUI && {activeTo: `${baseUrl}/alerts/`})}
               analyticsItemName="issues_alerts"
               trailingItems={
-                hasWorkflowEngineUI ? (
-                  <Tooltip
-                    isHoverable
-                    title={
-                      <Fragment>
-                        <Text as="p">{t('Alerts now live under Monitors.')}</Text>
-                        <Text as="p">
-                          {tct('See the [link:new Alerts page here.]', {
-                            link: (
-                              <Link
-                                to={`/organizations/${organization.slug}/monitors/alerts/`}
-                              />
-                            ),
-                          })}
-                        </Text>
-                      </Fragment>
-                    }
-                  >
-                    <Badge variant="muted">{t('Moved')}</Badge>
-                  </Tooltip>
-                ) : null
+                <Tooltip
+                  isHoverable
+                  title={
+                    <Fragment>
+                      <Text as="p">{t('Alerts now live under Monitors.')}</Text>
+                      <Text as="p">
+                        {tct('See the [link:new Alerts page here.]', {
+                          link: (
+                            <Link
+                              to={`/organizations/${organization.slug}/monitors/alerts/`}
+                            />
+                          ),
+                        })}
+                      </Text>
+                    </Fragment>
+                  }
+                >
+                  <Badge variant="muted">{t('Moved')}</Badge>
+                </Tooltip>
               }
             >
               {t('Alerts')}


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/121003 to continue removing more workflow engine UI code from navigation and the command palette.