### PR TITLE
feat(action_log): Add action_log_buffer to automatically batch Action publishes

### DIFF
--- a/src/sentry/issues/action_log/__init__.py
+++ b/src/sentry/issues/action_log/__init__.py
@@ -4,7 +4,9 @@ from sentry.issues.action_log.base import (
 )
 from sentry.issues.action_log.publish import (
     ActionContext,
+    ActionLogBufferError,
     action_context_scope,
+    action_log_buffer,
     get_action_context,
     publish_action,
     publish_action_from_context,
@@ -19,11 +21,13 @@ from sentry.issues.action_log.types import (
 
 __all__ = [
     "ActionContext",
+    "ActionLogBufferError",
     "ActionSource",
     "GroupActionActor",
     "GroupActorType",
     "SYSTEM_ACTOR",
     "action_context_scope",
+    "action_log_buffer",
     "get_action_context",
     "publish_action",
     "publish_action_from_context",

--- a/src/sentry/issues/action_log/publish.py
+++ b/src/sentry/issues/action_log/publish.py
@@ -6,14 +6,13 @@ action_log.types — safe to import from models and other dependency-sensitive c
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable, Generator
+from collections.abc import Callable, Generator, Sequence
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
 from datetime import datetime
-from typing import TYPE_CHECKING, Optional, Sequence
+from typing import TYPE_CHECKING
 
-from sentry.hybridcloud.models.outbox import outbox_context
 from sentry.issues.action_log.types import (
     SYSTEM_ACTOR,
     ActionSource,
@@ -53,7 +52,33 @@ class ActionContext:
     actor: GroupActionActor = SYSTEM_ACTOR
 
 
+@dataclass(frozen=True)
+class _ActionPublication:
+    action: GroupAction
+    source: str
+    group_id: int
+    project: Project
+    actor: GroupActionActor
+    force_async_derived: bool
+    idempotency_key: str | None
+    date_added: datetime | None
+
+
+@dataclass
+class _ActionLogBuffer:
+    actions: list[_ActionPublication]
+    using: str
+    transaction_state: tuple[bool, tuple[str | None, ...]]
+
+
+class ActionLogBufferError(Exception):
+    """Raised when buffered actions cannot be published on a successful scope exit."""
+
+
 _action_context: ContextVar[ActionContext | None] = ContextVar("action_context", default=None)
+_action_log_buffer: ContextVar[_ActionLogBuffer | None] = ContextVar(
+    "action_log_buffer", default=None
+)
 
 
 @contextmanager
@@ -71,6 +96,51 @@ def action_context_scope(source: str, actor: GroupActionActor = SYSTEM_ACTOR) ->
 
 def get_action_context() -> ActionContext | None:
     return _action_context.get()
+
+
+def _get_transaction_state(using: str) -> tuple[bool, tuple[str | None, ...]]:
+    from django.db import connections
+
+    connection = connections[using]
+    return connection.in_atomic_block, tuple(connection.savepoint_ids)
+
+
+@contextmanager
+def action_log_buffer() -> Generator[None]:
+    """Buffer actions published at the current transaction level and flush them in bulk.
+
+    Actions published from a nested transaction or savepoint bypass this buffer so their
+    outbox rows retain the nested transaction's rollback semantics.
+    """
+    current_buffer = _action_log_buffer.get()
+    if current_buffer is not None:
+        yield
+        return
+
+    from django.db import router
+
+    from sentry.hybridcloud.models.outbox import CellOutbox
+
+    using = router.db_for_write(CellOutbox)
+    buffer = _ActionLogBuffer(
+        actions=[], using=using, transaction_state=_get_transaction_state(using)
+    )
+    token = _action_log_buffer.set(buffer)
+    try:
+        yield
+    except BaseException:
+        _action_log_buffer.reset(token)
+        try:
+            _publish_actions_bulk(buffer.actions)
+        except Exception:
+            logger.exception("Failed to flush group action log buffer during exception handling")
+        raise
+    else:
+        _action_log_buffer.reset(token)
+        try:
+            _publish_actions_bulk(buffer.actions)
+        except Exception as error:
+            raise ActionLogBufferError("Failed to flush group action log buffer") from error
 
 
 def publish_action(
@@ -103,8 +173,26 @@ def publish_action(
     Log publishing is managed by an outbox that flushes on commit by
     default. Wrap in ``outbox_context(flush=False)`` to defer the drain.
     """
-    # Deferred imports: keep this module free of Django/outbox/features deps at
-    # load time so it can be imported from models without creating cycles.
+    publication = _ActionPublication(
+        action=action,
+        source=source,
+        group_id=group_id,
+        project=project,
+        actor=actor,
+        force_async_derived=force_async_derived,
+        idempotency_key=idempotency_key,
+        date_added=date_added,
+    )
+    buffer = _action_log_buffer.get()
+    if buffer is not None and _get_transaction_state(buffer.using) == buffer.transaction_state:
+        buffer.actions.append(publication)
+        return
+
+    _publish_action(publication)
+
+
+def _publish_action(publication: _ActionPublication) -> None:
+    # Deferred imports keep this module safe to import from models without creating cycles.
     from django.db import router, transaction
 
     from sentry import features
@@ -113,17 +201,23 @@ def publish_action(
     from sentry.utils import metrics
 
     for callback in _publish_callbacks.get():
-        callback(action, source, group_id, project, actor)
+        callback(
+            publication.action,
+            publication.source,
+            publication.group_id,
+            publication.project,
+            publication.actor,
+        )
 
-    action_name = action.get_type().name.lower()
-    write_to_db = features.has("projects:issue-action-log-write-to-db", project)
+    action_name = publication.action.get_type().name.lower()
+    write_to_db = features.has("projects:issue-action-log-write-to-db", publication.project)
 
     metrics.incr(
         "issues.action_log",
         tags={
             "action": action_name,
-            "source": source,
-            "actor_type": actor.actor_type.name.lower(),
+            "source": publication.source,
+            "actor_type": publication.actor.actor_type.name.lower(),
             "persisted": write_to_db,
         },
     )
@@ -131,15 +225,15 @@ def publish_action(
         "group.action_log",
         extra={
             "action": action_name,
-            "source": source,
+            "source": publication.source,
             # IDs are stringified so large values aren't rendered in scientific
             # notation by downstream log tooling.
-            "group_id": str(group_id),
-            "organization_id": str(project.organization_id),
-            "project_id": str(project.id),
-            "actor_type": actor.actor_type.name.lower(),
-            "actor_id": str(actor.actor_id),
-            "metadata": action.dict(),
+            "group_id": str(publication.group_id),
+            "organization_id": str(publication.project.organization_id),
+            "project_id": str(publication.project.id),
+            "actor_type": publication.actor.actor_type.name.lower(),
+            "actor_id": str(publication.actor.actor_id),
+            "metadata": publication.action.dict(),
         },
     )
 
@@ -147,24 +241,24 @@ def publish_action(
         return
 
     payload: GroupActionLogPayload = {
-        "group_id": group_id,
-        "project_id": project.id,
-        "type": action.get_type().value,
-        "actor_type": actor.actor_type.value,
-        "actor_id": actor.actor_id,
-        "source": source,
-        "data": action.dict(),
-        "force_async_derived": force_async_derived,
+        "group_id": publication.group_id,
+        "project_id": publication.project.id,
+        "type": publication.action.get_type().value,
+        "actor_type": publication.actor.actor_type.value,
+        "actor_id": publication.actor.actor_id,
+        "source": publication.source,
+        "data": publication.action.dict(),
+        "force_async_derived": publication.force_async_derived,
     }
 
-    if idempotency_key is not None:
-        payload["idempotency_key"] = idempotency_key
-    if date_added is not None:
-        payload["date_added"] = date_added.isoformat()
+    if publication.idempotency_key is not None:
+        payload["idempotency_key"] = publication.idempotency_key
+    if publication.date_added is not None:
+        payload["date_added"] = publication.date_added.isoformat()
 
     outbox = CellOutbox(
         shard_scope=OutboxScope.GROUP_SCOPE,
-        shard_identifier=group_id,
+        shard_identifier=publication.group_id,
         category=OutboxCategory.GROUP_ACTION_LOG_EVENT,
         object_identifier=CellOutbox.next_object_identifier(),
         payload=payload,
@@ -180,7 +274,7 @@ def publish_action_from_context(
     group_id: int,
     project: Project,
     force_async_derived: bool = False,
-    idempotency_key: Optional[str] = None,
+    idempotency_key: str | None = None,
     date_added: datetime | None = None,
 ) -> None:
     """
@@ -214,7 +308,7 @@ def publish_action_from_context(
 
 
 def publish_actions_from_context_bulk(
-    actions: Sequence[tuple[GroupAction, Project, int, str | None]],
+    actions: Sequence[tuple[GroupAction, Project, int, str | None, datetime | None]],
     *,
     force_async_derived: bool = False,
 ) -> None:
@@ -223,7 +317,8 @@ def publish_actions_from_context_bulk(
     publish_action_from_context. The distinction is that this is a function to publish
     multiple GroupActions at once while only flushing the Outbox once.
 
-    Input is a sequence of tuples of (GroupAction, Project, GroupID, IdempotencyKey)
+    Input is a sequence of tuples of
+    (GroupAction, Project, GroupID, IdempotencyKey, DateAdded).
     """
     if len(actions) == 0:
         return
@@ -243,25 +338,32 @@ def publish_actions_from_context_bulk(
         source = ctx.source
         actor = ctx.actor
 
-    with outbox_context(flush=False):
-        for apgi in actions[:-1]:
-            publish_action(
-                apgi[0],
+    _publish_actions_bulk(
+        [
+            _ActionPublication(
+                action=action,
                 source=source,
-                group_id=apgi[2],
-                project=apgi[1],
+                group_id=group_id,
+                project=project,
                 actor=actor,
                 force_async_derived=force_async_derived,
-                idempotency_key=apgi[3],
+                idempotency_key=idempotency_key,
+                date_added=date_added,
             )
+            for action, project, group_id, idempotency_key, date_added in actions
+        ]
+    )
+
+
+def _publish_actions_bulk(actions: Sequence[_ActionPublication]) -> None:
+    if not actions:
+        return
+
+    from sentry.hybridcloud.models.outbox import outbox_context
+
+    with outbox_context(flush=False):
+        for action in actions[:-1]:
+            _publish_action(action)
 
     # Flushes the outbox by default.
-    publish_action(
-        actions[-1][0],
-        source=source,
-        group_id=actions[-1][2],
-        project=actions[-1][1],
-        actor=actor,
-        force_async_derived=force_async_derived,
-        idempotency_key=actions[-1][3],
-    )
+    _publish_action(actions[-1])

--- a/src/sentry/issues/action_log/publish.py
+++ b/src/sentry/issues/action_log/publish.py
@@ -143,6 +143,15 @@ def action_log_buffer() -> Generator[None]:
             raise ActionLogBufferError("Failed to flush group action log buffer") from error
 
 
+def _buffer_publications(publications: Sequence[_ActionPublication]) -> bool:
+    buffer = _action_log_buffer.get()
+    if buffer is None or _get_transaction_state(buffer.using) != buffer.transaction_state:
+        return False
+
+    buffer.actions.extend(publications)
+    return True
+
+
 def publish_action(
     action: GroupAction,
     *,
@@ -183,9 +192,7 @@ def publish_action(
         idempotency_key=idempotency_key,
         date_added=date_added,
     )
-    buffer = _action_log_buffer.get()
-    if buffer is not None and _get_transaction_state(buffer.using) == buffer.transaction_state:
-        buffer.actions.append(publication)
+    if _buffer_publications((publication,)):
         return
 
     _publish_action(publication)
@@ -338,21 +345,21 @@ def publish_actions_from_context_bulk(
         source = ctx.source
         actor = ctx.actor
 
-    _publish_actions_bulk(
-        [
-            _ActionPublication(
-                action=action,
-                source=source,
-                group_id=group_id,
-                project=project,
-                actor=actor,
-                force_async_derived=force_async_derived,
-                idempotency_key=idempotency_key,
-                date_added=date_added,
-            )
-            for action, project, group_id, idempotency_key, date_added in actions
-        ]
-    )
+    publications = [
+        _ActionPublication(
+            action=action,
+            source=source,
+            group_id=group_id,
+            project=project,
+            actor=actor,
+            force_async_derived=force_async_derived,
+            idempotency_key=idempotency_key,
+            date_added=date_added,
+        )
+        for action, project, group_id, idempotency_key, date_added in actions
+    ]
+    if not _buffer_publications(publications):
+        _publish_actions_bulk(publications)
 
 
 def _publish_actions_bulk(actions: Sequence[_ActionPublication]) -> None:

--- a/src/sentry/models/activity.py
+++ b/src/sentry/models/activity.py
@@ -171,7 +171,13 @@ class ActivityManager(BaseManager["Activity"]):
                 # This loads the group just to fetch the ID, which isn't ideal... but we need the
                 # group ID for each activity, which can be different. No real way around it.
                 # Thankfully, this function is rarely-used (and isn't in any perf-sensitive paths)
-                (aa[0], aa[1].project, aa[1].group.id, activity_action_idempotency_key(aa[1]))
+                (
+                    aa[0],
+                    aa[1].project,
+                    aa[1].group.id,
+                    activity_action_idempotency_key(aa[1]),
+                    aa[1].datetime,
+                )
                 for aa in actions_with_activities
                 if aa[0] is not None and aa[1].group is not None
             ]

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -43,6 +43,7 @@ from sentry.db.models import (
 from sentry.db.models.fields.jsonfield import LegacyTextJSONField
 from sentry.db.models.manager.base import BaseManager
 from sentry.db.models.manager.base_query_set import BaseQuerySet
+from sentry.issues.action_log.publish import ActionLogBufferError, action_log_buffer
 from sentry.issues.grouptype import GroupCategory, get_group_type_by_type_id
 from sentry.issues.priority import (
     PRIORITY_TO_GROUP_HISTORY_STATUS,
@@ -66,6 +67,7 @@ from sentry.types.group import (
 )
 from sentry.utils import metrics
 from sentry.utils.dates import outside_retention_with_modified_start
+from sentry.utils.env import in_test_environment
 from sentry.utils.numbers import base32_decode, base32_encode
 from sentry.utils.safe import get_path
 from sentry.utils.strings import strip, truncatechars
@@ -745,61 +747,70 @@ class GroupManager(BaseManager["Group"]):
             modified_groups_list, ["status", "substatus", "priority", "resolved_at"]
         )
 
-        for group in modified_groups_list:
-            activity = Activity.objects.create_group_activity(
-                group,
-                activity_type,
-                data=activity_data,
-                send_notification=send_activity_notification,
-                datetime=update_date,
-                detector_id=detector_id,
-            )
-            record_group_history_from_activity_type(group, activity_type.value)
-
-            if group.id in updated_priority:
-                new_priority = updated_priority[group.id]
-                Activity.objects.create_group_activity(
-                    group=group,
-                    type=ActivityType.SET_PRIORITY,
-                    data={
-                        "priority": new_priority.to_str(),
-                        "reason": PriorityChangeReason.ONGOING,
-                    },
-                    datetime=update_date,
-                    detector_id=detector_id,
-                )
-                record_group_history(group, PRIORITY_TO_GROUP_HISTORY_STATUS[new_priority])
-
-            is_status_resolved = status == GroupStatus.RESOLVED
-            is_status_unresolved = status == GroupStatus.UNRESOLVED
-
-            # The open period is only updated when a group is resolved or reopened. We don't want to
-            # update the open period when a group transitions between different substatuses within UNRESOLVED.
-            if is_status_resolved:
-                update_group_open_period(
-                    group=group,
-                    new_status=GroupStatus.RESOLVED,
-                    resolution_time=activity.datetime,
-                    resolution_activity=activity,
-                )
-            elif is_status_unresolved and should_reopen_open_period[group.id]:
-                update_group_open_period(
-                    group=group,
-                    new_status=GroupStatus.UNRESOLVED,
-                )
-
-            should_update_incident = is_status_resolved or (
-                is_status_unresolved and should_reopen_open_period[group.id]
-            )
-            # TODO (aci cleanup): remove this once we've deprecated the incident model
-            if group.type == MetricIssue.type_id and should_update_incident:
-                if detector_id is None:
-                    logger.error(
-                        "Call to update metric issue status missing detector ID",
-                        extra={"group_id": group.id},
+        try:
+            with action_log_buffer():
+                for group in modified_groups_list:
+                    activity = Activity.objects.create_group_activity(
+                        group,
+                        activity_type,
+                        data=activity_data,
+                        send_notification=send_activity_notification,
+                        datetime=update_date,
+                        detector_id=detector_id,
                     )
-                    continue
-                update_incident_based_on_open_period_status_change(group, status)
+                    record_group_history_from_activity_type(group, activity_type.value)
+
+                    if group.id in updated_priority:
+                        new_priority = updated_priority[group.id]
+                        Activity.objects.create_group_activity(
+                            group=group,
+                            type=ActivityType.SET_PRIORITY,
+                            data={
+                                "priority": new_priority.to_str(),
+                                "reason": PriorityChangeReason.ONGOING,
+                            },
+                            datetime=update_date,
+                            detector_id=detector_id,
+                        )
+                        record_group_history(group, PRIORITY_TO_GROUP_HISTORY_STATUS[new_priority])
+
+                    is_status_resolved = status == GroupStatus.RESOLVED
+                    is_status_unresolved = status == GroupStatus.UNRESOLVED
+
+                    # The open period is only updated when a group is resolved or reopened. We don't want to
+                    # update the open period when a group transitions between different substatuses within UNRESOLVED.
+                    if is_status_resolved:
+                        update_group_open_period(
+                            group=group,
+                            new_status=GroupStatus.RESOLVED,
+                            resolution_time=activity.datetime,
+                            resolution_activity=activity,
+                        )
+                    elif is_status_unresolved and should_reopen_open_period[group.id]:
+                        update_group_open_period(
+                            group=group,
+                            new_status=GroupStatus.UNRESOLVED,
+                        )
+
+                    should_update_incident = is_status_resolved or (
+                        is_status_unresolved and should_reopen_open_period[group.id]
+                    )
+                    # TODO (aci cleanup): remove this once we've deprecated the incident model
+                    if group.type == MetricIssue.type_id and should_update_incident:
+                        if detector_id is None:
+                            logger.error(
+                                "Call to update metric issue status missing detector ID",
+                                extra={"group_id": group.id},
+                            )
+                            continue
+                        update_incident_based_on_open_period_status_change(group, status)
+        except ActionLogBufferError:
+            logger.info(
+                "Failed to publish buffered activities to GALE",
+                extra={"group_ids": [group.id for group in modified_groups_list]},
+            )
+            if in_test_environment():
+                raise
 
     def from_share_id(self, share_id: str) -> Group:
         if not share_id or len(share_id) != 32:

--- a/tests/sentry/issues/test_action_log.py
+++ b/tests/sentry/issues/test_action_log.py
@@ -1,9 +1,11 @@
+from datetime import timedelta
 from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
 from django.contrib.auth.models import AnonymousUser
 from django.db import router, transaction
+from django.utils import timezone
 
 from sentry.auth.services.auth import AuthenticatedToken
 from sentry.hybridcloud.models.outbox import CellOutbox, outbox_context
@@ -13,6 +15,7 @@ from sentry.issues.action_log import (
     ActionContext,
     GroupActionActor,
     action_context_scope,
+    action_log_buffer,
     get_action_context,
     publish_action,
     resolve_action_actor,
@@ -281,22 +284,50 @@ class TestPublishActionFromContext(TestCase):
         info_record = [r for r in logs.records if r.message == "group.action_log"][0]
         assert getattr(info_record, "source") == "unknown"
 
+    def test_buffer_preserves_each_action_context(self) -> None:
+        from sentry.issues.action_log import publish_action_from_context
+
+        first_actor = GroupActionActor.user(1)
+        second_actor = GroupActionActor.user(2)
+        with capture_action_log() as log, action_log_buffer():
+            with action_context_scope(source=ActionSource.API, actor=first_actor):
+                publish_action_from_context(
+                    ViewAction(), group_id=self.group.id, project=self.group.project
+                )
+            with action_context_scope(source=ActionSource.SLACK, actor=second_actor):
+                publish_action_from_context(
+                    ResolveAction(), group_id=self.group.id, project=self.group.project
+                )
+
+        log.assert_logged(
+            ViewAction, group_id=self.group.id, source=ActionSource.API, actor=first_actor
+        )
+        log.assert_logged(
+            ResolveAction,
+            group_id=self.group.id,
+            source=ActionSource.SLACK,
+            actor=second_actor,
+        )
+
 
 class TestPublishActionsFromContextBulk(TestCase):
     def test_multiple_writes(self) -> None:
         from sentry.issues.action_log import action_context_scope, publish_actions_from_context_bulk
 
         actor = GroupActionActor.user(42)
+        date_added = timezone.now() - timedelta(minutes=1)
         with self.feature("projects:issue-action-log-write-to-db"), outbox_runner():
             with action_context_scope(source="web", actor=actor):
                 publish_actions_from_context_bulk(
                     [
-                        (ViewAction(), self.group.project, self.group.id, None),
-                        (ResolveAction(), self.group.project, self.group.id, None),
+                        (ViewAction(), self.group.project, self.group.id, None, date_added),
+                        (ResolveAction(), self.group.project, self.group.id, None, date_added),
                     ],
                 )
 
-        assert GroupActionLogEntry.objects.filter(group_id=self.group.id).count() == 2
+        entries = GroupActionLogEntry.objects.filter(group_id=self.group.id)
+        assert entries.count() == 2
+        assert all(entry.date_added == date_added for entry in entries)
 
 
 class TestActionLogIntegration(APITestCase, SnubaTestCase):
@@ -444,6 +475,28 @@ class TestUpdateGroupStatusActionLog(APITestCase, SnubaTestCase):
                     activity_type=ActivityType.SET_IGNORED,
                 )
         log.assert_logged(ArchiveAction, group_id=group.id, source=ActionSource.SYSTEM)
+
+    def test_multiple_groups_publish_actions_in_one_batch(self) -> None:
+        groups = [
+            self.create_group(status=GroupStatus.UNRESOLVED, substatus=GroupSubStatus.ONGOING),
+            self.create_group(status=GroupStatus.UNRESOLVED, substatus=GroupSubStatus.ONGOING),
+        ]
+
+        with patch("sentry.issues.action_log.publish._publish_actions_bulk") as bulk_publish:
+            with action_context_scope(source=ActionSource.SYSTEM, actor=SYSTEM_ACTOR):
+                Group.objects.update_group_status(
+                    groups=groups,
+                    status=GroupStatus.RESOLVED,
+                    substatus=None,
+                    activity_type=ActivityType.SET_RESOLVED,
+                )
+
+        bulk_publish.assert_called_once()
+        publications = bulk_publish.call_args.args[0]
+        assert len(publications) == 2
+        assert {publication.group_id for publication in publications} == {
+            group.id for group in groups
+        }
 
 
 class TestExternalIssueLinkingActionLog(APITestCase, SnubaTestCase):
@@ -622,6 +675,88 @@ class TestPublishActionWrite(TestCase):
         entries = list(GroupActionLogEntry.objects.filter(group_id=self.group.id))
         assert len(entries) == 1
         assert entries[0].type == GroupActionType.VIEW
+
+    def test_buffered_action_rolls_back_with_transaction(self) -> None:
+        with self.feature("projects:issue-action-log-write-to-db"):
+            try:
+                with transaction.atomic(using=router.db_for_write(CellOutbox)):
+                    with action_log_buffer():
+                        publish_action(
+                            ViewAction(),
+                            source=ActionSource.API,
+                            group_id=self.group.id,
+                            project=self.group.project,
+                        )
+
+                    assert CellOutbox.objects.filter(
+                        category=OutboxCategory.GROUP_ACTION_LOG_EVENT
+                    ).exists()
+                    raise IntentionalRollback()
+            except IntentionalRollback:
+                pass
+
+        assert not CellOutbox.objects.filter(
+            category=OutboxCategory.GROUP_ACTION_LOG_EVENT
+        ).exists()
+
+    def test_nested_savepoint_action_bypasses_outer_buffer(self) -> None:
+        with self.feature("projects:issue-action-log-write-to-db"), outbox_runner():
+            with action_log_buffer():
+                publish_action(
+                    ViewAction(),
+                    source=ActionSource.API,
+                    group_id=self.group.id,
+                    project=self.group.project,
+                )
+                assert not CellOutbox.objects.filter(
+                    category=OutboxCategory.GROUP_ACTION_LOG_EVENT
+                ).exists()
+
+                try:
+                    with transaction.atomic(using=router.db_for_write(CellOutbox)):
+                        publish_action(
+                            ResolveAction(),
+                            source=ActionSource.API,
+                            group_id=self.group.id,
+                            project=self.group.project,
+                        )
+                        assert (
+                            CellOutbox.objects.filter(
+                                category=OutboxCategory.GROUP_ACTION_LOG_EVENT
+                            ).count()
+                            == 1
+                        )
+                        raise IntentionalRollback()
+                except IntentionalRollback:
+                    pass
+
+                assert not CellOutbox.objects.filter(
+                    category=OutboxCategory.GROUP_ACTION_LOG_EVENT
+                ).exists()
+
+        entries = list(GroupActionLogEntry.objects.filter(group_id=self.group.id))
+        assert len(entries) == 1
+        assert entries[0].type == GroupActionType.VIEW
+
+    def test_nested_buffers_flush_once(self) -> None:
+        with patch("sentry.issues.action_log.publish._publish_actions_bulk") as bulk_publish:
+            with action_log_buffer():
+                publish_action(
+                    ViewAction(),
+                    source=ActionSource.API,
+                    group_id=self.group.id,
+                    project=self.group.project,
+                )
+                with action_log_buffer():
+                    publish_action(
+                        ResolveAction(),
+                        source=ActionSource.API,
+                        group_id=self.group.id,
+                        project=self.group.project,
+                    )
+
+        bulk_publish.assert_called_once()
+        assert len(bulk_publish.call_args.args[0]) == 2
 
     def test_feature_disabled_skips_write(self) -> None:
         publish_action(
@@ -820,6 +955,52 @@ class TestCaptureActionLog(TestCase):
 
 
 class TestActivitiesCreateActions(TestCase):
+    def test_buffered_activity_loop_publishes_one_batch(self) -> None:
+        from sentry.issues.action_log.publish import _publish_actions_bulk
+        from sentry.utils.action_log.activity_translator import activity_action_idempotency_key
+
+        activity_types = [
+            ActivityType.SET_RESOLVED,
+            ActivityType.SET_UNRESOLVED,
+            ActivityType.SET_REGRESSION,
+        ]
+        with (
+            self.feature("projects:issue-action-log-write-to-db"),
+            outbox_runner(),
+            patch(
+                "sentry.issues.action_log.publish._publish_actions_bulk",
+                wraps=_publish_actions_bulk,
+            ) as bulk_publish,
+        ):
+            with (
+                action_context_scope(source=ActionSource.SYSTEM),
+                action_log_buffer(),
+            ):
+                activities = [
+                    Activity.objects.create(
+                        group=self.group,
+                        project=self.project,
+                        type=activity_type.value,
+                        user_id=self.user.id,
+                        data={},
+                    )
+                    for activity_type in activity_types
+                ]
+
+        bulk_publish.assert_called_once()
+        assert len(bulk_publish.call_args.args[0]) == len(activities)
+        assert Activity.objects.filter(id__in=[activity.id for activity in activities]).count() == 3
+
+        entries = list(GroupActionLogEntry.objects.filter(group_id=self.group.id))
+        assert {entry.type for entry in entries} == {
+            GroupActionType.RESOLVE,
+            GroupActionType.UNRESOLVE,
+            GroupActionType.SET_REGRESSED,
+        }
+        assert {entry.idempotency_key for entry in entries} == {
+            activity_action_idempotency_key(activity) for activity in activities
+        }
+
     def test_basic(self) -> None:
         with capture_action_log() as log:
             Activity.objects.create(

--- a/tests/sentry/issues/test_action_log.py
+++ b/tests/sentry/issues/test_action_log.py
@@ -311,6 +311,39 @@ class TestPublishActionFromContext(TestCase):
 
 
 class TestPublishActionsFromContextBulk(TestCase):
+    def test_respects_action_log_buffer(self) -> None:
+        from sentry.issues.action_log import publish_actions_from_context_bulk
+
+        with patch("sentry.issues.action_log.publish._publish_actions_bulk") as bulk_publish:
+            with action_context_scope(source=ActionSource.SYSTEM), action_log_buffer():
+                publish_actions_from_context_bulk(
+                    [
+                        (ViewAction(), self.group.project, self.group.id, None, None),
+                        (ResolveAction(), self.group.project, self.group.id, None, None),
+                    ]
+                )
+                bulk_publish.assert_not_called()
+
+        bulk_publish.assert_called_once()
+        assert len(bulk_publish.call_args.args[0]) == 2
+
+    def test_nested_savepoint_bypasses_outer_buffer(self) -> None:
+        from sentry.issues.action_log import publish_actions_from_context_bulk
+
+        group = self.group
+        with patch("sentry.issues.action_log.publish._publish_action") as publish:
+            with action_context_scope(source=ActionSource.SYSTEM), action_log_buffer():
+                with transaction.atomic(using=router.db_for_write(CellOutbox)):
+                    publish_actions_from_context_bulk(
+                        [
+                            (ViewAction(), group.project, group.id, None, None),
+                            (ResolveAction(), group.project, group.id, None, None),
+                        ]
+                    )
+                assert publish.call_count == 2
+
+        assert publish.call_count == 2
+
     def test_multiple_writes(self) -> None:
         from sentry.issues.action_log import action_context_scope, publish_actions_from_context_bulk
 


### PR DESCRIPTION
It's a bit of an odd fit with transactionality, but this contextual buffering allows us to handle loops of legacy code that generate a lot of action publishes (particuarly those that don't particularly care about sync processing) very efficiently via optimized batch handling methods.

Part of ISWF-3221.