### PR TITLE
feat(inbox): Add copy markdown button to autofix sections

### DIFF
--- a/static/app/views/issueDetails/issuePreview/copySectionMarkdown.tsx
+++ b/static/app/views/issueDetails/issuePreview/copySectionMarkdown.tsx
@@ -1,0 +1,28 @@
+import {Button} from '@sentry/scraps/button';
+
+import {
+  type AutofixSection,
+  getAutofixArtifactFromSection,
+} from 'sentry/components/events/autofix/useExplorerAutofix';
+import {artifactToMarkdown} from 'sentry/components/events/autofix/v3/utils';
+import {IconCopy} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
+
+export function CopySectionMarkdown({section}: {section: AutofixSection}) {
+  const {copy} = useCopyToClipboard();
+  const artifact =
+    section.status === 'completed' ? getAutofixArtifactFromSection(section) : null;
+  const markdown = artifact ? artifactToMarkdown(artifact) : null;
+
+  return markdown ? (
+    <Button
+      size="xs"
+      variant="transparent"
+      icon={<IconCopy size="xs" />}
+      aria-label={t('Copy as Markdown')}
+      tooltipProps={{title: t('Copy as Markdown')}}
+      onClick={() => copy(markdown, {successMessage: t('Copied to clipboard.')})}
+    />
+  ) : null;
+}

--- a/static/app/views/issueDetails/issuePreview/issuePreviewAutofixPlanSection.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewAutofixPlanSection.tsx
@@ -1,3 +1,5 @@
+import {Fragment} from 'react';
+
 import {Container, Stack} from '@sentry/scraps/layout';
 import {Markdown} from '@sentry/scraps/markdown';
 import {Text} from '@sentry/scraps/text';
@@ -10,6 +12,7 @@ import {
 } from 'sentry/components/events/autofix/useExplorerAutofix';
 import {t} from 'sentry/locale';
 
+import {CopySectionMarkdown} from './copySectionMarkdown';
 import {IssuePreviewSection} from './issuePreviewSection';
 import {RetryableAutofixSection} from './retryableAutofixSection';
 import {WorkingIndicator} from './workingIndicator';
@@ -32,7 +35,14 @@ export function IssuePreviewAutofixPlanSection({
         aria-label={t('Implementation Plan')}
         defaultExpanded={defaultExpanded}
       >
-        <IssuePreviewSection.Title trailingItems={<RetryableAutofixSection.Button />}>
+        <IssuePreviewSection.Title
+          trailingItems={
+            <Fragment>
+              <RetryableAutofixSection.Button />
+              <CopySectionMarkdown section={section} />
+            </Fragment>
+          }
+        >
           {t('Implementation Plan')}
         </IssuePreviewSection.Title>
         <IssuePreviewSection.Summary>

--- a/static/app/views/issueDetails/issuePreview/issuePreviewAutofixProposalSection.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewAutofixProposalSection.tsx
@@ -1,4 +1,4 @@
-import {useMemo} from 'react';
+import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import {Stack} from '@sentry/scraps/layout';
@@ -14,6 +14,7 @@ import {
 import {t, tn} from 'sentry/locale';
 import {FileDiffViewer} from 'sentry/views/seerExplorer/components/fileDiffViewer';
 
+import {CopySectionMarkdown} from './copySectionMarkdown';
 import {IssuePreviewSection} from './issuePreviewSection';
 import {RetryableAutofixSection} from './retryableAutofixSection';
 import {WorkingIndicator} from './workingIndicator';
@@ -45,7 +46,14 @@ export function IssuePreviewAutofixProposalSection({
   return (
     <RetryableAutofixSection autofix={autofix} section={section} step="code_changes">
       <IssuePreviewSection aria-label={t('Proposal')} defaultExpanded={defaultExpanded}>
-        <IssuePreviewSection.Title trailingItems={<RetryableAutofixSection.Button />}>
+        <IssuePreviewSection.Title
+          trailingItems={
+            <Fragment>
+              <RetryableAutofixSection.Button />
+              <CopySectionMarkdown section={section} />
+            </Fragment>
+          }
+        >
           {t('Proposal')}
         </IssuePreviewSection.Title>
         <IssuePreviewSection.Summary>

--- a/static/app/views/issueDetails/issuePreview/issuePreviewAutofixRootCauseSection.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewAutofixRootCauseSection.tsx
@@ -1,3 +1,5 @@
+import {Fragment} from 'react';
+
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Markdown} from '@sentry/scraps/markdown';
 import {Text} from '@sentry/scraps/text';
@@ -12,6 +14,7 @@ import {AutofixEvidence} from 'sentry/components/events/autofix/v3/autofixEviden
 import {useAutofixSectionEvidence} from 'sentry/components/events/autofix/v3/useAutofixSectionEvidence';
 import {t} from 'sentry/locale';
 
+import {CopySectionMarkdown} from './copySectionMarkdown';
 import {IssuePreviewSection} from './issuePreviewSection';
 import {RetryableAutofixSection} from './retryableAutofixSection';
 import {WorkingIndicator} from './workingIndicator';
@@ -34,7 +37,14 @@ export function IssuePreviewAutofixRootCauseSection({
   return (
     <RetryableAutofixSection autofix={autofix} section={section} step="root_cause">
       <IssuePreviewSection aria-label={t('Root Cause')} defaultExpanded={defaultExpanded}>
-        <IssuePreviewSection.Title trailingItems={<RetryableAutofixSection.Button />}>
+        <IssuePreviewSection.Title
+          trailingItems={
+            <Fragment>
+              <RetryableAutofixSection.Button />
+              <CopySectionMarkdown section={section} />
+            </Fragment>
+          }
+        >
           {t('Root Cause')}
         </IssuePreviewSection.Title>
         <IssuePreviewSection.Summary>

--- a/static/app/views/issueDetails/issuePreview/issuePreviewAutofixSummary.spec.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewAutofixSummary.spec.tsx
@@ -329,4 +329,5 @@ describe('IssuePreviewAutofixSummary', () => {
       insertIndex: 0,
     });
   });
+
 });

--- a/static/app/views/issueDetails/issuePreview/issuePreviewAutofixSummary.spec.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewAutofixSummary.spec.tsx
@@ -57,6 +57,12 @@ const solutionArtifact = AutofixSolutionArtifactFixture({
 });
 
 describe('IssuePreviewAutofixSummary', () => {
+  beforeEach(() => {
+    Object.assign(navigator, {
+      clipboard: {writeText: jest.fn().mockResolvedValue(undefined)},
+    });
+  });
+
   it('renders summaries in the requested order with the first section expanded', async () => {
     const runState = ExplorerAutofixStateFixture({
       blocks: [
@@ -330,4 +336,22 @@ describe('IssuePreviewAutofixSummary', () => {
     });
   });
 
+  it('copies a completed section as markdown', async () => {
+    render(
+      <IssuePreviewAutofixSummary
+        autofix={ExplorerAutofixFixture({
+          runState: ExplorerAutofixStateFixture({
+            blocks: [ExplorerAutofixBlockFixture({artifacts: [rootCauseArtifact]})],
+          }),
+        })}
+        groupId="preview-group"
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Copy as Markdown'}));
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      '# Root Cause\n\nAn unexpected null value reached the user handler.\n\n## Why did this happen?\n\n- The handler accessed the user without checking for null.\n- The upstream lookup can return no user.\n\n## Reproduction Steps\n\n1. Request a user ID that does not exist.'
+    );
+  });
 });


### PR DESCRIPTION
Closes ISWF-3153

<img width="312" height="202" alt="CleanShot 2026-08-05 at 17 14 54@2x" src="https://github.com/user-attachments/assets/f932b94a-fa72-4bd5-a31f-41f22c0eb2d0" />
