### PR TITLE
feat(admin): Improve admin search dropdowns

### DIFF
--- a/static/app/utils/api/knownGetsentryApiUrls.ts
+++ b/static/app/utils/api/knownGetsentryApiUrls.ts
@@ -7,6 +7,7 @@
 
 export type KnownGetsentryApiUrls =
   | '/_admin/cells/$region/admin-invoices/$invoiceId/'
+  | '/_admin/cells/$region/customers/'
   | '/_admin/cells/$region/invoice-comparison/'
   | '/audit-logs/'
   | '/beacons/'

--- a/static/gsAdmin/components/adminSearchCombobox.spec.tsx
+++ b/static/gsAdmin/components/adminSearchCombobox.spec.tsx
@@ -1,18 +1,18 @@
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import {DebounceSearch} from 'admin/components/debounceSearch';
+import {AdminSearchCombobox} from 'admin/components/adminSearchCombobox';
 
 type Result = {
   id: string;
   name: string;
 };
 
-describe('DebounceSearch', () => {
+describe('AdminSearchCombobox', () => {
   it('queries and selects a result', async () => {
     const result: Result = {id: '1', name: 'Alice'};
     const onSelectResult = jest.fn<void, [Result]>();
     render(
-      <DebounceSearch
+      <AdminSearchCombobox
         label="Users"
         placeholder="Query users"
         getResultKey={item => item.id}

--- a/static/gsAdmin/components/adminSearchCombobox.tsx
+++ b/static/gsAdmin/components/adminSearchCombobox.tsx
@@ -13,7 +13,7 @@ import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 
 const SEARCH_DEBOUNCE_MS = 300;
 
-type SearchOption<TResult> = SelectValue<string> &
+type AdminSearchComboboxOption<TResult> = SelectValue<string> &
   ({kind: 'query'; query: string} | {kind: 'result'; result: TResult});
 
 function getBestMatchScore(searchTerms: readonly string[], query: string) {
@@ -30,7 +30,7 @@ function getBestMatchScore(searchTerms: readonly string[], query: string) {
   return bestScore;
 }
 
-type Props<TQueryData, TResult, TQueryKey extends QueryKey> = {
+type AdminSearchComboboxProps<TQueryData, TResult, TQueryKey extends QueryKey> = {
   getResultKey: (result: TResult) => string;
   getResultSearchTerms: (result: TResult) => readonly string[];
   label: string;
@@ -44,7 +44,7 @@ type Props<TQueryData, TResult, TQueryKey extends QueryKey> = {
   placeholder?: string;
 };
 
-export function DebounceSearch<TQueryData, TResult, TQueryKey extends QueryKey>({
+export function AdminSearchCombobox<TQueryData, TResult, TQueryKey extends QueryKey>({
   getResultKey,
   getResultSearchTerms,
   isExactMatch,
@@ -54,24 +54,22 @@ export function DebounceSearch<TQueryData, TResult, TQueryKey extends QueryKey>(
   placeholder = label,
   queryOptions,
   renderResult,
-}: Props<TQueryData, TResult, TQueryKey>) {
+}: AdminSearchComboboxProps<TQueryData, TResult, TQueryKey>) {
   const inputId = useId();
   const theme = useTheme();
   const [inputValue, setInputValue] = useState('');
   const normalizedInput = inputValue.trim();
+  const hasInput = normalizedInput.length > 0;
   const debouncedQuery = useDebouncedValue(normalizedInput, SEARCH_DEBOUNCE_MS);
 
   const options = queryOptions(debouncedQuery);
   const query = useQuery({
     ...options,
-    enabled:
-      normalizedInput.length > 0 &&
-      debouncedQuery.length > 0 &&
-      options.enabled !== false,
+    enabled: hasInput && debouncedQuery.length > 0 && options.enabled !== false,
   });
 
   const hasSettledInput = normalizedInput === debouncedQuery;
-  const resultOptions: Array<SearchOption<TResult>> = hasSettledInput
+  const resultOptions: Array<AdminSearchComboboxOption<TResult>> = hasSettledInput
     ? (query.data ?? [])
         .map(result => {
           const searchTerms = getResultSearchTerms(result);
@@ -93,30 +91,32 @@ export function DebounceSearch<TQueryData, TResult, TQueryKey extends QueryKey>(
           textValue: searchTerms.join(' '),
         }))
     : [];
-  const selectOptions = onSearch
-    ? [
-        {
-          kind: 'query',
-          query: normalizedInput,
-          value: `query:${normalizedInput}`,
-          label: `Search ${label.toLowerCase()} for "${normalizedInput}"`,
-        } satisfies SearchOption<TResult>,
-        ...resultOptions,
-      ]
-    : resultOptions;
-  const isLoading = normalizedInput.length > 0 && (!hasSettledInput || query.isFetching);
+  const selectOptions =
+    onSearch && hasInput
+      ? [
+          {
+            kind: 'query',
+            query: normalizedInput,
+            value: `query:${normalizedInput}`,
+            label: `Search ${label.toLowerCase()} for "${normalizedInput}"`,
+          } satisfies AdminSearchComboboxOption<TResult>,
+          ...resultOptions,
+        ]
+      : resultOptions;
+  const isLoading = hasInput && (!hasSettledInput || query.isFetching);
 
   return (
     <Stack gap="sm">
       <Text as="label" htmlFor={inputId} bold>
         {label}
       </Text>
-      <Select<SearchOption<TResult>>
+      <Select<AdminSearchComboboxOption<TResult>>
         inputId={inputId}
         inputValue={inputValue}
         isLoading={isLoading}
         isSearchable
-        openMenuOnClick={false}
+        openMenuOnClick={hasInput}
+        openMenuOnFocus={hasInput}
         options={selectOptions}
         placeholder={placeholder}
         styles={{

--- a/static/gsAdmin/components/debounceSearch.spec.tsx
+++ b/static/gsAdmin/components/debounceSearch.spec.tsx
@@ -1,0 +1,38 @@
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {DebounceSearch} from 'admin/components/debounceSearch';
+
+type Result = {
+  id: string;
+  name: string;
+};
+
+describe('DebounceSearch', () => {
+  it('queries and selects a result', async () => {
+    const result: Result = {id: '1', name: 'Alice'};
+    const onSelectResult = jest.fn<void, [Result]>();
+    render(
+      <DebounceSearch
+        label="Users"
+        placeholder="Query users"
+        getResultKey={item => item.id}
+        getResultSearchTerms={item => [item.name]}
+        onSelectResult={onSelectResult}
+        queryOptions={query => ({
+          queryKey: ['admin-search-test', query],
+          queryFn: () => Promise.resolve([result]),
+          staleTime: Infinity,
+        })}
+        renderResult={item => item.name}
+      />
+    );
+    const user = userEvent.setup();
+    const input = screen.getByRole('textbox', {name: 'Users'});
+
+    await user.type(input, 'ali');
+    expect(await screen.findByText('Alice')).toBeInTheDocument();
+
+    await user.click(screen.getByText('Alice'));
+    expect(onSelectResult).toHaveBeenCalledWith(result);
+  });
+});

--- a/static/gsAdmin/components/debounceSearch.tsx
+++ b/static/gsAdmin/components/debounceSearch.tsx
@@ -1,179 +1,164 @@
-import type {ReactElement} from 'react';
-import {useCallback, useEffect, useRef, useState} from 'react';
-import styled from '@emotion/styled';
-import debounce from 'lodash/debounce';
+import type {ReactNode} from 'react';
+import {useId, useState} from 'react';
+import {useTheme} from '@emotion/react';
+import type {QueryKey, UseQueryOptions} from '@tanstack/react-query';
+import {useQuery} from '@tanstack/react-query';
 
-import {Container} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Select, type SelectValue} from '@sentry/scraps/select';
+import {Text} from '@sentry/scraps/text';
 
-import {LoadingIndicator} from 'sentry/components/loadingIndicator';
-import {SearchBar} from 'sentry/components/searchBar';
-import {useApi} from 'sentry/utils/useApi';
-import {useKeyPress} from 'sentry/utils/useKeyPress';
+import {fzf} from 'sentry/utils/search/fzf';
+import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 
-type Props = {
-  onSelectResult: (value: string) => void;
-  path: string;
-  placeholder: string;
-  suggestionContent: (suggestion: any) => ReactElement;
-  createSuggestionPath?: (suggestion: any) => string;
-  host?: string;
-  onSearch?: (value: string) => void;
-  queryParam?: string;
-};
+const SEARCH_DEBOUNCE_MS = 300;
 
-export function DebounceSearch({
-  createSuggestionPath,
-  onSearch,
-  onSelectResult,
-  host,
-  path,
-  placeholder,
-  queryParam = '',
-  suggestionContent,
-}: Props) {
-  const [error, setError] = useState('');
-  const [loading, setLoading] = useState(false);
-  const [query, setQuery] = useState('');
-  const [queryResults, setQueryResults] = useState([]);
-  const [showResults, setShowResults] = useState(false);
-  const [node, setNode] = useState<HTMLDivElement | null>();
-  const setKeyHandlers = useCallback((nodeRef: HTMLDivElement | null) => {
-    setNode(nodeRef);
-  }, []);
-  const downPress = useKeyPress('ArrowDown', node);
-  const upPress = useKeyPress('ArrowUp', node);
-  const enterPress = useKeyPress('Enter', node);
-  const escapePress = useKeyPress('Escape', node);
+type SearchOption<TResult> = SelectValue<string> &
+  ({kind: 'query'; query: string} | {kind: 'result'; result: TResult});
 
-  const [cursor, setCursor] = useState(0);
+function getBestMatchScore(searchTerms: readonly string[], query: string) {
+  const normalizedQuery = query.toLowerCase();
+  let bestScore = Number.NEGATIVE_INFINITY;
 
-  const api = useApi();
-
-  const debouncedSearch = useRef(
-    debounce(async (searchHost, searchPath, value) => {
-      // Avoid slow-fetch race conditions
-      api.clear();
-      setError('');
-      setQueryResults([]);
-
-      if (value) {
-        try {
-          const queryParams = {
-            query: [queryParam, value].filter(Boolean).join(':'),
-            per_page: 10,
-          };
-          const results = await api.requestPromise(searchPath, {
-            method: 'GET',
-            host: searchHost,
-            data: queryParams,
-          });
-          setQueryResults(results);
-        } catch (err) {
-          setError((err as Error).message);
-        }
-      }
-      setLoading(false);
-      value ? setShowResults(true) : setShowResults(false);
-    }, 300)
-  ).current;
-
-  const onChange = useCallback(
-    (value: string) => {
-      value ? setLoading(true) : setLoading(false);
-      value ? setShowResults(true) : setShowResults(false);
-      setQuery(value);
-      debouncedSearch(host, path, value);
-    },
-    [host, path, debouncedSearch]
-  );
-
-  useEffect(() => {
-    if (queryResults.length && downPress) {
-      setCursor(prevState =>
-        prevState < queryResults.length ? prevState + 1 : prevState
-      );
+  for (const searchTerm of searchTerms) {
+    const match = fzf(searchTerm, normalizedQuery, false);
+    if (match.end !== -1) {
+      bestScore = Math.max(bestScore, match.score);
     }
-  }, [downPress, queryResults.length]);
+  }
 
-  useEffect(() => {
-    if (queryResults.length && upPress) {
-      setCursor(prevState => (prevState > 0 ? prevState - 1 : prevState));
-    }
-  }, [upPress, queryResults.length]);
-
-  useEffect(() => {
-    if (enterPress && cursor === 0) {
-      if (onSearch) {
-        onSearch(query);
-      } else {
-        onChange(query);
-      }
-    } else if (enterPress && cursor <= queryResults.length) {
-      const item = queryResults[cursor - 1]!;
-      onSelectResult(item);
-    }
-  }, [cursor, enterPress, onChange, onSearch, onSelectResult, query, queryResults]);
-
-  useEffect(() => {
-    api.clear();
-    setCursor(0);
-    setError('');
-    setLoading(false);
-    setQueryResults([]);
-    setShowResults(false);
-  }, [escapePress, debouncedSearch, api, host, path]);
-
-  const renderSuggestion = (item: any, idx: number) => {
-    return (
-      <a
-        target="_blank"
-        href={createSuggestionPath?.(item)}
-        rel="noreferrer"
-        key={item.id}
-      >
-        <SuggestionCard highlight={cursor === idx + 1}>
-          {suggestionContent(item)}
-        </SuggestionCard>
-      </a>
-    );
-  };
-
-  return (
-    <div>
-      <div ref={setKeyHandlers}>
-        <SearchBar
-          placeholder={placeholder}
-          onChange={onChange}
-          style={error ? {border: '1px solid red'} : {}}
-        />
-      </div>
-      <Container marginBottom="xl">
-        {loading && <LoadingIndicator />}
-        {!loading && showResults && queryResults.map(renderSuggestion)}
-        {!loading && showResults && !queryResults.length && <Card>No results found</Card>}
-      </Container>
-      {error && <Error>{error}</Error>}
-    </div>
-  );
+  return bestScore;
 }
 
-const Card = styled('div')<{highlight?: boolean}>`
-  background: ${p =>
-    p.highlight ? p.theme.colors.gray100 : p.theme.tokens.background.primary};
-  color: ${p =>
-    p.highlight
-      ? p.theme.tokens.interactive.link.accent.active
-      : p.theme.tokens.content.primary};
-  box-shadow: ${p => p.theme.shadow.medium};
-  padding: ${p => p.theme.space.xl};
-`;
-const Error = styled('div')`
-  color: red;
-`;
-const SuggestionCard = styled(Card)`
-  &:hover {
-    color: ${p => p.theme.tokens.interactive.link.accent.active};
-    background: ${p => p.theme.colors.gray100};
-    cursor: pointer;
-  }
-`;
+type Props<TQueryData, TResult, TQueryKey extends QueryKey> = {
+  getResultKey: (result: TResult) => string;
+  getResultSearchTerms: (result: TResult) => readonly string[];
+  label: string;
+  onSelectResult: (result: TResult) => void;
+  queryOptions: (
+    query: string
+  ) => UseQueryOptions<TQueryData, Error, readonly TResult[], TQueryKey>;
+  renderResult: (result: TResult) => ReactNode;
+  isExactMatch?: (result: TResult, query: string) => boolean;
+  onSearch?: (query: string) => void;
+  placeholder?: string;
+};
+
+export function DebounceSearch<TQueryData, TResult, TQueryKey extends QueryKey>({
+  getResultKey,
+  getResultSearchTerms,
+  isExactMatch,
+  label,
+  onSearch,
+  onSelectResult,
+  placeholder = label,
+  queryOptions,
+  renderResult,
+}: Props<TQueryData, TResult, TQueryKey>) {
+  const inputId = useId();
+  const theme = useTheme();
+  const [inputValue, setInputValue] = useState('');
+  const normalizedInput = inputValue.trim();
+  const debouncedQuery = useDebouncedValue(normalizedInput, SEARCH_DEBOUNCE_MS);
+
+  const options = queryOptions(debouncedQuery);
+  const query = useQuery({
+    ...options,
+    enabled:
+      normalizedInput.length > 0 &&
+      debouncedQuery.length > 0 &&
+      options.enabled !== false,
+  });
+
+  const hasSettledInput = normalizedInput === debouncedQuery;
+  const resultOptions: Array<SearchOption<TResult>> = hasSettledInput
+    ? (query.data ?? [])
+        .map(result => {
+          const searchTerms = getResultSearchTerms(result);
+          return {
+            isExactMatch: isExactMatch?.(result, debouncedQuery) ?? false,
+            result,
+            score: getBestMatchScore(searchTerms, debouncedQuery),
+            searchTerms,
+          };
+        })
+        .toSorted(
+          (a, b) => Number(b.isExactMatch) - Number(a.isExactMatch) || b.score - a.score
+        )
+        .map(({result, searchTerms}) => ({
+          kind: 'result',
+          result,
+          value: `result:${getResultKey(result)}`,
+          label: renderResult(result),
+          textValue: searchTerms.join(' '),
+        }))
+    : [];
+  const selectOptions = onSearch
+    ? [
+        {
+          kind: 'query',
+          query: normalizedInput,
+          value: `query:${normalizedInput}`,
+          label: `Search ${label.toLowerCase()} for "${normalizedInput}"`,
+        } satisfies SearchOption<TResult>,
+        ...resultOptions,
+      ]
+    : resultOptions;
+  const isLoading = normalizedInput.length > 0 && (!hasSettledInput || query.isFetching);
+
+  return (
+    <Stack gap="sm">
+      <Text as="label" htmlFor={inputId} bold>
+        {label}
+      </Text>
+      <Select<SearchOption<TResult>>
+        inputId={inputId}
+        inputValue={inputValue}
+        isLoading={isLoading}
+        isSearchable
+        openMenuOnClick={false}
+        options={selectOptions}
+        placeholder={placeholder}
+        styles={{
+          control: provided => ({
+            ...provided,
+            backgroundColor: theme.tokens.background.primary,
+          }),
+        }}
+        value={null}
+        components={{
+          DropdownIndicator: null,
+          LoadingMessage: () => (
+            <Flex align="center" justify="center" padding="md">
+              <Text size="md" variant="muted">
+                Loading results…
+              </Text>
+            </Flex>
+          ),
+        }}
+        filterOption={null}
+        noOptionsMessage={() =>
+          query.isError ? 'Unable to load results' : 'No results found'
+        }
+        onInputChange={(value, action) => {
+          if (action.action !== 'input-change') {
+            return;
+          }
+          setInputValue(value);
+        }}
+        onChange={option => {
+          if (option.kind === 'query') {
+            onSearch?.(option.query);
+          } else {
+            onSelectResult(option.result);
+          }
+        }}
+      />
+      {hasSettledInput && query.error && (
+        <Text as="div" role="alert" size="sm" variant="danger">
+          {query.error.message}
+        </Text>
+      )}
+    </Stack>
+  );
+}

--- a/static/gsAdmin/views/home.tsx
+++ b/static/gsAdmin/views/home.tsx
@@ -1,18 +1,95 @@
 import {useState} from 'react';
 import styled from '@emotion/styled';
+import {skipToken} from '@tanstack/react-query';
 
+import {UserAvatar} from '@sentry/scraps/avatar';
+import {Badge} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
-import {Flex, Container} from '@sentry/scraps/layout';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
+import {Text} from '@sentry/scraps/text';
 
-import {UserBadge} from 'sentry/components/idBadge/userBadge';
-import {Truncate} from 'sentry/components/truncate';
+import type {OrganizationSummary} from 'sentry/types/organization';
+import type {Project} from 'sentry/types/project';
+import type {User} from 'sentry/types/user';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {getCells} from 'sentry/utils/cells';
 import {useNavigate} from 'sentry/utils/useNavigate';
 
 import {DebounceSearch} from 'admin/components/debounceSearch';
 import {Overview} from 'admin/views/overview';
+
+type OrganizationSearchResult = Pick<OrganizationSummary, 'id' | 'name' | 'slug'>;
+
+type ProjectSearchResult = Pick<Project, 'id' | 'slug'> & {
+  organization: Pick<OrganizationSummary, 'slug'>;
+};
+
+function renderOrganizationResult(organization: OrganizationSearchResult) {
+  return (
+    <Text as="span">
+      <Text as="span" bold>
+        {organization.slug}
+      </Text>{' '}
+      (
+      <Text as="span" variant="muted">
+        {organization.name}
+      </Text>
+      )
+    </Text>
+  );
+}
+
+function renderUserResult(user: User) {
+  const displayName = user.name || user.username || user.email;
+  const identifiers = [...new Set([user.email, user.username])].filter(
+    identifier => identifier && identifier !== displayName
+  );
+
+  return (
+    <Flex align="center" gap="md" minWidth={0}>
+      <UserAvatar user={user} size={32} />
+      <Stack gap="2xs" flex={1} minWidth={0}>
+        <Grid align="center" columns="minmax(0, 1fr) auto" gap="sm">
+          <Text as="span" bold ellipsis>
+            {displayName}
+          </Text>
+          <Flex align="center" gap="xs">
+            {user.isSuperuser ? (
+              <Badge variant="internal">Superuser</Badge>
+            ) : user.isStaff ? (
+              <Badge variant="muted">Staff</Badge>
+            ) : null}
+            {user.isSuspended ? (
+              <Badge variant="danger">Suspended</Badge>
+            ) : user.isActive ? null : (
+              <Badge variant="warning">Inactive</Badge>
+            )}
+          </Flex>
+        </Grid>
+        <Text as="span" size="sm" variant="muted" ellipsis>
+          {[...identifiers, `ID ${user.id}`].join(' · ')}
+        </Text>
+      </Stack>
+    </Flex>
+  );
+}
+
+function renderProjectResult(project: ProjectSearchResult) {
+  return (
+    <Text as="span">
+      <Text as="span" bold>
+        {project.organization.slug}
+      </Text>
+      : {project.slug} (id:{' '}
+      <Text as="span" variant="muted">
+        {project.id}
+      </Text>
+      )
+    </Text>
+  );
+}
 
 export function HomePage() {
   const navigate = useNavigate();
@@ -21,9 +98,8 @@ export function HomePage() {
   const [localityUrl, setLocalityUrl] = useState(cells[0]!.locality_url);
   const selectedCell = cells.find(cell => cell.locality_url === localityUrl);
 
-  const buildOrgPath = (org: any) => `/_admin/customers/${org.slug}/`;
-  const orgSelect = (org: any) => {
-    navigate(buildOrgPath(org));
+  const orgSelect = (organization: OrganizationSearchResult) => {
+    navigate(`/_admin/customers/${organization.slug}/`);
   };
   const orgSubmit = (query: string) => {
     navigate({
@@ -34,9 +110,8 @@ export function HomePage() {
       },
     });
   };
-  const buildUserPath = (user: any) => `/_admin/users/${user.id}/`;
-  const userSelect = (user: any) => {
-    navigate(buildUserPath(user));
+  const userSelect = (user: User) => {
+    navigate(`/_admin/users/${user.id}/`);
   };
   const userSubmit = (query: string) => {
     navigate({
@@ -46,35 +121,8 @@ export function HomePage() {
       },
     });
   };
-  const buildProjPath = (proj: any) =>
-    `/_admin/customers/${proj.organization.slug}/projects/${proj.slug}/`;
-  const projSelect = (proj: any) => {
-    navigate(buildProjPath(proj));
-  };
-
-  const renderOrgSuggestion = (org: any) => {
-    return (
-      <div>
-        <strong>{org.slug}</strong> (<SecondaryText>{org.name}</SecondaryText>)
-      </div>
-    );
-  };
-  const renderUserSuggestion = (user: any) => {
-    return (
-      <UserBadge
-        hideEmail
-        user={user}
-        displayName={<Truncate maxLength={40} value={user.name} />}
-      />
-    );
-  };
-  const renderProjSuggestion = (proj: any) => {
-    return (
-      <div>
-        <strong>{proj.organization.slug}</strong>: {proj.slug} (id:{' '}
-        <SecondaryText>{proj.id}</SecondaryText>)
-      </div>
-    );
+  const projSelect = (project: ProjectSearchResult) => {
+    navigate(`/_admin/customers/${project.organization.slug}/projects/${project.slug}/`);
   };
 
   if (oldSplash) {
@@ -108,19 +156,23 @@ export function HomePage() {
           <span>All actions are logged and audited</span>
         </Warning>
       </Flex>
-      <div>
-        <Container as="label" display="block" marginTop="xl">
-          Users
-        </Container>
+      <Container paddingTop="xl">
         <DebounceSearch
-          path="/users/"
+          label="Users"
+          placeholder="Query users"
+          getResultKey={user => user.id}
+          getResultSearchTerms={user => [user.username, user.email, user.name]}
           onSelectResult={userSelect}
           onSearch={userSubmit}
-          suggestionContent={renderUserSuggestion}
-          placeholder="Query users"
-          createSuggestionPath={buildUserPath}
+          queryOptions={query =>
+            apiOptions.as<User[]>()('/users/', {
+              query: {query, per_page: 10},
+              staleTime: 30_000,
+            })
+          }
+          renderResult={renderUserResult}
         />
-      </div>
+      </Container>
       <Container padding="3xl 0">
         <CompactSelect
           trigger={triggerProps => (
@@ -136,33 +188,53 @@ export function HomePage() {
           }}
         />
 
-        <Container as="label" display="block" marginTop="xl">
-          Organizations
+        <Container paddingTop="xl">
+          <DebounceSearch
+            label="Organizations"
+            placeholder="Query organizations"
+            getResultKey={organization => organization.id}
+            getResultSearchTerms={organization => [organization.slug, organization.name]}
+            isExactMatch={(organization, query) =>
+              organization.slug.toLowerCase() === query.toLowerCase()
+            }
+            onSelectResult={orgSelect}
+            onSearch={orgSubmit}
+            queryOptions={query =>
+              apiOptions.as<OrganizationSearchResult[]>()(
+                '/_admin/cells/$region/customers/',
+                {
+                  path: selectedCell ? {region: selectedCell.name} : skipToken,
+                  query: {query, per_page: 50, sortBy: 'members'},
+                  host: localityUrl,
+                  staleTime: 30_000,
+                }
+              )
+            }
+            renderResult={renderOrganizationResult}
+          />
         </Container>
-        <DebounceSearch
-          host={localityUrl}
-          path={
-            selectedCell ? `/_admin/cells/${selectedCell.name}/customers/` : '/customers/'
-          }
-          onSelectResult={orgSelect}
-          onSearch={orgSubmit}
-          suggestionContent={renderOrgSuggestion}
-          placeholder="Query organizations"
-          createSuggestionPath={buildOrgPath}
-        />
 
-        <Container as="label" display="block" marginTop="xl">
-          Projects (by ID)
+        <Container paddingTop="xl">
+          <DebounceSearch
+            label="Projects (by ID)"
+            placeholder="Project ID"
+            getResultKey={project => project.id}
+            getResultSearchTerms={project => [
+              project.id,
+              project.slug,
+              project.organization.slug,
+            ]}
+            onSelectResult={projSelect}
+            queryOptions={query =>
+              apiOptions.as<ProjectSearchResult[]>()('/projects/', {
+                query: {query: `id:${query}`, per_page: 10, show: 'all'},
+                host: localityUrl,
+                staleTime: 30_000,
+              })
+            }
+            renderResult={renderProjectResult}
+          />
         </Container>
-        <DebounceSearch
-          createSuggestionPath={buildProjPath}
-          onSelectResult={projSelect}
-          placeholder="Project ID"
-          queryParam="id"
-          host={localityUrl}
-          path="/projects/?show=all"
-          suggestionContent={renderProjSuggestion}
-        />
       </Container>
 
       <Container margin="xl 0">
@@ -180,10 +252,6 @@ const HeaderTitle = styled('h3')`
   font-size: ${p => p.theme.font.size.xl};
   font-weight: normal;
   color: ${p => p.theme.tokens.content.primary};
-`;
-
-const SecondaryText = styled('span')`
-  color: ${p => p.theme.tokens.content.secondary};
 `;
 
 const Warning = styled('div')`

--- a/static/gsAdmin/views/home.tsx
+++ b/static/gsAdmin/views/home.tsx
@@ -17,7 +17,7 @@ import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {getCells} from 'sentry/utils/cells';
 import {useNavigate} from 'sentry/utils/useNavigate';
 
-import {DebounceSearch} from 'admin/components/debounceSearch';
+import {AdminSearchCombobox} from 'admin/components/adminSearchCombobox';
 import {Overview} from 'admin/views/overview';
 
 type OrganizationSearchResult = Pick<OrganizationSummary, 'id' | 'name' | 'slug'>;
@@ -157,7 +157,7 @@ export function HomePage() {
         </Warning>
       </Flex>
       <Container paddingTop="xl">
-        <DebounceSearch
+        <AdminSearchCombobox
           label="Users"
           placeholder="Query users"
           getResultKey={user => user.id}
@@ -189,7 +189,7 @@ export function HomePage() {
         />
 
         <Container paddingTop="xl">
-          <DebounceSearch
+          <AdminSearchCombobox
             label="Organizations"
             placeholder="Query organizations"
             getResultKey={organization => organization.id}
@@ -215,7 +215,7 @@ export function HomePage() {
         </Container>
 
         <Container paddingTop="xl">
-          <DebounceSearch
+          <AdminSearchCombobox
             label="Projects (by ID)"
             placeholder="Project ID"
             getResultKey={project => project.id}


### PR DESCRIPTION
replaces gsAdmin's hand-rolled debounced search with Select and React Query and Select

organization search now respects the selected region and member ordering. user results show enough identity and account status to actually distinguish people.

arrow keys and enter work now

before

<img width="1279" height="333" alt="image" src="https://github.com/user-attachments/assets/e113b534-cd79-45c4-886e-c1650d0e5845" />

after

<img width="1274" height="340" alt="Screenshot 2026-08-06 at 4 08 32 PM" src="https://github.com/user-attachments/assets/f6800356-67e4-4864-a8f6-6abb620fb62f" />
