### PR TITLE
impr(jira): Add audit log and transaction for jira project mappings updates

### DIFF
--- a/src/sentry/audit_log/register.py
+++ b/src/sentry/audit_log/register.py
@@ -245,7 +245,7 @@ default_manager.add(
         # mapping cleared by mistake can be rebuilt from this entry.
         template=(
             "updated project status mappings for the {provider} integration "
-            "({added_count} added, {removed_count} removed)"
+            "({added_count} added, {updated_count} updated, {removed_count} removed)"
         ),
     )
 )

--- a/src/sentry/audit_log/register.py
+++ b/src/sentry/audit_log/register.py
@@ -238,6 +238,19 @@ default_manager.add(events.IntegrationEditAuditLogEvent())
 default_manager.add(events.IntegrationRemoveAuditLogEvent())
 default_manager.add(
     AuditLogEvent(
+        event_id=114,
+        name="INTEGRATION_PROJECT_MAPPINGS_UPDATE",
+        api_name="integration.project-mappings-update",
+        # `removed_project_mappings` carries the prior values of anything removed, so a
+        # mapping cleared by mistake can be rebuilt from this entry.
+        template=(
+            "updated project status mappings for the {provider} integration "
+            "({added_count} added, {removed_count} removed)"
+        ),
+    )
+)
+default_manager.add(
+    AuditLogEvent(
         event_id=113,
         name="SENTRY_APP_ADD",
         api_name="sentry-app.add",

--- a/src/sentry/integrations/api/endpoints/organization_integration_details.py
+++ b/src/sentry/integrations/api/endpoints/organization_integration_details.py
@@ -152,7 +152,7 @@ class OrganizationIntegrationDetailsEndpoint(OrganizationIntegrationBaseEndpoint
         integration = self.get_integration(organization.id, integration_id)
         installation = integration.get_installation(organization_id=organization.id)
         try:
-            installation.update_organization_config(request.data)
+            extra_audit_data = installation.update_organization_config(request.data) or {}
         except (IntegrationError, ApiError) as e:
             sentry_sdk.capture_exception(e)
             return self.respond({"detail": str(e)}, status=400)
@@ -164,5 +164,17 @@ class OrganizationIntegrationDetailsEndpoint(OrganizationIntegrationBaseEndpoint
             event=audit_log.get_event_id("INTEGRATION_EDIT"),
             data={"provider": integration.provider, "name": "config"},
         )
+
+        # `INTEGRATION_EDIT` only records that "config" changed. Project status mappings own
+        # rows of their own, so record what was added and removed under a dedicated event.
+        project_mapping_changes = extra_audit_data.get("sync_status_forward")
+        if project_mapping_changes:
+            self.create_audit_entry(
+                request=request,
+                organization=organization,
+                target_object=integration.id,
+                event=audit_log.get_event_id("INTEGRATION_PROJECT_MAPPINGS_UPDATE"),
+                data={"provider": integration.provider, **project_mapping_changes},
+            )
 
         return self.respond(status=200)

--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -422,14 +422,19 @@ class IntegrationInstallation(abc.ABC):
         """
         return []
 
-    def update_organization_config(self, data: MutableMapping[str, Any]) -> None:
+    def update_organization_config(
+        self, data: MutableMapping[str, Any]
+    ) -> Mapping[str, Any] | None:
         """
         Update the configuration field for an organization integration.
+
+        May return per-config-field detail for the caller to record on an audit log entry,
+        keyed by the config field it describes. `None` means there is nothing extra to record.
         """
         from sentry.integrations.services.integration import integration_service
 
         if not self.org_integration:
-            return
+            return None
 
         config = self.org_integration.config
         config.update(data)
@@ -439,6 +444,8 @@ class IntegrationInstallation(abc.ABC):
         )
         if org_integration is not None:
             self.org_integration = org_integration
+
+        return None
 
     def get_config_data(self) -> Mapping[str, Any]:
         if not self.org_integration:

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -518,20 +518,25 @@ class JiraIntegration(IssueSyncIntegration):
                     id__in=[existing[external_id].id for external_id in removals]
                 ).delete()
 
-            for external_id in additions:
-                IntegrationExternalProject.objects.create(
+            IntegrationExternalProject.objects.bulk_create(
+                IntegrationExternalProject(
                     organization_integration_id=self.org_integration.id,
                     external_id=external_id,
                     resolved_status=desired[external_id]["on_resolve"],
                     unresolved_status=desired[external_id]["on_unresolve"],
                 )
+                for external_id in additions
+            )
 
             for external_id in updates:
-                existing[external_id].update(
-                    resolved_status=desired[external_id]["on_resolve"],
-                    unresolved_status=desired[external_id]["on_unresolve"],
-                    date_updated=timezone.now(),
-                )
+                iep = existing[external_id]
+                iep.resolved_status = desired[external_id]["on_resolve"]
+                iep.unresolved_status = desired[external_id]["on_unresolve"]
+                iep.date_updated = timezone.now()
+            IntegrationExternalProject.objects.bulk_update(
+                [existing[external_id] for external_id in updates],
+                ["resolved_status", "unresolved_status", "date_updated"],
+            )
 
         return audit_data
 

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -11,9 +11,11 @@ import orjson
 import sentry_sdk
 from django.conf import settings
 from django.core.signing import BadSignature, SignatureExpired
+from django.db import router, transaction
 from django.db.models import QuerySet
 from django.http.request import HttpRequest
 from django.urls import reverse
+from django.utils import timezone
 from django.utils.functional import classproperty
 from django.utils.translation import gettext as _
 from rest_framework import serializers
@@ -385,29 +387,15 @@ class JiraIntegration(IssueSyncIntegration):
         Update the configuration field for an organization integration.
         """
         config = self.org_integration.config
+        audit_data: dict[str, Any] = {}
 
-        if "sync_status_forward" in data:
-            project_mappings = data.pop("sync_status_forward")
-
-            if any(
-                not mapping["on_unresolve"] or not mapping["on_resolve"]
-                for mapping in project_mappings.values()
-            ):
-                raise IntegrationError("Resolve and unresolve status are required.")
-
-            data["sync_status_forward"] = bool(project_mappings)
-
-            IntegrationExternalProject.objects.filter(
-                organization_integration_id=self.org_integration.id
-            ).delete()
-
-            for project_id, statuses in project_mappings.items():
-                IntegrationExternalProject.objects.create(
-                    organization_integration_id=self.org_integration.id,
-                    external_id=project_id,
-                    resolved_status=statuses["on_resolve"],
-                    unresolved_status=statuses["on_unresolve"],
-                )
+        if self.outbound_status_key in data:
+            project_mappings = data.pop(self.outbound_status_key)
+            mapping_changes = self._reconcile_project_status_mappings(project_mappings)
+            if mapping_changes["added_count"] or mapping_changes["removed_count"]:
+                # Keyed by the config field it describes so the caller knows what it is looking at.
+                audit_data[self.outbound_status_key] = mapping_changes
+            data[self.outbound_status_key] = bool(project_mappings)
 
         if self.issues_ignored_fields_key in data:
             ignored_fields_text = data.pop(self.issues_ignored_fields_key)
@@ -430,6 +418,8 @@ class JiraIntegration(IssueSyncIntegration):
         if org_integration is not None:
             self.org_integration = org_integration
 
+        return audit_data or None
+
     def _filter_active_projects(self, project_mappings: QuerySet[IntegrationExternalProject]):
         client = self.get_client()
         if features.has("organizations:jira-paginated-project-config", self.organization):
@@ -445,8 +435,104 @@ class JiraIntegration(IssueSyncIntegration):
         project_ids_set = {p["id"] for p in client.get_projects_list()}
         return [pm for pm in project_mappings if pm.external_id in project_ids_set]
 
+    @staticmethod
+    def _validate_project_status_mappings(
+        project_mappings: Mapping[str, Any],
+    ) -> dict[str, tuple[str, str]]:
+        """
+        Normalize the `sync_status_forward` payload into `{external_id: (resolved, unresolved)}`.
+
+        External IDs are coerced to strings because the model stores them as a `CharField` but
+        clients may send them as numbers, which would make an existing mapping look both new
+        and removed.
+        """
+        validated: dict[str, tuple[str, str]] = {}
+        for external_id, statuses in project_mappings.items():
+            resolved_status = statuses.get("on_resolve")
+            unresolved_status = statuses.get("on_unresolve")
+            if not resolved_status or not unresolved_status:
+                raise IntegrationError("Resolve and unresolve status are required.")
+
+            validated[str(external_id)] = (str(resolved_status), str(unresolved_status))
+
+        return validated
+
+    def _reconcile_project_status_mappings(
+        self, project_mappings: Mapping[str, Any]
+    ) -> dict[str, Any]:
+        """
+        Bring the stored `IntegrationExternalProject` rows in line with `project_mappings`.
+
+        The payload is the caller's complete desired state, so mappings missing from it are
+        removed. That makes a truncated payload destructive, so rather than deleting every row
+        and recreating it, this reconciles a diff inside a transaction: an unrelated mapping is
+        only ever touched when the caller explicitly dropped it, and a failure part-way through
+        rolls the whole save back.
+
+        Returns the diff for the caller to record on an audit log entry.
+        """
+        desired = self._validate_project_status_mappings(project_mappings)
+
+        existing = {
+            iep.external_id: iep
+            for iep in IntegrationExternalProject.objects.filter(
+                organization_integration_id=self.org_integration.id
+            )
+        }
+        removals = [iep for external_id, iep in existing.items() if external_id not in desired]
+        additions = [external_id for external_id in desired if external_id not in existing]
+
+        with transaction.atomic(router.db_for_write(IntegrationExternalProject)):
+            if removals:
+                IntegrationExternalProject.objects.filter(
+                    id__in=[iep.id for iep in removals]
+                ).delete()
+
+            for external_id, (resolved_status, unresolved_status) in desired.items():
+                current = existing.get(external_id)
+                if current is None:
+                    IntegrationExternalProject.objects.create(
+                        organization_integration_id=self.org_integration.id,
+                        external_id=external_id,
+                        resolved_status=resolved_status,
+                        unresolved_status=unresolved_status,
+                    )
+                elif (
+                    current.resolved_status != resolved_status
+                    or current.unresolved_status != unresolved_status
+                ):
+                    current.update(
+                        resolved_status=resolved_status,
+                        unresolved_status=unresolved_status,
+                        date_updated=timezone.now(),
+                    )
+
+        return {
+            "added_count": len(additions),
+            "removed_count": len(removals),
+            "added_project_mappings": [
+                {
+                    "external_id": external_id,
+                    "on_resolve": desired[external_id][0],
+                    "on_unresolve": desired[external_id][1],
+                }
+                for external_id in additions
+            ],
+            # Prior values, so a mapping removed by mistake can be rebuilt from the audit log.
+            "removed_project_mappings": [
+                {
+                    "external_id": iep.external_id,
+                    "on_resolve": iep.resolved_status,
+                    "on_unresolve": iep.unresolved_status,
+                }
+                for iep in removals
+            ],
+        }
+
     def get_config_data(self):
-        config = self.org_integration.config
+        # Copied because the mapping dict assembled below is only for the response; the stored
+        # value of this key is a bool.
+        config = dict(self.org_integration.config)
         project_mappings = IntegrationExternalProject.objects.filter(
             organization_integration_id=self.org_integration.id
         )
@@ -459,7 +545,7 @@ class JiraIntegration(IssueSyncIntegration):
                 "on_unresolve": pm.unresolved_status,
                 "on_resolve": pm.resolved_status,
             }
-        config["sync_status_forward"] = sync_status_forward
+        config[self.outbound_status_key] = sync_status_forward
         config[self.issues_ignored_fields_key] = ", ".join(
             config.get(self.issues_ignored_fields_key, "")
         )

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -392,7 +392,7 @@ class JiraIntegration(IssueSyncIntegration):
         if self.outbound_status_key in data:
             project_mappings = data.pop(self.outbound_status_key)
             mapping_changes = self._reconcile_project_status_mappings(project_mappings)
-            if mapping_changes["added_count"] or mapping_changes["removed_count"]:
+            if mapping_changes is not None:
                 # Keyed by the config field it describes so the caller knows what it is looking at.
                 audit_data[self.outbound_status_key] = mapping_changes
             data[self.outbound_status_key] = bool(project_mappings)
@@ -455,7 +455,7 @@ class JiraIntegration(IssueSyncIntegration):
 
     def _reconcile_project_status_mappings(
         self, project_mappings: Mapping[str, Any]
-    ) -> dict[str, Any]:
+    ) -> dict[str, Any] | None:
         """
         Get the desired mappings(project mappings in the right format[i.e has on_resolve and on_unresolve]) and the existing mappings(IEPs).
 
@@ -470,6 +470,16 @@ class JiraIntegration(IssueSyncIntegration):
         }
         removals = [iep for external_id, iep in existing.items() if external_id not in desired]
         additions = [external_id for external_id in desired if external_id not in existing]
+        # external_id -> prior statuses, captured before the rows below are mutated.
+        updates = {
+            external_id: (iep.resolved_status, iep.unresolved_status)
+            for external_id, iep in existing.items()
+            if external_id in desired
+            and (iep.resolved_status, iep.unresolved_status) != desired[external_id]
+        }
+
+        if not (removals or additions or updates):
+            return None
 
         with transaction.atomic(router.db_for_write(IntegrationExternalProject)):
             if removals:
@@ -477,27 +487,28 @@ class JiraIntegration(IssueSyncIntegration):
                     id__in=[iep.id for iep in removals]
                 ).delete()
 
-            for external_id, (resolved_status, unresolved_status) in desired.items():
-                current = existing.get(external_id)
-                if current is None:
-                    IntegrationExternalProject.objects.create(
-                        organization_integration_id=self.org_integration.id,
-                        external_id=external_id,
-                        resolved_status=resolved_status,
-                        unresolved_status=unresolved_status,
-                    )
-                elif (
-                    current.resolved_status != resolved_status
-                    or current.unresolved_status != unresolved_status
-                ):
-                    current.update(
-                        resolved_status=resolved_status,
-                        unresolved_status=unresolved_status,
-                        date_updated=timezone.now(),
-                    )
+            for external_id in additions:
+                resolved_status, unresolved_status = desired[external_id]
+                IntegrationExternalProject.objects.create(
+                    organization_integration_id=self.org_integration.id,
+                    external_id=external_id,
+                    resolved_status=resolved_status,
+                    unresolved_status=unresolved_status,
+                )
 
+            for external_id in updates:
+                resolved_status, unresolved_status = desired[external_id]
+                existing[external_id].update(
+                    resolved_status=resolved_status,
+                    unresolved_status=unresolved_status,
+                    date_updated=timezone.now(),
+                )
+
+        # Prior statuses are recorded alongside the new ones so a mapping removed or
+        # overwritten by mistake can be rebuilt from the audit log.
         return {
             "added_count": len(additions),
+            "updated_count": len(updates),
             "removed_count": len(removals),
             "added_project_mappings": [
                 {
@@ -507,7 +518,19 @@ class JiraIntegration(IssueSyncIntegration):
                 }
                 for external_id in additions
             ],
-            # Prior values, so a mapping removed by mistake can be rebuilt from the audit log.
+            "updated_project_mappings": [
+                {
+                    "external_id": external_id,
+                    "on_resolve": desired[external_id][0],
+                    "on_unresolve": desired[external_id][1],
+                    "previous_on_resolve": previous_resolved,
+                    "previous_on_unresolve": previous_unresolved,
+                }
+                for external_id, (
+                    previous_resolved,
+                    previous_unresolved,
+                ) in updates.items()
+            ],
             "removed_project_mappings": [
                 {
                     "external_id": iep.external_id,

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -153,6 +153,11 @@ HIDDEN_ISSUE_FIELDS = ["issuelinks"]
 MAX_PER_PROJECT_QUERIES = 10
 
 
+def _stored_statuses(iep: IntegrationExternalProject) -> dict[str, str]:
+    """A stored mapping's statuses, in the same shape as the `sync_status_forward` payload."""
+    return {"on_resolve": iep.resolved_status, "on_unresolve": iep.unresolved_status}
+
+
 class JiraProjectMapping(TypedDict):
     value: str
     label: str
@@ -438,18 +443,21 @@ class JiraIntegration(IssueSyncIntegration):
     @staticmethod
     def _validate_project_status_mappings(
         project_mappings: Mapping[str, Any],
-    ) -> dict[str, tuple[str, str]]:
+    ) -> dict[str, dict[str, str]]:
         """
         Normalize the `sync_status_forward` payload into `{external_id:string : {on_resolve: string, on_unresolve: string}}`.
         """
-        validated: dict[str, tuple[str, str]] = {}
+        validated: dict[str, dict[str, str]] = {}
         for external_id, statuses in project_mappings.items():
             resolved_status = statuses.get("on_resolve")
             unresolved_status = statuses.get("on_unresolve")
             if not resolved_status or not unresolved_status:
                 raise IntegrationError("Resolve and unresolve status are required.")
 
-            validated[str(external_id)] = (str(resolved_status), str(unresolved_status))
+            validated[str(external_id)] = {
+                "on_resolve": str(resolved_status),
+                "on_unresolve": str(unresolved_status),
+            }
 
         return validated
 
@@ -468,78 +476,64 @@ class JiraIntegration(IssueSyncIntegration):
                 organization_integration_id=self.org_integration.id
             )
         }
-        removals = [iep for external_id, iep in existing.items() if external_id not in desired]
+        removals = [external_id for external_id in existing if external_id not in desired]
         additions = [external_id for external_id in desired if external_id not in existing]
-        # external_id -> prior statuses, captured before the rows below are mutated.
-        updates = {
-            external_id: (iep.resolved_status, iep.unresolved_status)
-            for external_id, iep in existing.items()
-            if external_id in desired
-            and (iep.resolved_status, iep.unresolved_status) != desired[external_id]
-        }
+        updates = [
+            external_id
+            for external_id in desired
+            if external_id in existing
+            and _stored_statuses(existing[external_id]) != desired[external_id]
+        ]
 
         if not (removals or additions or updates):
             return None
 
-        with transaction.atomic(router.db_for_write(IntegrationExternalProject)):
-            if removals:
-                IntegrationExternalProject.objects.filter(
-                    id__in=[iep.id for iep in removals]
-                ).delete()
-
-            for external_id in additions:
-                resolved_status, unresolved_status = desired[external_id]
-                IntegrationExternalProject.objects.create(
-                    organization_integration_id=self.org_integration.id,
-                    external_id=external_id,
-                    resolved_status=resolved_status,
-                    unresolved_status=unresolved_status,
-                )
-
-            for external_id in updates:
-                resolved_status, unresolved_status = desired[external_id]
-                existing[external_id].update(
-                    resolved_status=resolved_status,
-                    unresolved_status=unresolved_status,
-                    date_updated=timezone.now(),
-                )
-
-        # Prior statuses are recorded alongside the new ones so a mapping removed or
-        # overwritten by mistake can be rebuilt from the audit log.
-        return {
+        # Built before the writes below, while the existing rows still hold their prior
+        # statuses, so a mapping removed or overwritten by mistake can be rebuilt from this.
+        audit_data = {
             "added_count": len(additions),
             "updated_count": len(updates),
             "removed_count": len(removals),
             "added_project_mappings": [
-                {
-                    "external_id": external_id,
-                    "on_resolve": desired[external_id][0],
-                    "on_unresolve": desired[external_id][1],
-                }
-                for external_id in additions
+                {"external_id": external_id, **desired[external_id]} for external_id in additions
             ],
             "updated_project_mappings": [
                 {
                     "external_id": external_id,
-                    "on_resolve": desired[external_id][0],
-                    "on_unresolve": desired[external_id][1],
-                    "previous_on_resolve": previous_resolved,
-                    "previous_on_unresolve": previous_unresolved,
+                    **desired[external_id],
+                    "previous_on_resolve": existing[external_id].resolved_status,
+                    "previous_on_unresolve": existing[external_id].unresolved_status,
                 }
-                for external_id, (
-                    previous_resolved,
-                    previous_unresolved,
-                ) in updates.items()
+                for external_id in updates
             ],
             "removed_project_mappings": [
-                {
-                    "external_id": iep.external_id,
-                    "on_resolve": iep.resolved_status,
-                    "on_unresolve": iep.unresolved_status,
-                }
-                for iep in removals
+                {"external_id": external_id, **_stored_statuses(existing[external_id])}
+                for external_id in removals
             ],
         }
+
+        with transaction.atomic(router.db_for_write(IntegrationExternalProject)):
+            if removals:
+                IntegrationExternalProject.objects.filter(
+                    id__in=[existing[external_id].id for external_id in removals]
+                ).delete()
+
+            for external_id in additions:
+                IntegrationExternalProject.objects.create(
+                    organization_integration_id=self.org_integration.id,
+                    external_id=external_id,
+                    resolved_status=desired[external_id]["on_resolve"],
+                    unresolved_status=desired[external_id]["on_unresolve"],
+                )
+
+            for external_id in updates:
+                existing[external_id].update(
+                    resolved_status=desired[external_id]["on_resolve"],
+                    unresolved_status=desired[external_id]["on_unresolve"],
+                    date_updated=timezone.now(),
+                )
+
+        return audit_data
 
     def get_config_data(self):
         # Copied because the mapping dict assembled below is only for the response; the stored

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -440,11 +440,7 @@ class JiraIntegration(IssueSyncIntegration):
         project_mappings: Mapping[str, Any],
     ) -> dict[str, tuple[str, str]]:
         """
-        Normalize the `sync_status_forward` payload into `{external_id: (resolved, unresolved)}`.
-
-        External IDs are coerced to strings because the model stores them as a `CharField` but
-        clients may send them as numbers, which would make an existing mapping look both new
-        and removed.
+        Normalize the `sync_status_forward` payload into `{external_id:string : {on_resolve: string, on_unresolve: string}}`.
         """
         validated: dict[str, tuple[str, str]] = {}
         for external_id, statuses in project_mappings.items():
@@ -461,15 +457,8 @@ class JiraIntegration(IssueSyncIntegration):
         self, project_mappings: Mapping[str, Any]
     ) -> dict[str, Any]:
         """
-        Bring the stored `IntegrationExternalProject` rows in line with `project_mappings`.
+        Get the desired mappings(project mappings in the right format[i.e has on_resolve and on_unresolve]) and the existing mappings(IEPs).
 
-        The payload is the caller's complete desired state, so mappings missing from it are
-        removed. That makes a truncated payload destructive, so rather than deleting every row
-        and recreating it, this reconciles a diff inside a transaction: an unrelated mapping is
-        only ever touched when the caller explicitly dropped it, and a failure part-way through
-        rolls the whole save back.
-
-        Returns the diff for the caller to record on an audit log entry.
         """
         desired = self._validate_project_status_mappings(project_mappings)
 

--- a/src/sentry/integrations/opsgenie/integration.py
+++ b/src/sentry/integrations/opsgenie/integration.py
@@ -114,12 +114,14 @@ class OpsgenieIntegration(IntegrationInstallation):
 
         return fields
 
-    def update_organization_config(self, data: MutableMapping[str, Any]) -> None:
+    def update_organization_config(
+        self, data: MutableMapping[str, Any]
+    ) -> Mapping[str, Any] | None:
         from sentry.integrations.services.integration import integration_service
 
         # add the integration ID to a newly added row
         if not self.org_integration:
-            return
+            return None
 
         teams = data["team_table"]
         unsaved_teams = [team for team in teams if team["id"] == ""]

--- a/tests/sentry/integrations/api/endpoints/test_organization_integration_details.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_integration_details.py
@@ -78,6 +78,49 @@ class OrganizationIntegrationDetailsPostTest(OrganizationIntegrationDetailsTest)
             data={"provider": self.integration.provider, "name": "config"},
         ).exists()
 
+    def test_update_config_records_project_mapping_changes(self) -> None:
+        jira = self.create_provider_integration(provider="jira", name="Example Jira")
+        jira.add_organization(self.organization, self.user)
+        for external_id in ("1", "2"):
+            self.create_integration_external_project(
+                organization_id=self.organization.id,
+                integration_id=jira.id,
+                external_id=external_id,
+                resolved_status="done",
+                unresolved_status="in_progress",
+            )
+
+        self.get_success_response(self.organization.slug, jira.id, **{"sync_status_forward": {}})
+
+        entry = AuditLogEntry.objects.get(
+            organization_id=self.organization.id,
+            event=audit_log.get_event_id("INTEGRATION_PROJECT_MAPPINGS_UPDATE"),
+            target_object=jira.id,
+        )
+        assert entry.actor_id == self.user.id
+        assert entry.data["provider"] == "jira"
+        assert entry.data["added_project_mappings"] == []
+        assert sorted(entry.data["removed_project_mappings"], key=lambda m: m["external_id"]) == [
+            {"external_id": "1", "on_resolve": "done", "on_unresolve": "in_progress"},
+            {"external_id": "2", "on_resolve": "done", "on_unresolve": "in_progress"},
+        ]
+        assert audit_log.get(entry.event).render(entry) == (
+            "updated project status mappings for the jira integration (0 added, 2 removed)"
+        )
+
+    def test_update_config_skips_project_mapping_entry_when_unchanged(self) -> None:
+        """Providers that report no mapping changes get only the `INTEGRATION_EDIT` entry."""
+        config = {"setting": "new_value"}
+        with patch(
+            "sentry.integrations.gitlab.integration.repository_service.schedule_update_gitlab_project_webhooks"
+        ):
+            self.get_success_response(self.organization.slug, self.integration.id, **config)
+
+        assert not AuditLogEntry.objects.filter(
+            organization_id=self.organization.id,
+            event=audit_log.get_event_id("INTEGRATION_PROJECT_MAPPINGS_UPDATE"),
+        ).exists()
+
     def test_update_config_error(self) -> None:
         config = {"setting": "new_value", "setting2": "baz"}
 

--- a/tests/sentry/integrations/api/endpoints/test_organization_integration_details.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_integration_details.py
@@ -105,7 +105,8 @@ class OrganizationIntegrationDetailsPostTest(OrganizationIntegrationDetailsTest)
             {"external_id": "2", "on_resolve": "done", "on_unresolve": "in_progress"},
         ]
         assert audit_log.get(entry.event).render(entry) == (
-            "updated project status mappings for the jira integration (0 added, 2 removed)"
+            "updated project status mappings for the jira integration "
+            "(0 added, 0 updated, 2 removed)"
         )
 
     def test_update_config_skips_project_mapping_entry_when_unchanged(self) -> None:

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -1431,6 +1431,7 @@ class JiraIntegrationTest(APITestCase):
 
         installation = integration.get_installation(self.organization.id)
 
+        payload: dict[str, Any]
         for payload in (
             {"2": {}},
             {"2": {"on_resolve": "done"}},

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -1210,12 +1210,6 @@ class JiraIntegrationTest(APITestCase):
         )
         integration.add_organization(self.organization, self.user)
 
-        responses.add(
-            responses.GET,
-            "https://example.atlassian.net/rest/api/2/project",
-            json=[{"id": "12345", "name": "Example Project"}],
-        )
-
         org_integration = OrganizationIntegration.objects.get(
             organization_id=self.organization.id, integration_id=integration.id
         )
@@ -1229,19 +1223,26 @@ class JiraIntegrationTest(APITestCase):
         }
         org_integration.save()
 
+        responses.add(
+            responses.GET,
+            "https://example.atlassian.net/rest/api/2/project",
+            json=[{"id": "12345", "name": "Example Project"}],
+        )
+
         # Create a valid project mapping
-        IntegrationExternalProject.objects.create(
-            organization_integration_id=org_integration.id,
+        self.create_integration_external_project(
+            organization_id=self.organization.id,
+            integration_id=integration.id,
             external_id="12345",
             unresolved_status="in_progress",
             resolved_status="done",
         )
 
-        # Create a project mapping that is missing from the projects list response.
-        # We expect this to be "healed" by the config query, and removed as the
-        # project is no longer visible in our integration.
-        IntegrationExternalProject.objects.create(
-            organization_integration_id=org_integration.id,
+        # Create a project mapping that is missing from the projects list response. It is
+        # hidden from the config response, but the row itself is left alone.
+        self.create_integration_external_project(
+            organization_id=self.organization.id,
+            integration_id=integration.id,
             external_id="67890",
             unresolved_status="in_progress",
             resolved_status="done",
@@ -1257,6 +1258,10 @@ class JiraIntegrationTest(APITestCase):
             "sync_status_forward": {"12345": {"on_resolve": "done", "on_unresolve": "in_progress"}},
             "issues_ignored_fields": "",
         }
+
+        # Building the response must not rewrite the stored config, which keeps a bool here.
+        assert installation.org_integration is not None
+        assert installation.org_integration.config["sync_status_forward"] is True
 
     @responses.activate
     def test_get_config_data_filters_via_paginated_endpoint_with_flag(self) -> None:
@@ -1285,18 +1290,14 @@ class JiraIntegrationTest(APITestCase):
         }
         org_integration.save()
 
-        IntegrationExternalProject.objects.create(
-            organization_integration_id=org_integration.id,
-            external_id="12345",
-            unresolved_status="in_progress",
-            resolved_status="done",
-        )
-        IntegrationExternalProject.objects.create(
-            organization_integration_id=org_integration.id,
-            external_id="67890",
-            unresolved_status="in_progress",
-            resolved_status="done",
-        )
+        for external_id in ("12345", "67890"):
+            self.create_integration_external_project(
+                organization_id=self.organization.id,
+                integration_id=integration.id,
+                external_id=external_id,
+                unresolved_status="in_progress",
+                resolved_status="done",
+            )
 
         responses.add(
             responses.GET,
@@ -1316,6 +1317,174 @@ class JiraIntegrationTest(APITestCase):
         assert "rest/api/2/project/search" in responses.calls[0].request.url
         assert "id=12345" in responses.calls[0].request.url
         assert "id=67890" in responses.calls[0].request.url
+
+    def test_update_organization_config_only_touches_changed_mappings(self) -> None:
+        """
+        The payload is still the complete desired state, so omitted mappings are removed --
+        but untouched rows are left in place rather than deleted and recreated.
+        """
+        integration = self.create_provider_integration(provider="jira", name="Example Jira")
+        integration.add_organization(self.organization, self.user)
+
+        org_integration = OrganizationIntegration.objects.get(
+            organization_id=self.organization.id, integration_id=integration.id
+        )
+        for external_id in ("1", "2", "3"):
+            self.create_integration_external_project(
+                organization_id=self.organization.id,
+                integration_id=integration.id,
+                external_id=external_id,
+                resolved_status="done",
+                unresolved_status="in_progress",
+            )
+
+        unchanged_row_id = IntegrationExternalProject.objects.get(
+            organization_integration_id=org_integration.id, external_id="1"
+        ).id
+
+        installation = integration.get_installation(self.organization.id)
+        audit_data = installation.update_organization_config(
+            {
+                "sync_status_forward": {
+                    # unchanged
+                    "1": {"on_resolve": "done", "on_unresolve": "in_progress"},
+                    # status changed
+                    "2": {"on_resolve": "closed", "on_unresolve": "open"},
+                    # "3" omitted -> removed
+                    # new
+                    "4": {"on_resolve": "shipped", "on_unresolve": "todo"},
+                }
+            }
+        )
+
+        mappings = {
+            iep.external_id: (iep.resolved_status, iep.unresolved_status)
+            for iep in IntegrationExternalProject.objects.filter(
+                organization_integration_id=org_integration.id
+            )
+        }
+        assert mappings == {
+            "1": ("done", "in_progress"),
+            "2": ("closed", "open"),
+            "4": ("shipped", "todo"),
+        }
+
+        # An untouched mapping keeps its row instead of being deleted and recreated.
+        assert (
+            IntegrationExternalProject.objects.get(
+                organization_integration_id=org_integration.id, external_id="1"
+            ).id
+            == unchanged_row_id
+        )
+
+        assert audit_data == {
+            "sync_status_forward": {
+                "added_count": 1,
+                "removed_count": 1,
+                "added_project_mappings": [
+                    {"external_id": "4", "on_resolve": "shipped", "on_unresolve": "todo"}
+                ],
+                "removed_project_mappings": [
+                    {"external_id": "3", "on_resolve": "done", "on_unresolve": "in_progress"}
+                ],
+            }
+        }
+
+    def test_update_organization_config_returns_no_audit_data_when_unchanged(self) -> None:
+        integration = self.create_provider_integration(provider="jira", name="Example Jira")
+        integration.add_organization(self.organization, self.user)
+        self.create_integration_external_project(
+            organization_id=self.organization.id,
+            integration_id=integration.id,
+            external_id="1",
+            resolved_status="done",
+            unresolved_status="in_progress",
+        )
+
+        installation = integration.get_installation(self.organization.id)
+        assert (
+            installation.update_organization_config(
+                {
+                    "sync_status_forward": {
+                        "1": {"on_resolve": "done", "on_unresolve": "in_progress"}
+                    }
+                }
+            )
+            is None
+        )
+
+    def test_update_organization_config_rejects_incomplete_mappings(self) -> None:
+        """An incomplete mapping is rejected before any row is touched."""
+        integration = self.create_provider_integration(provider="jira", name="Example Jira")
+        integration.add_organization(self.organization, self.user)
+
+        org_integration = OrganizationIntegration.objects.get(
+            organization_id=self.organization.id, integration_id=integration.id
+        )
+        self.create_integration_external_project(
+            organization_id=self.organization.id,
+            integration_id=integration.id,
+            external_id="1",
+            resolved_status="done",
+            unresolved_status="in_progress",
+        )
+
+        installation = integration.get_installation(self.organization.id)
+
+        for payload in (
+            {"2": {}},
+            {"2": {"on_resolve": "done"}},
+            {"2": {"on_resolve": "done", "on_unresolve": ""}},
+        ):
+            with pytest.raises(IntegrationError):
+                installation.update_organization_config({"sync_status_forward": payload})
+
+        assert (
+            IntegrationExternalProject.objects.filter(
+                organization_integration_id=org_integration.id
+            ).count()
+            == 1
+        )
+
+    def test_update_organization_config_mapping_write_is_atomic(self) -> None:
+        """A failure part-way through must not leave the mappings half-written."""
+        integration = self.create_provider_integration(provider="jira", name="Example Jira")
+        integration.add_organization(self.organization, self.user)
+
+        org_integration = OrganizationIntegration.objects.get(
+            organization_id=self.organization.id, integration_id=integration.id
+        )
+        self.create_integration_external_project(
+            organization_id=self.organization.id,
+            integration_id=integration.id,
+            external_id="1",
+            resolved_status="done",
+            unresolved_status="in_progress",
+        )
+
+        installation = integration.get_installation(self.organization.id)
+
+        with patch.object(
+            IntegrationExternalProject.objects,
+            "create",
+            side_effect=OSError("boom"),
+        ):
+            with pytest.raises(OSError):
+                installation.update_organization_config(
+                    {
+                        "sync_status_forward": {
+                            "2": {"on_resolve": "closed", "on_unresolve": "open"},
+                        }
+                    }
+                )
+
+        mappings = {
+            iep.external_id: (iep.resolved_status, iep.unresolved_status)
+            for iep in IntegrationExternalProject.objects.filter(
+                organization_integration_id=org_integration.id
+            )
+        }
+        assert mappings == {"1": ("done", "in_progress")}
 
     @responses.activate
     def test_get_config_data_issue_keys(self) -> None:

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -1380,13 +1380,64 @@ class JiraIntegrationTest(APITestCase):
         assert audit_data == {
             "sync_status_forward": {
                 "added_count": 1,
+                "updated_count": 1,
                 "removed_count": 1,
                 "added_project_mappings": [
                     {"external_id": "4", "on_resolve": "shipped", "on_unresolve": "todo"}
                 ],
+                "updated_project_mappings": [
+                    {
+                        "external_id": "2",
+                        "on_resolve": "closed",
+                        "on_unresolve": "open",
+                        "previous_on_resolve": "done",
+                        "previous_on_unresolve": "in_progress",
+                    }
+                ],
                 "removed_project_mappings": [
                     {"external_id": "3", "on_resolve": "done", "on_unresolve": "in_progress"}
                 ],
+            }
+        }
+
+    def test_update_organization_config_audits_a_status_only_change(self) -> None:
+        """
+        Overwriting an existing mapping's statuses is audited too.
+
+        Nothing is added or removed in this case, but the prior statuses are gone from the
+        database -- so they have to be recorded or the change is unrecoverable.
+        """
+        integration = self.create_provider_integration(provider="jira", name="Example Jira")
+        integration.add_organization(self.organization, self.user)
+        self.create_integration_external_project(
+            organization_id=self.organization.id,
+            integration_id=integration.id,
+            external_id="1",
+            resolved_status="done",
+            unresolved_status="in_progress",
+        )
+
+        installation = integration.get_installation(self.organization.id)
+        audit_data = installation.update_organization_config(
+            {"sync_status_forward": {"1": {"on_resolve": "closed", "on_unresolve": "open"}}}
+        )
+
+        assert audit_data == {
+            "sync_status_forward": {
+                "added_count": 0,
+                "updated_count": 1,
+                "removed_count": 0,
+                "added_project_mappings": [],
+                "updated_project_mappings": [
+                    {
+                        "external_id": "1",
+                        "on_resolve": "closed",
+                        "on_unresolve": "open",
+                        "previous_on_resolve": "done",
+                        "previous_on_unresolve": "in_progress",
+                    }
+                ],
+                "removed_project_mappings": [],
             }
         }
 

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -1518,7 +1518,7 @@ class JiraIntegrationTest(APITestCase):
 
         with patch.object(
             IntegrationExternalProject.objects,
-            "create",
+            "bulk_create",
             side_effect=OSError("boom"),
         ):
             with pytest.raises(OSError):


### PR DESCRIPTION
This PR
- Adds audit log for when jira outbound status sync project mappings are updated
- Adds a transaction for the project mapping option and makes the IEP (IntegrationExternalProject) creation bulk
