### PR TITLE
feat(api): Add response schema to organization traces endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_traces.py
+++ b/src/sentry/api/endpoints/organization_traces.py
@@ -7,6 +7,7 @@ from typing import Any, Literal, NotRequired, TypedDict
 
 import sentry_sdk
 from django.utils import timezone
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import serializers
 from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
@@ -39,8 +40,18 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
+from sentry.api.endpoints.organization_events import EventsMeta
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.utils import handle_query_errors
+from sentry.apidocs.constants import (
+    RESPONSE_BAD_REQUEST,
+    RESPONSE_FORBIDDEN,
+    RESPONSE_NOT_FOUND,
+    RESPONSE_UNAUTHORIZED,
+)
+from sentry.apidocs.parameters import GlobalParams, OrganizationParams, VisibilityParams
+from sentry.apidocs.response_types import ValidationErrorResponse, as_validation_errors
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models.organization import Organization
 from sentry.models.project import Project
@@ -104,6 +115,55 @@ class TraceResult(TypedDict):
     breakdowns: list[TraceInterval]
 
 
+# Only used for api docs — the shape `handle_results_with_meta` emits.
+class TracesApiResponse(TypedDict):
+    data: list[TraceResult]
+    meta: EventsMeta
+
+
+DATASET_QUERY_PARAM = OpenApiParameter(
+    name="dataset",
+    location="query",
+    required=False,
+    type=str,
+    enum=["spans"],
+    description="The dataset to query. Defaults to `spans`.",
+)
+
+TRACES_QUERY_PARAM = OpenApiParameter(
+    name="query",
+    location="query",
+    required=False,
+    many=True,
+    type=str,
+    description=(
+        "Sentry [search syntax](https://docs.sentry.io/concepts/search/) matched against spans. "
+        "Pass the parameter more than once to require that a trace contain a span matching each "
+        "query, which is how you find traces where several conditions co-occur."
+    ),
+)
+
+SORT_QUERY_PARAM = OpenApiParameter(
+    name="sort",
+    location="query",
+    required=False,
+    type=str,
+    enum=["timestamp", "-timestamp"],
+    description="Sort order for the returned traces.",
+)
+
+BREAKDOWN_SLICES_QUERY_PARAM = OpenApiParameter(
+    name="breakdownSlices",
+    location="query",
+    required=False,
+    type=int,
+    description=(
+        "Number of time slices used to compute each trace's per-project breakdown. "
+        "Defaults to 40; must be between 1 and 100."
+    ),
+)
+
+
 class OrganizationTracesSerializer(serializers.Serializer):
     dataset = serializers.ChoiceField(["spans"], required=False, default="spans")
 
@@ -147,9 +207,40 @@ class OrganizationTracesEndpointBase(OrganizationEventsEndpointBase):
     owner = ApiOwner.DATA_BROWSING
 
 
+@extend_schema(tags=["Explore"])
 @cell_silo_endpoint
 class OrganizationTracesEndpoint(OrganizationTracesEndpointBase):
-    def get(self, request: Request, organization: Organization) -> Response:
+    @extend_schema(
+        operation_id="listOrganizationTraces",
+        summary="List an Organization's Traces",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            OrganizationParams.PROJECT,
+            GlobalParams.ENVIRONMENT,
+            GlobalParams.STATS_PERIOD,
+            GlobalParams.START,
+            GlobalParams.END,
+            DATASET_QUERY_PARAM,
+            TRACES_QUERY_PARAM,
+            SORT_QUERY_PARAM,
+            BREAKDOWN_SLICES_QUERY_PARAM,
+            VisibilityParams.PER_PAGE,
+        ],
+        responses={
+            200: inline_sentry_response_serializer("ListTracesResponse", TracesApiResponse),
+            400: RESPONSE_BAD_REQUEST,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
+    def get(
+        self, request: Request, organization: Organization
+    ) -> Response[TracesApiResponse] | Response[ValidationErrorResponse] | Response[None]:
+        """
+        List traces matching one or more span queries, with a per-project timing
+        breakdown for each trace.
+        """
         if not features.has(
             "organizations:visibility-explore-view", organization, actor=request.user
         ):
@@ -167,7 +258,7 @@ class OrganizationTracesEndpoint(OrganizationTracesEndpointBase):
 
         serializer = OrganizationTracesSerializer(data=request.GET)
         if not serializer.is_valid():
-            return Response(serializer.errors, status=400)
+            return Response(as_validation_errors(serializer), status=400)
         serialized = serializer.validated_data
 
         with handle_query_errors():

--- a/src/sentry/api/endpoints/organization_traces.py
+++ b/src/sentry/api/endpoints/organization_traces.py
@@ -134,12 +134,10 @@ TRACES_QUERY_PARAM = OpenApiParameter(
     name="query",
     location="query",
     required=False,
-    many=True,
     type=str,
     description=(
         "Sentry [search syntax](https://docs.sentry.io/concepts/search/) matched against spans. "
-        "Pass the parameter more than once to require that a trace contain a span matching each "
-        "query, which is how you find traces where several conditions co-occur."
+        "A trace is returned when any of its spans match. Only one query is supported."
     ),
 )
 
@@ -172,6 +170,14 @@ class OrganizationTracesSerializer(serializers.Serializer):
         required=False, allow_empty=True, child=serializers.CharField(allow_blank=True)
     )
     sort = serializers.CharField(required=False)
+
+    def validate_query(self, value: list[str]) -> list[str]:
+        # process_rpc_user_queries only supports a single query and raises
+        # ValueError beyond that, which would surface as a 500. Reject it here so
+        # the caller gets a 400 alongside the other validation errors.
+        if len(value) > 1:
+            raise serializers.ValidationError("Only 1 query is supported.")
+        return value
 
     def validate_dataset(self, value):
         sentry_sdk.set_tag("query.dataset", value)
@@ -238,8 +244,8 @@ class OrganizationTracesEndpoint(OrganizationTracesEndpointBase):
         self, request: Request, organization: Organization
     ) -> Response[TracesApiResponse] | Response[ValidationErrorResponse] | Response[None]:
         """
-        List traces matching one or more span queries, with a per-project timing
-        breakdown for each trace.
+        List traces containing at least one span that matches the query, with a
+        per-project timing breakdown for each trace.
         """
         if not features.has(
             "organizations:visibility-explore-view", organization, actor=request.user

--- a/tests/sentry/api/endpoints/test_organization_traces.py
+++ b/tests/sentry/api/endpoints/test_organization_traces.py
@@ -307,6 +307,21 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
             ),
         }
 
+    def test_bad_params_too_many_queries(self) -> None:
+        query = {
+            "project": [self.project.id],
+            "field": ["id"],
+            "query": ["foo:bar", "baz:qux"],
+        }
+
+        response = self.do_request(query)
+        assert response.status_code == 400, response.data
+        assert response.data == {
+            "query": [
+                ErrorDetail(string="Only 1 query is supported.", code="invalid"),
+            ],
+        }
+
     def test_no_traces(self) -> None:
         query = {
             "project": [self.project.id],


### PR DESCRIPTION
Documents the request params and response type for `GET /organizations/{org}/traces/` so internal tooling can generate a typed client for it. That generator only admits an operation whose success response resolves to a concrete schema.

Fourth of five related endpoints (BROWSE-693); same pattern as #121319, #121328, #121332.

**`publish_status` stays `EXPERIMENTAL`** — absent from the public spec. Verified the generated public spec is **byte-identical**, since this imports from `organization_events.py`, which hosts a public endpoint.

Notes on scope:
- The endpoint returns an **envelope** from `handle_results_with_meta`, not a bare list, so this adds `TracesApiResponse` pairing the existing `TraceResult` rows with the `EventsMeta` already declared for the events endpoint. Reusing that type rather than adding a third copy — the import is one-way, so no cycle.
- The 400 branch now uses `as_validation_errors()` so the declared union is satisfied without a `cast`; the response body is unchanged.
- `breakdownSlices` documents its 1–100 bound and default of 40.

Verified the declared shape against a real response: all 12 `TraceResult` fields and all 10 `TraceInterval` fields match, `components` is correctly absent (it's `NotRequired`), and every emitted `meta` key is present in `EventsMeta`.

### Second commit: fixes a 500 the first one would have advertised

My initial `query` param description claimed multi-value support. It doesn't exist: `process_rpc_user_queries` raises a bare `ValueError` beyond one query, and `handle_query_errors` doesn't catch `ValueError`, so two `query` params returned an unhandled **500**. The runtime has been single-query since the RPC migration in 4d2365ebbd1.

- Corrected the param description and docstring, and dropped `many=True` — the generated client now emits `query?: string` and can't construct the failing request.
- Added `validate_query` to the serializer so a hand-built request gets `400 {'query': ['Only 1 query is supported.']}`. Kept it in the serializer beside the existing `dataset`/`sort` validation rather than widening `handle_query_errors`, which is shared by many endpoints.
- Added `test_bad_params_too_many_queries` so this can't silently regress.

`pytest tests/sentry/api/endpoints/test_organization_traces.py` → 42 passed.

Refs BROWSE-693