### PR TITLE
Add confirmation step during vercel installs

### DIFF
--- a/static/app/components/pipeline/integrationVercel/index.spec.tsx
+++ b/static/app/components/pipeline/integrationVercel/index.spec.tsx
@@ -1,18 +1,19 @@
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {createMakeStepProps} from 'sentry/components/pipeline/testUtils';
 
 import {vercelIntegrationPipeline} from '.';
 
-const VercelInstallStep = vercelIntegrationPipeline.steps[0].component;
+const VercelOAuthStep = vercelIntegrationPipeline.steps[0].component;
+const VercelConfirmInstallStep = vercelIntegrationPipeline.steps[1].component;
 
-const makeStepProps = createMakeStepProps({totalSteps: 1});
+const makeStepProps = createMakeStepProps({totalSteps: 2});
 
-describe('VercelInstallStep', () => {
-  it('auto-advances with the pipeline state and shows a finishing message', () => {
+describe('VercelOAuthStep', () => {
+  it('auto-advances with the pipeline state and shows a connecting message', () => {
     const advance = jest.fn();
     render(
-      <VercelInstallStep
+      <VercelOAuthStep
         {...makeStepProps({
           stepData: {state: 'pipeline-sig'},
           advance,
@@ -22,15 +23,84 @@ describe('VercelInstallStep', () => {
 
     expect(advance).toHaveBeenCalledWith({state: 'pipeline-sig'});
     expect(advance).toHaveBeenCalledTimes(1);
-    expect(
-      screen.getByText('Finishing up Vercel integration installation...')
-    ).toBeInTheDocument();
+    expect(screen.getByText('Connecting to Vercel...')).toBeInTheDocument();
   });
 
   it('does not advance until stepData is available', () => {
     const advance = jest.fn();
-    render(<VercelInstallStep {...makeStepProps({stepData: null, advance})} />);
+    render(<VercelOAuthStep {...makeStepProps({stepData: null, advance})} />);
 
+    expect(advance).not.toHaveBeenCalled();
+  });
+});
+
+describe('VercelConfirmInstallStep', () => {
+  const stepData = {
+    account: 'My Team Name',
+    accountType: 'team',
+    organization: 'My Org',
+    state: 'pipeline-sig',
+  };
+
+  it('renders the account, organization, and a warning without auto-advancing', () => {
+    const advance = jest.fn();
+    render(
+      <VercelConfirmInstallStep {...makeStepProps({stepData, advance, stepIndex: 1})} />
+    );
+
+    expect(
+      screen.getByRole('heading', {name: 'Connect Vercel to Sentry'})
+    ).toBeInTheDocument();
+    expect(screen.getByText('Vercel team:')).toBeInTheDocument();
+    expect(screen.getByText('My Team Name')).toBeInTheDocument();
+    expect(screen.getByText(/My Org/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/If you did not start this installation yourself/)
+    ).toBeInTheDocument();
+
+    // No auto-advance: the user must click to confirm.
+    expect(advance).not.toHaveBeenCalled();
+  });
+
+  it('labels a personal account differently from a team', () => {
+    render(
+      <VercelConfirmInstallStep
+        {...makeStepProps({
+          stepData: {...stepData, accountType: 'user', account: 'my_user_name'},
+          stepIndex: 1,
+        })}
+      />
+    );
+
+    expect(screen.getByText('Vercel account:')).toBeInTheDocument();
+    expect(screen.getByText('my_user_name')).toBeInTheDocument();
+  });
+
+  it('advances with the pipeline state when the install button is clicked', async () => {
+    const advance = jest.fn();
+    render(
+      <VercelConfirmInstallStep {...makeStepProps({stepData, advance, stepIndex: 1})} />
+    );
+
+    await userEvent.click(
+      screen.getByRole('button', {name: 'Install Vercel integration'})
+    );
+
+    expect(advance).toHaveBeenCalledWith({state: 'pipeline-sig'});
+    expect(advance).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the install button until step data is available', () => {
+    const advance = jest.fn();
+    render(
+      <VercelConfirmInstallStep
+        {...makeStepProps({stepData: null, advance, stepIndex: 1})}
+      />
+    );
+
+    expect(
+      screen.getByRole('button', {name: 'Install Vercel integration'})
+    ).toBeDisabled();
     expect(advance).not.toHaveBeenCalled();
   });
 });

--- a/static/app/components/pipeline/integrationVercel/index.tsx
+++ b/static/app/components/pipeline/integrationVercel/index.tsx
@@ -1,24 +1,33 @@
 import {useEffect, useRef} from 'react';
 
-import {Text} from '@sentry/scraps/text';
+import {Button} from '@sentry/scraps/button';
+import {Stack} from '@sentry/scraps/layout';
+import {Heading, Text} from '@sentry/scraps/text';
 
 import type {
   PipelineDefinition,
   PipelineStepProps,
 } from 'sentry/components/pipeline/types';
 import {pipelineComplete} from 'sentry/components/pipeline/types';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import type {IntegrationWithConfig} from 'sentry/types/integrations';
 
-function VercelInstallStep({
+interface VercelConfirmStepData {
+  account: string;
+  accountType: string;
+  organization: string;
+  state: string;
+}
+
+function VercelOAuthStep({
   stepData,
   advance,
 }: PipelineStepProps<{state: string}, {state: string}>) {
   // Vercel installs are initiated from the Vercel marketplace, which performs
-  // the OAuth grant and forwards the `code` as initialData. By the time the
-  // modal opens everything the pipeline needs is already bound to state, so we
-  // advance immediately with no user interaction. The ref guards against React
-  // strict mode double-firing the effect.
+  // the OAuth grant and forwards the `code` as initialData. Exchanging it
+  // creates nothing in Sentry, so we advance immediately and let the following
+  // step confirm the resulting account. The ref guards against React strict
+  // mode double-firing the effect.
   const hasAutoAdvanced = useRef(false);
   useEffect(() => {
     if (!stepData?.state || hasAutoAdvanced.current) {
@@ -28,7 +37,59 @@ function VercelInstallStep({
     advance({state: stepData.state});
   }, [stepData, advance]);
 
-  return <Text>{t('Finishing up Vercel integration installation...')}</Text>;
+  return <Text>{t('Connecting to Vercel...')}</Text>;
+}
+
+function VercelConfirmInstallStep({
+  stepData,
+  advance,
+  isAdvancing,
+}: PipelineStepProps<VercelConfirmStepData, {state: string}>) {
+  // We do NOT auto-advance: a copied install link could connect an attacker's
+  // Vercel account to a victim's org, so we surface the account and
+  // organization and require an explicit confirmation before installing.
+  return (
+    <Stack gap="lg" align="start">
+      <Heading as="h3">{t('Connect Vercel to Sentry')}</Heading>
+
+      <Text>
+        {tct(
+          'You are about to connect a Vercel account to the [organization] Sentry organization. Deploys from this account will be able to create releases in the organization.',
+          {
+            organization: (
+              <Text as="span" bold>
+                {stepData?.organization}
+              </Text>
+            ),
+          }
+        )}
+      </Text>
+
+      {stepData?.account && (
+        <Text>
+          {stepData.accountType === 'team' ? t('Vercel team:') : t('Vercel account:')}{' '}
+          <Text as="span" bold>
+            {stepData.account}
+          </Text>
+        </Text>
+      )}
+
+      <Text variant="warning">
+        {t(
+          'If you did not start this installation yourself, do not continue. The link may have been sent to you by someone else.'
+        )}
+      </Text>
+
+      <Button
+        variant="primary"
+        busy={isAdvancing}
+        disabled={!stepData}
+        onClick={() => stepData && advance({state: stepData.state})}
+      >
+        {t('Install Vercel integration')}
+      </Button>
+    </Stack>
+  );
 }
 
 export const vercelIntegrationPipeline = {
@@ -40,8 +101,13 @@ export const vercelIntegrationPipeline = {
   steps: [
     {
       stepId: 'oauth_login',
-      shortDescription: t('Finishing installation'),
-      component: VercelInstallStep,
+      shortDescription: t('Connecting to Vercel'),
+      component: VercelOAuthStep,
+    },
+    {
+      stepId: 'vercel_confirm_install',
+      shortDescription: t('Confirming installation'),
+      component: VercelConfirmInstallStep,
     },
   ],
 } as const satisfies PipelineDefinition;

--- a/static/app/views/integrationOrganizationLink/index.spec.tsx
+++ b/static/app/views/integrationOrganizationLink/index.spec.tsx
@@ -145,8 +145,9 @@ describe('IntegrationOrganizationLink', () => {
       body: org2,
     });
 
-    // Drive the API pipeline: initialize hands back the auto-advancing Vercel
-    // step, and advancing completes the install with the new integration.
+    // Drive the API pipeline: initialize hands back the auto-advancing token
+    // exchange step, which advances to the confirmation step. Only confirming
+    // completes the install with the new integration.
     MockApiClient.addMockResponse({
       url: `/organizations/${org2.slug}/pipeline/integration_pipeline/`,
       method: 'POST',
@@ -154,7 +155,7 @@ describe('IntegrationOrganizationLink', () => {
       body: {
         step: 'oauth_login',
         stepIndex: 0,
-        totalSteps: 1,
+        totalSteps: 2,
         provider: 'vercel',
         data: {state: 'pipeline-sig'},
       },
@@ -163,6 +164,24 @@ describe('IntegrationOrganizationLink', () => {
       url: `/organizations/${org2.slug}/pipeline/integration_pipeline/`,
       method: 'POST',
       match: [MockApiClient.matchData({state: 'pipeline-sig'})],
+      body: {
+        status: 'advance',
+        step: 'vercel_confirm_install',
+        stepIndex: 1,
+        totalSteps: 2,
+        provider: 'vercel',
+        data: {
+          account: 'My Team Name',
+          accountType: 'team',
+          organization: org2.name,
+          state: 'confirm-sig',
+        },
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org2.slug}/pipeline/integration_pipeline/`,
+      method: 'POST',
+      match: [MockApiClient.matchData({state: 'confirm-sig'})],
       body: {status: 'complete', data: {id: '123', provider: {key: 'vercel'}}},
     });
 
@@ -180,6 +199,10 @@ describe('IntegrationOrganizationLink', () => {
 
     await selectEvent.select(await screen.findByRole('textbox'), org2.name);
     await userEvent.click(screen.getByRole('button', {name: 'Install Vercel'}));
+
+    await userEvent.click(
+      await screen.findByRole('button', {name: 'Install Vercel integration'})
+    );
 
     await waitFor(() => {
       expect(testableWindowLocation.assign).toHaveBeenCalledWith(


### PR DESCRIPTION
First half of adding a confirmation modal during vercel installs. Same way we do Jira now, safer. 