### PR TITLE
feat(explore): Surface array attributes in search autocomplete

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/utils.tsx
@@ -56,9 +56,9 @@ export function useShiftFocusToChild(
   };
 }
 
-const EXPLICIT_TAG_KEY_PATTERN = /^tags\[(.*),(string|number|boolean)\]$/;
+const EXPLICIT_TAG_KEY_PATTERN = /^tags\[(.*),(string|number|boolean|array)\]$/;
 
-type ExplicitTagType = 'string' | 'number' | 'boolean';
+type ExplicitTagType = 'string' | 'number' | 'boolean' | 'array';
 
 type FilterKeyResolverItem = {
   options?: FilterKeyResolverItem[];
@@ -118,7 +118,12 @@ function getTagsFromResolverItems(items: FilterKeyResolverItem[]): Tag[] {
 }
 
 function findExplicitTagMatch(tags: Tag[], input: string): string | null {
-  for (const tagType of ['string', 'number', 'boolean'] satisfies ExplicitTagType[]) {
+  for (const tagType of [
+    'string',
+    'number',
+    'boolean',
+    'array',
+  ] satisfies ExplicitTagType[]) {
     const match = tags.find(
       tag => getExplicitTagType(tag.key) === tagType && tagMatchesInput(tag, input)
     );

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -22,6 +22,7 @@ export enum FieldKind {
   METRICS = 'metric',
   NUMERIC_METRICS = 'numeric_metric',
   BOOLEAN = 'boolean',
+  ARRAY = 'array',
 }
 
 export enum FieldKey {
@@ -304,6 +305,7 @@ export enum FieldValueType {
   PERCENT_CHANGE = 'percent_change',
   SCORE = 'score',
   CURRENCY = 'currency',
+  ARRAY = 'array',
 }
 
 export enum WebVital {
@@ -3642,6 +3644,10 @@ function _getFieldFromMappings(
         return {kind: FieldKind.FIELD, valueType: FieldValueType.BOOLEAN};
       }
 
+      if (kind === FieldKind.ARRAY) {
+        return {kind: FieldKind.FIELD, valueType: FieldValueType.ARRAY};
+      }
+
       return null;
 
     case 'span':
@@ -3662,6 +3668,10 @@ function _getFieldFromMappings(
 
       if (kind === FieldKind.BOOLEAN) {
         return {kind: FieldKind.FIELD, valueType: FieldValueType.BOOLEAN};
+      }
+
+      if (kind === FieldKind.ARRAY) {
+        return {kind: FieldKind.FIELD, valueType: FieldValueType.ARRAY};
       }
 
       return null;
@@ -3686,6 +3696,10 @@ function _getFieldFromMappings(
         return {kind: FieldKind.FIELD, valueType: FieldValueType.BOOLEAN};
       }
 
+      if (kind === FieldKind.ARRAY) {
+        return {kind: FieldKind.FIELD, valueType: FieldValueType.ARRAY};
+      }
+
       return null;
 
     case 'tracemetric':
@@ -3706,6 +3720,10 @@ function _getFieldFromMappings(
 
       if (kind === FieldKind.BOOLEAN) {
         return {kind: FieldKind.FIELD, valueType: FieldValueType.BOOLEAN};
+      }
+
+      if (kind === FieldKind.ARRAY) {
+        return {kind: FieldKind.FIELD, valueType: FieldValueType.ARRAY};
       }
 
       return null;

--- a/static/app/views/dashboards/widgets/common/types.tsx
+++ b/static/app/views/dashboards/widgets/common/types.tsx
@@ -14,7 +14,8 @@ type AttributeValueType =
   | 'size'
   | 'rate'
   | 'score'
-  | 'currency';
+  | 'currency'
+  | 'array';
 
 type AttributeValueUnit = DataUnit | null;
 

--- a/static/app/views/explore/components/typeBadge.tsx
+++ b/static/app/views/explore/components/typeBadge.tsx
@@ -80,6 +80,10 @@ export function TypeBadge({
     return <Text variant="success">{t('currency')}</Text>;
   }
 
+  if (valueType === FieldValueType.ARRAY || kind === FieldKind.ARRAY) {
+    return <Text variant="success">{t('array')}</Text>;
+  }
+
   if (
     kind === FieldKind.MEASUREMENT ||
     valueType === FieldValueType.NUMBER ||

--- a/static/app/views/explore/hooks/useGetTraceItemAttributeKeys.tsx
+++ b/static/app/views/explore/hooks/useGetTraceItemAttributeKeys.tsx
@@ -48,6 +48,7 @@ export function useGetTraceItemAttributeKeys({
             projectIds: projectIds ?? selection.projects,
             search: queryString,
             query,
+            type: ['string', 'number', 'boolean', 'array'],
             staleTime: EXPLORE_FIVE_MIN_STALE_TIME,
           })
         );

--- a/static/app/views/explore/utils/traceItemAttributeKeysOptions.spec.tsx
+++ b/static/app/views/explore/utils/traceItemAttributeKeysOptions.spec.tsx
@@ -14,7 +14,7 @@ type Attribute = {
   attributeSource: {
     source_type: 'sentry' | 'user';
   };
-  attributeType: 'boolean' | 'number' | 'string';
+  attributeType: 'array' | 'boolean' | 'number' | 'string';
   key: string;
   name: string;
 };
@@ -306,6 +306,22 @@ describe('getTraceItemTagCollection', () => {
         key,
         name: key,
         kind: FieldKind.TAG,
+        secondaryAliases: [],
+        attributeSource: 'user',
+      },
+    });
+  });
+
+  it('surfaces array tags in the string collection with FieldKind.ARRAY', () => {
+    const key = 'tags[data_export.csv_headers,array]';
+
+    // Arrays live in the string collection (they filter like string tags) but keep
+    // FieldKind.ARRAY so they resolve to the `array` value type and render as "array".
+    expect(getTraceItemTagCollection([makeAttribute(key, 'array')], 'array')).toEqual({
+      [key]: {
+        key,
+        name: key,
+        kind: FieldKind.ARRAY,
         secondaryAliases: [],
         attributeSource: 'user',
       },

--- a/static/app/views/explore/utils/traceItemAttributeKeysOptions.tsx
+++ b/static/app/views/explore/utils/traceItemAttributeKeysOptions.tsx
@@ -23,7 +23,7 @@ type AttributeType = {
   secondaryAliases?: string[];
 };
 
-type TraceItemAttributeType = 'string' | 'number' | 'boolean';
+type TraceItemAttributeType = 'string' | 'number' | 'boolean' | 'array';
 
 type TraceItemAttributeKeyOptions = Pick<
   ReturnType<typeof normalizeDateTimeParams>,
@@ -167,7 +167,7 @@ export function getTraceItemTagCollection(
     // SnQL forbids `-` but is allowed in RPC. So add it back later
     if (
       !/^[\w.:@-]+$/.test(attribute.key) &&
-      !/^tags\[[\w.:@-]+,(number|boolean|string)\]$/.test(attribute.key)
+      !/^tags\[[\w.:@-]+,(number|boolean|string|array)\]$/.test(attribute.key)
     ) {
       continue;
     }
@@ -178,11 +178,17 @@ export function getTraceItemTagCollection(
         ? attribute.attributeType
         : undefined;
 
-    if (attributeType === 'string') {
+    // TODO: Array plumbing is not done yet. For now an array's query syntax is the
+    // same as a string's, so array attributes are placed in the string collection as
+    // a placeholder until dedicated array query support is added. They are still
+    // tagged FieldKind.ARRAY (not TAG) to keep arrays distinct from strings — for the
+    // correct "array" type badge now, and as the seam that the expanded array query
+    // syntax will build on later.
+    if (attributeType === 'string' || attributeType === 'array') {
       stringAttributes[attribute.key] = {
         key: attribute.key,
         name: attribute.name,
-        kind: FieldKind.TAG,
+        kind: attributeType === 'array' ? FieldKind.ARRAY : FieldKind.TAG,
         secondaryAliases: attribute?.secondaryAliases ?? [],
         attributeSource: attribute.attributeSource?.source_type,
       };
@@ -213,7 +219,8 @@ export function getTraceItemTagCollection(
     return booleanAttributes;
   }
 
-  if (type === 'string') {
+  if (type === 'string' || type === 'array') {
+    // Arrays are placeholdered in the string collection for now (see above).
     return stringAttributes;
   }
 


### PR DESCRIPTION
Recognize `array` as an attribute type in the trace-item search bar. Array attributes come back from the attributes endpoint with `attributeType: array`; they now appear in the autocomplete and render with an `array` type badge instead of being dropped or mislabeled as `string`.

<img width="1490" height="573" alt="image" src="https://github.com/user-attachments/assets/b264b1b1-d472-4376-97c8-3777163001f7" />

The search bar requests all attribute types including array; the backend decides whether to return arrays based on its own feature gate.

Refs EXP-1129
