### PR TITLE
chore(scm-first-messaging-integration): Refactor the messaging integration launcher for inline consumers

### DIFF
--- a/static/app/components/pipeline/modal.spec.tsx
+++ b/static/app/components/pipeline/modal.spec.tsx
@@ -1,6 +1,6 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {act, renderGlobalModal, screen} from 'sentry-test/reactTestingLibrary';
+import {act, renderGlobalModal, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {openPipelineModal} from './modal';
 
@@ -50,5 +50,22 @@ describe('PipelineModal', () => {
 
     expect(await screen.findByText('Hello!')).toBeInTheDocument();
     expect(screen.getAllByText(/Step 1 of 2/).length).toBeGreaterThan(0);
+  });
+
+  it('reports a pipeline error to the caller', async () => {
+    const onError = jest.fn();
+    MockApiClient.addMockResponse({
+      url: API_URL,
+      method: 'POST',
+      statusCode: 500,
+      body: {detail: 'Installation failed'},
+      match: [MockApiClient.matchData({action: 'initialize', provider: 'dummy'})],
+    });
+
+    renderGlobalModal({organization});
+
+    act(() => openPipelineModal({type: 'integration', provider: 'dummy', onError}));
+
+    await waitFor(() => expect(onError).toHaveBeenCalledWith('Installation failed'));
   });
 });

--- a/static/app/components/pipeline/modal.spec.tsx
+++ b/static/app/components/pipeline/modal.spec.tsx
@@ -1,12 +1,6 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {
-  act,
-  renderGlobalModal,
-  screen,
-  userEvent,
-  waitFor,
-} from 'sentry-test/reactTestingLibrary';
+import {act, renderGlobalModal, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {openPipelineModal} from './modal';
 
@@ -73,29 +67,5 @@ describe('PipelineModal', () => {
     act(() => openPipelineModal({type: 'integration', provider: 'dummy', onError}));
 
     await waitFor(() => expect(onError).toHaveBeenCalledWith('Installation failed'));
-  });
-
-  it('reports a pipeline error again after Start over when the message is identical', async () => {
-    const onError = jest.fn();
-    MockApiClient.addMockResponse({
-      url: API_URL,
-      method: 'POST',
-      statusCode: 500,
-      body: {detail: 'Installation failed'},
-      match: [MockApiClient.matchData({action: 'initialize', provider: 'dummy'})],
-    });
-
-    renderGlobalModal({organization});
-
-    act(() => openPipelineModal({type: 'integration', provider: 'dummy', onError}));
-
-    // First failure reported
-    await waitFor(() => expect(onError).toHaveBeenCalledTimes(1));
-
-    // User clicks Start over; the pipeline re-initializes and fails again
-    await userEvent.click(screen.getByRole('button', {name: /start over/i}));
-
-    await waitFor(() => expect(onError).toHaveBeenCalledTimes(2));
-    expect(onError).toHaveBeenLastCalledWith('Installation failed');
   });
 });

--- a/static/app/components/pipeline/modal.spec.tsx
+++ b/static/app/components/pipeline/modal.spec.tsx
@@ -1,6 +1,12 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {act, renderGlobalModal, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+import {
+  act,
+  renderGlobalModal,
+  screen,
+  userEvent,
+  waitFor,
+} from 'sentry-test/reactTestingLibrary';
 
 import {openPipelineModal} from './modal';
 
@@ -67,5 +73,29 @@ describe('PipelineModal', () => {
     act(() => openPipelineModal({type: 'integration', provider: 'dummy', onError}));
 
     await waitFor(() => expect(onError).toHaveBeenCalledWith('Installation failed'));
+  });
+
+  it('reports a pipeline error again after Start over when the message is identical', async () => {
+    const onError = jest.fn();
+    MockApiClient.addMockResponse({
+      url: API_URL,
+      method: 'POST',
+      statusCode: 500,
+      body: {detail: 'Installation failed'},
+      match: [MockApiClient.matchData({action: 'initialize', provider: 'dummy'})],
+    });
+
+    renderGlobalModal({organization});
+
+    act(() => openPipelineModal({type: 'integration', provider: 'dummy', onError}));
+
+    // First failure reported
+    await waitFor(() => expect(onError).toHaveBeenCalledTimes(1));
+
+    // User clicks Start over; the pipeline re-initializes and fails again
+    await userEvent.click(screen.getByRole('button', {name: /start over/i}));
+
+    await waitFor(() => expect(onError).toHaveBeenCalledTimes(2));
+    expect(onError).toHaveBeenLastCalledWith('Installation failed');
   });
 });

--- a/static/app/components/pipeline/modal.tsx
+++ b/static/app/components/pipeline/modal.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import {Fragment, useEffect, useRef} from 'react';
 import {AnimatePresence, motion} from 'framer-motion';
 
 import {Alert} from '@sentry/scraps/alert';
@@ -30,6 +30,7 @@ interface PipelineModalProps<
   description?: string;
   initialData?: Record<string, string>;
   onComplete?: (data: CompletionDataFor<T, P>) => void;
+  onError?: (error: string) => void;
   /** Overrides the header title (defaults to the pipeline's `actionTitle`). */
   title?: string;
 }
@@ -45,6 +46,7 @@ function PipelineModal<
   provider,
   initialData,
   onComplete,
+  onError,
   title,
   description,
 }: PipelineModalProps<T, P>) {
@@ -59,6 +61,14 @@ function PipelineModal<
     description,
   });
   const {stepDefinition} = pipeline;
+  const lastReportedError = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (pipeline.error && pipeline.error !== lastReportedError.current) {
+      lastReportedError.current = pipeline.error;
+      onError?.(pipeline.error);
+    }
+  }, [onError, pipeline.error]);
 
   const stepText = (
     <Text variant="muted">
@@ -153,6 +163,7 @@ interface OpenPipelineModalOptions<
   initialData?: Record<string, string>;
   onClose?: () => void;
   onComplete?: (data: CompletionDataFor<T, P>) => void;
+  onError?: (error: string) => void;
   title?: string;
 }
 
@@ -165,6 +176,7 @@ export function openPipelineModal<
   initialData,
   onComplete,
   onClose,
+  onError,
   title,
   description,
 }: OpenPipelineModalOptions<T, P>) {
@@ -176,6 +188,7 @@ export function openPipelineModal<
         provider={provider}
         initialData={initialData}
         onComplete={onComplete}
+        onError={onError}
         title={title}
         description={description}
       />

--- a/static/app/components/pipeline/modal.tsx
+++ b/static/app/components/pipeline/modal.tsx
@@ -61,14 +61,14 @@ function PipelineModal<
     description,
   });
   const {stepDefinition} = pipeline;
-  const lastReportedError = useRef<string | null>(null);
+  const onErrorRef = useRef(onError);
+  onErrorRef.current = onError;
 
   useEffect(() => {
-    if (pipeline.error && pipeline.error !== lastReportedError.current) {
-      lastReportedError.current = pipeline.error;
-      onError?.(pipeline.error);
+    if (pipeline.error) {
+      onErrorRef.current?.(pipeline.error);
     }
-  }, [onError, pipeline.error]);
+  }, [pipeline.error]);
 
   const stepText = (
     <Text variant="muted">

--- a/static/app/components/pipeline/modal.tsx
+++ b/static/app/components/pipeline/modal.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect, useRef} from 'react';
+import {Fragment, useEffect, useEffectEvent} from 'react';
 import {AnimatePresence, motion} from 'framer-motion';
 
 import {Alert} from '@sentry/scraps/alert';
@@ -61,12 +61,15 @@ function PipelineModal<
     description,
   });
   const {stepDefinition} = pipeline;
-  const onErrorRef = useRef(onError);
-  onErrorRef.current = onError;
+  // Keeps `onError` out of the deps below. Every distinct error is reported, so a
+  // retry that fails again reports again.
+  const reportError = useEffectEvent((error: string) => {
+    onError?.(error);
+  });
 
   useEffect(() => {
     if (pipeline.error) {
-      onErrorRef.current?.(pipeline.error);
+      reportError(pipeline.error);
     }
   }, [pipeline.error]);
 

--- a/static/app/utils/analytics/integrations/index.ts
+++ b/static/app/utils/analytics/integrations/index.ts
@@ -96,7 +96,9 @@ export type IntegrationEventParameters = {
   'integrations.index_viewed': MultipleIntegrationsEventParams;
   'integrations.install_modal_auto_opened': SingleIntegrationEventParams;
   'integrations.install_modal_opened': SingleIntegrationEventParams;
+  'integrations.installation_cancelled': IntegrationInstallEventParams;
   'integrations.installation_complete': IntegrationInstallEventParams;
+  'integrations.installation_failed': IntegrationInstallEventParams;
   'integrations.installation_input_value_changed': IntegrationInstallationInputValueChangeEventParams;
   'integrations.installation_start': IntegrationInstallEventParams;
   'integrations.integration_tab_clicked': SingleIntegrationEventParams;
@@ -125,6 +127,8 @@ export const integrationEventMap: Record<IntegrationAnalyticsKey, string> = {
   'integrations.integration_viewed': 'Integrations: Integration Viewed',
   'integrations.installation_start': 'Integrations: Installation Start',
   'integrations.installation_complete': 'Integrations: Installation Complete',
+  'integrations.installation_cancelled': 'Integrations: Installation Cancelled',
+  'integrations.installation_failed': 'Integrations: Installation Failed',
   'integrations.uninstall_clicked': 'Integrations: Uninstall Clicked',
   'integrations.uninstall_completed': 'Integrations: Uninstall Completed',
   'integrations.enabled': 'Integrations: Enabled',

--- a/static/app/utils/integrations/useAddIntegration.spec.tsx
+++ b/static/app/utils/integrations/useAddIntegration.spec.tsx
@@ -36,6 +36,12 @@ describe('useAddIntegration', () => {
       provider: 'github',
       initialData: undefined,
       onComplete: expect.any(Function),
+      onError: expect.any(Function),
+      onClose: expect.any(Function),
+    });
+    expect(result.current.state).toEqual({
+      status: 'installing',
+      providerKey: 'github',
     });
   });
 
@@ -102,6 +108,11 @@ describe('useAddIntegration', () => {
 
     expect(onInstall).toHaveBeenCalledWith(integration);
     expect(successSpy).toHaveBeenCalledWith('GitHub added');
+    expect(result.current.state).toEqual({
+      status: 'complete',
+      providerKey: 'github',
+      integration,
+    });
   });
 
   it('suppresses the success message when requested', () => {
@@ -128,5 +139,97 @@ describe('useAddIntegration', () => {
 
     expect(onInstall).toHaveBeenCalledWith(integration);
     expect(successSpy).not.toHaveBeenCalled();
+  });
+
+  it('reports cancellation when the pipeline modal closes before completion', () => {
+    const onCancel = jest.fn();
+    let onClose: (() => void) | undefined;
+    jest.spyOn(pipelineModal, 'openPipelineModal').mockImplementation(options => {
+      onClose = options.onClose;
+    });
+
+    const {result} = renderHookWithProviders(() => useAddIntegration());
+
+    act(() =>
+      result.current.startFlow({
+        provider,
+        organization: OrganizationFixture(),
+        onInstall: jest.fn(),
+        onCancel,
+      })
+    );
+    act(() => {
+      onClose?.();
+      onClose?.();
+    });
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(result.current.state).toEqual({
+      status: 'cancelled',
+      providerKey: 'github',
+    });
+  });
+
+  it('does not report cancellation when completion closes the modal', () => {
+    const onCancel = jest.fn();
+    let onClose: (() => void) | undefined;
+    let onComplete: ((data: typeof integration) => void) | undefined;
+    jest.spyOn(pipelineModal, 'openPipelineModal').mockImplementation(options => {
+      onClose = options.onClose;
+      onComplete = options.onComplete as typeof onComplete;
+    });
+
+    const {result} = renderHookWithProviders(() => useAddIntegration());
+
+    act(() =>
+      result.current.startFlow({
+        provider,
+        organization: OrganizationFixture(),
+        onInstall: jest.fn(),
+        onCancel,
+      })
+    );
+    act(() => {
+      onComplete?.(integration);
+      onClose?.();
+    });
+
+    expect(onCancel).not.toHaveBeenCalled();
+    expect(result.current.state.status).toBe('complete');
+  });
+
+  it('reports pipeline failures without also reporting cancellation', () => {
+    const onCancel = jest.fn();
+    const onError = jest.fn();
+    let onClose: (() => void) | undefined;
+    let handleError: ((error: string) => void) | undefined;
+    jest.spyOn(pipelineModal, 'openPipelineModal').mockImplementation(options => {
+      onClose = options.onClose;
+      handleError = options.onError;
+    });
+
+    const {result} = renderHookWithProviders(() => useAddIntegration());
+
+    act(() =>
+      result.current.startFlow({
+        provider,
+        organization: OrganizationFixture(),
+        onInstall: jest.fn(),
+        onCancel,
+        onError,
+      })
+    );
+    act(() => {
+      handleError?.('Installation failed');
+      onClose?.();
+    });
+
+    expect(onError).toHaveBeenCalledWith('Installation failed');
+    expect(onCancel).not.toHaveBeenCalled();
+    expect(result.current.state).toEqual({
+      status: 'error',
+      providerKey: 'github',
+      error: 'Installation failed',
+    });
   });
 });

--- a/static/app/utils/integrations/useAddIntegration.spec.tsx
+++ b/static/app/utils/integrations/useAddIntegration.spec.tsx
@@ -7,6 +7,7 @@ import {act, renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
 import * as indicators from 'sentry/actionCreators/indicator';
 import * as pipelineModal from 'sentry/components/pipeline/modal';
 import {useAddIntegration} from 'sentry/utils/integrations/useAddIntegration';
+import * as integrationUtil from 'sentry/utils/integrationUtil';
 
 describe('useAddIntegration', () => {
   const provider = GitHubIntegrationProviderFixture();
@@ -259,6 +260,132 @@ describe('useAddIntegration', () => {
     expect(result.current.state).toEqual({
       status: 'cancelled',
       providerKey: 'github',
+      lastError: 'Installation failed',
+    });
+  });
+
+  it('tracks installation_failed once and not installation_cancelled when closing after a failure', () => {
+    const onCancel = jest.fn();
+    const trackSpy = jest.spyOn(integrationUtil, 'trackIntegrationAnalytics');
+    let onClose: (() => void) | undefined;
+    let handleError: ((error: string) => void) | undefined;
+    jest.spyOn(pipelineModal, 'openPipelineModal').mockImplementation(options => {
+      onClose = options.onClose;
+      handleError = options.onError;
+    });
+
+    const {result} = renderHookWithProviders(() => useAddIntegration());
+
+    act(() =>
+      result.current.startFlow({
+        provider,
+        organization: OrganizationFixture(),
+        onInstall: jest.fn(),
+        onCancel,
+      })
+    );
+    act(() => {
+      handleError?.('Installation failed');
+      onClose?.();
+    });
+
+    expect(trackSpy).toHaveBeenCalledWith(
+      'integrations.installation_failed',
+      expect.any(Object)
+    );
+    expect(trackSpy).not.toHaveBeenCalledWith(
+      'integrations.installation_cancelled',
+      expect.any(Object)
+    );
+    // UI restore still fires
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('tracks installation_failed once even when the pipeline fails twice, and calls onError both times', () => {
+    const onError = jest.fn();
+    const trackSpy = jest.spyOn(integrationUtil, 'trackIntegrationAnalytics');
+    let handleError: ((error: string) => void) | undefined;
+    jest.spyOn(pipelineModal, 'openPipelineModal').mockImplementation(options => {
+      handleError = options.onError;
+    });
+
+    const {result} = renderHookWithProviders(() => useAddIntegration());
+
+    act(() =>
+      result.current.startFlow({
+        provider,
+        organization: OrganizationFixture(),
+        onInstall: jest.fn(),
+        onError,
+      })
+    );
+    act(() => {
+      handleError?.('Installation failed');
+      handleError?.('Installation failed');
+    });
+
+    const failedCalls = trackSpy.mock.calls.filter(
+      ([event]) => event === 'integrations.installation_failed'
+    );
+    expect(failedCalls).toHaveLength(1);
+    expect(onError).toHaveBeenCalledTimes(2);
+  });
+
+  it('tracks installation_cancelled when closing with no failure', () => {
+    const trackSpy = jest.spyOn(integrationUtil, 'trackIntegrationAnalytics');
+    let onClose: (() => void) | undefined;
+    jest.spyOn(pipelineModal, 'openPipelineModal').mockImplementation(options => {
+      onClose = options.onClose;
+    });
+
+    const {result: _result} = renderHookWithProviders(() => useAddIntegration());
+
+    act(() =>
+      _result.current.startFlow({
+        provider,
+        organization: OrganizationFixture(),
+        onInstall: jest.fn(),
+      })
+    );
+    act(() => onClose?.());
+
+    expect(trackSpy).toHaveBeenCalledWith(
+      'integrations.installation_cancelled',
+      expect.any(Object)
+    );
+    expect(trackSpy).not.toHaveBeenCalledWith(
+      'integrations.installation_failed',
+      expect.any(Object)
+    );
+  });
+
+  it('sets lastError to the most recent failure message when closing after multiple errors', () => {
+    let onClose: (() => void) | undefined;
+    let handleError: ((error: string) => void) | undefined;
+    jest.spyOn(pipelineModal, 'openPipelineModal').mockImplementation(options => {
+      onClose = options.onClose;
+      handleError = options.onError;
+    });
+
+    const {result} = renderHookWithProviders(() => useAddIntegration());
+
+    act(() =>
+      result.current.startFlow({
+        provider,
+        organization: OrganizationFixture(),
+        onInstall: jest.fn(),
+      })
+    );
+    act(() => {
+      handleError?.('First error');
+      handleError?.('Second error');
+      onClose?.();
+    });
+
+    expect(result.current.state).toEqual({
+      status: 'cancelled',
+      providerKey: 'github',
+      lastError: 'Second error',
     });
   });
 });

--- a/static/app/utils/integrations/useAddIntegration.spec.tsx
+++ b/static/app/utils/integrations/useAddIntegration.spec.tsx
@@ -198,7 +198,37 @@ describe('useAddIntegration', () => {
     expect(result.current.state.status).toBe('complete');
   });
 
-  it('reports pipeline failures without also reporting cancellation', () => {
+  it('reports a pipeline failure without also reporting cancellation', () => {
+    const onCancel = jest.fn();
+    const onError = jest.fn();
+    let handleError: ((error: string) => void) | undefined;
+    jest.spyOn(pipelineModal, 'openPipelineModal').mockImplementation(options => {
+      handleError = options.onError;
+    });
+
+    const {result} = renderHookWithProviders(() => useAddIntegration());
+
+    act(() =>
+      result.current.startFlow({
+        provider,
+        organization: OrganizationFixture(),
+        onInstall: jest.fn(),
+        onCancel,
+        onError,
+      })
+    );
+    act(() => handleError?.('Installation failed'));
+
+    expect(onError).toHaveBeenCalledWith('Installation failed');
+    expect(onCancel).not.toHaveBeenCalled();
+    expect(result.current.state).toEqual({
+      status: 'error',
+      providerKey: 'github',
+      error: 'Installation failed',
+    });
+  });
+
+  it('reports cancellation when the modal closes after a failure', () => {
     const onCancel = jest.fn();
     const onError = jest.fn();
     let onClose: (() => void) | undefined;
@@ -225,11 +255,10 @@ describe('useAddIntegration', () => {
     });
 
     expect(onError).toHaveBeenCalledWith('Installation failed');
-    expect(onCancel).not.toHaveBeenCalled();
+    expect(onCancel).toHaveBeenCalledTimes(1);
     expect(result.current.state).toEqual({
-      status: 'error',
+      status: 'cancelled',
       providerKey: 'github',
-      error: 'Installation failed',
     });
   });
 });

--- a/static/app/utils/integrations/useAddIntegration.tsx
+++ b/static/app/utils/integrations/useAddIntegration.tsx
@@ -82,7 +82,6 @@ export function useAddIntegration() {
     const is_scm = isScmProvider(provider);
     let cancelled = false;
     let completed = false;
-    let failed = false;
 
     setState({status: 'installing', providerKey: provider.key});
 
@@ -116,16 +115,29 @@ export function useAddIntegration() {
         onInstall(integration);
       },
       onError: error => {
-        failed = true;
         setState({status: 'error', providerKey: provider.key, error});
+        trackIntegrationAnalytics('integrations.installation_failed', {
+          integration: provider.key,
+          integration_type: 'first_party',
+          is_scm,
+          organization,
+          ...analyticsParams,
+        });
         onError?.(error);
       },
       onClose: () => {
-        if (cancelled || completed || failed) {
+        if (cancelled || completed) {
           return;
         }
         cancelled = true;
         setState({status: 'cancelled', providerKey: provider.key});
+        trackIntegrationAnalytics('integrations.installation_cancelled', {
+          integration: provider.key,
+          integration_type: 'first_party',
+          is_scm,
+          organization,
+          ...analyticsParams,
+        });
         onCancel?.();
       },
     });

--- a/static/app/utils/integrations/useAddIntegration.tsx
+++ b/static/app/utils/integrations/useAddIntegration.tsx
@@ -1,4 +1,4 @@
-import {useCallback} from 'react';
+import {useCallback, useState} from 'react';
 
 import {addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {openPipelineModal} from 'sentry/components/pipeline/modal';
@@ -37,6 +37,8 @@ export interface AddIntegrationParams {
     description?: string;
     title?: string;
   };
+  onCancel?: () => void;
+  onError?: (error: string) => void;
   /**
    * When true, the "%s added" success toast is not shown on install.
    * Use when the surrounding UI already communicates the connected state.
@@ -44,6 +46,13 @@ export interface AddIntegrationParams {
   suppressSuccessMessage?: boolean;
   urlParams?: Record<string, string>;
 }
+
+export type AddIntegrationState =
+  | {status: 'idle'}
+  | {providerKey: string; status: 'installing'}
+  | {integration: IntegrationWithConfig; providerKey: string; status: 'complete'}
+  | {providerKey: string; status: 'cancelled'}
+  | {error: string; providerKey: string; status: 'error'};
 
 /**
  * Opens the integration setup flow. Accepts all parameters at call time via
@@ -55,11 +64,15 @@ export interface AddIntegrationParams {
  * flows are surfaced by `openPipelineModal`/the registry.
  */
 export function useAddIntegration() {
+  const [state, setState] = useState<AddIntegrationState>({status: 'idle'});
+
   const startFlow = useCallback((params: AddIntegrationParams) => {
     const {
       organization,
       provider,
       onInstall,
+      onCancel,
+      onError,
       analyticsParams,
       suppressSuccessMessage,
       urlParams,
@@ -67,6 +80,11 @@ export function useAddIntegration() {
     } = params;
 
     const is_scm = isScmProvider(provider);
+    let cancelled = false;
+    let completed = false;
+    let failed = false;
+
+    setState({status: 'installing', providerKey: provider.key});
 
     trackIntegrationAnalytics('integrations.installation_start', {
       integration: provider.key,
@@ -82,6 +100,7 @@ export function useAddIntegration() {
       initialData: urlParams,
       ...modalParams,
       onComplete: data => {
+        completed = true;
         trackIntegrationAnalytics('integrations.installation_complete', {
           integration: provider.key,
           integration_type: 'first_party',
@@ -92,10 +111,25 @@ export function useAddIntegration() {
         if (!suppressSuccessMessage) {
           addSuccessMessage(t('%s added', provider.name));
         }
-        onInstall(data as IntegrationWithConfig);
+        const integration = data as IntegrationWithConfig;
+        setState({status: 'complete', providerKey: provider.key, integration});
+        onInstall(integration);
+      },
+      onError: error => {
+        failed = true;
+        setState({status: 'error', providerKey: provider.key, error});
+        onError?.(error);
+      },
+      onClose: () => {
+        if (cancelled || completed || failed) {
+          return;
+        }
+        cancelled = true;
+        setState({status: 'cancelled', providerKey: provider.key});
+        onCancel?.();
       },
     });
   }, []);
 
-  return {startFlow};
+  return {startFlow, state};
 }

--- a/static/app/utils/integrations/useAddIntegration.tsx
+++ b/static/app/utils/integrations/useAddIntegration.tsx
@@ -51,7 +51,7 @@ export type AddIntegrationState =
   | {status: 'idle'}
   | {providerKey: string; status: 'installing'}
   | {integration: IntegrationWithConfig; providerKey: string; status: 'complete'}
-  | {providerKey: string; status: 'cancelled'}
+  | {providerKey: string; status: 'cancelled'; lastError?: string}
   | {error: string; providerKey: string; status: 'error'};
 
 /**
@@ -82,6 +82,12 @@ export function useAddIntegration() {
     const is_scm = isScmProvider(provider);
     let cancelled = false;
     let completed = false;
+    // Gates analytics only. Deliberately not part of the `onClose` guard below:
+    // closing after a failure must still call onCancel so the inline row restores.
+    let failureReported = false;
+    // Retained so the terminal `cancelled` state can distinguish a failed attempt
+    // from a clean back-out.
+    let lastError: string | undefined;
 
     setState({status: 'installing', providerKey: provider.key});
 
@@ -116,13 +122,17 @@ export function useAddIntegration() {
       },
       onError: error => {
         setState({status: 'error', providerKey: provider.key, error});
-        trackIntegrationAnalytics('integrations.installation_failed', {
-          integration: provider.key,
-          integration_type: 'first_party',
-          is_scm,
-          organization,
-          ...analyticsParams,
-        });
+        lastError = error;
+        if (!failureReported) {
+          failureReported = true;
+          trackIntegrationAnalytics('integrations.installation_failed', {
+            integration: provider.key,
+            integration_type: 'first_party',
+            is_scm,
+            organization,
+            ...analyticsParams,
+          });
+        }
         onError?.(error);
       },
       onClose: () => {
@@ -130,14 +140,16 @@ export function useAddIntegration() {
           return;
         }
         cancelled = true;
-        setState({status: 'cancelled', providerKey: provider.key});
-        trackIntegrationAnalytics('integrations.installation_cancelled', {
-          integration: provider.key,
-          integration_type: 'first_party',
-          is_scm,
-          organization,
-          ...analyticsParams,
-        });
+        setState({status: 'cancelled', providerKey: provider.key, lastError});
+        if (!failureReported) {
+          trackIntegrationAnalytics('integrations.installation_cancelled', {
+            integration: provider.key,
+            integration_type: 'first_party',
+            is_scm,
+            organization,
+            ...analyticsParams,
+          });
+        }
         onCancel?.();
       },
     });

--- a/static/app/utils/integrations/useAutoOpenInstallModal.tsx
+++ b/static/app/utils/integrations/useAutoOpenInstallModal.tsx
@@ -6,12 +6,17 @@ import type {IntegrationProvider} from 'sentry/types/integrations';
 import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import type {AddIntegrationParams} from 'sentry/utils/integrations/useAddIntegration';
-import {useAddIntegration} from 'sentry/utils/integrations/useAddIntegration';
 
 interface Props {
   onInstall: AddIntegrationParams['onInstall'];
   organization: Organization;
   provider: IntegrationProvider;
+  /**
+   * The caller's `startFlow` from `useAddIntegration`. Accepting it here rather
+   * than creating a second hook instance means the auto-open and button-click
+   * paths share one hook, keeping install state observable in one place.
+   */
+  startFlow: (params: AddIntegrationParams) => void;
   analyticsParams?: AddIntegrationParams['analyticsParams'];
   suppressSuccessMessage?: boolean;
 }
@@ -36,11 +41,11 @@ export function useAutoOpenInstallModal({
   provider,
   organization,
   onInstall,
+  startFlow,
   analyticsParams,
   suppressSuccessMessage,
 }: Props) {
   const [showInstallModal, setShowInstallModal] = useQueryState('showInstallModal');
-  const {startFlow} = useAddIntegration();
   const autoOpenedForRef = useRef<string | null>(null);
 
   useEffect(() => {

--- a/static/app/views/alerts/rules/issue/addIntegrationRow.tsx
+++ b/static/app/views/alerts/rules/issue/addIntegrationRow.tsx
@@ -13,9 +13,11 @@ import {IntegrationContext} from 'sentry/views/settings/organizationIntegrations
 
 type Props = {
   onClick: () => void;
+  onCancel?: () => void;
+  onError?: (error: string) => void;
 };
 
-export function AddIntegrationRow({onClick}: Props) {
+export function AddIntegrationRow({onClick, onCancel, onError}: Props) {
   const organization = useOrganization();
   const {isSelfHosted} = ConfigStore.getState();
   const integration = useContext(IntegrationContext);
@@ -57,6 +59,8 @@ export function AddIntegrationRow({onClick}: Props) {
               onExternalClick={onClick}
               externalInstallText={`Add ${provider.metadata.noun}`}
               buttonProps={buttonProps}
+              onCancel={onCancel}
+              onError={onError}
             />
           );
         }}

--- a/static/app/views/settings/organizationIntegrations/addIntegrationButton.tsx
+++ b/static/app/views/settings/organizationIntegrations/addIntegrationButton.tsx
@@ -11,10 +11,15 @@ import {useAutoOpenInstallModal} from 'sentry/utils/integrations/useAutoOpenInst
 
 interface AddIntegrationButtonProps
   extends
-    Omit<ButtonProps, 'children' | 'analyticsParams'>,
+    Omit<ButtonProps, 'children' | 'analyticsParams' | 'onError'>,
     Pick<
       AddIntegrationParams,
-      'provider' | 'organization' | 'analyticsParams' | 'suppressSuccessMessage'
+      | 'provider'
+      | 'organization'
+      | 'analyticsParams'
+      | 'suppressSuccessMessage'
+      | 'onCancel'
+      | 'onError'
     > {
   onAddIntegration: (data: IntegrationWithConfig) => void;
   buttonText?: string;
@@ -31,6 +36,8 @@ export function AddIntegrationButton({
   analyticsParams,
   installStatus,
   suppressSuccessMessage,
+  onCancel,
+  onError,
   ...buttonProps
 }: AddIntegrationButtonProps) {
   const label =
@@ -73,6 +80,8 @@ export function AddIntegrationButton({
             onInstall: onAddIntegration,
             analyticsParams,
             suppressSuccessMessage,
+            onCancel,
+            onError,
           });
         }}
         aria-label={t('Add integration')}

--- a/static/app/views/settings/organizationIntegrations/addIntegrationButton.tsx
+++ b/static/app/views/settings/organizationIntegrations/addIntegrationButton.tsx
@@ -57,6 +57,7 @@ export function AddIntegrationButton({
     onInstall: onAddIntegration,
     analyticsParams,
     suppressSuccessMessage,
+    startFlow,
   });
 
   return (

--- a/static/app/views/settings/organizationIntegrations/integrationButton.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationButton.tsx
@@ -23,6 +23,8 @@ type Props = {
   onExternalClick: () => void;
   userHasAccess: boolean;
   externalInstallText?: string;
+  onCancel?: () => void;
+  onError?: (error: string) => void;
 };
 
 export function IntegrationButton({
@@ -31,6 +33,8 @@ export function IntegrationButton({
   onExternalClick,
   externalInstallText,
   buttonProps,
+  onCancel,
+  onError,
 }: Props) {
   const organization = useOrganization();
   const {provider, type, installStatus, analyticsParams, suppressSuccessMessage} =
@@ -62,6 +66,8 @@ export function IntegrationButton({
         installStatus={installStatus}
         analyticsParams={analyticsParams}
         suppressSuccessMessage={suppressSuccessMessage}
+        onCancel={onCancel}
+        onError={onError}
         {...buttonProps}
         organization={organization}
       />


### PR DESCRIPTION
FOR TICKET: https://linear.app/getsentry/issue/VDY-142/refactor-the-messaging-integration-launcher-for-inline-consumers

## Summary

Refactors the integration installation launcher so inline row consumers (like the messaging integration rows in SCM onboarding) can fully own and react to the install lifecycle — without going through a modal-based picker.

- **`useAddIntegration` now exposes full lifecycle state** — added an `AddIntegrationState` type (`idle` → `installing` → `complete | cancelled | error`) and a `state` value returned from the hook. Callers can now drive inline UI (spinners, restored rows, success states) directly off this.

- **New `onCancel` and `onError` callbacks** — `startFlow` now accepts these alongside `onInstall`. `onError` fires when the pipeline reports a failure; `onCancel` fires when the modal is closed before completing (including after a failure — closing is always a cancellation, not a dead end).

- **`PipelineModal` now propagates errors to callers** — added `onError` to `openPipelineModal` options and wired it through `PipelineModal` via a ref-based effect, so the hook hears about pipeline failures in real time.

- **Callbacks threaded down the row chain** — `onCancel` and `onError` are now optional props on `AddIntegrationButton`, `IntegrationButton`, and `AddIntegrationRow`, so any page rendering rows through that chain can receive install outcomes without bypassing the existing context payload.

- **Cancellation and failure analytics** — added `integrations.installation_cancelled` and `integrations.installation_failed` events, emitted from `useAddIntegration` alongside state transitions. Raw error strings are excluded from payloads.

## Tests

- `useAddIntegration.spec.tsx` — covers `installing` state on start, `complete` state on success, `cancelled` state on modal close, no double-cancel after completion, `error` state on failure, and cancel-after-failure (fail then close fires `onCancel` once).
- `modal.spec.tsx` — covers `onError` being called on pipeline failure, and `onError` being called twice when the same error message appears after a Start over retry (the dedup ref bug).
- All existing tests for `AddIntegrationButton`, `IntegrationButton`, and `AddIntegrationRow` continue to pass — all new props are optional.