### PR TITLE
Remove isLegacyAlert from the anomaly thresholds hook

### DIFF
--- a/static/app/views/detectors/hooks/useMetricDetectorAnomalyThresholds.spec.tsx
+++ b/static/app/views/detectors/hooks/useMetricDetectorAnomalyThresholds.spec.tsx
@@ -110,48 +110,4 @@ describe('useMetricDetectorAnomalyThresholds', () => {
 
     expect(anomalyDataRequest).not.toHaveBeenCalled();
   });
-
-  it('includes legacy_alert query param when isLegacyAlert is true', async () => {
-    const organization = OrganizationFixture();
-
-    const mockData = [
-      {
-        external_alert_id: 24,
-        timestamp: 1609459200,
-        value: 100,
-        yhat_lower: 80,
-        yhat_upper: 120,
-      },
-    ];
-
-    const anomalyDataRequest = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/detectors/123/anomaly-data/`,
-      body: {data: mockData},
-      match: [MockApiClient.matchQuery({legacy_alert: 'true'})],
-    });
-
-    const series = [
-      {
-        seriesName: 'count()',
-        data: [{name: 1609459200000, value: 100}],
-      },
-    ];
-
-    renderHookWithProviders(
-      () =>
-        useMetricDetectorAnomalyThresholds({
-          detectorId: '123',
-          detectionType: 'dynamic',
-          startTimestamp: 1609459200,
-          endTimestamp: 1609545600,
-          series,
-          isLegacyAlert: true,
-        }),
-      {organization}
-    );
-
-    await waitFor(() => {
-      expect(anomalyDataRequest).toHaveBeenCalled();
-    });
-  });
 });

--- a/static/app/views/detectors/hooks/useMetricDetectorAnomalyThresholds.tsx
+++ b/static/app/views/detectors/hooks/useMetricDetectorAnomalyThresholds.tsx
@@ -29,7 +29,6 @@ interface UseMetricDetectorAnomalyThresholdsProps {
   detectorId: string;
   detectionType?: string;
   endTimestamp?: number;
-  isLegacyAlert?: boolean; // for Alerts, remove this once every AlertRule has a migrated Detector
   series?: Series[];
   startTimestamp?: number;
 }
@@ -49,7 +48,6 @@ export function useMetricDetectorAnomalyThresholds({
   startTimestamp,
   endTimestamp,
   series = [],
-  isLegacyAlert = false,
 }: UseMetricDetectorAnomalyThresholdsProps): UseMetricDetectorAnomalyThresholdsResult {
   const organization = useOrganization();
   const theme = useTheme();
@@ -72,7 +70,6 @@ export function useMetricDetectorAnomalyThresholds({
         query: {
           start: startTimestamp,
           end: endTimestamp,
-          ...(isLegacyAlert && {legacy_alert: 'true'}),
         },
       },
     ],


### PR DESCRIPTION
Now that the backend never expects this, we can remove the front end usage of legacy alerts for anomaly detection.