### PR TITLE
ref(spans): Only fetch issue detection settings once

### DIFF
--- a/src/sentry/issue_detection/detectors/span_first/run_detectors.py
+++ b/src/sentry/issue_detection/detectors/span_first/run_detectors.py
@@ -6,11 +6,11 @@ from collections.abc import Sequence
 from types import NoneType
 from typing import Any
 
+from sentry.issue_detection.base import DetectorType
 from sentry.issue_detection.detectors.span_first.base import SpanFirstDetector
 from sentry.issue_detection.detectors.span_first.slow_db_query_detector import (
     SpanFirstSlowDBQueryDetector,
 )
-from sentry.issue_detection.performance_detection import get_detection_settings
 from sentry.issue_detection.performance_problem import PerformanceProblem, PerformanceProblemDict
 from sentry.issue_detection.types import StandaloneSpan
 from sentry.issues.grouptype import (
@@ -43,7 +43,7 @@ def run_span_first_detectors(
     grouptypes: Sequence[str],
     segment_span: StandaloneSpan,
     spans: Sequence[StandaloneSpan],
-    project: Project,
+    detection_settings: dict[DetectorType, dict[str, Any]],
 ) -> dict[str, list[PerformanceProblem]]:
     """
     For each of grouptype slugs in `grouptypes`, run the corresponding span-first detectors, and
@@ -56,7 +56,6 @@ def run_span_first_detectors(
     `SpanFirstDetectorsRolloutController.should_check_experiment`). This function does no sampling
     of its own.
     """
-    detection_settings = get_detection_settings(project)
     span_first_problems: dict[str, list[PerformanceProblem]] = {}
 
     for grouptype in grouptypes:

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -346,7 +346,7 @@ def _detect_performance_problems(
     # Note: Not all legacy detectors have span-first analogs yet. Results from those that don't are
     # just ignored in the comparison.
     _maybe_run_span_first_detector_parity_check(
-        segment_span, spans, project, legacy_detected_problems
+        segment_span, spans, project, legacy_detected_problems, detection_settings
     )
 
 
@@ -410,6 +410,7 @@ def _maybe_run_span_first_detector_parity_check(
     segment: list[CompatibleSpan],
     project: Project,
     all_control_problems: list[PerformanceProblem],
+    detection_settings: dict[DetectorType, dict[str, Any]],
 ) -> None:
     if not options.get(SPAN_FIRST_DETECTORS_ENABLEMENT_OPTION):
         return

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -18,6 +18,7 @@ from sentry.dynamic_sampling.rules.helpers.latest_releases import record_latest_
 from sentry.event_manager import INSIGHT_MODULE_TO_PROJECT_FLAG_NAME
 from sentry.insights import FilterSpan
 from sentry.insights import modules as insights_modules
+from sentry.issue_detection.base import DetectorType
 from sentry.issue_detection.detectors.span_first.run_detectors import (
     SPAN_FIRST_DETECTORS_BY_GROUPTYPE,
     compare_span_first_problems_to_control_data,
@@ -27,7 +28,10 @@ from sentry.issue_detection.detectors.span_first.span_first_utils import (
     SPAN_FIRST_DETECTORS_ENABLEMENT_OPTION,
     SpanFirstDetectorsRolloutController,
 )
-from sentry.issue_detection.performance_detection import detect_performance_problems
+from sentry.issue_detection.performance_detection import (
+    detect_performance_problems,
+    get_detection_settings,
+)
 from sentry.issue_detection.performance_problem import PerformanceProblem
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
@@ -329,7 +333,10 @@ def _detect_performance_problems(
     try:
         # Run the legacy detectors and, if the `_performance_issues_spans` flag is set on the
         # segment span, produce occurrences from the results
-        legacy_detected_problems = _run_legacy_detectors(segment_span, spans, project)
+        detection_settings = get_detection_settings(project)
+        legacy_detected_problems = _run_legacy_detectors(
+            segment_span, spans, project, detection_settings
+        )
     except Exception:
         logger.exception("segment_consumer_legacy_issue_detectors.error")
         # If the legacy detectors error out, there's no point in running the experiment, so bail now
@@ -344,7 +351,10 @@ def _detect_performance_problems(
 
 
 def _run_legacy_detectors(
-    segment_span: CompatibleSpan, segment: list[CompatibleSpan], project: Project
+    segment_span: CompatibleSpan,
+    segment: list[CompatibleSpan],
+    project: Project,
+    detection_settings: dict[DetectorType, dict[str, Any]],
 ) -> list[PerformanceProblem]:
     """
     Run legacy issue detectors on segment data by first creating a fake transaction event. If the
@@ -353,7 +363,9 @@ def _run_legacy_detectors(
     # Create a fake transaction event out of the segment data, to match what the legacy detectors
     # are expecting
     event_data = build_shim_event_data(segment_span, segment)
-    detected_problems = detect_performance_problems(event_data, project, standalone=True)
+    detected_problems = detect_performance_problems(
+        event_data, project, detection_settings=detection_settings, standalone=True
+    )
 
     # This flag is set in Relay, and here enables producing occurrences from the legacy detector
     # results. For segments derived from transactions, it additionally suppresses the running of

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -425,7 +425,7 @@ def _maybe_run_span_first_detector_parity_check(
 
     try:
         span_first_problems_by_grouptype = run_span_first_detectors(
-            sampled_grouptypes, segment_span, segment, project
+            sampled_grouptypes, segment_span, segment, detection_settings
         )
 
         compare_span_first_problems_to_control_data(

--- a/tests/sentry/issue_detection/span_first/test_run_detectors.py
+++ b/tests/sentry/issue_detection/span_first/test_run_detectors.py
@@ -16,6 +16,7 @@ from sentry.issue_detection.detectors.span_first.run_detectors import (
     run_detector,
     run_span_first_detectors,
 )
+from sentry.issue_detection.performance_detection import get_detection_settings
 from sentry.issue_detection.performance_problem import PerformanceProblem, PerformanceProblemDict
 from sentry.issue_detection.types import StandaloneSpan
 from sentry.issues.grouptype import (
@@ -145,7 +146,7 @@ class RunSpanFirstDetectorsTest(TestCase):
                 [SLOW_DB_SLUG, N_PLUS_ONE_API_SLUG],
                 dummy_segment[0],
                 dummy_segment,
-                self.project,
+                get_detection_settings(self.project),
             )
 
             assert set(span_first_problems_by_grouptype.keys()) == {

--- a/tests/sentry/spans/consumers/process_segments/test_message.py
+++ b/tests/sentry/spans/consumers/process_segments/test_message.py
@@ -6,6 +6,15 @@ from unittest import mock
 import pytest
 from django.utils import timezone
 
+from sentry.issue_detection.detectors.span_first.run_detectors import run_span_first_detectors
+from sentry.issue_detection.detectors.span_first.span_first_utils import (
+    SPAN_FIRST_DETECTORS_ENABLEMENT_OPTION,
+    SpanFirstDetectorsRolloutController,
+)
+from sentry.issue_detection.performance_detection import (
+    detect_performance_problems,
+    get_detection_settings,
+)
 from sentry.issues.grouptype import PerformanceNPlusOneGroupType
 from sentry.models.environment import Environment
 from sentry.models.release import Release
@@ -277,6 +286,44 @@ class TestSpansTask(TestCase):
             ).hexdigest()
         ]
         assert performance_problem.type == PerformanceNPlusOneGroupType
+
+    def test_detector_settings_only_fetched_once(self) -> None:
+        spans = self.generate_basic_spans()
+        detection_settings = get_detection_settings(self.project)
+
+        with (
+            override_options(
+                {
+                    "spans.process-segments.detect-performance-problems.enable": True,
+                    SPAN_FIRST_DETECTORS_ENABLEMENT_OPTION: True,
+                }
+            ),
+            mock.patch.object(
+                SpanFirstDetectorsRolloutController, "should_check_experiment", return_value=True
+            ),
+            mock.patch(
+                "sentry.spans.consumers.process_segments.message.get_detection_settings",
+                return_value=detection_settings,
+            ) as mock_get_detection_settings,
+            mock.patch(
+                "sentry.spans.consumers.process_segments.message.detect_performance_problems",
+                wraps=detect_performance_problems,
+            ) as legacy_detectors_spy,
+            mock.patch(
+                "sentry.spans.consumers.process_segments.message.run_span_first_detectors",
+                wraps=run_span_first_detectors,
+            ) as span_first_detectors_spy,
+        ):
+            process_segment(spans)
+
+            assert mock_get_detection_settings.call_count == 1
+            mock_get_detection_settings.assert_called_with(self.project)
+
+            legacy_settings = legacy_detectors_spy.call_args.kwargs["detection_settings"]
+            span_first_settings = span_first_detectors_spy.call_args.args[3]
+
+            assert legacy_settings is detection_settings
+            assert span_first_settings is detection_settings
 
     @mock.patch("sentry.spans.consumers.process_segments.message.track_outcome")
     @pytest.mark.skip("temporarily disabled")


### PR DESCRIPTION
This is a follow-up to https://github.com/getsentry/sentry/pull/121094 (which allowed passing pre-fetched detection settings to the helpers which run existing issue detectors), taking advantage of that ability in our span-first vs. existing detectors experiment, such that we only fetch detection settings once, rather than once for the existing detectors and again for span-first detectors.