### PR TITLE
feat(issues): Add copy to clipboard button for http requests

### DIFF
--- a/static/app/components/events/interfaces/request/index.tsx
+++ b/static/app/components/events/interfaces/request/index.tsx
@@ -7,6 +7,7 @@ import {ExternalLink} from '@sentry/scraps/link';
 import {SegmentedControl} from '@sentry/scraps/segmentedControl';
 import {Text} from '@sentry/scraps/text';
 
+import {CopyAsDropdown} from 'sentry/components/copyAsDropdown';
 import {ErrorBoundary} from 'sentry/components/errorBoundary';
 import {KeyValueList} from 'sentry/components/events/interfaces/keyValueList';
 import {GraphQlRequestBody} from 'sentry/components/events/interfaces/request/graphQlRequestBody';
@@ -24,6 +25,7 @@ import type {EntryRequest, Event} from 'sentry/types/event';
 import {EntryType} from 'sentry/types/event';
 import {defined} from 'sentry/utils/defined';
 import {isValidUrl} from 'sentry/utils/string/isValidUrl';
+import {copyToClipboard} from 'sentry/utils/useCopyToClipboard';
 import {SectionKey} from 'sentry/views/issueDetails/context';
 import {FoldSection} from 'sentry/views/issueDetails/foldSection';
 
@@ -146,21 +148,46 @@ export function Request({data, event}: RequestProps) {
     parsedUrl.href = fullUrl;
   }
 
-  let actions: React.ReactNode = null;
+  const canGenerateCurlCommand = !isPartial && fullUrl;
 
-  if (!isPartial && fullUrl) {
-    actions = (
-      <SegmentedControl aria-label={t('View')} size="xs" value={view} onChange={setView}>
-        <SegmentedControl.Item key="formatted">
-          {/* Translators: this means "formatted" rendering (fancy tables) */}
-          {t('Formatted')}
-        </SegmentedControl.Item>
-        <SegmentedControl.Item key="curl" textValue="curl">
-          <Text monospace>curl</Text>
-        </SegmentedControl.Item>
-      </SegmentedControl>
-    );
-  }
+  const actions = (
+    <Flex gap="sm" align="center">
+      {canGenerateCurlCommand && (
+        <SegmentedControl
+          aria-label={t('View')}
+          size="xs"
+          value={view}
+          onChange={setView}
+        >
+          <SegmentedControl.Item key="formatted">
+            {/* Translators: this means "formatted" rendering (fancy tables) */}
+            {t('Formatted')}
+          </SegmentedControl.Item>
+          <SegmentedControl.Item key="curl" textValue="curl">
+            <Text monospace>curl</Text>
+          </SegmentedControl.Item>
+        </SegmentedControl>
+      )}
+
+      <CopyAsDropdown
+        size="xs"
+        items={[
+          {
+            key: 'fullUrl',
+            label: t('Full URL'),
+            onAction: () => copyToClipboard(fullUrl ?? ''),
+            disabled: !fullUrl,
+          },
+          {
+            key: 'path',
+            label: t('Path'),
+            onAction: () => copyToClipboard(parsedUrl?.pathname ?? ''),
+            disabled: !parsedUrl,
+          },
+        ]}
+      />
+    </Flex>
+  );
 
   const title = (
     <TruncatedPathLink method={data.method} url={parsedUrl} fullUrl={fullUrl} />

--- a/static/app/components/events/interfaces/request/index.tsx
+++ b/static/app/components/events/interfaces/request/index.tsx
@@ -148,46 +148,56 @@ export function Request({data, event}: RequestProps) {
     parsedUrl.href = fullUrl;
   }
 
+  let actions: React.ReactNode | null = null;
+
   const canGenerateCurlCommand = !isPartial && fullUrl;
 
-  const actions = (
-    <Flex gap="sm" align="center">
-      {canGenerateCurlCommand && (
-        <SegmentedControl
-          aria-label={t('View')}
-          size="xs"
-          value={view}
-          onChange={setView}
-        >
-          <SegmentedControl.Item key="formatted">
-            {/* Translators: this means "formatted" rendering (fancy tables) */}
-            {t('Formatted')}
-          </SegmentedControl.Item>
-          <SegmentedControl.Item key="curl" textValue="curl">
-            <Text monospace>curl</Text>
-          </SegmentedControl.Item>
-        </SegmentedControl>
-      )}
+  const shouldRenderCopyAsDropdown = fullUrl || parsedUrl?.pathname;
 
-      <CopyAsDropdown
-        size="xs"
-        items={[
-          {
-            key: 'fullUrl',
-            label: t('Full URL'),
-            onAction: () => copyToClipboard(fullUrl ?? ''),
-            disabled: !fullUrl,
-          },
-          {
-            key: 'path',
-            label: t('Path'),
-            onAction: () => copyToClipboard(parsedUrl?.pathname ?? ''),
-            disabled: !parsedUrl,
-          },
-        ]}
-      />
-    </Flex>
-  );
+  const shouldRenderActions = canGenerateCurlCommand || shouldRenderCopyAsDropdown;
+
+  if (shouldRenderActions) {
+    actions = (
+      <Flex gap="sm" align="center">
+        {canGenerateCurlCommand && (
+          <SegmentedControl
+            aria-label={t('View')}
+            size="xs"
+            value={view}
+            onChange={setView}
+          >
+            <SegmentedControl.Item key="formatted">
+              {/* Translators: this means "formatted" rendering (fancy tables) */}
+              {t('Formatted')}
+            </SegmentedControl.Item>
+            <SegmentedControl.Item key="curl" textValue="curl">
+              <Text monospace>curl</Text>
+            </SegmentedControl.Item>
+          </SegmentedControl>
+        )}
+
+        {shouldRenderCopyAsDropdown && (
+          <CopyAsDropdown
+            size="xs"
+            items={[
+              {
+                key: 'fullUrl',
+                label: t('Full URL'),
+                onAction: () => copyToClipboard(fullUrl ?? ''),
+                disabled: !fullUrl,
+              },
+              {
+                key: 'path',
+                label: t('Path'),
+                onAction: () => copyToClipboard(parsedUrl?.pathname ?? ''),
+                disabled: !parsedUrl?.pathname,
+              },
+            ]}
+          />
+        )}
+      </Flex>
+    );
+  }
 
   const title = (
     <TruncatedPathLink method={data.method} url={parsedUrl} fullUrl={fullUrl} />

--- a/static/app/components/events/interfaces/request/index.tsx
+++ b/static/app/components/events/interfaces/request/index.tsx
@@ -148,7 +148,7 @@ export function Request({data, event}: RequestProps) {
     parsedUrl.href = fullUrl;
   }
 
-  let actions: React.ReactNode | null = null;
+  let actions: React.ReactNode = null;
 
   const canGenerateCurlCommand = !isPartial && fullUrl;
 


### PR DESCRIPTION
Addresses getsentry/sentry#103883

You could theoretically hover over the link and right click to copy the link but this adds a button to do so

There are two views of the request component depending on whether or not we can construct the full request (method, url, etc. to make the full curl command) this handles both and the images below show the change

When a curl command can't be made

Old

<img src="https://github.com/user-attachments/assets/ab1a937d-2322-411e-aeeb-2e15eecad2f8 " alt="image" width="883" data-linear-height="49" />

New

<img src="https://github.com/user-attachments/assets/9da2a195-d5f9-4c63-98d7-1544cb609f80 " alt="image" width="1084" data-linear-height="56" />

When a curl command can be made

Old

<img src="https://github.com/user-attachments/assets/fab14912-84b8-44cc-b7b7-29ab308c15e3 " alt="image" width="876" data-linear-height="55" />

New

<img src="https://github.com/user-attachments/assets/597a39a1-2a1c-4244-abe1-9c310036e2d4 " alt="image" width="1092" data-linear-height="178" />

When the path name and full url aren't available it will show it greyed out

<img src="https://github.com/user-attachments/assets/073362ec-85d1-45bc-aa5d-6cf0152fa308 " alt="image" width="1071" data-linear-height="56" />

Concern: I don't like the wording of "Copy as" and instead would prefer "Copy" but like everywhere in the group view it uses that component so it keeps it consistent. Could theoretically add a label prop to the copyasbutton component but will leave that for review discussion