### PR TITLE
fix(onboarding): Clip the SCM reveal during its exit tween

### DIFF
--- a/static/app/components/onboarding/scm/scmCollapsibleReveal.tsx
+++ b/static/app/components/onboarding/scm/scmCollapsibleReveal.tsx
@@ -1,5 +1,4 @@
-import {useState} from 'react';
-import {AnimatePresence, motion, type Variants} from 'framer-motion';
+import {AnimatePresence, motion} from 'framer-motion';
 
 interface ScmCollapsibleRevealProps {
   children: React.ReactNode;
@@ -17,39 +16,21 @@ interface ScmCollapsibleRevealProps {
  * initial={false} renders the open state without animating on mount.
  */
 export function ScmCollapsibleReveal({open, id, children}: ScmCollapsibleRevealProps) {
-  // Clip while height is changing, then release overflow once expanded. The
-  // exit variant must own the clip because AnimatePresence freezes its child.
-  const [isSettled, setIsSettled] = useState(open);
-  const variants: Variants = {
-    collapsed: {height: 0, opacity: 0, overflow: 'hidden'},
-    expanded: {
-      height: 'auto',
-      opacity: 1,
-      overflow: isSettled ? 'visible' : 'hidden',
-    },
-  };
-
   return (
     <AnimatePresence initial={false}>
       {open && (
         <motion.div
           key="content"
           id={id}
-          variants={variants}
-          initial="collapsed"
-          animate="expanded"
-          exit="collapsed"
+          initial={{height: 0, opacity: 0, overflow: 'hidden'}}
+          animate={{
+            height: 'auto',
+            opacity: 1,
+            overflow: 'hidden',
+            transitionEnd: {overflow: 'visible'},
+          }}
+          exit={{height: 0, opacity: 0, overflow: 'hidden'}}
           transition={{duration: 0.2, ease: 'easeOut'}}
-          onAnimationStart={definition => {
-            if (definition === 'collapsed') {
-              setIsSettled(false);
-            }
-          }}
-          onAnimationComplete={definition => {
-            if (definition === 'expanded') {
-              setIsSettled(true);
-            }
-          }}
           style={{width: '100%'}}
         >
           {children}

--- a/static/app/components/onboarding/scm/scmCollapsibleReveal.tsx
+++ b/static/app/components/onboarding/scm/scmCollapsibleReveal.tsx
@@ -1,4 +1,5 @@
-import {AnimatePresence, motion} from 'framer-motion';
+import {useState} from 'react';
+import {AnimatePresence, motion, type Variants} from 'framer-motion';
 
 interface ScmCollapsibleRevealProps {
   children: React.ReactNode;
@@ -16,20 +17,39 @@ interface ScmCollapsibleRevealProps {
  * initial={false} renders the open state without animating on mount.
  */
 export function ScmCollapsibleReveal({open, id, children}: ScmCollapsibleRevealProps) {
+  // Clip while height is changing, then release overflow once expanded. The
+  // exit variant must own the clip because AnimatePresence freezes its child.
+  const [isSettled, setIsSettled] = useState(open);
+  const variants: Variants = {
+    collapsed: {height: 0, opacity: 0, overflow: 'hidden'},
+    expanded: {
+      height: 'auto',
+      opacity: 1,
+      overflow: isSettled ? 'visible' : 'hidden',
+    },
+  };
+
   return (
     <AnimatePresence initial={false}>
       {open && (
         <motion.div
           key="content"
           id={id}
-          // Clip content before it enters and as it exits, but allow focus
-          // rings and menus to overflow whenever the content is present.
-          // AnimatePresence exits from its last rendered props, so overflow
-          // must stay in the animation targets rather than React state.
-          initial={{height: 0, opacity: 0, overflow: 'hidden'}}
-          animate={{height: 'auto', opacity: 1, overflow: 'visible'}}
-          exit={{height: 0, opacity: 0, overflow: 'hidden'}}
+          variants={variants}
+          initial="collapsed"
+          animate="expanded"
+          exit="collapsed"
           transition={{duration: 0.2, ease: 'easeOut'}}
+          onAnimationStart={definition => {
+            if (definition === 'collapsed') {
+              setIsSettled(false);
+            }
+          }}
+          onAnimationComplete={definition => {
+            if (definition === 'expanded') {
+              setIsSettled(true);
+            }
+          }}
           style={{width: '100%'}}
         >
           {children}

--- a/static/app/components/onboarding/scm/scmCollapsibleReveal.tsx
+++ b/static/app/components/onboarding/scm/scmCollapsibleReveal.tsx
@@ -22,15 +22,12 @@ export function ScmCollapsibleReveal({open, id, children}: ScmCollapsibleRevealP
         <motion.div
           key="content"
           id={id}
-          // Clip content while its height changes, then allow focus rings and
-          // menus to overflow once expanded. Keep overflow in the animation
-          // targets because AnimatePresence exits from its last rendered props.
+          // Clip content before it enters and as it exits, but allow focus
+          // rings and menus to overflow whenever the content is present.
+          // AnimatePresence exits from its last rendered props, so overflow
+          // must stay in the animation targets rather than React state.
           initial={{height: 0, opacity: 0, overflow: 'hidden'}}
-          animate={{
-            height: 'auto',
-            opacity: 1,
-            transitionEnd: {overflow: 'visible'},
-          }}
+          animate={{height: 'auto', opacity: 1, overflow: 'visible'}}
           exit={{height: 0, opacity: 0, overflow: 'hidden'}}
           transition={{duration: 0.2, ease: 'easeOut'}}
           style={{width: '100%'}}

--- a/static/app/components/onboarding/scm/scmCollapsibleReveal.tsx
+++ b/static/app/components/onboarding/scm/scmCollapsibleReveal.tsx
@@ -23,6 +23,8 @@ export function ScmCollapsibleReveal({open, id, children}: ScmCollapsibleRevealP
           key="content"
           id={id}
           initial={{height: 0, opacity: 0, overflow: 'hidden'}}
+          // Settle to overflow visible once open so focus rings at the edges
+          // and menus opening past the bounds are not clipped.
           animate={{
             height: 'auto',
             opacity: 1,

--- a/static/app/components/onboarding/scm/scmCollapsibleReveal.tsx
+++ b/static/app/components/onboarding/scm/scmCollapsibleReveal.tsx
@@ -1,4 +1,3 @@
-import {useRef, useState} from 'react';
 import {AnimatePresence, motion} from 'framer-motion';
 
 interface ScmCollapsibleRevealProps {
@@ -17,34 +16,24 @@ interface ScmCollapsibleRevealProps {
  * initial={false} renders the open state without animating on mount.
  */
 export function ScmCollapsibleReveal({open, id, children}: ScmCollapsibleRevealProps) {
-  // overflow:hidden is needed while the height tween runs so the content clips
-  // cleanly, but kept on it would also clip anything that extends past the
-  // settled bounds, e.g. a focus ring at the edge or an open select menu below.
-  // Switch to visible once open and settled, back to hidden whenever animating.
-  const [overflow, setOverflow] = useState<'hidden' | 'visible'>(
-    open ? 'visible' : 'hidden'
-  );
-  // On collapse, AnimatePresence keeps a frozen snapshot of the last open
-  // render, so a closure over `open` reads a stale `true` and never resets
-  // overflow. Read the live value through a ref so completion settles correctly.
-  const openRef = useRef(open);
-  openRef.current = open;
-
   return (
     <AnimatePresence initial={false}>
       {open && (
         <motion.div
           key="content"
           id={id}
-          initial={{height: 0, opacity: 0}}
-          animate={{height: 'auto', opacity: 1}}
-          exit={{height: 0, opacity: 0}}
-          transition={{duration: 0.2, ease: 'easeOut'}}
-          onAnimationStart={() => setOverflow('hidden')}
-          onAnimationComplete={() => {
-            setOverflow(openRef.current ? 'visible' : 'hidden');
+          // Clip content while its height changes, then allow focus rings and
+          // menus to overflow once expanded. Keep overflow in the animation
+          // targets because AnimatePresence exits from its last rendered props.
+          initial={{height: 0, opacity: 0, overflow: 'hidden'}}
+          animate={{
+            height: 'auto',
+            opacity: 1,
+            transitionEnd: {overflow: 'visible'},
           }}
-          style={{overflow, width: '100%'}}
+          exit={{height: 0, opacity: 0, overflow: 'hidden'}}
+          transition={{duration: 0.2, ease: 'easeOut'}}
+          style={{width: '100%'}}
         >
           {children}
         </motion.div>

--- a/static/app/components/onboarding/scm/scmCollapsibleSection.spec.tsx
+++ b/static/app/components/onboarding/scm/scmCollapsibleSection.spec.tsx
@@ -1,30 +1,8 @@
-import {MotionGlobalConfig} from 'framer-motion';
-
-import {
-  act,
-  render,
-  screen,
-  userEvent,
-  waitFor,
-  waitForElementToBeRemoved,
-} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {ScmCollapsibleSection} from './scmCollapsibleSection';
 
-function waitForAnimationToStart() {
-  return act(
-    () =>
-      new Promise<void>(resolve => {
-        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
-      })
-  );
-}
-
 describe('ScmCollapsibleSection', () => {
-  afterEach(() => {
-    MotionGlobalConfig.skipAnimations = true;
-  });
-
   it('renders content with visible overflow when expanded by default', () => {
     render(
       <ScmCollapsibleSection title="Section title">
@@ -48,33 +26,6 @@ describe('ScmCollapsibleSection', () => {
     );
 
     expect(screen.queryByText('Body content')).not.toBeInTheDocument();
-  });
-
-  it('clips content while expanding and collapsing', async () => {
-    MotionGlobalConfig.skipAnimations = false;
-    render(
-      <ScmCollapsibleSection title="Section title" defaultExpanded={false}>
-        <div>Body content</div>
-      </ScmCollapsibleSection>
-    );
-
-    const toggle = screen.getByRole('button', {name: 'Section title'});
-    await userEvent.click(toggle);
-    const contentId = toggle.getAttribute('aria-controls');
-    expect(contentId).not.toBeNull();
-    const content = document.getElementById(contentId!);
-    expect(content).not.toBeNull();
-
-    await waitForAnimationToStart();
-    expect(content).toHaveStyle({overflow: 'hidden'});
-
-    await waitFor(() => expect(content).toHaveStyle({overflow: 'visible'}));
-
-    await userEvent.click(toggle);
-    await waitForAnimationToStart();
-    expect(content).toBeInTheDocument();
-    expect(content).toHaveStyle({overflow: 'hidden'});
-    await waitForElementToBeRemoved(content);
   });
 
   it('toggles the content when the title is clicked', async () => {

--- a/static/app/components/onboarding/scm/scmCollapsibleSection.spec.tsx
+++ b/static/app/components/onboarding/scm/scmCollapsibleSection.spec.tsx
@@ -3,18 +3,14 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {ScmCollapsibleSection} from './scmCollapsibleSection';
 
 describe('ScmCollapsibleSection', () => {
-  it('renders content with visible overflow when expanded by default', () => {
+  it('renders the title and content expanded by default', () => {
     render(
       <ScmCollapsibleSection title="Section title">
         <div>Body content</div>
       </ScmCollapsibleSection>
     );
 
-    const toggle = screen.getByRole('button', {name: 'Section title'});
-    const contentId = toggle.getAttribute('aria-controls');
-
-    expect(contentId).not.toBeNull();
-    expect(document.getElementById(contentId!)).toHaveStyle({overflow: 'visible'});
+    expect(screen.getByRole('button', {name: 'Section title'})).toBeInTheDocument();
     expect(screen.getByText('Body content')).toBeInTheDocument();
   });
 

--- a/static/app/components/onboarding/scm/scmCollapsibleSection.spec.tsx
+++ b/static/app/components/onboarding/scm/scmCollapsibleSection.spec.tsx
@@ -14,6 +14,20 @@ describe('ScmCollapsibleSection', () => {
     expect(screen.getByText('Body content')).toBeInTheDocument();
   });
 
+  it('allows content to overflow when expanded by default', () => {
+    render(
+      <ScmCollapsibleSection title="Section title">
+        <div>Body content</div>
+      </ScmCollapsibleSection>
+    );
+
+    const toggle = screen.getByRole('button', {name: 'Section title'});
+    const contentId = toggle.getAttribute('aria-controls');
+
+    expect(contentId).not.toBeNull();
+    expect(document.getElementById(contentId!)).toHaveStyle({overflow: 'visible'});
+  });
+
   it('starts collapsed when defaultExpanded is false', () => {
     render(
       <ScmCollapsibleSection title="Section title" defaultExpanded={false}>

--- a/static/app/components/onboarding/scm/scmCollapsibleSection.spec.tsx
+++ b/static/app/components/onboarding/scm/scmCollapsibleSection.spec.tsx
@@ -1,8 +1,30 @@
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {MotionGlobalConfig} from 'framer-motion';
+
+import {
+  act,
+  render,
+  screen,
+  userEvent,
+  waitFor,
+  waitForElementToBeRemoved,
+} from 'sentry-test/reactTestingLibrary';
 
 import {ScmCollapsibleSection} from './scmCollapsibleSection';
 
+function waitForAnimationToStart() {
+  return act(
+    () =>
+      new Promise<void>(resolve => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+      })
+  );
+}
+
 describe('ScmCollapsibleSection', () => {
+  afterEach(() => {
+    MotionGlobalConfig.skipAnimations = true;
+  });
+
   it('renders the title and content expanded by default', () => {
     render(
       <ScmCollapsibleSection title="Section title">
@@ -36,6 +58,33 @@ describe('ScmCollapsibleSection', () => {
     );
 
     expect(screen.queryByText('Body content')).not.toBeInTheDocument();
+  });
+
+  it('clips content while expanding and collapsing', async () => {
+    MotionGlobalConfig.skipAnimations = false;
+    render(
+      <ScmCollapsibleSection title="Section title" defaultExpanded={false}>
+        <div>Body content</div>
+      </ScmCollapsibleSection>
+    );
+
+    const toggle = screen.getByRole('button', {name: 'Section title'});
+    await userEvent.click(toggle);
+    const contentId = toggle.getAttribute('aria-controls');
+    expect(contentId).not.toBeNull();
+    const content = document.getElementById(contentId!);
+    expect(content).not.toBeNull();
+
+    await waitForAnimationToStart();
+    expect(content).toHaveStyle({overflow: 'hidden'});
+
+    await waitFor(() => expect(content).toHaveStyle({overflow: 'visible'}));
+
+    await userEvent.click(toggle);
+    await waitForAnimationToStart();
+    expect(content).toBeInTheDocument();
+    expect(content).toHaveStyle({overflow: 'hidden'});
+    await waitForElementToBeRemoved(content);
   });
 
   it('toggles the content when the title is clicked', async () => {

--- a/static/app/components/onboarding/scm/scmCollapsibleSection.spec.tsx
+++ b/static/app/components/onboarding/scm/scmCollapsibleSection.spec.tsx
@@ -25,18 +25,7 @@ describe('ScmCollapsibleSection', () => {
     MotionGlobalConfig.skipAnimations = true;
   });
 
-  it('renders the title and content expanded by default', () => {
-    render(
-      <ScmCollapsibleSection title="Section title">
-        <div>Body content</div>
-      </ScmCollapsibleSection>
-    );
-
-    expect(screen.getByRole('button', {name: 'Section title'})).toBeInTheDocument();
-    expect(screen.getByText('Body content')).toBeInTheDocument();
-  });
-
-  it('allows content to overflow when expanded by default', () => {
+  it('renders content with visible overflow when expanded by default', () => {
     render(
       <ScmCollapsibleSection title="Section title">
         <div>Body content</div>
@@ -48,6 +37,7 @@ describe('ScmCollapsibleSection', () => {
 
     expect(contentId).not.toBeNull();
     expect(document.getElementById(contentId!)).toHaveStyle({overflow: 'visible'});
+    expect(screen.getByText('Body content')).toBeInTheDocument();
   });
 
   it('starts collapsed when defaultExpanded is false', () => {


### PR DESCRIPTION
## TLDR

SCM collapsible reveals now clip their content while the collapse tween runs, instead of letting it spill past the shrinking bounds. Fully expanded content can still overflow, so focus rings and open menus are not clipped.

## Details

`AnimatePresence` freezes the last render of an exiting node, so the previous approach of tracking overflow in React state could never reach the collapse tween: the frozen snapshot kept the settled `overflow: visible` while the height shrank. `ScmCollapsibleReveal` now hands overflow to Framer Motion entirely: `initial`, `animate`, and `exit` all carry `overflow: hidden`, and `transitionEnd` flips it to visible only once the opening tween settles.

Refs VDY-150
