### PR TITLE
perf(grouping): Avoid serializing exceptions for enhancements

### DIFF
--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -5,7 +5,7 @@ import logging
 import os
 import re
 import zlib
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from functools import cached_property
 from typing import Any, Literal, overload
@@ -129,10 +129,15 @@ def _make_rust_exception_data(
     exception_data: dict[str, Any] | None,
 ) -> RustExceptionData:
     exception_data = exception_data or {}
+    mechanism = exception_data.get("mechanism")
     rust_data = {
         "type": exception_data.get("type"),
         "value": exception_data.get("value"),
-        "mechanism": get_path(exception_data, "mechanism", "type"),
+        "mechanism": (
+            mechanism.get("type")
+            if isinstance(mechanism, Mapping)
+            else getattr(mechanism, "type", None)
+        ),
     }
 
     # Convert string values to bytes

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -580,7 +580,7 @@ def single_exception(
 
     if exception.stacktrace is not None:
         with context:
-            context["exception_data"] = exception.to_json()
+            context["exception_data"] = exception.get_raw_data()
             stacktrace_components_by_variant: dict[str, StacktraceGroupingComponent] = (
                 get_grouping_components_by_variant(exception.stacktrace, event, context, **kwargs)
             )

--- a/tests/sentry/grouping/test_components.py
+++ b/tests/sentry/grouping/test_components.py
@@ -125,6 +125,28 @@ class ComponentTest(TestCase):
 
             assert [frame_component.in_app for frame_component in frame_components] == [False, True]
 
+    def test_exception_enhancements_apply_during_grouping(self) -> None:
+        self.event.data["exception"]["values"][0].update(
+            {
+                "mechanism": {"type": "signal"},
+                "stacktrace": {"frames": [self.contributing_in_app_frame]},
+            }
+        )
+        self.project.update_option(
+            "sentry:grouping_enhancements",
+            "error.type:FailedToFetchError error.value:Charlie* error.mechanism:signal -group",
+        )
+
+        variants = self.event.get_grouping_variants(normalize_stacktraces=True)
+
+        for variant_name in ["app", "system"]:
+            exception_component = variants[variant_name].root_component.values[0]
+            assert isinstance(exception_component, ExceptionGroupingComponent)
+            stacktrace_component = find_given_child_component(
+                exception_component, StacktraceGroupingComponent
+            )
+            assert stacktrace_component.contributes is False
+
     def test_stacktrace_component_tallies_frame_types_simple(self) -> None:
         self.event.data["exception"]["values"][0]["stacktrace"] = {
             "frames": (


### PR DESCRIPTION
`single_exception` calls `exception.to_json()` just to give grouping enhancements the exception type, value, and mechanism. For exceptions with stacktraces, that also rebuilds every processed and raw frame.

`get_raw_data()` already has those three fields, so pass that instead. The conversion helper now handles the normalized `Mechanism` object, and the event-level test covers type, value, and mechanism matching through normal grouping.

For an exception with 100 processed and 100 raw frames, this took the conversion from 369 µs / 40.6 KB to 0.68 µs / 849 B in a local microbenchmark.