### PR TITLE
fix(migrations): Ignore SET COMPRESSION in schema drift compare

### DIFF
--- a/tests/tools/test_migrations_compare.py
+++ b/tests/tools/test_migrations_compare.py
@@ -1,0 +1,28 @@
+from tools.migrations.compare import _remove_set_compression, norm
+
+_TABLE = """\
+CREATE TABLE public.sentry_pullrequest_activity_log (
+    data jsonb NOT NULL,
+    id bigint NOT NULL
+);
+"""
+
+_COMPRESSION = (
+    "ALTER TABLE ONLY public.sentry_pullrequest_activity_log "
+    "ALTER COLUMN data SET COMPRESSION lz4;\n"
+)
+
+
+def test_remove_set_compression_strips_only_compression() -> None:
+    assert _remove_set_compression(_TABLE + _COMPRESSION) == _TABLE
+
+
+def test_remove_set_compression_preserves_other_alter_table() -> None:
+    other = "ALTER TABLE ONLY public.sentry_other ADD CONSTRAINT x PRIMARY KEY (id);\n"
+    assert _remove_set_compression(other) == other
+
+
+def test_norm_ignores_compression_only_difference() -> None:
+    real = f"\\connect sentry\n{_TABLE}{_COMPRESSION}"
+    state = f"\\connect sentry\n{_TABLE}"
+    assert norm(real) == norm(state)

--- a/tools/migrations/compare.py
+++ b/tools/migrations/compare.py
@@ -19,9 +19,18 @@ DJANGO_TABLES = re.compile(
     re.M | re.DOTALL,
 )
 
+SET_COMPRESSION = re.compile(
+    r"^ALTER TABLE (?:ONLY )?[^;]* ALTER COLUMN [^;]* SET COMPRESSION [^;]*;\n?",
+    re.M,
+)
+
 
 def _remove_migrations_tables(s: str) -> str:
     return DJANGO_TABLES.sub("", s)
+
+
+def _remove_set_compression(s: str) -> str:
+    return SET_COMPRESSION.sub("", s)
 
 
 def norm(s: str) -> dict[str, str]:
@@ -33,6 +42,7 @@ def norm(s: str) -> dict[str, str]:
     create_table_parts: list[str] = []
 
     s = _remove_migrations_tables(s)
+    s = _remove_set_compression(s)
 
     for line in s.splitlines(True):
         if line.startswith(r"\connect "):


### PR DESCRIPTION
> **Bottom of a 2-PR stack.** Merge this first; the orphaned-file cleanup PR stacks on top of it.

## What's broken

CI's "migration drift" check rebuilds the DB schema two ways and compares them — a mismatch means something's wrong with your migrations.

One column (`data` on `sentry_pullrequest_activity_log`) has **lz4 compression**, set via hand-written SQL in migration `1133`. But one side of the comparison is rebuilt from Django *models*, and models have no way to express column compression — it's raw-SQL-only. So:

- Real schema: has `SET COMPRESSION lz4`
- Rebuilt-from-models schema: can't have it

They never match on that line, so the check reports permanent "drift" even though nothing is actually wrong.

## The fix

Ignore `SET COMPRESSION` lines before comparing — the check already skips other noise lines (like `django_migrations` tables) the same way. Real drift is still caught; this one fake difference stops firing.

## Why it's separate

The orphaned-file cleanup PR (stacked on top of this one) fixes an earlier step of the same check. Once that passes, the check runs further and hits *this* compression false alarm. Both fixes are needed for "migration drift" to actually go green.

## Testing

New `tests/tools/test_migrations_compare.py` (there were none): confirms `SET COMPRESSION` is stripped, unrelated `ALTER TABLE` lines are kept, and a compression-only difference no longer reports drift. `prek run` clean.

