### PR TITLE
ref: Remove unused project plugin feature

### DIFF
--- a/src/sentry/features/base.py
+++ b/src/sentry/features/base.py
@@ -7,7 +7,6 @@ __all__ = [
     "FeatureHandlerStrategy",
     "OrganizationFeature",
     "ProjectFeature",
-    "ProjectPluginFeature",
     "SystemFeature",
 ]
 
@@ -59,16 +58,6 @@ class ProjectFeature(Feature):
     def __init__(self, name: str, project: Project) -> None:
         super().__init__(name)
         self.project = project
-
-    def get_subject(self) -> Organization:
-        return self.project.organization
-
-
-class ProjectPluginFeature(Feature):
-    def __init__(self, name: str, project: Project, plugin: Any) -> None:
-        super().__init__(name)
-        self.project = project
-        self.plugin = plugin
 
     def get_subject(self) -> Organization:
         return self.project.organization

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -2,7 +2,6 @@ from .base import (
     FeatureHandlerStrategy,
     OrganizationFeature,
     ProjectFeature,
-    ProjectPluginFeature,
     SystemFeature,
 )
 from .manager import FeatureManager
@@ -504,8 +503,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Starfish: extract metrics from the spans
     manager.add("projects:span-metrics-extraction", ProjectFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     manager.add("projects:span-metrics-extraction-addons", ProjectFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
-    # Project plugin features
-    manager.add("projects:plugins", ProjectPluginFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=True)
     # Enables experimental span attachment processing in Relay.
     manager.add("projects:span-v2-attachment-processing", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enables experimental trace attachment processing in Relay.


### PR DESCRIPTION
This feature flag was unused, deleted the getsentry handler in https://github.com/getsentry/getsentry/pull/21363