### PR TITLE
fix(issues): Include suggested issues in inbox

### DIFF
--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -161,24 +161,27 @@ describe('InboxPage', () => {
   function mockSuccessfulSections() {
     return [
       mockSection(
-        'issue.progress:fix_proposed is:unresolved assigned:[me,my_teams]',
+        'issue.progress:fix_proposed is:unresolved assigned_or_suggested:me',
         [fixProposedGroup],
         200,
         2
       ),
       mockSection(
-        'issue.progress:diagnosed is:unresolved assigned:[me,my_teams]',
+        'issue.progress:diagnosed is:unresolved assigned_or_suggested:me',
         [diagnosedGroup],
         200,
         2
       ),
       mockSection(
-        'issue.progress:assigned is:unresolved assigned:[me,my_teams]',
+        'issue.progress:assigned is:unresolved assigned_or_suggested:me',
         [assignedGroup],
         200,
         12
       ),
-      mockSection('issue.progress:fix_applied is:unresolved assigned:[me,my_teams]', []),
+      mockSection(
+        'issue.progress:fix_applied is:unresolved assigned_or_suggested:me',
+        []
+      ),
     ];
   }
 
@@ -283,10 +286,10 @@ describe('InboxPage', () => {
     expect(screen.getByRole('heading', {name: 'Issues', level: 2})).toBeInTheDocument();
 
     for (const [index, query] of [
-      'issue.progress:fix_proposed is:unresolved assigned:[me,my_teams]',
-      'issue.progress:diagnosed is:unresolved assigned:[me,my_teams]',
-      'issue.progress:assigned is:unresolved assigned:[me,my_teams]',
-      'issue.progress:fix_applied is:unresolved assigned:[me,my_teams]',
+      'issue.progress:fix_proposed is:unresolved assigned_or_suggested:me',
+      'issue.progress:diagnosed is:unresolved assigned_or_suggested:me',
+      'issue.progress:assigned is:unresolved assigned_or_suggested:me',
+      'issue.progress:fix_applied is:unresolved assigned_or_suggested:me',
     ].entries()) {
       await waitFor(() =>
         expect(requests[index]).toHaveBeenCalledWith(
@@ -407,19 +410,19 @@ describe('InboxPage', () => {
       url: '/organizations/org-slug/issues/',
       match: [
         MockApiClient.matchQuery({
-          query: `issue.progress:fix_proposed is:unresolved assigned:[me,my_teams]${INBOX_AUTOFIX_CATEGORY_FILTER}`,
+          query: `issue.progress:fix_proposed is:unresolved assigned_or_suggested:me${INBOX_AUTOFIX_CATEGORY_FILTER}`,
         }),
       ],
       body: [fixProposedGroup],
       headers: {'X-Hits': '1000', 'X-Max-Hits': '1000'},
     });
-    mockSection('issue.progress:diagnosed is:unresolved assigned:[me,my_teams]', [
+    mockSection('issue.progress:diagnosed is:unresolved assigned_or_suggested:me', [
       diagnosedGroup,
     ]);
-    mockSection('issue.progress:assigned is:unresolved assigned:[me,my_teams]', [
+    mockSection('issue.progress:assigned is:unresolved assigned_or_suggested:me', [
       assignedGroup,
     ]);
-    mockSection('issue.progress:fix_applied is:unresolved assigned:[me,my_teams]', []);
+    mockSection('issue.progress:fix_applied is:unresolved assigned_or_suggested:me', []);
 
     render(<InboxPage />, {organization: seerOrganization, initialRouterConfig});
 
@@ -457,13 +460,23 @@ describe('InboxPage', () => {
   it('filters sections by the selected assignee', async () => {
     mockSuccessfulSections();
     mockIssuePreview();
-    const meRequests = [
-      mockSection('issue.progress:fix_proposed is:unresolved assigned:me', [
-        fixProposedGroup,
-      ]),
-      mockSection('issue.progress:diagnosed is:unresolved assigned:me', [diagnosedGroup]),
-      mockSection('issue.progress:assigned is:unresolved assigned:me', [assignedGroup]),
-      mockSection('issue.progress:fix_applied is:unresolved assigned:me', []),
+    const myTeamsRequests = [
+      mockSection(
+        'issue.progress:fix_proposed is:unresolved assigned_or_suggested:[me,my_teams]',
+        [fixProposedGroup]
+      ),
+      mockSection(
+        'issue.progress:diagnosed is:unresolved assigned_or_suggested:[me,my_teams]',
+        [diagnosedGroup]
+      ),
+      mockSection(
+        'issue.progress:assigned is:unresolved assigned_or_suggested:[me,my_teams]',
+        [assignedGroup]
+      ),
+      mockSection(
+        'issue.progress:fix_applied is:unresolved assigned_or_suggested:[me,my_teams]',
+        []
+      ),
     ];
     const allRequests = [
       mockSection('issue.progress:fix_proposed is:unresolved', [fixProposedGroup]),
@@ -481,16 +494,16 @@ describe('InboxPage', () => {
     const meFilter = screen.getByRole('radio', {name: 'Me'});
     const myTeamsFilter = screen.getByRole('radio', {name: 'My Teams'});
     const allFilter = screen.getByRole('radio', {name: 'All'});
-    expect(meFilter).not.toBeChecked();
-    expect(myTeamsFilter).toBeChecked();
+    expect(meFilter).toBeChecked();
+    expect(myTeamsFilter).not.toBeChecked();
     expect(allFilter).not.toBeChecked();
     expect(await screen.findByText('Fix proposed issue')).toBeInTheDocument();
 
-    await userEvent.click(meFilter);
+    await userEvent.click(myTeamsFilter);
 
-    expect(meFilter).toBeChecked();
-    expect(router.location.query.assignment).toBe('me');
-    for (const request of meRequests) {
+    expect(myTeamsFilter).toBeChecked();
+    expect(router.location.query.assignment).toBe('my_teams');
+    for (const request of myTeamsRequests) {
       await waitFor(() => expect(request).toHaveBeenCalledTimes(1));
     }
 
@@ -574,7 +587,7 @@ describe('InboxPage', () => {
       url: '/organizations/org-slug/issues/',
       match: [
         MockApiClient.matchQuery({
-          query: `issue.progress:fix_proposed is:unresolved assigned:[me,my_teams]${INBOX_AUTOFIX_CATEGORY_FILTER}`,
+          query: `issue.progress:fix_proposed is:unresolved assigned_or_suggested:me${INBOX_AUTOFIX_CATEGORY_FILTER}`,
         }),
       ],
       body: [fixProposedGroup],
@@ -587,7 +600,7 @@ describe('InboxPage', () => {
       url: '/organizations/org-slug/issues/',
       match: [
         MockApiClient.matchQuery({
-          query: `issue.progress:fix_proposed is:unresolved assigned:[me,my_teams]${INBOX_AUTOFIX_CATEGORY_FILTER}`,
+          query: `issue.progress:fix_proposed is:unresolved assigned_or_suggested:me${INBOX_AUTOFIX_CATEGORY_FILTER}`,
           cursor: '0:10:0',
         }),
       ],
@@ -595,13 +608,13 @@ describe('InboxPage', () => {
       headers: {'X-Hits': '2'},
       asyncDelay: 100,
     });
-    mockSection('issue.progress:diagnosed is:unresolved assigned:[me,my_teams]', [
+    mockSection('issue.progress:diagnosed is:unresolved assigned_or_suggested:me', [
       diagnosedGroup,
     ]);
-    mockSection('issue.progress:assigned is:unresolved assigned:[me,my_teams]', [
+    mockSection('issue.progress:assigned is:unresolved assigned_or_suggested:me', [
       assignedGroup,
     ]);
-    mockSection('issue.progress:fix_applied is:unresolved assigned:[me,my_teams]', []);
+    mockSection('issue.progress:fix_applied is:unresolved assigned_or_suggested:me', []);
 
     render(<InboxPage />, {organization, initialRouterConfig});
 

--- a/static/app/views/issueList/pages/inbox.tsx
+++ b/static/app/views/issueList/pages/inbox.tsx
@@ -52,8 +52,8 @@ const INBOX_MAX_SIZE = 640;
 type AssignmentFilter = (typeof ASSIGNMENT_FILTERS)[number];
 
 const ASSIGNMENT_QUERY_SUFFIXES: Record<AssignmentFilter, string> = {
-  me: ' assigned:me',
-  my_teams: ' assigned:[me,my_teams]',
+  me: ' assigned_or_suggested:me',
+  my_teams: ' assigned_or_suggested:[me,my_teams]',
   all: '',
 };
 interface InboxSectionContext {
@@ -143,7 +143,7 @@ function InboxContent() {
   const [assignmentFilter, setAssignmentFilter] = useQueryState(
     ASSIGNMENT_QUERY_PARAM,
     parseAsStringLiteral(ASSIGNMENT_FILTERS)
-      .withDefault('my_teams')
+      .withDefault('me')
       .withOptions({history: 'replace'})
   );
   const [selectedIssueId, setSelectedIssueId] = useQueryState(

--- a/static/app/views/issueList/queries/useInboxIssueCount.tsx
+++ b/static/app/views/issueList/queries/useInboxIssueCount.tsx
@@ -5,9 +5,9 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 
 import {INBOX_AUTOFIX_CATEGORY_FILTER} from './inbox';
 
-// Count all issues assigned to me/my teams which are assigned or further along
-const INBOX_COUNT_QUERY = `is:unresolved issue.progress:[fix_proposed,diagnosed,assigned] assigned:[me,my_teams]${INBOX_AUTOFIX_CATEGORY_FILTER}`;
-const INBOX_COUNT_QUERY_NO_SEER = `is:unresolved issue.progress:[fix_proposed] assigned:[me,my_teams]${INBOX_AUTOFIX_CATEGORY_FILTER}`;
+// Count all issues assigned or suggested to me which are assigned or further along
+const INBOX_COUNT_QUERY = `is:unresolved issue.progress:[fix_proposed,diagnosed,assigned] assigned_or_suggested:me${INBOX_AUTOFIX_CATEGORY_FILTER}`;
+const INBOX_COUNT_QUERY_NO_SEER = `is:unresolved issue.progress:[fix_proposed] assigned_or_suggested:me${INBOX_AUTOFIX_CATEGORY_FILTER}`;
 
 export function useInboxIssueCount() {
   const organization = useOrganization();

--- a/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.spec.tsx
+++ b/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.spec.tsx
@@ -7,8 +7,8 @@ import {IssuesSecondaryNavigation} from 'sentry/views/navigation/secondary/secti
 import {SecondaryNavigationContextProvider} from 'sentry/views/navigation/secondaryNavigationContext';
 
 describe('IssuesSecondaryNavigation', () => {
-  const inboxCountQuery = `is:unresolved issue.progress:[fix_proposed,diagnosed,assigned] assigned:[me,my_teams]${INBOX_AUTOFIX_CATEGORY_FILTER}`;
-  const inboxCountNoSeerQuery = `is:unresolved issue.progress:[fix_proposed] assigned:[me,my_teams]${INBOX_AUTOFIX_CATEGORY_FILTER}`;
+  const inboxCountQuery = `is:unresolved issue.progress:[fix_proposed,diagnosed,assigned] assigned_or_suggested:me${INBOX_AUTOFIX_CATEGORY_FILTER}`;
+  const inboxCountNoSeerQuery = `is:unresolved issue.progress:[fix_proposed] assigned_or_suggested:me${INBOX_AUTOFIX_CATEGORY_FILTER}`;
   const organization = OrganizationFixture({
     features: ['issue-stream-progress-ui', 'seat-based-seer-enabled'],
   });
@@ -36,7 +36,7 @@ describe('IssuesSecondaryNavigation', () => {
     );
   }
 
-  it('shows the inbox count for Seer progress sections and the user and their teams', async () => {
+  it('shows the inbox count for Seer progress sections assigned or suggested to the user', async () => {
     const request = mockInboxCount({
       [inboxCountQuery]: 12,
     });
@@ -53,7 +53,7 @@ describe('IssuesSecondaryNavigation', () => {
     expect(query).toContain('diagnosed');
     expect(query).toContain('assigned');
     expect(query).toContain('is:unresolved');
-    expect(query).toContain('assigned:[me,my_teams]');
+    expect(query).toContain('assigned_or_suggested:me');
   });
 
   it('only counts fix proposed issues without Seer', async () => {


### PR DESCRIPTION
Closes ISWF-3237

We are now:

- Including suggested assignees to your inbox issues
- Defaulting to "me"
- The inbox count in the nav now shows all issues assigned or suggested to yourself