### PR TITLE
fix(autofix): Drain queued CI feedback on green suites

### DIFF
--- a/src/sentry/seer/autofix/pr_iteration/listeners/check_suite.py
+++ b/src/sentry/seer/autofix/pr_iteration/listeners/check_suite.py
@@ -13,6 +13,7 @@ from sentry.seer.autofix.pr_iteration.check_suites import (
     GREEN_CONCLUSIONS,
     READY_FOR_REVIEW_EXTRA,
     REVIEW_REQUESTS_EXTRA,
+    check_suite_head_match,
     confirm_green_check_suite,
     resolve_green_check_suite,
 )
@@ -29,6 +30,45 @@ from sentry.seer.autofix.pr_iteration.run_markers import get_run_marker
 logger = logging.getLogger(__name__)
 
 
+def _trigger_queued_feedback_if_ci_complete(check_suite_event: CheckSuiteEvent) -> None:
+    """Schedule a queued-feedback consume once a green suite completes CI.
+
+    Failed check suites enqueue feedback while other checks can still be
+    running. ``should_trigger`` sweeps every check run for this head, so using
+    the completing green suite as the trigger schedules a consume only after
+    CI is complete. The green suite itself is not enqueued as feedback.
+    """
+    try:
+        raw = orjson.loads(check_suite_event.subscription_event["event"])
+        source = CheckSuiteFeedbackSource(event=raw)
+        autofix_run = source.autofix_run
+    except MissingCheckSuiteAutofixRun:
+        # Expected for check suites on PRs without an Autofix run.
+        return
+    except (orjson.JSONDecodeError, ValidationError, TypeError, ValueError) as e:
+        # Malformed webhook payload — report and drop; do not fail the listener task.
+        sentry_sdk.capture_exception(e)
+        return
+
+    # Unlike failed suites, this suite was not passed through ``should_queue``,
+    # so reject stale-head webhooks here. Otherwise a completed suite from an
+    # older commit could prematurely drain failure feedback for the current head.
+    if not check_suite_head_match(source.event, autofix_run.run_state).matched:
+        return
+
+    # Lazy: tasks.seer.pr_iteration → scm.factory → github → jira client
+    # which calls absolute_uri() at import time (needs options cache).
+    # stream.py is loaded in AppConfig.ready before options init.
+    from sentry.tasks.seer.pr_iteration import trigger_consume_pr_iteration_feedback
+
+    trigger_consume_pr_iteration_feedback(
+        run_id=autofix_run.run_state.run_id,
+        organization_id=autofix_run.repository.organization_id,
+        feedback=Feedback(source=source),
+        run_state=autofix_run.run_state,
+    )
+
+
 @scm_event_stream.listen_for(event_type="check_suite")
 def pr_iteration_from_check_suite_listener(check_suite_event: CheckSuiteEvent):
     if check_suite_event.action != "completed":
@@ -36,6 +76,11 @@ def pr_iteration_from_check_suite_listener(check_suite_event: CheckSuiteEvent):
 
     conclusion = check_suite_event.check_suite["conclusion"]
     if conclusion in GREEN_CONCLUSIONS:
+        # A green suite may be the last one to finish after a failed suite put
+        # feedback on the queue. Re-evaluate CI completion so that feedback can
+        # drain now rather than waiting for its delayed fallback task.
+        _trigger_queued_feedback_if_ci_complete(check_suite_event)
+
         # Cheap resolve → read markers once → skip SCM if both done → confirm
         # green → run only the missing side effects. Undraft before
         # review-request: GitHub may CODEOWNERS-request after undraft; see TODO

--- a/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
@@ -421,8 +421,21 @@ class TriggerQueuedFeedbackOnGreenCheckSuiteTest(TestCase):
         }
         event = CheckSuiteEvent(
             action="completed",
-            check_suite={"conclusion": "success"},
-            subscription_event={"event": orjson.dumps(raw).decode()},
+            check_suite={
+                "id": "1",
+                "status": "completed",
+                "conclusion": "success",
+                "html_url": "",
+                "pull_request_ids": [],
+            },
+            subscription_event={
+                "event": orjson.dumps(raw).decode(),
+                "event_type_hint": "check_suite",
+                "extra": {},
+                "received_at": 0,
+                "sentry_meta": None,
+                "type": "github",
+            },
         )
 
         _trigger_queued_feedback_if_ci_complete(event)
@@ -469,8 +482,21 @@ class TriggerQueuedFeedbackOnGreenCheckSuiteTest(TestCase):
         }
         event = CheckSuiteEvent(
             action="completed",
-            check_suite={"conclusion": "success"},
-            subscription_event={"event": orjson.dumps(raw).decode()},
+            check_suite={
+                "id": "1",
+                "status": "completed",
+                "conclusion": "success",
+                "html_url": "",
+                "pull_request_ids": [],
+            },
+            subscription_event={
+                "event": orjson.dumps(raw).decode(),
+                "event_type_hint": "check_suite",
+                "extra": {},
+                "received_at": 0,
+                "sentry_meta": None,
+                "type": "github",
+            },
         )
 
         _trigger_queued_feedback_if_ci_complete(event)

--- a/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
@@ -19,6 +19,7 @@ from sentry.seer.autofix.pr_iteration.feedback_sources.github_comment import (
 )
 from sentry.seer.autofix.pr_iteration.feedback_sources.user_ui import UserUIFeedbackSource
 from sentry.seer.autofix.pr_iteration.listeners.check_suite import (
+    _trigger_queued_feedback_if_ci_complete,
     pr_iteration_from_check_suite_listener,
 )
 from sentry.testutils.cases import TestCase
@@ -90,6 +91,7 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         pr_iteration_from_check_suite_listener(self._event(conclusion="cancelled"))
         mock_get_state.assert_not_called()
 
+    @patch(f"{CHECK_PATH}._trigger_queued_feedback_if_ci_complete")
     @patch(f"{CHECK_PATH}.get_run_marker", return_value=None)
     @patch(f"{CHECK_PATH}.request_review_from_context")
     @patch(f"{CHECK_PATH}.mark_ready_for_review")
@@ -104,6 +106,7 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         mock_mark_ready: MagicMock,
         mock_request_review: MagicMock,
         _mock_marker: MagicMock,
+        mock_trigger_queued: MagicMock,
     ) -> None:
         event = self._event(self._raw(), conclusion="success")
         resolved = MagicMock()
@@ -116,6 +119,7 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
 
         pr_iteration_from_check_suite_listener(event)
 
+        mock_trigger_queued.assert_called_once_with(event)
         mock_resolve.assert_called_once_with(event)
         mock_confirm.assert_called_once_with(resolved)
         mock_mark_ready.assert_called_once_with(ctx)
@@ -384,6 +388,94 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         _, kwargs = mock_enqueue.call_args
         assert kwargs["organization_id"] == self.organization.id
         mock_trigger_consume.assert_called_once()
+
+
+class TriggerQueuedFeedbackOnGreenCheckSuiteTest(TestCase):
+    @patch(TRIGGER_CONSUME_PATH)
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_autofix_run")
+    def test_uses_completed_green_suite_to_trigger_queued_feedback(
+        self, mock_resolve: MagicMock, mock_trigger_consume: MagicMock
+    ) -> None:
+        state = SeerRunState(
+            run_id=67890,
+            blocks=[],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+            repo_pr_states={"owner/repo": RepoPRState(repo_name="owner/repo", commit_sha="abc")},
+        )
+        repository = MagicMock(organization_id=self.organization.id)
+        mock_resolve.return_value = CheckSuiteAutofixRun(
+            repository=repository, run_state=state, pr_id=1, group_id=1
+        )
+        raw = {
+            "check_suite": {
+                "id": 1,
+                "head_sha": "abc",
+                "check_runs_url": "https://github.com/owner/repo/check-runs",
+                "app": {"name": "CI"},
+            },
+            "repository": {
+                "html_url": "https://github.com/owner/repo",
+                "full_name": "owner/repo",
+            },
+        }
+        event = CheckSuiteEvent(
+            action="completed",
+            check_suite={"conclusion": "success"},
+            subscription_event={"event": orjson.dumps(raw).decode()},
+        )
+
+        _trigger_queued_feedback_if_ci_complete(event)
+
+        mock_trigger_consume.assert_called_once()
+        assert mock_trigger_consume.call_args.kwargs["run_id"] == state.run_id
+        assert mock_trigger_consume.call_args.kwargs["organization_id"] == self.organization.id
+        assert mock_trigger_consume.call_args.kwargs["run_state"] is state
+        assert isinstance(
+            mock_trigger_consume.call_args.kwargs["feedback"].source, CheckSuiteFeedbackSource
+        )
+
+    @patch(TRIGGER_CONSUME_PATH)
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_autofix_run")
+    def test_does_not_trigger_for_stale_head(
+        self, mock_resolve: MagicMock, mock_trigger_consume: MagicMock
+    ) -> None:
+        state = SeerRunState(
+            run_id=67890,
+            blocks=[],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+            repo_pr_states={
+                "owner/repo": RepoPRState(repo_name="owner/repo", commit_sha="new-head")
+            },
+        )
+        mock_resolve.return_value = CheckSuiteAutofixRun(
+            repository=MagicMock(organization_id=self.organization.id),
+            run_state=state,
+            pr_id=1,
+            group_id=1,
+        )
+        raw = {
+            "check_suite": {
+                "id": 1,
+                "head_sha": "old-head",
+                "check_runs_url": "https://github.com/owner/repo/check-runs",
+                "app": {"name": "CI"},
+            },
+            "repository": {
+                "html_url": "https://github.com/owner/repo",
+                "full_name": "owner/repo",
+            },
+        }
+        event = CheckSuiteEvent(
+            action="completed",
+            check_suite={"conclusion": "success"},
+            subscription_event={"event": orjson.dumps(raw).decode()},
+        )
+
+        _trigger_queued_feedback_if_ci_complete(event)
+
+        mock_trigger_consume.assert_not_called()
 
 
 class ResolveCheckSuiteAutofixRunTest(TestCase):


### PR DESCRIPTION
Wake delayed failure feedback when a later green check suite completes CI. Ignore stale-head completion webhooks.

Fixes CW-1696