### PR TITLE
ref(seer): add viewer_context_scope to post_process_group

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -44,6 +44,7 @@ from sentry.utils.sdk import bind_organization_context, set_current_event_projec
 from sentry.utils.sdk_crashes.sdk_crash_detection_config import build_sdk_crash_detection_configs
 from sentry.utils.services import build_instance_from_options_of_type
 from sentry.utils.tracing import start_span, trace
+from sentry.viewer_context import ActorType, ViewerContext, viewer_context_scope
 
 if TYPE_CHECKING:
     from sentry.eventstream.base import GroupState
@@ -610,41 +611,48 @@ def post_process_group(
                 Organization.objects.get_from_cache(id=event.project.organization_id),
             )
 
-        is_reprocessed = is_reprocessed_event(event.data)
-        sentry_sdk.set_tag("is_reprocessed", is_reprocessed)
-        sentry_sdk.set_attribute("is_reprocessed", is_reprocessed)
-
-        metric_tags = {}
-        if group_id:
-            group_state: GroupState = {
-                "id": group_id,
-                "is_new": is_new,
-                "is_regression": bool(is_regression),
-                "is_new_group_environment": is_new_group_environment,
-            }
-
-            group_event = update_event_group(event, group_state)
-            bind_organization_context(event.project.organization)
-            _capture_event_stats(event)
-
-            group_event.occurrence = occurrence
-
-            run_post_process_job(
-                {
-                    "event": group_event,
-                    "group_state": group_state,
-                    "is_reprocessed": is_reprocessed,
-                    "has_reappeared": bool(not group_state["is_new"]),
-                    "has_escalated": kwargs.get("has_escalated", False),
-                }
+        with viewer_context_scope(
+            ViewerContext(
+                organization_id=event.project.organization_id,
+                project_id=event.project_id,
+                actor_type=ActorType.SYSTEM,
             )
-            metric_tags["occurrence_type"] = group_event.group.issue_type.slug
+        ):
+            is_reprocessed = is_reprocessed_event(event.data)
+            sentry_sdk.set_tag("is_reprocessed", is_reprocessed)
+            sentry_sdk.set_attribute("is_reprocessed", is_reprocessed)
 
-        track_event_since_received(
-            step="end_post_process",
-            event_data=event.data,
-            tags=metric_tags,
-        )
+            metric_tags = {}
+            if group_id:
+                group_state: GroupState = {
+                    "id": group_id,
+                    "is_new": is_new,
+                    "is_regression": bool(is_regression),
+                    "is_new_group_environment": is_new_group_environment,
+                }
+
+                group_event = update_event_group(event, group_state)
+                bind_organization_context(event.project.organization)
+                _capture_event_stats(event)
+
+                group_event.occurrence = occurrence
+
+                run_post_process_job(
+                    {
+                        "event": group_event,
+                        "group_state": group_state,
+                        "is_reprocessed": is_reprocessed,
+                        "has_reappeared": bool(not group_state["is_new"]),
+                        "has_escalated": kwargs.get("has_escalated", False),
+                    }
+                )
+                metric_tags["occurrence_type"] = group_event.group.issue_type.slug
+
+            track_event_since_received(
+                step="end_post_process",
+                event_data=event.data,
+                tags=metric_tags,
+            )
 
 
 def run_post_process_job(job: PostProcessJob) -> None:


### PR DESCRIPTION
## Summary

- Set `viewer_context_scope` in `post_process_group` after project/org resolution, covering all downstream Seer calls in the post-process pipeline (`lightweight_rca_cluster`, etc.)
- Tasks dispatched from `post_process_group` (like `trigger_lightweight_rca_cluster_task`) will also get ViewerContext propagated via taskbroker's `ViewerContextHook`
- This addresses the remaining `seer.viewer_context_not_set` warnings that persisted after #121467 — all traced to `lightweight_rca_cluster` running in `task-ingest-push-worker`

Part of [AIML-3206](https://linear.app/getsentry/issue/AIML-3206) (SeerViewerContext retirement Step 2).

## Test plan

- [x] Lint and mypy pass
- [x] post_process tests require devservices (Snuba) — pre-existing, not related to this change
- [ ] After deploy: `seer.viewer_context_not_set` warnings in GCP logs should drop
- [ ] Datadog `seer.viewer_context_resolution` metric `contextvar_missing` should drop