### PR TITLE
feat(investigations): Add response serializers

### DIFF
--- a/src/sentry/investigations/endpoints/serializers/__init__.py
+++ b/src/sentry/investigations/endpoints/serializers/__init__.py
@@ -1,0 +1,23 @@
+__all__ = (
+    "InvestigationBlockSerializer",
+    "InvestigationBlockSerializerResponse",
+    "InvestigationDetailsSerializer",
+    "InvestigationDetailsSerializerResponse",
+    "InvestigationParameterSerializer",
+    "InvestigationParameterSerializerResponse",
+    "InvestigationSerializer",
+    "InvestigationSerializerResponse",
+)
+
+
+from .block import InvestigationBlockSerializer, InvestigationBlockSerializerResponse
+from .investigation import (
+    InvestigationDetailsSerializer,
+    InvestigationDetailsSerializerResponse,
+    InvestigationSerializer,
+    InvestigationSerializerResponse,
+)
+from .parameter import (
+    InvestigationParameterSerializer,
+    InvestigationParameterSerializerResponse,
+)

--- a/src/sentry/investigations/endpoints/serializers/block.py
+++ b/src/sentry/investigations/endpoints/serializers/block.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Mapping, MutableMapping, Sequence
+from datetime import datetime
+from typing import Any, TypedDict, override
+
+from django.contrib.auth.models import AnonymousUser
+
+from sentry.api.serializers import Serializer
+from sentry.investigations.models import (
+    InvestigationBlock,
+    InvestigationBlockDependency,
+    InvestigationBlockExecution,
+    InvestigationBlockExecutionStatus,
+    InvestigationBlockKind,
+    InvestigationBlockParameter,
+)
+from sentry.users.models.user import User
+from sentry.users.services.user.model import RpcUser
+
+
+class InvestigationBlockExecutionSerializerResponse(TypedDict):
+    id: str
+    status: str
+    executor: str
+    schemaVersion: int
+    startedAt: datetime | None
+    completedAt: datetime | None
+    error: Any | None
+
+
+class InvestigationBlockSerializerResponse(TypedDict):
+    id: str
+    position: int
+    kind: str
+    title: str
+    content: str
+    generationPrompt: str
+    generatedContent: str
+    output: Any | None
+    outputStatus: str
+    currentExecution: InvestigationBlockExecutionSerializerResponse | None
+    config: dict[str, Any]
+    display: dict[str, Any]
+    dependencies: list[str]
+    parameterKeys: list[str]
+    version: int
+    staleAt: datetime | None
+    createdBy: str | None
+    lastEditedBy: str | None
+
+
+class InvestigationBlockSerializer(Serializer[InvestigationBlockSerializerResponse]):
+    """
+    Serializes a block, hiding output the viewer may not see.
+
+    ``accessible_project_ids`` is the set of projects the viewer can read. A
+    block's persisted output is withheld unless every project that contributed
+    to it is in that set, so it must be supplied by the caller.
+    """
+
+    def __init__(self, accessible_project_ids: set[int]) -> None:
+        self.accessible_project_ids = accessible_project_ids
+
+    @override
+    def get_attrs(
+        self,
+        item_list: Sequence[InvestigationBlock],
+        user: User | RpcUser | AnonymousUser,
+        **kwargs: Any,
+    ) -> MutableMapping[InvestigationBlock, dict[str, Any]]:
+        dependencies: MutableMapping[int, list[str]] = defaultdict(list)
+        for link in (
+            InvestigationBlockDependency.objects.filter(block__in=item_list)
+            .values_list("block_id", "depends_on_id")
+            .order_by("id")
+        ):
+            dependencies[link[0]].append(str(link[1]))
+
+        parameter_keys: MutableMapping[int, list[str]] = defaultdict(list)
+        for block_id, key in (
+            InvestigationBlockParameter.objects.filter(block__in=item_list)
+            .values_list("block_id", "parameter__key")
+            .order_by("parameter__position")
+        ):
+            parameter_keys[block_id].append(key)
+
+        return {
+            block: {
+                "dependencies": dependencies[block.id],
+                "parameter_keys": parameter_keys[block.id],
+            }
+            for block in item_list
+        }
+
+    def _execution_project_ids(self, execution: InvestigationBlockExecution) -> set[int]:
+        return {project.id for project in execution.data_projects.all()}
+
+    @override
+    def serialize(
+        self,
+        obj: InvestigationBlock,
+        attrs: Mapping[Any, Any],
+        user: User | RpcUser | AnonymousUser,
+        **kwargs: Any,
+    ) -> InvestigationBlockSerializerResponse:
+        execution = obj.current_execution
+        result_execution = obj.result_execution
+        content_execution = obj.content_execution
+        content_restricted = bool(
+            obj.kind == InvestigationBlockKind.TEXT
+            and content_execution is not None
+            and not self._execution_project_ids(content_execution).issubset(
+                self.accessible_project_ids
+            )
+        )
+        if execution is None:
+            output = None
+            output_status = "notRun"
+        else:
+            visible_execution = (
+                result_execution if obj.kind == InvestigationBlockKind.QUERY else execution
+            )
+            data_project_ids = (
+                self._execution_project_ids(visible_execution)
+                if visible_execution is not None
+                else set()
+            )
+            if not data_project_ids.issubset(self.accessible_project_ids):
+                output = None
+                output_status = "restricted"
+            else:
+                output = visible_execution.result if visible_execution is not None else None
+                output_status = (
+                    "available"
+                    if execution.status == InvestigationBlockExecutionStatus.COMPLETED
+                    else execution.status
+                )
+        if content_restricted:
+            output = None
+            output_status = "restricted"
+
+        content = obj.content
+        generated_content = obj.generated_content
+        if obj.kind == InvestigationBlockKind.TEXT and output_status == "restricted":
+            content = ""
+            generated_content = ""
+
+        return {
+            "id": str(obj.id),
+            "position": obj.position,
+            "kind": obj.kind,
+            "title": obj.title,
+            "content": content,
+            "generationPrompt": obj.prompt,
+            "generatedContent": generated_content,
+            "output": output,
+            "outputStatus": output_status,
+            "currentExecution": (
+                {
+                    "id": str(execution.id),
+                    "status": execution.status,
+                    "executor": execution.executor,
+                    "schemaVersion": execution.result_schema_version,
+                    "startedAt": execution.started_at,
+                    "completedAt": execution.completed_at,
+                    "error": execution.error,
+                }
+                if execution is not None
+                else None
+            ),
+            "config": obj.config,
+            "display": obj.display,
+            "dependencies": attrs["dependencies"],
+            "parameterKeys": attrs["parameter_keys"],
+            "version": obj.version,
+            "staleAt": obj.stale_at,
+            "createdBy": str(obj.created_by_id) if obj.created_by_id is not None else None,
+            "lastEditedBy": (
+                str(obj.last_edited_by_id) if obj.last_edited_by_id is not None else None
+            ),
+        }

--- a/src/sentry/investigations/endpoints/serializers/block.py
+++ b/src/sentry/investigations/endpoints/serializers/block.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from typing import Any, TypedDict, override
 
 from django.contrib.auth.models import AnonymousUser
+from django.db.models import prefetch_related_objects
 
 from sentry.api.serializers import Serializer
 from sentry.investigations.models import (
@@ -86,6 +87,13 @@ class InvestigationBlockSerializer(Serializer[InvestigationBlockSerializerRespon
         ):
             parameter_keys[block_id].append(key)
 
+        prefetch_related_objects(
+            item_list,
+            "current_execution__data_projects",
+            "content_execution__data_projects",
+            "result_execution__data_projects",
+        )
+
         return {
             block: {
                 "dependencies": dependencies[block.id],
@@ -93,9 +101,6 @@ class InvestigationBlockSerializer(Serializer[InvestigationBlockSerializerRespon
             }
             for block in item_list
         }
-
-    def _execution_project_ids(self, execution: InvestigationBlockExecution) -> set[int]:
-        return {project.id for project in execution.data_projects.all()}
 
     @override
     def serialize(
@@ -105,15 +110,20 @@ class InvestigationBlockSerializer(Serializer[InvestigationBlockSerializerRespon
         user: User | RpcUser | AnonymousUser,
         **kwargs: Any,
     ) -> InvestigationBlockSerializerResponse:
+        def is_accessible(execution: InvestigationBlockExecution | None) -> bool:
+            if execution is None:
+                return True
+            return {project.id for project in execution.data_projects.all()}.issubset(
+                self.accessible_project_ids
+            )
+
         execution = obj.current_execution
         result_execution = obj.result_execution
         content_execution = obj.content_execution
         content_restricted = bool(
             obj.kind == InvestigationBlockKind.TEXT
             and content_execution is not None
-            and not self._execution_project_ids(content_execution).issubset(
-                self.accessible_project_ids
-            )
+            and not is_accessible(content_execution)
         )
         if execution is None:
             output = None
@@ -122,12 +132,7 @@ class InvestigationBlockSerializer(Serializer[InvestigationBlockSerializerRespon
             visible_execution = (
                 result_execution if obj.kind == InvestigationBlockKind.QUERY else execution
             )
-            data_project_ids = (
-                self._execution_project_ids(visible_execution)
-                if visible_execution is not None
-                else set()
-            )
-            if not data_project_ids.issubset(self.accessible_project_ids):
+            if not is_accessible(visible_execution):
                 output = None
                 output_status = "restricted"
             else:
@@ -143,7 +148,7 @@ class InvestigationBlockSerializer(Serializer[InvestigationBlockSerializerRespon
 
         content = obj.content
         generated_content = obj.generated_content
-        if obj.kind == InvestigationBlockKind.TEXT and output_status == "restricted":
+        if content_restricted:
             content = ""
             generated_content = ""
 

--- a/src/sentry/investigations/endpoints/serializers/investigation.py
+++ b/src/sentry/investigations/endpoints/serializers/investigation.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Mapping, MutableMapping, Sequence
+from datetime import datetime
+from typing import Any, TypedDict, override
+
+from django.contrib.auth.models import AnonymousUser
+from django.db.models import Count, Prefetch, Q
+
+from sentry.api.serializers import Serializer, register, serialize
+from sentry.investigations.endpoints.serializers.block import (
+    InvestigationBlockSerializer,
+    InvestigationBlockSerializerResponse,
+)
+from sentry.investigations.endpoints.serializers.parameter import (
+    InvestigationParameterSerializer,
+    InvestigationParameterSerializerResponse,
+)
+from sentry.investigations.models import (
+    Investigation,
+    InvestigationBlock,
+    InvestigationBlockDependency,
+    InvestigationBlockParameter,
+    InvestigationFavoriteUser,
+    InvestigationParameter,
+    InvestigationProject,
+)
+from sentry.users.models.user import User
+from sentry.users.services.user.model import RpcUser
+
+
+class InvestigationTemplateSerializerResponse(TypedDict):
+    key: str | None
+    version: int | None
+
+
+class InvestigationSourceSerializerResponse(TypedDict):
+    type: str
+    ref: dict[str, Any]
+    revision: int | None
+
+
+class InvestigationTitleGenerationSerializerResponse(TypedDict):
+    status: str | None
+
+
+class InvestigationSerializerResponse(TypedDict):
+    id: str
+    title: str
+    status: str
+    sourceType: str
+    createdBy: str | None
+    dateCreated: datetime
+    dateUpdated: datetime
+    version: int
+    blockCount: int
+    isFavorited: bool
+
+
+class InvestigationDetailsSerializerResponse(InvestigationSerializerResponse):
+    template: InvestigationTemplateSerializerResponse | None
+    source: InvestigationSourceSerializerResponse
+    filters: dict[str, Any]
+    projectIds: list[int]
+    parameters: list[InvestigationParameterSerializerResponse]
+    blocks: list[InvestigationBlockSerializerResponse]
+    titleGeneration: InvestigationTitleGenerationSerializerResponse
+
+
+@register(Investigation)
+class InvestigationSerializer(Serializer):
+    @override
+    def get_attrs(
+        self,
+        item_list: Sequence[Investigation],
+        user: User | RpcUser | AnonymousUser,
+        **kwargs: Any,
+    ) -> MutableMapping[Investigation, dict[str, Any]]:
+        block_counts = dict(
+            Investigation.objects.filter(id__in=[i.id for i in item_list])
+            .annotate(active_block_count=Count("blocks", filter=Q(blocks__deleted_at__isnull=True)))
+            .values_list("id", "active_block_count")
+        )
+
+        favorited_ids: set[int] = set()
+        user_id = getattr(user, "id", None)
+        if user_id is not None:
+            favorited_ids = set(
+                InvestigationFavoriteUser.objects.filter(
+                    user_id=user_id, investigation__in=item_list
+                ).values_list("investigation_id", flat=True)
+            )
+
+        return {
+            investigation: {
+                "block_count": block_counts.get(investigation.id, 0),
+                "is_favorited": investigation.id in favorited_ids,
+            }
+            for investigation in item_list
+        }
+
+    @override
+    def serialize(
+        self,
+        obj: Investigation,
+        attrs: Mapping[Any, Any],
+        user: User | RpcUser | AnonymousUser,
+        **kwargs: Any,
+    ) -> InvestigationSerializerResponse:
+        return {
+            "id": str(obj.id),
+            "title": obj.title,
+            "status": obj.status,
+            "sourceType": obj.source_type,
+            "createdBy": (str(obj.created_by_id) if obj.created_by_id is not None else None),
+            "dateCreated": obj.date_added,
+            "dateUpdated": obj.date_updated,
+            "version": obj.version,
+            "blockCount": attrs["block_count"],
+            "isFavorited": attrs["is_favorited"],
+        }
+
+
+class InvestigationDetailsSerializer(InvestigationSerializer):
+    """
+    Serializes an investigation along with its project selection, parameters,
+    and blocks. Use this for single-investigation reads; the base serializer
+    omits the nested collections so list reads stay cheap.
+    """
+
+    def __init__(self, accessible_project_ids: set[int]) -> None:
+        self.accessible_project_ids = accessible_project_ids
+
+    def _blocks_by_investigation(
+        self, item_list: Sequence[Investigation], user: User | RpcUser | AnonymousUser
+    ) -> MutableMapping[int, list[InvestigationBlockSerializerResponse]]:
+        blocks = list(
+            InvestigationBlock.objects.filter(investigation__in=item_list, deleted_at__isnull=True)
+            .select_related("content_execution", "current_execution", "result_execution")
+            .prefetch_related(
+                Prefetch(
+                    "dependency_links",
+                    queryset=InvestigationBlockDependency.objects.select_related(
+                        "depends_on"
+                    ).order_by("id"),
+                    to_attr="serialized_dependency_links",
+                ),
+                Prefetch(
+                    "parameter_links",
+                    queryset=InvestigationBlockParameter.objects.select_related(
+                        "parameter"
+                    ).order_by("parameter__position"),
+                    to_attr="serialized_parameter_links",
+                ),
+                "current_execution__data_projects",
+                "content_execution__data_projects",
+                "result_execution__data_projects",
+            )
+            .order_by("position", "id")
+        )
+        serialized = serialize(
+            blocks,
+            user,
+            InvestigationBlockSerializer(accessible_project_ids=self.accessible_project_ids),
+        )
+
+        by_investigation: MutableMapping[int, list[InvestigationBlockSerializerResponse]] = (
+            defaultdict(list)
+        )
+        for block, block_response in zip(blocks, serialized):
+            by_investigation[block.investigation_id].append(block_response)
+        return by_investigation
+
+    def _parameters_by_investigation(
+        self, item_list: Sequence[Investigation], user: User | RpcUser | AnonymousUser
+    ) -> MutableMapping[int, list[InvestigationParameterSerializerResponse]]:
+        parameters = list(
+            InvestigationParameter.objects.filter(investigation__in=item_list).order_by(
+                "position", "id"
+            )
+        )
+        serialized = serialize(parameters, user, InvestigationParameterSerializer())
+
+        by_investigation: MutableMapping[int, list[InvestigationParameterSerializerResponse]] = (
+            defaultdict(list)
+        )
+        for parameter, parameter_response in zip(parameters, serialized):
+            by_investigation[parameter.investigation_id].append(parameter_response)
+        return by_investigation
+
+    @override
+    def get_attrs(
+        self,
+        item_list: Sequence[Investigation],
+        user: User | RpcUser | AnonymousUser,
+        **kwargs: Any,
+    ) -> MutableMapping[Investigation, dict[str, Any]]:
+        attrs = super().get_attrs(item_list, user, **kwargs)
+
+        blocks_by_investigation = self._blocks_by_investigation(item_list, user)
+        parameters_by_investigation = self._parameters_by_investigation(item_list, user)
+
+        project_ids_by_investigation: MutableMapping[int, list[int]] = defaultdict(list)
+        for investigation_id, project_id in (
+            InvestigationProject.objects.filter(investigation__in=item_list)
+            .order_by("project_id")
+            .values_list("investigation_id", "project_id")
+        ):
+            project_ids_by_investigation[investigation_id].append(project_id)
+
+        for investigation in item_list:
+            attrs[investigation]["blocks"] = blocks_by_investigation[investigation.id]
+            attrs[investigation]["parameters"] = parameters_by_investigation[investigation.id]
+            attrs[investigation]["project_ids"] = project_ids_by_investigation[investigation.id]
+
+        return attrs
+
+    @override
+    def serialize(
+        self,
+        obj: Investigation,
+        attrs: Mapping[Any, Any],
+        user: User | RpcUser | AnonymousUser,
+        **kwargs: Any,
+    ) -> InvestigationDetailsSerializerResponse:
+        return {
+            **super().serialize(obj, attrs, user, **kwargs),
+            "template": (
+                {"key": obj.template_key, "version": obj.template_version}
+                if obj.template_key is not None
+                else None
+            ),
+            "source": {
+                "type": obj.source_type,
+                "ref": obj.source_ref,
+                "revision": obj.source_revision,
+            },
+            "filters": obj.filters,
+            "projectIds": attrs["project_ids"],
+            "parameters": attrs["parameters"],
+            "blocks": attrs["blocks"],
+            "titleGeneration": {"status": obj.title_generation_status},
+        }

--- a/src/sentry/investigations/endpoints/serializers/investigation.py
+++ b/src/sentry/investigations/endpoints/serializers/investigation.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import Any, TypedDict, override
 
 from django.contrib.auth.models import AnonymousUser
-from django.db.models import Count, Prefetch, Q
+from django.db.models import Count, Q
 
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.investigations.endpoints.serializers.block import (
@@ -20,8 +20,6 @@ from sentry.investigations.endpoints.serializers.parameter import (
 from sentry.investigations.models import (
     Investigation,
     InvestigationBlock,
-    InvestigationBlockDependency,
-    InvestigationBlockParameter,
     InvestigationFavoriteUser,
     InvestigationParameter,
     InvestigationProject,
@@ -136,28 +134,9 @@ class InvestigationDetailsSerializer(InvestigationSerializer):
         self, item_list: Sequence[Investigation], user: User | RpcUser | AnonymousUser
     ) -> MutableMapping[int, list[InvestigationBlockSerializerResponse]]:
         blocks = list(
-            InvestigationBlock.objects.filter(investigation__in=item_list, deleted_at__isnull=True)
-            .select_related("content_execution", "current_execution", "result_execution")
-            .prefetch_related(
-                Prefetch(
-                    "dependency_links",
-                    queryset=InvestigationBlockDependency.objects.select_related(
-                        "depends_on"
-                    ).order_by("id"),
-                    to_attr="serialized_dependency_links",
-                ),
-                Prefetch(
-                    "parameter_links",
-                    queryset=InvestigationBlockParameter.objects.select_related(
-                        "parameter"
-                    ).order_by("parameter__position"),
-                    to_attr="serialized_parameter_links",
-                ),
-                "current_execution__data_projects",
-                "content_execution__data_projects",
-                "result_execution__data_projects",
-            )
-            .order_by("position", "id")
+            InvestigationBlock.objects.filter(
+                investigation__in=item_list, deleted_at__isnull=True
+            ).order_by("position", "id")
         )
         serialized = serialize(
             blocks,

--- a/src/sentry/investigations/endpoints/serializers/parameter.py
+++ b/src/sentry/investigations/endpoints/serializers/parameter.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypedDict, override
+
+from django.contrib.auth.models import AnonymousUser
+
+from sentry.api.serializers import Serializer, register
+from sentry.investigations.models import InvestigationParameter
+from sentry.users.models.user import User
+from sentry.users.services.user.model import RpcUser
+
+
+class InvestigationParameterSerializerResponse(TypedDict):
+    id: str
+    key: str
+    label: str
+    description: str
+    type: str
+    required: bool
+    constraints: dict[str, Any]
+    defaultValue: Any | None
+    savedValue: Any | None
+    source: str
+    position: int
+    version: int
+
+
+@register(InvestigationParameter)
+class InvestigationParameterSerializer(Serializer[InvestigationParameterSerializerResponse]):
+    @override
+    def serialize(
+        self,
+        obj: InvestigationParameter,
+        attrs: Mapping[Any, Any],
+        user: User | RpcUser | AnonymousUser,
+        **kwargs: Any,
+    ) -> InvestigationParameterSerializerResponse:
+        return {
+            "id": str(obj.id),
+            "key": obj.key,
+            "label": obj.label,
+            "description": obj.description,
+            "type": obj.type,
+            "required": obj.required,
+            "constraints": obj.validation_constraints,
+            "defaultValue": obj.default_value,
+            "savedValue": obj.saved_value,
+            "source": obj.source,
+            "position": obj.position,
+            "version": obj.version,
+        }

--- a/tests/sentry/investigations/endpoints/serializers/test_block.py
+++ b/tests/sentry/investigations/endpoints/serializers/test_block.py
@@ -9,6 +9,7 @@ from sentry.investigations.endpoints.serializers import (
     InvestigationBlockSerializerResponse,
 )
 from sentry.investigations.models import (
+    InvestigationBlock,
     InvestigationBlockExecution,
     InvestigationBlockExecutionStatus,
 )
@@ -158,3 +159,76 @@ class InvestigationBlockSerializerTest(TestCase):
 
         assert len(all_blocks) == 10
         assert len(many_queries.captured_queries) == len(few_queries.captured_queries)
+
+    def test_keeps_readable_markdown_when_a_newer_run_is_restricted(self) -> None:
+        self.block.update(
+            kind="text", content="Readable markdown", generated_content="Readable draft"
+        )
+        other_project = self.create_project(organization=self.organization)
+        content_execution = self.create_investigation_block_execution(
+            block=self.block,
+            executor="manual",
+            block_version=1,
+            input_fingerprint="a" * 64,
+            status=InvestigationBlockExecutionStatus.COMPLETED,
+            result={"schemaVersion": 1},
+        )
+        self.create_investigation_block_execution_project(
+            execution=content_execution, project=self.project
+        )
+        pending_execution = self.create_investigation_block_execution(
+            block=self.block,
+            executor="manual",
+            block_version=2,
+            input_fingerprint="b" * 64,
+        )
+        self.create_investigation_block_execution_project(
+            execution=pending_execution, project=other_project
+        )
+        self.block.update(content_execution=content_execution, current_execution=pending_execution)
+
+        result = self.serialize_block(accessible_project_ids={self.project.id})
+
+        assert result["outputStatus"] == "restricted"
+        assert result["output"] is None
+        assert result["content"] == "Readable markdown"
+        assert result["generatedContent"] == "Readable draft"
+
+    def test_query_count_is_constant_for_a_bare_queryset(self) -> None:
+        for position in range(1, 6):
+            block = self.create_investigation_block(
+                investigation=self.investigation, position=position, kind="query"
+            )
+            execution = self.create_investigation_block_execution(
+                block=block,
+                executor="manual",
+                block_version=1,
+                input_fingerprint="f" * 64,
+                status=InvestigationBlockExecutionStatus.COMPLETED,
+                result={"schemaVersion": 1},
+            )
+            self.create_investigation_block_execution_project(
+                execution=execution, project=self.project
+            )
+            block.update(
+                current_execution=execution,
+                content_execution=execution,
+                result_execution=execution,
+            )
+        self.completed_execution()
+
+        serializer = InvestigationBlockSerializer(accessible_project_ids={self.project.id})
+
+        def block_queryset() -> list[InvestigationBlock]:
+            return list(
+                InvestigationBlock.objects.filter(investigation=self.investigation).order_by("id")
+            )
+
+        with CaptureQueriesContext(connection) as one_block:
+            serialize(block_queryset()[:1], self.user, serializer)
+
+        with CaptureQueriesContext(connection) as all_blocks:
+            results = serialize(block_queryset(), self.user, serializer)
+
+        assert len(results) == 6
+        assert len(all_blocks.captured_queries) == len(one_block.captured_queries)

--- a/tests/sentry/investigations/endpoints/serializers/test_block.py
+++ b/tests/sentry/investigations/endpoints/serializers/test_block.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+
+from sentry.api.serializers import serialize
+from sentry.investigations.endpoints.serializers import (
+    InvestigationBlockSerializer,
+    InvestigationBlockSerializerResponse,
+)
+from sentry.investigations.models import (
+    InvestigationBlockExecution,
+    InvestigationBlockExecutionStatus,
+)
+from sentry.models.project import Project
+from sentry.testutils.cases import TestCase
+
+
+class InvestigationBlockSerializerTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.investigation = self.create_investigation(
+            organization=self.organization, created_by=self.user, title="Investigation"
+        )
+        self.block = self.create_investigation_block(
+            investigation=self.investigation, position=0, kind="query"
+        )
+
+    def serialize_block(
+        self, accessible_project_ids: set[int] | None = None
+    ) -> InvestigationBlockSerializerResponse:
+        return serialize(
+            self.block,
+            self.user,
+            InvestigationBlockSerializer(
+                accessible_project_ids=(
+                    {self.project.id} if accessible_project_ids is None else accessible_project_ids
+                )
+            ),
+        )
+
+    def completed_execution(self, project: Project | None = None) -> InvestigationBlockExecution:
+        execution = self.create_investigation_block_execution(
+            block=self.block,
+            executor="manual",
+            block_version=1,
+            input_fingerprint="f" * 64,
+            status=InvestigationBlockExecutionStatus.COMPLETED,
+            result={"schemaVersion": 1},
+        )
+        self.create_investigation_block_execution_project(
+            execution=execution, project=project or self.project
+        )
+        self.block.update(
+            current_execution=execution,
+            content_execution=execution,
+            result_execution=execution,
+        )
+        return execution
+
+    def test_reports_not_run_without_an_execution(self) -> None:
+        result = self.serialize_block()
+
+        assert result["outputStatus"] == "notRun"
+        assert result["output"] is None
+        assert result["currentExecution"] is None
+
+    def test_exposes_output_when_every_data_project_is_accessible(self) -> None:
+        execution = self.completed_execution()
+
+        result = self.serialize_block()
+
+        assert result["outputStatus"] == "available"
+        assert result["output"] == {"schemaVersion": 1}
+        assert result["currentExecution"] is not None
+        assert result["currentExecution"]["id"] == str(execution.id)
+
+    def test_withholds_output_when_a_data_project_is_inaccessible(self) -> None:
+        self.completed_execution()
+
+        result = self.serialize_block(accessible_project_ids=set())
+
+        assert result["outputStatus"] == "restricted"
+        assert result["output"] is None
+
+    def test_withholds_output_when_only_some_data_projects_are_accessible(self) -> None:
+        other_project = self.create_project(organization=self.organization)
+        execution = self.completed_execution()
+        self.create_investigation_block_execution_project(
+            execution=execution, project=other_project
+        )
+
+        result = self.serialize_block(accessible_project_ids={self.project.id})
+
+        assert result["outputStatus"] == "restricted"
+        assert result["output"] is None
+
+    def test_reports_a_pending_execution_status_verbatim(self) -> None:
+        execution = self.create_investigation_block_execution(
+            block=self.block,
+            executor="manual",
+            block_version=1,
+            input_fingerprint="f" * 64,
+        )
+        self.block.update(current_execution=execution, result_execution=execution)
+
+        assert self.serialize_block()["outputStatus"] == (InvestigationBlockExecutionStatus.PENDING)
+
+    def test_blanks_restricted_text_content(self) -> None:
+        self.block.update(kind="text", content="Secret finding", generated_content="Secret draft")
+        self.completed_execution()
+
+        result = self.serialize_block(accessible_project_ids=set())
+
+        assert result["outputStatus"] == "restricted"
+        assert result["content"] == ""
+        assert result["generatedContent"] == ""
+
+    def test_keeps_text_content_when_projects_are_accessible(self) -> None:
+        self.block.update(kind="text", content="Visible finding")
+        self.completed_execution()
+
+        assert self.serialize_block()["content"] == "Visible finding"
+
+    def test_serializes_dependencies_and_parameter_keys(self) -> None:
+        upstream = self.create_investigation_block(investigation=self.investigation, position=1)
+        self.create_investigation_block_dependency(block=self.block, depends_on=upstream)
+        parameter = self.create_investigation_parameter(
+            investigation=self.investigation,
+            key="environment",
+            label="Environment",
+            type="string",
+            position=0,
+        )
+        self.create_investigation_block_parameter(block=self.block, parameter=parameter)
+
+        result = self.serialize_block()
+
+        assert result["dependencies"] == [str(upstream.id)]
+        assert result["parameterKeys"] == ["environment"]
+
+    def test_query_count_does_not_grow_with_the_number_of_blocks(self) -> None:
+        for position in range(1, 10):
+            self.create_investigation_block(investigation=self.investigation, position=position)
+
+        from sentry.investigations.models import InvestigationBlock
+
+        all_blocks = list(
+            InvestigationBlock.objects.filter(investigation=self.investigation).order_by("id")
+        )
+        serializer = InvestigationBlockSerializer(accessible_project_ids={self.project.id})
+
+        with CaptureQueriesContext(connection) as few_queries:
+            serialize(all_blocks[:2], self.user, serializer)
+
+        with CaptureQueriesContext(connection) as many_queries:
+            serialize(all_blocks, self.user, serializer)
+
+        assert len(all_blocks) == 10
+        assert len(many_queries.captured_queries) == len(few_queries.captured_queries)

--- a/tests/sentry/investigations/endpoints/serializers/test_investigation.py
+++ b/tests/sentry/investigations/endpoints/serializers/test_investigation.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from typing import Any
+
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+
+from sentry.api.serializers import serialize
+from sentry.investigations.endpoints.serializers import (
+    InvestigationDetailsSerializer,
+    InvestigationDetailsSerializerResponse,
+    InvestigationSerializer,
+)
+from sentry.investigations.models import Investigation, InvestigationBlockExecutionStatus
+from sentry.testutils.cases import TestCase
+
+
+class InvestigationSerializerTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.investigation = self.create_investigation(
+            organization=self.organization, created_by=self.user, title="Latency spike"
+        )
+
+    def test_serializes_the_list_representation(self) -> None:
+        result = serialize(self.investigation, self.user, InvestigationSerializer())
+
+        assert result == {
+            "id": str(self.investigation.id),
+            "title": "Latency spike",
+            "status": self.investigation.status,
+            "sourceType": self.investigation.source_type,
+            "createdBy": str(self.user.id),
+            "dateCreated": self.investigation.date_added,
+            "dateUpdated": self.investigation.date_updated,
+            "version": 1,
+            "blockCount": 0,
+            "isFavorited": False,
+        }
+
+    def test_counts_only_active_blocks(self) -> None:
+        self.create_investigation_block(investigation=self.investigation, position=0)
+        deleted = self.create_investigation_block(investigation=self.investigation, position=1)
+        deleted.update(deleted_at=self.investigation.date_added)
+
+        result = serialize(self.investigation, self.user, InvestigationSerializer())
+
+        assert result["blockCount"] == 1
+
+    def test_reports_the_viewers_own_favorite(self) -> None:
+        other_user = self.create_user()
+        self.create_investigation_favorite(investigation=self.investigation, user=other_user)
+
+        assert not serialize(self.investigation, self.user, InvestigationSerializer())[
+            "isFavorited"
+        ]
+        assert serialize(self.investigation, other_user, InvestigationSerializer())["isFavorited"]
+
+    def test_is_registered_for_bare_serialize_calls(self) -> None:
+        assert serialize(self.investigation, self.user) == serialize(
+            self.investigation, self.user, InvestigationSerializer()
+        )
+
+    def test_query_count_does_not_grow_with_the_number_of_investigations(self) -> None:
+        for index in range(3):
+            investigation = self.create_investigation(
+                organization=self.organization, title=f"First {index}"
+            )
+            self.create_investigation_block(investigation=investigation, position=0)
+            self.create_investigation_favorite(investigation=investigation, user=self.user)
+
+        first_batch = list(Investigation.objects.filter(organization=self.organization))
+        with CaptureQueriesContext(connection) as first_queries:
+            serialize(first_batch, self.user, InvestigationSerializer())
+
+        for index in range(3, 12):
+            investigation = self.create_investigation(
+                organization=self.organization, title=f"Second {index}"
+            )
+            self.create_investigation_block(investigation=investigation, position=0)
+            self.create_investigation_favorite(investigation=investigation, user=self.user)
+
+        second_batch = list(Investigation.objects.filter(organization=self.organization))
+        with CaptureQueriesContext(connection) as second_queries:
+            results = serialize(second_batch, self.user, InvestigationSerializer())
+
+        assert len(second_batch) > len(first_batch)
+        assert len(second_queries.captured_queries) == len(first_queries.captured_queries)
+        counts = sorted(result["blockCount"] for result in results)
+        # Only the setUp investigation has no blocks; every created one has exactly one.
+        assert counts == [0] + [1] * (len(second_batch) - 1)
+
+
+class InvestigationDetailsSerializerTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.investigation = self.create_investigation(
+            organization=self.organization, created_by=self.user, title="Investigation"
+        )
+        self.create_investigation_project(investigation=self.investigation, project=self.project)
+        self.parameter = self.create_investigation_parameter(
+            investigation=self.investigation,
+            key="environment",
+            label="Environment",
+            type="string",
+            position=0,
+        )
+        self.block = self.create_investigation_block(investigation=self.investigation, position=0)
+
+    def serialize_detail(
+        self, accessible_project_ids: set[int] | None = None
+    ) -> InvestigationDetailsSerializerResponse:
+        return serialize(
+            self.investigation,
+            self.user,
+            InvestigationDetailsSerializer(
+                accessible_project_ids=(
+                    {self.project.id} if accessible_project_ids is None else accessible_project_ids
+                )
+            ),
+        )
+
+    def test_extends_the_list_representation(self) -> None:
+        listed = serialize(self.investigation, self.user, InvestigationSerializer())
+        detail = self.serialize_detail()
+
+        # cast to a plain dict: a TypedDict cannot be indexed by a variable key
+        detail_items: dict[str, Any] = dict(detail)
+        assert set(listed) < set(detail_items)
+        for key, value in listed.items():
+            assert detail_items[key] == value
+
+    def test_serializes_nested_collections(self) -> None:
+        detail = self.serialize_detail()
+
+        assert detail["projectIds"] == [self.project.id]
+        assert [parameter["key"] for parameter in detail["parameters"]] == ["environment"]
+        assert [block["id"] for block in detail["blocks"]] == [str(self.block.id)]
+
+    def test_orders_blocks_by_position(self) -> None:
+        second = self.create_investigation_block(investigation=self.investigation, position=1)
+        third = self.create_investigation_block(investigation=self.investigation, position=2)
+
+        detail = self.serialize_detail()
+
+        assert [block["id"] for block in detail["blocks"]] == [
+            str(self.block.id),
+            str(second.id),
+            str(third.id),
+        ]
+
+    def test_omits_soft_deleted_blocks(self) -> None:
+        deleted = self.create_investigation_block(investigation=self.investigation, position=1)
+        deleted.update(deleted_at=self.investigation.date_added)
+
+        detail = self.serialize_detail()
+
+        assert [block["id"] for block in detail["blocks"]] == [str(self.block.id)]
+
+    def test_reports_no_template_for_a_manual_investigation(self) -> None:
+        detail = self.serialize_detail()
+
+        assert detail["template"] is None
+        assert detail["source"]["type"] == self.investigation.source_type
+        assert detail["titleGeneration"] == {"status": None}
+
+    def test_reports_the_template_that_created_the_investigation(self) -> None:
+        self.investigation.update(template_key="breached_metric", template_version=1)
+
+        detail = self.serialize_detail()
+
+        assert detail["template"] == {"key": "breached_metric", "version": 1}
+
+    def test_forwards_accessible_projects_to_blocks(self) -> None:
+        execution = self.create_investigation_block_execution(
+            block=self.block,
+            executor="manual",
+            block_version=1,
+            input_fingerprint="f" * 64,
+            status=InvestigationBlockExecutionStatus.COMPLETED,
+            result={"schemaVersion": 1},
+        )
+        self.create_investigation_block_execution_project(execution=execution, project=self.project)
+        self.block.update(current_execution=execution, result_execution=execution)
+
+        assert self.serialize_detail()["blocks"][0]["outputStatus"] == "available"
+        assert (
+            self.serialize_detail(accessible_project_ids=set())["blocks"][0]["outputStatus"]
+            == "restricted"
+        )

--- a/tests/sentry/investigations/endpoints/serializers/test_investigation.py
+++ b/tests/sentry/investigations/endpoints/serializers/test_investigation.py
@@ -188,3 +188,46 @@ class InvestigationDetailsSerializerTest(TestCase):
             self.serialize_detail(accessible_project_ids=set())["blocks"][0]["outputStatus"]
             == "restricted"
         )
+
+    def test_query_count_is_constant_for_a_bare_queryset(self) -> None:
+        def build(index: int) -> Investigation:
+            investigation = self.create_investigation(
+                organization=self.organization, title=f"Extra {index}"
+            )
+            self.create_investigation_project(investigation=investigation, project=self.project)
+            parameter = self.create_investigation_parameter(
+                investigation=investigation, key="env", label="Env", type="string", position=0
+            )
+            block = self.create_investigation_block(investigation=investigation, position=0)
+            self.create_investigation_block_parameter(block=block, parameter=parameter)
+            execution = self.create_investigation_block_execution(
+                block=block,
+                executor="manual",
+                block_version=1,
+                input_fingerprint="f" * 64,
+                status=InvestigationBlockExecutionStatus.COMPLETED,
+                result={"schemaVersion": 1},
+            )
+            self.create_investigation_block_execution_project(
+                execution=execution, project=self.project
+            )
+            block.update(
+                current_execution=execution,
+                content_execution=execution,
+                result_execution=execution,
+            )
+            return investigation
+
+        serializer = InvestigationDetailsSerializer(accessible_project_ids={self.project.id})
+        first = [build(0)]
+
+        with CaptureQueriesContext(connection) as one:
+            serialize(first, self.user, serializer)
+
+        many_investigations = first + [build(index) for index in range(1, 5)]
+
+        with CaptureQueriesContext(connection) as many:
+            results = serialize(many_investigations, self.user, serializer)
+
+        assert len(results) == 5
+        assert len(many.captured_queries) == len(one.captured_queries)

--- a/tests/sentry/investigations/endpoints/serializers/test_parameter.py
+++ b/tests/sentry/investigations/endpoints/serializers/test_parameter.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from sentry.api.serializers import serialize
+from sentry.investigations.endpoints.serializers import InvestigationParameterSerializer
+from sentry.testutils.cases import TestCase
+
+
+class InvestigationParameterSerializerTest(TestCase):
+    def test_serializes_a_parameter(self) -> None:
+        investigation = self.create_investigation(
+            organization=self.organization, title="Investigation"
+        )
+        parameter = self.create_investigation_parameter(
+            investigation=investigation,
+            key="environment",
+            label="Environment",
+            description="Which environment to inspect",
+            type="string",
+            position=0,
+            required=True,
+            validation_constraints={"maxLength": 64},
+            default_value="prod",
+        )
+
+        result = serialize(parameter, self.user, InvestigationParameterSerializer())
+
+        assert result == {
+            "id": str(parameter.id),
+            "key": "environment",
+            "label": "Environment",
+            "description": "Which environment to inspect",
+            "type": "string",
+            "required": True,
+            "constraints": {"maxLength": 64},
+            "defaultValue": "prod",
+            "savedValue": None,
+            "source": parameter.source,
+            "position": 0,
+            "version": 1,
+        }


### PR DESCRIPTION
This splits out the response serializers from https://github.com/getsentry/sentry/pull/121403 to keep the total pr size down, and restructures them into separate folders.

<!-- Describe your PR here. -->