### PR TITLE
fix(replays): route delete-script task to long pool and lighten its per-task cost

### DIFF
--- a/src/sentry/replays/tasks.py
+++ b/src/sentry/replays/tasks.py
@@ -98,7 +98,7 @@ def process_replay_recording(message_bytes: bytes) -> None:
 
 @instrumented_task(
     name="sentry.replays.tasks.delete_recording_async",
-    namespace=replays_tasks,
+    namespace=replays_long_tasks,
     processing_deadline_duration=120,
     retry=Retry(times=5, delay=5),
     silo_mode=SiloMode.CELL,
@@ -126,8 +126,7 @@ def delete_replays_script_async(
     for segment in segments:
         rrweb_filenames.append(make_recording_filename(segment))
 
-    with ContextPropagatingThreadPoolExecutor(max_workers=100) as pool:
-        pool.map(_delete_if_exists, rrweb_filenames)
+    _delete_filenames_concurrently(rrweb_filenames)
 
     # Backwards compatibility. Should be deleted one day.
     segments_from_django_models = ReplayRecordingSegment.objects.filter(
@@ -168,8 +167,11 @@ def delete_replay_recording(project_id: int, replay_id: str) -> None:
             direct_storage_segments.append(segment)
 
     # Issue concurrent delete requests when interacting with a remote service provider.
-    with ContextPropagatingThreadPoolExecutor(max_workers=100) as pool:
-        if direct_storage_segments:
+    # Make the threads reuse one client instead of racing to build their own
+    if direct_storage_segments:
+        storage.initialize_client()
+        max_workers = min(len(direct_storage_segments), _DELETE_THREAD_POOL_SIZE)
+        with ContextPropagatingThreadPoolExecutor(max_workers=max_workers) as pool:
             pool.map(storage.delete, direct_storage_segments)
 
     # This will only run if "filestore" was used to store the files. This hasn't been the
@@ -196,6 +198,23 @@ def _delete_if_exists(filename: str) -> None:
         storage_kv.delete(filename)
     except NotFound:
         pass
+
+
+#  Keeping this small bounds threads-per-task so `worker_concurrency x N` stays under pod memory limit
+_DELETE_THREAD_POOL_SIZE = 32
+
+
+def _delete_filenames_concurrently(filenames: list[str]) -> None:
+    if not filenames:
+        return
+
+    # Warm the process-global client before the threads start so they reuse it instead of racing to build their own
+    # Mimics the API endpoint's behavior
+    storage_kv.initialize_client()
+
+    max_workers = min(len(filenames), _DELETE_THREAD_POOL_SIZE)
+    with ContextPropagatingThreadPoolExecutor(max_workers=max_workers) as pool:
+        pool.map(_delete_if_exists, filenames)
 
 
 @instrumented_task(

--- a/tests/sentry/replays/tasks/test_delete_replays_script_async.py
+++ b/tests/sentry/replays/tasks/test_delete_replays_script_async.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from unittest.mock import patch
 from uuid import uuid4
 
-from sentry.replays.tasks import delete_replays_script_async
+from sentry.replays.tasks import _DELETE_THREAD_POOL_SIZE, delete_replays_script_async
+from sentry.taskworker.namespaces import replays_long_tasks
 from sentry.testutils.cases import TestCase
 
 
@@ -36,3 +37,58 @@ class TestDeleteReplaysScriptAsync(TestCase):
         )
 
         assert mock_delete.call_count == 0  # type: ignore[attr-defined]
+
+    def test_registered_on_long_pool_with_alias(self) -> None:
+        name = "sentry.replays.tasks.delete_recording_async"
+        assert replays_long_tasks.contains(name)
+
+    @patch("sentry.replays.tasks.storage_kv")
+    def test_storage_client_is_warmed_once_per_task(self, mock_storage_kv: object) -> None:
+        replay_id = uuid4().hex
+
+        with patch("sentry.replays.tasks.make_recording_filename", side_effect=lambda s: str(s)):
+            delete_replays_script_async(
+                retention_days=90,
+                project_id=self.project.id,
+                replay_id=replay_id,
+                max_segment_id=3,
+            )
+
+        # The client is warmed exactly once, before the fan-out, not once per
+        # segment. The four segments are still each deleted through the shared client.
+        assert mock_storage_kv.initialize_client.call_count == 1  # type: ignore[attr-defined]
+        assert mock_storage_kv.delete.call_count == 4  # type: ignore[attr-defined]
+
+    @patch("sentry.replays.tasks._delete_if_exists")
+    @patch("sentry.replays.tasks.ContextPropagatingThreadPoolExecutor")
+    def test_thread_pool_is_bounded_by_segment_count(
+        self, mock_pool: object, mock_delete: object
+    ) -> None:
+        # A single-segment replay must not open the full pool.
+        replay_id = uuid4().hex
+
+        with patch("sentry.replays.tasks.make_recording_filename", side_effect=lambda s: str(s)):
+            delete_replays_script_async(
+                retention_days=90,
+                project_id=self.project.id,
+                replay_id=replay_id,
+                max_segment_id=0,
+            )
+
+        mock_pool.assert_called_once_with(max_workers=1)  # type: ignore[attr-defined]
+
+    @patch("sentry.replays.tasks._delete_if_exists")
+    @patch("sentry.replays.tasks.ContextPropagatingThreadPoolExecutor")
+    def test_thread_pool_is_capped_at_the_max(self, mock_pool: object, mock_delete: object) -> None:
+        # A replay with more segments than the cap opens at most N threads.
+        replay_id = uuid4().hex
+
+        with patch("sentry.replays.tasks.make_recording_filename", side_effect=lambda s: str(s)):
+            delete_replays_script_async(
+                retention_days=90,
+                project_id=self.project.id,
+                replay_id=replay_id,
+                max_segment_id=_DELETE_THREAD_POOL_SIZE + 50,
+            )
+
+        mock_pool.assert_called_once_with(max_workers=_DELETE_THREAD_POOL_SIZE)  # type: ignore[attr-defined]


### PR DESCRIPTION
The `delete_replays_script_async` task  ran on `namespace=replays_tasks` (plain `replays`), which is not in the default worker's `TASKWORKER_ROUTES` map, so it fell through to the latency-sensitive default pool. In INC-2400 a `delete_replays` GoCD run enqueued thousands of these very fast, took all the default-pool workers, and backlogged it.

Each task was also heavy: a fresh 100-thread pool per replay (even a one-segment replay), and a new storage client per file. This likely is the root cause for the sporadic task failures seen during the incident.

Fix:
1. Route to the long pool.
2. Warm the client once so the threads reuse one process-global client instead of racing to build their own
3. Cap the pool at `min(segment_count, 32)`. A one-segment replay no longer opens 100 threads.

The same warm-client + pool-cap fix is applied to `delete_replay_recording` (shared by `delete_replay` and `delete_replay_recording_async`), which had the identical 100-thread + per-call-`get_storage` pattern.

Refs INC-2401