### PR TITLE
chore(agents): Trim derivable content from AGENTS.md

### DIFF
--- a/.agents/skills/feature-flags/SKILL.md
+++ b/.agents/skills/feature-flags/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: feature-flags
+description: Gate a Sentry feature behind a FlagPole feature flag. Use when adding a feature flag, registering a flag in temporary.py, checking a flag from Python or the frontend, enabling a flag in tests, or asking where FlagPole rollout config lives. Trigger on "add a feature flag", "gate this behind a flag", "register a flag", "features.has", "api_expose", "OrganizationFeature", "ProjectFeature", "FlagPole".
+---
+
+# Feature Flags (FlagPole)
+
+New features should be gated behind a feature flag.
+
+1. **Register** the flag in `src/sentry/features/temporary.py`:
+
+   ```python
+   manager.add("organizations:my-feature", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+   ```
+
+   Use `api_expose=True` if the frontend needs to check the flag. Use `ProjectFeature` and a `projects:` prefix for project-scoped flags.
+
+2. **Python check**:
+
+   ```python
+   if features.has("organizations:my-feature", organization, actor=user):
+   ```
+
+3. **Frontend check** (requires `api_expose=True`):
+
+   ```typescript
+   organization.features.includes('my-feature');
+   ```
+
+4. **Tests**:
+
+   ```python
+   with self.feature("organizations:my-feature"):
+       ...
+   ```
+
+5. **Rollout**: FlagPole YAML config lives in the `sentry-options-automator` repo, not here.
+
+See https://develop.sentry.dev/feature-flags/ for full docs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,8 +4,6 @@
 
 ## Command Execution Guide
 
-This section contains critical command execution instructions that apply across all Sentry development.
-
 ### Python Command Execution Requirements
 
 **CRITICAL**: When running Python commands (pytest, mypy, prek, etc.), you MUST use the virtual environment.
@@ -85,32 +83,17 @@ For backend-scoped changes, prioritize running the individual relevant pytest fi
 #### Database Operations
 
 ```bash
-# Run migrations
-sentry django migrate
-
-# Create new migration
-sentry django makemigrations
-
 # Update migration after rebase conflict (handles renaming, dependencies, lockfile)
 ./bin/update-migration <migration_name_or_number> <app_label>
 # Example: ./bin/update-migration 0101_workflow_when_condition_group_unique workflow_engine
-
-# Reset database
-make reset-db
 ```
 
 ### Frontend Development Commands
 
 #### Development Setup
 
-```bash
-# Start the full development server (requires devservices up)
-pnpm run dev
-
-# Start only the UI development server with hot reload
-# Proxies API requests to production sentry.io
-pnpm run dev-ui
-```
+`pnpm run dev` starts the full development server (requires `devservices up`).
+`pnpm run dev-ui` starts only the UI dev server with hot reload, proxying API requests to production sentry.io.
 
 **Dev server URLs:**
 
@@ -119,36 +102,18 @@ pnpm run dev-ui
 
 #### Typechecking
 
-To typecheck frontend code, run `pnpm typecheck` script.
+To typecheck frontend code, run `pnpm run typecheck`.
 It checks the whole project and does not accept file paths.
 DO NOT use `tsc` directly.
 
-```bash
-pnpm run typecheck
-```
-
 #### Linting
 
-```bash
-# JavaScript/TypeScript linting
-pnpm run lint:js
-
-# Linting for specific file(s)
-pnpm run lint:js components/avatar.tsx [...other files]
-
-# Fix linting issues
-pnpm run fix
-```
+`pnpm run lint:js` lints JS/TS; it accepts file paths (`pnpm run lint:js components/avatar.tsx`).
+`pnpm run fix` fixes what it can automatically.
 
 #### Testing
 
-```bash
-# Run JavaScript tests
-pnpm test-ci <file_path>
-
-# Run specific test file(s)
-pnpm test-ci components/avatar.spec.tsx
-```
+`pnpm test-ci <file_path>` runs JS tests for the given file(s).
 
 ### Git worktrees
 
@@ -177,49 +142,9 @@ Skills under `.agents/skills/` should follow the same current-practice conventio
 - Keep skill descriptions aligned with natural user requests like PR review, branch audit, and Warden follow-up.
 - If a downstream review harness controls the final response shape, do not hardcode a competing output format in the skill. Specify required evidence instead.
 
-## Backend
-
-For backend development patterns, security guidelines, and architecture, see `src/AGENTS.md`.
-For backend testing patterns and best practices, see `tests/AGENTS.md`.
-
-## Frontend
-
-For frontend development patterns, design system guidelines, and React testing best practices, see `static/AGENTS.md`.
-
 ## Feature Flags (FlagPole)
 
-New features should be gated behind a feature flag.
-
-1. **Register** the flag in `src/sentry/features/temporary.py`:
-
-   ```python
-   manager.add("organizations:my-feature", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-   ```
-
-   Use `api_expose=True` if the frontend needs to check the flag. Use `ProjectFeature` and a `projects:` prefix for project-scoped flags.
-
-2. **Python check**:
-
-   ```python
-   if features.has("organizations:my-feature", organization, actor=user):
-   ```
-
-3. **Frontend check** (requires `api_expose=True`):
-
-   ```typescript
-   organization.features.includes('my-feature');
-   ```
-
-4. **Tests**:
-
-   ```python
-   with self.feature("organizations:my-feature"):
-       ...
-   ```
-
-5. **Rollout**: FlagPole YAML config lives in the `sentry-options-automator` repo, not here.
-
-See https://develop.sentry.dev/feature-flags/ for full docs.
+New features should be gated behind a feature flag. See the **feature-flags** skill (`.agents/skills/feature-flags/`) for registration, the `features.has(...)` check, the frontend check, and test usage.
 
 ## Customer Information
 

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -162,7 +162,7 @@ return Response({"message": "Invalid input"}, status=400)
 
 ### Feature Flags
 
-See **Feature Flags (FlagPole)** in `/AGENTS.md` for registration, the `features.has(...)` check, and test usage.
+See the **feature-flags** skill (`.agents/skills/feature-flags/`) for registration, the `features.has(...)` check, and test usage.
 
 ### Permissions
 


### PR DESCRIPTION
I ran `claude doctor` and these were the suggestions


# Slop

`AGENTS.md` is loaded into every session's context in this repo (the root `CLAUDE.md` is just `@AGENTS.md`), so every line costs tokens on every turn. This trims content a session can reconstruct on its own, and moves one task-specific workflow behind lazy loading.

**Net: `AGENTS.md` 8,623 → 7,243 chars (~2,155 → ~1,810 est. tokens), minus ~108 est. tokens for the new skill's resident description.**

## Removed as derivable from the repo

| Cut | Why it's derivable |
|---|---|
| Frontend command fences | `dev`, `dev-ui`, `typecheck`, `lint:js`, `fix`, `test-ci` are all `package.json` scripts |
| `sentry django migrate` / `makemigrations` / `make reset-db` | Standard Django + Make invocations |
| `## Backend` / `## Frontend` pointer sections | Duplicated the "Context-Aware Loading" table directly above them |
| Filler sentence under "Command Execution Guide" | Said nothing actionable |

The frontend sections became prose rather than being deleted, because the *non-derivable* facts were interleaved with the derivable commands — that `typecheck` accepts no file paths, that `lint:js` does, and the two dev-server URLs. Those all stay.

`./bin/update-migration` also stays: it's a repo-specific script with non-obvious arguments, so it fails the derivability test.

## Moved to lazy loading

The five-step FlagPole workflow is now the **`feature-flags` skill**. Only its description stays resident; the body loads when the model routes to it. The body is byte-identical to what was removed.

`AGENTS.md` keeps a one-line stub under the same heading, so the *policy* — new features should be gated — is still always in context even though the mechanics aren't. `src/AGENTS.md` had the only inbound reference and now points at the skill.

## Drive-by fix

The typecheck line said `pnpm typecheck`; `package.json` defines the script as `pnpm run typecheck`.

## Verification

- `prek run` passes (`format`, whitespace, EOF, case conflicts).
- Confirmed no dangling references to the moved section anywhere in the repo.
- Confirmed the migrated skill body is byte-identical to the removed section via `diff`.
- Every `package.json` script named in the removed fences verified present before cutting.

## What was deliberately *not* changed

The `devservices` guidance stays as-is. My local `~/.claude/CLAUDE.md` tells agents never to run it (it pegs the CPU on my machine), which contradicts `AGENTS.md` — but that's a machine-specific constraint and the checked-in guidance is correct for the team.
