### PR TITLE
fix(tracemetrics): Map sentry.segment.name to transaction

### DIFF
--- a/src/sentry/search/eap/trace_metrics/attributes.py
+++ b/src/sentry/search/eap/trace_metrics/attributes.py
@@ -1,11 +1,9 @@
 from typing import Literal
 
+from sentry_conventions.attributes import ATTRIBUTE_NAMES
+
 from sentry.search.eap import constants
-from sentry.search.eap.columns import (
-    AttributeContext,
-    ResolvedAttribute,
-    simple_sentry_field,
-)
+from sentry.search.eap.columns import AttributeContext, ResolvedAttribute, simple_sentry_field
 from sentry.search.eap.common_columns import COMMON_COLUMNS, project_virtual_contexts
 from sentry.search.utils import validate_event_id
 from sentry.utils.validators import normalize_event_id_strict
@@ -94,6 +92,7 @@ TRACE_METRICS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS: dict[
     | {
         # sentry.service is the project id as a string, but map to project for convenience
         "sentry.service": "project",
+        ATTRIBUTE_NAMES.SENTRY_SEGMENT_NAME: "transaction",
     },
     "boolean": {
         definition.internal_name: definition.public_alias

--- a/src/sentry/search/eap/trace_metrics/attributes.py
+++ b/src/sentry/search/eap/trace_metrics/attributes.py
@@ -97,7 +97,6 @@ TRACE_METRICS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS: dict[
     | {
         # sentry.service is the project id as a string, but map to project for convenience
         "sentry.service": "project",
-        ATTRIBUTE_NAMES.SENTRY_SEGMENT_NAME: "transaction",
     },
     "boolean": {
         definition.internal_name: definition.public_alias

--- a/src/sentry/search/eap/trace_metrics/attributes.py
+++ b/src/sentry/search/eap/trace_metrics/attributes.py
@@ -70,6 +70,11 @@ TRACE_METRICS_ATTRIBUTE_DEFINITIONS = {
             internal_name="sentry.metric_unit",
             search_type="string",
         ),
+        ResolvedAttribute(
+            public_alias="transaction",
+            internal_name=ATTRIBUTE_NAMES.SENTRY_SEGMENT_NAME,
+            search_type="string",
+        ),
     ]
 }
 

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -49,10 +49,7 @@ from sentry_kafka_schemas.schema_types.uptime_results_v1 import (
     CheckStatus,
     CheckStatusReason,
 )
-from sentry_protos.snuba.v1.request_common_pb2 import (
-    TRACE_ITEM_TYPE_OCCURRENCE,
-    TraceItemType,
-)
+from sentry_protos.snuba.v1.request_common_pb2 import TRACE_ITEM_TYPE_OCCURRENCE, TraceItemType
 from sentry_protos.snuba.v1.trace_item_pb2 import AnyValue, TraceItem
 from sentry_relay.consts import SPAN_STATUS_NAME_TO_CODE
 from slack_sdk.web import SlackResponse
@@ -64,9 +61,7 @@ from sentry.api.serializers.models.dashboard import DATASET_SOURCES
 from sentry.auth.authenticators.totp import TotpInterface
 from sentry.auth.provider import Provider
 from sentry.auth.providers.dummy import DummyProvider
-from sentry.auth.providers.saml2.activedirectory.apps import (
-    ACTIVE_DIRECTORY_PROVIDER_NAME,
-)
+from sentry.auth.providers.saml2.activedirectory.apps import ACTIVE_DIRECTORY_PROVIDER_NAME
 from sentry.auth.staff import COOKIE_DOMAIN as STAFF_COOKIE_DOMAIN
 from sentry.auth.staff import COOKIE_NAME as STAFF_COOKIE_NAME
 from sentry.auth.staff import COOKIE_PATH as STAFF_COOKIE_PATH
@@ -116,12 +111,8 @@ from sentry.models.repository import Repository
 from sentry.models.rule import RuleSource
 from sentry.monitors.models import Monitor, MonitorEnvironment, ScheduleType
 from sentry.new_migrations.monkey.state import SentryProjectState
-from sentry.notifications.models.notificationsettingoption import (
-    NotificationSettingOption,
-)
-from sentry.notifications.models.notificationsettingprovider import (
-    NotificationSettingProvider,
-)
+from sentry.notifications.models.notificationsettingoption import NotificationSettingOption
+from sentry.notifications.models.notificationsettingprovider import NotificationSettingProvider
 from sentry.notifications.notifications.base import alert_page_needs_org_id
 from sentry.notifications.types import FineTuningAPIKey
 from sentry.organizations.services.organization.serial import serialize_rpc_organization

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -49,7 +49,10 @@ from sentry_kafka_schemas.schema_types.uptime_results_v1 import (
     CheckStatus,
     CheckStatusReason,
 )
-from sentry_protos.snuba.v1.request_common_pb2 import TRACE_ITEM_TYPE_OCCURRENCE, TraceItemType
+from sentry_protos.snuba.v1.request_common_pb2 import (
+    TRACE_ITEM_TYPE_OCCURRENCE,
+    TraceItemType,
+)
 from sentry_protos.snuba.v1.trace_item_pb2 import AnyValue, TraceItem
 from sentry_relay.consts import SPAN_STATUS_NAME_TO_CODE
 from slack_sdk.web import SlackResponse
@@ -61,7 +64,9 @@ from sentry.api.serializers.models.dashboard import DATASET_SOURCES
 from sentry.auth.authenticators.totp import TotpInterface
 from sentry.auth.provider import Provider
 from sentry.auth.providers.dummy import DummyProvider
-from sentry.auth.providers.saml2.activedirectory.apps import ACTIVE_DIRECTORY_PROVIDER_NAME
+from sentry.auth.providers.saml2.activedirectory.apps import (
+    ACTIVE_DIRECTORY_PROVIDER_NAME,
+)
 from sentry.auth.staff import COOKIE_DOMAIN as STAFF_COOKIE_DOMAIN
 from sentry.auth.staff import COOKIE_NAME as STAFF_COOKIE_NAME
 from sentry.auth.staff import COOKIE_PATH as STAFF_COOKIE_PATH
@@ -111,8 +116,12 @@ from sentry.models.repository import Repository
 from sentry.models.rule import RuleSource
 from sentry.monitors.models import Monitor, MonitorEnvironment, ScheduleType
 from sentry.new_migrations.monkey.state import SentryProjectState
-from sentry.notifications.models.notificationsettingoption import NotificationSettingOption
-from sentry.notifications.models.notificationsettingprovider import NotificationSettingProvider
+from sentry.notifications.models.notificationsettingoption import (
+    NotificationSettingOption,
+)
+from sentry.notifications.models.notificationsettingprovider import (
+    NotificationSettingProvider,
+)
 from sentry.notifications.notifications.base import alert_page_needs_org_id
 from sentry.notifications.types import FineTuningAPIKey
 from sentry.organizations.services.organization.serial import serialize_rpc_organization

--- a/tests/snuba/api/endpoints/test_organization_events_trace_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace_metrics.py
@@ -6,9 +6,7 @@ from rest_framework.exceptions import ErrorDetail
 
 from sentry.conf.types.sentry_config import SentryMode
 from sentry.utils.snuba_rpc import table_rpc
-from tests.snuba.api.endpoints.test_organization_events import (
-    OrganizationEventsEndpointTestBase,
-)
+from tests.snuba.api.endpoints.test_organization_events import OrganizationEventsEndpointTestBase
 
 
 class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestBase):
@@ -981,3 +979,40 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
         assert meta["fields"]["per_minute_if(`release:abcdef`,value)"] == "rate"
         assert meta["units"]["per_minute_if(`release:abcdef`,value)"] == "1/minute"
         assert meta["dataset"] == "tracemetrics"
+
+    def test_segment_name_mapped_to_transaction(self) -> None:
+        trace_metrics = [
+            self.create_trace_metric(
+                "request_duration",
+                100.0,
+                "distribution",
+                attributes={"sentry.segment.name": "/api/users"},
+            ),
+            self.create_trace_metric(
+                "request_duration",
+                200.0,
+                "distribution",
+                attributes={"sentry.segment.name": "/api/orders"},
+            ),
+            self.create_trace_metric(
+                "request_duration",
+                300.0,
+                "distribution",
+                attributes={"sentry.segment.name": "/api/users"},
+            ),
+        ]
+        self.store_eap_items(trace_metrics)
+
+        response = self.do_request(
+            {
+                "field": ["transaction", "sum(value)"],
+                "query": "transaction:/api/users",
+                "orderby": "transaction",
+                "dataset": self.dataset,
+            }
+        )
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        assert len(data) == 1
+        assert data[0]["transaction"] == "/api/users"
+        assert data[0]["sum(value)"] == 400

--- a/tests/snuba/api/endpoints/test_project_trace_item_details.py
+++ b/tests/snuba/api/endpoints/test_project_trace_item_details.py
@@ -12,6 +12,7 @@ from sentry.testutils.cases import (
     SnubaTestCase,
     SpanTestCase,
     TraceAttachmentTestCase,
+    TraceMetricsTestCase,
 )
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.options import override_options
@@ -24,6 +25,7 @@ class ProjectTraceItemDetailsEndpointTest(
     OurLogTestCase,
     SpanTestCase,
     TraceAttachmentTestCase,
+    TraceMetricsTestCase,
     OccurrenceTestCase,
 ):
     def setUp(self) -> None:
@@ -776,3 +778,27 @@ class ProjectTraceItemDetailsEndpointTest(
         response = self.do_request("logs", item_id)
         assert response.status_code == 429
         assert b"Rate limit exceeded" in response.content
+
+    def test_trace_metric_segment_name_mapped_to_transaction(self) -> None:
+        trace_metric = self.create_trace_metric(
+            metric_name="request_duration",
+            metric_value=100.0,
+            metric_type="distribution",
+            trace_id=self.trace_uuid,
+            attributes={"sentry.segment.name": "/api/users"},
+        )
+        self.store_eap_items([trace_metric])
+        item_id = uuid.UUID(bytes=trace_metric.item_id).hex
+
+        response = self.do_request(
+            "tracemetrics",
+            item_id,
+            features={**self.features, "organizations:tracemetrics-enabled": True},
+        )
+        assert response.status_code == 200, response.content
+
+        by_name = {attr["name"]: attr for attr in response.data["attributes"]}
+        assert "transaction" in by_name
+        assert by_name["transaction"]["value"] == "/api/users"
+        assert by_name["transaction"]["type"] == "str"
+        assert "sentry.segment.name" not in by_name


### PR DESCRIPTION
Avoid exposing the `segment` terminology and instead expose `transaction` for tracemetrics attributes.