### PR TITLE
ref(data_export): Rename array telemetry attrs to unprefixed names

### DIFF
--- a/src/sentry/data_export/tasks.py
+++ b/src/sentry/data_export/tasks.py
@@ -178,13 +178,13 @@ def export_chunk_to_stored_blobs(
             page_token=page_token,
         )
         csv_headers = [str(header) for header in processor.header_fields]
-        set_span_data(span, "data_export.csv_headers", csv_headers)
+        set_span_data(span, "csv_headers", csv_headers)
         if first_page:
             sentry_sdk.logger.info(
                 "dataexport.csv_headers",
                 attributes={
                     "data_export.data_export_id": data_export.id,
-                    "data_export.csv_headers": csv_headers,
+                    "csv_headers": csv_headers,
                 },
             )
 
@@ -789,12 +789,12 @@ def merge_export_blobs(
                     if blob.checksum != blob_checksum.hexdigest():
                         raise AssembleChecksumMismatch("Checksum mismatch")
 
-                set_span_data(span, "data_export.blob_offsets", blob_offsets)
+                set_span_data(span, "blob_offsets", blob_offsets)
                 sentry_sdk.logger.info(
                     "dataexport.blob_offsets",
                     attributes={
                         "data_export.data_export_id": data_export_id,
-                        "data_export.blob_offsets": blob_offsets,
+                        "blob_offsets": blob_offsets,
                     },
                 )
 


### PR DESCRIPTION
Emit the two array-valued export telemetry attributes as `csv_headers` and `blob_offsets` instead of `data_export.csv_headers` and `data_export.blob_offsets`, at both the span-data and structured-log sites. The `data_export.data_export_id` attribute and the `dataexport.*` log message names are left unchanged.
In current naming structure, the ingestion string-ify the arrays.

