### PR TITLE
ref(seer): instrument _resolve_viewer_context for SeerViewerContext retirement

### DIFF
--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -75,6 +75,17 @@ def _resolve_viewer_context(
     )
 
     if vc is None:
+        logger.warning(
+            "seer.viewer_context_not_set",
+            extra={
+                "explicit_org_id": explicit_vc.organization_id,
+                "explicit_user_id": explicit_vc.user_id,
+            },
+        )
+        metrics.incr(
+            "seer.viewer_context_resolution",
+            tags={"outcome": "contextvar_missing"},
+        )
         return explicit_vc
 
     has_mismatch = False
@@ -106,6 +117,14 @@ def _resolve_viewer_context(
             )
             has_mismatch = True
         user_id = explicit_vc.user_id
+
+    metrics.incr(
+        "seer.viewer_context_resolution",
+        tags={
+            "outcome": "mismatch" if has_mismatch else "match",
+            "has_project": str(vc.project_id is not None).lower(),
+        },
+    )
 
     return ViewerContext(
         organization_id=org_id,

--- a/tests/sentry/seer/test_signed_seer_api.py
+++ b/tests/sentry/seer/test_signed_seer_api.py
@@ -139,11 +139,27 @@ class TestResolveViewerContext:
         assert result.user_id == 7
         assert result.actor_type == ActorType.USER
 
-    def test_explicit_only(self) -> None:
+    @patch("sentry.seer.signed_seer_api.metrics")
+    @patch("sentry.seer.signed_seer_api.logger")
+    def test_explicit_only_warns_contextvar_missing(
+        self, mock_logger: MagicMock, mock_metrics: MagicMock
+    ) -> None:
         result = _resolve_viewer_context(SeerViewerContext(organization_id=99, user_id=5))
         assert result is not None
         assert result.organization_id == 99
         assert result.user_id == 5
+
+        mock_logger.warning.assert_called_once_with(
+            "seer.viewer_context_not_set",
+            extra={
+                "explicit_org_id": 99,
+                "explicit_user_id": 5,
+            },
+        )
+        mock_metrics.incr.assert_called_once_with(
+            "seer.viewer_context_resolution",
+            tags={"outcome": "contextvar_missing"},
+        )
 
     def test_contextvar_with_token(self) -> None:
         token = AuthenticatedToken(
@@ -170,8 +186,11 @@ class TestResolveViewerContext:
         assert result.user_id == 99
         assert result.actor_type == ActorType.USER
 
+    @patch("sentry.seer.signed_seer_api.metrics")
     @patch("sentry.seer.signed_seer_api.logger")
-    def test_mismatch_warns_and_strips_token(self, mock_logger: MagicMock) -> None:
+    def test_mismatch_warns_and_strips_token(
+        self, mock_logger: MagicMock, mock_metrics: MagicMock
+    ) -> None:
         token = AuthenticatedToken(
             kind="api_token",
             scopes=["org:read"],
@@ -186,6 +205,38 @@ class TestResolveViewerContext:
         assert result.token is None
         mock_logger.warning.assert_called_once()
         assert mock_logger.warning.call_args[0][0] == "seer.viewer_context_mismatch"
+        mock_metrics.incr.assert_called_once_with(
+            "seer.viewer_context_resolution",
+            tags={"outcome": "mismatch", "has_project": "false"},
+        )
+
+    @patch("sentry.seer.signed_seer_api.metrics")
+    def test_match_emits_metric_with_project_id(self, mock_metrics: MagicMock) -> None:
+        ctx = ViewerContext(
+            organization_id=42, user_id=7, project_id=100, actor_type=ActorType.USER
+        )
+        with viewer_context_scope(ctx):
+            result = _resolve_viewer_context(SeerViewerContext(organization_id=42, user_id=7))
+
+        assert result is not None
+        assert result.project_id == 100
+        mock_metrics.incr.assert_called_once_with(
+            "seer.viewer_context_resolution",
+            tags={"outcome": "match", "has_project": "true"},
+        )
+
+    @patch("sentry.seer.signed_seer_api.metrics")
+    def test_match_emits_metric_without_project_id(self, mock_metrics: MagicMock) -> None:
+        ctx = ViewerContext(organization_id=42, user_id=7, actor_type=ActorType.USER)
+        with viewer_context_scope(ctx):
+            result = _resolve_viewer_context(SeerViewerContext(organization_id=42, user_id=7))
+
+        assert result is not None
+        assert result.project_id is None
+        mock_metrics.incr.assert_called_once_with(
+            "seer.viewer_context_resolution",
+            tags={"outcome": "match", "has_project": "false"},
+        )
 
     def test_no_mismatch_keeps_token(self) -> None:
         token = AuthenticatedToken(


### PR DESCRIPTION
## Summary

- Adds `logger.warning` and `metrics.incr` to `_resolve_viewer_context` to identify call sites where the contextvar `ViewerContext` is missing or mismatched with the explicit `SeerViewerContext`
- Tracks three outcomes: `contextvar_missing`, `mismatch`, `match` — plus `has_project` on match to identify project attribution gaps
- Zero behavior change — only adds observability

This is Step 1 of the `SeerViewerContext` retirement plan ([AIML-3206](https://linear.app/getsentry/issue/AIML-3206)). Once deployed, the warnings will identify which entrypoints (consumers, periodic tasks) need `viewer_context_scope` added before `SeerViewerContext` can be removed.

## Test plan

- [x] Existing tests pass
- [x] New tests cover all three resolution outcomes (contextvar_missing, mismatch, match)
- [x] New tests verify `has_project` tag tracks project_id presence
- [ ] Deploy and monitor `seer.viewer_context_not_set` warnings in production to identify gaps