### PR TITLE
feat(api): Add response schema to events validate endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_events_validate.py
+++ b/src/sentry/api/endpoints/organization_events_validate.py
@@ -14,6 +14,9 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase, UnknownEnvironments
 from sentry.api.utils import handle_query_errors
+from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_UNAUTHORIZED
+from sentry.apidocs.parameters import GlobalParams, OrganizationParams, VisibilityParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.discover.arithmetic import is_equation, strip_equation
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models.organization import Organization
@@ -142,7 +145,7 @@ class OrganizationEventsValidateEndpoint(OrganizationEventsEndpointBase):
     def serialize_response(
         self,
         validity: ValidationResponse,
-    ) -> Response:
+    ) -> Response[ValidationResponse]:
         return Response(
             status=200 if validity["valid"] else 400,
             data=validity,
@@ -195,7 +198,43 @@ class OrganizationEventsValidateEndpoint(OrganizationEventsEndpointBase):
                 )
         return validities, attributes_to_lookup, valid
 
-    def get(self, request: Request, organization: Organization) -> Response:
+    @extend_schema(
+        operation_id="validateOrganizationEventsQuery",
+        summary="Validate an Explore Query",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            OrganizationParams.PROJECT,
+            GlobalParams.ENVIRONMENT,
+            GlobalParams.STATS_PERIOD,
+            GlobalParams.START,
+            GlobalParams.END,
+            VisibilityParams.DATASET,
+            VisibilityParams.FIELD,
+            VisibilityParams.QUERY,
+            VisibilityParams.SORT,
+        ],
+        responses={
+            # Both statuses carry the same body: the endpoint reports validity in
+            # `valid` and returns 400 when any part of the query is invalid.
+            200: inline_sentry_response_serializer(
+                "ValidateEventsQueryResponse", ValidationResponse
+            ),
+            400: inline_sentry_response_serializer(
+                "InvalidEventsQueryResponse", ValidationResponse
+            ),
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+        },
+    )
+    def get(
+        self, request: Request, organization: Organization
+    ) -> Response[ValidationResponse] | Response[None]:
+        """
+        Check whether a set of fields, a search query, and a sort would form a valid
+        query, without running it. Reports each field, orderby, and query term
+        separately so an invalid one can be corrected in place; `valid` is false and
+        the status is 400 when any part fails.
+        """
         if not self.has_feature(organization, request):
             return Response(status=400)
 

--- a/src/sentry/api/endpoints/organization_events_validate.py
+++ b/src/sentry/api/endpoints/organization_events_validate.py
@@ -1,7 +1,5 @@
 from collections import defaultdict
-from dataclasses import asdict, dataclass
-from dataclasses import field as dataclass_field
-from typing import Any
+from typing import Any, TypedDict
 
 from drf_spectacular.utils import extend_schema
 from rest_framework.exceptions import ParseError
@@ -30,36 +28,31 @@ from sentry.utils import snuba_rpc
 from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 
 
-@dataclass(kw_only=True)
-class Validation:
+class Validation(TypedDict):
     valid: bool
     error: str | None
 
 
-@dataclass(kw_only=True)
 class NamedValidation(Validation):
     name: str
 
 
-@dataclass(kw_only=True)
 class AttributeValidation(NamedValidation):
     # None when its an error
     attrType: str | None
 
 
-@dataclass(kw_only=True)
 class QueryValidation(Validation):
-    fields: list[AttributeValidation] = dataclass_field(default_factory=list)
+    fields: list[AttributeValidation]
 
 
-@dataclass(kw_only=True)
-class ValidationResponse:
+class ValidationResponse(TypedDict):
     valid: bool
-    dataset: list[NamedValidation] = dataclass_field(default_factory=list)
-    environment: list[Validation] = dataclass_field(default_factory=list)
-    field: list[AttributeValidation] = dataclass_field(default_factory=list)
-    orderby: list[AttributeValidation] = dataclass_field(default_factory=list)
-    projects: list[Validation] = dataclass_field(default_factory=list)
+    dataset: list[NamedValidation]
+    environment: list[Validation]
+    field: list[AttributeValidation]
+    orderby: list[AttributeValidation]
+    projects: list[Validation]
     query: QueryValidation
 
 
@@ -151,8 +144,8 @@ class OrganizationEventsValidateEndpoint(OrganizationEventsEndpointBase):
         validity: ValidationResponse,
     ) -> Response:
         return Response(
-            status=200 if validity.valid else 400,
-            data=asdict(validity),
+            status=200 if validity["valid"] else 400,
+            data=validity,
         )
 
     def validate_columns(
@@ -206,7 +199,15 @@ class OrganizationEventsValidateEndpoint(OrganizationEventsEndpointBase):
         if not self.has_feature(organization, request):
             return Response(status=400)
 
-        response = ValidationResponse(valid=True, query=QueryValidation(valid=True, error=None))
+        response = ValidationResponse(
+            valid=True,
+            dataset=[],
+            environment=[],
+            field=[],
+            orderby=[],
+            projects=[],
+            query=QueryValidation(valid=True, error=None, fields=[]),
+        )
 
         try:
             snuba_params = self.get_snuba_params(
@@ -214,21 +215,21 @@ class OrganizationEventsValidateEndpoint(OrganizationEventsEndpointBase):
                 organization,
             )
         except NoProjects:
-            response.valid = False
-            response.projects.append(
+            response["valid"] = False
+            response["projects"].append(
                 Validation(valid=False, error="At least one valid project is required to query")
             )
             return self.serialize_response(response)
         except UnknownEnvironments as error:
-            response.valid = False
-            response.environment.append(Validation(valid=False, error=str(error)))
+            response["valid"] = False
+            response["environment"].append(Validation(valid=False, error=str(error)))
             return self.serialize_response(response)
 
         try:
             dataset = self.get_dataset(request, organization)
         except ParseError as error:
-            response.valid = False
-            response.dataset.append(
+            response["valid"] = False
+            response["dataset"].append(
                 NamedValidation(
                     name=request.GET.get("dataset", "discover"), valid=False, error=str(error)
                 )
@@ -236,7 +237,7 @@ class OrganizationEventsValidateEndpoint(OrganizationEventsEndpointBase):
             return self.serialize_response(response)
 
         if dataset not in RPC_DATASETS:
-            response.dataset.append(
+            response["dataset"].append(
                 NamedValidation(
                     name=request.GET.get("dataset", "discover"),
                     valid=True,
@@ -254,7 +255,7 @@ class OrganizationEventsValidateEndpoint(OrganizationEventsEndpointBase):
             selected_columns, resolver
         )
         if not valid:
-            response.valid = valid
+            response["valid"] = valid
 
         # Validate query
         query_string = request.GET.get("query", "")
@@ -276,18 +277,19 @@ class OrganizationEventsValidateEndpoint(OrganizationEventsEndpointBase):
                 else:
                     parsed_terms = []
             query_columns = resolver.collect_terms(parsed_terms)
-            response.query.fields, query_attributes_to_lookup, valid = self.validate_columns(
+            query_field_validity, query_attributes_to_lookup, valid = self.validate_columns(
                 query_columns, resolver
             )
+            response["query"]["fields"] = query_field_validity
             if not valid:
-                response.valid = valid
+                response["valid"] = valid
             # While resolve_query also runs parse_search_query, we don't need the resolved_query just want to dry-run it
             # to get any errors
             resolver.resolve_query(query_string)
         except InvalidSearchQuery as error:
-            response.valid = False
-            response.query.error = str(error)
-            response.query.valid = False
+            response["valid"] = False
+            response["query"]["error"] = str(error)
+            response["query"]["valid"] = False
 
         # Lookup unknown fields and add to validities
         # Combine the lookup dictionaries
@@ -315,7 +317,7 @@ class OrganizationEventsValidateEndpoint(OrganizationEventsEndpointBase):
                                 valid=True,
                             )
                         else:
-                            response.valid = False
+                            response["valid"] = False
                             validity = AttributeValidation(
                                 attrType=None,
                                 error="Unknown attribute",
@@ -329,17 +331,17 @@ class OrganizationEventsValidateEndpoint(OrganizationEventsEndpointBase):
                             column_validity.append(validity)
                         if (
                             resolved.public_alias in query_columns
-                            and validity not in response.query.fields
+                            and validity not in response["query"]["fields"]
                         ):
-                            response.query.fields.append(validity)
+                            response["query"]["fields"].append(validity)
 
-        response.field.extend(column_validity)
+        response["field"].extend(column_validity)
         # If the response is still valid check if there's a field validity we wanna use
-        if response.query.valid:
-            for field in response.query.fields:
-                if not field.valid:
-                    response.query.valid = False
-                    response.query.error = field.error
+        if response["query"]["valid"]:
+            for field in response["query"]["fields"]:
+                if not field["valid"]:
+                    response["query"]["valid"] = False
+                    response["query"]["error"] = field["error"]
                     break
 
         # Validate orderby
@@ -352,12 +354,12 @@ class OrganizationEventsValidateEndpoint(OrganizationEventsEndpointBase):
                 found = False
                 for field in column_validity:
                     if (
-                        field.name == stripped_orderby
-                        or fields.get_function_alias(field.name) == stripped_orderby
+                        field["name"] == stripped_orderby
+                        or fields.get_function_alias(field["name"]) == stripped_orderby
                     ):
                         orderby_validity.append(
                             AttributeValidation(
-                                attrType=field.attrType, error=None, name=orderby, valid=True
+                                attrType=field["attrType"], error=None, name=orderby, valid=True
                             )
                         )
                         found = True
@@ -370,7 +372,7 @@ class OrganizationEventsValidateEndpoint(OrganizationEventsEndpointBase):
                         )
                         found = True
                 if not found:
-                    response.valid = False
+                    response["valid"] = False
                     orderby_validity.append(
                         AttributeValidation(
                             attrType=None,
@@ -379,6 +381,6 @@ class OrganizationEventsValidateEndpoint(OrganizationEventsEndpointBase):
                             valid=False,
                         )
                     )
-        response.orderby.extend(orderby_validity)
+        response["orderby"].extend(orderby_validity)
 
         return self.serialize_response(response)


### PR DESCRIPTION
Documents the request params and response type for `GET /organizations/{org}/events/validate/` so internal tooling can generate a typed client for it. That generator only admits an operation whose success response resolves to a concrete schema.

Last of five related endpoints (BROWSE-693); same pattern as #121319, #121328, #121332, #121334.

**`publish_status` stays `EXPERIMENTAL`** — absent from the public spec, which I verified is byte-identical to master.

### Two commits

**1. `ref`: dataclasses → TypedDicts.** The response was assembled from five dataclasses and flattened with `asdict()`. drf-spectacular's type resolver has no dataclass branch and raises on one, so the response couldn't be documented without this. The inheritance chain maps directly, `asdict()` was only producing the dict the TypedDicts already are, and the `validity not in ...` identity check still works because dict equality is structural. Also drops an `asdict()` deep copy per request.

Two non-mechanical bits: TypedDicts have no `default_factory`, so the `ValidationResponse` constructor now passes its six empty lists explicitly; and `response.query.fields` was assigned via tuple unpacking, which doesn't work on a subscript, so it became an explicit assignment.

**2. `feat`: the schema.** Declares 200 and 400 with the same component — the endpoint reports validity in the body and returns 400 when any part of the query is invalid, so both statuses carry an identical shape.

### Verification

The refactor is the risky half, so I checked it against behaviour rather than relying on the 25 existing tests. Captured a golden snapshot of status + full body across nine request permutations covering every branch that builds the response (no-projects, bad dataset, bad environment, valid fields, unknown attribute, bad query syntax, orderby-not-selected, aggregate field, non-RPC dataset), then diffed: **byte-identical** after the refactor, and still identical after the schema commit.

`pytest tests/sentry/api/endpoints/test_organization_events_validate.py` → 25 passed.

### Why this one is worth it

The generated response type goes from an opaque dict to per-field, per-orderby, and per-query-term validity with types and error strings — the difference between "your query is invalid" and "`totally.not.a.field` is unknown, the rest is fine."

Refs BROWSE-693