### PR TITLE
fix(ask-seer): Use grammar-neutral Ask Seer fallback labels

### DIFF
--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerStepUtils.spec.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerStepUtils.spec.ts
@@ -1,0 +1,25 @@
+import {formatStep} from './askSeerStepUtils';
+
+describe('formatStep', () => {
+  it.each([
+    ['get_field_values', 'Investigating your tags...', 'Investigated tags'],
+    ['get_metric_candidates', 'Finding matching metrics...', 'Found matching metrics'],
+    ['execute_query', 'Fine-tuning your query...', 'Fine-tuned query'],
+    ['finalize_queries', 'Double-checking everything...', 'All done!'],
+    ['mark_unsupported', 'Working through this...', 'This query is not supported'],
+  ])('uses explicit labels for %s', (key, loadingLabel, completedLabel) => {
+    expect(formatStep({key}, true, 0)).toBe(loadingLabel);
+    expect(formatStep({key}, false, 0)).toBe(completedLabel);
+  });
+
+  it.each([
+    ['be_ready', 'Be ready'],
+    ['die_safely', 'Die safely'],
+    ['fix_query', 'Fix query'],
+    ['open_trace', 'Open trace'],
+    ['play_back', 'Play back'],
+  ])('uses grammar-neutral fallback labels for unknown step %s', (key, label) => {
+    expect(formatStep({key}, true, 0)).toBe(`Running step: ${label}...`);
+    expect(formatStep({key}, false, 0)).toBe(`Finished step: ${label}`);
+  });
+});

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerStepUtils.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerStepUtils.ts
@@ -112,38 +112,21 @@ const STEP_LABELS: Record<string, StepLabel[]> = {
 };
 
 /**
- * Convert a step key to a grammatically correct phrase.
- * e.g., "get_field_values" -> "Getting field values"
- *       "search_spans" -> "Searching spans"
+ * Format unknown step keys without trying to conjugate arbitrary English verbs.
  */
 function formatStepKey(key: string, isLoading: boolean): string {
-  const words = key.split('_');
-  const verb = words[0];
-  if (!verb) {
+  const humanizedKey = key.split('_').join(' ');
+  if (!humanizedKey) {
     return key;
   }
 
-  const rest = words.slice(1).join(' ');
+  const capitalizedKey = humanizedKey.charAt(0).toUpperCase() + humanizedKey.slice(1);
 
   if (isLoading) {
-    // Convert verb to -ing form
-    let ingVerb = verb;
-    if (verb.endsWith('e') && !verb.endsWith('ee')) {
-      ingVerb = verb.slice(0, -1) + 'ing';
-    } else if (verb.match(/[aeiou][^aeiou]$/)) {
-      // Double consonant for short vowel + consonant (e.g., run -> running)
-      ingVerb = verb + verb.slice(-1) + 'ing';
-    } else {
-      ingVerb = verb + 'ing';
-    }
-    // Capitalize first letter
-    ingVerb = ingVerb.charAt(0).toUpperCase() + ingVerb.slice(1);
-    return rest ? `${ingVerb} ${rest}...` : `${ingVerb}...`;
+    return t('Running step: %s...', capitalizedKey);
   }
 
-  // For completed state, capitalize first letter
-  const capitalized = verb.charAt(0).toUpperCase() + verb.slice(1);
-  return rest ? `${capitalized} ${rest}` : capitalized;
+  return t('Finished step: %s', capitalizedKey);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Replace heuristic English -ing conjugation for unknown Ask Seer steps with grammar-neutral fallback copy
- Keep explicit product labels for every currently emitted Seer step
- Make the unknown-step fallback translatable

Closes BROWSE-625