### PR TITLE
fix(replays): Strip dashes from replay_id in bulk delete blob keys

### DIFF
--- a/src/sentry/replays/usecases/delete.py
+++ b/src/sentry/replays/usecases/delete.py
@@ -94,7 +94,10 @@ def _make_recording_filenames(project_id: int, rows: list[MatchedRow]) -> Iterat
         # We assume every segment between 0 and the max_segment_id exists. Its a waste of time to
         # delete a non-existent segment but its not so significant that we'd want to query ClickHouse
         # to verify it exists.
-        replay_id = row["replay_id"]
+
+        # Snuba returns `replay_id` in dashed UUID form because the column is a ClickHouse UUID, but
+        # blob storage keys use the dash-stripped 32-hex form.
+        replay_id = row["replay_id"].replace("-", "")
         retention_days = row["retention_days"]
 
         for segment_id in range(row["max_segment_id"] + 1):

--- a/tests/sentry/replays/tasks/test_delete_replays_bulk.py
+++ b/tests/sentry/replays/tasks/test_delete_replays_bulk.py
@@ -8,11 +8,13 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 from taskbroker_client.worker.workerchild import ProcessingDeadlineExceeded
 
+from sentry.replays.lib.storage import RecordingSegmentStorageMeta, StorageBlob
 from sentry.replays.models import DeletionJobStatus, ReplayDeletionJobModel
 from sentry.replays.tasks import run_bulk_replay_delete_job
 from sentry.replays.testutils import mock_replay
 from sentry.replays.usecases.delete import (
     MatchedRows,
+    delete_matched_rows,
     fetch_rows_matching_pattern,
 )
 from sentry.testutils.cases import APITestCase, ReplaysSnubaTestCase
@@ -394,6 +396,54 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
         )
         assert len(result["rows"]) == 1
         assert result["rows"][0]["replay_id"] == str(uuid.UUID(replay_id))
+
+    def test_delete_matched_rows_deletes_blob(self) -> None:
+        """End-to-end: a real blob stored under the stripped key is deleted.
+
+        Snuba returns `replay_id` in dashed UUID form, but blob storage keys use the
+        dash-stripped 32-hex form. This exercises `delete_matched_rows` without mocking
+        it, so a dashed-vs-stripped key mismatch would leave the blob in place and fail.
+        """
+        replay_id = uuid.uuid4().hex
+        retention_days = 30
+        max_segment_id = 1
+
+        blob = StorageBlob()
+        for segment_id in range(max_segment_id + 1):
+            blob.set(
+                RecordingSegmentStorageMeta(
+                    project_id=self.project.id,
+                    replay_id=replay_id,
+                    segment_id=segment_id,
+                    retention_days=retention_days,
+                ),
+                b"[]",
+            )
+
+        # `delete_matched_rows` receives the dashed form, matching what Snuba returns.
+        delete_matched_rows(
+            self.project.id,
+            [
+                {
+                    "retention_days": retention_days,
+                    "replay_id": str(uuid.UUID(replay_id)),
+                    "max_segment_id": max_segment_id,
+                }
+            ],
+        )
+
+        for segment_id in range(max_segment_id + 1):
+            assert (
+                blob.get(
+                    RecordingSegmentStorageMeta(
+                        project_id=self.project.id,
+                        replay_id=replay_id,
+                        segment_id=segment_id,
+                        retention_days=retention_days,
+                    )
+                )
+                is None
+            )
 
     @patch("sentry.replays.usecases.delete.make_replay_delete_request")
     @patch("sentry.replays.tasks.fetch_rows_matching_pattern")


### PR DESCRIPTION
Problem: `run_bulk_replay_delete_job` archived replays but did not delete their rrweb recording blobs in production. It built blob keys from the dashed UUID form of `replay_id` that Snuba returns (for example `000019d5-0b7b-451b-8230-1119772f71f3`), but blobs are stored under the dash-stripped 32-hex form (`000019d50b7b451b82301119772f71f3`). The keys did not match, so the blob delete was a silent no-op. The replay disappeared from the UI (archived), but the PII stayed in GCS.

Root cause: `replay_id` in the Snuba `replays` entity is a ClickHouse `UUID` column, so Snuba returns it dashed. The filename builder (`make_recording_filename`) interpolates the id verbatim and does no normalization, so the caller must strip the dashes. The bulk path did not: `_make_recording_filenames` passed the dashed `row["replay_id"]` straight through. The script path (`scripts/delete_replays.py`) already strips correctly, which is why this was only wrong on the bulk path.

Fix: strip the dashes in `_make_recording_filenames` so the key matches the real blob. The Seer call in `tasks.py` keeps the dashed `replay_id`, which is the canonical UUID Seer keys on. Two downstreams, two forms: blobs want stripped, Seer wants dashed.

## Why the tests did not catch it

Every delete assertion in `test_delete_replays_bulk.py` used toy ids like `"a"` and `"b"`, and `delete_matched_rows` was fully mocked. The 32-hex-vs-dashed key mismatch was never exercised end to end.

This PR adds `test_delete_matched_rows_deletes_blob`, which stores real segment blobs through the normal `StorageBlob` interface (stripped key), calls `delete_matched_rows` with the dashed `replay_id` (the form Snuba returns), and asserts the blobs are gone.

## Validation

- ✅ New test and the existing finder test pass.
- ✅ Confirmed the test catches the bug: with the fix reverted, it fails with `assert b'[]' is None` (blob not deleted). With the fix, it passes.
- ✅ Full test file passes serially (20 tests). One test failed only under parallel workers; it passes in isolation and is a pre-existing Snuba parallel-state flake, unrelated to this change.
- ✅ `prek` clean on both files.

## Scope note

The script path (`scripts/delete_replays.py`) is unchanged. Its dash handling is already correct on both downstreams. Only the bulk path needed the fix.