### PR TITLE
chore(alerts): Increase brownouts for legacy alerts API even more

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1703,10 +1703,10 @@ register(
 )
 
 # Brownout schedule for the deprecated alerts API endpoints.
-# 5 minute blackout 24 times a day (every hour, on the hour, UTC).
+# 5 minute blackout every half hour
 register(
     "api.deprecation.alerts-cron",
-    default="0 * * * *",
+    default="0 30 * * *",
     type=String,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1706,7 +1706,7 @@ register(
 # 5 minute blackout every half hour
 register(
     "api.deprecation.alerts-cron",
-    default="0 30 * * *",
+    default="0,30 * * *",
     type=String,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1703,7 +1703,7 @@ register(
 )
 
 # Brownout schedule for the deprecated alerts API endpoints.
-# 2 minute blackout 24 times a day (every hour, on the hour, UTC).
+# 5 minute blackout 24 times a day (every hour, on the hour, UTC).
 register(
     "api.deprecation.alerts-cron",
     default="0 * * * *",
@@ -1713,7 +1713,7 @@ register(
 register(
     "api.deprecation.alerts-duration",
     type=Int,
-    default=120,
+    default=300,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1706,7 +1706,7 @@ register(
 # 5 minute blackout every half hour
 register(
     "api.deprecation.alerts-cron",
-    default="0,30 * * *",
+    default="0,30 * * * *",
     type=String,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/118680 to increase the brownouts even more. 