### PR TITLE
fix(gdd): Use generate_project_derived_data in backfill

### DIFF
--- a/src/sentry/tasks/backfill_group_action_log.py
+++ b/src/sentry/tasks/backfill_group_action_log.py
@@ -339,6 +339,6 @@ def _complete_project_backfill(project: Project, chain_pr_lifecycle: bool) -> No
 
         backfill_pr_lifecycle_action_log_for_project.delay(project_id=project.id)
     else:
-        from sentry.issues.derived.tasks import process_project_derived_data
+        from sentry.issues.derived.tasks import generate_project_derived_data
 
-        process_project_derived_data.delay(project_id=project.id)
+        generate_project_derived_data.delay(project_id=project.id)

--- a/src/sentry/tasks/backfill_pr_lifecycle_action_log.py
+++ b/src/sentry/tasks/backfill_pr_lifecycle_action_log.py
@@ -134,7 +134,7 @@ def _backfill_project(
     activation_id: str | None = None,
 ) -> None:
     from sentry.issues.action_log.backfill import backfill_group_pr_lifecycle
-    from sentry.issues.derived.tasks import process_project_derived_data
+    from sentry.issues.derived.tasks import generate_project_derived_data
 
     batch_size: int = options.get("issues.backfill_pr_lifecycle_action_log.batch_size")
     inter_batch_delay_s: int = options.get(
@@ -165,7 +165,7 @@ def _backfill_project(
             "backfill_pr_lifecycle_action_log.project_completed",
             extra={"project_id": project.id},
         )
-        process_project_derived_data.delay(project_id=project.id)
+        generate_project_derived_data.delay(project_id=project.id)
         return
 
     total_created = 0
@@ -202,4 +202,4 @@ def _backfill_project(
             "backfill_pr_lifecycle_action_log.project_completed",
             extra={"project_id": project.id},
         )
-        process_project_derived_data.delay(project_id=project.id)
+        generate_project_derived_data.delay(project_id=project.id)

--- a/tests/sentry/tasks/test_backfill_group_action_log.py
+++ b/tests/sentry/tasks/test_backfill_group_action_log.py
@@ -475,7 +475,7 @@ class BackfillGroupActionLogForProjectTest(TestCase):
 
         mock_reset.assert_not_called()
 
-    @patch("sentry.issues.derived.tasks.process_project_derived_data.delay")
+    @patch("sentry.issues.derived.tasks.generate_project_derived_data.delay")
     def test_triggers_derived_data_on_completion(self, mock_derived: Any) -> None:
         with self._options():
             backfill_group_action_log_for_project(self.project.id)
@@ -489,7 +489,9 @@ class BackfillGroupActionLogForProjectTest(TestCase):
                 "sentry.tasks.backfill_pr_lifecycle_action_log."
                 "backfill_pr_lifecycle_action_log_for_project.delay"
             ) as mock_pr_lifecycle,
-            patch("sentry.issues.derived.tasks.process_project_derived_data.delay") as mock_derived,
+            patch(
+                "sentry.issues.derived.tasks.generate_project_derived_data.delay"
+            ) as mock_derived,
         ):
             backfill_group_action_log_for_project(
                 self.project.id,
@@ -508,7 +510,9 @@ class BackfillGroupActionLogForProjectTest(TestCase):
                 "sentry.tasks.backfill_pr_lifecycle_action_log."
                 "backfill_pr_lifecycle_action_log_for_project.delay"
             ) as mock_pr_lifecycle,
-            patch("sentry.issues.derived.tasks.process_project_derived_data.delay") as mock_derived,
+            patch(
+                "sentry.issues.derived.tasks.generate_project_derived_data.delay"
+            ) as mock_derived,
         ):
             backfill_group_action_log_for_project(
                 self.project.id,

--- a/tests/sentry/tasks/test_backfill_pr_lifecycle_action_log.py
+++ b/tests/sentry/tasks/test_backfill_pr_lifecycle_action_log.py
@@ -90,7 +90,9 @@ class BackfillPullRequestLifecycleActionLogTest(TestCase):
         with (
             self._options(),
             patch.object(backfill_pr_lifecycle_action_log_for_project, "apply_async"),
-            patch("sentry.issues.derived.tasks.process_project_derived_data.delay") as mock_derived,
+            patch(
+                "sentry.issues.derived.tasks.generate_project_derived_data.delay"
+            ) as mock_derived,
         ):
             backfill_pr_lifecycle_action_log_for_project(self.project.id)
 
@@ -120,7 +122,9 @@ class BackfillPullRequestLifecycleActionLogTest(TestCase):
                 backfill_pr_lifecycle_action_log_for_project,
                 "apply_async",
             ) as mock_apply,
-            patch("sentry.issues.derived.tasks.process_project_derived_data.delay") as mock_derived,
+            patch(
+                "sentry.issues.derived.tasks.generate_project_derived_data.delay"
+            ) as mock_derived,
         ):
             backfill_pr_lifecycle_action_log_for_project(self.project.id)
 
@@ -138,7 +142,9 @@ class BackfillPullRequestLifecycleActionLogTest(TestCase):
     def test_project_task_processes_derived_data_when_complete(self) -> None:
         with (
             self._options(),
-            patch("sentry.issues.derived.tasks.process_project_derived_data.delay") as mock_derived,
+            patch(
+                "sentry.issues.derived.tasks.generate_project_derived_data.delay"
+            ) as mock_derived,
         ):
             backfill_pr_lifecycle_action_log_for_project(self.project.id)
 
@@ -156,7 +162,7 @@ class BackfillPullRequestLifecycleActionLogTest(TestCase):
 
         with (
             self._options(),
-            patch("sentry.issues.derived.tasks.process_project_derived_data.delay"),
+            patch("sentry.issues.derived.tasks.generate_project_derived_data.delay"),
         ):
             backfill_pr_lifecycle_action_log_for_project(self.project.id, reset=True)
 


### PR DESCRIPTION
The old "create if missing" task is going away, and the new one is more correct and useful.
It's also doing too much work by default, but we can fix that later.
