### PR TITLE
feat(investigations): add lifecycle services [4/13]

### DIFF
--- a/src/sentry/investigations/services/__init__.py
+++ b/src/sentry/investigations/services/__init__.py
@@ -1,0 +1,2 @@
+from .investigations import *  # NOQA
+from .parameters import *  # NOQA

--- a/src/sentry/investigations/services/breached_metrics.py
+++ b/src/sentry/investigations/services/breached_metrics.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any, Iterable
+
+from django.utils import timezone
+
+from sentry.constants import ObjectStatus
+from sentry.incidents.grouptype import MetricIssue
+from sentry.incidents.models.alert_rule import AlertRuleDetectionType
+from sentry.incidents.utils.types import DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION
+from sentry.models.group import Group, GroupStatus
+from sentry.models.groupopenperiod import GroupOpenPeriod
+from sentry.models.organization import Organization
+from sentry.snuba.dataset import Dataset
+from sentry.snuba.models import QuerySubscription, SnubaQueryEventType
+from sentry.workflow_engine.models import DataSourceDetector, DetectorGroup
+from sentry.workflow_engine.models.data_condition import Condition
+
+MAX_BREACH_WINDOW = timedelta(days=45)
+
+
+@dataclass(frozen=True)
+class BreachedMetricSource:
+    group: Group
+    open_period: GroupOpenPeriod
+    project_id: int
+    project_slug: str
+    source_key: str
+    dataset: str
+    snapshot: dict[str, Any]
+
+
+def _code_mode_dataset(
+    dataset: Dataset, event_types: list[SnubaQueryEventType.EventType]
+) -> str | None:
+    if dataset == Dataset.Events:
+        return "errors"
+    if dataset == Dataset.IssuePlatform:
+        return "issues"
+    if dataset == Dataset.SpansIndexed:
+        return "spans"
+    if dataset != Dataset.EventsAnalyticsPlatform or len(event_types) != 1:
+        return None
+    return {
+        SnubaQueryEventType.EventType.ERROR: "errors",
+        SnubaQueryEventType.EventType.TRACE_ITEM_SPAN: "spans",
+        SnubaQueryEventType.EventType.TRACE_ITEM_LOG: "logs",
+        SnubaQueryEventType.EventType.TRACE_ITEM_METRIC: "metrics",
+    }.get(event_types[0])
+
+
+def _source_key(group_id: int, open_period_id: int) -> str:
+    value = f"breached_metric:{group_id}:{open_period_id}"
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+def _direction(conditions: list[dict[str, Any]]) -> str:
+    condition_types = {condition["type"] for condition in conditions}
+    if condition_types & {Condition.GREATER, Condition.GREATER_OR_EQUAL}:
+        return "above"
+    if condition_types & {Condition.LESS, Condition.LESS_OR_EQUAL}:
+        return "below"
+    return "comparison"
+
+
+def _analysis_window(open_period: GroupOpenPeriod, now: datetime) -> dict[str, str]:
+    breach_start = max(open_period.date_started, now - MAX_BREACH_WINDOW)
+    baseline_start = breach_start - (now - breach_start)
+    return {
+        "baselineStart": baseline_start.isoformat(),
+        "breachStart": breach_start.isoformat(),
+        "end": now.isoformat(),
+    }
+
+
+def resolve_breached_metric_sources(
+    *,
+    organization: Organization,
+    group_ids: Iterable[int],
+    accessible_project_ids: set[int],
+    now: datetime | None = None,
+) -> dict[int, BreachedMetricSource]:
+    """Resolve supported current metric breaches in bulk.
+
+    Missing entries are deliberately unavailable. The caller should not reveal
+    whether an inaccessible or invalid issue exists.
+    """
+    unique_group_ids = set(group_ids)
+    if not unique_group_ids:
+        return {}
+
+    groups = {
+        group.id: group
+        for group in Group.objects.filter(
+            id__in=unique_group_ids,
+            project__organization=organization,
+            project_id__in=accessible_project_ids,
+            type=MetricIssue.type_id,
+            status=GroupStatus.UNRESOLVED,
+        ).select_related("project")
+    }
+    open_periods = {
+        period.group_id: period
+        for period in GroupOpenPeriod.objects.filter(
+            group_id__in=groups, date_ended__isnull=True
+        ).select_related("group")
+    }
+    detector_groups = {
+        link.group_id: link
+        for link in DetectorGroup.objects.filter(
+            group_id__in=groups,
+            detector__isnull=False,
+            detector__status=ObjectStatus.ACTIVE,
+        )
+        .select_related("detector", "detector__workflow_condition_group")
+        .prefetch_related("detector__workflow_condition_group__conditions")
+    }
+    data_source_links = {
+        link.detector_id: link
+        for link in DataSourceDetector.objects.filter(
+            detector_id__in=[link.detector_id for link in detector_groups.values()],
+            data_source__type=DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION,
+        ).select_related("data_source")
+    }
+    subscription_ids: set[int] = set()
+    for link in data_source_links.values():
+        try:
+            subscription_ids.add(int(link.data_source.source_id))
+        except (TypeError, ValueError):
+            continue
+    subscriptions = {
+        subscription.id: subscription
+        for subscription in QuerySubscription.objects.filter(id__in=subscription_ids)
+        .select_related("project", "snuba_query", "snuba_query__environment")
+        .prefetch_related("snuba_query__snubaqueryeventtype_set")
+    }
+
+    resolved: dict[int, BreachedMetricSource] = {}
+    current_time = now or timezone.now()
+    for group_id, group in groups.items():
+        open_period = open_periods.get(group_id)
+        detector_group = detector_groups.get(group_id)
+        if open_period is None or detector_group is None or detector_group.detector is None:
+            continue
+        detector = detector_group.detector
+        if (
+            detector.type != "metric_issue"
+            or detector.project_id != group.project_id
+            or detector.config.get("detection_type") != AlertRuleDetectionType.STATIC
+        ):
+            continue
+        data_source_link = data_source_links.get(detector.id)
+        if data_source_link is None:
+            continue
+        try:
+            subscription_id = int(data_source_link.data_source.source_id)
+        except (TypeError, ValueError):
+            continue
+        subscription = subscriptions.get(subscription_id)
+        if subscription is None or subscription.project_id != group.project_id:
+            continue
+        snuba_query = subscription.snuba_query
+        try:
+            dataset = Dataset(snuba_query.dataset)
+        except ValueError:
+            continue
+        code_mode_dataset = _code_mode_dataset(dataset, snuba_query.event_types)
+        if code_mode_dataset is None:
+            continue
+        condition_group = detector.workflow_condition_group
+        if condition_group is None:
+            continue
+        conditions = [
+            {
+                "type": condition.type,
+                "comparison": condition.comparison,
+                "result": condition.condition_result,
+            }
+            for condition in condition_group.conditions.all()
+        ]
+        if not conditions:
+            continue
+        snapshot = {
+            "groupId": str(group.id),
+            "groupTitle": group.title,
+            "openPeriodId": str(open_period.id),
+            "monitor": {
+                "id": str(detector.id),
+                "name": detector.name,
+                "dataset": code_mode_dataset,
+                "query": snuba_query.query,
+                "aggregate": snuba_query.aggregate,
+                "groupBy": snuba_query.group_by or [],
+                "timeWindowSeconds": snuba_query.time_window,
+                "comparisonDeltaSeconds": detector.config.get("comparison_delta"),
+                "direction": _direction(conditions),
+                "conditions": conditions,
+                "environment": (
+                    snuba_query.environment.name if snuba_query.environment is not None else None
+                ),
+            },
+            "project": {"id": str(group.project_id), "slug": group.project.slug},
+            "analysisWindow": _analysis_window(open_period, current_time),
+        }
+        resolved[group_id] = BreachedMetricSource(
+            group=group,
+            open_period=open_period,
+            project_id=group.project_id,
+            project_slug=group.project.slug,
+            source_key=_source_key(group.id, open_period.id),
+            dataset=code_mode_dataset,
+            snapshot=snapshot,
+        )
+    return resolved

--- a/src/sentry/investigations/services/investigations.py
+++ b/src/sentry/investigations/services/investigations.py
@@ -9,6 +9,7 @@ from django.db import IntegrityError, router, transaction
 from django.db.models import Max
 from django.utils import timezone
 
+from sentry.db.models.fields.bounded import I64_MAX
 from sentry.investigations.models import (
     Investigation,
     InvestigationBlock,
@@ -31,6 +32,7 @@ from sentry.investigations.services.parameters import (
 )
 from sentry.investigations.templates import InvestigationTemplateSpec, get_investigation_template
 from sentry.models.organization import Organization
+from sentry.models.project import Project
 
 
 class InvestigationServiceError(Exception):
@@ -94,10 +96,23 @@ def _validate_template_graph(template: InvestigationTemplateSpec) -> None:
 
 
 def _create_project_links(investigation: Investigation, project_ids: Iterable[int]) -> None:
+    requested = sorted(set(project_ids))
+    if not requested:
+        return
+    known = set(
+        Project.objects.filter(
+            id__in=requested, organization_id=investigation.organization_id
+        ).values_list("id", flat=True)
+    )
+    unknown = [project_id for project_id in requested if project_id not in known]
+    if unknown:
+        raise InvestigationValidationError(
+            {"projectIds": "One or more projects are not in this organization."}
+        )
     InvestigationProject.objects.bulk_create(
         [
             InvestigationProject(investigation=investigation, project_id=project_id)
-            for project_id in sorted(set(project_ids))
+            for project_id in requested
         ]
     )
 
@@ -185,7 +200,9 @@ def duplicate_investigation(*, investigation: Investigation, user_id: int) -> In
                     block=blocks_by_id[link.block_id],
                     parameter=parameters_by_id[link.parameter_id],
                 )
-                for link in InvestigationBlockParameter.objects.filter(block_id__in=blocks_by_id)
+                for link in InvestigationBlockParameter.objects.filter(
+                    block_id__in=blocks_by_id, parameter_id__in=parameters_by_id
+                )
             ]
         )
         InvestigationBlockDependency.objects.bulk_create(
@@ -224,6 +241,8 @@ def _resolve_breached_metric_source(
         normalized_group_id = int(group_id)
         normalized_open_period_id = int(open_period_id)
     except (TypeError, ValueError):
+        raise InvestigationSourceNotFound
+    if not 0 < normalized_group_id <= I64_MAX or not 0 < normalized_open_period_id <= I64_MAX:
         raise InvestigationSourceNotFound
     source = resolve_breached_metric_sources(
         organization=organization,
@@ -297,7 +316,6 @@ def _create_template_investigation(
             accessible_project_ids=accessible_project_ids,
         )
         project_ids = [source.project_id]
-        render_context: dict[str, Any] = {}
         resolved_title = title or "Untitled investigation"
         normalized_source_ref = {
             "groupId": str(source.group.id),
@@ -369,9 +387,9 @@ def _create_template_investigation(
                 position=position,
                 kind=block_spec.kind,
                 title=block_spec.title,
-                content=block_spec.content.format(**render_context),
-                prompt=block_spec.generation_prompt.format(**render_context),
-                generated_content=block_spec.generated_content.format(**render_context),
+                content=block_spec.content,
+                prompt=block_spec.generation_prompt,
+                generated_content=block_spec.generated_content,
                 config={
                     **deepcopy(block_spec.config),
                     **({"datasetHint": source.dataset} if block_spec.kind == "query" else {}),
@@ -548,6 +566,9 @@ def delete_cell(
             raise InvestigationValidationError({"detail": "Archived investigations are read-only."})
         if locked.version != expected_block_version:
             raise InvestigationConflictError("Block has changed.")
+        mark_downstream_blocks_stale(
+            investigation_id=investigation.id, upstream_block_ids={locked.id}
+        )
         locked.deleted_at = timezone.now()
         locked.version += 1
         locked.save(update_fields=["deleted_at", "version", "date_updated"])

--- a/src/sentry/investigations/services/investigations.py
+++ b/src/sentry/investigations/services/investigations.py
@@ -35,6 +35,16 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 
 UPDATABLE_INVESTIGATION_FIELDS = frozenset({"title", "status", "filters"})
+MAX_INVESTIGATION_TITLE_LENGTH = 255
+
+CREATABLE_BLOCK_FIELDS = frozenset({"kind", "title", "content", "prompt", "config", "display"})
+UPDATABLE_BLOCK_FIELDS = CREATABLE_BLOCK_FIELDS - {"kind"}
+
+
+def _reject_unsupported_fields(values: dict[str, Any], allowed: frozenset[str]) -> None:
+    unsupported = sorted(set(values) - allowed)
+    if unsupported:
+        raise InvestigationValidationError({"fields": f"Cannot be set: {', '.join(unsupported)}."})
 
 
 class InvestigationServiceError(Exception):
@@ -139,6 +149,11 @@ def create_manual_investigation(
     return investigation
 
 
+def _copy_title(title: str) -> str:
+    prefix = "Copy of "
+    return prefix + title[: MAX_INVESTIGATION_TITLE_LENGTH - len(prefix)]
+
+
 def duplicate_investigation(*, investigation: Investigation, user_id: int) -> Investigation:
     """Copy notebook structure without executions, comments, or collaboration state."""
 
@@ -150,7 +165,7 @@ def duplicate_investigation(*, investigation: Investigation, user_id: int) -> In
         duplicate = Investigation.objects.create(
             organization=source.organization,
             created_by_id=user_id,
-            title=f"Copy of {source.title}",
+            title=_copy_title(source.title),
             template_key=source.template_key,
             template_version=source.template_version,
             source_type=InvestigationSourceType.MANUAL,
@@ -191,9 +206,9 @@ def duplicate_investigation(*, investigation: Investigation, user_id: int) -> In
                 position=block.position,
                 kind=block.kind,
                 title=block.title,
-                content=block.content,
+                content="" if block.content_execution_id else block.content,
                 prompt=block.prompt,
-                generated_content=block.generated_content,
+                generated_content="" if block.content_execution_id else block.generated_content,
                 config=deepcopy(block.config),
                 display=deepcopy(block.display),
             )
@@ -476,6 +491,8 @@ def update_investigation(
 def archive_investigation(*, investigation: Investigation, expected_version: int) -> Investigation:
     with transaction.atomic(using=router.db_for_write(Investigation)):
         locked = lock_investigation(investigation, expected_version)
+        if locked.status == InvestigationStatus.ARCHIVED:
+            return locked
         locked.status = InvestigationStatus.ARCHIVED
         bump_investigation_version(locked)
         if locked.source_key is not None:
@@ -500,6 +517,7 @@ def create_block(
         locked = lock_investigation(investigation, expected_investigation_version)
         if locked.status != InvestigationStatus.ACTIVE:
             raise InvestigationValidationError({"detail": "Archived investigations are read-only."})
+        _reject_unsupported_fields(values, CREATABLE_BLOCK_FIELDS)
         maximum = InvestigationBlock.objects.filter(
             investigation=locked, deleted_at__isnull=True
         ).aggregate(maximum=Max("position"))["maximum"]
@@ -533,6 +551,7 @@ def update_block(
             raise InvestigationValidationError({"detail": "Archived investigations are read-only."})
         if locked.version != expected_block_version:
             raise InvestigationConflictError("Block has changed.")
+        _reject_unsupported_fields(values, UPDATABLE_BLOCK_FIELDS)
         stale_fields = {"content", "prompt", "config"}
         inputs_changed = bool(stale_fields.intersection(values))
         if inputs_changed:

--- a/src/sentry/investigations/services/investigations.py
+++ b/src/sentry/investigations/services/investigations.py
@@ -6,7 +6,7 @@ from copy import deepcopy
 from typing import Any
 
 from django.db import IntegrityError, router, transaction
-from django.db.models import Max
+from django.db.models import F, Max
 from django.utils import timezone
 
 from sentry.db.models.fields.bounded import I64_MAX
@@ -33,6 +33,8 @@ from sentry.investigations.services.parameters import (
 from sentry.investigations.templates import InvestigationTemplateSpec, get_investigation_template
 from sentry.models.organization import Organization
 from sentry.models.project import Project
+
+UPDATABLE_INVESTIGATION_FIELDS = frozenset({"title", "status", "filters"})
 
 
 class InvestigationServiceError(Exception):
@@ -141,7 +143,10 @@ def duplicate_investigation(*, investigation: Investigation, user_id: int) -> In
     """Copy notebook structure without executions, comments, or collaboration state."""
 
     with transaction.atomic(using=router.db_for_write(Investigation)):
-        source = Investigation.objects.select_for_update().get(id=investigation.id)
+        try:
+            source = Investigation.objects.select_for_update().get(id=investigation.id)
+        except Investigation.DoesNotExist:
+            raise InvestigationSourceNotFound
         duplicate = Investigation.objects.create(
             organization=source.organization,
             created_by_id=user_id,
@@ -331,7 +336,8 @@ def _create_template_investigation(
         # uniqueness constraint remains the final guard for other writers.
         Organization.objects.select_for_update().get(id=organization.id)
         active = (
-            Investigation.objects.filter(
+            Investigation.objects.select_for_update()
+            .filter(
                 organization=organization,
                 source_type=template.source_type,
                 source_key=source_key,
@@ -421,7 +427,10 @@ def _create_template_investigation(
 
 
 def lock_investigation(investigation: Investigation, expected_version: int) -> Investigation:
-    locked = Investigation.objects.select_for_update().get(id=investigation.id)
+    try:
+        locked = Investigation.objects.select_for_update().get(id=investigation.id)
+    except Investigation.DoesNotExist:
+        raise InvestigationSourceNotFound
     if locked.version != expected_version:
         raise InvestigationConflictError("Investigation has changed.")
     return locked
@@ -450,6 +459,11 @@ def update_investigation(
             raise InvestigationConflictError(
                 "Archived source investigations cannot be reactivated; create a new revision."
             )
+        unsupported = sorted(set(fields) - UPDATABLE_INVESTIGATION_FIELDS)
+        if unsupported:
+            raise InvestigationValidationError(
+                {"fields": f"Cannot be updated: {', '.join(unsupported)}."}
+            )
         for field, value in fields.items():
             setattr(locked, field, value)
         if project_ids is not None:
@@ -469,7 +483,9 @@ def archive_investigation(*, investigation: Investigation, expected_version: int
                 organization=locked.organization,
                 source_type=locked.source_type,
                 source_key=locked.source_key,
-            ).exclude(id=locked.id).update(status=InvestigationStatus.ARCHIVED)
+            ).exclude(id=locked.id).update(
+                status=InvestigationStatus.ARCHIVED, version=F("version") + 1
+            )
     return locked
 
 
@@ -509,7 +525,10 @@ def update_block(
 ) -> InvestigationBlock:
     with transaction.atomic(using=router.db_for_write(InvestigationBlock)):
         investigation = lock_investigation(block.investigation, expected_investigation_version)
-        locked = InvestigationBlock.objects.select_for_update().get(id=block.id)
+        try:
+            locked = InvestigationBlock.objects.select_for_update().get(id=block.id)
+        except InvestigationBlock.DoesNotExist:
+            raise InvestigationSourceNotFound
         if investigation.status != InvestigationStatus.ACTIVE:
             raise InvestigationValidationError({"detail": "Archived investigations are read-only."})
         if locked.version != expected_block_version:
@@ -561,7 +580,10 @@ def delete_block(
 ) -> None:
     with transaction.atomic(using=router.db_for_write(InvestigationBlock)):
         investigation = lock_investigation(block.investigation, expected_investigation_version)
-        locked = InvestigationBlock.objects.select_for_update().get(id=block.id)
+        try:
+            locked = InvestigationBlock.objects.select_for_update().get(id=block.id)
+        except InvestigationBlock.DoesNotExist:
+            raise InvestigationSourceNotFound
         if investigation.status != InvestigationStatus.ACTIVE:
             raise InvestigationValidationError({"detail": "Archived investigations are read-only."})
         if locked.version != expected_block_version:

--- a/src/sentry/investigations/services/investigations.py
+++ b/src/sentry/investigations/services/investigations.py
@@ -473,7 +473,7 @@ def archive_investigation(*, investigation: Investigation, expected_version: int
     return locked
 
 
-def create_cell(
+def create_block(
     *,
     investigation: Investigation,
     expected_investigation_version: int,
@@ -499,7 +499,7 @@ def create_cell(
     return block
 
 
-def update_cell(
+def update_block(
     *,
     block: InvestigationBlock,
     expected_investigation_version: int,
@@ -556,7 +556,7 @@ def mark_downstream_blocks_stale(
     return stale_ids
 
 
-def delete_cell(
+def delete_block(
     *, block: InvestigationBlock, expected_investigation_version: int, expected_block_version: int
 ) -> None:
     with transaction.atomic(using=router.db_for_write(InvestigationBlock)):
@@ -577,13 +577,13 @@ def delete_cell(
             .filter(investigation=investigation, deleted_at__isnull=True)
             .order_by("position", "id")
         )
-        for position, active_cell in enumerate(active_blocks):
-            active_cell.position = position
+        for position, active_block in enumerate(active_blocks):
+            active_block.position = position
         InvestigationBlock.objects.bulk_update(active_blocks, ["position"])
         bump_investigation_version(investigation)
 
 
-def reorder_cells(
+def reorder_blocks(
     *, investigation: Investigation, expected_version: int, block_ids: list[int]
 ) -> Investigation:
     with transaction.atomic(using=router.db_for_write(Investigation)):
@@ -597,10 +597,10 @@ def reorder_cells(
         )
         existing = {block.id: block for block in blocks}
         if len(block_ids) != len(set(block_ids)):
-            raise InvestigationValidationError({"cellIds": "Block IDs must be unique."})
+            raise InvestigationValidationError({"blockIds": "Block IDs must be unique."})
         if set(block_ids) != set(existing):
             raise InvestigationValidationError(
-                {"cellIds": "Must contain every active block exactly once."}
+                {"blockIds": "Must contain every active block exactly once."}
             )
         ordered = [existing[block_id] for block_id in block_ids]
         for position, block in enumerate(ordered):

--- a/src/sentry/investigations/services/investigations.py
+++ b/src/sentry/investigations/services/investigations.py
@@ -1,0 +1,660 @@
+from __future__ import annotations
+
+from collections import defaultdict, deque
+from collections.abc import Iterable
+from copy import deepcopy
+from typing import Any
+
+from django.db import IntegrityError, router, transaction
+from django.db.models import Max
+from django.utils import timezone
+
+from sentry.investigations.models import (
+    Investigation,
+    InvestigationBlock,
+    InvestigationBlockDependency,
+    InvestigationBlockParameter,
+    InvestigationParameter,
+    InvestigationParameterSource,
+    InvestigationProject,
+    InvestigationSourceType,
+    InvestigationStatus,
+)
+from sentry.investigations.services.breached_metrics import (
+    BreachedMetricSource,
+    resolve_breached_metric_sources,
+)
+from sentry.investigations.services.parameters import (
+    ParameterValidationError,
+    validate_parameter_value,
+    validate_template_parameters,
+)
+from sentry.investigations.templates import InvestigationTemplateSpec, get_investigation_template
+from sentry.models.organization import Organization
+
+
+class InvestigationServiceError(Exception):
+    pass
+
+
+class InvestigationValidationError(InvestigationServiceError):
+    def __init__(self, errors: dict[str, Any]):
+        super().__init__(str(errors))
+        self.errors = errors
+
+
+class InvestigationConflictError(InvestigationServiceError):
+    pass
+
+
+class InvestigationSourceNotFound(InvestigationServiceError):
+    pass
+
+
+def _validate_template_graph(template: InvestigationTemplateSpec) -> None:
+    block_keys = {block.key for block in template.blocks}
+    if len(block_keys) != len(template.blocks):
+        raise InvestigationValidationError({"templateKey": "Template contains duplicate blocks."})
+
+    parameter_keys = {parameter.key for parameter in template.parameters}
+    incoming: dict[str, int] = {key: 0 for key in block_keys}
+    dependents: dict[str, list[str]] = defaultdict(list)
+    for block in template.blocks:
+        unknown_dependencies = sorted(set(block.dependencies) - block_keys)
+        if unknown_dependencies:
+            raise InvestigationValidationError(
+                {"templateKey": f"Block {block.key} has unknown dependencies."}
+            )
+        unknown_parameters = sorted(set(block.parameters) - parameter_keys)
+        if unknown_parameters:
+            raise InvestigationValidationError(
+                {"templateKey": f"Block {block.key} has unknown parameters."}
+            )
+        if block.key in block.dependencies:
+            raise InvestigationValidationError(
+                {"templateKey": f"Block {block.key} cannot depend on itself."}
+            )
+        incoming[block.key] = len(block.dependencies)
+        for dependency in block.dependencies:
+            dependents[dependency].append(block.key)
+
+    queue = deque(key for key, count in incoming.items() if count == 0)
+    visited = 0
+    while queue:
+        key = queue.popleft()
+        visited += 1
+        for dependent in dependents[key]:
+            incoming[dependent] -= 1
+            if incoming[dependent] == 0:
+                queue.append(dependent)
+    if visited != len(block_keys):
+        raise InvestigationValidationError(
+            {"templateKey": "Template dependencies contain a cycle."}
+        )
+
+
+def _create_project_links(investigation: Investigation, project_ids: Iterable[int]) -> None:
+    InvestigationProject.objects.bulk_create(
+        [
+            InvestigationProject(investigation=investigation, project_id=project_id)
+            for project_id in sorted(set(project_ids))
+        ]
+    )
+
+
+def create_manual_investigation(
+    *,
+    organization: Organization,
+    user_id: int,
+    title: str,
+    project_ids: list[int],
+    filters: dict[str, Any],
+) -> Investigation:
+    with transaction.atomic(using=router.db_for_write(Investigation)):
+        investigation = Investigation.objects.create(
+            organization=organization,
+            created_by_id=user_id,
+            title=title,
+            source_type=InvestigationSourceType.MANUAL,
+            filters=filters,
+        )
+        _create_project_links(investigation, project_ids)
+    return investigation
+
+
+def duplicate_investigation(*, investigation: Investigation, user_id: int) -> Investigation:
+    """Copy notebook structure without executions, comments, or collaboration state."""
+
+    with transaction.atomic(using=router.db_for_write(Investigation)):
+        source = Investigation.objects.select_for_update().get(id=investigation.id)
+        duplicate = Investigation.objects.create(
+            organization=source.organization,
+            created_by_id=user_id,
+            title=f"Copy of {source.title}",
+            template_key=source.template_key,
+            template_version=source.template_version,
+            source_type=InvestigationSourceType.MANUAL,
+            source_ref={},
+            filters=deepcopy(source.filters),
+        )
+        _create_project_links(
+            duplicate,
+            source.project_links.values_list("project_id", flat=True),
+        )
+
+        parameters_by_id: dict[int, InvestigationParameter] = {}
+        for parameter in source.parameters.order_by("position", "id"):
+            copied_parameter = InvestigationParameter.objects.create(
+                investigation=duplicate,
+                key=parameter.key,
+                label=parameter.label,
+                description=parameter.description,
+                type=parameter.type,
+                required=parameter.required,
+                validation_constraints=deepcopy(parameter.validation_constraints),
+                default_value=deepcopy(parameter.default_value),
+                saved_value=deepcopy(parameter.saved_value),
+                source=parameter.source,
+                position=parameter.position,
+            )
+            parameters_by_id[parameter.id] = copied_parameter
+
+        blocks_by_id: dict[int, InvestigationBlock] = {}
+        source_blocks = list(
+            source.blocks.filter(deleted_at__isnull=True).order_by("position", "id")
+        )
+        for block in source_blocks:
+            copied_block = InvestigationBlock.objects.create(
+                investigation=duplicate,
+                created_by_id=user_id,
+                last_edited_by_id=user_id,
+                position=block.position,
+                kind=block.kind,
+                title=block.title,
+                content=block.content,
+                prompt=block.prompt,
+                generated_content=block.generated_content,
+                config=deepcopy(block.config),
+                display=deepcopy(block.display),
+            )
+            blocks_by_id[block.id] = copied_block
+
+        InvestigationBlockParameter.objects.bulk_create(
+            [
+                InvestigationBlockParameter(
+                    block=blocks_by_id[link.block_id],
+                    parameter=parameters_by_id[link.parameter_id],
+                )
+                for link in InvestigationBlockParameter.objects.filter(block_id__in=blocks_by_id)
+            ]
+        )
+        InvestigationBlockDependency.objects.bulk_create(
+            [
+                InvestigationBlockDependency(
+                    block=blocks_by_id[link.block_id],
+                    depends_on=blocks_by_id[link.depends_on_id],
+                )
+                for link in InvestigationBlockDependency.objects.filter(
+                    block_id__in=blocks_by_id,
+                    depends_on_id__in=blocks_by_id,
+                )
+            ]
+        )
+
+    return duplicate
+
+
+def _resolve_breached_metric_source(
+    *, organization: Organization, source_ref: dict[str, Any], accessible_project_ids: set[int]
+) -> BreachedMetricSource:
+    if set(source_ref) != {"groupId", "openPeriodId"}:
+        raise InvestigationValidationError(
+            {"sourceRef": ("Must contain exactly groupId and openPeriodId for breached_metric.")}
+        )
+    group_id = source_ref["groupId"]
+    open_period_id = source_ref["openPeriodId"]
+    if (
+        isinstance(group_id, bool)
+        or not isinstance(group_id, int | str)
+        or isinstance(open_period_id, bool)
+        or not isinstance(open_period_id, int | str)
+    ):
+        raise InvestigationValidationError({"sourceRef": "groupId and openPeriodId must be IDs."})
+    try:
+        normalized_group_id = int(group_id)
+        normalized_open_period_id = int(open_period_id)
+    except (TypeError, ValueError):
+        raise InvestigationSourceNotFound
+    source = resolve_breached_metric_sources(
+        organization=organization,
+        group_ids=[normalized_group_id],
+        accessible_project_ids=accessible_project_ids,
+    ).get(normalized_group_id)
+    if source is None or source.open_period.id != normalized_open_period_id:
+        raise InvestigationSourceNotFound
+    return source
+
+
+def create_template_investigation(
+    *,
+    organization: Organization,
+    user_id: int,
+    template_key: str,
+    template_version: int,
+    source_ref: dict[str, Any],
+    supplied_parameters: dict[str, Any],
+    accessible_project_ids: set[int],
+    title: str | None = None,
+) -> Investigation:
+    for attempt in range(3):
+        try:
+            return _create_template_investigation(
+                organization=organization,
+                user_id=user_id,
+                template_key=template_key,
+                template_version=template_version,
+                source_ref=source_ref,
+                supplied_parameters=supplied_parameters,
+                accessible_project_ids=accessible_project_ids,
+                title=title,
+            )
+        except IntegrityError:
+            if attempt == 2:
+                raise
+    raise AssertionError("unreachable")
+
+
+def _create_template_investigation(
+    *,
+    organization: Organization,
+    user_id: int,
+    template_key: str,
+    template_version: int,
+    source_ref: dict[str, Any],
+    supplied_parameters: dict[str, Any],
+    accessible_project_ids: set[int],
+    title: str | None = None,
+) -> Investigation:
+    template = get_investigation_template(template_key, template_version)
+    if template is None:
+        raise InvestigationValidationError(
+            {"templateKey": "Unknown investigation template or version."}
+        )
+    _validate_template_graph(template)
+    try:
+        resolved_parameters = validate_template_parameters(
+            template.parameters,
+            supplied_parameters,
+            accessible_project_ids=accessible_project_ids,
+        )
+    except ParameterValidationError as error:
+        raise InvestigationValidationError({"parameters": str(error)})
+
+    if template.source_type == InvestigationSourceType.BREACHED_METRIC:
+        source = _resolve_breached_metric_source(
+            organization=organization,
+            source_ref=source_ref,
+            accessible_project_ids=accessible_project_ids,
+        )
+        project_ids = [source.project_id]
+        render_context: dict[str, Any] = {}
+        resolved_title = title or "Untitled investigation"
+        normalized_source_ref = {
+            "groupId": str(source.group.id),
+            "openPeriodId": str(source.open_period.id),
+        }
+        source_key = source.source_key
+        filters = {"breachedMetric": source.snapshot}
+    else:
+        raise InvestigationValidationError({"templateKey": "Unsupported template source."})
+
+    with transaction.atomic(using=router.db_for_write(Investigation)):
+        # Allocate revisions under an organization lock. The lineage/revision
+        # uniqueness constraint remains the final guard for other writers.
+        Organization.objects.select_for_update().get(id=organization.id)
+        active = (
+            Investigation.objects.filter(
+                organization=organization,
+                source_type=template.source_type,
+                source_key=source_key,
+                status=InvestigationStatus.ACTIVE,
+            )
+            .order_by("-source_revision", "-id")
+            .first()
+        )
+        if active is not None:
+            return active
+        latest_revision = Investigation.objects.filter(
+            organization=organization,
+            source_type=template.source_type,
+            source_key=source_key,
+        ).aggregate(latest=Max("source_revision"))["latest"]
+        investigation = Investigation.objects.create(
+            organization=organization,
+            created_by_id=user_id,
+            title=resolved_title,
+            template_key=template.key,
+            template_version=template.version,
+            source_type=template.source_type,
+            source_ref=normalized_source_ref,
+            source_key=source_key,
+            source_revision=(latest_revision or 0) + 1,
+            filters=filters,
+        )
+        _create_project_links(investigation, project_ids)
+
+        parameters_by_key: dict[str, InvestigationParameter] = {}
+        for position, parameter_spec in enumerate(template.parameters):
+            parameter = InvestigationParameter.objects.create(
+                investigation=investigation,
+                key=parameter_spec.key,
+                label=parameter_spec.label,
+                description=parameter_spec.description,
+                type=parameter_spec.type,
+                required=parameter_spec.required,
+                validation_constraints=deepcopy(parameter_spec.constraints),
+                default_value=deepcopy(parameter_spec.default_value),
+                saved_value=deepcopy(resolved_parameters[parameter_spec.key]),
+                source=InvestigationParameterSource.TEMPLATE,
+                position=position,
+            )
+            parameters_by_key[parameter.key] = parameter
+
+        blocks_by_key: dict[str, InvestigationBlock] = {}
+        for position, block_spec in enumerate(template.blocks):
+            block = InvestigationBlock.objects.create(
+                investigation=investigation,
+                created_by_id=user_id,
+                last_edited_by_id=user_id,
+                position=position,
+                kind=block_spec.kind,
+                title=block_spec.title,
+                content=block_spec.content.format(**render_context),
+                prompt=block_spec.generation_prompt.format(**render_context),
+                generated_content=block_spec.generated_content.format(**render_context),
+                config={
+                    **deepcopy(block_spec.config),
+                    **({"datasetHint": source.dataset} if block_spec.kind == "query" else {}),
+                },
+                display=deepcopy(block_spec.display),
+            )
+            blocks_by_key[block_spec.key] = block
+            InvestigationBlockParameter.objects.bulk_create(
+                [
+                    InvestigationBlockParameter(
+                        block=block, parameter=parameters_by_key[parameter_key]
+                    )
+                    for parameter_key in block_spec.parameters
+                ]
+            )
+
+        InvestigationBlockDependency.objects.bulk_create(
+            [
+                InvestigationBlockDependency(
+                    block=blocks_by_key[block_spec.key],
+                    depends_on=blocks_by_key[dependency_key],
+                )
+                for block_spec in template.blocks
+                for dependency_key in block_spec.dependencies
+            ]
+        )
+
+    return investigation
+
+
+def lock_investigation(investigation: Investigation, expected_version: int) -> Investigation:
+    locked = Investigation.objects.select_for_update().get(id=investigation.id)
+    if locked.version != expected_version:
+        raise InvestigationConflictError("Investigation has changed.")
+    return locked
+
+
+def bump_investigation_version(investigation: Investigation) -> None:
+    investigation.version += 1
+    investigation.save()
+
+
+def update_investigation(
+    *,
+    investigation: Investigation,
+    expected_version: int,
+    fields: dict[str, Any],
+    project_ids: list[int] | None,
+) -> Investigation:
+    with transaction.atomic(using=router.db_for_write(Investigation)):
+        locked = lock_investigation(investigation, expected_version)
+        restoring_source_investigation = (
+            locked.status == InvestigationStatus.ARCHIVED
+            and fields.get("status") == InvestigationStatus.ACTIVE
+            and locked.source_key is not None
+        )
+        if restoring_source_investigation:
+            raise InvestigationConflictError(
+                "Archived source investigations cannot be reactivated; create a new revision."
+            )
+        for field, value in fields.items():
+            setattr(locked, field, value)
+        if project_ids is not None:
+            InvestigationProject.objects.filter(investigation=locked).delete()
+            _create_project_links(locked, project_ids)
+        bump_investigation_version(locked)
+    return locked
+
+
+def archive_investigation(*, investigation: Investigation, expected_version: int) -> Investigation:
+    with transaction.atomic(using=router.db_for_write(Investigation)):
+        locked = lock_investigation(investigation, expected_version)
+        locked.status = InvestigationStatus.ARCHIVED
+        bump_investigation_version(locked)
+        if locked.source_key is not None:
+            Investigation.objects.filter(
+                organization=locked.organization,
+                source_type=locked.source_type,
+                source_key=locked.source_key,
+            ).exclude(id=locked.id).update(status=InvestigationStatus.ARCHIVED)
+    return locked
+
+
+def create_cell(
+    *,
+    investigation: Investigation,
+    expected_investigation_version: int,
+    user_id: int,
+    values: dict[str, Any],
+) -> InvestigationBlock:
+    with transaction.atomic(using=router.db_for_write(Investigation)):
+        locked = lock_investigation(investigation, expected_investigation_version)
+        if locked.status != InvestigationStatus.ACTIVE:
+            raise InvestigationValidationError({"detail": "Archived investigations are read-only."})
+        maximum = InvestigationBlock.objects.filter(
+            investigation=locked, deleted_at__isnull=True
+        ).aggregate(maximum=Max("position"))["maximum"]
+        position = 0 if maximum is None else maximum + 1
+        block = InvestigationBlock.objects.create(
+            investigation=locked,
+            created_by_id=user_id,
+            last_edited_by_id=user_id,
+            position=position,
+            **values,
+        )
+        bump_investigation_version(locked)
+    return block
+
+
+def update_cell(
+    *,
+    block: InvestigationBlock,
+    expected_investigation_version: int,
+    expected_block_version: int,
+    user_id: int,
+    values: dict[str, Any],
+) -> InvestigationBlock:
+    with transaction.atomic(using=router.db_for_write(InvestigationBlock)):
+        investigation = lock_investigation(block.investigation, expected_investigation_version)
+        locked = InvestigationBlock.objects.select_for_update().get(id=block.id)
+        if investigation.status != InvestigationStatus.ACTIVE:
+            raise InvestigationValidationError({"detail": "Archived investigations are read-only."})
+        if locked.version != expected_block_version:
+            raise InvestigationConflictError("Block has changed.")
+        stale_fields = {"content", "prompt", "config"}
+        inputs_changed = bool(stale_fields.intersection(values))
+        if inputs_changed:
+            locked.stale_at = timezone.now()
+        for field, value in values.items():
+            setattr(locked, field, value)
+        locked.last_edited_by_id = user_id
+        locked.version += 1
+        locked.save()
+        if inputs_changed:
+            mark_downstream_blocks_stale(
+                investigation_id=investigation.id, upstream_block_ids={locked.id}
+            )
+        bump_investigation_version(investigation)
+    return locked
+
+
+def mark_downstream_blocks_stale(
+    *, investigation_id: int, upstream_block_ids: set[int]
+) -> set[int]:
+    dependent_edges = InvestigationBlockDependency.objects.filter(
+        block__investigation_id=investigation_id,
+        block__deleted_at__isnull=True,
+        depends_on__deleted_at__isnull=True,
+    ).values_list("depends_on_id", "block_id")
+    dependents: dict[int, list[int]] = defaultdict(list)
+    for upstream_id, dependent_id in dependent_edges:
+        dependents[upstream_id].append(dependent_id)
+
+    stale_ids: set[int] = set()
+    queue = deque(upstream_block_ids)
+    while queue:
+        upstream_id = queue.popleft()
+        for dependent_id in dependents[upstream_id]:
+            if dependent_id not in stale_ids and dependent_id not in upstream_block_ids:
+                stale_ids.add(dependent_id)
+                queue.append(dependent_id)
+    if stale_ids:
+        InvestigationBlock.objects.filter(id__in=stale_ids).update(stale_at=timezone.now())
+    return stale_ids
+
+
+def delete_cell(
+    *, block: InvestigationBlock, expected_investigation_version: int, expected_block_version: int
+) -> None:
+    with transaction.atomic(using=router.db_for_write(InvestigationBlock)):
+        investigation = lock_investigation(block.investigation, expected_investigation_version)
+        locked = InvestigationBlock.objects.select_for_update().get(id=block.id)
+        if investigation.status != InvestigationStatus.ACTIVE:
+            raise InvestigationValidationError({"detail": "Archived investigations are read-only."})
+        if locked.version != expected_block_version:
+            raise InvestigationConflictError("Block has changed.")
+        locked.deleted_at = timezone.now()
+        locked.version += 1
+        locked.save(update_fields=["deleted_at", "version", "date_updated"])
+        active_blocks = list(
+            InvestigationBlock.objects.select_for_update()
+            .filter(investigation=investigation, deleted_at__isnull=True)
+            .order_by("position", "id")
+        )
+        for position, active_cell in enumerate(active_blocks):
+            active_cell.position = position
+        InvestigationBlock.objects.bulk_update(active_blocks, ["position"])
+        bump_investigation_version(investigation)
+
+
+def reorder_cells(
+    *, investigation: Investigation, expected_version: int, block_ids: list[int]
+) -> Investigation:
+    with transaction.atomic(using=router.db_for_write(Investigation)):
+        locked = lock_investigation(investigation, expected_version)
+        if locked.status != InvestigationStatus.ACTIVE:
+            raise InvestigationValidationError({"detail": "Archived investigations are read-only."})
+        blocks = list(
+            InvestigationBlock.objects.select_for_update().filter(
+                investigation=locked, deleted_at__isnull=True
+            )
+        )
+        existing = {block.id: block for block in blocks}
+        if len(block_ids) != len(set(block_ids)):
+            raise InvestigationValidationError({"cellIds": "Block IDs must be unique."})
+        if set(block_ids) != set(existing):
+            raise InvestigationValidationError(
+                {"cellIds": "Must contain every active block exactly once."}
+            )
+        ordered = [existing[block_id] for block_id in block_ids]
+        for position, block in enumerate(ordered):
+            block.position = position
+        InvestigationBlock.objects.bulk_update(ordered, ["position"])
+        bump_investigation_version(locked)
+    return locked
+
+
+def update_parameter_values(
+    *,
+    investigation: Investigation,
+    expected_version: int,
+    values: dict[str, Any],
+    accessible_project_ids: set[int],
+) -> Investigation:
+    with transaction.atomic(using=router.db_for_write(Investigation)):
+        locked = lock_investigation(investigation, expected_version)
+        if locked.status != InvestigationStatus.ACTIVE:
+            raise InvestigationValidationError({"detail": "Archived investigations are read-only."})
+        parameters = {
+            parameter.key: parameter
+            for parameter in InvestigationParameter.objects.select_for_update().filter(
+                investigation=locked
+            )
+        }
+        unknown = sorted(set(values) - set(parameters))
+        if unknown:
+            raise InvestigationValidationError(
+                {"values": f"Unknown parameters: {', '.join(unknown)}."}
+            )
+
+        changed_parameter_ids: list[int] = []
+        for key, value in values.items():
+            parameter = parameters[key]
+            try:
+                validated = validate_parameter_value(
+                    parameter_type=parameter.type,
+                    value=value,
+                    constraints=parameter.validation_constraints,
+                    accessible_project_ids=accessible_project_ids,
+                )
+            except ParameterValidationError as error:
+                raise InvestigationValidationError({"values": {key: str(error)}})
+            if parameter.saved_value != validated:
+                parameter.saved_value = validated
+                parameter.version += 1
+                parameter.save(update_fields=["saved_value", "version", "date_updated"])
+                changed_parameter_ids.append(parameter.id)
+
+        if changed_parameter_ids:
+            directly_stale = set(
+                InvestigationBlockParameter.objects.filter(
+                    parameter_id__in=changed_parameter_ids,
+                    block__investigation=locked,
+                    block__deleted_at__isnull=True,
+                ).values_list("block_id", flat=True)
+            )
+            dependent_edges = InvestigationBlockDependency.objects.filter(
+                block__investigation=locked,
+                block__deleted_at__isnull=True,
+                depends_on__deleted_at__isnull=True,
+            ).values_list("depends_on_id", "block_id")
+            dependents: dict[int, list[int]] = defaultdict(list)
+            for upstream_id, dependent_id in dependent_edges:
+                dependents[upstream_id].append(dependent_id)
+            stale_ids = set(directly_stale)
+            queue = deque(directly_stale)
+            while queue:
+                upstream_id = queue.popleft()
+                for dependent_id in dependents[upstream_id]:
+                    if dependent_id not in stale_ids:
+                        stale_ids.add(dependent_id)
+                        queue.append(dependent_id)
+            InvestigationBlock.objects.filter(id__in=stale_ids).update(stale_at=timezone.now())
+
+        bump_investigation_version(locked)
+    return locked

--- a/src/sentry/investigations/services/parameters.py
+++ b/src/sentry/investigations/services/parameters.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any
+
+from django.utils import timezone
+from django.utils.dateparse import parse_datetime
+
+from sentry.investigations.models import InvestigationParameterType
+from sentry.investigations.templates.types import TemplateParameterSpec
+
+
+class ParameterValidationError(ValueError):
+    pass
+
+
+def validate_parameter_value(
+    *,
+    parameter_type: str,
+    value: Any,
+    constraints: dict[str, Any],
+    accessible_project_ids: set[int] | None = None,
+) -> Any:
+    if parameter_type == InvestigationParameterType.STRING:
+        if not isinstance(value, str):
+            raise ParameterValidationError("Must be a string.")
+        max_length = constraints.get("maxLength")
+        if max_length is not None and len(value) > max_length:
+            raise ParameterValidationError(f"Must contain at most {max_length} characters.")
+        return value
+
+    if parameter_type == InvestigationParameterType.NUMBER:
+        if isinstance(value, bool) or not isinstance(value, int | float):
+            raise ParameterValidationError("Must be a number.")
+        if "min" in constraints and value < constraints["min"]:
+            raise ParameterValidationError(f"Must be at least {constraints['min']}.")
+        if "max" in constraints and value > constraints["max"]:
+            raise ParameterValidationError(f"Must be at most {constraints['max']}.")
+        return value
+
+    if parameter_type == InvestigationParameterType.BOOLEAN:
+        if not isinstance(value, bool):
+            raise ParameterValidationError("Must be a boolean.")
+        return value
+
+    if parameter_type == InvestigationParameterType.ENUM:
+        if value not in constraints.get("options", []):
+            raise ParameterValidationError("Must be one of the declared options.")
+        return value
+
+    if parameter_type == InvestigationParameterType.DURATION:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ParameterValidationError("Must be an integer number of seconds.")
+        if "min" in constraints and value < constraints["min"]:
+            raise ParameterValidationError(f"Must be at least {constraints['min']} seconds.")
+        if "max" in constraints and value > constraints["max"]:
+            raise ParameterValidationError(f"Must be at most {constraints['max']} seconds.")
+        return value
+
+    if parameter_type == InvestigationParameterType.DATETIME_RANGE:
+        if not isinstance(value, dict) or set(value) != {"start", "end"}:
+            raise ParameterValidationError("Must contain exactly start and end.")
+        start = parse_datetime(value["start"]) if isinstance(value["start"], str) else None
+        end = parse_datetime(value["end"]) if isinstance(value["end"], str) else None
+        if (
+            start is None
+            or end is None
+            or not timezone.is_aware(start)
+            or not timezone.is_aware(end)
+        ):
+            raise ParameterValidationError("Start and end must be timezone-aware ISO datetimes.")
+        if start >= end:
+            raise ParameterValidationError("Start must be before end.")
+        max_days = constraints.get("maxDays")
+        if max_days is not None and end - start > timedelta(days=max_days):
+            raise ParameterValidationError(f"Range must not exceed {max_days} days.")
+        return {"start": start.isoformat(), "end": end.isoformat()}
+
+    if parameter_type == InvestigationParameterType.PROJECT:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ParameterValidationError("Must be a project ID.")
+        if accessible_project_ids is not None and value not in accessible_project_ids:
+            raise ParameterValidationError("Project is inaccessible.")
+        return value
+
+    if parameter_type == InvestigationParameterType.PROJECT_LIST:
+        if not isinstance(value, list) or any(
+            isinstance(item, bool) or not isinstance(item, int) for item in value
+        ):
+            raise ParameterValidationError("Must be a list of project IDs.")
+        if len(set(value)) != len(value):
+            raise ParameterValidationError("Project IDs must be unique.")
+        if accessible_project_ids is not None and not set(value).issubset(accessible_project_ids):
+            raise ParameterValidationError("One or more projects are inaccessible.")
+        return value
+
+    if parameter_type == InvestigationParameterType.ENVIRONMENT_LIST:
+        if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+            raise ParameterValidationError("Must be a list of environment names.")
+        if len(set(value)) != len(value):
+            raise ParameterValidationError("Environment names must be unique.")
+        max_items = constraints.get("maxItems")
+        if max_items is not None and len(value) > max_items:
+            raise ParameterValidationError(f"Must contain at most {max_items} environments.")
+        return value
+
+    raise ParameterValidationError("Unsupported parameter type.")
+
+
+def validate_template_parameters(
+    specs: tuple[TemplateParameterSpec, ...],
+    supplied: dict[str, Any],
+    *,
+    accessible_project_ids: set[int] | None = None,
+) -> dict[str, Any]:
+    declared = {spec.key: spec for spec in specs}
+    extra = sorted(set(supplied) - set(declared))
+    if extra:
+        raise ParameterValidationError(f"Unknown parameters: {', '.join(extra)}.")
+
+    resolved: dict[str, Any] = {}
+    for spec in specs:
+        if spec.key in supplied:
+            value = supplied[spec.key]
+        elif spec.default_value is not None:
+            value = spec.default_value
+        elif spec.required:
+            raise ParameterValidationError(f"Missing required parameter: {spec.key}.")
+        else:
+            value = None
+
+        if value is not None:
+            value = validate_parameter_value(
+                parameter_type=spec.type,
+                value=value,
+                constraints=spec.constraints,
+                accessible_project_ids=accessible_project_ids,
+            )
+        resolved[spec.key] = value
+
+    return resolved

--- a/src/sentry/investigations/services/parameters.py
+++ b/src/sentry/investigations/services/parameters.py
@@ -122,6 +122,8 @@ def validate_template_parameters(
     for spec in specs:
         if spec.key in supplied:
             value = supplied[spec.key]
+            if value is None and spec.required:
+                raise ParameterValidationError(f"Missing required parameter: {spec.key}.")
         elif spec.default_value is not None:
             value = spec.default_value
         elif spec.required:

--- a/src/sentry/investigations/services/parameters.py
+++ b/src/sentry/investigations/services/parameters.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from datetime import timedelta
 from typing import Any
 
@@ -32,6 +33,8 @@ def validate_parameter_value(
     if parameter_type == InvestigationParameterType.NUMBER:
         if isinstance(value, bool) or not isinstance(value, int | float):
             raise ParameterValidationError("Must be a number.")
+        if isinstance(value, float) and not math.isfinite(value):
+            raise ParameterValidationError("Must be a finite number.")
         if "min" in constraints and value < constraints["min"]:
             raise ParameterValidationError(f"Must be at least {constraints['min']}.")
         if "max" in constraints and value > constraints["max"]:

--- a/tests/sentry/investigations/services/test_investigations.py
+++ b/tests/sentry/investigations/services/test_investigations.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+from django.db import IntegrityError
+
+from sentry.investigations.services.investigations import create_template_investigation
+
+TEMPLATE_KWARGS = {
+    "organization": mock.sentinel.organization,
+    "user_id": 1,
+    "template_key": "breached_metric",
+    "template_version": 1,
+    "source_ref": {},
+    "supplied_parameters": {},
+    "accessible_project_ids": set(),
+}
+
+
+def test_template_creation_retries_revision_uniqueness_collisions() -> None:
+    created = mock.sentinel.investigation
+    with mock.patch(
+        "sentry.investigations.services.investigations._create_template_investigation",
+        side_effect=[IntegrityError(), created],
+    ) as create:
+        result = create_template_investigation(**TEMPLATE_KWARGS)
+
+    assert result is created
+    assert create.call_count == 2
+
+
+def test_template_creation_succeeds_without_a_collision() -> None:
+    created = mock.sentinel.investigation
+    with mock.patch(
+        "sentry.investigations.services.investigations._create_template_investigation",
+        return_value=created,
+    ) as create:
+        result = create_template_investigation(**TEMPLATE_KWARGS)
+
+    assert result is created
+    assert create.call_count == 1
+
+
+def test_template_creation_reraises_after_exhausting_retries() -> None:
+    with mock.patch(
+        "sentry.investigations.services.investigations._create_template_investigation",
+        side_effect=IntegrityError(),
+    ) as create:
+        with pytest.raises(IntegrityError):
+            create_template_investigation(**TEMPLATE_KWARGS)
+
+    assert create.call_count == 3

--- a/tests/sentry/investigations/services/test_investigations.py
+++ b/tests/sentry/investigations/services/test_investigations.py
@@ -11,10 +11,10 @@ from sentry.investigations.services.investigations import (
     InvestigationSourceNotFound,
     InvestigationValidationError,
     _resolve_breached_metric_source,
-    create_cell,
+    create_block,
     create_manual_investigation,
     create_template_investigation,
-    delete_cell,
+    delete_block,
     update_investigation,
 )
 from sentry.testutils.cases import TestCase
@@ -128,14 +128,14 @@ class DeleteBlockStalenessTest(TestCase):
             project_ids=[],
             filters={},
         )
-        upstream = create_cell(
+        upstream = create_block(
             investigation=investigation,
             expected_investigation_version=investigation.version,
             user_id=self.user.id,
             values={"kind": "query"},
         )
         investigation.refresh_from_db()
-        dependent = create_cell(
+        dependent = create_block(
             investigation=investigation,
             expected_investigation_version=investigation.version,
             user_id=self.user.id,
@@ -145,7 +145,7 @@ class DeleteBlockStalenessTest(TestCase):
         InvestigationBlockDependency.objects.create(block=dependent, depends_on=upstream)
         assert dependent.stale_at is None
 
-        delete_cell(
+        delete_block(
             block=upstream,
             expected_investigation_version=investigation.version,
             expected_block_version=upstream.version,

--- a/tests/sentry/investigations/services/test_investigations.py
+++ b/tests/sentry/investigations/services/test_investigations.py
@@ -6,15 +6,23 @@ import pytest
 from django.db import IntegrityError
 
 from sentry.db.models.fields.bounded import I64_MAX
-from sentry.investigations.models import InvestigationBlockDependency, InvestigationProject
+from sentry.investigations.models import (
+    Investigation,
+    InvestigationBlockDependency,
+    InvestigationProject,
+    InvestigationSourceType,
+    InvestigationStatus,
+)
 from sentry.investigations.services.investigations import (
     InvestigationSourceNotFound,
     InvestigationValidationError,
     _resolve_breached_metric_source,
+    archive_investigation,
     create_block,
     create_manual_investigation,
     create_template_investigation,
     delete_block,
+    lock_investigation,
     update_investigation,
 )
 from sentry.testutils.cases import TestCase
@@ -171,3 +179,100 @@ class BreachedMetricSourceRefTest(TestCase):
                 source_ref={"groupId": "0", "openPeriodId": "1"},
                 accessible_project_ids={self.project.id},
             )
+
+
+class ConcurrentModificationTest(TestCase):
+    def lineage_pair(self) -> tuple[Investigation, Investigation]:
+        first = create_manual_investigation(
+            organization=self.organization,
+            user_id=self.user.id,
+            title="First",
+            project_ids=[],
+            filters={},
+        )
+        second = create_manual_investigation(
+            organization=self.organization,
+            user_id=self.user.id,
+            title="Second",
+            project_ids=[],
+            filters={},
+        )
+        for revision, investigation in enumerate((first, second), start=1):
+            Investigation.objects.filter(id=investigation.id).update(
+                source_type=InvestigationSourceType.BREACHED_METRIC,
+                source_key="lineage",
+                source_revision=revision,
+            )
+            investigation.refresh_from_db()
+        return first, second
+
+    def test_cascade_archive_bumps_sibling_versions(self) -> None:
+        """
+        Siblings are archived by a bulk update, so without a version bump a
+        client holding a stale reference would still pass the optimistic lock.
+        """
+        first, second = self.lineage_pair()
+        before = second.version
+
+        archive_investigation(investigation=first, expected_version=first.version)
+
+        second.refresh_from_db()
+        assert second.status == InvestigationStatus.ARCHIVED
+        assert second.version == before + 1
+
+    def test_locking_a_deleted_investigation_is_a_missing_source(self) -> None:
+        """A concurrent delete should not surface as an unhandled 500."""
+        investigation = create_manual_investigation(
+            organization=self.organization,
+            user_id=self.user.id,
+            title="Gone",
+            project_ids=[],
+            filters={},
+        )
+        Investigation.objects.filter(id=investigation.id).delete()
+
+        with pytest.raises(InvestigationSourceNotFound):
+            lock_investigation(investigation, investigation.version)
+
+
+class UpdateFieldAllowlistTest(TestCase):
+    def test_rejects_fields_outside_the_allowlist(self) -> None:
+        """The service does not trust its caller to have filtered `fields`."""
+        other_organization = self.create_organization(name="other")
+        investigation = create_manual_investigation(
+            organization=self.organization,
+            user_id=self.user.id,
+            title="Investigation",
+            project_ids=[],
+            filters={},
+        )
+
+        with pytest.raises(InvestigationValidationError):
+            update_investigation(
+                investigation=investigation,
+                expected_version=investigation.version,
+                fields={"organization_id": other_organization.id},
+                project_ids=None,
+            )
+
+        investigation.refresh_from_db()
+        assert investigation.organization_id == self.organization.id
+
+    def test_accepts_the_allowlisted_fields(self) -> None:
+        investigation = create_manual_investigation(
+            organization=self.organization,
+            user_id=self.user.id,
+            title="Investigation",
+            project_ids=[],
+            filters={},
+        )
+
+        updated = update_investigation(
+            investigation=investigation,
+            expected_version=investigation.version,
+            fields={"title": "Renamed", "filters": {"environment": ["prod"]}},
+            project_ids=None,
+        )
+
+        assert updated.title == "Renamed"
+        assert updated.filters == {"environment": ["prod"]}

--- a/tests/sentry/investigations/services/test_investigations.py
+++ b/tests/sentry/investigations/services/test_investigations.py
@@ -5,7 +5,19 @@ from unittest import mock
 import pytest
 from django.db import IntegrityError
 
-from sentry.investigations.services.investigations import create_template_investigation
+from sentry.db.models.fields.bounded import I64_MAX
+from sentry.investigations.models import InvestigationBlockDependency, InvestigationProject
+from sentry.investigations.services.investigations import (
+    InvestigationSourceNotFound,
+    InvestigationValidationError,
+    _resolve_breached_metric_source,
+    create_cell,
+    create_manual_investigation,
+    create_template_investigation,
+    delete_cell,
+    update_investigation,
+)
+from sentry.testutils.cases import TestCase
 
 TEMPLATE_KWARGS = {
     "organization": mock.sentinel.organization,
@@ -51,3 +63,111 @@ def test_template_creation_reraises_after_exhausting_retries() -> None:
             create_template_investigation(**TEMPLATE_KWARGS)
 
     assert create.call_count == 3
+
+
+class ProjectLinkScopingTest(TestCase):
+    def test_create_rejects_projects_from_another_organization(self) -> None:
+        other_organization = self.create_organization(name="other")
+        foreign_project = self.create_project(organization=other_organization)
+
+        with pytest.raises(InvestigationValidationError) as excinfo:
+            create_manual_investigation(
+                organization=self.organization,
+                user_id=self.user.id,
+                title="Investigation",
+                project_ids=[foreign_project.id],
+                filters={},
+            )
+
+        assert "projectIds" in excinfo.value.errors
+        assert not InvestigationProject.objects.filter(project_id=foreign_project.id).exists()
+
+    def test_create_accepts_projects_in_the_organization(self) -> None:
+        investigation = create_manual_investigation(
+            organization=self.organization,
+            user_id=self.user.id,
+            title="Investigation",
+            project_ids=[self.project.id],
+            filters={},
+        )
+
+        assert list(
+            InvestigationProject.objects.filter(investigation=investigation).values_list(
+                "project_id", flat=True
+            )
+        ) == [self.project.id]
+
+    def test_update_rejects_projects_from_another_organization(self) -> None:
+        other_organization = self.create_organization(name="other")
+        foreign_project = self.create_project(organization=other_organization)
+        investigation = create_manual_investigation(
+            organization=self.organization,
+            user_id=self.user.id,
+            title="Investigation",
+            project_ids=[self.project.id],
+            filters={},
+        )
+
+        with pytest.raises(InvestigationValidationError):
+            update_investigation(
+                investigation=investigation,
+                expected_version=investigation.version,
+                fields={},
+                project_ids=[foreign_project.id],
+            )
+
+        assert not InvestigationProject.objects.filter(project_id=foreign_project.id).exists()
+
+
+class DeleteBlockStalenessTest(TestCase):
+    def test_deleting_an_upstream_block_marks_its_dependents_stale(self) -> None:
+        investigation = create_manual_investigation(
+            organization=self.organization,
+            user_id=self.user.id,
+            title="Investigation",
+            project_ids=[],
+            filters={},
+        )
+        upstream = create_cell(
+            investigation=investigation,
+            expected_investigation_version=investigation.version,
+            user_id=self.user.id,
+            values={"kind": "query"},
+        )
+        investigation.refresh_from_db()
+        dependent = create_cell(
+            investigation=investigation,
+            expected_investigation_version=investigation.version,
+            user_id=self.user.id,
+            values={"kind": "text"},
+        )
+        investigation.refresh_from_db()
+        InvestigationBlockDependency.objects.create(block=dependent, depends_on=upstream)
+        assert dependent.stale_at is None
+
+        delete_cell(
+            block=upstream,
+            expected_investigation_version=investigation.version,
+            expected_block_version=upstream.version,
+        )
+
+        dependent.refresh_from_db()
+        assert dependent.stale_at is not None
+
+
+class BreachedMetricSourceRefTest(TestCase):
+    def test_out_of_range_ids_are_treated_as_a_missing_source(self) -> None:
+        with pytest.raises(InvestigationSourceNotFound):
+            _resolve_breached_metric_source(
+                organization=self.organization,
+                source_ref={"groupId": str(I64_MAX + 1), "openPeriodId": "1"},
+                accessible_project_ids={self.project.id},
+            )
+
+    def test_non_positive_ids_are_treated_as_a_missing_source(self) -> None:
+        with pytest.raises(InvestigationSourceNotFound):
+            _resolve_breached_metric_source(
+                organization=self.organization,
+                source_ref={"groupId": "0", "openPeriodId": "1"},
+                accessible_project_ids={self.project.id},
+            )

--- a/tests/sentry/investigations/services/test_parameters.py
+++ b/tests/sentry/investigations/services/test_parameters.py
@@ -4,6 +4,7 @@ import pytest
 
 from sentry.investigations.services.parameters import (
     ParameterValidationError,
+    validate_parameter_value,
     validate_template_parameters,
 )
 from sentry.investigations.templates.types import TemplateParameterSpec
@@ -33,3 +34,17 @@ def test_optional_parameter_still_accepts_an_explicit_null() -> None:
 def test_unknown_parameters_are_rejected() -> None:
     with pytest.raises(ParameterValidationError):
         validate_template_parameters((OPTIONAL,), {"nope": "x"})
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_number_parameter_rejects_non_finite_values(value: float) -> None:
+    """
+    JSON parsing accepts these, but a JSONField cannot store them, and every
+    comparison against them is False so min/max would not reject them either.
+    """
+    with pytest.raises(ParameterValidationError):
+        validate_parameter_value(parameter_type="number", value=value, constraints={})
+
+
+def test_number_parameter_accepts_finite_values() -> None:
+    assert validate_parameter_value(parameter_type="number", value=1.5, constraints={}) == 1.5

--- a/tests/sentry/investigations/services/test_parameters.py
+++ b/tests/sentry/investigations/services/test_parameters.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import pytest
+
+from sentry.investigations.services.parameters import (
+    ParameterValidationError,
+    validate_template_parameters,
+)
+from sentry.investigations.templates.types import TemplateParameterSpec
+
+REQUIRED = TemplateParameterSpec(key="env", label="Env", type="string", required=True)
+OPTIONAL = TemplateParameterSpec(key="env", label="Env", type="string")
+
+
+def test_required_parameter_rejects_an_omitted_key() -> None:
+    with pytest.raises(ParameterValidationError):
+        validate_template_parameters((REQUIRED,), {})
+
+
+def test_required_parameter_rejects_an_explicit_null() -> None:
+    with pytest.raises(ParameterValidationError):
+        validate_template_parameters((REQUIRED,), {"env": None})
+
+
+def test_required_parameter_accepts_a_value() -> None:
+    assert validate_template_parameters((REQUIRED,), {"env": "prod"}) == {"env": "prod"}
+
+
+def test_optional_parameter_still_accepts_an_explicit_null() -> None:
+    assert validate_template_parameters((OPTIONAL,), {"env": None}) == {"env": None}
+
+
+def test_unknown_parameters_are_rejected() -> None:
+    with pytest.raises(ParameterValidationError):
+        validate_template_parameters((OPTIONAL,), {"nope": "x"})


### PR DESCRIPTION
This PR adds the Investigation lifecycle services for creation, duplication, updates, archival, favorites, locking, project association, parameter handling, breached-metric source resolution, and restoration conflict behavior. It contains service-layer behavior only and is stacked on the schema and contracts below it.

All Investigation user-facing behavior is gated by organizations:investigations. Query and text execution plus breached-metric entry points also require organizations:investigations-query-execution. Keep the main flag disabled during deployment, then enable both flags for internal organizations first and expand gradually.