### PR TITLE
fix(search): Prevent Ask Seer footer from clipping Give Feedback

### DIFF
--- a/static/app/components/searchQueryBuilder/askSeer/askSeerFeedback.tsx
+++ b/static/app/components/searchQueryBuilder/askSeer/askSeerFeedback.tsx
@@ -39,7 +39,7 @@ export function AskSeerFeedback() {
       align="center"
       justify={hasAskSeerUxRework ? undefined : 'between'}
       gap="md"
-      flex="1"
+      flex={hasAskSeerUxRework ? undefined : '1'}
     >
       <AskSeerLabel fontWeight="normal">
         {hasAskSeerUxRework ? null : <IconSeer />}

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/baseAskSeerComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/baseAskSeerComboBox.tsx
@@ -517,7 +517,9 @@ export function BaseAskSeerComboBox<T extends QueryTokensProps>({
           )}
           {showFooter ? (
             <Flex
+              containerType="inline-size"
               justify={showLeftFooterAction ? 'between' : 'end'}
+              align="start"
               borderTop="primary"
               paddingTop="sm"
               paddingBottom="sm"
@@ -526,7 +528,11 @@ export function BaseAskSeerComboBox<T extends QueryTokensProps>({
               background={showLeftFooterAction ? 'secondary' : 'primary'}
               onMouseDown={e => e.preventDefault()}
             >
-              <Flex gap="sm">
+              <Flex
+                direction={{zero: 'column', md: 'row'}}
+                align={{zero: 'start', md: 'center'}}
+                gap="sm"
+              >
                 {showLeftFooterAction ? (
                   <Button
                     icon={<IconSync />}


### PR DESCRIPTION
The reworked Ask Seer results footer was clipping **Give Feedback** when Generate again and the thumbs prompt sat on one row in a narrow combobox.

The footer is now its own inline-size query container: below `md` those left actions stack, and Give Feedback stays top-aligned. The rework feedback row no longer grows with `flex: 1`, which was eating horizontal space beside Generate again.

Before:
<img width="399" height="45" alt="Screenshot 2026-08-05 at 09 35 16" src="https://github.com/user-attachments/assets/2dc84661-b025-42c2-85c4-ef3113eabbc7" />

After:
<img width="485" height="72" alt="Screenshot 2026-08-05 at 09 54 15" src="https://github.com/user-attachments/assets/4b6b3d6d-77c6-4dff-9fdd-8b6b6e6cd86d" />