### PR TITLE
ref(inbox): Show issue count even when it is 0

### DIFF
--- a/static/app/views/issueList/queries/useInboxIssueCount.tsx
+++ b/static/app/views/issueList/queries/useInboxIssueCount.tsx
@@ -1,4 +1,4 @@
-import {keepPreviousData, useQuery} from '@tanstack/react-query';
+import {useQuery} from '@tanstack/react-query';
 
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -17,7 +17,7 @@ export function useInboxIssueCount() {
       organization.features.includes('seer-added'));
   const inboxCountQuery = hasSeer ? INBOX_COUNT_QUERY : INBOX_COUNT_QUERY_NO_SEER;
 
-  const {data} = useQuery({
+  return useQuery({
     ...apiOptions.as<Record<string, number>>()(
       '/organizations/$organizationIdOrSlug/issues-count/',
       {
@@ -29,8 +29,6 @@ export function useInboxIssueCount() {
         staleTime: 180_000,
       }
     ),
-    placeholderData: keepPreviousData,
+    select: response => response.json[inboxCountQuery] ?? 0,
   });
-
-  return data?.[inboxCountQuery] ?? null;
 }

--- a/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.spec.tsx
+++ b/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.spec.tsx
@@ -79,17 +79,4 @@ describe('IssuesSecondaryNavigation', () => {
 
     expect(await screen.findByText('99+')).toBeInTheDocument();
   });
-
-  it('renders no badge when nothing is waiting', async () => {
-    mockInboxCount({
-      [inboxCountNoSeerQuery]: 0,
-    });
-
-    renderNavigation();
-
-    expect(
-      await screen.findByRole('link', {name: 'Inbox experimental'})
-    ).toBeInTheDocument();
-    expect(screen.queryByText('0')).not.toBeInTheDocument();
-  });
 });

--- a/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.tsx
@@ -11,13 +11,9 @@ import {IssueCount} from 'sentry/views/navigation/secondary/sections/issues/issu
 import {IssueViews} from 'sentry/views/navigation/secondary/sections/issues/issueViews/issueViews';
 
 function InboxCountBadge() {
-  const count = useInboxIssueCount();
+  const {data: count} = useInboxIssueCount();
 
-  if (!count) {
-    return null;
-  }
-
-  return <IssueCount count={count} />;
+  return count === undefined ? null : <IssueCount count={count} />;
 }
 
 export function IssuesSecondaryNavigation() {


### PR DESCRIPTION
Inbox count will now display even when the count is 0 (previously was hidden when falsey)
