### PR TITLE
feat: Add leading icon to TextCopyInput

### DIFF
--- a/static/app/components/textCopyInput.spec.tsx
+++ b/static/app/components/textCopyInput.spec.tsx
@@ -1,6 +1,7 @@
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {TextCopyInput} from 'sentry/components/textCopyInput';
+import {IconTerminal} from 'sentry/icons';
 
 describe('TextCopyInput', () => {
   beforeEach(() => {
@@ -19,6 +20,16 @@ describe('TextCopyInput', () => {
     await userEvent.click(button);
 
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith('Text to Copy');
+  });
+
+  it('renders a leading icon', () => {
+    render(
+      <TextCopyInput icon={<IconTerminal aria-label="Terminal" />}>
+        Text to Copy
+      </TextCopyInput>
+    );
+
+    expect(screen.getByRole('img', {name: 'Terminal'})).toBeInTheDocument();
   });
 
   it('selects text in input on click', async () => {

--- a/static/app/components/textCopyInput.tsx
+++ b/static/app/components/textCopyInput.tsx
@@ -15,6 +15,10 @@ interface Props extends Omit<InputProps, 'onCopy'> {
   children: string;
   className?: string;
   disabled?: boolean;
+  /**
+   * Icon displayed before the copied text.
+   */
+  icon?: React.ReactNode;
   onCopy?: (value: string) => void;
   /**
    * Always show the ending of a long overflowing text in input
@@ -26,6 +30,7 @@ interface Props extends Omit<InputProps, 'onCopy'> {
 export function TextCopyInput({
   className,
   disabled,
+  icon,
   style,
   onCopy,
   rtl,
@@ -61,6 +66,9 @@ export function TextCopyInput({
 
   return (
     <InputGroup className={className}>
+      {icon && (
+        <InputGroup.LeadingItems disablePointerEvents>{icon}</InputGroup.LeadingItems>
+      )}
       <StyledInput
         id={textNodeId}
         readOnly


### PR DESCRIPTION
Adds an optional leading icon slot to `TextCopyInput` using the existing `InputGroup.LeadingItems` primitive. This lets copyable command fields communicate their content type without one-off wrappers or styling.

Includes focused coverage for rendering the icon.