### PR TITLE
ref(inbox): Restyle event and user counts

### DIFF
--- a/static/app/views/issueDetails/header/eventUserCounts.tsx
+++ b/static/app/views/issueDetails/header/eventUserCounts.tsx
@@ -1,3 +1,5 @@
+import styled from '@emotion/styled';
+
 import {Container, Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
@@ -27,29 +29,21 @@ export function EventUserCounts({group, project}: EventUserCountsProps) {
   return (
     <Flex align="center" gap="sm">
       <Tooltip title={userLabel} skipWrapper>
-        <Flex
-          as="span"
-          align="center"
-          gap="xs"
-          height="32px"
-          padding="sm 0"
-          aria-label={userLabel}
-        >
+        <StatItem as="span" align="center" gap="xs" padding="sm 0" aria-label={userLabel}>
           <Text size="md" bold tabular>
             <Count value={userCount} />
           </Text>
           <Text size="sm" variant="muted">
             {t('Users')}
           </Text>
-        </Flex>
+        </StatItem>
       </Tooltip>
       <Container aria-hidden borderLeft="muted" height="16px" />
       <Tooltip title={eventLabel} skipWrapper>
-        <Flex
+        <StatItem
           as="span"
           align="center"
           gap="xs"
-          height="32px"
           padding="sm 0"
           aria-label={eventLabel}
         >
@@ -59,8 +53,12 @@ export function EventUserCounts({group, project}: EventUserCountsProps) {
           <Text size="sm" variant="muted">
             {t('Events')}
           </Text>
-        </Flex>
+        </StatItem>
       </Tooltip>
     </Flex>
   );
 }
+
+const StatItem = styled(Flex)`
+  height: ${p => p.theme.space['3xl']};
+`;

--- a/static/app/views/issueDetails/header/eventUserCounts.tsx
+++ b/static/app/views/issueDetails/header/eventUserCounts.tsx
@@ -27,7 +27,14 @@ export function EventUserCounts({group, project}: EventUserCountsProps) {
   return (
     <Flex align="center" gap="sm">
       <Tooltip title={userLabel} skipWrapper>
-        <Flex as="span" align="center" gap="2xs" aria-label={userLabel}>
+        <Flex
+          as="span"
+          align="center"
+          gap="xs"
+          height="32px"
+          padding="sm 0"
+          aria-label={userLabel}
+        >
           <Text size="md" bold tabular>
             <Count value={userCount} />
           </Text>
@@ -38,7 +45,14 @@ export function EventUserCounts({group, project}: EventUserCountsProps) {
       </Tooltip>
       <Container aria-hidden borderLeft="muted" height="16px" />
       <Tooltip title={eventLabel} skipWrapper>
-        <Flex as="span" align="center" gap="2xs" aria-label={eventLabel}>
+        <Flex
+          as="span"
+          align="center"
+          gap="xs"
+          height="32px"
+          padding="sm 0"
+          aria-label={eventLabel}
+        >
           <Text size="md" bold tabular>
             <Count value={eventCount} />
           </Text>

--- a/static/app/views/issueDetails/header/eventUserCounts.tsx
+++ b/static/app/views/issueDetails/header/eventUserCounts.tsx
@@ -1,5 +1,3 @@
-import styled from '@emotion/styled';
-
 import {Container, Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
@@ -29,36 +27,26 @@ export function EventUserCounts({group, project}: EventUserCountsProps) {
   return (
     <Flex align="center" gap="sm">
       <Tooltip title={userLabel} skipWrapper>
-        <StatItem as="span" align="center" gap="xs" padding="sm 0" aria-label={userLabel}>
+        <Flex as="span" align="center" gap="xs" padding="sm 0" aria-label={userLabel}>
           <Text size="md" bold tabular>
             <Count value={userCount} />
           </Text>
           <Text size="sm" variant="muted">
             {t('Users')}
           </Text>
-        </StatItem>
+        </Flex>
       </Tooltip>
       <Container aria-hidden borderLeft="muted" height="16px" />
       <Tooltip title={eventLabel} skipWrapper>
-        <StatItem
-          as="span"
-          align="center"
-          gap="xs"
-          padding="sm 0"
-          aria-label={eventLabel}
-        >
+        <Flex as="span" align="center" gap="xs" padding="sm 0" aria-label={eventLabel}>
           <Text size="md" bold tabular>
             <Count value={eventCount} />
           </Text>
           <Text size="sm" variant="muted">
             {t('Events')}
           </Text>
-        </StatItem>
+        </Flex>
       </Tooltip>
     </Flex>
   );
 }
-
-const StatItem = styled(Flex)`
-  height: ${p => p.theme.space['3xl']};
-`;

--- a/static/app/views/issueDetails/header/eventUserCounts.tsx
+++ b/static/app/views/issueDetails/header/eventUserCounts.tsx
@@ -1,10 +1,9 @@
-import {Tag} from '@sentry/scraps/badge';
-import {Flex} from '@sentry/scraps/layout';
+import {Container, Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {Count} from 'sentry/components/count';
-import {IconFile, IconUser} from 'sentry/icons';
-import {tn} from 'sentry/locale';
+import {t, tn} from 'sentry/locale';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
@@ -26,16 +25,27 @@ export function EventUserCounts({group, project}: EventUserCountsProps) {
   const userLabel = tn('%s affected user', '%s affected users', userCount);
 
   return (
-    <Flex align="center" gap="xs">
+    <Flex align="center" gap="sm">
       <Tooltip title={userLabel} skipWrapper>
-        <Tag variant="muted" icon={<IconUser />} aria-label={userLabel}>
-          <Count value={userCount} />
-        </Tag>
+        <Flex as="span" align="center" gap="2xs" aria-label={userLabel}>
+          <Text size="md" bold tabular>
+            <Count value={userCount} />
+          </Text>
+          <Text size="sm" variant="muted">
+            {t('Users')}
+          </Text>
+        </Flex>
       </Tooltip>
+      <Container aria-hidden borderLeft="muted" height="16px" />
       <Tooltip title={eventLabel} skipWrapper>
-        <Tag variant="muted" icon={<IconFile />} aria-label={eventLabel}>
-          <Count value={eventCount} />
-        </Tag>
+        <Flex as="span" align="center" gap="2xs" aria-label={eventLabel}>
+          <Text size="md" bold tabular>
+            <Count value={eventCount} />
+          </Text>
+          <Text size="sm" variant="muted">
+            {t('Events')}
+          </Text>
+        </Flex>
       </Tooltip>
     </Flex>
   );

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -65,6 +65,8 @@ describe('InboxPage', () => {
     hasSeen: false,
     lastSeen: '2026-07-19T12:00:00Z',
     level: 'error',
+    count: '2600',
+    userCount: 11,
     assignedTo: {id: '10', name: 'Jane Doe', type: 'user'},
     metadata: {
       type: 'TypeError',
@@ -672,6 +674,12 @@ describe('InboxPage', () => {
         name: 'Fix proposed issue',
       })
     ).toBeInTheDocument();
+    expect(within(preview).getByLabelText('11 affected users')).toHaveTextContent(
+      '11Users'
+    );
+    expect(within(preview).getByLabelText('2,600 events')).toHaveTextContent(
+      '2.6KEvents'
+    );
 
     await userEvent.click(await screen.findByRole('button', {name: 'Back to inbox'}));
     expect(router.location.query.preview).toBeUndefined();


### PR DESCRIPTION
Replaces the inbox preview event and user badges with inline count/label pairs matching the updated design. Counts use medium 14px text, labels use muted 12px text, and the metrics retain localized accessible labels and tooltips.

Refs [ISWF-3215](https://linear.app/getsentry/issue/ISWF-3215/update-userevent-styling-in-preview-header).