### PR TITLE
feat(onboarding): Add agentic setup interstitial to the welcome step

### DIFF
--- a/static/app/components/onboarding/onboardingContext.tsx
+++ b/static/app/components/onboarding/onboardingContext.tsx
@@ -14,12 +14,16 @@ type OnboardingContextProps = {
   discardOnboardingSession: () => void;
   messagingSetup: ScmMessagingSetup;
   resetOnboarding: () => void;
+  setAgentSetupProjectBaseline: (
+    baseline?: OnboardingSessionState['agentSetupProjectBaseline']
+  ) => void;
   setCreatedProjectSlug: (slug?: string) => void;
   setMessagingSetup: (messagingSetup: ScmMessagingSetup) => void;
   setSelectedFeatures: (features?: ProductSolution[]) => void;
   setSelectedIntegration: (integration?: Integration) => void;
   setSelectedPlatform: (selectedSDK?: OnboardingSelectedSDK) => void;
   setSelectedRepository: (repo?: Repository) => void;
+  agentSetupProjectBaseline?: OnboardingSessionState['agentSetupProjectBaseline'];
   createdProjectSlug?: string;
   selectedFeatures?: ProductSolution[];
   selectedIntegration?: Integration;
@@ -30,6 +34,10 @@ type OnboardingContextProps = {
 const ONBOARDING_SESSION_KEY = 'onboarding';
 
 type OnboardingSessionState = {
+  agentSetupProjectBaseline?: {
+    organizationId: string;
+    projectIds: string[];
+  };
   createdProjectSlug?: string;
   messagingSetup?: ScmMessagingSetup;
   selectedFeatures?: ProductSolution[];
@@ -54,6 +62,8 @@ const OnboardingContext = createContext<OnboardingContextProps>({
   setCreatedProjectSlug: () => {},
   messagingSetup: UNCONFIGURED_SCM_MESSAGING_SETUP,
   setMessagingSetup: () => {},
+  agentSetupProjectBaseline: undefined,
+  setAgentSetupProjectBaseline: () => {},
   clearDerivedState: () => {},
   resetOnboarding: () => {},
   discardOnboardingSession: () => {},
@@ -121,6 +131,12 @@ export function OnboardingContextProvider({children, initialValue}: ProviderProp
       messagingSetup: onboarding?.messagingSetup ?? UNCONFIGURED_SCM_MESSAGING_SETUP,
       setMessagingSetup: (messagingSetup: ScmMessagingSetup) => {
         setOnboarding(prev => ({...prev, messagingSetup}));
+      },
+      agentSetupProjectBaseline: onboarding?.agentSetupProjectBaseline,
+      setAgentSetupProjectBaseline: (
+        agentSetupProjectBaseline?: OnboardingSessionState['agentSetupProjectBaseline']
+      ) => {
+        setOnboarding(prev => ({...prev, agentSetupProjectBaseline}));
       },
       // Clear state derived from the selected repository (platform, features,
       // created project) without wiping the entire session. Use this when the

--- a/static/app/utils/analytics/onboardingAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/onboardingAnalyticsEvents.tsx
@@ -123,7 +123,11 @@ export type OnboardingEventParameters = {
   'onboarding.scm_view_sample_event_clicked': {
     platform?: string;
   };
+  'onboarding.scm_welcome_agent_command_copied': {
+    source: 'install_command' | 'prompt';
+  };
   'onboarding.scm_welcome_continue_clicked': Record<string, unknown>;
+  'onboarding.scm_welcome_present_agentic_interstitial_clicked': Record<string, unknown>;
   'onboarding.scm_welcome_step_viewed': Record<string, unknown>;
   'onboarding.select_framework_modal_close_button_clicked': {
     platform: string;
@@ -220,6 +224,10 @@ export const onboardingEventMap: Record<keyof OnboardingEventParameters, string>
     'Onboarding: SCM Setup Platform Later Clicked',
   'onboarding.scm_take_to_error_clicked': 'Onboarding: SCM Take to Error Clicked',
   'onboarding.scm_view_sample_event_clicked': 'Onboarding: SCM View Sample Event Clicked',
+  'onboarding.scm_welcome_agent_command_copied':
+    'Onboarding: SCM Welcome Agent Command Copied',
   'onboarding.scm_welcome_continue_clicked': 'Onboarding: SCM Welcome Continue Clicked',
+  'onboarding.scm_welcome_present_agentic_interstitial_clicked':
+    'Onboarding: SCM Welcome Present Agentic Interstitial Clicked',
   'onboarding.scm_welcome_step_viewed': 'Onboarding: SCM Welcome Step Viewed',
 };

--- a/static/app/views/onboarding/components/agentSetupWaiter.spec.tsx
+++ b/static/app/views/onboarding/components/agentSetupWaiter.spec.tsx
@@ -1,0 +1,143 @@
+import {GroupFixture} from 'sentry-fixture/group';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {OnboardingContextProvider} from 'sentry/components/onboarding/onboardingContext';
+import {EventOrGroupType} from 'sentry/types/event';
+import {AgentSetupWaiter} from 'sentry/views/onboarding/components/agentSetupWaiter';
+
+describe('AgentSetupWaiter', () => {
+  const organization = OrganizationFixture();
+  const agentProject = ProjectFixture({id: '10', slug: 'agent-witness'});
+
+  function mockProjects(projects: Array<ReturnType<typeof ProjectFixture>>) {
+    return MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      body: projects,
+    });
+  }
+
+  function mockIssues(issues: Array<ReturnType<typeof GroupFixture>>) {
+    return MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${agentProject.slug}/issues/`,
+      body: issues,
+    });
+  }
+
+  // The interval only has to outlast a render; the transitions are awaited.
+  function renderWaiter() {
+    return render(
+      <OnboardingContextProvider>
+        <AgentSetupWaiter pollInterval={20} />
+      </OnboardingContextProvider>,
+      {organization}
+    );
+  }
+
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+    window.sessionStorage.clear();
+  });
+
+  it('shows both milestones while waiting for the project', async () => {
+    mockProjects([]);
+
+    renderWaiter();
+
+    expect(await screen.findByText('Waiting for project creation')).toBeInTheDocument();
+    expect(screen.getByText('Waiting for verification error')).toBeInTheDocument();
+    expect(screen.queryByText('Project created:')).not.toBeInTheDocument();
+  });
+
+  it('reports the project once the agent creates it', async () => {
+    mockProjects([]);
+
+    renderWaiter();
+
+    expect(await screen.findByText('Waiting for project creation')).toBeInTheDocument();
+
+    mockProjects([agentProject]);
+    mockIssues([]);
+
+    expect(await screen.findByText('Project created:')).toBeInTheDocument();
+    expect(screen.getByText('agent-witness')).toBeInTheDocument();
+    // The second milestone is still outstanding
+    expect(screen.getByText('Waiting for verification error')).toBeInTheDocument();
+  });
+
+  it('links the verification error once it lands', async () => {
+    mockProjects([]);
+
+    renderWaiter();
+
+    expect(await screen.findByText('Waiting for project creation')).toBeInTheDocument();
+
+    mockProjects([agentProject]);
+    mockIssues([
+      GroupFixture({
+        id: '42',
+        project: agentProject,
+        type: EventOrGroupType.ERROR,
+        metadata: {value: 'Sentry verification: agent-witness first error'},
+      }),
+    ]);
+
+    const link = await screen.findByRole('link', {
+      name: /Sentry verification: agent-witness first error/,
+    });
+    expect(link).toHaveAttribute(
+      'href',
+      expect.stringContaining(`/organizations/${organization.slug}/issues/42/`)
+    );
+
+    await userEvent.tab();
+    expect(link).toHaveFocus();
+    await userEvent.tab();
+    expect(link).not.toContainElement(document.activeElement as HTMLElement);
+
+    expect(screen.queryByText('Waiting for verification error')).not.toBeInTheDocument();
+  });
+
+  it('ignores projects that already existed when it mounted', async () => {
+    const preexistingProject = ProjectFixture({id: '1', slug: 'preexisting'});
+    mockProjects([preexistingProject]);
+
+    renderWaiter();
+
+    expect(await screen.findByText('Waiting for project creation')).toBeInTheDocument();
+
+    // Give the poll several chances to mistake the existing project for a new one
+    await waitFor(() => {
+      expect(screen.queryByText('Project created:')).not.toBeInTheDocument();
+    });
+    expect(screen.getByText('Waiting for project creation')).toBeInTheDocument();
+
+    mockProjects([preexistingProject, agentProject]);
+    mockIssues([]);
+
+    expect(await screen.findByText('Project created:')).toBeInTheDocument();
+    expect(screen.getByText('agent-witness')).toBeInTheDocument();
+  });
+
+  it('preserves the project baseline across remounts', async () => {
+    const preexistingProject = ProjectFixture({id: '1', slug: 'preexisting'});
+    mockProjects([preexistingProject]);
+
+    const {unmount} = renderWaiter();
+
+    expect(await screen.findByText('Waiting for project creation')).toBeInTheDocument();
+
+    mockProjects([preexistingProject, agentProject]);
+    mockIssues([]);
+
+    expect(await screen.findByText('Project created:')).toBeInTheDocument();
+
+    unmount();
+    renderWaiter();
+
+    expect(await screen.findByText('Project created:')).toBeInTheDocument();
+    expect(screen.getByText('agent-witness')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/onboarding/components/agentSetupWaiter.tsx
+++ b/static/app/views/onboarding/components/agentSetupWaiter.tsx
@@ -1,0 +1,200 @@
+import {useEffect} from 'react';
+import {useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
+import {skipToken, useQuery} from '@tanstack/react-query';
+
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Link} from '@sentry/scraps/link';
+import {Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import {CircleIndicator} from 'sentry/components/circleIndicator';
+import ProjectBadge from 'sentry/components/idBadge/projectBadge';
+import {useOnboardingContext} from 'sentry/components/onboarding/onboardingContext';
+import {IconCheckmark} from 'sentry/icons';
+import {SvgIcon} from 'sentry/icons/svgIcon';
+import {t} from 'sentry/locale';
+import {pulsingIndicatorStyles} from 'sentry/styles/pulsingIndicator';
+import type {Group} from 'sentry/types/group';
+import type {Project} from 'sentry/types/project';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+import {getMessage, getTitle} from 'sentry/utils/events';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {createIssueLink} from 'sentry/views/issueList/utils';
+
+const DEFAULT_POLL_INTERVAL_MS = 5000;
+const ICON_SIZE = SvgIcon.ICON_SIZES.xs;
+
+interface AgentSetupWaiterProps {
+  /**
+   * How often to poll for each milestone.
+   */
+  pollInterval?: number;
+}
+
+/**
+ * Waits for the agent to create a project. Projects that already exist when this
+ * mounts are recorded and ignored, so an org that arrives here with projects
+ * doesn't report one of those as the agent's work.
+ */
+function useAgentCreatedProject(pollInterval: number): Project | undefined {
+  const organization = useOrganization();
+  const {agentSetupProjectBaseline, setAgentSetupProjectBaseline} =
+    useOnboardingContext();
+  const preexistingProjectIds =
+    agentSetupProjectBaseline?.organizationId === organization.id
+      ? agentSetupProjectBaseline.projectIds
+      : undefined;
+
+  const findNewProject = (candidates: Project[] | undefined) =>
+    preexistingProjectIds
+      ? candidates?.find(project => !preexistingProjectIds.includes(project.id))
+      : undefined;
+
+  const {data: projects} = useQuery({
+    ...apiOptions.as<Project[]>()('/organizations/$organizationIdOrSlug/projects/', {
+      path: {organizationIdOrSlug: organization.slug},
+      staleTime: 0,
+    }),
+    refetchInterval: query =>
+      findNewProject(query.state.data?.json) ? false : pollInterval,
+    refetchOnWindowFocus: true,
+  });
+
+  useEffect(() => {
+    if (projects && !preexistingProjectIds) {
+      setAgentSetupProjectBaseline({
+        organizationId: organization.id,
+        projectIds: projects.map(project => project.id),
+      });
+    }
+  }, [organization.id, preexistingProjectIds, projects, setAgentSetupProjectBaseline]);
+
+  return findNewProject(projects);
+}
+
+/**
+ * Waits for the first issue to land in the project the agent created. Any issue
+ * in a project that new is the verification event.
+ */
+function useFirstIssue(
+  project: Project | undefined,
+  pollInterval: number
+): Group | undefined {
+  const organization = useOrganization();
+
+  const {data: issues} = useQuery({
+    ...apiOptions.as<Group[]>()(
+      '/projects/$organizationIdOrSlug/$projectIdOrSlug/issues/',
+      {
+        path: project
+          ? {organizationIdOrSlug: organization.slug, projectIdOrSlug: project.slug}
+          : skipToken,
+        staleTime: 0,
+      }
+    ),
+    refetchInterval: query => (query.state.data?.json.length ? false : pollInterval),
+    refetchOnWindowFocus: true,
+  });
+
+  return issues?.[0];
+}
+
+/**
+ * The dot leading a step: pulsing while the step is what we're waiting on, and
+ * a resting grey circle until then.
+ */
+function StepSymbol({active, done}: {active: boolean; done: boolean}) {
+  const theme = useTheme();
+
+  if (done) {
+    return <IconCheckmark size="xs" variant="success" />;
+  }
+
+  return active ? (
+    <WaitingIndicator />
+  ) : (
+    <CircleIndicator size={8} color={theme.tokens.graphics.neutral.moderate} />
+  );
+}
+
+const WaitingIndicator = styled('div')`
+  ${pulsingIndicatorStyles};
+`;
+
+/**
+ * Tracks the agent through the two milestones it can't report back itself:
+ * creating the project, then sending the verification error. Both steps are
+ * always listed so the shape of what's coming is visible from the start, and
+ * each resolves in place as the agent gets there.
+ */
+export function AgentSetupWaiter({
+  pollInterval = DEFAULT_POLL_INTERVAL_MS,
+}: AgentSetupWaiterProps) {
+  const location = useLocation();
+  const organization = useOrganization();
+  const project = useAgentCreatedProject(pollInterval);
+  const firstIssue = useFirstIssue(project, pollInterval);
+
+  return (
+    <Stack gap="xs">
+      <Flex align="center" gap="xs">
+        <Flex
+          align="center"
+          justify="center"
+          width={ICON_SIZE}
+          height={ICON_SIZE}
+          flexShrink={0}
+        >
+          <StepSymbol done={!!project} active />
+        </Flex>
+        {project ? (
+          // The badge renders as a flex row, so it sits beside the label rather
+          // than inside it.
+          <Flex align="center" gap="xs">
+            <Text size="sm" variant="muted">
+              {t('Project created:')}
+            </Text>
+            <ProjectBadge project={project} avatarSize={16} disableLink />
+          </Flex>
+        ) : (
+          <Text size="sm" variant="promotion">
+            {t('Waiting for project creation')}
+          </Text>
+        )}
+      </Flex>
+      <Flex align="center" gap="xs">
+        <Flex
+          align="center"
+          justify="center"
+          width={ICON_SIZE}
+          height={ICON_SIZE}
+          flexShrink={0}
+        >
+          <StepSymbol done={!!firstIssue} active={!!project} />
+        </Flex>
+        {firstIssue ? (
+          <Tooltip title={t('View the verification error')} skipWrapper>
+            <Link
+              to={createIssueLink({
+                organization,
+                location,
+                data: firstIssue,
+                referrer: 'onboarding-agentic-setup',
+              })}
+            >
+              <Text size="sm" variant="inherit">
+                {getMessage(firstIssue) || getTitle(firstIssue).title}
+              </Text>
+            </Link>
+          </Tooltip>
+        ) : (
+          <Text size="sm" variant={project ? 'promotion' : 'muted'}>
+            {t('Waiting for verification error')}
+          </Text>
+        )}
+      </Flex>
+    </Stack>
+  );
+}

--- a/static/app/views/onboarding/components/newWelcome.tsx
+++ b/static/app/views/onboarding/components/newWelcome.tsx
@@ -1,5 +1,5 @@
-import {useEffect} from 'react';
-import {motion, type MotionProps} from 'framer-motion';
+import {useEffect, useState} from 'react';
+import {AnimatePresence, motion, type MotionProps} from 'framer-motion';
 
 import {FeatureBadge} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
@@ -19,12 +19,15 @@ import {
   IconWarning,
 } from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {useExperiment} from 'sentry/utils/useExperiment';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {GenericFooter} from 'sentry/views/onboarding/components/genericFooter';
 import {
   NewWelcomeProductCard,
   type ProductOption,
 } from 'sentry/views/onboarding/components/newWelcomeProductCard';
+import {WelcomeAgentSetup} from 'sentry/views/onboarding/components/welcomeAgentSetup';
 import {WelcomeBackgroundNewUi} from 'sentry/views/onboarding/components/welcomeBackground';
 import {WelcomeSkipButton} from 'sentry/views/onboarding/components/welcomeSkipButton';
 import {ONBOARDING_WELCOME_STAGGER_ITEM} from 'sentry/views/onboarding/consts';
@@ -119,10 +122,13 @@ const PRODUCT_OPTIONS: ProductOption[] = [
 ];
 
 export function NewWelcomeUI(props: StepProps) {
+  const organization = useOrganization();
   const {inExperiment: hasScmOnboarding} = useExperiment({
     feature: 'onboarding-scm-experiment',
     reportExposure: false,
   });
+  const hasAgenticSetup = organization.features.includes('onboarding-agentic-setup');
+  const [showAgentSetup, setShowAgentSetup] = useState(false);
 
   useWelcomeAnalyticsEffect();
 
@@ -135,6 +141,17 @@ export function NewWelcomeUI(props: StepProps) {
   }, []);
 
   const handleComplete = useWelcomeHandleComplete(props.onComplete);
+
+  const handleGetStarted = () => {
+    trackAnalytics('onboarding.scm_welcome_present_agentic_interstitial_clicked', {
+      organization,
+    });
+    setShowAgentSetup(true);
+  };
+
+  const handleCopyCommand = (source: 'install_command' | 'prompt') => {
+    trackAnalytics('onboarding.scm_welcome_agent_command_copied', {organization, source});
+  };
 
   return (
     <MotionContainer width="100%" margin="0 auto" maxWidth="900px" position="relative">
@@ -191,43 +208,77 @@ export function NewWelcomeUI(props: StepProps) {
             )}
           </MotionStack>
 
-          <MotionGrid
-            columns={{'screen:xs': '1fr', 'screen:sm': 'repeat(3, 1fr)'}}
-            gap="3xl"
-            width="100%"
-            {...ONBOARDING_WELCOME_STAGGER_ITEM}
-            border="muted"
-            background="secondary"
-            radius="lg"
-            padding="2xl"
-          >
-            {PRODUCT_OPTIONS.map(product => (
-              <NewWelcomeProductCard key={product.id} product={product} />
-            ))}
-          </MotionGrid>
-
-          {hasScmOnboarding ? (
-            <MotionFlex {...ONBOARDING_WELCOME_STAGGER_ITEM} width="100%" justify="end">
-              <Button
-                variant="primary"
-                onClick={handleComplete}
-                data-test-id="onboarding-welcome-start"
+          {/* Let the onboarding step's exit animate through this nested boundary. */}
+          <AnimatePresence mode="wait" initial={false} propagate>
+            {showAgentSetup ? (
+              // The agent setup swaps in after the stagger has already run, so it
+              // drives the shared variants itself rather than inheriting them.
+              // Declaring `animate` makes it a variant root, which also stops the
+              // step-level exit label from propagating in — hence the explicit exit.
+              <MotionContainer
+                key="agent-setup"
+                width="100%"
+                initial="initial"
+                animate="animate"
+                exit="exit"
+                {...ONBOARDING_WELCOME_STAGGER_ITEM}
               >
-                {t('Let’s get started')}
-              </Button>
-            </MotionFlex>
-          ) : (
-            <MotionContainer {...ONBOARDING_WELCOME_STAGGER_ITEM}>
-              <Flex align="center" gap="md" justify="center">
-                <IconCheckmark size="md" variant="success" />
-                <Text size="md" variant="muted">
-                  {t(
-                    "After the trial ends, you'll move to our free plan. You will not be charged for any usage, promise."
-                  )}
-                </Text>
-              </Flex>
-            </MotionContainer>
-          )}
+                <WelcomeAgentSetup
+                  onCopyCommand={handleCopyCommand}
+                  onSetupInBrowser={handleComplete}
+                />
+              </MotionContainer>
+            ) : (
+              <MotionStack
+                key="products"
+                gap="3xl"
+                width="100%"
+                transition={{staggerChildren: 0.125}}
+              >
+                <MotionGrid
+                  columns={{'screen:xs': '1fr', 'screen:sm': 'repeat(3, 1fr)'}}
+                  gap="3xl"
+                  width="100%"
+                  {...ONBOARDING_WELCOME_STAGGER_ITEM}
+                  border="muted"
+                  background="secondary"
+                  radius="lg"
+                  padding="2xl"
+                >
+                  {PRODUCT_OPTIONS.map(product => (
+                    <NewWelcomeProductCard key={product.id} product={product} />
+                  ))}
+                </MotionGrid>
+
+                {hasScmOnboarding ? (
+                  <MotionFlex
+                    {...ONBOARDING_WELCOME_STAGGER_ITEM}
+                    width="100%"
+                    justify="end"
+                  >
+                    <Button
+                      variant="primary"
+                      onClick={hasAgenticSetup ? handleGetStarted : handleComplete}
+                      data-test-id="onboarding-welcome-start"
+                    >
+                      {t('Let’s get started')}
+                    </Button>
+                  </MotionFlex>
+                ) : (
+                  <MotionContainer {...ONBOARDING_WELCOME_STAGGER_ITEM}>
+                    <Flex align="center" gap="md" justify="center">
+                      <IconCheckmark size="md" variant="success" />
+                      <Text size="md" variant="muted">
+                        {t(
+                          "After the trial ends, you'll move to our free plan. You will not be charged for any usage, promise."
+                        )}
+                      </Text>
+                    </Flex>
+                  </MotionContainer>
+                )}
+              </MotionStack>
+            )}
+          </AnimatePresence>
         </Stack>
         {hasScmOnboarding ? null : (
           <GenericFooter gap="3xl" padding="0 3xl">

--- a/static/app/views/onboarding/components/welcomeAgentSetup.tsx
+++ b/static/app/views/onboarding/components/welcomeAgentSetup.tsx
@@ -1,0 +1,241 @@
+import {Button} from '@sentry/scraps/button';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
+import {Heading, Text} from '@sentry/scraps/text';
+
+import {Hovercard} from 'sentry/components/hovercard';
+import {List} from 'sentry/components/list';
+import {ListItem} from 'sentry/components/list/listItem';
+import {TextCopyInput} from 'sentry/components/textCopyInput';
+import {
+  IconBot,
+  IconChat,
+  IconCheckmark,
+  IconGlobe,
+  IconInfo,
+  IconTerminal,
+} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {AgentSetupWaiter} from 'sentry/views/onboarding/components/agentSetupWaiter';
+
+type CopySource = 'install_command' | 'prompt';
+
+const INSTALL_PLUGIN_COMMAND = 'npx @sentry/agent-plugin install';
+
+const AGENT_CAPABILITIES = [
+  t('Detect your framework and language'),
+  t('Create and configure a new Sentry project'),
+  t('Install and instrument the Sentry SDK'),
+  t('Verify a real error reaches Sentry'),
+];
+
+interface WelcomeAgentSetupProps {
+  /**
+   * Fired when a command is copied out of one of the code blocks.
+   */
+  onCopyCommand: (source: CopySource) => void;
+  /**
+   * Leaves the agent path and continues into the step-by-step browser flow.
+   */
+  onSetupInBrowser: () => void;
+}
+
+export function WelcomeAgentSetup({
+  onCopyCommand,
+  onSetupInBrowser,
+}: WelcomeAgentSetupProps) {
+  return (
+    <Grid
+      columns={{'screen:xs': '1fr', 'screen:md': 'repeat(2, 1fr)'}}
+      gap="2xl"
+      width="100%"
+      align="start"
+    >
+      <Stack border="accent" radius="lg" overflow="hidden" gap="0">
+        <Stack padding="xl" gap="xl">
+          <Flex align="center" gap="sm">
+            <IconBot size="md" variant="secondary" />
+            {/* The slight offset optically aligns the label with the bot icon. */}
+            <Container paddingTop="2xs">
+              {props => (
+                <Text {...props} variant="muted" size="sm" bold uppercase>
+                  {t('Automatic')}
+                </Text>
+              )}
+            </Container>
+          </Flex>
+
+          <Stack gap="md">
+            <Heading as="h3" size="lg">
+              {t('Set up with your coding agent')}
+            </Heading>
+            <Text variant="muted" size="md" density="comfortable">
+              {t(
+                'Install the Sentry plugin, then open your agent in your project and let it handle the rest.'
+              )}
+            </Text>
+          </Stack>
+
+          <List symbol="colored-numeric">
+            <ListItem>
+              <Stack gap="md" paddingBottom="xl">
+                <StepLabel>{t('Install Sentry plugin')}</StepLabel>
+                <TextCopyInput
+                  size="sm"
+                  monospace
+                  icon={<IconTerminal size="xs" variant="secondary" />}
+                  onCopy={() => onCopyCommand('install_command')}
+                >
+                  {INSTALL_PLUGIN_COMMAND}
+                </TextCopyInput>
+              </Stack>
+            </ListItem>
+            <ListItem>
+              <Stack gap="xl">
+                <Stack gap="md">
+                  <StepLabel>
+                    {t('Then open your agent in your project and ask')}
+                  </StepLabel>
+                  <Stack gap="sm">
+                    <TextCopyInput
+                      size="sm"
+                      monospace
+                      icon={<IconChat size="xs" variant="secondary" />}
+                      onCopy={() => onCopyCommand('prompt')}
+                    >
+                      {t('Help me setup Sentry')}
+                    </TextCopyInput>
+                    <Flex>
+                      <Hovercard
+                        position="top"
+                        body={
+                          <Stack gap="md">
+                            {AGENT_CAPABILITIES.map(capability => (
+                              <Flex key={capability} align="center" gap="md">
+                                <Flex flexShrink={0}>
+                                  <IconCheckmark size="sm" variant="success" />
+                                </Flex>
+                                <Text variant="muted" size="sm">
+                                  {capability}
+                                </Text>
+                              </Flex>
+                            ))}
+                          </Stack>
+                        }
+                      >
+                        <Button
+                          variant="link"
+                          size="zero"
+                          icon={<IconInfo variant="secondary" />}
+                        >
+                          <Text size="sm" variant="muted" underline="dotted">
+                            {t('What will my agent do?')}
+                          </Text>
+                        </Button>
+                      </Hovercard>
+                    </Flex>
+                  </Stack>
+                </Stack>
+                <AgentSetupWaiter />
+              </Stack>
+            </ListItem>
+          </List>
+        </Stack>
+
+        <Flex
+          align="center"
+          justify="center"
+          background="secondary"
+          borderTop="muted"
+          padding="md xl"
+        >
+          <Text variant="muted" size="sm">
+            {t('Works with: Claude, Codex, Grok, and Cursor')}
+          </Text>
+        </Flex>
+      </Stack>
+
+      <Grid
+        columns={{'screen:xs': '1fr', 'screen:md': 'max-content 1fr'}}
+        gap="2xl"
+        align="stretch"
+      >
+        <Grid
+          columns={{'screen:xs': '1fr max-content 1fr', 'screen:md': 'none'}}
+          rows={{'screen:xs': 'none', 'screen:md': '1fr max-content 1fr'}}
+          align={{'screen:xs': 'center', 'screen:md': 'stretch'}}
+          justifyItems={{'screen:xs': 'stretch', 'screen:md': 'center'}}
+          gap="md"
+        >
+          <SeparatorRule />
+          <Text variant="muted" size="sm" bold uppercase>
+            {t('or')}
+          </Text>
+          <SeparatorRule />
+        </Grid>
+
+        <Stack
+          align="start"
+          gap="xl"
+          width="100%"
+          border="muted"
+          radius="lg"
+          padding="xl"
+        >
+          <Flex align="center" gap="sm">
+            <IconGlobe size="md" variant="secondary" />
+            <Text variant="muted" size="sm" bold uppercase>
+              {t('Manual')}
+            </Text>
+          </Flex>
+
+          <Stack gap="md">
+            <Heading as="h3" size="lg">
+              {t('Set up in browser')}
+            </Heading>
+            <Text variant="muted" size="md" density="comfortable" textWrap="pretty">
+              {t(
+                'Connect your repo, choose your platform, select, and instrument each product, step-by-step.'
+              )}
+            </Text>
+          </Stack>
+
+          <Button onClick={onSetupInBrowser} data-test-id="onboarding-setup-in-browser">
+            {t('Start setup')}
+          </Button>
+        </Stack>
+      </Grid>
+    </Grid>
+  );
+}
+
+/**
+ * List's numbered marker is a 24px circle pinned to the top of the item, which
+ * assumes a taller first line than this small uppercase label. The padding grows
+ * the label's box to match, and needs a block box to take effect.
+ */
+function StepLabel({children}: {children: React.ReactNode}) {
+  return (
+    <Container padding="sm 0">
+      {props => (
+        <Text {...props} display="block" size="md">
+          {children}
+        </Text>
+      )}
+    </Container>
+  );
+}
+
+/**
+ * One of the two rules flanking the "or" label. It draws as a horizontal line
+ * while the two setup paths stack, and turns vertical once they sit side by
+ * side. The grid stretches it along the line's axis and centers it on the
+ * other, so a single border edge is all the rule needs.
+ */
+function SeparatorRule() {
+  return (
+    <Container
+      borderTop={{'screen:xs': 'secondary', 'screen:md': 'none'}}
+      borderLeft={{'screen:xs': 'none', 'screen:md': 'secondary'}}
+    />
+  );
+}

--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -540,7 +540,7 @@ describe('Onboarding', () => {
 
   describe('SCM onboarding flow', () => {
     const scmOrganization = OrganizationFixture({
-      features: ['onboarding-scm-experiment'],
+      features: ['onboarding-scm-experiment', 'onboarding-agentic-setup'],
     });
 
     // Shares scmOrganization's slug, so the mocks registered in beforeEach below
@@ -580,6 +580,11 @@ describe('Onboarding', () => {
       });
       MockApiClient.addMockResponse({
         url: `/organizations/${scmOrganization.slug}/repos/`,
+        body: [],
+      });
+      // Polled by the agentic setup while it waits for the agent to create a project
+      MockApiClient.addMockResponse({
+        url: `/organizations/${scmOrganization.slug}/projects/`,
         body: [],
       });
     });
@@ -644,6 +649,7 @@ describe('Onboarding', () => {
       const {router} = renderOnboarding('welcome');
 
       await userEvent.click(screen.getByTestId('onboarding-welcome-start'));
+      await userEvent.click(await screen.findByRole('button', {name: 'Start setup'}));
 
       // Wait for scm-connect to render and its queries to resolve so the
       // mounted-effect fetches hit the mocked endpoints before afterEach
@@ -652,6 +658,37 @@ describe('Onboarding', () => {
 
       expect(router.location.pathname).toBe(
         `/onboarding/${scmOrganization.slug}/scm-connect/`
+      );
+    });
+
+    it('shows the agent setup on start click without leaving welcome', async () => {
+      const {router} = renderOnboarding('welcome');
+
+      await userEvent.click(screen.getByTestId('onboarding-welcome-start'));
+
+      expect(
+        await screen.findByDisplayValue('npx @sentry/agent-plugin install')
+      ).toBeInTheDocument();
+      expect(screen.getByDisplayValue('Help me setup Sentry')).toBeInTheDocument();
+      // The org has no projects yet, so the waiter is on its first milestone
+      expect(await screen.findByText('Waiting for project creation')).toBeInTheDocument();
+      expect(
+        screen.queryByText('Detect your framework and language')
+      ).not.toBeInTheDocument();
+
+      act(() => {
+        screen.getByRole('button', {name: 'What will my agent do?'}).focus();
+      });
+
+      expect(
+        await screen.findByText('Detect your framework and language')
+      ).toBeInTheDocument();
+      expect(trackAnalytics).toHaveBeenCalledWith(
+        'onboarding.scm_welcome_present_agentic_interstitial_clicked',
+        expect.objectContaining({organization: scmOrganization})
+      );
+      expect(router.location.pathname).toBe(
+        `/onboarding/${scmOrganization.slug}/welcome/`
       );
     });
 
@@ -679,6 +716,10 @@ describe('Onboarding', () => {
           selectedFeatures: [ProductSolution.ERROR_MONITORING],
           createdProjectSlug: 'javascript-nextjs',
           messagingSetup: selectedMessagingSetup,
+          agentSetupProjectBaseline: {
+            organizationId: scmOrganization.id,
+            projectIds: ['1'],
+          },
         })
       );
 
@@ -692,10 +733,23 @@ describe('Onboarding', () => {
       });
     });
 
-    it('fires scm_welcome_continue_clicked on start click and not the legacy event', async () => {
+    it('goes straight to scm-connect when the agentic setup is off', async () => {
+      const organization = OrganizationFixture({
+        features: ['onboarding-scm-experiment'],
+      });
+      const {router} = renderFlow(organization, 'welcome');
+
+      await userEvent.click(screen.getByTestId('onboarding-welcome-start'));
+
+      expect(await screen.findByText('GitHub')).toBeInTheDocument();
+      expect(router.location.pathname).toContain('/scm-connect/');
+    });
+
+    it('fires scm_welcome_continue_clicked on browser setup click and not the legacy event', async () => {
       renderOnboarding('welcome');
 
       await userEvent.click(screen.getByTestId('onboarding-welcome-start'));
+      await userEvent.click(await screen.findByRole('button', {name: 'Start setup'}));
 
       expect(trackAnalytics).toHaveBeenCalledWith(
         'onboarding.scm_welcome_continue_clicked',

--- a/tests/acceptance/test_scm_onboarding.py
+++ b/tests/acceptance/test_scm_onboarding.py
@@ -12,12 +12,16 @@ from sentry.models.rule import Rule
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.testutils.asserts import assert_existing_projects_status
 from sentry.testutils.cases import AcceptanceTestCase
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import no_silo_test
 
 pytestmark = pytest.mark.sentry_metrics
 
 
 @no_silo_test
+# start_onboarding() walks through the agentic setup interstitial to reach the
+# browser flow, which only renders with this flag on.
+@with_feature("organizations:onboarding-agentic-setup")
 class ScmOnboardingTest(AcceptanceTestCase):
     def setUp(self) -> None:
         super().setUp()
@@ -40,9 +44,15 @@ class ScmOnboardingTest(AcceptanceTestCase):
         return integration
 
     def start_onboarding(self) -> None:
+        """Walk the welcome step through to scm-connect.
+
+        Getting started opens the agentic setup interstitial rather than
+        advancing, so reaching the browser flow takes a second click.
+        """
         self.browser.get(f"/onboarding/{self.org.slug}/")
         self.browser.wait_until('[data-test-id="onboarding-step-welcome"]')
         self.browser.click('[data-test-id="onboarding-welcome-start"]')
+        self.browser.click('[data-test-id="onboarding-setup-in-browser"]')
         self.browser.wait_until('[data-test-id="onboarding-step-scm-connect"]')
 
     @contextmanager


### PR DESCRIPTION
The welcome step's only path forward was the click-through browser flow, which buries the fact that a coding agent can do the whole setup — including creating the project. Rather than adding a step to the flow, "Let's get started" now swaps the product grid for a two-path interstitial on the same view: agentic setup on the left, the browser flow as a card on the right.

Behind `organizations:onboarding-agentic-setup` (registered in #121364, **which needs to land first**) and limited to the `onboarding-scm-experiment` variant, since that's the only variant with a "Let's get started" button. With the flag off, that button goes straight into the browser flow exactly as it does today; the non-SCM welcome (footer + "Begin setup") is untouched either way.

### Agentic setup

Two numbered steps: install `npx @sentry/ai@latest install`, then paste a prompt that names the org, since the agent is what provisions the project:

```
Invoke the sentry-get-started skill for my new
Sentry Organization: <org-slug>
```

The prompt is hard-wrapped because code blocks scroll rather than wrap, and it's deliberately not run through `t()` — the agent parses it as a command, same as the npx line. The checklist under it mirrors the opening steps of that skill's `first-error-setup` spine in `getsentry/sentry-for-ai`.

### Progress feedback

`AgentSetupWaiter` tracks the two milestones the agent can't report back itself. Both steps are listed from the start so the shape of what's coming is visible, and each resolves in place:

| | |
|---|---|
| ◍ / ● | Waiting for project creation · Waiting for verification error (grey until active) |
| ✓ | Project created: `<project badge>` |
| ✓ | The error's message, linking to the issue |

It polls `/organizations/$org/projects/` every 5s, then the new project's issues. Projects that already exist when it mounts are recorded and ignored, so an org that re-enters onboarding with projects never reports one of those as the agent's work.

### Analytics

- `onboarding.scm_welcome_get_started_clicked` — new, fires when the interstitial opens
- `onboarding.scm_welcome_agent_command_copied` — new, with `source: install_command | prompt`
- `onboarding.scm_welcome_continue_clicked` — unchanged event, now fired by the browser card, so it keeps meaning "entered the step-by-step flow"

### Notes for review

- The NPX/CURL toggle from the design is dropped: only `npx @sentry/ai@latest install` exists, there's no documented curl installer.
- `tests/acceptance/test_scm_onboarding.py` rides along because it has to: `start_onboarding()` feeds most of that suite and asserts on this exact click path, so it can't land separately without one side being red. The flag is enabled for that class via `@with_feature` rather than added to each of its ten `self.feature` blocks.
- The step labels are padded via `StepLabel` so they center against `List`'s numbered marker, which is absolutely positioned at the item's top and assumes a taller first line than a small uppercase label. `display="block"` is required there because `Text` defaults to an inline span, where vertical padding wouldn't affect layout.
- `ProjectBadge` sits beside its label rather than inside it — `BaseBadge` renders a scraps `Flex`, so it can't flow inline in a `Text`.
- `AgentSetupWaiter` takes an optional `pollInterval` so its spec can drive the transitions without waiting 5s each, the same knob `useEventWaiter` exposes. Its four cases cover both milestones, the issue link, and the mount-time snapshot that keeps a pre-existing project from being reported as the agent's work.
