### PR TITLE
fix(tracemetrics): Apply min-width to aggregate table columns

### DIFF
--- a/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
@@ -254,7 +254,10 @@ export function AggregatesTab({traceMetric, isMetricOptionsEmpty}: AggregatesTab
                 {displayFields.map((field, j) => (
                   <AggregatesStyledRowCell
                     key={j}
-                    isAggregate={Boolean(parseFunction(field))}
+                    isAggregate={
+                      Boolean(parseFunction(field)) ||
+                      (isVisualizeEquation(visualize) && isEquation(field))
+                    }
                     offset={j === 0 ? firstColumnOffset : undefined}
                     source="metricsPage"
                   >

--- a/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
@@ -317,7 +317,7 @@ const AggregatesStyledHeaderCell = styled(StyledSimpleTableHeaderCell)<{
   ${p =>
     p.isAggregate &&
     css`
-      min-width: max-content;
+      min-width: min-content;
     `}
 `;
 
@@ -329,7 +329,7 @@ const AggregatesStyledRowCell = styled(StyledSimpleTableRowCell)<{
     p.isAggregate &&
     css`
       justify-content: flex-end;
-      min-width: max-content;
+      min-width: min-content;
     `}
   ${p =>
     p.offset &&

--- a/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
@@ -310,6 +310,12 @@ const AggregatesStyledHeaderCell = styled(StyledSimpleTableHeaderCell)<{
   padding: ${p => (p.noPadding ? 0 : p.theme.space.lg)};
   padding-top: ${p => (p.noPadding ? 0 : p.theme.space.xs)};
   padding-bottom: ${p => (p.noPadding ? 0 : p.theme.space.xs)};
+
+  ${p =>
+    p.isAggregate &&
+    css`
+      min-width: max-content;
+    `}
 `;
 
 const AggregatesStyledRowCell = styled(StyledSimpleTableRowCell)<{
@@ -320,6 +326,7 @@ const AggregatesStyledRowCell = styled(StyledSimpleTableRowCell)<{
     p.isAggregate &&
     css`
       justify-content: flex-end;
+      min-width: max-content;
     `}
   ${p =>
     p.offset &&


### PR DESCRIPTION
Applies a min-width to aggregate columns. They were being squashed due to the preceding grouping columns when they were larger. Applies `min-width: max-content` to both header and body cells for aggregations because the header could be wider than the body content and vice versa

Before (column gets squished and isn't even visible):
<img width="721" height="373" alt="Screenshot 2026-08-07 at 9 51 29 AM" src="https://github.com/user-attachments/assets/bc43960f-6f4d-48e8-bc76-89563629e436" />

After:
<img width="724" height="369" alt="Screenshot 2026-08-07 at 9 51 07 AM" src="https://github.com/user-attachments/assets/d1c99c8e-58ac-4113-bac5-bb6618e96193" />

