### PR TITLE
fix(eventstore): Measure stored event size in bytes

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2560,10 +2560,8 @@ def _materialize_event_metrics(jobs: Sequence[Job]) -> None:
         event_metrics = job["event"].data.get("_metrics") or {}
         job["event"].data["_metrics"] = event_metrics
 
-        # Capture the actual size that goes into node store.
-        event_metrics["bytes.stored.event"] = len(
-            orjson.dumps(dict(job["event"].data.items())).decode()
-        )
+        # Capture the UTF-8 serialized event size for node store accounting.
+        event_metrics["bytes.stored.event"] = len(orjson.dumps(dict(job["event"].data.items())))
 
         for metric_name in ("flag.processing.error", "flag.processing.fatal"):
             if event_metrics.get(metric_name):

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -9,6 +9,7 @@ from typing import Any
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
+import orjson
 import pytest
 from arroyo.backends.kafka.consumer import KafkaPayload
 from arroyo.backends.local.backend import LocalBroker
@@ -4343,6 +4344,15 @@ example_error_event = {
             "errors",
             id="errors",
         ),
+        pytest.param(
+            {
+                **example_error_event,
+                "event_id": "a0e3496eff734ab0ac993167aaa0d1cd",
+                "message": "é" * 10_000,
+            },
+            "errors",
+            id="errors-non-ascii",
+        ),
     ],
 )
 @django_db_all
@@ -4368,7 +4378,7 @@ def test_cogs_event_manager(
         normalized_data = dict(manager.get_data())
         _ = manager.save(default_project)
 
-        expected_len = len(json.dumps(normalized_data))
+        expected_len = len(orjson.dumps(normalized_data))
 
     msg1 = broker.consume(Partition(topic, 0), 0)
     assert msg1 is not None


### PR DESCRIPTION
`bytes.stored.event` feeds Nodestore COGS accounting as bytes, but decoding the `orjson` payload before calling `len()` makes non-ASCII events report Unicode codepoints. Measure the serialized UTF-8 bytes directly instead. ASCII events are unchanged; non-ASCII errors, transactions, and generic events report a larger and more accurate value.

This is still the logical uncompressed payload size, not physical compressed Bigtable bytes. The existing COGS integration test now includes non-ASCII input; before this change it reported 10,272 bytes for an event whose normalized UTF-8 serialization was already at least 17,364 bytes.

Microbenchmark, median of 7 runs:

| Payload | Before | After | Time saved | String allocation removed |
|---:|---:|---:|---:|---:|
| 10 KB | 0.834 µs | 0.457 µs | 45% | 10 KB |
| 100 KB | 6.647 µs | 2.955 µs | 56% | 100 KB |
| 1 MB | 59.198 µs | 27.535 µs | 53% | 1 MB |

The decoded length came through the `orjson` rollout in #69653 and was later inlined by #70133.