### PR TITLE
fix(action_log): Codify that pipeline_hash=NULL means invalidated

### DIFF
--- a/src/sentry/issues/derived/processing.py
+++ b/src/sentry/issues/derived/processing.py
@@ -154,6 +154,11 @@ def _process_batch(
     last-writer-wins semantics are safe because all writers compute the
     same deterministic result for overlapping entry ranges.
 
+    Invalidated rows (null pipeline_hash) are treated as compatible with
+    any writer's hash: the row is known to be out of date and awaiting
+    replacement, but there's no reason to freeze incremental progress in
+    the meantime.
+
     When *persist* is False, only the in-memory object is updated — the
     caller is responsible for persisting the result (e.g. via
     ``promote_to_live``). Used for full generations that accumulate
@@ -181,7 +186,7 @@ def _process_batch(
     updated = GroupDerivedData.objects.filter(
         Q(id=derived.id, generated_at=derived.generated_at)
         & (Q(cursor_date__lt=last_date) | Q(cursor_date=last_date, cursor_id__lte=last_id))
-        & Q(pipeline_hash=derived.pipeline_hash)
+        & (Q(pipeline_hash=derived.pipeline_hash) | Q(pipeline_hash__isnull=True))
     ).update(cursor_date=last_date, cursor_id=last_id, **state_update)
 
     if updated:

--- a/src/sentry/issues/models/groupderiveddata.py
+++ b/src/sentry/issues/models/groupderiveddata.py
@@ -81,7 +81,8 @@ class GroupDerivedData(DefaultFieldsModel):
 
     # Pipeline hash stamped at row creation. If it doesn't match the current
     # pipeline hash, this row wasn't fully generated with the current config
-    # and needs to be regenerated.
+    # and needs to be regenerated. A NULL value officially marks the row as
+    # invalidated (known-out-of-date, awaiting replacement).
     pipeline_hash = models.CharField(max_length=16, null=True, default=None)
 
     class Meta:

--- a/tests/sentry/issues/derived/test_processing.py
+++ b/tests/sentry/issues/derived/test_processing.py
@@ -468,6 +468,38 @@ class ProcessGroupLogTest(TestCase):
         assert derived.cursor_id == first_cursor
         assert derived.pipeline_hash == "reset"
 
+    def test_pipeline_hash_null_stale_still_incrementally_updates(self) -> None:
+        # NULL ``pipeline_hash`` officially marks a row as stale — known to
+        # be out of date and awaiting replacement. Incremental writes should
+        # still advance a stale row rather than be frozen out.
+        group = self.create_group()
+        _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
+
+        derived = process_group_log(group.id)
+        first_cursor = derived.cursor_id
+
+        new_entry = GroupActionLogEntry.objects.create(
+            group_id=group.id,
+            project_id=group.project_id,
+            type=GroupActionType.VIEW,
+            actor_type=GroupActorType.SYSTEM,
+            actor_id=0,
+            source=SOURCE,
+            data={},
+        )
+
+        # Officially mark the row stale by resetting pipeline_hash to NULL.
+        GroupDerivedData.objects.filter(group_id=group.id).update(pipeline_hash=None)
+
+        processing._process_batch(processing.PIPELINE, derived, 1)
+
+        derived.refresh_from_db()
+        assert derived.cursor_id == new_entry.id
+        assert derived.cursor_id != first_cursor
+        # The row remains stale (NULL) — it's up to a subsequent full
+        # generation to restamp the current pipeline_hash.
+        assert derived.pipeline_hash is None
+
     def test_generated_at_change_skips_incremental_write(self) -> None:
         from django.utils import timezone
 


### PR DESCRIPTION
We've been playing with using bad pipeline hashes to signal GroupDerivedData rows we know to need regeneration.
This makes that pattern official, and makes incremental updates aware of it so they aren't at risk of being confused by it.

Using this magic value is a bit quirky, but has advantages:
* It fits nicely into "things with bad pipeline hash are stale" logic
* It makes an explicit distinction between "stale" and "invalidated" (see ISWF-3212)
* The NULL value makes it easy for us to build a conditional index of only stale items
