### PR TITLE
feat(issue-inbox): Improve the linked pull request component when there is more room

### DIFF
--- a/static/app/components/group/externalIssuesList/linkedPullRequests.spec.tsx
+++ b/static/app/components/group/externalIssuesList/linkedPullRequests.spec.tsx
@@ -139,39 +139,6 @@ describe('LinkedPullRequests', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('preserves the existing row layout in compact mode', async () => {
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/issues/${group.id}/pull-requests/`,
-      body: {
-        pullRequests: [
-          {
-            ...PullRequestFixture({id: '123', repository}),
-            attribution: null,
-            checksStatus: 'failure',
-            dateLinked: '2026-06-08T23:11:32.000000Z',
-            reviewStatus: 'changes_requested',
-            status: 'open',
-          },
-        ],
-      },
-    });
-
-    render(<LinkedPullRequests group={group} variant="compact" />, {
-      organization,
-    });
-
-    const pullRequest = await screen.findByRole('link', {
-      name: /Pull request #123/,
-    });
-    const detailLine = within(pullRequest).getByText('Open').parentElement?.parentElement;
-
-    expect(detailLine).toContainElement(within(pullRequest).getByText('Checks failed'));
-    expect(detailLine).toContainElement(
-      within(pullRequest).getByText('Changes requested')
-    );
-    expect(within(pullRequest).queryByText('Pull request #123')).not.toBeInTheDocument();
-  });
-
   it('deduplicates pull request ids from group activity', () => {
     const activityGroup = GroupFixture({
       activity: [

--- a/static/app/components/group/externalIssuesList/linkedPullRequests.spec.tsx
+++ b/static/app/components/group/externalIssuesList/linkedPullRequests.spec.tsx
@@ -71,12 +71,13 @@ describe('LinkedPullRequests', () => {
     expect(linkedPullRequest).toHaveAccessibleName(
       `Pull request #123 in ${REPOSITORY_NAME}, Merged, Fix widget crash on startup`
     );
-    await userEvent.hover(within(linkedPullRequest).getByText('#123'));
-    expect(await screen.findByText('Fix widget crash on startup')).toBeInTheDocument();
+    await userEvent.hover(linkedPullRequest);
+    expect(await screen.findAllByText('Fix widget crash on startup')).toHaveLength(2);
     expect(within(list).getAllByRole('listitem')).toHaveLength(2);
-    expect(within(list).getByText('#123')).toBeInTheDocument();
-    expect(within(list).getByText('#124')).toBeInTheDocument();
-    expect(within(list).getAllByText(REPOSITORY_NAME)).toHaveLength(2);
+    expect(within(list).getByText(`${REPOSITORY_NAME}#123`)).toBeInTheDocument();
+    expect(within(list).getByText(`${REPOSITORY_NAME}#124`)).toBeInTheDocument();
+    expect(within(list).getByText('Fix widget crash on startup')).toBeInTheDocument();
+    expect(within(list).getByText('Remove unused widget fallback')).toBeInTheDocument();
     expect(within(list).getByText('Merged')).toBeInTheDocument();
     expect(within(list).getByText('Closed')).toBeInTheDocument();
     expect(within(linkedPullRequest).getByText('AL')).toBeInTheDocument();
@@ -99,7 +100,7 @@ describe('LinkedPullRequests', () => {
     );
   });
 
-  it('renders checks and review badges when available', async () => {
+  it('renders checks and review details when available', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/issues/${group.id}/pull-requests/`,
       body: {
@@ -127,15 +128,48 @@ describe('LinkedPullRequests', () => {
     render(<LinkedPullRequests group={group} />, {organization});
 
     const list = await screen.findByRole('list', {name: 'Linked pull requests'});
-    const withBadges = within(list).getByRole('link', {name: /Pull request #123/});
-    const withoutBadges = within(list).getByRole('link', {name: /Pull request #124/});
+    const withDetails = within(list).getByRole('link', {name: /Pull request #123/});
+    const withoutDetails = within(list).getByRole('link', {name: /Pull request #124/});
 
-    expect(within(withBadges).getByText('Checks failed')).toBeInTheDocument();
-    expect(within(withBadges).getByText('Changes requested')).toBeInTheDocument();
-    expect(within(withoutBadges).queryByText('Checks failed')).not.toBeInTheDocument();
+    expect(within(withDetails).getByText('Checks failed')).toBeInTheDocument();
+    expect(within(withDetails).getByText('Changes requested')).toBeInTheDocument();
+    expect(within(withoutDetails).queryByText('Checks failed')).not.toBeInTheDocument();
     expect(
-      within(withoutBadges).queryByText('Changes requested')
+      within(withoutDetails).queryByText('Changes requested')
     ).not.toBeInTheDocument();
+  });
+
+  it('preserves the existing row layout in compact mode', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${group.id}/pull-requests/`,
+      body: {
+        pullRequests: [
+          {
+            ...PullRequestFixture({id: '123', repository}),
+            attribution: null,
+            checksStatus: 'failure',
+            dateLinked: '2026-06-08T23:11:32.000000Z',
+            reviewStatus: 'changes_requested',
+            status: 'open',
+          },
+        ],
+      },
+    });
+
+    render(<LinkedPullRequests group={group} variant="compact" />, {
+      organization,
+    });
+
+    const pullRequest = await screen.findByRole('link', {
+      name: /Pull request #123/,
+    });
+    const detailLine = within(pullRequest).getByText('Open').parentElement?.parentElement;
+
+    expect(detailLine).toContainElement(within(pullRequest).getByText('Checks failed'));
+    expect(detailLine).toContainElement(
+      within(pullRequest).getByText('Changes requested')
+    );
+    expect(within(pullRequest).queryByText('Pull request #123')).not.toBeInTheDocument();
   });
 
   it('deduplicates pull request ids from group activity', () => {

--- a/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
+++ b/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
@@ -1,3 +1,4 @@
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 import {useQuery} from '@tanstack/react-query';
 
@@ -64,14 +65,17 @@ interface LinkedPullRequestsProps {
   group: Group;
   showChecksAndReview?: boolean;
   showEmptyState?: boolean;
+  variant?: 'compact' | 'default';
 }
 
 function LinkedPullRequestRow({
   group,
   pullRequest,
+  variant,
 }: {
   group: Group;
   pullRequest: LinkedPullRequest;
+  variant: 'compact' | 'default';
 }) {
   const organization = useOrganization();
   const title = pullRequest.title ?? t('Pull request #%s', pullRequest.id);
@@ -112,7 +116,11 @@ function LinkedPullRequestRow({
           })
         }
       >
-        <Grid columns="max-content minmax(0, 1fr)" gap="sm" padding="sm">
+        <Grid
+          columns="max-content minmax(0, 1fr)"
+          gap="sm"
+          padding={variant === 'compact' ? 'sm' : 'md'}
+        >
           <Flex as="span" aria-hidden align="start">
             <RepoProviderIcon
               provider={pullRequest.repository.provider.id}
@@ -120,36 +128,56 @@ function LinkedPullRequestRow({
               variant="muted"
             />
           </Flex>
-          <Stack gap="xs" minWidth={0}>
-            <PullRequestTitle>
-              <Text as="span" bold textWrap="nowrap">
-                {pullRequestLabel}
-              </Text>
-              <Text as="span" ellipsis>
-                {pullRequest.repository.name}
-              </Text>
-            </PullRequestTitle>
-            <Flex align="center" gap="xs">
+          <Stack gap={variant === 'default' ? 'sm' : 'xs'} minWidth={0}>
+            <Stack gap="xs">
+              {variant === 'default' && (
+                <Text as="span" bold ellipsis>
+                  {title}
+                </Text>
+              )}
+              <PullRequestTitle>
+                {variant === 'default' ? (
+                  <Fragment>
+                    <Text as="span" ellipsis variant="muted">
+                      {pullRequest.repository.name}
+                      {pullRequestLabel}
+                    </Text>
+                  </Fragment>
+                ) : (
+                  <Fragment>
+                    <Text as="span" bold textWrap="nowrap">
+                      {pullRequestLabel}
+                    </Text>
+                    <Text as="span" ellipsis>
+                      {pullRequest.repository.name}
+                    </Text>
+                  </Fragment>
+                )}
+              </PullRequestTitle>
+            </Stack>
+            <Flex align="center" gap="md" wrap="wrap">
               <PullRequestStatusBadge status={pullRequest.status} />
+              <Flex align="center" gap="xs">
+                {pullRequest.attribution ? (
+                  <PullRequestAttributionAvatar attribution={pullRequest.attribution} />
+                ) : author ? (
+                  <PullRequestAuthorAvatar author={author} />
+                ) : null}
+                <Text as="span" size="sm" variant="muted">
+                  <TimeSince
+                    date={pullRequest.dateLinked}
+                    suffix={t('ago')}
+                    tooltipPrefix={t('Linked')}
+                    unitStyle="short"
+                  />
+                </Text>
+              </Flex>
               {pullRequest.checksStatus && (
                 <PullRequestChecksBadge status={pullRequest.checksStatus} />
               )}
               {pullRequest.reviewStatus && (
                 <PullRequestReviewBadge status={pullRequest.reviewStatus} />
               )}
-              {pullRequest.attribution ? (
-                <PullRequestAttributionAvatar attribution={pullRequest.attribution} />
-              ) : author ? (
-                <PullRequestAuthorAvatar author={author} />
-              ) : null}
-              <Text as="span" size="sm" variant="muted">
-                <TimeSince
-                  date={pullRequest.dateLinked}
-                  suffix={t('ago')}
-                  tooltipPrefix={t('Linked')}
-                  unitStyle="short"
-                />
-              </Text>
             </Flex>
           </Stack>
         </Grid>
@@ -257,6 +285,7 @@ export function LinkedPullRequests({
   group,
   showChecksAndReview = true,
   showEmptyState,
+  variant = 'default',
 }: LinkedPullRequestsProps) {
   const {data, isError, isPending} = useLinkedPullRequests({
     group,
@@ -269,7 +298,7 @@ export function LinkedPullRequests({
   }
 
   if (isPending && activityPullRequestIds.size > 0) {
-    return <Placeholder height="52px" />;
+    return <Placeholder height={variant === 'compact' ? '52px' : '78px'} />;
   }
 
   if (data?.pullRequests.length === 0) {
@@ -301,7 +330,11 @@ export function LinkedPullRequests({
           borderTop={index === 0 ? undefined : 'primary'}
           style={{listStyle: 'none'}}
         >
-          <LinkedPullRequestRow group={group} pullRequest={pullRequest} />
+          <LinkedPullRequestRow
+            group={group}
+            pullRequest={pullRequest}
+            variant={variant}
+          />
         </Container>
       ))}
     </Stack>

--- a/static/app/components/group/externalIssuesList/pullRequestStatusBadge.tsx
+++ b/static/app/components/group/externalIssuesList/pullRequestStatusBadge.tsx
@@ -1,9 +1,10 @@
 import {Badge} from '@sentry/scraps/badge';
 import {Grid} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
 
 import {
   IconCheckmark,
-  IconClock,
+  IconCircle,
   IconClose,
   IconMerge,
   IconPullRequest,
@@ -21,6 +22,12 @@ type PullRequestBadgeConfig = {
   icon: React.ComponentType<SVGIconProps>;
   label: () => string;
   variant: React.ComponentProps<typeof Badge>['variant'];
+};
+
+type PullRequestDetailConfig = {
+  icon: React.ComponentType<SVGIconProps>;
+  label: () => string;
+  variant: SVGIconProps['variant'];
 };
 
 const STATUS_CONFIG = {
@@ -58,16 +65,16 @@ const CHECKS_CONFIG = {
     variant: 'danger',
   },
   pending: {
-    icon: IconClock,
+    icon: IconCircle,
     label: () => t('Checks running'),
-    variant: 'muted',
+    variant: 'warning',
   },
   success: {
     icon: IconCheckmark,
     label: () => t('Checks passed'),
     variant: 'success',
   },
-} satisfies Record<PullRequestChecksStatus, PullRequestBadgeConfig>;
+} satisfies Record<PullRequestChecksStatus, PullRequestDetailConfig>;
 
 const REVIEW_CONFIG = {
   approved: {
@@ -81,11 +88,11 @@ const REVIEW_CONFIG = {
     variant: 'danger',
   },
   review_required: {
-    icon: IconClock,
+    icon: IconCircle,
     label: () => t('Review required'),
-    variant: 'muted',
+    variant: 'warning',
   },
-} satisfies Record<PullRequestReviewStatus, PullRequestBadgeConfig>;
+} satisfies Record<PullRequestReviewStatus, PullRequestDetailConfig>;
 
 function PullRequestBadge({
   ariaLabel,
@@ -106,6 +113,19 @@ function PullRequestBadge({
   );
 }
 
+function PullRequestDetail({config}: {config: PullRequestDetailConfig}) {
+  const {icon: StatusIcon, label, variant} = config;
+
+  return (
+    <Grid as="span" align="center" columns="max-content max-content" gap="xs">
+      <StatusIcon aria-hidden size="xs" variant={variant} />
+      <Text as="span" variant="muted" size="sm">
+        {label()}
+      </Text>
+    </Grid>
+  );
+}
+
 export function getPullRequestStatusLabel(status: PullRequestStatus) {
   return STATUS_CONFIG[status].label();
 }
@@ -122,9 +142,9 @@ export function PullRequestStatusBadge({status}: {status: PullRequestStatus}) {
 }
 
 export function PullRequestChecksBadge({status}: {status: PullRequestChecksStatus}) {
-  return <PullRequestBadge config={CHECKS_CONFIG[status]} />;
+  return <PullRequestDetail config={CHECKS_CONFIG[status]} />;
 }
 
 export function PullRequestReviewBadge({status}: {status: PullRequestReviewStatus}) {
-  return <PullRequestBadge config={REVIEW_CONFIG[status]} />;
+  return <PullRequestDetail config={REVIEW_CONFIG[status]} />;
 }

--- a/static/app/views/issueDetails/sidebar/externalIssueSidebarList.tsx
+++ b/static/app/views/issueDetails/sidebar/externalIssueSidebarList.tsx
@@ -67,6 +67,7 @@ export function ExternalIssueSidebarList({event, group}: Props) {
               externalIssueData.integrations.length > 0 &&
               externalIssueData.linkedIssues.length === 0
             }
+            variant="compact"
           />
         </ErrorBoundary>
         {showEmptyIssueTrackerAction && (


### PR DESCRIPTION
Adds a `compact`/`default` variant prop to the linked pull requests component so that we can show more details when on the inbox issue preview view.

This is more aligned with the inbox designs. It shows the full PR title and updates the checks/review status to use icons with muted text instead of badges.

Before:

<img width="1058" height="132" alt="CleanShot 2026-08-07 at 14 45 22@2x" src="https://github.com/user-attachments/assets/ee4ec444-f146-401c-a10e-ebccc41a00b1" />


After:

<img width="1032" height="180" alt="CleanShot 2026-08-07 at 14 44 53@2x" src="https://github.com/user-attachments/assets/3b2378a0-2ecf-48d8-b271-6876ecff6b3f" />
