### PR TITLE
ref(autofix): Gate manual PR iteration behind its own feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -313,6 +313,10 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-autofix-introspection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the PR iteration feedback flow in the explorer autofix drawer
     manager.add("organizations:autofix-pr-iteration", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable human-triggered PR iteration: the drawer feedback form, `@sentry` PR
+    # comments, and PR reviews. Automated CI iteration stays on
+    # `organizations:autofix-pr-iteration`.
+    manager.add("organizations:autofix-pr-iteration-manual", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # On green CI: mark ready for review and request review from the triggering user.
     # Also opens Autofix PRs as draft until CI is green.
     manager.add("organizations:autofix-pr-iteration-review-request", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)

--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -353,8 +353,11 @@ class SeerAgentClient:
 
         self.enable_coding = enable_coding
 
-        if enable_pr_context_tools and not features.has(
-            "organizations:autofix-pr-iteration", organization, actor=user
+        # PR context tools back both the automated CI and the manual iteration flows,
+        # so either flag grants them.
+        if enable_pr_context_tools and not (
+            features.has("organizations:autofix-pr-iteration", organization, actor=user)
+            or features.has("organizations:autofix-pr-iteration-manual", organization, actor=user)
         ):
             raise SeerPermissionError("PR context tools are not enabled for this organization")
 

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -410,7 +410,12 @@ def trigger_autofix_agent(
 
     config = STEP_CONFIGS[step]
 
-    pr_iteration_enabled = features.has("organizations:autofix-pr-iteration", group.organization)
+    # Either flag enables the PR_ITERATION step itself: automated CI iteration runs
+    # under `autofix-pr-iteration`, human-triggered iteration under the `-manual`
+    # variant. Both reach this function via `trigger_autofix_agent`.
+    pr_iteration_enabled = features.has(
+        "organizations:autofix-pr-iteration", group.organization
+    ) or features.has("organizations:autofix-pr-iteration-manual", group.organization)
     is_iteration_step = step == AutofixStep.PR_ITERATION
 
     client = get_autofix_agent_client(
@@ -879,7 +884,7 @@ def build_pr_description_suffix(group: Group) -> str | None:
             linear_id = external_issue.display_name.replace("#", "-")
             lines.append(f"Fixes [{linear_id}]({external_issue.web_url})")
 
-    if features.has("organizations:autofix-pr-iteration", group.organization):
+    if features.has("organizations:autofix-pr-iteration-manual", group.organization):
         lines.append(
             "\n<sub>Comment `@sentry <feedback>` on this PR to have Autofix iterate on the changes.</sub>"
         )

--- a/src/sentry/seer/autofix/on_completion_hook.py
+++ b/src/sentry/seer/autofix/on_completion_hook.py
@@ -249,7 +249,7 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
         :eyes:->:tada: swap on top-level comments and clearing the lingering :eyes:
         on inline ones.
         """
-        if not features.has("organizations:autofix-pr-iteration", organization=organization):
+        if not features.has("organizations:autofix-pr-iteration-manual", organization=organization):
             return
 
         current_step, _ = cls._get_current_step(state)

--- a/src/sentry/seer/autofix/pr_iteration/listeners/review.py
+++ b/src/sentry/seer/autofix/pr_iteration/listeners/review.py
@@ -142,7 +142,7 @@ def handle_pull_request_review_for_autofix_iteration(event: PullRequestReviewEve
             continue
 
         repo_log_extra = {**log_extra, "organization_id": organization.id, "repo_id": repo.id}
-        if not features.has("organizations:autofix-pr-iteration", organization):
+        if not features.has("organizations:autofix-pr-iteration-manual", organization):
             logger.info(
                 "autofix.pr_iteration.review_listener.feature_disabled", extra=repo_log_extra
             )

--- a/src/sentry/seer/autofix/pr_iteration/mention.py
+++ b/src/sentry/seer/autofix/pr_iteration/mention.py
@@ -85,7 +85,7 @@ def _dispatch_autofix_iteration_from_comment(
     # log at info to make any silent drop debuggable.
     logger.info("autofix.pr_iteration.comment_trigger.received", extra=log_extra)
 
-    if not features.has("organizations:autofix-pr-iteration", organization):
+    if not features.has("organizations:autofix-pr-iteration-manual", organization):
         logger.info("autofix.pr_iteration.comment_trigger.feature_disabled", extra=log_extra)
         return None
 

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -576,6 +576,9 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                         agent_id: agent.dict() for agent_id, agent in state.coding_agents.items()
                     },
                     "pr_iteration_enabled": features.has(
+                        "organizations:autofix-pr-iteration", group.organization
+                    ),
+                    "manual_pr_iteration_enabled": features.has(
                         "organizations:autofix-pr-iteration-manual", group.organization
                     ),
                     "queued_feedback": queued_feedback,

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -355,7 +355,9 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                         status=status.HTTP_400_BAD_REQUEST,
                     )
 
-                if not features.has("organizations:autofix-pr-iteration", group.organization):
+                if not features.has(
+                    "organizations:autofix-pr-iteration-manual", group.organization
+                ):
                     return Response(
                         {"detail": "PR iteration is not enabled for this organization"},
                         status=status.HTTP_400_BAD_REQUEST,
@@ -574,7 +576,7 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                         agent_id: agent.dict() for agent_id, agent in state.coding_agents.items()
                     },
                     "pr_iteration_enabled": features.has(
-                        "organizations:autofix-pr-iteration", group.organization
+                        "organizations:autofix-pr-iteration-manual", group.organization
                     ),
                     "queued_feedback": queued_feedback,
                     "warnings": warnings,

--- a/tests/sentry/seer/agent/test_agent_client.py
+++ b/tests/sentry/seer/agent/test_agent_client.py
@@ -224,6 +224,15 @@ class TestSeerAgentClient(TestCase):
         assert client.enable_pr_context_tools is True
 
     @patch("sentry.seer.agent.client.has_seer_access_with_detail")
+    @with_feature("organizations:autofix-pr-iteration-manual")
+    def test_client_init_succeeds_when_manual_pr_ctx_tools_flag_enabled(self, mock_access):
+        """PR context tools back both iteration flows, so the manual flag alone grants them."""
+        mock_access.return_value = (True, None)
+
+        client = SeerAgentClient(self.organization, self.user, enable_pr_context_tools=True)
+        assert client.enable_pr_context_tools is True
+
+    @patch("sentry.seer.agent.client.has_seer_access_with_detail")
     @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
     @patch("sentry.seer.agent.client.collect_user_org_context")
     def test_start_run_defaults_pr_context_tools_disabled(

--- a/tests/sentry/seer/autofix/pr_iteration/test_mention.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_mention.py
@@ -85,8 +85,11 @@ class HandleIssueCommentForAutofixIterationTest(TestCase):
         mock_delay.assert_not_called()
 
     @patch(f"{MENTION_PATH}.trigger_pr_iteration_from_comment.delay")
-    def test_skips_when_feature_disabled(self, mock_delay: MagicMock) -> None:
-        self._call(self._event())
+    def test_skips_when_manual_feature_disabled(self, mock_delay: MagicMock) -> None:
+        # Automated CI iteration on, manual off: the comment trigger is manual-only,
+        # so the automated flag must not enable it.
+        with self.feature("organizations:autofix-pr-iteration"):
+            self._call(self._event())
         mock_delay.assert_not_called()
 
     @patch(f"{MENTION_PATH}.trigger_pr_iteration_from_comment.delay")

--- a/tests/sentry/seer/autofix/pr_iteration/test_mention.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_mention.py
@@ -43,7 +43,7 @@ class HandleIssueCommentForAutofixIterationTest(TestCase):
 
     @patch(f"{MENTION_PATH}.trigger_pr_iteration_from_comment.delay")
     def test_schedules_task_for_valid_command(self, mock_delay: MagicMock) -> None:
-        with self.feature("organizations:autofix-pr-iteration"):
+        with self.feature("organizations:autofix-pr-iteration-manual"):
             self._call(self._event())
 
         mock_delay.assert_called_once()
@@ -66,7 +66,7 @@ class HandleIssueCommentForAutofixIterationTest(TestCase):
 
     @patch(f"{MENTION_PATH}.trigger_pr_iteration_from_comment.delay")
     def test_skips_non_created_action(self, mock_delay: MagicMock) -> None:
-        with self.feature("organizations:autofix-pr-iteration"):
+        with self.feature("organizations:autofix-pr-iteration-manual"):
             self._call(self._event(action="edited"))
         mock_delay.assert_not_called()
 
@@ -74,13 +74,13 @@ class HandleIssueCommentForAutofixIterationTest(TestCase):
     def test_skips_when_not_pr_comment(self, mock_delay: MagicMock) -> None:
         event = self._event()
         event["issue"].pop("pull_request")
-        with self.feature("organizations:autofix-pr-iteration"):
+        with self.feature("organizations:autofix-pr-iteration-manual"):
             self._call(event)
         mock_delay.assert_not_called()
 
     @patch(f"{MENTION_PATH}.trigger_pr_iteration_from_comment.delay")
     def test_skips_when_not_iterate_command(self, mock_delay: MagicMock) -> None:
-        with self.feature("organizations:autofix-pr-iteration"):
+        with self.feature("organizations:autofix-pr-iteration-manual"):
             self._call(self._event(body="just a comment"))
         mock_delay.assert_not_called()
 
@@ -93,27 +93,27 @@ class HandleIssueCommentForAutofixIterationTest(TestCase):
     def test_skips_when_no_pr_number(self, mock_delay: MagicMock) -> None:
         event = self._event()
         event["issue"].pop("number")
-        with self.feature("organizations:autofix-pr-iteration"):
+        with self.feature("organizations:autofix-pr-iteration-manual"):
             self._call(event)
         mock_delay.assert_not_called()
 
     @patch(f"{MENTION_PATH}.trigger_pr_iteration_from_comment.delay")
     def test_skips_when_mention_has_hyphen_suffix(self, mock_delay: MagicMock) -> None:
         """Test that @sentry-cursor-agent doesn't trigger the command."""
-        with self.feature("organizations:autofix-pr-iteration"):
+        with self.feature("organizations:autofix-pr-iteration-manual"):
             self._call(self._event(body="@sentry-cursor-agent please help"))
         mock_delay.assert_not_called()
 
     @patch(f"{MENTION_PATH}.trigger_pr_iteration_from_comment.delay")
     def test_skips_when_mention_has_underscore_suffix(self, mock_delay: MagicMock) -> None:
         """Test that @sentry_bot doesn't trigger the command."""
-        with self.feature("organizations:autofix-pr-iteration"):
+        with self.feature("organizations:autofix-pr-iteration-manual"):
             self._call(self._event(body="@sentry_bot do something"))
         mock_delay.assert_not_called()
 
     @patch(f"{MENTION_PATH}.trigger_pr_iteration_from_comment.delay")
     def test_skips_when_mention_in_email(self, mock_delay: MagicMock) -> None:
         """Test that email@sentry.io doesn't trigger the command."""
-        with self.feature("organizations:autofix-pr-iteration"):
+        with self.feature("organizations:autofix-pr-iteration-manual"):
             self._call(self._event(body="contact email@sentry.io for help"))
         mock_delay.assert_not_called()

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -16,6 +16,7 @@ from sentry.seer.autofix.autofix_agent import (
     AutofixStep,
     NoSeerQuotaException,
     PrIterationNoPullRequestException,
+    PrIterationNotEnabledException,
     _build_base_shas_metadata,
     build_step_prompt,
     generate_autofix_handoff_prompt,
@@ -579,6 +580,54 @@ class TestTriggerAutofixAgent(TestCase):
 
         mock_client.continue_run.assert_not_called()
         mock_broadcast.assert_not_called()
+
+    @patch("sentry.quotas.backend.record_seer_run")
+    @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
+    @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
+    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    def test_pr_iteration_enabled_by_either_flag(
+        self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
+    ):
+        """Automated CI iteration and manual iteration each enable the PR_ITERATION step.
+
+        Automated CI iteration runs under ``autofix-pr-iteration`` and manual
+        iteration under the ``-manual`` variant, so either flag alone is enough and
+        neither flag rejects the step.
+        """
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.get_run.return_value = _state_with_blocks(
+            [_iteration_block(1)],
+            group_id=self.group.id,
+            repo_pr_states={
+                "owner/repo": RepoPRState(
+                    repo_name="owner/repo", pr_url="https://example.com/pull/7"
+                )
+            },
+        )
+        mock_client.continue_run.return_value = self.create_seer_run(
+            organization=self.group.organization, seer_run_state_id=67890
+        )
+
+        def trigger() -> None:
+            trigger_autofix_agent(
+                group=self.group,
+                step=AutofixStep.PR_ITERATION,
+                referrer=AutofixReferrer.GITHUB_PR_COMMENT,
+                run_id=67890,
+            )
+
+        with pytest.raises(PrIterationNotEnabledException):
+            trigger()
+        mock_client.continue_run.assert_not_called()
+
+        with self.feature("organizations:autofix-pr-iteration"):
+            trigger()
+        assert mock_client.continue_run.call_count == 1
+
+        with self.feature("organizations:autofix-pr-iteration-manual"):
+            trigger()
+        assert mock_client.continue_run.call_count == 2
 
     @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
     @patch("sentry.quotas.backend.check_seer_quota", return_value=False)

--- a/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
+++ b/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
@@ -997,9 +997,14 @@ class TestMaybeReactToCompletedIteration(TestCase):
 
     @patch(f"{REACT_PATH}.make_scm")
     @patch(f"{REACT_PATH}._add_comment_reaction")
-    def test_noop_when_feature_disabled(self, mock_react, mock_make_scm):
+    def test_noop_when_manual_feature_disabled(self, mock_react, mock_make_scm):
         state = self._state_with([self._top_level_source()])
-        AutofixOnCompletionHook._maybe_react_to_completed_iteration(self.organization, 123, state)
+        # Automated CI iteration on, manual off: only comment-triggered iterations have
+        # a comment to react to, so the automated flag must not enable the reaction.
+        with self.feature("organizations:autofix-pr-iteration"):
+            AutofixOnCompletionHook._maybe_react_to_completed_iteration(
+                self.organization, 123, state
+            )
         mock_react.assert_not_called()
 
     @patch(f"{REACT_PATH}.make_scm")

--- a/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
+++ b/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
@@ -946,7 +946,7 @@ class TestMaybeReactToCompletedIteration(TestCase):
         mock_make_scm.return_value = scm
         state = self._state_with([self._top_level_source(111), self._review_source(222)])
 
-        with self.feature("organizations:autofix-pr-iteration"):
+        with self.feature("organizations:autofix-pr-iteration-manual"):
             AutofixOnCompletionHook._maybe_react_to_completed_iteration(
                 self.organization, 123, state
             )
@@ -962,7 +962,7 @@ class TestMaybeReactToCompletedIteration(TestCase):
     @patch(f"{REACT_PATH}._add_comment_reaction")
     def test_noop_on_error_status(self, mock_react, mock_make_scm):
         state = self._state_with([self._top_level_source()], status="error")
-        with self.feature("organizations:autofix-pr-iteration"):
+        with self.feature("organizations:autofix-pr-iteration-manual"):
             AutofixOnCompletionHook._maybe_react_to_completed_iteration(
                 self.organization, 123, state
             )
@@ -972,7 +972,7 @@ class TestMaybeReactToCompletedIteration(TestCase):
     @patch(f"{REACT_PATH}._add_comment_reaction")
     def test_noop_when_step_not_pr_iteration(self, mock_react, mock_make_scm):
         state = run_state(blocks=[solution_memory_block()])
-        with self.feature("organizations:autofix-pr-iteration"):
+        with self.feature("organizations:autofix-pr-iteration-manual"):
             AutofixOnCompletionHook._maybe_react_to_completed_iteration(
                 self.organization, 123, state
             )
@@ -989,7 +989,7 @@ class TestMaybeReactToCompletedIteration(TestCase):
                 "owner/repo": RepoPRState(repo_name="owner/repo", pr_number=7, commit_sha="old-sha")
             },
         )
-        with self.feature("organizations:autofix-pr-iteration"):
+        with self.feature("organizations:autofix-pr-iteration-manual"):
             AutofixOnCompletionHook._maybe_react_to_completed_iteration(
                 self.organization, 123, state
             )
@@ -1021,7 +1021,7 @@ class TestMaybeReactToCompletedIteration(TestCase):
             ),
         }
 
-        with self.feature("organizations:autofix-pr-iteration"):
+        with self.feature("organizations:autofix-pr-iteration-manual"):
             AutofixOnCompletionHook._maybe_react_to_completed_iteration(
                 self.organization, 123, state
             )
@@ -1049,7 +1049,7 @@ class TestMaybeReactToCompletedIteration(TestCase):
             },
         )
 
-        with self.feature("organizations:autofix-pr-iteration"):
+        with self.feature("organizations:autofix-pr-iteration-manual"):
             AutofixOnCompletionHook._maybe_react_to_completed_iteration(
                 self.organization, 123, state
             )
@@ -1069,7 +1069,7 @@ class TestMaybeReactToCompletedIteration(TestCase):
         )
         state = self._state_with([self._top_level_source()])
 
-        with self.feature("organizations:autofix-pr-iteration"):
+        with self.feature("organizations:autofix-pr-iteration-manual"):
             AutofixOnCompletionHook._maybe_react_to_completed_iteration(
                 self.organization, 123, state
             )
@@ -1088,7 +1088,7 @@ class TestMaybeReactToCompletedIteration(TestCase):
         mock_make_scm.return_value = scm
         state = self._state_with([self._top_level_source(111)])
 
-        with self.feature("organizations:autofix-pr-iteration"):
+        with self.feature("organizations:autofix-pr-iteration-manual"):
             AutofixOnCompletionHook._maybe_react_to_completed_iteration(
                 self.organization, 123, state
             )
@@ -1113,7 +1113,7 @@ class TestMaybeReactToCompletedIteration(TestCase):
         mock_make_scm.return_value = scm
         state = self._state_with([self._top_level_source(111), self._review_source(222)])
 
-        with self.feature("organizations:autofix-pr-iteration"):
+        with self.feature("organizations:autofix-pr-iteration-manual"):
             AutofixOnCompletionHook._maybe_react_to_completed_iteration(
                 self.organization, 123, state
             )
@@ -1143,7 +1143,7 @@ class TestMaybeReactToCompletedIteration(TestCase):
         mock_make_scm.return_value = scm
         state = self._state_with([self._top_level_source(111)])
 
-        with self.feature("organizations:autofix-pr-iteration"):
+        with self.feature("organizations:autofix-pr-iteration-manual"):
             AutofixOnCompletionHook._maybe_react_to_completed_iteration(
                 self.organization, 123, state
             )

--- a/tests/sentry/seer/autofix/test_pr_iteration_review.py
+++ b/tests/sentry/seer/autofix/test_pr_iteration_review.py
@@ -79,7 +79,7 @@ class HandlePullRequestReviewForAutofixIterationTest(TestCase):
         self, mock_contexts: MagicMock, mock_delay: MagicMock
     ) -> None:
         self._mock_org_contexts(mock_contexts)
-        with self.feature("organizations:autofix-pr-iteration"):
+        with self.feature("organizations:autofix-pr-iteration-manual"):
             handle_pull_request_review_for_autofix_iteration(self._event())
 
         mock_delay.assert_called_once()
@@ -102,7 +102,7 @@ class HandlePullRequestReviewForAutofixIterationTest(TestCase):
         self, mock_contexts: MagicMock, mock_delay: MagicMock
     ) -> None:
         self._mock_org_contexts(mock_contexts)
-        with self.feature("organizations:autofix-pr-iteration"):
+        with self.feature("organizations:autofix-pr-iteration-manual"):
             handle_pull_request_review_for_autofix_iteration(self._event(action="edited"))
         mock_delay.assert_not_called()
 
@@ -114,7 +114,7 @@ class HandlePullRequestReviewForAutofixIterationTest(TestCase):
         self._mock_org_contexts(mock_contexts)
         # The listener dispatches every submitted review, bots included; the repo
         # write-access gate is enforced downstream in the task, not here.
-        with self.feature("organizations:autofix-pr-iteration"):
+        with self.feature("organizations:autofix-pr-iteration-manual"):
             handle_pull_request_review_for_autofix_iteration(
                 self._event(author_id="333333", is_bot=True)
             )
@@ -137,7 +137,7 @@ class HandlePullRequestReviewForAutofixIterationTest(TestCase):
         self, mock_contexts: MagicMock, mock_delay: MagicMock
     ) -> None:
         mock_contexts.return_value = MagicMock(integration=None, organization_integrations=[])
-        with self.feature("organizations:autofix-pr-iteration"):
+        with self.feature("organizations:autofix-pr-iteration-manual"):
             handle_pull_request_review_for_autofix_iteration(self._event())
         mock_delay.assert_not_called()
 
@@ -145,7 +145,7 @@ class HandlePullRequestReviewForAutofixIterationTest(TestCase):
     @patch(f"{REVIEW_PATH}.integration_service.organization_contexts")
     def test_skips_when_missing_ids(self, mock_contexts: MagicMock, mock_delay: MagicMock) -> None:
         self._mock_org_contexts(mock_contexts)
-        with self.feature("organizations:autofix-pr-iteration"):
+        with self.feature("organizations:autofix-pr-iteration-manual"):
             handle_pull_request_review_for_autofix_iteration(self._event(installation_id=None))
         mock_delay.assert_not_called()
 

--- a/tests/sentry/seer/autofix/test_pr_iteration_review.py
+++ b/tests/sentry/seer/autofix/test_pr_iteration_review.py
@@ -124,11 +124,14 @@ class HandlePullRequestReviewForAutofixIterationTest(TestCase):
 
     @patch(f"{TASK_PATH}.trigger_pr_iteration_from_review.delay")
     @patch(f"{REVIEW_PATH}.integration_service.organization_contexts")
-    def test_skips_when_feature_disabled(
+    def test_skips_when_manual_feature_disabled(
         self, mock_contexts: MagicMock, mock_delay: MagicMock
     ) -> None:
         self._mock_org_contexts(mock_contexts)
-        handle_pull_request_review_for_autofix_iteration(self._event())
+        # Automated CI iteration on, manual off: the review trigger is manual-only,
+        # so the automated flag must not enable it.
+        with self.feature("organizations:autofix-pr-iteration"):
+            handle_pull_request_review_for_autofix_iteration(self._event())
         mock_delay.assert_not_called()
 
     @patch(f"{TASK_PATH}.trigger_pr_iteration_from_review.delay")

--- a/tests/sentry/seer/autofix/test_pr_iteration_webhook.py
+++ b/tests/sentry/seer/autofix/test_pr_iteration_webhook.py
@@ -57,7 +57,7 @@ class HandleIssueCommentForAutofixIterationTest(TestCase):
 
     @patch(f"{MENTION_PATH}.trigger_pr_iteration_from_comment.delay")
     def test_schedules_task_for_valid_command(self, mock_delay: MagicMock) -> None:
-        with self.feature("organizations:autofix-pr-iteration"):
+        with self.feature("organizations:autofix-pr-iteration-manual"):
             self._call(self._event())
 
         mock_delay.assert_called_once()
@@ -79,7 +79,7 @@ class HandleIssueCommentForAutofixIterationTest(TestCase):
 
     @patch(f"{MENTION_PATH}.trigger_pr_iteration_from_comment.delay")
     def test_skips_non_created_action(self, mock_delay: MagicMock) -> None:
-        with self.feature("organizations:autofix-pr-iteration"):
+        with self.feature("organizations:autofix-pr-iteration-manual"):
             self._call(self._event(action="edited"))
         mock_delay.assert_not_called()
 
@@ -87,13 +87,13 @@ class HandleIssueCommentForAutofixIterationTest(TestCase):
     def test_skips_when_not_pr_comment(self, mock_delay: MagicMock) -> None:
         event = self._event()
         event["issue"].pop("pull_request")
-        with self.feature("organizations:autofix-pr-iteration"):
+        with self.feature("organizations:autofix-pr-iteration-manual"):
             self._call(event)
         mock_delay.assert_not_called()
 
     @patch(f"{MENTION_PATH}.trigger_pr_iteration_from_comment.delay")
     def test_skips_when_not_iterate_command(self, mock_delay: MagicMock) -> None:
-        with self.feature("organizations:autofix-pr-iteration"):
+        with self.feature("organizations:autofix-pr-iteration-manual"):
             self._call(self._event(body="just a comment"))
         mock_delay.assert_not_called()
 
@@ -106,7 +106,7 @@ class HandleIssueCommentForAutofixIterationTest(TestCase):
     def test_skips_when_no_pr_number(self, mock_delay: MagicMock) -> None:
         event = self._event()
         event["issue"].pop("number")
-        with self.feature("organizations:autofix-pr-iteration"):
+        with self.feature("organizations:autofix-pr-iteration-manual"):
             self._call(event)
         mock_delay.assert_not_called()
 

--- a/tests/sentry/seer/autofix/test_pr_iteration_webhook.py
+++ b/tests/sentry/seer/autofix/test_pr_iteration_webhook.py
@@ -98,8 +98,11 @@ class HandleIssueCommentForAutofixIterationTest(TestCase):
         mock_delay.assert_not_called()
 
     @patch(f"{MENTION_PATH}.trigger_pr_iteration_from_comment.delay")
-    def test_skips_when_feature_disabled(self, mock_delay: MagicMock) -> None:
-        self._call(self._event())
+    def test_skips_when_manual_feature_disabled(self, mock_delay: MagicMock) -> None:
+        # Automated CI iteration on, manual off: the comment trigger is manual-only,
+        # so the automated flag must not enable it.
+        with self.feature("organizations:autofix-pr-iteration"):
+            self._call(self._event())
         mock_delay.assert_not_called()
 
     @patch(f"{MENTION_PATH}.trigger_pr_iteration_from_comment.delay")

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -496,7 +496,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert response.status_code == 202, response.data
         action_log.assert_not_logged(TriggerAutofixAction, group_id=group.id)
 
-    @with_feature("organizations:autofix-pr-iteration")
+    @with_feature("organizations:autofix-pr-iteration-manual")
     @patch("sentry.seer.endpoints.group_ai_autofix.consume_queued_autofix_feedback")
     @patch("sentry.seer.endpoints.group_ai_autofix.try_enqueue_autofix_feedback")
     @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
@@ -529,7 +529,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert mock_try_enqueue.call_args.kwargs["actor_user_id"] == self.user.id
         mock_consume.apply_async.assert_called_once()
 
-    @with_feature({"organizations:autofix-pr-iteration": False})
+    @with_feature({"organizations:autofix-pr-iteration-manual": False})
     @patch("sentry.seer.endpoints.group_ai_autofix.consume_queued_autofix_feedback")
     @patch("sentry.seer.endpoints.group_ai_autofix.try_enqueue_autofix_feedback")
     def test_pr_iteration_requires_feature_flag(self, mock_try_enqueue, mock_consume):
@@ -546,7 +546,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert response.data["detail"] == "PR iteration is not enabled for this organization"
         mock_try_enqueue.assert_not_called()
 
-    @with_feature("organizations:autofix-pr-iteration")
+    @with_feature("organizations:autofix-pr-iteration-manual")
     @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
     def test_pr_iteration_requires_run_id(self, mock_trigger_explorer):
         group = self.create_group()
@@ -561,7 +561,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert response.status_code == 400, response.data
         mock_trigger_explorer.assert_not_called()
 
-    @with_feature("organizations:autofix-pr-iteration")
+    @with_feature("organizations:autofix-pr-iteration-manual")
     @patch("sentry.seer.endpoints.group_ai_autofix.try_enqueue_autofix_feedback")
     @patch("sentry.seer.endpoints.group_ai_autofix.get_autofix_run_state")
     def test_pr_iteration_requires_existing_pr(self, mock_run_state, mock_try_enqueue):

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -70,6 +70,43 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert response.data["autofix"]["sentry_run_id"] == str(run.uuid)
 
     @patch("sentry.seer.endpoints.group_ai_autofix.get_autofix_agent_state")
+    def test_get_reports_iteration_flags_independently(self, mock_get_explorer_state):
+        """``pr_iteration_enabled`` tracks automated CI iteration, the ``manual_``
+        field tracks human-triggered iteration, and neither implies the other."""
+        group = self.create_group()
+        mock_get_explorer_state.return_value = SeerRunState(
+            run_id=888,
+            blocks=[],
+            status="completed",
+            updated_at="2023-07-18T12:00:00Z",
+        )
+        self.login_as(user=self.user)
+
+        def get_flags() -> tuple[bool, bool]:
+            response = self.client.get(self._get_url(group.id), format="json")
+            assert response.status_code == 200, response.data
+            return (
+                response.data["autofix"]["pr_iteration_enabled"],
+                response.data["autofix"]["manual_pr_iteration_enabled"],
+            )
+
+        assert get_flags() == (False, False)
+
+        with self.feature("organizations:autofix-pr-iteration"):
+            assert get_flags() == (True, False)
+
+        with self.feature("organizations:autofix-pr-iteration-manual"):
+            assert get_flags() == (False, True)
+
+        with self.feature(
+            [
+                "organizations:autofix-pr-iteration",
+                "organizations:autofix-pr-iteration-manual",
+            ]
+        ):
+            assert get_flags() == (True, True)
+
+    @patch("sentry.seer.endpoints.group_ai_autofix.get_autofix_agent_state")
     def test_get_handles_block_with_null_metadata(self, mock_get_explorer_state):
         group = self.create_group()
         mock_get_explorer_state.return_value = SeerRunState(

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -529,10 +529,16 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert mock_try_enqueue.call_args.kwargs["actor_user_id"] == self.user.id
         mock_consume.apply_async.assert_called_once()
 
-    @with_feature({"organizations:autofix-pr-iteration-manual": False})
+    @with_feature(
+        {
+            "organizations:autofix-pr-iteration-manual": False,
+            # On, to pin that automated CI iteration does not grant manual iteration.
+            "organizations:autofix-pr-iteration": True,
+        }
+    )
     @patch("sentry.seer.endpoints.group_ai_autofix.consume_queued_autofix_feedback")
     @patch("sentry.seer.endpoints.group_ai_autofix.try_enqueue_autofix_feedback")
-    def test_pr_iteration_requires_feature_flag(self, mock_try_enqueue, mock_consume):
+    def test_pr_iteration_requires_manual_feature_flag(self, mock_try_enqueue, mock_consume):
         group = self.create_group()
 
         self.login_as(user=self.user)


### PR DESCRIPTION
Backend half of CW-1778. Frontend follows in a separate PR (`static/` and `src/` aren't atomically deployed); this lands first.

## Why

`organizations:autofix-pr-iteration` currently gates **both** manual and automated CI PR iteration. That means we can't roll out automated CI iteration without also exposing the manual flow. This adds `organizations:autofix-pr-iteration-manual` (`api_expose=True`, the frontend needs it) and moves the human-triggered entry points onto it, leaving automated CI iteration on the existing flag.

## Moved to `-manual`

| Site | Gates |
|---|---|
| `group_ai_autofix.py:358` | the `pr_iteration` POST gate — only reachable from the drawer feedback form; automated CI iteration enters via the check_suite listener, not this endpoint |
| `pr_iteration/mention.py:88` | `@sentry <feedback>` PR comment trigger |
| `pr_iteration/listeners/review.py:145` | PR review / inline review comment trigger |
| `autofix_agent.py:887` | the "Comment `@sentry <feedback>`…" PR description footer |
| `on_completion_hook.py:252` | :eyes:->:tada: reaction swap on the triggering comment |

## Accepts *either* flag

Two sites sit on the shared path and would have broken automated CI iteration if moved outright — the check_suite listener reaches both via `trigger_consume_pr_iteration_feedback` -> `trigger_autofix_agent(step=PR_ITERATION)`:

- `autofix_agent.py:416` — `pr_iteration_enabled`, which raises `PrIterationNotEnabledException` for *any* `PR_ITERATION` step
- `agent/client.py:359` — the `enable_pr_context_tools` permission check, set from `is_iteration_step` for both flows

## New response field

`pr_iteration_enabled` keeps its existing meaning (automated CI iteration). Manual state is reported by a **new** additive field, `manual_pr_iteration_enabled`, rather than by redefining the old one — an unread field today is one a future reader would misinterpret. `test_get_reports_iteration_flags_independently` pins all four flag combinations.

## Unchanged

The automated CI entry point (`pr_iteration/listeners/check_suite.py`) has no `autofix-pr-iteration` check of its own; its sub-features already use separate flags (`-review-request`, `-cap-assign`).

## Rollout

Orgs currently on `autofix-pr-iteration` keep automated CI iteration and lose manual iteration until `autofix-pr-iteration-manual` is enabled for them — enable the new flag for the existing org set before/with this deploy to keep behavior identical. Flagpole YAML lives in `sentry-options-automator`.

## Tests

Manual-gate tests moved to the new flag. Three things worth calling out, each verified by mutation testing rather than assumed — in every case I widened the gate back to the coupled behavior and confirmed the test fails:

- **The `feature_disabled` tests were vacuous.** They relied on *both* flags defaulting off, so they passed even with a manual gate mutated to also accept `autofix-pr-iteration`. Each now turns the automated flag **on** while manual is off, so the assertion is "automated CI iteration does not grant manual iteration."
- **The flag swaps in the `test_skips_*` tests are load-bearing, not churn.** Left on the old flag, the feature check short-circuits ahead of the condition each test targets: `test_skips_when_not_iterate_command` still passes when fed a *valid* `@sentry fix it` body, because the disabled feature is what stops dispatch. Swapping the flag is what keeps those assertions meaningful.
- **Both response fields report independently**, so the two flows can't be conflated by a future edit.

New coverage:
- `test_pr_iteration_enabled_by_either_flag` — neither flag raises `PrIterationNotEnabledException`; each flag alone enables the step. This exception had no coverage before.
- `test_client_init_succeeds_when_manual_pr_ctx_tools_flag_enabled` — PR context tools under the manual flag; the existing old-flag test now pins the automated path.
- `test_get_reports_iteration_flags_independently` — all four flag combinations for the two response fields.

`274 passed` across the touched files. 6 unrelated failures in `test_issue_search.py` / `test_coding_agent_handoffs.py` reproduce identically on a clean `master` tree (verified via `git stash`).

refs [CW-1778](https://linear.app/getsentry/issue/CW-1778/disable-manual-pr-iteration-by-another-feature-flag)
