### PR TITLE
ref(integrations): Clean up the sentry app request log

### DIFF
--- a/static/app/actionCreators/sentryApps.tsx
+++ b/static/app/actionCreators/sentryApps.tsx
@@ -8,7 +8,7 @@ import {
 } from 'sentry/actionCreators/indicator';
 import type {Client} from 'sentry/api';
 import {t} from 'sentry/locale';
-import type {SentryApp} from 'sentry/types/integrations';
+import type {SentryApp, SentryAppWebhookRequest} from 'sentry/types/integrations';
 import type {InternalAppApiToken} from 'sentry/types/user';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 
@@ -34,6 +34,25 @@ export function sentryAppApiOptions({appSlug}: {appSlug: string | null}) {
     path: appSlug ? {sentryAppIdOrSlug: appSlug} : skipToken,
     staleTime: 0,
   });
+}
+
+export function sentryAppWebhookRequestsApiOptions({
+  appSlug,
+  errorsOnly,
+  eventType,
+}: {
+  appSlug: string;
+  errorsOnly?: boolean;
+  eventType?: string;
+}) {
+  return apiOptions.as<SentryAppWebhookRequest[]>()(
+    '/sentry-apps/$sentryAppIdOrSlug/webhook-requests/',
+    {
+      path: {sentryAppIdOrSlug: appSlug},
+      query: {eventType, errorsOnly},
+      staleTime: 0,
+    }
+  );
 }
 
 export function sentryAppTokensApiOptions({appSlug}: {appSlug: string | null}) {

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -334,11 +334,6 @@ export type SentryAppWebhookRequest = {
   responseCode: number;
   sentryAppSlug: string;
   webhookUrl: string;
-  /**
-   * The fields below are snake_case to match the API, and are only present for
-   * failed requests (4xx/5xx and timeouts). See
-   * SentryAppWebhookRequestSerializer on the backend.
-   */
   error_id?: string | null;
   organization?: {
     id: number;

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -334,12 +334,25 @@ export type SentryAppWebhookRequest = {
   responseCode: number;
   sentryAppSlug: string;
   webhookUrl: string;
-  errorUrl?: string;
+  /**
+   * The fields below are snake_case to match the API, and are only present for
+   * failed requests (4xx/5xx and timeouts). See
+   * SentryAppWebhookRequestSerializer on the backend.
+   */
+  error_id?: string | null;
   organization?: {
-    id: string;
+    id: number;
     name: string;
     slug: string;
   };
+  project_id?: number | null;
+  request_body?: string | null;
+  /**
+   * Values of custom headers are masked before they reach the buffer, so only
+   * the header names are meaningful for those.
+   */
+  request_headers?: Record<string, string> | null;
+  response_body?: string | null;
 };
 
 /**

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/index.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/index.spec.tsx
@@ -114,6 +114,21 @@ describe('Sentry Application Dashboard', () => {
       ).toBeInTheDocument();
     });
 
+    it('shows an error if the request log fails to load', async () => {
+      MockApiClient.addMockResponse({
+        url: `/sentry-apps/${sentryApp.slug}/webhook-requests/`,
+        statusCode: 500,
+        body: {detail: 'Internal Error'},
+      });
+
+      renderDashboard();
+
+      expect(await screen.findByTestId('loading-error')).toBeInTheDocument();
+      expect(
+        screen.queryByText('No requests found in the last 30 days.')
+      ).not.toBeInTheDocument();
+    });
+
     it('shows integration and interactions chart with a deduplicated interaction fetch', async () => {
       renderDashboard();
 

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/requestLog.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/requestLog.tsx
@@ -77,7 +77,7 @@ const getEventTypes = memoize((app: SentryApp) => {
   return events;
 });
 
-export function ResponseCode({code}: {code: number}) {
+function ResponseCode({code}: {code: number}) {
   let variant: TagProps['variant'] = 'danger';
   if (code <= 399 && code >= 300) {
     variant = 'warning';

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/requestLog.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/requestLog.tsx
@@ -98,7 +98,7 @@ export function RequestLog({app}: RequestLogProps) {
   const [eventType, setEventType] = useState(ALL_EVENTS);
 
   const {slug, status} = app;
-  const hasOrganization = status !== 'internal';
+  const isInternal = status === 'internal';
 
   const {
     data: requests = [],
@@ -164,11 +164,11 @@ export function RequestLog({app}: RequestLogProps) {
       {isError ? (
         <LoadingError />
       ) : (
-        <RequestLogTable hasOrganization={hasOrganization}>
+        <RequestLogTable isInternal={isInternal}>
           <SimpleTable.Header>
             <SimpleTable.HeaderCell>{t('Time')}</SimpleTable.HeaderCell>
             <SimpleTable.HeaderCell>{t('Status Code')}</SimpleTable.HeaderCell>
-            {hasOrganization && (
+            {!isInternal && (
               <SimpleTable.HeaderCell>{t('Organization')}</SimpleTable.HeaderCell>
             )}
             <SimpleTable.HeaderCell>{t('Event Type')}</SimpleTable.HeaderCell>
@@ -201,7 +201,7 @@ export function RequestLog({app}: RequestLogProps) {
                 <SimpleTable.RowCell>
                   <ResponseCode code={request.responseCode} />
                 </SimpleTable.RowCell>
-                {hasOrganization && (
+                {!isInternal && (
                   <SimpleTable.RowCell>
                     <Text ellipsis>{request.organization?.name}</Text>
                   </SimpleTable.RowCell>
@@ -238,8 +238,8 @@ export function RequestLog({app}: RequestLogProps) {
 }
 
 const RequestLogTable = styled(SimpleTable, {
-  shouldForwardProp: prop => prop !== 'hasOrganization',
-})<{hasOrganization: boolean}>`
+  shouldForwardProp: prop => prop !== 'isInternal',
+})<{isInternal: boolean}>`
   grid-template-columns: ${p =>
-    p.hasOrganization ? '1fr 0.5fr 1fr 1fr 1fr' : '1fr 0.5fr 1fr 1fr'};
+    p.isInternal ? '1fr 0.5fr 1fr 1fr' : '1fr 0.5fr 1fr 1fr 1fr'};
 `;

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/requestLog.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/requestLog.tsx
@@ -1,34 +1,25 @@
-import {Fragment, useCallback, useMemo, useState} from 'react';
+import {useMemo, useState} from 'react';
 import styled from '@emotion/styled';
+import {useQuery} from '@tanstack/react-query';
 import memoize from 'lodash/memoize';
-import type moment from 'moment-timezone';
 
 import {Tag, type TagProps} from '@sentry/scraps/badge';
-import {Button} from '@sentry/scraps/button';
-import {Checkbox} from '@sentry/scraps/checkbox';
+import {Button, ButtonBar} from '@sentry/scraps/button';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
-import {Flex} from '@sentry/scraps/layout';
-import {ExternalLink} from '@sentry/scraps/link';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
+import {Switch} from '@sentry/scraps/switch';
+import {Heading, Text} from '@sentry/scraps/text';
 
+import {sentryAppWebhookRequestsApiOptions} from 'sentry/actionCreators/sentryApps';
 import {DateTime} from 'sentry/components/dateTime';
-import {EmptyMessage} from 'sentry/components/emptyMessage';
+import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
-import {Panel} from 'sentry/components/panels/panel';
-import {PanelBody} from 'sentry/components/panels/panelBody';
-import {PanelHeader} from 'sentry/components/panels/panelHeader';
-import {PanelItem} from 'sentry/components/panels/panelItem';
-import {IconChevron, IconFlag, IconOpen} from 'sentry/icons';
+import {SimpleTable} from 'sentry/components/tables/simpleTable';
+import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import type {
-  SentryApp,
-  SentryAppSchemaIssueLink,
-  SentryAppWebhookRequest,
-} from 'sentry/types/integrations';
-import type {ApiQueryKey} from 'sentry/utils/api/apiQueryKey';
-import {getApiUrl} from 'sentry/utils/api/getApiUrl';
+import type {SentryApp, SentryAppSchemaIssueLink} from 'sentry/types/integrations';
 import {shouldUse24Hours} from 'sentry/utils/dates';
-import {useApiQuery} from 'sentry/utils/queryClient';
 import {granularWebhookEvents} from 'sentry/views/settings/organizationDeveloperSettings/constants';
 
 const ALL_EVENTS = t('All Events');
@@ -86,7 +77,7 @@ const getEventTypes = memoize((app: SentryApp) => {
   return events;
 });
 
-function ResponseCode({code}: {code: number}) {
+export function ResponseCode({code}: {code: number}) {
   let variant: TagProps['variant'] = 'danger';
   if (code <= 399 && code >= 300) {
     variant = 'warning';
@@ -94,38 +85,11 @@ function ResponseCode({code}: {code: number}) {
     variant = 'success';
   }
 
-  return (
-    <Tags>
-      <StyledTag variant={variant}>{code === 0 ? 'timeout' : code}</StyledTag>
-    </Tags>
-  );
-}
-
-function TimestampLink({date, link}: {date: moment.MomentInput; link?: string}) {
-  return link ? (
-    <ExternalLink href={link}>
-      <DateTime date={date} />
-      <StyledIconOpen size="xs" />
-    </ExternalLink>
-  ) : (
-    <DateTime date={date} format={is24Hours ? 'MMM D, YYYY HH:mm:ss z' : 'll LTS z'} />
-  );
+  return <Tag variant={variant}>{code === 0 ? 'timeout' : code}</Tag>;
 }
 
 interface RequestLogProps {
   app: SentryApp;
-}
-
-function makeRequestLogQueryKey(
-  slug: string,
-  query: Record<string, string>
-): ApiQueryKey {
-  return [
-    getApiUrl('/sentry-apps/$sentryAppIdOrSlug/webhook-requests/', {
-      path: {sentryAppIdOrSlug: slug},
-    }),
-    {query},
-  ];
 }
 
 export function RequestLog({app}: RequestLogProps) {
@@ -133,68 +97,51 @@ export function RequestLog({app}: RequestLogProps) {
   const [errorsOnly, setErrorsOnly] = useState(false);
   const [eventType, setEventType] = useState(ALL_EVENTS);
 
-  const {slug} = app;
-
-  const query: any = {};
-  if (eventType !== ALL_EVENTS) {
-    query.eventType = eventType;
-  }
-  if (errorsOnly) {
-    query.errorsOnly = true;
-  }
+  const {slug, status} = app;
+  const hasOrganization = status !== 'internal';
 
   const {
     data: requests = [],
-    isLoading,
-    refetch,
-  } = useApiQuery<SentryAppWebhookRequest[]>(makeRequestLogQueryKey(slug, query), {
-    staleTime: Infinity,
-  });
+    isPending,
+    isError,
+  } = useQuery(
+    sentryAppWebhookRequestsApiOptions({
+      appSlug: slug,
+      eventType: eventType === ALL_EVENTS ? undefined : eventType,
+      errorsOnly: errorsOnly || undefined,
+    })
+  );
 
   const currentRequests = useMemo(
     () => requests.slice(currentPage * MAX_PER_PAGE, (currentPage + 1) * MAX_PER_PAGE),
     [currentPage, requests]
   );
 
-  const hasNextPage = useMemo(
-    () => (currentPage + 1) * MAX_PER_PAGE < requests.length,
-    [currentPage, requests]
-  );
-
-  const hasPrevPage = useMemo(() => currentPage > 0, [currentPage]);
+  const hasNextPage = (currentPage + 1) * MAX_PER_PAGE < requests.length;
+  const hasPrevPage = currentPage > 0;
 
   const handleChangeEventType = (newEventType: string) => {
     setEventType(newEventType);
     setCurrentPage(0);
-    refetch();
   };
 
-  const handleChangeErrorsOnly = useCallback(() => {
+  const handleChangeErrorsOnly = () => {
     setErrorsOnly(!errorsOnly);
     setCurrentPage(0);
-    refetch();
-  }, [errorsOnly, refetch]);
-
-  const handleNextPage = () => {
-    setCurrentPage(currentPage + 1);
-  };
-
-  const handlePrevPage = () => {
-    setCurrentPage(currentPage - 1);
   };
 
   return (
-    <Fragment>
-      <h5>{t('Request Log')}</h5>
+    <Stack gap="xl">
+      <Stack gap="md">
+        <Heading as="h5">{t('Request Log')}</Heading>
 
-      <div>
-        <p>
+        <Text>
           {t(
             'This log shows the status of any outgoing webhook requests from Sentry to your integration.'
           )}
-        </p>
+        </Text>
 
-        <RequestLogFilters>
+        <Flex align="center" gap="2xl">
           <CompactSelect
             trigger={triggerProps => (
               <OverlayTrigger.Button {...triggerProps}>{eventType}</OverlayTrigger.Button>
@@ -207,126 +154,92 @@ export function RequestLog({app}: RequestLogProps) {
             onChange={opt => handleChangeEventType(opt?.value)}
           />
 
-          <StyledErrorsOnlyButton onClick={handleChangeErrorsOnly}>
-            <Flex align="center" gap="md">
-              <Checkbox checked={errorsOnly} onChange={() => {}} />
-              {t('Errors Only')}
-            </Flex>
-          </StyledErrorsOnlyButton>
-        </RequestLogFilters>
-      </div>
+          <Flex as="label" align="center" gap="md" marginBottom="0">
+            <Text>{t('Errors Only')}</Text>
+            <Switch checked={errorsOnly} onChange={handleChangeErrorsOnly} />
+          </Flex>
+        </Flex>
+      </Stack>
 
-      <Panel>
-        <PanelHeader>
-          <TableLayout hasOrganization={app.status !== 'internal'}>
-            <div>{t('Time')}</div>
-            <div>{t('Status Code')}</div>
-            {app.status !== 'internal' && <div>{t('Organization')}</div>}
-            <div>{t('Event Type')}</div>
-            <div>{t('Webhook URL')}</div>
-          </TableLayout>
-        </PanelHeader>
-
-        {isLoading ? (
-          <LoadingIndicator />
-        ) : (
-          <PanelBody>
-            {currentRequests.length > 0 ? (
-              currentRequests.map((request, idx) => (
-                <PanelItem key={idx} data-test-id="request-item">
-                  <TableLayout hasOrganization={app.status !== 'internal'}>
-                    <TimestampLink date={request.date} link={request.errorUrl} />
-                    <ResponseCode code={request.responseCode} />
-                    {app.status !== 'internal' && (
-                      <div>{request.organization ? request.organization.name : null}</div>
-                    )}
-                    <div>{request.eventType}</div>
-                    <OverflowBox>{request.webhookUrl}</OverflowBox>
-                  </TableLayout>
-                </PanelItem>
-              ))
-            ) : (
-              <EmptyMessage icon={<IconFlag />}>
-                {t('No requests found in the last 30 days.')}
-              </EmptyMessage>
+      {isError ? (
+        <LoadingError />
+      ) : (
+        <RequestLogTable hasOrganization={hasOrganization}>
+          <SimpleTable.Header>
+            <SimpleTable.HeaderCell>{t('Time')}</SimpleTable.HeaderCell>
+            <SimpleTable.HeaderCell>{t('Status Code')}</SimpleTable.HeaderCell>
+            {hasOrganization && (
+              <SimpleTable.HeaderCell>{t('Organization')}</SimpleTable.HeaderCell>
             )}
-          </PanelBody>
-        )}
-      </Panel>
+            <SimpleTable.HeaderCell>{t('Event Type')}</SimpleTable.HeaderCell>
+            <SimpleTable.HeaderCell>{t('Webhook URL')}</SimpleTable.HeaderCell>
+          </SimpleTable.Header>
 
-      <PaginationButtons>
-        <Button
-          icon={<IconChevron direction="left" />}
-          onClick={handlePrevPage}
-          disabled={!hasPrevPage}
-          aria-label={t('Previous page')}
-        />
-        <Button
-          icon={<IconChevron direction="right" />}
-          onClick={handleNextPage}
-          disabled={!hasNextPage}
-          aria-label={t('Next page')}
-        />
-      </PaginationButtons>
-    </Fragment>
+          {isPending && (
+            <SimpleTable.Empty>
+              <LoadingIndicator />
+            </SimpleTable.Empty>
+          )}
+
+          {!isPending && currentRequests.length === 0 && (
+            <SimpleTable.Empty>
+              {t('No requests found in the last 30 days.')}
+            </SimpleTable.Empty>
+          )}
+
+          {!isPending &&
+            currentRequests.map((request, idx) => (
+              <SimpleTable.Row key={idx} data-test-id="request-item">
+                <SimpleTable.RowCell>
+                  <Text>
+                    <DateTime
+                      date={request.date}
+                      format={is24Hours ? 'MMM D, YYYY HH:mm:ss z' : 'll LTS z'}
+                    />
+                  </Text>
+                </SimpleTable.RowCell>
+                <SimpleTable.RowCell>
+                  <ResponseCode code={request.responseCode} />
+                </SimpleTable.RowCell>
+                {hasOrganization && (
+                  <SimpleTable.RowCell>
+                    <Text ellipsis>{request.organization?.name}</Text>
+                  </SimpleTable.RowCell>
+                )}
+                <SimpleTable.RowCell>
+                  <Text ellipsis>{request.eventType}</Text>
+                </SimpleTable.RowCell>
+                <SimpleTable.RowCell>
+                  <Text wordBreak="break-word">{request.webhookUrl}</Text>
+                </SimpleTable.RowCell>
+              </SimpleTable.Row>
+            ))}
+        </RequestLogTable>
+      )}
+
+      <Flex justify="end">
+        <ButtonBar>
+          <Button
+            icon={<IconChevron direction="left" />}
+            onClick={() => setCurrentPage(currentPage - 1)}
+            disabled={!hasPrevPage}
+            aria-label={t('Previous page')}
+          />
+          <Button
+            icon={<IconChevron direction="right" />}
+            onClick={() => setCurrentPage(currentPage + 1)}
+            disabled={!hasNextPage}
+            aria-label={t('Next page')}
+          />
+        </ButtonBar>
+      </Flex>
+    </Stack>
   );
 }
 
-const TableLayout = styled('div')<{hasOrganization: boolean}>`
-  display: grid;
-  grid-template-columns: 1fr 0.5fr ${p => (p.hasOrganization ? '1fr' : '')} 1fr 1fr;
-  grid-column-gap: ${p => p.theme.space.lg};
-  width: 100%;
-  align-items: center;
-`;
-
-const OverflowBox = styled('div')`
-  word-break: break-word;
-`;
-
-const PaginationButtons = styled('div')`
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-
-  > :first-child {
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
-  }
-
-  > :nth-child(2) {
-    margin-left: -1px;
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
-  }
-`;
-
-const RequestLogFilters = styled('div')`
-  display: flex;
-  align-items: center;
-  padding-bottom: ${p => p.theme.space.md};
-
-  > :first-child button,
-  > :first-child a {
-    border-radius: ${p => p.theme.radius.md} 0 0 ${p => p.theme.radius.md};
-  }
-`;
-
-const StyledErrorsOnlyButton = styled(Button)`
-  margin-left: -1px;
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
-`;
-
-const StyledIconOpen = styled(IconOpen)`
-  margin-left: 6px;
-  color: ${p => p.theme.tokens.content.secondary};
-`;
-
-const Tags = styled('div')`
-  margin: -${p => p.theme.space.xs};
-`;
-
-const StyledTag = styled(Tag)`
-  padding: ${p => p.theme.space.xs};
+const RequestLogTable = styled(SimpleTable, {
+  shouldForwardProp: prop => prop !== 'hasOrganization',
+})<{hasOrganization: boolean}>`
+  grid-template-columns: ${p =>
+    p.hasOrganization ? '1fr 0.5fr 1fr 1fr 1fr' : '1fr 0.5fr 1fr 1fr'};
 `;

--- a/tests/js/fixtures/sentryAppWebhookRequest.ts
+++ b/tests/js/fixtures/sentryAppWebhookRequest.ts
@@ -10,7 +10,7 @@ export function SentryAppWebhookRequestFixture(
     date: '2019-09-25T23:54:54.440Z',
     organization: {
       slug: 'test-org',
-      id: '1',
+      id: 1,
       name: 'Test Org',
     },
     responseCode: 400,


### PR DESCRIPTION
No behavior changes beyond fixing the error state and the "Errors Only" control.

- Correct `SentryAppWebhookRequest`. It was missing the five detail fields the API already returns (`project_id`, `error_id`, `request_body`, `request_headers`, `response_body`), declared `organization.id` as a string when the serializer emits an int, and carried an `errorUrl` field that only the dead legacy serializer ever set.
- Drop the unreachable `errorUrl` branch in `TimestampLink` along with the component itself, now that the field is gone.
- Migrate to `apiOptions` + `useQuery`; `useApiQuery` is deprecated. The two `refetch()` calls went with it - the filters are part of the query key, so changing one already refetches and the explicit call fired against the previous key.
- Handle the error state. A failed fetch rendered "No requests found in the last 30 days.", which is a lie; it now renders `LoadingError`.
- Replace the "Errors Only" checkbox-with-a-no-op-onChange nested inside a Button with a labelled Switch. The old control was not operable by keyboard or screen reader.
- Design system pass: `Heading`/`Text` for typography, `SimpleTable` for the hand-rolled grid and panel markup, `ButtonBar` for the pagination pill.

Before:
<img width="1630" height="972" alt="Screenshot 2026-08-07 at 9 32 43 AM" src="https://github.com/user-attachments/assets/18c5940a-e935-4161-8b65-9a6c52e140bf" />

After:
<img width="1631" height="904" alt="Screenshot 2026-08-07 at 9 32 26 AM" src="https://github.com/user-attachments/assets/336278b9-4e52-444d-8b3c-d57f841918e5" />
