### PR TITLE
fix(monitors): Fix layout issues in monitor details page by no longer styling Layout.Body

### DIFF
--- a/static/app/components/workflowEngine/layout/detail.tsx
+++ b/static/app/components/workflowEngine/layout/detail.tsx
@@ -1,5 +1,4 @@
 import {Fragment} from 'react';
-import styled from '@emotion/styled';
 
 import {Flex, Stack} from '@sentry/scraps/layout';
 
@@ -22,15 +21,14 @@ function DetailLayoutComponent({children}: WorkflowEngineDetailLayoutProps) {
   return <Stack flex={1}>{children}</Stack>;
 }
 
-const StyledBody = styled(Layout.Body)`
-  display: flex;
-  flex-direction: column;
-  gap: ${p => p.theme.space['2xl']};
-`;
-
 interface RequiredChildren {
   children: React.ReactNode;
 }
+
+function Body({children}: RequiredChildren) {
+  return <Layout.Body gap="2xl">{children}</Layout.Body>;
+}
+
 function Main({children}: RequiredChildren) {
   return (
     <Layout.Main>
@@ -60,7 +58,7 @@ function Title({title, project}: {title: string; project?: AvatarProject}) {
 }
 
 export const DetailLayout = Object.assign(DetailLayoutComponent, {
-  Body: StyledBody,
+  Body,
   Main,
   Sidebar,
   Title,


### PR DESCRIPTION
Styling Layout.Body added `flex` which breaks the layout grid and causes the page to be in a single column layout instead of 2 when the screen is large enough