### PR TITLE
fix(replays): Remove gcTime: infinite for replay dom caching

### DIFF
--- a/static/app/utils/replays/hooks/useExtractDiffMutations.tsx
+++ b/static/app/utils/replays/hooks/useExtractDiffMutations.tsx
@@ -265,6 +265,6 @@ export function useExtractDiffMutations({
     queryFn: () =>
       extractDiffMutations({replay, rangeStartTimestampMs, rangeEndTimestampMs}),
     enabled: true,
-    gcTime: Infinity,
+    staleTime: Infinity,
   });
 }

--- a/static/app/utils/replays/hooks/useExtractDomNodes.tsx
+++ b/static/app/utils/replays/hooks/useExtractDomNodes.tsx
@@ -18,7 +18,6 @@ export function useExtractDomNodes({replay, frame, enabled}: Params) {
     // visualize the rendered elements
     queryFn: () => replay?.getDomNodesForFrame({frame}) ?? null,
     enabled: Boolean(!replay?.isFetching() && enabled),
-    gcTime: Infinity,
     staleTime: Infinity,
     retry: false,
   });

--- a/static/app/utils/replays/hooks/useExtractPageHtml.tsx
+++ b/static/app/utils/replays/hooks/useExtractPageHtml.tsx
@@ -65,6 +65,6 @@ export function useExtractPageHtml({replay, offsetMsToStopAt}: Props) {
         startTimestampMs: replay?.getReplay().started_at.getTime() ?? 0,
       }),
     enabled: Boolean(replay),
-    gcTime: Infinity,
+    staleTime: Infinity,
   });
 }


### PR DESCRIPTION
allow react query to eject this data at some point. still cached while useQuery is listening.