### PR TITLE
fix(inbox): Remove progress badge from issue preview

### DIFF
--- a/static/app/views/issueDetails/issuePreview/issuePreview.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreview.tsx
@@ -44,7 +44,6 @@ import {
   ReprocessingStatus,
 } from 'sentry/views/issueDetails/utils';
 import {IssueSeenTimes} from 'sentry/views/issueList/pages/issueSeenTimes';
-import {IssueProgressTag} from 'sentry/views/issueList/utils/progress';
 
 interface IssuePreviewProps {
   groupId: string;
@@ -162,9 +161,6 @@ function IssuePreviewContent() {
               <GroupStatusSubtitle group={group} project={project} />
             </Flex>
             <Flex align="center" gap="xs" flexShrink={0} wrap="nowrap">
-              {group.derivedData?.progress && (
-                <IssueProgressTag state={group.derivedData.progress} />
-              )}
               <EventUserCounts group={group} project={project} />
             </Flex>
           </Flex>

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -672,6 +672,7 @@ describe('InboxPage', () => {
         name: 'Fix proposed issue',
       })
     ).toBeInTheDocument();
+    expect(within(preview).queryByText('Fix Proposed')).not.toBeInTheDocument();
 
     await userEvent.click(await screen.findByRole('button', {name: 'Back to inbox'}));
     expect(router.location.query.preview).toBeUndefined();

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -672,7 +672,6 @@ describe('InboxPage', () => {
         name: 'Fix proposed issue',
       })
     ).toBeInTheDocument();
-    expect(within(preview).queryByText('Fix Proposed')).not.toBeInTheDocument();
 
     await userEvent.click(await screen.findByRole('button', {name: 'Back to inbox'}));
     expect(router.location.query.preview).toBeUndefined();

--- a/static/app/views/issueList/utils/progress.tsx
+++ b/static/app/views/issueList/utils/progress.tsx
@@ -1,11 +1,8 @@
 import type {ReactNode} from 'react';
 
-import {Tag} from '@sentry/scraps/badge';
-
 import {ProgressMarker, type ProgressMarkerStep} from 'sentry/components/progressMarker';
 import {t} from 'sentry/locale';
 import {ProgressState} from 'sentry/types/group';
-import type {TagVariant} from 'sentry/utils/theme';
 import type {IconSize} from 'sentry/utils/theme/types';
 
 const PROGRESS_STATE_LABELS: Record<ProgressState, string> = {
@@ -37,24 +34,4 @@ export function getProgressIcon(state: ProgressState | null, size?: IconSize): R
   }
   const step = PROGRESS_STATE_STEPS[state];
   return step ? <ProgressMarker step={step} size={size} /> : null;
-}
-
-const PROGRESS_STATE_TAG_VARIANTS: Record<ProgressState, TagVariant> = {
-  [ProgressState.IDENTIFIED]: 'muted',
-  [ProgressState.ASSIGNED]: 'muted',
-  [ProgressState.DIAGNOSED]: 'warning',
-  [ProgressState.FIX_PROPOSED]: 'success',
-  [ProgressState.FIX_APPLIED]: 'success',
-};
-
-/** Progress state as a colored tag with a leading icon (e.g. a green "Fix Proposed"). */
-export function IssueProgressTag({state}: {state: ProgressState | null}) {
-  if (!state) {
-    return null;
-  }
-  return (
-    <Tag variant={PROGRESS_STATE_TAG_VARIANTS[state]} icon={getProgressIcon(state, 'xs')}>
-      {formatProgressState(state)}
-    </Tag>
-  );
 }


### PR DESCRIPTION
Removes the progress badge from the inbox issue preview header while preserving section progress indicators.

Refs [ISWF-3213](https://linear.app/getsentry/issue/ISWF-3213/remove-progress-badge-from-preview-header).