### PR TITLE
chore(spans): Remove unused issue detection enablement option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3222,11 +3222,6 @@ register(
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
-    "spans.process-segments.detect-performance-problems.enable",
-    default=False,
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
     "spans.process-segments.schema-validation",
     default=0.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,


### PR DESCRIPTION
This is the final PR in a series of PRs switching us from all-or-none issue detector enablement to selective detector enablement in the segment processing pipeline. Now that we've [stopped using the on/off option in code](https://github.com/getsentry/sentry/pull/121211), and now that it's [no longer referenced in options automator](https://github.com/getsentry/sentry-options-automator/pull/9045), we can delete the old option entirely.