### PR TITLE
ref(tables): wrap SimpleTable error states in SimpleTable.Empty

### DIFF
--- a/static/app/views/automations/components/automationHistoryList.tsx
+++ b/static/app/views/automations/components/automationHistoryList.tsx
@@ -99,7 +99,11 @@ export function AutomationHistoryList({
           <SimpleTable.HeaderCell>{t('Alerts')}</SimpleTable.HeaderCell>
         </SimpleTable.Header>
         {isLoading && <Skeletons />}
-        {isError && <LoadingError />}
+        {isError && (
+          <SimpleTable.Empty>
+            <LoadingError />
+          </SimpleTable.Empty>
+        )}
         {!isLoading && !isError && fireHistory.length === 0 && (
           <SimpleTable.Empty>{emptyMessage}</SimpleTable.Empty>
         )}

--- a/static/app/views/automations/components/automationListTable/index.tsx
+++ b/static/app/views/automations/components/automationListTable/index.tsx
@@ -201,7 +201,11 @@ export function AutomationListTable({
           </StyledFlex>
         </SimpleTable.Empty>
       )}
-      {isError && <LoadingError message={t('Error loading alerts')} />}
+      {isError && (
+        <SimpleTable.Empty>
+          <LoadingError message={t('Error loading alerts')} />
+        </SimpleTable.Empty>
+      )}
       {isPending && <LoadingSkeletons />}
       {isSuccess &&
         automations.map(automation => (

--- a/static/app/views/automations/components/connectedMonitorsList.tsx
+++ b/static/app/views/automations/components/connectedMonitorsList.tsx
@@ -148,7 +148,11 @@ export function ConnectedMonitorsList({
             }
           />
         )}
-        {isError && <LoadingError />}
+        {isError && (
+          <SimpleTable.Empty>
+            <LoadingError />
+          </SimpleTable.Empty>
+        )}
         {((isSuccess && detectors?.length === 0) || emptySelection) && (
           <SimpleTable.Empty>{emptyMessage}</SimpleTable.Empty>
         )}

--- a/static/app/views/automations/components/connectedProjectsList.tsx
+++ b/static/app/views/automations/components/connectedProjectsList.tsx
@@ -84,7 +84,11 @@ export function ConnectedProjectsList({automationId}: Props) {
             ))}
           </Fragment>
         )}
-        {isError && <LoadingError />}
+        {isError && (
+          <SimpleTable.Empty>
+            <LoadingError />
+          </SimpleTable.Empty>
+        )}
         {isSuccess && detectors.length === 0 && (
           <SimpleTable.Empty>{t('No projects connected')}</SimpleTable.Empty>
         )}

--- a/static/app/views/detectors/components/connectedAutomationList.tsx
+++ b/static/app/views/detectors/components/connectedAutomationList.tsx
@@ -128,7 +128,11 @@ export function ConnectedAutomationsList({
             }
           />
         )}
-        {isError && <LoadingError />}
+        {isError && (
+          <SimpleTable.Empty>
+            <LoadingError />
+          </SimpleTable.Empty>
+        )}
         {((isSuccess && automations?.length === 0) ||
           (automationIds !== null && automationIds.length === 0)) && (
           <SimpleTable.Empty>{emptyMessage}</SimpleTable.Empty>

--- a/static/app/views/detectors/components/details/common/automations.tsx
+++ b/static/app/views/detectors/components/details/common/automations.tsx
@@ -103,7 +103,11 @@ function AutomationsTable({detectorId, emptyMessage}: AutomationsTableProps) {
         </SimpleTable.HeaderCell>
       </SimpleTable.Header>
       {isPending && <Skeletons numberOfRows={AUTOMATIONS_PER_PAGE} />}
-      {isError && <LoadingError />}
+      {isError && (
+        <SimpleTable.Empty>
+          <LoadingError />
+        </SimpleTable.Empty>
+      )}
       {isSuccess && automations?.length === 0 && (
         <SimpleTable.Empty>
           {searchQuery ? t('No matching alerts found') : emptyMessage}


### PR DESCRIPTION
`SimpleTable` renders its children directly into the table's grid, so a bare `<LoadingError />` sibling lands in the column tracks rather than spanning the row. This wraps the error branches in `SimpleTable.Empty` so both status states span the row.

Split out of #120745, as part of DE-1392. See that PR for the full end state.