### PR TITLE
chore: exclude bin/ from pre-push mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,7 @@ repos:
         language: system
         stages: [pre-push]
         types: [python]
+        exclude: ^bin/
         require_serial: true
       - id: lint-requirements
         name: lint-requirements


### PR DESCRIPTION
## Summary
- Add `exclude: ^bin/` to the pre-push mypy hook so `bin/` paths (including extensionless shebang scripts) are not passed to mypy.
- Avoids `__main__` collisions from scripts that CI discovery never typechecks.

## Test plan
- [ ] `SENTRY_MYPY_PRE_PUSH=1 .venv/bin/prek run mypy --files bin/mock-event --stage pre-push` skips
- [ ] `SENTRY_MYPY_PRE_PUSH=1 .venv/bin/prek run mypy --files src/sentry/__init__.py --stage pre-push` still runs mypy
- [ ] Pushing changes under `bin/` no longer fails mypy solely due to those paths


Made with [Cursor](https://cursor.com)