### PR TITLE
ref: Replace backend driven feature lists with frontend mapping

### DIFF
--- a/static/gsApp/components/features/planFeature.spec.tsx
+++ b/static/gsApp/components/features/planFeature.spec.tsx
@@ -132,8 +132,10 @@ describe('PlanFeature', () => {
     });
     SubscriptionStore.set(organization.slug, sub);
 
+    // discover-basic is available on Team, but a sponsored subscription is only
+    // ever upsold to Business.
     render(
-      <PlanFeature organization={organization} features={['monitor-seat-billing']}>
+      <PlanFeature organization={organization} features={['discover-basic']}>
         {mockFn}
       </PlanFeature>
     );

--- a/static/gsApp/components/features/planFeature.tsx
+++ b/static/gsApp/components/features/planFeature.tsx
@@ -7,7 +7,80 @@ import {withSubscription} from 'getsentry/components/withSubscription';
 import {UNLIMITED_RESERVED} from 'getsentry/constants';
 import {useBillingConfig} from 'getsentry/hooks/useBillingConfig';
 import type {Plan, Subscription} from 'getsentry/types';
-import {isBizPlanFamily, isDeveloperPlan} from 'getsentry/utils/billing';
+import {
+  isBizPlanFamily,
+  isDeveloperPlan,
+  isTeamPlanFamily,
+} from 'getsentry/utils/billing';
+
+/**
+ * Plan tiers ordered from least to most capable. A plan satisfies a feature's
+ * requirement when its own rank is at or above the feature's minimum.
+ */
+const ORDERED_PLAN_TYPES = ['team', 'business', 'enterprise'] as const;
+
+type PlanType = (typeof ORDERED_PLAN_TYPES)[number];
+
+/**
+ * The lowest plan tier that includes each upsellable feature.
+ *
+ * Feature *gating* is owned by Flagpole; this map exists only to answer "which
+ * plan must a customer buy to get this?" so an upsell can name a plan. Keys are
+ * descoped feature names, so both `organizations:foo` and `foo` resolve here.
+ *
+ * A feature absent from this map has no upgrade target and its upsell renders
+ * without a plan name, so add an entry when wiring up a new `feature-disabled:*`
+ * override.
+ */
+const UPSELL_MINIMUM_PLAN_TYPE: Record<string, PlanType> = {
+  'custom-inbound-filters': 'business',
+  'custom-symbol-sources': 'business',
+  'data-forwarding': 'business',
+  'discard-groups': 'business',
+  'discover-basic': 'team',
+  'discover-query': 'team',
+  'extended-data-retention': 'team',
+  incidents: 'team',
+  'integrations-scm-multi-org': 'business',
+  'integrations-ticket-rules': 'business',
+  'issue-views': 'team',
+  'performance-view': 'team',
+  'rate-limits': 'business',
+  'spend-allocations': 'enterprise',
+  'sso-basic': 'team',
+  'sso-saml2': 'business',
+  'team-roles': 'business',
+};
+
+function planType(plan: Plan): PlanType | null {
+  if (plan.isEnterprise) {
+    return 'enterprise';
+  }
+  if (isBizPlanFamily(plan)) {
+    return 'business';
+  }
+  if (isTeamPlanFamily(plan)) {
+    return 'team';
+  }
+  return null;
+}
+
+/**
+ * Whether `plan` is capable enough for every requested feature.
+ */
+function planSatisfies(plan: Plan, requestedFeatures: string[]) {
+  const type = planType(plan);
+  if (type === null) {
+    return false;
+  }
+
+  const rank = ORDERED_PLAN_TYPES.indexOf(type);
+
+  return requestedFeatures.map(descopeFeatureName).every(feature => {
+    const required = UPSELL_MINIMUM_PLAN_TYPE[feature];
+    return required !== undefined && rank >= ORDERED_PLAN_TYPES.indexOf(required);
+  });
+}
 
 type RenderProps = {
   /**
@@ -83,9 +156,7 @@ function PlanFeature({subscription, features, organization, children}: Props) {
   }
 
   // Locate the first plan that offers these features
-  let requiredPlan = plans.find(plan =>
-    features.map(descopeFeatureName).every(f => plan.features.includes(f))
-  );
+  let requiredPlan = plans.find(plan => planSatisfies(plan, features));
 
   if (!requiredPlan && features.some(f => descopeFeatureName(f) === 'dashboards-edit')) {
     // XXX(isabella): This is a temporary fix to allow upsells using dashboards-edit


### PR DESCRIPTION
These features have been migrated to flagpole but we still need to know on the frontend which plan tier grants some features. Rather than including this in the "plan" object which is now served by billing platform and doesn't contain features, we can use this small list of features that replicate what is in flagpole