### PR TITLE
feat(issues): render PR checks status badge

### DIFF
--- a/static/app/components/group/externalIssuesList/linkedPullRequests.spec.tsx
+++ b/static/app/components/group/externalIssuesList/linkedPullRequests.spec.tsx
@@ -93,6 +93,43 @@ describe('LinkedPullRequests', () => {
     expect(mergedStatus.querySelector('svg')).toBeInTheDocument();
     expect(closedStatus.querySelector('svg')).toBeInTheDocument();
     expect(pullRequestsMock).toHaveBeenCalledTimes(1);
+    expect(pullRequestsMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({query: {expand: 'checksAndReview'}})
+    );
+  });
+
+  it('renders a checks badge only when the provider reports one', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${group.id}/pull-requests/`,
+      body: {
+        pullRequests: [
+          {
+            ...PullRequestFixture({id: '123', repository}),
+            attribution: null,
+            checksStatus: 'failure',
+            dateLinked: '2026-06-08T23:11:32.000000Z',
+            status: 'open',
+          },
+          {
+            ...PullRequestFixture({id: '124', repository}),
+            attribution: null,
+            checksStatus: null,
+            dateLinked: '2026-06-08T23:10:32.000000Z',
+            status: 'open',
+          },
+        ],
+      },
+    });
+
+    render(<LinkedPullRequests group={group} />, {organization});
+
+    const list = await screen.findByRole('list', {name: 'Linked pull requests'});
+    const withChecks = within(list).getByRole('link', {name: /Pull request #123/});
+    const withoutChecks = within(list).getByRole('link', {name: /Pull request #124/});
+
+    expect(within(withChecks).getByText('Checks failed')).toBeInTheDocument();
+    expect(within(withoutChecks).queryByText('Checks failed')).not.toBeInTheDocument();
   });
 
   it('deduplicates pull request ids from group activity', () => {

--- a/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
+++ b/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
@@ -32,6 +32,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 
 import {
   getPullRequestStatusLabel,
+  PullRequestChecksBadge,
   PullRequestStatusBadge,
 } from './pullRequestStatusBadge';
 
@@ -99,6 +100,7 @@ function LinkedPullRequestRow({
           trackAnalytics('issue_details.external_issue_pull_request_clicked', {
             organization,
             attribution_type: pullRequest.attribution?.type,
+            checks_status: pullRequest.checksStatus,
             pull_request_id: pullRequest.id,
             pull_request_status: pullRequest.status,
             repository_id: pullRequest.repository.id,
@@ -126,6 +128,9 @@ function LinkedPullRequestRow({
             </PullRequestTitle>
             <Flex align="center" gap="xs">
               <PullRequestStatusBadge status={pullRequest.status} />
+              {pullRequest.checksStatus && (
+                <PullRequestChecksBadge status={pullRequest.checksStatus} />
+              )}
               {pullRequest.attribution ? (
                 <PullRequestAttributionAvatar attribution={pullRequest.attribution} />
               ) : author ? (
@@ -229,6 +234,7 @@ export function useLinkedPullRequests({group}: {group: Group}) {
       '/organizations/$organizationIdOrSlug/issues/$issueId/pull-requests/',
       {
         path: {organizationIdOrSlug: organization.slug, issueId: group.id},
+        query: {expand: 'checksAndReview'},
         staleTime: 30_000,
       }
     )

--- a/static/app/components/group/externalIssuesList/pullRequestStatusBadge.tsx
+++ b/static/app/components/group/externalIssuesList/pullRequestStatusBadge.tsx
@@ -1,12 +1,19 @@
 import {Badge} from '@sentry/scraps/badge';
 import {Grid} from '@sentry/scraps/layout';
 
-import {IconMerge, IconPullRequest, IconPullRequestClosed} from 'sentry/icons';
+import {
+  IconCheckmark,
+  IconClock,
+  IconClose,
+  IconMerge,
+  IconPullRequest,
+  IconPullRequestClosed,
+} from 'sentry/icons';
 import type {SVGIconProps} from 'sentry/icons/svgIcon';
 import {t} from 'sentry/locale';
-import type {PullRequestStatus} from 'sentry/types/integrations';
+import type {PullRequestChecksStatus, PullRequestStatus} from 'sentry/types/integrations';
 
-type PullRequestStatusConfig = {
+type PullRequestBadgeConfig = {
   icon: React.ComponentType<SVGIconProps>;
   label: () => string;
   variant: React.ComponentProps<typeof Badge>['variant'];
@@ -38,22 +45,60 @@ const STATUS_CONFIG = {
     label: () => t('Unknown'),
     variant: 'muted',
   },
-} satisfies Record<PullRequestStatus, PullRequestStatusConfig>;
+} satisfies Record<PullRequestStatus, PullRequestBadgeConfig>;
+
+const CHECKS_CONFIG = {
+  failure: {
+    icon: IconClose,
+    label: () => t('Checks failed'),
+    variant: 'danger',
+  },
+  pending: {
+    icon: IconClock,
+    label: () => t('Checks running'),
+    variant: 'muted',
+  },
+  success: {
+    icon: IconCheckmark,
+    label: () => t('Checks passed'),
+    variant: 'success',
+  },
+} satisfies Record<PullRequestChecksStatus, PullRequestBadgeConfig>;
+
+function PullRequestBadge({
+  ariaLabel,
+  config,
+}: {
+  config: PullRequestBadgeConfig;
+  ariaLabel?: string;
+}) {
+  const {icon: StatusIcon, label, variant} = config;
+
+  return (
+    <Badge aria-label={ariaLabel} variant={variant}>
+      <Grid as="span" align="center" columns="max-content max-content" gap="2xs">
+        <StatusIcon aria-hidden size="xs" />
+        {label()}
+      </Grid>
+    </Badge>
+  );
+}
 
 export function getPullRequestStatusLabel(status: PullRequestStatus) {
   return STATUS_CONFIG[status].label();
 }
 
 export function PullRequestStatusBadge({status}: {status: PullRequestStatus}) {
-  const {icon: StatusIcon, variant} = STATUS_CONFIG[status];
   const statusLabel = getPullRequestStatusLabel(status);
 
   return (
-    <Badge aria-label={t('Pull request status: %s', statusLabel)} variant={variant}>
-      <Grid as="span" align="center" columns="max-content max-content" gap="2xs">
-        <StatusIcon aria-hidden size="xs" />
-        {statusLabel}
-      </Grid>
-    </Badge>
+    <PullRequestBadge
+      ariaLabel={t('Pull request status: %s', statusLabel)}
+      config={STATUS_CONFIG[status]}
+    />
   );
+}
+
+export function PullRequestChecksBadge({status}: {status: PullRequestChecksStatus}) {
+  return <PullRequestBadge config={CHECKS_CONFIG[status]} />;
 }

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -163,8 +163,11 @@ type SeerAttribution = {
 
 export type PullRequestAttribution = SeerAttribution;
 
+export type PullRequestChecksStatus = 'success' | 'failure' | 'pending';
+
 export interface LinkedPullRequest extends Omit<PullRequest, 'author'> {
   attribution: PullRequestAttribution | null;
+  checksStatus: PullRequestChecksStatus | null;
   dateLinked: string;
   status: PullRequestStatus;
   author?: PullRequestAuthor;

--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -1,6 +1,10 @@
 import type {FieldValue} from 'sentry/components/forms/model';
 import type {PriorityLevel} from 'sentry/types/group';
-import type {IntegrationType, PullRequestAttribution} from 'sentry/types/integrations';
+import type {
+  IntegrationType,
+  PullRequestAttribution,
+  PullRequestChecksStatus,
+} from 'sentry/types/integrations';
 import type {Broadcast} from 'sentry/types/system';
 import type {BaseEventAnalyticsParams} from 'sentry/utils/analytics/workflowAnalyticsEvents';
 import type {CommonGroupAnalyticsData} from 'sentry/utils/events';
@@ -37,6 +41,7 @@ interface ExternalIssueParams extends CommonGroupAnalyticsData {
 }
 
 interface ExternalIssuePullRequestParams extends CommonGroupAnalyticsData {
+  checks_status: PullRequestChecksStatus | null;
   pull_request_id: string;
   pull_request_status: string;
   repository_id: string;


### PR DESCRIPTION
Show the CI status of a linked pull request alongside its lifecycle badge, so triaging an issue doesn't require opening the PR to see whether it's green.

<img width="285" height="55" alt="Screenshot 2026-08-03 at 4 09 12 PM" src="https://github.com/user-attachments/assets/de0fe2ff-7ee8-42fd-b2f8-46a10d75c172" />
