### PR TITLE
ref(scraps): move alert from media queries to container queries

### DIFF
--- a/static/app/components/core/alert/alert.tsx
+++ b/static/app/components/core/alert/alert.tsx
@@ -1,12 +1,12 @@
-import {Fragment, useRef, useState} from 'react';
-import type {SerializedStyles, Theme} from '@emotion/react';
-import {css} from '@emotion/react';
+import {useRef, useState} from 'react';
+import {css, type SerializedStyles, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
 import type {DistributedOmit} from 'type-fest';
 
 import {Button, type ButtonProps} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Container, Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
 
 import {IconCheckmark, IconChevron, IconInfo, IconNot, IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -29,6 +29,8 @@ export interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
 const AlertPanel = styled('div')<AlertProps>`
   position: relative;
   display: grid;
+  width: 100%;
+  container-type: inline-size;
   grid-template-columns: ${p => getAlertGridLayout(p)};
   padding: ${p => p.theme.space.md} ${p => p.theme.space.lg};
   border-width: ${p => (p.system ? '0px 0px 1px 0px' : '1px')};
@@ -153,7 +155,7 @@ const StyledTrailingItems = styled('div')`
     align-self: center;
   }
 
-  @media (min-width: ${p => p.theme.breakpoints.sm}) {
+  @container (min-width: ${p => p.theme.container.sm}) {
     grid-area: auto;
     align-items: start;
   }
@@ -180,22 +182,6 @@ const StyledIconWrapper = styled('div')<{variant: AlertProps['variant']}>`
       : p.variant === 'muted'
         ? p.theme.tokens.content.primary
         : p.theme.colors.black};
-`;
-
-const StyledExpandContainer = styled('div')<{
-  showIcon: boolean;
-  showTrailingItems: boolean;
-}>`
-  color: ${p => p.theme.tokens.content.secondary};
-  grid-row: ${p => (p.showTrailingItems ? 3 : 2)};
-
-  grid-column: 1 / -1;
-  align-self: flex-start;
-  cursor: auto;
-
-  @media (min-width: ${p => p.theme.breakpoints.sm}) {
-    grid-row: 2;
-  }
 `;
 
 export function Alert({
@@ -267,15 +253,17 @@ export function Alert({
           </Flex>
         )}
         {isExpanded && (
-          <Fragment>
-            <StyledExpandContainer
-              ref={expandRef}
-              showIcon={!!showIcon}
-              showTrailingItems={!!trailingItems}
-            >
+          <Container
+            ref={expandRef}
+            row={{zero: trailingItems ? '3' : '2', xl: '2'}}
+            column="1 / -1"
+            alignSelf="flex-start"
+            cursor="auto"
+          >
+            <Text as="div" variant="muted">
               {expand}
-            </StyledExpandContainer>
-          </Fragment>
+            </Text>
+          </Container>
         )}
       </PanelProvider>
     </AlertPanel>
@@ -303,13 +291,15 @@ function AlertIcon({variant}: {variant: AlertProps['variant']}): React.ReactNode
 /**
  * Manages margins of Alert components
  */
-const Container = styled('div')`
+const AlertContainer = styled('div')`
+  width: 100%;
+
   > div {
     margin-bottom: ${p => p.theme.space.xl};
   }
 `;
 
-Alert.Container = Container;
+Alert.Container = AlertContainer;
 
 function AlertButton(props: DistributedOmit<ButtonProps, 'size'>) {
   return <Button {...props} size="zero" />;

--- a/static/app/views/seerExplorer/components/updateSlackAlert.tsx
+++ b/static/app/views/seerExplorer/components/updateSlackAlert.tsx
@@ -1,9 +1,8 @@
 import {Alert} from '@sentry/scraps/alert';
 import {Button, LinkButton} from '@sentry/scraps/button';
-import {Container, Flex, Grid} from '@sentry/scraps/layout';
+import {Container, Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
-import {IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -36,38 +35,11 @@ export function UpdateSlackAlert({num_configurations}: UpdateSlackAlertProps) {
     (num_configurations === 1 ? '&showInstallModal=1' : '');
 
   return (
-    <Container padding="lg" containerType="inline-size">
+    <Container padding="lg">
       <Alert
         variant="muted"
         trailingItems={
-          <Button
-            icon={<IconClose />}
-            variant="transparent"
-            size="xs"
-            aria-label={t('Dismiss')}
-            onClick={() => setIsDismissed(true)}
-          />
-        }
-      >
-        <Grid
-          columns={{zero: 'minmax(0, 1fr)', xs: 'minmax(0, 1fr) auto'}}
-          rows={{zero: 'auto auto', xs: 'auto'}}
-          align="start"
-          gap="lg"
-        >
-          <Container column="1" row="1" minWidth="0">
-            <Text>
-              {t(
-                'Chat, ask questions, and debug with Sentry in the new Slack app. Please reinstall the Slack app to get started.'
-              )}
-            </Text>
-          </Container>
-          <Flex
-            column={{zero: '1', xs: '2'}}
-            row={{zero: '2', xs: '1'}}
-            width="max-content"
-            align="center"
-          >
+          <Flex gap="md">
             <LinkButton
               to={to}
               variant="primary"
@@ -82,8 +54,17 @@ export function UpdateSlackAlert({num_configurations}: UpdateSlackAlertProps) {
             >
               {t('Update Now')}
             </LinkButton>
+            <Button variant="secondary" size="xs" onClick={() => setIsDismissed(true)}>
+              {t('Dismiss')}
+            </Button>
           </Flex>
-        </Grid>
+        }
+      >
+        <Text>
+          {t(
+            'Chat, ask questions, and debug with Sentry in the new Slack app. Please reinstall the Slack app to get started.'
+          )}
+        </Text>
       </Alert>
     </Container>
   );


### PR DESCRIPTION
now that alert moves `trailingItems` to the next row on smaller screens automatically, I could revert a lot of the changes in the `updateSlackAlert`. It looks like this now:

<img width="610" height="124" alt="Screenshot 2026-08-06 at 09 50 31" src="https://github.com/user-attachments/assets/4eebcbcc-5d88-4f4c-a622-c4d2c31ead95" />
<img width="398" height="146" alt="Screenshot 2026-08-06 at 09 50 19" src="https://github.com/user-attachments/assets/573a4ad7-1d26-4474-8179-e135e7642ec3" />

I made `Dismiss` a normal text button because next to `Update Now`, it looked a bit weird.