### PR TITLE
test: clear remaining stale flaky markers

### DIFF
--- a/static/app/components/charts/eventsRequest.spec.tsx
+++ b/static/app/components/charts/eventsRequest.spec.tsx
@@ -42,7 +42,7 @@ describe('EventsRequest', () => {
       );
     });
 
-    it.isKnownFlake('makes requests', async () => {
+    it('makes requests', async () => {
       render(<EventsRequest {...DEFAULTS}>{mock}</EventsRequest>);
       expect(mock).toHaveBeenNthCalledWith(
         1,

--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.spec.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.spec.tsx
@@ -115,56 +115,50 @@ describe('GlobalCommandPaletteActions - project settings ordering', () => {
     await screen.findByRole('textbox', {name: 'Search commands'});
   }
 
-  it.isKnownFlake(
-    'shows a "Current Project" tag on the active project entry',
-    async () => {
-      render(
-        <CommandPaletteProvider>
-          <GlobalCommandPaletteActions />
-          <SlotOutlets />
-          <CommandPalette {...makeRenderProps(jest.fn())} />
-        </CommandPaletteProvider>,
-        {
-          organization,
-          initialRouterConfig: {
-            location: {pathname: `/settings/${organization.slug}/projects/project-b/`},
-            route: '/settings/:orgId/projects/:projectId/',
-          },
-        }
-      );
+  it('shows a "Current Project" tag on the active project entry', async () => {
+    render(
+      <CommandPaletteProvider>
+        <GlobalCommandPaletteActions />
+        <SlotOutlets />
+        <CommandPalette {...makeRenderProps(jest.fn())} />
+      </CommandPaletteProvider>,
+      {
+        organization,
+        initialRouterConfig: {
+          location: {pathname: `/settings/${organization.slug}/projects/project-b/`},
+          route: '/settings/:orgId/projects/:projectId/',
+        },
+      }
+    );
 
-      await drillIntoGeneralSettings();
+    await drillIntoGeneralSettings();
 
-      expect(await screen.findByText('Current')).toBeInTheDocument();
-    }
-  );
+    expect(await screen.findByText('Current')).toBeInTheDocument();
+  });
 
-  it.isKnownFlake(
-    'places the current route project first when on a :projectId route',
-    async () => {
-      render(
-        <CommandPaletteProvider>
-          <GlobalCommandPaletteActions />
-          <SlotOutlets />
-          <CommandPalette {...makeRenderProps(jest.fn())} />
-        </CommandPaletteProvider>,
-        {
-          organization,
-          initialRouterConfig: {
-            location: {pathname: `/settings/${organization.slug}/projects/project-b/`},
-            route: '/settings/:orgId/projects/:projectId/',
-          },
-        }
-      );
+  it('places the current route project first when on a :projectId route', async () => {
+    render(
+      <CommandPaletteProvider>
+        <GlobalCommandPaletteActions />
+        <SlotOutlets />
+        <CommandPalette {...makeRenderProps(jest.fn())} />
+      </CommandPaletteProvider>,
+      {
+        organization,
+        initialRouterConfig: {
+          location: {pathname: `/settings/${organization.slug}/projects/project-b/`},
+          route: '/settings/:orgId/projects/:projectId/',
+        },
+      }
+    );
 
-      await drillIntoGeneralSettings();
+    await drillIntoGeneralSettings();
 
-      const option = (await screen.findAllByRole('option')).find(
-        el => !el.hasAttribute('aria-disabled')
-      );
-      expect(option).toHaveAccessibleName('project-b');
-    }
-  );
+    const option = (await screen.findAllByRole('option')).find(
+      el => !el.hasAttribute('aria-disabled')
+    );
+    expect(option).toHaveAccessibleName('project-b');
+  });
 
   it('does not duplicate the current project in the list', async () => {
     render(
@@ -188,35 +182,32 @@ describe('GlobalCommandPaletteActions - project settings ordering', () => {
     expect(screen.getAllByRole('option', {name: 'project-b'})).toHaveLength(1);
   });
 
-  it.isKnownFlake(
-    'places the project first when identified by a single ?project= query param',
-    async () => {
-      render(
-        <CommandPaletteProvider>
-          <GlobalCommandPaletteActions />
-          <SlotOutlets />
-          <CommandPalette {...makeRenderProps(jest.fn())} />
-        </CommandPaletteProvider>,
-        {
-          organization,
-          initialRouterConfig: {
-            location: {
-              pathname: `/organizations/${organization.slug}/issues/`,
-              query: {project: projectB.id},
-            },
+  it('places the project first when identified by a single ?project= query param', async () => {
+    render(
+      <CommandPaletteProvider>
+        <GlobalCommandPaletteActions />
+        <SlotOutlets />
+        <CommandPalette {...makeRenderProps(jest.fn())} />
+      </CommandPaletteProvider>,
+      {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/issues/`,
+            query: {project: projectB.id},
           },
-        }
-      );
+        },
+      }
+    );
 
-      await drillIntoGeneralSettings();
+    await drillIntoGeneralSettings();
 
-      const option = (await screen.findAllByRole('option')).find(
-        el => !el.hasAttribute('aria-disabled')
-      );
-      expect(option).toHaveAccessibleName('project-b');
-      expect(screen.getByText('Current')).toBeInTheDocument();
-    }
-  );
+    const option = (await screen.findAllByRole('option')).find(
+      el => !el.hasAttribute('aria-disabled')
+    );
+    expect(option).toHaveAccessibleName('project-b');
+    expect(screen.getByText('Current')).toBeInTheDocument();
+  });
 
   it('highlights all projects when multiple ?project= params are set', async () => {
     render(

--- a/static/app/components/core/form/field/baseField.spec.tsx
+++ b/static/app/components/core/form/field/baseField.spec.tsx
@@ -190,7 +190,7 @@ describe('BaseField indicator', () => {
     expect(mutationFn).toHaveBeenCalledWith({testField: 'changed'}, expect.anything());
   });
 
-  it.isKnownFlake('shows checkmark when auto-save succeeds', async () => {
+  it('shows checkmark when auto-save succeeds', async () => {
     const mutationFn = jest.fn((data: {testField: string}) => Promise.resolve(data));
 
     render(<AutoSaveTestForm mutationFn={mutationFn} initialValue="initial" />);

--- a/static/app/components/issueDiff/index.spec.tsx
+++ b/static/app/components/issueDiff/index.spec.tsx
@@ -45,7 +45,7 @@ describe('IssueDiff', () => {
     MockApiClient.clearMockResponses();
   });
 
-  it.isKnownFlake('can dynamically import SplitDiff', async () => {
+  it('can dynamically import SplitDiff', async () => {
     render(
       <IssueDiff
         baseIssueId="base"

--- a/static/app/components/performance/searchBar.spec.tsx
+++ b/static/app/components/performance/searchBar.spec.tsx
@@ -36,40 +36,35 @@ describe('SearchBar', () => {
     });
   });
 
-  it.isKnownFlake(
-    'Sends user input as a transaction search and shows the results',
-    async () => {
-      eventsMock = MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/events/`,
-        body: {
-          data: [{transaction: 'clients.call'}, {transaction: 'clients.fetch'}],
-        },
-      });
+  it('Sends user input as a transaction search and shows the results', async () => {
+    eventsMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      body: {
+        data: [{transaction: 'clients.call'}, {transaction: 'clients.fetch'}],
+      },
+    });
 
-      render(<SearchBar {...testProps} />);
+    render(<SearchBar {...testProps} />);
 
-      await userEvent.click(screen.getByRole('textbox'));
-      await userEvent.paste('proje');
-      expect(screen.getByRole('textbox')).toHaveValue('proje');
+    await userEvent.click(screen.getByRole('textbox'));
+    await userEvent.paste('proje');
+    expect(screen.getByRole('textbox')).toHaveValue('proje');
 
-      expect(eventsMock).toHaveBeenCalledTimes(1);
-      expect(eventsMock).toHaveBeenCalledWith(
-        '/organizations/org-slug/events/',
-        expect.objectContaining({
-          query: expect.objectContaining({
-            query: 'transaction:*proje* event.type:transaction',
-          }),
-        })
-      );
+    expect(eventsMock).toHaveBeenCalledTimes(1);
+    expect(eventsMock).toHaveBeenCalledWith(
+      '/organizations/org-slug/events/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          query: 'transaction:*proje* event.type:transaction',
+        }),
+      })
+    );
 
-      expect(screen.getByText(textWithMarkupMatcher('clients.call'))).toBeInTheDocument();
-      expect(
-        screen.getByText(textWithMarkupMatcher('clients.fetch'))
-      ).toBeInTheDocument();
-    }
-  );
+    expect(screen.getByText(textWithMarkupMatcher('clients.call'))).toBeInTheDocument();
+    expect(screen.getByText(textWithMarkupMatcher('clients.fetch'))).toBeInTheDocument();
+  });
 
-  it.isKnownFlake('Responds to keyboard navigation', async () => {
+  it('Responds to keyboard navigation', async () => {
     const onSearch = jest.fn();
     eventsMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,

--- a/static/app/components/pipeline/integrationGitLab/index.spec.tsx
+++ b/static/app/components/pipeline/integrationGitLab/index.spec.tsx
@@ -216,7 +216,7 @@ describe('InstallationConfigStep', () => {
     });
   });
 
-  it.isKnownFlake('strips trailing slashes from self-hosted URL', async () => {
+  it('strips trailing slashes from self-hosted URL', async () => {
     const advance = jest.fn();
     render(
       <InstallationConfigStep
@@ -297,7 +297,7 @@ describe('GitLabOAuthLoginStep', () => {
     expect(screen.getByRole('button', {name: 'Authorize GitLab'})).toBeInTheDocument();
   });
 
-  it.isKnownFlake('calls advance with code and state on OAuth callback', async () => {
+  it('calls advance with code and state on OAuth callback', async () => {
     const advance = jest.fn();
     render(
       <GitLabOAuthLoginStep

--- a/static/app/gettingStartedDocs/java-spring-boot/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/java-spring-boot/onboarding.spec.tsx
@@ -7,7 +7,7 @@ import {PackageManager} from 'sentry/gettingStartedDocs/java/utils';
 import {docs} from '.';
 
 describe('java-spring-boot onboarding docs', () => {
-  it.isKnownFlake('renders gradle docs correctly', async () => {
+  it('renders gradle docs correctly', async () => {
     renderWithOnboardingLayout(docs, {
       releaseRegistry: {
         'sentry.java.android.gradle-plugin': {
@@ -29,7 +29,7 @@ describe('java-spring-boot onboarding docs', () => {
     ).toBeInTheDocument();
   });
 
-  it.isKnownFlake('renders maven docs correctly', async () => {
+  it('renders maven docs correctly', async () => {
     renderWithOnboardingLayout(docs, {
       releaseRegistry: {
         'sentry.java.maven-plugin': {

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.spec.tsx
@@ -120,7 +120,7 @@ describe('SpansSearchBar', () => {
     await screen.findByLabelText('span.op:function');
   });
 
-  it.isKnownFlake('calls onSearch with the correct query', async () => {
+  it('calls onSearch with the correct query', async () => {
     const onSearch = jest.fn();
 
     renderWithProvider({
@@ -145,7 +145,7 @@ describe('SpansSearchBar', () => {
     });
   });
 
-  it.isKnownFlake('triggers onClose when the query changes', async () => {
+  it('triggers onClose when the query changes', async () => {
     const onClose = jest.fn();
 
     renderWithProvider({

--- a/static/app/views/dashboards/widgetCard/spansWidgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/spansWidgetQueries.spec.tsx
@@ -57,7 +57,7 @@ describe('spansWidgetQueries', () => {
     expect(await screen.findByText('low:partial')).toBeInTheDocument();
   });
 
-  it.isKnownFlake('calculates the confidence for a multi series', async () => {
+  it('calculates the confidence for a multi series', async () => {
     widget = WidgetFixture({
       queries: [
         {

--- a/static/app/views/detectors/components/forms/metric/metric.spec.tsx
+++ b/static/app/views/detectors/components/forms/metric/metric.spec.tsx
@@ -74,151 +74,134 @@ describe('NewMetricDetectorForm', () => {
     });
   });
 
-  it.isKnownFlake(
-    'shows default issue preview and updates subtitle when threshold changes',
-    async () => {
-      render(
-        <DetectorFormProvider detectorType="metric_issue">
-          <NewMetricDetectorForm />
-        </DetectorFormProvider>,
-        {organization}
-      );
+  it('shows default issue preview and updates subtitle when threshold changes', async () => {
+    render(
+      <DetectorFormProvider detectorType="metric_issue">
+        <NewMetricDetectorForm />
+      </DetectorFormProvider>,
+      {organization}
+    );
 
-      // Default title and subtitle
-      expect(await screen.findByText('Monitor title')).toBeInTheDocument();
-      expect(
-        screen.getByText('Critical: Number of errors above ... in 1 hour')
-      ).toBeInTheDocument();
+    // Default title and subtitle
+    expect(await screen.findByText('Monitor title')).toBeInTheDocument();
+    expect(
+      screen.getByText('Critical: Number of errors above ... in 1 hour')
+    ).toBeInTheDocument();
 
-      // Change the monitor name and verify it updates the preview
-      await userEvent.click(screen.getByTestId('editable-text-label'));
-      await userEvent.clear(screen.getByRole('textbox', {name: 'Monitor Name'}));
-      await userEvent.type(
-        screen.getByRole('textbox', {name: 'Monitor Name'}),
-        'My Custom Monitor'
-      );
-      await userEvent.keyboard('{Enter}');
-      const preview = screen.getByTestId('issue-preview-section');
-      expect(within(preview).getByText('My Custom Monitor')).toBeInTheDocument();
+    // Change the monitor name and verify it updates the preview
+    await userEvent.click(screen.getByTestId('editable-text-label'));
+    await userEvent.clear(screen.getByRole('textbox', {name: 'Monitor Name'}));
+    await userEvent.type(
+      screen.getByRole('textbox', {name: 'Monitor Name'}),
+      'My Custom Monitor'
+    );
+    await userEvent.keyboard('{Enter}');
+    const preview = screen.getByTestId('issue-preview-section');
+    expect(within(preview).getByText('My Custom Monitor')).toBeInTheDocument();
 
-      // Change the high threshold
-      await userEvent.type(
-        screen.getByRole('spinbutton', {name: 'High threshold'}),
-        '100'
-      );
+    // Change the high threshold
+    await userEvent.type(screen.getByRole('spinbutton', {name: 'High threshold'}), '100');
 
-      expect(
-        within(preview).getByText('Critical: Number of errors above 100 in 1 hour')
-      ).toBeInTheDocument();
+    expect(
+      within(preview).getByText('Critical: Number of errors above 100 in 1 hour')
+    ).toBeInTheDocument();
 
-      // Switch to percent change detection type — threshold value carries over
-      await userEvent.click(screen.getByRole('radio', {name: /Change/i}));
+    // Switch to percent change detection type — threshold value carries over
+    await userEvent.click(screen.getByRole('radio', {name: /Change/i}));
 
-      expect(
-        within(preview).getByText(
-          'Critical: Number of errors higher by 100% compared to past 1 hour'
-        )
-      ).toBeInTheDocument();
+    expect(
+      within(preview).getByText(
+        'Critical: Number of errors higher by 100% compared to past 1 hour'
+      )
+    ).toBeInTheDocument();
 
-      // Clear and set a new percent threshold
-      await userEvent.clear(screen.getByRole('spinbutton', {name: 'High threshold'}));
-      await userEvent.type(
-        screen.getByRole('spinbutton', {name: 'High threshold'}),
-        '50'
-      );
+    // Clear and set a new percent threshold
+    await userEvent.clear(screen.getByRole('spinbutton', {name: 'High threshold'}));
+    await userEvent.type(screen.getByRole('spinbutton', {name: 'High threshold'}), '50');
 
-      expect(
-        within(preview).getByText(
-          'Critical: Number of errors higher by 50% compared to past 1 hour'
-        )
-      ).toBeInTheDocument();
+    expect(
+      within(preview).getByText(
+        'Critical: Number of errors higher by 50% compared to past 1 hour'
+      )
+    ).toBeInTheDocument();
 
-      // Switch to dynamic (anomaly) detection type
-      await userEvent.click(screen.getByRole('radio', {name: /Dynamic/i}));
+    // Switch to dynamic (anomaly) detection type
+    await userEvent.click(screen.getByRole('radio', {name: /Dynamic/i}));
 
-      expect(
-        within(preview).getByText('Detected an anomaly in the query for Number of errors')
-      ).toBeInTheDocument();
+    expect(
+      within(preview).getByText('Detected an anomaly in the query for Number of errors')
+    ).toBeInTheDocument();
 
-      // Change the assignee and verify it shows in the preview
-      await selectEvent.select(screen.getByRole('textbox', {name: 'Assign'}), 'Foo Bar');
-      expect(within(preview).getByText('FB')).toBeInTheDocument();
-    }
-  );
+    // Change the assignee and verify it shows in the preview
+    await selectEvent.select(screen.getByRole('textbox', {name: 'Assign'}), 'Foo Bar');
+    expect(within(preview).getByText('FB')).toBeInTheDocument();
+  });
 
-  it.isKnownFlake(
-    'clears medium threshold error when high threshold is updated',
-    async () => {
-      render(
-        <DetectorFormProvider detectorType="metric_issue">
-          <NewMetricDetectorForm />
-        </DetectorFormProvider>,
-        {organization}
-      );
+  it('clears medium threshold error when high threshold is updated', async () => {
+    render(
+      <DetectorFormProvider detectorType="metric_issue">
+        <NewMetricDetectorForm />
+      </DetectorFormProvider>,
+      {organization}
+    );
 
-      const highThreshold = await screen.findByRole('spinbutton', {
-        name: 'High threshold',
-      });
-      const mediumThreshold = screen.getByRole('spinbutton', {
-        name: 'Medium threshold',
-      });
+    const highThreshold = await screen.findByRole('spinbutton', {
+      name: 'High threshold',
+    });
+    const mediumThreshold = screen.getByRole('spinbutton', {
+      name: 'Medium threshold',
+    });
 
-      // Set medium higher than high (invalid for "above" condition)
-      await userEvent.type(highThreshold, '50');
-      await userEvent.type(mediumThreshold, '100');
+    // Set medium higher than high (invalid for "above" condition)
+    await userEvent.type(highThreshold, '50');
+    await userEvent.type(mediumThreshold, '100');
 
-      expect(
-        screen.getByText('Medium threshold must be lower than high threshold (50)')
-      ).toBeInTheDocument();
+    expect(
+      screen.getByText('Medium threshold must be lower than high threshold (50)')
+    ).toBeInTheDocument();
 
-      // Update high threshold to be above medium — error should clear
-      await userEvent.clear(highThreshold);
-      await userEvent.type(highThreshold, '200');
+    // Update high threshold to be above medium — error should clear
+    await userEvent.clear(highThreshold);
+    await userEvent.type(highThreshold, '200');
 
-      expect(screen.queryByText(/Medium threshold must be/)).not.toBeInTheDocument();
-    }
-  );
+    expect(screen.queryByText(/Medium threshold must be/)).not.toBeInTheDocument();
+  });
 
-  it.isKnownFlake(
-    'removes is filters when switching away from the errors dataset',
-    async () => {
-      render(
-        <DetectorFormProvider detectorType="metric_issue">
-          <NewMetricDetectorForm />
-        </DetectorFormProvider>,
-        {
-          organization,
-          initialRouterConfig: {
-            location: {
-              pathname: '/new/metric/',
-              query: {
-                dataset: 'errors',
-                query: 'is:unresolved status:500',
-                project: project.id,
-              },
+  it('removes is filters when switching away from the errors dataset', async () => {
+    render(
+      <DetectorFormProvider detectorType="metric_issue">
+        <NewMetricDetectorForm />
+      </DetectorFormProvider>,
+      {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: '/new/metric/',
+            query: {
+              dataset: 'errors',
+              query: 'is:unresolved status:500',
+              project: project.id,
             },
           },
-        }
-      );
+        },
+      }
+    );
 
-      let search = await screen.findByTestId('search-query-builder');
+    let search = await screen.findByTestId('search-query-builder');
 
-      // Should have is:resolved and status:500 filters
-      expect(
-        within(search).getByRole('row', {name: 'is:unresolved'})
-      ).toBeInTheDocument();
-      expect(within(search).getByRole('row', {name: 'status:500'})).toBeInTheDocument();
+    // Should have is:resolved and status:500 filters
+    expect(within(search).getByRole('row', {name: 'is:unresolved'})).toBeInTheDocument();
+    expect(within(search).getByRole('row', {name: 'status:500'})).toBeInTheDocument();
 
-      // Switch to spans dataset
-      await selectEvent.select(screen.getByLabelText(/dataset/i), 'Spans');
+    // Switch to spans dataset
+    await selectEvent.select(screen.getByLabelText(/dataset/i), 'Spans');
 
-      search = await screen.findByTestId('search-query-builder');
-      // is:unresolved filter should be removed
-      expect(
-        within(search).queryByRole('row', {name: 'is:unresolved'})
-      ).not.toBeInTheDocument();
-      // status:500 filter should still be present
-      expect(within(search).getByRole('row', {name: 'status:500'})).toBeInTheDocument();
-    }
-  );
+    search = await screen.findByTestId('search-query-builder');
+    // is:unresolved filter should be removed
+    expect(
+      within(search).queryByRole('row', {name: 'is:unresolved'})
+    ).not.toBeInTheDocument();
+    // status:500 filter should still be present
+    expect(within(search).getByRole('row', {name: 'status:500'})).toBeInTheDocument();
+  });
 });

--- a/static/app/views/discover/results/resultsSearchQueryBuilder.spec.tsx
+++ b/static/app/views/discover/results/resultsSearchQueryBuilder.spec.tsx
@@ -33,7 +33,7 @@ describe('ResultsSearchQueryBuilder', () => {
     });
   });
 
-  it.isKnownFlake('does not show function tags in has: dropdown', async () => {
+  it('does not show function tags in has: dropdown', async () => {
     render(
       <ResultsSearchQueryBuilder
         query=""
@@ -64,7 +64,7 @@ describe('ResultsSearchQueryBuilder', () => {
     });
   });
 
-  it.isKnownFlake('shows normal tags, e.g. transaction, in the dropdown', async () => {
+  it('shows normal tags, e.g. transaction, in the dropdown', async () => {
     render(
       <ResultsSearchQueryBuilder
         query=""

--- a/static/app/views/explore/metrics/metricsTab.spec.tsx
+++ b/static/app/views/explore/metrics/metricsTab.spec.tsx
@@ -173,7 +173,7 @@ describe('MetricsTabContent', () => {
     });
   });
 
-  it.isKnownFlake('should add a metric when Add Metric button is clicked', async () => {
+  it('should add a metric when Add Metric button is clicked', async () => {
     render(
       <ProviderWrapper>
         <MetricsTabContent datePageFilterProps={datePageFilterProps} />
@@ -228,7 +228,7 @@ describe('MetricsTabContent', () => {
     expect(screen.getAllByTestId('metric-panel')).toHaveLength(3);
   });
 
-  it.isKnownFlake('should fire analytics for metadata', async () => {
+  it('should fire analytics for metadata', async () => {
     render(
       <ProviderWrapper>
         <MetricsTabContent datePageFilterProps={datePageFilterProps} />

--- a/static/app/views/explore/profiling/landing/slowestFunctionsWidget.spec.tsx
+++ b/static/app/views/explore/profiling/landing/slowestFunctionsWidget.spec.tsx
@@ -59,7 +59,7 @@ describe('SlowestFunctionsWidget', () => {
     expect(await screen.findByText('No functions found')).toBeInTheDocument();
   });
 
-  it.isKnownFlake('renders examples and chart', async () => {
+  it('renders examples and chart', async () => {
     // for the slowest functions query
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events/',

--- a/static/app/views/insights/crons/components/monitorForm.spec.tsx
+++ b/static/app/views/insights/crons/components/monitorForm.spec.tsx
@@ -40,34 +40,31 @@ describe('MonitorForm', () => {
     });
   });
 
-  it.isKnownFlake(
-    'shows validation errors on required sibling fields after first field change',
-    async () => {
-      render(
-        <MonitorForm
-          apiMethod="POST"
-          apiEndpoint={`/organizations/${organization.slug}/monitors/`}
-          onSubmitSuccess={jest.fn()}
-        />,
-        {organization}
-      );
+  it('shows validation errors on required sibling fields after first field change', async () => {
+    render(
+      <MonitorForm
+        apiMethod="POST"
+        apiEndpoint={`/organizations/${organization.slug}/monitors/`}
+        onSubmitSuccess={jest.fn()}
+      />,
+      {organization}
+    );
 
-      // Initially no validation error tooltips should be rendered
-      expect(document.querySelectorAll('[data-tooltip]')).toHaveLength(0);
+    // Initially no validation error tooltips should be rendered
+    expect(document.querySelectorAll('[data-tooltip]')).toHaveLength(0);
 
-      // Change one field (schedule) to trigger first-change validation
-      const schedule = screen.getByRole('textbox', {name: 'Crontab Schedule'});
-      await userEvent.clear(schedule);
-      await userEvent.type(schedule, '5 * * * *');
+    // Change one field (schedule) to trigger first-change validation
+    const schedule = screen.getByRole('textbox', {name: 'Crontab Schedule'});
+    await userEvent.clear(schedule);
+    await userEvent.type(schedule, '5 * * * *');
 
-      // Validation error tooltips should now appear on other required empty fields
-      await waitFor(() => {
-        expect(document.querySelectorAll('[data-tooltip]').length).toBeGreaterThan(0);
-      });
-    }
-  );
+    // Validation error tooltips should now appear on other required empty fields
+    await waitFor(() => {
+      expect(document.querySelectorAll('[data-tooltip]').length).toBeGreaterThan(0);
+    });
+  });
 
-  it.isKnownFlake('displays human readable schedule', async () => {
+  it('displays human readable schedule', async () => {
     render(
       <MonitorForm
         apiMethod="POST"
@@ -184,7 +181,7 @@ describe('MonitorForm', () => {
     expect(mockHandleSubmitSuccess).toHaveBeenCalled();
   });
 
-  it.isKnownFlake('prefills with an existing monitor', async () => {
+  it('prefills with an existing monitor', async () => {
     const monitor = MonitorFixture({project});
 
     const apiEndpont = `/projects/${organization.slug}/${monitor.project.slug}/monitors/${monitor.slug}/`;

--- a/static/app/views/settings/organizationIntegrations/repositoryProjectPathConfigForm.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/repositoryProjectPathConfigForm.spec.tsx
@@ -96,7 +96,7 @@ describe('RepositoryProjectPathConfigModal', () => {
     );
   });
 
-  it.isKnownFlake('POSTs to code-mappings endpoint in create mode', async () => {
+  it('POSTs to code-mappings endpoint in create mode', async () => {
     jest.spyOn(analytics, 'trackAnalytics');
     const mockPost = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/code-mappings/`,

--- a/static/app/views/settings/project/projectKeys/list/index.spec.tsx
+++ b/static/app/views/settings/project/projectKeys/list/index.spec.tsx
@@ -55,7 +55,7 @@ describe('ProjectKeys', () => {
     ).toBeInTheDocument();
   });
 
-  it.isKnownFlake('has clippable box', async () => {
+  it('has clippable box', async () => {
     render(<ProjectKeys />, {
       organization,
       outletContext: {project: ProjectFixture()},
@@ -68,7 +68,7 @@ describe('ProjectKeys', () => {
     expect(expandButton).not.toBeInTheDocument();
   });
 
-  it.isKnownFlake('renders for default project', async () => {
+  it('renders for default project', async () => {
     render(<ProjectKeys />, {
       organization,
       outletContext: {project: ProjectFixture({platform: 'other'})},

--- a/static/gsAdmin/components/deleteBillingMetricHistory.spec.tsx
+++ b/static/gsAdmin/components/deleteBillingMetricHistory.spec.tsx
@@ -99,95 +99,92 @@ describe('DeleteBillingMetricHistory', () => {
     expect(screen.getByRole('button', {name: 'Cancel'})).toBeInTheDocument();
   });
 
-  it.isKnownFlake(
-    'successfully deletes billing metric history when form is submitted',
-    async () => {
-      // Mock the billing config API call
-      MockApiClient.addMockResponse({
-        url: '/billing-config/',
-        body: {
-          category_info: {
-            '1': {
-              api_name: 'errors',
-              billed_category: 1,
-              display_name: 'Errors',
-              name: 'errors',
-              order: 1,
-              product_name: 'Error Tracking',
-              singular: 'error',
-              tally_type: 1,
-            },
-            '2': {
-              api_name: 'transactions',
-              billed_category: 2,
-              display_name: 'Transactions',
-              name: 'transactions',
-              order: 2,
-              product_name: 'Performance',
-              singular: 'transaction',
-              tally_type: 2,
-            },
+  it('successfully deletes billing metric history when form is submitted', async () => {
+    // Mock the billing config API call
+    MockApiClient.addMockResponse({
+      url: '/billing-config/',
+      body: {
+        category_info: {
+          '1': {
+            api_name: 'errors',
+            billed_category: 1,
+            display_name: 'Errors',
+            name: 'errors',
+            order: 1,
+            product_name: 'Error Tracking',
+            singular: 'error',
+            tally_type: 1,
           },
-          outcomes: {},
-          reason_codes: {},
+          '2': {
+            api_name: 'transactions',
+            billed_category: 2,
+            display_name: 'Transactions',
+            name: 'transactions',
+            order: 2,
+            product_name: 'Performance',
+            singular: 'transaction',
+            tally_type: 2,
+          },
         },
-      });
+        outcomes: {},
+        reason_codes: {},
+      },
+    });
 
-      // Mock the success indicator
-      const successIndicator = jest.spyOn(
-        require('sentry/actionCreators/indicator'),
-        'addSuccessMessage'
-      );
+    // Mock the success indicator
+    const successIndicator = jest.spyOn(
+      require('sentry/actionCreators/indicator'),
+      'addSuccessMessage'
+    );
 
-      // Mock the API endpoint for deleting billing metric history
-      const deleteBillingMetricHistoryMock = MockApiClient.addMockResponse({
-        url: `/api/0/customers/${organization.slug}/delete-billing-metric-history/`,
+    // Mock the API endpoint for deleting billing metric history
+    const deleteBillingMetricHistoryMock = MockApiClient.addMockResponse({
+      url: `/api/0/customers/${organization.slug}/delete-billing-metric-history/`,
+      method: 'POST',
+      body: {},
+    });
+
+    const onSuccess = jest.fn();
+    openDeleteModal({organization, onSuccess});
+
+    // Wait for the component to load
+    await waitFor(() => {
+      expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
+    });
+
+    // Wait for the form to be visible
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', {name: 'Data Category'})).toBeInTheDocument();
+    });
+
+    // Select a data category
+    await selectEvent.select(
+      screen.getByRole('textbox', {name: 'Data Category'}),
+      'Transactions (2)'
+    );
+
+    // Click the Delete button
+    await userEvent.click(screen.getByRole('button', {name: 'Delete'}));
+
+    // Check that the API call was made with the correct parameters
+    expect(deleteBillingMetricHistoryMock).toHaveBeenCalledWith(
+      `/api/0/customers/${organization.slug}/delete-billing-metric-history/`,
+      expect.objectContaining({
         method: 'POST',
-        body: {},
-      });
+        data: {
+          data_category: 2,
+        },
+      })
+    );
 
-      const onSuccess = jest.fn();
-      openDeleteModal({organization, onSuccess});
+    // Check that the success message was shown
+    expect(successIndicator).toHaveBeenCalledWith(
+      'Successfully deleted billing metric history.'
+    );
 
-      // Wait for the component to load
-      await waitFor(() => {
-        expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
-      });
-
-      // Wait for the form to be visible
-      await waitFor(() => {
-        expect(screen.getByRole('textbox', {name: 'Data Category'})).toBeInTheDocument();
-      });
-
-      // Select a data category
-      await selectEvent.select(
-        screen.getByRole('textbox', {name: 'Data Category'}),
-        'Transactions (2)'
-      );
-
-      // Click the Delete button
-      await userEvent.click(screen.getByRole('button', {name: 'Delete'}));
-
-      // Check that the API call was made with the correct parameters
-      expect(deleteBillingMetricHistoryMock).toHaveBeenCalledWith(
-        `/api/0/customers/${organization.slug}/delete-billing-metric-history/`,
-        expect.objectContaining({
-          method: 'POST',
-          data: {
-            data_category: 2,
-          },
-        })
-      );
-
-      // Check that the success message was shown
-      expect(successIndicator).toHaveBeenCalledWith(
-        'Successfully deleted billing metric history.'
-      );
-
-      // Check that the onSuccess callback was called
-      expect(onSuccess).toHaveBeenCalled();
-    }
-  );
+    // Check that the onSuccess callback was called
+    expect(onSuccess).toHaveBeenCalled();
+  });
 
   it('shows error message when API request fails', async () => {
     // Mock the billing config API call


### PR DESCRIPTION
Stacked on #121172 — review that one first.

I audited every remaining `it.isKnownFlake()` marker in the repo. #121172 fixes the only genuine flake I could find. This removes the other 30 markers across 17 files, which leaves zero usages in `static/`. The helper, its type declaration, and the CI wiring stay in place for future use.

The case for removing them is that the markers are unmaintained, not that these tests never fail. All 30 date to automation batches merged on 2026-05-26, 06-03, and 06-08. The automation only ever adds markers, and its last three PRs (#117642, #118116, #118627) were closed unmerged, so it has not revisited anything on master since. Eleven of the files have had no commit since their marker landed. Locally, every marked test passes in isolation, and 37 of 38 passed 50x stress across two full passes (3928 executions).

Two of these tests *did* fail on master in the last five weeks. Both were reported to #feed-frontend-tests and both are now resolved in Sentry:

- `explore/metrics/metricsTab.spec.tsx` → `should add a metric when Add Metric button is clicked` (JEST-2XZ0, 1 event, 2026-07-14)
- `dashboards/widgetCard/spansWidgetQueries.spec.tsx` → `calculates the confidence for a multi series` (JEST-21WY, 3 events, last seen 2026-07-02)

Of the 12 distinct issues that channel reported between 07-01 and 08-04, those are the only two I could attribute to a marked test; one alert (JEST-2Y29) has no spec frame in its stack, so I could not attribute it either way. Neither hit is among the jest issues currently unresolved. I'm still proposing to unmark both, but flagging them so that's a deliberate call rather than an omission.

The marker is a no-op in normal CI, expanding to 50 runs only when the `Frontend: Rerun Flaky Tests` label sets `RERUN_KNOWN_FLAKY_TESTS`. Removing it changes no default CI behavior, and it does not make a flaky test any likelier to fail — it stops advertising these tests as flaky. If either of the two above regresses, the Sentry alert is the signal that matters, and it fires with or without the marker.

Replaces #120851, which bundled the banner fix in with the marker removals.

Follow-up to a follow-up on LOGS-936
