### PR TITLE
ref(conversations): Consolidate preview normalization

### DIFF
--- a/static/app/views/explore/conversations/hooks/useConversations.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversations.tsx
@@ -54,6 +54,14 @@ interface ConversationApiResponse extends Omit<
 
 const CONVERSATION_LIST_PER_PAGE = 50;
 
+function normalizeConversationPreview(
+  content: ConversationApiResponse['firstInput']
+): string | null {
+  return typeof content === 'string'
+    ? content
+    : (content?.find(part => part.type === 'text')?.text ?? null);
+}
+
 export function useConversations() {
   const organization = useOrganization();
   const {cursor, setCursor} = useTableCursor();
@@ -94,14 +102,8 @@ export function useConversations() {
           lastOutput: rawLastOutput,
           ...rest
         }): Conversation => {
-          const firstInput =
-            typeof rawFirstInput === 'string'
-              ? rawFirstInput
-              : (rawFirstInput?.find(content => content.type === 'text')?.text ?? null);
-          const lastOutput =
-            typeof rawLastOutput === 'string'
-              ? rawLastOutput
-              : (rawLastOutput?.find(content => content.type === 'text')?.text ?? null);
+          const firstInput = normalizeConversationPreview(rawFirstInput);
+          const lastOutput = normalizeConversationPreview(rawLastOutput);
           return {...rest, firstInput, lastOutput};
         }
       )


### PR DESCRIPTION
Conversation list previews now normalize `firstInput` and `lastOutput` through the same typed path. Strings and the first text part of rich content continue to render exactly as before, preventing the two columns' fallback behavior from drifting.

Some more context - I am testing a simple skill we could use in coding agents to find these small refactors and QoL improvements for us automatically 