### PR TITLE
feat(onboarding): Track create attempts and failures on the legacy project flow

### DIFF
--- a/static/app/views/projectInstall/createProject.spec.tsx
+++ b/static/app/views/projectInstall/createProject.spec.tsx
@@ -523,6 +523,7 @@ describe('CreateProject', () => {
         allowMemberProjectCreation: true,
       },
     });
+    const trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
 
     const frameWorkModalMockRequests = renderFrameworkModalMockRequests({
       organization,
@@ -550,6 +551,14 @@ describe('CreateProject', () => {
       1
     );
     expect(addErrorMessage).toHaveBeenCalledWith('Failed to create project apple-ios');
+    expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+      'project_creation.project_details_create_clicked',
+      expect.objectContaining({variant: 'legacy'})
+    );
+    expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+      'project_creation.project_details_create_failed',
+      expect.objectContaining({variant: 'legacy'})
+    );
   });
 
   it('should display success message when using member endpoint', async () => {
@@ -664,6 +673,12 @@ describe('CreateProject', () => {
     expect(trackAnalyticsSpy).toHaveBeenCalledWith(
       'project_creation.select_framework_modal_close_button_clicked',
       expect.objectContaining({variant: 'legacy'})
+    );
+    // No POST was attempted, so this must not land in the create-failure rate
+    // denominator.
+    expect(trackAnalyticsSpy).not.toHaveBeenCalledWith(
+      'project_creation.project_details_create_clicked',
+      expect.anything()
     );
   });
 

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -295,6 +295,13 @@ export function CreateProject() {
       }) => {
       const selectedPlatform = selectedFramework ?? platform;
 
+      // Not in handleProjectCreation: every path into configurePlatform goes on
+      // to POST, so an abandoned framework modal stays out of the denominator.
+      trackAnalytics('project_creation.project_details_create_clicked', {
+        organization,
+        variant: 'legacy',
+      });
+
       try {
         const {project, notificationRule, ruleIds} =
           await createProjectAndRules.mutateAsync({
@@ -346,6 +353,13 @@ export function CreateProject() {
         });
       } catch (error: any) {
         addErrorMessage(t('Failed to create project %s', projectName));
+
+        // Unfiltered, unlike the Sentry captures: the SCM variant counts every
+        // caught failure, so filtering here would make the two rates disagree.
+        trackAnalytics('project_creation.project_details_create_failed', {
+          organization,
+          variant: 'legacy',
+        });
 
         if (error.status === 403) {
           Sentry.withScope(scope => {


### PR DESCRIPTION
## TLDR

Emits `project_details_create_clicked` and `project_details_create_failed` from the legacy project creation path with `variant: 'legacy'`, so create failure rate can be compared against the SCM variant that already reports both.

## Details

The SCM flow already emits both halves of a failure rate and the legacy flow emitted neither, so there is currently no way to tell whether the conversion gap between the two variants is failed creates or abandonment. Sentry cannot answer it either, for reasons PR 2 in this stack addresses.

`create_clicked` sits in `configurePlatform` rather than `handleProjectCreation` because all three entries into it (direct, framework-modal configure, modal skip) go on to POST, which keeps an abandoned modal out of the denominator. `create_failed` is unfiltered at the top of the existing catch, since matching the Sentry captures' 409/403 filtering would not line up with SCM's unfiltered event. One asymmetry remains: SCM emits `create_clicked` before its back-nav no-op early return, so its denominator counts a few attempts that never POST.

## Stack

- **PR 1 (this):** legacy create attempt and failure analytics
- [PR 2](https://github.com/getsentry/sentry/pull/121533): unified Sentry failure reporting

Refs VDY-153
