### PR TITLE
chore(dynamic-sampling): emit exception when reason unknown in per-org

### DIFF
--- a/src/sentry/dynamic_sampling/per_org/telemetry.py
+++ b/src/sentry/dynamic_sampling/per_org/telemetry.py
@@ -6,6 +6,8 @@ from contextlib import contextmanager
 from enum import StrEnum
 from typing import TypeVar
 
+import sentry_sdk
+
 from sentry.dynamic_sampling.per_org.gate import (
     is_killswitch_engaged,
     is_rollout_enabled,
@@ -131,8 +133,9 @@ def track_dynamic_sampling(func: F) -> F:
             except SnubaRPCError:
                 emit_status(status_metric, DynamicSamplingStatus.SNUBA_ERROR)
                 raise
-            except Exception:
+            except Exception as exc:
                 emit_status(status_metric, DynamicSamplingStatus.FAILED)
+                sentry_sdk.capture_exception(exc)
                 raise
 
             status = set_duration_status(result)


### PR DESCRIPTION
We've been swallowing these and are seeing a new uptick in errors today - restart emitting errors here