### PR TITLE
feat(autofix): add section retry controls

### DIFF
--- a/static/app/components/events/autofix/v3/autofixResetPrompt.tsx
+++ b/static/app/components/events/autofix/v3/autofixResetPrompt.tsx
@@ -30,6 +30,7 @@ export function AutofixResetPrompt({
       <TextArea
         autosize
         rows={2}
+        autoFocus
         placeholder={placeholder}
         value={userContext}
         onChange={event => setUserContext(event.target.value)}

--- a/static/app/components/events/autofix/v3/useResetAutofixStep.spec.tsx
+++ b/static/app/components/events/autofix/v3/useResetAutofixStep.spec.tsx
@@ -213,7 +213,7 @@ describe('useResetAutofixStep', () => {
         useResetAutofixStep({autofix, section, step: 'solution'})
       );
 
-      result.current.handleReset();
+      act(() => void result.current.handleReset());
 
       expect(autofix.startStep).toHaveBeenCalledWith('solution', {
         runId: 42,
@@ -240,7 +240,7 @@ describe('useResetAutofixStep', () => {
         })
       );
 
-      result.current.handleReset('Please focus on the auth module');
+      act(() => void result.current.handleReset('Please focus on the auth module'));
 
       expect(autofix.startStep).toHaveBeenCalledWith('code_changes', {
         runId: 7,

--- a/static/app/views/issueDetails/issuePreview/issuePreview.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreview.tsx
@@ -211,8 +211,8 @@ function IssuePreviewContent() {
           {hasAutofix ? (
             <IssuePreviewAutofixSummary
               key={group.id}
+              autofix={autofix}
               groupId={group.id}
-              runState={autofix.runState}
             />
           ) : null}
           <Container>

--- a/static/app/views/issueDetails/issuePreview/issuePreviewAutofixPlanSection.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewAutofixPlanSection.tsx
@@ -28,7 +28,10 @@ export function IssuePreviewAutofixPlanSection({
 
   return (
     <RetryableAutofixSection autofix={autofix} section={section} step="solution">
-      <IssuePreviewSection defaultExpanded={defaultExpanded}>
+      <IssuePreviewSection
+        aria-label={t('Implementation Plan')}
+        defaultExpanded={defaultExpanded}
+      >
         <IssuePreviewSection.Title trailingItems={<RetryableAutofixSection.Button />}>
           {t('Implementation Plan')}
         </IssuePreviewSection.Title>

--- a/static/app/views/issueDetails/issuePreview/issuePreviewAutofixPlanSection.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewAutofixPlanSection.tsx
@@ -1,0 +1,73 @@
+import {Container, Stack} from '@sentry/scraps/layout';
+import {Markdown} from '@sentry/scraps/markdown';
+import {Text} from '@sentry/scraps/text';
+
+import {
+  type AutofixSection,
+  getAutofixArtifactFromSection,
+  isSolutionArtifact,
+  type useExplorerAutofix,
+} from 'sentry/components/events/autofix/useExplorerAutofix';
+import {t} from 'sentry/locale';
+
+import {IssuePreviewSection} from './issuePreviewSection';
+import {RetryableAutofixSection} from './retryableAutofixSection';
+import {WorkingIndicator} from './workingIndicator';
+
+export function IssuePreviewAutofixPlanSection({
+  autofix,
+  defaultExpanded,
+  section,
+}: {
+  autofix: ReturnType<typeof useExplorerAutofix>;
+  defaultExpanded: boolean;
+  section: AutofixSection;
+}) {
+  const artifact = getAutofixArtifactFromSection(section);
+  const plan = isSolutionArtifact(artifact) && artifact.data ? artifact.data : null;
+
+  return (
+    <RetryableAutofixSection autofix={autofix} section={section} step="solution">
+      <IssuePreviewSection
+        title={t('Implementation Plan')}
+        defaultExpanded={defaultExpanded}
+      >
+        <IssuePreviewSection.Title trailingItems={<RetryableAutofixSection.Button />}>
+          {t('Implementation Plan')}
+        </IssuePreviewSection.Title>
+        <IssuePreviewSection.Summary>
+          <RetryableAutofixSection.Prompt
+            placeholder={t('Give seer additional context to improve this plan.')}
+            prompt={t('How can this plan be improved?')}
+          />
+          {section.status === 'processing' ? (
+            <WorkingIndicator>{t('Generating implementation plan...')}</WorkingIndicator>
+          ) : plan ? (
+            <Markdown raw={plan.one_line_summary} />
+          ) : (
+            <Text variant="muted">{t('No implementation plan was generated.')}</Text>
+          )}
+        </IssuePreviewSection.Summary>
+        <IssuePreviewSection.Content>
+          {plan?.steps.length ? (
+            <Stack gap="md">
+              <Text bold>{t('Steps to Resolve')}</Text>
+              <Stack as="ol" gap="md" paddingLeft="xl">
+                {plan.steps.map((step, index) => (
+                  <Container as="li" key={index}>
+                    <Stack gap="xs">
+                      <Markdown raw={step.title} />
+                      <Text size="sm" variant="muted">
+                        {step.description}
+                      </Text>
+                    </Stack>
+                  </Container>
+                ))}
+              </Stack>
+            </Stack>
+          ) : null}
+        </IssuePreviewSection.Content>
+      </IssuePreviewSection>
+    </RetryableAutofixSection>
+  );
+}

--- a/static/app/views/issueDetails/issuePreview/issuePreviewAutofixPlanSection.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewAutofixPlanSection.tsx
@@ -28,16 +28,13 @@ export function IssuePreviewAutofixPlanSection({
 
   return (
     <RetryableAutofixSection autofix={autofix} section={section} step="solution">
-      <IssuePreviewSection
-        title={t('Implementation Plan')}
-        defaultExpanded={defaultExpanded}
-      >
+      <IssuePreviewSection defaultExpanded={defaultExpanded}>
         <IssuePreviewSection.Title trailingItems={<RetryableAutofixSection.Button />}>
           {t('Implementation Plan')}
         </IssuePreviewSection.Title>
         <IssuePreviewSection.Summary>
           <RetryableAutofixSection.Prompt
-            placeholder={t('Give seer additional context to improve this plan.')}
+            placeholder={t('Give Seer additional context to improve this plan.')}
             prompt={t('How can this plan be improved?')}
           />
           {section.status === 'processing' ? (

--- a/static/app/views/issueDetails/issuePreview/issuePreviewAutofixProposalSection.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewAutofixProposalSection.tsx
@@ -1,4 +1,5 @@
 import {useMemo} from 'react';
+import styled from '@emotion/styled';
 
 import {Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
@@ -65,16 +66,17 @@ export function IssuePreviewAutofixProposalSection({
             {Array.from(patchesByRepo.entries(), ([repoName, patches]) => (
               <Stack key={repoName} gap="md">
                 <Text bold>{repoName}</Text>
-                {patches.map(patch => (
-                  <FileDiffViewer
-                    key={patch.patch.path}
-                    patch={patch.patch}
-                    repoName={repoName}
-                    showBorder
-                    collapsible
-                    defaultExpanded
-                  />
-                ))}
+                <FileDiffList gap="0">
+                  {patches.map(patch => (
+                    <FileDiffViewer
+                      key={patch.patch.path}
+                      patch={patch.patch}
+                      repoName={repoName}
+                      showBorder
+                      collapsible
+                    />
+                  ))}
+                </FileDiffList>
               </Stack>
             ))}
           </Stack>
@@ -83,3 +85,16 @@ export function IssuePreviewAutofixProposalSection({
     </RetryableAutofixSection>
   );
 }
+
+const FileDiffList = styled(Stack)`
+  & > :not(:first-child) {
+    border-top: 0;
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+  }
+
+  & > :not(:last-child) {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+`;

--- a/static/app/views/issueDetails/issuePreview/issuePreviewAutofixProposalSection.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewAutofixProposalSection.tsx
@@ -44,13 +44,13 @@ export function IssuePreviewAutofixProposalSection({
 
   return (
     <RetryableAutofixSection autofix={autofix} section={section} step="code_changes">
-      <IssuePreviewSection title={t('Proposal')} defaultExpanded={defaultExpanded}>
+      <IssuePreviewSection defaultExpanded={defaultExpanded}>
         <IssuePreviewSection.Title trailingItems={<RetryableAutofixSection.Button />}>
           {t('Proposal')}
         </IssuePreviewSection.Title>
         <IssuePreviewSection.Summary>
           <RetryableAutofixSection.Prompt
-            placeholder={t('Give seer additional context to improve this proposal.')}
+            placeholder={t('Give Seer additional context to improve this proposal.')}
             prompt={t('How can this code change be improved?')}
           />
           {section.status === 'processing' ? (

--- a/static/app/views/issueDetails/issuePreview/issuePreviewAutofixProposalSection.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewAutofixProposalSection.tsx
@@ -1,0 +1,85 @@
+import {useMemo} from 'react';
+
+import {Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {
+  collectPatches,
+  getAutofixArtifactFromSection,
+  isCodeChangesArtifact,
+  type AutofixSection,
+  type useExplorerAutofix,
+} from 'sentry/components/events/autofix/useExplorerAutofix';
+import {t, tn} from 'sentry/locale';
+import {FileDiffViewer} from 'sentry/views/seerExplorer/components/fileDiffViewer';
+
+import {IssuePreviewSection} from './issuePreviewSection';
+import {RetryableAutofixSection} from './retryableAutofixSection';
+import {WorkingIndicator} from './workingIndicator';
+
+export function IssuePreviewAutofixProposalSection({
+  autofix,
+  defaultExpanded,
+  section,
+}: {
+  autofix: ReturnType<typeof useExplorerAutofix>;
+  defaultExpanded: boolean;
+  section: AutofixSection;
+}) {
+  const patchesByRepo = useMemo(() => {
+    const artifact = getAutofixArtifactFromSection(section);
+    return collectPatches(isCodeChangesArtifact(artifact) ? artifact : []);
+  }, [section]);
+
+  const filesChanged = [...patchesByRepo.values()].reduce(
+    (count, patches) => count + patches.length,
+    0
+  );
+
+  const proposalSummary =
+    patchesByRepo.size === 1
+      ? tn('%s file changed in 1 repo', '%s files changed in 1 repo', filesChanged)
+      : t('%s files changed in %s repos', filesChanged, patchesByRepo.size);
+
+  return (
+    <RetryableAutofixSection autofix={autofix} section={section} step="code_changes">
+      <IssuePreviewSection title={t('Proposal')} defaultExpanded={defaultExpanded}>
+        <IssuePreviewSection.Title trailingItems={<RetryableAutofixSection.Button />}>
+          {t('Proposal')}
+        </IssuePreviewSection.Title>
+        <IssuePreviewSection.Summary>
+          <RetryableAutofixSection.Prompt
+            placeholder={t('Give seer additional context to improve this proposal.')}
+            prompt={t('How can this code change be improved?')}
+          />
+          {section.status === 'processing' ? (
+            <WorkingIndicator>{t('Generating proposal...')}</WorkingIndicator>
+          ) : patchesByRepo.size > 0 ? (
+            <Text>{proposalSummary}</Text>
+          ) : (
+            <Text variant="muted">{t('No code changes were proposed.')}</Text>
+          )}
+        </IssuePreviewSection.Summary>
+        <IssuePreviewSection.Content>
+          <Stack gap="lg">
+            {Array.from(patchesByRepo.entries(), ([repoName, patches]) => (
+              <Stack key={repoName} gap="md">
+                <Text bold>{repoName}</Text>
+                {patches.map(patch => (
+                  <FileDiffViewer
+                    key={patch.patch.path}
+                    patch={patch.patch}
+                    repoName={repoName}
+                    showBorder
+                    collapsible
+                    defaultExpanded
+                  />
+                ))}
+              </Stack>
+            ))}
+          </Stack>
+        </IssuePreviewSection.Content>
+      </IssuePreviewSection>
+    </RetryableAutofixSection>
+  );
+}

--- a/static/app/views/issueDetails/issuePreview/issuePreviewAutofixProposalSection.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewAutofixProposalSection.tsx
@@ -44,7 +44,7 @@ export function IssuePreviewAutofixProposalSection({
 
   return (
     <RetryableAutofixSection autofix={autofix} section={section} step="code_changes">
-      <IssuePreviewSection defaultExpanded={defaultExpanded}>
+      <IssuePreviewSection aria-label={t('Proposal')} defaultExpanded={defaultExpanded}>
         <IssuePreviewSection.Title trailingItems={<RetryableAutofixSection.Button />}>
           {t('Proposal')}
         </IssuePreviewSection.Title>

--- a/static/app/views/issueDetails/issuePreview/issuePreviewAutofixRootCauseSection.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewAutofixRootCauseSection.tsx
@@ -1,0 +1,99 @@
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {Markdown} from '@sentry/scraps/markdown';
+import {Text} from '@sentry/scraps/text';
+
+import {
+  type AutofixSection,
+  getAutofixArtifactFromSection,
+  isRootCauseArtifact,
+  type useExplorerAutofix,
+} from 'sentry/components/events/autofix/useExplorerAutofix';
+import {AutofixEvidence} from 'sentry/components/events/autofix/v3/autofixEvidence';
+import {useAutofixSectionEvidence} from 'sentry/components/events/autofix/v3/useAutofixSectionEvidence';
+import {t} from 'sentry/locale';
+
+import {IssuePreviewSection} from './issuePreviewSection';
+import {RetryableAutofixSection} from './retryableAutofixSection';
+import {WorkingIndicator} from './workingIndicator';
+
+export function IssuePreviewAutofixRootCauseSection({
+  autofix,
+  defaultExpanded,
+  groupId,
+  section,
+}: {
+  autofix: ReturnType<typeof useExplorerAutofix>;
+  defaultExpanded: boolean;
+  groupId: string;
+  section: AutofixSection;
+}) {
+  const artifact = getAutofixArtifactFromSection(section);
+  const rootCause = isRootCauseArtifact(artifact) && artifact.data ? artifact.data : null;
+  const evidence = useAutofixSectionEvidence({section});
+
+  return (
+    <RetryableAutofixSection autofix={autofix} section={section} step="root_cause">
+      <IssuePreviewSection title={t('Root Cause')} defaultExpanded={defaultExpanded}>
+        <IssuePreviewSection.Title trailingItems={<RetryableAutofixSection.Button />}>
+          {t('Root Cause')}
+        </IssuePreviewSection.Title>
+        <IssuePreviewSection.Summary>
+          <RetryableAutofixSection.Prompt
+            placeholder={t('Give seer additional context to improve this root cause.')}
+            prompt={t('How can this root cause be improved?')}
+          />
+          {section.status === 'processing' ? (
+            <WorkingIndicator>{t('Generating root cause...')}</WorkingIndicator>
+          ) : rootCause ? (
+            <Markdown raw={rootCause.one_line_description} />
+          ) : (
+            <Text variant="muted">{t('No root cause was identified.')}</Text>
+          )}
+        </IssuePreviewSection.Summary>
+        <IssuePreviewSection.Content>
+          <Stack gap="lg">
+            {rootCause?.five_whys.length ? (
+              <Stack gap="md">
+                <Text bold>{t('Why did this happen?')}</Text>
+                <Stack as="ul" gap="sm" paddingLeft="xl">
+                  {rootCause.five_whys.map((why, index) => (
+                    <Container as="li" key={index}>
+                      <Markdown raw={why} />
+                    </Container>
+                  ))}
+                </Stack>
+              </Stack>
+            ) : null}
+            {rootCause?.reproduction_steps?.length ? (
+              <Stack gap="md">
+                <Text bold>{t('Reproduction Steps')}</Text>
+                <Stack as="ol" gap="sm" paddingLeft="xl">
+                  {rootCause.reproduction_steps.map((step, index) => (
+                    <Container as="li" key={index}>
+                      <Markdown raw={step} />
+                    </Container>
+                  ))}
+                </Stack>
+              </Stack>
+            ) : null}
+            {rootCause && evidence.length > 0 ? (
+              <Stack gap="md">
+                <Text bold>{t('Evidence')}</Text>
+                <Flex gap="md" wrap="wrap">
+                  {evidence.map(item => (
+                    <AutofixEvidence
+                      key={item.toolCall.id}
+                      evidenceButtonProps={item.evidenceButtonProps}
+                      groupId={groupId}
+                      toolCall={item.toolCall}
+                    />
+                  ))}
+                </Flex>
+              </Stack>
+            ) : null}
+          </Stack>
+        </IssuePreviewSection.Content>
+      </IssuePreviewSection>
+    </RetryableAutofixSection>
+  );
+}

--- a/static/app/views/issueDetails/issuePreview/issuePreviewAutofixRootCauseSection.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewAutofixRootCauseSection.tsx
@@ -33,13 +33,13 @@ export function IssuePreviewAutofixRootCauseSection({
 
   return (
     <RetryableAutofixSection autofix={autofix} section={section} step="root_cause">
-      <IssuePreviewSection title={t('Root Cause')} defaultExpanded={defaultExpanded}>
+      <IssuePreviewSection defaultExpanded={defaultExpanded}>
         <IssuePreviewSection.Title trailingItems={<RetryableAutofixSection.Button />}>
           {t('Root Cause')}
         </IssuePreviewSection.Title>
         <IssuePreviewSection.Summary>
           <RetryableAutofixSection.Prompt
-            placeholder={t('Give seer additional context to improve this root cause.')}
+            placeholder={t('Give Seer additional context to improve this root cause.')}
             prompt={t('How can this root cause be improved?')}
           />
           {section.status === 'processing' ? (

--- a/static/app/views/issueDetails/issuePreview/issuePreviewAutofixRootCauseSection.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewAutofixRootCauseSection.tsx
@@ -33,7 +33,7 @@ export function IssuePreviewAutofixRootCauseSection({
 
   return (
     <RetryableAutofixSection autofix={autofix} section={section} step="root_cause">
-      <IssuePreviewSection defaultExpanded={defaultExpanded}>
+      <IssuePreviewSection aria-label={t('Root Cause')} defaultExpanded={defaultExpanded}>
         <IssuePreviewSection.Title trailingItems={<RetryableAutofixSection.Button />}>
           {t('Root Cause')}
         </IssuePreviewSection.Title>

--- a/static/app/views/issueDetails/issuePreview/issuePreviewAutofixSummary.spec.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewAutofixSummary.spec.tsx
@@ -8,6 +8,7 @@ import {
 
 import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
+import type {useExplorerAutofix} from 'sentry/components/events/autofix/useExplorerAutofix';
 import type {ExplorerFilePatch} from 'sentry/views/seerExplorer/types';
 
 import {IssuePreviewAutofixSummary} from './issuePreviewAutofixSummary';
@@ -26,6 +27,23 @@ function makePatch(repoName: string, path: string): ExplorerFilePatch {
       type: 'M',
     },
   } as ExplorerFilePatch;
+}
+
+function makeAutofix(
+  runState: ReturnType<typeof useExplorerAutofix>['runState']
+): ReturnType<typeof useExplorerAutofix> {
+  return {
+    runState,
+    startStep: jest.fn(),
+    createPR: jest.fn(),
+    reset: jest.fn(),
+    triggerCodingAgentHandoff: jest.fn(),
+    codingAgentErrors: [],
+    dismissCodingAgentError: jest.fn(),
+    warnings: [],
+    isLoading: false,
+    isPolling: false,
+  };
 }
 
 const rootCauseArtifact = AutofixRootCauseArtifactFixture({
@@ -124,7 +142,12 @@ describe('IssuePreviewAutofixSummary', () => {
       },
     });
 
-    render(<IssuePreviewAutofixSummary groupId="preview-group" runState={runState} />);
+    render(
+      <IssuePreviewAutofixSummary
+        autofix={makeAutofix(runState)}
+        groupId="preview-group"
+      />
+    );
 
     expect(
       screen.getAllByRole('heading', {level: 3}).map(heading => heading.textContent)
@@ -190,9 +213,11 @@ describe('IssuePreviewAutofixSummary', () => {
     render(
       <IssuePreviewAutofixSummary
         groupId="preview-group"
-        runState={ExplorerAutofixStateFixture({
-          blocks: [ExplorerAutofixBlockFixture({artifacts: [rootCauseArtifact]})],
-        })}
+        autofix={makeAutofix(
+          ExplorerAutofixStateFixture({
+            blocks: [ExplorerAutofixBlockFixture({artifacts: [rootCauseArtifact]})],
+          })
+        )}
       />
     );
 
@@ -211,19 +236,21 @@ describe('IssuePreviewAutofixSummary', () => {
     render(
       <IssuePreviewAutofixSummary
         groupId="preview-group"
-        runState={ExplorerAutofixStateFixture({
-          blocks: [
-            ExplorerAutofixBlockFixture({
-              artifacts: undefined,
-              message: {
-                content: 'Thinking...',
-                metadata: {step: 'root_cause'},
-                role: 'assistant',
-              },
-            }),
-          ],
-          status: 'processing',
-        })}
+        autofix={makeAutofix(
+          ExplorerAutofixStateFixture({
+            blocks: [
+              ExplorerAutofixBlockFixture({
+                artifacts: undefined,
+                message: {
+                  content: 'Thinking...',
+                  metadata: {step: 'root_cause'},
+                  role: 'assistant',
+                },
+              }),
+            ],
+            status: 'processing',
+          })
+        )}
       />
     );
 
@@ -236,36 +263,117 @@ describe('IssuePreviewAutofixSummary', () => {
     expect(screen.queryByRole('region', {name: 'Proposal'})).not.toBeInTheDocument();
   });
 
-  it.each([
-    [
-      'errored step',
-      ExplorerAutofixStateFixture({
-        blocks: [ExplorerAutofixBlockFixture({artifacts: [rootCauseArtifact]})],
-        status: 'error',
-      }),
-    ],
-    [
-      'invalid artifact',
-      ExplorerAutofixStateFixture({
-        blocks: [
-          ExplorerAutofixBlockFixture({
-            artifacts: [
-              AutofixRootCauseArtifactFixture({
-                reason: 'Malformed root cause',
-                data: {one_line_description: 'Missing required details'},
+  it('renders an empty state for an errored step', () => {
+    const runState = ExplorerAutofixStateFixture({
+      blocks: [ExplorerAutofixBlockFixture({artifacts: [rootCauseArtifact]})],
+      status: 'error',
+    });
+
+    render(
+      <IssuePreviewAutofixSummary
+        autofix={makeAutofix(runState)}
+        groupId="preview-group"
+      />
+    );
+
+    expect(
+      within(screen.getByRole('region', {name: 'Root Cause'})).getByText(
+        'No root cause was identified.'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('renders an empty state for an invalid artifact', () => {
+    const runState = ExplorerAutofixStateFixture({
+      blocks: [
+        ExplorerAutofixBlockFixture({
+          artifacts: [
+            AutofixRootCauseArtifactFixture({
+              reason: 'Malformed root cause',
+              data: {one_line_description: 'Missing required details'},
+            }),
+          ],
+        }),
+      ],
+    });
+
+    render(
+      <IssuePreviewAutofixSummary
+        autofix={makeAutofix(runState)}
+        groupId="preview-group"
+      />
+    );
+
+    expect(
+      within(screen.getByRole('region', {name: 'Root Cause'})).getByText(
+        'No root cause was identified.'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('renders an existing section with empty text when it has no artifact', () => {
+    render(
+      <IssuePreviewAutofixSummary
+        groupId="preview-group"
+        autofix={makeAutofix(
+          ExplorerAutofixStateFixture({
+            blocks: [
+              ExplorerAutofixBlockFixture({artifacts: [rootCauseArtifact]}),
+              ExplorerAutofixBlockFixture({
+                id: 'solution',
+                artifacts: [
+                  AutofixSolutionArtifactFixture({
+                    reason: 'Malformed plan',
+                    data: {one_line_summary: 'Missing steps'},
+                  }),
+                ],
+                message: {
+                  content: 'Plan complete',
+                  metadata: {step: 'solution'},
+                  role: 'assistant',
+                },
               }),
             ],
-          }),
-        ],
-      }),
-    ],
-  ])('renders nothing for a %s', (_label, runState) => {
-    render(<IssuePreviewAutofixSummary groupId="preview-group" runState={runState} />);
+          })
+        )}
+      />
+    );
 
-    expect(screen.queryByRole('region', {name: 'Proposal'})).not.toBeInTheDocument();
+    expect(screen.getByRole('region', {name: 'Root Cause'})).toBeInTheDocument();
+    const plan = screen.getByRole('region', {name: 'Implementation Plan'});
     expect(
-      screen.queryByRole('region', {name: 'Implementation Plan'})
-    ).not.toBeInTheDocument();
-    expect(screen.queryByRole('region', {name: 'Root Cause'})).not.toBeInTheDocument();
+      within(plan).getByText('No implementation plan was generated.')
+    ).toBeInTheDocument();
+  });
+
+  it('re-runs a section from its disclosure action', async () => {
+    const runState = ExplorerAutofixStateFixture({
+      blocks: [ExplorerAutofixBlockFixture({artifacts: [rootCauseArtifact]})],
+    });
+    const autofix = makeAutofix(runState);
+
+    render(<IssuePreviewAutofixSummary autofix={autofix} groupId="preview-group" />);
+
+    const rootCause = screen.getByRole('region', {name: 'Root Cause'});
+    const summary = within(rootCause).getByText(
+      'An unexpected null value reached the user handler.'
+    );
+    await userEvent.click(screen.getByRole('button', {name: 'Re-run step'}));
+    expect(
+      within(rootCause).getByText('How can this root cause be improved?')
+    ).toBeInTheDocument();
+    expect(
+      within(rootCause)
+        .getByText('How can this root cause be improved?')
+        .compareDocumentPosition(summary) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+    await userEvent.type(screen.getByRole('textbox'), 'Try again');
+    await userEvent.click(screen.getByRole('button', {name: 'Re-run from here'}));
+
+    expect(autofix.startStep).toHaveBeenCalledWith('root_cause', {
+      runId: runState.run_id,
+      userContext: 'Try again',
+      insertIndex: 0,
+    });
   });
 });

--- a/static/app/views/issueDetails/issuePreview/issuePreviewAutofixSummary.spec.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewAutofixSummary.spec.tsx
@@ -3,12 +3,12 @@ import {
   AutofixRootCauseArtifactFixture,
   AutofixSolutionArtifactFixture,
   ExplorerAutofixBlockFixture,
+  ExplorerAutofixFixture,
   ExplorerAutofixStateFixture,
 } from 'sentry-fixture/autofix';
 
 import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
-import type {useExplorerAutofix} from 'sentry/components/events/autofix/useExplorerAutofix';
 import type {ExplorerFilePatch} from 'sentry/views/seerExplorer/types';
 
 import {IssuePreviewAutofixSummary} from './issuePreviewAutofixSummary';
@@ -27,23 +27,6 @@ function makePatch(repoName: string, path: string): ExplorerFilePatch {
       type: 'M',
     },
   } as ExplorerFilePatch;
-}
-
-function makeAutofix(
-  runState: ReturnType<typeof useExplorerAutofix>['runState']
-): ReturnType<typeof useExplorerAutofix> {
-  return {
-    runState,
-    startStep: jest.fn(),
-    createPR: jest.fn(),
-    reset: jest.fn(),
-    triggerCodingAgentHandoff: jest.fn(),
-    codingAgentErrors: [],
-    dismissCodingAgentError: jest.fn(),
-    warnings: [],
-    isLoading: false,
-    isPolling: false,
-  };
 }
 
 const rootCauseArtifact = AutofixRootCauseArtifactFixture({
@@ -77,28 +60,7 @@ describe('IssuePreviewAutofixSummary', () => {
   it('renders summaries in the requested order with the first section expanded', async () => {
     const runState = ExplorerAutofixStateFixture({
       blocks: [
-        ExplorerAutofixBlockFixture({
-          artifacts: [rootCauseArtifact],
-          message: {
-            content: 'Root cause complete',
-            metadata: {step: 'root_cause'},
-            role: 'assistant',
-            tool_calls: [{id: 'event-tool', function: 'get_event_details', args: '{}'}],
-          },
-          tool_results: [
-            {
-              tool_call_id: 'event-tool',
-              tool_call_function: 'get_event_details',
-              content: 'Event details',
-            },
-          ],
-          tool_links: [
-            {
-              kind: 'get_event_details',
-              params: {issue_id: '12345', event_id: 'abcd1234efgh5678'},
-            },
-          ],
-        }),
+        ExplorerAutofixBlockFixture({artifacts: [rootCauseArtifact]}),
         ExplorerAutofixBlockFixture({
           id: 'solution',
           artifacts: [solutionArtifact],
@@ -144,7 +106,7 @@ describe('IssuePreviewAutofixSummary', () => {
 
     render(
       <IssuePreviewAutofixSummary
-        autofix={makeAutofix(runState)}
+        autofix={ExplorerAutofixFixture({runState})}
         groupId="preview-group"
       />
     );
@@ -205,19 +167,17 @@ describe('IssuePreviewAutofixSummary', () => {
     expect(
       within(rootCause).getByText('Request a user ID that does not exist.')
     ).toBeVisible();
-    expect(within(rootCause).getByText('Evidence')).toBeVisible();
-    expect(within(rootCause).getByText('Error: abcd1234')).toBeVisible();
   });
 
   it('renders only completed valid artifacts that exist in a partial run', () => {
     render(
       <IssuePreviewAutofixSummary
-        groupId="preview-group"
-        autofix={makeAutofix(
-          ExplorerAutofixStateFixture({
+        autofix={ExplorerAutofixFixture({
+          runState: ExplorerAutofixStateFixture({
             blocks: [ExplorerAutofixBlockFixture({artifacts: [rootCauseArtifact]})],
-          })
-        )}
+          }),
+        })}
+        groupId="preview-group"
       />
     );
 
@@ -235,9 +195,8 @@ describe('IssuePreviewAutofixSummary', () => {
   it('renders the section with a loading indicator while it is processing', () => {
     render(
       <IssuePreviewAutofixSummary
-        groupId="preview-group"
-        autofix={makeAutofix(
-          ExplorerAutofixStateFixture({
+        autofix={ExplorerAutofixFixture({
+          runState: ExplorerAutofixStateFixture({
             blocks: [
               ExplorerAutofixBlockFixture({
                 artifacts: undefined,
@@ -249,8 +208,9 @@ describe('IssuePreviewAutofixSummary', () => {
               }),
             ],
             status: 'processing',
-          })
-        )}
+          }),
+        })}
+        groupId="preview-group"
       />
     );
 
@@ -263,60 +223,52 @@ describe('IssuePreviewAutofixSummary', () => {
     expect(screen.queryByRole('region', {name: 'Proposal'})).not.toBeInTheDocument();
   });
 
-  it('renders an empty state for an errored step', () => {
-    const runState = ExplorerAutofixStateFixture({
-      blocks: [ExplorerAutofixBlockFixture({artifacts: [rootCauseArtifact]})],
-      status: 'error',
-    });
-
+  it.each([
+    [
+      'errored step',
+      ExplorerAutofixStateFixture({
+        blocks: [ExplorerAutofixBlockFixture({artifacts: [rootCauseArtifact]})],
+        status: 'error',
+      }),
+    ],
+    [
+      'invalid artifact',
+      ExplorerAutofixStateFixture({
+        blocks: [
+          ExplorerAutofixBlockFixture({
+            artifacts: [
+              AutofixRootCauseArtifactFixture({
+                reason: 'Malformed root cause',
+                data: {one_line_description: 'Missing required details'},
+              }),
+            ],
+          }),
+        ],
+      }),
+    ],
+  ])('renders an empty section for a %s', (_label, runState) => {
     render(
       <IssuePreviewAutofixSummary
-        autofix={makeAutofix(runState)}
+        autofix={ExplorerAutofixFixture({runState})}
         groupId="preview-group"
       />
     );
 
+    expect(screen.queryByRole('region', {name: 'Proposal'})).not.toBeInTheDocument();
     expect(
-      within(screen.getByRole('region', {name: 'Root Cause'})).getByText(
-        'No root cause was identified.'
-      )
-    ).toBeInTheDocument();
-  });
-
-  it('renders an empty state for an invalid artifact', () => {
-    const runState = ExplorerAutofixStateFixture({
-      blocks: [
-        ExplorerAutofixBlockFixture({
-          artifacts: [
-            AutofixRootCauseArtifactFixture({
-              reason: 'Malformed root cause',
-              data: {one_line_description: 'Missing required details'},
-            }),
-          ],
-        }),
-      ],
-    });
-
-    render(
-      <IssuePreviewAutofixSummary
-        autofix={makeAutofix(runState)}
-        groupId="preview-group"
-      />
-    );
-
+      screen.queryByRole('region', {name: 'Implementation Plan'})
+    ).not.toBeInTheDocument();
+    const rootCause = screen.getByRole('region', {name: 'Root Cause'});
     expect(
-      within(screen.getByRole('region', {name: 'Root Cause'})).getByText(
-        'No root cause was identified.'
-      )
+      within(rootCause).getByText('No root cause was identified.')
     ).toBeInTheDocument();
   });
 
   it('renders an existing section with empty text when it has no artifact', () => {
     render(
       <IssuePreviewAutofixSummary
-        groupId="preview-group"
-        autofix={makeAutofix(
-          ExplorerAutofixStateFixture({
+        autofix={ExplorerAutofixFixture({
+          runState: ExplorerAutofixStateFixture({
             blocks: [
               ExplorerAutofixBlockFixture({artifacts: [rootCauseArtifact]}),
               ExplorerAutofixBlockFixture({
@@ -334,8 +286,9 @@ describe('IssuePreviewAutofixSummary', () => {
                 },
               }),
             ],
-          })
-        )}
+          }),
+        })}
+        groupId="preview-group"
       />
     );
 
@@ -350,7 +303,7 @@ describe('IssuePreviewAutofixSummary', () => {
     const runState = ExplorerAutofixStateFixture({
       blocks: [ExplorerAutofixBlockFixture({artifacts: [rootCauseArtifact]})],
     });
-    const autofix = makeAutofix(runState);
+    const autofix = ExplorerAutofixFixture({runState});
 
     render(<IssuePreviewAutofixSummary autofix={autofix} groupId="preview-group" />);
 

--- a/static/app/views/issueDetails/issuePreview/issuePreviewAutofixSummary.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewAutofixSummary.tsx
@@ -1,312 +1,73 @@
 import {useMemo} from 'react';
 import styled from '@emotion/styled';
 
-import {Disclosure} from '@sentry/scraps/disclosure';
-import {Container, Flex, Stack} from '@sentry/scraps/layout';
-import {Markdown} from '@sentry/scraps/markdown';
-import {Heading, Text} from '@sentry/scraps/text';
-
 import {
-  collectPatches,
-  getAutofixArtifactFromSection,
   getOrderedAutofixSections,
-  isCodeChangesArtifact,
   isCodeChangesSection,
-  isRootCauseArtifact,
   isRootCauseSection,
-  isSolutionArtifact,
   isSolutionSection,
-  type AutofixSection,
-  type ExplorerAutofixState,
+  type useExplorerAutofix,
 } from 'sentry/components/events/autofix/useExplorerAutofix';
-import {AutofixEvidence} from 'sentry/components/events/autofix/v3/autofixEvidence';
-import {useAutofixSectionEvidence} from 'sentry/components/events/autofix/v3/useAutofixSectionEvidence';
-import {LoadingIndicator} from 'sentry/components/loadingIndicator';
-import {t, tn} from 'sentry/locale';
-import {FileDiffViewer} from 'sentry/views/seerExplorer/components/fileDiffViewer';
+
+import {IssuePreviewAutofixPlanSection} from './issuePreviewAutofixPlanSection';
+import {IssuePreviewAutofixProposalSection} from './issuePreviewAutofixProposalSection';
+import {IssuePreviewAutofixRootCauseSection} from './issuePreviewAutofixRootCauseSection';
 
 interface IssuePreviewAutofixSummaryProps {
+  autofix: ReturnType<typeof useExplorerAutofix>;
   groupId: string;
-  runState: ExplorerAutofixState | null;
 }
 
 export function IssuePreviewAutofixSummary({
+  autofix,
   groupId,
-  runState,
 }: IssuePreviewAutofixSummaryProps) {
+  const {runState} = autofix;
   const sections = useMemo(() => getOrderedAutofixSections(runState), [runState]);
 
   const proposalSection = sections.findLast(isCodeChangesSection);
   const planSection = sections.findLast(isSolutionSection);
   const rootCauseSection = sections.findLast(isRootCauseSection);
 
-  const proposalArtifact = useMemo(() => {
-    const artifact = proposalSection
-      ? getAutofixArtifactFromSection(proposalSection)
-      : null;
-    return isCodeChangesArtifact(artifact) ? artifact : null;
-  }, [proposalSection]);
-  const planArtifact = useMemo(() => {
-    const artifact = planSection ? getAutofixArtifactFromSection(planSection) : null;
-    return isSolutionArtifact(artifact) && artifact.data ? artifact.data : null;
-  }, [planSection]);
-  const rootCauseArtifact = useMemo(() => {
-    const artifact = rootCauseSection
-      ? getAutofixArtifactFromSection(rootCauseSection)
-      : null;
-    return isRootCauseArtifact(artifact) && artifact.data ? artifact.data : null;
-  }, [rootCauseSection]);
-
-  const patchesByRepo = useMemo(
-    () => collectPatches(proposalArtifact ?? []),
-    [proposalArtifact]
-  );
-
   if (!runState) {
     return null;
   }
 
-  const isProposalProcessing = proposalSection?.status === 'processing';
-  const isPlanProcessing = planSection?.status === 'processing';
-  const isRootCauseProcessing = rootCauseSection?.status === 'processing';
-  const hasProposal = patchesByRepo.size > 0;
-  if (
-    !hasProposal &&
-    !isProposalProcessing &&
-    !planArtifact &&
-    !isPlanProcessing &&
-    !rootCauseArtifact &&
-    !isRootCauseProcessing
-  ) {
-    return null;
-  }
-
-  const filesChanged = [...patchesByRepo.values()].reduce(
-    (count, patches) => count + patches.length,
-    0
-  );
-  const proposalSummary =
-    patchesByRepo.size === 1
-      ? tn('%s file changed in 1 repo', '%s files changed in 1 repo', filesChanged)
-      : t('%s files changed in %s repos', filesChanged, patchesByRepo.size);
-  const defaultExpandedSection = hasProposal
+  const defaultExpandedSection = proposalSection
     ? 'proposal'
-    : planArtifact || isPlanProcessing
+    : planSection
       ? 'plan'
       : 'rootCause';
 
   return (
     <Dividers>
-      {hasProposal || isProposalProcessing ? (
-        <Container>
-          <Disclosure
-            as="section"
-            aria-label={t('Proposal')}
-            size="md"
-            defaultExpanded={defaultExpandedSection === 'proposal'}
-          >
-            <Disclosure.Title>
-              <Heading as="h3" size="md">
-                {t('Proposal')}
-              </Heading>
-            </Disclosure.Title>
-            <SummaryContainer>
-              {isProposalProcessing ? (
-                <WorkingIndicator>{t('Generating proposal...')}</WorkingIndicator>
-              ) : (
-                <Text>{proposalSummary}</Text>
-              )}
-            </SummaryContainer>
-            <Disclosure.Content>
-              <Stack gap="lg">
-                {Array.from(patchesByRepo.entries(), ([repoName, patches]) => (
-                  <Stack key={repoName} gap="md">
-                    <Text bold>{repoName}</Text>
-                    <FileDiffList gap="0">
-                      {patches.map(patch => (
-                        <FileDiffViewer
-                          key={patch.patch.path}
-                          patch={patch.patch}
-                          repoName={repoName}
-                          showBorder
-                          collapsible
-                        />
-                      ))}
-                    </FileDiffList>
-                  </Stack>
-                ))}
-              </Stack>
-            </Disclosure.Content>
-          </Disclosure>
-        </Container>
+      {proposalSection ? (
+        <IssuePreviewAutofixProposalSection
+          autofix={autofix}
+          defaultExpanded={defaultExpandedSection === 'proposal'}
+          section={proposalSection}
+        />
       ) : null}
 
-      {planArtifact || isPlanProcessing ? (
-        <Container>
-          <Disclosure
-            as="section"
-            aria-label={t('Implementation Plan')}
-            size="md"
-            defaultExpanded={defaultExpandedSection === 'plan'}
-          >
-            <Disclosure.Title>
-              <Heading as="h3" size="md">
-                {t('Implementation Plan')}
-              </Heading>
-            </Disclosure.Title>
-            <SummaryContainer>
-              {isPlanProcessing ? (
-                <WorkingIndicator>
-                  {t('Generating implementation plan...')}
-                </WorkingIndicator>
-              ) : planArtifact ? (
-                <Markdown raw={planArtifact.one_line_summary} />
-              ) : null}
-            </SummaryContainer>
-            <Disclosure.Content>
-              {planArtifact?.steps.length ? (
-                <Stack gap="md">
-                  <Text bold>{t('Steps to Resolve')}</Text>
-                  <Stack as="ol" gap="md" paddingLeft="xl">
-                    {planArtifact.steps.map((step, index) => (
-                      <Container as="li" key={index}>
-                        <Stack gap="xs">
-                          <Markdown raw={step.title} />
-                          <Text size="sm" variant="muted">
-                            {step.description}
-                          </Text>
-                        </Stack>
-                      </Container>
-                    ))}
-                  </Stack>
-                </Stack>
-              ) : null}
-            </Disclosure.Content>
-          </Disclosure>
-        </Container>
+      {planSection ? (
+        <IssuePreviewAutofixPlanSection
+          autofix={autofix}
+          defaultExpanded={defaultExpandedSection === 'plan'}
+          section={planSection}
+        />
       ) : null}
 
-      {rootCauseArtifact || isRootCauseProcessing ? (
-        <Container>
-          <Disclosure
-            as="section"
-            aria-label={t('Root Cause')}
-            size="md"
-            defaultExpanded={defaultExpandedSection === 'rootCause'}
-          >
-            <Disclosure.Title>
-              <Heading as="h3" size="md">
-                {t('Root Cause')}
-              </Heading>
-            </Disclosure.Title>
-            <SummaryContainer>
-              {isRootCauseProcessing ? (
-                <WorkingIndicator>{t('Generating root cause...')}</WorkingIndicator>
-              ) : rootCauseArtifact ? (
-                <Markdown raw={rootCauseArtifact.one_line_description} />
-              ) : null}
-            </SummaryContainer>
-            <Disclosure.Content>
-              <Stack gap="lg">
-                {rootCauseArtifact?.five_whys.length ? (
-                  <Stack gap="md">
-                    <Text bold>{t('Why did this happen?')}</Text>
-                    <Stack as="ul" gap="sm" paddingLeft="xl">
-                      {rootCauseArtifact.five_whys.map((why, index) => (
-                        <Container as="li" key={index}>
-                          <Markdown raw={why} />
-                        </Container>
-                      ))}
-                    </Stack>
-                  </Stack>
-                ) : null}
-                {rootCauseArtifact?.reproduction_steps?.length ? (
-                  <Stack gap="md">
-                    <Text bold>{t('Reproduction Steps')}</Text>
-                    <Stack as="ol" gap="sm" paddingLeft="xl">
-                      {rootCauseArtifact.reproduction_steps.map((step, index) => (
-                        <Container as="li" key={index}>
-                          <Markdown raw={step} />
-                        </Container>
-                      ))}
-                    </Stack>
-                  </Stack>
-                ) : null}
-                {rootCauseArtifact && rootCauseSection ? (
-                  <IssuePreviewRootCauseEvidence
-                    groupId={groupId}
-                    section={rootCauseSection}
-                  />
-                ) : null}
-              </Stack>
-            </Disclosure.Content>
-          </Disclosure>
-        </Container>
+      {rootCauseSection ? (
+        <IssuePreviewAutofixRootCauseSection
+          autofix={autofix}
+          defaultExpanded={defaultExpandedSection === 'rootCause'}
+          groupId={groupId}
+          section={rootCauseSection}
+        />
       ) : null}
     </Dividers>
   );
 }
-
-function IssuePreviewRootCauseEvidence({
-  groupId,
-  section,
-}: {
-  groupId: string;
-  section: AutofixSection;
-}) {
-  const evidence = useAutofixSectionEvidence({section});
-  if (evidence.length === 0) {
-    return null;
-  }
-
-  return (
-    <Stack gap="md">
-      <Text bold>{t('Evidence')}</Text>
-      <Flex gap="md" wrap="wrap">
-        {evidence.map(item => (
-          <AutofixEvidence
-            key={item.toolCall.id}
-            evidenceButtonProps={item.evidenceButtonProps}
-            groupId={groupId}
-            toolCall={item.toolCall}
-          />
-        ))}
-      </Flex>
-    </Stack>
-  );
-}
-
-function WorkingIndicator({children}: {children: React.ReactNode}) {
-  return (
-    <Flex align="center" gap="sm">
-      <WorkingSpinner size={16} />
-      <Text variant="muted">{children}</Text>
-    </Flex>
-  );
-}
-
-// Summary container is always displayed event if Disclosure is closed
-// Left padding needs to match the indent of Disclosure.Content
-const SummaryContainer = styled(Container)`
-  padding: 0 ${p => p.theme.space.md} ${p => p.theme.space.md} 26px;
-`;
-
-const WorkingSpinner = styled(LoadingIndicator)`
-  margin: 0;
-`;
-
-const FileDiffList = styled(Stack)`
-  & > :not(:first-child) {
-    border-top: 0;
-    border-top-left-radius: 0;
-    border-top-right-radius: 0;
-  }
-
-  & > :not(:last-child) {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
-  }
-`;
 
 const Dividers = styled('div')`
   display: flex;

--- a/static/app/views/issueDetails/issuePreview/issuePreviewSection.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewSection.tsx
@@ -1,0 +1,64 @@
+import styled from '@emotion/styled';
+
+import {Disclosure} from '@sentry/scraps/disclosure';
+import {Container} from '@sentry/scraps/layout';
+import {Heading} from '@sentry/scraps/text';
+
+function IssuePreviewSectionComponent({
+  children,
+  defaultExpanded,
+  title,
+}: {
+  children: NonNullable<React.ReactNode>;
+  title: string;
+  defaultExpanded?: boolean;
+}) {
+  return (
+    <Container>
+      <Disclosure
+        as="section"
+        aria-label={title}
+        size="md"
+        defaultExpanded={defaultExpanded}
+      >
+        {children}
+      </Disclosure>
+    </Container>
+  );
+}
+
+function Title({
+  children,
+  trailingItems,
+}: {
+  children: React.ReactNode;
+  trailingItems?: React.ReactNode;
+}) {
+  return (
+    <Disclosure.Title trailingItems={trailingItems}>
+      <Heading as="h3" size="md">
+        {children}
+      </Heading>
+    </Disclosure.Title>
+  );
+}
+
+function Summary({children}: {children: React.ReactNode}) {
+  return <SummaryContainer>{children}</SummaryContainer>;
+}
+
+/**
+ * Thin abstraction over the Disclosure component which is meant to be used for the issue preview sections.
+ * Issue preview sections have summary lines which need to be indented to visually match the content lines.
+ */
+export const IssuePreviewSection = Object.assign(IssuePreviewSectionComponent, {
+  Content: Disclosure.Content,
+  Summary,
+  Title,
+});
+
+// Always displayed, even if the disclosure is closed. The left padding matches
+// the indent of Disclosure.Content.
+const SummaryContainer = styled(Container)`
+  padding: 0 ${p => p.theme.space.md} ${p => p.theme.space.md} 26px;
+`;

--- a/static/app/views/issueDetails/issuePreview/issuePreviewSection.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewSection.tsx
@@ -7,20 +7,13 @@ import {Heading} from '@sentry/scraps/text';
 function IssuePreviewSectionComponent({
   children,
   defaultExpanded,
-  title,
 }: {
   children: NonNullable<React.ReactNode>;
-  title: string;
   defaultExpanded?: boolean;
 }) {
   return (
     <Container>
-      <Disclosure
-        as="section"
-        aria-label={title}
-        size="md"
-        defaultExpanded={defaultExpanded}
-      >
+      <Disclosure as="section" size="md" defaultExpanded={defaultExpanded}>
         {children}
       </Disclosure>
     </Container>

--- a/static/app/views/issueDetails/issuePreview/issuePreviewSection.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewSection.tsx
@@ -5,15 +5,22 @@ import {Container} from '@sentry/scraps/layout';
 import {Heading} from '@sentry/scraps/text';
 
 function IssuePreviewSectionComponent({
+  'aria-label': ariaLabel,
   children,
   defaultExpanded,
 }: {
+  'aria-label': string;
   children: NonNullable<React.ReactNode>;
   defaultExpanded?: boolean;
 }) {
   return (
     <Container>
-      <Disclosure as="section" size="md" defaultExpanded={defaultExpanded}>
+      <Disclosure
+        as="section"
+        aria-label={ariaLabel}
+        size="md"
+        defaultExpanded={defaultExpanded}
+      >
         {children}
       </Disclosure>
     </Container>

--- a/static/app/views/issueDetails/issuePreview/retryableAutofixSection.tsx
+++ b/static/app/views/issueDetails/issuePreview/retryableAutofixSection.tsx
@@ -1,0 +1,106 @@
+import {createContext, use} from 'react';
+
+import {Button} from '@sentry/scraps/button';
+import {Container} from '@sentry/scraps/layout';
+
+import {
+  type AutofixExplorerStep,
+  type AutofixSection,
+  type useExplorerAutofix,
+} from 'sentry/components/events/autofix/useExplorerAutofix';
+import {AutofixResetPrompt} from 'sentry/components/events/autofix/v3/autofixResetPrompt';
+import {useResetAutofixStep} from 'sentry/components/events/autofix/v3/useResetAutofixStep';
+import {IconRefresh} from 'sentry/icons';
+import {t} from 'sentry/locale';
+
+interface RetryableAutofixSectionContextValue {
+  canReset: boolean;
+  handleReset: (userContext?: string) => Promise<void>;
+  setShouldShowReset: (shouldShowReset: boolean) => void;
+  shouldShowReset: boolean;
+}
+
+const RetryableAutofixSectionContext =
+  createContext<RetryableAutofixSectionContextValue | null>(null);
+
+export function RetryableAutofixSection({
+  autofix,
+  children,
+  section,
+  step,
+}: {
+  autofix: ReturnType<typeof useExplorerAutofix>;
+  children: React.ReactNode;
+  section: AutofixSection;
+  step: AutofixExplorerStep;
+}) {
+  const {canReset, shouldShowReset, setShouldShowReset, handleReset} =
+    useResetAutofixStep({
+      autofix,
+      section,
+      step,
+    });
+
+  return (
+    <RetryableAutofixSectionContext
+      value={{
+        canReset,
+        handleReset,
+        setShouldShowReset,
+        shouldShowReset,
+      }}
+    >
+      {children}
+    </RetryableAutofixSectionContext>
+  );
+}
+
+function RetryButton() {
+  const {canReset, setShouldShowReset} = useRetryableAutofixSection();
+
+  return (
+    <Button
+      size="xs"
+      variant="transparent"
+      icon={<IconRefresh size="xs" />}
+      aria-label={t('Re-run step')}
+      tooltipProps={{title: t('Re-run step')}}
+      onClick={() => setShouldShowReset(true)}
+      disabled={!canReset}
+    />
+  );
+}
+
+function ResetPrompt({
+  placeholder,
+  prompt,
+}: {
+  placeholder: string;
+  prompt: React.ReactNode;
+}) {
+  const {handleReset, setShouldShowReset, shouldShowReset} = useRetryableAutofixSection();
+
+  return shouldShowReset ? (
+    <Container paddingBottom="xl">
+      <AutofixResetPrompt
+        onClosePrompt={() => setShouldShowReset(false)}
+        onReset={handleReset}
+        placeholder={placeholder}
+        prompt={prompt}
+      />
+    </Container>
+  ) : null;
+}
+
+function useRetryableAutofixSection() {
+  const context = use(RetryableAutofixSectionContext);
+  if (!context) {
+    throw new Error(
+      'RetryableAutofixSection components must be rendered inside RetryableAutofixSection'
+    );
+  }
+  return context;
+}
+
+RetryableAutofixSection.Button = RetryButton;
+RetryableAutofixSection.Prompt = ResetPrompt;

--- a/static/app/views/issueDetails/issuePreview/workingIndicator.tsx
+++ b/static/app/views/issueDetails/issuePreview/workingIndicator.tsx
@@ -1,0 +1,19 @@
+import styled from '@emotion/styled';
+
+import {Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+
+export function WorkingIndicator({children}: {children: React.ReactNode}) {
+  return (
+    <Flex align="center" gap="sm">
+      <WorkingSpinner size={16} />
+      <Text variant="muted">{children}</Text>
+    </Flex>
+  );
+}
+
+const WorkingSpinner = styled(LoadingIndicator)`
+  margin: 0;
+`;

--- a/tests/js/fixtures/autofix.ts
+++ b/tests/js/fixtures/autofix.ts
@@ -1,8 +1,27 @@
 import type {
   ExplorerAutofixResponse,
   ExplorerAutofixState,
+  useExplorerAutofix,
 } from 'sentry/components/events/autofix/useExplorerAutofix';
 import type {Artifact, Block, RepoPRState} from 'sentry/views/seerExplorer/types';
+
+export function ExplorerAutofixFixture(
+  params: Partial<ReturnType<typeof useExplorerAutofix>> = {}
+): ReturnType<typeof useExplorerAutofix> {
+  return {
+    runState: ExplorerAutofixStateFixture(),
+    startStep: jest.fn(),
+    createPR: jest.fn(),
+    reset: jest.fn(),
+    triggerCodingAgentHandoff: jest.fn(),
+    codingAgentErrors: [],
+    dismissCodingAgentError: jest.fn(),
+    warnings: [],
+    isLoading: false,
+    isPolling: false,
+    ...params,
+  };
+}
 
 export function AutofixRootCauseArtifactFixture(
   params: Partial<Artifact> = {}


### PR DESCRIPTION
Closes ISWF-3151

Issue preview sections now have a restart button which displays a prompt, similar to the autofix drawer.

While making this change, also refactored the sections so that they all reside in their own file.

<img width="964" height="193" alt="CleanShot 2026-08-04 at 16 22 50" src="https://github.com/user-attachments/assets/35b4cba0-007c-4d15-93c7-f9af531f2d77" />
