### PR TITLE
ref(spans): Use selective issue detection enablement option

### DIFF
--- a/src/sentry/issue_detection/performance_detection.py
+++ b/src/sentry/issue_detection/performance_detection.py
@@ -688,6 +688,10 @@ DETECTOR_CLASSES: list[type[PerformanceDetector]] = [
     QueryInjectionDetector,
 ]
 
+DETECTOR_TYPE_TO_CLASS_MAP = {
+    detector_class.type.value: detector_class for detector_class in DETECTOR_CLASSES
+}
+
 
 def _detect_performance_problems(
     data: dict[str, Any],

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -326,8 +326,11 @@ def _create_models(
 def _detect_performance_problems(
     segment_span: CompatibleSpan, spans: list[CompatibleSpan], project: Project
 ) -> None:
-    # Killswitch for all segment-based issue detection
-    if not options.get("spans.process-segments.detect-performance-problems.enable"):
+    enabled_legacy_detector_types = options.get(
+        "spans.process-segments.detect-performance-problems.detectors-enabled"
+    )
+
+    if not enabled_legacy_detector_types:
         return
 
     try:

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -18,6 +18,7 @@ from sentry.dynamic_sampling.rules.helpers.latest_releases import record_latest_
 from sentry.event_manager import INSIGHT_MODULE_TO_PROJECT_FLAG_NAME
 from sentry.insights import FilterSpan
 from sentry.insights import modules as insights_modules
+from sentry.issue_detection import performance_detection
 from sentry.issue_detection.base import DetectorType
 from sentry.issue_detection.detectors.span_first.run_detectors import (
     SPAN_FIRST_DETECTORS_BY_GROUPTYPE,
@@ -29,6 +30,7 @@ from sentry.issue_detection.detectors.span_first.span_first_utils import (
     SpanFirstDetectorsRolloutController,
 )
 from sentry.issue_detection.performance_detection import (
+    DETECTOR_TYPE_TO_CLASS_MAP,
     detect_performance_problems,
     get_detection_settings,
 )
@@ -367,8 +369,30 @@ def _run_legacy_detectors(
     # Create a fake transaction event out of the segment data, to match what the legacy detectors
     # are expecting
     event_data = build_shim_event_data(segment_span, segment)
+
+    # Resolve the detector type strings into actual detector classes, and warn if we find anything
+    # weird
+    if detector_types == ["*"]:
+        detector_classes = performance_detection.DETECTOR_CLASSES
+    else:
+        detector_classes = [
+            DETECTOR_TYPE_TO_CLASS_MAP[detector_type]
+            for detector_type in detector_types
+            # They should all be in there, but in case we typo an option value, best to be safe
+            if detector_type in DETECTOR_TYPE_TO_CLASS_MAP
+        ]
+        if len(detector_types) > len(detector_classes):
+            logger.warning(
+                "issue_detection.span_processor.invalid_enablement_option",
+                extra={"option_value": detector_types},
+            )
+
     detected_problems = detect_performance_problems(
-        event_data, project, detection_settings=detection_settings, standalone=True
+        event_data,
+        project,
+        detector_classes=detector_classes,
+        detection_settings=detection_settings,
+        standalone=True,
     )
 
     # This flag is set in Relay, and here enables producing occurrences from the legacy detector

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -338,7 +338,7 @@ def _detect_performance_problems(
         # segment span, produce occurrences from the results
         detection_settings = get_detection_settings(project)
         legacy_detected_problems = _run_legacy_detectors(
-            segment_span, spans, project, detection_settings
+            segment_span, spans, project, enabled_legacy_detector_types, detection_settings
         )
     except Exception:
         logger.exception("segment_consumer_legacy_issue_detectors.error")
@@ -357,6 +357,7 @@ def _run_legacy_detectors(
     segment_span: CompatibleSpan,
     segment: list[CompatibleSpan],
     project: Project,
+    detector_types: list[str],
     detection_settings: dict[DetectorType, dict[str, Any]],
 ) -> list[PerformanceProblem]:
     """

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -363,8 +363,9 @@ def _run_legacy_detectors(
     detection_settings: dict[DetectorType, dict[str, Any]],
 ) -> list[PerformanceProblem]:
     """
-    Run legacy issue detectors on segment data by first creating a fake transaction event. If the
-    `_performance_issues_spans` flag is set, also create occurrences from the results.
+    Run legacy issue detectors corresponding to the given detector types on segment data by first
+    creating a fake transaction event. If the `_performance_issues_spans` flag is set, also create
+    occurrences from the results.
     """
     # Create a fake transaction event out of the segment data, to match what the legacy detectors
     # are expecting

--- a/tests/sentry/issue_detection/test_performance_detection.py
+++ b/tests/sentry/issue_detection/test_performance_detection.py
@@ -613,6 +613,14 @@ class PerformanceDetectionTest(TestCase):
             # All of the detectors ran, even though the slow DB detector errored out
             assert run_detector_spy.call_count == num_enabled_detectors
 
+    def test_each_detector_has_unique_detector_type(self) -> None:
+        assert all(type(detector_class.type) is DetectorType for detector_class in DETECTOR_CLASSES)
+        # Use a set so if there are any overlaps, we'll dedupe them
+        detector_types_from_classes = {
+            detector_class.type.value for detector_class in DETECTOR_CLASSES
+        }
+        assert len(detector_types_from_classes) == len(DetectorType)
+
 
 @pytest.mark.parametrize(
     "spans, duration",

--- a/tests/sentry/spans/consumers/process_segments/test_message.py
+++ b/tests/sentry/spans/consumers/process_segments/test_message.py
@@ -6,12 +6,14 @@ from unittest import mock
 import pytest
 from django.utils import timezone
 
+from sentry.issue_detection.detectors.n_plus_one_db_span_detector import NPlusOneDBSpanDetector
 from sentry.issue_detection.detectors.span_first.run_detectors import run_span_first_detectors
 from sentry.issue_detection.detectors.span_first.span_first_utils import (
     SPAN_FIRST_DETECTORS_ENABLEMENT_OPTION,
     SpanFirstDetectorsRolloutController,
 )
 from sentry.issue_detection.performance_detection import (
+    DETECTOR_CLASSES,
     detect_performance_problems,
     get_detection_settings,
 )
@@ -32,6 +34,8 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.issue_detection.experiments import exclude_experimental_detectors
 from tests.sentry.spans.consumers.process import build_mock_span
+
+DETECTORS_ENABLED_OPTION = "spans.process-segments.detect-performance-problems.detectors-enabled"
 
 
 @exclude_experimental_detectors
@@ -216,7 +220,7 @@ class TestSpansTask(TestCase):
 
         assert not Release.objects.filter(organization_id=self.organization.id).exists()
 
-    @override_options({"spans.process-segments.detect-performance-problems.enable": True})
+    @override_options({DETECTORS_ENABLED_OPTION: ["*"]})
     @mock.patch("sentry.issues.ingest.send_issue_occurrence_to_eventstream")
     def test_n_plus_one_issue_detection(self, mock_eventstream: mock.MagicMock) -> None:
         spans = self.generate_n_plus_one_spans()
@@ -233,7 +237,7 @@ class TestSpansTask(TestCase):
         ]
         assert performance_problem.type == PerformanceNPlusOneGroupType
 
-    @override_options({"spans.process-segments.detect-performance-problems.enable": True})
+    @override_options({DETECTORS_ENABLED_OPTION: ["*"]})
     @mock.patch("sentry.issues.ingest.send_issue_occurrence_to_eventstream")
     @pytest.mark.xfail(reason="batches without segment spans are not supported yet")
     def test_n_plus_one_issue_detection_without_segment_span(
@@ -293,10 +297,7 @@ class TestSpansTask(TestCase):
 
         with (
             override_options(
-                {
-                    "spans.process-segments.detect-performance-problems.enable": True,
-                    SPAN_FIRST_DETECTORS_ENABLEMENT_OPTION: True,
-                }
+                {DETECTORS_ENABLED_OPTION: ["*"], SPAN_FIRST_DETECTORS_ENABLEMENT_OPTION: True}
             ),
             mock.patch.object(
                 SpanFirstDetectorsRolloutController, "should_check_experiment", return_value=True
@@ -324,6 +325,86 @@ class TestSpansTask(TestCase):
 
             assert legacy_settings is detection_settings
             assert span_first_settings is detection_settings
+
+    def test_no_detectors_enabled(self) -> None:
+        """
+        An empty option value is the killswitch for all segment-based issue detection, so nothing
+        downstream of it should run -- not even the settings fetch.
+        """
+        spans = self.generate_n_plus_one_spans()
+
+        with (
+            override_options({DETECTORS_ENABLED_OPTION: []}),
+            mock.patch(
+                "sentry.spans.consumers.process_segments.message.get_detection_settings",
+            ) as get_detection_settings_mock,
+            mock.patch(
+                "sentry.spans.consumers.process_segments.message.detect_performance_problems",
+            ) as legacy_detectors_mock,
+        ):
+            process_segment(spans)
+
+            get_detection_settings_mock.assert_not_called()
+            legacy_detectors_mock.assert_not_called()
+
+    def test_blanket_detector_enablement(self) -> None:
+        spans = self.generate_n_plus_one_spans()
+
+        with (
+            override_options({DETECTORS_ENABLED_OPTION: ["*"]}),
+            mock.patch(
+                "sentry.spans.consumers.process_segments.message.detect_performance_problems",
+                wraps=detect_performance_problems,
+            ) as legacy_detectors_spy,
+        ):
+            process_segment(spans)
+
+            assert legacy_detectors_spy.call_args.kwargs["detector_classes"] == DETECTOR_CLASSES
+
+    def test_selective_detector_enablement(self) -> None:
+        spans = self.generate_n_plus_one_spans()
+
+        with (
+            override_options({DETECTORS_ENABLED_OPTION: ["n_plus_one_db"]}),
+            mock.patch(
+                "sentry.spans.consumers.process_segments.message.detect_performance_problems",
+                wraps=detect_performance_problems,
+            ) as legacy_detectors_spy,
+        ):
+            process_segment(spans)
+
+            assert legacy_detectors_spy.call_args.kwargs["detector_classes"] == [
+                NPlusOneDBSpanDetector
+            ]
+
+    def test_invalid_detector_types_ignored_in_enablement_option(self) -> None:
+        """
+        A detector type we don't recognize is almost certainly a typo in the option value. Skipping
+        it lets the valid entries keep working, but it needs to be noisy about it, because
+        otherwise a typo is indistinguishable from having deliberately switched that detector off.
+        """
+        spans = self.generate_n_plus_one_spans()
+
+        with (
+            override_options({DETECTORS_ENABLED_OPTION: ["n_plus_one_db", "dogs_are_great"]}),
+            mock.patch(
+                "sentry.spans.consumers.process_segments.message.detect_performance_problems",
+                wraps=detect_performance_problems,
+            ) as legacy_detectors_spy,
+            mock.patch(
+                "sentry.spans.consumers.process_segments.message.logger.warning"
+            ) as logger_warning_mock,
+        ):
+            process_segment(spans)
+
+            # The bogus entry is dropped, but the valid one still runs
+            assert legacy_detectors_spy.call_args.kwargs["detector_classes"] == [
+                NPlusOneDBSpanDetector
+            ]
+            logger_warning_mock.assert_called_once_with(
+                "issue_detection.span_processor.invalid_enablement_option",
+                extra={"option_value": ["n_plus_one_db", "dogs_are_great"]},
+            )
 
     @mock.patch("sentry.spans.consumers.process_segments.message.track_outcome")
     @pytest.mark.skip("temporarily disabled")


### PR DESCRIPTION
This is a follow-up to https://github.com/getsentry/sentry/pull/121108, which added a new option, `spans.process-segments.detect-performance-problems.detectors-enabled`, to allow us to selectively enable existing issue detectors in the segment-processing pipeline. In this PR, we switch to using the new option. Deleting the old option (`spans.process-segments.detect-performance-problems.enable`) has been deferred to a future PR, because it's still referenced in the options automator repo. Once this is merged, we can remove that reference, and then we'll be able to get rid of the old option all together.