### PR TITLE
feat(seer): Score non-top predictions properly, score team/shared-team differently

### DIFF
--- a/src/sentry/seer/smart_assignment/completion.py
+++ b/src/sentry/seer/smart_assignment/completion.py
@@ -27,25 +27,6 @@ def process_smart_assignment_completion(group: Group, activity: Activity) -> Non
     run = (
         SeerAgentRun.objects.filter(run_id=seer_run_id).first() if seer_run_id is not None else None
     )
-    if run is not None:
-        # Save the prediction to the run so it can be scored, either now (if ground truth
-        # already landed) or later (if ground truth hasn't landed yet).
-        record_prediction(run, predicted_assignee_user_ids)
-
-    _apply_prediction(group, predicted_assignee_user_ids, run_uuid=data.get("run_uuid"))
-
-
-def _apply_prediction(
-    group: Group,
-    predicted_assignee_user_ids: list[int | None],
-    run_uuid: str | None,
-) -> None:
-    """If the feature flag is enabled and we predicted an acutal org user,
-    create a (suggested) GroupOwner for them. Then promote the suggestion to an
-    assignment iff the project auto-assigns to owners."""
-    if not features.has(AUTO_ASSIGN_FEATURE_FLAG, group.organization):
-        return
-
     # We need someone who actually resolves to a Sentry user, so pick one further
     # down the list of suggestions if necessary.
     top_user_id, used_rank = next(
@@ -56,6 +37,27 @@ def _apply_prediction(
         ),
         (None, None),
     )
+
+    if run is not None:
+        # Save the prediction to the run so it can be scored, either now (if ground truth
+        # already landed) or later (if ground truth hasn't landed yet).
+        record_prediction(run, predicted_assignee_user_ids, top_user_id)
+
+    _apply_prediction(group, top_user_id, used_rank, run_uuid=data.get("run_uuid"))
+
+
+def _apply_prediction(
+    group: Group,
+    top_user_id: int | None,
+    used_rank: int | None,
+    run_uuid: str | None,
+) -> None:
+    """If the feature flag is enabled and we predicted an acutal org user,
+    create a (suggested) GroupOwner for them. Then promote the suggestion to an
+    assignment iff the project auto-assigns to owners."""
+    if not features.has(AUTO_ASSIGN_FEATURE_FLAG, group.organization):
+        return
+
     if top_user_id is None:
         # Agent abstained, or none of its candidates mapped to an org user.
         metrics.incr(

--- a/src/sentry/seer/smart_assignment/models.py
+++ b/src/sentry/seer/smart_assignment/models.py
@@ -69,8 +69,9 @@ class SmartAssignmentScore(models.TextChoices):
     """
 
     EXACT = "exact"  # predicted user is the actual assignee
-    TEAM = "team"  # predicted user isn't the assignee but is on the correct team
-    MISS = "miss"  # neither
+    TEAM = "team"  # the issue went to a team, and the predicted user is on it
+    SHARED_TEAM = "shared-team"  # predicted user shares a team with the actual assignee
+    MISS = "miss"  # none of the above
 
 
 class SmartAssignmentPayload(BaseModel):

--- a/src/sentry/seer/smart_assignment/scoring.py
+++ b/src/sentry/seer/smart_assignment/scoring.py
@@ -188,7 +188,7 @@ def _apply(run_id: int, updates: RunUpdates) -> bool:
             predicted_user_ids=predicted_user_ids,
             selected_user_id=extras.get(
                 "selected_assignee_user_id",
-                predicted_user_ids[0] if predicted_user_ids else None,
+                next((user_id for user_id in predicted_user_ids if user_id is not None), None),
             ),
             actual_user_id=extras.get("actual_assignee_user_id"),
             actual_team_id=extras.get("actual_assignee_team_id"),

--- a/src/sentry/seer/smart_assignment/scoring.py
+++ b/src/sentry/seer/smart_assignment/scoring.py
@@ -31,14 +31,25 @@ class RunUpdates(TypedDict, total=False):
     """The mirrored fields we write onto a run's ``extras`` before scoring."""
 
     predicted_assignee_user_ids: list[int | None]
+    selected_assignee_user_id: int | None
     actual_assignee_user_id: int | None
     actual_assignee_team_id: int | None
     ground_truth_source: str
 
 
-def record_prediction(run: SeerAgentRun, predicted_assignee_user_ids: list[int | None]) -> None:
+def record_prediction(
+    run: SeerAgentRun,
+    predicted_assignee_user_ids: list[int | None],
+    selected_assignee_user_id: int | None,
+) -> None:
     """Record the predicted assignee user IDs on the run."""
-    _apply(run.id, {"predicted_assignee_user_ids": predicted_assignee_user_ids})
+    _apply(
+        run.id,
+        {
+            "predicted_assignee_user_ids": predicted_assignee_user_ids,
+            "selected_assignee_user_id": selected_assignee_user_id,
+        },
+    )
 
 
 def record_ground_truth(
@@ -171,9 +182,14 @@ def _apply(run_id: int, updates: RunUpdates) -> bool:
             return False
         extras.update(updates)
         # Score the prediction against the ground truth if it's already landed.
+        predicted_user_ids = extras.get("predicted_assignee_user_ids") or []
         result, hit_rank = _score(
             run.run.organization_id,
-            predicted_user_ids=extras.get("predicted_assignee_user_ids") or [],
+            predicted_user_ids=predicted_user_ids,
+            selected_user_id=extras.get(
+                "selected_assignee_user_id",
+                predicted_user_ids[0] if predicted_user_ids else None,
+            ),
             actual_user_id=extras.get("actual_assignee_user_id"),
             actual_team_id=extras.get("actual_assignee_team_id"),
         )
@@ -200,14 +216,18 @@ def _apply(run_id: int, updates: RunUpdates) -> bool:
 def _score(
     organization_id: int,
     predicted_user_ids: list[int | None],
+    selected_user_id: int | None,
     actual_user_id: int | None,
     actual_team_id: int | None,
 ) -> tuple[SmartAssignmentScore | None, int | None]:
     """Score the prediction against the ground truth if we have both.
-    The top-predicted user is scored with EXACT if it's a match, TEAM if the prediction shares
-    a team with the ground truth, or MISS otherwise (including when we couldn't resolve the prediction to an org user).
+    The selected user is scored with EXACT if it's a match, TEAM if the issue went to a
+    team the selected user belongs to, SHARED_TEAM if the selected user shares a team with
+    the actual assignee, or MISS otherwise (including when we couldn't resolve any
+    candidate to an org user).
     hit_rank records the rank of the top-predicted user that matched the ground truth,
-    so we can track how often #2 or #3 was correct too.
+    so we can track how often #2 or #3 was correct too. It is the rank as delivered, so a
+    selected user found at #2 scores exact at rank 2.
     """
     if not predicted_user_ids:
         # No prediction; do nothing.
@@ -224,15 +244,13 @@ def _score(
                 hit_rank = rank
                 break
 
-    # A top pick we couldn't resolve to an org user (None) can't be EXACT or TEAM, so
-    # it's a miss -- but a lower-ranked candidate may still have named the assignee,
-    # which `hit_rank` records.
-    predicted_user_id = predicted_user_ids[0]
-    if predicted_user_id is not None:
-        if predicted_user_id == actual_user_id:
+    if selected_user_id is not None:
+        if selected_user_id == actual_user_id:
             return SmartAssignmentScore.EXACT, hit_rank
-        if _is_team_match(organization_id, predicted_user_id, actual_user_id, actual_team_id):
-            return SmartAssignmentScore.TEAM, hit_rank
+        if _is_team_match(organization_id, selected_user_id, actual_user_id, actual_team_id):
+            if actual_team_id is not None:
+                return SmartAssignmentScore.TEAM, hit_rank
+            return SmartAssignmentScore.SHARED_TEAM, hit_rank
     return SmartAssignmentScore.MISS, hit_rank
 
 

--- a/tests/sentry/seer/smart_assignment/test_scoring.py
+++ b/tests/sentry/seer/smart_assignment/test_scoring.py
@@ -58,7 +58,7 @@ class RecordPredictionScoringTest(ScoringTestBase):
     def test_exact_when_prediction_matches_user(self, mock_metrics: MagicMock) -> None:
         user = self.create_user()
         run = self._run(actual_assignee_user_id=user.id)
-        record_prediction(run, [user.id])
+        record_prediction(run, [user.id], user.id)
 
         self._assert_result(mock_metrics, SmartAssignmentScore.EXACT, hit_rank=1)
         run.refresh_from_db()
@@ -71,12 +71,12 @@ class RecordPredictionScoringTest(ScoringTestBase):
         alice = self.create_user()
         self.create_member(user=alice, organization=self.organization, teams=[team])
         run = self._run(actual_assignee_team_id=team.id)
-        record_prediction(run, [alice.id])
+        record_prediction(run, [alice.id], alice.id)
 
         self._assert_result(mock_metrics, SmartAssignmentScore.TEAM)
 
     @patch(METRICS_PATH)
-    def test_team_when_predicted_shares_team_with_actual_user(
+    def test_shared_team_when_predicted_shares_team_with_actual_user(
         self, mock_metrics: MagicMock
     ) -> None:
         team = self.create_team(organization=self.organization)
@@ -85,9 +85,9 @@ class RecordPredictionScoringTest(ScoringTestBase):
         self.create_member(user=alice, organization=self.organization, teams=[team])
         self.create_member(user=bob, organization=self.organization, teams=[team])
         run = self._run(actual_assignee_user_id=bob.id)
-        record_prediction(run, [alice.id])
+        record_prediction(run, [alice.id], alice.id)
 
-        self._assert_result(mock_metrics, SmartAssignmentScore.TEAM)
+        self._assert_result(mock_metrics, SmartAssignmentScore.SHARED_TEAM)
 
     @patch(METRICS_PATH)
     def test_miss_when_no_team_overlap(self, mock_metrics: MagicMock) -> None:
@@ -98,7 +98,48 @@ class RecordPredictionScoringTest(ScoringTestBase):
         self.create_member(user=alice, organization=self.organization, teams=[team_a])
         self.create_member(user=bob, organization=self.organization, teams=[team_b])
         run = self._run(actual_assignee_user_id=bob.id)
-        record_prediction(run, [alice.id])
+        record_prediction(run, [alice.id], alice.id)
+
+        self._assert_result(mock_metrics, SmartAssignmentScore.MISS)
+
+    @patch(METRICS_PATH)
+    def test_exact_when_selected_user_follows_an_unmapped_candidate(
+        self, mock_metrics: MagicMock
+    ) -> None:
+        # The top candidate never mapped to an org user, so completion suggested the
+        # second one -- the pick that reached the issue is the pick we grade.
+        alice = self.create_user()
+        run = self._run(actual_assignee_user_id=alice.id)
+        record_prediction(run, [None, alice.id], alice.id)
+
+        self._assert_result(mock_metrics, SmartAssignmentScore.EXACT, hit_rank=2)
+
+    @patch(METRICS_PATH)
+    def test_shared_team_when_selected_user_follows_an_unmapped_candidate(
+        self, mock_metrics: MagicMock
+    ) -> None:
+        team = self.create_team(organization=self.organization)
+        alice = self.create_user()
+        bob = self.create_user()
+        self.create_member(user=alice, organization=self.organization, teams=[team])
+        self.create_member(user=bob, organization=self.organization, teams=[team])
+        run = self._run(actual_assignee_user_id=bob.id)
+        record_prediction(run, [None, alice.id], alice.id)
+
+        self._assert_result(mock_metrics, SmartAssignmentScore.SHARED_TEAM)
+
+    def test_records_the_selected_candidate(self) -> None:
+        alice = self.create_user()
+        run = self._run()
+        record_prediction(run, [None, alice.id], alice.id)
+
+        run.refresh_from_db()
+        assert run.extras["selected_assignee_user_id"] == alice.id
+
+    @patch(METRICS_PATH)
+    def test_miss_when_no_candidate_maps_to_a_user(self, mock_metrics: MagicMock) -> None:
+        run = self._run(actual_assignee_user_id=self.create_user().id)
+        record_prediction(run, [None, None], None)
 
         self._assert_result(mock_metrics, SmartAssignmentScore.MISS)
 
@@ -109,7 +150,7 @@ class RecordPredictionScoringTest(ScoringTestBase):
         alice = self.create_user()
         bob = self.create_user()
         run = self._run(actual_assignee_user_id=bob.id)
-        record_prediction(run, [alice.id, bob.id])
+        record_prediction(run, [alice.id, bob.id], alice.id)
 
         self._assert_result(mock_metrics, SmartAssignmentScore.MISS, hit_rank=2)
 
@@ -118,27 +159,15 @@ class RecordPredictionScoringTest(ScoringTestBase):
         alice = self.create_user()
         bob = self.create_user()
         run = self._run(actual_assignee_user_id=bob.id)
-        record_prediction(run, [alice.id])
+        record_prediction(run, [alice.id], alice.id)
 
         self._assert_result(mock_metrics, SmartAssignmentScore.MISS, hit_rank=0)
-
-    @patch(METRICS_PATH)
-    def test_unresolved_top_pick_is_miss_but_lower_candidate_still_hits(
-        self, mock_metrics: MagicMock
-    ) -> None:
-        # Top pick couldn't be mapped to an org user (None), so the coarse outcome is a
-        # miss, but the actual assignee is the rank-2 candidate -- still a hit.
-        bob = self.create_user()
-        run = self._run(actual_assignee_user_id=bob.id)
-        record_prediction(run, [None, bob.id])
-
-        self._assert_result(mock_metrics, SmartAssignmentScore.MISS, hit_rank=2)
 
     @patch(METRICS_PATH)
     def test_unresolved_top_pick_alone_is_miss(self, mock_metrics: MagicMock) -> None:
         bob = self.create_user()
         run = self._run(actual_assignee_user_id=bob.id)
-        record_prediction(run, [None])
+        record_prediction(run, [None], None)
 
         self._assert_result(mock_metrics, SmartAssignmentScore.MISS, hit_rank=0)
 
@@ -148,7 +177,7 @@ class RecordPredictionScoringTest(ScoringTestBase):
         # match on the None == None comparison.
         team = self.create_team(organization=self.organization)
         run = self._run(actual_assignee_team_id=team.id)
-        record_prediction(run, [None])
+        record_prediction(run, [None], None)
 
         self._assert_result(mock_metrics, SmartAssignmentScore.MISS, hit_rank=0)
 
@@ -156,19 +185,19 @@ class RecordPredictionScoringTest(ScoringTestBase):
     def test_noop_without_both_sides(self, mock_metrics: MagicMock) -> None:
         # Prediction but no ground truth yet.
         run = self._run()
-        record_prediction(run, [7])
+        record_prediction(run, [7], 7)
         # Ground truth but no (resolvable) prediction (separate group).
         other = self.create_group()
         other_run = self._run(group=other, actual_assignee_user_id=9)
-        record_prediction(other_run, [])
+        record_prediction(other_run, [], None)
         mock_metrics.incr.assert_not_called()
 
     @patch(METRICS_PATH)
     def test_scores_only_once(self, mock_metrics: MagicMock) -> None:
         user = self.create_user()
         run = self._run(actual_assignee_user_id=user.id)
-        record_prediction(run, [user.id])
-        record_prediction(run, [user.id])
+        record_prediction(run, [user.id], user.id)
+        record_prediction(run, [user.id], user.id)
         assert mock_metrics.incr.call_count == 1
 
 
@@ -206,6 +235,18 @@ class RecordGroundTruthTest(ScoringTestBase):
         assert not SeerAgentRun.objects.filter(
             group_id=self.group.id, source=SEER_FEATURE_ID
         ).exists()
+
+    def test_scores_a_prediction_recorded_before_the_selected_field(self) -> None:
+        # A run whose prediction landed before `selected_assignee_user_id` existed still
+        # scores, off its top slot.
+        alice = self.create_user()
+        run = self._run(predicted_assignee_user_ids=[alice.id])
+        GroupAssignee.objects.create(group=self.group, project=self.group.project, user_id=alice.id)
+        record_ground_truth(self.group, ActivityType.ASSIGNED, self._assigned_activity(alice.id))
+
+        run.refresh_from_db()
+        assert run.extras["result"] == SmartAssignmentScore.EXACT
+        assert run.extras["hit_rank"] == 1
 
     def test_records_assignee_user(self) -> None:
         run = self._run()

--- a/tests/sentry/seer/smart_assignment/test_trigger.py
+++ b/tests/sentry/seer/smart_assignment/test_trigger.py
@@ -435,7 +435,7 @@ class TriggerSmartAssignmentTest(TestCase):
                 self.group, ActivityType.SEER_RCA_STARTED, self._seer_started()
             )
 
-        record_prediction(self._mirrors()[0], [assignee.id])
+        record_prediction(self._mirrors()[0], [assignee.id], assignee.id)
 
         mock_metrics.incr.assert_any_call(
             "smart_assignment.scored",


### PR DESCRIPTION
We sometimes correctly choose a lower-ranked mapped user as our prediction over a higher-ranked unmapped user, but still score that as a `MISS`. So, in addition to the full prediction ranks, store `selected_assignee_user_id` and score against that instead. Note that if we pick the user in the #2 slot, `hit_rank` will still be 2.

Also, branch the `TEAM` result (which is almost certainly a majority of predicted-user-in-assigned-team) off into the less-frequent/higher-signal variant `SHARED_TEAM` (the actual assigned user shares a team with the predicted user).

Relates to ISWF-2943