### PR TITLE
ref(seer): add viewer_context_scope to ingest and explorer_index paths

### DIFF
--- a/src/sentry/tasks/seer/explorer_index.py
+++ b/src/sentry/tasks/seer/explorer_index.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import logging
 from collections.abc import Generator, Iterator
 from datetime import datetime, timedelta
@@ -21,6 +22,7 @@ from sentry.tasks.utils import compute_delay
 from sentry.taskworker.namespaces import seer_tasks
 from sentry.utils.query import RangeQuerySetWrapper
 from sentry.utils.tracing import start_span
+from sentry.viewer_context import ActorType, ViewerContext, viewer_context_scope
 
 logger = logging.getLogger("sentry.tasks.seer_explorer_indexer")
 
@@ -228,25 +230,33 @@ def run_explorer_index_for_projects(
 
     # Only set viewer_context when all projects in the batch share the same org
     org_ids = {org_id for _, org_id in projects}
-    viewer_context = SeerViewerContext(organization_id=org_ids.pop()) if len(org_ids) == 1 else None
+    if len(org_ids) == 1:
+        the_org_id = org_ids.pop()
+        viewer_context = SeerViewerContext(organization_id=the_org_id)
+        vc = ViewerContext(organization_id=the_org_id, actor_type=ActorType.SYSTEM)
+        scope: contextlib.AbstractContextManager[None] = viewer_context_scope(vc)
+    else:
+        viewer_context = None
+        scope = contextlib.nullcontext()
 
-    try:
-        response = make_agent_index_request(
-            payload,
-            timeout=30,
-            viewer_context=viewer_context,
-        )
-        if response.status >= 400:
-            raise SeerApiError("Seer request failed", response.status)
-    except Exception as e:
-        logger.exception(
-            "Failed to schedule explorer index tasks in seer",
-            extra={
-                "num_projects": len(projects),
-                "error": str(e),
-            },
-        )
-        raise
+    with scope:
+        try:
+            response = make_agent_index_request(
+                payload,
+                timeout=30,
+                viewer_context=viewer_context,
+            )
+            if response.status >= 400:
+                raise SeerApiError("Seer request failed", response.status)
+        except Exception as e:
+            logger.exception(
+                "Failed to schedule explorer index tasks in seer",
+                extra={
+                    "num_projects": len(projects),
+                    "error": str(e),
+                },
+            )
+            raise
 
     result = response.json()
     scheduled_count = result.get("scheduled_count", 0)

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -38,6 +38,7 @@ from sentry.utils.event_tracker import TransactionStageStatus, track_sampled_eve
 from sentry.utils.safe import safe_execute
 from sentry.utils.sdk import set_current_event_project
 from sentry.utils.tracing import set_span_data, start_span, trace
+from sentry.viewer_context import ActorType, ViewerContext, viewer_context_scope
 
 error_logger = logging.getLogger("sentry.errors.events")
 info_logger = logging.getLogger("sentry.store")
@@ -550,35 +551,42 @@ def _do_save_event(
                 attachments = [a for a in all_attachments if not a.rate_limited]
             project = resolve_project(project_id)
 
-            if killswitch_matches_context(
-                "store.load-shed-save-event-projects",
-                {
-                    "project_id": project_id,
-                    "event_type": event_type,
-                    "platform": data.get("platform") or "none",
-                },
+            with viewer_context_scope(
+                ViewerContext(
+                    organization_id=project.organization_id,
+                    project_id=project.id,
+                    actor_type=ActorType.SYSTEM,
+                )
             ):
-                raise HashDiscarded("Load shedding save_event")
+                if killswitch_matches_context(
+                    "store.load-shed-save-event-projects",
+                    {
+                        "project_id": project_id,
+                        "event_type": event_type,
+                        "platform": data.get("platform") or "none",
+                    },
+                ):
+                    raise HashDiscarded("Load shedding save_event")
 
-            manager = EventManager(data)
-            # event.project.organization is populated after this statement.
-            manager.save(
-                project=project,
-                assume_normalized=True,
-                start_time=start_time,
-                cache_key=cache_key,
-                attachments=attachments,
-            )
-            # Put the updated event back into the cache so that post_process
-            # has the most recent data.
+                manager = EventManager(data)
+                # event.project.organization is populated after this statement.
+                manager.save(
+                    project=project,
+                    assume_normalized=True,
+                    start_time=start_time,
+                    cache_key=cache_key,
+                    attachments=attachments,
+                )
+                # Put the updated event back into the cache so that post_process
+                # has the most recent data.
 
-            # We don't need to update the event in the processing_store for transaction events
-            # because they're not used in post_process.
-            if consumer_type != ConsumerType.Transactions:
-                data = manager.get_data()
-                if not isinstance(data, dict):
-                    data = dict(data.items())
-                processing_store.store(data)
+                # We don't need to update the event in the processing_store for transaction events
+                # because they're not used in post_process.
+                if consumer_type != ConsumerType.Transactions:
+                    data = manager.get_data()
+                    if not isinstance(data, dict):
+                        data = dict(data.items())
+                    processing_store.store(data)
 
         except HashDiscarded:
             # Delete the event payload from cache since it won't show up in post-processing.

--- a/tests/sentry/tasks/seer/test_explorer_index.py
+++ b/tests/sentry/tasks/seer/test_explorer_index.py
@@ -15,6 +15,7 @@ from sentry.tasks.seer.explorer_index import (
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.pytest.fixtures import django_db_all
+from sentry.viewer_context import ActorType, get_viewer_context
 
 
 @django_db_all
@@ -385,3 +386,41 @@ class TestRunExplorerIndexForProjects(TestCase):
             ) as mock_request:
                 run_explorer_index_for_projects([(1, 100)], "2024-01-15T12:00:00+00:00")
                 mock_request.assert_not_called()
+
+    @patch("sentry.tasks.seer.explorer_index.make_agent_index_request")
+    def test_sets_viewer_context_for_single_org_batch(self, mock_request):
+        mock_request.return_value.status = 200
+        mock_request.return_value.json.return_value = {"scheduled_count": 2, "projects": []}
+
+        captured_vc = None
+
+        def capture_vc(*args, **kwargs):
+            nonlocal captured_vc
+            captured_vc = get_viewer_context()
+            return mock_request.return_value
+
+        mock_request.side_effect = capture_vc
+
+        run_explorer_index_for_projects([(1, 100), (2, 100)], "2024-01-15T12:00:00+00:00")
+
+        assert captured_vc is not None
+        assert captured_vc.organization_id == 100
+        assert captured_vc.actor_type == ActorType.SYSTEM
+
+    @patch("sentry.tasks.seer.explorer_index.make_agent_index_request")
+    def test_no_viewer_context_org_for_multi_org_batch(self, mock_request):
+        mock_request.return_value.status = 200
+        mock_request.return_value.json.return_value = {"scheduled_count": 2, "projects": []}
+
+        captured_vc = None
+
+        def capture_vc(*args, **kwargs):
+            nonlocal captured_vc
+            captured_vc = get_viewer_context()
+            return mock_request.return_value
+
+        mock_request.side_effect = capture_vc
+
+        run_explorer_index_for_projects([(1, 100), (2, 200)], "2024-01-15T12:00:00+00:00")
+
+        assert captured_vc is None

--- a/tests/sentry/tasks/test_store.py
+++ b/tests/sentry/tasks/test_store.py
@@ -15,6 +15,7 @@ from sentry.tasks.store import (
     should_process,
 )
 from sentry.testutils.pytest.fixtures import django_db_all
+from sentry.viewer_context import ActorType, get_viewer_context
 
 EVENT_ID = "cc3e6c2bb6b6498097f336d1e6979f4b"
 
@@ -280,6 +281,32 @@ def test_hash_discarded_raised(default_project, mock_refund) -> None:
     with mock.patch.object(EventManager, "save", mock_save):
         save_event(data=data, start_time=now)
         # should be caught
+
+
+@django_db_all
+def test_save_event_sets_viewer_context(default_project) -> None:
+    data = {
+        "project": default_project.id,
+        "platform": "python",
+        "logentry": {"formatted": "test"},
+        "event_id": EVENT_ID,
+        "extra": {"foo": "bar"},
+    }
+
+    captured_vc = None
+
+    def capture_vc(*args, **kwargs):
+        nonlocal captured_vc
+        captured_vc = get_viewer_context()
+        raise HashDiscarded("stop after capturing")
+
+    with mock.patch.object(EventManager, "save", side_effect=capture_vc):
+        save_event(data=data, start_time=time())
+
+    assert captured_vc is not None
+    assert captured_vc.organization_id == default_project.organization_id
+    assert captured_vc.project_id == default_project.id
+    assert captured_vc.actor_type == ActorType.SYSTEM
 
 
 @pytest.fixture(params=["org", "project"])


### PR DESCRIPTION
## Summary

- Set `viewer_context_scope` in `_do_save_event` (store.py) after project is resolved, wrapping `EventManager.save()` and downstream processing. Covers all Seer calls in the ingest pipeline (grouping similarity, training, severity scoring).
- Set `viewer_context_scope` in `run_explorer_index_for_projects` (explorer_index.py) for single-org batches around the `make_agent_index_request` call.
- These two paths account for 100% of `seer.viewer_context_not_set` warnings observed in production after deploying the instrumentation in #121270.

Part of [AIML-3206](https://linear.app/getsentry/issue/AIML-3206) (SeerViewerContext retirement Step 2).

## Test plan

- [x] New e2e tests verify `get_viewer_context()` returns correct org_id, project_id, and actor_type inside `EventManager.save()` and `make_agent_index_request`
- [x] All existing tests pass (38 total across store.py and explorer_index.py)
- [ ] After deploy: `seer.viewer_context_not_set` warnings in GCP logs (sentry-s4s2) should drop to zero