### PR TITLE
ref(feedback): Make transparent variant the default

### DIFF
--- a/static/app/components/events/featureFlags/eventFeatureFlagSection.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagSection.tsx
@@ -62,6 +62,7 @@ function BaseEventFeatureFlagList({event, group, project}: EventFeatureFlagSecti
 
   const feedbackButton = isXsScreen ? null : (
     <FeedbackButton
+      variant="secondary"
       aria-label={t('Give feedback on the feature flag section')}
       size="xs"
       feedbackOptions={{

--- a/static/app/components/feedback/summaryCategories/feedbackSummaryCategories.tsx
+++ b/static/app/components/feedback/summaryCategories/feedbackSummaryCategories.tsx
@@ -27,6 +27,7 @@ export function FeedbackSummaryCategories() {
   const feedbackButton = ({type}: {type: 'positive' | 'negative'}) => {
     return (
       <FeedbackButton
+        variant="secondary"
         aria-label={t('Give feedback on the AI-powered summary')}
         icon={<IconThumb direction={type === 'positive' ? 'up' : 'down'} />}
         tooltipProps={{

--- a/static/app/components/feedbackButton/feedbackButton.tsx
+++ b/static/app/components/feedbackButton/feedbackButton.tsx
@@ -30,7 +30,6 @@ interface Props extends Omit<ButtonProps, 'children'> {
  * @example
  * // Mix of Button and Feedback props
  * <FeedbackButton
- *   priority="primary"
  *   size="lg"
  *   feedbackOptions={{
  *     messagePlaceholder: 'Tell us what you think...',
@@ -46,12 +45,16 @@ interface Props extends Omit<ButtonProps, 'children'> {
  *
  * @param children - The content to display inside the button. If not provided, the default label 'Give Feedback' will be used.
  *
- * @param * - All standard Button props except `icon` (icon is fixed to megaphone).
- *                      Includes size, priority, disabled, onClick handlers, etc.
+ * @param * - All standard Button props. The button defaults to the `transparent` variant,
+ *            `sm` size, and megaphone icon; callers can override these defaults.
  *
  * @returns A Button that opens the feedback widget on click, or null if feedback is not enabled
  */
-export function FeedbackButton({feedbackOptions, ...buttonProps}: Props) {
+export function FeedbackButton({
+  feedbackOptions,
+  variant = 'transparent',
+  ...buttonProps
+}: Props) {
   const buttonRef = useRef<HTMLButtonElement>(null);
   const openForm = useFeedbackForm();
 
@@ -67,6 +70,7 @@ export function FeedbackButton({feedbackOptions, ...buttonProps}: Props) {
       ref={buttonRef}
       size="sm"
       icon={<IconMegaphone />}
+      variant={variant}
       {...buttonProps}
       onClick={e => {
         openForm?.(feedbackOptions);

--- a/static/app/components/replays/breadcrumbs/replayComparisonModal.tsx
+++ b/static/app/components/replays/breadcrumbs/replayComparisonModal.tsx
@@ -89,6 +89,7 @@ export default function ReplayComparisonModal({
               ) : null}
               {focusTrap ? (
                 <FeedbackButton
+                  variant="secondary"
                   feedbackOptions={{
                     onFormOpen: () => {
                       focusTrap.pause();

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
@@ -102,6 +102,7 @@ function FeedbackFooter({
         <OpenAskSeerButton ref={askSeerButtonRef} onTabForward={onAskSeerTabForward} />
       ) : null}
       <FeedbackButton
+        variant="secondary"
         size={hasAskSeerRework ? 'zero' : 'xs'}
         feedbackOptions={{
           messagePlaceholder: t('How can we make search better for you?'),

--- a/static/app/views/alerts/rules/metric/details/sidebar.tsx
+++ b/static/app/views/alerts/rules/metric/details/sidebar.tsx
@@ -162,6 +162,7 @@ export function MetricDetailsSidebar({
 
   const feedbackButton = (
     <FeedbackButton
+      variant="secondary"
       feedbackOptions={{
         formTitle: t('Anomaly Detection Feedback'),
         messagePlaceholder: t(

--- a/static/app/views/alerts/rules/metric/triggers/dynamicAlertsFeedbackButton.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/dynamicAlertsFeedbackButton.tsx
@@ -14,6 +14,7 @@ export function DynamicAlertsFeedbackButton() {
   return (
     <ButtonContainer>
       <FeedbackButton
+        variant="secondary"
         feedbackOptions={{
           formTitle: t('Anomaly Detection Feedback'),
           messagePlaceholder: t(

--- a/static/app/views/dashboards/widgets/widget/widget.tsx
+++ b/static/app/views/dashboards/widgets/widget/widget.tsx
@@ -20,6 +20,7 @@ const RENDER_ERROR_MESSAGE = t('Something went wrong displaying this widget.');
 function FeedbackAction() {
   return (
     <FeedbackButton
+      variant="secondary"
       size="xs"
       feedbackOptions={{
         messagePlaceholder: t('What were you doing when this widget broke?'),

--- a/static/app/views/explore/releases/detail/header/releaseActions.tsx
+++ b/static/app/views/explore/releases/detail/header/releaseActions.tsx
@@ -199,7 +199,7 @@ export function ReleaseActions({
   return (
     <Flex gap="sm" align="center">
       {showFeedbackButton ? (
-        <FeedbackButton feedbackOptions={releaseFeedbackOptions}>
+        <FeedbackButton variant="secondary" feedbackOptions={releaseFeedbackOptions}>
           {t('Give Feedback')}
         </FeedbackButton>
       ) : null}

--- a/static/app/views/explore/replays/detail/ai/ai.tsx
+++ b/static/app/views/explore/replays/detail/ai/ai.tsx
@@ -264,6 +264,7 @@ function ThumbsUpDownButton({
 }) {
   return (
     <FeedbackButton
+      variant="secondary"
       aria-label={t('Give feedback on the replay summary section')}
       icon={<IconThumb direction={type === 'positive' ? 'up' : 'down'} />}
       tooltipProps={{

--- a/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.tsx
+++ b/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.tsx
@@ -419,6 +419,7 @@ function TriggeredConditionDetails({
         actions={
           <Flex gap="xs">
             <FeedbackButton
+              variant="secondary"
               aria-label={t('Give feedback on metric issues')}
               size="xs"
               feedbackOptions={{

--- a/static/app/views/issueList/supergroups/supergroupDrawer.tsx
+++ b/static/app/views/issueList/supergroups/supergroupDrawer.tsx
@@ -90,6 +90,7 @@ export function SupergroupDetailDrawer({
             <Badge variant="experimental">{t('Experimental')}</Badge>
           </Flex>
           <FeedbackButton
+            variant="secondary"
             size="xs"
             feedbackOptions={{
               formTitle: t('Give feedback on Issue Groups'),

--- a/static/gsApp/views/amCheckout/components/checkoutSuccess.tsx
+++ b/static/gsApp/views/amCheckout/components/checkoutSuccess.tsx
@@ -615,7 +615,11 @@ export function CheckoutSuccess({
             >
               {t('Edit plan')}
             </LinkButton>
-            <FeedbackButton feedbackOptions={checkoutSuccessFeedbackOptions} size="md" />
+            <FeedbackButton
+              variant="secondary"
+              feedbackOptions={checkoutSuccessFeedbackOptions}
+              size="md"
+            />
           </Flex>
         </Stack>
       </Stack>


### PR DESCRIPTION
Feedback buttons now default to the transparent variant so top-header call sites share a consistent low-emphasis presentation without repeating configuration.

Existing buttons outside top headers explicitly retain their previous secondary presentation, while callers can continue to request another variant when needed.
