### PR TITLE
fix(release): use spans dataset for transaction table

### DIFF
--- a/static/app/components/discover/transactionsList.spec.tsx
+++ b/static/app/components/discover/transactionsList.spec.tsx
@@ -3,6 +3,7 @@ import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrar
 
 import {TransactionsList} from 'sentry/components/discover/transactionsList';
 import {EventView} from 'sentry/utils/discover/eventView';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {OrganizationContext} from 'sentry/utils/organizationContext';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 
@@ -174,6 +175,66 @@ describe('TransactionsList', () => {
 
       const gridCells = screen.getAllByTestId('grid-cell');
       expect(gridCells.map(e => e.textContent)).toEqual(['/a', '100', '/b', '1,000']);
+    });
+
+    it('links "Open in Explore" to Explore > Traces when Discover is deprecated', async () => {
+      initialize({
+        organization: {
+          features: [
+            'discover-basic',
+            'deprecate-discover',
+            'discover-saved-queries-deprecation',
+          ],
+        },
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/events/`,
+        body: {
+          meta: {fields: {transaction: 'string', 'failure_count()': 'number'}},
+          data: [{transaction: '/a', 'failure_count()': 1}],
+        },
+      });
+      const spansEventView = EventView.fromSavedQuery({
+        id: '',
+        name: 'test query',
+        version: 2,
+        fields: ['transaction', 'failure_count()', 'epm()', 'p50()'],
+        query: 'is_transaction:true release:"1.0" failure_count():>0',
+        orderby: '-failure_count',
+        projects: [Number(project.id)],
+        dataset: DiscoverDatasets.SPANS,
+      });
+
+      render(
+        <WrapperComponent
+          api={api}
+          location={location}
+          organization={organization}
+          eventView={spansEventView}
+          selected={{sort: {kind: 'desc', field: 'failure_count'}, value: 'count'}}
+          options={options}
+          handleDropdownChange={handleDropdownChange}
+        />
+      );
+
+      expect(await screen.findByTestId('transactions-table')).toBeInTheDocument();
+
+      const link = screen.getByRole('button', {name: 'Open in Explore'});
+      const href = link.getAttribute('href')!;
+      expect(href).toContain('/organizations/org-slug/explore/traces/');
+      expect(href).toContain('mode=aggregate');
+
+      const query = new URLSearchParams(href.split('?')[1]);
+      expect(query.get('groupBy')).toBe('transaction');
+      // Aggregate HAVING conditions are dropped; row-level filters are kept.
+      expect(query.get('query')).toBe('is_transaction:true release:1.0');
+      // Columns stay in the list's field order; `p50()` gains its required
+      // column argument for the spans dataset.
+      expect(query.getAll('visualize')).toEqual([
+        JSON.stringify({yAxes: ['failure_count()', 'epm()', 'p50(span.duration)']}),
+      ]);
+      // The list's sort is preserved via the aggregate sort param.
+      expect(query.get('aggregateSort')).toBe('-failure_count()');
     });
 
     it('renders a trend view', async () => {

--- a/static/app/components/discover/transactionsList.tsx
+++ b/static/app/components/discover/transactionsList.tsx
@@ -17,7 +17,9 @@ import type {TableDataRow} from 'sentry/utils/discover/discoverQuery';
 import {DiscoverQuery} from 'sentry/utils/discover/discoverQuery';
 import type {EventView} from 'sentry/utils/discover/eventView';
 import type {Sort} from 'sentry/utils/discover/fields';
+import {isAggregateField, parseFunction} from 'sentry/utils/discover/fields';
 import {SavedQueryDatasets} from 'sentry/utils/discover/types';
+import {getFieldDefinition} from 'sentry/utils/fields';
 import {TrendsEventsDiscoverQuery} from 'sentry/utils/performance/trends/trendsDiscoverQuery';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
@@ -27,6 +29,8 @@ import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
 import type {Actions} from 'sentry/views/discover/table/cellAction';
 import type {TableColumn} from 'sentry/views/discover/table/types';
 import {decodeColumnOrder, getDiscoverDeprecation} from 'sentry/views/discover/utils';
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+import {getExploreUrl} from 'sentry/views/explore/utils';
 import type {DomainView, DomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 import type {SpanOperationBreakdownFilter} from 'sentry/views/performance/transactionSummary/filter';
 import {mapShowTransactionToPercentile} from 'sentry/views/performance/transactionSummary/transactionEvents/utils';
@@ -38,6 +42,65 @@ import type {TrendChangeType, TrendView} from 'sentry/views/performance/trends/t
 import {TransactionsTable} from './transactionsTable';
 
 const DEFAULT_TRANSACTION_LIMIT = 5;
+
+/**
+ * Normalize an aggregate yAxis so it carries an explicit column argument where
+ * the spans dataset requires one (e.g. `p50()` -> `p50(span.duration)`).
+ */
+function normalizeExploreYAxis(yAxis: string): string {
+  const parsed = parseFunction(yAxis);
+  if (!parsed || parsed.arguments.length > 0) {
+    return yAxis;
+  }
+
+  const definition = getFieldDefinition(parsed.name, 'span');
+  const columnParameter = definition?.parameters?.find(
+    parameter => parameter.kind === 'column'
+  );
+  if (columnParameter?.defaultValue) {
+    return `${parsed.name}(${columnParameter.defaultValue})`;
+  }
+
+  return yAxis;
+}
+
+/**
+ * Build an Explore > Traces URL that reproduces the aggregate view described by
+ * the given (spans dataset) EventView.
+ */
+function getExploreTarget(eventView: EventView, organization: Organization): string {
+  const fields = eventView.getFields();
+  const groupBy = fields.filter(field => !isAggregateField(field));
+  const yAxes = fields.filter(isAggregateField).map(normalizeExploreYAxis);
+
+  const sort = eventView.sorts[0];
+  let aggregateSort: string | undefined;
+  if (sort) {
+    const sortedYAxis = yAxes.find(yAxis => parseFunction(yAxis)?.name === sort.field);
+    if (sortedYAxis) {
+      aggregateSort = `${sort.kind === 'desc' ? '-' : ''}${sortedYAxis}`;
+    }
+  }
+
+  // Explore's search cannot express aggregate (HAVING) conditions such as
+  // `epm():>0.01`.
+  const search = new MutableSearch(eventView.query);
+  Object.keys(search.filters).forEach(key => {
+    if (isAggregateField(key)) {
+      search.removeFilter(key);
+    }
+  });
+
+  return getExploreUrl({
+    organization,
+    selection: eventView.getPageFilters(),
+    mode: Mode.AGGREGATE,
+    query: search.formatString(),
+    groupBy,
+    visualize: yAxes.length > 0 ? [{yAxes}] : undefined,
+    aggregateSort,
+  });
+}
 
 export type DropdownOption = {
   /**
@@ -315,13 +378,17 @@ class _TransactionsList extends Component<Props> {
             <GuideAnchor target="release_transactions_open_in_discover">
               <DiscoverButton
                 onClick={handleOpenInDiscoverClick}
-                to={this.generateDiscoverEventView().getResultsViewUrlTarget(
-                  organization,
-                  false,
-                  hasDatasetSelector(organization)
-                    ? SavedQueryDatasets.TRANSACTIONS
-                    : undefined
-                )}
+                to={
+                  getDiscoverDeprecation(organization)
+                    ? getExploreTarget(this.generateDiscoverEventView(), organization)
+                    : this.generateDiscoverEventView().getResultsViewUrlTarget(
+                        organization,
+                        false,
+                        hasDatasetSelector(organization)
+                          ? SavedQueryDatasets.TRANSACTIONS
+                          : undefined
+                      )
+                }
                 size="xs"
                 data-test-id="discover-open"
               >

--- a/static/app/views/explore/releases/detail/overview/index.tsx
+++ b/static/app/views/explore/releases/detail/overview/index.tsx
@@ -29,6 +29,7 @@ import {getUtcDateString} from 'sentry/utils/dates';
 import {DemoTourElement, DemoTourStep} from 'sentry/utils/demoMode/demoTours';
 import type {TableDataRow} from 'sentry/utils/discover/discoverQuery';
 import {EventView} from 'sentry/utils/discover/eventView';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useApi} from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -67,7 +68,6 @@ export enum TransactionsListOption {
   FAILURE_COUNT = 'failure_count',
   TPM = 'tpm',
   SLOW = 'slow',
-  SLOW_LCP = 'slow_lcp',
   REGRESSION = 'regression',
   IMPROVEMENT = 'improved',
 }
@@ -174,7 +174,7 @@ function ReleaseOverview() {
       id: undefined,
       version: 2,
       name: `Release ${formatVersion(version)}`,
-      query: `event.type:transaction ${searchReleaseVersion(version)}`,
+      query: `is_transaction:true ${searchReleaseVersion(version)}`,
       fields: ['transaction', 'failure_count()', 'epm()', 'p50()'],
       orderby: '-failure_count',
       range: statsPeriod || undefined,
@@ -182,25 +182,19 @@ function ReleaseOverview() {
       projects: [projectId],
       start: start ? getUtcDateString(start) : undefined,
       end: end ? getUtcDateString(end) : undefined,
+      dataset: DiscoverDatasets.SPANS,
     };
 
     switch (selectedSort.value) {
-      case TransactionsListOption.SLOW_LCP:
-        return EventView.fromSavedQuery({
-          ...baseQuery,
-          query: `event.type:transaction release:${version} epm():>0.01 has:measurements.lcp`,
-          fields: ['transaction', 'failure_count()', 'epm()', 'p75(measurements.lcp)'],
-          orderby: 'p75_measurements_lcp',
-        });
       case TransactionsListOption.SLOW:
         return EventView.fromSavedQuery({
           ...baseQuery,
-          query: `event.type:transaction release:${version} epm():>0.01`,
+          query: `is_transaction:true release:${version} epm():>0.01`,
         });
       case TransactionsListOption.FAILURE_COUNT:
         return EventView.fromSavedQuery({
           ...baseQuery,
-          query: `event.type:transaction release:${version} failure_count():>0`,
+          query: `is_transaction:true release:${version} failure_count():>0`,
         });
       default:
         return EventView.fromSavedQuery(baseQuery);
@@ -276,10 +270,7 @@ function ReleaseOverview() {
   const {environments} = selection;
   const {selectedSort, sortOptions} = getTransactionsListSort(location);
   const releaseEventView = getReleaseEventView(project.id, selectedSort);
-  const titles =
-    selectedSort.value === TransactionsListOption.SLOW_LCP
-      ? [t('transaction'), t('failure_count()'), t('tpm()'), t('p75(lcp)')]
-      : [t('transaction'), t('failure_count()'), t('tpm()'), t('p50()')];
+  const titles = [t('transaction'), t('failure_count()'), t('tpm()'), t('p50()')];
   const releaseTrendView = getReleaseTrendView(project.id, releaseMeta.released);
 
   const generateLink = {
@@ -522,11 +513,6 @@ function getDropdownOptions(): DropdownOption[] {
       sort: {kind: 'desc', field: 'p50'},
       value: TransactionsListOption.SLOW,
       label: t('Slow Transactions'),
-    },
-    {
-      sort: {kind: 'desc', field: 'p75_measurements_lcp'},
-      value: TransactionsListOption.SLOW_LCP,
-      label: t('Slow LCP'),
     },
     {
       sort: {kind: 'desc', field: 'trend_percentage()'},

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -63,6 +63,7 @@ import {makeTracesPathname} from 'sentry/views/traces/pathnames';
 export interface GetExploreUrlArgs {
   organization: Organization;
   aggregateField?: Array<GroupBy | BaseVisualize>;
+  aggregateSort?: string;
   caseInsensitive?: CaseInsensitive;
   chartSelection?: ChartSelectionQueryParam;
   crossEvents?: CrossEvent[];
@@ -91,6 +92,7 @@ export function getExploreUrl({
   query,
   groupBy,
   sort,
+  aggregateSort,
   field,
   id,
   table,
@@ -115,6 +117,7 @@ export function getExploreUrl({
     visualize: visualize?.map(v => JSON.stringify(v)),
     groupBy,
     sort,
+    aggregateSort,
     field,
     utc,
     id,


### PR DESCRIPTION
The release details page has a table of transactions with various sorts (Failing Transactions, Frequent Transactions, etc). This used the deprecated `discover` dataset with `event.type:transaction`. Use the `spans` dataset with `is_transaction:true` instead.

⚠️ The LCP search isn't supported with the `spans` dataset, so this drops the "Slow LCP" sort. We did the same thing on the Transaction Summary page when converting it to use `spans`.

<img width="1281" height="291" alt="Screenshot 2026-08-07 at 16 26 00" src="https://github.com/user-attachments/assets/782da984-6aa3-4b59-9101-f35fd7ae685f" />

Fixes BROWSE-677.
