### PR TITLE
ref(ai-monitoring): Stop sending apiVersion on conversation details

### DIFF
--- a/static/app/views/explore/conversations/hooks/useConversation.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversation.tsx
@@ -241,7 +241,6 @@ export function useConversation(
   const queryParams = {
     project,
     per_page: 1000,
-    apiVersion: 2,
     ...datetimeParams,
   };
 


### PR DESCRIPTION
Conversation details fetches no longer pass `apiVersion=2`. The endpoint always returns the metadata envelope now (#121143), so the version query param is unused.

