### PR TITLE
feat(investigations): add parameter APIs [7/13]

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -314,6 +314,9 @@ from sentry.investigations.endpoints.organization_investigation_favorite import 
 from sentry.investigations.endpoints.organization_investigation_index import (
     OrganizationInvestigationsIndexEndpoint,
 )
+from sentry.investigations.endpoints.organization_investigation_parameters import (
+    OrganizationInvestigationParametersEndpoint,
+)
 from sentry.issues.endpoints import (
     ActionableItemsEndpoint,
     EventIdLookupEndpoint,
@@ -2420,6 +2423,11 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^/]+)/investigations/(?P<investigation_id>[^/]+)/duplicate/$",
         OrganizationInvestigationsDuplicateEndpoint.as_view(),
         name="sentry-api-0-organization-investigation-duplicate",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/investigations/(?P<investigation_id>[^/]+)/parameters/$",
+        OrganizationInvestigationParametersEndpoint.as_view(),
+        name="sentry-api-0-organization-investigation-parameters",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/trace-explorer-ai/setup/$",

--- a/src/sentry/investigations/endpoints/organization_investigation_parameters.py
+++ b/src/sentry/investigations/endpoints/organization_investigation_parameters.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from drf_spectacular.utils import extend_schema
+from rest_framework import status
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import cell_silo_endpoint
+from sentry.api.serializers import serialize
+from sentry.constants import ObjectStatus
+from sentry.investigations.endpoints.base import (
+    OrganizationInvestigationEndpoint,
+    require_authenticated_user,
+    service_error,
+)
+from sentry.investigations.endpoints.serializers import InvestigationDetailsSerializer
+from sentry.investigations.endpoints.validators import ParameterValuesValidator
+from sentry.investigations.models import Investigation
+from sentry.investigations.services import update_parameter_values
+from sentry.models.organization import Organization
+from sentry.models.project import Project
+
+
+@extend_schema(tags=["Investigations"])
+@cell_silo_endpoint
+class OrganizationInvestigationParametersEndpoint(OrganizationInvestigationEndpoint):
+    publish_status = {"PUT": ApiPublishStatus.PRIVATE}
+
+    def put(
+        self, request: Request, organization: Organization, investigation: Investigation
+    ) -> Response:
+        require_authenticated_user(request)
+        validator = ParameterValuesValidator(data=request.data)
+        if not validator.is_valid():
+            return Response(validator.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        project_ids = frozenset(
+            Project.objects.filter(
+                id__in=request.access.accessible_project_ids,
+                organization_id=organization.id,
+                status=ObjectStatus.ACTIVE,
+            ).values_list("id", flat=True)
+        )
+        try:
+            updated = update_parameter_values(
+                investigation=investigation,
+                expected_version=validator.validated_data["investigation_version"],
+                values=validator.validated_data["values"],
+                accessible_project_ids=project_ids,
+            )
+        except Exception as error:
+            response = service_error(error)
+            if response is not None:
+                return response
+            raise
+
+        return Response(
+            serialize(
+                updated,
+                request.user,
+                InvestigationDetailsSerializer(accessible_project_ids=project_ids),
+            )
+        )

--- a/src/sentry/investigations/services/investigations.py
+++ b/src/sentry/investigations/services/investigations.py
@@ -691,15 +691,22 @@ def update_parameter_values(
         changed_parameter_ids: list[int] = []
         for key, value in values.items():
             parameter = parameters[key]
-            try:
-                validated = validate_parameter_value(
-                    parameter_type=parameter.type,
-                    value=value,
-                    constraints=parameter.validation_constraints,
-                    accessible_project_ids=accessible_project_ids,
-                )
-            except ParameterValidationError as error:
-                raise InvestigationValidationError({"values": {key: str(error)}})
+            if value is None:
+                if parameter.required:
+                    raise InvestigationValidationError(
+                        {"values": {key: f"Missing required parameter: {key}."}}
+                    )
+                validated = None
+            else:
+                try:
+                    validated = validate_parameter_value(
+                        parameter_type=parameter.type,
+                        value=value,
+                        constraints=parameter.validation_constraints,
+                        accessible_project_ids=accessible_project_ids,
+                    )
+                except ParameterValidationError as error:
+                    raise InvestigationValidationError({"values": {key: str(error)}})
             if parameter.saved_value != validated:
                 parameter.saved_value = validated
                 parameter.version += 1

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -204,6 +204,7 @@ export type KnownSentryApiUrls =
   | '/organizations/$organizationIdOrSlug/investigations/$investigationId/blocks/order/'
   | '/organizations/$organizationIdOrSlug/investigations/$investigationId/duplicate/'
   | '/organizations/$organizationIdOrSlug/investigations/$investigationId/favorite/'
+  | '/organizations/$organizationIdOrSlug/investigations/$investigationId/parameters/'
   | '/organizations/$organizationIdOrSlug/invite-requests/'
   | '/organizations/$organizationIdOrSlug/invite-requests/$memberId/'
   | '/organizations/$organizationIdOrSlug/issue-view-title/generate/'

--- a/tests/sentry/investigations/endpoints/test_organization_investigation_details.py
+++ b/tests/sentry/investigations/endpoints/test_organization_investigation_details.py
@@ -110,6 +110,33 @@ class OrganizationInvestigationDetailsTest(APITestCase):
         investigation = Investigation.objects.get(id=created["id"])
         assert investigation.title == "After"
 
+    def test_regular_member_can_edit_and_archive_another_users_investigation(self) -> None:
+        investigation = self.create_investigation(
+            organization=self.organization,
+            created_by=self.user,
+            title="Created by someone else",
+        )
+        member_user = self.create_user()
+        self.create_member(organization=self.organization, user=member_user, role="member")
+        self.login_as(member_user)
+        url = self.details_url(investigation)
+
+        response = self.client.put(
+            url,
+            data={"investigationVersion": investigation.version, "title": "Updated by member"},
+            format="json",
+        )
+        assert response.status_code == 200, response.data
+
+        response = self.client.delete(
+            url,
+            data={"investigationVersion": response.data["version"]},
+            format="json",
+        )
+        assert response.status_code == 204
+        investigation.refresh_from_db()
+        assert investigation.status == InvestigationStatus.ARCHIVED
+
     def archived_investigation(self) -> Investigation:
         investigation = self.create_investigation(
             organization=self.organization, created_by=self.user, title="Archived"

--- a/tests/sentry/investigations/endpoints/test_organization_investigation_index.py
+++ b/tests/sentry/investigations/endpoints/test_organization_investigation_index.py
@@ -54,6 +54,20 @@ class OrganizationInvestigationIndexTest(APITestCase):
         assert response.data[0]["blockCount"] == 0
         assert response.data[0]["isFavorited"] is False
 
+    def test_regular_member_can_create_an_investigation(self) -> None:
+        member_user = self.create_user()
+        self.create_member(organization=self.organization, user=member_user, role="member")
+        self.login_as(member_user)
+
+        response = self.client.post(
+            self.collection_url,
+            data={"title": "Created by member"},
+            format="json",
+        )
+
+        assert response.status_code == 201, response.data
+        assert response.data["createdBy"] == str(member_user.id)
+
     def test_manual_creation_rejects_inaccessible_project(self) -> None:
         other_organization = self.create_organization()
         other_project = self.create_project(organization=other_organization)

--- a/tests/sentry/investigations/endpoints/test_organization_investigation_parameters.py
+++ b/tests/sentry/investigations/endpoints/test_organization_investigation_parameters.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+from django.urls import reverse
+
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.features import with_feature
+
+FEATURE = "organizations:investigations"
+
+
+@with_feature(FEATURE)
+class InvestigationParametersEndpointTest(APITestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(self.user)
+        self.investigation = self.create_investigation(
+            organization=self.organization,
+            created_by=self.user,
+            title="Parameter tests",
+        )
+
+    def test_parameter_update_marks_transitive_dependents_stale(self) -> None:
+        parameter = self.create_investigation_parameter(
+            investigation=self.investigation,
+            key="environment",
+            label="Environment",
+            type="string",
+            position=0,
+        )
+        first = self.create_investigation_block(
+            investigation=self.investigation, position=0, kind="query"
+        )
+        second = self.create_investigation_block(
+            investigation=self.investigation, position=1, kind="text"
+        )
+        unrelated = self.create_investigation_block(
+            investigation=self.investigation, position=2, kind="text"
+        )
+        self.create_investigation_block_parameter(block=first, parameter=parameter)
+        self.create_investigation_block_dependency(block=second, depends_on=first)
+        url = reverse(
+            "sentry-api-0-organization-investigation-parameters",
+            kwargs={
+                "organization_id_or_slug": self.organization.slug,
+                "investigation_id": self.investigation.id,
+            },
+        )
+        response = self.client.put(
+            url,
+            data={
+                "investigationVersion": self.investigation.version,
+                "values": {"environment": "production"},
+            },
+            format="json",
+        )
+        assert response.status_code == 200, response.data
+        parameter.refresh_from_db()
+        first.refresh_from_db()
+        second.refresh_from_db()
+        unrelated.refresh_from_db()
+        self.investigation.refresh_from_db()
+        assert parameter.saved_value == "production"
+        assert parameter.version == 2
+        assert self.investigation.version == 2
+        assert first.stale_at is not None
+        assert second.stale_at is not None
+        assert unrelated.stale_at is None
+
+    def test_project_parameter_update_accepts_accessible_project(self) -> None:
+        parameter = self.create_investigation_parameter(
+            investigation=self.investigation,
+            key="project",
+            label="Project",
+            type="project",
+            position=0,
+        )
+        project = self.create_project(organization=self.organization)
+        filtered_project = self.create_project(organization=self.organization)
+        url = reverse(
+            "sentry-api-0-organization-investigation-parameters",
+            kwargs={
+                "organization_id_or_slug": self.organization.slug,
+                "investigation_id": self.investigation.id,
+            },
+        )
+
+        response = self.client.put(
+            f"{url}?project={filtered_project.id}",
+            data={
+                "investigationVersion": self.investigation.version,
+                "values": {"project": project.id},
+            },
+            format="json",
+        )
+
+        assert response.status_code == 200, response.data
+        parameter.refresh_from_db()
+        self.investigation.refresh_from_db()
+        assert parameter.saved_value == project.id
+        assert parameter.version == 2
+        assert self.investigation.version == 2
+
+    def test_parameter_update_allows_optional_null_and_rejects_required_null(self) -> None:
+        optional = self.create_investigation_parameter(
+            investigation=self.investigation,
+            key="optional",
+            label="Optional",
+            type="string",
+            position=0,
+            saved_value="production",
+        )
+        required = self.create_investigation_parameter(
+            investigation=self.investigation,
+            key="required",
+            label="Required",
+            type="string",
+            position=1,
+            required=True,
+            saved_value="production",
+        )
+        url = reverse(
+            "sentry-api-0-organization-investigation-parameters",
+            kwargs={
+                "organization_id_or_slug": self.organization.slug,
+                "investigation_id": self.investigation.id,
+            },
+        )
+
+        response = self.client.put(
+            url,
+            data={"investigationVersion": 1, "values": {"optional": None}},
+            format="json",
+        )
+        assert response.status_code == 200, response.data
+        optional.refresh_from_db()
+        self.investigation.refresh_from_db()
+        assert optional.saved_value is None
+        assert optional.version == 2
+        assert self.investigation.version == 2
+
+        response = self.client.put(
+            url,
+            data={"investigationVersion": 2, "values": {"required": None}},
+            format="json",
+        )
+        assert response.status_code == 400
+        required.refresh_from_db()
+        self.investigation.refresh_from_db()
+        assert required.saved_value == "production"
+        assert required.version == 1
+        assert self.investigation.version == 2
+
+    def test_project_parameter_update_rejects_inaccessible_project(self) -> None:
+        parameter = self.create_investigation_parameter(
+            investigation=self.investigation,
+            key="project",
+            label="Project",
+            type="project",
+            position=0,
+        )
+        foreign_project = self.create_project(organization=self.create_organization())
+        url = reverse(
+            "sentry-api-0-organization-investigation-parameters",
+            kwargs={
+                "organization_id_or_slug": self.organization.slug,
+                "investigation_id": self.investigation.id,
+            },
+        )
+        response = self.client.put(
+            url,
+            data={
+                "investigationVersion": self.investigation.version,
+                "values": {"project": foreign_project.id},
+            },
+            format="json",
+        )
+        assert response.status_code == 400
+        parameter.refresh_from_db()
+        assert parameter.saved_value is None
+        assert parameter.version == 1
+        self.investigation.refresh_from_db()
+        assert self.investigation.version == 1
+
+    def test_sentry_app_cannot_update_parameters(self) -> None:
+        parameter = self.create_investigation_parameter(
+            investigation=self.investigation,
+            key="environment",
+            label="Environment",
+            type="string",
+            position=0,
+        )
+        sentry_app_user = self.create_user(is_sentry_app=True)
+        self.create_member(
+            organization=self.organization,
+            user=sentry_app_user,
+            role="member",
+        )
+        self.login_as(sentry_app_user)
+        url = reverse(
+            "sentry-api-0-organization-investigation-parameters",
+            kwargs={
+                "organization_id_or_slug": self.organization.slug,
+                "investigation_id": self.investigation.id,
+            },
+        )
+
+        response = self.client.put(
+            url,
+            data={
+                "investigationVersion": self.investigation.version,
+                "values": {"environment": "production"},
+            },
+            format="json",
+        )
+
+        assert response.status_code == 403
+        parameter.refresh_from_db()
+        assert parameter.saved_value is None


### PR DESCRIPTION
This PR adds the Investigation parameter value update API, including project-access validation, optional-value clearing, transitive stale-state propagation, URL registration, and endpoint coverage.

Investigation access continues to use the existing organization-wide model: the product is gated to open-enrollment organizations, and any authenticated human organization member can create, edit, archive, and delete investigations. This PR adds no per-investigation, team, creator, or manager restrictions.

All Investigation user-facing behavior remains gated by `organizations:investigations`. Query execution and its rollout flag belong to the later agent-execution PR and are not part of this change.