### PR TITLE
feat(seer): Record run milestones from Seer run state

### DIFF
--- a/src/sentry/seer/autofix/coding_agent_handoffs.py
+++ b/src/sentry/seer/autofix/coding_agent_handoffs.py
@@ -18,6 +18,7 @@ from sentry.seer.autofix.utils import (
     update_coding_agent_state,
 )
 from sentry.seer.endpoints.utils import get_seer_run
+from sentry.seer.milestones import record_has_pull_request
 from sentry.seer.models.run import (
     SeerAgentRun,
     SeerRunCodingAgentHandoff,
@@ -140,6 +141,9 @@ def sync_coding_agent_status(
                 log_context=link_log_context,
                 coding_agent_handoff=handoff,
             )
+
+            if pr_number is not None:
+                record_has_pull_request(handoff.seer_run)
 
     known_to_seer = update_coding_agent_state(
         agent_id=agent_id, status=status, agent_url=agent_url, result=result

--- a/src/sentry/seer/autofix/on_completion_hook.py
+++ b/src/sentry/seer/autofix/on_completion_hook.py
@@ -51,7 +51,7 @@ from sentry.seer.autofix.utils import (
     get_automation_handoff,
 )
 from sentry.seer.entrypoints.operator import SeerAutofixOperator, process_autofix_updates
-from sentry.seer.milestones import milestones_from_state, reconcile_milestones
+from sentry.seer.milestones import reconcile_milestones
 from sentry.seer.models import (
     SeerAutomationHandoffConfiguration,
     SeerRun,
@@ -451,7 +451,7 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
             return
 
         if seer_run is not None:
-            reconcile_milestones(seer_run, desired=milestones_from_state(state))
+            reconcile_milestones(seer_run, state)
 
         event_name = webhook_action_type.value
 

--- a/src/sentry/seer/autofix/on_completion_hook.py
+++ b/src/sentry/seer/autofix/on_completion_hook.py
@@ -51,6 +51,7 @@ from sentry.seer.autofix.utils import (
     get_automation_handoff,
 )
 from sentry.seer.entrypoints.operator import SeerAutofixOperator, process_autofix_updates
+from sentry.seer.milestones import milestones_from_state, reconcile_milestones
 from sentry.seer.models import (
     SeerAutomationHandoffConfiguration,
     SeerRun,
@@ -383,18 +384,14 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
         """
         current_step, current_referrer = cls._get_current_step(state)
 
-        sentry_run_id = (
-            SeerRun.objects.filter(
-                organization_id=organization.id,
-                seer_run_state_id=run_id,
-            )
-            .values_list("uuid", flat=True)
-            .first()
-        )
+        seer_run = SeerRun.objects.filter(
+            organization_id=organization.id,
+            seer_run_state_id=run_id,
+        ).first()
 
         webhook_payload = {
             "run_id": run_id,
-            "sentry_run_id": str(sentry_run_id) if sentry_run_id is not None else None,
+            "sentry_run_id": str(seer_run.uuid) if seer_run is not None else None,
             "group_id": group.id,
         }
 
@@ -452,6 +449,9 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
 
         if not webhook_action_type:
             return
+
+        if seer_run is not None:
+            reconcile_milestones(seer_run, desired=milestones_from_state(state))
 
         event_name = webhook_action_type.value
 

--- a/src/sentry/seer/milestones.py
+++ b/src/sentry/seer/milestones.py
@@ -23,10 +23,8 @@ SEER_STATE_MILESTONES = frozenset(
 
 
 def _has_pull_request(state: SeerRunState) -> bool:
-    # Native Seer PRs mark the block that was pushed (block-derived, so it resets
-    # when a re-run truncates blocks). Coding-agent PRs live in the coding_agents
-    # side-channel; pr_number (not pr_url, which may be a pushed branch) confirms
-    # an actual PR. A run can't be re-run once either exists, so neither goes stale.
+    # Native Seer PRs mark a pushed block; coding-agent PRs live in coding_agents.
+    # pr_number (not pr_url, which may be a pushed branch) confirms an actual PR.
     if any(block.pr_commit_shas for block in state.blocks):
         return True
     return any(
@@ -75,3 +73,11 @@ def reconcile_milestones(seer_run: SeerRun, desired: Collection[str]) -> None:
                 [SeerRunMilestone(seer_run=seer_run, milestone=m) for m in to_insert],
                 ignore_conflicts=True,
             )
+
+
+def record_has_pull_request(seer_run: SeerRun) -> None:
+    # Coding-agent PRs land via the async status sync, after the step webhook that
+    # runs reconcile_milestones; record the milestone here so it isn't missed.
+    SeerRunMilestone.objects.get_or_create(
+        seer_run=seer_run, milestone=SeerRunMilestoneType.HAS_PULL_REQUEST
+    )

--- a/src/sentry/seer/milestones.py
+++ b/src/sentry/seer/milestones.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from collections.abc import Collection
+from typing import TYPE_CHECKING
+
+from django.db import router, transaction
+
+from sentry.seer.models.run import SeerRun, SeerRunMilestone, SeerRunMilestoneType
+
+if TYPE_CHECKING:
+    from sentry.seer.agent.client_models import SeerRunState
+
+# The milestone subset derived from and reconciled against Seer run state.
+# PULL_REQUESTS_MERGED is excluded: it is owned by the PR-merge webhook.
+SEER_STATE_MILESTONES = frozenset(
+    {
+        SeerRunMilestoneType.ROOT_CAUSE,
+        SeerRunMilestoneType.SOLUTION,
+        SeerRunMilestoneType.CODE_CHANGES,
+        SeerRunMilestoneType.HAS_PULL_REQUEST,
+    }
+)
+
+
+def _has_pull_request(state: SeerRunState) -> bool:
+    # Native Seer PRs mark the block that was pushed (block-derived, so it resets
+    # when a re-run truncates blocks). Coding-agent PRs live in the coding_agents
+    # side-channel; pr_number (not pr_url, which may be a pushed branch) confirms
+    # an actual PR. A run can't be re-run once either exists, so neither goes stale.
+    if any(block.pr_commit_shas for block in state.blocks):
+        return True
+    return any(
+        result.pr_number is not None
+        for agent in state.coding_agents.values()
+        for result in agent.results
+    )
+
+
+def milestones_from_state(state: SeerRunState) -> set[str]:
+    """Derive reached milestones from ``state.blocks`` (not ``repo_pr_states``,
+    which persists across a re-run) so a re-run correctly shrinks the set.
+    """
+    milestones: set[str] = set()
+    artifacts = state.get_artifacts()
+    if "root_cause" in artifacts:
+        milestones.add(SeerRunMilestoneType.ROOT_CAUSE)
+    if "solution" in artifacts:
+        milestones.add(SeerRunMilestoneType.SOLUTION)
+    if state.get_diffs_by_repo():
+        milestones.add(SeerRunMilestoneType.CODE_CHANGES)
+    if _has_pull_request(state):
+        milestones.add(SeerRunMilestoneType.HAS_PULL_REQUEST)
+    return milestones
+
+
+def reconcile_milestones(seer_run: SeerRun, desired: Collection[str]) -> None:
+    """Make the run's SEER_STATE_MILESTONES match ``desired``, inserting missing
+    ones and deleting no-longer-desired ones. Milestones outside that set (e.g.
+    PULL_REQUESTS_MERGED) are left untouched.
+    """
+    desired_managed = set(desired) & SEER_STATE_MILESTONES
+    with transaction.atomic(using=router.db_for_write(SeerRunMilestone)):
+        existing = set(
+            SeerRunMilestone.objects.filter(
+                seer_run=seer_run, milestone__in=SEER_STATE_MILESTONES
+            ).values_list("milestone", flat=True)
+        )
+        to_delete = existing - desired_managed
+        if to_delete:
+            SeerRunMilestone.objects.filter(seer_run=seer_run, milestone__in=to_delete).delete()
+
+        to_insert = desired_managed - existing
+        if to_insert:
+            SeerRunMilestone.objects.bulk_create(
+                [SeerRunMilestone(seer_run=seer_run, milestone=m) for m in to_insert],
+                ignore_conflicts=True,
+            )

--- a/src/sentry/seer/milestones.py
+++ b/src/sentry/seer/milestones.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Collection
 from typing import TYPE_CHECKING
 
 from django.db import router, transaction
@@ -51,12 +50,12 @@ def milestones_from_state(state: SeerRunState) -> set[str]:
     return milestones
 
 
-def reconcile_milestones(seer_run: SeerRun, desired: Collection[str]) -> None:
-    """Make the run's SEER_STATE_MILESTONES match ``desired``, inserting missing
-    ones and deleting no-longer-desired ones. Milestones outside that set (e.g.
-    PULL_REQUESTS_MERGED) are left untouched.
+def reconcile_milestones(seer_run: SeerRun, state: SeerRunState) -> None:
+    """Make the run's SEER_STATE_MILESTONES match what ``state`` has reached,
+    inserting newly-reached ones and deleting ones a re-run undid. Milestones
+    outside that set (e.g. PULL_REQUESTS_MERGED) are left untouched.
     """
-    desired_managed = set(desired) & SEER_STATE_MILESTONES
+    desired_managed = milestones_from_state(state) & SEER_STATE_MILESTONES
     with transaction.atomic(using=router.db_for_write(SeerRunMilestone)):
         existing = set(
             SeerRunMilestone.objects.filter(

--- a/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
+++ b/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
@@ -26,6 +26,7 @@ from sentry.seer.autofix.pr_iteration.feedback_sources.github_comment import (
 )
 from sentry.seer.autofix.utils import AutofixStoppingPoint
 from sentry.seer.models import AutofixHandoffPoint, SeerAutomationHandoffConfiguration
+from sentry.seer.models.run import SeerRunMilestone, SeerRunMilestoneType
 from sentry.sentry_apps.utils.webhooks import SeerActionType
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import before_now
@@ -1157,3 +1158,113 @@ class TestMaybeReactToCompletedIteration(TestCase):
         # :tada: is still added, but the eyes-delete is skipped entirely.
         assert mock_react.call_args.kwargs["reaction"] == "hooray"
         mock_delete_eyes.assert_not_called()
+
+
+class TestAutofixOnCompletionHookMilestones(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.organization = self.create_organization()
+        self.project = self.create_project(organization=self.organization)
+        self.group = self.create_group(project=self.project)
+        self.run_id = 123
+        self.seer_run = self.create_seer_run(
+            organization=self.organization, seer_run_state_id=self.run_id
+        )
+
+    def _recorded_milestones(self) -> set[str]:
+        return set(
+            SeerRunMilestone.objects.filter(seer_run=self.seer_run).values_list(
+                "milestone", flat=True
+            )
+        )
+
+    def _run_hook(self, state) -> None:
+        AutofixOnCompletionHook._send_step_webhook(
+            self.organization, self.run_id, state, self.group
+        )
+
+    @patch("sentry.seer.autofix.on_completion_hook.broadcast_webhooks_for_organization.delay")
+    def test_records_reached_milestones_from_state(self, mock_broadcast):
+        # Milestones are the monotonic set the run has reached, derived from
+        # state. Firing twice is idempotent (no duplicate rows).
+        state = run_state(
+            blocks=[
+                root_cause_memory_block(),
+                solution_memory_block(),
+                code_changes_memory_block(),
+            ]
+        )
+        self._run_hook(state)
+        self._run_hook(state)
+        assert self._recorded_milestones() == {
+            SeerRunMilestoneType.ROOT_CAUSE,
+            SeerRunMilestoneType.SOLUTION,
+            SeerRunMilestoneType.CODE_CHANGES,
+        }
+        assert SeerRunMilestone.objects.filter(seer_run=self.seer_run).count() == 3
+
+    @patch("sentry.seer.autofix.on_completion_hook.analytics.record")
+    @patch("sentry.seer.autofix.on_completion_hook.broadcast_webhooks_for_organization.delay")
+    def test_has_pull_request_is_block_derived_not_repo_pr_states(
+        self, mock_broadcast, mock_analytics
+    ):
+        # repo_pr_states persists across a re-run, so it must NOT be the source:
+        # a run with repo_pr_states but no PR-commit block records no PR milestone.
+        state = run_state(
+            blocks=[
+                root_cause_memory_block(),
+                solution_memory_block(),
+                code_changes_memory_block(),
+            ]
+        )
+        state.repo_pr_states = {
+            "test-repo": RepoPRState(
+                repo_name="test-repo",
+                pr_id=77,
+                pr_number=7,
+                pr_url="https://example.com/pull/7",
+                pr_creation_status="completed",
+                commit_sha="synced-sha",
+            )
+        }
+        self._run_hook(state)
+        assert SeerRunMilestoneType.HAS_PULL_REQUEST not in self._recorded_milestones()
+
+        # A block carrying pr_commit_shas is the actual signal.
+        state.blocks.append(pr_iteration_memory_block(commit_sha="synced-sha"))
+        self._run_hook(state)
+        assert SeerRunMilestoneType.HAS_PULL_REQUEST in self._recorded_milestones()
+
+    @patch("sentry.seer.autofix.on_completion_hook.broadcast_webhooks_for_organization.delay")
+    def test_rerun_clears_downstream_milestones(self, mock_broadcast):
+        self._run_hook(
+            run_state(
+                blocks=[
+                    root_cause_memory_block(),
+                    solution_memory_block(),
+                    code_changes_memory_block(),
+                ]
+            )
+        )
+        # Re-running root cause truncates the run's blocks; the derived set
+        # shrinks and the downstream milestones are deleted.
+        self._run_hook(run_state(blocks=[root_cause_memory_block()]))
+        assert self._recorded_milestones() == {SeerRunMilestoneType.ROOT_CAUSE}
+
+    @patch("sentry.seer.autofix.on_completion_hook.broadcast_webhooks_for_organization.delay")
+    def test_rerun_does_not_clear_pull_requests_merged(self, mock_broadcast):
+        # pull_requests_merged is owned by the PR-merge webhook, not Seer state,
+        # so the state reconcile must leave it in place.
+        SeerRunMilestone.objects.create(
+            seer_run=self.seer_run, milestone=SeerRunMilestoneType.PULL_REQUESTS_MERGED
+        )
+        self._run_hook(run_state(blocks=[root_cause_memory_block()]))
+        assert self._recorded_milestones() == {
+            SeerRunMilestoneType.ROOT_CAUSE,
+            SeerRunMilestoneType.PULL_REQUESTS_MERGED,
+        }
+
+    @patch("sentry.seer.autofix.on_completion_hook.broadcast_webhooks_for_organization.delay")
+    def test_no_milestone_when_no_step_matches(self, mock_broadcast):
+        self._run_hook(run_state(blocks=[]))
+        assert self._recorded_milestones() == set()

--- a/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
+++ b/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
@@ -1184,9 +1184,9 @@ class TestAutofixOnCompletionHookMilestones(TestCase):
         )
 
     @patch("sentry.seer.autofix.on_completion_hook.broadcast_webhooks_for_organization.delay")
-    def test_records_reached_milestones_from_state(self, mock_broadcast):
-        # Milestones are the monotonic set the run has reached, derived from
-        # state. Firing twice is idempotent (no duplicate rows).
+    def test_reconciles_milestones_from_state(self, mock_broadcast):
+        # The hook wires state through to reconcile_milestones; firing twice on the
+        # same state is idempotent, matching webhook redelivery.
         state = run_state(
             blocks=[
                 root_cause_memory_block(),
@@ -1203,68 +1203,15 @@ class TestAutofixOnCompletionHookMilestones(TestCase):
         }
         assert SeerRunMilestone.objects.filter(seer_run=self.seer_run).count() == 3
 
-    @patch("sentry.seer.autofix.on_completion_hook.analytics.record")
     @patch("sentry.seer.autofix.on_completion_hook.broadcast_webhooks_for_organization.delay")
-    def test_has_pull_request_is_block_derived_not_repo_pr_states(
-        self, mock_broadcast, mock_analytics
-    ):
-        # repo_pr_states persists across a re-run, so it must NOT be the source:
-        # a run with repo_pr_states but no PR-commit block records no PR milestone.
-        state = run_state(
-            blocks=[
-                root_cause_memory_block(),
-                solution_memory_block(),
-                code_changes_memory_block(),
-            ]
+    def test_skips_reconcile_when_no_step_completed(self, mock_broadcast):
+        # A block with a reached artifact but no step metadata would derive
+        # ROOT_CAUSE, but the hook returns before reconcile when no step matches.
+        block = MemoryBlock(
+            id="b",
+            message=Message(role="assistant", content="c"),
+            timestamp="2026-02-10T00:00:00Z",
+            artifacts=[Artifact(key="root_cause", data={}, reason="explorer")],
         )
-        state.repo_pr_states = {
-            "test-repo": RepoPRState(
-                repo_name="test-repo",
-                pr_id=77,
-                pr_number=7,
-                pr_url="https://example.com/pull/7",
-                pr_creation_status="completed",
-                commit_sha="synced-sha",
-            )
-        }
-        self._run_hook(state)
-        assert SeerRunMilestoneType.HAS_PULL_REQUEST not in self._recorded_milestones()
-
-        # A block carrying pr_commit_shas is the actual signal.
-        state.blocks.append(pr_iteration_memory_block(commit_sha="synced-sha"))
-        self._run_hook(state)
-        assert SeerRunMilestoneType.HAS_PULL_REQUEST in self._recorded_milestones()
-
-    @patch("sentry.seer.autofix.on_completion_hook.broadcast_webhooks_for_organization.delay")
-    def test_rerun_clears_downstream_milestones(self, mock_broadcast):
-        self._run_hook(
-            run_state(
-                blocks=[
-                    root_cause_memory_block(),
-                    solution_memory_block(),
-                    code_changes_memory_block(),
-                ]
-            )
-        )
-        # Re-running root cause truncates the run's blocks; the derived set
-        # shrinks and the downstream milestones are deleted.
-        self._run_hook(run_state(blocks=[root_cause_memory_block()]))
-        assert self._recorded_milestones() == {SeerRunMilestoneType.ROOT_CAUSE}
-
-    @patch("sentry.seer.autofix.on_completion_hook.broadcast_webhooks_for_organization.delay")
-    def test_rerun_does_not_clear_pull_requests_merged(self, mock_broadcast):
-        # pull_requests_merged is owned by the PR-merge webhook, not Seer state,
-        # so the state reconcile must leave it in place.
-        SeerRunMilestone.objects.create(
-            seer_run=self.seer_run, milestone=SeerRunMilestoneType.PULL_REQUESTS_MERGED
-        )
-        self._run_hook(run_state(blocks=[root_cause_memory_block()]))
-        assert self._recorded_milestones() == {
-            SeerRunMilestoneType.ROOT_CAUSE,
-            SeerRunMilestoneType.PULL_REQUESTS_MERGED,
-        }
-
-    @patch("sentry.seer.autofix.on_completion_hook.broadcast_webhooks_for_organization.delay")
-    def test_no_milestone_when_no_step_matches(self, mock_broadcast):
-        self._run_hook(run_state(blocks=[]))
+        self._run_hook(run_state(blocks=[block]))
         assert self._recorded_milestones() == set()

--- a/tests/sentry/seer/autofix/test_coding_agent_handoffs.py
+++ b/tests/sentry/seer/autofix/test_coding_agent_handoffs.py
@@ -8,7 +8,13 @@ from sentry.seer.autofix.coding_agent_handoffs import (
 )
 from sentry.seer.autofix.constants import CodingAgentStatus
 from sentry.seer.autofix.utils import CodingAgentProviderType, CodingAgentResult, CodingAgentState
-from sentry.seer.models.run import SeerRunCodingAgentHandoff, SeerRunPullRequest, SeerRunType
+from sentry.seer.models.run import (
+    SeerRunCodingAgentHandoff,
+    SeerRunMilestone,
+    SeerRunMilestoneType,
+    SeerRunPullRequest,
+    SeerRunType,
+)
 from sentry.testutils.cases import TestCase
 
 REPO_NAME = "getsentry/sentry"
@@ -163,6 +169,31 @@ class SyncCodingAgentStatusTest(TestCase):
         link = SeerRunPullRequest.objects.get(pull_request=pull_request)
         assert link.seer_run_id == self.seer_run.id
         assert link.coding_agent_handoff_id == self.handoff.id
+
+        assert SeerRunMilestone.objects.filter(
+            seer_run=self.seer_run, milestone=SeerRunMilestoneType.HAS_PULL_REQUEST
+        ).exists()
+
+    @patch(MOCK_UPDATE_STATE_PATH)
+    def test_no_pull_request_milestone_for_branch_without_pr(self, mock_update_state: Mock) -> None:
+        mock_update_state.return_value = True
+        result = CodingAgentResult(
+            description="Pushed a branch",
+            repo_provider="github",
+            repo_full_name=REPO_NAME,
+            pr_url="https://github.com/getsentry/sentry/tree/some-branch",
+        )
+
+        sync_coding_agent_status(
+            agent_id="agent-1",
+            organization_id=self.organization.id,
+            status=CodingAgentStatus.COMPLETED,
+            result=result,
+        )
+
+        assert not SeerRunMilestone.objects.filter(
+            seer_run=self.seer_run, milestone=SeerRunMilestoneType.HAS_PULL_REQUEST
+        ).exists()
 
     @patch(MOCK_UPDATE_STATE_PATH)
     def test_links_multiple_pull_requests_on_same_handoff(self, mock_update_state: Mock) -> None:

--- a/tests/sentry/seer/test_milestones.py
+++ b/tests/sentry/seer/test_milestones.py
@@ -1,5 +1,6 @@
 from sentry.seer.agent.client_models import (
     AgentFilePatch,
+    Artifact,
     CodingAgentResult,
     CodingAgentState,
     FilePatch,
@@ -49,6 +50,55 @@ def _coding_agent(pr_number: int | None, pr_url: str | None) -> CodingAgentState
     )
 
 
+def _block(
+    *,
+    artifact_keys: tuple[str, ...] = (),
+    with_diff: bool = False,
+    pr_commit_shas: dict[str, str] | None = None,
+) -> MemoryBlock:
+    return MemoryBlock(
+        id="b",
+        message=Message(role="assistant", content="c"),
+        timestamp="2026-02-10T00:00:00Z",
+        artifacts=[Artifact(key=k, data={}, reason="r") for k in artifact_keys],
+        merged_file_patches=(
+            [
+                AgentFilePatch(
+                    repo_name="owner/repo",
+                    patch=FilePatch(path="a.py", type="M", added=1, removed=0),
+                )
+            ]
+            if with_diff
+            else None
+        ),
+        pr_commit_shas=pr_commit_shas,
+    )
+
+
+def _state_reaching(milestones: set[str]) -> SeerRunState:
+    keys = tuple(
+        k
+        for m, k in (
+            (SeerRunMilestoneType.ROOT_CAUSE, "root_cause"),
+            (SeerRunMilestoneType.SOLUTION, "solution"),
+        )
+        if m in milestones
+    )
+    return _state(
+        blocks=[
+            _block(
+                artifact_keys=keys,
+                with_diff=SeerRunMilestoneType.CODE_CHANGES in milestones,
+                pr_commit_shas=(
+                    {"owner/repo": "abc"}
+                    if SeerRunMilestoneType.HAS_PULL_REQUEST in milestones
+                    else None
+                ),
+            )
+        ]
+    )
+
+
 class MilestonesFromStateTest(TestCase):
     def test_native_pr_from_block_commit_shas(self) -> None:
         block = MemoryBlock(
@@ -89,23 +139,23 @@ class ReconcileMilestonesTest(TestCase):
             )
         )
 
-    def test_reconciles_managed_set_to_desired(self) -> None:
-        reconcile_milestones(self.seer_run, desired=SEER_STATE_MILESTONES)
+    def test_reconciles_managed_set_to_state(self) -> None:
+        reconcile_milestones(self.seer_run, _state_reaching(set(SEER_STATE_MILESTONES)))
         assert self._recorded() == set(SEER_STATE_MILESTONES)
-        # A re-run shrinks the derived set; no-longer-desired managed rows go.
-        reconcile_milestones(self.seer_run, desired={SeerRunMilestoneType.ROOT_CAUSE})
+        # A re-run shrinks the derived set; no-longer-reached managed rows go.
+        reconcile_milestones(self.seer_run, _state_reaching({SeerRunMilestoneType.ROOT_CAUSE}))
         assert self._recorded() == {SeerRunMilestoneType.ROOT_CAUSE}
-        # Empty desired clears the rest.
-        reconcile_milestones(self.seer_run, desired=set())
+        # A state that reached nothing clears the rest.
+        reconcile_milestones(self.seer_run, _state_reaching(set()))
         assert self._recorded() == set()
 
     def test_leaves_unmanaged_milestones_untouched(self) -> None:
         SeerRunMilestone.objects.create(
             seer_run=self.seer_run, milestone=SeerRunMilestoneType.PULL_REQUESTS_MERGED
         )
-        reconcile_milestones(self.seer_run, desired={SeerRunMilestoneType.ROOT_CAUSE})
+        reconcile_milestones(self.seer_run, _state_reaching({SeerRunMilestoneType.ROOT_CAUSE}))
         # pull_requests_merged is outside SEER_STATE_MILESTONES, so reconcile must
-        # not delete it even though it is absent from `desired`.
+        # not delete it even though the state did not reach it.
         assert self._recorded() == {
             SeerRunMilestoneType.ROOT_CAUSE,
             SeerRunMilestoneType.PULL_REQUESTS_MERGED,
@@ -134,7 +184,7 @@ class RecordHasPullRequestTest(TestCase):
         assert self._recorded() == {SeerRunMilestoneType.HAS_PULL_REQUEST}
 
     def test_preserves_other_milestones(self) -> None:
-        reconcile_milestones(self.seer_run, desired={SeerRunMilestoneType.ROOT_CAUSE})
+        reconcile_milestones(self.seer_run, _state_reaching({SeerRunMilestoneType.ROOT_CAUSE}))
         record_has_pull_request(self.seer_run)
         assert self._recorded() == {
             SeerRunMilestoneType.ROOT_CAUSE,

--- a/tests/sentry/seer/test_milestones.py
+++ b/tests/sentry/seer/test_milestones.py
@@ -1,0 +1,108 @@
+from sentry.seer.agent.client_models import (
+    AgentFilePatch,
+    CodingAgentResult,
+    CodingAgentState,
+    FilePatch,
+    MemoryBlock,
+    Message,
+    SeerRunState,
+)
+from sentry.seer.milestones import (
+    SEER_STATE_MILESTONES,
+    milestones_from_state,
+    reconcile_milestones,
+)
+from sentry.seer.models.run import SeerRunMilestone, SeerRunMilestoneType
+from sentry.testutils.cases import TestCase
+
+
+def _state(blocks=None, coding_agents=None) -> SeerRunState:
+    return SeerRunState(
+        run_id=1,
+        blocks=blocks or [],
+        status="completed",
+        updated_at="2026-02-10T00:00:00Z",
+        coding_agents=coding_agents or {},
+    )
+
+
+def _coding_agent(pr_number: int | None, pr_url: str | None) -> CodingAgentState:
+    return CodingAgentState(
+        id="agent-1",
+        status="completed",
+        provider="cursor_background_agent",
+        name="Cursor",
+        started_at="2026-02-10T00:00:00Z",
+        results=[
+            CodingAgentResult(
+                description="d",
+                repo_provider="github",
+                repo_full_name="owner/repo",
+                pr_number=pr_number,
+                pr_url=pr_url,
+            )
+        ],
+    )
+
+
+class MilestonesFromStateTest(TestCase):
+    def test_native_pr_from_block_commit_shas(self) -> None:
+        block = MemoryBlock(
+            id="b",
+            message=Message(role="assistant", content="c", metadata={"step": "code_changes"}),
+            timestamp="2026-02-10T00:00:00Z",
+            merged_file_patches=[
+                AgentFilePatch(
+                    repo_name="owner/repo",
+                    patch=FilePatch(path="a.py", type="M", added=1, removed=0),
+                )
+            ],
+            pr_commit_shas={"owner/repo": "abc"},
+        )
+        milestones = milestones_from_state(_state(blocks=[block]))
+        assert SeerRunMilestoneType.HAS_PULL_REQUEST in milestones
+
+    def test_coding_agent_pr_from_pr_number(self) -> None:
+        state = _state(coding_agents={"agent-1": _coding_agent(pr_number=7, pr_url="url")})
+        assert SeerRunMilestoneType.HAS_PULL_REQUEST in milestones_from_state(state)
+
+    def test_coding_agent_branch_without_pr_number_is_not_a_pr(self) -> None:
+        # pr_url can point at a pushed branch when the agent did not open a PR;
+        # only pr_number confirms an actual PR.
+        state = _state(coding_agents={"agent-1": _coding_agent(pr_number=None, pr_url="branch")})
+        assert SeerRunMilestoneType.HAS_PULL_REQUEST not in milestones_from_state(state)
+
+
+class ReconcileMilestonesTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.seer_run = self.create_seer_run(organization=self.organization)
+
+    def _recorded(self) -> set[str]:
+        return set(
+            SeerRunMilestone.objects.filter(seer_run=self.seer_run).values_list(
+                "milestone", flat=True
+            )
+        )
+
+    def test_reconciles_managed_set_to_desired(self) -> None:
+        reconcile_milestones(self.seer_run, desired=SEER_STATE_MILESTONES)
+        assert self._recorded() == set(SEER_STATE_MILESTONES)
+        # A re-run shrinks the derived set; no-longer-desired managed rows go.
+        reconcile_milestones(self.seer_run, desired={SeerRunMilestoneType.ROOT_CAUSE})
+        assert self._recorded() == {SeerRunMilestoneType.ROOT_CAUSE}
+        # Empty desired clears the rest.
+        reconcile_milestones(self.seer_run, desired=set())
+        assert self._recorded() == set()
+
+    def test_leaves_unmanaged_milestones_untouched(self) -> None:
+        SeerRunMilestone.objects.create(
+            seer_run=self.seer_run, milestone=SeerRunMilestoneType.PULL_REQUESTS_MERGED
+        )
+        reconcile_milestones(self.seer_run, desired={SeerRunMilestoneType.ROOT_CAUSE})
+        # pull_requests_merged is outside SEER_STATE_MILESTONES, so reconcile must
+        # not delete it even though it is absent from `desired`.
+        assert self._recorded() == {
+            SeerRunMilestoneType.ROOT_CAUSE,
+            SeerRunMilestoneType.PULL_REQUESTS_MERGED,
+        }

--- a/tests/sentry/seer/test_milestones.py
+++ b/tests/sentry/seer/test_milestones.py
@@ -6,6 +6,7 @@ from sentry.seer.agent.client_models import (
     FilePatch,
     MemoryBlock,
     Message,
+    RepoPRState,
     SeerRunState,
 )
 from sentry.seer.milestones import (
@@ -21,6 +22,7 @@ from sentry.testutils.cases import TestCase
 def _state(
     blocks: list[MemoryBlock] | None = None,
     coding_agents: dict[str, CodingAgentState] | None = None,
+    repo_pr_states: dict[str, RepoPRState] | None = None,
 ) -> SeerRunState:
     return SeerRunState(
         run_id=1,
@@ -28,6 +30,7 @@ def _state(
         status="completed",
         updated_at="2026-02-10T00:00:00Z",
         coding_agents=coding_agents or {},
+        repo_pr_states=repo_pr_states or {},
     )
 
 
@@ -126,6 +129,12 @@ class MilestonesFromStateTest(TestCase):
         state = _state(coding_agents={"agent-1": _coding_agent(pr_number=None, pr_url="branch")})
         assert SeerRunMilestoneType.HAS_PULL_REQUEST not in milestones_from_state(state)
 
+    def test_repo_pr_states_is_not_a_pr_source(self) -> None:
+        # repo_pr_states persists across a re-run, so it must not drive the milestone;
+        # only a pr_commit_shas block or a coding-agent pr_number does.
+        state = _state(repo_pr_states={"owner/repo": RepoPRState(repo_name="owner/repo")})
+        assert SeerRunMilestoneType.HAS_PULL_REQUEST not in milestones_from_state(state)
+
 
 class ReconcileMilestonesTest(TestCase):
     def setUp(self) -> None:
@@ -174,19 +183,12 @@ class RecordHasPullRequestTest(TestCase):
             )
         )
 
-    def test_records_has_pull_request(self) -> None:
-        record_has_pull_request(self.seer_run)
-        assert self._recorded() == {SeerRunMilestoneType.HAS_PULL_REQUEST}
-
-    def test_is_idempotent(self) -> None:
-        record_has_pull_request(self.seer_run)
-        record_has_pull_request(self.seer_run)
-        assert self._recorded() == {SeerRunMilestoneType.HAS_PULL_REQUEST}
-
-    def test_preserves_other_milestones(self) -> None:
+    def test_records_pr_idempotently_beside_other_milestones(self) -> None:
         reconcile_milestones(self.seer_run, _state_reaching({SeerRunMilestoneType.ROOT_CAUSE}))
+        record_has_pull_request(self.seer_run)
         record_has_pull_request(self.seer_run)
         assert self._recorded() == {
             SeerRunMilestoneType.ROOT_CAUSE,
             SeerRunMilestoneType.HAS_PULL_REQUEST,
         }
+        assert SeerRunMilestone.objects.filter(seer_run=self.seer_run).count() == 2

--- a/tests/sentry/seer/test_milestones.py
+++ b/tests/sentry/seer/test_milestones.py
@@ -11,12 +11,16 @@ from sentry.seer.milestones import (
     SEER_STATE_MILESTONES,
     milestones_from_state,
     reconcile_milestones,
+    record_has_pull_request,
 )
 from sentry.seer.models.run import SeerRunMilestone, SeerRunMilestoneType
 from sentry.testutils.cases import TestCase
 
 
-def _state(blocks=None, coding_agents=None) -> SeerRunState:
+def _state(
+    blocks: list[MemoryBlock] | None = None,
+    coding_agents: dict[str, CodingAgentState] | None = None,
+) -> SeerRunState:
     return SeerRunState(
         run_id=1,
         blocks=blocks or [],
@@ -105,4 +109,34 @@ class ReconcileMilestonesTest(TestCase):
         assert self._recorded() == {
             SeerRunMilestoneType.ROOT_CAUSE,
             SeerRunMilestoneType.PULL_REQUESTS_MERGED,
+        }
+
+
+class RecordHasPullRequestTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.seer_run = self.create_seer_run(organization=self.organization)
+
+    def _recorded(self) -> set[str]:
+        return set(
+            SeerRunMilestone.objects.filter(seer_run=self.seer_run).values_list(
+                "milestone", flat=True
+            )
+        )
+
+    def test_records_has_pull_request(self) -> None:
+        record_has_pull_request(self.seer_run)
+        assert self._recorded() == {SeerRunMilestoneType.HAS_PULL_REQUEST}
+
+    def test_is_idempotent(self) -> None:
+        record_has_pull_request(self.seer_run)
+        record_has_pull_request(self.seer_run)
+        assert self._recorded() == {SeerRunMilestoneType.HAS_PULL_REQUEST}
+
+    def test_preserves_other_milestones(self) -> None:
+        reconcile_milestones(self.seer_run, desired={SeerRunMilestoneType.ROOT_CAUSE})
+        record_has_pull_request(self.seer_run)
+        assert self._recorded() == {
+            SeerRunMilestoneType.ROOT_CAUSE,
+            SeerRunMilestoneType.HAS_PULL_REQUEST,
         }


### PR DESCRIPTION
This PR records Autofix milestones from Seer run state instead of webhook action types. The completion hook reconciles root cause, solution, code changes, and native PR milestones against the current state, so rerunning a step removes milestones invalidated when its blocks are truncated. Coding-agent PRs are recorded separately when status sync receives a real `pr_number` (`pr_url` may only identify a pushed branch).

The reconciliation only owns the Seer-derived milestones: `autofix_root_cause`, `autofix_solution`, `autofix_code_changes`, and `has_pull_request`. `pull_requests_merged` remains owned by the PR-merge webhook and will land separately; read-side changes and backfill are also out of scope.
