### PR TITLE
ref(performance): Rename Agent Timeline

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -450,7 +450,7 @@ function Highlights({
                 },
               }}
             >
-              {t('Open Agent Timeline')}
+              {t('Open Agent Activity')}
             </OpenInAIFocusButton>
           )}
           {!hidePanelAndBreakdown && (

--- a/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.tsx
@@ -53,7 +53,7 @@ const TAB_DEFINITIONS: Record<TraceLayoutTabKeys, Tab> = {
   },
   [TraceLayoutTabKeys.AI_SPANS]: {
     slug: TraceLayoutTabKeys.AI_SPANS,
-    label: t('Agent Timeline'),
+    label: t('Agent Activity'),
   },
 };
 


### PR DESCRIPTION
Trace details now presents the AI span view and its navigation action as Agent Activity, keeping the user-facing product name consistent without changing the tab route or behavior.
