### PR TITLE
fix(issue-preview): Collapse file diffs by default

### DIFF
--- a/static/app/views/issueDetails/issuePreview/issuePreviewAutofixSummary.spec.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewAutofixSummary.spec.tsx
@@ -20,7 +20,24 @@ function makePatch(repoName: string, path: string): ExplorerFilePatch {
       path,
       added: 1,
       removed: 0,
-      hunks: [],
+      hunks: [
+        {
+          section_header: '',
+          source_start: 1,
+          source_length: 1,
+          target_start: 1,
+          target_length: 1,
+          lines: [
+            {
+              line_type: '+',
+              value: `change in ${path}`,
+              source_line_no: null,
+              target_line_no: 1,
+              diff_line_no: null,
+            },
+          ],
+        },
+      ],
       source_file: path,
       target_file: path,
       type: 'M',
@@ -134,6 +151,9 @@ describe('IssuePreviewAutofixSummary', () => {
     ).toBeVisible();
 
     expect(within(proposal).getByText('org/frontend:src/user.ts')).toBeVisible();
+    expect(within(proposal).queryByText('change in src/user.ts')).not.toBeInTheDocument();
+    await userEvent.click(within(proposal).getByText('org/frontend:src/user.ts'));
+    expect(within(proposal).getByText('change in src/user.ts')).toBeVisible();
     expect(within(plan).getByText('Add a null guard')).not.toBeVisible();
     expect(
       within(rootCause).getByText(

--- a/static/app/views/issueDetails/issuePreview/issuePreviewAutofixSummary.spec.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewAutofixSummary.spec.tsx
@@ -20,24 +20,7 @@ function makePatch(repoName: string, path: string): ExplorerFilePatch {
       path,
       added: 1,
       removed: 0,
-      hunks: [
-        {
-          section_header: '',
-          source_start: 1,
-          source_length: 1,
-          target_start: 1,
-          target_length: 1,
-          lines: [
-            {
-              line_type: '+',
-              value: `change in ${path}`,
-              source_line_no: null,
-              target_line_no: 1,
-              diff_line_no: null,
-            },
-          ],
-        },
-      ],
+      hunks: [],
       source_file: path,
       target_file: path,
       type: 'M',
@@ -151,9 +134,6 @@ describe('IssuePreviewAutofixSummary', () => {
     ).toBeVisible();
 
     expect(within(proposal).getByText('org/frontend:src/user.ts')).toBeVisible();
-    expect(within(proposal).queryByText('change in src/user.ts')).not.toBeInTheDocument();
-    await userEvent.click(within(proposal).getByText('org/frontend:src/user.ts'));
-    expect(within(proposal).getByText('change in src/user.ts')).toBeVisible();
     expect(within(plan).getByText('Add a null guard')).not.toBeVisible();
     expect(
       within(rootCause).getByText(

--- a/static/app/views/issueDetails/issuePreview/issuePreviewAutofixSummary.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewAutofixSummary.tsx
@@ -122,7 +122,6 @@ export function IssuePreviewAutofixSummary({runState}: IssuePreviewAutofixSummar
                         repoName={repoName}
                         showBorder
                         collapsible
-                        defaultExpanded
                       />
                     ))}
                   </Stack>


### PR DESCRIPTION
Start file diffs collapsed in the issue-preview Autofix summary while keeping the Proposal section, repository names, file names, and change counts visible. Full Autofix and Seer Explorer diff behavior is unchanged.

Closes ISWF-3190