### PR TITLE
fix(dashboards): use default query client instead of context api for events query

### DIFF
--- a/static/app/views/dashboards/widgetCard/hooks/useErrorsAndTransactionsWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useErrorsAndTransactionsWidgetQuery.tsx
@@ -21,6 +21,7 @@ import type {DiscoverQueryRequestParams} from 'sentry/utils/discover/genericDisc
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {MEPState} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {shouldUseOnDemandMetrics} from 'sentry/utils/performance/contexts/onDemandControl';
+import {QUERY_API_CLIENT} from 'sentry/utils/queryClient';
 import type {WidgetQueryParams} from 'sentry/views/dashboards/datasetConfig/base';
 import {
   doOnDemandMetricsRequest,
@@ -186,7 +187,7 @@ export function useErrorsAndTransactionsSeriesQuery(
                 const fetchFnRef = {
                   current: () =>
                     doOnDemandMetricsRequest(
-                      context.meta?.api,
+                      QUERY_API_CLIENT,
                       onDemandRequestData,
                       filteredWidget.widgetType
                     )
@@ -198,7 +199,7 @@ export function useErrorsAndTransactionsSeriesQuery(
             }
 
             return doOnDemandMetricsRequest(
-              context.meta?.api,
+              QUERY_API_CLIENT,
               onDemandRequestData,
               filteredWidget.widgetType
             ).then(toApiResponse);

--- a/static/app/views/dashboards/widgetCard/hooks/useTransactionsWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useTransactionsWidgetQuery.tsx
@@ -22,6 +22,7 @@ import type {DiscoverQueryRequestParams} from 'sentry/utils/discover/genericDisc
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {MEPState} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {shouldUseOnDemandMetrics} from 'sentry/utils/performance/contexts/onDemandControl';
+import {QUERY_API_CLIENT} from 'sentry/utils/queryClient';
 import type {WidgetQueryParams} from 'sentry/views/dashboards/datasetConfig/base';
 import {doOnDemandMetricsRequest} from 'sentry/views/dashboards/datasetConfig/errorsAndTransactions';
 import {TransactionsConfig} from 'sentry/views/dashboards/datasetConfig/transactions';
@@ -165,7 +166,7 @@ export function useTransactionsSeriesQuery(
                 const fetchFnRef = {
                   current: () =>
                     doOnDemandMetricsRequest(
-                      context.meta?.api,
+                      QUERY_API_CLIENT,
                       onDemandRequestData,
                       filteredWidget.widgetType
                     )
@@ -177,7 +178,7 @@ export function useTransactionsSeriesQuery(
             }
 
             return doOnDemandMetricsRequest(
-              context.meta?.api,
+              QUERY_API_CLIENT,
               onDemandRequestData,
               filteredWidget.widgetType
             ).then(toApiResponse);


### PR DESCRIPTION
Since we migrated we couldn't really see this issue as it mainly pertains to discover and transactions widgets. Basically with the deprecation of `api.requestPromise` query functions, some of the querying wasn't updated. Within dashboards, the on demand or metrics enhanced queries use this style of querying by using the api in the context meta. Since that's not used anymore i replaced it with the default `QUERY_API_CLIENT`. This won't be needed much longer fwiw since we're gonna be able to nuke all of this but for the time being it's good to make sure that it works!

| Before | After |
|--------|--------|
| <img width="1228" height="528" alt="image" src="https://github.com/user-attachments/assets/b3241af9-5e0e-47a8-b7f2-6003004f03c2" /> | <img width="1240" height="534" alt="image" src="https://github.com/user-attachments/assets/d1677864-f329-4ff7-a36c-767a66fd61df" /> | 