### PR TITLE
feat(grouping): Reject Seer matches on meaningful exception type differences

### DIFF
--- a/src/sentry/grouping/ingest/exception_types.py
+++ b/src/sentry/grouping/ingest/exception_types.py
@@ -23,12 +23,14 @@ from sentry.grouping.parameterization import parameterizer
 # Platforms whose exception types are stable, human-authored identifiers. Elsewhere, minifiers and
 # obfuscators rename classes per build, so `V` in one release and `bm` in the next may well be the
 # very same class.
+#
+# `java` is deliberately absent: Android events arrive with that platform (it's the only JVM value
+# Relay normalizes to), and without an applied ProGuard/R8 mapping their types stay obfuscated.
 PLATFORMS_WITH_STABLE_TYPE_NAMES = frozenset(
     [
         "python",
         "ruby",
         "php",
-        "java",
         "go",
         "csharp",
         "elixir",

--- a/src/sentry/grouping/ingest/exception_types.py
+++ b/src/sentry/grouping/ingest/exception_types.py
@@ -40,11 +40,16 @@ PLATFORMS_WITH_STABLE_TYPE_NAMES = frozenset(
 # tells us the type is absent — not that it differs from the other side.
 GENERIC_TYPE_PLACEHOLDER = "Error"
 
-# Cocoa app-hang types are built by the SDK from two independent dimensions:
+# The app-hang types the Cocoa SDK can produce (see `SentryAppHangTypeMapper`):
 #
-#   ("Fatal " | "") + "App Hang" + (" Fully Blocked" | " Non Fully Blocked")
+#   Fatal App Hang Fully Blocked
+#   Fatal App Hang Non Fully Blocked
+#   App Hang Fully Blocked
+#   App Hang Non Fully Blocked
+#   App Hanging          (older SDKs, which can't tell the two blocked kinds apart)
 #
-# Older SDK versions also emit "App Hanging".
+# Note that non-fatal is spelled as the absence of the `Fatal ` prefix; the `Non ` in the list above
+# belongs to the trailing blocked dimension, not to fatality.
 _APP_HANG_RE = re.compile(r"^(?P<fatal>fatal\s+)?app\s+hang(ing)?\b", re.IGNORECASE)
 
 

--- a/src/sentry/grouping/ingest/exception_types.py
+++ b/src/sentry/grouping/ingest/exception_types.py
@@ -1,0 +1,169 @@
+"""
+Comparison logic for deciding whether two exception types are different enough that a Seer
+similarity match between them should be rejected.
+
+Baseline (hash-based) grouping treats ``exception.type`` as a hard grouping input: two events with
+different types never share a hash. Seer ignores the type entirely and matches on stacktrace
+similarity, which is frequently what we want — it rescues events whose stacktraces drifted (minified
+frames, changing paths, inlined frames) but which are the same underlying bug.
+
+So the question here is never "are these two events similar?" — Seer has already said yes. It's
+narrower: **is the type difference by itself proof that Seer is wrong?** We only reject when we're
+confident the answer is yes, because rejecting is not free: with
+``seer.similarity.ingest.num_matches_to_request`` set to 1 there is no runner-up match to fall back
+on, so every rejection opens a brand-new group.
+
+Two families of difference clear that bar today:
+
+1. **App hangs of differing fatality.** A fatal hang (the app was killed) and a non-fatal hang (it
+   recovered) are different events for the user even when the stacktrace is identical, and mixing
+   them corrupts the fatal-only alerting that `error.type` powers. See ``_app_hang_mismatch``.
+
+2. **Distinct, stable, hand-written type names.** ``ValueError`` vs ``TypeError`` is a real
+   difference in kind, not an artifact. See ``_distinct_stable_type_names``.
+
+Everything else — types containing whitespace, types differing only in embedded variable data,
+namespace-relative spellings of the same class, minified names — is deliberately left to fall
+through and be accepted, and is logged by the caller so we can keep narrowing.
+"""
+
+from __future__ import annotations
+
+import re
+from enum import StrEnum
+
+from sentry.grouping.parameterization import parameterizer
+
+# Platforms whose exception types are stable, human-authored identifiers. Restricting the
+# distinct-type-name rejection to these keeps us away from platforms where the same class can
+# legitimately show up under different names: minifiers and obfuscators (JavaScript, obfuscated
+# Android) rename classes per build, so `V` in one release and `bm` in the next may well be the very
+# same class. Those get logged, not rejected.
+PLATFORMS_WITH_STABLE_TYPE_NAMES = frozenset(
+    [
+        "python",
+        "ruby",
+        "php",
+        "java",
+        "go",
+        "csharp",
+        "elixir",
+        "perl",
+    ]
+)
+
+# `ErrorEvent.extract_metadata` falls back to this when an exception has no type at all, so seeing it
+# tells us the type is absent — not that it differs from the other side.
+GENERIC_TYPE_PLACEHOLDER = "Error"
+
+# Cocoa app-hang types are built by the SDK from two independent dimensions:
+#
+#   ("Fatal " | "") + "App Hang" + (" Fully Blocked" | " Non Fully Blocked")
+#
+# e.g. "Fatal App Hang Fully Blocked", "App Hang Non Fully Blocked". Older SDK versions also emit
+# "App Hanging". The frontend's ANR-rate query (`static/app/views/projectDetail/utils.tsx`) selects
+# on exactly the two fatal spellings, which is why conflating fatal with non-fatal skews that
+# number.
+_APP_HANG_RE = re.compile(r"^(?P<fatal>fatal\s+)?app\s+hang(ing)?\b", re.IGNORECASE)
+
+
+class MismatchReason(StrEnum):
+    """
+    Why two exception types were considered different, or — for the non-rejecting values — why we
+    declined to act on the difference. Used as a metrics tag, so keep the set small and bounded.
+    """
+
+    # Rejections
+    APP_HANG_FATALITY = "app_hang_fatality"
+    DISTINCT_TYPE_NAMES = "distinct_type_names"
+
+    # Accepted-but-noted
+    APP_HANG_OTHER = "app_hang_other"
+    CONTAINS_WHITESPACE = "contains_whitespace"
+    PARAMETERIZES_EQUAL = "parameterizes_equal"
+    GENERIC_PLACEHOLDER = "generic_placeholder"
+    UNSTABLE_PLATFORM = "unstable_platform"
+
+
+def _is_app_hang(error_type: str) -> bool:
+    return _APP_HANG_RE.match(error_type) is not None
+
+
+def _is_fatal_app_hang(error_type: str) -> bool:
+    match = _APP_HANG_RE.match(error_type)
+    return match is not None and match.group("fatal") is not None
+
+
+def _app_hang_mismatch(event_type: str, parent_type: str) -> MismatchReason:
+    """
+    Classify a mismatch between two app-hang types.
+
+    Fatality is the one dimension we're confident about: a fatal hang means the app was terminated
+    while a non-fatal one means it recovered, so they belong in separate groups regardless of how
+    similar their stacktraces are. The blocked/non-fully-blocked dimension and the
+    "hang"/"hanging" spelling difference are *not* settled — pending confirmation from the native
+    SDK team on which combinations describe the same underlying problem — so those are accepted and
+    logged.
+    """
+    if _is_fatal_app_hang(event_type) != _is_fatal_app_hang(parent_type):
+        return MismatchReason.APP_HANG_FATALITY
+
+    return MismatchReason.APP_HANG_OTHER
+
+
+def _distinct_stable_type_names(
+    event_type: str, parent_type: str, platform: str | None
+) -> MismatchReason:
+    """
+    Classify a mismatch between two non-app-hang types, rejecting only when the difference is in the
+    stable part of a hand-written type name.
+
+    Three conditions must all hold to reject, each ruling out a way the difference could be an
+    artifact rather than a real difference in kind:
+
+    - **No whitespace on either side.** A whitespace-free string is an identifier the SDK read off a
+      real type. Once there's whitespace we're likely looking at a message that got stuffed into the
+      `type` field, where the difference may be a severity prefix or an appended value.
+    - **Parameterization is a no-op and they still differ.** This is what keeps runtime-generated
+      names out: `Foo$$Lambda$14/0x...` vs `Foo$$Lambda$27/0x...` and `Error_a3f2b1` vs
+      `Error_c9d4e7` both collapse to a single string once variable data is replaced, so their
+      difference *is* the variable data. Note that this subsumes the `Namespace::Type` case — `::`
+      contains no whitespace and doesn't parameterize, so `RestClient::BadRequest` vs
+      `RestClient::NotFound` is rejected without needing a rule of its own.
+    - **Neither side is the bare placeholder.** See ``GENERIC_TYPE_PLACEHOLDER``.
+
+    Platform is checked by the caller (see ``PLATFORMS_WITH_STABLE_TYPE_NAMES``).
+    """
+    if platform not in PLATFORMS_WITH_STABLE_TYPE_NAMES:
+        return MismatchReason.UNSTABLE_PLATFORM
+
+    if GENERIC_TYPE_PLACEHOLDER in (event_type, parent_type):
+        return MismatchReason.GENERIC_PLACEHOLDER
+
+    if any(char.isspace() for char in event_type + parent_type):
+        return MismatchReason.CONTAINS_WHITESPACE
+
+    if parameterizer.parameterize(event_type) == parameterizer.parameterize(parent_type):
+        return MismatchReason.PARAMETERIZES_EQUAL
+
+    return MismatchReason.DISTINCT_TYPE_NAMES
+
+
+REJECTING_REASONS = frozenset(
+    [MismatchReason.APP_HANG_FATALITY, MismatchReason.DISTINCT_TYPE_NAMES]
+)
+
+
+def classify_exception_type_mismatch(
+    event_type: str, parent_type: str, platform: str | None
+) -> MismatchReason:
+    """
+    Categorize why two differing exception types differ.
+
+    Callers should reject the Seer match when the returned reason is in ``REJECTING_REASONS``, and
+    accept (but log) otherwise. Assumes the two types are already known to differ.
+    """
+    if _is_app_hang(event_type) and _is_app_hang(parent_type):
+        return _app_hang_mismatch(event_type, parent_type)
+
+    return _distinct_stable_type_names(event_type, parent_type, platform)

--- a/src/sentry/grouping/ingest/exception_types.py
+++ b/src/sentry/grouping/ingest/exception_types.py
@@ -2,29 +2,15 @@
 Comparison logic for deciding whether two exception types are different enough that a Seer
 similarity match between them should be rejected.
 
-Baseline (hash-based) grouping treats ``exception.type`` as a hard grouping input: two events with
-different types never share a hash. Seer ignores the type entirely and matches on stacktrace
-similarity, which is frequently what we want — it rescues events whose stacktraces drifted (minified
-frames, changing paths, inlined frames) but which are the same underlying bug.
+Seer ignores ``exception.type`` and matches on stacktrace similarity, which is frequently what we
+want — it rescues events whose stacktraces drifted but which are the same underlying bug. So the
+question here is never "are these similar?" (Seer already said yes) but "is the type difference by
+itself proof that Seer is wrong?"
 
-So the question here is never "are these two events similar?" — Seer has already said yes. It's
-narrower: **is the type difference by itself proof that Seer is wrong?** We only reject when we're
-confident the answer is yes, because rejecting is not free: with
-``seer.similarity.ingest.num_matches_to_request`` set to 1 there is no runner-up match to fall back
-on, so every rejection opens a brand-new group.
-
-Two families of difference clear that bar today:
-
-1. **App hangs of differing fatality.** A fatal hang (the app was killed) and a non-fatal hang (it
-   recovered) are different events for the user even when the stacktrace is identical, and mixing
-   them corrupts the fatal-only alerting that `error.type` powers. See ``_app_hang_mismatch``.
-
-2. **Distinct, stable, hand-written type names.** ``ValueError`` vs ``TypeError`` is a real
-   difference in kind, not an artifact. See ``_distinct_stable_type_names``.
-
-Everything else — types containing whitespace, types differing only in embedded variable data,
-namespace-relative spellings of the same class, minified names — is deliberately left to fall
-through and be accepted, and is logged by the caller so we can keep narrowing.
+We only reject when we're confident the answer is yes, because rejecting isn't free: with
+``seer.similarity.ingest.num_matches_to_request`` set to 1 there's no runner-up to fall back on, so
+every rejection opens a brand-new group. Everything we're not confident about is categorized and
+accepted, and logged by the caller so we can keep narrowing.
 """
 
 from __future__ import annotations
@@ -34,11 +20,9 @@ from enum import StrEnum
 
 from sentry.grouping.parameterization import parameterizer
 
-# Platforms whose exception types are stable, human-authored identifiers. Restricting the
-# distinct-type-name rejection to these keeps us away from platforms where the same class can
-# legitimately show up under different names: minifiers and obfuscators (JavaScript, obfuscated
-# Android) rename classes per build, so `V` in one release and `bm` in the next may well be the very
-# same class. Those get logged, not rejected.
+# Platforms whose exception types are stable, human-authored identifiers. Elsewhere, minifiers and
+# obfuscators rename classes per build, so `V` in one release and `bm` in the next may well be the
+# very same class.
 PLATFORMS_WITH_STABLE_TYPE_NAMES = frozenset(
     [
         "python",
@@ -60,10 +44,7 @@ GENERIC_TYPE_PLACEHOLDER = "Error"
 #
 #   ("Fatal " | "") + "App Hang" + (" Fully Blocked" | " Non Fully Blocked")
 #
-# e.g. "Fatal App Hang Fully Blocked", "App Hang Non Fully Blocked". Older SDK versions also emit
-# "App Hanging". The frontend's ANR-rate query (`static/app/views/projectDetail/utils.tsx`) selects
-# on exactly the two fatal spellings, which is why conflating fatal with non-fatal skews that
-# number.
+# Older SDK versions also emit "App Hanging".
 _APP_HANG_RE = re.compile(r"^(?P<fatal>fatal\s+)?app\s+hang(ing)?\b", re.IGNORECASE)
 
 
@@ -99,11 +80,10 @@ def _app_hang_mismatch(event_type: str, parent_type: str) -> MismatchReason:
     Classify a mismatch between two app-hang types.
 
     Fatality is the one dimension we're confident about: a fatal hang means the app was terminated
-    while a non-fatal one means it recovered, so they belong in separate groups regardless of how
-    similar their stacktraces are. The blocked/non-fully-blocked dimension and the
-    "hang"/"hanging" spelling difference are *not* settled — pending confirmation from the native
-    SDK team on which combinations describe the same underlying problem — so those are accepted and
-    logged.
+    while a non-fatal one means it recovered, so they belong in separate groups however similar
+    their stacktraces are. The blocked/non-fully-blocked dimension and the "hang"/"hanging"
+    spelling difference aren't settled — pending confirmation from the native SDK team — so those
+    are accepted and logged.
     """
     if _is_fatal_app_hang(event_type) != _is_fatal_app_hang(parent_type):
         return MismatchReason.APP_HANG_FATALITY
@@ -118,21 +98,10 @@ def _distinct_stable_type_names(
     Classify a mismatch between two non-app-hang types, rejecting only when the difference is in the
     stable part of a hand-written type name.
 
-    Three conditions must all hold to reject, each ruling out a way the difference could be an
-    artifact rather than a real difference in kind:
-
-    - **No whitespace on either side.** A whitespace-free string is an identifier the SDK read off a
-      real type. Once there's whitespace we're likely looking at a message that got stuffed into the
-      `type` field, where the difference may be a severity prefix or an appended value.
-    - **Parameterization is a no-op and they still differ.** This is what keeps runtime-generated
-      names out: `Foo$$Lambda$14/0x...` vs `Foo$$Lambda$27/0x...` and `Error_a3f2b1` vs
-      `Error_c9d4e7` both collapse to a single string once variable data is replaced, so their
-      difference *is* the variable data. Note that this subsumes the `Namespace::Type` case — `::`
-      contains no whitespace and doesn't parameterize, so `RestClient::BadRequest` vs
-      `RestClient::NotFound` is rejected without needing a rule of its own.
-    - **Neither side is the bare placeholder.** See ``GENERIC_TYPE_PLACEHOLDER``.
-
-    Platform is checked by the caller (see ``PLATFORMS_WITH_STABLE_TYPE_NAMES``).
+    Each check rules out a way the difference could be an artifact rather than a real difference in
+    kind: whitespace suggests a message stuffed into the `type` field rather than a real identifier,
+    and types that collapse to the same string under parameterization (`Error_a3f2b1` vs
+    `Error_c9d4e7`) differ only in runtime-generated data.
     """
     if platform not in PLATFORMS_WITH_STABLE_TYPE_NAMES:
         return MismatchReason.UNSTABLE_PLATFORM

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -539,10 +539,8 @@ def _should_use_seer_match_for_grouping(
     Checks applied in order:
     - Exception type mismatch: rejects when event and parent have exception types whose difference
       we're confident is meaningful (see `sentry.grouping.ingest.exception_types`), and the
-      `seer.similarity.ingest.reject_exception_type_mismatches` option is on. Every mismatch is
-      logged as `seer.exception_type_mismatch` with a `would_reject` verdict regardless of the
-      option; actual rejections additionally log `seer.exception_type_mismatch_rejected`. Skipped
-      for synthetic exceptions (matching regular grouping behavior).
+      `seer.similarity.ingest.reject_exception_type_mismatches` option is on. Skipped for synthetic
+      exceptions (matching regular grouping behavior).
     - Hybrid fingerprint compatibility: rejects when fingerprint types or values don't match.
     """
     parent_group = parent_grouphash.group
@@ -559,13 +557,8 @@ def _should_use_seer_match_for_grouping(
         mismatch_reason = classify_exception_type_mismatch(
             event_exception_type, parent_exception_type, event.platform
         )
-        # Two separate questions, deliberately kept apart. `would_reject` is the categorization's
-        # verdict: is this type difference by itself proof that Seer got it wrong? `reject` is
-        # whether we act on that verdict, which the option gates. Splitting them means the verdict
-        # is visible in the logs while the option is still off, so it can be validated before it
-        # starts splitting groups. Reasons other than the confident ones fall through and are
-        # accepted either way, keeping the (frequently useful) Seer matches that cross type
-        # boundaries while we narrow down further categories.
+        # The verdict and the action are kept separate so the verdict is visible in the logs while
+        # the option is still off.
         would_reject = mismatch_reason in REJECTING_REASONS
         reject = would_reject and options.get(
             "seer.similarity.ingest.reject_exception_type_mismatches"
@@ -597,13 +590,11 @@ def _should_use_seer_match_for_grouping(
             "would_reject": would_reject,
         }
 
-        # Emitted for every mismatch, whatever we do about it. `would_reject` is the verdict, so
-        # this is the log to query when assessing what turning the option on would separate.
+        # Emitted for every mismatch; query `would_reject` to see what enabling the option would
+        # separate.
         logger.info("seer.exception_type_mismatch", extra=mismatch_log_context)
 
         if reject:
-            # Emitted only when the match is actually rejected — i.e. a new group is about to be
-            # created that today's behavior would have merged.
             logger.info("seer.exception_type_mismatch_rejected", extra=mismatch_log_context)
 
             # Not hybrid-fingerprint-related, so this rejection shouldn't count towards the hybrid

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -538,9 +538,11 @@ def _should_use_seer_match_for_grouping(
 
     Checks applied in order:
     - Exception type mismatch: rejects when event and parent have exception types whose difference
-      we're confident is meaningful (see `sentry.grouping.ingest.exception_types`). Other mismatches
-      are logged and accepted. Skipped for synthetic exceptions (matching regular grouping
-      behavior).
+      we're confident is meaningful (see `sentry.grouping.ingest.exception_types`), and the
+      `seer.similarity.ingest.reject_exception_type_mismatches` option is on. Every mismatch is
+      logged as `seer.exception_type_mismatch` with a `would_reject` verdict regardless of the
+      option; actual rejections additionally log `seer.exception_type_mismatch_rejected`. Skipped
+      for synthetic exceptions (matching regular grouping behavior).
     - Hybrid fingerprint compatibility: rejects when fingerprint types or values don't match.
     """
     parent_group = parent_grouphash.group
@@ -557,10 +559,15 @@ def _should_use_seer_match_for_grouping(
         mismatch_reason = classify_exception_type_mismatch(
             event_exception_type, parent_exception_type, event.platform
         )
-        # We only reject when the type difference is by itself proof that Seer got it wrong.
-        # Everything else falls through and is accepted, so we keep the (frequently useful) Seer
-        # matches that cross type boundaries while we narrow down further categories.
-        reject = mismatch_reason in REJECTING_REASONS and options.get(
+        # Two separate questions, deliberately kept apart. `would_reject` is the categorization's
+        # verdict: is this type difference by itself proof that Seer got it wrong? `reject` is
+        # whether we act on that verdict, which the option gates. Splitting them means the verdict
+        # is visible in the logs while the option is still off, so it can be validated before it
+        # starts splitting groups. Reasons other than the confident ones fall through and are
+        # accepted either way, keeping the (frequently useful) Seer matches that cross type
+        # boundaries while we narrow down further categories.
+        would_reject = mismatch_reason in REJECTING_REASONS
+        reject = would_reject and options.get(
             "seer.similarity.ingest.reject_exception_type_mismatches"
         )
 
@@ -573,26 +580,32 @@ def _should_use_seer_match_for_grouping(
                 "rejected": reject,
             },
         )
-        logger.info(
-            "seer.exception_type_mismatch",
-            extra={
-                "event_id": event.event_id,
-                "organization_id": event.project.organization_id,
-                "project_id": event.project.id,
-                "platform": event.platform,
-                "sdk": get_path(event.data, "sdk", "name"),
-                "event_exception_type": event_exception_type,
-                "event_exception_value": event_exception_value,
-                "parent_exception_type": parent_exception_type,
-                "parent_exception_value": get_path(parent_group.data, "metadata", "value"),
-                "parent_group_id": parent_group.id,
-                "parent_hash": parent_grouphash.hash,
-                "mismatch_reason": mismatch_reason.value,
-                "rejected": reject,
-            },
-        )
+
+        mismatch_log_context = {
+            "event_id": event.event_id,
+            "organization_id": event.project.organization_id,
+            "project_id": event.project.id,
+            "platform": event.platform,
+            "sdk": get_path(event.data, "sdk", "name"),
+            "event_exception_type": event_exception_type,
+            "event_exception_value": event_exception_value,
+            "parent_exception_type": parent_exception_type,
+            "parent_exception_value": get_path(parent_group.data, "metadata", "value"),
+            "parent_group_id": parent_group.id,
+            "parent_hash": parent_grouphash.hash,
+            "mismatch_reason": mismatch_reason.value,
+            "would_reject": would_reject,
+        }
+
+        # Emitted for every mismatch, whatever we do about it. `would_reject` is the verdict, so
+        # this is the log to query when assessing what turning the option on would separate.
+        logger.info("seer.exception_type_mismatch", extra=mismatch_log_context)
 
         if reject:
+            # Emitted only when the match is actually rejected — i.e. a new group is about to be
+            # created that today's behavior would have merged.
+            logger.info("seer.exception_type_mismatch_rejected", extra=mismatch_log_context)
+
             # Not hybrid-fingerprint-related, so this rejection shouldn't count towards the hybrid
             # fingerprint metrics.
             return SeerMatchResult(accepted=False, hybrid_related=False)

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -11,6 +11,10 @@ from sentry import ratelimits as ratelimiter
 from sentry.eventtypes.error import ErrorEvent
 from sentry.grouping.fingerprinting.utils import get_fingerprint_type
 from sentry.grouping.grouping_info import get_grouping_info_from_variants_legacy
+from sentry.grouping.ingest.exception_types import (
+    REJECTING_REASONS,
+    classify_exception_type_mismatch,
+)
 from sentry.grouping.ingest.grouphash_metadata import (
     check_grouphashes_for_positive_fingerprint_match,
 )
@@ -533,13 +537,12 @@ def _should_use_seer_match_for_grouping(
     check is hybrid-fingerprint-related (for metrics accounting).
 
     Checks applied in order:
-    - Exception type mismatch: rejects when event and parent have different exception types.
-      Skipped for synthetic exceptions (matching regular grouping behavior).
+    - Exception type mismatch: rejects when event and parent have exception types whose difference
+      we're confident is meaningful (see `sentry.grouping.ingest.exception_types`). Other mismatches
+      are logged and accepted. Skipped for synthetic exceptions (matching regular grouping
+      behavior).
     - Hybrid fingerprint compatibility: rejects when fingerprint types or values don't match.
     """
-    # Exception type check — log mismatches for now so we can assess how often Seer matches
-    # across different exception types before deciding whether to reject them.
-
     parent_group = parent_grouphash.group
     if parent_group is None:
         raise SimilarHashMissingGroupError(
@@ -551,10 +554,24 @@ def _should_use_seer_match_for_grouping(
         and parent_exception_type
         and event_exception_type != parent_exception_type
     ):
+        mismatch_reason = classify_exception_type_mismatch(
+            event_exception_type, parent_exception_type, event.platform
+        )
+        # We only reject when the type difference is by itself proof that Seer got it wrong.
+        # Everything else falls through and is accepted, so we keep the (frequently useful) Seer
+        # matches that cross type boundaries while we narrow down further categories.
+        reject = mismatch_reason in REJECTING_REASONS and options.get(
+            "seer.similarity.ingest.reject_exception_type_mismatches"
+        )
+
         metrics.incr(
             "grouping.similarity.exception_type_mismatch",
             sample_rate=options.get("seer.similarity.metrics_sample_rate"),
-            tags={"platform": event.platform},
+            tags={
+                "platform": event.platform,
+                "reason": mismatch_reason.value,
+                "rejected": reject,
+            },
         )
         logger.info(
             "seer.exception_type_mismatch",
@@ -570,8 +587,15 @@ def _should_use_seer_match_for_grouping(
                 "parent_exception_value": get_path(parent_group.data, "metadata", "value"),
                 "parent_group_id": parent_group.id,
                 "parent_hash": parent_grouphash.hash,
+                "mismatch_reason": mismatch_reason.value,
+                "rejected": reject,
             },
         )
+
+        if reject:
+            # Not hybrid-fingerprint-related, so this rejection shouldn't count towards the hybrid
+            # fingerprint metrics.
+            return SeerMatchResult(accepted=False, hybrid_related=False)
 
     parent_has_hybrid_fingerprint = (
         get_fingerprint_type(parent_grouphash.get_associated_fingerprint()) == "hybrid"

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -590,8 +590,6 @@ def _should_use_seer_match_for_grouping(
             "would_reject": would_reject,
         }
 
-        # Emitted for every mismatch; query `would_reject` to see what enabling the option would
-        # separate.
         logger.info("seer.exception_type_mismatch", extra=mismatch_log_context)
 
         if reject:

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1197,6 +1197,17 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Whether to reject Seer matches whose exception type differs from the parent's in a way we're
+# confident is meaningful (see `sentry.grouping.ingest.exception_types`). Off by default so the
+# categorization can be validated against the `seer.exception_type_mismatch` logs before it starts
+# splitting groups; mismatches are logged either way.
+register(
+    "seer.similarity.ingest.reject_exception_type_mismatches",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 
 # TODO: Once Seer grouping is GA-ed, we probably either want to turn this down or get rid of it in
 # favor of the default 10% sample rate

--- a/tests/sentry/grouping/seer_similarity/test_get_seer_similar_issues.py
+++ b/tests/sentry/grouping/seer_similarity/test_get_seer_similar_issues.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, call, patch
 from sentry import options
 from sentry.conf.server import DEFAULT_GROUPING_CONFIG
 from sentry.grouping.grouping_info import get_grouping_info_from_variants_legacy
-from sentry.grouping.ingest.exception_types import MismatchReason
+from sentry.grouping.ingest.exception_types import REJECTING_REASONS, MismatchReason
 from sentry.grouping.ingest.grouphash_metadata import create_or_update_grouphash_metadata_if_needed
 from sentry.grouping.ingest.seer import get_seer_similar_issues
 from sentry.grouping.variants import BaseVariant
@@ -698,10 +698,14 @@ class ExceptionTypeMismatchTest(TestCase):
         """Run a single Seer match against a parent with `parent_type` and assert the outcome.
 
         `expected_match` controls whether the match is used (vs rejected), and
-        `expect_mismatch_metric` whether the exception-type mismatch metric is recorded (with
-        `expected_reason` as its reason tag). `reject_enabled` sets the option controlling whether
-        rejecting reasons actually reject. The incoming event is built by `create_new_event` with
-        `new_type`, unless a fully-built `new_event` is passed instead.
+        `expect_mismatch_metric` whether the exception-type mismatch metric and detection log are
+        recorded (with `expected_reason` as the reason). `reject_enabled` sets the option controlling
+        whether rejecting reasons actually reject. The incoming event is built by `create_new_event`
+        with `new_type`, unless a fully-built `new_event` is passed instead.
+
+        Also asserts the two logs stay distinct: the detection log carries a `would_reject` verdict
+        independent of the option, while the rejection log is emitted only when the match is really
+        rejected.
         """
         existing_event = self._create_existing_event(
             error_type=parent_type, synthetic=parent_synthetic
@@ -732,6 +736,7 @@ class ExceptionTypeMismatchTest(TestCase):
 
         with (
             patch("sentry.grouping.ingest.seer.metrics.incr") as mock_incr,
+            patch("sentry.grouping.ingest.seer.logger.info") as mock_logger_info,
             patch(
                 "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
                 return_value=(seer_result_data, "v1"),
@@ -746,6 +751,8 @@ class ExceptionTypeMismatchTest(TestCase):
             (0.01, existing_grouphash, "v1") if expected_match else (None, None, "v1")
         )
 
+        logged_events = [call.args[0] for call in mock_logger_info.mock_calls]
+
         if expect_mismatch_metric:
             assert expected_reason is not None
             mock_incr.assert_any_call(
@@ -757,9 +764,22 @@ class ExceptionTypeMismatchTest(TestCase):
                     "rejected": not expected_match,
                 },
             )
+            # The detection log records the verdict, which doesn't depend on the option.
+            assert "seer.exception_type_mismatch" in logged_events
+            detection_extra = next(
+                call.kwargs["extra"]
+                for call in mock_logger_info.mock_calls
+                if call.args[0] == "seer.exception_type_mismatch"
+            )
+            assert detection_extra["mismatch_reason"] == expected_reason.value
+            assert detection_extra["would_reject"] == (expected_reason in REJECTING_REASONS)
         else:
             recorded = {call.args[0] for call in mock_incr.mock_calls}
             assert "grouping.similarity.exception_type_mismatch" not in recorded
+            assert "seer.exception_type_mismatch" not in logged_events
+
+        # The rejection log is emitted if and only if we really rejected.
+        assert ("seer.exception_type_mismatch_rejected" in logged_events) == (not expected_match)
 
     def test_rejects_match_with_different_exception_type(self) -> None:
         # create_new_event uses "FailedToFetchError"; both it and "TypeError" are distinct, stable,

--- a/tests/sentry/grouping/seer_similarity/test_get_seer_similar_issues.py
+++ b/tests/sentry/grouping/seer_similarity/test_get_seer_similar_issues.py
@@ -764,7 +764,7 @@ class ExceptionTypeMismatchTest(TestCase):
                     "rejected": not expected_match,
                 },
             )
-            # The detection log records the verdict, which doesn't depend on the option.
+            # The verdict is logged regardless of the option.
             assert "seer.exception_type_mismatch" in logged_events
             detection_extra = next(
                 call.kwargs["extra"]
@@ -782,8 +782,6 @@ class ExceptionTypeMismatchTest(TestCase):
         assert ("seer.exception_type_mismatch_rejected" in logged_events) == (not expected_match)
 
     def test_rejects_match_with_different_exception_type(self) -> None:
-        # create_new_event uses "FailedToFetchError"; both it and "TypeError" are distinct, stable,
-        # single-token names on a stable platform, so the mismatch is proof Seer got it wrong.
         self._assert_match_result(
             parent_type="TypeError",
             expected_match=False,
@@ -793,14 +791,11 @@ class ExceptionTypeMismatchTest(TestCase):
         )
 
     def test_accepts_match_with_same_exception_type(self) -> None:
-        # create_new_event uses exception type "FailedToFetchError", matching the parent.
         self._assert_match_result(
             parent_type="FailedToFetchError", expected_match=True, expect_mismatch_metric=False
         )
 
     def test_logs_mismatch_but_still_accepts_when_option_is_off(self) -> None:
-        # Same mismatch as `test_rejects_match_with_different_exception_type`, but with the option
-        # off (the default) it stays log-only.
         self._assert_match_result(
             parent_type="TypeError",
             expected_match=True,
@@ -810,8 +805,7 @@ class ExceptionTypeMismatchTest(TestCase):
         )
 
     def test_logs_mismatch_but_still_accepts_uncertain_category(self) -> None:
-        # "Failed To Fetch Error" contains whitespace, so we can't tell whether the difference from
-        # "FailedToFetchError" is meaningful. Accepted even with rejecting enabled.
+        # Whitespace makes the difference unjudgeable, so it's accepted even with rejecting on.
         self._assert_match_result(
             parent_type="Failed To Fetch Error",
             expected_match=True,
@@ -830,7 +824,6 @@ class ExceptionTypeMismatchTest(TestCase):
         )
 
     def test_skips_check_when_parent_has_no_type(self) -> None:
-        # The parent has no stored exception type (synthetic), so there's nothing to compare.
         self._assert_match_result(
             parent_type="Error",
             parent_synthetic=True,
@@ -839,8 +832,6 @@ class ExceptionTypeMismatchTest(TestCase):
         )
 
     def test_rejects_app_hang_of_differing_fatality(self) -> None:
-        # A fatal hang (app killed) and a non-fatal one (app recovered) are different events for the
-        # user even with identical stacktraces.
         self._assert_match_result(
             parent_type="App Hang Fully Blocked",
             new_type="Fatal App Hang Fully Blocked",
@@ -851,8 +842,7 @@ class ExceptionTypeMismatchTest(TestCase):
         )
 
     def test_accepts_app_hang_differing_only_in_blocked_dimension(self) -> None:
-        # The blocked/non-fully-blocked dimension isn't confirmed yet, so it doesn't reject even with
-        # rejecting enabled.
+        # Only fatality rejects; the blocked dimension isn't confirmed yet.
         self._assert_match_result(
             parent_type="Fatal App Hang Non Fully Blocked",
             new_type="Fatal App Hang Fully Blocked",

--- a/tests/sentry/grouping/seer_similarity/test_get_seer_similar_issues.py
+++ b/tests/sentry/grouping/seer_similarity/test_get_seer_similar_issues.py
@@ -1,11 +1,10 @@
 from typing import Any
 from unittest.mock import MagicMock, call, patch
 
-import pytest
-
 from sentry import options
 from sentry.conf.server import DEFAULT_GROUPING_CONFIG
 from sentry.grouping.grouping_info import get_grouping_info_from_variants_legacy
+from sentry.grouping.ingest.exception_types import MismatchReason
 from sentry.grouping.ingest.grouphash_metadata import create_or_update_grouphash_metadata_if_needed
 from sentry.grouping.ingest.seer import get_seer_similar_issues
 from sentry.grouping.variants import BaseVariant
@@ -17,6 +16,7 @@ from sentry.seer.similarity.utils import get_stacktrace_string
 from sentry.services.eventstore.models import Event
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.eventprocessing import save_new_event
+from sentry.testutils.helpers.options import override_options
 
 
 def create_new_event(
@@ -24,8 +24,8 @@ def create_new_event(
     num_frames: int = 1,
     stacktrace_string: str | None = None,
     fingerprint: list[str] | None = None,
+    error_type: str = "FailedToFetchError",
 ) -> tuple[Event, dict[str, BaseVariant], GroupHash, str]:
-    error_type = "FailedToFetchError"
     error_value = "Charlie didn't bring the ball back"
     event = Event(
         project_id=project.id,
@@ -689,14 +689,19 @@ class ExceptionTypeMismatchTest(TestCase):
         parent_type: str,
         expected_match: bool,
         expect_mismatch_metric: bool,
+        expected_reason: MismatchReason | None = None,
+        reject_enabled: bool = False,
         parent_synthetic: bool = False,
+        new_type: str = "FailedToFetchError",
         new_event: Event | None = None,
     ) -> None:
         """Run a single Seer match against a parent with `parent_type` and assert the outcome.
 
         `expected_match` controls whether the match is used (vs rejected), and
-        `expect_mismatch_metric` whether the exception-type mismatch metric is recorded. When
-        `new_event` is omitted, the default `create_new_event` (type "FailedToFetchError") is used.
+        `expect_mismatch_metric` whether the exception-type mismatch metric is recorded (with
+        `expected_reason` as its reason tag). `reject_enabled` sets the option controlling whether
+        rejecting reasons actually reject. The incoming event is built by `create_new_event` with
+        `new_type`, unless a fully-built `new_event` is passed instead.
         """
         existing_event = self._create_existing_event(
             error_type=parent_type, synthetic=parent_synthetic
@@ -707,7 +712,9 @@ class ExceptionTypeMismatchTest(TestCase):
         ).first()
 
         if new_event is None:
-            new_event, new_variants, new_grouphash, _ = create_new_event(self.project)
+            new_event, new_variants, new_grouphash, _ = create_new_event(
+                self.project, error_type=new_type
+            )
         else:
             new_variants = new_event.get_grouping_variants()
             new_grouphash = GroupHash.objects.create(
@@ -729,6 +736,9 @@ class ExceptionTypeMismatchTest(TestCase):
                 "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
                 return_value=(seer_result_data, "v1"),
             ),
+            override_options(
+                {"seer.similarity.ingest.reject_exception_type_mismatches": reject_enabled}
+            ),
         ):
             result = get_seer_similar_issues(new_event, new_grouphash, new_variants)
 
@@ -737,19 +747,29 @@ class ExceptionTypeMismatchTest(TestCase):
         )
 
         if expect_mismatch_metric:
+            assert expected_reason is not None
             mock_incr.assert_any_call(
                 "grouping.similarity.exception_type_mismatch",
                 sample_rate=options.get("seer.similarity.metrics_sample_rate"),
-                tags={"platform": "python"},
+                tags={
+                    "platform": "python",
+                    "reason": expected_reason.value,
+                    "rejected": not expected_match,
+                },
             )
         else:
             recorded = {call.args[0] for call in mock_incr.mock_calls}
             assert "grouping.similarity.exception_type_mismatch" not in recorded
 
-    @pytest.mark.skip(reason="Exception type mismatch currently logs only, not rejecting yet")
     def test_rejects_match_with_different_exception_type(self) -> None:
+        # create_new_event uses "FailedToFetchError"; both it and "TypeError" are distinct, stable,
+        # single-token names on a stable platform, so the mismatch is proof Seer got it wrong.
         self._assert_match_result(
-            parent_type="TypeError", expected_match=False, expect_mismatch_metric=True
+            parent_type="TypeError",
+            expected_match=False,
+            expect_mismatch_metric=True,
+            expected_reason=MismatchReason.DISTINCT_TYPE_NAMES,
+            reject_enabled=True,
         )
 
     def test_accepts_match_with_same_exception_type(self) -> None:
@@ -758,11 +778,26 @@ class ExceptionTypeMismatchTest(TestCase):
             parent_type="FailedToFetchError", expected_match=True, expect_mismatch_metric=False
         )
 
-    def test_logs_mismatch_but_still_accepts(self) -> None:
-        # create_new_event uses "FailedToFetchError", differing from "TypeError". The check is
-        # log-only for now: it records the metric but the match is still used.
+    def test_logs_mismatch_but_still_accepts_when_option_is_off(self) -> None:
+        # Same mismatch as `test_rejects_match_with_different_exception_type`, but with the option
+        # off (the default) it stays log-only.
         self._assert_match_result(
-            parent_type="TypeError", expected_match=True, expect_mismatch_metric=True
+            parent_type="TypeError",
+            expected_match=True,
+            expect_mismatch_metric=True,
+            expected_reason=MismatchReason.DISTINCT_TYPE_NAMES,
+            reject_enabled=False,
+        )
+
+    def test_logs_mismatch_but_still_accepts_uncertain_category(self) -> None:
+        # "Failed To Fetch Error" contains whitespace, so we can't tell whether the difference from
+        # "FailedToFetchError" is meaningful. Accepted even with rejecting enabled.
+        self._assert_match_result(
+            parent_type="Failed To Fetch Error",
+            expected_match=True,
+            expect_mismatch_metric=True,
+            expected_reason=MismatchReason.CONTAINS_WHITESPACE,
+            reject_enabled=True,
         )
 
     def test_skips_check_for_synthetic_incoming_event(self) -> None:
@@ -781,6 +816,30 @@ class ExceptionTypeMismatchTest(TestCase):
             parent_synthetic=True,
             expected_match=True,
             expect_mismatch_metric=False,
+        )
+
+    def test_rejects_app_hang_of_differing_fatality(self) -> None:
+        # A fatal hang (app killed) and a non-fatal one (app recovered) are different events for the
+        # user even with identical stacktraces.
+        self._assert_match_result(
+            parent_type="App Hang Fully Blocked",
+            new_type="Fatal App Hang Fully Blocked",
+            expected_match=False,
+            expect_mismatch_metric=True,
+            expected_reason=MismatchReason.APP_HANG_FATALITY,
+            reject_enabled=True,
+        )
+
+    def test_accepts_app_hang_differing_only_in_blocked_dimension(self) -> None:
+        # The blocked/non-fully-blocked dimension isn't confirmed yet, so it doesn't reject even with
+        # rejecting enabled.
+        self._assert_match_result(
+            parent_type="Fatal App Hang Non Fully Blocked",
+            new_type="Fatal App Hang Fully Blocked",
+            expected_match=True,
+            expect_mismatch_metric=True,
+            expected_reason=MismatchReason.APP_HANG_OTHER,
+            reject_enabled=True,
         )
 
 

--- a/tests/sentry/grouping/test_exception_types.py
+++ b/tests/sentry/grouping/test_exception_types.py
@@ -10,12 +10,10 @@ from sentry.grouping.ingest.exception_types import (
 @pytest.mark.parametrize(
     "event_type,parent_type",
     [
-        # Fatal vs non-fatal, both spellings of the blocked dimension
         ("Fatal App Hang Fully Blocked", "App Hang Fully Blocked"),
         ("App Hang Non Fully Blocked", "Fatal App Hang Non Fully Blocked"),
-        # Fatality still decides even when the blocked dimension also differs
+        # Fatality still decides when the blocked dimension or the spelling also differs
         ("Fatal App Hang Fully Blocked", "App Hang Non Fully Blocked"),
-        # ...and across the older "Hanging" spelling
         ("Fatal App Hanging", "App Hang Fully Blocked"),
     ],
     ids=str,
@@ -30,10 +28,10 @@ def test_rejects_app_hangs_of_differing_fatality(event_type: str, parent_type: s
 @pytest.mark.parametrize(
     "event_type,parent_type",
     [
-        # Blocked dimension alone — unconfirmed, so accepted for now
+        # Blocked dimension alone
         ("Fatal App Hang Fully Blocked", "Fatal App Hang Non Fully Blocked"),
         ("App Hang Fully Blocked", "App Hang Non Fully Blocked"),
-        # "Hang" vs "Hanging" from differing SDK versions
+        # "Hang" vs "Hanging", from differing SDK versions
         ("App Hanging", "App Hang Fully Blocked"),
         ("Fatal App Hanging", "Fatal App Hang Fully Blocked"),
     ],
@@ -57,8 +55,7 @@ def test_app_hang_check_is_case_insensitive() -> None:
 
 
 def test_app_hang_check_ignores_platform() -> None:
-    # Fatality is meaningful regardless of platform, unlike the type-name comparison. (Hangs come
-    # from Cocoa today, but nothing here depends on that.)
+    # Unlike the type-name comparison, fatality is meaningful on any platform.
     reason = classify_exception_type_mismatch(
         "Fatal App Hang Fully Blocked", "App Hang Fully Blocked", "javascript"
     )
@@ -67,7 +64,6 @@ def test_app_hang_check_ignores_platform() -> None:
 
 
 def test_type_merely_starting_with_app_hang_words_is_not_a_hang() -> None:
-    # The word boundary keeps us from treating an ordinary identifier as a hang type.
     reason = classify_exception_type_mismatch("AppHangaroo", "AppHangaloo", "python")
 
     assert reason == MismatchReason.DISTINCT_TYPE_NAMES
@@ -78,12 +74,9 @@ def test_type_merely_starting_with_app_hang_words_is_not_a_hang() -> None:
     [
         ("ValueError", "TypeError"),
         ("OSError", "IOError"),
-        # Fully-qualified names
         ("java.lang.NullPointerException", "java.lang.IllegalStateException"),
-        # `Namespace::Type` — no separate rule needed, `::` neither contains whitespace nor
-        # parameterizes
         ("RestClient::BadRequest", "RestClient::NotFound"),
-        # Digits that don't parameterize because they're mid-token
+        # Digits that don't parameterize, because they're mid-token
         ("Error1234", "Error5678"),
         ("HTTP404", "HTTP500"),
         ("Timeout30s", "Timeout60s"),
@@ -124,11 +117,11 @@ def test_accepts_types_differing_only_in_variable_data(event_type: str, parent_t
 @pytest.mark.parametrize(
     "event_type,parent_type",
     [
-        # A message stuffed into the `type` field, differing by a severity prefix...
+        # Messages stuffed into the `type` field, differing by a severity prefix or an appended
+        # value
         ("Fatal error in worker", "Error in worker"),
-        # ...or by an appended value
         ("Error: Get Order Delivery", "Error: Get Order Refund"),
-        # Only one side needs whitespace to make the pair unsafe to judge
+        # Only one side needs whitespace
         ("SomeError: it broke", "SomeError"),
     ],
     ids=str,
@@ -142,7 +135,6 @@ def test_accepts_types_containing_whitespace(event_type: str, parent_type: str) 
 
 @pytest.mark.parametrize("platform", ["javascript", "node", "cocoa", "android", None, "other"])
 def test_accepts_distinct_type_names_on_unstable_platforms(platform: str | None) -> None:
-    # Minifiers rename classes per build, so two different short names may be the same type.
     reason = classify_exception_type_mismatch("V", "bm", platform)
 
     assert reason == MismatchReason.UNSTABLE_PLATFORM
@@ -160,8 +152,7 @@ def test_accepts_distinct_type_names_on_unstable_platforms(platform: str | None)
 def test_accepts_when_either_type_is_the_generic_placeholder(
     event_type: str, parent_type: str
 ) -> None:
-    # `ErrorEvent.extract_metadata` defaults a missing type to "Error", so this means the type is
-    # absent rather than different.
+    # "Error" is what a *missing* type gets defaulted to, so it isn't a real difference.
     reason = classify_exception_type_mismatch(event_type, parent_type, "python")
 
     assert reason == MismatchReason.GENERIC_PLACEHOLDER

--- a/tests/sentry/grouping/test_exception_types.py
+++ b/tests/sentry/grouping/test_exception_types.py
@@ -74,7 +74,6 @@ def test_type_merely_starting_with_app_hang_words_is_not_a_hang() -> None:
     [
         ("ValueError", "TypeError"),
         ("OSError", "IOError"),
-        ("java.lang.NullPointerException", "java.lang.IllegalStateException"),
         ("RestClient::BadRequest", "RestClient::NotFound"),
         # Digits that don't parameterize, because they're mid-token
         ("Error1234", "Error5678"),
@@ -136,6 +135,26 @@ def test_accepts_types_containing_whitespace(event_type: str, parent_type: str) 
 @pytest.mark.parametrize("platform", ["javascript", "node", "cocoa", "android", None, "other"])
 def test_accepts_distinct_type_names_on_unstable_platforms(platform: str | None) -> None:
     reason = classify_exception_type_mismatch("V", "bm", platform)
+
+    assert reason == MismatchReason.UNSTABLE_PLATFORM
+    assert reason not in REJECTING_REASONS
+
+
+@pytest.mark.parametrize(
+    "event_type,parent_type",
+    [
+        # Obfuscated class names, which can differ build to build without the underlying class
+        # changing
+        ("g$a", "bm$c"),
+        # Even fully-qualified names are only meaningful with a mapping applied
+        ("java.lang.NullPointerException", "java.lang.IllegalStateException"),
+    ],
+    ids=str,
+)
+def test_accepts_distinct_type_names_on_java(event_type: str, parent_type: str) -> None:
+    # Android events come through as `java`, and their types stay obfuscated when no ProGuard/R8
+    # mapping has been applied.
+    reason = classify_exception_type_mismatch(event_type, parent_type, "java")
 
     assert reason == MismatchReason.UNSTABLE_PLATFORM
     assert reason not in REJECTING_REASONS

--- a/tests/sentry/grouping/test_exception_types.py
+++ b/tests/sentry/grouping/test_exception_types.py
@@ -1,0 +1,175 @@
+import pytest
+
+from sentry.grouping.ingest.exception_types import (
+    REJECTING_REASONS,
+    MismatchReason,
+    classify_exception_type_mismatch,
+)
+
+
+@pytest.mark.parametrize(
+    "event_type,parent_type",
+    [
+        # Fatal vs non-fatal, both spellings of the blocked dimension
+        ("Fatal App Hang Fully Blocked", "App Hang Fully Blocked"),
+        ("App Hang Non Fully Blocked", "Fatal App Hang Non Fully Blocked"),
+        # Fatality still decides even when the blocked dimension also differs
+        ("Fatal App Hang Fully Blocked", "App Hang Non Fully Blocked"),
+        # ...and across the older "Hanging" spelling
+        ("Fatal App Hanging", "App Hang Fully Blocked"),
+    ],
+    ids=str,
+)
+def test_rejects_app_hangs_of_differing_fatality(event_type: str, parent_type: str) -> None:
+    reason = classify_exception_type_mismatch(event_type, parent_type, "cocoa")
+
+    assert reason == MismatchReason.APP_HANG_FATALITY
+    assert reason in REJECTING_REASONS
+
+
+@pytest.mark.parametrize(
+    "event_type,parent_type",
+    [
+        # Blocked dimension alone — unconfirmed, so accepted for now
+        ("Fatal App Hang Fully Blocked", "Fatal App Hang Non Fully Blocked"),
+        ("App Hang Fully Blocked", "App Hang Non Fully Blocked"),
+        # "Hang" vs "Hanging" from differing SDK versions
+        ("App Hanging", "App Hang Fully Blocked"),
+        ("Fatal App Hanging", "Fatal App Hang Fully Blocked"),
+    ],
+    ids=str,
+)
+def test_accepts_app_hang_differences_other_than_fatality(
+    event_type: str, parent_type: str
+) -> None:
+    reason = classify_exception_type_mismatch(event_type, parent_type, "cocoa")
+
+    assert reason == MismatchReason.APP_HANG_OTHER
+    assert reason not in REJECTING_REASONS
+
+
+def test_app_hang_check_is_case_insensitive() -> None:
+    reason = classify_exception_type_mismatch(
+        "FATAL APP HANG FULLY BLOCKED", "app hang fully blocked", "cocoa"
+    )
+
+    assert reason == MismatchReason.APP_HANG_FATALITY
+
+
+def test_app_hang_check_ignores_platform() -> None:
+    # Fatality is meaningful regardless of platform, unlike the type-name comparison. (Hangs come
+    # from Cocoa today, but nothing here depends on that.)
+    reason = classify_exception_type_mismatch(
+        "Fatal App Hang Fully Blocked", "App Hang Fully Blocked", "javascript"
+    )
+
+    assert reason == MismatchReason.APP_HANG_FATALITY
+
+
+def test_type_merely_starting_with_app_hang_words_is_not_a_hang() -> None:
+    # The word boundary keeps us from treating an ordinary identifier as a hang type.
+    reason = classify_exception_type_mismatch("AppHangaroo", "AppHangaloo", "python")
+
+    assert reason == MismatchReason.DISTINCT_TYPE_NAMES
+
+
+@pytest.mark.parametrize(
+    "event_type,parent_type",
+    [
+        ("ValueError", "TypeError"),
+        ("OSError", "IOError"),
+        # Fully-qualified names
+        ("java.lang.NullPointerException", "java.lang.IllegalStateException"),
+        # `Namespace::Type` — no separate rule needed, `::` neither contains whitespace nor
+        # parameterizes
+        ("RestClient::BadRequest", "RestClient::NotFound"),
+        # Digits that don't parameterize because they're mid-token
+        ("Error1234", "Error5678"),
+        ("HTTP404", "HTTP500"),
+        ("Timeout30s", "Timeout60s"),
+    ],
+    ids=str,
+)
+def test_rejects_distinct_stable_type_names(event_type: str, parent_type: str) -> None:
+    reason = classify_exception_type_mismatch(event_type, parent_type, "python")
+
+    assert reason == MismatchReason.DISTINCT_TYPE_NAMES
+    assert reason in REJECTING_REASONS
+
+
+@pytest.mark.parametrize(
+    "event_type,parent_type",
+    [
+        # Runtime-generated JVM lambda and anonymous class names
+        (
+            "com.example.Foo$$Lambda$14/0x00000008000c1440",
+            "com.example.Foo$$Lambda$27/0x00000008000d9920",
+        ),
+        ("Module$$Anonymous$a1b2c3", "Module$$Anonymous$d4e5f6"),
+        # Embedded hex / ints / IDs
+        ("Error_a3f2b1", "Error_c9d4e7"),
+        ("Chunk_12", "Chunk_34"),
+        ("ErrorCode0x1F3A", "ErrorCode0x2B4C"),
+        ("Err-3f8a9c2b1d4e5f6a", "Err-9b2c4d6e8f0a1b3c"),
+    ],
+    ids=str,
+)
+def test_accepts_types_differing_only_in_variable_data(event_type: str, parent_type: str) -> None:
+    reason = classify_exception_type_mismatch(event_type, parent_type, "python")
+
+    assert reason == MismatchReason.PARAMETERIZES_EQUAL
+    assert reason not in REJECTING_REASONS
+
+
+@pytest.mark.parametrize(
+    "event_type,parent_type",
+    [
+        # A message stuffed into the `type` field, differing by a severity prefix...
+        ("Fatal error in worker", "Error in worker"),
+        # ...or by an appended value
+        ("Error: Get Order Delivery", "Error: Get Order Refund"),
+        # Only one side needs whitespace to make the pair unsafe to judge
+        ("SomeError: it broke", "SomeError"),
+    ],
+    ids=str,
+)
+def test_accepts_types_containing_whitespace(event_type: str, parent_type: str) -> None:
+    reason = classify_exception_type_mismatch(event_type, parent_type, "python")
+
+    assert reason == MismatchReason.CONTAINS_WHITESPACE
+    assert reason not in REJECTING_REASONS
+
+
+@pytest.mark.parametrize("platform", ["javascript", "node", "cocoa", "android", None, "other"])
+def test_accepts_distinct_type_names_on_unstable_platforms(platform: str | None) -> None:
+    # Minifiers rename classes per build, so two different short names may be the same type.
+    reason = classify_exception_type_mismatch("V", "bm", platform)
+
+    assert reason == MismatchReason.UNSTABLE_PLATFORM
+    assert reason not in REJECTING_REASONS
+
+
+@pytest.mark.parametrize(
+    "event_type,parent_type",
+    [
+        ("Error", "ValueError"),
+        ("ValueError", "Error"),
+    ],
+    ids=str,
+)
+def test_accepts_when_either_type_is_the_generic_placeholder(
+    event_type: str, parent_type: str
+) -> None:
+    # `ErrorEvent.extract_metadata` defaults a missing type to "Error", so this means the type is
+    # absent rather than different.
+    reason = classify_exception_type_mismatch(event_type, parent_type, "python")
+
+    assert reason == MismatchReason.GENERIC_PLACEHOLDER
+    assert reason not in REJECTING_REASONS
+
+
+def test_generic_placeholder_check_is_exact() -> None:
+    # "Error" is only a placeholder on its own; a type that merely contains it is a real name.
+    reason = classify_exception_type_mismatch("ErrorLike", "Errors", "python")
+
+    assert reason == MismatchReason.DISTINCT_TYPE_NAMES


### PR DESCRIPTION
## Context

Baseline (hash-based) grouping treats `exception.type` as a hard grouping input: two events with different types never share a hash. Seer ignores the type entirely and matches on stacktrace similarity, which is frequently what we want — it rescues events whose stacktraces drifted (minified frames, changing paths, inlined frames) but which are the same underlying bug.

We've been logging type mismatches in `_should_use_seer_match_for_grouping` rather than acting on them, precisely because those rescues are valuable. But sometimes the type difference really does mean two separate problems, and merging them hides one behind the other — most visibly for Cocoa app hangs, where a fatal hang and a recoverable one end up in the same group.

Rejecting is not free: with `seer.similarity.ingest.num_matches_to_request` set to 1 there is no runner-up candidate, so every rejection opens a brand-new group. That asymmetry is why this starts small.

## What this does

Categorizes each type mismatch and rejects only the narrow subset where **the type difference is by itself proof that Seer got it wrong**. Two categories qualify today: app hangs that differ in fatality, and distinct type names on platforms where those names are stable and hand-written.

Everything else keeps being accepted, but is now categorized and logged with a reason — minified names, whitespace-bearing types, names differing only in embedded variable data, and so on. Those reasons are how we narrow further, from real data rather than guesses.

## Rollout

Gated behind `seer.similarity.ingest.reject_exception_type_mismatches`, off by default and `FLAG_AUTOMATOR_MODIFIABLE`. Categorization is unconditional — only the *action* is gated — so this can be deployed, observed, and then enabled.

Observability keeps "is this difference meaningful?" separate from "did we act on it?", since the option collapses the second while it's off:

- `seer.exception_type_mismatch` log — every mismatch, with a `would_reject` verdict. Query this to see what enabling the option would separate, while it's still off.
- `seer.exception_type_mismatch_rejected` log — only on a real rejection.
- `grouping.similarity.exception_type_mismatch` metric — tagged `reason` / `rejected`, for volume per reason and platform.


Part of ID-1654.
