### PR TITLE
feat(issue-preview): Show root cause evidence

### DIFF
--- a/static/app/views/issueDetails/issuePreview/issuePreview.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreview.tsx
@@ -213,7 +213,11 @@ function IssuePreviewContent() {
         <Dividers>
           <LinkedPullRequests group={group} showEmptyState={false} />
           {hasAutofix ? (
-            <IssuePreviewAutofixSummary key={group.id} runState={autofix.runState} />
+            <IssuePreviewAutofixSummary
+              key={group.id}
+              groupId={group.id}
+              runState={autofix.runState}
+            />
           ) : null}
           <Container>
             <ErrorBoundary mini>

--- a/static/app/views/issueDetails/issuePreview/issuePreviewAutofixSummary.spec.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewAutofixSummary.spec.tsx
@@ -59,7 +59,28 @@ describe('IssuePreviewAutofixSummary', () => {
   it('renders summaries in the requested order with the first section expanded', async () => {
     const runState = ExplorerAutofixStateFixture({
       blocks: [
-        ExplorerAutofixBlockFixture({artifacts: [rootCauseArtifact]}),
+        ExplorerAutofixBlockFixture({
+          artifacts: [rootCauseArtifact],
+          message: {
+            content: 'Root cause complete',
+            metadata: {step: 'root_cause'},
+            role: 'assistant',
+            tool_calls: [{id: 'event-tool', function: 'get_event_details', args: '{}'}],
+          },
+          tool_results: [
+            {
+              tool_call_id: 'event-tool',
+              tool_call_function: 'get_event_details',
+              content: 'Event details',
+            },
+          ],
+          tool_links: [
+            {
+              kind: 'get_event_details',
+              params: {issue_id: '12345', event_id: 'abcd1234efgh5678'},
+            },
+          ],
+        }),
         ExplorerAutofixBlockFixture({
           id: 'solution',
           artifacts: [solutionArtifact],
@@ -103,7 +124,7 @@ describe('IssuePreviewAutofixSummary', () => {
       },
     });
 
-    render(<IssuePreviewAutofixSummary runState={runState} />);
+    render(<IssuePreviewAutofixSummary groupId="preview-group" runState={runState} />);
 
     expect(
       screen.getAllByRole('heading', {level: 3}).map(heading => heading.textContent)
@@ -161,11 +182,14 @@ describe('IssuePreviewAutofixSummary', () => {
     expect(
       within(rootCause).getByText('Request a user ID that does not exist.')
     ).toBeVisible();
+    expect(within(rootCause).getByText('Evidence')).toBeVisible();
+    expect(within(rootCause).getByText('Error: abcd1234')).toBeVisible();
   });
 
   it('renders only completed valid artifacts that exist in a partial run', () => {
     render(
       <IssuePreviewAutofixSummary
+        groupId="preview-group"
         runState={ExplorerAutofixStateFixture({
           blocks: [ExplorerAutofixBlockFixture({artifacts: [rootCauseArtifact]})],
         })}
@@ -186,6 +210,7 @@ describe('IssuePreviewAutofixSummary', () => {
   it('renders the section with a loading indicator while it is processing', () => {
     render(
       <IssuePreviewAutofixSummary
+        groupId="preview-group"
         runState={ExplorerAutofixStateFixture({
           blocks: [
             ExplorerAutofixBlockFixture({
@@ -235,7 +260,7 @@ describe('IssuePreviewAutofixSummary', () => {
       }),
     ],
   ])('renders nothing for a %s', (_label, runState) => {
-    render(<IssuePreviewAutofixSummary runState={runState} />);
+    render(<IssuePreviewAutofixSummary groupId="preview-group" runState={runState} />);
 
     expect(screen.queryByRole('region', {name: 'Proposal'})).not.toBeInTheDocument();
     expect(

--- a/static/app/views/issueDetails/issuePreview/issuePreviewAutofixSummary.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewAutofixSummary.tsx
@@ -16,17 +16,24 @@ import {
   isRootCauseSection,
   isSolutionArtifact,
   isSolutionSection,
+  type AutofixSection,
   type ExplorerAutofixState,
 } from 'sentry/components/events/autofix/useExplorerAutofix';
+import {AutofixEvidence} from 'sentry/components/events/autofix/v3/autofixEvidence';
+import {useAutofixSectionEvidence} from 'sentry/components/events/autofix/v3/useAutofixSectionEvidence';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {t, tn} from 'sentry/locale';
 import {FileDiffViewer} from 'sentry/views/seerExplorer/components/fileDiffViewer';
 
 interface IssuePreviewAutofixSummaryProps {
+  groupId: string;
   runState: ExplorerAutofixState | null;
 }
 
-export function IssuePreviewAutofixSummary({runState}: IssuePreviewAutofixSummaryProps) {
+export function IssuePreviewAutofixSummary({
+  groupId,
+  runState,
+}: IssuePreviewAutofixSummaryProps) {
   const sections = useMemo(() => getOrderedAutofixSections(runState), [runState]);
 
   const proposalSection = sections.findLast(isCodeChangesSection);
@@ -225,12 +232,47 @@ export function IssuePreviewAutofixSummary({runState}: IssuePreviewAutofixSummar
                     </Stack>
                   </Stack>
                 ) : null}
+                {rootCauseArtifact && rootCauseSection ? (
+                  <IssuePreviewRootCauseEvidence
+                    groupId={groupId}
+                    section={rootCauseSection}
+                  />
+                ) : null}
               </Stack>
             </Disclosure.Content>
           </Disclosure>
         </Container>
       ) : null}
     </Dividers>
+  );
+}
+
+function IssuePreviewRootCauseEvidence({
+  groupId,
+  section,
+}: {
+  groupId: string;
+  section: AutofixSection;
+}) {
+  const evidence = useAutofixSectionEvidence({section});
+  if (evidence.length === 0) {
+    return null;
+  }
+
+  return (
+    <Stack gap="md">
+      <Text bold>{t('Evidence')}</Text>
+      <Flex gap="md" wrap="wrap">
+        {evidence.map(item => (
+          <AutofixEvidence
+            key={item.toolCall.id}
+            evidenceButtonProps={item.evidenceButtonProps}
+            groupId={groupId}
+            toolCall={item.toolCall}
+          />
+        ))}
+      </Flex>
+    </Stack>
   );
 }
 


### PR DESCRIPTION
Show completed Autofix root-cause evidence in the issue preview using the existing Autofix evidence resolver and chips, including their links, tooltips, icons, and analytics.

Closes ISWF-3194