### PR TITLE
feat(seer): add ToolCall chat component

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -21,6 +21,7 @@ const productionEntryPoints = [
   'static/app/components/core/revealOnHover/*.tsx',
   // TODO: Remove when wired into Seer Explorer
   'static/app/components/core/chat/thinkingBlock.tsx',
+  'static/app/components/core/chat/toolCall.tsx',
   // todo we currently keep all icons
   'static/app/icons/**/*.{js,ts,tsx}',
   // todo find out how chartcuterie works

--- a/static/app/components/core/chat/index.tsx
+++ b/static/app/components/core/chat/index.tsx
@@ -2,6 +2,7 @@ export {AssistantMessage} from './assistantMessage';
 export {AssistantActions} from './assistantActions';
 export {UserMessage} from './userMessage';
 export {ToolCallIndicator, type ToolCallStatus} from './toolCallIndicator';
+/** @public */
 export {ToolCall, type ToolCallReference} from './toolCall';
 export {Spinner} from './spinner';
 export {MessageRow} from './messageRow';

--- a/static/app/components/core/chat/index.tsx
+++ b/static/app/components/core/chat/index.tsx
@@ -2,6 +2,7 @@ export {AssistantMessage} from './assistantMessage';
 export {AssistantActions} from './assistantActions';
 export {UserMessage} from './userMessage';
 export {ToolCallIndicator, type ToolCallStatus} from './toolCallIndicator';
+export {ToolCall, type ToolCallReference} from './toolCall';
 export {Spinner} from './spinner';
 export {MessageRow} from './messageRow';
 /** @public */

--- a/static/app/components/core/chat/toolCall.mdx
+++ b/static/app/components/core/chat/toolCall.mdx
@@ -1,0 +1,97 @@
+---
+title: ToolCall
+description: A single agent tool call — a quiet read or an expanded query.
+category: chat
+source: '@sentry/scraps/chat'
+resources:
+  js: https://github.com/getsentry/sentry/blob/master/static/app/components/core/chat/toolCall.tsx
+---
+
+import {ToolCall} from '@sentry/scraps/chat';
+import {Container} from '@sentry/scraps/layout';
+
+import * as Storybook from 'sentry/stories';
+
+export const documentation = import('!!type-loader!@sentry/scraps/chat/toolCall');
+
+The `ToolCall` renders a single step an agent took, within a `ThinkingBlock`. A
+leading glyph communicates lifecycle `status` (a spinner while running, a
+semantic icon once settled — see `ToolCallIndicator`).
+
+## Anatomy
+
+A tool call collapses to a single title line, with an optional trailing
+`reference` chip pointing at the entity the call acted on.
+
+<Storybook.Demo align="stretch">
+  <Container width="100%" background="secondary" radius="md" padding="lg">
+    <ToolCall
+      title="Read trace waterfall"
+      status="success"
+      reference={{label: 'Trace', value: 'a3805648'}}
+    />
+    <ToolCall
+      title="Read trace with span details"
+      status="success"
+      reference={{label: 'Span', value: 'a469c305'}}
+    />
+  </Container>
+</Storybook.Demo>
+
+```jsx
+<ToolCall
+  title="Read trace waterfall"
+  status="success"
+  reference={{label: 'Trace', value: 'a3805648'}}
+/>
+```
+
+## Output
+
+When a call produces a primary result, pass `output` to surface it as a chip
+under an `Output:` label.
+
+<Storybook.Demo align="stretch">
+  <Container width="100%" background="secondary" radius="md" padding="lg">
+    <ToolCall
+      title="Query spans"
+      status="success"
+      output={{label: 'Trace', value: 'a3805648'}}
+    />
+  </Container>
+</Storybook.Demo>
+
+```jsx
+<ToolCall
+  title="Query spans"
+  status="success"
+  output={{label: 'Trace', value: 'a3805648'}}
+/>
+```
+
+## Status
+
+The leading glyph reflects the call's lifecycle.
+
+<Storybook.Demo align="stretch">
+  <Container width="100%" background="secondary" radius="md" padding="lg">
+    <ToolCall title="Running query" status="loading" />
+    <ToolCall title="Awaiting approval" status="pending" />
+    <ToolCall title="Query succeeded" status="success" />
+    <ToolCall title="Query failed" status="failure" />
+  </Container>
+</Storybook.Demo>
+
+## Notifications
+
+Pass `notifications` to surface short status lines beneath a call.
+
+<Storybook.Demo align="stretch">
+  <Container width="100%" background="secondary" radius="md" padding="lg">
+    <ToolCall
+      title="Query spans"
+      status="success"
+      notifications={['Truncated to 100 rows']}
+    />
+  </Container>
+</Storybook.Demo>

--- a/static/app/components/core/chat/toolCall.mdx
+++ b/static/app/components/core/chat/toolCall.mdx
@@ -9,6 +9,7 @@ resources:
 
 import {ToolCall} from '@sentry/scraps/chat';
 import {Container} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
 
 import * as Storybook from 'sentry/stories';
 
@@ -93,5 +94,45 @@ Pass `notifications` to surface short status lines beneath a call.
       status="success"
       notifications={['Truncated to 100 rows']}
     />
+  </Container>
+</Storybook.Demo>
+
+## Links
+
+Give a `reference` or `output` chip a `to` to render it as a real link (an
+anchor supporting middle/cmd-click and keyboard access) rather than an
+`onClick` button.
+
+<Storybook.Demo align="stretch">
+  <Container width="100%" background="secondary" radius="md" padding="lg">
+    <ToolCall
+      title="Read trace waterfall"
+      status="success"
+      reference={{label: 'Trace', value: 'a3805648', to: '/traces/a3805648/'}}
+    />
+  </Container>
+</Storybook.Demo>
+
+```jsx
+<ToolCall
+  title="Read trace waterfall"
+  status="success"
+  reference={{label: 'Trace', value: 'a3805648', to: '/traces/a3805648/'}}
+/>
+```
+
+## Detail
+
+Pass `children` to render supplementary detail beneath the call — for example an
+expandable request/response. It aligns under the title rather than the status
+glyph.
+
+<Storybook.Demo align="stretch">
+  <Container width="100%" background="secondary" radius="md" padding="lg">
+    <ToolCall title="Query spans" status="success">
+      <Text size="xs" variant="muted" monospace>
+        GET /api/0/organizations/sentry/traces/
+      </Text>
+    </ToolCall>
   </Container>
 </Storybook.Demo>

--- a/static/app/components/core/chat/toolCall.mdx
+++ b/static/app/components/core/chat/toolCall.mdx
@@ -85,6 +85,13 @@ The leading glyph reflects the call's lifecycle.
   </Container>
 </Storybook.Demo>
 
+```jsx
+<ToolCall title="Running query" status="loading" />
+<ToolCall title="Awaiting approval" status="pending" />
+<ToolCall title="Query succeeded" status="success" />
+<ToolCall title="Query failed" status="failure" />
+```
+
 ## Notifications
 
 Pass `notifications` to surface short status lines beneath a call.
@@ -98,6 +105,14 @@ Pass `notifications` to surface short status lines beneath a call.
     />
   </Container>
 </Storybook.Demo>
+
+```jsx
+<ToolCall
+  title="Query spans"
+  status="success"
+  notifications={['Truncated to 100 rows']}
+/>
+```
 
 ## Links
 

--- a/static/app/components/core/chat/toolCall.mdx
+++ b/static/app/components/core/chat/toolCall.mdx
@@ -16,10 +16,11 @@ import * as Storybook from 'sentry/stories';
 export const documentation = import('!!type-loader!@sentry/scraps/chat/toolCall');
 
 The `ToolCall` renders a single step an agent took, within a `ThinkingBlock`.
-Like `ThinkingBlock`, it is an outline `Disclosure`: a leading glyph communicates
-lifecycle `status` (a spinner while running, a semantic icon once settled — see
-`ToolCallIndicator`), the `title` is the toggle, and any `children` expand into
-the panel below.
+Like `ThinkingBlock`, it is built on an outline `Disclosure`: a leading glyph
+communicates lifecycle `status` (a spinner while running, a semantic icon once
+settled — see `ToolCallIndicator`), and the `title` is the toggle. A call only
+renders as an actual (toggleable) `Disclosure` when it has `children` to reveal
+— see [Detail](#detail); otherwise it's a plain row with no toggle affordance.
 
 ## Anatomy
 
@@ -32,11 +33,6 @@ A tool call collapses to a single title line, with an optional trailing
       title="Read trace waterfall"
       status="success"
       reference={{label: 'Trace', value: 'a3805648'}}
-    />
-    <ToolCall
-      title="Read trace with span details"
-      status="success"
-      reference={{label: 'Span', value: 'a469c305'}}
     />
   </Container>
 </Storybook.Demo>

--- a/static/app/components/core/chat/toolCall.mdx
+++ b/static/app/components/core/chat/toolCall.mdx
@@ -15,9 +15,11 @@ import * as Storybook from 'sentry/stories';
 
 export const documentation = import('!!type-loader!@sentry/scraps/chat/toolCall');
 
-The `ToolCall` renders a single step an agent took, within a `ThinkingBlock`. A
-leading glyph communicates lifecycle `status` (a spinner while running, a
-semantic icon once settled — see `ToolCallIndicator`).
+The `ToolCall` renders a single step an agent took, within a `ThinkingBlock`.
+Like `ThinkingBlock`, it is an outline `Disclosure`: a leading glyph communicates
+lifecycle `status` (a spinner while running, a semantic icon once settled — see
+`ToolCallIndicator`), the `title` is the toggle, and any `children` expand into
+the panel below.
 
 ## Anatomy
 
@@ -123,9 +125,9 @@ anchor supporting middle/cmd-click and keyboard access) rather than an
 
 ## Detail
 
-Pass `children` to render supplementary detail beneath the call — for example an
-expandable request/response. It aligns under the title rather than the status
-glyph.
+Pass `children` to tuck supplementary detail beneath the call — for example an
+expandable request/response. It lives in the collapsible panel, revealed by
+toggling the title.
 
 <Storybook.Demo align="stretch">
   <Container width="100%" background="secondary" radius="md" padding="lg">

--- a/static/app/components/core/chat/toolCall.spec.tsx
+++ b/static/app/components/core/chat/toolCall.spec.tsx
@@ -52,4 +52,29 @@ describe('ToolCall', () => {
     );
     expect(screen.getByText('Truncated to 100 rows')).toBeInTheDocument();
   });
+
+  it('renders a reference with a `to` as a real link', () => {
+    render(
+      <ToolCall
+        title="Read trace waterfall"
+        status="success"
+        reference={{label: 'Trace', value: 'a3805648', to: '/traces/a3805648/'}}
+      />
+    );
+
+    // LinkButton renders an anchor (href, middle/cmd-click) with role="button".
+    expect(screen.getByRole('button', {name: /a3805648/})).toHaveAttribute(
+      'href',
+      '/traces/a3805648/'
+    );
+  });
+
+  it('renders supplementary detail passed as children', () => {
+    render(
+      <ToolCall title="Query spans" status="success">
+        <div>GET /api/0/traces/a3805648/</div>
+      </ToolCall>
+    );
+    expect(screen.getByText('GET /api/0/traces/a3805648/')).toBeInTheDocument();
+  });
 });

--- a/static/app/components/core/chat/toolCall.spec.tsx
+++ b/static/app/components/core/chat/toolCall.spec.tsx
@@ -1,0 +1,55 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {ToolCall} from '@sentry/scraps/chat';
+
+describe('ToolCall', () => {
+  it('renders a title plus a trailing reference, no output', () => {
+    render(
+      <ToolCall
+        title="Read trace waterfall"
+        status="success"
+        reference={{label: 'Trace', value: 'a3805648'}}
+      />
+    );
+
+    expect(screen.getByText('Read trace waterfall')).toBeInTheDocument();
+    expect(screen.getByText('a3805648')).toBeInTheDocument();
+    expect(screen.queryByText('Output:')).not.toBeInTheDocument();
+  });
+
+  it('renders an output chip when output is provided', () => {
+    render(
+      <ToolCall
+        title="Query spans"
+        status="success"
+        output={{label: 'Trace', value: 'a3805648'}}
+      />
+    );
+
+    expect(screen.getByText('Query spans')).toBeInTheDocument();
+    expect(screen.getByText('Output:')).toBeInTheDocument();
+    expect(screen.getByText('a3805648')).toBeInTheDocument();
+  });
+
+  it('communicates status via the leading glyph', () => {
+    const {rerender} = render(<ToolCall title="Query" status="success" />);
+    expect(screen.getByLabelText('Succeeded')).toBeInTheDocument();
+
+    rerender(<ToolCall title="Query" status="failure" />);
+    expect(screen.getByLabelText('Failed')).toBeInTheDocument();
+
+    rerender(<ToolCall title="Query" status="loading" />);
+    expect(screen.getByLabelText('Running')).toBeInTheDocument();
+  });
+
+  it('surfaces notifications', () => {
+    render(
+      <ToolCall
+        title="Query spans"
+        status="success"
+        notifications={['Truncated to 100 rows']}
+      />
+    );
+    expect(screen.getByText('Truncated to 100 rows')).toBeInTheDocument();
+  });
+});

--- a/static/app/components/core/chat/toolCall.spec.tsx
+++ b/static/app/components/core/chat/toolCall.spec.tsx
@@ -1,4 +1,4 @@
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {ToolCall} from '@sentry/scraps/chat';
 
@@ -69,12 +69,19 @@ describe('ToolCall', () => {
     );
   });
 
-  it('renders supplementary detail passed as children', () => {
+  it('reveals supplementary detail children when expanded', async () => {
     render(
       <ToolCall title="Query spans" status="success">
         <div>GET /api/0/traces/a3805648/</div>
       </ToolCall>
     );
-    expect(screen.getByText('GET /api/0/traces/a3805648/')).toBeInTheDocument();
+
+    // Detail lives in the collapsible panel, so it is hidden until the title is toggled.
+    const detail = screen.getByText('GET /api/0/traces/a3805648/');
+    expect(detail).not.toBeVisible();
+
+    await userEvent.click(screen.getByRole('button', {name: /Query spans/}));
+
+    expect(detail).toBeVisible();
   });
 });

--- a/static/app/components/core/chat/toolCall.tsx
+++ b/static/app/components/core/chat/toolCall.tsx
@@ -1,0 +1,159 @@
+import type {ReactNode} from 'react';
+
+import {Button} from '@sentry/scraps/button';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {IconSpan} from 'sentry/icons';
+import {t} from 'sentry/locale';
+
+import {ToolCallIndicator, type ToolCallStatus} from './toolCallIndicator';
+
+/**
+ * A compact chip referencing an entity a tool call produced or acted on (e.g.
+ * `Trace: a3805648`). Rendered as a small button so it can optionally link to
+ * the referenced resource.
+ */
+export interface ToolCallReference {
+  /**
+   * The referenced identifier, emphasized in the chip (e.g. a trace or span id).
+   */
+  value: string;
+  /**
+   * Leading glyph. Defaults to `IconSpan`.
+   */
+  icon?: ReactNode;
+  /**
+   * A short type label shown before the value (e.g. `Trace`, `Span`).
+   */
+  label?: string;
+  /**
+   * Fires when the chip is activated. When omitted the chip is still rendered
+   * but non-interactive.
+   */
+  onClick?: () => void;
+}
+
+interface ToolCallProps {
+  /**
+   * Lifecycle status. Drives the leading glyph (spinner while running, semantic
+   * icon once settled) via `ToolCallIndicator`.
+   */
+  status: ToolCallStatus;
+  /**
+   * The tool call's headline (e.g. `Query spans`, `Read trace waterfall`).
+   */
+  title: string;
+  /**
+   * Short status lines surfaced beneath the call (e.g. "Truncated to 100 rows").
+   */
+  notifications?: string[];
+  /**
+   * The primary result of the call, rendered as a chip under an `Output:` label.
+   */
+  output?: ToolCallReference;
+  /**
+   * A trailing chip shown inline with the title. Typically the entity the call
+   * acted on.
+   */
+  reference?: ToolCallReference;
+}
+
+function ReferenceChip({reference}: {reference: ToolCallReference}) {
+  const {label, value, icon, onClick} = reference;
+  return (
+    <Button
+      size="xs"
+      icon={icon ?? <IconSpan size="xs" />}
+      onClick={onClick}
+      aria-disabled={onClick ? undefined : true}
+    >
+      {label ? (
+        <Text size="sm">
+          {`${label}: `}
+          <Text size="sm" bold>
+            {value}
+          </Text>
+        </Text>
+      ) : (
+        <Text size="sm" bold>
+          {value}
+        </Text>
+      )}
+    </Button>
+  );
+}
+
+function SecondaryBox({children}: {children: ReactNode}) {
+  return (
+    <Container background="secondary" radius="md" padding="sm" width="100%">
+      {children}
+    </Container>
+  );
+}
+
+function getStatusLabel(status: ToolCallStatus): string | undefined {
+  switch (status) {
+    case 'loading':
+      return t('Running');
+    case 'pending':
+      return t('Waiting');
+    case 'success':
+      return t('Succeeded');
+    case 'failure':
+      return t('Failed');
+    case 'mixed':
+      return t('Partially succeeded');
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * A single agent tool call within a `ThinkingBlock`.
+ *
+ * Renders as a title line (with an optional trailing `reference` chip) preceded
+ * by a leading glyph that communicates lifecycle status; see
+ * `ToolCallIndicator`. When the call produces a primary result, pass `output` to
+ * surface it as a chip under an `Output:` label.
+ */
+export function ToolCall({
+  title,
+  status,
+  output,
+  reference,
+  notifications,
+}: ToolCallProps) {
+  return (
+    <Flex gap="md" align="start" width="100%">
+      <Container paddingTop="sm">
+        <ToolCallIndicator status={status} aria-label={getStatusLabel(status)} />
+      </Container>
+      <Stack gap="xs" flex={1} minWidth={0}>
+        <Flex align="center" justify="between" gap="md" minHeight="24px">
+          <Text size="sm" variant="secondary" monospace>
+            {title}
+          </Text>
+          {reference ? <ReferenceChip reference={reference} /> : null}
+        </Flex>
+
+        {output ? (
+          <SecondaryBox>
+            <Flex align="center" gap="sm" wrap="wrap">
+              <Text size="sm" variant="secondary" monospace bold>
+                {t('Output:')}
+              </Text>
+              <ReferenceChip reference={output} />
+            </Flex>
+          </SecondaryBox>
+        ) : null}
+
+        {notifications?.map((note, i) => (
+          <Text key={i} size="sm" variant="muted">
+            {note}
+          </Text>
+        ))}
+      </Stack>
+    </Flex>
+  );
+}

--- a/static/app/components/core/chat/toolCall.tsx
+++ b/static/app/components/core/chat/toolCall.tsx
@@ -1,9 +1,9 @@
-import type {MouseEvent, ReactNode} from 'react';
+import {Fragment, type MouseEvent, type ReactNode} from 'react';
 import type {LocationDescriptor} from 'history';
 
 import {Button, LinkButton} from '@sentry/scraps/button';
 import {Disclosure} from '@sentry/scraps/disclosure';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 import {useTranslation} from '@sentry/scraps/translationContext';
 
@@ -56,7 +56,9 @@ interface ToolCallProps {
   /**
    * Supplementary detail rendered beneath the title and output — e.g. an
    * expandable request/response for the call. Kept in the title's column so it
-   * aligns under the headline rather than the status glyph.
+   * aligns under the headline rather than the status glyph. When omitted, the
+   * call renders as a plain row with no toggle affordance, since there is
+   * nothing to disclose.
    */
   children?: ReactNode;
   /**
@@ -151,7 +153,9 @@ function getStatusLabel(
  * (`ToolCallIndicator`) is the leading item, the `title` is the toggle, and an
  * optional `reference` chip trails it. `output` and `notifications` sit under the
  * title and stay visible; pass `children` to tuck supplementary detail (e.g. the
- * request/response) into the collapsible panel.
+ * request/response) into the collapsible panel. Without `children` there is
+ * nothing to disclose, so the call renders as a plain (non-toggleable) row
+ * instead of promising an expand affordance that has no content behind it.
  */
 export function ToolCall({
   title,
@@ -163,19 +167,18 @@ export function ToolCall({
 }: ToolCallProps) {
   const {t} = useTranslation();
 
-  return (
-    <Disclosure variant="outline" size="sm" gap="xs" flex={1}>
-      <Disclosure.Title
-        leadingItems={
-          <ToolCallIndicator status={status} aria-label={getStatusLabel(status, t)} />
-        }
-        trailingItems={reference ? <ReferenceChip reference={reference} /> : undefined}
-      >
-        <Text size="sm" variant="secondary" monospace>
-          {title}
-        </Text>
-      </Disclosure.Title>
+  const indicator = (
+    <ToolCallIndicator status={status} aria-label={getStatusLabel(status, t)} />
+  );
+  const titleText = (
+    <Text size="sm" variant="secondary" monospace>
+      {title}
+    </Text>
+  );
+  const referenceChip = reference ? <ReferenceChip reference={reference} /> : null;
 
+  const details = (
+    <Fragment>
       {output ? (
         <SecondaryBox>
           <Flex align="center" gap="sm" wrap="wrap">
@@ -192,8 +195,34 @@ export function ToolCall({
           {note}
         </Text>
       ))}
+    </Fragment>
+  );
 
-      {children ? <Disclosure.Content>{children}</Disclosure.Content> : null}
+  if (!children) {
+    return (
+      <Stack gap="xs" flex={1}>
+        <Flex align="center" gap="sm" width="100%">
+          {indicator}
+          <Flex flexGrow={1}>{titleText}</Flex>
+          {referenceChip}
+        </Flex>
+        {details}
+      </Stack>
+    );
+  }
+
+  return (
+    <Disclosure variant="outline" size="sm" gap="xs" flex={1}>
+      <Disclosure.Title
+        leadingItems={indicator}
+        trailingItems={referenceChip ?? undefined}
+      >
+        {titleText}
+      </Disclosure.Title>
+
+      {details}
+
+      <Disclosure.Content>{children}</Disclosure.Content>
     </Disclosure>
   );
 }

--- a/static/app/components/core/chat/toolCall.tsx
+++ b/static/app/components/core/chat/toolCall.tsx
@@ -1,6 +1,7 @@
-import type {ReactNode} from 'react';
+import type {MouseEvent, ReactNode} from 'react';
+import type {LocationDescriptor} from 'history';
 
-import {Button} from '@sentry/scraps/button';
+import {Button, LinkButton} from '@sentry/scraps/button';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
@@ -12,8 +13,8 @@ import {ToolCallIndicator, type ToolCallStatus} from './toolCallIndicator';
 
 /**
  * A compact chip referencing an entity a tool call produced or acted on (e.g.
- * `Trace: a3805648`). Rendered as a small button so it can optionally link to
- * the referenced resource.
+ * `Trace: a3805648`). Renders as a real link when given `to`, an interactive
+ * button when given `onClick`, or a non-interactive display chip otherwise.
  */
 export interface ToolCallReference {
   /**
@@ -29,10 +30,16 @@ export interface ToolCallReference {
    */
   label?: string;
   /**
-   * Fires when the chip is activated. When omitted the chip is still rendered
-   * but non-interactive.
+   * Fires when the chip is activated. When omitted (and no `to` is set) the chip
+   * is still rendered but non-interactive. Receives the event so callers can stop
+   * propagation or record analytics; pair it with `to` to track a navigation.
    */
-  onClick?: () => void;
+  onClick?: (event: MouseEvent<HTMLElement>) => void;
+  /**
+   * Navigation target. When set, the chip renders as a real link (anchor) so it
+   * supports middle/cmd-click and keyboard access, rather than an `onClick` button.
+   */
+  to?: LocationDescriptor;
 }
 
 interface ToolCallProps {
@@ -45,6 +52,12 @@ interface ToolCallProps {
    * The tool call's headline (e.g. `Query spans`, `Read trace waterfall`).
    */
   title: string;
+  /**
+   * Supplementary detail rendered beneath the title and output — e.g. an
+   * expandable request/response for the call. Kept in the title's column so it
+   * aligns under the headline rather than the status glyph.
+   */
+  children?: ReactNode;
   /**
    * Short status lines surfaced beneath the call (e.g. "Truncated to 100 rows").
    */
@@ -60,27 +73,39 @@ interface ToolCallProps {
   reference?: ToolCallReference;
 }
 
+function ChipContent({label, value}: {value: string; label?: string}) {
+  return label ? (
+    <Text size="sm">
+      {`${label}: `}
+      <Text size="sm" bold>
+        {value}
+      </Text>
+    </Text>
+  ) : (
+    <Text size="sm" bold>
+      {value}
+    </Text>
+  );
+}
+
 function ReferenceChip({reference}: {reference: ToolCallReference}) {
-  const {label, value, icon, onClick} = reference;
+  const {label, value, icon, onClick, to} = reference;
+  const chipIcon = icon ?? <IconSpan size="xs" />;
+  const content = <ChipContent label={label} value={value} />;
+
+  // A navigation target renders as a real anchor so middle/cmd-click and keyboard access work; an
+  // `onClick`-only chip stays a button; a chip with neither is a non-interactive display chip.
+  if (to) {
+    return (
+      <LinkButton size="xs" icon={chipIcon} to={to} onClick={onClick}>
+        {content}
+      </LinkButton>
+    );
+  }
+
   return (
-    <Button
-      size="xs"
-      icon={icon ?? <IconSpan size="xs" />}
-      onClick={onClick}
-      disabled={!onClick}
-    >
-      {label ? (
-        <Text size="sm">
-          {`${label}: `}
-          <Text size="sm" bold>
-            {value}
-          </Text>
-        </Text>
-      ) : (
-        <Text size="sm" bold>
-          {value}
-        </Text>
-      )}
+    <Button size="xs" icon={chipIcon} onClick={onClick} disabled={!onClick}>
+      {content}
     </Button>
   );
 }
@@ -126,6 +151,7 @@ export function ToolCall({
   output,
   reference,
   notifications,
+  children,
 }: ToolCallProps) {
   return (
     <Flex gap="md" align="start" width="100%">
@@ -156,6 +182,8 @@ export function ToolCall({
             {note}
           </Text>
         ))}
+
+        {children}
       </Stack>
     </Flex>
   );

--- a/static/app/components/core/chat/toolCall.tsx
+++ b/static/app/components/core/chat/toolCall.tsx
@@ -6,6 +6,7 @@ import {Text} from '@sentry/scraps/text';
 
 import {IconSpan} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {unreachable} from 'sentry/utils/unreachable';
 
 import {ToolCallIndicator, type ToolCallStatus} from './toolCallIndicator';
 
@@ -66,7 +67,7 @@ function ReferenceChip({reference}: {reference: ToolCallReference}) {
       size="xs"
       icon={icon ?? <IconSpan size="xs" />}
       onClick={onClick}
-      aria-disabled={onClick ? undefined : true}
+      disabled={!onClick}
     >
       {label ? (
         <Text size="sm">
@@ -104,8 +105,10 @@ function getStatusLabel(status: ToolCallStatus): string | undefined {
       return t('Failed');
     case 'mixed':
       return t('Partially succeeded');
-    default:
+    case 'content':
       return undefined;
+    default:
+      return unreachable(status);
   }
 }
 

--- a/static/app/components/core/chat/toolCall.tsx
+++ b/static/app/components/core/chat/toolCall.tsx
@@ -2,7 +2,8 @@ import type {MouseEvent, ReactNode} from 'react';
 import type {LocationDescriptor} from 'history';
 
 import {Button, LinkButton} from '@sentry/scraps/button';
-import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {Disclosure} from '@sentry/scraps/disclosure';
+import {Container, Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {IconSpan} from 'sentry/icons';
@@ -140,10 +141,11 @@ function getStatusLabel(status: ToolCallStatus): string | undefined {
 /**
  * A single agent tool call within a `ThinkingBlock`.
  *
- * Renders as a title line (with an optional trailing `reference` chip) preceded
- * by a leading glyph that communicates lifecycle status; see
- * `ToolCallIndicator`. When the call produces a primary result, pass `output` to
- * surface it as a chip under an `Output:` label.
+ * Built on the same outline `Disclosure` as `ThinkingBlock`: the lifecycle glyph
+ * (`ToolCallIndicator`) is the leading item, the `title` is the toggle, and an
+ * optional `reference` chip trails it. `output` and `notifications` sit under the
+ * title and stay visible; pass `children` to tuck supplementary detail (e.g. the
+ * request/response) into the collapsible panel.
  */
 export function ToolCall({
   title,
@@ -154,37 +156,36 @@ export function ToolCall({
   children,
 }: ToolCallProps) {
   return (
-    <Flex gap="md" align="start" width="100%">
-      <Container paddingTop="sm">
-        <ToolCallIndicator status={status} aria-label={getStatusLabel(status)} />
-      </Container>
-      <Stack gap="xs" flex={1} minWidth={0}>
-        <Flex align="center" justify="between" gap="md" minHeight="24px">
-          <Text size="sm" variant="secondary" monospace>
-            {title}
-          </Text>
-          {reference ? <ReferenceChip reference={reference} /> : null}
-        </Flex>
+    <Disclosure variant="outline" size="sm" gap="xs" flex={1}>
+      <Disclosure.Title
+        leadingItems={
+          <ToolCallIndicator status={status} aria-label={getStatusLabel(status)} />
+        }
+        trailingItems={reference ? <ReferenceChip reference={reference} /> : undefined}
+      >
+        <Text size="sm" variant="secondary" monospace>
+          {title}
+        </Text>
+      </Disclosure.Title>
 
-        {output ? (
-          <SecondaryBox>
-            <Flex align="center" gap="sm" wrap="wrap">
-              <Text size="sm" variant="secondary" monospace bold>
-                {t('Output:')}
-              </Text>
-              <ReferenceChip reference={output} />
-            </Flex>
-          </SecondaryBox>
-        ) : null}
+      {output ? (
+        <SecondaryBox>
+          <Flex align="center" gap="sm" wrap="wrap">
+            <Text size="sm" variant="secondary" monospace bold>
+              {t('Output:')}
+            </Text>
+            <ReferenceChip reference={output} />
+          </Flex>
+        </SecondaryBox>
+      ) : null}
 
-        {notifications?.map((note, i) => (
-          <Text key={i} size="sm" variant="muted">
-            {note}
-          </Text>
-        ))}
+      {notifications?.map((note, i) => (
+        <Text key={i} size="sm" variant="muted">
+          {note}
+        </Text>
+      ))}
 
-        {children}
-      </Stack>
-    </Flex>
+      {children ? <Disclosure.Content>{children}</Disclosure.Content> : null}
+    </Disclosure>
   );
 }

--- a/static/app/components/core/chat/toolCall.tsx
+++ b/static/app/components/core/chat/toolCall.tsx
@@ -5,9 +5,9 @@ import {Button, LinkButton} from '@sentry/scraps/button';
 import {Disclosure} from '@sentry/scraps/disclosure';
 import {Container, Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
+import {useTranslation} from '@sentry/scraps/translationContext';
 
 import {IconSpan} from 'sentry/icons';
-import {t} from 'sentry/locale';
 import {unreachable} from 'sentry/utils/unreachable';
 
 import {ToolCallIndicator, type ToolCallStatus} from './toolCallIndicator';
@@ -119,7 +119,10 @@ function SecondaryBox({children}: {children: ReactNode}) {
   );
 }
 
-function getStatusLabel(status: ToolCallStatus): string | undefined {
+function getStatusLabel(
+  status: ToolCallStatus,
+  t: (text: string) => string
+): string | undefined {
   switch (status) {
     case 'loading':
       return t('Running');
@@ -155,11 +158,13 @@ export function ToolCall({
   notifications,
   children,
 }: ToolCallProps) {
+  const {t} = useTranslation();
+
   return (
     <Disclosure variant="outline" size="sm" gap="xs" flex={1}>
       <Disclosure.Title
         leadingItems={
-          <ToolCallIndicator status={status} aria-label={getStatusLabel(status)} />
+          <ToolCallIndicator status={status} aria-label={getStatusLabel(status, t)} />
         }
         trailingItems={reference ? <ReferenceChip reference={reference} /> : undefined}
       >

--- a/static/app/components/core/chat/toolCall.tsx
+++ b/static/app/components/core/chat/toolCall.tsx
@@ -91,7 +91,10 @@ function ChipContent({label, value}: {value: string; label?: string}) {
 
 function ReferenceChip({reference}: {reference: ToolCallReference}) {
   const {label, value, icon, onClick, to} = reference;
-  const chipIcon = icon ?? <IconSpan size="xs" />;
+  // No explicit size: `Button`/`LinkButton` already scale their `icon` via
+  // `IconDefaultsProvider`, and a hardcoded size here would fight that when the
+  // chip's button size ever changes.
+  const chipIcon = icon ?? <IconSpan />;
   const content = <ChipContent label={label} value={value} />;
 
   // A navigation target renders as a real anchor so middle/cmd-click and keyboard access work; an

--- a/static/app/components/core/disclosure/disclosure.tsx
+++ b/static/app/components/core/disclosure/disclosure.tsx
@@ -139,14 +139,16 @@ function Title({children, leadingItems, trailingItems, ...rest}: DisclosureTitle
   );
 }
 
-// The row owns the hover background so it spans the full title — behind the
-// leading and trailing items — rather than only the toggle button between them.
-// The press (:active) state deliberately stays on the button (below), so that
-// pressing a leading or trailing item does not bubble an active background onto
-// the whole row.
+// The row — not the button — owns the hover/active background so a single
+// background spans the full title (behind the leading and trailing items) for
+// both states, rather than the button rendering its own nested patch on top.
 const TitleRow = styled(Flex)`
   &:hover {
     background: ${p => p.theme.tokens.interactive.transparent.neutral.background.hover};
+  }
+
+  &:active {
+    background: ${p => p.theme.tokens.interactive.transparent.neutral.background.active};
   }
 `;
 
@@ -155,16 +157,11 @@ const StretchedButton = styled(Button)`
   justify-content: flex-start;
   padding-left: ${p => p.theme.space.xs};
 
-  /* The TitleRow provides the full-width hover background; suppress the button's
-   * own hover so the two don't stack into a darker patch behind the label. Keep
-   * the press state on the button so it reflects the toggle specifically. */
-  &&:hover {
-    background-color: transparent;
-  }
-
+  /* TitleRow owns the row's hover/active background; suppress the button's own
+   * states entirely so it never renders a second, nested background on top. */
+  &&:hover,
   &&:active {
-    background-color: ${p =>
-      p.theme.tokens.interactive.transparent.neutral.background.active};
+    background-color: transparent;
   }
 `;
 

--- a/static/app/components/core/disclosure/disclosure.tsx
+++ b/static/app/components/core/disclosure/disclosure.tsx
@@ -101,13 +101,18 @@ function Title({children, leadingItems, trailingItems, ...rest}: DisclosureTitle
   const chevron = <IconChevron direction={state.isExpanded ? 'down' : 'right'} />;
 
   // With a leading slot the chevron trails the title, so the leading content is
-  // the visual anchor and the toggle still reads label-then-affordance.
+  // the visual anchor and the toggle still reads label-then-affordance. Without
+  // leadingItems, the toggle button itself supplies left padding (see
+  // StretchedButton); with leadingItems, that content sits outside the button
+  // and needs its own matching left padding so the row isn't flush left while
+  // trailingItems get `paddingRight`.
   return (
     <TitleRow
       justify="start"
       gap={context.size}
       align="center"
       width="100%"
+      paddingLeft={leadingItems ? 'xs' : undefined}
       paddingRight="xs"
       radius="md"
     >


### PR DESCRIPTION
## Summary
Adds the **`ToolCall`** chat primitive used to render a single agent tool call inside a `ThinkingBlock`:

- A leading glyph communicates lifecycle status (spinner while running, semantic icon once settled) via `ToolCallIndicator`.
- A monospace `title`, an optional trailing `reference` chip pointing at the entity the call acted on, an optional `output` chip, and short `notification` lines beneath the call.

Presentation only — it holds no state.

## Out of scope
Tokenized search-query rendering (the former `QueryTokens` primitive and the `query`/`variant` props) has been dropped from this PR. Those visuals belong with the generic `Chip` work in #121345, which migrates the existing token renderers (`FormattedQuery`, askSeer, `searchQueryBuilder`).

## Test plan
- `toolCall.spec.tsx` — green.
- `pnpm typecheck` — green.
- Story: `toolCall.mdx`.
