### PR TITLE
feat(aci): Add every_event data condition for alert triggers

### DIFF
--- a/src/sentry/workflow_engine/handlers/condition/__init__.py
+++ b/src/sentry/workflow_engine/handlers/condition/__init__.py
@@ -6,17 +6,18 @@ __all__ = [
     "EventFrequencyCountHandler",
     "EventFrequencyPercentHandler",
     "EventSeenCountConditionHandler",
+    "EveryEventConditionHandler",
     "ExistingHighPriorityIssueConditionHandler",
     "FirstSeenEventConditionHandler",
     "IssueCategoryConditionHandler",
     "IssueOccurrencesConditionHandler",
     "IssueOpenDurationConditionHandler",
-    "IssueTypeConditionHandler",
     "IssuePriorityCondition",
-    "IssuePriorityGreaterOrEqualConditionHandler",
     "IssuePriorityDeescalatingConditionHandler",
+    "IssuePriorityGreaterOrEqualConditionHandler",
     "IssueResolutionConditionHandler",
     "IssueResolvedTriggerCondition",
+    "IssueTypeConditionHandler",
     "LatestAdoptedReleaseConditionHandler",
     "LatestReleaseConditionHandler",
     "LevelConditionHandler",
@@ -35,6 +36,7 @@ from .event_attribute_handler import EventAttributeConditionHandler
 from .event_created_by_detector_handler import EventCreatedByDetectorConditionHandler
 from .event_frequency_handlers import EventFrequencyCountHandler, EventFrequencyPercentHandler
 from .event_seen_count_handler import EventSeenCountConditionHandler
+from .every_event_handler import EveryEventConditionHandler
 from .existing_high_priority_issue_handler import ExistingHighPriorityIssueConditionHandler
 from .first_seen_event_handler import FirstSeenEventConditionHandler
 from .issue_category_handler import IssueCategoryConditionHandler

--- a/src/sentry/workflow_engine/handlers/condition/every_event_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/every_event_handler.py
@@ -1,0 +1,16 @@
+from typing import Any
+
+from sentry.workflow_engine.models.data_condition import Condition
+from sentry.workflow_engine.registry import condition_handler_registry
+from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
+
+
+@condition_handler_registry.register(Condition.EVERY_EVENT)
+class EveryEventConditionHandler(DataConditionHandler[WorkflowEventData]):
+    group = DataConditionHandler.Group.WORKFLOW_TRIGGER
+    comparison_json_schema = {"type": "boolean"}
+    label_template = "The event occurs"
+
+    @staticmethod
+    def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:
+        return True

--- a/src/sentry/workflow_engine/models/data_condition.py
+++ b/src/sentry/workflow_engine/models/data_condition.py
@@ -38,13 +38,14 @@ class Condition(StrEnum):
     EVENT_ATTRIBUTE = "event_attribute"
     EVENT_CREATED_BY_DETECTOR = "event_created_by_detector"
     EVENT_SEEN_COUNT = "event_seen_count"
+    EVERY_EVENT = "every_event"
     EXISTING_HIGH_PRIORITY_ISSUE = "existing_high_priority_issue"
     FIRST_SEEN_EVENT = "first_seen_event"
     ISSUE_CATEGORY = "issue_category"
     ISSUE_OCCURRENCES = "issue_occurrences"
     ISSUE_OPEN_DURATION = "issue_open_duration"
-    ISSUE_PRIORITY_EQUALS = "issue_priority_equals"
     ISSUE_PRIORITY_DEESCALATING = "issue_priority_deescalating"
+    ISSUE_PRIORITY_EQUALS = "issue_priority_equals"
     ISSUE_PRIORITY_GREATER_OR_EQUAL = "issue_priority_greater_or_equal"
     ISSUE_RESOLUTION_CHANGE = "issue_resolution_change"
     ISSUE_RESOLVED_TRIGGER = "issue_resolved_trigger"
@@ -64,9 +65,6 @@ class Condition(StrEnum):
     EVENT_UNIQUE_USER_FREQUENCY_PERCENT = "event_unique_user_frequency_percent"
     PERCENT_SESSIONS_COUNT = "percent_sessions_count"
     PERCENT_SESSIONS_PERCENT = "percent_sessions_percent"
-
-    # Migration Only
-    EVERY_EVENT = "every_event"
 
     # Activity trigger conditions
     SEER_ACTIVITY_TRIGGER = "seer_activity_trigger"

--- a/tests/sentry/workflow_engine/handlers/condition/test_every_event_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_every_event_handler.py
@@ -1,0 +1,69 @@
+from typing import Any, Mapping
+
+import pytest
+from jsonschema import ValidationError
+
+from sentry.eventstream.base import GroupState
+from sentry.rules.conditions.every_event import EveryEventCondition
+from sentry.workflow_engine.models.data_condition import Condition
+from sentry.workflow_engine.types import WorkflowEventData
+from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionTestCase
+
+
+class TestEveryEventCondition(ConditionTestCase):
+    condition = Condition.EVERY_EVENT
+    payload: Mapping[str, Any] = {"id": EveryEventCondition.id}
+
+    def test_dual_write(self) -> None:
+        dcg = self.create_data_condition_group()
+        dc = self.translate_to_data_condition(self.payload, dcg)
+
+        assert dc.type == self.condition
+        assert dc.comparison is True
+        assert dc.condition_result is True
+        assert dc.condition_group == dcg
+
+    def test_json_schema(self) -> None:
+        dc = self.create_data_condition(
+            type=self.condition,
+            comparison=True,
+            condition_result=True,
+        )
+
+        dc.comparison = False
+        dc.save()
+
+        dc.comparison = {"time": "asdf"}
+        with pytest.raises(ValidationError):
+            dc.save()
+
+        dc.comparison = "hello"
+        with pytest.raises(ValidationError):
+            dc.save()
+
+    def test(self) -> None:
+        job = WorkflowEventData(
+            event=self.group_event,
+            group=self.group_event.group,
+            group_state=GroupState(
+                {
+                    "id": 1,
+                    "is_regression": True,
+                    "is_new": False,
+                    "is_new_group_environment": False,
+                }
+            ),
+        )
+
+        dc = self.create_data_condition(
+            type=self.condition,
+            comparison=True,
+            condition_result=True,
+        )
+
+        self.assert_passes(dc, job)
+
+        assert job.group_state
+        job.group_state["is_regression"] = False
+
+        self.assert_passes(dc, job)


### PR DESCRIPTION
Part 2 of 2 for https://linear.app/getsentry/issue/ISWF-2970/add-every-event-data-condition-for-workflows

This adds the every_event condition to the backend and makes it so you can select it from the frontend

This is what selecting it looks like for the user

<img width="295" height="117" alt="image" src="https://github.com/user-attachments/assets/e9dbf4fa-cb27-4a2c-abae-a5388ce150cd" />