### PR TITLE
fix(issues): paginate project derived data generation

### DIFF
--- a/src/sentry/issues/derived/tasks.py
+++ b/src/sentry/issues/derived/tasks.py
@@ -25,12 +25,13 @@ BATCH_PROCESSING_DEADLINE = timedelta(seconds=30)  # taskworker hard kill timeou
 BATCH_RETRIGGER_TIMEOUT = timedelta(seconds=20)  # self-reschedule before the hard kill
 
 _BATCH_TASK_KEY = "process_project_derived_data_batch"
+_GENERATE_PROJECT_TASK_KEY = "generate_project_derived_data"
 _GENERATE_BATCH_TASK_KEY = "generate_project_derived_data_batch"
 _GENERATE_GROUP_TASK_KEY = "generate_group_derived_data"
 
 # Cap self-rescheduling rebuilds to avoid infinite loops on very large groups.
 _MAX_GENERATION_RUNS = 20
-# Hard limit on group IDs loaded per project-level task to bound memory.
+# Maximum group IDs loaded by one project-level task invocation.
 _MAX_PROJECT_GROUPS = 10_000
 
 
@@ -490,54 +491,65 @@ def process_project_derived_data_batch(
     silo_mode=SiloMode.CELL,
 )
 def generate_project_derived_data(
-    project_id: int, *, stale_only: bool = False, **kwargs: object
+    project_id: int,
+    cursor_group_id: int = 0,
+    *,
+    stale_only: bool = False,
+    **kwargs: object,
 ) -> None:
     """Generate derived data for groups in a project via build-and-promote.
 
-    Fans out ``build_and_promote_derived_data`` batches, which replace
-    existing rows via CAS without deleting them.
+    Pages through group IDs and fans out ``build_and_promote_derived_data``
+    batches, which replace existing rows via CAS without deleting them.
 
     When *stale_only* is True, only groups with a ``GroupDerivedData``
     row whose ``pipeline_hash`` is outdated or NULL are included.
     Groups without a row are not affected.
     """
+    from taskbroker_client.state import current_task
+
     from sentry import options
     from sentry.issues.derived.processing import PIPELINE
     from sentry.models.group import Group
+    from sentry.taskworker.selfchain_idempotency import already_spawned, mark_spawned
+
+    task_state = current_task()
+    activation_id = task_state.id if task_state else None
+    if activation_id and already_spawned(_GENERATE_PROJECT_TASK_KEY, activation_id):
+        logger.info(
+            "generate_project_derived_data.duplicate_redelivery.skipped",
+            extra={"project_id": project_id, "activation_id": activation_id},
+        )
+        metrics.incr(
+            "taskworker.selfchain.duplicate_skipped",
+            tags={"task": _GENERATE_PROJECT_TASK_KEY},
+        )
+        return
 
     batch_size = options.get("issues.derived.project-batch-size")
     max_tasks = options.get("issues.derived.project-max-tasks")
 
-    # TODO: support very large projects via paginated iteration
-    qs = Group.objects.filter(project_id=project_id)
+    page_size = min(_MAX_PROJECT_GROUPS, batch_size * max_tasks)
+    if page_size <= 0:
+        logger.error(
+            "generate_project_derived_data.invalid_batch_configuration",
+            extra={"batch_size": batch_size, "max_tasks": max_tasks},
+        )
+        return
+
+    qs = Group.objects.filter(project_id=project_id, id__gt=cursor_group_id)
     if stale_only:
         qs = _stale_pipeline_filter(qs, PIPELINE.pipeline_hash)
-    group_ids = list(qs.order_by("id").values_list("id", flat=True)[:_MAX_PROJECT_GROUPS])
+    group_ids = list(qs.order_by("id").values_list("id", flat=True)[: page_size + 1])
 
     if not group_ids:
         return
 
-    if len(group_ids) >= _MAX_PROJECT_GROUPS:
-        logger.error(
-            "generate_project_derived_data.too_many_groups",
-            extra={
-                "project_id": project_id,
-                "limit": _MAX_PROJECT_GROUPS,
-            },
-        )
+    has_more = len(group_ids) > page_size
+    group_ids = group_ids[:page_size]
+    next_cursor_group_id = group_ids[-1] if has_more else None
 
     ranges = _chunk_group_ids_into_ranges(group_ids, batch_size)
-
-    if len(ranges) > max_tasks:
-        logger.error(
-            "generate_project_derived_data.too_many_tasks",
-            extra={
-                "project_id": project_id,
-                "task_count": len(ranges),
-                "max_tasks": max_tasks,
-            },
-        )
-        return
 
     for start, end in ranges:
         generate_project_derived_data_batch.delay(
@@ -547,12 +559,25 @@ def generate_project_derived_data(
             stale_only=stale_only,
         )
 
+    if next_cursor_group_id is not None:
+        generate_project_derived_data.apply_async(
+            kwargs={
+                "project_id": project_id,
+                "cursor_group_id": next_cursor_group_id,
+                "stale_only": stale_only,
+            },
+            headers={"sentry-propagate-traces": False},
+        )
+        if activation_id:
+            mark_spawned(_GENERATE_PROJECT_TASK_KEY, activation_id)
+
     logger.info(
         "generate_project_derived_data.scheduled",
         extra={
             "project_id": project_id,
             "group_count": len(group_ids),
             "task_count": len(ranges),
+            "next_cursor_group_id": next_cursor_group_id,
         },
     )
 

--- a/tests/sentry/issues/derived/test_tasks.py
+++ b/tests/sentry/issues/derived/test_tasks.py
@@ -413,6 +413,87 @@ class GenerateProjectDerivedDataBatchResumeTest(DerivedDataTaskTestBase):
 
 
 @with_feature("projects:issue-action-log-write-to-db")
+class GenerateProjectDerivedDataPaginationTest(DerivedDataTaskTestBase):
+    def test_limits_page_to_max_tasks(self) -> None:
+        groups = self.create_unprocessed_groups(3)
+        group_ids = sorted(group.id for group in groups)
+
+        with (
+            override_options(
+                {
+                    "issues.derived.project-batch-size": 2,
+                    "issues.derived.project-max-tasks": 1,
+                }
+            ),
+            patch.object(generate_project_derived_data_batch, "delay") as mock_batch_delay,
+            patch.object(generate_project_derived_data, "apply_async") as mock_project_delay,
+        ):
+            generate_project_derived_data(project_id=self.project.id)
+
+        mock_batch_delay.assert_called_once_with(
+            project_id=self.project.id,
+            group_id_start=group_ids[0],
+            group_id_end=group_ids[1] + 1,
+            stale_only=False,
+        )
+        mock_project_delay.assert_called_once_with(
+            kwargs={
+                "project_id": self.project.id,
+                "cursor_group_id": group_ids[1],
+                "stale_only": False,
+            },
+            headers={"sentry-propagate-traces": False},
+        )
+
+    def test_schedules_the_next_page(self) -> None:
+        groups = self.create_unprocessed_groups(3)
+        group_ids = sorted(group.id for group in groups)
+
+        with (
+            patch("sentry.issues.derived.tasks._MAX_PROJECT_GROUPS", 2),
+            patch.object(generate_project_derived_data_batch, "delay") as mock_batch_delay,
+            patch.object(generate_project_derived_data, "apply_async") as mock_project_delay,
+        ):
+            generate_project_derived_data(project_id=self.project.id)
+
+        mock_batch_delay.assert_called_once_with(
+            project_id=self.project.id,
+            group_id_start=group_ids[0],
+            group_id_end=group_ids[1] + 1,
+            stale_only=False,
+        )
+        mock_project_delay.assert_called_once_with(
+            kwargs={
+                "project_id": self.project.id,
+                "cursor_group_id": group_ids[1],
+                "stale_only": False,
+            },
+            headers={"sentry-propagate-traces": False},
+        )
+
+    def test_resumes_after_the_cursor(self) -> None:
+        groups = self.create_unprocessed_groups(3)
+        group_ids = sorted(group.id for group in groups)
+
+        with (
+            patch.object(generate_project_derived_data_batch, "delay") as mock_batch_delay,
+            patch.object(generate_project_derived_data, "apply_async") as mock_project_delay,
+        ):
+            generate_project_derived_data(
+                project_id=self.project.id,
+                cursor_group_id=group_ids[1],
+            )
+
+        mock_batch_delay.assert_called_once_with(
+            project_id=self.project.id,
+            group_id_start=group_ids[2],
+            group_id_end=group_ids[2] + 1,
+            stale_only=False,
+        )
+        mock_project_delay.assert_not_called()
+
+
+@with_feature("projects:issue-action-log-write-to-db")
 class HealStaleDerivedDataTest(DerivedDataTaskTestBase):
     def test_finds_stale_projects_and_schedules(self) -> None:
         groups = self.create_unprocessed_groups(2)


### PR DESCRIPTION
Paginate the `generate_project_derived_data` backfill job.