### PR TITLE
test(conversations): Type conversation detail responses

### DIFF
--- a/static/app/views/explore/conversations/components/conversationView.spec.tsx
+++ b/static/app/views/explore/conversations/components/conversationView.spec.tsx
@@ -3,18 +3,26 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
+import type {
+  ConversationApiResponse,
+  ConversationApiSpan,
+} from 'sentry/views/explore/conversations/hooks/useConversation';
 
 import {ConversationViewContent} from './conversationView';
 
 const CONVERSATION_ID = 'conv-1';
 
-function spanFixture(overrides: Record<string, unknown>) {
+function spanFixture(overrides: Partial<ConversationApiSpan> = {}): ConversationApiSpan {
   return {
     'gen_ai.conversation.id': CONVERSATION_ID,
     parent_span: 'parent-1',
+    'precise.finish_ts': 1000.5,
+    'precise.start_ts': 1000,
     project: 'test-project',
     'project.id': 1,
+    'span.name': 'gen_ai.generate',
     'span.status': 'ok',
+    span_id: 'span-id',
     trace: 'trace-1',
     'gen_ai.operation.type': 'ai_client',
     ...overrides,
@@ -44,7 +52,11 @@ const CONVERSATION_BODY = [
 function mockConversation() {
   MockApiClient.addMockResponse({
     url: `/organizations/org-slug/ai-conversations/${CONVERSATION_ID}/`,
-    body: {conversationId: CONVERSATION_ID, title: null, spans: CONVERSATION_BODY},
+    body: {
+      conversationId: CONVERSATION_ID,
+      title: null,
+      spans: CONVERSATION_BODY,
+    } satisfies ConversationApiResponse,
   });
   // The detail pane fetches full attributes per span; keep it empty.
   MockApiClient.addMockResponse({

--- a/static/app/views/explore/conversations/conversationDetail.spec.tsx
+++ b/static/app/views/explore/conversations/conversationDetail.spec.tsx
@@ -12,17 +12,22 @@ import {
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {TopBar} from 'sentry/views/navigation/topBar';
 
+import type {ConversationApiResponse, ConversationApiSpan} from './hooks/useConversation';
 import ConversationDetailPage from './conversationDetail';
 
 const CONVERSATION_ID = 'conv-1';
 
-function spanFixture(overrides: Record<string, unknown>) {
+function spanFixture(overrides: Partial<ConversationApiSpan> = {}): ConversationApiSpan {
   return {
     'gen_ai.conversation.id': CONVERSATION_ID,
     parent_span: 'parent-1',
+    'precise.finish_ts': 1000.5,
+    'precise.start_ts': 1000,
     project: 'test-project',
     'project.id': 1,
+    'span.name': 'gen_ai.generate',
     'span.status': 'ok',
+    span_id: 'span-id',
     trace: 'trace-1',
     'gen_ai.operation.type': 'ai_client',
     ...overrides,
@@ -50,11 +55,15 @@ const CONVERSATION_BODY = [
 
 function mockApis(
   title: string | null = null,
-  spans: Array<Record<string, unknown>> = CONVERSATION_BODY
+  spans: ConversationApiSpan[] = CONVERSATION_BODY
 ) {
   MockApiClient.addMockResponse({
     url: `/organizations/org-slug/ai-conversations/${CONVERSATION_ID}/`,
-    body: {conversationId: CONVERSATION_ID, title, spans},
+    body: {
+      conversationId: CONVERSATION_ID,
+      title,
+      spans,
+    } satisfies ConversationApiResponse,
   });
   MockApiClient.addMockResponse({
     url: '/organizations/org-slug/trace-items/attributes/',

--- a/static/app/views/explore/conversations/hooks/useConversation.spec.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversation.spec.tsx
@@ -5,9 +5,10 @@ import {act, renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLib
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {SpanFields} from 'sentry/views/insights/types';
 
+import type {ConversationApiResponse, ConversationApiSpan} from './useConversation';
 import {useConversation} from './useConversation';
 
-const BASE_SPAN = {
+const BASE_SPAN: ConversationApiSpan = {
   'gen_ai.conversation.id': 'conv-123',
   parent_span: 'parent-1',
   'precise.finish_ts': 1000.5,
@@ -21,12 +22,12 @@ const BASE_SPAN = {
   'gen_ai.operation.type': 'ai_client',
 };
 
-function envelope(
-  spans: Array<Record<string, unknown>>,
+function conversationResponse(
+  spans: ConversationApiSpan[],
   title: string | null = null
-): Record<string, unknown> {
+): ConversationApiResponse {
   return {
-    conversationId: (spans[0]?.['gen_ai.conversation.id'] as string) ?? '',
+    conversationId: spans[0]?.['gen_ai.conversation.id'] ?? '',
     title,
     spans,
   };
@@ -57,7 +58,7 @@ describe('useConversation', () => {
   it('returns the conversation title from the envelope', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/ai-conversations/conv-title/`,
-      body: envelope(
+      body: conversationResponse(
         [{...BASE_SPAN, 'gen_ai.conversation.id': 'conv-title', span_id: 'span-title'}],
         'My great conversation'
       ),
@@ -76,7 +77,7 @@ describe('useConversation', () => {
   it('returns a null title when the envelope has none', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/ai-conversations/conv-123/`,
-      body: envelope([BASE_SPAN]),
+      body: conversationResponse([BASE_SPAN]),
     });
 
     const {result} = renderHookWithProviders(
@@ -94,7 +95,7 @@ describe('useConversation', () => {
 
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/ai-conversations/conv-123/`,
-      body: envelope([
+      body: conversationResponse([
         {
           'gen_ai.conversation.id': 'conv-123',
           parent_span: 'parent-1',
@@ -138,7 +139,7 @@ describe('useConversation', () => {
 
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/ai-conversations/conv-output/`,
-      body: envelope([
+      body: conversationResponse([
         {
           'gen_ai.conversation.id': 'conv-output',
           parent_span: 'parent-1',
@@ -179,7 +180,7 @@ describe('useConversation', () => {
 
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/ai-conversations/conv-456/`,
-      body: envelope([
+      body: conversationResponse([
         {
           'gen_ai.conversation.id': 'conv-456',
           parent_span: 'parent-1',
@@ -216,7 +217,7 @@ describe('useConversation', () => {
   it('uses empty string for missing optional fields', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/ai-conversations/conv-789/`,
-      body: envelope([
+      body: conversationResponse([
         {
           'gen_ai.conversation.id': 'conv-789',
           parent_span: 'parent-1',
@@ -255,7 +256,7 @@ describe('useConversation', () => {
   it('uses conversation timestamps when provided', async () => {
     const mockRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/ai-conversations/conv-timestamps/`,
-      body: envelope([
+      body: conversationResponse([
         {
           'gen_ai.conversation.id': 'conv-timestamps',
           parent_span: 'parent-1',
@@ -310,7 +311,7 @@ describe('useConversation', () => {
   it('uses span.name for description and name fields', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/ai-conversations/conv-name/`,
-      body: envelope([
+      body: conversationResponse([
         {
           'gen_ai.conversation.id': 'conv-name',
           parent_span: 'parent-1',
@@ -346,7 +347,7 @@ describe('useConversation', () => {
   it('sorts nodes by start timestamp for AI spans list', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/ai-conversations/conv-sort/`,
-      body: envelope([
+      body: conversationResponse([
         {
           'gen_ai.conversation.id': 'conv-sort',
           parent_span: 'parent-1',
@@ -396,7 +397,7 @@ describe('useConversation', () => {
 
     const mockRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/ai-conversations/conv-123/`,
-      body: envelope([BASE_SPAN]),
+      body: conversationResponse([BASE_SPAN]),
     });
 
     const {result} = renderHookWithProviders(
@@ -426,7 +427,7 @@ describe('useConversation', () => {
 
     const mockRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/ai-conversations/conv-123/`,
-      body: envelope([BASE_SPAN]),
+      body: conversationResponse([BASE_SPAN]),
     });
 
     const {result} = renderHookWithProviders(
@@ -453,7 +454,7 @@ describe('useConversation', () => {
   it('falls back to ALL_ACCESS_PROJECTS with no time params when no filters are set', async () => {
     const mockRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/ai-conversations/conv-123/`,
-      body: envelope([BASE_SPAN]),
+      body: conversationResponse([BASE_SPAN]),
     });
 
     const {result} = renderHookWithProviders(
@@ -490,7 +491,7 @@ describe('useConversation', () => {
 
     const mockRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/ai-conversations/conv-123/`,
-      body: envelope([BASE_SPAN]),
+      body: conversationResponse([BASE_SPAN]),
     });
 
     const {result} = renderHookWithProviders(
@@ -516,7 +517,7 @@ describe('useConversation', () => {
   it('filters to only gen_ai spans', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/ai-conversations/conv-filter/`,
-      body: envelope([
+      body: conversationResponse([
         {
           'gen_ai.conversation.id': 'conv-filter',
           parent_span: 'parent-1',
@@ -563,7 +564,7 @@ describe('useConversation', () => {
   it('maps errors and occurrences from the response onto the node', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/ai-conversations/conv-issues/`,
-      body: envelope([
+      body: conversationResponse([
         {
           ...BASE_SPAN,
           'gen_ai.conversation.id': 'conv-issues',
@@ -617,7 +618,7 @@ describe('useConversation', () => {
   it('defaults to no issues when the response omits errors and occurrences', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/ai-conversations/conv-no-issues/`,
-      body: envelope([
+      body: conversationResponse([
         {...BASE_SPAN, 'gen_ai.conversation.id': 'conv-no-issues', span_id: 'span-x'},
       ]),
     });

--- a/static/app/views/explore/conversations/hooks/useConversation.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversation.tsx
@@ -25,7 +25,7 @@ export interface UseConversationsOptions {
 /**
  * Raw span data returned from the AI conversation details endpoint
  */
-interface ConversationApiSpan {
+export interface ConversationApiSpan {
   'gen_ai.conversation.id': string;
   parent_span: string;
   'precise.finish_ts': number;
@@ -62,7 +62,7 @@ interface ConversationApiSpan {
   'user.username'?: string;
 }
 
-interface ConversationApiResponse {
+export interface ConversationApiResponse {
   conversationId: string;
   spans: ConversationApiSpan[];
   title: string | null;


### PR DESCRIPTION
Conversation-detail frontend tests now construct typed API responses from the hook's response contract. This makes response-shape drift fail during typechecking while preserving each test's focused span data.