### PR TITLE
feat(agent-monitoring): Add agent conversation API URLs

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -1756,9 +1756,19 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         name="sentry-api-0-organization-ai-conversations",
     ),
     re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/agents/conversations/$",
+        OrganizationAIConversationsEndpoint.as_view(),
+        name="sentry-api-0-organization-agent-conversations",
+    ),
+    re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/ai-conversations/(?P<conversation_id>[^/]+)/$",
         OrganizationAIConversationDetailsEndpoint.as_view(),
         name="sentry-api-0-organization-ai-conversation-details",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/agents/conversations/(?P<conversation_id>[^/]+)/$",
+        OrganizationAIConversationDetailsEndpoint.as_view(),
+        name="sentry-api-0-organization-agent-conversation-details",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/trace-items/attributes/$",

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -70,6 +70,8 @@ export type KnownSentryApiUrls =
   | '/organizations/$organizationIdOrSlug/access-requests/$requestId/'
   | '/organizations/$organizationIdOrSlug/agent/approve/'
   | '/organizations/$organizationIdOrSlug/agent/token/'
+  | '/organizations/$organizationIdOrSlug/agents/conversations/'
+  | '/organizations/$organizationIdOrSlug/agents/conversations/$conversationId/'
   | '/organizations/$organizationIdOrSlug/ai-conversations/'
   | '/organizations/$organizationIdOrSlug/ai-conversations/$conversationId/'
   | '/organizations/$organizationIdOrSlug/alert-rule-detector/'

--- a/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
@@ -20,6 +20,20 @@ from .test_organization_ai_conversations_base import BaseAIConversationsTestCase
 class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase):
     view = "sentry-api-0-organization-ai-conversation-details"
 
+    def test_agents_conversation_details_url(self) -> None:
+        conversation_id = "123"
+
+        assert (
+            reverse(
+                "sentry-api-0-organization-agent-conversation-details",
+                kwargs={
+                    "organization_id_or_slug": self.organization.slug,
+                    "conversation_id": conversation_id,
+                },
+            )
+            == f"/api/0/organizations/{self.organization.slug}/agents/conversations/{conversation_id}/"
+        )
+
     def do_request(self, conversation_id, query=None, features=None, **kwargs):
         if features is None:
             features = ["organizations:gen-ai-conversations"]

--- a/tests/sentry/api/endpoints/test_organization_ai_conversations.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversations.py
@@ -114,6 +114,15 @@ class TestGetLastOutput:
 class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
     view = "sentry-api-0-organization-ai-conversations"
 
+    def test_agents_conversations_url(self) -> None:
+        assert (
+            reverse(
+                "sentry-api-0-organization-agent-conversations",
+                kwargs={"organization_id_or_slug": self.organization.slug},
+            )
+            == f"/api/0/organizations/{self.organization.slug}/agents/conversations/"
+        )
+
     def do_request(self, query=None, features=None, **kwargs):
         if features is None:
             features = ["organizations:gen-ai-conversations"]


### PR DESCRIPTION
Organization conversation APIs are now also available under `/agents/conversations/` for list and detail requests. The existing `/ai-conversations/` routes remain available and continue to serve the same behavior, allowing clients to migrate without a compatibility break.
