### PR TITLE
fix(seer): Resolve default branch before Cursor agent launch

### DIFF
--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -29,7 +29,6 @@ from sentry.analytics.events.autofix_events import (
 )
 from sentry.constants import ENABLE_SEER_CODING_DEFAULT, DataCategory
 from sentry.integrations.services.integration import integration_service
-from sentry.scm import factory as scm_factory
 from sentry.seer.agent.client import SeerAgentClient
 from sentry.seer.agent.client_models import SeerRunState
 from sentry.seer.autofix.artifact_schemas import (
@@ -342,6 +341,7 @@ def _resolve_default_branch(
 ) -> str | None:
     if repo.repository_id is None:
         return None
+    from sentry.scm import factory as scm_factory
 
     try:
         scm = scm_factory.new(group.organization.id, repo.repository_id, referrer.value)

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -29,6 +29,7 @@ from sentry.analytics.events.autofix_events import (
 )
 from sentry.constants import ENABLE_SEER_CODING_DEFAULT, DataCategory
 from sentry.integrations.services.integration import integration_service
+from sentry.scm import factory as scm_factory
 from sentry.seer.agent.client import SeerAgentClient
 from sentry.seer.agent.client_models import SeerRunState
 from sentry.seer.autofix.artifact_schemas import (
@@ -334,6 +335,24 @@ def _get_group_run_state(client: SeerAgentClient, group: Group, run_id: int) -> 
 
     _validate_run_belongs_to_group(state, group)
     return state
+
+
+def _resolve_default_branch(
+    group: Group, repo: SeerRepoDefinition, referrer: AutofixReferrer
+) -> str | None:
+    if repo.repository_id is None:
+        return None
+
+    try:
+        scm = scm_factory.new(group.organization.id, repo.repository_id, referrer.value)
+        if isinstance(scm, GetRepositoryProtocol):
+            return scm.get_repository()["data"]["default_branch"]
+    except Exception:
+        logger.exception(
+            "autofix.resolve_default_branch_failed",
+            extra={"repo": f"{repo.owner}/{repo.name}", "group_id": group.id},
+        )
+    return None
 
 
 def _build_base_shas_metadata(group: Group, referrer: AutofixReferrer) -> str | None:
@@ -765,6 +784,9 @@ def trigger_coding_agent_handoff(
     state = _get_group_run_state(client, group, run_id)
 
     repo = _get_relevant_repo(state, repo_definitions, run_id, group)
+
+    if not repo.branch_name:
+        repo.branch_name = _resolve_default_branch(group, repo, referrer)
 
     short_id = group.qualified_short_id
     issue_url = group.get_absolute_url() if short_id else None

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -1431,6 +1431,28 @@ class TestTriggerCodingAgentHandoff(TestCase):
         repos = mock_client.launch_coding_agents.call_args.kwargs["repos"]
         assert repos[0].branch_name == "release/v2"
 
+    @patch("sentry.seer.autofix.autofix_agent._resolve_default_branch", return_value="main")
+    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    def test_trigger_coding_agent_handoff_resolves_default_branch_when_empty(
+        self, mock_client_class, mock_resolve
+    ):
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.get_run.return_value = self._make_run_state()
+        mock_client.launch_coding_agents.return_value = {"successes": [], "failures": []}
+        self._make_repo_and_projectrepo(external_id="1", branch_name="")
+
+        trigger_coding_agent_handoff(
+            group=self.group,
+            run_id=123,
+            referrer=AutofixReferrer.UNKNOWN,
+            integration_id=456,
+        )
+
+        mock_resolve.assert_called_once()
+        repos = mock_client.launch_coding_agents.call_args.kwargs["repos"]
+        assert repos[0].branch_name == "main"
+
 
 class TestTriggerPushChanges(TestCase):
     """Tests for trigger_push_changes function."""


### PR DESCRIPTION
## Summary
- When `SeerRepoDefinition.branch_name` is empty, the Cursor API receives no `ref` and fails with `400 "Failed to determine repository default branch"` (SENTRY-5KB7, 81 occurrences, last seen today)
- The existing `or None` guard in the Cursor client omits `ref` from the payload, but Cursor can't resolve the default branch itself
- This fix resolves the GitHub default branch via SCM before launching the coding agent, so Cursor always gets a valid `ref`

## Changes
- Added `_resolve_default_branch()` helper in `autofix_agent.py` — fetches the default branch from GitHub via the SCM integration (same pattern as `_build_base_shas_metadata`)
- Called it in `trigger_coding_agent_handoff()` when `repo.branch_name` is falsy, before passing to `launch_coding_agents`

Fixes SENTRY-5KB7

## Test plan
- [x] Added test for empty `branch_name` resolution path
- [x] All 23 existing handoff tests pass
- [x] ruff and mypy clean