### PR TITLE
feat(migrations): Make drift check reconstitute pending safe-deletes

### DIFF
--- a/.github/workflows/migrations-drift.yml
+++ b/.github/workflows/migrations-drift.yml
@@ -53,6 +53,15 @@ jobs:
       - name: capture database schema before
         run: docker exec postgres-postgres-1 bash -c 'pg_dumpall -U postgres -s --restrict-key=driftcheck' > schema-before
 
+      # Must run before "squash migrations": squash deletes the sequential
+      # migration files, which is the only place the pending-deletion registry
+      # is populated. Safe-deleted columns/tables (SafeRemoveField/SafeDeleteModel
+      # with MOVE_TO_PENDING) are kept in the real DB but absent from the
+      # regenerated model-state schema, so we capture the DDL that reconstitutes
+      # them and replay it after the squashed apply below.
+      - name: capture pending-deletion DDL
+        run: sentry django pending_deletion_ddl dump --out pending-deletions.json
+
       - name: clear db
         run: make drop-db create-db
 
@@ -63,6 +72,13 @@ jobs:
         env:
           SENTRY_NO_CREATE_DEFAULT_PROJECT: 1
         run: make drop-db apply-migrations
+
+      - name: replay pending-deletion DDL
+        run: sentry django pending_deletion_ddl apply pending-deletions.json
+
+      - name: print pending-deletion DDL on failure
+        if: failure()
+        run: cat pending-deletions.json || true
 
       - name: capture database schema after
         run: docker exec postgres-postgres-1 bash -c 'pg_dumpall -U postgres -s --restrict-key=driftcheck' > schema-after

--- a/src/sentry/management/commands/pending_deletion_ddl.py
+++ b/src/sentry/management/commands/pending_deletion_ddl.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from django.core.management.base import BaseCommand, CommandParser
+from django.db import connections, router
+from django.db.backends.base.base import BaseDatabaseWrapper
+from django.db.migrations.loader import MigrationLoader
+from django.db.migrations.state import ProjectState
+
+from sentry.utils import json
+
+LOCKFILE = "migrations_lockfile.txt"
+
+
+def squashed_apps_from_lockfile(contents: str) -> set[str]:
+    apps = set()
+    for line in contents.splitlines():
+        if ": " not in line:
+            continue
+        app, current = line.split(": ", 1)
+        if current[4:14] == "_squashed_":
+            continue
+        apps.add(app.strip())
+    return apps
+
+
+def collect_pending_deletion_ddl(
+    state: ProjectState,
+    connection: BaseDatabaseWrapper,
+    squashed_apps: Iterable[str],
+) -> list[str]:
+    squashed = {app.lower() for app in squashed_apps}
+    pending_models = getattr(state, "pending_deletion_models", {})
+    pending_fields = getattr(state, "pending_deletion_fields", {})
+
+    alias = connection.alias
+    with connection.schema_editor(collect_sql=True, atomic=False) as schema_editor:
+        for (app_label, model_name), model in sorted(pending_models.items()):
+            if app_label not in squashed:
+                continue
+            if not router.allow_migrate_model(alias, model):
+                continue
+            schema_editor.create_model(model)
+
+        for (app_label, model_name, _field_name), field in sorted(pending_fields.items()):
+            if app_label not in squashed:
+                continue
+            if (app_label, model_name) in state.models:
+                model = state.apps.get_model(app_label, model_name)
+            elif (app_label, model_name) in pending_models:
+                # The model is itself pending: create_model above emitted its table
+                # from a snapshot taken after this field was removed from state, so
+                # the column is missing and must be added back explicitly.
+                model = pending_models[(app_label, model_name)]
+            else:
+                continue
+            if not router.allow_migrate_model(alias, model):
+                continue
+            schema_editor.add_field(model, field)
+
+    return schema_editor.collected_sql
+
+
+def _dump(squashed_apps: set[str]) -> dict[str, list[str]]:
+    loader = MigrationLoader(None, ignore_no_migrations=True)
+    state = loader.project_state(nodes=None, at_end=True)
+    result = {}
+    for alias in connections:
+        sql = collect_pending_deletion_ddl(state, connections[alias], squashed_apps)
+        if sql:
+            result[alias] = sql
+    return result
+
+
+class Command(BaseCommand):
+    help = "Emit or replay DDL that reconstitutes pending safe-deletion columns/tables."
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        sub = parser.add_subparsers(dest="action", required=True)
+        dump = sub.add_parser("dump", help="Write pending-deletion DDL to a JSON file.")
+        dump.add_argument("--out", required=True)
+        apply_ = sub.add_parser("apply", help="Replay pending-deletion DDL from a JSON file.")
+        apply_.add_argument("path")
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        if options["action"] == "dump":
+            with open(LOCKFILE) as f:
+                squashed_apps = squashed_apps_from_lockfile(f.read())
+            with open(options["out"], "w") as f:
+                json.dump(_dump(squashed_apps), f)
+            return
+
+        with open(options["path"]) as f:
+            by_alias = json.load(f)
+        for alias, statements in by_alias.items():
+            with connections[alias].cursor() as cursor:
+                for statement in statements:
+                    cursor.execute(statement)

--- a/src/sentry/new_migrations/monkey/state.py
+++ b/src/sentry/new_migrations/monkey/state.py
@@ -17,7 +17,7 @@ class SentryProjectState(ProjectState):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.pending_deletion_models: dict[tuple[str, str], type[Model]] = {}
-        self.pending_deletion_fields: dict[tuple[str, str, str], type[Field]] = {}
+        self.pending_deletion_fields: dict[tuple[str, str, str], Field] = {}
 
     def get_pending_deletion_model(self, app_label: str, model_name: str) -> type[Model]:
         model_key = (app_label.lower(), model_name.lower())
@@ -28,9 +28,7 @@ class SentryProjectState(ProjectState):
             )
         return self.pending_deletion_models[model_key]
 
-    def get_pending_deletion_field(
-        self, app_label: str, model_name: str, field_name: str
-    ) -> type[Field]:
+    def get_pending_deletion_field(self, app_label: str, model_name: str, field_name: str) -> Field:
         field_key = (app_label.lower(), model_name.lower(), field_name.lower())
         if field_key not in self.pending_deletion_fields:
             raise UnsafeOperationException(

--- a/tests/sentry/management/commands/test_pending_deletion_ddl.py
+++ b/tests/sentry/management/commands/test_pending_deletion_ddl.py
@@ -1,0 +1,123 @@
+from unittest import mock
+
+from django.db import connections
+from django.db.migrations.state import ModelState
+from django.db.utils import DEFAULT_DB_ALIAS
+
+from sentry.management.commands.pending_deletion_ddl import (
+    collect_pending_deletion_ddl,
+    squashed_apps_from_lockfile,
+)
+from sentry.models.organization import Organization
+from sentry.new_migrations.monkey.state import DeletionAction, SentryProjectState
+from sentry.testutils.cases import TestCase
+
+
+class CollectPendingDeletionDDLTest(TestCase):
+    def _state_with_model(self, model: type) -> SentryProjectState:
+        state = SentryProjectState()
+        state.add_model(ModelState.from_model(model))
+        return state
+
+    def test_pending_field_emits_add_column(self) -> None:
+        state = self._state_with_model(Organization)
+        field = Organization._meta.get_field("is_test")
+        state.pending_deletion_fields[("sentry", "organization", "is_test")] = field
+
+        sql = collect_pending_deletion_ddl(
+            state, connections[DEFAULT_DB_ALIAS], squashed_apps={"sentry"}
+        )
+
+        assert any('ADD COLUMN "is_test"' in stmt and "sentry_organization" in stmt for stmt in sql)
+
+    def test_field_in_unsquashed_app_is_skipped(self) -> None:
+        state = self._state_with_model(Organization)
+        field = Organization._meta.get_field("is_test")
+        state.pending_deletion_fields[("sentry", "organization", "is_test")] = field
+
+        sql = collect_pending_deletion_ddl(
+            state, connections[DEFAULT_DB_ALIAS], squashed_apps={"getsentry"}
+        )
+
+        assert sql == []
+
+    def test_pending_field_on_removed_model_is_skipped(self) -> None:
+        state = SentryProjectState()
+        field = Organization._meta.get_field("is_test")
+        state.pending_deletion_fields[("sentry", "organization", "is_test")] = field
+
+        sql = collect_pending_deletion_ddl(
+            state, connections[DEFAULT_DB_ALIAS], squashed_apps={"sentry"}
+        )
+
+        assert sql == []
+
+    def test_pending_indexed_field_emits_dependent_index(self) -> None:
+        state = self._state_with_model(Organization)
+        field = Organization._meta.get_field("slug")
+        state.pending_deletion_fields[("sentry", "organization", "slug")] = field
+
+        sql = collect_pending_deletion_ddl(
+            state, connections[DEFAULT_DB_ALIAS], squashed_apps={"sentry"}
+        )
+
+        assert any('ADD COLUMN "slug"' in stmt for stmt in sql)
+        assert any("CREATE INDEX" in stmt and "slug" in stmt for stmt in sql)
+
+    def test_pending_model_emits_create_table(self) -> None:
+        state = SentryProjectState()
+        state.pending_deletion_models[("sentry", "organization")] = Organization
+
+        sql = collect_pending_deletion_ddl(
+            state, connections[DEFAULT_DB_ALIAS], squashed_apps={"sentry"}
+        )
+
+        assert any("CREATE TABLE" in stmt and "sentry_organization" in stmt for stmt in sql)
+
+    def test_field_pending_before_its_model_is_reconstituted(self) -> None:
+        state = SentryProjectState()
+        state.add_model(ModelState.from_model(Organization))
+        state.remove_field(
+            "sentry", "organization", "is_test", deletion_action=DeletionAction.MOVE_TO_PENDING
+        )
+        state.remove_model("sentry", "organization", deletion_action=DeletionAction.MOVE_TO_PENDING)
+
+        sql = collect_pending_deletion_ddl(
+            state, connections[DEFAULT_DB_ALIAS], squashed_apps={"sentry"}
+        )
+
+        assert any("CREATE TABLE" in stmt and "sentry_organization" in stmt for stmt in sql)
+        assert any('ADD COLUMN "is_test"' in stmt for stmt in sql)
+
+    def test_model_not_routed_to_alias_is_skipped(self) -> None:
+        state = self._state_with_model(Organization)
+        field = Organization._meta.get_field("is_test")
+        state.pending_deletion_fields[("sentry", "organization", "is_test")] = field
+        state.pending_deletion_models[("sentry", "organization")] = Organization
+
+        with mock.patch(
+            "sentry.management.commands.pending_deletion_ddl.router.allow_migrate_model",
+            return_value=False,
+        ):
+            sql = collect_pending_deletion_ddl(
+                state, connections[DEFAULT_DB_ALIAS], squashed_apps={"sentry"}
+            )
+
+        assert sql == []
+
+
+class SquashedAppsFromLockfileTest(TestCase):
+    def test_includes_unsquashed_and_excludes_already_squashed(self) -> None:
+        contents = (
+            "ai_monitoring: 0001_create_ai_conversation_metadata\n"
+            "\n"
+            "discover: 0001_squashed_0003_discover_json_field\n"
+            "\n"
+            "explore: 0010_remove_last_received_from_attribute_context\n"
+        )
+
+        apps = squashed_apps_from_lockfile(contents)
+
+        assert "ai_monitoring" in apps
+        assert "explore" in apps
+        assert "discover" not in apps

--- a/tools/migrations/compare.py
+++ b/tools/migrations/compare.py
@@ -83,10 +83,9 @@ def main() -> int:
         green = "\033[32m"
         red = "\033[31m"
         bold = "\033[1m"
-        subtle = "\033[2m"
         reset = "\033[m"
     else:
-        green = red = bold = subtle = reset = ""
+        green = red = bold = reset = ""
 
     with open(args.before) as f:
         before = norm(f.read())
@@ -125,7 +124,6 @@ def main() -> int:
             f"{''.join(differences)}\n"
             f"---\n\n"
             f"{bold}migrations drift detected!{reset}\n\n"
-            f"{subtle}(drift due to step 1 of deletion is normal){reset}\n\n"
             f"^^^ diff printed above ^^^"
         )
     else:


### PR DESCRIPTION
## Summary

The `migrations-drift` check builds the post-squash schema from Django **model state** and diffs it against the **real** sequential schema. A column or table removed via `SafeRemoveField`/`SafeDeleteModel` with `MOVE_TO_PENDING` (step 1 of the safe two-step deletion) is kept in the real DB but dropped from model state — so it shows up as permanent drift on **every** migration PR. Today the check prints "(drift due to step 1 of deletion is normal)" and is simply eyeballed and ignored, which defeats its purpose.

This makes the check account for pending safe-deletes automatically.

## Approach: reconstitute, don't suppress

Rather than teach the differ to *ignore* pending-deleted columns (an ignore-list would also **mask genuine drift** — a real missing column or type mismatch), we **rebuild** them so both schemas genuinely match:

1. A new `pending_deletion_ddl` management command reads the pending-deletion registry (`SentryProjectState.pending_deletion_fields` / `pending_deletion_models`) at the migration-graph head and uses `schema_editor(collect_sql=True)` to emit the exact `ADD COLUMN` / `CREATE TABLE` DDL.
2. CI runs `dump` **before** the squash step (which deletes the sequential migrations that populate the registry) and `apply` **after** applying the squashed migrations.
3. `compare.py` is otherwise untouched (stays a Django-free text differ); only the now-obsolete "step 1 of deletion is normal" hint is removed.

## Why this is correct

- **Cannot mask real drift.** The replayed DDL is generated from model state, never read from the live DB. If the real column has the wrong type/nullability, or is genuinely missing, the diff still fires.
- **Dependent artifacts come for free.** Indexes, constraints, defaults, and sequences tied to a pending column/table are rebuilt by Postgres from the historical field/model — no name-hash reproduction.
- **Correctly scoped.** Extraction is limited to apps the squash regenerates (unsquashed in `migrations_lockfile.txt`), so it stays correct in getsentry, which squashes a different app set. This avoids a "column already exists" failure there.

## Testing

- New `tests/sentry/management/commands/test_pending_deletion_ddl.py`: pending field → `ADD COLUMN`; dependent index emitted; unsquashed-app skip; pending-field-on-removed-model skip (registry leak guard); pending model → `CREATE TABLE`; lockfile app-scoping.
- Verified end-to-end against the real repo: `dump` emits exactly the two current pending columns (`explore.last_received`), correctly scoped.
- Existing `new_migrations` tests still pass; mypy + prek clean.

## Scope / rollout

- The current real pending set is just the two `explore.last_received` columns (already being dropped in a separate stack). This mechanism is for the **next** safe-delete and is covered by synthetic tests rather than the live (soon-empty) pending set.
- The job stays **non-blocking** in this PR. A follow-up can add the getsentry workflow steps (command is inherited) and a staleness policy gate (fail if a `MOVE_TO_PENDING` sits without its `DELETE` beyond N migrations) — the piece that keeps the signal deliberate rather than silently green.
- Also fixes a latent annotation bug in `SentryProjectState.pending_deletion_fields` (typed `type[Field]`, stores a `Field` instance).
