### PR TITLE
feat(investigations): add agent execution engine [9/1/13]

### DIFF
--- a/src/sentry/investigations/agent.py
+++ b/src/sentry/investigations/agent.py
@@ -1,0 +1,814 @@
+from __future__ import annotations
+
+import ast
+import html
+from typing import Any
+
+from django.db import router, transaction
+from django.utils import timezone
+
+from sentry.investigations.contracts import validate_query_result, validate_text_result
+from sentry.investigations.models import (
+    Investigation,
+    InvestigationBlock,
+    InvestigationBlockExecution,
+    InvestigationBlockExecutionProject,
+    InvestigationBlockExecutionStatus,
+    InvestigationBlockKind,
+    InvestigationStatus,
+)
+from sentry.investigations.services.investigations import mark_downstream_blocks_stale
+from sentry.models.organization import Organization
+from sentry.models.project import Project
+from sentry.seer.agent.client import SeerAgentClient
+from sentry.seer.agent.client_models import MemoryBlock, SeerRunState
+from sentry.seer.agent.client_utils import AgentUpdateRequest, make_agent_update_request
+from sentry.seer.agent.on_completion_hook import AgentOnCompletionHook
+from sentry.users.services.user.service import user_service
+from sentry.utils import json
+
+MAX_TRANSCRIPT_BYTES = 1024 * 1024
+MAX_TOOL_CONTENT_CHARS = 100_000
+PRIVATE_TRANSCRIPT_KEYS = {
+    "authorization",
+    "credentials",
+    "headers",
+    "metadata",
+    "secret",
+    "signature",
+    "token",
+}
+
+
+QUERY_INSTRUCTIONS = """You are answering a query block inside a Sentry investigation.
+Use Code Mode only for telemetry analysis. You may call sentry.telemetry_live_search and
+sentry.render_chart, combine multiple telemetry results, and perform local read-only data
+transformations. Do not call any other Sentry API and never mutate data. Restrict every
+telemetry call to the supplied project slugs. Every sentry.telemetry_live_search call must
+pass project_slugs as a literal list of string values in the call itself, for example
+project_slugs=["project-one", "project-two"]. Never build that argument from a variable,
+loop variable, comprehension, or other expression; write separate calls when different literal
+project lists are needed. Do not import sentry, sentry_sdk, or tool input types; use the provided
+sentry object directly. For a time-series chart, call sentry.render_chart with a title and series shaped like
+[{"label": "Errors", "data": [{"x": "2026-08-04T00:00:00+00:00", "y": 1}]}],
+for example title="Error volume", x_axis="time", y_axis_unit="number", and a supported
+visualization such as "line". Pass chart points and series as inline plain dictionaries; do not
+import type helpers. Time-axis
+x values must be offset-bearing ISO 8601 timestamps. If the question cannot be answered with telemetry, ask the user an
+inline clarification. Finish by returning exactly one raw JSON object in your final response.
+The first character must be { and the last character must be }.
+Do not wrap the object in a Markdown code fence or include prose before or after it. Do not call any function to
+write or save the result. tableMarkdown must be a complete Markdown table (or an empty table). When
+render_chart returns a chart embed, put its chart body JSON object directly in the chart field
+and rename each series label to name. Keep every telemetry_live_search return object reachable
+in the Code Mode call's returned value so Sentry can retain its exact query link. Do not copy
+telemetry links or any other metadata into the final response. The final object must contain
+exactly these five keys and no others: tableMarkdown, chart, preferredView, isEmpty, and
+chartUnavailableReason. preferredView must be exactly
+table or chart. Do not put explanatory prose in tableMarkdown.
+"""
+
+TEXT_INSTRUCTIONS = """Rewrite the current investigation text block as useful Markdown using
+only the supplied notebook context. Be brief by default: aim for two or three short paragraphs,
+using a compact list or small table only when it materially improves clarity. Do not produce a
+long report unless the request explicitly requires one. Do not use tools or embeds. Return the
+complete replacement Markdown directly in your final response. Do not call any function to write
+or save it.
+"""
+
+
+def build_agent_prompt(execution: InvestigationBlockExecution) -> str:
+    snapshot = execution.input_snapshot
+    instruction = (
+        QUERY_INSTRUCTIONS
+        if execution.block.kind == InvestigationBlockKind.QUERY
+        else TEXT_INSTRUCTIONS
+    )
+    context = {
+        "request": snapshot.get("prompt"),
+        "projectSlugs": snapshot.get("projectSlugs", []),
+        "filters": snapshot.get("filters", {}),
+        "parameters": snapshot.get("parameters", {}),
+        "notebookContext": snapshot.get("context", []),
+        "datasetHint": snapshot.get("datasetHint"),
+    }
+    return (
+        f"{instruction}\n<investigation_context>\n{json.dumps(context)}\n</investigation_context>"
+    )
+
+
+def start_execution_run(
+    execution: InvestigationBlockExecution,
+    organization: Organization,
+    user: Any,
+    client: SeerAgentClient | None = None,
+) -> None:
+    is_query = execution.block.kind == InvestigationBlockKind.QUERY
+    if client is None:
+        client = SeerAgentClient(organization, user)
+    client.on_completion_hook = InvestigationAgentCompletionHook
+    client.is_interactive = is_query
+    client.enable_code_mode_tools = "only" if is_query else "off"
+    client.enable_coding = False
+    client.enable_bash_tools = False
+    client.enable_embeds = is_query
+    client.enable_streaming = True
+    client.max_iterations = 20 if is_query else 5
+    client.start_run(
+        build_agent_prompt(execution),
+        metadata={
+            "referrer": "investigation-block",
+            "investigation_id": str(execution.block.investigation.id),
+            "block_id": str(execution.block.id),
+            "execution_id": str(execution.id),
+        },
+        record_in_history=False,
+        on_run_created=lambda run: _mark_dispatched(execution, run.id),
+    )
+
+
+def _mark_dispatched(execution: InvestigationBlockExecution, seer_run_id: int) -> None:
+    InvestigationBlockExecution.objects.filter(id=execution.id).update(
+        seer_run_id=seer_run_id,
+        status=InvestigationBlockExecutionStatus.RUNNING,
+        started_at=timezone.now(),
+    )
+
+
+def _block_policy_error(
+    block: MemoryBlock,
+    *,
+    allow_query_tools: bool,
+    allowed_project_slugs: set[str] | None = None,
+) -> str | None:
+    for call in block.message.tool_calls or []:
+        if call.function == "sentry_api_search":
+            if allow_query_tools:
+                continue
+            return "Tools are not allowed for this block."
+        if call.function != "sentry_api_execute":
+            return f"Unsupported tool call: {call.function}."
+        if not allow_query_tools:
+            return "Tools are not allowed for this block."
+        try:
+            args = json.loads(call.args)
+        except (TypeError, ValueError):
+            return "The Code Mode call had invalid arguments."
+        policy_error = _code_policy_error(
+            str(args.get("code", "")),
+            allow_query_tools=allow_query_tools,
+            allowed_project_slugs=allowed_project_slugs,
+        )
+        if policy_error is not None and not _code_mode_lint_prevented_execution(block, call.id):
+            return policy_error
+    return None
+
+
+def _code_mode_lint_prevented_execution(block: MemoryBlock, tool_call_id: str | None) -> bool:
+    """A Code Mode lint failure is proof that the submitted code never ran."""
+    if tool_call_id is None:
+        return False
+    for result in block.tool_results or []:
+        if (
+            result is not None
+            and result.tool_call_id == tool_call_id
+            and result.tool_call_function == "sentry_api_execute"
+            and "Lint errors (code not executed):" in (result.content or "")
+        ):
+            return True
+    return False
+
+
+def _telemetry_project_slugs(call: ast.Call) -> list[str] | None:
+    value: ast.AST | None = None
+    for keyword in call.keywords:
+        if keyword.arg == "project_slugs":
+            value = keyword.value
+            break
+    if value is None and len(call.args) >= 3:
+        value = call.args[2]
+    if value is None:
+        return None
+    try:
+        project_slugs = ast.literal_eval(value)
+    except (TypeError, ValueError, SyntaxError):
+        return None
+    if not isinstance(project_slugs, list) or any(
+        not isinstance(slug, str) for slug in project_slugs
+    ):
+        return None
+    return project_slugs
+
+
+def _code_policy_error(
+    code: str,
+    *,
+    allow_query_tools: bool,
+    allowed_project_slugs: set[str] | None = None,
+) -> str | None:
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return "The Code Mode call contained invalid Python."
+    allowed = {"telemetry_live_search", "render_chart"} if allow_query_tools else set()
+    allowed_imports = {
+        "collections",
+        "datetime",
+        "decimal",
+        "functools",
+        "itertools",
+        "json",
+        "math",
+        "numpy",
+        "pandas",
+        "statistics",
+    }
+    blocked_calls = {
+        "__import__",
+        "compile",
+        "delattr",
+        "eval",
+        "exec",
+        "getattr",
+        "open",
+        "setattr",
+    }
+    parents: dict[ast.AST, ast.AST] = {}
+    for parent in ast.walk(tree):
+        for child in ast.iter_child_nodes(parent):
+            parents[child] = parent
+
+    used: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            if any(alias.name.split(".", 1)[0] not in allowed_imports for alias in node.names):
+                return "This import is not allowed in an investigation query."
+        if isinstance(node, ast.ImportFrom):
+            if node.module is None or node.module.split(".", 1)[0] not in allowed_imports:
+                return "This import is not allowed in an investigation query."
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id in blocked_calls
+        ):
+            return f"The {node.func.id} function is not allowed in an investigation query."
+        if not isinstance(node, ast.Name) or node.id != "sentry":
+            continue
+        attribute = parents.get(node)
+        call = parents.get(attribute) if isinstance(attribute, ast.Attribute) else None
+        if (
+            not isinstance(attribute, ast.Attribute)
+            or attribute.value is not node
+            or not isinstance(call, ast.Call)
+            or call.func is not attribute
+        ):
+            return "Dynamic or aliased access to the Sentry API is unsupported."
+        used.add(attribute.attr)
+    unsupported = sorted(used - allowed)
+    if unsupported:
+        return (
+            "Unsupported Sentry API call: "
+            + ", ".join(f"sentry.{function}" for function in unsupported)
+            + "."
+        )
+    if allowed_project_slugs is not None:
+        for node in ast.walk(tree):
+            if not (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "sentry"
+                and node.func.attr == "telemetry_live_search"
+            ):
+                continue
+            project_slugs = _telemetry_project_slugs(node)
+            if project_slugs is None:
+                return "Telemetry calls must use a literal project_slugs list."
+            if not set(project_slugs).issubset(allowed_project_slugs):
+                return "The telemetry call requested a project outside this investigation."
+    return None
+
+
+def _sanitize_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: "[hidden]" if key.lower() in PRIVATE_TRANSCRIPT_KEYS else _sanitize_value(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_sanitize_value(item) for item in value]
+    return value
+
+
+def sanitize_state(
+    state: SeerRunState,
+    *,
+    allow_query_tools: bool = True,
+    allowed_project_slugs: set[str] | None = None,
+) -> tuple[list[dict[str, Any]], bool, bool]:
+    blocks: list[dict[str, Any]] = []
+    off_policy = False
+    for block in state.blocks:
+        policy_error = _block_policy_error(
+            block,
+            allow_query_tools=allow_query_tools,
+            allowed_project_slugs=allowed_project_slugs,
+        )
+        off_policy = off_policy or policy_error is not None
+        message = _sanitize_value(block.message.dict(exclude={"thinking_content", "metadata"}))
+        item: dict[str, Any] = {
+            "id": block.id,
+            "timestamp": block.timestamp,
+            "loading": block.loading,
+            "message": message,
+            "artifacts": [_sanitize_value(artifact.dict()) for artifact in block.artifacts],
+            "toolLinks": [
+                _sanitize_value(link.dict()) if link else None for link in block.tool_links or []
+            ],
+            "toolResults": [],
+        }
+        if policy_error is not None:
+            item["policyError"] = policy_error
+        for result in block.tool_results or []:
+            if result is None:
+                item["toolResults"].append(None)
+                continue
+            value = _sanitize_value(result.dict())
+            if policy_error is not None:
+                value["content"] = f"[Result hidden: {policy_error}]"
+                value["structuredContent"] = None
+            elif value.get("content") and len(value["content"]) > MAX_TOOL_CONTENT_CHARS:
+                value["content"] = value["content"][:MAX_TOOL_CONTENT_CHARS] + "\n[truncated]"
+            item["toolResults"].append(value)
+        if not (block.loading and state.status not in {"processing", "awaiting_user_input"}):
+            blocks.append(item)
+
+    truncated = False
+    while len(json.dumps(blocks).encode()) > MAX_TRANSCRIPT_BYTES and blocks:
+        truncated = True
+        removed = False
+        for transcript_block in blocks:
+            for result in transcript_block.get("toolResults", []):
+                if isinstance(result, dict) and result.get("content") not in {None, "[truncated]"}:
+                    result["content"] = "[truncated]"
+                    result["structuredContent"] = None
+                    removed = True
+                    break
+            if removed:
+                break
+        if not removed:
+            blocks.pop(0)
+    return blocks, truncated, off_policy
+
+
+def _result_payload(content: str | None) -> Any:
+    if not content:
+        return None
+    opening = '<UNTRUSTED_DATA source="sentry_api"'
+    start = content.find(opening)
+    if start < 0:
+        return None
+    start = content.find(">", start + len(opening))
+    if start < 0:
+        return None
+    end = content.find("</UNTRUSTED_DATA>", start + 1)
+    if end < 0:
+        return None
+    try:
+        return ast.literal_eval(html.unescape(content[start + 1 : end].strip()))
+    except (SyntaxError, TypeError, ValueError):
+        return None
+
+
+def _telemetry_links_from_payload(value: Any) -> list[dict[str, Any]]:
+    links: list[dict[str, Any]] = []
+    if isinstance(value, dict):
+        link_params = value.get("link_params")
+        if isinstance(link_params, dict):
+            links.append({"kind": "telemetry", "params": link_params})
+        for item in value.values():
+            links.extend(_telemetry_links_from_payload(item))
+    elif isinstance(value, list | tuple):
+        for item in value:
+            links.extend(_telemetry_links_from_payload(item))
+    return links
+
+
+def _project_slugs_from_code(code: str) -> set[str]:
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return set()
+    slugs: set[str] = set()
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "sentry"
+            and node.func.attr == "telemetry_live_search"
+        ):
+            slugs.update(_telemetry_project_slugs(node) or [])
+    return slugs
+
+
+def _successful_links_and_projects(
+    state: SeerRunState, organization: Organization
+) -> tuple[list[dict[str, Any]], list[Project]]:
+    links: list[dict[str, Any]] = []
+    seen_links: set[str] = set()
+    slugs: set[str] = set()
+    organization_wide = False
+    for block in state.blocks:
+        raw_links: list[dict[str, Any]] = [
+            link.dict() for link in block.tool_links or [] if link is not None
+        ]
+        for result in block.tool_results or []:
+            if result is None:
+                continue
+            if result.structuredContent is not None:
+                structured_links = result.structuredContent.get("links")
+                if isinstance(structured_links, list):
+                    raw_links.extend(link for link in structured_links if isinstance(link, dict))
+            raw_links.extend(_telemetry_links_from_payload(_result_payload(result.content)))
+        has_successful_telemetry = False
+        for link in raw_links:
+            params = link.get("params")
+            if not isinstance(params, dict) or params.get("is_error"):
+                continue
+            project_slugs = params.get("project_slugs") or params.get("projectSlugs") or []
+            if isinstance(project_slugs, str):
+                project_slugs = [project_slugs]
+            if project_slugs:
+                slugs.update(str(slug) for slug in project_slugs)
+            if "dataset" in params or "query" in params:
+                has_successful_telemetry = True
+                key = json.dumps(link, sort_keys=True)
+                if key not in seen_links:
+                    seen_links.add(key)
+                    links.append(link)
+                organization_wide = organization_wide or not project_slugs
+        if has_successful_telemetry:
+            for call in block.message.tool_calls or []:
+                if call.function != "sentry_api_execute":
+                    continue
+                try:
+                    args = json.loads(call.args)
+                except (TypeError, ValueError):
+                    continue
+                slugs.update(_project_slugs_from_code(str(args.get("code", ""))))
+    projects = list(
+        Project.objects.filter(organization=organization)
+        if organization_wide
+        else Project.objects.filter(organization=organization, slug__in=slugs)
+    )
+    return links, projects
+
+
+def _normalize_chart(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+    chart = dict(value)
+    series = chart.get("series")
+    if isinstance(series, list):
+        chart["series"] = [
+            {**item, "name": item.get("name", item.get("label"))}
+            if isinstance(item, dict)
+            else item
+            for item in series
+        ]
+        for item in chart["series"]:
+            if isinstance(item, dict):
+                item.pop("label", None)
+    return chart
+
+
+def _result_from_final_message(state: SeerRunState, *, block_kind: str) -> dict[str, Any] | None:
+    for block in reversed(state.blocks):
+        if block.message.role != "assistant" or not block.message.content:
+            continue
+        content = block.message.content
+        if block_kind == InvestigationBlockKind.TEXT:
+            return {"schemaVersion": 1, "markdown": content}
+        try:
+            candidate = json.loads(content)
+        except (TypeError, ValueError):
+            return None
+        required_fields = {
+            "tableMarkdown",
+            "chart",
+            "preferredView",
+            "isEmpty",
+            "chartUnavailableReason",
+        }
+        if not isinstance(candidate, dict) or set(candidate) != required_fields:
+            return None
+        if (
+            not isinstance(candidate["tableMarkdown"], str)
+            or (candidate["chart"] is not None and not isinstance(candidate["chart"], dict))
+            or candidate["preferredView"] not in {"table", "chart"}
+            or not isinstance(candidate["isEmpty"], bool)
+            or (
+                candidate["chartUnavailableReason"] is not None
+                and not isinstance(candidate["chartUnavailableReason"], str)
+            )
+        ):
+            return None
+        return {
+            "schemaVersion": 1,
+            "tableMarkdown": candidate["tableMarkdown"],
+            "chart": _normalize_chart(candidate.get("chart")),
+            "preferredView": candidate["preferredView"],
+            "isEmpty": candidate["isEmpty"],
+            "chartUnavailableReason": candidate["chartUnavailableReason"],
+        }
+    return None
+
+
+def synchronize_execution(execution: InvestigationBlockExecution, state: SeerRunState) -> None:
+    blocks, transcript_truncated, off_policy = sanitize_state(
+        state,
+        allow_query_tools=execution.block.kind == InvestigationBlockKind.QUERY,
+        allowed_project_slugs=set(execution.input_snapshot.get("projectSlugs", [])),
+    )
+    pending_import_lint = off_policy and all(
+        block.get("policyError") == "This import is not allowed in an investigation query."
+        and not block.get("toolResults")
+        for block in blocks
+        if block.get("policyError")
+    )
+    if (
+        off_policy
+        and not pending_import_lint
+        and state.status
+        in {
+            "processing",
+            "awaiting_user_input",
+        }
+    ):
+        blocks = [block for block in blocks if not block.get("loading")]
+        policy_error = next(
+            (str(block["policyError"]) for block in blocks if block.get("policyError")),
+            "The agent attempted an unsupported operation.",
+        )
+        if execution.seer_run and execution.seer_run.seer_run_state_id:
+            interrupt_run(
+                execution.block.investigation.organization, execution.seer_run.seer_run_state_id
+            )
+        InvestigationBlockExecution.objects.filter(id=execution.id).update(
+            status=InvestigationBlockExecutionStatus.FAILED,
+            transcript=blocks,
+            transcript_truncated=transcript_truncated,
+            error={
+                "code": "unsupported_tool_use",
+                "message": policy_error,
+            },
+            completed_at=timezone.now(),
+        )
+        return
+    status = {
+        "processing": InvestigationBlockExecutionStatus.RUNNING,
+        "awaiting_user_input": InvestigationBlockExecutionStatus.AWAITING_INPUT,
+    }.get(state.status)
+    if status:
+        InvestigationBlockExecution.objects.filter(id=execution.id).exclude(
+            status__in=[
+                InvestigationBlockExecutionStatus.COMPLETED,
+                InvestigationBlockExecutionStatus.FAILED,
+                InvestigationBlockExecutionStatus.CANCELLED,
+            ]
+        ).update(status=status, transcript=blocks, transcript_truncated=transcript_truncated)
+        return
+
+    database = router.db_for_write(InvestigationBlockExecution)
+    with transaction.atomic(using=database):
+        execution = (
+            InvestigationBlockExecution.objects.select_for_update()
+            .select_related("block__investigation")
+            .get(id=execution.id)
+        )
+        if execution.status in {
+            InvestigationBlockExecutionStatus.COMPLETED,
+            InvestigationBlockExecutionStatus.FAILED,
+            InvestigationBlockExecutionStatus.CANCELLED,
+        }:
+            return
+        execution.transcript = blocks
+        execution.transcript_truncated = transcript_truncated
+        execution.completed_at = timezone.now()
+        if state.status == "error" or off_policy:
+            policy_error = next(
+                (str(block["policyError"]) for block in blocks if block.get("policyError")),
+                "The agent attempted an unsupported operation.",
+            )
+            execution.status = InvestigationBlockExecutionStatus.FAILED
+            execution.error = {
+                "code": "unsupported_tool_use" if off_policy else "seer_execution_failed",
+                "message": policy_error if off_policy else "The agent run failed.",
+            }
+            execution.save()
+            return
+
+        raw_result = _result_from_final_message(state, block_kind=execution.block.kind)
+        if raw_result is None:
+            execution.status = InvestigationBlockExecutionStatus.FAILED
+            final_content = next(
+                (
+                    block.message.content
+                    for block in reversed(state.blocks)
+                    if block.message.role == "assistant" and block.message.content
+                ),
+                None,
+            )
+            if final_content is None:
+                execution.error = {
+                    "code": "missing_result",
+                    "message": "The run returned no final result.",
+                }
+            else:
+                execution.error = {
+                    "code": "invalid_result",
+                    "message": "The agent returned malformed or unsupported result JSON.",
+                }
+            execution.save()
+            return
+        try:
+            if execution.block.kind == InvestigationBlockKind.QUERY:
+                result = dict(raw_result)
+                result["chart"] = _normalize_chart(result.get("chart"))
+                links, projects = _successful_links_and_projects(
+                    state, execution.block.investigation.organization
+                )
+                result["queryLinks"] = links
+                result = validate_query_result(result)
+                allowed_project_ids = set(execution.input_snapshot.get("projectIds", []))
+                if not {project.id for project in projects}.issubset(allowed_project_ids):
+                    raise ValueError("The result queried outside the investigation project scope.")
+            else:
+                context_project_ids = execution.input_snapshot.get("contextDataProjectIds", [])
+                projects = list(
+                    Project.objects.filter(
+                        organization=execution.block.investigation.organization,
+                        id__in=context_project_ids,
+                    ).order_by("id")
+                )
+                result = validate_text_result(raw_result)
+        except Exception as error:
+            execution.status = InvestigationBlockExecutionStatus.FAILED
+            execution.error = {"code": "invalid_result", "message": str(error)[:1000]}
+            execution.save()
+            return
+
+        execution.result = result
+        execution.status = InvestigationBlockExecutionStatus.COMPLETED
+        execution.error = None
+        execution.save()
+        InvestigationBlockExecutionProject.objects.bulk_create(
+            [InvestigationBlockExecutionProject(execution=execution, project=p) for p in projects],
+            ignore_conflicts=True,
+        )
+        block = (
+            InvestigationBlock.objects.select_for_update()
+            .select_related("investigation")
+            .get(id=execution.block_id)
+        )
+        if block.current_execution_id != execution.id or block.version != execution.block_version:
+            return
+        if block.deleted_at is not None or block.investigation.status != InvestigationStatus.ACTIVE:
+            return
+        if block.kind == InvestigationBlockKind.QUERY:
+            block.result_execution = execution
+            block.stale_at = None
+            block.save(update_fields=["result_execution", "stale_at", "date_updated"])
+        else:
+            markdown = result["markdown"]
+            block.content = markdown
+            block.generated_content = markdown
+            block.content_execution = execution
+            block.stale_at = None
+            block.version += 1
+            block.save()
+        mark_downstream_blocks_stale(
+            investigation_id=block.investigation_id, upstream_block_ids={block.id}
+        )
+        transaction.on_commit(
+            lambda: _maybe_start_title_generation(block.investigation, execution.triggered_by_id),
+            using=database,
+        )
+
+
+def _maybe_start_title_generation(investigation: Investigation, user_id: int | None) -> None:
+    database = router.db_for_write(Investigation)
+    with transaction.atomic(using=database):
+        investigation = (
+            Investigation.objects.select_for_update()
+            .select_related("organization")
+            .get(id=investigation.id)
+        )
+        if (
+            investigation.title != "Untitled investigation"
+            or investigation.title_generation_status in {"pending", "running"}
+        ):
+            return
+        investigation.title_generation_status = "pending"
+        investigation.save(update_fields=["title_generation_status", "date_updated"])
+    user = user_service.get_user(user_id=user_id) if user_id else None
+    client = SeerAgentClient(
+        investigation.organization,
+        user,
+        on_completion_hook=InvestigationAgentCompletionHook,
+        enable_code_mode_tools="only",
+        enable_coding=False,
+        enable_bash_tools=False,
+        enable_embeds=False,
+        enable_streaming=True,
+        max_iterations=3,
+    )
+    block_context = "\n".join(
+        f"- {block.title}: {(block.prompt or block.content)[:1000]}"
+        for block in investigation.blocks.filter(deleted_at__isnull=True).order_by("position")
+    )
+    prompt = (
+        "Write a concise, single-line title that identifies the specific incident being "
+        "investigated. Prefer concrete incident details such as the monitor or issue name, "
+        "affected project, breached threshold or direction, and relevant time window. Avoid "
+        "generic titles such as 'Metric Monitor Breach Investigation' or 'Incident Analysis'. "
+        "Do not use tools. Return only the title text. Do not call any function to write or save "
+        "it.\n<source_context>\n"
+        f"{json.dumps(investigation.source_ref)}\n</source_context>\n"
+        f"<block_context>\n{block_context}\n</block_context>"
+    )
+
+    def link_title_run(run: Any) -> None:
+        Investigation.objects.filter(id=investigation.id).update(
+            title_seer_run_id=run.id, title_generation_status="running"
+        )
+
+    try:
+        client.start_run(
+            prompt,
+            metadata={
+                "referrer": "investigation-title",
+                "investigation_id": str(investigation.id),
+            },
+            record_in_history=False,
+            on_run_created=link_title_run,
+        )
+    except Exception:
+        Investigation.objects.filter(id=investigation.id, title_generation_status="pending").update(
+            title_generation_status="failed"
+        )
+        raise
+
+
+def synchronize_title(investigation: Investigation, state: SeerRunState) -> None:
+    if any(
+        _block_policy_error(block, allow_query_tools=False) is not None for block in state.blocks
+    ):
+        if state.status in {"processing", "awaiting_user_input"}:
+            interrupt_run(investigation.organization, state.run_id)
+        Investigation.objects.filter(id=investigation.id).update(title_generation_status="failed")
+        return
+    if state.status in {"processing", "awaiting_user_input"}:
+        return
+    title = next(
+        (
+            " ".join(block.message.content.split())[:255]
+            for block in reversed(state.blocks)
+            if block.message.role == "assistant" and block.message.content
+        ),
+        "",
+    )
+    updates: dict[str, Any] = {"title_generation_status": "completed" if title else "failed"}
+    if title and investigation.title == "Untitled investigation":
+        updates["title"] = title
+        updates["version"] = investigation.version + 1
+    Investigation.objects.filter(id=investigation.id).update(**updates)
+
+
+def interrupt_run(organization: Organization, run_id: int) -> None:
+    response = make_agent_update_request(
+        AgentUpdateRequest(
+            run_id=run_id, organization_id=organization.id, payload={"type": "interrupt"}
+        )
+    )
+    if response.status >= 400:
+        raise RuntimeError("Unable to stop the agent run")
+
+
+class InvestigationAgentCompletionHook(AgentOnCompletionHook):
+    @classmethod
+    def execute(cls, organization: Organization, run_id: int) -> None:
+        state = SeerAgentClient(organization, None).get_run(run_id)
+        execution = InvestigationBlockExecution.objects.filter(
+            seer_run__seer_run_state_id=run_id,
+            block__investigation__organization=organization,
+        ).first()
+        if execution is not None:
+            synchronize_execution(execution, state)
+            return
+        investigation = Investigation.objects.filter(
+            organization=organization, title_seer_run__seer_run_state_id=run_id
+        ).first()
+        if investigation is not None:
+            synchronize_title(investigation, state)

--- a/src/sentry/investigations/agent.py
+++ b/src/sentry/investigations/agent.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import ast
 import html
+from enum import StrEnum
 from typing import Any
 
 from django.db import router, transaction
+from django.db.models import F
 from django.utils import timezone
 
 from sentry.investigations.contracts import validate_query_result, validate_text_result
@@ -17,7 +19,10 @@ from sentry.investigations.models import (
     InvestigationBlockKind,
     InvestigationStatus,
 )
-from sentry.investigations.services.investigations import mark_downstream_blocks_stale
+from sentry.investigations.services.investigations import (
+    DEFAULT_INVESTIGATION_TITLE,
+    mark_downstream_blocks_stale,
+)
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.seer.agent.client import SeerAgentClient
@@ -29,6 +34,7 @@ from sentry.utils import json
 
 MAX_TRANSCRIPT_BYTES = 1024 * 1024
 MAX_TOOL_CONTENT_CHARS = 100_000
+IMPORT_NOT_ALLOWED_ERROR = "This import is not allowed in an investigation query."
 PRIVATE_TRANSCRIPT_KEYS = {
     "authorization",
     "credentials",
@@ -38,6 +44,18 @@ PRIVATE_TRANSCRIPT_KEYS = {
     "signature",
     "token",
 }
+
+
+class TitleGenerationStatus(StrEnum):
+    """Values stored in `Investigation.title_generation_status`."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+IN_FLIGHT_TITLE_STATUSES = (TitleGenerationStatus.PENDING, TitleGenerationStatus.RUNNING)
 
 
 QUERY_INSTRUCTIONS = """You are answering a query block inside a Sentry investigation.
@@ -128,7 +146,7 @@ def start_execution_run(
 
 
 def _mark_dispatched(execution: InvestigationBlockExecution, seer_run_id: int) -> None:
-    InvestigationBlockExecution.objects.filter(id=execution.id).update(
+    execution.update(
         seer_run_id=seer_run_id,
         status=InvestigationBlockExecutionStatus.RUNNING,
         started_at=timezone.now(),
@@ -242,10 +260,10 @@ def _code_policy_error(
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             if any(alias.name.split(".", 1)[0] not in allowed_imports for alias in node.names):
-                return "This import is not allowed in an investigation query."
+                return IMPORT_NOT_ALLOWED_ERROR
         if isinstance(node, ast.ImportFrom):
             if node.module is None or node.module.split(".", 1)[0] not in allowed_imports:
-                return "This import is not allowed in an investigation query."
+                return IMPORT_NOT_ALLOWED_ERROR
         if (
             isinstance(node, ast.Call)
             and isinstance(node.func, ast.Name)
@@ -532,8 +550,7 @@ def synchronize_execution(execution: InvestigationBlockExecution, state: SeerRun
         allowed_project_slugs=set(execution.input_snapshot.get("projectSlugs", [])),
     )
     pending_import_lint = off_policy and all(
-        block.get("policyError") == "This import is not allowed in an investigation query."
-        and not block.get("toolResults")
+        block.get("policyError") == IMPORT_NOT_ALLOWED_ERROR and not block.get("toolResults")
         for block in blocks
         if block.get("policyError")
     )
@@ -555,7 +572,7 @@ def synchronize_execution(execution: InvestigationBlockExecution, state: SeerRun
             interrupt_run(
                 execution.block.investigation.organization, execution.seer_run.seer_run_state_id
             )
-        InvestigationBlockExecution.objects.filter(id=execution.id).update(
+        execution.update(
             status=InvestigationBlockExecutionStatus.FAILED,
             transcript=blocks,
             transcript_truncated=transcript_truncated,
@@ -571,13 +588,21 @@ def synchronize_execution(execution: InvestigationBlockExecution, state: SeerRun
         "awaiting_user_input": InvestigationBlockExecutionStatus.AWAITING_INPUT,
     }.get(state.status)
     if status:
-        InvestigationBlockExecution.objects.filter(id=execution.id).exclude(
-            status__in=[
-                InvestigationBlockExecutionStatus.COMPLETED,
-                InvestigationBlockExecutionStatus.FAILED,
-                InvestigationBlockExecutionStatus.CANCELLED,
-            ]
-        ).update(status=status, transcript=blocks, transcript_truncated=transcript_truncated)
+        updated = (
+            InvestigationBlockExecution.objects.filter(id=execution.id)
+            .exclude(
+                status__in=[
+                    InvestigationBlockExecutionStatus.COMPLETED,
+                    InvestigationBlockExecutionStatus.FAILED,
+                    InvestigationBlockExecutionStatus.CANCELLED,
+                ]
+            )
+            .update(status=status, transcript=blocks, transcript_truncated=transcript_truncated)
+        )
+        if updated:
+            execution.status = status
+            execution.transcript = blocks
+            execution.transcript_truncated = transcript_truncated
         return
 
     database = router.db_for_write(InvestigationBlockExecution)
@@ -698,20 +723,8 @@ def synchronize_execution(execution: InvestigationBlockExecution, state: SeerRun
 
 
 def _maybe_start_title_generation(investigation: Investigation, user_id: int | None) -> None:
-    database = router.db_for_write(Investigation)
-    with transaction.atomic(using=database):
-        investigation = (
-            Investigation.objects.select_for_update()
-            .select_related("organization")
-            .get(id=investigation.id)
-        )
-        if (
-            investigation.title != "Untitled investigation"
-            or investigation.title_generation_status in {"pending", "running"}
-        ):
-            return
-        investigation.title_generation_status = "pending"
-        investigation.save(update_fields=["title_generation_status", "date_updated"])
+    if investigation.title != DEFAULT_INVESTIGATION_TITLE:
+        return
     user = user_service.get_user(user_id=user_id) if user_id else None
     client = SeerAgentClient(
         investigation.organization,
@@ -739,9 +752,19 @@ def _maybe_start_title_generation(investigation: Investigation, user_id: int | N
         f"<block_context>\n{block_context}\n</block_context>"
     )
 
+    database = router.db_for_write(Investigation)
+    with transaction.atomic(using=database):
+        locked = Investigation.objects.select_for_update().get(id=investigation.id)
+        if (
+            locked.title != DEFAULT_INVESTIGATION_TITLE
+            or locked.title_generation_status in IN_FLIGHT_TITLE_STATUSES
+        ):
+            return
+        locked.update(title_generation_status=TitleGenerationStatus.PENDING)
+
     def link_title_run(run: Any) -> None:
         Investigation.objects.filter(id=investigation.id).update(
-            title_seer_run_id=run.id, title_generation_status="running"
+            title_seer_run_id=run.id, title_generation_status=TitleGenerationStatus.RUNNING
         )
 
     try:
@@ -755,9 +778,9 @@ def _maybe_start_title_generation(investigation: Investigation, user_id: int | N
             on_run_created=link_title_run,
         )
     except Exception:
-        Investigation.objects.filter(id=investigation.id, title_generation_status="pending").update(
-            title_generation_status="failed"
-        )
+        Investigation.objects.filter(
+            id=investigation.id, title_generation_status__in=IN_FLIGHT_TITLE_STATUSES
+        ).update(title_generation_status=TitleGenerationStatus.FAILED)
         raise
 
 
@@ -767,7 +790,7 @@ def synchronize_title(investigation: Investigation, state: SeerRunState) -> None
     ):
         if state.status in {"processing", "awaiting_user_input"}:
             interrupt_run(investigation.organization, state.run_id)
-        Investigation.objects.filter(id=investigation.id).update(title_generation_status="failed")
+        investigation.update(title_generation_status=TitleGenerationStatus.FAILED)
         return
     if state.status in {"processing", "awaiting_user_input"}:
         return
@@ -779,11 +802,15 @@ def synchronize_title(investigation: Investigation, state: SeerRunState) -> None
         ),
         "",
     )
-    updates: dict[str, Any] = {"title_generation_status": "completed" if title else "failed"}
-    if title and investigation.title == "Untitled investigation":
+    updates: dict[str, Any] = {
+        "title_generation_status": (
+            TitleGenerationStatus.COMPLETED if title else TitleGenerationStatus.FAILED
+        )
+    }
+    if title and investigation.title == DEFAULT_INVESTIGATION_TITLE:
         updates["title"] = title
-        updates["version"] = investigation.version + 1
-    Investigation.objects.filter(id=investigation.id).update(**updates)
+        updates["version"] = F("version") + 1
+    investigation.update(**updates)
 
 
 def interrupt_run(organization: Organization, run_id: int) -> None:

--- a/src/sentry/investigations/agent.py
+++ b/src/sentry/investigations/agent.py
@@ -34,6 +34,7 @@ from sentry.utils import json
 
 MAX_TRANSCRIPT_BYTES = 1024 * 1024
 MAX_TOOL_CONTENT_CHARS = 100_000
+MAX_QUERY_LINK_PARAM_CHARS = 2000
 IMPORT_NOT_ALLOWED_ERROR = "This import is not allowed in an investigation query."
 PRIVATE_TRANSCRIPT_KEYS = {
     "authorization",
@@ -171,6 +172,8 @@ def _block_policy_error(
         try:
             args = json.loads(call.args)
         except (TypeError, ValueError):
+            args = None
+        if not isinstance(args, dict):
             return "The Code Mode call had invalid arguments."
         policy_error = _code_policy_error(
             str(args.get("code", "")),
@@ -300,8 +303,8 @@ def _code_policy_error(
             ):
                 continue
             project_slugs = _telemetry_project_slugs(node)
-            if project_slugs is None:
-                return "Telemetry calls must use a literal project_slugs list."
+            if not project_slugs:
+                return "Telemetry calls must use a non-empty literal project_slugs list."
             if not set(project_slugs).issubset(allowed_project_slugs):
                 return "The telemetry call requested a project outside this investigation."
     return None
@@ -430,6 +433,24 @@ def _project_slugs_from_code(code: str) -> set[str]:
     return slugs
 
 
+def _sanitized_query_link(link: dict[str, Any]) -> dict[str, Any]:
+    params: dict[str, Any] = {}
+    for key, value in (link.get("params") or {}).items():
+        if isinstance(value, str):
+            params[str(key)] = value[:MAX_QUERY_LINK_PARAM_CHARS]
+        elif isinstance(value, bool | int | float) or value is None:
+            params[str(key)] = value
+        elif isinstance(value, list | tuple) and all(
+            item is None or isinstance(item, str | bool | int | float) for item in value
+        ):
+            params[str(key)] = [
+                item[:MAX_QUERY_LINK_PARAM_CHARS] if isinstance(item, str) else item
+                for item in value
+            ]
+    kind = link.get("kind")
+    return {"kind": kind if isinstance(kind, str) else "telemetry", "params": params}
+
+
 def _successful_links_and_projects(
     state: SeerRunState, organization: Organization
 ) -> tuple[list[dict[str, Any]], list[Project]]:
@@ -461,10 +482,11 @@ def _successful_links_and_projects(
                 slugs.update(str(slug) for slug in project_slugs)
             if "dataset" in params or "query" in params:
                 has_successful_telemetry = True
-                key = json.dumps(link, sort_keys=True)
+                sanitized = _sanitized_query_link(link)
+                key = json.dumps(sanitized, sort_keys=True)
                 if key not in seen_links:
                     seen_links.add(key)
-                    links.append(link)
+                    links.append(sanitized)
                 organization_wide = organization_wide or not project_slugs
         if has_successful_telemetry:
             for call in block.message.tool_calls or []:
@@ -473,6 +495,8 @@ def _successful_links_and_projects(
                 try:
                     args = json.loads(call.args)
                 except (TypeError, ValueError):
+                    args = None
+                if not isinstance(args, dict):
                     continue
                 slugs.update(_project_slugs_from_code(str(args.get("code", ""))))
     projects = list(

--- a/src/sentry/investigations/contracts.py
+++ b/src/sentry/investigations/contracts.py
@@ -205,6 +205,22 @@ class VisualizationSerializer(StrictContractSerializer):
     topN = serializers.IntegerField(required=False, allow_null=True, min_value=1, max_value=20)
 
 
+class InvestigationQueryLinkSerializer(StrictContractSerializer):
+    kind = serializers.CharField(max_length=64)
+    params = serializers.DictField()
+
+    def validate_params(self, value: dict[str, Any]) -> dict[str, Any]:
+        for item in value.values():
+            nested = (
+                any(isinstance(entry, dict | list) for entry in item)
+                if isinstance(item, list)
+                else isinstance(item, dict)
+            )
+            if nested:
+                raise serializers.ValidationError("Link params must not be nested.")
+        return value
+
+
 class InvestigationQueryResultSerializer(StrictContractSerializer):
     schemaVersion = serializers.IntegerField(min_value=1, max_value=1)
     tableMarkdown = serializers.CharField(max_length=MAX_MARKDOWN_CHARS, trim_whitespace=False)
@@ -212,7 +228,9 @@ class InvestigationQueryResultSerializer(StrictContractSerializer):
     preferredView = serializers.ChoiceField(choices=("table", "chart"), default="table")
     isEmpty = serializers.BooleanField(default=False)
     chartUnavailableReason = serializers.CharField(required=False, allow_null=True)
-    queryLinks = serializers.ListField(child=serializers.JSONField(), required=False, default=list)
+    queryLinks = serializers.ListField(
+        child=InvestigationQueryLinkSerializer(), required=False, default=list
+    )
 
     def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
         if attrs["preferredView"] == "chart" and attrs.get("chart") is None:

--- a/src/sentry/investigations/services/investigations.py
+++ b/src/sentry/investigations/services/investigations.py
@@ -37,6 +37,7 @@ from sentry.models.project import Project
 
 UPDATABLE_INVESTIGATION_FIELDS = frozenset({"title", "status", "filters"})
 MAX_INVESTIGATION_TITLE_LENGTH = 255
+DEFAULT_INVESTIGATION_TITLE = "Untitled investigation"
 
 CREATABLE_BLOCK_FIELDS = frozenset({"kind", "title", "content", "prompt", "config", "display"})
 UPDATABLE_BLOCK_FIELDS = CREATABLE_BLOCK_FIELDS - {"kind"}
@@ -343,7 +344,7 @@ def _create_template_investigation(
             accessible_project_ids=accessible_project_ids,
         )
         project_ids = [source.project_id]
-        resolved_title = title or "Untitled investigation"
+        resolved_title = title or DEFAULT_INVESTIGATION_TITLE
         normalized_source_ref = {
             "groupId": str(source.group.id),
             "openPeriodId": str(source.open_period.id),

--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -329,6 +329,7 @@ class SeerAgentClient:
         code_review_enabled: bool = False,
         max_iterations: int | None = None,
         enable_embeds: bool = True,
+        enable_streaming: bool | None = None,
     ):
         self.organization = organization
         self.user = user
@@ -348,6 +349,7 @@ class SeerAgentClient:
         self.code_review_enabled = code_review_enabled
         self.max_iterations = max_iterations
         self.enable_embeds = enable_embeds
+        self.enable_streaming = enable_streaming
 
         if enable_coding and not organization.get_option("sentry:enable_seer_coding", True):
             raise SeerPermissionError("Seer coding is not enabled for this organization")
@@ -397,6 +399,8 @@ class SeerAgentClient:
         request: Request | None = None,
         override_ce_enable: bool = True,
         ui_tools: str | None = None,
+        record_in_history: bool = True,
+        on_run_created: Callable[[SeerRun], None] | None = None,
     ) -> SeerRun:
         """
         Start a new Seer Agent session.
@@ -502,24 +506,27 @@ class SeerAgentClient:
         )
 
         def _create_agent_run(run: SeerRun) -> None:
-            source = self.category_key or ""
-            if not source:
-                logger.warning(
-                    "seer_agent_run.missing_source",
-                    extra={
-                        "organization_id": self.organization.id,
-                        "seer_run_id": run.id,
-                        "user_id": user_id,
-                    },
+            if record_in_history:
+                source = self.category_key or ""
+                if not source:
+                    logger.warning(
+                        "seer_agent_run.missing_source",
+                        extra={
+                            "organization_id": self.organization.id,
+                            "seer_run_id": run.id,
+                            "user_id": user_id,
+                        },
+                    )
+                SeerAgentRun.objects.create(
+                    run=run,
+                    title=prompt[:255] + "…" if len(prompt) > 256 else prompt,
+                    source=source,
+                    project=self.project,
+                    group=self.group,
+                    extras=({"category_value": self.category_value} if self.category_value else {}),
                 )
-            SeerAgentRun.objects.create(
-                run=run,
-                title=prompt[:255] + "…" if len(prompt) > 256 else prompt,
-                source=source,
-                project=self.project,
-                group=self.group,
-                extras=({"category_value": self.category_value} if self.category_value else {}),
-            )
+            if on_run_created is not None:
+                on_run_created(run)
 
         return enqueue_seer_run(
             organization=self.organization,
@@ -650,10 +657,13 @@ class SeerAgentClient:
         if self._embed_widgets_enabled():
             opts["embed_widgets"] = get_embed_widgets(self.organization, self.user)
 
-        if features.has(
-            "organizations:seer-explorer-stream",
-            self.organization,
-            actor=self.user,
+        if self.enable_streaming is True or (
+            self.enable_streaming is None
+            and features.has(
+                "organizations:seer-explorer-stream",
+                self.organization,
+                actor=self.user,
+            )
         ):
             opts["enable_streaming"] = True
 

--- a/tests/sentry/investigations/test_agent.py
+++ b/tests/sentry/investigations/test_agent.py
@@ -1,0 +1,553 @@
+from unittest.mock import MagicMock, patch
+
+from sentry.investigations.agent import (
+    _maybe_start_title_generation,
+    sanitize_state,
+    start_execution_run,
+    synchronize_execution,
+    synchronize_title,
+)
+from sentry.investigations.models import InvestigationBlockExecutionStatus
+from sentry.seer.agent.client_models import (
+    MemoryBlock,
+    Message,
+    SeerRunState,
+    ToolCall,
+    ToolLink,
+    ToolResult,
+)
+from sentry.seer.models.run import SeerRunType
+from sentry.testutils.cases import TestCase
+from sentry.utils import json
+
+
+def state(*, blocks: list[MemoryBlock], status: str = "completed") -> SeerRunState:
+    return SeerRunState(
+        run_id=42,
+        blocks=blocks,
+        status=status,
+        updated_at="2026-08-03T00:00:00Z",
+    )
+
+
+class InvestigationAgentTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.investigation = self.create_investigation(
+            organization=self.organization,
+            created_by=self.user,
+            title="Already titled",
+        )
+        self.block = self.create_investigation_block(
+            investigation=self.investigation,
+            kind="query",
+            prompt="Count errors",
+        )
+        self.seer_run = self.create_seer_run(
+            organization=self.organization,
+            type=SeerRunType.EXPLORER,
+            seer_run_state_id=42,
+        )
+        self.execution = self.create_investigation_block_execution(
+            block=self.block,
+            seer_run=self.seer_run,
+            executor="code_mode",
+            status=InvestigationBlockExecutionStatus.RUNNING,
+            block_version=self.block.version,
+            input_snapshot={
+                "projectIds": [self.project.id],
+                "projectSlugs": [self.project.slug],
+            },
+        )
+        self.block.current_execution = self.execution
+        self.block.save(update_fields=["current_execution"])
+
+    def test_completed_query_keeps_result_and_source_projects(self) -> None:
+        run_state = state(
+            blocks=[
+                MemoryBlock(
+                    id="query",
+                    timestamp="2026-08-03T00:00:00Z",
+                    message=Message(
+                        role="tool_use",
+                        tool_calls=[
+                            ToolCall(
+                                id="call",
+                                function="sentry_api_execute",
+                                args=json.dumps(
+                                    {
+                                        "code": (
+                                            "sentry.telemetry_live_search("
+                                            "'count errors', 'errors', "
+                                            f"project_slugs=['{self.project.slug}'])"
+                                        )
+                                    }
+                                ),
+                            )
+                        ],
+                    ),
+                    tool_results=[
+                        ToolResult(
+                            tool_call_id="call",
+                            tool_call_function="sentry_api_execute",
+                            content=(
+                                '<UNTRUSTED_DATA source="sentry_api" trust="UNTRUSTED">\n'
+                                "{'result': '12 errors', 'link_params': "
+                                "{'dataset': 'errors', 'query': 'is:unresolved', "
+                                f"'project_slugs': ['{self.project.slug}']}}}}\n"
+                                "</UNTRUSTED_DATA>"
+                            ),
+                        )
+                    ],
+                ),
+                MemoryBlock(
+                    id="result",
+                    timestamp="2026-08-03T00:00:00Z",
+                    message=Message(
+                        role="assistant",
+                        content=(
+                            '{"tableMarkdown":"| Errors |\\n| ---: |\\n| 12 |",'
+                            '"chart":null,"preferredView":"table","isEmpty":false,'
+                            '"chartUnavailableReason":"A chart is not useful."}'
+                        ),
+                    ),
+                ),
+            ]
+        )
+
+        synchronize_execution(self.execution, run_state)
+
+        self.execution.refresh_from_db()
+        self.block.refresh_from_db()
+        assert self.execution.status == InvestigationBlockExecutionStatus.COMPLETED
+        assert self.execution.result["tableMarkdown"].startswith("| Errors |")
+        assert self.execution.result["queryLinks"][0]["kind"] == "telemetry"
+        assert list(self.execution.data_projects.all()) == [self.project]
+        assert self.block.result_execution == self.execution
+
+    def test_completed_text_keeps_snapshotted_context_projects(self) -> None:
+        self.block.kind = "text"
+        self.block.save(update_fields=["kind"])
+        self.execution.input_snapshot = {"contextDataProjectIds": [self.project.id]}
+        self.execution.save(update_fields=["input_snapshot"])
+        run_state = state(
+            blocks=[
+                MemoryBlock(
+                    id="result",
+                    timestamp="2026-08-03T00:00:00Z",
+                    message=Message(
+                        role="assistant",
+                        content='{"markdown":"Checkout errors increased after deployment."}',
+                    ),
+                )
+            ]
+        )
+
+        synchronize_execution(self.execution, run_state)
+
+        self.execution.refresh_from_db()
+        assert self.execution.status == InvestigationBlockExecutionStatus.COMPLETED
+        assert list(self.execution.data_projects.all()) == [self.project]
+
+    def test_start_run_requests_a_final_response_without_an_artifact_writer(self) -> None:
+        client = MagicMock()
+
+        start_execution_run(self.execution, self.organization, self.user, client)
+
+        prompt = client.start_run.call_args.args[0]
+        options = client.start_run.call_args.kwargs
+        assert "write or save the result" in prompt
+        assert "project_slugs as a literal list of string values" in prompt
+        assert "Never build that argument from a variable" in prompt
+        assert "Do not import sentry, sentry_sdk, or tool input types" in prompt
+        assert 'title="Error volume"' in prompt
+        assert "inline plain dictionaries" in prompt
+        assert 'x_axis="time", y_axis_unit="number"' in prompt
+        assert "offset-bearing ISO 8601 timestamps" in prompt
+        assert "first character must be { and the last character must be }" in prompt
+        assert "Do not wrap the object in a Markdown code fence" in prompt
+        assert "exactly these five keys and no others" in prompt
+        assert "artifact_key" not in options
+        assert "artifact_schema" not in options
+
+    def test_completed_query_accepts_strict_json_final_message(self) -> None:
+        run_state = state(
+            blocks=[
+                MemoryBlock(
+                    id="result",
+                    timestamp="2026-08-03T00:00:00Z",
+                    message=Message(
+                        role="assistant",
+                        content=(
+                            '{"tableMarkdown":"| Errors |\\n| ---: |\\n| 12 |",'
+                            '"chart":null,"preferredView":"table","isEmpty":false,'
+                            '"chartUnavailableReason":"No chart was requested."}'
+                        ),
+                    ),
+                    tool_links=[
+                        ToolLink(
+                            kind="telemetry",
+                            params={
+                                "dataset": "errors",
+                                "query": "is:unresolved",
+                                "project_slugs": [self.project.slug],
+                            },
+                        )
+                    ],
+                )
+            ]
+        )
+
+        synchronize_execution(self.execution, run_state)
+
+        self.execution.refresh_from_db()
+        assert self.execution.status == InvestigationBlockExecutionStatus.COMPLETED
+        assert self.execution.result["tableMarkdown"].startswith("| Errors |")
+
+    def test_completed_query_rejects_prose_wrapped_json(self) -> None:
+        run_state = state(
+            blocks=[
+                MemoryBlock(
+                    id="result",
+                    timestamp="2026-08-03T00:00:00Z",
+                    message=Message(
+                        role="assistant",
+                        content=(
+                            "Here is the result:\n"
+                            '{"tableMarkdown":"| Errors |\\n| ---: |\\n| 12 |",'
+                            '"chart":null,"preferredView":"table","isEmpty":false,'
+                            '"chartUnavailableReason":"No chart was requested."}'
+                        ),
+                    ),
+                )
+            ]
+        )
+
+        synchronize_execution(self.execution, run_state)
+
+        self.execution.refresh_from_db()
+        assert self.execution.status == InvestigationBlockExecutionStatus.FAILED
+        assert self.execution.error == {
+            "code": "invalid_result",
+            "message": "The agent returned malformed or unsupported result JSON.",
+        }
+
+    @patch("sentry.investigations.agent.interrupt_run")
+    def test_pending_disallowed_import_waits_for_code_mode_lint(
+        self, interrupt_run: MagicMock
+    ) -> None:
+        run_state = state(
+            status="processing",
+            blocks=[
+                MemoryBlock(
+                    id="pending-import",
+                    timestamp="2026-08-03T00:00:00Z",
+                    message=Message(
+                        role="tool_use",
+                        tool_calls=[
+                            ToolCall(
+                                id="call",
+                                function="sentry_api_execute",
+                                args='{"code":"from sentry_sdk import ChartSeries"}',
+                            )
+                        ],
+                    ),
+                )
+            ],
+        )
+
+        synchronize_execution(self.execution, run_state)
+
+        self.execution.refresh_from_db()
+        assert self.execution.status == InvestigationBlockExecutionStatus.RUNNING
+        interrupt_run.assert_not_called()
+
+    @patch("sentry.investigations.agent.interrupt_run")
+    def test_unsupported_execute_is_redacted_and_stopped(self, interrupt_run: MagicMock) -> None:
+        run_state = state(
+            status="processing",
+            blocks=[
+                MemoryBlock(
+                    id="unsafe",
+                    timestamp="2026-08-03T00:00:00Z",
+                    message=Message(
+                        role="tool_use",
+                        tool_calls=[
+                            ToolCall(
+                                id="call",
+                                function="sentry_api_execute",
+                                args='{"code":"sentry.get_issue(issue_id=1)"}',
+                            )
+                        ],
+                    ),
+                    tool_results=[
+                        ToolResult(
+                            tool_call_id="call",
+                            tool_call_function="sentry_api_execute",
+                            content="sensitive result",
+                        )
+                    ],
+                )
+            ],
+        )
+
+        blocks, _, off_policy = sanitize_state(run_state)
+        assert off_policy is True
+        assert blocks[0]["toolResults"][0]["content"].startswith("[Result hidden")
+
+        synchronize_execution(self.execution, run_state)
+        self.execution.refresh_from_db()
+        assert self.execution.status == InvestigationBlockExecutionStatus.FAILED
+        assert self.execution.error["code"] == "unsupported_tool_use"
+        interrupt_run.assert_called_once()
+
+    def test_text_mode_rejects_and_hides_tool_results(self) -> None:
+        run_state = state(
+            status="processing",
+            blocks=[
+                MemoryBlock(
+                    id="tool",
+                    timestamp="2026-08-03T00:00:00Z",
+                    message=Message(
+                        role="tool_use",
+                        tool_calls=[ToolCall(id="call", function="search_issues", args="{}")],
+                    ),
+                    tool_results=[
+                        ToolResult(
+                            tool_call_id="call",
+                            tool_call_function="search_issues",
+                            content="private issue data",
+                        )
+                    ],
+                )
+            ],
+        )
+
+        blocks, _, off_policy = sanitize_state(run_state, allow_query_tools=False)
+
+        assert off_policy is True
+        assert blocks[0]["toolResults"][0]["content"].startswith("[Result hidden")
+
+    def test_query_mode_allows_sentry_api_search_for_tool_discovery(self) -> None:
+        run_state = state(
+            status="processing",
+            blocks=[
+                MemoryBlock(
+                    id="search",
+                    timestamp="2026-08-03T00:00:00Z",
+                    message=Message(
+                        role="tool_use",
+                        tool_calls=[
+                            ToolCall(
+                                id="call",
+                                function="sentry_api_search",
+                                args='{"code":"[skill for skill in skills if skill[0] == '
+                                "'errors-search']\"}",
+                            )
+                        ],
+                    ),
+                )
+            ],
+        )
+
+        blocks, _, off_policy = sanitize_state(run_state)
+
+        assert off_policy is False
+        assert "policyError" not in blocks[0]
+
+    def test_result_writer_is_not_an_allowed_sentry_api(self) -> None:
+        run_state = state(
+            status="processing",
+            blocks=[
+                MemoryBlock(
+                    id="artifact",
+                    timestamp="2026-08-03T00:00:00Z",
+                    message=Message(
+                        role="tool_use",
+                        tool_calls=[
+                            ToolCall(
+                                id="call",
+                                function="sentry_api_execute",
+                                args='{"code":"sentry.write_investigation_query_result()"}',
+                            )
+                        ],
+                    ),
+                )
+            ],
+        )
+
+        blocks, _, off_policy = sanitize_state(run_state)
+
+        assert off_policy is True
+        assert blocks[0]["policyError"] == (
+            "Unsupported Sentry API call: sentry.write_investigation_query_result."
+        )
+
+    def test_sentry_api_alias_is_rejected(self) -> None:
+        run_state = state(
+            status="processing",
+            blocks=[
+                MemoryBlock(
+                    id="alias",
+                    timestamp="2026-08-03T00:00:00Z",
+                    message=Message(
+                        role="tool_use",
+                        tool_calls=[
+                            ToolCall(
+                                id="call",
+                                function="sentry_api_execute",
+                                args='{"code":"client = sentry\\nclient.get_issue(issue_id=1)"}',
+                            )
+                        ],
+                    ),
+                )
+            ],
+        )
+
+        blocks, _, off_policy = sanitize_state(run_state)
+
+        assert off_policy is True
+        assert blocks[0]["policyError"] == (
+            "Dynamic or aliased access to the Sentry API is unsupported."
+        )
+
+    def test_dynamic_import_is_rejected(self) -> None:
+        run_state = state(
+            status="processing",
+            blocks=[
+                MemoryBlock(
+                    id="dynamic-import",
+                    timestamp="2026-08-03T00:00:00Z",
+                    message=Message(
+                        role="tool_use",
+                        tool_calls=[
+                            ToolCall(
+                                id="call",
+                                function="sentry_api_execute",
+                                args='{"code":"client = __import__(\\"sentry\\")"}',
+                            )
+                        ],
+                    ),
+                )
+            ],
+        )
+
+        blocks, _, off_policy = sanitize_state(run_state)
+
+        assert off_policy is True
+        assert blocks[0]["policyError"] == (
+            "The __import__ function is not allowed in an investigation query."
+        )
+
+    def test_nonexecuted_lint_failure_does_not_trigger_policy(self) -> None:
+        run_state = state(
+            status="processing",
+            blocks=[
+                MemoryBlock(
+                    id="lint-failure",
+                    timestamp="2026-08-03T00:00:00Z",
+                    message=Message(
+                        role="tool_use",
+                        tool_calls=[
+                            ToolCall(
+                                id="call",
+                                function="sentry_api_execute",
+                                args='{"code":"from sentry_sdk import ChartSeries"}',
+                            )
+                        ],
+                    ),
+                    tool_results=[
+                        ToolResult(
+                            tool_call_id="call",
+                            tool_call_function="sentry_api_execute",
+                            content=(
+                                "Error executing code:\n"
+                                "Lint errors (code not executed):\n"
+                                "  Line 1: Cannot import 'sentry_sdk'."
+                            ),
+                        )
+                    ],
+                )
+            ],
+        )
+
+        blocks, _, off_policy = sanitize_state(run_state)
+
+        assert off_policy is False
+        assert "policyError" not in blocks[0]
+        assert "Lint errors (code not executed)" in blocks[0]["toolResults"][0]["content"]
+
+    def test_telemetry_call_cannot_escape_the_project_scope(self) -> None:
+        run_state = state(
+            status="processing",
+            blocks=[
+                MemoryBlock(
+                    id="other-project",
+                    timestamp="2026-08-03T00:00:00Z",
+                    message=Message(
+                        role="tool_use",
+                        tool_calls=[
+                            ToolCall(
+                                id="call",
+                                function="sentry_api_execute",
+                                args=json.dumps(
+                                    {
+                                        "code": (
+                                            "sentry.telemetry_live_search("
+                                            "'errors', 'errors', project_slugs=['other'])"
+                                        )
+                                    }
+                                ),
+                            )
+                        ],
+                    ),
+                )
+            ],
+        )
+
+        blocks, _, off_policy = sanitize_state(run_state, allowed_project_slugs={self.project.slug})
+
+        assert off_policy is True
+        assert blocks[0]["policyError"] == (
+            "The telemetry call requested a project outside this investigation."
+        )
+
+    def test_title_uses_the_final_assistant_message(self) -> None:
+        self.investigation.title = "Untitled investigation"
+        self.investigation.title_generation_status = "running"
+        self.investigation.save(update_fields=["title", "title_generation_status"])
+        run_state = state(
+            blocks=[
+                MemoryBlock(
+                    id="title",
+                    timestamp="2026-08-03T00:00:00Z",
+                    message=Message(role="assistant", content="Daily error volume by project"),
+                )
+            ]
+        )
+
+        synchronize_title(self.investigation, run_state)
+
+        self.investigation.refresh_from_db()
+        assert self.investigation.title == "Daily error volume by project"
+        assert self.investigation.title_generation_status == "completed"
+
+    @patch("sentry.investigations.agent.SeerAgentClient")
+    def test_title_prompt_uses_specific_incident_source_context(
+        self, mock_client: MagicMock
+    ) -> None:
+        self.investigation.title = "Untitled investigation"
+        self.investigation.source_ref = {
+            "groupTitle": "Checkout errors breached 100 events",
+            "project": {"slug": "checkout-api"},
+            "monitor": {"name": "Checkout errors", "direction": "above"},
+        }
+        self.investigation.save(update_fields=["title", "source_ref"])
+
+        _maybe_start_title_generation(self.investigation, None)
+
+        prompt = mock_client.return_value.start_run.call_args.args[0]
+        assert "specific incident" in prompt
+        assert "Checkout errors breached 100 events" in prompt
+        assert "checkout-api" in prompt
+        assert "Avoid generic titles" in prompt

--- a/tests/sentry/investigations/test_agent.py
+++ b/tests/sentry/investigations/test_agent.py
@@ -516,6 +516,134 @@ class InvestigationAgentTest(TestCase):
             "The telemetry call requested a project outside this investigation."
         )
 
+    def test_empty_project_slugs_cannot_widen_the_scope(self) -> None:
+        # An empty list reaches the telemetry tools as "no scope supplied", which
+        # makes them query every project in the organization.
+        run_state = state(
+            status="processing",
+            blocks=[
+                MemoryBlock(
+                    id="no-project",
+                    timestamp="2026-08-03T00:00:00Z",
+                    message=Message(
+                        role="tool_use",
+                        tool_calls=[
+                            ToolCall(
+                                id="call",
+                                function="sentry_api_execute",
+                                args=json.dumps(
+                                    {
+                                        "code": (
+                                            "sentry.telemetry_live_search("
+                                            "'errors', 'errors', project_slugs=[])"
+                                        )
+                                    }
+                                ),
+                            )
+                        ],
+                    ),
+                )
+            ],
+        )
+
+        blocks, _, off_policy = sanitize_state(run_state, allowed_project_slugs={self.project.slug})
+
+        assert off_policy is True
+        assert blocks[0]["policyError"] == (
+            "Telemetry calls must use a non-empty literal project_slugs list."
+        )
+
+    def test_non_object_tool_call_args_are_rejected_without_crashing(self) -> None:
+        run_state = state(
+            status="processing",
+            blocks=[
+                MemoryBlock(
+                    id="bad-args",
+                    timestamp="2026-08-03T00:00:00Z",
+                    message=Message(
+                        role="tool_use",
+                        tool_calls=[
+                            ToolCall(id="call", function="sentry_api_execute", args="null")
+                        ],
+                    ),
+                )
+            ],
+        )
+
+        blocks, _, off_policy = sanitize_state(run_state, allowed_project_slugs={self.project.slug})
+
+        assert off_policy is True
+        assert blocks[0]["policyError"] == "The Code Mode call had invalid arguments."
+
+    def test_query_links_drop_nested_and_oversized_params(self) -> None:
+        run_state = state(
+            blocks=[
+                MemoryBlock(
+                    id="query",
+                    timestamp="2026-08-03T00:00:00Z",
+                    message=Message(
+                        role="tool_use",
+                        tool_calls=[
+                            ToolCall(
+                                id="call",
+                                function="sentry_api_execute",
+                                args=json.dumps(
+                                    {
+                                        "code": (
+                                            "sentry.telemetry_live_search("
+                                            "'count errors', 'errors', "
+                                            f"project_slugs=['{self.project.slug}'])"
+                                        )
+                                    }
+                                ),
+                            )
+                        ],
+                    ),
+                    tool_results=[
+                        ToolResult(
+                            tool_call_id="call",
+                            tool_call_function="sentry_api_execute",
+                            structuredContent={
+                                "links": [
+                                    {
+                                        "kind": "telemetry",
+                                        "smuggled": "top-level",
+                                        "params": {
+                                            "dataset": "errors",
+                                            "query": "x" * 3000,
+                                            "project_slugs": [self.project.slug],
+                                            "nested": {"secret": "value"},
+                                        },
+                                    }
+                                ]
+                            },
+                        )
+                    ],
+                ),
+                MemoryBlock(
+                    id="result",
+                    timestamp="2026-08-03T00:00:00Z",
+                    message=Message(
+                        role="assistant",
+                        content=(
+                            '{"tableMarkdown":"| Errors |\\n| ---: |\\n| 12 |",'
+                            '"chart":null,"preferredView":"table","isEmpty":false,'
+                            '"chartUnavailableReason":"A chart is not useful."}'
+                        ),
+                    ),
+                ),
+            ]
+        )
+
+        synchronize_execution(self.execution, run_state)
+
+        self.execution.refresh_from_db()
+        assert self.execution.status == InvestigationBlockExecutionStatus.COMPLETED
+        link = self.execution.result["queryLinks"][0]
+        assert set(link) == {"kind", "params"}
+        assert set(link["params"]) == {"dataset", "query", "project_slugs"}
+        assert len(link["params"]["query"]) == 2000
+
     def test_title_uses_the_final_assistant_message(self) -> None:
         self.investigation.title = "Untitled investigation"
         self.investigation.title_generation_status = "running"

--- a/tests/sentry/investigations/test_agent.py
+++ b/tests/sentry/investigations/test_agent.py
@@ -1,4 +1,7 @@
+from typing import Any
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from sentry.investigations.agent import (
     _maybe_start_title_generation,
@@ -8,6 +11,7 @@ from sentry.investigations.agent import (
     synchronize_title,
 )
 from sentry.investigations.models import InvestigationBlockExecutionStatus
+from sentry.investigations.services.investigations import DEFAULT_INVESTIGATION_TITLE
 from sentry.seer.agent.client_models import (
     MemoryBlock,
     Message,
@@ -551,3 +555,54 @@ class InvestigationAgentTest(TestCase):
         assert "Checkout errors breached 100 events" in prompt
         assert "checkout-api" in prompt
         assert "Avoid generic titles" in prompt
+
+    @patch("sentry.investigations.agent.SeerAgentClient")
+    def test_title_generation_skips_an_in_flight_run(self, mock_client: MagicMock) -> None:
+        self.investigation.update(
+            title=DEFAULT_INVESTIGATION_TITLE, title_generation_status="running"
+        )
+
+        _maybe_start_title_generation(self.investigation, None)
+
+        assert mock_client.return_value.start_run.call_count == 0
+        self.investigation.refresh_from_db()
+        assert self.investigation.title_generation_status == "running"
+
+    @patch("sentry.investigations.agent.SeerAgentClient")
+    def test_title_dispatch_failure_releases_the_in_flight_status(
+        self, mock_client: MagicMock
+    ) -> None:
+        self.investigation.update(title=DEFAULT_INVESTIGATION_TITLE)
+
+        def start_run(prompt: str, **kwargs: Any) -> None:
+            kwargs["on_run_created"](self.seer_run)
+            raise RuntimeError("Seer is unavailable")
+
+        mock_client.return_value.start_run.side_effect = start_run
+
+        with pytest.raises(RuntimeError):
+            _maybe_start_title_generation(self.investigation, None)
+
+        self.investigation.refresh_from_db()
+        assert self.investigation.title_seer_run_id == self.seer_run.id
+        assert self.investigation.title_generation_status == "failed"
+
+    def test_title_increments_the_investigation_version(self) -> None:
+        self.investigation.update(
+            title=DEFAULT_INVESTIGATION_TITLE, title_generation_status="running"
+        )
+        version = self.investigation.version
+        run_state = state(
+            blocks=[
+                MemoryBlock(
+                    id="title",
+                    timestamp="2026-08-03T00:00:00Z",
+                    message=Message(role="assistant", content="Checkout errors above threshold"),
+                )
+            ]
+        )
+
+        synchronize_title(self.investigation, run_state)
+        assert self.investigation.version == version + 1
+        self.investigation.refresh_from_db()
+        assert self.investigation.version == version + 1


### PR DESCRIPTION
This is part 1 of 4 in the Investigation execution/frontend split.

This PR adds the backend agent execution engine without exposing new Investigation APIs or frontend behavior:

- generic Seer client support for forced streaming, optional history suppression, and atomic run-created callbacks
- Investigation prompts, tool policy enforcement, transcript sanitization, and result validation
- execution synchronization, result promotion, completion hooks, and title generation internals
- focused backend coverage for the engine

Auto-run activation, taskworker dispatch, HTTP endpoints, feature registration, and breached-metric launch are intentionally deferred to [9/2/13].

Validation:
- `.venv/bin/pytest -q --reuse-db tests/sentry/investigations/test_agent.py` (16 passed)
- pre-commit hooks passed
- pre-push mypy passed