### PR TITLE
build(ui): Restore lazy type-loader dev-ui startup

### DIFF
--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -119,6 +119,10 @@ const SENTRY_SPA_DSN = SENTRY_EXPERIMENTAL_SPA ? env.SENTRY_SPA_DSN : undefined;
 const sentryDjangoAppPath = path.join(import.meta.dirname, 'src/sentry/static/sentry');
 const distPath = path.join(sentryDjangoAppPath, 'dist');
 const staticPrefix = path.join(import.meta.dirname, 'static');
+const typeLoaderPath = path.resolve(
+  import.meta.dirname,
+  'static/app/stories/typeLoader.ts'
+);
 
 // Locale compilation and optimizations.
 //
@@ -307,7 +311,7 @@ const appConfig: Configuration = {
     // Always lazy-compile type-loader modules (they run the TS compiler and are expensive)
     test(module) {
       if ('request' in module && typeof module.request === 'string') {
-        if (module.request.includes('type-loader')) {
+        if (module.request.includes(typeLoaderPath)) {
           return true;
         }
       }
@@ -488,10 +492,7 @@ const appConfig: Configuration = {
 
   resolveLoader: {
     alias: {
-      'type-loader': path.resolve(
-        import.meta.dirname,
-        'static/app/stories/typeLoader.ts'
-      ),
+      'type-loader': typeLoaderPath,
     },
   },
 


### PR DESCRIPTION
Renaming `type-loader.ts` to `typeLoader.ts` left the targeted lazy compilation filter matching the old filename. That made 64 documentation imports eagerly run their own TypeScript programs during `dev-ui` startup.

Reuse the resolved loader path for both the alias and the filter. General lazy compilation stays off - this only restores the existing exception for the expensive type documentation loader.

| Version | Cold startup |
|---|---:|
| Before the regression | 6.7-7.6s |
| Current broken | 22.9s |
| With this fix | 6.9-7.2s |

refs https://github.com/getsentry/sentry/pull/120103
