### PR TITLE
o11y(replays): Log how far a delete_replays run got

### DIFF
--- a/src/sentry/replays/scripts/delete_replays.py
+++ b/src/sentry/replays/scripts/delete_replays.py
@@ -93,6 +93,10 @@ def delete_replays(
                     "window_end": window_end,
                     "has_more": has_more,
                     "total_replays": total_replays,
+                    # How far the run got. A job killed at `max-job-duration` never reaches the end
+                    # of the loop, so this is the only record of where it stopped.
+                    "window_offset_days": window_offset_days,
+                    "after_replay_id_hash": cursor,
                 }
                 if dry_run:
                     logger.info(


### PR DESCRIPTION
**Closed without merging.** Superseded by a broader observability pass on replay deletion rather than landing two log fields on their own.

The change was four lines: `window_offset_days` and `after_replay_id_hash` added to the existing per-page `logging_context`, so a run killed by the GoCD `max-job-duration` left a record of where it stopped.

## Context worth keeping

This started as full resume-from-position (plus getsentry#21375 to feed `START_FROM` back in) and was cut down to logging, then dropped. The reasoning:

- **Re-running is already safe.** Deletes swallow 404s, duplicate archive markers are harmless, Seer deletes are idempotent. The jobs README requires scripts be *"restartable (it's safe to restart the script when it fails or is killed)"* — idempotency satisfies that; it does not require resuming from a position.
- **Little to redo.** With per-day manifests and a finder that prunes (#121336, merged), a project-day is roughly 55 pages and single-digit minutes against a 30-minute cap.
- **Cost was disproportionate** for the resume half: a cursor format, a signature change in shared code, and cross-repo deploy ordering.

Refs REPLAY-965