### PR TITLE
fix(issues): attribute attachment deletions in the group action log

### DIFF
--- a/src/sentry/api/endpoints/event_attachment_details.py
+++ b/src/sentry/api/endpoints/event_attachment_details.py
@@ -21,6 +21,11 @@ from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.auth.superuser import superuser_has_permission
 from sentry.auth.system import is_system_auth
 from sentry.constants import ATTACHMENTS_ROLE_DEFAULT
+from sentry.issues.action_log import (
+    action_context_scope,
+    resolve_action_actor,
+    resolve_action_source,
+)
 from sentry.models.activity import Activity
 from sentry.models.eventattachment import EventAttachment
 from sentry.models.organizationmember import OrganizationMember
@@ -187,12 +192,15 @@ class EventAttachmentDetailsEndpoint(ProjectEndpoint):
 
         # an activity with no group cannot be associated with an issue or displayed in an issue details page
         if attachment.group_id is not None:
-            Activity.objects.create(
-                group_id=attachment.group_id,
-                project=project,
-                type=ActivityType.DELETED_ATTACHMENT.value,
-                user_id=request.user.id,
-                data={},
-            )
+            with action_context_scope(
+                source=resolve_action_source(request), actor=resolve_action_actor(request)
+            ):
+                Activity.objects.create(
+                    group_id=attachment.group_id,
+                    project=project,
+                    type=ActivityType.DELETED_ATTACHMENT.value,
+                    user_id=request.user.id,
+                    data={},
+                )
         attachment.delete()
         return self.respond(status=204)

--- a/tests/sentry/api/endpoints/test_event_attachment_details.py
+++ b/tests/sentry/api/endpoints/test_event_attachment_details.py
@@ -2,9 +2,12 @@ import pytest
 from django.test import override_settings
 
 from sentry.attachments.base import CachedAttachment
+from sentry.issues.action_log import GroupActionActor
+from sentry.issues.action_log.types import DeletedAttachmentAction
 from sentry.models.activity import Activity
 from sentry.models.eventattachment import EventAttachment
 from sentry.testutils.cases import APITestCase, PermissionTestCase, TestCase
+from sentry.testutils.helpers.action_log import capture_action_log
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.options import override_options
@@ -202,6 +205,21 @@ class EventAttachmentDetailsTest(APITestCase, CreateAttachmentMixin):
         assert delete_activity.group_id == group_id
         assert delete_activity.group is not None
         assert delete_activity.group.id == group_id
+
+    @with_feature("organizations:event-attachments")
+    def test_delete_activity_attributes_to_request_user(self) -> None:
+        self.login_as(user=self.user)
+
+        group_id = self.create_group().id
+        self.create_attachment(group_id=group_id)
+        path = f"/api/0/projects/{self.organization.slug}/{self.project.slug}/events/{self.event.event_id}/attachments/{self.attachment.id}/"
+        with capture_action_log() as log:
+            response = self.client.delete(path)
+        assert response.status_code == 204
+
+        log.assert_logged(
+            DeletedAttachmentAction, group_id=group_id, actor=GroupActionActor.user(self.user.id)
+        )
 
 
 class EventAttachmentDetailsPermissionTest(PermissionTestCase, CreateAttachmentMixin):


### PR DESCRIPTION
Add `ActionContext` to attachment deletion activity -> group action logging.

Fixes SENTRY-5RK9
