### PR TITLE
fix(errors): transactions homepage showed broken state

### DIFF
--- a/static/app/views/discover/homepage.spec.tsx
+++ b/static/app/views/discover/homepage.spec.tsx
@@ -567,18 +567,21 @@ describe('Discover > Homepage', () => {
       },
     });
 
-    render(<Homepage />, {
+    const {router} = render(<Homepage />, {
       initialRouterConfig: {
         location: {
-          pathname: `/organizations/${organization.slug}/explore/discover/homepage/`,
+          pathname: `/organizations/${organization.slug}/explore/errors/homepage/`,
         },
-        route: '/organizations/:orgId/explore/discover/homepage/',
+        route: '/organizations/:orgId/explore/errors/homepage/',
       },
       organization,
     });
 
-    expect(await screen.findByText('New Query')).toBeInTheDocument();
+    expect(await screen.findByText('Results')).toBeInTheDocument();
     expect(screen.queryByText('homepage query')).not.toBeInTheDocument();
     expect(screen.queryByText('environment')).not.toBeInTheDocument();
+
+    expect(router.location.query.dataset).toBe('errors');
+    expect(router.location.query.queryDataset).toBe('error-events');
   });
 });

--- a/static/app/views/discover/homepage.spec.tsx
+++ b/static/app/views/discover/homepage.spec.tsx
@@ -519,4 +519,60 @@ describe('Discover > Homepage', () => {
       screen.queryByRole('menuitemradio', {name: 'Remove Default'})
     ).not.toBeInTheDocument();
   });
+
+  it('shows default homepage when discover deprecation is enabled with transaction dataset homepage query', () => {
+    organization = OrganizationFixture({
+      features: ['discover-basic', 'discover-query'],
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {
+        meta: {
+          discoverSplitDecision: 'transaction-like',
+        },
+        data: [],
+      },
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/discover/homepage/`,
+      method: 'GET',
+      statusCode: 200,
+      body: {
+        id: '2',
+        name: 'homepage query',
+        projects: [],
+        version: 2,
+        expired: false,
+        dateCreated: '2021-04-08T17:53:25.195782Z',
+        dateUpdated: '2021-04-09T12:13:18.567264Z',
+        createdBy: {
+          id: '2',
+        },
+        environment: [],
+        fields: ['environment'],
+        widths: ['-1'],
+        range: '14d',
+        orderby: '-environment',
+        display: 'previous',
+        query: 'event.type:transaction',
+        topEvents: '5',
+        queryDataset: 'transaction-like',
+      },
+    });
+
+    render(<Homepage />, {
+      initialRouterConfig: {
+        location: {
+          pathname: `/organizations/${organization.slug}/explore/discover/homepage/`,
+        },
+        route: '/organizations/:orgId/explore/discover/homepage/',
+      },
+      organization,
+    });
+
+    expect(screen.queryByText('homepage query')).not.toBeInTheDocument();
+    expect(screen.queryByText('environment')).not.toBeInTheDocument();
+  });
 });

--- a/static/app/views/discover/homepage.spec.tsx
+++ b/static/app/views/discover/homepage.spec.tsx
@@ -520,9 +520,14 @@ describe('Discover > Homepage', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('shows default homepage when discover deprecation is enabled with transaction dataset homepage query', () => {
+  it('shows default homepage when discover deprecation is enabled with transaction dataset homepage query', async () => {
     organization = OrganizationFixture({
-      features: ['discover-basic', 'discover-query'],
+      features: [
+        'discover-basic',
+        'discover-query',
+        'discover-saved-queries-deprecation',
+        'deprecate-discover',
+      ],
     });
 
     MockApiClient.addMockResponse({
@@ -572,6 +577,7 @@ describe('Discover > Homepage', () => {
       organization,
     });
 
+    expect(await screen.findByText('New Query')).toBeInTheDocument();
     expect(screen.queryByText('homepage query')).not.toBeInTheDocument();
     expect(screen.queryByText('environment')).not.toBeInTheDocument();
   });

--- a/static/app/views/discover/homepage.tsx
+++ b/static/app/views/discover/homepage.tsx
@@ -19,6 +19,7 @@ import type {Organization, SavedQuery} from 'sentry/types/organization';
 import type {ApiQueryKey} from 'sentry/utils/api/apiQueryKey';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {EventView} from 'sentry/utils/discover/eventView';
+import {DiscoverDatasets, SavedQueryDatasets} from 'sentry/utils/discover/types';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {useApi} from 'sentry/utils/useApi';
 import {useDatePageFilterProps} from 'sentry/utils/useDatePageFilterProps';
@@ -29,6 +30,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {usePrevious} from 'sentry/utils/usePrevious';
 import {useGlobalAlerts} from 'sentry/views/app/globalAlerts';
 import {getSavedQueryWithDataset} from 'sentry/views/discover/savedQuery/utils';
+import {getDiscoverDeprecation} from 'sentry/views/discover/utils';
 
 import {Results} from './results';
 
@@ -61,6 +63,11 @@ function Homepage() {
 
   const previousSavedQuery = usePrevious(savedQuery);
 
+  const shouldHideThisTransactionsQuery =
+    getDiscoverDeprecation(organization) &&
+    (savedQuery?.queryDataset === SavedQueryDatasets.TRANSACTIONS ||
+      savedQuery?.dataset === DiscoverDatasets.TRANSACTIONS);
+
   useEffect(() => {
     const hasFetchedSavedQuery = !previousSavedQuery && savedQuery;
     const sidebarClicked = savedQuery && location.search === '';
@@ -70,6 +77,10 @@ function Homepage() {
       savedQuery &&
       ((hasFetchedSavedQuery && !hasValidEventViewInURL) || sidebarClicked)
     ) {
+      if (shouldHideThisTransactionsQuery) {
+        return;
+      }
+
       const eventView = EventView.fromSavedQuery(savedQuery);
       const pageFilterState = getPageFilterStorage(organization.slug);
       let query = {
@@ -111,7 +122,14 @@ function Homepage() {
         {replace: true}
       );
     }
-  }, [savedQuery, location, previousSavedQuery, navigate, organization.slug]);
+  }, [
+    savedQuery,
+    location,
+    previousSavedQuery,
+    navigate,
+    organization.slug,
+    shouldHideThisTransactionsQuery,
+  ]);
 
   if (isLoading) {
     return <LoadingIndicator />;
@@ -137,7 +155,7 @@ function Homepage() {
       selection={selection}
       setSavedQuery={setSavedQuery}
       isHomepage
-      savedQuery={savedQuery}
+      savedQuery={shouldHideThisTransactionsQuery ? undefined : savedQuery}
     />
   );
 }

--- a/static/app/views/discover/homepage.tsx
+++ b/static/app/views/discover/homepage.tsx
@@ -166,7 +166,6 @@ function Homepage() {
       selection={selection}
       setSavedQuery={setSavedQuery}
       isHomepage
-      // savedQuery={shouldHideThisTransactionsQuery ? undefined : savedQuery}
       savedQuery={savedQuery}
     />
   );

--- a/static/app/views/discover/homepage.tsx
+++ b/static/app/views/discover/homepage.tsx
@@ -29,6 +29,7 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {usePrevious} from 'sentry/utils/usePrevious';
 import {useGlobalAlerts} from 'sentry/views/app/globalAlerts';
+import {DEFAULT_EVENT_VIEW_MAP} from 'sentry/views/discover/results/data';
 import {getSavedQueryWithDataset} from 'sentry/views/discover/savedQuery/utils';
 import {getDiscoverDeprecation} from 'sentry/views/discover/utils';
 
@@ -78,6 +79,18 @@ function Homepage() {
       ((hasFetchedSavedQuery && !hasValidEventViewInURL) || sidebarClicked)
     ) {
       if (shouldHideThisTransactionsQuery) {
+        // use default error view instead of homepage
+        const defaultEventView = EventView.fromNewQueryWithLocation(
+          DEFAULT_EVENT_VIEW_MAP[SavedQueryDatasets.ERRORS],
+          location
+        );
+        navigate(
+          {
+            ...location,
+            query: defaultEventView.generateQueryStringObject(),
+          },
+          {replace: true}
+        );
         return;
       }
 

--- a/static/app/views/discover/homepage.tsx
+++ b/static/app/views/discover/homepage.tsx
@@ -1,5 +1,6 @@
 import {useEffect} from 'react';
 import {useQueryClient} from '@tanstack/react-query';
+import type {Query} from 'history';
 
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
@@ -78,27 +79,24 @@ function Homepage() {
       savedQuery &&
       ((hasFetchedSavedQuery && !hasValidEventViewInURL) || sidebarClicked)
     ) {
+      let query: Query = {};
+      const pageFilterState = getPageFilterStorage(organization.slug);
+      let dataset = savedQuery?.queryDataset;
+
       if (shouldHideThisTransactionsQuery) {
         // use default error view instead of homepage
         const defaultEventView = EventView.fromNewQueryWithLocation(
           DEFAULT_EVENT_VIEW_MAP[SavedQueryDatasets.ERRORS],
           location
         );
-        navigate(
-          {
-            ...location,
-            query: defaultEventView.generateQueryStringObject(),
-          },
-          {replace: true}
-        );
-        return;
+        query = {...defaultEventView.generateQueryStringObject()};
+        dataset = SavedQueryDatasets.ERRORS;
+      } else {
+        const eventView = EventView.fromSavedQuery(savedQuery);
+        query = {
+          ...eventView.generateQueryStringObject(),
+        };
       }
-
-      const eventView = EventView.fromSavedQuery(savedQuery);
-      const pageFilterState = getPageFilterStorage(organization.slug);
-      let query = {
-        ...eventView.generateQueryStringObject(),
-      };
 
       // Handle locked filters explicitly because we can't expect
       // PageFilterContainer to properly overwrite stored filters
@@ -129,7 +127,7 @@ function Homepage() {
           ...location,
           query: {
             ...query,
-            queryDataset: savedQuery?.queryDataset,
+            queryDataset: dataset,
           },
         },
         {replace: true}
@@ -168,7 +166,8 @@ function Homepage() {
       selection={selection}
       setSavedQuery={setSavedQuery}
       isHomepage
-      savedQuery={shouldHideThisTransactionsQuery ? undefined : savedQuery}
+      // savedQuery={shouldHideThisTransactionsQuery ? undefined : savedQuery}
+      savedQuery={savedQuery}
     />
   );
 }


### PR DESCRIPTION
some users had a discover homepage that was a transactions dataset query. This would result in the page looking very funky. What i've done is ignore the transactions homepage query and act like there's no homepage when that happens. Here's what it looks like:

| Before | After |
|--------|--------|
| <img width="1440" height="763" alt="image" src="https://github.com/user-attachments/assets/473ff551-8a20-43f7-bff7-9a662e36bd6f" /> | <img width="1435" height="737" alt="image" src="https://github.com/user-attachments/assets/54884fd3-2122-4c06-8478-dd574dced1a6" />| 