### PR TITLE
fix(replays): Speed up Replay bulk delete code by paginating on sorting key

### DIFF
--- a/src/sentry/replays/endpoints/project_replay_jobs_delete.py
+++ b/src/sentry/replays/endpoints/project_replay_jobs_delete.py
@@ -183,8 +183,6 @@ class ProjectReplayDeletionJobsIndexEndpoint(ProjectEndpoint):
         # We don't check Seer features because an org may have previously had them on, then turned them off.
         has_seer_data = features.has("organizations:replay-ai-summaries", project.organization)
 
-        # A null cursor starts from the beginning of the range. Future work doesn't need to obey
-        # this: pass `after_replay_id_hash` to resume from a known `cityHash64(replay_id)` position.
         run_bulk_replay_delete_job.delay(job.id, has_seer_data=has_seer_data)
 
         self.create_audit_entry(

--- a/src/sentry/replays/endpoints/project_replay_jobs_delete.py
+++ b/src/sentry/replays/endpoints/project_replay_jobs_delete.py
@@ -183,9 +183,9 @@ class ProjectReplayDeletionJobsIndexEndpoint(ProjectEndpoint):
         # We don't check Seer features because an org may have previously had them on, then turned them off.
         has_seer_data = features.has("organizations:replay-ai-summaries", project.organization)
 
-        # We always start with an offset of 0 (obviously) but future work doesn't need to obey
-        # this. You're free to start from wherever you want.
-        run_bulk_replay_delete_job.delay(job.id, offset=0, has_seer_data=has_seer_data)
+        # A null cursor starts from the beginning of the range. Future work doesn't need to obey
+        # this: pass `after_replay_id_hash` to resume from a known `cityHash64(replay_id)` position.
+        run_bulk_replay_delete_job.delay(job.id, has_seer_data=has_seer_data)
 
         self.create_audit_entry(
             request,

--- a/src/sentry/replays/scripts/delete_replays.py
+++ b/src/sentry/replays/scripts/delete_replays.py
@@ -65,17 +65,17 @@ def delete_replays(
         window_end = min(window_start + timedelta(days=chunk_size_days), end_utc)
 
         # Reset per window because the cursor space is scoped to the window's result set
-        last_replay_id = None
+        cursor = None
 
         has_more = True
         while has_more:
-            replays, has_more, last_replay_id = _get_rows_matching_deletion_pattern(
+            replays, has_more, cursor = _get_rows_matching_deletion_pattern(
                 project_id=project_id,
                 organization_id=organization.id,
                 start=window_start,
                 end=window_end,
                 limit=batch_size,
-                after_replay_id=last_replay_id,
+                after_replay_id_hash=cursor,
                 search_filters=search_filters,
                 environment=environment,
             )
@@ -170,20 +170,33 @@ def _get_rows_matching_deletion_pattern(
     project_id: int,
     organization_id: int,
     limit: int,
-    after_replay_id: str | None,
+    after_replay_id_hash: int | None,
     end: datetime,
     start: datetime,
     search_filters: Sequence[QueryToken],
     environment: list[str],
-) -> tuple[list[tuple[int, str, int]], bool, str | None]:
+) -> tuple[list[tuple[int, str, int]], bool, int | None]:
     where = handle_search_filters(scalar_search_config, search_filters)
 
     if environment:
         where.append(Condition(Column("environment"), Op.IN, environment))
 
-    # Keyset cursor in order to walk result set in fixed-cost pages. Need the ORDER BY to keep it deterministic
-    if after_replay_id is not None:
-        where.append(Condition(Column("replay_id"), Op.GT, after_replay_id))
+    # Page by `cityHash64(replay_id)`, the third component of the table's sort key
+    # `(project_id, toStartOfDay(timestamp), cityHash64(replay_id), event_hash)`. Seeking on it lets
+    # ClickHouse prune granules: measured against one project-day, a mid-range cursor halved rows
+    # read (39.3M -> 19.7M). A cursor on the raw `replay_id` prunes nothing, because the raw value
+    # is not in the sort key -- every page read the whole window and filtered afterwards.
+    replay_id_hash = Function(
+        "cityHash64", parameters=[Column("replay_id")], alias="replay_id_hash"
+    )
+    if after_replay_id_hash is not None:
+        where.append(
+            Condition(
+                Function("cityHash64", parameters=[Column("replay_id")]),
+                Op.GT,
+                after_replay_id_hash,
+            )
+        )
 
     query = Query(
         match=Entity("replays"),
@@ -191,6 +204,7 @@ def _get_rows_matching_deletion_pattern(
             Function("any", parameters=[Column("retention_days")], alias="retention_days"),
             Column("replay_id"),
             Function("max", parameters=[Column("segment_id")], alias="max_segment_id"),
+            replay_id_hash,
         ],
         where=[
             Condition(Column("project_id"), Op.EQ, project_id),
@@ -199,8 +213,10 @@ def _get_rows_matching_deletion_pattern(
             Condition(Column("segment_id"), Op.IS_NOT_NULL),
             *where,
         ],
-        groupby=[Column("replay_id")],
-        orderby=[OrderBy(Column("replay_id"), Direction.ASC)],
+        # The hash is a function of `replay_id`, so grouping by both leaves cardinality unchanged
+        # while keeping every selected and ordered expression a group key.
+        groupby=[Column("replay_id"), replay_id_hash],
+        orderby=[OrderBy(replay_id_hash, Direction.ASC)],
         granularity=Granularity(3600),
         limit=Limit(limit),
     )
@@ -221,8 +237,8 @@ def _get_rows_matching_deletion_pattern(
     data = response.get("data", [])
     has_more = len(data) == limit
 
-    # The next page seeks past the last raw replay_id in this page
-    next_cursor = data[-1]["replay_id"] if data else None
+    # Rows are ordered by the hash, so the next page seeks past the last row's hash.
+    next_cursor = data[-1]["replay_id_hash"] if data else None
 
     return (
         [

--- a/src/sentry/replays/scripts/delete_replays.py
+++ b/src/sentry/replays/scripts/delete_replays.py
@@ -181,12 +181,9 @@ def _get_rows_matching_deletion_pattern(
     if environment:
         where.append(Condition(Column("environment"), Op.IN, environment))
 
-    # Page by `cityHash64(replay_id)`, the third component of the table's sort key
-    # `(project_id, toStartOfDay(timestamp), cityHash64(replay_id), event_hash)`. Seeking on it lets
-    # ClickHouse prune granules: measured against one project-day, a mid-range cursor halved rows
-    # read (39.3M -> 19.7M). A cursor on the raw `replay_id` prunes nothing, because the raw value
-    # is not in the sort key -- every page read the whole window and filtered afterwards.
-    replay_id_hash = Function(
+    # Fetch `cityHash64(replay_id)`. This, unlike `replay_id` is part of the
+    # _sharding key_, which allows ClickHouse to skip granules while scanning.
+    replay_id_hash_column = Function(
         "cityHash64", parameters=[Column("replay_id")], alias="replay_id_hash"
     )
     if after_replay_id_hash is not None:
@@ -204,7 +201,7 @@ def _get_rows_matching_deletion_pattern(
             Function("any", parameters=[Column("retention_days")], alias="retention_days"),
             Column("replay_id"),
             Function("max", parameters=[Column("segment_id")], alias="max_segment_id"),
-            replay_id_hash,
+            replay_id_hash_column,
         ],
         where=[
             Condition(Column("project_id"), Op.EQ, project_id),
@@ -215,8 +212,8 @@ def _get_rows_matching_deletion_pattern(
         ],
         # The hash is a function of `replay_id`, so grouping by both leaves cardinality unchanged
         # while keeping every selected and ordered expression a group key.
-        groupby=[Column("replay_id"), replay_id_hash],
-        orderby=[OrderBy(replay_id_hash, Direction.ASC)],
+        groupby=[Column("replay_id"), replay_id_hash_column],
+        orderby=[OrderBy(replay_id_hash_column, Direction.ASC)],
         granularity=Granularity(3600),
         limit=Limit(limit),
     )

--- a/src/sentry/replays/scripts/delete_replays.py
+++ b/src/sentry/replays/scripts/delete_replays.py
@@ -181,8 +181,8 @@ def _get_rows_matching_deletion_pattern(
     if environment:
         where.append(Condition(Column("environment"), Op.IN, environment))
 
-    # Fetch `cityHash64(replay_id)`. This, unlike `replay_id` is part of the
-    # _sharding key_, which allows ClickHouse to skip granules while scanning.
+    # Fetch `cityHash64(replay_id)`. Unlike raw `replay_id` it is part of the table's
+    # _sort key_, so ClickHouse can use it to skip granules while scanning.
     replay_id_hash_column = Function(
         "cityHash64", parameters=[Column("replay_id")], alias="replay_id_hash"
     )
@@ -210,9 +210,7 @@ def _get_rows_matching_deletion_pattern(
             Condition(Column("segment_id"), Op.IS_NOT_NULL),
             *where,
         ],
-        # The hash is a function of `replay_id`, so grouping by both leaves cardinality unchanged
-        # while keeping every selected and ordered expression a group key.
-        # Group by both the `replay_id` and `cityHash64(replay_id)` so we able
+        # Group by both the `replay_id` and `cityHash64(replay_id)` so we are able
         # to keep track of the cursor _and_ still get the Replay IDs out. Since
         # the hash is a function of the ID, this doesn't change the row contents.
         groupby=[Column("replay_id"), replay_id_hash_column],

--- a/src/sentry/replays/scripts/delete_replays.py
+++ b/src/sentry/replays/scripts/delete_replays.py
@@ -212,6 +212,9 @@ def _get_rows_matching_deletion_pattern(
         ],
         # The hash is a function of `replay_id`, so grouping by both leaves cardinality unchanged
         # while keeping every selected and ordered expression a group key.
+        # Group by both the `replay_id` and `cityHash64(replay_id)` so we able
+        # to keep track of the cursor _and_ still get the Replay IDs out. Since
+        # the hash is a function of the ID, this doesn't change the row contents.
         groupby=[Column("replay_id"), replay_id_hash_column],
         orderby=[OrderBy(replay_id_hash_column, Direction.ASC)],
         granularity=Granularity(3600),
@@ -234,7 +237,6 @@ def _get_rows_matching_deletion_pattern(
     data = response.get("data", [])
     has_more = len(data) == limit
 
-    # Rows are ordered by the hash, so the next page seeks past the last row's hash.
     next_cursor = data[-1]["replay_id_hash"] if data else None
 
     return (

--- a/src/sentry/replays/tasks.py
+++ b/src/sentry/replays/tasks.py
@@ -231,18 +231,23 @@ def _delete_filenames_concurrently(filenames: list[str]) -> None:
 )
 def run_bulk_replay_delete_job(
     replay_delete_job_id: int,
-    offset: int,
+    offset: int | None = None,
     limit: int = 100,
     has_seer_data: bool = False,
     total_deleted: int = 0,
     window_offset_days: int = 0,
+    after_replay_id_hash: int | None = None,
 ) -> None:
     """Replay bulk deletion task.
 
-    We specify retry behavior in the task definition. However, if the task fails more than 5 times
-    the process will stop and the task has permanently failed. We checkpoint our offset position
-    in the model. Restarting the task will use the offset passed by the caller. If you want to
-    restart the task from the previous checkpoint you must pass the checkpoint explicitly.
+    Pages through the job's range with a keyset cursor on `cityHash64(replay_id)` and chains a
+    follow-up activation per page. Each page is idempotent: re-running one re-deletes blobs that
+    are already gone (a swallowed 404) and re-publishes an archive event.
+
+    `offset` is the cursor from the previous deploy's `OFFSET` pagination. It is accepted and
+    ignored so activations enqueued before this deploy still resolve; such an activation restarts
+    its window from the beginning rather than failing. Remove the argument once the queue has
+    drained.
     """
     chunk_size_days = options.get("replay.bulk_delete_job.chunk_size_days") or 7
     job = ReplayDeletionJobModel.objects.get(id=replay_delete_job_id)
@@ -263,8 +268,8 @@ def run_bulk_replay_delete_job(
     window_end = min(window_start + timedelta(days=chunk_size_days), job.range_end)
 
     try:
-        # Delete the replays within a limited range. If more replays exist an incremented offset value
-        # is returned.
+        # Delete the replays within a limited range. If more replays exist a cursor to seek the next
+        # page from is returned.
         results = fetch_rows_matching_pattern(
             project_id=job.project_id,
             start=window_start,
@@ -272,7 +277,7 @@ def run_bulk_replay_delete_job(
             query=job.query,
             environment=job.environments,
             limit=limit,
-            offset=offset,
+            after_replay_id_hash=after_replay_id_hash,
         )
 
         # Delete the matched rows if any rows were returned.
@@ -309,37 +314,40 @@ def run_bulk_replay_delete_job(
         _transition_status(job.id, DeletionJobStatus.IN_PROGRESS, DeletionJobStatus.FAILED)
         raise
 
-    # `next_offset` is the SQL pagination cursor for the current window.
     # `new_total` is the running count of all replays deleted across all windows.
     num_rows_deleted = len(results["rows"])
-    next_offset = offset + num_rows_deleted
     new_total = total_deleted + num_rows_deleted
 
-    if results["has_more"]:
+    # A null cursor with `has_more` set only happens for `limit=0`, where every page is empty and
+    # seeks nowhere. Treating that as "window done" stops it chaining activations forever.
+    next_cursor = results["next_cursor"]
+
+    if results["has_more"] and next_cursor is not None:
         # Checkpoint before continuing within the same window.
         _advance_offset(job.id, new_total)
         run_bulk_replay_delete_job.delay(
             job.id,
-            next_offset,
             limit=limit,
             has_seer_data=has_seer_data,
             total_deleted=new_total,
             window_offset_days=window_offset_days,
+            after_replay_id_hash=next_cursor,
         )
         return None
 
     # Current window exhausted. Check if more time windows remain.
     if window_end < job.range_end:
-        # Advance to the next 7-day window by incrementing the cursor in the task args.
+        # Advance to the next window by incrementing the day offset in the task args, and reset the
+        # cursor: it is a position within a window's result set, not a global one.
         # job.range_start is never mutated so the API always returns the original range.
         _advance_offset(job.id, new_total)
         run_bulk_replay_delete_job.delay(
             job.id,
-            0,
             limit=limit,
             has_seer_data=has_seer_data,
             total_deleted=new_total,
             window_offset_days=window_offset_days + chunk_size_days,
+            after_replay_id_hash=None,
         )
         return None
 

--- a/src/sentry/replays/usecases/delete.py
+++ b/src/sentry/replays/usecases/delete.py
@@ -132,8 +132,8 @@ def fetch_rows_matching_pattern(
     if environment:
         where.append(Condition(Column("environment"), Op.IN, environment))
 
-    # Fetch `cityHash64(replay_id)`. This, unlike `replay_id` is part of the
-    # _sharding key_, which allows ClickHouse to skip granules while scanning.
+    # Fetch `cityHash64(replay_id)`. Unlike raw `replay_id` it is part of the table's
+    # _sort key_, so ClickHouse can use it to skip granules while scanning.
     replay_id_hash_column = Function(
         "cityHash64", parameters=[Column("replay_id")], alias="replay_id_hash"
     )
@@ -163,7 +163,7 @@ def fetch_rows_matching_pattern(
             *where,
         ],
         having=having,
-        # Group by both the `replay_id` and `cityHash64(replay_id)` so we able
+        # Group by both the `replay_id` and `cityHash64(replay_id)` so we are able
         # to keep track of the cursor _and_ still get the Replay IDs out. Since
         # the hash is a function of the ID, this doesn't change the row contents.
         groupby=[Column("replay_id"), replay_id_hash_column],

--- a/src/sentry/replays/usecases/delete.py
+++ b/src/sentry/replays/usecases/delete.py
@@ -132,20 +132,12 @@ def fetch_rows_matching_pattern(
     if environment:
         where.append(Condition(Column("environment"), Op.IN, environment))
 
-    # Page by `cityHash64(replay_id)`, the third component of the table's sort key
-    # `(project_id, toStartOfDay(timestamp), cityHash64(replay_id), event_hash)`. Seeking on it lets
-    # ClickHouse prune granules: measured against one project-day, a mid-range cursor halved rows
-    # read (39.3M -> 19.7M). The raw `replay_id` is not in the sort key at all, so a `replay_id >`
-    # cursor read every row in the window and filtered afterwards, and `OFFSET` paging re-aggregated
-    # the whole window on every page. `OFFSET` was also ordered by `min(timestamp)` at hourly
-    # granularity, where ties are dense enough that page boundaries were non-deterministic and rows
-    # could be skipped between pages.
-    replay_id_hash = Function(
+    # Fetch `cityHash64(replay_id)`. This, unlike `replay_id` is part of the
+    # _sharding key_, which allows ClickHouse to skip granules while scanning.
+    replay_id_hash_column = Function(
         "cityHash64", parameters=[Column("replay_id")], alias="replay_id_hash"
     )
     if after_replay_id_hash is not None:
-        # Unaliased twin: the alias belongs to the SELECT, and this is the form already proven
-        # against this entity elsewhere (see `organization_replay_selector_index`).
         where.append(
             Condition(
                 Function("cityHash64", parameters=[Column("replay_id")]),
@@ -160,7 +152,7 @@ def fetch_rows_matching_pattern(
             Function("any", parameters=[Column("retention_days")], alias="retention_days"),
             Column("replay_id"),
             Function("max", parameters=[Column("segment_id")], alias="max_segment_id"),
-            replay_id_hash,
+            replay_id_hash_column,
         ],
         where=[
             Condition(Column("project_id"), Op.EQ, project_id),
@@ -173,8 +165,11 @@ def fetch_rows_matching_pattern(
         having=having,
         # The hash is a function of `replay_id`, so grouping by both leaves cardinality unchanged
         # while keeping every selected and ordered expression a group key.
-        groupby=[Column("replay_id"), replay_id_hash],
-        orderby=[OrderBy(replay_id_hash, Direction.ASC)],
+        # Group by both the `replay_id` and `cityHash64(replay_id)` so we able
+        # to keep track of the cursor _and_ still get the Replay IDs out. Since
+        # the hash is a function of the ID, this doesn't change the row contents.
+        groupby=[Column("replay_id"), replay_id_hash_column],
+        orderby=[OrderBy(replay_id_hash_column, Direction.ASC)],
         granularity=Granularity(3600),
         limit=Limit(limit),
     )
@@ -198,7 +193,6 @@ def fetch_rows_matching_pattern(
     rows = response.get("data", [])
     has_more = len(rows) == limit
 
-    # Rows are ordered by the hash, so the last row is where the next page seeks from.
     next_cursor = rows[-1]["replay_id_hash"] if rows else None
 
     return {

--- a/src/sentry/replays/usecases/delete.py
+++ b/src/sentry/replays/usecases/delete.py
@@ -163,8 +163,6 @@ def fetch_rows_matching_pattern(
             *where,
         ],
         having=having,
-        # The hash is a function of `replay_id`, so grouping by both leaves cardinality unchanged
-        # while keeping every selected and ordered expression a group key.
         # Group by both the `replay_id` and `cityHash64(replay_id)` so we able
         # to keep track of the cursor _and_ still get the Replay IDs out. Since
         # the hash is a function of the ID, this doesn't change the row contents.

--- a/src/sentry/replays/usecases/delete.py
+++ b/src/sentry/replays/usecases/delete.py
@@ -15,7 +15,6 @@ from snuba_sdk import (
     Function,
     Granularity,
     Limit,
-    Offset,
     Op,
     OrderBy,
     Query,
@@ -114,6 +113,7 @@ class MatchedRow(TypedDict):
 class MatchedRows(TypedDict):
     rows: list[MatchedRow]
     has_more: bool
+    next_cursor: int | None
 
 
 def fetch_rows_matching_pattern(
@@ -123,7 +123,7 @@ def fetch_rows_matching_pattern(
     query: str,
     environment: list[str],
     limit: int,
-    offset: int,
+    after_replay_id_hash: int | None = None,
 ) -> MatchedRows:
     search_filters = parse_search_query(query, config=replay_url_parser_config)
     having = handle_search_filters(agg_search_config, search_filters)
@@ -132,12 +132,35 @@ def fetch_rows_matching_pattern(
     if environment:
         where.append(Condition(Column("environment"), Op.IN, environment))
 
+    # Page by `cityHash64(replay_id)`, the third component of the table's sort key
+    # `(project_id, toStartOfDay(timestamp), cityHash64(replay_id), event_hash)`. Seeking on it lets
+    # ClickHouse prune granules: measured against one project-day, a mid-range cursor halved rows
+    # read (39.3M -> 19.7M). The raw `replay_id` is not in the sort key at all, so a `replay_id >`
+    # cursor read every row in the window and filtered afterwards, and `OFFSET` paging re-aggregated
+    # the whole window on every page. `OFFSET` was also ordered by `min(timestamp)` at hourly
+    # granularity, where ties are dense enough that page boundaries were non-deterministic and rows
+    # could be skipped between pages.
+    replay_id_hash = Function(
+        "cityHash64", parameters=[Column("replay_id")], alias="replay_id_hash"
+    )
+    if after_replay_id_hash is not None:
+        # Unaliased twin: the alias belongs to the SELECT, and this is the form already proven
+        # against this entity elsewhere (see `organization_replay_selector_index`).
+        where.append(
+            Condition(
+                Function("cityHash64", parameters=[Column("replay_id")]),
+                Op.GT,
+                after_replay_id_hash,
+            )
+        )
+
     query = Query(
         match=Entity("replays"),
         select=[
             Function("any", parameters=[Column("retention_days")], alias="retention_days"),
             Column("replay_id"),
             Function("max", parameters=[Column("segment_id")], alias="max_segment_id"),
+            replay_id_hash,
         ],
         where=[
             Condition(Column("project_id"), Op.EQ, project_id),
@@ -148,11 +171,12 @@ def fetch_rows_matching_pattern(
             *where,
         ],
         having=having,
-        groupby=[Column("replay_id")],
-        orderby=[OrderBy(Function("min", parameters=[Column("timestamp")]), Direction.ASC)],
+        # The hash is a function of `replay_id`, so grouping by both leaves cardinality unchanged
+        # while keeping every selected and ordered expression a group key.
+        groupby=[Column("replay_id"), replay_id_hash],
+        orderby=[OrderBy(replay_id_hash, Direction.ASC)],
         granularity=Granularity(3600),
         limit=Limit(limit),
-        offset=Offset(offset),
     )
 
     # Queries are retried for a max for 5 attempts. Retries are exponentially delayed. This is
@@ -174,8 +198,12 @@ def fetch_rows_matching_pattern(
     rows = response.get("data", [])
     has_more = len(rows) == limit
 
+    # Rows are ordered by the hash, so the last row is where the next page seeks from.
+    next_cursor = rows[-1]["replay_id_hash"] if rows else None
+
     return {
         "has_more": has_more,
+        "next_cursor": next_cursor,
         "rows": [
             {
                 "max_segment_id": row["max_segment_id"],

--- a/tests/sentry/replays/endpoints/test_project_replay_jobs_delete.py
+++ b/tests/sentry/replays/endpoints/test_project_replay_jobs_delete.py
@@ -186,7 +186,7 @@ class ProjectReplayDeletionJobsIndexTest(APITestCase):
         assert job.status == "pending"
 
         # Verify task was scheduled
-        mock_task.assert_called_once_with(job.id, offset=0, has_seer_data=False)
+        mock_task.assert_called_once_with(job.id, has_seer_data=False)
 
         with assume_test_silo_mode(SiloMode.CELL):
             CellOutbox(
@@ -460,7 +460,7 @@ class ProjectReplayDeletionJobsIndexTest(APITestCase):
         assert job.project_id == self.project.id
         assert job.status == "pending"
 
-        mock_task.assert_called_once_with(job.id, offset=0, has_seer_data=True)
+        mock_task.assert_called_once_with(job.id, has_seer_data=True)
 
 
 @cell_silo_test

--- a/tests/sentry/replays/tasks/test_delete_replays_bulk.py
+++ b/tests/sentry/replays/tasks/test_delete_replays_bulk.py
@@ -66,10 +66,11 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
                 },
             ],
             "has_more": True,
+            "next_cursor": 5678,
         }
 
         # Run the job
-        run_bulk_replay_delete_job(self.job.id, offset=0)
+        run_bulk_replay_delete_job(self.job.id)
 
         # Verify the job status was updated
         self.job.refresh_from_db()
@@ -89,7 +90,7 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
             query=self.query,
             environment=self.environments,
             limit=100,
-            offset=0,
+            after_replay_id_hash=None,
         )
 
         # Verify metrics were recorded
@@ -129,10 +130,11 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
                 },
             ],
             "has_more": False,
+            "next_cursor": 5678,
         }
 
         # Run the job
-        run_bulk_replay_delete_job(self.job.id, offset=100)
+        run_bulk_replay_delete_job(self.job.id, after_replay_id_hash=100)
 
         # Verify the job status was updated to completed
         self.job.refresh_from_db()
@@ -151,7 +153,7 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
             query=self.query,
             environment=self.environments,
             limit=100,
-            offset=100,
+            after_replay_id_hash=100,
         )
 
         # Verify metrics were recorded
@@ -179,10 +181,11 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
         mock_fetch_rows.return_value = {
             "rows": [],
             "has_more": False,
+            "next_cursor": None,
         }
 
         # Run the job
-        run_bulk_replay_delete_job(self.job.id, offset=0)
+        run_bulk_replay_delete_job(self.job.id)
 
         # Verify the job status was updated to completed
         self.job.refresh_from_db()
@@ -199,7 +202,7 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
             query=self.query,
             environment=self.environments,
             limit=100,
-            offset=0,
+            after_replay_id_hash=None,
         )
 
     def test_run_bulk_replay_delete_job_chained_runs(self) -> None:
@@ -224,7 +227,7 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
         )
 
         with TaskRunner():
-            run_bulk_replay_delete_job.delay(self.job.id, offset=0, limit=1)
+            run_bulk_replay_delete_job.delay(self.job.id, limit=1)
 
         # Runs were chained.
         self.job.refresh_from_db()
@@ -242,7 +245,7 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
         self.job.save()
 
         with TaskRunner():
-            run_bulk_replay_delete_job.delay(self.job.id, offset=0, limit=0)
+            run_bulk_replay_delete_job.delay(self.job.id, limit=0)
 
         # Runs were chained.
         self.job.refresh_from_db()
@@ -251,7 +254,7 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
 
     def test_run_bulk_replay_delete_job_no_matches(self) -> None:
         with TaskRunner():
-            run_bulk_replay_delete_job.delay(self.job.id, offset=0)
+            run_bulk_replay_delete_job.delay(self.job.id)
 
         self.job.refresh_from_db()
         assert self.job.status == "completed"
@@ -266,6 +269,7 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
         mock_fetch_rows.return_value = {
             "rows": [{"retention_days": 90, "replay_id": "a", "max_segment_id": 1}],
             "has_more": True,
+            "next_cursor": 1234,
         }
 
         self.job.status = DeletionJobStatus.IN_PROGRESS
@@ -273,7 +277,7 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
         self.job.save()
 
         with patch.object(run_bulk_replay_delete_job, "delay"):
-            run_bulk_replay_delete_job(self.job.id, offset=100)
+            run_bulk_replay_delete_job(self.job.id, after_replay_id_hash=100)
 
         self.job.refresh_from_db()
         assert self.job.status == "in-progress"
@@ -288,13 +292,14 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
         mock_fetch_rows.return_value = {
             "rows": [{"retention_days": 90, "replay_id": "a", "max_segment_id": 1}],
             "has_more": False,
+            "next_cursor": 1234,
         }
 
         self.job.status = DeletionJobStatus.IN_PROGRESS
         self.job.offset = 100
         self.job.save()
 
-        run_bulk_replay_delete_job(self.job.id, offset=0)
+        run_bulk_replay_delete_job(self.job.id)
 
         self.job.refresh_from_db()
         assert self.job.status == "completed"
@@ -309,6 +314,7 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
         mock_fetch_rows.return_value = {
             "rows": [{"retention_days": 90, "replay_id": "a", "max_segment_id": 1}],
             "has_more": True,
+            "next_cursor": 1234,
         }
 
         self.job.status = DeletionJobStatus.IN_PROGRESS
@@ -319,7 +325,7 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
 
         mock_delete_matched_rows.side_effect = advance_checkpoint
 
-        run_bulk_replay_delete_job(self.job.id, offset=0)
+        run_bulk_replay_delete_job(self.job.id)
 
         self.job.refresh_from_db()
         assert self.job.offset == 500
@@ -343,7 +349,7 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
 
         with patch("sentry.replays.tasks.current_task", return_value=Mock(retries_remaining=2)):
             with pytest.raises(ProcessingDeadlineExceeded):
-                run_bulk_replay_delete_job(self.job.id, offset=0)
+                run_bulk_replay_delete_job(self.job.id)
 
         self.job.refresh_from_db()
         assert self.job.status == "in-progress"
@@ -361,7 +367,7 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
 
         with patch("sentry.replays.tasks.current_task", return_value=Mock(retries_remaining=0)):
             with pytest.raises(ProcessingDeadlineExceeded):
-                run_bulk_replay_delete_job(self.job.id, offset=0)
+                run_bulk_replay_delete_job(self.job.id)
 
         self.job.refresh_from_db()
         assert self.job.status == "failed"
@@ -384,7 +390,7 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
         self.job.save()
 
         with pytest.raises(ValueError):
-            run_bulk_replay_delete_job(self.job.id, offset=200)
+            run_bulk_replay_delete_job(self.job.id, after_replay_id_hash=200)
 
         self.job.refresh_from_db()
         assert self.job.status == "failed"
@@ -404,6 +410,7 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
         mock_fetch_rows.return_value = {
             "rows": [{"retention_days": 90, "replay_id": "a", "max_segment_id": 1}],
             "has_more": True,
+            "next_cursor": 1234,
         }
 
         self.job.status = DeletionJobStatus.IN_PROGRESS
@@ -417,7 +424,7 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
         mock_delete_matched_rows.side_effect = complete_job
 
         with patch.object(run_bulk_replay_delete_job, "delay"):
-            run_bulk_replay_delete_job(self.job.id, offset=0)
+            run_bulk_replay_delete_job(self.job.id)
 
         self.job.refresh_from_db()
         assert self.job.status == "completed"
@@ -439,10 +446,44 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
             query="count_errors:<100",
             environment=["prod"],
             limit=50,
-            offset=0,
+            after_replay_id_hash=None,
         )
         assert len(result["rows"]) == 1
         assert result["rows"][0]["replay_id"] == str(uuid.UUID(replay_id))
+
+    def test_fetch_rows_matching_pattern_keyset_pagination(self) -> None:
+        """Test paging by `cityHash64(replay_id)` returns every replay exactly once.
+
+        Every replay shares one timestamp here, which is the case the previous pagination got wrong:
+        it ordered by `min(timestamp)` at hourly granularity and paged with a growing `OFFSET`, so
+        ties made page boundaries non-deterministic and rows could be skipped or repeated.
+        """
+        timestamp = datetime.datetime.now() - datetime.timedelta(seconds=10)
+        replay_ids = {uuid.uuid4().hex for _ in range(5)}
+        for replay_id in replay_ids:
+            self.store_replays(
+                mock_replay(timestamp, self.project.id, replay_id, segment_id=0, environment="prod")
+            )
+
+        seen: list[str] = []
+        cursor: int | None = None
+        has_more = True
+        while has_more:
+            result = fetch_rows_matching_pattern(
+                self.project.id,
+                timestamp - datetime.timedelta(seconds=10),
+                timestamp + datetime.timedelta(seconds=10),
+                query="",
+                environment=["prod"],
+                limit=2,
+                after_replay_id_hash=cursor,
+            )
+            seen.extend(row["replay_id"] for row in result["rows"])
+            cursor = result["next_cursor"]
+            has_more = result["has_more"]
+
+        assert len(seen) == len(set(seen)), "a replay was returned on more than one page"
+        assert {uuid.UUID(replay_id).hex for replay_id in seen} == replay_ids
 
     def test_delete_matched_rows_deletes_blob(self) -> None:
         """End-to-end: a real blob stored under the stripped key is deleted.
@@ -516,6 +557,7 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
                     },
                 ],
                 "has_more": True,
+                "next_cursor": 1234,
             }
             yield {
                 "rows": [
@@ -526,6 +568,7 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
                     },
                 ],
                 "has_more": False,
+                "next_cursor": 1234,
             }
 
         mock_fetch_rows.side_effect = row_generator()
@@ -535,7 +578,7 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
         mock_make_seer_api_request.return_value = mock_response
 
         with TaskRunner():
-            run_bulk_replay_delete_job.delay(self.job.id, offset=0, limit=2, has_seer_data=True)
+            run_bulk_replay_delete_job.delay(self.job.id, limit=2, has_seer_data=True)
 
         # Runs were chained.
         self.job.refresh_from_db()
@@ -585,22 +628,25 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
             yield {
                 "rows": [{"retention_days": 90, "replay_id": "a", "max_segment_id": 1}],
                 "has_more": False,
+                "next_cursor": 1234,
             }
             # Window 2: range_start + 7 days to range_start + 14 days
             yield {
                 "rows": [{"retention_days": 90, "replay_id": "b", "max_segment_id": 1}],
                 "has_more": False,
+                "next_cursor": 1234,
             }
             # Window 3: range_start + 14 days to range_end
             yield {
                 "rows": [{"retention_days": 90, "replay_id": "c", "max_segment_id": 1}],
                 "has_more": False,
+                "next_cursor": 1234,
             }
 
         mock_fetch_rows.side_effect = row_generator()
 
         with TaskRunner():
-            run_bulk_replay_delete_job.delay(job.id, offset=0, limit=100)
+            run_bulk_replay_delete_job.delay(job.id, limit=100)
 
         job.refresh_from_db()
         assert job.status == "completed"
@@ -649,22 +695,25 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
             yield {
                 "rows": [{"retention_days": 90, "replay_id": "a", "max_segment_id": 1}],
                 "has_more": True,
+                "next_cursor": 1234,
             }
             # Window 1, page 2: no more rows, advance to next window
             yield {
                 "rows": [{"retention_days": 90, "replay_id": "b", "max_segment_id": 1}],
                 "has_more": False,
+                "next_cursor": 1234,
             }
             # Window 2: final window
             yield {
                 "rows": [],
                 "has_more": False,
+                "next_cursor": 1234,
             }
 
         mock_fetch_rows.side_effect = row_generator()
 
         with TaskRunner():
-            run_bulk_replay_delete_job.delay(job.id, offset=0, limit=1)
+            run_bulk_replay_delete_job.delay(job.id, limit=1)
 
         job.refresh_from_db()
         assert job.status == "completed"
@@ -709,6 +758,7 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
                     },
                 ],
                 "has_more": True,
+                "next_cursor": 1234,
             }
             yield {
                 "rows": [
@@ -719,12 +769,13 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
                     },
                 ],
                 "has_more": False,
+                "next_cursor": 1234,
             }
 
         mock_fetch_rows.side_effect = row_generator()
 
         with TaskRunner():
-            run_bulk_replay_delete_job.delay(self.job.id, offset=0, limit=2, has_seer_data=False)
+            run_bulk_replay_delete_job.delay(self.job.id, limit=2, has_seer_data=False)
 
         # Runs were chained.
         self.job.refresh_from_db()

--- a/tests/sentry/replays/tasks/test_delete_replays_bulk.py
+++ b/tests/sentry/replays/tasks/test_delete_replays_bulk.py
@@ -662,15 +662,15 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
         # Window 1
         assert calls[0].kwargs["start"] == range_start
         assert calls[0].kwargs["end"] == range_start + datetime.timedelta(days=7)
-        assert calls[0].kwargs["offset"] == 0
+        assert calls[0].kwargs["after_replay_id_hash"] is None
         # Window 2
         assert calls[1].kwargs["start"] == range_start + datetime.timedelta(days=7)
         assert calls[1].kwargs["end"] == range_start + datetime.timedelta(days=14)
-        assert calls[1].kwargs["offset"] == 0
+        assert calls[1].kwargs["after_replay_id_hash"] is None
         # Window 3
         assert calls[2].kwargs["start"] == range_start + datetime.timedelta(days=14)
         assert calls[2].kwargs["end"] == range_end
-        assert calls[2].kwargs["offset"] == 0
+        assert calls[2].kwargs["after_replay_id_hash"] is None
 
     @patch("sentry.replays.tasks.fetch_rows_matching_pattern")
     @patch("sentry.replays.tasks.delete_matched_rows")
@@ -724,18 +724,18 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
         assert job.range_start == range_start
 
         calls = mock_fetch_rows.call_args_list
-        # Window 1, page 1 — offset 0
+        # Window 1, page 1 — no cursor yet
         assert calls[0].kwargs["start"] == range_start
         assert calls[0].kwargs["end"] == range_start + datetime.timedelta(days=7)
-        assert calls[0].kwargs["offset"] == 0
-        # Window 1, page 2 — offset 1
+        assert calls[0].kwargs["after_replay_id_hash"] is None
+        # Window 1, page 2 — seeks from the cursor page 1 returned
         assert calls[1].kwargs["start"] == range_start
         assert calls[1].kwargs["end"] == range_start + datetime.timedelta(days=7)
-        assert calls[1].kwargs["offset"] == 1
-        # Window 2 — offset reset to 0
+        assert calls[1].kwargs["after_replay_id_hash"] == 1234
+        # Window 2 — cursor reset, because it is a position within a window's result set
         assert calls[2].kwargs["start"] == range_start + datetime.timedelta(days=7)
         assert calls[2].kwargs["end"] == range_end
-        assert calls[2].kwargs["offset"] == 0
+        assert calls[2].kwargs["after_replay_id_hash"] is None
 
     @patch("requests.post")
     @patch("sentry.replays.tasks.fetch_rows_matching_pattern")


### PR DESCRIPTION
We have a Replay bulk delete task (started from the UI) and a Replay bulk delete _job_ (started from GoCD). The _job_ has a clever improvement, it uses the Replay ID as an offset while chunking the deletes. Unfortunately, that doesn't _work_ because Replays IDs are stored in `cityHash64` form so we _must_ query and order and offset by `cityHash64(replay_id)` to allow ClickHouse to skip the granules. The _task_ uses _plain_ `OFFSET` which is even worse actually.

This change will make it _much_ faster to chunk the data while deleting Replays from a big range, by scanning by `cityHash64(replay_id)` in both the job and the task.

There's a lot of duplicated code there to unify, but for now this makes the improvement in two places. Pierre helped me confirm that `cityHash64` scanning actually skips the granules.

N.B. `run_bulk_replay_delete_job` keeps `offset` as an accepted-and-ignored argument so activations enqueued before this deploy still resolve, we can trash that later.

Closes REPLAY-962

