### PR TITLE
fix(replays): register delete_recording_async under the old replays namespace too

### DIFF
--- a/src/sentry/replays/tasks.py
+++ b/src/sentry/replays/tasks.py
@@ -99,6 +99,7 @@ def process_replay_recording(message_bytes: bytes) -> None:
 @instrumented_task(
     name="sentry.replays.tasks.delete_recording_async",
     namespace=replays_long_tasks,
+    alias_namespace=replays_tasks,
     processing_deadline_duration=120,
     retry=Retry(times=5, delay=5),
     silo_mode=SiloMode.CELL,


### PR DESCRIPTION
Problem: the new code registers the task only under `replays.long`. Any activation still addressed to the old `replays` name (enqueued before the cutover, or by any producer not yet on the new release) has no matching registration, so the broker discards it before execution. A dropped activation is a skipped blob delete, not a crash, but it's silent.

Fix: add `alias_namespace=replays_tasks` so the task registers under both `replays.long` and `replays`, mirroring `run_bulk_replay_delete_job` which already does this. An activation addressed to either name now resolves and runs.

Refs INC-2401