### PR TITLE
fix(search): Add mean severity aggregation option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -854,6 +854,12 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
+    "snuba.search.recommended.severity-aggregate",
+    type=String,
+    default="max",
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
     "snuba.search.recommended.user-impact-weight",
     default=0.05,
     flags=FLAG_AUTOMATOR_MODIFIABLE,

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -854,15 +854,21 @@ def _recommended_aggregation(
     total_3d = f"countIf(lessOrEquals(minus(now(), {timestamp_column}), {3 * 24 * hour}))"
     spike = f"least(1.0, divide({recent_6h}, plus({total_3d}, 1)))"
 
-    # Severity: max log level - maps fatal=1.0, error=0.75, warning=0.5, info=0.25, debug=0.0
+    # Severity: maps fatal=1.0, error=0.75, warning=0.5, info=0.25, debug=0.0
     severity_weight = options.get("snuba.search.recommended.severity-weight")
-    severity = (
-        "max(multiIf("
+    severity_signal = (
+        "multiIf("
         "equals(level, 'fatal'), 1.0, "
         "equals(level, 'error'), 0.75, "
         "equals(level, 'warning'), 0.5, "
         "equals(level, 'info'), 0.25, "
-        "0.0))"
+        "0.0)"
+    )
+    severity_aggregate = options.get("snuba.search.recommended.severity-aggregate")
+    severity = (
+        f"divide(sum({severity_signal}), count())"
+        if severity_aggregate == "mean"
+        else f"max({severity_signal})"
     )
 
     # User impact: ln(uniq(tags[sentry:user]) + 1)/ln(1001) - maps 1→~0, 10→0.33, 100→0.67, 1000→1.0

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -4183,6 +4183,83 @@ class EventsRecommendedSortTest(TestCase, SharedSnubaMixin, OccurrenceTestMixin)
         # Fatal event should score higher despite being slightly older
         assert scores[fatal_group.id] > scores[info_group.id]
 
+    def test_recommended_sort_severity_mean_uses_event_distribution(self) -> None:
+        timestamp = before_now(hours=1).isoformat()
+
+        for i in range(20):
+            self.store_event(
+                data={
+                    "fingerprint": ["mostly-error-group"],
+                    "event_id": f"a{i:031x}",
+                    "message": "mostly error",
+                    "timestamp": timestamp,
+                    "level": "error",
+                },
+                project_id=self.project.id,
+            )
+            self.store_event(
+                data={
+                    "fingerprint": ["mostly-fatal-group"],
+                    "event_id": f"b{i:031x}",
+                    "message": "mostly fatal",
+                    "timestamp": timestamp,
+                    "level": "fatal",
+                },
+                project_id=self.project.id,
+            )
+
+        self.store_event(
+            data={
+                "fingerprint": ["mostly-error-group"],
+                "event_id": "c" * 32,
+                "message": "mostly error",
+                "timestamp": timestamp,
+                "level": "fatal",
+            },
+            project_id=self.project.id,
+        )
+        self.store_event(
+            data={
+                "fingerprint": ["mostly-fatal-group"],
+                "event_id": "d" * 32,
+                "message": "mostly fatal",
+                "timestamp": timestamp,
+                "level": "error",
+            },
+            project_id=self.project.id,
+        )
+
+        mostly_error = Group.objects.get(project=self.project, message="mostly error")
+        mostly_fatal = Group.objects.get(project=self.project, message="mostly fatal")
+        severity_only_options = {
+            "snuba.search.recommended.recency-weight": 0.0,
+            "snuba.search.recommended.spike-weight": 0.0,
+            "snuba.search.recommended.severity-weight": 1.0,
+            "snuba.search.recommended.user-impact-weight": 0.0,
+            "snuba.search.recommended.event-volume-weight": 0.0,
+            "snuba.search.recommended.group-type-boost": {},
+            "snuba.search.recommended.message-penalty-weight": 0.0,
+        }
+
+        with self.options(
+            {
+                **severity_only_options,
+                "snuba.search.recommended.severity-aggregate": "mean",
+            }
+        ):
+            mean_scores = self._recommended_scores([mostly_error.id, mostly_fatal.id])
+
+        with self.options(
+            {
+                **severity_only_options,
+                "snuba.search.recommended.severity-aggregate": "max",
+            }
+        ):
+            max_scores = self._recommended_scores([mostly_error.id, mostly_fatal.id])
+
+        assert mean_scores[mostly_error.id] < mean_scores[mostly_fatal.id]
+        assert max_scores[mostly_error.id] >= max_scores[mostly_fatal.id]
+
     def test_recommended_user_impact(self) -> None:
         base_datetime = before_now(hours=1)
 


### PR DESCRIPTION
Add a gated count-weighted mean for the recommended issue sort severity signal. The new `snuba.search.recommended.severity-aggregate` option accepts `max` or `mean` and defaults to `max`, so this ships as a no-op until the separate automator rollout. Both events and issue-platform variants share the updated aggregation path.