### PR TITLE
feat(agent-monitoring): detect and fence unescaped HTML and JSON in AI content

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentFencing.spec.ts
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentFencing.spec.ts
@@ -33,6 +33,28 @@ ${FENCE}
 `);
   });
 
+  it('fences a Python-repr dict with brackets inside a single-quoted value', () => {
+    const input = "{'msg': 'oops }', 'tpl': 'Hello {name}'}";
+    expect(fenceContent(input)).toBe(`
+
+${FENCE}json
+${input}
+${FENCE}
+
+`);
+  });
+
+  it('fences JSON with an apostrophe inside a double-quoted value', () => {
+    const input = '{"note": "it\'s fine", "n": 1}';
+    expect(fenceContent(input)).toBe(`
+
+${FENCE}json
+${input}
+${FENCE}
+
+`);
+  });
+
   it('fences an attributed HTML block', () => {
     expect(fenceContent('<div class="box">hi</div>')).toBe(`
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentFencing.spec.ts
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentFencing.spec.ts
@@ -82,6 +82,14 @@ Done.`);
     );
   });
 
+  it('wraps JSON followed by a sentence period in inline code', () => {
+    expect(fenceContent('See {"a": 1, "b": 2}.')).toBe('See `{"a": 1, "b": 2}`.');
+  });
+
+  it('wraps JSON followed by a comma in inline code', () => {
+    expect(fenceContent('Given {"a": 1}, proceed')).toBe('Given `{"a": 1}`, proceed');
+  });
+
   it('leaves JSON glued to other tokens untouched', () => {
     const input = 'call with key={"a":1,"b":2} now';
     expect(fenceContent(input)).toBe(input);

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentFencing.spec.ts
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentFencing.spec.ts
@@ -76,6 +76,54 @@ ${FENCE}
 Done.`);
   });
 
+  it('fences nested same-name HTML tags as one block, not truncated', () => {
+    const input = '<div><div>inner</div></div>';
+    expect(fenceContent(input)).toBe(`
+
+${FENCE}html
+${input}
+${FENCE}
+
+`);
+  });
+
+  it('fences a nested list without orphaning closing tags', () => {
+    const input = `<ul>
+  <li>one
+    <ul>
+      <li>nested</li>
+    </ul>
+  </li>
+</ul>`;
+    expect(fenceContent(input)).toBe(`
+
+${FENCE}html
+${input}
+${FENCE}
+
+`);
+  });
+
+  it('keeps a self-closing child inside its enclosing HTML block', () => {
+    const input = '<div>one<br/>two</div>';
+    expect(fenceContent(input)).toBe(`
+
+${FENCE}html
+${input}
+${FENCE}
+
+`);
+  });
+
+  it('does not fence a standalone self-closing tag', () => {
+    expect(fenceContent('<br/>')).toBe('<br/>');
+  });
+
+  it('does not fence a standalone void element', () => {
+    const input = '<img src="x">';
+    expect(fenceContent(input)).toBe(input);
+  });
+
   it('wraps JSON that has prose beside it in inline code', () => {
     expect(fenceContent('the payload {"a":1,"b":2} failed')).toBe(
       'the payload `{"a":1,"b":2}` failed'

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentFencing.spec.ts
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentFencing.spec.ts
@@ -1,0 +1,132 @@
+import {fenceContent} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentFencing';
+
+const FENCE = '```';
+
+describe('fenceContent', () => {
+  it('fences a standalone HTML block as an html code block', () => {
+    expect(fenceContent('<div>markup</div>')).toBe(`
+
+${FENCE}html
+<div>markup</div>
+${FENCE}
+
+`);
+  });
+
+  it('fences a standalone JSON block as a json code block', () => {
+    expect(fenceContent('{"a": 1, "b": 2}')).toBe(`
+
+${FENCE}json
+{"a": 1, "b": 2}
+${FENCE}
+
+`);
+  });
+
+  it('fences a Python-repr dict as a json code block', () => {
+    expect(fenceContent("{'a': 1, 'b': 2}")).toBe(`
+
+${FENCE}json
+{'a': 1, 'b': 2}
+${FENCE}
+
+`);
+  });
+
+  it('fences an attributed HTML block', () => {
+    expect(fenceContent('<div class="box">hi</div>')).toBe(`
+
+${FENCE}html
+<div class="box">hi</div>
+${FENCE}
+
+`);
+  });
+
+  it('fences a multi-line HTML block as a single code block', () => {
+    const input = `<ul>
+  <li>one</li>
+  <li>two</li>
+</ul>`;
+    expect(fenceContent(input)).toBe(`
+
+${FENCE}html
+${input}
+${FENCE}
+
+`);
+  });
+
+  it('fences a multi-line HTML block surrounded by prose', () => {
+    const input = `Here is the markup:
+<div>
+  <span>hi</span>
+</div>
+Done.`;
+    expect(fenceContent(input)).toBe(`Here is the markup:
+
+
+${FENCE}html
+<div>
+  <span>hi</span>
+</div>
+${FENCE}
+
+
+Done.`);
+  });
+
+  it('wraps JSON that has prose beside it in inline code', () => {
+    expect(fenceContent('the payload {"a":1,"b":2} failed')).toBe(
+      'the payload `{"a":1,"b":2}` failed'
+    );
+  });
+
+  it('leaves JSON glued to other tokens untouched', () => {
+    const input = 'call with key={"a":1,"b":2} now';
+    expect(fenceContent(input)).toBe(input);
+  });
+
+  it('leaves trivial braces untouched', () => {
+    const input = 'look at {} and [] here';
+    expect(fenceContent(input)).toBe(input);
+  });
+
+  it('does not re-fence content already inside a code fence', () => {
+    const input = `${FENCE}json
+{"a":1}
+${FENCE}`;
+    expect(fenceContent(input)).toBe(input);
+  });
+
+  it('does not fence unknown/custom tags as HTML', () => {
+    const input = '<thinking>a deep thought</thinking>';
+    expect(fenceContent(input)).toBe(input);
+  });
+
+  it('fences the outer HTML block, not JSON nested inside it', () => {
+    const input = `<pre>
+{"a": 1, "b": 2}
+</pre>`;
+    expect(fenceContent(input)).toBe(`
+
+${FENCE}html
+${input}
+${FENCE}
+
+`);
+  });
+
+  it('fences the outer JSON block, not HTML nested in a string value', () => {
+    const input = `{
+  "markup": "<div>x</div>"
+}`;
+    expect(fenceContent(input)).toBe(`
+
+${FENCE}json
+${input}
+${FENCE}
+
+`);
+  });
+});

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentFencing.ts
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentFencing.ts
@@ -63,7 +63,7 @@ const jsonDetector: ContentDetector = {
       // Only fence runs that stand on their own; skip JSON glued to other text
       // (e.g. `key={"a":1}` or `arr[0]`) which is part of an expression.
       if (
-        hasWhitespaceBoundary(text, i, end + 1) &&
+        hasStandaloneBoundary(text, i, end + 1) &&
         looksLikeJson(text.slice(i, end + 1))
       ) {
         blocks.push({start: i, end: end + 1, language: 'json'});
@@ -174,10 +174,20 @@ function findBalancedEnd(text: string, start: number): number {
   return -1;
 }
 
-/** Whether the run at [start, end) is bounded by whitespace or the string edges. */
-function hasWhitespaceBoundary(text: string, start: number, end: number): boolean {
+// Trailing punctuation that can legitimately follow standalone JSON in prose,
+// e.g. a sentence-ending period or a comma in a list. The leading side stays
+// strict so expression glue like `arr[0]` and `key={…}` is still rejected.
+const TRAILING_PUNCTUATION = /[.,;:!?)]/;
+
+/**
+ * Whether the run at [start, end) stands on its own: preceded by whitespace or
+ * the string start, and followed by whitespace, the string end, or trailing
+ * sentence punctuation.
+ */
+function hasStandaloneBoundary(text: string, start: number, end: number): boolean {
   const beforeOk = start === 0 || /\s/.test(text[start - 1]!);
-  const afterOk = end === text.length || /\s/.test(text[end]!);
+  const afterOk =
+    end === text.length || /\s/.test(text[end]!) || TRAILING_PUNCTUATION.test(text[end]!);
   return beforeOk && afterOk;
 }
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentFencing.ts
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentFencing.ts
@@ -173,23 +173,24 @@ function getProtectedRanges(text: string): Array<{end: number; start: number}> {
 
 /**
  * Returns the offset of the bracket that closes the one at `start`, or -1 if
- * unbalanced. Tracks string state so brackets inside JSON strings don't count.
+ * unbalanced. Tracks string state so brackets inside strings don't count. Both
+ * quote styles are handled since JSON uses `"` and Python-repr dicts use `'`.
  */
 function findBalancedEnd(text: string, start: number): number {
   let depth = 0;
-  let inString = false;
+  let stringChar: '"' | "'" | null = null;
   for (let i = start; i < text.length; i++) {
     const ch = text[i];
-    if (inString) {
+    if (stringChar !== null) {
       if (ch === '\\') {
         i++; // skip escaped char
-      } else if (ch === '"') {
-        inString = false;
+      } else if (ch === stringChar) {
+        stringChar = null;
       }
       continue;
     }
-    if (ch === '"') {
-      inString = true;
+    if (ch === '"' || ch === "'") {
+      stringChar = ch;
     } else if (ch === '{' || ch === '[') {
       depth++;
     } else if (ch === '}' || ch === ']') {

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentFencing.ts
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentFencing.ts
@@ -27,25 +27,53 @@ interface ContentDetector {
   name: string;
 }
 
-const HTML_PAIR_REGEX = /<([a-zA-Z][\w-]*)\b[^>]*>[\s\S]*?<\/\1\s*>/g;
+// Matches a single opening or self-closing HTML tag; group 1 is the tag name.
+// Closing tags (`</tag>`) don't match because a `/` can't follow `<` here.
+const HTML_OPEN_REGEX = /<([a-zA-Z][\w-]*)\b[^>]*>/g;
 
 /** Detects balanced HTML tag pairs whose tag name is a known HTML element. */
 const htmlDetector: ContentDetector = {
   name: 'html',
   detect(text) {
     const blocks: DetectedBlock[] = [];
-    for (const match of text.matchAll(HTML_PAIR_REGEX)) {
-      if (isKnownHtmlTag(match[1]!)) {
-        blocks.push({
-          start: match.index,
-          end: match.index + match[0].length,
-          language: 'html',
-        });
+    for (const match of text.matchAll(HTML_OPEN_REGEX)) {
+      const tagName = match[1]!;
+      // Skip non-HTML tags and self-closing tags, which have no closing pair.
+      if (!isKnownHtmlTag(tagName) || match[0].endsWith('/>')) {
+        continue;
       }
+      const end = findHtmlPairEnd(text, tagName, match.index + match[0].length);
+      if (end === -1) {
+        continue;
+      }
+      blocks.push({start: match.index, end, language: 'html'});
     }
     return blocks;
   },
 };
+
+/**
+ * Given an opening `<tagName>` whose `>` ends at `openEnd`, returns the offset
+ * just past the `</tagName>` that closes it, counting nested same-name tags so
+ * `<div><div>…</div></div>` pairs correctly. Returns -1 if unbalanced.
+ */
+function findHtmlPairEnd(text: string, tagName: string, openEnd: number): number {
+  // Tag names only ever contain `[a-zA-Z][\w-]*`, so they are regex-safe.
+  const tagRegex = new RegExp(`<(/?)${tagName}\\b[^>]*?(/?)>`, 'gi');
+  tagRegex.lastIndex = openEnd;
+  let depth = 1;
+  for (let m = tagRegex.exec(text); m; m = tagRegex.exec(text)) {
+    if (m[1] === '/') {
+      depth--;
+      if (depth === 0) {
+        return m.index + m[0].length;
+      }
+    } else if (m[2] !== '/') {
+      depth++; // nested opening tag of the same name
+    }
+  }
+  return -1;
+}
 
 /** Detects balanced `{...}` / `[...]` runs that parse as a non-trivial object or array. */
 const jsonDetector: ContentDetector = {

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentFencing.ts
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentFencing.ts
@@ -1,0 +1,235 @@
+import {parseJsonWithFix} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
+
+import {tryParsePythonDict} from './aiContentDetection';
+import {isKnownHtmlTag} from './htmlTags';
+
+/**
+ * Wraps raw HTML and JSON found in AI content in fenced code blocks, so the
+ * markdown renderer highlights them instead of rendering HTML as literal markup
+ * or letting markdown mangle JSON.
+ *
+ * The layer is a list of {@link ContentDetector}s. Adding support for another
+ * content type is a matter of appending a detector — see {@link DETECTORS}.
+ */
+
+interface DetectedBlock {
+  /** Exclusive end offset into the source string. */
+  end: number;
+  /** Info-string / language hint for the fence (e.g. `json`, `html`). */
+  language: string;
+  /** Inclusive start offset into the source string. */
+  start: number;
+}
+
+interface ContentDetector {
+  /** Returns every candidate block found in `text`. Overlaps are resolved by the driver. */
+  detect: (text: string) => DetectedBlock[];
+  name: string;
+}
+
+const HTML_PAIR_REGEX = /<([a-zA-Z][\w-]*)\b[^>]*>[\s\S]*?<\/\1\s*>/g;
+
+/** Detects balanced HTML tag pairs whose tag name is a known HTML element. */
+const htmlDetector: ContentDetector = {
+  name: 'html',
+  detect(text) {
+    const blocks: DetectedBlock[] = [];
+    for (const match of text.matchAll(HTML_PAIR_REGEX)) {
+      if (isKnownHtmlTag(match[1]!)) {
+        blocks.push({
+          start: match.index,
+          end: match.index + match[0].length,
+          language: 'html',
+        });
+      }
+    }
+    return blocks;
+  },
+};
+
+/** Detects balanced `{...}` / `[...]` runs that parse as a non-trivial object or array. */
+const jsonDetector: ContentDetector = {
+  name: 'json',
+  detect(text) {
+    const blocks: DetectedBlock[] = [];
+    for (let i = 0; i < text.length; i++) {
+      if (text[i] !== '{' && text[i] !== '[') {
+        continue;
+      }
+      const end = findBalancedEnd(text, i);
+      if (end === -1) {
+        continue;
+      }
+      // Only fence runs that stand on their own; skip JSON glued to other text
+      // (e.g. `key={"a":1}` or `arr[0]`) which is part of an expression.
+      if (
+        hasWhitespaceBoundary(text, i, end + 1) &&
+        looksLikeJson(text.slice(i, end + 1))
+      ) {
+        blocks.push({start: i, end: end + 1, language: 'json'});
+        i = end; // skip past this block so nested braces aren't re-detected
+      }
+    }
+    return blocks;
+  },
+};
+
+const DETECTORS: readonly ContentDetector[] = [htmlDetector, jsonDetector];
+
+/**
+ * Returns `text` with any detected HTML/JSON runs wrapped in fenced code
+ * blocks. Content already inside fenced or inline code is left untouched.
+ */
+export function fenceContent(
+  text: string,
+  detectors: readonly ContentDetector[] = DETECTORS
+): string {
+  const protectedRanges = getProtectedRanges(text);
+  const overlapsProtected = (start: number, end: number) =>
+    protectedRanges.some(r => start < r.end && end > r.start);
+
+  const candidates = detectors
+    .flatMap(detector => detector.detect(text))
+    .filter(block => !overlapsProtected(block.start, block.end))
+    // Earliest first; on a tie prefer the longer block.
+    .sort((a, b) => a.start - b.start || b.end - a.end);
+
+  // Greedily keep non-overlapping blocks (first match wins).
+  const chosen: DetectedBlock[] = [];
+  let lastEnd = -1;
+  for (const block of candidates) {
+    if (block.start >= lastEnd) {
+      chosen.push(block);
+      lastEnd = block.end;
+    }
+  }
+
+  // Apply edits back-to-front so earlier offsets stay valid.
+  let result = text;
+  for (let i = chosen.length - 1; i >= 0; i--) {
+    const {start, end, language} = chosen[i]!;
+    const raw = text.slice(start, end);
+    // A fenced block is block-level and would split surrounding prose. When the
+    // run sits inline (text on the same line), keep it inline with inline code.
+    const replacement = isInlinePosition(text, start, end)
+      ? wrapInlineCode(raw)
+      : wrapInFence(raw, language);
+    result = result.slice(0, start) + replacement + result.slice(end);
+  }
+  return result;
+}
+
+/** Whether a detected run is single-line and has prose beside it on that line. */
+function isInlinePosition(text: string, start: number, end: number): boolean {
+  if (text.slice(start, end).includes('\n')) {
+    return false; // multi-line runs are inherently block-level
+  }
+  const lineStart = text.lastIndexOf('\n', start - 1) + 1;
+  const nextNewline = text.indexOf('\n', end);
+  const before = text.slice(lineStart, start);
+  const after = text.slice(end, nextNewline === -1 ? text.length : nextNewline);
+  return before.trim() !== '' || after.trim() !== '';
+}
+
+/** Offset ranges already inside fenced or inline code, which must not be re-fenced. */
+function getProtectedRanges(text: string): Array<{end: number; start: number}> {
+  const ranges: Array<{end: number; start: number}> = [];
+  const patterns = [/```[\s\S]*?```/g, /~~~[\s\S]*?~~~/g, /(`+)[^`]*\1/g];
+  for (const pattern of patterns) {
+    for (const match of text.matchAll(pattern)) {
+      ranges.push({start: match.index, end: match.index + match[0].length});
+    }
+  }
+  return ranges;
+}
+
+/**
+ * Returns the offset of the bracket that closes the one at `start`, or -1 if
+ * unbalanced. Tracks string state so brackets inside JSON strings don't count.
+ */
+function findBalancedEnd(text: string, start: number): number {
+  let depth = 0;
+  let inString = false;
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i];
+    if (inString) {
+      if (ch === '\\') {
+        i++; // skip escaped char
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+    } else if (ch === '{' || ch === '[') {
+      depth++;
+    } else if (ch === '}' || ch === ']') {
+      depth--;
+      if (depth === 0) {
+        return i;
+      }
+    }
+  }
+  return -1;
+}
+
+/** Whether the run at [start, end) is bounded by whitespace or the string edges. */
+function hasWhitespaceBoundary(text: string, start: number, end: number): boolean {
+  const beforeOk = start === 0 || /\s/.test(text[start - 1]!);
+  const afterOk = end === text.length || /\s/.test(text[end]!);
+  return beforeOk && afterOk;
+}
+
+function looksLikeJson(candidate: string): boolean {
+  const trimmed = candidate.trim();
+  try {
+    if (isNonTrivial(JSON.parse(trimmed))) {
+      return true;
+    }
+  } catch {
+    // fall through to the lenient parsers
+  }
+  const {parsed, fixedInvalidJson} = parseJsonWithFix(trimmed);
+  if (fixedInvalidJson && isNonTrivial(parsed)) {
+    return true;
+  }
+  // Also accept Python-repr dicts (single quotes, True/False/None).
+  const pythonDict = tryParsePythonDict(trimmed);
+  return pythonDict !== null && isNonTrivial(pythonDict);
+}
+
+/** Guards against fencing noise like `{}`, `[]`, or a bare `{word}`. */
+function isNonTrivial(value: unknown): boolean {
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+  return typeof value === 'object' && value !== null && Object.keys(value).length > 0;
+}
+
+function wrapInFence(raw: string, language: string): string {
+  const fence = '`'.repeat(Math.max(3, longestBacktickRun(raw) + 1));
+  return `\n\n${fence}${language}\n${raw.trim()}\n${fence}\n\n`;
+}
+
+function wrapInlineCode(raw: string): string {
+  const trimmed = raw.trim();
+  const ticks = '`'.repeat(longestBacktickRun(trimmed) + 1);
+  // Pad with spaces when content starts/ends with a backtick (CommonMark rule).
+  const pad = trimmed.startsWith('`') || trimmed.endsWith('`') ? ' ' : '';
+  return `${ticks}${pad}${trimmed}${pad}${ticks}`;
+}
+
+function longestBacktickRun(text: string): number {
+  let max = 0;
+  let current = 0;
+  for (const ch of text) {
+    if (ch === '`') {
+      current++;
+      max = Math.max(max, current);
+    } else {
+      current = 0;
+    }
+  }
+  return max;
+}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentRenderer.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentRenderer.spec.tsx
@@ -40,6 +40,29 @@ describe('AIContentRenderer', () => {
     expect(screen.getByText(/name/)).toBeInTheDocument();
   });
 
+  it('detects and renders an unescaped JSON blob as a tree', () => {
+    const text = `<note>
+{"alpha": 1, "beta": 2}
+</note>`;
+    render(<AIContentRenderer text={text} inline />);
+    expect(screen.getByText(/alpha/)).toBeInTheDocument();
+    expect(screen.getByText(/beta/)).toBeInTheDocument();
+  });
+
+  it('fences raw HTML and JSON wrapped in a custom tag', () => {
+    const text = `<note>
+{"alpha": 1}
+<div>markup</div>
+</note>`;
+    render(<AIContentRenderer text={text} inline />);
+    // Custom tag collapses...
+    expect(screen.getByText('<note>')).toBeInTheDocument();
+    // ...its JSON content renders as a tree...
+    expect(screen.getByText(/alpha/)).toBeInTheDocument();
+    // ...and its HTML is fenced as code, not collapsed as a tag.
+    expect(screen.queryByText('<div>')).not.toBeInTheDocument();
+  });
+
   it('renders inline XML tags as italic text within the flow', () => {
     render(<AIContentRenderer text="Before <thinking>inner thought</thinking> After" />);
     expect(screen.getByText(/thinking: inner thought/)).toBeInTheDocument();

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentRenderer.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentRenderer.tsx
@@ -15,6 +15,7 @@ import {
   preprocessInlineXmlTags,
   tryParsePythonDict,
 } from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentDetection';
+import {fenceContent} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentFencing';
 import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/styles';
 import {parseJsonWithFix} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
 
@@ -87,6 +88,12 @@ const markdownComponents: MarkdownProps['components'] = {
     return <Default lang={lang}>{children}</Default>;
   },
 };
+
+/** Fences raw AI content and renders it. Memoized since fencing scans the whole string. */
+function FencedMarkdown({raw}: {raw: string}) {
+  const fenced = useMemo(() => fenceContent(raw), [raw]);
+  return <Markdown raw={fenced} components={markdownComponents} />;
+}
 
 interface AIContentRendererProps {
   text: string;
@@ -181,7 +188,7 @@ function MarkdownWithXmlRenderer({
             collapsible={collapsibleXmlTags}
           />
         ) : (
-          <Markdown key={i} raw={segment.content} components={markdownComponents} />
+          <FencedMarkdown key={i} raw={segment.content} />
         )
       )}
     </Fragment>
@@ -239,14 +246,12 @@ export function AIContentRenderer({
 
     case 'markdown':
       if (inline) {
-        return <Markdown raw={text} components={markdownComponents} />;
+        return <FencedMarkdown raw={text} />;
       }
       return (
         <TraceDrawerComponents.MultilineText
           clip={clipText}
-          renderFormatted={rawText => (
-            <Markdown raw={rawText} components={markdownComponents} />
-          )}
+          renderFormatted={rawText => <FencedMarkdown raw={rawText} />}
         >
           {text}
         </TraceDrawerComponents.MultilineText>


### PR DESCRIPTION
Raw HTML and JSON that appears unescaped in agent conversation content is now detected and wrapped in code fences before rendering — so an HTML snippet shows as a highlighted code block, and a JSON or Python-repr dict blob renders as the interactive tree, instead of showing as raw text or being mangled by markdown.

Detection is conservative: only known HTML tag pairs and standalone, balanced JSON/dict runs are fenced; JSON glued to surrounding tokens (`key={…}`, `arr[0]`), trivial `{}`/`[]`, and content already inside code are left alone. Block-level runs become fenced blocks; single-line runs with prose beside them stay inline. Fencing is memoized and only runs for content that reaches the markdown path.

Final PR of a three-PR stack, on top of #121152.

Closes TET-2772
Closes TET-2797
