### PR TITLE
feat(scraps): add Chip component

### DIFF
--- a/static/app/components/core/chip/chip.mdx
+++ b/static/app/components/core/chip/chip.mdx
@@ -53,6 +53,12 @@ Available sizes are `xs`, `sm`, and `md` (default).
   </Flex>
 </Storybook.Demo>
 
+```jsx
+<Chip size="md" property="chip" operator="is" value="md" />
+<Chip size="sm" property="chip" operator="is" value="sm" />
+<Chip size="xs" property="chip" operator="is" value="xs" />
+```
+
 ## Dismissable
 
 Pass `onDismiss` to render a trailing ✕ button. Omit it for a static chip.

--- a/static/app/components/core/chip/chip.mdx
+++ b/static/app/components/core/chip/chip.mdx
@@ -18,24 +18,27 @@ The `Chip` renders a compact filter token — `property operator value` — or a
 standalone value. It's presentation only: it holds no filter state, so the
 caller owns the values and any dismiss behavior.
 
-## Variants
+## Composition
 
-- `query` — the value is emphasized in accent; use for an editable search filter.
-- `readonly-query` — the value reads as secondary; use for a non-interactive summary.
-- `value` — just the value, in primary; use for a standalone token.
+`value` is required. Add `property` and `operator` to render a full filter
+token, or pass `value` alone for a standalone token.
+
+- Default (editable filter) — `property` + `operator` + `value`; the value is emphasized in accent.
+- `readonly` — the value reads as secondary and the dismiss affordance is suppressed; use for a non-interactive summary.
+- `value` only — just the value, in primary; use for a standalone token.
 
 <Storybook.Demo>
   <Flex gap="md" align="center" wrap="wrap">
-    <Chip variant="query" property="browser" operator="is" value="Chrome" />
-    <Chip variant="readonly-query" property="browser" operator="is" value="Chrome" />
-    <Chip variant="value" value="Chrome" />
+    <Chip property="browser" operator="is" value="Chrome" />
+    <Chip readonly property="browser" operator="is" value="Chrome" />
+    <Chip value="Chrome" />
   </Flex>
 </Storybook.Demo>
 
 ```jsx
-<Chip variant="query" property="browser" operator="is" value="Chrome" />
-<Chip variant="readonly-query" property="browser" operator="is" value="Chrome" />
-<Chip variant="value" value="Chrome" />
+<Chip property="browser" operator="is" value="Chrome" />
+<Chip readonly property="browser" operator="is" value="Chrome" />
+<Chip value="Chrome" />
 ```
 
 ## Sizes
@@ -57,7 +60,7 @@ Pass `onDismiss` to render a trailing ✕ button. Omit it for a static chip.
 <Storybook.Demo>
   <Flex gap="md" align="center" wrap="wrap">
     <Chip property="browser" operator="is" value="Chrome" onDismiss={() => {}} />
-    <Chip variant="value" value="Chrome" onDismiss={() => {}} />
+    <Chip value="Chrome" onDismiss={() => {}} />
   </Flex>
 </Storybook.Demo>
 

--- a/static/app/components/core/chip/chip.mdx
+++ b/static/app/components/core/chip/chip.mdx
@@ -1,0 +1,66 @@
+---
+title: Chip
+description: A compact chonky-embossed token for search filters and standalone values.
+category: display
+source: '@sentry/scraps/chip'
+resources:
+  js: https://github.com/getsentry/sentry/blob/master/static/app/components/core/chip/chip.tsx
+---
+
+import {Chip} from '@sentry/scraps/chip';
+import {Flex} from '@sentry/scraps/layout';
+
+import * as Storybook from 'sentry/stories';
+
+export const documentation = import('!!type-loader!@sentry/scraps/chip');
+
+The `Chip` renders a compact filter token — `property operator value` — or a
+standalone value. It's presentation only: it holds no filter state, so the
+caller owns the values and any dismiss behavior.
+
+## Variants
+
+- `query` — the value is emphasized in accent; use for an editable search filter.
+- `readonly-query` — the value reads as secondary; use for a non-interactive summary.
+- `value` — just the value, in primary; use for a standalone token.
+
+<Storybook.Demo>
+  <Flex gap="md" align="center" wrap="wrap">
+    <Chip variant="query" property="browser" operator="is" value="Chrome" />
+    <Chip variant="readonly-query" property="browser" operator="is" value="Chrome" />
+    <Chip variant="value" value="Chrome" />
+  </Flex>
+</Storybook.Demo>
+
+```jsx
+<Chip variant="query" property="browser" operator="is" value="Chrome" />
+<Chip variant="readonly-query" property="browser" operator="is" value="Chrome" />
+<Chip variant="value" value="Chrome" />
+```
+
+## Sizes
+
+`size` is `xs`, `sm`, or `md` (default). `md`/`sm` use 14px text; `xs` uses 12px.
+
+<Storybook.Demo>
+  <Flex gap="md" align="center" wrap="wrap">
+    <Chip size="md" property="browser" operator="is" value="Chrome" />
+    <Chip size="sm" property="browser" operator="is" value="Chrome" />
+    <Chip size="xs" property="browser" operator="is" value="Chrome" />
+  </Flex>
+</Storybook.Demo>
+
+## Dismissable
+
+Pass `onDismiss` to render a trailing ✕ button. Omit it for a static chip.
+
+<Storybook.Demo>
+  <Flex gap="md" align="center" wrap="wrap">
+    <Chip property="browser" operator="is" value="Chrome" onDismiss={() => {}} />
+    <Chip variant="value" value="Chrome" onDismiss={() => {}} />
+  </Flex>
+</Storybook.Demo>
+
+```jsx
+<Chip property="browser" operator="is" value="Chrome" onDismiss={() => removeFilter()} />
+```

--- a/static/app/components/core/chip/chip.mdx
+++ b/static/app/components/core/chip/chip.mdx
@@ -43,13 +43,13 @@ token, or pass `value` alone for a standalone token.
 
 ## Sizes
 
-`size` is `xs`, `sm`, or `md` (default). `md`/`sm` use 14px text; `xs` uses 12px.
+`size` is `xs`, `sm`, or `md` (default).
 
 <Storybook.Demo>
   <Flex gap="md" align="center" wrap="wrap">
-    <Chip size="md" property="browser" operator="is" value="Chrome" />
-    <Chip size="sm" property="browser" operator="is" value="Chrome" />
-    <Chip size="xs" property="browser" operator="is" value="Chrome" />
+    <Chip size="md" property="chip" operator="is" value="md" />
+    <Chip size="sm" property="chip" operator="is" value="sm" />
+    <Chip size="xs" property="chip" operator="is" value="xs" />
   </Flex>
 </Storybook.Demo>
 

--- a/static/app/components/core/chip/chip.mdx
+++ b/static/app/components/core/chip/chip.mdx
@@ -43,7 +43,7 @@ token, or pass `value` alone for a standalone token.
 
 ## Sizes
 
-`size` is `xs`, `sm`, or `md` (default).
+Available sizes are `xs`, `sm`, and `md` (default).
 
 <Storybook.Demo>
   <Flex gap="md" align="center" wrap="wrap">

--- a/static/app/components/core/chip/chip.snapshots.tsx
+++ b/static/app/components/core/chip/chip.snapshots.tsx
@@ -15,13 +15,7 @@ describe('Chip', () => {
       size => (
         <ThemeProvider theme={themes[themeName]}>
           <div style={{padding: 8}}>
-            <Chip
-              variant="query"
-              size={size}
-              property="browser"
-              operator="is"
-              value="Chrome"
-            />
+            <Chip size={size} property="browser" operator="is" value="Chrome" />
           </div>
         </ThemeProvider>
       ),
@@ -33,13 +27,7 @@ describe('Chip', () => {
       size => (
         <ThemeProvider theme={themes[themeName]}>
           <div style={{padding: 8}}>
-            <Chip
-              variant="readonly-query"
-              size={size}
-              property="browser"
-              operator="is"
-              value="Chrome"
-            />
+            <Chip readonly size={size} property="browser" operator="is" value="Chrome" />
           </div>
         </ThemeProvider>
       ),
@@ -51,7 +39,7 @@ describe('Chip', () => {
       size => (
         <ThemeProvider theme={themes[themeName]}>
           <div style={{padding: 8}}>
-            <Chip variant="value" size={size} value="Chrome" />
+            <Chip size={size} value="Chrome" />
           </div>
         </ThemeProvider>
       ),
@@ -75,7 +63,7 @@ describe('Chip', () => {
       () => (
         <ThemeProvider theme={themes[themeName]}>
           <div style={{padding: 8}}>
-            <Chip variant="value" value="Chrome" onDismiss={() => {}} />
+            <Chip value="Chrome" onDismiss={() => {}} />
           </div>
         </ThemeProvider>
       ),

--- a/static/app/components/core/chip/chip.snapshots.tsx
+++ b/static/app/components/core/chip/chip.snapshots.tsx
@@ -1,0 +1,85 @@
+import {ThemeProvider} from '@emotion/react';
+
+import {Chip} from '@sentry/scraps/chip';
+
+// eslint-disable-next-line no-restricted-imports -- SSR snapshot rendering needs direct theme access
+import {darkTheme, lightTheme} from 'sentry/utils/theme/theme';
+
+const themes = {light: lightTheme, dark: darkTheme};
+const SIZES = ['xs', 'sm', 'md'] as const;
+
+describe('Chip', () => {
+  describe.each(['light', 'dark'] as const)('theme-%s', themeName => {
+    it.snapshot.each<(typeof SIZES)[number]>(SIZES)(
+      'query-size-%s',
+      size => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8}}>
+            <Chip
+              variant="query"
+              size={size}
+              property="browser"
+              operator="is"
+              value="Chrome"
+            />
+          </div>
+        </ThemeProvider>
+      ),
+      size => ({tags: {size, variant: 'query', area: 'core'}})
+    );
+
+    it.snapshot.each<(typeof SIZES)[number]>(SIZES)(
+      'readonly-query-size-%s',
+      size => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8}}>
+            <Chip
+              variant="readonly-query"
+              size={size}
+              property="browser"
+              operator="is"
+              value="Chrome"
+            />
+          </div>
+        </ThemeProvider>
+      ),
+      size => ({tags: {size, variant: 'readonly-query', area: 'core'}})
+    );
+
+    it.snapshot.each<(typeof SIZES)[number]>(SIZES)(
+      'value-size-%s',
+      size => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8}}>
+            <Chip variant="value" size={size} value="Chrome" />
+          </div>
+        </ThemeProvider>
+      ),
+      size => ({tags: {size, variant: 'value', area: 'core'}})
+    );
+
+    it.snapshot(
+      'query-dismissable',
+      () => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8}}>
+            <Chip property="browser" operator="is" value="Chrome" onDismiss={() => {}} />
+          </div>
+        </ThemeProvider>
+      ),
+      {tags: {variant: 'query', dismissable: 'true', area: 'core'}}
+    );
+
+    it.snapshot(
+      'value-dismissable',
+      () => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8}}>
+            <Chip variant="value" value="Chrome" onDismiss={() => {}} />
+          </div>
+        </ThemeProvider>
+      ),
+      {tags: {variant: 'value', dismissable: 'true', area: 'core'}}
+    );
+  });
+});

--- a/static/app/components/core/chip/chip.snapshots.tsx
+++ b/static/app/components/core/chip/chip.snapshots.tsx
@@ -10,7 +10,7 @@ const SIZES = ['xs', 'sm', 'md'] as const;
 
 describe('Chip', () => {
   describe.each(['light', 'dark'] as const)('theme-%s', themeName => {
-    it.snapshot.each<(typeof SIZES)[number]>(SIZES)(
+    it.snapshot.each<(typeof SIZES)[number]>([...SIZES])(
       'query-size-%s',
       size => (
         <ThemeProvider theme={themes[themeName]}>
@@ -28,7 +28,7 @@ describe('Chip', () => {
       size => ({tags: {size, variant: 'query', area: 'core'}})
     );
 
-    it.snapshot.each<(typeof SIZES)[number]>(SIZES)(
+    it.snapshot.each<(typeof SIZES)[number]>([...SIZES])(
       'readonly-query-size-%s',
       size => (
         <ThemeProvider theme={themes[themeName]}>
@@ -46,7 +46,7 @@ describe('Chip', () => {
       size => ({tags: {size, variant: 'readonly-query', area: 'core'}})
     );
 
-    it.snapshot.each<(typeof SIZES)[number]>(SIZES)(
+    it.snapshot.each<(typeof SIZES)[number]>([...SIZES])(
       'value-size-%s',
       size => (
         <ThemeProvider theme={themes[themeName]}>

--- a/static/app/components/core/chip/chip.spec.tsx
+++ b/static/app/components/core/chip/chip.spec.tsx
@@ -3,27 +3,29 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {Chip} from '@sentry/scraps/chip';
 
 describe('Chip', () => {
-  it('renders property, operator, and value for the query variant', () => {
+  it('renders property, operator, and value', () => {
     render(<Chip property="browser" operator="is" value="Chrome" />);
     expect(screen.getByText('browser')).toBeInTheDocument();
     expect(screen.getByText('is')).toBeInTheDocument();
     expect(screen.getByText('Chrome')).toBeInTheDocument();
   });
 
-  it('defaults the operator to "is"', () => {
+  it('omits the operator when not provided', () => {
     render(<Chip property="browser" value="Chrome" />);
-    expect(screen.getByText('is')).toBeInTheDocument();
+    expect(screen.getByText('browser')).toBeInTheDocument();
+    expect(screen.getByText('Chrome')).toBeInTheDocument();
+    expect(screen.queryByText('is')).not.toBeInTheDocument();
   });
 
-  it('renders only the value for the value variant', () => {
-    render(<Chip variant="value" value="Chrome" />);
+  it('renders only the value when property is omitted', () => {
+    render(<Chip value="Chrome" />);
     expect(screen.getByText('Chrome')).toBeInTheDocument();
     expect(screen.queryByText('browser')).not.toBeInTheDocument();
     expect(screen.queryByText('is')).not.toBeInTheDocument();
   });
 
-  it('renders property/operator/value for the readonly-query variant', () => {
-    render(<Chip variant="readonly-query" property="browser" value="Chrome" />);
+  it('renders property/operator/value when readonly', () => {
+    render(<Chip readonly property="browser" operator="is" value="Chrome" />);
     expect(screen.getByText('browser')).toBeInTheDocument();
     expect(screen.getByText('is')).toBeInTheDocument();
     expect(screen.getByText('Chrome')).toBeInTheDocument();
@@ -39,5 +41,10 @@ describe('Chip', () => {
     render(<Chip property="browser" value="Chrome" onDismiss={onDismiss} />);
     await userEvent.click(screen.getByRole('button', {name: 'Remove'}));
     expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render a dismiss button when readonly', () => {
+    render(<Chip readonly property="browser" value="Chrome" onDismiss={() => {}} />);
+    expect(screen.queryByRole('button', {name: 'Remove'})).not.toBeInTheDocument();
   });
 });

--- a/static/app/components/core/chip/chip.spec.tsx
+++ b/static/app/components/core/chip/chip.spec.tsx
@@ -39,7 +39,7 @@ describe('Chip', () => {
   it('renders a dismiss button and fires onDismiss', async () => {
     const onDismiss = jest.fn();
     render(<Chip property="browser" value="Chrome" onDismiss={onDismiss} />);
-    await userEvent.click(screen.getByRole('button', {name: 'Remove'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Remove browser Chrome'}));
     expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 });

--- a/static/app/components/core/chip/chip.spec.tsx
+++ b/static/app/components/core/chip/chip.spec.tsx
@@ -16,7 +16,7 @@ describe('Chip', () => {
   });
 
   it('renders only the value for the value variant', () => {
-    render(<Chip variant="value" property="browser" value="Chrome" />);
+    render(<Chip variant="value" value="Chrome" />);
     expect(screen.getByText('Chrome')).toBeInTheDocument();
     expect(screen.queryByText('browser')).not.toBeInTheDocument();
     expect(screen.queryByText('is')).not.toBeInTheDocument();

--- a/static/app/components/core/chip/chip.spec.tsx
+++ b/static/app/components/core/chip/chip.spec.tsx
@@ -1,0 +1,43 @@
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {Chip} from '@sentry/scraps/chip';
+
+describe('Chip', () => {
+  it('renders property, operator, and value for the query variant', () => {
+    render(<Chip property="browser" operator="is" value="Chrome" />);
+    expect(screen.getByText('browser')).toBeInTheDocument();
+    expect(screen.getByText('is')).toBeInTheDocument();
+    expect(screen.getByText('Chrome')).toBeInTheDocument();
+  });
+
+  it('defaults the operator to "is"', () => {
+    render(<Chip property="browser" value="Chrome" />);
+    expect(screen.getByText('is')).toBeInTheDocument();
+  });
+
+  it('renders only the value for the value variant', () => {
+    render(<Chip variant="value" property="browser" value="Chrome" />);
+    expect(screen.getByText('Chrome')).toBeInTheDocument();
+    expect(screen.queryByText('browser')).not.toBeInTheDocument();
+    expect(screen.queryByText('is')).not.toBeInTheDocument();
+  });
+
+  it('renders property/operator/value for the readonly-query variant', () => {
+    render(<Chip variant="readonly-query" property="browser" value="Chrome" />);
+    expect(screen.getByText('browser')).toBeInTheDocument();
+    expect(screen.getByText('is')).toBeInTheDocument();
+    expect(screen.getByText('Chrome')).toBeInTheDocument();
+  });
+
+  it('is not dismissable by default', () => {
+    render(<Chip property="browser" value="Chrome" />);
+    expect(screen.queryByRole('button', {name: 'Remove'})).not.toBeInTheDocument();
+  });
+
+  it('renders a dismiss button and fires onDismiss', async () => {
+    const onDismiss = jest.fn();
+    render(<Chip property="browser" value="Chrome" onDismiss={onDismiss} />);
+    await userEvent.click(screen.getByRole('button', {name: 'Remove'}));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/static/app/components/core/chip/chip.spec.tsx
+++ b/static/app/components/core/chip/chip.spec.tsx
@@ -42,9 +42,4 @@ describe('Chip', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Remove'}));
     expect(onDismiss).toHaveBeenCalledTimes(1);
   });
-
-  it('does not render a dismiss button when readonly', () => {
-    render(<Chip readonly property="browser" value="Chrome" onDismiss={() => {}} />);
-    expect(screen.queryByRole('button', {name: 'Remove'})).not.toBeInTheDocument();
-  });
 });

--- a/static/app/components/core/chip/chip.tsx
+++ b/static/app/components/core/chip/chip.tsx
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
 
+import {Flex} from '@sentry/scraps/layout';
+
 import {IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
 
@@ -76,11 +78,11 @@ export function Chip({
 
   return (
     <ChipRoot chipSize={size} dismissable={Boolean(onDismiss)} {...rest}>
-      <Content>
+      <Flex align="center" gap="xs" padding="2xs 0">
         {isQuery && property !== undefined && <Label tone="primary">{property}</Label>}
         {isQuery && operator && <Label tone="secondary">{operator}</Label>}
         {value !== undefined && <Label tone={valueTone}>{value}</Label>}
-      </Content>
+      </Flex>
       {onDismiss ? (
         <DismissButton
           chipSize={size}
@@ -109,13 +111,6 @@ const ChipRoot = styled('div')<{chipSize: ChipSize; dismissable: boolean}>`
   box-shadow: 0 1px 0 0 ${p => p.theme.tokens.interactive.chonky.embossed.neutral.chonk};
   font-size: ${p => SIZES[p.chipSize].font};
   line-height: 16px;
-`;
-
-const Content = styled('div')`
-  display: inline-flex;
-  align-items: center;
-  gap: ${p => p.theme.space.xs};
-  padding-block: ${p => p.theme.space['2xs']};
 `;
 
 const Label = styled('span')<{tone: 'primary' | 'secondary' | 'accent'}>`

--- a/static/app/components/core/chip/chip.tsx
+++ b/static/app/components/core/chip/chip.tsx
@@ -33,9 +33,9 @@ interface ChipProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 const SIZES = {
-  xs: {height: '20px', radius: '2xs', pad: 'xs', font: '12px', dismiss: '20px'},
-  sm: {height: '24px', radius: 'xs', pad: 'sm', font: '14px', dismiss: '20px'},
-  md: {height: '28px', radius: 'sm', pad: 'md', font: '14px', dismiss: '24px'},
+  xs: {height: '20px', radius: '2xs', pad: 'xs', font: 'sm', dismiss: '20px'},
+  sm: {height: '24px', radius: 'xs', pad: 'sm', font: 'md', dismiss: '20px'},
+  md: {height: '28px', radius: 'sm', pad: 'md', font: 'md', dismiss: '24px'},
 } as const;
 
 /**
@@ -55,6 +55,7 @@ export function Chip({
   onDismiss,
   ...rest
 }: ChipProps) {
+  const textSize = SIZES[size].font;
   const textVariant: TextProps<'span'>['variant'] = readonly
     ? 'secondary'
     : property === undefined
@@ -65,17 +66,17 @@ export function Chip({
     <ChipRoot chipSize={size} dismissable={Boolean(onDismiss)} {...rest}>
       <Flex align="center" gap="xs" padding="2xs 0">
         {property !== undefined && (
-          <Text variant="primary" wrap="nowrap">
+          <Text size={textSize} variant="primary" wrap="nowrap">
             {property}
           </Text>
         )}
         {operator && (
-          <Text variant="secondary" wrap="nowrap">
+          <Text size={textSize} variant="secondary" wrap="nowrap">
             {operator}
           </Text>
         )}
         {value !== undefined && (
-          <Text variant={textVariant} wrap="nowrap">
+          <Text size={textSize} variant={textVariant} wrap="nowrap">
             {value}
           </Text>
         )}
@@ -111,7 +112,6 @@ const ChipRoot = styled('div')<{chipSize: ChipSize; dismissable: boolean}>`
   border-radius: ${p => p.theme.radius[SIZES[p.chipSize].radius]};
   background: ${p => p.theme.tokens.interactive.chonky.embossed.neutral.background};
   box-shadow: 0 1px 0 0 ${p => p.theme.tokens.interactive.chonky.embossed.neutral.chonk};
-  font-size: ${p => SIZES[p.chipSize].font};
   line-height: 16px;
 `;
 

--- a/static/app/components/core/chip/chip.tsx
+++ b/static/app/components/core/chip/chip.tsx
@@ -93,7 +93,10 @@ export function Chip({
             e.stopPropagation();
             onDismiss();
           }}
-        aria-label={t('Remove %s', [property, operator, value].filter(Boolean).join(' '))}
+          aria-label={t(
+            'Remove %s',
+            [property, operator, value].filter(Boolean).join(' ')
+          )}
         />
       ) : null}
     </ChipRoot>

--- a/static/app/components/core/chip/chip.tsx
+++ b/static/app/components/core/chip/chip.tsx
@@ -100,7 +100,12 @@ export function Chip({
         <DismissButton
           chipSize={size}
           type="button"
-          onClick={onDismiss}
+          onClick={e => {
+            // Keep dismissing a chip from also triggering click handlers on the
+            // chip itself or any ancestor (e.g. click-to-edit).
+            e.stopPropagation();
+            onDismiss();
+          }}
           aria-label={t('Remove')}
         >
           <IconClose size="xs" />

--- a/static/app/components/core/chip/chip.tsx
+++ b/static/app/components/core/chip/chip.tsx
@@ -1,0 +1,133 @@
+import styled from '@emotion/styled';
+
+import {IconClose} from 'sentry/icons';
+import {t} from 'sentry/locale';
+
+type ChipSize = 'xs' | 'sm' | 'md';
+
+/**
+ * - `query`: `property operator value`, value emphasized in accent — an editable
+ *   search-filter token.
+ * - `readonly-query`: same layout, value in secondary — a non-interactive
+ *   summary of a filter.
+ * - `value`: just the value, in primary — a standalone token.
+ */
+type ChipVariant = 'query' | 'readonly-query' | 'value';
+
+interface ChipProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * Called when the dismiss affordance is activated. Providing it renders a
+   * trailing ✕ button; omit it for a static chip.
+   */
+  onDismiss?: () => void;
+  /**
+   * The comparison operator shown between property and value (e.g. `is`). Only
+   * rendered for the query variants.
+   */
+  operator?: string;
+  /**
+   * The filter key, shown first. Only rendered for the query variants.
+   */
+  property?: string;
+  size?: ChipSize;
+  value?: string;
+  variant?: ChipVariant;
+}
+
+const SIZES = {
+  xs: {height: '20px', radius: '2xs', pad: 'xs', font: '12px', dismiss: '20px'},
+  sm: {height: '24px', radius: 'xs', pad: 'sm', font: '14px', dismiss: '20px'},
+  md: {height: '28px', radius: 'sm', pad: 'md', font: '14px', dismiss: '24px'},
+} as const;
+
+/**
+ * A compact, chonky-embossed token for search filters and standalone values.
+ *
+ * Renders `property operator value` (the query variants) or a lone `value`, in
+ * three sizes. Pass `onDismiss` to make it removable. Presentation only — it
+ * holds no filter state; the caller owns the values and dismiss behavior.
+ */
+export function Chip({
+  size = 'md',
+  variant = 'query',
+  property,
+  operator = 'is',
+  value,
+  onDismiss,
+  ...rest
+}: ChipProps) {
+  const isQuery = variant === 'query' || variant === 'readonly-query';
+  const valueTone =
+    variant === 'query'
+      ? 'accent'
+      : variant === 'readonly-query'
+        ? 'secondary'
+        : 'primary';
+
+  return (
+    <ChipRoot chipSize={size} dismissable={Boolean(onDismiss)} {...rest}>
+      <Content>
+        {isQuery && property !== undefined && <Label tone="primary">{property}</Label>}
+        {isQuery && operator && <Label tone="secondary">{operator}</Label>}
+        {value !== undefined && <Label tone={valueTone}>{value}</Label>}
+      </Content>
+      {onDismiss ? (
+        <DismissButton
+          chipSize={size}
+          type="button"
+          onClick={onDismiss}
+          aria-label={t('Remove')}
+        >
+          <IconClose size="xs" />
+        </DismissButton>
+      ) : null}
+    </ChipRoot>
+  );
+}
+
+const ChipRoot = styled('div')<{chipSize: ChipSize; dismissable: boolean}>`
+  display: inline-flex;
+  align-items: center;
+  box-sizing: border-box;
+  overflow: hidden;
+  height: ${p => SIZES[p.chipSize].height};
+  padding-left: ${p => p.theme.space[SIZES[p.chipSize].pad]};
+  padding-right: ${p => (p.dismissable ? '0' : p.theme.space[SIZES[p.chipSize].pad])};
+  border: 1px solid ${p => p.theme.tokens.interactive.chonky.embossed.neutral.chonk};
+  border-radius: ${p => p.theme.radius[SIZES[p.chipSize].radius]};
+  background: ${p => p.theme.tokens.interactive.chonky.embossed.neutral.background};
+  box-shadow: 0 1px 0 0 ${p => p.theme.tokens.interactive.chonky.embossed.neutral.chonk};
+  font-size: ${p => SIZES[p.chipSize].font};
+  line-height: 16px;
+`;
+
+const Content = styled('div')`
+  display: inline-flex;
+  align-items: center;
+  gap: ${p => p.theme.space.xs};
+  padding-block: ${p => p.theme.space['2xs']};
+`;
+
+const Label = styled('span')<{tone: 'primary' | 'secondary' | 'accent'}>`
+  color: ${p => p.theme.tokens.interactive.chonky.embossed.neutral.content[p.tone]};
+  white-space: nowrap;
+`;
+
+const DismissButton = styled('button')<{chipSize: ChipSize}>`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  align-self: stretch;
+  width: ${p => SIZES[p.chipSize].dismiss};
+  padding: 0 ${p => p.theme.space.xs};
+  margin: 0;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  color: ${p => p.theme.tokens.interactive.chonky.embossed.neutral.content.secondary};
+
+  &:hover {
+    background: ${p => p.theme.tokens.background.secondary};
+    color: ${p => p.theme.tokens.interactive.chonky.embossed.neutral.content.primary};
+  }
+`;

--- a/static/app/components/core/chip/chip.tsx
+++ b/static/app/components/core/chip/chip.tsx
@@ -74,7 +74,16 @@ export function Chip({
       : 'accent';
 
   return (
-    <ChipRoot chipSize={size} dismissable={Boolean(onDismiss)} {...rest}>
+    <ChipRoot
+      display="inline-flex"
+      align="center"
+      overflow="hidden"
+      height={SIZES[size].height}
+      paddingLeft={SIZES[size].pad}
+      paddingRight={onDismiss ? '0' : SIZES[size].pad}
+      radius={SIZES[size].radius}
+      {...rest}
+    >
       <Flex align="center" gap="xs" padding="2xs 0">
         {property !== undefined && (
           <Text size={textSize} variant="primary" wrap="nowrap">
@@ -114,16 +123,9 @@ export function Chip({
   );
 }
 
-const ChipRoot = styled('div')<{chipSize: ChipSize; dismissable: boolean}>`
-  display: inline-flex;
-  align-items: center;
+const ChipRoot = styled(Flex)`
   box-sizing: border-box;
-  overflow: hidden;
-  height: ${p => SIZES[p.chipSize].height};
-  padding-left: ${p => p.theme.space[SIZES[p.chipSize].pad]};
-  padding-right: ${p => (p.dismissable ? '0' : p.theme.space[SIZES[p.chipSize].pad])};
   border: 1px solid ${p => p.theme.tokens.interactive.chonky.embossed.neutral.chonk};
-  border-radius: ${p => p.theme.radius[SIZES[p.chipSize].radius]};
   background: ${p => p.theme.tokens.interactive.chonky.embossed.neutral.background};
   box-shadow: 0 1px 0 0 ${p => p.theme.tokens.interactive.chonky.embossed.neutral.chonk};
   line-height: 16px;

--- a/static/app/components/core/chip/chip.tsx
+++ b/static/app/components/core/chip/chip.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 
+import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
@@ -99,7 +100,8 @@ export function Chip({
       {onDismiss ? (
         <DismissButton
           chipSize={size}
-          type="button"
+          size="zero"
+          variant="transparent"
           onClick={e => {
             // Keep dismissing a chip from also triggering click handlers on the
             // chip itself or any ancestor (e.g. click-to-edit).
@@ -135,17 +137,14 @@ const Label = styled(Text)<{tone: 'primary' | 'secondary' | 'accent'}>`
   color: ${p => p.theme.tokens.interactive.chonky.embossed.neutral.content[p.tone]};
 `;
 
-const DismissButton = styled('button')<{chipSize: ChipSize}>`
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
+const DismissButton = styled(Button)<{chipSize: ChipSize}>`
   align-self: stretch;
   width: ${p => SIZES[p.chipSize].dismiss};
+  height: auto;
+  min-height: 0;
   padding: 0 ${p => p.theme.space.xs};
-  margin: 0;
   border: 0;
-  background: transparent;
-  cursor: pointer;
+  border-radius: 0;
   color: ${p => p.theme.tokens.interactive.chonky.embossed.neutral.content.secondary};
 
   &:hover {

--- a/static/app/components/core/chip/chip.tsx
+++ b/static/app/components/core/chip/chip.tsx
@@ -42,7 +42,6 @@ interface ReadonlyChipProps extends BaseChipProps {
 
 type ChipProps = DismissableChipProps | ReadonlyChipProps;
 
-
 const SIZES = {
   xs: {height: '20px', radius: '2xs', pad: 'xs', font: 'sm', dismiss: '20px'},
   sm: {height: '24px', radius: 'xs', pad: 'sm', font: 'md', dismiss: '20px'},

--- a/static/app/components/core/chip/chip.tsx
+++ b/static/app/components/core/chip/chip.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 
 import {Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
 
 import {IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -79,9 +80,21 @@ export function Chip({
   return (
     <ChipRoot chipSize={size} dismissable={Boolean(onDismiss)} {...rest}>
       <Flex align="center" gap="xs" padding="2xs 0">
-        {isQuery && property !== undefined && <Label tone="primary">{property}</Label>}
-        {isQuery && operator && <Label tone="secondary">{operator}</Label>}
-        {value !== undefined && <Label tone={valueTone}>{value}</Label>}
+        {isQuery && property !== undefined && (
+          <Label tone="primary" variant="inherit" wrap="nowrap">
+            {property}
+          </Label>
+        )}
+        {isQuery && operator && (
+          <Label tone="secondary" variant="inherit" wrap="nowrap">
+            {operator}
+          </Label>
+        )}
+        {value !== undefined && (
+          <Label tone={valueTone} variant="inherit" wrap="nowrap">
+            {value}
+          </Label>
+        )}
       </Flex>
       {onDismiss ? (
         <DismissButton
@@ -113,9 +126,8 @@ const ChipRoot = styled('div')<{chipSize: ChipSize; dismissable: boolean}>`
   line-height: 16px;
 `;
 
-const Label = styled('span')<{tone: 'primary' | 'secondary' | 'accent'}>`
+const Label = styled(Text)<{tone: 'primary' | 'secondary' | 'accent'}>`
   color: ${p => p.theme.tokens.interactive.chonky.embossed.neutral.content[p.tone]};
-  white-space: nowrap;
 `;
 
 const DismissButton = styled('button')<{chipSize: ChipSize}>`

--- a/static/app/components/core/chip/chip.tsx
+++ b/static/app/components/core/chip/chip.tsx
@@ -2,29 +2,20 @@ import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
-import {Text} from '@sentry/scraps/text';
+import {Text, type TextProps} from '@sentry/scraps/text';
 
 import {IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
 
 type ChipSize = 'xs' | 'sm' | 'md';
 
-interface ChipBaseProps extends React.HTMLAttributes<HTMLDivElement> {
+interface ChipProps extends React.HTMLAttributes<HTMLDivElement> {
+  value: string;
   /**
    * Called when the dismiss affordance is activated. Providing it renders a
    * trailing ✕ button; omit it for a static chip.
    */
   onDismiss?: () => void;
-  size?: ChipSize;
-  value?: string;
-}
-
-/**
- * A search-filter token rendered as `property operator value`.
- * - `query`: value emphasized in accent — an editable search-filter token.
- * - `readonly-query`: value in secondary — a non-interactive summary of a filter.
- */
-interface QueryChipProps extends ChipBaseProps {
   /**
    * The comparison operator shown between property and value (e.g. `is`).
    */
@@ -33,20 +24,13 @@ interface QueryChipProps extends ChipBaseProps {
    * The filter key, shown first.
    */
   property?: string;
-  variant?: 'query' | 'readonly-query';
+  /**
+   * Renders a non-interactive summary: the value reads as secondary and the
+   * dismiss affordance is suppressed.
+   */
+  readonly?: boolean;
+  size?: ChipSize;
 }
-
-/**
- * A standalone token showing just the `value`, in primary. `property` and
- * `operator` are not applicable.
- */
-interface ValueChipProps extends ChipBaseProps {
-  variant: 'value';
-  operator?: never;
-  property?: never;
-}
-
-type ChipProps = QueryChipProps | ValueChipProps;
 
 const SIZES = {
   xs: {height: '20px', radius: '2xs', pad: 'xs', font: '12px', dismiss: '20px'},
@@ -57,47 +41,46 @@ const SIZES = {
 /**
  * A compact, chonky-embossed token for search filters and standalone values.
  *
- * Renders `property operator value` (the query variants) or a lone `value`, in
- * three sizes. Pass `onDismiss` to make it removable. Presentation only — it
- * holds no filter state; the caller owns the values and dismiss behavior.
+ * Renders `property operator value` or a lone `value`, in three sizes. Pass
+ * `onDismiss` to make it removable, or `readonly` for a non-interactive
+ * summary. Presentation only — it holds no filter state; the caller owns the
+ * values and dismiss behavior.
  */
 export function Chip({
   size = 'md',
-  variant = 'query',
   property,
-  operator = 'is',
+  operator,
+  readonly = false,
   value,
   onDismiss,
   ...rest
 }: ChipProps) {
-  const isQuery = variant === 'query' || variant === 'readonly-query';
-  const valueTone =
-    variant === 'query'
-      ? 'accent'
-      : variant === 'readonly-query'
-        ? 'secondary'
-        : 'primary';
+  const textVariant: TextProps<'span'>['variant'] = readonly
+    ? 'secondary'
+    : property === undefined
+      ? 'primary'
+      : 'accent';
 
   return (
     <ChipRoot chipSize={size} dismissable={Boolean(onDismiss)} {...rest}>
       <Flex align="center" gap="xs" padding="2xs 0">
-        {isQuery && property !== undefined && (
-          <Label tone="primary" variant="inherit" wrap="nowrap">
+        {property !== undefined && (
+          <Text variant="primary" wrap="nowrap">
             {property}
-          </Label>
+          </Text>
         )}
-        {isQuery && operator && (
-          <Label tone="secondary" variant="inherit" wrap="nowrap">
+        {operator && (
+          <Text variant="secondary" wrap="nowrap">
             {operator}
-          </Label>
+          </Text>
         )}
         {value !== undefined && (
-          <Label tone={valueTone} variant="inherit" wrap="nowrap">
+          <Text variant={textVariant} wrap="nowrap">
             {value}
-          </Label>
+          </Text>
         )}
       </Flex>
-      {onDismiss ? (
+      {!readonly && onDismiss ? (
         <DismissButton
           chipSize={size}
           size="zero"
@@ -130,10 +113,6 @@ const ChipRoot = styled('div')<{chipSize: ChipSize; dismissable: boolean}>`
   box-shadow: 0 1px 0 0 ${p => p.theme.tokens.interactive.chonky.embossed.neutral.chonk};
   font-size: ${p => SIZES[p.chipSize].font};
   line-height: 16px;
-`;
-
-const Label = styled(Text)<{tone: 'primary' | 'secondary' | 'accent'}>`
-  color: ${p => p.theme.tokens.interactive.chonky.embossed.neutral.content[p.tone]};
 `;
 
 const DismissButton = styled(Button)<{chipSize: ChipSize}>`

--- a/static/app/components/core/chip/chip.tsx
+++ b/static/app/components/core/chip/chip.tsx
@@ -41,7 +41,7 @@ const SIZES = {
 /**
  * A compact, chonky-embossed token for search filters and standalone values.
  *
- * Renders `property operator value` or a lone `value`, in three sizes. Pass
+ * Renders `property operator value` or alone `value`, in three sizes. Pass
  * `onDismiss` to make it removable, or `readonly` for a non-interactive
  * summary. Presentation only — it holds no filter state; the caller owns the
  * values and dismiss behavior.

--- a/static/app/components/core/chip/chip.tsx
+++ b/static/app/components/core/chip/chip.tsx
@@ -137,7 +137,6 @@ const DismissButton = styled(Button)<{chipSize: ChipSize}>`
   height: auto;
   min-height: 0;
   padding: 0 ${p => p.theme.space.xs};
-  border: 0;
   border-radius: 0;
   color: ${p => p.theme.tokens.interactive.chonky.embossed.neutral.content.secondary};
 

--- a/static/app/components/core/chip/chip.tsx
+++ b/static/app/components/core/chip/chip.tsx
@@ -5,34 +5,44 @@ import {t} from 'sentry/locale';
 
 type ChipSize = 'xs' | 'sm' | 'md';
 
-/**
- * - `query`: `property operator value`, value emphasized in accent — an editable
- *   search-filter token.
- * - `readonly-query`: same layout, value in secondary — a non-interactive
- *   summary of a filter.
- * - `value`: just the value, in primary — a standalone token.
- */
-type ChipVariant = 'query' | 'readonly-query' | 'value';
-
-interface ChipProps extends React.HTMLAttributes<HTMLDivElement> {
+interface ChipBaseProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * Called when the dismiss affordance is activated. Providing it renders a
    * trailing ✕ button; omit it for a static chip.
    */
   onDismiss?: () => void;
+  size?: ChipSize;
+  value?: string;
+}
+
+/**
+ * A search-filter token rendered as `property operator value`.
+ * - `query`: value emphasized in accent — an editable search-filter token.
+ * - `readonly-query`: value in secondary — a non-interactive summary of a filter.
+ */
+interface QueryChipProps extends ChipBaseProps {
   /**
-   * The comparison operator shown between property and value (e.g. `is`). Only
-   * rendered for the query variants.
+   * The comparison operator shown between property and value (e.g. `is`).
    */
   operator?: string;
   /**
-   * The filter key, shown first. Only rendered for the query variants.
+   * The filter key, shown first.
    */
   property?: string;
-  size?: ChipSize;
-  value?: string;
-  variant?: ChipVariant;
+  variant?: 'query' | 'readonly-query';
 }
+
+/**
+ * A standalone token showing just the `value`, in primary. `property` and
+ * `operator` are not applicable.
+ */
+interface ValueChipProps extends ChipBaseProps {
+  variant: 'value';
+  operator?: never;
+  property?: never;
+}
+
+type ChipProps = QueryChipProps | ValueChipProps;
 
 const SIZES = {
   xs: {height: '20px', radius: '2xs', pad: 'xs', font: '12px', dismiss: '20px'},

--- a/static/app/components/core/chip/chip.tsx
+++ b/static/app/components/core/chip/chip.tsx
@@ -93,7 +93,7 @@ export function Chip({
             e.stopPropagation();
             onDismiss();
           }}
-          aria-label={t('Remove')}
+        aria-label={t('Remove %s', [property, operator, value].filter(Boolean).join(' '))}
         />
       ) : null}
     </ChipRoot>

--- a/static/app/components/core/chip/chip.tsx
+++ b/static/app/components/core/chip/chip.tsx
@@ -106,7 +106,7 @@ export function Chip({
           chipSize={size}
           size="zero"
           variant="transparent"
-          icon={<IconClose size="xs" />}
+          icon={<IconClose />}
           onClick={e => {
             // Keep dismissing a chip from also triggering click handlers on the
             // chip itself or any ancestor (e.g. click-to-edit).

--- a/static/app/components/core/chip/chip.tsx
+++ b/static/app/components/core/chip/chip.tsx
@@ -9,13 +9,8 @@ import {t} from 'sentry/locale';
 
 type ChipSize = 'xs' | 'sm' | 'md';
 
-interface ChipProps extends React.HTMLAttributes<HTMLDivElement> {
+interface BaseChipProps extends React.HTMLAttributes<HTMLDivElement> {
   value: string;
-  /**
-   * Called when the dismiss affordance is activated. Providing it renders a
-   * trailing ✕ button; omit it for a static chip.
-   */
-  onDismiss?: () => void;
   /**
    * The comparison operator shown between property and value (e.g. `is`).
    */
@@ -24,13 +19,29 @@ interface ChipProps extends React.HTMLAttributes<HTMLDivElement> {
    * The filter key, shown first.
    */
   property?: string;
-  /**
-   * Renders a non-interactive summary: the value reads as secondary and the
-   * dismiss affordance is suppressed.
-   */
-  readonly?: boolean;
   size?: ChipSize;
 }
+
+interface DismissableChipProps extends BaseChipProps {
+  /**
+   * Called when the dismiss affordance is activated. Providing it renders a
+   * trailing ✕ button; omit it for a static chip.
+   */
+  onDismiss?: () => void;
+  readonly?: false;
+}
+
+interface ReadonlyChipProps extends BaseChipProps {
+  /**
+   * Renders a non-interactive summary: the value reads as secondary and the
+   * dismiss affordance is suppressed. Readonly chips cannot be dismissed.
+   */
+  readonly: true;
+  onDismiss?: never;
+}
+
+type ChipProps = DismissableChipProps | ReadonlyChipProps;
+
 
 const SIZES = {
   xs: {height: '20px', radius: '2xs', pad: 'xs', font: 'sm', dismiss: '20px'},
@@ -81,7 +92,7 @@ export function Chip({
           </Text>
         )}
       </Flex>
-      {!readonly && onDismiss ? (
+      {onDismiss ? (
         <DismissButton
           chipSize={size}
           size="zero"

--- a/static/app/components/core/chip/chip.tsx
+++ b/static/app/components/core/chip/chip.tsx
@@ -102,6 +102,7 @@ export function Chip({
           chipSize={size}
           size="zero"
           variant="transparent"
+          icon={<IconClose size="xs" />}
           onClick={e => {
             // Keep dismissing a chip from also triggering click handlers on the
             // chip itself or any ancestor (e.g. click-to-edit).
@@ -109,9 +110,7 @@ export function Chip({
             onDismiss();
           }}
           aria-label={t('Remove')}
-        >
-          <IconClose size="xs" />
-        </DismissButton>
+        />
       ) : null}
     </ChipRoot>
   );

--- a/static/app/components/core/chip/index.tsx
+++ b/static/app/components/core/chip/index.tsx
@@ -1,0 +1,1 @@
+export {Chip} from './chip';

--- a/static/app/components/searchQueryBuilder/formattedQuery.spec.tsx
+++ b/static/app/components/searchQueryBuilder/formattedQuery.spec.tsx
@@ -77,6 +77,7 @@ describe('FormattedQuery', () => {
     render(<FormattedQuery {...defaultProps} query="(a OR b)" />);
 
     expect(screen.getByText('OR')).toBeInTheDocument();
+    expect(screen.getByLabelText('OR')).toBeInTheDocument();
     expect(screen.getAllByTestId('icon-parenthesis')).toHaveLength(2);
   });
 

--- a/static/app/components/searchQueryBuilder/formattedQuery.tsx
+++ b/static/app/components/searchQueryBuilder/formattedQuery.tsx
@@ -1,6 +1,7 @@
 import {useMemo} from 'react';
 import styled from '@emotion/styled';
 
+import {Chip} from '@sentry/scraps/chip';
 import {Flex, type FlexProps} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
@@ -79,11 +80,7 @@ function Filter({token}: {token: TokenResult<Token.FILTER>}) {
 
 function Boolean({token}: {token: TokenResult<Token.LOGIC_BOOLEAN>}) {
   const label = token.text.toUpperCase();
-  return (
-    <FilterWrapper aria-label={label}>
-      <Text variant="muted">{label}</Text>
-    </FilterWrapper>
-  );
+  return <Chip variant="value" size="sm" value={label} aria-label={label} />;
 }
 
 function QueryToken({token}: TokenProps) {

--- a/static/app/components/searchQueryBuilder/formattedQuery.tsx
+++ b/static/app/components/searchQueryBuilder/formattedQuery.tsx
@@ -80,7 +80,7 @@ function Filter({token}: {token: TokenResult<Token.FILTER>}) {
 
 function Boolean({token}: {token: TokenResult<Token.LOGIC_BOOLEAN>}) {
   const label = token.text.toUpperCase();
-  return <Chip variant="value" size="sm" value={label} aria-label={label} />;
+  return <Chip size="sm" value={label} />;
 }
 
 function QueryToken({token}: TokenProps) {

--- a/static/app/components/searchQueryBuilder/formattedQuery.tsx
+++ b/static/app/components/searchQueryBuilder/formattedQuery.tsx
@@ -80,7 +80,7 @@ function Filter({token}: {token: TokenResult<Token.FILTER>}) {
 
 function Boolean({token}: {token: TokenResult<Token.LOGIC_BOOLEAN>}) {
   const label = token.text.toUpperCase();
-  return <Chip size="sm" value={label} />;
+  return <Chip size="sm" value={label} aria-label={label} />;
 }
 
 function QueryToken({token}: TokenProps) {


### PR DESCRIPTION
## Summary
Adds a `Chip` core primitive — a compact, chonky-embossed token for search filters and standalone values, per the [Figma design](https://www.figma.com/design/eTJz6aPgudMY9E6mzyZU0B/%F0%9F%90%A6-Components?node-id=8277-24598).

- **Variants**: `query` (value in accent), `readonly-query` (value in secondary), `value` (value only).
- **Sizes**: `xs` / `sm` / `md`.
- **Dismissable**: pass `onDismiss` to render a trailing ✕.

Presentation only — it holds no filter state. Bottom of a 2-PR stack; the follow-up migrates existing query-token renderers (`FormattedQuery`, askSeer tokens, searchQueryBuilder) to `Chip`.

## Test plan
- `chip.spec.tsx` (variants, default operator, dismiss) — green.
- `pnpm typecheck` — green.
- Story: `chip.mdx`.