### PR TITLE
fix(search): Keep Ask Seer cross-event filters on a new line

### DIFF
--- a/static/app/components/searchQueryBuilder/askSeerCombobox/queryTokens.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/queryTokens.tsx
@@ -170,13 +170,14 @@ function NewQueryTokens({
     );
   }
 
+  const crossEventTokens: React.ReactNode[] = [];
   crossEvents?.forEach((crossEvent, idx) => {
     const filterQuery = getCrossEventFilterQuery(crossEvent);
     const parsedCrossEvent = filterQuery
       ? parseQueryBuilderValue(filterQuery, getFieldDefinition)
       : null;
 
-    tokens.push(
+    crossEventTokens.push(
       <Stack overflow="hidden" key={`${crossEvent.type}-${idx}`}>
         <ExploreParamTitle>{t('Cross Event Filter:')}</ExploreParamTitle>
         <Flex gap="md" wrap="wrap">
@@ -204,9 +205,18 @@ function NewQueryTokens({
   });
 
   return (
-    <Flex gap="xl" padding="md" wrap="wrap">
-      {tokens}
-    </Flex>
+    <Stack gap="xl" padding="md">
+      {tokens.length > 0 ? (
+        <Flex gap="xl" wrap="wrap">
+          {tokens}
+        </Flex>
+      ) : null}
+      {crossEventTokens.length > 0 ? (
+        <Flex gap="xl" wrap="wrap">
+          {crossEventTokens}
+        </Flex>
+      ) : null}
+    </Stack>
   );
 }
 

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/queryTokens.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/queryTokens.tsx
@@ -45,7 +45,7 @@ function NewQueryTokens({
   expandedProjectIds,
   crossEvents,
 }: QueryTokensProps) {
-  const tokens = [];
+  const tokens: React.ReactNode[] = [];
   const {getFieldDefinition} = useSearchQueryBuilderConfig();
   const {projects} = useProjects();
   // Project is applied to the page-level project selector, so surface it as the


### PR DESCRIPTION
Ask Seer query suggestions now put cross-event filter details on their own row instead of wrapping them inline with the main query tokens. That keeps multi-event results readable when a suggestion includes both a primary query and cross-event filters.

Closes BROWSE-696

Before
<img width="855" height="190" alt="Screenshot 2026-08-06 at 07 19 59" src="https://github.com/user-attachments/assets/c36ba8da-c2f6-453c-89be-f65a541d63d6" />

After
<img width="809" height="253" alt="Screenshot 2026-08-06 at 07 24 47" src="https://github.com/user-attachments/assets/08956ff4-02df-4d9c-9f67-569757c75b6d" />