### PR TITLE
feat(autofix): Guard re-run against runs with a PR or coding agent

### DIFF
--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -415,7 +415,9 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                 if data.get("insert_index") is not None and resolved_run_id is not None:
                     try:
                         run_state = get_autofix_run_state(group, resolved_run_id)
-                    except SeerPermissionError:
+                    except SeerPermissionError as e:
+                        if _is_unknown_run_id_error(e):
+                            return Response(status=status.HTTP_404_NOT_FOUND)
                         raise PermissionDenied(SEER_PERMISSION_DENIED)
 
                     if run_state.repo_pr_states or run_state.coding_agents:

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -410,6 +410,22 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                 run_id, sentry_run_id = resolved_run_id, resolved_sentry_run_id
 
             case _:
+                # A truncating re-run would strand a PR/coding agent (they live
+                # outside the blocks). Refuse it, mirroring the frontend gate.
+                if data.get("insert_index") is not None and resolved_run_id is not None:
+                    try:
+                        run_state = get_autofix_run_state(group, resolved_run_id)
+                    except SeerPermissionError:
+                        raise PermissionDenied(SEER_PERMISSION_DENIED)
+
+                    if run_state.repo_pr_states or run_state.coding_agents:
+                        return Response(
+                            {
+                                "detail": "Cannot re-run a step after a pull request or coding agent has started"
+                            },
+                            status=status.HTTP_409_CONFLICT,
+                        )
+
                 triggered_at = timezone.now() if is_autofix_kickoff else None
                 try:
                     run = trigger_autofix_agent(

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -369,6 +369,23 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
 
     @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
     @patch("sentry.seer.endpoints.group_ai_autofix.get_autofix_run_state")
+    def test_insert_index_unknown_run_returns_404(self, mock_run_state, mock_trigger_explorer):
+        """The re-run guard surfaces an unknown run as 404, not 403."""
+        group = self.create_group()
+        mock_run_state.side_effect = SeerPermissionError("Unknown run id for group")
+
+        self.login_as(user=self.user)
+        response = self.client.post(
+            self._get_url(group.id),
+            data={"step": "solution", "run_id": 42, "insert_index": 3},
+            format="json",
+        )
+
+        assert response.status_code == 404, response.data
+        mock_trigger_explorer.assert_not_called()
+
+    @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
+    @patch("sentry.seer.endpoints.group_ai_autofix.get_autofix_run_state")
     def test_insert_index_rejected_when_coding_agent_exists(
         self, mock_run_state, mock_trigger_explorer
     ):

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -4,7 +4,13 @@ from unittest.mock import ANY, Mock, patch
 from sentry.integrations.services.integration import RpcIntegration
 from sentry.issues.action_log.types import GroupActionActor, TriggerAutofixAction
 from sentry.models.activity import Activity
-from sentry.seer.agent.client_models import MemoryBlock, Message, RepoPRState, SeerRunState
+from sentry.seer.agent.client_models import (
+    CodingAgentState,
+    MemoryBlock,
+    Message,
+    RepoPRState,
+    SeerRunState,
+)
 from sentry.seer.autofix.autofix_agent import AutofixStep, NoSeerQuotaException
 from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.autofix.github_perms import MissingGithubPermissions
@@ -303,12 +309,20 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
             enable_bash_tools=False,
         )
 
+    @patch("sentry.seer.endpoints.group_ai_autofix.get_autofix_run_state")
     @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
-    def test_insert_index_passed_through(self, mock_trigger_explorer):
+    def test_insert_index_passed_through(self, mock_trigger_explorer, mock_run_state):
         """POST passes insert_index to trigger_autofix_agent for retry-from-step."""
         group = self.create_group()
         run = self.create_seer_run(organization=self.organization, seer_run_state_id=123)
         mock_trigger_explorer.return_value = run
+        mock_run_state.return_value = SeerRunState(
+            run_id=42,
+            blocks=[],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+            repo_pr_states={},
+        )
 
         self.login_as(user=self.user)
         response = self.client.post(
@@ -329,6 +343,62 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
             user=ANY,
             enable_bash_tools=False,
         )
+
+    @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
+    @patch("sentry.seer.endpoints.group_ai_autofix.get_autofix_run_state")
+    def test_insert_index_rejected_when_pr_exists(self, mock_run_state, mock_trigger_explorer):
+        """A re-run is refused once the run has opened a PR."""
+        group = self.create_group()
+        mock_run_state.return_value = SeerRunState(
+            run_id=42,
+            blocks=[],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+            repo_pr_states={"owner/repo": RepoPRState(repo_name="owner/repo")},
+        )
+
+        self.login_as(user=self.user)
+        response = self.client.post(
+            self._get_url(group.id),
+            data={"step": "solution", "run_id": 42, "insert_index": 3},
+            format="json",
+        )
+
+        assert response.status_code == 409, response.data
+        mock_trigger_explorer.assert_not_called()
+
+    @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
+    @patch("sentry.seer.endpoints.group_ai_autofix.get_autofix_run_state")
+    def test_insert_index_rejected_when_coding_agent_exists(
+        self, mock_run_state, mock_trigger_explorer
+    ):
+        """A re-run is refused once the run has handed off to a coding agent."""
+        group = self.create_group()
+        mock_run_state.return_value = SeerRunState(
+            run_id=42,
+            blocks=[],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+            coding_agents={
+                "agent-1": CodingAgentState(
+                    id="agent-1",
+                    status="completed",
+                    provider="cursor_background_agent",
+                    name="Cursor",
+                    started_at="2024-01-01T00:00:00Z",
+                )
+            },
+        )
+
+        self.login_as(user=self.user)
+        response = self.client.post(
+            self._get_url(group.id),
+            data={"step": "solution", "run_id": 42, "insert_index": 3},
+            format="json",
+        )
+
+        assert response.status_code == 409, response.data
+        mock_trigger_explorer.assert_not_called()
 
     @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
     def test_kickoff_emits_trigger_autofix_action(self, mock_trigger):


### PR DESCRIPTION
The autofix endpoint accepts an `insert_index` to re-run from an earlier step, which truncates the run's block history. A PR's state (`repo_pr_states`) and a coding agent's state (`coding_agents`) live outside those blocks, so re-running a run that already opened a PR or handed off to a coding agent leaves that PR/agent stranded on a rewound run.

The frontend already disables the re-run button in exactly this case (`useResetAutofixStep`, added in #114204), but the endpoint is `PUBLIC` (and MCP-reachable) and performed the truncation unconditionally — so a direct API call bypassed the invariant. This adds the same gate on the server: when an `insert_index` re-run targets a run that has `repo_pr_states` or `coding_agents`, respond `409 Conflict` instead of truncating.

Scoped to the re-run path only (the `insert_index` branch); a fresh kickoff or a normal continuation is unaffected.