### PR TITLE
fix(issue-details): Remove linked pull request checks and review status

### DIFF
--- a/static/app/components/group/externalIssuesList/linkedPullRequests.spec.tsx
+++ b/static/app/components/group/externalIssuesList/linkedPullRequests.spec.tsx
@@ -138,6 +138,34 @@ describe('LinkedPullRequests', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('can omit checks and review expansion', async () => {
+    const pullRequestsMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${group.id}/pull-requests/`,
+      body: {
+        pullRequests: [
+          {
+            ...PullRequestFixture({id: '123', repository}),
+            attribution: null,
+            dateLinked: '2026-06-08T23:11:32.000000Z',
+            status: 'open',
+          },
+        ],
+      },
+    });
+
+    render(<LinkedPullRequests group={group} showChecksAndReview={false} />, {
+      organization,
+    });
+
+    expect(
+      await screen.findByRole('link', {name: /Pull request #123/})
+    ).toBeInTheDocument();
+    expect(pullRequestsMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.not.objectContaining({query: {expand: 'checksAndReview'}})
+    );
+  });
+
   it('deduplicates pull request ids from group activity', () => {
     const activityGroup = GroupFixture({
       activity: [

--- a/static/app/components/group/externalIssuesList/linkedPullRequests.spec.tsx
+++ b/static/app/components/group/externalIssuesList/linkedPullRequests.spec.tsx
@@ -138,34 +138,6 @@ describe('LinkedPullRequests', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('can omit checks and review expansion', async () => {
-    const pullRequestsMock = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/issues/${group.id}/pull-requests/`,
-      body: {
-        pullRequests: [
-          {
-            ...PullRequestFixture({id: '123', repository}),
-            attribution: null,
-            dateLinked: '2026-06-08T23:11:32.000000Z',
-            status: 'open',
-          },
-        ],
-      },
-    });
-
-    render(<LinkedPullRequests group={group} showChecksAndReview={false} />, {
-      organization,
-    });
-
-    expect(
-      await screen.findByRole('link', {name: /Pull request #123/})
-    ).toBeInTheDocument();
-    expect(pullRequestsMock).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.not.objectContaining({query: {expand: 'checksAndReview'}})
-    );
-  });
-
   it('deduplicates pull request ids from group activity', () => {
     const activityGroup = GroupFixture({
       activity: [

--- a/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
+++ b/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
@@ -62,6 +62,7 @@ export function getLinkedPullRequestActivityIds(group: Group) {
 
 interface LinkedPullRequestsProps {
   group: Group;
+  showChecksAndReview?: boolean;
   showEmptyState?: boolean;
 }
 
@@ -231,7 +232,13 @@ function SeerAttributionAvatar() {
   );
 }
 
-export function useLinkedPullRequests({group}: {group: Group}) {
+export function useLinkedPullRequests({
+  group,
+  includeChecksAndReview = true,
+}: {
+  group: Group;
+  includeChecksAndReview?: boolean;
+}) {
   const organization = useOrganization();
 
   return useQuery(
@@ -239,15 +246,22 @@ export function useLinkedPullRequests({group}: {group: Group}) {
       '/organizations/$organizationIdOrSlug/issues/$issueId/pull-requests/',
       {
         path: {organizationIdOrSlug: organization.slug, issueId: group.id},
-        query: {expand: 'checksAndReview'},
+        query: includeChecksAndReview ? {expand: 'checksAndReview'} : undefined,
         staleTime: 30_000,
       }
     )
   );
 }
 
-export function LinkedPullRequests({group, showEmptyState}: LinkedPullRequestsProps) {
-  const {data, isError, isPending} = useLinkedPullRequests({group});
+export function LinkedPullRequests({
+  group,
+  showChecksAndReview = true,
+  showEmptyState,
+}: LinkedPullRequestsProps) {
+  const {data, isError, isPending} = useLinkedPullRequests({
+    group,
+    includeChecksAndReview: showChecksAndReview,
+  });
   const activityPullRequestIds = getLinkedPullRequestActivityIds(group);
 
   if (isError) {

--- a/static/app/views/issueDetails/sidebar/externalIssueSidebarList.tsx
+++ b/static/app/views/issueDetails/sidebar/externalIssueSidebarList.tsx
@@ -24,7 +24,7 @@ interface Props {
 export function ExternalIssueSidebarList({event, group}: Props) {
   const externalIssueData = useGroupExternalIssues({group, event});
   const {data: linkedPullRequestsData, isPending: isLinkedPullRequestsLoading} =
-    useLinkedPullRequests({group});
+    useLinkedPullRequests({group, includeChecksAndReview: false});
   const hasLinkedPullRequestActivity = getLinkedPullRequestActivityIds(group).size > 0;
   const showEmptyIssueTrackerAction =
     !externalIssueData.isLoading &&
@@ -60,6 +60,7 @@ export function ExternalIssueSidebarList({event, group}: Props) {
         <ErrorBoundary customComponent={null}>
           <LinkedPullRequests
             group={group}
+            showChecksAndReview={false}
             showEmptyState={
               !showEmptyIssueTrackerAction &&
               !externalIssueData.isLoading &&


### PR DESCRIPTION
The added checks and review cause overflow on the issue details sidebar, so we're just opting this component out for now. We can go back later and design this properly if we want to include those.

<img width="315" height="120" alt="CleanShot 2026-08-06 at 13 58 27" src="https://github.com/user-attachments/assets/94906e00-c4f8-448e-aaba-2b238c01e623" />
