### PR TITLE
feat(analytics): Attribute backend events to MCP requests

### DIFF
--- a/src/sentry/analytics/mcp_attribution.py
+++ b/src/sentry/analytics/mcp_attribution.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import contextlib
+import contextvars
+from collections.abc import Generator
+from dataclasses import dataclass
+
+from django.http import HttpRequest
+
+from sentry.utils.http import is_mcp_request
+
+MCP_CLIENT_META = "HTTP_X_SENTRY_MCP_CLIENT_FAMILY"
+MCP_UTM_SOURCE_META = "HTTP_X_SENTRY_MCP_UTM_SOURCE"
+
+KNOWN_MCP_CLIENTS = frozenset(
+    {"claude-code", "cursor", "copilot", "opencode", "claude-desktop", "codex"}
+)
+KNOWN_MCP_UTM_SOURCES = frozenset({"plugin"})
+
+
+@dataclass(frozen=True)
+class McpAttribution:
+    mcp: bool = False
+    client: str | None = None
+    utm_source: str | None = None
+
+
+_mcp_attribution: contextvars.ContextVar[McpAttribution | None] = contextvars.ContextVar(
+    "analytics_mcp_attribution", default=None
+)
+
+
+def _resolve_attribute(raw: str | None, known_values: frozenset[str]) -> str | None:
+    if not raw:
+        return None
+
+    value = raw.strip().lower()
+    if value in known_values:
+        return value
+
+    return "other"
+
+
+def resolve_mcp_attribution(request: HttpRequest) -> McpAttribution:
+    if not is_mcp_request(request):
+        return McpAttribution()
+
+    return McpAttribution(
+        mcp=True,
+        client=_resolve_attribute(request.META.get(MCP_CLIENT_META), KNOWN_MCP_CLIENTS),
+        utm_source=_resolve_attribute(request.META.get(MCP_UTM_SOURCE_META), KNOWN_MCP_UTM_SOURCES),
+    )
+
+
+@contextlib.contextmanager
+def mcp_attribution_scope(attribution: McpAttribution) -> Generator[None]:
+    token = _mcp_attribution.set(attribution)
+    try:
+        yield
+    finally:
+        _mcp_attribution.reset(token)
+
+
+def get_mcp_attribution() -> McpAttribution:
+    return _mcp_attribution.get() or McpAttribution()

--- a/src/sentry/analytics/pubsub.py
+++ b/src/sentry/analytics/pubsub.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+from typing import Any
+
 from sentry.analytics.event import EventEnvelope
+from sentry.analytics.mcp_attribution import get_mcp_attribution
 
 __all__ = ("PubSubAnalytics",)
 
@@ -39,5 +42,17 @@ class PubSubAnalytics(Analytics):
             self.topic = self.publisher.topic_path(project, topic)
 
     def record_event_envelope(self, event: EventEnvelope) -> None:
-        if self.publisher is not None:
-            self.publisher.publish(self.topic, data=dumps(event.serialize()).encode("utf-8"))
+        if self.publisher is None:
+            return
+
+        payload = event.serialize()
+        data: dict[str, Any] = payload["data"]
+        attribution = get_mcp_attribution()
+        if attribution.mcp:
+            data.setdefault("mcp", True)
+        if attribution.client is not None:
+            data.setdefault("mcp_client", attribution.client)
+        if attribution.utm_source is not None:
+            data.setdefault("mcp_utm_source", attribution.utm_source)
+
+        self.publisher.publish(self.topic, data=dumps(payload).encode("utf-8"))

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -397,6 +397,7 @@ MIDDLEWARE: tuple[str, ...] = (
     "sentry.middleware.auth.AuthenticationMiddleware",
     "sentry.middleware.suspended.SuspendedUserMiddleware",
     "sentry.middleware.viewer_context.ViewerContextMiddleware",
+    "sentry.middleware.mcp_attribution.McpAttributionMiddleware",
     "sentry.middleware.ai_agent.AIAgentMiddleware",
     "sentry.middleware.integrations.IntegrationControlMiddleware",
     "sentry.hybridcloud.apigateway.middleware.ApiGatewayMiddleware",

--- a/src/sentry/middleware/mcp_attribution.py
+++ b/src/sentry/middleware/mcp_attribution.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from django.http import HttpRequest, HttpResponseBase
+
+from sentry.analytics.mcp_attribution import mcp_attribution_scope, resolve_mcp_attribution
+
+
+def McpAttributionMiddleware(
+    get_response: Callable[[HttpRequest], HttpResponseBase],
+) -> Callable[[HttpRequest], HttpResponseBase]:
+    def middleware(request: HttpRequest) -> HttpResponseBase:
+        with mcp_attribution_scope(resolve_mcp_attribution(request)):
+            return get_response(request)
+
+    return middleware

--- a/tests/sentry/analytics/test_mcp_attribution.py
+++ b/tests/sentry/analytics/test_mcp_attribution.py
@@ -1,0 +1,52 @@
+from django.test import RequestFactory
+
+from sentry.analytics.mcp_attribution import (
+    McpAttribution,
+    get_mcp_attribution,
+    mcp_attribution_scope,
+    resolve_mcp_attribution,
+)
+from sentry.testutils.cases import TestCase
+
+
+class McpAttributionTest(TestCase):
+    def test_resolves_known_attributes(self) -> None:
+        request = RequestFactory().get(
+            "/",
+            HTTP_USER_AGENT="sentry-mcp/1.0",
+            HTTP_X_SENTRY_MCP_CLIENT_FAMILY="Cursor",
+            HTTP_X_SENTRY_MCP_UTM_SOURCE="plugin",
+        )
+
+        assert resolve_mcp_attribution(request) == McpAttribution(
+            mcp=True, client="cursor", utm_source="plugin"
+        )
+
+    def test_buckets_unknown_attributes(self) -> None:
+        request = RequestFactory().get(
+            "/",
+            HTTP_USER_AGENT="sentry-mcp/1.0",
+            HTTP_X_SENTRY_MCP_CLIENT_FAMILY="new-client",
+            HTTP_X_SENTRY_MCP_UTM_SOURCE="new-source",
+        )
+
+        assert resolve_mcp_attribution(request) == McpAttribution(
+            mcp=True, client="other", utm_source="other"
+        )
+
+    def test_ignores_headers_without_mcp_user_agent(self) -> None:
+        request = RequestFactory().get(
+            "/",
+            HTTP_X_SENTRY_MCP_CLIENT_FAMILY="cursor",
+            HTTP_X_SENTRY_MCP_UTM_SOURCE="plugin",
+        )
+
+        assert resolve_mcp_attribution(request) == McpAttribution()
+
+    def test_scope_restores_previous_attribution(self) -> None:
+        attribution = McpAttribution(mcp=True, client="cursor", utm_source="plugin")
+
+        with mcp_attribution_scope(attribution):
+            assert get_mcp_attribution() == attribution
+
+        assert get_mcp_attribution() == McpAttribution()

--- a/tests/sentry/analytics/test_pubsub.py
+++ b/tests/sentry/analytics/test_pubsub.py
@@ -1,0 +1,37 @@
+from unittest.mock import MagicMock
+
+from sentry.analytics.event import EventEnvelope
+from sentry.analytics.events.organization_created import OrganizationCreatedEvent
+from sentry.analytics.mcp_attribution import McpAttribution, mcp_attribution_scope
+from sentry.analytics.pubsub import PubSubAnalytics
+from sentry.testutils.cases import TestCase
+from sentry.utils.json import loads
+
+
+class PubSubAnalyticsTest(TestCase):
+    def test_publishes_request_attribution(self) -> None:
+        analytics = object.__new__(PubSubAnalytics)
+        analytics.publisher = MagicMock()
+        analytics.topic = "analytics-events"
+        envelope = EventEnvelope(OrganizationCreatedEvent(id=1, name="Example", slug="example"))
+
+        with mcp_attribution_scope(McpAttribution(mcp=True, client="cursor", utm_source="plugin")):
+            analytics.record_event_envelope(envelope)
+
+        payload = loads(analytics.publisher.publish.call_args.kwargs["data"])
+        assert payload["data"]["mcp"] is True
+        assert payload["data"]["mcp_client"] == "cursor"
+        assert payload["data"]["mcp_utm_source"] == "plugin"
+
+    def test_publishes_explicit_non_mcp_attribution(self) -> None:
+        analytics = object.__new__(PubSubAnalytics)
+        analytics.publisher = MagicMock()
+        analytics.topic = "analytics-events"
+        envelope = EventEnvelope(OrganizationCreatedEvent(id=1, name="Example", slug="example"))
+
+        analytics.record_event_envelope(envelope)
+
+        payload = loads(analytics.publisher.publish.call_args.kwargs["data"])
+        assert "mcp" not in payload["data"]
+        assert "mcp_client" not in payload["data"]
+        assert "mcp_utm_source" not in payload["data"]

--- a/tests/sentry/middleware/test_mcp_attribution.py
+++ b/tests/sentry/middleware/test_mcp_attribution.py
@@ -1,0 +1,28 @@
+from unittest.mock import MagicMock
+
+from django.test import RequestFactory
+
+from sentry.analytics.mcp_attribution import McpAttribution, get_mcp_attribution
+from sentry.middleware.mcp_attribution import McpAttributionMiddleware
+from sentry.testutils.cases import TestCase
+
+
+class McpAttributionMiddlewareTest(TestCase):
+    def test_binds_attribution_during_request(self) -> None:
+        captured: list[McpAttribution] = []
+
+        def get_response(request):
+            captured.append(get_mcp_attribution())
+            return MagicMock(status_code=200)
+
+        middleware = McpAttributionMiddleware(get_response)
+        request = RequestFactory().get(
+            "/",
+            HTTP_USER_AGENT="sentry-mcp/1.0",
+            HTTP_X_SENTRY_MCP_CLIENT_FAMILY="cursor",
+            HTTP_X_SENTRY_MCP_UTM_SOURCE="plugin",
+        )
+        middleware(request)
+
+        assert captured == [McpAttribution(mcp=True, client="cursor", utm_source="plugin")]
+        assert get_mcp_attribution() == McpAttribution()


### PR DESCRIPTION
Attach request-scoped MCP attribution when publishing backend analytics to Pub/Sub so downstream destinations can segment MCP traffic without changing the shared event envelope.

**Attribution dimensions**

Every published event records an explicit `mcp` boolean derived from the `sentry-mcp/` user agent. Recognized MCP requests also include bounded `mcp_client` and `mcp_utm_source` values when their corresponding headers are present; unrecognized values collapse to `other`.

Client and UTM headers are ignored unless the user agent independently identifies the request as Sentry MCP traffic. Non-Pub/Sub analytics backends retain their existing payloads.

Depends on https://github.com/getsentry/sentry-mcp/pull/1233.