### PR TITLE
fix(issues): attribute ingest-side regressions in the group action log

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -89,6 +89,7 @@ from sentry.insights import modules as insights_modules
 from sentry.integrations.tasks.kick_off_status_syncs import kick_off_status_syncs
 from sentry.issue_detection.performance_detection import detect_performance_problems
 from sentry.issue_detection.performance_problem import PerformanceProblem
+from sentry.issues.action_log import SYSTEM_ACTOR, ActionSource, action_context_scope
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
 from sentry.killswitches import killswitch_matches_context
@@ -1920,7 +1921,8 @@ def _process_existing_aggregate(
     if group.first_seen > event.datetime:
         updated_group_values["first_seen"] = event.datetime
 
-    is_regression = _handle_regression(group, event, release, incoming_group_values)
+    with action_context_scope(source=ActionSource.SYSTEM, actor=SYSTEM_ACTOR):
+        is_regression = _handle_regression(group, event, release, incoming_group_values)
 
     existing_data = group.data
     existing_metadata = group.data.get("metadata", {})

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -46,6 +46,8 @@ from sentry.incidents.grouptype import MetricIssue
 from sentry.ingest.inbound_filters import FilterStatKeys
 from sentry.ingest.transaction_clusterer import ClustererNamespace
 from sentry.integrations.models.external_issue import ExternalIssue
+from sentry.issues.action_log import SYSTEM_ACTOR, ActionSource
+from sentry.issues.action_log.types import SetRegressedAction
 from sentry.issues.grouptype import (
     GroupCategory,
     PerformanceNPlusOneGroupType,
@@ -83,6 +85,7 @@ from sentry.testutils.cases import (
     TestCase,
 )
 from sentry.testutils.helpers import override_options
+from sentry.testutils.helpers.action_log import capture_action_log
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.usage_accountant import usage_accountant_backend
@@ -709,6 +712,31 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         group = Group.objects.get(id=group.id)
         assert not group.is_resolved()
         assert send_robust.called
+
+    def test_regression_attributes_to_system(self) -> None:
+        manager = EventManager(
+            make_event(
+                event_id="a" * 32, checksum="a" * 32, timestamp=before_now(minutes=5).isoformat()
+            )
+        )
+        with self.tasks():
+            event = manager.save(self.project.id)
+
+        assert event.group_id is not None
+        group = Group.objects.get(id=event.group_id)
+        group.update(status=GroupStatus.RESOLVED, substatus=None)
+
+        manager = EventManager(
+            make_event(
+                event_id="b" * 32, checksum="a" * 32, timestamp=before_now(minutes=3).isoformat()
+            )
+        )
+        with capture_action_log() as log:
+            manager.save(self.project.id)
+
+        log.assert_logged(
+            SetRegressedAction, group_id=group.id, source=ActionSource.SYSTEM, actor=SYSTEM_ACTOR
+        )
 
     @mock.patch("sentry.tasks.activity.send_activity_notifications.delay")
     def test_marks_as_unresolved_with_new_release(


### PR DESCRIPTION
Another case where activities are being created in the GAL and we need to set a more explicit context for source/actor.

Fixes SENTRY-5RJZ
