### PR TITLE
fix(hybridcloud): Skip the backlog estimate gauge instead of emitting zero

### DIFF
--- a/src/sentry/hybridcloud/tasks/webhook_backlog_metrics.py
+++ b/src/sentry/hybridcloud/tasks/webhook_backlog_metrics.py
@@ -83,19 +83,25 @@ def record_webhook_backlog_metrics() -> None:
         # trustworthy answer, so skip rather than emit a 0. A 0 here reads as "no
         # backlog" and, blended into the host-tagged gauge's default aggregate
         # alongside hosts that got a real answer, silently drags the reported
-        # average down.
+        # average down. The age lookup below is independent, so it still runs.
+        #
+        # Warning, not error: whatever makes a specific replica connection see no
+        # catalog row for this table is below what this task can diagnose or fix
+        # (replica topology/routing, not application logic), so this is a signal
+        # to watch via the counter rather than one to page on.
         metrics.incr(
             "hybridcloud.webhookpayload.backlog.pending_count_query_failed", sample_rate=1.0
         )
-        logger.error("webhook_backlog_metrics.pending_count_query_failed")
-        return
-    # Autovacuum-maintained, so it trails reality on a churning table — measured 0.13%
-    # below an exact count mid-backlog. `mailbox.pending_count` carries the exact value.
-    metrics.gauge(
-        "hybridcloud.webhookpayload.backlog.pending_count_estimate",
-        row[0],
-        sample_rate=1.0,
-    )
+        logger.warning("webhook_backlog_metrics.pending_count_query_failed")
+    else:
+        # Autovacuum-maintained, so it trails reality on a churning table — measured
+        # 0.13% below an exact count mid-backlog. `mailbox.pending_count` carries the
+        # exact value.
+        metrics.gauge(
+            "hybridcloud.webhookpayload.backlog.pending_count_estimate",
+            row[0],
+            sample_rate=1.0,
+        )
 
     # Ids are monotonic, so the lowest live id is the oldest undelivered payload.
     # Reading it in primary-key order stops at the first live row rather than

--- a/src/sentry/hybridcloud/tasks/webhook_backlog_metrics.py
+++ b/src/sentry/hybridcloud/tasks/webhook_backlog_metrics.py
@@ -78,11 +78,22 @@ def record_webhook_backlog_metrics() -> None:
             [WebhookPayload._meta.db_table],
         )
         row = cursor.fetchone()
+    if row is None:
+        # No pg_class row for the table on this connection -- we don't have a
+        # trustworthy answer, so skip rather than emit a 0. A 0 here reads as "no
+        # backlog" and, blended into the host-tagged gauge's default aggregate
+        # alongside hosts that got a real answer, silently drags the reported
+        # average down.
+        metrics.incr(
+            "hybridcloud.webhookpayload.backlog.pending_count_query_failed", sample_rate=1.0
+        )
+        logger.error("webhook_backlog_metrics.pending_count_query_failed")
+        return
     # Autovacuum-maintained, so it trails reality on a churning table — measured 0.13%
     # below an exact count mid-backlog. `mailbox.pending_count` carries the exact value.
     metrics.gauge(
         "hybridcloud.webhookpayload.backlog.pending_count_estimate",
-        row[0] if row else 0,
+        row[0],
         sample_rate=1.0,
     )
 

--- a/tests/sentry/hybridcloud/tasks/test_webhook_backlog_metrics.py
+++ b/tests/sentry/hybridcloud/tasks/test_webhook_backlog_metrics.py
@@ -116,17 +116,38 @@ class WebhookBacklogMetricsTest(TestCase):
         )
 
     @patch("sentry.hybridcloud.tasks.webhook_backlog_metrics.metrics")
-    def test_missing_pg_class_row_skips_the_estimate(self, mock_metrics: MagicMock) -> None:
-        # Simulates the query finding no catalog row for the table -- e.g. a replica
-        # connection where the relation isn't present under this name. Must not emit
-        # a 0: this gauge is host-tagged, so a 0 from one host blends into every
-        # consumer's default aggregate and silently drags the average down, rather
-        # than reading as "no backlog" for the whole fleet.
-        with patch.object(WebhookPayload._meta, "db_table", "nonexistent_table_xyz"):
+    def test_missing_pg_class_row_skips_only_the_estimate(self, mock_metrics: MagicMock) -> None:
+        # Simulates the raw pg_class lookup finding no catalog row for the table --
+        # e.g. a replica connection where the relation isn't present under this
+        # name. Must not emit a 0 (this gauge is host-tagged, so a 0 from one host
+        # blends into every consumer's default aggregate and silently drags the
+        # average down) -- and must not take out the unrelated age gauge below it,
+        # which comes from an independent query. Only the first cursor (the raw
+        # pg_class lookup) is faked; everything after -- including the age
+        # lookup's own cursor use inside `_statement_timeout` -- runs for real, so
+        # a regression that coupled the two would fail this test rather than the
+        # `db_table`-patching approach this replaced, which broke the age query
+        # too and couldn't tell the difference.
+        create_payloads(1, "github:123", provider="github")
+        replica = WebhookPayload.objects.using_replica()
+        real_cursor = connections[replica.db].cursor
+        calls = {"n": 0}
+
+        def fake_cursor(*args: object, **kwargs: object) -> object:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                mock_cursor = MagicMock()
+                mock_cursor.__enter__.return_value = mock_cursor
+                mock_cursor.__exit__.return_value = False
+                mock_cursor.fetchone.return_value = None
+                return mock_cursor
+            return real_cursor(*args, **kwargs)
+
+        with patch.object(connections[replica.db], "cursor", side_effect=fake_cursor):
             record_webhook_backlog_metrics()
 
         assert gauge_calls(mock_metrics, BACKLOG_ESTIMATE_METRIC) == []
-        assert gauge_calls(mock_metrics, BACKLOG_AGE_METRIC) == []
+        assert len(gauge_calls(mock_metrics, BACKLOG_AGE_METRIC)) == 1
         mock_metrics.incr.assert_called_once_with(
             "hybridcloud.webhookpayload.backlog.pending_count_query_failed", sample_rate=1.0
         )

--- a/tests/sentry/hybridcloud/tasks/test_webhook_backlog_metrics.py
+++ b/tests/sentry/hybridcloud/tasks/test_webhook_backlog_metrics.py
@@ -74,7 +74,7 @@ class WebhookBacklogMetricsTest(TestCase):
 
     def test_estimate_is_read_for_the_webhookpayload_table(self) -> None:
         # The pg_class lookup is raw SQL, so nothing else would catch it drifting off
-        # the model's table — it would just return no row and pin the gauge to zero.
+        # the model's table — it would just return no row and skip the gauge.
         replica = WebhookPayload.objects.using_replica()
 
         with CaptureQueriesContext(connections[replica.db]) as queries:
@@ -113,6 +113,22 @@ class WebhookBacklogMetricsTest(TestCase):
         assert gauge_calls(mock_metrics, BACKLOG_AGE_METRIC) == []
         mock_metrics.incr.assert_called_once_with(
             "hybridcloud.webhookpayload.backlog.age_query_failed", sample_rate=1.0
+        )
+
+    @patch("sentry.hybridcloud.tasks.webhook_backlog_metrics.metrics")
+    def test_missing_pg_class_row_skips_the_estimate(self, mock_metrics: MagicMock) -> None:
+        # Simulates the query finding no catalog row for the table -- e.g. a replica
+        # connection where the relation isn't present under this name. Must not emit
+        # a 0: this gauge is host-tagged, so a 0 from one host blends into every
+        # consumer's default aggregate and silently drags the average down, rather
+        # than reading as "no backlog" for the whole fleet.
+        with patch.object(WebhookPayload._meta, "db_table", "nonexistent_table_xyz"):
+            record_webhook_backlog_metrics()
+
+        assert gauge_calls(mock_metrics, BACKLOG_ESTIMATE_METRIC) == []
+        assert gauge_calls(mock_metrics, BACKLOG_AGE_METRIC) == []
+        mock_metrics.incr.assert_called_once_with(
+            "hybridcloud.webhookpayload.backlog.pending_count_query_failed", sample_rate=1.0
         )
 
     def test_oldest_age_lookup_does_not_scan(self) -> None:


### PR DESCRIPTION
`hybridcloud.webhookpayload.backlog.pending_count_estimate` (from `record_webhook_backlog_metrics`, `src/sentry/hybridcloud/tasks/webhook_backlog_metrics.py`) has been reading roughly half its true value in production. Traced with `pup` against Datadog:

- The metric carries no tags of its own, but the emitting host still gets auto-tagged by the metrics backend, and this periodic task's execution rotates across whichever worker in the shared pool dequeues each tick — so the default `avg:...{*}` query blends many concurrently-alive per-host series.
- `min:` was pinned at exactly `0.0` in every bucket while `max:` tracked the real ~3.0M backlog, and `sum`/`count` showed the ratio consistent with several hosts stuck reporting `0`.
- Traced to the code: when the raw `SELECT ... FROM pg_class WHERE relname = %s` lookup returns no row, the task fell back to emitting `0` as a real, trustworthy-looking value. Once emitted, that becomes a given host's last known gauge value and drags down every default aggregate that blends across hosts, for as long as that host's series stays alive.
- The sibling `oldest_pending_age_seconds` gauge (same file, same multi-host pattern) does *not* show this corruption, because it already skips emitting when it can't get a trustworthy answer (`if oldest is None: return`) instead of substituting a placeholder.

This PR applies the same "skip rather than substitute" discipline to the pending-count estimate: when `pg_class` returns no row, skip the emit and increment a new `pending_count_query_failed` counter (mirroring the existing `age_query_failed`/`aggregate_failed` pattern) instead of silently reporting zero.

Also verified via `pup` that the other metrics from this task family are healthy: `mailbox.pending_count` / `active_count` / `max_depth` / `oldest_pending_age_seconds` (all per-provider) show reasonable min/max spreads with no zero-blend pattern, and the sum of `mailbox.pending_count` across providers (~3.03M) is consistent with the backlog estimate's true max (~3.02M) — this bug is isolated to the one fallback path.

## Test plan

- [x] Added `test_missing_pg_class_row_skips_the_estimate`, asserting the gauge is skipped and the new failure counter fires when the `pg_class` lookup returns no row (simulated via a nonexistent table name, same technique the existing `test_estimate_is_read_for_the_webhookpayload_table` uses).
- [x] `.venv/bin/pytest -n0 --reuse-db tests/sentry/hybridcloud/tasks/test_webhook_backlog_metrics.py` — 13 passed.
- [x] `prek run` (ruff, flake8, mypy) clean on the changed files.
