### PR TITLE
fix(issues): Remove alerts secondary nav item

### DIFF
--- a/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.tsx
@@ -1,18 +1,11 @@
 import {Fragment} from 'react';
-import {css} from '@emotion/react';
-import styled from '@emotion/styled';
 
-import {Badge, FeatureBadge} from '@sentry/scraps/badge';
-import {Link} from '@sentry/scraps/link';
-import {Text} from '@sentry/scraps/text';
-import {Tooltip} from '@sentry/scraps/tooltip';
+import {FeatureBadge} from '@sentry/scraps/badge';
 
-import {t, tct} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {makeAutomationBasePathname} from 'sentry/views/automations/pathnames';
 import {useInboxIssueCount} from 'sentry/views/issueList/queries/useInboxIssueCount';
 import {ISSUE_TAXONOMY_CONFIG} from 'sentry/views/issueList/taxonomies';
-import {usePrimaryNavigation} from 'sentry/views/navigation/primaryNavigationContext';
 import {SecondaryNavigation} from 'sentry/views/navigation/secondary/components';
 import {IssueCount} from 'sentry/views/navigation/secondary/sections/issues/issueCount';
 import {IssueViews} from 'sentry/views/navigation/secondary/sections/issues/issueViews/issueViews';
@@ -124,73 +117,7 @@ export function IssuesSecondaryNavigation() {
           </SecondaryNavigation.List>
         </SecondaryNavigation.Section>
         <IssueViews />
-        <ConfigureSection />
       </SecondaryNavigation.Body>
     </Fragment>
   );
 }
-
-function ConfigureSection() {
-  const organization = useOrganization();
-  const {layout} = usePrimaryNavigation();
-  const isSticky = layout === 'sidebar';
-
-  const alertsLink = makeAutomationBasePathname(organization.slug);
-
-  return (
-    <Fragment>
-      <SecondaryNavigation.Separator />
-      <StickyBottomSection
-        id="issues-configure"
-        title={t('Configure')}
-        collapsible={false}
-        isSticky={isSticky}
-      >
-        <SecondaryNavigation.List>
-          <SecondaryNavigation.ListItem>
-            <SecondaryNavigation.Link
-              to={alertsLink}
-              analyticsItemName="issues_alerts"
-              trailingItems={
-                <Tooltip
-                  isHoverable
-                  title={
-                    <Fragment>
-                      <Text as="p">{t('Alerts now live under Monitors.')}</Text>
-                      <Text as="p">
-                        {tct('See the [link:new Alerts page here.]', {
-                          link: (
-                            <Link
-                              to={`/organizations/${organization.slug}/monitors/alerts/`}
-                            />
-                          ),
-                        })}
-                      </Text>
-                    </Fragment>
-                  }
-                >
-                  <Badge variant="muted">{t('Moved')}</Badge>
-                </Tooltip>
-              }
-            >
-              {t('Alerts')}
-            </SecondaryNavigation.Link>
-          </SecondaryNavigation.ListItem>
-        </SecondaryNavigation.List>
-      </StickyBottomSection>
-    </Fragment>
-  );
-}
-
-const StickyBottomSection = styled(SecondaryNavigation.Section, {
-  shouldForwardProp: prop => prop !== 'isSticky',
-})<{isSticky: boolean}>`
-  ${p =>
-    p.isSticky &&
-    css`
-      position: sticky;
-      bottom: 0;
-      z-index: 1;
-      background: ${p.theme.tokens.background.secondary};
-    `}
-`;


### PR DESCRIPTION
Removes the old "alerts" nav item which prompts users to use the new monitor/alerts since it's been long enough.

<img width="193" height="77" alt="CleanShot 2026-08-06 at 11 44 40" src="https://github.com/user-attachments/assets/8d6de544-a4a0-46ae-a791-461cf5e78fe8" />
