### PR TITLE
feat(preprod): Block size analysis uploads for single-tenant

### DIFF
--- a/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
+++ b/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import jsonschema
 import orjson
+from django.conf import settings
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -12,6 +13,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
+from sentry.conf.types.sentry_config import SentryMode
 from sentry.debug_files.upload import find_missing_chunks
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.orgauthtoken import is_org_auth_token_auth, update_org_auth_token_last_used
@@ -139,6 +141,12 @@ class ProjectPreprodArtifactAssembleEndpoint(ProjectEndpoint):
         """
         Assembles a preprod artifact (mobile build, etc.) and stores it in the database.
         """
+
+        if settings.SENTRY_MODE == SentryMode.SINGLE_TENANT:
+            return Response(
+                {"detail": "Size analysis uploads are not enabled for this organization."},
+                status=403,
+            )
 
         analytics.record(
             PreprodArtifactApiAssembleEvent(

--- a/tests/sentry/preprod/api/endpoints/test_organization_preprod_artifact_assemble.py
+++ b/tests/sentry/preprod/api/endpoints/test_organization_preprod_artifact_assemble.py
@@ -3,8 +3,10 @@ from unittest.mock import MagicMock, patch
 
 import orjson
 from django.core.files.base import ContentFile
+from django.test import override_settings
 from django.urls import reverse
 
+from sentry.conf.types.sentry_config import SentryMode
 from sentry.constants import ObjectStatus
 from sentry.models.apitoken import ApiToken
 from sentry.models.files.fileblob import FileBlob
@@ -1130,3 +1132,26 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
         )
         assert response.status_code == 403, response.content
         assert response.data["detail"] == "Organization does not have quota for preprod features"
+
+    @override_settings(SENTRY_MODE=SentryMode.SINGLE_TENANT)
+    def test_assemble_single_tenant_returns_403(self) -> None:
+        """Test that endpoint returns 403 for single-tenant deployments."""
+        content = b"test single tenant content"
+        total_checksum = sha1(content).hexdigest()
+
+        blob = FileBlob.from_file(ContentFile(content))
+        FileBlobOwner.objects.get_or_create(organization_id=self.organization.id, blob=blob)
+
+        response = self.client.post(
+            self.url,
+            data={
+                "checksum": total_checksum,
+                "chunks": [blob.checksum],
+            },
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
+        )
+        assert response.status_code == 403, response.content
+        assert (
+            response.data["detail"]
+            == "Size analysis uploads are not enabled for this organization."
+        )


### PR DESCRIPTION
## Summary

Blocks preprod / mobile build uploads on **single-tenant** deployments (e.g. LY, Goldman Sachs, GEICO) while leaving SaaS and self-hosted unaffected.

Single-tenant customers don't have the infrastructure/billing set up for size analysis, so uploads should be rejected with a clear message rather than silently accepted and processed.

## Changes

- At the start of `ProjectPreprodArtifactAssembleEndpoint.post`, return `403` with `{"detail": "Size analysis uploads are not enabled for this organization."}` when `settings.SENTRY_MODE == SentryMode.SINGLE_TENANT`. This mirrors the existing `NoPreprodQuota` 403 already in the endpoint.
- Add `test_assemble_single_tenant_returns_403`, which forces `SENTRY_MODE` to single-tenant via `override_settings`.

## Notes

- **Self-hosted is unaffected** — the guard checks `== SINGLE_TENANT`, not `!= SAAS`.
- No feature flag / config change required; the gate keys off deployment mode. Re-enabling for a specific single-tenant customer would require a code change.

## Test plan

- `pytest tests/sentry/preprod/api/endpoints/test_organization_preprod_artifact_assemble.py` — 63 passed, including the new single-tenant test.