### PR TITLE
chore(relay): Remove relay.invalidation-direct-outside-atomic option check

### DIFF
--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -4,7 +4,6 @@ import time
 import sentry_sdk
 from django.db import connections, router, transaction
 
-from sentry import options
 from sentry.constants import DataCategory
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organization import Organization
@@ -354,10 +353,7 @@ def schedule_invalidate_project_config(
         name="relay.projectconfig_cache.invalidation.schedule_after_db_transaction",
     ) as span:
         set_span_tag(span, "transaction_db", transaction_db)
-        if (
-            options.get("relay.invalidation-direct-outside-atomic")
-            and not connections[transaction_db].in_atomic_block
-        ):
+        if not connections[transaction_db].in_atomic_block:
             _do_schedule()
         else:
             transaction.on_commit(_do_schedule, using=transaction_db)

--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -353,7 +353,11 @@ def schedule_invalidate_project_config(
         name="relay.projectconfig_cache.invalidation.schedule_after_db_transaction",
     ) as span:
         set_span_tag(span, "transaction_db", transaction_db)
-        if not connections[transaction_db].in_atomic_block:
+        connection = connections[transaction_db]
+        # Outside an atomic block, on_commit() runs the callback immediately under
+        # autocommit, but raises TransactionManagementError under manual transaction
+        # management, which is how the taskworker runs. Schedule directly in that case.
+        if not connection.in_atomic_block and not connection.get_autocommit():
             _do_schedule()
         else:
             transaction.on_commit(_do_schedule, using=transaction_db)

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
@@ -481,15 +481,17 @@ const SectionedOverlay = styled(Overlay, {
             'tabs tabs'
             'list list'
             'footer footer';
-          ${p.fullWidth &&
-          css`
-            grid-template-areas:
-              'seer seer'
-              'recentFilters recentFilters'
-              'tabs tabs'
-              ${p.showDetailsPane ? "'list details'" : "'list list'"}
-              'footer footer';
-          `}
+          ${
+            p.fullWidth &&
+            css`
+              grid-template-areas:
+                'seer seer'
+                'recentFilters recentFilters'
+                'tabs tabs'
+                ${p.showDetailsPane ? "'list details'" : "'list list'"}
+                'footer footer';
+            `
+          }
         `
       : css`
           grid-template-rows: auto auto 1fr auto;
@@ -499,14 +501,16 @@ const SectionedOverlay = styled(Overlay, {
             'tabs tabs'
             'list list'
             'footer footer';
-          ${p.fullWidth &&
-          css`
-            grid-template-areas:
-              'recentFilters recentFilters'
-              'tabs tabs'
-              ${p.showDetailsPane ? "'list details'" : "'list list'"}
-              'footer footer';
-          `}
+          ${
+            p.fullWidth &&
+            css`
+              grid-template-areas:
+                'recentFilters recentFilters'
+                'tabs tabs'
+                ${p.showDetailsPane ? "'list details'" : "'list list'"}
+                'footer footer';
+            `
+          }
         `}
   overflow: hidden;
   height: 400px;

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
@@ -481,17 +481,15 @@ const SectionedOverlay = styled(Overlay, {
             'tabs tabs'
             'list list'
             'footer footer';
-          ${
-            p.fullWidth &&
-            css`
-              grid-template-areas:
-                'seer seer'
-                'recentFilters recentFilters'
-                'tabs tabs'
-                ${p.showDetailsPane ? "'list details'" : "'list list'"}
-                'footer footer';
-            `
-          }
+          ${p.fullWidth &&
+          css`
+            grid-template-areas:
+              'seer seer'
+              'recentFilters recentFilters'
+              'tabs tabs'
+              ${p.showDetailsPane ? "'list details'" : "'list list'"}
+              'footer footer';
+          `}
         `
       : css`
           grid-template-rows: auto auto 1fr auto;
@@ -501,16 +499,14 @@ const SectionedOverlay = styled(Overlay, {
             'tabs tabs'
             'list list'
             'footer footer';
-          ${
-            p.fullWidth &&
-            css`
-              grid-template-areas:
-                'recentFilters recentFilters'
-                'tabs tabs'
-                ${p.showDetailsPane ? "'list details'" : "'list list'"}
-                'footer footer';
-            `
-          }
+          ${p.fullWidth &&
+          css`
+            grid-template-areas:
+              'recentFilters recentFilters'
+              'tabs tabs'
+              ${p.showDetailsPane ? "'list details'" : "'list list'"}
+              'footer footer';
+          `}
         `}
   overflow: hidden;
   height: 400px;

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
@@ -102,6 +102,7 @@ function FeedbackFooter({
         <OpenAskSeerButton ref={askSeerButtonRef} onTabForward={onAskSeerTabForward} />
       ) : null}
       <FeedbackButton
+        variant="secondary"
         size={hasAskSeerRework ? 'zero' : 'xs'}
         feedbackOptions={{
           messagePlaceholder: t('How can we make search better for you?'),
@@ -480,15 +481,17 @@ const SectionedOverlay = styled(Overlay, {
             'tabs tabs'
             'list list'
             'footer footer';
-          ${p.fullWidth &&
-          css`
-            grid-template-areas:
-              'seer seer'
-              'recentFilters recentFilters'
-              'tabs tabs'
-              ${p.showDetailsPane ? "'list details'" : "'list list'"}
-              'footer footer';
-          `}
+          ${
+            p.fullWidth &&
+            css`
+              grid-template-areas:
+                'seer seer'
+                'recentFilters recentFilters'
+                'tabs tabs'
+                ${p.showDetailsPane ? "'list details'" : "'list list'"}
+                'footer footer';
+            `
+          }
         `
       : css`
           grid-template-rows: auto auto 1fr auto;
@@ -498,14 +501,16 @@ const SectionedOverlay = styled(Overlay, {
             'tabs tabs'
             'list list'
             'footer footer';
-          ${p.fullWidth &&
-          css`
-            grid-template-areas:
-              'recentFilters recentFilters'
-              'tabs tabs'
-              ${p.showDetailsPane ? "'list details'" : "'list list'"}
-              'footer footer';
-          `}
+          ${
+            p.fullWidth &&
+            css`
+              grid-template-areas:
+                'recentFilters recentFilters'
+                'tabs tabs'
+                ${p.showDetailsPane ? "'list details'" : "'list list'"}
+                'footer footer';
+            `
+          }
         `}
   overflow: hidden;
   height: 400px;

--- a/tests/sentry/tasks/test_relay.py
+++ b/tests/sentry/tasks/test_relay.py
@@ -462,7 +462,7 @@ class TestInvalidationTask:
         wraps=_schedule_invalidate_project_config,
     )
     @mock.patch("django.db.transaction.on_commit", wraps=transaction.on_commit)
-    def test_project_config_invalidations_outside_transaction(
+    def test_project_config_invalidations_after_commit(
         self,
         oncommit,
         schedule_inner,
@@ -472,7 +472,7 @@ class TestInvalidationTask:
             trigger="test", project_id=default_project.id, countdown=2
         )
 
-        assert oncommit.call_count == 0
+        assert oncommit.call_count == 1
         assert schedule_inner.call_count == 1
         assert schedule_inner.call_args == mock.call(
             trigger="test",

--- a/tests/sentry/tasks/test_relay.py
+++ b/tests/sentry/tasks/test_relay.py
@@ -3,7 +3,6 @@ from unittest import mock
 
 import pytest
 from django.db import connections, router, transaction
-from django.db.transaction import TransactionManagementError
 
 from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
 from sentry.models.options.project_option import ProjectOption
@@ -17,7 +16,6 @@ from sentry.tasks.relay import (
     schedule_build_project_config,
     schedule_invalidate_project_config,
 )
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.helpers.task_runner import BurstTaskRunner
 from sentry.testutils.hybrid_cloud import simulated_transaction_watermarks
 from sentry.testutils.pytest.fixtures import django_db_all
@@ -464,7 +462,7 @@ class TestInvalidationTask:
         wraps=_schedule_invalidate_project_config,
     )
     @mock.patch("django.db.transaction.on_commit", wraps=transaction.on_commit)
-    def test_project_config_invalidations_after_commit(
+    def test_project_config_invalidations_outside_transaction(
         self,
         oncommit,
         schedule_inner,
@@ -474,7 +472,7 @@ class TestInvalidationTask:
             trigger="test", project_id=default_project.id, countdown=2
         )
 
-        assert oncommit.call_count == 1
+        assert oncommit.call_count == 0
         assert schedule_inner.call_count == 1
         assert schedule_inner.call_args == mock.call(
             trigger="test",
@@ -540,34 +538,11 @@ def test_invalidate_hierarchy(
 
 
 @django_db_all(transaction=True)
-@override_options({"relay.invalidation-direct-outside-atomic": False})
-def test_schedule_invalidate_project_config_without_autocommit_option_off(default_project):
+def test_schedule_invalidate_project_config_without_autocommit(default_project):
     """
-    Without the option, the old behavior is preserved: on_commit() is called
-    unconditionally, which raises TransactionManagementError when autocommit
-    is off and there is no active atomic block.
-    """
-    conn = connections["default"]
-    conn.ensure_connection()
-    try:
-        conn.set_autocommit(False)
-        with pytest.raises(TransactionManagementError):
-            schedule_invalidate_project_config(
-                project_id=default_project.id,
-                trigger="test",
-            )
-    finally:
-        conn.rollback()
-        conn.set_autocommit(True)
-
-
-@django_db_all(transaction=True)
-@override_options({"relay.invalidation-direct-outside-atomic": True})
-def test_schedule_invalidate_project_config_without_autocommit_option_on(default_project):
-    """
-    Regression test: with the option enabled, schedule_invalidate_project_config
-    must not raise TransactionManagementError when called without autocommit and
-    outside an atomic block, as happens in the taskworker.
+    Regression test: schedule_invalidate_project_config must not raise
+    TransactionManagementError when called without autocommit and outside an
+    atomic block, as happens in the taskworker.
 
     See: https://sentry.sentry.io/issues/7223923952/
     """


### PR DESCRIPTION
- The option has been on by default for a few months now, everything works as expected - so we can remove it and make this the default behavior