### PR TITLE
ref(dynamic-sampling): return per-org calculations instead of logging them

### DIFF
--- a/src/sentry/dynamic_sampling/per_org/calculations.py
+++ b/src/sentry/dynamic_sampling/per_org/calculations.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-import logging
 from collections.abc import Iterable
-from dataclasses import replace
+from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, cast
 
@@ -19,7 +18,6 @@ from sentry.dynamic_sampling.models.transactions_rebalancing import (
     TransactionsRebalancingInput,
     TransactionsRebalancingModel,
 )
-from sentry.dynamic_sampling.per_org.gate import project_balancing_debug_project_ids
 from sentry.dynamic_sampling.per_org.queries import (
     ProjectTransactionCounts,
     ProjectVolume,
@@ -28,6 +26,7 @@ from sentry.dynamic_sampling.per_org.queries import (
     get_generic_metrics_transaction_volumes,
     get_outcomes_organization_volume,
 )
+from sentry.dynamic_sampling.per_org.telemetry import DynamicSamplingStatus
 from sentry.dynamic_sampling.rules.utils import get_redis_client_for_ds
 from sentry.dynamic_sampling.sample_rate_override import get_sample_rate_overrides
 from sentry.dynamic_sampling.tasks.common import (
@@ -52,15 +51,63 @@ if TYPE_CHECKING:
     from sentry.dynamic_sampling.per_org.configuration import (
         AutomaticDynamicSamplingConfiguration,
         BaseDynamicSamplingConfiguration,
+        ProjectSampleRates,
     )
 
 PROJECT_BALANCING_COMPARISON_RELATIVE_TOLERANCE = 0.05
 TRANSACTION_BALANCING_COMPARISON_RELATIVE_TOLERANCE = 0.05
 RECALIBRATION_FACTOR_COMPARISON_RELATIVE_TOLERANCE = 0.05
 REBALANCE_INTENSITY = 0.8
-PROJECT_BALANCING_DEBUG_METRIC_PREFIX = "dynamic_sampling.per_org.project_balancing_debug"
 SLIDING_WINDOW_METRIC_PREFIX = "dynamic_sampling.per_org.sliding_window"
-logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TransactionVolumeDebug:
+    """The raw per-transaction volumes both pipelines saw for one project."""
+
+    project_id: int
+    eap_volumes: dict[str, float]
+    generic_metrics_volumes: dict[str, float]
+
+
+@dataclass
+class PerOrgCalculations:
+    """Everything one run of the per-org pipeline queried and computed for an organization.
+
+    The pipeline fills this in step by step and stops at the first step with nothing to work
+    on, which it records in ``status``; the fields of the steps it never reached stay empty.
+    The ``cached_*`` fields hold what the legacy (generic metrics) pipeline computed for the
+    same organization, so that reporting can compare the two sides without querying again.
+    """
+
+    config: BaseDynamicSamplingConfiguration
+    status: DynamicSamplingStatus | None = None
+    project_volumes: list[ProjectVolume] = field(default_factory=list)
+    rebalanced_projects: list[RebalancedItem] = field(default_factory=list)
+    rebalanced_transactions: dict[int, tuple[list[RebalancedItem], float]] = field(
+        default_factory=dict
+    )
+    transaction_volume_debug: list[TransactionVolumeDebug] = field(default_factory=list)
+    recalibration_ran: bool = False
+    recalibration_factor: float | None = None
+    cached_organization_sample_rate: float | None = None
+    cached_project_sample_rates: dict[int, float | None] = field(default_factory=dict)
+    cached_transaction_sample_rates: dict[int, tuple[dict[str, float], float] | None] = field(
+        default_factory=dict
+    )
+    cached_recalibration_factor: float | None = None
+    # Set for the organizations that log a summary of both pipelines. The pipeline reads the
+    # legacy caches for every project instead of only the rebalanced ones when it is on.
+    summary_log_enabled: bool = False
+
+    @property
+    def project_sample_rates(self) -> ProjectSampleRates:
+        """The sample rates this run leaves the projects of the organization on."""
+        return self.config.get_project_sample_rates()
+
+    def stopped_at(self, status: DynamicSamplingStatus) -> PerOrgCalculations:
+        self.status = status
+        return self
 
 
 def calculate_recalibration_factor(
@@ -89,33 +136,6 @@ def calculate_recalibration_factor(
 
 def get_cached_recalibration_factor(org_id: int) -> float:
     return legacy_recalibration_cache.get_adjusted_factor(org_id)
-
-
-def compare_recalibration_factor_with_cache(
-    config: BaseDynamicSamplingConfiguration,
-    calculated_factor: float | None,
-    cached_factor: float | None,
-) -> None:
-    logger.info(
-        "dynamic_sampling.per_org.recalibration_factor_comparison",
-        extra={
-            "org_id": config.organization.id,
-            "sample_rate": config.get_sample_rate(),
-            "generic_metrics_factor": cached_factor,
-            "eap_factor": calculated_factor,
-            "relative_deviation": (
-                None
-                if calculated_factor is None
-                else get_relative_deviation(cached_factor, calculated_factor)
-            ),
-            "is_equal": calculated_factor is not None
-            and is_within_relative_tolerance(
-                cached_factor,
-                calculated_factor,
-                RECALIBRATION_FACTOR_COMPARISON_RELATIVE_TOLERANCE,
-            ),
-        },
-    )
 
 
 def compare_organization_sliding_window_sample_rates(
@@ -301,101 +321,6 @@ def get_relative_deviation(
     return abs(cached_sample_rate - calculated_sample_rate) / abs(calculated_sample_rate)
 
 
-def compare_rebalanced_projects_with_cache(
-    config: BaseDynamicSamplingConfiguration,
-    rebalanced_projects: list[RebalancedItem],
-    cached_sample_rates: dict[int, float | None],
-    project_volumes: list[ProjectVolume],
-) -> None:
-    rebalanced_projects_by_id = {int(project.id): project for project in rebalanced_projects}
-    project_volumes_by_id = {
-        project_volume.project_id: project_volume for project_volume in project_volumes
-    }
-    debug_project_ids = project_balancing_debug_project_ids()
-
-    for project_id, rebalanced_project in sorted(rebalanced_projects_by_id.items()):
-        eap_sample_rate = rebalanced_project.new_sample_rate
-        generic_metrics_sample_rate = cached_sample_rates.get(project_id)
-        project_volume = project_volumes_by_id.get(project_id)
-        eap_volume_without_extrapolation = (
-            project_volume.keep if project_volume is not None else None
-        )
-        logger.info(
-            "dynamic_sampling.per_org.project_balancing_comparison",
-            extra={
-                "org_id": config.organization.id,
-                "ds_proj_id": project_id,
-                "generic_metrics_sample_rate": generic_metrics_sample_rate,
-                "eap_sample_rate": eap_sample_rate,
-                "relative_deviation": get_relative_deviation(
-                    generic_metrics_sample_rate, eap_sample_rate
-                ),
-                "is_equal": is_within_relative_tolerance(
-                    generic_metrics_sample_rate, eap_sample_rate
-                ),
-                "total_volume_eap": rebalanced_project.count,
-                "total_volume_eap_without_extrapolation": eap_volume_without_extrapolation,
-            },
-        )
-        if project_id in debug_project_ids:
-            _emit_project_balancing_debug_metrics(
-                org_id=config.organization.id,
-                project_id=project_id,
-                eap_sample_rate=eap_sample_rate,
-                generic_metrics_sample_rate=generic_metrics_sample_rate,
-                eap_volume=rebalanced_project.count,
-                eap_volume_without_extrapolation=eap_volume_without_extrapolation,
-                seconds_since_last_item=(
-                    project_volume.seconds_since_last_item if project_volume is not None else None
-                ),
-            )
-
-
-def _emit_project_balancing_debug_metrics(
-    org_id: int,
-    project_id: int,
-    eap_sample_rate: float,
-    generic_metrics_sample_rate: float | None,
-    eap_volume: float,
-    eap_volume_without_extrapolation: float | None,
-    seconds_since_last_item: float | None,
-) -> None:
-    tags = {"org": str(org_id), "ds_project": str(project_id)}
-    metrics.distribution(
-        f"{PROJECT_BALANCING_DEBUG_METRIC_PREFIX}.eap_sample_rate",
-        eap_sample_rate,
-        sample_rate=1.0,
-        tags=tags,
-    )
-    if seconds_since_last_item is not None:
-        metrics.distribution(
-            f"{PROJECT_BALANCING_DEBUG_METRIC_PREFIX}.eap_seconds_since_last_item",
-            seconds_since_last_item,
-            sample_rate=1.0,
-            tags=tags,
-        )
-    if generic_metrics_sample_rate is not None:
-        metrics.distribution(
-            f"{PROJECT_BALANCING_DEBUG_METRIC_PREFIX}.generic_metrics_sample_rate",
-            generic_metrics_sample_rate,
-            sample_rate=1.0,
-            tags=tags,
-        )
-    metrics.distribution(
-        f"{PROJECT_BALANCING_DEBUG_METRIC_PREFIX}.eap_volume",
-        eap_volume,
-        sample_rate=1.0,
-        tags=tags,
-    )
-    if eap_volume_without_extrapolation is not None:
-        metrics.distribution(
-            f"{PROJECT_BALANCING_DEBUG_METRIC_PREFIX}.eap_volume_without_extrapolation",
-            eap_volume_without_extrapolation,
-            sample_rate=1.0,
-            tags=tags,
-        )
-
-
 def run_transaction_balancing(
     config: BaseDynamicSamplingConfiguration,
     project_volumes: list[ProjectVolume],
@@ -477,96 +402,33 @@ def get_cached_rebalanced_transaction_sample_rates(
     return result
 
 
-def compare_rebalanced_transactions_with_cache(
-    config: BaseDynamicSamplingConfiguration,
-    rebalanced_transactions: dict[int, tuple[list[RebalancedItem], float]],
-    cached_sample_rates: dict[int, tuple[dict[str, float], float] | None],
-) -> None:
-    for project_id, (named_rates, eap_implicit_rate) in sorted(rebalanced_transactions.items()):
-        cached = cached_sample_rates.get(project_id)
-        generic_metrics_named_rates: dict[str, float] = {} if cached is None else cached[0]
-        generic_metrics_implicit_rate = None if cached is None else cached[1]
-
-        logger.info(
-            "dynamic_sampling.per_org.transaction_balancing_implicit_comparison",
-            extra={
-                "org_id": config.organization.id,
-                "ds_proj_id": project_id,
-                "generic_metrics_implicit_rate": generic_metrics_implicit_rate,
-                "eap_implicit_rate": eap_implicit_rate,
-                "relative_deviation": get_relative_deviation(
-                    generic_metrics_implicit_rate, eap_implicit_rate
-                ),
-                "is_equal": is_within_relative_tolerance(
-                    generic_metrics_implicit_rate,
-                    eap_implicit_rate,
-                    TRANSACTION_BALANCING_COMPARISON_RELATIVE_TOLERANCE,
-                ),
-            },
-        )
-
-        for item in named_rates:
-            transaction = str(item.id)
-            generic_metrics_rate = generic_metrics_named_rates.get(transaction)
-            logger.info(
-                "dynamic_sampling.per_org.transaction_balancing_comparison",
-                extra={
-                    "org_id": config.organization.id,
-                    "ds_proj_id": project_id,
-                    "transaction": transaction,
-                    "generic_metrics_sample_rate": generic_metrics_rate,
-                    "eap_sample_rate": item.new_sample_rate,
-                    "relative_deviation": get_relative_deviation(
-                        generic_metrics_rate, item.new_sample_rate
-                    ),
-                    "is_equal": is_within_relative_tolerance(
-                        generic_metrics_rate,
-                        item.new_sample_rate,
-                        TRANSACTION_BALANCING_COMPARISON_RELATIVE_TOLERANCE,
-                    ),
-                },
-            )
-
-
-def log_transaction_volume_debug(
+def collect_transaction_volume_debug(
     config: BaseDynamicSamplingConfiguration,
     transaction_volumes: list[ProjectTransactionCounts],
     debug_project_ids: set[int],
-) -> None:
+) -> list[TransactionVolumeDebug]:
     """
-    Logs the raw per-transaction volumes EAP fed into balancing next to the legacy
+    Collects the raw per-transaction volumes EAP fed into balancing next to the legacy
     generic-metrics volumes for the same window, for every transaction on either side —
     not just the ones that survived the top-N cutoff and rebalancing model. Used to debug
-    discrepancies between the two pipelines' transaction counts directly, since
-    ``compare_rebalanced_transactions_with_cache`` only ever sees post-rebalancing sample
-    rates for the transactions EAP kept.
+    discrepancies between the two pipelines' transaction counts directly, since the
+    per-transaction comparison only ever sees post-rebalancing sample rates for the
+    transactions EAP kept.
     """
-    eap_counts_by_project = {
+    eap_volumes_by_project = {
         project_data.project_id: dict(project_data.transaction_counts)
         for project_data in transaction_volumes
         if project_data.project_id in debug_project_ids
     }
-    generic_metrics_counts_by_project = get_generic_metrics_transaction_volumes(
+    generic_metrics_volumes_by_project = get_generic_metrics_transaction_volumes(
         config.organization.id, debug_project_ids
     )
 
-    for project_id in sorted(debug_project_ids):
-        eap_counts = eap_counts_by_project.get(project_id, {})
-        generic_metrics_counts = dict(generic_metrics_counts_by_project.get(project_id, []))
-
-        transactions = {
-            transaction: {
-                "eap_volume": eap_counts.get(transaction),
-                "generic_metrics_volume": generic_metrics_counts.get(transaction),
-            }
-            for transaction in eap_counts.keys() | generic_metrics_counts.keys()
-        }
-
-        logger.info(
-            "dynamic_sampling.per_org.transaction_volume_debug",
-            extra={
-                "org_id": config.organization.id,
-                "ds_proj_id": project_id,
-                "transactions": transactions,
-            },
+    return [
+        TransactionVolumeDebug(
+            project_id=project_id,
+            eap_volumes=eap_volumes_by_project.get(project_id, {}),
+            generic_metrics_volumes=dict(generic_metrics_volumes_by_project.get(project_id, [])),
         )
+        for project_id in sorted(debug_project_ids)
+    ]

--- a/src/sentry/dynamic_sampling/per_org/legacy_comparison.py
+++ b/src/sentry/dynamic_sampling/per_org/legacy_comparison.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+import logging
+
+from sentry.dynamic_sampling.per_org.calculations import (
+    PROJECT_BALANCING_COMPARISON_RELATIVE_TOLERANCE,
+    RECALIBRATION_FACTOR_COMPARISON_RELATIVE_TOLERANCE,
+    TRANSACTION_BALANCING_COMPARISON_RELATIVE_TOLERANCE,
+    PerOrgCalculations,
+    get_relative_deviation,
+    is_within_relative_tolerance,
+)
+from sentry.dynamic_sampling.per_org.gate import project_balancing_debug_project_ids
+from sentry.utils import metrics
+
+PROJECT_BALANCING_DEBUG_METRIC_PREFIX = "dynamic_sampling.per_org.project_balancing_debug"
+
+logger = logging.getLogger(__name__)
+
+
+def log_comparison_with_legacy_pipeline(calculations: PerOrgCalculations) -> None:
+    """
+    Reports what a per-org run computed next to what the legacy (generic metrics) pipeline
+    cached for the same organization, while both pipelines run side by side.
+
+    This is the only place the per-org pipeline logs from. It reads a finished run and emits,
+    so a run behaves the same with or without it and the whole module can go away with the
+    legacy pipeline.
+    """
+    _log_project_balancing(calculations)
+    _log_transaction_volume_debug(calculations)
+    _log_transaction_balancing(calculations)
+    if calculations.summary_log_enabled:
+        _log_sample_rates_summary(calculations)
+    if calculations.recalibration_ran:
+        _log_recalibration_factor(calculations)
+
+
+def _log_project_balancing(calculations: PerOrgCalculations) -> None:
+    org_id = calculations.config.organization.id
+    rebalanced_projects_by_id = {
+        int(project.id): project for project in calculations.rebalanced_projects
+    }
+    project_volumes_by_id = {
+        project_volume.project_id: project_volume for project_volume in calculations.project_volumes
+    }
+    debug_project_ids = project_balancing_debug_project_ids()
+
+    for project_id, rebalanced_project in sorted(rebalanced_projects_by_id.items()):
+        eap_sample_rate = rebalanced_project.new_sample_rate
+        generic_metrics_sample_rate = calculations.cached_project_sample_rates.get(project_id)
+        project_volume = project_volumes_by_id.get(project_id)
+        eap_volume_without_extrapolation = (
+            project_volume.keep if project_volume is not None else None
+        )
+        logger.info(
+            "dynamic_sampling.per_org.project_balancing_comparison",
+            extra={
+                "org_id": org_id,
+                "ds_proj_id": project_id,
+                "generic_metrics_sample_rate": generic_metrics_sample_rate,
+                "eap_sample_rate": eap_sample_rate,
+                "relative_deviation": get_relative_deviation(
+                    generic_metrics_sample_rate, eap_sample_rate
+                ),
+                "is_equal": is_within_relative_tolerance(
+                    generic_metrics_sample_rate,
+                    eap_sample_rate,
+                    PROJECT_BALANCING_COMPARISON_RELATIVE_TOLERANCE,
+                ),
+                "total_volume_eap": rebalanced_project.count,
+                "total_volume_eap_without_extrapolation": eap_volume_without_extrapolation,
+            },
+        )
+        if project_id in debug_project_ids:
+            _emit_project_balancing_debug_metrics(
+                org_id=org_id,
+                project_id=project_id,
+                eap_sample_rate=eap_sample_rate,
+                generic_metrics_sample_rate=generic_metrics_sample_rate,
+                eap_volume=rebalanced_project.count,
+                eap_volume_without_extrapolation=eap_volume_without_extrapolation,
+                seconds_since_last_item=(
+                    project_volume.seconds_since_last_item if project_volume is not None else None
+                ),
+            )
+
+
+def _emit_project_balancing_debug_metrics(
+    org_id: int,
+    project_id: int,
+    eap_sample_rate: float,
+    generic_metrics_sample_rate: float | None,
+    eap_volume: float,
+    eap_volume_without_extrapolation: float | None,
+    seconds_since_last_item: float | None,
+) -> None:
+    tags = {"org": str(org_id), "ds_project": str(project_id)}
+    metrics.distribution(
+        f"{PROJECT_BALANCING_DEBUG_METRIC_PREFIX}.eap_sample_rate",
+        eap_sample_rate,
+        sample_rate=1.0,
+        tags=tags,
+    )
+    if seconds_since_last_item is not None:
+        metrics.distribution(
+            f"{PROJECT_BALANCING_DEBUG_METRIC_PREFIX}.eap_seconds_since_last_item",
+            seconds_since_last_item,
+            sample_rate=1.0,
+            tags=tags,
+        )
+    if generic_metrics_sample_rate is not None:
+        metrics.distribution(
+            f"{PROJECT_BALANCING_DEBUG_METRIC_PREFIX}.generic_metrics_sample_rate",
+            generic_metrics_sample_rate,
+            sample_rate=1.0,
+            tags=tags,
+        )
+    metrics.distribution(
+        f"{PROJECT_BALANCING_DEBUG_METRIC_PREFIX}.eap_volume",
+        eap_volume,
+        sample_rate=1.0,
+        tags=tags,
+    )
+    if eap_volume_without_extrapolation is not None:
+        metrics.distribution(
+            f"{PROJECT_BALANCING_DEBUG_METRIC_PREFIX}.eap_volume_without_extrapolation",
+            eap_volume_without_extrapolation,
+            sample_rate=1.0,
+            tags=tags,
+        )
+
+
+def _log_transaction_volume_debug(calculations: PerOrgCalculations) -> None:
+    for debug in calculations.transaction_volume_debug:
+        logger.info(
+            "dynamic_sampling.per_org.transaction_volume_debug",
+            extra={
+                "org_id": calculations.config.organization.id,
+                "ds_proj_id": debug.project_id,
+                "transactions": {
+                    transaction: {
+                        "eap_volume": debug.eap_volumes.get(transaction),
+                        "generic_metrics_volume": debug.generic_metrics_volumes.get(transaction),
+                    }
+                    for transaction in debug.eap_volumes.keys()
+                    | debug.generic_metrics_volumes.keys()
+                },
+            },
+        )
+
+
+def _log_transaction_balancing(calculations: PerOrgCalculations) -> None:
+    org_id = calculations.config.organization.id
+
+    for project_id, (named_rates, eap_implicit_rate) in sorted(
+        calculations.rebalanced_transactions.items()
+    ):
+        cached = calculations.cached_transaction_sample_rates.get(project_id)
+        generic_metrics_named_rates: dict[str, float] = {} if cached is None else cached[0]
+        generic_metrics_implicit_rate = None if cached is None else cached[1]
+
+        logger.info(
+            "dynamic_sampling.per_org.transaction_balancing_implicit_comparison",
+            extra={
+                "org_id": org_id,
+                "ds_proj_id": project_id,
+                "generic_metrics_implicit_rate": generic_metrics_implicit_rate,
+                "eap_implicit_rate": eap_implicit_rate,
+                "relative_deviation": get_relative_deviation(
+                    generic_metrics_implicit_rate, eap_implicit_rate
+                ),
+                "is_equal": is_within_relative_tolerance(
+                    generic_metrics_implicit_rate,
+                    eap_implicit_rate,
+                    TRANSACTION_BALANCING_COMPARISON_RELATIVE_TOLERANCE,
+                ),
+            },
+        )
+
+        for item in named_rates:
+            transaction = str(item.id)
+            generic_metrics_rate = generic_metrics_named_rates.get(transaction)
+            logger.info(
+                "dynamic_sampling.per_org.transaction_balancing_comparison",
+                extra={
+                    "org_id": org_id,
+                    "ds_proj_id": project_id,
+                    "transaction": transaction,
+                    "generic_metrics_sample_rate": generic_metrics_rate,
+                    "eap_sample_rate": item.new_sample_rate,
+                    "relative_deviation": get_relative_deviation(
+                        generic_metrics_rate, item.new_sample_rate
+                    ),
+                    "is_equal": is_within_relative_tolerance(
+                        generic_metrics_rate,
+                        item.new_sample_rate,
+                        TRANSACTION_BALANCING_COMPARISON_RELATIVE_TOLERANCE,
+                    ),
+                },
+            )
+
+
+def _log_recalibration_factor(calculations: PerOrgCalculations) -> None:
+    calculated_factor = calculations.recalibration_factor
+    cached_factor = calculations.cached_recalibration_factor
+    logger.info(
+        "dynamic_sampling.per_org.recalibration_factor_comparison",
+        extra={
+            "org_id": calculations.config.organization.id,
+            "sample_rate": calculations.config.get_sample_rate(),
+            "generic_metrics_factor": cached_factor,
+            "eap_factor": calculated_factor,
+            "relative_deviation": (
+                None
+                if calculated_factor is None
+                else get_relative_deviation(cached_factor, calculated_factor)
+            ),
+            "is_equal": calculated_factor is not None
+            and is_within_relative_tolerance(
+                cached_factor,
+                calculated_factor,
+                RECALIBRATION_FACTOR_COMPARISON_RELATIVE_TOLERANCE,
+            ),
+        },
+    )
+
+
+def _log_sample_rates_summary(calculations: PerOrgCalculations) -> None:
+    """
+    One line per org per cycle with the org, project and transaction sample rates of both
+    the EAP and the generic metrics (legacy) pipeline, for side-by-side comparison without
+    having to join the per-project and per-transaction comparison logs.
+    """
+    config = calculations.config
+    project_sample_rates = calculations.project_sample_rates
+    projects_summary = {}
+    for project in config.projects:
+        project_id = project.id
+        eap_named_rates, eap_implicit_rate = calculations.rebalanced_transactions.get(
+            project_id, ([], None)
+        )
+        cached_transactions = calculations.cached_transaction_sample_rates.get(project_id)
+        generic_metrics_named_rates, generic_metrics_implicit_rate = (
+            ({}, None) if cached_transactions is None else cached_transactions
+        )
+        projects_summary[str(project_id)] = {
+            "eap_sample_rate": project_sample_rates.get(project_id),
+            "generic_metrics_sample_rate": calculations.cached_project_sample_rates.get(project_id),
+            "eap_transaction_implicit_sample_rate": eap_implicit_rate,
+            "generic_metrics_transaction_implicit_sample_rate": generic_metrics_implicit_rate,
+            "eap_transaction_sample_rates": {
+                str(item.id): item.new_sample_rate for item in eap_named_rates
+            },
+            "generic_metrics_transaction_sample_rates": generic_metrics_named_rates,
+        }
+
+    logger.info(
+        "dynamic_sampling.per_org.sample_rates_summary",
+        extra={
+            "org_id": config.organization.id,
+            "eap_org_sample_rate": config.get_sample_rate(),
+            "eap_org_serving_sample_rate": config.get_serving_sample_rate(),
+            "generic_metrics_org_sample_rate": calculations.cached_organization_sample_rate,
+            "projects": projects_summary,
+        },
+    )

--- a/src/sentry/dynamic_sampling/per_org/scheduler.py
+++ b/src/sentry/dynamic_sampling/per_org/scheduler.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from datetime import timedelta
 
 import sentry_sdk
@@ -8,25 +7,20 @@ from django.db.models import Exists, OuterRef
 from taskbroker_client.retry import Retry
 
 from sentry.constants import ObjectStatus
-from sentry.dynamic_sampling.models.common import RebalancedItem
 from sentry.dynamic_sampling.per_org.calculations import (
+    PerOrgCalculations,
     apply_project_sample_rate_overrides,
+    collect_transaction_volume_debug,
     compare_organization_sliding_window_sample_rates,
-    compare_rebalanced_projects_with_cache,
-    compare_rebalanced_transactions_with_cache,
-    compare_recalibration_factor_with_cache,
     get_cached_organization_sample_rate,
     get_cached_rebalanced_project_sample_rates,
     get_cached_rebalanced_transaction_sample_rates,
     get_cached_recalibration_factor,
-    log_transaction_volume_debug,
     run_project_balancing,
     run_transaction_balancing,
 )
 from sentry.dynamic_sampling.per_org.configuration import (
     AutomaticDynamicSamplingConfiguration,
-    BaseDynamicSamplingConfiguration,
-    ProjectSampleRates,
     get_configuration,
 )
 from sentry.dynamic_sampling.per_org.gate import (
@@ -36,6 +30,7 @@ from sentry.dynamic_sampling.per_org.gate import (
     sliding_window_comparison_org_ids,
     transaction_volume_debug_project_ids,
 )
+from sentry.dynamic_sampling.per_org.legacy_comparison import log_comparison_with_legacy_pipeline
 from sentry.dynamic_sampling.per_org.queries import (
     get_eap_organization_volume,
     get_eap_project_volumes,
@@ -57,8 +52,6 @@ from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import telemetry_experience_tasks
 from sentry.utils.cursored_scheduler import CursoredScheduler
 
-logger = logging.getLogger(__name__)
-
 # How long a full pass through all organizations should take.
 CYCLE_DURATION = timedelta(minutes=10)
 
@@ -75,36 +68,50 @@ def run_calculations_per_org_task_entry(org_id: OrganizationId) -> None:
 
 @track_dynamic_sampling
 def run_calculations_per_org_task(org_id: OrganizationId) -> DynamicSamplingStatus | None:
+    calculations = run_per_org_calculations(org_id)
+    log_comparison_with_legacy_pipeline(calculations)
+    return calculations.status
+
+
+def run_per_org_calculations(org_id: OrganizationId) -> PerOrgCalculations:
+    """Compute the sample rates of one organization and of its projects and transactions.
+
+    Queries the volumes, runs the balancing models, recalibrates, and returns everything a
+    run produced. Reporting is left to the caller, so that a run can be exercised through
+    what it computed rather than through what it logged.
+    """
     config = get_configuration(org_id)
+    calculations = PerOrgCalculations(config=config)
+
     if not config.is_enabled:
-        return DynamicSamplingStatus.ORG_HAS_NO_DYNAMIC_SAMPLING
+        return calculations.stopped_at(DynamicSamplingStatus.ORG_HAS_NO_DYNAMIC_SAMPLING)
 
     if not config.projects:
-        return DynamicSamplingStatus.ORG_HAS_NO_PROJECTS
+        return calculations.stopped_at(DynamicSamplingStatus.ORG_HAS_NO_PROJECTS)
 
-    org_volume_5m = get_eap_organization_volume(config)
-    if org_volume_5m is None:
-        return DynamicSamplingStatus.NO_ORG_VOLUME
+    if get_eap_organization_volume(config) is None:
+        return calculations.stopped_at(DynamicSamplingStatus.NO_ORG_VOLUME)
 
-    project_volumes = get_eap_project_volumes(config)
-    if not project_volumes:
-        return DynamicSamplingStatus.NO_PROJECT_VOLUMES
+    calculations.project_volumes = get_eap_project_volumes(config)
+    if not calculations.project_volumes:
+        return calculations.stopped_at(DynamicSamplingStatus.NO_PROJECT_VOLUMES)
 
-    log_summary = is_org_in_sample_rates_summary_log_rollout(config.organization.id)
+    calculations.summary_log_enabled = is_org_in_sample_rates_summary_log_rollout(
+        config.organization.id
+    )
 
     # Read outside the balancing branch when the summary log is on, so orgs that skip project
     # balancing (project-mode custom sampling) still get a generic metrics side in the log.
-    cached_sample_rates: dict[int, float | None] = {}
-    if config.should_balance_projects or log_summary:
-        cached_sample_rates = get_cached_rebalanced_project_sample_rates(config.organization.id)
+    if config.should_balance_projects or calculations.summary_log_enabled:
+        calculations.cached_project_sample_rates = get_cached_rebalanced_project_sample_rates(
+            config.organization.id
+        )
 
     if config.should_balance_projects:
-        rebalanced_projects = run_project_balancing(config, project_volumes)
-        rebalanced_projects = apply_project_sample_rate_overrides(rebalanced_projects)
-        config.set_rebalanced_project_sample_rates(rebalanced_projects)
-        compare_rebalanced_projects_with_cache(
-            config, rebalanced_projects, cached_sample_rates, project_volumes
+        calculations.rebalanced_projects = apply_project_sample_rate_overrides(
+            run_project_balancing(config, calculations.project_volumes)
         )
+        config.set_rebalanced_project_sample_rates(calculations.rebalanced_projects)
 
     if (
         isinstance(config, AutomaticDynamicSamplingConfiguration)
@@ -115,7 +122,7 @@ def run_calculations_per_org_task(org_id: OrganizationId) -> DynamicSamplingStat
         except Exception as exc:
             sentry_sdk.capture_exception(exc)
 
-    sample_rates = config.get_project_sample_rates()
+    sample_rates = calculations.project_sample_rates
     # Emitted once per org per scheduler cycle, so summing over one CYCLE_DURATION
     # window yields the total number of projects sampled below 100%.
     projects_below_full_sample_rate = sum(
@@ -127,96 +134,47 @@ def run_calculations_per_org_task(org_id: OrganizationId) -> DynamicSamplingStat
         project for project in config.projects if sample_rates.get(project.id) != 1.0
     ]
     if not projects_to_balance:
-        return DynamicSamplingStatus.ALL_PROJECTS_AT_FULL_SAMPLE_RATE
+        return calculations.stopped_at(DynamicSamplingStatus.ALL_PROJECTS_AT_FULL_SAMPLE_RATE)
 
     transaction_volumes = get_eap_transaction_volumes(config)
     if not transaction_volumes:
-        return DynamicSamplingStatus.NO_TRANSACTION_VOLUMES
+        return calculations.stopped_at(DynamicSamplingStatus.NO_TRANSACTION_VOLUMES)
 
     debug_project_ids = transaction_volume_debug_project_ids() & {
         project.id for project in projects_to_balance
     }
     if debug_project_ids:
-        log_transaction_volume_debug(config, transaction_volumes, debug_project_ids)
+        calculations.transaction_volume_debug = collect_transaction_volume_debug(
+            config, transaction_volumes, debug_project_ids
+        )
 
-    rebalanced_transactions = run_transaction_balancing(
-        config, project_volumes, transaction_volumes
+    calculations.rebalanced_transactions = run_transaction_balancing(
+        config, calculations.project_volumes, transaction_volumes
     )
     # When the summary log is on, the cache is read for every project rather than only the
     # EAP-rebalanced ones, so the log can report a generic metrics side even where EAP
     # produced no transaction rates.
-    cached_transaction_sample_rates = get_cached_rebalanced_transaction_sample_rates(
+    calculations.cached_transaction_sample_rates = get_cached_rebalanced_transaction_sample_rates(
         org_id=config.organization.id,
         project_ids=(
             [project.id for project in config.projects]
-            if log_summary
-            else list(rebalanced_transactions.keys())
+            if calculations.summary_log_enabled
+            else list(calculations.rebalanced_transactions.keys())
         ),
     )
-    compare_rebalanced_transactions_with_cache(
-        config, rebalanced_transactions, cached_transaction_sample_rates
-    )
-
-    if log_summary:
-        log_sample_rates_summary(
-            config,
-            project_sample_rates=sample_rates,
-            cached_project_sample_rates=cached_sample_rates,
-            rebalanced_transactions=rebalanced_transactions,
-            cached_transaction_sample_rates=cached_transaction_sample_rates,
+    if calculations.summary_log_enabled:
+        calculations.cached_organization_sample_rate = get_cached_organization_sample_rate(
+            config.organization.id
         )
 
     if is_org_in_recalibration_rollout(org_id):
-        calculated_factor = config.recalibrate()
-        cached_factor = get_cached_recalibration_factor(config.organization.id)
-        compare_recalibration_factor_with_cache(config, calculated_factor, cached_factor)
-
-    return None
-
-
-def log_sample_rates_summary(
-    config: BaseDynamicSamplingConfiguration,
-    project_sample_rates: ProjectSampleRates,
-    cached_project_sample_rates: dict[int, float | None],
-    rebalanced_transactions: dict[int, tuple[list[RebalancedItem], float]],
-    cached_transaction_sample_rates: dict[int, tuple[dict[str, float], float] | None],
-) -> None:
-    """
-    One line per org per cycle with the org, project and transaction sample rates of both
-    the EAP and the generic metrics (legacy) pipeline, for side-by-side comparison without
-    having to join the per-project and per-transaction comparison logs.
-    """
-    projects_summary = {}
-    for project in config.projects:
-        project_id = project.id
-        eap_named_rates, eap_implicit_rate = rebalanced_transactions.get(project_id, ([], None))
-        cached_transactions = cached_transaction_sample_rates.get(project_id)
-        generic_metrics_named_rates, generic_metrics_implicit_rate = (
-            ({}, None) if cached_transactions is None else cached_transactions
+        calculations.recalibration_ran = True
+        calculations.recalibration_factor = config.recalibrate()
+        calculations.cached_recalibration_factor = get_cached_recalibration_factor(
+            config.organization.id
         )
-        projects_summary[str(project_id)] = {
-            "eap_sample_rate": project_sample_rates.get(project_id),
-            "generic_metrics_sample_rate": cached_project_sample_rates.get(project_id),
-            "eap_transaction_implicit_sample_rate": eap_implicit_rate,
-            "generic_metrics_transaction_implicit_sample_rate": generic_metrics_implicit_rate,
-            "eap_transaction_sample_rates": {
-                str(item.id): item.new_sample_rate for item in eap_named_rates
-            },
-            "generic_metrics_transaction_sample_rates": generic_metrics_named_rates,
-        }
 
-    logger.info(
-        "dynamic_sampling.per_org.sample_rates_summary",
-        extra={
-            "org_id": config.organization.id,
-            "eap_org_sample_rate": config.get_sample_rate(),
-            "eap_org_serving_sample_rate": config.get_serving_sample_rate(),
-            "generic_metrics_org_sample_rate": get_cached_organization_sample_rate(
-                config.organization.id
-            ),
-            "projects": projects_summary,
-        },
-    )
+    return calculations
 
 
 @instrumented_task(

--- a/tests/sentry/dynamic_sampling/per_org/test_cache.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_cache.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from sentry.dynamic_sampling.per_org import cache as per_org_recalibration_cache
+from sentry.dynamic_sampling.rules.utils import get_redis_client_for_ds
+from sentry.dynamic_sampling.tasks.helpers import (
+    recalibrate_orgs as legacy_recalibration_cache,
+)
+from sentry.testutils.cases import TestCase
+
+
+class PerOrgRecalibrationCacheTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.redis = get_redis_client_for_ds()
+        self.org = self.create_organization()
+        self.cache_key = per_org_recalibration_cache.generate_recalibrate_orgs_cache_key(
+            self.org.id
+        )
+        self.legacy_cache_key = legacy_recalibration_cache.generate_recalibrate_orgs_cache_key(
+            self.org.id
+        )
+        self.redis.delete(self.cache_key, self.legacy_cache_key)
+        self.addCleanup(self.redis.delete, self.cache_key, self.legacy_cache_key)
+
+    def test_does_not_cross_pollinate_with_the_legacy_cache(self) -> None:
+        assert self.cache_key != self.legacy_cache_key
+
+        self.redis.set(self.legacy_cache_key, 2.5)
+        assert legacy_recalibration_cache.get_adjusted_factor(self.org.id) == 2.5
+        assert per_org_recalibration_cache.get_adjusted_factor(self.org.id) == 1.0
+
+        self.redis.delete(self.legacy_cache_key)
+        self.redis.set(self.cache_key, 3.5)
+        assert per_org_recalibration_cache.get_adjusted_factor(self.org.id) == 3.5
+        assert legacy_recalibration_cache.get_adjusted_factor(self.org.id) == 1.0
+
+    def test_sets_and_deletes_the_adjusted_factor(self) -> None:
+        per_org_recalibration_cache.set_guarded_adjusted_factor(self.org.id, 2.5)
+        assert per_org_recalibration_cache.get_adjusted_factor(self.org.id) == 2.5
+
+        # A factor of 1.0 means "no adjustment", so it clears the key instead of storing it.
+        per_org_recalibration_cache.set_guarded_adjusted_factor(self.org.id, 1.0)
+        assert self.redis.get(self.cache_key) is None
+        assert per_org_recalibration_cache.get_adjusted_factor(self.org.id) == 1.0
+
+    def test_missing_factor_defaults_to_no_adjustment(self) -> None:
+        assert per_org_recalibration_cache.get_adjusted_factor(self.org.id) == 1.0
+
+    def test_delete_is_idempotent(self) -> None:
+        per_org_recalibration_cache.delete_adjusted_factor(self.org.id)
+        per_org_recalibration_cache.delete_adjusted_factor(self.org.id)
+
+        assert per_org_recalibration_cache.get_adjusted_factor(self.org.id) == 1.0

--- a/tests/sentry/dynamic_sampling/per_org/test_calculations.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_calculations.py
@@ -10,11 +10,10 @@ import pytest
 from sentry.dynamic_sampling.models.common import RebalancedItem
 from sentry.dynamic_sampling.models.projects_rebalancing import ProjectsRebalancingInput
 from sentry.dynamic_sampling.per_org.calculations import (
+    TransactionVolumeDebug,
     apply_project_sample_rate_overrides,
     calculate_recalibration_factor,
-    compare_rebalanced_projects_with_cache,
-    compare_rebalanced_transactions_with_cache,
-    compare_recalibration_factor_with_cache,
+    collect_transaction_volume_debug,
     get_cached_rebalanced_project_sample_rates,
     get_cached_rebalanced_transaction_sample_rates,
     get_cached_recalibration_factor,
@@ -43,9 +42,9 @@ from tests.sentry.dynamic_sampling.per_org.test_helpers import (
 )
 
 CALCULATIONS = "sentry.dynamic_sampling.per_org.calculations"
-LOGGER_INFO = f"{CALCULATIONS}.logger.info"
 PROJECTS_MODEL_RUN = f"{CALCULATIONS}.ProjectsRebalancingModel.run"
 TRANSACTIONS_MODEL_RUN = f"{CALCULATIONS}.TransactionsRebalancingModel.run"
+GENERIC_METRICS_TRANSACTION_VOLUMES = f"{CALCULATIONS}.get_generic_metrics_transaction_volumes"
 
 
 class ProjectBalancingCalculationsTest(TestCase):
@@ -175,56 +174,6 @@ class ProjectBalancingCalculationsTest(TestCase):
         result = apply_project_sample_rate_overrides(rebalanced_projects)
         assert result == rebalanced_projects
 
-    def test_compare_rebalanced_projects_with_cache_logs_per_project(self) -> None:
-        org = self.create_organization()
-        project_with_volume = self.create_project(organization=org)
-        project_without_volume = self.create_project(organization=org)
-        config = mock_configuration(org)
-        rebalanced_projects = [
-            RebalancedItem(id=project_with_volume.id, count=100, new_sample_rate=0.25),
-            RebalancedItem(id=project_without_volume.id, count=0, new_sample_rate=1.0),
-        ]
-        cached_sample_rates: dict[int, float | None] = {
-            project_with_volume.id: 0.2,
-            project_without_volume.id: 0.96,
-        }
-        project_volumes = [
-            ProjectVolume(project_id=project_with_volume.id, total=200, keep=100, drop=100),
-            ProjectVolume(project_id=project_without_volume.id, total=0, keep=0, drop=0),
-        ]
-
-        with patch(LOGGER_INFO) as logger_info:
-            compare_rebalanced_projects_with_cache(
-                config, rebalanced_projects, cached_sample_rates, project_volumes
-            )
-
-        assert [call.args for call in logger_info.call_args_list] == [
-            ("dynamic_sampling.per_org.project_balancing_comparison",),
-            ("dynamic_sampling.per_org.project_balancing_comparison",),
-        ]
-        assert [call.kwargs["extra"] for call in logger_info.call_args_list] == [
-            {
-                "org_id": org.id,
-                "ds_proj_id": project_with_volume.id,
-                "generic_metrics_sample_rate": 0.2,
-                "eap_sample_rate": 0.25,
-                "relative_deviation": pytest.approx(0.2),
-                "is_equal": False,
-                "total_volume_eap": 100,
-                "total_volume_eap_without_extrapolation": 100,
-            },
-            {
-                "org_id": org.id,
-                "ds_proj_id": project_without_volume.id,
-                "generic_metrics_sample_rate": 0.96,
-                "eap_sample_rate": 1.0,
-                "relative_deviation": pytest.approx(0.04),
-                "is_equal": True,
-                "total_volume_eap": 0,
-                "total_volume_eap_without_extrapolation": 0,
-            },
-        ]
-
     def test_project_balancing_relative_tolerance(self) -> None:
         assert is_within_relative_tolerance(0.95, 1.0)
         assert is_within_relative_tolerance(1.05, 1.0)
@@ -257,41 +206,6 @@ class ProjectBalancingCalculationsTest(TestCase):
         self.redis.set(cache_key, 2.5)
 
         assert get_cached_recalibration_factor(org.id) == 2.5
-
-    def test_compare_recalibration_factor_with_cache_logs_the_deviation(self) -> None:
-        org = self.create_organization()
-        config = mock_configuration(org, sample_rate=0.5)
-
-        with patch(LOGGER_INFO) as logger_info:
-            compare_recalibration_factor_with_cache(config, 2.8, 2.0)
-
-        logger_info.assert_called_once_with(
-            "dynamic_sampling.per_org.recalibration_factor_comparison",
-            extra={
-                "org_id": org.id,
-                "sample_rate": 0.5,
-                "generic_metrics_factor": 2.0,
-                "eap_factor": 2.8,
-                "relative_deviation": pytest.approx(0.2857142857142857),
-                "is_equal": False,
-            },
-        )
-
-    def test_compare_recalibration_factor_with_cache_reports_a_skipped_factor(self) -> None:
-        org = self.create_organization()
-        config = mock_configuration(org, sample_rate=0.5)
-
-        with patch(LOGGER_INFO) as logger_info:
-            compare_recalibration_factor_with_cache(config, None, 2.0)
-
-        assert logger_info.call_args.kwargs["extra"] == {
-            "org_id": org.id,
-            "sample_rate": 0.5,
-            "generic_metrics_factor": 2.0,
-            "eap_factor": None,
-            "relative_deviation": None,
-            "is_equal": False,
-        }
 
 
 def _project_transactions(
@@ -470,84 +384,30 @@ class TransactionBalancingCalculationsTest(TestCase):
             project_miss.id: None,
         }
 
-    def test_compare_rebalanced_transactions_with_cache_logs_per_transaction(self) -> None:
+    def test_collect_transaction_volume_debug_collects_both_pipelines(self) -> None:
         org = self.create_organization()
-        project = self.create_project(organization=org)
-        config = mock_configuration(org)
-        rebalanced_transactions = {
-            project.id: (
-                [
-                    RebalancedItem(id="checkout", count=100, new_sample_rate=0.25),
-                    RebalancedItem(id="cart", count=50, new_sample_rate=0.96),
-                ],
-                0.5,
-            ),
-        }
-        cached_sample_rates: dict[int, tuple[dict[str, float], float] | None] = {
-            project.id: ({"checkout": 0.2, "cart": 1.0}, 0.45),
-        }
-
-        with patch(LOGGER_INFO) as logger_info:
-            compare_rebalanced_transactions_with_cache(
-                config, rebalanced_transactions, cached_sample_rates
-            )
-
-        messages = [call.args[0] for call in logger_info.call_args_list]
-        assert messages == [
-            "dynamic_sampling.per_org.transaction_balancing_implicit_comparison",
-            "dynamic_sampling.per_org.transaction_balancing_comparison",
-            "dynamic_sampling.per_org.transaction_balancing_comparison",
-        ]
-        extras = [call.kwargs["extra"] for call in logger_info.call_args_list]
-        assert extras == [
-            {
-                "org_id": org.id,
-                "ds_proj_id": project.id,
-                "generic_metrics_implicit_rate": 0.45,
-                "eap_implicit_rate": 0.5,
-                "relative_deviation": pytest.approx(0.1),
-                "is_equal": False,
-            },
-            {
-                "org_id": org.id,
-                "ds_proj_id": project.id,
-                "transaction": "checkout",
-                "generic_metrics_sample_rate": 0.2,
-                "eap_sample_rate": 0.25,
-                "relative_deviation": pytest.approx(0.2),
-                "is_equal": False,
-            },
-            {
-                "org_id": org.id,
-                "ds_proj_id": project.id,
-                "transaction": "cart",
-                "generic_metrics_sample_rate": 1.0,
-                "eap_sample_rate": 0.96,
-                "relative_deviation": pytest.approx(0.04166666666666674),
-                "is_equal": True,
-            },
+        debugged = self.create_project(organization=org)
+        other = self.create_project(organization=org)
+        config = mock_configuration(org, projects=[debugged, other])
+        transaction_volumes = [
+            _project_transactions(org.id, debugged.id, [("/checkout", 600.0)]),
+            _project_transactions(org.id, other.id, [("/api", 200.0)]),
         ]
 
-    def test_compare_rebalanced_transactions_with_cache_handles_cache_miss(self) -> None:
-        org = self.create_organization()
-        project = self.create_project(organization=org)
-        config = mock_configuration(org)
-        rebalanced_transactions = {
-            project.id: ([RebalancedItem(id="checkout", count=10, new_sample_rate=0.5)], 0.5),
-        }
+        with patch_configuration(
+            {GENERIC_METRICS_TRANSACTION_VOLUMES: {debugged.id: [("/legacy-only", 20.0)]}}
+        ):
+            result = collect_transaction_volume_debug(config, transaction_volumes, {debugged.id})
 
-        with patch(LOGGER_INFO) as logger_info:
-            compare_rebalanced_transactions_with_cache(
-                config, rebalanced_transactions, {project.id: None}
+        # Only the debugged project is collected, with the volumes of both pipelines side by
+        # side even where a transaction is missing from one of them.
+        assert result == [
+            TransactionVolumeDebug(
+                project_id=debugged.id,
+                eap_volumes={"/checkout": 600.0},
+                generic_metrics_volumes={"/legacy-only": 20.0},
             )
-
-        extras = [call.kwargs["extra"] for call in logger_info.call_args_list]
-        assert extras[0]["generic_metrics_implicit_rate"] is None
-        assert extras[0]["relative_deviation"] is None
-        assert extras[0]["is_equal"] is False
-        assert extras[1]["generic_metrics_sample_rate"] is None
-        assert extras[1]["relative_deviation"] is None
-        assert extras[1]["is_equal"] is False
+        ]
 
 
 class TransactionBalancingModelOutputTest(TestCase):

--- a/tests/sentry/dynamic_sampling/per_org/test_helpers.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_helpers.py
@@ -27,14 +27,21 @@ LEGACY_GET_FACTOR = f"{CALCULATIONS}.legacy_recalibration_cache.get_adjusted_fac
 def patch_configuration(targets: dict[str, Any]) -> Iterator[dict[str, MagicMock]]:
     """Patch the given targets, each with the given return value.
 
-    Pass ``DEFAULT`` as the return value to patch a target without one. The yielded
-    mocks are keyed by target so that callers can assert on the calls.
+    Pass ``DEFAULT`` as the return value to patch a target without one, or an exception
+    class to raise it instead of returning. The yielded mocks are keyed by target so that
+    callers can assert on the calls.
     """
     with ExitStack() as stack:
         yield {
-            target: stack.enter_context(patch(target, return_value=return_value))
-            for target, return_value in targets.items()
+            target: stack.enter_context(_patch_with(target, value))
+            for target, value in targets.items()
         }
+
+
+def _patch_with(target: str, value: Any) -> Any:
+    if isinstance(value, type) and issubclass(value, BaseException):
+        return patch(target, side_effect=value)
+    return patch(target, return_value=value)
 
 
 def make_project_volume(project_id: int, total: int = 100, keep: int = 25) -> ProjectVolume:
@@ -46,6 +53,7 @@ def mock_configuration(
     projects: list[Project] | None = None,
     sample_rate: float | None = None,
     project_sample_rates: ProjectSampleRates | None = None,
+    serving_sample_rate: float | None = None,
 ) -> Mock:
     """A stand-in configuration whose getters return the given sample rates."""
     return Mock(
@@ -53,6 +61,7 @@ def mock_configuration(
         projects=projects or [],
         **{
             "get_sample_rate.return_value": sample_rate,
+            "get_serving_sample_rate.return_value": serving_sample_rate,
             "get_project_sample_rates.return_value": project_sample_rates or {},
         },
     )

--- a/tests/sentry/dynamic_sampling/per_org/test_legacy_comparison.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_legacy_comparison.py
@@ -1,0 +1,326 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from sentry.dynamic_sampling.models.common import RebalancedItem
+from sentry.dynamic_sampling.per_org.calculations import PerOrgCalculations, TransactionVolumeDebug
+from sentry.dynamic_sampling.per_org.legacy_comparison import log_comparison_with_legacy_pipeline
+from sentry.dynamic_sampling.per_org.queries import ProjectVolume
+from sentry.dynamic_sampling.per_org.telemetry import DynamicSamplingStatus
+from sentry.testutils.cases import TestCase
+from tests.sentry.dynamic_sampling.per_org.test_helpers import mock_configuration
+
+LOGGER_INFO = "sentry.dynamic_sampling.per_org.legacy_comparison.logger.info"
+
+PROJECT_COMPARISON = "dynamic_sampling.per_org.project_balancing_comparison"
+IMPLICIT_COMPARISON = "dynamic_sampling.per_org.transaction_balancing_implicit_comparison"
+TRANSACTION_COMPARISON = "dynamic_sampling.per_org.transaction_balancing_comparison"
+VOLUME_DEBUG = "dynamic_sampling.per_org.transaction_volume_debug"
+FACTOR_COMPARISON = "dynamic_sampling.per_org.recalibration_factor_comparison"
+SAMPLE_RATES_SUMMARY = "dynamic_sampling.per_org.sample_rates_summary"
+
+Log = tuple[str, dict[str, Any]]
+
+
+def log_lines(calculations: PerOrgCalculations) -> list[Log]:
+    """The messages and extras a finished run is reported with, in the order they are logged."""
+    with patch(LOGGER_INFO) as logger_info:
+        log_comparison_with_legacy_pipeline(calculations)
+    return [(call.args[0], call.kwargs.get("extra", {})) for call in logger_info.call_args_list]
+
+
+def extras(logs: list[Log], message: str) -> list[dict[str, Any]]:
+    return [extra for logged, extra in logs if logged == message]
+
+
+class ProjectBalancingComparisonTest(TestCase):
+    def test_logs_one_line_per_rebalanced_project(self) -> None:
+        org = self.create_organization()
+        project_with_volume = self.create_project(organization=org)
+        project_without_volume = self.create_project(organization=org)
+        calculations = PerOrgCalculations(
+            config=mock_configuration(org),
+            rebalanced_projects=[
+                RebalancedItem(id=project_with_volume.id, count=100, new_sample_rate=0.25),
+                RebalancedItem(id=project_without_volume.id, count=0, new_sample_rate=1.0),
+            ],
+            cached_project_sample_rates={
+                project_with_volume.id: 0.2,
+                project_without_volume.id: 0.96,
+            },
+            project_volumes=[
+                ProjectVolume(project_id=project_with_volume.id, total=200, keep=100, drop=100),
+                ProjectVolume(project_id=project_without_volume.id, total=0, keep=0, drop=0),
+            ],
+        )
+
+        assert extras(log_lines(calculations), PROJECT_COMPARISON) == [
+            {
+                "org_id": org.id,
+                "ds_proj_id": project_with_volume.id,
+                "generic_metrics_sample_rate": 0.2,
+                "eap_sample_rate": 0.25,
+                "relative_deviation": pytest.approx(0.2),
+                "is_equal": False,
+                "total_volume_eap": 100,
+                "total_volume_eap_without_extrapolation": 100,
+            },
+            {
+                "org_id": org.id,
+                "ds_proj_id": project_without_volume.id,
+                "generic_metrics_sample_rate": 0.96,
+                "eap_sample_rate": 1.0,
+                "relative_deviation": pytest.approx(0.04),
+                "is_equal": True,
+                "total_volume_eap": 0,
+                "total_volume_eap_without_extrapolation": 0,
+            },
+        ]
+
+    def test_reports_a_project_the_legacy_pipeline_has_no_rate_for(self) -> None:
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        calculations = PerOrgCalculations(
+            config=mock_configuration(org),
+            rebalanced_projects=[RebalancedItem(id=project.id, count=100, new_sample_rate=0.25)],
+        )
+
+        (project_comparison,) = extras(log_lines(calculations), PROJECT_COMPARISON)
+        assert project_comparison["generic_metrics_sample_rate"] is None
+        assert project_comparison["relative_deviation"] is None
+        assert project_comparison["is_equal"] is False
+        assert project_comparison["total_volume_eap_without_extrapolation"] is None
+
+
+class TransactionBalancingComparisonTest(TestCase):
+    def test_logs_the_implicit_rate_and_one_line_per_transaction(self) -> None:
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        calculations = PerOrgCalculations(
+            config=mock_configuration(org),
+            rebalanced_transactions={
+                project.id: (
+                    [
+                        RebalancedItem(id="checkout", count=100, new_sample_rate=0.25),
+                        RebalancedItem(id="cart", count=50, new_sample_rate=0.96),
+                    ],
+                    0.5,
+                ),
+            },
+            cached_transaction_sample_rates={
+                project.id: ({"checkout": 0.2, "cart": 1.0}, 0.45),
+            },
+        )
+
+        logs = log_lines(calculations)
+
+        assert [message for message, _ in logs] == [
+            IMPLICIT_COMPARISON,
+            TRANSACTION_COMPARISON,
+            TRANSACTION_COMPARISON,
+        ]
+        assert extras(logs, IMPLICIT_COMPARISON) == [
+            {
+                "org_id": org.id,
+                "ds_proj_id": project.id,
+                "generic_metrics_implicit_rate": 0.45,
+                "eap_implicit_rate": 0.5,
+                "relative_deviation": pytest.approx(0.1),
+                "is_equal": False,
+            },
+        ]
+        assert extras(logs, TRANSACTION_COMPARISON) == [
+            {
+                "org_id": org.id,
+                "ds_proj_id": project.id,
+                "transaction": "checkout",
+                "generic_metrics_sample_rate": 0.2,
+                "eap_sample_rate": 0.25,
+                "relative_deviation": pytest.approx(0.2),
+                "is_equal": False,
+            },
+            {
+                "org_id": org.id,
+                "ds_proj_id": project.id,
+                "transaction": "cart",
+                "generic_metrics_sample_rate": 1.0,
+                "eap_sample_rate": 0.96,
+                "relative_deviation": pytest.approx(0.04166666666666674),
+                "is_equal": True,
+            },
+        ]
+
+    def test_reports_a_project_the_legacy_pipeline_has_no_rates_for(self) -> None:
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        calculations = PerOrgCalculations(
+            config=mock_configuration(org),
+            rebalanced_transactions={
+                project.id: ([RebalancedItem(id="checkout", count=10, new_sample_rate=0.5)], 0.5),
+            },
+            cached_transaction_sample_rates={project.id: None},
+        )
+
+        logs = log_lines(calculations)
+
+        (implicit_comparison,) = extras(logs, IMPLICIT_COMPARISON)
+        assert implicit_comparison["generic_metrics_implicit_rate"] is None
+        assert implicit_comparison["relative_deviation"] is None
+        assert implicit_comparison["is_equal"] is False
+        (transaction_comparison,) = extras(logs, TRANSACTION_COMPARISON)
+        assert transaction_comparison["generic_metrics_sample_rate"] is None
+        assert transaction_comparison["relative_deviation"] is None
+        assert transaction_comparison["is_equal"] is False
+
+
+class TransactionVolumeDebugTest(TestCase):
+    def test_logs_the_volumes_of_both_pipelines_per_transaction(self) -> None:
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        calculations = PerOrgCalculations(
+            config=mock_configuration(org),
+            transaction_volume_debug=[
+                TransactionVolumeDebug(
+                    project_id=project.id,
+                    eap_volumes={"/checkout": 600.0, "/eap-only": 10.0},
+                    generic_metrics_volumes={"/checkout": 580.0, "/legacy-only": 20.0},
+                )
+            ],
+        )
+
+        assert extras(log_lines(calculations), VOLUME_DEBUG) == [
+            {
+                "org_id": org.id,
+                "ds_proj_id": project.id,
+                "transactions": {
+                    "/checkout": {"eap_volume": 600.0, "generic_metrics_volume": 580.0},
+                    "/eap-only": {"eap_volume": 10.0, "generic_metrics_volume": None},
+                    "/legacy-only": {"eap_volume": None, "generic_metrics_volume": 20.0},
+                },
+            },
+        ]
+
+
+class RecalibrationFactorComparisonTest(TestCase):
+    def test_logs_the_deviation(self) -> None:
+        org = self.create_organization()
+        calculations = PerOrgCalculations(
+            config=mock_configuration(org, sample_rate=0.5),
+            recalibration_ran=True,
+            recalibration_factor=2.8,
+            cached_recalibration_factor=2.0,
+        )
+
+        assert extras(log_lines(calculations), FACTOR_COMPARISON) == [
+            {
+                "org_id": org.id,
+                "sample_rate": 0.5,
+                "generic_metrics_factor": 2.0,
+                "eap_factor": 2.8,
+                "relative_deviation": pytest.approx(0.2857142857142857),
+                "is_equal": False,
+            },
+        ]
+
+    def test_reports_a_skipped_factor(self) -> None:
+        org = self.create_organization()
+        calculations = PerOrgCalculations(
+            config=mock_configuration(org, sample_rate=0.5),
+            recalibration_ran=True,
+            recalibration_factor=None,
+            cached_recalibration_factor=2.0,
+        )
+
+        assert extras(log_lines(calculations), FACTOR_COMPARISON) == [
+            {
+                "org_id": org.id,
+                "sample_rate": 0.5,
+                "generic_metrics_factor": 2.0,
+                "eap_factor": None,
+                "relative_deviation": None,
+                "is_equal": False,
+            },
+        ]
+
+    def test_says_nothing_when_recalibration_did_not_run(self) -> None:
+        org = self.create_organization()
+        calculations = PerOrgCalculations(config=mock_configuration(org, sample_rate=0.5))
+
+        assert extras(log_lines(calculations), FACTOR_COMPARISON) == []
+
+
+class SampleRatesSummaryTest(TestCase):
+    def calculations_for_both_pipelines(self, summary_log_enabled: bool) -> PerOrgCalculations:
+        self.busy_project = self.create_project(organization=self.organization)
+        self.quiet_project = self.create_project(organization=self.organization)
+        return PerOrgCalculations(
+            config=mock_configuration(
+                self.organization,
+                projects=[self.busy_project, self.quiet_project],
+                sample_rate=0.5,
+                serving_sample_rate=0.5,
+                project_sample_rates={self.busy_project.id: 0.4, self.quiet_project.id: 1.0},
+            ),
+            rebalanced_transactions={
+                self.busy_project.id: (
+                    [
+                        RebalancedItem(id="/cart", count=200, new_sample_rate=0.45),
+                        RebalancedItem(id="/checkout", count=600, new_sample_rate=0.2),
+                    ],
+                    0.96,
+                ),
+            },
+            cached_organization_sample_rate=0.45,
+            cached_project_sample_rates={self.busy_project.id: 0.41, self.quiet_project.id: 0.5},
+            cached_transaction_sample_rates={
+                self.busy_project.id: None,
+                self.quiet_project.id: ({"/api": 0.6}, 0.62),
+            },
+            summary_log_enabled=summary_log_enabled,
+        )
+
+    def test_reports_both_pipelines_side_by_side(self) -> None:
+        calculations = self.calculations_for_both_pipelines(summary_log_enabled=True)
+
+        (summary,) = extras(log_lines(calculations), SAMPLE_RATES_SUMMARY)
+
+        assert summary["org_id"] == self.organization.id
+        assert summary["eap_org_sample_rate"] == 0.5
+        assert summary["eap_org_serving_sample_rate"] == 0.5
+        assert summary["generic_metrics_org_sample_rate"] == 0.45
+        assert summary["projects"][str(self.busy_project.id)] == {
+            "eap_sample_rate": 0.4,
+            "generic_metrics_sample_rate": 0.41,
+            "eap_transaction_implicit_sample_rate": 0.96,
+            "generic_metrics_transaction_implicit_sample_rate": None,
+            "eap_transaction_sample_rates": {"/cart": 0.45, "/checkout": 0.2},
+            "generic_metrics_transaction_sample_rates": {},
+        }
+        # The quiet project produced no EAP transaction rates, yet the summary still reports
+        # its legacy ones.
+        assert summary["projects"][str(self.quiet_project.id)] == {
+            "eap_sample_rate": 1.0,
+            "generic_metrics_sample_rate": 0.5,
+            "eap_transaction_implicit_sample_rate": None,
+            "generic_metrics_transaction_implicit_sample_rate": 0.62,
+            "eap_transaction_sample_rates": {},
+            "generic_metrics_transaction_sample_rates": {"/api": 0.6},
+        }
+
+    def test_says_nothing_outside_the_summary_log_rollout(self) -> None:
+        calculations = self.calculations_for_both_pipelines(summary_log_enabled=False)
+
+        assert extras(log_lines(calculations), SAMPLE_RATES_SUMMARY) == []
+
+
+class StoppedRunTest(TestCase):
+    def test_says_nothing_about_a_run_that_computed_nothing(self) -> None:
+        calculations = PerOrgCalculations(
+            config=mock_configuration(self.organization),
+            status=DynamicSamplingStatus.NO_ORG_VOLUME,
+        )
+
+        assert log_lines(calculations) == []

--- a/tests/sentry/dynamic_sampling/per_org/test_scheduler.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_scheduler.py
@@ -1,34 +1,53 @@
 from __future__ import annotations
 
-from unittest.mock import DEFAULT, Mock, patch
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import MagicMock, patch
 
+import orjson
+import pytest
 from django.core.exceptions import ObjectDoesNotExist
 
 from sentry.constants import ObjectStatus
-from sentry.dynamic_sampling.models.common import RebalancedItem
 from sentry.dynamic_sampling.per_org import cache as per_org_recalibration_cache
-from sentry.dynamic_sampling.per_org.configuration import BaseDynamicSamplingConfiguration
-from sentry.dynamic_sampling.per_org.gate import is_org_in_rollout
-from sentry.dynamic_sampling.per_org.queries import ProjectTransactionCounts
+from sentry.dynamic_sampling.per_org.calculations import PerOrgCalculations
+from sentry.dynamic_sampling.per_org.gate import (
+    RECALIBRATION_ROLLOUT_RATE_OPTION,
+    ROLLOUT_RATE_OPTION,
+    SAMPLE_RATES_SUMMARY_LOG_ROLLOUT_RATE_OPTION,
+)
+from sentry.dynamic_sampling.per_org.queries import ProjectTransactionCounts, ProjectVolume
 from sentry.dynamic_sampling.per_org.scheduler import (
     run_calculations_per_org_task,
+    run_per_org_calculations,
     schedule_per_org_calculations,
 )
-from sentry.dynamic_sampling.per_org.telemetry import DynamicSamplingStatus
+from sentry.dynamic_sampling.per_org.telemetry import (
+    DynamicSamplingException,
+    DynamicSamplingStatus,
+)
 from sentry.dynamic_sampling.rules.utils import get_redis_client_for_ds
 from sentry.dynamic_sampling.tasks.common import OrganizationDataVolume
 from sentry.dynamic_sampling.tasks.helpers import (
     recalibrate_orgs as legacy_recalibration_cache,
+)
+from sentry.dynamic_sampling.tasks.helpers.boost_low_volume_projects import (
+    generate_boost_low_volume_projects_cache_key,
+)
+from sentry.dynamic_sampling.tasks.helpers.boost_low_volume_transactions import (
+    generate_boost_low_volume_transactions_cache_key,
+)
+from sentry.dynamic_sampling.tasks.helpers.sliding_window import (
+    generate_sliding_window_org_cache_key,
 )
 from sentry.dynamic_sampling.types import DynamicSamplingMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
 from tests.sentry.dynamic_sampling.per_org.test_helpers import (
     BLENDED_SAMPLE_RATE,
-    LEGACY_GET_FACTOR,
+    OUTCOMES_VOLUME,
     SAMPLED_VOLUME,
-    SET_FACTOR,
-    make_project_volume,
     patch_configuration,
 )
 
@@ -36,555 +55,472 @@ SCHEDULER = "sentry.dynamic_sampling.per_org.scheduler"
 ORG_VOLUME = f"{SCHEDULER}.get_eap_organization_volume"
 PROJECT_VOLUMES = f"{SCHEDULER}.get_eap_project_volumes"
 TRANSACTION_VOLUMES = f"{SCHEDULER}.get_eap_transaction_volumes"
-PROJECT_BALANCING = f"{SCHEDULER}.run_project_balancing"
-TRANSACTION_BALANCING = f"{SCHEDULER}.run_transaction_balancing"
-CACHED_PROJECT_RATES = f"{SCHEDULER}.get_cached_rebalanced_project_sample_rates"
-COMPARE_PROJECTS = f"{SCHEDULER}.compare_rebalanced_projects_with_cache"
-CACHED_FACTOR = f"{SCHEDULER}.get_cached_recalibration_factor"
-COMPARE_FACTOR = f"{SCHEDULER}.compare_recalibration_factor_with_cache"
+LOG_COMPARISON = f"{SCHEDULER}.log_comparison_with_legacy_pipeline"
+
+# What the transaction model gives "/checkout" once the busy project sits at a 40% rate.
+CHECKOUT_SAMPLE_RATE = 0.19666666666666666
 
 
-def _assert_called_once_with_config(
-    mock: Mock,
-    organization_id: int,
-) -> BaseDynamicSamplingConfiguration:
-    mock.assert_called_once()
-    config = mock.call_args.args[0]
-    assert isinstance(config, BaseDynamicSamplingConfiguration)
-    assert config.organization.id == organization_id
-    return config
+def transaction_sample_rates(
+    calculations: PerOrgCalculations, project_id: int
+) -> tuple[dict[str, float], float]:
+    """The balanced transaction rates of one project, by transaction, plus its implicit rate."""
+    named_rates, implicit_rate = calculations.rebalanced_transactions[project_id]
+    return {str(item.id): item.new_sample_rate for item in named_rates}, implicit_rate
 
 
-class PerOrgRecalibrationCacheTest(TestCase):
-    def test_per_org_cache_does_not_cross_pollinate_with_legacy_cache(self) -> None:
-        org = self.create_organization()
-        redis = get_redis_client_for_ds()
-        legacy_key = legacy_recalibration_cache.generate_recalibrate_orgs_cache_key(org.id)
-        per_org_key = per_org_recalibration_cache.generate_recalibrate_orgs_cache_key(org.id)
-        self.addCleanup(redis.delete, legacy_key, per_org_key)
-        redis.delete(legacy_key, per_org_key)
+class PerOrgTaskTestCase(TestCase):
+    """Base for tests that run the per-org calculations end to end.
 
-        assert legacy_key != per_org_key
+    Only the boundaries are stubbed: the billing API and the Snuba queries. Balancing and the
+    redis caches all run for real, so tests assert on what a run produced instead of which
+    helper it happened to call.
 
-        redis.set(legacy_key, 2.5)
-        assert legacy_recalibration_cache.get_adjusted_factor(org.id) == 2.5
-        assert per_org_recalibration_cache.get_adjusted_factor(org.id) == 1.0
+    The default scenario is an AM2 organization at a 50% sample rate with two projects. The
+    busy one keeps its balanced rate; the quiet one is pushed to 100% by the balancing
+    model, which exercises the paths that skip projects already sampled in full.
+    """
 
-        redis.delete(legacy_key)
-        redis.set(per_org_key, 3.5)
-        assert per_org_recalibration_cache.get_adjusted_factor(org.id) == 3.5
-        assert legacy_recalibration_cache.get_adjusted_factor(org.id) == 1.0
+    def setUp(self) -> None:
+        super().setUp()
+        self.org = self.create_organization()
+        self.busy_project = self.create_project(organization=self.org)
+        self.quiet_project = self.create_project(organization=self.org)
+        self.queries: Mapping[str, MagicMock] = {}
 
-    def test_per_org_cache_sets_and_deletes_adjusted_factor(self) -> None:
-        org = self.create_organization()
-        redis = get_redis_client_for_ds()
-        cache_key = per_org_recalibration_cache.generate_recalibrate_orgs_cache_key(org.id)
-        self.addCleanup(redis.delete, cache_key)
-        redis.delete(cache_key)
+        self.org_volume = OrganizationDataVolume(org_id=self.org.id, total=1200, indexed=300)
+        self.project_volumes = [
+            ProjectVolume(
+                project_id=self.busy_project.id,
+                total=1000,
+                keep=250,
+                drop=750,
+                num_distinct_transactions=4,
+            ),
+            ProjectVolume(
+                project_id=self.quiet_project.id,
+                total=200,
+                keep=50,
+                drop=150,
+                num_distinct_transactions=2,
+            ),
+        ]
+        self.transaction_volumes = [
+            ProjectTransactionCounts(
+                org_id=self.org.id,
+                project_id=self.busy_project.id,
+                transaction_counts=[("/checkout", 600.0), ("/cart", 200.0)],
+            ),
+            ProjectTransactionCounts(
+                org_id=self.org.id,
+                project_id=self.quiet_project.id,
+                transaction_counts=[("/api", 200.0)],
+            ),
+        ]
+        # An effective sample rate of 300/1200 against a 50% target doubles the factor.
+        self.sampled_volume = OrganizationDataVolume(org_id=self.org.id, total=1200, indexed=300)
 
-        per_org_recalibration_cache.set_guarded_adjusted_factor(org.id, 2.5)
-        assert per_org_recalibration_cache.get_adjusted_factor(org.id) == 2.5
+        self.redis = get_redis_client_for_ds()
+        cache_keys = [
+            per_org_recalibration_cache.generate_recalibrate_orgs_cache_key(self.org.id),
+            legacy_recalibration_cache.generate_recalibrate_orgs_cache_key(self.org.id),
+            generate_boost_low_volume_projects_cache_key(org_id=self.org.id),
+            generate_sliding_window_org_cache_key(self.org.id),
+            *(
+                generate_boost_low_volume_transactions_cache_key(
+                    org_id=self.org.id, proj_id=project.id
+                )
+                for project in (self.busy_project, self.quiet_project)
+            ),
+        ]
+        self.redis.delete(*cache_keys)
+        self.addCleanup(self.redis.delete, *cache_keys)
 
-        per_org_recalibration_cache.set_guarded_adjusted_factor(org.id, 1.0)
-        assert per_org_recalibration_cache.get_adjusted_factor(org.id) == 1.0
+    @contextmanager
+    def patched(
+        self,
+        boundaries: Mapping[str, Any] | None = None,
+        *,
+        options: Mapping[str, Any] | None = None,
+    ) -> Iterator[None]:
+        """Stub the boundaries of a run and expose their mocks as ``self.queries``."""
+        stubs: dict[str, Any] = {
+            BLENDED_SAMPLE_RATE: 0.5,
+            # No 24h outcomes volume, so the sliding window leaves the blended rate in place.
+            OUTCOMES_VOLUME: None,
+            SAMPLED_VOLUME: self.sampled_volume,
+            ORG_VOLUME: self.org_volume,
+            PROJECT_VOLUMES: self.project_volumes,
+            TRANSACTION_VOLUMES: self.transaction_volumes,
+            **(boundaries or {}),
+        }
+        with (
+            override_options(
+                {
+                    ROLLOUT_RATE_OPTION: 1.0,
+                    RECALIBRATION_ROLLOUT_RATE_OPTION: 1.0,
+                    **(options or {}),
+                }
+            ),
+            patch_configuration(stubs) as queries,
+        ):
+            self.queries = queries
+            yield
+
+    def run_calculations(
+        self,
+        boundaries: Mapping[str, Any] | None = None,
+        *,
+        options: Mapping[str, Any] | None = None,
+        org_id: int | None = None,
+    ) -> PerOrgCalculations:
+        with self.patched(boundaries, options=options):
+            return run_per_org_calculations(self.org.id if org_id is None else org_id)
+
+    def seed_legacy_project_sample_rates(self, sample_rates: Mapping[int, float]) -> None:
+        cache_key = generate_boost_low_volume_projects_cache_key(org_id=self.org.id)
+        for project_id, rate in sample_rates.items():
+            self.redis.hset(cache_key, str(project_id), str(rate))
+
+    def seed_legacy_organization_sample_rate(self, sample_rate: float) -> None:
+        self.redis.set(generate_sliding_window_org_cache_key(self.org.id), sample_rate)
+
+    def seed_legacy_transaction_sample_rates(
+        self, project_id: int, named_rates: Mapping[str, float], implicit_rate: float
+    ) -> None:
+        self.redis.set(
+            generate_boost_low_volume_transactions_cache_key(
+                org_id=self.org.id, proj_id=project_id
+            ),
+            orjson.dumps([named_rates, implicit_rate]).decode(),
+        )
+
+    def seed_legacy_recalibration_factor(self, factor: float) -> None:
+        self.redis.set(
+            legacy_recalibration_cache.generate_recalibrate_orgs_cache_key(self.org.id), factor
+        )
 
 
 class SchedulePerOrgCalculationsTest(TestCase):
-    """Tests for the scheduling wrapper: rollout gating and active-org filtering."""
+    """The dispatch task: which organizations reach the per-org task."""
 
-    @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
-    def test_dispatches_only_active_orgs(self) -> None:
-        active = self.create_organization()
-        self.create_project(organization=active)
-        pending_deletion = self.create_organization()
-        self.create_project(organization=pending_deletion)
-        pending_deletion.status = 1  # PENDING_DELETION
-        pending_deletion.save()
-
-        with patch("sentry.dynamic_sampling.per_org.scheduler.CursoredScheduler") as MockScheduler:
-            mock_instance = MockScheduler.return_value
-            mock_instance.tick.return_value = False
+    def dispatched_org_ids(self) -> set[int]:
+        with patch(f"{SCHEDULER}.CursoredScheduler") as scheduler:
+            scheduler.return_value.tick.return_value = False
             schedule_per_org_calculations()
 
-            queryset = MockScheduler.call_args.kwargs["queryset"]
-            org_ids = set(queryset.values_list("id", flat=True))
+            queryset = scheduler.call_args.kwargs["queryset"]
+            return set(queryset.values_list("id", flat=True))
+
+    @override_options({ROLLOUT_RATE_OPTION: 1.0})
+    def test_skips_organizations_that_are_not_active(self) -> None:
+        active = self.create_organization()
+        self.create_project(organization=active)
+        pending_deletion = self.create_organization(status=ObjectStatus.PENDING_DELETION)
+        self.create_project(organization=pending_deletion)
+
+        org_ids = self.dispatched_org_ids()
 
         assert active.id in org_ids
         assert pending_deletion.id not in org_ids
 
-    @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
-    def test_dispatches_only_orgs_with_active_projects(self) -> None:
-        org_with_project = self.create_organization()
-        self.create_project(organization=org_with_project)
-        org_without_projects = self.create_organization()
-        org_with_inactive_project = self.create_organization()
-        inactive_project = self.create_project(organization=org_with_inactive_project)
-        inactive_project.status = ObjectStatus.PENDING_DELETION
-        inactive_project.save()
+    @override_options({ROLLOUT_RATE_OPTION: 1.0})
+    def test_skips_organizations_without_an_active_project(self) -> None:
+        with_project = self.create_organization()
+        self.create_project(organization=with_project)
+        without_projects = self.create_organization()
+        with_inactive_project = self.create_organization()
+        inactive_project = self.create_project(organization=with_inactive_project)
+        inactive_project.update(status=ObjectStatus.PENDING_DELETION)
 
-        with patch("sentry.dynamic_sampling.per_org.scheduler.CursoredScheduler") as MockScheduler:
-            mock_instance = MockScheduler.return_value
-            mock_instance.tick.return_value = False
+        org_ids = self.dispatched_org_ids()
+
+        assert with_project.id in org_ids
+        assert without_projects.id not in org_ids
+        assert with_inactive_project.id not in org_ids
+
+    def test_dispatches_only_organizations_inside_the_rollout(self) -> None:
+        org = self.create_organization()
+        self.create_project(organization=org)
+
+        with (
+            override_options({ROLLOUT_RATE_OPTION: 1.0}),
+            patch(f"{SCHEDULER}.CursoredScheduler") as scheduler,
+        ):
+            scheduler.return_value.tick.return_value = False
             schedule_per_org_calculations()
+            validate_item = scheduler.call_args.kwargs["validate_item"]
 
-            queryset = MockScheduler.call_args.kwargs["queryset"]
-            org_ids = set(queryset.values_list("id", flat=True))
+            assert validate_item(org.id) is True
 
-        assert org_with_project.id in org_ids
-        assert org_without_projects.id not in org_ids
-        assert org_with_inactive_project.id not in org_ids
-
-    @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
-    def test_org_in_rollout_is_dispatched(self) -> None:
-        org = self.create_organization()
-        assert is_org_in_rollout(org.id) is True
-
-    @override_options({"dynamic-sampling.per_org.rollout-rate": 0.0})
-    def test_org_not_in_rollout_is_skipped(self) -> None:
-        org = self.create_organization()
-        assert is_org_in_rollout(org.id) is False
+        with override_options({ROLLOUT_RATE_OPTION: 0.0}):
+            assert validate_item(org.id) is False
 
 
-class RunCalculationsPerOrgTest(TestCase):
-    @override_options(
-        {
-            "dynamic-sampling.per_org.rollout-rate": 1.0,
-            "dynamic-sampling.per_org.recalibration-rollout-rate": 1.0,
+class PerOrgTaskTest(PerOrgTaskTestCase):
+    """The task around the calculations: it reports a run, then returns its status."""
+
+    def test_reports_the_calculations_and_returns_no_status_for_a_full_run(self) -> None:
+        with self.patched(), patch(LOG_COMPARISON) as log_comparison:
+            status = run_calculations_per_org_task(self.org.id)
+
+        assert status is None
+        reported = log_comparison.call_args.args[0]
+        assert reported.status is None
+        assert reported.project_sample_rates == {
+            self.busy_project.id: 0.4,
+            self.quiet_project.id: 1.0,
         }
-    )
-    def test_run_calculations_per_org_returns_no_volume_without_traffic(self) -> None:
-        org = self.create_organization()
-        self.create_project(organization=org)
 
-        with patch_configuration(
-            {
-                BLENDED_SAMPLE_RATE: 1.0,
-                ORG_VOLUME: None,
-                PROJECT_VOLUMES: DEFAULT,
-                SAMPLED_VOLUME: DEFAULT,
-                SET_FACTOR: DEFAULT,
-            }
-        ) as mocks:
-            result = run_calculations_per_org_task(org.id)
+    def test_returns_the_status_the_calculations_stopped_at(self) -> None:
+        with self.patched({ORG_VOLUME: None}), patch(LOG_COMPARISON) as log_comparison:
+            status = run_calculations_per_org_task(self.org.id)
 
-        assert result == DynamicSamplingStatus.NO_ORG_VOLUME
-        _assert_called_once_with_config(mocks[ORG_VOLUME], org.id)
-        mocks[BLENDED_SAMPLE_RATE].assert_called_once_with(organization_id=org.id)
-        mocks[PROJECT_VOLUMES].assert_not_called()
-        mocks[SAMPLED_VOLUME].assert_not_called()
-        mocks[SET_FACTOR].assert_not_called()
+        assert status == DynamicSamplingStatus.NO_ORG_VOLUME
+        assert log_comparison.call_args.args[0].status == status
 
-    @override_options(
-        {
-            "dynamic-sampling.per_org.rollout-rate": 1.0,
-            "dynamic-sampling.per_org.recalibration-rollout-rate": 1.0,
+
+class PerOrgTaskGateTest(PerOrgTaskTestCase):
+    """Every status a run can stop at, and how far it got first."""
+
+    def test_unknown_organization(self) -> None:
+        calculations = self.run_calculations(org_id=99999999)
+
+        assert calculations.status == DynamicSamplingStatus.ORG_HAS_NO_DYNAMIC_SAMPLING
+        self.queries[ORG_VOLUME].assert_not_called()
+
+    def test_organization_without_a_blended_sample_rate(self) -> None:
+        calculations = self.run_calculations({BLENDED_SAMPLE_RATE: None})
+
+        assert calculations.status == DynamicSamplingStatus.ORG_HAS_NO_DYNAMIC_SAMPLING
+        self.queries[ORG_VOLUME].assert_not_called()
+
+    def test_organization_without_a_subscription(self) -> None:
+        # Raised rather than returned: the task decorator turns it into a status metric.
+        with pytest.raises(DynamicSamplingException) as exc_info:
+            self.run_calculations({BLENDED_SAMPLE_RATE: ObjectDoesNotExist})
+
+        assert exc_info.value.status == DynamicSamplingStatus.NO_SUBSCRIPTION
+        self.queries[ORG_VOLUME].assert_not_called()
+
+    def test_organization_without_projects(self) -> None:
+        calculations = self.run_calculations(org_id=self.create_organization().id)
+
+        assert calculations.status == DynamicSamplingStatus.ORG_HAS_NO_PROJECTS
+        self.queries[ORG_VOLUME].assert_not_called()
+
+    def test_project_mode_organization_without_target_sample_rates(self) -> None:
+        self.org.update_option("sentry:sampling_mode", DynamicSamplingMode.PROJECT)
+
+        with self.feature("organizations:dynamic-sampling-custom"):
+            calculations = self.run_calculations()
+
+        assert calculations.status == DynamicSamplingStatus.ORG_HAS_NO_DYNAMIC_SAMPLING
+        self.queries[BLENDED_SAMPLE_RATE].assert_not_called()
+        self.queries[ORG_VOLUME].assert_not_called()
+
+    def test_organization_without_volume(self) -> None:
+        calculations = self.run_calculations({ORG_VOLUME: None})
+
+        assert calculations.status == DynamicSamplingStatus.NO_ORG_VOLUME
+        self.queries[PROJECT_VOLUMES].assert_not_called()
+
+    def test_organization_without_project_volumes(self) -> None:
+        calculations = self.run_calculations({PROJECT_VOLUMES: []})
+
+        assert calculations.status == DynamicSamplingStatus.NO_PROJECT_VOLUMES
+        assert calculations.project_volumes == []
+        assert calculations.project_sample_rates == {}
+        self.queries[TRANSACTION_VOLUMES].assert_not_called()
+
+    def test_every_project_already_at_the_full_sample_rate(self) -> None:
+        calculations = self.run_calculations({BLENDED_SAMPLE_RATE: 1.0})
+
+        assert calculations.status == DynamicSamplingStatus.ALL_PROJECTS_AT_FULL_SAMPLE_RATE
+        assert calculations.project_sample_rates == {
+            self.busy_project.id: 1.0,
+            self.quiet_project.id: 1.0,
         }
-    )
-    def test_run_calculations_per_org_skips_transaction_volumes_at_full_sample_rate(self) -> None:
-        org = self.create_organization()
-        project = self.create_project(organization=org)
-        org_volume = OrganizationDataVolume(org_id=org.id, total=100, indexed=25)
-        project_volumes = [make_project_volume(project.id)]
-        rebalanced_projects = [RebalancedItem(id=project.id, count=100, new_sample_rate=1.0)]
-        cached_sample_rates: dict[int, float | None] = {}
+        self.queries[TRANSACTION_VOLUMES].assert_not_called()
+        assert per_org_recalibration_cache.get_adjusted_factor(self.org.id) == 1.0
 
-        with patch_configuration(
-            {
-                BLENDED_SAMPLE_RATE: 1.0,
-                ORG_VOLUME: org_volume,
-                PROJECT_VOLUMES: project_volumes,
-                PROJECT_BALANCING: rebalanced_projects,
-                CACHED_PROJECT_RATES: cached_sample_rates,
-                COMPARE_PROJECTS: DEFAULT,
-                TRANSACTION_VOLUMES: DEFAULT,
-                TRANSACTION_BALANCING: DEFAULT,
-                SAMPLED_VOLUME: DEFAULT,
-                SET_FACTOR: DEFAULT,
-            }
-        ) as mocks:
-            result = run_calculations_per_org_task(org.id)
+    def test_organization_without_transaction_volumes(self) -> None:
+        calculations = self.run_calculations({TRANSACTION_VOLUMES: []})
 
-        assert result == DynamicSamplingStatus.ALL_PROJECTS_AT_FULL_SAMPLE_RATE
-        _assert_called_once_with_config(mocks[ORG_VOLUME], org.id)
-        mocks[BLENDED_SAMPLE_RATE].assert_called_once_with(organization_id=org.id)
-        project_config = _assert_called_once_with_config(mocks[PROJECT_VOLUMES], org.id)
-        mocks[PROJECT_BALANCING].assert_called_once_with(project_config, project_volumes)
-        mocks[CACHED_PROJECT_RATES].assert_called_once_with(org.id)
-        mocks[COMPARE_PROJECTS].assert_called_once_with(
-            project_config, rebalanced_projects, cached_sample_rates, project_volumes
+        assert calculations.status == DynamicSamplingStatus.NO_TRANSACTION_VOLUMES
+        # Project balancing already ran and left its rates on the configuration.
+        assert calculations.project_sample_rates == {
+            self.busy_project.id: 0.4,
+            self.quiet_project.id: 1.0,
+        }
+        assert calculations.rebalanced_transactions == {}
+        # Recalibration is the last step, so the run stops before writing a factor.
+        assert calculations.recalibration_ran is False
+        assert per_org_recalibration_cache.get_adjusted_factor(self.org.id) == 1.0
+
+
+class PerOrgTaskPipelineTest(PerOrgTaskTestCase):
+    """Runs that reach the end of the pipeline, and what each step computed."""
+
+    def test_full_run_balances_projects_and_transactions_then_recalibrates(self) -> None:
+        calculations = self.run_calculations()
+
+        assert calculations.status is None
+        assert calculations.project_sample_rates == {
+            self.busy_project.id: 0.4,
+            self.quiet_project.id: 1.0,
+        }
+        # The quiet project sits at 100%, so it is balanced away and never reaches the
+        # transaction model.
+        assert set(calculations.rebalanced_transactions) == {self.busy_project.id}
+        assert transaction_sample_rates(calculations, self.busy_project.id) == (
+            {"/cart": 0.45, "/checkout": CHECKOUT_SAMPLE_RATE},
+            0.96,
         )
-        mocks[TRANSACTION_VOLUMES].assert_not_called()
-        mocks[TRANSACTION_BALANCING].assert_not_called()
-        # Recalibration is the last step, so a full-sample-rate org returns before it runs.
-        mocks[SAMPLED_VOLUME].assert_not_called()
-        mocks[SET_FACTOR].assert_not_called()
+        assert calculations.recalibration_ran is True
+        assert calculations.recalibration_factor == 2.0
+        assert per_org_recalibration_cache.get_adjusted_factor(self.org.id) == 2.0
 
-    @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
-    def test_run_calculations_per_org_returns_no_volume_without_project_volumes(self) -> None:
-        org = self.create_organization()
-        self.create_project(organization=org)
-        org_volume = OrganizationDataVolume(org_id=org.id, total=100, indexed=25)
-
-        with patch_configuration(
-            {
-                BLENDED_SAMPLE_RATE: 1.0,
-                ORG_VOLUME: org_volume,
-                PROJECT_VOLUMES: [],
-                TRANSACTION_VOLUMES: DEFAULT,
-                PROJECT_BALANCING: None,
-            }
-        ) as mocks:
-            result = run_calculations_per_org_task(org.id)
-
-        assert result == DynamicSamplingStatus.NO_PROJECT_VOLUMES
-        mocks[BLENDED_SAMPLE_RATE].assert_called_once_with(organization_id=org.id)
-        _assert_called_once_with_config(mocks[ORG_VOLUME], org.id)
-        _assert_called_once_with_config(mocks[PROJECT_VOLUMES], org.id)
-        mocks[PROJECT_BALANCING].assert_not_called()
-        mocks[TRANSACTION_VOLUMES].assert_not_called()
-
-    @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
-    def test_run_calculations_per_org_returns_no_volume_without_transaction_volumes(self) -> None:
-        org = self.create_organization()
-        project = self.create_project(organization=org)
-        org_volume = OrganizationDataVolume(org_id=org.id, total=100, indexed=25)
-        project_volumes = [make_project_volume(project.id)]
-        rebalanced_projects = [RebalancedItem(id=project.id, count=100, new_sample_rate=0.5)]
-        cached_sample_rates: dict[int, float | None] = {}
-
-        with patch_configuration(
-            {
-                BLENDED_SAMPLE_RATE: 1.0,
-                ORG_VOLUME: org_volume,
-                PROJECT_VOLUMES: project_volumes,
-                PROJECT_BALANCING: rebalanced_projects,
-                CACHED_PROJECT_RATES: cached_sample_rates,
-                COMPARE_PROJECTS: DEFAULT,
-                TRANSACTION_VOLUMES: [],
-            }
-        ) as mocks:
-            result = run_calculations_per_org_task(org.id)
-
-        assert result == DynamicSamplingStatus.NO_TRANSACTION_VOLUMES
-        mocks[BLENDED_SAMPLE_RATE].assert_called_once_with(organization_id=org.id)
-        _assert_called_once_with_config(mocks[ORG_VOLUME], org.id)
-        project_config = _assert_called_once_with_config(mocks[PROJECT_VOLUMES], org.id)
-        mocks[PROJECT_BALANCING].assert_called_once_with(project_config, project_volumes)
-        mocks[CACHED_PROJECT_RATES].assert_called_once_with(org.id)
-        mocks[COMPARE_PROJECTS].assert_called_once_with(
-            project_config, rebalanced_projects, cached_sample_rates, project_volumes
+    def test_full_run_reads_what_the_legacy_pipeline_computed(self) -> None:
+        self.seed_legacy_project_sample_rates(
+            {self.busy_project.id: 0.41, self.quiet_project.id: 0.5}
         )
-        _assert_called_once_with_config(mocks[TRANSACTION_VOLUMES], org.id)
+        self.seed_legacy_transaction_sample_rates(
+            self.busy_project.id, {"/checkout": 0.19, "/cart": 0.44}, 0.95
+        )
+        self.seed_legacy_recalibration_factor(1.95)
 
-    @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
-    def test_run_calculations_per_org_skips_project_balancing_for_project_mode(self) -> None:
-        org = self.create_organization()
-        project = self.create_project(organization=org)
-        org.update_option("sentry:sampling_mode", DynamicSamplingMode.PROJECT)
-        project.update_option("sentry:target_sample_rate", 0.2)
-        org_volume = OrganizationDataVolume(org_id=org.id, total=100, indexed=25)
-        project_volumes = [make_project_volume(project.id)]
-        transaction_volumes = [
-            ProjectTransactionCounts(
-                org_id=org.id,
-                project_id=project.id,
-                transaction_counts=[("checkout", 1.0)],
-            )
-        ]
+        calculations = self.run_calculations()
 
-        with (
-            self.feature("organizations:dynamic-sampling-custom"),
-            patch_configuration(
-                {
-                    BLENDED_SAMPLE_RATE: DEFAULT,
-                    ORG_VOLUME: org_volume,
-                    PROJECT_VOLUMES: project_volumes,
-                    PROJECT_BALANCING: DEFAULT,
-                    TRANSACTION_VOLUMES: transaction_volumes,
-                    TRANSACTION_BALANCING: {},
+        assert calculations.cached_project_sample_rates == {
+            self.busy_project.id: 0.41,
+            self.quiet_project.id: 0.5,
+        }
+        # Only the projects that reached the transaction model are read back.
+        assert calculations.cached_transaction_sample_rates == {
+            self.busy_project.id: ({"/checkout": 0.19, "/cart": 0.44}, 0.95),
+        }
+        assert calculations.cached_recalibration_factor == 1.95
+        # The organization rate is only needed by the summary log.
+        assert calculations.cached_organization_sample_rate is None
+
+    def test_org_mode_custom_sampling_balances_against_the_target_sample_rate(self) -> None:
+        self.org.update_option("sentry:sampling_mode", DynamicSamplingMode.ORGANIZATION)
+        self.org.update_option("sentry:target_sample_rate", 0.5)
+
+        with self.feature("organizations:dynamic-sampling-custom"):
+            calculations = self.run_calculations()
+
+        assert calculations.status is None
+        # The target rate replaces the blended one, and the rest of the run matches the
+        # subscription-backed org at the same rate.
+        self.queries[BLENDED_SAMPLE_RATE].assert_not_called()
+        assert calculations.project_sample_rates == {
+            self.busy_project.id: 0.4,
+            self.quiet_project.id: 1.0,
+        }
+        assert calculations.recalibration_factor == 2.0
+        assert per_org_recalibration_cache.get_adjusted_factor(self.org.id) == 2.0
+
+    def test_project_mode_custom_sampling_uses_the_project_target_sample_rates(self) -> None:
+        self.org.update_option("sentry:sampling_mode", DynamicSamplingMode.PROJECT)
+        self.busy_project.update_option("sentry:target_sample_rate", 0.4)
+        self.quiet_project.update_option("sentry:target_sample_rate", 1.0)
+
+        with self.feature("organizations:dynamic-sampling-custom"):
+            calculations = self.run_calculations()
+
+        assert calculations.status is None
+        assert calculations.project_sample_rates == {
+            self.busy_project.id: 0.4,
+            self.quiet_project.id: 1.0,
+        }
+        # Project mode is never rebalanced, so nothing is balanced and nothing is read from
+        # the balanced cache.
+        assert calculations.rebalanced_projects == []
+        assert calculations.cached_project_sample_rates == {}
+        # The per-project target rates drive transaction balancing instead, giving the same
+        # rates the balanced 0.4 produced.
+        assert transaction_sample_rates(calculations, self.busy_project.id) == (
+            {"/cart": 0.45, "/checkout": CHECKOUT_SAMPLE_RATE},
+            0.96,
+        )
+        # Recalibration needs an org-wide sample rate, which project mode does not have.
+        assert calculations.recalibration_factor is None
+        assert per_org_recalibration_cache.get_adjusted_factor(self.org.id) == 1.0
+
+    def test_project_sample_rate_override_replaces_the_balanced_rate(self) -> None:
+        calculations = self.run_calculations(
+            options={
+                "dynamic-sampling.sample-rate-override-per-project": {
+                    str(self.busy_project.id): 0.2
                 }
-            ) as mocks,
-        ):
-            result = run_calculations_per_org_task(org.id)
-
-        assert result is None
-        mocks[BLENDED_SAMPLE_RATE].assert_not_called()
-        _assert_called_once_with_config(mocks[ORG_VOLUME], org.id)
-        _assert_called_once_with_config(mocks[PROJECT_VOLUMES], org.id)
-        mocks[PROJECT_BALANCING].assert_not_called()
-        transaction_config = _assert_called_once_with_config(mocks[TRANSACTION_VOLUMES], org.id)
-        mocks[TRANSACTION_BALANCING].assert_called_once_with(
-            transaction_config, project_volumes, transaction_volumes
-        )
-
-    @override_options(
-        {
-            "dynamic-sampling.per_org.rollout-rate": 1.0,
-            "dynamic-sampling.per_org.recalibration-rollout-rate": 1.0,
-        }
-    )
-    def test_run_calculations_per_org_queries_projects_for_am3_org_mode(self) -> None:
-        org = self.create_organization()
-        project = self.create_project(organization=org)
-        org.update_option("sentry:sampling_mode", DynamicSamplingMode.ORGANIZATION)
-        org_volume = OrganizationDataVolume(org_id=org.id, total=100, indexed=25)
-        project_volumes = [make_project_volume(project.id)]
-        rebalanced_projects = [RebalancedItem(id=project.id, count=100, new_sample_rate=0.5)]
-        cached_sample_rates: dict[int, float | None] = {}
-        transaction_volumes = [
-            ProjectTransactionCounts(
-                org_id=org.id,
-                project_id=project.id,
-                transaction_counts=[("checkout", 1.0)],
-            )
-        ]
-
-        with (
-            self.feature("organizations:dynamic-sampling-custom"),
-            patch_configuration(
-                {
-                    BLENDED_SAMPLE_RATE: DEFAULT,
-                    ORG_VOLUME: org_volume,
-                    PROJECT_VOLUMES: project_volumes,
-                    PROJECT_BALANCING: rebalanced_projects,
-                    CACHED_PROJECT_RATES: cached_sample_rates,
-                    COMPARE_PROJECTS: DEFAULT,
-                    TRANSACTION_VOLUMES: transaction_volumes,
-                    TRANSACTION_BALANCING: {},
-                    SAMPLED_VOLUME: org_volume,
-                    LEGACY_GET_FACTOR: 1.0,
-                    SET_FACTOR: DEFAULT,
-                }
-            ) as mocks,
-        ):
-            result = run_calculations_per_org_task(org.id)
-
-        assert result is None
-        mocks[BLENDED_SAMPLE_RATE].assert_not_called()
-        _assert_called_once_with_config(mocks[ORG_VOLUME], org.id)
-        project_config = _assert_called_once_with_config(mocks[PROJECT_VOLUMES], org.id)
-        mocks[PROJECT_BALANCING].assert_called_once_with(project_config, project_volumes)
-        mocks[CACHED_PROJECT_RATES].assert_called_once_with(org.id)
-        mocks[COMPARE_PROJECTS].assert_called_once_with(
-            project_config, rebalanced_projects, cached_sample_rates, project_volumes
-        )
-        transaction_config = _assert_called_once_with_config(mocks[TRANSACTION_VOLUMES], org.id)
-        mocks[TRANSACTION_BALANCING].assert_called_once_with(
-            transaction_config, project_volumes, transaction_volumes
-        )
-        mocks[SET_FACTOR].assert_called_once_with(org.id, 4.0)
-
-    @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
-    def test_run_calculations_per_org_skips_project_mode_without_project_rates(self) -> None:
-        org = self.create_organization()
-        self.create_project(organization=org)
-        org.update_option("sentry:sampling_mode", DynamicSamplingMode.PROJECT)
-
-        with (
-            self.feature("organizations:dynamic-sampling-custom"),
-            patch_configuration(
-                {
-                    BLENDED_SAMPLE_RATE: DEFAULT,
-                    ORG_VOLUME: DEFAULT,
-                    PROJECT_VOLUMES: DEFAULT,
-                }
-            ) as mocks,
-        ):
-            result = run_calculations_per_org_task(org.id)
-
-        assert result == DynamicSamplingStatus.ORG_HAS_NO_DYNAMIC_SAMPLING
-        mocks[BLENDED_SAMPLE_RATE].assert_not_called()
-        mocks[ORG_VOLUME].assert_not_called()
-        mocks[PROJECT_VOLUMES].assert_not_called()
-
-    @override_options(
-        {
-            "dynamic-sampling.per_org.rollout-rate": 1.0,
-            "dynamic-sampling.per_org.recalibration-rollout-rate": 1.0,
-        }
-    )
-    def test_run_calculations_per_org_queries_projects_for_am2(self) -> None:
-        org = self.create_organization()
-        project = self.create_project(organization=org)
-        org_volume = OrganizationDataVolume(org_id=org.id, total=100, indexed=25)
-        project_volumes = [make_project_volume(project.id)]
-        rebalanced_projects = [RebalancedItem(id=project.id, count=100, new_sample_rate=0.5)]
-        cached_sample_rates: dict[int, float | None] = {}
-        transaction_volumes = [
-            ProjectTransactionCounts(
-                org_id=org.id,
-                project_id=project.id,
-                transaction_counts=[("checkout", 1.0)],
-            )
-        ]
-
-        with patch_configuration(
-            {
-                BLENDED_SAMPLE_RATE: 1.0,
-                ORG_VOLUME: org_volume,
-                PROJECT_VOLUMES: project_volumes,
-                PROJECT_BALANCING: rebalanced_projects,
-                CACHED_PROJECT_RATES: cached_sample_rates,
-                COMPARE_PROJECTS: DEFAULT,
-                TRANSACTION_VOLUMES: transaction_volumes,
-                TRANSACTION_BALANCING: {},
-                SAMPLED_VOLUME: org_volume,
-                LEGACY_GET_FACTOR: 1.0,
-                SET_FACTOR: DEFAULT,
-                COMPARE_FACTOR: DEFAULT,
             }
-        ) as mocks:
-            result = run_calculations_per_org_task(org.id)
-
-        assert result is None
-        mocks[BLENDED_SAMPLE_RATE].assert_called_once_with(organization_id=org.id)
-        _assert_called_once_with_config(mocks[ORG_VOLUME], org.id)
-        project_config = _assert_called_once_with_config(mocks[PROJECT_VOLUMES], org.id)
-        mocks[PROJECT_BALANCING].assert_called_once_with(project_config, project_volumes)
-        mocks[CACHED_PROJECT_RATES].assert_called_once_with(org.id)
-        mocks[COMPARE_PROJECTS].assert_called_once_with(
-            project_config, rebalanced_projects, cached_sample_rates, project_volumes
         )
-        transaction_config = _assert_called_once_with_config(mocks[TRANSACTION_VOLUMES], org.id)
-        # Every root project is queried, not only the ones being rebalanced. Narrowing
-        # to `projects_to_balance` drops every segment rooted at a project sampled at
-        # 100%, so those root projects report no transaction volume at all.
-        assert "root_projects" not in mocks[TRANSACTION_VOLUMES].call_args.kwargs
-        mocks[TRANSACTION_BALANCING].assert_called_once_with(
-            transaction_config, project_volumes, transaction_volumes
+
+        assert calculations.status is None
+        assert calculations.project_sample_rates == {
+            self.busy_project.id: 0.2,
+            self.quiet_project.id: 1.0,
+        }
+        # The override lands before the rates reach the configuration, so transaction
+        # balancing runs against 0.2 rather than the balanced 0.4.
+        named_rates, _ = transaction_sample_rates(calculations, self.busy_project.id)
+        assert named_rates == {
+            "/cart": 0.225,
+            "/checkout": pytest.approx(0.09166666666666666),
+        }
+
+    def test_transaction_volumes_are_queried_for_every_root_project(self) -> None:
+        calculations = self.run_calculations()
+
+        # Narrowing the query to the projects being balanced would drop every segment rooted
+        # at a project sampled at 100%, leaving those root projects with no volume at all.
+        self.queries[TRANSACTION_VOLUMES].assert_called_once_with(calculations.config)
+
+    def test_recalibration_outside_its_own_rollout(self) -> None:
+        calculations = self.run_calculations(options={RECALIBRATION_ROLLOUT_RATE_OPTION: 0.0})
+
+        assert calculations.status is None
+        assert calculations.recalibration_ran is False
+        assert calculations.recalibration_factor is None
+        assert calculations.cached_recalibration_factor is None
+        self.queries[SAMPLED_VOLUME].assert_not_called()
+        assert per_org_recalibration_cache.get_adjusted_factor(self.org.id) == 1.0
+
+    def test_recalibration_without_a_five_minute_volume(self) -> None:
+        self.seed_legacy_recalibration_factor(1.95)
+
+        calculations = self.run_calculations({SAMPLED_VOLUME: None})
+
+        assert calculations.status is None
+        assert calculations.recalibration_factor is None
+        assert per_org_recalibration_cache.get_adjusted_factor(self.org.id) == 1.0
+        # The legacy factor is still read, so that a skipped factor can be reported next to it.
+        assert calculations.recalibration_ran is True
+        assert calculations.cached_recalibration_factor == 1.95
+
+    def test_summary_log_rollout_reads_the_legacy_rates_of_every_project(self) -> None:
+        self.seed_legacy_organization_sample_rate(0.45)
+        self.seed_legacy_project_sample_rates(
+            {self.busy_project.id: 0.41, self.quiet_project.id: 0.5}
         )
-        assert project_config.organization_recalibration_factor == 4.0
-        mocks[SET_FACTOR].assert_called_once_with(org.id, 4.0)
-        mocks[COMPARE_FACTOR].assert_called_once_with(project_config, 4.0, 1.0)
+        self.seed_legacy_transaction_sample_rates(self.quiet_project.id, {"/api": 0.6}, 0.62)
 
-    @override_options(
-        {
-            "dynamic-sampling.per_org.rollout-rate": 1.0,
-            "dynamic-sampling.per_org.recalibration-rollout-rate": 1.0,
+        calculations = self.run_calculations(
+            options={SAMPLE_RATES_SUMMARY_LOG_ROLLOUT_RATE_OPTION: 1.0}
+        )
+
+        assert calculations.summary_log_enabled is True
+        assert calculations.cached_organization_sample_rate == 0.45
+        assert calculations.cached_project_sample_rates == {
+            self.busy_project.id: 0.41,
+            self.quiet_project.id: 0.5,
         }
-    )
-    def test_run_calculations_per_org_skips_recalibration_without_valid_5_minute_volume(
-        self,
-    ) -> None:
-        org = self.create_organization()
-        project = self.create_project(organization=org)
-        org_volume = OrganizationDataVolume(org_id=org.id, total=100, indexed=25)
-        project_volumes = [make_project_volume(project.id)]
-        transaction_volumes = [
-            ProjectTransactionCounts(
-                org_id=org.id,
-                project_id=project.id,
-                transaction_counts=[("checkout", 1.0)],
-            )
-        ]
-
-        with patch_configuration(
-            {
-                BLENDED_SAMPLE_RATE: 0.5,
-                ORG_VOLUME: org_volume,
-                PROJECT_VOLUMES: project_volumes,
-                PROJECT_BALANCING: [RebalancedItem(id=project.id, count=100, new_sample_rate=0.5)],
-                CACHED_PROJECT_RATES: {},
-                COMPARE_PROJECTS: DEFAULT,
-                TRANSACTION_VOLUMES: transaction_volumes,
-                TRANSACTION_BALANCING: {},
-                SAMPLED_VOLUME: None,
-                LEGACY_GET_FACTOR: 1.0,
-                SET_FACTOR: DEFAULT,
-                COMPARE_FACTOR: DEFAULT,
-            }
-        ) as mocks:
-            result = run_calculations_per_org_task(org.id)
-
-        assert result is None
-        project_config = _assert_called_once_with_config(mocks[PROJECT_VOLUMES], org.id)
-        assert project_config.organization_recalibration_factor is None
-        mocks[SAMPLED_VOLUME].assert_called_once()
-        mocks[SET_FACTOR].assert_not_called()
-        # The comparison still runs, so the legacy factor is reported next to no EAP factor.
-        mocks[COMPARE_FACTOR].assert_called_once_with(project_config, None, 1.0)
-
-    @override_options(
-        {
-            "dynamic-sampling.per_org.rollout-rate": 1.0,
-            "dynamic-sampling.per_org.recalibration-rollout-rate": 0.0,
+        # The quiet project produced no EAP transaction rates, yet its legacy ones are read:
+        # the cache is read for every project once the summary log is on.
+        assert set(calculations.rebalanced_transactions) == {self.busy_project.id}
+        assert calculations.cached_transaction_sample_rates == {
+            self.busy_project.id: None,
+            self.quiet_project.id: ({"/api": 0.6}, 0.62),
         }
-    )
-    def test_run_calculations_per_org_skips_recalibration_outside_its_rollout(self) -> None:
-        org = self.create_organization()
-        project = self.create_project(organization=org)
-        org_volume = OrganizationDataVolume(org_id=org.id, total=100, indexed=25)
-        project_volumes = [make_project_volume(project.id)]
-        transaction_volumes = [
-            ProjectTransactionCounts(
-                org_id=org.id,
-                project_id=project.id,
-                transaction_counts=[("checkout", 1.0)],
-            )
-        ]
-
-        with patch_configuration(
-            {
-                BLENDED_SAMPLE_RATE: 0.5,
-                ORG_VOLUME: org_volume,
-                PROJECT_VOLUMES: project_volumes,
-                PROJECT_BALANCING: [RebalancedItem(id=project.id, count=100, new_sample_rate=0.5)],
-                CACHED_PROJECT_RATES: {},
-                COMPARE_PROJECTS: DEFAULT,
-                TRANSACTION_VOLUMES: transaction_volumes,
-                TRANSACTION_BALANCING: {},
-                SAMPLED_VOLUME: DEFAULT,
-                CACHED_FACTOR: DEFAULT,
-                COMPARE_FACTOR: DEFAULT,
-            }
-        ) as mocks:
-            result = run_calculations_per_org_task(org.id)
-
-        assert result is None
-        project_config = _assert_called_once_with_config(mocks[PROJECT_VOLUMES], org.id)
-        assert project_config.organization_recalibration_factor is None
-        mocks[SAMPLED_VOLUME].assert_not_called()
-        mocks[CACHED_FACTOR].assert_not_called()
-        mocks[COMPARE_FACTOR].assert_not_called()
-
-    @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
-    def test_run_calculations_per_org_skips_org_without_transaction_sample_rate(self) -> None:
-        org = self.create_organization()
-
-        with patch_configuration({BLENDED_SAMPLE_RATE: None, ORG_VOLUME: DEFAULT}) as mocks:
-            result = run_calculations_per_org_task(org.id)
-
-        assert result == DynamicSamplingStatus.ORG_HAS_NO_DYNAMIC_SAMPLING
-        mocks[BLENDED_SAMPLE_RATE].assert_called_once_with(organization_id=org.id)
-        mocks[ORG_VOLUME].assert_not_called()
-
-    @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
-    def test_run_calculations_per_org_skips_org_without_projects(self) -> None:
-        org = self.create_organization()
-
-        with patch_configuration({BLENDED_SAMPLE_RATE: 1.0, ORG_VOLUME: DEFAULT}) as mocks:
-            result = run_calculations_per_org_task(org.id)
-
-        assert result == DynamicSamplingStatus.ORG_HAS_NO_PROJECTS
-        mocks[ORG_VOLUME].assert_not_called()
-
-    @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
-    def test_run_calculations_per_org_skips_org_without_subscription(self) -> None:
-        org = self.create_organization()
-
-        with (
-            patch(BLENDED_SAMPLE_RATE, side_effect=ObjectDoesNotExist),
-            patch_configuration({ORG_VOLUME: DEFAULT}) as mocks,
-        ):
-            result = run_calculations_per_org_task(org.id)
-
-        assert result == DynamicSamplingStatus.NO_SUBSCRIPTION
-        mocks[ORG_VOLUME].assert_not_called()
-
-    @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
-    def test_run_calculations_per_org_skips_missing_org(self) -> None:
-        with patch_configuration({ORG_VOLUME: DEFAULT}) as mocks:
-            result = run_calculations_per_org_task(99999999)
-
-        assert result == DynamicSamplingStatus.ORG_HAS_NO_DYNAMIC_SAMPLING
-        mocks[ORG_VOLUME].assert_not_called()


### PR DESCRIPTION
- `run_per_org_calculations` returns a `PerOrgCalculations` object that carries everything a run queried and computed: project volumes, balanced project and transaction rates, the recalibration factor, and the legacy rates it compared against
- The task keeps its contract: it runs the calculations, reports them, then returns `calculations.status`
- New `per_org/legacy_comparison.py` owns every log line of the per-org pipeline and the per-project debug metrics; no logger is left anywhere else in `per_org/`
- `log_transaction_volume_debug` became `collect_transaction_volume_debug`, which returns the volumes of both pipelines instead of logging them
- Scheduler tests assert on the returned object; the log assertions moved to `test_legacy_comparison.py`, which builds result objects directly
- No behavior change: same queries, same log messages and extras, same metrics
- The comparison logs go away with the legacy pipeline — that removal is now one module plus the `cached_*` fields
