### PR TITLE
feat(trace): Include event data in trace item details API

### DIFF
--- a/src/sentry/api/endpoints/project_trace_item_details.py
+++ b/src/sentry/api/endpoints/project_trace_item_details.py
@@ -259,6 +259,37 @@ def serialize_meta(
     return meta_result
 
 
+# Attribute name -> `event` field name
+_SERIALIZED_EVENT_ATTRIBUTES: dict[str, str] = {
+    "sentry.event.serialized_contexts": "contexts",
+    "sentry.event.serialized_extra": "extra",
+    "sentry.event.serialized_breadcrumbs": "breadcrumbs",
+}
+
+
+def serialize_event(attributes: list[dict]) -> dict[str, Any] | None:
+    """A few event fields (contexts, extra, breadcrumbs) are stored as
+    JSON-serialized strings under internal `sentry.event.serialized_*`
+    attributes. Parse any that are present back into JSON and return them,
+    wrapped in a single `event` dict."""
+    result: dict[str, Any] = {}
+    for attribute in attributes:
+        event_key = _SERIALIZED_EVENT_ATTRIBUTES.get(attribute["name"])
+        if event_key is None:
+            continue
+
+        value = attribute.get("value", {}).get("valStr", None)
+        if value is None:
+            continue
+
+        try:
+            result[event_key] = json.loads(value)
+        except json.JSONDecodeError as e:
+            sentry_sdk.capture_exception(e)
+
+    return result or None
+
+
 def serialize_links(attributes: list[dict]) -> list[dict] | None:
     """Links are temporarily stored in `sentry.links` so lets parse that back out and return separately"""
     link_attribute = None
@@ -440,6 +471,10 @@ class ProjectTraceItemDetailsEndpoint(ProjectEndpoint):
             "meta": serialize_meta(resp["attributes"], item_type),
             "links": serialize_links(resp["attributes"]),
         }
+
+        event = serialize_event(resp["attributes"])
+        if event is not None:
+            resp_dict["event"] = event
 
         if debug:
             resp_dict["meta"]["debug_info"] = {

--- a/tests/snuba/api/endpoints/test_project_trace_item_details.py
+++ b/tests/snuba/api/endpoints/test_project_trace_item_details.py
@@ -15,6 +15,7 @@ from sentry.testutils.cases import (
 )
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.options import override_options
+from sentry.utils import json
 from sentry.utils.snuba_rpc import SnubaRPCRateLimitExceeded
 
 
@@ -426,6 +427,89 @@ class ProjectTraceItemDetailsEndpointTest(
             ).isoformat()
             + "Z",
         }
+
+    def test_serialized_event_json_attributes(self) -> None:
+        contexts = {"trace": {"trace_id": self.trace_uuid, "span_id": "abc123"}}
+        extra = {"custom_key": "custom_value", "count": 3}
+        breadcrumbs = [{"type": "default", "message": "first"}, {"type": "http", "message": "req"}]
+        log = self.create_ourlog(
+            {
+                "body": "foo",
+                "trace_id": self.trace_uuid,
+            },
+            attributes={
+                "sentry.event.serialized_contexts": json.dumps(contexts),
+                "sentry.event.serialized_extra": json.dumps(extra),
+                "sentry.event.serialized_breadcrumbs": json.dumps(breadcrumbs),
+            },
+            timestamp=self.one_min_ago,
+        )
+        self.store_eap_items([log])
+        item_id = log.item_id.hex()
+
+        trace_details_response = self.do_request("logs", item_id)
+
+        assert trace_details_response.status_code == 200, trace_details_response.content
+        assert trace_details_response.data["event"] == {
+            "contexts": contexts,
+            "extra": extra,
+            "breadcrumbs": breadcrumbs,
+        }
+
+    def test_serialized_event_json_attributes_partial(self) -> None:
+        extra = {"custom_key": "custom_value"}
+        log = self.create_ourlog(
+            {
+                "body": "foo",
+                "trace_id": self.trace_uuid,
+            },
+            attributes={
+                "sentry.event.serialized_extra": json.dumps(extra),
+            },
+            timestamp=self.one_min_ago,
+        )
+        self.store_eap_items([log])
+        item_id = log.item_id.hex()
+
+        trace_details_response = self.do_request("logs", item_id)
+
+        assert trace_details_response.status_code == 200, trace_details_response.content
+        assert trace_details_response.data["event"] == {"extra": extra}
+
+    def test_serialized_event_json_attributes_absent(self) -> None:
+        log = self.create_ourlog(
+            {
+                "body": "foo",
+                "trace_id": self.trace_uuid,
+            },
+            timestamp=self.one_min_ago,
+        )
+        self.store_eap_items([log])
+        item_id = log.item_id.hex()
+
+        trace_details_response = self.do_request("logs", item_id)
+
+        assert trace_details_response.status_code == 200, trace_details_response.content
+        assert "event" not in trace_details_response.data
+
+    def test_serialized_event_json_attributes_invalid_json(self) -> None:
+        log = self.create_ourlog(
+            {
+                "body": "foo",
+                "trace_id": self.trace_uuid,
+            },
+            attributes={
+                "sentry.event.serialized_contexts": "not valid json",
+            },
+            timestamp=self.one_min_ago,
+        )
+        self.store_eap_items([log])
+        item_id = log.item_id.hex()
+
+        trace_details_response = self.do_request("logs", item_id)
+
+        assert trace_details_response.status_code == 200, trace_details_response.content
+        assert "event" not in trace_details_response.data
 
     def test_sentry_links(self) -> None:
         span_1 = self.create_span(


### PR DESCRIPTION
Adds an `event` field to the trace item details endpoint response, containing `contexts`, `extra`, and `breadcrumbs` properties. These are taken from the incoming transaction event and stored as attributes by Relay. (https://github.com/getsentry/relay/pull/6286).

The span details pane in the trace waterfall currently uses the transaction event JSON to populate these properties when they're present. With this change we can use EAP instead, allowing us to break the dependency on transaction events (facilitating transaction ingestion shutdown).

Will always be missing for span streaming SDKs as expected, as those use attributes and logs for this data instead.

See BROWSE-673.