### PR TITLE
feat(api): Add response schema to organization tag values endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_tagkey_values.py
+++ b/src/sentry/api/endpoints/organization_tagkey_values.py
@@ -1,4 +1,5 @@
 import sentry_sdk
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -10,9 +11,18 @@ from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
 from sentry.api.paginator import SequencePaginator
 from sentry.api.serializers import serialize
 from sentry.api.utils import handle_query_errors
+from sentry.apidocs.constants import (
+    RESPONSE_BAD_REQUEST,
+    RESPONSE_FORBIDDEN,
+    RESPONSE_NOT_FOUND,
+    RESPONSE_UNAUTHORIZED,
+)
+from sentry.apidocs.parameters import GlobalParams, OrganizationParams
+from sentry.apidocs.response_types import DetailResponse
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.snuba.dataset import Dataset
 from sentry.tagstore.base import TAG_KEY_RE
-from sentry.tagstore.types import TagValue
+from sentry.tagstore.types import TagValue, TagValueSerializerResponse
 
 
 def validate_sort_field(field_name: str) -> str:
@@ -21,13 +31,80 @@ def validate_sort_field(field_name: str) -> str:
     return field_name
 
 
+@extend_schema(tags=["Explore"])
 @cell_silo_endpoint
 class OrganizationTagKeyValuesEndpoint(OrganizationEventsEndpointBase):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
 
-    def get(self, request: Request, organization, key) -> Response:
+    @extend_schema(
+        operation_id="listOrganizationTagValues",
+        summary="List an Organization's Tag Values",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            OrganizationParams.PROJECT,
+            GlobalParams.ENVIRONMENT,
+            GlobalParams.STATS_PERIOD,
+            GlobalParams.START,
+            GlobalParams.END,
+            OpenApiParameter(
+                name="key",
+                location="path",
+                required=True,
+                type=str,
+                description="The tag key to look up.",
+            ),
+            OpenApiParameter(
+                name="dataset",
+                location="query",
+                required=False,
+                type=str,
+                description="The dataset to query. Defaults to `events`.",
+                enum=["discover", "events", "search_issues", "replays"],
+            ),
+            OpenApiParameter(
+                name="query",
+                location="query",
+                required=False,
+                type=str,
+                description='Perform a "contains" match on the tag values.',
+            ),
+            OpenApiParameter(
+                name="sort",
+                location="query",
+                required=False,
+                type=str,
+                description="The sort order of the values. Defaults to `-last_seen`. Use `-count` to rank by how often each value occurs.",
+                enum=["-last_seen", "-count"],
+            ),
+            OpenApiParameter(
+                name="useFlagsBackend",
+                location="query",
+                required=False,
+                type=str,
+                description='Set to `"1"` when `key` names a feature flag rather than a tag. Flags are stored alongside tags but in a separate column, so a flag key looked up as a tag returns no values.',
+                enum=["0", "1"],
+            ),
+        ],
+        responses={
+            200: inline_sentry_response_serializer(
+                "ListOrganizationTagValuesResponse", list[TagValueSerializerResponse]
+            ),
+            400: RESPONSE_BAD_REQUEST,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
+    def get(
+        self, request: Request, organization, key
+    ) -> Response[list[TagValueSerializerResponse]] | Response[DetailResponse]:
+        """
+        Return a list of values associated with this tag key across the organization's
+        projects. The `query` parameter can be used to perform a "contains" match on
+        values.
+        """
         if not TAG_KEY_RE.match(key):
             return Response({"detail": f'Invalid tag key format for "{key}"'}, status=400)
 


### PR DESCRIPTION
Documents the request params and response type for `GET /organizations/{org}/tags/{key}/values/` so internal tooling can generate a typed client for it. That generator only admits an operation whose success response resolves to a concrete schema.

First of four related endpoints (BROWSE-693); the rest follow as separate PRs using the same pattern.

**`publish_status` stays `PRIVATE`** — the endpoint remains absent from the public spec and unchanged on docs.sentry.io.

Notes on scope:
- Tagged `Explore`, not `Discover`, following ff19d81eb4a.
- Params limited to those useful for building a query. Omitted `includeTransactions`/`includeReplays` (superseded by `dataset`), `includeSessions` (only affects the `release` key), and `cursor` (the consuming client never surfaces the `Link` header a cursor value would come from).
- `dataset` enum matches the values the paginator handles, mirroring `OrganizationTagsEndpoint`.

Verified the declared response against a live response, since the existing tests only assert `value`/`count` and wouldn't catch drift in the other five keys. `pytest tests/snuba/api/endpoints/test_organization_tagkey_values.py` → 36 passed.

Refs BROWSE-693