### PR TITLE
build(ui): Stop dev-ui-production rebuild loop

### DIFF
--- a/build-utils/story-manifest.ts
+++ b/build-utils/story-manifest.ts
@@ -6,7 +6,6 @@ import rspack from '@rspack/core';
 import {parse as parseYaml} from 'yaml';
 
 const appDir = path.resolve(import.meta.dirname, '../static/app');
-const modulePath = 'app/stories/storyManifest.generated.ts';
 const PLUGIN_NAME = 'StoryManifestPlugin';
 const STORY_GLOB = '**/*.{stories.tsx,mdx}';
 const STORY_FILE_PATTERN = /(?:\.stories\.tsx|\.mdx)$/;
@@ -53,6 +52,8 @@ if (import.meta.webpackHot) {
 }
 
 export class StoryManifestPlugin implements RspackPluginInstance {
+  static readonly modulePath = 'app/stories/storyManifest.generated.ts';
+
   private manifest = createManifest();
   private pending = new Set<string>();
   private timer?: NodeJS.Timeout;
@@ -60,7 +61,7 @@ export class StoryManifestPlugin implements RspackPluginInstance {
   // Rust compiler is initialized.
   // https://rspack.rs/plugins/rspack/virtual-modules-plugin#dynamic-module-creation
   private readonly virtualModules = new rspack.experiments.VirtualModulesPlugin({
-    [modulePath]: this.manifest.source,
+    [StoryManifestPlugin.modulePath]: this.manifest.source,
   });
   private watcher?: fs.FSWatcher;
 
@@ -121,7 +122,7 @@ export class StoryManifestPlugin implements RspackPluginInstance {
       manifestChanged = next.source !== this.manifest.source;
       if (manifestChanged) {
         this.manifest = next;
-        this.virtualModules.writeModule(modulePath, next.source);
+        this.virtualModules.writeModule(StoryManifestPlugin.modulePath, next.source);
       }
     }
     if (!manifestChanged || changedExistingStory) {

--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -294,8 +294,10 @@ const appConfig: Configuration = {
   incremental: DEV_MODE,
   watchOptions: {
     // StoryManifestPlugin owns these watches so it can update the virtual
-    // manifest before invalidating changed and removed story dependencies.
-    ignored: ['**/*.stories.tsx', '**/*.mdx'],
+    // manifest before invalidating changed and removed story dependencies. Its
+    // virtual module must also be ignored so the filesystem watcher does not
+    // repeatedly report the intentionally nonexistent file as removed.
+    ignored: ['**/*.stories.tsx', '**/*.mdx', `**/${StoryManifestPlugin.modulePath}`],
   },
   experiments: {
     futureDefaults: true,


### PR DESCRIPTION
#119885 moved story discovery into a virtual manifest, but `dev-ui-production` watch mode treated that virtual `.ts` file as removed after every successful build. That immediately started another full production build, so the server rebuilt forever.