### PR TITLE
chore(slack): Hardcode Seer event dedupe, drop retry diagnostics

### DIFF
--- a/src/sentry/middleware/integrations/parsers/slack.py
+++ b/src/sentry/middleware/integrations/parsers/slack.py
@@ -15,7 +15,6 @@ from rest_framework import status
 from rest_framework.request import Request
 from slack_sdk.errors import SlackApiError
 
-from sentry import options
 from sentry.hybridcloud.outbox.category import WebhookProviderIdentifier
 from sentry.hybridcloud.services.organization_mapping.model import RpcOrganizationMapping
 from sentry.integrations.messaging import commands
@@ -64,9 +63,6 @@ SLACK_WEBHOOK_METRIC_EVENT_TYPES = frozenset(
 
 # Slack retries for ~5 minutes after http_timeout; keep keys long enough to cover that window.
 SEER_SLACK_EVENT_DEDUP_TTL = 60 * 60
-
-# Slack gives us 3 seconds to respond before it considers the delivery failed.
-SLACK_RESPONSE_TIMEOUT_SECONDS = 3
 
 
 class SlackRequestParser(BaseRequestParser):
@@ -338,12 +334,7 @@ class SlackRequestParser(BaseRequestParser):
         cannot be deduped, so they always proceed (and are logged — Slack's
         ``event_callback`` envelope always includes ``event_id``; only
         ``url_verification`` omits it, and that is handled earlier).
-
-        Gated by ``slack.dedupe-seer-webhook-events`` (default off).
         """
-        if not options.get("slack.dedupe-seer-webhook-events"):
-            return True
-
         event_id = slack_request.data.get("event_id")
         log_extra = {
             "integration_id": slack_request.integration.id,
@@ -372,13 +363,10 @@ class SlackRequestParser(BaseRequestParser):
     def _release_seer_slack_event_claim(self, slack_request: SlackEventRequest) -> None:
         """Drop the dedupe claim so a Slack retry can re-schedule routing.
 
-        Only deletes when the claim key would have been written (flag on +
-        event_id present). Call after ``apply_async`` fails — otherwise the
-        TTL window ACKs retries as duplicates and Seer never runs.
+        Only deletes when the claim key would have been written (event_id
+        present). Call after ``apply_async`` fails — otherwise the TTL window
+        ACKs retries as duplicates and Seer never runs.
         """
-        if not options.get("slack.dedupe-seer-webhook-events"):
-            return
-
         event_id = slack_request.data.get("event_id")
         if not event_id:
             return
@@ -430,53 +418,15 @@ class SlackRequestParser(BaseRequestParser):
             sample_rate=1.0,
         )
 
-        if elapsed > SLACK_RESPONSE_TIMEOUT_SECONDS and options.get(
-            "slack.log-webhook-retry-diagnostics"
-        ):
-            slack_event_id = self.slack_request.data.get("event_id") if self.slack_request else None
-            logger.info(
-                "slack.control.response_time_exceeded",
-                extra={
-                    "path": self.request.path,
-                    "url_name": self.match.url_name,
-                    "status_code": status_code,
-                    "event_type": self._get_metric_event_type(),
-                    "slack_event_id": slack_event_id,
-                    "elapsed": elapsed,
-                },
-            )
-
-    def _log_seer_agent_retry_headers(self, status_code: int | str) -> None:
-        if not options.get("slack.log-webhook-retry-diagnostics"):
-            return
-
-        if not self._is_seer_agent_request(self.slack_request):
-            return
-
-        logger.info(
-            "slack.control.webhook_retry_headers",
-            extra={
-                "path": self.request.path,
-                "url_name": self.match.url_name,
-                "status_code": status_code,
-                "event_type": self.slack_request.type,
-                "slack_event_id": self.slack_request.data.get("event_id"),
-                "retry_num": self.request.META.get("HTTP_X_SLACK_RETRY_NUM"),
-                "retry_reason": self.request.META.get("HTTP_X_SLACK_RETRY_REASON"),
-            },
-        )
-
     def get_response(self) -> HttpResponseBase:
         try:
             response = self._get_response()
         except Exception:
             # The final status code is decided further up the stack.
             self._record_response_time("error")
-            self._log_seer_agent_retry_headers("error")
             raise
 
         self._record_response_time(response.status_code)
-        self._log_seer_agent_retry_headers(response.status_code)
 
         return response
 

--- a/tests/sentry/middleware/integrations/parsers/test_slack.py
+++ b/tests/sentry/middleware/integrations/parsers/test_slack.py
@@ -24,7 +24,6 @@ from sentry.integrations.slack.utils.auth import _encode_data
 from sentry.integrations.slack.views import SALT
 from sentry.middleware.integrations.parsers.slack import SlackRequestParser
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.outbox import assert_no_webhook_payloads
 from sentry.testutils.silo import assume_test_silo_mode_of, control_silo_test, create_test_cells
 from sentry.utils import json
@@ -427,7 +426,6 @@ class SlackRequestParserTest(TestCase):
         assert kwargs["payload"]["method"] == "POST"
         assert kwargs["payload"]["path"].startswith("/extensions/slack/event")
 
-    @override_options({"slack.dedupe-seer-webhook-events": True})
     @patch("sentry.middleware.integrations.parsers.slack.route_slack_seer_event.apply_async")
     def test_seer_event_dedupes_by_event_id(self, mock_apply):
         event_id = "EvDEDUP1"
@@ -445,7 +443,6 @@ class SlackRequestParserTest(TestCase):
         assert second.status_code == status.HTTP_200_OK
         mock_apply.assert_called_once()
 
-    @override_options({"slack.dedupe-seer-webhook-events": True})
     @patch("sentry.middleware.integrations.parsers.slack.route_slack_seer_event.apply_async")
     def test_seer_event_releases_claim_on_schedule_failure(self, mock_apply):
         # Claim must not stick if apply_async fails — otherwise Slack retries
@@ -467,21 +464,6 @@ class SlackRequestParserTest(TestCase):
         assert response.status_code == status.HTTP_200_OK
         assert mock_apply.call_count == 2
 
-    @override_options({"slack.dedupe-seer-webhook-events": False})
-    @patch("sentry.middleware.integrations.parsers.slack.route_slack_seer_event.apply_async")
-    def test_seer_event_dedupe_disabled_schedules_duplicates(self, mock_apply):
-        event_id = "EvDEDUP_OFF"
-
-        self._make_parser_with_seer_event(
-            event_type="app_mention", event_id=event_id
-        ).get_response()
-        self._make_parser_with_seer_event(
-            event_type="app_mention", event_id=event_id
-        ).get_response()
-
-        assert mock_apply.call_count == 2
-
-    @override_options({"slack.dedupe-seer-webhook-events": True})
     @patch("sentry.middleware.integrations.parsers.slack.route_slack_seer_event.apply_async")
     def test_seer_event_different_event_ids_are_not_deduped(self, mock_apply):
         self._make_parser_with_seer_event(event_type="app_mention", event_id="EvA").get_response()
@@ -489,7 +471,6 @@ class SlackRequestParserTest(TestCase):
 
         assert mock_apply.call_count == 2
 
-    @override_options({"slack.dedupe-seer-webhook-events": True})
     @patch("sentry.middleware.integrations.parsers.slack.logger")
     @patch("sentry.middleware.integrations.parsers.slack.route_slack_seer_event.apply_async")
     def test_seer_event_missing_event_id_logs_and_schedules(


### PR DESCRIPTION
Seer Slack event_id dedupe has run in production long enough to confirm
duplicate Agent replies are gone, so the cache.add claim path is now
unconditional instead of gated on slack.dedupe-seer-webhook-events.

The diagnostics behind slack.log-webhook-retry-diagnostics served their
purpose (confirming redeliveries came from http_timeout), so the slow
response and x-slack-retry-* header logs are deleted along with the
now-unused SLACK_RESPONSE_TIMEOUT_SECONDS. The response_time metric stays.

Both options stay registered here so this can land while
sentry-options-automator still sets them; the registrations come out in a
follow-up once the automator has stopped writing the keys.

Refs CW-1742, CW-1743