### PR TITLE
o11y(seer): fix query validation logs to be warning level

### DIFF
--- a/src/sentry/seer/agent/tools.py
+++ b/src/sentry/seer/agent/tools.py
@@ -238,21 +238,21 @@ def _validate_events_query_params(
             params=params,
         )
         if isinstance(resp.data, dict) and resp.data.get("valid") is False:
-            error = _format_events_query_validation_errors(resp.data)
+            error_detail = _format_events_query_validation_errors(resp.data)
             logger.warning(
                 "execute_table_query: validation failed",
-                extra={"org_id": organization.id, "error_detail": error},
+                extra={"org_id": organization.id, "error_detail": error_detail},
             )
-            return ExecuteQueryErrorResponse(error=error)
+            return ExecuteQueryErrorResponse(error=error_detail)
         return None
     except client.ApiError as e:
         if e.status_code == 400 and isinstance(e.body, dict) and "valid" in e.body:
-            error = _format_events_query_validation_errors(e.body)
+            error_detail = _format_events_query_validation_errors(e.body)
             logger.warning(
                 "execute_table_query: validation failed",
-                extra={"org_id": organization.id, "error_detail": error},
+                extra={"org_id": organization.id, "error_detail": error_detail},
             )
-            return ExecuteQueryErrorResponse(error=error)
+            return ExecuteQueryErrorResponse(error=error_detail)
         logger.exception(
             "execute_table_query: validate request failed",
             extra={"org_id": organization.id},
@@ -377,13 +377,13 @@ def execute_table_query(
     except client.ApiError as e:
         # For 400 errors, return an error string for the query builder agent.
         if e.status_code == 400:
-            error_detail = e.body.get("detail") if isinstance(e.body, dict) else None
-            error = str(error_detail) if error_detail is not None else str(e.body)
+            detail = e.body.get("detail") if isinstance(e.body, dict) else None
+            error_detail = str(detail) if detail is not None else str(e.body)
             logger.warning(
                 "execute_table_query: validation failed",
-                extra={"org_id": org_id, "error_detail": error},
+                extra={"org_id": org_id, "error_detail": error_detail},
             )
-            return ExecuteQueryErrorResponse(error=error)
+            return ExecuteQueryErrorResponse(error=error_detail)
         raise
 
 
@@ -472,13 +472,13 @@ def execute_timeseries_query(
         # Use a reserved "_seer_error_detail" key so it can't collide with a
         # group_by value (which becomes a top-level key in grouped responses below).
         if e.status_code == 400:
-            error_detail = e.body.get("detail") if isinstance(e.body, dict) else None
-            error = str(error_detail) if error_detail is not None else str(e.body)
+            detail = e.body.get("detail") if isinstance(e.body, dict) else None
+            error_detail = str(detail) if detail is not None else str(e.body)
             logger.warning(
                 "execute_timeseries_query: validation failed",
-                extra={"org_id": org_id, "error_detail": error},
+                extra={"org_id": org_id, "error_detail": error_detail},
             )
-            return ExecuteTimeseriesQueryErrorResponse(seer_error_detail=error)
+            return ExecuteTimeseriesQueryErrorResponse(seer_error_detail=error_detail)
         raise
     data = resp.data
 
@@ -575,13 +575,13 @@ def execute_trace_table_query(
     except client.ApiError as e:
         # For 400 errors, return an error string for the query builder agent.
         if e.status_code == 400:
-            error_detail = e.body.get("detail") if isinstance(e.body, dict) else None
-            error = str(error_detail) if error_detail is not None else str(e.body)
+            detail = e.body.get("detail") if isinstance(e.body, dict) else None
+            error_detail = str(detail) if detail is not None else str(e.body)
             logger.warning(
                 "execute_trace_table_query: validation failed",
-                extra={"org_id": organization_id, "error_detail": error},
+                extra={"org_id": organization_id, "error_detail": error_detail},
             )
-            return ExecuteQueryErrorResponse(error=error)
+            return ExecuteQueryErrorResponse(error=error_detail)
         raise
 
 
@@ -633,20 +633,20 @@ def execute_replays_query(
         return None
 
     if not features.has("organizations:session-replay", organization):
-        error = "Session Replay is not enabled for this organization."
+        error_detail = "Session Replay is not enabled for this organization."
         logger.warning(
             "execute_replays_query: validation failed",
-            extra={"org_id": organization_id, "error_detail": error},
+            extra={"org_id": organization_id, "error_detail": error_detail},
         )
-        return ExecuteQueryErrorResponse(error=error)
+        return ExecuteQueryErrorResponse(error=error_detail)
 
     if project_ids and project_slugs:
-        error = "Pass either project_ids or project_slugs, not both."
+        error_detail = "Pass either project_ids or project_slugs, not both."
         logger.warning(
             "execute_replays_query: validation failed",
-            extra={"org_id": organization_id, "error_detail": error},
+            extra={"org_id": organization_id, "error_detail": error_detail},
         )
-        return ExecuteQueryErrorResponse(error=error)
+        return ExecuteQueryErrorResponse(error=error_detail)
 
     project_filter: dict[str, Any] = {}
     if project_ids:
@@ -667,12 +667,12 @@ def execute_replays_query(
     requested_fields = fields or DEFAULT_REPLAY_SEARCH_FIELDS
     invalid_fields = sorted(set(requested_fields) - set(REPLAY_VALID_FIELD_SET))
     if invalid_fields:
-        error = f"Invalid replay field(s): {', '.join(invalid_fields)}"
+        error_detail = f"Invalid replay field(s): {', '.join(invalid_fields)}"
         logger.warning(
             "execute_replays_query: validation failed",
-            extra={"org_id": organization_id, "error_detail": error},
+            extra={"org_id": organization_id, "error_detail": error_detail},
         )
-        return ExecuteQueryErrorResponse(error=error)
+        return ExecuteQueryErrorResponse(error=error_detail)
 
     date_params: dict[str, Any] = {}
     if start and end:
@@ -701,24 +701,24 @@ def execute_replays_query(
         )
         processed_response = process_raw_response(response.response, fields=requested_fields)
     except KeyError as e:
-        error = f"Invalid replay field: {e.args[0]}" if e.args else "Invalid replay field"
+        error_detail = f"Invalid replay field: {e.args[0]}" if e.args else "Invalid replay field"
         logger.warning(
             "execute_replays_query: validation failed",
             extra={
                 "org_id": organization_id,
                 "query": query,
                 "field": e.args[0] if e.args else None,
-                "error_detail": error,
+                "error_detail": error_detail,
             },
         )
-        return ExecuteQueryErrorResponse(error=error)
+        return ExecuteQueryErrorResponse(error=error_detail)
     except (InvalidParams, InvalidSearchQuery, SentryBadRequest, BadRequest, ParseError) as e:
-        error = str(e)
+        error_detail = str(e)
         logger.warning(
             "execute_replays_query: validation failed",
-            extra={"org_id": organization_id, "query": query, "error_detail": error},
+            extra={"org_id": organization_id, "query": query, "error_detail": error_detail},
         )
-        return ExecuteQueryErrorResponse(error=error)
+        return ExecuteQueryErrorResponse(error=error_detail)
 
     return ExecuteQuerySuccessResponse(
         data=processed_response,

--- a/src/sentry/seer/agent/tools.py
+++ b/src/sentry/seer/agent/tools.py
@@ -238,13 +238,21 @@ def _validate_events_query_params(
             params=params,
         )
         if isinstance(resp.data, dict) and resp.data.get("valid") is False:
-            return ExecuteQueryErrorResponse(
-                error=_format_events_query_validation_errors(resp.data)
+            error = _format_events_query_validation_errors(resp.data)
+            logger.warning(
+                "execute_table_query: validation failed",
+                extra={"org_id": organization.id, "error": error},
             )
+            return ExecuteQueryErrorResponse(error=error)
         return None
     except client.ApiError as e:
         if e.status_code == 400 and isinstance(e.body, dict) and "valid" in e.body:
-            return ExecuteQueryErrorResponse(error=_format_events_query_validation_errors(e.body))
+            error = _format_events_query_validation_errors(e.body)
+            logger.warning(
+                "execute_table_query: validation failed",
+                extra={"org_id": organization.id, "error": error},
+            )
+            return ExecuteQueryErrorResponse(error=error)
         logger.exception(
             "execute_table_query: validate request failed",
             extra={"org_id": organization.id},
@@ -369,11 +377,13 @@ def execute_table_query(
     except client.ApiError as e:
         # For 400 errors, return an error string for the query builder agent.
         if e.status_code == 400:
-            logger.exception("execute_table_query: bad request", extra={"org_id": org_id})
             error_detail = e.body.get("detail") if isinstance(e.body, dict) else None
-            return ExecuteQueryErrorResponse(
-                error=str(error_detail) if error_detail is not None else str(e.body)
+            error = str(error_detail) if error_detail is not None else str(e.body)
+            logger.warning(
+                "execute_table_query: validation failed",
+                extra={"org_id": org_id, "error": error},
             )
+            return ExecuteQueryErrorResponse(error=error)
         raise
 
 
@@ -462,11 +472,13 @@ def execute_timeseries_query(
         # Use a reserved "_seer_error_detail" key so it can't collide with a
         # group_by value (which becomes a top-level key in grouped responses below).
         if e.status_code == 400:
-            logger.exception("execute_timeseries_query: bad request", extra={"org_id": org_id})
             error_detail = e.body.get("detail") if isinstance(e.body, dict) else None
-            return ExecuteTimeseriesQueryErrorResponse(
-                seer_error_detail=(str(error_detail) if error_detail is not None else str(e.body))
+            error = str(error_detail) if error_detail is not None else str(e.body)
+            logger.warning(
+                "execute_timeseries_query: validation failed",
+                extra={"org_id": org_id, "error": error},
             )
+            return ExecuteTimeseriesQueryErrorResponse(seer_error_detail=error)
         raise
     data = resp.data
 
@@ -563,13 +575,13 @@ def execute_trace_table_query(
     except client.ApiError as e:
         # For 400 errors, return an error string for the query builder agent.
         if e.status_code == 400:
-            logger.exception(
-                "execute_trace_table_query: bad request", extra={"org_id": organization_id}
-            )
             error_detail = e.body.get("detail") if isinstance(e.body, dict) else None
-            return ExecuteQueryErrorResponse(
-                error=str(error_detail) if error_detail is not None else str(e.body)
+            error = str(error_detail) if error_detail is not None else str(e.body)
+            logger.warning(
+                "execute_trace_table_query: validation failed",
+                extra={"org_id": organization_id, "error": error},
             )
+            return ExecuteQueryErrorResponse(error=error)
         raise
 
 
@@ -621,14 +633,20 @@ def execute_replays_query(
         return None
 
     if not features.has("organizations:session-replay", organization):
-        return ExecuteQueryErrorResponse(
-            error="Session Replay is not enabled for this organization."
+        error = "Session Replay is not enabled for this organization."
+        logger.warning(
+            "execute_replays_query: validation failed",
+            extra={"org_id": organization_id, "error": error},
         )
+        return ExecuteQueryErrorResponse(error=error)
 
     if project_ids and project_slugs:
-        return ExecuteQueryErrorResponse(
-            error="Pass either project_ids or project_slugs, not both."
+        error = "Pass either project_ids or project_slugs, not both."
+        logger.warning(
+            "execute_replays_query: validation failed",
+            extra={"org_id": organization_id, "error": error},
         )
+        return ExecuteQueryErrorResponse(error=error)
 
     project_filter: dict[str, Any] = {}
     if project_ids:
@@ -649,9 +667,12 @@ def execute_replays_query(
     requested_fields = fields or DEFAULT_REPLAY_SEARCH_FIELDS
     invalid_fields = sorted(set(requested_fields) - set(REPLAY_VALID_FIELD_SET))
     if invalid_fields:
-        return ExecuteQueryErrorResponse(
-            error=f"Invalid replay field(s): {', '.join(invalid_fields)}"
+        error = f"Invalid replay field(s): {', '.join(invalid_fields)}"
+        logger.warning(
+            "execute_replays_query: validation failed",
+            extra={"org_id": organization_id, "error": error},
         )
+        return ExecuteQueryErrorResponse(error=error)
 
     date_params: dict[str, Any] = {}
     if start and end:
@@ -680,23 +701,24 @@ def execute_replays_query(
         )
         processed_response = process_raw_response(response.response, fields=requested_fields)
     except KeyError as e:
-        logger.exception(
-            "execute_replays_query: unsupported response field",
+        error = f"Invalid replay field: {e.args[0]}" if e.args else "Invalid replay field"
+        logger.warning(
+            "execute_replays_query: validation failed",
             extra={
                 "org_id": organization_id,
                 "query": query,
                 "field": e.args[0] if e.args else None,
+                "error": error,
             },
         )
-        return ExecuteQueryErrorResponse(
-            error=f"Invalid replay field: {e.args[0]}" if e.args else "Invalid replay field"
-        )
+        return ExecuteQueryErrorResponse(error=error)
     except (InvalidParams, InvalidSearchQuery, SentryBadRequest, BadRequest, ParseError) as e:
-        logger.exception(
-            "execute_replays_query: bad request",
-            extra={"org_id": organization_id, "query": query},
+        error = str(e)
+        logger.warning(
+            "execute_replays_query: validation failed",
+            extra={"org_id": organization_id, "query": query, "error": error},
         )
-        return ExecuteQueryErrorResponse(error=str(e))
+        return ExecuteQueryErrorResponse(error=error)
 
     return ExecuteQuerySuccessResponse(
         data=processed_response,

--- a/src/sentry/seer/agent/tools.py
+++ b/src/sentry/seer/agent/tools.py
@@ -692,6 +692,14 @@ def execute_replays_query(
         )
         processed_response = process_raw_response(response.response, fields=requested_fields)
     except KeyError as e:
+        logger.exception(
+            "execute_replays_query: unsupported response field",
+            extra={
+                "org_id": organization_id,
+                "query": query,
+                "field": e.args[0] if e.args else None,
+            },
+        )
         return ExecuteQueryErrorResponse(
             error=f"Invalid replay field: {e.args[0]}" if e.args else "Invalid replay field"
         )

--- a/src/sentry/seer/agent/tools.py
+++ b/src/sentry/seer/agent/tools.py
@@ -241,7 +241,7 @@ def _validate_events_query_params(
             error = _format_events_query_validation_errors(resp.data)
             logger.warning(
                 "execute_table_query: validation failed",
-                extra={"org_id": organization.id, "error": error},
+                extra={"org_id": organization.id, "error_detail": error},
             )
             return ExecuteQueryErrorResponse(error=error)
         return None
@@ -250,7 +250,7 @@ def _validate_events_query_params(
             error = _format_events_query_validation_errors(e.body)
             logger.warning(
                 "execute_table_query: validation failed",
-                extra={"org_id": organization.id, "error": error},
+                extra={"org_id": organization.id, "error_detail": error},
             )
             return ExecuteQueryErrorResponse(error=error)
         logger.exception(
@@ -381,7 +381,7 @@ def execute_table_query(
             error = str(error_detail) if error_detail is not None else str(e.body)
             logger.warning(
                 "execute_table_query: validation failed",
-                extra={"org_id": org_id, "error": error},
+                extra={"org_id": org_id, "error_detail": error},
             )
             return ExecuteQueryErrorResponse(error=error)
         raise
@@ -476,7 +476,7 @@ def execute_timeseries_query(
             error = str(error_detail) if error_detail is not None else str(e.body)
             logger.warning(
                 "execute_timeseries_query: validation failed",
-                extra={"org_id": org_id, "error": error},
+                extra={"org_id": org_id, "error_detail": error},
             )
             return ExecuteTimeseriesQueryErrorResponse(seer_error_detail=error)
         raise
@@ -579,7 +579,7 @@ def execute_trace_table_query(
             error = str(error_detail) if error_detail is not None else str(e.body)
             logger.warning(
                 "execute_trace_table_query: validation failed",
-                extra={"org_id": organization_id, "error": error},
+                extra={"org_id": organization_id, "error_detail": error},
             )
             return ExecuteQueryErrorResponse(error=error)
         raise
@@ -636,7 +636,7 @@ def execute_replays_query(
         error = "Session Replay is not enabled for this organization."
         logger.warning(
             "execute_replays_query: validation failed",
-            extra={"org_id": organization_id, "error": error},
+            extra={"org_id": organization_id, "error_detail": error},
         )
         return ExecuteQueryErrorResponse(error=error)
 
@@ -644,7 +644,7 @@ def execute_replays_query(
         error = "Pass either project_ids or project_slugs, not both."
         logger.warning(
             "execute_replays_query: validation failed",
-            extra={"org_id": organization_id, "error": error},
+            extra={"org_id": organization_id, "error_detail": error},
         )
         return ExecuteQueryErrorResponse(error=error)
 
@@ -670,7 +670,7 @@ def execute_replays_query(
         error = f"Invalid replay field(s): {', '.join(invalid_fields)}"
         logger.warning(
             "execute_replays_query: validation failed",
-            extra={"org_id": organization_id, "error": error},
+            extra={"org_id": organization_id, "error_detail": error},
         )
         return ExecuteQueryErrorResponse(error=error)
 
@@ -708,7 +708,7 @@ def execute_replays_query(
                 "org_id": organization_id,
                 "query": query,
                 "field": e.args[0] if e.args else None,
-                "error": error,
+                "error_detail": error,
             },
         )
         return ExecuteQueryErrorResponse(error=error)
@@ -716,7 +716,7 @@ def execute_replays_query(
         error = str(e)
         logger.warning(
             "execute_replays_query: validation failed",
-            extra={"org_id": organization_id, "query": query, "error": error},
+            extra={"org_id": organization_id, "query": query, "error_detail": error},
         )
         return ExecuteQueryErrorResponse(error=error)
 

--- a/src/sentry/seer/agent/tools.py
+++ b/src/sentry/seer/agent/tools.py
@@ -240,7 +240,7 @@ def _validate_events_query_params(
         if isinstance(resp.data, dict) and resp.data.get("valid") is False:
             error_detail = _format_events_query_validation_errors(resp.data)
             logger.warning(
-                "execute_table_query: validation failed",
+                "execute_table_query: bad request",
                 extra={"org_id": organization.id, "error_detail": error_detail},
             )
             return ExecuteQueryErrorResponse(error=error_detail)
@@ -249,7 +249,7 @@ def _validate_events_query_params(
         if e.status_code == 400 and isinstance(e.body, dict) and "valid" in e.body:
             error_detail = _format_events_query_validation_errors(e.body)
             logger.warning(
-                "execute_table_query: validation failed",
+                "execute_table_query: bad request",
                 extra={"org_id": organization.id, "error_detail": error_detail},
             )
             return ExecuteQueryErrorResponse(error=error_detail)
@@ -380,7 +380,7 @@ def execute_table_query(
             detail = e.body.get("detail") if isinstance(e.body, dict) else None
             error_detail = str(detail) if detail is not None else str(e.body)
             logger.warning(
-                "execute_table_query: validation failed",
+                "execute_table_query: bad request",
                 extra={"org_id": org_id, "error_detail": error_detail},
             )
             return ExecuteQueryErrorResponse(error=error_detail)
@@ -475,7 +475,7 @@ def execute_timeseries_query(
             detail = e.body.get("detail") if isinstance(e.body, dict) else None
             error_detail = str(detail) if detail is not None else str(e.body)
             logger.warning(
-                "execute_timeseries_query: validation failed",
+                "execute_timeseries_query: bad request",
                 extra={"org_id": org_id, "error_detail": error_detail},
             )
             return ExecuteTimeseriesQueryErrorResponse(seer_error_detail=error_detail)
@@ -578,7 +578,7 @@ def execute_trace_table_query(
             detail = e.body.get("detail") if isinstance(e.body, dict) else None
             error_detail = str(detail) if detail is not None else str(e.body)
             logger.warning(
-                "execute_trace_table_query: validation failed",
+                "execute_trace_table_query: bad request",
                 extra={"org_id": organization_id, "error_detail": error_detail},
             )
             return ExecuteQueryErrorResponse(error=error_detail)
@@ -698,7 +698,7 @@ def execute_replays_query(
     except (InvalidParams, InvalidSearchQuery, SentryBadRequest, BadRequest, ParseError) as e:
         error_detail = str(e)
         logger.warning(
-            "execute_replays_query: validation failed",
+            "execute_replays_query: bad request",
             extra={"org_id": organization_id, "query": query, "error_detail": error_detail},
         )
         return ExecuteQueryErrorResponse(error=error_detail)

--- a/src/sentry/seer/agent/tools.py
+++ b/src/sentry/seer/agent/tools.py
@@ -633,20 +633,14 @@ def execute_replays_query(
         return None
 
     if not features.has("organizations:session-replay", organization):
-        error_detail = "Session Replay is not enabled for this organization."
-        logger.warning(
-            "execute_replays_query: validation failed",
-            extra={"org_id": organization_id, "error_detail": error_detail},
+        return ExecuteQueryErrorResponse(
+            error="Session Replay is not enabled for this organization."
         )
-        return ExecuteQueryErrorResponse(error=error_detail)
 
     if project_ids and project_slugs:
-        error_detail = "Pass either project_ids or project_slugs, not both."
-        logger.warning(
-            "execute_replays_query: validation failed",
-            extra={"org_id": organization_id, "error_detail": error_detail},
+        return ExecuteQueryErrorResponse(
+            error="Pass either project_ids or project_slugs, not both."
         )
-        return ExecuteQueryErrorResponse(error=error_detail)
 
     project_filter: dict[str, Any] = {}
     if project_ids:
@@ -667,12 +661,9 @@ def execute_replays_query(
     requested_fields = fields or DEFAULT_REPLAY_SEARCH_FIELDS
     invalid_fields = sorted(set(requested_fields) - set(REPLAY_VALID_FIELD_SET))
     if invalid_fields:
-        error_detail = f"Invalid replay field(s): {', '.join(invalid_fields)}"
-        logger.warning(
-            "execute_replays_query: validation failed",
-            extra={"org_id": organization_id, "error_detail": error_detail},
+        return ExecuteQueryErrorResponse(
+            error=f"Invalid replay field(s): {', '.join(invalid_fields)}"
         )
-        return ExecuteQueryErrorResponse(error=error_detail)
 
     date_params: dict[str, Any] = {}
     if start and end:
@@ -701,17 +692,9 @@ def execute_replays_query(
         )
         processed_response = process_raw_response(response.response, fields=requested_fields)
     except KeyError as e:
-        error_detail = f"Invalid replay field: {e.args[0]}" if e.args else "Invalid replay field"
-        logger.warning(
-            "execute_replays_query: validation failed",
-            extra={
-                "org_id": organization_id,
-                "query": query,
-                "field": e.args[0] if e.args else None,
-                "error_detail": error_detail,
-            },
+        return ExecuteQueryErrorResponse(
+            error=f"Invalid replay field: {e.args[0]}" if e.args else "Invalid replay field"
         )
-        return ExecuteQueryErrorResponse(error=error_detail)
     except (InvalidParams, InvalidSearchQuery, SentryBadRequest, BadRequest, ParseError) as e:
         error_detail = str(e)
         logger.warning(

--- a/src/sentry/seer/assisted_query/issues_tools.py
+++ b/src/sentry/seer/assisted_query/issues_tools.py
@@ -731,7 +731,7 @@ def execute_issues_query(
             error = str(error_detail) if error_detail is not None else str(e.body)
             logger.warning(
                 "execute_issues_query: validation failed",
-                extra={"org_id": organization.id, "error": error},
+                extra={"org_id": organization.id, "error_detail": error},
             )
             return ExecuteQueryErrorResponse(error=error)
         raise

--- a/src/sentry/seer/assisted_query/issues_tools.py
+++ b/src/sentry/seer/assisted_query/issues_tools.py
@@ -727,13 +727,13 @@ def execute_issues_query(
         return ExecuteIssuesQuerySuccessResponse(__root__=resp.data)
     except ApiError as e:
         if e.status_code == 400:
-            error_detail = e.body.get("detail") if isinstance(e.body, dict) else None
-            error = str(error_detail) if error_detail is not None else str(e.body)
+            detail = e.body.get("detail") if isinstance(e.body, dict) else None
+            error_detail = str(detail) if detail is not None else str(e.body)
             logger.warning(
                 "execute_issues_query: validation failed",
-                extra={"org_id": organization.id, "error_detail": error},
+                extra={"org_id": organization.id, "error_detail": error_detail},
             )
-            return ExecuteQueryErrorResponse(error=error)
+            return ExecuteQueryErrorResponse(error=error_detail)
         raise
 
 

--- a/src/sentry/seer/assisted_query/issues_tools.py
+++ b/src/sentry/seer/assisted_query/issues_tools.py
@@ -730,7 +730,7 @@ def execute_issues_query(
             detail = e.body.get("detail") if isinstance(e.body, dict) else None
             error_detail = str(detail) if detail is not None else str(e.body)
             logger.warning(
-                "execute_issues_query: validation failed",
+                "execute_issues_query: bad request",
                 extra={"org_id": organization.id, "error_detail": error_detail},
             )
             return ExecuteQueryErrorResponse(error=error_detail)

--- a/src/sentry/seer/assisted_query/issues_tools.py
+++ b/src/sentry/seer/assisted_query/issues_tools.py
@@ -728,9 +728,12 @@ def execute_issues_query(
     except ApiError as e:
         if e.status_code == 400:
             error_detail = e.body.get("detail") if isinstance(e.body, dict) else None
-            return ExecuteQueryErrorResponse(
-                error=str(error_detail) if error_detail is not None else str(e.body)
+            error = str(error_detail) if error_detail is not None else str(e.body)
+            logger.warning(
+                "execute_issues_query: validation failed",
+                extra={"org_id": organization.id, "error": error},
             )
+            return ExecuteQueryErrorResponse(error=error)
         raise
 
 


### PR DESCRIPTION
### Motivation

[SENTRY-5DPB](https://sentry.sentry.io/issues/7061761476/events/bb785909d81a435dbbc4a77913ebe107/)

The Seer query tools call `logger.exception` when a query the agent built fails validation, which reports to Sentry at **error** level. These failures are expected and self-correcting — the agent gets the error string back and retries with a fixed query — so they're just noise in the issue stream.

We still want the visibility, just not at error level.

### Changes

Every code path that returns an `ExecuteQueryErrorResponse` or `ExecuteTimeseriesQueryErrorResponse` now logs `logger.warning("<func>: bad request", extra={"org_id": ..., "error_detail": ...})` first. The error string is hoisted into a local so the log line and the response the agent sees carry the same message.

`src/sentry/seer/agent/tools.py`
- `_validate_events_query_params` — both invalid-query branches (a `valid: false` body and a 400 whose body contains `valid`). The `logger.exception` on the *unexpected* validate-request failure is left as-is; that path doesn't return an error response and is a genuine error.
- `execute_table_query`, `execute_timeseries_query`, `execute_trace_table_query` — 400 handlers: `logger.exception(... bad request)` → `logger.warning(... bad request)`.
- `execute_replays_query` — the `InvalidParams`/`InvalidSearchQuery`/`SentryBadRequest`/`BadRequest`/`ParseError` handler converted to `warning`. The other error returns here (feature flag off, conflicting project args, invalid field names, `KeyError`) carry static hardcoded text, so they aren't logged at all — the message adds nothing the code doesn't already say.

`src/sentry/seer/assisted_query/issues_tools.py`
- `execute_issues_query` 400 handler — previously silent, now logs a warning.

No behavior change for callers: the returned error responses are identical.

### Testing

- `tests/sentry/seer/agent/test_tools.py` — replay + table/timeseries/validate tests pass
- `tests/sentry/seer/assisted_query/test_issues_tools.py` — 59 passed
- `prek run -q` clean
