### PR TITLE
ref(issues): Remove dead processing traversal

### DIFF
--- a/src/sentry/stacktraces/processing.py
+++ b/src/sentry/stacktraces/processing.py
@@ -3,20 +3,15 @@ from __future__ import annotations
 import logging
 import re
 from collections.abc import Mapping, MutableMapping, Sequence
-from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, NamedTuple
 from urllib.parse import urlparse
 
 import sentry_sdk
 
-from sentry.models.project import Project
-from sentry.models.release import Release
 from sentry.stacktraces.functions import set_in_app, trim_function_name
 from sentry.utils import metrics
-from sentry.utils.cache import cache
-from sentry.utils.hashlib import hash_values
 from sentry.utils.safe import get_path, set_path, setdefault_path
-from sentry.utils.tracing import set_span_data, start_span, trace
+from sentry.utils.tracing import start_span
 
 logger = logging.getLogger(__name__)
 op = "stacktrace_processing"
@@ -44,23 +39,6 @@ class StacktraceInfo(NamedTuple):
     exception_type: str | None
     exception_module: str | None
 
-    def __hash__(self) -> int:
-        return id(self)
-
-    def __eq__(self, other: object) -> bool:
-        return self is other
-
-    def __ne__(self, other: object) -> bool:
-        return self is not other
-
-    def get_exception(self) -> str | None:
-        """Returns the fully qualified exception name (module.type) or None if not an exception."""
-        if self.exception_type is None:
-            return None
-        if self.exception_module:
-            return f"{self.exception_module}.{self.exception_type}"
-        return self.exception_type
-
     def get_frames(self) -> Sequence[dict[str, Any]]:
         return _safe_get_frames(self.stacktrace)
 
@@ -72,160 +50,13 @@ def _safe_get_frames(stacktrace) -> Sequence[dict[str, Any]]:
     return frames
 
 
-class ProcessableFrame:
-    def __init__(self, frame, idx, processor, stacktrace_info, processable_frames):
-        self.frame = frame
-        self.idx = idx
-        self.processor = processor
-        self.stacktrace_info = stacktrace_info
-        self.data = None
-        self.cache_key = None
-        self.cache_value = None
-        self.processable_frames = processable_frames
-
-    def __repr__(self) -> str:
-        return "<ProcessableFrame {!r} #{!r} at {!r}>".format(
-            self.frame.get("function") or "unknown",
-            self.idx,
-            self.frame.get("instruction_addr"),
-        )
-
-    def __contains__(self, key):
-        return key in self.frame
-
-    def __getitem__(self, key):
-        return self.frame[key]
-
-    def get(self, key, default=None):
-        return self.frame.get(key, default)
-
-    def close(self):
-        # manually break circular references
-        self.closed = True
-        self.processable_frames = None
-        self.stacktrace_info = None
-        self.processor = None
-
-    @property
-    def previous_frame(self):
-        last_idx = len(self.processable_frames) - self.idx - 1 - 1
-        if last_idx < 0:
-            return
-        return self.processable_frames[last_idx]
-
-    def set_cache_value(self, value):
-        if self.cache_key is not None:
-            cache.set(self.cache_key, value, 3600)
-            return True
-        return False
-
-    def set_cache_key_from_values(self, values):
-        if values is None:
-            self.cache_key = None
-            return
-
-        h = hash_values(values, seed=self.processor.__class__.__name__)
-        self.cache_key = rv = "pf:%s" % h
-        return rv
-
-
-class StacktraceProcessingTask:
-    def __init__(self, processable_stacktraces, processors):
-        self.processable_stacktraces = processable_stacktraces
-        self.processors = processors
-
-    def close(self):
-        for frame in self.iter_processable_frames():
-            frame.close()
-
-    def iter_processors(self):
-        return iter(self.processors)
-
-    def iter_processable_stacktraces(self):
-        return self.processable_stacktraces.items()
-
-    def iter_processable_frames(self, processor=None):
-        for _, frames in self.iter_processable_stacktraces():
-            for frame in frames:
-                if processor is None or frame.processor == processor:
-                    yield frame
-
-
-class StacktraceProcessor:
-    def __init__(self, data, stacktrace_infos, project=None):
-        self.data = data
-        self.stacktrace_infos = stacktrace_infos
-        if project is None:
-            project = Project.objects.get_from_cache(id=data["project"])
-        self.project = project
-
-    def close(self):
-        pass
-
-    def get_release(self, create=False):
-        """Convenient helper to return the release for the current data
-        and optionally creates the release if it's missing.  In case there
-        is no release info it will return `None`.
-        """
-        release = self.data.get("release")
-        if not release:
-            return None
-        if not create:
-            return Release.get(project=self.project, version=self.data["release"])
-        timestamp = self.data.get("timestamp")
-        if timestamp is not None:
-            date = datetime.fromtimestamp(timestamp).replace(tzinfo=timezone.utc)
-        else:
-            date = None
-        return Release.get_or_create(
-            project=self.project, version=self.data["release"], date_added=date
-        )
-
-    def handles_frame(self, frame, stacktrace_info):
-        """Returns true if this processor can handle this frame.  This is the
-        earliest check and operates on a raw frame and stacktrace info.  If
-        this returns `True` a processable frame is created.
-        """
-        return False
-
-    def preprocess_frame(self, processable_frame):
-        """After a processable frame has been created this method is invoked
-        to give the processor a chance to store additional data to the frame
-        if wanted.  In particular a cache key can be set here.
-        """
-
-    def process_exception(self, exception):
-        """Processes an exception."""
-        return False
-
-    def process_frame(self, processable_frame, processing_task):
-        """Processes the processable frame and returns a tuple of three
-        lists: ``(frames, raw_frames, errors)`` where frames is the list of
-        processed frames, raw_frames is the list of raw unprocessed frames
-        (which however can also be modified if needed) as well as a list of
-        optional errors.  Each one of the items can be `None` in which case
-        the original input frame is assumed.
-        """
-
-    def preprocess_step(self, processing_task):
-        """After frames are preprocessed but before frame processing kicks in
-        the preprocessing step is run.  This already has access to the cache
-        values on the frames.
-        """
-        return False
-
-
 def find_stacktraces_in_data(
-    data: Mapping[str, Any], include_raw: bool = False, include_empty_exceptions: bool = False
+    data: Mapping[str, Any], include_raw: bool = False
 ) -> list[StacktraceInfo]:
     """
     Finds all stacktraces in a given data blob and returns them together with some meta information.
 
     If `include_raw` is True, then also raw stacktraces are included.
-
-    If `include_empty_exceptions` is set to `True` then null/empty stacktraces and stacktraces with
-    no or only null/empty frames are included (where they otherwise would not be), with the
-    `is_exception` flag is set on their `StacktraceInfo` object.
     """
     rv = []
 
@@ -240,16 +71,10 @@ def find_stacktraces_in_data(
         exception_type: str | None = None,
         # The exception module (e.g., "__builtins__") if this stacktrace belongs to an exception
         exception_module: str | None = None,
-        # Prevent skipping empty/null stacktraces from `exception.values` (other empty/null
-        # stacktraces are always skipped)
-        include_empty_exceptions: bool = False,
     ) -> None:
         frames = _safe_get_frames(stacktrace)
 
-        if is_exception and include_empty_exceptions:
-            # win-fast bypass of null/empty check
-            pass
-        elif not stacktrace or not frames:
+        if not stacktrace or not frames:
             return
 
         platforms = _get_frames_metadata(frames, data.get("platform", "unknown"))
@@ -272,7 +97,6 @@ def find_stacktraces_in_data(
             is_exception=True,
             exception_type=exc.get("type"),
             exception_module=exc.get("module"),
-            include_empty_exceptions=include_empty_exceptions,
         )
 
     # Look for stacktraces under the key `stacktrace`
@@ -286,9 +110,8 @@ def find_stacktraces_in_data(
         # Iterate over a copy of rv, otherwise, it will infinitely append to itself
         for info in rv[:]:
             if info.container is not None:
-                # We don't set `is_exception` to `True` here, even if `info.is_exception` is set,
-                # because otherwise we'd end up processing each exception container twice in
-                # `process_stacktraces`
+                # Treat the raw stacktrace as non-exception so exception-specific normalization
+                # only applies once to its container.
                 _append_stacktrace(info.container.get("raw_stacktrace"), container=info.container)
 
     return rv
@@ -307,8 +130,7 @@ def _normalize_in_app(stacktrace: Sequence[dict[str, str]]) -> str:
     has_in_app_frames = False
     has_system_frames = False
 
-    # Default to false in all cases where processors or grouping enhancers
-    # have not yet set in_app.
+    # Default to false when grouping enhancers have not set in_app.
     for frame in stacktrace:
         if frame.get("in_app") is None:
             set_in_app(frame, False)
@@ -481,71 +303,6 @@ def _trim_function_name(frame: dict[str, Any], platform: str | None) -> None:
         frame["function"] = trimmed_function
 
 
-def get_processable_frames(stacktrace_info, processors) -> list[ProcessableFrame]:
-    """Returns thin wrappers around the frames in a stacktrace associated
-    with the processor for it.
-    """
-    frames = stacktrace_info.get_frames()
-    frame_count = len(frames)
-    rv: list[ProcessableFrame] = []
-    for idx, frame in enumerate(frames):
-        processor = next((p for p in processors if p.handles_frame(frame, stacktrace_info)), None)
-        if processor is not None:
-            rv.append(
-                ProcessableFrame(frame, frame_count - idx - 1, processor, stacktrace_info, rv)
-            )
-    return rv
-
-
-def process_single_stacktrace(processing_task, stacktrace_info, processable_frames):
-    # TODO: associate errors with the frames and processing issues
-    changed_raw = False
-    changed_processed = False
-    raw_frames = []
-    processed_frames = []
-    all_errors: list[Any] = []
-
-    bare_frames = stacktrace_info.get_frames()
-    frame_count = len(bare_frames)
-    processable_frames = {frame.idx: frame for frame in processable_frames}
-
-    for i, bare_frame in enumerate(bare_frames):
-        idx = frame_count - i - 1
-        rv = None
-
-        if idx in processable_frames:
-            processable_frame = processable_frames[idx]
-            assert processable_frame.frame is bare_frame
-            try:
-                rv = processable_frame.processor.process_frame(processable_frame, processing_task)
-            except Exception:
-                logger.exception("Failed to process frame")
-
-        expand_processed, expand_raw, errors = rv or (None, None, None)
-
-        if expand_processed is not None:
-            processed_frames.extend(expand_processed)
-            changed_processed = True
-        elif expand_raw:  # is not empty
-            processed_frames.extend(expand_raw)
-            changed_processed = True
-        else:
-            processed_frames.append(bare_frame)
-
-        if expand_raw is not None:
-            raw_frames.extend(expand_raw)
-            changed_raw = True
-        else:
-            raw_frames.append(bare_frame)
-        all_errors.extend(errors or ())
-
-    return (
-        processed_frames if changed_processed else None,
-        raw_frames if changed_raw else None,
-        all_errors,
-    )
-
-
 def get_crash_frame_from_event_data(data, frame_filter=None):
     """
     Return the highest (closest to the crash) in-app frame in the top stacktrace
@@ -584,136 +341,3 @@ def get_crash_frame_from_event_data(data, frame_filter=None):
 
     if default:
         return default
-
-
-def lookup_frame_cache(keys):
-    rv = {}
-    for key in keys:
-        rv[key] = cache.get(key)
-    return rv
-
-
-def get_stacktrace_processing_task(infos, processors):
-    """Returns a list of all tasks for the processors.  This can skip over
-    processors that seem to not handle any frames.
-    """
-    by_processor: dict[str, list[Any]] = {}
-    to_lookup: dict[str, ProcessableFrame] = {}
-
-    # by_stacktrace_info requires stable sorting as it is used in
-    # StacktraceProcessingTask.iter_processable_stacktraces. This is important
-    # to guarantee reproducible symbolicator requests.
-    by_stacktrace_info: dict[str, Any] = {}
-
-    for info in infos:
-        processable_frames = get_processable_frames(info, processors)
-        for processable_frame in processable_frames:
-            processable_frame.processor.preprocess_frame(processable_frame)
-            by_processor.setdefault(processable_frame.processor, []).append(processable_frame)
-            by_stacktrace_info.setdefault(processable_frame.stacktrace_info, []).append(
-                processable_frame
-            )
-            if processable_frame.cache_key is not None:
-                to_lookup[processable_frame.cache_key] = processable_frame
-
-    frame_cache = lookup_frame_cache(to_lookup)
-    for cache_key, processable_frame in to_lookup.items():
-        processable_frame.cache_value = frame_cache.get(cache_key)
-
-    return StacktraceProcessingTask(
-        processable_stacktraces=by_stacktrace_info, processors=by_processor
-    )
-
-
-def dedup_errors(errors):
-    # This operation scales bad but we do not expect that many items to
-    # end up in rv, so that should be okay enough to do.
-    rv = []
-    for error in errors:
-        if error not in rv:
-            rv.append(error)
-    return rv
-
-
-@trace
-def process_stacktraces(
-    data: MutableMapping[str, Any], make_processors=None, set_raw_stacktrace: bool = True
-) -> MutableMapping[str, Any] | None:
-    infos = find_stacktraces_in_data(data, include_empty_exceptions=True)
-    if make_processors is None:
-        return None
-    else:
-        processors = make_processors(data, infos)
-
-    changed = False
-
-    # Build a new processing task
-    processing_task = get_stacktrace_processing_task(infos, processors)
-    try:
-        # Preprocess step
-        for processor in processing_task.iter_processors():
-            with start_span(
-                op="stacktraces.processing.process_stacktraces.preprocess_step",
-                name="stacktraces.processing.process_stacktraces.preprocess_step",
-            ) as span:
-                set_span_data(span, "processor", processor.__class__.__name__)
-                if processor.preprocess_step(processing_task):
-                    changed = True
-                    set_span_data(span, "data_changed", True)
-
-        # Process all stacktraces
-        for stacktrace_info, processable_frames in processing_task.iter_processable_stacktraces():
-            # Let the stacktrace processors touch the exception
-            if stacktrace_info.is_exception and stacktrace_info.container:
-                for processor in processing_task.iter_processors():
-                    with start_span(
-                        op="stacktraces.processing.process_stacktraces.process_exception",
-                        name="stacktraces.processing.process_stacktraces.process_exception",
-                    ) as span:
-                        set_span_data(span, "processor", processor.__class__.__name__)
-                        if processor.process_exception(stacktrace_info.container):
-                            changed = True
-                            set_span_data(span, "data_changed", True)
-
-            # If the stacktrace is empty we skip it for processing
-            if not stacktrace_info.stacktrace:
-                continue
-            with start_span(
-                op="stacktraces.processing.process_stacktraces.process_single_stacktrace",
-                name="stacktraces.processing.process_stacktraces.process_single_stacktrace",
-            ) as span:
-                new_frames, new_raw_frames, errors = process_single_stacktrace(
-                    processing_task, stacktrace_info, processable_frames
-                )
-                if new_frames is not None:
-                    stacktrace_info.stacktrace["frames"] = new_frames
-                    changed = True
-                    set_span_data(span, "data_changed", True)
-            if (
-                set_raw_stacktrace
-                and new_raw_frames is not None
-                and stacktrace_info.container is not None
-            ):
-                stacktrace_info.container["raw_stacktrace"] = dict(
-                    stacktrace_info.stacktrace, frames=new_raw_frames
-                )
-                changed = True
-            if errors:
-                data.setdefault("errors", []).extend(dedup_errors(errors))
-                data.setdefault("_metrics", {})["flag.processing.error"] = True
-                changed = True
-
-    except Exception:
-        logger.exception("stacktraces.processing.crash")
-        data.setdefault("_metrics", {})["flag.processing.fatal"] = True
-        data.setdefault("_metrics", {})["flag.processing.error"] = True
-        changed = True
-    finally:
-        for processor in processors:
-            processor.close()
-        processing_task.close()
-
-    if changed:
-        return data
-    else:
-        return None

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -24,7 +24,6 @@ from sentry.models.project import Project
 from sentry.relay.datascrubbing import scrub_data
 from sentry.services.eventstore import processing
 from sentry.silo.base import SiloMode
-from sentry.stacktraces.processing import process_stacktraces
 from sentry.tasks.base import instrumented_task
 from sentry.tasks.symbolication import get_symbolication_functions
 from sentry.taskworker.namespaces import (
@@ -359,33 +358,15 @@ def do_process_event(
 
     has_changed = data_has_changed
 
-    # Stacktrace based event processors.
-    new_data = process_stacktraces(data)
-
-    if new_data is not None:
-        has_changed = True
-        data = new_data
-
     attachments = data.get("_attachments", None)
 
-    # Second round of datascrubbing after stacktrace and language-specific
-    # processing. First round happened as part of ingest.
+    # Second round of datascrubbing after symbolication. The first round
+    # happened as part of ingest.
     #
-    # *Right now* the only sensitive data that is added in stacktrace
-    # processing are usernames in filepaths, so we run directly after
-    # stacktrace processors.
+    # Symbolication can add sensitive data such as usernames in filepaths.
     #
-    # We do not yet want to deal with context data produced by plugins like
-    # sessionstack or fullstory (which are in `get_event_preprocessors`), as
-    # this data is very unlikely to be sensitive data. This is why scrubbing
-    # happens somewhere in the middle of the pipeline.
-    #
-    # On the other hand, Javascript event error translation is happening after
-    # this block because it uses `get_event_preprocessors`.
-    #
-    # We are fairly confident, however, that this should run *before*
-    # re-normalization as it is hard to find sensitive data in partially
-    # trimmed strings.
+    # This should run before event preprocessors and re-normalization because
+    # it is hard to find sensitive data in partially trimmed strings.
     if has_changed:
         new_data = safe_execute(scrub_data, project=project, event=data)
 

--- a/tests/sentry/test_stacktraces.py
+++ b/tests/sentry/test_stacktraces.py
@@ -5,10 +5,9 @@ from typing import Any
 import pytest
 
 from sentry.stacktraces.processing import find_stacktraces_in_data, get_crash_frame_from_event_data
-from sentry.testutils.cases import TestCase
 
 
-class FindStacktracesTest(TestCase):
+class TestFindStacktraces:
     def test_stacktraces_basics(self) -> None:
         data: dict[str, Any] = {
             "message": "hello",
@@ -40,7 +39,6 @@ class FindStacktracesTest(TestCase):
         assert infos[0].is_exception is False
         assert infos[0].exception_type is None
         assert infos[0].exception_module is None
-        assert infos[0].get_exception() is None
 
     def test_stacktraces_exception(self) -> None:
         data: dict[str, Any] = {
@@ -78,7 +76,6 @@ class FindStacktracesTest(TestCase):
         assert infos[0].is_exception is True
         assert infos[0].exception_type == "Error"
         assert infos[0].exception_module is None
-        assert infos[0].get_exception() == "Error"
 
     def test_stacktraces_exception_with_module(self) -> None:
         data: dict[str, Any] = {
@@ -109,7 +106,6 @@ class FindStacktracesTest(TestCase):
         assert infos[0].is_exception is True
         assert infos[0].exception_type == "RuntimeException"
         assert infos[0].exception_module == "java.lang"
-        assert infos[0].get_exception() == "java.lang.RuntimeException"
 
     def test_stacktraces_threads(self) -> None:
         data: dict[str, Any] = {
@@ -147,15 +143,14 @@ class FindStacktracesTest(TestCase):
         assert infos[0].is_exception is False
         assert infos[0].exception_type is None
         assert infos[0].exception_module is None
-        assert infos[0].get_exception() is None
 
     def test_find_stacktraces_skip_none(self) -> None:
         # This tests:
         #  1. exception is None
         #  2. stacktrace is None
         #  3. frames is None
-        #  3. frames contains only None
-        #  4. frame is None
+        #  4. frames contains only None
+        #  5. frame is None
         data: dict[str, Any] = {
             "message": "hello",
             "platform": "javascript",
@@ -189,23 +184,11 @@ class FindStacktracesTest(TestCase):
             },
         }
 
-        infos = find_stacktraces_in_data(data, include_empty_exceptions=True)
-        assert len(infos) == 4
-        assert sum(1 for x in infos if x.stacktrace) == 3
-        assert sum(1 for x in infos if x.is_exception) == 4
-        # All exceptions have type "Error" and no module
-        assert all(x.exception_type == "Error" for x in infos)
-        assert all(x.exception_module is None for x in infos)
-        assert all(x.get_exception() == "Error" for x in infos)
-        # XXX: The null frame is still part of this stack trace!
-        assert len(infos[3].stacktrace["frames"]) == 3
-
         infos = find_stacktraces_in_data(data)
         assert len(infos) == 1
         # XXX: The null frame is still part of this stack trace!
         assert len(infos[0].stacktrace["frames"]) == 3
         assert infos[0].exception_type == "Error"
-        assert infos[0].get_exception() == "Error"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
`do_process_event` calls `process_stacktraces(data)` without supplying any processors. `process_stacktraces` still finds every stacktrace and scans every frame, but then returns `None` because there are no processors to run. The result is discarded and the event is unchanged.

There cannot be a default processor anymore. The last implementation moved to Symbolicator in [#73905](https://github.com/getsentry/sentry/pull/73905), and the plugin system that registered these processors was removed in [#118397](https://github.com/getsentry/sentry/pull/118397).

Remove the no-op call and the now-unreachable processor framework behind it. Symbolication still happens through the existing JS, JVM, and native Symbolicator paths before this point. Stacktrace discovery, raw stacktrace merging, grouping normalization, and crash-frame selection are unchanged.