### PR TITLE
fix(issues): standardize vertical alignment of the "Jump to:" label

### DIFF
--- a/static/app/views/issueDetails/eventNavigation/issueDetailsJumpTo.tsx
+++ b/static/app/views/issueDetails/eventNavigation/issueDetailsJumpTo.tsx
@@ -152,7 +152,7 @@ function JumpToLink({config}: {config: JumpToSectionConfig}) {
 }
 
 const JumpToLabel = styled('div')`
-  margin-top: ${p => p.theme.space['2xs']};
+  line-height: ${p => p.theme.font.lineHeight.fixed};
 `;
 
 const JumpTo = styled('div')`
@@ -161,7 +161,7 @@ const JumpTo = styled('div')`
   flex-direction: row;
   align-items: center;
   color: ${p => p.theme.tokens.content.secondary};
-  font-size: ${p => p.theme.font.size.sm};
+  font-size: ${p => p.theme.form.xs.fontSize};
   white-space: nowrap;
   overflow: hidden;
 `;


### PR DESCRIPTION
<table><thead><tr><th>Scroll</th><th>Before</th><th>After</th></tr></thead><tbody><tr><td><code>0</code></td><td><img alt="Jump to label sitting one pixel below the section links at scroll 0" src="https://github.com/user-attachments/assets/32914ab8-3005-4920-bed8-33352105b0b4" /></td><td><img alt="Jump to label aligned with the section links at scroll 0" src="https://github.com/user-attachments/assets/a4db397e-dbf6-44f5-be3b-9ce018a4b546" /></td></tr><tr><td><code>200</code></td><td><img alt="Jump to label sitting one pixel below the section links at scroll 200" src="https://github.com/user-attachments/assets/948f889e-900b-4dba-b32b-f9ebc15a2465" /></td><td><img alt="Jump to label aligned with the section links at scroll 200" src="https://github.com/user-attachments/assets/ac77e951-3718-4253-bd15-d768cc2a85f5" /></td></tr><tr><td><code>600</code></td><td><img alt="Jump to label aligned with the section links at scroll 600, where the nav is stuck" src="https://github.com/user-attachments/assets/1422a233-210b-4bde-819e-30b6afe211c7" /></td><td><img alt="Jump to label aligned with the section links at scroll 600" src="https://github.com/user-attachments/assets/b29551d4-e8dd-483a-9d20-73ad387e0ed6" /></td></tr><tr><td><code>1600</code></td><td><img alt="Jump to label aligned with the section links at scroll 1600, where the nav is stuck" src="https://github.com/user-attachments/assets/8cfecf57-1990-4d21-b7aa-c9b04e87f6cc" /></td><td><img alt="Jump to label aligned with the section links at scroll 1600" src="https://github.com/user-attachments/assets/5da67739-5dfe-4e54-aebc-30ae5710b877" /></td></tr></tbody></table>

Closes ISWF-3242.