### PR TITLE
fix(issues): Remove hidden custom event tab

### DIFF
--- a/static/app/views/issueDetails/eventNavigation/issueDetailsEventNavigation.spec.tsx
+++ b/static/app/views/issueDetails/eventNavigation/issueDetailsEventNavigation.spec.tsx
@@ -115,7 +115,7 @@ describe('IssueDetailsEventNavigation', () => {
     });
   });
 
-  it('shows the custom tab when navigating from a preset to a specific event', async () => {
+  it('clears the selected preset when navigating to a specific event', async () => {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/issues/group-id/events/next-event-id/',
       body: EventFixture(),
@@ -130,10 +130,12 @@ describe('IssueDetailsEventNavigation', () => {
 
     await userEvent.click(screen.getByRole('button', {name: 'Next Event'}));
 
-    expect(await screen.findByRole('tab', {name: 'Custom'})).toHaveAttribute(
-      'aria-selected',
-      'true'
-    );
+    await waitFor(() => {
+      screen
+        .getAllByRole('tab')
+        .forEach(tab => expect(tab).toHaveAttribute('aria-selected', 'false'));
+    });
+    expect(screen.queryByRole('tab', {name: 'Custom'})).not.toBeInTheDocument();
   });
 
   it('can navigate next/previous events', async () => {

--- a/static/app/views/issueDetails/eventNavigation/issueDetailsEventNavigation.spec.tsx
+++ b/static/app/views/issueDetails/eventNavigation/issueDetailsEventNavigation.spec.tsx
@@ -115,6 +115,27 @@ describe('IssueDetailsEventNavigation', () => {
     });
   });
 
+  it('shows the custom tab when navigating from a preset to a specific event', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/group-id/events/next-event-id/',
+      body: EventFixture(),
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/group-id/events/prev-event-id/',
+      body: EventFixture(),
+    });
+    render(<IssueDetailsEventNavigation {...defaultProps} />, {
+      initialRouterConfig: latestRouterConfig,
+    });
+
+    await userEvent.click(screen.getByRole('button', {name: 'Next Event'}));
+
+    expect(await screen.findByRole('tab', {name: 'Custom'})).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+  });
+
   it('can navigate next/previous events', async () => {
     render(<IssueDetailsEventNavigation {...defaultProps} />, {
       initialRouterConfig: latestRouterConfig,

--- a/static/app/views/issueDetails/eventNavigation/issueDetailsEventNavigation.spec.tsx
+++ b/static/app/views/issueDetails/eventNavigation/issueDetailsEventNavigation.spec.tsx
@@ -124,18 +124,20 @@ describe('IssueDetailsEventNavigation', () => {
       url: '/organizations/org-slug/issues/group-id/events/prev-event-id/',
       body: EventFixture(),
     });
-    render(<IssueDetailsEventNavigation {...defaultProps} />, {
+    const {router} = render(<IssueDetailsEventNavigation {...defaultProps} />, {
       initialRouterConfig: latestRouterConfig,
     });
 
     await userEvent.click(screen.getByRole('button', {name: 'Next Event'}));
 
     await waitFor(() => {
+      expect(router.location.pathname).toBe(
+        '/organizations/org-slug/issues/group-id/events/next-event-id/'
+      );
       screen
         .getAllByRole('tab')
         .forEach(tab => expect(tab).toHaveAttribute('aria-selected', 'false'));
     });
-    expect(screen.queryByRole('tab', {name: 'Custom'})).not.toBeInTheDocument();
   });
 
   it('can navigate next/previous events', async () => {

--- a/static/app/views/issueDetails/eventNavigation/issueDetailsEventNavigation.spec.tsx
+++ b/static/app/views/issueDetails/eventNavigation/issueDetailsEventNavigation.spec.tsx
@@ -115,31 +115,6 @@ describe('IssueDetailsEventNavigation', () => {
     });
   });
 
-  it('clears the selected preset when navigating to a specific event', async () => {
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/issues/group-id/events/next-event-id/',
-      body: EventFixture(),
-    });
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/issues/group-id/events/prev-event-id/',
-      body: EventFixture(),
-    });
-    const {router} = render(<IssueDetailsEventNavigation {...defaultProps} />, {
-      initialRouterConfig: latestRouterConfig,
-    });
-
-    await userEvent.click(screen.getByRole('button', {name: 'Next Event'}));
-
-    await waitFor(() => {
-      expect(router.location.pathname).toBe(
-        '/organizations/org-slug/issues/group-id/events/next-event-id/'
-      );
-      screen
-        .getAllByRole('tab')
-        .forEach(tab => expect(tab).toHaveAttribute('aria-selected', 'false'));
-    });
-  });
-
   it('can navigate next/previous events', async () => {
     render(<IssueDetailsEventNavigation {...defaultProps} />, {
       initialRouterConfig: latestRouterConfig,

--- a/static/app/views/issueDetails/eventNavigation/issueDetailsEventNavigation.tsx
+++ b/static/app/views/issueDetails/eventNavigation/issueDetailsEventNavigation.tsx
@@ -1,10 +1,9 @@
-import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
+import {Fragment, useCallback, useEffect, useState} from 'react';
 import {css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {LinkButton} from '@sentry/scraps/button';
 import {TabList, Tabs} from '@sentry/scraps/tabs';
-import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -18,19 +17,6 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {useGroupEvent} from 'sentry/views/issueDetails/useGroupEvent';
 import {useDefaultIssueEvent} from 'sentry/views/issueDetails/utils';
-
-const enum EventNavOptions {
-  RECOMMENDED = 'recommended',
-  LATEST = 'latest',
-  OLDEST = 'oldest',
-  CUSTOM = 'custom',
-}
-
-const EventNavPresetOrder = [
-  EventNavOptions.OLDEST,
-  EventNavOptions.LATEST,
-  EventNavOptions.RECOMMENDED,
-];
 
 interface IssueDetailsEventNavigationProps {
   event: Event | undefined;
@@ -77,36 +63,33 @@ export function IssueDetailsEventNavigation({
     []
   );
 
-  const selectedOption = useMemo(() => {
-    switch (params.eventId) {
-      case EventNavOptions.RECOMMENDED:
-      case EventNavOptions.LATEST:
-      case EventNavOptions.OLDEST:
-        return params.eventId;
-      case undefined:
-        return defaultIssueEvent;
-      default:
-        return EventNavOptions.CUSTOM;
+  const eventNavPresets = [
+    {
+      key: 'oldest',
+      label: t('First'),
+      tooltip: t('Earliest event matching filters'),
+    },
+    {
+      key: 'latest',
+      label: t('Latest'),
+      tooltip: t('Newest event matching filters'),
+    },
+    {
+      key: 'recommended',
+      label: isSmallNav ? t('Rec.') : t('Recommended'),
+      tooltip: t('Recent event with richer content'),
+    },
+  ] as const;
+  const currentEventKey = params.eventId ?? defaultIssueEvent;
+
+  const onTabChange = (tabKey: string) => {
+    const preset = eventNavPresets.find(({key}) => key === tabKey);
+    if (!preset) {
+      return;
     }
-  }, [params.eventId, defaultIssueEvent]);
-
-  const EventNavLabels = {
-    [EventNavOptions.RECOMMENDED]: isSmallNav ? t('Rec.') : t('Recommended'),
-    [EventNavOptions.OLDEST]: t('First'),
-    [EventNavOptions.LATEST]: t('Latest'),
-    [EventNavOptions.CUSTOM]: t('Custom'),
-  };
-
-  const EventNavTooltips = {
-    [EventNavOptions.RECOMMENDED]: t('Recent event with richer content'),
-    [EventNavOptions.OLDEST]: t('Earliest event matching filters'),
-    [EventNavOptions.LATEST]: t('Newest event matching filters'),
-  };
-
-  const onTabChange = (tabKey: typeof selectedOption) => {
     trackAnalytics('issue_details.event_navigation_selected', {
       organization,
-      content: EventNavLabels[tabKey as keyof typeof EventNavLabels],
+      content: preset.label,
     });
   };
 
@@ -166,28 +149,24 @@ export function IssueDetailsEventNavigation({
           }}
         />
       </Navigation>
-      <Tabs value={selectedOption} disableOverflow onChange={onTabChange} size="xs">
+      <Tabs value={currentEventKey} disableOverflow onChange={onTabChange} size="xs">
         <TabList variant="floating">
-          {EventNavPresetOrder.map(label => {
+          {eventNavPresets.map(({key, label, tooltip}) => {
             const eventPath =
-              label === selectedOption
+              key === currentEventKey
                 ? undefined
                 : {
-                    pathname: normalizeUrl(baseEventsPath + label + '/'),
-                    query: {...location.query, referrer: `${label}-event`},
+                    pathname: normalizeUrl(baseEventsPath + key + '/'),
+                    query: {...location.query, referrer: `${key}-event`},
                   };
             return (
               <TabList.Item
                 to={eventPath}
-                key={label}
-                textValue={EventNavLabels[label as keyof typeof EventNavLabels]}
+                key={key}
+                textValue={label}
+                tooltip={{title: tooltip}}
               >
-                <Tooltip
-                  title={EventNavTooltips[label as keyof typeof EventNavTooltips]}
-                  skipWrapper
-                >
-                  {EventNavLabels[label as keyof typeof EventNavLabels]}
-                </Tooltip>
+                {label}
               </TabList.Item>
             );
           })}

--- a/static/app/views/issueDetails/eventNavigation/issueDetailsEventNavigation.tsx
+++ b/static/app/views/issueDetails/eventNavigation/issueDetailsEventNavigation.tsx
@@ -30,7 +30,6 @@ const EventNavOrder = [
   EventNavOptions.OLDEST,
   EventNavOptions.LATEST,
   EventNavOptions.RECOMMENDED,
-  EventNavOptions.CUSTOM,
 ];
 
 interface IssueDetailsEventNavigationProps {
@@ -181,10 +180,6 @@ export function IssueDetailsEventNavigation({
               <TabList.Item
                 to={eventPath}
                 key={label}
-                hidden={
-                  label === EventNavOptions.CUSTOM &&
-                  selectedOption !== EventNavOptions.CUSTOM
-                }
                 textValue={EventNavLabels[label as keyof typeof EventNavLabels]}
               >
                 <Tooltip

--- a/static/app/views/issueDetails/eventNavigation/issueDetailsEventNavigation.tsx
+++ b/static/app/views/issueDetails/eventNavigation/issueDetailsEventNavigation.tsx
@@ -181,7 +181,10 @@ export function IssueDetailsEventNavigation({
               <TabList.Item
                 to={eventPath}
                 key={label}
-                hidden={label === EventNavOptions.CUSTOM}
+                hidden={
+                  label === EventNavOptions.CUSTOM &&
+                  selectedOption !== EventNavOptions.CUSTOM
+                }
                 textValue={EventNavLabels[label as keyof typeof EventNavLabels]}
               >
                 <Tooltip

--- a/static/app/views/issueDetails/eventNavigation/issueDetailsEventNavigation.tsx
+++ b/static/app/views/issueDetails/eventNavigation/issueDetailsEventNavigation.tsx
@@ -26,7 +26,7 @@ const enum EventNavOptions {
   CUSTOM = 'custom',
 }
 
-const EventNavOrder = [
+const EventNavPresetOrder = [
   EventNavOptions.OLDEST,
   EventNavOptions.LATEST,
   EventNavOptions.RECOMMENDED,
@@ -168,7 +168,7 @@ export function IssueDetailsEventNavigation({
       </Navigation>
       <Tabs value={selectedOption} disableOverflow onChange={onTabChange} size="xs">
         <TabList variant="floating">
-          {EventNavOrder.map(label => {
+          {EventNavPresetOrder.map(label => {
             const eventPath =
               label === selectedOption
                 ? undefined


### PR DESCRIPTION
Specific event pages could crash because the selected Custom tab was hidden. Remove that unused tab and leave the visible presets unselected instead.

fixes JAVASCRIPT-3ATW