### PR TITLE
fix(objectstore): Correct upload and response timeout handling

### DIFF
--- a/src/sentry/objectstore/__init__.py
+++ b/src/sentry/objectstore/__init__.py
@@ -97,7 +97,7 @@ def create_client() -> Client:
         timeout_ms=options.get("timeout_ms", None),
         connection_kwargs=options.get(
             "connection_kwargs",
-            {"timeout": urllib3.Timeout(connect=5.0), "maxsize": 32},
+            {"timeout": urllib3.Timeout(connect=5.0, read=None), "maxsize": 32},
         ),
         token=token_generator,
     )

--- a/src/sentry/objectstore/__init__.py
+++ b/src/sentry/objectstore/__init__.py
@@ -97,8 +97,7 @@ def create_client() -> Client:
         timeout_ms=options.get("timeout_ms", None),
         connection_kwargs=options.get(
             "connection_kwargs",
-            # timeout is a workaround for 0.0.14's default read timeout, can be removed with 0.0.15
-            {"timeout": urllib3.Timeout(connect=0.1), "maxsize": 32},
+            {"timeout": urllib3.Timeout(connect=5.0), "maxsize": 32},
         ),
         token=token_generator,
     )


### PR DESCRIPTION
Increase the Objectstore client's connection timeout from 100ms to 5s and explicitly disable the response read timeout.

Despite its name, urllib3 keeps the connection timeout on the socket while streaming the request body, so it also limits each body-chunk write on PUT/POST requests. Large uploads perform thousands of these socket writes, making a transient Envoy backpressure or scheduling pause much more likely to trip the 100ms limit even when the connection and Objectstore are healthy.

Five seconds matches HTTPX's default per-chunk write timeout and is close to the six-second timeout used by Sentry's GCS and Symbolicator clients. Other established storage clients are more permissive: Botocore and Google Cloud Storage default to 60 seconds.

We intended to remove the Objectstore response read timeout when the client default changed in 0.0.15  (https://github.com/getsentry/sentry/pull/108112). However, our override omitted `read` rather than setting `read=None`, so urllib3 inadvertently inherited Sentry's global five-second socket timeout. This caused Sentry to abandon uploads while Objectstore was still processing them, before Envoy's route timeout could apply. Setting `read=None` restores the intended behavior and lets Envoy enforce the post-upload request deadline.

Fixes SENTRY-5S15
Fixes SENTRY-5S1C
Fixes SENTRY-5RMG
Fixes SENTRY-5RXK
