### PR TITLE
feat(aci): Add frontend changes for "every_event" data condition

### DIFF
--- a/static/app/types/workflowEngine/dataConditions.tsx
+++ b/static/app/types/workflowEngine/dataConditions.tsx
@@ -30,6 +30,7 @@ export enum DataConditionType {
   LATEST_RELEASE = 'latest_release',
   LEVEL = 'level',
   NEW_HIGH_PRIORITY_ISSUE = 'new_high_priority_issue',
+  EVERY_EVENT = 'every_event',
   REGRESSION_EVENT = 'regression_event',
   REAPPEARED_EVENT = 'reappeared_event',
   ISSUE_RESOLVED_TRIGGER = 'issue_resolved_trigger',

--- a/static/app/views/automations/components/automationBuilder.tsx
+++ b/static/app/views/automations/components/automationBuilder.tsx
@@ -39,41 +39,38 @@ export function AutomationBuilder() {
       <Stack gap="md">
         <Step>
           <StepLead>
-            {tct(
-              '[when:When] an issue event is captured and [selector] of the following occur',
-              {
-                when: <ConditionBadge />,
-                selector: showTriggerLogicTypeSelector ? (
-                  <Container width="80px">
-                    <EmbeddedSelectField
-                      styles={{
-                        control: (provided: any) => ({
-                          ...provided,
-                          minHeight: '21px',
-                          height: '21px',
-                        }),
-                      }}
-                      isSearchable={false}
-                      isClearable={false}
-                      name={`${state.triggers.id}.logicType`}
-                      value={
-                        // We do not expose ANY as a valid option, but it is
-                        state.triggers.logicType === DataConditionGroupLogicType.ANY
-                          ? DataConditionGroupLogicType.ANY_SHORT_CIRCUIT
-                          : state.triggers.logicType
-                      }
-                      onChange={(option: SelectValue<DataConditionGroupLogicType>) =>
-                        actions.updateWhenLogicType(option.value)
-                      }
-                      options={TRIGGER_MATCH_OPTIONS}
-                      size="xs"
-                    />
-                  </Container>
-                ) : (
-                  <strong>{t('any')}</strong>
-                ),
-              }
-            )}
+            {tct('[when:When] [selector] of the following occur', {
+              when: <ConditionBadge />,
+              selector: showTriggerLogicTypeSelector ? (
+                <Container width="80px">
+                  <EmbeddedSelectField
+                    styles={{
+                      control: (provided: any) => ({
+                        ...provided,
+                        minHeight: '21px',
+                        height: '21px',
+                      }),
+                    }}
+                    isSearchable={false}
+                    isClearable={false}
+                    name={`${state.triggers.id}.logicType`}
+                    value={
+                      // We do not expose ANY as a valid option, but it is
+                      state.triggers.logicType === DataConditionGroupLogicType.ANY
+                        ? DataConditionGroupLogicType.ANY_SHORT_CIRCUIT
+                        : state.triggers.logicType
+                    }
+                    onChange={(option: SelectValue<DataConditionGroupLogicType>) =>
+                      actions.updateWhenLogicType(option.value)
+                    }
+                    options={TRIGGER_MATCH_OPTIONS}
+                    size="xs"
+                  />
+                </Container>
+              ) : (
+                <strong>{t('any')}</strong>
+              ),
+            })}
           </StepLead>
         </Step>
         <DataConditionNodeList

--- a/static/app/views/automations/components/conditionsPanel.tsx
+++ b/static/app/views/automations/components/conditionsPanel.tsx
@@ -32,17 +32,14 @@ export function ConditionsPanel({triggers, actionFilters}: ConditionsPanelProps)
       <ConditionGroupWrapper>
         <ConditionGroupHeader>
           {triggers?.conditions && triggers.conditions.length > 0
-            ? tct(
-                '[when:When] an issue event is captured and [logicType] of the following occur',
-                {
-                  when: <ConditionBadge />,
-                  logicType:
-                    TRIGGER_MATCH_OPTIONS.find(
-                      choice => choice.value === triggers?.logicType
-                    )?.label || t('any'),
-                }
-              )
-            : tct('[when:When] an issue event is captured', {
+            ? tct('[when:When] [logicType] of the following occur', {
+                when: <ConditionBadge />,
+                logicType:
+                  TRIGGER_MATCH_OPTIONS.find(
+                    choice => choice.value === triggers?.logicType
+                  )?.label || t('any'),
+              })
+            : tct('[when:When] an event is captured', {
                 when: <ConditionBadge />,
               })}
         </ConditionGroupHeader>

--- a/static/app/views/automations/components/dataConditionNodes.tsx
+++ b/static/app/views/automations/components/dataConditionNodes.tsx
@@ -142,6 +142,13 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
     },
   ],
   [
+    DataConditionType.EVERY_EVENT,
+    {
+      label: t('An event is captured'),
+      validate: undefined,
+    },
+  ],
+  [
     DataConditionType.REGRESSION_EVENT,
     {
       label: t('A resolved issue becomes unresolved'),


### PR DESCRIPTION
PR 1 of 2 for https://linear.app/getsentry/issue/ISWF-2970/add-every-event-data-condition-for-workflows

Per Josh's advice remove the wording of "an issue event occurs"

In this PR, there are 2 states the user sees when viewing the alert

state 1: no conditions selected

<img width="347" height="88" alt="image" src="https://github.com/user-attachments/assets/07fc7ff4-2f0f-40ff-8e69-e807d9fa3fcb" />

state 2: there is 1 or more conditions

<img width="445" height="113" alt="image" src="https://github.com/user-attachments/assets/682367aa-4b09-4a07-b96c-7aaedcfc7b85" />

A followup PR will contains the backend changes and must not be merged until this one is fully deployed

Note: the form when you edit / make a new one only has one state, which is always showing the following. This makes sense as it is prompting the user

<img width="1212" height="130" alt="image" src="https://github.com/user-attachments/assets/5e6b1c2d-895a-4e3e-9bae-08365ca6e691" />

