### PR TITLE
ref(dynamic-sampling): Slim down per-org configuration tests

### DIFF
--- a/tests/sentry/dynamic_sampling/per_org/test_configuration.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_configuration.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import ExitStack, contextmanager
 from datetime import timedelta
-from typing import NamedTuple
-from unittest.mock import patch
+from typing import Any, NamedTuple
+from unittest.mock import DEFAULT, MagicMock, patch
 
 import pytest
 from django.core.exceptions import ObjectDoesNotExist
 
+from sentry.dynamic_sampling.models.common import RebalancedItem
 from sentry.dynamic_sampling.per_org.configuration import (
     AutomaticDynamicSamplingConfiguration,
+    BaseDynamicSamplingConfiguration,
     CustomDynamicSamplingOrganizationConfiguration,
     CustomDynamicSamplingProjectConfiguration,
     NoDynamicSamplingConfiguration,
@@ -25,7 +28,34 @@ from sentry.dynamic_sampling.types import DynamicSamplingMode, SamplingMeasure
 from sentry.models.organization import Organization
 from sentry.testutils.cases import TestCase
 
+CONFIGURATION = "sentry.dynamic_sampling.per_org.configuration"
+BLENDED_SAMPLE_RATE = f"{CONFIGURATION}.quotas.backend.get_blended_sample_rate"
+OUTCOMES_VOLUME = f"{CONFIGURATION}.get_outcomes_organization_volume"
+SLIDING_WINDOW_RATE = f"{CONFIGURATION}.compute_sliding_window_sample_rate"
+
 SpanOrgIds = Callable[[Organization], list[int]]
+
+
+@contextmanager
+def patch_configuration(targets: dict[str, Any]) -> Iterator[dict[str, MagicMock]]:
+    """Patch targets in the configuration module, each with the given return value.
+
+    Pass ``DEFAULT`` as the return value to patch a target without one. The yielded
+    mocks are keyed by target so that callers can assert on the calls.
+    """
+    with ExitStack() as stack:
+        yield {
+            target: stack.enter_context(patch(target, return_value=return_value))
+            for target, return_value in targets.items()
+        }
+
+
+def assert_measure(
+    configuration: BaseDynamicSamplingConfiguration, expected: SamplingMeasure
+) -> None:
+    assert configuration.measure == expected
+    assert configuration.is_span_based == (expected == SamplingMeasure.SPANS)
+    assert configuration.is_segment_based == (expected == SamplingMeasure.SEGMENTS)
 
 
 class MeasureOptionCase(NamedTuple):
@@ -51,23 +81,26 @@ MEASURE_OPTION_CASES = (
 
 
 class DynamicSamplingOrgConfigurationTest(TestCase):
+    def measure_options(self, case: MeasureOptionCase, organization: Organization) -> Any:
+        return self.options(
+            {
+                "dynamic-sampling.check_span_feature_flag": case.check_span_feature_flag,
+                "dynamic-sampling.measure.spans": case.span_org_ids(organization),
+            }
+        )
+
     def test_subscription_backed_org_uses_blended_sample_rate(self) -> None:
         org = self.create_organization()
 
-        with patch(
-            "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate",
-            return_value=0.5,
-        ) as get_blended_sample_rate:
+        with patch_configuration({BLENDED_SAMPLE_RATE: 0.5}) as mocks:
             configuration = get_configuration(org.id)
 
         assert isinstance(configuration, AutomaticDynamicSamplingConfiguration)
         assert configuration.is_enabled
-        assert configuration.measure == SamplingMeasure.SEGMENTS
-        assert configuration.is_segment_based
-        assert not configuration.is_span_based
+        assert_measure(configuration, SamplingMeasure.SEGMENTS)
         assert configuration.sample_rate == 0.5
         assert configuration.project_sample_rates == {}
-        get_blended_sample_rate.assert_called_once_with(organization_id=org.id)
+        mocks[BLENDED_SAMPLE_RATE].assert_called_once_with(organization_id=org.id)
         assert configuration.get_sample_rate() == 0.5
 
     def test_subscription_backed_org_uses_outcomes_sliding_window_sample_rate(self) -> None:
@@ -75,31 +108,24 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
         self.create_project(organization=org)
         sliding_window_volume = OrganizationDataVolume(org_id=org.id, total=1000, indexed=250)
 
-        with (
-            patch(
-                "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate",
-                return_value=0.5,
-            ),
-            patch(
-                "sentry.dynamic_sampling.per_org.configuration.get_outcomes_organization_volume",
-                return_value=sliding_window_volume,
-            ) as get_volume,
-            patch(
-                "sentry.dynamic_sampling.per_org.configuration.compute_sliding_window_sample_rate",
-                return_value=0.25,
-            ) as compute_sample_rate,
-        ):
+        with patch_configuration(
+            {
+                BLENDED_SAMPLE_RATE: 0.5,
+                OUTCOMES_VOLUME: sliding_window_volume,
+                SLIDING_WINDOW_RATE: 0.25,
+            }
+        ) as mocks:
             configuration = get_configuration(org.id)
 
         assert isinstance(configuration, AutomaticDynamicSamplingConfiguration)
         assert configuration.get_sample_rate() == 0.25
         # Blended rate is below 100%, so serving is not gated and matches the usage rate.
         assert configuration.get_serving_sample_rate() == 0.25
-        get_volume.assert_called_once()
-        assert get_volume.call_args.kwargs["time_interval"] == timedelta(
+        mocks[OUTCOMES_VOLUME].assert_called_once()
+        assert mocks[OUTCOMES_VOLUME].call_args.kwargs["time_interval"] == timedelta(
             hours=FALLBACK_SLIDING_WINDOW_SIZE
         )
-        compute_sample_rate.assert_called_once_with(
+        mocks[SLIDING_WINDOW_RATE].assert_called_once_with(
             org_id=org.id,
             project_id=None,
             total_root_count=1000,
@@ -111,19 +137,12 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
         self.create_project(organization=org)
         sliding_window_volume = OrganizationDataVolume(org_id=org.id, total=1000, indexed=250)
 
-        with (
-            patch(
-                "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate",
-                return_value=1.0,
-            ),
-            patch(
-                "sentry.dynamic_sampling.per_org.configuration.get_outcomes_organization_volume",
-                return_value=sliding_window_volume,
-            ),
-            patch(
-                "sentry.dynamic_sampling.per_org.configuration.compute_sliding_window_sample_rate",
-                return_value=0.25,
-            ),
+        with patch_configuration(
+            {
+                BLENDED_SAMPLE_RATE: 1.0,
+                OUTCOMES_VOLUME: sliding_window_volume,
+                SLIDING_WINDOW_RATE: 0.25,
+            }
         ):
             configuration = get_configuration(org.id)
 
@@ -140,43 +159,29 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
         org = self.create_organization()
         self.create_project(organization=org)
 
-        with (
-            patch(
-                "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate",
-                return_value=0.5,
-            ),
-            patch(
-                "sentry.dynamic_sampling.per_org.configuration.get_outcomes_organization_volume",
-                return_value=None,
-            ),
-            patch(
-                "sentry.dynamic_sampling.per_org.configuration.compute_sliding_window_sample_rate",
-            ) as compute_sample_rate,
-        ):
+        with patch_configuration(
+            {
+                BLENDED_SAMPLE_RATE: 0.5,
+                OUTCOMES_VOLUME: None,
+                SLIDING_WINDOW_RATE: DEFAULT,
+            }
+        ) as mocks:
             configuration = get_configuration(org.id)
 
         assert isinstance(configuration, AutomaticDynamicSamplingConfiguration)
         assert configuration.get_sample_rate() == 0.5
-        compute_sample_rate.assert_not_called()
+        mocks[SLIDING_WINDOW_RATE].assert_not_called()
 
     def test_subscription_backed_org_without_sample_rate_is_disabled(self) -> None:
         org = self.create_organization()
         self.create_project(organization=org)
 
-        with (
-            patch(
-                "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate",
-                return_value=None,
-            ),
-            patch(
-                "sentry.dynamic_sampling.per_org.configuration.get_outcomes_organization_volume",
-            ) as get_volume,
-        ):
+        with patch_configuration({BLENDED_SAMPLE_RATE: None, OUTCOMES_VOLUME: DEFAULT}) as mocks:
             configuration = get_configuration(org.id)
 
         assert isinstance(configuration, NoDynamicSamplingConfiguration)
         assert not configuration.is_enabled
-        get_volume.assert_not_called()
+        mocks[OUTCOMES_VOLUME].assert_not_called()
         with pytest.raises(AttributeError):
             getattr(configuration, "measure")
         with pytest.raises(AttributeError):
@@ -186,10 +191,7 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
         org = self.create_organization()
 
         with (
-            patch(
-                "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate",
-                side_effect=ObjectDoesNotExist,
-            ),
+            patch(BLENDED_SAMPLE_RATE, side_effect=ObjectDoesNotExist),
             pytest.raises(DynamicSamplingException) as exc_info,
         ):
             get_configuration(org.id)
@@ -200,10 +202,7 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
         org = self.create_organization()
         org.update_option("sentry:sampling_mode", DynamicSamplingMode.PROJECT)
 
-        with patch(
-            "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate",
-            return_value=0.5,
-        ):
+        with patch_configuration({BLENDED_SAMPLE_RATE: 0.5}):
             configuration = get_configuration(org.id)
 
         assert isinstance(configuration, AutomaticDynamicSamplingConfiguration)
@@ -211,42 +210,29 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
         assert configuration.project_sample_rates == {}
 
     def test_org_mode_custom_dynamic_sampling_uses_org_target_sample_rate(self) -> None:
-        for measure_case in MEASURE_OPTION_CASES:
-            with self.subTest(measure_case=measure_case.name):
+        for case in MEASURE_OPTION_CASES:
+            with self.subTest(measure_case=case.name):
                 org = self.create_organization()
                 org.update_option("sentry:target_sample_rate", 0.3)
 
                 with (
                     self.feature("organizations:dynamic-sampling-custom"),
-                    self.options(
-                        {
-                            "dynamic-sampling.check_span_feature_flag": measure_case.check_span_feature_flag,
-                            "dynamic-sampling.measure.spans": measure_case.span_org_ids(org),
-                        }
-                    ),
-                    patch(
-                        "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate"
-                    ) as get_blended_sample_rate,
+                    self.measure_options(case, org),
+                    patch_configuration({BLENDED_SAMPLE_RATE: DEFAULT}) as mocks,
                 ):
                     configuration = get_configuration(org.id)
 
                 assert isinstance(configuration, CustomDynamicSamplingOrganizationConfiguration)
                 assert configuration.is_enabled
-                assert configuration.measure == measure_case.expected_measure
-                assert configuration.is_span_based == (
-                    measure_case.expected_measure == SamplingMeasure.SPANS
-                )
-                assert configuration.is_segment_based == (
-                    measure_case.expected_measure == SamplingMeasure.SEGMENTS
-                )
+                assert_measure(configuration, case.expected_measure)
                 assert configuration.sample_rate == 0.3
                 assert configuration.get_sample_rate() == 0.3
                 assert configuration.project_sample_rates == {}
-                get_blended_sample_rate.assert_not_called()
+                mocks[BLENDED_SAMPLE_RATE].assert_not_called()
 
     def test_project_mode_custom_dynamic_sampling_stores_project_sample_rates(self) -> None:
-        for measure_case in MEASURE_OPTION_CASES:
-            with self.subTest(measure_case=measure_case.name):
+        for case in MEASURE_OPTION_CASES:
+            with self.subTest(measure_case=case.name):
                 org = self.create_organization()
                 project = self.create_project(organization=org)
                 project_without_rate = self.create_project(organization=org)
@@ -255,27 +241,14 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
 
                 with (
                     self.feature("organizations:dynamic-sampling-custom"),
-                    self.options(
-                        {
-                            "dynamic-sampling.check_span_feature_flag": measure_case.check_span_feature_flag,
-                            "dynamic-sampling.measure.spans": measure_case.span_org_ids(org),
-                        }
-                    ),
-                    patch(
-                        "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate"
-                    ) as get_blended_sample_rate,
+                    self.measure_options(case, org),
+                    patch_configuration({BLENDED_SAMPLE_RATE: DEFAULT}) as mocks,
                 ):
                     configuration = get_configuration(org.id)
 
                 assert isinstance(configuration, CustomDynamicSamplingProjectConfiguration)
                 assert configuration.is_enabled
-                assert configuration.measure == measure_case.expected_measure
-                assert configuration.is_span_based == (
-                    measure_case.expected_measure == SamplingMeasure.SPANS
-                )
-                assert configuration.is_segment_based == (
-                    measure_case.expected_measure == SamplingMeasure.SEGMENTS
-                )
+                assert_measure(configuration, case.expected_measure)
                 assert configuration.project_sample_rates == {
                     project.id: 0.2,
                     project_without_rate.id: None,
@@ -283,87 +256,63 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
                 assert configuration.get_sample_rate() is None
                 with pytest.raises(AttributeError):
                     getattr(configuration, "sample_rate")
-                get_blended_sample_rate.assert_not_called()
+                mocks[BLENDED_SAMPLE_RATE].assert_not_called()
 
     def test_project_mode_custom_dynamic_sampling_without_project_rates_is_disabled(
         self,
     ) -> None:
-        for measure_case in MEASURE_OPTION_CASES:
-            with self.subTest(measure_case=measure_case.name):
+        for case in MEASURE_OPTION_CASES:
+            with self.subTest(measure_case=case.name):
                 org = self.create_organization()
                 project = self.create_project(organization=org)
                 org.update_option("sentry:sampling_mode", DynamicSamplingMode.PROJECT)
 
                 with (
                     self.feature("organizations:dynamic-sampling-custom"),
-                    self.options(
-                        {
-                            "dynamic-sampling.check_span_feature_flag": measure_case.check_span_feature_flag,
-                            "dynamic-sampling.measure.spans": measure_case.span_org_ids(org),
-                        }
-                    ),
+                    self.measure_options(case, org),
                 ):
                     configuration = get_configuration(org.id)
 
                 assert isinstance(configuration, CustomDynamicSamplingProjectConfiguration)
                 assert not configuration.is_enabled
-                assert configuration.measure == measure_case.expected_measure
+                assert configuration.measure == case.expected_measure
                 assert configuration.project_sample_rates == {project.id: None}
                 with pytest.raises(AttributeError):
                     getattr(configuration, "sample_rate")
 
     def test_project_mode_custom_dynamic_sampling_without_projects_is_disabled(self) -> None:
-        for measure_case in MEASURE_OPTION_CASES:
-            with self.subTest(measure_case=measure_case.name):
+        for case in MEASURE_OPTION_CASES:
+            with self.subTest(measure_case=case.name):
                 org = self.create_organization()
                 org.update_option("sentry:sampling_mode", DynamicSamplingMode.PROJECT)
 
                 with (
                     self.feature("organizations:dynamic-sampling-custom"),
-                    self.options(
-                        {
-                            "dynamic-sampling.check_span_feature_flag": measure_case.check_span_feature_flag,
-                            "dynamic-sampling.measure.spans": measure_case.span_org_ids(org),
-                        }
-                    ),
+                    self.measure_options(case, org),
                 ):
                     configuration = get_configuration(org.id)
 
                 assert isinstance(configuration, CustomDynamicSamplingProjectConfiguration)
                 assert not configuration.is_enabled
-                assert configuration.measure == measure_case.expected_measure
+                assert configuration.measure == case.expected_measure
                 assert configuration.project_sample_rates == {}
                 with pytest.raises(AttributeError):
                     getattr(configuration, "sample_rate")
 
     def test_subscription_backed_org_uses_measure_options(self) -> None:
-        for measure_case in MEASURE_OPTION_CASES:
-            with self.subTest(measure_case=measure_case.name):
+        for case in MEASURE_OPTION_CASES:
+            with self.subTest(measure_case=case.name):
                 org = self.create_organization()
 
                 with (
-                    self.options(
-                        {
-                            "dynamic-sampling.check_span_feature_flag": measure_case.check_span_feature_flag,
-                            "dynamic-sampling.measure.spans": measure_case.span_org_ids(org),
-                        }
-                    ),
-                    patch(
-                        "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate",
-                        return_value=1.0,
-                    ),
+                    self.measure_options(case, org),
+                    patch_configuration({BLENDED_SAMPLE_RATE: 1.0}),
                 ):
                     configuration = get_configuration(org.id)
 
                 assert isinstance(configuration, AutomaticDynamicSamplingConfiguration)
                 assert configuration.is_enabled
-                assert configuration.measure == measure_case.expected_measure
-                assert configuration.is_span_based == (
-                    measure_case.expected_measure == SamplingMeasure.SPANS
-                )
-                assert configuration.is_segment_based == (
-                    measure_case.expected_measure == SamplingMeasure.SEGMENTS
-                )
+                assert_measure(configuration, case.expected_measure)
                 assert configuration.sample_rate == 1.0
 
 
@@ -390,8 +339,6 @@ class GetProjectSampleRatesTest(TestCase):
         }
 
     def test_org_mode_uses_rebalanced_project_rates(self) -> None:
-        from sentry.dynamic_sampling.models.common import RebalancedItem
-
         org = self.create_organization()
         project_a = self.create_project(organization=org)
         project_b = self.create_project(organization=org)
@@ -430,15 +377,10 @@ class GetProjectSampleRatesTest(TestCase):
         assert configuration.get_project_sample_rates() == {}
 
     def test_automatic_mode_uses_rebalanced_project_rates(self) -> None:
-        from sentry.dynamic_sampling.models.common import RebalancedItem
-
         org = self.create_organization()
         project = self.create_project(organization=org)
 
-        with patch(
-            "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate",
-            return_value=0.5,
-        ):
+        with patch_configuration({BLENDED_SAMPLE_RATE: 0.5}):
             configuration = get_configuration(org.id)
 
         assert isinstance(configuration, AutomaticDynamicSamplingConfiguration)
@@ -452,10 +394,7 @@ class GetProjectSampleRatesTest(TestCase):
         self.create_project(organization=org)
         self.create_project(organization=org)
 
-        with patch(
-            "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate",
-            return_value=0.5,
-        ):
+        with patch_configuration({BLENDED_SAMPLE_RATE: 0.5}):
             configuration = get_configuration(org.id)
 
         assert isinstance(configuration, AutomaticDynamicSamplingConfiguration)


### PR DESCRIPTION
- Add a helper to patch the configuration more compactly, so this doesn't take up dozens of lines everytime a few variables are mocked