### PR TITLE
fix(trace): Buffer compressed gaps around errors

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/utils.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/utils.spec.tsx
@@ -1,0 +1,17 @@
+import type {BaseNode} from './baseNode';
+import {isZeroDurationNode} from './utils';
+
+function nodeWithSpace(space: [number, number]) {
+  return {space} as BaseNode;
+}
+
+describe('isZeroDurationNode', () => {
+  it('identifies nodes with zero duration', () => {
+    expect(isZeroDurationNode(nodeWithSpace([100, 0]))).toBe(true);
+  });
+
+  it('does not identify positive or negative durations as zero duration', () => {
+    expect(isZeroDurationNode(nodeWithSpace([100, 1]))).toBe(false);
+    expect(isZeroDurationNode(nodeWithSpace([100, -1]))).toBe(false);
+  });
+});

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/utils.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/utils.tsx
@@ -1,5 +1,9 @@
 import type {BaseNode} from './baseNode';
 
+export function isZeroDurationNode(node: BaseNode): boolean {
+  return node.space[1] === 0;
+}
+
 export function traceChronologicalSort(a: BaseNode, b: BaseNode) {
   return a.space[0] - b.space[0];
 }

--- a/static/app/views/performance/newTraceDetails/traceRenderers/traceTimeCompression.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/traceTimeCompression.spec.tsx
@@ -1,4 +1,4 @@
-import {TraceTimeCompression} from './traceTimeCompression';
+import {COLLAPSED_GAP_WIDTH_PX, TraceTimeCompression} from './traceTimeCompression';
 
 function node(type: string, space: [number, number]) {
   return {type, space} as any;
@@ -57,18 +57,28 @@ describe('TraceTimeCompression', () => {
     expect(compression.gaps).toHaveLength(0);
   });
 
-  it('keeps marker padding around zero-duration activity', () => {
+  it('keeps a pixel-derived buffer around zero-duration errors', () => {
+    const physicalWidth = 600;
     const compression = TraceTimeCompression.FromVisibleItems({
       enabled: true,
-      traceSpace: [0, 10_000],
-      physicalWidth: 1000,
-      nodes: [node('error', [5000, 0])],
+      traceSpace: [0, 3_600_000],
+      physicalWidth,
+      nodes: [
+        node('span', [0, 600_000]),
+        node('error', [2_100_000, 0]),
+        node('span', [3_000_000, 600_000]),
+      ],
       indicators: [],
     });
 
     expect(compression.gaps).toHaveLength(2);
-    expect(compression.gaps[0]).toMatchObject({start: 0, end: 4900});
-    expect(compression.gaps[1]).toMatchObject({start: 5100, end: 10_000});
+    const [beforeError, afterError] = compression.gaps;
+    const errorBufferPx =
+      ((afterError!.compressedStart - beforeError!.compressedEnd) /
+        compression.compressedDuration) *
+      physicalWidth;
+
+    expect(errorBufferPx).toBeGreaterThanOrEqual(COLLAPSED_GAP_WIDTH_PX * 2);
   });
 
   it('round trips between real and compressed coordinates', () => {

--- a/static/app/views/performance/newTraceDetails/traceRenderers/traceTimeCompression.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/traceTimeCompression.tsx
@@ -182,6 +182,10 @@ function collectVisibleIntervals(options: TraceTimeCompressionOptions): Interval
     options.physicalWidth > 0
       ? (traceDuration / options.physicalWidth) * DURATION_LABEL_BUFFER_PX
       : 0;
+  const zeroDurationErrorBuffer =
+    options.physicalWidth > 0
+      ? (traceDuration / options.physicalWidth) * COLLAPSED_GAP_WIDTH_PX
+      : 0;
   const intervals: Interval[] = [];
 
   for (const node of options.nodes) {
@@ -198,9 +202,11 @@ function collectVisibleIntervals(options: TraceTimeCompressionOptions): Interval
         clampTimestamp(end + durationLabelBuffer, traceStart, traceEnd),
       ]);
     } else {
+      const zeroDurationNodeBuffer =
+        node.type === 'error' ? zeroDurationErrorBuffer : markerPadding;
       intervals.push([
-        clampTimestamp(start - markerPadding, traceStart, traceEnd),
-        clampTimestamp(start + markerPadding, traceStart, traceEnd),
+        clampTimestamp(start - zeroDurationNodeBuffer, traceStart, traceEnd),
+        clampTimestamp(start + zeroDurationNodeBuffer, traceStart, traceEnd),
       ]);
     }
   }

--- a/static/app/views/performance/newTraceDetails/traceRenderers/traceTimeCompression.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/traceTimeCompression.tsx
@@ -1,5 +1,6 @@
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import type {BaseNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode';
+import {isZeroDurationNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/utils';
 
 const COLLAPSE_THRESHOLD_RATIO = 0.05;
 export const COLLAPSED_GAP_WIDTH_PX = 28;
@@ -182,7 +183,7 @@ function collectVisibleIntervals(options: TraceTimeCompressionOptions): Interval
     options.physicalWidth > 0
       ? (traceDuration / options.physicalWidth) * DURATION_LABEL_BUFFER_PX
       : 0;
-  const zeroDurationErrorBuffer =
+  const zeroDurationBuffer =
     options.physicalWidth > 0
       ? (traceDuration / options.physicalWidth) * COLLAPSED_GAP_WIDTH_PX
       : 0;
@@ -202,11 +203,10 @@ function collectVisibleIntervals(options: TraceTimeCompressionOptions): Interval
         clampTimestamp(end + durationLabelBuffer, traceStart, traceEnd),
       ]);
     } else {
-      const zeroDurationNodeBuffer =
-        node.type === 'error' ? zeroDurationErrorBuffer : markerPadding;
+      const nodeBuffer = isZeroDurationNode(node) ? zeroDurationBuffer : markerPadding;
       intervals.push([
-        clampTimestamp(start - zeroDurationNodeBuffer, traceStart, traceEnd),
-        clampTimestamp(start + zeroDurationNodeBuffer, traceStart, traceEnd),
+        clampTimestamp(start - nodeBuffer, traceStart, traceEnd),
+        clampTimestamp(start + nodeBuffer, traceStart, traceEnd),
       ]);
     }
   }

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
@@ -430,11 +430,11 @@ describe('VirtualizedViewManger', () => {
       );
 
       manager.view.setTraceSpace([0, 0, 1000, 1]);
-      manager.view.setTracePhysicalSpace([0, 0, 20, 1], [0, 0, 20, 1]);
+      manager.view.setTracePhysicalSpace([0, 0, 100, 1], [0, 0, 100, 1]);
       manager.time_compression = TraceTimeCompression.FromVisibleItems({
         enabled: true,
         traceSpace: [0, 1000],
-        physicalWidth: 20,
+        physicalWidth: 100,
         nodes: [
           {type: 'span', space: [100, 0]},
           {type: 'span', space: [900, 0]},


### PR DESCRIPTION
## Summary

- Reserve a pixel-derived buffer around zero-duration error nodes before selecting compressible gaps
- Prevent adjacent compressed regions from overlapping around errors in long traces
- Add regression coverage modeling a one-hour trace at constrained waterfall width

Closes EXP-1091

Before
<img width="287" height="185" alt="Screenshot 2026-08-06 at 09 09 11" src="https://github.com/user-attachments/assets/e9677af1-ebaf-4496-8099-4d6e73008967" />

After
<img width="373" height="198" alt="Screenshot 2026-08-06 at 09 09 42" src="https://github.com/user-attachments/assets/6c9dfe09-fc80-455c-bfec-ade90eb6f721" />