### PR TITLE
ref: simplify useProjectWebVitalsScoresTimeseriesQuery

### DIFF
--- a/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useProjectWebVitalsScoresTimeseriesQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useProjectWebVitalsScoresTimeseriesQuery.tsx
@@ -1,18 +1,8 @@
 import type {SeriesDataUnit} from 'sentry/types/echarts';
-import type {Tag} from 'sentry/types/group';
 import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {Referrer} from 'sentry/views/insights/browser/webVitals/referrers';
 import {DEFAULT_QUERY_FILTER} from 'sentry/views/insights/browser/webVitals/settings';
-import type {BrowserType} from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
-import {SpanFields, type SubregionCode} from 'sentry/views/insights/types';
-
-type Props = {
-  browserTypes?: BrowserType[];
-  subregions?: SubregionCode[];
-  tag?: Tag;
-  transaction?: string | null;
-};
 
 export type WebVitalsScoreBreakdown = {
   cls: SeriesDataUnit[];
@@ -23,25 +13,8 @@ export type WebVitalsScoreBreakdown = {
   ttfb: SeriesDataUnit[];
 };
 
-export const useProjectWebVitalsScoresTimeseriesQuery = ({
-  transaction,
-  tag,
-  browserTypes,
-  subregions,
-}: Props) => {
-  const search = new MutableSearch([
-    'has:measurements.score.total',
-    ...(tag ? [`${tag.key}:"${tag.name}"`] : []),
-  ]);
-  if (transaction) {
-    search.addFilterValue('transaction', transaction);
-  }
-  if (subregions) {
-    search.addDisjunctionFilterValues(SpanFields.USER_GEO_SUBREGION, subregions);
-  }
-  if (browserTypes) {
-    search.addDisjunctionFilterValues(SpanFields.BROWSER_NAME, browserTypes);
-  }
+export const useProjectWebVitalsScoresTimeseriesQuery = () => {
+  const search = new MutableSearch(['has:measurements.score.total']);
 
   const result = useFetchSpanTimeSeries(
     {
@@ -79,5 +52,5 @@ export const useProjectWebVitalsScoresTimeseriesQuery = ({
     total: getSeriesData('count()'),
   };
 
-  return {...result, data};
+  return {data, isLoading: result.isLoading};
 };

--- a/static/app/views/performance/landing/widgets/widgets/performanceScoreListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/performanceScoreListWidget.tsx
@@ -55,7 +55,7 @@ export function PerformanceScoreListWidget(props: PerformanceWidgetProps) {
     useTransactionWebVitalsScoresQuery({limit: 4});
 
   const {data: timeseriesData, isLoading: isTimeseriesQueryLoading} =
-    useProjectWebVitalsScoresTimeseriesQuery({});
+    useProjectWebVitalsScoresTimeseriesQuery();
 
   const assembleAccordionItems = () =>
     getHeaders().map(header => ({header, content: getAreaChart()}));


### PR DESCRIPTION
Motivation: While updating `tanstack-query` to take advantage of the improved lint rules, I noticed that this hook now correctly errors with:

```
  82:11  error  Object rest destructuring on a query will observe all changes to the query, leading to excessive re-renders  @tanstack/query/no-rest-destructuring
```

That’s because the lint rule now keeps track of queries over custom hooks, which it didn’t do before.

That led me down the path to inspect consumers, noticing that none of the props are actually used (so I removed the props).

Then, the quickest fix was to only observe `result.data` and `result.isLoading` because those are the fields the only consumer is interested in.

A different, more involved fix would’ve been doing the data transformation inside `select`, which we would need to pass down multiple layers of custom hooks. That would allow us to return the full `result`, allowing consumers to observe whichever properties they want.