### PR TITLE
feat(explore): Support array attributes in trace item attributes endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable, Sequence
 from datetime import datetime, timedelta
-from typing import Any, Literal
+from typing import Any
 
 import sentry_sdk
 from django.db.models import Q
@@ -73,6 +73,7 @@ from sentry.search.eap.spans.definitions import SPAN_DEFINITIONS
 from sentry.search.eap.trace_metrics.definitions import TRACE_METRICS_DEFINITIONS
 from sentry.search.eap.types import (
     AttributeSourceType,
+    ColumnType,
     SearchResolverConfig,
     SupportedTraceItemType,
 )
@@ -99,7 +100,9 @@ from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 from sentry.utils.cursors import Cursor, CursorResult
 from sentry.utils.tracing import set_span_data, start_span
 
-POSSIBLE_ATTRIBUTE_TYPES = ["string", "number", "boolean"]
+SCALAR_ATTRIBUTE_TYPES = ["string", "number", "boolean"]
+# "array" is gated behind organizations:trace-item-array-query-support (see get()).
+POSSIBLE_ATTRIBUTE_TYPES = [*SCALAR_ATTRIBUTE_TYPES, "array"]
 
 # Subset of SupportedTraceItemType that get_column_definitions handles.
 SUPPORTED_DATASETS = [
@@ -319,7 +322,7 @@ SENTRY_ALWAYS_INCLUDED_ATTRIBUTES: dict[SupportedTraceItemType, frozenset[str]] 
 }
 
 
-def _search_type_to_context_type(search_type: str) -> Literal["string", "number", "boolean"]:
+def _search_type_to_context_type(search_type: str) -> ColumnType:
     """Collapse an EAP search type to the coarse type used for context matching."""
     if search_type == "string":
         return "string"
@@ -331,7 +334,7 @@ def _search_type_to_context_type(search_type: str) -> Literal["string", "number"
 def build_sentry_convention_context(
     public_name: str,
     internal_name: str,
-    attribute_type: Literal["string", "number", "boolean"] | None = None,
+    attribute_type: ColumnType | None = None,
 ) -> TraceItemAttributeContext | None:
     """
     Build the sentry conventions context for an attribute, if it maps to a known
@@ -394,7 +397,7 @@ def build_sentry_convention_context(
 
 def build_sentry_attribute_context(
     public_name: str,
-    attribute_type: Literal["string", "number", "boolean"] | None,
+    attribute_type: ColumnType | None,
     item_type: SupportedTraceItemType,
 ) -> TraceItemAttributeContext | None:
     """
@@ -513,7 +516,7 @@ def is_known_attribute(name: str, definitions: ColumnDefinitions) -> bool:
 
 def as_attribute_key(
     name: str,
-    attr_type: Literal["string", "number", "boolean"],
+    attr_type: ColumnType,
     item_type: SupportedTraceItemType,
     is_proxy: bool = False,
     include_context: bool = False,
@@ -532,6 +535,9 @@ def as_attribute_key(
         public_name = name
     elif attr_type == "boolean":
         public_key = f"tags[{name},boolean]"
+        public_name = name
+    elif attr_type == "array":
+        public_key = f"tags[{name},array]"
         public_name = name
     else:
         public_key = name
@@ -684,9 +690,21 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
         substring_match = serialized.get("substring_match", "")
         query_string = serialized.get("query")
         attribute_types = serialized.get("attribute_type")
-        # When not passed the user wants all types
+        # Array attributes are gated behind their own feature flag. When it's off,
+        # "array" is neither queried by default nor honored if explicitly requested.
+        supports_arrays = features.has(
+            "organizations:trace-item-array-query-support",
+            organization,
+            actor=request.user,
+        )
+        allowed_attribute_types = (
+            POSSIBLE_ATTRIBUTE_TYPES if supports_arrays else SCALAR_ATTRIBUTE_TYPES
+        )
+        # When not passed the user wants all (allowed) types
         if attribute_types is None or len(attribute_types) == 0:
-            attribute_types = POSSIBLE_ATTRIBUTE_TYPES
+            attribute_types = allowed_attribute_types
+        else:
+            attribute_types = [t for t in attribute_types if t in allowed_attribute_types]
         # Deprecating this so we're using the same param name as the events endpoints
         item_type = serialized.get("item_type")
         # Dataset is going to replace item_type
@@ -700,7 +718,7 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
         column_definitions = get_column_definitions(trace_item_type)
         resolver = SearchResolver(
             params=snuba_params,
-            config=SearchResolverConfig(),
+            config=SearchResolverConfig(disable_array_attributes=not supports_arrays),
             definitions=column_definitions,
         )
         with handle_query_errors():
@@ -788,7 +806,7 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
         meta: RequestMeta,
         query_filter: TraceItemFilter | None,
         substring_match: str,
-        attribute_type: Literal["string", "number", "boolean"],
+        attribute_type: ColumnType,
         column_definitions: ColumnDefinitions,
         trace_item_type: SupportedTraceItemType,
         include_internal: bool,
@@ -910,7 +928,7 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
     def serialize_trace_attributes(
         self,
         rpc_response: TraceItemAttributeNamesResponse,
-        attribute_type: Literal["string", "number", "boolean"],
+        attribute_type: ColumnType,
         trace_item_type: SupportedTraceItemType,
         include_internal: bool,
         substring_match: str,
@@ -921,6 +939,9 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
         attribute_keys = {}
         for attribute in rpc_response.attributes:
             if not attribute.name:
+                continue
+            returned_bucket = constants.PROTO_TYPE_TO_ATTRIBUTE_TYPE_MAP.get(attribute.type)
+            if returned_bucket is not None and returned_bucket != attribute_type:
                 continue
             attr_key = as_attribute_key(
                 attribute.name,
@@ -984,6 +1005,7 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
 
 @cell_silo_endpoint
 class OrganizationTraceItemAttributeValuesEndpoint(OrganizationTraceItemAttributesEndpointBase):
+    
     def get(self, request: Request, organization: Organization, key: str) -> Response:
         if not self.has_feature(organization, request):
             return Response(status=404)

--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -690,8 +690,6 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
         substring_match = serialized.get("substring_match", "")
         query_string = serialized.get("query")
         attribute_types = serialized.get("attribute_type")
-        # Array attributes are gated behind their own feature flag. When it's off,
-        # "array" is neither queried by default nor honored if explicitly requested.
         supports_arrays = features.has(
             "organizations:trace-item-array-query-support",
             organization,
@@ -1005,7 +1003,6 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
 
 @cell_silo_endpoint
 class OrganizationTraceItemAttributeValuesEndpoint(OrganizationTraceItemAttributesEndpointBase):
-    
     def get(self, request: Request, organization: Organization, key: str) -> Response:
         if not self.has_feature(organization, request):
             return Response(status=404)

--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -937,6 +937,9 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
         for attribute in rpc_response.attributes:
             if not attribute.name:
                 continue
+
+            # Remove following when we migrate to cooccurring-attrs v2. use attribute_type only.
+            # Then returned type should be same as attribute_type.
             returned_bucket = constants.PROTO_TYPE_TO_ATTRIBUTE_TYPE_MAP.get(attribute.type)
             if returned_bucket is not None and returned_bucket != attribute_type:
                 continue

--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -101,7 +101,6 @@ from sentry.utils.cursors import Cursor, CursorResult
 from sentry.utils.tracing import set_span_data, start_span
 
 SCALAR_ATTRIBUTE_TYPES = ["string", "number", "boolean"]
-# "array" is gated behind organizations:trace-item-array-query-support (see get()).
 POSSIBLE_ATTRIBUTE_TYPES = [*SCALAR_ATTRIBUTE_TYPES, "array"]
 
 # Subset of SupportedTraceItemType that get_column_definitions handles.

--- a/src/sentry/api/endpoints/organization_trace_item_attributes_types.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes_types.py
@@ -1,5 +1,7 @@
 from typing import Any, Literal, NotRequired, TypedDict
 
+from sentry.search.eap.types import ColumnType
+
 
 class TraceItemAttributeSource(TypedDict):
     source_type: Literal["sentry", "user"]
@@ -43,7 +45,9 @@ class TraceItemAttributeKey(TypedDict):
     name: str
     secondaryAliases: NotRequired[list[str]]
     attributeSource: TraceItemAttributeSource
-    attributeType: Literal["string", "number", "boolean"]
-    # Attribute context, only present when requested via ``expand=context``.
-    # Attached to every attribute, and empty when it has no metadata.
+    attributeType: ColumnType
+    # Attribute context, only present when requested via ``expand=context`` (and
+    # gated behind the feature flag). Attached to every attribute when
+    # requested; currently empty for custom (non-convention) attributes, which
+    # will be populated once custom attribute context is served.
     context: NotRequired[TraceItemAttributeContext]

--- a/src/sentry/api/endpoints/organization_trace_item_attributes_types.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes_types.py
@@ -46,8 +46,6 @@ class TraceItemAttributeKey(TypedDict):
     secondaryAliases: NotRequired[list[str]]
     attributeSource: TraceItemAttributeSource
     attributeType: ColumnType
-    # Attribute context, only present when requested via ``expand=context`` (and
-    # gated behind the feature flag). Attached to every attribute when
-    # requested; currently empty for custom (non-convention) attributes, which
-    # will be populated once custom attribute context is served.
+    # Attribute context, only present when requested via ``expand=context``.
+    # Attached to every attribute, and empty when it has no metadata.
     context: NotRequired[TraceItemAttributeContext]

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -54,6 +54,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:anomaly-detection-eap", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable array fields in trace item details endpoint
     manager.add("organizations:trace-item-details-array-fields", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable array query support for trace items (array attributes in querying/autocomplete)
+    manager.add("organizations:trace-item-array-query-support", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Auto-link repos to projects by matching repo name suffix to project slug
     manager.add("organizations:auto-link-repos-by-name", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Expose the per-project toggle for auto-creating releases from ingested telemetry

--- a/src/sentry/search/eap/constants.py
+++ b/src/sentry/search/eap/constants.py
@@ -6,7 +6,7 @@ from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey, ExtrapolationMode
 from sentry_protos.snuba.v1.trace_item_filter_pb2 import ComparisonFilter
 
-from sentry.search.eap.types import SupportedTraceItemType
+from sentry.search.eap.types import ColumnType, SupportedTraceItemType
 from sentry.search.events.constants import DURATION_UNITS, SIZE_UNITS, DurationUnit, SizeUnit
 from sentry.search.events.types import SAMPLING_MODES
 
@@ -258,4 +258,19 @@ ATTRIBUTES_QUERY_PARAM_TO_ATTRIBUTE_TYPE_MAP = {
     "number": AttributeKey.Type.TYPE_DOUBLE,
     "boolean": AttributeKey.Type.TYPE_BOOLEAN,
     "string": AttributeKey.Type.TYPE_STRING,
+    "array": AttributeKey.Type.TYPE_ARRAY,
+}
+
+
+PROTO_TYPE_TO_ATTRIBUTE_TYPE_MAP: dict[AttributeKey.Type.ValueType, ColumnType] = {
+    AttributeKey.Type.TYPE_STRING: "string",
+    AttributeKey.Type.TYPE_BOOLEAN: "boolean",
+    AttributeKey.Type.TYPE_INT: "number",
+    AttributeKey.Type.TYPE_FLOAT: "number",
+    AttributeKey.Type.TYPE_DOUBLE: "number",
+    AttributeKey.Type.TYPE_ARRAY: "array",
+    AttributeKey.Type.TYPE_ARRAY_STRING: "array",
+    AttributeKey.Type.TYPE_ARRAY_INT: "array",
+    AttributeKey.Type.TYPE_ARRAY_DOUBLE: "array",
+    AttributeKey.Type.TYPE_ARRAY_BOOL: "array",
 }

--- a/src/sentry/search/eap/utils.py
+++ b/src/sentry/search/eap/utils.py
@@ -60,7 +60,12 @@ from sentry.search.eap.trace_metrics.attributes import (
     TRACE_METRICS_REPLACEMENT_MAP,
 )
 from sentry.search.eap.trace_metrics.definitions import TRACE_METRICS_DEFINITIONS
-from sentry.search.eap.types import AttributeSource, AttributeSourceType, SupportedTraceItemType
+from sentry.search.eap.types import (
+    AttributeSource,
+    AttributeSourceType,
+    ColumnType,
+    SupportedTraceItemType,
+)
 
 
 def add_start_end_conditions(
@@ -169,7 +174,7 @@ def translate_search_type_for_internal_column(
 
 def translate_internal_to_public_alias(
     internal_alias: str,
-    search_type: Literal["string", "number", "boolean"],
+    search_type: ColumnType,
     item_type: SupportedTraceItemType,
 ) -> tuple[str | None, str | None, AttributeSource]:
     mapping = INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS.get(item_type, {}).get(search_type, {})

--- a/src/sentry/search/eap/utils.py
+++ b/src/sentry/search/eap/utils.py
@@ -177,10 +177,11 @@ def translate_internal_to_public_alias(
     search_type: ColumnType,
     item_type: SupportedTraceItemType,
 ) -> tuple[str | None, str | None, AttributeSource]:
-    mapping = INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS.get(item_type, {}).get(search_type, {})
-    public_alias = mapping.get(internal_alias)
-    if public_alias is not None:
-        return public_alias, public_alias, {"source_type": AttributeSourceType.SENTRY}
+    if search_type != "array":
+        mapping = INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS.get(item_type, {}).get(search_type, {})
+        public_alias = mapping.get(internal_alias)
+        if public_alias is not None:
+            return public_alias, public_alias, {"source_type": AttributeSourceType.SENTRY}
 
     resolved_column = PUBLIC_ALIAS_TO_INTERNAL_MAPPING.get(item_type, {}).get(internal_alias)
     if resolved_column is not None:

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -8,7 +8,11 @@ from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from rest_framework.exceptions import ErrorDetail
 from sentry_conventions.attributes import ATTRIBUTE_METADATA
+from sentry_protos.snuba.v1.endpoint_trace_item_attributes_pb2 import (
+    TraceItemAttributeNamesResponse,
+)
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey
+from sentry_protos.snuba.v1.trace_item_pb2 import AnyValue, ArrayValue
 
 from sentry.api.endpoints.organization_trace_item_attributes import build_sentry_convention_context
 from sentry.api.endpoints.organization_trace_item_attributes_types import (
@@ -116,6 +120,11 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
     OrganizationTraceItemAttributesEndpointTestBase, OurLogTestCase
 ):
     feature_flags = {"organizations:ourlogs-enabled": True}
+    # Endpoint access flags plus the array-support gate, for the array tests below.
+    array_feature_flags = {
+        "organizations:ourlogs-enabled": True,
+        "organizations:trace-item-array-query-support": True,
+    }
     item_type = SupportedTraceItemType.LOGS
 
     def test_no_feature(self) -> None:
@@ -483,6 +492,141 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
         assert "tags[is_deleted,boolean]" in keys
         assert "tags[feature_enabled,boolean]" in keys
         assert "tags[another_flag,boolean]" in keys
+
+    def _store_array_log(self) -> None:
+        """Write real string[] and int[] attributes (plus a scalar control)
+        straight to EAP storage — no mocking of the ingest or query path."""
+        logs = [
+            self.create_ourlog(
+                organization=self.organization,
+                project=self.project,
+                attributes={
+                    # string[] — matches the real data_export.csv_headers shape
+                    "data_export.csv_headers": {
+                        "array_value": ArrayValue(
+                            values=[
+                                AnyValue(string_value="title"),
+                                AnyValue(string_value="project"),
+                            ]
+                        )
+                    },
+                    # int[] — matches the real data_export.blob_offsets shape
+                    "data_export.blob_offsets": {
+                        "array_value": ArrayValue(
+                            values=[AnyValue(int_value=0), AnyValue(int_value=1048576)]
+                        )
+                    },
+                    # scalar control, proves the item and non-array attrs surface
+                    "data_export.status": {"string_value": "finished"},
+                },
+            ),
+        ]
+        self.store_eap_items(logs)
+
+    @pytest.mark.xfail(
+        strict=False,
+        reason=(
+            "Real array attribute names require Snuba's co-occurring-attrs v2 roll-up, "
+            "which is gated behind a Snuba option and a data-window cutoff and is not the "
+            "default in the local test Snuba, so this insert is served by v1 (no array "
+            "columns). Remove this marker once co-occurring-attrs v2 is the default."
+        ),
+    )
+    def test_array_attributes_surface_with_array_kind(self) -> None:
+        """An array-typed attribute is surfaced. Array keys come
+        back wrapped as `tags[name,array]`, so look them up by name."""
+        self._store_array_log()
+
+        response = self.do_request(features=self.array_feature_flags)
+        assert response.status_code == 200, response.content
+        by_name = {item["name"]: item for item in response.data}
+
+        assert "data_export.csv_headers" in by_name
+        assert by_name["data_export.csv_headers"]["attributeType"] == "array"
+        assert by_name["data_export.csv_headers"]["key"] == "tags[data_export.csv_headers,array]"
+
+        assert "data_export.blob_offsets" in by_name
+        assert by_name["data_export.blob_offsets"]["attributeType"] == "array"
+
+    def _mock_attribute_names_rpc(self, response_by_type):
+        """Patch the attribute-names RPC to return a patched response when snuba
+        gates  co-occurring-attrs v2 attributes"""
+
+        def _fake(rpc_request, debug=False):
+            return response_by_type.get(rpc_request.type, TraceItemAttributeNamesResponse())
+
+        return mock.patch(
+            "sentry.utils.snuba_rpc.attribute_names_rpc",
+            side_effect=_fake,
+        )
+
+    def test_array_pass_does_not_mislabel_scalars_as_arrays(self) -> None:
+        """v1-shaped response when type is array. Remove alongside the array branch of the endpoint's
+        returned-type guard when co-occurring-attrs v1 is retired in Snuba.
+        """
+        Attribute = TraceItemAttributeNamesResponse.Attribute
+        response_by_type = {
+            AttributeKey.Type.TYPE_STRING: TraceItemAttributeNamesResponse(
+                attributes=[
+                    Attribute(name="data_export.status", type=AttributeKey.Type.TYPE_STRING)
+                ]
+            ),
+            AttributeKey.Type.TYPE_DOUBLE: TraceItemAttributeNamesResponse(
+                attributes=[Attribute(name="my.number", type=AttributeKey.Type.TYPE_DOUBLE)]
+            ),
+            AttributeKey.Type.TYPE_ARRAY: TraceItemAttributeNamesResponse(
+                attributes=[
+                    Attribute(name="data_export.status", type=AttributeKey.Type.TYPE_STRING),
+                    Attribute(name="my.number", type=AttributeKey.Type.TYPE_DOUBLE),
+                ]
+            ),
+        }
+
+        with self._mock_attribute_names_rpc(response_by_type):
+            response = self.do_request(
+                query={"project": self.project.id}, features=self.array_feature_flags
+            )
+
+        assert response.status_code == 200, response.content
+        keys = [item["key"] for item in response.data]
+        # scalar type in reponse
+        assert "data_export.status" in keys
+        assert not any(key.endswith(",array]") for key in keys), keys
+
+    def test_array_pass_surfaces_real_array_attributes(self) -> None:
+        """v2-shaped response: the co-occurring-attrs v2 storage answers an array
+        request with real array element types. Those must surface as
+        `tags[<name>,array]` with an `array` attributeType."""
+        Attribute = TraceItemAttributeNamesResponse.Attribute
+        response_by_type = {
+            AttributeKey.Type.TYPE_ARRAY: TraceItemAttributeNamesResponse(
+                attributes=[
+                    Attribute(
+                        name="data_export.csv_headers",
+                        type=AttributeKey.Type.TYPE_ARRAY_STRING,
+                    ),
+                    Attribute(
+                        name="data_export.blob_offsets",
+                        type=AttributeKey.Type.TYPE_ARRAY_INT,
+                    ),
+                ]
+            ),
+        }
+
+        with self._mock_attribute_names_rpc(response_by_type):
+            response = self.do_request(
+                query={"project": self.project.id}, features=self.array_feature_flags
+            )
+
+        assert response.status_code == 200, response.content
+        by_name = {item["name"]: item for item in response.data}
+
+        assert "data_export.csv_headers" in by_name
+        assert by_name["data_export.csv_headers"]["attributeType"] == "array"
+        assert by_name["data_export.csv_headers"]["key"] == "tags[data_export.csv_headers,array]"
+
+        assert "data_export.blob_offsets" in by_name
+        assert by_name["data_export.blob_offsets"]["attributeType"] == "array"
 
     def test_debug_as_superuser(self) -> None:
         logs = [

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -120,7 +120,6 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
     OrganizationTraceItemAttributesEndpointTestBase, OurLogTestCase
 ):
     feature_flags = {"organizations:ourlogs-enabled": True}
-    # Endpoint access flags plus the array-support gate, for the array tests below.
     array_feature_flags = {
         "organizations:ourlogs-enabled": True,
         "organizations:trace-item-array-query-support": True,
@@ -494,14 +493,11 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
         assert "tags[another_flag,boolean]" in keys
 
     def _store_array_log(self) -> None:
-        """Write real string[] and int[] attributes (plus a scalar control)
-        straight to EAP storage — no mocking of the ingest or query path."""
         logs = [
             self.create_ourlog(
                 organization=self.organization,
                 project=self.project,
                 attributes={
-                    # string[] — matches the real data_export.csv_headers shape
                     "data_export.csv_headers": {
                         "array_value": ArrayValue(
                             values=[
@@ -510,13 +506,11 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
                             ]
                         )
                     },
-                    # int[] — matches the real data_export.blob_offsets shape
                     "data_export.blob_offsets": {
                         "array_value": ArrayValue(
                             values=[AnyValue(int_value=0), AnyValue(int_value=1048576)]
                         )
                     },
-                    # scalar control, proves the item and non-array attrs surface
                     "data_export.status": {"string_value": "finished"},
                 },
             ),
@@ -533,8 +527,6 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
         ),
     )
     def test_array_attributes_surface_with_array_kind(self) -> None:
-        """An array-typed attribute is surfaced. Array keys come
-        back wrapped as `tags[name,array]`, so look them up by name."""
         self._store_array_log()
 
         response = self.do_request(features=self.array_feature_flags)
@@ -594,9 +586,7 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
         assert not any(key.endswith(",array]") for key in keys), keys
 
     def test_array_pass_surfaces_real_array_attributes(self) -> None:
-        """v2-shaped response: the co-occurring-attrs v2 storage answers an array
-        request with real array element types. Those must surface as
-        `tags[<name>,array]` with an `array` attributeType."""
+        """v2-shaped mocked response"""
         Attribute = TraceItemAttributeNamesResponse.Attribute
         response_by_type = {
             AttributeKey.Type.TYPE_ARRAY: TraceItemAttributeNamesResponse(


### PR DESCRIPTION
Add `array` as a queryable attribute type in the trace-item attributes endpoint, gated behind organizations:trace-item-array-query-support. When the flag is on, custom array attributes surface as `tags[<name>,array]` so the Explore autocomplete can offer them; when off, the array pass is not run and array attributes are never returned.

Classify each attribute-names RPC result by the type Snuba returns rather than the type requested.
`cooccurring-attrs` v1 returns scalars for arrays, thus requested type is not same as returned type.                                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                                                                                            
Arrays are in `coocurring-attrs` v2 and has been rolled out completely, so tests are marked with proper annotations to cover the  roll out. 

Refs EXP-1130