### PR TITLE
fix(explore): Validate metric group by selections

### DIFF
--- a/static/app/views/explore/hooks/useValidatedGroupBys.tsx
+++ b/static/app/views/explore/hooks/useValidatedGroupBys.tsx
@@ -1,0 +1,90 @@
+import {useLayoutEffect, useMemo, useRef} from 'react';
+import isEqual from 'lodash/isEqual';
+
+import {
+  filterInvalidGroupBys,
+  filterVisibleGroupBys,
+} from 'sentry/views/explore/utils/groupByValidation';
+import type {EventValidationData} from 'sentry/views/explore/utils/validateEventParamsOptions';
+
+interface UseValidatedGroupBysOptions {
+  groupBys: readonly string[];
+  onGroupBysCleanup: (groupBys: string[]) => void;
+  validationData: EventValidationData | undefined;
+  validationIsPending: boolean;
+}
+
+export function useValidatedGroupBys({
+  groupBys,
+  validationData,
+  validationIsPending,
+  onGroupBysCleanup,
+}: UseValidatedGroupBysOptions) {
+  const pendingValidatedGroupBys = useRef<{
+    from: readonly string[];
+    to: readonly string[];
+  } | null>(null);
+  const validationGroupBys = useRef<{
+    data: EventValidationData;
+    groupBys: readonly string[];
+  } | null>(null);
+
+  const validatedGroupBys = useMemo(
+    () => filterInvalidGroupBys(groupBys, validationData?.field),
+    [groupBys, validationData?.field]
+  );
+  const visibleGroupBys = useMemo(
+    () => filterVisibleGroupBys(groupBys, validationData?.field, validationIsPending),
+    [groupBys, validationData?.field, validationIsPending]
+  );
+
+  useLayoutEffect(() => {
+    if (pendingValidatedGroupBys.current) {
+      if (isEqual(groupBys, pendingValidatedGroupBys.current.to)) {
+        pendingValidatedGroupBys.current = null;
+      } else if (
+        isEqual(groupBys, pendingValidatedGroupBys.current.from) &&
+        isEqual(validatedGroupBys, pendingValidatedGroupBys.current.to)
+      ) {
+        return;
+      }
+    }
+
+    if (validationIsPending || !validationData) {
+      return;
+    }
+
+    let validationGroupBySnapshot = validationGroupBys.current;
+    if (
+      !validationGroupBySnapshot?.data ||
+      validationGroupBySnapshot.data !== validationData
+    ) {
+      validationGroupBySnapshot = {
+        data: validationData,
+        groupBys,
+      };
+      validationGroupBys.current = validationGroupBySnapshot;
+    }
+
+    if (
+      !isEqual(groupBys, validationGroupBySnapshot.groupBys) ||
+      isEqual(groupBys, validatedGroupBys)
+    ) {
+      return;
+    }
+
+    pendingValidatedGroupBys.current = {
+      from: groupBys,
+      to: validatedGroupBys,
+    };
+    onGroupBysCleanup(validatedGroupBys);
+  }, [
+    groupBys,
+    onGroupBysCleanup,
+    validatedGroupBys,
+    validationData,
+    validationIsPending,
+  ]);
+
+  return {visibleGroupBys};
+}

--- a/static/app/views/explore/metrics/hooks/useValidateMetricsTab.tsx
+++ b/static/app/views/explore/metrics/hooks/useValidateMetricsTab.tsx
@@ -30,7 +30,7 @@ export function useValidateMetricsTab({
   const groupBys = useQueryParamsGroupBys();
   const visualizes = useQueryParamsVisualizes({validate: true});
 
-  const {data, isLoading} = useQuery({
+  const {data, isFetching, isLoading, isPlaceholderData} = useQuery({
     ...validateEventParamsOptions({
       organization,
       selection,
@@ -54,6 +54,8 @@ export function useValidateMetricsTab({
 
   return {
     data,
+    isFetching,
+    isPlaceholderData,
     isLoading,
   };
 }

--- a/static/app/views/explore/metrics/metricPanel/index.spec.tsx
+++ b/static/app/views/explore/metrics/metricPanel/index.spec.tsx
@@ -75,6 +75,20 @@ function setupMocks(orgSlug: string) {
   });
 
   MockApiClient.addMockResponse({
+    url: `/organizations/${orgSlug}/events/validate/`,
+    method: 'GET',
+    body: {
+      dataset: [],
+      environment: [],
+      field: [],
+      orderby: [],
+      projects: [],
+      query: {error: null, fields: [], valid: true},
+      valid: true,
+    },
+  });
+
+  MockApiClient.addMockResponse({
     url: `/organizations/${orgSlug}/recent-searches/`,
     method: 'GET',
     body: [],

--- a/static/app/views/explore/metrics/metricToolbar/groupBySelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/groupBySelector.tsx
@@ -68,7 +68,7 @@ export function GroupBySelector({
     isFetching: validationFetching,
     isLoading: validationLoading,
     isPlaceholderData: validationIsPlaceholderData,
-  } = useValidateMetricsTab({enabled: groupBys.some(Boolean)});
+  } = useValidateMetricsTab();
   const pendingValidatedGroupBys = useRef<{
     from: readonly string[];
     to: readonly string[];

--- a/static/app/views/explore/metrics/metricToolbar/groupBySelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/groupBySelector.tsx
@@ -1,6 +1,5 @@
-import {useCallback, useLayoutEffect, useMemo, useRef} from 'react';
+import {useCallback, useMemo} from 'react';
 import {useQuery} from '@tanstack/react-query';
-import isEqual from 'lodash/isEqual';
 
 import type {SelectOption} from '@sentry/scraps/compactSelect';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
@@ -8,12 +7,10 @@ import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {t} from 'sentry/locale';
-import type {TagCollection} from 'sentry/types/group';
-import {FieldKind} from 'sentry/utils/fields';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {prettifyAttributeName} from 'sentry/views/explore/components/traceItemAttributes/utils';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {useGroupByFields} from 'sentry/views/explore/hooks/useGroupByFields';
+import {useValidatedGroupBys} from 'sentry/views/explore/hooks/useValidatedGroupBys';
 import {HiddenTraceMetricGroupByFields} from 'sentry/views/explore/metrics/constants';
 import {useValidateMetricsTab} from 'sentry/views/explore/metrics/hooks/useValidateMetricsTab';
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
@@ -23,12 +20,12 @@ import {
   useSetQueryParamsGroupBys,
 } from 'sentry/views/explore/queryParams/context';
 import {TraceItemDataset} from 'sentry/views/explore/types';
+import {mergeValidatedGroupByTags} from 'sentry/views/explore/utils/groupByValidation';
 import {sortSearchedAttributes} from 'sentry/views/explore/utils/sortSearchedAttributes';
 import {
   selectTraceItemTagCollection,
   traceItemAttributeKeysOptions,
 } from 'sentry/views/explore/utils/traceItemAttributeKeysOptions';
-import type {EventValidationData} from 'sentry/views/explore/utils/validateEventParamsOptions';
 
 interface GroupBySelectorProps {
   /**
@@ -69,78 +66,14 @@ export function GroupBySelector({
     isLoading: validationLoading,
     isPlaceholderData: validationIsPlaceholderData,
   } = useValidateMetricsTab();
-  const pendingValidatedGroupBys = useRef<{
-    from: readonly string[];
-    to: readonly string[];
-  } | null>(null);
-  const validationGroupBys = useRef<{
-    data: EventValidationData;
-    groupBys: readonly string[];
-  } | null>(null);
   const validationIsPending =
     validationFetching || validationLoading || validationIsPlaceholderData;
-
-  const validatedGroupBys = useMemo(
-    () => filterInvalidGroupBys(groupBys, validatedSearchQueryData?.field),
-    [groupBys, validatedSearchQueryData?.field]
-  );
-  const visibleGroupBys = useMemo(
-    () =>
-      filterVisibleGroupBys(
-        groupBys,
-        validatedSearchQueryData?.field,
-        validationIsPending
-      ),
-    [groupBys, validatedSearchQueryData?.field, validationIsPending]
-  );
-
-  useLayoutEffect(() => {
-    if (pendingValidatedGroupBys.current) {
-      if (isEqual(groupBys, pendingValidatedGroupBys.current.to)) {
-        pendingValidatedGroupBys.current = null;
-      } else if (
-        isEqual(groupBys, pendingValidatedGroupBys.current.from) &&
-        isEqual(validatedGroupBys, pendingValidatedGroupBys.current.to)
-      ) {
-        return;
-      }
-    }
-
-    if (validationIsPending || !validatedSearchQueryData) {
-      return;
-    }
-
-    let validationGroupBySnapshot = validationGroupBys.current;
-    if (
-      !validationGroupBySnapshot?.data ||
-      validationGroupBySnapshot.data !== validatedSearchQueryData
-    ) {
-      validationGroupBySnapshot = {
-        data: validatedSearchQueryData,
-        groupBys,
-      };
-      validationGroupBys.current = validationGroupBySnapshot;
-    }
-
-    if (
-      !isEqual(groupBys, validationGroupBySnapshot.groupBys) ||
-      isEqual(groupBys, validatedGroupBys)
-    ) {
-      return;
-    }
-
-    pendingValidatedGroupBys.current = {
-      from: groupBys,
-      to: validatedGroupBys,
-    };
-    setGroupBys(validatedGroupBys);
-  }, [
+  const {visibleGroupBys} = useValidatedGroupBys({
     groupBys,
-    setGroupBys,
-    validatedGroupBys,
-    validatedSearchQueryData,
+    validationData: validatedSearchQueryData,
     validationIsPending,
-  ]);
+    onGroupBysCleanup: setGroupBys,
+  });
 
   const traceMetricFilter = createTraceMetricFilter(traceMetric);
 
@@ -172,7 +105,7 @@ export function GroupBySelector({
       )
     );
 
-    return mergeValidatedTags({
+    return mergeValidatedGroupByTags({
       booleanTags: visibleBooleanTags,
       numberTags: visibleNumberTags,
       stringTags: visibleStringTags,
@@ -247,67 +180,4 @@ export function GroupBySelector({
       style={{width: '100%'}}
     />
   );
-}
-
-function filterInvalidGroupBys(
-  groupBys: readonly string[],
-  fields: EventValidationData['field'] | undefined
-): string[] {
-  const invalidFields = new Set(
-    fields?.filter(field => !field.valid).map(field => field.name)
-  );
-
-  if (invalidFields.size === 0) {
-    return [...groupBys];
-  }
-
-  return groupBys.filter(groupBy => groupBy === '' || !invalidFields.has(groupBy));
-}
-
-function filterVisibleGroupBys(
-  groupBys: readonly string[],
-  fields: EventValidationData['field'] | undefined,
-  validationIsPending: boolean
-): string[] {
-  return groupBys.filter(groupBy => {
-    if (groupBy === '') {
-      return true;
-    }
-
-    const field = fields?.find(({name}) => name === groupBy);
-    return field?.valid || (!validationIsPending && field?.valid !== false);
-  });
-}
-
-function mergeValidatedTags({
-  booleanTags,
-  numberTags,
-  stringTags,
-  validatedFields = [],
-}: {
-  booleanTags: TagCollection;
-  numberTags: TagCollection;
-  stringTags: TagCollection;
-  validatedFields?: EventValidationData['field'];
-}) {
-  const validatedBooleanTags = {...booleanTags};
-  const validatedNumberTags = {...numberTags};
-  const validatedStringTags = {...stringTags};
-
-  for (const validatedField of validatedFields) {
-    const tag = {
-      key: validatedField.name,
-      name: prettifyAttributeName(validatedField.name),
-    };
-
-    if (validatedField.attrType === 'boolean') {
-      validatedBooleanTags[validatedField.name] = {...tag, kind: FieldKind.BOOLEAN};
-    } else if (validatedField.attrType === 'number') {
-      validatedNumberTags[validatedField.name] = {...tag, kind: FieldKind.MEASUREMENT};
-    } else if (validatedField.attrType === 'string') {
-      validatedStringTags[validatedField.name] = {...tag, kind: FieldKind.TAG};
-    }
-  }
-
-  return {validatedBooleanTags, validatedNumberTags, validatedStringTags};
 }

--- a/static/app/views/explore/metrics/metricToolbar/groupBySelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/groupBySelector.tsx
@@ -1,5 +1,6 @@
-import {useCallback, useMemo} from 'react';
+import {useCallback, useLayoutEffect, useMemo, useRef} from 'react';
 import {useQuery} from '@tanstack/react-query';
+import isEqual from 'lodash/isEqual';
 
 import type {SelectOption} from '@sentry/scraps/compactSelect';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
@@ -7,10 +8,14 @@ import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {t} from 'sentry/locale';
+import type {TagCollection} from 'sentry/types/group';
+import {FieldKind} from 'sentry/utils/fields';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {prettifyAttributeName} from 'sentry/views/explore/components/traceItemAttributes/utils';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {useGroupByFields} from 'sentry/views/explore/hooks/useGroupByFields';
 import {HiddenTraceMetricGroupByFields} from 'sentry/views/explore/metrics/constants';
+import {useValidateMetricsTab} from 'sentry/views/explore/metrics/hooks/useValidateMetricsTab';
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 import {createTraceMetricFilter} from 'sentry/views/explore/metrics/utils';
 import {
@@ -23,6 +28,7 @@ import {
   selectTraceItemTagCollection,
   traceItemAttributeKeysOptions,
 } from 'sentry/views/explore/utils/traceItemAttributeKeysOptions';
+import type {EventValidationData} from 'sentry/views/explore/utils/validateEventParamsOptions';
 
 interface GroupBySelectorProps {
   /**
@@ -57,6 +63,84 @@ export function GroupBySelector({
   const groupBys = useQueryParamsGroupBys();
   const setGroupBys = useSetQueryParamsGroupBys();
   const isDisabled = disabledReason !== undefined;
+  const {
+    data: validatedSearchQueryData,
+    isFetching: validationFetching,
+    isLoading: validationLoading,
+    isPlaceholderData: validationIsPlaceholderData,
+  } = useValidateMetricsTab({enabled: groupBys.some(Boolean)});
+  const pendingValidatedGroupBys = useRef<{
+    from: readonly string[];
+    to: readonly string[];
+  } | null>(null);
+  const validationGroupBys = useRef<{
+    data: EventValidationData;
+    groupBys: readonly string[];
+  } | null>(null);
+  const validationIsPending =
+    validationFetching || validationLoading || validationIsPlaceholderData;
+
+  const validatedGroupBys = useMemo(
+    () => filterInvalidGroupBys(groupBys, validatedSearchQueryData?.field),
+    [groupBys, validatedSearchQueryData?.field]
+  );
+  const visibleGroupBys = useMemo(
+    () =>
+      filterVisibleGroupBys(
+        groupBys,
+        validatedSearchQueryData?.field,
+        validationIsPending
+      ),
+    [groupBys, validatedSearchQueryData?.field, validationIsPending]
+  );
+
+  useLayoutEffect(() => {
+    if (pendingValidatedGroupBys.current) {
+      if (isEqual(groupBys, pendingValidatedGroupBys.current.to)) {
+        pendingValidatedGroupBys.current = null;
+      } else if (
+        isEqual(groupBys, pendingValidatedGroupBys.current.from) &&
+        isEqual(validatedGroupBys, pendingValidatedGroupBys.current.to)
+      ) {
+        return;
+      }
+    }
+
+    if (validationIsPending || !validatedSearchQueryData) {
+      return;
+    }
+
+    let validationGroupBySnapshot = validationGroupBys.current;
+    if (
+      !validationGroupBySnapshot?.data ||
+      validationGroupBySnapshot.data !== validatedSearchQueryData
+    ) {
+      validationGroupBySnapshot = {
+        data: validatedSearchQueryData,
+        groupBys,
+      };
+      validationGroupBys.current = validationGroupBySnapshot;
+    }
+
+    if (
+      !isEqual(groupBys, validationGroupBySnapshot.groupBys) ||
+      isEqual(groupBys, validatedGroupBys)
+    ) {
+      return;
+    }
+
+    pendingValidatedGroupBys.current = {
+      from: groupBys,
+      to: validatedGroupBys,
+    };
+    setGroupBys(validatedGroupBys);
+  }, [
+    groupBys,
+    setGroupBys,
+    validatedGroupBys,
+    validatedSearchQueryData,
+    validationIsPending,
+  ]);
 
   const traceMetricFilter = createTraceMetricFilter(traceMetric);
 
@@ -71,32 +155,44 @@ export function GroupBySelector({
     enabled: skipTraceMetricFilter || Boolean(traceMetricFilter),
   });
 
-  const {visibleBooleanTags, visibleNumberTags, visibleStringTags} = useMemo(
-    () => ({
-      visibleBooleanTags: Object.fromEntries(
-        Object.entries(data?.booleanAttributes ?? {}).filter(
-          ([key]) => !HiddenTraceMetricGroupByFields.includes(key)
-        )
+  const {validatedBooleanTags, validatedNumberTags, validatedStringTags} = useMemo(() => {
+    const visibleBooleanTags = Object.fromEntries(
+      Object.entries(data?.booleanAttributes ?? {}).filter(
+        ([key]) => !HiddenTraceMetricGroupByFields.includes(key)
+      )
+    );
+    const visibleNumberTags = Object.fromEntries(
+      Object.entries(data?.numberAttributes ?? {}).filter(
+        ([key]) => !HiddenTraceMetricGroupByFields.includes(key)
+      )
+    );
+    const visibleStringTags = Object.fromEntries(
+      Object.entries(data?.stringAttributes ?? {}).filter(
+        ([key]) => !HiddenTraceMetricGroupByFields.includes(key)
+      )
+    );
+
+    return mergeValidatedTags({
+      booleanTags: visibleBooleanTags,
+      numberTags: visibleNumberTags,
+      stringTags: visibleStringTags,
+      validatedFields: validatedSearchQueryData?.field.filter(
+        field => field.valid && groupBys.includes(field.name)
       ),
-      visibleNumberTags: Object.fromEntries(
-        Object.entries(data?.numberAttributes ?? {}).filter(
-          ([key]) => !HiddenTraceMetricGroupByFields.includes(key)
-        )
-      ),
-      visibleStringTags: Object.fromEntries(
-        Object.entries(data?.stringAttributes ?? {}).filter(
-          ([key]) => !HiddenTraceMetricGroupByFields.includes(key)
-        )
-      ),
-    }),
-    [data?.booleanAttributes, data?.numberAttributes, data?.stringAttributes]
-  );
+    });
+  }, [
+    data?.booleanAttributes,
+    data?.numberAttributes,
+    data?.stringAttributes,
+    groupBys,
+    validatedSearchQueryData?.field,
+  ]);
 
   const enabledOptions = useGroupByFields({
-    groupBys,
-    numberTags: visibleNumberTags ?? {},
-    stringTags: visibleStringTags ?? {},
-    booleanTags: visibleBooleanTags ?? {},
+    groupBys: visibleGroupBys,
+    numberTags: validatedNumberTags,
+    stringTags: validatedStringTags,
+    booleanTags: validatedBooleanTags,
     traceItemType: TraceItemDataset.TRACEMETRICS,
     hideEmptyOption: true,
   });
@@ -139,11 +235,79 @@ export function GroupBySelector({
         />
       )}
       options={enabledOptions}
-      value={[...groupBys]}
-      loading={isLoading}
-      disabled={isDisabled || isLoading || (!skipTraceMetricFilter && !traceMetricFilter)}
+      value={visibleGroupBys}
+      loading={isLoading || validationIsPending}
+      disabled={
+        isDisabled ||
+        isLoading ||
+        validationIsPending ||
+        (!skipTraceMetricFilter && !traceMetricFilter)
+      }
       onChange={handleChange}
       style={{width: '100%'}}
     />
   );
+}
+
+function filterInvalidGroupBys(
+  groupBys: readonly string[],
+  fields: EventValidationData['field'] | undefined
+): string[] {
+  const invalidFields = new Set(
+    fields?.filter(field => !field.valid).map(field => field.name)
+  );
+
+  if (invalidFields.size === 0) {
+    return [...groupBys];
+  }
+
+  return groupBys.filter(groupBy => groupBy === '' || !invalidFields.has(groupBy));
+}
+
+function filterVisibleGroupBys(
+  groupBys: readonly string[],
+  fields: EventValidationData['field'] | undefined,
+  validationIsPending: boolean
+): string[] {
+  return groupBys.filter(groupBy => {
+    if (groupBy === '') {
+      return true;
+    }
+
+    const field = fields?.find(({name}) => name === groupBy);
+    return field?.valid || (!validationIsPending && field?.valid !== false);
+  });
+}
+
+function mergeValidatedTags({
+  booleanTags,
+  numberTags,
+  stringTags,
+  validatedFields = [],
+}: {
+  booleanTags: TagCollection;
+  numberTags: TagCollection;
+  stringTags: TagCollection;
+  validatedFields?: EventValidationData['field'];
+}) {
+  const validatedBooleanTags = {...booleanTags};
+  const validatedNumberTags = {...numberTags};
+  const validatedStringTags = {...stringTags};
+
+  for (const validatedField of validatedFields) {
+    const tag = {
+      key: validatedField.name,
+      name: prettifyAttributeName(validatedField.name),
+    };
+
+    if (validatedField.attrType === 'boolean') {
+      validatedBooleanTags[validatedField.name] = {...tag, kind: FieldKind.BOOLEAN};
+    } else if (validatedField.attrType === 'number') {
+      validatedNumberTags[validatedField.name] = {...tag, kind: FieldKind.MEASUREMENT};
+    } else if (validatedField.attrType === 'string') {
+      validatedStringTags[validatedField.name] = {...tag, kind: FieldKind.TAG};
+    }
+  }
+
+  return {validatedBooleanTags, validatedNumberTags, validatedStringTags};
 }

--- a/static/app/views/explore/metrics/metricToolbar/index.spec.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/index.spec.tsx
@@ -1,7 +1,7 @@
-import {type ReactNode} from 'react';
+import {type ReactNode, useCallback, useState} from 'react';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {MetricsQueryParamsProvider} from 'sentry/views/explore/metrics/metricsQueryParams';
 import {MetricToolbar} from 'sentry/views/explore/metrics/metricToolbar';
@@ -13,6 +13,7 @@ import {
   VisualizeEquation,
   VisualizeFunction,
 } from 'sentry/views/explore/queryParams/visualize';
+import type {EventValidationData} from 'sentry/views/explore/utils/validateEventParamsOptions';
 
 jest.mock('sentry/views/explore/components/traceItemSearchQueryBuilder', () => {
   const actual = jest.requireActual(
@@ -56,6 +57,55 @@ function Wrapper({
       </MetricsQueryParamsProvider>
     </MultiMetricsQueryParamsProvider>
   );
+}
+
+function StatefulWrapper({
+  children,
+  initialQueryParams,
+  onQueryParamsChange,
+}: {
+  children: ReactNode;
+  initialQueryParams: ReadableQueryParams;
+  onQueryParamsChange: (queryParams: ReadableQueryParams) => void;
+}) {
+  const [queryParams, setQueryParams] = useState(initialQueryParams);
+  const handleQueryParamsChange = useCallback(
+    (nextQueryParams: ReadableQueryParams) => {
+      setQueryParams(nextQueryParams);
+      onQueryParamsChange(nextQueryParams);
+    },
+    [onQueryParamsChange]
+  );
+
+  return (
+    <MultiMetricsQueryParamsProvider>
+      <MetricsQueryParamsProvider
+        traceMetric={{name: 'test_metric', type: 'distribution'}}
+        queryParams={queryParams}
+        setQueryParams={handleQueryParamsChange}
+        removeMetric={() => {}}
+        setTraceMetric={() => {}}
+      >
+        {children}
+      </MetricsQueryParamsProvider>
+    </MultiMetricsQueryParamsProvider>
+  );
+}
+
+function makeValidationBody(fields: EventValidationData['field']): EventValidationData {
+  return {
+    dataset: [],
+    environment: [],
+    field: fields,
+    orderby: [],
+    projects: [],
+    query: {
+      error: null,
+      fields: [],
+      valid: true,
+    },
+    valid: fields.every(field => field.valid),
+  };
 }
 
 describe('MetricToolbar', () => {
@@ -204,6 +254,262 @@ describe('MetricToolbar', () => {
     await waitFor(() => {
       expect(screen.getByRole('button', {name: /Group by/})).toBeEnabled();
     });
+  });
+
+  it('uses validated field type for the selected group by', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/validate/',
+      body: makeValidationBody([
+        {
+          attrType: 'number',
+          error: null,
+          name: 'custom.measurement',
+          valid: true,
+        },
+      ]),
+    });
+
+    const queryParams = new ReadableQueryParams({
+      extrapolate: true,
+      mode: Mode.AGGREGATE,
+      query: '',
+      cursor: '',
+      fields: ['id', 'timestamp'],
+      sortBys: [{field: 'timestamp', kind: 'desc'}],
+      aggregateCursor: '',
+      aggregateFields: [
+        {groupBy: 'custom.measurement'},
+        new VisualizeFunction('sum(value,test_metric,distribution,none)'),
+      ],
+      aggregateSortBys: [
+        {field: 'sum(value,test_metric,distribution,none)', kind: 'desc'},
+      ],
+    });
+
+    render(
+      <MetricToolbar
+        traceMetric={{name: 'test_metric', type: 'distribution'}}
+        queryLabel="A"
+      />,
+      {
+        additionalWrapper: ({children}: {children: ReactNode}) => (
+          <Wrapper queryParams={queryParams}>{children}</Wrapper>
+        ),
+      }
+    );
+
+    await userEvent.click(
+      await screen.findByRole('button', {name: /custom.measurement/})
+    );
+    const option = await screen.findByRole('option', {name: 'custom.measurement'});
+    expect(option).toHaveTextContent('number');
+  });
+
+  it('does not render unvalidated selected group bys while validation loads', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/validate/',
+      asyncDelay: 50,
+      body: makeValidationBody([
+        {
+          attrType: null,
+          error: 'Invalid attribute',
+          name: 'invalid.attribute',
+          valid: false,
+        },
+      ]),
+    });
+
+    const queryParams = new ReadableQueryParams({
+      extrapolate: true,
+      mode: Mode.AGGREGATE,
+      query: '',
+      cursor: '',
+      fields: ['id', 'timestamp'],
+      sortBys: [{field: 'timestamp', kind: 'desc'}],
+      aggregateCursor: '',
+      aggregateFields: [
+        {groupBy: 'invalid.attribute'},
+        new VisualizeFunction('sum(value,test_metric,distribution,none)'),
+      ],
+      aggregateSortBys: [
+        {field: 'sum(value,test_metric,distribution,none)', kind: 'desc'},
+      ],
+    });
+
+    render(
+      <MetricToolbar
+        traceMetric={{name: 'test_metric', type: 'distribution'}}
+        queryLabel="A"
+      />,
+      {
+        additionalWrapper: ({children}: {children: ReactNode}) => (
+          <Wrapper queryParams={queryParams}>{children}</Wrapper>
+        ),
+      }
+    );
+
+    expect(
+      screen.queryByRole('button', {name: /invalid.attribute/})
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('button', {name: /Group by/})).toBeDisabled();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', {name: /Group by/})).toBeEnabled();
+    });
+  });
+
+  it('does not remove selected group bys using placeholder validation data', async () => {
+    const delayedValidateMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/validate/',
+      asyncDelay: 1000,
+      body: makeValidationBody([
+        {
+          attrType: null,
+          error: 'Invalid attribute',
+          name: 'invalid.attribute',
+          valid: false,
+        },
+      ]),
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/validate/',
+      match: [
+        (_url, options) => JSON.stringify(options.query?.field).includes('valid.first'),
+      ],
+      body: makeValidationBody([
+        {
+          attrType: 'string',
+          error: null,
+          name: 'valid.first',
+          valid: true,
+        },
+        {
+          attrType: null,
+          error: 'Invalid attribute',
+          name: 'invalid.attribute',
+          valid: false,
+        },
+      ]),
+    });
+
+    const visualize = new VisualizeFunction('sum(value,test_metric,distribution,none)');
+    const initialQueryParams = new ReadableQueryParams({
+      extrapolate: true,
+      mode: Mode.AGGREGATE,
+      query: '',
+      cursor: '',
+      fields: ['id', 'timestamp'],
+      sortBys: [{field: 'timestamp', kind: 'desc'}],
+      aggregateCursor: '',
+      aggregateFields: [{groupBy: 'valid.first'}, visualize],
+      aggregateSortBys: [{field: visualize.yAxis, kind: 'desc'}],
+    });
+    const nextQueryParams = initialQueryParams.replace({
+      aggregateFields: [{groupBy: 'invalid.attribute'}, visualize],
+    });
+    let currentGroupBys: readonly string[] = [];
+
+    function Component() {
+      const [queryParams, setQueryParams] = useState(initialQueryParams);
+      currentGroupBys = queryParams.groupBys;
+
+      return (
+        <MultiMetricsQueryParamsProvider>
+          <button type="button" onClick={() => setQueryParams(nextQueryParams)}>
+            Load invalid group by
+          </button>
+          <MetricsQueryParamsProvider
+            traceMetric={{name: 'test_metric', type: 'distribution'}}
+            queryParams={queryParams}
+            setQueryParams={setQueryParams}
+            removeMetric={() => {}}
+            setTraceMetric={() => {}}
+          >
+            <MetricToolbar
+              traceMetric={{name: 'test_metric', type: 'distribution'}}
+              queryLabel="A"
+            />
+          </MetricsQueryParamsProvider>
+        </MultiMetricsQueryParamsProvider>
+      );
+    }
+
+    render(<Component />);
+
+    expect(await screen.findByRole('button', {name: /valid.first/})).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', {name: 'Load invalid group by'}));
+
+    await waitFor(() => expect(delayedValidateMock).toHaveBeenCalled());
+    expect(currentGroupBys).toEqual(['invalid.attribute']);
+
+    await waitFor(() => expect(currentGroupBys).toEqual([]), {timeout: 2000});
+  });
+
+  it('removes invalid selected group bys and preserves empty values', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/validate/',
+      body: makeValidationBody([
+        {
+          attrType: null,
+          error: 'Invalid attribute',
+          name: 'invalid.attribute',
+          valid: false,
+        },
+        {
+          attrType: 'string',
+          error: null,
+          name: 'environment',
+          valid: true,
+        },
+      ]),
+    });
+
+    const queryParams = new ReadableQueryParams({
+      extrapolate: true,
+      mode: Mode.AGGREGATE,
+      query: '',
+      cursor: '',
+      fields: ['id', 'timestamp'],
+      sortBys: [{field: 'timestamp', kind: 'desc'}],
+      aggregateCursor: '',
+      aggregateFields: [
+        {groupBy: 'invalid.attribute'},
+        {groupBy: ''},
+        {groupBy: 'environment'},
+        new VisualizeFunction('sum(value,test_metric,distribution,none)'),
+      ],
+      aggregateSortBys: [
+        {field: 'sum(value,test_metric,distribution,none)', kind: 'desc'},
+      ],
+    });
+    let updatedQueryParams: ReadableQueryParams | undefined;
+
+    render(
+      <MetricToolbar
+        traceMetric={{name: 'test_metric', type: 'distribution'}}
+        queryLabel="A"
+      />,
+      {
+        additionalWrapper: ({children}: {children: ReactNode}) => (
+          <StatefulWrapper
+            initialQueryParams={queryParams}
+            onQueryParamsChange={nextQueryParams => {
+              updatedQueryParams = nextQueryParams;
+            }}
+          >
+            {children}
+          </StatefulWrapper>
+        ),
+      }
+    );
+
+    await waitFor(() => {
+      expect(updatedQueryParams?.groupBys).toEqual(['', 'environment']);
+    });
+    expect(updatedQueryParams?.mode).toBe(Mode.AGGREGATE);
+    expect(
+      screen.queryByRole('button', {name: /invalid.attribute/})
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/static/app/views/explore/metrics/metricToolbar/index.spec.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/index.spec.tsx
@@ -124,6 +124,10 @@ describe('MetricToolbar', () => {
       url: '/organizations/org-slug/recent-searches/',
       body: [],
     });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/validate/',
+      body: makeValidationBody([]),
+    });
   });
 
   it('renders group by selector for equation visualizations', async () => {
@@ -455,13 +459,19 @@ describe('MetricToolbar', () => {
           name: 'invalid.attribute',
           valid: false,
         },
-        {
-          attrType: 'string',
-          error: null,
-          name: 'environment',
-          valid: true,
-        },
       ]),
+      match: [
+        (_url, options) =>
+          JSON.stringify(options.query?.field).includes('invalid.attribute'),
+      ],
+    });
+    const cleanedValidateMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/validate/',
+      body: makeValidationBody([]),
+      match: [
+        (_url, options) =>
+          !JSON.stringify(options.query?.field).includes('invalid.attribute'),
+      ],
     });
 
     const queryParams = new ReadableQueryParams({
@@ -475,7 +485,6 @@ describe('MetricToolbar', () => {
       aggregateFields: [
         {groupBy: 'invalid.attribute'},
         {groupBy: ''},
-        {groupBy: 'environment'},
         new VisualizeFunction('sum(value,test_metric,distribution,none)'),
       ],
       aggregateSortBys: [
@@ -504,12 +513,14 @@ describe('MetricToolbar', () => {
     );
 
     await waitFor(() => {
-      expect(updatedQueryParams?.groupBys).toEqual(['', 'environment']);
+      expect(updatedQueryParams?.groupBys).toEqual(['']);
     });
     expect(updatedQueryParams?.mode).toBe(Mode.AGGREGATE);
     expect(
       screen.queryByRole('button', {name: /invalid.attribute/})
     ).not.toBeInTheDocument();
+    await waitFor(() => expect(cleanedValidateMock).toHaveBeenCalled());
+    expect(screen.getByRole('button', {name: /Group by/})).toBeEnabled();
   });
 });
 

--- a/static/app/views/explore/metrics/metricsTab.spec.tsx
+++ b/static/app/views/explore/metrics/metricsTab.spec.tsx
@@ -482,6 +482,12 @@ describe('MetricsTabContent', () => {
     setupPageFilters();
 
     MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/validate/`,
+      method: 'GET',
+      body: validationBody,
+    });
+
+    MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
       method: 'GET',
       body: {data: []},

--- a/static/app/views/explore/toolbar/toolbarGroupBy.tsx
+++ b/static/app/views/explore/toolbar/toolbarGroupBy.tsx
@@ -1,8 +1,5 @@
-import {useCallback, useLayoutEffect, useMemo, useRef, useState} from 'react';
-import isEqual from 'lodash/isEqual';
+import {useCallback, useMemo, useState} from 'react';
 
-import type {TagCollection} from 'sentry/types/group';
-import {FieldKind} from 'sentry/utils/fields';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {
   ToolbarFooter,
@@ -13,14 +10,18 @@ import {
   ToolbarGroupByDropdown,
   ToolbarGroupByHeader,
 } from 'sentry/views/explore/components/toolbar/toolbarGroupBy';
-import {prettifyAttributeName} from 'sentry/views/explore/components/traceItemAttributes/utils';
 import {DragNDropContext} from 'sentry/views/explore/contexts/dragNDropContext';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import type {Column} from 'sentry/views/explore/hooks/useDragNDropColumns';
 import {useGroupByFields} from 'sentry/views/explore/hooks/useGroupByFields';
 import {useSpanItemAttributes} from 'sentry/views/explore/hooks/useTraceItemAttributes';
+import {useValidatedGroupBys} from 'sentry/views/explore/hooks/useValidatedGroupBys';
 import {useValidateSpansTab} from 'sentry/views/explore/spans/hooks/useValidateSpansTab';
 import {TraceItemDataset} from 'sentry/views/explore/types';
+import {
+  mergeValidatedGroupByTags,
+  shouldHideGroupByForValidation,
+} from 'sentry/views/explore/utils/groupByValidation';
 import type {EventValidationData} from 'sentry/views/explore/utils/validateEventParamsOptions';
 
 interface ToolbarGroupByProps {
@@ -35,83 +36,25 @@ export function ToolbarGroupBy({groupBys, setGroupBys}: ToolbarGroupByProps) {
     isLoading: validationLoading,
     isPlaceholderData: validationIsPlaceholderData,
   } = useValidateSpansTab();
-  const pendingValidatedGroupBys = useRef<{
-    from: readonly string[];
-    to: readonly string[];
-  } | null>(null);
-  const validationGroupBys = useRef<{
-    data: EventValidationData;
-    groupBys: readonly string[];
-  } | null>(null);
   const validationIsPending =
     validationFetching || validationLoading || validationIsPlaceholderData;
 
-  const validatedGroupBys = useMemo(
-    () => filterInvalidGroupBys(groupBys, validatedSearchQueryData?.field),
-    [groupBys, validatedSearchQueryData?.field]
-  );
-  const visibleGroupBys = useMemo(
-    () =>
-      filterVisibleGroupBys(
-        groupBys,
-        validatedSearchQueryData?.field,
-        validationIsPending
-      ),
-    [groupBys, validatedSearchQueryData?.field, validationIsPending]
-  );
-
-  useLayoutEffect(() => {
-    if (pendingValidatedGroupBys.current) {
-      if (isEqual(groupBys, pendingValidatedGroupBys.current.to)) {
-        pendingValidatedGroupBys.current = null;
-      } else if (
-        isEqual(groupBys, pendingValidatedGroupBys.current.from) &&
-        isEqual(validatedGroupBys, pendingValidatedGroupBys.current.to)
-      ) {
-        return;
+  const cleanupInvalidGroupBys = useCallback(
+    (validatedGroupBys: string[]) => {
+      if (validatedGroupBys.some(Boolean)) {
+        setGroupBys(validatedGroupBys);
+      } else {
+        setGroupBys(validatedGroupBys, Mode.SAMPLES);
       }
-    }
-
-    if (validationIsPending || !validatedSearchQueryData) {
-      return;
-    }
-
-    let validationGroupBySnapshot = validationGroupBys.current;
-    if (
-      !validationGroupBySnapshot?.data ||
-      validationGroupBySnapshot.data !== validatedSearchQueryData
-    ) {
-      validationGroupBySnapshot = {
-        data: validatedSearchQueryData,
-        groupBys,
-      };
-      validationGroupBys.current = validationGroupBySnapshot;
-    }
-
-    if (
-      !isEqual(groupBys, validationGroupBySnapshot.groupBys) ||
-      isEqual(groupBys, validatedGroupBys)
-    ) {
-      return;
-    }
-
-    pendingValidatedGroupBys.current = {
-      from: groupBys,
-      to: validatedGroupBys,
-    };
-
-    if (validatedGroupBys.some(Boolean)) {
-      setGroupBys(validatedGroupBys);
-    } else {
-      setGroupBys(validatedGroupBys, Mode.SAMPLES);
-    }
-  }, [
+    },
+    [setGroupBys]
+  );
+  const {visibleGroupBys} = useValidatedGroupBys({
     groupBys,
-    setGroupBys,
-    validatedGroupBys,
-    validatedSearchQueryData,
+    validationData: validatedSearchQueryData,
     validationIsPending,
-  ]);
+    onGroupBysCleanup: cleanupInvalidGroupBys,
+  });
 
   const setGroupBysWithOp = useCallback(
     (columns: string[], op: 'insert' | 'update' | 'delete' | 'reorder') => {
@@ -207,7 +150,12 @@ function ToolbarGroupByItem({
       };
     }
 
-    return mergeValidatedTags({booleanTags, numberTags, stringTags, validatedField});
+    return mergeValidatedGroupByTags({
+      booleanTags,
+      numberTags,
+      stringTags,
+      validatedFields: [validatedField],
+    });
   }, [booleanTags, column, numberTags, stringTags, validatedSearchQueryData?.field]);
 
   const options = useGroupByFields({
@@ -241,116 +189,4 @@ function ToolbarGroupByItem({
       onColumnDelete={onColumnDelete}
     />
   );
-}
-
-function filterInvalidGroupBys(
-  groupBys: readonly string[],
-  fields: EventValidationData['field'] | undefined
-): string[] {
-  const invalidFields = new Set(
-    fields?.filter(field => !field.valid).map(field => field.name)
-  );
-
-  if (invalidFields.size === 0) {
-    return [...groupBys];
-  }
-
-  return groupBys.filter(groupBy => groupBy === '' || !invalidFields.has(groupBy));
-}
-
-function filterVisibleGroupBys(
-  groupBys: readonly string[],
-  fields: EventValidationData['field'] | undefined,
-  validationIsPending: boolean
-): string[] {
-  return groupBys.filter(
-    groupBy => !shouldHideGroupByForValidation(groupBy, fields, validationIsPending)
-  );
-}
-
-function shouldHideGroupByForValidation(
-  groupBy: string,
-  fields: EventValidationData['field'] | undefined,
-  validationIsPending: boolean
-): boolean {
-  if (groupBy === '') {
-    return false;
-  }
-
-  const field = fields?.find(({name}) => name === groupBy);
-
-  if (field?.valid) {
-    return false;
-  }
-
-  return validationIsPending || field?.valid === false;
-}
-
-function mergeValidatedTags({
-  booleanTags,
-  numberTags,
-  stringTags,
-  validatedField,
-}: {
-  booleanTags: TagCollection;
-  numberTags: TagCollection;
-  stringTags: TagCollection;
-  validatedField: EventValidationData['field'][number];
-}) {
-  switch (validatedField.attrType) {
-    case 'boolean': {
-      const validatedBooleanTags = {
-        ...booleanTags,
-        [validatedField.name]: {
-          key: validatedField.name,
-          name: prettifyAttributeName(validatedField.name),
-          kind: FieldKind.BOOLEAN,
-        },
-      };
-
-      return {
-        validatedBooleanTags,
-        validatedNumberTags: numberTags,
-        validatedStringTags: stringTags,
-      };
-    }
-    case 'number': {
-      const validatedNumberTags = {
-        ...numberTags,
-        [validatedField.name]: {
-          key: validatedField.name,
-          name: prettifyAttributeName(validatedField.name),
-          kind: FieldKind.MEASUREMENT,
-        },
-      };
-
-      return {
-        validatedBooleanTags: booleanTags,
-        validatedNumberTags,
-        validatedStringTags: stringTags,
-      };
-    }
-    case 'string': {
-      const validatedStringTags = {
-        ...stringTags,
-        [validatedField.name]: {
-          key: validatedField.name,
-          name: prettifyAttributeName(validatedField.name),
-          kind: FieldKind.TAG,
-        },
-      };
-
-      return {
-        validatedBooleanTags: booleanTags,
-        validatedNumberTags: numberTags,
-        validatedStringTags,
-      };
-    }
-    default:
-      return {
-        validatedBooleanTags: booleanTags,
-        validatedNumberTags: numberTags,
-        validatedStringTags: stringTags,
-      };
-  }
 }

--- a/static/app/views/explore/utils/groupByValidation.tsx
+++ b/static/app/views/explore/utils/groupByValidation.tsx
@@ -1,0 +1,84 @@
+import type {TagCollection} from 'sentry/types/group';
+import {FieldKind} from 'sentry/utils/fields';
+import {prettifyAttributeName} from 'sentry/views/explore/components/traceItemAttributes/utils';
+import type {EventValidationData} from 'sentry/views/explore/utils/validateEventParamsOptions';
+
+export function filterInvalidGroupBys(
+  groupBys: readonly string[],
+  fields: EventValidationData['field'] | undefined
+): string[] {
+  const invalidFields = new Set(
+    fields?.filter(field => !field.valid).map(field => field.name)
+  );
+
+  if (invalidFields.size === 0) {
+    return [...groupBys];
+  }
+
+  return groupBys.filter(groupBy => groupBy === '' || !invalidFields.has(groupBy));
+}
+
+export function filterVisibleGroupBys(
+  groupBys: readonly string[],
+  fields: EventValidationData['field'] | undefined,
+  validationIsPending: boolean
+): string[] {
+  return groupBys.filter(
+    groupBy => !shouldHideGroupByForValidation(groupBy, fields, validationIsPending)
+  );
+}
+
+export function shouldHideGroupByForValidation(
+  groupBy: string,
+  fields: EventValidationData['field'] | undefined,
+  validationIsPending: boolean
+): boolean {
+  if (groupBy === '') {
+    return false;
+  }
+
+  const field = fields?.find(({name}) => name === groupBy);
+
+  if (field?.valid) {
+    return false;
+  }
+
+  return validationIsPending || field?.valid === false;
+}
+
+export function mergeValidatedGroupByTags({
+  booleanTags,
+  numberTags,
+  stringTags,
+  validatedFields = [],
+}: {
+  booleanTags: TagCollection;
+  numberTags: TagCollection;
+  stringTags: TagCollection;
+  validatedFields?: EventValidationData['field'];
+}) {
+  const validatedBooleanTags = {...booleanTags};
+  const validatedNumberTags = {...numberTags};
+  const validatedStringTags = {...stringTags};
+
+  for (const validatedField of validatedFields) {
+    if (!validatedField.valid) {
+      continue;
+    }
+
+    const tag = {
+      key: validatedField.name,
+      name: prettifyAttributeName(validatedField.name),
+    };
+
+    if (validatedField.attrType === 'boolean') {
+      validatedBooleanTags[validatedField.name] = {...tag, kind: FieldKind.BOOLEAN};
+    } else if (validatedField.attrType === 'number') {
+      validatedNumberTags[validatedField.name] = {...tag, kind: FieldKind.MEASUREMENT};
+    } else if (validatedField.attrType === 'string') {
+      validatedStringTags[validatedField.name] = {...tag, kind: FieldKind.TAG};
+    }
+  }
+
+  return {validatedBooleanTags, validatedNumberTags, validatedStringTags};
+}


### PR DESCRIPTION
Metric group-by selectors now validate URL and user selections against the events validation endpoint when selected fields are absent from attribute results. Valid fields render with their validated types, unresolved or invalid values stay hidden, and invalid selections are removed only after validation settles while preserving blank values and aggregate mode.

The cleanup associates each validation response with its group-by snapshot so placeholder data from a previous query cannot strip a newer selection. This mirrors the spans group-by behavior and covers field classification, loading state, stale validation data, and query-parameter cleanup.

Closes EXP-1024
