### PR TITLE
ref(dynamic-sampling): Slim down the remaining per-org tests

### DIFF
--- a/tests/sentry/dynamic_sampling/per_org/test_calculations.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_calculations.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from unittest.mock import Mock, patch
+from collections.abc import Iterator
+from contextlib import contextmanager
+from unittest.mock import DEFAULT, MagicMock, patch
 
 import orjson
 import pytest
@@ -27,10 +29,16 @@ from sentry.dynamic_sampling.tasks.helpers.boost_low_volume_transactions import 
 )
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
+from tests.sentry.dynamic_sampling.per_org.test_helpers import (
+    make_project_volume,
+    mock_configuration,
+    patch_config,
+)
 
-
-def _project_volume(project_id: int, total: int = 100, keep: int = 25) -> ProjectVolume:
-    return ProjectVolume(project_id=project_id, total=total, keep=keep, drop=max(total - keep, 0))
+CALCULATIONS = "sentry.dynamic_sampling.per_org.calculations"
+LOGGER_INFO = f"{CALCULATIONS}.logger.info"
+PROJECTS_MODEL_RUN = f"{CALCULATIONS}.ProjectsRebalancingModel.run"
+TRANSACTIONS_MODEL_RUN = f"{CALCULATIONS}.TransactionsRebalancingModel.run"
 
 
 class ProjectBalancingCalculationsTest(TestCase):
@@ -43,27 +51,24 @@ class ProjectBalancingCalculationsTest(TestCase):
         project_with_volume = self.create_project(organization=org)
         project_without_volume = self.create_project(organization=org)
         other_project = self.create_project()
-        config = Mock()
-        config.organization = org
-        config.projects = [project_with_volume, project_without_volume]
-        config.get_sample_rate.return_value = 0.5
+        config = mock_configuration(
+            org, projects=[project_with_volume, project_without_volume], sample_rate=0.5
+        )
         rebalanced_projects = [
             RebalancedItem(id=project_with_volume.id, count=100, new_sample_rate=0.25),
         ]
 
-        with patch(
-            "sentry.dynamic_sampling.per_org.calculations.ProjectsRebalancingModel.run",
-            return_value=rebalanced_projects,
-        ) as model_run:
+        with patch_config({PROJECTS_MODEL_RUN: rebalanced_projects}) as mocks:
             result = run_project_balancing(
                 config,
                 [
-                    _project_volume(project_with_volume.id),
-                    _project_volume(project_without_volume.id, total=0, keep=0),
-                    _project_volume(other_project.id),
+                    make_project_volume(project_with_volume.id),
+                    make_project_volume(project_without_volume.id, total=0, keep=0),
+                    make_project_volume(other_project.id),
                 ],
             )
 
+        model_run = mocks[PROJECTS_MODEL_RUN]
         model_run.assert_called_once()
         model_input = model_run.call_args.args[-1]
         assert isinstance(model_input, ProjectsRebalancingInput)
@@ -83,22 +88,20 @@ class ProjectBalancingCalculationsTest(TestCase):
         org = self.create_organization()
         busy = self.create_project(organization=org)
         idle = self.create_project(organization=org)
-        config = Mock()
-        config.organization = org
-        config.projects = [busy, idle]
-        config.get_sample_rate.return_value = 1.0
+        config = mock_configuration(org, projects=[busy, idle], sample_rate=1.0)
 
-        with patch(
-            "sentry.dynamic_sampling.per_org.calculations.ProjectsRebalancingModel.run"
-        ) as model_run:
+        with patch_config({PROJECTS_MODEL_RUN: DEFAULT}) as mocks:
             result = run_project_balancing(
                 config,
-                [_project_volume(busy.id, total=1000), _project_volume(idle.id, total=0, keep=0)],
+                [
+                    make_project_volume(busy.id, total=1000),
+                    make_project_volume(idle.id, total=0, keep=0),
+                ],
             )
 
         # Mirrors legacy serving: a 100% org rate gives every project 100% and the balancing
         # model never runs.
-        model_run.assert_not_called()
+        mocks[PROJECTS_MODEL_RUN].assert_not_called()
         assert {int(item.id): item.new_sample_rate for item in result} == {
             busy.id: 1.0,
             idle.id: 1.0,
@@ -108,16 +111,15 @@ class ProjectBalancingCalculationsTest(TestCase):
         org = self.create_organization()
         project_with_volume = self.create_project(organization=org)
         project_without_volume = self.create_project(organization=org)
-        config = Mock()
-        config.organization = org
-        config.projects = [project_with_volume, project_without_volume]
-        config.get_sample_rate.return_value = 0.5
+        config = mock_configuration(
+            org, projects=[project_with_volume, project_without_volume], sample_rate=0.5
+        )
 
         result = run_project_balancing(
             config,
             [
-                _project_volume(project_with_volume.id, total=100),
-                _project_volume(project_without_volume.id, total=0, keep=0),
+                make_project_volume(project_with_volume.id, total=100),
+                make_project_volume(project_without_volume.id, total=0, keep=0),
             ],
         )
 
@@ -128,16 +130,13 @@ class ProjectBalancingCalculationsTest(TestCase):
         org = self.create_organization()
         project_a = self.create_project(organization=org)
         project_b = self.create_project(organization=org)
-        config = Mock()
-        config.organization = org
-        config.projects = [project_a, project_b]
-        config.get_sample_rate.return_value = 0.5
+        config = mock_configuration(org, projects=[project_a, project_b], sample_rate=0.5)
 
         result = run_project_balancing(
             config,
             [
-                _project_volume(project_a.id, total=0, keep=0),
-                _project_volume(project_b.id, total=0, keep=0),
+                make_project_volume(project_a.id, total=0, keep=0),
+                make_project_volume(project_b.id, total=0, keep=0),
             ],
         )
 
@@ -173,8 +172,7 @@ class ProjectBalancingCalculationsTest(TestCase):
         org = self.create_organization()
         project_with_volume = self.create_project(organization=org)
         project_without_volume = self.create_project(organization=org)
-        config = Mock()
-        config.organization = org
+        config = mock_configuration(org)
         rebalanced_projects = [
             RebalancedItem(id=project_with_volume.id, count=100, new_sample_rate=0.25),
             RebalancedItem(id=project_without_volume.id, count=0, new_sample_rate=1.0),
@@ -188,7 +186,7 @@ class ProjectBalancingCalculationsTest(TestCase):
             ProjectVolume(project_id=project_without_volume.id, total=0, keep=0, drop=0),
         ]
 
-        with patch("sentry.dynamic_sampling.per_org.calculations.logger.info") as logger_info:
+        with patch(LOGGER_INFO) as logger_info:
             compare_rebalanced_projects_with_cache(
                 config, rebalanced_projects, cached_sample_rates, project_volumes
             )
@@ -252,6 +250,16 @@ def _project_transactions(
     )
 
 
+@contextmanager
+def patch_transactions_model() -> Iterator[MagicMock]:
+    """Patch the rebalancing model to echo back the sample rate it received."""
+    with patch(
+        TRANSACTIONS_MODEL_RUN,
+        side_effect=lambda model_input: ([], model_input.sample_rate),
+    ) as model_run:
+        yield model_run
+
+
 class TransactionBalancingCalculationsTest(TestCase):
     def setUp(self) -> None:
         super().setUp()
@@ -261,17 +269,14 @@ class TransactionBalancingCalculationsTest(TestCase):
         org = self.create_organization()
         project_a = self.create_project(organization=org)
         project_b = self.create_project(organization=org)
-        config = Mock()
-        config.organization = org
-        config.get_project_sample_rates.return_value = {project_a.id: 0.2, project_b.id: 0.8}
+        config = mock_configuration(
+            org, project_sample_rates={project_a.id: 0.2, project_b.id: 0.8}
+        )
 
-        with patch(
-            "sentry.dynamic_sampling.per_org.calculations.TransactionsRebalancingModel.run",
-            side_effect=lambda model_input: ([], model_input.sample_rate),
-        ) as model_run:
+        with patch_transactions_model() as model_run:
             run_transaction_balancing(
                 config,
-                [_project_volume(project_a.id), _project_volume(project_b.id)],
+                [make_project_volume(project_a.id), make_project_volume(project_b.id)],
                 [
                     _project_transactions(org.id, project_a.id, [("/a", 1.0)]),
                     _project_transactions(org.id, project_b.id, [("/b", 1.0)]),
@@ -286,17 +291,14 @@ class TransactionBalancingCalculationsTest(TestCase):
         org = self.create_organization()
         project_a = self.create_project(organization=org)
         project_b = self.create_project(organization=org)
-        config = Mock()
-        config.organization = org
-        config.get_project_sample_rates.return_value = {project_a.id: 0.5, project_b.id: None}
+        config = mock_configuration(
+            org, project_sample_rates={project_a.id: 0.5, project_b.id: None}
+        )
 
-        with patch(
-            "sentry.dynamic_sampling.per_org.calculations.TransactionsRebalancingModel.run",
-            side_effect=lambda model_input: ([], model_input.sample_rate),
-        ) as model_run:
+        with patch_transactions_model() as model_run:
             result = run_transaction_balancing(
                 config,
-                [_project_volume(project_a.id), _project_volume(project_b.id)],
+                [make_project_volume(project_a.id), make_project_volume(project_b.id)],
                 [
                     _project_transactions(org.id, project_a.id, [("/a", 1.0)]),
                     _project_transactions(org.id, project_b.id, [("/b", 1.0)]),
@@ -311,17 +313,14 @@ class TransactionBalancingCalculationsTest(TestCase):
         org = self.create_organization()
         project_a = self.create_project(organization=org)
         project_b = self.create_project(organization=org)
-        config = Mock()
-        config.organization = org
-        config.get_project_sample_rates.return_value = {project_a.id: 0.5, project_b.id: 1.0}
+        config = mock_configuration(
+            org, project_sample_rates={project_a.id: 0.5, project_b.id: 1.0}
+        )
 
-        with patch(
-            "sentry.dynamic_sampling.per_org.calculations.TransactionsRebalancingModel.run",
-            side_effect=lambda model_input: ([], model_input.sample_rate),
-        ) as model_run:
+        with patch_transactions_model() as model_run:
             result = run_transaction_balancing(
                 config,
-                [_project_volume(project_a.id), _project_volume(project_b.id)],
+                [make_project_volume(project_a.id), make_project_volume(project_b.id)],
                 [
                     _project_transactions(org.id, project_a.id, [("/a", 1.0)]),
                     _project_transactions(org.id, project_b.id, [("/b", 1.0)]),
@@ -336,19 +335,16 @@ class TransactionBalancingCalculationsTest(TestCase):
         org = self.create_organization()
         project_a = self.create_project(organization=org)
         project_b = self.create_project(organization=org)
-        config = Mock()
-        config.organization = org
-        config.get_project_sample_rates.return_value = {project_a.id: 0.5, project_b.id: 0.5}
+        config = mock_configuration(
+            org, project_sample_rates={project_a.id: 0.5, project_b.id: 0.5}
+        )
 
-        with patch(
-            "sentry.dynamic_sampling.per_org.calculations.TransactionsRebalancingModel.run",
-            side_effect=lambda model_input: ([], model_input.sample_rate),
-        ) as model_run:
+        with patch_transactions_model() as model_run:
             # project_b has transactions but no matching ProjectVolume — it must be
             # skipped instead of raising a KeyError that aborts the whole org's run.
             result = run_transaction_balancing(
                 config,
-                [_project_volume(project_a.id)],
+                [make_project_volume(project_a.id)],
                 [
                     _project_transactions(org.id, project_a.id, [("/a", 1.0)]),
                     _project_transactions(org.id, project_b.id, [("/b", 1.0)]),
@@ -361,29 +357,24 @@ class TransactionBalancingCalculationsTest(TestCase):
     def test_run_transaction_balancing_passes_min_sample_rate_option(self) -> None:
         org = self.create_organization()
         project = self.create_project(organization=org)
-        config = Mock()
-        config.organization = org
-        config.get_project_sample_rates.return_value = {project.id: 0.5}
+        config = mock_configuration(org, project_sample_rates={project.id: 0.5})
 
-        with override_options({"dynamic-sampling.prioritise_transactions.min_sample_rate": 0.002}):
-            with patch(
-                "sentry.dynamic_sampling.per_org.calculations.TransactionsRebalancingModel.run",
-                side_effect=lambda model_input: ([], model_input.sample_rate),
-            ) as model_run:
-                run_transaction_balancing(
-                    config,
-                    [_project_volume(project.id)],
-                    [_project_transactions(org.id, project.id, [("/a", 1.0)])],
-                )
+        with (
+            override_options({"dynamic-sampling.prioritise_transactions.min_sample_rate": 0.002}),
+            patch_transactions_model() as model_run,
+        ):
+            run_transaction_balancing(
+                config,
+                [make_project_volume(project.id)],
+                [_project_transactions(org.id, project.id, [("/a", 1.0)])],
+            )
 
         assert model_run.call_args.args[-1].min_sample_rate == 0.002
 
     def test_run_transaction_balancing_floors_dominant_transaction(self) -> None:
         org = self.create_organization()
         project = self.create_project(organization=org)
-        config = Mock()
-        config.organization = org
-        config.get_project_sample_rates.return_value = {project.id: 0.05}
+        config = mock_configuration(org, project_sample_rates={project.id: 0.05})
 
         project_volume = ProjectVolume(
             project_id=project.id,
@@ -426,8 +417,7 @@ class TransactionBalancingCalculationsTest(TestCase):
     def test_compare_rebalanced_transactions_with_cache_logs_per_transaction(self) -> None:
         org = self.create_organization()
         project = self.create_project(organization=org)
-        config = Mock()
-        config.organization = org
+        config = mock_configuration(org)
         rebalanced_transactions = {
             project.id: (
                 [
@@ -441,7 +431,7 @@ class TransactionBalancingCalculationsTest(TestCase):
             project.id: ({"checkout": 0.2, "cart": 1.0}, 0.45),
         }
 
-        with patch("sentry.dynamic_sampling.per_org.calculations.logger.info") as logger_info:
+        with patch(LOGGER_INFO) as logger_info:
             compare_rebalanced_transactions_with_cache(
                 config, rebalanced_transactions, cached_sample_rates
             )
@@ -485,13 +475,12 @@ class TransactionBalancingCalculationsTest(TestCase):
     def test_compare_rebalanced_transactions_with_cache_handles_cache_miss(self) -> None:
         org = self.create_organization()
         project = self.create_project(organization=org)
-        config = Mock()
-        config.organization = org
+        config = mock_configuration(org)
         rebalanced_transactions = {
             project.id: ([RebalancedItem(id="checkout", count=10, new_sample_rate=0.5)], 0.5),
         }
 
-        with patch("sentry.dynamic_sampling.per_org.calculations.logger.info") as logger_info:
+        with patch(LOGGER_INFO) as logger_info:
             compare_rebalanced_transactions_with_cache(
                 config, rebalanced_transactions, {project.id: None}
             )
@@ -509,9 +498,7 @@ class TransactionBalancingModelOutputTest(TestCase):
     def test_model_output_is_stored_as_is(self) -> None:
         org = self.create_organization()
         project = self.create_project(organization=org)
-        config = Mock()
-        config.organization = org
-        config.get_project_sample_rates.return_value = {project.id: 0.1}
+        config = mock_configuration(org, project_sample_rates={project.id: 0.1})
 
         # Branch 3 of TransactionsRebalancingModel: the explicit pool is too small to absorb
         # its budget share, so the model returns an implicit rate below the project rate.

--- a/tests/sentry/dynamic_sampling/per_org/test_calculations.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_calculations.py
@@ -32,7 +32,7 @@ from sentry.testutils.helpers.options import override_options
 from tests.sentry.dynamic_sampling.per_org.test_helpers import (
     make_project_volume,
     mock_configuration,
-    patch_config,
+    patch_configuration,
 )
 
 CALCULATIONS = "sentry.dynamic_sampling.per_org.calculations"
@@ -58,7 +58,7 @@ class ProjectBalancingCalculationsTest(TestCase):
             RebalancedItem(id=project_with_volume.id, count=100, new_sample_rate=0.25),
         ]
 
-        with patch_config({PROJECTS_MODEL_RUN: rebalanced_projects}) as mocks:
+        with patch_configuration({PROJECTS_MODEL_RUN: rebalanced_projects}) as mocks:
             result = run_project_balancing(
                 config,
                 [
@@ -90,7 +90,7 @@ class ProjectBalancingCalculationsTest(TestCase):
         idle = self.create_project(organization=org)
         config = mock_configuration(org, projects=[busy, idle], sample_rate=1.0)
 
-        with patch_config({PROJECTS_MODEL_RUN: DEFAULT}) as mocks:
+        with patch_configuration({PROJECTS_MODEL_RUN: DEFAULT}) as mocks:
             result = run_project_balancing(
                 config,
                 [

--- a/tests/sentry/dynamic_sampling/per_org/test_configuration.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_configuration.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Iterator
-from contextlib import ExitStack, contextmanager
+from collections.abc import Callable
 from datetime import timedelta
 from typing import Any, NamedTuple
-from unittest.mock import DEFAULT, MagicMock, patch
+from unittest.mock import DEFAULT, patch
 
 import pytest
 from django.core.exceptions import ObjectDoesNotExist
@@ -27,27 +26,14 @@ from sentry.dynamic_sampling.tasks.helpers.sliding_window import FALLBACK_SLIDIN
 from sentry.dynamic_sampling.types import DynamicSamplingMode, SamplingMeasure
 from sentry.models.organization import Organization
 from sentry.testutils.cases import TestCase
-
-CONFIGURATION = "sentry.dynamic_sampling.per_org.configuration"
-BLENDED_SAMPLE_RATE = f"{CONFIGURATION}.quotas.backend.get_blended_sample_rate"
-OUTCOMES_VOLUME = f"{CONFIGURATION}.get_outcomes_organization_volume"
-SLIDING_WINDOW_RATE = f"{CONFIGURATION}.compute_sliding_window_sample_rate"
+from tests.sentry.dynamic_sampling.per_org.test_helpers import (
+    BLENDED_SAMPLE_RATE,
+    OUTCOMES_VOLUME,
+    SLIDING_WINDOW_RATE,
+    patch_config,
+)
 
 SpanOrgIds = Callable[[Organization], list[int]]
-
-
-@contextmanager
-def patch_configuration(targets: dict[str, Any]) -> Iterator[dict[str, MagicMock]]:
-    """Patch targets in the configuration module, each with the given return value.
-
-    Pass ``DEFAULT`` as the return value to patch a target without one. The yielded
-    mocks are keyed by target so that callers can assert on the calls.
-    """
-    with ExitStack() as stack:
-        yield {
-            target: stack.enter_context(patch(target, return_value=return_value))
-            for target, return_value in targets.items()
-        }
 
 
 def assert_measure(
@@ -92,7 +78,7 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
     def test_subscription_backed_org_uses_blended_sample_rate(self) -> None:
         org = self.create_organization()
 
-        with patch_configuration({BLENDED_SAMPLE_RATE: 0.5}) as mocks:
+        with patch_config({BLENDED_SAMPLE_RATE: 0.5}) as mocks:
             configuration = get_configuration(org.id)
 
         assert isinstance(configuration, AutomaticDynamicSamplingConfiguration)
@@ -108,7 +94,7 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
         self.create_project(organization=org)
         sliding_window_volume = OrganizationDataVolume(org_id=org.id, total=1000, indexed=250)
 
-        with patch_configuration(
+        with patch_config(
             {
                 BLENDED_SAMPLE_RATE: 0.5,
                 OUTCOMES_VOLUME: sliding_window_volume,
@@ -137,7 +123,7 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
         self.create_project(organization=org)
         sliding_window_volume = OrganizationDataVolume(org_id=org.id, total=1000, indexed=250)
 
-        with patch_configuration(
+        with patch_config(
             {
                 BLENDED_SAMPLE_RATE: 1.0,
                 OUTCOMES_VOLUME: sliding_window_volume,
@@ -159,7 +145,7 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
         org = self.create_organization()
         self.create_project(organization=org)
 
-        with patch_configuration(
+        with patch_config(
             {
                 BLENDED_SAMPLE_RATE: 0.5,
                 OUTCOMES_VOLUME: None,
@@ -176,7 +162,7 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
         org = self.create_organization()
         self.create_project(organization=org)
 
-        with patch_configuration({BLENDED_SAMPLE_RATE: None, OUTCOMES_VOLUME: DEFAULT}) as mocks:
+        with patch_config({BLENDED_SAMPLE_RATE: None, OUTCOMES_VOLUME: DEFAULT}) as mocks:
             configuration = get_configuration(org.id)
 
         assert isinstance(configuration, NoDynamicSamplingConfiguration)
@@ -202,7 +188,7 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
         org = self.create_organization()
         org.update_option("sentry:sampling_mode", DynamicSamplingMode.PROJECT)
 
-        with patch_configuration({BLENDED_SAMPLE_RATE: 0.5}):
+        with patch_config({BLENDED_SAMPLE_RATE: 0.5}):
             configuration = get_configuration(org.id)
 
         assert isinstance(configuration, AutomaticDynamicSamplingConfiguration)
@@ -218,7 +204,7 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
                 with (
                     self.feature("organizations:dynamic-sampling-custom"),
                     self.measure_options(case, org),
-                    patch_configuration({BLENDED_SAMPLE_RATE: DEFAULT}) as mocks,
+                    patch_config({BLENDED_SAMPLE_RATE: DEFAULT}) as mocks,
                 ):
                     configuration = get_configuration(org.id)
 
@@ -242,7 +228,7 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
                 with (
                     self.feature("organizations:dynamic-sampling-custom"),
                     self.measure_options(case, org),
-                    patch_configuration({BLENDED_SAMPLE_RATE: DEFAULT}) as mocks,
+                    patch_config({BLENDED_SAMPLE_RATE: DEFAULT}) as mocks,
                 ):
                     configuration = get_configuration(org.id)
 
@@ -306,7 +292,7 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
 
                 with (
                     self.measure_options(case, org),
-                    patch_configuration({BLENDED_SAMPLE_RATE: 1.0}),
+                    patch_config({BLENDED_SAMPLE_RATE: 1.0}),
                 ):
                     configuration = get_configuration(org.id)
 
@@ -380,7 +366,7 @@ class GetProjectSampleRatesTest(TestCase):
         org = self.create_organization()
         project = self.create_project(organization=org)
 
-        with patch_configuration({BLENDED_SAMPLE_RATE: 0.5}):
+        with patch_config({BLENDED_SAMPLE_RATE: 0.5}):
             configuration = get_configuration(org.id)
 
         assert isinstance(configuration, AutomaticDynamicSamplingConfiguration)
@@ -394,7 +380,7 @@ class GetProjectSampleRatesTest(TestCase):
         self.create_project(organization=org)
         self.create_project(organization=org)
 
-        with patch_configuration({BLENDED_SAMPLE_RATE: 0.5}):
+        with patch_config({BLENDED_SAMPLE_RATE: 0.5}):
             configuration = get_configuration(org.id)
 
         assert isinstance(configuration, AutomaticDynamicSamplingConfiguration)

--- a/tests/sentry/dynamic_sampling/per_org/test_configuration.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_configuration.py
@@ -30,7 +30,7 @@ from tests.sentry.dynamic_sampling.per_org.test_helpers import (
     BLENDED_SAMPLE_RATE,
     OUTCOMES_VOLUME,
     SLIDING_WINDOW_RATE,
-    patch_config,
+    patch_configuration,
 )
 
 SpanOrgIds = Callable[[Organization], list[int]]
@@ -78,7 +78,7 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
     def test_subscription_backed_org_uses_blended_sample_rate(self) -> None:
         org = self.create_organization()
 
-        with patch_config({BLENDED_SAMPLE_RATE: 0.5}) as mocks:
+        with patch_configuration({BLENDED_SAMPLE_RATE: 0.5}) as mocks:
             configuration = get_configuration(org.id)
 
         assert isinstance(configuration, AutomaticDynamicSamplingConfiguration)
@@ -94,7 +94,7 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
         self.create_project(organization=org)
         sliding_window_volume = OrganizationDataVolume(org_id=org.id, total=1000, indexed=250)
 
-        with patch_config(
+        with patch_configuration(
             {
                 BLENDED_SAMPLE_RATE: 0.5,
                 OUTCOMES_VOLUME: sliding_window_volume,
@@ -123,7 +123,7 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
         self.create_project(organization=org)
         sliding_window_volume = OrganizationDataVolume(org_id=org.id, total=1000, indexed=250)
 
-        with patch_config(
+        with patch_configuration(
             {
                 BLENDED_SAMPLE_RATE: 1.0,
                 OUTCOMES_VOLUME: sliding_window_volume,
@@ -145,7 +145,7 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
         org = self.create_organization()
         self.create_project(organization=org)
 
-        with patch_config(
+        with patch_configuration(
             {
                 BLENDED_SAMPLE_RATE: 0.5,
                 OUTCOMES_VOLUME: None,
@@ -162,7 +162,7 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
         org = self.create_organization()
         self.create_project(organization=org)
 
-        with patch_config({BLENDED_SAMPLE_RATE: None, OUTCOMES_VOLUME: DEFAULT}) as mocks:
+        with patch_configuration({BLENDED_SAMPLE_RATE: None, OUTCOMES_VOLUME: DEFAULT}) as mocks:
             configuration = get_configuration(org.id)
 
         assert isinstance(configuration, NoDynamicSamplingConfiguration)
@@ -188,7 +188,7 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
         org = self.create_organization()
         org.update_option("sentry:sampling_mode", DynamicSamplingMode.PROJECT)
 
-        with patch_config({BLENDED_SAMPLE_RATE: 0.5}):
+        with patch_configuration({BLENDED_SAMPLE_RATE: 0.5}):
             configuration = get_configuration(org.id)
 
         assert isinstance(configuration, AutomaticDynamicSamplingConfiguration)
@@ -204,7 +204,7 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
                 with (
                     self.feature("organizations:dynamic-sampling-custom"),
                     self.measure_options(case, org),
-                    patch_config({BLENDED_SAMPLE_RATE: DEFAULT}) as mocks,
+                    patch_configuration({BLENDED_SAMPLE_RATE: DEFAULT}) as mocks,
                 ):
                     configuration = get_configuration(org.id)
 
@@ -228,7 +228,7 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
                 with (
                     self.feature("organizations:dynamic-sampling-custom"),
                     self.measure_options(case, org),
-                    patch_config({BLENDED_SAMPLE_RATE: DEFAULT}) as mocks,
+                    patch_configuration({BLENDED_SAMPLE_RATE: DEFAULT}) as mocks,
                 ):
                     configuration = get_configuration(org.id)
 
@@ -292,7 +292,7 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
 
                 with (
                     self.measure_options(case, org),
-                    patch_config({BLENDED_SAMPLE_RATE: 1.0}),
+                    patch_configuration({BLENDED_SAMPLE_RATE: 1.0}),
                 ):
                     configuration = get_configuration(org.id)
 
@@ -366,7 +366,7 @@ class GetProjectSampleRatesTest(TestCase):
         org = self.create_organization()
         project = self.create_project(organization=org)
 
-        with patch_config({BLENDED_SAMPLE_RATE: 0.5}):
+        with patch_configuration({BLENDED_SAMPLE_RATE: 0.5}):
             configuration = get_configuration(org.id)
 
         assert isinstance(configuration, AutomaticDynamicSamplingConfiguration)
@@ -380,7 +380,7 @@ class GetProjectSampleRatesTest(TestCase):
         self.create_project(organization=org)
         self.create_project(organization=org)
 
-        with patch_config({BLENDED_SAMPLE_RATE: 0.5}):
+        with patch_configuration({BLENDED_SAMPLE_RATE: 0.5}):
             configuration = get_configuration(org.id)
 
         assert isinstance(configuration, AutomaticDynamicSamplingConfiguration)

--- a/tests/sentry/dynamic_sampling/per_org/test_helpers.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_helpers.py
@@ -17,7 +17,7 @@ SLIDING_WINDOW_RATE = f"{CONFIGURATION}.compute_sliding_window_sample_rate"
 
 
 @contextmanager
-def patch_config(targets: dict[str, Any]) -> Iterator[dict[str, MagicMock]]:
+def patch_configuration(targets: dict[str, Any]) -> Iterator[dict[str, MagicMock]]:
     """Patch the given targets, each with the given return value.
 
     Pass ``DEFAULT`` as the return value to patch a target without one. The yielded

--- a/tests/sentry/dynamic_sampling/per_org/test_helpers.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_helpers.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import ExitStack, contextmanager
+from typing import Any
+from unittest.mock import MagicMock, Mock, patch
+
+from sentry.dynamic_sampling.per_org.configuration import ProjectSampleRates
+from sentry.dynamic_sampling.per_org.queries import ProjectVolume
+from sentry.models.organization import Organization
+from sentry.models.project import Project
+
+CONFIGURATION = "sentry.dynamic_sampling.per_org.configuration"
+BLENDED_SAMPLE_RATE = f"{CONFIGURATION}.quotas.backend.get_blended_sample_rate"
+OUTCOMES_VOLUME = f"{CONFIGURATION}.get_outcomes_organization_volume"
+SLIDING_WINDOW_RATE = f"{CONFIGURATION}.compute_sliding_window_sample_rate"
+
+
+@contextmanager
+def patch_config(targets: dict[str, Any]) -> Iterator[dict[str, MagicMock]]:
+    """Patch the given targets, each with the given return value.
+
+    Pass ``DEFAULT`` as the return value to patch a target without one. The yielded
+    mocks are keyed by target so that callers can assert on the calls.
+    """
+    with ExitStack() as stack:
+        yield {
+            target: stack.enter_context(patch(target, return_value=return_value))
+            for target, return_value in targets.items()
+        }
+
+
+def make_project_volume(project_id: int, total: int = 100, keep: int = 25) -> ProjectVolume:
+    return ProjectVolume(project_id=project_id, total=total, keep=keep, drop=max(total - keep, 0))
+
+
+def mock_configuration(
+    organization: Organization,
+    projects: list[Project] | None = None,
+    sample_rate: float | None = None,
+    project_sample_rates: ProjectSampleRates | None = None,
+) -> Mock:
+    """A stand-in configuration whose getters return the given sample rates."""
+    return Mock(
+        organization=organization,
+        projects=projects or [],
+        **{
+            "get_sample_rate.return_value": sample_rate,
+            "get_project_sample_rates.return_value": project_sample_rates or {},
+        },
+    )

--- a/tests/sentry/dynamic_sampling/per_org/test_queries.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_queries.py
@@ -30,6 +30,16 @@ from sentry.search.events.types import SnubaParams
 from sentry.snuba.referrer import Referrer
 from sentry.testutils.cases import SnubaTestCase, SpanTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now
+from tests.sentry.dynamic_sampling.per_org.test_helpers import (
+    BLENDED_SAMPLE_RATE,
+    OUTCOMES_VOLUME,
+    patch_config,
+)
+
+QUERIES = "sentry.dynamic_sampling.per_org.queries"
+RUN_TABLE_QUERY = f"{QUERIES}.Spans.run_table_query"
+RUN_CHUNKED_TABLE_QUERY = f"{QUERIES}.run_eap_spans_table_query_in_chunks"
+RUN_OUTCOMES_QUERY = f"{QUERIES}.run_outcomes_query_totals"
 
 
 class EAPSpansTableQueryChunkingTest(TestCase, SnubaTestCase, SpanTestCase):
@@ -88,16 +98,7 @@ class EAPOrganizationVolumeTest(TestCase, SnubaTestCase, SpanTestCase):
         self,
         organization: Organization,
     ) -> BaseDynamicSamplingConfiguration:
-        with (
-            patch(
-                "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate",
-                return_value=1.0,
-            ),
-            patch(
-                "sentry.dynamic_sampling.per_org.configuration.get_outcomes_organization_volume",
-                return_value=None,
-            ),
-        ):
+        with patch_config({BLENDED_SAMPLE_RATE: 1.0, OUTCOMES_VOLUME: None}):
             return get_configuration(organization.id)
 
     def test_get_eap_organization_volume_existing_org(self) -> None:
@@ -105,7 +106,7 @@ class EAPOrganizationVolumeTest(TestCase, SnubaTestCase, SpanTestCase):
         project = self.create_project(organization=organization)
 
         with patch(
-            "sentry.dynamic_sampling.per_org.queries.Spans.run_table_query",
+            RUN_TABLE_QUERY,
             return_value={"data": [{DynamicSamplingQueryFields.COUNT: 2, "count_sample()": 2}]},
         ) as run_table_query:
             org_volume = get_eap_organization_volume(
@@ -133,7 +134,7 @@ class EAPOrganizationVolumeTest(TestCase, SnubaTestCase, SpanTestCase):
         self.create_project(organization=organization)
 
         with patch(
-            "sentry.dynamic_sampling.per_org.queries.Spans.run_table_query",
+            RUN_TABLE_QUERY,
             return_value={"data": [{"count()": 10, DynamicSamplingQueryFields.COUNT_SAMPLE: 1}]},
         ):
             org_volume = get_eap_organization_volume(
@@ -156,7 +157,7 @@ class EAPOrganizationVolumeTest(TestCase, SnubaTestCase, SpanTestCase):
         organization = self.create_organization()
 
         with patch(
-            "sentry.dynamic_sampling.per_org.queries.Spans.run_table_query",
+            RUN_TABLE_QUERY,
             return_value={"data": []},
         ) as run_table_query:
             org_volume = get_eap_organization_volume(
@@ -176,7 +177,7 @@ class EAPOrganizationVolumeTest(TestCase, SnubaTestCase, SpanTestCase):
 
         received = (datetime.now(UTC) - timedelta(seconds=120)).timestamp()
         with patch(
-            "sentry.dynamic_sampling.per_org.queries.run_eap_spans_table_query_in_chunks",
+            RUN_CHUNKED_TABLE_QUERY,
             return_value=[
                 {
                     "sentry.dsc.project_id": project.id,
@@ -233,7 +234,7 @@ class EAPOrganizationVolumeTest(TestCase, SnubaTestCase, SpanTestCase):
         self.create_project(organization=organization)
 
         with patch(
-            "sentry.dynamic_sampling.per_org.queries.run_eap_spans_table_query_in_chunks",
+            RUN_CHUNKED_TABLE_QUERY,
             return_value=[],
         ):
             project_volumes = get_eap_project_volumes(
@@ -247,7 +248,7 @@ class EAPOrganizationVolumeTest(TestCase, SnubaTestCase, SpanTestCase):
         project = self.create_project(organization=organization)
 
         with patch(
-            "sentry.dynamic_sampling.per_org.queries.run_eap_spans_table_query_in_chunks",
+            RUN_CHUNKED_TABLE_QUERY,
             return_value=[
                 {
                     "sentry.dsc.project_id": project.id,
@@ -263,7 +264,7 @@ class EAPOrganizationVolumeTest(TestCase, SnubaTestCase, SpanTestCase):
         project = self.create_project(organization=organization)
 
         with patch(
-            "sentry.dynamic_sampling.per_org.queries.run_eap_spans_table_query_in_chunks",
+            RUN_CHUNKED_TABLE_QUERY,
             return_value=[
                 {
                     "sentry.dsc.project_id": None,
@@ -285,7 +286,7 @@ class EAPOrganizationVolumeTest(TestCase, SnubaTestCase, SpanTestCase):
         organization = self.create_organization()
 
         with patch(
-            "sentry.dynamic_sampling.per_org.queries.run_eap_spans_table_query_in_chunks",
+            RUN_CHUNKED_TABLE_QUERY,
             return_value=[],
         ) as run_table_query:
             project_volumes = get_eap_project_volumes(
@@ -301,7 +302,7 @@ class EAPOrganizationVolumeTest(TestCase, SnubaTestCase, SpanTestCase):
         organization = self.create_organization()
 
         with patch(
-            "sentry.dynamic_sampling.per_org.queries.run_outcomes_query_totals",
+            RUN_OUTCOMES_QUERY,
             return_value=[{"quantity": 10}],
         ) as run_outcomes_query_totals:
             org_volume = get_outcomes_organization_volume(
@@ -318,7 +319,7 @@ class EAPOrganizationVolumeTest(TestCase, SnubaTestCase, SpanTestCase):
         organization = self.create_organization()
 
         with patch(
-            "sentry.dynamic_sampling.per_org.queries.run_outcomes_query_totals",
+            RUN_OUTCOMES_QUERY,
             return_value=[],
         ):
             org_volume = get_outcomes_organization_volume(
@@ -330,10 +331,7 @@ class EAPOrganizationVolumeTest(TestCase, SnubaTestCase, SpanTestCase):
 
 class EAPTransactionVolumesTest(TestCase, SnubaTestCase, SpanTestCase):
     def get_config(self, organization: Organization) -> BaseDynamicSamplingConfiguration:
-        with patch(
-            "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate",
-            return_value=1.0,
-        ):
+        with patch_config({BLENDED_SAMPLE_RATE: 1.0}):
             return get_configuration(organization.id)
 
     def test_get_eap_transaction_volumes(self) -> None:

--- a/tests/sentry/dynamic_sampling/per_org/test_queries.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_queries.py
@@ -33,7 +33,7 @@ from sentry.testutils.helpers.datetime import before_now
 from tests.sentry.dynamic_sampling.per_org.test_helpers import (
     BLENDED_SAMPLE_RATE,
     OUTCOMES_VOLUME,
-    patch_config,
+    patch_configuration,
 )
 
 QUERIES = "sentry.dynamic_sampling.per_org.queries"
@@ -98,7 +98,7 @@ class EAPOrganizationVolumeTest(TestCase, SnubaTestCase, SpanTestCase):
         self,
         organization: Organization,
     ) -> BaseDynamicSamplingConfiguration:
-        with patch_config({BLENDED_SAMPLE_RATE: 1.0, OUTCOMES_VOLUME: None}):
+        with patch_configuration({BLENDED_SAMPLE_RATE: 1.0, OUTCOMES_VOLUME: None}):
             return get_configuration(organization.id)
 
     def test_get_eap_organization_volume_existing_org(self) -> None:
@@ -331,7 +331,7 @@ class EAPOrganizationVolumeTest(TestCase, SnubaTestCase, SpanTestCase):
 
 class EAPTransactionVolumesTest(TestCase, SnubaTestCase, SpanTestCase):
     def get_config(self, organization: Organization) -> BaseDynamicSamplingConfiguration:
-        with patch_config({BLENDED_SAMPLE_RATE: 1.0}):
+        with patch_configuration({BLENDED_SAMPLE_RATE: 1.0}):
             return get_configuration(organization.id)
 
     def test_get_eap_transaction_volumes(self) -> None:

--- a/tests/sentry/dynamic_sampling/per_org/test_scheduler.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_scheduler.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from unittest.mock import Mock, patch
+from unittest.mock import DEFAULT, Mock, patch
 
 from django.core.exceptions import ObjectDoesNotExist
 
@@ -8,7 +8,7 @@ from sentry.constants import ObjectStatus
 from sentry.dynamic_sampling.models.common import RebalancedItem
 from sentry.dynamic_sampling.per_org.configuration import BaseDynamicSamplingConfiguration
 from sentry.dynamic_sampling.per_org.gate import is_org_in_rollout
-from sentry.dynamic_sampling.per_org.queries import ProjectTransactionCounts, ProjectVolume
+from sentry.dynamic_sampling.per_org.queries import ProjectTransactionCounts
 from sentry.dynamic_sampling.per_org.scheduler import (
     run_calculations_per_org_task,
     schedule_per_org_calculations,
@@ -18,6 +18,20 @@ from sentry.dynamic_sampling.tasks.common import OrganizationDataVolume
 from sentry.dynamic_sampling.types import DynamicSamplingMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
+from tests.sentry.dynamic_sampling.per_org.test_helpers import (
+    BLENDED_SAMPLE_RATE,
+    make_project_volume,
+    patch_config,
+)
+
+SCHEDULER = "sentry.dynamic_sampling.per_org.scheduler"
+ORG_VOLUME = f"{SCHEDULER}.get_eap_organization_volume"
+PROJECT_VOLUMES = f"{SCHEDULER}.get_eap_project_volumes"
+TRANSACTION_VOLUMES = f"{SCHEDULER}.get_eap_transaction_volumes"
+PROJECT_BALANCING = f"{SCHEDULER}.run_project_balancing"
+TRANSACTION_BALANCING = f"{SCHEDULER}.run_transaction_balancing"
+CACHED_PROJECT_RATES = f"{SCHEDULER}.get_cached_rebalanced_project_sample_rates"
+COMPARE_PROJECTS = f"{SCHEDULER}.compare_rebalanced_projects_with_cache"
 
 
 def _assert_called_once_with_config(
@@ -29,10 +43,6 @@ def _assert_called_once_with_config(
     assert isinstance(config, BaseDynamicSamplingConfiguration)
     assert config.organization.id == organization_id
     return config
-
-
-def _project_volume(project_id: int, total: int = 100, keep: int = 25) -> ProjectVolume:
-    return ProjectVolume(project_id=project_id, total=total, keep=keep, drop=max(total - keep, 0))
 
 
 class SchedulePerOrgCalculationsTest(TestCase):
@@ -97,79 +107,54 @@ class RunCalculationsPerOrgTest(TestCase):
         org = self.create_organization()
         self.create_project(organization=org)
 
-        with (
-            patch(
-                "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate",
-                return_value=1.0,
-            ) as get_blended_sample_rate,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_organization_volume",
-                return_value=None,
-            ) as get_volume,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_project_volumes"
-            ) as get_project_volumes,
-        ):
+        with patch_config(
+            {
+                BLENDED_SAMPLE_RATE: 1.0,
+                ORG_VOLUME: None,
+                PROJECT_VOLUMES: DEFAULT,
+            }
+        ) as mocks:
             result = run_calculations_per_org_task(org.id)
 
         assert result == DynamicSamplingStatus.NO_ORG_VOLUME
-        _assert_called_once_with_config(get_volume, org.id)
-        get_blended_sample_rate.assert_called_once_with(organization_id=org.id)
-        get_project_volumes.assert_not_called()
+        _assert_called_once_with_config(mocks[ORG_VOLUME], org.id)
+        mocks[BLENDED_SAMPLE_RATE].assert_called_once_with(organization_id=org.id)
+        mocks[PROJECT_VOLUMES].assert_not_called()
 
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
     def test_run_calculations_per_org_skips_transaction_volumes_at_full_sample_rate(self) -> None:
         org = self.create_organization()
         project = self.create_project(organization=org)
         org_volume = OrganizationDataVolume(org_id=org.id, total=100, indexed=25)
-        project_volumes = [_project_volume(project.id)]
+        project_volumes = [make_project_volume(project.id)]
         rebalanced_projects = [RebalancedItem(id=project.id, count=100, new_sample_rate=1.0)]
         cached_sample_rates: dict[int, float | None] = {}
 
-        with (
-            patch(
-                "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate",
-                return_value=1.0,
-            ) as get_blended_sample_rate,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_organization_volume",
-                return_value=org_volume,
-            ) as get_volume,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_project_volumes",
-                return_value=project_volumes,
-            ) as get_project_volumes,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.run_project_balancing",
-                return_value=rebalanced_projects,
-            ) as project_balancing,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_cached_rebalanced_project_sample_rates",
-                return_value=cached_sample_rates,
-            ) as get_cached_sample_rates,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.compare_rebalanced_projects_with_cache"
-            ) as compare_rebalanced_projects,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_transaction_volumes"
-            ) as get_transaction_volumes,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.run_transaction_balancing"
-            ) as transaction_balancing,
-        ):
+        with patch_config(
+            {
+                BLENDED_SAMPLE_RATE: 1.0,
+                ORG_VOLUME: org_volume,
+                PROJECT_VOLUMES: project_volumes,
+                PROJECT_BALANCING: rebalanced_projects,
+                CACHED_PROJECT_RATES: cached_sample_rates,
+                COMPARE_PROJECTS: DEFAULT,
+                TRANSACTION_VOLUMES: DEFAULT,
+                TRANSACTION_BALANCING: DEFAULT,
+            }
+        ) as mocks:
             result = run_calculations_per_org_task(org.id)
 
         assert result == DynamicSamplingStatus.ALL_PROJECTS_AT_FULL_SAMPLE_RATE
-        _assert_called_once_with_config(get_volume, org.id)
-        get_blended_sample_rate.assert_called_once_with(organization_id=org.id)
-        project_config = _assert_called_once_with_config(get_project_volumes, org.id)
-        project_balancing.assert_called_once_with(project_config, project_volumes)
-        get_cached_sample_rates.assert_called_once_with(org.id)
-        compare_rebalanced_projects.assert_called_once_with(
+        _assert_called_once_with_config(mocks[ORG_VOLUME], org.id)
+        mocks[BLENDED_SAMPLE_RATE].assert_called_once_with(organization_id=org.id)
+        project_config = _assert_called_once_with_config(mocks[PROJECT_VOLUMES], org.id)
+        mocks[PROJECT_BALANCING].assert_called_once_with(project_config, project_volumes)
+        mocks[CACHED_PROJECT_RATES].assert_called_once_with(org.id)
+        mocks[COMPARE_PROJECTS].assert_called_once_with(
             project_config, rebalanced_projects, cached_sample_rates, project_volumes
         )
-        get_transaction_volumes.assert_not_called()
-        transaction_balancing.assert_not_called()
+        mocks[TRANSACTION_VOLUMES].assert_not_called()
+        mocks[TRANSACTION_BALANCING].assert_not_called()
 
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
     def test_run_calculations_per_org_returns_no_volume_without_project_volumes(self) -> None:
@@ -177,86 +162,56 @@ class RunCalculationsPerOrgTest(TestCase):
         self.create_project(organization=org)
         org_volume = OrganizationDataVolume(org_id=org.id, total=100, indexed=25)
 
-        with (
-            patch(
-                "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate",
-                return_value=1.0,
-            ) as get_blended_sample_rate,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_organization_volume",
-                return_value=org_volume,
-            ) as get_volume,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_project_volumes",
-                return_value=[],
-            ) as get_project_volumes,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_transaction_volumes"
-            ) as get_transaction_volumes,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.run_project_balancing",
-                return_value=None,
-            ) as project_balancing,
-        ):
+        with patch_config(
+            {
+                BLENDED_SAMPLE_RATE: 1.0,
+                ORG_VOLUME: org_volume,
+                PROJECT_VOLUMES: [],
+                TRANSACTION_VOLUMES: DEFAULT,
+                PROJECT_BALANCING: None,
+            }
+        ) as mocks:
             result = run_calculations_per_org_task(org.id)
 
         assert result == DynamicSamplingStatus.NO_PROJECT_VOLUMES
-        get_blended_sample_rate.assert_called_once_with(organization_id=org.id)
-        _assert_called_once_with_config(get_volume, org.id)
-        _assert_called_once_with_config(get_project_volumes, org.id)
-        project_balancing.assert_not_called()
-        get_transaction_volumes.assert_not_called()
+        mocks[BLENDED_SAMPLE_RATE].assert_called_once_with(organization_id=org.id)
+        _assert_called_once_with_config(mocks[ORG_VOLUME], org.id)
+        _assert_called_once_with_config(mocks[PROJECT_VOLUMES], org.id)
+        mocks[PROJECT_BALANCING].assert_not_called()
+        mocks[TRANSACTION_VOLUMES].assert_not_called()
 
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
     def test_run_calculations_per_org_returns_no_volume_without_transaction_volumes(self) -> None:
         org = self.create_organization()
         project = self.create_project(organization=org)
         org_volume = OrganizationDataVolume(org_id=org.id, total=100, indexed=25)
-        project_volumes = [_project_volume(project.id)]
+        project_volumes = [make_project_volume(project.id)]
         rebalanced_projects = [RebalancedItem(id=project.id, count=100, new_sample_rate=0.5)]
         cached_sample_rates: dict[int, float | None] = {}
 
-        with (
-            patch(
-                "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate",
-                return_value=1.0,
-            ) as get_blended_sample_rate,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_organization_volume",
-                return_value=org_volume,
-            ) as get_volume,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_project_volumes",
-                return_value=project_volumes,
-            ) as get_project_volumes,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.run_project_balancing",
-                return_value=rebalanced_projects,
-            ) as project_balancing,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_cached_rebalanced_project_sample_rates",
-                return_value=cached_sample_rates,
-            ) as get_cached_sample_rates,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.compare_rebalanced_projects_with_cache"
-            ) as compare_rebalanced_projects,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_transaction_volumes",
-                return_value=[],
-            ) as get_transaction_volumes,
-        ):
+        with patch_config(
+            {
+                BLENDED_SAMPLE_RATE: 1.0,
+                ORG_VOLUME: org_volume,
+                PROJECT_VOLUMES: project_volumes,
+                PROJECT_BALANCING: rebalanced_projects,
+                CACHED_PROJECT_RATES: cached_sample_rates,
+                COMPARE_PROJECTS: DEFAULT,
+                TRANSACTION_VOLUMES: [],
+            }
+        ) as mocks:
             result = run_calculations_per_org_task(org.id)
 
         assert result == DynamicSamplingStatus.NO_TRANSACTION_VOLUMES
-        get_blended_sample_rate.assert_called_once_with(organization_id=org.id)
-        _assert_called_once_with_config(get_volume, org.id)
-        project_config = _assert_called_once_with_config(get_project_volumes, org.id)
-        project_balancing.assert_called_once_with(project_config, project_volumes)
-        get_cached_sample_rates.assert_called_once_with(org.id)
-        compare_rebalanced_projects.assert_called_once_with(
+        mocks[BLENDED_SAMPLE_RATE].assert_called_once_with(organization_id=org.id)
+        _assert_called_once_with_config(mocks[ORG_VOLUME], org.id)
+        project_config = _assert_called_once_with_config(mocks[PROJECT_VOLUMES], org.id)
+        mocks[PROJECT_BALANCING].assert_called_once_with(project_config, project_volumes)
+        mocks[CACHED_PROJECT_RATES].assert_called_once_with(org.id)
+        mocks[COMPARE_PROJECTS].assert_called_once_with(
             project_config, rebalanced_projects, cached_sample_rates, project_volumes
         )
-        _assert_called_once_with_config(get_transaction_volumes, org.id)
+        _assert_called_once_with_config(mocks[TRANSACTION_VOLUMES], org.id)
 
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
     def test_run_calculations_per_org_skips_project_balancing_for_project_mode(self) -> None:
@@ -265,49 +220,38 @@ class RunCalculationsPerOrgTest(TestCase):
         org.update_option("sentry:sampling_mode", DynamicSamplingMode.PROJECT)
         project.update_option("sentry:target_sample_rate", 0.2)
         org_volume = OrganizationDataVolume(org_id=org.id, total=100, indexed=25)
-        project_volumes = [_project_volume(project.id)]
+        project_volumes = [make_project_volume(project.id)]
+        transaction_volumes = [
+            ProjectTransactionCounts(
+                org_id=org.id,
+                project_id=project.id,
+                transaction_counts=[("checkout", 1.0)],
+            )
+        ]
 
         with (
             self.feature("organizations:dynamic-sampling-custom"),
-            patch(
-                "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate"
-            ) as get_blended_sample_rate,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_organization_volume",
-                return_value=org_volume,
-            ) as get_volume,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_project_volumes",
-                return_value=project_volumes,
-            ) as get_project_volumes,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.run_project_balancing",
-            ) as project_balancing,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_transaction_volumes",
-                return_value=[
-                    ProjectTransactionCounts(
-                        org_id=org.id,
-                        project_id=project.id,
-                        transaction_counts=[("checkout", 1.0)],
-                    )
-                ],
-            ) as get_transaction_volumes,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.run_transaction_balancing",
-                return_value={},
-            ) as transaction_balancing,
+            patch_config(
+                {
+                    BLENDED_SAMPLE_RATE: DEFAULT,
+                    ORG_VOLUME: org_volume,
+                    PROJECT_VOLUMES: project_volumes,
+                    PROJECT_BALANCING: DEFAULT,
+                    TRANSACTION_VOLUMES: transaction_volumes,
+                    TRANSACTION_BALANCING: {},
+                }
+            ) as mocks,
         ):
             result = run_calculations_per_org_task(org.id)
 
         assert result is None
-        get_blended_sample_rate.assert_not_called()
-        _assert_called_once_with_config(get_volume, org.id)
-        _assert_called_once_with_config(get_project_volumes, org.id)
-        project_balancing.assert_not_called()
-        transaction_config = _assert_called_once_with_config(get_transaction_volumes, org.id)
-        transaction_balancing.assert_called_once_with(
-            transaction_config, project_volumes, get_transaction_volumes.return_value
+        mocks[BLENDED_SAMPLE_RATE].assert_not_called()
+        _assert_called_once_with_config(mocks[ORG_VOLUME], org.id)
+        _assert_called_once_with_config(mocks[PROJECT_VOLUMES], org.id)
+        mocks[PROJECT_BALANCING].assert_not_called()
+        transaction_config = _assert_called_once_with_config(mocks[TRANSACTION_VOLUMES], org.id)
+        mocks[TRANSACTION_BALANCING].assert_called_once_with(
+            transaction_config, project_volumes, transaction_volumes
         )
 
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
@@ -316,63 +260,46 @@ class RunCalculationsPerOrgTest(TestCase):
         project = self.create_project(organization=org)
         org.update_option("sentry:sampling_mode", DynamicSamplingMode.ORGANIZATION)
         org_volume = OrganizationDataVolume(org_id=org.id, total=100, indexed=25)
-        project_volumes = [_project_volume(project.id)]
+        project_volumes = [make_project_volume(project.id)]
         rebalanced_projects = [RebalancedItem(id=project.id, count=100, new_sample_rate=0.5)]
         cached_sample_rates: dict[int, float | None] = {}
+        transaction_volumes = [
+            ProjectTransactionCounts(
+                org_id=org.id,
+                project_id=project.id,
+                transaction_counts=[("checkout", 1.0)],
+            )
+        ]
 
         with (
             self.feature("organizations:dynamic-sampling-custom"),
-            patch(
-                "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate"
-            ) as get_blended_sample_rate,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_organization_volume",
-                return_value=org_volume,
-            ) as get_volume,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_project_volumes",
-                return_value=project_volumes,
-            ) as get_project_volumes,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.run_project_balancing",
-                return_value=rebalanced_projects,
-            ) as project_balancing,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_cached_rebalanced_project_sample_rates",
-                return_value=cached_sample_rates,
-            ) as get_cached_sample_rates,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.compare_rebalanced_projects_with_cache"
-            ) as compare_rebalanced_projects,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_transaction_volumes",
-                return_value=[
-                    ProjectTransactionCounts(
-                        org_id=org.id,
-                        project_id=project.id,
-                        transaction_counts=[("checkout", 1.0)],
-                    )
-                ],
-            ) as get_transaction_volumes,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.run_transaction_balancing",
-                return_value={},
-            ) as transaction_balancing,
+            patch_config(
+                {
+                    BLENDED_SAMPLE_RATE: DEFAULT,
+                    ORG_VOLUME: org_volume,
+                    PROJECT_VOLUMES: project_volumes,
+                    PROJECT_BALANCING: rebalanced_projects,
+                    CACHED_PROJECT_RATES: cached_sample_rates,
+                    COMPARE_PROJECTS: DEFAULT,
+                    TRANSACTION_VOLUMES: transaction_volumes,
+                    TRANSACTION_BALANCING: {},
+                }
+            ) as mocks,
         ):
             result = run_calculations_per_org_task(org.id)
 
         assert result is None
-        get_blended_sample_rate.assert_not_called()
-        _assert_called_once_with_config(get_volume, org.id)
-        project_config = _assert_called_once_with_config(get_project_volumes, org.id)
-        project_balancing.assert_called_once_with(project_config, project_volumes)
-        get_cached_sample_rates.assert_called_once_with(org.id)
-        compare_rebalanced_projects.assert_called_once_with(
+        mocks[BLENDED_SAMPLE_RATE].assert_not_called()
+        _assert_called_once_with_config(mocks[ORG_VOLUME], org.id)
+        project_config = _assert_called_once_with_config(mocks[PROJECT_VOLUMES], org.id)
+        mocks[PROJECT_BALANCING].assert_called_once_with(project_config, project_volumes)
+        mocks[CACHED_PROJECT_RATES].assert_called_once_with(org.id)
+        mocks[COMPARE_PROJECTS].assert_called_once_with(
             project_config, rebalanced_projects, cached_sample_rates, project_volumes
         )
-        transaction_config = _assert_called_once_with_config(get_transaction_volumes, org.id)
-        transaction_balancing.assert_called_once_with(
-            transaction_config, project_volumes, get_transaction_volumes.return_value
+        transaction_config = _assert_called_once_with_config(mocks[TRANSACTION_VOLUMES], org.id)
+        mocks[TRANSACTION_BALANCING].assert_called_once_with(
+            transaction_config, project_volumes, transaction_volumes
         )
 
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
@@ -383,152 +310,107 @@ class RunCalculationsPerOrgTest(TestCase):
 
         with (
             self.feature("organizations:dynamic-sampling-custom"),
-            patch(
-                "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate"
-            ) as get_blended_sample_rate,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_organization_volume"
-            ) as get_volume,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_project_volumes"
-            ) as get_project_volumes,
+            patch_config(
+                {
+                    BLENDED_SAMPLE_RATE: DEFAULT,
+                    ORG_VOLUME: DEFAULT,
+                    PROJECT_VOLUMES: DEFAULT,
+                }
+            ) as mocks,
         ):
             result = run_calculations_per_org_task(org.id)
 
         assert result == DynamicSamplingStatus.ORG_HAS_NO_DYNAMIC_SAMPLING
-        get_blended_sample_rate.assert_not_called()
-        get_volume.assert_not_called()
-        get_project_volumes.assert_not_called()
+        mocks[BLENDED_SAMPLE_RATE].assert_not_called()
+        mocks[ORG_VOLUME].assert_not_called()
+        mocks[PROJECT_VOLUMES].assert_not_called()
 
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
     def test_run_calculations_per_org_queries_projects_for_am2(self) -> None:
         org = self.create_organization()
         project = self.create_project(organization=org)
         org_volume = OrganizationDataVolume(org_id=org.id, total=100, indexed=25)
-        project_volumes = [_project_volume(project.id)]
+        project_volumes = [make_project_volume(project.id)]
         rebalanced_projects = [RebalancedItem(id=project.id, count=100, new_sample_rate=0.5)]
         cached_sample_rates: dict[int, float | None] = {}
+        transaction_volumes = [
+            ProjectTransactionCounts(
+                org_id=org.id,
+                project_id=project.id,
+                transaction_counts=[("checkout", 1.0)],
+            )
+        ]
 
-        with (
-            patch(
-                "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate",
-                return_value=1.0,
-            ) as get_blended_sample_rate,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_organization_volume",
-                return_value=org_volume,
-            ) as get_volume,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_project_volumes",
-                return_value=project_volumes,
-            ) as get_project_volumes,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.run_project_balancing",
-                return_value=rebalanced_projects,
-            ) as project_balancing,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_cached_rebalanced_project_sample_rates",
-                return_value=cached_sample_rates,
-            ) as get_cached_sample_rates,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.compare_rebalanced_projects_with_cache"
-            ) as compare_rebalanced_projects,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_transaction_volumes",
-                return_value=[
-                    ProjectTransactionCounts(
-                        org_id=org.id,
-                        project_id=project.id,
-                        transaction_counts=[("checkout", 1.0)],
-                    )
-                ],
-            ) as get_transaction_volumes,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.run_transaction_balancing",
-                return_value={},
-            ) as transaction_balancing,
-        ):
+        with patch_config(
+            {
+                BLENDED_SAMPLE_RATE: 1.0,
+                ORG_VOLUME: org_volume,
+                PROJECT_VOLUMES: project_volumes,
+                PROJECT_BALANCING: rebalanced_projects,
+                CACHED_PROJECT_RATES: cached_sample_rates,
+                COMPARE_PROJECTS: DEFAULT,
+                TRANSACTION_VOLUMES: transaction_volumes,
+                TRANSACTION_BALANCING: {},
+            }
+        ) as mocks:
             result = run_calculations_per_org_task(org.id)
 
         assert result is None
-        get_blended_sample_rate.assert_called_once_with(organization_id=org.id)
-        _assert_called_once_with_config(get_volume, org.id)
-        project_config = _assert_called_once_with_config(get_project_volumes, org.id)
-        project_balancing.assert_called_once_with(project_config, project_volumes)
-        get_cached_sample_rates.assert_called_once_with(org.id)
-        compare_rebalanced_projects.assert_called_once_with(
+        mocks[BLENDED_SAMPLE_RATE].assert_called_once_with(organization_id=org.id)
+        _assert_called_once_with_config(mocks[ORG_VOLUME], org.id)
+        project_config = _assert_called_once_with_config(mocks[PROJECT_VOLUMES], org.id)
+        mocks[PROJECT_BALANCING].assert_called_once_with(project_config, project_volumes)
+        mocks[CACHED_PROJECT_RATES].assert_called_once_with(org.id)
+        mocks[COMPARE_PROJECTS].assert_called_once_with(
             project_config, rebalanced_projects, cached_sample_rates, project_volumes
         )
-        transaction_config = _assert_called_once_with_config(get_transaction_volumes, org.id)
+        transaction_config = _assert_called_once_with_config(mocks[TRANSACTION_VOLUMES], org.id)
         # Every root project is queried, not only the ones being rebalanced. Narrowing
         # to `projects_to_balance` drops every segment rooted at a project sampled at
         # 100%, so those root projects report no transaction volume at all.
-        assert "root_projects" not in get_transaction_volumes.call_args.kwargs
-        transaction_balancing.assert_called_once_with(
-            transaction_config, project_volumes, get_transaction_volumes.return_value
+        assert "root_projects" not in mocks[TRANSACTION_VOLUMES].call_args.kwargs
+        mocks[TRANSACTION_BALANCING].assert_called_once_with(
+            transaction_config, project_volumes, transaction_volumes
         )
 
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
     def test_run_calculations_per_org_skips_org_without_transaction_sample_rate(self) -> None:
         org = self.create_organization()
 
-        with (
-            patch(
-                "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate",
-                return_value=None,
-            ) as get_blended_sample_rate,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_organization_volume"
-            ) as get_volume,
-        ):
+        with patch_config({BLENDED_SAMPLE_RATE: None, ORG_VOLUME: DEFAULT}) as mocks:
             result = run_calculations_per_org_task(org.id)
 
         assert result == DynamicSamplingStatus.ORG_HAS_NO_DYNAMIC_SAMPLING
-        get_blended_sample_rate.assert_called_once_with(organization_id=org.id)
-        get_volume.assert_not_called()
+        mocks[BLENDED_SAMPLE_RATE].assert_called_once_with(organization_id=org.id)
+        mocks[ORG_VOLUME].assert_not_called()
 
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
     def test_run_calculations_per_org_skips_org_without_projects(self) -> None:
         org = self.create_organization()
 
-        with (
-            patch(
-                "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate",
-                return_value=1.0,
-            ),
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_organization_volume"
-            ) as get_volume,
-        ):
+        with patch_config({BLENDED_SAMPLE_RATE: 1.0, ORG_VOLUME: DEFAULT}) as mocks:
             result = run_calculations_per_org_task(org.id)
 
         assert result == DynamicSamplingStatus.ORG_HAS_NO_PROJECTS
-        get_volume.assert_not_called()
+        mocks[ORG_VOLUME].assert_not_called()
 
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
     def test_run_calculations_per_org_skips_org_without_subscription(self) -> None:
         org = self.create_organization()
 
         with (
-            patch(
-                "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate",
-                side_effect=ObjectDoesNotExist,
-            ),
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_organization_volume"
-            ) as get_volume,
+            patch(BLENDED_SAMPLE_RATE, side_effect=ObjectDoesNotExist),
+            patch_config({ORG_VOLUME: DEFAULT}) as mocks,
         ):
             result = run_calculations_per_org_task(org.id)
 
         assert result == DynamicSamplingStatus.NO_SUBSCRIPTION
-        get_volume.assert_not_called()
+        mocks[ORG_VOLUME].assert_not_called()
 
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
     def test_run_calculations_per_org_skips_missing_org(self) -> None:
-        with patch(
-            "sentry.dynamic_sampling.per_org.scheduler.get_eap_organization_volume"
-        ) as get_volume:
+        with patch_config({ORG_VOLUME: DEFAULT}) as mocks:
             result = run_calculations_per_org_task(99999999)
 
         assert result == DynamicSamplingStatus.ORG_HAS_NO_DYNAMIC_SAMPLING
-        get_volume.assert_not_called()
+        mocks[ORG_VOLUME].assert_not_called()

--- a/tests/sentry/dynamic_sampling/per_org/test_scheduler.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_scheduler.py
@@ -21,7 +21,7 @@ from sentry.testutils.helpers.options import override_options
 from tests.sentry.dynamic_sampling.per_org.test_helpers import (
     BLENDED_SAMPLE_RATE,
     make_project_volume,
-    patch_config,
+    patch_configuration,
 )
 
 SCHEDULER = "sentry.dynamic_sampling.per_org.scheduler"
@@ -107,7 +107,7 @@ class RunCalculationsPerOrgTest(TestCase):
         org = self.create_organization()
         self.create_project(organization=org)
 
-        with patch_config(
+        with patch_configuration(
             {
                 BLENDED_SAMPLE_RATE: 1.0,
                 ORG_VOLUME: None,
@@ -130,7 +130,7 @@ class RunCalculationsPerOrgTest(TestCase):
         rebalanced_projects = [RebalancedItem(id=project.id, count=100, new_sample_rate=1.0)]
         cached_sample_rates: dict[int, float | None] = {}
 
-        with patch_config(
+        with patch_configuration(
             {
                 BLENDED_SAMPLE_RATE: 1.0,
                 ORG_VOLUME: org_volume,
@@ -162,7 +162,7 @@ class RunCalculationsPerOrgTest(TestCase):
         self.create_project(organization=org)
         org_volume = OrganizationDataVolume(org_id=org.id, total=100, indexed=25)
 
-        with patch_config(
+        with patch_configuration(
             {
                 BLENDED_SAMPLE_RATE: 1.0,
                 ORG_VOLUME: org_volume,
@@ -189,7 +189,7 @@ class RunCalculationsPerOrgTest(TestCase):
         rebalanced_projects = [RebalancedItem(id=project.id, count=100, new_sample_rate=0.5)]
         cached_sample_rates: dict[int, float | None] = {}
 
-        with patch_config(
+        with patch_configuration(
             {
                 BLENDED_SAMPLE_RATE: 1.0,
                 ORG_VOLUME: org_volume,
@@ -231,7 +231,7 @@ class RunCalculationsPerOrgTest(TestCase):
 
         with (
             self.feature("organizations:dynamic-sampling-custom"),
-            patch_config(
+            patch_configuration(
                 {
                     BLENDED_SAMPLE_RATE: DEFAULT,
                     ORG_VOLUME: org_volume,
@@ -273,7 +273,7 @@ class RunCalculationsPerOrgTest(TestCase):
 
         with (
             self.feature("organizations:dynamic-sampling-custom"),
-            patch_config(
+            patch_configuration(
                 {
                     BLENDED_SAMPLE_RATE: DEFAULT,
                     ORG_VOLUME: org_volume,
@@ -310,7 +310,7 @@ class RunCalculationsPerOrgTest(TestCase):
 
         with (
             self.feature("organizations:dynamic-sampling-custom"),
-            patch_config(
+            patch_configuration(
                 {
                     BLENDED_SAMPLE_RATE: DEFAULT,
                     ORG_VOLUME: DEFAULT,
@@ -341,7 +341,7 @@ class RunCalculationsPerOrgTest(TestCase):
             )
         ]
 
-        with patch_config(
+        with patch_configuration(
             {
                 BLENDED_SAMPLE_RATE: 1.0,
                 ORG_VOLUME: org_volume,
@@ -377,7 +377,7 @@ class RunCalculationsPerOrgTest(TestCase):
     def test_run_calculations_per_org_skips_org_without_transaction_sample_rate(self) -> None:
         org = self.create_organization()
 
-        with patch_config({BLENDED_SAMPLE_RATE: None, ORG_VOLUME: DEFAULT}) as mocks:
+        with patch_configuration({BLENDED_SAMPLE_RATE: None, ORG_VOLUME: DEFAULT}) as mocks:
             result = run_calculations_per_org_task(org.id)
 
         assert result == DynamicSamplingStatus.ORG_HAS_NO_DYNAMIC_SAMPLING
@@ -388,7 +388,7 @@ class RunCalculationsPerOrgTest(TestCase):
     def test_run_calculations_per_org_skips_org_without_projects(self) -> None:
         org = self.create_organization()
 
-        with patch_config({BLENDED_SAMPLE_RATE: 1.0, ORG_VOLUME: DEFAULT}) as mocks:
+        with patch_configuration({BLENDED_SAMPLE_RATE: 1.0, ORG_VOLUME: DEFAULT}) as mocks:
             result = run_calculations_per_org_task(org.id)
 
         assert result == DynamicSamplingStatus.ORG_HAS_NO_PROJECTS
@@ -400,7 +400,7 @@ class RunCalculationsPerOrgTest(TestCase):
 
         with (
             patch(BLENDED_SAMPLE_RATE, side_effect=ObjectDoesNotExist),
-            patch_config({ORG_VOLUME: DEFAULT}) as mocks,
+            patch_configuration({ORG_VOLUME: DEFAULT}) as mocks,
         ):
             result = run_calculations_per_org_task(org.id)
 
@@ -409,7 +409,7 @@ class RunCalculationsPerOrgTest(TestCase):
 
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
     def test_run_calculations_per_org_skips_missing_org(self) -> None:
-        with patch_config({ORG_VOLUME: DEFAULT}) as mocks:
+        with patch_configuration({ORG_VOLUME: DEFAULT}) as mocks:
             result = run_calculations_per_org_task(99999999)
 
         assert result == DynamicSamplingStatus.ORG_HAS_NO_DYNAMIC_SAMPLING

--- a/tests/sentry/dynamic_sampling/per_org/test_telemetry.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_telemetry.py
@@ -1,8 +1,5 @@
 from __future__ import annotations
 
-from contextlib import contextmanager
-from unittest.mock import patch
-
 import pytest
 
 from sentry.dynamic_sampling.per_org.telemetry import (
@@ -13,6 +10,8 @@ from sentry.dynamic_sampling.per_org.telemetry import (
 from sentry.testutils.helpers.options import override_options
 from sentry.utils.snuba_rpc import SnubaRPCError, SnubaRPCTimeout
 
+# The metrics sample rate is overridden only so emitting a metric does not read the
+# option from the database; none of these tests assert on the emitted metrics.
 _GATE_OPTIONS = {
     "dynamic-sampling.per_org.killswitch": False,
     "dynamic-sampling.per_org.metrics-sample-rate": 1.0,
@@ -20,140 +19,84 @@ _GATE_OPTIONS = {
 }
 
 
-def _capture_timer_tags() -> tuple[object, dict[str, str]]:
-    tags: dict[str, str] = {}
-
-    @contextmanager
-    def timer(*args: object, **kwargs: object):
-        yield tags
-
-    return timer, tags
-
-
 @override_options(_GATE_OPTIONS)
-def test_records_duration_and_reraises_with_failed_status_on_exception() -> None:
-    error = ValueError("nope")
-
+def test_reraises_exception() -> None:
     @track_dynamic_sampling
     def boom() -> None:
-        raise error
+        raise ValueError("nope")
 
-    timer, timer_tags = _capture_timer_tags()
-
-    with (
-        patch("sentry.dynamic_sampling.per_org.telemetry.metrics") as mock_metrics,
-        patch("sentry.dynamic_sampling.per_org.telemetry.emit_status") as emit,
-        pytest.raises(ValueError),
-    ):
-        mock_metrics.timer.side_effect = timer
+    with pytest.raises(ValueError):
         boom()
-
-    assert timer_tags["status"] == DynamicSamplingStatus.FAILED.value
-    emit.assert_called_once_with("dynamic_sampling.boom.status", DynamicSamplingStatus.FAILED)
 
 
 @override_options(_GATE_OPTIONS)
-def test_reraises_snuba_timeout_and_emits_timeout_status() -> None:
-    error = SnubaRPCTimeout("timed out")
-
+def test_reraises_snuba_timeout() -> None:
     @track_dynamic_sampling
     def boom() -> None:
-        raise error
+        raise SnubaRPCTimeout("timed out")
 
-    timer, timer_tags = _capture_timer_tags()
-
-    with (
-        patch("sentry.dynamic_sampling.per_org.telemetry.metrics") as mock_metrics,
-        patch("sentry.dynamic_sampling.per_org.telemetry.emit_status") as emit,
-        pytest.raises(SnubaRPCTimeout),
-    ):
-        mock_metrics.timer.side_effect = timer
+    with pytest.raises(SnubaRPCTimeout):
         boom()
-
-    assert timer_tags["status"] == DynamicSamplingStatus.FAILED.value
-    emit.assert_called_once_with(
-        "dynamic_sampling.boom.status", DynamicSamplingStatus.SNUBA_TIMEOUT
-    )
 
 
 @override_options(_GATE_OPTIONS)
-def test_reraises_snuba_error_and_emits_snuba_error_status() -> None:
-    error = SnubaRPCError("snuba failed")
-
+def test_reraises_snuba_error() -> None:
     @track_dynamic_sampling
     def boom() -> None:
-        raise error
+        raise SnubaRPCError("snuba failed")
 
-    timer, timer_tags = _capture_timer_tags()
-
-    with (
-        patch("sentry.dynamic_sampling.per_org.telemetry.metrics") as mock_metrics,
-        patch("sentry.dynamic_sampling.per_org.telemetry.emit_status") as emit,
-        pytest.raises(SnubaRPCError),
-    ):
-        mock_metrics.timer.side_effect = timer
+    with pytest.raises(SnubaRPCError):
         boom()
-
-    assert timer_tags["status"] == DynamicSamplingStatus.FAILED.value
-    emit.assert_called_once_with("dynamic_sampling.boom.status", DynamicSamplingStatus.SNUBA_ERROR)
 
 
 @override_options(_GATE_OPTIONS)
-def test_passes_result_through_and_emits_completed_on_success() -> None:
+def test_passes_result_through() -> None:
     @track_dynamic_sampling
     def add(x: int, y: int) -> int:
         return x + y
 
-    timer, timer_tags = _capture_timer_tags()
-    with (
-        patch("sentry.dynamic_sampling.per_org.telemetry.metrics") as mock_metrics,
-        patch("sentry.dynamic_sampling.per_org.telemetry.emit_status") as emit,
-    ):
-        mock_metrics.timer.side_effect = timer
-        assert add(2, 3) == 5
-
-    mock_metrics.timer.assert_called_once_with("dynamic_sampling.add.duration", sample_rate=1.0)
-    assert timer_tags["status"] == DynamicSamplingStatus.COMPLETED.value
-    emit.assert_called_once_with("dynamic_sampling.add.status", DynamicSamplingStatus.COMPLETED)
+    assert add(2, 3) == 5
 
 
 @override_options(_GATE_OPTIONS)
-def test_emits_returned_terminal_status_without_completed_status() -> None:
+def test_returns_terminal_status_unchanged() -> None:
     @track_dynamic_sampling
     def skipped() -> DynamicSamplingStatus:
         return DynamicSamplingStatus.NOT_IN_ROLLOUT
 
-    timer, timer_tags = _capture_timer_tags()
-    with (
-        patch("sentry.dynamic_sampling.per_org.telemetry.metrics") as mock_metrics,
-        patch("sentry.dynamic_sampling.per_org.telemetry.emit_status") as emit,
-    ):
-        mock_metrics.timer.side_effect = timer
-        assert skipped() == DynamicSamplingStatus.NOT_IN_ROLLOUT
-
-    mock_metrics.timer.assert_called_once_with("dynamic_sampling.skipped.duration", sample_rate=1.0)
-    assert timer_tags["status"] == DynamicSamplingStatus.NOT_IN_ROLLOUT.value
-    emit.assert_called_once_with(
-        "dynamic_sampling.skipped.status", DynamicSamplingStatus.NOT_IN_ROLLOUT
-    )
+    assert skipped() == DynamicSamplingStatus.NOT_IN_ROLLOUT
 
 
 @override_options(_GATE_OPTIONS)
-def test_emits_terminal_status_exception_without_failed_status() -> None:
+def test_terminal_status_exception_becomes_return_value() -> None:
     @track_dynamic_sampling
     def skipped() -> None:
         raise DynamicSamplingException(DynamicSamplingStatus.NO_SUBSCRIPTION)
 
-    timer, timer_tags = _capture_timer_tags()
-    with (
-        patch("sentry.dynamic_sampling.per_org.telemetry.metrics") as mock_metrics,
-        patch("sentry.dynamic_sampling.per_org.telemetry.emit_status") as emit,
-    ):
-        mock_metrics.timer.side_effect = timer
-        assert skipped() == DynamicSamplingStatus.NO_SUBSCRIPTION
+    assert skipped() == DynamicSamplingStatus.NO_SUBSCRIPTION
 
-    mock_metrics.timer.assert_called_once_with("dynamic_sampling.skipped.duration", sample_rate=1.0)
-    assert timer_tags["status"] == DynamicSamplingStatus.NO_SUBSCRIPTION.value
-    emit.assert_called_once_with(
-        "dynamic_sampling.skipped.status", DynamicSamplingStatus.NO_SUBSCRIPTION
-    )
+
+@override_options({**_GATE_OPTIONS, "dynamic-sampling.per_org.killswitch": True})
+def test_killswitch_skips_the_wrapped_function() -> None:
+    calls: list[None] = []
+
+    @track_dynamic_sampling
+    def work() -> str:
+        calls.append(None)
+        return "ran"
+
+    assert work() == DynamicSamplingStatus.KILLSWITCHED
+    assert calls == []
+
+
+@override_options({**_GATE_OPTIONS, "dynamic-sampling.per_org.rollout-rate": 0.0})
+def test_disabled_rollout_skips_the_wrapped_function() -> None:
+    calls: list[None] = []
+
+    @track_dynamic_sampling
+    def work() -> str:
+        calls.append(None)
+        return "ran"
+
+    assert work() == DynamicSamplingStatus.ROLLOUT_DISABLED
+    assert calls == []


### PR DESCRIPTION
Applies the patch helper from #121142 to the other per-org test modules.

- Move the patch helper and mock path constants into a shared `test_helpers` module
- Share `make_project_volume`, previously duplicated in two modules
- Add `mock_configuration` to replace the repeated four-line `Mock` setup
- Remove the metrics assertions from the telemetry tests
- Add tests for the killswitch and disabled-rollout paths of the decorator