### PR TITLE
feat(issues): show linked issues in trace preview

### DIFF
--- a/static/app/components/events/interfaces/performance/eventTraceView.spec.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.spec.tsx
@@ -5,7 +5,6 @@ import {initializeData} from 'sentry-test/performance/initializePerformanceData'
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {EntryType} from 'sentry/types/event';
-import type {TraceEventResponse} from 'sentry/views/issueDetails/traceTimeline/useTraceTimelineEvents';
 import {
   makeTraceError,
   makeTransaction,
@@ -24,6 +23,8 @@ describe('EventTraceView', () => {
   });
   const group = GroupFixture();
   const event = EventFixture({
+    groupID: group.id,
+    projectID: group.project.id,
     contexts: {
       trace: {
         trace_id: traceId,
@@ -31,15 +32,19 @@ describe('EventTraceView', () => {
     },
     eventID: 'issue-5',
   });
-  const issuePlatformBody: TraceEventResponse = {
-    data: [],
-    meta: {fields: {}, units: {}},
-  };
-
   beforeEach(() => {
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events/`,
-      body: issuePlatformBody,
+      url: `/organizations/${organization.slug}/issues/`,
+      body: [],
+      headers: {'X-Hits': '0'},
+      match: [
+        MockApiClient.matchQuery({
+          limit: '20',
+          project: '-1',
+          query: `trace:${traceId} !issue.id:${group.id}`,
+          statsPeriod: '90d',
+        }),
+      ],
     });
   });
 

--- a/static/app/components/events/interfaces/performance/eventTraceView.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useMemo} from 'react';
+import {useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import {LinkButton} from '@sentry/scraps/button';
@@ -18,12 +18,9 @@ import {type Event} from 'sentry/types/event';
 import {type Group} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
-import {useRouteAnalyticsParams} from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
 import {useLocation} from 'sentry/utils/useLocation';
 import {SectionKey} from 'sentry/views/issueDetails/context';
 import {FoldSection} from 'sentry/views/issueDetails/foldSection';
-import {TraceIssueEvent} from 'sentry/views/issueDetails/traceTimeline/traceIssue';
-import {useTraceTimelineEvents} from 'sentry/views/issueDetails/traceTimeline/useTraceTimelineEvents';
 import {IssuesTraceWaterfall} from 'sentry/views/performance/newTraceDetails/issuesTraceWaterfall';
 import {getTraceLinkForIssue} from 'sentry/views/performance/newTraceDetails/issuesTraceWaterfallOverlay';
 import {useIssuesTraceTree} from 'sentry/views/performance/newTraceDetails/traceApi/useIssuesTraceTree';
@@ -38,6 +35,8 @@ import {TraceStateProvider} from 'sentry/views/performance/newTraceDetails/trace
 import {useTraceEventView} from 'sentry/views/performance/newTraceDetails/useTraceEventView';
 import {useTraceQueryParams} from 'sentry/views/performance/newTraceDetails/useTraceQueryParams';
 import {useTraceStateAnalytics} from 'sentry/views/performance/newTraceDetails/useTraceStateAnalytics';
+
+import {TraceLinkedIssues} from './traceLinkedIssues';
 
 const DEFAULT_ISSUE_DETAILS_TRACE_VIEW_PREFERENCES: TracePreferencesState = {
   drawer: {
@@ -121,22 +120,6 @@ function EventTraceViewInner({event, organization, traceId}: EventTraceViewInner
   );
 }
 
-function OneOtherIssueEvent({event}: {event: Event}) {
-  const {isLoading, oneOtherIssueEvent} = useTraceTimelineEvents({event});
-  useRouteAnalyticsParams(oneOtherIssueEvent ? {has_related_trace_issue: true} : {});
-
-  if (isLoading || !oneOtherIssueEvent) {
-    return null;
-  }
-
-  return (
-    <Fragment>
-      <span>{t('One other issue appears in the same trace.')}</span>
-      <TraceIssueEvent event={oneOtherIssueEvent} />
-    </Fragment>
-  );
-}
-
 const IssuesTraceContainer = styled('div')`
   position: relative;
 `;
@@ -200,7 +183,7 @@ export function EventTraceView({group, event, organization}: EventTraceViewProps
         </Grid>
       }
     >
-      <OneOtherIssueEvent event={event} />
+      <TraceLinkedIssues event={event} />
       <LazyRender observerOptions={ISSUE_DETAILS_LAZY_RENDER_OBSERVER_OPTIONS}>
         {hasTracePreviewFeature && (
           <TraceStateProvider

--- a/static/app/components/events/interfaces/performance/traceLinkedIssues.spec.tsx
+++ b/static/app/components/events/interfaces/performance/traceLinkedIssues.spec.tsx
@@ -46,6 +46,7 @@ describe('TraceLinkedIssues', () => {
       headers: {'X-Hits': '22'},
       match: [
         MockApiClient.matchQuery({
+          collapse: 'filtered',
           limit: '20',
           project: '-1',
           query: `trace:${traceId} !issue.id:${currentIssueId}`,

--- a/static/app/components/events/interfaces/performance/traceLinkedIssues.spec.tsx
+++ b/static/app/components/events/interfaces/performance/traceLinkedIssues.spec.tsx
@@ -1,0 +1,71 @@
+import {EventFixture} from 'sentry-fixture/event';
+import {GroupFixture} from 'sentry-fixture/group';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {TraceLinkedIssues} from './traceLinkedIssues';
+
+describe('TraceLinkedIssues', () => {
+  const organization = OrganizationFixture();
+  const project = ProjectFixture();
+  const traceId = 'trace-id';
+  const currentIssueId = '999';
+  const event = EventFixture({
+    groupID: currentIssueId,
+    projectID: project.id,
+    contexts: {
+      trace: {
+        trace_id: traceId,
+      },
+    },
+  });
+
+  beforeEach(() => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/users/`,
+      body: [],
+    });
+  });
+
+  it('fetches and renders trace-linked issues with one issue search', async () => {
+    const linkedIssueIds = Array.from({length: 22}, (_, index) => String(index + 1));
+    const groups = linkedIssueIds.map(issueId =>
+      GroupFixture({
+        id: issueId,
+        shortId: `EXAMPLE-${issueId}`,
+        title: `Issue ${issueId}`,
+        project,
+      })
+    );
+
+    const issuesMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/`,
+      body: groups.slice(0, 20),
+      headers: {'X-Hits': '22'},
+      match: [
+        MockApiClient.matchQuery({
+          limit: '20',
+          project: '-1',
+          query: `trace:${traceId} !issue.id:${currentIssueId}`,
+          statsPeriod: '90d',
+        }),
+      ],
+    });
+
+    render(<TraceLinkedIssues event={event} />, {organization});
+
+    expect(
+      await screen.findByText('22 other issues appear in this trace.')
+    ).toBeInTheDocument();
+    expect(await screen.findByText('EXAMPLE-20')).toBeInTheDocument();
+    expect(issuesMock).toHaveBeenCalledTimes(1);
+
+    const openInIssues = screen.getByRole('link', {name: 'Open in Issues'});
+    expect(openInIssues).toHaveAttribute(
+      'href',
+      `/organizations/${organization.slug}/issues/?project=-1&query=${encodeURIComponent(`trace:${traceId}`)}&statsPeriod=90d`
+    );
+  });
+});

--- a/static/app/components/events/interfaces/performance/traceLinkedIssues.tsx
+++ b/static/app/components/events/interfaces/performance/traceLinkedIssues.tsx
@@ -1,0 +1,88 @@
+import styled from '@emotion/styled';
+
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Link} from '@sentry/scraps/link';
+import {Text} from '@sentry/scraps/text';
+
+import {ClippedBox} from 'sentry/components/clippedBox';
+import {GroupList} from 'sentry/components/issues/groupList';
+import {t, tn} from 'sentry/locale';
+import type {Event} from 'sentry/types/event';
+import {useRouteAnalyticsParams} from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+import {
+  TRACE_ISSUES_STALE_TIME,
+  TRACE_ISSUES_STATS_PERIOD,
+  useTraceLinkedIssues,
+} from './useTraceLinkedIssues';
+
+export function TraceLinkedIssues({event}: {event: Event}) {
+  const organization = useOrganization();
+  const {groups, isError, isPending, query, queryParams, totalHits} =
+    useTraceLinkedIssues({event});
+
+  useRouteAnalyticsParams(groups.length > 0 ? {has_related_trace_issue: true} : {});
+
+  if (isPending || isError || groups.length === 0 || !query) {
+    return null;
+  }
+
+  const traceId = event.contexts.trace?.trace_id;
+  const issueTable = (
+    <GroupList
+      query={query}
+      queryParams={queryParams}
+      source="issue-details-trace-preview"
+      canSelectGroups={false}
+      withChart
+      withColumns={['event', 'firstSeen', 'lastSeen']}
+      withPagination={false}
+      numPlaceholderRows={3}
+      staleTime={TRACE_ISSUES_STALE_TIME}
+    />
+  );
+
+  return (
+    <Stack gap="md">
+      <Flex align="center" gap="xs" wrap="wrap">
+        <Text>
+          {tn(
+            '%s other issue appears in this trace.',
+            '%s other issues appear in this trace.',
+            totalHits
+          )}
+        </Text>
+        <Link
+          to={{
+            pathname: `/organizations/${organization.slug}/issues/`,
+            query: {
+              project: '-1',
+              query: `trace:${traceId}`,
+              statsPeriod: TRACE_ISSUES_STATS_PERIOD,
+            },
+          }}
+        >
+          {t('Open in Issues')}
+        </Link>
+      </Flex>
+      {groups.length > 3 ? (
+        <ClippedIssueTable
+          defaultClipped
+          collapsible
+          clipHeight={300}
+          btnText={t('View more')}
+          collapseBtnText={t('View fewer')}
+        >
+          {issueTable}
+        </ClippedIssueTable>
+      ) : (
+        issueTable
+      )}
+    </Stack>
+  );
+}
+
+const ClippedIssueTable = styled(ClippedBox)`
+  padding: 0;
+`;

--- a/static/app/components/events/interfaces/performance/traceLinkedIssues.tsx
+++ b/static/app/components/events/interfaces/performance/traceLinkedIssues.tsx
@@ -36,7 +36,7 @@ export function TraceLinkedIssues({event}: {event: Event}) {
       source="issue-details-trace-preview"
       canSelectGroups={false}
       withChart
-      withColumns={['firstSeen', 'lastSeen']}
+      withColumns={['event', 'firstSeen', 'lastSeen']}
       withPagination={false}
       numPlaceholderRows={3}
       staleTime={TRACE_ISSUES_STALE_TIME}

--- a/static/app/components/events/interfaces/performance/traceLinkedIssues.tsx
+++ b/static/app/components/events/interfaces/performance/traceLinkedIssues.tsx
@@ -36,7 +36,7 @@ export function TraceLinkedIssues({event}: {event: Event}) {
       source="issue-details-trace-preview"
       canSelectGroups={false}
       withChart
-      withColumns={['event', 'firstSeen', 'lastSeen']}
+      withColumns={['firstSeen', 'lastSeen']}
       withPagination={false}
       numPlaceholderRows={3}
       staleTime={TRACE_ISSUES_STALE_TIME}

--- a/static/app/components/events/interfaces/performance/useTraceLinkedIssues.tsx
+++ b/static/app/components/events/interfaces/performance/useTraceLinkedIssues.tsx
@@ -17,6 +17,7 @@ export function useTraceLinkedIssues({event}: {event: Event}) {
       ? `trace:${traceId} !issue.id:${currentIssueId}`
       : undefined;
   const queryParams = {
+    collapse: 'filtered',
     limit: '20',
     project: '-1',
     query,

--- a/static/app/components/events/interfaces/performance/useTraceLinkedIssues.tsx
+++ b/static/app/components/events/interfaces/performance/useTraceLinkedIssues.tsx
@@ -1,0 +1,43 @@
+import {skipToken, useQuery} from '@tanstack/react-query';
+
+import type {Event} from 'sentry/types/event';
+import type {Group} from 'sentry/types/group';
+import {apiOptions, selectJsonWithHeaders} from 'sentry/utils/api/apiOptions';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+export const TRACE_ISSUES_STATS_PERIOD = '90d';
+export const TRACE_ISSUES_STALE_TIME = 60_000;
+
+export function useTraceLinkedIssues({event}: {event: Event}) {
+  const organization = useOrganization();
+  const traceId = event.contexts.trace?.trace_id;
+  const currentIssueId = event.groupID;
+  const query =
+    traceId && currentIssueId
+      ? `trace:${traceId} !issue.id:${currentIssueId}`
+      : undefined;
+  const queryParams = {
+    limit: '20',
+    project: '-1',
+    query,
+    statsPeriod: TRACE_ISSUES_STATS_PERIOD,
+  };
+  const {data, isError, isPending} = useQuery({
+    ...apiOptions.as<Group[]>()('/organizations/$organizationIdOrSlug/issues/', {
+      path: query ? {organizationIdOrSlug: organization.slug} : skipToken,
+      query: queryParams,
+      staleTime: TRACE_ISSUES_STALE_TIME,
+    }),
+    select: selectJsonWithHeaders,
+  });
+  const groups = data?.json ?? [];
+
+  return {
+    groups,
+    isError,
+    isPending,
+    query,
+    queryParams,
+    totalHits: data?.headers['X-Hits'] ?? groups.length,
+  };
+}

--- a/static/app/components/issues/groupList.tsx
+++ b/static/app/components/issues/groupList.tsx
@@ -78,6 +78,7 @@ type Props = {
   renderErrorMessage?: (props: {detail: string}, retry: () => void) => React.ReactNode;
   // where the group list is rendered
   source?: string;
+  staleTime?: number;
   useFilteredStats?: boolean;
   useTintRow?: boolean;
   withChart?: boolean;
@@ -113,6 +114,7 @@ export function GroupList({
   customStatsPeriod,
   queryFilterDescription,
   source,
+  staleTime = 0,
   query,
   numPlaceholderRows,
   withColumns = DEFAULT_COLUMNS,
@@ -201,12 +203,12 @@ export function GroupList({
       ? apiOptions.as<Group[]>()(endpoint.path, {
           path: {organizationIdOrSlug: organization.slug},
           query: computedQueryParams,
-          staleTime: 0,
+          staleTime,
         })
       : apiOptions.as<Group[]>()(endpoint.path, {
           path: {organizationIdOrSlug: organization.slug, version: endpoint.version},
           query: computedQueryParams,
-          staleTime: 0,
+          staleTime,
         });
   const {
     data,


### PR DESCRIPTION
replaces the one-off related trace issue card with standard issue stream rows. it shows up to 20 other issues from the same trace with 90d stats, shows the expand button at > 3 rows, and links out to the full trace search in Issues.

the summary and table share one cached issue search so this does not double-fetch the Issues endpoint.

before

<img width="1113" height="313" alt="image" src="https://github.com/user-attachments/assets/6e3a3055-4182-4e1a-8fe5-3d3a29ac1b07" />

after

<img width="1113" height="361" alt="image" src="https://github.com/user-attachments/assets/031aa2bf-b5ab-4f09-a22d-316ce9b92842" />

after (multiple issues)

<img width="1097" height="470" alt="image" src="https://github.com/user-attachments/assets/b3300808-3e8c-44d2-a020-a50e1e7e3cea" />

fixes https://linear.app/getsentry/issue/ENG-7944