### PR TITLE
fix(ourlogs): resolve received time in the timestamp hover tooltip

### DIFF
--- a/static/app/views/explore/hooks/useTraceItemDetails.spec.tsx
+++ b/static/app/views/explore/hooks/useTraceItemDetails.spec.tsx
@@ -256,6 +256,48 @@ describe('useTraceItemDetails', () => {
     await waitFor(() => expect(traceItemDetailsMock).toHaveBeenCalledTimes(1));
   });
 
+  it('reports pending only while the prefetched details request is in flight', async () => {
+    initializePageFilters({
+      period: '14d',
+      start: null,
+      end: null,
+      utc: false,
+    });
+    MockApiClient.addMockResponse({
+      method: 'GET',
+      url: `/projects/${organization.slug}/${project.slug}/trace-items/item-id/`,
+      asyncDelay: 100,
+      body: {
+        itemId: 'item-id',
+        links: null,
+        meta: {},
+        timestamp: '2025-04-03T15:50:10.000Z',
+        attributes: [],
+      },
+    });
+
+    const {result} = renderHookWithProviders(usePrefetchTraceItemDetailsOnHover, {
+      organization,
+      initialProps: {
+        projectId: project.id,
+        traceItemId: 'item-id',
+        traceId: '1234567890abcdef1234567890abcdef',
+        traceItemType: TraceItemDataset.LOGS,
+        referrer: 'api.explore.log-item-details',
+        timestamp: 123,
+        sharedHoverTimeoutRef: {current: null},
+        timeout: 0,
+      },
+    });
+
+    await waitFor(() => expect(ProjectsStore.getState().projects).toHaveLength(1));
+    expect(result.current.isTraceItemDetailsPending).toBe(false);
+
+    act(() => result.current.prefetch());
+    await waitFor(() => expect(result.current.isTraceItemDetailsPending).toBe(true));
+    await waitFor(() => expect(result.current.isTraceItemDetailsPending).toBe(false));
+  });
+
   it('does not fetch details when the hovered element unmounts before the hover timeout elapses', async () => {
     jest.useFakeTimers();
     initializePageFilters({

--- a/static/app/views/explore/hooks/useTraceItemDetails.tsx
+++ b/static/app/views/explore/hooks/useTraceItemDetails.tsx
@@ -214,6 +214,7 @@ function useTraceItemDetailsPrefetch({
   const [traceItemAttributes, setTraceItemAttributes] = useState<
     TraceItemResponseAttribute[] | undefined
   >();
+  const [isPending, setIsPending] = useState(true);
 
   const prefetch = useCallback(() => {
     const currentProject = projectRef.current;
@@ -236,8 +237,9 @@ function useTraceItemDetailsPrefetch({
       response => {
         setTraceItemMeta(response?.json?.meta);
         setTraceItemAttributes(response?.json?.attributes);
+        setIsPending(false);
       },
-      () => {}
+      () => setIsPending(false)
     );
   }, [
     organization.slug,
@@ -250,7 +252,7 @@ function useTraceItemDetailsPrefetch({
     traceItemType,
   ]);
 
-  return {prefetch, project, traceItemMeta, traceItemAttributes};
+  return {prefetch, project, traceItemMeta, traceItemAttributes, isPending};
 }
 
 export function usePrefetchTraceItemDetailsOnHover({
@@ -278,7 +280,7 @@ export function usePrefetchTraceItemDetailsOnHover({
    */
   hoverPrefetchDisabled?: boolean;
 }) {
-  const {prefetch, project, traceItemMeta, traceItemAttributes} =
+  const {prefetch, project, traceItemMeta, traceItemAttributes, isPending} =
     useTraceItemDetailsPrefetch({
       traceItemId,
       projectId,
@@ -328,6 +330,7 @@ export function usePrefetchTraceItemDetailsOnHover({
     isProjectReady: Boolean(project?.slug),
     traceItemMeta,
     traceItemAttributes,
+    isTraceItemDetailsPending: isPending,
   };
 }
 

--- a/static/app/views/explore/hooks/useTraceItemDetails.tsx
+++ b/static/app/views/explore/hooks/useTraceItemDetails.tsx
@@ -217,7 +217,7 @@ function useTraceItemDetailsPrefetch({
       traceItemType,
       referrer,
       traceId,
-      ...(defined(timestamp)
+      ...(timestamp
         ? {timestamp: normalizeTimestampToSeconds(timestamp)}
         : normalizeDateTimeParams(selection.datetime)),
     }),

--- a/static/app/views/explore/hooks/useTraceItemDetails.tsx
+++ b/static/app/views/explore/hooks/useTraceItemDetails.tsx
@@ -1,7 +1,7 @@
 import {useCallback, useEffect, useRef, useState} from 'react';
 import {useHover} from '@react-aria/interactions';
 import {captureException} from '@sentry/react';
-import {skipToken, useQuery, useQueryClient} from '@tanstack/react-query';
+import {skipToken, useIsFetching, useQuery, useQueryClient} from '@tanstack/react-query';
 
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
@@ -207,51 +207,38 @@ function useTraceItemDetailsPrefetch({
   const organization = useOrganization();
   const {selection} = usePageFilters();
   const project = useProjectFromId({project_id: projectId});
-  const projectRef = useRef(project);
-  projectRef.current = project;
   const queryClient = useQueryClient();
   const [traceItemMeta, setTraceItemMeta] = useState<TraceItemDetailsMeta | undefined>();
   const [traceItemAttributes, setTraceItemAttributes] = useState<
     TraceItemResponseAttribute[] | undefined
   >();
-  const [isPending, setIsPending] = useState(false);
+
+  const options = traceItemDetailsApiOptions({
+    organizationSlug: organization.slug,
+    projectSlug: project?.slug ?? '',
+    traceItemId,
+    traceItemType,
+    referrer,
+    traceId,
+    ...(defined(timestamp)
+      ? {timestamp: normalizeTimestampToSeconds(timestamp)}
+      : normalizeDateTimeParams(selection.datetime)),
+  });
 
   const prefetch = useCallback(() => {
-    const currentProject = projectRef.current;
-    if (!currentProject?.slug) {
+    if (!project?.slug) {
       return;
     }
-    const timeQueryParams = defined(timestamp)
-      ? {timestamp: normalizeTimestampToSeconds(timestamp)}
-      : normalizeDateTimeParams(selection.datetime);
-    const options = traceItemDetailsApiOptions({
-      organizationSlug: organization.slug,
-      projectSlug: currentProject.slug,
-      traceItemId,
-      traceItemType,
-      referrer,
-      traceId,
-      ...timeQueryParams,
-    });
-    setIsPending(true);
     queryClient.fetchQuery(options).then(
       response => {
         setTraceItemMeta(response?.json?.meta);
         setTraceItemAttributes(response?.json?.attributes);
-        setIsPending(false);
       },
-      () => setIsPending(false)
+      () => {}
     );
-  }, [
-    organization.slug,
-    queryClient,
-    referrer,
-    selection.datetime,
-    timestamp,
-    traceId,
-    traceItemId,
-    traceItemType,
-  ]);
+  }, [options, project?.slug, queryClient]);
+
+  const isPending = useIsFetching({queryKey: options.queryKey, exact: true}) > 0;
 
   return {prefetch, project, traceItemMeta, traceItemAttributes, isPending};
 }

--- a/static/app/views/explore/hooks/useTraceItemDetails.tsx
+++ b/static/app/views/explore/hooks/useTraceItemDetails.tsx
@@ -1,7 +1,7 @@
 import {useCallback, useEffect, useRef, useState} from 'react';
 import {useHover} from '@react-aria/interactions';
 import {captureException} from '@sentry/react';
-import {skipToken, useIsFetching, useQuery, useQueryClient} from '@tanstack/react-query';
+import {skipToken, useQuery} from '@tanstack/react-query';
 
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
@@ -207,40 +207,32 @@ function useTraceItemDetailsPrefetch({
   const organization = useOrganization();
   const {selection} = usePageFilters();
   const project = useProjectFromId({project_id: projectId});
-  const queryClient = useQueryClient();
-  const [traceItemMeta, setTraceItemMeta] = useState<TraceItemDetailsMeta | undefined>();
-  const [traceItemAttributes, setTraceItemAttributes] = useState<
-    TraceItemResponseAttribute[] | undefined
-  >();
+  const [shouldFetch, setShouldFetch] = useState(false);
 
-  const options = traceItemDetailsApiOptions({
-    organizationSlug: organization.slug,
-    projectSlug: project?.slug ?? '',
-    traceItemId,
-    traceItemType,
-    referrer,
-    traceId,
-    ...(defined(timestamp)
-      ? {timestamp: normalizeTimestampToSeconds(timestamp)}
-      : normalizeDateTimeParams(selection.datetime)),
+  const {data, isFetching} = useQuery({
+    ...traceItemDetailsApiOptions({
+      organizationSlug: organization.slug,
+      projectSlug: project?.slug ?? '',
+      traceItemId,
+      traceItemType,
+      referrer,
+      traceId,
+      ...(defined(timestamp)
+        ? {timestamp: normalizeTimestampToSeconds(timestamp)}
+        : normalizeDateTimeParams(selection.datetime)),
+    }),
+    enabled: shouldFetch && !!project?.slug,
   });
 
-  const prefetch = useCallback(() => {
-    if (!project?.slug) {
-      return;
-    }
-    queryClient.fetchQuery(options).then(
-      response => {
-        setTraceItemMeta(response?.json?.meta);
-        setTraceItemAttributes(response?.json?.attributes);
-      },
-      () => {}
-    );
-  }, [options, project?.slug, queryClient]);
+  const prefetch = useCallback(() => setShouldFetch(true), []);
 
-  const isPending = useIsFetching({queryKey: options.queryKey, exact: true}) > 0;
-
-  return {prefetch, project, traceItemMeta, traceItemAttributes, isPending};
+  return {
+    prefetch,
+    project,
+    traceItemMeta: data?.meta,
+    traceItemAttributes: data?.attributes,
+    isPending: isFetching,
+  };
 }
 
 export function usePrefetchTraceItemDetailsOnHover({

--- a/static/app/views/explore/hooks/useTraceItemDetails.tsx
+++ b/static/app/views/explore/hooks/useTraceItemDetails.tsx
@@ -214,7 +214,7 @@ function useTraceItemDetailsPrefetch({
   const [traceItemAttributes, setTraceItemAttributes] = useState<
     TraceItemResponseAttribute[] | undefined
   >();
-  const [isPending, setIsPending] = useState(true);
+  const [isPending, setIsPending] = useState(false);
 
   const prefetch = useCallback(() => {
     const currentProject = projectRef.current;
@@ -233,6 +233,7 @@ function useTraceItemDetailsPrefetch({
       traceId,
       ...timeQueryParams,
     });
+    setIsPending(true);
     queryClient.fetchQuery(options).then(
       response => {
         setTraceItemMeta(response?.json?.meta);

--- a/static/app/views/explore/logs/constants.tsx
+++ b/static/app/views/explore/logs/constants.tsx
@@ -72,7 +72,7 @@ export const HiddenLogDetailFields: OurLogFieldKey[] = [
 
   // deprecated/otel fields that clutter the UI
   'sentry.timestamp_nanos',
-  'sentry.observed_timestamp_nanos',
+  OurLogKnownFieldKey.OBSERVED_TIMESTAMP_NANOS,
   'tags[sentry.trace_flags,number]',
 ];
 

--- a/static/app/views/explore/logs/fieldRenderers.tsx
+++ b/static/app/views/explore/logs/fieldRenderers.tsx
@@ -83,6 +83,7 @@ export interface RendererExtra extends RenderFunctionBaggage {
   logColors: ReturnType<typeof getLogColors>;
   align?: 'left' | 'center' | 'right';
   canAppendTemplateToBody?: boolean;
+  isTraceItemDetailsPending?: boolean;
   logEnd?: string;
   logStart?: string;
   meta?: EventsMetaType;
@@ -166,6 +167,7 @@ function TimestampRenderer(props: LogFieldRendererProps) {
       <LogsTimestampTooltip
         timestamp={props.item.value!}
         attributes={props.extra.attributes}
+        isTraceItemDetailsPending={props.extra.isTraceItemDetailsPending}
         shouldRender={props.extra.shouldRenderHoverElements}
       >
         <DateTime seconds milliseconds date={timestampToUse} />
@@ -213,6 +215,7 @@ function RelativeTimestampRenderer(props: LogFieldRendererProps) {
       <LogsTimestampTooltip
         timestamp={props.item.value!}
         attributes={props.extra.attributes}
+        isTraceItemDetailsPending={props.extra.isTraceItemDetailsPending}
         shouldRender={props.extra.shouldRenderHoverElements}
         relativeTimeToReplay={relativeTimestampMs}
       >

--- a/static/app/views/explore/logs/logsTimeTooltip.spec.tsx
+++ b/static/app/views/explore/logs/logsTimeTooltip.spec.tsx
@@ -91,8 +91,28 @@ describe('TimestampTooltipBody', () => {
       </TimezoneProvider>
     );
 
-    expect(screen.getByText('Occurred')).toBeInTheDocument();
+    expect(screen.queryByText('Received')).not.toBeInTheDocument();
     expect(screen.queryAllByRole('time')).toHaveLength(2);
+  });
+
+  it('renders received time when the observed timestamp uses its internal name', () => {
+    const user = UserFixture();
+    user.options.timezone = 'America/New_York';
+    ConfigStore.set('user', user);
+
+    const attributes = {
+      [OurLogKnownFieldKey.TIMESTAMP_PRECISE]: '1705333530456789012',
+      [OurLogKnownFieldKey.OBSERVED_TIMESTAMP_NANOS]: '1705333540456789012',
+    };
+
+    render(
+      <TimezoneProvider timezone="America/New_York">
+        <TimestampTooltipBody timestamp={timestamp} attributes={attributes} />
+      </TimezoneProvider>
+    );
+
+    expect(screen.getByText('Received')).toBeInTheDocument();
+    expect(screen.queryAllByRole('time')).toHaveLength(3);
   });
 
   it('renders in 24h format when user preference is set', () => {

--- a/static/app/views/explore/logs/logsTimeTooltip.spec.tsx
+++ b/static/app/views/explore/logs/logsTimeTooltip.spec.tsx
@@ -115,6 +115,29 @@ describe('TimestampTooltipBody', () => {
     expect(screen.queryAllByRole('time')).toHaveLength(3);
   });
 
+  it('renders a loading received time when the trace item details are still pending', () => {
+    const user = UserFixture();
+    user.options.timezone = 'America/New_York';
+    ConfigStore.set('user', user);
+
+    const attributes = {
+      [OurLogKnownFieldKey.TIMESTAMP_PRECISE]: '1705333530456789012',
+    };
+
+    render(
+      <TimezoneProvider timezone="America/New_York">
+        <TimestampTooltipBody
+          timestamp={timestamp}
+          attributes={attributes}
+          isTraceItemDetailsPending
+        />
+      </TimezoneProvider>
+    );
+
+    expect(screen.getByText('Received')).toBeInTheDocument();
+    expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
+  });
+
   it('renders in 24h format when user preference is set', () => {
     const user = UserFixture();
     user.options.timezone = 'America/New_York';

--- a/static/app/views/explore/logs/logsTimeTooltip.tsx
+++ b/static/app/views/explore/logs/logsTimeTooltip.tsx
@@ -7,7 +7,6 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 import {AutoSelectText} from 'sentry/components/autoSelectText';
 import {DateTime} from 'sentry/components/dateTime';
 import {Duration} from 'sentry/components/duration/duration';
-import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {useTimezone} from 'sentry/components/timezoneProvider';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -39,7 +38,11 @@ function TimestampTooltipBody({
     : null;
   const timestampToUse = preciseTimestampMs ? new Date(preciseTimestampMs) : timestamp;
 
-  const observedTimeNanos = attributes[OurLogKnownFieldKey.OBSERVED_TIMESTAMP_PRECISE];
+  // Trace item details only alias the observed timestamp when it comes back as an int,
+  // so string-stored values arrive under the internal name instead.
+  const observedTimeNanos =
+    attributes[OurLogKnownFieldKey.OBSERVED_TIMESTAMP_PRECISE] ??
+    attributes[OurLogKnownFieldKey.OBSERVED_TIMESTAMP_NANOS];
   const observedTime = observedTimeNanos
     ? new Date(Math.floor(Number(observedTimeNanos) / 1_000_000))
     : null;
@@ -94,21 +97,19 @@ function TimestampTooltipBody({
         </Fragment>
       )}
 
-      <Fragment>
-        <HorizontalRule />
-        <dt>{t('Received')}</dt>
-        <dd>
-          {observedTime ? (
+      {observedTime && (
+        <Fragment>
+          <HorizontalRule />
+          <dt>{t('Received')}</dt>
+          <dd>
             <TimestampValues>
               <AutoSelectText>
                 <DateTime date={observedTime} seconds timeZone />
               </AutoSelectText>
             </TimestampValues>
-          ) : (
-            <LoadingIndicator size={16} style={{margin: 0}} />
-          )}
-        </dd>
-      </Fragment>
+          </dd>
+        </Fragment>
+      )}
     </DescriptionList>
   );
 }

--- a/static/app/views/explore/logs/logsTimeTooltip.tsx
+++ b/static/app/views/explore/logs/logsTimeTooltip.tsx
@@ -7,6 +7,7 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 import {AutoSelectText} from 'sentry/components/autoSelectText';
 import {DateTime} from 'sentry/components/dateTime';
 import {Duration} from 'sentry/components/duration/duration';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {useTimezone} from 'sentry/components/timezoneProvider';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -17,6 +18,7 @@ type Props = {
   attributes: Record<string, string | number | boolean>;
   children: React.ReactNode;
   timestamp: string | number;
+  isTraceItemDetailsPending?: boolean;
   relativeTimeToReplay?: number;
   shouldRender?: boolean;
 };
@@ -24,10 +26,12 @@ type Props = {
 function TimestampTooltipBody({
   timestamp,
   attributes,
+  isTraceItemDetailsPending,
   relativeTime,
 }: {
   attributes: Record<string, string | number | boolean>;
   timestamp: string | number;
+  isTraceItemDetailsPending?: boolean;
   relativeTime?: number;
 }) {
   const currentTimezone = useTimezone();
@@ -38,8 +42,6 @@ function TimestampTooltipBody({
     : null;
   const timestampToUse = preciseTimestampMs ? new Date(preciseTimestampMs) : timestamp;
 
-  // Trace item details only alias the observed timestamp when it comes back as an int,
-  // so string-stored values arrive under the internal name instead.
   const observedTimeNanos =
     attributes[OurLogKnownFieldKey.OBSERVED_TIMESTAMP_PRECISE] ??
     attributes[OurLogKnownFieldKey.OBSERVED_TIMESTAMP_NANOS];
@@ -97,16 +99,20 @@ function TimestampTooltipBody({
         </Fragment>
       )}
 
-      {observedTime && (
+      {(observedTime || isTraceItemDetailsPending) && (
         <Fragment>
           <HorizontalRule />
           <dt>{t('Received')}</dt>
           <dd>
-            <TimestampValues>
-              <AutoSelectText>
-                <DateTime date={observedTime} seconds timeZone />
-              </AutoSelectText>
-            </TimestampValues>
+            {observedTime ? (
+              <TimestampValues>
+                <AutoSelectText>
+                  <DateTime date={observedTime} seconds timeZone />
+                </AutoSelectText>
+              </TimestampValues>
+            ) : (
+              <LoadingIndicator size={16} style={{margin: 0}} />
+            )}
           </dd>
         </Fragment>
       )}
@@ -120,6 +126,7 @@ export function LogsTimestampTooltip({
   timestamp,
   attributes,
   children,
+  isTraceItemDetailsPending,
   shouldRender = true,
   relativeTimeToReplay: relativeTime,
 }: Props) {
@@ -138,6 +145,7 @@ export function LogsTimestampTooltip({
           <TimestampTooltipBody
             timestamp={timestamp}
             attributes={attributes}
+            isTraceItemDetailsPending={isTraceItemDetailsPending}
             relativeTime={relativeTime}
           />
         </div>

--- a/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
@@ -411,6 +411,64 @@ describe('logsTableRow', () => {
     );
   });
 
+  it('renders a received time in the details timestamp tooltip when the observed timestamp uses its internal name', async () => {
+    const {
+      [OurLogKnownFieldKey.OBSERVED_TIMESTAMP_PRECISE]: observedTimestamp,
+      ...rowDataWithInternalObservedTimestamp
+    } = LogFixture({
+      [OurLogKnownFieldKey.ID]: '4',
+      [OurLogKnownFieldKey.PROJECT_ID]: project.id,
+      [OurLogKnownFieldKey.ORGANIZATION_ID]: Number(organization.id),
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/trace-items/4/`,
+      method: 'GET',
+      body: {
+        itemId: '4',
+        links: null,
+        meta: {},
+        timestamp: rowDataWithInternalObservedTimestamp[OurLogKnownFieldKey.TIMESTAMP],
+        attributes: [
+          ...Object.entries(rowDataWithInternalObservedTimestamp).map(
+            ([k, v]) =>
+              ({
+                name: k,
+                value: v,
+                type: typeof v === 'string' ? 'str' : 'float',
+              }) as TraceItemResponseAttribute
+          ),
+          {
+            name: OurLogKnownFieldKey.OBSERVED_TIMESTAMP_NANOS,
+            value: String(observedTimestamp),
+            type: 'str',
+          },
+        ],
+      },
+    });
+
+    render(
+      <LogRowContent
+        dataRow={rowDataWithInternalObservedTimestamp}
+        highlightTerms={[]}
+        meta={LogFixtureMeta(rowDataWithInternalObservedTimestamp)}
+        sharedHoverTimeoutRef={{current: null}}
+      />,
+      {organization, initialRouterConfig, additionalWrapper: ProviderWrapper}
+    );
+
+    await userEvent.click(await screen.findByTestId('log-table-row'));
+
+    const attributesTree = await screen.findByTestId('fields-tree');
+    const [treeTimestamp] = within(attributesTree).getAllByText(
+      'Apr 10, 2025 7:21:10.049 PM'
+    );
+    await userEvent.hover(treeTimestamp!);
+
+    expect(await screen.findByText('Received')).toBeInTheDocument();
+    expect(screen.getByText('Apr 10, 2025 7:21:10 PM UTC')).toBeInTheDocument();
+  });
+
   it('adds a similar spans action to the log message dropdown', async () => {
     const rowDataWithQuotedMessage = {
       ...rowData,

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -382,7 +382,7 @@ export const LogRowContent = memo(function LogRowContentImpl({
   const [caseInsensitivity] = useCaseInsensitivity();
 
   const observedTimestamp = traceItemAttributes?.find(
-    a => a.name === 'sentry.observed_timestamp_nanos'
+    a => a.name === OurLogKnownFieldKey.OBSERVED_TIMESTAMP_NANOS
   );
 
   const rendererExtra: RendererExtra = {

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -357,17 +357,23 @@ export const LogRowContent = memo(function LogRowContentImpl({
   const logTimestampSeconds = isRegularLogResponseItem(dataRow)
     ? getLogRowTimestampMillis(dataRow) / 1000
     : null;
-  const {hoverProps, prefetch, isProjectReady, traceItemMeta, traceItemAttributes} =
-    usePrefetchTraceItemDetailsOnHover({
-      traceItemId: rowId,
-      projectId: String(dataRow[OurLogKnownFieldKey.PROJECT_ID]),
-      traceId: String(dataRow[OurLogKnownFieldKey.TRACE_ID]),
-      traceItemType: TraceItemDataset.LOGS,
-      referrer: 'api.explore.log-item-details',
-      timestamp: logTimestampSeconds,
-      sharedHoverTimeoutRef,
-      timeout: prefetchTimeout,
-    });
+  const {
+    hoverProps,
+    prefetch,
+    isProjectReady,
+    isTraceItemDetailsPending,
+    traceItemMeta,
+    traceItemAttributes,
+  } = usePrefetchTraceItemDetailsOnHover({
+    traceItemId: rowId,
+    projectId: String(dataRow[OurLogKnownFieldKey.PROJECT_ID]),
+    traceId: String(dataRow[OurLogKnownFieldKey.TRACE_ID]),
+    traceItemType: TraceItemDataset.LOGS,
+    referrer: 'api.explore.log-item-details',
+    timestamp: logTimestampSeconds,
+    sharedHoverTimeoutRef,
+    timeout: prefetchTimeout,
+  });
   usePrefetchTraceItemDetailsOnMount({
     prefetch,
     enabled: isHighlighted,
@@ -383,6 +389,7 @@ export const LogRowContent = memo(function LogRowContentImpl({
     highlightTerms,
     caseSensitiveHighlighting: !caseInsensitivity,
     datetime: selection.datetime,
+    isTraceItemDetailsPending,
     logColors,
     useFullSeverityText: false,
     location,

--- a/static/app/views/explore/logs/types.tsx
+++ b/static/app/views/explore/logs/types.tsx
@@ -55,6 +55,9 @@ export enum OurLogKnownFieldKey {
   // From the EAP dataset directly not using a column alias, should be hidden.
   ITEM_TYPE = 'sentry.item_type',
 
+  // Trace item details fall back to this when OBSERVED_TIMESTAMP_PRECISE can't be aliased.
+  OBSERVED_TIMESTAMP_NANOS = 'sentry.observed_timestamp_nanos',
+
   // Deprecated fields
   TIMESTAMP_NANOS = 'sentry.timestamp_nanos',
 


### PR DESCRIPTION
The "Received" row in the log timestamp hover tooltip spun on a loading indicator forever in the expanded log details.

`observed_timestamp` is declared with `search_type="number"` but stored as a string, and `LOGS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS` is keyed by `search_type`. The trace item details endpoint looks the alias up using the type of the value it actually got back ("string"`) so it misses the `"number"` bucket and falls back to emitting the internal name:

```json
{"name": "sentry.observed_timestamp_nanos", "type": "str", "value": "1786046484244158487"}
```

The log table row works because it maps that internal name in while merging the prefetched attributes. But the tooltip only read the `observed_timestamp` alias. The expanded log details key their attribute map by the raw response names, so the lookup missed and the placeholder spinner added in #115505 had nothing to resolve to.

The tooltip now accepts either name. It also stops spinning once the trace item details request has settled, so a log that just misses the attribute no longer leaves a spinner up forever. 

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="3200" height="1800" alt="before" src="https://github.com/user-attachments/assets/27703a6c-f5ca-4aa3-88a3-5b0d2bc9ba8b" />
</td>
<td>
<img width="3200" height="1800" alt="after" src="https://github.com/user-attachments/assets/454aa219-8284-40d3-8fcd-57789f81c407" />
</td>
</tr>
</tbody>
</table>

Closes LOGS-937.
