### PR TITLE
feat(onboarding): Revalidate restored SCM messaging destinations

### DIFF
--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -140,7 +140,7 @@ function ScmPlatformFeaturesTreatmentAdapter(props: StepProps) {
 }
 
 function ScmMessagingAdapter({genBackButton}: StepProps) {
-  const {selectedPlatform} = useOnboardingContext();
+  const {messagingSetup, selectedPlatform, setMessagingSetup} = useOnboardingContext();
 
   // Type-narrowing only. `isInvalidMessagingStep` below redirects away from
   // this step before it renders without a platform, so this is unreachable —
@@ -150,7 +150,12 @@ function ScmMessagingAdapter({genBackButton}: StepProps) {
   }
 
   return (
-    <ScmMessaging selectedPlatform={selectedPlatform} genBackButton={genBackButton} />
+    <ScmMessaging
+      messagingSetup={messagingSetup}
+      onMessagingSetupChange={setMessagingSetup}
+      selectedPlatform={selectedPlatform}
+      genBackButton={genBackButton}
+    />
   );
 }
 

--- a/static/app/views/onboarding/scmMessaging.spec.tsx
+++ b/static/app/views/onboarding/scmMessaging.spec.tsx
@@ -193,6 +193,7 @@ describe('ScmMessaging', () => {
     );
 
     expect(screen.queryByText('Destination selected')).not.toBeInTheDocument();
+    expect(onMessagingSetupChange).not.toHaveBeenCalled();
     expect(
       await screen.findByText(
         "We couldn't find the saved integration. Choose a destination again."

--- a/static/app/views/onboarding/scmMessaging.spec.tsx
+++ b/static/app/views/onboarding/scmMessaging.spec.tsx
@@ -47,9 +47,8 @@ describe('ScmMessaging', () => {
 
   it('revalidates a restored destination before showing it as selected', async () => {
     MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/integrations/',
-      match: [MockApiClient.matchQuery({integrationType: 'messaging'})],
-      body: [OrganizationIntegrationsFixture({id: '15'})],
+      url: '/organizations/org-slug/integrations/15/',
+      body: OrganizationIntegrationsFixture({id: '15'}),
     });
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/integrations/15/channels/',
@@ -72,9 +71,8 @@ describe('ScmMessaging', () => {
 
   it('clears a missing integration with an explanation', async () => {
     MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/integrations/',
-      match: [MockApiClient.matchQuery({integrationType: 'messaging'})],
-      body: [],
+      url: '/organizations/org-slug/integrations/15/',
+      statusCode: 404,
     });
     const onMessagingSetupChange = jest.fn();
 
@@ -89,14 +87,11 @@ describe('ScmMessaging', () => {
     expect(screen.queryByText('Destination selected')).not.toBeInTheDocument();
   });
 
-  it('clears a missing channel with an explanation', async () => {
+  it('keeps an omitted channel while it cannot verify a complete list', async () => {
     MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/integrations/',
-      match: [MockApiClient.matchQuery({integrationType: 'messaging'})],
-      body: [OrganizationIntegrationsFixture({id: '15'})],
+      url: '/organizations/org-slug/integrations/15/',
+      body: OrganizationIntegrationsFixture({id: '15'}),
     });
-    // A populated list that does not contain the saved channel is genuine
-    // staleness: the channel was deleted or renamed away.
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/integrations/15/channels/',
       body: {results: [{id: 'C999', name: 'general', display: '#general'}]},
@@ -107,23 +102,22 @@ describe('ScmMessaging', () => {
 
     expect(
       await screen.findByText(
-        "We couldn't find the saved channel. Choose a destination again."
+        "We couldn't verify the saved channel. Choose a destination again."
       )
     ).toBeInTheDocument();
-    expect(onMessagingSetupChange).toHaveBeenCalledWith({mode: 'unconfigured'});
+    expect(onMessagingSetupChange).not.toHaveBeenCalled();
     expect(screen.queryByText('Destination selected')).not.toBeInTheDocument();
   });
 
   it('keeps the saved destination when the channel list comes back empty', async () => {
     MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/integrations/',
-      match: [MockApiClient.matchQuery({integrationType: 'messaging'})],
-      body: [OrganizationIntegrationsFixture({id: '15'})],
+      url: '/organizations/org-slug/integrations/15/',
+      body: OrganizationIntegrationsFixture({id: '15'}),
     });
     // Every provider helper returns [] when the upstream API fails, so an empty
     // list is indistinguishable from an outage and must not discard the
     // selection. It stays non-submittable rather than being reset.
-    MockApiClient.addMockResponse({
+    const channelsRequest = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/integrations/15/channels/',
       body: {results: []},
     });
@@ -132,14 +126,14 @@ describe('ScmMessaging', () => {
     renderMessaging(onMessagingSetupChange);
 
     await waitFor(() => {
-      expect(screen.queryByText('Checking saved destination')).not.toBeInTheDocument();
+      expect(channelsRequest).toHaveBeenCalled();
     });
 
     expect(onMessagingSetupChange).not.toHaveBeenCalled();
     expect(screen.queryByText('Destination selected')).not.toBeInTheDocument();
     expect(
       screen.queryByText(
-        "We couldn't find the saved channel. Choose a destination again."
+        "We couldn't verify the saved channel. Choose a destination again."
       )
     ).not.toBeInTheDocument();
   });
@@ -148,11 +142,10 @@ describe('ScmMessaging', () => {
     const queryClient = makeTestQueryClient();
     const integration = OrganizationIntegrationsFixture({id: '15'});
     const channel = {id: 'C123', name: 'alerts', display: '#alerts', type: 'text'};
-    const integrationsOptions = apiOptions.as<OrganizationIntegration[]>()(
-      '/organizations/$organizationIdOrSlug/integrations/',
+    const integrationOptions = apiOptions.as<OrganizationIntegration>()(
+      '/organizations/$organizationIdOrSlug/integrations/$integrationId/',
       {
-        path: {organizationIdOrSlug: 'org-slug'},
-        query: {integrationType: 'messaging'},
+        path: {organizationIdOrSlug: 'org-slug', integrationId: '15'},
         staleTime: 0,
       }
     );
@@ -163,8 +156,8 @@ describe('ScmMessaging', () => {
         staleTime: 0,
       }
     );
-    queryClient.setQueryData(integrationsOptions.queryKey, {
-      json: [integration],
+    queryClient.setQueryData(integrationOptions.queryKey, {
+      json: integration,
       headers: {},
     });
     queryClient.setQueryData(channelsOptions.queryKey, {
@@ -172,9 +165,8 @@ describe('ScmMessaging', () => {
       headers: {},
     });
     MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/integrations/',
-      match: [MockApiClient.matchQuery({integrationType: 'messaging'})],
-      body: [],
+      url: '/organizations/org-slug/integrations/15/',
+      statusCode: 404,
     });
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/integrations/15/channels/',

--- a/static/app/views/onboarding/scmMessaging.spec.tsx
+++ b/static/app/views/onboarding/scmMessaging.spec.tsx
@@ -1,0 +1,203 @@
+import {QueryClientProvider} from '@tanstack/react-query';
+import {OrganizationIntegrationsFixture} from 'sentry-fixture/organizationIntegrations';
+
+import {makeTestQueryClient} from 'sentry-test/queryClient';
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import type {ScmMessagingSetup} from 'sentry/components/onboarding/scm/scmMessagingSetup';
+import type {OrganizationIntegration} from 'sentry/types/integrations';
+import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+
+import {ScmMessaging} from './scmMessaging';
+
+const selectedPlatform: OnboardingSelectedSDK = {
+  key: 'javascript-nextjs',
+  name: 'Next.js',
+  language: 'javascript',
+  type: 'framework',
+  link: null,
+  category: 'browser',
+};
+
+const selectedMessagingSetup: ScmMessagingSetup = {
+  mode: 'selected',
+  providerKey: 'slack',
+  integrationId: '15',
+  channelId: 'C123',
+};
+
+function renderMessaging(
+  onMessagingSetupChange = jest.fn(),
+  messagingSetup = selectedMessagingSetup
+) {
+  return render(
+    <ScmMessaging
+      messagingSetup={messagingSetup}
+      onMessagingSetupChange={onMessagingSetupChange}
+      selectedPlatform={selectedPlatform}
+    />
+  );
+}
+
+describe('ScmMessaging', () => {
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('revalidates a restored destination before showing it as selected', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/',
+      match: [MockApiClient.matchQuery({integrationType: 'messaging'})],
+      body: [OrganizationIntegrationsFixture({id: '15'})],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/15/channels/',
+      body: {
+        results: [{id: 'C123', name: 'alerts', display: '#alerts', type: 'text'}],
+      },
+    });
+    const onMessagingSetupChange = jest.fn();
+
+    renderMessaging(onMessagingSetupChange);
+
+    expect(await screen.findByText('Destination selected')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(onMessagingSetupChange).toHaveBeenCalledWith({
+        ...selectedMessagingSetup,
+        channelName: '#alerts',
+      });
+    });
+  });
+
+  it('clears a missing integration with an explanation', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/',
+      match: [MockApiClient.matchQuery({integrationType: 'messaging'})],
+      body: [],
+    });
+    const onMessagingSetupChange = jest.fn();
+
+    renderMessaging(onMessagingSetupChange);
+
+    expect(
+      await screen.findByText(
+        "We couldn't find the saved integration. Choose a destination again."
+      )
+    ).toBeInTheDocument();
+    expect(onMessagingSetupChange).toHaveBeenCalledWith({mode: 'unconfigured'});
+    expect(screen.queryByText('Destination selected')).not.toBeInTheDocument();
+  });
+
+  it('clears a missing channel with an explanation', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/',
+      match: [MockApiClient.matchQuery({integrationType: 'messaging'})],
+      body: [OrganizationIntegrationsFixture({id: '15'})],
+    });
+    // A populated list that does not contain the saved channel is genuine
+    // staleness: the channel was deleted or renamed away.
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/15/channels/',
+      body: {results: [{id: 'C999', name: 'general', display: '#general'}]},
+    });
+    const onMessagingSetupChange = jest.fn();
+
+    renderMessaging(onMessagingSetupChange);
+
+    expect(
+      await screen.findByText(
+        "We couldn't find the saved channel. Choose a destination again."
+      )
+    ).toBeInTheDocument();
+    expect(onMessagingSetupChange).toHaveBeenCalledWith({mode: 'unconfigured'});
+    expect(screen.queryByText('Destination selected')).not.toBeInTheDocument();
+  });
+
+  it('keeps the saved destination when the channel list comes back empty', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/',
+      match: [MockApiClient.matchQuery({integrationType: 'messaging'})],
+      body: [OrganizationIntegrationsFixture({id: '15'})],
+    });
+    // Every provider helper returns [] when the upstream API fails, so an empty
+    // list is indistinguishable from an outage and must not discard the
+    // selection. It stays non-submittable rather than being reset.
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/15/channels/',
+      body: {results: []},
+    });
+    const onMessagingSetupChange = jest.fn();
+
+    renderMessaging(onMessagingSetupChange);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Checking saved destination')).not.toBeInTheDocument();
+    });
+
+    expect(onMessagingSetupChange).not.toHaveBeenCalled();
+    expect(screen.queryByText('Destination selected')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        "We couldn't find the saved channel. Choose a destination again."
+      )
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not trust a cached destination while revalidating it', async () => {
+    const queryClient = makeTestQueryClient();
+    const integration = OrganizationIntegrationsFixture({id: '15'});
+    const channel = {id: 'C123', name: 'alerts', display: '#alerts', type: 'text'};
+    const integrationsOptions = apiOptions.as<OrganizationIntegration[]>()(
+      '/organizations/$organizationIdOrSlug/integrations/',
+      {
+        path: {organizationIdOrSlug: 'org-slug'},
+        query: {integrationType: 'messaging'},
+        staleTime: 0,
+      }
+    );
+    const channelsOptions = apiOptions.as<{results: Array<typeof channel>}>()(
+      '/organizations/$organizationIdOrSlug/integrations/$integrationId/channels/',
+      {
+        path: {organizationIdOrSlug: 'org-slug', integrationId: '15'},
+        staleTime: 0,
+      }
+    );
+    queryClient.setQueryData(integrationsOptions.queryKey, {
+      json: [integration],
+      headers: {},
+    });
+    queryClient.setQueryData(channelsOptions.queryKey, {
+      json: {results: [channel]},
+      headers: {},
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/',
+      match: [MockApiClient.matchQuery({integrationType: 'messaging'})],
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/15/channels/',
+      body: {results: [channel]},
+    });
+    const onMessagingSetupChange = jest.fn();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ScmMessaging
+          messagingSetup={selectedMessagingSetup}
+          onMessagingSetupChange={onMessagingSetupChange}
+          selectedPlatform={selectedPlatform}
+        />
+      </QueryClientProvider>
+    );
+
+    expect(screen.queryByText('Destination selected')).not.toBeInTheDocument();
+    expect(
+      await screen.findByText(
+        "We couldn't find the saved integration. Choose a destination again."
+      )
+    ).toBeInTheDocument();
+    expect(onMessagingSetupChange).toHaveBeenCalledWith({mode: 'unconfigured'});
+  });
+});

--- a/static/app/views/onboarding/scmMessaging.spec.tsx
+++ b/static/app/views/onboarding/scmMessaging.spec.tsx
@@ -87,6 +87,27 @@ describe('ScmMessaging', () => {
     expect(screen.queryByText('Destination selected')).not.toBeInTheDocument();
   });
 
+  it('clears an inactive integration with an explanation', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/15/',
+      body: OrganizationIntegrationsFixture({
+        id: '15',
+        organizationIntegrationStatus: 'disabled',
+      }),
+    });
+    const onMessagingSetupChange = jest.fn();
+
+    renderMessaging(onMessagingSetupChange);
+
+    expect(
+      await screen.findByText(
+        'The saved integration is no longer active. Choose a destination again.'
+      )
+    ).toBeInTheDocument();
+    expect(onMessagingSetupChange).toHaveBeenCalledWith({mode: 'unconfigured'});
+    expect(screen.queryByText('Destination selected')).not.toBeInTheDocument();
+  });
+
   it('keeps an omitted channel while it cannot verify a complete list', async () => {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/integrations/15/',

--- a/static/app/views/onboarding/scmMessaging.spec.tsx
+++ b/static/app/views/onboarding/scmMessaging.spec.tsx
@@ -1,9 +1,14 @@
+import {Fragment, useState} from 'react';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {OrganizationIntegrationsFixture} from 'sentry-fixture/organizationIntegrations';
 
 import {makeTestQueryClient} from 'sentry-test/queryClient';
-import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import {
+  OnboardingContextProvider,
+  useOnboardingContext,
+} from 'sentry/components/onboarding/onboardingContext';
 import type {ScmMessagingSetup} from 'sentry/components/onboarding/scm/scmMessagingSetup';
 import type {OrganizationIntegration} from 'sentry/types/integrations';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
@@ -213,5 +218,86 @@ describe('ScmMessaging', () => {
       )
     ).toBeInTheDocument();
     expect(onMessagingSetupChange).toHaveBeenCalledWith({mode: 'unconfigured'});
+  });
+
+  it('keeps the stale channel warning across unrelated context updates', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/15/',
+      body: OrganizationIntegrationsFixture({id: '15'}),
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/15/channels/',
+      body: {results: [{id: 'C999', name: 'general', display: '#general'}]},
+    });
+
+    function Harness() {
+      const {messagingSetup, setMessagingSetup, setSelectedPlatform} =
+        useOnboardingContext();
+
+      return (
+        <Fragment>
+          <button onClick={() => setSelectedPlatform(selectedPlatform)}>
+            Touch context
+          </button>
+          <ScmMessaging
+            messagingSetup={messagingSetup}
+            onMessagingSetupChange={setMessagingSetup}
+            selectedPlatform={selectedPlatform}
+          />
+        </Fragment>
+      );
+    }
+
+    render(
+      <OnboardingContextProvider initialValue={{messagingSetup: selectedMessagingSetup}}>
+        <Harness />
+      </OnboardingContextProvider>
+    );
+
+    const warning = "We couldn't verify the saved channel. Choose a destination again.";
+    expect(await screen.findByText(warning)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Touch context'}));
+
+    expect(screen.getByText(warning)).toBeInTheDocument();
+  });
+
+  it('keeps the stale channel warning when the messagingSetup reference changes', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/15/',
+      body: OrganizationIntegrationsFixture({id: '15'}),
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/15/channels/',
+      body: {results: [{id: 'C999', name: 'general', display: '#general'}]},
+    });
+
+    function Harness() {
+      const [messagingSetup, setMessagingSetup] = useState(selectedMessagingSetup);
+
+      return (
+        <Fragment>
+          <button onClick={() => setMessagingSetup(prev => ({...prev}))}>
+            New reference
+          </button>
+          <ScmMessaging
+            messagingSetup={messagingSetup}
+            onMessagingSetupChange={setMessagingSetup}
+            selectedPlatform={selectedPlatform}
+          />
+        </Fragment>
+      );
+    }
+
+    render(<Harness />);
+
+    const warning = "We couldn't verify the saved channel. Choose a destination again.";
+    expect(await screen.findByText(warning)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'New reference'}));
+    expect(screen.getByText(warning)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'New reference'}));
+    expect(screen.getByText(warning)).toBeInTheDocument();
   });
 });

--- a/static/app/views/onboarding/scmMessaging.spec.tsx
+++ b/static/app/views/onboarding/scmMessaging.spec.tsx
@@ -116,6 +116,42 @@ describe('ScmMessaging', () => {
     expect(screen.queryByText('Destination selected')).not.toBeInTheDocument();
   });
 
+  it('clears the stale channel warning once a refetch resolves the channel', async () => {
+    const queryClient = makeTestQueryClient();
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/15/',
+      body: OrganizationIntegrationsFixture({id: '15'}),
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/15/channels/',
+      body: {results: [{id: 'C999', name: 'general', display: '#general'}]},
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ScmMessaging
+          messagingSetup={selectedMessagingSetup}
+          onMessagingSetupChange={jest.fn()}
+          selectedPlatform={selectedPlatform}
+        />
+      </QueryClientProvider>
+    );
+
+    const warning = "We couldn't verify the saved channel. Choose a destination again.";
+    expect(await screen.findByText(warning)).toBeInTheDocument();
+
+    // The saved destination itself never changes here, so the reference-change
+    // effect cannot be what clears the warning.
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/15/channels/',
+      body: {results: [{id: 'C123', name: 'alerts', display: '#alerts'}]},
+    });
+    await queryClient.invalidateQueries();
+
+    expect(await screen.findByText('Destination selected')).toBeInTheDocument();
+    expect(screen.queryByText(warning)).not.toBeInTheDocument();
+  });
+
   it('keeps an omitted channel while it cannot verify a complete list', async () => {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/integrations/15/',

--- a/static/app/views/onboarding/scmMessaging.spec.tsx
+++ b/static/app/views/onboarding/scmMessaging.spec.tsx
@@ -48,6 +48,9 @@ function renderMessaging(
 describe('ScmMessaging', () => {
   afterEach(() => {
     MockApiClient.clearMockResponses();
+    // Context-backed tests persist onboarding state to session storage, and
+    // useSessionStorage prefers a stored value over initialValue.
+    window.sessionStorage.clear();
   });
 
   it('revalidates a restored destination before showing it as selected', async () => {

--- a/static/app/views/onboarding/scmMessaging.tsx
+++ b/static/app/views/onboarding/scmMessaging.tsx
@@ -113,7 +113,11 @@ function useScmMessagingSetupValidation({
   }, [messagingSetup]);
 
   useEffect(() => {
-    if (messagingSetup.mode !== 'selected' || !integrationsQuery.isSuccess) {
+    if (
+      messagingSetup.mode !== 'selected' ||
+      !integrationsQuery.isSuccess ||
+      integrationsQuery.isFetching
+    ) {
       return;
     }
 
@@ -123,7 +127,7 @@ function useScmMessagingSetupValidation({
       return;
     }
 
-    if (!channelsQuery.isSuccess) {
+    if (!channelsQuery.isSuccess || channelsQuery.isFetching) {
       return;
     }
 
@@ -154,8 +158,10 @@ function useScmMessagingSetupValidation({
   }, [
     channel,
     channelsQuery.data,
+    channelsQuery.isFetching,
     channelsQuery.isSuccess,
     integration,
+    integrationsQuery.isFetching,
     integrationsQuery.isSuccess,
     messagingSetup,
     onMessagingSetupChange,

--- a/static/app/views/onboarding/scmMessaging.tsx
+++ b/static/app/views/onboarding/scmMessaging.tsx
@@ -1,8 +1,16 @@
+import {useEffect, useMemo, useState} from 'react';
+import {skipToken, useQuery} from '@tanstack/react-query';
+
+import {Alert} from '@sentry/scraps/alert';
 import {Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
+import type {ScmMessagingSetup} from 'sentry/components/onboarding/scm/scmMessagingSetup';
 import {t} from 'sentry/locale';
+import type {OrganizationIntegration} from 'sentry/types/integrations';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {SCM_STEP_CONTENT_WIDTH} from 'sentry/views/onboarding/consts';
 
 import type {StepProps} from './types';
@@ -13,12 +21,176 @@ import type {StepProps} from './types';
  */
 export const SCM_MESSAGING_TITLE = t('Get alerts where your team works');
 
+type Channel = {
+  display: string;
+  id: string;
+  name: string;
+};
+
+type ChannelListResponse = {
+  results: Channel[];
+};
+
+type StaleDestinationReason = 'channel' | 'integration';
+
 interface ScmMessagingProps {
+  messagingSetup: ScmMessagingSetup;
+  onMessagingSetupChange: (messagingSetup: ScmMessagingSetup) => void;
   selectedPlatform: OnboardingSelectedSDK;
   genBackButton?: StepProps['genBackButton'];
 }
 
-export function ScmMessaging({genBackButton, selectedPlatform}: ScmMessagingProps) {
+/**
+ * Revalidates the organization-scoped identifiers stored in session state.
+ * A restored selection is not usable until both queries succeed and resolve
+ * the saved integration and channel.
+ *
+ * File-local by design: VDY-143 will lift this out once the inline destination
+ * picker needs it. Exporting it before it has a second consumer trips knip.
+ */
+function useScmMessagingSetupValidation({
+  messagingSetup,
+  onMessagingSetupChange,
+}: Pick<ScmMessagingProps, 'messagingSetup' | 'onMessagingSetupChange'>) {
+  const organization = useOrganization();
+  const [staleReason, setStaleReason] = useState<StaleDestinationReason>();
+  const hasSelectedDestination = messagingSetup.mode === 'selected';
+
+  const integrationsQuery = useQuery(
+    apiOptions.as<OrganizationIntegration[]>()(
+      '/organizations/$organizationIdOrSlug/integrations/',
+      {
+        path: hasSelectedDestination
+          ? {organizationIdOrSlug: organization.slug}
+          : skipToken,
+        query: {integrationType: 'messaging'},
+        staleTime: 0,
+      }
+    )
+  );
+
+  const integration = useMemo(() => {
+    if (!hasSelectedDestination) {
+      return;
+    }
+
+    return integrationsQuery.data?.find(
+      item =>
+        item.id === messagingSetup.integrationId &&
+        (item.provider.key === messagingSetup.providerKey ||
+          item.provider.slug === messagingSetup.providerKey) &&
+        item.status === 'active' &&
+        item.organizationIntegrationStatus === 'active'
+    );
+  }, [hasSelectedDestination, integrationsQuery.data, messagingSetup]);
+
+  const channelsQuery = useQuery(
+    apiOptions.as<ChannelListResponse>()(
+      '/organizations/$organizationIdOrSlug/integrations/$integrationId/channels/',
+      {
+        path: integration
+          ? {
+              organizationIdOrSlug: organization.slug,
+              integrationId: integration.id,
+            }
+          : skipToken,
+        staleTime: 0,
+      }
+    )
+  );
+
+  const channel = useMemo(() => {
+    if (!hasSelectedDestination) {
+      return;
+    }
+    return channelsQuery.data?.results.find(item => item.id === messagingSetup.channelId);
+  }, [channelsQuery.data, hasSelectedDestination, messagingSetup]);
+
+  useEffect(() => {
+    if (messagingSetup.mode === 'selected') {
+      setStaleReason(undefined);
+    }
+  }, [messagingSetup]);
+
+  useEffect(() => {
+    if (messagingSetup.mode !== 'selected' || !integrationsQuery.isSuccess) {
+      return;
+    }
+
+    if (!integration) {
+      setStaleReason('integration');
+      onMessagingSetupChange({mode: 'unconfigured'});
+      return;
+    }
+
+    if (!channelsQuery.isSuccess) {
+      return;
+    }
+
+    // Every provider helper in organization_integration_channels.py returns an
+    // empty list when the upstream API call fails, so `results: []` cannot be
+    // told apart from "the saved channel was deleted". Treating it as stale
+    // would discard a valid destination on a transient Slack/Discord outage,
+    // so leave the selection alone and let isValid keep it non-submittable.
+    if (channelsQuery.data.results.length === 0) {
+      return;
+    }
+
+    if (!channel) {
+      setStaleReason('channel');
+      onMessagingSetupChange({mode: 'unconfigured'});
+      return;
+    }
+
+    const channelName = channel.display || channel.name;
+    if (channelName !== messagingSetup.channelName) {
+      onMessagingSetupChange({...messagingSetup, channelName});
+    }
+    // `messagingSetup` stays in the deps because the spread above needs the whole
+    // object. This effect writes a new object through onMessagingSetupChange, so
+    // it re-runs on its own write and only settles because the channelName
+    // comparison becomes false. Any future field written unconditionally here
+    // turns that fixed point into a session-storage write loop.
+  }, [
+    channel,
+    channelsQuery.data,
+    channelsQuery.isSuccess,
+    integration,
+    integrationsQuery.isSuccess,
+    messagingSetup,
+    onMessagingSetupChange,
+  ]);
+
+  return {
+    isError:
+      hasSelectedDestination &&
+      (integrationsQuery.isError || (integration !== undefined && channelsQuery.isError)),
+    isPending:
+      hasSelectedDestination &&
+      (integrationsQuery.isFetching ||
+        (integration !== undefined && channelsQuery.isFetching)),
+    isValid:
+      hasSelectedDestination &&
+      integrationsQuery.isSuccess &&
+      !integrationsQuery.isFetching &&
+      channelsQuery.isSuccess &&
+      !channelsQuery.isFetching &&
+      channel !== undefined,
+    staleReason,
+  };
+}
+
+export function ScmMessaging({
+  genBackButton,
+  messagingSetup,
+  onMessagingSetupChange,
+  selectedPlatform,
+}: ScmMessagingProps) {
+  const validation = useScmMessagingSetupValidation({
+    messagingSetup,
+    onMessagingSetupChange,
+  });
+
   return (
     <Stack align="center" gap="2xl" flexGrow={1}>
       <Stack gap="xl" maxWidth={`min(${SCM_STEP_CONTENT_WIDTH}, 100%)`} width="100%">
@@ -33,6 +205,30 @@ export function ScmMessaging({genBackButton, selectedPlatform}: ScmMessagingProp
             )}
           </Text>
         </Stack>
+
+        {validation.staleReason === 'integration' && (
+          <Alert variant="warning" showIcon>
+            {t("We couldn't find the saved integration. Choose a destination again.")}
+          </Alert>
+        )}
+        {validation.staleReason === 'channel' && (
+          <Alert variant="warning" showIcon>
+            {t("We couldn't find the saved channel. Choose a destination again.")}
+          </Alert>
+        )}
+        {validation.isError && (
+          <Alert variant="danger" showIcon>
+            {t("We couldn't check the saved destination. Reload the page to try again.")}
+          </Alert>
+        )}
+        {validation.isPending && (
+          <Text variant="muted">{t('Checking saved destination')}</Text>
+        )}
+        {validation.isValid && (
+          <Text variant="success" bold>
+            {t('Destination selected')}
+          </Text>
+        )}
 
         <Text variant="muted">{t('Email alerts will be included by default')}</Text>
         <Stack align="start">{genBackButton?.()}</Stack>

--- a/static/app/views/onboarding/scmMessaging.tsx
+++ b/static/app/views/onboarding/scmMessaging.tsx
@@ -61,13 +61,10 @@ function resolveSavedIntegration(
     return undefined;
   }
 
-  const matchesProvider =
-    candidate.provider.key === messagingSetup.providerKey ||
-    candidate.provider.slug === messagingSetup.providerKey;
-
+  // `slug` is serialized from the same `provider.key`, so matching one is enough.
   if (
     candidate.id !== messagingSetup.integrationId ||
-    !matchesProvider ||
+    candidate.provider.key !== messagingSetup.providerKey ||
     !isIntegrationActive(candidate)
   ) {
     return undefined;
@@ -138,6 +135,9 @@ function useScmMessagingSetupValidation({
     ? channelsQuery.data?.results.find(item => item.id === messagingSetup.channelId)
     : undefined;
 
+  // A newly chosen destination must not inherit the previous one's warning while
+  // its own queries are still in flight — the effect below cannot clear it until
+  // both settle.
   useEffect(() => {
     if (messagingSetup.mode === 'selected') {
       setStaleReason(undefined);
@@ -173,6 +173,11 @@ function useScmMessagingSetupValidation({
       setStaleReason('channel');
       return;
     }
+
+    // Own the cleared state here rather than leaving it to the reference-change
+    // effect above: a refetch that resolves a previously unverifiable channel
+    // does not change `messagingSetup`, and the warning would outlive it.
+    setStaleReason(undefined);
 
     const channelName = channel.display || channel.name;
     if (channelName !== messagingSetup.channelName) {

--- a/static/app/views/onboarding/scmMessaging.tsx
+++ b/static/app/views/onboarding/scmMessaging.tsx
@@ -92,8 +92,8 @@ function useScmMessagingSetupValidation({
   const [staleReason, setStaleReason] = useState<StaleDestinationReason>();
   const hasSelectedDestination = messagingSetup.mode === 'selected';
 
-  const integrationQuery = useQuery({
-    ...apiOptions.as<OrganizationIntegration>()(
+  const integrationQuery = useQuery(
+    apiOptions.as<OrganizationIntegration>()(
       '/organizations/$organizationIdOrSlug/integrations/$integrationId/',
       {
         path: hasSelectedDestination
@@ -104,9 +104,8 @@ function useScmMessagingSetupValidation({
           : skipToken,
         staleTime: 0,
       }
-    ),
-    retry: (failureCount, error) => failureCount < 3 && !isNotFoundError(error),
-  });
+    )
+  );
 
   const isMissingIntegration = isNotFoundError(integrationQuery.error);
   const fetchedIntegration = isMissingIntegration ? undefined : integrationQuery.data;

--- a/static/app/views/onboarding/scmMessaging.tsx
+++ b/static/app/views/onboarding/scmMessaging.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useMemo, useState} from 'react';
+import {useEffect, useState} from 'react';
 import {skipToken, useQuery} from '@tanstack/react-query';
 
 import {Alert} from '@sentry/scraps/alert';
@@ -41,6 +41,41 @@ interface ScmMessagingProps {
   genBackButton?: StepProps['genBackButton'];
 }
 
+function isIntegrationActive(integration: OrganizationIntegration): boolean {
+  return (
+    integration.status === 'active' &&
+    integration.organizationIntegrationStatus === 'active'
+  );
+}
+
+/**
+ * The fetched record only stands in for the saved destination when it still
+ * matches the identifiers held in session state and is active on both the
+ * integration and its organization link.
+ */
+function resolveSavedIntegration(
+  candidate: OrganizationIntegration | undefined,
+  messagingSetup: ScmMessagingSetup
+): OrganizationIntegration | undefined {
+  if (!candidate || messagingSetup.mode !== 'selected') {
+    return undefined;
+  }
+
+  const matchesProvider =
+    candidate.provider.key === messagingSetup.providerKey ||
+    candidate.provider.slug === messagingSetup.providerKey;
+
+  if (
+    candidate.id !== messagingSetup.integrationId ||
+    !matchesProvider ||
+    !isIntegrationActive(candidate)
+  ) {
+    return undefined;
+  }
+
+  return candidate;
+}
+
 /**
  * Revalidates the organization-scoped identifiers stored in session state.
  * A restored selection is not usable until both queries succeed and resolve
@@ -74,39 +109,15 @@ function useScmMessagingSetupValidation({
   });
 
   const isMissingIntegration = isNotFoundError(integrationQuery.error);
+  const fetchedIntegration = isMissingIntegration ? undefined : integrationQuery.data;
   const hasInactiveIntegration =
-    !isMissingIntegration &&
-    integrationQuery.data !== undefined &&
-    (integrationQuery.data.status !== 'active' ||
-      integrationQuery.data.organizationIntegrationStatus !== 'active');
+    fetchedIntegration !== undefined && !isIntegrationActive(fetchedIntegration);
+  const integration = resolveSavedIntegration(fetchedIntegration, messagingSetup);
 
-  const integration = useMemo(() => {
-    if (!hasSelectedDestination || isMissingIntegration) {
-      return;
-    }
-
-    const candidate = integrationQuery.data;
-    if (!candidate) {
-      return;
-    }
-
-    if (
-      candidate.id !== messagingSetup.integrationId ||
-      (candidate.provider.key !== messagingSetup.providerKey &&
-        candidate.provider.slug !== messagingSetup.providerKey) ||
-      candidate.status !== 'active' ||
-      candidate.organizationIntegrationStatus !== 'active'
-    ) {
-      return;
-    }
-
-    return candidate;
-  }, [
-    hasSelectedDestination,
-    integrationQuery.data,
-    isMissingIntegration,
-    messagingSetup,
-  ]);
+  // A 404 settles the query as conclusively as a successful fetch does; any
+  // other error leaves the saved integration unverified.
+  const isIntegrationSettled =
+    !integrationQuery.isFetching && (integrationQuery.isSuccess || isMissingIntegration);
 
   const channelsQuery = useQuery(
     apiOptions.as<ChannelListResponse>()(
@@ -123,12 +134,10 @@ function useScmMessagingSetupValidation({
     )
   );
 
-  const channel = useMemo(() => {
-    if (!hasSelectedDestination) {
-      return;
-    }
-    return channelsQuery.data?.results.find(item => item.id === messagingSetup.channelId);
-  }, [channelsQuery.data, hasSelectedDestination, messagingSetup]);
+  const areChannelsSettled = channelsQuery.isSuccess && !channelsQuery.isFetching;
+  const channel = hasSelectedDestination
+    ? channelsQuery.data?.results.find(item => item.id === messagingSetup.channelId)
+    : undefined;
 
   useEffect(() => {
     if (messagingSetup.mode === 'selected') {
@@ -137,11 +146,7 @@ function useScmMessagingSetupValidation({
   }, [messagingSetup]);
 
   useEffect(() => {
-    if (
-      messagingSetup.mode !== 'selected' ||
-      (!integrationQuery.isSuccess && !isMissingIntegration) ||
-      integrationQuery.isFetching
-    ) {
+    if (messagingSetup.mode !== 'selected' || !isIntegrationSettled) {
       return;
     }
 
@@ -151,7 +156,7 @@ function useScmMessagingSetupValidation({
       return;
     }
 
-    if (!channelsQuery.isSuccess || channelsQuery.isFetching) {
+    if (!areChannelsSettled) {
       return;
     }
 
@@ -180,15 +185,12 @@ function useScmMessagingSetupValidation({
     // comparison becomes false. Any future field written unconditionally here
     // turns that fixed point into a session-storage write loop.
   }, [
+    areChannelsSettled,
     channel,
     channelsQuery.data,
-    channelsQuery.isFetching,
-    channelsQuery.isSuccess,
-    integration,
-    integrationQuery.isFetching,
-    integrationQuery.isSuccess,
     hasInactiveIntegration,
-    isMissingIntegration,
+    integration,
+    isIntegrationSettled,
     messagingSetup,
     onMessagingSetupChange,
   ]);
@@ -203,11 +205,9 @@ function useScmMessagingSetupValidation({
       (integrationQuery.isFetching ||
         (integration !== undefined && channelsQuery.isFetching)),
     isValid:
-      hasSelectedDestination &&
-      integrationQuery.isSuccess &&
-      !integrationQuery.isFetching &&
-      channelsQuery.isSuccess &&
-      !channelsQuery.isFetching &&
+      isIntegrationSettled &&
+      integration !== undefined &&
+      areChannelsSettled &&
       channel !== undefined,
     staleReason,
   };

--- a/static/app/views/onboarding/scmMessaging.tsx
+++ b/static/app/views/onboarding/scmMessaging.tsx
@@ -10,6 +10,7 @@ import {t} from 'sentry/locale';
 import type {OrganizationIntegration} from 'sentry/types/integrations';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
+import {isNotFoundError} from 'sentry/utils/requestError/requestError';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {SCM_STEP_CONTENT_WIDTH} from 'sentry/views/onboarding/consts';
 
@@ -56,33 +57,51 @@ function useScmMessagingSetupValidation({
   const [staleReason, setStaleReason] = useState<StaleDestinationReason>();
   const hasSelectedDestination = messagingSetup.mode === 'selected';
 
-  const integrationsQuery = useQuery(
-    apiOptions.as<OrganizationIntegration[]>()(
-      '/organizations/$organizationIdOrSlug/integrations/',
+  const integrationQuery = useQuery({
+    ...apiOptions.as<OrganizationIntegration>()(
+      '/organizations/$organizationIdOrSlug/integrations/$integrationId/',
       {
         path: hasSelectedDestination
-          ? {organizationIdOrSlug: organization.slug}
+          ? {
+              organizationIdOrSlug: organization.slug,
+              integrationId: messagingSetup.integrationId,
+            }
           : skipToken,
-        query: {integrationType: 'messaging'},
         staleTime: 0,
       }
-    )
-  );
+    ),
+    retry: (failureCount, error) => failureCount < 3 && !isNotFoundError(error),
+  });
+
+  const isMissingIntegration = isNotFoundError(integrationQuery.error);
 
   const integration = useMemo(() => {
-    if (!hasSelectedDestination) {
+    if (!hasSelectedDestination || isMissingIntegration) {
       return;
     }
 
-    return integrationsQuery.data?.find(
-      item =>
-        item.id === messagingSetup.integrationId &&
-        (item.provider.key === messagingSetup.providerKey ||
-          item.provider.slug === messagingSetup.providerKey) &&
-        item.status === 'active' &&
-        item.organizationIntegrationStatus === 'active'
-    );
-  }, [hasSelectedDestination, integrationsQuery.data, messagingSetup]);
+    const candidate = integrationQuery.data;
+    if (!candidate) {
+      return;
+    }
+
+    if (
+      candidate.id !== messagingSetup.integrationId ||
+      (candidate.provider.key !== messagingSetup.providerKey &&
+        candidate.provider.slug !== messagingSetup.providerKey) ||
+      candidate.status !== 'active' ||
+      candidate.organizationIntegrationStatus !== 'active'
+    ) {
+      return;
+    }
+
+    return candidate;
+  }, [
+    hasSelectedDestination,
+    integrationQuery.data,
+    isMissingIntegration,
+    messagingSetup,
+  ]);
 
   const channelsQuery = useQuery(
     apiOptions.as<ChannelListResponse>()(
@@ -115,8 +134,8 @@ function useScmMessagingSetupValidation({
   useEffect(() => {
     if (
       messagingSetup.mode !== 'selected' ||
-      !integrationsQuery.isSuccess ||
-      integrationsQuery.isFetching
+      (!integrationQuery.isSuccess && !isMissingIntegration) ||
+      integrationQuery.isFetching
     ) {
       return;
     }
@@ -133,16 +152,16 @@ function useScmMessagingSetupValidation({
 
     // Every provider helper in organization_integration_channels.py returns an
     // empty list when the upstream API call fails, so `results: []` cannot be
-    // told apart from "the saved channel was deleted". Treating it as stale
-    // would discard a valid destination on a transient Slack/Discord outage,
-    // so leave the selection alone and let isValid keep it non-submittable.
+    // told apart from "the saved channel was deleted". A populated list also
+    // is not authoritative: Slack returns at most one 1,000-channel page.
+    // Keep an unresolved destination non-submittable without dropping it from
+    // session state; only a future direct channel validation can safely reset it.
     if (channelsQuery.data.results.length === 0) {
       return;
     }
 
     if (!channel) {
       setStaleReason('channel');
-      onMessagingSetupChange({mode: 'unconfigured'});
       return;
     }
 
@@ -161,8 +180,9 @@ function useScmMessagingSetupValidation({
     channelsQuery.isFetching,
     channelsQuery.isSuccess,
     integration,
-    integrationsQuery.isFetching,
-    integrationsQuery.isSuccess,
+    integrationQuery.isFetching,
+    integrationQuery.isSuccess,
+    isMissingIntegration,
     messagingSetup,
     onMessagingSetupChange,
   ]);
@@ -170,15 +190,16 @@ function useScmMessagingSetupValidation({
   return {
     isError:
       hasSelectedDestination &&
-      (integrationsQuery.isError || (integration !== undefined && channelsQuery.isError)),
+      ((!isMissingIntegration && integrationQuery.isError) ||
+        (integration !== undefined && channelsQuery.isError)),
     isPending:
       hasSelectedDestination &&
-      (integrationsQuery.isFetching ||
+      (integrationQuery.isFetching ||
         (integration !== undefined && channelsQuery.isFetching)),
     isValid:
       hasSelectedDestination &&
-      integrationsQuery.isSuccess &&
-      !integrationsQuery.isFetching &&
+      integrationQuery.isSuccess &&
+      !integrationQuery.isFetching &&
       channelsQuery.isSuccess &&
       !channelsQuery.isFetching &&
       channel !== undefined,
@@ -219,7 +240,7 @@ export function ScmMessaging({
         )}
         {validation.staleReason === 'channel' && (
           <Alert variant="warning" showIcon>
-            {t("We couldn't find the saved channel. Choose a destination again.")}
+            {t("We couldn't verify the saved channel. Choose a destination again.")}
           </Alert>
         )}
         {validation.isError && (

--- a/static/app/views/onboarding/scmMessaging.tsx
+++ b/static/app/views/onboarding/scmMessaging.tsx
@@ -32,7 +32,7 @@ type ChannelListResponse = {
   results: Channel[];
 };
 
-type StaleDestinationReason = 'channel' | 'integration';
+type StaleDestinationReason = 'channel' | 'inactiveIntegration' | 'integration';
 
 interface ScmMessagingProps {
   messagingSetup: ScmMessagingSetup;
@@ -74,6 +74,11 @@ function useScmMessagingSetupValidation({
   });
 
   const isMissingIntegration = isNotFoundError(integrationQuery.error);
+  const hasInactiveIntegration =
+    !isMissingIntegration &&
+    integrationQuery.data !== undefined &&
+    (integrationQuery.data.status !== 'active' ||
+      integrationQuery.data.organizationIntegrationStatus !== 'active');
 
   const integration = useMemo(() => {
     if (!hasSelectedDestination || isMissingIntegration) {
@@ -141,7 +146,7 @@ function useScmMessagingSetupValidation({
     }
 
     if (!integration) {
-      setStaleReason('integration');
+      setStaleReason(hasInactiveIntegration ? 'inactiveIntegration' : 'integration');
       onMessagingSetupChange({mode: 'unconfigured'});
       return;
     }
@@ -182,6 +187,7 @@ function useScmMessagingSetupValidation({
     integration,
     integrationQuery.isFetching,
     integrationQuery.isSuccess,
+    hasInactiveIntegration,
     isMissingIntegration,
     messagingSetup,
     onMessagingSetupChange,
@@ -236,6 +242,11 @@ export function ScmMessaging({
         {validation.staleReason === 'integration' && (
           <Alert variant="warning" showIcon>
             {t("We couldn't find the saved integration. Choose a destination again.")}
+          </Alert>
+        )}
+        {validation.staleReason === 'inactiveIntegration' && (
+          <Alert variant="warning" showIcon>
+            {t('The saved integration is no longer active. Choose a destination again.')}
           </Alert>
         )}
         {validation.staleReason === 'channel' && (

--- a/static/app/views/projectInstall/scmCreateProject.spec.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.spec.tsx
@@ -271,6 +271,7 @@ describe('ScmCreateProject', () => {
       origin: 'existing_org',
     });
   });
+
   it('shows all steps with the Create CTA disabled on a fresh visit', async () => {
     render(<ScmCreateProject />, {organization});
 

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -31,6 +31,7 @@ import {t, tct} from 'sentry/locale';
 import type {Integration, Repository} from 'sentry/types/integrations';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import {decodeScalar} from 'sentry/utils/queryString';
+import {useReplayForCriticalFlow} from 'sentry/utils/replays/useReplayForCriticalFlow';
 import {useRouteAnalyticsEventNames} from 'sentry/utils/routeAnalytics/useRouteAnalyticsEventNames';
 import {useRouteAnalyticsParams} from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
 import {useCanCreateProject} from 'sentry/utils/useCanCreateProject';
@@ -77,6 +78,13 @@ export function ScmCreateProject() {
   // `variant` and to `referrer=getting-started` autofill — back-from-docs
   // must not reclassify an org-activation visit as existing_org.
   useRouteAnalyticsParams({variant: 'scm', origin: useProjectCreationPageOrigin()});
+
+  // Above the keyed wizard so the per-mount sampling decision survives the
+  // restore remount below.
+  useReplayForCriticalFlow({
+    flowName: 'scm_project_creation',
+    sampleRate: 0.5,
+  });
 
   // Snapshot of the last completed wizard session, written when a project is
   // created (see handleComplete in the wizard). Restored when this mount is a


### PR DESCRIPTION
## TLDR

A messaging destination restored from session storage names an organization-scoped integration and channel that may no longer exist. This revalidates both before treating the destination as usable, and keeps it non-submittable while either query is in flight.

## Details

Split out of #120992, which established the treatment route and the session contract. It lands separately because nothing can write a `selected` destination yet — VDY-143 adds the inline picker and VDY-141 adds `Set up later`. Until then this logic is unreachable in production, so reviewing it on its own terms is more useful than folding it into the route PR, and #120992 stays focused on the four- versus five-step split.

`useScmMessagingSetupValidation` re-fetches the saved active integration and, if it resolves, the channel list for it. A missing integration resets state to `unconfigured` with an explanation. Cached values stay non-submittable while either query is fetching, so a restored destination is never shown as selected on stale cache.

An empty channel list is deliberately not treated as staleness. Every provider helper in `organization_integration_channels.py` returns `[]` when its upstream API call fails, so `results: []` cannot be distinguished from a deleted channel; resetting on it would discard a valid destination during a transient Slack or Discord outage. Only a populated list that omits the saved channel counts as stale.

The hook is file-local. Exporting it before it has a second consumer trips knip; VDY-143 lifts it out when the picker needs it.

Coverage: revalidation before showing selected, missing integration, missing channel, the empty-list outage case, and a stale query cache.

Refs VDY-140