### PR TITLE
fix(integrations): halt on IntegrationConfigurationError in sync_status_outbound

### DIFF
--- a/src/sentry/integrations/tasks/sync_status_outbound.py
+++ b/src/sentry/integrations/tasks/sync_status_outbound.py
@@ -14,7 +14,11 @@ from sentry.integrations.project_management.metrics import (
 )
 from sentry.integrations.services.integration import integration_service
 from sentry.models.group import Group, GroupStatus
-from sentry.shared_integrations.exceptions import ApiUnauthorized, IntegrationFormError
+from sentry.shared_integrations.exceptions import (
+    ApiUnauthorized,
+    IntegrationConfigurationError,
+    IntegrationFormError,
+)
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, track_group_async_operation
 from sentry.taskworker.namespaces import integrations_tasks
@@ -86,6 +90,7 @@ def sync_status_outbound(group_id: int, external_issue_id: int) -> bool | None:
         except (
             IntegrationFormError,
             ApiUnauthorized,
+            IntegrationConfigurationError,
             OrganizationIntegrationNotFound,
             InvalidIdentity,
         ) as e:

--- a/tests/sentry/integrations/tasks/test_sync_status_outbound.py
+++ b/tests/sentry/integrations/tasks/test_sync_status_outbound.py
@@ -6,7 +6,11 @@ from sentry.integrations.example import ExampleIntegration
 from sentry.integrations.models import ExternalIssue, Integration
 from sentry.integrations.tasks import sync_status_outbound
 from sentry.integrations.types import EventLifecycleOutcome
-from sentry.shared_integrations.exceptions import ApiUnauthorized, IntegrationFormError
+from sentry.shared_integrations.exceptions import (
+    ApiUnauthorized,
+    IntegrationConfigurationError,
+    IntegrationFormError,
+)
 from sentry.testutils.asserts import assert_count_of_metric, assert_halt_metric
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode_of, cell_silo_test
@@ -22,6 +26,10 @@ def raise_integration_form_error(*args, **kwargs):
 
 def raise_api_unauthorized_error(*args, **kwargs):
     raise ApiUnauthorized(text="auth failed")
+
+
+def raise_integration_configuration_error(*args, **kwargs):
+    raise IntegrationConfigurationError("Repository was archived so is read-only.")
 
 
 @cell_silo_test
@@ -164,3 +172,28 @@ class TestSyncStatusOutbound(TestCase):
         )
 
         assert_halt_metric(mock_record=mock_record, error_msg=ApiUnauthorized("auth failed"))
+
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    @mock.patch.object(ExampleIntegration, "sync_status_outbound")
+    def test_integration_configuration_error_halts(
+        self, mock_sync_status: mock.MagicMock, mock_record: mock.MagicMock
+    ) -> None:
+        """IntegrationConfigurationError (e.g. archived repo) should halt, not fail."""
+        mock_sync_status.side_effect = raise_integration_configuration_error
+        external_issue: ExternalIssue = self.create_integration_external_issue(
+            group=self.group, key="foo_integration", integration=self.example_integration
+        )
+
+        sync_status_outbound(self.group.id, external_issue_id=external_issue.id)
+
+        assert_count_of_metric(
+            mock_record=mock_record, outcome=EventLifecycleOutcome.STARTED, outcome_count=1
+        )
+        assert_count_of_metric(
+            mock_record=mock_record, outcome=EventLifecycleOutcome.HALTED, outcome_count=1
+        )
+
+        assert_halt_metric(
+            mock_record=mock_record,
+            error_msg=IntegrationConfigurationError("Repository was archived so is read-only."),
+        )


### PR DESCRIPTION
## Summary

Dispatched by automated triage routine.

**Sentry issue:** group ID 7280261938, culprit `sentry.integrations.tasks.sync_status_outbound`

### Root cause

When `sync_status_outbound` tries to sync a resolved Sentry group to a GitHub issue whose repository is archived:

1. `installation.sync_status_outbound(...)` calls `client.update_issue_status(...)`, which gets a 403 from GitHub.
2. `self.raise_error(e)` in the GitHub client converts the 403 to `IntegrationConfigurationError('Repository was archived so is read-only.')`.
3. This propagates out of the `ProjectManagementEvent(...).capture()` context in `sync_status_outbound.py`.
4. `IntegrationEventLifecycle.__exit__` falls through to `record_failure(exc_value, create_issue=True)` → `sentry_sdk.capture_exception()` → a new Sentry error is filed.

An archived GitHub repository is an **expected external configuration state** (the user or org configured Sentry to sync against a now-archived repo). It is not an application bug.

### Fix

Add `IntegrationConfigurationError` to the `except` tuple in `sync_status_outbound.py` that already halts for similar expected-external-state errors: `ApiUnauthorized`, `InvalidIdentity`, `IntegrationFormError`, `OrganizationIntegrationNotFound`.

A test `test_integration_configuration_error_halts` was added to confirm the task records a halt (not a failure) when this exception is raised, consistent with the existing `test_api_unauthorized_error_halts` pattern.

### What was ruled out

- **Modifying `metrics.py`** — too broad; would affect all integrations and event types.
- **Modifying `issue_sync.py`** — wrong layer. The exception originates there correctly (403 → `IntegrationConfigurationError`), but the halt/fail decision belongs in the task, where all other integration-level exception routing already lives.

## Changes

- `src/sentry/integrations/tasks/sync_status_outbound.py`: import `IntegrationConfigurationError` and add it to the halt-exception tuple.
- `tests/sentry/integrations/tasks/test_sync_status_outbound.py`: add `test_integration_configuration_error_halts` to verify halt behavior.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FpwTkfJh3ErdX3gN4aHLSE)_