### PR TITLE
ref(seer): use Chip for askSeer value tokens

### DIFF
--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.spec.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.spec.tsx
@@ -476,7 +476,9 @@ describe('AskSeerComboBox', () => {
     await userEvent.type(input, 'test{Enter}');
 
     const groupBy = await screen.findByText('span.name');
-    expect(getEmotionRules(groupBy).join(' ')).toContain('width: fit-content');
+    // The value renders in a Chip, which is inline-flex and therefore sizes to
+    // its content rather than stretching to fill the row.
+    expect(getEmotionRules(groupBy.closest('div')).join(' ')).toContain('inline-flex');
   });
 
   it('hides the feedback option when the rework is enabled', async () => {

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/oldQueryTokens.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/oldQueryTokens.tsx
@@ -1,6 +1,7 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
+import {Chip} from '@sentry/scraps/chip';
 import {Flex} from '@sentry/scraps/layout';
 
 import type {QueryTokensProps} from 'sentry/components/searchQueryBuilder/askSeerCombobox/types';
@@ -231,20 +232,11 @@ const ExploreParamTitle = styled('span')`
   height: 24px;
 `;
 
-const ExploreVisualizes = styled('span')`
-  font-size: ${p => p.theme.form.sm.fontSize};
-  background: ${p => p.theme.tokens.background.primary};
-  padding: ${p => p.theme.space['2xs']} ${p => p.theme.space.xs};
-  border: 1px solid ${p => p.theme.tokens.border.secondary};
-  border-radius: ${p => p.theme.radius.md};
-  min-height: 24px;
-  width: fit-content;
-  max-width: 100%;
-  overflow-wrap: anywhere;
-  white-space: normal;
-  display: inline-flex;
-  align-items: center;
-`;
+function ExploreValueChip({children}: {children: string}) {
+  return <Chip variant="value" size="sm" value={children} />;
+}
+
+const ExploreVisualizes = ExploreValueChip;
 
 const ExploreGroupBys = ExploreVisualizes;
 

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/queryTokens.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/queryTokens.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 
+import {Chip} from '@sentry/scraps/chip';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
@@ -232,20 +233,11 @@ function ExploreParamTitle({children}: {children: React.ReactNode}) {
   );
 }
 
-const ExploreVisualizes = styled('span')`
-  font-size: ${p => p.theme.form.sm.fontSize};
-  background: ${p => p.theme.tokens.background.primary};
-  padding: ${p => p.theme.space['2xs']} ${p => p.theme.space.xs};
-  border: 1px solid ${p => p.theme.tokens.border.secondary};
-  border-radius: ${p => p.theme.radius.md};
-  min-height: 24px;
-  width: fit-content;
-  max-width: 100%;
-  overflow-wrap: anywhere;
-  white-space: normal;
-  display: inline-flex;
-  align-items: center;
-`;
+function ExploreValueChip({children}: {children: string}) {
+  return <Chip variant="value" size="sm" value={children} />;
+}
+
+const ExploreVisualizes = ExploreValueChip;
 
 const ExploreGroupBys = ExploreVisualizes;
 


### PR DESCRIPTION
Formatted query filters now render with readonly compound `Chip` primitives instead of bespoke bordered layout styling. This updates every `FormattedQuery` consumer while preserving rich filter values and middle-ellipsis behavior.

`Chip.Root` regains automatic and manual focus ownership for composite-widget integrations, and `Chip.Value` accepts `maxWidth` so consumers can constrain rich values without depending on the component's internal DOM.
