### PR TITLE
ref(replays): remove the Arroyo ingest replay recordings consumers

### DIFF
--- a/bin/mock-replay-recording
+++ b/bin/mock-replay-recording
@@ -3,11 +3,8 @@
 
 Helpful commands:
 
-    - Run the consumer.
-        - `sentry run consumer ingest-replay-recordings --consumer-group 0`
-        - `sentry run consumer ingest-replay-recordings-two-step --consumer-group 0`
     - Check if offsets are committed correctly.
-        - `docker exec -it kafka-kafka-1 kafka-consumer-groups --bootstrap-server localhost:9092 --describe --group 0`
+        - `docker exec -it kafka-kafka-1 kafka-consumer-groups --bootstrap-server localhost:9092 --describe --group sentry-consumer`
 """
 
 import logging

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1556,7 +1556,7 @@ SENTRY_POST_PROCESS_GROUP_APM_SAMPLING = 1 if DEBUG else 0
 # sample rate for all reprocessing tasks (except for the per-event ones)
 SENTRY_REPROCESSING_APM_SAMPLING = 1 if DEBUG else 0
 
-# sample rate for the ingest-replay-recordings processing (consumer and task)
+# sample rate for the ingest-replay-recordings task
 SENTRY_REPLAY_RECORDINGS_CONSUMER_APM_SAMPLING = 0
 
 # ----

--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -145,16 +145,6 @@ def issue_occurrence_options() -> list[click.Option]:
     ]
 
 
-def ingest_replay_recordings_options() -> list[click.Option]:
-    """Return a list of ingest-replay-recordings options."""
-    options = multiprocessing_options(default_max_batch_size=10)
-    options.append(click.Option(["--threads", "num_threads"], type=int, default=4))
-    options.append(
-        click.Option(["--max-pending-futures", "max_pending_futures"], type=int, default=100)
-    )
-    return options
-
-
 def ingest_monitors_options() -> list[click.Option]:
     """Return a list of ingest-monitors options."""
     options = [
@@ -315,11 +305,6 @@ _POST_PROCESS_FORWARDER_OPTIONS = multiprocessing_options(
 
 # consumer name -> consumer definition
 KAFKA_CONSUMERS: Mapping[str, ConsumerDefinition] = {
-    "ingest-replay-recordings": {
-        "topic": Topic.INGEST_REPLAYS_RECORDINGS,
-        "strategy_factory": "sentry.replays.consumers.recording.ProcessReplayRecordingStrategyFactory",
-        "click_options": ingest_replay_recordings_options(),
-    },
     "ingest-monitors": {
         "topic": Topic.INGEST_MONITORS,
         "strategy_factory": "sentry.monitors.consumers.monitor_consumer.StoreMonitorCheckInStrategyFactory",

--- a/src/sentry/replays/consumers/recording.py
+++ b/src/sentry/replays/consumers/recording.py
@@ -1,22 +1,14 @@
 import logging
 import zlib
-from collections.abc import Mapping
 from typing import cast
 
 import sentry_sdk
-from arroyo.backends.kafka.consumer import KafkaPayload
-from arroyo.processing.strategies import RunTaskInThreads
-from arroyo.processing.strategies.abstract import ProcessingStrategy, ProcessingStrategyFactory
-from arroyo.processing.strategies.commit import CommitOffsets
-from arroyo.types import Commit, Message, Partition
-from django.conf import settings
 from sentry_kafka_schemas.codecs import Codec, ValidationError
 from sentry_kafka_schemas.schema_types.ingest_replay_recordings_v1 import ReplayRecording
 from sentry_sdk import set_tag
 
 from sentry import options
 from sentry.conf.types.kafka_definition import Topic, get_topic_codec
-from sentry.replays.lib.cache import AutoCache
 from sentry.replays.usecases.ingest import (
     DropEvent,
     Event,
@@ -25,11 +17,10 @@ from sentry.replays.usecases.ingest import (
     process_recording_event,
     track_recording_metadata,
 )
-from sentry.replays.usecases.ingest.cache import make_has_sent_replays_cache, make_options_cache
 from sentry.replays.usecases.ingest.types import ProcessorContext
 from sentry.services.filestore.gcs import GCS_RETRYABLE_ERRORS
 from sentry.utils import json, metrics
-from sentry.utils.tracing import start_span, trace
+from sentry.utils.tracing import trace
 
 RECORDINGS_CODEC: Codec[ReplayRecording] = get_topic_codec(Topic.INGEST_REPLAYS_RECORDINGS)
 
@@ -38,70 +29,6 @@ logger = logging.getLogger(__name__)
 
 class DropSilently(Exception):
     pass
-
-
-class ProcessReplayRecordingStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
-    def __init__(
-        self,
-        input_block_size: int | None,
-        max_batch_size: int,
-        max_batch_time: int,
-        num_processes: int,
-        output_block_size: int | None,
-        num_threads: int = 4,  # Defaults to 4 for self-hosted.
-        force_synchronous: bool = False,  # Force synchronous runner (only used in test suite).
-        max_pending_futures: int = 100,
-    ) -> None:
-        # For information on configuring this consumer refer to this page:
-        #   https://getsentry.github.io/arroyo/strategies/run_task_with_multiprocessing.html
-        self.input_block_size = input_block_size
-        self.max_batch_size = max_batch_size
-        self.max_batch_time = max_batch_time
-        self.num_processes = num_processes
-        self.num_threads = num_threads
-        self.output_block_size = output_block_size
-        self.force_synchronous = force_synchronous
-        self.max_pending_futures = max_pending_futures
-
-    def create_with_partitions(
-        self,
-        commit: Commit,
-        partitions: Mapping[Partition, int],
-    ) -> ProcessingStrategy[KafkaPayload]:
-        has_sent_replays_cache: AutoCache[int, bool] | None = None
-        options_cache: AutoCache[int, tuple[bool, bool]] | None = None
-
-        if options.get("replay.consumer.enable_new_query_caching_system"):
-            has_sent_replays_cache = make_has_sent_replays_cache()
-            options_cache = make_options_cache()
-
-        context: ProcessorContext = {
-            "has_sent_replays_cache": has_sent_replays_cache,
-            "options_cache": options_cache,
-        }
-
-        return RunTaskInThreads(
-            processing_function=lambda msg: process_and_commit_message(msg, context),
-            concurrency=self.num_threads,
-            max_pending_futures=self.max_pending_futures,
-            next_step=CommitOffsets(commit),
-        )
-
-
-def process_and_commit_message(message: Message[KafkaPayload], context: ProcessorContext) -> None:
-    isolation_scope = sentry_sdk.get_isolation_scope().fork()
-    with sentry_sdk.scope.use_isolation_scope(isolation_scope):
-        with start_span(
-            name="replays.consumer.recording.process_and_commit_message",
-            op="replays.consumer.recording.process_and_commit_message",
-            custom_sampling_context={
-                "sample_rate": settings.SENTRY_REPLAY_RECORDINGS_CONSUMER_APM_SAMPLING
-            },
-            transaction=True,
-        ):
-            processed_message = process_message(message.payload.value)
-            if processed_message:
-                commit_message(processed_message, context)
 
 
 # Processing Task

--- a/src/sentry/replays/lib/kafka.py
+++ b/src/sentry/replays/lib/kafka.py
@@ -33,8 +33,7 @@ def _in_process_replay_recording_task() -> bool:
     That task hands its delivery guarantee to the TaskProducer: the worker only
     acks an activation once all of its producer futures succeed, otherwise the
     task is retried. We scope this to the one task by name so we don't change
-    delivery behavior for anyone else sharing these producers (the arroyo
-    consumer, or any other task that happens to publish).
+    delivery behavior for any other task or caller sharing these producers.
     """
     task = current_task()
     return task is not None and task.taskname == PROCESS_REPLAY_RECORDING_TASK_NAME

--- a/tests/sentry/consumers/test_run.py
+++ b/tests/sentry/consumers/test_run.py
@@ -41,8 +41,6 @@ def test_dlq(consumer_def) -> None:
         "generic-metrics-last-seen-updater",
         "billing-metrics-consumer",
         "ingest-occurrences",
-        "ingest-replay-recordings",
-        "ingest-replay-recordings-two-step",
     ]
 
     consumer_name, defn = consumer_def

--- a/tests/sentry/replays/consumers/test_recording.py
+++ b/tests/sentry/replays/consumers/test_recording.py
@@ -3,31 +3,21 @@ from __future__ import annotations
 import time
 import uuid
 import zlib
-from datetime import datetime
 from unittest.mock import ANY, MagicMock, patch
 
 import msgpack
-from arroyo.backends.kafka import KafkaPayload
-from arroyo.types import BrokerValue, Message, Partition, Topic
 from sentry_kafka_schemas.schema_types.ingest_replay_recordings_v1 import ReplayRecording
 
-from sentry.analytics.events.first_replay_sent import FirstReplaySentEvent
 from sentry.models.organizationonboardingtask import OnboardingTask, OnboardingTaskStatus
-from sentry.replays.consumers.recording import ProcessReplayRecordingStrategyFactory
 from sentry.replays.lib.storage import _make_recording_filename, storage_kv
 from sentry.replays.tasks import process_replay_recording
 from sentry.replays.usecases.pack import unpack
 from sentry.testutils.cases import TransactionTestCase
-from sentry.testutils.helpers.analytics import assert_any_analytics_event
-from sentry.testutils.thread_leaks.pytest import thread_leak_allowlist
 from sentry.utils import json
-from sentry.utils.projectflags import set_project_flag_and_signal
 
 
 class RecordingTestCase(TransactionTestCase):
     replay_id = uuid.uuid4().hex
-    replay_recording_id = uuid.uuid4().hex
-    force_synchronous = True
 
     def get_recording_data(self, segment_id: int) -> memoryview:
         result = storage_kv.get(
@@ -40,47 +30,6 @@ class RecordingTestCase(TransactionTestCase):
         )
         assert result is not None, "Expecting non-None result here"
         return unpack(zlib.decompress(result))[1]
-
-    def get_video_data(self, segment_id: int) -> memoryview | None:
-        result = storage_kv.get(
-            _make_recording_filename(
-                project_id=self.project.id,
-                replay_id=self.replay_id,
-                segment_id=segment_id,
-                retention_days=30,
-            )
-        )
-        if result:
-            return unpack(zlib.decompress(result))[0]
-        return None
-
-    def processing_factory(self) -> ProcessReplayRecordingStrategyFactory:
-        return ProcessReplayRecordingStrategyFactory(
-            input_block_size=1,
-            max_batch_size=1,
-            max_batch_time=1,
-            num_processes=1,
-            num_threads=1,
-            output_block_size=1,
-            force_synchronous=self.force_synchronous,
-        )
-
-    def submit(self, messages: list[ReplayRecording]) -> None:
-        strategy = self.processing_factory().create_with_partitions(lambda x, force=False: None, {})
-        for message in messages:
-            strategy.submit(
-                Message(
-                    BrokerValue(
-                        KafkaPayload(b"key", msgpack.packb(message), [("should_drop", b"1")]),
-                        Partition(Topic("ingest-replay-recordings"), 1),
-                        1,
-                        datetime.now(),
-                    )
-                )
-            )
-        strategy.poll()
-        strategy.join(1)
-        strategy.terminate()
 
     def nonchunked_messages(
         self,
@@ -108,184 +57,10 @@ class RecordingTestCase(TransactionTestCase):
         ]
 
     @patch("sentry.models.OrganizationOnboardingTask.objects.record")
-    @patch("sentry.analytics.record")
     @patch("sentry.replays.usecases.ingest.track_outcome")
-    @patch("sentry.replays.usecases.ingest.report_hydration_error")
-    @thread_leak_allowlist(reason="replays", issue=97033)
-    def test_end_to_end_consumer_processing_old(
-        self,
-        report_hydration_issue: MagicMock,
-        track_outcome: MagicMock,
-        mock_record: MagicMock,
-        mock_onboarding_task: MagicMock,
-    ) -> None:
-        data = [
-            {
-                "type": 5,
-                "data": {
-                    "tag": "breadcrumb",
-                    "payload": {
-                        "category": "replay.hydrate-error",
-                        "timestamp": 1.0,
-                        "data": {"url": "https://sentry.io"},
-                    },
-                },
-            }
-        ]
-        segment_id = 0
-        self.submit(
-            self.nonchunked_messages(
-                message=json.dumps(data).encode(),
-                segment_id=segment_id,
-                compressed=True,
-                replay_event=json.dumps(
-                    {
-                        "type": "replay_event",
-                        "replay_id": self.replay_id,
-                        "timestamp": int(time.time()),
-                    }
-                ).encode(),
-                replay_video=b"hello, world!",
-            )
-        )
-
-        dat = self.get_recording_data(segment_id)
-        assert json.loads(bytes(dat).decode("utf-8")) == data
-        video_data = self.get_video_data(segment_id)
-        assert video_data is not None
-        assert bytes(video_data) == b"hello, world!"
-
-        self.project.refresh_from_db()
-        assert self.project.flags.has_replays
-
-        mock_onboarding_task.assert_called_with(
-            organization_id=self.project.organization_id,
-            task=OnboardingTask.SESSION_REPLAY,
-            status=OnboardingTaskStatus.COMPLETE,
-            date_completed=ANY,
-        )
-
-        assert_any_analytics_event(
-            mock_record,
-            FirstReplaySentEvent(
-                organization_id=self.organization.id,
-                project_id=self.project.id,
-                platform=self.project.platform,
-                user_id=self.organization.default_owner_id,
-            ),
-        )
-
-        assert track_outcome.called
-        assert report_hydration_issue.called
-
-    @patch("sentry.models.OrganizationOnboardingTask.objects.record")
-    @patch("sentry.analytics.record")
-    @patch("sentry.replays.usecases.ingest.track_outcome")
-    @patch("sentry.replays.usecases.ingest.report_hydration_error")
-    @patch(
-        "sentry.replays.usecases.ingest.set_project_flag_and_signal",
-        wraps=set_project_flag_and_signal,
-    )
-    @thread_leak_allowlist(reason="replays", issue=97033)
-    def test_end_to_end_consumer_processing_new(
-        self,
-        set_project_flag_and_signal: MagicMock,
-        report_hydration_issue: MagicMock,
-        track_outcome: MagicMock,
-        mock_record: MagicMock,
-        mock_onboarding_task: MagicMock,
-    ) -> None:
-        data = [
-            {
-                "type": 5,
-                "data": {
-                    "tag": "breadcrumb",
-                    "payload": {
-                        "category": "replay.hydrate-error",
-                        "timestamp": 1.0,
-                        "data": {"url": "https://sentry.io"},
-                    },
-                },
-            }
-        ]
-        segment_id = 0
-
-        with self.options({"replay.consumer.enable_new_query_caching_system": True}):
-            self.submit(
-                [
-                    *self.nonchunked_messages(
-                        message=json.dumps(data).encode(),
-                        segment_id=segment_id,
-                        compressed=True,
-                        replay_event=json.dumps(
-                            {
-                                "type": "replay_event",
-                                "replay_id": self.replay_id,
-                                "timestamp": int(time.time()),
-                            }
-                        ).encode(),
-                        replay_video=b"hello, world!",
-                    ),
-                    *self.nonchunked_messages(
-                        message=json.dumps(data).encode(),
-                        segment_id=segment_id,
-                        compressed=True,
-                        replay_event=json.dumps(
-                            {
-                                "type": "replay_event",
-                                "replay_id": self.replay_id,
-                                "timestamp": int(time.time()),
-                            }
-                        ).encode(),
-                        replay_video=b"hello, world!",
-                    ),
-                ]
-            )
-
-            dat = self.get_recording_data(segment_id)
-            assert json.loads(bytes(dat).decode("utf-8")) == data
-            video_data = self.get_video_data(segment_id)
-            assert video_data is not None
-            assert bytes(video_data) == b"hello, world!"
-
-            self.project.refresh_from_db()
-            assert bool(self.project.flags.has_replays) is True
-
-            mock_onboarding_task.assert_called_with(
-                organization_id=self.project.organization_id,
-                task=OnboardingTask.SESSION_REPLAY,
-                status=OnboardingTaskStatus.COMPLETE,
-                date_completed=ANY,
-            )
-
-            assert_any_analytics_event(
-                mock_record,
-                FirstReplaySentEvent(
-                    organization_id=self.organization.id,
-                    project_id=self.project.id,
-                    platform=self.project.platform,
-                    user_id=self.organization.default_owner_id,
-                ),
-            )
-
-            # We emit a new outcome because its a segment-0 event. We emit a hydration error because
-            # thats our cached configuration but we don't emit an onboarding metric because this is
-            # our second event.
-            assert track_outcome.called
-            assert track_outcome.call_count == 2
-            assert report_hydration_issue.called
-            assert report_hydration_issue.call_count == 2
-            assert set_project_flag_and_signal.call_count == 1
-
-    @patch("sentry.models.OrganizationOnboardingTask.objects.record")
-    @patch("sentry.analytics.record")
-    @patch("sentry.replays.usecases.ingest.track_outcome")
-    @patch("sentry.replays.usecases.ingest.report_hydration_error")
     def test_process_replay_recording_task(
         self,
-        report_hydration_issue: MagicMock,
         track_outcome: MagicMock,
-        mock_record: MagicMock,
         mock_onboarding_task: MagicMock,
     ) -> None:
         # The raw-mode taskbroker entrypoint: a single Kafka message is handed to

--- a/tests/sentry/replays/integration/consumers/test_recording.py
+++ b/tests/sentry/replays/integration/consumers/test_recording.py
@@ -1,53 +1,17 @@
-"""Test Arroyo recording-consumer integration."""
+"""Test replay-recording task integration."""
 
 import zlib
-from datetime import datetime
-from typing import Any
 from unittest import mock
 from unittest.mock import MagicMock
 
 import msgpack
-import pytest
-from arroyo.backends.kafka import KafkaPayload
-from arroyo.processing.strategies.abstract import ProcessingStrategy
-from arroyo.types import BrokerValue, Message, Partition, Topic
 
-from sentry.replays.consumers.recording import ProcessReplayRecordingStrategyFactory
+from sentry.replays.tasks import process_replay_recording
 from sentry.utils import json
 
 
-@pytest.fixture
 @mock.patch("sentry.options.get")
-def consumer(options_get: MagicMock) -> ProcessingStrategy[KafkaPayload]:
-    options_get.return_value = True
-    return ProcessReplayRecordingStrategyFactory(
-        input_block_size=1,
-        max_batch_size=1,
-        max_batch_time=1,
-        num_processes=1,
-        num_threads=1,
-        output_block_size=1,
-    ).create_with_partitions(lambda x, force=False: None, {})
-
-
-def submit(consumer: ProcessingStrategy[KafkaPayload], message: dict[str, Any]) -> None:
-    consumer.submit(
-        Message(
-            BrokerValue(
-                payload=KafkaPayload(b"key", msgpack.packb(message), [("should_drop", b"1")]),
-                partition=Partition(Topic("topic"), 1),
-                offset=0,
-                timestamp=datetime.now(),
-            )
-        )
-    )
-    consumer.poll()
-    consumer.join(1)
-    consumer.terminate()
-
-
-@mock.patch("sentry.options.get")
-def test_recording_consumer(options_get, consumer: ProcessingStrategy[KafkaPayload]) -> None:  # type: ignore[no-untyped-def]
+def test_recording_task(options_get: MagicMock) -> None:
     options_get.return_value = True
 
     headers = json.dumps({"segment_id": 42}).encode()
@@ -67,7 +31,7 @@ def test_recording_consumer(options_get, consumer: ProcessingStrategy[KafkaPaylo
         "version": 0,
     }
     with mock.patch("sentry.replays.consumers.recording.commit_recording_message") as commit:
-        submit(consumer, message)
+        process_replay_recording(msgpack.packb(message))
 
         # Message was successfully processed and the result was committed.
         assert commit.called
@@ -96,9 +60,9 @@ def test_recording_consumer(options_get, consumer: ProcessingStrategy[KafkaPaylo
         # assert actions.options_events == ...
 
 
-def test_recording_consumer_invalid_message(consumer: ProcessingStrategy[KafkaPayload]) -> None:
+def test_recording_task_invalid_message() -> None:
     with mock.patch("sentry.replays.consumers.recording.commit_recording_message") as commit:
-        submit(consumer, {})
+        process_replay_recording(msgpack.packb({}))
 
         # Message was not successfully processed and the result was dropped.
         assert not commit.called


### PR DESCRIPTION
Refs STREAM-1290

We have rolled out replays taskbroker raw to replace consumers in all regions, and the consumer code is good to be removed.