### PR TITLE
feat(preprod): Show image hash in snapshot metadata tooltip

### DIFF
--- a/static/app/views/preprod/snapshots/main/snapshotCards.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotCards.tsx
@@ -392,7 +392,7 @@ function MetadataTooltip({json}: {json: string}) {
   );
 }
 
-const METADATA_BLOCKLIST = new Set(['key', 'diff_image_key']);
+const METADATA_BLOCKLIST = new Set(['diff_image_key']);
 
 function MetadataInfoButton({
   copyData,

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.spec.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.spec.tsx
@@ -347,6 +347,7 @@ describe('SnapshotMainContent', () => {
         display_name: 'Button / light old',
         height: 180,
         image_file_name: 'button.light.old.png',
+        key: 'base-button-light-old',
         width: 320,
       },
       head_image: {
@@ -354,6 +355,7 @@ describe('SnapshotMainContent', () => {
         group: 'components',
         height: 180,
         image_file_name: 'button.light.png',
+        key: 'head-button-light',
         width: 320,
       },
     });


### PR DESCRIPTION
The per-image metadata tooltip on the snapshot detail view (`/preprod/snapshots/...`) now includes each image's content hash. The tooltip previously blocklisted the `key` field, which holds the image's content hash — product now wants that hash visible to users.

The hash is already present in the API response as the image `key` (it is content-addressed storage: the image is stored and served at `{org}/{project}/{content_hash}`), so this is a display-only change: drop `key` from `METADATA_BLOCKLIST`. It renders in the tooltip labeled `key`, since that is the field name on the wire; no backend or type change is needed.

`diff_image_key` stays blocklisted — unlike `key`, it is not a hash but an internal objectstore path to the generated diff-mask image (`{head_artifact_id}/{base_artifact_id}/diff/<file>.png`), so it is not meaningful user-facing metadata.

The copy-metadata test is updated to expect `key` in the emitted JSON.