### PR TITLE
fix(seer): Require owners for Issue Fix continuations

### DIFF
--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -280,7 +280,12 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
         resolved_run_id: int | None = None
         resolved_sentry_run_id: str | None = None
         if run_ref is not None:
-            resolved = resolve_seer_run(run_ref, group.organization, for_continue=True)
+            resolved = resolve_seer_run(
+                run_ref,
+                group.organization,
+                for_continue=True,
+                user_id=request.user.id if request.user else None,
+            )
             if isinstance(resolved, Response):
                 return resolved
             resolved_run_id = resolved.seer_run_state_id

--- a/src/sentry/seer/endpoints/organization_seer_agent_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_agent_chat.py
@@ -269,10 +269,12 @@ class OrganizationSeerAgentChatEndpoint(OrganizationEndpoint):
                 pass
         resolved: ResolvedSeerRun | None = None
         if run_id:
-            user_id = request.user.id
-            if user_id is None:
-                raise PermissionDenied("A user account is required to continue a conversation.")
-            result = resolve_seer_run(run_id, organization, for_continue=True, user_id=user_id)
+            result = resolve_seer_run(
+                run_id,
+                organization,
+                for_continue=True,
+                user_id=request.user.id,
+            )
             if isinstance(result, Response):
                 return result
             resolved = result

--- a/src/sentry/seer/endpoints/utils.py
+++ b/src/sentry/seer/endpoints/utils.py
@@ -37,11 +37,17 @@ def resolve_seer_run(
 ) -> ResolvedSeerRun | Response:
     """Resolve a client-facing run id (numeric ``seer_run_state_id`` or
     ``SeerRun.uuid``) to a :class:`ResolvedSeerRun`, or an error ``Response``
-    (narrow with ``isinstance``). When ``user_id`` is supplied, the mirrored run
-    must belong to that user. For a not-ready run, a poll gets the 200
-    ``{"session": {"status": ...}}`` shape; ``for_continue`` instead gets 409
-    (still mirroring) or 422 (mirror failed).
+    (narrow with ``isinstance``). A continuation requires ``user_id``; user-owned
+    mirrored runs must belong to that user. For a not-ready run, a poll gets the
+    200 ``{"session": {"status": ...}}`` shape; ``for_continue`` instead gets
+    409 (still mirroring) or 422 (mirror failed).
     """
+    if for_continue and user_id is None:
+        return Response(
+            {"detail": "A user account is required to continue a conversation."},
+            status=status.HTTP_403_FORBIDDEN,
+        )
+
     try:
         seer_run_state_id = int(run_id)
     except (TypeError, ValueError):
@@ -51,7 +57,12 @@ def resolve_seer_run(
         if not validate_bigint(seer_run_state_id):
             return Response({"detail": "Invalid run_id"}, status=status.HTTP_400_BAD_REQUEST)
         run = get_seer_run(seer_run_state_id, organization)
-        if user_id is not None and (run is None or run.user_id != user_id):
+        if (
+            user_id is not None
+            and run is not None
+            and run.user_id is not None
+            and run.user_id != user_id
+        ):
             return Response(
                 {"detail": "This conversation belongs to another user and is read-only."},
                 status=status.HTTP_403_FORBIDDEN,
@@ -66,7 +77,7 @@ def resolve_seer_run(
     run = SeerRun.objects.filter(uuid=run_uuid, organization=organization).first()
     if run is None:
         return Response({"session": None}, status=status.HTTP_404_NOT_FOUND)
-    if user_id is not None and run.user_id != user_id:
+    if user_id is not None and run.user_id is not None and run.user_id != user_id:
         return Response(
             {"detail": "This conversation belongs to another user and is read-only."},
             status=status.HTTP_403_FORBIDDEN,

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -182,7 +182,9 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
     @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
     def test_post_continue_with_sentry_run_id_resolves_to_numeric_id(self, mock_trigger_explorer):
         group = self.create_group()
-        run = self.create_seer_run(organization=self.organization, seer_run_state_id=555)
+        run = self.create_seer_run(
+            organization=self.organization, seer_run_state_id=555, user_id=self.user.id
+        )
         mock_trigger_explorer.return_value = run
 
         self.login_as(user=self.user)
@@ -200,7 +202,9 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
     def test_post_continue_with_numeric_run_id_still_works(self, mock_trigger_explorer):
         """The legacy numeric run_id field keeps working unchanged."""
         group = self.create_group()
-        run = self.create_seer_run(organization=self.organization, seer_run_state_id=321)
+        run = self.create_seer_run(
+            organization=self.organization, seer_run_state_id=321, user_id=self.user.id
+        )
         mock_trigger_explorer.return_value = run
 
         self.login_as(user=self.user)
@@ -213,6 +217,51 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert response.status_code == 202, response.data
         assert response.data == {"run_id": 321, "sentry_run_id": str(run.uuid)}
         assert mock_trigger_explorer.call_args.kwargs["run_id"] == 321
+
+    @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
+    def test_post_continue_owned_by_another_user_is_denied(self, mock_trigger_explorer):
+        group = self.create_group()
+        run = self.create_seer_run(
+            organization=self.organization, seer_run_state_id=555, user_id=self.user.id
+        )
+        member = self.create_user()
+        self.create_member(user=member, organization=self.organization, role="member")
+        self.login_as(user=member)
+
+        response = self.client.post(
+            self._get_url(group.id),
+            data={"step": "solution", "run_id": run.seer_run_state_id},
+            format="json",
+        )
+
+        assert response.status_code == 403, response.data
+        assert response.data == {
+            "detail": "This conversation belongs to another user and is read-only."
+        }
+        mock_trigger_explorer.assert_not_called()
+
+    @patch("sentry.seer.endpoints.group_ai_autofix.trigger_coding_agent_handoff")
+    def test_post_continue_with_api_key_is_denied(self, mock_handoff):
+        group = self.create_group()
+        run = self.create_seer_run(
+            organization=self.organization, seer_run_state_id=555, user_id=self.user.id
+        )
+        api_key = self.create_api_key(organization=self.organization, scope_list=["event:write"])
+
+        response = self.client.post(
+            self._get_url(group.id),
+            data={
+                "step": "coding_agent_handoff",
+                "run_id": run.seer_run_state_id,
+                "provider": "github_copilot",
+            },
+            format="json",
+            HTTP_AUTHORIZATION=self.create_basic_auth_header(api_key.key),
+        )
+
+        assert response.status_code == 403, response.data
+        assert response.data == {"detail": "A user account is required to continue a conversation."}
+        mock_handoff.assert_not_called()
 
     @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
     def test_post_continue_with_unknown_sentry_run_id_returns_404(self, mock_trigger_explorer):

--- a/tests/sentry/seer/endpoints/test_utils.py
+++ b/tests/sentry/seer/endpoints/test_utils.py
@@ -52,6 +52,36 @@ class ResolveSeerRunTest(TestCase):
 
         assert result == ResolvedSeerRun(555, str(run.uuid))
 
+    def test_continuation_requires_a_user_id(self) -> None:
+        result = resolve_seer_run("555", self.organization, for_continue=True)
+
+        assert isinstance(result, Response)
+        assert result.status_code == status.HTTP_403_FORBIDDEN
+        assert result.data == {"detail": "A user account is required to continue a conversation."}
+
+    def test_user_scope_allows_legacy_numeric_run(self) -> None:
+        result = resolve_seer_run("555", self.organization, for_continue=True, user_id=self.user.id)
+
+        assert result == ResolvedSeerRun(555, None)
+
+    def test_user_scope_allows_unowned_numeric_run(self) -> None:
+        run = self.create_seer_run(organization=self.organization, seer_run_state_id=555)
+
+        result = resolve_seer_run(
+            str(run.seer_run_state_id), self.organization, for_continue=True, user_id=self.user.id
+        )
+
+        assert result == ResolvedSeerRun(555, str(run.uuid))
+
+    def test_user_scope_allows_unowned_uuid_run(self) -> None:
+        run = self.create_seer_run(organization=self.organization, seer_run_state_id=555)
+
+        result = resolve_seer_run(
+            str(run.uuid), self.organization, for_continue=True, user_id=self.user.id
+        )
+
+        assert result == ResolvedSeerRun(555, str(run.uuid))
+
     def test_user_scope_rejects_another_users_numeric_run(self) -> None:
         run = self.create_seer_run(
             organization=self.organization, seer_run_state_id=555, user_id=self.user.id
@@ -111,10 +141,13 @@ class ResolveSeerRunTest(TestCase):
         run = self.create_seer_run(
             organization=self.organization,
             seer_run_state_id=None,
+            user_id=self.user.id,
             mirror_status=SeerRunMirrorStatus.PENDING,
         )
 
-        result = resolve_seer_run(str(run.uuid), self.organization, for_continue=True)
+        result = resolve_seer_run(
+            str(run.uuid), self.organization, for_continue=True, user_id=self.user.id
+        )
 
         assert isinstance(result, Response)
         assert result.status_code == status.HTTP_409_CONFLICT
@@ -122,10 +155,13 @@ class ResolveSeerRunTest(TestCase):
     def test_uuid_failed_mirror_for_continue_returns_422(self) -> None:
         run = self.create_seer_run(
             organization=self.organization,
+            user_id=self.user.id,
             mirror_status=SeerRunMirrorStatus.FAILED,
         )
 
-        result = resolve_seer_run(str(run.uuid), self.organization, for_continue=True)
+        result = resolve_seer_run(
+            str(run.uuid), self.organization, for_continue=True, user_id=self.user.id
+        )
 
         assert isinstance(result, Response)
         assert result.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY


### PR DESCRIPTION
Seer Issue Fix continuations now reject userless organization API keys before invoking Seer or repository-handoff code. User-owned runs remain restricted to their owner, while system-owned automated runs may be continued by an authenticated user; the shared resolver enforces both rules. New Issue Fix kickoffs remain unchanged; the restriction applies only when a request references an existing run.