### PR TITLE
ref: Remove unnecessary insights-query-date-range-limit check

### DIFF
--- a/static/gsApp/components/features/insightsDateRangeQueryLimitFooter.spec.tsx
+++ b/static/gsApp/components/features/insightsDateRangeQueryLimitFooter.spec.tsx
@@ -1,57 +1,37 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {BillingConfigFixture} from 'getsentry-test/fixtures/billingConfig';
-import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
-import {PlanTier} from 'getsentry-test/planTier';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {InsightsDateRangeQueryLimitFooter} from 'getsentry/components/features/insightsDateRangeQueryLimitFooter';
 
-describe('InsightsUpsellPage', () => {
-  const organization = OrganizationFixture();
-  const subscription = SubscriptionFixture({
-    organization,
-    plan: 'am3_team',
-    isFree: true,
-  });
+describe('InsightsDateRangeQueryLimitFooter', () => {
+  const DESCRIPTION =
+    'To view more trends for your Performance data, upgrade to Business.';
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();
-    MockApiClient.addMockResponse({
-      url: `/customers/${organization.slug}/billing-config/`,
-      body: BillingConfigFixture(PlanTier.AM3),
-    });
+    // The nested footer is withSubscription-wrapped and loads the subscription.
     MockApiClient.addMockResponse({
       url: '/customers/org-slug/',
       body: {},
     });
-
-    subscription.planDetails.features = [];
   });
 
-  it('renders if plan includes feature', async () => {
-    subscription.planDetails.features = ['insights-query-date-range-limit'];
-
-    render(<InsightsDateRangeQueryLimitFooter subscription={subscription} />, {
-      organization,
+  it('renders if the org has the feature', async () => {
+    render(<InsightsDateRangeQueryLimitFooter />, {
+      organization: OrganizationFixture({
+        features: ['insights-query-date-range-limit'],
+      }),
     });
 
-    expect(
-      await screen.findByText(
-        'To view more trends for your Performance data, upgrade to Business.'
-      )
-    ).toBeInTheDocument();
+    expect(await screen.findByText(DESCRIPTION)).toBeInTheDocument();
   });
 
-  it('does not render if feature is not included', () => {
-    render(<InsightsDateRangeQueryLimitFooter subscription={subscription} />, {
-      organization,
+  it('does not render if the org lacks the feature', () => {
+    render(<InsightsDateRangeQueryLimitFooter />, {
+      organization: OrganizationFixture({features: []}),
     });
 
-    expect(
-      screen.queryByText(
-        'To view more trends for your Performance data, upgrade to Business.'
-      )
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(DESCRIPTION)).not.toBeInTheDocument();
   });
 });

--- a/static/gsApp/components/features/insightsDateRangeQueryLimitFooter.tsx
+++ b/static/gsApp/components/features/insightsDateRangeQueryLimitFooter.tsx
@@ -1,15 +1,7 @@
 import {t} from 'sentry/locale';
-import type {Organization} from 'sentry/types/organization';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 import DateRangeQueryLimitFooter from 'getsentry/components/features/dateRangeQueryLimitFooter';
-import {withSubscription} from 'getsentry/components/withSubscription';
-import {useBillingConfig} from 'getsentry/hooks/useBillingConfig';
-import type {Subscription} from 'getsentry/types';
-
-interface Props {
-  subscription: Subscription;
-}
 
 const DESCRIPTION = t(
   'To view more trends for your Performance data, upgrade to Business.'
@@ -17,11 +9,10 @@ const DESCRIPTION = t(
 
 const QUERY_LIMIT_REFERRER = 'insights-query-limit-footer';
 
-export function InsightsDateRangeQueryLimitFooter({subscription}: Props) {
+export function InsightsDateRangeQueryLimitFooter() {
   const organization = useOrganization();
-  const shouldShowQueryLimitFooter = useHasRequiredFeatures(organization, subscription);
 
-  if (!shouldShowQueryLimitFooter) {
+  if (!organization.features.includes('insights-query-date-range-limit')) {
     return null;
   }
 
@@ -29,28 +20,3 @@ export function InsightsDateRangeQueryLimitFooter({subscription}: Props) {
     <DateRangeQueryLimitFooter description={DESCRIPTION} source={QUERY_LIMIT_REFERRER} />
   );
 }
-
-const useHasRequiredFeatures = (
-  organization: Organization,
-  subscription: Subscription
-) => {
-  const {data: billingConfig} = useBillingConfig({organization});
-  const subscriptionPlan = subscription.planDetails;
-  const subscriptionPlanFeatures = subscriptionPlan?.features ?? [];
-
-  const trialPlan = subscription.trialPlan
-    ? billingConfig?.planList?.find(plan => plan.id === subscription.trialPlan)
-    : undefined;
-  const trialPlanFeatures = trialPlan?.features ?? [];
-
-  const enabledFeatures = [
-    ...new Set([
-      ...subscriptionPlanFeatures,
-      ...trialPlanFeatures,
-      ...organization.features,
-    ]),
-  ];
-  return enabledFeatures.includes('insights-query-date-range-limit');
-};
-
-export default withSubscription(InsightsDateRangeQueryLimitFooter, {noLoader: true});

--- a/static/gsApp/registerOverrides.tsx
+++ b/static/gsApp/registerOverrides.tsx
@@ -20,7 +20,7 @@ import DisabledDateRange from 'getsentry/components/features/disabledDateRange';
 import {DisabledDiscardGroup} from 'getsentry/components/features/disabledDiscardGroup';
 import {DisabledRateLimits} from 'getsentry/components/features/disabledRateLimits';
 import DisabledSelectorItems from 'getsentry/components/features/disabledSelectorItems';
-import InsightsDateRangeQueryLimitFooter from 'getsentry/components/features/insightsDateRangeQueryLimitFooter';
+import {InsightsDateRangeQueryLimitFooter} from 'getsentry/components/features/insightsDateRangeQueryLimitFooter';
 import {PerformanceNewProjectPrompt} from 'getsentry/components/features/performanceNewProjectPrompt';
 import {ProjectPerformanceScoreCard} from 'getsentry/components/features/projectPerformanceScoreCard';
 import {HelpSearchFooter} from 'getsentry/components/helpSearchFooter';


### PR DESCRIPTION
The `insights-query-date-range-limit` feature is not used on any plans, so deleted the plan check here and left only the organization feature check