### PR TITLE
chore(dynamic-sampling): add feature check to per-org scheduler

### DIFF
--- a/src/sentry/dynamic_sampling/per_org/scheduler.py
+++ b/src/sentry/dynamic_sampling/per_org/scheduler.py
@@ -50,6 +50,7 @@ from sentry.dynamic_sampling.per_org.telemetry import (
     track_dynamic_sampling,
 )
 from sentry.dynamic_sampling.rules.utils import OrganizationId
+from sentry.dynamic_sampling.utils import has_dynamic_sampling
 from sentry.models.organization import Organization, OrganizationStatus
 from sentry.models.project import Project
 from sentry.silo.base import SiloMode
@@ -230,11 +231,21 @@ def log_sample_rates_summary(
 def schedule_per_org_calculations() -> None:
     dispatched = 0
     skipped = 0
+    without_dynamic_sampling = 0
 
     def validate_and_track(org_id: int) -> bool:
-        nonlocal dispatched, skipped
+        nonlocal dispatched, skipped, without_dynamic_sampling
         if not is_org_in_rollout(org_id):
             skipped += 1
+            return False
+        # The PK snapshot is taken once per cycle, so an org can be deleted before its
+        # turn to be dispatched comes up.
+        try:
+            organization = Organization.objects.get_from_cache(id=org_id)
+        except Organization.DoesNotExist:
+            organization = None
+        if not has_dynamic_sampling(organization):
+            without_dynamic_sampling += 1
             return False
         dispatched += 1
         return True
@@ -266,4 +277,9 @@ def schedule_per_org_calculations() -> None:
         SCHEDULER_BUCKET_ORG_STATUS_METRIC,
         DynamicSamplingStatus.ROLLOUT_EXCLUDED,
         amount=skipped,
+    )
+    emit_status(
+        SCHEDULER_BUCKET_ORG_STATUS_METRIC,
+        DynamicSamplingStatus.ORG_HAS_NO_DYNAMIC_SAMPLING,
+        amount=without_dynamic_sampling,
     )

--- a/tests/sentry/dynamic_sampling/per_org/test_scheduler.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_scheduler.py
@@ -134,6 +134,51 @@ class SchedulePerOrgCalculationsTest(TestCase):
         assert org_without_projects.id not in org_ids
         assert org_with_inactive_project.id not in org_ids
 
+    def _dispatched_org_ids(self) -> set[int]:
+        """Run the real validate_item callback over every org in the queryset."""
+        with patch("sentry.dynamic_sampling.per_org.scheduler.CursoredScheduler") as MockScheduler:
+            mock_instance = MockScheduler.return_value
+            mock_instance.tick.return_value = False
+            schedule_per_org_calculations()
+
+            kwargs = MockScheduler.call_args.kwargs
+            validate_item = kwargs["validate_item"]
+            org_ids = kwargs["queryset"].values_list("id", flat=True)
+            return {org_id for org_id in org_ids if validate_item(org_id)}
+
+    @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
+    def test_skips_orgs_without_dynamic_sampling(self) -> None:
+        with_dynamic_sampling = self.create_organization()
+        self.create_project(organization=with_dynamic_sampling)
+        without_dynamic_sampling = self.create_organization()
+        self.create_project(organization=without_dynamic_sampling)
+
+        with self.feature(
+            {
+                "organizations:dynamic-sampling": [with_dynamic_sampling.slug],
+            }
+        ):
+            org_ids = self._dispatched_org_ids()
+
+        assert with_dynamic_sampling.id in org_ids
+        assert without_dynamic_sampling.id not in org_ids
+
+    @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
+    def test_skips_org_deleted_after_the_cycle_snapshot(self) -> None:
+        org = self.create_organization()
+        self.create_project(organization=org)
+
+        with (
+            self.feature("organizations:dynamic-sampling"),
+            patch(f"{SCHEDULER}.CursoredScheduler") as MockScheduler,
+        ):
+            MockScheduler.return_value.tick.return_value = False
+            schedule_per_org_calculations()
+            validate_item = MockScheduler.call_args.kwargs["validate_item"]
+
+            assert validate_item(org.id) is True
+            assert validate_item(99999999) is False
+
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
     def test_org_in_rollout_is_dispatched(self) -> None:
         org = self.create_organization()


### PR DESCRIPTION
- Add feature check
- Record orgs without the feature separately to the rollout flag