### PR TITLE
fix(seer): Label every Explorer tool link instead of its raw name

### DIFF
--- a/static/app/views/seerExplorer/components/chat/toolUse.spec.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.spec.tsx
@@ -1,7 +1,11 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {BlockComponent} from 'sentry/views/seerExplorer/components/chat';
+import {NAV_LINK_LABELS} from 'sentry/views/seerExplorer/components/chat/toolUse';
 import type {Block} from 'sentry/views/seerExplorer/types';
+import {buildToolLinkUrl} from 'sentry/views/seerExplorer/utils';
 
 function createBlock(overrides?: Partial<Block>): Block {
   return {
@@ -447,5 +451,113 @@ describe('ToolUseBlock', () => {
     expect(
       screen.queryByRole('button', {name: 'I like this response'})
     ).not.toBeInTheDocument();
+  });
+
+  describe('bus link labels', () => {
+    it('labels a kind seer emits rather than showing the raw function name', () => {
+      // Regression: get_log_attributes and get_metric_attributes were emitted by seer but absent
+      // from NAV_LINK_LABELS, so they rendered with their raw function names as the link text.
+      const block = createBlock({
+        message: {
+          role: 'tool_use',
+          content: null,
+          tool_calls: [{id: 'call-1', function: 'sentry_api_execute', args: '{}'}],
+        },
+        tool_links: [null],
+        tool_results: [
+          {
+            tool_call_id: 'call-1',
+            tool_call_function: 'sentry_api_execute',
+            content: 'ran',
+            structuredContent: {
+              links: [
+                {kind: 'get_log_attributes', params: {trace_id: 'abc'}},
+                {kind: 'get_metric_attributes', params: {trace_id: 'abc'}},
+              ],
+            },
+          },
+        ],
+      });
+
+      render(<BlockComponent block={block} blockIndex={0} blocks={[block]} />);
+
+      expect(screen.getByText('View logs')).toBeInTheDocument();
+      expect(screen.getByText('View metrics')).toBeInTheDocument();
+      expect(screen.queryByText('get_log_attributes')).not.toBeInTheDocument();
+      expect(screen.queryByText('get_metric_attributes')).not.toBeInTheDocument();
+    });
+
+    it('renders no link for a kind the client does not support', () => {
+      // seer may emit a kind ahead of client support. Such a kind has no URL builder, so it is
+      // dropped by the url filter; the label filter alongside it is belt-and-braces for the case
+      // where a URL builder is added without a label, which the coverage test below is what
+      // actually enforces.
+      const block = createBlock({
+        message: {
+          role: 'tool_use',
+          content: null,
+          tool_calls: [{id: 'call-1', function: 'sentry_api_execute', args: '{}'}],
+        },
+        tool_links: [null],
+        tool_results: [
+          {
+            tool_call_id: 'call-1',
+            tool_call_function: 'sentry_api_execute',
+            content: 'ran',
+            structuredContent: {
+              links: [
+                {kind: 'some_future_tool', params: {issue_id: '123'}},
+                {kind: 'get_issue_details', params: {issue_id: '123'}},
+              ],
+            },
+          },
+        ],
+      });
+
+      render(<BlockComponent block={block} blockIndex={0} blocks={[block]} />);
+
+      expect(screen.queryByText('some_future_tool')).not.toBeInTheDocument();
+      // The labeled sibling still renders.
+      expect(screen.getByText('View issue')).toBeInTheDocument();
+      expect(screen.getAllByRole('link')).toHaveLength(1);
+    });
+  });
+});
+
+// Guards the invariant that NAV_LINK_LABELS and buildToolLinkUrl cover the same set of kinds. Adding
+// a URL builder without a label would make the link silently unrenderable; adding a label without a
+// builder would make it dead. Extend PARAMS when buildToolLinkUrl gains a case.
+describe('navigation link coverage', () => {
+  const PARAMS: Record<string, Record<string, any>> = {
+    get_issue_details: {issue_id: '123'},
+    get_trace_waterfall: {trace_id: 'abc'},
+    get_replay_details: {replay_id: 'replay-1'},
+    get_profile_flamegraph: {profile_id: 'prof-1', project_id: '1'},
+    get_event_details: {issue_id: '123', event_id: 'event-1'},
+    get_log_attributes: {trace_id: 'abc'},
+    get_metric_attributes: {trace_id: 'abc'},
+    telemetry_live_search: {query: 'is:unresolved'},
+  };
+
+  it('labels exactly the kinds that can build a URL', () => {
+    expect(Object.keys(NAV_LINK_LABELS).sort()).toEqual(Object.keys(PARAMS).sort());
+  });
+
+  it('resolves a URL for every labeled kind', () => {
+    const organization = OrganizationFixture();
+    const projects = [{id: '1', slug: 'project-slug'}];
+
+    for (const kind of Object.keys(NAV_LINK_LABELS)) {
+      expect(
+        buildToolLinkUrl({kind, params: PARAMS[kind]!}, organization, projects)
+      ).not.toBeNull();
+    }
+  });
+
+  it('uses human-readable labels, never a raw identifier', () => {
+    for (const [kind, label] of Object.entries(NAV_LINK_LABELS)) {
+      expect(label).not.toBe(kind);
+      expect(label).not.toContain('_');
+    }
   });
 });

--- a/static/app/views/seerExplorer/components/chat/toolUse.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.tsx
@@ -231,11 +231,22 @@ function ToolCallList({block, blocks, getPageReferrer}: ToolCallListProps) {
           .filter(link => linkKey(link) !== positionalKey)
           .map(link => ({
             kind: link.kind,
+            label: navLinkLabel(link.kind),
             url: buildToolLinkUrl(link, organization, projects),
           }))
+          // Fail closed on both axes: drop a link we cannot build a URL for, and drop one we have
+          // no label for rather than falling back to the raw kind. An unsupported kind already has
+          // no URL builder, so the label check only bites if a builder is ever added without a
+          // label — the coverage test keeps those two sets in step, and this is the backstop that
+          // keeps an internal identifier off screen if it drifts anyway.
           .filter(
-            (item): item is {kind: string; url: NonNullable<typeof item.url>} =>
-              !!item.url
+            (
+              item
+            ): item is {
+              kind: string;
+              label: string;
+              url: NonNullable<typeof item.url>;
+            } => !!item.url && !!item.label
           );
 
         return (
@@ -258,6 +269,8 @@ function ToolCallList({block, blocks, getPageReferrer}: ToolCallListProps) {
 
 interface NavItem {
   kind: string;
+  /** Resolved at construction, so an unlabeled kind never reaches the renderer. */
+  label: string;
   url: NonNullable<ReturnType<typeof buildToolLinkUrl>>;
 }
 
@@ -323,12 +336,26 @@ function ToolCallRow({
   );
 }
 
-const NAV_LINK_LABELS: Record<string, string> = {
+// One entry per link kind buildToolLinkUrl can resolve. A kind absent here is not rendered at all
+// (see navLinkLabel): showing the raw kind would leak an internal function name like
+// `get_log_attributes` as the visible link text. Keeping this in step with buildToolLinkUrl's cases
+// is enforced by a test, so a kind seer starts emitting cannot reach users unlabeled.
+export const NAV_LINK_LABELS: Record<string, string> = {
   get_issue_details: t('View issue'),
   get_trace_waterfall: t('View trace'),
   get_replay_details: t('View replay'),
   get_profile_flamegraph: t('View profile'),
+  get_event_details: t('View event'),
+  get_log_attributes: t('View logs'),
+  get_metric_attributes: t('View metrics'),
+  // Dataset-dependent (issues / errors / spans / logs), so the label stays neutral.
+  telemetry_live_search: t('View results'),
 };
+
+/** The visible label for a bus link, or undefined when the kind is not renderable. */
+function navLinkLabel(kind: string): string | undefined {
+  return NAV_LINK_LABELS[kind];
+}
 
 function NavLinks({
   navItems,
@@ -345,7 +372,7 @@ function NavLinks({
               class, colors the label the same way it does the positional row link. */}
           <ToolCallLink to={item.url} onClick={onNavLinkClick?.(item.kind)}>
             <ToolCallText size="xs" monospace>
-              {NAV_LINK_LABELS[item.kind] ?? item.kind}
+              {item.label}
             </ToolCallText>
             <ToolCallLinkIconWrapper>
               <ToolCallLinkIcon size="xs" />


### PR DESCRIPTION
Explorer's tool rail renders deep-links back into Sentry (view an issue, a trace, a replay). Each link arrives from Seer as a `kind` — the name of the Seer tool that produced it — and the frontend maps that kind to a human label and a URL.

Two kinds Seer emits today, `get_log_attributes` and `get_metric_attributes`, were missing from that label map. The renderer fell back to showing the kind verbatim, so users saw a link labelled literally `get_log_attributes`.

Add labels for all eight kinds `buildToolLinkUrl` can resolve, and change the fallback: a kind with no label is now omitted rather than displayed raw. Failing closed is the safer default, because Seer can start emitting a new kind before the frontend knows about it — a missing link is a smaller defect than a leaked internal identifier.

A test asserts the label map and the URL builder cover exactly the same set of kinds, so the next kind Seer adds cannot reach users unlabelled without CI noticing.

Frontend only, and independent of any Seer change.