### PR TITLE
fix(deps): Bump seroval to patch critical deserialization vuln

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8241,8 +8241,8 @@ packages:
     peerDependencies:
       seroval: ^1.0
 
-  seroval@1.5.0:
-    resolution: {integrity: sha512-OE4cvmJ1uSPrKorFIH9/w/Qwuvi/IMcGbv5RKgcJ/zjA/IohDLU6SVaxFN9FwajbP7nsX0dQqMDes1whk3y+yw==}
+  seroval@1.5.6:
+    resolution: {integrity: sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA==}
     engines: {node: '>=10'}
 
   set-function-length@1.2.2:
@@ -17891,11 +17891,11 @@ snapshots:
 
   serialize-javascript@7.0.7: {}
 
-  seroval-plugins@1.5.0(seroval@1.5.0):
+  seroval-plugins@1.5.0(seroval@1.5.6):
     dependencies:
-      seroval: 1.5.0
+      seroval: 1.5.6
 
-  seroval@1.5.0: {}
+  seroval@1.5.6: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -18034,8 +18034,8 @@ snapshots:
   solid-js@1.9.11:
     dependencies:
       csstype: 3.2.3
-      seroval: 1.5.0
-      seroval-plugins: 1.5.0(seroval@1.5.0)
+      seroval: 1.5.6
+      seroval-plugins: 1.5.0(seroval@1.5.6)
 
   source-map-generator@2.0.2: {}
 


### PR DESCRIPTION
Bumps the transitive `seroval` dependency from `1.5.0` to `1.5.6`, patching a critical deserialization type confusion in `seroval.fromJSON()` ([GHSA-mv8w-475r-vwqw](https://github.com/lxsmnsyc/seroval/security/advisories/GHSA-mv8w-475r-vwqw), CVSS 9.8) where attacker-controlled JSON could invoke unintended methods during deserialization.

`seroval` is pulled in transitively via `solid-js`, which several TanStack devtools packages (`react-devtools`, `react-form-devtools`, `react-pacer-devtools`) depend on. `solid-js`'s existing dependency range already permitted the patched version, so this is a lockfile-only refresh (`pnpm update seroval seroval-plugins --lockfile-only`) — no `package.json` changes.

Fixes GHSA-mv8w-475r-vwqw
