### PR TITLE
ci: Show flake8-sentry violations in the terminal

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,6 @@ repos:
         entry: uv run flake8 --select=S
         language: system
         types: [python]
-        log_file: '.artifacts/flake8.pycodestyle.log'
         require_serial: true
       - id: mypy
         name: mypy


### PR DESCRIPTION
The `flake8-sentry` hook redirected stdout/stderr to `.artifacts/flake8.pycodestyle.log`, so S* rule failures exited non-zero without printing findings in the terminal. Removing `log_file` restores the usual pre-commit failure output. Nothing else consumed that artifact path.

Made with [Cursor](https://cursor.com)