### PR TITLE
feat(gdd): When invalidating, ensure an invalidated GDD row exists

### DIFF
--- a/src/sentry/issues/derived/processing.py
+++ b/src/sentry/issues/derived/processing.py
@@ -587,9 +587,18 @@ def invalidate_group_derived_data(
         if soft and not row_exists:
             # Race-safe: if a concurrent writer inserted a live row first,
             # get_or_create is a no-op and we fall through to pure-append.
-            _, created = GroupDerivedData.objects.get_or_create(
-                group_id=group_id, defaults={"pipeline_hash": None}
-            )
+            # If the group itself was deleted since the existence check, the
+            # insert fails — treat as a no-op.
+            try:
+                _, created = GroupDerivedData.objects.get_or_create(
+                    group_id=group_id, defaults={"pipeline_hash": None}
+                )
+            except IntegrityError:
+                logger.info(
+                    "issues.derived.invalidate.group_missing",
+                    extra={"group_id": group_id},
+                )
+                return
             if created:
                 logger.info(
                     "issues.derived.invalidated",

--- a/src/sentry/issues/derived/processing.py
+++ b/src/sentry/issues/derived/processing.py
@@ -537,53 +537,56 @@ def invalidate_group_derived_data(
     """Mark a group's derived data as out-of-date with respect to its action log.
 
     *cursor* is ``(date_added, id)`` of the earliest affected entry. If the
-    row's own cursor is behind that point, the mutation is a pure append and
-    the row is left alone (an incremental drain will catch it up).
+    row's cursor is behind that point the mutation is a pure append and the
+    row is left alone — an incremental drain will catch it up.
 
-    Otherwise the row is invalidated: ``soft=True`` (default) nulls
-    ``pipeline_hash`` so the row stays readable but is flagged stale for
-    bulk regeneration; ``soft=False`` deletes the row so readers cannot
-    observe pre-mutation state.
+    Otherwise: ``soft=True`` (default) nulls ``pipeline_hash`` and bumps
+    ``generated_at`` — the row stays readable but flagged stale, and any
+    in-flight generation started before this call loses its promotion CAS.
+    ``soft=False`` deletes the row so readers cannot observe pre-mutation
+    state.
 
-    Under ``soft=True``, if no row exists for the group at all, one is
-    inserted with ``pipeline_hash=None``. That row's other fields are just
-    defaults — no more accurate than the implicit defaults readers would use
-    for an absent row — but the null hash is an explicit "known stale" marker
-    that lets bookkeeping and healing code treat "null or stale pipeline_hash"
-    uniformly as "needs regen".
+    Under ``soft=True`` with no existing row, one is inserted with
+    ``pipeline_hash=None`` as an explicit "needs regen" marker for bulk
+    healing (uniform with already-stale rows).
 
-    If *trigger_regenerate* is True (default), schedules a background task
-    to bring the row up to date. Pass False in bulk contexts that will
-    drive regeneration themselves.
+    If *trigger_regenerate* is True (default), schedules a follow-up task.
+    Bulk callers driving their own regeneration should pass False.
     """
     if cursor is None:
         invalid_predicate = Q(group_id=group_id)
     else:
         cursor_date, cursor_id = cursor
+        # Null-hash rows are matched unconditionally: they're already stale
+        # so there's no up-to-date state to protect, and refreshing their
+        # ``generated_at`` forces any in-flight generation started before
+        # this call to lose its promotion CAS (see below).
         invalid_predicate = Q(group_id=group_id) & (
-            Q(cursor_date__gt=cursor_date) | Q(cursor_date=cursor_date, cursor_id__gte=cursor_id)
+            Q(pipeline_hash__isnull=True)
+            | Q(cursor_date__gt=cursor_date)
+            | Q(cursor_date=cursor_date, cursor_id__gte=cursor_id)
         )
 
-    # Reuse the invalidation predicate so a concurrent writer that already
-    # promoted past our cursor is not clobbered. Combining the check with the
-    # write avoids a second query.
+    # Combine the guard with the write so a concurrent promotion past our
+    # cursor isn't clobbered.
     qs = GroupDerivedData.objects.filter(invalid_predicate)
     if soft:
-        affected = qs.update(pipeline_hash=None)
+        # Bumping ``generated_at`` reuses ``promote_to_live``'s SUPERSEDED
+        # CAS path — pre-invalidation snapshots can't win over the null-hash
+        # row.
+        affected = qs.update(pipeline_hash=None, generated_at=timezone.now())
     else:
         affected, _ = qs.delete()
 
     if not affected:
-        # Either nothing exists yet, or a row exists but its cursor is already
-        # past the affected point (a pure append relative to that row).
-        # Distinguish the two: for a soft invalidation with no existing row,
-        # insert one with pipeline_hash=None so "null or stale pipeline_hash"
-        # is a reliable "needs regen" signal for bulk regeneration/healing.
+        # Either no row exists yet, or an existing row's cursor is already
+        # past the affected point (pure append). Under soft=True with no
+        # row, insert a null-hash placeholder so bulk healing sees a
+        # uniform "needs regen" signal.
         row_exists = GroupDerivedData.objects.filter(group_id=group_id).exists()
         if soft and not row_exists:
-            # Race-safe: if a concurrent writer just inserted a fully-generated
-            # row, the unique group_id constraint makes this a no-op and we
-            # fall through to the pure-append branch.
+            # Race-safe: if a concurrent writer inserted a live row first,
+            # get_or_create is a no-op and we fall through to pure-append.
             _, created = GroupDerivedData.objects.get_or_create(
                 group_id=group_id, defaults={"pipeline_hash": None}
             )
@@ -603,8 +606,7 @@ def invalidate_group_derived_data(
                     generate_group_derived_data.delay(group_id)
                 return
 
-        # Pure append (or nothing to invalidate under soft=False): a normal
-        # drain will pick up any new entries.
+        # Pure append (or nothing to delete): a normal drain suffices.
         if trigger_regenerate:
             process_group_log_task.delay(group_id)
         return

--- a/src/sentry/issues/derived/processing.py
+++ b/src/sentry/issues/derived/processing.py
@@ -545,6 +545,13 @@ def invalidate_group_derived_data(
     bulk regeneration; ``soft=False`` deletes the row so readers cannot
     observe pre-mutation state.
 
+    Under ``soft=True``, if no row exists for the group at all, one is
+    inserted with ``pipeline_hash=None``. That row's other fields are just
+    defaults — no more accurate than the implicit defaults readers would use
+    for an absent row — but the null hash is an explicit "known stale" marker
+    that lets bookkeeping and healing code treat "null or stale pipeline_hash"
+    uniformly as "needs regen".
+
     If *trigger_regenerate* is True (default), schedules a background task
     to bring the row up to date. Pass False in bulk contexts that will
     drive regeneration themselves.
@@ -567,8 +574,37 @@ def invalidate_group_derived_data(
         affected, _ = qs.delete()
 
     if not affected:
-        # Pure append (or nothing to invalidate): a normal drain will pick
-        # up any new entries.
+        # Either nothing exists yet, or a row exists but its cursor is already
+        # past the affected point (a pure append relative to that row).
+        # Distinguish the two: for a soft invalidation with no existing row,
+        # insert one with pipeline_hash=None so "null or stale pipeline_hash"
+        # is a reliable "needs regen" signal for bulk regeneration/healing.
+        row_exists = GroupDerivedData.objects.filter(group_id=group_id).exists()
+        if soft and not row_exists:
+            # Race-safe: if a concurrent writer just inserted a fully-generated
+            # row, the unique group_id constraint makes this a no-op and we
+            # fall through to the pure-append branch.
+            _, created = GroupDerivedData.objects.get_or_create(
+                group_id=group_id, defaults={"pipeline_hash": None}
+            )
+            if created:
+                logger.info(
+                    "issues.derived.invalidated",
+                    extra={
+                        "group_id": group_id,
+                        "cursor_date": str(cursor[0]) if cursor else None,
+                        "cursor_id": cursor[1] if cursor else None,
+                        "soft": True,
+                        "trigger_regenerate": trigger_regenerate,
+                        "inserted": True,
+                    },
+                )
+                if trigger_regenerate:
+                    generate_group_derived_data.delay(group_id)
+                return
+
+        # Pure append (or nothing to invalidate under soft=False): a normal
+        # drain will pick up any new entries.
         if trigger_regenerate:
             process_group_log_task.delay(group_id)
         return

--- a/src/sentry/issues/models/groupderiveddata.py
+++ b/src/sentry/issues/models/groupderiveddata.py
@@ -37,8 +37,8 @@ class GroupDerivedData(DefaultFieldsModel):
     and set ``pipeline_hash`` to null and ``generated_at`` to now to say
     "this is invalid as of now".
 
-    Outside of those, we're just a log summary, so concurrent updates
-    are safe: whoever has seen more of the log wins, and
+    Outside of those, we're just a deterministic log summary, so concurrent
+    updates are safe: whoever has seen more of the log wins, and
     ``(cursor_date, cursor_id)`` tracks that progress.
 
     Update safety

--- a/src/sentry/issues/models/groupderiveddata.py
+++ b/src/sentry/issues/models/groupderiveddata.py
@@ -27,11 +27,23 @@ class GroupDerivedData(DefaultFieldsModel):
     Materialized state derived from GroupActionLogEntry entries.
     One row per group (enforced by ``unique=True`` on the FK).
 
+    High level
+    ~~~~~~~~~~~~~
+    Incrementally accumulated feature values from the group action log.
+    ``pipeline_hash`` tracks the code version when we started processing
+    the group; ``generated_at`` is a timestamp telling us the log state.
+    If the code changes or history was rewritten, these tell us a regen
+    is needed. If we're changing history ourselves, we can be explicit
+    and set ``pipeline_hash`` to null and ``generated_at`` to now to say
+    "this is invalid as of now".
+
+    Outside of those, we're just a log summary, so concurrent updates
+    are safe: whoever has seen more of the log wins, and
+    ``(cursor_date, cursor_id)`` tracks that progress.
+
     Update safety
     ~~~~~~~~~~~~~
-    The pipeline is deterministic: replaying the same log produces the same
-    state. However, the log is not strictly append-only — historical entries
-    may be inserted, which is a primary reason generations are triggered.
+    Precise rules for the markers above:
 
     * **generated_at** — timestamp of when the generation that produced
       this row's current state *started* processing. This is a CAS version:
@@ -47,6 +59,15 @@ class GroupDerivedData(DefaultFieldsModel):
     * **pipeline_hash** — stamped at row creation, incremental writes only
       succeed if the pipeline version hasn't changed since the row was
       read. A pipeline upgrade invalidates in-flight incremental work.
+      A NULL value is the canonical "known stale, needs regen" marker:
+      the row is readable but not authoritative and should be replaced.
+
+    Invalidation (via ``invalidate_group_derived_data``) either nulls
+    ``pipeline_hash`` and bumps ``generated_at`` (soft) or deletes the row
+    (hard). Under soft invalidation, a placeholder row with
+    ``pipeline_hash=None`` is inserted when none exists, so a missing row
+    unambiguously means "no derived data computed yet" while a null-hash
+    row means "known stale."
 
     See ``processing.py`` for the full lifecycle.
     """

--- a/tests/sentry/issues/derived/test_processing.py
+++ b/tests/sentry/issues/derived/test_processing.py
@@ -409,9 +409,6 @@ class ProcessGroupLogTest(TestCase):
         mock_delay.assert_called_once_with(group.id)
 
     def test_invalidate_soft_inserts_null_row_when_missing(self) -> None:
-        # No row exists (e.g. group predates the derived-data backfill).
-        # Soft invalidation inserts a placeholder row with pipeline_hash=None
-        # so "null or stale pipeline_hash" is a reliable "needs regen" signal.
         group = self.create_group()
         assert not GroupDerivedData.objects.filter(group_id=group.id).exists()
 
@@ -429,8 +426,6 @@ class ProcessGroupLogTest(TestCase):
         mock_process.assert_not_called()
 
     def test_invalidate_soft_inserts_null_row_when_missing_no_trigger(self) -> None:
-        # With trigger_regenerate=False the placeholder is still inserted,
-        # but no task is scheduled — bulk callers drive regeneration.
         group = self.create_group()
         assert not GroupDerivedData.objects.filter(group_id=group.id).exists()
 
@@ -448,9 +443,6 @@ class ProcessGroupLogTest(TestCase):
         mock_process.assert_not_called()
 
     def test_invalidate_soft_inserts_null_row_when_missing_with_cursor(self) -> None:
-        # Cursor is irrelevant when no row exists: we can't reason about
-        # "pure append" against an absent baseline, so we still insert a
-        # null-hash placeholder.
         group = self.create_group()
         assert not GroupDerivedData.objects.filter(group_id=group.id).exists()
 
@@ -463,24 +455,6 @@ class ProcessGroupLogTest(TestCase):
         row = GroupDerivedData.objects.get(group_id=group.id)
         assert row.pipeline_hash is None
         mock_generate.assert_called_once_with(group.id)
-
-    def test_invalidate_hard_missing_row_does_not_insert(self) -> None:
-        # Hard-delete semantics: readers must not observe any row. Never
-        # materialize a placeholder on the delete path.
-        group = self.create_group()
-        assert not GroupDerivedData.objects.filter(group_id=group.id).exists()
-
-        with (
-            patch(
-                "sentry.issues.derived.processing.generate_group_derived_data.delay"
-            ) as mock_generate,
-            patch("sentry.issues.derived.processing.process_group_log_task.delay") as mock_process,
-        ):
-            invalidate_group_derived_data(group.id, soft=False)
-
-        assert not GroupDerivedData.objects.filter(group_id=group.id).exists()
-        mock_generate.assert_not_called()
-        mock_process.assert_called_once_with(group.id)
 
     def test_invalidate_soft_missing_group_is_noop(self) -> None:
         # Force FK constraints to IMMEDIATE so the violation fires at INSERT time (matching
@@ -503,8 +477,6 @@ class ProcessGroupLogTest(TestCase):
         mock_process.assert_not_called()
 
     def test_invalidate_soft_bumps_generated_at(self) -> None:
-        # ``generated_at`` is bumped alongside the pipeline_hash null so any
-        # in-flight generation started before this call loses its CAS.
         group = self.create_group()
         _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
         derived = process_group_log(group.id)

--- a/tests/sentry/issues/derived/test_processing.py
+++ b/tests/sentry/issues/derived/test_processing.py
@@ -482,6 +482,79 @@ class ProcessGroupLogTest(TestCase):
         mock_generate.assert_not_called()
         mock_process.assert_called_once_with(group.id)
 
+    def test_invalidate_soft_bumps_generated_at(self) -> None:
+        # ``generated_at`` is bumped alongside the pipeline_hash null so any
+        # in-flight generation started before this call loses its CAS.
+        group = self.create_group()
+        _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
+        derived = process_group_log(group.id)
+        before = derived.generated_at
+
+        with patch("sentry.issues.derived.processing.generate_group_derived_data.delay"):
+            invalidate_group_derived_data(group.id)
+
+        derived.refresh_from_db()
+        assert derived.pipeline_hash is None
+        assert derived.generated_at > before
+
+    def test_invalidate_matches_null_hash_row_regardless_of_cursor(self) -> None:
+        # A null-hash row is already stale — a subsequent invalidation whose
+        # cursor is past the row's cursor must still refresh the CAS rather
+        # than fall into the pure-append branch.
+        group = self.create_group()
+        _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
+        derived = process_group_log(group.id)
+
+        # Null the hash directly to simulate a prior invalidation (placeholder
+        # left behind by the missing-row insert path or an in-flight null).
+        GroupDerivedData.objects.filter(group_id=group.id).update(pipeline_hash=None)
+        derived.refresh_from_db()
+        before_gen = derived.generated_at
+
+        # Cursor is well past the row's cursor — under the old predicate this
+        # would look like a pure append.
+        future = derived.cursor_date.replace(year=derived.cursor_date.year + 1)
+        with (
+            patch(
+                "sentry.issues.derived.processing.generate_group_derived_data.delay"
+            ) as mock_generate,
+            patch("sentry.issues.derived.processing.process_group_log_task.delay") as mock_process,
+        ):
+            invalidate_group_derived_data(group.id, cursor=(future, derived.cursor_id + 1000))
+
+        derived.refresh_from_db()
+        assert derived.pipeline_hash is None
+        assert derived.generated_at > before_gen
+        mock_generate.assert_called_once_with(group.id)
+        mock_process.assert_not_called()
+
+    def test_invalidate_supersedes_in_flight_generation(self) -> None:
+        # A generation task that started before invalidation must not
+        # promote its (pre-invalidation) snapshot over the null-hash row.
+        group = self.create_group()
+        _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
+
+        # Snapshot a candidate as if a generation started here.
+        candidate = GroupDerivedData(
+            group_id=group.id,
+            generated_at=django_timezone.now(),
+            cursor_date=EPOCH,
+            cursor_id=0,
+            data={},
+            pipeline_hash=PIPELINE.pipeline_hash,
+        )
+        processing._drain_log(candidate, PIPELINE, time_limit=timedelta(minutes=5), persist=False)
+
+        # Invalidation happens between the drain and the promote — either
+        # against an existing row or (as here) inserting the placeholder.
+        with patch("sentry.issues.derived.processing.generate_group_derived_data.delay"):
+            invalidate_group_derived_data(group.id)
+
+        # Promotion of the pre-invalidation snapshot must lose.
+        assert promote_to_live(candidate) is PromotionResult.SUPERSEDED
+        row = GroupDerivedData.objects.get(group_id=group.id)
+        assert row.pipeline_hash is None
+
     def test_invalidate_then_reprocess(self) -> None:
         group = self.create_group()
         user = self.user

--- a/tests/sentry/issues/derived/test_processing.py
+++ b/tests/sentry/issues/derived/test_processing.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 import pytest
-from django.db import router, transaction
+from django.db import connection, router, transaction
 from django.utils import timezone as django_timezone
 
 from sentry.hybridcloud.models.outbox import CellOutbox
@@ -482,6 +482,26 @@ class ProcessGroupLogTest(TestCase):
         mock_generate.assert_not_called()
         mock_process.assert_called_once_with(group.id)
 
+    def test_invalidate_soft_missing_group_is_noop(self) -> None:
+        # Force FK constraints to IMMEDIATE so the violation fires at INSERT time (matching
+        # production autocommit behaviour) rather than at test teardown.
+        with connection.cursor() as cursor:
+            cursor.execute("SET CONSTRAINTS ALL IMMEDIATE")
+
+        nonexistent_group_id = 9_999_999_999
+        with (
+            patch(
+                "sentry.issues.derived.processing.generate_group_derived_data.delay"
+            ) as mock_generate,
+            patch("sentry.issues.derived.processing.process_group_log_task.delay") as mock_process,
+        ):
+            # Should not raise IntegrityError — the invalidator swallows it.
+            invalidate_group_derived_data(nonexistent_group_id)
+
+        assert not GroupDerivedData.objects.filter(group_id=nonexistent_group_id).exists()
+        mock_generate.assert_not_called()
+        mock_process.assert_not_called()
+
     def test_invalidate_soft_bumps_generated_at(self) -> None:
         # ``generated_at`` is bumped alongside the pipeline_hash null so any
         # in-flight generation started before this call loses its CAS.
@@ -725,6 +745,12 @@ class ProcessGroupLogTest(TestCase):
         derived = process_group_log(group.id)
         first_cursor = derived.cursor_id
 
+        # Direct-create bypasses the outbox and takes ``date_added`` from
+        # ``db_default=Now()`` — Postgres ``NOW()`` returns the enclosing
+        # transaction's start time, which in a test transaction can predate
+        # the outbox-delivered entry above (whose ``date_added`` was stamped
+        # by wall-clock ``timezone.now()``). Set it explicitly so the cursor
+        # predicate sees new_entry as strictly newer.
         new_entry = GroupActionLogEntry.objects.create(
             group_id=group.id,
             project_id=group.project_id,
@@ -733,6 +759,7 @@ class ProcessGroupLogTest(TestCase):
             actor_id=0,
             source=SOURCE,
             data={},
+            date_added=derived.cursor_date + timedelta(seconds=1),
         )
 
         # Officially mark the row stale by resetting pipeline_hash to NULL.

--- a/tests/sentry/issues/derived/test_processing.py
+++ b/tests/sentry/issues/derived/test_processing.py
@@ -408,6 +408,80 @@ class ProcessGroupLogTest(TestCase):
         assert derived.cursor_id == old_cursor
         mock_delay.assert_called_once_with(group.id)
 
+    def test_invalidate_soft_inserts_null_row_when_missing(self) -> None:
+        # No row exists (e.g. group predates the derived-data backfill).
+        # Soft invalidation inserts a placeholder row with pipeline_hash=None
+        # so "null or stale pipeline_hash" is a reliable "needs regen" signal.
+        group = self.create_group()
+        assert not GroupDerivedData.objects.filter(group_id=group.id).exists()
+
+        with (
+            patch(
+                "sentry.issues.derived.processing.generate_group_derived_data.delay"
+            ) as mock_generate,
+            patch("sentry.issues.derived.processing.process_group_log_task.delay") as mock_process,
+        ):
+            invalidate_group_derived_data(group.id)
+
+        row = GroupDerivedData.objects.get(group_id=group.id)
+        assert row.pipeline_hash is None
+        mock_generate.assert_called_once_with(group.id)
+        mock_process.assert_not_called()
+
+    def test_invalidate_soft_inserts_null_row_when_missing_no_trigger(self) -> None:
+        # With trigger_regenerate=False the placeholder is still inserted,
+        # but no task is scheduled — bulk callers drive regeneration.
+        group = self.create_group()
+        assert not GroupDerivedData.objects.filter(group_id=group.id).exists()
+
+        with (
+            patch(
+                "sentry.issues.derived.processing.generate_group_derived_data.delay"
+            ) as mock_generate,
+            patch("sentry.issues.derived.processing.process_group_log_task.delay") as mock_process,
+        ):
+            invalidate_group_derived_data(group.id, trigger_regenerate=False)
+
+        row = GroupDerivedData.objects.get(group_id=group.id)
+        assert row.pipeline_hash is None
+        mock_generate.assert_not_called()
+        mock_process.assert_not_called()
+
+    def test_invalidate_soft_inserts_null_row_when_missing_with_cursor(self) -> None:
+        # Cursor is irrelevant when no row exists: we can't reason about
+        # "pure append" against an absent baseline, so we still insert a
+        # null-hash placeholder.
+        group = self.create_group()
+        assert not GroupDerivedData.objects.filter(group_id=group.id).exists()
+
+        cursor = (django_timezone.now(), 12345)
+        with patch(
+            "sentry.issues.derived.processing.generate_group_derived_data.delay"
+        ) as mock_generate:
+            invalidate_group_derived_data(group.id, cursor=cursor)
+
+        row = GroupDerivedData.objects.get(group_id=group.id)
+        assert row.pipeline_hash is None
+        mock_generate.assert_called_once_with(group.id)
+
+    def test_invalidate_hard_missing_row_does_not_insert(self) -> None:
+        # Hard-delete semantics: readers must not observe any row. Never
+        # materialize a placeholder on the delete path.
+        group = self.create_group()
+        assert not GroupDerivedData.objects.filter(group_id=group.id).exists()
+
+        with (
+            patch(
+                "sentry.issues.derived.processing.generate_group_derived_data.delay"
+            ) as mock_generate,
+            patch("sentry.issues.derived.processing.process_group_log_task.delay") as mock_process,
+        ):
+            invalidate_group_derived_data(group.id, soft=False)
+
+        assert not GroupDerivedData.objects.filter(group_id=group.id).exists()
+        mock_generate.assert_not_called()
+        mock_process.assert_called_once_with(group.id)
+
     def test_invalidate_then_reprocess(self) -> None:
         group = self.create_group()
         user = self.user


### PR DESCRIPTION
This isn't as important in normal group invalidation where we'll be triggering an immediate regen, but as a matter of policy we want to have positive evidence that group derived data is invalid. 
We allow absent GroupDerivedData to mean "no actions yet", and if we're invalidating it, that's no longer the case.
Inserting an explicitly wrong default row rather than leaving an ambiguous absent default row is more correct.

This idiom is more valuable as we do bulk backfills, where some subset of groups will be modified, and it's good to have explicit record of all known to be in need of regen for follow-up processing.

Fixes ISWF-3231.