### PR TITLE
fix(inbox): Rename create PR action

### DIFF
--- a/static/app/views/issueDetails/issuePreview/issuePreviewSeerActions.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewSeerActions.tsx
@@ -149,7 +149,7 @@ function getAutofixPrimaryAction(autofix: ExplorerAutofix): SeerAction | null {
 
   switch (nextStep?.action) {
     case 'create_pr':
-      return {...AUTOFIX_ANALYTICS.create_pr, kind: 'create_pr', label: t('Draft a PR')};
+      return {...AUTOFIX_ANALYTICS.create_pr, kind: 'create_pr', label: t('Create PR')};
     case 'code_changes':
       return {
         ...AUTOFIX_ANALYTICS.code_changes,

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -1,5 +1,6 @@
 import {
   AutofixRepoPRStateFixture,
+  ExplorerAutofixBlockFixture,
   ExplorerAutofixResponseFixture,
   ExplorerAutofixStateFixture,
 } from 'sentry-fixture/autofix';
@@ -769,6 +770,39 @@ describe('InboxPage', () => {
         })
       )
     );
+  });
+
+  it('offers to create a PR when code changes are complete', async () => {
+    mockSuccessfulSections();
+    mockIssuePreview();
+    mockAutofixResponse(
+      ExplorerAutofixResponseFixture({
+        autofix: ExplorerAutofixStateFixture({
+          blocks: [
+            ExplorerAutofixBlockFixture({
+              message: {
+                content: 'Code changes complete',
+                metadata: {step: 'code_changes'},
+                role: 'assistant',
+              },
+            }),
+          ],
+        }),
+      })
+    );
+
+    render(<InboxPage />, {
+      organization: seerOrganization,
+      initialRouterConfig,
+    });
+
+    const preview = await openFixProposedPreview();
+    expect(
+      await within(preview).findByRole('button', {name: 'Create PR'})
+    ).toBeInTheDocument();
+    expect(
+      within(preview).queryByRole('button', {name: 'Draft a PR'})
+    ).not.toBeInTheDocument();
   });
 
   it('links to a completed Autofix pull request while polling', async () => {

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -800,9 +800,6 @@ describe('InboxPage', () => {
     expect(
       await within(preview).findByRole('button', {name: 'Create PR'})
     ).toBeInTheDocument();
-    expect(
-      within(preview).queryByRole('button', {name: 'Draft a PR'})
-    ).not.toBeInTheDocument();
   });
 
   it('links to a completed Autofix pull request while polling', async () => {


### PR DESCRIPTION
Renames the inbox preview action from `Draft a PR` to `Create PR` because Autofix creates an open pull request rather than a draft. Adds coverage for the completed-code-changes state that exposes this action.

Refs [ISWF-3220](https://linear.app/getsentry/issue/ISWF-3220/update-draft-a-pr-cta).