### PR TITLE
ref: update typescript-eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -282,7 +282,7 @@
     "tinyglobby": "0.2.16",
     "typescript": "npm:@typescript/typescript6@6.0.2",
     "typescript-7": "npm:typescript@^7.0.2",
-    "typescript-eslint": "8.58.0"
+    "typescript-eslint": "8.66.0"
   },
   "optionalDependencies": {
     "fsevents": "^2.3.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -711,8 +711,8 @@ importers:
         specifier: npm:typescript@^7.0.2
         version: typescript@7.0.2
       typescript-eslint:
-        specifier: 8.58.0
-        version: 8.58.0(@typescript/typescript6@6.0.2)(eslint@10.8.0(jiti@2.7.0))
+        specifier: 8.66.0
+        version: 8.66.0(@typescript/typescript6@6.0.2)(eslint@10.8.0(jiti@2.7.0))
     optionalDependencies:
       fsevents:
         specifier: ^2.3.3
@@ -3888,14 +3888,6 @@ packages:
   '@types/yargs@17.0.33':
     resolution: {integrity: sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==}
 
-  '@typescript-eslint/eslint-plugin@8.58.0':
-    resolution: {integrity: sha512-RLkVSiNuUP1C2ROIWfqX+YcUfLaSnxGE/8M+Y57lopVwg9VTYYfhuz15Yf1IzCKgZj6/rIbYTmJCUSqr76r0Wg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^8.58.0
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
-
   '@typescript-eslint/eslint-plugin@8.66.0':
     resolution: {integrity: sha512-p088eaGrzYz1s+7cov0aMOCkNGTJlVxF4jgubf28c8L0Cv9Rloj8YBHnv4hXLq6IIEE1AsjNWavO+k+8kP2Y0A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -3964,13 +3956,6 @@ packages:
     resolution: {integrity: sha512-9D5gLYZG4rOjcoag8MQ/fWI8WqA9wcPDyOGyWtWFhvM1lHRbliqUSPIY5J3zqCU1tvSwzXxnnjhQhz5Ne7mJ4g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/type-utils@8.58.0':
-    resolution: {integrity: sha512-aGsCQImkDIqMyx1u4PrVlbi/krmDsQUs4zAcCV6M7yPcPev+RqVlndsJy9kJ8TLihW9TZ0kbDAzctpLn5o+lOg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
   '@typescript-eslint/type-utils@8.66.0':
@@ -4668,6 +4653,10 @@ packages:
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
+
+  ci-info@4.2.0:
+    resolution: {integrity: sha512-cYY9mypksY8NRqgDB1XD1RiJL338v/551niynFTGkZOO2LHuB2OmOYxDIe/ttN9AHwrqdum1360G3ald0W9kCg==}
+    engines: {node: '>=8'}
 
   ci-info@4.4.0:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
@@ -5962,8 +5951,8 @@ packages:
     resolution: {integrity: sha512-bqWEnJ1Nt3neqx2q5SFfGS8r/ahumIakg3HcwtNlrVlwXIeNumWn/c7Pn/wKzGhf6SaW6H6uWXLqC30STCMchQ==}
     engines: {node: '>=18'}
 
-  globals@17.9.0:
-    resolution: {integrity: sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==}
+  globals@17.5.0:
+    resolution: {integrity: sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==}
     engines: {node: '>=18'}
 
   globalthis@1.0.4:
@@ -7993,8 +7982,8 @@ packages:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
 
-  regjsparser@0.13.2:
-    resolution: {integrity: sha512-NgRBy2Nx/bE+9F27nVHnqcN5HjyLmecqsqx2PJHu3/IEtADD4WuxuXIVExD5PoSDFVrl78dOonfcOe5O+5nbzQ==}
+  regjsparser@0.13.1:
+    resolution: {integrity: sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==}
     hasBin: true
 
   rehype-expressive-code@0.41.2:
@@ -8067,6 +8056,11 @@ packages:
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  resolve@1.22.10:
+    resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
 
   resolve@1.22.11:
     resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
@@ -8723,8 +8717,8 @@ packages:
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
-  typescript-eslint@8.58.0:
-    resolution: {integrity: sha512-e2TQzKfaI85fO+F3QywtX+tCTsu/D3WW5LVU6nz8hTFKFZ8yBJ6mSYRpXqdR3mFjPWmO0eWsTa5f+UpAOe/FMA==}
+  typescript-eslint@8.66.0:
+    resolution: {integrity: sha512-QlEbBPz/RuJ1XUHj29nm3t0F/O/cSlEnntozqPOYHnnTGAXFamnMBu5i9Vn6vhUPHGAjR+Vl+5J8vPN/BMUrJw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -12406,22 +12400,6 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 15.0.0
 
-  '@typescript-eslint/eslint-plugin@8.58.0(@typescript-eslint/parser@8.58.0(@typescript/typescript6@6.0.2)(eslint@10.8.0(jiti@2.7.0)))(@typescript/typescript6@6.0.2)(eslint@10.8.0(jiti@2.7.0))':
-    dependencies:
-      '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.58.0(@typescript/typescript6@6.0.2)(eslint@10.8.0(jiti@2.7.0))
-      '@typescript-eslint/scope-manager': 8.58.0
-      '@typescript-eslint/type-utils': 8.58.0(@typescript/typescript6@6.0.2)(eslint@10.8.0(jiti@2.7.0))
-      '@typescript-eslint/utils': 8.58.0(@typescript/typescript6@6.0.2)(eslint@10.8.0(jiti@2.7.0))
-      '@typescript-eslint/visitor-keys': 8.58.0
-      eslint: 10.8.0(jiti@2.7.0)
-      ignore: 7.0.5
-      natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(@typescript/typescript6@6.0.2)
-      typescript: '@typescript/typescript6@6.0.2'
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/eslint-plugin@8.66.0(@typescript-eslint/parser@8.66.0(@typescript/typescript6@6.0.2)(eslint@10.8.0(jiti@2.7.0)))(@typescript/typescript6@6.0.2)(eslint@10.8.0(jiti@2.7.0))':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -12437,7 +12415,6 @@ snapshots:
       typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   '@typescript-eslint/experimental-utils@5.62.0(@typescript/typescript6@6.0.2)(eslint@10.8.0(jiti@2.7.0))':
     dependencies:
@@ -12526,18 +12503,6 @@ snapshots:
     dependencies:
       typescript: '@typescript/typescript6@6.0.2'
 
-  '@typescript-eslint/type-utils@8.58.0(@typescript/typescript6@6.0.2)(eslint@10.8.0(jiti@2.7.0))':
-    dependencies:
-      '@typescript-eslint/types': 8.58.0
-      '@typescript-eslint/typescript-estree': 8.58.0(@typescript/typescript6@6.0.2)
-      '@typescript-eslint/utils': 8.58.0(@typescript/typescript6@6.0.2)(eslint@10.8.0(jiti@2.7.0))
-      debug: 4.4.3
-      eslint: 10.8.0(jiti@2.7.0)
-      ts-api-utils: 2.5.0(@typescript/typescript6@6.0.2)
-      typescript: '@typescript/typescript6@6.0.2'
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/type-utils@8.66.0(@typescript/typescript6@6.0.2)(eslint@10.8.0(jiti@2.7.0))':
     dependencies:
       '@typescript-eslint/types': 8.66.0
@@ -12549,7 +12514,6 @@ snapshots:
       typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   '@typescript-eslint/types@5.62.0': {}
 
@@ -13033,9 +12997,9 @@ snapshots:
 
   babel-plugin-macros@3.1.0:
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.27.6
       cosmiconfig: 7.0.1
-      resolve: 1.22.11
+      resolve: 1.22.10
 
   babel-preset-current-node-syntax@1.2.0(@babel/core@7.29.0):
     dependencies:
@@ -13227,6 +13191,8 @@ snapshots:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.3
+
+  ci-info@4.2.0: {}
 
   ci-info@4.4.0: {}
 
@@ -13818,7 +13784,7 @@ snapshots:
       has-property-descriptors: 1.0.2
       has-proto: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.4
+      hasown: 2.0.2
       internal-slot: 1.1.0
       is-array-buffer: 3.0.5
       is-callable: 1.2.7
@@ -13869,7 +13835,7 @@ snapshots:
       has-property-descriptors: 1.0.2
       has-proto: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.4
+      hasown: 2.0.2
       internal-slot: 1.1.0
       is-array-buffer: 3.0.5
       is-callable: 1.2.7
@@ -13939,22 +13905,22 @@ snapshots:
     dependencies:
       get-intrinsic: 1.2.6
       has-tostringtag: 1.0.2
-      hasown: 2.0.4
+      hasown: 2.0.2
 
   es-set-tostringtag@2.1.0:
     dependencies:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.4
+      hasown: 2.0.2
 
   es-shim-unscopables@1.0.2:
     dependencies:
-      hasown: 2.0.4
+      hasown: 2.0.2
 
   es-shim-unscopables@1.1.0:
     dependencies:
-      hasown: 2.0.4
+      hasown: 2.0.2
 
   es-to-primitive@1.3.0:
     dependencies:
@@ -14270,13 +14236,13 @@ snapshots:
       core-js-compat: 3.49.0
       eslint: 10.8.0(jiti@2.7.0)
       find-up-simple: 1.0.1
-      globals: 17.9.0
+      globals: 17.5.0
       indent-string: 5.0.0
       is-builtin-module: 5.0.0
       jsesc: 3.1.0
       pluralize: 8.0.0
       regexp-tree: 0.1.27
-      regjsparser: 0.13.2
+      regjsparser: 0.13.1
       semver: 7.8.5
       strip-indent: 4.1.1
 
@@ -14648,7 +14614,7 @@ snapshots:
       call-bound: 1.0.4
       define-properties: 1.2.1
       functions-have-names: 1.2.3
-      hasown: 2.0.4
+      hasown: 2.0.2
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
@@ -14669,7 +14635,7 @@ snapshots:
       function-bind: 1.1.2
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.4
+      hasown: 2.0.2
       math-intrinsics: 1.1.0
 
   get-intrinsic@1.3.0:
@@ -14682,7 +14648,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.4
+      hasown: 2.0.2
       math-intrinsics: 1.1.0
 
   get-package-type@0.1.0: {}
@@ -14784,7 +14750,7 @@ snapshots:
 
   globals@16.3.0: {}
 
-  globals@17.9.0: {}
+  globals@17.5.0: {}
 
   globalthis@1.0.4:
     dependencies:
@@ -15137,7 +15103,7 @@ snapshots:
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
-      hasown: 2.0.4
+      hasown: 2.0.2
       side-channel: 1.1.0
 
   intl-messageformat@10.7.16:
@@ -15195,7 +15161,7 @@ snapshots:
 
   is-core-module@2.16.1:
     dependencies:
-      hasown: 2.0.4
+      hasown: 2.0.2
 
   is-data-view@1.0.2:
     dependencies:
@@ -15258,7 +15224,7 @@ snapshots:
       call-bound: 1.0.3
       gopd: 1.2.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.4
+      hasown: 2.0.2
 
   is-set@2.0.3: {}
 
@@ -15692,7 +15658,7 @@ snapshots:
       '@jest/types': 30.0.0
       '@types/node': 24.13.2
       chalk: 4.1.2
-      ci-info: 4.4.0
+      ci-info: 4.2.0
       graceful-fs: 4.2.11
       picomatch: 4.0.5
 
@@ -17564,7 +17530,7 @@ snapshots:
       gopd: 1.2.0
       set-function-name: 2.0.2
 
-  regjsparser@0.13.2:
+  regjsparser@0.13.1:
     dependencies:
       jsesc: 3.1.0
 
@@ -17675,6 +17641,12 @@ snapshots:
   resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
+
+  resolve@1.22.10:
+    dependencies:
+      is-core-module: 2.16.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
 
   resolve@1.22.11:
     dependencies:
@@ -18428,12 +18400,12 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typescript-eslint@8.58.0(@typescript/typescript6@6.0.2)(eslint@10.8.0(jiti@2.7.0)):
+  typescript-eslint@8.66.0(@typescript/typescript6@6.0.2)(eslint@10.8.0(jiti@2.7.0)):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.58.0(@typescript-eslint/parser@8.58.0(@typescript/typescript6@6.0.2)(eslint@10.8.0(jiti@2.7.0)))(@typescript/typescript6@6.0.2)(eslint@10.8.0(jiti@2.7.0))
-      '@typescript-eslint/parser': 8.58.0(@typescript/typescript6@6.0.2)(eslint@10.8.0(jiti@2.7.0))
-      '@typescript-eslint/typescript-estree': 8.58.0(@typescript/typescript6@6.0.2)
-      '@typescript-eslint/utils': 8.58.0(@typescript/typescript6@6.0.2)(eslint@10.8.0(jiti@2.7.0))
+      '@typescript-eslint/eslint-plugin': 8.66.0(@typescript-eslint/parser@8.66.0(@typescript/typescript6@6.0.2)(eslint@10.8.0(jiti@2.7.0)))(@typescript/typescript6@6.0.2)(eslint@10.8.0(jiti@2.7.0))
+      '@typescript-eslint/parser': 8.66.0(@typescript/typescript6@6.0.2)(eslint@10.8.0(jiti@2.7.0))
+      '@typescript-eslint/typescript-estree': 8.66.0(@typescript/typescript6@6.0.2)
+      '@typescript-eslint/utils': 8.66.0(@typescript/typescript6@6.0.2)(eslint@10.8.0(jiti@2.7.0))
       eslint: 10.8.0(jiti@2.7.0)
       typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:

--- a/static/app/components/charts/components/tooltip.tsx
+++ b/static/app/components/charts/components/tooltip.tsx
@@ -389,6 +389,7 @@ export function computeChartTooltip(
      */
     position(pos, _params, dom, _rec, size) {
       // Types seem to be broken on dom
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
       dom = dom as HTMLDivElement;
       // Center the tooltip slightly above the cursor.
       const [tipWidth, tipHeight] = size.contentSize;

--- a/static/app/components/charts/useChartXRangeSelection.spec.tsx
+++ b/static/app/components/charts/useChartXRangeSelection.spec.tsx
@@ -579,6 +579,7 @@ describe('useChartXRangeSelection', () => {
           }),
         {
           initialProps: {
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
             selection: initialSelection as typeof initialSelection | undefined,
           },
         }

--- a/static/app/components/checkInTimeline/utils/mergeStats.tsx
+++ b/static/app/components/checkInTimeline/utils/mergeStats.tsx
@@ -9,8 +9,6 @@ export function mergeStats<Status extends string>(
 ): StatsBucket<Status> {
   const combinedStats = {} as StatsBucket<Status>;
   for (const status of statusPrecedent) {
-    // Will be fixed by https://github.com/typescript-eslint/typescript-eslint/pull/12206
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
     combinedStats[status] = stats.reduce<number>(
       (curr, next) => curr + (next[status] ?? 0),
       0

--- a/static/app/components/commandPalette/ui/collection.spec.tsx
+++ b/static/app/components/commandPalette/ui/collection.spec.tsx
@@ -35,10 +35,10 @@ function StoreCapture({
   return null;
 }
 
-function makeStoreRef() {
-  return createRef() as React.MutableRefObject<ReturnType<
-    typeof TestCollection.useStore
-  > | null>;
+function makeStoreRef(): React.MutableRefObject<ReturnType<
+  typeof TestCollection.useStore
+> | null> {
+  return createRef();
 }
 
 describe('Collection', () => {

--- a/static/app/components/core/form/autoSaveForm.tsx
+++ b/static/app/components/core/form/autoSaveForm.tsx
@@ -166,8 +166,6 @@ interface AutoSaveFormProps<
 export function AutoSaveForm<
   TData,
   TContext,
-  // Will be fixed by https://github.com/typescript-eslint/typescript-eslint/pull/12206
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
   TSchema extends z.ZodObject<z.ZodRawShape>,
   TFieldName extends Extract<keyof SchemaInput<TSchema>, string>,
 >(props: AutoSaveFormProps<TData, TContext, TSchema, TFieldName>) {

--- a/static/app/components/core/form/field/selectField.spec.tsx
+++ b/static/app/components/core/form/field/selectField.spec.tsx
@@ -373,7 +373,7 @@ it('does not pass unmatched object values to react-select callbacks like getOpti
   function GetOptionValueForm() {
     const form = useScrapsForm({
       ...defaultFormOptions,
-      defaultValues: {fruit: {id: '99', name: 'Mango'} as {id: string; name: string}},
+      defaultValues: {fruit: {id: '99', name: 'Mango'}},
     });
 
     return (

--- a/static/app/components/core/form/field/selectField.tsx
+++ b/static/app/components/core/form/field/selectField.tsx
@@ -159,9 +159,7 @@ export function SelectField<TValue>({
             ) => {
               if (multiple) {
                 // For multi-select, option is an array
-                (onChange as (value: TValue[]) => void)(
-                  Array.isArray(option) ? option.map(o => o.value) : []
-                );
+                onChange(Array.isArray(option) ? option.map(o => o.value) : []);
                 // For multi-select in auto-save context, trigger save when menu is closed
                 // (e.g., clicking X on a tag or clear all while menu is not open)
                 if (autoSaveContext && !isMenuOpenRef.current) {

--- a/static/app/components/core/layout/styles.spec.tsx
+++ b/static/app/components/core/layout/styles.spec.tsx
@@ -536,7 +536,7 @@ describe('useContainerBreakpoint', () => {
 
   beforeEach(() => {
     originalResizeObserver = window.ResizeObserver;
-    window.ResizeObserver = MockResizeObserver as unknown as typeof window.ResizeObserver;
+    window.ResizeObserver = MockResizeObserver;
   });
 
   afterEach(() => {

--- a/static/app/components/core/tabs/tabs.spec.tsx
+++ b/static/app/components/core/tabs/tabs.spec.tsx
@@ -308,7 +308,7 @@ describe('Tabs overflow', () => {
           x: 0,
           y: 0,
           toJSON: () => ({}),
-        } as DOMRect;
+        };
       });
 
     // Only the tab list wrapper (whose direct child is the tablist) reports the
@@ -330,7 +330,7 @@ describe('Tabs overflow', () => {
       observe() {}
       unobserve() {}
       disconnect() {}
-    } as unknown as typeof ResizeObserver;
+    };
   });
 
   afterEach(() => {

--- a/static/app/components/events/autofix/useExplorerAutofix.spec.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.spec.tsx
@@ -450,7 +450,7 @@ describe('getOrderedAutofixSections', () => {
 
   function makeBlock(
     overrides: Omit<Partial<Block>, 'message'> & {message?: Partial<Block['message']>}
-  ) {
+  ): Block {
     const {message, ...rest} = overrides;
     return {
       id: `block-${blockId++}`,
@@ -461,7 +461,7 @@ describe('getOrderedAutofixSections', () => {
         ...message,
       },
       ...rest,
-    } as Block;
+    };
   }
 
   function makePatch(repoName: string, path: string, diff = 'diff'): ExplorerFilePatch {
@@ -632,7 +632,7 @@ describe('isPrIterationBlock', () => {
       id: 'block-1',
       timestamp: '2026-01-01T00:00:00Z',
       message: {content: 'hello', role: 'assistant', metadata},
-    } as Block;
+    };
   }
 
   it('is true only for blocks whose step is pr_iteration', () => {
@@ -668,7 +668,7 @@ describe('isLastStepPrIteration', () => {
         role: 'assistant',
         metadata: step ? {step} : undefined,
       },
-    } as Block;
+    };
   }
   function state(blocks: Block[]): ExplorerAutofixState {
     return {

--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -1841,7 +1841,7 @@ describe('ArtifactCard', () => {
         <CodingAgentsCard
           autofix={mockAutofix}
           section={makeSection('coding_agents', 'completed', [
-            [makeCodingAgent({provider: 'unknown_provider' as any})],
+            [makeCodingAgent({provider: 'unknown_provider'})],
           ])}
         />
       );

--- a/static/app/components/events/autofix/v3/autofixPreviews.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixPreviews.spec.tsx
@@ -380,9 +380,7 @@ describe('CodingAgentPreview', () => {
   it('renders default title for unknown provider', () => {
     render(
       <CodingAgentPreview
-        section={makeSection('coding_agents', [
-          [makeCodingAgent({provider: 'unknown' as any})],
-        ])}
+        section={makeSection('coding_agents', [[makeCodingAgent({provider: 'unknown'})]])}
       />
     );
 

--- a/static/app/components/events/interfaces/spans/utils.tsx
+++ b/static/app/components/events/interfaces/spans/utils.tsx
@@ -493,7 +493,7 @@ export function parseTrace(
       span = {
         type: 'orphan',
         ...span,
-      } as OrphanSpanType;
+      };
     }
 
     assert(span.parent_span_id);

--- a/static/app/components/feedback/feedbackItem/feedbackActivitySection.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackActivitySection.tsx
@@ -28,7 +28,7 @@ export function FeedbackActivitySection(props: Props) {
 
   return (
     <ActivitySection
-      group={{...feedbackItem, activity: filteredActivity} as unknown as Group}
+      group={{...feedbackItem, activity: filteredActivity}}
       onCommentCreated={handleCommentChange}
       onCommentDeleted={handleCommentChange}
       onCommentEdited={handleCommentChange}

--- a/static/app/components/forms/formIndicators.tsx
+++ b/static/app/components/forms/formIndicators.tsx
@@ -119,8 +119,8 @@ const PRETTY_VALUES = new Map<unknown, string>([
   [null, '<none>'],
   [undefined, '<unset>'],
   // if we don't cast as any, then typescript complains because booleans are not valid keys
-  [true as any, 'enabled'],
-  [false as any, 'disabled'],
+  [true, 'enabled'],
+  [false, 'disabled'],
 ]);
 
 // Transform form values into a string

--- a/static/app/components/modals/debugFileCustomRepository/index.spec.tsx
+++ b/static/app/components/modals/debugFileCustomRepository/index.spec.tsx
@@ -8,7 +8,7 @@ import {GcsRepository, S3Repository} from './objectStorage';
 
 const stubEl = ({children}: {children?: React.ReactNode}) => <div>{children}</div>;
 const modalProps = {
-  Header: stubEl as ModalRenderProps['Header'],
+  Header: stubEl,
   Body: stubEl as ModalRenderProps['Body'],
   Footer: stubEl as ModalRenderProps['Footer'],
 };

--- a/static/app/components/pageFilters/project/projectPageFilter.spec.tsx
+++ b/static/app/components/pageFilters/project/projectPageFilter.spec.tsx
@@ -590,6 +590,7 @@ describe('ProjectPageFilter', () => {
       memberCount: 52,
       nonMemberCount: 1,
       urlProjects: [] as number[],
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
       urlQuery: {} as Record<string, string>,
       triggerName: 'My Projects',
     },

--- a/static/app/components/pipeline/usePipeline.tsx
+++ b/static/app/components/pipeline/usePipeline.tsx
@@ -392,7 +392,7 @@ export function usePipeline<
  */
 function getErrorMessage(err: Error): string {
   if (err instanceof RequestError) {
-    const detail = (err.responseJSON as Record<string, unknown> | undefined)?.detail;
+    const detail = err.responseJSON?.detail;
     if (typeof detail === 'string') {
       return detail;
     }
@@ -422,7 +422,7 @@ function getPipelineError(
     return getErrorMessage(initializeError);
   }
   if (advanceError) {
-    const json = advanceError.responseJSON as Record<string, unknown> | undefined;
+    const json = advanceError.responseJSON;
     if (json?.status === 'error') {
       const data = json.data as Record<string, unknown> | undefined;
       if (typeof data?.detail === 'string') {

--- a/static/app/components/replays/player/replayLoadingState.spec.tsx
+++ b/static/app/components/replays/player/replayLoadingState.spec.tsx
@@ -24,7 +24,7 @@ function makeReaderResult(overrides: Partial<ReaderResult> = {}): ReaderResult {
     replayRecord: undefined,
     status: 'success',
     ...overrides,
-  } as ReaderResult;
+  };
 }
 
 function requestError(status: number) {

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/useAskSeerPolling.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/useAskSeerPolling.tsx
@@ -182,8 +182,6 @@ export function useAskSeerPolling<T extends QueryTokensProps>(
     setWaitingForResponse(false);
     setStartFailed(false);
     if (queryKey) {
-      // Will be fixed soon when we get rid of setApiQueryData.
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
       setApiQueryData<AskSeerPollingResponse<T>>(
         queryClient,
         queryKey,

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -211,8 +211,6 @@ function countPreviousItemsOfType({
   }
   const currentIndex = itemKeys.indexOf(focusedKey);
 
-  // Will be fixed by https://github.com/typescript-eslint/typescript-eslint/pull/12206
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
   return itemKeys.slice(0, currentIndex).reduce<number>((count, next) => {
     if (next.toString().includes(type)) {
       return count + 1;

--- a/static/app/components/searchQueryBuilder/tokens/useSearchTokenCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/useSearchTokenCombobox.tsx
@@ -176,10 +176,10 @@ export function useSearchTokenCombobox<T>(
       onKeyDown: isReadOnly
         ? props.onKeyDown
         : chain(state.isOpen && collectionProps.onKeyDown, onKeyDown, props.onKeyDown),
-      onBlur: onBlur as (e: FocusEvent) => void,
+      onBlur,
       value: state.inputValue,
       defaultValue: state.defaultInputValue,
-      onFocus: onFocus as (e: FocusEvent) => void,
+      onFocus,
       autoComplete: 'off',
       validate: undefined,
       [privateValidationStateProp]: state,

--- a/static/app/components/seer/markdown/embeds/schemas.ts
+++ b/static/app/components/seer/markdown/embeds/schemas.ts
@@ -256,7 +256,7 @@ export function seerEmbedsToJsonSchemas(): Array<{
       name,
       description: def.description,
       level: [...def.level],
-      body: z.toJSONSchema(def.schema) as Record<string, unknown>,
+      body: z.toJSONSchema(def.schema),
       ...(def.examples && {
         examples: def.examples.map(e => ({label: e.label, data: e.data})),
       }),

--- a/static/app/components/seer/repoDetails/repoDetailsForm.tsx
+++ b/static/app/components/seer/repoDetails/repoDetailsForm.tsx
@@ -64,7 +64,6 @@ export function RepoDetailsForm({organization, repoWithSettings}: Props) {
     },
     onError: (_error, _data, context) => {
       if (context?.previous) {
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
         setApiQueryData<RepositoryWithSettings>(
           queryClient,
           repoQueryKey,

--- a/static/app/components/seer/repoTable/seerRepoTableRow.tsx
+++ b/static/app/components/seer/repoTable/seerRepoTableRow.tsx
@@ -134,7 +134,6 @@ export function SeerRepoTableRow({
               },
               {
                 onError: () => {
-                  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
                   setApiQueryData<RepositoryWithSettings>(
                     queryClient,
                     queryKey,

--- a/static/app/components/stackTrace/issueStackTrace/index.spec.tsx
+++ b/static/app/components/stackTrace/issueStackTrace/index.spec.tsx
@@ -37,7 +37,7 @@ function makeStackTraceData(): {
           ...frame,
           inApp: index >= 2,
         })) ?? [],
-    } as StacktraceWithFrames,
+    },
   };
 }
 

--- a/static/app/components/stackTrace/stackTrace.spec.tsx
+++ b/static/app/components/stackTrace/stackTrace.spec.tsx
@@ -45,7 +45,7 @@ function makeStackTraceData(): {
           ...frame,
           inApp: index >= 2,
         })) ?? [],
-    } as StacktraceWithFrames,
+    },
   };
 }
 

--- a/static/app/components/stackTrace/stackTrace.stories.tsx
+++ b/static/app/components/stackTrace/stackTrace.stories.tsx
@@ -272,7 +272,7 @@ function makeCircularStackTraceData(): StackTraceStoryData {
         {...inAppRecursiveFrame},
         {...inAppRecursiveFrame},
       ],
-    } as StacktraceWithFrames,
+    },
   };
 }
 
@@ -294,7 +294,7 @@ function makeSourceMapTooltipStackTraceData(): StackTraceStoryData {
           inApp: true,
         },
       ],
-    } as StacktraceWithFrames,
+    },
   };
 }
 
@@ -315,7 +315,7 @@ function makeLongPathStackTraceData(): StackTraceStoryData {
           inApp: true,
         };
       }),
-    } as StacktraceWithFrames,
+    },
   };
 }
 
@@ -333,7 +333,7 @@ function makeLongPathAndFunctionStackTraceData(): StackTraceStoryData {
           '__with_additional_context_and_nested_handler_resolution_chain',
         inApp: true,
       })),
-    } as StacktraceWithFrames,
+    },
   };
 }
 
@@ -356,7 +356,7 @@ function makeRawFunctionAndPackageStackTraceData(): StackTraceStoryData {
             },
           ]
         : [],
-    } as StacktraceWithFrames,
+    },
   };
 }
 
@@ -398,7 +398,7 @@ function makeMixedExpandabilityStackTraceData(): StackTraceStoryData {
           package: null,
         }),
       ],
-    } as StacktraceWithFrames,
+    },
   };
 }
 

--- a/static/app/utils/discover/urls.tsx
+++ b/static/app/utils/discover/urls.tsx
@@ -81,7 +81,7 @@ export function generateLinkToEventInTraceView({
   if (!traceSlug) {
     Sentry.withScope(scope => {
       scope.setExtras({traceSlug, source});
-      scope.setLevel('warning' as any);
+      scope.setLevel('warning');
       Sentry.captureException(new Error('Trace slug is missing'));
     });
   }

--- a/static/app/utils/number/rangeMap.spec.tsx
+++ b/static/app/utils/number/rangeMap.spec.tsx
@@ -63,11 +63,9 @@ describe('RangeMap', () => {
   });
 
   test('enforces type', () => {
-    type Salutation = 'Hello' | 'Hi';
-
     const ladder = new RangeMap([
-      {min: 0, max: 10, value: 'Hello' as Salutation},
-      {min: 10, max: 20, value: 'Hi' as Salutation},
+      {min: 0, max: 10, value: 'Hello'},
+      {min: 10, max: 20, value: 'Hi'},
     ]);
 
     const salutation = ladder.get(0);

--- a/static/app/utils/profiling/differentialFlamegraph.tsx
+++ b/static/app/utils/profiling/differentialFlamegraph.tsx
@@ -142,7 +142,7 @@ export class DifferentialFlamegraph extends Flamegraph {
     differentialFlamegraph.colorBuffer = makeColorBufferForNodes(
       sourceFlamegraph.frames,
       colorMap,
-      theme.COLORS.FRAME_FALLBACK_COLOR as unknown as ColorChannels
+      theme.COLORS.FRAME_FALLBACK_COLOR
     );
 
     differentialFlamegraph.newFrames = newFrames;

--- a/static/app/utils/profiling/flamegraph/flamegraphKeyboardNavigation.spec.ts
+++ b/static/app/utils/profiling/flamegraph/flamegraphKeyboardNavigation.spec.ts
@@ -44,13 +44,13 @@ describe('selectNearestFrame', () => {
     const root = createFlamegraphFrame();
     const firstChild = addChild(root);
 
-    const next = selectNearestFrame(root as any, 'down');
+    const next = selectNearestFrame(root, 'down');
     expect(next).toBe(firstChild);
   });
   it('selects parent when walking up', () => {
     const root = createFlamegraphFrame();
     const firstChild = addChild(root);
-    const next = selectNearestFrame(firstChild as any, 'up');
+    const next = selectNearestFrame(firstChild, 'up');
     expect(next).toBe(root);
   });
 
@@ -58,7 +58,7 @@ describe('selectNearestFrame', () => {
     const root = createFlamegraphFrame();
     const leftGrandChild = addChildrenToDepth(root, 2);
     const rightGrandChild = addChildrenToDepth(root, 2);
-    const next = selectNearestFrame(leftGrandChild as any, 'right');
+    const next = selectNearestFrame(leftGrandChild, 'right');
     expect(next).toBe(rightGrandChild);
     expect(next.depth).toBe(rightGrandChild.depth);
   });
@@ -67,7 +67,7 @@ describe('selectNearestFrame', () => {
     const root = createFlamegraphFrame();
     const leftGrandChild = addChildrenToDepth(root, 4);
     const rightGrandChild = addChildrenToDepth(root, 2);
-    const next = selectNearestFrame(leftGrandChild as any, 'right');
+    const next = selectNearestFrame(leftGrandChild, 'right');
     expect(next).toBe(rightGrandChild);
     expect(next.depth).not.toBe(leftGrandChild.depth);
   });
@@ -76,7 +76,7 @@ describe('selectNearestFrame', () => {
     const root = createFlamegraphFrame();
     const leftGrandChild = addChildrenToDepth(root, 2);
     const rightGrandChild = addChildrenToDepth(root, 2);
-    const next = selectNearestFrame(rightGrandChild as any, 'left');
+    const next = selectNearestFrame(rightGrandChild, 'left');
     expect(next).toBe(leftGrandChild);
     expect(next.depth).toBe(rightGrandChild.depth);
   });
@@ -85,21 +85,21 @@ describe('selectNearestFrame', () => {
     const root = createFlamegraphFrame();
     const leftGrandChild = addChildrenToDepth(root, 2);
     const rightGrandChild = addChildrenToDepth(root, 4);
-    const next = selectNearestFrame(rightGrandChild as any, 'left');
+    const next = selectNearestFrame(rightGrandChild, 'left');
     expect(next).toBe(leftGrandChild);
     expect(next.depth).not.toBe(rightGrandChild.depth);
   });
 
   it('returns current node when moving up from root', () => {
     const root = createFlamegraphFrame();
-    const next = selectNearestFrame(root as any, 'up');
+    const next = selectNearestFrame(root, 'up');
     expect(next).toBe(root);
   });
 
   it('returns current node when at max depth at bottom boundary and no adjacent stack', () => {
     const root = createFlamegraphFrame();
     const grandChild = addChildrenToDepth(root, 2);
-    const next = selectNearestFrame(grandChild as any, 'down');
+    const next = selectNearestFrame(grandChild, 'down');
     expect(next).toBe(grandChild);
   });
 
@@ -107,7 +107,7 @@ describe('selectNearestFrame', () => {
     const root = createFlamegraphFrame();
     const leftGrandChild = addChildrenToDepth(root, 2);
     const rightGrandChild = addChildrenToDepth(root, 2);
-    const next = selectNearestFrame(leftGrandChild as any, 'down');
+    const next = selectNearestFrame(leftGrandChild, 'down');
     expect(next).toBe(rightGrandChild.parent);
   });
 
@@ -118,7 +118,7 @@ describe('selectNearestFrame', () => {
       },
     });
     const leftChild = addChildrenToDepth(root, 1);
-    const next = selectNearestFrame(leftChild as any, 'up');
+    const next = selectNearestFrame(leftChild, 'up');
     expect(next).toBe(leftChild);
   });
 });

--- a/static/app/utils/profiling/routes.tsx
+++ b/static/app/utils/profiling/routes.tsx
@@ -183,7 +183,7 @@ export function generateProfileRouteFromProfileReference({
         frameName,
         framePackage,
         eventId,
-        tid: reference.thread_id as unknown as string,
+        tid: reference.thread_id,
       }),
     });
   }

--- a/static/app/utils/replays/hooks/useTimelineScale.tsx
+++ b/static/app/utils/replays/hooks/useTimelineScale.tsx
@@ -1,7 +1,5 @@
 import {createContext, useContext, useState} from 'react';
 
-// Will be fixed by https://github.com/typescript-eslint/typescript-eslint/pull/12206
-// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
 const Context = createContext<[scale: number, setScale: (scale: number) => void]>([
   1,
   (_scale: number) => {},

--- a/static/app/utils/replays/projectSupportsReplay.spec.tsx
+++ b/static/app/utils/replays/projectSupportsReplay.spec.tsx
@@ -19,18 +19,18 @@ describe('projectSupportsReplay & projectCanLinkToReplay', () => {
   const organization = OrganizationFixture();
 
   it.each([
-    'javascript-angular' as PlatformKey,
-    'javascript-nextjs' as PlatformKey,
-    'javascript-react' as PlatformKey,
-    'javascript' as PlatformKey,
-    'electron' as PlatformKey,
-  ])('should SUPPORT & LINK frontend platform %s', platform => {
+    'javascript-angular',
+    'javascript-nextjs',
+    'javascript-react',
+    'javascript',
+    'electron',
+  ] as const)('should SUPPORT & LINK frontend platform %s', platform => {
     const project = mockProjectFixture(platform);
     expect(projectSupportsReplay(project)).toBeTruthy();
     expect(projectCanLinkToReplay(organization, project)).toBeTruthy();
   });
 
-  it.each(['javascript-angularjs' as PlatformKey])(
+  it.each(['javascript-angularjs'] as const)(
     'should FAIL for old, unsupported frontend framework %s',
     platform => {
       const project = mockProjectFixture(platform);
@@ -39,19 +39,16 @@ describe('projectSupportsReplay & projectCanLinkToReplay', () => {
     }
   );
 
-  it.each([
-    'node' as PlatformKey,
-    'php' as PlatformKey,
-    'bun' as PlatformKey,
-    'elixir' as PlatformKey,
-    'go' as PlatformKey,
-  ])('should SUPPORT Backend framework %s', platform => {
-    const project = mockProjectFixture(platform);
-    expect(projectSupportsReplay(project)).toBeTruthy();
-    expect(projectCanLinkToReplay(organization, project)).toBeTruthy();
-  });
+  it.each(['node', 'php', 'bun', 'elixir', 'go'] as const)(
+    'should SUPPORT Backend framework %s',
+    platform => {
+      const project = mockProjectFixture(platform);
+      expect(projectSupportsReplay(project)).toBeTruthy();
+      expect(projectCanLinkToReplay(organization, project)).toBeTruthy();
+    }
+  );
 
-  it.each(['java' as PlatformKey, 'rust' as PlatformKey, 'python' as PlatformKey])(
+  it.each(['java', 'rust', 'python'] as const)(
     'should NOT SUPPORT but CAN LINK for Backend framework %s',
     platform => {
       const project = mockProjectFixture(platform);

--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -649,11 +649,13 @@ function makeChartColorPalette<T extends ChartColorPalette>(
     length: Length | number | 'all'
   ): T[Length] {
     if (length === 'all') {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
       return palette.at(-1) as unknown as T[Length];
     }
     // @TODO(jonasbadalic) we guarantee type safety and sort of guarantee runtime safety by clamping and
     // the palette is not sparse, but we should probably add a runtime check here as well.
     const index = Math.max(0, Math.min(palette.length - 1, length));
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     return palette[index] as unknown as T[Length];
   };
 }

--- a/static/app/views/alerts/rules/metric/eapMetricsField.tsx
+++ b/static/app/views/alerts/rules/metric/eapMetricsField.tsx
@@ -108,7 +108,7 @@ export function EAPMetricsField({
         label: option[TraceMetricKnownFieldKey.METRIC_NAME],
         value: makeMetricSelectValue({
           name: option[TraceMetricKnownFieldKey.METRIC_NAME],
-          type: option[TraceMetricKnownFieldKey.METRIC_TYPE] as TraceMetricTypeValue,
+          type: option[TraceMetricKnownFieldKey.METRIC_TYPE],
           unit: hasMetricUnitsUI
             ? (option[TraceMetricKnownFieldKey.METRIC_UNIT] ?? NONE_UNIT)
             : undefined,

--- a/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
@@ -289,7 +289,7 @@ class TriggersChart extends PureComponent<Props, State> {
     });
 
     let queryDataset = queryExtras.dataset as undefined | DiscoverDatasets;
-    const queryOverride = (queryExtras.query as string | undefined) ?? query;
+    const queryOverride = queryExtras.query ?? query;
 
     if (shouldUseErrorsDiscoverDataset(query, dataset, organization)) {
       queryDataset = DiscoverDatasets.ERRORS;

--- a/static/app/views/dashboards/dashboardRevisionsDiff.spec.ts
+++ b/static/app/views/dashboards/dashboardRevisionsDiff.spec.ts
@@ -10,7 +10,7 @@ function makeWidget(overrides: Partial<Widget> = {}): Widget {
     queries: [],
     interval: '1h',
     ...overrides,
-  } as Widget;
+  };
 }
 
 function makeDashboard(widgets: Widget[]): DashboardDetails {
@@ -21,7 +21,7 @@ function makeDashboard(widgets: Widget[]): DashboardDetails {
     widgets,
     filters: {},
     projects: [],
-  } as unknown as DashboardDetails;
+  };
 }
 
 describe('diffWidgets', () => {
@@ -73,7 +73,7 @@ describe('diffWidgets', () => {
           columns: [],
           orderby: '',
           name: '',
-        } as any,
+        },
       ],
     });
     const snap = makeWidget({
@@ -85,7 +85,7 @@ describe('diffWidgets', () => {
           columns: [],
           orderby: '',
           name: '',
-        } as any,
+        },
       ],
     });
     const result = diffWidgets(makeDashboard([base]), makeDashboard([snap]));
@@ -360,7 +360,7 @@ describe('diffFilters', () => {
       filters: {},
       projects: [],
       ...overrides,
-    } as unknown as DashboardDetails;
+    };
   }
 
   // Resolver that uses a slug map for known IDs, falls back to the numeric string.

--- a/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
+++ b/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
@@ -238,7 +238,7 @@ export function transformEventsResponseToTable(
   tableData = {
     ...data,
     meta: {...fields, ...otherMeta, fields},
-  } as TableData;
+  };
   return tableData;
 }
 

--- a/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
+++ b/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
@@ -356,7 +356,7 @@ export const TraceMetricsConfig: DatasetConfig<
       } else if (timeSeries.yAxis.includes('per_minute(')) {
         acc[timeSeries.yAxis] = RateUnit.PER_MINUTE;
       } else {
-        acc[timeSeries.yAxis] = timeSeries.meta.valueUnit as DataUnit;
+        acc[timeSeries.yAxis] = timeSeries.meta.valueUnit;
       }
       return acc;
     }, {});

--- a/static/app/views/dashboards/revisionListItem.spec.tsx
+++ b/static/app/views/dashboards/revisionListItem.spec.tsx
@@ -90,7 +90,7 @@ describe('RevisionListItem', () => {
     });
     MockApiClient.addMockResponse({url: BASE_SNAPSHOT_URL, body: makeSnapshot()});
 
-    renderItem({snapshotOverride: makeSnapshot() as any});
+    renderItem({snapshotOverride: makeSnapshot()});
 
     await screen.findByText('No widget changes in this revision.');
     expect(snapshotRequest).not.toHaveBeenCalled();
@@ -102,7 +102,7 @@ describe('RevisionListItem', () => {
     renderItem({
       isCurrentVersion: true,
       revisionId: undefined,
-      snapshotOverride: makeSnapshot() as any,
+      snapshotOverride: makeSnapshot(),
     });
 
     expect(screen.getByText('Current Version')).toBeInTheDocument();

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
@@ -2849,7 +2849,7 @@ describe('useWidgetBuilderState', () => {
         result.current.dispatch({
           type: BuilderStateAction.SET_TEXT_CONTENT,
           payload: 'new text content',
-        } as any);
+        });
       });
 
       jest.runAllTimers();

--- a/static/app/views/dashboards/widgetCard/index.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/index.spec.tsx
@@ -38,7 +38,7 @@ describe('Dashboards > WidgetCard', () => {
     organization: OrganizationFixture({
       features: ['dashboards-edit', 'discover-basic'],
     }),
-  } as Parameters<typeof initializeOrg>[0]);
+  });
 
   const renderWithProviders = (component: React.ReactNode, features: string[] = []) =>
     render(

--- a/static/app/views/dashboards/widgetCard/widgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetQueries.tsx
@@ -122,6 +122,7 @@ export function WidgetQueries({
   const isSeriesMetricsExtractedDataResults: Array<boolean | undefined> = [];
   const afterFetchSeriesData = (rawResults: SeriesResult) => {
     if (rawResults.data) {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
       rawResults = rawResults as EventsStats;
       if (rawResults.isMetricsData !== undefined) {
         isSeriesMetricsDataResults.push(rawResults.isMetricsData);

--- a/static/app/views/dashboards/widgets/categoricalSeriesWidget/plottables/bars.tsx
+++ b/static/app/views/dashboards/widgets/categoricalSeriesWidget/plottables/bars.tsx
@@ -36,8 +36,6 @@ interface BarsConfig extends CategoricalDataSeriesConfig {
  * A plottable that renders a categorical bar series.
  */
 export class Bars
-  // Will be fixed by https://github.com/typescript-eslint/typescript-eslint/pull/12206
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
   extends CategoricalDataSeries<BarsConfig>
   implements CategoricalPlottable
 {
@@ -95,12 +93,11 @@ export class Bars
         itemStyle: {
           opacity: 1,
         },
-        data: this.categoricalSeries.values.map(
-          item =>
-            // This name must match with the `data` setting of the `xAxis` config
-            // in ECharts. ECharts wants both a full list of the categories for
-            // the X axis, and for the series data points to specify the name.
-            [formatXAxisValue(item.category), item.value]
+        data: this.categoricalSeries.values.map(item =>
+          // This name must match with the `data` setting of the `xAxis` config
+          // in ECharts. ECharts wants both a full list of the categories for
+          // the X axis, and for the series data points to specify the name.
+          [formatXAxisValue(item.category), item.value]
         ),
       }),
     ];

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/bars.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/bars.tsx
@@ -19,8 +19,6 @@ interface BarsConfig extends ContinuousTimeSeriesConfig {
   stack?: string;
 }
 
-// Will be fixed by https://github.com/typescript-eslint/typescript-eslint/pull/12206
-// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
 export class Bars extends ContinuousTimeSeries<BarsConfig> implements Plottable {
   onHighlight(dataIndex: number): void {
     const {config = {}} = this;

--- a/static/app/views/detectors/components/forms/metric/metricsVisualize.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricsVisualize.tsx
@@ -112,7 +112,7 @@ export function MetricsVisualize() {
         label: option[TraceMetricKnownFieldKey.METRIC_NAME],
         value: makeMetricSelectValue({
           name: option[TraceMetricKnownFieldKey.METRIC_NAME],
-          type: option[TraceMetricKnownFieldKey.METRIC_TYPE] as TraceMetricTypeValue,
+          type: option[TraceMetricKnownFieldKey.METRIC_TYPE],
           unit: hasMetricUnitsUI
             ? (option[TraceMetricKnownFieldKey.METRIC_UNIT] ?? NONE_UNIT)
             : undefined,

--- a/static/app/views/detectors/datasetConfig/utils/timePeriods.tsx
+++ b/static/app/views/detectors/datasetConfig/utils/timePeriods.tsx
@@ -155,9 +155,9 @@ export function getEapTimePeriodsForInterval(
  * Uses hours for 1d (Last 24 hours) and days for multi-day periods.
  */
 export function getTimePeriodLabel(period: MetricDetectorTimePeriod): string {
-  const hours = parsePeriodToHours(period as unknown as string);
+  const hours = parsePeriodToHours(period);
   if (hours <= 0) {
-    return period as unknown as string;
+    return period;
   }
   if (hours <= 24) {
     return t('Last %s hours', hours);

--- a/static/app/views/detectors/hooks/useMetricDetectorAnomalyPeriods.tsx
+++ b/static/app/views/detectors/hooks/useMetricDetectorAnomalyPeriods.tsx
@@ -160,7 +160,7 @@ export function useMetricDetectorAnomalyPeriods({
     eventTypes,
     environment,
     projectId,
-    statsPeriod: historicalPeriod as TimePeriod,
+    statsPeriod: historicalPeriod,
     options: {
       enabled,
     },

--- a/static/app/views/discover/table/index.tsx
+++ b/static/app/views/discover/table/index.tsx
@@ -5,7 +5,6 @@ import type {Location} from 'history';
 import type {CursorHandler} from '@sentry/scraps/pagination';
 import {Pagination} from '@sentry/scraps/pagination';
 
-import type {EventQuery} from 'sentry/actionCreators/events';
 import type {Client} from 'sentry/api';
 import {ErrorBoundary} from 'sentry/components/errorBoundary';
 import {t} from 'sentry/locale';
@@ -13,7 +12,7 @@ import type {Organization} from 'sentry/types/organization';
 import {metric, trackAnalytics} from 'sentry/utils/analytics';
 import {CustomMeasurementsContext} from 'sentry/utils/customMeasurements/customMeasurementsContext';
 import type {TableData} from 'sentry/utils/discover/discoverQuery';
-import type {EventView, LocationQuery} from 'sentry/utils/discover/eventView';
+import type {EventView} from 'sentry/utils/discover/eventView';
 import {isAPIPayloadSimilar, isFieldsSimilar} from 'sentry/utils/discover/eventView';
 import {SPAN_OP_BREAKDOWN_FIELDS} from 'sentry/utils/discover/fields';
 import type {DiscoverDatasets, SavedQueryDatasets} from 'sentry/utils/discover/types';
@@ -154,8 +153,7 @@ class Table extends PureComponent<TableProps, TableState> {
     const url = `/organizations/${organization.slug}/events/`;
     const tableFetchID = Symbol('tableFetchID');
 
-    const apiPayload = eventView.getEventsAPIPayload(location) as LocationQuery &
-      EventQuery;
+    const apiPayload = eventView.getEventsAPIPayload(location);
 
     // We are now routing to the trace view on clicking event ids. Therefore, we need the trace slug associated to the event id.
     // Note: Event ID or 'id' is added to the fields in the API payload response by default for all non-aggregate queries.

--- a/static/app/views/explore/contexts/logs/logsPageParams.tsx
+++ b/static/app/views/explore/contexts/logs/logsPageParams.tsx
@@ -33,6 +33,7 @@ export function usePersistedLogsPageParams() {
   });
 
   return useLocalStorageState(getLogsParamsStorageKey(LOGS_PARAMS_VERSION), {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     fields: defaultLogFields() as string[],
     sortBys: [logsTimestampDescendingSortBy],
   });

--- a/static/app/views/explore/conversations/hooks/useConversation.spec.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversation.spec.tsx
@@ -26,7 +26,7 @@ function envelope(
   title: string | null = null
 ): Record<string, unknown> {
   return {
-    conversationId: (spans[0]?.['gen_ai.conversation.id'] as string) ?? '',
+    conversationId: spans[0]?.['gen_ai.conversation.id'] ?? '',
     title,
     spans,
   };

--- a/static/app/views/explore/conversations/hooks/useFocusedToolSpan.spec.tsx
+++ b/static/app/views/explore/conversations/hooks/useFocusedToolSpan.spec.tsx
@@ -32,6 +32,7 @@ describe('useFocusedToolSpan', () => {
           onSpanFound,
         }),
       {
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
         initialProps: {focusedTool: 'first-tool' as string | null},
       }
     );

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -393,7 +393,7 @@ export const LogRowContent = memo(function LogRowContentImpl({
       ...(observedTimestamp && {
         [OurLogKnownFieldKey.OBSERVED_TIMESTAMP_PRECISE]: String(observedTimestamp.value),
       }),
-    } as OurLogsResponseItem,
+    },
     attributeTypes: meta?.fields ?? {},
     theme,
     projectSlug,

--- a/static/app/views/explore/logs/useLogsSearchQueryBuilderProps.tsx
+++ b/static/app/views/explore/logs/useLogsSearchQueryBuilderProps.tsx
@@ -141,7 +141,7 @@ export function useLogsSearchQueryBuilderProps({
       booleanAttributes: validatedBooleanAttributes,
       numberAttributes: validatedNumberAttributes,
       stringAttributes: validatedStringAttributes,
-      itemType: TraceItemDataset.LOGS as TraceItemDataset.LOGS,
+      itemType: TraceItemDataset.LOGS,
       booleanSecondaryAliases,
       numberSecondaryAliases,
       stringSecondaryAliases,

--- a/static/app/views/explore/releases/detail/overview/releaseComparisonChart/releaseEventsChart.tsx
+++ b/static/app/views/explore/releases/detail/overview/releaseComparisonChart/releaseEventsChart.tsx
@@ -1,6 +1,5 @@
 import {Fragment} from 'react';
 import {useTheme} from '@emotion/react';
-import type {ToolboxComponentOption} from 'echarts';
 
 import {Client} from 'sentry/api';
 import {EventsChart} from 'sentry/components/charts/eventsChart';
@@ -213,7 +212,7 @@ export function ReleaseEventsChart({
 
                 return tooltipFormatter(val, aggregateOutputType(getYAxis()));
               },
-            } as ToolboxComponentOption,
+            },
           }}
           usePageZoom
           height={240}

--- a/static/app/views/explore/releases/list/mobileBuildsChart.tsx
+++ b/static/app/views/explore/releases/list/mobileBuildsChart.tsx
@@ -125,7 +125,7 @@ export function MobileBuildsChart({
         symbolSize: 6,
         emphasis: {
           focus: 'series',
-        } as LineSeriesOption['emphasis'],
+        } as const satisfies LineSeriesOption['emphasis'],
       };
     });
 

--- a/static/app/views/explore/releases/list/releasesAdoptionChart.tsx
+++ b/static/app/views/explore/releases/list/releasesAdoptionChart.tsx
@@ -112,7 +112,7 @@ export function ReleasesAdoptionChart({
       ),
       emphasis: {
         focus: 'series',
-      } as LineSeriesOption['emphasis'],
+      } as const satisfies LineSeriesOption['emphasis'],
     }));
   };
 

--- a/static/app/views/explore/replays/detail/trace/useReplayTraces.tsx
+++ b/static/app/views/explore/replays/detail/trace/useReplayTraces.tsx
@@ -147,7 +147,7 @@ export function useReplayTraces({
           indexError: indexError as Error,
           indexComplete: true,
         }));
-        cursor = {cursor: '', results: false, href: ''} as ParsedHeader;
+        cursor = {cursor: '', results: false, href: ''};
       }
     }
   }, [api, listEventView, orgSlug, start, end]);

--- a/static/app/views/insights/browser/webVitals/queries/useSpanSamplesWebVitalsQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/useSpanSamplesWebVitalsQuery.tsx
@@ -50,7 +50,7 @@ export function useSpanSamplesWebVitalsQuery({
   const sort = useWebVitalsSort({
     sortName,
     defaultSort: DEFAULT_INDEXED_SPANS_SORT,
-    sortableFields: filteredSortableFields as unknown as string[],
+    sortableFields: filteredSortableFields,
   });
 
   const mutableSearch = MutableSearch.fromQueryObject({

--- a/static/app/views/insights/common/components/chart.tsx
+++ b/static/app/views/insights/common/components/chart.tsx
@@ -64,7 +64,7 @@ export enum ChartType {
 }
 
 export function isChartType(value: any): value is ChartType {
-  return typeof value === 'number' && Object.values(ChartType).includes(value as any);
+  return typeof value === 'number' && Object.values(ChartType).includes(value);
 }
 
 interface ChartRenderingProps {

--- a/static/app/views/issueList/mutations/useUpdateGroupSearchViewStarredOrder.tsx
+++ b/static/app/views/issueList/mutations/useUpdateGroupSearchViewStarredOrder.tsx
@@ -7,7 +7,6 @@ import type {RequestError} from 'sentry/utils/requestError/requestError';
 import {useApi} from 'sentry/utils/useApi';
 import {starredGroupSearchViewsApiOptions} from 'sentry/views/issueList/queries/starredGroupSearchViews';
 import {groupSearchViewsApiOptions} from 'sentry/views/issueList/queries/useFetchGroupSearchViews';
-import type {StarredGroupSearchView} from 'sentry/views/issueList/types';
 
 type UpdateGroupSearchViewStarredOrderVariables = {
   orgSlug: string;
@@ -38,10 +37,7 @@ export const useUpdateGroupSearchViewStarredOrder = () => {
 
       queryClient.setQueryData(
         starredGroupSearchViewsApiOptions({orgSlug: parameters.orgSlug}).queryKey,
-        prevData =>
-          prevData
-            ? {...prevData, json: newViewsOrder as StarredGroupSearchView[]}
-            : prevData
+        prevData => (prevData ? {...prevData, json: newViewsOrder} : prevData)
       );
     },
     onError: () => {

--- a/static/app/views/issueList/utils/useFetchIssueTags.tsx
+++ b/static/app/views/issueList/utils/useFetchIssueTags.tsx
@@ -341,7 +341,7 @@ function builtInIssuesFields({
         value,
         type: ItemType.TAG_VALUE,
         children: [],
-      })) as SearchGroup[],
+      })),
       predefined: true,
     },
     [FieldKey.LAST_SEEN]: {

--- a/static/app/views/organizationStats/usageChart/utils.spec.tsx
+++ b/static/app/views/organizationStats/usageChart/utils.spec.tsx
@@ -19,7 +19,7 @@ beforeEach(() => {
       ...ConfigStore.get('user')?.options,
       timezone: 'America/New_York',
     },
-  } as any);
+  });
 });
 
 describe('getDateFromMoment', () => {

--- a/static/app/views/performance/landing/widgets/components/performanceWidget.tsx
+++ b/static/app/views/performance/landing/widgets/components/performanceWidget.tsx
@@ -39,7 +39,7 @@ export function GenericPerformanceWidget<T extends WidgetDataConstraint>(
   const setWidgetDataForKey = useCallback(
     (dataKey: string, result?: WidgetDataResult) => {
       const _widgetData = widgetDataRef.current;
-      const newWidgetData = {..._widgetData, [dataKey]: result} as T;
+      const newWidgetData = {..._widgetData, [dataKey]: result};
       widgetDataRef.current = newWidgetData;
       setWidgetData({[props.chartSetting]: newWidgetData});
     },

--- a/static/app/views/performance/newTraceDetails/trace.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.spec.tsx
@@ -870,7 +870,7 @@ async function assertHighlightedRowAtIndex(
 
 describe('trace view', () => {
   beforeEach(() => {
-    globalThis.ResizeObserver = MockResizeObserver as any;
+    globalThis.ResizeObserver = MockResizeObserver;
     mockQueryString('');
     MockDate.reset();
 
@@ -1313,7 +1313,7 @@ describe('trace view', () => {
               ],
               toCompressedOffset: (timestamp: number) => timestamp - traceStart,
               toRealTimestamp: (offset: number) => traceStart + offset,
-            } as TraceTimeCompression;
+            };
           });
 
         try {

--- a/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.tsx
@@ -386,7 +386,7 @@ export function useTraceMeta(options: UseTraceMetaOptions): TraceMetaQueryResult
   if (mode === 'demo') {
     return {
       errors: [],
-      status: 'success' as QueryStatus,
+      status: 'success',
       isLoading: false,
       data: isEAP
         ? {

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/autogroup/index.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/autogroup/index.spec.tsx
@@ -41,7 +41,7 @@ describe('AutogroupNodeDetails', () => {
     render(
       <TraceStateProvider initialPreferences={DEFAULT_TRACE_VIEW_PREFERENCES}>
         <AutogroupNodeDetails
-          node={node as any}
+          node={node}
           organization={organization}
           onTabScrollToNode={jest.fn()}
           onParentClick={jest.fn()}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/error.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/error.spec.tsx
@@ -51,7 +51,7 @@ describe('ErrorNodeDetails', () => {
     render(
       <TraceStateProvider initialPreferences={DEFAULT_TRACE_VIEW_PREFERENCES}>
         <ErrorNodeDetails
-          node={node as any}
+          node={node}
           organization={organization}
           onTabScrollToNode={jest.fn()}
           onParentClick={jest.fn()}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/missingInstrumentation.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/missingInstrumentation.spec.tsx
@@ -76,7 +76,7 @@ describe('MissingInstrumentationNodeDetails', () => {
     render(
       <TraceStateProvider initialPreferences={DEFAULT_TRACE_VIEW_PREFERENCES}>
         <MissingInstrumentationNodeDetails
-          node={node as any}
+          node={node}
           organization={organization}
           onTabScrollToNode={jest.fn()}
           onParentClick={jest.fn()}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.spec.tsx
@@ -77,7 +77,7 @@ describe('SpanNodeDetails', () => {
     render(
       <TraceStateProvider initialPreferences={DEFAULT_TRACE_VIEW_PREFERENCES}>
         <EAPSpanNodeDetails
-          node={node as any}
+          node={node}
           organization={organization}
           onTabScrollToNode={jest.fn()}
           onParentClick={jest.fn()}
@@ -116,7 +116,7 @@ describe('SpanNodeDetails', () => {
     render(
       <TraceStateProvider initialPreferences={DEFAULT_TRACE_VIEW_PREFERENCES}>
         <SpanNodeDetails
-          node={node as any}
+          node={node}
           organization={organization}
           onTabScrollToNode={jest.fn()}
           onParentClick={jest.fn()}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/index.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/index.spec.tsx
@@ -70,7 +70,7 @@ describe('TransactionNodeDetails', () => {
     render(
       <TraceStateProvider initialPreferences={DEFAULT_TRACE_VIEW_PREFERENCES}>
         <TransactionNodeDetails
-          node={node as any}
+          node={node}
           organization={organization}
           onTabScrollToNode={jest.fn()}
           onParentClick={jest.fn()}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/uptime/index.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/uptime/index.spec.tsx
@@ -55,7 +55,7 @@ describe('UptimeNodeDetails', () => {
     render(
       <TraceStateProvider initialPreferences={DEFAULT_TRACE_VIEW_PREFERENCES}>
         <UptimeNodeDetails
-          node={node as any}
+          node={node}
           organization={organization}
           onTabScrollToNode={jest.fn()}
           onParentClick={jest.fn()}

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.incremental.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.incremental.spec.tsx
@@ -1,4 +1,3 @@
-import type {Location} from 'history';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {waitFor} from 'sentry-test/reactTestingLibrary';
@@ -76,7 +75,7 @@ describe('incremental trace fetch', () => {
       filters: {},
       organization,
       rerender: () => {},
-      urlParams: {} as Location['query'],
+      urlParams: {},
       type: 'non-eap',
       meta: null,
     });
@@ -150,7 +149,7 @@ describe('incremental trace fetch', () => {
       filters: {},
       organization,
       rerender: () => {},
-      urlParams: {} as Location['query'],
+      urlParams: {},
       type: 'non-eap',
       meta: null,
     });
@@ -237,7 +236,7 @@ describe('incremental trace fetch', () => {
       filters: {},
       organization,
       rerender: () => {},
-      urlParams: {} as Location['query'],
+      urlParams: {},
       type: 'eap',
       meta: null,
     });
@@ -317,7 +316,7 @@ describe('incremental trace fetch', () => {
       filters: {},
       organization,
       rerender: () => {},
-      urlParams: {} as Location['query'],
+      urlParams: {},
       type: 'eap',
       meta: null,
     });

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/parentAutogroupNode.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/parentAutogroupNode.spec.tsx
@@ -465,7 +465,7 @@ describe('ParentAutogroupNode', () => {
       );
 
       const tree = createMockTraceTree();
-      tree.list = [node as any];
+      tree.list = [node];
 
       node.expanded = false; // Start collapsed
       const result = node.expand(true, tree);
@@ -502,7 +502,7 @@ describe('ParentAutogroupNode', () => {
       );
 
       const tree = createMockTraceTree();
-      tree.list = [node as any];
+      tree.list = [node];
 
       node.expanded = true; // Start expanded
       const result = node.expand(false, tree);

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/spanNode.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/spanNode.spec.tsx
@@ -223,7 +223,7 @@ describe('SpanNode', () => {
 
     it('should handle missing op with fallback', () => {
       const span = makeSpan({
-        op: undefined as any,
+        op: undefined,
         description: 'Some description',
       });
       const node = new SpanNode(null, span, createMockExtra());

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/transactionNode.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/transactionNode.spec.tsx
@@ -56,7 +56,7 @@ describe('TransactionNode', () => {
       );
 
       const child = new TransactionNode(
-        parent as any,
+        parent,
         makeTransaction({start_timestamp: 500}),
         createMockExtra()
       );
@@ -361,7 +361,7 @@ describe('TransactionNode', () => {
 
     it('should handle missing transaction with fallback', () => {
       const transaction = makeTransaction({
-        transaction: undefined as any,
+        transaction: undefined,
         'transaction.op': 'http.server',
       });
       const node = new TransactionNode(null, transaction, createMockExtra());
@@ -372,7 +372,7 @@ describe('TransactionNode', () => {
     it('should handle missing operation with fallback', () => {
       const transaction = makeTransaction({
         transaction: 'GET /api/users',
-        'transaction.op': undefined as any,
+        'transaction.op': undefined,
       });
       const node = new TransactionNode(null, transaction, createMockExtra());
 

--- a/static/app/views/performance/newTraceDetails/traceRenderers/traceScheduler.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/traceScheduler.tsx
@@ -76,9 +76,7 @@ export class TraceScheduler {
       return;
     }
 
-    (this.events as any)[eventName] = arr.filter(a => a[1] !== cb) as unknown as Array<
-      [TraceEventPriority, K]
-    >;
+    (this.events as any)[eventName] = arr.filter(a => a[1] !== cb);
   }
 
   dispatch<K extends keyof TraceEvents>(

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
@@ -134,7 +134,7 @@ describe('VirtualizedViewManger', () => {
       width: 520,
       height: 238,
       toJSON: () => ({}),
-    } as DOMRect);
+    });
 
     let dispatchedContainerPhysicalSpace: [number, number, number, number] | null = null;
     scheduler.on('set container physical space', containerPhysicalSpace => {
@@ -1389,7 +1389,7 @@ describe('VirtualizedViewManger', () => {
           }
           return compressedOffset + removedDuration;
         },
-      } as TraceTimeCompression;
+      };
       manager.recomputeSpanToPXMatrix();
 
       const markerRef = document.createElement('div');

--- a/static/app/views/performance/newTraceDetails/traceRow/traceEAPSpanRow.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceEAPSpanRow.tsx
@@ -44,8 +44,8 @@ function getAIEnhancedDescription(node: EapSpanNode): string | undefined {
   }
 
   if (opType === GenAiOperationType.TOOL) {
-    const toolName = getStringAttr(node as any, SpanFields.GEN_AI_TOOL_NAME);
-    const inputPreview = getToolInputPreview(node as any);
+    const toolName = getStringAttr(node, SpanFields.GEN_AI_TOOL_NAME);
+    const inputPreview = getToolInputPreview(node);
     if (toolName && inputPreview) {
       return `${toolName}: ${inputPreview}`;
     }
@@ -53,7 +53,7 @@ function getAIEnhancedDescription(node: EapSpanNode): string | undefined {
   }
 
   if (opType === GenAiOperationType.AI_CLIENT) {
-    const responseModel = getStringAttr(node as any, SpanFields.GEN_AI_RESPONSE_MODEL);
+    const responseModel = getStringAttr(node, SpanFields.GEN_AI_RESPONSE_MODEL);
     return responseModel ?? undefined;
   }
 

--- a/static/app/views/performance/transactionSummary/transactionEvents/eapSampledEventsTab.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eapSampledEventsTab.tsx
@@ -89,7 +89,7 @@ export function EAPSampledEventsTab() {
       'performance_views.transactionEvents.display_filter_dropdown.selection',
       {
         organization,
-        action: newFilterName as string,
+        action: newFilterName,
       }
     );
 

--- a/static/app/views/performance/transactionSummary/transactionReplays/useReplaysFromTransaction.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/useReplaysFromTransaction.tsx
@@ -64,8 +64,6 @@ export function useReplaysFromTransaction({
         `/organizations/${organization.slug}/events/`,
         replayIdsEventView.getEventsAPIPayload({
           query: {cursor},
-          // Will be fixed by https://github.com/typescript-eslint/typescript-eslint/pull/12206
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
         } as Location<ReplayListLocationQuery>)
       );
 

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -173,8 +173,6 @@ export default function SnapshotsPage() {
 
   const pushHistory = {history: 'push' as const};
   const palette = theme.chart.getColorPalette(10);
-  // Will be fixed by https://github.com/typescript-eslint/typescript-eslint/pull/12206
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
   const [overlayColor, setOverlayColor] = useLocalStorageState<string>(
     'snapshot-overlay-color',
     palette.at(-3) ?? palette[0]

--- a/static/app/views/preprod/types/appSizeTypes.ts
+++ b/static/app/views/preprod/types/appSizeTypes.ts
@@ -138,11 +138,11 @@ export interface FileSavingsResultGroup {
   total_savings: number;
 }
 
-export interface FilesInsightResult extends BaseInsightResult {
+interface FilesInsightResult extends BaseInsightResult {
   files: FileSavingsResult[];
 }
 
-export interface GroupsInsightResult extends BaseInsightResult {
+interface GroupsInsightResult extends BaseInsightResult {
   groups: FileSavingsResultGroup[];
 }
 

--- a/static/app/views/preprod/utils/insightProcessing.ts
+++ b/static/app/views/preprod/utils/insightProcessing.ts
@@ -2,8 +2,6 @@ import {t} from 'sentry/locale';
 import type {
   FileSavingsResult,
   FileSavingsResultGroup,
-  FilesInsightResult,
-  GroupsInsightResult,
   InsightResults,
   OptimizableImageFile,
   StripBinaryFileInfo,
@@ -273,7 +271,7 @@ export function processInsights(
   }
 
   if (insights.duplicate_files?.total_savings) {
-    const insight = insights.duplicate_files as GroupsInsightResult;
+    const insight = insights.duplicate_files;
     const config = INSIGHT_CONFIGS.find(c => c.key === 'duplicate_files');
     if (config) {
       const groups = Array.isArray(insight.groups) ? insight.groups : [];
@@ -323,7 +321,7 @@ export function processInsights(
   }
 
   if (insights.loose_images?.total_savings) {
-    const insight = insights.loose_images as GroupsInsightResult;
+    const insight = insights.loose_images;
     const config = INSIGHT_CONFIGS.find(c => c.key === 'loose_images');
     if (config) {
       const groups = Array.isArray(insight.groups) ? insight.groups : [];
@@ -364,7 +362,7 @@ export function processInsights(
   ] as const;
 
   regularInsightKeys.forEach(key => {
-    const insight = insights[key] as FilesInsightResult | undefined;
+    const insight = insights[key];
     if (insight?.total_savings) {
       const config = INSIGHT_CONFIGS.find(c => c.key === key);
       if (config) {

--- a/static/app/views/projectInstall/messagingIntegrationAlertRule.spec.tsx
+++ b/static/app/views/projectInstall/messagingIntegrationAlertRule.spec.tsx
@@ -444,7 +444,7 @@ describe('useMessagingIntegrationAlertRule channel label reconciliation', () => 
           setIntegration: jest.fn(),
           setProvider: jest.fn(),
           ...props,
-        } as IssueAlertNotificationProps),
+        }),
       {organization}
     );
   }
@@ -526,7 +526,7 @@ describe('useMessagingIntegrationAlertRule change analytics', () => {
             setChannel: jest.fn(),
             setIntegration: jest.fn(),
             setProvider: jest.fn(),
-          } as IssueAlertNotificationProps,
+          },
           variant
         ),
       {organization}

--- a/static/app/views/seerExplorer/components/prWidget.tsx
+++ b/static/app/views/seerExplorer/components/prWidget.tsx
@@ -315,7 +315,7 @@ export function PRWidget({
   }
 
   return (
-    <Button ref={ref as any} onClick={onToggleMenu}>
+    <Button ref={ref} onClick={onToggleMenu}>
       <Flex align="center" gap="md">
         <Flex>
           <Text variant="success" monospace>

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -239,8 +239,6 @@ export const useSeerExplorer = () => {
     onError: (e, params) => {
       if (params.runId !== null) {
         // API data is disabled for null runId (new runs).
-        // Will be fixed soon when we get rid of setApiQueryData.
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
         setApiQueryData<SeerExplorerResponse>(
           queryClient,
           makeSeerExplorerQueryKey(params.orgSlug, params.runId),
@@ -308,8 +306,6 @@ export const useSeerExplorer = () => {
       if (params.runId !== null) {
         // API data is disabled for null runId (new runs).
 
-        // Will be fixed soon when we get rid of setApiQueryData.
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
         setApiQueryData<SeerExplorerResponse>(
           queryClient,
           makeSeerExplorerQueryKey(params.orgSlug, params.runId),

--- a/static/app/views/seerWorkflows/overview/cardAction.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/cardAction.spec.tsx
@@ -9,7 +9,6 @@ import type {
   AutofixStateKey,
   CardAction,
   OverviewRow,
-  RunStatus,
 } from 'sentry/views/seerWorkflows/overview/types';
 
 function makeRow(overrides: Partial<OverviewRow> = {}): OverviewRow {
@@ -91,10 +90,10 @@ describe('IssuePrimaryAction', () => {
   });
 
   it.each([
-    {runStatus: 'processing' as RunStatus, overlay: 'Running'},
-    {runStatus: 'error' as RunStatus, overlay: 'Retry'},
-    {runStatus: 'awaiting_user_input' as RunStatus, overlay: 'Add context'},
-  ])(
+    {runStatus: 'processing', overlay: 'Running'},
+    {runStatus: 'error', overlay: 'Retry'},
+    {runStatus: 'awaiting_user_input', overlay: 'Add context'},
+  ] as const)(
     'paints the $overlay overlay over the section action when the run is $runStatus',
     ({runStatus, overlay}) => {
       // A review_pr card (section anchor) whose live run is mid-flight: the
@@ -168,17 +167,17 @@ describe('IssuePrimaryAction', () => {
 
   it.each([
     {
-      action: {type: 'code_changes_ready'} as CardAction,
+      action: {type: 'code_changes_ready'},
       label: 'Draft PR',
       row: makeRow({runStatus: 'completed'}),
     },
     {
-      action: {type: 'solution_ready'} as CardAction,
+      action: {type: 'solution_ready'},
       label: 'Generate code',
       row: makeRow({runStatus: 'completed'}),
     },
     {
-      action: {type: 'needs_investigation'} as CardAction,
+      action: {type: 'needs_investigation'},
       label: 'Create Plan',
       row: makeRow({runStatus: 'completed'}),
     },
@@ -187,21 +186,21 @@ describe('IssuePrimaryAction', () => {
         type: 'review_pr',
         prUrl: undefined,
         prNumber: undefined,
-      } as CardAction,
+      },
       label: 'Review PR',
       row: makeRow({runStatus: 'completed'}),
     },
     {
-      action: {type: 'needs_investigation'} as CardAction,
+      action: {type: 'needs_investigation'},
       label: 'Retry',
       row: makeRow({runStatus: 'error'}),
     },
     {
-      action: {type: 'needs_investigation'} as CardAction,
+      action: {type: 'needs_investigation'},
       label: 'Add context',
       row: makeRow({runStatus: 'awaiting_user_input'}),
     },
-  ])(
+  ] as const)(
     'links the $label action to the issue when inline opening is unavailable',
     ({action, label, row}) => {
       renderAction(action, row, {inline: false});

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -133,12 +133,12 @@ describe('AutofixOverview', () => {
       observe(target: Element) {
         this.callback(
           [{target, isIntersecting: true} as IntersectionObserverEntry],
-          this as unknown as IntersectionObserver
+          this
         );
       }
       unobserve() {}
       disconnect() {}
-    } as unknown as typeof IntersectionObserver;
+    };
   });
   afterAll(() => {
     window.IntersectionObserver = OriginalIntersectionObserver;

--- a/static/app/views/seerWorkflows/overview/types.ts
+++ b/static/app/views/seerWorkflows/overview/types.ts
@@ -50,7 +50,7 @@ export type OverviewView = 'cards' | 'table';
 // Live run status, mirrored straight from ExplorerAutofixState.status. Drives
 // the transient card overlays (Running / Retry / Add context), never the
 // section-driven primary action.
-export type RunStatus = 'processing' | 'completed' | 'error' | 'awaiting_user_input';
+type RunStatus = 'processing' | 'completed' | 'error' | 'awaiting_user_input';
 
 // The primary action a card offers, derived from its section. review_pr carries
 // the linked PR so it can offer the external review button.

--- a/static/app/views/settings/account/apiApplications/details.tsx
+++ b/static/app/views/settings/account/apiApplications/details.tsx
@@ -117,8 +117,6 @@ function ApiApplicationsDetails() {
 
   const onSaveError = () => addErrorMessage(t('Unable to save change'));
   const onSaveSuccess = (updated: ApiApplication) => {
-    // Will be fixed soon when we get rid of setApiQueryData.
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
     setApiQueryData<ApiApplication>(queryClient, getAppQueryKey(appId), updated);
     addSuccessMessage(t('Changes applied.'));
   };

--- a/static/app/views/settings/account/apiTokens.tsx
+++ b/static/app/views/settings/account/apiTokens.tsx
@@ -73,8 +73,6 @@ function ApiTokens() {
       addErrorMessage(t('Unable to remove token. Please try again.'));
 
       if (context?.previous) {
-        // Will be fixed soon when we get rid of setApiQueryData.
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
         setApiQueryData<InternalAppApiToken[]>(
           queryClient,
           API_TOKEN_QUERY_KEY,

--- a/static/app/views/settings/account/mergeAccounts.tsx
+++ b/static/app/views/settings/account/mergeAccounts.tsx
@@ -84,8 +84,6 @@ function MergeAccounts() {
     onSuccess: data => {
       addSuccessMessage(t('Accounts merged!'));
       setSelectedUserIds([]);
-      // Will be fixed soon when we get rid of setApiQueryData.
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
       setApiQueryData<UserWithOrganizations[]>(
         queryClient,
         makeMergeAccountsEndpointKey(),

--- a/static/app/views/settings/components/dataScrubbing/modals/form/attributeField.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/form/attributeField.tsx
@@ -8,7 +8,6 @@ import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {TextOverflow} from 'sentry/components/textOverflow';
 import {t} from 'sentry/locale';
-import type {TagCollection} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -92,7 +91,7 @@ export function AttributeField({
   });
   const [suggestedAttributeValues, setSuggestedAttributeValues] = useLocalStorageState(
     `advanced-data-scrubbing.suggested-attribute-values:v3:${projectId ? projectId : 'all'}`,
-    {} as TagCollection
+    {}
   );
 
   const traceItemFieldSelector = TraceItemFieldSelector.fromSourceString(value);

--- a/static/app/views/settings/organizationDataForwarding/util/hooks.tsx
+++ b/static/app/views/settings/organizationDataForwarding/util/hooks.tsx
@@ -94,7 +94,7 @@ export function useDeleteDataForwarder({
         makeDataForwarderMutationQueryKey({
           dataForwarderId: dfId,
           orgSlug: os,
-        })[0] as string,
+        })[0],
         {method: 'DELETE'}
       ),
     onSuccess: () => {

--- a/static/app/views/settings/organizationIntegrations/installedIntegration.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/installedIntegration.spec.tsx
@@ -86,11 +86,9 @@ describe('InstalledIntegration', () => {
     render(
       <InstalledIntegration
         {...defaultProps}
-        integration={
-          OrganizationIntegrationsFixture({
-            organizationIntegrationStatus: 'disabled',
-          }) as any
-        }
+        integration={OrganizationIntegrationsFixture({
+          organizationIntegrationStatus: 'disabled',
+        })}
         requiresUpgrade
       />
     );

--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
@@ -307,7 +307,6 @@ export default function IntegrationDetailedView() {
     },
     onError: (_error, _integration, context) => {
       if (context?.previousConfigurations) {
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
         setApiQueryData<Integration[]>(
           queryClient,
           makeIntegrationQueryKey({orgSlug: organization.slug, integrationSlug}),

--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
@@ -19,7 +19,6 @@ import {PanelItem} from 'sentry/components/panels/panelItem';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {PluginIcon} from 'sentry/icons/pluginIcon';
 import {t} from 'sentry/locale';
-import type {ObjectStatus} from 'sentry/types/core';
 import type {Integration, IntegrationProvider} from 'sentry/types/integrations';
 import type {Organization} from 'sentry/types/organization';
 import type {ApiQueryKey} from 'sentry/utils/api/apiQueryKey';
@@ -297,7 +296,7 @@ export default function IntegrationDetailedView() {
           config.id === integration.id
             ? {
                 ...config,
-                organizationIntegrationStatus: 'pending_deletion' as ObjectStatus,
+                organizationIntegrationStatus: 'pending_deletion',
               }
             : config
         )

--- a/static/app/views/settings/organizationIntegrations/integrationExternalMappings.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationExternalMappings.tsx
@@ -71,8 +71,6 @@ export function IntegrationExternalMappings(props: Props) {
   >([]);
 
   const organization = useOrganization();
-  // Will be fixed by https://github.com/typescript-eslint/typescript-eslint/pull/12206
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
   const location = useLocation<LocationQuery>();
   const {cursor} = location.query;
   const isFirstPage = cursor ? cursor.split(':')[1] === '0' : true;

--- a/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
@@ -109,8 +109,6 @@ function OrganizationMemberDetailContent({member}: {member: Member}) {
     },
     onSuccess: data => {
       addSuccessMessage(t('Saved'));
-      // Will be fixed soon when we get rid of setApiQueryData.
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
       setApiQueryData<Member>(
         queryClient,
         getMemberQueryKey(organization.slug, member.id),
@@ -136,8 +134,6 @@ function OrganizationMemberDetailContent({member}: {member: Member}) {
       onSuccess: data => {
         addSuccessMessage(t('Sent invite!'));
 
-        // Will be fixed soon when we get rid of setApiQueryData.
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
         setApiQueryData<Member>(
           queryClient,
           getMemberQueryKey(organization.slug, member.id),

--- a/static/app/views/settings/project/preprod/useSizeRules.ts
+++ b/static/app/views/settings/project/preprod/useSizeRules.ts
@@ -96,14 +96,17 @@ export function useSizeRules(project: DetailedProject, config: SizeRulesConfig) 
   const setEnabled = useCallback(
     (value: boolean) => {
       addLoadingMessage(t('Saving...'));
-      updateProject.mutate({[config.enabledField]: value} as Partial<DetailedProject>, {
-        onSuccess: () => {
-          addSuccessMessage(value ? config.toasts.enabled : config.toasts.disabled);
-        },
-        onError: () => {
-          addErrorMessage(t('Failed to save changes. Please try again.'));
-        },
-      });
+      updateProject.mutate(
+        {[config.enabledField]: value},
+        {
+          onSuccess: () => {
+            addSuccessMessage(value ? config.toasts.enabled : config.toasts.disabled);
+          },
+          onError: () => {
+            addErrorMessage(t('Failed to save changes. Please try again.'));
+          },
+        }
+      );
     },
     [updateProject, config.enabledField, config.toasts]
   );
@@ -112,7 +115,7 @@ export function useSizeRules(project: DetailedProject, config: SizeRulesConfig) 
     (newRules: StatusCheckRule[], successMessage?: string) => {
       addLoadingMessage(t('Saving...'));
       updateProject.mutate(
-        {[config.rulesField]: newRules as unknown[]} as Partial<DetailedProject>,
+        {[config.rulesField]: newRules as unknown[]},
         {
           onSuccess: () => {
             if (successMessage) {

--- a/static/app/views/settings/project/projectKeys/details/index.tsx
+++ b/static/app/views/settings/project/projectKeys/details/index.tsx
@@ -44,8 +44,6 @@ export default function ProjectKeyDetails() {
   );
 
   function onDataChange(data: ProjectKey) {
-    // Will be fixed soon when we get rid of setApiQueryData.
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
     setApiQueryData<ProjectKey>(
       queryClient,
       [

--- a/static/app/views/settings/projectDebugFiles/index.tsx
+++ b/static/app/views/settings/projectDebugFiles/index.tsx
@@ -176,7 +176,7 @@ export default function ProjectDebugSymbols() {
                 <Checkbox
                   checked={showDetails}
                   onChange={e => {
-                    setShowDetails((e.target as HTMLInputElement).checked);
+                    setShowDetails(e.target.checked);
                   }}
                 />
                 {t('show details')}

--- a/static/app/views/settings/projectSourceMaps/sourceMapsDetails.tsx
+++ b/static/app/views/settings/projectSourceMaps/sourceMapsDetails.tsx
@@ -41,7 +41,7 @@ enum DebugIdBundleArtifactType {
   INDEXED_RAM_BUNDLE = 4,
 }
 
-const debugIdBundleTypeLabels = {
+const debugIdBundleTypeLabels: Record<number, string> = {
   [DebugIdBundleArtifactType.INVALID]: t('Invalid'),
   [DebugIdBundleArtifactType.SOURCE]: t('Source'),
   [DebugIdBundleArtifactType.MINIFIED_SOURCE]: t('Minified'),
@@ -285,9 +285,7 @@ export function SourceMapsDetails({bundleId, project}: Props) {
                   key={data.id}
                   size={data.fileSize}
                   name={data.filePath}
-                  type={
-                    debugIdBundleTypeLabels[data.fileType as DebugIdBundleArtifactType]
-                  }
+                  type={debugIdBundleTypeLabels[data.fileType]}
                   downloadUrl={downloadUrl}
                   orgSlug={organization.slug}
                   artifactColumnDetails={

--- a/static/app/views/setupWizard/utils/useOrganizationsWithRegion.tsx
+++ b/static/app/views/setupWizard/utils/useOrganizationsWithRegion.tsx
@@ -39,7 +39,7 @@ export function useOrganizationsWithRegion() {
           });
           return [];
         }
-        return [{...org, region: locality} as OrganizationSummaryWithLocality];
+        return [{...org, region: locality}];
       });
     },
   });

--- a/static/gsAdmin/components/resultGrid.spec.tsx
+++ b/static/gsAdmin/components/resultGrid.spec.tsx
@@ -11,7 +11,7 @@ function setupCells() {
   ConfigStore.set('cells', [
     {name: 'us', locality_url: US_URL},
     {name: 'de', locality_url: DE_URL},
-  ] as any);
+  ]);
 }
 
 function renderGrid(

--- a/static/gsAdmin/views/invoiceDetails.tsx
+++ b/static/gsAdmin/views/invoiceDetails.tsx
@@ -66,8 +66,6 @@ export function InvoiceDetails() {
   const isDeleted = customer.isDeleted;
 
   const updateCache = (updatedInvoice: Invoice) => {
-    // Will be fixed soon when we get rid of setApiQueryData.
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
     setApiQueryData<Invoice>(queryClient, QUERY_KEY, updatedInvoice);
   };
 

--- a/static/gsAdmin/views/promoCodeDetails.tsx
+++ b/static/gsAdmin/views/promoCodeDetails.tsx
@@ -136,8 +136,6 @@ export function PromoCodeDetails() {
                 {...deps}
                 promoCode={promoCode}
                 onSubmit={(newCode: PromoCode) => {
-                  // Will be fixed soon when we get rid of setApiQueryData.
-                  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
                   setApiQueryData<PromoCode>(queryClient, [ENDPOINT], newCode);
                 }}
               />

--- a/static/gsAdmin/views/relocationDetails.tsx
+++ b/static/gsAdmin/views/relocationDetails.tsx
@@ -132,7 +132,7 @@ const getArtifactRow = (row: RelocationArtifact) => [
 const getOrgRow = (row: Organization) => [
   <td key="customer">
     <CustomerName>
-      <OrganizationAvatar size={36} organization={row as any} />
+      <OrganizationAvatar size={36} organization={row} />
       <div>
         <strong>
           <Link to={`/_admin/customers/${row.slug}/`}>{row.name}</Link>

--- a/static/gsApp/components/ai/aiConfigureSeerQuotaSidebar.spec.tsx
+++ b/static/gsApp/components/ai/aiConfigureSeerQuotaSidebar.spec.tsx
@@ -115,7 +115,7 @@ describe('AiConfigureSeerQuotaSidebar', () => {
 
   it('renders upsell card with disabled button when user lacks billing permissions', () => {
     const organization = OrganizationFixture({
-      access: [] as any,
+      access: [],
     });
     const subscription = SubscriptionFixture({organization, canSelfServe: false});
     act(() => SubscriptionStore.set(organization.slug, subscription));

--- a/static/gsApp/components/billingDetails/form.spec.tsx
+++ b/static/gsApp/components/billingDetails/form.spec.tsx
@@ -58,8 +58,8 @@ describe('BillingDetailsForm', () => {
 
   it('shows warning when Stripe hooks return null', async () => {
     const stripeImport = await import('@stripe/react-stripe-js');
-    jest.spyOn(stripeImport, 'useStripe').mockReturnValue(null as any);
-    jest.spyOn(stripeImport, 'useElements').mockReturnValue(null as any);
+    jest.spyOn(stripeImport, 'useStripe').mockReturnValue(null);
+    jest.spyOn(stripeImport, 'useElements').mockReturnValue(null);
 
     render(<BillingDetailsForm {...defaultProps} />);
 

--- a/static/gsApp/components/creditCardEdit/intentForms/innerIntentForm.spec.tsx
+++ b/static/gsApp/components/creditCardEdit/intentForms/innerIntentForm.spec.tsx
@@ -40,8 +40,8 @@ describe('InnerIntentForm', () => {
     jest.useFakeTimers();
 
     const stripeImport = await import('@stripe/react-stripe-js');
-    jest.spyOn(stripeImport, 'useStripe').mockReturnValue(null as any);
-    jest.spyOn(stripeImport, 'useElements').mockReturnValue(null as any);
+    jest.spyOn(stripeImport, 'useStripe').mockReturnValue(null);
+    jest.spyOn(stripeImport, 'useElements').mockReturnValue(null);
 
     render(<InnerIntentForm {...defaultProps} />);
 

--- a/static/gsApp/overrides/dashboardsLimit.spec.tsx
+++ b/static/gsApp/overrides/dashboardsLimit.spec.tsx
@@ -294,7 +294,7 @@ describe('useDashboardsLimit', () => {
   it('handles missing subscription planDetails gracefully (defaults to 10)', async () => {
     const subscription = SubscriptionFixture({
       organization: mockOrganization,
-      planDetails: undefined as any,
+      planDetails: undefined,
     });
 
     SubscriptionStore.set(mockOrganization.slug, subscription);

--- a/static/gsApp/stores/trialRequestedStore.tsx
+++ b/static/gsApp/stores/trialRequestedStore.tsx
@@ -8,12 +8,13 @@ type State = {
 
 type TrialRequestedStoreInterface = {
   getTrialRequstedState: () => State['requested'];
+  state: State;
 };
 
 const storeConfig: Reflux.StoreDefinition & TrialRequestedStoreInterface = {
   state: {
     requested: false,
-  } as State,
+  },
 
   init() {
     this.listenTo(TrialRequestedActions.requested, this.onRequested);

--- a/static/gsApp/utils/dataCategory.tsx
+++ b/static/gsApp/utils/dataCategory.tsx
@@ -41,8 +41,7 @@ export function getCategoryInfoFromPlural(
  */
 export function getCreditDataCategory(credit: RecurringCredit): DataCategory | null {
   const category =
-    (DATA_CATEGORY_INFO[credit.type as string as DataCategoryExact]
-      ?.plural as DataCategory) || null;
+    DATA_CATEGORY_INFO[credit.type as string as DataCategoryExact]?.plural || null;
   if (!category) {
     return null;
   }

--- a/static/gsApp/views/amCheckout/index.tsx
+++ b/static/gsApp/views/amCheckout/index.tsx
@@ -500,7 +500,7 @@ function AMCheckout(props: Props) {
       if (!isEqual(validData.reserved, data.reserved)) {
         Sentry.withScope(scope => {
           scope.setExtras({validData, updatedData, previous: formData});
-          scope.setLevel('warning' as any);
+          scope.setLevel('warning');
           Sentry.captureException(new Error('Plan event levels do not match'));
         });
       }

--- a/static/gsApp/views/subscriptionPage/reservedUsageChart.tsx
+++ b/static/gsApp/views/subscriptionPage/reservedUsageChart.tsx
@@ -387,7 +387,7 @@ export function mapStatsToChart({
           other: sumOther,
           overQuota: sumOverQuota,
           spikeProtection: sumSpikeProtection,
-        } as DroppedBreakdown,
+        },
       });
     }
   });

--- a/tests/js/sentry-test/initializeOrg.tsx
+++ b/tests/js/sentry-test/initializeOrg.tsx
@@ -70,7 +70,7 @@ export function initializeOrg<RouterParams = {orgId: string; projectId: string}>
    */
   const routerProps: RouteComponentProps<RouterParams> = {
     params: router.params as any,
-    routeParams: router.params as any,
+    routeParams: router.params,
     router,
     route: router.routes[0]!,
     routes: router.routes,

--- a/tests/js/sentry-test/reactTestingLibrary.tsx
+++ b/tests/js/sentry-test/reactTestingLibrary.tsx
@@ -417,7 +417,7 @@ function renderHookWithProviders<Result = unknown, Props = unknown>(
 
   const {initialProps, ...rest} = options;
 
-  const hookResult = rtl.renderHook(callback as (initialProps: Props) => Result, {
+  const hookResult = rtl.renderHook(callback, {
     ...(rest as Omit<rtl.RenderHookOptions<Props>, 'wrapper'>),
     initialProps,
     wrapper: Wrapper,

--- a/tests/js/sentry-test/snapshots/snapshot-setup.ts
+++ b/tests/js/sentry-test/snapshots/snapshot-setup.ts
@@ -35,7 +35,7 @@ if (globalThis.window === undefined) {
     requestAnimationFrame: (cb: () => void) => setTimeout(cb, 0),
   } as any;
 
-  globalThis.localStorage = localStorageShim as unknown as Storage;
+  globalThis.localStorage = localStorageShim;
 }
 
 // CompactSelect and other core components call `CSS.escape` during render, but

--- a/tests/js/setup.ts
+++ b/tests/js/setup.ts
@@ -318,7 +318,7 @@ declare global {
 }
 
 // needed by cbor-web for webauthn
-window.TextEncoder = TextEncoder as typeof window.TextEncoder;
+window.TextEncoder = TextEncoder;
 window.TextDecoder = TextDecoder as typeof window.TextDecoder;
 
 // This is so we can use async/await in tests instead of wrapping with `setTimeout`.


### PR DESCRIPTION
looks huge, but is actually just two things:

1) remove unnecessary `eslint-disable-line` because ts-eslint got better: 84180a13
2) auto-fix (mostly) `no-unnecessary-type-assertion`: 540ab09d
The rule had an overhaul with regards to assignability (https://github.com/typescript-eslint/typescript-eslint/pull/11789) which left some false positives that were either worked around manually with `as const satisfies ...` or disabled inline. Might be worth raising back upstream (@JoshuaKGoldberg FYI)