### PR TITLE
feat(conversations): Make table row titles actual links

### DIFF
--- a/static/app/views/explore/conversations/components/conversationsTable.spec.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTable.spec.tsx
@@ -67,6 +67,17 @@ describe('ConversationsTable', () => {
     expect(await screen.findByText('Summarize Q2 revenue trends')).toBeInTheDocument();
   });
 
+  it('renders a native link to the conversation detail', async () => {
+    mockConversations([{...BASE_CONVERSATION, title: 'Open in a new tab'}]);
+
+    renderTable();
+
+    expect(await screen.findByRole('link', {name: /Open in a new tab/})).toHaveAttribute(
+      'href',
+      expect.stringContaining('/conversations/conv-1/')
+    );
+  });
+
   it('falls back to the first input message when there is no title', async () => {
     mockConversations([
       {...BASE_CONVERSATION, title: null, firstInput: 'Debug failing auth middleware'},

--- a/static/app/views/explore/conversations/components/conversationsTable.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTable.tsx
@@ -604,6 +604,7 @@ const FixedRowHeightGrid = styled('div')`
 
 const ConversationLink = styled(Link)`
   display: block;
+  min-width: 0;
   color: inherit;
 
   &:hover {

--- a/static/app/views/explore/conversations/components/conversationsTable.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTable.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import {ProjectAvatar} from '@sentry/scraps/avatar';
 import {Tag} from '@sentry/scraps/badge';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
-import {ExternalLink} from '@sentry/scraps/link';
+import {ExternalLink, Link} from '@sentry/scraps/link';
 import {Pagination} from '@sentry/scraps/pagination';
 import {Separator} from '@sentry/scraps/separator';
 import {Text} from '@sentry/scraps/text';
@@ -184,10 +184,15 @@ export function ConversationsTable() {
   );
 
   const renderBodyCell = useCallback(
-    (column: GridColumnOrder<ColumnKey>, dataRow: Conversation) => (
-      <BodyCell column={column} conversation={dataRow} />
-    ),
-    []
+    (column: GridColumnOrder<ColumnKey>, dataRow: Conversation) => {
+      const detailUrl = getConversationDetailUrl(
+        organization.slug,
+        dataRow,
+        selection.projects
+      );
+      return <BodyCell column={column} conversation={dataRow} detailUrl={detailUrl} />;
+    },
+    [organization.slug, selection.projects]
   );
 
   return (
@@ -228,13 +233,15 @@ export function ConversationsTable() {
 function BodyCell({
   column,
   conversation,
+  detailUrl,
 }: {
   column: GridColumnOrder<ColumnKey>;
   conversation: Conversation;
+  detailUrl: string;
 }) {
   switch (column.key) {
     case 'conversation':
-      return <ConversationCell conversation={conversation} />;
+      return <ConversationCell conversation={conversation} detailUrl={detailUrl} />;
     case 'duration':
       return (
         <Text tabular>
@@ -300,7 +307,13 @@ function getConversationIdLabel(conversationId: string): string {
   return isUUID(conversationId) ? conversationId.slice(0, 8) : conversationId;
 }
 
-function ConversationCell({conversation}: {conversation: Conversation}) {
+function ConversationCell({
+  conversation,
+  detailUrl,
+}: {
+  conversation: Conversation;
+  detailUrl: string;
+}) {
   // Flattening markdown to plain text renders HTML + parses it, so memoize on
   // the inputs to avoid recomputing on unrelated re-renders (hover, resize).
   const title = useMemo(
@@ -312,28 +325,30 @@ function ConversationCell({conversation}: {conversation: Conversation}) {
   });
 
   return (
-    <Stack gap="xs" minWidth={0}>
-      <Text size="lg" ellipsis>
-        {title ?? <Text variant="muted">{t('Untitled conversation')}</Text>}
-      </Text>
-      <Flex align="center" gap="sm" minWidth={0}>
-        <Flex align="center" gap="xs" minWidth={0}>
-          {project && (
-            <ProjectAvatar
-              project={project}
-              size={14}
-              hasTooltip
-              tooltip={project.slug}
-            />
-          )}
-          <Text size="sm" variant="muted" ellipsis>
-            {getConversationIdLabel(conversation.conversationId)}
-          </Text>
+    <ConversationLink to={detailUrl} onClick={event => event.stopPropagation()}>
+      <Stack gap="xs" minWidth={0}>
+        <Text size="lg" ellipsis>
+          {title ?? <Text variant="muted">{t('Untitled conversation')}</Text>}
+        </Text>
+        <Flex align="center" gap="sm" minWidth={0}>
+          <Flex align="center" gap="xs" minWidth={0}>
+            {project && (
+              <ProjectAvatar
+                project={project}
+                size={14}
+                hasTooltip
+                tooltip={project.slug}
+              />
+            )}
+            <Text size="sm" variant="muted" ellipsis>
+              {getConversationIdLabel(conversation.conversationId)}
+            </Text>
+          </Flex>
+          <CellDivider orientation="vertical" />
+          <ConversationUserLabel user={conversation.user} />
         </Flex>
-        <CellDivider orientation="vertical" />
-        <ConversationUserLabel user={conversation.user} />
-      </Flex>
-    </Stack>
+      </Stack>
+    </ConversationLink>
   );
 }
 
@@ -584,6 +599,15 @@ const FixedRowHeightGrid = styled('div')`
      size because its larger min-height wins over this fixed height. */
   tbody td {
     height: ${ROW_HEIGHT}px;
+  }
+`;
+
+const ConversationLink = styled(Link)`
+  display: block;
+  color: inherit;
+
+  &:hover {
+    color: inherit;
   }
 `;
 


### PR DESCRIPTION
I'm not at all familiar with this code, so bear with me! This is mostly for my own utility: while browsing the Conversations, table, I'd like to open several conversations in other tabs without navigating away from the search interface.

It's nontrivial to convert the entire _row_ to a link, but making the title text a normal link is straightforward.