### PR TITLE
fix(dashboards): handle discover split datasets with null widget type

### DIFF
--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -316,15 +316,16 @@ class DashboardWidgetSerializer(Serializer[DashboardWidgetResponse]):
                 or DashboardWidgetTypes.TYPE_NAMES[0]
             )
 
-        if (
-            obj.widget_type == DashboardWidgetTypes.DISCOVER
-            and obj.discover_widget_split is not None
-        ):
+        discover_widget_type = (
+            obj.widget_type == DashboardWidgetTypes.DISCOVER or obj.widget_type is None
+        )
+
+        if discover_widget_type and obj.discover_widget_split is not None:
             widget_type = DashboardWidgetTypes.get_type_name(obj.discover_widget_split)
 
         explore_urls = None
         if obj.widget_type == DashboardWidgetTypes.TRANSACTION_LIKE or (
-            obj.widget_type == DashboardWidgetTypes.DISCOVER
+            discover_widget_type
             and obj.discover_widget_split == DashboardWidgetTypes.TRANSACTION_LIKE
         ):
             try:

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -249,6 +249,16 @@ class OrganizationDashboardDetailsGetTest(OrganizationDashboardDetailsTestCase):
             detail={"layout": {"x": 0, "y": 0, "w": 1, "h": 1, "minH": 2}},
         )
 
+        DashboardWidget.objects.create(
+            dashboard=dashboard,
+            title="no split",
+            display_type=DashboardWidgetDisplayTypes.LINE_CHART,
+            widget_type=None,
+            discover_widget_split=DashboardWidgetTypes.TRANSACTION_LIKE,
+            interval="1d",
+            detail={"layout": {"x": 0, "y": 0, "w": 1, "h": 1, "minH": 2}},
+        )
+
         response = self.do_request(
             "get",
             self.url(dashboard.id),
@@ -257,6 +267,7 @@ class OrganizationDashboardDetailsGetTest(OrganizationDashboardDetailsTestCase):
         assert response.data["widgets"][0]["widgetType"] == "error-events"
         assert response.data["widgets"][1]["widgetType"] == "transaction-like"
         assert response.data["widgets"][2]["widgetType"] == "discover"
+        assert response.data["widgets"][3]["widgetType"] == "transaction-like"
 
     def test_dashboard_widget_returns_dataset_source(self) -> None:
         dashboard = Dashboard.objects.create(


### PR DESCRIPTION
There's a bug in the dashboard widget serializer that doesn't handle discover split values properly if there's a `null` widget type. From the previous migration there were some widgets that were migrated that happen to have null datasets. Their migration was done correctly but the endpoint doesn't return this properly and just defaults the dataset to discover which no longer exists and is throwing errors 😭 