### PR TITLE
ref(wfe-evals): To Logger Method

### DIFF
--- a/src/sentry/workflow_engine/processors/evaluation_logging.py
+++ b/src/sentry/workflow_engine/processors/evaluation_logging.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import random
+from collections.abc import Mapping
+from logging import Logger
+from typing import TYPE_CHECKING
+
+from sentry_sdk import logger as sentry_logger
+
+from sentry import features, options
+from sentry.workflow_engine.processors.evaluations.workflow import WorkflowEvaluation
+from sentry.workflow_engine.types import WorkflowId
+
+if TYPE_CHECKING:
+    from sentry.models.organization import Organization
+
+
+def emit_workflow_evaluation_logs(
+    logger: Logger,
+    *,
+    organization: Organization,
+    evaluations: Mapping[WorkflowId, WorkflowEvaluation],
+) -> bool:
+    """Sample a batch and emit one self-contained artifact per workflow evaluation."""
+    if not evaluations:
+        return False
+
+    should_log = features.has("organizations:workflow-engine-log-evaluations", organization)
+    if not should_log:
+        should_log = random.random() < options.get("workflow_engine.evaluation_log_sample_rate")
+
+    if not should_log:
+        return False
+
+    direct_to_sentry = options.get("workflow_engine.evaluation_logs_direct_to_sentry")
+    for evaluation in evaluations.values():
+        artifact = evaluation.to_artifact()
+        log_name = "workflow_engine.process_workflows.evaluation"
+        if artifact["triggered_action_ids"]:
+            log_name = f"{log_name}.actions.triggered"
+        elif evaluation.triggered:
+            log_name = f"{log_name}.workflows.triggered"
+        else:
+            log_name = f"{log_name}.workflows.not_triggered"
+
+        if direct_to_sentry:
+            sentry_logger.info(log_name, attributes=artifact)
+        else:
+            logger.info(log_name, extra=artifact)
+
+    return True

--- a/src/sentry/workflow_engine/processors/evaluation_logging.py
+++ b/src/sentry/workflow_engine/processors/evaluation_logging.py
@@ -1,30 +1,29 @@
 from __future__ import annotations
 
 import random
-from collections.abc import Mapping
 from logging import Logger
 from typing import TYPE_CHECKING
 
 from sentry_sdk import logger as sentry_logger
 
 from sentry import features, options
-from sentry.workflow_engine.processors.evaluations.workflow import WorkflowEvaluation
-from sentry.workflow_engine.types import WorkflowId
+from sentry.workflow_engine.processors.evaluations.workflow import ProcessWorkflowsResult
 
 if TYPE_CHECKING:
     from sentry.models.organization import Organization
+
+
+WORKFLOW_EVALUATION_LOG_PREFIX = "workflow_engine.process_workflows.evaluation"
 
 
 def emit_workflow_evaluation_logs(
     logger: Logger,
     *,
     organization: Organization,
-    evaluations: Mapping[WorkflowId, WorkflowEvaluation],
+    result: ProcessWorkflowsResult,
+    log_prefix: str = WORKFLOW_EVALUATION_LOG_PREFIX,
 ) -> bool:
     """Sample a batch and emit one self-contained artifact per workflow evaluation."""
-    if not evaluations:
-        return False
-
     should_log = features.has("organizations:workflow-engine-log-evaluations", organization)
     if not should_log:
         should_log = random.random() < options.get("workflow_engine.evaluation_log_sample_rate")
@@ -33,19 +32,17 @@ def emit_workflow_evaluation_logs(
         return False
 
     direct_to_sentry = options.get("workflow_engine.evaluation_logs_direct_to_sentry")
-    for evaluation in evaluations.values():
-        artifact = evaluation.to_artifact()
-        log_name = "workflow_engine.process_workflows.evaluation"
-        if artifact["triggered_action_ids"]:
-            log_name = f"{log_name}.actions.triggered"
-        elif evaluation.triggered:
-            log_name = f"{log_name}.workflows.triggered"
-        else:
-            log_name = f"{log_name}.workflows.not_triggered"
+    artifacts = (
+        [evaluation.to_artifact() for evaluation in result.evaluations.values()]
+        if result.evaluations
+        else [result.to_artifact()]
+    )
+    for artifact in artifacts:
+        artifact["organization_id"] = organization.id
 
         if direct_to_sentry:
-            sentry_logger.info(log_name, attributes=artifact)
+            sentry_logger.info(log_prefix, attributes=artifact)
         else:
-            logger.info(log_name, extra=artifact)
+            logger.info(log_prefix, extra=artifact)
 
     return True

--- a/src/sentry/workflow_engine/processors/evaluation_logging.py
+++ b/src/sentry/workflow_engine/processors/evaluation_logging.py
@@ -4,9 +4,8 @@ import random
 from logging import Logger
 from typing import TYPE_CHECKING
 
-from sentry_sdk import logger as sentry_logger
-
 from sentry import features, options
+from sentry.utils.sdk import sdk_logger
 from sentry.workflow_engine.processors.evaluations.workflow import ProcessWorkflowsResult
 
 if TYPE_CHECKING:
@@ -41,7 +40,7 @@ def emit_workflow_evaluation_logs(
         artifact["organization_id"] = organization.id
 
         if direct_to_sentry:
-            sentry_logger.info(log_prefix, attributes=artifact)
+            sdk_logger.info(log_prefix, attributes=artifact)
         else:
             logger.info(log_prefix, extra=artifact)
 

--- a/src/sentry/workflow_engine/processors/evaluations/__init__.py
+++ b/src/sentry/workflow_engine/processors/evaluations/__init__.py
@@ -4,7 +4,6 @@ __all__ = [
     "DataConditionGroupEvaluation",
     "DetectorEvaluation",
     "DetectorEvaluationData",
-    "GroupedWorkflowEvaluationResult",
     "WorkflowEvaluation",
     "WorkflowEvaluationData",
 ]
@@ -13,7 +12,6 @@ from .condition import DataConditionEvaluation, DataConditionEvaluationException
 from .condition_group import DataConditionGroupEvaluation
 from .detector import DetectorEvaluation, DetectorEvaluationData
 from .workflow import (
-    GroupedWorkflowEvaluationResult,
     WorkflowEvaluation,
     WorkflowEvaluationData,
 )

--- a/src/sentry/workflow_engine/processors/evaluations/__init__.py
+++ b/src/sentry/workflow_engine/processors/evaluations/__init__.py
@@ -4,14 +4,20 @@ __all__ = [
     "DataConditionGroupEvaluation",
     "DetectorEvaluation",
     "DetectorEvaluationData",
+    "DeferredWorkflowEvaluationResult",
+    "ProcessWorkflowsResult",
     "WorkflowEvaluation",
     "WorkflowEvaluationData",
+    "WorkflowEvaluationOutcome",
 ]
 
 from .condition import DataConditionEvaluation, DataConditionEvaluationException
 from .condition_group import DataConditionGroupEvaluation
 from .detector import DetectorEvaluation, DetectorEvaluationData
 from .workflow import (
+    DeferredWorkflowEvaluationResult,
+    ProcessWorkflowsResult,
     WorkflowEvaluation,
     WorkflowEvaluationData,
+    WorkflowEvaluationOutcome,
 )

--- a/src/sentry/workflow_engine/processors/evaluations/base.py
+++ b/src/sentry/workflow_engine/processors/evaluations/base.py
@@ -1,14 +1,9 @@
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field, replace
-from typing import Any, TypedDict
+from typing import Any
 
 from sentry.workflow_engine.types import ConditionError
-
-
-class EvaluationArtifact(TypedDict):
-    triggered: bool
-    error: str | None
 
 
 def _find_error(
@@ -54,15 +49,16 @@ class BaseWorkflowEngineEvaluation[R, D](ABC):
         """
         return self.error is not None
 
-    def _base_artifact(self) -> EvaluationArtifact:
+    def to_artifact(self) -> dict[str, Any]:
         return {
             "triggered": self.triggered,
             "error": self.error.msg if self.error else None,
+            **self._artifact_data(),
         }
 
     @abstractmethod
-    def to_artifact(self) -> dict[str, Any]:
-        """Return an explicit, logger-safe representation of this evaluation."""
+    def _artifact_data(self) -> dict[str, Any]:
+        """Return the evaluation-specific fields for the artifact."""
         raise NotImplementedError
 
     def with_error(self, error: ConditionError) -> "BaseWorkflowEngineEvaluation[R, D]":

--- a/src/sentry/workflow_engine/processors/evaluations/base.py
+++ b/src/sentry/workflow_engine/processors/evaluations/base.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field, replace
 from typing import Any, TypedDict
@@ -5,7 +6,7 @@ from typing import Any, TypedDict
 from sentry.workflow_engine.types import ConditionError
 
 
-class EvaluationLog(TypedDict):
+class EvaluationArtifact(TypedDict):
     triggered: bool
     error: str | None
 
@@ -19,7 +20,7 @@ def _find_error(
 
 
 @dataclass(frozen=True, kw_only=True)
-class BaseWorkflowEngineEvaluation[R, D]:
+class BaseWorkflowEngineEvaluation[R, D](ABC):
     """
     This is a shared base class for all Evaluation classes.
 
@@ -35,6 +36,9 @@ class BaseWorkflowEngineEvaluation[R, D]:
     The static `any`/`all`/`none` and `choose_tainted` helpers implement taint-aware boolean
     algebra over evaluations: when an input had an error that could affect the result, the returned
     `(triggered, error)` carries a representative error so the taint propagates.
+
+    Concrete evaluations implement `to_artifact` to select safe, useful fields from their
+    result and data without generically serializing models or event payloads.
     """
 
     result: R
@@ -50,12 +54,16 @@ class BaseWorkflowEngineEvaluation[R, D]:
         """
         return self.error is not None
 
-    def to_log(self) -> EvaluationLog:
-        """Return the common, logger-safe fields for an evaluation."""
+    def _base_artifact(self) -> EvaluationArtifact:
         return {
             "triggered": self.triggered,
             "error": self.error.msg if self.error else None,
         }
+
+    @abstractmethod
+    def to_artifact(self) -> dict[str, Any]:
+        """Return an explicit, logger-safe representation of this evaluation."""
+        raise NotImplementedError
 
     def with_error(self, error: ConditionError) -> "BaseWorkflowEngineEvaluation[R, D]":
         """

--- a/src/sentry/workflow_engine/processors/evaluations/base.py
+++ b/src/sentry/workflow_engine/processors/evaluations/base.py
@@ -51,9 +51,9 @@ class BaseWorkflowEngineEvaluation[R, D](ABC):
 
     def to_artifact(self) -> dict[str, Any]:
         return {
+            **self.artifact_fields,
             "triggered": self.triggered,
             "error": self.error.msg if self.error else None,
-            **self.artifact_fields,
         }
 
     @property

--- a/src/sentry/workflow_engine/processors/evaluations/base.py
+++ b/src/sentry/workflow_engine/processors/evaluations/base.py
@@ -1,8 +1,13 @@
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field, replace
-from typing import Any
+from typing import Any, TypedDict
 
 from sentry.workflow_engine.types import ConditionError
+
+
+class EvaluationLog(TypedDict):
+    triggered: bool
+    error: str | None
 
 
 def _find_error(
@@ -44,6 +49,13 @@ class BaseWorkflowEngineEvaluation[R, D]:
         evaluation.
         """
         return self.error is not None
+
+    def to_log(self) -> EvaluationLog:
+        """Return the common, logger-safe fields for an evaluation."""
+        return {
+            "triggered": self.triggered,
+            "error": self.error.msg if self.error else None,
+        }
 
     def with_error(self, error: ConditionError) -> "BaseWorkflowEngineEvaluation[R, D]":
         """

--- a/src/sentry/workflow_engine/processors/evaluations/base.py
+++ b/src/sentry/workflow_engine/processors/evaluations/base.py
@@ -32,8 +32,8 @@ class BaseWorkflowEngineEvaluation[R, D](ABC):
     algebra over evaluations: when an input had an error that could affect the result, the returned
     `(triggered, error)` carries a representative error so the taint propagates.
 
-    Concrete evaluations implement `to_artifact` to select safe, useful fields from their
-    result and data without generically serializing models or event payloads.
+    Concrete evaluations provide `artifact_fields` to select safe, useful fields from their
+    result and data. `to_artifact` combines those fields with the common evaluation state.
     """
 
     result: R
@@ -53,12 +53,13 @@ class BaseWorkflowEngineEvaluation[R, D](ABC):
         return {
             "triggered": self.triggered,
             "error": self.error.msg if self.error else None,
-            **self._artifact_data(),
+            **self.artifact_fields,
         }
 
+    @property
     @abstractmethod
-    def _artifact_data(self) -> dict[str, Any]:
-        """Return the evaluation-specific fields for the artifact."""
+    def artifact_fields(self) -> dict[str, Any]:
+        """The evaluation-specific fields included in the artifact."""
         raise NotImplementedError
 
     def with_error(self, error: ConditionError) -> "BaseWorkflowEngineEvaluation[R, D]":

--- a/src/sentry/workflow_engine/processors/evaluations/condition.py
+++ b/src/sentry/workflow_engine/processors/evaluations/condition.py
@@ -42,3 +42,14 @@ class DataConditionEvaluation(
 
     result: DataConditionResult = None
     condition: DataCondition
+
+    def to_artifact(self) -> dict[str, Any]:
+        safe_input = self.data if isinstance(self.data, (bool, int, float)) else None
+        return {
+            **self._base_artifact(),
+            "condition_id": self.condition.id,
+            "condition_type": self.condition.type,
+            "input_type": type(self.data).__name__,
+            "input": safe_input,
+            "result": getattr(self.result, "value", self.result),
+        }

--- a/src/sentry/workflow_engine/processors/evaluations/condition.py
+++ b/src/sentry/workflow_engine/processors/evaluations/condition.py
@@ -43,7 +43,8 @@ class DataConditionEvaluation(
     result: DataConditionResult = None
     condition: DataCondition
 
-    def _artifact_data(self) -> dict[str, Any]:
+    @property
+    def artifact_fields(self) -> dict[str, Any]:
         safe_input = self.data if isinstance(self.data, (bool, int, float, str)) else None
         return {
             "condition_id": self.condition.id,

--- a/src/sentry/workflow_engine/processors/evaluations/condition.py
+++ b/src/sentry/workflow_engine/processors/evaluations/condition.py
@@ -43,10 +43,9 @@ class DataConditionEvaluation(
     result: DataConditionResult = None
     condition: DataCondition
 
-    def to_artifact(self) -> dict[str, Any]:
-        safe_input = self.data if isinstance(self.data, (bool, int, float)) else None
+    def _artifact_data(self) -> dict[str, Any]:
+        safe_input = self.data if isinstance(self.data, (bool, int, float, str)) else None
         return {
-            **self._base_artifact(),
             "condition_id": self.condition.id,
             "condition_type": self.condition.type,
             "input_type": type(self.data).__name__,

--- a/src/sentry/workflow_engine/processors/evaluations/condition_group.py
+++ b/src/sentry/workflow_engine/processors/evaluations/condition_group.py
@@ -31,10 +31,9 @@ class DataConditionGroupEvaluation(BaseWorkflowEngineEvaluation[bool, GroupEvalu
     - triggered: bool - whether the group's conditions passed
     """
 
-    def to_artifact(self) -> dict[str, Any]:
+    def _artifact_data(self) -> dict[str, Any]:
         logic_type = self.data["logic_type"]
         return {
-            **self._base_artifact(),
             "logic_type": getattr(logic_type, "value", logic_type),
             "result": self.result,
             "condition_evaluations": [

--- a/src/sentry/workflow_engine/processors/evaluations/condition_group.py
+++ b/src/sentry/workflow_engine/processors/evaluations/condition_group.py
@@ -31,7 +31,8 @@ class DataConditionGroupEvaluation(BaseWorkflowEngineEvaluation[bool, GroupEvalu
     - triggered: bool - whether the group's conditions passed
     """
 
-    def _artifact_data(self) -> dict[str, Any]:
+    @property
+    def artifact_fields(self) -> dict[str, Any]:
         logic_type = self.data["logic_type"]
         return {
             "logic_type": getattr(logic_type, "value", logic_type),

--- a/src/sentry/workflow_engine/processors/evaluations/condition_group.py
+++ b/src/sentry/workflow_engine/processors/evaluations/condition_group.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict
 
 from .base import BaseWorkflowEngineEvaluation
 from .condition import DataConditionEvaluation
@@ -31,4 +31,13 @@ class DataConditionGroupEvaluation(BaseWorkflowEngineEvaluation[bool, GroupEvalu
     - triggered: bool - whether the group's conditions passed
     """
 
-    pass
+    def to_artifact(self) -> dict[str, Any]:
+        logic_type = self.data["logic_type"]
+        return {
+            **self._base_artifact(),
+            "logic_type": getattr(logic_type, "value", logic_type),
+            "result": self.result,
+            "condition_evaluations": [
+                evaluation.to_artifact() for evaluation in self.data["condition_evaluations"]
+            ],
+        }

--- a/src/sentry/workflow_engine/processors/evaluations/detector.py
+++ b/src/sentry/workflow_engine/processors/evaluations/detector.py
@@ -42,9 +42,10 @@ class DetectorEvaluation(
 
     @property
     def artifact_fields(self) -> dict[str, Any]:
+        # Each trigger group evaluation will log the value used in evaluation
+        # We only need to extract the top level detector items for tracking here.
         return {
             "group_key": self.data["group_key"],
             "priority": self.priority.value,
-            "result_type": type(self.result).__name__ if self.result is not None else None,
             "trigger_group_evaluation": self.data["trigger_group_evaluation"].to_artifact(),
         }

--- a/src/sentry/workflow_engine/processors/evaluations/detector.py
+++ b/src/sentry/workflow_engine/processors/evaluations/detector.py
@@ -39,3 +39,12 @@ class DetectorEvaluation(
 
     result: DetectorResult = None
     priority: DetectorPriorityLevel
+
+    def to_artifact(self) -> dict[str, Any]:
+        return {
+            **self._base_artifact(),
+            "group_key": self.data["group_key"],
+            "priority": self.priority.value,
+            "result_type": type(self.result).__name__ if self.result is not None else None,
+            "trigger_group_evaluation": self.data["trigger_group_evaluation"].to_artifact(),
+        }

--- a/src/sentry/workflow_engine/processors/evaluations/detector.py
+++ b/src/sentry/workflow_engine/processors/evaluations/detector.py
@@ -40,9 +40,8 @@ class DetectorEvaluation(
     result: DetectorResult = None
     priority: DetectorPriorityLevel
 
-    def to_artifact(self) -> dict[str, Any]:
+    def _artifact_data(self) -> dict[str, Any]:
         return {
-            **self._base_artifact(),
             "group_key": self.data["group_key"],
             "priority": self.priority.value,
             "result_type": type(self.result).__name__ if self.result is not None else None,

--- a/src/sentry/workflow_engine/processors/evaluations/detector.py
+++ b/src/sentry/workflow_engine/processors/evaluations/detector.py
@@ -40,7 +40,8 @@ class DetectorEvaluation(
     result: DetectorResult = None
     priority: DetectorPriorityLevel
 
-    def _artifact_data(self) -> dict[str, Any]:
+    @property
+    def artifact_fields(self) -> dict[str, Any]:
         return {
             "group_key": self.data["group_key"],
             "priority": self.priority.value,

--- a/src/sentry/workflow_engine/processors/evaluations/workflow.py
+++ b/src/sentry/workflow_engine/processors/evaluations/workflow.py
@@ -4,16 +4,22 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import TypedDict
 
-from sentry.workflow_engine.types import WorkflowEvaluationResult, WorkflowEventData, WorkflowId
+from sentry.workflow_engine.types import (
+    WORKFLOW_EVALUATION_DEFERRED,
+    DataConditionGroupId,
+    WorkflowEvaluationResult,
+    WorkflowEventData,
+    WorkflowId,
+)
 
 from .base import BaseWorkflowEngineEvaluation
 from .condition_group import DataConditionGroupEvaluation
 
 
 class DeferredWorkflowEvaluationData(TypedDict):
-    delayed_when_group_id: int | None
-    delayed_if_group_ids: list[int]
-    passing_if_group_ids: list[int]
+    delayed_when_group_id: DataConditionGroupId | None
+    delayed_if_group_ids: list[DataConditionGroupId]
+    passing_if_group_ids: list[DataConditionGroupId]
 
 
 class WorkflowEvaluationData(TypedDict):
@@ -56,8 +62,8 @@ class WorkflowEvaluation(
     detector_id: int
     detector_type: str
 
-    def to_artifact(self) -> dict[str, object]:
-        if self.result == "deferred":
+    def _artifact_data(self) -> dict[str, object]:
+        if self.result == WORKFLOW_EVALUATION_DEFERRED:
             result_type = "deferred"
             triggered_action_ids: list[int] = []
         else:
@@ -67,7 +73,6 @@ class WorkflowEvaluation(
         event_data = self.data["event"]
         event_id = getattr(event_data.event, "event_id", None)
         return {
-            **self._base_artifact(),
             "workflow_id": self.workflow_id,
             "detector_id": self.detector_id,
             "detector_type": self.detector_type,
@@ -85,6 +90,6 @@ class WorkflowEvaluation(
 
 def has_triggered_actions(evaluations: Mapping[WorkflowId, WorkflowEvaluation]) -> bool:
     return any(
-        evaluation.result != "deferred" and bool(evaluation.result)
+        evaluation.result != WORKFLOW_EVALUATION_DEFERRED and bool(evaluation.result)
         for evaluation in evaluations.values()
     )

--- a/src/sentry/workflow_engine/processors/evaluations/workflow.py
+++ b/src/sentry/workflow_engine/processors/evaluations/workflow.py
@@ -1,24 +1,19 @@
 from __future__ import annotations
 
-import random
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, TypedDict
+from typing import TypedDict
 
-from sentry_sdk import logger as sentry_logger
+from sentry.workflow_engine.types import WorkflowEvaluationResult, WorkflowEventData, WorkflowId
 
-from sentry import features, options
-from sentry.workflow_engine.types import WorkflowEvaluationResult, WorkflowEventData
-
-from .base import BaseWorkflowEngineEvaluation, EvaluationLog
+from .base import BaseWorkflowEngineEvaluation
 from .condition_group import DataConditionGroupEvaluation
 
-if TYPE_CHECKING:
-    from logging import Logger
 
-    from sentry.models.organization import Organization
-    from sentry.workflow_engine.models import Detector
-    from sentry.workflow_engine.types import WorkflowId
+class DeferredWorkflowEvaluationData(TypedDict):
+    delayed_when_group_id: int | None
+    delayed_if_group_ids: list[int]
+    passing_if_group_ids: list[int]
 
 
 class WorkflowEvaluationData(TypedDict):
@@ -30,28 +25,13 @@ class WorkflowEvaluationData(TypedDict):
     `trigger_group_eval`: The evaluation of the conditions for triggering a workflow.
     `filter_group_evals`: All of the condition groups that determine if an action should be triggered.
     `event`: The data that started the workflow's evaluation.
+    `deferred`: A snapshot of condition-group IDs pending slow evaluation.
     """
 
     trigger_group_eval: DataConditionGroupEvaluation
     filter_group_evals: Sequence[DataConditionGroupEvaluation]
     event: WorkflowEventData
-
-
-class WorkflowEvaluationLog(EvaluationLog):
-    triggered_action_ids: list[int]
-    deferred: bool
-
-
-class WorkflowEvaluationsLog(TypedDict):
-    event_id: str | None
-    group_id: int
-    detection_type: str | None
-    workflow_ids: list[int] | None
-    triggered_workflow_ids: list[int]
-    delayed_conditions: list[str] | None
-    action_filter_group_ids: list[int]
-    triggered_action_ids: list[int]
-    debug_msg: str | None
+    deferred: DeferredWorkflowEvaluationData | None
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -72,18 +52,34 @@ class WorkflowEvaluation(
     - `triggered`: bool - Whether the workflow's trigger (WHEN) conditions passed.
     """
 
-    def to_log(self) -> WorkflowEvaluationLog:
-        if self.result == "deferred":
-            return {
-                **super().to_log(),
-                "triggered_action_ids": [],
-                "deferred": True,
-            }
+    workflow_id: WorkflowId
+    detector_id: int
+    detector_type: str
 
+    def to_artifact(self) -> dict[str, object]:
+        if self.result == "deferred":
+            result_type = "deferred"
+            triggered_action_ids: list[int] = []
+        else:
+            result_type = "actions"
+            triggered_action_ids = [action.id for action in self.result]
+
+        event_data = self.data["event"]
+        event_id = getattr(event_data.event, "event_id", None)
         return {
-            **super().to_log(),
-            "triggered_action_ids": [action.id for action in self.result],
-            "deferred": False,
+            **self._base_artifact(),
+            "workflow_id": self.workflow_id,
+            "detector_id": self.detector_id,
+            "detector_type": self.detector_type,
+            "event_id": str(event_id) if event_id else None,
+            "group_id": event_data.group.id,
+            "result_type": result_type,
+            "triggered_action_ids": triggered_action_ids,
+            "deferred": self.data["deferred"],
+            "trigger_group_evaluation": self.data["trigger_group_eval"].to_artifact(),
+            "filter_group_evaluations": [
+                evaluation.to_artifact() for evaluation in self.data["filter_group_evals"]
+            ],
         }
 
 
@@ -92,62 +88,3 @@ def has_triggered_actions(evaluations: Mapping[WorkflowId, WorkflowEvaluation]) 
         evaluation.result != "deferred" and bool(evaluation.result)
         for evaluation in evaluations.values()
     )
-
-
-def log_workflow_evaluations(
-    logger: Logger,
-    *,
-    organization: Organization,
-    event_data: WorkflowEventData,
-    evaluations: Mapping[WorkflowId, WorkflowEvaluation],
-    detector: Detector | None = None,
-    workflow_ids: Sequence[WorkflowId] | None = None,
-    delayed_conditions: Sequence[str] | None = None,
-    action_filter_group_ids: Sequence[int] = (),
-    debug_msg: str | None = None,
-) -> bool:
-    """Sample and emit a flattened log for a batch of workflow evaluations."""
-    should_log = features.has("organizations:workflow-engine-log-evaluations", organization)
-    if not should_log:
-        should_log = random.random() < options.get("workflow_engine.evaluation_log_sample_rate")
-
-    if not should_log:
-        return False
-
-    triggered_workflow_ids: list[WorkflowId] = []
-    triggered_action_ids: list[int] = []
-    for workflow_id, evaluation in evaluations.items():
-        evaluation_log = evaluation.to_log()
-        if evaluation_log["triggered"]:
-            triggered_workflow_ids.append(workflow_id)
-        triggered_action_ids.extend(evaluation_log["triggered_action_ids"])
-
-    triggered_workflow_ids.sort()
-    triggered_action_ids.sort()
-
-    log_name = "workflow_engine.process_workflows.evaluation"
-    if triggered_action_ids:
-        log_name = f"{log_name}.actions.triggered"
-    elif triggered_workflow_ids:
-        log_name = f"{log_name}.workflows.triggered"
-    else:
-        log_name = f"{log_name}.workflows.not_triggered"
-
-    event_id = getattr(event_data.event, "event_id", None)
-    extra = WorkflowEvaluationsLog(
-        event_id=str(event_id) if event_id else None,
-        group_id=event_data.group.id,
-        detection_type=detector.type if detector else None,
-        workflow_ids=sorted(workflow_ids) if workflow_ids else None,
-        triggered_workflow_ids=triggered_workflow_ids,
-        delayed_conditions=sorted(delayed_conditions) if delayed_conditions else None,
-        action_filter_group_ids=sorted(action_filter_group_ids),
-        triggered_action_ids=triggered_action_ids,
-        debug_msg=debug_msg,
-    )
-
-    if options.get("workflow_engine.evaluation_logs_direct_to_sentry"):
-        sentry_logger.info(log_name, attributes=extra)
-    else:
-        logger.info(log_name, extra=extra)
-    return True

--- a/src/sentry/workflow_engine/processors/evaluations/workflow.py
+++ b/src/sentry/workflow_engine/processors/evaluations/workflow.py
@@ -114,19 +114,16 @@ def log_workflow_evaluations(
     if not should_log:
         return False
 
-    evaluation_logs = {
-        workflow_id: evaluation.to_log() for workflow_id, evaluation in evaluations.items()
-    }
-    triggered_workflow_ids = sorted(
-        workflow_id
-        for workflow_id, evaluation_log in evaluation_logs.items()
-        if evaluation_log["triggered"]
-    )
-    triggered_action_ids = sorted(
-        action_id
-        for evaluation_log in evaluation_logs.values()
-        for action_id in evaluation_log["triggered_action_ids"]
-    )
+    triggered_workflow_ids: list[WorkflowId] = []
+    triggered_action_ids: list[int] = []
+    for workflow_id, evaluation in evaluations.items():
+        evaluation_log = evaluation.to_log()
+        if evaluation_log["triggered"]:
+            triggered_workflow_ids.append(workflow_id)
+        triggered_action_ids.extend(evaluation_log["triggered_action_ids"])
+
+    triggered_workflow_ids.sort()
+    triggered_action_ids.sort()
 
     log_name = "workflow_engine.process_workflows.evaluation"
     if triggered_action_ids:

--- a/src/sentry/workflow_engine/processors/evaluations/workflow.py
+++ b/src/sentry/workflow_engine/processors/evaluations/workflow.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import random
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, TypedDict
 
@@ -10,22 +10,14 @@ from sentry_sdk import logger as sentry_logger
 from sentry import features, options
 from sentry.workflow_engine.types import WorkflowEvaluationResult, WorkflowEventData
 
-from .base import BaseWorkflowEngineEvaluation
+from .base import BaseWorkflowEngineEvaluation, EvaluationLog
 from .condition_group import DataConditionGroupEvaluation
 
 if TYPE_CHECKING:
     from logging import Logger
 
-    from sentry.models.activity import Activity
-    from sentry.models.group import Group
     from sentry.models.organization import Organization
-    from sentry.services.eventstore.models import GroupEvent
-    from sentry.workflow_engine.buffer.batch_client import DelayedWorkflowItem
-    from sentry.workflow_engine.models import Action, DataConditionGroup, Detector, Workflow
-    from sentry.workflow_engine.models.action import ActionSnapshot
-    from sentry.workflow_engine.models.data_condition_group import DataConditionGroupSnapshot
-    from sentry.workflow_engine.models.detector import DetectorSnapshot
-    from sentry.workflow_engine.models.workflow import WorkflowSnapshot
+    from sentry.workflow_engine.models import Detector
     from sentry.workflow_engine.types import WorkflowId
 
 
@@ -43,6 +35,23 @@ class WorkflowEvaluationData(TypedDict):
     trigger_group_eval: DataConditionGroupEvaluation
     filter_group_evals: Sequence[DataConditionGroupEvaluation]
     event: WorkflowEventData
+
+
+class WorkflowEvaluationLog(EvaluationLog):
+    triggered_action_ids: list[int]
+    deferred: bool
+
+
+class WorkflowEvaluationsLog(TypedDict):
+    event_id: str | None
+    group_id: int
+    detection_type: str | None
+    workflow_ids: list[int] | None
+    triggered_workflow_ids: list[int]
+    delayed_conditions: list[str] | None
+    action_filter_group_ids: list[int]
+    triggered_action_ids: list[int]
+    debug_msg: str | None
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -63,156 +72,85 @@ class WorkflowEvaluation(
     - `triggered`: bool - Whether the workflow's trigger (WHEN) conditions passed.
     """
 
-    pass
-
-
-class WorkflowEvaluationSnapshot(TypedDict):
-    """
-    A snapshot of data used to evaluate workflows for an event.
-    Ensure that this size is kept smaller, since it's used in logging.
-    """
-
-    associated_detector: DetectorSnapshot | None
-    event_id: str | None  # ID in NodeStore
-    group: Group | None
-    workflow_ids: list[int] | None
-    triggered_workflows: list[WorkflowSnapshot] | None
-    delayed_conditions: list[str] | None
-    action_filter_conditions: list[DataConditionGroupSnapshot] | None
-    triggered_actions: list[ActionSnapshot] | None
-
-
-@dataclass(frozen=True, kw_only=True)
-class GroupedWorkflowEvaluationResult:
-    """
-    The result of `process_workflows` for a single event: the per-workflow
-    `WorkflowEvaluation` objects plus the batch-level context needed for logging
-    and to drive downstream side effects (service hooks).
-
-    Mirrors `GroupedDetectorEvaluationResult` from the detector path.
-
-    The `tainted` flag indicates whether actions have been triggered during the
-    workflows evaluation (`False` only once actions fire, `True` for every early exit).
-
-    The `msg` field is used for debug information during the evaluation.
-    """
-
-    # Per-workflow evaluations, keyed by workflow id. Empty for sentinel early-returns.
-    result: dict[WorkflowId, WorkflowEvaluation]
-    tainted: bool
-
-    # Batch-level context used by log_to / get_snapshot / consumers.
-    organization: Organization
-    event: GroupEvent | Activity
-    group: Group | None = None
-    msg: str | None = None
-    associated_detector: Detector | None = None
-    workflows: set[Workflow] | None = None
-    triggered_workflows: set[Workflow] | None = None
-    action_groups: set[DataConditionGroup] | None = None
-    triggered_actions: set[Action] | None = None
-    delayed_conditions: dict[Workflow, DelayedWorkflowItem] | None = None
-
-    def get_snapshot(self) -> WorkflowEvaluationSnapshot:
-        """
-        This method will take the complex data structures, like models / list of models,
-        and turn them into the critical attributes of a model or lists of IDs.
-        """
-
-        associated_detector = None
-        if self.associated_detector:
-            associated_detector = self.associated_detector.get_snapshot()
-
-        workflow_ids = None
-        if self.workflows:
-            workflow_ids = [workflow.id for workflow in self.workflows]
-
-        triggered_workflows = None
-        if self.triggered_workflows:
-            triggered_workflows = [workflow.get_snapshot() for workflow in self.triggered_workflows]
-
-        action_filter_conditions = None
-        if self.action_groups:
-            action_filter_conditions = [group.get_snapshot() for group in self.action_groups]
-
-        triggered_actions = None
-        if self.triggered_actions:
-            triggered_actions = [action.get_snapshot() for action in self.triggered_actions]
-
-        event_id = None
-        if hasattr(self.event, "event_id"):
-            event_id = str(self.event.event_id)
-
-        delayed_conditions = None
-        if self.delayed_conditions:
-            delayed_conditions = [
-                delayed_item.buffer_key() for _, delayed_item in self.delayed_conditions.items()
-            ]
+    def to_log(self) -> WorkflowEvaluationLog:
+        if self.result == "deferred":
+            return {
+                **super().to_log(),
+                "triggered_action_ids": [],
+                "deferred": True,
+            }
 
         return {
-            "associated_detector": associated_detector,
-            "event_id": event_id,
-            "group": self.event.group,
-            "workflow_ids": workflow_ids,
-            "triggered_workflows": triggered_workflows,
-            "delayed_conditions": delayed_conditions,
-            "action_filter_conditions": action_filter_conditions,
-            "triggered_actions": triggered_actions,
+            **super().to_log(),
+            "triggered_action_ids": [action.id for action in self.result],
+            "deferred": False,
         }
 
-    def log_to(self, logger: Logger) -> bool:
-        """
-        Logs workflow evaluation data.
-        Logging may be skipped if the organization isn't opted in and logs are being
-        sampled.
-        Returns True if logged, False otherwise.
-        """
-        # Check if we should log this evaluation
-        organization = self.organization
-        should_log = features.has("organizations:workflow-engine-log-evaluations", organization)
-        direct_to_sentry = options.get("workflow_engine.evaluation_logs_direct_to_sentry")
 
-        if not should_log:
-            sample_rate = options.get("workflow_engine.evaluation_log_sample_rate")
-            should_log = random.random() < sample_rate
+def has_triggered_actions(evaluations: Mapping[WorkflowId, WorkflowEvaluation]) -> bool:
+    return any(
+        evaluation.result != "deferred" and bool(evaluation.result)
+        for evaluation in evaluations.values()
+    )
 
-        if not should_log:
-            return False
 
-        log_str = "workflow_engine.process_workflows.evaluation"
+def log_workflow_evaluations(
+    logger: Logger,
+    *,
+    organization: Organization,
+    event_data: WorkflowEventData,
+    evaluations: Mapping[WorkflowId, WorkflowEvaluation],
+    detector: Detector | None = None,
+    workflow_ids: Sequence[WorkflowId] | None = None,
+    delayed_conditions: Sequence[str] | None = None,
+    action_filter_group_ids: Sequence[int] = (),
+    debug_msg: str | None = None,
+) -> bool:
+    """Sample and emit a flattened log for a batch of workflow evaluations."""
+    should_log = features.has("organizations:workflow-engine-log-evaluations", organization)
+    if not should_log:
+        should_log = random.random() < options.get("workflow_engine.evaluation_log_sample_rate")
 
-        if self.tainted:
-            if not self.triggered_workflows:
-                log_str = f"{log_str}.workflows.not_triggered"
-            else:
-                log_str = f"{log_str}.workflows.triggered"
-        else:
-            log_str = f"{log_str}.actions.triggered"
+    if not should_log:
+        return False
 
-        data_snapshot = self.get_snapshot()
-        detection_type = (
-            data_snapshot["associated_detector"]["type"]
-            if data_snapshot["associated_detector"]
-            else None
-        )
-        group_id = data_snapshot["group"].id if data_snapshot["group"] else None
-        triggered_workflows = data_snapshot["triggered_workflows"] or []
-        action_filter_conditions = data_snapshot["action_filter_conditions"] or []
-        triggered_actions = data_snapshot["triggered_actions"] or []
-        extra = {
-            "event_id": data_snapshot["event_id"],
-            "group_id": group_id,
-            "detection_type": detection_type,
-            "workflow_ids": data_snapshot["workflow_ids"],
-            "triggered_workflow_ids": [w["id"] for w in triggered_workflows],
-            "delayed_conditions": data_snapshot["delayed_conditions"],
-            "action_filter_group_ids": [afg["id"] for afg in action_filter_conditions],
-            "triggered_action_ids": [a["id"] for a in triggered_actions],
-            "debug_msg": self.msg,
-        }
+    evaluation_logs = {
+        workflow_id: evaluation.to_log() for workflow_id, evaluation in evaluations.items()
+    }
+    triggered_workflow_ids = sorted(
+        workflow_id
+        for workflow_id, evaluation_log in evaluation_logs.items()
+        if evaluation_log["triggered"]
+    )
+    triggered_action_ids = sorted(
+        action_id
+        for evaluation_log in evaluation_logs.values()
+        for action_id in evaluation_log["triggered_action_ids"]
+    )
 
-        if direct_to_sentry:
-            sentry_logger.info(log_str, attributes=extra)
-        else:
-            logger.info(log_str, extra=extra)
-        return True
+    log_name = "workflow_engine.process_workflows.evaluation"
+    if triggered_action_ids:
+        log_name = f"{log_name}.actions.triggered"
+    elif triggered_workflow_ids:
+        log_name = f"{log_name}.workflows.triggered"
+    else:
+        log_name = f"{log_name}.workflows.not_triggered"
+
+    event_id = getattr(event_data.event, "event_id", None)
+    extra = WorkflowEvaluationsLog(
+        event_id=str(event_id) if event_id else None,
+        group_id=event_data.group.id,
+        detection_type=detector.type if detector else None,
+        workflow_ids=sorted(workflow_ids) if workflow_ids else None,
+        triggered_workflow_ids=triggered_workflow_ids,
+        delayed_conditions=sorted(delayed_conditions) if delayed_conditions else None,
+        action_filter_group_ids=sorted(action_filter_group_ids),
+        triggered_action_ids=triggered_action_ids,
+        debug_msg=debug_msg,
+    )
+
+    if options.get("workflow_engine.evaluation_logs_direct_to_sentry"):
+        sentry_logger.info(log_name, attributes=extra)
+    else:
+        logger.info(log_name, extra=extra)
+    return True

--- a/src/sentry/workflow_engine/processors/evaluations/workflow.py
+++ b/src/sentry/workflow_engine/processors/evaluations/workflow.py
@@ -30,15 +30,18 @@ type WorkflowEvaluationResult = Sequence[Action] | DeferredWorkflowEvaluationRes
 
 
 class WorkflowEvaluationOutcome(StrEnum):
-    COMPLETED = "completed"
-    NO_DETECTOR = "no_detector"
+    # Error Outcomes
     ENVIRONMENT_NOT_FOUND = "environment_not_found"
+    ERROR = "error"
+    NO_DETECTOR = "no_detector"
     NO_WORKFLOWS = "no_workflows"
-    NOT_TRIGGERED = "not_triggered"
+
+    # Finished evaluation outcomes
+    ACTIONS_TRIGGERED = "actions_triggered"
+    COMPLETED = "completed"
     DEFERRED = "deferred"
     NO_ACTIONS = "no_actions"
-    ACTIONS_TRIGGERED = "actions_triggered"
-    ERROR = "error"
+    NOT_TRIGGERED = "not_triggered"
 
 
 class WorkflowEvaluationData(TypedDict):

--- a/src/sentry/workflow_engine/processors/evaluations/workflow.py
+++ b/src/sentry/workflow_engine/processors/evaluations/workflow.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import TypedDict
+from enum import StrEnum
+from typing import TYPE_CHECKING, TypedDict
 
+from sentry.services.eventstore.models import GroupEvent
 from sentry.workflow_engine.types import (
-    WORKFLOW_EVALUATION_DEFERRED,
     DataConditionGroupId,
-    WorkflowEvaluationResult,
     WorkflowEventData,
     WorkflowId,
 )
@@ -15,11 +15,30 @@ from sentry.workflow_engine.types import (
 from .base import BaseWorkflowEngineEvaluation
 from .condition_group import DataConditionGroupEvaluation
 
+if TYPE_CHECKING:
+    from sentry.workflow_engine.models import Action
 
-class DeferredWorkflowEvaluationData(TypedDict):
+
+@dataclass(frozen=True, kw_only=True)
+class DeferredWorkflowEvaluationResult:
     delayed_when_group_id: DataConditionGroupId | None
-    delayed_if_group_ids: list[DataConditionGroupId]
-    passing_if_group_ids: list[DataConditionGroupId]
+    delayed_if_group_ids: frozenset[DataConditionGroupId]
+    passing_if_group_ids: frozenset[DataConditionGroupId]
+
+
+type WorkflowEvaluationResult = Sequence[Action] | DeferredWorkflowEvaluationResult
+
+
+class WorkflowEvaluationOutcome(StrEnum):
+    COMPLETED = "completed"
+    NO_DETECTOR = "no_detector"
+    ENVIRONMENT_NOT_FOUND = "environment_not_found"
+    NO_WORKFLOWS = "no_workflows"
+    NOT_TRIGGERED = "not_triggered"
+    DEFERRED = "deferred"
+    NO_ACTIONS = "no_actions"
+    ACTIONS_TRIGGERED = "actions_triggered"
+    ERROR = "error"
 
 
 class WorkflowEvaluationData(TypedDict):
@@ -31,13 +50,11 @@ class WorkflowEvaluationData(TypedDict):
     `trigger_group_eval`: The evaluation of the conditions for triggering a workflow.
     `filter_group_evals`: All of the condition groups that determine if an action should be triggered.
     `event`: The data that started the workflow's evaluation.
-    `deferred`: A snapshot of condition-group IDs pending slow evaluation.
     """
 
     trigger_group_eval: DataConditionGroupEvaluation
     filter_group_evals: Sequence[DataConditionGroupEvaluation]
     event: WorkflowEventData
-    deferred: DeferredWorkflowEvaluationData | None
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -51,8 +68,8 @@ class WorkflowEvaluation(
     Stores the evaluation of a single workflow.
 
     Inherited Properties
-    - `result`: The actions that are triggered from the workflow, or the "deferred"
-        sentinel when there are slow conditions to batch evaluate.
+    - `result`: The actions triggered from the workflow, or deferred evaluation details
+        when there are slow conditions to batch evaluate.
     - `data`: WorkflowEvaluationData
     - `error`: ConditionError - Set when there's an error while evaluating the workflow.
     - `triggered`: bool - Whether the workflow's trigger (WHEN) conditions passed.
@@ -62,25 +79,51 @@ class WorkflowEvaluation(
     detector_id: int
     detector_type: str
 
-    def _artifact_data(self) -> dict[str, object]:
-        if self.result == WORKFLOW_EVALUATION_DEFERRED:
+    @property
+    def outcome(self) -> WorkflowEvaluationOutcome:
+        if isinstance(self.result, DeferredWorkflowEvaluationResult):
+            return WorkflowEvaluationOutcome.DEFERRED
+        if self.error or any(evaluation.error for evaluation in self.data["filter_group_evals"]):
+            return WorkflowEvaluationOutcome.ERROR
+        if not self.triggered:
+            return WorkflowEvaluationOutcome.NOT_TRIGGERED
+
+        if self.result:
+            return WorkflowEvaluationOutcome.ACTIONS_TRIGGERED
+        return WorkflowEvaluationOutcome.NO_ACTIONS
+
+    @property
+    def artifact_fields(self) -> dict[str, object]:
+        if isinstance(self.result, DeferredWorkflowEvaluationResult):
             result_type = "deferred"
             triggered_action_ids: list[int] = []
+            deferred: dict[str, object] | None = {
+                "delayed_when_group_id": self.result.delayed_when_group_id,
+                "delayed_if_group_ids": sorted(self.result.delayed_if_group_ids),
+                "passing_if_group_ids": sorted(self.result.passing_if_group_ids),
+            }
         else:
             result_type = "actions"
             triggered_action_ids = [action.id for action in self.result]
+            deferred = None
 
         event_data = self.data["event"]
-        event_id = getattr(event_data.event, "event_id", None)
+        event_id = (
+            event_data.event.event_id
+            if isinstance(event_data.event, GroupEvent)
+            else event_data.event.id
+        )
         return {
             "workflow_id": self.workflow_id,
             "detector_id": self.detector_id,
             "detector_type": self.detector_type,
+            "project_id": event_data.event.project_id,
             "event_id": str(event_id) if event_id else None,
             "group_id": event_data.group.id,
+            "outcome": self.outcome,
             "result_type": result_type,
             "triggered_action_ids": triggered_action_ids,
-            "deferred": self.data["deferred"],
+            "deferred": deferred,
             "trigger_group_evaluation": self.data["trigger_group_eval"].to_artifact(),
             "filter_group_evaluations": [
                 evaluation.to_artifact() for evaluation in self.data["filter_group_evals"]
@@ -88,8 +131,29 @@ class WorkflowEvaluation(
         }
 
 
-def has_triggered_actions(evaluations: Mapping[WorkflowId, WorkflowEvaluation]) -> bool:
-    return any(
-        evaluation.result != WORKFLOW_EVALUATION_DEFERRED and bool(evaluation.result)
-        for evaluation in evaluations.values()
-    )
+@dataclass(frozen=True, kw_only=True)
+class ProcessWorkflowsResult:
+    evaluations: dict[WorkflowId, WorkflowEvaluation]
+    outcome: WorkflowEvaluationOutcome
+    project_id: int
+    group_id: int
+    event_id: str | None
+    detector_id: int | None = None
+    detector_type: str | None = None
+
+    def has_triggered_actions(self) -> bool:
+        return any(
+            not isinstance(evaluation.result, DeferredWorkflowEvaluationResult)
+            and bool(evaluation.result)
+            for evaluation in self.evaluations.values()
+        )
+
+    def to_artifact(self) -> dict[str, object]:
+        return {
+            "outcome": self.outcome,
+            "project_id": self.project_id,
+            "group_id": self.group_id,
+            "event_id": self.event_id,
+            "detector_id": self.detector_id,
+            "detector_type": self.detector_type,
+        }

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -28,8 +28,8 @@ from sentry.workflow_engine.processors.data_condition_group import (
 from sentry.workflow_engine.processors.detector import get_detectors_for_event_data
 from sentry.workflow_engine.processors.evaluations import DataConditionGroupEvaluation
 from sentry.workflow_engine.processors.evaluations.workflow import (
-    GroupedWorkflowEvaluationResult,
     WorkflowEvaluation,
+    log_workflow_evaluations,
 )
 from sentry.workflow_engine.processors.workflow_fire_history import create_workflow_fire_histories
 from sentry.workflow_engine.types import (
@@ -485,7 +485,7 @@ def process_workflows(
     event_data: WorkflowEventData,
     event_start_time: datetime,
     detector: Detector | None = None,
-) -> GroupedWorkflowEvaluationResult:
+) -> dict[WorkflowId, WorkflowEvaluation]:
     """
     This method will get the detector based on the event, and then gather the associated workflows.
     Next, it will evaluate the "when" (or trigger) conditions for each workflow, if the conditions are met,
@@ -518,14 +518,14 @@ def process_workflows(
             )
         )
     except Detector.DoesNotExist:
-        return GroupedWorkflowEvaluationResult(
-            result={},
-            tainted=True,
+        log_workflow_evaluations(
+            logger,
             organization=organization,
-            event=event_data.event,
-            group=event_data.group,
-            msg="No Detectors associated with the issue were found",
+            event_data=event_data,
+            evaluations={},
+            debug_msg="No Detectors associated with the issue were found",
         )
+        return {}
 
     associated_detector = event_detectors.preferred_detector
 
@@ -541,15 +541,15 @@ def process_workflows(
             )
         )
     except Environment.DoesNotExist:
-        return GroupedWorkflowEvaluationResult(
-            result={},
-            tainted=True,
+        log_workflow_evaluations(
+            logger,
             organization=organization,
-            event=event_data.event,
-            group=event_data.group,
-            msg="Environment for event not found",
-            associated_detector=associated_detector,
+            event_data=event_data,
+            evaluations={},
+            detector=associated_detector,
+            debug_msg="Environment for event not found",
         )
+        return {}
 
     if features.has("organizations:workflow-engine-process-workflows-logs", organization):
         log_context.set_verbose(True)
@@ -592,37 +592,40 @@ def process_workflows(
         )
 
     if not workflows:
-        return GroupedWorkflowEvaluationResult(
-            result={},
-            tainted=True,
+        log_workflow_evaluations(
+            logger,
             organization=organization,
-            event=event_data.event,
-            group=event_data.group,
-            msg="No workflows are associated with the detector in the event",
-            associated_detector=associated_detector,
-            workflows=workflows,
+            event_data=event_data,
+            evaluations={},
+            detector=associated_detector,
+            debug_msg="No workflows are associated with the detector in the event",
         )
+        return {}
 
     triggered_workflows, queue_items_by_workflow_id, trigger_stats, trigger_evals = (
         evaluate_workflow_triggers(workflows, event_data, event_start_time)
     )
 
-    triggered_workflow_set = set(triggered_workflows.keys())
-
     if not triggered_workflows and not queue_items_by_workflow_id:
         trigger_stats.report_metrics("process_workflows.workflows_evaluated")
-        # TODO - re-think tainted once the actions are removed from process_workflows.
-        return GroupedWorkflowEvaluationResult(
-            result={},
-            tainted=True,
-            organization=organization,
-            event=event_data.event,
-            group=event_data.group,
-            msg="No items were triggered or queued for slow evaluation",
-            associated_detector=associated_detector,
-            workflows=workflows,
-            triggered_workflows=triggered_workflow_set,
+        workflow_evaluations = _build_workflow_evaluations(
+            event_data=event_data,
+            trigger_evals=trigger_evals,
+            filter_evals={},
+            deferred_workflow_ids=set(),
+            actions=[],
+            action_to_workflow_id={},
         )
+        log_workflow_evaluations(
+            logger,
+            organization=organization,
+            event_data=event_data,
+            evaluations=workflow_evaluations,
+            detector=associated_detector,
+            workflow_ids=[workflow.id for workflow in workflows],
+            debug_msg="No items were triggered or queued for slow evaluation",
+        )
+        return workflow_evaluations
 
     # TODO - we should probably return here and have the rest from here be
     # `process_actions`, this will take a list of "triggered_workflows"
@@ -653,20 +656,18 @@ def process_workflows(
     sentry_sdk.set_attribute("workflow_engine.triggered_actions", len(triggered_actions))
 
     if not actions:
-        return GroupedWorkflowEvaluationResult(
-            result=workflow_evaluations,
-            tainted=True,
+        log_workflow_evaluations(
+            logger,
             organization=organization,
-            event=event_data.event,
-            group=event_data.group,
-            msg="No actions to evaluate; filtered or not triggered",
-            associated_detector=associated_detector,
-            workflows=workflows,
-            triggered_workflows=triggered_workflow_set,
-            action_groups=actions_to_trigger,
-            triggered_actions=triggered_actions,
-            delayed_conditions=queue_items_by_workflow_id,
+            event_data=event_data,
+            evaluations=workflow_evaluations,
+            detector=associated_detector,
+            workflow_ids=[workflow.id for workflow in workflows],
+            delayed_conditions=[item.buffer_key() for item in queue_items_by_workflow_id.values()],
+            action_filter_group_ids=[group.id for group in actions_to_trigger],
+            debug_msg="No actions to evaluate; filtered or not triggered",
         )
+        return workflow_evaluations
 
     fire_histories = create_workflow_fire_histories(
         actions,
@@ -689,16 +690,14 @@ def process_workflows(
         action_to_workflow_id=action_to_workflow_id,
     )
 
-    return GroupedWorkflowEvaluationResult(
-        result=workflow_evaluations,
-        tainted=False,
+    log_workflow_evaluations(
+        logger,
         organization=organization,
-        event=event_data.event,
-        group=event_data.group,
-        associated_detector=associated_detector,
-        workflows=workflows,
-        triggered_workflows=triggered_workflow_set,
-        action_groups=actions_to_trigger,
-        triggered_actions=triggered_actions,
-        delayed_conditions=queue_items_by_workflow_id,
+        event_data=event_data,
+        evaluations=workflow_evaluations,
+        detector=associated_detector,
+        workflow_ids=[workflow.id for workflow in workflows],
+        delayed_conditions=[item.buffer_key() for item in queue_items_by_workflow_id.values()],
+        action_filter_group_ids=[group.id for group in actions_to_trigger],
     )
+    return workflow_evaluations

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -616,7 +616,6 @@ def process_workflows(
     logger.debug(
         "workflow_engine.process_workflows",
         extra={
-            "payload": event_data,
             "group_id": event_data.group.id,
             "event_id": event_id,
             "event_environment_id": environment.id if environment else None,

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -28,8 +28,8 @@ from sentry.workflow_engine.processors.data_condition_group import (
 from sentry.workflow_engine.processors.detector import get_detectors_for_event_data
 from sentry.workflow_engine.processors.evaluations import DataConditionGroupEvaluation
 from sentry.workflow_engine.processors.evaluations.workflow import (
+    DeferredWorkflowEvaluationData,
     WorkflowEvaluation,
-    log_workflow_evaluations,
 )
 from sentry.workflow_engine.processors.workflow_fire_history import create_workflow_fire_histories
 from sentry.workflow_engine.types import (
@@ -437,10 +437,11 @@ def _get_associated_workflows(
 
 def _build_workflow_evaluations(
     *,
+    detector: Detector,
     event_data: WorkflowEventData,
     trigger_evals: dict[Workflow, DataConditionGroupEvaluation],
     filter_evals: dict[Workflow, list[DataConditionGroupEvaluation]],
-    deferred_workflow_ids: set[WorkflowId],
+    delayed_items: dict[Workflow, DelayedWorkflowItem],
     actions: Iterable[Action],
     action_to_workflow_id: dict[int, WorkflowId],
 ) -> dict[WorkflowId, WorkflowEvaluation]:
@@ -451,8 +452,7 @@ def _build_workflow_evaluations(
     `result` is the "deferred" sentinel for workflows enqueued for slow evaluation, otherwise
     the actions that fired for that workflow (empty when the workflow triggered but no actions
     fired). `action_to_workflow_id` attributes each action to a single workflow, so an action
-    shared across workflows is counted once here; the batch-level triggered_actions holds the
-    complete set.
+    shared across workflows is counted once here.
     """
     actions_by_workflow_id: dict[WorkflowId, list[Action]] = defaultdict(list)
     for action in actions:
@@ -461,12 +461,22 @@ def _build_workflow_evaluations(
 
     workflow_evaluations: dict[WorkflowId, WorkflowEvaluation] = {}
     for workflow, trigger_eval in trigger_evals.items():
-        result: WorkflowEvaluationResult = (
-            "deferred"
-            if workflow.id in deferred_workflow_ids
-            else actions_by_workflow_id.get(workflow.id, [])
-        )
+        delayed_item = delayed_items.get(workflow)
+        if delayed_item:
+            result: WorkflowEvaluationResult = "deferred"
+            deferred: DeferredWorkflowEvaluationData | None = {
+                "delayed_when_group_id": delayed_item.delayed_when_group_id,
+                "delayed_if_group_ids": sorted(delayed_item.delayed_if_group_ids),
+                "passing_if_group_ids": sorted(delayed_item.passing_if_group_ids),
+            }
+        else:
+            result = actions_by_workflow_id.get(workflow.id, [])
+            deferred = None
+
         workflow_evaluations[workflow.id] = WorkflowEvaluation(
+            workflow_id=workflow.id,
+            detector_id=detector.id,
+            detector_type=detector.type,
             result=result,
             triggered=trigger_eval.triggered,
             error=trigger_eval.error,
@@ -474,6 +484,7 @@ def _build_workflow_evaluations(
                 "trigger_group_eval": trigger_eval,
                 "filter_group_evals": filter_evals.get(workflow, []),
                 "event": event_data,
+                "deferred": deferred,
             },
         )
     return workflow_evaluations
@@ -518,13 +529,6 @@ def process_workflows(
             )
         )
     except Detector.DoesNotExist:
-        log_workflow_evaluations(
-            logger,
-            organization=organization,
-            event_data=event_data,
-            evaluations={},
-            debug_msg="No Detectors associated with the issue were found",
-        )
         return {}
 
     associated_detector = event_detectors.preferred_detector
@@ -541,14 +545,6 @@ def process_workflows(
             )
         )
     except Environment.DoesNotExist:
-        log_workflow_evaluations(
-            logger,
-            organization=organization,
-            event_data=event_data,
-            evaluations={},
-            detector=associated_detector,
-            debug_msg="Environment for event not found",
-        )
         return {}
 
     if features.has("organizations:workflow-engine-process-workflows-logs", organization):
@@ -570,39 +566,27 @@ def process_workflows(
         if options.get("workflow_engine.filter_cross_org_workflows"):
             workflows = workflows - wrong_org_workflows
 
-    if workflows:
-        metrics_incr("process_workflows", len(workflows))
-
-        event_id = (
-            event_data.event.event_id
-            if isinstance(event_data.event, GroupEvent)
-            else event_data.event.id
-        )
-        logger.debug(
-            "workflow_engine.process_workflows",
-            extra={
-                "payload": event_data,
-                "group_id": event_data.group.id,
-                "event_id": event_id,
-                "event_data": asdict(event_data),
-                "event_environment_id": environment.id if environment else None,
-                "workflows": [workflow.id for workflow in workflows],
-                "detector_types": [d.type for d in event_detectors.detectors],
-            },
-        )
-
     if not workflows:
-        log_workflow_evaluations(
-            logger,
-            organization=organization,
-            event_data=event_data,
-            evaluations={},
-            detector=associated_detector,
-            debug_msg="No workflows are associated with the detector in the event",
-        )
         return {}
 
-    workflow_ids = [workflow.id for workflow in workflows]
+    metrics_incr("process_workflows", len(workflows))
+    event_id = (
+        event_data.event.event_id
+        if isinstance(event_data.event, GroupEvent)
+        else event_data.event.id
+    )
+    logger.debug(
+        "workflow_engine.process_workflows",
+        extra={
+            "payload": event_data,
+            "group_id": event_data.group.id,
+            "event_id": event_id,
+            "event_data": asdict(event_data),
+            "event_environment_id": environment.id if environment else None,
+            "workflows": [workflow.id for workflow in workflows],
+            "detector_types": [d.type for d in event_detectors.detectors],
+        },
+    )
 
     triggered_workflows, queue_items_by_workflow_id, trigger_stats, trigger_evals = (
         evaluate_workflow_triggers(workflows, event_data, event_start_time)
@@ -610,24 +594,15 @@ def process_workflows(
 
     if not triggered_workflows and not queue_items_by_workflow_id:
         trigger_stats.report_metrics("process_workflows.workflows_evaluated")
-        workflow_evaluations = _build_workflow_evaluations(
+        return _build_workflow_evaluations(
+            detector=associated_detector,
             event_data=event_data,
             trigger_evals=trigger_evals,
             filter_evals={},
-            deferred_workflow_ids=set(),
+            delayed_items={},
             actions=[],
             action_to_workflow_id={},
         )
-        log_workflow_evaluations(
-            logger,
-            organization=organization,
-            event_data=event_data,
-            evaluations=workflow_evaluations,
-            detector=associated_detector,
-            workflow_ids=workflow_ids,
-            debug_msg="No items were triggered or queued for slow evaluation",
-        )
-        return workflow_evaluations
 
     # TODO - we should probably return here and have the rest from here be
     # `process_actions`, this will take a list of "triggered_workflows"
@@ -645,63 +620,39 @@ def process_workflows(
     )
 
     workflow_evaluations = _build_workflow_evaluations(
+        detector=associated_detector,
         event_data=event_data,
         trigger_evals=trigger_evals,
         filter_evals=filter_evals,
-        deferred_workflow_ids={wf.id for wf in queue_items_by_workflow_id},
+        delayed_items=queue_items_by_workflow_id,
         actions=actions,
         action_to_workflow_id=action_to_workflow_id,
     )
-    delayed_condition_keys = [item.buffer_key() for item in queue_items_by_workflow_id.values()]
-    action_filter_group_ids = [group.id for group in actions_to_trigger]
 
-    triggered_actions = set(actions)
-    sentry_sdk.set_tag("workflow_engine.triggered_actions", len(triggered_actions))
-    sentry_sdk.set_attribute("workflow_engine.triggered_actions", len(triggered_actions))
+    triggered_action_count = len(set(actions))
+    sentry_sdk.set_tag("workflow_engine.triggered_actions", triggered_action_count)
+    sentry_sdk.set_attribute("workflow_engine.triggered_actions", triggered_action_count)
 
-    if not actions:
-        log_workflow_evaluations(
-            logger,
-            organization=organization,
-            event_data=event_data,
-            evaluations=workflow_evaluations,
-            detector=associated_detector,
-            workflow_ids=workflow_ids,
-            delayed_conditions=delayed_condition_keys,
-            action_filter_group_ids=action_filter_group_ids,
-            debug_msg="No actions to evaluate; filtered or not triggered",
+    if actions:
+        fire_histories = create_workflow_fire_histories(
+            actions,
+            event_data,
+            is_delayed=False,
+            start_timestamp=event_start_time,
         )
-        return workflow_evaluations
 
-    fire_histories = create_workflow_fire_histories(
-        actions,
-        event_data,
-        is_delayed=False,
-        start_timestamp=event_start_time,
-    )
+        # Create mapping: workflow_id -> notification_uuid for propagation
+        workflow_uuid_map: dict[WorkflowId, str] = {}
+        if fire_histories:
+            workflow_uuid_map = {
+                history.workflow_id: str(history.notification_uuid) for history in fire_histories
+            }
 
-    # Create mapping: workflow_id -> notification_uuid for propagation
-    workflow_uuid_map: dict[WorkflowId, str] = {}
-    if fire_histories:
-        workflow_uuid_map = {
-            history.workflow_id: str(history.notification_uuid) for history in fire_histories
-        }
+        fire_actions(
+            actions,
+            event_data,
+            workflow_uuid_map=workflow_uuid_map,
+            action_to_workflow_id=action_to_workflow_id,
+        )
 
-    fire_actions(
-        actions,
-        event_data,
-        workflow_uuid_map=workflow_uuid_map,
-        action_to_workflow_id=action_to_workflow_id,
-    )
-
-    log_workflow_evaluations(
-        logger,
-        organization=organization,
-        event_data=event_data,
-        evaluations=workflow_evaluations,
-        detector=associated_detector,
-        workflow_ids=workflow_ids,
-        delayed_conditions=delayed_condition_keys,
-        action_filter_group_ids=action_filter_group_ids,
-    )
     return workflow_evaluations

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -619,7 +619,6 @@ def process_workflows(
             "payload": event_data,
             "group_id": event_data.group.id,
             "event_id": event_id,
-            "event_data": asdict(event_data),
             "event_environment_id": environment.id if environment else None,
             "workflows": [workflow.id for workflow in workflows],
             "detector_types": [d.type for d in event_detectors.detectors],

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -33,6 +33,7 @@ from sentry.workflow_engine.processors.evaluations.workflow import (
 )
 from sentry.workflow_engine.processors.workflow_fire_history import create_workflow_fire_histories
 from sentry.workflow_engine.types import (
+    WORKFLOW_EVALUATION_DEFERRED,
     WorkflowEvaluationResult,
     WorkflowEventData,
     WorkflowId,
@@ -463,7 +464,7 @@ def _build_workflow_evaluations(
     for workflow, trigger_eval in trigger_evals.items():
         delayed_item = delayed_items.get(workflow)
         if delayed_item:
-            result: WorkflowEvaluationResult = "deferred"
+            result: WorkflowEvaluationResult = WORKFLOW_EVALUATION_DEFERRED
             deferred: DeferredWorkflowEvaluationData | None = {
                 "delayed_when_group_id": delayed_item.delayed_when_group_id,
                 "delayed_if_group_ids": sorted(delayed_item.delayed_if_group_ids),
@@ -633,7 +634,7 @@ def process_workflows(
     sentry_sdk.set_tag("workflow_engine.triggered_actions", triggered_action_count)
     sentry_sdk.set_attribute("workflow_engine.triggered_actions", triggered_action_count)
 
-    if actions:
+    if triggered_action_count:
         fire_histories = create_workflow_fire_histories(
             actions,
             event_data,

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -602,6 +602,8 @@ def process_workflows(
         )
         return {}
 
+    workflow_ids = [workflow.id for workflow in workflows]
+
     triggered_workflows, queue_items_by_workflow_id, trigger_stats, trigger_evals = (
         evaluate_workflow_triggers(workflows, event_data, event_start_time)
     )
@@ -622,7 +624,7 @@ def process_workflows(
             event_data=event_data,
             evaluations=workflow_evaluations,
             detector=associated_detector,
-            workflow_ids=[workflow.id for workflow in workflows],
+            workflow_ids=workflow_ids,
             debug_msg="No items were triggered or queued for slow evaluation",
         )
         return workflow_evaluations
@@ -650,6 +652,8 @@ def process_workflows(
         actions=actions,
         action_to_workflow_id=action_to_workflow_id,
     )
+    delayed_condition_keys = [item.buffer_key() for item in queue_items_by_workflow_id.values()]
+    action_filter_group_ids = [group.id for group in actions_to_trigger]
 
     triggered_actions = set(actions)
     sentry_sdk.set_tag("workflow_engine.triggered_actions", len(triggered_actions))
@@ -662,9 +666,9 @@ def process_workflows(
             event_data=event_data,
             evaluations=workflow_evaluations,
             detector=associated_detector,
-            workflow_ids=[workflow.id for workflow in workflows],
-            delayed_conditions=[item.buffer_key() for item in queue_items_by_workflow_id.values()],
-            action_filter_group_ids=[group.id for group in actions_to_trigger],
+            workflow_ids=workflow_ids,
+            delayed_conditions=delayed_condition_keys,
+            action_filter_group_ids=action_filter_group_ids,
             debug_msg="No actions to evaluate; filtered or not triggered",
         )
         return workflow_evaluations
@@ -696,8 +700,8 @@ def process_workflows(
         event_data=event_data,
         evaluations=workflow_evaluations,
         detector=associated_detector,
-        workflow_ids=[workflow.id for workflow in workflows],
-        delayed_conditions=[item.buffer_key() for item in queue_items_by_workflow_id.values()],
-        action_filter_group_ids=[group.id for group in actions_to_trigger],
+        workflow_ids=workflow_ids,
+        delayed_conditions=delayed_condition_keys,
+        action_filter_group_ids=action_filter_group_ids,
     )
     return workflow_evaluations

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -28,16 +28,14 @@ from sentry.workflow_engine.processors.data_condition_group import (
 from sentry.workflow_engine.processors.detector import get_detectors_for_event_data
 from sentry.workflow_engine.processors.evaluations import DataConditionGroupEvaluation
 from sentry.workflow_engine.processors.evaluations.workflow import (
-    DeferredWorkflowEvaluationData,
+    DeferredWorkflowEvaluationResult,
+    ProcessWorkflowsResult,
     WorkflowEvaluation,
+    WorkflowEvaluationOutcome,
+    WorkflowEvaluationResult,
 )
 from sentry.workflow_engine.processors.workflow_fire_history import create_workflow_fire_histories
-from sentry.workflow_engine.types import (
-    WORKFLOW_EVALUATION_DEFERRED,
-    WorkflowEvaluationResult,
-    WorkflowEventData,
-    WorkflowId,
-)
+from sentry.workflow_engine.types import WorkflowEventData, WorkflowId
 from sentry.workflow_engine.utils import log_context, scopedstats
 from sentry.workflow_engine.utils.metrics import metrics_incr
 
@@ -450,10 +448,10 @@ def _build_workflow_evaluations(
     Build a per-workflow WorkflowEvaluation for every evaluated workflow, capturing its
     trigger (WHEN) evaluation, action-filter (IF) evaluations, and resulting actions.
 
-    `result` is the "deferred" sentinel for workflows enqueued for slow evaluation, otherwise
-    the actions that fired for that workflow (empty when the workflow triggered but no actions
-    fired). `action_to_workflow_id` attributes each action to a single workflow, so an action
-    shared across workflows is counted once here.
+    `result` contains deferred evaluation details for workflows enqueued for slow evaluation,
+    otherwise the actions enqueued for that workflow (empty when the workflow triggered but no
+    actions were enqueued). `action_to_workflow_id` attributes each action to a single workflow,
+    so an action shared across workflows is counted once here.
     """
     actions_by_workflow_id: dict[WorkflowId, list[Action]] = defaultdict(list)
     for action in actions:
@@ -464,15 +462,13 @@ def _build_workflow_evaluations(
     for workflow, trigger_eval in trigger_evals.items():
         delayed_item = delayed_items.get(workflow)
         if delayed_item:
-            result: WorkflowEvaluationResult = WORKFLOW_EVALUATION_DEFERRED
-            deferred: DeferredWorkflowEvaluationData | None = {
-                "delayed_when_group_id": delayed_item.delayed_when_group_id,
-                "delayed_if_group_ids": sorted(delayed_item.delayed_if_group_ids),
-                "passing_if_group_ids": sorted(delayed_item.passing_if_group_ids),
-            }
+            result: WorkflowEvaluationResult = DeferredWorkflowEvaluationResult(
+                delayed_when_group_id=delayed_item.delayed_when_group_id,
+                delayed_if_group_ids=frozenset(delayed_item.delayed_if_group_ids),
+                passing_if_group_ids=frozenset(delayed_item.passing_if_group_ids),
+            )
         else:
             result = actions_by_workflow_id.get(workflow.id, [])
-            deferred = None
 
         workflow_evaluations[workflow.id] = WorkflowEvaluation(
             workflow_id=workflow.id,
@@ -480,15 +476,45 @@ def _build_workflow_evaluations(
             detector_type=detector.type,
             result=result,
             triggered=trigger_eval.triggered,
-            error=trigger_eval.error,
+            error=trigger_eval.error
+            or next(
+                (
+                    evaluation.error
+                    for evaluation in filter_evals.get(workflow, [])
+                    if evaluation.error
+                ),
+                None,
+            ),
             data={
                 "trigger_group_eval": trigger_eval,
                 "filter_group_evals": filter_evals.get(workflow, []),
                 "event": event_data,
-                "deferred": deferred,
             },
         )
     return workflow_evaluations
+
+
+def _build_process_workflows_result(
+    *,
+    event_data: WorkflowEventData,
+    outcome: WorkflowEvaluationOutcome,
+    detector: Detector | None = None,
+    evaluations: dict[WorkflowId, WorkflowEvaluation] | None = None,
+) -> ProcessWorkflowsResult:
+    event_id = (
+        event_data.event.event_id
+        if isinstance(event_data.event, GroupEvent)
+        else event_data.event.id
+    )
+    return ProcessWorkflowsResult(
+        evaluations=evaluations or {},
+        outcome=outcome,
+        project_id=event_data.event.project_id,
+        group_id=event_data.group.id,
+        event_id=str(event_id) if event_id else None,
+        detector_id=detector.id if detector else None,
+        detector_type=detector.type if detector else None,
+    )
 
 
 @log_context.root()
@@ -497,7 +523,7 @@ def process_workflows(
     event_data: WorkflowEventData,
     event_start_time: datetime,
     detector: Detector | None = None,
-) -> dict[WorkflowId, WorkflowEvaluation]:
+) -> ProcessWorkflowsResult:
     """
     This method will get the detector based on the event, and then gather the associated workflows.
     Next, it will evaluate the "when" (or trigger) conditions for each workflow, if the conditions are met,
@@ -530,7 +556,10 @@ def process_workflows(
             )
         )
     except Detector.DoesNotExist:
-        return {}
+        return _build_process_workflows_result(
+            event_data=event_data,
+            outcome=WorkflowEvaluationOutcome.NO_DETECTOR,
+        )
 
     associated_detector = event_detectors.preferred_detector
 
@@ -546,7 +575,11 @@ def process_workflows(
             )
         )
     except Environment.DoesNotExist:
-        return {}
+        return _build_process_workflows_result(
+            event_data=event_data,
+            outcome=WorkflowEvaluationOutcome.ENVIRONMENT_NOT_FOUND,
+            detector=associated_detector,
+        )
 
     if features.has("organizations:workflow-engine-process-workflows-logs", organization):
         log_context.set_verbose(True)
@@ -568,7 +601,11 @@ def process_workflows(
             workflows = workflows - wrong_org_workflows
 
     if not workflows:
-        return {}
+        return _build_process_workflows_result(
+            event_data=event_data,
+            outcome=WorkflowEvaluationOutcome.NO_WORKFLOWS,
+            detector=associated_detector,
+        )
 
     metrics_incr("process_workflows", len(workflows))
     event_id = (
@@ -589,13 +626,13 @@ def process_workflows(
         },
     )
 
-    triggered_workflows, queue_items_by_workflow_id, trigger_stats, trigger_evals = (
+    triggered_workflows, delayed_items_by_workflow, trigger_stats, trigger_evals = (
         evaluate_workflow_triggers(workflows, event_data, event_start_time)
     )
 
-    if not triggered_workflows and not queue_items_by_workflow_id:
+    if not triggered_workflows and not delayed_items_by_workflow:
         trigger_stats.report_metrics("process_workflows.workflows_evaluated")
-        return _build_workflow_evaluations(
+        workflow_evaluations = _build_workflow_evaluations(
             detector=associated_detector,
             event_data=event_data,
             trigger_evals=trigger_evals,
@@ -604,30 +641,26 @@ def process_workflows(
             actions=[],
             action_to_workflow_id={},
         )
+        return _build_process_workflows_result(
+            event_data=event_data,
+            outcome=WorkflowEvaluationOutcome.COMPLETED,
+            detector=associated_detector,
+            evaluations=workflow_evaluations,
+        )
 
     # TODO - we should probably return here and have the rest from here be
     # `process_actions`, this will take a list of "triggered_workflows"
-    actions_to_trigger, queue_items_by_workflow_id, action_stats, filter_evals = (
+    actions_to_trigger, delayed_items_by_workflow, action_stats, filter_evals = (
         evaluate_workflows_action_filters(
-            triggered_workflows, event_data, queue_items_by_workflow_id, event_start_time
+            triggered_workflows, event_data, delayed_items_by_workflow, event_start_time
         )
     )
     (trigger_stats + action_stats).report_metrics("process_workflows.workflows_evaluated")
 
-    enqueue_workflows(batch_client, queue_items_by_workflow_id)
+    enqueue_workflows(batch_client, delayed_items_by_workflow)
 
     actions, action_to_workflow_id = filter_recently_fired_workflow_actions(
         actions_to_trigger, event_data
-    )
-
-    workflow_evaluations = _build_workflow_evaluations(
-        detector=associated_detector,
-        event_data=event_data,
-        trigger_evals=trigger_evals,
-        filter_evals=filter_evals,
-        delayed_items=queue_items_by_workflow_id,
-        actions=actions,
-        action_to_workflow_id=action_to_workflow_id,
     )
 
     triggered_action_count = len(set(actions))
@@ -656,4 +689,19 @@ def process_workflows(
             action_to_workflow_id=action_to_workflow_id,
         )
 
-    return workflow_evaluations
+    workflow_evaluations = _build_workflow_evaluations(
+        detector=associated_detector,
+        event_data=event_data,
+        trigger_evals=trigger_evals,
+        filter_evals=filter_evals,
+        delayed_items=delayed_items_by_workflow,
+        actions=actions,
+        action_to_workflow_id=action_to_workflow_id,
+    )
+
+    return _build_process_workflows_result(
+        event_data=event_data,
+        outcome=WorkflowEvaluationOutcome.COMPLETED,
+        detector=associated_detector,
+        evaluations=workflow_evaluations,
+    )

--- a/src/sentry/workflow_engine/tasks/workflows.py
+++ b/src/sentry/workflow_engine/tasks/workflows.py
@@ -23,7 +23,6 @@ from sentry.utils.locking import UnableToAcquireLock
 from sentry.workflow_engine.buffer.batch_client import DelayedWorkflowClient
 from sentry.workflow_engine.models import DataConditionGroup, Detector
 from sentry.workflow_engine.processors.evaluation_logging import emit_workflow_evaluation_logs
-from sentry.workflow_engine.processors.evaluations.workflow import has_triggered_actions
 from sentry.workflow_engine.tasks.utils import (
     EventNotFoundError,
     ProjectNotActiveError,
@@ -73,14 +72,14 @@ def process_workflow_activity(activity_id: int, group_id: int, detector_id: Dete
     )
     with quiet_redis_noise():
         batch_client = DelayedWorkflowClient()
-        evaluations = process_workflows(
+        result = process_workflows(
             batch_client, event_data, event_start_time=activity.datetime, detector=detector
         )
 
     emit_workflow_evaluation_logs(
         logger,
         organization=event_data.event.project.organization,
-        evaluations=evaluations,
+        result=result,
     )
 
     metrics.incr(
@@ -168,19 +167,17 @@ def _process_workflows_event(
         )
         with quiet_redis_noise():
             batch_client = DelayedWorkflowClient()
-            evaluations = process_workflows(
-                batch_client, event_data, event_start_time=event_start_time
-            )
+            result = process_workflows(batch_client, event_data, event_start_time=event_start_time)
             if isinstance(event_data.event, GroupEvent):
                 kick_off_service_hooks(
                     event_data.event,
-                    has_triggered_actions(evaluations),
+                    result.has_triggered_actions(),
                 )
 
     emit_workflow_evaluation_logs(
         logger,
         organization=event_data.event.project.organization,
-        evaluations=evaluations,
+        result=result,
     )
     duration = time.time() - start_time
     is_slow = duration > 1.0

--- a/src/sentry/workflow_engine/tasks/workflows.py
+++ b/src/sentry/workflow_engine/tasks/workflows.py
@@ -22,6 +22,7 @@ from sentry.utils.exceptions import quiet_redis_noise, quiet_retriable_timeouts
 from sentry.utils.locking import UnableToAcquireLock
 from sentry.workflow_engine.buffer.batch_client import DelayedWorkflowClient
 from sentry.workflow_engine.models import DataConditionGroup, Detector
+from sentry.workflow_engine.processors.evaluation_logging import emit_workflow_evaluation_logs
 from sentry.workflow_engine.processors.evaluations.workflow import has_triggered_actions
 from sentry.workflow_engine.tasks.utils import (
     EventNotFoundError,
@@ -72,9 +73,15 @@ def process_workflow_activity(activity_id: int, group_id: int, detector_id: Dete
     )
     with quiet_redis_noise():
         batch_client = DelayedWorkflowClient()
-        process_workflows(
+        evaluations = process_workflows(
             batch_client, event_data, event_start_time=activity.datetime, detector=detector
         )
+
+    emit_workflow_evaluation_logs(
+        logger,
+        organization=event_data.event.project.organization,
+        evaluations=evaluations,
+    )
 
     metrics.incr(
         "workflow_engine.tasks.process_workflows.activity_update.executed",
@@ -169,6 +176,12 @@ def _process_workflows_event(
                     event_data.event,
                     has_triggered_actions(evaluations),
                 )
+
+    emit_workflow_evaluation_logs(
+        logger,
+        organization=event_data.event.project.organization,
+        evaluations=evaluations,
+    )
     duration = time.time() - start_time
     is_slow = duration > 1.0
     # We want full coverage for particularly slow cases, plus a random sampling.

--- a/src/sentry/workflow_engine/tasks/workflows.py
+++ b/src/sentry/workflow_engine/tasks/workflows.py
@@ -22,6 +22,7 @@ from sentry.utils.exceptions import quiet_redis_noise, quiet_retriable_timeouts
 from sentry.utils.locking import UnableToAcquireLock
 from sentry.workflow_engine.buffer.batch_client import DelayedWorkflowClient
 from sentry.workflow_engine.models import DataConditionGroup, Detector
+from sentry.workflow_engine.processors.evaluations.workflow import has_triggered_actions
 from sentry.workflow_engine.tasks.utils import (
     EventNotFoundError,
     ProjectNotActiveError,
@@ -71,11 +72,9 @@ def process_workflow_activity(activity_id: int, group_id: int, detector_id: Dete
     )
     with quiet_redis_noise():
         batch_client = DelayedWorkflowClient()
-        evaluation = process_workflows(
+        process_workflows(
             batch_client, event_data, event_start_time=activity.datetime, detector=detector
         )
-
-    evaluation.log_to(logger)
 
     metrics.incr(
         "workflow_engine.tasks.process_workflows.activity_update.executed",
@@ -162,17 +161,14 @@ def _process_workflows_event(
         )
         with quiet_redis_noise():
             batch_client = DelayedWorkflowClient()
-            evaluation = process_workflows(
+            evaluations = process_workflows(
                 batch_client, event_data, event_start_time=event_start_time
             )
             if isinstance(event_data.event, GroupEvent):
                 kick_off_service_hooks(
                     event_data.event,
-                    evaluation.triggered_actions is not None
-                    and len(evaluation.triggered_actions) > 0,
+                    has_triggered_actions(evaluations),
                 )
-
-    evaluation.log_to(logger)
     duration = time.time() - start_time
     is_slow = duration > 1.0
     # We want full coverage for particularly slow cases, plus a random sampling.

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -9,7 +9,6 @@ from typing import (
     Any,
     ClassVar,
     Generic,
-    Literal,
     Sequence,
     TypeAlias,
     TypedDict,
@@ -90,9 +89,6 @@ class ConditionError:
 
 
 type DetectorResult = IssueOccurrence | StatusChangeMessage | None
-type WorkflowEvaluationDeferred = Literal["deferred"]
-WORKFLOW_EVALUATION_DEFERRED: WorkflowEvaluationDeferred = "deferred"
-type WorkflowEvaluationResult = Sequence[Action] | WorkflowEvaluationDeferred
 
 
 class _WorkflowEventLocalCache(TypedDict, total=False):

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -91,6 +91,7 @@ class ConditionError:
 
 type DetectorResult = IssueOccurrence | StatusChangeMessage | None
 type WorkflowEvaluationDeferred = Literal["deferred"]
+WORKFLOW_EVALUATION_DEFERRED: WorkflowEvaluationDeferred = "deferred"
 type WorkflowEvaluationResult = Sequence[Action] | WorkflowEvaluationDeferred
 
 

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -90,6 +90,7 @@ class ConditionError:
 
 type DetectorResult = IssueOccurrence | StatusChangeMessage | None
 type WorkflowEvaluationDeferred = Literal["deferred"]
+WORKFLOW_EVALUATION_DEFERRED: WorkflowEvaluationDeferred = "deferred"
 type WorkflowEvaluationResult = Sequence[Action] | WorkflowEvaluationDeferred
 
 

--- a/tests/sentry/workflow_engine/processors/evaluations/test_base.py
+++ b/tests/sentry/workflow_engine/processors/evaluations/test_base.py
@@ -141,8 +141,14 @@ class TestWithError:
     def test_is_noop_when_already_tainted(self) -> None:
         assert _ev(True, ERR).with_error(OTHER_ERR).error == ERR
 
-    def test_to_log_flattens_common_fields(self) -> None:
-        assert _ev(True, ERR).to_log() == {"triggered": True, "error": ERR.msg}
+    def test_to_artifact_includes_common_fields(self) -> None:
+        assert _ev(True, ERR).to_artifact() == {
+            "triggered": True,
+            "error": ERR.msg,
+            "logic_type": DataConditionGroup.Type.ANY,
+            "result": True,
+            "condition_evaluations": [],
+        }
 
 
 class TestChooseTainted:

--- a/tests/sentry/workflow_engine/processors/evaluations/test_base.py
+++ b/tests/sentry/workflow_engine/processors/evaluations/test_base.py
@@ -141,6 +141,9 @@ class TestWithError:
     def test_is_noop_when_already_tainted(self) -> None:
         assert _ev(True, ERR).with_error(OTHER_ERR).error == ERR
 
+    def test_to_log_flattens_common_fields(self) -> None:
+        assert _ev(True, ERR).to_log() == {"triggered": True, "error": ERR.msg}
+
 
 class TestChooseTainted:
     def test_returns_first_tainted(self) -> None:

--- a/tests/sentry/workflow_engine/processors/evaluations/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/evaluations/test_workflow.py
@@ -124,6 +124,17 @@ class TestWorkflowEvaluationArtifact(TestCase):
         }
         assert "user@example.com" not in str(artifact)
 
+    def test_condition_artifact_includes_string_input(self) -> None:
+        condition = self.create_data_condition()
+        evaluation = DataConditionEvaluation(
+            condition=condition,
+            result=True,
+            triggered=True,
+            data="production",
+        )
+
+        assert evaluation.to_artifact()["input"] == "production"
+
     def test_emitter_always_logs_with_feature_enabled(self) -> None:
         evaluation = self._build_evaluation()
         mock_logger = mock.MagicMock()

--- a/tests/sentry/workflow_engine/processors/evaluations/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/evaluations/test_workflow.py
@@ -240,7 +240,7 @@ class TestWorkflowEvaluationArtifact(TestCase):
         with (
             Feature({"organizations:workflow-engine-log-evaluations": True}),
             override_options({"workflow_engine.evaluation_logs_direct_to_sentry": True}),
-            mock.patch(f"{LOGGING_MODULE}.sentry_logger") as mock_sentry_logger,
+            mock.patch(f"{LOGGING_MODULE}.sdk_logger") as mock_sentry_logger,
         ):
             assert emit_workflow_evaluation_logs(
                 mock_logger,

--- a/tests/sentry/workflow_engine/processors/evaluations/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/evaluations/test_workflow.py
@@ -3,98 +3,140 @@ from unittest import mock
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.features import Feature
 from sentry.testutils.helpers.options import override_options
-from sentry.workflow_engine.processors.evaluations.workflow import GroupedWorkflowEvaluationResult
+from sentry.workflow_engine.models import DataConditionGroup
+from sentry.workflow_engine.processors.evaluations import (
+    DataConditionGroupEvaluation,
+    WorkflowEvaluation,
+)
+from sentry.workflow_engine.processors.evaluations.workflow import (
+    log_workflow_evaluations,
+)
+from sentry.workflow_engine.types import ConditionError, WorkflowEventData
 
-LOG_TO_MODULE = "sentry.workflow_engine.processors.evaluations.workflow"
+LOG_MODULE = "sentry.workflow_engine.processors.evaluations.workflow"
 
 
-class TestGroupedWorkflowEvaluationResultLogTo(TestCase):
+class TestWorkflowEvaluationLog(TestCase):
     def setUp(self) -> None:
         super().setUp()
         self.organization = self.create_organization()
         self.project = self.create_project(organization=self.organization)
         self.event = self.store_event(data={}, project_id=self.project.id)
+        self.event_data = WorkflowEventData(event=self.event, group=self.event.group)
 
-    def _build_result(self) -> GroupedWorkflowEvaluationResult:
-        return GroupedWorkflowEvaluationResult(
-            result={},
-            tainted=True,
-            organization=self.organization,
-            event=self.event,
+    def _build_evaluation(
+        self, *, triggered: bool = False, error: ConditionError | None = None
+    ) -> WorkflowEvaluation:
+        trigger_evaluation = DataConditionGroupEvaluation(
+            result=triggered,
+            triggered=triggered,
+            error=error,
+            data={
+                "condition_evaluations": [],
+                "logic_type": DataConditionGroup.Type.ANY,
+            },
+        )
+        return WorkflowEvaluation(
+            result=[],
+            triggered=triggered,
+            error=error,
+            data={
+                "trigger_group_eval": trigger_evaluation,
+                "filter_group_evals": [],
+                "event": self.event_data,
+            },
         )
 
-    def test_log_to_always_logs_with_feature_enabled(self) -> None:
-        evaluation = self._build_result()
+    def test_to_log_flattens_evaluation(self) -> None:
+        evaluation = self._build_evaluation(
+            triggered=True, error=ConditionError(msg="evaluation failed")
+        )
 
+        assert evaluation.to_log() == {
+            "triggered": True,
+            "error": "evaluation failed",
+            "triggered_action_ids": [],
+            "deferred": False,
+        }
+
+    def test_always_logs_with_feature_enabled(self) -> None:
         mock_logger = mock.MagicMock()
-
-        with Feature({"organizations:workflow-engine-log-evaluations": True}):
-            with override_options(
+        with (
+            Feature({"organizations:workflow-engine-log-evaluations": True}),
+            override_options(
                 {
                     "workflow_engine.evaluation_log_sample_rate": 0.0,
                     "workflow_engine.evaluation_logs_direct_to_sentry": False,
                 }
-            ):
-                assert evaluation.log_to(mock_logger) is True
+            ),
+        ):
+            assert log_workflow_evaluations(
+                mock_logger,
+                organization=self.organization,
+                event_data=self.event_data,
+                evaluations={},
+            )
 
-    def test_log_to_respects_sample_rate_when_feature_disabled(self) -> None:
-        evaluation = self._build_result()
+        mock_logger.info.assert_called_once()
+
+    def test_respects_sample_rate_when_feature_disabled(self) -> None:
         mock_logger = mock.MagicMock()
-
-        with Feature({"organizations:workflow-engine-log-evaluations": False}):
-            with override_options(
-                {
-                    "workflow_engine.evaluation_log_sample_rate": 0.0,
-                    "workflow_engine.evaluation_logs_direct_to_sentry": False,
-                }
-            ):
-                with mock.patch(f"{LOG_TO_MODULE}.random.random", return_value=0.5):
-                    assert not evaluation.log_to(mock_logger)
-
-            with override_options(
-                {
-                    "workflow_engine.evaluation_log_sample_rate": 1.0,
-                    "workflow_engine.evaluation_logs_direct_to_sentry": False,
-                }
-            ):
-                with mock.patch(f"{LOG_TO_MODULE}.random.random", return_value=0.5):
-                    assert evaluation.log_to(mock_logger)
-
-    def test_log_to_samples_correctly(self) -> None:
-        evaluation = self._build_result()
-        mock_logger = mock.MagicMock()
-
-        with Feature({"organizations:workflow-engine-log-evaluations": False}):
-            with override_options(
+        with (
+            Feature({"organizations:workflow-engine-log-evaluations": False}),
+            override_options(
                 {
                     "workflow_engine.evaluation_log_sample_rate": 0.1,
                     "workflow_engine.evaluation_logs_direct_to_sentry": False,
                 }
-            ):
-                with mock.patch(f"{LOG_TO_MODULE}.random.random", return_value=0.05):
-                    assert evaluation.log_to(mock_logger)
+            ),
+            mock.patch(f"{LOG_MODULE}.random.random", side_effect=[0.05, 0.15]),
+        ):
+            assert log_workflow_evaluations(
+                mock_logger,
+                organization=self.organization,
+                event_data=self.event_data,
+                evaluations={},
+            )
+            assert not log_workflow_evaluations(
+                mock_logger,
+                organization=self.organization,
+                event_data=self.event_data,
+                evaluations={},
+            )
 
-                with mock.patch(f"{LOG_TO_MODULE}.random.random", return_value=0.15):
-                    assert not evaluation.log_to(mock_logger)
+        mock_logger.info.assert_called_once()
 
-    def test_log_to_sentry_logger_when_direct_to_sentry_enabled(self) -> None:
-        evaluation = self._build_result()
+    def test_logs_flattened_batch_to_sentry_logger(self) -> None:
+        evaluation = self._build_evaluation(triggered=True)
         mock_logger = mock.MagicMock()
+        with (
+            Feature({"organizations:workflow-engine-log-evaluations": True}),
+            override_options({"workflow_engine.evaluation_logs_direct_to_sentry": True}),
+            mock.patch(f"{LOG_MODULE}.sentry_logger") as mock_sentry_logger,
+        ):
+            assert log_workflow_evaluations(
+                mock_logger,
+                organization=self.organization,
+                event_data=self.event_data,
+                evaluations={10: evaluation},
+                workflow_ids=[10],
+                action_filter_group_ids=[30],
+                delayed_conditions=["buffer-key"],
+                debug_msg="debug message",
+            )
 
-        with Feature({"organizations:workflow-engine-log-evaluations": True}):
-            with override_options({"workflow_engine.evaluation_logs_direct_to_sentry": True}):
-                with mock.patch(f"{LOG_TO_MODULE}.sentry_logger") as mock_sentry_logger:
-                    assert evaluation.log_to(mock_logger)
-                    mock_sentry_logger.info.assert_called_once()
-                    mock_logger.info.assert_not_called()
-
-    def test_log_to_regular_logger_when_direct_to_sentry_disabled(self) -> None:
-        evaluation = self._build_result()
-        mock_logger = mock.MagicMock()
-
-        with Feature({"organizations:workflow-engine-log-evaluations": True}):
-            with override_options({"workflow_engine.evaluation_logs_direct_to_sentry": False}):
-                with mock.patch(f"{LOG_TO_MODULE}.sentry_logger") as mock_sentry_logger:
-                    assert evaluation.log_to(mock_logger)
-                    mock_logger.info.assert_called_once()
-                    mock_sentry_logger.info.assert_not_called()
+        mock_sentry_logger.info.assert_called_once_with(
+            "workflow_engine.process_workflows.evaluation.workflows.triggered",
+            attributes={
+                "event_id": self.event.event_id,
+                "group_id": self.event.group.id,
+                "detection_type": None,
+                "workflow_ids": [10],
+                "triggered_workflow_ids": [10],
+                "delayed_conditions": ["buffer-key"],
+                "action_filter_group_ids": [30],
+                "triggered_action_ids": [],
+                "debug_msg": "debug message",
+            },
+        )
+        mock_logger.info.assert_not_called()

--- a/tests/sentry/workflow_engine/processors/evaluations/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/evaluations/test_workflow.py
@@ -8,7 +8,10 @@ from sentry.workflow_engine.processors.evaluation_logging import emit_workflow_e
 from sentry.workflow_engine.processors.evaluations import (
     DataConditionEvaluation,
     DataConditionGroupEvaluation,
+    DeferredWorkflowEvaluationResult,
+    ProcessWorkflowsResult,
     WorkflowEvaluation,
+    WorkflowEvaluationOutcome,
 )
 from sentry.workflow_engine.types import ConditionError, WorkflowEventData
 
@@ -31,6 +34,7 @@ class TestWorkflowEvaluationArtifact(TestCase):
         error: ConditionError | None = None,
         deferred: bool = False,
         workflow_id: int = 10,
+        filter_group_evaluations: list[DataConditionGroupEvaluation] | None = None,
     ) -> WorkflowEvaluation:
         trigger_evaluation = DataConditionGroupEvaluation(
             result=triggered,
@@ -45,23 +49,38 @@ class TestWorkflowEvaluationArtifact(TestCase):
             workflow_id=workflow_id,
             detector_id=self.detector.id,
             detector_type=self.detector.type,
-            result="deferred" if deferred else [],
+            result=(
+                DeferredWorkflowEvaluationResult(
+                    delayed_when_group_id=20,
+                    delayed_if_group_ids=frozenset({30}),
+                    passing_if_group_ids=frozenset({40}),
+                )
+                if deferred
+                else []
+            ),
             triggered=triggered,
             error=error,
             data={
                 "trigger_group_eval": trigger_evaluation,
-                "filter_group_evals": [],
+                "filter_group_evals": filter_group_evaluations or [],
                 "event": self.event_data,
-                "deferred": (
-                    {
-                        "delayed_when_group_id": 20,
-                        "delayed_if_group_ids": [30],
-                        "passing_if_group_ids": [40],
-                    }
-                    if deferred
-                    else None
-                ),
             },
+        )
+
+    def _build_batch_result(
+        self,
+        evaluations: dict[int, WorkflowEvaluation] | None = None,
+        *,
+        outcome: WorkflowEvaluationOutcome = WorkflowEvaluationOutcome.COMPLETED,
+    ) -> ProcessWorkflowsResult:
+        return ProcessWorkflowsResult(
+            evaluations=evaluations or {},
+            outcome=outcome,
+            project_id=self.project.id,
+            group_id=self.event.group.id,
+            event_id=self.event.event_id,
+            detector_id=self.detector.id,
+            detector_type=self.detector.type,
         )
 
     def test_to_artifact_is_self_describing_and_recursive(self) -> None:
@@ -75,8 +94,10 @@ class TestWorkflowEvaluationArtifact(TestCase):
             "workflow_id": 10,
             "detector_id": self.detector.id,
             "detector_type": self.detector.type,
+            "project_id": self.project.id,
             "event_id": self.event.event_id,
             "group_id": self.event.group.id,
+            "outcome": WorkflowEvaluationOutcome.ERROR,
             "result_type": "actions",
             "triggered_action_ids": [],
             "deferred": None,
@@ -96,11 +117,37 @@ class TestWorkflowEvaluationArtifact(TestCase):
         artifact = evaluation.to_artifact()
 
         assert artifact["result_type"] == "deferred"
+        assert artifact["outcome"] == WorkflowEvaluationOutcome.DEFERRED
         assert artifact["deferred"] == {
             "delayed_when_group_id": 20,
             "delayed_if_group_ids": [30],
             "passing_if_group_ids": [40],
         }
+
+    def test_deferred_outcome_takes_precedence_over_error(self) -> None:
+        evaluation = self._build_evaluation(
+            deferred=True,
+            error=ConditionError(msg="fast condition failed"),
+        )
+
+        assert evaluation.outcome == WorkflowEvaluationOutcome.DEFERRED
+
+    def test_action_filter_error_sets_error_outcome(self) -> None:
+        filter_evaluation = DataConditionGroupEvaluation(
+            result=False,
+            triggered=False,
+            error=ConditionError(msg="action filter failed"),
+            data={
+                "condition_evaluations": [],
+                "logic_type": DataConditionGroup.Type.ANY,
+            },
+        )
+        evaluation = self._build_evaluation(
+            triggered=True,
+            filter_group_evaluations=[filter_evaluation],
+        )
+
+        assert evaluation.outcome == WorkflowEvaluationOutcome.ERROR
 
     def test_condition_artifact_excludes_raw_input_data(self) -> None:
         condition = self.create_data_condition()
@@ -150,7 +197,7 @@ class TestWorkflowEvaluationArtifact(TestCase):
             assert emit_workflow_evaluation_logs(
                 mock_logger,
                 organization=self.organization,
-                evaluations={10: evaluation},
+                result=self._build_batch_result({10: evaluation}),
             )
 
         mock_logger.info.assert_called_once()
@@ -171,12 +218,12 @@ class TestWorkflowEvaluationArtifact(TestCase):
             assert emit_workflow_evaluation_logs(
                 mock_logger,
                 organization=self.organization,
-                evaluations={10: evaluation},
+                result=self._build_batch_result({10: evaluation}),
             )
             assert not emit_workflow_evaluation_logs(
                 mock_logger,
                 organization=self.organization,
-                evaluations={10: evaluation},
+                result=self._build_batch_result({10: evaluation}),
             )
 
         mock_logger.info.assert_called_once()
@@ -192,12 +239,12 @@ class TestWorkflowEvaluationArtifact(TestCase):
             assert emit_workflow_evaluation_logs(
                 mock_logger,
                 organization=self.organization,
-                evaluations={10: evaluation},
+                result=self._build_batch_result({10: evaluation}),
             )
 
         mock_sentry_logger.info.assert_called_once_with(
-            "workflow_engine.process_workflows.evaluation.workflows.triggered",
-            attributes=evaluation.to_artifact(),
+            "workflow_engine.process_workflows.evaluation",
+            attributes={**evaluation.to_artifact(), "organization_id": self.organization.id},
         )
         mock_logger.info.assert_not_called()
 
@@ -214,7 +261,7 @@ class TestWorkflowEvaluationArtifact(TestCase):
             assert emit_workflow_evaluation_logs(
                 mock_logger,
                 organization=self.organization,
-                evaluations=evaluations,
+                result=self._build_batch_result(evaluations),
             )
 
         assert mock_logger.info.call_count == 2
@@ -225,12 +272,27 @@ class TestWorkflowEvaluationArtifact(TestCase):
             11,
         ]
 
-    def test_emitter_skips_empty_evaluations(self) -> None:
+    def test_emitter_logs_empty_batch_outcome(self) -> None:
         mock_logger = mock.MagicMock()
 
-        assert not emit_workflow_evaluation_logs(
-            mock_logger,
-            organization=self.organization,
-            evaluations={},
+        with Feature({"organizations:workflow-engine-log-evaluations": True}):
+            assert emit_workflow_evaluation_logs(
+                mock_logger,
+                organization=self.organization,
+                result=self._build_batch_result(
+                    outcome=WorkflowEvaluationOutcome.NO_WORKFLOWS,
+                ),
+            )
+
+        mock_logger.info.assert_called_once_with(
+            "workflow_engine.process_workflows.evaluation",
+            extra={
+                "outcome": WorkflowEvaluationOutcome.NO_WORKFLOWS,
+                "project_id": self.project.id,
+                "group_id": self.event.group.id,
+                "event_id": self.event.event_id,
+                "detector_id": self.detector.id,
+                "detector_type": self.detector.type,
+                "organization_id": self.organization.id,
+            },
         )
-        mock_logger.info.assert_not_called()

--- a/tests/sentry/workflow_engine/processors/evaluations/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/evaluations/test_workflow.py
@@ -4,28 +4,33 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.features import Feature
 from sentry.testutils.helpers.options import override_options
 from sentry.workflow_engine.models import DataConditionGroup
+from sentry.workflow_engine.processors.evaluation_logging import emit_workflow_evaluation_logs
 from sentry.workflow_engine.processors.evaluations import (
+    DataConditionEvaluation,
     DataConditionGroupEvaluation,
     WorkflowEvaluation,
 )
-from sentry.workflow_engine.processors.evaluations.workflow import (
-    log_workflow_evaluations,
-)
 from sentry.workflow_engine.types import ConditionError, WorkflowEventData
 
-LOG_MODULE = "sentry.workflow_engine.processors.evaluations.workflow"
+LOGGING_MODULE = "sentry.workflow_engine.processors.evaluation_logging"
 
 
-class TestWorkflowEvaluationLog(TestCase):
+class TestWorkflowEvaluationArtifact(TestCase):
     def setUp(self) -> None:
         super().setUp()
         self.organization = self.create_organization()
         self.project = self.create_project(organization=self.organization)
         self.event = self.store_event(data={}, project_id=self.project.id)
         self.event_data = WorkflowEventData(event=self.event, group=self.event.group)
+        self.detector = self.create_detector(project=self.project)
 
     def _build_evaluation(
-        self, *, triggered: bool = False, error: ConditionError | None = None
+        self,
+        *,
+        triggered: bool = False,
+        error: ConditionError | None = None,
+        deferred: bool = False,
+        workflow_id: int = 10,
     ) -> WorkflowEvaluation:
         trigger_evaluation = DataConditionGroupEvaluation(
             result=triggered,
@@ -37,29 +42,90 @@ class TestWorkflowEvaluationLog(TestCase):
             },
         )
         return WorkflowEvaluation(
-            result=[],
+            workflow_id=workflow_id,
+            detector_id=self.detector.id,
+            detector_type=self.detector.type,
+            result="deferred" if deferred else [],
             triggered=triggered,
             error=error,
             data={
                 "trigger_group_eval": trigger_evaluation,
                 "filter_group_evals": [],
                 "event": self.event_data,
+                "deferred": (
+                    {
+                        "delayed_when_group_id": 20,
+                        "delayed_if_group_ids": [30],
+                        "passing_if_group_ids": [40],
+                    }
+                    if deferred
+                    else None
+                ),
             },
         )
 
-    def test_to_log_flattens_evaluation(self) -> None:
+    def test_to_artifact_is_self_describing_and_recursive(self) -> None:
         evaluation = self._build_evaluation(
             triggered=True, error=ConditionError(msg="evaluation failed")
         )
 
-        assert evaluation.to_log() == {
+        assert evaluation.to_artifact() == {
             "triggered": True,
             "error": "evaluation failed",
+            "workflow_id": 10,
+            "detector_id": self.detector.id,
+            "detector_type": self.detector.type,
+            "event_id": self.event.event_id,
+            "group_id": self.event.group.id,
+            "result_type": "actions",
             "triggered_action_ids": [],
-            "deferred": False,
+            "deferred": None,
+            "trigger_group_evaluation": {
+                "triggered": True,
+                "error": "evaluation failed",
+                "logic_type": DataConditionGroup.Type.ANY,
+                "result": True,
+                "condition_evaluations": [],
+            },
+            "filter_group_evaluations": [],
         }
 
-    def test_always_logs_with_feature_enabled(self) -> None:
+    def test_to_artifact_includes_deferred_conditions(self) -> None:
+        evaluation = self._build_evaluation(deferred=True)
+
+        artifact = evaluation.to_artifact()
+
+        assert artifact["result_type"] == "deferred"
+        assert artifact["deferred"] == {
+            "delayed_when_group_id": 20,
+            "delayed_if_group_ids": [30],
+            "passing_if_group_ids": [40],
+        }
+
+    def test_condition_artifact_excludes_raw_input_data(self) -> None:
+        condition = self.create_data_condition()
+        evaluation = DataConditionEvaluation(
+            condition=condition,
+            result=True,
+            triggered=True,
+            data={"email": "user@example.com"},
+        )
+
+        artifact = evaluation.to_artifact()
+
+        assert artifact == {
+            "triggered": True,
+            "error": None,
+            "condition_id": condition.id,
+            "condition_type": condition.type,
+            "input_type": "dict",
+            "input": None,
+            "result": True,
+        }
+        assert "user@example.com" not in str(artifact)
+
+    def test_emitter_always_logs_with_feature_enabled(self) -> None:
+        evaluation = self._build_evaluation()
         mock_logger = mock.MagicMock()
         with (
             Feature({"organizations:workflow-engine-log-evaluations": True}),
@@ -70,16 +136,16 @@ class TestWorkflowEvaluationLog(TestCase):
                 }
             ),
         ):
-            assert log_workflow_evaluations(
+            assert emit_workflow_evaluation_logs(
                 mock_logger,
                 organization=self.organization,
-                event_data=self.event_data,
-                evaluations={},
+                evaluations={10: evaluation},
             )
 
         mock_logger.info.assert_called_once()
 
-    def test_respects_sample_rate_when_feature_disabled(self) -> None:
+    def test_emitter_respects_sample_rate_when_feature_disabled(self) -> None:
+        evaluation = self._build_evaluation()
         mock_logger = mock.MagicMock()
         with (
             Feature({"organizations:workflow-engine-log-evaluations": False}),
@@ -89,54 +155,71 @@ class TestWorkflowEvaluationLog(TestCase):
                     "workflow_engine.evaluation_logs_direct_to_sentry": False,
                 }
             ),
-            mock.patch(f"{LOG_MODULE}.random.random", side_effect=[0.05, 0.15]),
+            mock.patch(f"{LOGGING_MODULE}.random.random", side_effect=[0.05, 0.15]),
         ):
-            assert log_workflow_evaluations(
+            assert emit_workflow_evaluation_logs(
                 mock_logger,
                 organization=self.organization,
-                event_data=self.event_data,
-                evaluations={},
+                evaluations={10: evaluation},
             )
-            assert not log_workflow_evaluations(
+            assert not emit_workflow_evaluation_logs(
                 mock_logger,
                 organization=self.organization,
-                event_data=self.event_data,
-                evaluations={},
+                evaluations={10: evaluation},
             )
 
         mock_logger.info.assert_called_once()
 
-    def test_logs_flattened_batch_to_sentry_logger(self) -> None:
+    def test_emitter_logs_artifact_to_sentry_logger(self) -> None:
         evaluation = self._build_evaluation(triggered=True)
         mock_logger = mock.MagicMock()
         with (
             Feature({"organizations:workflow-engine-log-evaluations": True}),
             override_options({"workflow_engine.evaluation_logs_direct_to_sentry": True}),
-            mock.patch(f"{LOG_MODULE}.sentry_logger") as mock_sentry_logger,
+            mock.patch(f"{LOGGING_MODULE}.sentry_logger") as mock_sentry_logger,
         ):
-            assert log_workflow_evaluations(
+            assert emit_workflow_evaluation_logs(
                 mock_logger,
                 organization=self.organization,
-                event_data=self.event_data,
                 evaluations={10: evaluation},
-                workflow_ids=[10],
-                action_filter_group_ids=[30],
-                delayed_conditions=["buffer-key"],
-                debug_msg="debug message",
             )
 
         mock_sentry_logger.info.assert_called_once_with(
             "workflow_engine.process_workflows.evaluation.workflows.triggered",
-            attributes={
-                "event_id": self.event.event_id,
-                "group_id": self.event.group.id,
-                "detection_type": None,
-                "workflow_ids": [10],
-                "triggered_workflow_ids": [10],
-                "delayed_conditions": ["buffer-key"],
-                "action_filter_group_ids": [30],
-                "triggered_action_ids": [],
-                "debug_msg": "debug message",
-            },
+            attributes=evaluation.to_artifact(),
+        )
+        mock_logger.info.assert_not_called()
+
+    def test_emitter_logs_each_workflow_evaluation(self) -> None:
+        evaluations = {
+            10: self._build_evaluation(workflow_id=10),
+            11: self._build_evaluation(workflow_id=11),
+        }
+        mock_logger = mock.MagicMock()
+        with (
+            Feature({"organizations:workflow-engine-log-evaluations": True}),
+            override_options({"workflow_engine.evaluation_logs_direct_to_sentry": False}),
+        ):
+            assert emit_workflow_evaluation_logs(
+                mock_logger,
+                organization=self.organization,
+                evaluations=evaluations,
+            )
+
+        assert mock_logger.info.call_count == 2
+        assert [
+            call.kwargs["extra"]["workflow_id"] for call in mock_logger.info.call_args_list
+        ] == [
+            10,
+            11,
+        ]
+
+    def test_emitter_skips_empty_evaluations(self) -> None:
+        mock_logger = mock.MagicMock()
+
+        assert not emit_workflow_evaluation_logs(
+            mock_logger,
+            organization=self.organization,
+            evaluations={},
         )
         mock_logger.info.assert_not_called()

--- a/tests/sentry/workflow_engine/processors/evaluations/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/evaluations/test_workflow.py
@@ -24,7 +24,13 @@ class TestWorkflowEvaluationArtifact(TestCase):
         self.organization = self.create_organization()
         self.project = self.create_project(organization=self.organization)
         self.event = self.store_event(data={}, project_id=self.project.id)
-        self.event_data = WorkflowEventData(event=self.event, group=self.event.group)
+        self.group = self.event.group
+        assert self.group is not None
+
+        self.event_data = WorkflowEventData(
+            event=self.event.for_group(self.group),
+            group=self.group,
+        )
         self.detector = self.create_detector(project=self.project)
 
     def _build_evaluation(

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -22,6 +22,7 @@ from sentry.workflow_engine.processors.data_condition_group import (
     get_data_conditions_for_group,
 )
 from sentry.workflow_engine.processors.evaluations import DataConditionGroupEvaluation
+from sentry.workflow_engine.processors.evaluations.workflow import has_triggered_actions
 from sentry.workflow_engine.processors.workflow import (
     EvaluationStats,
     enqueue_workflows,
@@ -98,7 +99,9 @@ class TestProcessWorkflows(BaseWorkflowTest):
         )
 
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
-        assert result.triggered_workflows == {self.error_workflow}
+        assert {
+            workflow_id for workflow_id, evaluation in result.items() if evaluation.triggered
+        } == {self.error_workflow.id}
 
     def test_filters_cross_org_workflows(self) -> None:
         other_org = self.create_organization()
@@ -122,13 +125,16 @@ class TestProcessWorkflows(BaseWorkflowTest):
 
         with self.options({"workflow_engine.filter_cross_org_workflows": True}):
             result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
-        assert result.triggered_workflows == {self.error_workflow}
-        assert result.workflows is not None
-        assert cross_org_workflow not in result.workflows
+        assert {
+            workflow_id for workflow_id, evaluation in result.items() if evaluation.triggered
+        } == {self.error_workflow.id}
+        assert cross_org_workflow.id not in result
 
     def test_error_event(self) -> None:
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
-        assert result.triggered_workflows == {self.error_workflow}
+        assert {
+            workflow_id for workflow_id, evaluation in result.items() if evaluation.triggered
+        } == {self.error_workflow.id}
 
     @patch("sentry.workflow_engine.processors.action.fire_actions")
     def test_process_workflows_event(self, mock_fire_actions: MagicMock) -> None:
@@ -285,7 +291,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
 
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
         mock_filter.assert_called_with({workflow_filters}, self.event_data)
-        assert result.tainted is False
+        assert result[workflow.id].triggered
 
     def test_same_environment_only(self) -> None:
         env = self.create_environment(project=self.project)
@@ -332,7 +338,12 @@ class TestProcessWorkflows(BaseWorkflowTest):
         )
 
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
-        assert result.triggered_workflows == {self.error_workflow, matching_env_workflow}
+        assert {
+            workflow_id for workflow_id, evaluation in result.items() if evaluation.triggered
+        } == {
+            self.error_workflow.id,
+            matching_env_workflow.id,
+        }
 
     def test_issue_occurrence_event(self) -> None:
         issue_occurrence = self.build_occurrence(evidence_data={"detector_id": self.detector.id})
@@ -340,7 +351,9 @@ class TestProcessWorkflows(BaseWorkflowTest):
         self.group_event.group.type = issue_occurrence.type.type_id
 
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
-        assert result.triggered_workflows == {self.workflow}
+        assert {
+            workflow_id for workflow_id, evaluation in result.items() if evaluation.triggered
+        } == {self.workflow.id}
 
     def test_regressed_event(self) -> None:
         dcg = self.create_data_condition_group()
@@ -358,7 +371,12 @@ class TestProcessWorkflows(BaseWorkflowTest):
         )
 
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
-        assert result.triggered_workflows == {self.error_workflow, workflow}
+        assert {
+            workflow_id for workflow_id, evaluation in result.items() if evaluation.triggered
+        } == {
+            self.error_workflow.id,
+            workflow.id,
+        }
 
     @patch("sentry.utils.metrics.incr")
     @patch("sentry.workflow_engine.processors.detector.logger")
@@ -367,7 +385,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
         self.issue_stream_detector.delete()
 
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
-        assert result.msg == "No Detectors associated with the issue were found"
+        assert result == {}
 
     @patch("sentry.utils.metrics.incr")
     @patch("sentry.workflow_engine.processors.detector.logger")
@@ -392,8 +410,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
         cache.clear()
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
 
-        assert not result.triggered_workflows
-        assert result.msg == "Environment for event not found"
+        assert result == {}
 
         mock_logger.info.assert_called_once_with(
             "workflow_engine.process_workflows.environment_not_found",
@@ -409,7 +426,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
         self.issue_stream_detector.delete()
 
         process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
-        mock_incr.assert_called_with("workflow_engine.detectors.error")  # called twice
+        mock_incr.assert_any_call("workflow_engine.detectors.error")  # called twice
         mock_logger.exception.assert_called()  # called twice
 
     @patch("sentry.utils.metrics.incr")
@@ -478,10 +495,10 @@ class TestProcessWorkflows(BaseWorkflowTest):
 
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
 
-        assert result.tainted is True
-        assert result.triggered_workflows == {issue_stream_workflow}
-        assert result.triggered_actions is not None
-        assert len(result.triggered_actions) == 0
+        assert {
+            workflow_id for workflow_id, evaluation in result.items() if evaluation.triggered
+        } == {issue_stream_workflow.id}
+        assert not has_triggered_actions(result)
 
     def test_multiple_detectors__preferred(self) -> None:
         self.create_detector_workflow(
@@ -490,8 +507,9 @@ class TestProcessWorkflows(BaseWorkflowTest):
         )
 
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
-        assert result.triggered_workflows == {self.error_workflow}
-        assert result.associated_detector == self.error_detector
+        assert {
+            workflow_id for workflow_id, evaluation in result.items() if evaluation.triggered
+        } == {self.error_workflow.id}
 
 
 class TestEvaluateWorkflowTriggers(BaseWorkflowTest):

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -536,10 +536,8 @@ class TestProcessWorkflows(BaseWorkflowTest):
         )
 
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
-        assert result.workflows
-        assert all_projects_workflow in result.workflows
-        assert result.triggered_workflows
-        assert all_projects_workflow in result.triggered_workflows
+        assert all_projects_workflow.id in result.evaluations
+        assert all_projects_workflow.id in _triggered_workflow_ids(result)
 
 
 class TestEvaluateWorkflowTriggers(BaseWorkflowTest):

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -23,7 +23,10 @@ from sentry.workflow_engine.models.workflow_fire_history import WorkflowFireHist
 from sentry.workflow_engine.processors.data_condition_group import (
     get_data_conditions_for_group,
 )
-from sentry.workflow_engine.processors.evaluations import DataConditionGroupEvaluation
+from sentry.workflow_engine.processors.evaluations import (
+    DataConditionGroupEvaluation,
+    WorkflowEvaluation,
+)
 from sentry.workflow_engine.processors.evaluations.workflow import has_triggered_actions
 from sentry.workflow_engine.processors.workflow import (
     EvaluationStats,
@@ -49,6 +52,10 @@ def _triggered_when_eval(error: ConditionError | None = None) -> DataConditionGr
         error=error,
         data={"condition_evaluations": [], "logic_type": DataConditionGroup.Type.ANY},
     )
+
+
+def _triggered_workflow_ids(result: dict[int, WorkflowEvaluation]) -> set[int]:
+    return {workflow_id for workflow_id, evaluation in result.items() if evaluation.triggered}
 
 
 class TestProcessWorkflows(BaseWorkflowTest):
@@ -101,9 +108,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
         )
 
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
-        assert {
-            workflow_id for workflow_id, evaluation in result.items() if evaluation.triggered
-        } == {self.error_workflow.id}
+        assert _triggered_workflow_ids(result) == {self.error_workflow.id}
 
     def test_filters_cross_org_workflows(self) -> None:
         other_org = self.create_organization()
@@ -127,16 +132,12 @@ class TestProcessWorkflows(BaseWorkflowTest):
 
         with self.options({"workflow_engine.filter_cross_org_workflows": True}):
             result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
-        assert {
-            workflow_id for workflow_id, evaluation in result.items() if evaluation.triggered
-        } == {self.error_workflow.id}
+        assert _triggered_workflow_ids(result) == {self.error_workflow.id}
         assert cross_org_workflow.id not in result
 
     def test_error_event(self) -> None:
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
-        assert {
-            workflow_id for workflow_id, evaluation in result.items() if evaluation.triggered
-        } == {self.error_workflow.id}
+        assert _triggered_workflow_ids(result) == {self.error_workflow.id}
 
     @patch("sentry.workflow_engine.processors.action.fire_actions")
     def test_process_workflows_event(self, mock_fire_actions: MagicMock) -> None:
@@ -340,9 +341,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
         )
 
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
-        assert {
-            workflow_id for workflow_id, evaluation in result.items() if evaluation.triggered
-        } == {
+        assert _triggered_workflow_ids(result) == {
             self.error_workflow.id,
             matching_env_workflow.id,
         }
@@ -353,9 +352,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
         self.group_event.group.type = issue_occurrence.type.type_id
 
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
-        assert {
-            workflow_id for workflow_id, evaluation in result.items() if evaluation.triggered
-        } == {self.workflow.id}
+        assert _triggered_workflow_ids(result) == {self.workflow.id}
 
     def test_regressed_event(self) -> None:
         dcg = self.create_data_condition_group()
@@ -373,9 +370,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
         )
 
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
-        assert {
-            workflow_id for workflow_id, evaluation in result.items() if evaluation.triggered
-        } == {
+        assert _triggered_workflow_ids(result) == {
             self.error_workflow.id,
             workflow.id,
         }
@@ -501,9 +496,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
 
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
 
-        assert {
-            workflow_id for workflow_id, evaluation in result.items() if evaluation.triggered
-        } == {issue_stream_workflow.id}
+        assert _triggered_workflow_ids(result) == {issue_stream_workflow.id}
         assert not has_triggered_actions(result)
 
     def test_multiple_detectors__preferred(self) -> None:
@@ -513,9 +506,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
         )
 
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
-        assert {
-            workflow_id for workflow_id, evaluation in result.items() if evaluation.triggered
-        } == {self.error_workflow.id}
+        assert _triggered_workflow_ids(result) == {self.error_workflow.id}
 
     @override_options({"workflow_engine.all_projects_detectors_enabled": True})
     def test_all_projects_workflow_via_process_workflows(self) -> None:

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -21,7 +21,10 @@ from sentry.workflow_engine.models.workflow_fire_history import WorkflowFireHist
 from sentry.workflow_engine.processors.data_condition_group import (
     get_data_conditions_for_group,
 )
-from sentry.workflow_engine.processors.evaluations import DataConditionGroupEvaluation
+from sentry.workflow_engine.processors.evaluations import (
+    DataConditionGroupEvaluation,
+    WorkflowEvaluation,
+)
 from sentry.workflow_engine.processors.evaluations.workflow import has_triggered_actions
 from sentry.workflow_engine.processors.workflow import (
     EvaluationStats,
@@ -47,6 +50,10 @@ def _triggered_when_eval(error: ConditionError | None = None) -> DataConditionGr
         error=error,
         data={"condition_evaluations": [], "logic_type": DataConditionGroup.Type.ANY},
     )
+
+
+def _triggered_workflow_ids(result: dict[int, WorkflowEvaluation]) -> set[int]:
+    return {workflow_id for workflow_id, evaluation in result.items() if evaluation.triggered}
 
 
 class TestProcessWorkflows(BaseWorkflowTest):
@@ -99,9 +106,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
         )
 
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
-        assert {
-            workflow_id for workflow_id, evaluation in result.items() if evaluation.triggered
-        } == {self.error_workflow.id}
+        assert _triggered_workflow_ids(result) == {self.error_workflow.id}
 
     def test_filters_cross_org_workflows(self) -> None:
         other_org = self.create_organization()
@@ -125,16 +130,12 @@ class TestProcessWorkflows(BaseWorkflowTest):
 
         with self.options({"workflow_engine.filter_cross_org_workflows": True}):
             result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
-        assert {
-            workflow_id for workflow_id, evaluation in result.items() if evaluation.triggered
-        } == {self.error_workflow.id}
+        assert _triggered_workflow_ids(result) == {self.error_workflow.id}
         assert cross_org_workflow.id not in result
 
     def test_error_event(self) -> None:
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
-        assert {
-            workflow_id for workflow_id, evaluation in result.items() if evaluation.triggered
-        } == {self.error_workflow.id}
+        assert _triggered_workflow_ids(result) == {self.error_workflow.id}
 
     @patch("sentry.workflow_engine.processors.action.fire_actions")
     def test_process_workflows_event(self, mock_fire_actions: MagicMock) -> None:
@@ -338,9 +339,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
         )
 
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
-        assert {
-            workflow_id for workflow_id, evaluation in result.items() if evaluation.triggered
-        } == {
+        assert _triggered_workflow_ids(result) == {
             self.error_workflow.id,
             matching_env_workflow.id,
         }
@@ -351,9 +350,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
         self.group_event.group.type = issue_occurrence.type.type_id
 
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
-        assert {
-            workflow_id for workflow_id, evaluation in result.items() if evaluation.triggered
-        } == {self.workflow.id}
+        assert _triggered_workflow_ids(result) == {self.workflow.id}
 
     def test_regressed_event(self) -> None:
         dcg = self.create_data_condition_group()
@@ -371,9 +368,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
         )
 
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
-        assert {
-            workflow_id for workflow_id, evaluation in result.items() if evaluation.triggered
-        } == {
+        assert _triggered_workflow_ids(result) == {
             self.error_workflow.id,
             workflow.id,
         }
@@ -495,9 +490,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
 
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
 
-        assert {
-            workflow_id for workflow_id, evaluation in result.items() if evaluation.triggered
-        } == {issue_stream_workflow.id}
+        assert _triggered_workflow_ids(result) == {issue_stream_workflow.id}
         assert not has_triggered_actions(result)
 
     def test_multiple_detectors__preferred(self) -> None:
@@ -507,9 +500,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
         )
 
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
-        assert {
-            workflow_id for workflow_id, evaluation in result.items() if evaluation.triggered
-        } == {self.error_workflow.id}
+        assert _triggered_workflow_ids(result) == {self.error_workflow.id}
 
 
 class TestEvaluateWorkflowTriggers(BaseWorkflowTest):

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -25,9 +25,9 @@ from sentry.workflow_engine.processors.data_condition_group import (
 )
 from sentry.workflow_engine.processors.evaluations import (
     DataConditionGroupEvaluation,
-    WorkflowEvaluation,
+    ProcessWorkflowsResult,
+    WorkflowEvaluationOutcome,
 )
-from sentry.workflow_engine.processors.evaluations.workflow import has_triggered_actions
 from sentry.workflow_engine.processors.workflow import (
     EvaluationStats,
     enqueue_workflows,
@@ -54,8 +54,12 @@ def _triggered_when_eval(error: ConditionError | None = None) -> DataConditionGr
     )
 
 
-def _triggered_workflow_ids(result: dict[int, WorkflowEvaluation]) -> set[int]:
-    return {workflow_id for workflow_id, evaluation in result.items() if evaluation.triggered}
+def _triggered_workflow_ids(result: ProcessWorkflowsResult) -> set[int]:
+    return {
+        workflow_id
+        for workflow_id, evaluation in result.evaluations.items()
+        if evaluation.triggered
+    }
 
 
 class TestProcessWorkflows(BaseWorkflowTest):
@@ -133,7 +137,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
         with self.options({"workflow_engine.filter_cross_org_workflows": True}):
             result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
         assert _triggered_workflow_ids(result) == {self.error_workflow.id}
-        assert cross_org_workflow.id not in result
+        assert cross_org_workflow.id not in result.evaluations
 
     def test_error_event(self) -> None:
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
@@ -294,7 +298,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
 
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
         mock_filter.assert_called_with({workflow_filters}, self.event_data)
-        assert result[workflow.id].triggered
+        assert result.evaluations[workflow.id].triggered
 
     def test_same_environment_only(self) -> None:
         env = self.create_environment(project=self.project)
@@ -382,7 +386,8 @@ class TestProcessWorkflows(BaseWorkflowTest):
         self.issue_stream_detector.delete()
 
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
-        assert result == {}
+        assert result.evaluations == {}
+        assert result.outcome == WorkflowEvaluationOutcome.NO_DETECTOR
 
     @patch("sentry.utils.metrics.incr")
     @patch("sentry.workflow_engine.processors.detector.logger")
@@ -409,7 +414,8 @@ class TestProcessWorkflows(BaseWorkflowTest):
         cache.clear()
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
 
-        assert result == {}
+        assert result.evaluations == {}
+        assert result.outcome == WorkflowEvaluationOutcome.ENVIRONMENT_NOT_FOUND
 
         mock_logger.info.assert_called_once_with(
             "workflow_engine.process_workflows.environment_not_found",
@@ -497,7 +503,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
 
         assert _triggered_workflow_ids(result) == {issue_stream_workflow.id}
-        assert not has_triggered_actions(result)
+        assert not result.has_triggered_actions()
 
     def test_multiple_detectors__preferred(self) -> None:
         self.create_detector_workflow(

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -24,6 +24,7 @@ from sentry.workflow_engine.processors.data_condition_group import (
     get_data_conditions_for_group,
 )
 from sentry.workflow_engine.processors.evaluations import DataConditionGroupEvaluation
+from sentry.workflow_engine.processors.evaluations.workflow import has_triggered_actions
 from sentry.workflow_engine.processors.workflow import (
     EvaluationStats,
     enqueue_workflows,
@@ -100,7 +101,9 @@ class TestProcessWorkflows(BaseWorkflowTest):
         )
 
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
-        assert result.triggered_workflows == {self.error_workflow}
+        assert {
+            workflow_id for workflow_id, evaluation in result.items() if evaluation.triggered
+        } == {self.error_workflow.id}
 
     def test_filters_cross_org_workflows(self) -> None:
         other_org = self.create_organization()
@@ -124,13 +127,16 @@ class TestProcessWorkflows(BaseWorkflowTest):
 
         with self.options({"workflow_engine.filter_cross_org_workflows": True}):
             result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
-        assert result.triggered_workflows == {self.error_workflow}
-        assert result.workflows is not None
-        assert cross_org_workflow not in result.workflows
+        assert {
+            workflow_id for workflow_id, evaluation in result.items() if evaluation.triggered
+        } == {self.error_workflow.id}
+        assert cross_org_workflow.id not in result
 
     def test_error_event(self) -> None:
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
-        assert result.triggered_workflows == {self.error_workflow}
+        assert {
+            workflow_id for workflow_id, evaluation in result.items() if evaluation.triggered
+        } == {self.error_workflow.id}
 
     @patch("sentry.workflow_engine.processors.action.fire_actions")
     def test_process_workflows_event(self, mock_fire_actions: MagicMock) -> None:
@@ -287,7 +293,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
 
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
         mock_filter.assert_called_with({workflow_filters}, self.event_data)
-        assert result.tainted is False
+        assert result[workflow.id].triggered
 
     def test_same_environment_only(self) -> None:
         env = self.create_environment(project=self.project)
@@ -334,7 +340,12 @@ class TestProcessWorkflows(BaseWorkflowTest):
         )
 
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
-        assert result.triggered_workflows == {self.error_workflow, matching_env_workflow}
+        assert {
+            workflow_id for workflow_id, evaluation in result.items() if evaluation.triggered
+        } == {
+            self.error_workflow.id,
+            matching_env_workflow.id,
+        }
 
     def test_issue_occurrence_event(self) -> None:
         issue_occurrence = self.build_occurrence(evidence_data={"detector_id": self.detector.id})
@@ -342,7 +353,9 @@ class TestProcessWorkflows(BaseWorkflowTest):
         self.group_event.group.type = issue_occurrence.type.type_id
 
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
-        assert result.triggered_workflows == {self.workflow}
+        assert {
+            workflow_id for workflow_id, evaluation in result.items() if evaluation.triggered
+        } == {self.workflow.id}
 
     def test_regressed_event(self) -> None:
         dcg = self.create_data_condition_group()
@@ -360,7 +373,12 @@ class TestProcessWorkflows(BaseWorkflowTest):
         )
 
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
-        assert result.triggered_workflows == {self.error_workflow, workflow}
+        assert {
+            workflow_id for workflow_id, evaluation in result.items() if evaluation.triggered
+        } == {
+            self.error_workflow.id,
+            workflow.id,
+        }
 
     @patch("sentry.utils.metrics.incr")
     @patch("sentry.workflow_engine.processors.detector.logger")
@@ -369,7 +387,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
         self.issue_stream_detector.delete()
 
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
-        assert result.msg == "No Detectors associated with the issue were found"
+        assert result == {}
 
     @patch("sentry.utils.metrics.incr")
     @patch("sentry.workflow_engine.processors.detector.logger")
@@ -396,8 +414,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
         cache.clear()
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
 
-        assert not result.triggered_workflows
-        assert result.msg == "Environment for event not found"
+        assert result == {}
 
         mock_logger.info.assert_called_once_with(
             "workflow_engine.process_workflows.environment_not_found",
@@ -416,7 +433,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
         mock_incr.assert_any_call(
             "workflow_engine.detectors.error", tags={"detector_type": "issue_stream"}
         )
-        mock_logger.exception.assert_called()  # called twice
+        mock_logger.exception.assert_called()
 
     @patch("sentry.utils.metrics.incr")
     def test_metrics_with_workflows(self, mock_incr: MagicMock) -> None:
@@ -484,10 +501,10 @@ class TestProcessWorkflows(BaseWorkflowTest):
 
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
 
-        assert result.tainted is True
-        assert result.triggered_workflows == {issue_stream_workflow}
-        assert result.triggered_actions is not None
-        assert len(result.triggered_actions) == 0
+        assert {
+            workflow_id for workflow_id, evaluation in result.items() if evaluation.triggered
+        } == {issue_stream_workflow.id}
+        assert not has_triggered_actions(result)
 
     def test_multiple_detectors__preferred(self) -> None:
         self.create_detector_workflow(
@@ -496,8 +513,9 @@ class TestProcessWorkflows(BaseWorkflowTest):
         )
 
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
-        assert result.triggered_workflows == {self.error_workflow}
-        assert result.associated_detector == self.error_detector
+        assert {
+            workflow_id for workflow_id, evaluation in result.items() if evaluation.triggered
+        } == {self.error_workflow.id}
 
     @override_options({"workflow_engine.all_projects_detectors_enabled": True})
     def test_all_projects_workflow_via_process_workflows(self) -> None:

--- a/tests/sentry/workflow_engine/test_task.py
+++ b/tests/sentry/workflow_engine/test_task.py
@@ -136,7 +136,7 @@ class TestProcessWorkflowActivity(TestCase):
         "sentry.workflow_engine.processors.action.filter_recently_fired_workflow_actions",
         return_value=([], {}),
     )
-    @mock.patch("sentry.workflow_engine.processors.workflow.logger")
+    @mock.patch("sentry.workflow_engine.tasks.workflows.logger")
     def test_process_workflow_activity(
         self, mock_logger: mock.MagicMock, mock_filter_actions: mock.MagicMock
     ) -> None:

--- a/tests/sentry/workflow_engine/test_task.py
+++ b/tests/sentry/workflow_engine/test_task.py
@@ -12,7 +12,10 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import assume_test_silo_mode_of
 from sentry.types.activity import ActivityType
-from sentry.workflow_engine.processors.evaluations import DataConditionGroupEvaluation
+from sentry.workflow_engine.processors.evaluations import (
+    DataConditionGroupEvaluation,
+    WorkflowEvaluationOutcome,
+)
 from sentry.workflow_engine.processors.workflow import EvaluationStats
 from sentry.workflow_engine.tasks.utils import fetch_event
 from sentry.workflow_engine.tasks.workflows import process_workflow_activity
@@ -66,7 +69,12 @@ class TestProcessWorkflowActivity(TestCase):
             # Short-circuit evaluation, no workflows associated
             assert mock_evaluate.call_count == 0
 
-            mock_logger.info.assert_not_called()
+            mock_logger.info.assert_called_once()
+            assert mock_logger.info.call_args.args == (
+                "workflow_engine.process_workflows.evaluation",
+            )
+            artifact = mock_logger.info.call_args.kwargs["extra"]
+            assert artifact["outcome"] == WorkflowEvaluationOutcome.NO_WORKFLOWS
 
     @override_options({"workflow_engine.evaluation_log_sample_rate": 1.0})
     @mock.patch("sentry.workflow_engine.processors.workflow.evaluate_workflow_triggers")
@@ -109,8 +117,12 @@ class TestProcessWorkflowActivity(TestCase):
 
         mock_logger.info.assert_called_once()
         (log_name,) = mock_logger.info.call_args.args
-        assert log_name == "workflow_engine.process_workflows.evaluation.workflows.not_triggered"
+        assert log_name == "workflow_engine.process_workflows.evaluation"
         assert mock_logger.info.call_args.kwargs["extra"]["workflow_id"] == self.workflow.id
+        assert (
+            mock_logger.info.call_args.kwargs["extra"]["outcome"]
+            == WorkflowEvaluationOutcome.NOT_TRIGGERED
+        )
 
     @mock.patch(
         "sentry.workflow_engine.processors.action.filter_recently_fired_workflow_actions",
@@ -193,10 +205,11 @@ class TestProcessWorkflowActivity(TestCase):
 
         mock_logger.info.assert_called_once()
         (log_name,) = mock_logger.info.call_args.args
-        assert log_name == "workflow_engine.process_workflows.evaluation.actions.triggered"
+        assert log_name == "workflow_engine.process_workflows.evaluation"
         artifact = mock_logger.info.call_args.kwargs["extra"]
         assert artifact["workflow_id"] == self.workflow.id
         assert artifact["triggered_action_ids"] == [self.action.id]
+        assert artifact["outcome"] == WorkflowEvaluationOutcome.ACTIONS_TRIGGERED
 
     @mock.patch(
         "sentry.workflow_engine.models.incident_groupopenperiod.update_incident_based_on_open_period_status_change"

--- a/tests/sentry/workflow_engine/test_task.py
+++ b/tests/sentry/workflow_engine/test_task.py
@@ -52,7 +52,7 @@ class TestProcessWorkflowActivity(TestCase):
         self.detector = self.create_detector(type=MetricIssue.slug)
 
     @override_options({"workflow_engine.evaluation_log_sample_rate": 1.0})
-    @mock.patch("sentry.workflow_engine.processors.workflow.logger")
+    @mock.patch("sentry.workflow_engine.tasks.workflows.logger")
     def test_process_workflow_activity__no_workflows(self, mock_logger: mock.MagicMock) -> None:
         with mock.patch(
             "sentry.workflow_engine.processors.workflow.evaluate_workflow_triggers",
@@ -66,31 +66,15 @@ class TestProcessWorkflowActivity(TestCase):
             # Short-circuit evaluation, no workflows associated
             assert mock_evaluate.call_count == 0
 
-            mock_logger.info.assert_called_once_with(
-                "workflow_engine.process_workflows.evaluation.workflows.not_triggered",
-                extra={
-                    "workflow_ids": None,
-                    "detection_type": self.detector.type,
-                    "event_id": None,
-                    "group_id": self.activity.group.id,
-                    "action_filter_group_ids": [],
-                    "triggered_action_ids": [],
-                    "triggered_workflow_ids": [],
-                    "delayed_conditions": None,
-                    "debug_msg": "No workflows are associated with the detector in the event",
-                },
-            )
+            mock_logger.info.assert_not_called()
 
     @override_options({"workflow_engine.evaluation_log_sample_rate": 1.0})
-    @mock.patch(
-        "sentry.workflow_engine.processors.workflow.evaluate_workflow_triggers",
-        return_value=({}, {}, EvaluationStats(), {}),
-    )
+    @mock.patch("sentry.workflow_engine.processors.workflow.evaluate_workflow_triggers")
     @mock.patch(
         "sentry.workflow_engine.processors.workflow.evaluate_workflows_action_filters",
         return_value=(set(), {}, EvaluationStats(), {}),
     )
-    @mock.patch("sentry.workflow_engine.processors.workflow.logger")
+    @mock.patch("sentry.workflow_engine.tasks.workflows.logger")
     def test_process_workflow_activity__workflows__no_actions(
         self,
         mock_logger: mock.MagicMock,
@@ -102,6 +86,12 @@ class TestProcessWorkflowActivity(TestCase):
             detector=self.detector,
             workflow=self.workflow,
         )
+        trigger_eval = DataConditionGroupEvaluation(
+            result=False,
+            triggered=False,
+            data={"condition_evaluations": [], "logic_type": "any"},
+        )
+        mock_evaluate.return_value = ({}, {}, EvaluationStats(), {self.workflow: trigger_eval})
 
         process_workflow_activity(
             activity_id=self.activity.id,
@@ -117,20 +107,10 @@ class TestProcessWorkflowActivity(TestCase):
         mock_evaluate.assert_called_once_with({self.workflow}, event_data, mock.ANY)
         assert mock_eval_actions.call_count == 0
 
-        mock_logger.info.assert_called_once_with(
-            "workflow_engine.process_workflows.evaluation.workflows.not_triggered",
-            extra={
-                "workflow_ids": [self.workflow.id],
-                "detection_type": self.detector.type,
-                "group_id": self.activity.group.id,
-                "event_id": None,
-                "action_filter_group_ids": [],
-                "triggered_action_ids": [],
-                "triggered_workflow_ids": [],
-                "delayed_conditions": None,
-                "debug_msg": "No items were triggered or queued for slow evaluation",
-            },
-        )
+        mock_logger.info.assert_called_once()
+        (log_name,) = mock_logger.info.call_args.args
+        assert log_name == "workflow_engine.process_workflows.evaluation.workflows.not_triggered"
+        assert mock_logger.info.call_args.kwargs["extra"]["workflow_id"] == self.workflow.id
 
     @mock.patch(
         "sentry.workflow_engine.processors.action.filter_recently_fired_workflow_actions",
@@ -170,7 +150,7 @@ class TestProcessWorkflowActivity(TestCase):
 
     @override_options({"workflow_engine.evaluation_log_sample_rate": 1.0})
     @mock.patch("sentry.workflow_engine.processors.workflow.evaluate_workflow_triggers")
-    @mock.patch("sentry.workflow_engine.processors.workflow.logger")
+    @mock.patch("sentry.workflow_engine.tasks.workflows.logger")
     def test_process_workflow_activity__success_logs(
         self, mock_logger: mock.MagicMock, mock_evaluate_workflow_triggers: mock.MagicMock
     ) -> None:
@@ -211,20 +191,12 @@ class TestProcessWorkflowActivity(TestCase):
             detector_id=self.detector.id,
         )
 
-        mock_logger.info.assert_called_once_with(
-            "workflow_engine.process_workflows.evaluation.actions.triggered",
-            extra={
-                "workflow_ids": [self.workflow.id],
-                "detection_type": self.detector.type,
-                "group_id": self.activity.group.id,
-                "event_id": None,
-                "action_filter_group_ids": [self.action_group.id],
-                "triggered_action_ids": [self.action.id],
-                "triggered_workflow_ids": [self.workflow.id],
-                "delayed_conditions": None,
-                "debug_msg": None,
-            },
-        )
+        mock_logger.info.assert_called_once()
+        (log_name,) = mock_logger.info.call_args.args
+        assert log_name == "workflow_engine.process_workflows.evaluation.actions.triggered"
+        artifact = mock_logger.info.call_args.kwargs["extra"]
+        assert artifact["workflow_id"] == self.workflow.id
+        assert artifact["triggered_action_ids"] == [self.action.id]
 
     @mock.patch(
         "sentry.workflow_engine.models.incident_groupopenperiod.update_incident_based_on_open_period_status_change"

--- a/tests/sentry/workflow_engine/test_task.py
+++ b/tests/sentry/workflow_engine/test_task.py
@@ -52,7 +52,7 @@ class TestProcessWorkflowActivity(TestCase):
         self.detector = self.create_detector(type=MetricIssue.slug)
 
     @override_options({"workflow_engine.evaluation_log_sample_rate": 1.0})
-    @mock.patch("sentry.workflow_engine.tasks.workflows.logger")
+    @mock.patch("sentry.workflow_engine.processors.workflow.logger")
     def test_process_workflow_activity__no_workflows(self, mock_logger: mock.MagicMock) -> None:
         with mock.patch(
             "sentry.workflow_engine.processors.workflow.evaluate_workflow_triggers",
@@ -90,7 +90,7 @@ class TestProcessWorkflowActivity(TestCase):
         "sentry.workflow_engine.processors.workflow.evaluate_workflows_action_filters",
         return_value=(set(), {}, EvaluationStats(), {}),
     )
-    @mock.patch("sentry.workflow_engine.tasks.workflows.logger")
+    @mock.patch("sentry.workflow_engine.processors.workflow.logger")
     def test_process_workflow_activity__workflows__no_actions(
         self,
         mock_logger: mock.MagicMock,
@@ -136,7 +136,7 @@ class TestProcessWorkflowActivity(TestCase):
         "sentry.workflow_engine.processors.action.filter_recently_fired_workflow_actions",
         return_value=([], {}),
     )
-    @mock.patch("sentry.workflow_engine.tasks.workflows.logger")
+    @mock.patch("sentry.workflow_engine.processors.workflow.logger")
     def test_process_workflow_activity(
         self, mock_logger: mock.MagicMock, mock_filter_actions: mock.MagicMock
     ) -> None:
@@ -170,7 +170,7 @@ class TestProcessWorkflowActivity(TestCase):
 
     @override_options({"workflow_engine.evaluation_log_sample_rate": 1.0})
     @mock.patch("sentry.workflow_engine.processors.workflow.evaluate_workflow_triggers")
-    @mock.patch("sentry.workflow_engine.tasks.workflows.logger")
+    @mock.patch("sentry.workflow_engine.processors.workflow.logger")
     def test_process_workflow_activity__success_logs(
         self, mock_logger: mock.MagicMock, mock_evaluate_workflow_triggers: mock.MagicMock
     ) -> None:


### PR DESCRIPTION
# Description
This PR starts the refactor for GroupedWorkflowEvaluationResult -> `.to_log` methods on the evaluation classes.

Since Workflows are always batch evaluated, we still need some aspects of `GroupedWorkflowEvaluationResult` and that is the artifact left in `log_workflow_evaluations`.

---

*NOTE* - Sorry for the comment noise, trying out a new workflow with coding agents.