### PR TITLE
fix(explore): segment.name or segment_name

### DIFF
--- a/src/sentry/search/eap/spans/attributes.py
+++ b/src/sentry/search/eap/spans/attributes.py
@@ -4,6 +4,7 @@ from typing import Any, Literal
 
 from sentry_conventions.attributes import (
     ATTRIBUTE_METADATA,
+    ATTRIBUTE_NAMES,
     AttributeMetadata,
     DeprecationStatus,
 )
@@ -797,7 +798,7 @@ SPANS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS: dict[
         # to return the new aliases, remove these temp mappings.
         "sentry.description": "sentry.normalized_description",
         "sentry.span_id": "id",
-        "sentry.segment_name": "transaction",
+        ATTRIBUTE_NAMES.SENTRY_SEGMENT_NAME: "transaction",
     },
     "boolean": {
         definition.internal_name: definition.public_alias


### PR DESCRIPTION
### Summary
This uses the sentry convention to match the segment name properly as we were previously mapping the wrong attr key to 'transaction' (we aren't surfacing 'segment' in the UI at this time).

