### PR TITLE
ref(autofix): Gate manual PR iteration UI behind its own feature flag

### DIFF
--- a/static/app/components/events/autofix/useExplorerAutofix.spec.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.spec.tsx
@@ -643,10 +643,16 @@ describe('isPrIterationBlock', () => {
 });
 
 describe('isRunValidForPrIteration', () => {
-  it('is true only when the autofix-pr-iteration feature is enabled', () => {
+  it('is true only when the autofix-pr-iteration-manual feature is enabled', () => {
+    expect(
+      isRunValidForPrIteration(
+        OrganizationFixture({features: ['autofix-pr-iteration-manual']})
+      )
+    ).toBe(true);
+    // Automated CI iteration does not enable the manual feedback form.
     expect(
       isRunValidForPrIteration(OrganizationFixture({features: ['autofix-pr-iteration']}))
-    ).toBe(true);
+    ).toBe(false);
     expect(isRunValidForPrIteration(OrganizationFixture({features: []}))).toBe(false);
   });
 });

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -497,7 +497,7 @@ export function isCodingAgentsSection(section: AutofixSection): boolean {
 }
 
 export function isRunValidForPrIteration(organization: Organization): boolean {
-  return organization.features.includes('autofix-pr-iteration');
+  return organization.features.includes('autofix-pr-iteration-manual');
 }
 
 export function isLastStepPrIteration(runState: ExplorerAutofixState | null): boolean {

--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -29,6 +29,11 @@ const prIterationOrganization = OrganizationFixture({
   features: ['autofix-pr-iteration'],
 });
 
+// For the feedback form and its reset behavior, which are manual-only.
+const manualPrIterationOrganization = OrganizationFixture({
+  features: ['autofix-pr-iteration-manual'],
+});
+
 function makeSection(
   step: string,
   status: AutofixSection['status'],
@@ -672,7 +677,7 @@ describe('ArtifactCard', () => {
             [makeAssistantBlock('The relevant files are not in the connected repo.')]
           )}
         />,
-        {organization: prIterationOrganization}
+        {organization: manualPrIterationOrganization}
       );
 
       await userEvent.click(screen.getByRole('button', {name: 'Add context & retry'}));
@@ -691,6 +696,44 @@ describe('ArtifactCard', () => {
         runId: 123,
         userContext: 'Try the other repo',
       });
+    });
+
+    it('does not open PR iteration feedback when only automated CI iteration is enabled', async () => {
+      const autofixWithPR: ReturnType<typeof useExplorerAutofix> = {
+        ...mockAutofixWithRunState,
+        runState: {
+          run_id: 123,
+          blocks: [],
+          status: 'completed',
+          updated_at: '2026-01-01T00:00:00Z',
+          repo_pr_states: {'org/repo': makePR()},
+        },
+      };
+
+      render(
+        <CodeChangesCard
+          groupId="1"
+          autofix={autofixWithPR}
+          section={makeSection(
+            'code_changes',
+            'completed',
+            [],
+            [makeAssistantBlock('The relevant files are not in the connected repo.')]
+          )}
+        />,
+        {organization: prIterationOrganization}
+      );
+
+      await userEvent.click(screen.getByRole('button', {name: 'Add context & retry'}));
+
+      // Reset is ineligible once a PR exists without the manual flag, so neither
+      // the PR iteration form nor the free-text reset prompt opens.
+      expect(
+        screen.queryByText('Anything else you want to see on your PR?')
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText('What additional context should Seer use?')
+      ).not.toBeInTheDocument();
     });
 
     it('falls back to the generic failure copy when there is no explanation', () => {
@@ -1388,6 +1431,34 @@ describe('ArtifactCard', () => {
       expect(screen.queryByTestId('feedback-processed')).not.toBeInTheDocument();
     });
 
+    it('disables reset once PRs exist when only automated CI iteration is enabled', () => {
+      const autofix: ReturnType<typeof useExplorerAutofix> = {
+        ...mockAutofix,
+        runState: {
+          run_id: 123,
+          blocks: [],
+          status: 'processing',
+          updated_at: '2026-01-01T00:00:00Z',
+          repo_pr_states: {'org/repo': makePR()},
+        },
+      };
+
+      render(
+        <CodeChangesCard
+          groupId="1"
+          autofix={autofix}
+          section={makeSection('code_changes', 'completed', [
+            [makePatch('org/repo', 'src/app.py')],
+          ])}
+        />,
+        {organization: prIterationOrganization}
+      );
+
+      // Reset opens the manual feedback form, so the automated flag must not
+      // unlock it once a PR exists.
+      expect(screen.getByRole('button', {name: 'Re-run step'})).toBeDisabled();
+    });
+
     it('keeps reset enabled with the feature flag even when PRs exist', () => {
       const autofix: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofix,
@@ -1408,7 +1479,7 @@ describe('ArtifactCard', () => {
             [makePatch('org/repo', 'src/app.py')],
           ])}
         />,
-        {organization: prIterationOrganization}
+        {organization: manualPrIterationOrganization}
       );
 
       expect(screen.getByRole('button', {name: 'Re-run step'})).toBeEnabled();
@@ -1460,7 +1531,7 @@ describe('ArtifactCard', () => {
             [makePatch('org/repo', 'src/app.py')],
           ])}
         />,
-        {organization: prIterationOrganization}
+        {organization: manualPrIterationOrganization}
       );
 
       expect(screen.getByRole('button', {name: 'Re-run step'})).toBeEnabled();
@@ -1540,7 +1611,7 @@ describe('ArtifactCard', () => {
             [makePrIterationBlock(0, {text: 'fix the CI failure'})]
           )}
         />,
-        {organization: prIterationOrganization}
+        {organization: manualPrIterationOrganization}
       );
 
       await userEvent.click(screen.getByRole('button', {name: 'Re-run step'}));

--- a/static/app/components/events/autofix/v3/codeChangesCard.stories.tsx
+++ b/static/app/components/events/autofix/v3/codeChangesCard.stories.tsx
@@ -19,7 +19,7 @@ import type {ExplorerFilePatch} from 'sentry/views/seerExplorer/types';
 
 // The Feedback section is gated behind this feature flag; the wrapper below
 // injects it so every example renders it.
-const PR_ITERATION_FEATURE = 'autofix-pr-iteration';
+const PR_ITERATION_FEATURE = 'autofix-pr-iteration-manual';
 
 const noop = () => {};
 
@@ -447,7 +447,7 @@ export default Storybook.story('CodeChangesCard Feedback', story => {
 });
 
 /**
- * Injects the `autofix-pr-iteration` feature into the surrounding organization
+ * Injects the `autofix-pr-iteration-manual` feature into the surrounding organization
  * so the Feedback section renders. Mirrors the pattern used by
  * activityLineItem.stories.tsx.
  */

--- a/static/app/components/events/autofix/v3/codeChangesCard.tsx
+++ b/static/app/components/events/autofix/v3/codeChangesCard.tsx
@@ -56,7 +56,13 @@ function getFinalExplanation(section: AutofixSection): string | null {
 
 export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProps) {
   const organization = useOrganization();
-  const hasPrIterationFeature = organization.features.includes('autofix-pr-iteration');
+  // Reporting on an iteration applies to both flows; only the form is manual.
+  const hasPrIterationFeature =
+    organization.features.includes('autofix-pr-iteration') ||
+    organization.features.includes('autofix-pr-iteration-manual');
+  const hasManualPrIterationFeature = organization.features.includes(
+    'autofix-pr-iteration-manual'
+  );
 
   const isIterating =
     hasPrIterationFeature &&
@@ -95,12 +101,12 @@ export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProp
     [artifact]
   );
 
-  const prIterationEnabled = hasPrIterationFeature;
   const hasPRs = Object.keys(autofix.runState?.repo_pr_states ?? {}).length > 0;
   const noCodingAgents =
     Object.values(autofix.runState?.coding_agents ?? {}).length === 0;
 
-  const isResetEligible = prIterationEnabled
+  // Reset-after-PR is only reachable where reset opens the manual form.
+  const isResetEligible = hasManualPrIterationFeature
     ? noCodingAgents && (hasPRs || autofix.runState?.status !== 'processing')
     : noCodingAgents && !hasPRs && autofix.runState?.status !== 'processing';
 
@@ -137,7 +143,7 @@ export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProp
     return t('%s files changed in %s repos', filesChanged.size, reposChanged);
   }, [patchesByRepo]);
 
-  const showPrIterationForm = hasPRs && prIterationEnabled;
+  const showPrIterationForm = hasPRs && hasManualPrIterationFeature;
   const prIterationForm = (
     <PrIterationFeedbackForm
       autofix={autofix}

--- a/static/app/components/events/autofix/v3/drawer.tsx
+++ b/static/app/components/events/autofix/v3/drawer.tsx
@@ -40,7 +40,10 @@ export function SeerDrawer({group, project}: SeerDrawerProps) {
   const organization = useOrganization();
   const aiConfig = useAiConfig(group, project);
   const aiAutofix = useExplorerAutofix(group, {
-    pollPR: organization.features.includes('autofix-pr-iteration'),
+    // Automated CI iteration pushes commits with no user action, so poll for both.
+    pollPR:
+      organization.features.includes('autofix-pr-iteration') ||
+      organization.features.includes('autofix-pr-iteration-manual'),
   });
 
   const handleCopyMarkdown = useHandleCopyMarkdown({aiAutofix});

--- a/static/app/components/events/autofix/v3/nextStep.spec.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.spec.tsx
@@ -660,7 +660,7 @@ describe('SeerDrawerNextStep', () => {
 
   describe('PullRequestNextStep', () => {
     const prIterationOrganization = OrganizationFixture({
-      features: ['autofix-pr-iteration'],
+      features: ['autofix-pr-iteration-manual'],
     });
 
     function makePrIterationAutofix(

--- a/static/app/views/issueDetails/sidebar/seerDrawer.spec.tsx
+++ b/static/app/views/issueDetails/sidebar/seerDrawer.spec.tsx
@@ -338,7 +338,7 @@ describe('SeerDrawer', () => {
       });
     }
 
-    it('does not poll the autofix endpoint when autofix-pr-iteration is disabled', async () => {
+    it('does not poll the autofix endpoint when both PR iteration features are disabled', async () => {
       const getMock = mockAutofixWithPr();
 
       render(<SeerDrawer group={mockGroup} project={mockProject} />, {organization});
@@ -353,28 +353,31 @@ describe('SeerDrawer', () => {
       expect(getMock.mock.calls).toHaveLength(callsAfterLoad);
     });
 
-    it('polls the autofix endpoint when autofix-pr-iteration is enabled and a PR exists', async () => {
-      const getMock = mockAutofixWithPr();
+    it.each([['autofix-pr-iteration'], ['autofix-pr-iteration-manual']])(
+      'polls the autofix endpoint when %s is enabled and a PR exists',
+      async feature => {
+        const getMock = mockAutofixWithPr();
 
-      render(<SeerDrawer group={mockGroup} project={mockProject} />, {
-        organization: OrganizationFixture({
-          hideAiFeatures: false,
-          features: ['gen-ai-features', 'autofix-pr-iteration'],
-        }),
-      });
+        render(<SeerDrawer group={mockGroup} project={mockProject} />, {
+          organization: OrganizationFixture({
+            hideAiFeatures: false,
+            features: ['gen-ai-features', feature],
+          }),
+        });
 
-      await waitForElementToBeRemoved(() =>
-        screen.queryByTestId('ai-setup-loading-indicator')
-      );
+        await waitForElementToBeRemoved(() =>
+          screen.queryByTestId('ai-setup-loading-indicator')
+        );
 
-      const callsAfterLoad = getMock.mock.calls.length;
+        const callsAfterLoad = getMock.mock.calls.length;
 
-      await waitFor(
-        () => {
-          expect(getMock.mock.calls.length).toBeGreaterThan(callsAfterLoad);
-        },
-        {timeout: 5000}
-      );
-    });
+        await waitFor(
+          () => {
+            expect(getMock.mock.calls.length).toBeGreaterThan(callsAfterLoad);
+          },
+          {timeout: 5000}
+        );
+      }
+    );
   });
 });


### PR DESCRIPTION
Frontend half of CW-1778. Depends on #121180 (backend) for the new flag registration — land that first.

`autofix-pr-iteration` gates both manual and automated CI PR iteration, so automated CI iteration can't ship without also exposing the manual UI. The backend PR added `organizations:autofix-pr-iteration-manual`; this moves the user-driven affordances onto it.

current ui when manual feature flag is of -- you can still see the automatic iterations in the form of feedback, but we removed the form to trigger the iteration with a manual feedback.

<img width="824" height="632" alt="image" src="https://github.com/user-attachments/assets/f76f7b83-1c48-4584-ac33-a10549135be1" />

with the manual flag -- show manual feedback form again:

<img width="823" height="722" alt="image" src="https://github.com/user-attachments/assets/16b13200-d6c2-4342-aad7-0b304f44bc95" />


Fixes [CW-1778](https://linear.app/getsentry/issue/CW-1778/disable-manual-pr-iteration-by-another-feature-flag)
