### PR TITLE
fix(seer): Record activities before async updates

### DIFF
--- a/src/sentry/issues/action_log/publish.py
+++ b/src/sentry/issues/action_log/publish.py
@@ -10,7 +10,6 @@ from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
-from datetime import datetime
 from typing import TYPE_CHECKING, Optional, Sequence
 
 from sentry.hybridcloud.models.outbox import outbox_context
@@ -82,7 +81,6 @@ def publish_action(
     actor: GroupActionActor = SYSTEM_ACTOR,
     force_async_derived: bool = False,
     idempotency_key: str | None = None,
-    date_added: datetime | None = None,
 ) -> None:
     """
     Record an issue action.
@@ -96,9 +94,6 @@ def publish_action(
 
     If *idempotency_key* is set, the GroupActionLogEntry is created if and only if there
     does not already exist a GALE with that group id & idempotency key; else it's a no-op.
-
-    If *date_added* is set, it records when the action occurred instead of when the outbox
-    receiver processed it.
 
     Log publishing is managed by an outbox that flushes on commit by
     default. Wrap in ``outbox_context(flush=False)`` to defer the drain.
@@ -156,8 +151,6 @@ def publish_action(
 
     if idempotency_key is not None:
         payload["idempotency_key"] = idempotency_key
-    if date_added is not None:
-        payload["date_added"] = date_added.isoformat()
 
     outbox = CellOutbox(
         shard_scope=OutboxScope.GROUP_SCOPE,
@@ -178,7 +171,6 @@ def publish_action_from_context(
     project: Project,
     force_async_derived: bool = False,
     idempotency_key: Optional[str] = None,
-    date_added: datetime | None = None,
 ) -> None:
     """
     Record an issue action using the current ActionContext. This is the primary API
@@ -206,7 +198,6 @@ def publish_action_from_context(
         actor=actor,
         force_async_derived=force_async_derived,
         idempotency_key=idempotency_key,
-        date_added=date_added,
     )
 
 

--- a/src/sentry/issues/action_log/types.py
+++ b/src/sentry/issues/action_log/types.py
@@ -552,7 +552,6 @@ class GroupActionLogPayload(TypedDict):
     data: dict[str, Any]
     force_async_derived: bool
     idempotency_key: NotRequired[str]
-    date_added: NotRequired[str]
 
 
 class SetPublicAction(GroupAction):

--- a/src/sentry/models/activity.py
+++ b/src/sentry/models/activity.py
@@ -151,7 +151,6 @@ class ActivityManager(BaseManager["Activity"]):
                         group_id=group_id,
                         project=activity.project,
                         idempotency_key=activity_action_idempotency_key(activity),
-                        date_added=activity.datetime,
                     )
             except Exception:
                 _default_logger.info("Failed to translate activity %d to GALE", activity.id)

--- a/src/sentry/receivers/outbox/cell.py
+++ b/src/sentry/receivers/outbox/cell.py
@@ -10,12 +10,10 @@ from __future__ import annotations
 
 import json  # noqa: S003 - urllib3 raises stdlib JSONDecodeError, not simplejson's
 import logging
-from datetime import datetime
 from typing import Any, assert_never, cast
 
 from django.db import IntegrityError, router, transaction
 from django.dispatch import receiver
-from django.utils import timezone
 
 from sentry.audit_log.services.log import AuditLogEvent, UserIpEvent, log_rpc_service
 from sentry.auth.services.auth import auth_service
@@ -353,7 +351,6 @@ def process_group_action_log_event(payload: GroupActionLogPayload, **kwds: Any) 
 
         group_id = payload["group_id"]
         force_async_derived = payload["force_async_derived"]
-        date_added = payload.get("date_added")
 
         try:
             with transaction.atomic(using=using):
@@ -366,9 +363,6 @@ def process_group_action_log_event(payload: GroupActionLogPayload, **kwds: Any) 
                     source=payload["source"],
                     data=payload["data"],
                     idempotency_key=payload.get("idempotency_key"),
-                    date_added=(
-                        datetime.fromisoformat(date_added) if date_added else timezone.now()
-                    ),
                 )
         except IntegrityError:
             # Idempotency conflict; we treat this as a no-op.

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -53,6 +53,7 @@ from sentry.seer.entrypoints.operator import (
     SeerActivityAttribution,
     SeerAutofixOperator,
     process_autofix_updates,
+    record_seer_activity,
 )
 from sentry.seer.models import SeerRepoDefinition
 from sentry.seer.models.run import SeerRun
@@ -519,18 +520,26 @@ def trigger_autofix_agent(
     try:
         sentry_app_event_type = SentryAppEventType(event_type)
         if SeerAutofixOperator.has_access(organization=group.organization):
+            activity_attribution: SeerActivityAttribution | None = None
             task_kwargs: dict[str, Any] = {
                 "event_type": sentry_app_event_type,
                 "event_payload": payload,
                 "organization_id": group.organization.id,
+                "record_activity": False,
             }
             if is_iteration_step:
-                activity_attribution: SeerActivityAttribution = {
+                activity_attribution = {
                     "referrer": referrer,
                 }
                 if actor_user_id is not None:
                     activity_attribution["actor_user_id"] = actor_user_id
                 task_kwargs["activity_attribution"] = activity_attribution
+            record_seer_activity(
+                group=group,
+                event_type=sentry_app_event_type,
+                event_payload=payload,
+                activity_attribution=activity_attribution,
+            )
             process_autofix_updates.apply_async(kwargs=task_kwargs)
     except ValueError:
         logger.exception(

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -8,7 +8,6 @@ from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 import sentry_sdk
-from django.utils import timezone
 from pydantic import BaseModel
 from rest_framework.exceptions import PermissionDenied
 from scm.types import GetBranchProtocol, GetRepositoryProtocol
@@ -491,8 +490,6 @@ def trigger_autofix_agent(
             insert_index=insert_index,
         )
 
-    activity_datetime = timezone.now().isoformat()
-
     # Emit the started event after run_id is resolved so it can be joined to
     # downstream completed/PR events.
     if config.started_event is not None:
@@ -526,7 +523,6 @@ def trigger_autofix_agent(
                 "event_type": sentry_app_event_type,
                 "event_payload": payload,
                 "organization_id": group.organization.id,
-                "activity_datetime": activity_datetime,
             }
             if is_iteration_step:
                 activity_attribution: SeerActivityAttribution = {

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -8,7 +8,6 @@ import orjson
 import sentry_sdk
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
-from django.utils import timezone
 from taskbroker_client.retry import Retry
 from urllib3 import BaseHTTPResponse
 from urllib3.connectionpool import HTTPConnectionPool
@@ -184,7 +183,6 @@ def _trigger_autofix_task(
         )
 
         run: SeerRun | None = None
-        triggered_at = timezone.now()
         try:
             run = trigger_autofix_agent(
                 group=group,
@@ -199,7 +197,6 @@ def _trigger_autofix_task(
                     ActivityType.TRIGGER_AUTOFIX,
                     data={"referrer": referrer.value},
                     send_notification=False,
-                    datetime=triggered_at,
                 )
         except NoSeerQuotaException:
             pass

--- a/src/sentry/seer/autofix/on_completion_hook.py
+++ b/src/sentry/seer/autofix/on_completion_hook.py
@@ -468,7 +468,6 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
                         "event_type": sentry_app_event_type,
                         "event_payload": webhook_payload,
                         "organization_id": organization.id,
-                        "activity_datetime": state.updated_at,
                     }
                 )
         except ValueError:

--- a/src/sentry/seer/autofix/on_completion_hook.py
+++ b/src/sentry/seer/autofix/on_completion_hook.py
@@ -50,7 +50,11 @@ from sentry.seer.autofix.utils import (
     clear_preference_automation_handoff,
     get_automation_handoff,
 )
-from sentry.seer.entrypoints.operator import SeerAutofixOperator, process_autofix_updates
+from sentry.seer.entrypoints.operator import (
+    SeerAutofixOperator,
+    process_autofix_updates,
+    record_seer_activity,
+)
 from sentry.seer.models import (
     SeerAutomationHandoffConfiguration,
     SeerRun,
@@ -463,11 +467,17 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
                     "autofix.on_completion_hook.process_autofix_updates",
                     tags={"event_type": str(event_type)},
                 )
+                record_seer_activity(
+                    group=group,
+                    event_type=sentry_app_event_type,
+                    event_payload=webhook_payload,
+                )
                 process_autofix_updates.apply_async(
                     kwargs={
                         "event_type": sentry_app_event_type,
                         "event_payload": webhook_payload,
                         "organization_id": organization.id,
+                        "record_activity": False,
                     }
                 )
         except ValueError:

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -4,7 +4,6 @@ import logging
 import uuid
 from typing import Any
 
-from django.utils import timezone
 from drf_spectacular.utils import extend_schema
 from rest_framework import serializers, status
 from rest_framework.exceptions import PermissionDenied
@@ -410,7 +409,6 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                 run_id, sentry_run_id = resolved_run_id, resolved_sentry_run_id
 
             case _:
-                triggered_at = timezone.now() if is_autofix_kickoff else None
                 try:
                     run = trigger_autofix_agent(
                         group=group,
@@ -450,7 +448,6 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                             ),
                             data={"referrer": referrer.value},
                             send_notification=False,
-                            datetime=triggered_at,
                         )
                     sentry_run_id = str(run.uuid)
                 else:

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -644,6 +644,49 @@ def _create_seer_activity(
     )
 
 
+def record_seer_activity(
+    *,
+    group: Group,
+    event_type: SentryAppEventType,
+    event_payload: dict[str, Any],
+    activity_attribution: SeerActivityAttribution | None = None,
+) -> None:
+    iteration_attribution: SeerActivityAttribution | None = None
+    if event_type == SentryAppEventType.SEER_ITERATION_STARTED and activity_attribution:
+        try:
+            referrer = AutofixReferrer(activity_attribution["referrer"])
+        except ValueError:
+            pass
+        else:
+            iteration_attribution = {"referrer": referrer}
+            actor_user_id = activity_attribution.get("actor_user_id")
+            if actor_user_id is not None:
+                iteration_attribution["actor_user_id"] = actor_user_id
+
+    action_source = ActionSource.SEER_EXPLORER
+    action_actor = SYSTEM_ACTOR
+    if iteration_attribution is not None:
+        action_source = ITERATION_REFERRER_TO_ACTION_SOURCE.get(
+            iteration_attribution["referrer"], ActionSource.SEER_EXPLORER
+        )
+        actor_user_id = iteration_attribution.get("actor_user_id")
+        if actor_user_id is not None:
+            action_actor = GroupActionActor.user(actor_user_id)
+
+    try:
+        with action_context_scope(action_source, action_actor):
+            _create_seer_activity(group, event_type, event_payload, iteration_attribution)
+    except Exception:
+        logger.exception(
+            "seer.activity_creation_failed",
+            extra={
+                "group_id": group.id,
+                "run_id": event_payload.get("run_id"),
+                "event_type": str(event_type),
+            },
+        )
+
+
 @instrumented_task(
     name="sentry.seer.entrypoints.operator.process_autofix_updates",
     namespace=seer_tasks,
@@ -656,6 +699,7 @@ def process_autofix_updates(
     event_payload: dict[str, Any],
     organization_id: int,
     activity_attribution: SeerActivityAttribution | None = None,
+    record_activity: bool = True,
 ) -> None:
     """
     Use the registry to iterate over all entrypoints and check if this payload's run_id or group_id
@@ -695,36 +739,12 @@ def process_autofix_updates(
             lifecycle.record_halt(halt_reason="no_operator_access")
             return
 
-        iteration_attribution: SeerActivityAttribution | None = None
-        if event_type == SentryAppEventType.SEER_ITERATION_STARTED and activity_attribution:
-            try:
-                activity_attribution["referrer"] = AutofixReferrer(activity_attribution["referrer"])
-            except ValueError:
-                pass
-            else:
-                iteration_attribution = activity_attribution
-
-        action_source = ActionSource.SEER_EXPLORER
-        action_actor = SYSTEM_ACTOR
-        if iteration_attribution is not None:
-            action_source = ITERATION_REFERRER_TO_ACTION_SOURCE.get(
-                iteration_attribution["referrer"], ActionSource.SEER_EXPLORER
-            )
-            actor_user_id = iteration_attribution.get("actor_user_id")
-            if actor_user_id is not None:
-                action_actor = GroupActionActor.user(actor_user_id)
-
-        try:
-            with action_context_scope(action_source, action_actor):
-                _create_seer_activity(group, event_type, event_payload, iteration_attribution)
-        except Exception:
-            logger.exception(
-                "seer.activity_creation_failed",
-                extra={
-                    "group_id": group_id,
-                    "run_id": run_id,
-                    "event_type": str(event_type),
-                },
+        if record_activity:
+            record_seer_activity(
+                group=group,
+                event_type=event_type,
+                event_payload=event_payload,
+                activity_attribution=activity_attribution,
             )
 
         for entrypoint_key, entrypoint_cls in autofix_entrypoint_registry.registrations.items():

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -1,8 +1,5 @@
 import logging
-from datetime import datetime
 from typing import Any, NotRequired, TypedDict
-
-from django.utils import timezone
 
 from sentry import features, options
 from sentry.constants import DataCategory
@@ -234,7 +231,6 @@ class SeerAutofixOperator[CachePayloadT]:
 
             try:
                 if not run_id:
-                    triggered_at = timezone.now()
                     with action_context_scope(ActionSource.SLACK, GroupActionActor.user(user.id)):
                         run = trigger_autofix_agent(
                             group=group,
@@ -250,7 +246,6 @@ class SeerAutofixOperator[CachePayloadT]:
                             user_id=user.id,
                             data={"referrer": AutofixReferrer.SLACK.value},
                             send_notification=False,
-                            datetime=triggered_at,
                         )
                 elif stopping_point == AutofixStoppingPoint.OPEN_PR:
                     trigger_push_changes(
@@ -599,7 +594,6 @@ def _create_seer_activity(
     event_type: SentryAppEventType,
     event_payload: dict[str, Any],
     activity_attribution: SeerActivityAttribution | None = None,
-    activity_datetime: datetime | None = None,
 ) -> None:
     activity_type = SEER_EVENT_TO_ACTIVITY_TYPE.get(event_type)
     if not activity_type:
@@ -647,7 +641,6 @@ def _create_seer_activity(
         user_id=actor_user_id,
         data=activity_data if activity_data else None,
         send_notification=False,
-        datetime=activity_datetime,
     )
 
 
@@ -663,7 +656,6 @@ def process_autofix_updates(
     event_payload: dict[str, Any],
     organization_id: int,
     activity_attribution: SeerActivityAttribution | None = None,
-    activity_datetime: str | None = None,
 ) -> None:
     """
     Use the registry to iterate over all entrypoints and check if this payload's run_id or group_id
@@ -724,15 +716,7 @@ def process_autofix_updates(
 
         try:
             with action_context_scope(action_source, action_actor):
-                _create_seer_activity(
-                    group,
-                    event_type,
-                    event_payload,
-                    activity_attribution=iteration_attribution,
-                    activity_datetime=(
-                        datetime.fromisoformat(activity_datetime) if activity_datetime else None
-                    ),
-                )
+                _create_seer_activity(group, event_type, event_payload, iteration_attribution)
         except Exception:
             logger.exception(
                 "seer.activity_creation_failed",

--- a/src/sentry/seer/night_shift/delivery.py
+++ b/src/sentry/seer/night_shift/delivery.py
@@ -8,7 +8,6 @@ from typing import Any
 from uuid import UUID
 
 import sentry_sdk
-from django.utils import timezone
 
 from sentry.constants import SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT, ObjectStatus
 from sentry.issues.action_log import SYSTEM_ACTOR, ActionSource, action_context_scope
@@ -222,7 +221,6 @@ def _process_verdicts(
                 if reason
                 else None
             )
-            triggered_at = timezone.now()
             try:
                 triggered_run = trigger_autofix_agent(
                     group=group,
@@ -245,7 +243,6 @@ def _process_verdicts(
                     ActivityType.TRIGGER_AUTOFIX,
                     data={"referrer": referrer.value},
                     send_notification=False,
-                    datetime=triggered_at,
                 )
 
         sentry_sdk.metrics.count("night_shift.autofix_triggered", len(run_by_group))

--- a/tests/sentry/models/test_activity.py
+++ b/tests/sentry/models/test_activity.py
@@ -4,10 +4,8 @@ from unittest.mock import MagicMock, patch
 
 from sentry.event_manager import EventManager
 from sentry.incidents.grouptype import MetricIssue
-from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
 from sentry.models.activity import Activity
 from sentry.testutils.cases import TestCase
-from sentry.testutils.outbox import outbox_runner
 from sentry.types.activity import ActivityType
 from sentry.types.group import PriorityLevel
 from sentry.utils.iterators import chunked
@@ -414,20 +412,18 @@ class ActivityTest(TestCase):
 
         custom_datetime = datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
 
-        with self.feature("projects:issue-action-log-write-to-db"), outbox_runner():
-            activity = Activity.objects.create_group_activity(
-                group=group,
-                type=ActivityType.SET_RESOLVED,
-                user=user,
-                data={"reason": "test"},
-                send_notification=False,
-                datetime=custom_datetime,
-            )
+        activity = Activity.objects.create_group_activity(
+            group=group,
+            type=ActivityType.SET_RESOLVED,
+            user=user,
+            data={"reason": "test"},
+            send_notification=False,
+            datetime=custom_datetime,
+        )
 
         assert activity.datetime == custom_datetime
         assert activity.type == ActivityType.SET_RESOLVED.value
         assert activity.user_id == user.id
-        assert GroupActionLogEntry.objects.get(group_id=group.id).date_added == custom_datetime
 
     def test_create_group_activity_without_custom_datetime(self) -> None:
         project = self.create_project(name="test_default_datetime")

--- a/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
+++ b/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
@@ -1,6 +1,7 @@
 from typing import TypedDict
 from unittest.mock import MagicMock, patch
 
+from sentry.models.activity import Activity
 from sentry.seer.agent.client_models import (
     AgentFilePatch,
     Artifact,
@@ -29,6 +30,7 @@ from sentry.seer.models import AutofixHandoffPoint, SeerAutomationHandoffConfigu
 from sentry.sentry_apps.utils.webhooks import SeerActionType
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import before_now
+from sentry.types.activity import ActivityType
 
 
 def run_state(run_id=123, blocks: list[MemoryBlock] | None = None, metadata=None):
@@ -525,6 +527,14 @@ class TestAutofixOnCompletionHookWebhooks(TestCase):
         self, mock_broadcast, mock_has_access, mock_process_autofix_updates, mock_analytics
     ):
         mock_has_access.return_value = True
+
+        def assert_activity_exists(**_kwargs: object) -> None:
+            assert Activity.objects.filter(
+                group=self.group,
+                type=ActivityType.SEER_ITERATION_COMPLETED.value,
+            ).exists()
+
+        mock_process_autofix_updates.side_effect = assert_activity_exists
         state = run_state(
             blocks=[
                 root_cause_memory_block(),
@@ -557,6 +567,7 @@ class TestAutofixOnCompletionHookWebhooks(TestCase):
         assert call_kwargs["payload"]["pull_requests"][0]["provider"] == "github"
         assert call_kwargs["payload"]["pull_requests"][0]["pull_request"]["pr_number"] == 7
         mock_process_autofix_updates.assert_called_once()
+        assert mock_process_autofix_updates.call_args.kwargs["kwargs"]["record_activity"] is False
         assert (
             mock_analytics.call_args.args[0].referrer
             == AutofixReferrer.GROUP_AUTOFIX_ENDPOINT.value

--- a/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
+++ b/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
@@ -558,10 +558,6 @@ class TestAutofixOnCompletionHookWebhooks(TestCase):
         assert call_kwargs["payload"]["pull_requests"][0]["pull_request"]["pr_number"] == 7
         mock_process_autofix_updates.assert_called_once()
         assert (
-            mock_process_autofix_updates.call_args.kwargs["kwargs"]["activity_datetime"]
-            == state.updated_at
-        )
-        assert (
             mock_analytics.call_args.args[0].referrer
             == AutofixReferrer.GROUP_AUTOFIX_ENDPOINT.value
         )

--- a/tests/sentry/seer/entrypoints/test_operator.py
+++ b/tests/sentry/seer/entrypoints/test_operator.py
@@ -501,7 +501,6 @@ class SeerOperatorTest(TestCase):
 
     @patch.object(SeerAutofixOperator, "has_access", return_value=True)
     def test_seer_event_creates_activity_solution_completed(self, _mock_has_access):
-        activity_datetime = datetime.fromisoformat("2024-01-15T10:30:00+00:00")
         event_payload = {
             "run_id": MOCK_RUN_ID,
             "group_id": self.group.id,
@@ -515,7 +514,6 @@ class SeerOperatorTest(TestCase):
             event_type=SentryAppEventType.SEER_SOLUTION_COMPLETED,
             event_payload=event_payload,
             organization_id=self.organization.id,
-            activity_datetime=activity_datetime.isoformat(),
         )
 
         activity = Activity.objects.get(
@@ -525,7 +523,6 @@ class SeerOperatorTest(TestCase):
         assert activity.data["summary"] == "Test solution summary"
         assert "solution" not in activity.data
         assert "steps" not in activity.data
-        assert activity.datetime == activity_datetime
 
     @patch.object(SeerAutofixOperator, "has_access", return_value=True)
     def test_seer_event_creates_activity_coding_completed(self, _mock_has_access):


### PR DESCRIPTION
Seer activities were timestamped when async workers processed them, so completed and next-step-started events could appear out of order.

Reverts #120983's caller-supplied timestamp plumbing. Instead, internal step activities are inserted before the worker is queued; the worker still records activities for other callers.