### PR TITLE
perf(dynamic-sampling): Interleave organization scheduler order

### DIFF
--- a/src/sentry/dynamic_sampling/per_org/scheduler.py
+++ b/src/sentry/dynamic_sampling/per_org/scheduler.py
@@ -4,7 +4,8 @@ import logging
 from datetime import timedelta
 
 import sentry_sdk
-from django.db.models import Exists, OuterRef
+from django.db.models import Exists, F, OuterRef
+from django.db.models.functions import Mod
 from taskbroker_client.retry import Retry
 
 from sentry.constants import ObjectStatus
@@ -253,10 +254,13 @@ def schedule_per_org_calculations() -> None:
                 )
             ),
             status=OrganizationStatus.ACTIVE,
-        ),
+        )
+        .annotate(_order_bucket=Mod(F("id"), 10))
+        .order_by("_order_bucket", "id"),
         task=run_calculations_per_org_task_entry,
         cycle_duration=CYCLE_DURATION,
         validate_item=validate_and_track,
+        preserve_queryset_order=True,
     )
     scheduler.tick()
 

--- a/src/sentry/utils/cursored_scheduler.py
+++ b/src/sentry/utils/cursored_scheduler.py
@@ -52,6 +52,10 @@ Optional validate_item callback:
 
 When provided, validate_item is called for each PK before dispatching.
 Items that fail validation are skipped without dispatching the task.
+
+By default, the scheduler snapshots PKs in ascending PK order. Set
+preserve_queryset_order=True to retain an explicit, deterministic ordering on
+the queryset instead.
 """
 
 from __future__ import annotations
@@ -125,7 +129,9 @@ class CursoredScheduler[M: Model]:
     Batch size is auto-calculated at the start of each cycle based on the total
     row count, cycle_duration, and the tick interval from the schedule config,
     so that one full pass through the queryset completes within approximately
-    cycle_duration.
+    cycle_duration. By default, snapshots are ordered by PK. Set
+    preserve_queryset_order=True to retain an explicit, deterministic queryset
+    ordering instead.
     """
 
     def __init__(
@@ -138,6 +144,7 @@ class CursoredScheduler[M: Model]:
         lock_duration: int = DEFAULT_LOCK_DURATION_SECONDS,
         validate_item: Callable[[int], bool] | None = None,
         shuffle: bool = False,
+        preserve_queryset_order: bool = False,
     ):
         self.name = name
         self.schedule_key = schedule_key
@@ -154,6 +161,7 @@ class CursoredScheduler[M: Model]:
         self.lock_duration = lock_duration
         self.validate_item = validate_item
         self.shuffle = shuffle
+        self.preserve_queryset_order = preserve_queryset_order
         self._metric_tags = {"scheduler": name}
 
     @property
@@ -233,8 +241,11 @@ class CursoredScheduler[M: Model]:
 
     def _initialize_cycle(self) -> int:
         init_start = time.time()
+        queryset = self.queryset
+        if not self.preserve_queryset_order:
+            queryset = queryset.order_by("pk")
 
-        all_pks = list(self.queryset.order_by("pk").values_list("pk", flat=True))
+        all_pks = list(queryset.values_list("pk", flat=True))
 
         if self.shuffle:
             random.shuffle(all_pks)

--- a/tests/sentry/utils/test_cursored_scheduler.py
+++ b/tests/sentry/utils/test_cursored_scheduler.py
@@ -489,6 +489,30 @@ class CursoredSchedulerTest(TestCase):
 
         assert all_dispatched == sorted_pks
 
+    def test_preserve_queryset_order(self):
+        """When enabled, preserve the queryset's explicit ordering in the PK snapshot."""
+        ois = self._create_org_integrations(30)
+        queryset = OrganizationIntegration.objects.filter(
+            integration__provider="github",
+            status=ObjectStatus.ACTIVE,
+        ).order_by("-pk")
+        scheduler = CursoredScheduler(
+            name="test_scheduler",
+            schedule_key="test-scheduler-beat",
+            queryset=queryset,
+            task=self.mock_task,
+            cycle_duration=timedelta(minutes=3),
+            preserve_queryset_order=True,
+        )
+
+        all_dispatched: list[int] = []
+        while scheduler.tick():
+            all_dispatched.extend(c.args[0] for c in self.mock_task.delay.call_args_list)
+            self.mock_task.reset_mock()
+        all_dispatched.extend(c.args[0] for c in self.mock_task.delay.call_args_list)
+
+        assert all_dispatched == [oi.pk for oi in reversed(ois)]
+
     def test_interval_decrease_halves_batch_size(self):
         """When tick interval is halved, batch size is halved for remaining items."""
         self._create_org_integrations(30)


### PR DESCRIPTION
The per-org scheduler currently snapshots organizations in ascending ID order. This can produce uneven task-dispatch bursts across a cycle.

Order the snapshot by `MOD(id, 10), id` instead. This interleaves stable ID buckets while preserving deterministic ordering as organizations are added. The database ordering adds roughly 0.5 seconds to the once-per-cycle snapshot query.

`CursoredScheduler` now supports preserving an explicit deterministic queryset order instead of imposing PK order.

Refs TET-2274
Refs TET-2679