### PR TITLE
ref(issue detection): Allow passing settings and detectors to detection runner

### DIFF
--- a/src/sentry/issue_detection/performance_detection.py
+++ b/src/sentry/issue_detection/performance_detection.py
@@ -678,7 +678,7 @@ DETECTOR_CLASSES: list[type[PerformanceDetector]] = [
 
 
 def _detect_performance_problems(
-    data: dict[str, Any], sdk_span: Any, project: Project, standalone: bool = False
+    data: dict[str, Any], sdk_span: Span | StreamedSpan, project: Project, standalone: bool = False
 ) -> list[PerformanceProblem]:
     event_id = data.get("event_id", None)
     organization = project.organization

--- a/src/sentry/issue_detection/performance_detection.py
+++ b/src/sentry/issue_detection/performance_detection.py
@@ -126,7 +126,10 @@ PERFORMANCE_WFE_DETECTOR_TYPES: frozenset[str] = frozenset(
 
 # Facade in front of performance detection to limit impact of detection on our events ingestion
 def detect_performance_problems(
-    data: dict[str, Any], project: Project, standalone: bool = False
+    data: dict[str, Any],
+    project: Project,
+    detection_settings: dict[DetectorType, dict[str, Any]] | None = None,
+    standalone: bool = False,
 ) -> list[PerformanceProblem]:
     try:
         rate = options.get("performance.issues.all.problem-detection")
@@ -138,7 +141,9 @@ def detect_performance_problems(
                 metrics.timer("performance.detect_performance_issue", sample_rate=0.01),
                 start_span(op="py.detect_performance_issue", name="none") as sdk_span,
             ):
-                return _detect_performance_problems(data, sdk_span, project, standalone=standalone)
+                return _detect_performance_problems(
+                    data, sdk_span, project, detection_settings, standalone
+                )
     except Exception:
         logging.exception("Failed to detect performance problems")
     return []
@@ -678,13 +683,18 @@ DETECTOR_CLASSES: list[type[PerformanceDetector]] = [
 
 
 def _detect_performance_problems(
-    data: dict[str, Any], sdk_span: Span | StreamedSpan, project: Project, standalone: bool = False
+    data: dict[str, Any],
+    sdk_span: Span | StreamedSpan,
+    project: Project,
+    detection_settings: dict[DetectorType, dict[str, Any]] | None = None,
+    standalone: bool = False,
 ) -> list[PerformanceProblem]:
     event_id = data.get("event_id", None)
     organization = project.organization
 
-    with start_span(op="function", name="get_detection_settings"):
-        detection_settings = get_detection_settings(project)
+    if detection_settings is None:
+        with start_span(op="function", name="get_detection_settings"):
+            detection_settings = get_detection_settings(project)
 
     # The performance detectors expect the span list to be ordered/flattened in the way they
     # are structured in the tree. This is an implicit assumption in the performance detectors.

--- a/src/sentry/issue_detection/performance_detection.py
+++ b/src/sentry/issue_detection/performance_detection.py
@@ -128,6 +128,7 @@ PERFORMANCE_WFE_DETECTOR_TYPES: frozenset[str] = frozenset(
 def detect_performance_problems(
     data: dict[str, Any],
     project: Project,
+    *,
     detector_classes: list[type[PerformanceDetector]] | None = None,
     detection_settings: dict[DetectorType, dict[str, Any]] | None = None,
     standalone: bool = False,
@@ -143,7 +144,12 @@ def detect_performance_problems(
                 start_span(op="py.detect_performance_issue", name="none") as sdk_span,
             ):
                 return _detect_performance_problems(
-                    data, sdk_span, project, detector_classes, detection_settings, standalone
+                    data,
+                    sdk_span,
+                    project,
+                    detector_classes=detector_classes,
+                    detection_settings=detection_settings,
+                    standalone=standalone,
                 )
     except Exception:
         logging.exception("Failed to detect performance problems")
@@ -687,6 +693,7 @@ def _detect_performance_problems(
     data: dict[str, Any],
     sdk_span: Span | StreamedSpan,
     project: Project,
+    *,
     detector_classes: list[type[PerformanceDetector]] | None = None,
     detection_settings: dict[DetectorType, dict[str, Any]] | None = None,
     standalone: bool = False,

--- a/src/sentry/issue_detection/performance_detection.py
+++ b/src/sentry/issue_detection/performance_detection.py
@@ -128,6 +128,7 @@ PERFORMANCE_WFE_DETECTOR_TYPES: frozenset[str] = frozenset(
 def detect_performance_problems(
     data: dict[str, Any],
     project: Project,
+    detector_classes: list[type[PerformanceDetector]] | None = None,
     detection_settings: dict[DetectorType, dict[str, Any]] | None = None,
     standalone: bool = False,
 ) -> list[PerformanceProblem]:
@@ -142,7 +143,7 @@ def detect_performance_problems(
                 start_span(op="py.detect_performance_issue", name="none") as sdk_span,
             ):
                 return _detect_performance_problems(
-                    data, sdk_span, project, detection_settings, standalone
+                    data, sdk_span, project, detector_classes, detection_settings, standalone
                 )
     except Exception:
         logging.exception("Failed to detect performance problems")
@@ -686,11 +687,13 @@ def _detect_performance_problems(
     data: dict[str, Any],
     sdk_span: Span | StreamedSpan,
     project: Project,
+    detector_classes: list[type[PerformanceDetector]] | None = None,
     detection_settings: dict[DetectorType, dict[str, Any]] | None = None,
     standalone: bool = False,
 ) -> list[PerformanceProblem]:
     event_id = data.get("event_id", None)
     organization = project.organization
+    detector_classes = detector_classes if detector_classes is not None else DETECTOR_CLASSES
 
     if detection_settings is None:
         with start_span(op="function", name="get_detection_settings"):
@@ -708,7 +711,7 @@ def _detect_performance_problems(
     with start_span(op="initialize", name="PerformanceDetector"):
         detectors: list[PerformanceDetector] = [
             detector_class(detection_settings[detector_class.settings_key], data)
-            for detector_class in DETECTOR_CLASSES
+            for detector_class in detector_classes
             if detector_class.is_detection_allowed_for_system()
         ]
 

--- a/tests/sentry/issue_detection/test_performance_detection.py
+++ b/tests/sentry/issue_detection/test_performance_detection.py
@@ -137,6 +137,102 @@ class PerformanceDetectionTest(TestCase):
         perf_problems = _detect_performance_problems(n_plus_one_event, sdk_span_mock, self.project)
         assert perf_problems == []
 
+    @override_options(BASE_DETECTOR_OPTIONS)
+    def test_fetches_detection_settings_when_not_given_any(self) -> None:
+        n_plus_one_event = get_event("n-plus-one-db/n-plus-one-in-django-index-view")
+
+        with patch(
+            "sentry.issue_detection.performance_detection.get_detection_settings",
+            wraps=get_detection_settings,
+        ) as get_detection_settings_spy:
+            detect_performance_problems(n_plus_one_event, self.project)
+
+            get_detection_settings_spy.assert_called_once_with(self.project)
+
+    @override_options(BASE_DETECTOR_OPTIONS)
+    def test_uses_given_detection_settings_if_provided(self) -> None:
+        n_plus_one_event = get_event("n-plus-one-db/n-plus-one-in-django-index-view")
+
+        detection_settings = get_detection_settings(self.project)
+        # Change the N+1 settings so that the N+1 problem which would normally be caught will be
+        # ignored instead. This way, when we run detection and find no problems, it'll prove these
+        # settings were used.
+        detection_settings[DetectorType.N_PLUS_ONE_DB_QUERIES]["duration_threshold"] = 100000
+
+        with patch(
+            "sentry.issue_detection.performance_detection.get_detection_settings",
+            wraps=get_detection_settings,
+        ) as get_detection_settings_spy:
+            detected_problems = detect_performance_problems(
+                n_plus_one_event, self.project, detection_settings=detection_settings
+            )
+
+            get_detection_settings_spy.assert_not_called()
+            assert detected_problems == []
+
+    def test_every_detector_class_has_detection_settings(self) -> None:
+        """
+        `_detect_performance_problems` looks each detector's settings up by `settings_key`, so a
+        detector added to `DETECTOR_CLASSES` without a matching entry in `get_detection_settings`
+        raises a `KeyError` for every event. Worse, `detect_performance_problems` swallows that
+        error, so detection would quietly stop finding anything at all.
+        """
+        detection_settings = get_detection_settings(self.project)
+
+        detectors_missing_settings = {
+            detector_class.settings_key for detector_class in DETECTOR_CLASSES
+        } - set(detection_settings.keys())
+
+        assert detectors_missing_settings == set()
+
+    @override_options(BASE_DETECTOR_OPTIONS)
+    def test_uses_default_detectors_when_not_given_any(self) -> None:
+        n_plus_one_event = get_event("n-plus-one-db/n-plus-one-in-django-index-view")
+
+        with patch(
+            "sentry.issue_detection.performance_detection.run_detector_on_data",
+            wraps=run_detector_on_data,
+        ) as run_detector_spy:
+            detected_problems = detect_performance_problems(n_plus_one_event, self.project)
+
+            detectors_run = [type(call.args[0]) for call in run_detector_spy.call_args_list]
+            assert detectors_run == [
+                detector_class
+                for detector_class in DETECTOR_CLASSES
+                if detector_class.is_detection_allowed_for_system()
+            ]
+            assert_n_plus_one_db_problem(detected_problems)
+
+    @override_options(BASE_DETECTOR_OPTIONS)
+    def test_runs_only_the_given_detectors(self) -> None:
+        n_plus_one_event = get_event("n-plus-one-db/n-plus-one-in-django-index-view")
+
+        with patch(
+            "sentry.issue_detection.performance_detection.run_detector_on_data",
+            wraps=run_detector_on_data,
+        ) as run_detector_spy:
+            detected_problems = detect_performance_problems(
+                n_plus_one_event, self.project, detector_classes=[NPlusOneDBSpanDetector]
+            )
+
+            detectors_run = [type(call.args[0]) for call in run_detector_spy.call_args_list]
+            assert detectors_run == [NPlusOneDBSpanDetector]
+            # The one detector we asked for still found its problem
+            assert_n_plus_one_db_problem(detected_problems)
+
+    @override_options(BASE_DETECTOR_OPTIONS)
+    def test_runs_no_detectors_when_given_an_empty_list(self) -> None:
+        n_plus_one_event = get_event("n-plus-one-db/n-plus-one-in-django-index-view")
+
+        with patch(
+            "sentry.issue_detection.performance_detection.run_detector_on_data",
+            wraps=run_detector_on_data,
+        ) as run_detector_spy:
+            detect_performance_problems(n_plus_one_event, self.project, detector_classes=[])
+
+            # Passing in an empty list of detectors should result in no detectors running
+            run_detector_spy.assert_not_called()
+
     def test_project_options_overrides_default_detection_settings(self) -> None:
         default_settings = get_detection_settings(self.project)
 


### PR DESCRIPTION
This makes two changes to the main and helper functions we use for running our existing issue detectors, to enable them to work better as part of our transition to using span-first detectors.

- As part of our testing, we run the existing and span-first detectors side by side to compare results, and currently, we fetch detection settings twice, once for each set of detectors. This therefore adds an optional `detection_settings` parameter to both functions so that we can get the settings once and pass them in to both sets of detectors.

- Relatedly, when doing the results comparison it would be nice to be able to only run the existing detectors we're currently testing, rather than all of them. This also can serve as a safety measure for our shim running segments through the existing detectors, in case there are latency problems there. This therefore also adds an optional `detector_classes` parameter, so that we can pass in which detectors to run.

To make sure all of this parameter-changing doesn't cause future bugs, it also switches all of the optional parameters in both functions to be keyword-only. Further, to keep things easier to review, though tests of their use are included here, actual in-code use of these parameters will be included in a follow-up PR. 