### PR TITLE
feat(agent-monitoring): Restyle timeline row titles for readability

### DIFF
--- a/static/app/views/insights/pages/agents/components/aiSpanTimeline.tsx
+++ b/static/app/views/insights/pages/agents/components/aiSpanTimeline.tsx
@@ -198,17 +198,17 @@ const TimelineRow = memo(function TimelineRowImpl({
                   </EllipsisTag>
                 </Flex>
               ) : (
-                <TitleContainer maxWidth="50%" minWidth="0">
+                <Container maxWidth="50%" minWidth="0">
                   <InfoText
                     title={title}
                     mode="overflowOnly"
                     size="sm"
-                    variant="inherit"
+                    variant="primary"
                     bold
                   >
                     {title}
                   </InfoText>
-                </TitleContainer>
+                </Container>
               )}
               <Flex flex="1" minWidth="0">
                 {secondary && (
@@ -370,13 +370,6 @@ function getSpanPresentation(
       };
   }
 }
-
-// Applies the header color to the row title. Text/InfoText can't express the
-// headings token through its `variant` prop, so the token is set here and the
-// title inherits it via `variant="inherit"`.
-const TitleContainer = styled(Container)`
-  color: ${p => p.theme.tokens.content.headings};
-`;
 
 // Tag's inner text already truncates, but text-overflow is ignored on its flex
 // container, so flip it to block. Width is bounded by the Flex wrapper.

--- a/static/app/views/insights/pages/agents/components/aiSpanTimeline.tsx
+++ b/static/app/views/insights/pages/agents/components/aiSpanTimeline.tsx
@@ -198,17 +198,17 @@ const TimelineRow = memo(function TimelineRowImpl({
                   </EllipsisTag>
                 </Flex>
               ) : (
-                <Container maxWidth="50%" minWidth="0">
+                <TitleContainer maxWidth="50%" minWidth="0">
                   <InfoText
                     title={title}
                     mode="overflowOnly"
                     size="sm"
-                    variant={isSelected ? 'primary' : 'muted'}
-                    monospace
+                    variant="inherit"
+                    bold
                   >
                     {title}
                   </InfoText>
-                </Container>
+                </TitleContainer>
               )}
               <Flex flex="1" minWidth="0">
                 {secondary && (
@@ -370,6 +370,13 @@ function getSpanPresentation(
       };
   }
 }
+
+// Applies the header color to the row title. Text/InfoText can't express the
+// headings token through its `variant` prop, so the token is set here and the
+// title inherits it via `variant="inherit"`.
+const TitleContainer = styled(Container)`
+  color: ${p => p.theme.tokens.content.headings};
+`;
 
 // Tag's inner text already truncates, but text-overflow is ignored on its flex
 // container, so flip it to block. Width is bounded by the Flex wrapper.


### PR DESCRIPTION
Span titles in the conversation-details Timeline view were rendered in a monospace, muted font that was hard to scan. This updates them to sans-serif, medium weight, and the primary text color so each row's title reads clearly as the primary label. Secondary text, metrics, and tool-call tags are unchanged.


Closes TET-2788