### PR TITLE
fix(scraps): Stop tooltip content clicks from triggering ancestors

### DIFF
--- a/static/app/components/core/tooltip/tooltip.spec.tsx
+++ b/static/app/components/core/tooltip/tooltip.spec.tsx
@@ -186,4 +186,19 @@ describe('Tooltip', () => {
 
     expect(screen.queryByText('test')).not.toBeInTheDocument();
   });
+
+  it('does not trigger the wrapping element when clicking tooltip content', async () => {
+    const handleAncestorClick = jest.fn();
+
+    render(
+      <button type="button" onClick={handleAncestorClick}>
+        <Tooltip title={<span>Copy</span>} isHoverable forceVisible>
+          <div>Trigger</div>
+        </Tooltip>
+      </button>
+    );
+
+    await userEvent.click(screen.getByText('Copy'));
+    expect(handleAncestorClick).not.toHaveBeenCalled();
+  });
 });

--- a/static/app/components/core/tooltip/tooltip.tsx
+++ b/static/app/components/core/tooltip/tooltip.tsx
@@ -95,7 +95,20 @@ export function Tooltip({
         snapClosed ? null : (
           <AnimatePresence>
             {isOpen ? (
-              <PositionWrapper zIndex={theme.zIndex.tooltip} {...overlayProps}>
+              <PositionWrapper
+                zIndex={theme.zIndex.tooltip}
+                {...overlayProps}
+                // The tooltip content is portaled to the document body, but
+                // React events still bubble through the React tree — so a click
+                // inside the tooltip would reach the trigger's interactive
+                // ancestor (a Link, tab, menu item, ...) and fire its action.
+                // Stop the interaction-initiating events here so interacting
+                // with tooltip content (selecting text, clicking a copy button)
+                // never triggers the element the tooltip is attached to.
+                onClick={stopPropagation}
+                onMouseDown={stopPropagation}
+                onPointerDown={stopPropagation}
+              >
                 <TooltipContent
                   animated
                   maxWidth={maxWidth}
@@ -115,6 +128,10 @@ export function Tooltip({
       )}
     </Fragment>
   );
+}
+
+function stopPropagation(e: React.SyntheticEvent) {
+  e.stopPropagation();
 }
 
 const TooltipContent = styled(Overlay, {

--- a/static/app/components/version.tsx
+++ b/static/app/components/version.tsx
@@ -116,13 +116,7 @@ export function Version({
   };
 
   const renderTooltipContent = () => (
-    <Flex
-      as="span"
-      align="center"
-      onClick={e => {
-        e.stopPropagation();
-      }}
-    >
+    <Flex as="span" align="center">
       <TooltipVersionWrapper>{version}</TooltipVersionWrapper>
       <CopyToClipboardButton
         variant="transparent"


### PR DESCRIPTION
Tooltip content is portaled to `document.body`, but React events still bubble through the React component tree — not the DOM tree. So a click inside a tooltip reaches whatever interactive element the tooltip is nested within and fires its action. Clicking a link inside the tooltip, or pressing a button in it, or even selecting the tooltip text, would trigger the ancestor.

This bites whenever an interactive element is an *ancestor* of the `<Tooltip>` (as opposed to being the tooltip's trigger, which is a harmless sibling of the content). Concrete cases:

- A `FeatureBadge` in a tab header: clicking the badge tooltip navigates the tab.
- A component like `Version` dropped inside a clickable row: clicking the copy button in its tooltip triggers the row.
- A `Button` whose label carries an `InfoText`: a click aimed at a link inside the tip fires the button (e.g. finalizing a release).

The fix stops the interaction-initiating events (`click`, `mousedown`, `pointerdown`) at the portaled overlay, so tooltip content can never trigger the element the tooltip is attached to. This covers both event models — react-router `<Link>` fires on `click`, react-aria tabs and menu items fire on `pointerdown`. Non-triggering events (text selection, keyboard) are left untouched.

`Version` previously worked around this with a manual `stopPropagation` on its tooltip content; that's now redundant and is removed.

before:

https://github.com/user-attachments/assets/8099c55d-ef43-47ca-b28e-89e5d850d03a

after:

https://github.com/user-attachments/assets/6dd30b64-63c2-4501-bf03-57fb961824d9

