### PR TITLE
ref(seer): Remove activity rollout compatibility

### DIFF
--- a/src/sentry/issues/action_log/publish.py
+++ b/src/sentry/issues/action_log/publish.py
@@ -10,7 +10,6 @@ from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
-from datetime import datetime
 from typing import TYPE_CHECKING, Optional, Sequence
 
 from sentry.hybridcloud.models.outbox import outbox_context
@@ -82,7 +81,6 @@ def publish_action(
     actor: GroupActionActor = SYSTEM_ACTOR,
     force_async_derived: bool = False,
     idempotency_key: str | None = None,
-    date_added: datetime | None = None,
 ) -> None:
     """
     Record an issue action.
@@ -96,9 +94,6 @@ def publish_action(
 
     If *idempotency_key* is set, the GroupActionLogEntry is created if and only if there
     does not already exist a GALE with that group id & idempotency key; else it's a no-op.
-
-    If *date_added* is set, it records when the action occurred instead of when the outbox
-    receiver processed it.
 
     Log publishing is managed by an outbox that flushes on commit by
     default. Wrap in ``outbox_context(flush=False)`` to defer the drain.
@@ -156,8 +151,6 @@ def publish_action(
 
     if idempotency_key is not None:
         payload["idempotency_key"] = idempotency_key
-    if date_added is not None:
-        payload["date_added"] = date_added.isoformat()
 
     outbox = CellOutbox(
         shard_scope=OutboxScope.GROUP_SCOPE,
@@ -178,7 +171,6 @@ def publish_action_from_context(
     project: Project,
     force_async_derived: bool = False,
     idempotency_key: Optional[str] = None,
-    date_added: datetime | None = None,
 ) -> None:
     """
     Record an issue action using the current ActionContext. This is the primary API
@@ -206,7 +198,6 @@ def publish_action_from_context(
         actor=actor,
         force_async_derived=force_async_derived,
         idempotency_key=idempotency_key,
-        date_added=date_added,
     )
 
 

--- a/src/sentry/issues/action_log/types.py
+++ b/src/sentry/issues/action_log/types.py
@@ -552,7 +552,6 @@ class GroupActionLogPayload(TypedDict):
     data: dict[str, Any]
     force_async_derived: bool
     idempotency_key: NotRequired[str]
-    date_added: NotRequired[str]
 
 
 class SetPublicAction(GroupAction):

--- a/src/sentry/models/activity.py
+++ b/src/sentry/models/activity.py
@@ -151,7 +151,6 @@ class ActivityManager(BaseManager["Activity"]):
                         group_id=group_id,
                         project=activity.project,
                         idempotency_key=activity_action_idempotency_key(activity),
-                        date_added=activity.datetime,
                     )
             except Exception:
                 _default_logger.info("Failed to translate activity %d to GALE", activity.id)

--- a/src/sentry/receivers/outbox/cell.py
+++ b/src/sentry/receivers/outbox/cell.py
@@ -10,12 +10,10 @@ from __future__ import annotations
 
 import json  # noqa: S003 - urllib3 raises stdlib JSONDecodeError, not simplejson's
 import logging
-from datetime import datetime
 from typing import Any, assert_never, cast
 
 from django.db import IntegrityError, router, transaction
 from django.dispatch import receiver
-from django.utils import timezone
 
 from sentry.audit_log.services.log import AuditLogEvent, UserIpEvent, log_rpc_service
 from sentry.auth.services.auth import auth_service
@@ -353,7 +351,6 @@ def process_group_action_log_event(payload: GroupActionLogPayload, **kwds: Any) 
 
         group_id = payload["group_id"]
         force_async_derived = payload["force_async_derived"]
-        date_added = payload.get("date_added")
 
         try:
             with transaction.atomic(using=using):
@@ -366,9 +363,6 @@ def process_group_action_log_event(payload: GroupActionLogPayload, **kwds: Any) 
                     source=payload["source"],
                     data=payload["data"],
                     idempotency_key=payload.get("idempotency_key"),
-                    date_added=(
-                        datetime.fromisoformat(date_added) if date_added else timezone.now()
-                    ),
                 )
         except IntegrityError:
             # Idempotency conflict; we treat this as a no-op.

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -525,7 +525,6 @@ def trigger_autofix_agent(
                 "event_type": sentry_app_event_type,
                 "event_payload": payload,
                 "organization_id": group.organization.id,
-                "record_activity": False,
             }
             if is_iteration_step:
                 activity_attribution = {
@@ -533,7 +532,6 @@ def trigger_autofix_agent(
                 }
                 if actor_user_id is not None:
                     activity_attribution["actor_user_id"] = actor_user_id
-                task_kwargs["activity_attribution"] = activity_attribution
             record_seer_activity(
                 group=group,
                 event_type=sentry_app_event_type,

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -8,7 +8,6 @@ import orjson
 import sentry_sdk
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
-from django.utils import timezone
 from taskbroker_client.retry import Retry
 from urllib3 import BaseHTTPResponse
 from urllib3.connectionpool import HTTPConnectionPool
@@ -184,7 +183,6 @@ def _trigger_autofix_task(
         )
 
         run: SeerRun | None = None
-        triggered_at = timezone.now()
         try:
             run = trigger_autofix_agent(
                 group=group,
@@ -199,7 +197,6 @@ def _trigger_autofix_task(
                     ActivityType.TRIGGER_AUTOFIX,
                     data={"referrer": referrer.value},
                     send_notification=False,
-                    datetime=triggered_at,
                 )
         except NoSeerQuotaException:
             pass

--- a/src/sentry/seer/autofix/on_completion_hook.py
+++ b/src/sentry/seer/autofix/on_completion_hook.py
@@ -477,7 +477,6 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
                         "event_type": sentry_app_event_type,
                         "event_payload": webhook_payload,
                         "organization_id": organization.id,
-                        "record_activity": False,
                     }
                 )
         except ValueError:

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -4,7 +4,6 @@ import logging
 import uuid
 from typing import Any
 
-from django.utils import timezone
 from drf_spectacular.utils import extend_schema
 from rest_framework import serializers, status
 from rest_framework.exceptions import PermissionDenied
@@ -410,7 +409,6 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                 run_id, sentry_run_id = resolved_run_id, resolved_sentry_run_id
 
             case _:
-                triggered_at = timezone.now() if is_autofix_kickoff else None
                 try:
                     run = trigger_autofix_agent(
                         group=group,
@@ -450,7 +448,6 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                             ),
                             data={"referrer": referrer.value},
                             send_notification=False,
-                            datetime=triggered_at,
                         )
                     sentry_run_id = str(run.uuid)
                 else:

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -703,7 +703,6 @@ def send_seer_webhook(
         return SendSeerWebhookErrorResponse(error="Organization not found or not active")
 
     if SeerAutofixOperator.has_access(organization=organization):
-        record_activity = True
         group_id = payload.get("group_id")
         if group_id:
             try:
@@ -719,14 +718,12 @@ def send_seer_webhook(
                     event_type=sentry_app_event_type,
                     event_payload=payload,
                 )
-                record_activity = False
 
         process_autofix_updates.apply_async(
             kwargs={
                 "event_type": sentry_app_event_type,
                 "event_payload": payload,
                 "organization_id": organization_id,
-                "record_activity": record_activity,
             }
         )
 

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -1,8 +1,5 @@
 import logging
-from datetime import datetime
 from typing import Any, NotRequired, TypedDict
-
-from django.utils import timezone
 
 from sentry import features, options
 from sentry.constants import DataCategory
@@ -234,7 +231,6 @@ class SeerAutofixOperator[CachePayloadT]:
 
             try:
                 if not run_id:
-                    triggered_at = timezone.now()
                     with action_context_scope(ActionSource.SLACK, GroupActionActor.user(user.id)):
                         run = trigger_autofix_agent(
                             group=group,
@@ -250,7 +246,6 @@ class SeerAutofixOperator[CachePayloadT]:
                             user_id=user.id,
                             data={"referrer": AutofixReferrer.SLACK.value},
                             send_notification=False,
-                            datetime=triggered_at,
                         )
                 elif stopping_point == AutofixStoppingPoint.OPEN_PR:
                     trigger_push_changes(
@@ -599,7 +594,6 @@ def _create_seer_activity(
     event_type: SentryAppEventType,
     event_payload: dict[str, Any],
     activity_attribution: SeerActivityAttribution | None = None,
-    activity_datetime: datetime | None = None,
 ) -> None:
     activity_type = SEER_EVENT_TO_ACTIVITY_TYPE.get(event_type)
     if not activity_type:
@@ -647,7 +641,6 @@ def _create_seer_activity(
         user_id=actor_user_id,
         data=activity_data if activity_data else None,
         send_notification=False,
-        datetime=activity_datetime,
     )
 
 
@@ -657,7 +650,6 @@ def record_seer_activity(
     event_type: SentryAppEventType,
     event_payload: dict[str, Any],
     activity_attribution: SeerActivityAttribution | None = None,
-    activity_datetime: datetime | None = None,
 ) -> None:
     iteration_attribution: SeerActivityAttribution | None = None
     if event_type == SentryAppEventType.SEER_ITERATION_STARTED and activity_attribution:
@@ -683,13 +675,7 @@ def record_seer_activity(
 
     try:
         with action_context_scope(action_source, action_actor):
-            _create_seer_activity(
-                group,
-                event_type,
-                event_payload,
-                iteration_attribution,
-                activity_datetime,
-            )
+            _create_seer_activity(group, event_type, event_payload, iteration_attribution)
     except Exception:
         logger.exception(
             "seer.activity_creation_failed",
@@ -712,9 +698,6 @@ def process_autofix_updates(
     event_type: SentryAppEventType,
     event_payload: dict[str, Any],
     organization_id: int,
-    activity_attribution: SeerActivityAttribution | None = None,
-    activity_datetime: str | None = None,
-    record_activity: bool = True,
 ) -> None:
     """
     Use the registry to iterate over all entrypoints and check if this payload's run_id or group_id
@@ -753,17 +736,6 @@ def process_autofix_updates(
         if not SeerAutofixOperator.has_access(organization=organization):
             lifecycle.record_halt(halt_reason="no_operator_access")
             return
-
-        if record_activity:
-            record_seer_activity(
-                group=group,
-                event_type=event_type,
-                event_payload=event_payload,
-                activity_attribution=activity_attribution,
-                activity_datetime=(
-                    datetime.fromisoformat(activity_datetime) if activity_datetime else None
-                ),
-            )
 
         for entrypoint_key, entrypoint_cls in autofix_entrypoint_registry.registrations.items():
             logging_ctx = {

--- a/src/sentry/seer/night_shift/delivery.py
+++ b/src/sentry/seer/night_shift/delivery.py
@@ -8,7 +8,6 @@ from typing import Any
 from uuid import UUID
 
 import sentry_sdk
-from django.utils import timezone
 
 from sentry.constants import SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT, ObjectStatus
 from sentry.issues.action_log import SYSTEM_ACTOR, ActionSource, action_context_scope
@@ -222,7 +221,6 @@ def _process_verdicts(
                 if reason
                 else None
             )
-            triggered_at = timezone.now()
             try:
                 triggered_run = trigger_autofix_agent(
                     group=group,
@@ -245,7 +243,6 @@ def _process_verdicts(
                     ActivityType.TRIGGER_AUTOFIX,
                     data={"referrer": referrer.value},
                     send_notification=False,
-                    datetime=triggered_at,
                 )
 
         sentry_sdk.metrics.count("night_shift.autofix_triggered", len(run_by_group))

--- a/tests/sentry/models/test_activity.py
+++ b/tests/sentry/models/test_activity.py
@@ -4,10 +4,8 @@ from unittest.mock import MagicMock, patch
 
 from sentry.event_manager import EventManager
 from sentry.incidents.grouptype import MetricIssue
-from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
 from sentry.models.activity import Activity
 from sentry.testutils.cases import TestCase
-from sentry.testutils.outbox import outbox_runner
 from sentry.types.activity import ActivityType
 from sentry.types.group import PriorityLevel
 from sentry.utils.iterators import chunked
@@ -414,20 +412,18 @@ class ActivityTest(TestCase):
 
         custom_datetime = datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
 
-        with self.feature("projects:issue-action-log-write-to-db"), outbox_runner():
-            activity = Activity.objects.create_group_activity(
-                group=group,
-                type=ActivityType.SET_RESOLVED,
-                user=user,
-                data={"reason": "test"},
-                send_notification=False,
-                datetime=custom_datetime,
-            )
+        activity = Activity.objects.create_group_activity(
+            group=group,
+            type=ActivityType.SET_RESOLVED,
+            user=user,
+            data={"reason": "test"},
+            send_notification=False,
+            datetime=custom_datetime,
+        )
 
         assert activity.datetime == custom_datetime
         assert activity.type == ActivityType.SET_RESOLVED.value
         assert activity.user_id == user.id
-        assert GroupActionLogEntry.objects.get(group_id=group.id).date_added == custom_datetime
 
     def test_create_group_activity_without_custom_datetime(self) -> None:
         project = self.create_project(name="test_default_datetime")

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -469,9 +469,7 @@ class TestTriggerAutofixAgent(TestCase):
             mock_broadcast.assert_called_once()
             call_kwargs = mock_broadcast.call_args.kwargs
             assert call_kwargs["event_name"] == expected_action.value
-            assert (
-                mock_process_autofix_updates.call_args.kwargs["kwargs"]["record_activity"] is False
-            )
+            mock_process_autofix_updates.assert_called_once()
 
     @patch("sentry.quotas.backend.record_seer_run")
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)

--- a/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
+++ b/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
@@ -568,7 +568,7 @@ class TestAutofixOnCompletionHookWebhooks(TestCase):
         assert call_kwargs["payload"]["pull_requests"][0]["pull_request"]["pr_number"] == 7
         mock_process_autofix_updates.assert_called_once()
         task_kwargs = mock_process_autofix_updates.call_args.kwargs["kwargs"]
-        assert task_kwargs["record_activity"] is False
+        assert "record_activity" not in task_kwargs
         assert "activity_datetime" not in task_kwargs
         assert (
             mock_analytics.call_args.args[0].referrer

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -534,7 +534,6 @@ class TestSeerRpcMethods(APITestCase):
                 "event_type": SentryAppEventType.SEER_ROOT_CAUSE_COMPLETED,
                 "event_payload": event_payload,
                 "organization_id": self.organization.id,
-                "record_activity": False,
             },
         )
         mock_broadcast.assert_called_once()

--- a/tests/sentry/seer/entrypoints/test_operator.py
+++ b/tests/sentry/seer/entrypoints/test_operator.py
@@ -33,6 +33,7 @@ from sentry.seer.entrypoints.operator import (
     SeerOperatorCompletionHook,
     get_autofix_explorer_status,
     process_autofix_updates,
+    record_seer_activity,
 )
 from sentry.seer.entrypoints.registry import autofix_entrypoint_registry
 from sentry.seer.entrypoints.types import (
@@ -382,7 +383,7 @@ class SeerOperatorTest(TestCase):
 
     @patch.object(SeerAutofixOperator, "has_access", return_value=True)
     @patch("sentry.seer.entrypoints.cache.SeerOperatorAutofixCache.get")
-    def test_process_autofix_updates_without_recording_activity(
+    def test_process_autofix_updates_does_not_record_activity(
         self, mock_autofix_cache_get, _mock_has_access
     ):
         cache_payload = self.entrypoint.create_autofix_cache_payload()
@@ -403,7 +404,6 @@ class SeerOperatorTest(TestCase):
                 event_type=event_type,
                 event_payload=event_payload,
                 organization_id=self.organization.id,
-                record_activity=False,
             )
 
         assert not Activity.objects.filter(
@@ -507,8 +507,7 @@ class SeerOperatorTest(TestCase):
         ):
             assert SeerAutofixOperator.can_trigger_autofix(group=self.group) is False
 
-    @patch.object(SeerAutofixOperator, "has_access", return_value=True)
-    def test_seer_event_creates_activity_rca_completed(self, _mock_has_access):
+    def test_seer_event_creates_activity_rca_completed(self):
         event_payload = {
             "run_id": MOCK_RUN_ID,
             "group_id": self.group.id,
@@ -520,10 +519,10 @@ class SeerOperatorTest(TestCase):
             },
         }
 
-        process_autofix_updates(
+        record_seer_activity(
+            group=self.group,
             event_type=SentryAppEventType.SEER_ROOT_CAUSE_COMPLETED,
             event_payload=event_payload,
-            organization_id=self.organization.id,
         )
 
         activity = Activity.objects.get(
@@ -534,9 +533,7 @@ class SeerOperatorTest(TestCase):
         assert "root_cause" not in activity.data
         assert "five_whys" not in activity.data
 
-    @patch.object(SeerAutofixOperator, "has_access", return_value=True)
-    def test_seer_event_creates_activity_solution_completed(self, _mock_has_access):
-        activity_datetime = datetime.fromisoformat("2024-01-15T10:30:00+00:00")
+    def test_seer_event_creates_activity_solution_completed(self):
         event_payload = {
             "run_id": MOCK_RUN_ID,
             "group_id": self.group.id,
@@ -546,11 +543,10 @@ class SeerOperatorTest(TestCase):
             },
         }
 
-        process_autofix_updates(
+        record_seer_activity(
+            group=self.group,
             event_type=SentryAppEventType.SEER_SOLUTION_COMPLETED,
             event_payload=event_payload,
-            organization_id=self.organization.id,
-            activity_datetime=activity_datetime.isoformat(),
         )
 
         activity = Activity.objects.get(
@@ -560,20 +556,18 @@ class SeerOperatorTest(TestCase):
         assert activity.data["summary"] == "Test solution summary"
         assert "solution" not in activity.data
         assert "steps" not in activity.data
-        assert activity.datetime == activity_datetime
 
-    @patch.object(SeerAutofixOperator, "has_access", return_value=True)
-    def test_seer_event_creates_activity_coding_completed(self, _mock_has_access):
+    def test_seer_event_creates_activity_coding_completed(self):
         event_payload = {
             "run_id": MOCK_RUN_ID,
             "group_id": self.group.id,
             "code_changes": {"getsentry/sentry": [{"diff": "...", "path": "foo.py"}]},
         }
 
-        process_autofix_updates(
+        record_seer_activity(
+            group=self.group,
             event_type=SentryAppEventType.SEER_CODING_COMPLETED,
             event_payload=event_payload,
-            organization_id=self.organization.id,
         )
 
         activity = Activity.objects.get(
@@ -583,34 +577,33 @@ class SeerOperatorTest(TestCase):
         assert "changes" not in activity.data
         assert "code_changes" not in activity.data
 
-    @patch.object(SeerAutofixOperator, "has_access", return_value=True)
-    def test_create_seer_activity_all_mapped_event_types(self, _mock_has_access):
+    def test_create_seer_activity_all_mapped_event_types(self):
         with capture_action_log() as action_log:
             for seer_event, expected_activity_type in SEER_EVENT_TO_ACTIVITY_TYPE.items():
                 event_payload = {"run_id": MOCK_RUN_ID, "group_id": self.group.id}
-                process_autofix_updates(
+                record_seer_activity(
+                    group=self.group,
                     event_type=seer_event,
                     event_payload=event_payload,
-                    organization_id=self.organization.id,
                     activity_attribution={"referrer": AutofixReferrer.GITHUB_PR_COMMENT},
                 )
                 assert Activity.objects.filter(
                     group=self.group, type=expected_activity_type.value
                 ).exists(), f"Activity not created for {seer_event}"
 
-            process_autofix_updates(
+            record_seer_activity(
+                group=self.group,
                 event_type=SentryAppEventType.SEER_ITERATION_STARTED,
                 event_payload={"run_id": MOCK_RUN_ID, "group_id": self.group.id},
-                organization_id=self.organization.id,
                 activity_attribution={
                     "referrer": AutofixReferrer.WEB,
                     "actor_user_id": self.user.id,
                 },
             )
-            process_autofix_updates(
+            record_seer_activity(
+                group=self.group,
                 event_type=SentryAppEventType.SEER_ITERATION_STARTED,
                 event_payload={"run_id": MOCK_RUN_ID, "group_id": self.group.id},
-                organization_id=self.organization.id,
                 activity_attribution={"referrer": AutofixReferrer.UNKNOWN},
             )
 
@@ -644,35 +637,32 @@ class SeerOperatorTest(TestCase):
             user_id=self.user.id,
         ).exists()
 
-    @patch.object(SeerAutofixOperator, "has_access", return_value=True)
-    def test_create_seer_activity_skips_non_seer_events(self, _mock_has_access):
+    def test_create_seer_activity_skips_non_seer_events(self):
         event_payload = {"run_id": MOCK_RUN_ID, "group_id": self.group.id}
 
-        process_autofix_updates(
+        record_seer_activity(
+            group=self.group,
             event_type=SentryAppEventType.ISSUE_CREATED,
             event_payload=event_payload,
-            organization_id=self.organization.id,
         )
 
         seer_type_values = [t.value for t in SEER_EVENT_TO_ACTIVITY_TYPE.values()]
         assert not Activity.objects.filter(group=self.group, type__in=seer_type_values).exists()
 
-    @patch.object(SeerAutofixOperator, "has_access", return_value=True)
-    def test_create_seer_activity_option_disabled(self, _mock_has_access):
+    def test_create_seer_activity_option_disabled(self):
         event_payload = {"run_id": MOCK_RUN_ID, "group_id": self.group.id}
 
         with override_options({"issues.record-seer-actions-as-activities": False}):
-            process_autofix_updates(
+            record_seer_activity(
+                group=self.group,
                 event_type=SentryAppEventType.SEER_ROOT_CAUSE_STARTED,
                 event_payload=event_payload,
-                organization_id=self.organization.id,
             )
 
         seer_type_values = [t.value for t in SEER_EVENT_TO_ACTIVITY_TYPE.values()]
         assert not Activity.objects.filter(group=self.group, type__in=seer_type_values).exists()
 
-    @patch.object(SeerAutofixOperator, "has_access", return_value=True)
-    def test_create_seer_activity_pr_created_with_pull_requests(self, _mock_has_access):
+    def test_create_seer_activity_pr_created_with_pull_requests(self):
         event_payload = {
             "run_id": MOCK_RUN_ID,
             "group_id": self.group.id,
@@ -688,10 +678,10 @@ class SeerOperatorTest(TestCase):
             ],
         }
 
-        process_autofix_updates(
+        record_seer_activity(
+            group=self.group,
             event_type=SentryAppEventType.SEER_PR_CREATED,
             event_payload=event_payload,
-            organization_id=self.organization.id,
         )
 
         activity = Activity.objects.get(group=self.group, type=ActivityType.SEER_PR_CREATED.value)
@@ -701,8 +691,7 @@ class SeerOperatorTest(TestCase):
             == "https://github.com/owner/repo/pull/42"
         )
 
-    @patch.object(SeerAutofixOperator, "has_access", return_value=True)
-    def test_create_seer_activity_iteration_completed(self, _mock_has_access):
+    def test_create_seer_activity_iteration_completed(self):
         event_payload = {
             "run_id": MOCK_RUN_ID,
             "group_id": self.group.id,
@@ -719,10 +708,10 @@ class SeerOperatorTest(TestCase):
             ],
         }
 
-        process_autofix_updates(
+        record_seer_activity(
+            group=self.group,
             event_type=SentryAppEventType.SEER_ITERATION_COMPLETED,
             event_payload=event_payload,
-            organization_id=self.organization.id,
         )
 
         activity = Activity.objects.get(
@@ -732,16 +721,13 @@ class SeerOperatorTest(TestCase):
         assert activity.data["code_changes"]["owner/repo"][0]["path"] == "foo.py"
 
     @patch("sentry.models.activity.invoke_workflow_activity_handlers")
-    @patch.object(SeerAutofixOperator, "has_access", return_value=True)
-    def test_create_seer_activity_invokes_workflow_activity_handlers(
-        self, _mock_has_access, mock_invoke
-    ):
+    def test_create_seer_activity_invokes_workflow_activity_handlers(self, mock_invoke):
         event_payload = {"run_id": MOCK_RUN_ID, "group_id": self.group.id}
 
-        process_autofix_updates(
+        record_seer_activity(
+            group=self.group,
             event_type=SentryAppEventType.SEER_ROOT_CAUSE_STARTED,
             event_payload=event_payload,
-            organization_id=self.organization.id,
         )
 
         mock_invoke.assert_called_once()


### PR DESCRIPTION
Removes worker-side activity creation and the temporary task arguments once every producer records synchronously. It also removes the original backdating plumbing.

Order: 3/3. After #121117 merges, retarget this to master. Merge once #121117 is fully deployed and older process_autofix_updates tasks have drained.