### PR TITLE
ci: Replace curl-pipe-bash with action-setup-cli for Sentry CLI setup

### DIFF
--- a/.github/workflows/frontend-snapshots.yml
+++ b/.github/workflows/frontend-snapshots.yml
@@ -68,7 +68,9 @@ jobs:
 
       - name: Install sentry-cli
         if: ${{ !cancelled() }}
-        run: curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION=3.5.0 sh
+        uses: getsentry/action-setup-cli@70d7e587b84c2e78cf4d37cd33d7b74fb3729c1b # v1
+        with:
+          version: '3.5.0'
 
       - name: Upload snapshots
         id: upload


### PR DESCRIPTION
## Summary
- The "Install sentry-cli" step in `frontend-snapshots.yml` used `curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION=3.5.0 sh`, piping a remote install script directly into a shell.
- Replaced it with [`getsentry/action-setup-cli`](https://github.com/getsentry/action-setup-cli), which downloads the `sentry-cli` release asset for the runner's OS/arch and verifies its sha256 against the digest GitHub recorded for that asset via the Releases API, before adding it to `PATH`. Uses `gh` only, no `curl`.
- Same pinned version (`3.5.0`) preserved via the action's `version` input; existing `if:` condition kept.

## Test plan
- [x] Validated `frontend-snapshots.yml` parses correctly; pre-commit hooks passed
- [ ] Verify the job still installs sentry-cli 3.5.0 and uploads snapshots correctly on this PR

Fixes VULN-2275

🤖 Generated with [Claude Code](https://claude.com/claude-code)