### PR TITLE
ref(seer): Move seer automation guards into the task

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1547,46 +1547,14 @@ def check_if_flags_sent(job: PostProcessJob) -> None:
 
 
 def kick_off_seer_automation(job: PostProcessJob) -> None:
-    from sentry.seer.autofix.issue_summary import (
-        get_issue_summary_cache_key,
-        get_issue_summary_lock_key,
-    )
-    from sentry.seer.autofix.trigger import get_default_seer_automation_skip_reason
-    from sentry.seer.autofix.utils import is_seer_seat_based_tier_enabled
-    from sentry.tasks.seer.autofix import (
-        generate_issue_summary_only,
-        generate_summary_and_run_automation,
-    )
+    from sentry.tasks.seer.autofix import generate_summary_and_run_automation
 
-    event = job["event"]
-    group = event.group
-
-    if is_seer_seat_based_tier_enabled(group.organization):
-        # Guards to prevent thundering herd on issue summary generation.
-        if options.get("seer.post-process-issue-summary-killswitch.enabled"):
-            return
-        if group.seer_fixability_score is not None:
-            return
-        # Issues created in last 5 minutes only. This can be removed once this is live past 1 week.
-        # We don't want to backfill old issues since that will overwhelm Seer.
-        if (timezone.now() - group.first_seen).total_seconds() > 300:
-            return
-        # Generate issue summary and fixability score if not cached.
-        # Agentic Triage handles automations for seat-based orgs but still needs these.
-        cache_key = get_issue_summary_cache_key(group.id)
-        if cache.get(cache_key) is None:
-            lock_key, lock_name = get_issue_summary_lock_key(group.id)
-            lock = locks.get(lock_key, duration=1, name=lock_name)
-            if not lock.locked():
-                generate_issue_summary_only.delay(group.id)
+    if options.get("seer.post-process-issue-summary-killswitch.enabled"):
         return
 
-    skip_reason = get_default_seer_automation_skip_reason(group, locks)
-    if skip_reason is not None:
-        metrics.incr("seer.automation.filtered", tags={"reason": skip_reason, "tier": "default"})
-        return
-
-    generate_summary_and_run_automation.delay(group.id, trigger_path="old_seer_automation")
+    generate_summary_and_run_automation.delay(
+        job["event"].group.id, trigger_path="old_seer_automation"
+    )
 
 
 def kick_off_lightweight_rca_cluster(job: PostProcessJob) -> None:

--- a/src/sentry/tasks/seer/autofix.py
+++ b/src/sentry/tasks/seer/autofix.py
@@ -18,6 +18,14 @@ from sentry.seer.autofix.constants import (
     AutofixAutomationTuningSettings,
     SeerAutomationSource,
 )
+from sentry.seer.autofix.issue_summary import (
+    get_and_update_group_fixability_score,
+    get_issue_summary,
+    get_issue_summary_cache_key,
+    get_issue_summary_lock_key,
+    run_automation,
+)
+from sentry.seer.autofix.trigger import get_default_seer_automation_skip_reason
 from sentry.seer.autofix.utils import (
     SEAT_BASED_STOPPING_POINTS,
     AutofixStoppingPoint,
@@ -26,6 +34,7 @@ from sentry.seer.autofix.utils import (
     bulk_read_preferences_from_sentry_db,
     get_org_default_seer_automation_handoff,
     get_seer_seat_based_tier_cache_key,
+    is_seer_seat_based_tier_enabled,
     update_seer_project_settings,
 )
 from sentry.tasks.base import instrumented_task
@@ -52,14 +61,6 @@ def _get_group_or_log(group_id: int, task_name: str) -> Group | None:
     retry=Retry(times=1),
 )
 def generate_summary_and_run_automation(group_id: int, **kwargs) -> None:
-    from sentry.seer.autofix.issue_summary import (
-        get_issue_summary,
-        get_issue_summary_cache_key,
-        get_issue_summary_lock_key,
-    )
-    from sentry.seer.autofix.trigger import get_default_seer_automation_skip_reason
-    from sentry.seer.autofix.utils import is_seer_seat_based_tier_enabled
-
     trigger_path = kwargs.get("trigger_path", "unknown")
     sentry_sdk.set_tag("trigger_path", trigger_path)
     sentry_sdk.set_attribute("trigger_path", trigger_path)
@@ -120,11 +121,6 @@ def generate_issue_summary_only(group_id: int) -> None:
     Generate issue summary WITHOUT triggering automation.
     Used for triage signals flow when event count < AUTOFIX_AUTOMATION_OCCURRENCE_THRESHOLD or when summary doesn't exist yet.
     """
-    from sentry.seer.autofix.issue_summary import (
-        get_and_update_group_fixability_score,
-        get_issue_summary,
-    )
-
     group = _get_group_or_log(group_id, "generate_issue_summary_only")
     if group is None:
         return
@@ -164,8 +160,6 @@ def run_automation_only_task(group_id: int) -> None:
     Used for triage signals flow when event count >= AUTOFIX_AUTOMATION_OCCURRENCE_THRESHOLD and summary exists.
     """
     from django.contrib.auth.models import AnonymousUser
-
-    from sentry.seer.autofix.issue_summary import run_automation
 
     group = _get_group_or_log(group_id, "run_automation_only_task")
     if group is None:

--- a/src/sentry/tasks/seer/autofix.py
+++ b/src/sentry/tasks/seer/autofix.py
@@ -10,6 +10,7 @@ from sentry.analytics.events.autofix_automation_events import AiAutofixAutomatio
 from sentry.constants import (
     ObjectStatus,
 )
+from sentry.locks import locks
 from sentry.models.group import Group
 from sentry.models.organization import Organization
 from sentry.models.project import Project
@@ -51,7 +52,13 @@ def _get_group_or_log(group_id: int, task_name: str) -> Group | None:
     retry=Retry(times=1),
 )
 def generate_summary_and_run_automation(group_id: int, **kwargs) -> None:
-    from sentry.seer.autofix.issue_summary import get_issue_summary
+    from sentry.seer.autofix.issue_summary import (
+        get_issue_summary,
+        get_issue_summary_cache_key,
+        get_issue_summary_lock_key,
+    )
+    from sentry.seer.autofix.trigger import get_default_seer_automation_skip_reason
+    from sentry.seer.autofix.utils import is_seer_seat_based_tier_enabled
 
     trigger_path = kwargs.get("trigger_path", "unknown")
     sentry_sdk.set_tag("trigger_path", trigger_path)
@@ -61,6 +68,29 @@ def generate_summary_and_run_automation(group_id: int, **kwargs) -> None:
     if group is None:
         return
     organization = group.project.organization
+
+    if is_seer_seat_based_tier_enabled(organization):
+        # Guards to prevent thundering herd on issue summary generation.
+        if group.seer_fixability_score is not None:
+            return
+        # Issues created in last 5 minutes only. This can be removed once this is live past 1 week.
+        # We don't want to backfill old issues since that will overwhelm Seer.
+        if (timezone.now() - group.first_seen).total_seconds() > 300:
+            return
+        # Generate issue summary and fixability score if not cached.
+        # Agentic Triage handles automations for seat-based orgs but still needs these.
+        cache_key = get_issue_summary_cache_key(group.id)
+        if cache.get(cache_key) is None:
+            lock_key, lock_name = get_issue_summary_lock_key(group.id)
+            lock = locks.get(lock_key, duration=1, name=lock_name)
+            if not lock.locked():
+                generate_issue_summary_only.delay(group.id)
+        return
+
+    skip_reason = get_default_seer_automation_skip_reason(group, locks)
+    if skip_reason is not None:
+        metrics.incr("seer.automation.filtered", tags={"reason": skip_reason, "tier": "default"})
+        return
 
     task_state = current_task()
     if task_state is None or task_state.attempt == 0:

--- a/tests/sentry/tasks/seer/test_autofix.py
+++ b/tests/sentry/tasks/seer/test_autofix.py
@@ -18,7 +18,7 @@ from sentry.utils.cache import cache
 
 class TestGenerateIssueSummaryOnly(SentryTestCase):
     @patch("sentry.seer.autofix.issue_summary._generate_fixability_score")
-    @patch("sentry.seer.autofix.issue_summary.get_issue_summary")
+    @patch("sentry.tasks.seer.autofix.get_issue_summary")
     def test_generates_fixability_score_after_summary(
         self, mock_get_issue_summary: MagicMock, mock_generate_fixability: MagicMock
     ) -> None:


### PR DESCRIPTION
Currently the post process step: `kick_off_seer_automation`:
- Does some work to decide if an issue is eligible
- If it is, spawns a task to do some of that work

This reorganizes the code to:
- Always spawn the task.
- The first thing the task does is check if it is eligible and early out if not.
 
We trade "always doing some work" in the hot path for "always spawning a task" in the hot path.

This came up as part of inc-2410. It seems like `is_seer_seat_based_tier_enabled` (which is called to
check eligibility) slowed down - this broke ingestion.

The killswitch is left in the initial call.
