### PR TITLE
fix(trace): Stringify EAP breadcrumb timestamps

### DIFF
--- a/src/sentry/api/endpoints/project_trace_item_details.py
+++ b/src/sentry/api/endpoints/project_trace_item_details.py
@@ -280,7 +280,10 @@ def _normalize_breadcrumbs(breadcrumbs: Any) -> None:
             continue
         timestamp = crumb.get("timestamp")
         if isinstance(timestamp, (int, float)) and not isinstance(timestamp, bool):
-            crumb["timestamp"] = to_datetime(timestamp)
+            try:
+                crumb["timestamp"] = to_datetime(timestamp)
+            except Exception as e:
+                sentry_sdk.capture_exception(e)
 
 
 def serialize_event(attributes: list[dict]) -> dict[str, Any] | None:

--- a/src/sentry/api/endpoints/project_trace_item_details.py
+++ b/src/sentry/api/endpoints/project_trace_item_details.py
@@ -41,6 +41,7 @@ from sentry.search.eap.utils import (
 from sentry.search.utils import InvalidQuery, parse_datetime_string
 from sentry.snuba.referrer import Referrer
 from sentry.utils import json
+from sentry.utils.dates import to_datetime
 from sentry.utils.snuba_rpc import trace_item_details_rpc
 
 _NUMERIC_COERCIONS: dict[str, type] = {"valFloat": float, "valDouble": float}
@@ -267,6 +268,21 @@ _SERIALIZED_EVENT_ATTRIBUTES: dict[str, str] = {
 }
 
 
+def _normalize_breadcrumbs(breadcrumbs: Any) -> None:
+    """Convert breadcrumb timestamps to datetimes so they serialize as strings.
+    Matches the event endpoint's breadcrumb serialization (see
+    Breadcrumbs.get_api_context)."""
+    if not isinstance(breadcrumbs, dict):
+        return
+
+    for crumb in breadcrumbs.get("values") or []:
+        if not isinstance(crumb, dict):
+            continue
+        timestamp = crumb.get("timestamp")
+        if isinstance(timestamp, (int, float)) and not isinstance(timestamp, bool):
+            crumb["timestamp"] = to_datetime(timestamp)
+
+
 def serialize_event(attributes: list[dict]) -> dict[str, Any] | None:
     """A few event fields (contexts, extra, breadcrumbs) are stored as
     JSON-serialized strings under internal `sentry.event.serialized_*`
@@ -283,9 +299,15 @@ def serialize_event(attributes: list[dict]) -> dict[str, Any] | None:
             continue
 
         try:
-            result[event_key] = json.loads(value)
+            parsed = json.loads(value)
         except json.JSONDecodeError as e:
             sentry_sdk.capture_exception(e)
+            continue
+
+        if event_key == "breadcrumbs":
+            _normalize_breadcrumbs(parsed)
+
+        result[event_key] = parsed
 
     return result or None
 

--- a/tests/sentry/api/endpoints/test_project_trace_item_details.py
+++ b/tests/sentry/api/endpoints/test_project_trace_item_details.py
@@ -1,7 +1,14 @@
+from datetime import UTC, datetime
+from typing import Any
+
 import pytest
 
-from sentry.api.endpoints.project_trace_item_details import convert_rpc_attribute_to_json
+from sentry.api.endpoints.project_trace_item_details import (
+    convert_rpc_attribute_to_json,
+    serialize_event,
+)
 from sentry.search.eap.types import SupportedTraceItemType
+from sentry.utils import json
 
 
 def test_convert_rpc_attribute_to_json_serializes_known_string_array_without_array_flag() -> None:
@@ -71,6 +78,76 @@ def test_convert_rpc_attribute_to_json_exposes_array_with_array_flag() -> None:
             "value": ["assistant output"],
         }
     ]
+
+
+class TestSerializeEvent:
+    def _breadcrumb_attribute(self, values: list[dict[str, Any]]) -> dict[str, Any]:
+        return {
+            "name": "sentry.event.serialized_breadcrumbs",
+            "value": {"valStr": json.dumps({"values": values})},
+        }
+
+    def test_returns_none_when_no_event_attributes(self) -> None:
+        assert serialize_event([{"name": "sentry.op", "value": {"valStr": "http"}}]) is None
+
+    def test_normalizes_numeric_breadcrumb_timestamp_to_datetime(self) -> None:
+        # Relay serializes breadcrumb timestamps as epoch-seconds floats.
+        result = serialize_event(
+            [self._breadcrumb_attribute([{"type": "default", "timestamp": 1785955938.308}])]
+        )
+
+        assert result is not None
+        crumb = result["breadcrumbs"]["values"][0]
+        assert crumb["timestamp"] == datetime(2026, 8, 5, 18, 52, 18, 308000, tzinfo=UTC)
+
+    def test_leaves_string_breadcrumb_timestamp_untouched(self) -> None:
+        result = serialize_event(
+            [
+                self._breadcrumb_attribute(
+                    [{"type": "default", "timestamp": "2026-08-05T18:52:18.308000Z"}]
+                )
+            ]
+        )
+
+        assert result is not None
+        crumb = result["breadcrumbs"]["values"][0]
+        assert crumb["timestamp"] == "2026-08-05T18:52:18.308000Z"
+
+    def test_handles_breadcrumb_without_timestamp(self) -> None:
+        result = serialize_event([self._breadcrumb_attribute([{"type": "default"}])])
+
+        assert result is not None
+        assert "timestamp" not in result["breadcrumbs"]["values"][0]
+
+    def test_does_not_coerce_boolean_timestamp(self) -> None:
+        # bool is a subclass of int; ensure we don't treat it as an epoch value.
+        result = serialize_event(
+            [self._breadcrumb_attribute([{"type": "default", "timestamp": True}])]
+        )
+
+        assert result is not None
+        assert result["breadcrumbs"]["values"][0]["timestamp"] is True
+
+    def test_passes_through_contexts_and_extra(self) -> None:
+        result = serialize_event(
+            [
+                {
+                    "name": "sentry.event.serialized_contexts",
+                    "value": {
+                        "valStr": json.dumps({"device": {"boot_time": "2018-02-08T12:52:12Z"}})
+                    },
+                },
+                {
+                    "name": "sentry.event.serialized_extra",
+                    "value": {"valStr": json.dumps({"foo": "bar"})},
+                },
+            ]
+        )
+
+        assert result == {
+            "contexts": {"device": {"boot_time": "2018-02-08T12:52:12Z"}},
+            "extra": {"foo": "bar"},
+        }
 
 
 class TestReplacementAttributeFiltering:

--- a/tests/sentry/api/endpoints/test_project_trace_item_details.py
+++ b/tests/sentry/api/endpoints/test_project_trace_item_details.py
@@ -128,6 +128,16 @@ class TestSerializeEvent:
         assert result is not None
         assert result["breadcrumbs"]["values"][0]["timestamp"] is True
 
+    def test_leaves_out_of_range_timestamp_untouched(self) -> None:
+        # A millisecond-scale epoch is out of datetime's range; degrade to the
+        # raw value instead of 500ing the whole response.
+        result = serialize_event(
+            [self._breadcrumb_attribute([{"type": "default", "timestamp": 1785955938308.0}])]
+        )
+
+        assert result is not None
+        assert result["breadcrumbs"]["values"][0]["timestamp"] == 1785955938308.0
+
     def test_passes_through_contexts_and_extra(self) -> None:
         result = serialize_event(
             [


### PR DESCRIPTION
The frontend expects ISO strings for breadcrumb timestamps because that's how the event endpoints serialize them:

https://github.com/getsentry/sentry/blob/774aeab7616eb892cff28cc63b80a5b477bea454/src/sentry/interfaces/breadcrumbs.py#L76

Do the same for breadcrumbs stashed in EAP so we can keep using the same frontend breadcrumb code.