### PR TITLE
feat(workflow-engine): Hook into organization creation signals

### DIFF
--- a/src/sentry/hybridcloud/services/cell_organization_provisioning/impl.py
+++ b/src/sentry/hybridcloud/services/cell_organization_provisioning/impl.py
@@ -21,7 +21,7 @@ from sentry.models.organizationmember import OrganizationMember
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.organizationslugreservation import OrganizationSlugReservationType
 from sentry.services.organization import OrganizationOptions, OrganizationProvisioningOptions
-from sentry.signals import terms_accepted
+from sentry.signals import organization_created, terms_accepted
 from sentry.users.services.user.model import RpcUser
 from sentry.utils.audit import create_audit_entry_from_user
 
@@ -214,6 +214,12 @@ class DatabaseBackedCellOrganizationProvisioningRpcService(CellOrganizationProvi
                 )
             except Exception as e:
                 capture_exception(e)
+
+        organization_created.send_robust(
+            organization=organization,
+            user=provision_options.owner,
+            sender=type(self),
+        )
 
     def update_organization_slug_from_reservation(
         self,

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3415,7 +3415,7 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
-    "workflow_engine.all_projects_detector_creation_enabled",
+    "workflow_engine.all_projects_auto_creation_enabled",
     type=Bool,
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3414,6 +3414,12 @@ register(
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "workflow_engine.all_projects_detector_creation_enabled",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 register(
     "workflow_engine.group.type_id.open_periods_type_denylist",

--- a/src/sentry/signals.py
+++ b/src/sentry/signals.py
@@ -99,6 +99,7 @@ transaction_processed = BetterSignal()  # ["project", "event"]
 event_accepted = BetterSignal()  # ["ip", "data", "project"]
 
 # Organization Onboarding Signals
+organization_created = BetterSignal()  # ["organization", "user"]
 project_created = BetterSignal()  # ["project", "user", "default_rules"]
 project_transferred = BetterSignal()  # ["old_org_id", "project"]
 

--- a/src/sentry/workflow_engine/defaults/workflows.py
+++ b/src/sentry/workflow_engine/defaults/workflows.py
@@ -6,12 +6,19 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.types import FallthroughChoiceType
-from sentry.workflow_engine.defaults.detectors import _ensure_detector
+from sentry.workflow_engine.defaults.detectors import (
+    _ensure_detector,
+    ensure_default_all_projects_detector,
+)
+from sentry.workflow_engine.handlers.condition.seer_activity_trigger_handler import (
+    SeerActivityTriggerStage,
+)
 from sentry.workflow_engine.models import (
     Action,
     DataCondition,
     DataConditionGroup,
     DataConditionGroupAction,
+    Detector,
     DetectorWorkflow,
     Workflow,
     WorkflowDataConditionGroup,
@@ -20,26 +27,15 @@ from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.typings.grouptype import IssueStreamGroupType
 
 DEFAULT_WORKFLOW_LABEL = "Send a notification for high priority issues"
+PULL_REQUEST_WORKFLOW_LABEL = "Send a notification when pull requests are ready"
 
 
-def connect_workflows_to_issue_stream(
-    project: Project,
+def connect_workflows_to_detector(
+    detector: Detector,
     workflows: list[Workflow],
 ) -> Sequence[DetectorWorkflow]:
-    # Because we don't know if this signal is handled already or not...
-    issue_stream_detector = _ensure_detector(project, IssueStreamGroupType.slug)
-
-    connections = [
-        DetectorWorkflow(
-            workflow=workflow,
-            detector=issue_stream_detector,
-        )
-        for workflow in workflows
-    ]
-    return DetectorWorkflow.objects.bulk_create(
-        connections,
-        ignore_conflicts=True,
-    )
+    connections = [DetectorWorkflow(workflow=workflow, detector=detector) for workflow in workflows]
+    return DetectorWorkflow.objects.bulk_create(connections, ignore_conflicts=True)
 
 
 def create_priority_workflow(org: Organization) -> Workflow:
@@ -105,8 +101,67 @@ def create_priority_workflow(org: Organization) -> Workflow:
     return workflow
 
 
+def create_pull_request_workflow(organization: Organization) -> Workflow:
+    with transaction.atomic(router.db_for_write(Workflow)):
+        when_condition_group = DataConditionGroup.objects.create(
+            logic_type=DataConditionGroup.Type.ANY_SHORT_CIRCUIT, organization=organization
+        )
+        workflow = Workflow.objects.create(
+            organization=organization,
+            name=PULL_REQUEST_WORKFLOW_LABEL,
+            when_condition_group=when_condition_group,
+            config={"frequency": 0},
+        )
+        DataCondition.objects.create(
+            type=Condition.SEER_ACTIVITY_TRIGGER,
+            condition_group=when_condition_group,
+            comparison=[SeerActivityTriggerStage.PR_CREATED.value],
+            condition_result=True,
+        )
+        action_filter = DataConditionGroup.objects.create(
+            logic_type=DataConditionGroup.Type.ANY_SHORT_CIRCUIT,
+            organization=organization,
+        )
+        action = Action.objects.create(
+            type=Action.Type.EMAIL,
+            config={
+                "target_type": ActionTarget.ISSUE_OWNERS,
+                "target_identifier": None,
+            },
+            data={
+                "fallthrough_type": FallthroughChoiceType.ACTIVE_MEMBERS.value,
+            },
+        )
+        DataConditionGroupAction.objects.create(action=action, condition_group=action_filter)
+        WorkflowDataConditionGroup.objects.create(workflow=workflow, condition_group=action_filter)
+
+    return workflow
+
+
 def ensure_default_workflows(project: Project) -> list[Workflow]:
     workflows = [create_priority_workflow(project.organization)]
-    connect_workflows_to_issue_stream(project, workflows)
+    # Because we don't know if this signal is handled already or not...
+    issue_stream_detector = _ensure_detector(project, IssueStreamGroupType.slug)
+    connect_workflows_to_detector(issue_stream_detector, workflows)
+    return workflows
 
+
+def ensure_pull_request_workflow(organization: Organization, detector: Detector) -> Workflow:
+    """
+    A primitive attempt to prevent duplicate workflows by checking if this label/detector combo
+    already exists. We don't intend to call `ensure_default_organization_workflows` twice regardless,
+    but this will guard if that does happen in quick succession (maybe from an RPC blip somehow).
+    """
+    existing = Workflow.objects.filter(
+        organization=organization,
+        name=PULL_REQUEST_WORKFLOW_LABEL,
+        detectorworkflow__detector=detector,
+    ).first()
+    return existing if existing else create_pull_request_workflow(organization)
+
+
+def ensure_default_organization_workflows(organization: Organization) -> list[Workflow]:
+    all_projects_detector = ensure_default_all_projects_detector(organization.id)
+    workflows = [ensure_pull_request_workflow(organization, all_projects_detector)]
+    connect_workflows_to_detector(all_projects_detector, workflows)
     return workflows

--- a/src/sentry/workflow_engine/defaults/workflows.py
+++ b/src/sentry/workflow_engine/defaults/workflows.py
@@ -127,6 +127,9 @@ def create_priority_workflow(org: Organization) -> Workflow:
 def create_and_connect_pull_request_workflow(
     organization: Organization, detector: Detector
 ) -> Workflow:
+    """
+    Creates the default PR workflow and connects it to a given detector.
+    """
     with transaction.atomic(router.db_for_write(Workflow)):
         when_condition_group = DataConditionGroup.objects.create(
             logic_type=DataConditionGroup.Type.ANY_SHORT_CIRCUIT, organization=organization

--- a/src/sentry/workflow_engine/defaults/workflows.py
+++ b/src/sentry/workflow_engine/defaults/workflows.py
@@ -2,11 +2,14 @@ from typing import Sequence
 
 from django.db import router, transaction
 
+from sentry.locks import locks
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.types import FallthroughChoiceType
+from sentry.utils.locking import UnableToAcquireLock
 from sentry.workflow_engine.defaults.detectors import (
+    UnableToAcquireLockApiError,
     _ensure_detector,
     ensure_default_all_projects_detector,
 )
@@ -28,6 +31,26 @@ from sentry.workflow_engine.typings.grouptype import IssueStreamGroupType
 
 DEFAULT_WORKFLOW_LABEL = "Send a notification for high priority issues"
 PULL_REQUEST_WORKFLOW_LABEL = "Send a notification when pull requests are ready"
+
+
+def connect_workflows_to_issue_stream(
+    project: Project,
+    workflows: list[Workflow],
+) -> Sequence[DetectorWorkflow]:
+    # Because we don't know if this signal is handled already or not...
+    issue_stream_detector = _ensure_detector(project, IssueStreamGroupType.slug)
+
+    connections = [
+        DetectorWorkflow(
+            workflow=workflow,
+            detector=issue_stream_detector,
+        )
+        for workflow in workflows
+    ]
+    return DetectorWorkflow.objects.bulk_create(
+        connections,
+        ignore_conflicts=True,
+    )
 
 
 def connect_workflows_to_detector(
@@ -101,7 +124,9 @@ def create_priority_workflow(org: Organization) -> Workflow:
     return workflow
 
 
-def create_pull_request_workflow(organization: Organization) -> Workflow:
+def create_and_connect_pull_request_workflow(
+    organization: Organization, detector: Detector
+) -> Workflow:
     with transaction.atomic(router.db_for_write(Workflow)):
         when_condition_group = DataConditionGroup.objects.create(
             logic_type=DataConditionGroup.Type.ANY_SHORT_CIRCUIT, organization=organization
@@ -135,15 +160,14 @@ def create_pull_request_workflow(organization: Organization) -> Workflow:
         )
         DataConditionGroupAction.objects.create(action=action, condition_group=action_filter)
         WorkflowDataConditionGroup.objects.create(workflow=workflow, condition_group=action_filter)
+        DetectorWorkflow.objects.create(workflow=workflow, detector=detector)
 
     return workflow
 
 
 def ensure_default_workflows(project: Project) -> list[Workflow]:
     workflows = [create_priority_workflow(project.organization)]
-    # Because we don't know if this signal is handled already or not...
-    issue_stream_detector = _ensure_detector(project, IssueStreamGroupType.slug)
-    connect_workflows_to_detector(issue_stream_detector, workflows)
+    connect_workflows_to_issue_stream(project, workflows)
     return workflows
 
 
@@ -160,11 +184,32 @@ def ensure_pull_request_workflow(organization: Organization, detector: Detector)
         name=PULL_REQUEST_WORKFLOW_LABEL,
         detectorworkflow__detector=detector,
     ).first()
-    return existing if existing else create_pull_request_workflow(organization)
+    if existing:
+        return existing
+
+    lock = locks.get(
+        f"workflow-engine-org-{IssueStreamGroupType.slug}-detector:pr-workflow:{organization.id}",
+        duration=2,
+        name="workflow_engine_pull_request_workflow",
+    )
+    try:
+        with (
+            lock.blocking_acquire(initial_delay=0.1, timeout=3),
+            transaction.atomic(router.db_for_write(Workflow)),
+        ):
+            existing = Workflow.objects.filter(
+                organization=organization,
+                name=PULL_REQUEST_WORKFLOW_LABEL,
+                detectorworkflow__detector=detector,
+            ).first()
+            if existing:
+                return existing
+            return create_and_connect_pull_request_workflow(organization, detector)
+    except UnableToAcquireLock:
+        raise UnableToAcquireLockApiError
 
 
 def ensure_default_organization_workflows(organization: Organization) -> list[Workflow]:
     all_projects_detector = ensure_default_all_projects_detector(organization.id)
     workflows = [ensure_pull_request_workflow(organization, all_projects_detector)]
-    connect_workflows_to_detector(all_projects_detector, workflows)
     return workflows

--- a/src/sentry/workflow_engine/defaults/workflows.py
+++ b/src/sentry/workflow_engine/defaults/workflows.py
@@ -115,6 +115,7 @@ def create_pull_request_workflow(organization: Organization) -> Workflow:
         DataCondition.objects.create(
             type=Condition.SEER_ACTIVITY_TRIGGER,
             condition_group=when_condition_group,
+            # TODO(Leander): Update this with PR_READY_FOR_REVIEW when that's done
             comparison=[SeerActivityTriggerStage.PR_CREATED.value],
             condition_result=True,
         )
@@ -151,6 +152,8 @@ def ensure_pull_request_workflow(organization: Organization, detector: Detector)
     A primitive attempt to prevent duplicate workflows by checking if this label/detector combo
     already exists. We don't intend to call `ensure_default_organization_workflows` twice regardless,
     but this will guard if that does happen in quick succession (maybe from an RPC blip somehow).
+
+    Note: If the detector is not connected, a new pull request workflow will be created.
     """
     existing = Workflow.objects.filter(
         organization=organization,

--- a/src/sentry/workflow_engine/receivers/__init__.py
+++ b/src/sentry/workflow_engine/receivers/__init__.py
@@ -5,6 +5,7 @@ from .data_source import *  # NOQA
 from .data_source_detector import *  # NOQA
 from .detector import *  # NOQA
 from .detector_workflow import *  # NOQA
+from .organization_detectors import *  # noqa: F401,F403
 from .project_detectors import *  # noqa: F401,F403
 from .project_workflows import *  # noqa: F401,F403
 from .workflow import *  # NOQA

--- a/src/sentry/workflow_engine/receivers/__init__.py
+++ b/src/sentry/workflow_engine/receivers/__init__.py
@@ -6,6 +6,7 @@ from .data_source_detector import *  # NOQA
 from .detector import *  # NOQA
 from .detector_workflow import *  # NOQA
 from .organization_detectors import *  # noqa: F401,F403
+from .organization_workflows import *  # noqa: F401,F403
 from .project_detectors import *  # noqa: F401,F403
 from .project_workflows import *  # noqa: F401,F403
 from .workflow import *  # NOQA

--- a/src/sentry/workflow_engine/receivers/organization_detectors.py
+++ b/src/sentry/workflow_engine/receivers/organization_detectors.py
@@ -1,0 +1,27 @@
+from typing import Any
+
+import sentry_sdk
+
+from sentry import options
+from sentry.models.organization import Organization
+from sentry.signals import organization_created
+from sentry.workflow_engine.defaults.detectors import (
+    UnableToAcquireLockApiError,
+    ensure_default_organization_detectors,
+)
+
+
+def create_organization_detectors(organization: Organization, **kwargs: Any) -> None:
+    if not options.get("workflow_engine.all_projects_detector_creation_enabled"):
+        return
+    try:
+        ensure_default_organization_detectors(organization)
+    except UnableToAcquireLockApiError as e:
+        sentry_sdk.capture_exception(e)
+
+
+organization_created.connect(
+    create_organization_detectors,
+    dispatch_uid="create_organization_detectors",
+    weak=False,
+)

--- a/src/sentry/workflow_engine/receivers/organization_detectors.py
+++ b/src/sentry/workflow_engine/receivers/organization_detectors.py
@@ -9,15 +9,17 @@ from sentry.workflow_engine.defaults.detectors import (
     UnableToAcquireLockApiError,
     ensure_default_organization_detectors,
 )
+from sentry.workflow_engine.models import Detector
 
 
-def create_organization_detectors(organization: Organization, **kwargs: Any) -> None:
+def create_organization_detectors(organization: Organization, **kwargs: Any) -> dict[str, Detector]:
     if not options.get("workflow_engine.all_projects_auto_creation_enabled"):
-        return
+        return {}
     try:
-        ensure_default_organization_detectors(organization)
+        return ensure_default_organization_detectors(organization)
     except UnableToAcquireLockApiError as e:
         sentry_sdk.capture_exception(e)
+    return {}
 
 
 organization_created.connect(

--- a/src/sentry/workflow_engine/receivers/organization_workflows.py
+++ b/src/sentry/workflow_engine/receivers/organization_workflows.py
@@ -7,21 +7,21 @@ from sentry.models.organization import Organization
 from sentry.signals import organization_created
 from sentry.workflow_engine.defaults.detectors import (
     UnableToAcquireLockApiError,
-    ensure_default_organization_detectors,
 )
+from sentry.workflow_engine.defaults.workflows import ensure_default_organization_workflows
 
 
-def create_organization_detectors(organization: Organization, **kwargs: Any) -> None:
+def create_organization_workflows(organization: Organization, **kwargs: Any) -> None:
     if not options.get("workflow_engine.all_projects_auto_creation_enabled"):
         return
     try:
-        ensure_default_organization_detectors(organization)
+        ensure_default_organization_workflows(organization)
     except UnableToAcquireLockApiError as e:
         sentry_sdk.capture_exception(e)
 
 
 organization_created.connect(
-    create_organization_detectors,
-    dispatch_uid="create_organization_detectors",
+    create_organization_workflows,
+    dispatch_uid="create_organization_workflows",
     weak=False,
 )

--- a/tests/sentry/workflow_engine/defaults/test_workflows.py
+++ b/tests/sentry/workflow_engine/defaults/test_workflows.py
@@ -1,10 +1,20 @@
 from sentry.notifications.types import FallthroughChoiceType
 from sentry.testutils.cases import TestCase
-from sentry.workflow_engine.defaults.detectors import ensure_default_detectors
+from sentry.workflow_engine.defaults.detectors import (
+    ensure_default_all_projects_detector,
+    ensure_default_detectors,
+    ensure_default_organization_detectors,
+)
 from sentry.workflow_engine.defaults.workflows import (
-    connect_workflows_to_issue_stream,
+    connect_workflows_to_detector,
     create_priority_workflow,
+    create_pull_request_workflow,
+    ensure_default_organization_workflows,
     ensure_default_workflows,
+    ensure_pull_request_workflow,
+)
+from sentry.workflow_engine.handlers.condition.seer_activity_trigger_handler import (
+    SeerActivityTriggerStage,
 )
 from sentry.workflow_engine.models import (
     Action,
@@ -20,8 +30,8 @@ from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.typings.grouptype import IssueStreamGroupType
 
 
-class TestConnectWorkflowsToIssueStream(TestCase):
-    def test_creates_detector_workflow_connections(self) -> None:
+class TestConnectWorkflows(TestCase):
+    def test_connect_workflows_to_detector(self) -> None:
         project = self.create_project(create_default_detectors=False)
         workflow1 = self.create_workflow(
             name="Test Workflow 1",
@@ -31,8 +41,8 @@ class TestConnectWorkflowsToIssueStream(TestCase):
             name="Test Workflow 2",
             organization=project.organization,
         )
-
-        connections = connect_workflows_to_issue_stream(project, [workflow1, workflow2])
+        issue_stream_detector = ensure_default_detectors(project)[IssueStreamGroupType.slug]
+        connections = connect_workflows_to_detector(issue_stream_detector, [workflow1, workflow2])
 
         assert len(connections) == 2
         assert DetectorWorkflow.objects.filter(workflow=workflow1).exists()
@@ -43,50 +53,7 @@ class TestConnectWorkflowsToIssueStream(TestCase):
         assert len(detector_ids) == 1
         detector = Detector.objects.get(id=detector_ids.pop())
         assert detector.type == IssueStreamGroupType.slug
-
-    def test_uses_issue_stream_detector(self) -> None:
-        project = self.create_project(create_default_detectors=False)
-        workflow = self.create_workflow(
-            organization=project.organization,
-            name="Test Workflow",
-        )
-
-        connections = connect_workflows_to_issue_stream(project, [workflow])
-
-        connection = connections[0]
-        assert connection.detector.type == IssueStreamGroupType.slug
-        assert connection.detector.project_id == project.id
-
-        # Verify only one issue stream detector exists
-        issue_stream_detectors = Detector.objects.filter(
-            project=project, type=IssueStreamGroupType.slug
-        )
-        assert issue_stream_detectors.count() == 1
-
-    def test_uses_preexisting_issue_stream_detector(self) -> None:
-        """Integration test: verifies that if an issue stream detector already exists, it reuses it."""
-        project = self.create_project(create_default_detectors=False)
-
-        # Create the default detectors first (simulating project setup signal)
-        default_detectors = ensure_default_detectors(project)
-        existing_detector = default_detectors[IssueStreamGroupType.slug]
-
-        # Now connect workflows - should use the existing detector
-        workflow = self.create_workflow(
-            organization=project.organization,
-            name="Test Workflow",
-        )
-
-        connections = connect_workflows_to_issue_stream(project, [workflow])
-
-        # Verify it used the pre-existing detector
-        assert connections[0].detector_id == existing_detector.id
-
-        # Verify still only one issue stream detector exists
-        issue_stream_detectors = Detector.objects.filter(
-            project=project, type=IssueStreamGroupType.slug
-        )
-        assert issue_stream_detectors.count() == 1
+        assert detector.id == issue_stream_detector.id
 
 
 class TestCreatePriorityWorkflow(TestCase):
@@ -181,10 +148,149 @@ class TestEnsureDefaultWorkflows(TestCase):
         assert connection.detector.type == IssueStreamGroupType.slug
         assert connection.detector.project_id == project.id
 
+    def test_uses_existing_issue_stream(self) -> None:
+        project = self.create_project(create_default_detectors=False)
+        issue_stream_detector = ensure_default_detectors(project)[IssueStreamGroupType.slug]
+        workflows = ensure_default_workflows(project)
+
+        assert len(workflows) == 1
+        workflow = workflows[0]
+        # Verify it connected to the existing, and no other exists
+        connection = DetectorWorkflow.objects.get(workflow=workflow)
+        assert connection.detector == issue_stream_detector
+        assert Detector.objects.filter(type=IssueStreamGroupType.slug).count() == 1
+
     def test_returns_workflows_list(self) -> None:
         project = self.create_project()
 
         workflows = ensure_default_workflows(project)
 
+        assert isinstance(workflows, list)
+        assert all(isinstance(w, Workflow) for w in workflows)
+
+
+class TestCreatePullRequestWorkflow(TestCase):
+    def test_creates_workflow_with_correct_name(self) -> None:
+        workflow = create_pull_request_workflow(self.organization)
+
+        assert workflow.name == "Send a notification when pull requests are ready"
+        assert workflow.organization_id == self.organization.id
+        assert workflow.config == {"frequency": 0}
+
+    def test_creates_when_condition_group(self) -> None:
+        workflow = create_pull_request_workflow(self.organization)
+
+        assert workflow.when_condition_group is not None
+        assert workflow.when_condition_group.logic_type == DataConditionGroup.Type.ANY_SHORT_CIRCUIT
+
+    def test_creates_data_condition(self) -> None:
+        workflow = create_pull_request_workflow(self.organization)
+
+        conditions = DataCondition.objects.filter(condition_group=workflow.when_condition_group)
+        assert conditions.count() == 1
+
+        condition = conditions[0]
+        assert condition.type == Condition.SEER_ACTIVITY_TRIGGER
+        assert condition.comparison == [SeerActivityTriggerStage.PR_CREATED.value]
+        assert condition.condition_result is True
+
+    def test_creates_email_action(self) -> None:
+        create_pull_request_workflow(self.organization)
+
+        action = Action.objects.get(type=Action.Type.EMAIL)
+        assert action.config == {"target_type": 4, "target_identifier": None}
+        assert action.data == {"fallthrough_type": FallthroughChoiceType.ACTIVE_MEMBERS.value}
+
+    def test_creates_action_filter_and_links(self) -> None:
+        workflow = create_pull_request_workflow(self.organization)
+
+        workflow_dcg = WorkflowDataConditionGroup.objects.get(workflow=workflow)
+        action_filter = workflow_dcg.condition_group
+
+        action = Action.objects.get(type=Action.Type.EMAIL)
+        dcg_action = DataConditionGroupAction.objects.get(action=action)
+        assert dcg_action.condition_group == action_filter
+
+        assert action_filter.logic_type == DataConditionGroup.Type.ANY_SHORT_CIRCUIT
+
+
+class TestEnsurePullRequestWorkflow(TestCase):
+    def setUp(self) -> None:
+        self.all_projects_detector = ensure_default_organization_detectors(self.organization)[
+            IssueStreamGroupType.slug
+        ]
+
+    def test_creates_workflow(self) -> None:
+        workflow = ensure_pull_request_workflow(self.organization, self.all_projects_detector)
+        assert workflow.name == "Send a notification when pull requests are ready"
+        assert workflow.organization_id == self.organization.id
+
+    def test_reuses_connected_workflow(self) -> None:
+        first = ensure_pull_request_workflow(self.organization, self.all_projects_detector)
+        connect_workflows_to_detector(self.all_projects_detector, [first])
+        second = ensure_pull_request_workflow(self.organization, self.all_projects_detector)
+
+        assert first.id == second.id
+        assert (
+            Workflow.objects.filter(
+                organization=self.organization,
+                name="Send a notification when pull requests are ready",
+            ).count()
+            == 1
+        )
+
+    def test_creates_new_workflow_when_none_connected(self) -> None:
+        first = ensure_pull_request_workflow(self.organization, self.all_projects_detector)
+        second = ensure_pull_request_workflow(self.organization, self.all_projects_detector)
+
+        assert first.id != second.id
+        assert (
+            DetectorWorkflow.objects.filter(
+                workflow=first, detector=self.all_projects_detector
+            ).count()
+            == 0
+        )
+
+    def test_creates_separate_workflows_for_separate_detectors(self) -> None:
+        random_detector = self.create_detector(self.project)
+        first = ensure_pull_request_workflow(self.organization, self.all_projects_detector)
+        connect_workflows_to_detector(self.all_projects_detector, [first])
+        second = ensure_pull_request_workflow(self.organization, random_detector)
+
+        assert first.id != second.id
+
+
+class TestEnsureDefaultOrganizationWorkflows(TestCase):
+    def test_creates_and_connects_workflows(self) -> None:
+        workflows = ensure_default_organization_workflows(self.organization)
+
+        assert len(workflows) == 1
+        workflow = workflows[0]
+        assert workflow.name == "Send a notification when pull requests are ready"
+        assert workflow.organization_id == self.organization.id
+
+        connection = DetectorWorkflow.objects.get(workflow=workflow)
+        assert connection.detector.type == IssueStreamGroupType.slug
+        assert connection.detector.project is None
+        assert connection.detector.config["organization_id"] == self.organization.id
+
+    def test_uses_existing_all_projects_detector(self) -> None:
+        existing_detector = ensure_default_all_projects_detector(self.organization.id)
+        workflows = ensure_default_organization_workflows(self.organization)
+
+        assert len(workflows) == 1
+        connection = DetectorWorkflow.objects.get(workflow=workflows[0])
+        assert connection.detector == existing_detector
+        assert (
+            Detector.objects.filter(
+                type=IssueStreamGroupType.slug,
+                project__isnull=True,
+                config__organization_id=self.organization.id,
+            ).count()
+            == 1
+        )
+
+    def test_returns_workflows_list(self) -> None:
+        workflows = ensure_default_organization_workflows(self.organization)
         assert isinstance(workflows, list)
         assert all(isinstance(w, Workflow) for w in workflows)

--- a/tests/sentry/workflow_engine/defaults/test_workflows.py
+++ b/tests/sentry/workflow_engine/defaults/test_workflows.py
@@ -6,9 +6,9 @@ from sentry.workflow_engine.defaults.detectors import (
     ensure_default_organization_detectors,
 )
 from sentry.workflow_engine.defaults.workflows import (
-    connect_workflows_to_detector,
+    connect_workflows_to_issue_stream,
+    create_and_connect_pull_request_workflow,
     create_priority_workflow,
-    create_pull_request_workflow,
     ensure_default_organization_workflows,
     ensure_default_workflows,
     ensure_pull_request_workflow,
@@ -30,8 +30,8 @@ from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.typings.grouptype import IssueStreamGroupType
 
 
-class TestConnectWorkflows(TestCase):
-    def test_connect_workflows_to_detector(self) -> None:
+class TestConnectWorkflowsToIssueStream(TestCase):
+    def test_creates_detector_workflow_connections(self) -> None:
         project = self.create_project(create_default_detectors=False)
         workflow1 = self.create_workflow(
             name="Test Workflow 1",
@@ -41,8 +41,8 @@ class TestConnectWorkflows(TestCase):
             name="Test Workflow 2",
             organization=project.organization,
         )
-        issue_stream_detector = ensure_default_detectors(project)[IssueStreamGroupType.slug]
-        connections = connect_workflows_to_detector(issue_stream_detector, [workflow1, workflow2])
+
+        connections = connect_workflows_to_issue_stream(project, [workflow1, workflow2])
 
         assert len(connections) == 2
         assert DetectorWorkflow.objects.filter(workflow=workflow1).exists()
@@ -53,7 +53,50 @@ class TestConnectWorkflows(TestCase):
         assert len(detector_ids) == 1
         detector = Detector.objects.get(id=detector_ids.pop())
         assert detector.type == IssueStreamGroupType.slug
-        assert detector.id == issue_stream_detector.id
+
+    def test_uses_issue_stream_detector(self) -> None:
+        project = self.create_project(create_default_detectors=False)
+        workflow = self.create_workflow(
+            organization=project.organization,
+            name="Test Workflow",
+        )
+
+        connections = connect_workflows_to_issue_stream(project, [workflow])
+
+        connection = connections[0]
+        assert connection.detector.type == IssueStreamGroupType.slug
+        assert connection.detector.project_id == project.id
+
+        # Verify only one issue stream detector exists
+        issue_stream_detectors = Detector.objects.filter(
+            project=project, type=IssueStreamGroupType.slug
+        )
+        assert issue_stream_detectors.count() == 1
+
+    def test_uses_preexisting_issue_stream_detector(self) -> None:
+        """Integration test: verifies that if an issue stream detector already exists, it reuses it."""
+        project = self.create_project(create_default_detectors=False)
+
+        # Create the default detectors first (simulating project setup signal)
+        default_detectors = ensure_default_detectors(project)
+        existing_detector = default_detectors[IssueStreamGroupType.slug]
+
+        # Now connect workflows - should use the existing detector
+        workflow = self.create_workflow(
+            organization=project.organization,
+            name="Test Workflow",
+        )
+
+        connections = connect_workflows_to_issue_stream(project, [workflow])
+
+        # Verify it used the pre-existing detector
+        assert connections[0].detector_id == existing_detector.id
+
+        # Verify still only one issue stream detector exists
+        issue_stream_detectors = Detector.objects.filter(
+            project=project, type=IssueStreamGroupType.slug
+        )
+        assert issue_stream_detectors.count() == 1
 
 
 class TestCreatePriorityWorkflow(TestCase):
@@ -148,18 +191,6 @@ class TestEnsureDefaultWorkflows(TestCase):
         assert connection.detector.type == IssueStreamGroupType.slug
         assert connection.detector.project_id == project.id
 
-    def test_uses_existing_issue_stream(self) -> None:
-        project = self.create_project(create_default_detectors=False)
-        issue_stream_detector = ensure_default_detectors(project)[IssueStreamGroupType.slug]
-        workflows = ensure_default_workflows(project)
-
-        assert len(workflows) == 1
-        workflow = workflows[0]
-        # Verify it connected to the existing, and no other exists
-        connection = DetectorWorkflow.objects.get(workflow=workflow)
-        assert connection.detector == issue_stream_detector
-        assert Detector.objects.filter(type=IssueStreamGroupType.slug).count() == 1
-
     def test_returns_workflows_list(self) -> None:
         project = self.create_project()
 
@@ -169,22 +200,33 @@ class TestEnsureDefaultWorkflows(TestCase):
         assert all(isinstance(w, Workflow) for w in workflows)
 
 
-class TestCreatePullRequestWorkflow(TestCase):
+class TestCreateAndConnectPullRequestWorkflow(TestCase):
+    def setUp(self) -> None:
+        self.all_projects_detector = ensure_default_organization_detectors(self.organization)[
+            IssueStreamGroupType.slug
+        ]
+
     def test_creates_workflow_with_correct_name(self) -> None:
-        workflow = create_pull_request_workflow(self.organization)
+        workflow = create_and_connect_pull_request_workflow(
+            self.organization, self.all_projects_detector
+        )
 
         assert workflow.name == "Send a notification when pull requests are ready"
         assert workflow.organization_id == self.organization.id
         assert workflow.config == {"frequency": 0}
 
     def test_creates_when_condition_group(self) -> None:
-        workflow = create_pull_request_workflow(self.organization)
+        workflow = create_and_connect_pull_request_workflow(
+            self.organization, self.all_projects_detector
+        )
 
         assert workflow.when_condition_group is not None
         assert workflow.when_condition_group.logic_type == DataConditionGroup.Type.ANY_SHORT_CIRCUIT
 
     def test_creates_data_condition(self) -> None:
-        workflow = create_pull_request_workflow(self.organization)
+        workflow = create_and_connect_pull_request_workflow(
+            self.organization, self.all_projects_detector
+        )
 
         conditions = DataCondition.objects.filter(condition_group=workflow.when_condition_group)
         assert conditions.count() == 1
@@ -195,14 +237,16 @@ class TestCreatePullRequestWorkflow(TestCase):
         assert condition.condition_result is True
 
     def test_creates_email_action(self) -> None:
-        create_pull_request_workflow(self.organization)
+        create_and_connect_pull_request_workflow(self.organization, self.all_projects_detector)
 
         action = Action.objects.get(type=Action.Type.EMAIL)
         assert action.config == {"target_type": 4, "target_identifier": None}
         assert action.data == {"fallthrough_type": FallthroughChoiceType.ACTIVE_MEMBERS.value}
 
     def test_creates_action_filter_and_links(self) -> None:
-        workflow = create_pull_request_workflow(self.organization)
+        workflow = create_and_connect_pull_request_workflow(
+            self.organization, self.all_projects_detector
+        )
 
         workflow_dcg = WorkflowDataConditionGroup.objects.get(workflow=workflow)
         action_filter = workflow_dcg.condition_group
@@ -213,6 +257,27 @@ class TestCreatePullRequestWorkflow(TestCase):
 
         assert action_filter.logic_type == DataConditionGroup.Type.ANY_SHORT_CIRCUIT
 
+    def test_connects_workflow_to_detector(self) -> None:
+        workflow = create_and_connect_pull_request_workflow(
+            self.organization, self.all_projects_detector
+        )
+
+        connection = DetectorWorkflow.objects.get(workflow=workflow)
+        assert connection.detector == self.all_projects_detector
+
+    def test_creates_separate_workflow_per_call(self) -> None:
+        """Each call creates a new Workflow so that each org gets its own."""
+        workflow1 = create_and_connect_pull_request_workflow(
+            self.organization, self.all_projects_detector
+        )
+        workflow2 = create_and_connect_pull_request_workflow(
+            self.organization, self.all_projects_detector
+        )
+
+        assert workflow1.id != workflow2.id
+        connections = DetectorWorkflow.objects.filter(detector=self.all_projects_detector)
+        assert {c.workflow_id for c in connections} == {workflow1.id, workflow2.id}
+
 
 class TestEnsurePullRequestWorkflow(TestCase):
     def setUp(self) -> None:
@@ -220,14 +285,16 @@ class TestEnsurePullRequestWorkflow(TestCase):
             IssueStreamGroupType.slug
         ]
 
-    def test_creates_workflow(self) -> None:
+    def test_creates_and_connects_workflow(self) -> None:
         workflow = ensure_pull_request_workflow(self.organization, self.all_projects_detector)
         assert workflow.name == "Send a notification when pull requests are ready"
         assert workflow.organization_id == self.organization.id
 
-    def test_reuses_connected_workflow(self) -> None:
+        connection = DetectorWorkflow.objects.get(workflow=workflow)
+        assert connection.detector == self.all_projects_detector
+
+    def test_reuses_existing_workflow(self) -> None:
         first = ensure_pull_request_workflow(self.organization, self.all_projects_detector)
-        connect_workflows_to_detector(self.all_projects_detector, [first])
         second = ensure_pull_request_workflow(self.organization, self.all_projects_detector)
 
         assert first.id == second.id
@@ -238,23 +305,16 @@ class TestEnsurePullRequestWorkflow(TestCase):
             ).count()
             == 1
         )
-
-    def test_creates_new_workflow_when_none_connected(self) -> None:
-        first = ensure_pull_request_workflow(self.organization, self.all_projects_detector)
-        second = ensure_pull_request_workflow(self.organization, self.all_projects_detector)
-
-        assert first.id != second.id
         assert (
             DetectorWorkflow.objects.filter(
                 workflow=first, detector=self.all_projects_detector
             ).count()
-            == 0
+            == 1
         )
 
     def test_creates_separate_workflows_for_separate_detectors(self) -> None:
         random_detector = self.create_detector(self.project)
         first = ensure_pull_request_workflow(self.organization, self.all_projects_detector)
-        connect_workflows_to_detector(self.all_projects_detector, [first])
         second = ensure_pull_request_workflow(self.organization, random_detector)
 
         assert first.id != second.id

--- a/tests/sentry/workflow_engine/receivers/test_organization_detectors.py
+++ b/tests/sentry/workflow_engine/receivers/test_organization_detectors.py
@@ -1,0 +1,71 @@
+from unittest import mock
+
+from sentry.signals import organization_created
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.options import override_options
+from sentry.workflow_engine.defaults.detectors import (
+    UnableToAcquireLockApiError,
+    ensure_default_organization_detectors,
+)
+from sentry.workflow_engine.models import Detector
+from sentry.workflow_engine.typings.grouptype import IssueStreamGroupType
+
+
+class TestCreateOrganizationDetectors(TestCase):
+    def send_signal(self) -> None:
+        organization_created.send_robust(
+            organization=self.organization,
+            user=self.user,
+            sender=type(self),
+        )
+
+    def test_does_not_create_detector_when_option_disabled(self) -> None:
+        self.send_signal()
+        assert not Detector.objects.filter(
+            type=IssueStreamGroupType.slug,
+            project__isnull=True,
+            config__organization_id=self.organization.id,
+        ).exists()
+
+    @override_options({"workflow_engine.all_projects_detector_creation_enabled": True})
+    def test_creates_detector(self) -> None:
+        self.send_signal()
+        detector = Detector.objects.get(
+            type=IssueStreamGroupType.slug,
+            project__isnull=True,
+            config__organization_id=self.organization.id,
+        )
+        assert detector.enabled is True
+
+    @override_options({"workflow_engine.all_projects_detector_creation_enabled": True})
+    def test_no_duplicates_ever(self) -> None:
+        # Multiple signal emissions
+        self.send_signal()
+        self.send_signal()
+        # Multiple manual calls
+        ensure_default_organization_detectors(self.organization)
+        ensure_default_organization_detectors(self.organization)
+
+        assert (
+            Detector.objects.filter(
+                type=IssueStreamGroupType.slug,
+                project__isnull=True,
+                config__organization_id=self.organization.id,
+            ).count()
+            == 1
+        )
+
+    @override_options({"workflow_engine.all_projects_detector_creation_enabled": True})
+    @mock.patch("sentry.workflow_engine.receivers.organization_detectors.sentry_sdk")
+    def test_captures_exception_on_creation_failure(self, mock_sdk: mock.MagicMock) -> None:
+        organization = self.create_organization()
+
+        with mock.patch(
+            "sentry.workflow_engine.receivers.organization_detectors.ensure_default_organization_detectors",
+            side_effect=UnableToAcquireLockApiError,
+        ):
+            organization_created.send_robust(
+                organization=organization, user=self.user, sender=type(self)
+            )
+
+        mock_sdk.capture_exception.assert_called_once()

--- a/tests/sentry/workflow_engine/receivers/test_organization_detectors.py
+++ b/tests/sentry/workflow_engine/receivers/test_organization_detectors.py
@@ -27,7 +27,7 @@ class TestCreateOrganizationDetectors(TestCase):
             config__organization_id=self.organization.id,
         ).exists()
 
-    @override_options({"workflow_engine.all_projects_detector_creation_enabled": True})
+    @override_options({"workflow_engine.all_projects_auto_creation_enabled": True})
     def test_creates_detector(self) -> None:
         self.send_signal()
         detector = Detector.objects.get(
@@ -35,9 +35,9 @@ class TestCreateOrganizationDetectors(TestCase):
             project__isnull=True,
             config__organization_id=self.organization.id,
         )
-        assert detector.enabled is True
+        assert detector.enabled
 
-    @override_options({"workflow_engine.all_projects_detector_creation_enabled": True})
+    @override_options({"workflow_engine.all_projects_auto_creation_enabled": True})
     def test_no_duplicates_ever(self) -> None:
         # Multiple signal emissions
         self.send_signal()
@@ -55,7 +55,7 @@ class TestCreateOrganizationDetectors(TestCase):
             == 1
         )
 
-    @override_options({"workflow_engine.all_projects_detector_creation_enabled": True})
+    @override_options({"workflow_engine.all_projects_auto_creation_enabled": True})
     @mock.patch("sentry.workflow_engine.receivers.organization_detectors.sentry_sdk")
     def test_captures_exception_on_creation_failure(self, mock_sdk: mock.MagicMock) -> None:
         organization = self.create_organization()

--- a/tests/sentry/workflow_engine/receivers/test_organization_workflows.py
+++ b/tests/sentry/workflow_engine/receivers/test_organization_workflows.py
@@ -1,0 +1,72 @@
+from unittest import mock
+
+from sentry.signals import organization_created
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.options import override_options
+from sentry.workflow_engine.defaults.detectors import UnableToAcquireLockApiError
+from sentry.workflow_engine.defaults.workflows import (
+    PULL_REQUEST_WORKFLOW_LABEL,
+    ensure_default_organization_workflows,
+)
+from sentry.workflow_engine.models import DetectorWorkflow, Workflow
+
+
+class TestCreateOrganizationWorkflows(TestCase):
+    def send_signal(self) -> None:
+        organization_created.send_robust(
+            organization=self.organization, user=self.user, sender=type(self)
+        )
+
+    def test_does_not_create_workflow_when_option_disabled(self) -> None:
+        self.send_signal()
+        assert not Workflow.objects.filter(
+            organization=self.organization, name=PULL_REQUEST_WORKFLOW_LABEL
+        ).exists()
+
+    @override_options({"workflow_engine.all_projects_auto_creation_enabled": True})
+    def test_creates_workflow(self) -> None:
+        self.send_signal()
+        workflow = Workflow.objects.get(
+            organization=self.organization, name=PULL_REQUEST_WORKFLOW_LABEL
+        )
+        assert workflow.enabled
+
+    @override_options({"workflow_engine.all_projects_auto_creation_enabled": True})
+    def test_connects_workflow_to_detector(self) -> None:
+        self.send_signal()
+        workflow = Workflow.objects.get(
+            organization=self.organization, name=PULL_REQUEST_WORKFLOW_LABEL
+        )
+        assert DetectorWorkflow.objects.filter(workflow=workflow).exists()
+
+    @override_options({"workflow_engine.all_projects_auto_creation_enabled": True})
+    def test_no_duplicates_ever(self) -> None:
+        # Multiple signal emissions
+        self.send_signal()
+        self.send_signal()
+        # Multiple manual calls
+        ensure_default_organization_workflows(self.organization)
+        ensure_default_organization_workflows(self.organization)
+
+        assert (
+            Workflow.objects.filter(
+                organization=self.organization,
+                name=PULL_REQUEST_WORKFLOW_LABEL,
+            ).count()
+            == 1
+        )
+
+    @override_options({"workflow_engine.all_projects_auto_creation_enabled": True})
+    @mock.patch("sentry.workflow_engine.receivers.organization_workflows.sentry_sdk")
+    def test_captures_exception_on_creation_failure(self, mock_sdk: mock.MagicMock) -> None:
+        organization = self.create_organization()
+
+        with mock.patch(
+            "sentry.workflow_engine.receivers.organization_workflows.ensure_default_organization_workflows",
+            side_effect=UnableToAcquireLockApiError,
+        ):
+            organization_created.send_robust(
+                organization=organization, user=self.user, sender=type(self)
+            )
+
+        mock_sdk.capture_exception.assert_called_once()


### PR DESCRIPTION
Adds a new BetterSignal, and triggers it from the cell provisioning rpc for creating organizations. There is precedent for this with the `terms_accepted` signal, so it should be okay.

We're also adding the receiver, but it's gated by an option to be a noop on merge, we can control its rollout when we're ready. 

 

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>