### PR TITLE
feat(issue-details): surface Seer assignee suggestions

### DIFF
--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -231,73 +231,40 @@ export function AssigneeSelectorDropdown({
 
   const getSuggestedAssignees = (): SuggestedAssignee[] => {
     const currAssignableTeams = getAssignableTeams();
+    // Use owners from the group if no owners are provided
+    const suggestedOwners =
+      owners ??
+      uniqBy(group.owners ?? [], owner => owner.owner).map(suggestion => {
+        const [type, id] = suggestion.owner.split(':') as [Actor['type'], string];
+        return {
+          id,
+          type,
+          name: '',
+          suggestedReason: suggestion.type,
+          suggestedReasonText: suggestedReasonTable[suggestion.type],
+        };
+      });
 
-    if (owners !== undefined) {
-      // Add team or user from store
-      return owners
-        .map<SuggestedAssignee | null>(owner => {
-          if (owner.type === 'user') {
-            const member = currentMemberList.find(user => user.id === owner.id);
-            if (member) {
-              return {
-                ...owner,
-                assignee: member,
-              };
-            }
-          }
-          if (owner.type === 'team') {
-            const matchingTeam = currAssignableTeams.find(
-              assignableTeam => assignableTeam.team.id === owner.id
-            );
-            if (matchingTeam) {
-              return {
-                ...owner,
-                assignee: matchingTeam,
-              };
-            }
-          }
-
-          return null;
-        })
-        .filter((owner): owner is SuggestedAssignee => !!owner);
-    }
-
-    const suggestedOwners = group.owners ?? [];
-    if (!suggestedOwners) {
-      return [];
-    }
-
-    const uniqueSuggestions = uniqBy(suggestedOwners, owner => owner.owner);
-    return uniqueSuggestions
-      .map<SuggestedAssignee | null>(suggestion => {
-        const [suggestionType, suggestionId] = suggestion.owner.split(':') as [
-          string,
-          string,
-        ];
-        const suggestedReasonText = suggestedReasonTable[suggestion.type];
-        if (suggestionType === 'user') {
-          const member = currentMemberList.find(user => user.id === suggestionId);
+    return suggestedOwners
+      .map<SuggestedAssignee | null>(owner => {
+        if (owner.type === 'user') {
+          const member = currentMemberList.find(user => user.id === owner.id);
           if (member) {
             return {
-              id: suggestionId,
-              type: 'user',
-              name: member.name,
-              suggestedReason: suggestion.type,
-              suggestedReasonText,
+              ...owner,
+              name: owner.name || member.name,
               assignee: member,
             };
           }
-        } else if (suggestionType === 'team') {
+        }
+        if (owner.type === 'team') {
           const matchingTeam = currAssignableTeams.find(
-            assignableTeam => assignableTeam.id === suggestion.owner
+            assignableTeam => assignableTeam.team.id === owner.id
           );
           if (matchingTeam) {
             return {
-              id: suggestionId,
-              type: 'team',
-              name: matchingTeam.team.name,
-              suggestedReason: suggestion.type,
-              suggestedReasonText,
+              ...owner,
+              name: owner.name || matchingTeam.team.name,
               assignee: matchingTeam,
             };
           }

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -561,7 +561,7 @@ export type SuggestedOwnerReason =
   | 'codeowners';
 
 // Received from the backend to denote suggested owners of an issue
-type SuggestedOwner = {
+export type SuggestedOwner = {
   date_added: string;
   owner: string;
   type: SuggestedOwnerReason;

--- a/static/app/views/issueDetails/actions/index.spec.tsx
+++ b/static/app/views/issueDetails/actions/index.spec.tsx
@@ -100,10 +100,6 @@ describe('GroupActions', () => {
       body: [],
     });
     MockApiClient.addMockResponse({
-      url: `/projects/${organization.slug}/${project.slug}/events//committers/`,
-      body: {committers: []},
-    });
-    MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/events//owners/`,
       body: {owners: [], rules: []},
     });

--- a/static/app/views/issueDetails/groupDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupDetails.spec.tsx
@@ -211,12 +211,6 @@ describe('groupDetails', () => {
       },
     });
     MockApiClient.addMockResponse({
-      url: `/projects/${defaultInit.organization.slug}/${project.slug}/events/${event.id}/committers/`,
-      body: {
-        committers: [],
-      },
-    });
-    MockApiClient.addMockResponse({
       url: `/projects/${defaultInit.organization.slug}/${project.slug}/events/${event.id}/actionable-items/`,
       body: {errors: []},
     });

--- a/static/app/views/issueDetails/groupDetailsLayout.spec.tsx
+++ b/static/app/views/issueDetails/groupDetailsLayout.spec.tsx
@@ -95,10 +95,6 @@ describe('GroupDetailsLayout', () => {
       body: TagsFixture(),
     });
     MockApiClient.addMockResponse({
-      url: '/projects/org-slug/project-slug/events/1/committers/',
-      body: {committers: []},
-    });
-    MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/issues/${group.id}/autofix/setup/`,
       body: AutofixSetupFixture({
         integration: {ok: true, reason: null},

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
@@ -191,11 +191,6 @@ const mockGroupApis = (
   });
 
   MockApiClient.addMockResponse({
-    url: `/projects/${organization.slug}/${project.slug}/events/${event.id}/owners/`,
-    body: {owners: [], rules: []},
-  });
-
-  MockApiClient.addMockResponse({
     url: `/organizations/${organization.slug}/issues/${group.id}/tags/`,
     body: [],
   });

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
@@ -191,11 +191,6 @@ const mockGroupApis = (
   });
 
   MockApiClient.addMockResponse({
-    url: `/projects/${organization.slug}/${project.slug}/events/${event.id}/committers/`,
-    body: {committers: []},
-  });
-
-  MockApiClient.addMockResponse({
     url: `/projects/${organization.slug}/${project.slug}/events/${event.id}/owners/`,
     body: {owners: [], rules: []},
   });

--- a/static/app/views/issueDetails/header/assigneeSelector.spec.tsx
+++ b/static/app/views/issueDetails/header/assigneeSelector.spec.tsx
@@ -9,22 +9,16 @@ import {UserFixture} from 'sentry-fixture/user';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {GroupActivityType} from 'sentry/types/group';
-import type {Committer} from 'sentry/types/integrations';
 import {GroupHeaderAssigneeSelector} from 'sentry/views/issueDetails/header/assigneeSelector';
 import type {EventOwners} from 'sentry/views/issueDetails/header/getOwnerList';
 
 describe('GroupHeaderAssigneeSelector', () => {
   const organization = OrganizationFixture();
-  const group = GroupFixture();
   const project = ProjectFixture();
   const event = EventFixture();
 
   it('should render suggested assignees', async () => {
     const commitUser = UserFixture({id: '91', email: 'frodo@sentry.io', name: 'Frodo'});
-    const committer: Committer = {
-      author: commitUser,
-      commits: [],
-    };
     const ownerActor = ActorFixture({id: '101', email: 'sam@sentry.io', name: 'Sam'});
     const eventOwners: EventOwners = {
       owners: [ownerActor],
@@ -36,17 +30,23 @@ describe('GroupHeaderAssigneeSelector', () => {
       body: eventOwners,
     });
     MockApiClient.addMockResponse({
-      url: `/projects/${organization.slug}/${project.slug}/events/${event.id}/committers/`,
-      body: {committers: [committer]},
-    });
-    MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/users/`,
       body: [
         MemberFixture({user: commitUser}),
         MemberFixture({user: UserFixture({...ownerActor})}),
       ],
     });
-    render(<GroupHeaderAssigneeSelector group={group} project={project} event={event} />);
+    render(
+      <GroupHeaderAssigneeSelector
+        group={GroupFixture({
+          owners: [
+            {type: 'suspectCommit', owner: `user:${commitUser.id}`, date_added: ''},
+          ],
+        })}
+        project={project}
+        event={event}
+      />
+    );
 
     await userEvent.click(await screen.findByLabelText('Modify issue assignee'));
     expect(await screen.findByText(commitUser.name)).toBeInTheDocument();
@@ -55,6 +55,67 @@ describe('GroupHeaderAssigneeSelector', () => {
     expect(screen.getByText(ownerActor.name)).toBeInTheDocument();
     expect(screen.getByText('Codeowners:/issues')).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Ownership'})).toBeInTheDocument();
+  });
+
+  it('shows Seer suggestions alongside suspect commit authors', async () => {
+    const commitUser = UserFixture({id: '91', email: 'frodo@sentry.io', name: 'Frodo'});
+    const seerUser = UserFixture({id: '92', email: 'sam@sentry.io', name: 'Sam'});
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/events/${event.id}/owners/`,
+      body: {owners: [], rule: null, rules: []},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/users/`,
+      body: [MemberFixture({user: commitUser}), MemberFixture({user: seerUser})],
+    });
+
+    render(
+      <GroupHeaderAssigneeSelector
+        group={GroupFixture({
+          owners: [
+            {type: 'suspectCommit', owner: `user:${commitUser.id}`, date_added: ''},
+            {type: 'seerSuggested', owner: `user:${seerUser.id}`, date_added: ''},
+          ],
+        })}
+        project={project}
+        event={event}
+      />
+    );
+
+    await userEvent.click(await screen.findByLabelText('Modify issue assignee'));
+    expect(await screen.findByText(commitUser.name)).toBeInTheDocument();
+    expect(screen.getByText('Suspect commit author')).toBeInTheDocument();
+    expect(screen.getByText(seerUser.name)).toBeInTheDocument();
+    expect(screen.getByText('Seer Suggestion')).toBeInTheDocument();
+  });
+
+  it('ignores ownership rule group owners in favor of current event owners', async () => {
+    const staleUser = UserFixture({id: '91', email: 'frodo@sentry.io', name: 'Frodo'});
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/events/${event.id}/owners/`,
+      body: {owners: [], rule: null, rules: []},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/users/`,
+      body: [MemberFixture({user: staleUser})],
+    });
+
+    render(
+      <GroupHeaderAssigneeSelector
+        group={GroupFixture({
+          owners: [
+            {type: 'ownershipRule', owner: `user:${staleUser.id}`, date_added: ''},
+          ],
+        })}
+        project={project}
+        event={event}
+      />
+    );
+
+    await userEvent.click(await screen.findByLabelText('Modify issue assignee'));
+    expect(await screen.findByText(staleUser.name)).toBeInTheDocument();
+    expect(screen.queryByText('Ownership Rule')).not.toBeInTheDocument();
+    expect(screen.queryByText('Suggested')).not.toBeInTheDocument();
   });
 
   it('uses assignment activity for self-assignment tooltip details', async () => {
@@ -88,17 +149,6 @@ describe('GroupHeaderAssigneeSelector', () => {
     MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/events/${event.id}/owners/`,
       body: {owners: [], rule: ['path', ''], rules: []},
-    });
-    MockApiClient.addMockResponse({
-      url: `/projects/${organization.slug}/${project.slug}/events/${event.id}/committers/`,
-      body: {
-        committers: [
-          {
-            author: assignedUser,
-            commits: [],
-          },
-        ],
-      },
     });
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/users/`,
@@ -148,10 +198,6 @@ describe('GroupHeaderAssigneeSelector', () => {
     MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/events/${event.id}/owners/`,
       body: {owners: [], rule: ['path', ''], rules: []},
-    });
-    MockApiClient.addMockResponse({
-      url: `/projects/${organization.slug}/${project.slug}/events/${event.id}/committers/`,
-      body: {committers: []},
     });
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/users/`,

--- a/static/app/views/issueDetails/header/assigneeSelector.tsx
+++ b/static/app/views/issueDetails/header/assigneeSelector.tsx
@@ -25,7 +25,6 @@ import type {Project} from 'sentry/types/project';
 import {buildTeamId} from 'sentry/utils';
 import {useProjectMembersQueryOptions} from 'sentry/utils/members/projectMembers';
 import {selectUsersFromMembers} from 'sentry/utils/members/shared';
-import {useCommitters} from 'sentry/utils/useCommitters';
 import {useIssueEventOwners} from 'sentry/utils/useIssueEventOwners';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useUser} from 'sentry/utils/useUser';
@@ -116,16 +115,16 @@ export function GroupHeaderAssigneeSelector({
     eventId: event?.id ?? '',
     projectSlug: project.slug,
   });
-  const {data: committersResponse} = useCommitters({
-    eventId: event?.id ?? '',
-    projectSlug: project.slug,
-    group,
+  const {data: memberList = []} = useQuery({
+    ...useProjectMembersQueryOptions([project.id]),
+    select: resp => selectUsersFromMembers(resp.json),
   });
 
   const owners = getOwnerList(
-    committersResponse?.committers ?? [],
+    group.owners ?? [],
     eventOwners,
-    group.assignedTo
+    group.assignedTo,
+    memberList
   );
 
   return (
@@ -172,21 +171,12 @@ export function GroupHeaderAssigneeCommandPaletteAction({
     eventId: event?.id ?? '',
     projectSlug: project.slug,
   });
-  const {data: committersResponse} = useCommitters({
-    eventId: event?.id ?? '',
-    projectSlug: project.slug,
-    group,
-  });
   const {data: members = []} = useQuery({
     ...useProjectMembersQueryOptions([project.id]),
     select: resp => selectUsersFromMembers(resp.json),
   });
 
-  const owners = getOwnerList(
-    committersResponse?.committers ?? [],
-    eventOwners,
-    group.assignedTo
-  );
+  const owners = getOwnerList(group.owners ?? [], eventOwners, group.assignedTo, members);
   const currentAssigneeIcon = group.assignedTo ? (
     <ActorAvatar actor={group.assignedTo} size={16} hasTooltip={false} />
   ) : (

--- a/static/app/views/issueDetails/header/getOwnerList.tsx
+++ b/static/app/views/issueDetails/header/getOwnerList.tsx
@@ -1,7 +1,6 @@
 import {t} from 'sentry/locale';
 import type {Actor} from 'sentry/types/core';
-import type {SuggestedOwnerReason} from 'sentry/types/group';
-import type {Commit, Committer} from 'sentry/types/integrations';
+import type {SuggestedOwner, SuggestedOwnerReason} from 'sentry/types/group';
 import type {Team} from 'sentry/types/organization';
 import type {User} from 'sentry/types/user';
 import {toTitleCase} from 'sentry/utils/string/toTitleCase';
@@ -42,8 +41,7 @@ function findMatchedRules(
 
 type IssueOwner = {
   actor: Actor;
-  source: 'codeowners' | 'projectOwnership' | 'suspectCommit';
-  commits?: Commit[];
+  source: 'codeowners' | 'projectOwnership' | 'seerSuggested' | 'suspectCommit';
   rules?: Array<[string, string]> | null;
 };
 export interface EventOwners {
@@ -53,8 +51,12 @@ export interface EventOwners {
 }
 
 function getSuggestedReason(owner: IssueOwner) {
-  if (owner.commits) {
+  if (owner.source === 'suspectCommit') {
     return t('Suspect commit author');
+  }
+
+  if (owner.source === 'seerSuggested') {
+    return t('Seer Suggestion');
   }
 
   if (owner.rules?.length) {
@@ -79,9 +81,12 @@ type AssignableTeam = {
 };
 
 /**
- * Combine the committer and ownership data into a single array, merging
- * users who are both owners based on having commits, and owners matching
- * project ownership rules into one array.
+ * Combine the owners Sentry recorded against the group — suspect commit authors
+ * and Seer suggestions — with the ownership rules matched by the current event,
+ * merging users who appear in both into a single suggestion.
+ *
+ * Group owners are only surfaced when they resolve to someone in `memberList`,
+ * since an actor who isn't a project member can't be assigned the issue.
  *
  * ### The return array will include objects of the format:
  *
@@ -90,28 +95,36 @@ type AssignableTeam = {
  *    type,              # Either user or team
  *    {User},            # API expanded user object
  *    {email, id, name}  # Sentry user which is *not* expanded
- *    {email, name}      # Unidentified user (from commits)
  *    {id, name},        # Sentry team (check `type`)
  *   >,
- * ```
- *
- * ### One or both of commits and rules will be present
- *
- * ```ts
- *   commits: [...]  # List of commits made by this owner
- *   rules:   [...]  # Project rules matched for this owner
+ *   rules: [...]        # Project rules matched for this owner
  * ```
  */
 export function getOwnerList(
-  committers: Committer[],
+  groupOwners: SuggestedOwner[],
   eventOwners: EventOwners | undefined,
-  assignedTo: Actor | null
+  assignedTo: Actor | null,
+  memberList: User[] = []
 ): Array<Omit<SuggestedAssignee, 'assignee'>> {
-  const owners: IssueOwner[] = committers.map(commiter => ({
-    actor: {...commiter.author, type: 'user'},
-    commits: commiter.commits,
-    source: 'suspectCommit',
-  }));
+  const owners: IssueOwner[] = [];
+
+  groupOwners.forEach(({owner, type}) => {
+    if (type !== 'suspectCommit' && type !== 'seerSuggested') {
+      return;
+    }
+
+    const [actorType, actorId] = owner.split(':');
+    const member =
+      actorType === 'user' ? memberList.find(user => user.id === actorId) : undefined;
+    if (!member || owners.some(existing => existing.actor.id === member.id)) {
+      return;
+    }
+
+    owners.push({
+      actor: {id: member.id, type: 'user', name: member.name, email: member.email},
+      source: type,
+    });
+  });
 
   eventOwners?.owners.forEach(owner => {
     const matchingRule = findMatchedRules(eventOwners?.rules || [], owner);
@@ -122,7 +135,7 @@ export function getOwnerList(
     };
 
     const existingIdx =
-      committers.length > 0 && owner.email && owner.type === 'user'
+      owner.email && owner.type === 'user'
         ? owners.findIndex(o => o.actor.email === owner.email)
         : -1;
     if (existingIdx > -1) {


### PR DESCRIPTION
Previously, the `SUGGESTED` assignee dropdown section was populated with live-calculated ownership rules, merged with suspect-commit authors coming from the detailed suspect-commits endpoint `/projects/{org_slug}/{project_slug}/events/{event_id}/committers/`, which is used to fetch the commits themselves. But there was no existing pathway for "Seer Suggested" assignees to make it to the dropdown. So, switch to pulling suspect-commit authors AND seer-suggested assignees from the `/organizations/{org_slug}/issues/{issue_id}/?expand=owners` endpoint, using `group.owners` for both.

This lets us remove a bunch of mock responses from tests.

Optional but nice-to-have: while we're here, tweak the logic in `AssigneeSelectorDropdown.getSuggestedAssignees` to be a little shorter and more straightforward: First, build up the suggested owners list, normalizing it from different sources (`group.owners` vs `owners` if passed in), then filter it based on finding the member/team in those currently assignable by the user. Not strictly necessary for this change, but while I was here it looked like worthwhile cleanup.

Recommend viewing with [whitespace changes hidden](https://github.com/getsentry/sentry/pull/121251/changes?w=1)

<img width="396" height="704" alt="Screenshot 2026-08-04 at 2 00 44 PM" src="https://github.com/user-attachments/assets/080b44bd-c9ff-4582-a067-521bf84bd9d3" />

<img width="1436" height="818" alt="Screenshot 2026-08-04 at 2 03 04 PM" src="https://github.com/user-attachments/assets/3d664833-ac37-4e11-8007-53d9db1d1b2e" />

Resolves ISWF-3208