### PR TITLE
ref(preprod): buildDetails to container queries

### DIFF
--- a/static/app/views/preprod/buildDetails/buildDetails.tsx
+++ b/static/app/views/preprod/buildDetails/buildDetails.tsx
@@ -1,5 +1,4 @@
 import {useEffect, useRef} from 'react';
-import styled from '@emotion/styled';
 import {useMutation} from '@tanstack/react-query';
 
 import {Button} from '@sentry/scraps/button';
@@ -195,17 +194,21 @@ export default function BuildDetails() {
           />
         </Layout.Header>
 
-        <BuildDetailsBody>
+        <Layout.Body gap={{zero: '2xl', '4xl': '3xl'}}>
           <UrlParamBatchProvider>
-            <BuildDetailsSide>
+            <Layout.Side
+              minWidth={{zero: 'auto', '4xl': '325px'}}
+              maxWidth={{zero: 'none', '4xl': '325px'}}
+              row={{zero: 'auto', '4xl': '1'}}
+            >
               <BuildDetailsSidebarContent
                 buildDetailsData={buildDetailsQuery.data}
                 isBuildDetailsPending={buildDetailsQuery.isLoading}
                 artifactId={artifactId}
                 projectId={projectSlug ?? null}
               />
-            </BuildDetailsSide>
-            <BuildDetailsMain>
+            </Layout.Side>
+            <Layout.Main row={{zero: 'auto', '4xl': '1'}}>
               <BuildDetailsMainContent
                 appSizeQuery={appSizeQuery}
                 onRerunAnalysis={onRerunAnalysis}
@@ -215,31 +218,10 @@ export default function BuildDetails() {
                 projectType={projectType}
                 projectId={projectSlug}
               />
-            </BuildDetailsMain>
+            </Layout.Main>
           </UrlParamBatchProvider>
-        </BuildDetailsBody>
+        </Layout.Body>
       </Stack>
     </SentryDocumentTitle>
   );
 }
-
-const BuildDetailsBody = styled(Layout.Body)`
-  @media (min-width: ${p => p.theme.breakpoints.lg}) {
-    display: flex;
-    flex-direction: row-reverse;
-    gap: ${p => p.theme.space['3xl']};
-  }
-`;
-
-const BuildDetailsMain = styled(Layout.Main)`
-  @media (min-width: ${p => p.theme.breakpoints.lg}) {
-    width: 100%;
-  }
-`;
-
-const BuildDetailsSide = styled(Layout.Side)`
-  @media (min-width: ${p => p.theme.breakpoints.lg}) {
-    min-width: 325px;
-    max-width: 325px;
-  }
-`;


### PR DESCRIPTION
before:

https://github.com/user-attachments/assets/bcbd0377-4e1b-4dee-b1e4-626cf4537c86

after:

https://github.com/user-attachments/assets/3ff16fc6-acf4-490f-aa74-0bd3b2ee1f1a

Note: header bar still overlaps with all those buttons, needs to move to our `Breadcrumbs`, which is a different migration.