### PR TITLE
fix(issues): scope trace-connected related issues to accessible projects

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -19,11 +19,11 @@ from sentry.api.helpers.environments import get_environments
 from sentry.api.helpers.projects import (
     ParsedProjectIdOrSlugParams,
     ProjectIdOrSlugField,
+    filter_projects_by_permissions,
     parse_id_or_slug_params,
 )
 from sentry.api.permissions import DemoSafePermission, StaffPermissionMixin
 from sentry.api.utils import get_date_range_from_params, is_member_disabled_from_limit
-from sentry.auth.staff import is_active_staff
 from sentry.auth.superuser import is_active_superuser
 from sentry.constants import ALL_ACCESS_PROJECT_ID, ALL_ACCESS_PROJECTS_SLUG, ObjectStatus
 from sentry.exceptions import InvalidParams
@@ -46,7 +46,7 @@ from sentry.utils import auth
 from sentry.utils.hashlib import hash_values
 from sentry.utils.numbers import format_grouped_length
 from sentry.utils.sdk import bind_organization_context, set_span_attribute
-from sentry.utils.tracing import set_span_data, set_span_tag, start_span
+from sentry.utils.tracing import set_span_data, start_span
 
 
 class NoProjects(Exception):
@@ -458,34 +458,13 @@ class OrganizationEndpoint(Endpoint):
         force_global_perms: bool = False,
         include_all_accessible: bool = False,
     ) -> list[Project]:
-        with start_span(op="apply_project_permissions", name="apply_project_permissions") as span:
-            set_span_data(span, "Project Count", len(projects))
-            if force_global_perms:
-                set_span_tag(span, "mode", "force_global_perms")
-                return projects
-
-            # There is a special case for staff, where we want to fetch a single project (OrganizationStatsEndpointV2)
-            # or all projects (OrganizationMetricsDetailsEndpoint) in _admin. Staff cannot use has_project_access
-            # like superuser because it fails due to staff having no scopes. The workaround is to create a lambda that
-            # mimics checking for active projects like has_project_access without further validation.
-            # NOTE: We must check staff before superuser or else _admin will fail when both cookies are active
-            if is_active_staff(request):
-                set_span_tag(span, "mode", "staff_fetch_all")
-                proj_filter = lambda proj: proj.status == ObjectStatus.ACTIVE  # noqa: E731
-            # Superuser should fetch all projects.
-            # Also fetch all accessible projects if requesting $all
-            elif is_active_superuser(request) or include_all_accessible:
-                set_span_tag(span, "mode", "has_project_access")
-                proj_filter = request.access.has_project_access
-            # Check if explicitly requesting specific projects
-            elif not filter_by_membership:
-                set_span_tag(span, "mode", "has_project_access")
-                proj_filter = request.access.has_project_access
-            else:
-                set_span_tag(span, "mode", "has_project_membership")
-                proj_filter = request.access.has_project_membership
-
-            return [p for p in projects if proj_filter(p)]
+        return filter_projects_by_permissions(
+            projects=projects,
+            request=request,
+            filter_by_membership=filter_by_membership,
+            force_global_perms=force_global_perms,
+            include_all_accessible=include_all_accessible,
+        )
 
     def get_requested_project_ids_unchecked(self, request: HttpRequest) -> set[int]:
         """

--- a/src/sentry/api/helpers/projects.py
+++ b/src/sentry/api/helpers/projects.py
@@ -3,11 +3,16 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import NamedTuple, TypeAlias
 
+from django.http.request import HttpRequest
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
-from sentry.constants import ALL_ACCESS_PROJECT_ID, ALL_ACCESS_PROJECTS_SLUG
+from sentry.auth.staff import is_active_staff
+from sentry.auth.superuser import is_active_superuser
+from sentry.constants import ALL_ACCESS_PROJECT_ID, ALL_ACCESS_PROJECTS_SLUG, ObjectStatus
+from sentry.models.project import Project
 from sentry.utils.slug import DEFAULT_SLUG_ERROR_MESSAGE, MIXED_SLUG_REGEX
+from sentry.utils.tracing import set_span_data, set_span_tag, start_span
 
 ProjectIdOrSlug: TypeAlias = int | str
 
@@ -51,6 +56,49 @@ def parse_id_or_slug_params(
         else:
             slugs.add(value_str)
     return ParsedProjectIdOrSlugParams(ids=ids, slugs=slugs)
+
+
+def filter_projects_by_permissions(
+    projects: list[Project],
+    request: HttpRequest,
+    filter_by_membership: bool = False,
+    force_global_perms: bool = False,
+    include_all_accessible: bool = False,
+) -> list[Project]:
+    """
+    Filter ``projects`` down to the ones the request is allowed to read.
+
+    ``include_all_accessible`` grants org-wide access to members of open-membership
+    organizations; otherwise access falls back to team membership.
+    """
+    with start_span(op="apply_project_permissions", name="apply_project_permissions") as span:
+        set_span_data(span, "Project Count", len(projects))
+        if force_global_perms:
+            set_span_tag(span, "mode", "force_global_perms")
+            return projects
+
+        # There is a special case for staff, where we want to fetch a single project (OrganizationStatsEndpointV2)
+        # or all projects (OrganizationMetricsDetailsEndpoint) in _admin. Staff cannot use has_project_access
+        # like superuser because it fails due to staff having no scopes. The workaround is to create a lambda that
+        # mimics checking for active projects like has_project_access without further validation.
+        # NOTE: We must check staff before superuser or else _admin will fail when both cookies are active
+        if is_active_staff(request):
+            set_span_tag(span, "mode", "staff_fetch_all")
+            proj_filter = lambda proj: proj.status == ObjectStatus.ACTIVE  # noqa: E731
+        # Superuser should fetch all projects.
+        # Also fetch all accessible projects if requesting $all
+        elif is_active_superuser(request) or include_all_accessible:
+            set_span_tag(span, "mode", "has_project_access")
+            proj_filter = request.access.has_project_access
+        # Check if explicitly requesting specific projects
+        elif not filter_by_membership:
+            set_span_tag(span, "mode", "has_project_access")
+            proj_filter = request.access.has_project_access
+        else:
+            set_span_tag(span, "mode", "has_project_membership")
+            proj_filter = request.access.has_project_membership
+
+        return [p for p in projects if proj_filter(p)]
 
 
 @extend_schema_field(field=PROJECT_ID_OR_SLUG_SCHEMA)

--- a/src/sentry/issues/endpoints/related_issues.py
+++ b/src/sentry/issues/endpoints/related_issues.py
@@ -6,11 +6,13 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.helpers.deprecation import deprecated
-from sentry.constants import CELL_API_DEPRECATION_DATE
+from sentry.api.helpers.projects import filter_projects_by_permissions
+from sentry.constants import CELL_API_DEPRECATION_DATE, ObjectStatus
 from sentry.issues.endpoints.bases.group import GroupEndpoint
 from sentry.issues.related.same_root_cause import same_root_cause_analysis
 from sentry.issues.related.trace_connected import trace_connected_analysis
 from sentry.models.group import Group
+from sentry.models.project import Project
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
@@ -57,13 +59,23 @@ class RelatedIssuesEndpoint(GroupEndpoint):
         _data = serializer.validated_data
         related_type = _data["type"]
         try:
-            data, meta = (
-                same_root_cause_analysis(group)
-                if related_type == "same_root_cause"
-                else trace_connected_analysis(
-                    group, event_id=_data.get("event_id"), project_id=_data.get("project_id")
+            if related_type == "same_root_cause":
+                data, meta = same_root_cause_analysis(group)
+            else:
+                # A trace can span any project in the organization
+                org_projects = Project.objects.filter(
+                    organization_id=group.project.organization_id, status=ObjectStatus.ACTIVE
                 )
-            )
+                data, meta = trace_connected_analysis(
+                    group,
+                    projects=filter_projects_by_permissions(
+                        projects=list(org_projects),
+                        request=request,
+                        include_all_accessible=True,
+                    ),
+                    event_id=_data.get("event_id"),
+                    project_id=_data.get("project_id"),
+                )
             return Response({"type": related_type, "data": data, "meta": meta})
         except AssertionError:
             return Response({}, status=400)

--- a/src/sentry/issues/related/trace_connected.py
+++ b/src/sentry/issues/related/trace_connected.py
@@ -19,7 +19,10 @@ from sentry.utils.snuba import bulk_snuba_queries
 
 # If we drop trace connected issues from similar issues we can stop using the group
 def trace_connected_analysis(
-    group: Group, event_id: str | None = None, project_id: int | None = None
+    group: Group,
+    projects: list[Project],
+    event_id: str | None = None,
+    project_id: int | None = None,
 ) -> tuple[list[int], dict[str, str]]:
     """Determine if the group has a trace connected to it and return other issues that were part of it."""
     issues: list[int] = []
@@ -38,7 +41,7 @@ def trace_connected_analysis(
         event = group.get_recommended_event_for_environments()
 
     if event:
-        issues, meta = trace_connected_issues(event)
+        issues, meta = trace_connected_issues(event, projects)
     else:
         meta["error"] = "No event found for group."
 
@@ -100,7 +103,9 @@ def _trace_connected_issues_eap(
     return group_ids
 
 
-def trace_connected_issues(event: Event | GroupEvent) -> tuple[list[int], dict[str, str]]:
+def trace_connected_issues(
+    event: Event | GroupEvent, projects: list[Project]
+) -> tuple[list[int], dict[str, str]]:
     meta = {"event_id": event.event_id}
     if event.trace_id:
         meta["trace_id"] = event.trace_id
@@ -110,9 +115,8 @@ def trace_connected_issues(event: Event | GroupEvent) -> tuple[list[int], dict[s
 
     assert event.group is not None
     group = event.group
-    org_id = group.project.organization_id
-    organization = Organization.objects.get(id=org_id)
-    projects = list(Project.objects.filter(organization_id=org_id))
+    organization = group.project.organization
+    org_id = organization.id
     project_ids = [p.id for p in projects]
 
     snuba_results = _trace_connected_issues_snuba(

--- a/tests/sentry/issues/endpoints/test_related_issues.py
+++ b/tests/sentry/issues/endpoints/test_related_issues.py
@@ -95,6 +95,59 @@ class RelatedIssuesTest(APITestCase, SnubaTestCase, TraceTestCase):
             },
         }
 
+    def test_trace_connected_excludes_projects_member_cannot_access(self) -> None:
+        error_event, _, _ = self.load_errors(self.project)
+        assert error_event.group is not None
+        recommended_event = error_event.group.get_recommended_event_for_environments()
+        assert recommended_event is not None
+
+        self.organization.flags.allow_joinleave = False
+        self.organization.save()
+        team = self.create_team(organization=self.organization)
+        self.project.add_team(team)
+        member = self.create_user()
+        self.create_member(organization=self.organization, user=member, teams=[team])
+        self.login_as(user=member)
+
+        self.group_id = error_event.group_id
+        response = self.get_success_response(qs_params={"type": "trace_connected"})
+
+        assert response.json() == {
+            "type": "trace_connected",
+            # The connected issue lives in a project the member has no access to
+            "data": [],
+            "meta": {
+                "event_id": recommended_event.event_id,
+                "trace_id": error_event.trace_id,
+            },
+        }
+
+    def test_trace_connected_open_membership_spans_projects(self) -> None:
+        error_event, _, another_proj_event = self.load_errors(self.project)
+        assert error_event.group is not None
+        recommended_event = error_event.group.get_recommended_event_for_environments()
+        assert recommended_event is not None
+
+        team = self.create_team(organization=self.organization)
+        self.project.add_team(team)
+        member = self.create_user()
+        self.create_member(organization=self.organization, user=member, teams=[team])
+        self.login_as(user=member)
+
+        self.group_id = error_event.group_id
+        response = self.get_success_response(qs_params={"type": "trace_connected"})
+
+        assert response.json() == {
+            "type": "trace_connected",
+            # Open membership grants access to the whole organization, including the
+            # project the member has no team membership in
+            "data": [another_proj_event.group_id],
+            "meta": {
+                "event_id": recommended_event.event_id,
+                "trace_id": error_event.trace_id,
+            },
+        }
+
     def test_validation(self) -> None:
         error_event, _, _ = self.load_errors(self.project)
         self.group_id = error_event.group_id


### PR DESCRIPTION
Related issues queried every project in the organization, so the response disclosed issue ids from projects the requester cannot access whenever a trace spanned them. Authorization was only enforced on the source group, not on the issues returned.

To resolve this, extract `filter_projects_by_permissions` out into a helper and use it to filter to candidate projects. This only will tighten access for non-open membership projects.

Fixes ID-1681
