### PR TITLE
ref(replays): Bound the GCS delete pool on the bulk replay delete path

### DIFF
--- a/src/sentry/replays/tasks.py
+++ b/src/sentry/replays/tasks.py
@@ -5,7 +5,6 @@ from datetime import timedelta
 from typing import Any
 
 from django.utils import timezone
-from google.cloud.exceptions import NotFound
 from taskbroker_client.constants import CompressionType
 from taskbroker_client.retry import Retry
 from taskbroker_client.state import current_task
@@ -19,10 +18,11 @@ from sentry.replays.lib.storage import (
     filestore,
     make_recording_filename,
     storage,
-    storage_kv,
 )
 from sentry.replays.models import DeletionJobStatus, ReplayDeletionJobModel, ReplayRecordingSegment
 from sentry.replays.usecases.delete import (
+    DELETE_THREAD_POOL_SIZE,
+    delete_filenames_concurrently,
     delete_matched_rows,
     delete_seer_replay_data,
     fetch_rows_matching_pattern,
@@ -127,7 +127,7 @@ def delete_replays_script_async(
     for segment in segments:
         rrweb_filenames.append(make_recording_filename(segment))
 
-    _delete_filenames_concurrently(rrweb_filenames)
+    delete_filenames_concurrently(rrweb_filenames)
 
     # Backwards compatibility. Should be deleted one day.
     segments_from_django_models = ReplayRecordingSegment.objects.filter(
@@ -171,7 +171,7 @@ def delete_replay_recording(project_id: int, replay_id: str) -> None:
     # Make the threads reuse one client instead of racing to build their own
     if direct_storage_segments:
         storage.initialize_client()
-        max_workers = min(len(direct_storage_segments), _DELETE_THREAD_POOL_SIZE)
+        max_workers = min(len(direct_storage_segments), DELETE_THREAD_POOL_SIZE)
         with ContextPropagatingThreadPoolExecutor(max_workers=max_workers) as pool:
             pool.map(storage.delete, direct_storage_segments)
 
@@ -191,31 +191,6 @@ def archive_replay(project_id: int, replay_id: str) -> None:
     # We publish manually here because we sometimes provide a managed Kafka
     # publisher interface which has its own setup and teardown behavior.
     publish_replay_event(message)
-
-
-def _delete_if_exists(filename: str) -> None:
-    """Delete the blob if it exists or silence the 404."""
-    try:
-        storage_kv.delete(filename)
-    except NotFound:
-        pass
-
-
-#  Keeping this small bounds threads-per-task so `worker_concurrency x N` stays under pod memory limit
-_DELETE_THREAD_POOL_SIZE = 32
-
-
-def _delete_filenames_concurrently(filenames: list[str]) -> None:
-    if not filenames:
-        return
-
-    # Warm the process-global client before the threads start so they reuse it instead of racing to build their own
-    # Mimics the API endpoint's behavior
-    storage_kv.initialize_client()
-
-    max_workers = min(len(filenames), _DELETE_THREAD_POOL_SIZE)
-    with ContextPropagatingThreadPoolExecutor(max_workers=max_workers) as pool:
-        pool.map(_delete_if_exists, filenames)
 
 
 @instrumented_task(

--- a/src/sentry/replays/usecases/delete.py
+++ b/src/sentry/replays/usecases/delete.py
@@ -62,10 +62,7 @@ def delete_matched_rows(project_id: int, rows: list[MatchedRow]) -> int | None:
     if not rows:
         return None
 
-    with ContextPropagatingThreadPoolExecutor(max_workers=100) as pool:
-        filenames = list(_make_recording_filenames(project_id, rows))
-        pool.map(_delete_if_exists, filenames)
-
+    delete_filenames_concurrently(list(_make_recording_filenames(project_id, rows)))
     delete_replays(project_id, [row["replay_id"] for row in rows])
     return None
 
@@ -74,6 +71,23 @@ def delete_replays(project_id: int, replay_ids: list[str]) -> None:
     """Set the archived bit flag to true on each replay."""
     for replay_id in replay_ids:
         publish_replay_event(archive_event(project_id, replay_id))
+
+
+#  Keeping this small bounds threads-per-task so `worker_concurrency x N` stays under pod memory limit
+DELETE_THREAD_POOL_SIZE = 32
+
+
+def delete_filenames_concurrently(filenames: list[str]) -> None:
+    if not filenames:
+        return
+
+    # Warm the process-global client before the threads start so they reuse it instead of racing to
+    # build their own.
+    storage_kv.initialize_client()
+
+    max_workers = min(len(filenames), DELETE_THREAD_POOL_SIZE)
+    with ContextPropagatingThreadPoolExecutor(max_workers=max_workers) as pool:
+        pool.map(_delete_if_exists, filenames)
 
 
 def _delete_if_exists(filename: str) -> None:

--- a/tests/sentry/replays/tasks/test_delete_replays_script_async.py
+++ b/tests/sentry/replays/tasks/test_delete_replays_script_async.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 from unittest.mock import patch
 from uuid import uuid4
 
-from sentry.replays.tasks import _DELETE_THREAD_POOL_SIZE, delete_replays_script_async
+from sentry.replays.tasks import delete_replays_script_async
+from sentry.replays.usecases.delete import DELETE_THREAD_POOL_SIZE
 from sentry.taskworker.namespaces import replays_long_tasks
 from sentry.testutils.cases import TestCase
 
 
 class TestDeleteReplaysScriptAsync(TestCase):
-    @patch("sentry.replays.tasks._delete_if_exists")
+    @patch("sentry.replays.usecases.delete._delete_if_exists")
     def test_deletes_inclusive_of_top_segment(self, mock_delete: object) -> None:
         replay_id = uuid4().hex
 
@@ -25,7 +26,7 @@ class TestDeleteReplaysScriptAsync(TestCase):
         # leave segment 3 (the top segment) behind.
         assert mock_delete.call_count == 4  # type: ignore[attr-defined]
 
-    @patch("sentry.replays.tasks._delete_if_exists")
+    @patch("sentry.replays.usecases.delete._delete_if_exists")
     def test_null_max_segment_id_is_a_no_op(self, mock_delete: object) -> None:
         replay_id = uuid4().hex
 
@@ -42,7 +43,7 @@ class TestDeleteReplaysScriptAsync(TestCase):
         name = "sentry.replays.tasks.delete_recording_async"
         assert replays_long_tasks.contains(name)
 
-    @patch("sentry.replays.tasks.storage_kv")
+    @patch("sentry.replays.usecases.delete.storage_kv")
     def test_storage_client_is_warmed_once_per_task(self, mock_storage_kv: object) -> None:
         replay_id = uuid4().hex
 
@@ -59,8 +60,8 @@ class TestDeleteReplaysScriptAsync(TestCase):
         assert mock_storage_kv.initialize_client.call_count == 1  # type: ignore[attr-defined]
         assert mock_storage_kv.delete.call_count == 4  # type: ignore[attr-defined]
 
-    @patch("sentry.replays.tasks._delete_if_exists")
-    @patch("sentry.replays.tasks.ContextPropagatingThreadPoolExecutor")
+    @patch("sentry.replays.usecases.delete._delete_if_exists")
+    @patch("sentry.replays.usecases.delete.ContextPropagatingThreadPoolExecutor")
     def test_thread_pool_is_bounded_by_segment_count(
         self, mock_pool: object, mock_delete: object
     ) -> None:
@@ -77,8 +78,8 @@ class TestDeleteReplaysScriptAsync(TestCase):
 
         mock_pool.assert_called_once_with(max_workers=1)  # type: ignore[attr-defined]
 
-    @patch("sentry.replays.tasks._delete_if_exists")
-    @patch("sentry.replays.tasks.ContextPropagatingThreadPoolExecutor")
+    @patch("sentry.replays.usecases.delete._delete_if_exists")
+    @patch("sentry.replays.usecases.delete.ContextPropagatingThreadPoolExecutor")
     def test_thread_pool_is_capped_at_the_max(self, mock_pool: object, mock_delete: object) -> None:
         # A replay with more segments than the cap opens at most N threads.
         replay_id = uuid4().hex
@@ -88,7 +89,7 @@ class TestDeleteReplaysScriptAsync(TestCase):
                 retention_days=90,
                 project_id=self.project.id,
                 replay_id=replay_id,
-                max_segment_id=_DELETE_THREAD_POOL_SIZE + 50,
+                max_segment_id=DELETE_THREAD_POOL_SIZE + 50,
             )
 
-        mock_pool.assert_called_once_with(max_workers=_DELETE_THREAD_POOL_SIZE)  # type: ignore[attr-defined]
+        mock_pool.assert_called_once_with(max_workers=DELETE_THREAD_POOL_SIZE)  # type: ignore[attr-defined]


### PR DESCRIPTION
A bit of cleanup here. The GoCD job that deletes Replays limits the pool to 32, which I think is wise. Here I'm doing the same for the UI-started jobs. I'll be adding more error handling in another PR, too.

Closes REPLAY-963
