### PR TITLE
feat(seer): Read Explorer todos and artifacts from tool results too

### DIFF
--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -47,6 +47,7 @@ import {
   type RepoPRState,
   type SeerExplorerRunId,
 } from 'sentry/views/seerExplorer/types';
+import {collectArtifacts} from 'sentry/views/seerExplorer/utils';
 
 /**
  * Available autofix steps that can be triggered via the Explorer.
@@ -360,7 +361,9 @@ function buildSection(
   blocks: Block[],
   runState: ExplorerAutofixState | null
 ): AutofixSection {
-  const artifacts: AutofixArtifact[] = blocks.flatMap(block => block.artifacts ?? []);
+  // Both channels: the classic block field and Code Mode's structuredContent
+  // (codemode-structured-content-only).
+  const artifacts = collectArtifacts(blocks) as AutofixArtifact[];
 
   const section: AutofixSection = {
     index,

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -363,7 +363,7 @@ function buildSection(
 ): AutofixSection {
   // Both channels: the classic block field and Code Mode's structuredContent
   // (codemode-structured-content-only).
-  const artifacts = collectArtifacts(blocks) as AutofixArtifact[];
+  const artifacts: AutofixArtifact[] = collectArtifacts(blocks);
 
   const section: AutofixSection = {
     index,

--- a/static/app/views/seerExplorer/components/chat/toolUse.spec.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.spec.tsx
@@ -453,6 +453,107 @@ describe('ToolUseBlock', () => {
     ).not.toBeInTheDocument();
   });
 
+  describe('todos from either channel', () => {
+    // seer no longer projects Code Mode todos onto block.todos, so the checklist must resolve from
+    // the tool result's structuredContent too (codemode-structured-content-only).
+    function codeModeTodosBlock(
+      id: string,
+      todos: Array<{content: string; status: string}>
+    ) {
+      return createBlock({
+        id,
+        message: {
+          role: 'tool_use',
+          content: null,
+          tool_calls: [{id: `${id}-call`, function: 'sentry_api_execute', args: '{}'}],
+        },
+        tool_links: [null],
+        tool_results: [
+          {
+            tool_call_id: `${id}-call`,
+            tool_call_function: 'sentry_api_execute',
+            content: 'ran',
+            structuredContent: {todos: todos as any},
+          },
+        ],
+      });
+    }
+
+    it('renders a checklist that arrived on structuredContent', () => {
+      const block = codeModeTodosBlock('b1', [
+        {content: 'Investigate p95', status: 'in_progress'},
+        {content: 'Propose a fix', status: 'pending'},
+      ]);
+      render(<BlockComponent block={block} blockIndex={0} blocks={[block]} />);
+      expect(screen.getByText('Investigate p95')).toBeInTheDocument();
+      expect(screen.getByText('Propose a fix')).toBeInTheDocument();
+    });
+
+    it('renders the same checklist from either channel', () => {
+      const classic = createBlock({
+        message: {
+          role: 'tool_use',
+          content: null,
+          tool_calls: [{id: 'call-1', function: 'todo_write', args: '{}'}],
+        },
+        todos: [{content: 'Ship it', status: 'completed'}],
+      });
+      render(<BlockComponent block={classic} blockIndex={0} blocks={[classic]} />);
+      expect(screen.getByText('Ship it')).toBeInTheDocument();
+      expect(screen.getByRole('checkbox')).toBeChecked();
+    });
+
+    it('a later structured snapshot supersedes an earlier classic one', () => {
+      const first = createBlock({
+        id: 'b1',
+        message: {
+          role: 'tool_use',
+          content: null,
+          tool_calls: [{id: 'c1', function: 'todo_write', args: '{}'}],
+        },
+        todos: [{content: 'Stale item', status: 'pending'}],
+      });
+      const second = codeModeTodosBlock('b2', [
+        {content: 'Fresh item', status: 'pending'},
+      ]);
+      const blocks = [first, second];
+
+      render(<BlockComponent block={first} blockIndex={0} blocks={blocks} />);
+      expect(screen.queryByText('Stale item')).not.toBeInTheDocument();
+
+      render(<BlockComponent block={second} blockIndex={1} blocks={blocks} />);
+      expect(screen.getByText('Fresh item')).toBeInTheDocument();
+    });
+
+    it('a later classic snapshot supersedes an earlier structured one', () => {
+      const first = codeModeTodosBlock('b1', [
+        {content: 'Stale item', status: 'pending'},
+      ]);
+      const second = createBlock({
+        id: 'b2',
+        message: {
+          role: 'tool_use',
+          content: null,
+          tool_calls: [{id: 'c2', function: 'todo_write', args: '{}'}],
+        },
+        todos: [{content: 'Fresh item', status: 'completed'}],
+      });
+      const blocks = [first, second];
+
+      render(<BlockComponent block={first} blockIndex={0} blocks={blocks} />);
+      expect(screen.queryByText('Stale item')).not.toBeInTheDocument();
+
+      render(<BlockComponent block={second} blockIndex={1} blocks={blocks} />);
+      expect(screen.getByText('Fresh item')).toBeInTheDocument();
+    });
+
+    it('renders nothing when neither channel carries a snapshot', () => {
+      const block = createBlock();
+      render(<BlockComponent block={block} blockIndex={0} blocks={[block]} />);
+      expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+    });
+  });
+
   describe('bus link labels', () => {
     it('labels a kind seer emits rather than showing the raw function name', () => {
       // Regression: get_log_attributes and get_metric_attributes were emitted by seer but absent

--- a/static/app/views/seerExplorer/components/chat/toolUse.spec.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.spec.tsx
@@ -4,7 +4,7 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {BlockComponent} from 'sentry/views/seerExplorer/components/chat';
 import {NAV_LINK_LABELS} from 'sentry/views/seerExplorer/components/chat/toolUse';
-import type {Block} from 'sentry/views/seerExplorer/types';
+import type {Block, TodoItem} from 'sentry/views/seerExplorer/types';
 import {buildToolLinkUrl} from 'sentry/views/seerExplorer/utils';
 
 function createBlock(overrides?: Partial<Block>): Block {
@@ -456,10 +456,7 @@ describe('ToolUseBlock', () => {
   describe('todos from either channel', () => {
     // seer no longer projects Code Mode todos onto block.todos, so the checklist must resolve from
     // the tool result's structuredContent too (codemode-structured-content-only).
-    function codeModeTodosBlock(
-      id: string,
-      todos: Array<{content: string; status: string}>
-    ) {
+    function codeModeTodosBlock(id: string, todos: TodoItem[]) {
       return createBlock({
         id,
         message: {
@@ -473,7 +470,7 @@ describe('ToolUseBlock', () => {
             tool_call_id: `${id}-call`,
             tool_call_function: 'sentry_api_execute',
             content: 'ran',
-            structuredContent: {todos: todos as any},
+            structuredContent: {todos},
           },
         ],
       });

--- a/static/app/views/seerExplorer/components/chat/toolUse.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.tsx
@@ -164,6 +164,7 @@ function ToolCallList({block, blocks, getPageReferrer}: ToolCallListProps) {
   } = useToolLinks(block);
   const toolsUsed = getToolsStringFromBlock(block);
   const blockStatus = getBlockStatus(block);
+  const latestTodos = useMemo(() => findLatestTodos(blocks), [blocks]);
 
   return (
     <Stack gap="md" width="100%" minWidth={0} paddingRight="lg">
@@ -195,16 +196,11 @@ function ToolCallList({block, blocks, getPageReferrer}: ToolCallListProps) {
           ? trackLinkClick(positionalLink.kind)
           : undefined;
 
-        // Render the checklist once per block (on the last tool-call row), regardless of
-        // which tool produced it — classic `todo_write` or Code Mode `sentry_api_execute`,
-        // which projects its todos onto block.todos (code-mode-effects-bus).
+        // Render the checklist once per block, on the last tool-call row of whichever block holds
+        // the newest snapshot — from either channel (codemode-structured-content-only).
         const isLastToolCall = idx === (block.message.tool_calls?.length ?? 0) - 1;
         const todos =
-          isLastToolCall &&
-          block.todos?.length &&
-          blocks?.findLast(b => b.todos?.length) === block
-            ? block.todos
-            : null;
+          isLastToolCall && latestTodos?.block === block ? latestTodos.todos : null;
 
         const failureTooltip = toolLinkParams?.is_error
           ? t('Tool call failed')
@@ -355,6 +351,31 @@ export const NAV_LINK_LABELS: Record<string, string> = {
 /** The visible label for a bus link, or undefined when the kind is not renderable. */
 function navLinkLabel(kind: string): string | undefined {
   return NAV_LINK_LABELS[kind];
+}
+
+/**
+ * The newest todo snapshot in the conversation and the block that carries it.
+ *
+ * A snapshot arrives on either channel: a classic `todo_write` writes `block.todos`, while Code Mode
+ * returns it on a tool result's `structuredContent.todos`. Neither is converted into the other, so
+ * both are walked in run order — blocks in sequence, and within a block its tool results in sequence,
+ * with the legacy field first so a same-block collision resolves to the structured value. Returns
+ * null when no block carries one.
+ */
+function findLatestTodos(blocks?: Block[]): {block: Block; todos: TodoItem[]} | null {
+  let latest: {block: Block; todos: TodoItem[]} | null = null;
+  for (const block of blocks ?? []) {
+    if (block.todos?.length) {
+      latest = {block, todos: block.todos};
+    }
+    for (const result of block.tool_results ?? []) {
+      const todos = result?.structuredContent?.todos;
+      if (todos?.length) {
+        latest = {block, todos};
+      }
+    }
+  }
+  return latest;
 }
 
 function NavLinks({

--- a/static/app/views/seerExplorer/types.tsx
+++ b/static/app/views/seerExplorer/types.tsx
@@ -86,8 +86,13 @@ export interface ToolResult {
   // old seer responses, in which case only the legacy field is read.
   //
   // `links` is a tool result's own deep-links as a {kind, params} list — one result can carry many,
-  // so there's no index alignment. `todos` is the latest checklist snapshot.
-  structuredContent?: {links?: ToolLink[]; todos?: TodoItem[]} | null;
+  // so there's no index alignment. `todos` is the latest checklist snapshot. `artifacts` are the run
+  // artifacts produced by that call.
+  structuredContent?: {
+    artifacts?: Artifact[];
+    links?: ToolLink[];
+    todos?: TodoItem[];
+  } | null;
 }
 
 export interface ToolCall {

--- a/static/app/views/seerExplorer/types.tsx
+++ b/static/app/views/seerExplorer/types.tsx
@@ -80,11 +80,14 @@ export interface ToolResult {
   content: string;
   tool_call_function: string;
   tool_call_id: string;
-  // MCP-style structured payload carried from seer (code-mode-effects-registry).
-  // The links bus: a tool result's own deep-links as a {kind, params} list — one result can
-  // carry many, so there's no index alignment. Optional — absent on old seer responses, in
-  // which case the frontend falls back to the positional block.tool_links.
-  structuredContent?: {links?: ToolLink[]} | null;
+  // MCP-style structured payload carried from seer (codemode-structured-content-only). Code Mode
+  // returns every surface it produces here rather than on a bespoke block field, so a renderer
+  // resolves a surface from this *and* the legacy field. Keys are optional and additive — absent on
+  // old seer responses, in which case only the legacy field is read.
+  //
+  // `links` is a tool result's own deep-links as a {kind, params} list — one result can carry many,
+  // so there's no index alignment. `todos` is the latest checklist snapshot.
+  structuredContent?: {links?: ToolLink[]; todos?: TodoItem[]} | null;
 }
 
 export interface ToolCall {

--- a/static/app/views/seerExplorer/utils.tsx
+++ b/static/app/views/seerExplorer/utils.tsx
@@ -38,6 +38,7 @@ import {Mode} from 'sentry/views/explore/queryParams/mode';
 import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
 import {makeReplaysPathname} from 'sentry/views/explore/replays/pathnames';
 import type {
+  Artifact,
   Block,
   SeerExplorerRunId,
   SeerExplorerSidebarPosition,
@@ -1245,4 +1246,23 @@ export function useSeerExplorerSidebarOrientation(
     return isWideScreen || isShortLandscape ? 'right' : 'bottom';
   }
   return sidebarPosition;
+}
+
+/**
+ * Every artifact in the conversation, from whichever channel carried it.
+ *
+ * A classic artifact tool appends to `block.artifacts`; Code Mode returns them on a tool result's
+ * `structuredContent.artifacts`. Neither is converted into the other, so both are walked in run
+ * order — blocks in sequence, and within a block its tool results in sequence
+ * (codemode-structured-content-only).
+ */
+export function collectArtifacts(blocks: Block[]): Artifact[] {
+  const artifacts: Artifact[] = [];
+  for (const block of blocks) {
+    artifacts.push(...(block.artifacts ?? []));
+    for (const result of block.tool_results ?? []) {
+      artifacts.push(...(result?.structuredContent?.artifacts ?? []));
+    }
+  }
+  return artifacts;
 }


### PR DESCRIPTION
Explorer state arrives from Seer in two different shapes, and the frontend currently only understands one of them.

The old shape is a set of per-feature fields on each block — `block.todos`, `block.artifacts` — written directly by the tool that produced them. The new shape is MCP's `structuredContent`: a keyed object a tool returns alongside its text output, which is the standard way a tool returns structured data. Seer's Code Mode uses the new shape.

Until now Seer copied Code Mode's todos into `block.todos` so existing readers kept working. That copy is being removed (getsentry/seer#7612), because leaving it in place means the per-feature fields stay the only thing anyone reads and can never be deleted.

So teach the two consumers to check both places. The todo checklist and the autofix artifact list now walk blocks in order and, within each block, its tool results in order, taking the per-feature field and any `structuredContent` entry. For todos the newest snapshot wins; artifacts accumulate.

This is inert on its own — nothing emits those keys yet, so it reads exactly what it read before. It has to ship and deploy *before* getsentry/seer#7612, otherwise Code Mode checklists would stop rendering in the window between the two.

Stacked on #121247.