### PR TITLE
style(preprod): Remove treemap label shadows

### DIFF
--- a/static/app/views/preprod/buildComparison/main/treemapDiffSection.tsx
+++ b/static/app/views/preprod/buildComparison/main/treemapDiffSection.tsx
@@ -78,9 +78,6 @@ export function TreemapDiffSection({diffItems}: TreemapDiffSectionProps) {
         color: theme.colors.white,
         fontFamily: 'Rubik',
         padding: 0,
-        textShadowBlur: 2,
-        textShadowColor: theme.colors.gray800,
-        textShadowOffsetY: 0.5,
       },
       upperLabel: {
         show: true,
@@ -92,9 +89,6 @@ export function TreemapDiffSection({diffItems}: TreemapDiffSectionProps) {
         borderRadius: [2, 2, 0, 0],
         fontFamily: 'Rubik',
         padding: 0,
-        textShadowBlur: 2,
-        textShadowColor: theme.colors.gray800,
-        textShadowOffsetY: 0.5,
       },
     };
 

--- a/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
+++ b/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
@@ -225,9 +225,6 @@ export function AppSizeTreemap(props: AppSizeTreemapProps) {
         color: theme.colors.white,
         fontFamily: 'Rubik',
         padding: 0,
-        textShadowBlur: 2,
-        textShadowColor: theme.colors.gray800,
-        textShadowOffsetY: 0.5,
       },
       upperLabel: {
         show: true,
@@ -239,9 +236,6 @@ export function AppSizeTreemap(props: AppSizeTreemapProps) {
         borderRadius: [2, 2, 0, 0],
         fontFamily: 'Rubik',
         padding: 0,
-        textShadowBlur: 2,
-        textShadowColor: theme.colors.gray800,
-        textShadowOffsetY: 0.5,
       },
     };
 


### PR DESCRIPTION
Removed the blurred text shadow styling on the binary treemap UI bits. IMO it's much easier to read now:

| Before | After |
| --- | --- |
|<img width="597" height="513" alt="blurry-before" src="https://github.com/user-attachments/assets/4ca0daf4-1bd8-4e45-8531-04231d56d20e" />|<img width="596" height="511" alt="crisp-after" src="https://github.com/user-attachments/assets/5bde7f57-23c7-42a8-ba08-6b9c1c4a6388" />|
