### PR TITLE
fix(gdd): More efficient heal_stale_derived_data

### DIFF
--- a/src/sentry/issues/derived/tasks.py
+++ b/src/sentry/issues/derived/tasks.py
@@ -6,7 +6,7 @@ from collections.abc import Sequence
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Literal, NamedTuple
 
-from django.db.models import Exists, OuterRef
+from django.db.models import Exists, OuterRef, Q
 
 from sentry.silo.base import SiloMode
 
@@ -26,12 +26,19 @@ BATCH_RETRIGGER_TIMEOUT = timedelta(seconds=20)  # self-reschedule before the ha
 
 _GENERATE_PROJECT_TASK_KEY = "generate_project_derived_data"
 _GENERATE_BATCH_TASK_KEY = "generate_project_derived_data_batch"
+_REGENERATE_STALE_BATCH_TASK_KEY = "regenerate_stale_derived_data_batch"
 _GENERATE_GROUP_TASK_KEY = "generate_group_derived_data"
 
 # Cap self-rescheduling rebuilds to avoid infinite loops on very large groups.
 _MAX_GENERATION_RUNS = 20
 # Maximum group IDs loaded by one project-level task invocation.
 _MAX_PROJECT_GROUPS = 10_000
+# Hard cap on distinct stale pipeline hashes handled per heal invocation.
+# In practice we expect a handful at most; truncating still makes progress.
+_MAX_STALE_HASHES = 5
+# Hard cap on stale group IDs loaded per heal invocation, across all
+# stale hashes combined. The task runs every 15 minutes; overflow waits.
+_MAX_STALE_GROUPS = 10_000
 
 
 def _stale_pipeline_filter(qs: BaseQuerySet[Group], pipeline_hash: str) -> BaseQuerySet[Group]:
@@ -157,6 +164,28 @@ def _record_batch_metrics(
         metrics.incr(metric_name, amount=count, sample_rate=1.0, tags=tags)
 
 
+def _resume_generation_id(
+    group_id: int,
+    resume_generated_at: str | None,
+    resume_pipeline_hash: str | None,
+) -> GenerationId | None:
+    """Reconstruct a ``GenerationId`` from resume kwargs, or ``None`` if either is missing.
+
+    Tasks accept ``resume_generated_at`` / ``resume_pipeline_hash`` as separate
+    scalars (rather than a single ``GenerationId``) because tasks serialize
+    kwargs as JSON. This helper re-hydrates them at task entry.
+    """
+    from sentry.issues.derived.processing import GenerationId
+
+    if resume_generated_at is None or resume_pipeline_hash is None:
+        return None
+    return GenerationId(
+        group_id,
+        datetime.fromisoformat(resume_generated_at).replace(tzinfo=timezone.utc),
+        resume_pipeline_hash,
+    )
+
+
 @instrumented_task(
     name="sentry.issues.derived.tasks.process_group_log_task",
     namespace=issues_tasks,
@@ -194,7 +223,6 @@ def generate_group_derived_data(
     from taskbroker_client.state import current_task
 
     from sentry.issues.derived.processing import (
-        GenerationId,
         GroupLogTimeout,
         PromotionFailed,
         build_and_promote_derived_data,
@@ -215,13 +243,7 @@ def generate_group_derived_data(
         )
         return
 
-    generation_id: GenerationId | None = None
-    if resume_generated_at is not None and resume_pipeline_hash is not None:
-        generation_id = GenerationId(
-            group_id,
-            datetime.fromisoformat(resume_generated_at).replace(tzinfo=timezone.utc),
-            resume_pipeline_hash,
-        )
+    generation_id = _resume_generation_id(group_id, resume_generated_at, resume_pipeline_hash)
 
     try:
         build_and_promote_derived_data(
@@ -381,10 +403,7 @@ def generate_project_derived_data_batch(
     """
     from taskbroker_client.state import current_task
 
-    from sentry.issues.derived.processing import (
-        PIPELINE,
-        GenerationId,
-    )
+    from sentry.issues.derived.processing import PIPELINE
     from sentry.models.group import Group
     from sentry.taskworker.selfchain_idempotency import already_spawned, mark_spawned
 
@@ -402,13 +421,7 @@ def generate_project_derived_data_batch(
         return
 
     # Reconstruct generation_id for resuming the first group from cache.
-    generation_id: GenerationId | None = None
-    if resume_generated_at is not None and resume_pipeline_hash is not None:
-        generation_id = GenerationId(
-            group_id_start,
-            datetime.fromisoformat(resume_generated_at).replace(tzinfo=timezone.utc),
-            resume_pipeline_hash,
-        )
+    generation_id = _resume_generation_id(group_id_start, resume_generated_at, resume_pipeline_hash)
 
     start = time.monotonic()
 
@@ -473,20 +486,39 @@ def generate_project_derived_data_batch(
 # ---------------------------------------------------------------------------
 
 
+def _discover_stale_pipeline_hashes(current_hash: str, limit: int) -> list[str]:
+    """Return up to ``limit`` distinct non-null GroupDerivedData ``pipeline_hash`` values that aren't ``current_hash``.
+    NULL is always stale, so we don't bother finding it here.
+    """
+    from sentry.issues.models.groupderiveddata import GroupDerivedData
+
+    stale = Q(pipeline_hash__gt=current_hash) | Q(pipeline_hash__lt=current_hash)
+    # Type is `str | None` from the column, but the filter excludes NULL.
+    return [
+        h
+        for h in GroupDerivedData.objects.filter(stale)
+        .order_by("pipeline_hash")
+        .values_list("pipeline_hash", flat=True)
+        .distinct()[:limit]
+        if h is not None
+    ]
+
+
+def _stale_hash_filter(pipeline_hashes: Sequence[str]) -> Q:
+    """Q filter matching GroupDerivedData rows whose ``pipeline_hash`` is NULL or in ``pipeline_hashes``."""
+    stale = Q(pipeline_hash__isnull=True)
+    if pipeline_hashes:
+        stale |= Q(pipeline_hash__in=list(pipeline_hashes))
+    return stale
+
+
 @instrumented_task(
     name="sentry.issues.derived.tasks.heal_stale_derived_data",
     namespace=issues_tasks,
     silo_mode=SiloMode.CELL,
 )
 def heal_stale_derived_data(**kwargs: object) -> None:
-    """Find projects with stale GroupDerivedData and rebuild them.
-
-    Stale means having a ``GroupDerivedData`` row whose ``pipeline_hash``
-    is NULL or doesn't match the current pipeline.
-
-    Schedules ``generate_project_derived_data(stale_only=True)`` for up
-    to N projects, which replaces rows via CAS without deleting them.
-    """
+    """Rebuild a chunk of GroupDerivedData rows whose ``pipeline_hash`` is stale/NULL."""
     from sentry import options
     from sentry.issues.derived.processing import PIPELINE
     from sentry.issues.models.groupderiveddata import GroupDerivedData
@@ -495,26 +527,139 @@ def heal_stale_derived_data(**kwargs: object) -> None:
         logger.info("heal_stale_derived_data.disabled")
         return
 
-    limit = options.get("issues.derived.heal-project-limit")
+    batch_size = options.get("issues.derived.heal-batch-size")
+    max_tasks = options.get("issues.derived.heal-max-tasks")
     current_hash = PIPELINE.pipeline_hash
 
-    project_ids = list(
-        GroupDerivedData.objects.exclude(pipeline_hash=current_hash)
-        .values_list("group__project_id", flat=True)
-        .distinct()[:limit]
-    )
+    # We fetch known stale hashes and match on those for better index usage.
+    # Querying for rows that aren't the fresh hash ends up being a full index scan,
+    # whereas providing positive examples to match lets us do more efficient btree walking.
+    stale_hashes = _discover_stale_pipeline_hashes(current_hash, _MAX_STALE_HASHES)
 
-    if not project_ids:
+    group_ids = list(
+        GroupDerivedData.objects.filter(_stale_hash_filter(stale_hashes))
+        .order_by("group_id")
+        .values_list("group_id", flat=True)[:_MAX_STALE_GROUPS]
+    )
+    if not group_ids:
         logger.info("heal_stale_derived_data.nothing_to_heal")
         return
 
-    for project_id in project_ids:
-        generate_project_derived_data.delay(project_id=project_id, stale_only=True)
+    ranges = _chunk_group_ids_into_ranges(group_ids, batch_size)[:max_tasks]
+
+    for start, end in ranges:
+        regenerate_stale_derived_data_batch.delay(
+            stale_pipeline_hashes=stale_hashes,
+            group_id_start=start,
+            group_id_end=end,
+        )
 
     logger.info(
         "heal_stale_derived_data.scheduled",
         extra={
-            "project_count": len(project_ids),
+            "stale_hashes": stale_hashes,
+            "task_count": len(ranges),
+            "group_count": len(group_ids),
             "pipeline_hash": current_hash,
+        },
+    )
+
+
+@instrumented_task(
+    name="sentry.issues.derived.tasks.regenerate_stale_derived_data_batch",
+    namespace=issues_tasks,
+    silo_mode=SiloMode.CELL,
+    processing_deadline_duration=int(BATCH_PROCESSING_DEADLINE.total_seconds()),
+)
+def regenerate_stale_derived_data_batch(
+    stale_pipeline_hashes: list[str],
+    group_id_start: int,
+    group_id_end: int,
+    resume_generated_at: str | None = None,
+    resume_pipeline_hash: str | None = None,
+    **kwargs: object,
+) -> None:
+    """Rebuild GroupDerivedData rows in ``[group_id_start, group_id_end)`` whose ``pipeline_hash`` is NULL or in ``stale_pipeline_hashes``.
+
+    Rows that have raced to the current hash are filtered out naturally.
+    Reschedules the remaining range on batch or per-group timeout.
+    """
+    from taskbroker_client.state import current_task
+
+    from sentry.issues.models.groupderiveddata import GroupDerivedData
+    from sentry.taskworker.selfchain_idempotency import already_spawned, mark_spawned
+
+    task_state = current_task()
+    activation_id = task_state.id if task_state else None
+    if activation_id and already_spawned(_REGENERATE_STALE_BATCH_TASK_KEY, activation_id):
+        logger.info(
+            "regenerate_stale_derived_data_batch.duplicate_skipped",
+            extra={
+                "stale_pipeline_hashes": stale_pipeline_hashes,
+                "activation_id": activation_id,
+            },
+        )
+        metrics.incr(
+            "taskworker.selfchain.duplicate_skipped",
+            tags={"task": _REGENERATE_STALE_BATCH_TASK_KEY},
+        )
+        return
+
+    # Reconstruct generation_id for resuming the first group from cache.
+    generation_id = _resume_generation_id(group_id_start, resume_generated_at, resume_pipeline_hash)
+
+    start = time.monotonic()
+
+    group_ids = list(
+        GroupDerivedData.objects.filter(
+            _stale_hash_filter(stale_pipeline_hashes),
+            group_id__gte=group_id_start,
+            group_id__lt=group_id_end,
+        )
+        .order_by("group_id")
+        .values_list("group_id", flat=True)
+    )
+
+    result = _run_build_and_promote_batch(
+        group_ids,
+        timeout=BATCH_RETRIGGER_TIMEOUT,
+        initial_generation_id=generation_id,
+        log_key="regenerate_stale_derived_data_batch",
+    )
+
+    rescheduled = False
+    if result.timeout_reason is not None:
+        rescheduled = True
+        metrics.incr(
+            "issues.derived.regenerate_stale_batch_rescheduled",
+            sample_rate=1.0,
+            tags={"reason": result.timeout_reason},
+        )
+        assert result.resume_from_group_id is not None
+        gen_id = result.resume_generation_id
+        regenerate_stale_derived_data_batch.delay(
+            stale_pipeline_hashes=stale_pipeline_hashes,
+            group_id_start=result.resume_from_group_id,
+            group_id_end=group_id_end,
+            resume_generated_at=gen_id.generated_at.isoformat() if gen_id else None,
+            resume_pipeline_hash=gen_id.pipeline_hash if gen_id else None,
+        )
+        if activation_id:
+            mark_spawned(_REGENERATE_STALE_BATCH_TASK_KEY, activation_id)
+
+    _record_batch_metrics(
+        result.processed,
+        metric_name="issues.derived.regenerate_stale_groups_processed",
+    )
+    logger.info(
+        "regenerate_stale_derived_data_batch.complete",
+        extra={
+            "stale_pipeline_hashes": stale_pipeline_hashes,
+            "group_id_start": group_id_start,
+            "group_id_end": group_id_end,
+            "processed": {r.value: c for r, c in result.processed.items()},
+            "total": len(group_ids),
+            "rescheduled": rescheduled,
+            "elapsed": time.monotonic() - start,
         },
     )

--- a/src/sentry/issues/derived/tasks.py
+++ b/src/sentry/issues/derived/tasks.py
@@ -491,17 +491,27 @@ def _discover_stale_pipeline_hashes(current_hash: str, limit: int) -> list[str]:
     NULL is always stale, so we don't bother finding it here.
     """
     from sentry.issues.models.groupderiveddata import GroupDerivedData
+    # A simple select distinct works here, but Postgres isn't (yet?) smart enough to
+    # do it without O(stale rows) work. So instead, we just loop through the pipeline
+    # hashes in the table, doing one very fast btree lookup each, and ignore the current
+    # one. len(unique hashes) should always be single-digit in practice, so this should
+    # always be fast. We could also do a recursive query to avoid some roundtrips; this is
+    # just less exotic.
 
-    stale = Q(pipeline_hash__gt=current_hash) | Q(pipeline_hash__lt=current_hash)
-    # Type is `str | None` from the column, but the filter excludes NULL.
-    return [
-        h
-        for h in GroupDerivedData.objects.filter(stale)
-        .order_by("pipeline_hash")
-        .values_list("pipeline_hash", flat=True)
-        .distinct()[:limit]
-        if h is not None
-    ]
+    results: list[str] = []
+    cursor = ""
+    while len(results) < limit:
+        cursor = (
+            GroupDerivedData.objects.filter(pipeline_hash__gt=cursor)
+            .order_by("pipeline_hash")
+            .values_list("pipeline_hash", flat=True)
+            .first()
+        )
+        if cursor is None:
+            break
+        if cursor != current_hash:
+            results.append(cursor)
+    return results
 
 
 def _stale_hash_filter(pipeline_hashes: Sequence[str]) -> Q:

--- a/src/sentry/issues/derived/tasks.py
+++ b/src/sentry/issues/derived/tasks.py
@@ -499,7 +499,7 @@ def _discover_stale_pipeline_hashes(current_hash: str, limit: int) -> list[str]:
     # just less exotic.
 
     results: list[str] = []
-    cursor = ""
+    cursor: str | None = ""
     while len(results) < limit:
         cursor = (
             GroupDerivedData.objects.filter(pipeline_hash__gt=cursor)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -4084,18 +4084,26 @@ register(
     type=Int,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
-# Number of projects to schedule for reprocessing per heal_stale_derived_data invocation.
-register(
-    "issues.derived.heal-project-limit",
-    default=3,
-    type=Int,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 # Kill switch for heal_stale_derived_data task.
 register(
     "issues.derived.heal-enabled",
     default=True,
     type=Bool,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+# Number of groups per batch task when fanning out heal_stale_derived_data.
+register(
+    "issues.derived.heal-batch-size",
+    default=500,
+    type=Int,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+# Maximum number of batch tasks a single heal_stale_derived_data invocation
+# may schedule. Overflow waits for the next invocation.
+register(
+    "issues.derived.heal-max-tasks",
+    default=100,
+    type=Int,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 

--- a/tests/sentry/issues/derived/test_tasks.py
+++ b/tests/sentry/issues/derived/test_tasks.py
@@ -3,11 +3,13 @@ from unittest.mock import patch
 
 from sentry.issues.action_log.publish import publish_action
 from sentry.issues.action_log.types import ActionSource, GroupActionActor, ViewAction
-from sentry.issues.derived.processing import process_group_log
+from sentry.issues.derived.processing import PIPELINE, GroupLogTimeout, process_group_log
 from sentry.issues.derived.tasks import (
+    BATCH_RETRIGGER_TIMEOUT,
     generate_project_derived_data,
     generate_project_derived_data_batch,
     heal_stale_derived_data,
+    regenerate_stale_derived_data_batch,
 )
 from sentry.issues.models.groupderiveddata import GroupDerivedData
 from sentry.models.group import Group
@@ -227,27 +229,35 @@ class GenerateProjectDerivedDataPaginationTest(DerivedDataTaskTestBase):
 
 @with_feature("projects:issue-action-log-write-to-db")
 class HealStaleDerivedDataTest(DerivedDataTaskTestBase):
-    def test_finds_stale_projects_and_schedules(self) -> None:
+    def _pick_stale_hash(self, seed: str = "0") -> str:
+        h = seed * 16
+        return h if PIPELINE.pipeline_hash != h else ("z" * 16)
+
+    def test_finds_stale_groups_and_schedules_batch(self) -> None:
         groups = self.create_unprocessed_groups(2)
         group_ids = sorted(g.id for g in groups)
 
         for gid in group_ids:
             process_group_log(gid)
 
-        # Make one group stale
-        GroupDerivedData.objects.filter(group_id=group_ids[0]).update(pipeline_hash="stale")
+        stale = self._pick_stale_hash()
+        GroupDerivedData.objects.filter(group_id=group_ids[0]).update(pipeline_hash=stale)
 
-        with patch.object(generate_project_derived_data, "delay") as mock_delay:
+        with patch.object(regenerate_stale_derived_data_batch, "delay") as mock_delay:
             heal_stale_derived_data()
 
-        mock_delay.assert_called_once_with(project_id=self.project.id, stale_only=True)
+        mock_delay.assert_called_once_with(
+            stale_pipeline_hashes=[stale],
+            group_id_start=group_ids[0],
+            group_id_end=group_ids[0] + 1,
+        )
 
     def test_no_stale_data(self) -> None:
         groups = self.create_unprocessed_groups(2)
         for g in groups:
             process_group_log(g.id)
 
-        with patch.object(generate_project_derived_data, "delay") as mock_delay:
+        with patch.object(regenerate_stale_derived_data_batch, "delay") as mock_delay:
             heal_stale_derived_data()
 
         mock_delay.assert_not_called()
@@ -255,45 +265,190 @@ class HealStaleDerivedDataTest(DerivedDataTaskTestBase):
     def test_respects_killswitch(self) -> None:
         groups = self.create_unprocessed_groups(1)
         process_group_log(groups[0].id)
-        GroupDerivedData.objects.filter(group_id=groups[0].id).update(pipeline_hash="stale")
+        GroupDerivedData.objects.filter(group_id=groups[0].id).update(
+            pipeline_hash=self._pick_stale_hash()
+        )
 
         with (
             override_options({"issues.derived.heal-enabled": False}),
-            patch.object(generate_project_derived_data, "delay") as mock_delay,
+            patch.object(regenerate_stale_derived_data_batch, "delay") as mock_delay,
         ):
             heal_stale_derived_data()
 
         mock_delay.assert_not_called()
 
-    def test_respects_project_limit(self) -> None:
-        projects = [self.create_project(organization=self.organization) for _ in range(3)]
-        for proj in projects:
-            group = self.create_group(project=proj)
-            with outbox_runner():
-                publish_action(
-                    ViewAction(),
-                    source=ActionSource.API,
-                    group_id=group.id,
-                    project=proj,
-                    actor=GroupActionActor.user(self.user.id),
-                )
-            # Stamp with stale hash
-            GroupDerivedData.objects.filter(group_id=group.id).update(pipeline_hash="stale")
+    def test_dispatches_all_stale_hashes_in_one_batch_range(self) -> None:
+        groups = self.create_unprocessed_groups(3)
+        group_ids = sorted(g.id for g in groups)
 
-        with (
-            override_options({"issues.derived.heal-project-limit": 2}),
-            patch.object(generate_project_derived_data, "delay") as mock_delay,
-        ):
+        for gid in group_ids:
+            process_group_log(gid)
+
+        hash_a = self._pick_stale_hash("0")
+        hash_b = self._pick_stale_hash("y")
+        GroupDerivedData.objects.filter(group_id__in=group_ids[:2]).update(pipeline_hash=hash_a)
+        GroupDerivedData.objects.filter(group_id=group_ids[2]).update(pipeline_hash=hash_b)
+
+        with patch.object(regenerate_stale_derived_data_batch, "delay") as mock_delay:
             heal_stale_derived_data()
 
-        assert mock_delay.call_count == 2
+        # One batch covering the whole ID range, with both stale hashes.
+        mock_delay.assert_called_once()
+        kwargs = mock_delay.call_args.kwargs
+        assert sorted(kwargs["stale_pipeline_hashes"]) == sorted([hash_a, hash_b])
+        assert kwargs["group_id_start"] == group_ids[0]
+        assert kwargs["group_id_end"] == group_ids[2] + 1
 
-    def test_treats_null_hash_as_stale(self) -> None:
+    def test_null_hash_is_always_stale_without_being_listed(self) -> None:
         groups = self.create_unprocessed_groups(1)
         process_group_log(groups[0].id)
         GroupDerivedData.objects.filter(group_id=groups[0].id).update(pipeline_hash=None)
 
-        with patch.object(generate_project_derived_data, "delay") as mock_delay:
+        with patch.object(regenerate_stale_derived_data_batch, "delay") as mock_delay:
             heal_stale_derived_data()
 
-        mock_delay.assert_called_once_with(project_id=self.project.id, stale_only=True)
+        mock_delay.assert_called_once()
+        kwargs = mock_delay.call_args.kwargs
+        # NULL is handled unconditionally by the batch task; the list is empty.
+        assert kwargs["stale_pipeline_hashes"] == []
+        assert kwargs["group_id_start"] == groups[0].id
+        assert kwargs["group_id_end"] == groups[0].id + 1
+
+    def test_respects_max_tasks(self) -> None:
+        groups = self.create_unprocessed_groups(3)
+        group_ids = sorted(g.id for g in groups)
+        for gid in group_ids:
+            process_group_log(gid)
+        stale = self._pick_stale_hash()
+        GroupDerivedData.objects.filter(group_id__in=group_ids).update(pipeline_hash=stale)
+
+        with (
+            override_options(
+                {
+                    "issues.derived.heal-batch-size": 1,
+                    "issues.derived.heal-max-tasks": 2,
+                }
+            ),
+            patch.object(regenerate_stale_derived_data_batch, "delay") as mock_delay,
+        ):
+            heal_stale_derived_data()
+
+        # 3 chunks would be produced, but max_tasks caps to 2.
+        assert mock_delay.call_count == 2
+
+
+@with_feature("projects:issue-action-log-write-to-db")
+class RegenerateStaleDerivedDataBatchTest(DerivedDataTaskTestBase):
+    @staticmethod
+    def _stale() -> str:
+        return "0" * 16 if PIPELINE.pipeline_hash != "0" * 16 else "z" * 16
+
+    def test_rebuilds_stale_rows(self) -> None:
+        groups = self.create_unprocessed_groups(2)
+        group_ids = sorted(g.id for g in groups)
+
+        for gid in group_ids:
+            process_group_log(gid)
+
+        stale = self._stale()
+        GroupDerivedData.objects.filter(group_id__in=group_ids).update(pipeline_hash=stale)
+
+        regenerate_stale_derived_data_batch(
+            stale_pipeline_hashes=[stale],
+            group_id_start=group_ids[0],
+            group_id_end=group_ids[-1] + 1,
+        )
+
+        for gid in group_ids:
+            gdd = GroupDerivedData.objects.get(group_id=gid)
+            assert gdd.pipeline_hash == PIPELINE.pipeline_hash
+
+    def test_rebuilds_null_hash_rows_even_when_list_is_empty(self) -> None:
+        groups = self.create_unprocessed_groups(1)
+        gid = groups[0].id
+        process_group_log(gid)
+        GroupDerivedData.objects.filter(group_id=gid).update(pipeline_hash=None)
+
+        regenerate_stale_derived_data_batch(
+            stale_pipeline_hashes=[],
+            group_id_start=gid,
+            group_id_end=gid + 1,
+        )
+
+        gdd = GroupDerivedData.objects.get(group_id=gid)
+        assert gdd.pipeline_hash == PIPELINE.pipeline_hash
+
+    def test_skips_rows_no_longer_stale(self) -> None:
+        # Row now has the current hash — the range query should return
+        # nothing so build_and_promote is never called.
+        groups = self.create_unprocessed_groups(1)
+        gid = groups[0].id
+        process_group_log(gid)
+
+        with patch("sentry.issues.derived.processing.build_and_promote_derived_data") as mock_build:
+            regenerate_stale_derived_data_batch(
+                stale_pipeline_hashes=[self._stale()],
+                group_id_start=gid,
+                group_id_end=gid + 1,
+            )
+        mock_build.assert_not_called()
+
+    def test_reschedules_on_batch_timeout(self) -> None:
+        groups = self.create_unprocessed_groups(3)
+        group_ids = sorted(g.id for g in groups)
+        for gid in group_ids:
+            process_group_log(gid)
+
+        stale = self._stale()
+        GroupDerivedData.objects.filter(group_id__in=group_ids).update(pipeline_hash=stale)
+
+        with (
+            patch("sentry.issues.derived.tasks.time") as mock_time,
+            patch("sentry.issues.derived.processing.build_and_promote_derived_data") as mock_build,
+            patch.object(regenerate_stale_derived_data_batch, "delay") as mock_delay,
+        ):
+            expired = BATCH_RETRIGGER_TIMEOUT.total_seconds() + 1
+            # Outer start(), helper start(), iter 1 remaining, iter 1 deadline
+            # check (triggers reschedule), then outer log message elapsed.
+            mock_time.monotonic.side_effect = [0.0, 0.0, 0.0, expired, expired]
+
+            regenerate_stale_derived_data_batch(
+                stale_pipeline_hashes=[stale],
+                group_id_start=group_ids[0],
+                group_id_end=group_ids[-1] + 1,
+            )
+
+        mock_build.assert_called_once()
+        mock_delay.assert_called_once()
+        kwargs = mock_delay.call_args.kwargs
+        assert kwargs["stale_pipeline_hashes"] == [stale]
+        assert kwargs["group_id_start"] == group_ids[0] + 1
+        assert kwargs["group_id_end"] == group_ids[-1] + 1
+
+    def test_reschedules_on_group_log_timeout(self) -> None:
+        groups = self.create_unprocessed_groups(2)
+        group_ids = sorted(g.id for g in groups)
+        for gid in group_ids:
+            process_group_log(gid)
+
+        stale = self._stale()
+        GroupDerivedData.objects.filter(group_id__in=group_ids).update(pipeline_hash=stale)
+
+        with (
+            patch(
+                "sentry.issues.derived.processing.build_and_promote_derived_data",
+                side_effect=GroupLogTimeout(0),
+            ),
+            patch.object(regenerate_stale_derived_data_batch, "delay") as mock_delay,
+        ):
+            regenerate_stale_derived_data_batch(
+                stale_pipeline_hashes=[stale],
+                group_id_start=group_ids[0],
+                group_id_end=group_ids[-1] + 1,
+            )
+
+        mock_delay.assert_called_once()
+        kwargs = mock_delay.call_args.kwargs
+        # Resume from the SAME group on a per-group timeout.
+        assert kwargs["group_id_start"] == group_ids[0]
+        assert kwargs["stale_pipeline_hashes"] == [stale]

--- a/tests/sentry/issues/derived/test_tasks.py
+++ b/tests/sentry/issues/derived/test_tasks.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from datetime import datetime, timezone
 from unittest.mock import patch
 
@@ -457,7 +458,7 @@ class RegenerateStaleDerivedDataBatchTest(DerivedDataTaskTestBase):
 
 @with_feature("projects:issue-action-log-write-to-db")
 class DiscoverStalePipelineHashesTest(DerivedDataTaskTestBase):
-    def _seed_hashes(self, hashes: list[str | None], per_hash: int = 1) -> None:
+    def _seed_hashes(self, hashes: Sequence[str | None], per_hash: int = 1) -> None:
         for h in hashes:
             groups = self.create_unprocessed_groups(per_hash)
             for group in groups:

--- a/tests/sentry/issues/derived/test_tasks.py
+++ b/tests/sentry/issues/derived/test_tasks.py
@@ -6,6 +6,7 @@ from sentry.issues.action_log.types import ActionSource, GroupActionActor, ViewA
 from sentry.issues.derived.processing import PIPELINE, GroupLogTimeout, process_group_log
 from sentry.issues.derived.tasks import (
     BATCH_RETRIGGER_TIMEOUT,
+    _discover_stale_pipeline_hashes,
     generate_project_derived_data,
     generate_project_derived_data_batch,
     heal_stale_derived_data,
@@ -452,3 +453,72 @@ class RegenerateStaleDerivedDataBatchTest(DerivedDataTaskTestBase):
         # Resume from the SAME group on a per-group timeout.
         assert kwargs["group_id_start"] == group_ids[0]
         assert kwargs["stale_pipeline_hashes"] == [stale]
+
+
+@with_feature("projects:issue-action-log-write-to-db")
+class DiscoverStalePipelineHashesTest(DerivedDataTaskTestBase):
+    def _seed_hashes(self, hashes: list[str | None], per_hash: int = 1) -> None:
+        for h in hashes:
+            groups = self.create_unprocessed_groups(per_hash)
+            for group in groups:
+                GroupDerivedData.objects.create(group_id=group.id, pipeline_hash=h)
+
+    def test_returns_empty_when_only_current_hash_present(self) -> None:
+        current = PIPELINE.pipeline_hash
+        self._seed_hashes([current, current, current])
+
+        assert _discover_stale_pipeline_hashes(current, limit=5) == []
+
+    def test_returns_empty_when_table_empty(self) -> None:
+        assert _discover_stale_pipeline_hashes(PIPELINE.pipeline_hash, limit=5) == []
+
+    def test_excludes_null_pipeline_hash(self) -> None:
+        current = PIPELINE.pipeline_hash
+        self._seed_hashes([None, None])
+
+        assert _discover_stale_pipeline_hashes(current, limit=5) == []
+
+    def test_excludes_current_hash(self) -> None:
+        current = PIPELINE.pipeline_hash
+        stale_low = "0" * 16
+        stale_high = "z" * 16
+        self._seed_hashes([stale_low, current, stale_high])
+
+        result = _discover_stale_pipeline_hashes(current, limit=5)
+        assert current not in result
+        assert set(result) == {stale_low, stale_high}
+
+    def test_returns_distinct_hashes_across_many_duplicate_rows(self) -> None:
+        current = PIPELINE.pipeline_hash
+        stale = "0" * 16 if current != "0" * 16 else "1" * 16
+        self._seed_hashes([stale], per_hash=25)
+
+        assert _discover_stale_pipeline_hashes(current, limit=5) == [stale]
+
+    def test_respects_limit(self) -> None:
+        current = PIPELINE.pipeline_hash
+        stale_hashes = [f"stale-{i:02d}" for i in range(5)]
+        assert current not in stale_hashes
+        self._seed_hashes(stale_hashes)
+
+        result = _discover_stale_pipeline_hashes(current, limit=3)
+        assert len(result) == 3
+        assert result == sorted(result)
+        assert set(result).issubset(set(stale_hashes))
+
+    def test_returns_hashes_in_ascending_order(self) -> None:
+        current = PIPELINE.pipeline_hash
+        stale_hashes = ["c-hash", "a-hash", "b-hash"]
+        assert current not in stale_hashes
+        self._seed_hashes(stale_hashes)
+
+        result = _discover_stale_pipeline_hashes(current, limit=10)
+        assert result == ["a-hash", "b-hash", "c-hash"]
+
+    def test_limit_honored_when_current_hash_appears_mid_walk(self) -> None:
+        current = "m-current"
+        stale_hashes = ["a-hash", "b-hash", "y-hash", "z-hash"]
+        self._seed_hashes(stale_hashes + [current])
+
+        result = _discover_stale_pipeline_hashes(current, limit=3)
+        assert result == ["a-hash", "b-hash", "y-hash"]


### PR DESCRIPTION
The per-project query was too slow and timed out. Efficiently identify stale group id ranges using the pipeline_hash index, and schedule work over those ranges via a new regenerate_stale_derived_data_batch task.

Fixes ISWF-3206.
