### PR TITLE
perf(replays): Add smart chunking for Replay bulk delete job

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -511,15 +511,8 @@ register(
     default=0.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
-# Window size the bulk delete job pages within. One day is the useful value:
-#   - `timestamp` is in the replays sort key only at day granularity, so narrowing below a day
-#     prunes nothing.
-#   - A window wider than a day cannot assert its day and reads roughly twice the granules.
-#   - The replays storage sets `max_rows_to_group_by = 1000000` with `group_by_overflow_mode =
-#     break`, and the finder groups by `replay_id`. A window holding more than a million replays is
-#     therefore silently truncated rather than rejected, so replays go quietly undeleted. One day
-#     leaves ample headroom; the previous 7-day default truncated for any project above ~143k
-#     replays/day.
+# No longer read: the bulk delete job always windows by one UTC day. See `day_aligned_window` for
+# why nothing else is worth using. Kept registered pending removal.
 register(
     "replay.bulk_delete_job.chunk_size_days",
     default=1,

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -511,9 +511,15 @@ register(
     default=0.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
-# Window size the bulk delete job pages within. One day is the useful value: `timestamp` is in the
-# replays sort key only at day granularity, so a window cannot be narrowed below a day, and a window
-# wider than a day cannot assert its day and reads roughly twice the granules.
+# Window size the bulk delete job pages within. One day is the useful value:
+#   - `timestamp` is in the replays sort key only at day granularity, so narrowing below a day
+#     prunes nothing.
+#   - A window wider than a day cannot assert its day and reads roughly twice the granules.
+#   - The replays storage sets `max_rows_to_group_by = 1000000` with `group_by_overflow_mode =
+#     break`, and the finder groups by `replay_id`. A window holding more than a million replays is
+#     therefore silently truncated rather than rejected, so replays go quietly undeleted. One day
+#     leaves ample headroom; the previous 7-day default truncated for any project above ~143k
+#     replays/day.
 register(
     "replay.bulk_delete_job.chunk_size_days",
     default=1,

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -511,11 +511,10 @@ register(
     default=0.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
-# No longer read: the bulk delete job always windows by one UTC day. See `day_aligned_window` for
-# why nothing else is worth using. Kept registered pending removal.
+# Chunk size for bulk delete job
 register(
     "replay.bulk_delete_job.chunk_size_days",
-    default=1,
+    default=7,
     type=Int,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -511,10 +511,12 @@ register(
     default=0.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
-# Chunk size for bulk delete job
+# Window size the bulk delete job pages within. One day is the useful value: `timestamp` is in the
+# replays sort key only at day granularity, so a window cannot be narrowed below a day, and a window
+# wider than a day cannot assert its day and reads roughly twice the granules.
 register(
     "replay.bulk_delete_job.chunk_size_days",
-    default=7,
+    default=1,
     type=Int,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )

--- a/src/sentry/replays/scripts/delete_replays.py
+++ b/src/sentry/replays/scripts/delete_replays.py
@@ -19,7 +19,7 @@ from snuba_sdk import (
     Query,
 )
 
-from sentry import features, options
+from sentry import features
 from sentry.api.event_search import QueryToken, parse_search_query
 from sentry.models.organization import Organization
 from sentry.replays.query import replay_url_parser_config
@@ -59,10 +59,7 @@ def delete_replays(
     # Running tally of replays to be deleted, accumulated across windows and pages
     total_replays = 0
 
-    # Chunk the range into fixed-size windows
-    chunk_size_days = options.get("replay.bulk_delete_job.chunk_size_days") or 7
-
-    for window_start, window_end in day_aligned_windows(start_utc, end_utc, chunk_size_days):
+    for window_start, window_end in day_aligned_windows(start_utc, end_utc):
         # Reset per window because the cursor space is scoped to the window's result set
         cursor = None
 

--- a/src/sentry/replays/scripts/delete_replays.py
+++ b/src/sentry/replays/scripts/delete_replays.py
@@ -24,7 +24,11 @@ from sentry.api.event_search import QueryToken, parse_search_query
 from sentry.models.organization import Organization
 from sentry.replays.query import replay_url_parser_config
 from sentry.replays.tasks import archive_replay, delete_replays_script_async
-from sentry.replays.usecases.delete import SNUBA_RETRY_EXCEPTIONS, delete_seer_replay_data
+from sentry.replays.usecases.delete import (
+    SNUBA_RETRY_EXCEPTIONS,
+    day_pin_conditions,
+    delete_seer_replay_data,
+)
 from sentry.replays.usecases.query import execute_query, handle_search_filters
 from sentry.replays.usecases.query.configs.scalar import scalar_search_config
 from sentry.snuba.referrer import Referrer
@@ -57,12 +61,18 @@ def delete_replays(
     # Chunk the range into fixed-size windows
     chunk_size_days = options.get("replay.bulk_delete_job.chunk_size_days") or 7
 
+    # Windows are laid out from the start of `start_utc`'s UTC day rather than from `start_utc`,
+    # so a one-day window lands inside a single day and can assert it. See `day_pin_conditions`.
+    range_day_start = start_utc.replace(hour=0, minute=0, second=0, microsecond=0)
+
     window_offset_days = 0
     while True:
-        window_start = start_utc + timedelta(days=window_offset_days)
+        window_start = max(range_day_start + timedelta(days=window_offset_days), start_utc)
         if window_start >= end_utc:
             break
-        window_end = min(window_start + timedelta(days=chunk_size_days), end_utc)
+        window_end = min(
+            range_day_start + timedelta(days=window_offset_days + chunk_size_days), end_utc
+        )
 
         # Reset per window because the cursor space is scoped to the window's result set
         cursor = None
@@ -208,6 +218,7 @@ def _get_rows_matching_deletion_pattern(
             Condition(Column("timestamp"), Op.LT, end),
             Condition(Column("timestamp"), Op.GTE, start),
             Condition(Column("segment_id"), Op.IS_NOT_NULL),
+            *day_pin_conditions(start, end),
             *where,
         ],
         # Group by both the `replay_id` and `cityHash64(replay_id)` so we are able

--- a/src/sentry/replays/scripts/delete_replays.py
+++ b/src/sentry/replays/scripts/delete_replays.py
@@ -4,7 +4,7 @@ import functools
 import logging
 import uuid
 from collections.abc import Sequence
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 
 from snuba_sdk import (
     Column,
@@ -26,6 +26,7 @@ from sentry.replays.query import replay_url_parser_config
 from sentry.replays.tasks import archive_replay, delete_replays_script_async
 from sentry.replays.usecases.delete import (
     SNUBA_RETRY_EXCEPTIONS,
+    day_aligned_windows,
     day_pin_conditions,
     delete_seer_replay_data,
 )
@@ -61,19 +62,7 @@ def delete_replays(
     # Chunk the range into fixed-size windows
     chunk_size_days = options.get("replay.bulk_delete_job.chunk_size_days") or 7
 
-    # Windows are laid out from the start of `start_utc`'s UTC day rather than from `start_utc`,
-    # so a one-day window lands inside a single day and can assert it. See `day_pin_conditions`.
-    range_day_start = start_utc.replace(hour=0, minute=0, second=0, microsecond=0)
-
-    window_offset_days = 0
-    while True:
-        window_start = max(range_day_start + timedelta(days=window_offset_days), start_utc)
-        if window_start >= end_utc:
-            break
-        window_end = min(
-            range_day_start + timedelta(days=window_offset_days + chunk_size_days), end_utc
-        )
-
+    for window_start, window_end in day_aligned_windows(start_utc, end_utc, chunk_size_days):
         # Reset per window because the cursor space is scoped to the window's result set
         cursor = None
 
@@ -116,8 +105,6 @@ def delete_replays(
                         has_seer_data=has_seer_data,
                         total_replays=total_replays,
                     )
-
-        window_offset_days += chunk_size_days
 
 
 def translate_cli_tags_param_to_snuba_tag_param(tags: list[str]) -> Sequence[QueryToken]:

--- a/src/sentry/replays/scripts/delete_replays.py
+++ b/src/sentry/replays/scripts/delete_replays.py
@@ -26,8 +26,8 @@ from sentry.replays.query import replay_url_parser_config
 from sentry.replays.tasks import archive_replay, delete_replays_script_async
 from sentry.replays.usecases.delete import (
     SNUBA_RETRY_EXCEPTIONS,
+    datetime_as_start_of_day_conditions,
     day_aligned_windows,
-    day_pin_conditions,
     delete_seer_replay_data,
 )
 from sentry.replays.usecases.query import execute_query, handle_search_filters
@@ -202,7 +202,7 @@ def _get_rows_matching_deletion_pattern(
             Condition(Column("timestamp"), Op.LT, end),
             Condition(Column("timestamp"), Op.GTE, start),
             Condition(Column("segment_id"), Op.IS_NOT_NULL),
-            *day_pin_conditions(start, end),
+            *datetime_as_start_of_day_conditions(start, end),
             *where,
         ],
         # Group by both the `replay_id` and `cityHash64(replay_id)` so we are able

--- a/src/sentry/replays/tasks.py
+++ b/src/sentry/replays/tasks.py
@@ -240,9 +240,10 @@ def run_bulk_replay_delete_job(
     # day means `window_offset_days` indexes them directly.
     windows = day_aligned_windows(job.range_start, job.range_end)
     if window_offset_days >= len(windows):
-        # An activation pointing past the last window has nothing left to delete.
-        _transition_status(job.id, DeletionJobStatus.IN_PROGRESS, DeletionJobStatus.COMPLETED)
-        metrics.incr("replays.bulk_delete_job", tags={"status": "completed"}, sample_rate=1.0)
+        # The chain never schedules an offset past the last window, so this only catches an
+        # activation enqueued before the range was windowed the way it is now. Complete rather than
+        # let the index raise, which would fail the task and strand the job in progress.
+        _complete_job(job.id)
         return None
 
     window_start, window_end = windows[window_offset_days]
@@ -302,9 +303,11 @@ def run_bulk_replay_delete_job(
     # seeks nowhere. Treating that as "window done" stops it chaining activations forever.
     next_cursor = results["next_cursor"]
 
+    # This page's deletes are done, so checkpoint before deciding what comes next.
+    _advance_offset(job.id, new_total)
+
     if results["has_more"] and next_cursor is not None:
-        # Checkpoint before continuing within the same window.
-        _advance_offset(job.id, new_total)
+        # More pages in this window.
         run_bulk_replay_delete_job.delay(
             job.id,
             limit=limit,
@@ -315,25 +318,26 @@ def run_bulk_replay_delete_job(
         )
         return None
 
-    # Current window exhausted. Advance if any windows remain.
-    if window_offset_days + 1 < len(windows):
-        # Reset the cursor: it is a position within a window's result set, not a global one.
-        _advance_offset(job.id, new_total)
-        run_bulk_replay_delete_job.delay(
-            job.id,
-            limit=limit,
-            has_seer_data=has_seer_data,
-            total_deleted=new_total,
-            window_offset_days=window_offset_days + 1,
-            after_replay_id_hash=None,
-        )
+    # Window exhausted and there is no next one to schedule, so the job is done.
+    if window_offset_days + 1 >= len(windows):
+        _complete_job(job.id)
         return None
 
-    # All windows processed. Mark the job as completed.
-    _advance_offset(job.id, new_total)
-    _transition_status(job.id, DeletionJobStatus.IN_PROGRESS, DeletionJobStatus.COMPLETED)
-    metrics.incr("replays.bulk_delete_job", tags={"status": "completed"}, sample_rate=1.0)
+    run_bulk_replay_delete_job.delay(
+        job.id,
+        limit=limit,
+        has_seer_data=has_seer_data,
+        total_deleted=new_total,
+        window_offset_days=window_offset_days + 1,
+        # Reset the cursor: it is a position within a window's result set, not a global one.
+        after_replay_id_hash=None,
+    )
     return None
+
+
+def _complete_job(job_id: int) -> None:
+    _transition_status(job_id, DeletionJobStatus.IN_PROGRESS, DeletionJobStatus.COMPLETED)
+    metrics.incr("replays.bulk_delete_job", tags={"status": "completed"}, sample_rate=1.0)
 
 
 def _advance_offset(job_id: int, offset: int) -> None:

--- a/src/sentry/replays/tasks.py
+++ b/src/sentry/replays/tasks.py
@@ -9,7 +9,6 @@ from taskbroker_client.retry import Retry
 from taskbroker_client.state import current_task
 from taskbroker_client.worker.workerchild import ProcessingDeadlineExceeded
 
-from sentry import options
 from sentry.replays.consumers.recording import commit_message, process_message
 from sentry.replays.lib.kafka import PROCESS_REPLAY_RECORDING_TASK_NAME, publish_replay_event
 from sentry.replays.lib.storage import (
@@ -224,7 +223,6 @@ def run_bulk_replay_delete_job(
     its window from the beginning rather than failing. Remove the argument once the queue has
     drained.
     """
-    chunk_size_days = options.get("replay.bulk_delete_job.chunk_size_days") or 7
     job = ReplayDeletionJobModel.objects.get(id=replay_delete_job_id)
 
     # If this is the first run of the task we set the model to in-progress.
@@ -239,7 +237,7 @@ def run_bulk_replay_delete_job(
 
     # Derive the current window from the immutable job range and the cursor. job.range_start is
     # never mutated, so the API always returns the original range.
-    window = day_aligned_window(job.range_start, job.range_end, window_offset_days, chunk_size_days)
+    window = day_aligned_window(job.range_start, job.range_end, window_offset_days)
     if window is None:
         # The cursor is past the end of the range; there is nothing left to delete.
         _transition_status(job.id, DeletionJobStatus.IN_PROGRESS, DeletionJobStatus.COMPLETED)
@@ -327,7 +325,7 @@ def run_bulk_replay_delete_job(
             limit=limit,
             has_seer_data=has_seer_data,
             total_deleted=new_total,
-            window_offset_days=window_offset_days + chunk_size_days,
+            window_offset_days=window_offset_days + 1,
             after_replay_id_hash=None,
         )
         return None

--- a/src/sentry/replays/tasks.py
+++ b/src/sentry/replays/tasks.py
@@ -20,7 +20,7 @@ from sentry.replays.lib.storage import (
 from sentry.replays.models import DeletionJobStatus, ReplayDeletionJobModel, ReplayRecordingSegment
 from sentry.replays.usecases.delete import (
     DELETE_THREAD_POOL_SIZE,
-    day_aligned_window,
+    day_aligned_windows,
     delete_filenames_concurrently,
     delete_matched_rows,
     delete_seer_replay_data,
@@ -235,16 +235,17 @@ def run_bulk_replay_delete_job(
     if job.status != DeletionJobStatus.IN_PROGRESS:
         return None
 
-    # Derive the current window from the immutable job range and the cursor. job.range_start is
-    # never mutated, so the API always returns the original range.
-    window = day_aligned_window(job.range_start, job.range_end, window_offset_days)
-    if window is None:
-        # The cursor is past the end of the range; there is nothing left to delete.
+    # Windows are recomputed from the job's range on every activation rather than stored, so
+    # job.range_start is never mutated and the API always returns the original range. One window per
+    # day means `window_offset_days` indexes them directly.
+    windows = day_aligned_windows(job.range_start, job.range_end)
+    if window_offset_days >= len(windows):
+        # An activation pointing past the last window has nothing left to delete.
         _transition_status(job.id, DeletionJobStatus.IN_PROGRESS, DeletionJobStatus.COMPLETED)
         metrics.incr("replays.bulk_delete_job", tags={"status": "completed"}, sample_rate=1.0)
         return None
 
-    window_start, window_end = window
+    window_start, window_end = windows[window_offset_days]
 
     try:
         # Delete the replays within a limited range. If more replays exist a cursor to seek the next
@@ -314,11 +315,9 @@ def run_bulk_replay_delete_job(
         )
         return None
 
-    # Current window exhausted. Check if more time windows remain.
-    if window_end < job.range_end:
-        # Advance to the next window by incrementing the day offset in the task args, and reset the
-        # cursor: it is a position within a window's result set, not a global one.
-        # job.range_start is never mutated so the API always returns the original range.
+    # Current window exhausted. Advance if any windows remain.
+    if window_offset_days + 1 < len(windows):
+        # Reset the cursor: it is a position within a window's result set, not a global one.
         _advance_offset(job.id, new_total)
         run_bulk_replay_delete_job.delay(
             job.id,

--- a/src/sentry/replays/tasks.py
+++ b/src/sentry/replays/tasks.py
@@ -237,10 +237,15 @@ def run_bulk_replay_delete_job(
     if job.status != DeletionJobStatus.IN_PROGRESS:
         return None
 
-    # Derive the current window boundaries from the immutable job range and the cursor.
-    # Chunking into 7-day windows avoids full table scans in ClickHouse.
-    window_start = job.range_start + timedelta(days=window_offset_days)
-    window_end = min(window_start + timedelta(days=chunk_size_days), job.range_end)
+    # Derive the current window boundaries from the immutable job range and the cursor. Windows
+    # are laid out from the start of `range_start`'s UTC day rather than from `range_start` itself,
+    # so that a one-day window lands inside a single day and can assert it. See
+    # `day_pin_conditions`. Both ends are clamped to the job's range.
+    range_day_start = job.range_start.replace(hour=0, minute=0, second=0, microsecond=0)
+    window_start = max(range_day_start + timedelta(days=window_offset_days), job.range_start)
+    window_end = min(
+        range_day_start + timedelta(days=window_offset_days + chunk_size_days), job.range_end
+    )
 
     try:
         # Delete the replays within a limited range. If more replays exist a cursor to seek the next

--- a/src/sentry/replays/tasks.py
+++ b/src/sentry/replays/tasks.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from datetime import timedelta
 from typing import Any
 
 from django.utils import timezone
@@ -22,6 +21,7 @@ from sentry.replays.lib.storage import (
 from sentry.replays.models import DeletionJobStatus, ReplayDeletionJobModel, ReplayRecordingSegment
 from sentry.replays.usecases.delete import (
     DELETE_THREAD_POOL_SIZE,
+    day_aligned_window,
     delete_filenames_concurrently,
     delete_matched_rows,
     delete_seer_replay_data,
@@ -237,15 +237,16 @@ def run_bulk_replay_delete_job(
     if job.status != DeletionJobStatus.IN_PROGRESS:
         return None
 
-    # Derive the current window boundaries from the immutable job range and the cursor. Windows
-    # are laid out from the start of `range_start`'s UTC day rather than from `range_start` itself,
-    # so that a one-day window lands inside a single day and can assert it. See
-    # `day_pin_conditions`. Both ends are clamped to the job's range.
-    range_day_start = job.range_start.replace(hour=0, minute=0, second=0, microsecond=0)
-    window_start = max(range_day_start + timedelta(days=window_offset_days), job.range_start)
-    window_end = min(
-        range_day_start + timedelta(days=window_offset_days + chunk_size_days), job.range_end
-    )
+    # Derive the current window from the immutable job range and the cursor. job.range_start is
+    # never mutated, so the API always returns the original range.
+    window = day_aligned_window(job.range_start, job.range_end, window_offset_days, chunk_size_days)
+    if window is None:
+        # The cursor is past the end of the range; there is nothing left to delete.
+        _transition_status(job.id, DeletionJobStatus.IN_PROGRESS, DeletionJobStatus.COMPLETED)
+        metrics.incr("replays.bulk_delete_job", tags={"status": "completed"}, sample_rate=1.0)
+        return None
+
+    window_start, window_end = window
 
     try:
         # Delete the replays within a limited range. If more replays exist a cursor to seek the next

--- a/src/sentry/replays/usecases/delete.py
+++ b/src/sentry/replays/usecases/delete.py
@@ -90,14 +90,21 @@ def _start_of_day(value: datetime) -> datetime:
 def datetime_as_start_of_day_conditions(start: datetime, end: datetime) -> list[Condition]:
     """Restate `[start, end)` as bounds on `toStartOfDay(timestamp)`.
 
-    Where a table is sorted by `toStartOfDay(timestamp)`, ClickHouse already derives day bounds from
-    a predicate on the raw column -- but a strict `timestamp < midnight` can only weaken to a
-    non-strict bound on the day, so the index also scans the day the range ends on. Naming the last
-    day the range really touches drops it: one day of granules at any range width, which on a table
-    with the real sort key took a one-day range from 25 granules to 13.
+    A table sorted by `toStartOfDay(timestamp)` keeps its rows grouped by day, and its index knows
+    only which day each block of rows belongs to. Conditions written in those same terms line up
+    with how the rows are ordered, so whole days can be skipped without being read at all. That is
+    what makes filtering by day cheap on such a table, and why it is worth asking for the day
+    directly.
 
-    The derived lower bound is already tight, so the `>=` here buys nothing measurable; it is stated
-    so the pair reads as the range of days it is instead of leaving one side implicit.
+    A condition on the raw `timestamp` has to be translated into days first, and the translation is
+    deliberately careful at the top end: it includes the day the upper bound falls in, because a
+    bound at, say, noon really does leave matching rows in that day. A bound at midnight leaves
+    none, but the day gets read regardless. Naming the last day the range actually reaches drops
+    it -- one day of blocks at any range width, which on a table with the real sort key took a
+    one-day range from 25 blocks to 13.
+
+    The bottom end translates exactly, so the `>=` neither costs nor saves anything measurable. It
+    is here so the pair reads as the span of days it is.
 
     `end` is exclusive, so a range ending exactly at midnight does not reach that day.
     """

--- a/src/sentry/replays/usecases/delete.py
+++ b/src/sentry/replays/usecases/delete.py
@@ -57,41 +57,29 @@ SNUBA_RETRY_EXCEPTIONS = (
 logger = logging.getLogger(__name__)
 
 
-def day_aligned_window(
-    range_start: datetime, range_end: datetime, offset_days: int
-) -> tuple[datetime, datetime] | None:
-    """Return the `offset_days`th UTC day of `[range_start, range_end)`, or None past the end.
-
-    A window is one whole UTC day intersected with the requested range, so the caller's own bounds
-    survive: the first window opens at `range_start`, the last closes at `range_end`, and only those
-    two are ever shorter than a day. Consecutive windows meet exactly, so the range is covered with
-    no gaps and no overlap. All datetimes are UTC.
-
-    Taking whole days, rather than `range_start` plus a day, is what stops a window from straddling
-    midnight -- which is what lets `day_pin_conditions` assert the window's day.
-
-    One day per window is the only size worth using:
-      - `timestamp` is in the replays sort key at day granularity, so a narrower window prunes
-        nothing.
-      - A wider window cannot assert its day and so reads roughly twice the granules.
-      - The replays storage sets `max_rows_to_group_by = 1000000` with `group_by_overflow_mode =
-        break`, and the finders group by `replay_id`. A window holding more than a million replays is
-        silently truncated rather than rejected, so replays go quietly undeleted. A day leaves ample
-        headroom; the 7-day window this replaced truncated for any project above ~143k replays/day.
-    """
-    day_start = _start_of_day(range_start) + timedelta(days=offset_days)
-
-    return _intersect((day_start, day_start + timedelta(days=1)), (range_start, range_end))
-
-
 def day_aligned_windows(
     range_start: datetime, range_end: datetime
-) -> Iterator[tuple[datetime, datetime]]:
-    """Walk `[range_start, range_end)` one UTC day at a time. See `day_aligned_window`."""
-    offset_days = 0
-    while window := day_aligned_window(range_start, range_end, offset_days):
-        yield window
-        offset_days += 1
+) -> list[tuple[datetime, datetime]]:
+    """Split `[range_start, range_end)` into one window per UTC day it touches.
+
+    Each window is a whole UTC day intersected with the range, so the caller's own bounds survive:
+    the first window opens at `range_start`, the last closes at `range_end`, and only those two are
+    ever shorter than a day. Consecutive windows meet exactly, so the range is covered with no gaps
+    and no overlap. All datetimes are UTC.
+
+    Whole days rather than `range_start` plus a day is what keeps a window from straddling midnight.
+    See `day_pin_conditions` for why a day is the unit worth paging in.
+    """
+    windows = []
+
+    day_start = _start_of_day(range_start)
+    while window := _intersect(
+        (day_start, day_start + timedelta(days=1)), (range_start, range_end)
+    ):
+        windows.append(window)
+        day_start += timedelta(days=1)
+
+    return windows
 
 
 def _intersect(
@@ -115,7 +103,16 @@ def day_pin_conditions(start: datetime, end: datetime) -> list[Condition]:
     Asserting the day collapses that. Measured against a table with the real sort key, a single-day
     window went from 25 granules to 13 with identical row counts.
 
-    Every window from `day_aligned_window` lies inside one day, so in practice the pin always
+    This assertion is why the finders page a day at a time. `timestamp` is in the replays sort key
+    only at day granularity, so a narrower window prunes nothing -- 24h, 6h, 1h and 1min all read the
+    same granules -- while a wider one cannot assert a day at all and so reads roughly twice as
+    many. A day also stays well under the storage's `max_rows_to_group_by = 1000000`, which is paired
+    with `group_by_overflow_mode = break`: because the finders group by `replay_id`, a window holding
+    more than a million replays is silently truncated rather than rejected, and the replays past the
+    cut go quietly undeleted. The 7-day window this replaced truncated for any project above ~143k
+    replays/day.
+
+    Every window from `day_aligned_windows` lies inside one day, so in practice the pin always
     applies. The guard stays because the finders accept an arbitrary range: pinning one that spanned
     days would silently drop every row past the first day, which on this path means PII reported as
     deleted that was not.

--- a/src/sentry/replays/usecases/delete.py
+++ b/src/sentry/replays/usecases/delete.py
@@ -58,34 +58,46 @@ logger = logging.getLogger(__name__)
 
 
 def day_aligned_window(
-    range_start: datetime, range_end: datetime, offset_days: int, days_per_window: int
+    range_start: datetime, range_end: datetime, offset_days: int
 ) -> tuple[datetime, datetime] | None:
     """Return the window `offset_days` into `[range_start, range_end)`, or None past the end.
 
+    One UTC day per window, which is the only size worth using:
+      - `timestamp` is in the replays sort key at day granularity, so a narrower window prunes
+        nothing.
+      - A wider window cannot assert its day (see `day_pin_conditions`) and so reads roughly twice
+        the granules.
+      - The replays storage sets `max_rows_to_group_by = 1000000` with `group_by_overflow_mode =
+        break`, and the finders group by `replay_id`. A window holding more than a million replays is
+        silently truncated rather than rejected, so replays go quietly undeleted. A day leaves ample
+        headroom; the 7-day window this replaced truncated for any project above ~143k replays/day.
+
     Windows are laid out from the start of `range_start`'s UTC day rather than from `range_start`
-    itself, so a one-day window lands inside a single UTC day and `day_pin_conditions` can assert
-    it. Both ends are clamped to the range, so the first and last windows can be shorter.
+    itself, so each one lands inside a single day. Both ends are clamped to the range, so the first
+    and last windows can be shorter than a day.
 
     Consecutive windows meet exactly -- window N ends where window N+1 begins -- so the range is
     covered without gaps or overlap.
     """
-    day_start = range_start.replace(hour=0, minute=0, second=0, microsecond=0)
+    day = range_start.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(
+        days=offset_days
+    )
 
-    start = max(day_start + timedelta(days=offset_days), range_start)
+    start = max(day, range_start)
     if start >= range_end:
         return None
 
-    return start, min(day_start + timedelta(days=offset_days + days_per_window), range_end)
+    return start, min(day + timedelta(days=1), range_end)
 
 
 def day_aligned_windows(
-    range_start: datetime, range_end: datetime, days_per_window: int
+    range_start: datetime, range_end: datetime
 ) -> Iterator[tuple[datetime, datetime]]:
-    """Walk `[range_start, range_end)` as day-aligned windows. See `day_aligned_window`."""
+    """Walk `[range_start, range_end)` one UTC day at a time. See `day_aligned_window`."""
     offset_days = 0
-    while window := day_aligned_window(range_start, range_end, offset_days, days_per_window):
+    while window := day_aligned_window(range_start, range_end, offset_days):
         yield window
-        offset_days += days_per_window
+        offset_days += 1
 
 
 def day_pin_conditions(start: datetime, end: datetime) -> list[Condition]:
@@ -96,7 +108,10 @@ def day_pin_conditions(start: datetime, end: datetime) -> list[Condition]:
     Asserting the day collapses that. Measured against a table with the real sort key, a single-day
     window went from 25 granules to 13 with identical row counts.
 
-    Returns nothing when the window spans a day boundary, where the assertion would be wrong.
+    Every window from `day_aligned_window` lies inside one day, so in practice the pin always
+    applies. The guard stays because the finders accept an arbitrary range: pinning one that spanned
+    days would silently drop every row past the first day, which on this path means PII reported as
+    deleted that was not.
     """
     day = start.replace(hour=0, minute=0, second=0, microsecond=0)
     if end > day + timedelta(days=1):

--- a/src/sentry/replays/usecases/delete.py
+++ b/src/sentry/replays/usecases/delete.py
@@ -62,60 +62,47 @@ def day_aligned_windows(
 ) -> list[tuple[datetime, datetime]]:
     """Split `[range_start, range_end)` into one window per UTC day it touches.
 
-    Each window is a whole UTC day intersected with the range, so the caller's own bounds survive:
-    the first window opens at `range_start`, the last closes at `range_end`, and only those two are
-    ever shorter than a day. Consecutive windows meet exactly, so the range is covered with no gaps
-    and no overlap. All datetimes are UTC.
+    Every window but the last runs from where the previous one ended to the next UTC midnight; the
+    last closes at `range_end`. The caller's own bounds therefore survive -- the first window opens
+    at `range_start`, not at midnight -- and only the first and last are ever shorter than a day.
+    Consecutive windows meet exactly, so the range is covered with no gaps and no overlap. All
+    datetimes are UTC.
 
-    Whole days rather than `range_start` plus a day is what keeps a window from straddling midnight.
-    See `day_pin_conditions` for why a day is the unit worth paging in.
+    Never crossing midnight is what lets `datetime_as_start_of_day_conditions` assert a window's
+    day. A day also holds a window's replay count well under the storage's `max_rows_to_group_by`,
+    which is paired with `group_by_overflow_mode = break`: past a million replays the finders' GROUP
+    BY is truncated rather than rejected, and the replays past the cut go quietly undeleted.
     """
+    if range_start >= range_end:
+        return []
+
     windows = []
 
-    day_start = _start_of_day(range_start)
-    while window := _intersect(
-        (day_start, day_start + timedelta(days=1)), (range_start, range_end)
-    ):
-        windows.append(window)
-        day_start += timedelta(days=1)
+    start = range_start
+    while (next_midnight := _start_of_day(start) + timedelta(days=1)) < range_end:
+        windows.append((start, next_midnight))
+        start = next_midnight
+
+    windows.append((start, range_end))
 
     return windows
-
-
-def _intersect(
-    first: tuple[datetime, datetime], second: tuple[datetime, datetime]
-) -> tuple[datetime, datetime] | None:
-    """Overlap of two half-open intervals, or None when they do not overlap."""
-    start, end = max(first[0], second[0]), min(first[1], second[1])
-
-    return (start, end) if start < end else None
 
 
 def _start_of_day(value: datetime) -> datetime:
     return value.replace(hour=0, minute=0, second=0, microsecond=0)
 
 
-def day_pin_conditions(start: datetime, end: datetime) -> list[Condition]:
-    """Assert the UTC day, when the window lies inside one.
+def datetime_as_start_of_day_conditions(start: datetime, end: datetime) -> list[Condition]:
+    """Restate a single-day window as an equality on `toStartOfDay(timestamp)`.
 
-    `timestamp < midnight` only degrades to a *non-strict* bound on `toStartOfDay(timestamp)`,
-    because that function is not injective, so the primary index selects the following day as well.
-    Asserting the day collapses that. Measured against a table with the real sort key, a single-day
-    window went from 25 granules to 13 with identical row counts.
+    Worth doing because the replays sort key holds `timestamp` only as `toStartOfDay(timestamp)`. A
+    strict `timestamp < midnight` degrades to a non-strict bound on that, so the primary index reads
+    the following day as well. The equality collapses it: measured against a table with the real
+    sort key, a single-day window went from 25 granules to 13 for identical row counts.
 
-    This assertion is why the finders page a day at a time. `timestamp` is in the replays sort key
-    only at day granularity, so a narrower window prunes nothing -- 24h, 6h, 1h and 1min all read the
-    same granules -- while a wider one cannot assert a day at all and so reads roughly twice as
-    many. A day also stays well under the storage's `max_rows_to_group_by = 1000000`, which is paired
-    with `group_by_overflow_mode = break`: because the finders group by `replay_id`, a window holding
-    more than a million replays is silently truncated rather than rejected, and the replays past the
-    cut go quietly undeleted. The 7-day window this replaced truncated for any project above ~143k
-    replays/day.
-
-    Every window from `day_aligned_windows` lies inside one day, so in practice the pin always
-    applies. The guard stays because the finders accept an arbitrary range: pinning one that spanned
-    days would silently drop every row past the first day, which on this path means PII reported as
-    deleted that was not.
+    Returns nothing when the window crosses midnight, where the equality would be false for the rows
+    after it. No window from `day_aligned_windows` can, but the finders accept an arbitrary range,
+    and dropping those rows silently would mean PII reported as deleted that was not.
     """
     day = _start_of_day(start)
     if end > day + timedelta(days=1):
@@ -241,7 +228,7 @@ def fetch_rows_matching_pattern(
             Condition(Column("timestamp"), Op.GTE, start),
             # We only match segment rows because those contain the PII we want to delete.
             Condition(Column("segment_id"), Op.IS_NOT_NULL),
-            *day_pin_conditions(start, end),
+            *datetime_as_start_of_day_conditions(start, end),
             *where,
         ],
         having=having,

--- a/src/sentry/replays/usecases/delete.py
+++ b/src/sentry/replays/usecases/delete.py
@@ -60,34 +60,28 @@ logger = logging.getLogger(__name__)
 def day_aligned_window(
     range_start: datetime, range_end: datetime, offset_days: int
 ) -> tuple[datetime, datetime] | None:
-    """Return the window `offset_days` into `[range_start, range_end)`, or None past the end.
+    """Return the `offset_days`th UTC day of `[range_start, range_end)`, or None past the end.
 
-    One UTC day per window, which is the only size worth using:
+    A window is one whole UTC day intersected with the requested range, so the caller's own bounds
+    survive: the first window opens at `range_start`, the last closes at `range_end`, and only those
+    two are ever shorter than a day. Consecutive windows meet exactly, so the range is covered with
+    no gaps and no overlap. All datetimes are UTC.
+
+    Taking whole days, rather than `range_start` plus a day, is what stops a window from straddling
+    midnight -- which is what lets `day_pin_conditions` assert the window's day.
+
+    One day per window is the only size worth using:
       - `timestamp` is in the replays sort key at day granularity, so a narrower window prunes
         nothing.
-      - A wider window cannot assert its day (see `day_pin_conditions`) and so reads roughly twice
-        the granules.
+      - A wider window cannot assert its day and so reads roughly twice the granules.
       - The replays storage sets `max_rows_to_group_by = 1000000` with `group_by_overflow_mode =
         break`, and the finders group by `replay_id`. A window holding more than a million replays is
         silently truncated rather than rejected, so replays go quietly undeleted. A day leaves ample
         headroom; the 7-day window this replaced truncated for any project above ~143k replays/day.
-
-    Windows are laid out from the start of `range_start`'s UTC day rather than from `range_start`
-    itself, so each one lands inside a single day. Both ends are clamped to the range, so the first
-    and last windows can be shorter than a day.
-
-    Consecutive windows meet exactly -- window N ends where window N+1 begins -- so the range is
-    covered without gaps or overlap.
     """
-    day = range_start.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(
-        days=offset_days
-    )
+    day_start = _start_of_day(range_start) + timedelta(days=offset_days)
 
-    start = max(day, range_start)
-    if start >= range_end:
-        return None
-
-    return start, min(day + timedelta(days=1), range_end)
+    return _intersect((day_start, day_start + timedelta(days=1)), (range_start, range_end))
 
 
 def day_aligned_windows(
@@ -98,6 +92,19 @@ def day_aligned_windows(
     while window := day_aligned_window(range_start, range_end, offset_days):
         yield window
         offset_days += 1
+
+
+def _intersect(
+    first: tuple[datetime, datetime], second: tuple[datetime, datetime]
+) -> tuple[datetime, datetime] | None:
+    """Overlap of two half-open intervals, or None when they do not overlap."""
+    start, end = max(first[0], second[0]), min(first[1], second[1])
+
+    return (start, end) if start < end else None
+
+
+def _start_of_day(value: datetime) -> datetime:
+    return value.replace(hour=0, minute=0, second=0, microsecond=0)
 
 
 def day_pin_conditions(start: datetime, end: datetime) -> list[Condition]:
@@ -113,7 +120,7 @@ def day_pin_conditions(start: datetime, end: datetime) -> list[Condition]:
     days would silently drop every row past the first day, which on this path means PII reported as
     deleted that was not.
     """
-    day = start.replace(hour=0, minute=0, second=0, microsecond=0)
+    day = _start_of_day(start)
     if end > day + timedelta(days=1):
         return []
 

--- a/src/sentry/replays/usecases/delete.py
+++ b/src/sentry/replays/usecases/delete.py
@@ -67,12 +67,6 @@ def day_aligned_windows(
     at `range_start`, not at midnight -- and only the first and last are ever shorter than a day.
     Consecutive windows meet exactly, so the range is covered with no gaps and no overlap. All
     datetimes are UTC.
-
-    Never crossing midnight is what lets `datetime_as_start_of_day_conditions` narrow the sort key
-    to a single day. A day also holds a window's replay count under the storage's
-    `max_rows_to_group_by`,
-    which is paired with `group_by_overflow_mode = break`: past a million replays the finders' GROUP
-    BY is truncated rather than rejected, and the replays past the cut go quietly undeleted.
     """
     if range_start >= range_end:
         return []
@@ -96,10 +90,14 @@ def _start_of_day(value: datetime) -> datetime:
 def datetime_as_start_of_day_conditions(start: datetime, end: datetime) -> list[Condition]:
     """Restate `[start, end)` as bounds on `toStartOfDay(timestamp)`.
 
-    Where a table is sorted by `toStartOfDay(timestamp)` rather than by `timestamp`, a bound on the
-    raw column only bounds the day it lands in, so the primary index also scans the day the range
-    ends on. Naming the first and last day the range touches removes that. A range inside one day
-    bounds that day from both sides, which the index reads as an equality.
+    Where a table is sorted by `toStartOfDay(timestamp)`, ClickHouse already derives day bounds from
+    a predicate on the raw column -- but a strict `timestamp < midnight` can only weaken to a
+    non-strict bound on the day, so the index also scans the day the range ends on. Naming the last
+    day the range really touches drops it: one day of granules at any range width, which on a table
+    with the real sort key took a one-day range from 25 granules to 13.
+
+    The derived lower bound is already tight, so the `>=` here buys nothing measurable; it is stated
+    so the pair reads as the range of days it is instead of leaving one side implicit.
 
     `end` is exclusive, so a range ending exactly at midnight does not reach that day.
     """

--- a/src/sentry/replays/usecases/delete.py
+++ b/src/sentry/replays/usecases/delete.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import functools
 import logging
 from collections.abc import Iterator
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import TypedDict
 
 from google.cloud.exceptions import NotFound
@@ -55,6 +55,23 @@ SNUBA_RETRY_EXCEPTIONS = (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def day_pin_conditions(start: datetime, end: datetime) -> list[Condition]:
+    """Assert the UTC day, when the window lies inside one.
+
+    `timestamp < midnight` only degrades to a *non-strict* bound on `toStartOfDay(timestamp)`,
+    because that function is not injective, so the primary index selects the following day as well.
+    Asserting the day collapses that. Measured against a table with the real sort key, a single-day
+    window went from 25 granules to 13 with identical row counts.
+
+    Returns nothing when the window spans a day boundary, where the assertion would be wrong.
+    """
+    day = start.replace(hour=0, minute=0, second=0, microsecond=0)
+    if end > day + timedelta(days=1):
+        return []
+
+    return [Condition(Function("toStartOfDay", parameters=[Column("timestamp")]), Op.EQ, day)]
 
 
 def delete_matched_rows(project_id: int, rows: list[MatchedRow]) -> int | None:
@@ -174,6 +191,7 @@ def fetch_rows_matching_pattern(
             Condition(Column("timestamp"), Op.GTE, start),
             # We only match segment rows because those contain the PII we want to delete.
             Condition(Column("segment_id"), Op.IS_NOT_NULL),
+            *day_pin_conditions(start, end),
             *where,
         ],
         having=having,

--- a/src/sentry/replays/usecases/delete.py
+++ b/src/sentry/replays/usecases/delete.py
@@ -57,6 +57,37 @@ SNUBA_RETRY_EXCEPTIONS = (
 logger = logging.getLogger(__name__)
 
 
+def day_aligned_window(
+    range_start: datetime, range_end: datetime, offset_days: int, days_per_window: int
+) -> tuple[datetime, datetime] | None:
+    """Return the window `offset_days` into `[range_start, range_end)`, or None past the end.
+
+    Windows are laid out from the start of `range_start`'s UTC day rather than from `range_start`
+    itself, so a one-day window lands inside a single UTC day and `day_pin_conditions` can assert
+    it. Both ends are clamped to the range, so the first and last windows can be shorter.
+
+    Consecutive windows meet exactly -- window N ends where window N+1 begins -- so the range is
+    covered without gaps or overlap.
+    """
+    day_start = range_start.replace(hour=0, minute=0, second=0, microsecond=0)
+
+    start = max(day_start + timedelta(days=offset_days), range_start)
+    if start >= range_end:
+        return None
+
+    return start, min(day_start + timedelta(days=offset_days + days_per_window), range_end)
+
+
+def day_aligned_windows(
+    range_start: datetime, range_end: datetime, days_per_window: int
+) -> Iterator[tuple[datetime, datetime]]:
+    """Walk `[range_start, range_end)` as day-aligned windows. See `day_aligned_window`."""
+    offset_days = 0
+    while window := day_aligned_window(range_start, range_end, offset_days, days_per_window):
+        yield window
+        offset_days += days_per_window
+
+
 def day_pin_conditions(start: datetime, end: datetime) -> list[Condition]:
     """Assert the UTC day, when the window lies inside one.
 

--- a/src/sentry/replays/usecases/delete.py
+++ b/src/sentry/replays/usecases/delete.py
@@ -68,8 +68,9 @@ def day_aligned_windows(
     Consecutive windows meet exactly, so the range is covered with no gaps and no overlap. All
     datetimes are UTC.
 
-    Never crossing midnight is what lets `datetime_as_start_of_day_conditions` assert a window's
-    day. A day also holds a window's replay count well under the storage's `max_rows_to_group_by`,
+    Never crossing midnight is what lets `datetime_as_start_of_day_conditions` narrow the sort key
+    to a single day. A day also holds a window's replay count under the storage's
+    `max_rows_to_group_by`,
     which is paired with `group_by_overflow_mode = break`: past a million replays the finders' GROUP
     BY is truncated rather than rejected, and the replays past the cut go quietly undeleted.
     """
@@ -93,20 +94,21 @@ def _start_of_day(value: datetime) -> datetime:
 
 
 def datetime_as_start_of_day_conditions(start: datetime, end: datetime) -> list[Condition]:
-    """Restate a window that falls within one day as an equality on `toStartOfDay(timestamp)`.
+    """Restate `[start, end)` as bounds on `toStartOfDay(timestamp)`.
 
     Where a table is sorted by `toStartOfDay(timestamp)` rather than by `timestamp`, a bound on the
-    raw column only bounds the day it lands in, so the primary index also scans the day the window
-    ends on. Naming the day directly removes that.
+    raw column only bounds the day it lands in, so the primary index also scans the day the range
+    ends on. Naming the first and last day the range touches removes that. A range inside one day
+    bounds that day from both sides, which the index reads as an equality.
 
-    Returns nothing for a window that crosses midnight, where the equality would exclude rows the
-    caller asked for.
+    `end` is exclusive, so a range ending exactly at midnight does not reach that day.
     """
-    day = _start_of_day(start)
-    if end > day + timedelta(days=1):
-        return []
+    day = Function("toStartOfDay", parameters=[Column("timestamp")])
 
-    return [Condition(Function("toStartOfDay", parameters=[Column("timestamp")]), Op.EQ, day)]
+    return [
+        Condition(day, Op.GTE, _start_of_day(start)),
+        Condition(day, Op.LTE, _start_of_day(end - timedelta(microseconds=1))),
+    ]
 
 
 def delete_matched_rows(project_id: int, rows: list[MatchedRow]) -> int | None:

--- a/src/sentry/replays/usecases/delete.py
+++ b/src/sentry/replays/usecases/delete.py
@@ -93,16 +93,14 @@ def _start_of_day(value: datetime) -> datetime:
 
 
 def datetime_as_start_of_day_conditions(start: datetime, end: datetime) -> list[Condition]:
-    """Restate a single-day window as an equality on `toStartOfDay(timestamp)`.
+    """Restate a window that falls within one day as an equality on `toStartOfDay(timestamp)`.
 
-    Worth doing because the replays sort key holds `timestamp` only as `toStartOfDay(timestamp)`. A
-    strict `timestamp < midnight` degrades to a non-strict bound on that, so the primary index reads
-    the following day as well. The equality collapses it: measured against a table with the real
-    sort key, a single-day window went from 25 granules to 13 for identical row counts.
+    Where a table is sorted by `toStartOfDay(timestamp)` rather than by `timestamp`, a bound on the
+    raw column only bounds the day it lands in, so the primary index also scans the day the window
+    ends on. Naming the day directly removes that.
 
-    Returns nothing when the window crosses midnight, where the equality would be false for the rows
-    after it. No window from `day_aligned_windows` can, but the finders accept an arbitrary range,
-    and dropping those rows silently would mean PII reported as deleted that was not.
+    Returns nothing for a window that crosses midnight, where the equality would exclude rows the
+    caller asked for.
     """
     day = _start_of_day(start)
     if end > day + timedelta(days=1):

--- a/tests/sentry/replays/scripts/test_delete_replays.py
+++ b/tests/sentry/replays/scripts/test_delete_replays.py
@@ -327,44 +327,6 @@ class TestDeleteReplays(ReplaysSnubaTestCase):
         self.assert_recording_not_deleted(replay_id_other_project)
         self.assert_recording_not_deleted(replay_id_outside_timerange)
 
-    def test_deletion_replays_multiple_time_windows(self) -> None:
-        # Store replays days apart so the finder has to walk more than one one-day window, and no
-        # single window holds two of them. Each must still be deleted.
-        old_replay = uuid4().hex
-        self.store_replay_segments(
-            old_replay,
-            self.project.id,
-            datetime.datetime.now() - datetime.timedelta(days=20),
-        )
-        mid_replay = uuid4().hex
-        self.store_replay_segments(
-            mid_replay,
-            self.project.id,
-            datetime.datetime.now() - datetime.timedelta(days=10),
-        )
-        recent_replay = uuid4().hex
-        self.store_replay_segments(
-            recent_replay,
-            self.project.id,
-            datetime.datetime.now() - datetime.timedelta(seconds=10),
-        )
-
-        # One-day windows over a ~30-day range means ~31 windows, each replay in its own.
-        with TaskRunner():
-            delete_replays(
-                project_id=self.project.id,
-                batch_size=self.small_batch_size,
-                environment=[],
-                tags=[],
-                start_utc=datetime.datetime.utcnow() - datetime.timedelta(days=30),
-                end_utc=self.default_end_time,
-                dry_run=False,
-            )
-
-        self.assert_recording_deleted(old_replay)
-        self.assert_recording_deleted(mid_replay)
-        self.assert_recording_deleted(recent_replay)
-
     @patch("sentry.replays.scripts.delete_replays.delete_seer_replay_data")
     def test_deletion_replays_seer_delete_gated(self, mock_delete_seer: object) -> None:
         to_delete = uuid4().hex

--- a/tests/sentry/replays/scripts/test_delete_replays.py
+++ b/tests/sentry/replays/scripts/test_delete_replays.py
@@ -328,8 +328,8 @@ class TestDeleteReplays(ReplaysSnubaTestCase):
         self.assert_recording_not_deleted(replay_id_outside_timerange)
 
     def test_deletion_replays_multiple_time_windows(self) -> None:
-        # Store replays spread across a range wider than the chunk size so the finder has to walk
-        # more than one time window. Each must still be deleted.
+        # Store replays days apart so the finder has to walk more than one one-day window, and no
+        # single window holds two of them. Each must still be deleted.
         old_replay = uuid4().hex
         self.store_replay_segments(
             old_replay,
@@ -349,9 +349,8 @@ class TestDeleteReplays(ReplaysSnubaTestCase):
             datetime.datetime.now() - datetime.timedelta(seconds=10),
         )
 
-        # A 3-day chunk over a ~30-day range forces roughly ten windows, so each replay lands in a
-        # different window from the others.
-        with self.options({"replay.bulk_delete_job.chunk_size_days": 3}), TaskRunner():
+        # One-day windows over a ~30-day range means ~31 windows, each replay in its own.
+        with TaskRunner():
             delete_replays(
                 project_id=self.project.id,
                 batch_size=self.small_batch_size,

--- a/tests/sentry/replays/tasks/test_delete_replays_bulk.py
+++ b/tests/sentry/replays/tasks/test_delete_replays_bulk.py
@@ -15,8 +15,8 @@ from sentry.replays.tasks import run_bulk_replay_delete_job
 from sentry.replays.testutils import mock_replay
 from sentry.replays.usecases.delete import (
     MatchedRows,
+    datetime_as_start_of_day_conditions,
     day_aligned_windows,
-    day_pin_conditions,
     delete_matched_rows,
     fetch_rows_matching_pattern,
 )
@@ -606,75 +606,11 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
             "project_id": self.job.project_id,
         }
 
-    @patch("sentry.replays.tasks.fetch_rows_matching_pattern")
-    @patch("sentry.replays.tasks.delete_matched_rows")
-    def test_run_bulk_replay_delete_job_time_window_chunking(
-        self, mock_delete_matched_rows: MagicMock, mock_fetch_rows: MagicMock
-    ) -> None:
-        """Test a range is chunked into windows aligned to UTC midnight.
-
-        `range_start` is deliberately mid-day: windows are laid out from the start of its day rather
-        than from `range_start`, so every window lands inside a single UTC day and can assert it.
-        The first and last are clamped to the job's range.
-        """
-        range_start = datetime.datetime(2025, 6, 1, 14, 30, tzinfo=datetime.UTC)
-        range_end = datetime.datetime(2025, 6, 4, tzinfo=datetime.UTC)
-        job = ReplayDeletionJobModel.objects.create(
-            organization_id=self.project.organization.id,
-            project_id=self.project.id,
-            range_start=range_start,
-            range_end=range_end,
-            query="",
-            environments=["prod"],
-            status="pending",
-        )
-
-        # Each window returns rows with has_more=False so the task advances to the next window.
-        def row_generator() -> Generator[MatchedRows]:
-            for replay_id in ("a", "b", "c"):
-                yield {
-                    "rows": [{"retention_days": 90, "replay_id": replay_id, "max_segment_id": 1}],
-                    "has_more": False,
-                    "next_cursor": 1234,
-                }
-
-        mock_fetch_rows.side_effect = row_generator()
-
-        with TaskRunner():
-            run_bulk_replay_delete_job.delay(job.id, limit=100)
-
-        job.refresh_from_db()
-        assert job.status == "completed"
-        assert mock_fetch_rows.call_count == 3
-        assert mock_delete_matched_rows.call_count == 3
-        # countDeleted must reflect all three windows (1 replay each).
-        assert job.offset == 3
-        # range_start must never be mutated — the API always returns the original value.
-        assert job.range_start == range_start
-
-        midnight_2 = datetime.datetime(2025, 6, 2, tzinfo=datetime.UTC)
-        midnight_3 = datetime.datetime(2025, 6, 3, tzinfo=datetime.UTC)
-        windows = [
-            (call.kwargs["start"], call.kwargs["end"]) for call in mock_fetch_rows.call_args_list
-        ]
-        assert windows == [
-            # Clamped to range_start rather than starting at midnight.
-            (range_start, midnight_2),
-            (midnight_2, midnight_3),
-            (midnight_3, range_end),
-        ]
-        # Every window resets the cursor, because it is a position within a window's result set.
-        assert [call.kwargs["after_replay_id_hash"] for call in mock_fetch_rows.call_args_list] == [
-            None,
-            None,
-            None,
-        ]
-
     def test_day_aligned_windows_open_and_close_on_the_range(self) -> None:
         """Test a mid-day range is split on UTC days without escaping the range at either end.
 
         Whole days rather than range-start-plus-a-day is what keeps a window inside one UTC day, so
-        `day_pin_conditions` can assert it. The range's own bounds still win: the first window opens
+        `datetime_as_start_of_day_conditions` can assert it. The range's own bounds still win: the first window opens
         at 17:00, not at midnight.
         """
         range_start = datetime.datetime(2026, 7, 23, 17, 0, tzinfo=datetime.UTC)
@@ -724,7 +660,7 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
             for earlier, later in zip(windows, windows[1:]):
                 assert earlier[1] == later[0]
 
-    def test_day_pin_conditions_only_fire_inside_one_day(self) -> None:
+    def test_datetime_as_start_of_day_conditions_only_fire_inside_one_day(self) -> None:
         """Test the day assertion is added only when the window cannot escape a single UTC day.
 
         `timestamp < midnight` degrades to a non-strict bound on `toStartOfDay(timestamp)`, so the
@@ -733,20 +669,20 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
         """
         day = datetime.datetime(2025, 6, 2, tzinfo=datetime.UTC)
 
-        assert day_pin_conditions(day, day + datetime.timedelta(days=1)) == [
+        assert datetime_as_start_of_day_conditions(day, day + datetime.timedelta(days=1)) == [
             Condition(Function("toStartOfDay", parameters=[Column("timestamp")]), Op.EQ, day)
         ]
-        assert day_pin_conditions(
+        assert datetime_as_start_of_day_conditions(
             day + datetime.timedelta(hours=3), day + datetime.timedelta(hours=20)
         )
         # Mid-day to mid-day, and anything wider than a day, span a boundary.
         assert (
-            day_pin_conditions(
+            datetime_as_start_of_day_conditions(
                 day + datetime.timedelta(hours=3), day + datetime.timedelta(days=1, hours=3)
             )
             == []
         )
-        assert day_pin_conditions(day, day + datetime.timedelta(days=2)) == []
+        assert datetime_as_start_of_day_conditions(day, day + datetime.timedelta(days=2)) == []
 
     @patch("sentry.replays.tasks.fetch_rows_matching_pattern")
     @patch("sentry.replays.tasks.delete_matched_rows")

--- a/tests/sentry/replays/tasks/test_delete_replays_bulk.py
+++ b/tests/sentry/replays/tasks/test_delete_replays_bulk.py
@@ -15,7 +15,6 @@ from sentry.replays.tasks import run_bulk_replay_delete_job
 from sentry.replays.testutils import mock_replay
 from sentry.replays.usecases.delete import (
     MatchedRows,
-    day_aligned_window,
     day_aligned_windows,
     day_pin_conditions,
     delete_matched_rows,
@@ -671,13 +670,31 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
             None,
         ]
 
-    def test_day_aligned_windows_never_escape_a_utc_day(self) -> None:
-        """Test windows tile the range without gaps and each stays inside one UTC day.
+    def test_day_aligned_windows_open_and_close_on_the_range(self) -> None:
+        """Test a mid-day range is split on UTC days without escaping the range at either end.
 
-        Laying windows out from the start of the range's day, rather than from the range start, is
-        what lets `day_pin_conditions` assert a day. Both ends are clamped to the range, so the
-        first and last windows can be short.
+        Whole days rather than range-start-plus-a-day is what keeps a window inside one UTC day, so
+        `day_pin_conditions` can assert it. The range's own bounds still win: the first window opens
+        at 17:00, not at midnight.
         """
+        range_start = datetime.datetime(2026, 7, 23, 17, 0, tzinfo=datetime.UTC)
+        range_end = datetime.datetime(2026, 7, 26, 9, 30, tzinfo=datetime.UTC)
+
+        assert day_aligned_windows(range_start, range_end) == [
+            (range_start, datetime.datetime(2026, 7, 24, tzinfo=datetime.UTC)),
+            (
+                datetime.datetime(2026, 7, 24, tzinfo=datetime.UTC),
+                datetime.datetime(2026, 7, 25, tzinfo=datetime.UTC),
+            ),
+            (
+                datetime.datetime(2026, 7, 25, tzinfo=datetime.UTC),
+                datetime.datetime(2026, 7, 26, tzinfo=datetime.UTC),
+            ),
+            (datetime.datetime(2026, 7, 26, tzinfo=datetime.UTC), range_end),
+        ]
+
+    def test_day_aligned_windows_never_escape_a_utc_day(self) -> None:
+        """Test windows tile the range without gaps and each stays inside one UTC day."""
         cases = [
             (
                 datetime.datetime(2026, 7, 23, tzinfo=datetime.UTC),
@@ -697,7 +714,7 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
             ),
         ]
         for range_start, range_end in cases:
-            windows = list(day_aligned_windows(range_start, range_end))
+            windows = day_aligned_windows(range_start, range_end)
 
             assert windows[0][0] == range_start
             assert windows[-1][1] == range_end
@@ -706,16 +723,6 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
                 assert start.date() == (end - datetime.timedelta(microseconds=1)).date()
             for earlier, later in zip(windows, windows[1:]):
                 assert earlier[1] == later[0]
-
-    def test_day_aligned_window_returns_none_past_the_end(self) -> None:
-        """Test the accessor the task uses agrees with the iterator and terminates."""
-        range_start = datetime.datetime(2026, 7, 23, 14, 30, tzinfo=datetime.UTC)
-        range_end = datetime.datetime(2026, 7, 26, tzinfo=datetime.UTC)
-
-        assert [day_aligned_window(range_start, range_end, offset) for offset in range(3)] == (
-            list(day_aligned_windows(range_start, range_end))
-        )
-        assert day_aligned_window(range_start, range_end, 3) is None
 
     def test_day_pin_conditions_only_fire_inside_one_day(self) -> None:
         """Test the day assertion is added only when the window cannot escape a single UTC day.

--- a/tests/sentry/replays/tasks/test_delete_replays_bulk.py
+++ b/tests/sentry/replays/tasks/test_delete_replays_bulk.py
@@ -15,6 +15,8 @@ from sentry.replays.tasks import run_bulk_replay_delete_job
 from sentry.replays.testutils import mock_replay
 from sentry.replays.usecases.delete import (
     MatchedRows,
+    day_aligned_window,
+    day_aligned_windows,
     day_pin_conditions,
     delete_matched_rows,
     fetch_rows_matching_pattern,
@@ -668,6 +670,52 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
             None,
             None,
         ]
+
+    def test_day_aligned_windows_never_escape_a_utc_day(self) -> None:
+        """Test windows tile the range without gaps and each stays inside one UTC day.
+
+        Laying windows out from the start of the range's day, rather than from the range start, is
+        what lets `day_pin_conditions` assert a day. Both ends are clamped to the range, so the
+        first and last windows can be short.
+        """
+        cases = [
+            (
+                datetime.datetime(2026, 7, 23, tzinfo=datetime.UTC),
+                datetime.datetime(2026, 7, 26, tzinfo=datetime.UTC),
+            ),
+            (
+                datetime.datetime(2026, 7, 23, 14, 30, tzinfo=datetime.UTC),
+                datetime.datetime(2026, 7, 26, tzinfo=datetime.UTC),
+            ),
+            (
+                datetime.datetime(2026, 7, 23, 14, 30, tzinfo=datetime.UTC),
+                datetime.datetime(2026, 7, 25, 9, 15, tzinfo=datetime.UTC),
+            ),
+            (
+                datetime.datetime(2026, 7, 23, 3, tzinfo=datetime.UTC),
+                datetime.datetime(2026, 7, 23, 6, tzinfo=datetime.UTC),
+            ),
+        ]
+        for range_start, range_end in cases:
+            windows = list(day_aligned_windows(range_start, range_end, 1))
+
+            assert windows[0][0] == range_start
+            assert windows[-1][1] == range_end
+            for start, end in windows:
+                assert start < end
+                assert start.date() == (end - datetime.timedelta(microseconds=1)).date()
+            for earlier, later in zip(windows, windows[1:]):
+                assert earlier[1] == later[0]
+
+    def test_day_aligned_window_returns_none_past_the_end(self) -> None:
+        """Test the accessor the task uses agrees with the iterator and terminates."""
+        range_start = datetime.datetime(2026, 7, 23, 14, 30, tzinfo=datetime.UTC)
+        range_end = datetime.datetime(2026, 7, 26, tzinfo=datetime.UTC)
+
+        assert [day_aligned_window(range_start, range_end, offset, 1) for offset in range(3)] == (
+            list(day_aligned_windows(range_start, range_end, 1))
+        )
+        assert day_aligned_window(range_start, range_end, 3, 1) is None
 
     def test_day_pin_conditions_only_fire_inside_one_day(self) -> None:
         """Test the day assertion is added only when the window cannot escape a single UTC day.

--- a/tests/sentry/replays/tasks/test_delete_replays_bulk.py
+++ b/tests/sentry/replays/tasks/test_delete_replays_bulk.py
@@ -6,6 +6,7 @@ from collections.abc import Generator
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+from snuba_sdk import Column, Condition, Function, Op
 from taskbroker_client.worker.workerchild import ProcessingDeadlineExceeded
 
 from sentry.replays.lib.storage import RecordingSegmentStorageMeta, StorageBlob
@@ -14,6 +15,7 @@ from sentry.replays.tasks import run_bulk_replay_delete_job
 from sentry.replays.testutils import mock_replay
 from sentry.replays.usecases.delete import (
     MatchedRows,
+    day_pin_conditions,
     delete_matched_rows,
     fetch_rows_matching_pattern,
 )
@@ -608,10 +610,14 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
     def test_run_bulk_replay_delete_job_time_window_chunking(
         self, mock_delete_matched_rows: MagicMock, mock_fetch_rows: MagicMock
     ) -> None:
-        """Test that wide date ranges are chunked into 7-day windows."""
-        # Create a job spanning 20 days so it requires 3 windows (7 + 7 + 6).
-        range_start = datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(days=20)
-        range_end = datetime.datetime.now(tz=datetime.UTC)
+        """Test a range is chunked into windows aligned to UTC midnight.
+
+        `range_start` is deliberately mid-day: windows are laid out from the start of its day rather
+        than from `range_start`, so every window lands inside a single UTC day and can assert it.
+        The first and last are clamped to the job's range.
+        """
+        range_start = datetime.datetime(2025, 6, 1, 14, 30, tzinfo=datetime.UTC)
+        range_end = datetime.datetime(2025, 6, 4, tzinfo=datetime.UTC)
         job = ReplayDeletionJobModel.objects.create(
             organization_id=self.project.organization.id,
             project_id=self.project.id,
@@ -624,24 +630,12 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
 
         # Each window returns rows with has_more=False so the task advances to the next window.
         def row_generator() -> Generator[MatchedRows]:
-            # Window 1: range_start to range_start + 7 days
-            yield {
-                "rows": [{"retention_days": 90, "replay_id": "a", "max_segment_id": 1}],
-                "has_more": False,
-                "next_cursor": 1234,
-            }
-            # Window 2: range_start + 7 days to range_start + 14 days
-            yield {
-                "rows": [{"retention_days": 90, "replay_id": "b", "max_segment_id": 1}],
-                "has_more": False,
-                "next_cursor": 1234,
-            }
-            # Window 3: range_start + 14 days to range_end
-            yield {
-                "rows": [{"retention_days": 90, "replay_id": "c", "max_segment_id": 1}],
-                "has_more": False,
-                "next_cursor": 1234,
-            }
+            for replay_id in ("a", "b", "c"):
+                yield {
+                    "rows": [{"retention_days": 90, "replay_id": replay_id, "max_segment_id": 1}],
+                    "has_more": False,
+                    "next_cursor": 1234,
+                }
 
         mock_fetch_rows.side_effect = row_generator()
 
@@ -657,20 +651,47 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
         # range_start must never be mutated — the API always returns the original value.
         assert job.range_start == range_start
 
-        # Verify each call used the correct window boundaries.
-        calls = mock_fetch_rows.call_args_list
-        # Window 1
-        assert calls[0].kwargs["start"] == range_start
-        assert calls[0].kwargs["end"] == range_start + datetime.timedelta(days=7)
-        assert calls[0].kwargs["after_replay_id_hash"] is None
-        # Window 2
-        assert calls[1].kwargs["start"] == range_start + datetime.timedelta(days=7)
-        assert calls[1].kwargs["end"] == range_start + datetime.timedelta(days=14)
-        assert calls[1].kwargs["after_replay_id_hash"] is None
-        # Window 3
-        assert calls[2].kwargs["start"] == range_start + datetime.timedelta(days=14)
-        assert calls[2].kwargs["end"] == range_end
-        assert calls[2].kwargs["after_replay_id_hash"] is None
+        midnight_2 = datetime.datetime(2025, 6, 2, tzinfo=datetime.UTC)
+        midnight_3 = datetime.datetime(2025, 6, 3, tzinfo=datetime.UTC)
+        windows = [
+            (call.kwargs["start"], call.kwargs["end"]) for call in mock_fetch_rows.call_args_list
+        ]
+        assert windows == [
+            # Clamped to range_start rather than starting at midnight.
+            (range_start, midnight_2),
+            (midnight_2, midnight_3),
+            (midnight_3, range_end),
+        ]
+        # Every window resets the cursor, because it is a position within a window's result set.
+        assert [call.kwargs["after_replay_id_hash"] for call in mock_fetch_rows.call_args_list] == [
+            None,
+            None,
+            None,
+        ]
+
+    def test_day_pin_conditions_only_fire_inside_one_day(self) -> None:
+        """Test the day assertion is added only when the window cannot escape a single UTC day.
+
+        `timestamp < midnight` degrades to a non-strict bound on `toStartOfDay(timestamp)`, so the
+        index also selects the following day. Asserting the day collapses that, but asserting it for
+        a window that spans a boundary would drop rows.
+        """
+        day = datetime.datetime(2025, 6, 2, tzinfo=datetime.UTC)
+
+        assert day_pin_conditions(day, day + datetime.timedelta(days=1)) == [
+            Condition(Function("toStartOfDay", parameters=[Column("timestamp")]), Op.EQ, day)
+        ]
+        assert day_pin_conditions(
+            day + datetime.timedelta(hours=3), day + datetime.timedelta(hours=20)
+        )
+        # Mid-day to mid-day, and anything wider than a day, span a boundary.
+        assert (
+            day_pin_conditions(
+                day + datetime.timedelta(hours=3), day + datetime.timedelta(days=1, hours=3)
+            )
+            == []
+        )
+        assert day_pin_conditions(day, day + datetime.timedelta(days=2)) == []
 
     @patch("sentry.replays.tasks.fetch_rows_matching_pattern")
     @patch("sentry.replays.tasks.delete_matched_rows")
@@ -678,8 +699,8 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
         self, mock_delete_matched_rows: MagicMock, mock_fetch_rows: MagicMock
     ) -> None:
         """Test pagination within a time window followed by advancing to the next window."""
-        range_start = datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(days=10)
-        range_end = datetime.datetime.now(tz=datetime.UTC)
+        range_start = datetime.datetime(2025, 6, 1, tzinfo=datetime.UTC)
+        range_end = datetime.datetime(2025, 6, 3, tzinfo=datetime.UTC)
         job = ReplayDeletionJobModel.objects.create(
             organization_id=self.project.organization.id,
             project_id=self.project.id,
@@ -724,16 +745,17 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
         assert job.range_start == range_start
 
         calls = mock_fetch_rows.call_args_list
+        midnight_2 = datetime.datetime(2025, 6, 2, tzinfo=datetime.UTC)
         # Window 1, page 1 — no cursor yet
         assert calls[0].kwargs["start"] == range_start
-        assert calls[0].kwargs["end"] == range_start + datetime.timedelta(days=7)
+        assert calls[0].kwargs["end"] == midnight_2
         assert calls[0].kwargs["after_replay_id_hash"] is None
         # Window 1, page 2 — seeks from the cursor page 1 returned
         assert calls[1].kwargs["start"] == range_start
-        assert calls[1].kwargs["end"] == range_start + datetime.timedelta(days=7)
+        assert calls[1].kwargs["end"] == midnight_2
         assert calls[1].kwargs["after_replay_id_hash"] == 1234
         # Window 2 — cursor reset, because it is a position within a window's result set
-        assert calls[2].kwargs["start"] == range_start + datetime.timedelta(days=7)
+        assert calls[2].kwargs["start"] == midnight_2
         assert calls[2].kwargs["end"] == range_end
         assert calls[2].kwargs["after_replay_id_hash"] is None
 

--- a/tests/sentry/replays/tasks/test_delete_replays_bulk.py
+++ b/tests/sentry/replays/tasks/test_delete_replays_bulk.py
@@ -660,29 +660,36 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
             for earlier, later in zip(windows, windows[1:]):
                 assert earlier[1] == later[0]
 
-    def test_datetime_as_start_of_day_conditions_only_fire_inside_one_day(self) -> None:
-        """Test the day assertion is added only when the window cannot escape a single UTC day.
-
-        `timestamp < midnight` degrades to a non-strict bound on `toStartOfDay(timestamp)`, so the
-        index also selects the following day. Asserting the day collapses that, but asserting it for
-        a window that spans a boundary would drop rows.
-        """
+    def test_datetime_as_start_of_day_conditions_bound_the_days_a_range_touches(self) -> None:
+        """Test a range is restated as its first and last UTC day, whatever its width."""
         day = datetime.datetime(2025, 6, 2, tzinfo=datetime.UTC)
+        next_day = day + datetime.timedelta(days=1)
+        start_of_day = Function("toStartOfDay", parameters=[Column("timestamp")])
 
-        assert datetime_as_start_of_day_conditions(day, day + datetime.timedelta(days=1)) == [
-            Condition(Function("toStartOfDay", parameters=[Column("timestamp")]), Op.EQ, day)
+        # A whole day bounds that day from both sides, which the index reads as an equality.
+        assert datetime_as_start_of_day_conditions(day, next_day) == [
+            Condition(start_of_day, Op.GTE, day),
+            Condition(start_of_day, Op.LTE, day),
         ]
+        # So does any range inside it.
         assert datetime_as_start_of_day_conditions(
             day + datetime.timedelta(hours=3), day + datetime.timedelta(hours=20)
-        )
-        # Mid-day to mid-day, and anything wider than a day, span a boundary.
-        assert (
-            datetime_as_start_of_day_conditions(
-                day + datetime.timedelta(hours=3), day + datetime.timedelta(days=1, hours=3)
-            )
-            == []
-        )
-        assert datetime_as_start_of_day_conditions(day, day + datetime.timedelta(days=2)) == []
+        ) == [
+            Condition(start_of_day, Op.GTE, day),
+            Condition(start_of_day, Op.LTE, day),
+        ]
+        # A range crossing midnight bounds both days rather than giving up on the sort key.
+        assert datetime_as_start_of_day_conditions(
+            day + datetime.timedelta(hours=3), next_day + datetime.timedelta(hours=3)
+        ) == [
+            Condition(start_of_day, Op.GTE, day),
+            Condition(start_of_day, Op.LTE, next_day),
+        ]
+        # `end` is exclusive, so ending exactly at midnight must not reach that day.
+        assert datetime_as_start_of_day_conditions(day, day + datetime.timedelta(days=2)) == [
+            Condition(start_of_day, Op.GTE, day),
+            Condition(start_of_day, Op.LTE, next_day),
+        ]
 
     @patch("sentry.replays.tasks.fetch_rows_matching_pattern")
     @patch("sentry.replays.tasks.delete_matched_rows")

--- a/tests/sentry/replays/tasks/test_delete_replays_bulk.py
+++ b/tests/sentry/replays/tasks/test_delete_replays_bulk.py
@@ -28,8 +28,13 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.project = self.create_project(name="test_project")
-        self.range_start = datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(days=1)
-        self.range_end = datetime.datetime.now(tz=datetime.UTC)
+        # Exactly one UTC day, so the job is a single window. These tests are about status
+        # transitions, checkpointing and Seer rather than windowing, and a range crossing midnight
+        # would make each of them chain an extra activation.
+        self.range_start = datetime.datetime.now(tz=datetime.UTC).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
+        self.range_end = self.range_start + datetime.timedelta(days=1)
         self.query = ""
         self.environments = ["prod"]
 
@@ -211,7 +216,9 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
     def test_run_bulk_replay_delete_job_chained_runs(self) -> None:
         project = self.create_project()
 
-        t1 = datetime.datetime.now() - datetime.timedelta(seconds=10)
+        # Inside the job's window rather than relative to now, which lands in the previous UTC day
+        # when the suite runs just after midnight.
+        t1 = self.range_start + datetime.timedelta(seconds=10)
         replay_id1 = uuid.uuid4().hex
         replay_id2 = uuid.uuid4().hex
         replay_id3 = uuid.uuid4().hex

--- a/tests/sentry/replays/tasks/test_delete_replays_bulk.py
+++ b/tests/sentry/replays/tasks/test_delete_replays_bulk.py
@@ -697,7 +697,7 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
             ),
         ]
         for range_start, range_end in cases:
-            windows = list(day_aligned_windows(range_start, range_end, 1))
+            windows = list(day_aligned_windows(range_start, range_end))
 
             assert windows[0][0] == range_start
             assert windows[-1][1] == range_end
@@ -712,10 +712,10 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
         range_start = datetime.datetime(2026, 7, 23, 14, 30, tzinfo=datetime.UTC)
         range_end = datetime.datetime(2026, 7, 26, tzinfo=datetime.UTC)
 
-        assert [day_aligned_window(range_start, range_end, offset, 1) for offset in range(3)] == (
-            list(day_aligned_windows(range_start, range_end, 1))
+        assert [day_aligned_window(range_start, range_end, offset) for offset in range(3)] == (
+            list(day_aligned_windows(range_start, range_end))
         )
-        assert day_aligned_window(range_start, range_end, 3, 1) is None
+        assert day_aligned_window(range_start, range_end, 3) is None
 
     def test_day_pin_conditions_only_fire_inside_one_day(self) -> None:
         """Test the day assertion is added only when the window cannot escape a single UTC day.


### PR DESCRIPTION
Replay bulk deletes work as follows:

- accept a date range for deletion (could be an hour, could be many days)
- window the date range into 7 day windows
- for each range, fetch chunks of rows from that range, and process them

The idea is, the smaller the date range we're paging through, the faster the pages, but the _specifics_ are super important as it turns out. We were using sort of naive chunking, which is actually not that helpful.

The approach in this PR is a bit more sophisticated, it _should_ help us a lot. Here's the gist:

1. Accept a date range for deletion
2. Chunk this date range by UTC date boundary
3. For each "window", fetch chunks of rows as before

Imagine someone requests a 7 day range from 2pm to 2pm. The windows are

- 2pm to UTC midnight
- UTC midnight to UTC midnight
- ... several more UTC windows
- UTC midnight to 2pm

As opposed to the current approach of making windows from 2pm to 2pm.

This is important for two reasons. The important context is that the sort key for `replays` has four items:

- `project_id`
- `toStartOfDay(timestamp)`
- `cityHash64(replay_id)`
- `event_hash`

Most effective use of the sort key is what makes or breaks query performance because ClickHouse can use that sort key to _discard entire granules_ and not have to scan them at all.

The idea of this PR is twofold, making use of the `toStartOfDay(timestamp)` sort key.

1. Add a `toStartOfDay(timestamp)` clause so ClickHouse can directly make sure of that sort key to discard irrelevant granules (similar to how I added `cityHash64(replay_id)` to the filter in a recent PR)
2. _Force_ the `toStartOfDay(timestamp)` condition to only scan one day at a time

So, `toStartOfDay(timestamp)` creates entires like `2026-07-12`, `2026-07-13`, etc. in the index. If a window is from 2pm to 2pm of the 12th to the 13th that means it needs to look at granules for _both dates_ which is inefficient. If we _pin_ each window, with a condition that looks like `toStartOfDate(timestamp) <= '2026-07-12'` ClickHouse can efficiently discard any granules that are on any other day without having to scan them. Since the _offsetting_ is making use of `cityHash64(replay_id)` it should mean that we scan very efficiently.

My suggestion is that scanning in _day_ chunks is actually probably more efficient than smaller buckets because it makes better use of ClickHouse sort keys, so we don't want to have an _option_ for chunking, or chunk in any chunk other than day. This seemed to work a treat in local testing, so I have high hopes.

The jobs now create these windows, and iterate though the as necessary (in a loop, or spawning subsequent jobs that proceed through the windows)

Closes REPLAY-964
