### PR TITLE
feat(post-process): Generic killswitch for pipeline steps

### DIFF
--- a/src/sentry/killswitches.py
+++ b/src/sentry/killswitches.py
@@ -141,6 +141,29 @@ ALL_KILLSWITCH_OPTIONS = {
             "project_id": "A project ID to filter events by.",
         },
     ),
+    "post_process.disable-pipeline-steps": KillswitchInfo(
+        description="""
+        Skip individual steps of the post_process_group pipeline.
+
+        `pipeline_step` is the name of the step function as it appears in
+        GROUP_CATEGORY_POST_PROCESS_PIPELINE / GENERIC_POST_PROCESS_PIPELINE,
+        e.g. `kick_off_seer_automation`. Leaving it unset is a wildcard that
+        disables *every* step, i.e. all of post-processing.
+
+        The same step function runs in more than one pipeline (e.g.
+        process_snoozes runs for both error and feedback issues). Set
+        `issue_category` to target only one of them.
+
+        Work skipped this way is dropped for good, nothing catches up when the
+        switch is turned off again.
+        """,
+        fields={
+            "pipeline_step": "Name of the post-process step function, e.g. kick_off_seer_automation.",
+            "project_id": "A project ID to filter events by.",
+            "organization_id": "An organization ID to filter events by.",
+            "issue_category": "Lowercased GroupCategory name, e.g. error or feedback.",
+        },
+    ),
     "reprocessing2.drop-delete-old-primary-hash": KillswitchInfo(
         description="""
         Drop per-event messages emitted from delete_old_primary_hash. This message is currently lacking batching, and for the time being we should be able to drop it on a whim.

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1446,6 +1446,12 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
+    "post_process.disable-pipeline-steps",
+    type=Sequence,
+    default=[],
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
     "api.organization.disable-last-deploys",
     type=Sequence,
     default=[],

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import logging
 import random
 import uuid
@@ -18,7 +19,11 @@ from sentry import features, options, projectoptions
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.issues.grouptype import GroupCategory
 from sentry.issues.issue_occurrence import IssueOccurrence
-from sentry.killswitches import killswitch_matches_context
+from sentry.killswitches import (
+    get_killswitch_value,
+    killswitch_matches_context,
+    value_matches,
+)
 from sentry.replays.lib.event_linking import transform_event_for_linking_payload
 from sentry.replays.lib.kafka import publish_replay_event
 from sentry.signals import event_processed, issue_unignored
@@ -664,7 +669,36 @@ def run_post_process_job(job: PostProcessJob) -> None:
     else:
         pipeline = GENERIC_POST_PROCESS_PIPELINE
 
+    # Read the killswitch once per job instead of once per step: the error
+    # pipeline has 25 steps, and killswitch_matches_context would redo the
+    # options.get() and normalize_value() on every one of them.
+    disabled_steps = get_killswitch_value("post_process.disable-pipeline-steps")
+    killswitch_context = (
+        {
+            "project_id": group_event.project_id,
+            "organization_id": group_event.project.organization_id,
+            "issue_category": issue_category_metric,
+        }
+        if disabled_steps
+        else None
+    )
+
     for pipeline_step in pipeline:
+        if killswitch_context is not None and value_matches(
+            "post_process.disable-pipeline-steps",
+            disabled_steps,
+            {"pipeline_step": pipeline_step.__name__, **killswitch_context},
+            emit_metrics=False,
+        ):
+            metrics.incr(
+                "sentry.tasks.post_process.post_process_group.killswitched",
+                tags={
+                    "issue_category": issue_category_metric,
+                    "pipeline": pipeline_step.__name__,
+                },
+            )
+            continue
+
         try:
             with (
                 metrics.timer(
@@ -1315,6 +1349,10 @@ def sdk_crash_monitoring(job: PostProcessJob) -> None:
 def feedback_filter_decorator(
     func: Callable[[PostProcessJob], None],
 ) -> Callable[[PostProcessJob], None]:
+    # wraps() keeps the wrapped step's name, which run_post_process_job uses for
+    # metric tags, span names and the post_process.disable-pipeline-steps
+    # killswitch. Without it every feedback step reports as "wrapper".
+    @functools.wraps(func)
     def wrapper(job: PostProcessJob) -> None:
         if not should_postprocess_feedback(job):
             return

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -14,7 +14,7 @@ from django.db import router
 from django.test import override_settings
 from django.utils import timezone
 
-from sentry import buffer
+from sentry import buffer, killswitches
 from sentry.analytics.events.first_flag_sent import FirstFlagSentEvent
 from sentry.eventstream.types import EventStreamEventType
 from sentry.feedback.lib.utils import FeedbackCreationSource
@@ -54,6 +54,7 @@ from sentry.silo.safety import unguarded_write
 from sentry.tasks import post_process as post_process_module
 from sentry.tasks.merge import merge_groups
 from sentry.tasks.post_process import (
+    GENERIC_POST_PROCESS_PIPELINE,
     GROUP_CATEGORY_POST_PROCESS_PIPELINE,
     HIGHER_ISSUE_OWNERS_PER_PROJECT_PER_MIN_RATELIMIT,
     ISSUE_OWNERS_PER_PROJECT_PER_MIN_RATELIMIT,
@@ -174,6 +175,20 @@ class SiemSecurityLoggingTest(TestCase):
             set_siem_security_log_hook(original)
 
         assert calls == [{}]
+
+
+class PipelineStepNamesTest(TestCase):
+    def test_step_names_are_usable_as_killswitch_keys(self) -> None:
+        # post_process.disable-pipeline-steps addresses steps by function name, and
+        # so do the pipeline metric tags and span names. A decorator that forgets
+        # functools.wraps would silently make its steps unaddressable.
+        for pipeline in [
+            *GROUP_CATEGORY_POST_PROCESS_PIPELINE.values(),
+            GENERIC_POST_PROCESS_PIPELINE,
+        ]:
+            names = [step.__name__ for step in pipeline]
+            assert "wrapper" not in names
+            assert len(names) == len(set(names))
 
 
 class BasePostProcessGroupMixin(BaseTestCase, metaclass=abc.ABCMeta):
@@ -2838,6 +2853,87 @@ class ProcessSimilarityTestMixin(BasePostProcessGroupMixin):
         self.assert_not_called_with(mock_safe_execute)
 
 
+class PipelineKillswitchTestMixin(BasePostProcessGroupMixin):
+    """
+    Exercises post_process.disable-pipeline-steps against process_similarity, which
+    is observable through the safe_execute call it makes.
+    """
+
+    def run_pipeline(self, mock_safe_execute: MagicMock) -> bool:
+        from sentry import similarity
+
+        event = self.create_event(data={}, project_id=self.project.id)
+        self.call_post_process_group(
+            is_new=True,
+            is_regression=False,
+            is_new_group_environment=False,
+            event=event,
+        )
+        return mock.call(similarity.record, mock.ANY, mock.ANY) in mock_safe_execute.mock_calls
+
+    @patch("sentry.tasks.post_process.safe_execute")
+    def test_step_runs_when_killswitch_is_empty(self, mock_safe_execute: MagicMock) -> None:
+        assert self.run_pipeline(mock_safe_execute)
+
+    @patch("sentry.tasks.post_process.safe_execute")
+    @override_options(
+        {"post_process.disable-pipeline-steps": [{"pipeline_step": "process_similarity"}]}
+    )
+    def test_step_is_skipped_by_name(self, mock_safe_execute: MagicMock) -> None:
+        assert not self.run_pipeline(mock_safe_execute)
+
+    @patch("sentry.tasks.post_process.safe_execute")
+    @override_options(
+        {"post_process.disable-pipeline-steps": [{"pipeline_step": "process_commits"}]}
+    )
+    def test_other_steps_are_unaffected(self, mock_safe_execute: MagicMock) -> None:
+        assert self.run_pipeline(mock_safe_execute)
+
+    @patch("sentry.tasks.post_process.safe_execute")
+    def test_step_is_skipped_for_matching_project(self, mock_safe_execute: MagicMock) -> None:
+        with self.options(
+            {
+                "post_process.disable-pipeline-steps": [
+                    {"pipeline_step": "process_similarity", "project_id": self.project.id}
+                ]
+            }
+        ):
+            assert not self.run_pipeline(mock_safe_execute)
+
+    @patch("sentry.tasks.post_process.safe_execute")
+    @override_options(
+        {
+            "post_process.disable-pipeline-steps": [
+                {"pipeline_step": "process_similarity", "project_id": 0}
+            ]
+        }
+    )
+    def test_step_runs_for_other_project(self, mock_safe_execute: MagicMock) -> None:
+        assert self.run_pipeline(mock_safe_execute)
+
+    @patch("sentry.tasks.post_process.safe_execute")
+    def test_step_is_skipped_by_fully_specified_condition(
+        self, mock_safe_execute: MagicMock
+    ) -> None:
+        # What the admin UI writes, as opposed to the partial conditions above.
+        with self.options(
+            {
+                "post_process.disable-pipeline-steps": killswitches.validate_user_input(
+                    "post_process.disable-pipeline-steps",
+                    [
+                        {
+                            "pipeline_step": "process_similarity",
+                            "project_id": self.project.id,
+                            "organization_id": self.organization.id,
+                            "issue_category": "error",
+                        }
+                    ],
+                )
+            }
+        ):
+            assert not self.run_pipeline(mock_safe_execute)
+
+
 class KickOffSeerAutomationTestMixin(BasePostProcessGroupMixin):
     @pytest.mark.xfail(reason="Seer automation was removed from the post-process pipeline")
     @patch("sentry.tasks.seer.autofix.generate_summary_and_run_automation.delay")
@@ -3298,6 +3394,7 @@ class PostProcessGroupErrorTest(
     UserReportEventLinkTestMixin,
     DetectBaseUrlsForUptimeTestMixin,
     ProcessSimilarityTestMixin,
+    PipelineKillswitchTestMixin,
     CheckIfFlagsSentTestMixin,
 ):
     @pytest.mark.xfail(reason="Seer automation was removed from the post-process pipeline")
@@ -3656,6 +3753,39 @@ class PostProcessGroupFeedbackTest(
                 eventstream_type=EventStreamEventType.Error.value,
             )
         return cache_key
+
+    def run_decorated_step(self, killswitch_conditions):
+        # The step is wrapped by feedback_filter_decorator, so this only works if the
+        # decorator preserves the wrapped function's name.
+        calls = []
+
+        def process_snoozes(job):
+            calls.append(job)
+
+        event = self.create_event(data={}, project_id=self.project.id)
+        with (
+            patch(
+                "sentry.tasks.post_process.GROUP_CATEGORY_POST_PROCESS_PIPELINE",
+                {GroupCategory.FEEDBACK: [feedback_filter_decorator(process_snoozes)]},
+            ),
+            self.options({"post_process.disable-pipeline-steps": killswitch_conditions}),
+        ):
+            self.call_post_process_group(
+                is_new=True,
+                is_regression=False,
+                is_new_group_environment=True,
+                event=event,
+                cache_key="total_rubbish",
+            )
+        return calls
+
+    def test_decorated_step_is_skipped_for_matching_issue_category(self) -> None:
+        conditions = [{"pipeline_step": "process_snoozes", "issue_category": "feedback"}]
+        assert self.run_decorated_step(conditions) == []
+
+    def test_decorated_step_runs_for_other_issue_category(self) -> None:
+        conditions = [{"pipeline_step": "process_snoozes", "issue_category": "error"}]
+        assert len(self.run_decorated_step(conditions)) == 1
 
     def test_not_ran_if_crash_report_option_disabled(self) -> None:
         self.project.update_option("sentry:feedback_user_report_notifications", False)


### PR DESCRIPTION
Adds `post_process.disable-pipeline-steps`, a `sentry.killswitches` entry that skips any step of the `post_process_group` pipeline by function name, optionally narrowed to a project, an organization, or an issue category.

Until now, shedding a piece of post-processing meant adding a bespoke boolean option plus a bespoke check to the step in question, and deploying it — `seer.post-process-issue-summary-killswitch.enabled` being the most recent example. That one stays as-is: it guards only the issue-summary branch inside `kick_off_seer_automation`, so the generic switch is not a drop-in replacement for it.

Fields:

| field | |
|---|---|
| `pipeline_step` | Step function name, e.g. `kick_off_seer_automation`. Unset is a wildcard and disables all of post-processing. |
| `project_id` | |
| `organization_id` | |
| `issue_category` | Lowercased `GroupCategory` name, e.g. `error` or `feedback`. |

Usual killswitch semantics: OR across conditions, AND within one, unset field is a wildcard. To turn off Seer automation for one org:

```json
[{"pipeline_step": "kick_off_seer_automation", "organization_id": "1"}]
```

Skipped steps emit `sentry.tasks.post_process.post_process_group.killswitched`, tagged with `pipeline` and `issue_category`.

The option is read once per job rather than once per step — the error pipeline has 25 steps, and `killswitch_matches_context` would redo the `options.get()` and `normalize_value()` on each one. With the option empty (the default) this is a single option read per job.

### Behaviour change worth noting

`feedback_filter_decorator` was missing `functools.wraps`, so all four `GroupCategory.FEEDBACK` steps reported as `wrapper`. That made them unaddressable by name, and also collapsed them into one bucket in the existing pipeline metrics and spans. Adding `wraps` fixes both, but **the `pipeline` metric tag and span name for those four steps change from `wrapper` to `process_snoozes` / `process_inbox_adds` / `process_workflow_engine` / `process_resource_change_bounds`** — anything keyed on `pipeline:wrapper` will need updating.

### Follow-up

Registering the option in `sentry-options-automator` is a separate change; it is not settable in production until then.

ref STREAM-1687
ref INC-2410

