### PR TITLE
feat(discover): put migration warning for discover split

### DIFF
--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -60,6 +60,7 @@ import {registerLLMContext} from 'sentry/views/seerExplorer/contexts/registerLLM
 import {VisualizationWidget} from './visualizationWidget';
 import {
   getMenuOptions,
+  useDiscoverSplitWarning,
   useDroppedColumnsWarning,
   useTransactionsDeprecationWarning,
 } from './widgetCardContextMenu';
@@ -231,6 +232,7 @@ function WidgetCard(props: Props) {
     widget,
     dashboardFilters,
   });
+  const discoverSplitWarning = useDiscoverSplitWarning(widget);
 
   const onDataFetchStart = () => {
     if (timeoutRef.current) {
@@ -329,6 +331,7 @@ function WidgetCard(props: Props) {
     transactionsDeprecationWarning,
     droppedColumnsWarning,
     conflictingFilterWarning,
+    discoverSplitWarning,
   ].filter(Boolean) as string[];
 
   const actionsDisabled = Boolean(props.isPreview);

--- a/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
@@ -162,7 +162,11 @@ export const useDroppedColumnsWarning = (widget: Widget): React.JSX.Element | nu
 };
 
 export const useDiscoverSplitWarning = (widget: Widget): React.JSX.Element | null => {
-  if (widget.widgetType === WidgetType.DISCOVER || !widget.widgetType) {
+  // make sure there's widget queries so we know it's not a text widget
+  if (
+    (widget.widgetType === WidgetType.DISCOVER || !widget.widgetType) &&
+    widget.queries.length > 0
+  ) {
     return (
       <div>
         <StyledText as="p">

--- a/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
@@ -161,6 +161,22 @@ export const useDroppedColumnsWarning = (widget: Widget): React.JSX.Element | nu
   return null;
 };
 
+export const useDiscoverSplitWarning = (widget: Widget): React.JSX.Element | null => {
+  if (widget.widgetType === WidgetType.DISCOVER || !widget.widgetType) {
+    return (
+      <div>
+        <StyledText as="p">
+          {t(
+            "We're splitting up the Discover dataset to be either Errors or Transactions. This widget's dataset will be adjusted."
+          )}
+        </StyledText>
+      </div>
+    );
+  }
+
+  return null;
+};
+
 const StyledText = styled(Text)`
   padding-bottom: ${p => p.theme.space.xs};
 `;


### PR DESCRIPTION
Since we're rerunning the discover split and then transaction->span migration we needed to make sure we have the right warnings in place. The discover split warnings were deleted but we're bringing them back 😞  This is what it looks like

<img width="527" height="443" alt="Screenshot 2026-08-05 at 2 43 17 PM" src="https://github.com/user-attachments/assets/d0a751ed-af92-4dd9-b110-012ec4452d52" />
