### PR TITLE
fix(scm): stop capturing ResourceForbidden/RateLimitExceeded as Sentry errors in SCM RPC

### DIFF
--- a/src/sentry/scm/private/helpers.py
+++ b/src/sentry/scm/private/helpers.py
@@ -1,8 +1,10 @@
+import logging
 import time
 from typing import cast
 
 import sentry_sdk
 from django.db.models import Q
+from scm.errors import RateLimitExceeded, ResourceForbidden, SCMCodedError
 from scm.providers.github.provider import GitHubProvider
 from scm.providers.gitlab.provider import GitLabProvider
 from scm.rate_limit import RateLimitProvider
@@ -16,6 +18,18 @@ from sentry.models.repository import Repository as RepositoryModel
 from sentry.scm.private.rate_limit import DynamicRateLimiter, RedisRateLimitProvider
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.utils import metrics
+
+logger = logging.getLogger(__name__)
+
+# SCMCodedError subclasses that represent expected external conditions (ACL
+# restrictions, rate limits, etc.) rather than application defects. These are
+# surfaced as warnings in the application log instead of being captured as
+# Sentry error events, which would pollute the error stream and obscure real
+# defects.
+_EXPECTED_EXTERNAL_CONDITION_TYPES = (
+    ResourceForbidden,
+    RateLimitExceeded,
+)
 
 
 def fetch_service_provider(
@@ -106,7 +120,28 @@ def fetch_repository(organization_id: int, repository_id: RepositoryId) -> Repos
 
 
 def report_error_to_sentry(e: Exception) -> None:
-    """Typing wrapper around sentry_sdk.capture_exception."""
+    """Capture an SCM RPC exception as a Sentry error event, or log it as a
+    warning when it represents an expected external condition.
+
+    IP allowlists, ACL restrictions (ResourceForbidden), and rate limits
+    (RateLimitExceeded) are set by the upstream service-provider or the
+    customer organization and are not application defects. Capturing them as
+    Sentry errors would pollute the error stream and make real defects harder
+    to find. They are logged at WARNING instead so they remain observable
+    without creating noise.
+
+    All other exceptions — including SCMCodedError subclasses for unexpected
+    responses and unhandled provider exceptions — are captured normally.
+    """
+    if isinstance(e, _EXPECTED_EXTERNAL_CONDITION_TYPES):
+        logger.warning(
+            "scm.rpc.expected_external_condition",
+            extra={
+                "error_code": e.code if isinstance(e, SCMCodedError) else None,
+                "detail": e.detail if isinstance(e, SCMCodedError) else str(e),
+            },
+        )
+        return
     sentry_sdk.capture_exception(e)
 
 

--- a/tests/sentry/scm/integration/test_helpers_integration.py
+++ b/tests/sentry/scm/integration/test_helpers_integration.py
@@ -1,9 +1,16 @@
+from unittest import mock
+
+from scm.errors import RateLimitExceeded, ResourceForbidden, UnhandledException
 from scm.providers.github.provider import GitHubProvider
 from scm.types import Repository
 
 from sentry.constants import ObjectStatus
 from sentry.models.repository import Repository as RepositoryModel
-from sentry.scm.private.helpers import fetch_repository, fetch_service_provider
+from sentry.scm.private.helpers import (
+    fetch_repository,
+    fetch_service_provider,
+    report_error_to_sentry,
+)
 from sentry.testutils.cases import TestCase
 
 
@@ -261,3 +268,62 @@ class TestFetchServiceProvider(TestCase):
             ),
         ):
             assert fetch_service_provider(self.organization.id, repository) is None
+
+
+class TestReportErrorToSentry(TestCase):
+    """report_error_to_sentry must not capture expected external conditions
+    (ACL blocks, rate limits) as Sentry error events.  Only true defects
+    should be forwarded to sentry_sdk.capture_exception."""
+
+    def test_resource_forbidden_is_not_captured(self) -> None:
+        """IP-allowlist and other ACL blocks must produce a warning log, not a
+        Sentry capture, so they do not pollute the error stream."""
+        exc = ResourceForbidden(
+            detail="the `stanbridge` organization has an IP allow list enabled"
+        )
+        with (
+            mock.patch("sentry_sdk.capture_exception") as mock_capture,
+            mock.patch("sentry.scm.private.helpers.logger") as mock_logger,
+        ):
+            report_error_to_sentry(exc)
+
+        mock_capture.assert_not_called()
+        mock_logger.warning.assert_called_once()
+
+    def test_rate_limit_exceeded_is_not_captured(self) -> None:
+        """Rate-limit errors are an expected external condition and must not
+        be forwarded to Sentry."""
+        exc = RateLimitExceeded()
+        with (
+            mock.patch("sentry_sdk.capture_exception") as mock_capture,
+            mock.patch("sentry.scm.private.helpers.logger") as mock_logger,
+        ):
+            report_error_to_sentry(exc)
+
+        mock_capture.assert_not_called()
+        mock_logger.warning.assert_called_once()
+
+    def test_unhandled_exception_is_captured(self) -> None:
+        """Errors that are true defects (UnhandledException) must still be
+        forwarded to Sentry for alerting."""
+        exc = UnhandledException()
+        with (
+            mock.patch("sentry_sdk.capture_exception") as mock_capture,
+            mock.patch("sentry.scm.private.helpers.logger") as mock_logger,
+        ):
+            report_error_to_sentry(exc)
+
+        mock_capture.assert_called_once_with(exc)
+        mock_logger.warning.assert_not_called()
+
+    def test_generic_exception_is_captured(self) -> None:
+        """Non-SCMCodedError exceptions must be forwarded to Sentry."""
+        exc = ValueError("something unexpected")
+        with (
+            mock.patch("sentry_sdk.capture_exception") as mock_capture,
+            mock.patch("sentry.scm.private.helpers.logger") as mock_logger,
+        ):
+            report_error_to_sentry(exc)
+
+        mock_capture.assert_called_once_with(exc)
+        mock_logger.warning.assert_not_called()


### PR DESCRIPTION
## Summary

Fixes Sentry issue [7525080812](https://sentry.io/organizations/sentry/issues/7525080812/) — `ResourceForbidden` spam from IP-allowlist blocks.

Dispatched from a triage session: https://claude.ai/code/session_01XWeQLx3MT9f2HwyNsugXMi

## Root-cause analysis

### What was happening

When a GitHub organization has an IP allowlist enabled, GitHub returns HTTP 403 with:

```
{"message":"Although you appear to have the correct authorization credentials, the `<org>` organization has an IP allow list enabled, and your IP address is not permitted to access this resource."}
```

The provider layer in `scm-platform` raises `ResourceForbidden` (a `SCMCodedError` subclass) for any 403 from the upstream service provider. The SCM-RPC server's `post()` handler catches all `SCMCodedError` and calls `self.emit_error(e)` unconditionally. In Sentry's wiring (`make_server()` in `scm_rpc.py`), `emit_error` is `report_error_to_sentry`, which was a thin wrapper around `sentry_sdk.capture_exception(e)`.

Result: every IP-allowlist block generates a full Sentry error event, polluting the error stream and masking real defects.

### What was ruled out

- **Patching `scm-platform`'s `post()` handler** — the handler already has a comment saying the errors "should almost always be a true defect," and the right fix is for the Sentry-side callback to be smarter, not to suppress all `SCMCodedError` forwarding from the server. The `get()` handler is already smarter (only calls `emit_error` for `unhandled_exception`).
- **Suppressing all `ResourceForbidden` globally** — this would hide real permission misconfigurations. The fix is scoped to not capturing as a Sentry event, while still logging.
- **Parsing the detail message for IP-allowlist keywords** — fragile and provider-specific. The error *code* (`resource_forbidden`) is the stable signal; the mechanism (IP allowlist vs. missing OAuth scope vs. org SSO requirement) is secondary. All `ResourceForbidden` represent an external party saying "you're not allowed here," not an application defect.

### Why this fix

`ResourceForbidden` (HTTP 403 ACL blocks) and `RateLimitExceeded` (HTTP 429) are expected external conditions:
- They are set by the customer organization or the service provider, not by a bug in Sentry.
- They are already counted by the `sentry.scm.rpc.request.post.failed` metric (recorded by the RPC server before `emit_error` is called) and now emitted as `WARNING` log entries for observability.
- Capturing them as Sentry errors generates noise that makes real defects (unhandled exceptions, unexpected response formats) harder to find.

The fix introduces `_EXPECTED_EXTERNAL_CONDITION_TYPES` in `report_error_to_sentry` — a narrowly scoped tuple of `SCMCodedError` subclasses for expected external conditions — and short-circuits to a `logger.warning` for those types. All other exceptions continue to be captured normally.

## Changes

- `src/sentry/scm/private/helpers.py`: `report_error_to_sentry` now logs a warning instead of capturing for `ResourceForbidden` and `RateLimitExceeded`.
- `tests/sentry/scm/integration/test_helpers_integration.py`: Four new test cases verifying the capture/no-capture behavior per error type.

<!-- Sentry employees and contractors can delete or ignore the following. -->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWeQLx3MT9f2HwyNsugXMi)_