### PR TITLE
ref(teams): extract and deduplicate shared teams-table styles

### DIFF
--- a/static/app/views/settings/organizationTeams/otherTeamsTable.tsx
+++ b/static/app/views/settings/organizationTeams/otherTeamsTable.tsx
@@ -1,12 +1,10 @@
 import {useMemo} from 'react';
 import {useTheme} from '@emotion/react';
-import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
 import {InfoText} from '@sentry/scraps/info';
 import InteractionStateLayer from '@sentry/scraps/interactionStateLayer';
 import {Flex} from '@sentry/scraps/layout';
-import {Link} from '@sentry/scraps/link';
 
 import {openCreateTeamModal} from 'sentry/actionCreators/modal';
 import {IdBadge} from 'sentry/components/idBadge';
@@ -19,6 +17,10 @@ import {useProjects} from 'sentry/utils/useProjects';
 import {useJoinTeam} from 'sentry/views/settings/organizationTeams/hooks/useJoinTeam';
 import {useRequestTeamAccess} from 'sentry/views/settings/organizationTeams/hooks/useRequestTeamAccess';
 import {TeamProjectsCell} from 'sentry/views/settings/organizationTeams/teamProjectsCell';
+import {
+  TeamLink,
+  TeamsTable,
+} from 'sentry/views/settings/organizationTeams/teamsTableStyles';
 import {getButtonHelpText} from 'sentry/views/settings/organizationTeams/utils';
 
 interface OtherTeamsTableProps {
@@ -65,7 +67,7 @@ export function OtherTeamsTable({
   };
 
   return (
-    <StyledSimpleTable>
+    <TeamsTable>
       <SimpleTable.Header>
         <SimpleTable.HeaderCell>{t('Other Teams')}</SimpleTable.HeaderCell>
         <SimpleTable.HeaderCell data-column-name="role" />
@@ -84,7 +86,7 @@ export function OtherTeamsTable({
               projects={projects}
             />
           ))}
-    </StyledSimpleTable>
+    </TeamsTable>
   );
 }
 
@@ -230,32 +232,3 @@ function TeamAction({
     </Button>
   );
 }
-
-const StyledSimpleTable = styled(SimpleTable)`
-  grid-template-columns: 1fr 125px 150px auto;
-  margin-bottom: ${p => p.theme.space.xl};
-
-  [data-column-name='actions'] {
-    padding-left: 0;
-  }
-
-  @media (max-width: ${p => p.theme.breakpoints.md}) {
-    grid-template-columns: 1fr 125px auto;
-
-    [data-column-name='projects'] {
-      display: none;
-    }
-  }
-
-  @media (max-width: ${p => p.theme.breakpoints.sm}) {
-    grid-template-columns: 1fr auto;
-
-    [data-column-name='role'] {
-      display: none;
-    }
-  }
-`;
-
-const TeamLink = styled(Link)`
-  ${SimpleTable.rowLinkStyle}
-`;

--- a/static/app/views/settings/organizationTeams/teamsTableStyles.tsx
+++ b/static/app/views/settings/organizationTeams/teamsTableStyles.tsx
@@ -1,0 +1,34 @@
+import styled from '@emotion/styled';
+
+import {Link} from '@sentry/scraps/link';
+
+import {SimpleTable} from 'sentry/components/tables/simpleTable';
+
+export const TeamsTable = styled(SimpleTable)`
+  grid-template-columns: 1fr 125px 150px auto;
+  margin-bottom: ${p => p.theme.space.xl};
+
+  [data-column-name='actions'] {
+    padding-left: 0;
+  }
+
+  @media (max-width: ${p => p.theme.breakpoints.md}) {
+    grid-template-columns: 1fr 125px auto;
+
+    [data-column-name='projects'] {
+      display: none;
+    }
+  }
+
+  @media (max-width: ${p => p.theme.breakpoints.sm}) {
+    grid-template-columns: 1fr auto;
+
+    [data-column-name='role'] {
+      display: none;
+    }
+  }
+`;
+
+export const TeamLink = styled(Link)`
+  ${SimpleTable.rowLinkStyle}
+`;

--- a/static/app/views/settings/organizationTeams/yourTeamsTable.tsx
+++ b/static/app/views/settings/organizationTeams/yourTeamsTable.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
 import InteractionStateLayer from '@sentry/scraps/interactionStateLayer';
-import {Link} from '@sentry/scraps/link';
 
 import {openCreateTeamModal} from 'sentry/actionCreators/modal';
 import {IdBadge} from 'sentry/components/idBadge';
@@ -18,6 +17,10 @@ import {useProjects} from 'sentry/utils/useProjects';
 import {useLeaveTeam} from 'sentry/views/settings/organizationTeams/hooks/useLeaveTeam';
 import {RoleOverwritePanelAlert} from 'sentry/views/settings/organizationTeams/roleOverwriteWarning';
 import {TeamProjectsCell} from 'sentry/views/settings/organizationTeams/teamProjectsCell';
+import {
+  TeamLink,
+  TeamsTable,
+} from 'sentry/views/settings/organizationTeams/teamsTableStyles';
 import {getButtonHelpText} from 'sentry/views/settings/organizationTeams/utils';
 
 interface YourTeamsTableProps {
@@ -84,7 +87,7 @@ export function YourTeamsTable({
   };
 
   return (
-    <StyledSimpleTable>
+    <TeamsTable>
       <SimpleTable.Header>
         <SimpleTable.HeaderCell>{t('Your Teams')}</SimpleTable.HeaderCell>
         <SimpleTable.HeaderCell data-column-name="role">
@@ -125,7 +128,7 @@ export function YourTeamsTable({
           : teams.map(team => (
               <YourTeamRow key={team.slug} team={team} projects={projects} />
             ))}
-    </StyledSimpleTable>
+    </TeamsTable>
   );
 }
 
@@ -206,35 +209,6 @@ function YourTeamRow({
     </SimpleTable.Row>
   );
 }
-
-const StyledSimpleTable = styled(SimpleTable)`
-  grid-template-columns: 1fr 125px 150px auto;
-  margin-bottom: ${p => p.theme.space.xl};
-
-  [data-column-name='actions'] {
-    padding-left: 0;
-  }
-
-  @media (max-width: ${p => p.theme.breakpoints.md}) {
-    grid-template-columns: 1fr 125px auto;
-
-    [data-column-name='projects'] {
-      display: none;
-    }
-  }
-
-  @media (max-width: ${p => p.theme.breakpoints.sm}) {
-    grid-template-columns: 1fr auto;
-
-    [data-column-name='role'] {
-      display: none;
-    }
-  }
-`;
-
-const TeamLink = styled(Link)`
-  ${SimpleTable.rowLinkStyle}
-`;
 
 const FullWidthAlert = styled('div')`
   grid-column: 1 / -1;


### PR DESCRIPTION
Stacked on top of #121176.

`yourTeamsTable` and `otherTeamsTable` each carried an identical copy of the `TeamsTable` grid definition and the `TeamLink` row-link style. This moves both into `teamsTableStyles`.

Split out of #120745, as part of DE-1392. See that PR for the full end state.