### PR TITLE
feat(seer): Add run milestone backfill task

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1017,6 +1017,7 @@ TASKWORKER_IMPORTS: tuple[str, ...] = (
     "sentry.tasks.seer.lightweight_rca_cluster",
     "sentry.tasks.seer.night_shift.cron",
     "sentry.tasks.seer.backfill_supergroups_lightweight",
+    "sentry.tasks.seer.backfill_run_milestones",
     # Used for tests
     "sentry.taskworker.tasks.examples",
 )

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1381,6 +1381,12 @@ register(
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
+    "seer.run_milestone_backfill.killswitch",
+    type=Bool,
+    default=False,
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
     "seer.supergroups_backfill_lightweight.batch_size",
     type=Int,
     default=40,

--- a/src/sentry/seer/milestones.py
+++ b/src/sentry/seer/milestones.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Collection
 from typing import TYPE_CHECKING
 
 from django.db import router, transaction
@@ -72,6 +73,18 @@ def milestones_from_state(state: SeerRunState) -> dict[str, SeerRunMilestoneExtr
     return result
 
 
+def milestones_to_delete(seer_run: SeerRun, desired: Collection[str]) -> set[str]:
+    existing = set(
+        SeerRunMilestone.objects.filter(
+            seer_run=seer_run, milestone__in=SEER_STATE_MILESTONES
+        ).values_list("milestone", flat=True)
+    )
+    to_delete = existing - set(desired)
+    if SeerRunMilestoneType.HAS_PULL_REQUEST in to_delete and seer_run.pull_requests.exists():
+        to_delete.discard(SeerRunMilestoneType.HAS_PULL_REQUEST)
+    return to_delete
+
+
 def reconcile_milestones(seer_run: SeerRun, state: SeerRunState) -> None:
     """Make the run's SEER_STATE_MILESTONES match what ``state`` has reached,
     inserting/refreshing extras and deleting ones a re-run undid. Milestones
@@ -84,12 +97,7 @@ def reconcile_milestones(seer_run: SeerRun, state: SeerRunState) -> None:
             desired[milestone] = reached[milestone]
 
     with transaction.atomic(using=router.db_for_write(SeerRunMilestone)):
-        existing = set(
-            SeerRunMilestone.objects.filter(
-                seer_run=seer_run, milestone__in=SEER_STATE_MILESTONES
-            ).values_list("milestone", flat=True)
-        )
-        to_delete = existing - desired.keys()
+        to_delete = milestones_to_delete(seer_run, desired.keys())
         if to_delete:
             SeerRunMilestone.objects.filter(seer_run=seer_run, milestone__in=to_delete).delete()
 
@@ -113,6 +121,11 @@ def record_has_pull_request(seer_run: SeerRun) -> None:
     )
 
 
+def all_linked_pull_requests_merged(seer_run: SeerRun) -> bool:
+    states = list(seer_run.pull_requests.values_list("state", flat=True))
+    return bool(states) and all(state == PullRequestLifecycleState.MERGED for state in states)
+
+
 def reconcile_pull_requests_merged_milestone(seer_run: SeerRun) -> bool:
     """Make PULL_REQUESTS_MERGED match the current state of every linked PR.
 
@@ -122,16 +135,12 @@ def reconcile_pull_requests_merged_milestone(seer_run: SeerRun) -> bool:
     database = router.db_for_write(SeerRunMilestone)
     with transaction.atomic(using=database):
         SeerRun.objects.select_for_update().values_list("id", flat=True).get(id=seer_run.id)
-        states = list(seer_run.pull_requests.values_list("state", flat=True))
         milestone = SeerRunMilestone.objects.filter(
             seer_run=seer_run,
             milestone=SeerRunMilestoneType.PULL_REQUESTS_MERGED,
         )
 
-        all_prs_merged = bool(states) and all(
-            state == PullRequestLifecycleState.MERGED for state in states
-        )
-        if not all_prs_merged:
+        if not all_linked_pull_requests_merged(seer_run):
             milestone.delete()
             return False
 

--- a/src/sentry/tasks/seer/backfill_run_milestones.py
+++ b/src/sentry/tasks/seer/backfill_run_milestones.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING
+
+from django.utils import timezone
+from pydantic import ValidationError
+from taskbroker_client.retry import Retry
+
+from sentry import options
+from sentry.models.organization import Organization
+from sentry.seer.agent.client_utils import fetch_run_status
+from sentry.seer.milestones import (
+    SEER_STATE_MILESTONES,
+    all_linked_pull_requests_merged,
+    milestones_from_state,
+    milestones_to_delete,
+    reconcile_milestones,
+    reconcile_pull_requests_merged_milestone,
+    record_has_pull_request,
+)
+from sentry.seer.models.run import (
+    SeerRun,
+    SeerRunMilestone,
+    SeerRunMilestoneType,
+    SeerRunMirrorStatus,
+)
+from sentry.seer.models.seer_api_models import SeerApiError
+from sentry.seer.signed_seer_api import SeerViewerContext
+from sentry.tasks.base import instrumented_task
+from sentry.taskworker.namespaces import seer_tasks
+
+if TYPE_CHECKING:
+    from sentry.seer.agent.client_models import SeerRunState
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BATCH_SIZE = 25
+MAX_BATCH_SIZE = 25
+BACKFILL_WINDOW = timedelta(days=30)
+
+
+def milestones_that_would_delete(seer_run: SeerRun, state: SeerRunState) -> set[str]:
+    desired = milestones_from_state(state).keys() & SEER_STATE_MILESTONES
+    to_delete = milestones_to_delete(seer_run, desired)
+    pr_merged_exists = SeerRunMilestone.objects.filter(
+        seer_run=seer_run, milestone=SeerRunMilestoneType.PULL_REQUESTS_MERGED
+    ).exists()
+    if pr_merged_exists and not all_linked_pull_requests_merged(seer_run):
+        to_delete.add(SeerRunMilestoneType.PULL_REQUESTS_MERGED)
+    return to_delete
+
+
+@instrumented_task(
+    name="sentry.tasks.seer.backfill_run_milestones.backfill_run_milestones_for_org",
+    namespace=seer_tasks,
+    processing_deadline_duration=15 * 60,
+    retry=Retry(times=3, delay=60, on=(Exception,), ignore=(ValueError,)),
+)
+def backfill_run_milestones_for_org(
+    organization_id: int,
+    last_seer_run_id: int = 0,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    dry_run: bool = True,
+    start_at: str | None = None,
+    end_at: str | None = None,
+) -> None:
+    """Backfill one explicitly supplied organization over the preceding 30 days."""
+    if options.get("seer.run_milestone_backfill.killswitch"):
+        logger.info("seer.run_milestone_backfill.killswitch_enabled")
+        return
+
+    if batch_size < 1 or batch_size > MAX_BATCH_SIZE:
+        raise ValueError(f"batch_size must be between 1 and {MAX_BATCH_SIZE}")
+
+    window_end = datetime.fromisoformat(end_at) if end_at else timezone.now()
+    window_start = datetime.fromisoformat(start_at) if start_at else window_end - BACKFILL_WINDOW
+
+    try:
+        organization = Organization.objects.get(id=organization_id)
+    except Organization.DoesNotExist:
+        logger.warning(
+            "seer.run_milestone_backfill.organization_not_found",
+            extra={"organization_id": organization_id},
+        )
+        return
+
+    candidates = list(
+        SeerRun.objects.filter(
+            id__gt=last_seer_run_id,
+            organization_id=organization_id,
+            agent__source__in=("autofix", "autofix_rca"),
+            mirror_status=SeerRunMirrorStatus.LIVE,
+            seer_run_state_id__isnull=False,
+            last_triggered_at__gte=window_start,
+            last_triggered_at__lt=window_end,
+        ).order_by("id")[: batch_size + 1]
+    )
+    runs = candidates[:batch_size]
+    has_more = len(candidates) > batch_size
+
+    if not runs:
+        logger.info(
+            "seer.run_milestone_backfill.completed",
+            extra={
+                "organization_id": organization_id,
+                "start": window_start.isoformat(),
+                "end": window_end.isoformat(),
+                "dry_run": dry_run,
+                "last_seer_run_id": last_seer_run_id,
+            },
+        )
+        return
+
+    viewer_context = SeerViewerContext(organization_id=organization_id)
+    milestone_counts: Counter[str] = Counter()
+    missing_state_count = 0
+    invalid_state_count = 0
+    fetch_failed_count = 0
+    processed_count = 0
+    would_delete_count = 0
+
+    for seer_run in runs:
+        log_extra = {
+            "organization_id": organization_id,
+            "seer_run_id": seer_run.id,
+            "seer_run_state_id": seer_run.seer_run_state_id,
+        }
+        try:
+            state = fetch_run_status(
+                seer_run.seer_run_state_id,
+                organization,
+                viewer_context=viewer_context,
+            )
+        except SeerApiError as error:
+            if error.status == 404:
+                missing_state_count += 1
+                logger.warning("seer.run_milestone_backfill.state_not_found", extra=log_extra)
+                continue
+            fetch_failed_count += 1
+            logger.warning(
+                "seer.run_milestone_backfill.fetch_failed",
+                exc_info=True,
+                extra={**log_extra, "status": error.status},
+            )
+            continue
+        except ValidationError:
+            invalid_state_count += 1
+            logger.warning(
+                "seer.run_milestone_backfill.state_invalid", exc_info=True, extra=log_extra
+            )
+            continue
+        except ValueError:
+            missing_state_count += 1
+            logger.warning("seer.run_milestone_backfill.state_missing_session", extra=log_extra)
+            continue
+
+        processed_count += 1
+        derived = milestones_from_state(state)
+        milestone_counts.update(derived.keys())
+        has_linked_pr = seer_run.pull_requests.exists()
+        if has_linked_pr and SeerRunMilestoneType.HAS_PULL_REQUEST not in derived:
+            milestone_counts[SeerRunMilestoneType.HAS_PULL_REQUEST] += 1
+        if all_linked_pull_requests_merged(seer_run):
+            milestone_counts[SeerRunMilestoneType.PULL_REQUESTS_MERGED] += 1
+
+        if dry_run:
+            would_delete_count += len(milestones_that_would_delete(seer_run, state))
+        else:
+            reconcile_milestones(seer_run, state)
+            if has_linked_pr:
+                record_has_pull_request(seer_run)
+            reconcile_pull_requests_merged_milestone(seer_run)
+
+    if fetch_failed_count == len(runs):
+        raise SeerApiError("Seer state fetch failed for the entire batch", 503)
+
+    logger.info(
+        "seer.run_milestone_backfill.batch_complete",
+        extra={
+            "organization_id": organization_id,
+            "start": window_start.isoformat(),
+            "end": window_end.isoformat(),
+            "dry_run": dry_run,
+            "runs_processed": processed_count,
+            "would_delete": would_delete_count,
+            "states_missing": missing_state_count,
+            "states_invalid": invalid_state_count,
+            "fetch_failed": fetch_failed_count,
+            "milestone_counts": dict(milestone_counts),
+            "last_seer_run_id": runs[-1].id,
+            "has_more": has_more,
+        },
+    )
+
+    if has_more:
+        backfill_run_milestones_for_org.apply_async(
+            args=[organization_id],
+            kwargs={
+                "last_seer_run_id": runs[-1].id,
+                "batch_size": batch_size,
+                "dry_run": dry_run,
+                "start_at": window_start.isoformat(),
+                "end_at": window_end.isoformat(),
+            },
+            countdown=5,
+            headers={"sentry-propagate-traces": False},
+        )
+    else:
+        logger.info(
+            "seer.run_milestone_backfill.completed",
+            extra={
+                "organization_id": organization_id,
+                "start": window_start.isoformat(),
+                "end": window_end.isoformat(),
+                "dry_run": dry_run,
+                "last_seer_run_id": runs[-1].id,
+            },
+        )

--- a/tests/sentry/seer/test_milestones.py
+++ b/tests/sentry/seer/test_milestones.py
@@ -22,7 +22,11 @@ from sentry.seer.milestones import (
     reconcile_pull_requests_merged_milestone,
     record_has_pull_request,
 )
-from sentry.seer.models.run import SeerRunMilestone, SeerRunMilestoneType
+from sentry.seer.models.run import (
+    SeerRunMilestone,
+    SeerRunMilestoneExtras,
+    SeerRunMilestoneType,
+)
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
 
@@ -292,8 +296,29 @@ class ReconcileMilestonesTest(TestCase):
         )
         return _state(blocks=[block])
 
-    def _extras(self, milestone: str) -> dict[str, object]:
+    def _extras(self, milestone: str) -> SeerRunMilestoneExtras:
         return SeerRunMilestone.objects.get(seer_run=self.seer_run, milestone=milestone).extras
+
+    def test_reconcile_keeps_has_pull_request_when_a_pr_is_linked(self) -> None:
+        # A coding-agent PR recorded via record_has_pull_request may be absent from
+        # state; a still-linked PR must keep the milestone from being deleted.
+        record_has_pull_request(self.seer_run)
+        repo = self.create_repo(self.project, name="getsentry/sentry")
+        pull_request = self.create_pull_request(
+            repository_id=repo.id, organization_id=self.organization.id, key="1"
+        )
+        self.create_seer_run_pull_request(run=self.seer_run, pull_request=pull_request)
+
+        reconcile_milestones(self.seer_run, _state())
+
+        assert SeerRunMilestoneType.HAS_PULL_REQUEST in self._recorded()
+
+    def test_reconcile_deletes_has_pull_request_without_linked_pr(self) -> None:
+        record_has_pull_request(self.seer_run)
+
+        reconcile_milestones(self.seer_run, _state())
+
+        assert SeerRunMilestoneType.HAS_PULL_REQUEST not in self._recorded()
 
     def test_reconcile_writes_then_refreshes_extras_on_rerun(self) -> None:
         reconcile_milestones(self.seer_run, self._root_cause_state("first"))

--- a/tests/sentry/tasks/seer/test_backfill_run_milestones.py
+++ b/tests/sentry/tasks/seer/test_backfill_run_milestones.py
@@ -1,0 +1,290 @@
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from sentry.models.organization import Organization
+from sentry.models.pullrequest import PullRequestLifecycleState
+from sentry.seer.agent.client_models import Artifact, MemoryBlock, Message, SeerRunState
+from sentry.seer.milestones import (
+    reconcile_milestones,
+    reconcile_pull_requests_merged_milestone,
+)
+from sentry.seer.models.run import (
+    SeerRun,
+    SeerRunMilestone,
+    SeerRunMilestoneType,
+    SeerRunMirrorStatus,
+)
+from sentry.seer.models.seer_api_models import SeerApiError
+from sentry.tasks.seer.backfill_run_milestones import backfill_run_milestones_for_org
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.datetime import freeze_time
+
+
+def _root_cause_state(run_id: int) -> SeerRunState:
+    return SeerRunState(
+        run_id=run_id,
+        blocks=[
+            MemoryBlock(
+                id="block",
+                message=Message(role="assistant", content="content"),
+                timestamp="2023-07-10T00:00:00Z",
+                artifacts=[
+                    Artifact(
+                        key="root_cause",
+                        data={"one_line_description": "Root cause"},
+                        reason="reason",
+                    )
+                ],
+            )
+        ],
+        status="completed",
+        updated_at="2023-07-10T00:00:00Z",
+    )
+
+
+def _empty_state(run_id: int) -> SeerRunState:
+    return SeerRunState(
+        run_id=run_id,
+        blocks=[],
+        status="completed",
+        updated_at="2023-07-10T00:00:00Z",
+    )
+
+
+@freeze_time("2023-08-05T00:00:00Z")
+class BackfillRunMilestonesTest(TestCase):
+    def _create_run(
+        self,
+        *,
+        organization: Organization | None = None,
+        seer_run_state_id: int,
+        last_triggered_at: datetime | None = None,
+        source: str = "autofix",
+        mirror_status: str = SeerRunMirrorStatus.LIVE,
+    ) -> SeerRun:
+        run = self.create_seer_run(
+            organization=organization or self.organization,
+            seer_run_state_id=seer_run_state_id,
+            last_triggered_at=last_triggered_at or datetime(2023, 7, 10, tzinfo=UTC),
+            mirror_status=mirror_status,
+        )
+        self.create_seer_agent_run(run, source=source)
+        return run
+
+    def _merged_pr(self, run: SeerRun, key: str) -> None:
+        repository = self.create_repo(self.project, name="getsentry/sentry")
+        pull_request = self.create_pull_request(
+            repository_id=repository.id, organization_id=self.organization.id, key=key
+        )
+        pull_request.update(state=PullRequestLifecycleState.MERGED)
+        self.create_seer_run_pull_request(run=run, pull_request=pull_request)
+
+    def _milestone_rows(self, run: SeerRun) -> set[tuple[str, str]]:
+        return {
+            (milestone, repr(extras))
+            for milestone, extras in SeerRunMilestone.objects.filter(seer_run=run).values_list(
+                "milestone", "extras"
+            )
+        }
+
+    @patch("sentry.tasks.seer.backfill_run_milestones.fetch_run_status")
+    def test_backfill_reconciles_to_final_truth(self, mock_fetch_run_status: MagicMock) -> None:
+        # The backfill reconciles a run to the same rows a direct reconcile of its
+        # state produces: it delegates to reconcile rather than reimplementing it.
+        state = _root_cause_state(200)
+        reference = self._create_run(seer_run_state_id=200)
+        self._merged_pr(reference, key="10")
+        reconcile_milestones(reference, state)
+        reconcile_pull_requests_merged_milestone(reference)
+
+        backfill_run = self._create_run(seer_run_state_id=201)
+        self._merged_pr(backfill_run, key="20")
+        mock_fetch_run_status.return_value = state
+
+        backfill_run_milestones_for_org(self.organization.id, dry_run=False)
+
+        assert self._milestone_rows(backfill_run) == self._milestone_rows(reference)
+        assert {SeerRunMilestoneType.ROOT_CAUSE, SeerRunMilestoneType.PULL_REQUESTS_MERGED} <= {
+            m for m, _ in self._milestone_rows(reference)
+        }
+
+    @patch("sentry.tasks.seer.backfill_run_milestones.fetch_run_status")
+    def test_dry_run_does_not_write(self, mock_fetch_run_status: MagicMock) -> None:
+        run = self._create_run(seer_run_state_id=102)
+        mock_fetch_run_status.return_value = _root_cause_state(102)
+
+        backfill_run_milestones_for_org(self.organization.id)
+
+        assert not SeerRunMilestone.objects.filter(seer_run=run).exists()
+
+    @patch("sentry.tasks.seer.backfill_run_milestones.fetch_run_status")
+    def test_scopes_candidates(self, mock_fetch_run_status: MagicMock) -> None:
+        eligible = self._create_run(seer_run_state_id=103)
+        rca = self._create_run(seer_run_state_id=114, source="autofix_rca")
+        other_organization = self.create_organization()
+        self._create_run(organization=other_organization, seer_run_state_id=104)
+        self._create_run(
+            seer_run_state_id=105,
+            last_triggered_at=datetime(2023, 7, 5, 23, 59, tzinfo=UTC),
+        )
+        self._create_run(
+            seer_run_state_id=106,
+            last_triggered_at=datetime(2023, 8, 5, tzinfo=UTC),
+        )
+        self._create_run(seer_run_state_id=107, source="chat")
+        self._create_run(
+            seer_run_state_id=108,
+            mirror_status=SeerRunMirrorStatus.PENDING,
+        )
+        mock_fetch_run_status.return_value = _empty_state(103)
+
+        backfill_run_milestones_for_org(self.organization.id)
+
+        assert {call.args[0] for call in mock_fetch_run_status.call_args_list} == {
+            eligible.seer_run_state_id,
+            rca.seer_run_state_id,
+        }
+
+    @patch("sentry.tasks.seer.backfill_run_milestones.backfill_run_milestones_for_org.apply_async")
+    @patch("sentry.tasks.seer.backfill_run_milestones.fetch_run_status")
+    def test_self_chains_with_cursor(
+        self, mock_fetch_run_status: MagicMock, mock_apply_async: MagicMock
+    ) -> None:
+        first = self._create_run(seer_run_state_id=109)
+        self._create_run(seer_run_state_id=110)
+        mock_fetch_run_status.return_value = _empty_state(109)
+
+        backfill_run_milestones_for_org(
+            self.organization.id,
+            batch_size=1,
+        )
+
+        mock_apply_async.assert_called_once()
+        assert mock_apply_async.call_args.kwargs["args"] == [self.organization.id]
+        assert mock_apply_async.call_args.kwargs["kwargs"] == {
+            "last_seer_run_id": first.id,
+            "batch_size": 1,
+            "dry_run": True,
+            "start_at": "2023-07-06T00:00:00+00:00",
+            "end_at": "2023-08-05T00:00:00+00:00",
+        }
+
+    @patch("sentry.tasks.seer.backfill_run_milestones.fetch_run_status")
+    def test_honors_explicit_window_over_now(self, mock_fetch_run_status: MagicMock) -> None:
+        # A chained batch must scan the window pinned on the first call, not a
+        # window recomputed from a later now() that has slid past edge runs.
+        run = self._create_run(
+            seer_run_state_id=116,
+            last_triggered_at=datetime(2023, 6, 1, tzinfo=UTC),
+        )
+        mock_fetch_run_status.return_value = _empty_state(116)
+
+        backfill_run_milestones_for_org(
+            self.organization.id,
+            start_at="2023-05-01T00:00:00+00:00",
+            end_at="2023-06-15T00:00:00+00:00",
+        )
+
+        mock_fetch_run_status.assert_called_once()
+        assert mock_fetch_run_status.call_args.args[0] == run.seer_run_state_id
+
+    @patch("sentry.tasks.seer.backfill_run_milestones.fetch_run_status")
+    def test_missing_state_does_not_block_later_runs(
+        self, mock_fetch_run_status: MagicMock
+    ) -> None:
+        missing = self._create_run(seer_run_state_id=111)
+        backfilled = self._create_run(seer_run_state_id=112)
+        mock_fetch_run_status.side_effect = [
+            SeerApiError("missing", 404),
+            _root_cause_state(112),
+        ]
+
+        backfill_run_milestones_for_org(
+            self.organization.id,
+            dry_run=False,
+        )
+
+        assert not SeerRunMilestone.objects.filter(seer_run=missing).exists()
+        assert SeerRunMilestone.objects.filter(
+            seer_run=backfilled,
+            milestone=SeerRunMilestoneType.ROOT_CAUSE,
+        ).exists()
+
+    @patch("sentry.tasks.seer.backfill_run_milestones.fetch_run_status")
+    def test_invalid_state_is_skipped(self, mock_fetch_run_status: MagicMock) -> None:
+        invalid = self._create_run(seer_run_state_id=117)
+        backfilled = self._create_run(seer_run_state_id=118)
+        mock_fetch_run_status.side_effect = [
+            ValidationError([], SeerRunState),
+            _root_cause_state(118),
+        ]
+
+        backfill_run_milestones_for_org(self.organization.id, dry_run=False)
+
+        assert not SeerRunMilestone.objects.filter(seer_run=invalid).exists()
+        assert SeerRunMilestone.objects.filter(
+            seer_run=backfilled, milestone=SeerRunMilestoneType.ROOT_CAUSE
+        ).exists()
+
+    @patch("sentry.tasks.seer.backfill_run_milestones.fetch_run_status")
+    def test_fetch_error_skips_run_and_continues(self, mock_fetch_run_status: MagicMock) -> None:
+        failed = self._create_run(seer_run_state_id=120)
+        backfilled = self._create_run(seer_run_state_id=121)
+        mock_fetch_run_status.side_effect = [
+            SeerApiError("boom", 500),
+            _root_cause_state(121),
+        ]
+
+        backfill_run_milestones_for_org(self.organization.id, dry_run=False)
+
+        assert not SeerRunMilestone.objects.filter(seer_run=failed).exists()
+        assert SeerRunMilestone.objects.filter(
+            seer_run=backfilled, milestone=SeerRunMilestoneType.ROOT_CAUSE
+        ).exists()
+
+    @patch("sentry.tasks.seer.backfill_run_milestones.fetch_run_status")
+    def test_whole_batch_fetch_failure_raises(self, mock_fetch_run_status: MagicMock) -> None:
+        self._create_run(seer_run_state_id=122)
+        self._create_run(seer_run_state_id=123)
+        mock_fetch_run_status.side_effect = SeerApiError("down", 503)
+
+        with pytest.raises(SeerApiError):
+            backfill_run_milestones_for_org(self.organization.id, dry_run=False)
+
+    @patch("sentry.tasks.seer.backfill_run_milestones.fetch_run_status")
+    def test_writes_has_pull_request_when_pr_linked_but_state_lacks_it(
+        self, mock_fetch_run_status: MagicMock
+    ) -> None:
+        # Coding-agent PRs are recorded live via record_has_pull_request and may be
+        # absent from Seer state; a linked PR row is authoritative.
+        run = self._create_run(seer_run_state_id=130)
+        self._merged_pr(run, key="30")
+        mock_fetch_run_status.return_value = _empty_state(130)
+
+        backfill_run_milestones_for_org(self.organization.id, dry_run=False)
+
+        assert SeerRunMilestone.objects.filter(
+            seer_run=run, milestone=SeerRunMilestoneType.HAS_PULL_REQUEST
+        ).exists()
+
+    @patch("sentry.tasks.seer.backfill_run_milestones.fetch_run_status")
+    def test_killswitch_halts_before_any_work(self, mock_fetch_run_status: MagicMock) -> None:
+        run = self._create_run(seer_run_state_id=119)
+
+        with self.options({"seer.run_milestone_backfill.killswitch": True}):
+            backfill_run_milestones_for_org(self.organization.id, dry_run=False)
+
+        mock_fetch_run_status.assert_not_called()
+        assert not SeerRunMilestone.objects.filter(seer_run=run).exists()
+
+    def test_rejects_invalid_batch_size(self) -> None:
+        for batch_size in (0, 101):
+            with self.subTest(batch_size=batch_size):
+                with pytest.raises(ValueError):
+                    backfill_run_milestones_for_org(
+                        self.organization.id,
+                        batch_size=batch_size,
+                    )


### PR DESCRIPTION
Adds a manually triggered, per-org task that backfills `SeerRunMilestone` rows for an org's historical autofix runs — the ones from before milestones were recorded. It fetches each run's Seer state and reuses the same `reconcile_milestones` / `reconcile_pull_requests_merged_milestone` logic the live path uses, so backfilled rows match what a run records today. Runs are processed id-ascending in bounded batches that self-chain.

A linked PR is treated as authoritative for `HAS_PULL_REQUEST`, so coding-agent PRs that never made it into Seer state are neither lost nor wrongly removed.

**Safety**
- `dry_run` (default) reports would-create and would-delete counts without writing.
- A killswitch option stops the chain without a deploy.
- The 30-day window is pinned once and passed down the chain, so it can't slide and skip runs.
- Bad Seer states get their own metric; one fetch failure skips its run, a whole-batch failure raises.

Rolling out to one org first, then widening once validated.