### PR TITLE
test(alerts): clear localStorage between anomaly banner tests

### DIFF
--- a/static/app/views/alerts/rules/metric/details/anomalyDetectionFeedbackBanner.spec.tsx
+++ b/static/app/views/alerts/rules/metric/details/anomalyDetectionFeedbackBanner.spec.tsx
@@ -24,7 +24,13 @@ describe('AnomalyDetectionFeedbackBanner', () => {
   const mockIncident2 = IncidentFixture({id: '6702'});
   const analyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
 
-  it.isKnownFlake('submits anomaly detection feedback (yes)', async () => {
+  // The banner records its dismissal in localStorage keyed by incident id, and
+  // jsdom keeps that store for the whole file.
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('submits anomaly detection feedback (yes)', async () => {
     const {container} = render(
       <AnomalyDetectionFeedbackBanner
         id={mockIncident.id}

--- a/static/app/views/alerts/rules/metric/details/anomalyDetectionFeedbackBanner.spec.tsx
+++ b/static/app/views/alerts/rules/metric/details/anomalyDetectionFeedbackBanner.spec.tsx
@@ -24,8 +24,6 @@ describe('AnomalyDetectionFeedbackBanner', () => {
   const mockIncident2 = IncidentFixture({id: '6702'});
   const analyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
 
-  // The banner records its dismissal in localStorage keyed by incident id, and
-  // jsdom keeps that store for the whole file.
   beforeEach(() => {
     localStorage.clear();
   });


### PR DESCRIPTION
`anomalyDetectionFeedbackBanner` → `submits anomaly detection feedback (yes)` fails all but the first of its runs when run repeatedly. The banner records dismissal in `localStorage` keyed by incident id via `useDismissable`, but never clears out the key.

Fixed by clearing `localStorage` in `beforeEach`.

Follow-up to a follow-up on LOGS-936