### PR TITLE
fix(onboarding): Clip the SCM product section reveal

### DIFF
--- a/static/app/components/onboarding/scm/scmFeatureSelectionPanel.spec.tsx
+++ b/static/app/components/onboarding/scm/scmFeatureSelectionPanel.spec.tsx
@@ -1,6 +1,6 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
@@ -73,8 +73,8 @@ describe('ScmFeatureSelectionPanel', () => {
     expect(screen.queryByText('5,000 errors / mo')).not.toBeInTheDocument();
   });
 
-  it('prompts for a platform without showing cards in project creation', async () => {
-    render(
+  it('reveals the cards once a platform with products is chosen', async () => {
+    const {rerender} = render(
       <ScmFeatureSelectionPanel
         {...defaultProps({
           analyticsFlow: 'project-creation',
@@ -88,21 +88,6 @@ describe('ScmFeatureSelectionPanel', () => {
     expect(
       screen.getByText('Select a platform to configure products')
     ).toBeInTheDocument();
-    expect(screen.queryByRole('checkbox', {name: /Tracing/})).not.toBeInTheDocument();
-  });
-
-  it('reveals the cards once a platform with products is chosen', async () => {
-    const {rerender} = render(
-      <ScmFeatureSelectionPanel
-        {...defaultProps({
-          analyticsFlow: 'project-creation',
-          selectedPlatform: undefined,
-        })}
-      />,
-      {organization}
-    );
-
-    expect(await screen.findByText('Products')).toBeInTheDocument();
     expect(screen.queryByRole('checkbox', {name: /Tracing/})).not.toBeInTheDocument();
 
     rerender(
@@ -120,19 +105,32 @@ describe('ScmFeatureSelectionPanel', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('drops the section and its trailing divider for a platform with no products', () => {
-    render(
+  it('drops the section and its trailing divider for a platform with no products', async () => {
+    const {rerender} = render(
       <ScmFeatureSelectionPanel
         {...defaultProps({
           analyticsFlow: 'project-creation',
-          selectedPlatform: platformWithoutProducts,
+          selectedPlatform: pythonPlatform,
           trailing: <div>Trailing divider</div>,
         })}
       />,
       {organization}
     );
 
-    expect(screen.queryByText('Products')).not.toBeInTheDocument();
+    expect(await screen.findByText('Products')).toBeInTheDocument();
+    expect(screen.getByText('Trailing divider')).toBeInTheDocument();
+
+    rerender(
+      <ScmFeatureSelectionPanel
+        {...defaultProps({
+          analyticsFlow: 'project-creation',
+          selectedPlatform: platformWithoutProducts,
+          trailing: <div>Trailing divider</div>,
+        })}
+      />
+    );
+
+    await waitForElementToBeRemoved(() => screen.queryByText('Products'));
     expect(screen.queryByText('Trailing divider')).not.toBeInTheDocument();
   });
 });

--- a/static/app/components/onboarding/scm/scmFeatureSelectionPanel.spec.tsx
+++ b/static/app/components/onboarding/scm/scmFeatureSelectionPanel.spec.tsx
@@ -16,6 +16,17 @@ const pythonPlatform: OnboardingSelectedSDK = {
   category: 'popular',
 };
 
+// In neither platformProductAvailability nor PLATFORM_PRODUCT_INFO, so the
+// section has nothing to configure.
+const platformWithoutProducts: OnboardingSelectedSDK = {
+  key: 'other',
+  name: 'Other',
+  language: 'other',
+  type: 'language',
+  link: 'https://docs.sentry.io/platforms/',
+  category: 'popular',
+};
+
 function defaultProps(overrides: Partial<Record<string, unknown>> = {}) {
   return {
     analyticsFlow: 'onboarding' as const,
@@ -60,5 +71,68 @@ describe('ScmFeatureSelectionPanel', () => {
 
     expect(screen.queryByText(/unlimited volume for 14 days/)).not.toBeInTheDocument();
     expect(screen.queryByText('5,000 errors / mo')).not.toBeInTheDocument();
+  });
+
+  it('prompts for a platform without showing cards in project creation', async () => {
+    render(
+      <ScmFeatureSelectionPanel
+        {...defaultProps({
+          analyticsFlow: 'project-creation',
+          selectedPlatform: undefined,
+        })}
+      />,
+      {organization}
+    );
+
+    expect(await screen.findByText('Products')).toBeInTheDocument();
+    expect(
+      screen.getByText('Select a platform to configure products')
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('checkbox', {name: /Tracing/})).not.toBeInTheDocument();
+  });
+
+  it('reveals the cards once a platform with products is chosen', async () => {
+    const {rerender} = render(
+      <ScmFeatureSelectionPanel
+        {...defaultProps({
+          analyticsFlow: 'project-creation',
+          selectedPlatform: undefined,
+        })}
+      />,
+      {organization}
+    );
+
+    expect(await screen.findByText('Products')).toBeInTheDocument();
+    expect(screen.queryByRole('checkbox', {name: /Tracing/})).not.toBeInTheDocument();
+
+    rerender(
+      <ScmFeatureSelectionPanel
+        {...defaultProps({
+          analyticsFlow: 'project-creation',
+          selectedPlatform: pythonPlatform,
+        })}
+      />
+    );
+
+    expect(await screen.findByRole('checkbox', {name: /Tracing/})).toBeInTheDocument();
+    expect(
+      screen.queryByText('Select a platform to configure products')
+    ).not.toBeInTheDocument();
+  });
+
+  it('drops the section and its trailing divider for a platform with no products', () => {
+    render(
+      <ScmFeatureSelectionPanel
+        {...defaultProps({
+          analyticsFlow: 'project-creation',
+          selectedPlatform: platformWithoutProducts,
+          trailing: <div>Trailing divider</div>,
+        })}
+      />,
+      {organization}
+    );
+
+    expect(screen.queryByText('Products')).not.toBeInTheDocument();
+    expect(screen.queryByText('Trailing divider')).not.toBeInTheDocument();
   });
 });

--- a/static/app/components/onboarding/scm/scmFeatureSelectionPanel.tsx
+++ b/static/app/components/onboarding/scm/scmFeatureSelectionPanel.tsx
@@ -183,10 +183,11 @@ export function ScmFeatureSelectionPanel({
 
   return (
     <ScmCollapsibleReveal open={showSection}>
-      {/* The panel and the host's trailing divider are a single reveal child
-          now, so the gap the host's section Stack used to put between them
-          lives here. Only project creation passes `trailing`. */}
-      <Stack gap="2xl" width="100%">
+      {/* No gap: the section claims no spacing of its own, so everything that
+          tweens away on collapse is inside this box. Hosts own the rhythm —
+          the section above supplies the space before it, and `trailing`
+          carries the space around itself. */}
+      <Stack gap="0" width="100%">
         <MotionStack layout="position" width="100%">
           {/* gap="0" because the spacing above the cards has to tween with
               them: a flex gap would snap in at full size while the revealed

--- a/static/app/components/onboarding/scm/scmFeatureSelectionPanel.tsx
+++ b/static/app/components/onboarding/scm/scmFeatureSelectionPanel.tsx
@@ -1,8 +1,8 @@
-import {Fragment, type ReactNode, useCallback, useMemo} from 'react';
+import {type ReactNode, useCallback, useMemo} from 'react';
 import {motion} from 'framer-motion';
 
 import {Tag} from '@sentry/scraps/badge';
-import {Flex, Stack} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
@@ -19,6 +19,7 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 import {type ScmAnalyticsFlow, scmFlowVariantParams} from './scmAnalyticsFlow';
+import {ScmCollapsibleReveal} from './scmCollapsibleReveal';
 import {ScmFeatureInfoCards} from './scmFeatureInfoCards';
 import {ScmFeatureSelectionCards} from './scmFeatureSelectionCards';
 import {
@@ -40,9 +41,10 @@ interface ScmFeatureSelectionPanelProps {
   selectedFeatures: ProductSolution[] | undefined;
   selectedPlatform: OnboardingSelectedSDK | undefined;
   selectedRepository: Repository | undefined;
-  // Optional element rendered as a sibling after the panel content (e.g. a
-  // divider from the host). Dropped together with the panel when there is
-  // nothing to show, so the host never strands an orphaned divider.
+  // Optional element rendered after the panel content (e.g. a divider from the
+  // host). Lives inside the panel's reveal, so it is dropped — and tweens away
+  // — together with the panel when there is nothing to show, and the host never
+  // strands an orphaned divider.
   trailing?: ReactNode;
 }
 
@@ -168,81 +170,98 @@ export function ScmFeatureSelectionPanel({
     ]
   );
 
-  // Hide the whole section when a resolved platform has no configurable
+  const hasFeatureCards = featureMode !== 'none';
+
+  // Show the whole section unless a resolved platform has no configurable
   // products. Before a platform is chosen (no resolved key), keep it visible in
   // project creation for the select-a-platform prompt; onboarding hides both.
-  if (featureMode === 'none' && (isOnboarding || !!currentPlatformKey)) {
-    return null;
-  }
+  // Expressed as a flag rather than an early `return null` so the reveal below
+  // stays mounted and can tween the section in and out. AnimatePresence's
+  // `initial={false}` still renders the settled state on first mount, so a page
+  // load with a platform already resolved does not animate.
+  const showSection = hasFeatureCards || (!isOnboarding && !currentPlatformKey);
 
   return (
-    <Fragment>
-      <MotionStack layout="position" width="100%">
-        <Stack
-          gap={isOnboarding ? '2xl' : 'lg'}
-          paddingTop={isOnboarding ? 'xs' : undefined}
-        >
-          {isOnboarding ? (
-            <Flex
-              padding="lg"
-              background="secondary"
-              border="secondary"
-              radius="md"
-              gap="lg"
-            >
-              <IconBusiness size="lg" variant="accent" />
-              <Text size="md" density="comfortable">
-                {tct(
-                  'You’ve got [bold:unlimited volume for 14 days] to try out everything. After that, free plan volumes apply ⋅ No credit card required',
-                  {
-                    bold: (
-                      <Text as="span" bold variant="accent">
-                        {null}
-                      </Text>
-                    ),
-                  }
+    <ScmCollapsibleReveal open={showSection}>
+      {/* The panel and the host's trailing divider are a single reveal child
+          now, so the gap the host's section Stack used to put between them
+          lives here. Only project creation passes `trailing`. */}
+      <Stack gap="2xl" width="100%">
+        <MotionStack layout="position" width="100%">
+          {/* gap="0" because the spacing above the cards has to tween with
+              them: a flex gap would snap in at full size while the revealed
+              height is still 0, jumping the layout by that much. The cards own
+              it as padding inside the reveal instead. */}
+          <Stack gap="0" paddingTop={isOnboarding ? 'xs' : undefined}>
+            {isOnboarding ? (
+              <Flex
+                padding="lg"
+                background="secondary"
+                border="secondary"
+                radius="md"
+                gap="lg"
+              >
+                <IconBusiness size="lg" variant="accent" />
+                <Text size="md" density="comfortable">
+                  {tct(
+                    'You’ve got [bold:unlimited volume for 14 days] to try out everything. After that, free plan volumes apply ⋅ No credit card required',
+                    {
+                      bold: (
+                        <Text as="span" bold variant="accent">
+                          {null}
+                        </Text>
+                      ),
+                    }
+                  )}
+                </Text>
+              </Flex>
+            ) : null}
+
+            {isOnboarding ? null : (
+              <Flex justify="between" align="center" gap="md">
+                <Heading as="h4">{t('Products')}</Heading>
+                {currentPlatformKey ? null : (
+                  <Tag variant="muted" icon={<IconInfo />} style={{minWidth: 0}}>
+                    <Text ellipsis variant="inherit">
+                      {t('Select a platform to configure products')}
+                    </Text>
+                  </Tag>
                 )}
-              </Text>
-            </Flex>
-          ) : null}
+              </Flex>
+            )}
 
-          {isOnboarding ? null : (
-            <Flex justify="between" align="center" gap="md">
-              <Heading as="h4">{t('Products')}</Heading>
-              {currentPlatformKey ? null : (
-                <Tag variant="muted" icon={<IconInfo />} style={{minWidth: 0}}>
-                  <Text ellipsis variant="inherit">
-                    {t('Select a platform to configure products')}
-                  </Text>
-                </Tag>
-              )}
-            </Flex>
-          )}
-
-          {featureMode === 'toggleable' ? (
-            <ScmFeatureSelectionCards
-              availableFeatures={availableFeatures}
-              selectedFeatures={currentFeatures}
-              disabledProducts={disabledProducts}
-              onToggleFeature={handleToggleFeature}
-              featureMeta={featureMeta}
-              isVolumeLoading={isFeatureMetaLoading}
-              isOnboarding={isOnboarding}
-            />
-          ) : featureMode === 'informational' ? (
-            <ScmFeatureInfoCards
-              availableFeatures={availableFeatures}
-              disabledProducts={disabledProducts}
-              featureMeta={featureMeta}
-              platformName={currentPlatformName}
-              isVolumeLoading={isFeatureMetaLoading}
-              isOnboarding={isOnboarding}
-            />
-          ) : null}
-        </Stack>
-      </MotionStack>
-      {trailing}
-    </Fragment>
+            {/* The cards mount at their full height, so without a clipped
+                height tween they paint over the sections below while
+                framer-motion is still animating those into place. */}
+            <ScmCollapsibleReveal open={hasFeatureCards}>
+              <Container paddingTop={isOnboarding ? '2xl' : 'lg'}>
+                {featureMode === 'toggleable' ? (
+                  <ScmFeatureSelectionCards
+                    availableFeatures={availableFeatures}
+                    selectedFeatures={currentFeatures}
+                    disabledProducts={disabledProducts}
+                    onToggleFeature={handleToggleFeature}
+                    featureMeta={featureMeta}
+                    isVolumeLoading={isFeatureMetaLoading}
+                    isOnboarding={isOnboarding}
+                  />
+                ) : featureMode === 'informational' ? (
+                  <ScmFeatureInfoCards
+                    availableFeatures={availableFeatures}
+                    disabledProducts={disabledProducts}
+                    featureMeta={featureMeta}
+                    platformName={currentPlatformName}
+                    isVolumeLoading={isFeatureMetaLoading}
+                    isOnboarding={isOnboarding}
+                  />
+                ) : null}
+              </Container>
+            </ScmCollapsibleReveal>
+          </Stack>
+        </MotionStack>
+        {trailing}
+      </Stack>
+    </ScmCollapsibleReveal>
   );
 }
 

--- a/static/app/components/onboarding/scm/scmFeatureSelectionPanel.tsx
+++ b/static/app/components/onboarding/scm/scmFeatureSelectionPanel.tsx
@@ -41,10 +41,7 @@ interface ScmFeatureSelectionPanelProps {
   selectedFeatures: ProductSolution[] | undefined;
   selectedPlatform: OnboardingSelectedSDK | undefined;
   selectedRepository: Repository | undefined;
-  // Optional element rendered after the panel content (e.g. a divider from the
-  // host). Lives inside the panel's reveal, so it is dropped — and tweens away
-  // — together with the panel when there is nothing to show, and the host never
-  // strands an orphaned divider.
+  // Kept inside the reveal so hosts do not strand a divider when the panel closes.
   trailing?: ReactNode;
 }
 
@@ -172,27 +169,42 @@ export function ScmFeatureSelectionPanel({
 
   const hasFeatureCards = featureMode !== 'none';
 
-  // Show the whole section unless a resolved platform has no configurable
-  // products. Before a platform is chosen (no resolved key), keep it visible in
-  // project creation for the select-a-platform prompt; onboarding hides both.
-  // Expressed as a flag rather than an early `return null` so the reveal below
-  // stays mounted and can tween the section in and out. AnimatePresence's
-  // `initial={false}` still renders the settled state on first mount, so a page
-  // load with a platform already resolved does not animate.
+  let featureCards: ReactNode = null;
+  if (featureMode === 'toggleable') {
+    featureCards = (
+      <ScmFeatureSelectionCards
+        availableFeatures={availableFeatures}
+        selectedFeatures={currentFeatures}
+        disabledProducts={disabledProducts}
+        onToggleFeature={handleToggleFeature}
+        featureMeta={featureMeta}
+        isVolumeLoading={isFeatureMetaLoading}
+        isOnboarding={isOnboarding}
+      />
+    );
+  } else if (featureMode === 'informational') {
+    featureCards = (
+      <ScmFeatureInfoCards
+        availableFeatures={availableFeatures}
+        disabledProducts={disabledProducts}
+        featureMeta={featureMeta}
+        platformName={currentPlatformName}
+        isVolumeLoading={isFeatureMetaLoading}
+        isOnboarding={isOnboarding}
+      />
+    );
+  }
+
+  // Project creation keeps the section open for the select-a-platform prompt.
+  // Otherwise, the reveal follows the availability of feature cards.
   const showSection = hasFeatureCards || (!isOnboarding && !currentPlatformKey);
 
   return (
     <ScmCollapsibleReveal open={showSection}>
-      {/* No gap: the section claims no spacing of its own, so everything that
-          tweens away on collapse is inside this box. Hosts own the rhythm —
-          the section above supplies the space before it, and `trailing`
-          carries the space around itself. */}
+      {/* Keep spacing inside the reveal so it collapses with the content. */}
       <Stack gap="0" width="100%">
         <MotionStack layout="position" width="100%">
-          {/* gap="0" because the spacing above the cards has to tween with
-              them: a flex gap would snap in at full size while the revealed
-              height is still 0, jumping the layout by that much. The cards own
-              it as padding inside the reveal instead. */}
+          {/* Padding, unlike a flex gap, is clipped during the card reveal. */}
           <Stack gap="0" paddingTop={isOnboarding ? 'xs' : undefined}>
             {isOnboarding ? (
               <Flex
@@ -231,31 +243,9 @@ export function ScmFeatureSelectionPanel({
               </Flex>
             )}
 
-            {/* The cards mount at their full height, so without a clipped
-                height tween they paint over the sections below while
-                framer-motion is still animating those into place. */}
             <ScmCollapsibleReveal open={hasFeatureCards}>
               <Container paddingTop={isOnboarding ? '2xl' : 'lg'}>
-                {featureMode === 'toggleable' ? (
-                  <ScmFeatureSelectionCards
-                    availableFeatures={availableFeatures}
-                    selectedFeatures={currentFeatures}
-                    disabledProducts={disabledProducts}
-                    onToggleFeature={handleToggleFeature}
-                    featureMeta={featureMeta}
-                    isVolumeLoading={isFeatureMetaLoading}
-                    isOnboarding={isOnboarding}
-                  />
-                ) : featureMode === 'informational' ? (
-                  <ScmFeatureInfoCards
-                    availableFeatures={availableFeatures}
-                    disabledProducts={disabledProducts}
-                    featureMeta={featureMeta}
-                    platformName={currentPlatformName}
-                    isVolumeLoading={isFeatureMetaLoading}
-                    isOnboarding={isOnboarding}
-                  />
-                ) : null}
+                {featureCards}
               </Container>
             </ScmCollapsibleReveal>
           </Stack>

--- a/static/app/components/onboarding/scm/scmFeatureSelectionPanel.tsx
+++ b/static/app/components/onboarding/scm/scmFeatureSelectionPanel.tsx
@@ -196,7 +196,6 @@ export function ScmFeatureSelectionPanel({
   }
 
   // Project creation keeps the section open for the select-a-platform prompt.
-  // Otherwise, the reveal follows the availability of feature cards.
   const showSection = hasFeatureCards || (!isOnboarding && !currentPlatformKey);
 
   return (

--- a/static/app/components/onboarding/scm/scmFeatureSelectionPanel.tsx
+++ b/static/app/components/onboarding/scm/scmFeatureSelectionPanel.tsx
@@ -49,10 +49,12 @@ interface ScmFeatureSelectionPanelProps {
  * Feature selection for the resolved platform, rendered as a sibling of
  * `ScmPlatformFeaturesCore`. Toggleable cards for platforms whose products are
  * user-configurable, informational cards for wizard-driven platforms, and
- * nothing when the platform has no product info. The resolved platform is the
+ * nothing when a resolved platform has no product info. The resolved platform is the
  * host's explicit selection or, before that commits, the first auto-detected
  * platform — re-derived here from the same (deduped) detection query Core uses.
- * Owns the feature-toggled analytic; renders nothing for an unresolved platform.
+ * Owns the feature-toggled analytic. In project creation, an unresolved platform
+ * keeps the section visible with the select-a-platform prompt; onboarding hides it
+ * until resolution.
  */
 export function ScmFeatureSelectionPanel({
   analyticsFlow,
@@ -200,7 +202,6 @@ export function ScmFeatureSelectionPanel({
 
   return (
     <ScmCollapsibleReveal open={showSection}>
-      {/* Keep spacing inside the reveal so it collapses with the content. */}
       <Stack gap="0" width="100%">
         <MotionStack layout="position" width="100%">
           {/* Padding, unlike a flex gap, is clipped during the card reveal. */}

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -244,12 +244,7 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
       <Access access={canUserCreateProject ? ['project:read'] : ['project:admin']}>
         <Stack padding="3xl" gap="2xl" align="center">
           <LayoutGroup>
-            {/* Section rhythm is each section's own paddingBottom rather than a
-              flex gap on this Stack. ScmFeatureSelectionPanel collapses to
-              nothing when its platform has no products, and a flex gap sits
-              outside the box it tweens: it would survive the whole collapse and
-              then vanish in one step on unmount. As padding it lives inside the
-              animated box and tweens away with the content. */}
+            {/* Keep spacing inside each animated section so it collapses with it. */}
             <MotionStack
               flexGrow={1}
               gap="0"
@@ -316,9 +311,6 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
                 <Separator orientation="horizontal" />
               </MotionContainer>
 
-              {/* The divider below the section is passed in so it collapses
-                with it. It carries the surrounding rhythm as padding for the
-                same reason the Stack above uses none. */}
               <ScmFeatureSelectionPanel
                 analyticsFlow="project-creation"
                 selectedRepository={selectedRepository}
@@ -347,7 +339,6 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
                 <Separator orientation="horizontal" />
               </MotionContainer>
 
-              {/* Last section, so no trailing padding. */}
               <MotionContainer layout="position">
                 <ScmAlertFrequencySection
                   analyticsFlow="project-creation"

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -3,7 +3,7 @@ import {LayoutGroup, motion} from 'framer-motion';
 
 import {Tag} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
-import {Flex, Stack} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Separator} from '@sentry/scraps/separator';
 import {Heading, Text} from '@sentry/scraps/text';
@@ -244,9 +244,15 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
       <Access access={canUserCreateProject ? ['project:read'] : ['project:admin']}>
         <Stack padding="3xl" gap="2xl" align="center">
           <LayoutGroup>
+            {/* Section rhythm is each section's own paddingBottom rather than a
+              flex gap on this Stack. ScmFeatureSelectionPanel collapses to
+              nothing when its platform has no products, and a flex gap sits
+              outside the box it tweens: it would survive the whole collapse and
+              then vanish in one step on unmount. As padding it lives inside the
+              animated box and tweens away with the content. */}
             <MotionStack
               flexGrow={1}
-              gap="2xl"
+              gap="0"
               padding="2xl"
               maxWidth={CREATE_PROJECT_MAX_WIDTH}
               width="100%"
@@ -256,7 +262,7 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
             >
               <Layout.Title>{t('Create a new project')}</Layout.Title>
 
-              <MotionStack gap="md" layout="position">
+              <MotionStack gap="md" paddingBottom="2xl" layout="position">
                 <Heading as="h1">{t('Create a project')}</Heading>
                 <Text variant="secondary" density="comfortable">
                   {tct(
@@ -270,7 +276,7 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
                 </Text>
               </MotionStack>
 
-              <MotionStack gap="md" layout="position">
+              <MotionStack gap="md" paddingBottom="2xl" layout="position">
                 <Flex justify="between" align="center">
                   <Stack gap="sm">
                     <Heading as="h4">{t('Repository')}</Heading>
@@ -295,7 +301,7 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
                 />
               </MotionStack>
 
-              <motion.div layout="position">
+              <MotionContainer layout="position" paddingBottom="2xl">
                 <ScmPlatformFeaturesCore
                   analyticsFlow="project-creation"
                   selectedRepository={selectedRepository}
@@ -304,12 +310,15 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
                   onFeaturesChange={handleFeaturesChange}
                   onClearProjectDetailsForm={handleClearProjectDetailsForm}
                 />
-              </motion.div>
+              </MotionContainer>
 
-              <motion.div layout="position">
+              <MotionContainer layout="position" paddingBottom="2xl">
                 <Separator orientation="horizontal" />
-              </motion.div>
+              </MotionContainer>
 
+              {/* The divider below the section is passed in so it collapses
+                with it. It carries the surrounding rhythm as padding for the
+                same reason the Stack above uses none. */}
               <ScmFeatureSelectionPanel
                 analyticsFlow="project-creation"
                 selectedRepository={selectedRepository}
@@ -317,13 +326,13 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
                 selectedFeatures={selectedFeatures}
                 onFeaturesChange={handleFeaturesChange}
                 trailing={
-                  <motion.div layout="position">
+                  <MotionContainer layout="position" paddingTop="2xl" paddingBottom="2xl">
                     <Separator orientation="horizontal" />
-                  </motion.div>
+                  </MotionContainer>
                 }
               />
 
-              <motion.div layout="position">
+              <MotionContainer layout="position" paddingBottom="2xl">
                 <ScmProjectDetailsCore
                   projectName={form.projectName}
                   onProjectNameChange={form.onProjectNameChange}
@@ -332,20 +341,21 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
                   onTeamChange={form.onTeamChange}
                   isOrgMemberWithNoAccess={form.isOrgMemberWithNoAccess}
                 />
-              </motion.div>
+              </MotionContainer>
 
-              <motion.div layout="position">
+              <MotionContainer layout="position" paddingBottom="2xl">
                 <Separator orientation="horizontal" />
-              </motion.div>
+              </MotionContainer>
 
-              <motion.div layout="position">
+              {/* Last section, so no trailing padding. */}
+              <MotionContainer layout="position">
                 <ScmAlertFrequencySection
                   analyticsFlow="project-creation"
                   alertRuleConfig={form.alertRuleConfig}
                   notificationProps={form.notificationProps}
                   onAlertChange={form.onAlertChange}
                 />
-              </motion.div>
+              </MotionContainer>
             </MotionStack>
             {/* Page-level CTA: disabled until a platform and project details are
               ready. */}
@@ -378,3 +388,4 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
 }
 
 const MotionStack = motion.create(Stack);
+const MotionContainer = motion.create(Container);


### PR DESCRIPTION
## TLDR

SCM product options now reveal and collapse without painting over later sections or snapping away the final 24px of spacing.

## Details

`ScmFeatureSelectionPanel` previously mounted product cards at their final height while `layout="position"` siblings were still moving. It now keeps both transitions behind `ScmCollapsibleReveal`:

- The outer reveal animates the whole section, including its trailing divider.
- The inner reveal handles project creation, where the Products heading stays mounted and only the cards change.

`ScmCreateProject` also moves section spacing from the parent flex gap into each animated section, so that spacing collapses with the content. The onboarding host keeps its existing spacing behavior.

Fixes VDY-150
