### PR TITLE
ref(autofix): Extract next step logic into a common utility function

### DIFF
--- a/static/app/components/events/autofix/getAutofixNextStep.ts
+++ b/static/app/components/events/autofix/getAutofixNextStep.ts
@@ -1,0 +1,56 @@
+import {
+  isCodeChangesSection,
+  isPullRequestsSection,
+  isRootCauseSection,
+  isSolutionSection,
+  type AutofixSection,
+} from 'sentry/components/events/autofix/useExplorerAutofix';
+import {defined} from 'sentry/utils/defined';
+
+export type AutofixNextStep =
+  | {action: 'root_cause'; section: AutofixSection}
+  | {action: 'solution'; section: AutofixSection}
+  | {action: 'code_changes'; section: AutofixSection}
+  | {action: 'create_pr'; section: AutofixSection}
+  | {action: 'pr_iteration'; section: AutofixSection};
+
+interface GetAutofixNextStepOptions {
+  sections: AutofixSection[];
+}
+
+/**
+ * For a given list of Autofix sections, return the next action to be taken.
+ * Takes completion status into account (the next step does not change until the current section is completed)
+ *
+ * If the most recent section is a completed root cause section, returns `solution`.
+ * If the most recent section is an in-progress root cause section, returns `root_cause`.
+ */
+export function getAutofixNextStep({
+  sections,
+}: GetAutofixNextStepOptions): AutofixNextStep | null {
+  const section = sections.at(-1);
+
+  if (!defined(section)) {
+    return null;
+  }
+
+  if (isPullRequestsSection(section)) {
+    return {action: 'pr_iteration', section};
+  }
+
+  const isCompleted = section.status === 'completed';
+
+  if (isRootCauseSection(section)) {
+    return {action: isCompleted ? 'solution' : 'root_cause', section};
+  }
+
+  if (isSolutionSection(section)) {
+    return {action: isCompleted ? 'code_changes' : 'solution', section};
+  }
+
+  if (isCodeChangesSection(section)) {
+    return {action: isCompleted ? 'create_pr' : 'code_changes', section};
+  }
+
+  return null;
+}

--- a/static/app/components/events/autofix/v3/nextStep.spec.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.spec.tsx
@@ -91,13 +91,14 @@ function defaultArtifacts(step: string): AutofixSection['artifacts'] {
 
 function makeSection(
   step: string,
-  artifacts?: AutofixSection['artifacts']
+  artifacts?: AutofixSection['artifacts'],
+  status: AutofixSection['status'] = 'completed'
 ): AutofixSection {
   return {
     step,
     artifacts: artifacts ?? defaultArtifacts(step),
     blocks: [],
-    status: 'completed',
+    status,
   };
 }
 
@@ -127,6 +128,18 @@ describe('SeerDrawerNextStep', () => {
         autofix={autofix}
       />
     );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('does not render a next-step button while a section is processing', () => {
+    const {container} = render(
+      <SeerDrawerNextStep
+        group={GroupFixture()}
+        sections={[makeSection('root_cause', undefined, 'processing')]}
+        autofix={makeAutofix({isPolling: true})}
+      />
+    );
+
     expect(container).toBeEmptyDOMElement();
   });
 

--- a/static/app/components/events/autofix/v3/nextStep.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.tsx
@@ -11,6 +11,7 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {DropdownMenuFooter} from 'sentry/components/dropdownMenu/footer';
 import {getAutofixRunId} from 'sentry/components/events/autofix/autofixRunId';
+import {getAutofixNextStep} from 'sentry/components/events/autofix/getAutofixNextStep';
 import {
   organizationIntegrationsCodingAgents,
   type CodingAgentIntegration,
@@ -18,11 +19,7 @@ import {
 import {useAutofixRepos} from 'sentry/components/events/autofix/useAutofixRepos';
 import {
   getAutofixArtifactFromSection,
-  isCodeChangesSection,
-  isPullRequestsSection,
-  isRootCauseSection,
   isRunValidForPrIteration,
-  isSolutionSection,
   type AutofixSection,
   type useExplorerAutofix,
 } from 'sentry/components/events/autofix/useExplorerAutofix';
@@ -54,66 +51,62 @@ interface SeerDrawerNextStepProps {
 
 export function SeerDrawerNextStep({sections, group, autofix}: SeerDrawerNextStepProps) {
   const runId = getAutofixRunId(autofix.runState);
-  const section = sections[sections.length - 1];
+  const nextStep = getAutofixNextStep({sections});
   const referrer = autofix.runState?.blocks?.[0]?.message?.metadata?.referrer;
 
-  if (!defined(runId) || !defined(section)) {
+  if (!defined(runId) || !nextStep) {
     return null;
   }
 
-  // The PR iteration form stays visible during a run: feedback submitted while
-  // processing is queued for the next iteration rather than dropped, so we want
-  // users to be able to keep submitting even mid-run.
-  if (isPullRequestsSection(section)) {
+  if (nextStep.action === 'pr_iteration') {
     return (
       <PullRequestNextStep
         group={group}
         autofix={autofix}
         runId={runId}
-        section={section}
+        section={nextStep.section}
         referrer={referrer}
       />
     );
   }
 
-  // Every other next-step action kicks off a fresh run and can't be queued, so
-  // hide them while a run is in progress (also hides them right after clicking a
-  // next-step button).
+  // These actions start a new run and cannot be queued. The shared classifier
+  // still returns the semantic next step so other surfaces can render it busy.
   if (autofix.isPolling) {
     return null;
   }
 
-  if (isRootCauseSection(section)) {
+  if (nextStep.action === 'solution') {
     return (
       <RootCauseNextStep
         group={group}
         autofix={autofix}
         runId={runId}
-        section={section}
+        section={nextStep.section}
         referrer={referrer}
       />
     );
   }
 
-  if (isSolutionSection(section)) {
+  if (nextStep.action === 'code_changes') {
     return (
       <SolutionNextStep
         group={group}
         autofix={autofix}
         runId={runId}
-        section={section}
+        section={nextStep.section}
         referrer={referrer}
       />
     );
   }
 
-  if (isCodeChangesSection(section)) {
+  if (nextStep.action === 'create_pr') {
     return (
       <CodeChangesNextStep
         group={group}
         autofix={autofix}
         runId={runId}
-        section={section}
+        section={nextStep.section}
         referrer={referrer}
       />
     );

--- a/static/app/components/events/autofix/v3/nextStep.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.tsx
@@ -11,7 +11,6 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {DropdownMenuFooter} from 'sentry/components/dropdownMenu/footer';
 import {getAutofixRunId} from 'sentry/components/events/autofix/autofixRunId';
-import {getAutofixNextStep} from 'sentry/components/events/autofix/getAutofixNextStep';
 import {
   organizationIntegrationsCodingAgents,
   type CodingAgentIntegration,
@@ -19,7 +18,11 @@ import {
 import {useAutofixRepos} from 'sentry/components/events/autofix/useAutofixRepos';
 import {
   getAutofixArtifactFromSection,
+  isCodeChangesSection,
+  isPullRequestsSection,
+  isRootCauseSection,
   isRunValidForPrIteration,
+  isSolutionSection,
   type AutofixSection,
   type useExplorerAutofix,
 } from 'sentry/components/events/autofix/useExplorerAutofix';
@@ -51,62 +54,66 @@ interface SeerDrawerNextStepProps {
 
 export function SeerDrawerNextStep({sections, group, autofix}: SeerDrawerNextStepProps) {
   const runId = getAutofixRunId(autofix.runState);
-  const nextStep = getAutofixNextStep({sections});
+  const section = sections[sections.length - 1];
   const referrer = autofix.runState?.blocks?.[0]?.message?.metadata?.referrer;
 
-  if (!defined(runId) || !nextStep) {
+  if (!defined(runId) || !defined(section)) {
     return null;
   }
 
-  if (nextStep.action === 'pr_iteration') {
+  // The PR iteration form stays visible during a run: feedback submitted while
+  // processing is queued for the next iteration rather than dropped, so we want
+  // users to be able to keep submitting even mid-run.
+  if (isPullRequestsSection(section)) {
     return (
       <PullRequestNextStep
         group={group}
         autofix={autofix}
         runId={runId}
-        section={nextStep.section}
+        section={section}
         referrer={referrer}
       />
     );
   }
 
-  // These actions start a new run and cannot be queued. The shared classifier
-  // still returns the semantic next step so other surfaces can render it busy.
+  // Every other next-step action kicks off a fresh run and can't be queued, so
+  // hide them while a run is in progress (also hides them right after clicking a
+  // next-step button).
   if (autofix.isPolling) {
     return null;
   }
 
-  if (nextStep.action === 'solution') {
+  if (isRootCauseSection(section)) {
     return (
       <RootCauseNextStep
         group={group}
         autofix={autofix}
         runId={runId}
-        section={nextStep.section}
+        section={section}
         referrer={referrer}
       />
     );
   }
 
-  if (nextStep.action === 'code_changes') {
+  if (isSolutionSection(section)) {
     return (
       <SolutionNextStep
         group={group}
         autofix={autofix}
         runId={runId}
-        section={nextStep.section}
+        section={section}
         referrer={referrer}
       />
     );
   }
 
-  if (nextStep.action === 'create_pr') {
+  if (isCodeChangesSection(section)) {
     return (
       <CodeChangesNextStep
         group={group}
         autofix={autofix}
         runId={runId}
-        section={nextStep.section}
+        section={section}
         referrer={referrer}
       />
     );

--- a/static/app/views/issueDetails/actions/seerCommandPaletteActions.tsx
+++ b/static/app/views/issueDetails/actions/seerCommandPaletteActions.tsx
@@ -3,16 +3,13 @@ import {useQuery} from '@tanstack/react-query';
 
 import {CMDKAction} from 'sentry/components/commandPalette/ui/cmdk';
 import {getAutofixRunId} from 'sentry/components/events/autofix/autofixRunId';
+import {getAutofixNextStep} from 'sentry/components/events/autofix/getAutofixNextStep';
 import {
   organizationIntegrationsCodingAgents,
   type CodingAgentIntegration,
 } from 'sentry/components/events/autofix/useAutofix';
 import {
   getOrderedAutofixSections,
-  isCodeChangesSection,
-  isPullRequestsSection,
-  isRootCauseSection,
-  isSolutionSection,
   useExplorerAutofix,
 } from 'sentry/components/events/autofix/useExplorerAutofix';
 import {IconSeer} from 'sentry/icons';
@@ -42,26 +39,12 @@ function useSeerState(group: Group, project: Project) {
     [autofix.runState]
   );
 
-  const completedRootCause = sections.some(
-    s => isRootCauseSection(s) && s.status === 'completed'
-  );
-  const completedSolution = sections.some(
-    s => isSolutionSection(s) && s.status === 'completed'
-  );
-  const completedCodeChanges = sections.some(
-    s => isCodeChangesSection(s) && s.status === 'completed'
-  );
-  const hasPR = sections.some(isPullRequestsSection);
-
   return {
     organization,
     aiConfig,
     issueTypeSupportsSeer,
     autofix,
-    completedRootCause,
-    completedSolution,
-    completedCodeChanges,
-    hasPR,
+    sections,
   };
 }
 
@@ -76,16 +59,10 @@ export function SeerCommandPaletteActions({
   project,
   event,
 }: SeerCommandPaletteActionsProps) {
-  const {
-    organization,
-    aiConfig,
-    issueTypeSupportsSeer,
-    autofix,
-    completedRootCause,
-    completedSolution,
-    completedCodeChanges,
-    hasPR,
-  } = useSeerState(group, project);
+  const {organization, aiConfig, issueTypeSupportsSeer, autofix, sections} = useSeerState(
+    group,
+    project
+  );
 
   const {openSeerDrawer} = useOpenSeerDrawer({group, project});
 
@@ -100,8 +77,13 @@ export function SeerCommandPaletteActions({
 
   const {runState, isPolling} = autofix;
   const runId = getAutofixRunId(runState);
-
+  const nextStep = getAutofixNextStep({sections});
   const canContinue = !isPolling && defined(runId);
+  const canHandOff =
+    canContinue &&
+    sections.some(
+      section => section.step === 'root_cause' && section.status === 'completed'
+    );
 
   function handleCodingAgentHandoff(integration: CodingAgentIntegration) {
     if (!defined(runId)) {
@@ -129,7 +111,7 @@ export function SeerCommandPaletteActions({
         />
       )}
 
-      {canContinue && completedRootCause && !completedSolution && (
+      {canContinue && nextStep?.action === 'solution' && (
         <CMDKAction
           display={{label: t('Seer: Generate solution'), icon: <IconSeer />}}
           keywords={['autofix', 'seer', 'ai', 'solution']}
@@ -140,7 +122,7 @@ export function SeerCommandPaletteActions({
         />
       )}
 
-      {canContinue && completedSolution && !completedCodeChanges && (
+      {canContinue && nextStep?.action === 'code_changes' && (
         <CMDKAction
           display={{label: t('Seer: Generate code changes'), icon: <IconSeer />}}
           keywords={['autofix', 'seer', 'ai', 'code', 'changes']}
@@ -151,7 +133,7 @@ export function SeerCommandPaletteActions({
         />
       )}
 
-      {canContinue && completedCodeChanges && !hasPR && (
+      {canContinue && nextStep?.action === 'create_pr' && (
         <CMDKAction
           display={{label: t('Seer: Open pull request'), icon: <IconSeer />}}
           keywords={['autofix', 'seer', 'ai', 'pr', 'pull request', 'open pr']}
@@ -162,8 +144,7 @@ export function SeerCommandPaletteActions({
         />
       )}
 
-      {canContinue &&
-        completedRootCause &&
+      {canHandOff &&
         codingAgentIntegrations?.map(integration => (
           <CMDKAction
             key={`coding-agent:${integration.id ?? integration.provider}`}

--- a/static/app/views/issueDetails/issuePreview/issuePreviewSeerActions.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewSeerActions.tsx
@@ -2,6 +2,7 @@ import {useState} from 'react';
 
 import {Button, LinkButton} from '@sentry/scraps/button';
 
+import {getAutofixNextStep} from 'sentry/components/events/autofix/getAutofixNextStep';
 import {
   findCodingAgentResultLink,
   getRepoPullRequestLink,
@@ -9,7 +10,6 @@ import {
 import {getCodingAgentName} from 'sentry/components/events/autofix/types';
 import {
   getOrderedAutofixSections,
-  type ExplorerAutofixState,
   type useExplorerAutofix,
 } from 'sentry/components/events/autofix/useExplorerAutofix';
 import {Placeholder} from 'sentry/components/placeholder';
@@ -68,15 +68,11 @@ const AUTOFIX_ANALYTICS = {
   },
 } as const;
 
-function getAutofixPrimaryAction(
-  runState: ExplorerAutofixState | null
-): SeerAction | null {
+function getAutofixPrimaryAction(autofix: ExplorerAutofix): SeerAction | null {
+  const {runState} = autofix;
   const sections = getOrderedAutofixSections(runState);
-  const lastCompletedSection = sections.findLast(
-    section => section.status === 'completed'
-  );
 
-  if (!runState || !lastCompletedSection) {
+  if (!runState || sections.length === 0) {
     return {
       ...AUTOFIX_ANALYTICS.root_cause,
       kind: 'root_cause',
@@ -125,75 +121,51 @@ function getAutofixPrimaryAction(
     };
   }
 
-  switch (lastCompletedSection.step) {
-    case 'pull_request': {
-      const pullRequest = pullRequests[0];
-      if (!pullRequest) {
-        return null;
-      }
+  const codingAgents = Object.values(runState.coding_agents ?? {});
+  const resultLink = findCodingAgentResultLink(codingAgents);
 
-      return {
-        ...AUTOFIX_ANALYTICS.create_pr,
-        kind: 'create_pr',
-        label: t('Retry PR in %s', pullRequest.repo_name),
-        repoName: pullRequest.repo_name,
-        tooltip: pullRequest.pr_creation_error,
-      };
-    }
+  if (resultLink) {
+    return {
+      ...AUTOFIX_ANALYTICS.view,
+      kind: 'link',
+      label: resultLink.label,
+      href: resultLink.url,
+    };
+  }
 
-    case 'coding_agents': {
-      const codingAgents = Object.values(runState.coding_agents ?? {});
-      const resultLink = findCodingAgentResultLink(codingAgents);
+  const codingAgent = codingAgents.find(agent => agent.agent_url);
+  if (codingAgent?.agent_url) {
+    return {
+      ...AUTOFIX_ANALYTICS.view,
+      kind: 'link',
+      label: t('Open in %s', getCodingAgentName(codingAgent.provider)),
+      href: codingAgent.agent_url,
+    };
+  }
 
-      if (resultLink) {
-        return {
-          ...AUTOFIX_ANALYTICS.view,
-          kind: 'link',
-          label: resultLink.label,
-          href: resultLink.url,
-        };
-      }
+  const nextStep = getAutofixNextStep({sections});
 
-      const codingAgent = codingAgents.find(agent => agent.agent_url);
-      if (codingAgent?.agent_url) {
-        return {
-          ...AUTOFIX_ANALYTICS.view,
-          kind: 'link',
-          label: t('Open in %s', getCodingAgentName(codingAgent.provider)),
-          href: codingAgent.agent_url,
-        };
-      }
+  if (nextStep?.section.status !== 'completed') {
+    return {
+      ...AUTOFIX_ANALYTICS.view,
+      kind: 'view_autofix',
+      label: t('Continue in Seer'),
+    };
+  }
 
-      return null;
-    }
-
+  switch (nextStep?.action) {
+    case 'create_pr':
+      return {...AUTOFIX_ANALYTICS.create_pr, kind: 'create_pr', label: t('Draft a PR')};
     case 'code_changes':
-      return {
-        ...AUTOFIX_ANALYTICS.create_pr,
-        kind: 'create_pr',
-        label: t('Draft a PR'),
-      };
-
-    case 'solution':
       return {
         ...AUTOFIX_ANALYTICS.code_changes,
         kind: 'code_changes',
         label: t('Write a Code Fix'),
       };
-
-    case 'root_cause':
-      return {
-        ...AUTOFIX_ANALYTICS.solution,
-        kind: 'solution',
-        label: t('Make a Plan'),
-      };
-
+    case 'solution':
+      return {...AUTOFIX_ANALYTICS.solution, kind: 'solution', label: t('Make a Plan')};
     default:
-      return {
-        ...AUTOFIX_ANALYTICS.root_cause,
-        kind: 'root_cause',
-        label: t('Find Root Cause'),
-      };
+      return null;
   }
 }
 
@@ -224,7 +196,7 @@ function IssuePreviewSeerButton({
   onContinueInSeer,
 }: IssuePreviewSeerActionsProps) {
   const [isStartingAction, setIsStartingAction] = useState(false);
-  const action = getAutofixPrimaryAction(autofix.runState);
+  const action = getAutofixPrimaryAction(autofix);
   const runId = autofix.runState?.run_id;
   const busy = autofix.isPolling || isStartingAction;
 

--- a/static/app/views/issueDetails/issuePreview/issuePreviewSeerActions.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewSeerActions.tsx
@@ -145,14 +145,6 @@ function getAutofixPrimaryAction(autofix: ExplorerAutofix): SeerAction | null {
 
   const nextStep = getAutofixNextStep({sections});
 
-  if (nextStep?.section.status !== 'completed') {
-    return {
-      ...AUTOFIX_ANALYTICS.view,
-      kind: 'view_autofix',
-      label: t('Continue in Seer'),
-    };
-  }
-
   switch (nextStep?.action) {
     case 'create_pr':
       return {...AUTOFIX_ANALYTICS.create_pr, kind: 'create_pr', label: t('Draft a PR')};

--- a/static/app/views/issueDetails/issuePreview/issuePreviewSeerActions.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewSeerActions.tsx
@@ -164,6 +164,12 @@ function getAutofixPrimaryAction(autofix: ExplorerAutofix): SeerAction | null {
       };
     case 'solution':
       return {...AUTOFIX_ANALYTICS.solution, kind: 'solution', label: t('Make a Plan')};
+    case 'pr_iteration':
+      return {
+        ...AUTOFIX_ANALYTICS.view,
+        kind: 'view_autofix',
+        label: t('Continue in Seer'),
+      };
     default:
       return null;
   }

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -351,6 +351,7 @@ describe('InboxPage', () => {
   });
 
   it('shows a plus sign when a section count reaches the API cap', async () => {
+    mockIssuePreview();
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/issues/',
       match: [

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -779,6 +779,34 @@ describe('InboxPage', () => {
     ).toHaveAttribute('href', 'https://github.com/org/repository/pull/649');
   });
 
+  it('continues in Seer when a completed Autofix pull request is missing data', async () => {
+    mockSuccessfulSections();
+    mockIssuePreview();
+    mockAutofixResponse(
+      ExplorerAutofixResponseFixture({
+        autofix: ExplorerAutofixStateFixture({
+          repo_pr_states: {
+            'org/repository': AutofixRepoPRStateFixture({
+              pr_creation_status: 'completed',
+              pr_number: null,
+              pr_url: null,
+            }),
+          },
+        }),
+      })
+    );
+
+    render(<InboxPage />, {
+      organization: seerOrganization,
+      initialRouterConfig,
+    });
+
+    const preview = await openFixProposedPreview();
+    expect(
+      await within(preview).findByRole('button', {name: 'Continue in Seer'})
+    ).toBeInTheDocument();
+  });
+
   it('retries a failed Autofix pull request', async () => {
     mockSuccessfulSections();
     mockIssuePreview();


### PR DESCRIPTION
In the new issue inbox we are doing something similar to the issue details autofix drawer, but we display it differently. Both locations need to know what the next step is in order to display primary CTAs.