### PR TITLE
fix(jira-server): Scope webhook integration lookup to the provider

### DIFF
--- a/src/sentry/integrations/jira_server/webhooks.py
+++ b/src/sentry/integrations/jira_server/webhooks.py
@@ -14,6 +14,7 @@ from sentry.api.base import Endpoint, cell_silo_endpoint
 from sentry.integrations.jira_server.utils import handle_assignee_change, handle_status_change
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.integrations.services.integration.service import integration_service
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.integrations.utils.scope import clear_organization_info
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.shared_integrations.exceptions import ApiError
@@ -39,7 +40,12 @@ def get_integration_from_token(token: str | None) -> RpcIntegration:
     if "id" not in unvalidated:
         raise ValueError("Token did not contain `id`")
 
-    integration = integration_service.get_integration(external_id=unvalidated["id"])
+    # Filter by provider as well: Integration's only index on external_id is the
+    # (provider, external_id) unique index, so an external_id-only lookup does a
+    # sequential scan of the whole table on every inbound Jira Server webhook.
+    integration = integration_service.get_integration(
+        provider=IntegrationProviderSlug.JIRA_SERVER.value, external_id=unvalidated["id"]
+    )
     if not integration:
         raise ValueError("Could not find integration for token")
     try:


### PR DESCRIPTION
`get_integration_from_token` resolved the webhook's integration with `get_integration(external_id=...)` — no provider. `Integration`'s only index covering `external_id` is the `(provider, external_id)` unique index, and with `provider` absent from the filter that index is unusable, so every inbound Jira Server webhook sequential-scans `sentry_integration`.

Database monitoring shows this as the **second most expensive query on the control primary**: 1.87M executions/day at 17.7ms average — over nine hours of query time per day (`SELECT ... FROM sentry_integration WHERE external_id = %s LIMIT 21`, traced to `/extensions/jira-server/issue-updated/{token}/`). Adding `provider=jira_server` turns it into a unique-index lookup, which should bring it to sub-millisecond.

**Behavior note (why this is actually a fix, not just perf improvement)**: the lookup now only matches Jira Server integrations. Previously an integration of any provider sharing the `external_id` could be returned (Django `.get()` would raise `MultipleObjectsReturned` if more than one matched), so the scoped filter is also strictly more correct — the JWT validation that follows expects a Jira Server integration's `webhook_secret`.

For the post-merge check, [the same DBM view (db-control-1 → Top Queries)](https://app.datadoghq.com/databases/detail/instance/db-control-1?query=&databaseType=PostgreSQL&dbEntityMainTab=queries&dbEntityQueriesTab=top-queries&dbEntitySummarySection=overview&dbQueryPanelTab=explainPlans&fromUser=true&mode=queries&sessionChartBy=%40db.wait_event&start=1785831008966&end=1785917408966&paused=false) should show this statement's avg duration collapse; the fast twin to compare against is the github-enterprise lookup, which already filters both columns.

Fixes [INC-2432](https://linear.app/getsentry/issue/INC-2432)
