### PR TITLE
fix(integrations): route ChunkedEncodingError to halt instead of failure in IntegrationEventLifecycle

### DIFF
--- a/src/sentry/integrations/utils/metrics.py
+++ b/src/sentry/integrations/utils/metrics.py
@@ -10,6 +10,7 @@ from types import TracebackType
 from typing import TYPE_CHECKING, Any, Self
 
 import sentry_sdk
+from requests.exceptions import ChunkedEncodingError
 
 from sentry import options
 from sentry.exceptions import RestrictedIPAddress
@@ -365,6 +366,15 @@ class IntegrationEventLifecycle(EventLifecycle):
             # ApiHostError is raised from RestrictedIPAddress
             self.record_halt(exc_value)
             return
+
+        if exc_value is not None and isinstance(exc_value, ChunkedEncodingError):
+            # ChunkedEncodingError is a transient network error (connection dropped
+            # while reading a response body). It is not a code defect and should not
+            # create a Sentry issue on every occurrence. Route it to halt so it is
+            # still counted in SLO metrics.
+            self.record_halt(exc_value)
+            return
+
         super().__exit__(exc_type, exc_value, traceback)
 
 

--- a/tests/sentry/integrations/utils/test_lifecycle_metrics.py
+++ b/tests/sentry/integrations/utils/test_lifecycle_metrics.py
@@ -1,6 +1,7 @@
 from unittest import TestCase, mock
 
 import pytest
+from requests.exceptions import ChunkedEncodingError
 
 from sentry.integrations.base import IntegrationDomain
 from sentry.integrations.types import EventLifecycleOutcome
@@ -493,3 +494,25 @@ class IntegrationEventLifecycleMetricTest(TestCase):
 
         # Should log since default is 1.0
         mock_logger.warning.assert_called_once()
+
+    @mock.patch("sentry.integrations.utils.metrics.sentry_sdk")
+    @mock.patch("sentry.integrations.utils.metrics.logger")
+    @mock.patch("sentry.integrations.utils.metrics.metrics")
+    def test_chunked_encoding_error_is_halted_not_failed(
+        self,
+        mock_metrics: mock.MagicMock,
+        mock_logger: mock.MagicMock,
+        mock_sentry_sdk: mock.MagicMock,
+    ) -> None:
+        """
+        ChunkedEncodingError is a transient network error and should be recorded
+        as a halt (not a failure), with no Sentry issue created.
+        """
+        metric_obj = self.TestLifecycleMetric()
+
+        with pytest.raises(ChunkedEncodingError):
+            with metric_obj.capture():
+                raise ChunkedEncodingError("Connection broken: IncompleteRead")
+
+        self._check_metrics_call_args(mock_metrics, "halted")
+        mock_sentry_sdk.capture_exception.assert_not_called()


### PR DESCRIPTION
## Summary

Fixes noisy Sentry issues created by transient network errors during GitHub webhook processing.

- **Root cause**: `IntegrationEventLifecycle.__exit__` calls `record_failure(exc_value, create_issue=True)` for any unhandled exception. A `requests.exceptions.ChunkedEncodingError` is raised when the TCP connection is dropped mid-stream while reading a response body — specifically observed during an RPC call to the control silo (e.g. `/api/0/internal/rpc/integration/organization_contexts/`) inside the `github.webhook.check_run` transaction. The HTTP 200 status was returned but the body was truncated by a transient infrastructure-level drop. This is not a code defect.
- **Why halt, not failure**: `record_failure` creates a Sentry issue on every occurrence. Because `ChunkedEncodingError` is transient and infrastructure-level, each network blip generates an independent Sentry issue, creating noise that drowns out real failures in SLO dashboards. `record_halt` still counts the event in SLO metrics without opening a new issue.
- **Fix**: In `IntegrationEventLifecycle.__exit__`, add a special-case check for `ChunkedEncodingError` that routes it to `record_halt()` — identical to the existing pattern for `RestrictedIPAddress`.

## Precedents

**`RestrictedIPAddress` pattern** (already in the same method):
```python
if exc_value is not None and isinstance(exc_value.__cause__, RestrictedIPAddress):
    self.record_halt(exc_value)
    return
```

**`data_forwarding/tasks.py`** (lines 34–42): `ChunkedEncodingError` is already listed in `_DATA_FORWARDING_SILENCED`, meaning it is explicitly excluded from retry and issue creation in that context. This PR brings `IntegrationEventLifecycle` in line with that precedent.

## What was ruled out

- **Retry logic**: Adding automatic retry inside the context manager was considered but deferred. The connection drop appears to be an occasional infrastructure blip at the region→control silo boundary, not an application-level error recoverable at the webhook handler level. Retrying the full webhook handler for every `ChunkedEncodingError` would require broader architectural changes that are out of scope for a noise-reduction fix.

## Changes

- `src/sentry/integrations/utils/metrics.py`: import `ChunkedEncodingError`; add halt branch in `IntegrationEventLifecycle.__exit__`.
- `tests/sentry/integrations/utils/test_lifecycle_metrics.py`: add `test_chunked_encoding_error_is_halted_not_failed` verifying that `ChunkedEncodingError` raised inside the context produces a halt outcome and does not call `sentry_sdk.capture_exception`.

## References

- Sentry issue: https://sentry.io/organizations/sentry/issues/7620156862/
- Triage session: https://claude.ai/code/session_019vjtRXsVGjJiCQq1aWuNZ9

<!-- Describe your PR here. -->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
_Generated by [Claude Code](https://claude.ai/code/session_019vjtRXsVGjJiCQq1aWuNZ9)_