### PR TITLE
feat(scraps): add a shared Table shell with a ColumnResizer

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -31,6 +31,7 @@ const productionEntryPoints = [
   'static/app/components/connectRepository/**/*.{ts,tsx}',
   // https://github.com/getsentry/sentry/pull/121178
   'static/app/components/core/table/*.tsx',
+  'static/app/components/core/dragHandle/*.tsx',
 ];
 
 const testingEntryPoints = [

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -29,6 +29,8 @@ const productionEntryPoints = [
   'static/app/views/seerExplorer/contexts/**/*.{js,ts,tsx}',
   // TODO: Remove when wired into the connect repository modal
   'static/app/components/connectRepository/**/*.{ts,tsx}',
+  // https://github.com/getsentry/sentry/pull/121178
+  'static/app/components/core/table/*.tsx',
 ];
 
 const testingEntryPoints = [

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -27,6 +27,8 @@ const productionEntryPoints = [
   'static/app/views/seerExplorer/contexts/**/*.{js,ts,tsx}',
   // TODO: Remove when wired into the connect repository modal
   'static/app/components/connectRepository/**/*.{ts,tsx}',
+  // https://github.com/getsentry/sentry/pull/121178
+  'static/app/components/core/table/*.tsx',
 ];
 
 const testingEntryPoints = [

--- a/static/app/components/core/dragHandle/__stories__/dragHandleDemos.tsx
+++ b/static/app/components/core/dragHandle/__stories__/dragHandleDemos.tsx
@@ -1,0 +1,43 @@
+import {useState} from 'react';
+
+import {DragHandle} from '@sentry/scraps/dragHandle';
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+const MIN_SIZE = 80;
+const MAX_SIZE = 360;
+const DEFAULT_SIZE = 200;
+
+const clamp = (size: number) => Math.max(MIN_SIZE, Math.min(MAX_SIZE, size));
+
+export function DragHandleDemo({
+  appearance,
+}: {
+  appearance?: React.ComponentProps<typeof DragHandle>['appearance'];
+}) {
+  const [size, setSize] = useState(DEFAULT_SIZE);
+
+  return (
+    <Stack gap="sm" width="100%">
+      <Text variant="muted">Sized pane width: {size}px</Text>
+      <Flex height="140px" border="primary" radius="md" overflow="hidden">
+        <Stack padding="md" background="secondary" flexShrink={0} flexBasis={`${size}px`}>
+          <Text bold>Sized</Text>
+        </Stack>
+        <DragHandle
+          appearance={appearance}
+          isSizedFirst
+          max={MAX_SIZE}
+          min={MIN_SIZE}
+          orientation="horizontal"
+          value={size}
+          onDoubleClick={() => setSize(DEFAULT_SIZE)}
+          onMove={delta => setSize(current => clamp(current + delta))}
+        />
+        <Stack padding="md" background="primary" flexGrow={1}>
+          <Text bold>Fill</Text>
+        </Stack>
+      </Flex>
+    </Stack>
+  );
+}

--- a/static/app/components/core/dragHandle/__stories__/dragHandleDemos.tsx
+++ b/static/app/components/core/dragHandle/__stories__/dragHandleDemos.tsx
@@ -1,6 +1,6 @@
 import {useState} from 'react';
 
-import {DragHandle} from '@sentry/scraps/dragHandle';
+import {DragHandle, type DragHandleAppearance} from '@sentry/scraps/dragHandle';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
@@ -10,11 +10,7 @@ const DEFAULT_SIZE = 200;
 
 const clamp = (size: number) => Math.max(MIN_SIZE, Math.min(MAX_SIZE, size));
 
-export function DragHandleDemo({
-  appearance,
-}: {
-  appearance?: React.ComponentProps<typeof DragHandle>['appearance'];
-}) {
+export function DragHandleDemo({appearance}: {appearance?: DragHandleAppearance}) {
   const [size, setSize] = useState(DEFAULT_SIZE);
 
   return (

--- a/static/app/components/core/dragHandle/__stories__/dragHandleDemos.tsx
+++ b/static/app/components/core/dragHandle/__stories__/dragHandleDemos.tsx
@@ -1,6 +1,6 @@
 import {useState} from 'react';
 
-import {DragHandle, type DragHandleAppearance} from '@sentry/scraps/dragHandle';
+import {DragHandle, type DragHandleVariant} from '@sentry/scraps/dragHandle';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
@@ -10,7 +10,7 @@ const DEFAULT_SIZE = 200;
 
 const clamp = (size: number) => Math.max(MIN_SIZE, Math.min(MAX_SIZE, size));
 
-export function DragHandleDemo({appearance}: {appearance?: DragHandleAppearance}) {
+export function DragHandleDemo({variant}: {variant?: DragHandleVariant}) {
   const [size, setSize] = useState(DEFAULT_SIZE);
 
   return (
@@ -21,12 +21,12 @@ export function DragHandleDemo({appearance}: {appearance?: DragHandleAppearance}
           <Text bold>Sized</Text>
         </Stack>
         <DragHandle
-          appearance={appearance}
           isSizedFirst
           max={MAX_SIZE}
           min={MIN_SIZE}
           orientation="horizontal"
           value={size}
+          variant={variant}
           onDoubleClick={() => setSize(DEFAULT_SIZE)}
           onMove={delta => setSize(current => clamp(current + delta))}
         />

--- a/static/app/components/core/dragHandle/__stories__/dragHandleDemos.tsx
+++ b/static/app/components/core/dragHandle/__stories__/dragHandleDemos.tsx
@@ -21,6 +21,7 @@ export function DragHandleDemo({variant}: {variant?: DragHandleVariant}) {
           <Text bold>Sized</Text>
         </Stack>
         <DragHandle
+          aria-label="Resize panes"
           isSizedFirst
           max={MAX_SIZE}
           min={MIN_SIZE}

--- a/static/app/components/core/dragHandle/dragHandle.mdx
+++ b/static/app/components/core/dragHandle/dragHandle.mdx
@@ -69,6 +69,10 @@ Use the `ghost` variant to draw it only while the handle is hovered, focused, or
 
 The handle is a `separator` with `tabIndex={0}`, and reports `aria-valuenow`, `aria-valuemin`, and `aria-valuemax` from the `value`, `min`, and `max` props.
 
+A focusable separator is a widget, so it must be named: pass either `aria-label` or `aria-labelledby`. Name what the handle resizes, such as `Resize panels`, rather than the handle itself; without a name it is announced as a bare number with no subject.
+
+Prefer `aria-labelledby` when the handle sits inside an element that takes its own name from its content, such as a table header cell. An `aria-label` there would also become part of that cell's name, so the column would announce as `duration Resize duration column`.
+
 The arrow keys along the handle's axis move it by 10px, or by 50px while shift is held.
 Pass `onKeyDown` to handle keys the handle does not claim, such as `Home` and `End`.
 

--- a/static/app/components/core/dragHandle/dragHandle.mdx
+++ b/static/app/components/core/dragHandle/dragHandle.mdx
@@ -1,0 +1,75 @@
+---
+title: DragHandle
+description: A focusable separator that a parent drives to resize an adjacent area, with pointer, double click, and keyboard affordances.
+category: layout
+source: '@sentry/scraps/dragHandle'
+status: stable
+resources:
+  js: https://github.com/getsentry/sentry/blob/master/static/app/components/core/dragHandle/dragHandle.tsx
+  a11y:
+    WCAG 2.1.1: https://www.w3.org/TR/WCAG22/#keyboard
+    WCAG 2.4.7: https://www.w3.org/TR/WCAG22/#focus-visible
+---
+
+import {DragHandleDemo} from './__stories__/dragHandleDemos';
+import * as Storybook from 'sentry/stories';
+
+export const documentation = import('!!type-loader!@sentry/scraps/dragHandle/dragHandle');
+
+## When to use
+
+`DragHandle` is the divider primitive shared by the components that let a user resize part of a layout.
+Reach for it when you are building such a component and need the divider itself: `SplitPanel` uses it between its two panes, and `Table` uses it as the column resize handle.
+
+Prefer `SplitPanel` when you need two resizable panes, and `Table` when you need resizable columns.
+Use `DragHandle` directly only when neither fits.
+
+## Anatomy
+
+`DragHandle` owns the interaction, and the parent owns the size.
+A pointer drag and the arrow keys both arrive as `onMove` with a delta in pixels along the handle's axis, which the parent applies and clamps however it likes.
+
+Pass the current `value` with its `min` and `max` so the handle can announce its position and point the cursor the only way it can still travel.
+
+<Storybook.Demo>
+  <DragHandleDemo />
+</Storybook.Demo>
+
+```jsx
+<DragHandle
+  isSizedFirst
+  max={maxSize}
+  min={minSize}
+  orientation="horizontal"
+  value={size}
+  onDoubleClick={() => setSize(defaultSize)}
+  onMove={delta => setSize(current => clamp(current + delta))}
+/>
+```
+
+Use `onMoveStart` and `onMoveEnd` when a drag needs to bracket its work, such as recording the size it started from so the change can be reported once at the end.
+
+An `orientation` of `horizontal` lays the panes out in a row and draws a vertical divider between them.
+Set `isSizedFirst` to `false` when the pane being sized sits after the divider, so the cursor and keys still match the direction the divider can move.
+
+## Appearance
+
+The divider line is drawn at all times by default.
+Set `appearance="hover"` to draw it only while the handle is hovered, focused, or held, for surfaces that already have their own separators, such as the column edges of a table.
+
+<Storybook.Demo>
+  <DragHandleDemo appearance="hover" />
+</Storybook.Demo>
+
+```jsx
+<DragHandle appearance="hover" {...props} />
+```
+
+## Accessibility
+
+The handle is a `separator` with `tabIndex={0}`, and reports `aria-valuenow`, `aria-valuemin`, and `aria-valuemax` from the `value`, `min`, and `max` props.
+
+The arrow keys along the handle's axis move it by `step`, or by `largeStep` while shift is held, defaulting to 10px and 50px.
+Pass `onKeyDown` to handle keys the handle does not claim, such as `Home` and `End`.
+
+Give `max` a real number wherever you can. ARIA defaults a focusable separator's `aria-valuemax` to 100, so an infinite `max` is omitted from the DOM and assistive technology then announces the value clamped to that default.

--- a/static/app/components/core/dragHandle/dragHandle.mdx
+++ b/static/app/components/core/dragHandle/dragHandle.mdx
@@ -52,17 +52,17 @@ Use `onMoveStart` and `onMoveEnd` when a drag needs to bracket its work, such as
 An `orientation` of `horizontal` lays the panes out in a row and draws a vertical divider between them.
 Set `isSizedFirst` to `false` when the pane being sized sits after the divider, so the cursor and keys still match the direction the divider can move.
 
-## Appearance
+## Variant
 
-The divider line is drawn at all times by default.
-Set `appearance="hover"` to draw it only while the handle is hovered, focused, or held, for surfaces that already have their own separators, such as the column edges of a table.
+The `solid` variant draws the divider line at all times.
+Use the `ghost` variant to draw it only while the handle is hovered, focused, or held, for surfaces that already have their own separators, such as the column edges of a table.
 
 <Storybook.Demo>
-  <DragHandleDemo appearance="hover" />
+  <DragHandleDemo variant="ghost" />
 </Storybook.Demo>
 
 ```jsx
-<DragHandle appearance="hover" {...props} />
+<DragHandle variant="ghost" {...props} />
 ```
 
 ## Accessibility

--- a/static/app/components/core/dragHandle/dragHandle.mdx
+++ b/static/app/components/core/dragHandle/dragHandle.mdx
@@ -69,7 +69,7 @@ Set `appearance="hover"` to draw it only while the handle is hovered, focused, o
 
 The handle is a `separator` with `tabIndex={0}`, and reports `aria-valuenow`, `aria-valuemin`, and `aria-valuemax` from the `value`, `min`, and `max` props.
 
-The arrow keys along the handle's axis move it by `step`, or by `largeStep` while shift is held, defaulting to 10px and 50px.
+The arrow keys along the handle's axis move it by 10px, or by 50px while shift is held.
 Pass `onKeyDown` to handle keys the handle does not claim, such as `Home` and `End`.
 
 Give `max` a real number wherever you can. ARIA defaults a focusable separator's `aria-valuemax` to 100, so an infinite `max` is omitted from the DOM and assistive technology then announces the value clamped to that default.

--- a/static/app/components/core/dragHandle/dragHandle.mdx
+++ b/static/app/components/core/dragHandle/dragHandle.mdx
@@ -52,9 +52,9 @@ Use `onMoveStart` and `onMoveEnd` when a drag needs to bracket its work, such as
 An `orientation` of `horizontal` lays the panes out in a row and draws a vertical divider between them.
 Set `isSizedFirst` to `false` when the pane being sized sits after the divider, so the cursor and keys still match the direction the divider can move.
 
-## Variant
+## Variants
 
-The `solid` variant draws the divider line at all times.
+The default `solid` variant draws the divider line at all times.
 Use the `ghost` variant to draw it only while the handle is hovered, focused, or held, for surfaces that already have their own separators, such as the column edges of a table.
 
 <Storybook.Demo>

--- a/static/app/components/core/dragHandle/dragHandle.tsx
+++ b/static/app/components/core/dragHandle/dragHandle.tsx
@@ -37,7 +37,17 @@ function getDragHandleCursor(
   return 'ns-resize';
 }
 
-export type DragHandleProps = {
+/**
+ * A focusable `separator` is a widget, so it needs a name, or it is announced as a bare
+ * value with no subject. Prefer `aria-labelledby` when the handle sits inside an element
+ * that is named from its content, such as a table header cell: an `aria-label` there
+ * would also become part of that element's own name.
+ */
+type DragHandleNameProps =
+  | {'aria-label': string; 'aria-labelledby'?: never}
+  | {'aria-labelledby': string; 'aria-label'?: never};
+
+export type DragHandleProps = DragHandleNameProps & {
   isSizedFirst: boolean;
   max: number;
   min: number;
@@ -52,6 +62,8 @@ export type DragHandleProps = {
 };
 
 export function DragHandle({
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledby,
   variant = 'solid',
   isSizedFirst,
   max,
@@ -84,6 +96,8 @@ export function DragHandle({
         <DragHandleLine
           {...mergeProps(moveProps, containerProps, {onDoubleClick, onKeyDown})}
           $cursor={cursor}
+          aria-label={ariaLabel}
+          aria-labelledby={ariaLabelledby}
           aria-orientation={orientation === 'horizontal' ? 'vertical' : 'horizontal'}
           aria-valuemax={Number.isFinite(max) ? max : undefined}
           aria-valuemin={min}
@@ -118,7 +132,7 @@ const DragHandleLine = styled('div')<{$cursor: React.CSSProperties['cursor']}>`
     z-index: ${p => p.theme.zIndex.drawer};
     opacity: 0.8;
     background: transparent;
-    transition: background ${p => p.theme.motion.smooth.slow} 0.1s;
+    transition: background ${p => p.theme.motion.smooth.slow};
   }
 
   &:hover::after,

--- a/static/app/components/core/dragHandle/dragHandle.tsx
+++ b/static/app/components/core/dragHandle/dragHandle.tsx
@@ -3,39 +3,13 @@ import {mergeProps} from '@react-aria/utils';
 
 import {Container} from '@sentry/scraps/layout';
 
-import {useDragMove} from './useDragMove';
+import {useDragSeparator} from './useDragSeparator';
 
 export type Orientation = 'horizontal' | 'vertical';
 
 export type DragHandleVariant = 'solid' | 'ghost';
 
 export const DRAG_HANDLE_SIZE = 1;
-
-// At a limit the handle can only travel one way, so point the cursor that way;
-// the grow/shrink direction flips when the sized pane sits after the handle.
-function getDragHandleCursor(
-  orientation: Orientation,
-  atMin: boolean,
-  atMax: boolean,
-  isSizedFirst: boolean
-): React.CSSProperties['cursor'] {
-  if (orientation === 'horizontal') {
-    if (atMin) {
-      return isSizedFirst ? 'e-resize' : 'w-resize';
-    }
-    if (atMax) {
-      return isSizedFirst ? 'w-resize' : 'e-resize';
-    }
-    return 'ew-resize';
-  }
-  if (atMin) {
-    return isSizedFirst ? 's-resize' : 'n-resize';
-  }
-  if (atMax) {
-    return isSizedFirst ? 'n-resize' : 's-resize';
-  }
-  return 'ns-resize';
-}
 
 /**
  * A focusable `separator` is a widget, so it needs a name, or it is announced as a bare
@@ -76,37 +50,26 @@ export function DragHandle({
   onMoveEnd,
   onMoveStart,
 }: DragHandleProps) {
-  const {isHeld, moveProps} = useDragMove({
+  const {cursor, separatorProps} = useDragSeparator({
+    isSizedFirst,
+    max,
+    min,
     onMove,
     onMoveEnd,
     onMoveStart,
     orientation,
+    value,
   });
-
-  const cursor = getDragHandleCursor(
-    orientation,
-    value <= min,
-    Number.isFinite(max) && value >= max,
-    isSizedFirst
-  );
 
   return (
     <Container position="relative" flexShrink={0}>
       {containerProps => (
         <DragHandleLine
-          {...mergeProps(moveProps, containerProps, {onDoubleClick, onKeyDown})}
+          {...mergeProps(separatorProps, containerProps, {onDoubleClick, onKeyDown})}
           $cursor={cursor}
           aria-label={ariaLabel}
           aria-labelledby={ariaLabelledby}
-          aria-orientation={orientation === 'horizontal' ? 'vertical' : 'horizontal'}
-          aria-valuemax={Number.isFinite(max) ? max : undefined}
-          aria-valuemin={min}
-          aria-valuenow={value}
           data-variant={variant}
-          data-is-held={isHeld}
-          data-orientation={orientation}
-          role="separator"
-          tabIndex={0}
         />
       )}
     </Container>

--- a/static/app/components/core/dragHandle/dragHandle.tsx
+++ b/static/app/components/core/dragHandle/dragHandle.tsx
@@ -7,8 +7,8 @@ import {useDragMove} from './useDragMove';
 
 export type Orientation = 'horizontal' | 'vertical';
 
-// The handle renders as a 1px border; account for it when a consumer derives
-// layout sizes (e.g. the max size of a panel next to it).
+export type DragHandleAppearance = 'always' | 'hover';
+
 export const DRAG_HANDLE_SIZE = 1;
 
 // At a limit the handle can only travel one way, so point the cursor that way;
@@ -45,22 +45,18 @@ export type DragHandleProps = {
   onMove: (delta: number) => void;
   orientation: Orientation;
   value: number;
-  appearance?: 'always' | 'hover';
-  largeStep?: number;
+  appearance?: DragHandleAppearance;
   onKeyDown?: React.KeyboardEventHandler<HTMLElement>;
   onMoveEnd?: () => void;
   onMoveStart?: () => void;
-  step?: number;
 };
 
 export function DragHandle({
   appearance = 'always',
   isSizedFirst,
-  largeStep,
   max,
   min,
   orientation,
-  step,
   value,
   onDoubleClick,
   onKeyDown,
@@ -69,12 +65,10 @@ export function DragHandle({
   onMoveStart,
 }: DragHandleProps) {
   const {isHeld, moveProps} = useDragMove({
-    largeStep,
     onMove,
     onMoveEnd,
     onMoveStart,
     orientation,
-    step,
   });
 
   const cursor = getDragHandleCursor(

--- a/static/app/components/core/dragHandle/dragHandle.tsx
+++ b/static/app/components/core/dragHandle/dragHandle.tsx
@@ -7,7 +7,7 @@ import {useDragMove} from './useDragMove';
 
 export type Orientation = 'horizontal' | 'vertical';
 
-export type DragHandleAppearance = 'always' | 'hover';
+export type DragHandleVariant = 'solid' | 'ghost';
 
 export const DRAG_HANDLE_SIZE = 1;
 
@@ -45,14 +45,14 @@ export type DragHandleProps = {
   onMove: (delta: number) => void;
   orientation: Orientation;
   value: number;
-  appearance?: DragHandleAppearance;
+  variant?: DragHandleVariant;
   onKeyDown?: React.KeyboardEventHandler<HTMLElement>;
   onMoveEnd?: () => void;
   onMoveStart?: () => void;
 };
 
 export function DragHandle({
-  appearance = 'always',
+  variant = 'solid',
   isSizedFirst,
   max,
   min,
@@ -88,7 +88,7 @@ export function DragHandle({
           aria-valuemax={Number.isFinite(max) ? max : undefined}
           aria-valuemin={min}
           aria-valuenow={value}
-          data-appearance={appearance}
+          data-variant={variant}
           data-is-held={isHeld}
           data-orientation={orientation}
           role="separator"
@@ -159,9 +159,9 @@ const DragHandleLine = styled('div')<{$cursor: React.CSSProperties['cursor']}>`
     }
   }
 
-  &[data-appearance='hover'] {
+  &[data-variant='ghost'] {
     border-color: transparent;
-    transition: border-color ${p => p.theme.motion.smooth.slow} 0.1s;
+    transition: border-color ${p => p.theme.motion.smooth.slow};
 
     &:hover,
     &:focus-visible,

--- a/static/app/components/core/dragHandle/dragHandle.tsx
+++ b/static/app/components/core/dragHandle/dragHandle.tsx
@@ -52,12 +52,12 @@ export type DragHandleProps = {
 };
 
 export function DragHandle({
+  variant = 'solid',
   isSizedFirst,
   max,
   min,
   orientation,
   value,
-  variant = 'solid',
   onDoubleClick,
   onKeyDown,
   onMove,
@@ -88,9 +88,9 @@ export function DragHandle({
           aria-valuemax={Number.isFinite(max) ? max : undefined}
           aria-valuemin={min}
           aria-valuenow={value}
+          data-variant={variant}
           data-is-held={isHeld}
           data-orientation={orientation}
-          data-variant={variant}
           role="separator"
           tabIndex={0}
         />

--- a/static/app/components/core/dragHandle/dragHandle.tsx
+++ b/static/app/components/core/dragHandle/dragHandle.tsx
@@ -45,19 +45,19 @@ export type DragHandleProps = {
   onMove: (delta: number) => void;
   orientation: Orientation;
   value: number;
-  variant?: DragHandleVariant;
   onKeyDown?: React.KeyboardEventHandler<HTMLElement>;
   onMoveEnd?: () => void;
   onMoveStart?: () => void;
+  variant?: DragHandleVariant;
 };
 
 export function DragHandle({
-  variant = 'solid',
   isSizedFirst,
   max,
   min,
   orientation,
   value,
+  variant = 'solid',
   onDoubleClick,
   onKeyDown,
   onMove,
@@ -88,9 +88,9 @@ export function DragHandle({
           aria-valuemax={Number.isFinite(max) ? max : undefined}
           aria-valuemin={min}
           aria-valuenow={value}
-          data-variant={variant}
           data-is-held={isHeld}
           data-orientation={orientation}
+          data-variant={variant}
           role="separator"
           tabIndex={0}
         />

--- a/static/app/components/core/dragHandle/dragHandle.tsx
+++ b/static/app/components/core/dragHandle/dragHandle.tsx
@@ -11,6 +11,13 @@ export type DragHandleVariant = 'solid' | 'ghost';
 
 export const DRAG_HANDLE_SIZE = 1;
 
+/** The 24x24 CSS pixel minimum that WCAG 2.5.8 asks of a pointer target. */
+export const DRAG_SEPARATOR_TARGET_SIZE = 24;
+
+const targetLength = 'var(--drag-separator-target-length, none)';
+
+const targetOffset = `calc(50% - ${DRAG_SEPARATOR_TARGET_SIZE / 2}px)`;
+
 /**
  * A focusable `separator` is a widget, so it needs a name, or it is announced as a bare
  * value with no subject. Prefer `aria-labelledby` when the handle sits inside an element
@@ -79,13 +86,15 @@ export function DragHandle({
 const DragHandleLine = styled('div')<{$cursor: React.CSSProperties['cursor']}>`
   user-select: none;
   touch-action: none;
-  cursor: ${p => p.$cursor};
+  pointer-events: none;
 
-  /* Invisible wider hit area for dragging */
+  /* Invisible wider hit area for dragging, and the only part that takes pointer events */
   &::before {
     content: '';
     position: absolute;
     z-index: ${p => p.theme.zIndex.drawer};
+    pointer-events: auto;
+    cursor: ${p => p.$cursor};
   }
 
   /* Accent bar that lights up on hover/drag */
@@ -110,8 +119,9 @@ const DragHandleLine = styled('div')<{$cursor: React.CSSProperties['cursor']}>`
     border-left: 1px solid ${p => p.theme.tokens.border.primary};
 
     &::before {
-      inset: 0 auto 0 -5px;
-      width: 11px;
+      inset: 0 auto 0 ${targetOffset};
+      width: ${DRAG_SEPARATOR_TARGET_SIZE}px;
+      max-height: ${targetLength};
     }
 
     &::after {
@@ -126,8 +136,9 @@ const DragHandleLine = styled('div')<{$cursor: React.CSSProperties['cursor']}>`
     border-top: 1px solid ${p => p.theme.tokens.border.primary};
 
     &::before {
-      inset: -5px 0 auto 0;
-      height: 11px;
+      inset: ${targetOffset} 0 auto 0;
+      height: ${DRAG_SEPARATOR_TARGET_SIZE}px;
+      max-width: ${targetLength};
     }
 
     &::after {

--- a/static/app/components/core/dragHandle/dragHandle.tsx
+++ b/static/app/components/core/dragHandle/dragHandle.tsx
@@ -1,6 +1,9 @@
 import styled from '@emotion/styled';
+import {mergeProps} from '@react-aria/utils';
 
 import {Container} from '@sentry/scraps/layout';
+
+import {useDragMove} from './useDragMove';
 
 export type Orientation = 'horizontal' | 'vertical';
 
@@ -35,28 +38,45 @@ function getDragHandleCursor(
 }
 
 export type DragHandleProps = {
-  isHeld: boolean;
   isSizedFirst: boolean;
   max: number;
   min: number;
   onDoubleClick: React.MouseEventHandler<HTMLElement>;
-  onKeyDown: React.KeyboardEventHandler<HTMLElement>;
-  onPointerDown: React.PointerEventHandler<HTMLElement>;
+  onMove: (delta: number) => void;
   orientation: Orientation;
   value: number;
+  appearance?: 'always' | 'hover';
+  largeStep?: number;
+  onKeyDown?: React.KeyboardEventHandler<HTMLElement>;
+  onMoveEnd?: () => void;
+  onMoveStart?: () => void;
+  step?: number;
 };
 
 export function DragHandle({
-  isHeld,
+  appearance = 'always',
   isSizedFirst,
+  largeStep,
   max,
   min,
   orientation,
+  step,
   value,
   onDoubleClick,
   onKeyDown,
-  onPointerDown,
+  onMove,
+  onMoveEnd,
+  onMoveStart,
 }: DragHandleProps) {
+  const {isHeld, moveProps} = useDragMove({
+    largeStep,
+    onMove,
+    onMoveEnd,
+    onMoveStart,
+    orientation,
+    step,
+  });
+
   const cursor = getDragHandleCursor(
     orientation,
     value <= min,
@@ -68,17 +88,15 @@ export function DragHandle({
     <Container position="relative" flexShrink={0}>
       {containerProps => (
         <DragHandleLine
-          {...containerProps}
+          {...mergeProps(moveProps, containerProps, {onDoubleClick, onKeyDown})}
           $cursor={cursor}
           aria-orientation={orientation === 'horizontal' ? 'vertical' : 'horizontal'}
           aria-valuemax={Number.isFinite(max) ? max : undefined}
           aria-valuemin={min}
           aria-valuenow={value}
+          data-appearance={appearance}
           data-is-held={isHeld}
           data-orientation={orientation}
-          onDoubleClick={onDoubleClick}
-          onKeyDown={onKeyDown}
-          onPointerDown={onPointerDown}
           role="separator"
           tabIndex={0}
         />
@@ -144,6 +162,17 @@ const DragHandleLine = styled('div')<{$cursor: React.CSSProperties['cursor']}>`
     &::after {
       inset: -2px 0 auto 0;
       height: 4px;
+    }
+  }
+
+  &[data-appearance='hover'] {
+    border-color: transparent;
+    transition: border-color ${p => p.theme.motion.smooth.slow} 0.1s;
+
+    &:hover,
+    &:focus-visible,
+    &[data-is-held='true'] {
+      border-color: ${p => p.theme.tokens.border.primary};
     }
   }
 

--- a/static/app/components/core/dragHandle/index.tsx
+++ b/static/app/components/core/dragHandle/index.tsx
@@ -1,2 +1,2 @@
-export {DragHandle, type DragHandleAppearance, DRAG_HANDLE_SIZE} from './dragHandle';
+export {DragHandle, type DragHandleVariant, DRAG_HANDLE_SIZE} from './dragHandle';
 export {useDragMove} from './useDragMove';

--- a/static/app/components/core/dragHandle/index.tsx
+++ b/static/app/components/core/dragHandle/index.tsx
@@ -1,2 +1,2 @@
-export {DragHandle, DRAG_HANDLE_SIZE} from './dragHandle';
+export {DragHandle, type DragHandleAppearance, DRAG_HANDLE_SIZE} from './dragHandle';
 export {useDragMove} from './useDragMove';

--- a/static/app/components/core/dragHandle/index.tsx
+++ b/static/app/components/core/dragHandle/index.tsx
@@ -1,3 +1,8 @@
-export {DragHandle, type DragHandleVariant, DRAG_HANDLE_SIZE} from './dragHandle';
+export {
+  DragHandle,
+  type DragHandleVariant,
+  DRAG_HANDLE_SIZE,
+  DRAG_SEPARATOR_TARGET_SIZE,
+} from './dragHandle';
 export {useDragMove} from './useDragMove';
 export {useDragSeparator} from './useDragSeparator';

--- a/static/app/components/core/dragHandle/index.tsx
+++ b/static/app/components/core/dragHandle/index.tsx
@@ -1,1 +1,2 @@
 export {DragHandle, DRAG_HANDLE_SIZE} from './dragHandle';
+export {useDragMove} from './useDragMove';

--- a/static/app/components/core/dragHandle/index.tsx
+++ b/static/app/components/core/dragHandle/index.tsx
@@ -1,2 +1,3 @@
 export {DragHandle, type DragHandleVariant, DRAG_HANDLE_SIZE} from './dragHandle';
 export {useDragMove} from './useDragMove';
+export {useDragSeparator} from './useDragSeparator';

--- a/static/app/components/core/dragHandle/useDragMove.spec.tsx
+++ b/static/app/components/core/dragHandle/useDragMove.spec.tsx
@@ -3,8 +3,19 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {useDragMove} from '@sentry/scraps/dragHandle';
 
-function TestHandle({onMove = jest.fn()}: {onMove?: (delta: number) => void}) {
-  const {isHeld, moveProps} = useDragMove({onMove, orientation: 'horizontal'});
+interface TestHandleProps {
+  onMove?: (delta: number) => void;
+  onMoveEnd?: () => void;
+  onMoveStart?: () => void;
+}
+
+function TestHandle({onMove = jest.fn(), onMoveEnd, onMoveStart}: TestHandleProps) {
+  const {isHeld, moveProps} = useDragMove({
+    onMove,
+    onMoveEnd,
+    onMoveStart,
+    orientation: 'horizontal',
+  });
 
   return <div {...moveProps} data-is-held={isHeld} data-test-id="handle" tabIndex={0} />;
 }
@@ -40,12 +51,18 @@ describe('useDragMove', () => {
 
   it('ignores arrow keys across the drag axis', async () => {
     const onMove = jest.fn();
-    render(<TestHandle onMove={onMove} />);
+    const onMoveEnd = jest.fn();
+    const onMoveStart = jest.fn();
+    render(
+      <TestHandle onMove={onMove} onMoveEnd={onMoveEnd} onMoveStart={onMoveStart} />
+    );
 
     await userEvent.tab();
     await userEvent.keyboard('{ArrowDown}');
 
+    expect(onMoveStart).not.toHaveBeenCalled();
     expect(onMove).not.toHaveBeenCalled();
+    expect(onMoveEnd).not.toHaveBeenCalled();
   });
 
   it('suppresses hover and selection on the document while dragging', () => {

--- a/static/app/components/core/dragHandle/useDragMove.spec.tsx
+++ b/static/app/components/core/dragHandle/useDragMove.spec.tsx
@@ -1,0 +1,75 @@
+import {dragHandle} from 'sentry-test/dragMove';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {useDragMove} from '@sentry/scraps/dragHandle';
+
+function TestHandle({onMove = jest.fn()}: {onMove?: (delta: number) => void}) {
+  const {isHeld, moveProps} = useDragMove({onMove, orientation: 'horizontal'});
+
+  return <div {...moveProps} data-is-held={isHeld} data-test-id="handle" tabIndex={0} />;
+}
+
+const handle = () => screen.getByTestId('handle');
+
+describe('useDragMove', () => {
+  it('reports the distance dragged along the axis', () => {
+    const onMove = jest.fn();
+    render(<TestHandle onMove={onMove} />);
+
+    dragHandle(handle(), {from: 100, to: 160});
+
+    expect(onMove).toHaveBeenCalledWith(60);
+  });
+
+  it.each([
+    {name: 'steps by 10 when arrowed', keys: '{ArrowRight}', expected: 10},
+    {
+      name: 'steps by 50 when shift is held',
+      keys: '{Shift>}{ArrowRight}{/Shift}',
+      expected: 50,
+    },
+  ])('$name', async ({keys, expected}) => {
+    const onMove = jest.fn();
+    render(<TestHandle onMove={onMove} />);
+
+    await userEvent.tab();
+    await userEvent.keyboard(keys);
+
+    expect(onMove).toHaveBeenCalledWith(expected);
+  });
+
+  it('ignores arrow keys across the drag axis', async () => {
+    const onMove = jest.fn();
+    render(<TestHandle onMove={onMove} />);
+
+    await userEvent.tab();
+    await userEvent.keyboard('{ArrowDown}');
+
+    expect(onMove).not.toHaveBeenCalled();
+  });
+
+  it('suppresses hover and selection on the document while dragging', () => {
+    render(<TestHandle />);
+
+    dragHandle(handle(), {from: 100, to: 160, release: false});
+
+    expect(document.body).toHaveStyle({pointerEvents: 'none'});
+  });
+
+  it('restores the document once the drag ends', () => {
+    render(<TestHandle />);
+
+    dragHandle(handle(), {from: 100, to: 160});
+
+    expect(document.body).toHaveStyle({pointerEvents: ''});
+  });
+
+  it('restores the document when unmounted mid-drag', () => {
+    const {unmount} = render(<TestHandle />);
+
+    dragHandle(handle(), {from: 100, to: 160, release: false});
+    unmount();
+
+    expect(document.body).toHaveStyle({pointerEvents: ''});
+  });
+});

--- a/static/app/components/core/dragHandle/useDragMove.tsx
+++ b/static/app/components/core/dragHandle/useDragMove.tsx
@@ -12,19 +12,15 @@ const KEYBOARD_STEP_LARGE = 50;
 interface UseDragMoveOptions {
   onMove: (delta: number) => void;
   orientation: Orientation;
-  largeStep?: number;
   onMoveEnd?: () => void;
   onMoveStart?: () => void;
-  step?: number;
 }
 
 export function useDragMove({
-  largeStep = KEYBOARD_STEP_LARGE,
   onMove,
   onMoveEnd,
   onMoveStart,
   orientation,
-  step = KEYBOARD_STEP,
 }: UseDragMoveOptions) {
   const [isHeld, setIsHeld] = useState(false);
   const isPointerDragRef = useRef(false);
@@ -58,7 +54,7 @@ export function useDragMove({
 
       onMove(
         event.pointerType === 'keyboard'
-          ? Math.sign(delta) * (event.shiftKey ? largeStep : step)
+          ? Math.sign(delta) * (event.shiftKey ? KEYBOARD_STEP_LARGE : KEYBOARD_STEP)
           : delta
       );
     },

--- a/static/app/components/core/dragHandle/useDragMove.tsx
+++ b/static/app/components/core/dragHandle/useDragMove.tsx
@@ -1,6 +1,8 @@
 import {useCallback, useEffect, useRef, useState} from 'react';
 import {useMove} from '@react-aria/interactions';
 
+import {setDocumentDragging} from 'sentry/utils/setDocumentDragging';
+
 import type {Orientation} from './dragHandle';
 
 const KEYBOARD_STEP = 10;
@@ -14,12 +16,6 @@ interface UseDragMoveOptions {
   onMoveEnd?: () => void;
   onMoveStart?: () => void;
   step?: number;
-}
-
-function setDocumentDragging(isDragging: boolean, cursor: string) {
-  document.body.style.pointerEvents = isDragging ? 'none' : '';
-  document.body.style.userSelect = isDragging ? 'none' : '';
-  document.documentElement.style.cursor = isDragging ? cursor : '';
 }
 
 export function useDragMove({
@@ -36,7 +32,7 @@ export function useDragMove({
   const stopDocumentDragging = useCallback(() => {
     if (isPointerDragRef.current) {
       isPointerDragRef.current = false;
-      setDocumentDragging(false, '');
+      setDocumentDragging(null);
     }
   }, []);
 
@@ -48,10 +44,7 @@ export function useDragMove({
 
       if (event.pointerType !== 'keyboard') {
         isPointerDragRef.current = true;
-        setDocumentDragging(
-          true,
-          orientation === 'horizontal' ? 'ew-resize' : 'ns-resize'
-        );
+        setDocumentDragging(orientation === 'horizontal' ? 'ew-resize' : 'ns-resize');
       }
 
       onMoveStart?.();

--- a/static/app/components/core/dragHandle/useDragMove.tsx
+++ b/static/app/components/core/dragHandle/useDragMove.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useRef, useState} from 'react';
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {useMove} from '@react-aria/interactions';
 
 import {setDocumentDragging} from 'sentry/utils/setDocumentDragging';
@@ -8,6 +8,11 @@ import type {Orientation} from './dragHandle';
 const KEYBOARD_STEP = 10;
 
 const KEYBOARD_STEP_LARGE = 50;
+
+const AXIS_KEYS: Record<Orientation, Set<string>> = {
+  horizontal: new Set(['ArrowLeft', 'ArrowRight', 'Left', 'Right']),
+  vertical: new Set(['ArrowUp', 'ArrowDown', 'Up', 'Down']),
+};
 
 interface UseDragMoveOptions {
   onMove: (delta: number) => void;
@@ -65,5 +70,19 @@ export function useDragMove({
     },
   });
 
-  return {isHeld, moveProps};
+  // useMove counts a key across the axis as a move, so it would start and end a move
+  // this hook then drops, leaving a consumer to commit a size that never changed.
+  const axisMoveProps = useMemo(
+    () => ({
+      ...moveProps,
+      onKeyDown: (event: React.KeyboardEvent<HTMLElement>) => {
+        if (AXIS_KEYS[orientation].has(event.key)) {
+          moveProps.onKeyDown?.(event);
+        }
+      },
+    }),
+    [moveProps, orientation]
+  );
+
+  return {isHeld, moveProps: axisMoveProps};
 }

--- a/static/app/components/core/dragHandle/useDragMove.tsx
+++ b/static/app/components/core/dragHandle/useDragMove.tsx
@@ -1,0 +1,80 @@
+import {useCallback, useEffect, useRef, useState} from 'react';
+import {useMove} from '@react-aria/interactions';
+
+import type {Orientation} from './dragHandle';
+
+const KEYBOARD_STEP = 10;
+
+const KEYBOARD_STEP_LARGE = 50;
+
+interface UseDragMoveOptions {
+  onMove: (delta: number) => void;
+  orientation: Orientation;
+  largeStep?: number;
+  onMoveEnd?: () => void;
+  onMoveStart?: () => void;
+  step?: number;
+}
+
+function setDocumentDragging(isDragging: boolean, cursor: string) {
+  document.body.style.pointerEvents = isDragging ? 'none' : '';
+  document.body.style.userSelect = isDragging ? 'none' : '';
+  document.documentElement.style.cursor = isDragging ? cursor : '';
+}
+
+export function useDragMove({
+  largeStep = KEYBOARD_STEP_LARGE,
+  onMove,
+  onMoveEnd,
+  onMoveStart,
+  orientation,
+  step = KEYBOARD_STEP,
+}: UseDragMoveOptions) {
+  const [isHeld, setIsHeld] = useState(false);
+  const isPointerDragRef = useRef(false);
+
+  const stopDocumentDragging = useCallback(() => {
+    if (isPointerDragRef.current) {
+      isPointerDragRef.current = false;
+      setDocumentDragging(false, '');
+    }
+  }, []);
+
+  useEffect(() => stopDocumentDragging, [stopDocumentDragging]);
+
+  const {moveProps} = useMove({
+    onMoveStart: event => {
+      setIsHeld(true);
+
+      if (event.pointerType !== 'keyboard') {
+        isPointerDragRef.current = true;
+        setDocumentDragging(
+          true,
+          orientation === 'horizontal' ? 'ew-resize' : 'ns-resize'
+        );
+      }
+
+      onMoveStart?.();
+    },
+    onMove: event => {
+      const delta = orientation === 'horizontal' ? event.deltaX : event.deltaY;
+
+      if (!delta) {
+        return;
+      }
+
+      onMove(
+        event.pointerType === 'keyboard'
+          ? Math.sign(delta) * (event.shiftKey ? largeStep : step)
+          : delta
+      );
+    },
+    onMoveEnd: () => {
+      setIsHeld(false);
+      stopDocumentDragging();
+      onMoveEnd?.();
+    },
+  });
+
+  return {isHeld, moveProps};
+}

--- a/static/app/components/core/dragHandle/useDragSeparator.spec.tsx
+++ b/static/app/components/core/dragHandle/useDragSeparator.spec.tsx
@@ -39,6 +39,7 @@ describe('useDragSeparator', () => {
   it('announces the size against its bounds', () => {
     render(<TestSeparator max={200} min={50} value={120} />);
 
+    // https://github.com/testing-library/jest-dom/issues/735
     // eslint-disable-next-line jest-dom/prefer-to-have-value
     expect(separator()).toHaveAttribute('aria-valuenow', '120');
     expect(separator()).toHaveAttribute('aria-valuemin', '50');

--- a/static/app/components/core/dragHandle/useDragSeparator.spec.tsx
+++ b/static/app/components/core/dragHandle/useDragSeparator.spec.tsx
@@ -1,0 +1,114 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {useDragSeparator} from '@sentry/scraps/dragHandle';
+
+type Options = Parameters<typeof useDragSeparator>[0];
+
+function TestSeparator(props: Partial<Options>) {
+  const {cursor, separatorProps} = useDragSeparator({
+    isSizedFirst: true,
+    onMove: jest.fn(),
+    orientation: 'horizontal',
+    ...props,
+  });
+
+  return <div {...separatorProps} aria-label="Handle" data-cursor={cursor} />;
+}
+
+const separator = () => screen.getByRole('separator');
+
+describe('useDragSeparator', () => {
+  it('exposes the handle as a focusable separator', () => {
+    render(<TestSeparator />);
+
+    expect(separator()).toHaveAttribute('tabindex', '0');
+  });
+
+  it('reports the axis across which it divides when horizontal', () => {
+    render(<TestSeparator orientation="horizontal" />);
+
+    expect(separator()).toHaveAttribute('aria-orientation', 'vertical');
+  });
+
+  it('reports the axis across which it divides when vertical', () => {
+    render(<TestSeparator orientation="vertical" />);
+
+    expect(separator()).toHaveAttribute('aria-orientation', 'horizontal');
+  });
+
+  it('announces the size against its bounds', () => {
+    render(<TestSeparator max={200} min={50} value={120} />);
+
+    // eslint-disable-next-line jest-dom/prefer-to-have-value
+    expect(separator()).toHaveAttribute('aria-valuenow', '120');
+    expect(separator()).toHaveAttribute('aria-valuemin', '50');
+    expect(separator()).toHaveAttribute('aria-valuemax', '200');
+  });
+
+  it('omits the upper bound when the size is unbounded', () => {
+    render(<TestSeparator max={Infinity} min={50} value={120} />);
+
+    expect(separator()).not.toHaveAttribute('aria-valuemax');
+  });
+
+  it('omits the values before the size has been measured', () => {
+    render(<TestSeparator />);
+
+    expect(separator()).not.toHaveAttribute('aria-valuenow');
+    expect(separator()).not.toHaveAttribute('aria-valuemin');
+    expect(separator()).not.toHaveAttribute('aria-valuemax');
+  });
+
+  it('is not held before a drag starts', () => {
+    render(<TestSeparator />);
+
+    expect(separator()).toHaveAttribute('data-is-held', 'false');
+  });
+
+  it.each([
+    {
+      name: 'points along the axis between the bounds',
+      props: {max: 200, min: 50, value: 120},
+      expected: 'ew-resize',
+    },
+    {
+      name: 'points back toward growth at the minimum',
+      props: {max: 200, min: 50, value: 50},
+      expected: 'e-resize',
+    },
+    {
+      name: 'points back toward shrinking at the maximum',
+      props: {max: 200, min: 50, value: 200},
+      expected: 'w-resize',
+    },
+    {
+      name: 'flips at the minimum when the sized pane is last',
+      props: {isSizedFirst: false, max: 200, min: 50, value: 50},
+      expected: 'w-resize',
+    },
+    {
+      name: 'flips at the maximum when the sized pane is last',
+      props: {isSizedFirst: false, max: 200, min: 50, value: 200},
+      expected: 'e-resize',
+    },
+    {
+      name: 'points along the vertical axis between the bounds',
+      props: {max: 200, min: 50, orientation: 'vertical' as const, value: 120},
+      expected: 'ns-resize',
+    },
+    {
+      name: 'points back toward growth at the vertical minimum',
+      props: {max: 200, min: 50, orientation: 'vertical' as const, value: 50},
+      expected: 's-resize',
+    },
+    {
+      name: 'ignores the limits until the size is measured',
+      props: {min: 50},
+      expected: 'ew-resize',
+    },
+  ])('$name', ({props, expected}) => {
+    render(<TestSeparator {...props} />);
+
+    expect(separator()).toHaveAttribute('data-cursor', expected);
+  });
+});

--- a/static/app/components/core/dragHandle/useDragSeparator.tsx
+++ b/static/app/components/core/dragHandle/useDragSeparator.tsx
@@ -1,0 +1,76 @@
+import {mergeProps} from '@react-aria/utils';
+
+import type {Orientation} from './dragHandle';
+import {useDragMove} from './useDragMove';
+
+// At a limit the handle can only travel one way, so point the cursor that way;
+// the grow/shrink direction flips when the sized pane sits after the handle.
+function getDragSeparatorCursor(
+  orientation: Orientation,
+  atMin: boolean,
+  atMax: boolean,
+  isSizedFirst: boolean
+): React.CSSProperties['cursor'] {
+  if (orientation === 'horizontal') {
+    if (atMin) {
+      return isSizedFirst ? 'e-resize' : 'w-resize';
+    }
+    if (atMax) {
+      return isSizedFirst ? 'w-resize' : 'e-resize';
+    }
+    return 'ew-resize';
+  }
+  if (atMin) {
+    return isSizedFirst ? 's-resize' : 'n-resize';
+  }
+  if (atMax) {
+    return isSizedFirst ? 'n-resize' : 's-resize';
+  }
+  return 'ns-resize';
+}
+
+interface UseDragSeparatorOptions {
+  isSizedFirst: boolean;
+  onMove: (delta: number) => void;
+  orientation: Orientation;
+  max?: number;
+  min?: number;
+  onMoveEnd?: () => void;
+  onMoveStart?: () => void;
+  value?: number;
+}
+
+export function useDragSeparator({
+  isSizedFirst,
+  max,
+  min,
+  onMove,
+  onMoveEnd,
+  onMoveStart,
+  orientation,
+  value,
+}: UseDragSeparatorOptions) {
+  const {isHeld, moveProps} = useDragMove({onMove, onMoveEnd, onMoveStart, orientation});
+
+  const hasMax = max !== undefined && Number.isFinite(max);
+  const cursor = getDragSeparatorCursor(
+    orientation,
+    min !== undefined && value !== undefined && value <= min,
+    hasMax && value !== undefined && value >= max,
+    isSizedFirst
+  );
+
+  return {
+    cursor,
+    separatorProps: mergeProps(moveProps, {
+      'aria-orientation': orientation === 'horizontal' ? 'vertical' : 'horizontal',
+      'aria-valuemax': hasMax ? max : undefined,
+      'aria-valuemin': min,
+      'aria-valuenow': value,
+      'data-is-held': isHeld,
+      'data-orientation': orientation,
+      role: 'separator',
+      tabIndex: 0,
+    }),
+  };
+}

--- a/static/app/components/core/splitPanel/splitPanel.spec.tsx
+++ b/static/app/components/core/splitPanel/splitPanel.spec.tsx
@@ -1,5 +1,6 @@
 import {createRef} from 'react';
 
+import {dragHandle} from 'sentry-test/dragMove';
 import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {SplitPanel, type SplitPanelHandle} from '@sentry/scraps/splitPanel';
@@ -347,17 +348,10 @@ describe('SplitPanel', () => {
       );
 
       const separator = screen.getByRole('separator');
-      await userEvent.pointer([
-        {keys: '[MouseLeft>]', target: separator, coords: {x: 200, y: 0}},
-        {target: separator, coords: {x: 150, y: 0}},
-      ]);
+      dragHandle(separator, {from: 200, to: 150});
+
       // eslint-disable-next-line jest-dom/prefer-to-have-value
       await waitFor(() => expect(separator).toHaveAttribute('aria-valuenow', '150'));
-
-      act(() => {
-        document.dispatchEvent(new MouseEvent('pointerup', {bubbles: true}));
-      });
-
       await waitFor(() =>
         expect(onResizeEnd).toHaveBeenCalledWith({
           startSize: 200,

--- a/static/app/components/core/splitPanel/splitPanel.spec.tsx
+++ b/static/app/components/core/splitPanel/splitPanel.spec.tsx
@@ -45,6 +45,7 @@ describe('SplitPanel', () => {
       />
     );
 
+    // https://github.com/testing-library/jest-dom/issues/735
     // eslint-disable-next-line jest-dom/prefer-to-have-value
     expect(screen.getByRole('separator')).toHaveAttribute('aria-valuenow', '100');
   });
@@ -101,6 +102,8 @@ describe('SplitPanel', () => {
     expect(separator).toHaveAttribute('aria-orientation', 'vertical');
     expect(separator).toHaveAttribute('aria-valuemin', '100');
     expect(separator).toHaveAttribute('aria-valuemax', '600');
+
+    // https://github.com/testing-library/jest-dom/issues/735
     // eslint-disable-next-line jest-dom/prefer-to-have-value
     expect(separator).toHaveAttribute('aria-valuenow', '200');
     expect(separator).toHaveAttribute('tabindex', '0');
@@ -120,12 +123,14 @@ describe('SplitPanel', () => {
       />
     );
 
+    // https://github.com/testing-library/jest-dom/issues/735
     // eslint-disable-next-line jest-dom/prefer-to-have-value
     expect(screen.getByRole('separator')).toHaveAttribute('aria-valuenow', '200');
 
     // Lets a parent seed the size from a post-mount measurement without a remount.
     act(() => ref.current?.setSize(350));
 
+    // https://github.com/testing-library/jest-dom/issues/735
     // eslint-disable-next-line jest-dom/prefer-to-have-value
     expect(screen.getByRole('separator')).toHaveAttribute('aria-valuenow', '350');
   });
@@ -192,12 +197,16 @@ describe('SplitPanel', () => {
 
       const separator = screen.getByRole('separator');
       // `initialSize` seeds the starting value.
+
+      // https://github.com/testing-library/jest-dom/issues/735
       // eslint-disable-next-line jest-dom/prefer-to-have-value
       expect(separator).toHaveAttribute('aria-valuenow', '400');
 
       await userEvent.dblClick(separator);
 
       // Resets to the canonical default and reports it so consumers can persist.
+
+      // https://github.com/testing-library/jest-dom/issues/735
       // eslint-disable-next-line jest-dom/prefer-to-have-value
       expect(separator).toHaveAttribute('aria-valuenow', '200');
       expect(onResizeEnd).toHaveBeenCalledWith({
@@ -223,6 +232,8 @@ describe('SplitPanel', () => {
 
       const separator = screen.getByRole('separator');
       // Renders floored at min, not the seeded -50.
+
+      // https://github.com/testing-library/jest-dom/issues/735
       // eslint-disable-next-line jest-dom/prefer-to-have-value
       expect(separator).toHaveAttribute('aria-valuenow', '100');
 
@@ -261,6 +272,8 @@ describe('SplitPanel', () => {
         endSize: 110,
         direction: 'increase',
       });
+
+      // https://github.com/testing-library/jest-dom/issues/735
       // eslint-disable-next-line jest-dom/prefer-to-have-value
       expect(separator).toHaveAttribute('aria-valuenow', '110');
     });
@@ -305,6 +318,7 @@ describe('SplitPanel', () => {
       // the container is measured, so it must not set an infinite size.
       await userEvent.keyboard('{Home}');
 
+      // https://github.com/testing-library/jest-dom/issues/735
       // eslint-disable-next-line jest-dom/prefer-to-have-value
       expect(separator).toHaveAttribute('aria-valuenow', '200');
       expect(onResizeEnd).not.toHaveBeenCalled();
@@ -350,6 +364,7 @@ describe('SplitPanel', () => {
       const separator = screen.getByRole('separator');
       dragHandle(separator, {from: 200, to: 150});
 
+      // https://github.com/testing-library/jest-dom/issues/735
       // eslint-disable-next-line jest-dom/prefer-to-have-value
       await waitFor(() => expect(separator).toHaveAttribute('aria-valuenow', '150'));
       await waitFor(() =>

--- a/static/app/components/core/splitPanel/splitPanel.tsx
+++ b/static/app/components/core/splitPanel/splitPanel.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useImperativeHandle, useRef} from 'react';
+import {useCallback, useImperativeHandle, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {DRAG_HANDLE_SIZE, DragHandle} from '@sentry/scraps/dragHandle';
@@ -111,13 +111,10 @@ export function SplitPanel({
     [onResizeEnd]
   );
 
-  const {
-    isHeld,
-    onPointerDown,
-    setSize,
-    size: containerSize,
-  } = useResizableDrawer({
-    // Flip the drag axis when the sized pane sits after the divider.
+  const [isHeld, setIsHeld] = useState(false);
+  const dragStateRef = useRef<{size: number; startSize: number} | null>(null);
+
+  const {setSize, size: containerSize} = useResizableDrawer({
     direction:
       orientation === 'horizontal'
         ? isSizedFirst
@@ -130,7 +127,6 @@ export function SplitPanel({
     min,
     max,
     onResize: newSize => onResize?.(newSize),
-    onResizeEnd: ({startSize, endSize}) => handleResizeEnd(startSize, endSize),
   });
 
   useImperativeHandle(ref, () => ({setSize}), [setSize]);
@@ -148,39 +144,46 @@ export function SplitPanel({
     handleResizeEnd(visibleSize, target);
   };
 
+  const handleMoveStart = () => {
+    dragStateRef.current = {size: visibleSize, startSize: visibleSize};
+    setIsHeld(true);
+  };
+
+  const handleMove = (delta: number) => {
+    const state = dragStateRef.current;
+    if (!state) {
+      return;
+    }
+
+    const sizeDelta = isSizedFirst ? delta : -delta;
+    state.size = Math.max(min, Math.min(max, state.size + sizeDelta));
+
+    setSize(Math.round(state.size), true);
+  };
+
+  const handleMoveEnd = () => {
+    const state = dragStateRef.current;
+    dragStateRef.current = null;
+    setIsHeld(false);
+
+    if (state) {
+      handleResizeEnd(state.startSize, Math.round(state.size));
+    }
+  };
+
   const handleKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
-    const step = event.shiftKey ? 50 : 10;
-    const isHorizontal = orientation === 'horizontal';
-    const towardStartKey = isHorizontal ? 'ArrowLeft' : 'ArrowUp';
-    const towardEndKey = isHorizontal ? 'ArrowRight' : 'ArrowDown';
-
-    // Keys map to physical separator direction; moving it toward `end` grows
-    // the sized pane only when it sits first, and shrinks it otherwise.
-    const growKey = isSizedFirst ? towardEndKey : towardStartKey;
-    const shrinkKey = isSizedFirst ? towardStartKey : towardEndKey;
-
-    // Step from the visible size so it still moves after the container shrank.
-    const current = visibleSize;
-
     let newSize: number | null = null;
-    if (event.key === shrinkKey) {
-      newSize = Math.max(min, current - step);
-    } else if (event.key === growKey) {
-      newSize = Math.min(max, current + step);
-    } else if (event.key === 'Home') {
-      // Separator to the start edge.
+    if (event.key === 'Home') {
       newSize = isSizedFirst ? min : max;
     } else if (event.key === 'End') {
-      // Separator to the end edge.
       newSize = isSizedFirst ? max : min;
     }
 
-    // Skip when the target is an unbounded max (not yet measured); min and
-    // stepped targets are always finite, so this only gates the edge keys.
+    // Skip when the target is an unbounded max (not yet measured).
     if (newSize !== null && Number.isFinite(newSize)) {
       event.preventDefault();
       setSize(newSize, true);
-      handleResizeEnd(current, newSize);
+      handleResizeEnd(visibleSize, newSize);
     }
   };
 
@@ -195,7 +198,6 @@ export function SplitPanel({
     panes.push(
       <DragHandle
         key="divider"
-        isHeld={isHeld}
         isSizedFirst={isSizedFirst}
         max={max}
         min={min}
@@ -203,7 +205,9 @@ export function SplitPanel({
         value={visibleSize}
         onDoubleClick={handleDoubleClick}
         onKeyDown={handleKeyDown}
-        onPointerDown={onPointerDown}
+        onMove={handleMove}
+        onMoveEnd={handleMoveEnd}
+        onMoveStart={handleMoveStart}
       />,
       <Pane key="fill" size={null}>
         {fill}

--- a/static/app/components/core/splitPanel/splitPanel.tsx
+++ b/static/app/components/core/splitPanel/splitPanel.tsx
@@ -5,6 +5,7 @@ import {DRAG_HANDLE_SIZE, DragHandle} from '@sentry/scraps/dragHandle';
 import {Flex, type Responsive, Stack} from '@sentry/scraps/layout';
 import {useResponsivePropValue} from '@sentry/scraps/layout/styles';
 
+import {t} from 'sentry/locale';
 import {useDimensions} from 'sentry/utils/useDimensions';
 import {useResizableDrawer} from 'sentry/utils/useResizableDrawer';
 
@@ -198,6 +199,7 @@ export function SplitPanel({
     panes.push(
       <DragHandle
         key="divider"
+        aria-label={t('Resize panels')}
         isSizedFirst={isSizedFirst}
         max={max}
         min={min}

--- a/static/app/components/core/table/__stories__/components.tsx
+++ b/static/app/components/core/table/__stories__/components.tsx
@@ -2,13 +2,19 @@ import styled from '@emotion/styled';
 
 import {Table, type TableColumnConfig} from '@sentry/scraps/table';
 
-const columns: TableColumnConfig[] = [
+interface Row {
+  browser: string;
+  count: number;
+  transaction: string;
+}
+
+const columns: Array<TableColumnConfig & {key: keyof Row}> = [
   {key: 'transaction', width: 260},
   {key: 'browser', width: 160},
   {key: 'count'},
 ];
 
-const data = [
+const data: Row[] = [
   {transaction: '/api/organizations/', browser: 'Chrome', count: 1284},
   {transaction: '/issues/', browser: 'Safari', count: 388},
 ];
@@ -29,9 +35,7 @@ export function OverviewDemo() {
         {data.map(row => (
           <Table.Row divider key={row.transaction}>
             {columns.map(column => (
-              <Table.Cell key={column.key}>
-                {row[column.key as keyof typeof row]}
-              </Table.Cell>
+              <Table.Cell key={column.key}>{row[column.key]}</Table.Cell>
             ))}
           </Table.Row>
         ))}
@@ -54,5 +58,6 @@ const StyledTable = styled(Table)`
   thead {
     background: ${p => p.theme.tokens.background.secondary};
     border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
+    border-radius: ${p => p.theme.radius.md} ${p => p.theme.radius.md} 0 0;
   }
 `;

--- a/static/app/components/core/table/__stories__/components.tsx
+++ b/static/app/components/core/table/__stories__/components.tsx
@@ -1,0 +1,58 @@
+import styled from '@emotion/styled';
+
+import {Table, type TableColumnConfig} from '@sentry/scraps/table';
+
+const columns: TableColumnConfig[] = [
+  {key: 'transaction', width: 260},
+  {key: 'browser', width: 160},
+  {key: 'count'},
+];
+
+const data = [
+  {transaction: '/api/organizations/', browser: 'Chrome', count: 1284},
+  {transaction: '/issues/', browser: 'Safari', count: 388},
+];
+
+export function OverviewDemo() {
+  return (
+    <StyledTable columns={columns}>
+      <Table.Head>
+        <Table.Row>
+          {columns.map(column => (
+            <Table.HeadCell column={column.key} key={column.key}>
+              {column.key}
+            </Table.HeadCell>
+          ))}
+        </Table.Row>
+      </Table.Head>
+      <Table.Body>
+        {data.map(row => (
+          <Table.Row divider key={row.transaction}>
+            {columns.map(column => (
+              <Table.Cell key={column.key}>
+                {row[column.key as keyof typeof row]}
+              </Table.Cell>
+            ))}
+          </Table.Row>
+        ))}
+      </Table.Body>
+    </StyledTable>
+  );
+}
+
+const StyledTable = styled(Table)`
+  border: 1px solid ${p => p.theme.tokens.border.primary};
+  border-radius: ${p => p.theme.radius.md};
+
+  th,
+  td {
+    display: flex;
+    align-items: center;
+    padding: ${p => p.theme.space.md} ${p => p.theme.space.xl};
+  }
+
+  thead {
+    background: ${p => p.theme.tokens.background.secondary};
+    border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
+  }
+`;

--- a/static/app/components/core/table/index.tsx
+++ b/static/app/components/core/table/index.tsx
@@ -1,1 +1,7 @@
-export {COL_WIDTH_UNDEFINED, Table, type TableColumnConfig} from './table';
+export {TABLE_HEAD_ROW_HEIGHT} from './styles';
+export {
+  COL_WIDTH_MINIMUM,
+  COL_WIDTH_UNDEFINED,
+  Table,
+  type TableColumnConfig,
+} from './table';

--- a/static/app/components/core/table/index.tsx
+++ b/static/app/components/core/table/index.tsx
@@ -1,0 +1,1 @@
+export {COL_WIDTH_UNDEFINED, Table, type TableColumnConfig} from './table';

--- a/static/app/components/core/table/styles.tsx
+++ b/static/app/components/core/table/styles.tsx
@@ -77,5 +77,6 @@ export const TableResizer = styled('div')`
   right: 0;
   display: flex;
   height: var(--column-resizer-height, ${TABLE_HEAD_ROW_HEIGHT}px);
+  pointer-events: none;
   z-index: ${Z_INDEX_RESIZER};
 `;

--- a/static/app/components/core/table/styles.tsx
+++ b/static/app/components/core/table/styles.tsx
@@ -1,0 +1,155 @@
+import type {CSSProperties} from 'react';
+import isPropValid from '@emotion/is-prop-valid';
+import {css} from '@emotion/react';
+import styled from '@emotion/styled';
+
+const TABLE_HEAD_ROW_HEIGHT = 45;
+
+const Z_INDEX_RESIZER = 1;
+
+const Z_INDEX_STICKY_HEAD = 2;
+
+export const TableGrid = styled('table')<{
+  definiteHeadRow?: boolean;
+  fit?: 'max-content';
+  height?: CSSProperties['height'];
+  scrollable?: boolean;
+}>`
+  position: inherit;
+  display: grid;
+
+  box-sizing: border-box;
+  border-collapse: collapse;
+  margin: 0;
+
+  ${p =>
+    p.scrollable &&
+    css`
+      overflow-x: auto;
+      overflow-y: scroll;
+    `}
+
+  ${p =>
+    p.height &&
+    css`
+      height: 100%;
+      max-height: ${typeof p.height === 'number' ? p.height + 'px' : p.height};
+      flex: 1;
+      min-height: 0;
+    `}
+
+  /* Pin the header to a definite track height; a content-based header track lets
+     Safari mis-size the <thead> on back/forward navigation. */
+  ${p =>
+    p.definiteHeadRow &&
+    css`
+      &:has(> thead + tbody) {
+        grid-template-rows: ${TABLE_HEAD_ROW_HEIGHT}px ${p.height ? '1fr' : 'auto'};
+      }
+
+      &:has(> thead + tbody + tbody) {
+        grid-template-rows: ${TABLE_HEAD_ROW_HEIGHT}px fit-content(100%) ${p.height
+            ? '1fr'
+            : 'auto'};
+      }
+    `}
+
+  min-width: ${p => p.fit};
+`;
+
+const subgrid = css`
+  display: grid;
+  grid-template-columns: subgrid;
+  grid-column: 1 / -1;
+`;
+
+export const TableHead = styled('thead')<{sticky?: boolean}>`
+  ${subgrid}
+
+  ${p =>
+    p.sticky &&
+    css`
+      position: sticky;
+      top: 0;
+      z-index: ${Z_INDEX_STICKY_HEAD};
+    `}
+`;
+
+export const TableBody = styled('tbody')`
+  ${subgrid}
+`;
+
+export const TableRow = styled('tr', {
+  shouldForwardProp: prop => prop !== 'divider' && isPropValid(prop),
+})<{divider?: boolean}>`
+  ${subgrid}
+  position: relative;
+
+  ${p =>
+    p.divider &&
+    css`
+      &:not(:last-child) {
+        border-bottom: 1px solid ${p.theme.tokens.border.secondary};
+      }
+    `}
+`;
+
+export const TableHeadCell = styled('th')`
+  position: relative;
+  min-width: 0;
+`;
+
+export const TableCell = styled('td')`
+  min-width: 0;
+`;
+
+export const TableStatusCell = styled('td')`
+  grid-column: 1 / -1;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const TableResizer = styled('div')`
+  position: absolute;
+  top: 0px;
+  right: -6px;
+  width: 11px;
+
+  height: var(--table-resizer-height, ${TABLE_HEAD_ROW_HEIGHT}px);
+
+  padding-left: 5px;
+  padding-right: 5px;
+
+  cursor: col-resize;
+  z-index: ${Z_INDEX_RESIZER};
+
+  &::after {
+    content: ' ';
+    display: block;
+    width: 100%; /* Equivalent to 1px */
+    height: 100%;
+  }
+
+  &:hover::after {
+    background-color: ${p => p.theme.colors.gray200};
+  }
+
+  &:active::after,
+  &:focus::after {
+    background-color: ${p => p.theme.tokens.focus.default};
+  }
+
+  &:hover::before {
+    position: absolute;
+    top: 0;
+    left: 2px;
+    content: ' ';
+    display: block;
+    width: 7px;
+    height: ${TABLE_HEAD_ROW_HEIGHT}px;
+    background-color: ${p => p.theme.tokens.graphics.accent.vibrant};
+    opacity: 0.4;
+  }
+`;

--- a/static/app/components/core/table/styles.tsx
+++ b/static/app/components/core/table/styles.tsx
@@ -76,6 +76,6 @@ export const TableResizer = styled('div')`
   top: 0;
   right: 0;
   display: flex;
-  height: var(--table-resizer-height, ${TABLE_HEAD_ROW_HEIGHT}px);
+  height: var(--column-resizer-height, ${TABLE_HEAD_ROW_HEIGHT}px);
   z-index: ${Z_INDEX_RESIZER};
 `;

--- a/static/app/components/core/table/styles.tsx
+++ b/static/app/components/core/table/styles.tsx
@@ -2,7 +2,7 @@ import isPropValid from '@emotion/is-prop-valid';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
-const TABLE_HEAD_ROW_HEIGHT = 45;
+export const TABLE_HEAD_ROW_HEIGHT = 45;
 
 const Z_INDEX_RESIZER = 1;
 

--- a/static/app/components/core/table/styles.tsx
+++ b/static/app/components/core/table/styles.tsx
@@ -1,4 +1,3 @@
-import type {CSSProperties} from 'react';
 import isPropValid from '@emotion/is-prop-valid';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -9,52 +8,13 @@ const Z_INDEX_RESIZER = 1;
 
 const Z_INDEX_STICKY_HEAD = 2;
 
-export const TableGrid = styled('table')<{
-  definiteHeadRow?: boolean;
-  fit?: 'max-content';
-  height?: CSSProperties['height'];
-  scrollable?: boolean;
-}>`
+export const TableGrid = styled('table')`
   position: inherit;
   display: grid;
 
   box-sizing: border-box;
   border-collapse: collapse;
   margin: 0;
-
-  ${p =>
-    p.scrollable &&
-    css`
-      overflow-x: auto;
-      overflow-y: scroll;
-    `}
-
-  ${p =>
-    p.height &&
-    css`
-      height: 100%;
-      max-height: ${typeof p.height === 'number' ? p.height + 'px' : p.height};
-      flex: 1;
-      min-height: 0;
-    `}
-
-  /* Pin the header to a definite track height; a content-based header track lets
-     Safari mis-size the <thead> on back/forward navigation. */
-  ${p =>
-    p.definiteHeadRow &&
-    css`
-      &:has(> thead + tbody) {
-        grid-template-rows: ${TABLE_HEAD_ROW_HEIGHT}px ${p.height ? '1fr' : 'auto'};
-      }
-
-      &:has(> thead + tbody + tbody) {
-        grid-template-rows: ${TABLE_HEAD_ROW_HEIGHT}px fit-content(100%) ${p.height
-            ? '1fr'
-            : 'auto'};
-      }
-    `}
-
-  min-width: ${p => p.fit};
 `;
 
 const subgrid = css`
@@ -113,43 +73,9 @@ export const TableStatusCell = styled('td')`
 
 export const TableResizer = styled('div')`
   position: absolute;
-  top: 0px;
-  right: -6px;
-  width: 11px;
-
+  top: 0;
+  right: 0;
+  display: flex;
   height: var(--table-resizer-height, ${TABLE_HEAD_ROW_HEIGHT}px);
-
-  padding-left: 5px;
-  padding-right: 5px;
-
-  cursor: col-resize;
   z-index: ${Z_INDEX_RESIZER};
-
-  &::after {
-    content: ' ';
-    display: block;
-    width: 100%; /* Equivalent to 1px */
-    height: 100%;
-  }
-
-  &:hover::after {
-    background-color: ${p => p.theme.colors.gray200};
-  }
-
-  &:active::after,
-  &:focus::after {
-    background-color: ${p => p.theme.tokens.focus.default};
-  }
-
-  &:hover::before {
-    position: absolute;
-    top: 0;
-    left: 2px;
-    content: ' ';
-    display: block;
-    width: 7px;
-    height: ${TABLE_HEAD_ROW_HEIGHT}px;
-    background-color: ${p => p.theme.tokens.graphics.accent.vibrant};
-    opacity: 0.4;
-  }
 `;

--- a/static/app/components/core/table/table.mdx
+++ b/static/app/components/core/table/table.mdx
@@ -1,0 +1,92 @@
+---
+title: Table
+description: A low-level table component that provides grid-based column tracks, subgrid rows, and column resizing.
+category: layout
+source: '@sentry/scraps/table'
+resources:
+  js: https://github.com/getsentry/sentry/blob/master/static/app/components/core/table/table.tsx
+---
+
+import * as Storybook from 'sentry/stories';
+
+import {OverviewDemo} from './__stories__/components';
+
+export const documentation = import('!!type-loader!@sentry/scraps/table');
+
+The `Table` component renders a `<table>` with `display: grid` and `grid-template-columns: subgrid`, so that every row shares one set of column tracks.
+It provides table geometry and column resizing only, without borders, padding, or empty and loading states.
+Higher level components like `SimpleTable` and `GridEditable` add those on top of it.
+
+## Basic Usage
+
+To create a table, pass a `columns` array and compose the contents with `Table.Head`, `Table.Body`, `Table.Row`, `Table.HeadCell`, and `Table.Cell`.
+Columns are passed as data rather than children because a resize needs a stable identity for each column.
+
+<Storybook.Demo>
+  <OverviewDemo />
+</Storybook.Demo>
+
+```jsx
+const columns = [
+  {key: 'transaction', width: 260},
+  {key: 'browser', width: 160},
+  {key: 'count'},
+];
+
+<Table columns={columns}>
+  <Table.Head>
+    <Table.Row>
+      {columns.map(column => (
+        <Table.HeadCell column={column.key} key={column.key}>
+          {column.key}
+        </Table.HeadCell>
+      ))}
+    </Table.Row>
+  </Table.Head>
+  <Table.Body>
+    {data.map(row => (
+      <Table.Row divider key={row.transaction}>
+        {columns.map(column => (
+          <Table.Cell key={column.key}>{row[column.key]}</Table.Cell>
+        ))}
+      </Table.Row>
+    ))}
+  </Table.Body>
+</Table>;
+```
+
+Drag the right edge of a header cell to resize that column, or double click it to reset the width.
+
+## Column Widths
+
+Set a column's `width` to a number of pixels or to any CSS track value.
+Omit it to size the column with `minmax(minimumColumnWidth, auto)`, and set `resizable: false` to stop a column from being resized.
+
+```jsx
+<Table
+  columns={[
+    {key: 'transaction', width: 260},
+    {key: 'browser', width: 'max-content', resizable: false},
+    {key: 'count'},
+  ]}
+>
+  ...
+</Table>
+```
+
+Widths are uncontrolled by default, and the component tracks them per column key.
+Pass `onColumnResize` to control them instead, which is how `GridEditable` persists widths to the URL.
+
+## Status Rows
+
+Use `Table.Status` to render a single cell that spans every column, for empty, loading, and error states.
+`Table.StatusBody` wraps it in its own `<tbody>` so that it can sit alongside the table body.
+
+```jsx
+<Table columns={columns}>
+  <Table.Head>...</Table.Head>
+  <Table.Body>
+    <Table.Status>No results found for your query</Table.Status>
+  </Table.Body>
+</Table>
+```

--- a/static/app/components/core/table/table.mdx
+++ b/static/app/components/core/table/table.mdx
@@ -21,6 +21,7 @@ Higher level components like `SimpleTable` and `GridEditable` add those on top o
 
 To create a table, pass a `columns` array and compose the contents with `Table.Head`, `Table.Body`, `Table.Row`, `Table.HeadCell`, and `Table.Cell`.
 Columns are passed as data rather than children because a resize needs a stable identity for each column.
+Identify each head cell with `column`, or with `columnIndex` when the cells come from an ordered list rather than a keyed config.
 
 <Storybook.Demo>
   <OverviewDemo />

--- a/static/app/components/core/table/table.mdx
+++ b/static/app/components/core/table/table.mdx
@@ -56,6 +56,7 @@ const columns = [
 ```
 
 Drag the right edge of a header cell to resize that column, or double click it to reset the width.
+Each handle is a focusable `DragHandle`, so it can also be tabbed to and resized with the left and right arrow keys.
 
 ## Column Widths
 

--- a/static/app/components/core/table/table.spec.tsx
+++ b/static/app/components/core/table/table.spec.tsx
@@ -1,0 +1,189 @@
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+  within,
+} from 'sentry-test/reactTestingLibrary';
+
+import {COL_WIDTH_UNDEFINED, Table, type TableColumnConfig} from '@sentry/scraps/table';
+
+const COLUMNS: TableColumnConfig[] = [
+  {key: 'name', width: 200},
+  {key: 'count', width: 150},
+  {key: 'age'},
+];
+
+function TestTable({
+  columns = COLUMNS,
+  ...props
+}: Partial<React.ComponentProps<typeof Table>>) {
+  return (
+    <Table columns={columns} {...props}>
+      <Table.Head>
+        <Table.Row>
+          {columns.map(column => (
+            <Table.HeadCell column={column.key} key={column.key}>
+              {column.key}
+            </Table.HeadCell>
+          ))}
+        </Table.Row>
+      </Table.Head>
+      <Table.Body>
+        <Table.Row>
+          {columns.map(column => (
+            <Table.Cell key={column.key}>{`${column.key}-value`}</Table.Cell>
+          ))}
+        </Table.Row>
+      </Table.Body>
+    </Table>
+  );
+}
+
+// jsdom reports offsetWidth as 0, so a dragged width equals the drag distance. The
+// whole gesture runs in one pointer() call so the held-button state stays coherent.
+function drag(resizer: HTMLElement, from: number, to: number) {
+  return userEvent.pointer([
+    {keys: '[MouseLeft>]', target: resizer, coords: {clientX: from}},
+    {coords: {clientX: to}},
+    {keys: '[/MouseLeft]', coords: {clientX: to}},
+  ]);
+}
+
+const gridTemplate = () => screen.getByRole('table').style.gridTemplateColumns;
+const resizers = () => screen.getAllByTestId('table-column-resizer');
+
+describe('Table', () => {
+  it('exposes table semantics when rendered', () => {
+    render(<TestTable />);
+
+    const table = screen.getByRole('table');
+    expect(within(table).getAllByRole('columnheader')).toHaveLength(3);
+    expect(within(table).getAllByRole('row')).toHaveLength(2);
+    expect(within(table).getAllByRole('cell')).toHaveLength(3);
+  });
+
+  it.each([
+    {
+      name: 'sizes declared widths and lets the last column absorb slack',
+      columns: COLUMNS,
+      expected: '200px 150px minmax(90px, auto)',
+    },
+    {
+      name: 'raises widths below the minimum up to the minimum',
+      columns: [{key: 'a', width: 10}, {key: 'b'}],
+      expected: '90px minmax(90px, auto)',
+    },
+    {
+      name: 'uses string widths verbatim',
+      columns: [{key: 'a', width: 'min-content'}, {key: 'b'}],
+      expected: 'min-content minmax(90px, auto)',
+    },
+  ])('$name', ({columns, expected}) => {
+    render(<TestTable columns={columns} />);
+
+    expect(gridTemplate()).toBe(expected);
+  });
+
+  it('pins the last column to its declared width when the last column is not flexible', () => {
+    render(<TestTable flexibleLastColumn={false} />);
+
+    expect(gridTemplate()).toBe('200px 150px minmax(90px, auto)');
+  });
+
+  it('restores the auto width of a non-flexible column when its handle is double-clicked', async () => {
+    render(
+      <TestTable
+        columns={[{key: 'a', width: 200}, {key: 'b'}]}
+        flexibleLastColumn={false}
+      />
+    );
+
+    await userEvent.dblClick(resizers()[0]!);
+
+    await waitFor(() =>
+      expect(gridTemplate()).toBe('minmax(90px, auto) minmax(90px, auto)')
+    );
+  });
+
+  it('prepends fixed tracks when given prependColumnWidths', () => {
+    render(<TestTable prependColumnWidths={['40px', 'min-content']} />);
+
+    expect(gridTemplate()).toBe('40px min-content 200px 150px minmax(90px, auto)');
+  });
+
+  it('renders a resize handle for every resizable column except the last', () => {
+    render(
+      <TestTable columns={[{key: 'a'}, {key: 'b', resizable: false}, {key: 'c'}]} />
+    );
+
+    expect(resizers()).toHaveLength(1);
+  });
+
+  it('writes the dragged width into the grid template while resizing', async () => {
+    render(<TestTable />);
+
+    await drag(resizers()[0]!, 100, 400);
+
+    await waitFor(() => expect(gridTemplate()).toBe('300px 150px minmax(90px, auto)'));
+  });
+
+  it('clamps a drag below the minimum width up to the minimum', async () => {
+    render(<TestTable />);
+
+    await drag(resizers()[0]!, 100, 110);
+
+    await waitFor(() => expect(gridTemplate()).toBe('90px 150px minmax(90px, auto)'));
+  });
+
+  it('reports the final width to onColumnResize when a drag ends', async () => {
+    const onColumnResize = jest.fn();
+    render(<TestTable onColumnResize={onColumnResize} />);
+
+    await drag(resizers()[1]!, 100, 350);
+
+    expect(onColumnResize).toHaveBeenCalledWith(1, 250);
+  });
+
+  it('retains the resized width when no onColumnResize is provided', async () => {
+    render(<TestTable />);
+
+    await drag(resizers()[0]!, 100, 400);
+    await waitFor(() => expect(gridTemplate()).toBe('300px 150px minmax(90px, auto)'));
+    await userEvent.click(screen.getByRole('table'));
+
+    expect(gridTemplate()).toBe('300px 150px minmax(90px, auto)');
+  });
+
+  it('restores the auto width when a resize handle is double-clicked', async () => {
+    render(<TestTable />);
+
+    await userEvent.dblClick(resizers()[0]!);
+
+    await waitFor(() =>
+      expect(gridTemplate()).toBe('minmax(90px, auto) 150px minmax(90px, auto)')
+    );
+  });
+
+  it('reports an undefined width to onColumnResize when a handle is double-clicked', async () => {
+    const onColumnResize = jest.fn();
+    render(<TestTable onColumnResize={onColumnResize} />);
+
+    await userEvent.dblClick(resizers()[0]!);
+
+    expect(onColumnResize).toHaveBeenCalledWith(0, COL_WIDTH_UNDEFINED);
+  });
+
+  it('leaves consumer-provided tracks alone when no columns are described', () => {
+    render(
+      <Table style={{gridTemplateColumns: '1fr 2fr'}}>
+        <Table.Body>
+          <Table.Status>No results</Table.Status>
+        </Table.Body>
+      </Table>
+    );
+
+    expect(gridTemplate()).toBe('1fr 2fr');
+    expect(screen.getByRole('cell')).toHaveTextContent('No results');
+  });
+});

--- a/static/app/components/core/table/table.spec.tsx
+++ b/static/app/components/core/table/table.spec.tsx
@@ -41,7 +41,6 @@ function TestTable({
   );
 }
 
-// jsdom reports offsetWidth as 0, so a dragged width equals the drag distance.
 const gridTemplate = () => screen.getByRole('table').style.gridTemplateColumns;
 const resizers = () => screen.getAllByRole('separator');
 

--- a/static/app/components/core/table/table.spec.tsx
+++ b/static/app/components/core/table/table.spec.tsx
@@ -187,6 +187,19 @@ describe('Table', () => {
     expect(resizers()[0]).toHaveAttribute('aria-orientation', 'vertical');
   });
 
+  it('names each resize handle after the column it resizes', () => {
+    render(<TestTable />);
+
+    expect(resizers()[0]).toHaveAccessibleName('name');
+    expect(resizers()[1]).toHaveAccessibleName('count');
+  });
+
+  it('leaves each header cell named by its own content', () => {
+    render(<TestTable />);
+
+    expect(screen.getAllByRole('columnheader')[0]).toHaveAccessibleName('name');
+  });
+
   it('commits a resize when a focused handle is arrowed', async () => {
     const onColumnResize = jest.fn();
     render(<TestTable onColumnResize={onColumnResize} />);

--- a/static/app/components/core/table/table.spec.tsx
+++ b/static/app/components/core/table/table.spec.tsx
@@ -86,9 +86,17 @@ describe('Table', () => {
   });
 
   it('pins the last column to its declared width when the last column is not flexible', () => {
-    render(<TestTable flexibleLastColumn={false} />);
+    render(
+      <TestTable
+        columns={[
+          {key: 'name', width: 200},
+          {key: 'count', width: 150},
+        ]}
+        flexibleLastColumn={false}
+      />
+    );
 
-    expect(gridTemplate()).toBe('200px 150px minmax(90px, auto)');
+    expect(gridTemplate()).toBe('200px 150px');
   });
 
   it('restores the auto width of a non-flexible column when its handle is double-clicked', async () => {

--- a/static/app/components/core/table/table.spec.tsx
+++ b/static/app/components/core/table/table.spec.tsx
@@ -135,7 +135,7 @@ describe('Table', () => {
     await waitFor(() => expect(gridTemplate()).toBe('90px 150px minmax(90px, auto)'));
   });
 
-  it('reports the final width to onColumnResize when a drag ends', async () => {
+  it('reports the final width to onColumnResize when a drag ends', () => {
     const onColumnResize = jest.fn();
     render(<TestTable onColumnResize={onColumnResize} />);
 
@@ -197,7 +197,7 @@ describe('Table', () => {
     expect(onColumnResize).toHaveBeenCalledWith(0, 90);
   });
 
-  it('does not commit a resize when a handle is right-clicked', async () => {
+  it('does not commit a resize when a handle is right-clicked', () => {
     const onColumnResize = jest.fn();
     render(<TestTable onColumnResize={onColumnResize} />);
 

--- a/static/app/components/core/table/table.spec.tsx
+++ b/static/app/components/core/table/table.spec.tsx
@@ -1,3 +1,4 @@
+import {dragHandle} from 'sentry-test/dragMove';
 import {
   render,
   screen,
@@ -40,18 +41,9 @@ function TestTable({
   );
 }
 
-// jsdom reports offsetWidth as 0, so a dragged width equals the drag distance. The
-// whole gesture runs in one pointer() call so the held-button state stays coherent.
-function drag(resizer: HTMLElement, from: number, to: number) {
-  return userEvent.pointer([
-    {keys: '[MouseLeft>]', target: resizer, coords: {clientX: from}},
-    {coords: {clientX: to}},
-    {keys: '[/MouseLeft]', coords: {clientX: to}},
-  ]);
-}
-
+// jsdom reports offsetWidth as 0, so a dragged width equals the drag distance.
 const gridTemplate = () => screen.getByRole('table').style.gridTemplateColumns;
-const resizers = () => screen.getAllByTestId('table-column-resizer');
+const resizers = () => screen.getAllByRole('separator');
 
 describe('Table', () => {
   it('exposes table semantics when rendered', () => {
@@ -131,7 +123,7 @@ describe('Table', () => {
   it('writes the dragged width into the grid template while resizing', async () => {
     render(<TestTable />);
 
-    await drag(resizers()[0]!, 100, 400);
+    dragHandle(resizers()[0]!, {from: 100, to: 400});
 
     await waitFor(() => expect(gridTemplate()).toBe('300px 150px minmax(90px, auto)'));
   });
@@ -139,7 +131,7 @@ describe('Table', () => {
   it('clamps a drag below the minimum width up to the minimum', async () => {
     render(<TestTable />);
 
-    await drag(resizers()[0]!, 100, 110);
+    dragHandle(resizers()[0]!, {from: 100, to: 110});
 
     await waitFor(() => expect(gridTemplate()).toBe('90px 150px minmax(90px, auto)'));
   });
@@ -148,7 +140,7 @@ describe('Table', () => {
     const onColumnResize = jest.fn();
     render(<TestTable onColumnResize={onColumnResize} />);
 
-    await drag(resizers()[1]!, 100, 350);
+    dragHandle(resizers()[1]!, {from: 100, to: 350});
 
     expect(onColumnResize).toHaveBeenCalledWith(1, 250);
   });
@@ -156,7 +148,7 @@ describe('Table', () => {
   it('retains the resized width when no onColumnResize is provided', async () => {
     render(<TestTable />);
 
-    await drag(resizers()[0]!, 100, 400);
+    dragHandle(resizers()[0]!, {from: 100, to: 400});
     await waitFor(() => expect(gridTemplate()).toBe('300px 150px minmax(90px, auto)'));
     await userEvent.click(screen.getByRole('table'));
 
@@ -180,6 +172,39 @@ describe('Table', () => {
     await userEvent.dblClick(resizers()[0]!);
 
     expect(onColumnResize).toHaveBeenCalledWith(0, COL_WIDTH_UNDEFINED);
+  });
+
+  it('places a resize handle in the tab order', async () => {
+    render(<TestTable />);
+
+    await userEvent.tab();
+
+    expect(resizers()[0]).toHaveFocus();
+  });
+
+  it('exposes a resize handle as a vertical separator', () => {
+    render(<TestTable />);
+
+    expect(resizers()[0]).toHaveAttribute('aria-orientation', 'vertical');
+  });
+
+  it('commits a resize when a focused handle is arrowed', async () => {
+    const onColumnResize = jest.fn();
+    render(<TestTable onColumnResize={onColumnResize} />);
+
+    await userEvent.tab();
+    await userEvent.keyboard('{ArrowRight}');
+
+    expect(onColumnResize).toHaveBeenCalledWith(0, 90);
+  });
+
+  it('does not commit a resize when a handle is right-clicked', async () => {
+    const onColumnResize = jest.fn();
+    render(<TestTable onColumnResize={onColumnResize} />);
+
+    dragHandle(resizers()[0]!, {button: 2, from: 100, to: 400});
+
+    expect(onColumnResize).not.toHaveBeenCalled();
   });
 
   it('leaves consumer-provided tracks alone when no columns are described', () => {

--- a/static/app/components/core/table/table.tsx
+++ b/static/app/components/core/table/table.tsx
@@ -227,7 +227,12 @@ export function Table({
 
   return (
     <TableContext value={contextValue}>
-      <TableGrid {...props} ref={gridRef} role="table">
+      <TableGrid
+        {...props}
+        ref={gridRef}
+        role="table"
+        style={template ? {...props.style, gridTemplateColumns: template} : props.style}
+      >
         {children}
       </TableGrid>
     </TableContext>

--- a/static/app/components/core/table/table.tsx
+++ b/static/app/components/core/table/table.tsx
@@ -303,12 +303,12 @@ function HeadCell({
       {showResizer && (
         <TableResizer onContextMenu={event => event.preventDefault()}>
           <DragHandle
-            appearance="hover"
             isSizedFirst
             max={Math.max(max, context.minimumColumnWidth)}
             min={context.minimumColumnWidth}
             orientation="horizontal"
             value={Math.max(width, context.minimumColumnWidth)}
+            variant="ghost"
             onDoubleClick={event => context.onResetColumnSize(event, index)}
             onMove={context.onResizeMove}
             onMoveEnd={context.onResizeEnd}

--- a/static/app/components/core/table/table.tsx
+++ b/static/app/components/core/table/table.tsx
@@ -1,0 +1,348 @@
+import type {
+  ComponentProps,
+  CSSProperties,
+  HTMLAttributes,
+  ReactNode,
+  RefObject,
+  TdHTMLAttributes,
+  ThHTMLAttributes,
+} from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+import {
+  getAriaSort,
+  SortableHeaderCell,
+  type SortDirection,
+} from 'sentry/components/tables/sortableHeaderCell';
+import {useColumnResize} from 'sentry/components/tables/useColumnResize';
+import {defined} from 'sentry/utils/defined';
+
+import {
+  TableBody,
+  TableCell,
+  TableGrid,
+  TableHead,
+  TableHeadCell,
+  TableResizer,
+  TableRow,
+  TableStatusCell,
+} from './styles';
+
+export const COL_WIDTH_UNDEFINED = -1;
+
+// Set to 90 as the edit/trash icons need this much space.
+const COL_WIDTH_MINIMUM = 90;
+
+export interface TableColumnConfig {
+  key: string;
+  resizable?: boolean;
+  width?: number | string;
+}
+
+type ResolvedWidth = number | string | undefined;
+
+function getDefaultColumnTrack(
+  width: ResolvedWidth,
+  {flexible, minimumColumnWidth}: {flexible: boolean; minimumColumnWidth: number}
+): string {
+  if (typeof width === 'string') {
+    return width;
+  }
+
+  if (!defined(width) || width === COL_WIDTH_UNDEFINED) {
+    return `minmax(${minimumColumnWidth}px, auto)`;
+  }
+
+  if (width > minimumColumnWidth) {
+    return flexible ? `minmax(${width}px, auto)` : `${width}px`;
+  }
+
+  return flexible ? `minmax(${minimumColumnWidth}px, auto)` : `${minimumColumnWidth}px`;
+}
+
+interface TableContextValue {
+  columnIndexByKey: Map<string, number>;
+  lastColumnIndex: number;
+  onResetColumnSize: (event: React.MouseEvent, index: number) => void;
+  onResizeMouseDown: (event: React.MouseEvent, index: number) => void;
+  resizableByIndex: boolean[];
+  tableRef: RefObject<HTMLTableElement | null>;
+}
+
+const TableContext = createContext<TableContextValue | null>(null);
+
+function useTableContext() {
+  return useContext(TableContext);
+}
+
+const EMPTY_COLUMNS: TableColumnConfig[] = [];
+
+export interface TableProps extends Omit<
+  HTMLAttributes<HTMLTableElement>,
+  'children' | 'onResize'
+> {
+  children: ReactNode;
+  columns?: TableColumnConfig[];
+  definiteHeadRow?: boolean;
+  fit?: 'max-content';
+  flexibleLastColumn?: boolean;
+  height?: CSSProperties['height'];
+  minimumColumnWidth?: number;
+  onColumnResize?: (index: number, width: number) => void;
+  prependColumnWidths?: string[];
+  ref?: RefObject<HTMLTableElement | null>;
+  scrollable?: boolean;
+}
+
+export function Table({
+  children,
+  columns = EMPTY_COLUMNS,
+  definiteHeadRow,
+  fit,
+  flexibleLastColumn = true,
+  height,
+  minimumColumnWidth = COL_WIDTH_MINIMUM,
+  onColumnResize,
+  prependColumnWidths,
+  ref,
+  scrollable,
+  ...props
+}: TableProps) {
+  const internalRef = useRef<HTMLTableElement>(null);
+  const gridRef = ref ?? internalRef;
+
+  const [internalWidths, setInternalWidths] = useState<Record<string, number>>({});
+  const isControlled = defined(onColumnResize);
+
+  const resolveWidth = useCallback(
+    (column: TableColumnConfig): ResolvedWidth =>
+      isControlled ? column.width : (internalWidths[column.key] ?? column.width),
+    [internalWidths, isControlled]
+  );
+
+  const buildTemplate = useCallback(
+    (overrideIndex?: number, overrideWidth?: number) => {
+      const tracks = columns.map((column, index) =>
+        getDefaultColumnTrack(
+          index === overrideIndex ? overrideWidth : resolveWidth(column),
+          {
+            flexible: flexibleLastColumn && index === columns.length - 1,
+            minimumColumnWidth,
+          }
+        )
+      );
+
+      if (!tracks.length) {
+        return '';
+      }
+
+      return [...(prependColumnWidths ?? []), ...tracks].join(' ');
+    },
+    [columns, flexibleLastColumn, minimumColumnWidth, prependColumnWidths, resolveWidth]
+  );
+
+  const commitWidth = useCallback(
+    (index: number, width: number) => {
+      const key = columns[index]?.key;
+
+      if (onColumnResize) {
+        onColumnResize(index, width);
+      } else if (key) {
+        setInternalWidths(current => ({...current, [key]: width}));
+      }
+    },
+    [columns, onColumnResize]
+  );
+
+  const getResizeTemplate = useCallback(
+    (index: number, newWidth: number) =>
+      buildTemplate(index, Math.max(newWidth, minimumColumnWidth)),
+    [buildTemplate, minimumColumnWidth]
+  );
+
+  const onColumnResizeEnd = useCallback(
+    (index: number, newWidth: number) =>
+      commitWidth(index, Math.max(newWidth, minimumColumnWidth)),
+    [commitWidth, minimumColumnWidth]
+  );
+
+  const {onResizeMouseDown, applyTemplate} = useColumnResize({
+    gridRef,
+    getResizeTemplate,
+    onColumnResizeEnd,
+  });
+
+  const onResetColumnSize = useCallback(
+    (event: React.MouseEvent, index: number) => {
+      event.stopPropagation();
+
+      applyTemplate(buildTemplate(index, COL_WIDTH_UNDEFINED));
+      commitWidth(index, COL_WIDTH_UNDEFINED);
+    },
+    [applyTemplate, buildTemplate, commitWidth]
+  );
+
+  const template = buildTemplate();
+
+  const redraw = useCallback(() => {
+    // An empty template means the shell has no opinion about tracks, so writing
+    // it would clobber whatever the consumer set via CSS or an inline style.
+    if (template) {
+      applyTemplate(template);
+    }
+  }, [applyTemplate, template]);
+
+  useLayoutEffect(() => {
+    redraw();
+  }, [redraw]);
+
+  useEffect(() => {
+    window.addEventListener('resize', redraw);
+    return () => window.removeEventListener('resize', redraw);
+  }, [redraw]);
+
+  useEffect(() => {
+    const grid = gridRef.current;
+    if (!grid) {
+      return () => {};
+    }
+
+    const observer = new ResizeObserver(() => {
+      grid.style.setProperty('--table-resizer-height', `${grid.offsetHeight}px`);
+    });
+    observer.observe(grid);
+
+    return () => observer.disconnect();
+  }, [gridRef]);
+
+  const contextValue = useMemo<TableContextValue>(
+    () => ({
+      columnIndexByKey: new Map(columns.map((column, index) => [column.key, index])),
+      lastColumnIndex: columns.length - 1,
+      onResetColumnSize,
+      onResizeMouseDown,
+      resizableByIndex: columns.map(column => column.resizable !== false),
+      tableRef: gridRef,
+    }),
+    [columns, gridRef, onResetColumnSize, onResizeMouseDown]
+  );
+
+  return (
+    <TableContext value={contextValue}>
+      <TableGrid
+        {...props}
+        definiteHeadRow={definiteHeadRow}
+        fit={fit}
+        height={height}
+        ref={gridRef}
+        role="table"
+        scrollable={scrollable}
+      >
+        {children}
+      </TableGrid>
+    </TableContext>
+  );
+}
+
+function Head(props: ComponentProps<typeof TableHead>) {
+  return <TableHead role="rowgroup" {...props} />;
+}
+
+function Body(props: ComponentProps<typeof TableBody>) {
+  return <TableBody role="rowgroup" {...props} />;
+}
+
+function Row(props: ComponentProps<typeof TableRow>) {
+  return <TableRow role="row" {...props} />;
+}
+
+function Cell(props: ComponentProps<typeof TableCell>) {
+  return <TableCell role="cell" {...props} />;
+}
+
+interface HeadCellProps extends ThHTMLAttributes<HTMLTableCellElement> {
+  column?: string;
+  columnIndex?: number;
+  onSort?: () => void;
+  overlays?: ReactNode;
+  sort?: SortDirection;
+}
+
+function HeadCell({
+  children,
+  column,
+  columnIndex,
+  onSort,
+  overlays,
+  sort,
+  ...props
+}: HeadCellProps) {
+  const context = useTableContext();
+  const index =
+    columnIndex ?? (defined(column) ? context?.columnIndexByKey.get(column) : undefined);
+
+  const showResizer =
+    defined(context) &&
+    defined(index) &&
+    index !== context.lastColumnIndex &&
+    context.resizableByIndex[index] === true;
+
+  const sortable = defined(onSort) || defined(sort) || defined(overlays);
+
+  return (
+    // aria-sort precedes the spread so a caller that announces sorting itself, as
+    // GridEditable does for its own sort links, still wins.
+    <TableHeadCell aria-sort={getAriaSort(sort)} {...props} role="columnheader">
+      {sortable ? (
+        <SortableHeaderCell direction={sort} onSort={onSort} overlays={overlays}>
+          {children}
+        </SortableHeaderCell>
+      ) : (
+        children
+      )}
+      {showResizer && (
+        <TableResizer
+          data-test-id="table-column-resizer"
+          onContextMenu={event => context.onResizeMouseDown(event, index)}
+          onDoubleClick={event => context.onResetColumnSize(event, index)}
+          onMouseDown={event => context.onResizeMouseDown(event, index)}
+        />
+      )}
+    </TableHeadCell>
+  );
+}
+
+function Status({children, ...props}: TdHTMLAttributes<HTMLTableCellElement>) {
+  return (
+    <Row>
+      <TableStatusCell {...props} role="cell">
+        {children}
+      </TableStatusCell>
+    </Row>
+  );
+}
+
+function StatusBody(props: TdHTMLAttributes<HTMLTableCellElement>) {
+  return (
+    <Body>
+      <Status {...props} />
+    </Body>
+  );
+}
+
+Table.Body = Body;
+Table.Cell = Cell;
+Table.Head = Head;
+Table.HeadCell = HeadCell;
+Table.Row = Row;
+Table.Status = Status;
+Table.StatusBody = StatusBody;

--- a/static/app/components/core/table/table.tsx
+++ b/static/app/components/core/table/table.tsx
@@ -1,6 +1,5 @@
 import type {
   ComponentProps,
-  CSSProperties,
   HTMLAttributes,
   ReactNode,
   RefObject,
@@ -17,6 +16,8 @@ import {
   useRef,
   useState,
 } from 'react';
+
+import {DragHandle} from '@sentry/scraps/dragHandle';
 
 import {
   getAriaSort,
@@ -72,10 +73,12 @@ function getDefaultColumnTrack(
 interface TableContextValue {
   columnIndexByKey: Map<string, number>;
   lastColumnIndex: number;
+  minimumColumnWidth: number;
   onResetColumnSize: (event: React.MouseEvent, index: number) => void;
-  onResizeMouseDown: (event: React.MouseEvent, index: number) => void;
+  onResizeEnd: () => void;
+  onResizeMove: (delta: number) => void;
+  onResizeStart: (index: number, cell: HTMLElement | null) => void;
   resizableByIndex: boolean[];
-  tableRef: RefObject<HTMLTableElement | null>;
 }
 
 const TableContext = createContext<TableContextValue | null>(null);
@@ -92,29 +95,21 @@ export interface TableProps extends Omit<
 > {
   children: ReactNode;
   columns?: TableColumnConfig[];
-  definiteHeadRow?: boolean;
-  fit?: 'max-content';
   flexibleLastColumn?: boolean;
-  height?: CSSProperties['height'];
   minimumColumnWidth?: number;
   onColumnResize?: (index: number, width: number) => void;
   prependColumnWidths?: string[];
   ref?: RefObject<HTMLTableElement | null>;
-  scrollable?: boolean;
 }
 
 export function Table({
   children,
   columns = EMPTY_COLUMNS,
-  definiteHeadRow,
-  fit,
   flexibleLastColumn = true,
-  height,
   minimumColumnWidth = COL_WIDTH_MINIMUM,
   onColumnResize,
   prependColumnWidths,
   ref,
-  scrollable,
   ...props
 }: TableProps) {
   const internalRef = useRef<HTMLTableElement>(null);
@@ -175,7 +170,7 @@ export function Table({
     [commitWidth, minimumColumnWidth]
   );
 
-  const {onResizeMouseDown, applyTemplate} = useColumnResize({
+  const {applyTemplate, onResizeEnd, onResizeMove, onResizeStart} = useColumnResize({
     gridRef,
     getResizeTemplate,
     onColumnResizeEnd,
@@ -228,25 +223,26 @@ export function Table({
     () => ({
       columnIndexByKey: new Map(columns.map((column, index) => [column.key, index])),
       lastColumnIndex: columns.length - 1,
+      minimumColumnWidth,
       onResetColumnSize,
-      onResizeMouseDown,
+      onResizeEnd,
+      onResizeMove,
+      onResizeStart,
       resizableByIndex: columns.map(column => column.resizable !== false),
-      tableRef: gridRef,
     }),
-    [columns, gridRef, onResetColumnSize, onResizeMouseDown]
+    [
+      columns,
+      minimumColumnWidth,
+      onResetColumnSize,
+      onResizeEnd,
+      onResizeMove,
+      onResizeStart,
+    ]
   );
 
   return (
     <TableContext value={contextValue}>
-      <TableGrid
-        {...props}
-        definiteHeadRow={definiteHeadRow}
-        fit={fit}
-        height={height}
-        ref={gridRef}
-        role="table"
-        scrollable={scrollable}
-      >
+      <TableGrid {...props} ref={gridRef} role="table">
         {children}
       </TableGrid>
     </TableContext>
@@ -298,10 +294,41 @@ function HeadCell({
 
   const sortable = defined(onSort) || defined(sort) || defined(overlays);
 
+  const cellRef = useRef<HTMLTableCellElement>(null);
+  const minimumColumnWidth = context?.minimumColumnWidth ?? COL_WIDTH_MINIMUM;
+  const [{max, width}, setMeasurements] = useState({
+    max: minimumColumnWidth,
+    width: minimumColumnWidth,
+  });
+
+  useEffect(() => {
+    const cell = cellRef.current;
+    const table = cell?.closest('table');
+    if (!showResizer || !cell || !table) {
+      return () => {};
+    }
+
+    const observer = new ResizeObserver(() =>
+      setMeasurements({
+        max: Math.max(table.clientWidth, cell.offsetWidth),
+        width: cell.offsetWidth,
+      })
+    );
+    observer.observe(cell);
+    observer.observe(table);
+
+    return () => observer.disconnect();
+  }, [showResizer]);
+
   return (
     // aria-sort precedes the spread so a caller that announces sorting itself, as
     // GridEditable does for its own sort links, still wins.
-    <TableHeadCell aria-sort={getAriaSort(sort)} {...props} role="columnheader">
+    <TableHeadCell
+      aria-sort={getAriaSort(sort)}
+      {...props}
+      ref={cellRef}
+      role="columnheader"
+    >
       {sortable ? (
         <SortableHeaderCell direction={sort} onSort={onSort} overlays={overlays}>
           {children}
@@ -310,12 +337,20 @@ function HeadCell({
         children
       )}
       {showResizer && (
-        <TableResizer
-          data-test-id="table-column-resizer"
-          onContextMenu={event => context.onResizeMouseDown(event, index)}
-          onDoubleClick={event => context.onResetColumnSize(event, index)}
-          onMouseDown={event => context.onResizeMouseDown(event, index)}
-        />
+        <TableResizer onContextMenu={event => event.preventDefault()}>
+          <DragHandle
+            appearance="hover"
+            isSizedFirst
+            max={max}
+            min={minimumColumnWidth}
+            orientation="horizontal"
+            value={width}
+            onDoubleClick={event => context.onResetColumnSize(event, index)}
+            onMove={context.onResizeMove}
+            onMoveEnd={context.onResizeEnd}
+            onMoveStart={() => context.onResizeStart(index, cellRef.current)}
+          />
+        </TableResizer>
       )}
     </TableHeadCell>
   );

--- a/static/app/components/core/table/table.tsx
+++ b/static/app/components/core/table/table.tsx
@@ -25,6 +25,7 @@ import {
   type SortDirection,
 } from 'sentry/components/tables/sortableHeaderCell';
 import {useColumnResize} from 'sentry/components/tables/useColumnResize';
+import {useObservedColumnSize} from 'sentry/components/tables/useObservedColumnSize';
 import {defined} from 'sentry/utils/defined';
 
 import {
@@ -205,20 +206,6 @@ export function Table({
     return () => window.removeEventListener('resize', redraw);
   }, [redraw]);
 
-  useEffect(() => {
-    const grid = gridRef.current;
-    if (!grid) {
-      return () => {};
-    }
-
-    const observer = new ResizeObserver(() => {
-      grid.style.setProperty('--table-resizer-height', `${grid.offsetHeight}px`);
-    });
-    observer.observe(grid);
-
-    return () => observer.disconnect();
-  }, [gridRef]);
-
   const contextValue = useMemo<TableContextValue>(
     () => ({
       columnIndexByKey: new Map(columns.map((column, index) => [column.key, index])),
@@ -296,29 +283,7 @@ function HeadCell({
 
   const cellRef = useRef<HTMLTableCellElement>(null);
   const minimumColumnWidth = context?.minimumColumnWidth ?? COL_WIDTH_MINIMUM;
-  const [{max, width}, setMeasurements] = useState({
-    max: minimumColumnWidth,
-    width: minimumColumnWidth,
-  });
-
-  useEffect(() => {
-    const cell = cellRef.current;
-    const table = cell?.closest('table');
-    if (!showResizer || !cell || !table) {
-      return () => {};
-    }
-
-    const observer = new ResizeObserver(() =>
-      setMeasurements({
-        max: Math.max(table.clientWidth, cell.offsetWidth),
-        width: cell.offsetWidth,
-      })
-    );
-    observer.observe(cell);
-    observer.observe(table);
-
-    return () => observer.disconnect();
-  }, [showResizer]);
+  const {max, width} = useObservedColumnSize(cellRef);
 
   return (
     // aria-sort precedes the spread so a caller that announces sorting itself, as
@@ -341,10 +306,10 @@ function HeadCell({
           <DragHandle
             appearance="hover"
             isSizedFirst
-            max={max}
+            max={Math.max(max, minimumColumnWidth)}
             min={minimumColumnWidth}
             orientation="horizontal"
-            value={width}
+            value={Math.max(width, minimumColumnWidth)}
             onDoubleClick={event => context.onResetColumnSize(event, index)}
             onMove={context.onResizeMove}
             onMoveEnd={context.onResizeEnd}

--- a/static/app/components/core/table/table.tsx
+++ b/static/app/components/core/table/table.tsx
@@ -11,6 +11,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useId,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -285,11 +286,14 @@ function HeadCell({
 
   const cellRef = useRef<HTMLTableCellElement>(null);
   const {max, width} = useObservedColumnSize(cellRef);
+  const fallbackId = useId();
+  const cellId = props.id ?? fallbackId;
 
   return (
     <TableHeadCell
       aria-sort={getAriaSort(sort)}
       {...props}
+      id={cellId}
       ref={cellRef}
       role="columnheader"
     >
@@ -303,6 +307,7 @@ function HeadCell({
       {showResizer && (
         <TableResizer onContextMenu={event => event.preventDefault()}>
           <DragHandle
+            aria-labelledby={cellId}
             isSizedFirst
             max={Math.max(max, context.minimumColumnWidth)}
             min={context.minimumColumnWidth}

--- a/static/app/components/core/table/table.tsx
+++ b/static/app/components/core/table/table.tsx
@@ -26,7 +26,6 @@ import {
 } from 'sentry/components/tables/sortableHeaderCell';
 import {useColumnResize} from 'sentry/components/tables/useColumnResize';
 import {useObservedColumnSize} from 'sentry/components/tables/useObservedColumnSize';
-import {defined} from 'sentry/utils/defined';
 
 import {
   TableBody,
@@ -39,10 +38,10 @@ import {
   TableStatusCell,
 } from './styles';
 
+// Auto layout width.
 export const COL_WIDTH_UNDEFINED = -1;
 
-// Set to 90 as the edit/trash icons need this much space.
-const COL_WIDTH_MINIMUM = 90;
+export const COL_WIDTH_MINIMUM = 90;
 
 export interface TableColumnConfig {
   key: string;
@@ -60,7 +59,7 @@ function getDefaultColumnTrack(
     return width;
   }
 
-  if (!defined(width) || width === COL_WIDTH_UNDEFINED) {
+  if (width === undefined || width === COL_WIDTH_UNDEFINED) {
     return `minmax(${minimumColumnWidth}px, auto)`;
   }
 
@@ -117,7 +116,7 @@ export function Table({
   const gridRef = ref ?? internalRef;
 
   const [internalWidths, setInternalWidths] = useState<Record<string, number>>({});
-  const isControlled = defined(onColumnResize);
+  const isControlled = !!onColumnResize;
 
   const resolveWidth = useCallback(
     (column: TableColumnConfig): ResolvedWidth =>
@@ -190,8 +189,6 @@ export function Table({
   const template = buildTemplate();
 
   const redraw = useCallback(() => {
-    // An empty template means the shell has no opinion about tracks, so writing
-    // it would clobber whatever the consumer set via CSS or an inline style.
     if (template) {
       applyTemplate(template);
     }
@@ -254,6 +251,10 @@ function Cell(props: ComponentProps<typeof TableCell>) {
 
 interface HeadCellProps extends ThHTMLAttributes<HTMLTableCellElement> {
   column?: string;
+  /**
+   * Identifies the column by position, for callers that render their head cells
+   * from an ordered list rather than from a keyed column config.
+   */
   columnIndex?: number;
   onSort?: () => void;
   overlays?: ReactNode;
@@ -271,23 +272,21 @@ function HeadCell({
 }: HeadCellProps) {
   const context = useTableContext();
   const index =
-    columnIndex ?? (defined(column) ? context?.columnIndexByKey.get(column) : undefined);
+    columnIndex ??
+    (column === undefined ? undefined : context?.columnIndexByKey.get(column));
 
   const showResizer =
-    defined(context) &&
-    defined(index) &&
+    context !== null &&
+    index !== undefined &&
     index !== context.lastColumnIndex &&
     context.resizableByIndex[index] === true;
 
-  const sortable = defined(onSort) || defined(sort) || defined(overlays);
+  const sortable = !!onSort || !!sort || !!overlays;
 
   const cellRef = useRef<HTMLTableCellElement>(null);
-  const minimumColumnWidth = context?.minimumColumnWidth ?? COL_WIDTH_MINIMUM;
   const {max, width} = useObservedColumnSize(cellRef);
 
   return (
-    // aria-sort precedes the spread so a caller that announces sorting itself, as
-    // GridEditable does for its own sort links, still wins.
     <TableHeadCell
       aria-sort={getAriaSort(sort)}
       {...props}
@@ -306,10 +305,10 @@ function HeadCell({
           <DragHandle
             appearance="hover"
             isSizedFirst
-            max={Math.max(max, minimumColumnWidth)}
-            min={minimumColumnWidth}
+            max={Math.max(max, context.minimumColumnWidth)}
+            min={context.minimumColumnWidth}
             orientation="horizontal"
-            value={Math.max(width, minimumColumnWidth)}
+            value={Math.max(width, context.minimumColumnWidth)}
             onDoubleClick={event => context.onResetColumnSize(event, index)}
             onMove={context.onResizeMove}
             onMoveEnd={context.onResizeEnd}

--- a/static/app/components/core/table/table.tsx
+++ b/static/app/components/core/table/table.tsx
@@ -287,7 +287,7 @@ function HeadCell({
   const cellRef = useRef<HTMLTableCellElement>(null);
   const {max, width} = useObservedColumnSize(cellRef);
   const fallbackId = useId();
-  const cellId = props.id ?? fallbackId;
+  const cellId = props.id || fallbackId;
 
   return (
     <TableHeadCell

--- a/static/app/components/tables/columnResizer.tsx
+++ b/static/app/components/tables/columnResizer.tsx
@@ -1,4 +1,4 @@
-import {useRef} from 'react';
+import {useEffect, useId, useRef} from 'react';
 import {mergeProps} from '@react-aria/utils';
 
 import {useDragMove} from '@sentry/scraps/dragHandle';
@@ -30,6 +30,24 @@ export function ColumnResizer({
 }: ColumnResizerProps) {
   const ref = useRef<HTMLDivElement>(null);
   const {max, width} = useObservedColumnSize(ref);
+  const fallbackCellId = useId();
+
+  // A focusable separator is a widget, so it needs a name. The header cell already
+  // carries the column's name, and pointing at it rather than repeating it as an
+  // `aria-label` keeps the resizer out of that cell's own name-from-content.
+  useEffect(() => {
+    const resizer = ref.current;
+    const cell = resizer?.closest('th');
+    if (!resizer || !cell) {
+      return;
+    }
+
+    if (!cell.id) {
+      cell.id = fallbackCellId;
+    }
+
+    resizer.setAttribute('aria-labelledby', cell.id);
+  }, [fallbackCellId]);
 
   const {moveProps} = useDragMove({
     onMove: onResizeMove,

--- a/static/app/components/tables/columnResizer.tsx
+++ b/static/app/components/tables/columnResizer.tsx
@@ -1,0 +1,78 @@
+import {useEffect, useRef, useState} from 'react';
+import {mergeProps} from '@react-aria/utils';
+
+import {useDragMove} from '@sentry/scraps/dragHandle';
+
+import {GridResizer} from 'sentry/components/tables/gridEditable/styles';
+
+interface ColumnResizerProps {
+  columnIndex: number;
+  dataRows: number;
+  onResizeEnd: () => void;
+  onResizeMove: (delta: number) => void;
+  onResizeStart: (columnIndex: number, cell: HTMLElement | null) => void;
+  minimumColumnWidth?: number;
+  onResetColumnSize?: (event: React.MouseEvent, columnIndex: number) => void;
+}
+
+/**
+ * The resize handle for the table shells that draw their own resizer, as opposed to
+ * `Table`, which uses `DragHandle` directly. Reports movement from a pointer drag or
+ * the arrow keys to a `useColumnResize`.
+ */
+export function ColumnResizer({
+  columnIndex,
+  dataRows,
+  minimumColumnWidth,
+  onResetColumnSize,
+  onResizeEnd,
+  onResizeMove,
+  onResizeStart,
+}: ColumnResizerProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [{max, width}, setMeasurements] = useState({max: 0, width: 0});
+
+  const {moveProps} = useDragMove({
+    onMove: onResizeMove,
+    onMoveEnd: onResizeEnd,
+    onMoveStart: () => onResizeStart(columnIndex, ref.current?.closest('th') ?? null),
+    orientation: 'horizontal',
+  });
+
+  useEffect(() => {
+    const cell = ref.current?.closest('th');
+    const table = cell?.closest('table');
+    if (!cell || !table) {
+      return () => {};
+    }
+
+    const observer = new ResizeObserver(() =>
+      setMeasurements({
+        max: Math.max(table.clientWidth, cell.offsetWidth),
+        width: cell.offsetWidth,
+      })
+    );
+    observer.observe(cell);
+    observer.observe(table);
+
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <GridResizer
+      {...mergeProps(moveProps, {
+        onContextMenu: (event: React.MouseEvent) => event.preventDefault(),
+        onDoubleClick: (event: React.MouseEvent) =>
+          onResetColumnSize?.(event, columnIndex),
+      })}
+      aria-orientation="vertical"
+      aria-valuemax={max || undefined}
+      aria-valuemin={minimumColumnWidth}
+      aria-valuenow={width || undefined}
+      dataRows={dataRows}
+      ref={ref}
+      role="separator"
+      tabIndex={0}
+    />
+  );
+}

--- a/static/app/components/tables/columnResizer.tsx
+++ b/static/app/components/tables/columnResizer.tsx
@@ -1,13 +1,13 @@
-import {useEffect, useRef, useState} from 'react';
+import {useRef} from 'react';
 import {mergeProps} from '@react-aria/utils';
 
 import {useDragMove} from '@sentry/scraps/dragHandle';
 
 import {GridResizer} from 'sentry/components/tables/gridEditable/styles';
+import {useObservedColumnSize} from 'sentry/components/tables/useObservedColumnSize';
 
 interface ColumnResizerProps {
   columnIndex: number;
-  dataRows: number;
   onResizeEnd: () => void;
   onResizeMove: (delta: number) => void;
   onResizeStart: (columnIndex: number, cell: HTMLElement | null) => void;
@@ -22,7 +22,6 @@ interface ColumnResizerProps {
  */
 export function ColumnResizer({
   columnIndex,
-  dataRows,
   minimumColumnWidth,
   onResetColumnSize,
   onResizeEnd,
@@ -30,7 +29,7 @@ export function ColumnResizer({
   onResizeStart,
 }: ColumnResizerProps) {
   const ref = useRef<HTMLDivElement>(null);
-  const [{max, width}, setMeasurements] = useState({max: 0, width: 0});
+  const {max, width} = useObservedColumnSize(ref);
 
   const {moveProps} = useDragMove({
     onMove: onResizeMove,
@@ -38,25 +37,6 @@ export function ColumnResizer({
     onMoveStart: () => onResizeStart(columnIndex, ref.current?.closest('th') ?? null),
     orientation: 'horizontal',
   });
-
-  useEffect(() => {
-    const cell = ref.current?.closest('th');
-    const table = cell?.closest('table');
-    if (!cell || !table) {
-      return () => {};
-    }
-
-    const observer = new ResizeObserver(() =>
-      setMeasurements({
-        max: Math.max(table.clientWidth, cell.offsetWidth),
-        width: cell.offsetWidth,
-      })
-    );
-    observer.observe(cell);
-    observer.observe(table);
-
-    return () => observer.disconnect();
-  }, []);
 
   return (
     <GridResizer
@@ -69,7 +49,6 @@ export function ColumnResizer({
       aria-valuemax={max || undefined}
       aria-valuemin={minimumColumnWidth}
       aria-valuenow={width || undefined}
-      dataRows={dataRows}
       ref={ref}
       role="separator"
       tabIndex={0}

--- a/static/app/components/tables/columnResizer.tsx
+++ b/static/app/components/tables/columnResizer.tsx
@@ -1,7 +1,7 @@
 import {useEffect, useId, useRef} from 'react';
 import {mergeProps} from '@react-aria/utils';
 
-import {useDragMove} from '@sentry/scraps/dragHandle';
+import {useDragSeparator} from '@sentry/scraps/dragHandle';
 
 import {GridResizer} from 'sentry/components/tables/gridEditable/styles';
 import {useObservedColumnSize} from 'sentry/components/tables/useObservedColumnSize';
@@ -35,7 +35,7 @@ export function ColumnResizer({
   // A focusable separator is a widget, so it needs a name. The header cell already
   // carries the column's name, and pointing at it rather than repeating it as an
   // `aria-label` keeps the resizer out of that cell's own name-from-content.
-  const cellId = cell?.id ?? fallbackCellId;
+  const cellId = cell?.id || fallbackCellId;
 
   useEffect(() => {
     if (cell && !cell.id) {
@@ -43,28 +43,27 @@ export function ColumnResizer({
     }
   }, [cell, fallbackCellId]);
 
-  const {moveProps} = useDragMove({
+  const {cursor, separatorProps} = useDragSeparator({
+    isSizedFirst: true,
+    max: max || undefined,
+    min: minimumColumnWidth,
     onMove: onResizeMove,
     onMoveEnd: onResizeEnd,
-    onMoveStart: () => onResizeStart(columnIndex, ref.current?.closest('th') ?? null),
+    onMoveStart: () => onResizeStart(columnIndex, cell),
     orientation: 'horizontal',
+    value: width || undefined,
   });
 
   return (
     <GridResizer
-      {...mergeProps(moveProps, {
+      {...mergeProps(separatorProps, {
         onContextMenu: (event: React.MouseEvent) => event.preventDefault(),
         onDoubleClick: (event: React.MouseEvent) =>
           onResetColumnSize?.(event, columnIndex),
       })}
       aria-labelledby={cellId}
-      aria-orientation="vertical"
-      aria-valuemax={max || undefined}
-      aria-valuemin={minimumColumnWidth}
-      aria-valuenow={width || undefined}
+      cursor={cursor}
       ref={ref}
-      role="separator"
-      tabIndex={0}
     />
   );
 }

--- a/static/app/components/tables/columnResizer.tsx
+++ b/static/app/components/tables/columnResizer.tsx
@@ -3,7 +3,10 @@ import {mergeProps} from '@react-aria/utils';
 
 import {useDragSeparator} from '@sentry/scraps/dragHandle';
 
-import {GridResizer} from 'sentry/components/tables/gridEditable/styles';
+import {
+  GridResizer,
+  GridResizerTarget,
+} from 'sentry/components/tables/gridEditable/styles';
 import {useObservedColumnSize} from 'sentry/components/tables/useObservedColumnSize';
 
 interface ColumnResizerProps {
@@ -64,6 +67,8 @@ export function ColumnResizer({
       aria-labelledby={cellId}
       cursor={cursor}
       ref={ref}
-    />
+    >
+      <GridResizerTarget />
+    </GridResizer>
   );
 }

--- a/static/app/components/tables/columnResizer.tsx
+++ b/static/app/components/tables/columnResizer.tsx
@@ -29,25 +29,19 @@ export function ColumnResizer({
   onResizeStart,
 }: ColumnResizerProps) {
   const ref = useRef<HTMLDivElement>(null);
-  const {max, width} = useObservedColumnSize(ref);
+  const {cell, max, width} = useObservedColumnSize(ref);
   const fallbackCellId = useId();
 
   // A focusable separator is a widget, so it needs a name. The header cell already
   // carries the column's name, and pointing at it rather than repeating it as an
   // `aria-label` keeps the resizer out of that cell's own name-from-content.
-  useEffect(() => {
-    const resizer = ref.current;
-    const cell = resizer?.closest('th');
-    if (!resizer || !cell) {
-      return;
-    }
+  const cellId = cell?.id ?? fallbackCellId;
 
-    if (!cell.id) {
+  useEffect(() => {
+    if (cell && !cell.id) {
       cell.id = fallbackCellId;
     }
-
-    resizer.setAttribute('aria-labelledby', cell.id);
-  }, [fallbackCellId]);
+  }, [cell, fallbackCellId]);
 
   const {moveProps} = useDragMove({
     onMove: onResizeMove,
@@ -63,6 +57,7 @@ export function ColumnResizer({
         onDoubleClick: (event: React.MouseEvent) =>
           onResetColumnSize?.(event, columnIndex),
       })}
+      aria-labelledby={cellId}
       aria-orientation="vertical"
       aria-valuemax={max || undefined}
       aria-valuemin={minimumColumnWidth}

--- a/static/app/components/tables/gridEditable/index.tsx
+++ b/static/app/components/tables/gridEditable/index.tsx
@@ -2,6 +2,7 @@ import type {CSSProperties, ReactNode} from 'react';
 import {Fragment, useCallback, useEffect, useRef} from 'react';
 
 import InteractionStateLayer from '@sentry/scraps/interactionStateLayer';
+import {COL_WIDTH_MINIMUM, COL_WIDTH_UNDEFINED} from '@sentry/scraps/table';
 
 import {ColumnResizer} from 'sentry/components/tables/columnResizer';
 import {GridEditableEmptyData} from 'sentry/components/tables/gridEditable/GridEditableEmptyData';
@@ -29,11 +30,7 @@ import type {GridColumnOrder, GridColumnSortBy, GridData} from './types';
 
 export type * from './types';
 
-// Auto layout width.
-export const COL_WIDTH_UNDEFINED = -1;
-
-// Set to 90 as the edit/trash icons need this much space.
-export const COL_WIDTH_MINIMUM = 90;
+export {COL_WIDTH_MINIMUM, COL_WIDTH_UNDEFINED} from '@sentry/scraps/table';
 
 type GridEditableProps<
   DataRow,

--- a/static/app/components/tables/gridEditable/index.tsx
+++ b/static/app/components/tables/gridEditable/index.tsx
@@ -167,7 +167,6 @@ export function GridEditable<
         width: newWidth,
       });
     },
-    writeResizerHeightVar: true,
   });
 
   const onResetColumnSize = (e: React.MouseEvent, i: number) => {
@@ -220,7 +219,6 @@ export function GridEditable<
             {i !== numColumn - 1 && resizable && (
               <ColumnResizer
                 columnIndex={i}
-                dataRows={!error && !isLoading && data ? data.length : 0}
                 minimumColumnWidth={minimumColWidth}
                 onResetColumnSize={onResetColumnSize}
                 onResizeEnd={onResizeEnd}

--- a/static/app/components/tables/gridEditable/index.tsx
+++ b/static/app/components/tables/gridEditable/index.tsx
@@ -3,6 +3,7 @@ import {Fragment, useCallback, useEffect, useRef} from 'react';
 
 import InteractionStateLayer from '@sentry/scraps/interactionStateLayer';
 
+import {ColumnResizer} from 'sentry/components/tables/columnResizer';
 import {GridEditableEmptyData} from 'sentry/components/tables/gridEditable/GridEditableEmptyData';
 import {GridEditableError} from 'sentry/components/tables/gridEditable/GridEditableError';
 import {GridEditableLoading} from 'sentry/components/tables/gridEditable/GridEditableLoading';
@@ -19,7 +20,6 @@ import {
   GridHead,
   GridHeadCell,
   GridHeadCellStatic,
-  GridResizer,
   GridRow,
   Header,
   HeaderButtonContainer,
@@ -151,7 +151,7 @@ export function GridEditable<
     [minimumColWidth, props.grid.prependColumnWidths]
   );
 
-  const {onResizeMouseDown, applyTemplate} = useColumnResize({
+  const {applyTemplate, onResizeEnd, onResizeMove, onResizeStart} = useColumnResize({
     gridRef: refGrid,
     getResizeTemplate: (columnIndex, newWidth) => {
       const nextColumnOrder = [...props.columnOrder];
@@ -207,30 +207,29 @@ export function GridEditable<
               {item}
             </GridHeadCellStatic>
           ))}
-        {
-          // Note that onResizeMouseDown assumes GridResizer is nested
-          // 1 levels under GridHeadCell
-          props.columnOrder.map((column, i) => (
-            <GridHeadCell
-              aria-sort={getAriaSort(
-                props.columnSortBy.find(sort => sort.key === column.key)?.order
-              )}
-              data-test-id="grid-head-cell"
-              key={`${i}.${String(column.key)}`}
-              isFirst={i === 0}
-            >
-              {grid.renderHeadCell ? grid.renderHeadCell(column, i) : column.name}
-              {i !== numColumn - 1 && resizable && (
-                <GridResizer
-                  dataRows={!error && !isLoading && data ? data.length : 0}
-                  onMouseDown={e => onResizeMouseDown(e, i)}
-                  onDoubleClick={e => onResetColumnSize(e, i)}
-                  onContextMenu={onResizeMouseDown}
-                />
-              )}
-            </GridHeadCell>
-          ))
-        }
+        {props.columnOrder.map((column, i) => (
+          <GridHeadCell
+            aria-sort={getAriaSort(
+              props.columnSortBy.find(sort => sort.key === column.key)?.order
+            )}
+            data-test-id="grid-head-cell"
+            key={`${i}.${String(column.key)}`}
+            isFirst={i === 0}
+          >
+            {grid.renderHeadCell ? grid.renderHeadCell(column, i) : column.name}
+            {i !== numColumn - 1 && resizable && (
+              <ColumnResizer
+                columnIndex={i}
+                dataRows={!error && !isLoading && data ? data.length : 0}
+                minimumColumnWidth={minimumColWidth}
+                onResetColumnSize={onResetColumnSize}
+                onResizeEnd={onResizeEnd}
+                onResizeMove={onResizeMove}
+                onResizeStart={onResizeStart}
+              />
+            )}
+          </GridHeadCell>
+        ))}
       </GridRow>
     );
   }

--- a/static/app/components/tables/gridEditable/styles.tsx
+++ b/static/app/components/tables/gridEditable/styles.tsx
@@ -3,6 +3,7 @@ import isPropValid from '@emotion/is-prop-valid';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
+import {DRAG_SEPARATOR_TARGET_SIZE} from '@sentry/scraps/dragHandle';
 import {Flex, type FlexProps} from '@sentry/scraps/layout';
 import {TABLE_HEAD_ROW_HEIGHT} from '@sentry/scraps/table';
 
@@ -320,9 +321,14 @@ export const GridResizer = styled('div', {
   padding-right: 5px;
 
   cursor: ${p => p.cursor ?? 'col-resize'};
+  pointer-events: none;
   touch-action: none;
   user-select: none;
   z-index: ${Z_INDEX_GRID_RESIZER};
+
+  && {
+    overflow: visible;
+  }
 
   /**
    * This element allows us to have a thick GridResizer that is easy to hover and
@@ -363,4 +369,16 @@ export const GridResizer = styled('div', {
     background-color: ${p => p.theme.tokens.graphics.accent.vibrant};
     opacity: 0.4;
   }
+`;
+
+export const GridResizerTarget = styled('div')`
+  position: absolute;
+  top: 0;
+  left: calc(50% - ${DRAG_SEPARATOR_TARGET_SIZE / 2}px);
+  width: ${DRAG_SEPARATOR_TARGET_SIZE}px;
+  height: var(--drag-separator-target-length, ${TABLE_HEAD_ROW_HEIGHT}px);
+  max-height: 100%;
+
+  pointer-events: auto;
+  touch-action: none;
 `;

--- a/static/app/components/tables/gridEditable/styles.tsx
+++ b/static/app/components/tables/gridEditable/styles.tsx
@@ -317,6 +317,8 @@ export const GridResizer = styled('div')`
   padding-right: 5px;
 
   cursor: col-resize;
+  touch-action: none;
+  user-select: none;
   z-index: ${Z_INDEX_GRID_RESIZER};
 
   /**

--- a/static/app/components/tables/gridEditable/styles.tsx
+++ b/static/app/components/tables/gridEditable/styles.tsx
@@ -1,4 +1,5 @@
 import type {CSSProperties} from 'react';
+import isPropValid from '@emotion/is-prop-valid';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -306,7 +307,9 @@ export function GridBodyCellStatus(props: any) {
  *
  * The right most cell does not have a resizer as resizing from that side does strange things.
  */
-export const GridResizer = styled('div')`
+export const GridResizer = styled('div', {
+  shouldForwardProp: prop => prop !== 'cursor' && isPropValid(prop),
+})<{cursor?: CSSProperties['cursor']}>`
   position: absolute;
   top: 0px;
   right: -6px;
@@ -316,7 +319,7 @@ export const GridResizer = styled('div')`
   padding-left: 5px;
   padding-right: 5px;
 
-  cursor: col-resize;
+  cursor: ${p => p.cursor ?? 'col-resize'};
   touch-action: none;
   user-select: none;
   z-index: ${Z_INDEX_GRID_RESIZER};
@@ -341,7 +344,8 @@ export const GridResizer = styled('div')`
    * the GridResizer is dragged
    */
   &:active::after,
-  &:focus::after {
+  &:focus-visible::after,
+  &[data-is-held='true']::after {
     background-color: ${p => p.theme.tokens.focus.default};
   }
 

--- a/static/app/components/tables/gridEditable/styles.tsx
+++ b/static/app/components/tables/gridEditable/styles.tsx
@@ -301,25 +301,17 @@ export function GridBodyCellStatus(props: any) {
 }
 
 /**
- * We have a fat GridResizer and we use the ::after pseudo-element to draw
+ * We have a thick GridResizer and we use the ::after pseudo-element to draw
  * a thin 1px border.
  *
  * The right most cell does not have a resizer as resizing from that side does strange things.
  */
-export const GridResizer = styled('div')<{dataRows: number}>`
+export const GridResizer = styled('div')`
   position: absolute;
   top: 0px;
   right: -6px;
   width: 11px;
-
-  height: ${p => {
-    const numOfRows = p.dataRows;
-    // 1px for the border
-    const fixedBodyHeight = numOfRows * (GRID_BODY_ROW_HEIGHT + 1);
-    const fallbackTotalHeight = GRID_HEAD_ROW_HEIGHT + fixedBodyHeight;
-
-    return `var(--grid-editable-resizer-height, ${fallbackTotalHeight}px)`;
-  }};
+  height: var(--column-resizer-height, ${GRID_HEAD_ROW_HEIGHT}px);
 
   padding-left: 5px;
   padding-right: 5px;
@@ -328,7 +320,7 @@ export const GridResizer = styled('div')<{dataRows: number}>`
   z-index: ${Z_INDEX_GRID_RESIZER};
 
   /**
-   * This element allows us to have a fat GridResizer that is easy to hover and
+   * This element allows us to have a thick GridResizer that is easy to hover and
    * drag, but still draws an appealing thin line for the border
    */
   &::after {

--- a/static/app/components/tables/gridEditable/styles.tsx
+++ b/static/app/components/tables/gridEditable/styles.tsx
@@ -3,11 +3,11 @@ import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Flex, type FlexProps} from '@sentry/scraps/layout';
+import {TABLE_HEAD_ROW_HEIGHT} from '@sentry/scraps/table';
 
 import {Panel} from 'sentry/components/panels/panel';
 import {PanelBody} from 'sentry/components/panels/panelBody';
 
-const GRID_HEAD_ROW_HEIGHT = 45;
 export const GRID_BODY_ROW_HEIGHT = 42;
 const GRID_STATUS_MESSAGE_HEIGHT = GRID_BODY_ROW_HEIGHT * 4;
 
@@ -107,20 +107,20 @@ export const Grid = styled('table')<{
           min-height: 0;
 
           &:has(> thead + tbody) {
-            grid-template-rows: ${GRID_HEAD_ROW_HEIGHT}px 1fr;
+            grid-template-rows: ${TABLE_HEAD_ROW_HEIGHT}px 1fr;
           }
 
           &:has(> thead + tbody + tbody) {
-            grid-template-rows: ${GRID_HEAD_ROW_HEIGHT}px fit-content(100%) 1fr;
+            grid-template-rows: ${TABLE_HEAD_ROW_HEIGHT}px fit-content(100%) 1fr;
           }
         `
       : css`
           &:has(> thead + tbody) {
-            grid-template-rows: ${GRID_HEAD_ROW_HEIGHT}px auto;
+            grid-template-rows: ${TABLE_HEAD_ROW_HEIGHT}px auto;
           }
 
           &:has(> thead + tbody + tbody) {
-            grid-template-rows: ${GRID_HEAD_ROW_HEIGHT}px fit-content(100%) auto;
+            grid-template-rows: ${TABLE_HEAD_ROW_HEIGHT}px fit-content(100%) auto;
           }
         `}
 
@@ -163,7 +163,7 @@ export const GridHeadCell = styled('th')<{isFirst: boolean}>`
   /* By default, a grid item cannot be smaller than the size of its content.
      We override this by setting min-width to be 0. */
   position: relative; /* Used by GridResizer */
-  height: ${GRID_HEAD_ROW_HEIGHT}px;
+  height: ${TABLE_HEAD_ROW_HEIGHT}px;
   display: flex;
   align-items: center;
   min-width: 24px;
@@ -202,7 +202,7 @@ export const GridHeadCell = styled('th')<{isFirst: boolean}>`
  * without interactive aspects.
  */
 export const GridHeadCellStatic = styled('th')`
-  height: ${GRID_HEAD_ROW_HEIGHT}px;
+  height: ${TABLE_HEAD_ROW_HEIGHT}px;
   display: flex;
   align-items: center;
   padding: 0 ${p => p.theme.space.xl};
@@ -311,7 +311,7 @@ export const GridResizer = styled('div')`
   top: 0px;
   right: -6px;
   width: 11px;
-  height: var(--column-resizer-height, ${GRID_HEAD_ROW_HEIGHT}px);
+  height: var(--column-resizer-height, ${TABLE_HEAD_ROW_HEIGHT}px);
 
   padding-left: 5px;
   padding-right: 5px;
@@ -353,7 +353,7 @@ export const GridResizer = styled('div')`
     content: ' ';
     display: block;
     width: 7px;
-    height: ${GRID_HEAD_ROW_HEIGHT}px;
+    height: ${TABLE_HEAD_ROW_HEIGHT}px;
     background-color: ${p => p.theme.tokens.graphics.accent.vibrant};
     opacity: 0.4;
   }

--- a/static/app/components/tables/useColumnResize.spec.tsx
+++ b/static/app/components/tables/useColumnResize.spec.tsx
@@ -154,6 +154,7 @@ describe('useColumnResize', () => {
 
     act(triggerResizeObservers);
 
+    // https://github.com/testing-library/jest-dom/issues/735
     // eslint-disable-next-line jest-dom/prefer-to-have-value
     expect(resizer()).toHaveAttribute('aria-valuenow', '150');
   });

--- a/static/app/components/tables/useColumnResize.spec.tsx
+++ b/static/app/components/tables/useColumnResize.spec.tsx
@@ -1,7 +1,9 @@
 import {useRef} from 'react';
 
+import {dragHandle} from 'sentry-test/dragMove';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import {ColumnResizer} from 'sentry/components/tables/columnResizer';
 import {useColumnResize} from 'sentry/components/tables/useColumnResize';
 
 interface TestTableProps {
@@ -16,7 +18,7 @@ function TestTable({
   writeResizerHeightVar,
 }: TestTableProps) {
   const gridRef = useRef<HTMLTableElement>(null);
-  const {onResizeMouseDown} = useColumnResize({
+  const {onResizeEnd, onResizeMove, onResizeStart} = useColumnResize({
     gridRef,
     getResizeTemplate,
     onColumnResizeEnd,
@@ -29,9 +31,13 @@ function TestTable({
         <tr>
           <th>
             <div>Column</div>
-            <div data-test-id="resizer" onMouseDown={e => onResizeMouseDown(e, 0)} />
-            {/* Mirrors the onContextMenu wiring, where no column index is passed. */}
-            <div data-test-id="no-index-handle" onMouseDown={onResizeMouseDown} />
+            <ColumnResizer
+              columnIndex={0}
+              dataRows={0}
+              onResizeEnd={onResizeEnd}
+              onResizeMove={onResizeMove}
+              onResizeStart={onResizeStart}
+            />
           </th>
         </tr>
       </thead>
@@ -40,30 +46,15 @@ function TestTable({
 }
 
 // Columns start at 0px in jsdom (offsetWidth is unavailable), so the resulting width
-// equals the horizontal drag distance. The whole gesture runs in one pointer() call
-// so the held-button state stays coherent across steps.
-function drag(
-  from: number,
-  {to, release, target = 'resizer'}: {release?: number; target?: string; to?: number} = {}
-) {
-  const steps: Parameters<typeof userEvent.pointer>[0] = [
-    {keys: '[MouseLeft>]', target: screen.getByTestId(target), coords: {clientX: from}},
-  ];
-  if (to !== undefined) {
-    steps.push({coords: {clientX: to}});
-  }
-  if (release !== undefined) {
-    steps.push({keys: '[/MouseLeft]', coords: {clientX: release}});
-  }
-  return userEvent.pointer(steps);
-}
+// equals the horizontal drag distance.
+const resizer = () => screen.getByRole('separator');
 
 describe('useColumnResize', () => {
   it('computes the new width from the drag distance', async () => {
     const getResizeTemplate = jest.fn(() => '60px');
     render(<TestTable getResizeTemplate={getResizeTemplate} />);
 
-    await drag(100, {to: 160, release: 160});
+    dragHandle(resizer(), {from: 100, to: 160});
 
     // Writes are batched into an animation frame.
     await waitFor(() => expect(getResizeTemplate).toHaveBeenCalledWith(0, 60));
@@ -73,7 +64,7 @@ describe('useColumnResize', () => {
     const onColumnResizeEnd = jest.fn();
     render(<TestTable onColumnResizeEnd={onColumnResizeEnd} />);
 
-    await drag(100, {release: 250});
+    dragHandle(resizer(), {from: 100, to: 250});
 
     expect(onColumnResizeEnd).toHaveBeenCalledWith(0, 150);
   });
@@ -82,37 +73,55 @@ describe('useColumnResize', () => {
     const getResizeTemplate = jest.fn(() => '40px');
     render(<TestTable getResizeTemplate={getResizeTemplate} />);
 
-    await drag(100, {to: 140, release: 140});
+    dragHandle(resizer(), {from: 100, to: 140});
     await waitFor(() => expect(getResizeTemplate).toHaveBeenCalled());
     getResizeTemplate.mockClear();
-    await userEvent.pointer({
-      target: screen.getByTestId('resizer'),
-      coords: {clientX: 999},
-    });
+    dragHandle(resizer(), {button: 1, from: 140, to: 999});
 
     expect(getResizeTemplate).not.toHaveBeenCalled();
   });
 
-  it('does not start a resize without a column index', async () => {
-    const getResizeTemplate = jest.fn(() => '10px');
+  it('does not start a resize from a non-primary button', async () => {
     const onColumnResizeEnd = jest.fn();
-    render(
-      <TestTable
-        getResizeTemplate={getResizeTemplate}
-        onColumnResizeEnd={onColumnResizeEnd}
-      />
-    );
+    render(<TestTable onColumnResizeEnd={onColumnResizeEnd} />);
 
-    await drag(100, {to: 200, release: 200, target: 'no-index-handle'});
+    dragHandle(resizer(), {button: 2, from: 100, to: 200});
 
-    expect(getResizeTemplate).not.toHaveBeenCalled();
+    expect(onColumnResizeEnd).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {name: 'grows the column when arrowed right', keys: '{ArrowRight}', expected: 10},
+    {name: 'shrinks the column when arrowed left', keys: '{ArrowLeft}', expected: -10},
+    {
+      name: 'takes a larger step when shift is held',
+      keys: '{Shift>}{ArrowRight}{/Shift}',
+      expected: 50,
+    },
+  ])('$name', async ({keys, expected}) => {
+    const onColumnResizeEnd = jest.fn();
+    render(<TestTable onColumnResizeEnd={onColumnResizeEnd} />);
+
+    await userEvent.tab();
+    await userEvent.keyboard(keys);
+
+    expect(onColumnResizeEnd).toHaveBeenCalledWith(0, expected);
+  });
+
+  it('does not resize when a key other than an arrow is pressed', async () => {
+    const onColumnResizeEnd = jest.fn();
+    render(<TestTable onColumnResizeEnd={onColumnResizeEnd} />);
+
+    await userEvent.tab();
+    await userEvent.keyboard('{Enter}');
+
     expect(onColumnResizeEnd).not.toHaveBeenCalled();
   });
 
   it('sets the resizer-height CSS variable when writeResizerHeightVar is enabled', async () => {
     render(<TestTable writeResizerHeightVar />);
 
-    await drag(100, {to: 150, release: 150});
+    dragHandle(resizer(), {from: 100, to: 150});
 
     await waitFor(() =>
       expect(
@@ -127,33 +136,11 @@ describe('useColumnResize', () => {
     const getResizeTemplate = jest.fn(() => '50px');
     render(<TestTable getResizeTemplate={getResizeTemplate} />);
 
-    await drag(100, {to: 150, release: 150});
+    dragHandle(resizer(), {from: 100, to: 150});
     await waitFor(() => expect(getResizeTemplate).toHaveBeenCalled());
 
     expect(
       screen.getByTestId('grid').style.getPropertyValue('--grid-editable-resizer-height')
     ).toBe('');
-  });
-
-  it('tears down a previous drag when a new one starts without a mouseup', async () => {
-    const getResizeTemplate = jest.fn(() => '10px');
-    render(<TestTable getResizeTemplate={getResizeTemplate} />);
-    const resizer = screen.getByTestId('resizer');
-
-    // A missed mouseup (e.g. the pointer was released outside the window) leaves the
-    // first drag's listeners attached; starting a second drag must remove them so a
-    // single move can't fire two handlers. userEvent cannot model a missed mouseup, so
-    // dispatch the events directly.
-    resizer.dispatchEvent(
-      new MouseEvent('mousedown', {bubbles: true, cancelable: true, clientX: 100})
-    );
-    resizer.dispatchEvent(
-      new MouseEvent('mousedown', {bubbles: true, cancelable: true, clientX: 100})
-    );
-    getResizeTemplate.mockClear();
-    window.dispatchEvent(new MouseEvent('mousemove', {bubbles: true, clientX: 160}));
-
-    await waitFor(() => expect(getResizeTemplate).toHaveBeenCalled());
-    expect(getResizeTemplate).toHaveBeenCalledTimes(1);
   });
 });

--- a/static/app/components/tables/useColumnResize.spec.tsx
+++ b/static/app/components/tables/useColumnResize.spec.tsx
@@ -127,6 +127,25 @@ describe('useColumnResize', () => {
     expect(onColumnResizeEnd).not.toHaveBeenCalled();
   });
 
+  it('does not commit a width when arrowed across the resize axis', async () => {
+    const onColumnResizeEnd = jest.fn();
+    render(<TestTable onColumnResizeEnd={onColumnResizeEnd} />);
+
+    await userEvent.tab();
+    await userEvent.keyboard('{ArrowDown}');
+
+    expect(onColumnResizeEnd).not.toHaveBeenCalled();
+  });
+
+  it('does not commit a width when the drag never travelled along the axis', () => {
+    const onColumnResizeEnd = jest.fn();
+    render(<TestTable onColumnResizeEnd={onColumnResizeEnd} />);
+
+    dragHandle(resizer(), {from: 100, to: 100, y: 60});
+
+    expect(onColumnResizeEnd).not.toHaveBeenCalled();
+  });
+
   // jsdom reports every element as zero-sized, so the geometry the resizer observes
   // has to be stubbed before the observers are triggered by hand.
   function stubGeometry({cell, table}: {cell: number; table: number}) {

--- a/static/app/components/tables/useColumnResize.spec.tsx
+++ b/static/app/components/tables/useColumnResize.spec.tsx
@@ -57,7 +57,7 @@ describe('useColumnResize', () => {
     await waitFor(() => expect(getResizeTemplate).toHaveBeenCalledWith(0, 60));
   });
 
-  it('commits the final width when the drag ends', async () => {
+  it('commits the final width when the drag ends', () => {
     const onColumnResizeEnd = jest.fn();
     render(<TestTable onColumnResizeEnd={onColumnResizeEnd} />);
 
@@ -78,7 +78,7 @@ describe('useColumnResize', () => {
     expect(getResizeTemplate).not.toHaveBeenCalled();
   });
 
-  it('does not start a resize from a non-primary button', async () => {
+  it('does not start a resize from a non-primary button', () => {
     const onColumnResizeEnd = jest.fn();
     render(<TestTable onColumnResizeEnd={onColumnResizeEnd} />);
 
@@ -142,6 +142,7 @@ describe('useColumnResize', () => {
 
     act(triggerResizeObservers);
 
+    // eslint-disable-next-line jest-dom/prefer-to-have-value
     expect(resizer()).toHaveAttribute('aria-valuenow', '150');
   });
 

--- a/static/app/components/tables/useColumnResize.spec.tsx
+++ b/static/app/components/tables/useColumnResize.spec.tsx
@@ -105,6 +105,18 @@ describe('useColumnResize', () => {
     expect(onColumnResizeEnd).toHaveBeenCalledWith(0, expected);
   });
 
+  it('names the resize handle after the column it resizes', () => {
+    render(<TestTable />);
+
+    expect(resizer()).toHaveAccessibleName('Column');
+  });
+
+  it('leaves the header cell named by its own content', () => {
+    render(<TestTable />);
+
+    expect(screen.getByRole('columnheader')).toHaveAccessibleName('Column');
+  });
+
   it('does not resize when a key other than an arrow is pressed', async () => {
     const onColumnResizeEnd = jest.fn();
     render(<TestTable onColumnResizeEnd={onColumnResizeEnd} />);

--- a/static/app/components/tables/useColumnResize.spec.tsx
+++ b/static/app/components/tables/useColumnResize.spec.tsx
@@ -1,7 +1,8 @@
 import {useRef} from 'react';
 
 import {dragHandle} from 'sentry-test/dragMove';
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {triggerResizeObservers} from 'sentry-test/resizeObserver';
 
 import {ColumnResizer} from 'sentry/components/tables/columnResizer';
 import {useColumnResize} from 'sentry/components/tables/useColumnResize';
@@ -9,20 +10,17 @@ import {useColumnResize} from 'sentry/components/tables/useColumnResize';
 interface TestTableProps {
   getResizeTemplate?: (columnIndex: number, newWidth: number) => string;
   onColumnResizeEnd?: (columnIndex: number, newWidth: number) => void;
-  writeResizerHeightVar?: boolean;
 }
 
 function TestTable({
   getResizeTemplate = (_index, newWidth) => `${Math.round(newWidth)}px`,
   onColumnResizeEnd,
-  writeResizerHeightVar,
 }: TestTableProps) {
   const gridRef = useRef<HTMLTableElement>(null);
   const {onResizeEnd, onResizeMove, onResizeStart} = useColumnResize({
     gridRef,
     getResizeTemplate,
     onColumnResizeEnd,
-    writeResizerHeightVar,
   });
 
   return (
@@ -33,7 +31,6 @@ function TestTable({
             <div>Column</div>
             <ColumnResizer
               columnIndex={0}
-              dataRows={0}
               onResizeEnd={onResizeEnd}
               onResizeMove={onResizeMove}
               onResizeStart={onResizeStart}
@@ -118,29 +115,42 @@ describe('useColumnResize', () => {
     expect(onColumnResizeEnd).not.toHaveBeenCalled();
   });
 
-  it('sets the resizer-height CSS variable when writeResizerHeightVar is enabled', async () => {
-    render(<TestTable writeResizerHeightVar />);
+  // jsdom reports every element as zero-sized, so the geometry the resizer observes
+  // has to be stubbed before the observers are triggered by hand.
+  function stubGeometry({cell, table}: {cell: number; table: number}) {
+    Object.defineProperty(screen.getByRole('columnheader'), 'offsetWidth', {
+      configurable: true,
+      get: () => cell,
+    });
+    const grid = screen.getByTestId('grid');
+    Object.defineProperty(grid, 'clientWidth', {configurable: true, get: () => table});
+    Object.defineProperty(grid, 'offsetHeight', {configurable: true, get: () => 240});
+  }
 
-    dragHandle(resizer(), {from: 100, to: 150});
+  it('publishes the table height to the handle as a CSS variable', () => {
+    render(<TestTable />);
+    stubGeometry({cell: 150, table: 900});
 
-    await waitFor(() =>
-      expect(
-        screen
-          .getByTestId('grid')
-          .style.getPropertyValue('--grid-editable-resizer-height')
-      ).toBe('0px')
-    );
+    act(triggerResizeObservers);
+
+    expect(resizer().style.getPropertyValue('--column-resizer-height')).toBe('240px');
   });
 
-  it('does not set the resizer-height CSS variable by default', async () => {
-    const getResizeTemplate = jest.fn(() => '50px');
-    render(<TestTable getResizeTemplate={getResizeTemplate} />);
+  it('announces the observed column width against the table width', () => {
+    render(<TestTable />);
+    stubGeometry({cell: 150, table: 900});
 
-    dragHandle(resizer(), {from: 100, to: 150});
-    await waitFor(() => expect(getResizeTemplate).toHaveBeenCalled());
+    act(triggerResizeObservers);
 
-    expect(
-      screen.getByTestId('grid').style.getPropertyValue('--grid-editable-resizer-height')
-    ).toBe('');
+    expect(resizer()).toHaveAttribute('aria-valuenow', '150');
+  });
+
+  it('announces the table width as the upper bound', () => {
+    render(<TestTable />);
+    stubGeometry({cell: 150, table: 900});
+
+    act(triggerResizeObservers);
+
+    expect(resizer()).toHaveAttribute('aria-valuemax', '900');
   });
 });

--- a/static/app/components/tables/useColumnResize.tsx
+++ b/static/app/components/tables/useColumnResize.tsx
@@ -33,6 +33,14 @@ export function useColumnResize<T extends HTMLElement>({
   onColumnResizeEnd,
 }: UseColumnResizeOptions<T>) {
   const resizeStateRef = useRef<ColumnResizeState | null>(null);
+  const frameRef = useRef<number | null>(null);
+
+  const cancelPendingFrame = useCallback(() => {
+    if (frameRef.current !== null) {
+      window.cancelAnimationFrame(frameRef.current);
+      frameRef.current = null;
+    }
+  }, []);
 
   const applyTemplate = useCallback(
     (template: string) => {
@@ -61,11 +69,16 @@ export function useColumnResize<T extends HTMLElement>({
       // fractional on a scaled display, and a consumer may persist the width.
       state.width += delta;
 
-      window.requestAnimationFrame(() =>
-        applyTemplate(getResizeTemplate(state.columnIndex, Math.round(state.width)))
-      );
+      // Several pointer moves can land in one frame, and they would all write the
+      // same template, so only the newest is kept.
+      cancelPendingFrame();
+
+      frameRef.current = window.requestAnimationFrame(() => {
+        frameRef.current = null;
+        applyTemplate(getResizeTemplate(state.columnIndex, Math.round(state.width)));
+      });
     },
-    [applyTemplate, getResizeTemplate]
+    [applyTemplate, cancelPendingFrame, getResizeTemplate]
   );
 
   const onResizeEnd = useCallback(() => {
@@ -74,9 +87,15 @@ export function useColumnResize<T extends HTMLElement>({
       return;
     }
 
+    // Written synchronously rather than left to the dropped frame: consumers that only
+    // track widths through `getResizeTemplate` have no other chance to see the last one.
+    cancelPendingFrame();
     resizeStateRef.current = null;
-    onColumnResizeEnd?.(state.columnIndex, Math.round(state.width));
-  }, [onColumnResizeEnd]);
+
+    const width = Math.round(state.width);
+    applyTemplate(getResizeTemplate(state.columnIndex, width));
+    onColumnResizeEnd?.(state.columnIndex, width);
+  }, [applyTemplate, cancelPendingFrame, getResizeTemplate, onColumnResizeEnd]);
 
   return {applyTemplate, onResizeEnd, onResizeMove, onResizeStart};
 }

--- a/static/app/components/tables/useColumnResize.tsx
+++ b/static/app/components/tables/useColumnResize.tsx
@@ -15,11 +15,6 @@ interface UseColumnResizeOptions<T extends HTMLElement> {
    * Persist the finalized width once the resize ends.
    */
   onColumnResizeEnd?: (columnIndex: number, newWidth: number) => void;
-
-  /**
-   * Whether to set the `--grid-editable-resizer-height` CSS var to the rendered height after writing.
-   */
-  writeResizerHeightVar?: boolean;
 }
 
 interface ColumnResizeState {
@@ -36,7 +31,6 @@ export function useColumnResize<T extends HTMLElement>({
   gridRef,
   getResizeTemplate,
   onColumnResizeEnd,
-  writeResizerHeightVar = false,
 }: UseColumnResizeOptions<T>) {
   const resizeStateRef = useRef<ColumnResizeState | null>(null);
 
@@ -48,15 +42,8 @@ export function useColumnResize<T extends HTMLElement>({
       }
 
       grid.style.gridTemplateColumns = template;
-
-      if (writeResizerHeightVar) {
-        grid.style.setProperty(
-          '--grid-editable-resizer-height',
-          `${grid.offsetHeight}px`
-        );
-      }
     },
-    [gridRef, writeResizerHeightVar]
+    [gridRef]
   );
 
   const onResizeStart = useCallback((columnIndex: number, cell: HTMLElement | null) => {

--- a/static/app/components/tables/useColumnResize.tsx
+++ b/static/app/components/tables/useColumnResize.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useRef} from 'react';
+import {useCallback, useRef} from 'react';
 
 interface UseColumnResizeOptions<T extends HTMLElement> {
   /**
@@ -12,7 +12,7 @@ interface UseColumnResizeOptions<T extends HTMLElement> {
   gridRef: React.RefObject<T | null>;
 
   /**
-   * Persist the finalized width once the drag ends (`mouseup`).
+   * Persist the finalized width once the resize ends.
    */
   onColumnResizeEnd?: (columnIndex: number, newWidth: number) => void;
 
@@ -24,14 +24,13 @@ interface UseColumnResizeOptions<T extends HTMLElement> {
 
 interface ColumnResizeState {
   columnIndex: number;
-  startWidth: number;
-  startX: number;
+  width: number;
 }
 
 /**
- * Shared column-resize drag mechanic for the sanctioned table shells. Owns the
- * pointer lifecycle (`mousedown` -> window `mousemove`/`mouseup` -> cleanup) and the
- * imperative write to the grid's `gridTemplateColumns`.
+ * Shared column-resize mechanic for the sanctioned table shells. Owns the width
+ * accumulation and the imperative write to the grid's `gridTemplateColumns`; the
+ * handles themselves own the interaction and report movement as a delta.
  */
 export function useColumnResize<T extends HTMLElement>({
   gridRef,
@@ -40,7 +39,6 @@ export function useColumnResize<T extends HTMLElement>({
   writeResizerHeightVar = false,
 }: UseColumnResizeOptions<T>) {
   const resizeStateRef = useRef<ColumnResizeState | null>(null);
-  const abortControllerRef = useRef<AbortController | null>(null);
 
   const applyTemplate = useCallback(
     (template: string) => {
@@ -61,66 +59,37 @@ export function useColumnResize<T extends HTMLElement>({
     [gridRef, writeResizerHeightVar]
   );
 
-  const onResizeMouseDown = useCallback(
-    (event: React.MouseEvent, columnIndex = -1) => {
-      event.stopPropagation();
-      event.preventDefault();
+  const onResizeStart = useCallback((columnIndex: number, cell: HTMLElement | null) => {
+    resizeStateRef.current = {columnIndex, width: cell?.offsetWidth ?? 0};
+  }, []);
 
-      // Block right-click and other funky stuff.
-      if (columnIndex === -1 || event.type === 'contextmenu') {
+  const onResizeMove = useCallback(
+    (delta: number) => {
+      const state = resizeStateRef.current;
+      if (!state) {
         return;
       }
 
-      // The resize handle is expected to be nested 1 level down from the head cell.
-      const cell = event.currentTarget.parentElement;
-      if (!cell) {
-        return;
-      }
+      // Accumulated at full precision, but reported rounded: pointer deltas are
+      // fractional on a scaled display, and a consumer may persist the width.
+      state.width += delta;
 
-      resizeStateRef.current = {
-        columnIndex,
-        startWidth: cell.offsetWidth,
-        startX: event.clientX,
-      };
-
-      const onMouseMove = (e: MouseEvent) => {
-        const state = resizeStateRef.current;
-        if (!state) {
-          return;
-        }
-
-        const newWidth = state.startWidth + (e.clientX - state.startX);
-
-        window.requestAnimationFrame(() =>
-          applyTemplate(getResizeTemplate(state.columnIndex, newWidth))
-        );
-      };
-
-      const onMouseUp = (e: MouseEvent) => {
-        const state = resizeStateRef.current;
-        if (state) {
-          onColumnResizeEnd?.(
-            state.columnIndex,
-            state.startWidth + (e.clientX - state.startX)
-          );
-        }
-        resizeStateRef.current = null;
-        abortControllerRef.current?.abort();
-      };
-
-      abortControllerRef.current?.abort();
-
-      const abortController = new AbortController();
-      abortControllerRef.current = abortController;
-
-      const {signal} = abortController;
-      window.addEventListener('mousemove', onMouseMove, {signal});
-      window.addEventListener('mouseup', onMouseUp, {signal});
+      window.requestAnimationFrame(() =>
+        applyTemplate(getResizeTemplate(state.columnIndex, Math.round(state.width)))
+      );
     },
-    [applyTemplate, getResizeTemplate, onColumnResizeEnd]
+    [applyTemplate, getResizeTemplate]
   );
 
-  useEffect(() => () => abortControllerRef.current?.abort(), []);
+  const onResizeEnd = useCallback(() => {
+    const state = resizeStateRef.current;
+    if (!state) {
+      return;
+    }
 
-  return {onResizeMouseDown, applyTemplate};
+    resizeStateRef.current = null;
+    onColumnResizeEnd?.(state.columnIndex, Math.round(state.width));
+  }, [onColumnResizeEnd]);
+
+  return {applyTemplate, onResizeEnd, onResizeMove, onResizeStart};
 }

--- a/static/app/components/tables/useColumnResize.tsx
+++ b/static/app/components/tables/useColumnResize.tsx
@@ -19,6 +19,7 @@ interface UseColumnResizeOptions<T extends HTMLElement> {
 
 interface ColumnResizeState {
   columnIndex: number;
+  moved: boolean;
   width: number;
 }
 
@@ -55,7 +56,7 @@ export function useColumnResize<T extends HTMLElement>({
   );
 
   const onResizeStart = useCallback((columnIndex: number, cell: HTMLElement | null) => {
-    resizeStateRef.current = {columnIndex, width: cell?.offsetWidth ?? 0};
+    resizeStateRef.current = {columnIndex, moved: false, width: cell?.offsetWidth ?? 0};
   }, []);
 
   const onResizeMove = useCallback(
@@ -68,6 +69,7 @@ export function useColumnResize<T extends HTMLElement>({
       // Accumulated at full precision, but reported rounded: pointer deltas are
       // fractional on a scaled display, and a consumer may persist the width.
       state.width += delta;
+      state.moved = true;
 
       // Several pointer moves can land in one frame, and they would all write the
       // same template, so only the newest is kept.
@@ -91,6 +93,12 @@ export function useColumnResize<T extends HTMLElement>({
     // track widths through `getResizeTemplate` have no other chance to see the last one.
     cancelPendingFrame();
     resizeStateRef.current = null;
+
+    // A drag that never travelled along the axis has nothing to commit, and committing
+    // would pin an auto-sized column to the width it happened to have.
+    if (!state.moved) {
+      return;
+    }
 
     const width = Math.round(state.width);
     applyTemplate(getResizeTemplate(state.columnIndex, width));

--- a/static/app/components/tables/useObservedColumnSize.tsx
+++ b/static/app/components/tables/useObservedColumnSize.tsx
@@ -8,23 +8,28 @@ interface ColumnAncestors {
 
 const NO_ANCESTORS: ColumnAncestors = {cell: null, table: null};
 
+function setProperty(element: HTMLElement, property: string, value: string) {
+  if (element.style.getPropertyValue(property) !== value) {
+    element.style.setProperty(property, value);
+  }
+}
+
 function measureColumn(
   element: HTMLElement,
   cell: HTMLTableCellElement,
   table: HTMLTableElement
 ) {
-  const height = `${table.offsetHeight}px`;
-
-  if (element.style.getPropertyValue('--column-resizer-height') !== height) {
-    element.style.setProperty('--column-resizer-height', height);
-  }
+  setProperty(element, '--column-resizer-height', `${table.offsetHeight}px`);
+  setProperty(element, '--drag-separator-target-length', `${cell.offsetHeight}px`);
 
   return {max: Math.max(table.clientWidth, cell.offsetWidth), width: cell.offsetWidth};
 }
 
 /**
  * Measures the column a resize handle belongs to, for the values the handle
- * announces, and sets the height it should span as `--column-resizer-height`.
+ * announces, the height it should span as `--column-resizer-height`, and the
+ * header row height its pointer target is capped to as
+ * `--drag-separator-target-length`.
  */
 export function useObservedColumnSize(elementRef: React.RefObject<HTMLElement | null>) {
   const [measurements, setMeasurements] = useState({max: 0, width: 0});

--- a/static/app/components/tables/useObservedColumnSize.tsx
+++ b/static/app/components/tables/useObservedColumnSize.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useMemo, useState} from 'react';
+import {useCallback, useLayoutEffect, useMemo, useState} from 'react';
 import {useResizeObserver} from '@react-aria/utils';
 
 interface ColumnAncestors {
@@ -8,6 +8,20 @@ interface ColumnAncestors {
 
 const NO_ANCESTORS: ColumnAncestors = {cell: null, table: null};
 
+function measureColumn(
+  element: HTMLElement,
+  cell: HTMLTableCellElement,
+  table: HTMLTableElement
+) {
+  const height = `${table.offsetHeight}px`;
+
+  if (element.style.getPropertyValue('--column-resizer-height') !== height) {
+    element.style.setProperty('--column-resizer-height', height);
+  }
+
+  return {max: Math.max(table.clientWidth, cell.offsetWidth), width: cell.offsetWidth};
+}
+
 /**
  * Measures the column a resize handle belongs to, for the values the handle
  * announces, and sets the height it should span as `--column-resizer-height`.
@@ -16,11 +30,28 @@ export function useObservedColumnSize(elementRef: React.RefObject<HTMLElement | 
   const [measurements, setMeasurements] = useState({max: 0, width: 0});
   const [{cell, table}, setAncestors] = useState(NO_ANCESTORS);
 
-  useEffect(() => {
-    const found = elementRef.current?.closest('th') ?? null;
+  const measure = useCallback(
+    (element: HTMLElement, target: HTMLTableCellElement, grid: HTMLTableElement) => {
+      const next = measureColumn(element, target, grid);
 
-    setAncestors({cell: found, table: found?.closest('table') ?? null});
-  }, [elementRef]);
+      setMeasurements(current =>
+        current.max === next.max && current.width === next.width ? current : next
+      );
+    },
+    []
+  );
+
+  useLayoutEffect(() => {
+    const element = elementRef.current;
+    const foundCell = element?.closest('th') ?? null;
+    const foundTable = foundCell?.closest('table') ?? null;
+
+    setAncestors({cell: foundCell, table: foundTable});
+
+    if (element && foundCell && foundTable) {
+      measure(element, foundCell, foundTable);
+    }
+  }, [elementRef, measure]);
 
   const cellRef = useMemo(() => ({current: cell}), [cell]);
   const tableRef = useMemo(() => ({current: table}), [table]);
@@ -31,13 +62,8 @@ export function useObservedColumnSize(elementRef: React.RefObject<HTMLElement | 
       return;
     }
 
-    element.style.setProperty('--column-resizer-height', `${table.offsetHeight}px`);
-
-    setMeasurements({
-      max: Math.max(table.clientWidth, cell.offsetWidth),
-      width: cell.offsetWidth,
-    });
-  }, [cell, elementRef, table]);
+    measure(element, cell, table);
+  }, [cell, elementRef, measure, table]);
 
   useResizeObserver({ref: cellRef, onResize});
   useResizeObserver({ref: tableRef, onResize});

--- a/static/app/components/tables/useObservedColumnSize.tsx
+++ b/static/app/components/tables/useObservedColumnSize.tsx
@@ -1,4 +1,12 @@
-import {useEffect, useState} from 'react';
+import {useCallback, useEffect, useMemo, useState} from 'react';
+import {useResizeObserver} from '@react-aria/utils';
+
+interface ColumnAncestors {
+  cell: HTMLTableCellElement | null;
+  table: HTMLTableElement | null;
+}
+
+const NO_ANCESTORS: ColumnAncestors = {cell: null, table: null};
 
 /**
  * Measures the column a resize handle belongs to, for the values the handle
@@ -6,28 +14,33 @@ import {useEffect, useState} from 'react';
  */
 export function useObservedColumnSize(elementRef: React.RefObject<HTMLElement | null>) {
   const [measurements, setMeasurements] = useState({max: 0, width: 0});
+  const [{cell, table}, setAncestors] = useState(NO_ANCESTORS);
 
   useEffect(() => {
-    const element = elementRef.current;
-    const cell = element?.closest('th');
-    const table = cell?.closest('table');
-    if (!element || !cell || !table) {
-      return () => {};
-    }
+    const found = elementRef.current?.closest('th') ?? null;
 
-    const observer = new ResizeObserver(() => {
-      element.style.setProperty('--column-resizer-height', `${table.offsetHeight}px`);
-
-      setMeasurements({
-        max: Math.max(table.clientWidth, cell.offsetWidth),
-        width: cell.offsetWidth,
-      });
-    });
-    observer.observe(cell);
-    observer.observe(table);
-
-    return () => observer.disconnect();
+    setAncestors({cell: found, table: found?.closest('table') ?? null});
   }, [elementRef]);
 
-  return measurements;
+  const cellRef = useMemo(() => ({current: cell}), [cell]);
+  const tableRef = useMemo(() => ({current: table}), [table]);
+
+  const onResize = useCallback(() => {
+    const element = elementRef.current;
+    if (!element || !cell || !table) {
+      return;
+    }
+
+    element.style.setProperty('--column-resizer-height', `${table.offsetHeight}px`);
+
+    setMeasurements({
+      max: Math.max(table.clientWidth, cell.offsetWidth),
+      width: cell.offsetWidth,
+    });
+  }, [cell, elementRef, table]);
+
+  useResizeObserver({ref: cellRef, onResize});
+  useResizeObserver({ref: tableRef, onResize});
+
+  return {cell, ...measurements};
 }

--- a/static/app/components/tables/useObservedColumnSize.tsx
+++ b/static/app/components/tables/useObservedColumnSize.tsx
@@ -1,0 +1,33 @@
+import {useEffect, useState} from 'react';
+
+/**
+ * Measures the column a resize handle belongs to, for the values the handle
+ * announces, and sets the height it should span as `--column-resizer-height`.
+ */
+export function useObservedColumnSize(elementRef: React.RefObject<HTMLElement | null>) {
+  const [measurements, setMeasurements] = useState({max: 0, width: 0});
+
+  useEffect(() => {
+    const element = elementRef.current;
+    const cell = element?.closest('th');
+    const table = cell?.closest('table');
+    if (!element || !cell || !table) {
+      return () => {};
+    }
+
+    const observer = new ResizeObserver(() => {
+      element.style.setProperty('--column-resizer-height', `${table.offsetHeight}px`);
+
+      setMeasurements({
+        max: Math.max(table.clientWidth, cell.offsetWidth),
+        width: cell.offsetWidth,
+      });
+    });
+    observer.observe(cell);
+    observer.observe(table);
+
+    return () => observer.disconnect();
+  }, [elementRef]);
+
+  return measurements;
+}

--- a/static/app/utils/setDocumentDragging.tsx
+++ b/static/app/utils/setDocumentDragging.tsx
@@ -1,0 +1,12 @@
+/**
+ * Locks the document for the duration of a drag, or releases it when passed `null`.
+ *
+ * A drag travels outside the element that started it, so suppressing hover and text
+ * selection — and holding the resize cursor — has to happen at the document level.
+ * The cursor goes on the root element because pointer events are disabled on `body`.
+ */
+export function setDocumentDragging(cursor: React.CSSProperties['cursor'] | null) {
+  document.body.style.pointerEvents = cursor ? 'none' : '';
+  document.body.style.userSelect = cursor ? 'none' : '';
+  document.documentElement.style.cursor = cursor ?? '';
+}

--- a/static/app/utils/useResizableDrawer.tsx
+++ b/static/app/utils/useResizableDrawer.tsx
@@ -1,5 +1,7 @@
 import {useCallback, useLayoutEffect, useRef, useState} from 'react';
 
+import {setDocumentDragging} from 'sentry/utils/setDocumentDragging';
+
 export interface UseResizableDrawerOptions {
   /**
    * When dragging, which direction should be used for the delta
@@ -123,12 +125,7 @@ export function useResizableDrawer(options: UseResizableDrawerOptions): {
       const isXAxis = options.direction === 'left' || options.direction === 'right';
       const isInverted = options.direction === 'down' || options.direction === 'left';
 
-      document.body.style.pointerEvents = 'none';
-      document.body.style.userSelect = 'none';
-
-      // We've disabled pointerEvents on the body, the cursor needs to be
-      // applied to the root most element to work
-      document.documentElement.style.cursor = isXAxis ? 'ew-resize' : 'ns-resize';
+      setDocumentDragging(isXAxis ? 'ew-resize' : 'ns-resize');
 
       if (rafIdRef.current !== null) {
         window.cancelAnimationFrame(rafIdRef.current);
@@ -168,9 +165,7 @@ export function useResizableDrawer(options: UseResizableDrawerOptions): {
   const dragStartSizeRef = useRef<number | null>(null);
 
   const onDragEnd = useCallback(() => {
-    document.body.style.pointerEvents = '';
-    document.body.style.userSelect = '';
-    document.documentElement.style.cursor = '';
+    setDocumentDragging(null);
     document.removeEventListener('mousemove', onDragMove);
     document.removeEventListener('mouseup', onDragEnd);
     document.removeEventListener('pointermove', onDragMove);

--- a/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.spec.tsx
+++ b/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.spec.tsx
@@ -3,6 +3,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {TabularColumnsFixture} from 'sentry-fixture/tabularColumns';
 import {ThemeFixture} from 'sentry-fixture/theme';
 
+import {dragHandle} from 'sentry-test/dragMove';
 import {
   render,
   screen,
@@ -264,11 +265,7 @@ describe('TableWidgetVisualization', () => {
       );
 
       const $gridResizer = screen.getAllByRole('columnheader')[0]?.children[1]!;
-      await userEvent.pointer([
-        {keys: '[MouseLeft>]', target: $gridResizer},
-        {target: $gridResizer, coords: {x: 100}},
-        {keys: '[/MouseLeft]'},
-      ]);
+      dragHandle($gridResizer as HTMLElement, {from: 0, to: 100});
       await waitFor(() =>
         expect(testRouter.location.query.width).toStrictEqual(['100', '-1'])
       );
@@ -284,11 +281,7 @@ describe('TableWidgetVisualization', () => {
       );
 
       const $gridResizer = screen.getAllByRole('columnheader')[0]?.children[1]!;
-      await userEvent.pointer([
-        {keys: '[MouseLeft>]', target: $gridResizer},
-        {target: $gridResizer, coords: {x: 100}},
-        {keys: '[/MouseLeft]'},
-      ]);
+      dragHandle($gridResizer as HTMLElement, {from: 0, to: 100});
       await waitFor(() =>
         expect(onResizeColumnMock).toHaveBeenCalledWith([
           {

--- a/static/app/views/explore/components/table.tsx
+++ b/static/app/views/explore/components/table.tsx
@@ -114,7 +114,7 @@ export function useTableStyles(
     [buildGridTemplateColumns]
   );
 
-  const {onResizeMouseDown} = useColumnResize({
+  const {onResizeEnd, onResizeMove, onResizeStart} = useColumnResize({
     gridRef: tableRef,
     getResizeTemplate: (index, newWidth) => {
       columnWidthsRef.current[index] = Math.max(minimumColumnWidth, newWidth);
@@ -122,7 +122,7 @@ export function useTableStyles(
     },
   });
 
-  return {initialTableStyles, onResizeMouseDown};
+  return {initialTableStyles, onResizeEnd, onResizeMove, onResizeStart};
 }
 
 export const TableBody = GridBody;

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
@@ -802,7 +802,7 @@ function LogsTableHeader({
   const sortBys = useQueryParamsSortBys();
   const setSortBys = useSetQueryParamsSortBys();
 
-  const {data, meta, isError, isPending} = useLogsPageDataQueryResult();
+  const {meta, isPending} = useLogsPageDataQueryResult();
   const resolvedMeta = useMemo(
     () => addValidatedFieldTypesToLogsMeta({meta, validatedFieldTypes}),
     [meta, validatedFieldTypes]
@@ -865,7 +865,6 @@ function LogsTableHeader({
               {index !== fields.length - 1 && (
                 <ColumnResizer
                   columnIndex={index}
-                  dataRows={!isError && !isPending && data ? data.length : 0}
                   onResizeEnd={onResizeEnd}
                   onResizeMove={onResizeMove}
                   onResizeStart={onResizeStart}

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
@@ -21,7 +21,7 @@ import {FileSize} from 'sentry/components/fileSize';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {JumpButtons} from 'sentry/components/replays/jumpButtons';
 import {useJumpButtons} from 'sentry/components/replays/useJumpButtons';
-import {GridResizer} from 'sentry/components/tables/gridEditable/styles';
+import {ColumnResizer} from 'sentry/components/tables/columnResizer';
 import {
   getAriaSort,
   SortableHeaderCell,
@@ -441,7 +441,7 @@ export function LogsInfiniteTable({
     dataLength: data?.length ?? 0,
   });
 
-  const {initialTableStyles, onResizeMouseDown} = useTableStyles(
+  const {initialTableStyles, onResizeEnd, onResizeMove, onResizeStart} = useTableStyles(
     fields.slice(),
     tableRef,
     {
@@ -650,7 +650,9 @@ export function LogsInfiniteTable({
             stringAttributes={stringAttributes}
             booleanAttributes={booleanAttributes}
             validatedFieldTypes={validatedFieldTypes}
-            onResizeMouseDown={onResizeMouseDown}
+            onResizeEnd={onResizeEnd}
+            onResizeMove={onResizeMove}
+            onResizeStart={onResizeStart}
           />
         )}
         {!isPending && logsPinning && (
@@ -784,13 +786,17 @@ function LogsTableHeader({
   numberAttributes,
   stringAttributes,
   validatedFieldTypes = {},
-  onResizeMouseDown,
+  onResizeEnd,
+  onResizeMove,
+  onResizeStart,
 }: Pick<
   LogsTableProps,
   'numberAttributes' | 'stringAttributes' | 'booleanAttributes' | 'validatedFieldTypes'
 > & {
   isFrozen: boolean;
-  onResizeMouseDown: (e: React.MouseEvent<HTMLDivElement>, index: number) => void;
+  onResizeEnd: () => void;
+  onResizeMove: (delta: number) => void;
+  onResizeStart: (columnIndex: number, cell: HTMLElement | null) => void;
 }) {
   const fields = useQueryParamsFields();
   const sortBys = useQueryParamsSortBys();
@@ -857,9 +863,12 @@ function LogsTableHeader({
                 {headerLabel}
               </SortableHeaderCell>
               {index !== fields.length - 1 && (
-                <GridResizer
+                <ColumnResizer
+                  columnIndex={index}
                   dataRows={!isError && !isPending && data ? data.length : 0}
-                  onMouseDown={e => onResizeMouseDown(e, index)}
+                  onResizeEnd={onResizeEnd}
+                  onResizeMove={onResizeMove}
+                  onResizeStart={onResizeStart}
                 />
               )}
             </LogTableHeadCell>

--- a/static/app/views/explore/tables/aggregatesTable.tsx
+++ b/static/app/views/explore/tables/aggregatesTable.tsx
@@ -9,7 +9,7 @@ import {EmptyStateWarning} from 'sentry/components/emptyStateWarning';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
-import {GridResizer} from 'sentry/components/tables/gridEditable/styles';
+import {ColumnResizer} from 'sentry/components/tables/columnResizer';
 import {
   getAriaSort,
   SortableHeaderCell,
@@ -106,7 +106,7 @@ export function AggregatesTable({
   );
 
   const tableRef = useRef<HTMLTableElement>(null);
-  const {initialTableStyles, onResizeMouseDown} = useTableStyles(
+  const {initialTableStyles, onResizeEnd, onResizeMove, onResizeStart} = useTableStyles(
     visibleAggregateFields.map(aggregateField => {
       if (isGroupBy(aggregateField)) {
         return aggregateField.groupBy;
@@ -188,13 +188,16 @@ export function AggregatesTable({
                     {label}
                   </SortableHeaderCell>
                   {i !== visibleAggregateFields.length - 1 && (
-                    <GridResizer
+                    <ColumnResizer
+                      columnIndex={i}
                       dataRows={
                         !result.isError && !result.isPending && result.data
                           ? result.data.length
                           : 0
                       }
-                      onMouseDown={e => onResizeMouseDown(e, i)}
+                      onResizeEnd={onResizeEnd}
+                      onResizeMove={onResizeMove}
+                      onResizeStart={onResizeStart}
                     />
                   )}
                 </TableHeadCell>

--- a/static/app/views/explore/tables/aggregatesTable.tsx
+++ b/static/app/views/explore/tables/aggregatesTable.tsx
@@ -190,11 +190,6 @@ export function AggregatesTable({
                   {i !== visibleAggregateFields.length - 1 && (
                     <ColumnResizer
                       columnIndex={i}
-                      dataRows={
-                        !result.isError && !result.isPending && result.data
-                          ? result.data.length
-                          : 0
-                      }
                       onResizeEnd={onResizeEnd}
                       onResizeMove={onResizeMove}
                       onResizeStart={onResizeStart}

--- a/static/app/views/explore/tables/spansTable.tsx
+++ b/static/app/views/explore/tables/spansTable.tsx
@@ -4,7 +4,7 @@ import {Pagination} from '@sentry/scraps/pagination';
 
 import {EmptyStateWarning} from 'sentry/components/emptyStateWarning';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
-import {GridResizer} from 'sentry/components/tables/gridEditable/styles';
+import {ColumnResizer} from 'sentry/components/tables/columnResizer';
 import {
   getAriaSort,
   SortableHeaderCell,
@@ -62,7 +62,7 @@ export function SpansTable({
   const {result, eventView} = spansTableResult;
 
   const tableRef = useRef<HTMLTableElement>(null);
-  const {initialTableStyles, onResizeMouseDown} = useTableStyles(
+  const {initialTableStyles, onResizeEnd, onResizeMove, onResizeStart} = useTableStyles(
     visibleFields,
     tableRef,
     {minimumColumnWidth: 50}
@@ -122,13 +122,16 @@ export function SpansTable({
                     {label}
                   </SortableHeaderCell>
                   {i !== visibleFields.length - 1 && (
-                    <GridResizer
+                    <ColumnResizer
+                      columnIndex={i}
                       dataRows={
                         !result.isError && !result.isPending && result.data
                           ? result.data.length
                           : 0
                       }
-                      onMouseDown={e => onResizeMouseDown(e, i)}
+                      onResizeEnd={onResizeEnd}
+                      onResizeMove={onResizeMove}
+                      onResizeStart={onResizeStart}
                     />
                   )}
                 </TableHeadCell>

--- a/static/app/views/explore/tables/spansTable.tsx
+++ b/static/app/views/explore/tables/spansTable.tsx
@@ -124,11 +124,6 @@ export function SpansTable({
                   {i !== visibleFields.length - 1 && (
                     <ColumnResizer
                       columnIndex={i}
-                      dataRows={
-                        !result.isError && !result.isPending && result.data
-                          ? result.data.length
-                          : 0
-                      }
                       onResizeEnd={onResizeEnd}
                       onResizeMove={onResizeMove}
                       onResizeStart={onResizeStart}

--- a/tests/js/sentry-test/dragMove.tsx
+++ b/tests/js/sentry-test/dragMove.tsx
@@ -1,0 +1,29 @@
+import {act} from 'sentry-test/reactTestingLibrary';
+
+function dispatch(target: EventTarget, type: string, pageX: number, button: number) {
+  const event = new MouseEvent(type, {bubbles: true, button, cancelable: true});
+  Object.defineProperty(event, 'pageX', {value: pageX});
+  Object.defineProperty(event, 'pageY', {value: 0});
+  target.dispatchEvent(event);
+}
+
+interface DragOptions {
+  from: number;
+  to: number;
+  button?: number;
+  release?: boolean;
+}
+
+export function dragHandle(
+  handle: HTMLElement,
+  {button = 0, from, release = true, to}: DragOptions
+) {
+  act(() => {
+    dispatch(handle, 'mousedown', from, button);
+    dispatch(window, 'mousemove', to, button);
+
+    if (release) {
+      dispatch(window, 'mouseup', to, button);
+    }
+  });
+}

--- a/tests/js/sentry-test/dragMove.tsx
+++ b/tests/js/sentry-test/dragMove.tsx
@@ -1,9 +1,15 @@
 import {act} from 'sentry-test/reactTestingLibrary';
 
-function dispatch(target: EventTarget, type: string, pageX: number, button: number) {
+function dispatch(
+  target: EventTarget,
+  type: string,
+  pageX: number,
+  pageY: number,
+  button: number
+) {
   const event = new MouseEvent(type, {bubbles: true, button, cancelable: true});
   Object.defineProperty(event, 'pageX', {value: pageX});
-  Object.defineProperty(event, 'pageY', {value: 0});
+  Object.defineProperty(event, 'pageY', {value: pageY});
   target.dispatchEvent(event);
 }
 
@@ -12,18 +18,19 @@ interface DragOptions {
   to: number;
   button?: number;
   release?: boolean;
+  y?: number;
 }
 
 export function dragHandle(
   handle: HTMLElement,
-  {button = 0, from, release = true, to}: DragOptions
+  {button = 0, from, release = true, to, y = 0}: DragOptions
 ) {
   act(() => {
-    dispatch(handle, 'mousedown', from, button);
-    dispatch(window, 'mousemove', to, button);
+    dispatch(handle, 'mousedown', from, 0, button);
+    dispatch(window, 'mousemove', to, y, button);
 
     if (release) {
-      dispatch(window, 'mouseup', to, button);
+      dispatch(window, 'mouseup', to, y, button);
     }
   });
 }

--- a/tests/js/sentry-test/resizeObserver.ts
+++ b/tests/js/sentry-test/resizeObserver.ts
@@ -2,22 +2,35 @@ const liveObservers = new Set<MockResizeObserver>();
 
 export class MockResizeObserver implements ResizeObserver {
   private callback: ResizeObserverCallback;
+  private targets = new Set<Element>();
 
   constructor(callback: ResizeObserverCallback) {
     this.callback = callback;
     liveObservers.add(this);
   }
 
-  observe() {}
+  observe(target: Element) {
+    this.targets.add(target);
+  }
 
-  unobserve() {}
+  unobserve(target: Element) {
+    this.targets.delete(target);
+  }
 
   disconnect() {
+    this.targets.clear();
     liveObservers.delete(this);
   }
 
   notify() {
-    this.callback([], this);
+    if (!this.targets.size) {
+      return;
+    }
+
+    this.callback(
+      Array.from(this.targets, target => ({target}) as ResizeObserverEntry),
+      this
+    );
   }
 }
 


### PR DESCRIPTION
Stacked on top of #121177 -> #121176.

Adds `core/table`: a UI shell that owns only table geometry. That's `<table>/<thead>/<tbody>/<th>/<td>` on `display: grid` with `grid-template-columns: subgrid`, column tracks, and the resize drag (delegated to the existing `useColumnResize` consolidated in #120563).

Columns are declared as data because a resize needs stable identity and a known column count. Cell contents stay as children.

Split out of #120745, as part of DE-1392. See that PR for the full end state.