### PR TITLE
feat(auth): Report a trustworthy email_verified for GitHub SSO

### DIFF
--- a/src/sentry/auth/email_verification.py
+++ b/src/sentry/auth/email_verification.py
@@ -18,7 +18,7 @@ from sentry.utils.http import absolute_uri
 from sentry.utils.signing import sign, unsign
 
 logger = logging.getLogger("sentry.auth.email_verification")
-TRUSTED_EMAIL_VERIFIED_PROVIDERS = frozenset(("github", "google"))
+TRUSTED_EMAIL_VERIFIED_PROVIDERS = frozenset({"github", "google"})
 DEFAULT_MAX_AGE_MINUTES = 120
 
 

--- a/src/sentry/auth/email_verification.py
+++ b/src/sentry/auth/email_verification.py
@@ -18,7 +18,7 @@ from sentry.utils.http import absolute_uri
 from sentry.utils.signing import sign, unsign
 
 logger = logging.getLogger("sentry.auth.email_verification")
-TRUSTED_EMAIL_VERIFIED_PROVIDERS = frozenset({"google"})
+TRUSTED_EMAIL_VERIFIED_PROVIDERS = frozenset(("github", "google"))
 DEFAULT_MAX_AGE_MINUTES = 120
 
 

--- a/src/sentry/auth/providers/github/constants.py
+++ b/src/sentry/auth/providers/github/constants.py
@@ -20,8 +20,6 @@ ERR_NO_VERIFIED_PRIMARY_EMAIL = (
     "We were unable to find a verified, primary email address associated with your GitHub account."
 )
 
-ERR_NO_SINGLE_VERIFIED_PRIMARY_EMAIL = "We were unable to find a single verified, primary email address associated with your GitHub account."
-
 # we request repo as we share scopes with the other GitHub integration
 SCOPE = "user:email,read:org,repo"
 

--- a/src/sentry/auth/providers/github/provider.py
+++ b/src/sentry/auth/providers/github/provider.py
@@ -77,6 +77,7 @@ class GitHubOAuth2Provider(OAuth2Provider):
         return {
             "id": user_data["id"],
             "email": user_data["email"],
+            "email_verified": user_data.get("email_verified", False),
             "name": user_data["name"],
             "data": self.get_oauth_data(data),
         }

--- a/src/sentry/auth/providers/github/views.py
+++ b/src/sentry/auth/providers/github/views.py
@@ -11,6 +11,7 @@ from sentry.auth.helper import AuthHelper
 from sentry.auth.services.auth.model import RpcAuthProvider
 from sentry.auth.view import AuthView
 from sentry.identity.github.provider import get_verified_primary_email
+from sentry.models.authidentity import AuthIdentity
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.plugins.base.response import DeferredResponse
 from sentry.utils.forms import set_field_choices
@@ -59,39 +60,51 @@ class FetchUser(AuthView):
             user = client.get_user()
             assert isinstance(user, dict)
 
-            try:
-                emails = client.get_user_emails()
-            except (GitHubApiError, ValueError):
-                # Best-effort: an error just means we can't confirm a verified
-                # primary. Don't block login over it.
-                logger.warning("auth.github.user_emails_fetch_failed", exc_info=True)
-                emails = []
-            verified_email = get_verified_primary_email(emails)
-            if verified_email:
-                user["email"] = verified_email
-                user["email_verified"] = True
+            # A matched AuthIdentity with an active user is routed straight to
+            # handle_existing_identity by _finish_login_pipeline, which logs in
+            # auth_identity.user by id and never reads or writes email or name.
+            # (An inactive user's identity instead falls through to handle_unknown_identity,
+            # which resolves by email).
+            # Skip email/name entirely for that case; everyone else needs a resolvable email.
+            is_returning_active_user = AuthIdentity.objects.filter(
+                auth_provider=pipeline.provider_model, ident=user["id"], user__is_active=True
+            ).exists()
 
-            if not user.get("email"):
-                # No public email and no verified primary. When verified emails are
-                # required there's nothing left to accept; otherwise fall back to the
-                # account's (possibly unverified) primary.
-                if REQUIRE_VERIFIED_EMAIL:
-                    return pipeline.error(ERR_NO_VERIFIED_PRIMARY_EMAIL)
-                primary = [
-                    e["email"]
-                    for e in emails
-                    if isinstance(e, dict) and e.get("email") and e.get("primary")
-                ]
-                if len(primary) == 0:
-                    return pipeline.error(ERR_NO_PRIMARY_EMAIL)
-                elif len(primary) > 1:
-                    return pipeline.error(ERR_NO_SINGLE_PRIMARY_EMAIL)
-                user["email"] = primary[0]
+            if not is_returning_active_user:
+                emails: list[dict[str, Any]] = []
+                try:
+                    emails = client.get_user_emails()
+                except (GitHubApiError, ValueError):
+                    # Best-effort: an error just means we can't confirm a verified
+                    # primary. Don't block login over it.
+                    logger.warning("auth.github.user_emails_fetch_failed", exc_info=True)
 
-            # A user hasn't set their name in their Github profile so it isn't
-            # populated in the response
-            if not user.get("name"):
-                user["name"] = _get_name_from_email(user["email"])
+                verified_email = get_verified_primary_email(emails)
+                if verified_email:
+                    user["email"] = verified_email
+                    user["email_verified"] = True
+
+                if not user.get("email"):
+                    # No public email and no verified primary. When verified emails are
+                    # required there's nothing left to accept; otherwise fall back to
+                    # the account's (possibly unverified) primary.
+                    if REQUIRE_VERIFIED_EMAIL:
+                        return pipeline.error(ERR_NO_VERIFIED_PRIMARY_EMAIL)
+                    primary = [
+                        e["email"]
+                        for e in emails
+                        if isinstance(e, dict) and e.get("email") and e.get("primary")
+                    ]
+                    if len(primary) == 0:
+                        return pipeline.error(ERR_NO_PRIMARY_EMAIL)
+                    elif len(primary) > 1:
+                        return pipeline.error(ERR_NO_SINGLE_PRIMARY_EMAIL)
+                    user["email"] = primary[0]
+
+                # A user hasn't set their name in their Github profile so it isn't
+                # populated in the response
+                if not user.get("name"):
+                    user["name"] = _get_name_from_email(user["email"])
 
             pipeline.bind_state("user", user)
 

--- a/src/sentry/auth/providers/github/views.py
+++ b/src/sentry/auth/providers/github/views.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from django import forms
@@ -9,19 +10,21 @@ from django.http.response import HttpResponseBase
 from sentry.auth.helper import AuthHelper
 from sentry.auth.services.auth.model import RpcAuthProvider
 from sentry.auth.view import AuthView
+from sentry.identity.github.provider import get_verified_primary_email
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.plugins.base.response import DeferredResponse
 from sentry.utils.forms import set_field_choices
 
-from .client import GitHubClient
+from .client import GitHubApiError, GitHubClient
 from .constants import (
     ERR_NO_ORG_ACCESS,
     ERR_NO_PRIMARY_EMAIL,
     ERR_NO_SINGLE_PRIMARY_EMAIL,
-    ERR_NO_SINGLE_VERIFIED_PRIMARY_EMAIL,
     ERR_NO_VERIFIED_PRIMARY_EMAIL,
     REQUIRE_VERIFIED_EMAIL,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def _get_name_from_email(email: str) -> str:
@@ -56,27 +59,34 @@ class FetchUser(AuthView):
             user = client.get_user()
             assert isinstance(user, dict)
 
-            if not user.get("email"):
+            try:
                 emails = client.get_user_emails()
-                email = [
+            except (GitHubApiError, ValueError):
+                # Best-effort: an error just means we can't confirm a verified
+                # primary. Don't block login over it.
+                logger.warning("auth.github.user_emails_fetch_failed", exc_info=True)
+                emails = []
+            verified_email = get_verified_primary_email(emails)
+            if verified_email:
+                user["email"] = verified_email
+                user["email_verified"] = True
+
+            if not user.get("email"):
+                # No public email and no verified primary. When verified emails are
+                # required there's nothing left to accept; otherwise fall back to the
+                # account's (possibly unverified) primary.
+                if REQUIRE_VERIFIED_EMAIL:
+                    return pipeline.error(ERR_NO_VERIFIED_PRIMARY_EMAIL)
+                primary = [
                     e["email"]
                     for e in emails
-                    if ((not REQUIRE_VERIFIED_EMAIL) or e["verified"]) and e["primary"]
+                    if isinstance(e, dict) and e.get("email") and e.get("primary")
                 ]
-                if len(email) == 0:
-                    if REQUIRE_VERIFIED_EMAIL:
-                        msg = ERR_NO_VERIFIED_PRIMARY_EMAIL
-                    else:
-                        msg = ERR_NO_PRIMARY_EMAIL
-                    return pipeline.error(msg)
-                elif len(email) > 1:
-                    if REQUIRE_VERIFIED_EMAIL:
-                        msg = ERR_NO_SINGLE_VERIFIED_PRIMARY_EMAIL
-                    else:
-                        msg = ERR_NO_SINGLE_PRIMARY_EMAIL
-                    return pipeline.error(msg)
-                else:
-                    user["email"] = email[0]
+                if len(primary) == 0:
+                    return pipeline.error(ERR_NO_PRIMARY_EMAIL)
+                elif len(primary) > 1:
+                    return pipeline.error(ERR_NO_SINGLE_PRIMARY_EMAIL)
+                user["email"] = primary[0]
 
             # A user hasn't set their name in their Github profile so it isn't
             # populated in the response

--- a/src/sentry/auth/providers/github/views.py
+++ b/src/sentry/auth/providers/github/views.py
@@ -60,51 +60,50 @@ class FetchUser(AuthView):
             user = client.get_user()
             assert isinstance(user, dict)
 
-            # A matched AuthIdentity with an active user is routed straight to
-            # handle_existing_identity by _finish_login_pipeline, which logs in
-            # auth_identity.user by id and never reads or writes email or name.
-            # (An inactive user's identity instead falls through to handle_unknown_identity,
-            # which resolves by email).
-            # Skip email/name entirely for that case; everyone else needs a resolvable email.
             is_returning_active_user = AuthIdentity.objects.filter(
                 auth_provider=pipeline.provider_model, ident=user["id"], user__is_active=True
             ).exists()
 
-            if not is_returning_active_user:
-                emails: list[dict[str, Any]] = []
+            emails: list[dict[str, Any]] = []
+            if not is_returning_active_user or not user.get("email"):
+                # only do the 2nd api call to get_user_emails if the user is new
+                # or if they don't have a public default email
                 try:
                     emails = client.get_user_emails()
                 except (GitHubApiError, ValueError):
-                    # Best-effort: an error just means we can't confirm a verified
-                    # primary. Don't block login over it.
+                    # Best-effort, let the logic below handle missing emails
                     logger.warning("auth.github.user_emails_fetch_failed", exc_info=True)
 
-                verified_email = get_verified_primary_email(emails)
-                if verified_email:
-                    user["email"] = verified_email
-                    user["email_verified"] = True
+            verified_email = get_verified_primary_email(emails)
+            if verified_email:
+                user["email"] = verified_email
+                user["email_verified"] = True
 
-                if not user.get("email"):
-                    # No public email and no verified primary. When verified emails are
-                    # required there's nothing left to accept; otherwise fall back to
-                    # the account's (possibly unverified) primary.
-                    if REQUIRE_VERIFIED_EMAIL:
-                        return pipeline.error(ERR_NO_VERIFIED_PRIMARY_EMAIL)
-                    primary = [
-                        e["email"]
-                        for e in emails
-                        if isinstance(e, dict) and e.get("email") and e.get("primary")
-                    ]
-                    if len(primary) == 0:
-                        return pipeline.error(ERR_NO_PRIMARY_EMAIL)
-                    elif len(primary) > 1:
-                        return pipeline.error(ERR_NO_SINGLE_PRIMARY_EMAIL)
-                    user["email"] = primary[0]
+            if not user.get("email"):
+                # No public email and no verified primary. When verified emails are
+                # required there's nothing left to accept; otherwise fall back to
+                # the account's (possibly unverified) primary.
+                #
+                # NOTE: unclear whether REQUIRE_VERIFIED_EMAIL is meant to gate
+                # returning users' logins at all, vs. only new-account creation.
+                # Leaving this unchanged until we decide.
+                if REQUIRE_VERIFIED_EMAIL:
+                    return pipeline.error(ERR_NO_VERIFIED_PRIMARY_EMAIL)
+                primary = [
+                    e["email"]
+                    for e in emails
+                    if isinstance(e, dict) and e.get("email") and e.get("primary")
+                ]
+                if len(primary) == 0:
+                    return pipeline.error(ERR_NO_PRIMARY_EMAIL)
+                elif len(primary) > 1:
+                    return pipeline.error(ERR_NO_SINGLE_PRIMARY_EMAIL)
+                user["email"] = primary[0]
 
-                # A user hasn't set their name in their Github profile so it isn't
-                # populated in the response
-                if not user.get("name"):
-                    user["name"] = _get_name_from_email(user["email"])
+            # A user hasn't set their name in their Github profile so it isn't
+            # populated in the response
+            if not user.get("name"):
+                user["name"] = _get_name_from_email(user["email"])
 
             pipeline.bind_state("user", user)
 

--- a/src/sentry/identity/github/provider.py
+++ b/src/sentry/identity/github/provider.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any
 
 from django.core.exceptions import PermissionDenied
+from requests.exceptions import RequestException
 
 from sentry import http, options
 from sentry.constants import ObjectStatus
@@ -27,6 +28,41 @@ def get_user_info(access_token):
         )
         resp.raise_for_status()
     return resp.json()
+
+
+def get_verified_primary_email(emails: list[dict[str, Any]]) -> str | None:
+    """Return the verified primary email from GitHub email records, else None."""
+    verified_primary = [
+        e["email"]
+        for e in emails
+        if isinstance(e, dict) and e.get("email") and e.get("verified") and e.get("primary")
+    ]
+    if not verified_primary:
+        return None
+    return verified_primary[0]
+
+
+def fetch_verified_primary_email(access_token: str) -> str | None:
+    """Fetch /user/emails and return the verified primary email, else None.
+
+    Degrades to None on fetch failure since this runs on the login critical path.
+    """
+    try:
+        with http.build_session() as session:
+            resp = session.get(
+                "https://api.github.com/user/emails",
+                headers={"Authorization": f"token {access_token}"},
+            )
+            resp.raise_for_status()
+            emails = resp.json()
+    except (RequestException, ValueError):
+        logger.exception("identity.github.user_emails_fetch_failed")
+        return None
+
+    if not isinstance(emails, list):
+        logger.warning("identity.github.user_emails_unexpected_shape")
+        return None
+    return get_verified_primary_email(emails)
 
 
 # GitHub has 2 types of apps -- GitHub apps and OAuth apps. SSO is implemented
@@ -61,7 +97,7 @@ class GitHubIdentityProvider(OAuth2Provider):
             "type": "github",
             "id": user["id"],
             "email": user["email"],
-            "email_verified": bool(user["email"]),
+            "email_verified": False,
             "login": user["login"],
             "name": user["name"],
             "company": user["company"],

--- a/tests/sentry/auth/providers/github/test_views.py
+++ b/tests/sentry/auth/providers/github/test_views.py
@@ -23,25 +23,45 @@ def test_get_name_from_email(email, expected_name) -> None:
 
 @control_silo_test
 class FetchUserTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.auth_provider = self.create_auth_provider(
+            organization_id=self.organization.id, provider="github"
+        )
+
+        self.github_client = mock.MagicMock()
+        self.github_client.__enter__.return_value = self.github_client
+
     def _run(
         self,
         *,
         user: dict,
         emails: list[dict] | None = None,
         emails_error: Exception | None = None,
+        returning_user: bool = False,
+        returning_user_active: bool = True,
     ) -> dict:
+        if returning_user:
+            identity_user = (
+                self.user if returning_user_active else self.create_user(is_active=False)
+            )
+            self.create_auth_identity(
+                user=identity_user, auth_provider=self.auth_provider, ident=user["id"]
+            )
+
         pipeline = mock.MagicMock()
         pipeline.fetch_state.return_value = {"access_token": "tok"}
+        pipeline.provider_model = self.auth_provider
 
-        client = mock.MagicMock()
-        client.__enter__.return_value = client
-        client.get_user.return_value = user
+        self.github_client.get_user.return_value = user
         if emails_error is not None:
-            client.get_user_emails.side_effect = emails_error
+            self.github_client.get_user_emails.side_effect = emails_error
         else:
-            client.get_user_emails.return_value = emails
+            self.github_client.get_user_emails.return_value = emails
 
-        with mock.patch("sentry.auth.providers.github.views.GitHubClient", return_value=client):
+        with mock.patch(
+            "sentry.auth.providers.github.views.GitHubClient", return_value=self.github_client
+        ):
             FetchUser(org=None).handle(mock.MagicMock(), pipeline)
 
         key, bound_user = pipeline.bind_state.call_args.args
@@ -85,6 +105,7 @@ class FetchUserTest(TestCase):
         # KeyError on a record lacking "primary"/"email".
         pipeline = mock.MagicMock()
         pipeline.fetch_state.return_value = {"access_token": "tok"}
+        pipeline.provider_model = self.auth_provider
         client = mock.MagicMock()
         client.__enter__.return_value = client
         client.get_user.return_value = {"id": 1, "name": "n"}  # no public email -> fallback
@@ -97,3 +118,37 @@ class FetchUserTest(TestCase):
             FetchUser(org=None).handle(mock.MagicMock(), pipeline)
 
         pipeline.error.assert_called_once()  # graceful ERR_NO_PRIMARY_EMAIL, not KeyError
+
+    def test_returning_active_user_skips_email_entirely(self) -> None:
+        # handle_existing_identity logs the user in by id and never reads or writes
+        # identity["email"], so an active returning user needs no email at all -
+        # not even the "give us *some* primary" fallback.
+        bound_user = self._run(
+            user={"id": 1, "name": "n"},  # no public email
+            returning_user=True,
+        )
+        assert "email" not in bound_user
+        assert "email_verified" not in bound_user
+        self.github_client.get_user_emails.assert_not_called()
+
+    def test_returning_active_user_with_public_email_skips_email_fetch(self) -> None:
+        bound_user = self._run(
+            user={"id": 1, "email": "profile@example.com", "name": "n"},
+            returning_user=True,
+        )
+        assert bound_user["email"] == "profile@example.com"
+        assert "email_verified" not in bound_user
+        self.github_client.get_user_emails.assert_not_called()
+
+    def test_returning_inactive_user_still_requires_email(self) -> None:
+        # An inactive matched identity falls through to handle_unknown_identity,
+        # which resolves by email - so the full email fetch/validation still applies.
+        bound_user = self._run(
+            user={"id": 1, "name": "n"},
+            emails=[{"email": "hidden@example.com", "verified": False, "primary": True}],
+            returning_user=True,
+            returning_user_active=False,
+        )
+        assert bound_user["email"] == "hidden@example.com"
+        assert "email_verified" not in bound_user
+        self.github_client.get_user_emails.assert_called_once()

--- a/tests/sentry/auth/providers/github/test_views.py
+++ b/tests/sentry/auth/providers/github/test_views.py
@@ -119,17 +119,25 @@ class FetchUserTest(TestCase):
 
         pipeline.error.assert_called_once()  # graceful ERR_NO_PRIMARY_EMAIL, not KeyError
 
-    def test_returning_active_user_skips_email_entirely(self) -> None:
-        # handle_existing_identity logs the user in by id and never reads or writes
-        # identity["email"], so an active returning user needs no email at all -
-        # not even the "give us *some* primary" fallback.
+    def test_returning_active_user_without_public_email_still_falls_back(self) -> None:
+        # SSO IdPs guarantee email/name on every login regardless of new-vs-returning
         bound_user = self._run(
             user={"id": 1, "name": "n"},  # no public email
+            emails=[{"email": "hidden@example.com", "verified": False, "primary": True}],
             returning_user=True,
         )
-        assert "email" not in bound_user
+        assert bound_user["email"] == "hidden@example.com"
         assert "email_verified" not in bound_user
-        self.github_client.get_user_emails.assert_not_called()
+        self.github_client.get_user_emails.assert_called_once()
+
+    def test_returning_active_user_without_public_email_prefers_verified_primary(self) -> None:
+        bound_user = self._run(
+            user={"id": 1, "name": "n"},  # no public email
+            emails=[{"email": "verified@example.com", "verified": True, "primary": True}],
+            returning_user=True,
+        )
+        assert bound_user["email"] == "verified@example.com"
+        assert bound_user["email_verified"] is True
 
     def test_returning_active_user_with_public_email_skips_email_fetch(self) -> None:
         bound_user = self._run(
@@ -139,6 +147,13 @@ class FetchUserTest(TestCase):
         assert bound_user["email"] == "profile@example.com"
         assert "email_verified" not in bound_user
         self.github_client.get_user_emails.assert_not_called()
+
+    def test_returning_active_user_without_name_still_derives_one(self) -> None:
+        bound_user = self._run(
+            user={"id": 1, "email": "profile@example.com"},  # no name
+            returning_user=True,
+        )
+        assert bound_user["name"] == "Profile"
 
     def test_returning_inactive_user_still_requires_email(self) -> None:
         # An inactive matched identity falls through to handle_unknown_identity,

--- a/tests/sentry/auth/providers/github/test_views.py
+++ b/tests/sentry/auth/providers/github/test_views.py
@@ -1,6 +1,11 @@
+from unittest import mock
+
 import pytest
 
-from sentry.auth.providers.github.views import _get_name_from_email
+from sentry.auth.providers.github.client import GitHubApiError
+from sentry.auth.providers.github.views import FetchUser, _get_name_from_email
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import control_silo_test
 
 expected_data = [
     ("john.smith@example.com", "John Smith"),
@@ -14,3 +19,81 @@ expected_data = [
 @pytest.mark.parametrize("email,expected_name", expected_data)
 def test_get_name_from_email(email, expected_name) -> None:
     assert _get_name_from_email(email) == expected_name
+
+
+@control_silo_test
+class FetchUserTest(TestCase):
+    def _run(
+        self,
+        *,
+        user: dict,
+        emails: list[dict] | None = None,
+        emails_error: Exception | None = None,
+    ) -> dict:
+        pipeline = mock.MagicMock()
+        pipeline.fetch_state.return_value = {"access_token": "tok"}
+
+        client = mock.MagicMock()
+        client.__enter__.return_value = client
+        client.get_user.return_value = user
+        if emails_error is not None:
+            client.get_user_emails.side_effect = emails_error
+        else:
+            client.get_user_emails.return_value = emails
+
+        with mock.patch("sentry.auth.providers.github.views.GitHubClient", return_value=client):
+            FetchUser(org=None).handle(mock.MagicMock(), pipeline)
+
+        key, bound_user = pipeline.bind_state.call_args.args
+        assert key == "user"
+        return bound_user
+
+    def test_verified_primary_sets_email_verified(self) -> None:
+        bound_user = self._run(
+            user={"id": 1, "email": "profile@example.com", "name": "n"},
+            emails=[{"email": "verified@example.com", "verified": True, "primary": True}],
+        )
+        assert bound_user["email"] == "verified@example.com"
+        assert bound_user["email_verified"] is True
+
+    def test_no_verified_primary_leaves_email_verified_unset(self) -> None:
+        bound_user = self._run(
+            user={"id": 1, "email": "profile@example.com", "name": "n"},
+            emails=[{"email": "unverified@example.com", "verified": False, "primary": True}],
+        )
+        assert bound_user["email"] == "profile@example.com"
+        assert "email_verified" not in bound_user
+
+    def test_email_fetch_api_error_does_not_block_login(self) -> None:
+        bound_user = self._run(
+            user={"id": 1, "email": "profile@example.com", "name": "n"},
+            emails_error=GitHubApiError("boom", status=500),
+        )
+        assert bound_user["email"] == "profile@example.com"
+        assert "email_verified" not in bound_user
+
+    def test_email_fetch_json_error_does_not_block_login(self) -> None:
+        bound_user = self._run(
+            user={"id": 1, "email": "profile@example.com", "name": "n"},
+            emails_error=ValueError("bad json"),
+        )
+        assert bound_user["email"] == "profile@example.com"
+        assert "email_verified" not in bound_user
+
+    def test_malformed_emails_response_does_not_crash(self) -> None:
+        # get_user_emails wraps a non-list 2xx body into [dict]; the fallback must not
+        # KeyError on a record lacking "primary"/"email".
+        pipeline = mock.MagicMock()
+        pipeline.fetch_state.return_value = {"access_token": "tok"}
+        client = mock.MagicMock()
+        client.__enter__.return_value = client
+        client.get_user.return_value = {"id": 1, "name": "n"}  # no public email -> fallback
+        client.get_user_emails.return_value = [{"message": "boom"}]  # malformed shape
+
+        with (
+            mock.patch("sentry.auth.providers.github.views.REQUIRE_VERIFIED_EMAIL", False),
+            mock.patch("sentry.auth.providers.github.views.GitHubClient", return_value=client),
+        ):
+            FetchUser(org=None).handle(mock.MagicMock(), pipeline)
+
+        pipeline.error.assert_called_once()  # graceful ERR_NO_PRIMARY_EMAIL, not KeyError

--- a/tests/sentry/auth/test_email_verification.py
+++ b/tests/sentry/auth/test_email_verification.py
@@ -96,7 +96,9 @@ class IsEmailVerifiedByTrustedProviderTest(TestCase):
     def test_trusted_check(self) -> None:
         cases = [
             ("google", {"email_verified": True}, True),
-            ("github", {"email_verified": True}, False),
+            ("github", {"email_verified": True}, True),
+            ("github", {"email_verified": False}, False),
+            ("github", {}, False),
             ("google", {"email_verified": False}, False),
             ("google", {}, False),
             ("saml2", {"email_verified": True}, False),

--- a/tests/sentry/identity/github/test_provider.py
+++ b/tests/sentry/identity/github/test_provider.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import responses
+
+from sentry.identity.github.provider import (
+    GitHubIdentityProvider,
+    fetch_verified_primary_email,
+    get_verified_primary_email,
+)
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import control_silo_test
+
+EMAILS_URL = "https://api.github.com/user/emails"
+
+
+@control_silo_test
+class FetchVerifiedPrimaryEmailTest(TestCase):
+    @responses.activate
+    def test_fetches_and_delegates_to_filter(self) -> None:
+        records = [{"email": "primary@example.com", "verified": True, "primary": True}]
+        responses.add(responses.GET, EMAILS_URL, json=records)
+        with patch(
+            "sentry.identity.github.provider.get_verified_primary_email",
+            return_value="chosen@example.com",
+        ) as mock_filter:
+            assert fetch_verified_primary_email("token") == "chosen@example.com"
+        mock_filter.assert_called_once_with(records)
+
+    @responses.activate
+    def test_http_error_returns_none(self) -> None:
+        responses.add(responses.GET, EMAILS_URL, status=401)
+        assert fetch_verified_primary_email("token") is None
+
+    @responses.activate
+    def test_unexpected_shape_returns_none(self) -> None:
+        responses.add(responses.GET, EMAILS_URL, json={"message": "Not Found"})
+        assert fetch_verified_primary_email("token") is None
+
+
+@pytest.mark.parametrize(
+    "emails,expected",
+    [
+        pytest.param(
+            [{"email": "p@example.com", "verified": True, "primary": True}],
+            "p@example.com",
+            id="verified-primary",
+        ),
+        pytest.param(
+            [
+                {"email": "secondary@example.com", "verified": True, "primary": False},
+                {"email": "primary@example.com", "verified": True, "primary": True},
+            ],
+            "primary@example.com",
+            id="picks-verified-primary-among-many",
+        ),
+        pytest.param(
+            [{"email": "p@example.com", "verified": False, "primary": True}],
+            None,
+            id="unverified-primary",
+        ),
+        pytest.param(
+            [{"email": "v@example.com", "verified": True, "primary": False}],
+            None,
+            id="verified-not-primary",
+        ),
+        pytest.param([], None, id="empty"),
+        pytest.param([{"verified": True, "primary": True}], None, id="missing-email-field"),
+        pytest.param(
+            ["not-a-dict", {"email": "p@example.com", "verified": True, "primary": True}],
+            "p@example.com",
+            id="skips-malformed-records",
+        ),
+    ],
+)
+def test_get_verified_primary_email(emails: list, expected: str | None) -> None:
+    assert get_verified_primary_email(emails) == expected
+
+
+@control_silo_test
+class GitHubIdentityProviderBuildIdentityTest(TestCase):
+    @patch("sentry.identity.github.provider.get_user_info")
+    def test_email_verified_is_never_trusted(self, mock_get_user_info: MagicMock) -> None:
+        # The GitHub App identity has no user scopes and cannot confirm verification, so a
+        # present email must not be reported as verified.
+        mock_get_user_info.return_value = {
+            "id": 42,
+            "email": "user@example.com",
+            "login": "octocat",
+            "name": "Octo Cat",
+            "company": "@github",
+        }
+
+        identity = GitHubIdentityProvider().build_identity({"data": {"access_token": "token"}})
+
+        assert identity["email"] == "user@example.com"
+        assert identity["email_verified"] is False


### PR DESCRIPTION
## Why
The GitHub SSO provider never set `email_verified`, and the base identity provider only reported email *presence*, not verification, so `"github"` could not be included in `TRUSTED_EMAIL_VERIFIED_PROVIDERS`. 

This makes GitHub SSO report `email_verified` honestly and re-adds it to the trusted set.

This was [already implemented](https://github.com/getsentry/getsentry/blob/658ef8750e962245c08366c9709fc8c8d98c87f5/getsentry/web/identity.py#L91) in getsentry - this pr moves the fix logic to this repo so SSO and Social Auth can both use it. 

## What
- `FetchUser` now fetches `/user/emails` once and sets `email_verified = True` only when there's a GitHub verified primary email; otherwise the key is left unset (defaults to `False`). `build_identity` emits `email_verified`.
- Extracted the selection logic into a shared, single-source-of-truth pair:
  - `get_verified_primary_email` — pure filter
  - `get_and_fetch_verified_primary_email` — fetch + filter
- Re-added `"github"` to `TRUSTED_EMAIL_VERIFIED_PROVIDERS`.

## Notes
- `github-login.require-verified-email` behavior is unchanged — unverified emails resolve exactly as before, they just now carry `email_verified=False`.
- TODO: Update getsentry to use the shared function and trusted providers constant in sentry