### PR TITLE
fix(explore): keep now up to date via ref instead of one-time useState

### DIFF
--- a/static/app/views/explore/releases/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/explore/releases/releaseBubbles/useReleaseBubbles.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo, useRef} from 'react';
+import {useCallback, useEffect, useMemo, useRef} from 'react';
 import {useTheme, type Theme} from '@emotion/react';
 import type {
   CustomSeriesOption,
@@ -393,11 +393,15 @@ export function useReleaseBubbles({
   // case of relative date selection). This is used for the tooltip to show the
   // proper timestamp for releases.
   const endTimeToUse = (datetime || selection.datetime).end;
+  const nowRef = useRef(Date.now());
+  useEffect(() => {
+    nowRef.current = Date.now();
+  });
   const releasesMaxTime = useMemo(
     () =>
       defined(endTimeToUse) && !Array.isArray(endTimeToUse)
         ? new Date(endTimeToUse).getTime()
-        : Date.now(),
+        : nowRef.current,
     [endTimeToUse]
   );
   const chartRef = useRef<ReactEchartsRef | null>(null);


### PR DESCRIPTION
`useReleaseBubbles` captured `Date.now()` once at mount via a lazy `useState` initializer, so the `now` fallback used for `releasesMaxTime` never advanced for the lifetime of the component. On long-lived pages this made the chart/tooltip fallback timestamp go stale.

`now` is now tracked in a ref that's updated every render via a dependency-less `useEffect`, so it stays current on every re-render without itself triggering one (unlike `useState`, which would cause an infinite render loop if updated unconditionally in an effect).
