### PR TITLE
feat(seer): Track when all run pull requests are merged

### DIFF
--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -89,7 +89,10 @@ from sentry.pr_metrics.webhooks import handle_review_thread as pr_metrics_handle
 from sentry.preprod.vcs.webhooks import handle_preprod_check_run_event
 from sentry.scm.private.stream_producer import produce_event_to_scm_stream
 from sentry.seer.autofix.pr_iteration.mention import handle_issue_comment_for_autofix_iteration
-from sentry.seer.autofix.webhooks import handle_github_pr_webhook_for_autofix
+from sentry.seer.autofix.webhooks import (
+    handle_github_pr_webhook_for_autofix,
+    handle_pull_requests_merged_milestone,
+)
 from sentry.seer.code_review.contributor_seats import (
     record_contributor_action,
     track_contributor_seat,
@@ -1084,6 +1087,7 @@ class PullRequestEventWebhook(GitHubWebhook):
     EVENT_TYPE = IntegrationWebhookEventType.MERGE_REQUEST
     WEBHOOK_EVENT_PROCESSORS = (
         _handle_pr_webhook_for_autofix_processor,
+        handle_pull_requests_merged_milestone,
         _track_contributor_action_processor,
         code_review_handle_webhook_event,
         pr_metrics_handle_attribution,

--- a/src/sentry/seer/autofix/webhooks.py
+++ b/src/sentry/seer/autofix/webhooks.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Mapping
 from datetime import datetime
 from typing import Any, Literal
 
@@ -12,6 +13,8 @@ from sentry.analytics.events.ai_autofix_pr_events import (
     AiAutofixPrMergedEvent,
     AiAutofixPrOpenedEvent,
 )
+from sentry.integrations.github.webhook_types import GithubWebhookType
+from sentry.integrations.services.integration import RpcIntegration
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.group import Group
 from sentry.models.organization import Organization
@@ -20,8 +23,11 @@ from sentry.models.pullrequest import (
     PullRequestAttributionSignalType,
     PullRequestAttributionSource,
 )
+from sentry.models.repository import Repository
 from sentry.pr_metrics.attribution import SentryAppSignalDetails, record_attribution_signal
 from sentry.seer.agent.client_utils import get_agent_state_from_pr_id
+from sentry.seer.milestones import reconcile_pull_requests_merged_milestone
+from sentry.seer.models.run import SeerRunPullRequest
 from sentry.utils import metrics
 
 logger = logging.getLogger("sentry.webhooks")
@@ -163,6 +169,41 @@ def _record_pr_attribution(
             run_id=run_id,
         ).dict(),
     )
+
+
+def handle_pull_requests_merged_milestone(
+    *,
+    github_event: GithubWebhookType,
+    event: Mapping[str, Any],
+    organization: Organization,
+    repo: Repository,
+    integration: RpcIntegration | None = None,
+    **kwargs: Any,
+) -> None:
+    """Reconcile the run's PULL_REQUESTS_MERGED milestone when one of its PRs merges,
+    resolving the run via the SeerRunPullRequest link (covers coding-agent PRs too).
+    """
+    pull_request = event.get("pull_request")
+    if not pull_request or event.get("action") != "closed" or not pull_request.get("merged"):
+        return
+
+    number = pull_request.get("number")
+    if number is None:
+        return
+
+    link = (
+        SeerRunPullRequest.objects.select_related("seer_run")
+        .filter(
+            pull_request__organization_id=organization.id,
+            pull_request__repository_id=repo.id,
+            pull_request__key=str(number),
+        )
+        .first()
+    )
+    if link is None:
+        return
+
+    reconcile_pull_requests_merged_milestone(link.seer_run)
 
 
 def _get_pr_timestamp_ms(pull_request: dict[str, Any], action: AnalyticAction) -> int:

--- a/src/sentry/seer/milestones.py
+++ b/src/sentry/seer/milestones.py
@@ -4,13 +4,14 @@ from typing import TYPE_CHECKING
 
 from django.db import router, transaction
 
+from sentry.models.pullrequest import PullRequestLifecycleState
 from sentry.seer.models.run import SeerRun, SeerRunMilestone, SeerRunMilestoneType
 
 if TYPE_CHECKING:
     from sentry.seer.agent.client_models import SeerRunState
 
 # The milestone subset derived from and reconciled against Seer run state.
-# PULL_REQUESTS_MERGED is excluded: it is owned by the PR-merge webhook.
+# PULL_REQUESTS_MERGED is reconciled separately from linked PR lifecycle state.
 SEER_STATE_MILESTONES = frozenset(
     {
         SeerRunMilestoneType.ROOT_CAUSE,
@@ -80,3 +81,37 @@ def record_has_pull_request(seer_run: SeerRun) -> None:
     SeerRunMilestone.objects.get_or_create(
         seer_run=seer_run, milestone=SeerRunMilestoneType.HAS_PULL_REQUEST
     )
+
+
+def reconcile_pull_requests_merged_milestone(seer_run: SeerRun) -> bool:
+    """Make PULL_REQUESTS_MERGED match the current state of every linked PR.
+
+    Reconciliations for one run are serialized so concurrent link and merge events
+    cannot apply their decisions out of order.
+    """
+    database = router.db_for_write(SeerRunMilestone)
+    with transaction.atomic(using=database):
+        SeerRun.objects.select_for_update().values_list("id", flat=True).get(id=seer_run.id)
+        states = list(seer_run.pull_requests.values_list("state", flat=True))
+        milestone = SeerRunMilestone.objects.filter(
+            seer_run=seer_run,
+            milestone=SeerRunMilestoneType.PULL_REQUESTS_MERGED,
+        )
+
+        all_prs_merged = bool(states) and all(
+            state == PullRequestLifecycleState.MERGED for state in states
+        )
+        if not all_prs_merged:
+            milestone.delete()
+            return False
+
+        SeerRunMilestone.objects.bulk_create(
+            [
+                SeerRunMilestone(
+                    seer_run=seer_run,
+                    milestone=SeerRunMilestoneType.PULL_REQUESTS_MERGED,
+                )
+            ],
+            ignore_conflicts=True,
+        )
+        return True

--- a/src/sentry/seer/pull_requests.py
+++ b/src/sentry/seer/pull_requests.py
@@ -11,6 +11,7 @@ from sentry.models.organization import Organization, OrganizationStatus
 from sentry.models.pullrequest import PullRequest
 from sentry.pr_metrics.attribution import attribute_seer_created_pull_requests
 from sentry.seer.endpoints.utils import get_seer_run
+from sentry.seer.milestones import reconcile_pull_requests_merged_milestone
 from sentry.seer.models.run import SeerRun, SeerRunCodingAgentHandoff, SeerRunPullRequest
 from sentry.seer.sentry_data_models import (
     NotifySeerPrCreatedErrorResponse,
@@ -123,6 +124,13 @@ def link_pull_request_to_seer_run(
             "seer.pr_link.created",
             extra={**log_context, "pull_request_id": resolved.pull_request.id},
         )
+        try:
+            reconcile_pull_requests_merged_milestone(seer_run)
+        except Exception:
+            logger.exception(
+                "seer.pr_link.milestone_failed",
+                extra={**log_context, "pull_request_id": resolved.pull_request.id},
+            )
 
     return resolved.pull_request
 

--- a/tests/sentry/integrations/github/test_webhook.py
+++ b/tests/sentry/integrations/github/test_webhook.py
@@ -52,6 +52,7 @@ from sentry.models.pullrequest import (
 )
 from sentry.models.repository import Repository
 from sentry.pr_metrics.webhooks import handle_check_suite as pr_metrics_handle_check_suite
+from sentry.seer.models.run import SeerRunMilestone, SeerRunMilestoneType
 from sentry.silo.base import SiloMode
 from sentry.testutils.asserts import assert_failure_metric, assert_success_metric
 from sentry.testutils.cases import APITestCase, TestCase
@@ -1974,6 +1975,70 @@ class PullRequestEventWebhookTest(APITestCase):
         assert pr.draft is None
 
         assert mock_metrics.incr.call_count == 1
+
+    def _repo_for_pull_request_events(self) -> Repository:
+        future_expires = datetime.now().replace(microsecond=0) + timedelta(minutes=5)
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            integration = self.create_integration(
+                organization=self.organization,
+                external_id="12345",
+                provider="github",
+                metadata={"access_token": "1234", "expires_at": future_expires.isoformat()},
+            )
+            integration.add_organization(self.project.organization.id, self.user)
+
+        return Repository.objects.create(
+            organization_id=self.project.organization.id,
+            external_id="35129377",
+            provider="integrations:github",
+            name="baxterthehacker/public-repo",
+            integration_id=integration.id,
+        )
+
+    def test_merged_records_seer_run_milestone(self) -> None:
+        repo = self._repo_for_pull_request_events()
+        seer_run = self.create_seer_run(organization=self.organization)
+        pull_request = self.create_pull_request(
+            repository_id=repo.id, organization_id=self.project.organization.id, key="1"
+        )
+        self.create_seer_run_pull_request(run=seer_run, pull_request=pull_request)
+
+        self._post_pull_request_event(PULL_REQUEST_CLOSED_EVENT_EXAMPLE)
+
+        assert SeerRunMilestone.objects.filter(
+            seer_run=seer_run, milestone=SeerRunMilestoneType.PULL_REQUESTS_MERGED
+        ).exists()
+
+    def test_merged_does_not_record_milestone_while_a_run_pull_request_is_open(self) -> None:
+        repo = self._repo_for_pull_request_events()
+        seer_run = self.create_seer_run(organization=self.organization)
+        merged_pr = self.create_pull_request(
+            repository_id=repo.id, organization_id=self.project.organization.id, key="1"
+        )
+        self.create_seer_run_pull_request(run=seer_run, pull_request=merged_pr)
+        open_pr = self.create_pull_request(
+            repository_id=repo.id, organization_id=self.project.organization.id, key="2"
+        )
+        open_pr.update(state=PullRequestLifecycleState.OPEN)
+        self.create_seer_run_pull_request(run=seer_run, pull_request=open_pr)
+
+        self._post_pull_request_event(PULL_REQUEST_CLOSED_EVENT_EXAMPLE)
+
+        assert not SeerRunMilestone.objects.filter(seer_run=seer_run).exists()
+
+    def test_closed_unmerged_does_not_record_seer_run_milestone(self) -> None:
+        repo = self._repo_for_pull_request_events()
+        seer_run = self.create_seer_run(organization=self.organization)
+        pull_request = self.create_pull_request(
+            repository_id=repo.id, organization_id=self.project.organization.id, key="1"
+        )
+        self.create_seer_run_pull_request(run=seer_run, pull_request=pull_request)
+
+        closed = json.loads(PULL_REQUEST_CLOSED_EVENT_EXAMPLE)
+        closed["pull_request"]["merged"] = False
+        self._post_pull_request_event(json.dumps(closed).encode())
+
+        assert not SeerRunMilestone.objects.filter(seer_run=seer_run).exists()
 
     @patch("sentry.integrations.github.webhook.track_contributor_seat")
     def test_pr_lifecycle_activities_are_attributed_to_acting_user(

--- a/tests/sentry/seer/test_milestones.py
+++ b/tests/sentry/seer/test_milestones.py
@@ -1,3 +1,4 @@
+from sentry.models.pullrequest import PullRequestLifecycleState
 from sentry.seer.agent.client_models import (
     AgentFilePatch,
     Artifact,
@@ -13,6 +14,7 @@ from sentry.seer.milestones import (
     SEER_STATE_MILESTONES,
     milestones_from_state,
     reconcile_milestones,
+    reconcile_pull_requests_merged_milestone,
     record_has_pull_request,
 )
 from sentry.seer.models.run import SeerRunMilestone, SeerRunMilestoneType
@@ -192,3 +194,95 @@ class RecordHasPullRequestTest(TestCase):
             SeerRunMilestoneType.HAS_PULL_REQUEST,
         }
         assert SeerRunMilestone.objects.filter(seer_run=self.seer_run).count() == 2
+
+
+class ReconcilePullRequestsMergedMilestoneTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.seer_run = self.create_seer_run(organization=self.organization)
+        self.repo = self.create_repo(self.project, name="getsentry/sentry")
+
+    def _recorded(self) -> set[str]:
+        return set(
+            SeerRunMilestone.objects.filter(seer_run=self.seer_run).values_list(
+                "milestone", flat=True
+            )
+        )
+
+    def _linked_pull_request(self, key: str, state: str) -> None:
+        pull_request = self.create_pull_request(
+            repository_id=self.repo.id, organization_id=self.organization.id, key=key
+        )
+        pull_request.update(state=state)
+        self.create_seer_run_pull_request(run=self.seer_run, pull_request=pull_request)
+
+    def test_records_when_all_linked_pull_requests_merged(self) -> None:
+        self._linked_pull_request("1", PullRequestLifecycleState.MERGED)
+        self._linked_pull_request("2", PullRequestLifecycleState.MERGED)
+
+        assert reconcile_pull_requests_merged_milestone(self.seer_run) is True
+        assert self._recorded() == {SeerRunMilestoneType.PULL_REQUESTS_MERGED}
+
+    def test_not_recorded_when_a_linked_pull_request_is_open(self) -> None:
+        self._linked_pull_request("1", PullRequestLifecycleState.MERGED)
+        self._linked_pull_request("2", PullRequestLifecycleState.OPEN)
+
+        assert reconcile_pull_requests_merged_milestone(self.seer_run) is False
+        assert self._recorded() == set()
+
+    def test_removes_milestone_when_an_open_pull_request_is_linked(self) -> None:
+        self._linked_pull_request("1", PullRequestLifecycleState.MERGED)
+        assert reconcile_pull_requests_merged_milestone(self.seer_run) is True
+
+        self._linked_pull_request("2", PullRequestLifecycleState.OPEN)
+
+        assert reconcile_pull_requests_merged_milestone(self.seer_run) is False
+        assert self._recorded() == set()
+
+        pull_request = self.seer_run.pull_requests.get(key="2")
+        pull_request.update(state=PullRequestLifecycleState.MERGED)
+
+        assert reconcile_pull_requests_merged_milestone(self.seer_run) is True
+        assert self._recorded() == {SeerRunMilestoneType.PULL_REQUESTS_MERGED}
+
+    def test_not_recorded_when_a_linked_pull_request_is_closed_unmerged(self) -> None:
+        self._linked_pull_request("1", PullRequestLifecycleState.CLOSED)
+
+        assert reconcile_pull_requests_merged_milestone(self.seer_run) is False
+        assert self._recorded() == set()
+
+    def test_not_recorded_without_linked_pull_requests(self) -> None:
+        assert reconcile_pull_requests_merged_milestone(self.seer_run) is False
+        assert self._recorded() == set()
+
+    def test_idempotent(self) -> None:
+        self._linked_pull_request("1", PullRequestLifecycleState.MERGED)
+
+        assert reconcile_pull_requests_merged_milestone(self.seer_run) is True
+        assert reconcile_pull_requests_merged_milestone(self.seer_run) is True
+        assert (
+            SeerRunMilestone.objects.filter(
+                seer_run=self.seer_run, milestone=SeerRunMilestoneType.PULL_REQUESTS_MERGED
+            ).count()
+            == 1
+        )
+
+    def test_leaves_state_derived_milestones_untouched(self) -> None:
+        reconcile_milestones(self.seer_run, _state_reaching(set(SEER_STATE_MILESTONES)))
+        self._linked_pull_request("1", PullRequestLifecycleState.MERGED)
+
+        reconcile_pull_requests_merged_milestone(self.seer_run)
+
+        assert self._recorded() == set(SEER_STATE_MILESTONES) | {
+            SeerRunMilestoneType.PULL_REQUESTS_MERGED
+        }
+
+    def test_removes_only_pull_requests_merged_milestone(self) -> None:
+        reconcile_milestones(self.seer_run, _state_reaching(set(SEER_STATE_MILESTONES)))
+        self._linked_pull_request("1", PullRequestLifecycleState.MERGED)
+        assert reconcile_pull_requests_merged_milestone(self.seer_run) is True
+
+        self._linked_pull_request("2", PullRequestLifecycleState.OPEN)
+        assert reconcile_pull_requests_merged_milestone(self.seer_run) is False
+
+        assert self._recorded() == set(SEER_STATE_MILESTONES)

--- a/tests/sentry/seer/test_pull_requests.py
+++ b/tests/sentry/seer/test_pull_requests.py
@@ -6,8 +6,15 @@ from sentry.models.pullrequest import (
     PullRequestAttribution,
     PullRequestAttributionSignalType,
     PullRequestAttributionSource,
+    PullRequestLifecycleState,
 )
-from sentry.seer.models.run import SeerRun, SeerRunPullRequest, SeerRunType
+from sentry.seer.models.run import (
+    SeerRun,
+    SeerRunMilestone,
+    SeerRunMilestoneType,
+    SeerRunPullRequest,
+    SeerRunType,
+)
 from sentry.seer.pull_requests import link_seer_run_pull_requests, notify_seer_pr_created
 from sentry.seer.sentry_data_models import (
     NotifySeerPrCreatedErrorResponse,
@@ -63,6 +70,47 @@ class LinkSeerRunPullRequestsTest(TestCase):
         link = SeerRunPullRequest.objects.get(pull_request=pull_request)
         assert link.seer_run_id == self.seer_run.id
         assert list(self.seer_run.pull_requests) == [pull_request]
+
+    def test_records_milestone_when_merged_pull_request_is_linked(self) -> None:
+        pull_request = self.create_pull_request(
+            repository_id=self.repo.id,
+            organization_id=self.organization.id,
+            key="42",
+        )
+        pull_request.update(state=PullRequestLifecycleState.MERGED)
+
+        self._link(self._payload())
+
+        assert SeerRunMilestone.objects.filter(
+            seer_run=self.seer_run,
+            milestone=SeerRunMilestoneType.PULL_REQUESTS_MERGED,
+        ).exists()
+
+    def test_removes_milestone_when_open_pull_request_is_linked(self) -> None:
+        merged_pull_request = self.create_pull_request(
+            repository_id=self.repo.id,
+            organization_id=self.organization.id,
+            key="42",
+        )
+        merged_pull_request.update(state=PullRequestLifecycleState.MERGED)
+        self._link(self._payload())
+        assert SeerRunMilestone.objects.filter(
+            seer_run=self.seer_run,
+            milestone=SeerRunMilestoneType.PULL_REQUESTS_MERGED,
+        ).exists()
+
+        open_pull_request = self.create_pull_request(
+            repository_id=self.repo.id,
+            organization_id=self.organization.id,
+            key="43",
+        )
+        open_pull_request.update(state=PullRequestLifecycleState.OPEN)
+        self._link(self._payload(pr_number=43))
+
+        assert not SeerRunMilestone.objects.filter(
+            seer_run=self.seer_run,
+            milestone=SeerRunMilestoneType.PULL_REQUESTS_MERGED,
+        ).exists()
 
     def test_first_run_keeps_pull_request(self) -> None:
         self._link(self._payload())


### PR DESCRIPTION
Tracks `pull_requests_merged` as the current aggregate state of every pull request linked to a Seer run. GitHub merge webhooks reconcile the milestone after the canonical pull-request lifecycle update, while new run links also reconcile it so merge-before-link delivery is recovered.

Reconciliation is serialized per run and inserts or removes only `PULL_REQUESTS_MERGED`. A later open pull request therefore clears stale state without affecting milestones derived from Seer run state. The shared link path covers both Seer-native and coding-agent pull requests.

**Stacked on #121111.** Review and merge that PR first. GitLab lifecycle support is tracked separately in AIML-3271.
