### PR TITLE
ref(spans): Add option to control which issue detectors run

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -4097,3 +4097,13 @@ register(
     type=Bool,
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+# Selectively allow issue detectors to run (via the create-a-fake-transaction-event shim) during
+# segment processing. Enabled detectors should be specified by their corresponding `DetectorType`
+# value. To run all possible detectors, set the value to `["*"]`.
+register(
+    "spans.process-segments.detect-performance-problems.detectors-enabled",
+    default=[],
+    type=Sequence,
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)


### PR DESCRIPTION
This adds a new option, `spans.process-segments.detect-performance-problems.detectors-enabled`, to control which detectors are run by the shim patching segments through to our existing issue detectors. Right now, the shim is either on or off, and is off by default. This keeps the same default, by passing an empty list of detectors to run, but allows us to turn them on individually.

To keep things in sync between the sentry repo and the options-automator repo, and to keep the experiment running, the old option is still what's used in the code. Once this is merged, we can set the option in the automator repo, and then once that's done, we can switch our code to use the new option and remove the old one.