### PR TITLE
fix(onboarding): Fire the welcome analytics event once per visit

### DIFF
--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -88,6 +88,47 @@ describe('Onboarding', () => {
       );
     });
 
+    it('fires the welcome event once when a stale platform is cleaned up', async () => {
+      // The cleanup below writes onboarding state, which changes the context
+      // value identity and re-runs the effect. The analytics event must not
+      // ride along with that second pass.
+      sessionStorage.setItem(
+        'onboarding',
+        JSON.stringify({
+          selectedPlatform: {
+            key: 'javascript-nextjs',
+            type: 'framework',
+            language: 'javascript',
+            category: 'browser',
+          },
+        })
+      );
+
+      render(
+        <OnboardingContextProvider>
+          <OnboardingWithoutContext />
+        </OnboardingContextProvider>,
+        {
+          initialRouterConfig: {
+            location: {
+              pathname: '/onboarding/org-slug/welcome/',
+            },
+            route: '/onboarding/:orgId/:step/',
+          },
+        }
+      );
+
+      await waitFor(() => {
+        expect(sessionStorage.getItem('onboarding')).toBeNull();
+      });
+
+      expect(
+        jest
+          .mocked(trackAnalytics)
+          .mock.calls.filter(call => call[0] === 'growth.onboarding_start_onboarding')
+      ).toHaveLength(1);
+    });
+
     it('calls trackAnalytics and onComplete on next button click', async () => {
       const {router} = render(
         <OnboardingContextProvider>

--- a/static/app/views/onboarding/useWelcomeAnalyticsEffect.ts
+++ b/static/app/views/onboarding/useWelcomeAnalyticsEffect.ts
@@ -14,6 +14,9 @@ export function useWelcomeAnalyticsEffect() {
     reportExposure: false,
   });
 
+  // Kept separate from the cleanup below: the onboarding context value changes
+  // identity whenever session state is written, so sharing an effect would let
+  // the cleanup re-fire this event.
   useEffect(() => {
     if (hasScmOnboarding) {
       trackAnalytics('onboarding.scm_welcome_step_viewed', {organization});
@@ -23,10 +26,12 @@ export function useWelcomeAnalyticsEffect() {
         source: ONBOARDING_WELCOME_SCREEN_SOURCE,
       });
     }
+  }, [organization, hasScmOnboarding]);
 
+  useEffect(() => {
     if (onboardingContext.selectedPlatform) {
       // At this point the selectedSDK shall be undefined but just in case, cleaning this up here too
       onboardingContext.setSelectedPlatform(undefined);
     }
-  }, [organization, onboardingContext, hasScmOnboarding]);
+  }, [onboardingContext]);
 }


### PR DESCRIPTION
## TLDR

`growth.onboarding_start_onboarding` fired twice for anyone who landed on the onboarding welcome step with a platform still staged in their session, inflating the top-of-funnel count against every other step, which reports once. It now fires once per visit.

## Details

The bug is a dependency-array problem, not a logic one, which is why it survived: `useWelcomeAnalyticsEffect` did two unrelated jobs in a single effect. It reported the step view, and it cleaned up a stale `selectedPlatform` left behind in the `onboarding` sessionStorage key. To do the cleanup it depended on the whole `onboardingContext`, whose value identity changes on every session write, so the cleanup's own `setSelectedPlatform(undefined)` re-ran the effect and reported a second view.

The double count only happens when there is a platform to clean up, so it tracks Back navigations from `select-platform` and mid-flow refreshes rather than fresh visits. That makes it a systematic skew toward users who backtrack, not uniform inflation — the welcome step looks busier than it is relative to the steps after it.

Splitting the two jobs into separate effects lets the analytics one depend on just `[organization, hasScmOnboarding]`, so a session write can no longer re-trigger it, while the cleanup keeps its `[onboardingContext]` dependency and its existing behavior. Deriving a "already reported" ref would also suppress the second call, but it leaves the real problem in place: an effect that reports analytics has no reason to depend on mutable session state at all, and the next field added to the context would reintroduce the coupling.

Coverage seeds a stale `selectedPlatform` into `sessionStorage`, waits for the cleanup to drain it, then asserts exactly one event. The assertion counts matching `trackAnalytics` calls rather than using `toHaveBeenCalledWith`, which passes at any call count and is what let the regression through; the new test reports `Received length: 2` against the old implementation.
