### PR TITLE
fix(notifications): Use per-project emails on workflow notifications

### DIFF
--- a/src/sentry/notifications/platform/strategies/issue_subscribers.py
+++ b/src/sentry/notifications/platform/strategies/issue_subscribers.py
@@ -26,5 +26,5 @@ class IssueSubscribersActivityStrategy(NotificationStrategy):
             return []
         participant_map = get_participants_for_group(group=group, user_id=self.activity.user_id)
         return get_targets_from_participant_map(
-            participant_map, organization_id=group.project.organization_id
+            participant_map, organization_id=group.project.organization_id, project=group.project
         )

--- a/src/sentry/notifications/platform/strategies/utils.py
+++ b/src/sentry/notifications/platform/strategies/utils.py
@@ -7,6 +7,7 @@ from sentry.integrations.types import (
     ExternalProviders,
 )
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
+from sentry.models.project import Project
 from sentry.notifications.platform.target import (
     GenericNotificationTarget,
     IntegrationNotificationTarget,
@@ -18,24 +19,24 @@ from sentry.notifications.platform.types import (
 )
 from sentry.notifications.utils.participants import ParticipantMap
 from sentry.types.actor import ActorType
-from sentry.users.services.user.service import user_service
+from sentry.utils.email.manager import get_email_addresses
 
 
 def get_targets_from_participant_map(
-    participant_map: ParticipantMap, *, organization_id: int
+    participant_map: ParticipantMap, *, organization_id: int, project: Project | None = None
 ) -> list[NotificationTarget]:
     """
     Converts legacy ParticipantMap types to the platform's new NotificationTarget list.
     Note: For simplicity, we ignore SLACK_STAGING and MSTEAMS since they are not available in prod.
     """
     return [
-        *_get_email_targets(participant_map, organization_id=organization_id),
+        *_get_email_targets(participant_map, organization_id=organization_id, project=project),
         *_get_slack_targets(participant_map, organization_id=organization_id),
     ]
 
 
 def _get_email_targets(
-    participant_map: ParticipantMap, organization_id: int
+    participant_map: ParticipantMap, organization_id: int, project: Project | None = None
 ) -> list[NotificationTarget]:
     user_ids: set[int] = set()
     team_ids: set[int] = set()
@@ -57,17 +58,15 @@ def _get_email_targets(
     if not user_ids:
         return []
 
-    users = user_service.get_many_by_id(ids=list(user_ids))
+    email_map = get_email_addresses(user_ids, project=project)
     targets: list[NotificationTarget] = []
-    for user in users:
-        if not user.email:
-            continue
+    for user_id, email in email_map.items():
         targets.append(
             GenericNotificationTarget(
                 provider_key=NotificationProviderKey.EMAIL,
                 resource_type=NotificationTargetResourceType.EMAIL,
-                resource_id=user.email,
-                specific_data={"user_id": user.id},
+                resource_id=email,
+                specific_data={"user_id": user_id},
             )
         )
     return targets

--- a/tests/sentry/notifications/platform/strategies/test_utils.py
+++ b/tests/sentry/notifications/platform/strategies/test_utils.py
@@ -129,6 +129,50 @@ class GetTargetsFromParticipantMapTest(TestCase):
 
         assert targets == []
 
+    def test_email_uses_project_specific_routing(self) -> None:
+        project = self.create_project(organization=self.organization)
+        alternate_email = "project-route@example.com"
+        self.create_useremail(user=self.user, email=alternate_email)
+        self.create_user_option(
+            user=self.user, project_id=project.id, key="mail:email", value=alternate_email
+        )
+
+        participant_map = ParticipantMap()
+        participant_map.add(
+            ExternalProviders.EMAIL,
+            Actor(id=self.user.id, actor_type=ActorType.USER),
+            0,
+        )
+
+        targets = get_targets_from_participant_map(
+            participant_map, organization_id=self.organization.id, project=project
+        )
+
+        assert len(targets) == 1
+        assert targets[0].resource_id == alternate_email
+
+    def test_email_uses_primary_email_without_project(self) -> None:
+        project = self.create_project(organization=self.organization)
+        alternate_email = "project-route@example.com"
+        self.create_useremail(user=self.user, email=alternate_email)
+        self.create_user_option(
+            user=self.user, project_id=project.id, key="mail:email", value=alternate_email
+        )
+
+        participant_map = ParticipantMap()
+        participant_map.add(
+            ExternalProviders.EMAIL,
+            Actor(id=self.user.id, actor_type=ActorType.USER),
+            0,
+        )
+
+        targets = get_targets_from_participant_map(
+            participant_map, organization_id=self.organization.id
+        )
+
+        assert len(targets) == 1
+        assert targets[0].resource_id == self.user.email
+
 
 class GetTargetsSlackUserTest(TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
The new notification platform path ignored these preferences. It doesn't anymore. Added tests for the util changes