### PR TITLE
feat(seer): Add Conduit stream credentials endpoint

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -103,6 +103,17 @@ x-sentry-service-config:
       description: Memcached used for caching
     spotlight:
       description: Spotlight server for local debugging
+    # Shared with seer, which declares the same remote dependency: seer publishes
+    # agent output to Conduit's publish service and browsers consume it as SSE from
+    # its gateway, so both must reach the same broker. devservices runs one clone
+    # per remote repo, so declaring it in both repos yields one instance, not two.
+    conduit:
+      description: Real-time delivery platform used to stream Seer agent output to the browser
+      remote:
+        repo_name: conduit
+        branch: main
+        repo_link: https://github.com/getsentry/conduit.git
+        mode: containerized
     # Local Relays used only by the `cell-routing` mode to exercise Relay's
     # advertised-upstream routing without touching the relay repo or the default
     # `relay` config. relay-cell replaces the plain `relay` in this mode.
@@ -180,6 +191,14 @@ x-sentry-service-config:
   modes:
     default: [snuba, postgres, relay, spotlight, objectstore]
     migrations: [postgres, redis]
+    # Streams Seer agent output over SSE instead of polling. Opt-in rather than
+    # part of `default`: the feature is flagged off, so the containers would
+    # otherwise be idle processes for everyone not working on it.
+    #
+    # Conduit's own containerized mode brings the redis-cluster its broker needs,
+    # so this must NOT also list sentry's `redis-cluster` -- the two use identical
+    # images and both bind 7000-7005, so running both fails to start.
+    conduit: [snuba, postgres, relay, spotlight, objectstore, conduit]
     acceptance-ci: [postgres, snuba, chartcuterie]
     chartcuterie: [postgres, snuba, chartcuterie, spotlight]
     launchpad:

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -248,6 +248,7 @@ const ESM_NODE_MODULES = [
   'color',
   'marked',
   '@sentry\\+sqlish',
+  'conduit-client',
 ];
 
 const config: Config.InitialOptions = {
@@ -283,6 +284,13 @@ const config: Config.InitialOptions = {
     // conditions. Jest's CJS resolver can't follow them without explicit mapping.
     '^@sentry/sqlish/react$': '<rootDir>/node_modules/@sentry/sqlish/dist/react.js',
     '^@sentry/sqlish$': '<rootDir>/node_modules/@sentry/sqlish/dist/index.js',
+
+    // conduit-client's `main`/`require` both point at dist/index.cjs, which its
+    // published tarball does not contain — so Jest's CJS resolution fails outright.
+    // Point at the ESM build (transformed via ESM_NODE_MODULES below), which is
+    // what rspack resolves anyway. Removable once the package ships the CJS build
+    // it claims to have.
+    '^conduit-client$': '<rootDir>/node_modules/conduit-client/dist/index.js',
 
     // Disabled @sentry/toolbar in tests. It depends on iframes and global
     // window/cookies state.

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -532,6 +532,9 @@ from sentry.seer.endpoints.organization_seer_agent_pr_groups import (
 from sentry.seer.endpoints.organization_seer_agent_update import (
     OrganizationSeerAgentUpdateEndpoint,
 )
+from sentry.seer.endpoints.organization_seer_explorer_stream import (
+    OrganizationSeerExplorerStreamCredentialsEndpoint,
+)
 from sentry.seer.endpoints.organization_seer_onboarding_check import OrganizationSeerOnboardingCheck
 from sentry.seer.endpoints.organization_seer_rpc import OrganizationSeerRpcEndpoint
 from sentry.seer.endpoints.organization_seer_runs import OrganizationSeerRunsEndpoint
@@ -2401,6 +2404,11 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^/]+)/seer/explorer-chat/(?P<run_id>[^/]+)/$",
         OrganizationSeerAgentChatEndpoint.as_view(),
         name="sentry-api-0-organization-seer-explorer-chat-run-id",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/seer/explorer-chat/(?P<run_id>[^/]+)/stream-credentials/$",
+        OrganizationSeerExplorerStreamCredentialsEndpoint.as_view(),
+        name="sentry-api-0-organization-seer-explorer-stream-credentials",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/seer/runs/$",

--- a/src/sentry/conduit/auth.py
+++ b/src/sentry/conduit/auth.py
@@ -67,21 +67,32 @@ def generate_conduit_token(
 def get_conduit_credentials(
     org_id: int,
     gateway_url: str | None = None,
+    channel_id: str | None = None,
+    referrer: str = "unknown",
 ) -> ConduitCredentials:
     """
     Generate all credentials needed to connect to Conduit.
+
+    Args:
+        channel_id: The channel to authorize. Omit for a fresh one-shot stream. Pass
+            an explicit value when the channel is derived from something longer-lived
+            than the connection (see ``sentry.conduit.channel``), so that reconnects
+            and additional tabs resume the same stream instead of starting new ones.
+        referrer: What the credentials are for, as a metrics tag.
 
     Returns:
         ConduitCredentials containing authentication details
     """
     if gateway_url is None:
         gateway_url = settings.CONDUIT_GATEWAY_URL
-    channel_id = generate_channel_id()
+    if channel_id is None:
+        channel_id = generate_channel_id()
     token = generate_conduit_token(org_id, channel_id)
 
     metrics.incr(
         "conduit.credentials.generated",
         sample_rate=1.0,
+        tags={"referrer": referrer},
     )
 
     return ConduitCredentials(

--- a/src/sentry/conduit/channel.py
+++ b/src/sentry/conduit/channel.py
@@ -1,0 +1,35 @@
+"""Deterministic Conduit channel derivation for Seer runs.
+
+A run outlives any single browser connection (reconnects, refreshes, a second tab),
+so the channel it streams on cannot be minted per-connection the way the Conduit demo
+endpoint does it. Deriving the channel from the run id instead lets Sentry and Seer
+each compute the same value independently -- no shared storage, no round trip, and
+every consumer of a run lands on the same stream.
+
+The derivation is a hash, not a secret: knowing a run id yields its channel id. That
+is fine because the channel is not the authorization boundary. Conduit's gateway
+requires an RS256 token whose ``org_id`` *and* ``channel_id`` claims match the
+request, and only Sentry can mint one -- and only after the permission checks in
+``OrganizationSeerExplorerStreamCredentialsEndpoint``.
+"""
+
+import uuid
+
+# Wire-format constant. MUST stay identical to CONDUIT_CHANNEL_NAMESPACE in seer's
+# src/seer/conduit/channel.py -- the two services derive channel ids independently
+# and only agree because they share this seed. Changing it silently breaks every
+# in-flight run at deploy (Sentry hands the browser one channel while Seer publishes
+# to another), so treat it as immutable.
+CONDUIT_CHANNEL_NAMESPACE = uuid.UUID("6f1a8f5e-3e9a-4a52-9b3b-2f0b6a7c1d84")
+
+
+def channel_id_for_seer_run(seer_run_state_id: int) -> str:
+    """The Conduit channel a Seer run streams on.
+
+    Args:
+        seer_run_state_id: The id of Seer's ``DbRunState`` row, which is what
+            ``SeerRun.seer_run_state_id`` mirrors. Not ``SeerRun.id`` and not the
+            run's uuid -- Seer only knows its own id, so that is what both sides
+            must derive from.
+    """
+    return str(uuid.uuid5(CONDUIT_CHANNEL_NAMESPACE, f"seer-run:{seer_run_state_id}"))

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -581,6 +581,11 @@ if ENVIRONMENT == "development":
         "ws://127.0.0.1:8000",
         "http://localhost:8969/stream",
         "webpack-internal:",
+        # Conduit gateway (Seer agent streaming). The browser opens this SSE
+        # connection directly rather than through Sentry, so it needs its own
+        # connect-src entry. Ports match CONDUIT_GATEWAY_URL's default.
+        "http://127.0.0.1:9096",
+        "http://localhost:9096",
     ]
 
 # Before enforcing Content Security Policy, we recommend creating a separate

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -315,6 +315,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enable thinking + tool-call summaries in Seer Agent
     manager.add("organizations:seer-explorer-thinking-summary", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:seer-explorer-stream", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Deliver Seer Agent output over Conduit (SSE) instead of polling the state endpoint
+    manager.add("organizations:seer-explorer-conduit", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable structured LLM context (JSON snapshot) instead of ASCII DOM snapshot
     manager.add("organizations:context-engine-structured-page-context", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable browser notifications for autofix runs

--- a/src/sentry/seer/endpoints/organization_seer_explorer_stream.py
+++ b/src/sentry/seer/endpoints/organization_seer_explorer_stream.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import logging
+
+import sentry_sdk
+from rest_framework import serializers, status
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import cell_silo_endpoint
+from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
+from sentry.conduit.auth import get_conduit_credentials
+from sentry.conduit.channel import channel_id_for_seer_run
+from sentry.models.organization import Organization
+from sentry.ratelimits.config import RateLimitConfig
+from sentry.seer.agent.client_utils import has_seer_agent_access_with_detail
+from sentry.seer.endpoints.utils import resolve_seer_run
+from sentry.seer.seer_setup import has_seer_access_with_detail
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
+
+logger = logging.getLogger(__name__)
+
+
+class ConduitCredentialsSerializer(serializers.Serializer):
+    token = serializers.CharField()
+    channel_id = serializers.UUIDField()
+    url = serializers.URLField()
+
+
+class ConduitCredentialsResponseSerializer(serializers.Serializer):
+    conduit = ConduitCredentialsSerializer()
+
+
+class OrganizationSeerExplorerStreamPermission(OrganizationPermission):
+    scope_map = {
+        # Reading a run's output. POST only because minting a credential is a
+        # side-effecting operation, not because it mutates the run.
+        "POST": ["org:read"],
+    }
+
+
+@cell_silo_endpoint
+class OrganizationSeerExplorerStreamCredentialsEndpoint(OrganizationEndpoint):
+    """Mint the credentials a browser needs to stream a Seer run from Conduit.
+
+    This is the authorization boundary for streaming. Conduit's gateway will serve
+    any channel to anyone holding a token whose ``org_id``/``channel_id`` claims
+    match, and only Sentry can sign one -- so the checks here are what stand between
+    a user and another org's agent output. They deliberately mirror the GET on
+    ``OrganizationSeerAgentChatEndpoint``: anything you can stream, you can already
+    poll.
+
+    Shaped for ``conduit-client``, which POSTs this URL to start a stream and again
+    on every reconnect. Tokens are therefore short-lived by design (10 min) with no
+    refresh path -- a reconnect just mints a new one.
+    """
+
+    publish_status = {
+        "POST": ApiPublishStatus.PRIVATE,
+    }
+    owner = ApiOwner.ML_AI
+    permission_classes = (OrganizationSeerExplorerStreamPermission,)
+    enforce_rate_limit = True
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            # Sized for connects and reconnects, not messages -- the stream itself
+            # costs nothing here. Generous enough to survive a flapping network
+            # without locking a user out of their own conversation.
+            "POST": {
+                RateLimitCategory.IP: RateLimit(limit=60, window=60),
+                RateLimitCategory.USER: RateLimit(limit=60, window=60),
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=600, window=60),
+            },
+        }
+    )
+
+    def post(self, request: Request, organization: Organization, run_id: str) -> Response:
+        """
+        Return the token, channel, and gateway URL for streaming ``run_id``.
+        """
+        if not features.has(
+            "organizations:seer-explorer-conduit", organization, actor=request.user
+        ):
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        has_agent_access, error = has_seer_agent_access_with_detail(organization, request.user)
+        has_seer_access, _ = has_seer_access_with_detail(organization, request.user)
+        if not has_agent_access and not has_seer_access:
+            raise PermissionDenied(error)
+
+        resolved = resolve_seer_run(run_id, organization)
+        if isinstance(resolved, Response):
+            # A run that isn't resolvable yet (still mirroring, or failed) has nothing
+            # to stream. The client falls back to polling, which is what surfaces those
+            # states to the user anyway.
+            return resolved
+
+        try:
+            credentials = get_conduit_credentials(
+                organization.id,
+                # Derived, not minted: the browser must land on the channel Seer is
+                # already publishing to, and must return to it after a reconnect.
+                channel_id=channel_id_for_seer_run(resolved.seer_run_state_id),
+                referrer="seer-explorer",
+            )
+        except ValueError as e:
+            # Conduit isn't configured. Not an error the user can act on, and not
+            # fatal -- the client keeps polling.
+            sentry_sdk.capture_exception(e, level="warning")
+            return Response(
+                {"detail": "Streaming is unavailable"},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+
+        serializer = ConduitCredentialsResponseSerializer({"conduit": credentials._asdict()})
+        return Response(serializer.data, status=status.HTTP_201_CREATED)

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -350,6 +350,7 @@ export type KnownSentryApiUrls =
   | '/organizations/$organizationIdOrSlug/seer-rpc/$methodName/'
   | '/organizations/$organizationIdOrSlug/seer/explorer-chat/'
   | '/organizations/$organizationIdOrSlug/seer/explorer-chat/$runId/'
+  | '/organizations/$organizationIdOrSlug/seer/explorer-chat/$runId/stream-credentials/'
   | '/organizations/$organizationIdOrSlug/seer/explorer-pr-groups/'
   | '/organizations/$organizationIdOrSlug/seer/explorer-update/$runId/'
   | '/organizations/$organizationIdOrSlug/seer/onboarding-check/'

--- a/static/app/views/seerExplorer/hooks/useSeerExplorerPolling.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorerPolling.tsx
@@ -4,6 +4,7 @@ import {getDateFromTimestampAssumeUtc} from 'sentry/utils/dates';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useTimeout} from 'sentry/utils/useTimeout';
+import {useSeerExplorerStream} from 'sentry/views/seerExplorer/hooks/useSeerExplorerStream';
 import type {PollingState} from 'sentry/views/seerExplorer/seerExplorerChatStateContext';
 import type {
   SeerExplorerResponse,
@@ -19,6 +20,18 @@ const POLL_INTERVAL = 500; // Poll every 500ms
 const ERROR_POLL_INTERVAL = 2500; // Poll every 2500ms on 5xx errors
 const MAX_ERROR_POLL_COUNT = Math.ceil(60_000 / ERROR_POLL_INTERVAL);
 const STALE_TIME_MS = 120_000;
+
+/**
+ * Poll interval while a Conduit stream is delivering this run's output.
+ *
+ * Not `false`. The stream already carries every update, so this is pure
+ * redundancy -- but at 1/30th the request volume it costs almost nothing, and it
+ * makes "the stream silently stopped delivering" impossible to experience as a
+ * frozen UI. Worth revisiting once production metrics show the stream is
+ * reliable; until then a 97% reduction that cannot strand a user beats a 100%
+ * reduction that can.
+ */
+const STREAMING_SAFETY_NET_INTERVAL = 15_000;
 
 /** Checks if session is in a terminal state where the agent is done processing. */
 const isResponseComplete = (sessionData: SeerExplorerResponse['session'] | undefined) =>
@@ -72,6 +85,11 @@ const getPollingState = (
  * Drives Seer session polling via `useApiQuery` with a dynamic refetch interval.
  * Called exclusively by `SeerExplorerChatStateProvider`, which dispatches the
  * derived polling state into context for all consumers.
+ *
+ * When the org has Conduit streaming enabled, this also opens the stream and
+ * drops the poll to a slow safety net while it stays healthy. The polling state
+ * machine below is untouched by that: it remains exactly what the stream falls
+ * back to, so a Conduit outage degrades to the behaviour we ship today.
  */
 export const useSeerExplorerPolling = ({runId}: {runId: SeerExplorerRunId | null}) => {
   const organization = useOrganization({allowNull: true});
@@ -85,6 +103,21 @@ export const useSeerExplorerPolling = ({runId}: {runId: SeerExplorerRunId | null
     prevRunIdRef.current = runId;
     errorPollCountRef.current = 0;
   }
+
+  const {isStreaming} = useSeerExplorerStream({
+    runId,
+    enabled:
+      !!runId &&
+      isSeerExplorerEnabled(organization) &&
+      !!organization?.features.includes('seer-explorer-conduit'),
+  });
+
+  // Read inside refetchInterval, which React Query calls outside of render and
+  // so does not re-run when this value changes.
+  const isStreamingRef = useRef(isStreaming);
+  useEffect(() => {
+    isStreamingRef.current = isStreaming;
+  }, [isStreaming]);
 
   const {
     data: apiData,
@@ -113,6 +146,10 @@ export const useSeerExplorerPolling = ({runId}: {runId: SeerExplorerRunId | null
       }
       if (state === 'polling') {
         errorPollCountRef.current = 0;
+        if (isStreamingRef.current) {
+          // The stream is delivering; this is only here to catch a stall.
+          return STREAMING_SAFETY_NET_INTERVAL;
+        }
         return POLL_INTERVAL;
       }
       return false;

--- a/static/app/views/seerExplorer/hooks/useSeerExplorerStream.spec.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorerStream.spec.tsx
@@ -22,6 +22,7 @@ const streamHandlers: {
     onConnect?: () => void;
     onError?: (e: Error) => void;
     onMessage?: (msg: any) => void;
+    startStreamUrl?: string;
   };
 } = {current: {}};
 
@@ -93,6 +94,21 @@ describe('useSeerExplorerStream', () => {
       render();
 
       await waitFor(() => expect(streamHandlers.current.enabled).toBe(true));
+    });
+
+    it('points conduit-client at the /api/0 credentials URL', async () => {
+      // conduit-client fetches this itself instead of going through
+      // api.requestPromise, so nothing prepends /api/0 for it. Without the prefix
+      // the request falls through to the frontend router and resolves to the SPA's
+      // index.html -- an HTML body, not a 404, so it fails as "invalid response"
+      // with no hint about the cause.
+      render();
+
+      await waitFor(() =>
+        expect(streamHandlers.current.startStreamUrl).toBe(
+          '/api/0/organizations/org-slug/seer/explorer-chat/42/stream-credentials/'
+        )
+      );
     });
 
     it('stays closed without the feature', async () => {

--- a/static/app/views/seerExplorer/hooks/useSeerExplorerStream.spec.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorerStream.spec.tsx
@@ -1,0 +1,273 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {act, renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {useSeerExplorerPolling} from './useSeerExplorerPolling';
+
+/**
+ * conduit-client owns the EventSource lifecycle, which jsdom can't drive. Mock
+ * `useStream` so tests can deliver messages directly and assert on what the hook
+ * does with them.
+ *
+ * These drive `useSeerExplorerPolling` rather than `useSeerExplorerStream`
+ * directly, because the two only work as a pair: the stream hook writes into and
+ * invalidates a query whose observer lives in the polling hook. Invalidating
+ * without that observer is a no-op, so testing the stream hook alone would assert
+ * on a wiring that doesn't exist in production.
+ */
+const streamHandlers: {
+  current: {
+    enabled?: boolean;
+    onClose?: () => void;
+    onConnect?: () => void;
+    onError?: (e: Error) => void;
+    onMessage?: (msg: any) => void;
+  };
+} = {current: {}};
+
+jest.mock('conduit-client', () => ({
+  useStream: (options: any) => {
+    streamHandlers.current = options;
+    return {isConnected: false, error: null};
+  },
+}));
+
+const BASE_FEATURES = ['seer-explorer', 'gen-ai-features'];
+
+function makeSession(content: string) {
+  return {
+    session: {
+      blocks: [
+        {
+          id: 'block-1',
+          message: {role: 'assistant', content},
+          timestamp: '2026-01-01T00:00:00Z',
+          loading: true,
+        },
+      ],
+      status: 'processing',
+      updated_at: new Date().toISOString(),
+    },
+  };
+}
+
+describe('useSeerExplorerStream', () => {
+  const organization = OrganizationFixture({
+    features: [...BASE_FEATURES, 'seer-explorer-conduit'],
+    hideAiFeatures: false,
+    openMembership: true,
+  });
+
+  let sessionMock: jest.Mock;
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    streamHandlers.current = {};
+    sessionMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/explorer-chat/42/`,
+      body: makeSession('Hello'),
+    });
+  });
+
+  function render(org = organization) {
+    return renderHookWithProviders(() => useSeerExplorerPolling({runId: 42}), {
+      organization: org,
+    });
+  }
+
+  const connect = () =>
+    act(() => {
+      streamHandlers.current.onConnect?.();
+    });
+
+  const send = (message: Record<string, unknown>) =>
+    act(() => {
+      streamHandlers.current.onMessage?.(message);
+    });
+
+  /** Let the debounced invalidate and any refetch settle. */
+  const settle = () => act(() => new Promise(resolve => setTimeout(resolve, 300)));
+
+  describe('enablement', () => {
+    it('opens the stream when the org has the feature', async () => {
+      render();
+
+      await waitFor(() => expect(streamHandlers.current.enabled).toBe(true));
+    });
+
+    it('stays closed without the feature', async () => {
+      const org = OrganizationFixture({
+        features: BASE_FEATURES,
+        hideAiFeatures: false,
+        openMembership: true,
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${org.slug}/seer/explorer-chat/42/`,
+        body: makeSession('Hello'),
+      });
+
+      render(org);
+
+      await waitFor(() => expect(streamHandlers.current.enabled).toBe(false));
+    });
+  });
+
+  describe('text deltas', () => {
+    it('appends without a network request', async () => {
+      // The whole point of streaming: text lands as a local cache write.
+      const {result} = render();
+      await waitFor(() => expect(result.current.apiData).toBeDefined());
+      connect();
+      await settle();
+      const callsBefore = sessionMock.mock.calls.length;
+
+      send({kind: 'text', block_id: 'block-1', text: ' world', offset: 0});
+      await settle();
+
+      expect(result.current.apiData?.session?.blocks[0]?.message.content).toBe(
+        'Hello world'
+      );
+      expect(sessionMock.mock.calls).toHaveLength(callsBefore);
+    });
+
+    it('appends consecutive deltas in order', async () => {
+      const {result} = render();
+      await waitFor(() => expect(result.current.apiData).toBeDefined());
+      connect();
+      await settle();
+
+      send({kind: 'text', block_id: 'block-1', text: ' one', offset: 0});
+      send({kind: 'text', block_id: 'block-1', text: ' two', offset: 4});
+      await settle();
+
+      expect(result.current.apiData?.session?.blocks[0]?.message.content).toBe(
+        'Hello one two'
+      );
+    });
+
+    it('refetches rather than render a gap when an offset does not line up', async () => {
+      // A dropped delta must degrade to a redundant fetch, never to text with an
+      // invisible hole in it.
+      const {result} = render();
+      await waitFor(() => expect(result.current.apiData).toBeDefined());
+      connect();
+      await settle();
+      const callsBefore = sessionMock.mock.calls.length;
+
+      send({kind: 'text', block_id: 'block-1', text: ' world', offset: 999});
+      await settle();
+
+      expect(sessionMock.mock.calls.length).toBeGreaterThan(callsBefore);
+      expect(result.current.apiData?.session?.blocks[0]?.message.content).toBe('Hello');
+    });
+
+    it('refetches when a delta arrives for an unknown block', async () => {
+      // Blocks arrive via the state endpoint, so a delta can outrun its block.
+      const {result} = render();
+      await waitFor(() => expect(result.current.apiData).toBeDefined());
+      connect();
+      await settle();
+      const callsBefore = sessionMock.mock.calls.length;
+
+      send({kind: 'text', block_id: 'nonexistent', text: 'hi', offset: 0});
+      await settle();
+
+      expect(sessionMock.mock.calls.length).toBeGreaterThan(callsBefore);
+    });
+  });
+
+  describe('nudges', () => {
+    it('refetches on invalidate', async () => {
+      const {result} = render();
+      await waitFor(() => expect(result.current.apiData).toBeDefined());
+      connect();
+      await settle();
+      const callsBefore = sessionMock.mock.calls.length;
+
+      send({kind: 'invalidate', reason: 'tool_call'});
+      await settle();
+
+      expect(sessionMock.mock.calls.length).toBeGreaterThan(callsBefore);
+    });
+
+    it('refetches on an unrecognized kind', async () => {
+      // Forward compatible: a newer Seer may publish kinds this build predates,
+      // and "go look again" is always a safe response.
+      const {result} = render();
+      await waitFor(() => expect(result.current.apiData).toBeDefined());
+      connect();
+      await settle();
+      const callsBefore = sessionMock.mock.calls.length;
+
+      send({kind: 'something-new'});
+      await settle();
+
+      expect(sessionMock.mock.calls.length).toBeGreaterThan(callsBefore);
+    });
+
+    it('collapses a burst into a single refetch', async () => {
+      const {result} = render();
+      await waitFor(() => expect(result.current.apiData).toBeDefined());
+      connect();
+      await settle();
+      const callsBefore = sessionMock.mock.calls.length;
+
+      for (let i = 0; i < 5; i++) {
+        send({kind: 'invalidate', reason: 'tool_call'});
+      }
+      await settle();
+
+      expect(sessionMock.mock.calls).toHaveLength(callsBefore + 1);
+    });
+  });
+
+  describe('fallback to polling', () => {
+    it('polls at the safety-net interval while streaming', async () => {
+      // Not zero requests: a slow poll makes "the stream silently stalled"
+      // impossible to experience as a frozen UI.
+      const {result} = render();
+      await waitFor(() => expect(result.current.apiData).toBeDefined());
+      connect();
+      await settle();
+      const callsBefore = sessionMock.mock.calls.length;
+
+      // Well past the 500ms poll interval, nowhere near the 15s safety net.
+      await settle();
+      await settle();
+
+      expect(sessionMock.mock.calls).toHaveLength(callsBefore);
+      expect(result.current.isPolling).toBe(true);
+    });
+
+    it('resumes fast polling after the stream errors', async () => {
+      // A dead stream must not leave the UI on the 15s safety-net cadence: the
+      // disconnect refetch is also what makes React Query recompute the interval.
+      const {result} = render();
+      await waitFor(() => expect(result.current.apiData).toBeDefined());
+      connect();
+      await settle();
+      const callsBefore = sessionMock.mock.calls.length;
+
+      act(() => {
+        streamHandlers.current.onError?.(new Error('connection lost'));
+      });
+      // Long enough for the 500ms poll to fire, but far short of the 15s safety
+      // net -- so a second fetch here can only mean fast polling resumed.
+      await act(() => new Promise(resolve => setTimeout(resolve, 900)));
+
+      expect(sessionMock.mock.calls.length).toBeGreaterThan(callsBefore + 1);
+    });
+
+    it('resyncs on connect, since the stream replays history', async () => {
+      const {result} = render();
+      await waitFor(() => expect(result.current.apiData).toBeDefined());
+      await settle();
+      const callsBefore = sessionMock.mock.calls.length;
+
+      connect();
+      await settle();
+
+      expect(sessionMock.mock.calls.length).toBeGreaterThan(callsBefore);
+    });
+  });
+});

--- a/static/app/views/seerExplorer/hooks/useSeerExplorerStream.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorerStream.tsx
@@ -203,12 +203,16 @@ export function useSeerExplorerStream({
 
   const streamHeaders = useMemo(() => ({'X-CSRFToken': getCsrfToken()}), []);
 
+  // Prefixed with /api/0 because conduit-client fetches this itself rather than
+  // going through `api.requestPromise`, which is what normally prepends it. Without
+  // the prefix the request falls through to the frontend router and resolves to the
+  // SPA's index.html, which fails as "invalid response" rather than as a 404.
   const startStreamUrl =
     orgSlug && runId !== null
-      ? getApiUrl(
+      ? `/api/0${getApiUrl(
           '/organizations/$organizationIdOrSlug/seer/explorer-chat/$runId/stream-credentials/',
           {path: {organizationIdOrSlug: orgSlug, runId}}
-        )
+        )}`
       : '';
 
   useStream<StreamMessage>({

--- a/static/app/views/seerExplorer/hooks/useSeerExplorerStream.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorerStream.tsx
@@ -1,0 +1,232 @@
+import {useCallback, useMemo, useRef, useState} from 'react';
+import {useQueryClient} from '@tanstack/react-query';
+import {useStream} from 'conduit-client';
+
+import {getApiUrl} from 'sentry/utils/api/getApiUrl';
+import {getCsrfToken} from 'sentry/utils/getCsrfToken';
+import {setApiQueryData} from 'sentry/utils/queryClient';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import type {
+  SeerExplorerResponse,
+  SeerExplorerRunId,
+} from 'sentry/views/seerExplorer/types';
+import {makeSeerExplorerQueryKey} from 'sentry/views/seerExplorer/utils';
+
+/**
+ * Window for collapsing invalidate nudges into a single refetch. Seer already
+ * coalesces on its side; this guards against bursts that survive the network.
+ */
+const INVALIDATE_DEBOUNCE_MS = 100;
+
+/**
+ * How long to tolerate silence from a stream whose run is still processing
+ * before falling back to polling. Covers the case where a run dies without
+ * publishing its terminal message, which would otherwise leave the user
+ * watching a spinner until Conduit's 120s idle cleanup.
+ */
+const STREAM_IDLE_TIMEOUT_MS = 30_000;
+
+type TextMessage = {
+  block_id: string;
+  kind: 'text';
+  offset: number;
+  text: string;
+};
+
+type InvalidateMessage = {
+  kind: 'invalidate';
+  reason: string;
+};
+
+type DoneMessage = {
+  kind: 'done';
+  status: string;
+};
+
+type StreamMessage = TextMessage | InvalidateMessage | DoneMessage;
+
+interface UseSeerExplorerStreamOptions {
+  enabled: boolean;
+  runId: SeerExplorerRunId | null;
+}
+
+export interface SeerExplorerStreamState {
+  /** True while a healthy stream is delivering this run's output. */
+  isStreaming: boolean;
+}
+
+/**
+ * Streams a Seer run's output over Conduit, writing into the same React Query
+ * cache entry that polling populates.
+ *
+ * Only assistant text arrives over the wire. Everything structural -- new
+ * blocks, tool results, patches, PR state -- arrives as a nudge that triggers
+ * one refetch of the existing state endpoint, which stays the source of truth.
+ * That keeps this hook from having to model Seer's state shape.
+ *
+ * The hook is an accelerator, never a dependency: every failure path leaves
+ * `isStreaming` false, and the caller's polling covers the gap.
+ */
+export function useSeerExplorerStream({
+  enabled,
+  runId,
+}: UseSeerExplorerStreamOptions): SeerExplorerStreamState {
+  const organization = useOrganization({allowNull: true});
+  const queryClient = useQueryClient();
+  const orgSlug = organization?.slug;
+
+  const [isConnected, setIsConnected] = useState(false);
+  const [isIdle, setIsIdle] = useState(false);
+  const [isComplete, setIsComplete] = useState(false);
+
+  const invalidateTimer = useRef<number | undefined>(undefined);
+  const idleTimer = useRef<number | undefined>(undefined);
+  /** Characters accumulated per block, to detect gaps in the delta sequence. */
+  const accumulated = useRef<Map<string, number>>(new Map());
+
+  const queryKey = useMemo(
+    () => makeSeerExplorerQueryKey(orgSlug || '', runId),
+    [orgSlug, runId]
+  );
+
+  const invalidate = useCallback(() => {
+    window.clearTimeout(invalidateTimer.current);
+    invalidateTimer.current = window.setTimeout(() => {
+      queryClient.invalidateQueries({queryKey});
+    }, INVALIDATE_DEBOUNCE_MS);
+  }, [queryClient, queryKey]);
+
+  const armIdleTimer = useCallback(() => {
+    window.clearTimeout(idleTimer.current);
+    setIsIdle(false);
+    idleTimer.current = window.setTimeout(() => setIsIdle(true), STREAM_IDLE_TIMEOUT_MS);
+  }, []);
+
+  const appendText = useCallback(
+    (message: TextMessage) => {
+      const expected = accumulated.current.get(message.block_id) ?? 0;
+      if (message.offset !== expected) {
+        // A delta went missing (a publish that exhausted its retries, or a
+        // reconnect that outran the stream's retention). Refetching is cheap and
+        // self-healing; rendering text with a hole in it is neither.
+        accumulated.current.delete(message.block_id);
+        invalidate();
+        return;
+      }
+
+      accumulated.current.set(message.block_id, expected + message.text.length);
+
+      // A local cache write, not a fetch -- this is where the latency win is.
+      //
+      // setApiQueryData is deprecated in favour of queryClient.setQueryData with
+      // apiOptions, but it has to be used here: this writes into the entry
+      // useSeerExplorerPolling populates via useApiQuery, whose cache values are
+      // {json, headers}-shaped. Writing a bare payload would corrupt it. Migrating
+      // that hook to apiOptions is the prerequisite for dropping this, and is
+      // deliberately not bundled into the streaming change.
+      setApiQueryData<SeerExplorerResponse>(queryClient, queryKey, existing => {
+        if (!existing?.session) {
+          // Nothing to append to yet; the initial fetch hasn't landed.
+          return existing;
+        }
+        const index = existing.session.blocks.findIndex(b => b.id === message.block_id);
+        if (index === -1) {
+          // The block arrives via the state endpoint, so a delta can beat it here.
+          // Refetch rather than fabricate one.
+          accumulated.current.delete(message.block_id);
+          invalidate();
+          return existing;
+        }
+
+        const block = existing.session.blocks[index]!;
+        const blocks = [...existing.session.blocks];
+        blocks[index] = {
+          ...block,
+          message: {
+            ...block.message,
+            content: (block.message.content ?? '') + message.text,
+          },
+        };
+        return {...existing, session: {...existing.session, blocks}};
+      });
+    },
+    [invalidate, queryClient, queryKey]
+  );
+
+  const onMessage = useCallback(
+    (message: StreamMessage) => {
+      armIdleTimer();
+
+      switch (message.kind) {
+        case 'text':
+          appendText(message);
+          break;
+        case 'invalidate':
+          // Structural change. The endpoint knows what it was; we don't need to.
+          invalidate();
+          break;
+        case 'done':
+          setIsComplete(true);
+          invalidate();
+          break;
+        default:
+          // Forward compatible: a newer Seer may publish kinds this build doesn't
+          // know. Refetching is always a safe response to "something happened".
+          invalidate();
+      }
+    },
+    [appendText, armIdleTimer, invalidate]
+  );
+
+  const onConnect = useCallback(() => {
+    // The stream replays recent history on connect, and a reconnect may have
+    // missed messages entirely. Resync from the endpoint and rebuild offsets
+    // from whatever it returns.
+    accumulated.current.clear();
+    setIsConnected(true);
+    setIsComplete(false);
+    armIdleTimer();
+    queryClient.invalidateQueries({queryKey});
+  }, [armIdleTimer, queryClient, queryKey]);
+
+  const onDisconnect = useCallback(() => {
+    window.clearTimeout(idleTimer.current);
+    setIsConnected(false);
+    accumulated.current.clear();
+    // Refetch immediately, for two reasons: whatever the stream was mid-way
+    // through delivering is now only available from the endpoint, and React Query
+    // recomputes `refetchInterval` after a fetch -- so this is also what promotes
+    // the caller back off the slow safety-net interval. Without it, a dropped
+    // stream would leave the UI on a 15s cadence until that timer next fired.
+    queryClient.invalidateQueries({queryKey});
+  }, [queryClient, queryKey]);
+
+  const streamHeaders = useMemo(() => ({'X-CSRFToken': getCsrfToken()}), []);
+
+  const startStreamUrl =
+    orgSlug && runId !== null
+      ? getApiUrl(
+          '/organizations/$organizationIdOrSlug/seer/explorer-chat/$runId/stream-credentials/',
+          {path: {organizationIdOrSlug: orgSlug, runId}}
+        )
+      : '';
+
+  useStream<StreamMessage>({
+    enabled: enabled && !!startStreamUrl && !!organization,
+    orgId: Number(organization?.id ?? 0),
+    startStreamUrl,
+    startStreamHeaders: streamHeaders,
+    onMessage,
+    onConnect,
+    onReconnect: onConnect,
+    onClose: onDisconnect,
+    onError: onDisconnect,
+  });
+
+  return {
+    // `isComplete` keeps polling off after the run ends: the stream closes on
+    // purpose there, and treating that as a failure would restart the timer we
+    // just retired.
+    isStreaming: (isConnected && !isIdle) || isComplete,
+  };
+}

--- a/tests/sentry/seer/endpoints/test_organization_seer_explorer_stream.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_explorer_stream.py
@@ -1,0 +1,258 @@
+import base64
+from unittest.mock import patch
+
+import jwt
+from django.test.utils import override_settings
+
+from sentry.conduit.channel import CONDUIT_CHANNEL_NAMESPACE, channel_id_for_seer_run
+from sentry.seer.models.run import SeerRunMirrorStatus, SeerRunType
+from sentry.silo.base import SiloMode
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers import with_feature
+from sentry.testutils.silo import assume_test_silo_mode, cell_silo_test
+from tests.sentry.utils.test_jwt import RS256_KEY
+
+RS256_KEY_B64 = base64.b64encode(RS256_KEY.encode()).decode()
+
+CONDUIT_SETTINGS = {
+    "CONDUIT_GATEWAY_PRIVATE_KEY": RS256_KEY_B64,
+    "CONDUIT_GATEWAY_JWT_ISSUER": "sentry",
+    "CONDUIT_GATEWAY_JWT_AUDIENCE": "conduit",
+    "CONDUIT_GATEWAY_URL": "https://conduit.example.com",
+}
+
+FEATURE = "organizations:seer-explorer-conduit"
+SEER_RUN_STATE_ID = 4242
+
+
+@cell_silo_test
+class OrganizationSeerExplorerStreamCredentialsTest(APITestCase):
+    endpoint = "sentry-api-0-organization-seer-explorer-stream-credentials"
+    method = "post"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(user=self.user)
+        self.run = self.create_seer_run(
+            user_id=self.user.id,
+            type=SeerRunType.EXPLORER,
+            seer_run_state_id=SEER_RUN_STATE_ID,
+            mirror_status=SeerRunMirrorStatus.LIVE,
+        )
+
+    def _post(self, run_id: object | None = None, **kwargs):
+        return self.get_response(
+            self.organization.slug,
+            str(run_id if run_id is not None else SEER_RUN_STATE_ID),
+            **kwargs,
+        )
+
+
+@cell_silo_test
+class TestCredentialShape(OrganizationSeerExplorerStreamCredentialsTest):
+    @override_settings(**CONDUIT_SETTINGS)
+    @with_feature(FEATURE)
+    @patch(
+        "sentry.seer.endpoints.organization_seer_explorer_stream.has_seer_agent_access_with_detail"
+    )
+    def test_returns_conduit_client_shape(self, mock_access) -> None:
+        """conduit-client reads exactly {conduit: {token, channel_id, url}}."""
+        mock_access.return_value = (True, None)
+
+        response = self._post()
+
+        assert response.status_code == 201, response.data
+        conduit = response.data["conduit"]
+        assert set(conduit) == {"token", "channel_id", "url"}
+        assert conduit["url"] == f"https://conduit.example.com/events/{self.organization.id}"
+
+    @override_settings(**CONDUIT_SETTINGS)
+    @with_feature(FEATURE)
+    @patch(
+        "sentry.seer.endpoints.organization_seer_explorer_stream.has_seer_agent_access_with_detail"
+    )
+    def test_channel_is_derived_from_the_run(self, mock_access) -> None:
+        """The browser must land on the channel Seer already publishes to, and
+        return to it after a reconnect -- so this cannot be freshly minted."""
+        mock_access.return_value = (True, None)
+
+        first = self._post()
+        second = self._post()
+
+        expected = channel_id_for_seer_run(SEER_RUN_STATE_ID)
+        assert str(first.data["conduit"]["channel_id"]) == expected
+        assert str(second.data["conduit"]["channel_id"]) == expected
+
+    @override_settings(**CONDUIT_SETTINGS)
+    @with_feature(FEATURE)
+    @patch(
+        "sentry.seer.endpoints.organization_seer_explorer_stream.has_seer_agent_access_with_detail"
+    )
+    def test_token_claims_bind_org_and_channel(self, mock_access) -> None:
+        """These claims are the authorization boundary: Conduit's gateway serves any
+        channel to whoever holds a token matching it."""
+        mock_access.return_value = (True, None)
+
+        response = self._post()
+
+        claims = jwt.decode(
+            response.data["conduit"]["token"],
+            RS256_KEY,
+            algorithms=["RS256"],
+            audience="conduit",
+            options={"verify_signature": False},
+        )
+        assert claims["org_id"] == self.organization.id
+        assert claims["channel_id"] == channel_id_for_seer_run(SEER_RUN_STATE_ID)
+        assert claims["iss"] == "sentry"
+        assert claims["aud"] == "conduit"
+
+    @override_settings(**CONDUIT_SETTINGS)
+    @with_feature(FEATURE)
+    @patch(
+        "sentry.seer.endpoints.organization_seer_explorer_stream.has_seer_agent_access_with_detail"
+    )
+    def test_accepts_run_uuid(self, mock_access) -> None:
+        """The frontend holds a uuid for mirrored runs, a numeric id otherwise."""
+        mock_access.return_value = (True, None)
+
+        response = self._post(run_id=self.run.uuid)
+
+        assert response.status_code == 201, response.data
+        assert str(response.data["conduit"]["channel_id"]) == channel_id_for_seer_run(
+            SEER_RUN_STATE_ID
+        )
+
+
+@cell_silo_test
+class TestAuthorization(OrganizationSeerExplorerStreamCredentialsTest):
+    """Streaming must not widen access beyond what polling already allows."""
+
+    @override_settings(**CONDUIT_SETTINGS)
+    def test_404_without_feature(self) -> None:
+        assert self._post().status_code == 404
+
+    @override_settings(**CONDUIT_SETTINGS)
+    @with_feature(FEATURE)
+    @patch("sentry.seer.endpoints.organization_seer_explorer_stream.has_seer_access_with_detail")
+    @patch(
+        "sentry.seer.endpoints.organization_seer_explorer_stream.has_seer_agent_access_with_detail"
+    )
+    def test_403_without_seer_access(self, mock_agent_access, mock_seer_access) -> None:
+        mock_agent_access.return_value = (False, "no access")
+        mock_seer_access.return_value = (False, "no access")
+
+        assert self._post().status_code == 403
+
+    @override_settings(**CONDUIT_SETTINGS)
+    @with_feature(FEATURE)
+    @patch(
+        "sentry.seer.endpoints.organization_seer_explorer_stream.has_seer_agent_access_with_detail"
+    )
+    def test_cannot_stream_another_orgs_run(self, mock_access) -> None:
+        """A token for another org's run would let its agent output be read."""
+        mock_access.return_value = (True, None)
+        other_org = self.create_organization(owner=self.create_user())
+        other_run = self.create_seer_run(
+            organization=other_org,
+            type=SeerRunType.EXPLORER,
+            seer_run_state_id=9999,
+            mirror_status=SeerRunMirrorStatus.LIVE,
+        )
+
+        response = self._post(run_id=other_run.uuid)
+
+        assert response.status_code == 404
+        assert "conduit" not in response.data
+
+    @override_settings(**CONDUIT_SETTINGS)
+    @with_feature(FEATURE)
+    @patch(
+        "sentry.seer.endpoints.organization_seer_explorer_stream.has_seer_agent_access_with_detail"
+    )
+    def test_rejects_malformed_run_id(self, mock_access) -> None:
+        mock_access.return_value = (True, None)
+
+        assert self._post(run_id="not-a-run").status_code == 400
+
+    @override_settings(**CONDUIT_SETTINGS)
+    @with_feature(FEATURE)
+    def test_401_when_not_logged_in(self) -> None:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.client.logout()
+
+        assert self._post().status_code == 401
+
+
+@cell_silo_test
+class TestUnavailableStates(OrganizationSeerExplorerStreamCredentialsTest):
+    """Every one of these leaves the client polling, which is the product today."""
+
+    @override_settings(**CONDUIT_SETTINGS)
+    @with_feature(FEATURE)
+    @patch(
+        "sentry.seer.endpoints.organization_seer_explorer_stream.has_seer_agent_access_with_detail"
+    )
+    def test_run_still_mirroring_has_nothing_to_stream(self, mock_access) -> None:
+        mock_access.return_value = (True, None)
+        pending = self.create_seer_run(
+            type=SeerRunType.EXPLORER,
+            seer_run_state_id=None,
+            mirror_status=SeerRunMirrorStatus.PENDING,
+        )
+
+        response = self._post(run_id=pending.uuid)
+
+        assert response.status_code == 200
+        assert "conduit" not in response.data
+
+    @override_settings(**CONDUIT_SETTINGS)
+    @with_feature(FEATURE)
+    @patch(
+        "sentry.seer.endpoints.organization_seer_explorer_stream.has_seer_agent_access_with_detail"
+    )
+    def test_failed_run_has_nothing_to_stream(self, mock_access) -> None:
+        mock_access.return_value = (True, None)
+        failed = self.create_seer_run(
+            type=SeerRunType.EXPLORER,
+            seer_run_state_id=None,
+            mirror_status=SeerRunMirrorStatus.FAILED,
+        )
+
+        response = self._post(run_id=failed.uuid)
+
+        assert response.status_code == 200
+        assert "conduit" not in response.data
+
+    @override_settings(CONDUIT_GATEWAY_PRIVATE_KEY=None)
+    @with_feature(FEATURE)
+    @patch(
+        "sentry.seer.endpoints.organization_seer_explorer_stream.has_seer_agent_access_with_detail"
+    )
+    def test_503_when_conduit_unconfigured(self, mock_access) -> None:
+        """Not something the user can act on, and not fatal -- they keep polling."""
+        mock_access.return_value = (True, None)
+
+        response = self._post()
+
+        assert response.status_code == 503
+        assert "conduit" not in response.data
+
+
+class TestChannelDerivation:
+    def test_is_deterministic(self) -> None:
+        assert channel_id_for_seer_run(42) == channel_id_for_seer_run(42)
+
+    def test_differs_per_run(self) -> None:
+        assert channel_id_for_seer_run(42) != channel_id_for_seer_run(43)
+
+    def test_matches_seer(self) -> None:
+        """Pin the wire constant.
+
+        Seer derives the same channel from the same seed in its own
+        src/seer/conduit/channel.py. If either side's namespace changes, in-flight
+        runs break silently at deploy: Sentry hands the browser one channel while
+        Seer publishes to another.
+        """
+        assert str(CONDUIT_CHANNEL_NAMESPACE) == "6f1a8f5e-3e9a-4a52-9b3b-2f0b6a7c1d84"
+        assert channel_id_for_seer_run(42) == "adc8e72a-111f-521d-bfab-44f3308a7b2e"


### PR DESCRIPTION
Mints the token, channel, and gateway URL a browser needs to stream a Seer run
from Conduit, so the frontend can stop polling the state endpoint every 500ms.

This is the authorization boundary for streaming. Conduit's gateway serves any
channel to whoever holds a token whose org_id/channel_id claims match it, and
only Sentry can sign one -- so the checks here are what stand between a user
and another org's agent output. They deliberately mirror the GET on
OrganizationSeerAgentChatEndpoint: anything you can stream, you can already
poll.

The channel is derived from the run id via uuid5 rather than minted per
connection, because a run outlives any single browser connection. Deriving it
means Seer computes the same value independently -- no shared storage, no round
trip -- and reconnects and second tabs resume the same stream. The namespace
constant is duplicated in seer's src/seer/conduit/channel.py and pinned by a
test on both sides: if the two ever diverge, Sentry hands the browser one
channel while Seer publishes to another, with no error to show for it.

get_conduit_credentials grows an optional channel_id for this, and a referrer
tag so the demo and explorer paths are separable in metrics.

Every unavailable state -- feature off, run still mirroring, Conduit
unconfigured -- returns without credentials rather than erroring, because the
client's fallback is the polling it does today.
