### PR TITLE
fix(integrations): halt on network errors in IntegrationEventLifecycle

### DIFF
--- a/src/sentry/integrations/utils/metrics.py
+++ b/src/sentry/integrations/utils/metrics.py
@@ -365,6 +365,23 @@ class IntegrationEventLifecycle(EventLifecycle):
             # ApiHostError is raised from RestrictedIPAddress
             self.record_halt(exc_value)
             return
+
+        # Network-level failures (timeout, connection refused/reset) mean the
+        # external server is unreachable — an operational condition for
+        # customer-hosted integrations such as self-hosted Perforce servers,
+        # not a Sentry code defect.  Walk the full exception chain so we catch
+        # cases where the network error is wrapped (e.g.
+        # TimeoutError → P4Exception → ApiError).
+        # TimeoutError and ConnectionError are both builtins (subclasses of
+        # OSError) — no import needed.
+        if exc_value is not None:
+            cause: BaseException | None = exc_value
+            while cause is not None:
+                if isinstance(cause, (TimeoutError, ConnectionError)):
+                    self.record_halt(exc_value)
+                    return
+                cause = cause.__cause__
+
         super().__exit__(exc_type, exc_value, traceback)
 
 

--- a/tests/sentry/integrations/utils/test_lifecycle_metrics.py
+++ b/tests/sentry/integrations/utils/test_lifecycle_metrics.py
@@ -409,6 +409,82 @@ class IntegrationEventLifecycleMetricTest(TestCase):
         mock_logger.warning.assert_not_called()
         mock_random.random.assert_called_once()
 
+    # ------------------------------------------------------------------
+    # IntegrationEventLifecycle.__exit__ network-error halt tests
+    # ------------------------------------------------------------------
+
+    @mock.patch("sentry.integrations.utils.metrics.sentry_sdk")
+    @mock.patch("sentry.integrations.utils.metrics.logger")
+    @mock.patch("sentry.integrations.utils.metrics.metrics")
+    def test_timeout_error_direct_causes_halt(
+        self, mock_metrics: mock.MagicMock, mock_logger: mock.MagicMock, mock_sentry_sdk: mock.MagicMock
+    ) -> None:
+        """A TimeoutError raised directly inside the lifecycle context records halt, not failure."""
+        metric_obj = self.TestLifecycleMetric()
+
+        with pytest.raises(TimeoutError):
+            with metric_obj.capture():
+                raise TimeoutError("timed out")
+
+        self._check_metrics_call_args(mock_metrics, "halted")
+        mock_sentry_sdk.capture_exception.assert_not_called()
+
+    @mock.patch("sentry.integrations.utils.metrics.sentry_sdk")
+    @mock.patch("sentry.integrations.utils.metrics.logger")
+    @mock.patch("sentry.integrations.utils.metrics.metrics")
+    def test_connection_error_direct_causes_halt(
+        self, mock_metrics: mock.MagicMock, mock_logger: mock.MagicMock, mock_sentry_sdk: mock.MagicMock
+    ) -> None:
+        """A ConnectionError raised directly inside the lifecycle context records halt, not failure."""
+        metric_obj = self.TestLifecycleMetric()
+
+        with pytest.raises(ConnectionError):
+            with metric_obj.capture():
+                raise ConnectionError("connection refused")
+
+        self._check_metrics_call_args(mock_metrics, "halted")
+        mock_sentry_sdk.capture_exception.assert_not_called()
+
+    @mock.patch("sentry.integrations.utils.metrics.sentry_sdk")
+    @mock.patch("sentry.integrations.utils.metrics.logger")
+    @mock.patch("sentry.integrations.utils.metrics.metrics")
+    def test_timeout_error_chained_via_cause_causes_halt(
+        self, mock_metrics: mock.MagicMock, mock_logger: mock.MagicMock, mock_sentry_sdk: mock.MagicMock
+    ) -> None:
+        """A TimeoutError buried in the __cause__ chain causes halt — mirrors the
+        Perforce pattern where TimeoutError → P4Exception → ApiError."""
+        metric_obj = self.TestLifecycleMetric()
+
+        timeout = TimeoutError("timed out")
+        intermediate = RuntimeError("connect to server failed")
+        intermediate.__cause__ = timeout
+        outer = ExampleException("Failed to connect: ...")
+        outer.__cause__ = intermediate
+
+        with pytest.raises(ExampleException):
+            with metric_obj.capture():
+                raise outer
+
+        self._check_metrics_call_args(mock_metrics, "halted")
+        mock_sentry_sdk.capture_exception.assert_not_called()
+
+    @mock.patch("sentry.integrations.utils.metrics.sentry_sdk")
+    @mock.patch("sentry.integrations.utils.metrics.logger")
+    @mock.patch("sentry.integrations.utils.metrics.metrics")
+    def test_unrelated_exception_still_causes_failure(
+        self, mock_metrics: mock.MagicMock, mock_logger: mock.MagicMock, mock_sentry_sdk: mock.MagicMock
+    ) -> None:
+        """An exception with no network error in its cause chain still records failure."""
+        mock_sentry_sdk.capture_exception.return_value = "test-event-id"
+        metric_obj = self.TestLifecycleMetric()
+
+        with pytest.raises(ExampleException):
+            with metric_obj.capture():
+                raise ExampleException("something else went wrong")
+
+        self._check_metrics_call_args(mock_metrics, "failure")
+        mock_sentry_sdk.capture_exception.assert_called_once()
+
     @mock.patch("sentry.integrations.utils.metrics.random")
     @mock.patch("sentry.integrations.utils.metrics.logger")
     @mock.patch("sentry.integrations.utils.metrics.metrics")


### PR DESCRIPTION
## Summary

**Sentry reference:** event `a8f3079a968b4c28827c0f2d011e85d0`, group 107331001

**Triage session:** https://claude.ai/code/session_01RUZMwbTkRRnjjKZ8E88Di9

### Root cause

`IntegrationEventLifecycle.__exit__` in `src/sentry/integrations/utils/metrics.py` already special-cases `RestrictedIPAddress` → `record_halt`. But it did **not** handle the case where the root cause of an exception chain is a `TimeoutError` or `ConnectionError`.

When a customer-hosted integration server (e.g. a self-hosted Perforce server) is unreachable, the exception chain looks like:

```
TimeoutError: timed out
  → P4Exception: connect to server failed; check P4PORT...
    → ApiError: Failed to connect to Perforce: ...
```

`__exit__` receives the outer `ApiError`. Because none of the three exceptions in the chain matched `RestrictedIPAddress`, `super().__exit__` was called, which invoked `record_failure(exc_value, create_issue=True)` → `sentry_sdk.capture_exception(...)`, generating a noisy Sentry issue for what is simply an unreachable external server.

### Fix

Walk the full `__cause__` chain in `IntegrationEventLifecycle.__exit__`. When any link in the chain is a `TimeoutError` or `ConnectionError` (both are `OSError` builtins — no import needed), call `record_halt` instead of `record_failure`. `record_halt` logs the event at warning level and increments the `halted` SLO counter but does **not** call `sentry_sdk.capture_exception`, so no noisy Sentry issue is created.

This mirrors the existing `RestrictedIPAddress` pattern in the same method and applies consistently to **all** integrations, not just Perforce.

### What was ruled out

- **Fix only in the Perforce layer** — catching `TimeoutError`/`ConnectionError` inside `PerforceClient._connect()` and translating them to a non-issue-creating path would work for Perforce but would leave the same problem latent in every other customer-hosted integration. The lifecycle layer is the right place because it is the single exit point for all integration event contexts.
- **Suppressing the Sentry issue via `record_failure(create_issue=False)`** — this would still record a `failure` outcome in SLO metrics, which is incorrect: an unreachable external server is not a Sentry code defect.

## Changes

- `src/sentry/integrations/utils/metrics.py` — extend `IntegrationEventLifecycle.__exit__` to walk the exception `__cause__` chain and call `record_halt` when the root cause is a `TimeoutError` or `ConnectionError`.
- `tests/sentry/integrations/utils/test_lifecycle_metrics.py` — four new tests covering: direct `TimeoutError`, direct `ConnectionError`, chained `TimeoutError` (the Perforce pattern), and confirmation that unrelated exceptions still produce `failure`.

## Test plan

- [ ] `pytest -xvs tests/sentry/integrations/utils/test_lifecycle_metrics.py` — new tests pass, existing tests unaffected
- [ ] `pytest -xvs tests/sentry/integrations/perforce/` — Perforce integration tests unaffected
- [ ] Confirm SLO metrics show `halted` (not `failure`) for TCP timeout events going forward


---
_Generated by [Claude Code](https://claude.ai/code/session_01RUZMwbTkRRnjjKZ8E88Di9)_