### PR TITLE
fix(seer): Don't run/score Smart Assignment against automatic assignments

### DIFF
--- a/src/sentry/seer/smart_assignment/models.py
+++ b/src/sentry/seer/smart_assignment/models.py
@@ -8,6 +8,8 @@ contract, and loosening them here means Seer adding a new signal source or
 confidence level can't make an otherwise-valid artifact fail to parse. `reason`
 and `confidence` are defaulted so a minimal-but-valid candidate (one that at least
 names someone) still round-trips.
+
+Also includes some utility functions for validating assignments.
 """
 
 from __future__ import annotations
@@ -17,6 +19,7 @@ from typing import Literal
 from django.db import models
 from pydantic import BaseModel, Field
 
+from sentry.models.activity import Activity, ActivityIntegration
 from sentry.types.activity import ActivityType
 
 # SeerAgentRun.source, the key we dedup/look up runs by.
@@ -36,6 +39,25 @@ RESOLUTION_ACTIVITIES = frozenset(
         ActivityType.SET_RESOLVED_IN_COMMIT,
     }
 )
+
+# We invalidate scoring against "ground truth" assignments from these sources, because they're
+# basically non-human actions: our own auto-assignment, project ownership, CODEOWNERS,
+# and the suspect commit feature. The agent is likely to make similar choices, so scoring
+# against these would inflate our success rate.
+UNSCORABLE_ASSIGNMENT_ORIGINS = frozenset(
+    {
+        ActivityIntegration.SEER_SUGGESTED.value,
+        ActivityIntegration.PROJECT_OWNERSHIP.value,
+        ActivityIntegration.CODEOWNERS.value,
+        ActivityIntegration.SUSPECT_COMMITTER.value,
+    }
+)
+
+
+def is_unscorable_assignment(activity: Activity | None) -> bool:
+    if activity is None or activity.type != ActivityType.ASSIGNED.value:
+        return False
+    return (activity.data or {}).get("integration") in UNSCORABLE_ASSIGNMENT_ORIGINS
 
 
 class SmartAssignmentScore(models.TextChoices):

--- a/src/sentry/seer/smart_assignment/scoring.py
+++ b/src/sentry/seer/smart_assignment/scoring.py
@@ -25,6 +25,19 @@ logger = logging.getLogger(__name__)
 # Right now the agent only returns 3 ranked candidates; this is the limit we score against.
 HIT_RANK_LIMIT = 3
 
+# We invalidate scoring against "ground truth" assignments from these sources, because they're
+# basically non-human actions: our own auto-assignment, project ownership, CODEOWNERS,
+# and the suspect commit feature. The agent is likely to make similar choices, so scoring
+# against these would inflate our success rate.
+UNSCORABLE_ASSIGNMENT_ORIGINS = frozenset(
+    {
+        ActivityIntegration.SEER_SUGGESTED.value,
+        ActivityIntegration.PROJECT_OWNERSHIP.value,
+        ActivityIntegration.CODEOWNERS.value,
+        ActivityIntegration.SUSPECT_COMMITTER.value,
+    }
+)
+
 
 class RunUpdates(TypedDict, total=False):
     """The mirrored fields we write onto a run's ``extras`` before scoring."""
@@ -93,8 +106,7 @@ def _ground_truth_updates(
     carries no useful signal.
 
     For an assignment we mirror the current assignee (user and/or team), unless it is
-    our own auto-assignment (tagged with the ``SEER_SUGGESTED`` integration by
-    ProjectOwnership.handle_auto_assignment, which would score us against ourselves).
+    from a source in ``UNSCORABLE_ASSIGNMENT_ORIGINS``.
     For a user-driven resolution we record the resolver as the assumed assignee only
     when no explicit assignee has been recorded -- an assignment is better truth.
     """
@@ -127,12 +139,12 @@ def _ground_truth_updates(
 
 def _assignment_updates(group: Group) -> RunUpdates | None:
     """Mirror the current assignee (user and/or team), or ``None`` when the group has
-    no assignee or the assignment is our own auto-assignment.
+    no assignee or the assignment is one we can't grade a prediction against.
     """
     assignee = GroupAssignee.objects.filter(group=group).first()
     if assignee is None:
         return None
-    if _is_seer_auto_assignment(group):
+    if _is_unscorable_assignment(group):
         return None
     return {
         "actual_assignee_user_id": assignee.user_id,
@@ -141,20 +153,20 @@ def _assignment_updates(group: Group) -> RunUpdates | None:
     }
 
 
-def _is_seer_auto_assignment(group: Group) -> bool:
-    """Whether the group's current assignment came from our own auto-assignment,
-    determined by the most recent ``ASSIGNED`` activity being tagged with the
-    ``SEER_SUGGESTED`` integration."""
+def _is_unscorable_assignment(group: Group) -> bool:
+    """Whether the group's current assignment came from a source we can't grade a
+    prediction against. The latest ASSIGNED activity always represents the current assignment,
+    and its ``integration`` indicates if it came from a human or not.
+    """
     latest_assignment = (
         Activity.objects.filter(group=group, type=ActivityType.ASSIGNED.value)
-        .order_by("-datetime")
+        # ``id`` breaks ties so same-timestamp activities resolve to the one written last.
+        .order_by("-datetime", "-id")
         .first()
     )
     if latest_assignment is None:
         return False
-    return (latest_assignment.data or {}).get(
-        "integration"
-    ) == ActivityIntegration.SEER_SUGGESTED.value
+    return (latest_assignment.data or {}).get("integration") in UNSCORABLE_ASSIGNMENT_ORIGINS
 
 
 def _apply(run_id: int, updates: RunUpdates) -> bool:

--- a/src/sentry/seer/smart_assignment/scoring.py
+++ b/src/sentry/seer/smart_assignment/scoring.py
@@ -5,7 +5,7 @@ from typing import TypedDict
 
 from django.db import router, transaction
 
-from sentry.models.activity import Activity, ActivityIntegration
+from sentry.models.activity import Activity
 from sentry.models.group import Group
 from sentry.models.groupassignee import GroupAssignee
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
@@ -14,6 +14,7 @@ from sentry.seer.smart_assignment.models import (
     RESOLUTION_ACTIVITIES,
     SEER_FEATURE_ID,
     SmartAssignmentScore,
+    is_unscorable_assignment,
 )
 from sentry.seer.utils import latest_run_for_group
 from sentry.types.activity import ActivityType
@@ -24,19 +25,6 @@ logger = logging.getLogger(__name__)
 
 # Right now the agent only returns 3 ranked candidates; this is the limit we score against.
 HIT_RANK_LIMIT = 3
-
-# We invalidate scoring against "ground truth" assignments from these sources, because they're
-# basically non-human actions: our own auto-assignment, project ownership, CODEOWNERS,
-# and the suspect commit feature. The agent is likely to make similar choices, so scoring
-# against these would inflate our success rate.
-UNSCORABLE_ASSIGNMENT_ORIGINS = frozenset(
-    {
-        ActivityIntegration.SEER_SUGGESTED.value,
-        ActivityIntegration.PROJECT_OWNERSHIP.value,
-        ActivityIntegration.CODEOWNERS.value,
-        ActivityIntegration.SUSPECT_COMMITTER.value,
-    }
-)
 
 
 class RunUpdates(TypedDict, total=False):
@@ -144,7 +132,7 @@ def _assignment_updates(group: Group) -> RunUpdates | None:
     assignee = GroupAssignee.objects.filter(group=group).first()
     if assignee is None:
         return None
-    if _is_unscorable_assignment(group):
+    if _has_unscorable_assignment(group):
         return None
     return {
         "actual_assignee_user_id": assignee.user_id,
@@ -153,20 +141,17 @@ def _assignment_updates(group: Group) -> RunUpdates | None:
     }
 
 
-def _is_unscorable_assignment(group: Group) -> bool:
+def _has_unscorable_assignment(group: Group) -> bool:
     """Whether the group's current assignment came from a source we can't grade a
     prediction against. The latest ASSIGNED activity always represents the current assignment,
     and its ``integration`` indicates if it came from a human or not.
     """
-    latest_assignment = (
+    return is_unscorable_assignment(
         Activity.objects.filter(group=group, type=ActivityType.ASSIGNED.value)
         # ``id`` breaks ties so same-timestamp activities resolve to the one written last.
         .order_by("-datetime", "-id")
         .first()
     )
-    if latest_assignment is None:
-        return False
-    return (latest_assignment.data or {}).get("integration") in UNSCORABLE_ASSIGNMENT_ORIGINS
 
 
 def _apply(run_id: int, updates: RunUpdates) -> bool:

--- a/src/sentry/seer/smart_assignment/trigger.py
+++ b/src/sentry/seer/smart_assignment/trigger.py
@@ -69,7 +69,7 @@ def trigger_smart_assignment(
         # We only want to run Smart Assignment on issues that are manually assigned.
         metrics.incr(
             "smart_assignment.trigger.skipped",
-            tags={"reason": "automated_assignment"},
+            tags={"reason": "automatic_assignment"},
             sample_rate=1.0,
         )
         return

--- a/src/sentry/seer/smart_assignment/trigger.py
+++ b/src/sentry/seer/smart_assignment/trigger.py
@@ -14,6 +14,7 @@ from sentry.seer.smart_assignment.models import (
     RESOLUTION_ACTIVITIES,
     SEER_FEATURE_ID,
     SmartAssignmentPayload,
+    is_unscorable_assignment,
 )
 from sentry.seer.smart_assignment.scoring import record_ground_truth, resolver_user_id
 from sentry.seer.utils import runs_for_group
@@ -64,11 +65,18 @@ def trigger_smart_assignment(
         )
         return
 
+    if is_unscorable_assignment(activity):
+        # We only want to run Smart Assignment on issues that are manually assigned.
+        metrics.incr(
+            "smart_assignment.trigger.skipped",
+            tags={"reason": "automated_assignment"},
+            sample_rate=1.0,
+        )
     # Policy gate: today we predict at most once per issue, ever. This lives in app
     # code (not a DB constraint) so re-runs are cheap to enable later -- e.g. gate on
     # a cooldown or a new-signal check against the latest run instead. The run mirror
     # is our durable record that a run was dispatched.
-    if not _already_predicted(group) and not _dispatch_rate_limited(organization):
+    elif not _already_predicted(group) and not _dispatch_rate_limited(organization):
         _dispatch(group, activity_type, activity)
 
     record_ground_truth(group, activity_type, activity)

--- a/src/sentry/seer/smart_assignment/trigger.py
+++ b/src/sentry/seer/smart_assignment/trigger.py
@@ -72,11 +72,13 @@ def trigger_smart_assignment(
             tags={"reason": "automated_assignment"},
             sample_rate=1.0,
         )
+        return
+
     # Policy gate: today we predict at most once per issue, ever. This lives in app
     # code (not a DB constraint) so re-runs are cheap to enable later -- e.g. gate on
     # a cooldown or a new-signal check against the latest run instead. The run mirror
     # is our durable record that a run was dispatched.
-    elif not _already_predicted(group) and not _dispatch_rate_limited(organization):
+    if not _already_predicted(group) and not _dispatch_rate_limited(organization):
         _dispatch(group, activity_type, activity)
 
     record_ground_truth(group, activity_type, activity)

--- a/tests/sentry/seer/smart_assignment/test_scoring.py
+++ b/tests/sentry/seer/smart_assignment/test_scoring.py
@@ -455,13 +455,13 @@ class AssignmentOriginTest(ScoringTestBase):
     """
 
     def _truth(self, run: SeerAgentRun) -> tuple[int | None, int | None]:
-        record_ground_truth(
-            self.group,
-            ActivityType.ASSIGNED,
+        latest_assignment = (
             Activity.objects.filter(group=self.group, type=ActivityType.ASSIGNED.value)
             .order_by("-datetime", "-id")
-            .first(),
+            .first()
         )
+        assert latest_assignment is not None
+        record_ground_truth(self.group, ActivityType.ASSIGNED, latest_assignment)
         run.refresh_from_db()
         return (
             run.extras.get("actual_assignee_user_id"),

--- a/tests/sentry/seer/smart_assignment/test_scoring.py
+++ b/tests/sentry/seer/smart_assignment/test_scoring.py
@@ -5,6 +5,7 @@ from django.utils import timezone
 from sentry.models.activity import Activity, ActivityIntegration
 from sentry.models.group import Group
 from sentry.models.groupassignee import GroupAssignee
+from sentry.models.team import Team
 from sentry.seer.models.run import SeerAgentRun, SeerRun, SeerRunType
 from sentry.seer.smart_assignment.models import SEER_FEATURE_ID, SmartAssignmentScore
 from sentry.seer.smart_assignment.scoring import (
@@ -19,6 +20,9 @@ METRICS_PATH = "sentry.seer.smart_assignment.scoring.metrics"
 # A representative dispatch trigger (a Seer AI-step start): its ActivityType name is
 # what gets seeded on the run mirror's `extras["trigger"]`.
 STARTED = ActivityType.SEER_RCA_STARTED
+
+# The `extra` an ownership rule stamps onto the ASSIGNED activity it writes.
+RULE_ORIGIN = {"integration": ActivityIntegration.CODEOWNERS.value}
 
 
 class ScoringTestBase(TestCase):
@@ -182,6 +186,17 @@ class RecordGroundTruthTest(ScoringTestBase):
             group=self.group, type=ActivityType.ASSIGNED.value, data=data
         )
 
+    def _assign_team(self, integration: str | None = None) -> tuple[Team, Activity]:
+        team = self.create_team(organization=self.organization)
+        GroupAssignee.objects.create(group=self.group, project=self.group.project, team=team)
+        data = {"assignee": str(team.id), "assigneeType": "team"}
+        if integration is not None:
+            data["integration"] = integration
+        activity = self.create_group_activity(
+            group=self.group, type=ActivityType.ASSIGNED.value, data=data
+        )
+        return team, activity
+
     def test_noop_without_run(self) -> None:
         record_ground_truth(
             self.group,
@@ -266,6 +281,91 @@ class RecordGroundTruthTest(ScoringTestBase):
         assert "actual_assignee_user_id" not in run.extras
         assert "ground_truth_source" not in run.extras
 
+    def test_ownership_rule_team_assignment_is_not_recorded(self) -> None:
+        # The agent reaches this team itself (get_issue_ownership -> get_team_members),
+        # so grading against it would score the routing config, not a prediction.
+        run = self._run()
+        _, activity = self._assign_team(integration=ActivityIntegration.PROJECT_OWNERSHIP.value)
+        record_ground_truth(self.group, ActivityType.ASSIGNED, activity)
+
+        run.refresh_from_db()
+        assert "actual_assignee_team_id" not in run.extras
+        assert "ground_truth_source" not in run.extras
+
+    def test_codeowners_team_assignment_is_not_recorded(self) -> None:
+        run = self._run()
+        _, activity = self._assign_team(integration=ActivityIntegration.CODEOWNERS.value)
+        record_ground_truth(self.group, ActivityType.ASSIGNED, activity)
+
+        run.refresh_from_db()
+        assert "actual_assignee_team_id" not in run.extras
+
+    def test_predicted_team_member_scores_no_hit_on_rule_assigned_team(self) -> None:
+        # The cheat this guards: a rule assigns the owning team, the agent expands that
+        # team and names one of its members, and the shared team reads as partial credit.
+        alice = self.create_user()
+        run = self._run(predicted_assignee_user_ids=[alice.id])
+        team, activity = self._assign_team(integration=ActivityIntegration.CODEOWNERS.value)
+        self.create_member(user=alice, organization=self.organization, teams=[team])
+        record_ground_truth(self.group, ActivityType.ASSIGNED, activity)
+
+        run.refresh_from_db()
+        assert "result" not in run.extras
+        assert "actual_assignee_team_id" not in run.extras
+
+    def test_manually_assigned_team_is_recorded(self) -> None:
+        run = self._run()
+        team, activity = self._assign_team()
+        record_ground_truth(self.group, ActivityType.ASSIGNED, activity)
+
+        run.refresh_from_db()
+        assert run.extras["actual_assignee_team_id"] == team.id
+        assert run.extras["ground_truth_source"] == ActivityType.ASSIGNED.name
+
+    def test_suspect_commit_assignment_is_not_recorded(self) -> None:
+        # The same author get_issue_committers hands the agent.
+        run = self._run()
+        assignee = self.create_user()
+        GroupAssignee.objects.create(
+            group=self.group, project=self.group.project, user_id=assignee.id
+        )
+        activity = self._assigned_activity(
+            assignee.id, integration=ActivityIntegration.SUSPECT_COMMITTER.value
+        )
+        record_ground_truth(self.group, ActivityType.ASSIGNED, activity)
+
+        run.refresh_from_db()
+        assert "actual_assignee_user_id" not in run.extras
+
+    def test_human_reassignment_over_rule_assignment_is_recorded(self) -> None:
+        run = self._run()
+        self._assign_team(integration=ActivityIntegration.PROJECT_OWNERSHIP.value)
+        human_assignee = self.create_user()
+        GroupAssignee.objects.filter(group=self.group).update(
+            team_id=None, user_id=human_assignee.id
+        )
+        record_ground_truth(
+            self.group, ActivityType.ASSIGNED, self._assigned_activity(human_assignee.id)
+        )
+
+        run.refresh_from_db()
+        assert run.extras["actual_assignee_user_id"] == human_assignee.id
+
+    def test_resolution_ignores_rule_assignment(self) -> None:
+        run = self._run()
+        self._assign_team(integration=ActivityIntegration.CODEOWNERS.value)
+        resolver = self.create_user()
+        record_ground_truth(
+            self.group,
+            ActivityType.SET_RESOLVED,
+            self._activity(ActivityType.SET_RESOLVED, resolver.id),
+        )
+
+        run.refresh_from_db()
+        assert "actual_assignee_team_id" not in run.extras
+        assert run.extras["actual_assignee_user_id"] == resolver.id
+        assert run.extras["ground_truth_source"] == ActivityType.SET_RESOLVED.name
+
     def _seer_auto_assign(self, assignee_id: int) -> Activity:
         GroupAssignee.objects.create(
             group=self.group, project=self.group.project, user_id=assignee_id
@@ -345,3 +445,75 @@ class RecordGroundTruthTest(ScoringTestBase):
         run.refresh_from_db()
         assert run.extras["actual_assignee_user_id"] == assignee.id
         assert run.extras["ground_truth_source"] == ActivityType.ASSIGNED.name
+
+
+class AssignmentOriginTest(ScoringTestBase):
+    """Which assignment the origin classifier reads when an issue changes hands.
+
+    These drive ``GroupAssignee.objects.assign()`` instead of writing rows directly,
+    because it is the activity that call writes that the classifier reads.
+    """
+
+    def _truth(self, run: SeerAgentRun) -> tuple[int | None, int | None]:
+        record_ground_truth(
+            self.group,
+            ActivityType.ASSIGNED,
+            Activity.objects.filter(group=self.group, type=ActivityType.ASSIGNED.value)
+            .order_by("-datetime", "-id")
+            .first(),
+        )
+        run.refresh_from_db()
+        return (
+            run.extras.get("actual_assignee_user_id"),
+            run.extras.get("actual_assignee_team_id"),
+        )
+
+    def test_rule_team_handed_off_to_human_user_is_scoreable(self) -> None:
+        run = self._run()
+        team = self.create_team(organization=self.organization)
+        human = self.create_user()
+        self.create_member(user=human, organization=self.organization, teams=[team])
+        GroupAssignee.objects.assign(self.group, team, extra=RULE_ORIGIN)
+        GroupAssignee.objects.assign(self.group, human)
+
+        assert self._truth(run) == (human.id, None)
+
+    def test_human_user_reclaimed_by_rule_team_is_not_scoreable(self) -> None:
+        # The reverse hand-off. Whoever assigned last is who we would grade against, so
+        # a rule taking the issue back leaves nothing scoreable, even though a human
+        # held it first.
+        run = self._run()
+        team = self.create_team(organization=self.organization)
+        human = self.create_user()
+        self.create_member(user=human, organization=self.organization, teams=[team])
+        GroupAssignee.objects.assign(self.group, human)
+        GroupAssignee.objects.assign(self.group, team, extra=RULE_ORIGIN)
+
+        assert self._truth(run) == (None, None)
+
+    def test_human_reassignment_after_unassign_is_scoreable(self) -> None:
+        # Unassigning leaves the rule's ASSIGNED activity behind; the human's later one
+        # still has to win.
+        run = self._run()
+        team = self.create_team(organization=self.organization)
+        human = self.create_user()
+        GroupAssignee.objects.assign(self.group, team, extra=RULE_ORIGIN)
+        GroupAssignee.objects.deassign(self.group)
+        GroupAssignee.objects.assign(self.group, human)
+
+        assert self._truth(run) == (human.id, None)
+
+    def test_same_timestamp_assignments_resolve_to_the_last_written(self) -> None:
+        run = self._run()
+        human = self.create_user()
+        GroupAssignee.objects.create(group=self.group, project=self.group.project, user_id=human.id)
+        stamped_at = timezone.now()
+        for extra in (RULE_ORIGIN, {}):
+            self.create_group_activity(
+                group=self.group,
+                type=ActivityType.ASSIGNED.value,
+                data={"assignee": str(human.id), "assigneeType": "user", **extra},
+                datetime=stamped_at,
+            )
+
+        assert self._truth(run) == (human.id, None)

--- a/tests/sentry/seer/smart_assignment/test_trigger.py
+++ b/tests/sentry/seer/smart_assignment/test_trigger.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock, patch
 
 from django.utils import timezone
 
-from sentry.models.activity import Activity
+from sentry.models.activity import Activity, ActivityIntegration
 from sentry.models.groupassignee import GroupAssignee
 from sentry.seer.models.run import SeerAgentRun, SeerRun, SeerRunType
 from sentry.seer.smart_assignment.models import SEER_FEATURE_ID
@@ -61,11 +61,17 @@ class TriggerSmartAssignmentTest(TestCase):
     def _seer_started(self) -> Activity:
         return self._activity(ActivityType.SEER_RCA_STARTED)
 
-    def _assigned_activity(self, assignee_id: int, assignee_type: str = "user") -> Activity:
+    def _assigned_activity(
+        self,
+        assignee_id: int,
+        assignee_type: str = "user",
+        integration: str | None = None,
+    ) -> Activity:
+        data = {"assignee": str(assignee_id), "assigneeType": assignee_type}
+        if integration is not None:
+            data["integration"] = integration
         return self.create_group_activity(
-            group=self.group,
-            type=ActivityType.ASSIGNED.value,
-            data={"assignee": str(assignee_id), "assigneeType": assignee_type},
+            group=self.group, type=ActivityType.ASSIGNED.value, data=data
         )
 
     @patch(CLIENT_PATH)
@@ -218,6 +224,92 @@ class TriggerSmartAssignmentTest(TestCase):
         assert extras["actual_assignee_user_id"] == assignee.id
         assert extras["ground_truth_source"] == ActivityType.ASSIGNED.name
         mock_client_cls.return_value.start_feature_run.assert_not_called()
+
+    @patch(CLIENT_PATH)
+    def test_automated_user_assignment_does_not_dispatch(self, mock_client_cls: MagicMock) -> None:
+        self._wire_client(mock_client_cls)
+        assignee = self.create_user()
+        GroupAssignee.objects.create(
+            group=self.group, project=self.group.project, user_id=assignee.id
+        )
+        with self.feature("organizations:seer-smart-assignment-run"):
+            trigger_smart_assignment(
+                self.group,
+                ActivityType.ASSIGNED,
+                self._assigned_activity(
+                    assignee.id, integration=ActivityIntegration.PROJECT_OWNERSHIP.value
+                ),
+            )
+
+        assert self._mirrors() == []
+        mock_client_cls.return_value.start_feature_run.assert_not_called()
+
+    @patch(CLIENT_PATH)
+    def test_automated_team_assignment_does_not_dispatch(self, mock_client_cls: MagicMock) -> None:
+        self._wire_client(mock_client_cls)
+        team = self.create_team(organization=self.organization)
+        GroupAssignee.objects.create(group=self.group, project=self.group.project, team=team)
+        with self.feature("organizations:seer-smart-assignment-run"):
+            trigger_smart_assignment(
+                self.group,
+                ActivityType.ASSIGNED,
+                self._assigned_activity(
+                    team.id, "team", integration=ActivityIntegration.CODEOWNERS.value
+                ),
+            )
+
+        assert self._mirrors() == []
+        mock_client_cls.return_value.start_feature_run.assert_not_called()
+
+    @patch(CLIENT_PATH)
+    def test_seer_start_dispatches_on_an_automatically_assigned_issue(
+        self, mock_client_cls: MagicMock
+    ) -> None:
+        # A Seer workflow still needs a person to notify, so the automated assignment
+        # only blocks its own trigger.
+        self._wire_client(mock_client_cls)
+        team = self.create_team(organization=self.organization)
+        GroupAssignee.objects.create(group=self.group, project=self.group.project, team=team)
+        self._assigned_activity(team.id, "team", integration=ActivityIntegration.CODEOWNERS.value)
+        with self.feature("organizations:seer-smart-assignment-run"):
+            trigger_smart_assignment(
+                self.group, ActivityType.SEER_RCA_STARTED, self._seer_started()
+            )
+
+        mirrors = self._mirrors()
+        assert len(mirrors) == 1
+        # The automated assignment still can't be graded against.
+        assert "actual_assignee_team_id" not in mirrors[0].extras
+
+    @patch(CLIENT_PATH)
+    def test_human_assignment_after_an_automated_one_dispatches(
+        self, mock_client_cls: MagicMock
+    ) -> None:
+        # The automated event must not spend the one prediction this issue gets.
+        self._wire_client(mock_client_cls)
+        team = self.create_team(organization=self.organization)
+        assignee = GroupAssignee.objects.create(
+            group=self.group, project=self.group.project, team=team
+        )
+        human = self.create_user()
+        with self.feature("organizations:seer-smart-assignment-run"):
+            trigger_smart_assignment(
+                self.group,
+                ActivityType.ASSIGNED,
+                self._assigned_activity(
+                    team.id, "team", integration=ActivityIntegration.PROJECT_OWNERSHIP.value
+                ),
+            )
+            assert self._mirrors() == []
+
+            assignee.update(team=None, user_id=human.id)
+            trigger_smart_assignment(
+                self.group, ActivityType.ASSIGNED, self._assigned_activity(human.id)
+            )
+
+        mirrors = self._mirrors()
+        assert len(mirrors) == 1
+        assert mirrors[0].extras["actual_assignee_user_id"] == human.id
 
     @patch(CLIENT_PATH)
     def test_automatic_resolution_is_skipped(self, mock_client_cls: MagicMock) -> None:

--- a/tests/sentry/seer/smart_assignment/test_trigger.py
+++ b/tests/sentry/seer/smart_assignment/test_trigger.py
@@ -262,6 +262,26 @@ class TriggerSmartAssignmentTest(TestCase):
         mock_client_cls.return_value.start_feature_run.assert_not_called()
 
     @patch(CLIENT_PATH)
+    def test_automated_assignment_leaves_a_waiting_run_untouched(
+        self, mock_client_cls: MagicMock
+    ) -> None:
+        self._mirror(trigger=ActivityType.SEER_RCA_STARTED.name)
+        team = self.create_team(organization=self.organization)
+        GroupAssignee.objects.create(group=self.group, project=self.group.project, team=team)
+        with self.feature("organizations:seer-smart-assignment-run"):
+            trigger_smart_assignment(
+                self.group,
+                ActivityType.ASSIGNED,
+                self._assigned_activity(
+                    team.id, "team", integration=ActivityIntegration.CODEOWNERS.value
+                ),
+            )
+
+        extras = self._mirrors()[0].extras
+        assert "actual_assignee_team_id" not in extras
+        assert "actual_assignee_user_id" not in extras
+
+    @patch(CLIENT_PATH)
     def test_seer_start_dispatches_on_an_automatically_assigned_issue(
         self, mock_client_cls: MagicMock
     ) -> None:


### PR DESCRIPTION
This fixes the biggest current hole in our scoring strategy: we were running Smart Assignment and scoring against "ground truths" that came from automated assignments that the Smart Assignment agent can read:
- ownership rules
- CODEOWNERS file
- suspect commit feature

For example, an ownership rule would trigger auto-assignment of an issue to a user/team. This would trigger a Smart Assignment run, assuming that assignment as ground truth. The SA agent would look at the ownership rule and suggest the user (or user from the team), then we would check if the suggestion matched the assignment -> we got it correct! This isn't a fair test.

So we collect the set of `ActivityIntegration`s that indicate automated assignment, and a) don't run Smart Assignment on these assignments, and b) don't consider these assignments as sources of ground truth during scoring.