### PR TITLE
feat(inbox): show last progress transition time

### DIFF
--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -352,6 +352,7 @@ describe('InboxPage', () => {
 
   it('expands and collapses progress sections', async () => {
     mockSuccessfulSections();
+    mockIssuePreview();
 
     render(<InboxPage />, {organization, initialRouterConfig});
 

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -75,7 +75,7 @@ describe('InboxPage', () => {
       hasOpenFixPr: true,
       isAssigned: true,
       hasRootCause: true,
-      lastProgressedAt: null,
+      lastProgressedAt: '2026-07-20T12:00:00Z',
     },
   });
   const diagnosedGroup = GroupFixture({
@@ -256,6 +256,7 @@ describe('InboxPage', () => {
 
   it('loads and renders the three progress sections with filtered issue metadata', async () => {
     const requests = mockSuccessfulSections();
+    mockIssuePreview();
 
     render(<InboxPage />, {organization, initialRouterConfig});
 
@@ -286,6 +287,7 @@ describe('InboxPage', () => {
               sort: 'progress',
               limit: 10,
               collapse: ['stats', 'unhandled'],
+              expand: ['derivedData'],
             },
           })
         )
@@ -320,7 +322,11 @@ describe('InboxPage', () => {
     );
     expect(within(fixSection).getByLabelText('Unread issue')).toBeInTheDocument();
     expect(within(fixSection).queryByRole('checkbox')).not.toBeInTheDocument();
-    expect(fixSection.querySelector('time')).not.toBeInTheDocument();
+    const lastProgressedTime = fixSection.querySelector('time');
+    expect(lastProgressedTime).toHaveAttribute('datetime', '2026-07-20T12:00:00.000Z');
+    await userEvent.hover(lastProgressedTime!);
+    const progressStatus = await screen.findByText('Fix Proposed', {selector: 'strong'});
+    expect(progressStatus.parentElement).toHaveTextContent('Changed to Fix Proposed');
     expect(screen.queryByRole('button', {name: '7D'})).not.toBeInTheDocument();
   });
 
@@ -372,6 +378,7 @@ describe('InboxPage', () => {
 
   it('filters sections by the selected assignee', async () => {
     mockSuccessfulSections();
+    mockIssuePreview();
     const meRequests = [
       mockSection('issue.progress:fix_proposed assigned:me', [fixProposedGroup]),
       mockSection('issue.progress:diagnosed assigned:me', [diagnosedGroup]),

--- a/static/app/views/issueList/pages/inbox.tsx
+++ b/static/app/views/issueList/pages/inbox.tsx
@@ -19,8 +19,9 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import {LoadingError} from 'sentry/components/loadingError';
 import {Placeholder} from 'sentry/components/placeholder';
 import {QueryCount} from 'sentry/components/queryCount';
+import {TimeSince} from 'sentry/components/timeSince';
 import {IconArrow, IconChevron} from 'sentry/icons';
-import {t, tn} from 'sentry/locale';
+import {t, tct, tn} from 'sentry/locale';
 import {ProgressState, type Group} from 'sentry/types/group';
 import type {User} from 'sentry/types/user';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
@@ -210,6 +211,7 @@ function InboxSection({assignmentFilter, section, selectedIssueId}: InboxSection
         sort: IssueSortOptions.PROGRESS,
         limit: ISSUE_LIMIT,
         collapse: ['stats', 'unhandled'],
+        expand: ['derivedData'],
       },
       staleTime: 0,
     }),
@@ -282,6 +284,7 @@ function InboxSection({assignmentFilter, section, selectedIssueId}: InboxSection
               <Container key={group.id} padding="0 xs">
                 <InboxIssueCard
                   group={group}
+                  progressLabel={section.label}
                   selected={selectedIssueId === group.id}
                   assignedUser={
                     group.assignedTo?.type === 'user'
@@ -313,9 +316,11 @@ function InboxSection({assignmentFilter, section, selectedIssueId}: InboxSection
 function InboxIssueCard({
   assignedUser,
   group,
+  progressLabel,
   selected,
 }: {
   group: Group;
+  progressLabel: string;
   selected: boolean;
   assignedUser?: User;
 }) {
@@ -357,7 +362,20 @@ function InboxIssueCard({
             </Text>
           </Flex>
         </Stack>
-        <Flex align="center">
+        <Stack align="end" justify="between">
+          {group.derivedData?.lastProgressedAt ? (
+            <Text size="sm" variant="muted">
+              <TimeSince
+                date={group.derivedData.lastProgressedAt}
+                tooltipPrefix={tct('Changed to [status]', {
+                  status: <strong>{progressLabel}</strong>,
+                })}
+                unitStyle="short"
+              />
+            </Text>
+          ) : (
+            <div />
+          )}
           {group.assignedTo &&
             (group.assignedTo.type === 'user' ? (
               <UserAvatar
@@ -374,7 +392,7 @@ function InboxIssueCard({
                 title={group.assignedTo.name}
               />
             ))}
-        </Flex>
+        </Stack>
       </Grid>
     </IssueCardLink>
   );


### PR DESCRIPTION
Closes ISWF-3193

Inbox issue cards now show how long ago each issue entered its current progress state, since this is the value that we're sorting on in this view (and not the first seen or last seen times that we normally have). Added a tooltip to make the value more clear.

<img width="208" height="132" alt="CleanShot 2026-08-03 at 14 29 46" src="https://github.com/user-attachments/assets/03242c75-0070-4d7b-8f83-fd5530806908" />
