### PR TITLE
fix(agent-monitoring): reserve tool tag height in conversation header

### DIFF
--- a/static/app/views/explore/conversations/components/conversationSummary.tsx
+++ b/static/app/views/explore/conversations/components/conversationSummary.tsx
@@ -438,8 +438,9 @@ export function ConversationAggregatesBar({
     query: `gen_ai.conversation.id:"${escapeDoubleQuotes(conversationId)}" span.status:[internal_error,error]`,
   });
 
+  // minHeight matches the tool Tag height so the row stays the same height whether or not tools render
   return (
-    <Flex align="center" gap="lg" minWidth={0}>
+    <Flex align="center" gap="lg" minWidth={0} minHeight="20px">
       <AggregateItem
         label={t('LLM Calls')}
         value={<Count value={aggregates.llmCalls} />}


### PR DESCRIPTION
The AI-tab conversation summary header jumped in height when switching between transcripts, depending on whether a conversation had tool calls. The "Used Tools" row only renders when tools are present, and the tool tag is taller than the plain-text stats, so the header grew whenever tools showed up.

This reserves a constant min-height on the header equal to the tool tag height, so the row is always tall enough for the tag and the height stays stable across transcripts.

Closes TET-2755