### PR TITLE
feat(action_log): Make Activity.datetime choice more explicit

### DIFF
--- a/src/sentry/models/activity.py
+++ b/src/sentry/models/activity.py
@@ -134,6 +134,10 @@ class ActivityManager(BaseManager["Activity"]):
         return super().create(**kwargs)
 
     def create(self, **kwargs: Any) -> Activity:
+        # Only forward an explicit datetime to the action log; otherwise let
+        # the outbox receiver use the DB default.
+        explicit_datetime: datetime | None = kwargs.get("datetime")
+
         activity: Activity = super().create(**kwargs)
 
         group_id = kwargs.get("group_id")
@@ -151,7 +155,7 @@ class ActivityManager(BaseManager["Activity"]):
                         group_id=group_id,
                         project=activity.project,
                         idempotency_key=activity_action_idempotency_key(activity),
-                        date_added=activity.datetime,
+                        date_added=explicit_datetime,
                     )
             except Exception:
                 _default_logger.info("Failed to translate activity %d to GALE", activity.id)

--- a/src/sentry/receivers/outbox/cell.py
+++ b/src/sentry/receivers/outbox/cell.py
@@ -15,7 +15,6 @@ from typing import Any, assert_never, cast
 
 from django.db import IntegrityError, router, transaction
 from django.dispatch import receiver
-from django.utils import timezone
 
 from sentry.audit_log.services.log import AuditLogEvent, UserIpEvent, log_rpc_service
 from sentry.auth.services.auth import auth_service
@@ -355,21 +354,24 @@ def process_group_action_log_event(payload: GroupActionLogPayload, **kwds: Any) 
         force_async_derived = payload["force_async_derived"]
         date_added = payload.get("date_added")
 
+        # Only pass date_added when explicitly provided; otherwise rely on the
+        # DB default (Now()) rather than a Python-supplied timestamp.
+        create_kwargs: dict[str, Any] = {
+            "group_id": group_id,
+            "project_id": payload["project_id"],
+            "type": payload["type"],
+            "actor_type": payload["actor_type"],
+            "actor_id": payload["actor_id"],
+            "source": payload["source"],
+            "data": payload["data"],
+            "idempotency_key": payload.get("idempotency_key"),
+        }
+        if date_added is not None:
+            create_kwargs["date_added"] = datetime.fromisoformat(date_added)
+
         try:
             with transaction.atomic(using=using):
-                GroupActionLogEntry.objects.create(
-                    group_id=group_id,
-                    project_id=payload["project_id"],
-                    type=payload["type"],
-                    actor_type=payload["actor_type"],
-                    actor_id=payload["actor_id"],
-                    source=payload["source"],
-                    data=payload["data"],
-                    idempotency_key=payload.get("idempotency_key"),
-                    date_added=(
-                        datetime.fromisoformat(date_added) if date_added else timezone.now()
-                    ),
-                )
+                GroupActionLogEntry.objects.create(**create_kwargs)
         except IntegrityError:
             # Idempotency conflict; we treat this as a no-op.
             # Return to skip the trigger_group_log_processing call.

--- a/tests/sentry/models/test_activity.py
+++ b/tests/sentry/models/test_activity.py
@@ -436,16 +436,56 @@ class ActivityTest(TestCase):
 
         before = datetime.now(timezone.utc)
 
-        activity = Activity.objects.create_group_activity(
-            group=group,
-            type=ActivityType.SET_IGNORED,
-            user=user,
-            send_notification=False,
-        )
+        with self.feature("projects:issue-action-log-write-to-db"), outbox_runner():
+            activity = Activity.objects.create_group_activity(
+                group=group,
+                type=ActivityType.SET_IGNORED,
+                user=user,
+                send_notification=False,
+            )
 
         after = datetime.now(timezone.utc)
 
         assert before <= activity.datetime <= after
+
+        # GALE relies on the DB default (Now()); only assert plausibility
+        # since app and DB clocks aren't synchronized.
+        gale = GroupActionLogEntry.objects.get(group_id=group.id)
+        assert gale.date_added is not None
+        assert abs((gale.date_added - after).total_seconds()) < 5
+
+    def test_create_without_explicit_datetime_passes_none_to_publish(self) -> None:
+        # No `datetime=` kwarg -> `date_added=None` so the outbox receiver
+        # falls back to the DB default rather than a Python-supplied "now".
+        project = self.create_project(name="test_publish_no_datetime")
+        group = self.create_group(project)
+
+        with patch("sentry.models.activity.publish_action_from_context") as mock_publish:
+            Activity.objects.create_group_activity(
+                group=group,
+                type=ActivityType.SET_RESOLVED,
+                send_notification=False,
+            )
+
+        assert mock_publish.called
+        assert mock_publish.call_args.kwargs["date_added"] is None
+
+    def test_create_with_explicit_datetime_passes_it_to_publish(self) -> None:
+        # Explicit `datetime=` is forwarded verbatim as `date_added`.
+        project = self.create_project(name="test_publish_with_datetime")
+        group = self.create_group(project)
+        custom_datetime = datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+
+        with patch("sentry.models.activity.publish_action_from_context") as mock_publish:
+            Activity.objects.create_group_activity(
+                group=group,
+                type=ActivityType.SET_RESOLVED,
+                send_notification=False,
+                datetime=custom_datetime,
+            )
+
+        assert mock_publish.called
+        assert mock_publish.call_args.kwargs["date_added"] == custom_datetime
 
     def test_create_group_activity_with_ident(self) -> None:
         project = self.create_project(name="test_with_ident")


### PR DESCRIPTION
Any Activity providing a custom datetime should be explicitly choosing to do so; in all other cases, we should use the DB-provided date_added.
