### PR TITLE
feat(seer): add ThinkingBlock with outline Disclosure

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -19,6 +19,8 @@ const productionEntryPoints = [
   'static/app/components/core/quote/*.tsx',
   'static/app/components/core/markdown/**/*.{ts,tsx}',
   'static/app/components/core/revealOnHover/*.tsx',
+  // TODO: Remove when wired into Seer Explorer
+  'static/app/components/core/chat/thinkingBlock.tsx',
   // todo we currently keep all icons
   'static/app/icons/**/*.{js,ts,tsx}',
   // todo find out how chartcuterie works

--- a/static/app/components/core/chat/index.tsx
+++ b/static/app/components/core/chat/index.tsx
@@ -4,3 +4,4 @@ export {UserMessage} from './userMessage';
 export {ToolCallIndicator, type ToolCallStatus} from './toolCallIndicator';
 export {Spinner} from './spinner';
 export {MessageRow} from './messageRow';
+export {ThinkingBlock} from './thinkingBlock';

--- a/static/app/components/core/chat/thinkingBlock.mdx
+++ b/static/app/components/core/chat/thinkingBlock.mdx
@@ -1,0 +1,119 @@
+---
+title: ThinkingBlock
+description: A collapsible disclosure that shows an agent's thinking progress with a live timer.
+category: chat
+source: '@sentry/scraps/chat'
+resources:
+  js: https://github.com/getsentry/sentry/blob/master/static/app/components/core/chat/thinkingBlock.tsx
+---
+
+import {useEffect, useState} from 'react';
+import {Container} from '@sentry/scraps/layout';
+import {ThinkingBlock} from '@sentry/scraps/chat';
+import {Text} from '@sentry/scraps/text';
+
+import * as Storybook from 'sentry/stories';
+
+export const documentation = import('!!type-loader!@sentry/scraps/chat/thinkingBlock');
+
+The `ThinkingBlock` wraps a `Disclosure` with a Seer icon, a stateful title,
+and a live-counting elapsed timer. It stays expanded while the agent is
+thinking and auto-collapses when `endTime` arrives.
+
+## Active (thinking)
+
+Pass only `startTime` — the timer counts up and the block stays open.
+
+export function ActiveDemo() {
+  const [start] = useState(() => new Date());
+  return (
+    <ThinkingBlock title="Analyzing source code..." startTime={start}>
+      <Text size="sm" monospace variant="muted">
+        The user is asking about a missing span in the DSL output. Let me search the spans
+        dataset first.
+      </Text>
+    </ThinkingBlock>
+  );
+}
+
+<Storybook.Demo>
+  <ActiveDemo />
+</Storybook.Demo>
+
+```jsx
+<ThinkingBlock title="Analyzing source code..." startTime={new Date()}>
+  <Text size="sm" monospace variant="muted">
+    Thinking content here...
+  </Text>
+</ThinkingBlock>
+```
+
+## Completed (collapsed)
+
+Once `endTime` is set the timer freezes and the block collapses. The user can
+still click to re-expand.
+
+export function CompletedDemo() {
+  const [start] = useState(() => new Date(Date.now() - 56_400));
+  const [end] = useState(() => new Date());
+  return (
+    <ThinkingBlock title="Analyzed source code" startTime={start} endTime={end}>
+      <Text size="sm" monospace variant="muted">
+        Found a trace ID in the logs. The agent generated a DSL string but project scoping
+        is handled by a separate UI control.
+      </Text>
+    </ThinkingBlock>
+  );
+}
+
+<Storybook.Demo>
+  <CompletedDemo />
+</Storybook.Demo>
+
+```jsx
+<ThinkingBlock title="Analyzed source code" startTime={start} endTime={end}>
+  …
+</ThinkingBlock>
+```
+
+## Transition
+
+The title can update while thinking, and passing `endTime` triggers the
+collapse transition.
+
+export function TransitionDemo() {
+  const [start] = useState(() => new Date());
+  const [title, setTitle] = useState('Searching spans...');
+  const [end, setEnd] = useState(undefined);
+  useEffect(() => {
+    const t1 = setTimeout(() => setTitle('Found trace, pulling waterfall...'), 3000);
+    const t2 = setTimeout(() => {
+      setTitle('Analysis complete');
+      setEnd(new Date());
+    }, 6000);
+    return () => {
+      clearTimeout(t1);
+      clearTimeout(t2);
+    };
+  }, []);
+  return (
+    <ThinkingBlock title={title} startTime={start} endTime={end}>
+      <Text size="sm" monospace variant="muted">
+        Thinking content that collapses after ~6 seconds.
+      </Text>
+    </ThinkingBlock>
+  );
+}
+
+<Storybook.Demo>
+  <TransitionDemo />
+</Storybook.Demo>
+
+```jsx
+const [title, setTitle] = useState('Searching spans...');
+const [end, setEnd] = useState(undefined);
+
+// later…
+setTitle('Analysis complete');
+setEnd(new Date());
+```

--- a/static/app/components/core/chat/thinkingBlock.spec.tsx
+++ b/static/app/components/core/chat/thinkingBlock.spec.tsx
@@ -34,7 +34,7 @@ describe('ThinkingBlock', () => {
     expect(screen.getByText('10.0s')).toBeInTheDocument();
   });
 
-  it('is expanded by default and collapses when endTime arrives', async () => {
+  it('is expanded by default and collapses when endTime arrives', () => {
     jest.useRealTimers();
     const start = new Date();
 

--- a/static/app/components/core/chat/thinkingBlock.spec.tsx
+++ b/static/app/components/core/chat/thinkingBlock.spec.tsx
@@ -1,0 +1,87 @@
+import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {ThinkingBlock} from '@sentry/scraps/chat';
+
+describe('ThinkingBlock', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  it('counts up until endTime is provided', () => {
+    const start = new Date('2025-01-01T00:00:00Z');
+    jest.setSystemTime(new Date('2025-01-01T00:00:05.300Z'));
+
+    const {rerender} = render(
+      <ThinkingBlock title="Analyzing..." startTime={start}>
+        <div>content</div>
+      </ThinkingBlock>
+    );
+
+    expect(screen.getByText('5.3s')).toBeInTheDocument();
+
+    act(() => jest.advanceTimersByTime(2000));
+    expect(screen.getByText('7.3s')).toBeInTheDocument();
+
+    const end = new Date('2025-01-01T00:00:10.000Z');
+    rerender(
+      <ThinkingBlock title="Analyzing..." startTime={start} endTime={end}>
+        <div>content</div>
+      </ThinkingBlock>
+    );
+
+    expect(screen.getByText('10.0s')).toBeInTheDocument();
+
+    act(() => jest.advanceTimersByTime(5000));
+    expect(screen.getByText('10.0s')).toBeInTheDocument();
+  });
+
+  it('is expanded by default and collapses when endTime arrives', async () => {
+    jest.useRealTimers();
+    const start = new Date();
+
+    const {rerender} = render(
+      <ThinkingBlock title="Thinking..." startTime={start}>
+        <div>inner content</div>
+      </ThinkingBlock>
+    );
+
+    expect(screen.getByText('inner content')).toBeVisible();
+
+    rerender(
+      <ThinkingBlock title="Thinking..." startTime={start} endTime={new Date()}>
+        <div>inner content</div>
+      </ThinkingBlock>
+    );
+
+    expect(screen.getByText('inner content')).not.toBeVisible();
+  });
+
+  it('can be manually toggled after collapsing', async () => {
+    jest.useRealTimers();
+    const start = new Date();
+    const end = new Date();
+
+    render(
+      <ThinkingBlock title="Done" startTime={start} endTime={end}>
+        <div>inner content</div>
+      </ThinkingBlock>
+    );
+
+    expect(screen.getByText('inner content')).not.toBeVisible();
+
+    await userEvent.click(screen.getByText('Done'));
+    expect(screen.getByText('inner content')).toBeVisible();
+  });
+
+  it('formats minutes for long durations', () => {
+    const start = new Date('2025-01-01T00:00:00Z');
+    const end = new Date('2025-01-01T00:01:30.000Z');
+
+    render(
+      <ThinkingBlock title="Done" startTime={start} endTime={end}>
+        <div>content</div>
+      </ThinkingBlock>
+    );
+
+    expect(screen.getByText('1.5min')).toBeInTheDocument();
+  });
+});

--- a/static/app/components/core/chat/thinkingBlock.tsx
+++ b/static/app/components/core/chat/thinkingBlock.tsx
@@ -38,19 +38,15 @@ interface ThinkingBlockProps {
 
 export function ThinkingBlock({title, startTime, endTime, children}: ThinkingBlockProps) {
   const elapsed = useElapsedTime(startTime, endTime);
-  const [isExpanded, setIsExpanded] = useState(!endTime);
   const isActive = !endTime;
+  const [userExpanded, setUserExpanded] = useState(false);
 
-  useEffect(() => {
-    if (!isActive) {
-      setIsExpanded(false);
-    }
-  }, [isActive]);
+  const isExpanded = isActive || userExpanded;
 
   return (
     <Disclosure
       expanded={isExpanded}
-      onExpandedChange={setIsExpanded}
+      onExpandedChange={setUserExpanded}
       size="sm"
       variant="outline"
       flex={1}

--- a/static/app/components/core/chat/thinkingBlock.tsx
+++ b/static/app/components/core/chat/thinkingBlock.tsx
@@ -1,6 +1,8 @@
-import {useEffect, useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
+import {Global} from '@emotion/react';
 
 import {Disclosure} from '@sentry/scraps/disclosure';
+import {streamingAnimationStyles, useTextDecodeAnimation} from '@sentry/scraps/markdown';
 import {Text} from '@sentry/scraps/text';
 
 import {IconSeer} from 'sentry/icons';
@@ -29,6 +31,39 @@ function useElapsedTime(
   return (endTime ?? now).getTime() - startTime.getTime();
 }
 
+/**
+ * A 1.5ch-wide, layout-stable ellipsis that cycles ".", "..", "..." to signal
+ * ongoing work. Width is fixed; the dots are absolutely positioned across it
+ * in even thirds so they fit the reserved space and never shift layout as the
+ * count changes. Decorative — hidden from AT.
+ */
+function AnimatedEllipsis({intervalMs = 400}: {intervalMs?: number}) {
+  const [count, setCount] = useState(1);
+
+  useEffect(() => {
+    const id = setInterval(() => setCount(c => (c % 3) + 1), intervalMs);
+    return () => clearInterval(id);
+  }, [intervalMs]);
+
+  return (
+    <span
+      aria-hidden
+      style={{
+        position: 'relative',
+        display: 'inline-block',
+        width: '1.5ch',
+        height: '1em',
+      }}
+    >
+      {Array.from({length: count}, (_, i) => (
+        <span key={i} style={{position: 'absolute', left: `${(i * 100) / 3}%`, top: 0}}>
+          .
+        </span>
+      ))}
+    </span>
+  );
+}
+
 interface ThinkingBlockProps {
   startTime: Date;
   title: string;
@@ -41,6 +76,12 @@ export function ThinkingBlock({title, startTime, endTime, children}: ThinkingBlo
   const isActive = !endTime;
   const [userExpanded, setUserExpanded] = useState(false);
 
+  const titleRef = useRef<HTMLSpanElement>(null);
+  // Strip trailing punctuation/whitespace so the animated ellipsis isn't
+  // doubled up when the title already ends in "." or "…".
+  const baseTitle = title.replace(/[.…\s]+$/u, '');
+  useTextDecodeAnimation(titleRef, baseTitle);
+
   const isExpanded = isActive || userExpanded;
 
   return (
@@ -51,6 +92,7 @@ export function ThinkingBlock({title, startTime, endTime, children}: ThinkingBlo
       variant="outline"
       flex={1}
     >
+      <Global styles={streamingAnimationStyles} />
       <Disclosure.Title
         leadingItems={<IconSeer size="xs" animation={isActive ? 'waiting' : undefined} />}
         trailingItems={
@@ -60,7 +102,10 @@ export function ThinkingBlock({title, startTime, endTime, children}: ThinkingBlo
         }
       >
         <Text size="sm" monospace variant="muted">
-          {title}
+          <span key={baseTitle} ref={titleRef}>
+            {baseTitle}
+          </span>
+          {isActive ? <AnimatedEllipsis /> : null}
         </Text>
       </Disclosure.Title>
       {children ? <Disclosure.Content>{children}</Disclosure.Content> : null}

--- a/static/app/components/core/chat/thinkingBlock.tsx
+++ b/static/app/components/core/chat/thinkingBlock.tsx
@@ -1,0 +1,70 @@
+import {useEffect, useState} from 'react';
+
+import {Disclosure} from '@sentry/scraps/disclosure';
+import {Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {IconSeer} from 'sentry/icons';
+import {getDuration} from 'sentry/utils/duration/getDuration';
+import {SECOND} from 'sentry/utils/formatters';
+
+/**
+ * Returns elapsed ms between `startTime` and `endTime`.
+ * While `endTime` is undefined, ticks every `intervalMs` to keep the value live.
+ */
+function useElapsedTime(
+  startTime: Date,
+  endTime: Date | undefined,
+  intervalMs = 100
+): number {
+  const [now, setNow] = useState(() => new Date());
+
+  useEffect(() => {
+    if (endTime) {
+      return;
+    }
+    const id = setInterval(() => setNow(new Date()), intervalMs);
+    return () => clearInterval(id);
+  }, [endTime, intervalMs]);
+
+  return (endTime ?? now).getTime() - startTime.getTime();
+}
+
+interface ThinkingBlockProps {
+  startTime: Date;
+  title: string;
+  children?: React.ReactNode;
+  endTime?: Date;
+}
+
+export function ThinkingBlock({title, startTime, endTime, children}: ThinkingBlockProps) {
+  const elapsed = useElapsedTime(startTime, endTime);
+  const [isExpanded, setIsExpanded] = useState(!endTime);
+  const isActive = !endTime;
+
+  useEffect(() => {
+    if (!isActive) {
+      setIsExpanded(false);
+    }
+  }, [isActive]);
+
+  return (
+    <Disclosure expanded={isExpanded} onExpandedChange={setIsExpanded} size="sm" flex={1}>
+      <Disclosure.Title
+        trailingItems={
+          <Text variant="secondary" size="sm" align="right" monospace>
+            {getDuration(elapsed / 1000, 1, true, false, false, SECOND)}
+          </Text>
+        }
+      >
+        <Flex align="center" gap="xs">
+          <IconSeer size="xs" animation={isActive ? 'waiting' : undefined} />
+          <Text size="sm" monospace variant="muted">
+            {title}
+          </Text>
+        </Flex>
+      </Disclosure.Title>
+      {children ? <Disclosure.Content>{children}</Disclosure.Content> : null}
+    </Disclosure>
+  );
+}

--- a/static/app/components/core/chat/thinkingBlock.tsx
+++ b/static/app/components/core/chat/thinkingBlock.tsx
@@ -1,7 +1,6 @@
 import {useEffect, useState} from 'react';
 
 import {Disclosure} from '@sentry/scraps/disclosure';
-import {Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {IconSeer} from 'sentry/icons';
@@ -49,20 +48,24 @@ export function ThinkingBlock({title, startTime, endTime, children}: ThinkingBlo
   }, [isActive]);
 
   return (
-    <Disclosure expanded={isExpanded} onExpandedChange={setIsExpanded} size="sm" flex={1}>
+    <Disclosure
+      expanded={isExpanded}
+      onExpandedChange={setIsExpanded}
+      size="sm"
+      variant="outline"
+      flex={1}
+    >
       <Disclosure.Title
+        leadingItems={<IconSeer size="xs" animation={isActive ? 'waiting' : undefined} />}
         trailingItems={
           <Text variant="secondary" size="sm" align="right" monospace>
             {getDuration(elapsed / 1000, 1, true, false, false, SECOND)}
           </Text>
         }
       >
-        <Flex align="center" gap="xs">
-          <IconSeer size="xs" animation={isActive ? 'waiting' : undefined} />
-          <Text size="sm" monospace variant="muted">
-            {title}
-          </Text>
-        </Flex>
+        <Text size="sm" monospace variant="muted">
+          {title}
+        </Text>
       </Disclosure.Title>
       {children ? <Disclosure.Content>{children}</Disclosure.Content> : null}
     </Disclosure>

--- a/static/app/components/core/disclosure/disclosure.mdx
+++ b/static/app/components/core/disclosure/disclosure.mdx
@@ -143,6 +143,44 @@ Note: The trailing items should be sized to match the disclosure size - this is 
 </Disclosure>
 ```
 
+### Leading Items
+
+Add a glyph or avatar before the title with `leadingItems`. When present, the
+chevron moves to sit after the title so the leading slot is the row's first
+element.
+
+<Storybook.Demo>
+  <Flex width="100%">
+    <Disclosure size="sm" defaultExpanded>
+      <Disclosure.Title leadingItems={<IconEdit size="xs" />}>
+        Title With A Leading Glyph
+      </Disclosure.Title>
+      <Disclosure.Content>This is the content of the disclosure</Disclosure.Content>
+    </Disclosure>
+  </Flex>
+</Storybook.Demo>
+
+### Outline Variant
+
+Set `variant="outline"` to render the content as a bordered, rounded card below
+the title instead of the default left-indented panel.
+
+<Storybook.Demo>
+  <Flex width="100%">
+    <Disclosure size="sm" variant="outline" defaultExpanded>
+      <Disclosure.Title>Outlined Disclosure</Disclosure.Title>
+      <Disclosure.Content>This content sits in a bordered card.</Disclosure.Content>
+    </Disclosure>
+  </Flex>
+</Storybook.Demo>
+
+```jsx
+<Disclosure size="sm" variant="outline" defaultExpanded>
+  <Disclosure.Title>Outlined Disclosure</Disclosure.Title>
+  <Disclosure.Content>This content sits in a bordered card.</Disclosure.Content>
+</Disclosure>
+```
+
 ### Remembering Expanded State
 
 The disclosure component provides a `onExpandedChange` prop that can be used to listen for changes to the expanded state - this allows you to store the state in a storage of your choice.

--- a/static/app/components/core/disclosure/disclosure.mdx
+++ b/static/app/components/core/disclosure/disclosure.mdx
@@ -33,7 +33,7 @@ The disclosure component supports a controlled and uncontrolled state via the `d
 
 <Storybook.Demo>
   <Flex width="100%">
-    <Disclosure>
+    <Disclosure flex={1}>
       <Disclosure.Title>This is a disclosure</Disclosure.Title>
       <Disclosure.Content>This is the content of the disclosure</Disclosure.Content>
     </Disclosure>
@@ -53,7 +53,7 @@ The disclosure can be uncontrolled by setting the `defaultExpanded` prop, or con
 
 <Storybook.Demo>
   <Flex width="100%">
-    <Disclosure defaultExpanded>
+    <Disclosure defaultExpanded flex={1}>
       <Disclosure.Title>This is a default expanded disclosure</Disclosure.Title>
       <Disclosure.Content>This is the content of the disclosure</Disclosure.Content>
     </Disclosure>
@@ -73,7 +73,7 @@ The disclosure can be sized by setting the `size` prop.
 
 <Storybook.Demo>
   <Flex width="100%">
-    <Stack direction="column" justify="center" gap="2xl">
+    <Stack direction="column" justify="center" gap="2xl" flex={1}>
       <Disclosure size="md" defaultExpanded>
         <Disclosure.Title>This is medium disclosure</Disclosure.Title>
         <Disclosure.Content>This is the content of the disclosure</Disclosure.Content>
@@ -113,7 +113,7 @@ Note: The trailing items should be sized to match the disclosure size - this is 
 
 <Storybook.Demo>
   <Flex width="100%">
-    <Disclosure size="sm" defaultExpanded>
+    <Disclosure size="sm" defaultExpanded flex={1}>
       <Disclosure.Title
         trailingItems={
           <Button size="xs" icon={<IconEdit />}>
@@ -151,7 +151,7 @@ element.
 
 <Storybook.Demo>
   <Flex width="100%">
-    <Disclosure size="sm" defaultExpanded>
+    <Disclosure size="sm" defaultExpanded flex={1}>
       <Disclosure.Title leadingItems={<IconEdit size="xs" />}>
         Title With A Leading Glyph
       </Disclosure.Title>
@@ -167,7 +167,7 @@ the title instead of the default left-indented panel.
 
 <Storybook.Demo>
   <Flex width="100%">
-    <Disclosure size="sm" variant="outline" defaultExpanded>
+    <Disclosure size="sm" variant="outline" defaultExpanded flex={1}>
       <Disclosure.Title>Outlined Disclosure</Disclosure.Title>
       <Disclosure.Content>This content sits in a bordered card.</Disclosure.Content>
     </Disclosure>
@@ -191,7 +191,7 @@ export function LocalStorageDisclosure() {
     const [expanded, setExpanded] = useLocalStorageState('my-disclosure-key', false);
 
     return (
-        <Disclosure expanded={expanded} onExpandedChange={setExpanded}>
+        <Disclosure expanded={expanded} onExpandedChange={setExpanded} flex={1}>
             <Disclosure.Title>The expanded state is saved to localStorage</Disclosure.Title>
             <Disclosure.Content>Reload the page to see the expanded state is remembered</Disclosure.Content>
         </Disclosure>
@@ -234,7 +234,7 @@ export function URLStateDisclosure() {
     const [expanded, setExpanded] = useQueryState('my-disclosure-key', parseAsBoolean.withDefault(false));
 
     return (
-        <Disclosure defaultExpanded={expanded} onExpandedChange={setExpanded}>
+        <Disclosure defaultExpanded={expanded} onExpandedChange={setExpanded} flex={1}>
             <Disclosure.Title>The expanded state is saved to URL state</Disclosure.Title>
             <Disclosure.Content>Reload the page to see the expanded state is remembered and new params are added to the URL</Disclosure.Content>
         </Disclosure>

--- a/static/app/components/core/disclosure/disclosure.spec.tsx
+++ b/static/app/components/core/disclosure/disclosure.spec.tsx
@@ -59,4 +59,31 @@ describe('Disclosure', () => {
     await userEvent.click(screen.getByRole('button', {name: 'This is a disclosure'}));
     expect(onExpandedChange).toHaveBeenCalledWith(false);
   });
+
+  it('renders leading items and still toggles', async () => {
+    render(
+      <Disclosure defaultExpanded>
+        <Disclosure.Title leadingItems={<span>glyph</span>}>Titled</Disclosure.Title>
+        <Disclosure.Content>Body</Disclosure.Content>
+      </Disclosure>
+    );
+
+    expect(screen.getByText('glyph')).toBeInTheDocument();
+    expect(screen.getByText('Body')).toBeVisible();
+    await userEvent.click(screen.getByRole('button', {name: 'Titled'}));
+    expect(screen.getByText('Body')).not.toBeVisible();
+  });
+
+  it('renders outline content and keeps it toggleable', async () => {
+    render(
+      <Disclosure variant="outline" defaultExpanded>
+        <Disclosure.Title>Titled</Disclosure.Title>
+        <Disclosure.Content>Outlined body</Disclosure.Content>
+      </Disclosure>
+    );
+
+    expect(screen.getByText('Outlined body')).toBeVisible();
+    await userEvent.click(screen.getByRole('button', {name: 'Titled'}));
+    expect(screen.getByText('Outlined body')).not.toBeVisible();
+  });
 });

--- a/static/app/components/core/disclosure/disclosure.tsx
+++ b/static/app/components/core/disclosure/disclosure.tsx
@@ -155,16 +155,14 @@ function Title({children, leadingItems, trailingItems, ...rest}: DisclosureTitle
   );
 }
 
-// The row owns the hover/press background so it spans the full title — behind
-// the leading and trailing items — rather than only the toggle button between
-// them.
+// The row owns the hover background so it spans the full title — behind the
+// leading and trailing items — rather than only the toggle button between them.
+// The press (:active) state deliberately stays on the button (below), so that
+// pressing a leading or trailing item does not bubble an active background onto
+// the whole row.
 const TitleRow = styled(Flex)`
   &:hover {
     background: ${p => p.theme.tokens.interactive.transparent.neutral.background.hover};
-  }
-
-  &:active {
-    background: ${p => p.theme.tokens.interactive.transparent.neutral.background.active};
   }
 `;
 
@@ -173,11 +171,16 @@ const StretchedButton = styled(Button)`
   justify-content: flex-start;
   padding-left: ${p => p.theme.space.xs};
 
-  /* The TitleRow provides the hover/press background; suppress the button's own
-   * so the two don't stack into a darker patch behind the label. */
-  &&:hover,
-  &&:active {
+  /* The TitleRow provides the full-width hover background; suppress the button's
+   * own hover so the two don't stack into a darker patch behind the label. Keep
+   * the press state on the button so it reflects the toggle specifically. */
+  &&:hover {
     background-color: transparent;
+  }
+
+  &&:active {
+    background-color: ${p =>
+      p.theme.tokens.interactive.transparent.neutral.background.active};
   }
 `;
 

--- a/static/app/components/core/disclosure/disclosure.tsx
+++ b/static/app/components/core/disclosure/disclosure.tsx
@@ -105,7 +105,7 @@ function Title({children, leadingItems, trailingItems, ...rest}: DisclosureTitle
   // the visual anchor and the toggle still reads label-then-affordance.
   if (leadingItems) {
     return (
-      <Flex
+      <TitleRow
         justify="start"
         gap={context.size}
         align="center"
@@ -127,12 +127,12 @@ function Title({children, leadingItems, trailingItems, ...rest}: DisclosureTitle
           </Flex>
         </StretchedButton>
         {trailingItems ?? null}
-      </Flex>
+      </TitleRow>
     );
   }
 
   return (
-    <Flex
+    <TitleRow
       justify="start"
       gap={context.size}
       align="center"
@@ -151,14 +151,34 @@ function Title({children, leadingItems, trailingItems, ...rest}: DisclosureTitle
         {children}
       </StretchedButton>
       {trailingItems ?? null}
-    </Flex>
+    </TitleRow>
   );
 }
+
+// The row owns the hover/press background so it spans the full title — behind
+// the leading and trailing items — rather than only the toggle button between
+// them.
+const TitleRow = styled(Flex)`
+  &:hover {
+    background: ${p => p.theme.tokens.interactive.transparent.neutral.background.hover};
+  }
+
+  &:active {
+    background: ${p => p.theme.tokens.interactive.transparent.neutral.background.active};
+  }
+`;
 
 const StretchedButton = styled(Button)`
   flex-grow: 1;
   justify-content: flex-start;
   padding-left: ${p => p.theme.space.xs};
+
+  /* The TitleRow provides the hover/press background; suppress the button's own
+   * so the two don't stack into a darker patch behind the label. */
+  &&:hover,
+  &&:active {
+    background-color: transparent;
+  }
 `;
 
 interface DisclosureContentProps extends React.HTMLAttributes<HTMLElement> {

--- a/static/app/components/core/disclosure/disclosure.tsx
+++ b/static/app/components/core/disclosure/disclosure.tsx
@@ -22,16 +22,24 @@ interface DisclosureProps
   expanded?: boolean;
   ref?: React.Ref<HTMLDivElement | null>;
   size?: 'xs' | 'sm' | 'md';
+  /**
+   * Visual treatment of the disclosure's content panel:
+   * - `default`: content is left-indented to align under the title.
+   * - `outline`: content is a bordered, rounded card sitting below the title.
+   */
+  variant?: 'default' | 'outline';
 }
 
-const DisclosureContext = createContext<
-  | (DisclosureAria & {
-      context: {size: NonNullable<DisclosureProps['size']>};
-      panelRef: React.RefObject<HTMLDivElement | null>;
-      state: DisclosureState;
-    })
-  | null
->(null);
+type DisclosureContextValue = DisclosureAria & {
+  context: {
+    size: NonNullable<DisclosureProps['size']>;
+    variant: NonNullable<DisclosureProps['variant']>;
+  };
+  panelRef: React.RefObject<HTMLDivElement | null>;
+  state: DisclosureState;
+};
+
+const DisclosureContext = createContext<DisclosureContextValue | null>(null);
 
 function useDisclosureContext() {
   const context = useContext(DisclosureContext);
@@ -44,6 +52,7 @@ function useDisclosureContext() {
 function DisclosureComponent({
   children,
   size = 'md',
+  variant = 'default',
   ref,
   onExpandedChange,
   ...props
@@ -64,7 +73,7 @@ function DisclosureComponent({
 
   return (
     <DisclosureContext.Provider
-      value={{buttonProps, panelProps, panelRef, state, context: {size}}}
+      value={{buttonProps, panelProps, panelRef, state, context: {size, variant}}}
     >
       <Stack data-disclosure align="start" ref={ref} {...props}>
         {children}
@@ -75,14 +84,52 @@ function DisclosureComponent({
 
 interface DisclosureTitleProps extends React.HTMLAttributes<HTMLButtonElement> {
   children?: NonNullable<React.ReactNode>;
+  /**
+   * Content rendered before the toggle (e.g. an avatar or brand mark). When
+   * provided, the chevron moves to sit after the title so the leading slot reads
+   * as the row's first element.
+   */
+  leadingItems?: React.ReactNode;
   trailingItems?: React.ReactNode;
 }
 
-function Title({children, trailingItems, ...rest}: DisclosureTitleProps) {
+function Title({children, leadingItems, trailingItems, ...rest}: DisclosureTitleProps) {
   const {buttonProps, state, context} = useDisclosureContext();
 
   const {isDisabled, ...restProps} = buttonProps;
   const {pressProps} = usePress({...restProps});
+
+  const chevron = <IconChevron direction={state.isExpanded ? 'down' : 'right'} />;
+
+  // With a leading slot the chevron trails the title, so the leading content is
+  // the visual anchor and the toggle still reads label-then-affordance.
+  if (leadingItems) {
+    return (
+      <Flex
+        justify="start"
+        gap={context.size}
+        align="center"
+        width="100%"
+        paddingRight="xs"
+        radius="md"
+      >
+        {leadingItems}
+        <StretchedButton
+          disabled={isDisabled}
+          size={context.size}
+          variant="transparent"
+          {...pressProps}
+          {...rest}
+        >
+          <Flex align="center" gap="xs">
+            {children}
+            {chevron}
+          </Flex>
+        </StretchedButton>
+        {trailingItems ?? null}
+      </Flex>
+    );
+  }
 
   return (
     <Flex
@@ -94,7 +141,7 @@ function Title({children, trailingItems, ...rest}: DisclosureTitleProps) {
       radius="md"
     >
       <StretchedButton
-        icon={<IconChevron direction={state.isExpanded ? 'down' : 'right'} />}
+        icon={chevron}
         disabled={isDisabled}
         size={context.size}
         variant="transparent"
@@ -118,8 +165,27 @@ interface DisclosureContentProps extends React.HTMLAttributes<HTMLElement> {
   children: React.ReactNode;
 }
 
+const OUTLINE_PADDING = {xs: 'sm', sm: 'md', md: 'lg'} as const;
+const OUTLINE_RADIUS = {xs: 'md', sm: 'lg', md: 'xl'} as const;
+
 function Content({children, ...props}: DisclosureContentProps) {
   const {panelProps, panelRef, context} = useDisclosureContext();
+
+  if (context.variant === 'outline') {
+    return (
+      <Container
+        ref={panelRef}
+        {...panelProps}
+        border="primary"
+        radius={OUTLINE_RADIUS[context.size]}
+        padding={OUTLINE_PADDING[context.size]}
+        width="100%"
+        {...props}
+      >
+        {children}
+      </Container>
+    );
+  }
 
   return (
     <AlignedContainer

--- a/static/app/components/core/disclosure/disclosure.tsx
+++ b/static/app/components/core/disclosure/disclosure.tsx
@@ -103,34 +103,6 @@ function Title({children, leadingItems, trailingItems, ...rest}: DisclosureTitle
 
   // With a leading slot the chevron trails the title, so the leading content is
   // the visual anchor and the toggle still reads label-then-affordance.
-  if (leadingItems) {
-    return (
-      <TitleRow
-        justify="start"
-        gap={context.size}
-        align="center"
-        width="100%"
-        paddingRight="xs"
-        radius="md"
-      >
-        {leadingItems}
-        <StretchedButton
-          disabled={isDisabled}
-          size={context.size}
-          variant="transparent"
-          {...pressProps}
-          {...rest}
-        >
-          <Flex align="center" gap="xs">
-            {children}
-            {chevron}
-          </Flex>
-        </StretchedButton>
-        {trailingItems ?? null}
-      </TitleRow>
-    );
-  }
-
   return (
     <TitleRow
       justify="start"
@@ -140,17 +112,25 @@ function Title({children, leadingItems, trailingItems, ...rest}: DisclosureTitle
       paddingRight="xs"
       radius="md"
     >
+      {leadingItems}
       <StretchedButton
-        icon={chevron}
+        icon={leadingItems ? undefined : chevron}
         disabled={isDisabled}
         size={context.size}
         variant="transparent"
         {...pressProps}
         {...rest}
       >
-        {children}
+        {leadingItems ? (
+          <Flex align="center" gap="xs">
+            {children}
+            {chevron}
+          </Flex>
+        ) : (
+          children
+        )}
       </StretchedButton>
-      {trailingItems ?? null}
+      {trailingItems}
     </TitleRow>
   );
 }

--- a/static/app/components/core/disclosure/disclosure.tsx
+++ b/static/app/components/core/disclosure/disclosure.tsx
@@ -9,15 +9,13 @@ import {usePress} from '@react-aria/interactions';
 import {useDisclosureState, type DisclosureState} from '@react-stately/disclosure';
 
 import {Button} from '@sentry/scraps/button';
-import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {Container, Flex, Stack, type StackProps} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {IconChevron} from 'sentry/icons';
 
 interface DisclosureProps
-  extends
-    Omit<AriaDisclosureProps, 'isDisabled' | 'isExpanded'>,
-    React.HTMLAttributes<HTMLDivElement> {
+  extends Omit<AriaDisclosureProps, 'isDisabled' | 'isExpanded'>, Omit<StackProps, 'as'> {
   children: NonNullable<React.ReactNode>;
   as?: 'section' | 'div';
   disabled?: boolean;

--- a/static/app/components/core/markdown/index.tsx
+++ b/static/app/components/core/markdown/index.tsx
@@ -1,1 +1,2 @@
 export {Markdown, type MarkdownProps} from './markdown';
+export {streamingAnimationStyles, useTextDecodeAnimation} from './useStreamingAnimation';

--- a/static/app/components/core/markdown/useStreamingAnimation.ts
+++ b/static/app/components/core/markdown/useStreamingAnimation.ts
@@ -1,4 +1,4 @@
-import {useEffect} from 'react';
+import {useEffect, useLayoutEffect, useRef} from 'react';
 import type {RefObject} from 'react';
 import {css, keyframes} from '@emotion/react';
 import {useReducedMotion} from 'framer-motion';
@@ -90,6 +90,45 @@ export function useStreamingAnimation(
       activeAnimations = [];
     };
   }, [containerRef, enabled, prefersReducedMotion]);
+}
+
+/**
+ * Runs the glyph-decode reveal on a single element whenever `key` changes.
+ *
+ * Unlike `useStreamingAnimation` (which observes a container of streaming
+ * block children), this targets one element whose text is swapped wholesale —
+ * e.g. a status/title label that updates in place.
+ *
+ * The caller MUST key the target element by the same value passed as `key`
+ * (e.g. `<span key={title} ref={ref}>{title}</span>`). `animateElement`
+ * replaces the element's text node with per-glyph spans, so React must remount
+ * the element on change rather than patch the now-mutated text node.
+ *
+ * The initial mount is skipped so the effect only fires on subsequent changes.
+ * Requires `streamingAnimationStyles` to be present in the tree.
+ */
+export function useTextDecodeAnimation(
+  ref: RefObject<HTMLElement | null>,
+  key: unknown
+): void {
+  const prefersReducedMotion = useReducedMotion();
+  const isInitial = useRef(true);
+
+  useLayoutEffect(() => {
+    if (isInitial.current) {
+      isInitial.current = false;
+      return;
+    }
+    if (prefersReducedMotion) {
+      return;
+    }
+    const element = ref.current;
+    if (!element) {
+      return;
+    }
+    const animation = animateElement(element);
+    return () => animation.destroy();
+  }, [ref, key, prefersReducedMotion]);
 }
 
 const STAGGER_MS = 8;


### PR DESCRIPTION
## Summary
Adds a `ThinkingBlock` for rendering an agent's "thinking": a collapsible header with the animated Seer glyph, a live-counting elapsed timer, and a bordered body of streamed content.

To support the design cleanly, `Disclosure` gains:
- `variant="outline"` — renders the content panel as a bordered, rounded card.
- `leadingItems` on `Disclosure.Title` — a slot before the toggle (repositions the chevron after the title).
- widened prop types (accepts `StackProps` like `flex`).

## Stack
Bottom of a 3-PR stack:
1. **this PR** → `master`
2. `nm/seer/tool-call` → this branch (ToolCall + QueryTokens)
3. `nm/seer/tool-embed` → tool-call (`{% tool %}` embed)

## Test plan
- `disclosure.spec.tsx` (outline + leadingItems), `thinkingBlock.spec.tsx` — green.
- Stories: `disclosure.mdx`, `thinkingBlock.mdx`.