### PR TITLE
chore(codeowners): we don't own all endpoints

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -656,7 +656,6 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /src/sentry/api/helpers/events.py                           @getsentry/issue-workflow
 /src/sentry/api/helpers/group_index/                        @getsentry/issue-workflow
 /src/sentry/api/helpers/source_map_helper.py                @getsentry/issue-workflow
-/src/sentry/api/endpoints/                                  @getsentry/issue-workflow
 /src/sentry/processing_errors/                              @getsentry/issue-detection-backend
 /src/sentry/api/helpers/group_index/delete.py               @getsentry/issue-detection-backend
 /src/sentry/deletions/defaults/group.py                     @getsentry/issue-detection-backend


### PR DESCRIPTION
This was a typo to begin with