### PR TITLE
fix(replays): remove unnecessary margins in table header cells

### DIFF
--- a/static/app/components/replays/table/replayTableColumns.tsx
+++ b/static/app/components/replays/table/replayTableColumns.tsx
@@ -595,8 +595,6 @@ const CheckboxHeaderContainer = styled(Flex)`
   justify-content: center;
   align-items: center;
   gap: ${p => p.theme.space.md};
-
-  margin: 0 -${p => p.theme.space.md} 0 -${p => p.theme.space.xs};
 `;
 
 const CheckboxClickCapture = styled('div')`
@@ -614,7 +612,6 @@ const CheckboxCellContainer = styled('div')`
   gap: ${p => p.theme.space.xs};
 
   padding: ${p => p.theme.space.xs} 0 0 0;
-  margin: 0 -${p => p.theme.space.md} 0 -${p => p.theme.space.xs};
 `;
 
 const CheckboxClickTarget = styled('label')`


### PR DESCRIPTION
Closes REPLAY-961. Which was actually reported originally in #121038 (thanks @wichopy)!

This PR's approach is different: instead of expanding the label (either arbitrarily per that PR's current code, or to max content like in https://github.com/getsentry/sentry/pull/121038#discussion_r3721743153), this removes the unnecessary horizontal margins that were squishing label contents.

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="322" height="117" alt="image" src="https://github.com/user-attachments/assets/e58fa0ec-8dac-4ad2-96ad-3ab315da3e48" />
</td>
<td>
<img width="322" height="117" alt="image" src="https://github.com/user-attachments/assets/e8469cfd-e2d5-4329-9279-9da117f318a4" />
</td>
</tr>
</tbody>
</table>

I'd caused this bug myself in #120587. 😬 