### PR TITLE
perf(hybridcloud): Fold the dispatch due-check into the claim update

### DIFF
--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -6,7 +6,7 @@ from concurrent.futures import as_completed
 import orjson
 import sentry_sdk
 from django.core.cache import cache
-from django.db.models import Case, CharField, Min, Subquery, Value, When
+from django.db.models import Case, CharField, Exists, Min, Subquery, Value, When
 from django.utils import timezone
 from requests import Response
 from requests.models import HTTPError
@@ -202,18 +202,24 @@ def _use_claim_dispatch(mailbox_name: str) -> bool:
 def _is_due(schedule_for: datetime.datetime) -> bool:
     """
     Whether a payload is ready to deliver — the in-Python form of the
-    `schedule_for__lte=timezone.now()` filter that `_claim_and_dispatch` and the
+    `schedule_for__lte=timezone.now()` bound that the claim's due-gate and the
     scheduler select on. Dispatchers call this rather than restating the bound,
     so the push path cannot drift from the rows the scheduler picks up.
     """
     return schedule_for <= timezone.now()
 
 
-def _claim_mailbox_batch(head_id: int, mailbox_name: str) -> int:
+def _claim_mailbox_batch(head_id: int, mailbox_name: str, *, only_if_head_due: bool = False) -> int:
     """
     Claim up to MAX_MAILBOX_DRAIN records at the head of the mailbox by scheduling
     them past the drain deadline, so no other dispatcher selects the mailbox for
     delivery until the drain that claimed them has had its full run.
+
+    With `only_if_head_due`, the whole claim is gated on the head still being due:
+    the check rides in the UPDATE's WHERE clause, so a head that another dispatcher
+    already claimed (or a drain already delivered) claims 0 rows in the same round
+    trip instead of needing a separate primary read. Lease-mode callers must not
+    gate — they claim unconditionally, matching the pre-claim-rollout behavior.
 
     Returns the number of records claimed — also the depth signal that picks the
     drain mode.
@@ -223,9 +229,11 @@ def _claim_mailbox_batch(head_id: int, mailbox_name: str) -> int:
         .order_by("id")
         .values("id")[:MAX_MAILBOX_DRAIN]
     )
-    return WebhookPayload.objects.filter(id__in=Subquery(mailbox_batch)).update(
-        schedule_for=timezone.now() + BATCH_SCHEDULE_OFFSET
-    )
+    batch = WebhookPayload.objects.filter(id__in=Subquery(mailbox_batch))
+    if only_if_head_due:
+        head_due = WebhookPayload.objects.filter(id=head_id, schedule_for__lte=timezone.now())
+        batch = batch.filter(Exists(head_due))
+    return batch.update(schedule_for=timezone.now() + BATCH_SCHEDULE_OFFSET)
 
 
 class DispatchOutcome(enum.StrEnum):
@@ -240,11 +248,11 @@ def _claim_and_dispatch(head_id: int, mailbox_name: str) -> DispatchOutcome:
     """
     Claim a batch for the mailbox and dispatch the drain matching its depth.
     Callers must hold the mailbox's drain lock so concurrent dispatchers cannot
-    interleave between the due-check and the claim.
+    interleave around the claim.
 
     Returns the dispatched drain's mode, or NOT_DUE when the head has already
     been claimed, delivered, or moved into a retry backoff. Dispatchers discover
-    mailbox heads outside the drain lock, so this due re-check under the lock is
+    mailbox heads outside the drain lock, so the due-gate inside the claim is
     what stops two of them from double-dispatching the same head.
 
     The drain is bounded to the claimed records (`claimed_count`). Without the
@@ -252,10 +260,7 @@ def _claim_and_dispatch(head_id: int, mailbox_name: str) -> DispatchOutcome:
     the mailbox head is due again and another dispatcher can start a second,
     overlapping drain — duplicating deliveries and breaking mailbox ordering.
     """
-    is_due = WebhookPayload.objects.filter(id=head_id, schedule_for__lte=timezone.now()).exists()
-    if not is_due:
-        return DispatchOutcome.NOT_DUE
-    claimed = _claim_mailbox_batch(head_id, mailbox_name)
+    claimed = _claim_mailbox_batch(head_id, mailbox_name, only_if_head_due=True)
     if not claimed:
         return DispatchOutcome.NOT_DUE
     if claimed >= PARALLEL_DRAIN_THRESHOLD:

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -6,6 +6,8 @@ import orjson
 import pytest
 import responses
 from django.core.cache import cache
+from django.db import connections
+from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 from requests.exceptions import ConnectionError, ReadTimeout
 
@@ -191,6 +193,35 @@ class ScheduleWebhooksTest(TestCase):
         webhook.refresh_from_db()
         # The existing claim must not be extended either.
         assert webhook.schedule_for == claimed_for
+
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox_parallel")
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_claim_and_dispatch_claims_in_a_single_query(
+        self, mock_drain: MagicMock, mock_drain_parallel: MagicMock
+    ) -> None:
+        # The due-gate rides in the claim UPDATE's WHERE clause. A separate
+        # primary read before the claim would double the per-mailbox dispatch
+        # round trips, so lock in the single-statement shape.
+        webhook = self.create_webhook_payload(
+            mailbox_name="github:123",
+            cell_name="us",
+        )
+
+        with CaptureQueriesContext(connections["control"]) as ctx:
+            outcome = _claim_and_dispatch(webhook.id, webhook.mailbox_name)
+
+        assert outcome == "sequential"
+        mock_drain.delay.assert_called_once_with(webhook.id, claimed_count=1)
+        queries = [
+            q["sql"]
+            for q in ctx.captured_queries
+            if not q["sql"].startswith(("SAVEPOINT", "RELEASE SAVEPOINT"))
+        ]
+        assert len(queries) == 1, queries
+        assert "UPDATE" in queries[0]
+        assert "EXISTS" in queries[0]
+        webhook.refresh_from_db()
+        assert webhook.schedule_for > timezone.now()
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
     @patch(


### PR DESCRIPTION
## Problem

Claim-mode dispatch issues two primary statements per mailbox: a `SELECT` re-checking that the replica-discovered head is still due, then the batch-claim `UPDATE`. The scheduler dispatches up to `BATCH_SIZE` (1000) mailboxes per ~10s cycle and push triggers re-run the same pair on every incoming webhook, so the re-check doubles the primary round trips of every dispatch.

## Approach

The due-check now rides in the claim `UPDATE`'s `WHERE` clause as an `EXISTS` gate on the head row: a head that another dispatcher already claimed (or a drain already delivered) claims zero rows, producing the same `NOT_DUE` outcome in a single statement. `test_claim_and_dispatch_claims_in_a_single_query` pins the one-statement shape and the gate.

Lease-mode scheduler dispatch keeps claiming unconditionally — gating it would change pre-rollout behavior, where a stale head's batch is still claimed before its drain runs.

Stacked on #121449.

Part of [INC-2431](https://linear.app/getsentry/issue/INC-2431)
