### PR TITLE
fix(auth): Validate org and provider in pipeline state

### DIFF
--- a/src/sentry/pipeline/base.py
+++ b/src/sentry/pipeline/base.py
@@ -23,6 +23,8 @@ from .types import PipelineRequestState, PipelineStepAction, PipelineStepResult
 from .views.base import ApiPipelineEndpoint, ApiPipelineStep, ApiPipelineSteps, PipelineView
 from .views.nested import NestedPipelineView
 
+logger = logging.getLogger(__name__)
+
 ERR_MISMATCHED_USER = "Current user does not match user that started the pipeline."
 
 
@@ -93,6 +95,8 @@ class Pipeline[M: Model, S: PipelineSessionStore](abc.ABC):
             )
             if org_context:
                 organization = org_context.organization
+            else:
+                return None
 
         provider_key = state.provider_key
 
@@ -147,11 +151,36 @@ class Pipeline[M: Model, S: PipelineSessionStore](abc.ABC):
         raise NotImplementedError
 
     def is_valid(self) -> bool:
-        return (
+        if not (
             self.state.is_valid()
             and self.state.signature == self.signature
             and self.state.step_index is not None
-        )
+        ):
+            return False
+
+        if self.state.org_id != (self.organization.id if self.organization else None):
+            logger.warning(
+                "pipeline.org-mismatch",
+                extra={
+                    "pipeline_org_id": self.state.org_id,
+                    "request_org_id": self.organization.id if self.organization else None,
+                },
+            )
+            return False
+
+        if self.state.provider_model_id != (
+            self.provider_model.id if self.provider_model else None
+        ):
+            logger.warning(
+                "pipeline.provider-mismatch",
+                extra={
+                    "pipeline_provider_id": self.state.provider_model_id,
+                    "request_provider_id": self.provider_model.id if self.provider_model else None,
+                },
+            )
+            return False
+
+        return True
 
     def initialize(self) -> None:
         self.state.regenerate(self.get_initial_state())

--- a/tests/sentry/auth/test_helper.py
+++ b/tests/sentry/auth/test_helper.py
@@ -154,10 +154,10 @@ class UserResolutionTest(AuthIdentityHandlerTest):
     def test_authenticated_user_resolves_to_session_user(self) -> None:
         """Session user takes priority over IdP email resolution."""
         session_user = self.set_up_user()
-        victim = self.create_user(email=self.email)
+        other_user = self.create_user(email=self.email)
 
         assert self.handler.user == session_user
-        assert self.handler.user != victim
+        assert self.handler.user != other_user
 
     def test_unauthenticated_with_no_email_match_resolves_to_anonymous(self) -> None:
         identity: _Identity = {
@@ -994,6 +994,86 @@ class AuthHelperTest(TestCase):
             f"Authentication error: {ERR_USER_SUSPENDED}",
         )
 
+    def test_rejects_pipeline_from_different_org(self) -> None:
+        other_org = self.create_organization()
+        other_auth_provider = AuthProvider.objects.create(
+            organization_id=other_org.id, provider=self.provider
+        )
+
+        with assume_test_silo_mode(SiloMode.CELL):
+            other_rpc_org = serialize_rpc_organization(other_org)
+
+        helper_org_a = AuthHelper(
+            request=self.request,
+            organization=other_rpc_org,
+            auth_provider=other_auth_provider,
+            flow=FLOW_LOGIN,
+        )
+        helper_org_a.initialize()
+        assert helper_org_a.is_valid()
+
+        with assume_test_silo_mode(SiloMode.CELL):
+            rpc_org = serialize_rpc_organization(self.organization)
+
+        helper_org_b = AuthHelper(
+            request=self.request,
+            organization=rpc_org,
+            auth_provider=self.auth_provider_inst,
+            flow=FLOW_LOGIN,
+        )
+        assert not helper_org_b.is_valid()
+
+    def test_rejects_different_provider_model(self) -> None:
+        """Even within the same org, swapping the provider_model_id is rejected."""
+        other_org = self.create_organization()
+        other_auth_provider = AuthProvider.objects.create(
+            organization_id=other_org.id, provider=self.provider
+        )
+
+        with assume_test_silo_mode(SiloMode.CELL):
+            rpc_org = serialize_rpc_organization(self.organization)
+
+        helper_a = AuthHelper(
+            request=self.request,
+            organization=rpc_org,
+            auth_provider=self.auth_provider_inst,
+            flow=FLOW_LOGIN,
+        )
+        helper_a.initialize()
+        assert helper_a.is_valid()
+
+        helper_b = AuthHelper(
+            request=self.request,
+            organization=rpc_org,
+            auth_provider=other_auth_provider,
+            flow=FLOW_LOGIN,
+        )
+        assert not helper_b.is_valid()
+
+    def test_get_for_request_binds_to_stored_org(self) -> None:
+        """get_for_request always reconstructs from stored state,
+        so the org is bound at init time."""
+        other_org = self.create_organization()
+        other_auth_provider = AuthProvider.objects.create(
+            organization_id=other_org.id, provider=self.provider
+        )
+
+        with assume_test_silo_mode(SiloMode.CELL):
+            other_rpc_org = serialize_rpc_organization(other_org)
+
+        helper = AuthHelper(
+            request=self.request,
+            organization=other_rpc_org,
+            auth_provider=other_auth_provider,
+            flow=FLOW_LOGIN,
+        )
+        helper.initialize()
+
+        restored = AuthHelper.get_for_request(self.request)
+        assert restored is not None
+        assert restored.is_valid()
+        assert restored.organization.id == other_org.id
+
 
 @control_silo_test
 class HasVerifiedAccountTest(AuthIdentityHandlerTest):
@@ -1256,7 +1336,7 @@ class InactiveUserIdentityTest(AuthIdentityHandlerTest):
         """Authenticated request + inactive-user identity routes through
         handle_unknown_identity and shows confirmation page, not a redirect."""
         inactive_user, auth_identity = self._create_inactive_user_with_identity()
-        attacker = self.set_up_user()
+        requesting_user = self.set_up_user()
 
         result = self.handler.handle_unknown_identity(self.state)
 
@@ -1264,7 +1344,7 @@ class InactiveUserIdentityTest(AuthIdentityHandlerTest):
         template = mock_render.call_args.args[0]
         assert template == "sentry/auth-confirm-link.html"
 
-        # AuthIdentity still points to the original inactive user, not the attacker
+        # AuthIdentity still points to the original inactive user
         auth_identity.refresh_from_db()
         assert auth_identity.user_id == inactive_user.id
-        assert auth_identity.user_id != attacker.id
+        assert auth_identity.user_id != requesting_user.id

--- a/tests/sentry/pipeline/test_pipeline.py
+++ b/tests/sentry/pipeline/test_pipeline.py
@@ -289,6 +289,68 @@ class PipelineTestCase(TestCase):
 
             assert not new_pipeline.is_valid()
 
+    def test_pipeline_rejects_different_org(self) -> None:
+        with assume_test_silo_mode(SiloMode.CELL):
+            other_org = serialize_rpc_organization(self.create_organization())
+
+        pipeline = DummyPipeline(self.request, "dummy", self.org)
+        pipeline.initialize()
+        assert pipeline.is_valid()
+
+        cross_org_pipeline = DummyPipeline(self.request, "dummy", other_org)
+        assert not cross_org_pipeline.is_valid()
+
+    def test_pipeline_rejects_different_provider_model(self) -> None:
+        idp_a = IdentityProvider.objects.create(type="dummy", external_id="a")
+        idp_b = IdentityProvider.objects.create(type="dummy", external_id="b")
+
+        with patch.object(DummyPipeline, "provider_model_cls", IdentityProvider):
+            pipeline = DummyPipeline(self.request, "dummy", self.org, provider_model=idp_a)
+            pipeline.initialize()
+            assert pipeline.is_valid()
+
+            cross_provider_pipeline = DummyPipeline(
+                self.request, "dummy", self.org, provider_model=idp_b
+            )
+            assert not cross_provider_pipeline.is_valid()
+
+    def test_get_for_request_uses_stored_org_not_url_org(self) -> None:
+        """get_for_request reconstructs from Redis state, so org always matches."""
+        with assume_test_silo_mode(SiloMode.CELL):
+            other_org = serialize_rpc_organization(self.create_organization())
+
+        pipeline = DummyPipeline(self.request, "dummy", self.org)
+        pipeline.initialize()
+
+        restored = DummyPipeline.get_for_request(self.request)
+        assert restored is not None
+        assert restored.is_valid()
+        assert restored.organization is not None
+        assert restored.organization.id == self.org.id
+        assert restored.organization.id != other_org.id
+
+    def test_pipeline_without_org_is_valid(self) -> None:
+        """Pipelines like IdentityPipeline can operate without an org."""
+        pipeline = DummyPipeline(self.request, "dummy", organization=None)
+        pipeline.initialize()
+        assert pipeline.is_valid()
+        assert pipeline.state.org_id is None
+
+    def test_pipeline_rejects_different_org_with_same_signature(self) -> None:
+        """Two orgs with identical provider types produce the same signature
+        but must not share pipeline state."""
+        with assume_test_silo_mode(SiloMode.CELL):
+            org_a = serialize_rpc_organization(self.create_organization())
+            org_b = serialize_rpc_organization(self.create_organization())
+
+        pipeline_a = DummyPipeline(self.request, "dummy", org_a)
+        pipeline_b = DummyPipeline(self.request, "dummy", org_b)
+        assert pipeline_a.signature == pipeline_b.signature
+
+        pipeline_a.initialize()
+        assert pipeline_a.is_valid()
+        assert not pipeline_b.is_valid()
+
     @patch("sentry.pipeline.base.bind_organization_context")
     def test_pipeline_intercept_fails(self, mock_bind_org_context: MagicMock) -> None:
         pipeline = DummyPipeline(self.request, "dummy", self.org, config={"some_config": True})

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -1047,6 +1047,62 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         assert resp.redirect_chain == [("/auth/login/", 302)]
         self.assertTemplateUsed(resp, "sentry/login.html")
 
+    def test_sso_pipeline_rejects_different_org(self) -> None:
+        AuthProvider.objects.create(organization_id=self.organization.id, provider="dummy")
+
+        other_org = self.create_organization(name="other-org")
+        AuthProvider.objects.create(organization_id=other_org.id, provider="dummy")
+        other_path = reverse("sentry-auth-organization", args=[other_org.slug])
+
+        resp = self.client.post(self.path, {"init": True})
+        assert resp.status_code == 200
+
+        resp = self.client.post(other_path)
+        assert resp.status_code == 302
+        assert resp["Location"] == other_path
+
+    def test_sso_pipeline_rejects_cross_org_newuser(self) -> None:
+        """Pipeline initialized for org A must not accept op=newuser
+        posted to org B."""
+        AuthProvider.objects.create(organization_id=self.organization.id, provider="dummy")
+
+        other_org = self.create_organization(name="other-org")
+        AuthProvider.objects.create(organization_id=other_org.id, provider="dummy")
+        other_path = reverse("sentry-auth-organization", args=[other_org.slug])
+
+        resp = self.client.post(self.path, {"init": True})
+        assert resp.status_code == 200
+
+        resp = self.client.post(other_path, {"op": "newuser"})
+        assert resp.status_code == 302
+        assert resp["Location"] == other_path
+
+    def test_sso_pipeline_rejects_cross_org_with_same_provider_type(self) -> None:
+        """Both orgs use the same provider type (identical pipeline signature)
+        but the org_id check must still reject."""
+        AuthProvider.objects.create(organization_id=self.organization.id, provider="dummy")
+
+        other_org = self.create_organization(name="other-org")
+        AuthProvider.objects.create(organization_id=other_org.id, provider="dummy")
+        other_path = reverse("sentry-auth-organization", args=[other_org.slug])
+
+        resp = self.client.post(self.path, {"init": True})
+        assert resp.status_code == 200
+
+        resp = self.client.post(other_path, {"op": "confirm"})
+        assert resp.status_code == 302
+        assert resp["Location"] == other_path
+
+    def test_sso_pipeline_valid_when_same_org(self) -> None:
+        """Normal flow: init and resume on the same org should work."""
+        AuthProvider.objects.create(organization_id=self.organization.id, provider="dummy")
+
+        resp = self.client.post(self.path, {"init": True})
+        assert resp.status_code == 200
+
+        resp = self.client.post(self.path)
+        assert resp.status_code == 200
+
 
 @control_silo_test
 class OrganizationAuthLoginNoPasswordTest(AuthProviderTestCase):


### PR DESCRIPTION
Pipeline.is_valid() now checks that the stored org_id and provider_model_id match the current request context. Also returns None from unpack_state() when the stored org no longer exists.
