### PR TITLE
feat(onboarding): Add flag for the agentic setup interstitial

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -172,6 +172,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:on-demand-metrics-ui-widgets", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Only enabled in sentry.io to enable onboarding flows.
     manager.add("organizations:onboarding", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
+    # Enable the agentic setup interstitial on the onboarding welcome step
+    manager.add("organizations:onboarding-agentic-setup", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable copy setup instructions button on project creation getting-started page
     manager.add("organizations:onboarding-copy-setup-instructions-project-creation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable new onboarding welcome and SDK setup UI


### PR DESCRIPTION
Registers `organizations:onboarding-agentic-setup` ahead of the frontend change (#121363) so the interstitial can be rolled out to a subset of new orgs rather than to everyone in the SCM onboarding experiment at once.

`api_expose=True` because the check is a frontend one — the interstitial is entirely client-side, there's no backend behavior behind this flag.

FlagPole config to follow in `sentry-options-automator`.