### PR TITLE
fix(search): Reduce recommended sort severity weight

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -850,7 +850,7 @@ register(
 )
 register(
     "snuba.search.recommended.severity-weight",
-    default=0.20,
+    default=0.10,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(


### PR DESCRIPTION
## Summary

Reduce the default Recommended sort severity weight from `0.20` to `0.10`. With severity aggregated across an issue's event distribution, this keeps severity meaningful without weighting it as heavily as recency, recent volume, and event volume. Follow up to https://github.com/getsentry/sentry/pull/121256
