### PR TITLE
ref(autofix): Route the remaining PR links through the shared resolver

### DIFF
--- a/static/app/components/events/autofix/pullRequests.spec.ts
+++ b/static/app/components/events/autofix/pullRequests.spec.ts
@@ -41,7 +41,12 @@ describe('getCodingAgentResultLink', () => {
       getCodingAgentResultLink(
         makeResult({pr_number: 99, pr_url: 'https://github.com/org/repo/pull/99'})
       )
-    ).toEqual({label: 'View org/repo#99', url: 'https://github.com/org/repo/pull/99'});
+    ).toEqual({
+      label: 'View org/repo#99',
+      repoName: 'org/repo',
+      prNumber: 99,
+      url: 'https://github.com/org/repo/pull/99',
+    });
   });
 
   it.each([
@@ -50,6 +55,8 @@ describe('getCodingAgentResultLink', () => {
   ])('names the repo alone for %s recorded without a number', (_case, pr_url) => {
     expect(getCodingAgentResultLink(makeResult({pr_url}))).toEqual({
       label: 'View org/repo',
+      repoName: 'org/repo',
+      prNumber: null,
       url: pr_url,
     });
   });
@@ -63,6 +70,8 @@ describe('getRepoPullRequestLink', () => {
   it('names the PR Seer opened', () => {
     expect(getRepoPullRequestLink(makeRepoPRState())).toEqual({
       label: 'View org/repo#7',
+      repoName: 'org/repo',
+      prNumber: 7,
       url: 'https://github.com/org/repo/pull/7',
     });
   });

--- a/static/app/components/events/autofix/pullRequests.ts
+++ b/static/app/components/events/autofix/pullRequests.ts
@@ -10,9 +10,14 @@ type CodingAgentResult = NonNullable<ExplorerCodingAgentState['results']>[number
 /**
  * A link to a pull request an autofix run produced, resolved from either of the two
  * shapes Seer reports one in so that every surface renders the same label.
+ *
+ * `label` is the button wording; surfaces that word the link themselves take
+ * `repoName` and `prNumber` instead.
  */
 interface AutofixResultLink {
   label: string;
+  prNumber: number | null;
+  repoName: string;
   url: string;
 }
 
@@ -29,6 +34,8 @@ export function getRepoPullRequestLink(state: RepoPRState): AutofixResultLink | 
 
   return {
     label: t('View %s#%s', state.repo_name, state.pr_number),
+    repoName: state.repo_name,
+    prNumber: state.pr_number,
     url: state.pr_url,
   };
 }
@@ -50,6 +57,8 @@ export function getCodingAgentResultLink(
     label: defined(result.pr_number)
       ? t('View %s#%s', result.repo_full_name, result.pr_number)
       : t('View %s', result.repo_full_name),
+    repoName: result.repo_full_name,
+    prNumber: result.pr_number,
     url: result.pr_url,
   };
 }

--- a/static/app/components/events/autofix/v3/autofixPreviews.tsx
+++ b/static/app/components/events/autofix/v3/autofixPreviews.tsx
@@ -8,6 +8,7 @@ import {ExternalLink} from '@sentry/scraps/link';
 import {Markdown} from '@sentry/scraps/markdown';
 import {Text} from '@sentry/scraps/text';
 
+import {getRepoPullRequestLink} from 'sentry/components/events/autofix/pullRequests';
 import {
   CodingAgentStatus,
   getCodingAgentName,
@@ -159,14 +160,11 @@ export function PullRequestsPreview({section}: ArtifactPreviewProps) {
           return <Placeholder key={pullRequest.repo_name} height="1.5rem" />;
         }
 
-        if (
-          pullRequest.pr_creation_status === 'completed' &&
-          pullRequest.pr_url &&
-          pullRequest.pr_number
-        ) {
+        const link = getRepoPullRequestLink(pullRequest);
+        if (link) {
           return (
-            <ExternalLink key={pullRequest.repo_name} href={pullRequest.pr_url}>
-              {pullRequest.repo_name}#{pullRequest.pr_number}
+            <ExternalLink key={link.repoName} href={link.url}>
+              {link.repoName}#{link.prNumber}
             </ExternalLink>
           );
         }

--- a/static/app/components/events/autofix/v3/utils.spec.ts
+++ b/static/app/components/events/autofix/v3/utils.spec.ts
@@ -237,6 +237,22 @@ describe('artifactToMarkdown', () => {
       );
     });
 
+    it('filters out a PR whose creation has not finished', () => {
+      // 'creating' carries the number of an already-open PR when it is an update.
+      const prs = [
+        makeRepoPRState({pr_creation_status: 'creating'}),
+        makeRepoPRState({pr_creation_status: 'error'}),
+        makeRepoPRState(), // valid
+      ];
+      expect(artifactToMarkdown(prs)).toBe(
+        [
+          '# Pull Requests',
+          '',
+          '[getsentry/sentry#42](https://github.com/getsentry/sentry/pull/42)',
+        ].join('\n')
+      );
+    });
+
     it('returns null for empty array', () => {
       const prs: RepoPRState[] = [];
       expect(artifactToMarkdown(prs)).toBeNull();

--- a/static/app/components/events/autofix/v3/utils.ts
+++ b/static/app/components/events/autofix/v3/utils.ts
@@ -1,3 +1,4 @@
+import {getRepoPullRequestLink} from 'sentry/components/events/autofix/pullRequests';
 import {getCodingAgentName} from 'sentry/components/events/autofix/types';
 import {
   isCodeChangesArtifact,
@@ -150,13 +151,9 @@ function repoPRStatesToMarkdown(
 
   parts.push(
     ...artifact
-      .map(pullRequest => {
-        if (!pullRequest.pr_url || !pullRequest.pr_number) {
-          return null;
-        }
-        return `[${pullRequest.repo_name}#${pullRequest.pr_number}](${pullRequest.pr_url})`;
-      })
+      .map(getRepoPullRequestLink)
       .filter(defined)
+      .map(link => `[${link.repoName}#${link.prNumber}](${link.url})`)
   );
 
   return parts.join('\n');


### PR DESCRIPTION
Standardize some more places where we were determining whether there was a linkable PR into `getRepoPullRequestLink`.
