### PR TITLE
feat(difs): Compress Objectstore-backed Debug Files with zstd

### DIFF
--- a/src/sentry/debug_files/objectstore_migration/utils.py
+++ b/src/sentry/debug_files/objectstore_migration/utils.py
@@ -17,7 +17,6 @@ from sentry.constants import KNOWN_DIF_FORMATS
 from sentry.models.debugfile import (
     ProjectDebugFile,
     _dif_file_extension,
-    _upload_dif_to_objectstore,
 )
 from sentry.models.files.file import File
 from sentry.models.project import Project
@@ -167,13 +166,11 @@ def upload_and_verify(debug_file: ProjectDebugFile) -> PostMigrationMetadata | N
                 f"(checksum={local_checksum!r} expected={expected_checksum!r}, "
                 f"size={local_size} expected={expected_size})"
             )
-        storage_path = _upload_dif_to_objectstore(
-            session,
+        storage_path = session.put(
             tmp,
-            content_type,
-            expected_size,
-            filename,
             key=f"legacy.{debug_file.id}",
+            content_type=content_type,
+            filename=filename,
         )
     finally:
         tmp.close()

--- a/src/sentry/debug_files/objectstore_migration/utils.py
+++ b/src/sentry/debug_files/objectstore_migration/utils.py
@@ -13,6 +13,7 @@ from django.db import router, transaction
 from django.db.models import ProtectedError
 from objectstore_client import GetResponse, Session
 
+from sentry import features
 from sentry.constants import KNOWN_DIF_FORMATS
 from sentry.models.debugfile import (
     ProjectDebugFile,
@@ -169,6 +170,13 @@ def upload_and_verify(debug_file: ProjectDebugFile) -> PostMigrationMetadata | N
         storage_path = session.put(
             tmp,
             key=f"legacy.{debug_file.id}",
+            compression=(
+                "zstd"
+                if features.has(
+                    "organizations:objectstore-debugfiles-compression", project.organization
+                )
+                else "none"
+            ),
             content_type=content_type,
             filename=filename,
         )

--- a/src/sentry/demo_mode/tasks.py
+++ b/src/sentry/demo_mode/tasks.py
@@ -7,7 +7,7 @@ from django.db.models import Q
 from django.db.utils import IntegrityError
 from django.utils import timezone
 
-from sentry import options
+from sentry import features, options
 from sentry.demo_mode.utils import get_demo_org, is_demo_mode_enabled
 from sentry.models.artifactbundle import (
     ArtifactBundle,
@@ -250,6 +250,13 @@ def _sync_project_debug_file(
                         target_org.id, target_project.id
                     ).put(
                         source_fileobj,
+                        compression=(
+                            "zstd"
+                            if features.has(
+                                "organizations:objectstore-debugfiles-compression", target_org
+                            )
+                            else "none"
+                        ),
                         content_type=source_project_debug_file.get_content_type(),
                     )
                 finally:

--- a/src/sentry/demo_mode/tasks.py
+++ b/src/sentry/demo_mode/tasks.py
@@ -250,7 +250,6 @@ def _sync_project_debug_file(
                         target_org.id, target_project.id
                     ).put(
                         source_fileobj,
-                        compression="none",
                         content_type=source_project_debug_file.get_content_type(),
                     )
                 finally:

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -190,6 +190,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:onboarding-scm-project-creation-experiment", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Double-write newly created debug files to Objectstore.
     manager.add("organizations:objectstore-debugfiles-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=False, api_expose=False)
+    # Compress Objectstore-backed debug files with zstd.
+    manager.add("organizations:objectstore-debugfiles-compression", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=False, api_expose=False)
     # Read debug files from Objectstore when an Objectstore copy is available.
     manager.add("organizations:objectstore-debugfiles-read", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=False, api_expose=False)
     # Redirect debug file download requests to read directly from Objectstore, instead of proxying file contents through Sentry.

--- a/src/sentry/models/debugfile.py
+++ b/src/sentry/models/debugfile.py
@@ -528,7 +528,18 @@ def create_dif_from_id(
         )
         try:
             with file.getfile() as source:
-                storage_path = session.put(source, content_type=content_type, filename=filename)
+                storage_path = session.put(
+                    source,
+                    compression=(
+                        "zstd"
+                        if features.has(
+                            "organizations:objectstore-debugfiles-compression", project.organization
+                        )
+                        else "none"
+                    ),
+                    content_type=content_type,
+                    filename=filename,
+                )
         except Exception:
             logger.exception("Failed to dual-write debug file to Objectstore")
         else:

--- a/src/sentry/models/debugfile.py
+++ b/src/sentry/models/debugfile.py
@@ -4,15 +4,11 @@ import enum
 import errno
 import hashlib
 import logging
-import math
 import os
 import os.path
-import random
 import re
 import shutil
 import tempfile
-import threading
-import time
 import uuid
 import zipfile
 from collections.abc import Container, Iterable, Mapping
@@ -24,11 +20,8 @@ from django.db.models import ProtectedError, Q
 from django.db.models.functions import Now
 from django.http import HttpRequest
 from django.utils import timezone
-from objectstore_client import RequestError
-from objectstore_client.multipart import CompletePart, MultipartUpload
 from symbolic.debuginfo import Archive, BcSymbolMap, Object, UuidMapping, normalize_debug_id
 from symbolic.exceptions import ObjectErrorUnsupportedObject, SymbolicError
-from urllib3.exceptions import HTTPError
 
 from sentry import features, options
 from sentry.backup.scopes import RelocationScope
@@ -47,7 +40,6 @@ from sentry.models.files.utils import clear_cached_files
 from sentry.objectstore import get_debug_files_session, get_download_redirect_url
 from sentry.objectstore.metrics import measure_storage_operation
 from sentry.utils import json, metrics
-from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 from sentry.utils.zip import safe_extract_zip
 
 if TYPE_CHECKING:
@@ -60,9 +52,6 @@ logger = logging.getLogger(__name__)
 DIF_MIMETYPES = {v: k for k, v in KNOWN_DIF_FORMATS.items()}
 
 _proguard_file_re = re.compile(r"/proguard/(?:mapping-)?(.*?)\.txt$")
-
-OBJECTSTORE_MULTIPART_UPLOAD_THRESHOLD = 128 * 1024 * 1024  # 128 MiB
-OBJECTSTORE_MULTIPART_UPLOAD_PART_SIZE = 32 * 1024 * 1024  # 32 MiB
 
 
 def _dif_file_extension(file_format: str, file_type: str | None) -> str:
@@ -438,81 +427,6 @@ def create_dif_from_file(
     return create_dif_from_id(project, result[0], file=file)
 
 
-def _upload_dif_to_objectstore(
-    session: Session,
-    fileobj: IO[bytes],
-    content_type: str,
-    file_size: int,
-    filename: str,
-    *,
-    key: str | None = None,
-) -> str:
-    """Uploads a debug file to Objectstore, returning the key under which the file was uploaded."""
-    if file_size <= OBJECTSTORE_MULTIPART_UPLOAD_THRESHOLD:
-        return session.put(fileobj, key=key, content_type=content_type, filename=filename)
-
-    return _upload_dif_to_objectstore_multipart(
-        session, fileobj, content_type, file_size, filename, key=key
-    )
-
-
-def _upload_dif_to_objectstore_multipart(
-    session: Session,
-    fileobj: IO[bytes],
-    content_type: str,
-    file_size: int,
-    filename: str,
-    *,
-    key: str | None = None,
-) -> str:
-    """Uploads a debug file to Objectstore via parallel multipart upload."""
-    upload = session.initiate_multipart_upload(
-        key=key, content_type=content_type, filename=filename
-    )
-
-    lock = threading.Lock()
-    num_parts = max(1, math.ceil(file_size / OBJECTSTORE_MULTIPART_UPLOAD_PART_SIZE))
-
-    def put_part_with_retry(
-        upload: MultipartUpload, chunk: bytes, part_number: int
-    ) -> CompletePart:
-        for attempt in range(3):
-            try:
-                return upload.put_part(chunk, part_number=part_number, content_length=len(chunk))
-            except (RequestError, HTTPError):
-                if attempt == 2:
-                    raise
-                delay = 2 ** (attempt + 1)
-                time.sleep(random.uniform(delay, delay * 2))
-        raise AssertionError("unreachable")
-
-    def read_and_put_part(part_number: int) -> CompletePart | None:
-        offset = (part_number - 1) * OBJECTSTORE_MULTIPART_UPLOAD_PART_SIZE
-        with lock:
-            fileobj.seek(offset)
-            chunk = fileobj.read(OBJECTSTORE_MULTIPART_UPLOAD_PART_SIZE)
-        if not chunk:
-            return None
-        return put_part_with_retry(upload, chunk, part_number)
-
-    try:
-        with ContextPropagatingThreadPoolExecutor(
-            max_workers=4,
-        ) as executor:
-            futures = [executor.submit(read_and_put_part, i + 1) for i in range(num_parts)]
-            parts = [part for f in futures if (part := f.result()) is not None]
-
-        storage_path = upload.complete(parts)
-        return storage_path
-    except Exception:
-        logger.exception("Failed to upload debug file to Objectstore")
-        try:
-            upload.abort()
-        except Exception:
-            pass
-        raise
-
-
 def create_dif_from_id(
     project: Project,
     meta: DifMeta,
@@ -614,9 +528,7 @@ def create_dif_from_id(
         )
         try:
             with file.getfile() as source:
-                storage_path = _upload_dif_to_objectstore(
-                    session, source, content_type, file_size, filename
-                )
+                storage_path = session.put(source, content_type=content_type, filename=filename)
         except Exception:
             logger.exception("Failed to dual-write debug file to Objectstore")
         else:

--- a/src/sentry/objectstore/__init__.py
+++ b/src/sentry/objectstore/__init__.py
@@ -71,7 +71,7 @@ class SentryMetricsBackend(MetricsBackend):
 _OBJECTSTORE_CLIENT: Client | None = None
 _ATTACHMENTS_USECASE: Usecase | None = None
 _DEBUG_FILES_USECASE = Usecase(
-    "debug_files", compression="zstd", expiration_policy=TimeToIdle(timedelta(days=90))
+    "debug_files", compression="none", expiration_policy=TimeToIdle(timedelta(days=90))
 )
 _PROFILE_ATTACHMENTS_USECASE: Usecase | None = None
 _PREPROD_USECASE = Usecase("preprod", expiration_policy=TimeToIdle(timedelta(days=30)))

--- a/src/sentry/objectstore/__init__.py
+++ b/src/sentry/objectstore/__init__.py
@@ -71,7 +71,7 @@ class SentryMetricsBackend(MetricsBackend):
 _OBJECTSTORE_CLIENT: Client | None = None
 _ATTACHMENTS_USECASE: Usecase | None = None
 _DEBUG_FILES_USECASE = Usecase(
-    "debug_files", compression="none", expiration_policy=TimeToIdle(timedelta(days=90))
+    "debug_files", compression="zstd", expiration_policy=TimeToIdle(timedelta(days=90))
 )
 _PROFILE_ATTACHMENTS_USECASE: Usecase | None = None
 _PREPROD_USECASE = Usecase("preprod", expiration_policy=TimeToIdle(timedelta(days=30)))

--- a/tests/sentry/debug_files/objectstore_migration/test_utils.py
+++ b/tests/sentry/debug_files/objectstore_migration/test_utils.py
@@ -47,6 +47,7 @@ class DebugFileObjectstoreMigrationUtilsTest(TestCase):
 
     def test_integrity_failure_does_not_cut_over(self) -> None:
         session = MagicMock()
+        session.put.return_value = "uploaded-key"
         session.get.side_effect = lambda *args, **kwargs: MagicMock(
             payload=BytesIO(b"not-the-original-contents")
         )
@@ -55,10 +56,6 @@ class DebugFileObjectstoreMigrationUtilsTest(TestCase):
             patch(
                 "sentry.debug_files.objectstore_migration.utils.get_debug_files_session",
                 return_value=session,
-            ),
-            patch(
-                "sentry.debug_files.objectstore_migration.utils._upload_dif_to_objectstore",
-                return_value="uploaded-key",
             ),
             patch("sentry.utils.retries.time.sleep"),
             pytest.raises(MigrationIntegrityError),
@@ -110,16 +107,13 @@ class DebugFileObjectstoreMigrationUtilsTest(TestCase):
         response = MagicMock()
         response.payload = BytesIO(b"debug-file-contents")
         session = MagicMock()
+        session.put.return_value = "os-key"
         session.get.return_value = response
 
         with (
             patch(
                 "sentry.debug_files.objectstore_migration.utils.get_debug_files_session",
                 return_value=session,
-            ),
-            patch(
-                "sentry.debug_files.objectstore_migration.utils._upload_dif_to_objectstore",
-                return_value="os-key",
             ),
             self.captureOnCommitCallbacks(execute=True),
         ):

--- a/tests/sentry/demo_mode/test_tasks.py
+++ b/tests/sentry/demo_mode/test_tasks.py
@@ -287,6 +287,11 @@ class SyncArtifactBundlesTest(TestCase):
         assert target_project_debug_file.file_size == len(content)
         assert target_project_debug_file.date_created == date_created
         assert target_project_debug_file.get_file().read() == content
+        target_metadata = get_debug_files_session(self.target_org.id, self.target_proj_foo.id).head(
+            target_project_debug_file.storage_path
+        )
+        assert target_metadata is not None
+        assert target_metadata.compression == "zstd"
 
         target_project_debug_file.delete()
         source_project_debug_file.refresh_from_db()

--- a/tests/sentry/demo_mode/test_tasks.py
+++ b/tests/sentry/demo_mode/test_tasks.py
@@ -269,11 +269,12 @@ class SyncArtifactBundlesTest(TestCase):
             data={"features": ["debug"]},
         )
 
-        _sync_project_debug_files(
-            source_org=self.source_org,
-            target_org=self.target_org,
-            cutoff_date=self.last_three_days(),
-        )
+        with self.feature("organizations:objectstore-debugfiles-compression"):
+            _sync_project_debug_files(
+                source_org=self.source_org,
+                target_org=self.target_org,
+                cutoff_date=self.last_three_days(),
+            )
 
         target_project_debug_file = ProjectDebugFile.objects.get(
             project_id=self.target_proj_foo.id,

--- a/tests/sentry/models/test_debugfile.py
+++ b/tests/sentry/models/test_debugfile.py
@@ -6,7 +6,7 @@ import time
 import zipfile
 from io import BytesIO
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from django.core.files.base import ContentFile
@@ -400,10 +400,12 @@ class CreateDebugFileTest(APITestCase):
     @requires_objectstore
     def test_objectstore_write_failure_preserves_legacy_dif(self) -> None:
         content = b"objectstore-dif-content"
+        session = MagicMock()
+        session.put.side_effect = RuntimeError
 
         with (
             self.feature("organizations:objectstore-debugfiles-write"),
-            patch("sentry.models.debugfile._upload_dif_to_objectstore", side_effect=RuntimeError),
+            patch("sentry.models.debugfile.get_debug_files_session", return_value=session),
         ):
             dif, created = self.create_dif(fileobj=BytesIO(content))
 

--- a/tests/symbolicator/test_minidump_full.py
+++ b/tests/symbolicator/test_minidump_full.py
@@ -1,3 +1,5 @@
+import os
+import tempfile
 import zipfile
 from io import BytesIO
 from unittest.mock import patch
@@ -7,6 +9,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 
 from sentry.lang.native.utils import STORE_CRASH_REPORTS_ALL
+from sentry.models.debugfile import ProjectDebugFile
 from sentry.models.eventattachment import EventAttachment
 from sentry.services import eventstore
 from sentry.testutils.cases import TransactionTestCase
@@ -14,7 +17,7 @@ from sentry.testutils.factories import get_fixture_path
 from sentry.testutils.helpers.task_runner import BurstTaskRunner
 from sentry.testutils.objectstore import debug_files_test_both_backends
 from sentry.testutils.relay import RelayStoreHelper
-from sentry.testutils.skips import requires_kafka, requires_symbolicator
+from sentry.testutils.skips import requires_kafka, requires_objectstore, requires_symbolicator
 from sentry.testutils.thread_leaks.pytest import thread_leak_allowlist
 from sentry.utils.safe import get_path
 from tests.symbolicator import insta_snapshot_native_stacktrace_data, redact_location
@@ -210,3 +213,78 @@ class SymbolicatorMinidumpIntegrationTest(RelayStoreHelper, TransactionTestCase)
 
         thread_name = get_path(event.data, "threads", "values", 1, "name")
         assert thread_name == "sentry-http"
+
+
+@pytest.mark.snuba
+@thread_leak_allowlist(reason="kafka testutils", issue=97046)
+@requires_objectstore
+class SymbolicatorLargeCompressedDifIntegrationTest(RelayStoreHelper, TransactionTestCase):
+    _FEATURES = {
+        "organizations:event-attachments": True,
+        "organizations:custom-symbol-sources": False,
+    }
+
+    @pytest.fixture(autouse=True)
+    def initialize(self, live_server, reset_snuba):
+        self.project.update_option("sentry:builtin_symbol_sources", [])
+
+        with (
+            patch("sentry.auth.system.is_internal_ip", return_value=True),
+            self.options({"system.url-prefix": live_server.url}),
+        ):
+            yield
+
+    def upload_large_symbols(self) -> None:
+        url = reverse(
+            "sentry-api-0-dsym-files",
+            kwargs={
+                "organization_id_or_slug": self.project.organization.slug,
+                "project_id_or_slug": self.project.slug,
+            },
+        )
+        self.login_as(user=self.user)
+
+        with tempfile.NamedTemporaryFile(suffix=".zip") as archive:
+            with zipfile.ZipFile(archive, "w") as zip_file:
+                with zip_file.open("crash.sym", "w") as symbol_file:
+                    with open(get_fixture_path("native", "windows.sym"), "rb") as fixture:
+                        symbol_file.write(fixture.read())
+
+                    remaining = 300 * 1024 * 1024  # 300 MB
+                    while remaining:
+                        chunk_size = min(64 * 1024, remaining)
+                        symbol_file.write(
+                            b"#" + os.urandom(chunk_size - 2).replace(b"\n", b" ") + b"\n"
+                        )
+                        remaining -= chunk_size
+
+            archive.seek(0)
+            response = self.client.post(url, {"file": archive}, format="multipart")
+
+        assert response.status_code == 201, response.content
+        assert len(response.json()) == 1
+
+    def test_full_minidump(self) -> None:
+        self.project.update_option("sentry:store_crash_reports", STORE_CRASH_REPORTS_ALL)
+
+        with self.feature(
+            {
+                **self._FEATURES,
+                "organizations:objectstore-debugfiles-write": True,
+                "organizations:objectstore-debugfiles-read": True,
+                "organizations:objectstore-debugfiles-direct-read": True,
+            }
+        ):
+            self.upload_large_symbols()
+
+            dif = ProjectDebugFile.objects.get(project_id=self.project.id)
+            assert dif.file_id is not None
+            assert dif.storage_path is not None
+
+            with open(get_fixture_path("native", "windows.dmp"), "rb") as minidump:
+                event = self.post_and_retrieve_minidump({"upload_file_minidump": minidump}, {})
+
+        candidate = event.data["debug_meta"]["images"][0]["candidates"][0]
+        assert candidate["debug"]["status"] == "ok"
+        frames = event.data["exception"]["values"][0]["stacktrace"]["frames"]
+        assert any(frame.get("function") == "main" for frame in frames)

--- a/tests/symbolicator/test_minidump_full.py
+++ b/tests/symbolicator/test_minidump_full.py
@@ -250,6 +250,7 @@ class SymbolicatorLargeCompressedDifIntegrationTest(RelayStoreHelper, Transactio
                     with open(get_fixture_path("native", "windows.sym"), "rb") as fixture:
                         symbol_file.write(fixture.read())
 
+                    # Pad the Breakpad .sym file with random (incompressible) comment lines to make the upload large without changing its symbol data.
                     remaining = 300 * 1024 * 1024  # 300 MB
                     while remaining:
                         chunk_size = min(64 * 1024, remaining)

--- a/tests/symbolicator/test_minidump_full.py
+++ b/tests/symbolicator/test_minidump_full.py
@@ -272,6 +272,7 @@ class SymbolicatorLargeCompressedDifIntegrationTest(RelayStoreHelper, Transactio
             {
                 **self._FEATURES,
                 "organizations:objectstore-debugfiles-write": True,
+                "organizations:objectstore-debugfiles-compression": True,
                 "organizations:objectstore-debugfiles-read": True,
                 "organizations:objectstore-debugfiles-direct-read": True,
             }


### PR DESCRIPTION
When uploading debug files, we now use zstd compression, subject to the `organizations:objectstore-debugfiles-compression` flag.

Moreover, we remove the multipart upload route, as we're going to eventually remove that API anyways.

An additional e2e Symbolicator test is added that uses a large debug file that is stored compressed, asserting that Symbolicator works in such a scenario after the https://github.com/getsentry/symbolicator/pull/1999 change.

Whenever `objectstore_client` compresses with zstd during the upload, it automatically records the `sentry.storage.put.compression_ratio` metric, so it will be easy for us to evaluate the impact of this change.

Close FS-390
Refs FS-475