### PR TITLE
fix(workflow_engine): attribute test-fired actions in the group action log

### DIFF
--- a/src/sentry/api/endpoints/project_rule_actions.py
+++ b/src/sentry/api/endpoints/project_rule_actions.py
@@ -12,6 +12,11 @@ from sentry.api.bases import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.api.helpers.deprecation import deprecated
 from sentry.api.serializers.rest_framework import DummyRuleSerializer
 from sentry.constants import ALERTS_API_DEPRECATION_DATE, ALERTS_API_DEPRECATION_KEY
+from sentry.issues.action_log import (
+    action_context_scope,
+    resolve_action_actor,
+    resolve_action_source,
+)
 from sentry.models.rule import Rule
 from sentry.notifications.types import TEST_NOTIFICATION_ID
 from sentry.plugins import HIDDEN_PLUGINS
@@ -98,7 +103,10 @@ class ProjectRuleActionsEndpoint(ProjectEndpoint):
             group=test_event.group,
         )
 
-        return self.execute_future_on_test_event_workflow_engine(group_event, rule)
+        with action_context_scope(
+            source=resolve_action_source(request), actor=resolve_action_actor(request)
+        ):
+            return self.execute_future_on_test_event_workflow_engine(group_event, rule)
 
     def execute_future_on_test_event_workflow_engine(
         self,

--- a/src/sentry/workflow_engine/endpoints/organization_test_fire_action.py
+++ b/src/sentry/workflow_engine/endpoints/organization_test_fire_action.py
@@ -15,6 +15,11 @@ from sentry.api.serializers.rest_framework import CamelSnakeSerializer
 from sentry.apidocs.constants import RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
 from sentry.apidocs.parameters import GlobalParams
 from sentry.constants import ObjectStatus
+from sentry.issues.action_log import (
+    action_context_scope,
+    resolve_action_actor,
+    resolve_action_source,
+)
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.notifications.notification_action.grouptype import get_test_notification_event_data
@@ -116,7 +121,10 @@ class OrganizationTestFireActionsEndpoint(OrganizationEndpoint):
                 status=HTTP_400_BAD_REQUEST,
             )
 
-        status, response_data = test_fire_actions(data.get("actions", []), project)
+        with action_context_scope(
+            source=resolve_action_source(request), actor=resolve_action_actor(request)
+        ):
+            status, response_data = test_fire_actions(data.get("actions", []), project)
 
         return Response(status=status, data=response_data)
 

--- a/src/sentry/workflow_engine/endpoints/utils/test_fire_action.py
+++ b/src/sentry/workflow_engine/endpoints/utils/test_fire_action.py
@@ -3,6 +3,7 @@ import uuid
 
 import sentry_sdk
 
+from sentry.issues.action_log import ActionSource, action_context_scope
 from sentry.shared_integrations.exceptions import IntegrationFormError
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.types import WorkflowEventData, WorkflowId
@@ -18,11 +19,12 @@ def test_fire_action(
     """
     action_exceptions = []
     try:
-        action.trigger(
-            event_data=event_data,
-            notification_uuid=str(uuid.uuid4()),
-            workflow_id=workflow_id,
-        )
+        with action_context_scope(ActionSource.SYSTEM):
+            action.trigger(
+                event_data=event_data,
+                notification_uuid=str(uuid.uuid4()),
+                workflow_id=workflow_id,
+            )
     except Exception as exc:
         if isinstance(exc, IntegrationFormError):
             logger.warning("%s.test_alert.integration_error", action.type, extra={"exc": exc})

--- a/tests/sentry/workflow_engine/endpoints/test_organization_test_fire_action.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_test_fire_action.py
@@ -6,6 +6,8 @@ from sentry.integrations.jira.integration import JiraIntegration
 from sentry.integrations.pagerduty.client import PagerDutyClient
 from sentry.integrations.pagerduty.utils import PagerDutyServiceDict, add_service
 from sentry.integrations.slack.utils.channel import SlackChannelIdData
+from sentry.issues.action_log import ActionSource, GroupActionActor
+from sentry.issues.action_log.types import CreateIssueAction
 from sentry.models.project import Project
 from sentry.notifications.notification_action.group_type_notification_registry import (
     IssueAlertRegistryHandler,
@@ -16,6 +18,7 @@ from sentry.notifications.notification_action.issue_alert_registry import (
 from sentry.shared_integrations.exceptions import IntegrationFormError
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.action_log import capture_action_log
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
 from sentry.workflow_engine.models import Action
@@ -187,6 +190,36 @@ class TestFireActionsEndpointTest(APITestCase, BaseWorkflowTest):
         assert response.status_code == 400
         assert mock_create_issue.call_count == 1
         assert response.data == {"actions": ["An unexpected error occurred. Error ID: 'abc-1234'"]}
+
+    @mock.patch.object(JiraIntegration, "create_issue")
+    def test_ticket_creation_attributes_to_request_user(
+        self, mock_create_issue: mock.MagicMock
+    ) -> None:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            jira_integration = self.create_provider_integration(
+                provider="jira", name="Jira", external_id="jira:1"
+            )
+            jira_integration.add_organization(self.organization, self.user)
+
+        mock_create_issue.return_value = {"key": "APP-123", "url": "https://example.com/APP-123"}
+
+        action_data = [
+            {
+                "type": Action.Type.JIRA.value,
+                "integration_id": jira_integration.id,
+                "data": {},
+                "config": {"target_type": "specific"},
+            }
+        ]
+
+        with capture_action_log() as log:
+            self.get_success_response(self.organization.slug, actions=action_data)
+
+        log.assert_logged(
+            CreateIssueAction,
+            source=ActionSource.WEB,
+            actor=GroupActionActor.user(self.user.id),
+        )
 
     def test_no_projects_available(self) -> None:
         """Test behavior when no projects are available for the organization"""

--- a/tests/sentry/workflow_engine/endpoints/test_organization_test_fire_action.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_test_fire_action.py
@@ -6,6 +6,8 @@ from sentry.integrations.jira.integration import JiraIntegration
 from sentry.integrations.pagerduty.client import PagerDutyClient
 from sentry.integrations.pagerduty.utils import PagerDutyServiceDict, add_service
 from sentry.integrations.slack.utils.channel import SlackChannelIdData
+from sentry.issues.action_log import SYSTEM_ACTOR, ActionSource
+from sentry.issues.action_log.types import CreateIssueAction
 from sentry.models.project import Project
 from sentry.notifications.notification_action.group_type_notification_registry import (
     IssueAlertRegistryHandler,
@@ -16,6 +18,7 @@ from sentry.notifications.notification_action.issue_alert_registry import (
 from sentry.shared_integrations.exceptions import IntegrationFormError
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.action_log import capture_action_log
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
 from sentry.workflow_engine.models import Action
@@ -187,6 +190,30 @@ class TestFireActionsEndpointTest(APITestCase, BaseWorkflowTest):
         assert response.status_code == 400
         assert mock_create_issue.call_count == 1
         assert response.data == {"actions": ["An unexpected error occurred. Error ID: 'abc-1234'"]}
+
+    @mock.patch.object(JiraIntegration, "create_issue")
+    def test_ticket_creation_attributes_to_system(self, mock_create_issue: mock.MagicMock) -> None:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            jira_integration = self.create_provider_integration(
+                provider="jira", name="Jira", external_id="jira:1"
+            )
+            jira_integration.add_organization(self.organization, self.user)
+
+        mock_create_issue.return_value = {"key": "APP-123", "url": "https://example.com/APP-123"}
+
+        action_data = [
+            {
+                "type": Action.Type.JIRA.value,
+                "integration_id": jira_integration.id,
+                "data": {},
+                "config": {"target_type": "specific"},
+            }
+        ]
+
+        with capture_action_log() as log:
+            self.get_success_response(self.organization.slug, actions=action_data)
+
+        log.assert_logged(CreateIssueAction, source=ActionSource.SYSTEM, actor=SYSTEM_ACTOR)
 
     def test_no_projects_available(self) -> None:
         """Test behavior when no projects are available for the organization"""


### PR DESCRIPTION
Very small edge case where triggering a new test event creates a new issue, but isn't correctly attributed to the source/actor.

Fixes SENTRY-5RK2
