### PR TITLE
feat(metrics): add support in the data export processor

### DIFF
--- a/src/sentry/data_export/endpoints/data_export.py
+++ b/src/sentry/data_export/endpoints/data_export.py
@@ -19,7 +19,6 @@ from sentry.data_export.base import ExportError, ExportQueryType
 from sentry.data_export.models import ExportedData
 from sentry.data_export.processors.discover import DiscoverProcessor
 from sentry.data_export.processors.explore import (
-    FULL_EXPORT_TRACE_ITEM_DATASETS,
     SUPPORTED_TRACE_ITEM_DATASETS,
     ExploreProcessor,
 )
@@ -84,17 +83,13 @@ class DataExportQuerySerializer(serializers.Serializer[dict[str, Any]]):
             ExportQueryType.EXPLORE_STR,
             ExportQueryType.TRACE_ITEM_FULL_EXPORT_STR,
         ):
-            supported_datasets = (
-                FULL_EXPORT_TRACE_ITEM_DATASETS
-                if query_type == ExportQueryType.TRACE_ITEM_FULL_EXPORT_STR
-                else SUPPORTED_TRACE_ITEM_DATASETS.keys()
-            )
             if not dataset:
+                supported = ", ".join(sorted(SUPPORTED_TRACE_ITEM_DATASETS))
                 raise serializers.ValidationError(
-                    f"Please specify dataset. Supported datasets for this query type are {str(supported_datasets)}."
+                    f"Please specify dataset. Supported datasets for this query type are {supported}."
                 )
 
-            if dataset not in supported_datasets:
+            if dataset not in SUPPORTED_TRACE_ITEM_DATASETS:
                 raise serializers.ValidationError(f"{dataset} is not supported for exports")
         query_info["dataset"] = dataset
         return query_info

--- a/src/sentry/data_export/endpoints/data_export.py
+++ b/src/sentry/data_export/endpoints/data_export.py
@@ -19,6 +19,7 @@ from sentry.data_export.base import ExportError, ExportQueryType
 from sentry.data_export.models import ExportedData
 from sentry.data_export.processors.discover import DiscoverProcessor
 from sentry.data_export.processors.explore import (
+    FULL_EXPORT_TRACE_ITEM_DATASETS,
     SUPPORTED_TRACE_ITEM_DATASETS,
     ExploreProcessor,
 )
@@ -83,12 +84,17 @@ class DataExportQuerySerializer(serializers.Serializer[dict[str, Any]]):
             ExportQueryType.EXPLORE_STR,
             ExportQueryType.TRACE_ITEM_FULL_EXPORT_STR,
         ):
+            supported_datasets = (
+                FULL_EXPORT_TRACE_ITEM_DATASETS
+                if query_type == ExportQueryType.TRACE_ITEM_FULL_EXPORT_STR
+                else SUPPORTED_TRACE_ITEM_DATASETS.keys()
+            )
             if not dataset:
                 raise serializers.ValidationError(
-                    f"Please specify dataset. Supported datasets for this query type are {str(SUPPORTED_TRACE_ITEM_DATASETS.keys())}."
+                    f"Please specify dataset. Supported datasets for this query type are {str(supported_datasets)}."
                 )
 
-            if dataset not in SUPPORTED_TRACE_ITEM_DATASETS:
+            if dataset not in supported_datasets:
                 raise serializers.ValidationError(f"{dataset} is not supported for exports")
         query_info["dataset"] = dataset
         return query_info

--- a/src/sentry/data_export/processors/explore.py
+++ b/src/sentry/data_export/processors/explore.py
@@ -102,9 +102,6 @@ class ExploreProcessor:
                 use_aggregate_conditions=use_aggregate_conditions,
             )
         elif self.scoped_dataset == TraceMetrics:
-            # The metric being exported is encoded in the aggregate arguments
-            # (e.g. `sum(value,llm.token_usage,distribution,-)`), which the config recovers
-            # from the selected columns, so there is no separate metric to pass here.
             self.config = TraceMetricsSearchResolverConfig(
                 metric=None,
                 use_aggregate_conditions=use_aggregate_conditions,

--- a/src/sentry/data_export/processors/explore.py
+++ b/src/sentry/data_export/processors/explore.py
@@ -6,7 +6,7 @@ from sentry_protos.snuba.v1.endpoint_trace_items_pb2 import (
     ExportTraceItemsRequest,
     ExportTraceItemsResponse,
 )
-from sentry_protos.snuba.v1.request_common_pb2 import PageToken, RequestMeta, TraceItemType
+from sentry_protos.snuba.v1.request_common_pb2 import PageToken, RequestMeta
 from sentry_protos.snuba.v1.trace_item_filter_pb2 import TraceItemFilter
 
 from sentry.api.utils import get_date_range_from_params
@@ -16,9 +16,12 @@ from sentry.data_export.writers import OutputMode
 from sentry.models.environment import Environment
 from sentry.models.organization import Organization
 from sentry.models.project import Project
+from sentry.search.eap.constants import SUPPORTED_TRACE_ITEM_TYPE_MAP
 from sentry.search.eap.ourlogs.definitions import OURLOG_DEFINITIONS
 from sentry.search.eap.resolver import SearchResolver
 from sentry.search.eap.spans.definitions import SPAN_DEFINITIONS
+from sentry.search.eap.trace_metrics.config import TraceMetricsSearchResolverConfig
+from sentry.search.eap.trace_metrics.definitions import TRACE_METRICS_DEFINITIONS
 from sentry.search.eap.types import (
     EAPResponse,
     FieldsACL,
@@ -30,6 +33,7 @@ from sentry.snuba.ourlogs import OurLogs
 from sentry.snuba.referrer import Referrer
 from sentry.snuba.rpc_dataset_common import TableQuery
 from sentry.snuba.spans_rpc import Spans
+from sentry.snuba.trace_metrics import TraceMetrics
 from sentry.utils.snuba_rpc import export_logs_rpc
 from sentry.utils.tracing import set_span_data, start_span
 
@@ -38,11 +42,23 @@ logger = logging.getLogger(__name__)
 SUPPORTED_TRACE_ITEM_DATASETS = {
     "spans": Spans,
     "logs": OurLogs,
+    "tracemetrics": TraceMetrics,
 }
+
+# The wide JSONL export goes through Snuba's `EndpointExportTraceItems`, which has not been
+# verified against every trace item type, so it stays a subset of the datasets above.
+FULL_EXPORT_TRACE_ITEM_DATASETS = ("spans", "logs")
 
 DEFINITIONS_MAP = {
     Spans: SPAN_DEFINITIONS,
     OurLogs: OURLOG_DEFINITIONS,
+    TraceMetrics: TRACE_METRICS_DEFINITIONS,
+}
+
+DATASET_TO_TRACE_ITEM_TYPE = {
+    "spans": SupportedTraceItemType.SPANS,
+    "logs": SupportedTraceItemType.LOGS,
+    "tracemetrics": SupportedTraceItemType.TRACEMETRICS,
 }
 
 
@@ -75,16 +91,8 @@ class ExploreProcessor:
 
         dataset: str = explore_query["dataset"]
         self.scoped_dataset = SUPPORTED_TRACE_ITEM_DATASETS[dataset]
-        self.trace_item_type = (
-            TraceItemType.TRACE_ITEM_TYPE_SPAN
-            if dataset == "spans"
-            else TraceItemType.TRACE_ITEM_TYPE_LOG
-        )
-        self._supported_trace_item_type = (
-            SupportedTraceItemType.LOGS
-            if self.trace_item_type == TraceItemType.TRACE_ITEM_TYPE_LOG
-            else SupportedTraceItemType.SPANS
-        )
+        self._supported_trace_item_type = DATASET_TO_TRACE_ITEM_TYPE[dataset]
+        self.trace_item_type = SUPPORTED_TRACE_ITEM_TYPE_MAP[self._supported_trace_item_type]
 
         use_aggregate_conditions = explore_query.get("allowAggregateConditions", "1") == "1"
         disable_extrapolation = explore_query.get("disableAggregateExtrapolation", "0") == "1"
@@ -92,6 +100,16 @@ class ExploreProcessor:
         if self.scoped_dataset == OurLogs:
             self.config = SearchResolverConfig(
                 use_aggregate_conditions=use_aggregate_conditions,
+            )
+        elif self.scoped_dataset == TraceMetrics:
+            # The metric being exported is encoded in the aggregate arguments
+            # (e.g. `sum(value,llm.token_usage,distribution,-)`), which the config recovers
+            # from the selected columns, so there is no separate metric to pass here.
+            self.config = TraceMetricsSearchResolverConfig(
+                metric=None,
+                use_aggregate_conditions=use_aggregate_conditions,
+                auto_fields=True,
+                disable_aggregate_extrapolation=disable_extrapolation,
             )
         else:
             self.config = SearchResolverConfig(

--- a/src/sentry/data_export/processors/explore.py
+++ b/src/sentry/data_export/processors/explore.py
@@ -45,8 +45,6 @@ SUPPORTED_TRACE_ITEM_DATASETS = {
     "tracemetrics": TraceMetrics,
 }
 
-# The wide JSONL export goes through Snuba's `EndpointExportTraceItems`, which has not been
-# verified against every trace item type, so it stays a subset of the datasets above.
 FULL_EXPORT_TRACE_ITEM_DATASETS = ("spans", "logs")
 
 DEFINITIONS_MAP = {

--- a/src/sentry/data_export/processors/explore.py
+++ b/src/sentry/data_export/processors/explore.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Any, cast
+from dataclasses import dataclass
+from typing import Any, Protocol, cast
 
 from sentry_protos.snuba.v1.downsampled_storage_pb2 import DownsampledStorageConfig
 from sentry_protos.snuba.v1.endpoint_trace_items_pb2 import (
@@ -16,6 +17,7 @@ from sentry.data_export.writers import OutputMode
 from sentry.models.environment import Environment
 from sentry.models.organization import Organization
 from sentry.models.project import Project
+from sentry.search.eap.columns import ColumnDefinitions
 from sentry.search.eap.constants import SUPPORTED_TRACE_ITEM_TYPE_MAP
 from sentry.search.eap.ourlogs.definitions import OURLOG_DEFINITIONS
 from sentry.search.eap.resolver import SearchResolver
@@ -31,7 +33,7 @@ from sentry.search.eap.types import (
 from sentry.search.events.types import SAMPLING_MODES, SnubaParams
 from sentry.snuba.ourlogs import OurLogs
 from sentry.snuba.referrer import Referrer
-from sentry.snuba.rpc_dataset_common import TableQuery
+from sentry.snuba.rpc_dataset_common import RPCBase, TableQuery
 from sentry.snuba.spans_rpc import Spans
 from sentry.snuba.trace_metrics import TraceMetrics
 from sentry.utils.snuba_rpc import export_logs_rpc
@@ -39,24 +41,70 @@ from sentry.utils.tracing import set_span_data, start_span
 
 logger = logging.getLogger(__name__)
 
+
+def _spans_config(
+    *, use_aggregate_conditions: bool, disable_extrapolation: bool
+) -> SearchResolverConfig:
+    return SearchResolverConfig(
+        auto_fields=True,
+        use_aggregate_conditions=use_aggregate_conditions,
+        fields_acl=FieldsACL(functions={"time_spent_percentage"}),
+        disable_aggregate_extrapolation=disable_extrapolation,
+    )
+
+
+def _logs_config(
+    *, use_aggregate_conditions: bool, disable_extrapolation: bool
+) -> SearchResolverConfig:
+    # Logs have never forwarded disable_extrapolation; preserved as-is so extracting these
+    # builders stays behaviour-neutral.
+    return SearchResolverConfig(use_aggregate_conditions=use_aggregate_conditions)
+
+
+def _trace_metrics_config(
+    *, use_aggregate_conditions: bool, disable_extrapolation: bool
+) -> SearchResolverConfig:
+    return TraceMetricsSearchResolverConfig(
+        metric=None,
+        use_aggregate_conditions=use_aggregate_conditions,
+        auto_fields=True,
+        disable_aggregate_extrapolation=disable_extrapolation,
+    )
+
+
+class ConfigBuilder(Protocol):
+    def __call__(
+        self, *, use_aggregate_conditions: bool, disable_extrapolation: bool
+    ) -> SearchResolverConfig: ...
+
+
+@dataclass(frozen=True, kw_only=True)
+class TraceItemExportDataset:
+    scoped_dataset: type[RPCBase]
+    definitions: ColumnDefinitions
+    trace_item_type: SupportedTraceItemType
+    build_config: ConfigBuilder
+
+
 SUPPORTED_TRACE_ITEM_DATASETS = {
-    "spans": Spans,
-    "logs": OurLogs,
-    "tracemetrics": TraceMetrics,
-}
-
-FULL_EXPORT_TRACE_ITEM_DATASETS = ("spans", "logs")
-
-DEFINITIONS_MAP = {
-    Spans: SPAN_DEFINITIONS,
-    OurLogs: OURLOG_DEFINITIONS,
-    TraceMetrics: TRACE_METRICS_DEFINITIONS,
-}
-
-DATASET_TO_TRACE_ITEM_TYPE = {
-    "spans": SupportedTraceItemType.SPANS,
-    "logs": SupportedTraceItemType.LOGS,
-    "tracemetrics": SupportedTraceItemType.TRACEMETRICS,
+    "spans": TraceItemExportDataset(
+        scoped_dataset=Spans,
+        definitions=SPAN_DEFINITIONS,
+        trace_item_type=SupportedTraceItemType.SPANS,
+        build_config=_spans_config,
+    ),
+    "logs": TraceItemExportDataset(
+        scoped_dataset=OurLogs,
+        definitions=OURLOG_DEFINITIONS,
+        trace_item_type=SupportedTraceItemType.LOGS,
+        build_config=_logs_config,
+    ),
+    "tracemetrics": TraceItemExportDataset(
+        scoped_dataset=TraceMetrics,
+        definitions=TRACE_METRICS_DEFINITIONS,
+        trace_item_type=SupportedTraceItemType.TRACEMETRICS,
+        build_config=_trace_metrics_config,
+    ),
 }
 
 
@@ -88,36 +136,20 @@ class ExploreProcessor:
             self.snuba_params.environments = self.environments
 
         dataset: str = explore_query["dataset"]
-        self.scoped_dataset = SUPPORTED_TRACE_ITEM_DATASETS[dataset]
-        self._supported_trace_item_type = DATASET_TO_TRACE_ITEM_TYPE[dataset]
+        export_dataset = SUPPORTED_TRACE_ITEM_DATASETS[dataset]
+        self.scoped_dataset = export_dataset.scoped_dataset
+        self._supported_trace_item_type = export_dataset.trace_item_type
         self.trace_item_type = SUPPORTED_TRACE_ITEM_TYPE_MAP[self._supported_trace_item_type]
 
-        use_aggregate_conditions = explore_query.get("allowAggregateConditions", "1") == "1"
-        disable_extrapolation = explore_query.get("disableAggregateExtrapolation", "0") == "1"
-
-        if self.scoped_dataset == OurLogs:
-            self.config = SearchResolverConfig(
-                use_aggregate_conditions=use_aggregate_conditions,
-            )
-        elif self.scoped_dataset == TraceMetrics:
-            self.config = TraceMetricsSearchResolverConfig(
-                metric=None,
-                use_aggregate_conditions=use_aggregate_conditions,
-                auto_fields=True,
-                disable_aggregate_extrapolation=disable_extrapolation,
-            )
-        else:
-            self.config = SearchResolverConfig(
-                auto_fields=True,
-                use_aggregate_conditions=use_aggregate_conditions,
-                fields_acl=FieldsACL(functions={"time_spent_percentage"}),
-                disable_aggregate_extrapolation=disable_extrapolation,
-            )
+        self.config = export_dataset.build_config(
+            use_aggregate_conditions=explore_query.get("allowAggregateConditions", "1") == "1",
+            disable_extrapolation=explore_query.get("disableAggregateExtrapolation", "0") == "1",
+        )
 
         self.search_resolver = SearchResolver(
             params=self.snuba_params,
             config=self.config,
-            definitions=DEFINITIONS_MAP[self.scoped_dataset],
+            definitions=export_dataset.definitions,
         )
 
         equations = explore_query.get("equations", [])

--- a/tests/sentry/data_export/endpoints/test_data_export.py
+++ b/tests/sentry/data_export/endpoints/test_data_export.py
@@ -536,6 +536,41 @@ class DataExportTest(APITestCase):
         assert query_info["field"] == ["message", "timestamp"]
         assert query_info["dataset"] == "logs"
 
+    def test_explore_valid_dataset_tracemetrics(self) -> None:
+        """
+        Tests that the tracemetrics dataset is valid for explore queries
+        """
+        payload = self.make_payload(
+            "explore",
+            {
+                "field": ["model", "sum(value,llm.token_usage,distribution,-)"],
+                "dataset": "tracemetrics",
+            },
+        )
+        with self.feature("organizations:discover-query"):
+            response = self.get_success_response(self.org.slug, status_code=201, **payload)
+        data_export = ExportedData.objects.get(id=response.data["id"])
+        query_info = data_export.query_info
+        assert query_info["field"] == ["model", "sum(value,llm.token_usage,distribution,-)"]
+        assert query_info["dataset"] == "tracemetrics"
+
+    def test_full_export_invalid_dataset_tracemetrics(self) -> None:
+        """
+        Tests that tracemetrics is rejected for full exports, which only support spans and logs
+        """
+        payload = {
+            "query_type": ExportQueryType.TRACE_ITEM_FULL_EXPORT_STR,
+            "query_info": {
+                "field": [],
+                "query": "",
+                "project": [self.project.id],
+                "dataset": "tracemetrics",
+            },
+        }
+        with self.feature("organizations:discover-query"):
+            response = self.get_error_response(self.org.slug, status_code=400, **payload)
+        assert response.data == {"non_field_errors": ["tracemetrics is not supported for exports"]}
+
     def test_explore_valid_jsonl_format(self) -> None:
         payload = self.make_payload("explore", {"format": "jsonl"})
         with self.feature("organizations:discover-query"):

--- a/tests/sentry/data_export/endpoints/test_data_export.py
+++ b/tests/sentry/data_export/endpoints/test_data_export.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+from django.urls import reverse
+
 from sentry.api.authentication import (
     ApiKeyAuthentication,
     OrgAuthTokenAuthentication,
@@ -17,6 +19,7 @@ from sentry.data_export.writers import OutputMode
 from sentry.search.utils import parse_datetime_string
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.utils import json
 from sentry.utils.snuba import MAX_FIELDS
 
 
@@ -554,12 +557,13 @@ class DataExportTest(APITestCase):
         assert query_info["field"] == ["model", "sum(value,llm.token_usage,distribution,-)"]
         assert query_info["dataset"] == "tracemetrics"
 
-    def test_full_export_invalid_dataset_tracemetrics(self) -> None:
+    def test_full_export_valid_dataset_tracemetrics(self) -> None:
         """
-        Tests that tracemetrics is rejected for full exports, which only support spans and logs
+        Tests that the tracemetrics dataset is valid for full exports
         """
         payload = {
             "query_type": ExportQueryType.TRACE_ITEM_FULL_EXPORT_STR,
+            "format": OutputMode.JSONL.value,
             "query_info": {
                 "field": [],
                 "query": "",
@@ -567,9 +571,18 @@ class DataExportTest(APITestCase):
                 "dataset": "tracemetrics",
             },
         }
+        url = reverse(
+            "sentry-api-0-organization-data-export",
+            kwargs={"organization_id_or_slug": self.org.slug},
+        )
         with self.feature("organizations:discover-query"):
-            response = self.get_error_response(self.org.slug, status_code=400, **payload)
-        assert response.data == {"non_field_errors": ["tracemetrics is not supported for exports"]}
+            response = self.client.post(
+                url, data=json.dumps(payload), content_type="application/json"
+            )
+        assert response.status_code == 201, response.content
+        data_export = ExportedData.objects.get(id=json.loads(response.content)["id"])
+        assert data_export.query_type == ExportQueryType.TRACE_ITEM_FULL_EXPORT
+        assert data_export.query_info["dataset"] == "tracemetrics"
 
     def test_explore_valid_jsonl_format(self) -> None:
         payload = self.make_payload("explore", {"format": "jsonl"})

--- a/tests/sentry/data_export/test_tasks.py
+++ b/tests/sentry/data_export/test_tasks.py
@@ -17,7 +17,13 @@ from sentry.data_export.writers import OutputMode
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models.files.file import File
 from sentry.search.events.constants import TIMEOUT_ERROR_MESSAGE
-from sentry.testutils.cases import OurLogTestCase, SnubaTestCase, SpanTestCase, TestCase
+from sentry.testutils.cases import (
+    OurLogTestCase,
+    SnubaTestCase,
+    SpanTestCase,
+    TestCase,
+    TraceMetricsTestCase,
+)
 from sentry.testutils.helpers.datetime import before_now
 from sentry.utils import json
 from sentry.utils.samples import load_data
@@ -707,7 +713,9 @@ class AssembleDownloadLargeTest(TestCase, SnubaTestCase):
         assert emailer.called
 
 
-class AssembleDownloadExploreTest(TestCase, SnubaTestCase, SpanTestCase, OurLogTestCase):
+class AssembleDownloadExploreTest(
+    TestCase, SnubaTestCase, SpanTestCase, OurLogTestCase, TraceMetricsTestCase
+):
     def setUp(self) -> None:
         super().setUp()
         self.user = self.create_user()
@@ -995,6 +1003,110 @@ class AssembleDownloadExploreTest(TestCase, SnubaTestCase, SpanTestCase, OurLogT
         with file.getfile() as f:
             content = f.read().strip()
         assert b"log.body,severity_text" in content
+
+    @patch("sentry.data_export.models.ExportedData.email_success")
+    def test_explore_tracemetrics_dataset_called_correctly(self, emailer: MagicMock) -> None:
+        metrics = [
+            self.create_trace_metric(
+                "llm.token_usage",
+                value,
+                "distribution",
+                timestamp=before_now(minutes=10),
+                organization=self.org,
+                project=self.project,
+                attributes={"model": model},
+            )
+            for model, value in (("gpt-5", 100.0), ("gpt-5", 50.0), ("claude-opus-5", 25.0))
+        ]
+        self.store_eap_items(metrics)
+
+        aggregate = "sum(value,llm.token_usage,distribution,-)"
+        de = ExportedData.objects.create(
+            user_id=self.user.id,
+            organization=self.org,
+            query_type=ExportQueryType.EXPLORE,
+            query_info={
+                "project": [self.project.id],
+                "field": ["model", aggregate],
+                "query": "",
+                "sort": [f"-{aggregate}"],
+                "dataset": "tracemetrics",
+                "start": before_now(minutes=15).isoformat(),
+                "end": before_now(minutes=5).isoformat(),
+            },
+        )
+
+        with self.tasks():
+            assemble_download(de.id, batch_size=1)
+
+        de = ExportedData.objects.get(id=de.id)
+        assert de.date_finished is not None
+        assert de.file_id is not None
+        file = de._get_file()
+        assert isinstance(file, File)
+        assert file.headers == {"Content-Type": "text/csv"}
+
+        with file.getfile() as f:
+            content = f.read().strip().decode()
+        rows = content.splitlines()
+
+        assert rows[0] == f'model,"{aggregate}"'
+        assert rows[1:] == ["gpt-5,150.0", "claude-opus-5,25.0"]
+
+    @patch("sentry.data_export.models.ExportedData.email_success")
+    def test_explore_tracemetrics_jsonl_full_export(self, emailer: MagicMock) -> None:
+        """
+        Wide JSONL export of trace metrics, which goes through Snuba's ExportTraceItems
+        endpoint rather than a table query.
+        """
+        metrics = [
+            self.create_trace_metric(
+                "llm.token_usage",
+                float(value),
+                "distribution",
+                timestamp=before_now(minutes=10, seconds=offset),
+                organization=self.org,
+                project=self.project,
+                attributes={"model": "gpt-5"},
+            )
+            for offset, value in ((0, 100), (30, 50))
+        ]
+        self.store_eap_items(metrics)
+
+        de = ExportedData.objects.create(
+            user_id=self.user.id,
+            organization=self.org,
+            query_type=ExportQueryType.TRACE_ITEM_FULL_EXPORT,
+            query_info={
+                "project": [self.project.id],
+                "field": [],
+                "equations": [],
+                "query": "",
+                "dataset": "tracemetrics",
+                "start": before_now(minutes=15).isoformat(),
+                "end": before_now(minutes=5).isoformat(),
+            },
+            export_format=OutputMode.JSONL.value,
+        )
+
+        with self.tasks():
+            assemble_download(de.id, batch_size=2, export_limit=100)
+
+        de = ExportedData.objects.get(id=de.id)
+        assert de.date_finished is not None
+        file = de._get_file()
+        assert isinstance(file, File)
+        assert file.headers == {"Content-Type": "application/x-ndjson"}
+
+        with file.getfile() as f:
+            rows = [json.loads(line) for line in f.read().strip().splitlines()]
+
+        assert len(rows) == len(metrics)
+        # The wide export carries every attribute, including ones no table query selected.
+        assert {row["value"] for row in rows} == {100.0, 50.0}
+        assert {row["metric.name"] for row in rows} == {"llm.token_usage"}
+        assert {row["model"] for row in rows} == {"gpt-5"}
+        assert emailer.called
 
     @patch("sentry.data_export.models.ExportedData.email_success")
     def test_explore_logs_jsonl_format(self, emailer: MagicMock) -> None:


### PR DESCRIPTION
Adds `TraceMetrics` to `SUPPORTED_TRACE_ITEM_DATASETS` with logic to map export queries to that dataset. This'll allow for an _Export Data_ flow similar to what Logs and Spans/Traces have (#121567).

Starts on LOGS-514.
