### PR TITLE
ref(hybridcloud): Read webhook payloads from primary in control tasks

### DIFF
--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -187,13 +187,14 @@ def schedule_webhook_delivery() -> None:
 
     Triggered frequently by task-scheduler.
     """
-    # Se use the replica for any read queries to webhook payload
-    WebhookPayloadReplica = WebhookPayload.objects.using_replica()
-
+    # Read from the primary rather than a replica. These scheduler reads run on a
+    # short interval and can scan the whole table; on a replica they contend with
+    # WAL replay and amplify replication lag, and lag also produces spurious
+    # DoesNotExist races in the drains they enqueue (see INC-2398).
     # The double call to .values() ensures that the group by includes mailbox_name
     # but only id_min is selected
     head_of_line = (
-        WebhookPayloadReplica.all()
+        WebhookPayload.objects.all()
         .values("mailbox_name")
         .annotate(id_min=Min("id"))
         .values("id_min")
@@ -202,7 +203,7 @@ def schedule_webhook_delivery() -> None:
     # Get any heads that are scheduled to run
     # Use provider field directly, with default priority for null values
     scheduled_mailboxes = (
-        WebhookPayloadReplica.filter(
+        WebhookPayload.objects.filter(
             schedule_for__lte=timezone.now(),
             id__in=Subquery(head_of_line),
         )
@@ -238,7 +239,7 @@ def schedule_webhook_delivery() -> None:
         # Reschedule the records that we will attempt to deliver next.
         # We update schedule_for in an attempt to minimize races for potentially in-flight batches.
         mailbox_batch = (
-            WebhookPayloadReplica.filter(id__gte=record["id"], mailbox_name=record["mailbox_name"])
+            WebhookPayload.objects.filter(id__gte=record["id"], mailbox_name=record["mailbox_name"])
             .order_by("id")
             .values("id")[:MAX_MAILBOX_DRAIN]
         )
@@ -266,21 +267,16 @@ def drain_mailbox(payload_id: int, mailbox_name: str | None = None) -> None:
     Once messages have successfully been delivered or discarded, they are deleted.
 
     `mailbox_name` is passed explicitly so we can release the drain lock in the
-    DoesNotExist early-return path (replication lag) without fetching the payload
-    a second time.
+    DoesNotExist early-return path without fetching the payload a second time.
     """
-    WebhookPayloadReplica = WebhookPayload.objects.using_replica()
-
     try:
-        payload = WebhookPayloadReplica.get(id=payload_id)
+        payload = WebhookPayload.objects.get(id=payload_id)
     except WebhookPayload.DoesNotExist:
         # We could have hit a race condition. Since we've lost already return
         # and let the other process continue, or a future process.
         metrics.incr("hybridcloud.deliver_webhooks.delivery", tags={"outcome": "race"})
         logger.info("deliver_webhook.potential_race", extra={"id": payload_id})
-        # Release the drain lock if we know the mailbox name. This can happen when
-        # maybe_trigger_drain queries the primary for head_id then drain_mailbox fetches
-        # from the replica — replication lag causes DoesNotExist, but the lock is still
+        # Release the drain lock if we know the mailbox name. Otherwise the lock is
         # held, blocking both push triggers and the scheduler for the full 15s TTL.
         if mailbox_name and options.get("hybridcloud.webhookpayload.push_drain_trigger"):
             _release_drain_lock(mailbox_name)
@@ -316,7 +312,7 @@ def drain_mailbox(payload_id: int, mailbox_name: str | None = None) -> None:
 
             # Fetch records from the batch in slices of 100. This avoids reading
             # redundant data should we hit an error and should help keep query duration low.
-            query = WebhookPayloadReplica.filter(
+            query = WebhookPayload.objects.filter(
                 id__gte=current_id, mailbox_name=payload.mailbox_name
             ).order_by("id")
 

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -1230,7 +1230,7 @@ class PushTriggerTest(TestCase):
         assert cache.get(f"wh:drain_active:{webhook.mailbox_name}") is None
 
     @override_options({"hybridcloud.webhookpayload.push_drain_trigger": True})
-    def test_drain_releases_lock_on_replica_doesnotexist(self) -> None:
+    def test_drain_releases_lock_on_doesnotexist(self) -> None:
         from django.core.cache import cache
 
         mailbox = "github:123"
@@ -1238,8 +1238,8 @@ class PushTriggerTest(TestCase):
         cache.add(f"wh:drain_active:{mailbox}", 1, timeout=15)
 
         # Call drain_mailbox with a non-existent ID but with mailbox_name, simulating
-        # a replica replication lag race where maybe_trigger_drain found the head on
-        # the primary but drain_mailbox can't see it on the replica yet.
+        # a race where maybe_trigger_drain found the head but the payload was deleted
+        # by a concurrent drain before this task fetched it.
         drain_mailbox(999999, mailbox_name=mailbox)
 
         # Lock must be released so new webhooks and the scheduler can reach this mailbox


### PR DESCRIPTION
## Summary

`schedule_webhook_delivery` (runs every 10s) and `drain_mailbox` read `hybridcloud_webhookpayload` from a replica via `using_replica()`. The scheduler's head-of-line query is an unbounded `MIN(id) GROUP BY mailbox_name` aggregate that scans the whole table. On a replica, a long read like this contends with WAL replay and amplifies replication lag; the lag in turn causes spurious `DoesNotExist` races in the drains these tasks enqueue.

This routes those reads to the primary, removing the replication-conflict amplifier that contributed to INC-2398. Writes/updates/deletes already targeted the primary, so this only changes where reads land.

## Notes

- Behavior is unchanged; only DB routing moves from replica to primary.
- The `DoesNotExist` race path is still valid (concurrent drains can delete a payload), so lock-release logic is kept. Renamed the related test and dropped stale replica-lag wording.
- This is prevention-first. The underlying unbounded-aggregate growth loop is a separate follow-up.

Refs INC-2398