### PR TITLE
ref(seer): Require the PR fields on a coding-agent result

### DIFF
--- a/static/app/views/seerExplorer/types.tsx
+++ b/static/app/views/seerExplorer/types.tsx
@@ -46,8 +46,8 @@ const codingAgentResultSchema = z.object({
   description: z.string(),
   repo_full_name: z.string(),
   repo_provider: z.string(),
-  pr_number: z.number().nullable().optional(),
-  pr_url: z.string().nullable().optional(),
+  pr_number: z.number().nullable(),
+  pr_url: z.string().nullable(),
 });
 
 const explorerCodingAgentStateSchema = z.object({


### PR DESCRIPTION
These fields will always be on coding agent results from now on, so cleaning up this type lets us simplify other frontend type checks.