### PR TITLE
RFC: Prototype pipeline-based editing of GAL-based Activity results

### DIFF
--- a/src/sentry/issues/endpoints/group_details.py
+++ b/src/sentry/issues/endpoints/group_details.py
@@ -2,9 +2,10 @@ import copy
 import functools
 import logging
 from collections.abc import Sequence
+from dataclasses import dataclass, field
 from datetime import timedelta
 from enum import StrEnum
-from typing import Any, TypedDict, cast
+from typing import Any, Self, cast
 
 from django.core.cache import cache
 from django.utils import timezone
@@ -117,25 +118,49 @@ class _SeerStep(StrEnum):
     ITERATION = "iteration"
 
 
-class _CommentValue(TypedDict):
+@dataclass(frozen=True)
+class _CommentMention:
+    id: int
+    actor_type: str
+    slug: str | None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"id": self.id, "actor_type": self.actor_type, "slug": self.slug}
+
+
+@dataclass(frozen=True)
+class _CommentValue:
     text: str | None
-    mentions: list[dict[str, Any]] | None
+    mentions: tuple[_CommentMention, ...] | None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "text": self.text,
+            "mentions": (
+                [mention.as_dict() for mention in self.mentions]
+                if self.mentions is not None
+                else None
+            ),
+        }
 
 
-class _Edits(TypedDict):
-    to_delete: list[int]
-    comment_values: dict[int, _CommentValue | None]
+@dataclass
+class _Edits:
+    to_delete: list[int] = field(default_factory=list)
+    comment_values: dict[int, _CommentValue | None] = field(default_factory=dict)
+
+    def copy(self) -> Self:
+        return type(self)(
+            to_delete=self.to_delete.copy(),
+            comment_values=self.comment_values.copy(),
+        )
 
 
 type _PendingSeerStarts = dict[tuple[_SeerStep, int | str], list[int]]
 
 
-def _empty_edits() -> _Edits:
-    return {"to_delete": [], "comment_values": {}}
-
-
 _PENDING_SEER_STARTS = Feature[_PendingSeerStarts]("pending_seer_starts", default_factory=dict)
-EDITS = Feature[_Edits]("edits", default_factory=_empty_edits)
+EDITS = Feature[_Edits]("edits", default_factory=_Edits)
 
 
 @aggregator(
@@ -155,29 +180,33 @@ EDITS = Feature[_Edits]("edits", default_factory=_empty_edits)
 )
 def _track_action_log_edits(state: StateView, entry: GroupActionLogEntry) -> AggregatorResult:
     action = entry.action
-    edits: _Edits = {
-        "to_delete": list(state[EDITS]["to_delete"]),
-        "comment_values": dict(state[EDITS]["comment_values"]),
-    }
+    edits = state[EDITS].copy()
     pending_starts: _PendingSeerStarts = {
         step: list(action_ids) for step, action_ids in state[_PENDING_SEER_STARTS].items()
     }
 
     match action:
         case CommentEditAction():
-            edits["to_delete"].append(entry.id)
-            edits["comment_values"][action.comment_id] = {
-                "text": action.text,
-                "mentions": (
-                    [mention.dict() for mention in action.mentions]
+            edits.to_delete.append(entry.id)
+            edits.comment_values[action.comment_id] = _CommentValue(
+                text=action.text,
+                mentions=(
+                    tuple(
+                        _CommentMention(
+                            id=mention.id,
+                            actor_type=mention.actor_type,
+                            slug=mention.slug,
+                        )
+                        for mention in action.mentions
+                    )
                     if action.mentions is not None
                     else None
                 ),
-            }
+            )
             return emit(_PENDING_SEER_STARTS.value(pending_starts), EDITS.value(edits))
         case CommentDeleteAction():
-            edits["to_delete"].append(entry.id)
-            edits["comment_values"][action.comment_id] = None
+            edits.to_delete.append(entry.id)
+            edits.comment_values[action.comment_id] = None
             return emit(_PENDING_SEER_STARTS.value(pending_starts), EDITS.value(edits))
         case SeerRCAStartedAction():
             step, completed = _SeerStep.RCA, False
@@ -204,7 +233,7 @@ def _track_action_log_edits(state: StateView, entry: GroupActionLogEntry) -> Agg
 
     key = (step, run_id)
     if completed:
-        edits["to_delete"].extend(pending_starts.pop(key, []))
+        edits.to_delete.extend(pending_starts.pop(key, []))
     else:
         pending_starts.setdefault(key, []).append(entry.id)
 
@@ -218,17 +247,17 @@ def _apply_action_log_edits(
     action_log: Sequence[GroupActionLogEntry],
 ) -> list[GroupActionLogEntry]:
     edits = _ACTION_LOG_PIPELINE.run(reversed(action_log))[EDITS]
-    to_delete = set(edits["to_delete"])
+    to_delete = set(edits.to_delete)
     edited_action_log = []
     for entry in action_log:
         if entry.id in to_delete:
             continue
-        if entry.id in edits["comment_values"]:
-            comment_value = edits["comment_values"][entry.id]
+        if entry.id in edits.comment_values:
+            comment_value = edits.comment_values[entry.id]
             if comment_value is None:
                 continue
             entry = copy.copy(entry)
-            entry.data = {**entry.data, **comment_value}
+            entry.data = {**entry.data, **comment_value.as_dict()}
             # The return value should probably be something different so we're not mutating
             # models not intended to be mutated, and so we can create synthetic activity results
             # if we want.

--- a/src/sentry/issues/endpoints/group_details.py
+++ b/src/sentry/issues/endpoints/group_details.py
@@ -1,8 +1,10 @@
+import copy
 import functools
 import logging
 from collections.abc import Sequence
 from datetime import timedelta
-from typing import Any, cast
+from enum import StrEnum
+from typing import Any, TypedDict, cast
 
 from django.core.cache import cache
 from django.utils import timezone
@@ -47,13 +49,33 @@ from sentry.issues.action_log import (
     resolve_action_actor,
     resolve_action_source,
 )
-from sentry.issues.action_log.types import ViewAction
+from sentry.issues.action_log.types import (
+    CommentDeleteAction,
+    CommentEditAction,
+    SeerCodingCompletedAction,
+    SeerCodingStartedAction,
+    SeerIterationCompletedAction,
+    SeerIterationStartedAction,
+    SeerRCACompletedAction,
+    SeerRCAStartedAction,
+    SeerSolutionCompletedAction,
+    SeerSolutionStartedAction,
+    ViewAction,
+)
 from sentry.issues.constants import (
     ISSUE_VIEW_CACHE_KEY_TTL,
     cache_key_for_issue_view,
     get_issue_tsdb_group_model,
 )
 from sentry.issues.derived.check import check_status_consistency
+from sentry.issues.derived.framework import (
+    AggregatorResult,
+    Feature,
+    Pipeline,
+    StateView,
+    aggregator,
+    emit,
+)
 from sentry.issues.derived.gate import derived_should_be_correct
 from sentry.issues.endpoints.bases.group import GroupEndpoint
 from sentry.issues.escalating.escalating_group_forecast import EscalatingGroupForecast
@@ -86,6 +108,133 @@ logger = logging.getLogger(__name__)
 def get_group_global_count(group: Group) -> str:
     fetch_buffered_group_stats(group)
     return str(group.times_seen_with_pending)
+
+
+class _SeerStep(StrEnum):
+    RCA = "rca"
+    SOLUTION = "solution"
+    CODING = "coding"
+    ITERATION = "iteration"
+
+
+class _CommentValue(TypedDict):
+    text: str | None
+    mentions: list[dict[str, Any]] | None
+
+
+class _Edits(TypedDict):
+    to_delete: list[int]
+    comment_values: dict[int, _CommentValue | None]
+
+
+type _PendingSeerStarts = dict[tuple[_SeerStep, int | str], list[int]]
+
+
+def _empty_edits() -> _Edits:
+    return {"to_delete": [], "comment_values": {}}
+
+
+_PENDING_SEER_STARTS = Feature[_PendingSeerStarts]("pending_seer_starts", default_factory=dict)
+EDITS = Feature[_Edits]("edits", default_factory=_empty_edits)
+
+
+@aggregator(
+    (_PENDING_SEER_STARTS, EDITS),
+    scope=(
+        CommentEditAction,
+        CommentDeleteAction,
+        SeerRCAStartedAction,
+        SeerRCACompletedAction,
+        SeerSolutionStartedAction,
+        SeerSolutionCompletedAction,
+        SeerCodingStartedAction,
+        SeerCodingCompletedAction,
+        SeerIterationStartedAction,
+        SeerIterationCompletedAction,
+    ),
+)
+def _track_action_log_edits(state: StateView, entry: GroupActionLogEntry) -> AggregatorResult:
+    action = entry.action
+    edits: _Edits = {
+        "to_delete": list(state[EDITS]["to_delete"]),
+        "comment_values": dict(state[EDITS]["comment_values"]),
+    }
+    pending_starts: _PendingSeerStarts = {
+        step: list(action_ids) for step, action_ids in state[_PENDING_SEER_STARTS].items()
+    }
+
+    match action:
+        case CommentEditAction():
+            edits["to_delete"].append(entry.id)
+            edits["comment_values"][action.comment_id] = {
+                "text": action.text,
+                "mentions": (
+                    [mention.dict() for mention in action.mentions]
+                    if action.mentions is not None
+                    else None
+                ),
+            }
+            return emit(_PENDING_SEER_STARTS.value(pending_starts), EDITS.value(edits))
+        case CommentDeleteAction():
+            edits["to_delete"].append(entry.id)
+            edits["comment_values"][action.comment_id] = None
+            return emit(_PENDING_SEER_STARTS.value(pending_starts), EDITS.value(edits))
+        case SeerRCAStartedAction():
+            step, completed = _SeerStep.RCA, False
+        case SeerRCACompletedAction():
+            step, completed = _SeerStep.RCA, True
+        case SeerSolutionStartedAction():
+            step, completed = _SeerStep.SOLUTION, False
+        case SeerSolutionCompletedAction():
+            step, completed = _SeerStep.SOLUTION, True
+        case SeerCodingStartedAction():
+            step, completed = _SeerStep.CODING, False
+        case SeerCodingCompletedAction():
+            step, completed = _SeerStep.CODING, True
+        case SeerIterationStartedAction():
+            step, completed = _SeerStep.ITERATION, False
+        case SeerIterationCompletedAction():
+            step, completed = _SeerStep.ITERATION, True
+        case _:
+            return None
+
+    run_id = getattr(action, "run_id", None)
+    if run_id is None:
+        return None
+
+    key = (step, run_id)
+    if completed:
+        edits["to_delete"].extend(pending_starts.pop(key, []))
+    else:
+        pending_starts.setdefault(key, []).append(entry.id)
+
+    return emit(_PENDING_SEER_STARTS.value(pending_starts), EDITS.value(edits))
+
+
+_ACTION_LOG_PIPELINE = Pipeline([_track_action_log_edits])
+
+
+def _apply_action_log_edits(
+    action_log: Sequence[GroupActionLogEntry],
+) -> list[GroupActionLogEntry]:
+    edits = _ACTION_LOG_PIPELINE.run(reversed(action_log))[EDITS]
+    to_delete = set(edits["to_delete"])
+    edited_action_log = []
+    for entry in action_log:
+        if entry.id in to_delete:
+            continue
+        if entry.id in edits["comment_values"]:
+            comment_value = edits["comment_values"][entry.id]
+            if comment_value is None:
+                continue
+            entry = copy.copy(entry)
+            entry.data = {**entry.data, **comment_value}
+            # The return value should probably be something different so we're not mutating
+            # models not intended to be mutated, and so we can create synthetic activity results
+            # if we want.
+            entry.__dict__.pop("action", None)
+        edited_action_log.append(entry)
+    return edited_action_log
 
 
 @extend_schema(tags=["Events"])
@@ -367,6 +516,7 @@ class GroupDetailsEndpoint(GroupEndpoint):
             ):
                 action_log = GroupActionLogEntry.objects.get_actions_for_group(group, 99)
                 if action_log:
+                    action_log = _apply_action_log_edits(action_log)
                     # swap action log data in under the activity name
                     first_seen_entry = cast(dict[str, Any], serialize_first_seen_entry(group))
                     data.update(

--- a/tests/sentry/issues/endpoints/test_group_details.py
+++ b/tests/sentry/issues/endpoints/test_group_details.py
@@ -11,9 +11,22 @@ from sentry.analytics.events.issue_viewed import IssueViewedEvent
 from sentry.buffer.redis import RedisBuffer
 from sentry.deletions.tasks.hybrid_cloud import schedule_hybrid_cloud_foreign_key_jobs
 from sentry.issues.action_log import action_context_scope
-from sentry.issues.action_log.types import ActionSource, GroupActionActor, ReconcileStatusAction
+from sentry.issues.action_log.types import (
+    ActionSource,
+    AssignAction,
+    GroupAction,
+    GroupActionActor,
+    GroupActionType,
+    ReconcileStatusAction,
+    SeerCodingCompletedAction,
+    SeerCodingStartedAction,
+    SeerRCACompletedAction,
+    SeerRCAStartedAction,
+    SeerSolutionStartedAction,
+)
 from sentry.issues.constants import cache_key_for_issue_view
 from sentry.issues.derived.gate import GROUP_ACTION_LOG_BACKFILL_COMPLETED_OPTION
+from sentry.issues.endpoints.group_details import _apply_action_log_edits
 from sentry.issues.grouptype import PerformanceSlowDBQueryGroupType
 from sentry.models.activity import Activity
 from sentry.models.apikey import ApiKey
@@ -159,6 +172,185 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
             "rule": None,
         }
         assert entry["dateCreated"] is not None
+
+    @with_feature("projects:issue-action-log-activity")
+    def test_group_action_log_collapses_comment_edits(self) -> None:
+        group = self.create_group()
+        created_at = timezone.now() - timedelta(hours=1)
+        comment = self.create_group_action_log_entry(
+            group=group,
+            type=GroupActionType.COMMENT,
+            data={"comment_id": 123, "text": "original", "mentions": []},
+            date_added=created_at,
+        )
+        first_edit = self.create_group_action_log_entry(
+            group=group,
+            type=GroupActionType.COMMENT_EDIT,
+            data={"comment_id": comment.id, "text": "first edit", "mentions": []},
+            date_added=created_at + timedelta(minutes=1),
+        )
+        latest_edit = self.create_group_action_log_entry(
+            group=group,
+            type=GroupActionType.COMMENT_EDIT,
+            data={
+                "comment_id": comment.id,
+                "text": "latest edit",
+                "mentions": [
+                    {"id": self.user.id, "actor_type": "User", "slug": self.user.username}
+                ],
+            },
+            date_added=created_at + timedelta(minutes=2),
+        )
+        self.login_as(user=self.user)
+
+        response = self.client.get(
+            f"/api/0/organizations/{group.organization.slug}/issues/{group.id}/", format="json"
+        )
+
+        assert response.status_code == 200
+        comment_entries = [entry for entry in response.data["activity"] if entry["type"] == "note"]
+        assert len(comment_entries) == 1
+        assert comment_entries[0]["id"] == str(comment.id)
+        assert comment_entries[0]["data"]["text"] == "latest edit"
+        activity_ids = {entry["id"] for entry in response.data["activity"]}
+        assert str(first_edit.id) not in activity_ids
+        assert str(latest_edit.id) not in activity_ids
+
+        edited_entries = _apply_action_log_edits([latest_edit, first_edit, comment])
+        assert edited_entries == [comment]
+        assert edited_entries[0].data["mentions"] == [
+            {"id": self.user.id, "actor_type": "User", "slug": self.user.username}
+        ]
+        assert comment.data["text"] == "original"
+
+    def test_apply_action_log_edits_removes_redundant_actions(self) -> None:
+        group = self.create_group()
+        raw_actions: list[GroupAction] = [
+            AssignAction(assignee=str(self.user.id)),
+            SeerCodingCompletedAction(run_id=3, changes=[]),
+            SeerRCACompletedAction(run_id=1, summary="root cause found"),
+            SeerCodingStartedAction(run_id=4),
+            SeerSolutionStartedAction(run_id=2),
+            SeerCodingStartedAction(run_id=3),
+            SeerRCAStartedAction(run_id=1),
+        ]
+        action_log = [
+            self.create_group_action_log_entry(
+                group=group,
+                type=action.get_type(),
+                data=action.dict(),
+            )
+            for action in raw_actions
+        ]
+
+        cleaned_actions = [entry.action for entry in _apply_action_log_edits(action_log)]
+
+        assert cleaned_actions == [
+            AssignAction(assignee=str(self.user.id)),
+            SeerCodingCompletedAction(run_id=3, changes=[]),
+            SeerRCACompletedAction(run_id=1, summary="root cause found"),
+            SeerCodingStartedAction(run_id=4),
+            SeerSolutionStartedAction(run_id=2),
+        ]
+
+    @with_feature("projects:issue-action-log-activity")
+    def test_group_action_log_removes_deleted_comment(self) -> None:
+        group = self.create_group()
+        created_at = timezone.now() - timedelta(hours=1)
+        comment = self.create_group_action_log_entry(
+            group=group,
+            type=GroupActionType.COMMENT,
+            data={"comment_id": 123, "text": "original", "mentions": []},
+            date_added=created_at,
+        )
+        edit = self.create_group_action_log_entry(
+            group=group,
+            type=GroupActionType.COMMENT_EDIT,
+            data={"comment_id": comment.id, "text": "edited", "mentions": []},
+            date_added=created_at + timedelta(minutes=1),
+        )
+        deletion = self.create_group_action_log_entry(
+            group=group,
+            type=GroupActionType.COMMENT_DELETE,
+            data={"comment_id": comment.id},
+            date_added=created_at + timedelta(minutes=2),
+        )
+        self.login_as(user=self.user)
+
+        response = self.client.get(
+            f"/api/0/organizations/{group.organization.slug}/issues/{group.id}/", format="json"
+        )
+
+        assert response.status_code == 200
+        activity_ids = {entry["id"] for entry in response.data["activity"]}
+        assert str(comment.id) not in activity_ids
+        assert str(edit.id) not in activity_ids
+        assert str(deletion.id) not in activity_ids
+        assert all(entry["type"] != "note" for entry in response.data["activity"])
+
+    @with_feature("projects:issue-action-log-activity")
+    def test_group_action_log_removes_completed_seer_starts(self) -> None:
+        group = self.create_group()
+        started_at = timezone.now() - timedelta(hours=1)
+        action_pairs = (
+            (GroupActionType.SEER_RCA_STARTED, GroupActionType.SEER_RCA_COMPLETED),
+            (GroupActionType.SEER_SOLUTION_STARTED, GroupActionType.SEER_SOLUTION_COMPLETED),
+            (GroupActionType.SEER_CODING_STARTED, GroupActionType.SEER_CODING_COMPLETED),
+        )
+        started_entries = []
+        completed_entries = []
+        for offset, (started_type, completed_type) in enumerate(action_pairs):
+            started_entries.append(
+                self.create_group_action_log_entry(
+                    group=group,
+                    type=started_type,
+                    data={"run_id": offset},
+                    date_added=started_at + timedelta(minutes=offset * 2),
+                )
+            )
+            completed_entries.append(
+                self.create_group_action_log_entry(
+                    group=group,
+                    type=completed_type,
+                    data={"run_id": offset},
+                    date_added=started_at + timedelta(minutes=offset * 2 + 1),
+                )
+            )
+        self.login_as(user=self.user)
+
+        response = self.client.get(
+            f"/api/0/organizations/{group.organization.slug}/issues/{group.id}/", format="json"
+        )
+
+        assert response.status_code == 200
+        activity_ids = {entry["id"] for entry in response.data["activity"]}
+        assert activity_ids.isdisjoint(str(entry.id) for entry in started_entries)
+        assert activity_ids.issuperset(str(entry.id) for entry in completed_entries)
+
+    @with_feature("projects:issue-action-log-activity")
+    def test_group_action_log_keeps_seer_start_after_completion(self) -> None:
+        group = self.create_group()
+        completed_at = timezone.now() - timedelta(hours=1)
+        self.create_group_action_log_entry(
+            group=group,
+            type=GroupActionType.SEER_CODING_COMPLETED,
+            data={},
+            date_added=completed_at,
+        )
+        started = self.create_group_action_log_entry(
+            group=group,
+            type=GroupActionType.SEER_CODING_STARTED,
+            data={},
+            date_added=completed_at + timedelta(minutes=1),
+        )
+        self.login_as(user=self.user)
+
+        response = self.client.get(
+            f"/api/0/organizations/{group.organization.slug}/issues/{group.id}/", format="json"
+        )
+
+        assert response.status_code == 200
+        assert str(started.id) in {entry["id"] for entry in response.data["activity"]}
 
     def test_pending_delete_pending_merge_excluded(self) -> None:
         group1 = self.create_group(status=GroupStatus.PENDING_DELETION)


### PR DESCRIPTION
This doesn't do the "query extra of certain types to make sure we have the full edit history" thing, but the core idea is there.
