### PR TITLE
feat(dashboards): register BFCache Metrics prebuilt dashboard

### DIFF
--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -92,6 +92,7 @@ class PrebuiltDashboardId(IntEnum):
     BACKEND_QUEUE_SUMMARY = 27
     BACKEND_CACHES = 28
     NODE_RUNTIME_METRICS = 29
+    BFCACHE_METRICS = 30
 
 
 class PrebuiltDashboard(TypedDict, total=False):
@@ -235,6 +236,10 @@ PREBUILT_DASHBOARDS: list[PrebuiltDashboard] = [
     {
         "prebuilt_id": PrebuiltDashboardId.NODE_RUNTIME_METRICS,
         "title": "Node.js Runtime Metrics",
+    },
+    {
+        "prebuilt_id": PrebuiltDashboardId.BFCACHE_METRICS,
+        "title": "BFCache Metrics",
     },
 ]
 


### PR DESCRIPTION
This registers the BFCache metrics dashboard on the BE. 

BFCache is a browser memory cache that only works for backward/forward navigations, but the browser has certain heuristics for deciding if a page is eligible or not. 

This PR builds on several other PRs around Sentry to expose the cache heuristics to the developer

- https://github.com/getsentry/sentry-conventions/pull/513
- https://github.com/getsentry/sentry-javascript/pull/22397

This PR contains the BE portion of the work needed to add this as a built-in dashboard.

Reference links:

- https://web.dev/articles/bfcache