### PR TITLE
fix(ci): add timeouts to snuba test endpoint requests

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1152,8 +1152,7 @@ class SnubaTestCase(BaseTestCase):
             files[f"item_{i}"] = trace_item.SerializeToString()
         assert (
             requests.post(
-                settings.SENTRY_SNUBA + EAP_ITEMS_INSERT_ENDPOINT,
-                files=files,
+                settings.SENTRY_SNUBA + EAP_ITEMS_INSERT_ENDPOINT, files=files, timeout=30
             ).status_code
             == 200
         )
@@ -1225,8 +1224,7 @@ class SnubaTestCase(BaseTestCase):
     def store_eap_items(self, items: Sequence[TraceItem]) -> None:
         files = {f"eap_items_{i}": item.SerializeToString() for i, item in enumerate(items)}
         response = requests.post(
-            settings.SENTRY_SNUBA + EAP_ITEMS_INSERT_ENDPOINT,
-            files=files,
+            settings.SENTRY_SNUBA + EAP_ITEMS_INSERT_ENDPOINT, files=files, timeout=30
         )
         assert response.status_code == 200
         # Reverse the ids since these are stored in little endian in
@@ -1240,6 +1238,7 @@ class SnubaTestCase(BaseTestCase):
             requests.post(
                 settings.SENTRY_SNUBA + "/tests/entities/search_issues/insert",
                 data=json.dumps(issues),
+                timeout=30,
             ).status_code
             == 200
         )
@@ -1307,6 +1306,7 @@ class SnubaTestCase(BaseTestCase):
             requests.post(
                 settings.SENTRY_SNUBA + "/tests/entities/events/insert",
                 data=json.dumps(events),
+                timeout=30,
             ).status_code
             == 200
         )
@@ -1662,6 +1662,7 @@ class BaseMetricsTestCase(SnubaTestCase):
             requests.post(
                 settings.SENTRY_SNUBA + cls.snuba_endpoint.format(entity=entity),
                 data=json.dumps(buckets),
+                timeout=30,
             ).status_code
             == 200
         )
@@ -2147,7 +2148,10 @@ class BaseIncidentsTest(SnubaTestCase):
 class OutcomesSnubaTest(TestCase):
     def setUp(self):
         super().setUp()
-        assert requests.post(settings.SENTRY_SNUBA + "/tests/outcomes/drop").status_code == 200
+        assert (
+            requests.post(settings.SENTRY_SNUBA + "/tests/outcomes/drop", timeout=30).status_code
+            == 200
+        )
 
     def store_outcomes(self, outcome, num_times=1):
         outcomes = []
@@ -2160,6 +2164,7 @@ class OutcomesSnubaTest(TestCase):
             requests.post(
                 settings.SENTRY_SNUBA + "/tests/entities/outcomes/insert",
                 data=json.dumps(outcomes),
+                timeout=30,
             ).status_code
             == 200
         )
@@ -2220,6 +2225,7 @@ class ProfilesSnubaTestCase(
         response = requests.post(
             settings.SENTRY_SNUBA + "/tests/entities/functions/insert",
             json=[functions_payload],
+            timeout=30,
         )
         assert response.status_code == 200
 
@@ -2280,6 +2286,7 @@ class ProfilesSnubaTestCase(
         response = requests.post(
             settings.SENTRY_SNUBA + "/tests/entities/functions/insert",
             json=[functions_payload],
+            timeout=30,
         )
         assert response.status_code == 200
 
@@ -2311,8 +2318,7 @@ class ProfilesSnubaTestCase(
             files[f"item_{i}"] = trace_item.SerializeToString()
         assert (
             requests.post(
-                settings.SENTRY_SNUBA + EAP_ITEMS_INSERT_ENDPOINT,
-                files=files,
+                settings.SENTRY_SNUBA + EAP_ITEMS_INSERT_ENDPOINT, files=files, timeout=30
             ).status_code
             == 200
         )
@@ -2323,11 +2329,14 @@ class ProfilesSnubaTestCase(
 class ReplaysSnubaTestCase(TestCase):
     def setUp(self):
         super().setUp()
-        assert requests.post(settings.SENTRY_SNUBA + "/tests/replays/drop").status_code == 200
+        assert (
+            requests.post(settings.SENTRY_SNUBA + "/tests/replays/drop", timeout=30).status_code
+            == 200
+        )
 
     def store_replays(self, replay):
         response = requests.post(
-            settings.SENTRY_SNUBA + "/tests/entities/replays/insert", json=[replay]
+            settings.SENTRY_SNUBA + "/tests/entities/replays/insert", json=[replay], timeout=30
         )
         assert response.status_code == 200
 
@@ -2353,6 +2362,7 @@ class UptimeCheckSnubaTestCase(TestCase):
         response = requests.post(
             settings.SENTRY_SNUBA + "/tests/entities/uptime_checks/insert",
             json=[uptime_check],
+            timeout=30,
         )
         assert response.status_code == 200
 
@@ -2428,14 +2438,17 @@ class ReplaysAcceptanceTestCase(AcceptanceTestCase, SnubaTestCase):
         self.addCleanup(patcher.stop)
 
     def drop_replays(self):
-        assert requests.post(settings.SENTRY_SNUBA + "/tests/replays/drop").status_code == 200
+        assert (
+            requests.post(settings.SENTRY_SNUBA + "/tests/replays/drop", timeout=30).status_code
+            == 200
+        )
 
     def store_replays(self, replays):
         assert len(replays) >= 2, (
             "You need to store at least 2 replay events for the replay to be considered valid"
         )
         response = requests.post(
-            settings.SENTRY_SNUBA + "/tests/entities/replays/insert", json=replays
+            settings.SENTRY_SNUBA + "/tests/entities/replays/insert", json=replays, timeout=30
         )
         assert response.status_code == 200
 

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -3018,6 +3018,7 @@ class Factories:
         response = requests.post(
             settings.SENTRY_SNUBA + EAP_ITEMS_INSERT_ENDPOINT,
             files={"item_0": trace_item.SerializeToString()},
+            timeout=30,
         )
         assert response.status_code == 200
 

--- a/src/sentry/testutils/pytest/fixtures.py
+++ b/src/sentry/testutils/pytest/fixtures.py
@@ -329,7 +329,7 @@ def _print_custom_insta_diff(reference_file, diff_text):
 @pytest.fixture
 def call_snuba(settings):
     def inner(endpoint):
-        return requests.post(settings.SENTRY_SNUBA + endpoint)
+        return requests.post(settings.SENTRY_SNUBA + endpoint, timeout=30)
 
     return inner
 


### PR DESCRIPTION
Since Aug 5, backend CI shards have been hanging until the 20 minute timeout kills them. 19 times on master ([1](https://github.com/getsentry/getsentry/actions/runs/31018535280/job/92349003928), [2](https://github.com/getsentry/getsentry/actions/runs/31029200432/job/92385344033), [3](https://github.com/getsentry/getsentry/actions/runs/31030915231/job/92391191343), [4](https://github.com/getsentry/getsentry/actions/runs/31034545133/job/92403303137), [5](https://github.com/getsentry/getsentry/actions/runs/31048895747/job/92451261296), [6](https://github.com/getsentry/getsentry/actions/runs/31054400517/job/92468684776), [7](https://github.com/getsentry/getsentry/actions/runs/31081718988/job/92551910506), [8](https://github.com/getsentry/getsentry/actions/runs/31085352189/job/92563483966), [9](https://github.com/getsentry/getsentry/actions/runs/31092605318/job/92587136757), [10](https://github.com/getsentry/getsentry/actions/runs/31100296295/job/92612014040), [11](https://github.com/getsentry/getsentry/actions/runs/31128566200/job/92712456796), [12](https://github.com/getsentry/getsentry/actions/runs/31131718817/job/92722114862), [13](https://github.com/getsentry/getsentry/actions/runs/31154694268/job/92791593757), [14](https://github.com/getsentry/getsentry/actions/runs/31165476120/job/92825234144), [15](https://github.com/getsentry/getsentry/actions/runs/31197849320/job/92930504713), [16](https://github.com/getsentry/getsentry/actions/runs/31201972900/job/92943955542), [17](https://github.com/getsentry/getsentry/actions/runs/31203437246/job/92948770800), [18](https://github.com/getsentry/getsentry/actions/runs/31203890205/job/92950239938), [19](https://github.com/getsentry/getsentry/actions/runs/31218062441/job/92996195481)). Every stuck test is a snuba test, an `OutcomesSnubaTest` or `SnubaTestCase` subclass that writes outcomes into the per-worker snuba over HTTP.

The hangs started with snuba's granian (web server) upgrade, getsentry/snuba#8267: the first one ever happened 13 minutes after the new snuba image went live, after 12 days with zero hangs. Looping the affected tests in CI reproduced it, and py-spy shows the test stuck waiting on an HTTP response that snuba's server never sends, while the server keeps answering everything else.

These test calls have no timeout, so one lost response hangs the whole shard for 20 minutes. With `timeout=30` the test fails fast instead and passes on the automatic rerun.
