### PR TITLE
feat(aci): Insert every_event condition when editing alerts with no "when" conditions

### DIFF
--- a/static/app/views/automations/components/automationBuilderContext.tsx
+++ b/static/app/views/automations/components/automationBuilderContext.tsx
@@ -297,7 +297,7 @@ type AutomationBuilderAction =
   | UpdateIfActionAction
   | UpdateIfLogicTypeAction;
 
-function createCondition(conditionType: DataConditionType): DataCondition {
+export function createCondition(conditionType: DataConditionType): DataCondition {
   return {
     id: uuid4(),
     type: conditionType,

--- a/static/app/views/automations/components/automationBuilderRow.tsx
+++ b/static/app/views/automations/components/automationBuilderRow.tsx
@@ -10,9 +10,9 @@ import {t} from 'sentry/locale';
 
 interface RowProps {
   children: React.ReactNode;
-  onDelete: () => void;
   errorMessage?: string;
   hasError?: boolean;
+  onDelete?: () => void;
   warningMessages?: string[];
 }
 
@@ -26,15 +26,19 @@ export function AutomationBuilderRow({
   return (
     <Stack gap="xs">
       <RowContainer incompatible={hasError}>
-        <RowLine>{children}</RowLine>
-        <DeleteButton
-          aria-label={t('Delete row')}
-          size="sm"
-          icon={<IconDelete />}
-          variant="transparent"
-          onClick={onDelete}
-          className="delete-row"
-        />
+        <RowLine>
+          {children}
+          {onDelete && (
+            <DeleteButton
+              aria-label={t('Delete row')}
+              size="sm"
+              icon={<IconDelete />}
+              variant="transparent"
+              onClick={onDelete}
+              className="delete-row"
+            />
+          )}
+        </RowLine>
       </RowContainer>
       {hasError && errorMessage && <Alert variant="danger">{errorMessage}</Alert>}
       {warningMessages.length > 0 && (

--- a/static/app/views/automations/components/automationBuilderRow.tsx
+++ b/static/app/views/automations/components/automationBuilderRow.tsx
@@ -10,26 +10,26 @@ import {t} from 'sentry/locale';
 
 interface RowProps {
   children: React.ReactNode;
-  isLastRow: boolean;
   onDelete: () => void;
   errorMessage?: string;
   hasError?: boolean;
+  hideDeleteButton?: boolean;
   warningMessages?: string[];
 }
 
 export function AutomationBuilderRow({
-  isLastRow,
   onDelete,
   children,
   hasError,
   errorMessage,
+  hideDeleteButton,
   warningMessages = [],
 }: RowProps) {
   return (
     <Stack gap="xs">
       <RowContainer incompatible={hasError}>
         <RowLine>{children}</RowLine>
-        {!isLastRow && (
+        {!hideDeleteButton && (
           <DeleteButton
             aria-label={t('Delete row')}
             size="sm"

--- a/static/app/views/automations/components/automationBuilderRow.tsx
+++ b/static/app/views/automations/components/automationBuilderRow.tsx
@@ -10,13 +10,15 @@ import {t} from 'sentry/locale';
 
 interface RowProps {
   children: React.ReactNode;
+  isLastRow: boolean;
+  onDelete: () => void;
   errorMessage?: string;
   hasError?: boolean;
-  onDelete?: () => void;
   warningMessages?: string[];
 }
 
 export function AutomationBuilderRow({
+  isLastRow,
   onDelete,
   children,
   hasError,
@@ -27,7 +29,7 @@ export function AutomationBuilderRow({
     <Stack gap="xs">
       <RowContainer incompatible={hasError}>
         <RowLine>{children}</RowLine>
-        {onDelete && (
+        {!isLastRow && (
           <DeleteButton
             aria-label={t('Delete row')}
             size="sm"

--- a/static/app/views/automations/components/automationBuilderRow.tsx
+++ b/static/app/views/automations/components/automationBuilderRow.tsx
@@ -26,19 +26,17 @@ export function AutomationBuilderRow({
   return (
     <Stack gap="xs">
       <RowContainer incompatible={hasError}>
-        <RowLine>
-          {children}
-          {onDelete && (
-            <DeleteButton
-              aria-label={t('Delete row')}
-              size="sm"
-              icon={<IconDelete />}
-              variant="transparent"
-              onClick={onDelete}
-              className="delete-row"
-            />
-          )}
-        </RowLine>
+        <RowLine>{children}</RowLine>
+        {onDelete && (
+          <DeleteButton
+            aria-label={t('Delete row')}
+            size="sm"
+            icon={<IconDelete />}
+            variant="transparent"
+            onClick={onDelete}
+            className="delete-row"
+          />
+        )}
       </RowContainer>
       {hasError && errorMessage && <Alert variant="danger">{errorMessage}</Alert>}
       {warningMessages.length > 0 && (

--- a/static/app/views/automations/components/conditionsPanel.tsx
+++ b/static/app/views/automations/components/conditionsPanel.tsx
@@ -39,7 +39,7 @@ export function ConditionsPanel({triggers, actionFilters}: ConditionsPanelProps)
                     choice => choice.value === triggers?.logicType
                   )?.label || t('any'),
               })
-            : tct('[when:When] an event is captured', {
+            : tct('[when:When] an event or issue activity is captured', {
                 when: <ConditionBadge />,
               })}
         </ConditionGroupHeader>

--- a/static/app/views/automations/components/dataConditionNodeList.spec.tsx
+++ b/static/app/views/automations/components/dataConditionNodeList.spec.tsx
@@ -190,23 +190,23 @@ describe('DataConditionNodeList', () => {
   it('deletes existing condition', async () => {
     render(
       <AutomationBuilderTestProvider>
-        <DataConditionNodeList
-          {...defaultProps}
-          conditions={[DataConditionFixture(), DataConditionFixture({id: '2'})]}
-        />
+        <DataConditionNodeList {...defaultProps} conditions={[DataConditionFixture()]} />
       </AutomationBuilderTestProvider>,
       {organization}
     );
 
-    const [deleteButton] = screen.getAllByRole('button', {name: 'Delete row'});
-    await userEvent.click(deleteButton!);
+    await userEvent.click(screen.getByRole('button', {name: 'Delete row'}));
     expect(mockOnDeleteRow).toHaveBeenCalledWith('1');
   });
 
-  it('hides delete button for the last remaining condition', () => {
+  it('hides delete button for the last remaining workflow trigger condition', () => {
     render(
       <AutomationBuilderTestProvider>
-        <DataConditionNodeList {...defaultProps} conditions={[DataConditionFixture()]} />
+        <DataConditionNodeList
+          {...defaultProps}
+          handlerGroup={DataConditionHandlerGroupType.WORKFLOW_TRIGGER}
+          conditions={[DataConditionFixture()]}
+        />
       </AutomationBuilderTestProvider>,
       {organization}
     );

--- a/static/app/views/automations/components/dataConditionNodeList.spec.tsx
+++ b/static/app/views/automations/components/dataConditionNodeList.spec.tsx
@@ -190,13 +190,28 @@ describe('DataConditionNodeList', () => {
   it('deletes existing condition', async () => {
     render(
       <AutomationBuilderTestProvider>
+        <DataConditionNodeList
+          {...defaultProps}
+          conditions={[DataConditionFixture(), DataConditionFixture({id: '2'})]}
+        />
+      </AutomationBuilderTestProvider>,
+      {organization}
+    );
+
+    const [deleteButton] = screen.getAllByRole('button', {name: 'Delete row'});
+    await userEvent.click(deleteButton!);
+    expect(mockOnDeleteRow).toHaveBeenCalledWith('1');
+  });
+
+  it('hides delete button for the last remaining condition', () => {
+    render(
+      <AutomationBuilderTestProvider>
         <DataConditionNodeList {...defaultProps} conditions={[DataConditionFixture()]} />
       </AutomationBuilderTestProvider>,
       {organization}
     );
 
-    await userEvent.click(screen.getByRole('button', {name: 'Delete row'}));
-    expect(mockOnDeleteRow).toHaveBeenCalledWith('1');
+    expect(screen.queryByRole('button', {name: 'Delete row'})).not.toBeInTheDocument();
   });
 
   it('shows conflicting condition warning for action filters', () => {

--- a/static/app/views/automations/components/dataConditionNodeList.tsx
+++ b/static/app/views/automations/components/dataConditionNodeList.tsx
@@ -144,6 +144,10 @@ export function DataConditionNodeList({
     ];
   }, [dataConditionHandlers, handlerGroup, state.triggers.conditions]);
 
+  const shouldHideDeleteButton =
+    handlerGroup === DataConditionHandlerGroupType.WORKFLOW_TRIGGER &&
+    conditions.length === 1;
+
   return (
     <Fragment>
       {conditions.map(condition => {
@@ -152,7 +156,7 @@ export function DataConditionNodeList({
         return (
           <AutomationBuilderRow
             key={condition.id}
-            isLastRow={conditions.length === 1}
+            hideDeleteButton={shouldHideDeleteButton}
             onDelete={() => onDeleteRow(condition.id)}
             hasError={conflictingConditions?.has(condition.id) || !!error}
             errorMessage={error}

--- a/static/app/views/automations/components/dataConditionNodeList.tsx
+++ b/static/app/views/automations/components/dataConditionNodeList.tsx
@@ -144,8 +144,15 @@ export function DataConditionNodeList({
     ];
   }, [dataConditionHandlers, handlerGroup, state.triggers.conditions]);
 
+  const everyEventLabel = dataConditionNodesMap.get(DataConditionType.EVERY_EVENT)?.label;
+
   return (
     <Fragment>
+      {/* Display a UI-only row to communicate an empty conditions list is equivalent to selecting the every_event condition */}
+      {conditions.length === 0 && (
+        <AutomationBuilderRow>{everyEventLabel}</AutomationBuilderRow>
+      )}
+
       {conditions.map(condition => {
         const error = errors?.[condition.id];
 

--- a/static/app/views/automations/components/dataConditionNodeList.tsx
+++ b/static/app/views/automations/components/dataConditionNodeList.tsx
@@ -144,21 +144,15 @@ export function DataConditionNodeList({
     ];
   }, [dataConditionHandlers, handlerGroup, state.triggers.conditions]);
 
-  const everyEventLabel = dataConditionNodesMap.get(DataConditionType.EVERY_EVENT)?.label;
-
   return (
     <Fragment>
-      {/* Display a UI-only row to communicate an empty conditions list is equivalent to selecting the every_event condition */}
-      {conditions.length === 0 && (
-        <AutomationBuilderRow>{everyEventLabel}</AutomationBuilderRow>
-      )}
-
       {conditions.map(condition => {
         const error = errors?.[condition.id];
 
         return (
           <AutomationBuilderRow
             key={condition.id}
+            isLastRow={conditions.length === 1}
             onDelete={() => onDeleteRow(condition.id)}
             hasError={conflictingConditions?.has(condition.id) || !!error}
             errorMessage={error}

--- a/static/app/views/automations/components/dataConditionNodes.tsx
+++ b/static/app/views/automations/components/dataConditionNodes.tsx
@@ -144,7 +144,7 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
   [
     DataConditionType.EVERY_EVENT,
     {
-      label: t('An event is captured'),
+      label: t('An event or issue activity is captured'),
       validate: undefined,
     },
   ],

--- a/static/app/views/automations/edit.spec.tsx
+++ b/static/app/views/automations/edit.spec.tsx
@@ -210,7 +210,7 @@ describe('EditAutomation', () => {
       frequency_minutes: 1440,
       environment: 'production',
       detectors_count: 1,
-      trigger_conditions_count: 0,
+      trigger_conditions_count: 1,
       actions_count: 1,
       success: true,
     });

--- a/static/app/views/automations/edit.spec.tsx
+++ b/static/app/views/automations/edit.spec.tsx
@@ -1,4 +1,8 @@
-import {ActionFilterFixture, AutomationFixture} from 'sentry-fixture/automations';
+import {
+  ActionFilterFixture,
+  AutomationFixture,
+  DataConditionFixture,
+} from 'sentry-fixture/automations';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {
@@ -10,9 +14,14 @@ import {
   within,
 } from 'sentry-test/reactTestingLibrary';
 
-import {DataConditionGroupLogicType} from 'sentry/types/workflowEngine/dataConditions';
+import type {Automation} from 'sentry/types/workflowEngine/automations';
+import {
+  DataConditionGroupLogicType,
+  DataConditionType,
+} from 'sentry/types/workflowEngine/dataConditions';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useParams} from 'sentry/utils/useParams';
+import {dataConditionNodesMap} from 'sentry/views/automations/components/dataConditionNodes';
 import AutomationEdit from 'sentry/views/automations/edit';
 
 jest.mock('sentry/utils/useParams');
@@ -220,5 +229,115 @@ describe('EditAutomation', () => {
         `/organizations/${organization.slug}/monitors/alerts/${automation.id}/`
       )
     );
+  });
+
+  describe('initial trigger conditions', () => {
+    const everyEventLabel = dataConditionNodesMap.get(
+      DataConditionType.EVERY_EVENT
+    )?.label;
+
+    if (!everyEventLabel) {
+      throw new Error('Every event label not found');
+    }
+
+    /**
+     * Mock opening the edit form with the given triggers and saving it
+     * Returns what the API received
+     */
+    async function getSubmittedTriggers(triggers: Automation['triggers']) {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/workflows/${automation.id}/`,
+        method: 'GET',
+        body: {...automation, triggers},
+      });
+
+      const mockUpdateAutomation = MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/workflows/${automation.id}/`,
+        method: 'PUT',
+        body: automation,
+      });
+
+      render(<AutomationEdit />, {organization});
+
+      await userEvent.click(await screen.findByRole('button', {name: 'Save'}));
+
+      await waitFor(() => expect(mockUpdateAutomation).toHaveBeenCalled());
+
+      return mockUpdateAutomation.mock.calls[0][1].data.triggers;
+    }
+
+    it('adds an every_event trigger when the automation has no trigger conditions', async () => {
+      const submittedTriggers = await getSubmittedTriggers({
+        id: '1',
+        logicType: DataConditionGroupLogicType.ANY,
+        conditions: [],
+      });
+
+      expect(submittedTriggers).toEqual(
+        expect.objectContaining({
+          logicType: DataConditionGroupLogicType.ANY,
+          conditions: [
+            {
+              type: DataConditionType.EVERY_EVENT,
+              comparison: true,
+              conditionResult: true,
+            },
+          ],
+        })
+      );
+
+      expect(screen.getByText(everyEventLabel)).toBeInTheDocument();
+    });
+
+    it('adds an every_event trigger when the automation has no trigger group', async () => {
+      const submittedTriggers = await getSubmittedTriggers(null);
+
+      expect(submittedTriggers).toEqual(
+        expect.objectContaining({
+          logicType: DataConditionGroupLogicType.ANY_SHORT_CIRCUIT,
+          conditions: [
+            {
+              type: DataConditionType.EVERY_EVENT,
+              comparison: true,
+              conditionResult: true,
+            },
+          ],
+        })
+      );
+
+      expect(screen.getByText(everyEventLabel)).toBeInTheDocument();
+    });
+
+    it('leaves existing trigger conditions untouched', async () => {
+      const submittedTriggers = await getSubmittedTriggers({
+        id: '1',
+        logicType: DataConditionGroupLogicType.ALL,
+        conditions: [
+          DataConditionFixture({
+            type: DataConditionType.FIRST_SEEN_EVENT,
+            comparison: true,
+          }),
+        ],
+      });
+
+      expect(submittedTriggers).toEqual(
+        expect.objectContaining({
+          logicType: DataConditionGroupLogicType.ALL,
+          conditions: [{type: DataConditionType.FIRST_SEEN_EVENT, comparison: true}],
+        })
+      );
+
+      const firstSeenEventText = dataConditionNodesMap.get(
+        DataConditionType.FIRST_SEEN_EVENT
+      )?.label;
+
+      if (!firstSeenEventText) {
+        throw new Error('First seen event text not found');
+      }
+
+      expect(screen.getByText(firstSeenEventText)).toBeInTheDocument();
+
+      expect(screen.queryByText(everyEventLabel)).not.toBeInTheDocument();
+    });
   });
 });

--- a/static/app/views/automations/edit.tsx
+++ b/static/app/views/automations/edit.tsx
@@ -19,13 +19,18 @@ import {useFormField} from 'sentry/components/workflowEngine/form/useFormField';
 import {StickyFooter} from 'sentry/components/workflowEngine/ui/footer';
 import {t} from 'sentry/locale';
 import type {Automation} from 'sentry/types/workflowEngine/automations';
-import {DataConditionGroupLogicType} from 'sentry/types/workflowEngine/dataConditions';
+import {
+  DataConditionGroupLogicType,
+  DataConditionType,
+  type DataConditionGroup,
+} from 'sentry/types/workflowEngine/dataConditions';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import type {AutomationBuilderState} from 'sentry/views/automations/components/automationBuilderContext';
 import {
+  createCondition,
   AutomationBuilderContext,
   useAutomationBuilderReducer,
 } from 'sentry/views/automations/components/automationBuilderContext';
@@ -106,21 +111,7 @@ function AutomationEditForm({automation}: {automation: Automation}) {
     return getAutomationFormData(automation);
   }, [automation]);
 
-  const initialState = useMemo((): AutomationBuilderState | undefined => {
-    if (!automation) {
-      return undefined;
-    }
-    return {
-      triggers: automation.triggers
-        ? automation.triggers
-        : {
-            id: 'when',
-            logicType: DataConditionGroupLogicType.ANY_SHORT_CIRCUIT,
-            conditions: [],
-          },
-      actionFilters: assignSubfilterIds(automation.actionFilters),
-    };
-  }, [automation]);
+  const initialState = useMemo(() => getInitialState(automation), [automation]);
 
   const model = useMemo(() => new FormModel(), []);
   const {state, actions} = useAutomationBuilderReducer(initialState);
@@ -265,4 +256,31 @@ function AutomationEditForm({automation}: {automation: Automation}) {
       </AutomationFormProvider>
     </FullHeightFormDeprecated>
   );
+}
+
+function getInitialState(automation: Automation): AutomationBuilderState | undefined {
+  if (!automation) {
+    return undefined;
+  }
+
+  return {
+    triggers: getInitialTriggers(automation.triggers),
+    actionFilters: assignSubfilterIds(automation.actionFilters),
+  };
+}
+
+function getInitialTriggers(triggers: DataConditionGroup | null): DataConditionGroup {
+  if (!triggers) {
+    return {
+      id: 'when',
+      logicType: DataConditionGroupLogicType.ANY_SHORT_CIRCUIT,
+      conditions: [createCondition(DataConditionType.EVERY_EVENT)],
+    };
+  }
+
+  if (triggers.conditions.length === 0) {
+    triggers.conditions.push(createCondition(DataConditionType.EVERY_EVENT));
+  }
+
+  return triggers;
 }

--- a/static/app/views/automations/edit.tsx
+++ b/static/app/views/automations/edit.tsx
@@ -279,7 +279,10 @@ function getInitialTriggers(triggers: DataConditionGroup | null): DataConditionG
   }
 
   if (triggers.conditions.length === 0) {
-    triggers.conditions.push(createCondition(DataConditionType.EVERY_EVENT));
+    return {
+      ...triggers,
+      conditions: [createCondition(DataConditionType.EVERY_EVENT)],
+    };
   }
 
   return triggers;


### PR DESCRIPTION
~Selecting no triggers is equivalent to selecting the every_event trigger but the UX of the form does not clearly reflect that. The simplest solution is a UI only element that shows what happens if you have no triggers selected.~

When someone opens the edit form and has no triggers, it is unclear what that means. This now inserts the every_event condition if they open the form so it is clear what they are doing. You also now can't delete a row if you only have one. This will slowly nudge people towards having their triggers explicitly laid out. No backend changes so scripts or people that never edit their alert have empty condition array work just fine