### PR TITLE
perf(replays): Window replay bulk deletes by hour instead of 7 days

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -511,10 +511,20 @@ register(
     default=0.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
-# Chunk size for bulk delete job
+# Superseded by replay.bulk_delete_job.chunk_size_minutes and no longer read. Still registered so
+# existing automator config does not fail validation; remove once that config is gone.
 register(
     "replay.bulk_delete_job.chunk_size_days",
     default=7,
+    type=Int,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+# Window size the bulk delete job pages within. Must divide 1440: the replays table sort key holds
+# toStartOfDay(timestamp) in second position, so a window covering two day values stops ClickHouse
+# pruning granules with the cityHash64(replay_id) cursor.
+register(
+    "replay.bulk_delete_job.chunk_size_minutes",
+    default=60,
     type=Int,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )

--- a/src/sentry/replays/scripts/delete_replays.py
+++ b/src/sentry/replays/scripts/delete_replays.py
@@ -4,7 +4,7 @@ import functools
 import logging
 import uuid
 from collections.abc import Sequence
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 
 from snuba_sdk import (
     Column,
@@ -19,12 +19,18 @@ from snuba_sdk import (
     Query,
 )
 
-from sentry import features, options
+from sentry import features
 from sentry.api.event_search import QueryToken, parse_search_query
 from sentry.models.organization import Organization
 from sentry.replays.query import replay_url_parser_config
 from sentry.replays.tasks import archive_replay, delete_replays_script_async
-from sentry.replays.usecases.delete import SNUBA_RETRY_EXCEPTIONS, delete_seer_replay_data
+from sentry.replays.usecases.delete import (
+    SNUBA_RETRY_EXCEPTIONS,
+    delete_seer_replay_data,
+    initial_window_offset_minutes,
+    window_bounds,
+    window_size_minutes,
+)
 from sentry.replays.usecases.query import execute_query, handle_search_filters
 from sentry.replays.usecases.query.configs.scalar import scalar_search_config
 from sentry.snuba.referrer import Referrer
@@ -54,15 +60,16 @@ def delete_replays(
     # Running tally of replays to be deleted, accumulated across windows and pages
     total_replays = 0
 
-    # Chunk the range into fixed-size windows
-    chunk_size_days = options.get("replay.bulk_delete_job.chunk_size_days") or 7
+    # Chunk the range into wall-clock-aligned windows so none spans a UTC day boundary
+    window_size = window_size_minutes()
 
-    window_offset_days = 0
+    window_offset_minutes = initial_window_offset_minutes(start_utc, window_size)
     while True:
-        window_start = start_utc + timedelta(days=window_offset_days)
+        window_start, window_end = window_bounds(
+            start_utc, end_utc, window_offset_minutes, window_size
+        )
         if window_start >= end_utc:
             break
-        window_end = min(window_start + timedelta(days=chunk_size_days), end_utc)
 
         # Reset per window because the cursor space is scoped to the window's result set
         last_replay_id = None
@@ -107,7 +114,7 @@ def delete_replays(
                         total_replays=total_replays,
                     )
 
-        window_offset_days += chunk_size_days
+        window_offset_minutes += window_size
 
 
 def translate_cli_tags_param_to_snuba_tag_param(tags: list[str]) -> Sequence[QueryToken]:

--- a/src/sentry/replays/tasks.py
+++ b/src/sentry/replays/tasks.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from datetime import timedelta
 from typing import Any
 
 from django.utils import timezone
@@ -11,7 +10,6 @@ from taskbroker_client.retry import Retry
 from taskbroker_client.state import current_task
 from taskbroker_client.worker.workerchild import ProcessingDeadlineExceeded
 
-from sentry import options
 from sentry.replays.consumers.recording import commit_message, process_message
 from sentry.replays.lib.kafka import PROCESS_REPLAY_RECORDING_TASK_NAME, publish_replay_event
 from sentry.replays.lib.storage import (
@@ -26,6 +24,9 @@ from sentry.replays.usecases.delete import (
     delete_matched_rows,
     delete_seer_replay_data,
     fetch_rows_matching_pattern,
+    initial_window_offset_minutes,
+    window_bounds,
+    window_size_minutes,
 )
 from sentry.replays.usecases.events import archive_event
 from sentry.replays.usecases.ingest.types import ProcessorContext
@@ -235,7 +236,8 @@ def run_bulk_replay_delete_job(
     limit: int = 100,
     has_seer_data: bool = False,
     total_deleted: int = 0,
-    window_offset_days: int = 0,
+    window_offset_days: int | None = None,
+    window_offset_minutes: int | None = None,
 ) -> None:
     """Replay bulk deletion task.
 
@@ -244,7 +246,7 @@ def run_bulk_replay_delete_job(
     in the model. Restarting the task will use the offset passed by the caller. If you want to
     restart the task from the previous checkpoint you must pass the checkpoint explicitly.
     """
-    chunk_size_days = options.get("replay.bulk_delete_job.chunk_size_days") or 7
+    window_size = window_size_minutes()
     job = ReplayDeletionJobModel.objects.get(id=replay_delete_job_id)
 
     # If this is the first run of the task we set the model to in-progress.
@@ -257,10 +259,13 @@ def run_bulk_replay_delete_job(
     if job.status != DeletionJobStatus.IN_PROGRESS:
         return None
 
-    # Derive the current window boundaries from the immutable job range and the cursor.
-    # Chunking into 7-day windows avoids full table scans in ClickHouse.
-    window_start = job.range_start + timedelta(days=window_offset_days)
-    window_end = min(window_start + timedelta(days=chunk_size_days), job.range_end)
+    # Derive the current window boundaries from the immutable job range and the cursor. Windows
+    # are snapped to the wall clock so none of them spans a UTC day boundary; see `window_bounds`.
+    if window_offset_minutes is None:
+        window_offset_minutes = initial_window_offset_minutes(job.range_start, window_size)
+    window_start, window_end = window_bounds(
+        job.range_start, job.range_end, window_offset_minutes, window_size
+    )
 
     try:
         # Delete the replays within a limited range. If more replays exist an incremented offset value
@@ -324,13 +329,13 @@ def run_bulk_replay_delete_job(
             limit=limit,
             has_seer_data=has_seer_data,
             total_deleted=new_total,
-            window_offset_days=window_offset_days,
+            window_offset_minutes=window_offset_minutes,
         )
         return None
 
     # Current window exhausted. Check if more time windows remain.
     if window_end < job.range_end:
-        # Advance to the next 7-day window by incrementing the cursor in the task args.
+        # Advance to the next window by incrementing the offset in the task args.
         # job.range_start is never mutated so the API always returns the original range.
         _advance_offset(job.id, new_total)
         run_bulk_replay_delete_job.delay(
@@ -339,7 +344,7 @@ def run_bulk_replay_delete_job(
             limit=limit,
             has_seer_data=has_seer_data,
             total_deleted=new_total,
-            window_offset_days=window_offset_days + chunk_size_days,
+            window_offset_minutes=window_offset_minutes + window_size,
         )
         return None
 

--- a/src/sentry/replays/usecases/delete.py
+++ b/src/sentry/replays/usecases/delete.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import functools
 import logging
 from collections.abc import Iterator
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import TypedDict
 
 from google.cloud.exceptions import NotFound
@@ -22,6 +22,7 @@ from snuba_sdk import (
 )
 from urllib3 import Retry
 
+from sentry import options
 from sentry.api.event_search import parse_search_query
 from sentry.models.organization import Organization
 from sentry.replays.lib.kafka import publish_replay_event
@@ -56,6 +57,52 @@ SNUBA_RETRY_EXCEPTIONS = (
 )
 
 logger = logging.getLogger(__name__)
+
+
+_MINUTES_PER_DAY = 1440
+_DEFAULT_WINDOW_MINUTES = 60
+
+
+def window_size_minutes() -> int:
+    """Return the configured window size, rejecting values that would straddle a day boundary."""
+    minutes = options.get("replay.bulk_delete_job.chunk_size_minutes")
+    if minutes <= 0 or _MINUTES_PER_DAY % minutes != 0:
+        logger.warning(
+            "Ignoring replay.bulk_delete_job.chunk_size_minutes=%s, it must divide %s.",
+            minutes,
+            _MINUTES_PER_DAY,
+        )
+        return _DEFAULT_WINDOW_MINUTES
+    return minutes
+
+
+def initial_window_offset_minutes(range_start: datetime, size_minutes: int) -> int:
+    """Return the offset of the first window, which is the one containing `range_start`."""
+    elapsed = range_start - _start_of_day(range_start)
+    return (int(elapsed.total_seconds()) // 60 // size_minutes) * size_minutes
+
+
+def window_bounds(
+    range_start: datetime, range_end: datetime, offset_minutes: int, size_minutes: int
+) -> tuple[datetime, datetime]:
+    """Return the window at `offset_minutes`, measured from the start of `range_start`'s UTC day.
+
+    Windows are snapped to the wall clock rather than laid out from `range_start`, so that no window
+    spans a UTC day boundary. That matters because the sort key is
+    `(project_id, toStartOfDay(timestamp), cityHash64(replay_id), event_hash)`: a condition on the
+    third component only prunes granules while the first two are pinned to single values, so a
+    window covering two days gives up the pruning that paging on the hash exists to get. Snapping
+    holds across days as long as the size divides 1440, which `window_size_minutes` enforces.
+
+    The first and last windows are clamped to the job's range, so they can be shorter than
+    `size_minutes`.
+    """
+    aligned = _start_of_day(range_start) + timedelta(minutes=offset_minutes)
+    return max(aligned, range_start), min(aligned + timedelta(minutes=size_minutes), range_end)
+
+
+def _start_of_day(value: datetime) -> datetime:
+    return value.replace(hour=0, minute=0, second=0, microsecond=0)
 
 
 def delete_matched_rows(project_id: int, rows: list[MatchedRow]) -> int | None:

--- a/tests/sentry/replays/tasks/test_delete_replays_bulk.py
+++ b/tests/sentry/replays/tasks/test_delete_replays_bulk.py
@@ -16,9 +16,13 @@ from sentry.replays.usecases.delete import (
     MatchedRows,
     delete_matched_rows,
     fetch_rows_matching_pattern,
+    initial_window_offset_minutes,
+    window_bounds,
+    window_size_minutes,
 )
 from sentry.testutils.cases import APITestCase, ReplaysSnubaTestCase
 from sentry.testutils.helpers import TaskRunner
+from sentry.testutils.helpers.options import override_options
 
 
 class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
@@ -422,6 +426,63 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
         self.job.refresh_from_db()
         assert self.job.status == "completed"
 
+    def test_window_size_minutes_rejects_sizes_that_straddle_a_day(self) -> None:
+        """Test a size that does not divide 1440 falls back rather than crossing midnight."""
+        with override_options({"replay.bulk_delete_job.chunk_size_minutes": 60}):
+            assert window_size_minutes() == 60
+        with override_options({"replay.bulk_delete_job.chunk_size_minutes": 1440}):
+            assert window_size_minutes() == 1440
+        # 50 does not divide 1440, so windows would drift across the boundary.
+        with override_options({"replay.bulk_delete_job.chunk_size_minutes": 50}):
+            assert window_size_minutes() == 60
+        with override_options({"replay.bulk_delete_job.chunk_size_minutes": 0}):
+            assert window_size_minutes() == 60
+
+    def test_initial_window_offset_minutes_snaps_back_to_the_wall_clock(self) -> None:
+        """Test the first offset is the aligned slot containing range_start, not range_start."""
+        assert (
+            initial_window_offset_minutes(
+                datetime.datetime(2025, 6, 1, 0, 0, tzinfo=datetime.UTC), 60
+            )
+            == 0
+        )
+        assert (
+            initial_window_offset_minutes(
+                datetime.datetime(2025, 6, 1, 3, 30, tzinfo=datetime.UTC), 60
+            )
+            == 180
+        )
+        assert (
+            initial_window_offset_minutes(
+                datetime.datetime(2025, 6, 1, 23, 59, tzinfo=datetime.UTC), 60
+            )
+            == 1380
+        )
+
+    def test_window_bounds_stay_inside_one_day_across_a_multi_day_range(self) -> None:
+        """Test every window in a multi-day range lands within a single UTC day."""
+        range_start = datetime.datetime(2025, 6, 1, 3, 30, tzinfo=datetime.UTC)
+        range_end = datetime.datetime(2025, 6, 4, 0, 0, tzinfo=datetime.UTC)
+
+        offset = initial_window_offset_minutes(range_start, 60)
+        windows = []
+        start, end = window_bounds(range_start, range_end, offset, 60)
+        while start < range_end:
+            windows.append((start, end))
+            offset += 60
+            start, end = window_bounds(range_start, range_end, offset, 60)
+
+        # 3:30 to midnight on day one, then two full days.
+        assert len(windows) == 21 + 24 + 24
+        assert windows[0] == (range_start, datetime.datetime(2025, 6, 1, 4, 0, tzinfo=datetime.UTC))
+        assert windows[-1][1] == range_end
+        for window_start, window_end in windows:
+            assert window_start < window_end
+            assert window_start.date() == (window_end - datetime.timedelta(microseconds=1)).date()
+        # The windows tile the range with no gaps.
+        for earlier, later in zip(windows, windows[1:]):
+            assert earlier[1] == later[0]
+
     def test_fetch_rows_matching_pattern(self) -> None:
         t1 = datetime.datetime.now() - datetime.timedelta(seconds=10)
         t2 = datetime.datetime.now() + datetime.timedelta(seconds=10)
@@ -565,10 +626,13 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
     def test_run_bulk_replay_delete_job_time_window_chunking(
         self, mock_delete_matched_rows: MagicMock, mock_fetch_rows: MagicMock
     ) -> None:
-        """Test that wide date ranges are chunked into 7-day windows."""
-        # Create a job spanning 20 days so it requires 3 windows (7 + 7 + 6).
-        range_start = datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(days=20)
-        range_end = datetime.datetime.now(tz=datetime.UTC)
+        """Test a range is chunked into windows snapped to the wall clock.
+
+        `range_start` is deliberately mid-hour: the first window must start at `range_start` while
+        every later boundary lands on the hour, so windows cannot drift across a day boundary.
+        """
+        range_start = datetime.datetime(2025, 6, 1, 3, 30, tzinfo=datetime.UTC)
+        range_end = datetime.datetime(2025, 6, 1, 6, 0, tzinfo=datetime.UTC)
         job = ReplayDeletionJobModel.objects.create(
             organization_id=self.project.organization.id,
             project_id=self.project.id,
@@ -581,17 +645,14 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
 
         # Each window returns rows with has_more=False so the task advances to the next window.
         def row_generator() -> Generator[MatchedRows]:
-            # Window 1: range_start to range_start + 7 days
             yield {
                 "rows": [{"retention_days": 90, "replay_id": "a", "max_segment_id": 1}],
                 "has_more": False,
             }
-            # Window 2: range_start + 7 days to range_start + 14 days
             yield {
                 "rows": [{"retention_days": 90, "replay_id": "b", "max_segment_id": 1}],
                 "has_more": False,
             }
-            # Window 3: range_start + 14 days to range_end
             yield {
                 "rows": [{"retention_days": 90, "replay_id": "c", "max_segment_id": 1}],
                 "has_more": False,
@@ -611,20 +672,61 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
         # range_start must never be mutated — the API always returns the original value.
         assert job.range_start == range_start
 
-        # Verify each call used the correct window boundaries.
-        calls = mock_fetch_rows.call_args_list
-        # Window 1
-        assert calls[0].kwargs["start"] == range_start
-        assert calls[0].kwargs["end"] == range_start + datetime.timedelta(days=7)
-        assert calls[0].kwargs["offset"] == 0
-        # Window 2
-        assert calls[1].kwargs["start"] == range_start + datetime.timedelta(days=7)
-        assert calls[1].kwargs["end"] == range_start + datetime.timedelta(days=14)
-        assert calls[1].kwargs["offset"] == 0
-        # Window 3
-        assert calls[2].kwargs["start"] == range_start + datetime.timedelta(days=14)
-        assert calls[2].kwargs["end"] == range_end
-        assert calls[2].kwargs["offset"] == 0
+        windows = [
+            (call.kwargs["start"], call.kwargs["end"]) for call in mock_fetch_rows.call_args_list
+        ]
+        assert windows == [
+            # Clamped to range_start rather than starting at 03:00.
+            (range_start, datetime.datetime(2025, 6, 1, 4, 0, tzinfo=datetime.UTC)),
+            (
+                datetime.datetime(2025, 6, 1, 4, 0, tzinfo=datetime.UTC),
+                datetime.datetime(2025, 6, 1, 5, 0, tzinfo=datetime.UTC),
+            ),
+            # Clamped to range_end.
+            (datetime.datetime(2025, 6, 1, 5, 0, tzinfo=datetime.UTC), range_end),
+        ]
+
+    @patch("sentry.replays.tasks.fetch_rows_matching_pattern")
+    @patch("sentry.replays.tasks.delete_matched_rows")
+    def test_run_bulk_replay_delete_job_windows_never_span_a_day_boundary(
+        self, mock_delete_matched_rows: MagicMock, mock_fetch_rows: MagicMock
+    ) -> None:
+        """Test a range crossing midnight is split at the boundary.
+
+        A window covering two `toStartOfDay(timestamp)` values gives up the granule pruning that
+        paging on `cityHash64(replay_id)` exists to get, so the split is the point of the feature.
+        """
+        range_start = datetime.datetime(2025, 6, 1, 23, 30, tzinfo=datetime.UTC)
+        range_end = datetime.datetime(2025, 6, 2, 0, 30, tzinfo=datetime.UTC)
+        job = ReplayDeletionJobModel.objects.create(
+            organization_id=self.project.organization.id,
+            project_id=self.project.id,
+            range_start=range_start,
+            range_end=range_end,
+            query="",
+            environments=["prod"],
+            status="pending",
+        )
+
+        def row_generator() -> Generator[MatchedRows]:
+            yield {"rows": [], "has_more": False}
+            yield {"rows": [], "has_more": False}
+
+        mock_fetch_rows.side_effect = row_generator()
+
+        with TaskRunner():
+            run_bulk_replay_delete_job.delay(job.id, offset=0, limit=100)
+
+        job.refresh_from_db()
+        assert job.status == "completed"
+
+        midnight = datetime.datetime(2025, 6, 2, 0, 0, tzinfo=datetime.UTC)
+        windows = [
+            (call.kwargs["start"], call.kwargs["end"]) for call in mock_fetch_rows.call_args_list
+        ]
+        assert windows == [(range_start, midnight), (midnight, range_end)]
+        for start, end in windows:
+            assert start.date() == (end - datetime.timedelta(microseconds=1)).date()
 
     @patch("sentry.replays.tasks.fetch_rows_matching_pattern")
     @patch("sentry.replays.tasks.delete_matched_rows")
@@ -632,8 +734,8 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
         self, mock_delete_matched_rows: MagicMock, mock_fetch_rows: MagicMock
     ) -> None:
         """Test pagination within a time window followed by advancing to the next window."""
-        range_start = datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(days=10)
-        range_end = datetime.datetime.now(tz=datetime.UTC)
+        range_start = datetime.datetime(2025, 6, 1, 0, 0, tzinfo=datetime.UTC)
+        range_end = datetime.datetime(2025, 6, 1, 2, 0, tzinfo=datetime.UTC)
         job = ReplayDeletionJobModel.objects.create(
             organization_id=self.project.organization.id,
             project_id=self.project.id,
@@ -675,16 +777,17 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
         assert job.range_start == range_start
 
         calls = mock_fetch_rows.call_args_list
+        hour_one = datetime.datetime(2025, 6, 1, 1, 0, tzinfo=datetime.UTC)
         # Window 1, page 1 — offset 0
         assert calls[0].kwargs["start"] == range_start
-        assert calls[0].kwargs["end"] == range_start + datetime.timedelta(days=7)
+        assert calls[0].kwargs["end"] == hour_one
         assert calls[0].kwargs["offset"] == 0
-        # Window 1, page 2 — offset 1
+        # Window 1, page 2 — offset 1, same window
         assert calls[1].kwargs["start"] == range_start
-        assert calls[1].kwargs["end"] == range_start + datetime.timedelta(days=7)
+        assert calls[1].kwargs["end"] == hour_one
         assert calls[1].kwargs["offset"] == 1
         # Window 2 — offset reset to 0
-        assert calls[2].kwargs["start"] == range_start + datetime.timedelta(days=7)
+        assert calls[2].kwargs["start"] == hour_one
         assert calls[2].kwargs["end"] == range_end
         assert calls[2].kwargs["offset"] == 0
 


### PR DESCRIPTION
**Closed without merging.** The premise is measurably wrong: sub-day windows do not prune anything.

`replays_local` is sorted by `(project_id, toStartOfDay(timestamp), cityHash64(replay_id), event_hash)`. Timestamp is in the key only at **day** granularity, and within a `(project, day)` block rows are ordered by the replay id hash rather than by time — so a narrow time slice is scattered across the whole day and there is no contiguous range to skip. Measured with `EXPLAIN indexes = 1`, day pinned, 200k rows in one day:

| timestamp window | granules read | rows matched |
| --- | --- | --- |
| whole day (24h) | 25/25 | 200,000 |
| 1 hour | 25/25 | 8,334 |
| 1 minute | 25/25 | 139 |

A one-minute window scans the entire day. The "~18x less scanning" claim in the original description assumed rows scanned scale with window span; below a day they do not. The arithmetic also cancels — total cost per day is independent of sub-day window size — so this PR was at best neutral and slightly negative once each window rounds up to whole pages.

Replaced by REPLAY-964, which keeps the wall-clock alignment idea for a different reason (a window inside one UTC day can assert that day, worth ~2x) and drops the sub-day machinery entirely.

---

<details><summary>Original description</summary>

Chunked both replay delete paths into hourly windows snapped to the wall clock, on the theory that total work scales inversely with window count.

</details>

Refs REPLAY-964