### PR TITLE
feat(onboarding): Capture session replays for SCM project creation

### DIFF
--- a/static/app/views/projectInstall/scmCreateProject.spec.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.spec.tsx
@@ -19,7 +19,6 @@ import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {TeamStore} from 'sentry/stores/teamStore';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import type {PlatformKey} from 'sentry/types/platform';
-import {useReplayForCriticalFlow} from 'sentry/utils/replays/useReplayForCriticalFlow';
 import {DEFAULT_ISSUE_ALERT_OPTIONS_VALUES} from 'sentry/views/projectInstall/issueAlertOptions';
 import {RouteAnalyticsContext} from 'sentry/views/routeAnalyticsContextProvider';
 
@@ -38,10 +37,6 @@ jest.mock('@tanstack/react-virtual', () => ({
     getTotalSize: () => count * 36,
     measureElement: jest.fn(),
   })),
-}));
-
-jest.mock('sentry/utils/replays/useReplayForCriticalFlow', () => ({
-  useReplayForCriticalFlow: jest.fn(),
 }));
 
 jest.mock('sentry/data/platforms', () => {
@@ -274,18 +269,6 @@ describe('ScmCreateProject', () => {
     expect(routeAnalytics.setRouteAnalyticsParams).toHaveBeenCalledWith({
       variant: 'scm',
       origin: 'existing_org',
-    });
-  });
-
-  it('records a sampled session replay tagged for the SCM project-creation flow', async () => {
-    render(<ScmCreateProject />, {organization});
-
-    await screen.findByRole('button', {name: 'Create project'});
-    // Own flow tag (not onboarding's) so the two SCM funnels stay separable,
-    // at onboarding's sample rate.
-    expect(useReplayForCriticalFlow).toHaveBeenCalledWith({
-      flowName: 'scm_project_creation',
-      sampleRate: 0.5,
     });
   });
 

--- a/static/app/views/projectInstall/scmCreateProject.spec.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.spec.tsx
@@ -19,6 +19,7 @@ import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {TeamStore} from 'sentry/stores/teamStore';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import type {PlatformKey} from 'sentry/types/platform';
+import {useReplayForCriticalFlow} from 'sentry/utils/replays/useReplayForCriticalFlow';
 import {DEFAULT_ISSUE_ALERT_OPTIONS_VALUES} from 'sentry/views/projectInstall/issueAlertOptions';
 import {RouteAnalyticsContext} from 'sentry/views/routeAnalyticsContextProvider';
 
@@ -37,6 +38,10 @@ jest.mock('@tanstack/react-virtual', () => ({
     getTotalSize: () => count * 36,
     measureElement: jest.fn(),
   })),
+}));
+
+jest.mock('sentry/utils/replays/useReplayForCriticalFlow', () => ({
+  useReplayForCriticalFlow: jest.fn(),
 }));
 
 jest.mock('sentry/data/platforms', () => {
@@ -271,6 +276,19 @@ describe('ScmCreateProject', () => {
       origin: 'existing_org',
     });
   });
+
+  it('records a sampled session replay tagged for the SCM project-creation flow', async () => {
+    render(<ScmCreateProject />, {organization});
+
+    await screen.findByRole('button', {name: 'Create project'});
+    // Own flow tag (not onboarding's) so the two SCM funnels stay separable,
+    // at onboarding's sample rate.
+    expect(useReplayForCriticalFlow).toHaveBeenCalledWith({
+      flowName: 'scm_project_creation',
+      sampleRate: 0.5,
+    });
+  });
+
   it('shows all steps with the Create CTA disabled on a fresh visit', async () => {
     render(<ScmCreateProject />, {organization});
 

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -79,11 +79,8 @@ export function ScmCreateProject() {
   // must not reclassify an org-activation visit as existing_org.
   useRouteAnalyticsParams({variant: 'scm', origin: useProjectCreationPageOrigin()});
 
-  // Own flow tag rather than onboarding's `scm_onboarding`, so the two SCM
-  // funnels stay separately filterable in Replays. Sampling matches
-  // onboarding. Lives here, above the keyed wizard, so the per-mount sampling
-  // decision survives the restore remount below. Reaching this component
-  // already implies the SCM flag (see newProject), so no `enabled` gate.
+  // Above the keyed wizard so the per-mount sampling decision survives the
+  // restore remount below.
   useReplayForCriticalFlow({
     flowName: 'scm_project_creation',
     sampleRate: 0.5,

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -31,6 +31,7 @@ import {t, tct} from 'sentry/locale';
 import type {Integration, Repository} from 'sentry/types/integrations';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import {decodeScalar} from 'sentry/utils/queryString';
+import {useReplayForCriticalFlow} from 'sentry/utils/replays/useReplayForCriticalFlow';
 import {useRouteAnalyticsEventNames} from 'sentry/utils/routeAnalytics/useRouteAnalyticsEventNames';
 import {useRouteAnalyticsParams} from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
 import {useCanCreateProject} from 'sentry/utils/useCanCreateProject';
@@ -77,6 +78,16 @@ export function ScmCreateProject() {
   // `variant` and to `referrer=getting-started` autofill — back-from-docs
   // must not reclassify an org-activation visit as existing_org.
   useRouteAnalyticsParams({variant: 'scm', origin: useProjectCreationPageOrigin()});
+
+  // Own flow tag rather than onboarding's `scm_onboarding`, so the two SCM
+  // funnels stay separately filterable in Replays. Sampling matches
+  // onboarding. Lives here, above the keyed wizard, so the per-mount sampling
+  // decision survives the restore remount below. Reaching this component
+  // already implies the SCM flag (see newProject), so no `enabled` gate.
+  useReplayForCriticalFlow({
+    flowName: 'scm_project_creation',
+    sampleRate: 0.5,
+  });
 
   // Snapshot of the last completed wizard session, written when a project is
   // created (see handleComplete in the wizard). Restored when this mount is a


### PR DESCRIPTION
## TLDR

The SCM project-creation wizard had no Session Replay coverage. Half of its sessions are now recorded and tagged `critical_flow: scm_project_creation`, matching the sample rate SCM onboarding already uses.

## Details

SCM onboarding and SCM project creation are separate entry points. Onboarding calls `useReplayForCriticalFlow` from `static/app/views/onboarding/onboarding.tsx` gated on the `onboarding-scm-experiment` assignment, but a user who lands on `/projects/new/` behind `onboarding-scm-project-creation` renders `ScmCreateProject` from `newProject.tsx` and never passes through that host. This adds the hook to the SCM wizard only; the legacy `CreateProject` branch of `newProject.tsx` is untouched.

The flow gets its own tag value rather than reusing `scm_onboarding`, so the two funnels stay independently filterable in the Replays product. No `enabled` option is passed: reaching `ScmCreateProject` already implies the feature flag, so the flag check would be redundant.

Placement matters more than it looks. The call sits in `ScmCreateProject`, above the `key`-remounted `ScmCreateProjectWizard`, not inside the wizard. The gsApp implementation in `static/gsApp/overrides/useReplayForCriticalFlow.tsx` makes its sampling decision once per mount via a lazy `useState` initializer, and `ScmCreateProject` deliberately remounts the wizard when a return from getting-started restores a persisted session. Calling the hook inside the wizard would re-roll `Math.random()` on that remount and could flip a recording session off midway through the flow — exactly the part of the funnel worth watching. Hoisting it above the `key` boundary makes the decision stable for the whole visit.

Self-hosted behavior is unchanged: `sentry/utils/replays/useReplayForCriticalFlow` falls through to a noop when the `react-hook:use-replay-for-critical-flow` override is unregistered, which is the case outside gsApp.

Refs VDY-149

