### PR TITLE
chore(slack): Unregister the Slack webhook dedupe and diagnostics options

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -615,10 +615,6 @@ register("slack.debug-workspace", flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("slack.debug-channel", flags=FLAG_AUTOMATOR_MODIFIABLE)
 # Log unfurl payloads for debugging
 register("slack.log-unfurl-payload", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
-# Deduplicate Seer Agent Slack event_callback deliveries by event_id (SET NX)
-register("slack.dedupe-seer-webhook-events", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
-# Log Slack webhook retry headers and slow (>3s) responses for debugging
-register("slack.log-webhook-retry-diagnostics", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 # Frequency of slack nudge blocks on issue alerts (0.0 to 1.0, where 0.3 = 30%)
 register(
     "slack.nudge-frequency",


### PR DESCRIPTION
Both options are unread as of the previous commit, and
sentry-options-automator no longer sets them, so drop the registrations.

Must land AFTER the sentry-options-automator removal is deployed. The
automator runs 'configoptions patch', which treats an unregistered key as
invalid and exits non-zero, so unregistering while app.yaml still sets
these keys breaks every automator run.

Fixes CW-1742, CW-1743