### PR TITLE
feat(onboarding): Report project creation failures identically across both flows

### DIFF
--- a/static/app/components/onboarding/captureProjectCreationFailure.spec.ts
+++ b/static/app/components/onboarding/captureProjectCreationFailure.spec.ts
@@ -1,0 +1,56 @@
+import * as Sentry from '@sentry/react';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {TeamFixture} from 'sentry-fixture/team';
+
+import {captureProjectCreationFailure} from 'sentry/components/onboarding/captureProjectCreationFailure';
+
+describe('captureProjectCreationFailure', () => {
+  const organization = OrganizationFixture();
+  const accessTeams = [TeamFixture({slug: 'team-slug', access: ['team:admin']})];
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('reports a generic failure', () => {
+    const captureMessage = jest.spyOn(Sentry, 'captureMessage');
+
+    captureProjectCreationFailure({
+      error: {status: 500},
+      organization,
+      team: 'team-slug',
+      accessTeams,
+      variant: 'scm',
+    });
+
+    expect(captureMessage).toHaveBeenCalledWith('Project creation failed');
+  });
+
+  it('reports permission denials under their own message', () => {
+    const captureMessage = jest.spyOn(Sentry, 'captureMessage');
+
+    captureProjectCreationFailure({
+      error: {status: 403},
+      organization,
+      team: 'team-slug',
+      accessTeams,
+      variant: 'legacy',
+    });
+
+    expect(captureMessage).toHaveBeenCalledWith('Project creation permission denied');
+  });
+
+  it('does not report a duplicate project name', () => {
+    const captureMessage = jest.spyOn(Sentry, 'captureMessage');
+
+    captureProjectCreationFailure({
+      error: {status: 409},
+      organization,
+      team: 'team-slug',
+      accessTeams,
+      variant: 'scm',
+    });
+
+    expect(captureMessage).not.toHaveBeenCalled();
+  });
+});

--- a/static/app/components/onboarding/captureProjectCreationFailure.ts
+++ b/static/app/components/onboarding/captureProjectCreationFailure.ts
@@ -1,0 +1,58 @@
+import * as Sentry from '@sentry/react';
+
+import type {Organization, Team} from 'sentry/types/organization';
+import type {ProjectCreationVariant} from 'sentry/utils/analytics/projectCreationAnalyticsEvents';
+
+interface CaptureProjectCreationFailureParams {
+  accessTeams: Team[];
+  error: any;
+  organization: Organization;
+  variant: ProjectCreationVariant;
+  team?: string;
+}
+
+/**
+ * Report a failed project creation to Sentry, identically for both flows.
+ *
+ * The message strings are shared on purpose: grouping is by message, so both
+ * flows land in one group per failure mode and the `project_creation_variant`
+ * tag splits them back apart. 409 is skipped because a duplicate project name
+ * is user error, not a defect.
+ */
+export function captureProjectCreationFailure({
+  error,
+  organization,
+  team,
+  accessTeams,
+  variant,
+}: CaptureProjectCreationFailureParams): void {
+  if (error?.status === 403) {
+    Sentry.withScope(scope => {
+      scope.setTag('project_creation_variant', variant);
+      scope.setExtra('err', error);
+      scope.setContext('permission_context', {
+        org_slug: organization.slug,
+        team,
+        org_access: organization.access,
+        org_features: organization.features,
+        org_allow_member_project_creation: organization.allowMemberProjectCreation,
+        user_team_access: team
+          ? accessTeams.find(teamItem => teamItem.slug === team)?.access
+          : null,
+        available_teams_count: accessTeams.length,
+      });
+      Sentry.captureMessage('Project creation permission denied');
+    });
+    return;
+  }
+
+  if (error?.status === 409) {
+    return;
+  }
+
+  Sentry.withScope(scope => {
+    scope.setTag('project_creation_variant', variant);
+    scope.setExtra('err', error);
+    Sentry.captureMessage('Project creation failed');
+  });
+}

--- a/static/app/components/onboarding/scm/useScmProjectDetails.ts
+++ b/static/app/components/onboarding/scm/useScmProjectDetails.ts
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/react';
 import isEqual from 'lodash/isEqual';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
+import {captureProjectCreationFailure} from 'sentry/components/onboarding/captureProjectCreationFailure';
 import type {ProjectDetailsFormState} from 'sentry/components/onboarding/scm/scmProjectDetailsTypes';
 import {useCreateProjectAndRules} from 'sentry/components/onboarding/useCreateProjectAndRules';
 import {t} from 'sentry/locale';
@@ -399,7 +400,13 @@ export function useScmProjectDetails({
             variant: 'scm',
           });
           addErrorMessage(t('Failed to create project'));
-          Sentry.captureException(error);
+          captureProjectCreationFailure({
+            error,
+            organization,
+            team: isOrgMemberWithNoAccess ? undefined : teamSlugResolved,
+            accessTeams,
+            variant: 'scm',
+          });
           return null;
         });
       if (!creation) {
@@ -435,6 +442,7 @@ export function useScmProjectDetails({
       setIsCompleting(false);
     }
   }, [
+    accessTeams,
     alertRuleConfig,
     canSubmit,
     createNotificationAction,

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -1,6 +1,5 @@
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
-import * as Sentry from '@sentry/react';
 import {useQuery} from '@tanstack/react-query';
 import debounce from 'lodash/debounce';
 import omit from 'lodash/omit';
@@ -18,6 +17,7 @@ import {Access} from 'sentry/components/acl/access';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {List} from 'sentry/components/list';
 import {ListItem} from 'sentry/components/list/listItem';
+import {captureProjectCreationFailure} from 'sentry/components/onboarding/captureProjectCreationFailure';
 import {SupportedLanguages} from 'sentry/components/onboarding/frameworkSuggestionModal';
 import {ProjectCreationErrorAlert} from 'sentry/components/onboarding/projectCreationErrorAlert';
 import {useCreateProjectAndRules} from 'sentry/components/onboarding/useCreateProjectAndRules';
@@ -364,35 +364,20 @@ export function CreateProject() {
       } catch (error: any) {
         addErrorMessage(t('Failed to create project %s', projectName));
 
-        // Unfiltered, unlike the Sentry captures: the SCM variant counts every
-        // caught failure, so filtering here would make the two rates disagree.
+        // Unfiltered, unlike captureProjectCreationFailure below: both variants
+        // count every caught failure, so filtering here would skew the rate.
         trackAnalytics('project_creation.project_details_create_failed', {
           organization,
           variant: 'legacy',
         });
 
-        if (error.status === 403) {
-          Sentry.withScope(scope => {
-            scope.setExtra('err', error);
-            scope.setContext('permission_context', {
-              org_slug: organization.slug,
-              team,
-              org_access: organization.access,
-              org_features: organization.features,
-              org_allow_member_project_creation: organization.allowMemberProjectCreation,
-              user_team_access: team
-                ? accessTeams.find(teamItem => teamItem.slug === team)?.access
-                : null,
-              available_teams_count: accessTeams.length,
-            });
-            Sentry.captureMessage('Project creation permission denied');
-          });
-        } else if (error.status !== 409) {
-          Sentry.withScope(scope => {
-            scope.setExtra('err', error);
-            Sentry.captureMessage('Project creation failed');
-          });
-        }
+        captureProjectCreationFailure({
+          error,
+          organization,
+          team,
+          accessTeams,
+          variant: 'legacy',
+        });
       }
     },
     [


### PR DESCRIPTION
## TLDR

Routes both create-project flows through one failure reporter, so legacy and SCM failures land in the same Sentry groups split by a `project_creation_variant` tag, instead of legacy having named groups while SCM scattered into generic request-error groups.

## Details

The two flows diverged three ways. Legacy called `captureMessage` with dedicated strings while SCM called `captureException` on the raw error, so SCM failures grouped by whatever the API client threw. Legacy dropped 409 and split 403 into its own message with a permission context while SCM filtered nothing. And SCM set no scope at all, leaving its events unattributable once grouped. `captureProjectCreationFailure` now owns that logic and both call sites delegate to it.

Sharing the message strings means SCM events join the existing legacy groups rather than forming parallel ones. That is deliberate. As `onboarding-scm-project-creation` rolls out, a legacy-only group sheds volume in proportion to the rollout percentage and reads as an improvement when nothing improved; one group covering both flows stays meaningful, and the tag splits it back apart. Adding the tag does not change grouping, so the existing groups keep their history.

## Stack

- [PR 1](https://github.com/getsentry/sentry/pull/121531): legacy create attempt and failure analytics
- **PR 2 (this):** unified Sentry failure reporting

Fixes VDY-153
