### PR TITLE
ref(ai-monitoring): Always return conversation details envelope

### DIFF
--- a/src/sentry/api/endpoints/organization_ai_conversation_details.py
+++ b/src/sentry/api/endpoints/organization_ai_conversation_details.py
@@ -15,7 +15,6 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
-from sentry.api.serializers.rest_framework import OrganizationAIConversationDetailsSerializer
 from sentry.api.utils import handle_query_errors
 from sentry.models.organization import Organization
 from sentry.search.eap.occurrences.query_utils import build_escaped_term_filter
@@ -75,7 +74,7 @@ AI_CONVERSATION_ATTRIBUTES = [
 
 
 class AIConversationDetailsResponse(TypedDict):
-    """Response body for ``apiVersion=2``: the span page plus conversation-level metadata."""
+    """Span page plus conversation-level metadata."""
 
     conversationId: str
     title: str | None
@@ -90,11 +89,6 @@ class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
     def get(self, request: Request, organization: Organization, conversation_id: str) -> Response:
         if not features.has("organizations:gen-ai-conversations", organization, actor=request.user):
             return Response(status=404)
-
-        serializer = OrganizationAIConversationDetailsSerializer(data=request.GET)
-        if not serializer.is_valid():
-            return Response(serializer.errors, status=400)
-        use_envelope = serializer.validated_data["apiVersion"] >= 2
 
         try:
             snuba_params = self.get_snuba_params(request, organization)
@@ -130,11 +124,7 @@ class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
                 self._annotate_issues(spans, resolved_params, organization)
                 return spans
 
-            def on_results(
-                spans: list[dict[str, Any]],
-            ) -> list[dict[str, Any]] | AIConversationDetailsResponse:
-                if not use_envelope:
-                    return spans
+            def on_results(spans: list[dict[str, Any]]) -> AIConversationDetailsResponse:
                 return {
                     "conversationId": conversation_id,
                     "title": self._resolve_title(conversation_id, spans, organization),

--- a/src/sentry/api/serializers/rest_framework/ai_conversations.py
+++ b/src/sentry/api/serializers/rest_framework/ai_conversations.py
@@ -1,13 +1,6 @@
 from rest_framework import serializers
 
 
-class OrganizationAIConversationDetailsSerializer(serializers.Serializer):
-    # Version 1 is the historical bare list of spans; version 2 wraps it in an object
-    # carrying conversation metadata. Once clients move to 2 it becomes the default and
-    # this field goes away.
-    apiVersion = serializers.ChoiceField(choices=[1, 2], required=False, default=1)
-
-
 class OrganizationAIConversationsSerializer(serializers.Serializer):
     sort = serializers.CharField(required=False, default="-timestamp")
     query = serializers.CharField(required=False, allow_blank=True)

--- a/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
@@ -80,7 +80,9 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
         response = self.do_request(conversation_id, query)
         assert response.status_code == 200
-        assert len(response.data) == 0
+        assert response.data["conversationId"] == conversation_id
+        assert response.data["title"] is None
+        assert response.data["spans"] == []
 
     def test_single_trace_conversation(self) -> None:
         now = before_now(days=20).replace(microsecond=0)
@@ -119,12 +121,12 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
         response = self.do_request(conversation_id, query)
         assert response.status_code == 200
-        assert len(response.data) == 3
+        assert len(response.data["spans"]) == 3
 
-        for span in response.data:
+        for span in response.data["spans"]:
             assert span["gen_ai.conversation.id"] == conversation_id
 
-        trace_ids = {span["trace"] for span in response.data}
+        trace_ids = {span["trace"] for span in response.data["spans"]}
         assert len(trace_ids) == 1
         assert trace_id in trace_ids
 
@@ -171,9 +173,9 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
         response = self.do_request(conversation_id, query)
         assert response.status_code == 200
-        assert len(response.data) == 4
+        assert len(response.data["spans"]) == 4
 
-        trace_ids = {span["trace"] for span in response.data}
+        trace_ids = {span["trace"] for span in response.data["spans"]}
         assert trace_ids == {trace_id_1, trace_id_2}
 
     def test_returns_conversation_attributes(self) -> None:
@@ -203,9 +205,9 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
         response = self.do_request(conversation_id, query)
         assert response.status_code == 200
-        assert len(response.data) == 1
+        assert len(response.data["spans"]) == 1
 
-        span = response.data[0]
+        span = response.data["spans"][0]
         assert "span_id" in span
         assert span["trace"] == trace_id
         assert "precise.start_ts" in span
@@ -247,7 +249,7 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
         response = self.do_request(conversation_id, query)
         assert response.status_code == 200
-        assert len(response.data) == 2
+        assert len(response.data["spans"]) == 2
 
         links = parse_link_header(response.headers["Link"])
         next_link = next(link for link in links.values() if link["rel"] == "next")
@@ -257,14 +259,14 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         query["cursor"] = next_link["cursor"]
         response = self.do_request(conversation_id, query)
         assert response.status_code == 200
-        assert len(response.data) == 2
+        assert len(response.data["spans"]) == 2
 
         links = parse_link_header(response.headers["Link"])
         next_link = next(link for link in links.values() if link["rel"] == "next")
         query["cursor"] = next_link["cursor"]
         response = self.do_request(conversation_id, query)
         assert response.status_code == 200
-        assert len(response.data) == 1
+        assert len(response.data["spans"]) == 1
 
     def test_span_ordering(self) -> None:
         now = before_now(days=5).replace(microsecond=0)
@@ -293,9 +295,9 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
         response = self.do_request(conversation_id, query)
         assert response.status_code == 200
-        assert len(response.data) == 3
+        assert len(response.data["spans"]) == 3
 
-        span_timestamps = [span["precise.start_ts"] for span in response.data]
+        span_timestamps = [span["precise.start_ts"] for span in response.data["spans"]]
         assert span_timestamps == sorted(span_timestamps)
 
     def test_only_returns_matching_conversation(self) -> None:
@@ -331,14 +333,14 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
         response = self.do_request(conversation_id_1, query)
         assert response.status_code == 200
-        assert len(response.data) == 2
-        for span in response.data:
+        assert len(response.data["spans"]) == 2
+        for span in response.data["spans"]:
             assert span["gen_ai.conversation.id"] == conversation_id_1
 
         response = self.do_request(conversation_id_2, query)
         assert response.status_code == 200
-        assert len(response.data) == 1
-        assert response.data[0]["gen_ai.conversation.id"] == conversation_id_2
+        assert len(response.data["spans"]) == 1
+        assert response.data["spans"][0]["gen_ai.conversation.id"] == conversation_id_2
 
     def test_returns_tool_attributes(self) -> None:
         now = before_now(days=5).replace(microsecond=0)
@@ -364,9 +366,9 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
         response = self.do_request(conversation_id, query)
         assert response.status_code == 200
-        assert len(response.data) == 1
+        assert len(response.data["spans"]) == 1
 
-        span = response.data[0]
+        span = response.data["spans"][0]
         assert span["span.op"] == "gen_ai.execute_tool"
         assert span["gen_ai.operation.type"] == "tool"
         assert span["gen_ai.tool.name"] == "search_database"
@@ -392,8 +394,8 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
         response = self.do_request(conversation_id, query)
         assert response.status_code == 200
-        assert len(response.data) == 1
-        assert response.data[0]["gen_ai.conversation.id"] == conversation_id
+        assert len(response.data["spans"]) == 1
+        assert response.data["spans"][0]["gen_ai.conversation.id"] == conversation_id
 
     def test_stats_period_recent_conversation_returned_without_widening(self) -> None:
         timestamp_1h = before_now(minutes=30).replace(microsecond=0)
@@ -414,7 +416,7 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
         response = self.do_request(conversation_id, query)
         assert response.status_code == 200
-        assert len(response.data) == 1
+        assert len(response.data["spans"]) == 1
 
     def test_no_time_params_falls_back_to_30d(self) -> None:
         timestamp = before_now(days=15).replace(microsecond=0)
@@ -432,8 +434,8 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
         response = self.do_request(conversation_id, query)
         assert response.status_code == 200
-        assert len(response.data) == 1
-        assert response.data[0]["gen_ai.conversation.id"] == conversation_id
+        assert len(response.data["spans"]) == 1
+        assert response.data["spans"][0]["gen_ai.conversation.id"] == conversation_id
 
     def test_tokens_on_multiple_span_types(self) -> None:
         now = before_now(days=5).replace(microsecond=0)
@@ -469,9 +471,9 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
         response = self.do_request(conversation_id, query)
         assert response.status_code == 200
-        assert len(response.data) == 2
+        assert len(response.data["spans"]) == 2
 
-        spans = sorted(response.data, key=lambda s: s["precise.start_ts"])
+        spans = sorted(response.data["spans"], key=lambda s: s["precise.start_ts"])
 
         agent_span = spans[0]
         assert agent_span["gen_ai.operation.type"] == "invoke_agent"
@@ -527,9 +529,9 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
         response = self.do_request(conversation_id, query)
         assert response.status_code == 200
-        assert len(response.data) == 1
-        assert response.data[0]["errors"] == []
-        assert response.data[0]["occurrences"] == []
+        assert len(response.data["spans"]) == 1
+        assert response.data["spans"][0]["errors"] == []
+        assert response.data["spans"][0]["occurrences"] == []
 
     def test_links_error_issue_to_span(self) -> None:
         now = before_now(days=10).replace(microsecond=0)
@@ -556,9 +558,9 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
         response = self.do_request(conversation_id, query)
         assert response.status_code == 200
-        assert len(response.data) == 1
+        assert len(response.data["spans"]) == 1
 
-        span_data = response.data[0]
+        span_data = response.data["spans"][0]
         assert span_data["span_id"] == span_id
         assert span_data["occurrences"] == []
         assert len(span_data["errors"]) == 1
@@ -600,9 +602,9 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
         response = self.do_request(conversation_id, query)
         assert response.status_code == 200
-        assert len(response.data) == 2
+        assert len(response.data["spans"]) == 2
 
-        by_span = {span["span_id"]: span for span in response.data}
+        by_span = {span["span_id"]: span for span in response.data["spans"]}
         assert len(by_span[failing_span["span_id"]]["errors"]) == 1
         assert by_span[healthy_span["span_id"]]["errors"] == []
 
@@ -640,9 +642,9 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
         response = self.do_request(conversation_id, query)
         assert response.status_code == 200
-        assert len(response.data) == 2
+        assert len(response.data["spans"]) == 2
 
-        by_span = {span["span_id"]: span for span in response.data}
+        by_span = {span["span_id"]: span for span in response.data["spans"]}
         assert len(by_span[span_1["span_id"]]["errors"]) == 1
         assert len(by_span[span_2["span_id"]]["errors"]) == 1
 
@@ -692,9 +694,9 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
         response = self.do_request(conversation_id, query)
         assert response.status_code == 200
-        assert len(response.data) == 1
+        assert len(response.data["spans"]) == 1
 
-        span_data = response.data[0]
+        span_data = response.data["spans"][0]
         assert span_data["span_id"] == span_id
         assert len(span_data["occurrences"]) == 1
         occurrence_issue = span_data["occurrences"][0]
@@ -702,7 +704,7 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         assert occurrence_issue["issue_id"] == group_info.group.id
         assert occurrence_issue["description"] == "File IO on Main Thread"
 
-    def test_default_and_api_version_1_return_a_bare_span_list(self) -> None:
+    def test_response_envelope_shape(self) -> None:
         now = before_now(days=5).replace(microsecond=0)
         conversation_id = uuid4().hex
 
@@ -714,36 +716,14 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
             "end": (now + timedelta(hours=1)).isoformat(),
         }
 
-        default_response = self.do_request(conversation_id, query)
-        v1_response = self.do_request(conversation_id, {**query, "apiVersion": "1"})
-
-        assert default_response.status_code == 200
-        assert v1_response.status_code == 200
-        assert isinstance(default_response.data, list)
-        assert len(default_response.data) == 1
-        assert v1_response.data == default_response.data
-
-    def test_api_version_2_wraps_spans_under_spans(self) -> None:
-        now = before_now(days=5).replace(microsecond=0)
-        conversation_id = uuid4().hex
-
-        self._store_conversation_span(conversation_id, now)
-
-        query: dict[str, Any] = {
-            "project": [self.project.id],
-            "start": (now - timedelta(hours=1)).isoformat(),
-            "end": (now + timedelta(hours=1)).isoformat(),
-        }
-
-        v1_response = self.do_request(conversation_id, query)
-        response = self.do_request(conversation_id, {**query, "apiVersion": "2"})
+        response = self.do_request(conversation_id, query)
 
         assert response.status_code == 200
         assert set(response.data) == {"conversationId", "title", "spans"}
         assert response.data["conversationId"] == conversation_id
-        assert response.data["spans"] == v1_response.data
+        assert len(response.data["spans"]) == 1
 
-    def test_api_version_2_returns_stored_title(self) -> None:
+    def test_returns_stored_title(self) -> None:
         now = before_now(days=5).replace(microsecond=0)
         conversation_id = uuid4().hex
 
@@ -757,7 +737,6 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
         query = {
             "project": [self.project.id],
-            "apiVersion": "2",
             "start": (now - timedelta(hours=1)).isoformat(),
             "end": (now + timedelta(hours=1)).isoformat(),
         }
@@ -767,7 +746,7 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         assert response.data["title"] == "Refund a duplicate charge"
         assert len(response.data["spans"]) == 1
 
-    def test_api_version_2_title_is_null_without_metadata(self) -> None:
+    def test_title_is_null_without_metadata(self) -> None:
         now = before_now(days=5).replace(microsecond=0)
         conversation_id = uuid4().hex
 
@@ -775,7 +754,6 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
         query = {
             "project": [self.project.id],
-            "apiVersion": "2",
             "start": (now - timedelta(hours=1)).isoformat(),
             "end": (now + timedelta(hours=1)).isoformat(),
         }
@@ -784,7 +762,7 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         assert response.status_code == 200
         assert response.data["title"] is None
 
-    def test_api_version_2_title_is_null_when_row_is_untitled(self) -> None:
+    def test_title_is_null_when_row_is_untitled(self) -> None:
         now = before_now(days=5).replace(microsecond=0)
         conversation_id = uuid4().hex
 
@@ -797,7 +775,6 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
         query = {
             "project": [self.project.id],
-            "apiVersion": "2",
             "start": (now - timedelta(hours=1)).isoformat(),
             "end": (now + timedelta(hours=1)).isoformat(),
         }
@@ -806,7 +783,7 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         assert response.status_code == 200
         assert response.data["title"] is None
 
-    def test_api_version_2_title_not_taken_from_unrelated_project(self) -> None:
+    def test_title_not_taken_from_unrelated_project(self) -> None:
         """A same-named conversation in a project without spans must not supply the title."""
         now = before_now(days=5).replace(microsecond=0)
         conversation_id = uuid4().hex
@@ -822,7 +799,6 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
         query = {
             "project": [self.project.id, other_project.id],
-            "apiVersion": "2",
             "start": (now - timedelta(hours=1)).isoformat(),
             "end": (now + timedelta(hours=1)).isoformat(),
         }
@@ -831,7 +807,7 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         assert response.status_code == 200
         assert response.data["title"] is None
 
-    def test_api_version_2_earliest_titled_project_wins(self) -> None:
+    def test_earliest_titled_project_wins(self) -> None:
         """A conversation spanning projects is titled from the earliest title source."""
         now = before_now(days=5).replace(microsecond=0)
         conversation_id = uuid4().hex
@@ -857,7 +833,6 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
         query = {
             "project": [self.project.id, other_project.id],
-            "apiVersion": "2",
             "start": (now - timedelta(hours=1)).isoformat(),
             "end": (now + timedelta(hours=1)).isoformat(),
         }
@@ -867,7 +842,7 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         assert len(response.data["spans"]) == 2
         assert response.data["title"] == "Started here"
 
-    def test_api_version_2_conversation_not_found(self) -> None:
+    def test_empty_conversation_returns_envelope(self) -> None:
         now = before_now(days=5).replace(microsecond=0)
         conversation_id = uuid4().hex
 
@@ -875,7 +850,6 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
         query = {
             "project": [self.project.id],
-            "apiVersion": "2",
             "start": (now - timedelta(hours=1)).isoformat(),
             "end": (now + timedelta(hours=1)).isoformat(),
         }
@@ -886,7 +860,7 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         assert response.data["title"] is None
         assert response.data["spans"] == []
 
-    def test_api_version_2_paginates(self) -> None:
+    def test_paginates_with_title(self) -> None:
         now = before_now(days=5).replace(microsecond=0)
         conversation_id = uuid4().hex
         trace_id = uuid4().hex
@@ -907,7 +881,6 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
         query: dict[str, Any] = {
             "project": [self.project.id],
-            "apiVersion": "2",
             "per_page": "2",
             "start": (now - timedelta(hours=1)).isoformat(),
             "end": (now + timedelta(hours=1)).isoformat(),
@@ -932,7 +905,7 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         "sentry.api.endpoints.organization_ai_conversation_details.fetch_conversation_title",
         side_effect=Exception("metadata unavailable"),
     )
-    def test_api_version_2_survives_a_failing_title_lookup(
+    def test_survives_a_failing_title_lookup(
         self, mock_fetch_conversation_title: MagicMock
     ) -> None:
         now = before_now(days=5).replace(microsecond=0)
@@ -942,7 +915,6 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
         query = {
             "project": [self.project.id],
-            "apiVersion": "2",
             "start": (now - timedelta(hours=1)).isoformat(),
             "end": (now + timedelta(hours=1)).isoformat(),
         }
@@ -952,17 +924,3 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         assert response.data["title"] is None
         assert len(response.data["spans"]) == 1
         assert mock_fetch_conversation_title.call_count == 1
-
-    def test_unsupported_api_version_returns_400(self) -> None:
-        query = {"project": [self.project.id], "apiVersion": "3"}
-
-        response = self.do_request(uuid4().hex, query)
-        assert response.status_code == 400
-        assert "apiVersion" in response.data
-
-    def test_non_numeric_api_version_returns_400(self) -> None:
-        query = {"project": [self.project.id], "apiVersion": "v2"}
-
-        response = self.do_request(uuid4().hex, query)
-        assert response.status_code == 400
-        assert "apiVersion" in response.data


### PR DESCRIPTION
Before https://github.com/getsentry/sentry/pull/120746 we had no way of easily extending API response for conversation details, but now we do. `apiVersion` was just a temporary hack to update all the known clients to the new conversation response. Those clients are now updated, and we can stop returning old response from the API endpoint.

