### PR TITLE
ref(seer): Render Code Mode calls instead of the generic tool row

### DIFF
--- a/static/app/views/seerExplorer/callRecords.tsx
+++ b/static/app/views/seerExplorer/callRecords.tsx
@@ -2,6 +2,7 @@ import type {LocationDescriptor} from 'history';
 
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
+import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import type {CallRecord} from 'sentry/views/seerExplorer/types';
 import {buildToolLinkUrl} from 'sentry/views/seerExplorer/utils';
 
@@ -70,11 +71,35 @@ export function callRecordUrl(
     if (params.every(name => pathParams[name])) {
       const url = buildToolLinkUrl({kind, params: pathParams}, organization, projects);
       if (url) {
-        return url;
+        return scopeToOrganization(url, organization);
       }
     }
   }
   return null;
+}
+
+/**
+ * Qualify an org-less path with the organization, then normalize.
+ *
+ * `buildToolLinkUrl` is inconsistent about this: some cases return
+ * `/organizations/{slug}/traces/`, others a bare `/issues/54/`. The bare form only resolves under
+ * a customer domain, so it 404s on a plain dev host. Emitting the qualified path and running it
+ * through `normalizeUrl` is correct in both worlds — normalizeUrl strips the prefix back off when
+ * a customer domain is in play.
+ */
+function scopeToOrganization(
+  url: LocationDescriptor,
+  organization: Organization
+): LocationDescriptor {
+  const prefix = `/organizations/${organization.slug}`;
+
+  if (typeof url === 'string') {
+    return normalizeUrl(url.startsWith('/organizations/') ? url : `${prefix}${url}`);
+  }
+  if (!url.pathname || url.pathname.startsWith('/organizations/')) {
+    return normalizeUrl(url);
+  }
+  return normalizeUrl({...url, pathname: `${prefix}${url.pathname}`});
 }
 
 /**

--- a/static/app/views/seerExplorer/callRecords.tsx
+++ b/static/app/views/seerExplorer/callRecords.tsx
@@ -56,7 +56,7 @@ export function callRecordUrl(
   organization: Organization,
   projects?: Array<{id: string; slug: string}>
 ): LocationDescriptor | null {
-  if (!record.path_params) {
+  if (!record.path_params || !addressesItsOwnResource(record)) {
     return null;
   }
 
@@ -76,6 +76,20 @@ export function callRecordUrl(
     }
   }
   return null;
+}
+
+/**
+ * Whether the route's own subject is the resource we would link to.
+ *
+ * Without this, every route containing `{issue_id}` links to the issue page — so fetching an
+ * issue, its latest event, and its tags produces three rows pointing at the same place, which
+ * tells the reader nothing and makes the links look arbitrary. A route only earns a link when it
+ * *ends* at the thing being linked; `/issues/{issue_id}/tags/` is about tags, and there is no tags
+ * page to send anyone to, so it gets none.
+ */
+function addressesItsOwnResource(record: CallRecord): boolean {
+  const path = record.path?.replace(/\/$/, '');
+  return Boolean(path?.endsWith('}'));
 }
 
 /**
@@ -155,6 +169,32 @@ export function callRecordFailure(record: CallRecord): string | null {
     return t('Returned HTTP %s', record.status);
   }
   return null;
+}
+
+/**
+ * The request a row stands for, for the expanded view: what ran, and with what.
+ *
+ * Reads `resolved_path` rather than reassembling the template, so what is shown is literally what
+ * was requested. Returns null for a lib call, which has no route of its own — its children carry
+ * the requests.
+ */
+export function callRecordDetail(
+  record: CallRecord
+): {params: Array<[string, string]>; request: string; status: string} | null {
+  if (record.kind !== 'api' || !record.method) {
+    return null;
+  }
+
+  const path = record.resolved_path ?? record.path;
+  if (!path) {
+    return null;
+  }
+
+  return {
+    request: `${record.method} ${path}`,
+    params: Object.entries(record.query_params ?? {}),
+    status: record.error ?? (record.status ? String(record.status) : t('pending')),
+  };
 }
 
 /** The calls in a block's tool results, flattened in the order they ran. */

--- a/static/app/views/seerExplorer/callRecords.tsx
+++ b/static/app/views/seerExplorer/callRecords.tsx
@@ -1,0 +1,140 @@
+import type {LocationDescriptor} from 'history';
+
+import {t} from 'sentry/locale';
+import type {Organization} from 'sentry/types/organization';
+import type {CallRecord} from 'sentry/views/seerExplorer/types';
+import {buildToolLinkUrl} from 'sentry/views/seerExplorer/utils';
+
+/**
+ * Presentation for the calls a Code Mode execute made.
+ *
+ * Seer reports what it did — route, params, title, outcome — and nothing about how it should look.
+ * Everything here is the client's choice: which calls are worth a link, what they're labeled, and
+ * whether a route gets bespoke treatment. Adding a handler is a frontend-only deploy.
+ */
+
+/**
+ * Path params that identify something a user can navigate to, mapped to the link kind whose URL
+ * builder knows how to reach it.
+ *
+ * Deliberately small. Path params concentrate hard across the ~790 routes seer exposes —
+ * `organization_id_or_slug` and `project_id_or_slug` appear in most of them but are scope, not
+ * destinations. These are the ones that name a resource with a page. Order matters: the first
+ * match wins, so more specific pairings (an event inside an issue) come before their parts.
+ */
+const NAVIGABLE_PARAMS: Array<{kind: string; params: readonly string[]}> = [
+  {kind: 'get_event_details', params: ['issue_id', 'event_id']},
+  {kind: 'get_issue_details', params: ['issue_id']},
+  {kind: 'get_trace_waterfall', params: ['trace_id']},
+  {kind: 'get_replay_details', params: ['replay_id']},
+];
+
+/**
+ * Param values that name a resource to the API but not to the UI.
+ *
+ * The Sentry API resolves these server-side — `GET /issues/54/events/latest/` returns the newest
+ * event — but the corresponding UI route expects a concrete id, so linking one produces a dead
+ * page. Any param carrying one of these is treated as non-identifying, which falls the record back
+ * to a coarser link (the issue rather than the event) instead of a broken one.
+ */
+const API_ONLY_ALIASES = new Set(['latest', 'oldest', 'recommended', 'me']);
+
+function identifies(value: string | undefined): value is string {
+  return Boolean(value) && !API_ONLY_ALIASES.has(value!);
+}
+
+/**
+ * A record's destination, or null when it identifies nothing navigable.
+ *
+ * Built here rather than in seer: `buildToolLinkUrl` already encodes every Sentry URL shape for the
+ * classic tool path, and duplicating that knowledge server-side would mean maintaining Sentry's
+ * routing against an OpenAPI spec that says nothing about it.
+ */
+export function callRecordUrl(
+  record: CallRecord,
+  organization: Organization,
+  projects?: Array<{id: string; slug: string}>
+): LocationDescriptor | null {
+  if (!record.path_params) {
+    return null;
+  }
+
+  // Drop alias-valued params up front rather than per-match. The URL builders read params beyond
+  // the ones a match keys on — `get_issue_details` also consults `event_id` — so an alias left in
+  // the bag would still reach a builder and produce the dead link we are avoiding.
+  const pathParams = Object.fromEntries(
+    Object.entries(record.path_params).filter(([, value]) => identifies(value))
+  );
+
+  for (const {kind, params} of NAVIGABLE_PARAMS) {
+    if (params.every(name => pathParams[name])) {
+      const url = buildToolLinkUrl({kind, params: pathParams}, organization, projects);
+      if (url) {
+        return url;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Bespoke rendering for a specific route or lib method.
+ *
+ * Keyed `"<METHOD> <templated path>"` for API records and by method name for lib records — the
+ * same keys seer reports, so a handler is registered without seer knowing it exists. A route with
+ * no handler falls back to the title seer shipped, which is why the map can stay small: it holds
+ * only the calls worth saying something better about than their spec name.
+ */
+const CALL_HANDLERS: Record<string, (record: CallRecord) => string | null> = {
+  'PUT /api/0/organizations/{organization_id_or_slug}/issues/': record =>
+    record.status && record.status < 300 ? t('Updated issues') : t('Update issues'),
+  code_search: () => t('Searched code'),
+  git_search: () => t('Searched commit history'),
+  bash: () => t('Ran a command'),
+  ask_user_question: () => t('Asked a question'),
+  review_code_changes: () => t('Reviewed code changes'),
+  telemetry_live_search: () => t('Queried telemetry'),
+};
+
+function handlerKey(record: CallRecord): string | null {
+  if (record.kind === 'lib') {
+    return record.name ?? null;
+  }
+  return record.method && record.path ? `${record.method} ${record.path}` : null;
+}
+
+/**
+ * What to show for a call, or null when we have nothing worth showing.
+ *
+ * Returning null rather than falling back to the route or an operation id is deliberate: a raw
+ * identifier on screen is worse than one fewer row.
+ */
+export function callRecordLabel(record: CallRecord): string | null {
+  const key = handlerKey(record);
+  const handler = key ? CALL_HANDLERS[key] : undefined;
+  if (handler) {
+    const label = handler(record);
+    if (label) {
+      return label;
+    }
+  }
+  return record.title?.trim() || null;
+}
+
+/** A call that failed, for the row's tooltip. Null when it succeeded or never reported. */
+export function callRecordFailure(record: CallRecord): string | null {
+  if (record.error) {
+    return t('Request failed: %s', record.error);
+  }
+  if (record.status && record.status >= 400) {
+    return t('Returned HTTP %s', record.status);
+  }
+  return null;
+}
+
+/** The calls in a block's tool results, flattened in the order they ran. */
+export function getCallRecords(
+  toolResults: Array<{structuredContent?: {calls?: CallRecord[]} | null} | null> | null
+): CallRecord[] {
+  return (toolResults ?? []).flatMap(result => result?.structuredContent?.calls ?? []);
+}

--- a/static/app/views/seerExplorer/callRecords.tsx
+++ b/static/app/views/seerExplorer/callRecords.tsx
@@ -182,8 +182,9 @@ export function callRecordDetail(record: CallRecord): {
   body: string | null;
   params: Array<[string, string]>;
   request: string;
-  response: string | null;
 } | null {
+  // A lib call is a heading for the api calls nested under it, and those carry the detail. Giving
+  // it its own expander would add a control that reveals less than the rows already below it.
   if (record.kind !== 'api' || !record.method) {
     return null;
   }
@@ -199,7 +200,6 @@ export function callRecordDetail(record: CallRecord): {
     // since the transport passes it separately rather than building it into the URL.
     params: Object.entries(record.query_params ?? {}),
     body: withEllipsis(record.body, record.body_truncated),
-    response: withEllipsis(record.response, record.response_truncated),
   };
 }
 

--- a/static/app/views/seerExplorer/callRecords.tsx
+++ b/static/app/views/seerExplorer/callRecords.tsx
@@ -79,20 +79,6 @@ export function callRecordLink(
 }
 
 /**
- * The destination alone, for callers that do not report the click.
- *
- * The kind matters to analytics: `tool_kind` is what distinguishes an issue navigation from a
- * trace one, and a row that reported its record kind instead would only ever say `api` or `lib`.
- */
-export function callRecordUrl(
-  record: CallRecord,
-  organization: Organization,
-  projects?: Array<{id: string; slug: string}>
-): LocationDescriptor | null {
-  return callRecordLink(record, organization, projects)?.url ?? null;
-}
-
-/**
  * Whether the route's own subject is the resource we would link to.
  *
  * Without this, every route containing `{issue_id}` links to the issue page — so fetching an

--- a/static/app/views/seerExplorer/callRecords.tsx
+++ b/static/app/views/seerExplorer/callRecords.tsx
@@ -178,9 +178,12 @@ export function callRecordFailure(record: CallRecord): string | null {
  * was requested. Returns null for a lib call, which has no route of its own — its children carry
  * the requests.
  */
-export function callRecordDetail(
-  record: CallRecord
-): {params: Array<[string, string]>; request: string; response: string | null} | null {
+export function callRecordDetail(record: CallRecord): {
+  body: string | null;
+  params: Array<[string, string]>;
+  request: string;
+  response: string | null;
+} | null {
   if (record.kind !== 'api' || !record.method) {
     return null;
   }
@@ -190,17 +193,25 @@ export function callRecordDetail(
     return null;
   }
 
-  const response = record.response
-    ? record.response_truncated
-      ? `${record.response}\n…`
-      : record.response
-    : null;
-
   return {
     request: `${record.method} ${path}`,
+    // Query only. Path params are already visible in the resolved path; the query string is not,
+    // since the transport passes it separately rather than building it into the URL.
     params: Object.entries(record.query_params ?? {}),
-    response,
+    body: withEllipsis(record.body, record.body_truncated),
+    response: withEllipsis(record.response, record.response_truncated),
   };
+}
+
+/** Mark a cut-short preview so the box does not read as the whole payload. */
+function withEllipsis(
+  text: string | undefined,
+  truncated: boolean | undefined
+): string | null {
+  if (!text) {
+    return null;
+  }
+  return truncated ? `${text}\n…` : text;
 }
 
 /** The calls in a block's tool results, flattened in the order they ran. */

--- a/static/app/views/seerExplorer/callRecords.tsx
+++ b/static/app/views/seerExplorer/callRecords.tsx
@@ -160,6 +160,21 @@ export function callRecordLabel(record: CallRecord): string | null {
   return record.title?.trim() || null;
 }
 
+/**
+ * How one call turned out, for the tick beside its row.
+ *
+ * Every row carries its own: a lib call that fans out into three requests is three separate
+ * outcomes, and one tick over the group cannot say which of them failed.
+ */
+export function callRecordStatus(record: CallRecord): 'loading' | 'success' | 'failure' {
+  if (record.error || (record.status && record.status >= 400)) {
+    return 'failure';
+  }
+  // No status yet means the request is still open — the live mirror publishes a record when the
+  // call starts, not when it returns.
+  return record.status === undefined ? 'loading' : 'success';
+}
+
 /** A call that failed, for the row's tooltip. Null when it succeeded or never reported. */
 export function callRecordFailure(record: CallRecord): string | null {
   if (record.error) {

--- a/static/app/views/seerExplorer/callRecords.tsx
+++ b/static/app/views/seerExplorer/callRecords.tsx
@@ -51,11 +51,11 @@ function identifies(value: string | undefined): value is string {
  * classic tool path, and duplicating that knowledge server-side would mean maintaining Sentry's
  * routing against an OpenAPI spec that says nothing about it.
  */
-export function callRecordUrl(
+export function callRecordLink(
   record: CallRecord,
   organization: Organization,
   projects?: Array<{id: string; slug: string}>
-): LocationDescriptor | null {
+): {kind: string; url: LocationDescriptor} | null {
   if (!record.path_params || !addressesItsOwnResource(record)) {
     return null;
   }
@@ -71,11 +71,25 @@ export function callRecordUrl(
     if (params.every(name => pathParams[name])) {
       const url = buildToolLinkUrl({kind, params: pathParams}, organization, projects);
       if (url) {
-        return scopeToOrganization(url, organization);
+        return {kind, url: scopeToOrganization(url, organization)};
       }
     }
   }
   return null;
+}
+
+/**
+ * The destination alone, for callers that do not report the click.
+ *
+ * The kind matters to analytics: `tool_kind` is what distinguishes an issue navigation from a
+ * trace one, and a row that reported its record kind instead would only ever say `api` or `lib`.
+ */
+export function callRecordUrl(
+  record: CallRecord,
+  organization: Organization,
+  projects?: Array<{id: string; slug: string}>
+): LocationDescriptor | null {
+  return callRecordLink(record, organization, projects)?.url ?? null;
 }
 
 /**

--- a/static/app/views/seerExplorer/callRecords.tsx
+++ b/static/app/views/seerExplorer/callRecords.tsx
@@ -180,7 +180,7 @@ export function callRecordFailure(record: CallRecord): string | null {
  */
 export function callRecordDetail(
   record: CallRecord
-): {params: Array<[string, string]>; request: string; status: string} | null {
+): {params: Array<[string, string]>; request: string; response: string | null} | null {
   if (record.kind !== 'api' || !record.method) {
     return null;
   }
@@ -190,10 +190,16 @@ export function callRecordDetail(
     return null;
   }
 
+  const response = record.response
+    ? record.response_truncated
+      ? `${record.response}\n…`
+      : record.response
+    : null;
+
   return {
     request: `${record.method} ${path}`,
     params: Object.entries(record.query_params ?? {}),
-    status: record.error ?? (record.status ? String(record.status) : t('pending')),
+    response,
   };
 }
 

--- a/static/app/views/seerExplorer/callRecords.tsx
+++ b/static/app/views/seerExplorer/callRecords.tsx
@@ -212,6 +212,24 @@ function withEllipsis(
   return truncated ? `${text}\n…` : text;
 }
 
+/**
+ * The records worth rendering, in the order they ran.
+ *
+ * A lib call that fanned out into api calls is dropped: it is a heading for rows that each say
+ * more than it does, and keeping it means a parent with no expander sitting above indented
+ * children. A lib call with no api children is kept — the Explorer-backed helpers (`code_search`,
+ * `bash`, `ask_user_question`) never touch the transport, so their own row is the only trace they
+ * leave.
+ */
+export function visibleCallRecords(records: CallRecord[]): CallRecord[] {
+  const hasChildren = new Set(
+    records.flatMap(record =>
+      record.parent === null || record.parent === undefined ? [] : [record.parent]
+    )
+  );
+  return records.filter(record => record.kind !== 'lib' || !hasChildren.has(record.id));
+}
+
 /** The calls in a block's tool results, flattened in the order they ran. */
 export function getCallRecords(
   toolResults: Array<{structuredContent?: {calls?: CallRecord[]} | null} | null> | null

--- a/static/app/views/seerExplorer/callRecords.tsx
+++ b/static/app/views/seerExplorer/callRecords.tsx
@@ -180,7 +180,6 @@ export function callRecordFailure(record: CallRecord): string | null {
  */
 export function callRecordDetail(record: CallRecord): {
   body: string | null;
-  params: Array<[string, string]>;
   request: string;
 } | null {
   // A lib call is a heading for the api calls nested under it, and those carry the detail. Giving
@@ -194,11 +193,10 @@ export function callRecordDetail(record: CallRecord): {
     return null;
   }
 
+  // Seer composes the query string into `resolved_path`, so the request line is the whole URL —
+  // a list of params underneath would restate what the URL already says.
   return {
     request: `${record.method} ${path}`,
-    // Query only. Path params are already visible in the resolved path; the query string is not,
-    // since the transport passes it separately rather than building it into the URL.
-    params: Object.entries(record.query_params ?? {}),
     body: withEllipsis(record.body, record.body_truncated),
   };
 }

--- a/static/app/views/seerExplorer/callRecords.tsx
+++ b/static/app/views/seerExplorer/callRecords.tsx
@@ -166,13 +166,24 @@ export function callRecordLabel(record: CallRecord): string | null {
  * Every row carries its own: a lib call that fans out into three requests is three separate
  * outcomes, and one tick over the group cannot say which of them failed.
  */
-export function callRecordStatus(record: CallRecord): 'loading' | 'success' | 'failure' {
+export function callRecordStatus(
+  record: CallRecord,
+  settled: boolean
+): 'loading' | 'success' | 'failure' {
   if (record.error || (record.status && record.status >= 400)) {
     return 'failure';
   }
-  // No status yet means the request is still open — the live mirror publishes a record when the
-  // call starts, not when it returns.
-  return record.status === undefined ? 'loading' : 'success';
+  if (record.status !== undefined) {
+    return 'success';
+  }
+  // No status and nothing settled means the request is still open — the live mirror publishes a
+  // record when the call starts, not when it returns.
+  //
+  // Once the execute has returned there is nothing still in flight, and a status may legitimately
+  // never arrive: the Explorer-backed lib calls (`code_search`, `bash`, `ask_user_question`) never
+  // reach the HTTP transport, so they have no status to report and only ever set `error`. Reading
+  // that as "still running" left them spinning forever.
+  return settled ? 'success' : 'loading';
 }
 
 /** A call that failed, for the row's tooltip. Null when it succeeded or never reported. */

--- a/static/app/views/seerExplorer/callRecords.tsx
+++ b/static/app/views/seerExplorer/callRecords.tsx
@@ -244,10 +244,3 @@ export function visibleCallRecords(records: CallRecord[]): CallRecord[] {
   );
   return records.filter(record => record.kind !== 'lib' || !hasChildren.has(record.id));
 }
-
-/** The calls in a block's tool results, flattened in the order they ran. */
-export function getCallRecords(
-  toolResults: Array<{structuredContent?: {calls?: CallRecord[]} | null} | null> | null
-): CallRecord[] {
-  return (toolResults ?? []).flatMap(result => result?.structuredContent?.calls ?? []);
-}

--- a/static/app/views/seerExplorer/components/chat/callRecords.spec.tsx
+++ b/static/app/views/seerExplorer/components/chat/callRecords.spec.tsx
@@ -1,6 +1,6 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {
   callRecordDetail,
@@ -105,6 +105,38 @@ describe('call record rendering', () => {
       'href',
       expect.stringContaining('/issues/139458447/')
     );
+  });
+
+  describe('a row that both expands and navigates', () => {
+    /** An api call with a destination *and* a request to show — both affordances on one row. */
+    function linkable(): CallRecord {
+      return apiRecord({
+        path: '/api/0/organizations/{organization_id_or_slug}/issues/{issue_id}/',
+        resolved_path: '/api/0/organizations/acme/issues/139458447/',
+        path_params: {organization_id_or_slug: 'acme', issue_id: '139458447'},
+        title: 'Retrieve an Issue',
+      });
+    }
+
+    it('keeps the link out of the disclosure button', () => {
+      render(<BlockComponent block={codeModeBlock([linkable()])} blockIndex={0} />);
+
+      // An anchor inside a button is invalid HTML, and it leaves expand and navigate sharing one
+      // click target and one tab stop.
+      const link = screen.getByRole('link', {name: /Retrieve an Issue/});
+      const expander = screen.getByRole('button', {name: /Retrieve an Issue/});
+      expect(expander).not.toContainElement(link);
+    });
+
+    it('still expands to the request it made', async () => {
+      render(<BlockComponent block={codeModeBlock([linkable()])} blockIndex={0} />);
+
+      await userEvent.click(screen.getByRole('button', {name: /Retrieve an Issue/}));
+
+      expect(
+        screen.getByText('GET /api/0/organizations/acme/issues/139458447/')
+      ).toBeInTheDocument();
+    });
   });
 
   it('renders a record with no navigable resource as plain text', () => {

--- a/static/app/views/seerExplorer/components/chat/callRecords.spec.tsx
+++ b/static/app/views/seerExplorer/components/chat/callRecords.spec.tsx
@@ -2,7 +2,11 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {callRecordLabel, callRecordUrl} from 'sentry/views/seerExplorer/callRecords';
+import {
+  callRecordDetail,
+  callRecordLabel,
+  callRecordUrl,
+} from 'sentry/views/seerExplorer/callRecords';
 import {BlockComponent} from 'sentry/views/seerExplorer/components/chat';
 import type {Block, CallRecord} from 'sentry/views/seerExplorer/types';
 
@@ -80,14 +84,16 @@ describe('call record rendering', () => {
   });
 
   it('drops a record with no title rather than showing its route', () => {
+    // The surviving row's expansion legitimately shows a route, so assert on the row count:
+    // the titleless record contributes nothing rather than falling back to its path.
     const block = codeModeBlock([
-      apiRecord({title: undefined}),
+      apiRecord({title: undefined, path: '/api/0/dropped/{thing_id}/'}),
       apiRecord({id: 2, title: 'List Your Organizations'}),
     ]);
     render(<BlockComponent block={block} blockIndex={0} />);
 
     expect(screen.getByText('List Your Organizations')).toBeInTheDocument();
-    expect(screen.queryByText(/api\/0/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/dropped/)).not.toBeInTheDocument();
   });
 
   it('links a record that identifies a navigable resource', () => {
@@ -222,6 +228,34 @@ describe('callRecordUrl', () => {
     expect(callRecordUrl(apiRecord({path_params: undefined}), organization)).toBeNull();
   });
 
+  describe('only the route its own subject', () => {
+    // Without this, get_issue_details' three requests all link to the issue page — three rows
+    // pointing at the same place, which reads as arbitrary.
+    const issueRoutes = [
+      ['/api/0/issues/{issue_id}/', true],
+      ['/api/0/issues/{issue_id}/events/latest/', false],
+      ['/api/0/issues/{issue_id}/tags/', false],
+    ] as const;
+
+    it.each(issueRoutes)('%s links: %s', (path, shouldLink) => {
+      const url = callRecordUrl(
+        apiRecord({path, path_params: {issue_id: '54'}}),
+        organization
+      );
+
+      expect(url === null).toBe(!shouldLink);
+    });
+
+    it('gives one link across a lib call and its children', () => {
+      const linked = issueRoutes
+        .map(([path]) =>
+          callRecordUrl(apiRecord({path, path_params: {issue_id: '54'}}), organization)
+        )
+        .filter(Boolean);
+
+      expect(linked).toHaveLength(1);
+    });
+  });
   describe('api-only aliases', () => {
     // The API resolves `latest`/`oldest`/`recommended` server-side, but the UI route needs a
     // concrete id — linking the alias straight through produces a dead page.
@@ -271,6 +305,44 @@ describe('callRecordUrl', () => {
 
       expect(JSON.stringify(url)).toContain('abc123');
     });
+  });
+});
+
+describe('callRecordDetail', () => {
+  it('shows the path actually requested, not the template', () => {
+    const detail = callRecordDetail(
+      apiRecord({
+        path: '/api/0/issues/{issue_id}/tags/',
+        resolved_path: '/api/0/issues/54/tags/',
+      })
+    );
+
+    expect(detail?.request).toBe('GET /api/0/issues/54/tags/');
+  });
+
+  it('lists query params', () => {
+    const detail = callRecordDetail(
+      apiRecord({query_params: {statsPeriod: '14d', environment: 'prod'}})
+    );
+
+    expect(detail?.params).toEqual([
+      ['statsPeriod', '14d'],
+      ['environment', 'prod'],
+    ]);
+  });
+
+  it('reports a transport failure over a status', () => {
+    expect(callRecordDetail(apiRecord({error: 'ConnectError'}))?.status).toBe(
+      'ConnectError'
+    );
+  });
+
+  it('reports pending while the call is in flight', () => {
+    expect(callRecordDetail(apiRecord({status: undefined}))?.status).toBe('pending');
+  });
+
+  it('has no detail for a lib call, which has no route of its own', () => {
+    expect(callRecordDetail({id: 1, kind: 'lib', name: 'get_issue_details'})).toBeNull();
   });
 });
 

--- a/static/app/views/seerExplorer/components/chat/callRecords.spec.tsx
+++ b/static/app/views/seerExplorer/components/chat/callRecords.spec.tsx
@@ -320,15 +320,38 @@ describe('callRecordDetail', () => {
     expect(detail?.request).toBe('GET /api/0/issues/54/tags/');
   });
 
-  it('lists query params', () => {
+  it('lists query params but not path params', () => {
+    // Path params are already visible in the resolved path; the query string is not, since the
+    // transport passes it separately rather than building it into the URL.
     const detail = callRecordDetail(
-      apiRecord({query_params: {statsPeriod: '14d', environment: 'prod'}})
+      apiRecord({
+        path_params: {issue_id: '54'},
+        query_params: {statsPeriod: '14d', environment: 'prod'},
+      })
     );
 
     expect(detail?.params).toEqual([
       ['statsPeriod', '14d'],
       ['environment', 'prod'],
     ]);
+  });
+
+  it('shows the request body', () => {
+    const detail = callRecordDetail(
+      apiRecord({method: 'PUT', body: '{\n  "status": "resolved"\n}'})
+    );
+
+    expect(detail?.body).toContain('"status": "resolved"');
+  });
+
+  it('marks a truncated body', () => {
+    const detail = callRecordDetail(apiRecord({body: '{"a":1', body_truncated: true}));
+
+    expect(detail?.body?.endsWith('…')).toBe(true);
+  });
+
+  it('has no body for a call that sent none', () => {
+    expect(callRecordDetail(apiRecord())?.body).toBeNull();
   });
 
   it('shows the response body', () => {

--- a/static/app/views/seerExplorer/components/chat/callRecords.spec.tsx
+++ b/static/app/views/seerExplorer/components/chat/callRecords.spec.tsx
@@ -172,6 +172,29 @@ describe('callRecordUrl', () => {
     expect(url).not.toBeNull();
   });
 
+  it('scopes an org-less path to the organization', () => {
+    // A bare `/issues/42/` only resolves under a customer domain, so it 404s on a plain host.
+    const url = callRecordUrl(apiRecord({path_params: {issue_id: '42'}}), organization);
+
+    expect(url).toEqual(
+      expect.objectContaining({
+        pathname: `/organizations/${organization.slug}/issues/42/`,
+      })
+    );
+  });
+
+  it('does not double-prefix a path that is already org-scoped', () => {
+    const url = callRecordUrl(
+      apiRecord({
+        path: '/api/0/organizations/{organization_id_or_slug}/replays/{replay_id}/',
+        path_params: {organization_id_or_slug: 'acme', replay_id: 'r1'},
+      }),
+      organization
+    );
+
+    expect(JSON.stringify(url)).not.toContain('/organizations/acme/organizations/');
+  });
+
   it('prefers the event URL when a record names both an issue and an event', () => {
     const url = callRecordUrl(
       apiRecord({
@@ -224,7 +247,11 @@ describe('callRecordUrl', () => {
         organization
       );
 
-      expect(url).toEqual(expect.objectContaining({pathname: '/issues/54/'}));
+      expect(url).toEqual(
+        expect.objectContaining({
+          pathname: `/organizations/${organization.slug}/issues/54/`,
+        })
+      );
     });
 
     it.each(['latest', 'oldest', 'recommended'])('rejects %s as an event id', alias => {

--- a/static/app/views/seerExplorer/components/chat/callRecords.spec.tsx
+++ b/static/app/views/seerExplorer/components/chat/callRecords.spec.tsx
@@ -331,14 +331,22 @@ describe('callRecordDetail', () => {
     ]);
   });
 
-  it('reports a transport failure over a status', () => {
-    expect(callRecordDetail(apiRecord({error: 'ConnectError'}))?.status).toBe(
-      'ConnectError'
-    );
+  it('shows the response body', () => {
+    const detail = callRecordDetail(apiRecord({response: '{\n  "id": "1"\n}'}));
+
+    expect(detail?.response).toContain('"id": "1"');
   });
 
-  it('reports pending while the call is in flight', () => {
-    expect(callRecordDetail(apiRecord({status: undefined}))?.status).toBe('pending');
+  it('marks a truncated response so the box does not look complete', () => {
+    const detail = callRecordDetail(
+      apiRecord({response: '{"a":1', response_truncated: true})
+    );
+
+    expect(detail?.response?.endsWith('…')).toBe(true);
+  });
+
+  it('has no response when the call did not return one', () => {
+    expect(callRecordDetail(apiRecord({response: undefined}))?.response).toBeNull();
   });
 
   it('has no detail for a lib call, which has no route of its own', () => {

--- a/static/app/views/seerExplorer/components/chat/callRecords.spec.tsx
+++ b/static/app/views/seerExplorer/components/chat/callRecords.spec.tsx
@@ -71,16 +71,10 @@ describe('call record rendering', () => {
     expect(screen.queryByText(/Used sentry_api_execute tool/)).not.toBeInTheDocument();
   });
 
-  it('falls back to the generic row when no records are present', () => {
+  it('never shows the tool name when a Code Mode call reported nothing', () => {
     render(<BlockComponent block={codeModeBlock(undefined)} blockIndex={0} />);
 
-    expect(screen.getByText(/Used sentry_api_execute tool/)).toBeInTheDocument();
-  });
-
-  it('falls back to the generic row when records are empty', () => {
-    render(<BlockComponent block={codeModeBlock([])} blockIndex={0} />);
-
-    expect(screen.getByText(/Used sentry_api_execute tool/)).toBeInTheDocument();
+    expect(screen.queryByText(/Used sentry_api_execute tool/)).not.toBeInTheDocument();
   });
 
   it('drops a record with no title rather than showing its route', () => {
@@ -127,15 +121,39 @@ describe('call record rendering', () => {
     expect(() => render(<BlockComponent block={block} blockIndex={0} />)).not.toThrow();
   });
 
-  it('renders lib records alongside api records', () => {
+  it('drops a lib row whose api calls say more than it does', () => {
+    const block = codeModeBlock([
+      {
+        id: 1,
+        parent: null,
+        kind: 'lib',
+        name: 'get_issue_details',
+        title: 'Retrieving details',
+      },
+      apiRecord({id: 2, parent: 1, title: 'Retrieving issue 54'}),
+    ]);
+    render(<BlockComponent block={block} blockIndex={0} />);
+
+    expect(screen.getByText('Retrieving issue 54')).toBeInTheDocument();
+    expect(screen.queryByText('Retrieving details')).not.toBeInTheDocument();
+  });
+
+  it('keeps a lib row that made no api calls of its own', () => {
+    // code_search never touches the transport, so its row is the only trace it leaves.
     const block = codeModeBlock([
       {id: 1, parent: null, kind: 'lib', name: 'code_search'},
-      apiRecord({id: 2, parent: 1}),
     ]);
     render(<BlockComponent block={block} blockIndex={0} />);
 
     expect(screen.getByText('Searched code')).toBeInTheDocument();
-    expect(screen.getByText('Retrieve an Organization')).toBeInTheDocument();
+  });
+
+  it('renders no row at all for a Code Mode call that reported nothing', () => {
+    // "Used sentry_api_execute tool" names none of the actions it covers, so it is never shown —
+    // a call with nothing to report leaves no row rather than an empty one.
+    render(<BlockComponent block={codeModeBlock([])} blockIndex={0} />);
+
+    expect(screen.queryByText(/Used sentry_api_execute tool/)).not.toBeInTheDocument();
   });
 });
 

--- a/static/app/views/seerExplorer/components/chat/callRecords.spec.tsx
+++ b/static/app/views/seerExplorer/components/chat/callRecords.spec.tsx
@@ -12,7 +12,7 @@ import {BlockComponent} from 'sentry/views/seerExplorer/components/chat';
 import type {Block, CallRecord} from 'sentry/views/seerExplorer/types';
 
 /**
- * Code Mode call records (openspec: codemode-call-visibility).
+ * Code Mode call records.
  *
  * `sentry_api_execute` covers every action Code Mode can take, so the row is built from the calls
  * the execute reported rather than from the tool's name.
@@ -195,6 +195,25 @@ describe('call record rendering', () => {
 
     expect(split).toEqual(together);
     expect(together).toEqual(['First call', 'Second call']);
+  });
+
+  it('renders no empty row when only trailing surfaces have content', () => {
+    // `toolString` is blank for Code Mode, so a block kept alive by todos or markdown alone
+    // used to render a labelless row — the lone status tick the hasContent guard exists to avoid.
+    const block = codeModeBlock([]);
+    block.tool_results![0]!.structuredContent = {
+      todos: [{content: 'Check the trace', status: 'pending'}],
+    };
+    // findLatestTodos reads the block list, so the checklist only renders when the block is
+    // reachable from it.
+    render(<BlockComponent block={block} blockIndex={0} blocks={[block]} />);
+
+    expect(screen.getByText('Check the trace')).toBeInTheDocument();
+    // The symptom is a row that exists but says nothing: an empty label beside a status tick.
+    // The tick is the only visible part, so assert it is absent — an empty label cannot be
+    // queried by text.
+    expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
+    expect(screen.queryAllByRole('img', {hidden: true})).toHaveLength(0);
   });
 
   it('renders no row at all for a Code Mode call that reported nothing', () => {

--- a/static/app/views/seerExplorer/components/chat/callRecords.spec.tsx
+++ b/static/app/views/seerExplorer/components/chat/callRecords.spec.tsx
@@ -354,26 +354,17 @@ describe('callRecordDetail', () => {
     expect(callRecordDetail(apiRecord())?.body).toBeNull();
   });
 
-  it('shows the response body', () => {
-    const detail = callRecordDetail(apiRecord({response: '{\n  "id": "1"\n}'}));
-
-    expect(detail?.response).toContain('"id": "1"');
-  });
-
-  it('marks a truncated response so the box does not look complete', () => {
-    const detail = callRecordDetail(
-      apiRecord({response: '{"a":1', response_truncated: true})
-    );
-
-    expect(detail?.response?.endsWith('…')).toBe(true);
-  });
-
-  it('has no response when the call did not return one', () => {
-    expect(callRecordDetail(apiRecord({response: undefined}))?.response).toBeNull();
-  });
-
-  it('has no detail for a lib call, which has no route of its own', () => {
-    expect(callRecordDetail({id: 1, kind: 'lib', name: 'get_issue_details'})).toBeNull();
+  it('has no detail for a lib call, even when it carries arguments', () => {
+    // A lib row is a heading for the api rows nested under it, and those carry the detail — an
+    // expander here would reveal less than what is already visible below.
+    expect(
+      callRecordDetail({
+        id: 1,
+        kind: 'lib',
+        name: 'get_issue_details',
+        params: {org: 'acme', issue_id: '54'},
+      })
+    ).toBeNull();
   });
 });
 

--- a/static/app/views/seerExplorer/components/chat/callRecords.spec.tsx
+++ b/static/app/views/seerExplorer/components/chat/callRecords.spec.tsx
@@ -149,6 +149,54 @@ describe('call record rendering', () => {
     expect(screen.getByText('Searched code')).toBeInTheDocument();
   });
 
+  it('renders calls from separate tool calls the same as calls from one', () => {
+    // How the run partitioned work into tool calls is invisible to the reader: one execute that
+    // made two calls must look exactly like two that made one each.
+    const rowsFor = (block: Block) => {
+      const {unmount} = render(<BlockComponent block={block} blockIndex={0} />);
+      const labels = screen.getAllByText(/call$/).map(node => node.textContent);
+      unmount();
+      return labels;
+    };
+
+    const together = rowsFor(
+      codeModeBlock([
+        apiRecord({id: 1, title: 'First call'}),
+        apiRecord({id: 2, title: 'Second call'}),
+      ])
+    );
+    const split = rowsFor({
+      id: 'tool-1',
+      message: {
+        role: 'tool_use',
+        content: null,
+        tool_calls: [
+          {id: 'call-1', function: 'sentry_api_execute', args: '{}'},
+          {id: 'call-2', function: 'sentry_api_execute', args: '{}'},
+        ],
+      },
+      timestamp: '2024-01-01T00:01:00Z',
+      loading: false,
+      tool_results: [
+        {
+          tool_call_id: 'call-1',
+          tool_call_function: 'sentry_api_execute',
+          content: 'ok',
+          structuredContent: {calls: [apiRecord({id: 1, title: 'First call'})]},
+        },
+        {
+          tool_call_id: 'call-2',
+          tool_call_function: 'sentry_api_execute',
+          content: 'ok',
+          structuredContent: {calls: [apiRecord({id: 2, title: 'Second call'})]},
+        },
+      ],
+    });
+
+    expect(split).toEqual(together);
+    expect(together).toEqual(['First call', 'Second call']);
+  });
+
   it('renders no row at all for a Code Mode call that reported nothing', () => {
     // "Used sentry_api_execute tool" names none of the actions it covers, so it is never shown —
     // a call with nothing to report leaves no row rather than an empty one.

--- a/static/app/views/seerExplorer/components/chat/callRecords.spec.tsx
+++ b/static/app/views/seerExplorer/components/chat/callRecords.spec.tsx
@@ -208,21 +208,35 @@ describe('call record rendering', () => {
 
 describe('callRecordStatus', () => {
   it('reports success for a completed call', () => {
-    expect(callRecordStatus(apiRecord({status: 200}))).toBe('success');
+    expect(callRecordStatus(apiRecord({status: 200}), false)).toBe('success');
   });
 
   it('reports failure for an error status', () => {
-    expect(callRecordStatus(apiRecord({status: 404}))).toBe('failure');
+    expect(callRecordStatus(apiRecord({status: 404}), false)).toBe('failure');
   });
 
   it('reports failure for a transport error', () => {
-    expect(callRecordStatus(apiRecord({status: undefined, error: 'ConnectError'}))).toBe(
-      'failure'
-    );
+    expect(
+      callRecordStatus(apiRecord({status: undefined, error: 'ConnectError'}), false)
+    ).toBe('failure');
   });
 
   it('reports loading while the call is still open', () => {
-    expect(callRecordStatus(apiRecord({status: undefined}))).toBe('loading');
+    expect(callRecordStatus(apiRecord({status: undefined}), false)).toBe('loading');
+  });
+
+  it('settles a lib call that never reports a status', () => {
+    // code_search / bash / ask_user_question never reach the HTTP transport, so a
+    // completed record carries no status. Before the execute returns that means
+    // still running; once it has returned, nothing is.
+    const libRecord = {id: 1, kind: 'lib' as const, name: 'code_search'};
+    expect(callRecordStatus(libRecord, false)).toBe('loading');
+    expect(callRecordStatus(libRecord, true)).toBe('success');
+  });
+
+  it('keeps a settled failure a failure', () => {
+    const failed = {id: 1, kind: 'lib' as const, name: 'bash', error: 'RuntimeError'};
+    expect(callRecordStatus(failed, true)).toBe('failure');
   });
 
   it('gives each call its own outcome', () => {
@@ -233,7 +247,11 @@ describe('callRecordStatus', () => {
       apiRecord({id: 3, status: undefined}),
     ];
 
-    expect(records.map(callRecordStatus)).toEqual(['success', 'failure', 'loading']);
+    expect(records.map(record => callRecordStatus(record, false))).toEqual([
+      'success',
+      'failure',
+      'loading',
+    ]);
   });
 });
 

--- a/static/app/views/seerExplorer/components/chat/callRecords.spec.tsx
+++ b/static/app/views/seerExplorer/components/chat/callRecords.spec.tsx
@@ -6,7 +6,7 @@ import {
   callRecordDetail,
   callRecordLabel,
   callRecordStatus,
-  callRecordUrl,
+  callRecordLink,
 } from 'sentry/views/seerExplorer/callRecords';
 import {BlockComponent} from 'sentry/views/seerExplorer/components/chat';
 import type {Block, CallRecord} from 'sentry/views/seerExplorer/types';
@@ -301,11 +301,16 @@ describe('callRecordLabel', () => {
   });
 });
 
-describe('callRecordUrl', () => {
+/** The destination a record links to, or null — the shape these cases assert on. */
+function urlFor(...args: Parameters<typeof callRecordLink>) {
+  return callRecordLink(...args)?.url ?? null;
+}
+
+describe('callRecordLink', () => {
   const organization = OrganizationFixture();
 
   it('builds an issue URL from an issue_id path param', () => {
-    const url = callRecordUrl(
+    const url = urlFor(
       apiRecord({path_params: {organization_id_or_slug: 'acme', issue_id: '42'}}),
       organization
     );
@@ -315,7 +320,7 @@ describe('callRecordUrl', () => {
 
   it('scopes an org-less path to the organization', () => {
     // A bare `/issues/42/` only resolves under a customer domain, so it 404s on a plain host.
-    const url = callRecordUrl(apiRecord({path_params: {issue_id: '42'}}), organization);
+    const url = urlFor(apiRecord({path_params: {issue_id: '42'}}), organization);
 
     expect(url).toEqual(
       expect.objectContaining({
@@ -325,7 +330,7 @@ describe('callRecordUrl', () => {
   });
 
   it('does not double-prefix a path that is already org-scoped', () => {
-    const url = callRecordUrl(
+    const url = urlFor(
       apiRecord({
         path: '/api/0/organizations/{organization_id_or_slug}/replays/{replay_id}/',
         path_params: {organization_id_or_slug: 'acme', replay_id: 'r1'},
@@ -337,7 +342,7 @@ describe('callRecordUrl', () => {
   });
 
   it('prefers the event URL when a record names both an issue and an event', () => {
-    const url = callRecordUrl(
+    const url = urlFor(
       apiRecord({
         path_params: {issue_id: '42', event_id: 'abc123'},
       }),
@@ -350,7 +355,7 @@ describe('callRecordUrl', () => {
   it('returns null when only scope params are present', () => {
     // organization/project slugs say where a call went, not what it points at.
     expect(
-      callRecordUrl(
+      urlFor(
         apiRecord({
           path_params: {organization_id_or_slug: 'acme', project_id_or_slug: 'web'},
         }),
@@ -360,7 +365,7 @@ describe('callRecordUrl', () => {
   });
 
   it('returns null when a record has no path params', () => {
-    expect(callRecordUrl(apiRecord({path_params: undefined}), organization)).toBeNull();
+    expect(urlFor(apiRecord({path_params: undefined}), organization)).toBeNull();
   });
 
   describe('only the route its own subject', () => {
@@ -373,10 +378,7 @@ describe('callRecordUrl', () => {
     ] as const;
 
     it.each(issueRoutes)('%s links: %s', (path, shouldLink) => {
-      const url = callRecordUrl(
-        apiRecord({path, path_params: {issue_id: '54'}}),
-        organization
-      );
+      const url = urlFor(apiRecord({path, path_params: {issue_id: '54'}}), organization);
 
       expect(url === null).toBe(!shouldLink);
     });
@@ -384,7 +386,7 @@ describe('callRecordUrl', () => {
     it('gives one link across a lib call and its children', () => {
       const linked = issueRoutes
         .map(([path]) =>
-          callRecordUrl(apiRecord({path, path_params: {issue_id: '54'}}), organization)
+          urlFor(apiRecord({path, path_params: {issue_id: '54'}}), organization)
         )
         .filter(Boolean);
 
@@ -395,7 +397,7 @@ describe('callRecordUrl', () => {
     // The API resolves `latest`/`oldest`/`recommended` server-side, but the UI route needs a
     // concrete id — linking the alias straight through produces a dead page.
     it('does not link an event alias as if it were an event id', () => {
-      const url = callRecordUrl(
+      const url = urlFor(
         apiRecord({
           path: '/api/0/organizations/{organization_id_or_slug}/issues/{issue_id}/events/{event_id}/',
           path_params: {
@@ -411,7 +413,7 @@ describe('callRecordUrl', () => {
     });
 
     it('falls back to the issue when the event is an alias', () => {
-      const url = callRecordUrl(
+      const url = urlFor(
         apiRecord({path_params: {issue_id: '54', event_id: 'latest'}}),
         organization
       );
@@ -424,7 +426,7 @@ describe('callRecordUrl', () => {
     });
 
     it.each(['latest', 'oldest', 'recommended'])('rejects %s as an event id', alias => {
-      const url = callRecordUrl(
+      const url = urlFor(
         apiRecord({path_params: {issue_id: '54', event_id: alias}}),
         organization
       );
@@ -433,7 +435,7 @@ describe('callRecordUrl', () => {
     });
 
     it('still links a real event id', () => {
-      const url = callRecordUrl(
+      const url = urlFor(
         apiRecord({path_params: {issue_id: '54', event_id: 'abc123'}}),
         organization
       );

--- a/static/app/views/seerExplorer/components/chat/callRecords.spec.tsx
+++ b/static/app/views/seerExplorer/components/chat/callRecords.spec.tsx
@@ -1,0 +1,337 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {callRecordLabel, callRecordUrl} from 'sentry/views/seerExplorer/callRecords';
+import {BlockComponent} from 'sentry/views/seerExplorer/components/chat';
+import type {Block, CallRecord} from 'sentry/views/seerExplorer/types';
+
+/**
+ * Code Mode call records (openspec: codemode-call-visibility).
+ *
+ * `sentry_api_execute` covers every action Code Mode can take, so the row is built from the calls
+ * the execute reported rather than from the tool's name.
+ */
+function codeModeBlock(calls: CallRecord[] | undefined): Block {
+  return {
+    id: 'tool-1',
+    message: {
+      role: 'tool_use',
+      content: null,
+      tool_calls: [
+        {id: 'call-1', function: 'sentry_api_execute', args: '{"code":"..."}'},
+      ],
+    },
+    timestamp: '2024-01-01T00:01:00Z',
+    loading: false,
+    tool_results: [
+      {
+        tool_call_id: 'call-1',
+        tool_call_function: 'sentry_api_execute',
+        content: 'ok',
+        structuredContent: calls ? {calls} : undefined,
+      },
+    ],
+  };
+}
+
+function apiRecord(overrides?: Partial<CallRecord>): CallRecord {
+  return {
+    id: 1,
+    parent: null,
+    kind: 'api',
+    method: 'GET',
+    path: '/api/0/organizations/{organization_id_or_slug}/',
+    path_params: {organization_id_or_slug: 'acme'},
+    title: 'Retrieve an Organization',
+    status: 200,
+    ...overrides,
+  };
+}
+
+describe('call record rendering', () => {
+  it('renders a row per call using the title seer shipped', () => {
+    const block = codeModeBlock([
+      apiRecord(),
+      apiRecord({id: 2, title: 'List Your Organizations'}),
+    ]);
+    render(<BlockComponent block={block} blockIndex={0} />);
+
+    expect(screen.getByText('Retrieve an Organization')).toBeInTheDocument();
+    expect(screen.getByText('List Your Organizations')).toBeInTheDocument();
+  });
+
+  it('replaces the generic tool row rather than sitting beside it', () => {
+    render(<BlockComponent block={codeModeBlock([apiRecord()])} blockIndex={0} />);
+
+    expect(screen.queryByText(/Used sentry_api_execute tool/)).not.toBeInTheDocument();
+  });
+
+  it('falls back to the generic row when no records are present', () => {
+    render(<BlockComponent block={codeModeBlock(undefined)} blockIndex={0} />);
+
+    expect(screen.getByText(/Used sentry_api_execute tool/)).toBeInTheDocument();
+  });
+
+  it('falls back to the generic row when records are empty', () => {
+    render(<BlockComponent block={codeModeBlock([])} blockIndex={0} />);
+
+    expect(screen.getByText(/Used sentry_api_execute tool/)).toBeInTheDocument();
+  });
+
+  it('drops a record with no title rather than showing its route', () => {
+    const block = codeModeBlock([
+      apiRecord({title: undefined}),
+      apiRecord({id: 2, title: 'List Your Organizations'}),
+    ]);
+    render(<BlockComponent block={block} blockIndex={0} />);
+
+    expect(screen.getByText('List Your Organizations')).toBeInTheDocument();
+    expect(screen.queryByText(/api\/0/)).not.toBeInTheDocument();
+  });
+
+  it('links a record that identifies a navigable resource', () => {
+    const block = codeModeBlock([
+      apiRecord({
+        path: '/api/0/organizations/{organization_id_or_slug}/issues/{issue_id}/',
+        path_params: {organization_id_or_slug: 'acme', issue_id: '139458447'},
+        title: 'Retrieve an Issue',
+      }),
+    ]);
+    render(<BlockComponent block={block} blockIndex={0} />);
+
+    expect(screen.getByRole('link', {name: /Retrieve an Issue/})).toHaveAttribute(
+      'href',
+      expect.stringContaining('/issues/139458447/')
+    );
+  });
+
+  it('renders a record with no navigable resource as plain text', () => {
+    render(<BlockComponent block={codeModeBlock([apiRecord()])} blockIndex={0} />);
+
+    expect(screen.getByText('Retrieve an Organization')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', {name: /Retrieve an Organization/})
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not fail the block on an unrecognized record shape', () => {
+    const block = codeModeBlock([{id: 1, kind: 'api'}]);
+
+    expect(() => render(<BlockComponent block={block} blockIndex={0} />)).not.toThrow();
+  });
+
+  it('renders lib records alongside api records', () => {
+    const block = codeModeBlock([
+      {id: 1, parent: null, kind: 'lib', name: 'code_search'},
+      apiRecord({id: 2, parent: 1}),
+    ]);
+    render(<BlockComponent block={block} blockIndex={0} />);
+
+    expect(screen.getByText('Searched code')).toBeInTheDocument();
+    expect(screen.getByText('Retrieve an Organization')).toBeInTheDocument();
+  });
+});
+
+describe('callRecordLabel', () => {
+  it('prefers a registered handler over the shipped title', () => {
+    const label = callRecordLabel({
+      id: 1,
+      kind: 'lib',
+      name: 'code_search',
+      title: 'Should not win',
+    });
+
+    expect(label).toBe('Searched code');
+  });
+
+  it('uses the shipped title when no handler matches', () => {
+    expect(callRecordLabel(apiRecord())).toBe('Retrieve an Organization');
+  });
+
+  it('returns null rather than a raw identifier when there is nothing to show', () => {
+    expect(
+      callRecordLabel({id: 1, kind: 'api', method: 'GET', path: '/api/0/x/'})
+    ).toBeNull();
+  });
+
+  it('treats a blank title as absent', () => {
+    expect(callRecordLabel(apiRecord({title: '   '}))).toBeNull();
+  });
+});
+
+describe('callRecordUrl', () => {
+  const organization = OrganizationFixture();
+
+  it('builds an issue URL from an issue_id path param', () => {
+    const url = callRecordUrl(
+      apiRecord({path_params: {organization_id_or_slug: 'acme', issue_id: '42'}}),
+      organization
+    );
+
+    expect(url).not.toBeNull();
+  });
+
+  it('prefers the event URL when a record names both an issue and an event', () => {
+    const url = callRecordUrl(
+      apiRecord({
+        path_params: {issue_id: '42', event_id: 'abc123'},
+      }),
+      organization
+    );
+
+    expect(JSON.stringify(url)).toContain('abc123');
+  });
+
+  it('returns null when only scope params are present', () => {
+    // organization/project slugs say where a call went, not what it points at.
+    expect(
+      callRecordUrl(
+        apiRecord({
+          path_params: {organization_id_or_slug: 'acme', project_id_or_slug: 'web'},
+        }),
+        organization
+      )
+    ).toBeNull();
+  });
+
+  it('returns null when a record has no path params', () => {
+    expect(callRecordUrl(apiRecord({path_params: undefined}), organization)).toBeNull();
+  });
+
+  describe('api-only aliases', () => {
+    // The API resolves `latest`/`oldest`/`recommended` server-side, but the UI route needs a
+    // concrete id — linking the alias straight through produces a dead page.
+    it('does not link an event alias as if it were an event id', () => {
+      const url = callRecordUrl(
+        apiRecord({
+          path: '/api/0/organizations/{organization_id_or_slug}/issues/{issue_id}/events/{event_id}/',
+          path_params: {
+            organization_id_or_slug: 'sentry',
+            issue_id: '54',
+            event_id: 'latest',
+          },
+        }),
+        organization
+      );
+
+      expect(JSON.stringify(url)).not.toContain('latest');
+    });
+
+    it('falls back to the issue when the event is an alias', () => {
+      const url = callRecordUrl(
+        apiRecord({path_params: {issue_id: '54', event_id: 'latest'}}),
+        organization
+      );
+
+      expect(url).toEqual(expect.objectContaining({pathname: '/issues/54/'}));
+    });
+
+    it.each(['latest', 'oldest', 'recommended'])('rejects %s as an event id', alias => {
+      const url = callRecordUrl(
+        apiRecord({path_params: {issue_id: '54', event_id: alias}}),
+        organization
+      );
+
+      expect(JSON.stringify(url)).not.toContain(alias);
+    });
+
+    it('still links a real event id', () => {
+      const url = callRecordUrl(
+        apiRecord({path_params: {issue_id: '54', event_id: 'abc123'}}),
+        organization
+      );
+
+      expect(JSON.stringify(url)).toContain('abc123');
+    });
+  });
+});
+
+describe('live call rendering', () => {
+  function liveBlock(overrides?: Partial<Block>): Block {
+    return {
+      id: 'tool-1',
+      message: {
+        role: 'tool_use',
+        content: null,
+        tool_calls: [
+          {id: 'call-1', function: 'sentry_api_execute', args: '{"code":"..."}'},
+        ],
+      },
+      timestamp: '2024-01-01T00:01:00Z',
+      loading: true,
+      tool_results: [],
+      ...overrides,
+    };
+  }
+
+  it('shows calls from the in-flight block before any result exists', () => {
+    const block = liveBlock({
+      live_calls: [apiRecord({title: 'Retrieve an Organization', status: undefined})],
+    });
+    render(<BlockComponent block={block} blockIndex={0} />);
+
+    expect(screen.getByText('Retrieve an Organization')).toBeInTheDocument();
+  });
+
+  it('prefers the finished result over the live mirror once it lands', () => {
+    const block = liveBlock({
+      loading: false,
+      live_calls: [apiRecord({title: 'Stale live row'})],
+      tool_results: [
+        {
+          tool_call_id: 'call-1',
+          tool_call_function: 'sentry_api_execute',
+          content: 'ok',
+          structuredContent: {calls: [apiRecord({title: 'Final row'})]},
+        },
+      ],
+    });
+    render(<BlockComponent block={block} blockIndex={0} />);
+
+    expect(screen.getByText('Final row')).toBeInTheDocument();
+    expect(screen.queryByText('Stale live row')).not.toBeInTheDocument();
+  });
+
+  it('does not duplicate the mirror across several in-flight calls', () => {
+    // The mirror is per block, so with two calls outstanding there is no way to say whose it is.
+    const block = liveBlock({
+      message: {
+        role: 'tool_use',
+        content: null,
+        tool_calls: [
+          {id: 'call-1', function: 'sentry_api_execute', args: '{}'},
+          {id: 'call-2', function: 'sentry_api_execute', args: '{}'},
+        ],
+      },
+      live_calls: [apiRecord({title: 'Ambiguous row'})],
+    });
+    render(<BlockComponent block={block} blockIndex={0} />);
+
+    expect(screen.queryByText('Ambiguous row')).not.toBeInTheDocument();
+  });
+
+  it('attributes the mirror to the one call still outstanding', () => {
+    const block = liveBlock({
+      message: {
+        role: 'tool_use',
+        content: null,
+        tool_calls: [
+          {id: 'call-1', function: 'sentry_api_execute', args: '{}'},
+          {id: 'call-2', function: 'sentry_api_execute', args: '{}'},
+        ],
+      },
+      tool_results: [
+        {
+          tool_call_id: 'call-1',
+          tool_call_function: 'sentry_api_execute',
+          content: 'ok',
+        },
+      ],
+      live_calls: [apiRecord({title: 'In-flight row'})],
+    });
+    render(<BlockComponent block={block} blockIndex={0} />);
+
+    expect(screen.getByText('In-flight row')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/seerExplorer/components/chat/callRecords.spec.tsx
+++ b/static/app/views/seerExplorer/components/chat/callRecords.spec.tsx
@@ -5,6 +5,7 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 import {
   callRecordDetail,
   callRecordLabel,
+  callRecordStatus,
   callRecordUrl,
 } from 'sentry/views/seerExplorer/callRecords';
 import {BlockComponent} from 'sentry/views/seerExplorer/components/chat';
@@ -154,6 +155,37 @@ describe('call record rendering', () => {
     render(<BlockComponent block={codeModeBlock([])} blockIndex={0} />);
 
     expect(screen.queryByText(/Used sentry_api_execute tool/)).not.toBeInTheDocument();
+  });
+});
+
+describe('callRecordStatus', () => {
+  it('reports success for a completed call', () => {
+    expect(callRecordStatus(apiRecord({status: 200}))).toBe('success');
+  });
+
+  it('reports failure for an error status', () => {
+    expect(callRecordStatus(apiRecord({status: 404}))).toBe('failure');
+  });
+
+  it('reports failure for a transport error', () => {
+    expect(callRecordStatus(apiRecord({status: undefined, error: 'ConnectError'}))).toBe(
+      'failure'
+    );
+  });
+
+  it('reports loading while the call is still open', () => {
+    expect(callRecordStatus(apiRecord({status: undefined}))).toBe('loading');
+  });
+
+  it('gives each call its own outcome', () => {
+    // One tick over a group cannot say which of three requests failed.
+    const records = [
+      apiRecord({id: 1, status: 200}),
+      apiRecord({id: 2, status: 500}),
+      apiRecord({id: 3, status: undefined}),
+    ];
+
+    expect(records.map(callRecordStatus)).toEqual(['success', 'failure', 'loading']);
   });
 });
 

--- a/static/app/views/seerExplorer/components/chat/callRecords.spec.tsx
+++ b/static/app/views/seerExplorer/components/chat/callRecords.spec.tsx
@@ -320,20 +320,18 @@ describe('callRecordDetail', () => {
     expect(detail?.request).toBe('GET /api/0/issues/54/tags/');
   });
 
-  it('lists query params but not path params', () => {
-    // Path params are already visible in the resolved path; the query string is not, since the
-    // transport passes it separately rather than building it into the URL.
+  it('shows the query string as part of the request line', () => {
+    // Seer composes it into resolved_path, so the URL is the request — no param list beside it.
     const detail = callRecordDetail(
       apiRecord({
-        path_params: {issue_id: '54'},
-        query_params: {statsPeriod: '14d', environment: 'prod'},
+        resolved_path:
+          '/api/0/organizations/sentry/issues/?query=is%3Aunresolved&limit=25',
       })
     );
 
-    expect(detail?.params).toEqual([
-      ['statsPeriod', '14d'],
-      ['environment', 'prod'],
-    ]);
+    expect(detail?.request).toBe(
+      'GET /api/0/organizations/sentry/issues/?query=is%3Aunresolved&limit=25'
+    );
   });
 
   it('shows the request body', () => {

--- a/static/app/views/seerExplorer/components/chat/toolUse.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.tsx
@@ -18,6 +18,7 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
 import {
+  callRecordDetail,
   callRecordFailure,
   callRecordLabel,
   callRecordUrl,
@@ -452,7 +453,9 @@ function ToolCallRow({
           <ToolCallPlainRow>{toolCallText}</ToolCallPlainRow>
         )}
       </Flex>
-      {navItems.length > 0 && (
+      {/* Call records already name and link what the execute did, so the links bus for the same
+          call is a duplicate — and a coarser one, since it links the tool rather than the call. */}
+      {navItems.length > 0 && !hasCallRows && (
         <NavLinks navItems={navItems} onNavLinkClick={onNavLinkClick} />
       )}
       {todos && <TodoList todos={todos} />}
@@ -484,22 +487,61 @@ function CallRows({
             </ToolCallText>
           </Tooltip>
         );
+        const row = url ? (
+          <ToolCallLink to={url} onClick={onCallLinkClick?.(record.kind)}>
+            {text}
+            <ToolCallLinkIconWrapper>
+              <ToolCallLinkIcon size="xs" />
+            </ToolCallLinkIconWrapper>
+          </ToolCallLink>
+        ) : (
+          <ToolCallPlainRow>{text}</ToolCallPlainRow>
+        );
+
+        const detail = callRecordDetail(record);
+
         return (
-          <Flex key={record.id} as="li" gap="sm" align="center">
-            {url ? (
-              <ToolCallLink to={url} onClick={onCallLinkClick?.(record.kind)}>
-                {text}
-                <ToolCallLinkIconWrapper>
-                  <ToolCallLinkIcon size="xs" />
-                </ToolCallLinkIconWrapper>
-              </ToolCallLink>
-            ) : (
-              <ToolCallPlainRow>{text}</ToolCallPlainRow>
-            )}
-          </Flex>
+          <Stack key={record.id} as="li" gap="xs" minWidth={0}>
+            <Flex gap="sm" align="center">
+              {row}
+            </Flex>
+            {detail && <CallDetail detail={detail} />}
+          </Stack>
         );
       })}
     </Stack>
+  );
+}
+
+/** The request behind a row, collapsed by default — the title says what, this says exactly what ran. */
+function CallDetail({
+  detail,
+}: {
+  detail: NonNullable<ReturnType<typeof callRecordDetail>>;
+}) {
+  return (
+    <Disclosure size="sm">
+      <Disclosure.Title>
+        <Text size="xs" variant="muted" monospace>
+          {t('Request')}
+        </Text>
+      </Disclosure.Title>
+      <Disclosure.Content>
+        <Stack gap="xs" minWidth={0}>
+          <Text size="xs" variant="muted" monospace>
+            {detail.request}
+          </Text>
+          {detail.params.map(([key, value]) => (
+            <Text key={key} size="xs" variant="muted" monospace>
+              {key}={value}
+            </Text>
+          ))}
+          <Text size="xs" variant="muted" monospace>
+            {t('status: %s', detail.status)}
+          </Text>
+        </Stack>
+      </Disclosure.Content>
+    </Disclosure>
   );
 }
 

--- a/static/app/views/seerExplorer/components/chat/toolUse.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.tsx
@@ -1,4 +1,4 @@
-import {useMemo} from 'react';
+import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
 import type {LocationDescriptor} from 'history';
 
@@ -78,10 +78,18 @@ export function ToolUseBlock({
     return <MessagePlaceholder />;
   }
 
+  // Each row gets its own MessageRow rather than sharing one. A Code Mode execute makes several
+  // api calls under a single tool call, but the reader has no notion of that grouping — an api
+  // call is a thing that happened, exactly like a classic tool call, and packing several into one
+  // row makes an execute that made three calls look different from three that made one each.
   return (
-    <MessageRow from="assistant" density="compact">
-      <Stack gap="md" width="100%" minWidth={0} overflow="hidden">
-        {showThinking && hasValidContent(block.message.thinking_content) && (
+    <AgentWriteApprovalProvider
+      pendingInput={pendingInput ?? null}
+      readOnly={readOnly}
+      respondToUserInput={respondToUserInput}
+    >
+      {showThinking && hasValidContent(block.message.thinking_content) && (
+        <MessageRow from="assistant" density="compact">
           <Disclosure size="sm">
             <Disclosure.Title>
               <Text size="sm" variant="muted" monospace>
@@ -92,22 +100,12 @@ export function ToolUseBlock({
               <SeerMarkdown raw={block.message.thinking_content} />
             </Disclosure.Content>
           </Disclosure>
-        )}
-        <AgentWriteApprovalProvider
-          pendingInput={pendingInput ?? null}
-          readOnly={readOnly}
-          respondToUserInput={respondToUserInput}
-        >
-          {block.message.tool_calls ? (
-            <ToolCallList
-              block={block}
-              blocks={blocks}
-              getPageReferrer={getPageReferrer}
-            />
-          ) : null}
-        </AgentWriteApprovalProvider>
-      </Stack>
-    </MessageRow>
+        </MessageRow>
+      )}
+      {block.message.tool_calls ? (
+        <ToolCallList block={block} blocks={blocks} getPageReferrer={getPageReferrer} />
+      ) : null}
+    </AgentWriteApprovalProvider>
   );
 }
 
@@ -263,13 +261,12 @@ function ToolCallList({block, blocks, getPageReferrer}: ToolCallListProps) {
   // on a Code Mode call that was suppressed.
   let rendered = 0;
 
-  // The Stack below uses `xs` to match the gap between call rows *within* one tool call. A block
-  // often holds a single Code Mode execute whose rows are the whole list, so a wider gap between
-  // tool calls only splits that list at a boundary the reader cannot see.
-
+  // `flatMap` into one row per call, each in its own MessageRow. How the run partitioned work into
+  // blocks and tool calls is invisible to the reader, so it must not show up as spacing: one
+  // execute that made three calls has to look exactly like three that made one each.
   return (
-    <Stack gap="xs" width="100%" minWidth={0} paddingRight="lg">
-      {block.message.tool_calls?.map((toolCall, idx) => {
+    <Fragment>
+      {block.message.tool_calls?.flatMap((toolCall, idx) => {
         const correspondingLinkIndex = toolCallToLinkIndexMap.get(idx);
         const toolLinkParams = toolCall.id
           ? toolLinkByCallId.get(toolCall.id)
@@ -381,28 +378,75 @@ function ToolCallList({block, blocks, getPageReferrer}: ToolCallListProps) {
           Boolean(todos) ||
           Boolean(structuredContentMarkdown);
         if (!hasContent) {
-          return null;
+          return [];
         }
-        rendered += 1;
+        const key = toolCall.id ?? `${toolCall.function}-${idx}`;
 
-        return (
-          <ToolCallRow
-            key={toolCall.id ?? `${toolCall.function}-${idx}`}
-            toolString={toolString}
-            blockStatus={rendered === 1 ? blockStatus : undefined}
-            toolUrl={toolUrl}
-            failureTooltip={failureTooltip}
-            onLinkClick={handleLinkClick}
-            todos={todos}
-            navItems={navItems}
-            structuredContentMarkdown={structuredContentMarkdown}
-            onNavLinkClick={trackLinkClick}
-            callRows={callRows}
-            onCallLinkClick={trackLinkClick}
-          />
-        );
+        // Both sources normalize to the same row shape. A classic tool contributes one row for
+        // itself; a Code Mode call contributes one per api call it made.
+        const rows: React.ReactNode[] = callRows.length
+          ? callRows.map(({record, label, url}) => (
+              <CallRow
+                key={`${key}-${record.id}`}
+                row={{
+                  label,
+                  url,
+                  failure: callRecordFailure(record),
+                  status: callRecordStatus(record),
+                  detail: callRecordDetail(record),
+                }}
+                onLinkClick={trackLinkClick(record.kind)}
+              />
+            ))
+          : [
+              <CallRow
+                key={key}
+                row={{
+                  label: toolString,
+                  url: toolUrl,
+                  failure: failureTooltip,
+                  // Only the first classic row shows the block status; call rows carry their own.
+                  status: ++rendered === 1 ? blockStatus : undefined,
+                  detail: null,
+                }}
+                onLinkClick={handleLinkClick}
+              />,
+            ];
+
+        // Trailing per-tool-call surfaces. These belong to the call as a whole rather than to any
+        // one row, so they follow its rows rather than sitting inside one.
+        //
+        // The links bus is skipped when call rows are present: those already name and link what
+        // the execute did, so it would repeat them at coarser granularity — the tool rather than
+        // the call.
+        if (navItems.length > 0 && callRows.length === 0) {
+          rows.push(
+            <NavLinks
+              key={`${key}-links`}
+              navItems={navItems}
+              onNavLinkClick={trackLinkClick}
+            />
+          );
+        }
+        if (structuredContentMarkdown) {
+          rows.push(
+            <SeerMarkdown
+              key={`${key}-markdown`}
+              raw={structuredContentMarkdown.content}
+              structuredContent={structuredContentMarkdown.structuredContent}
+            />
+          );
+        }
+        if (todos) {
+          rows.push(<TodoList key={`${key}-todos`} todos={todos} />);
+        }
+        return rows.map((row, rowIdx) => (
+          <MessageRow key={`${key}-row-${rowIdx}`} from="assistant" density="compact">
+            {row}
+          </MessageRow>
+        ));
       })}
-    </Stack>
+    </Fragment>
   );
 }
 
@@ -413,159 +457,69 @@ interface NavItem {
   url: NonNullable<ReturnType<typeof buildToolLinkUrl>>;
 }
 
-interface CallRow {
-  /** Resolved at construction, so an unlabeled record never reaches the renderer. */
+/** A row to render, normalized from either a classic tool call or one api call. */
+interface RenderRow {
+  /** The request behind the row, when it has one to expand. */
+  detail: ReturnType<typeof callRecordDetail>;
+  failure: string | null;
+  /** Resolved at construction, so an unlabeled row never reaches the renderer. */
   label: string;
-  record: CallRecord;
+  status: ToolCallStatus | undefined;
   url: LocationDescriptor | null;
 }
 
-function ToolCallRow({
-  toolString,
-  blockStatus,
-  toolUrl,
-  failureTooltip,
+/**
+ * One row in the list — a classic tool call or a single Sentry API call, rendered identically.
+ *
+ * An api call *is* a tool call as far as the reader is concerned: something happened, it succeeded
+ * or it did not, and it may point somewhere. Giving the two shapes separate components let their
+ * spacing and alignment drift apart, so they share one.
+ */
+function CallRow({
+  row,
   onLinkClick,
-  todos,
-  navItems,
-  structuredContentMarkdown,
-  onNavLinkClick,
-  callRows,
-  onCallLinkClick,
 }: {
-  blockStatus: ToolCallStatus | undefined;
-  failureTooltip: string | null;
-  navItems: NavItem[];
-  structuredContentMarkdown: ToolResult | undefined;
-  todos: TodoItem[] | null;
-  toolString: string;
-  toolUrl: ReturnType<typeof buildToolLinkUrl>;
-  callRows?: CallRow[];
-  onCallLinkClick?: (kind: string) => (e: React.MouseEvent) => void;
+  row: RenderRow;
   onLinkClick?: (e: React.MouseEvent) => void;
-  onNavLinkClick?: (kind: string) => (e: React.MouseEvent) => void;
 }) {
-  const hasLink = toolUrl !== null;
-  const hasCallRows = Boolean(callRows?.length);
-
-  const toolCallText = (
-    <Tooltip title={failureTooltip ?? ''} disabled={!failureTooltip}>
+  const text = (
+    <Tooltip title={row.failure ?? ''} disabled={!row.failure}>
       <ToolCallText size="xs" variant="muted" monospace>
-        {toolString}
+        {row.label}
       </ToolCallText>
     </Tooltip>
   );
-
-  return (
-    <Stack gap="xs">
-      <Flex display="inline-flex" align="start" gap="md" maxWidth="100%">
-        {/* Call rows each carry their own tick, so a block-level one would be a second, coarser
-            answer to the same question — and the wrong one when some calls failed. */}
-        {!hasCallRows && (
-          <Flex
-            display="inline-flex"
-            align="center"
-            justify="center"
-            width="12px"
-            height="12px"
-            flexShrink={0}
-            style={{transform: 'translateY(0.15em)'}}
-          >
-            {blockStatus && <ToolCallIndicator status={blockStatus} />}
-          </Flex>
-        )}
-        {/* Call records describe the work better than the tool's name, so they stand in for the
-            generic row rather than sitting beneath it. The status indicator above still applies. */}
-        {hasCallRows ? (
-          <CallRows callRows={callRows!} onCallLinkClick={onCallLinkClick} />
-        ) : hasLink ? (
-          <ToolCallLink to={toolUrl} onClick={onLinkClick}>
-            {toolCallText}
-            <ToolCallLinkIconWrapper>
-              <ToolCallLinkIcon size="xs" />
-            </ToolCallLinkIconWrapper>
-          </ToolCallLink>
-        ) : (
-          <ToolCallPlainRow>{toolCallText}</ToolCallPlainRow>
-        )}
-      </Flex>
-      {/* Call records already name and link what the execute did, so the links bus for the same
-          call is a duplicate — and a coarser one, since it links the tool rather than the call. */}
-      {navItems.length > 0 && !hasCallRows && (
-        <NavLinks navItems={navItems} onNavLinkClick={onNavLinkClick} />
-      )}
-      {todos && <TodoList todos={todos} />}
-      {structuredContentMarkdown && (
-        <SeerMarkdown
-          raw={structuredContentMarkdown.content}
-          structuredContent={structuredContentMarkdown.structuredContent}
-        />
-      )}
-    </Stack>
+  const label = row.url ? (
+    <ToolCallLink to={row.url} onClick={onLinkClick}>
+      {text}
+      <ToolCallLinkIconWrapper>
+        <ToolCallLinkIcon size="xs" />
+      </ToolCallLinkIconWrapper>
+    </ToolCallLink>
+  ) : (
+    <ToolCallPlainRow>{text}</ToolCallPlainRow>
   );
-}
 
-function CallRows({
-  callRows,
-  onCallLinkClick,
-}: {
-  callRows: CallRow[];
-  onCallLinkClick?: (kind: string) => (e: React.MouseEvent) => void;
-}) {
   return (
-    // `margin="0"` because a `ul` carries a default block margin, and the enclosing Stack already
-    // spaces this list from its siblings — leaving it adds a gap nothing asked for.
-    <Stack as="ul" gap="xs" padding="0" margin="0" minWidth={0}>
-      {callRows.map(({record, label, url}) => {
-        const status = callRecordStatus(record);
-        const failure = callRecordFailure(record);
-        const text = (
-          <Tooltip title={failure ?? ''} disabled={!failure}>
-            <ToolCallText size="xs" variant="muted" monospace>
-              {label}
-            </ToolCallText>
-          </Tooltip>
-        );
-        const row = url ? (
-          <ToolCallLink to={url} onClick={onCallLinkClick?.(record.kind)}>
-            {text}
-            <ToolCallLinkIconWrapper>
-              <ToolCallLinkIcon size="xs" />
-            </ToolCallLinkIconWrapper>
-          </ToolCallLink>
-        ) : (
-          <ToolCallPlainRow>{text}</ToolCallPlainRow>
-        );
-
-        const detail = callRecordDetail(record);
-
-        // The row is the disclosure's own title, so the chevron sits inline with the label rather
-        // than adding a second line beneath it. A row with nothing to show stays plain.
-        return (
-          <Stack key={record.id} as="li" gap="xs" minWidth={0}>
-            {/* One tick per call: a lib helper that fans out into three requests is three separate
-                outcomes, and a single tick above the group cannot say which of them failed. */}
-            <Flex gap="sm" align="center" minWidth={0}>
-              <StatusSlot>
-                <ToolCallIndicator status={status} />
-              </StatusSlot>
-              {detail ? (
-                <Disclosure size="xs">
-                  <Disclosure.Title>{row}</Disclosure.Title>
-                  <Disclosure.Content>
-                    <CallDetail detail={detail} />
-                  </Disclosure.Content>
-                </Disclosure>
-              ) : (
-                <Flex align="center" minWidth={0}>
-                  {row}
-                </Flex>
-              )}
-            </Flex>
-          </Stack>
-        );
-      })}
-    </Stack>
+    <Flex gap="sm" align="center" minWidth={0} maxWidth="100%">
+      {/* One tick per row: a lib helper that fans out into three requests is three separate
+          outcomes, and a single tick above the group could not say which of them failed. */}
+      <StatusSlot>{row.status && <ToolCallIndicator status={row.status} />}</StatusSlot>
+      {row.detail ? (
+        // The label is the disclosure's own title, so the chevron sits inline with it rather than
+        // adding a second line beneath. A row with nothing to show stays plain.
+        <Disclosure size="xs">
+          <Disclosure.Title>{label}</Disclosure.Title>
+          <Disclosure.Content>
+            <CallDetail detail={row.detail} />
+          </Disclosure.Content>
+        </Disclosure>
+      ) : (
+        <Flex align="center" minWidth={0}>
+          {label}
+        </Flex>
+      )}
+    </Flex>
   );
 }
 

--- a/static/app/views/seerExplorer/components/chat/toolUse.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.tsx
@@ -22,6 +22,7 @@ import {
   callRecordDetail,
   callRecordFailure,
   callRecordLabel,
+  callRecordStatus,
   callRecordUrl,
   visibleCallRecords,
 } from 'sentry/views/seerExplorer/callRecords';
@@ -262,8 +263,12 @@ function ToolCallList({block, blocks, getPageReferrer}: ToolCallListProps) {
   // on a Code Mode call that was suppressed.
   let rendered = 0;
 
+  // The Stack below uses `xs` to match the gap between call rows *within* one tool call. A block
+  // often holds a single Code Mode execute whose rows are the whole list, so a wider gap between
+  // tool calls only splits that list at a boundary the reader cannot see.
+
   return (
-    <Stack gap="md" width="100%" minWidth={0} paddingRight="lg">
+    <Stack gap="xs" width="100%" minWidth={0} paddingRight="lg">
       {block.message.tool_calls?.map((toolCall, idx) => {
         const correspondingLinkIndex = toolCallToLinkIndexMap.get(idx);
         const toolLinkParams = toolCall.id
@@ -453,26 +458,22 @@ function ToolCallRow({
 
   return (
     <Stack gap="xs">
-      {/* Call rows begin with a chevron button that carries its own left padding, so the row gap
-          that separates the indicator from a bare text label would double up into a visible gulf.
-          Let the button's padding do the spacing in that case. */}
-      <Flex
-        display="inline-flex"
-        align="start"
-        gap={hasCallRows ? '0' : 'md'}
-        maxWidth="100%"
-      >
-        <Flex
-          display="inline-flex"
-          align="center"
-          justify="center"
-          width="12px"
-          height="12px"
-          flexShrink={0}
-          style={{transform: 'translateY(0.15em)'}}
-        >
-          {blockStatus && <ToolCallIndicator status={blockStatus} />}
-        </Flex>
+      <Flex display="inline-flex" align="start" gap="md" maxWidth="100%">
+        {/* Call rows each carry their own tick, so a block-level one would be a second, coarser
+            answer to the same question — and the wrong one when some calls failed. */}
+        {!hasCallRows && (
+          <Flex
+            display="inline-flex"
+            align="center"
+            justify="center"
+            width="12px"
+            height="12px"
+            flexShrink={0}
+            style={{transform: 'translateY(0.15em)'}}
+          >
+            {blockStatus && <ToolCallIndicator status={blockStatus} />}
+          </Flex>
+        )}
         {/* Call records describe the work better than the tool's name, so they stand in for the
             generic row rather than sitting beneath it. The status indicator above still applies. */}
         {hasCallRows ? (
@@ -516,6 +517,7 @@ function CallRows({
     // spaces this list from its siblings — leaving it adds a gap nothing asked for.
     <Stack as="ul" gap="xs" padding="0" margin="0" minWidth={0}>
       {callRows.map(({record, label, url}) => {
+        const status = callRecordStatus(record);
         const failure = callRecordFailure(record);
         const text = (
           <Tooltip title={failure ?? ''} disabled={!failure}>
@@ -541,18 +543,25 @@ function CallRows({
         // than adding a second line beneath it. A row with nothing to show stays plain.
         return (
           <Stack key={record.id} as="li" gap="xs" minWidth={0}>
-            {detail ? (
-              <Disclosure size="xs">
-                <Disclosure.Title>{row}</Disclosure.Title>
-                <Disclosure.Content>
-                  <CallDetail detail={detail} />
-                </Disclosure.Content>
-              </Disclosure>
-            ) : (
-              // Only a lib call lands here, and it is the parent of the api rows beneath it — so
-              // sitting at a different indent than its children reads as the hierarchy it is.
-              <Flex align="center">{row}</Flex>
-            )}
+            {/* One tick per call: a lib helper that fans out into three requests is three separate
+                outcomes, and a single tick above the group cannot say which of them failed. */}
+            <Flex gap="sm" align="center" minWidth={0}>
+              <StatusSlot>
+                <ToolCallIndicator status={status} />
+              </StatusSlot>
+              {detail ? (
+                <Disclosure size="xs">
+                  <Disclosure.Title>{row}</Disclosure.Title>
+                  <Disclosure.Content>
+                    <CallDetail detail={detail} />
+                  </Disclosure.Content>
+                </Disclosure>
+              ) : (
+                <Flex align="center" minWidth={0}>
+                  {row}
+                </Flex>
+              )}
+            </Flex>
           </Stack>
         );
       })}
@@ -712,6 +721,16 @@ const ToolCallLinkIcon = styled(IconLink)`
   ${ToolCallLink}:hover & {
     color: ${p => p.theme.tokens.interactive.link.accent.hover};
   }
+`;
+
+// Matches the block-level indicator's box so a call row's tick sits on the same vertical rhythm.
+const StatusSlot = styled('span')`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 12px;
+  height: 12px;
+  flex-shrink: 0;
 `;
 
 const ToolCallPlainRow = styled('span')`

--- a/static/app/views/seerExplorer/components/chat/toolUse.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.tsx
@@ -353,6 +353,8 @@ function ToolCallList({block, blocks, getPageReferrer}: ToolCallListProps) {
           ? (callRecordsByCallId.get(toolCall.id) ?? [])
           : [];
         const live = toolCall.id ? (liveCallsForCallId.get(toolCall.id) ?? []) : [];
+        // A tool result exists, so the execute returned and nothing it reported is still running.
+        const callsAreSettled = finishedCalls.length > 0;
         const callRows = visibleCallRecords(finishedCalls.length ? finishedCalls : live)
           .map(record => ({
             record,
@@ -392,7 +394,7 @@ function ToolCallList({block, blocks, getPageReferrer}: ToolCallListProps) {
                   label,
                   url,
                   failure: callRecordFailure(record),
-                  status: callRecordStatus(record),
+                  status: callRecordStatus(record, callsAreSettled),
                   detail: callRecordDetail(record),
                 }}
                 onLinkClick={trackLinkClick(record.kind)}

--- a/static/app/views/seerExplorer/components/chat/toolUse.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.tsx
@@ -2,7 +2,6 @@ import {useMemo} from 'react';
 import styled from '@emotion/styled';
 import type {LocationDescriptor} from 'history';
 
-import {Button} from '@sentry/scraps/button';
 import {MessageRow, ToolCallIndicator, type ToolCallStatus} from '@sentry/scraps/chat';
 import {Checkbox} from '@sentry/scraps/checkbox';
 import {Disclosure} from '@sentry/scraps/disclosure';
@@ -13,7 +12,7 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {SeerMarkdown} from 'sentry/components/seer/markdown';
 import {AgentWriteApprovalProvider} from 'sentry/components/seer/markdown/embeds/components/agentWriteApproval';
-import {IconChevron, IconLink} from 'sentry/icons';
+import {IconLink} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -523,21 +522,9 @@ function CallRows({
                 </Disclosure.Content>
               </Disclosure>
             ) : (
-              // Reserve the chevron's footprint with the chevron itself rather than guessing at
-              // padding: it lives inside a Button, so its width is icon + button padding + icon
-              // gap. Without this a non-expandable row starts further left than its siblings and
-              // the column of labels comes apart.
-              <Flex align="center">
-                <ChevronSpacer aria-hidden>
-                  <Button
-                    size="xs"
-                    variant="transparent"
-                    aria-label=""
-                    icon={<IconChevron direction="right" />}
-                  />
-                </ChevronSpacer>
-                {row}
-              </Flex>
+              // Only a lib call lands here, and it is the parent of the api rows beneath it — so
+              // sitting at a different indent than its children reads as the hierarchy it is.
+              <Flex align="center">{row}</Flex>
             )}
           </Stack>
         );
@@ -719,16 +706,6 @@ const PayloadBox = styled('pre')`
   font-size: ${p => p.theme.font.size.xs};
   white-space: pre-wrap;
   word-break: break-word;
-`;
-
-// Holds the space a Disclosure's chevron occupies so a non-expandable row's label lines up with
-// its expandable siblings. Built from the same Button at the same size rather than from padding
-// tokens: the chevron sits inside a button whose icon gap is inherited, so the footprint cannot be
-// reproduced by hand without drifting the moment button styling changes.
-const ChevronSpacer = styled('span')`
-  visibility: hidden;
-  flex-shrink: 0;
-  pointer-events: none;
 `;
 
 const ToolCallPlainRow = styled('span')`

--- a/static/app/views/seerExplorer/components/chat/toolUse.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.tsx
@@ -486,7 +486,9 @@ function CallRows({
   onCallLinkClick?: (kind: string) => (e: React.MouseEvent) => void;
 }) {
   return (
-    <Stack as="ul" gap="xs" padding="0" minWidth={0}>
+    // `margin="0"` because a `ul` carries a default block margin, and the enclosing Stack already
+    // spaces this list from its siblings — leaving it adds a gap nothing asked for.
+    <Stack as="ul" gap="xs" padding="0" margin="0" minWidth={0}>
       {callRows.map(({record, label, url}) => {
         const failure = callRecordFailure(record);
         const text = (

--- a/static/app/views/seerExplorer/components/chat/toolUse.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.tsx
@@ -23,6 +23,7 @@ import {
   callRecordFailure,
   callRecordLabel,
   callRecordUrl,
+  visibleCallRecords,
 } from 'sentry/views/seerExplorer/callRecords';
 import type {
   Block,
@@ -44,6 +45,11 @@ import {MessagePlaceholder, getBlockStatus, hasValidContent} from './shared';
 // target are the same link whether or not one side also reports the call failed or came back empty.
 // Excluded from linkKey so the dedupe still matches a twin when only one channel carries them.
 const LINK_STATUS_PARAMS = new Set(['is_error', 'empty_results']);
+
+// Code Mode's tool names cover every action it can take, so "Used sentry_api_execute tool" names
+// nothing. These rows are built from the calls the execute reported instead; the tool's own label
+// is never rendered, and a call that produced nothing to show renders no row at all.
+const CODE_MODE_TOOLS = new Set(['sentry_api_execute', 'sentry_api_search']);
 
 // Identity for deduping a bus link against the positional row link. Params are sorted so the key
 // does not depend on object key order — today both channels derive params from the same object, but
@@ -252,6 +258,10 @@ function ToolCallList({block, blocks, getPageReferrer}: ToolCallListProps) {
   const blockStatus = getBlockStatus(block);
   const latestTodos = useMemo(() => findLatestTodos(blocks), [blocks]);
 
+  // Counts rows actually rendered, so the status tick lands on the first visible one rather than
+  // on a Code Mode call that was suppressed.
+  let rendered = 0;
+
   return (
     <Stack gap="md" width="100%" minWidth={0} paddingRight="lg">
       {block.message.tool_calls?.map((toolCall, idx) => {
@@ -341,7 +351,7 @@ function ToolCallList({block, blocks, getPageReferrer}: ToolCallListProps) {
           ? (callRecordsByCallId.get(toolCall.id) ?? [])
           : [];
         const live = toolCall.id ? (liveCallsForCallId.get(toolCall.id) ?? []) : [];
-        const callRows = (finishedCalls.length ? finishedCalls : live)
+        const callRows = visibleCallRecords(finishedCalls.length ? finishedCalls : live)
           .map(record => ({
             record,
             label: callRecordLabel(record),
@@ -354,11 +364,27 @@ function ToolCallList({block, blocks, getPageReferrer}: ToolCallListProps) {
               Boolean(row.label)
           );
 
+        const isCodeMode = CODE_MODE_TOOLS.has(toolCall.function);
+        const toolString = isCodeMode ? '' : (toolsUsed[idx] ?? '');
+
+        // Nothing to say: a Code Mode call whose label is suppressed and which reported no calls,
+        // todos, links or markdown would render an empty row with a lone status tick.
+        const hasContent =
+          Boolean(toolString) ||
+          callRows.length > 0 ||
+          navItems.length > 0 ||
+          Boolean(todos) ||
+          Boolean(structuredContentMarkdown);
+        if (!hasContent) {
+          return null;
+        }
+        rendered += 1;
+
         return (
           <ToolCallRow
             key={toolCall.id ?? `${toolCall.function}-${idx}`}
-            toolString={toolsUsed[idx] ?? ''}
-            blockStatus={idx === 0 ? blockStatus : undefined}
+            toolString={toolString}
+            blockStatus={rendered === 1 ? blockStatus : undefined}
             toolUrl={toolUrl}
             failureTooltip={failureTooltip}
             onLinkClick={handleLinkClick}

--- a/static/app/views/seerExplorer/components/chat/toolUse.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.tsx
@@ -1,7 +1,8 @@
-import {Fragment, useMemo} from 'react';
+import {useMemo} from 'react';
 import styled from '@emotion/styled';
 import type {LocationDescriptor} from 'history';
 
+import {Button} from '@sentry/scraps/button';
 import {MessageRow, ToolCallIndicator, type ToolCallStatus} from '@sentry/scraps/chat';
 import {Checkbox} from '@sentry/scraps/checkbox';
 import {Disclosure} from '@sentry/scraps/disclosure';
@@ -12,7 +13,7 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {SeerMarkdown} from 'sentry/components/seer/markdown';
 import {AgentWriteApprovalProvider} from 'sentry/components/seer/markdown/embeds/components/agentWriteApproval';
-import {IconLink} from 'sentry/icons';
+import {IconChevron, IconLink} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -512,7 +513,19 @@ function CallRows({
                 </Disclosure.Content>
               </Disclosure>
             ) : (
-              <Flex gap="sm" align="center">
+              // Reserve the chevron's footprint with the chevron itself rather than guessing at
+              // padding: it lives inside a Button, so its width is icon + button padding + icon
+              // gap. Without this a non-expandable row starts further left than its siblings and
+              // the column of labels comes apart.
+              <Flex align="center">
+                <ChevronSpacer aria-hidden>
+                  <Button
+                    size="sm"
+                    variant="transparent"
+                    aria-label=""
+                    icon={<IconChevron direction="right" />}
+                  />
+                </ChevronSpacer>
                 {row}
               </Flex>
             )}
@@ -539,22 +552,7 @@ function CallDetail({
           {key}={value}
         </Text>
       ))}
-      {detail.body && (
-        <Fragment>
-          <Text size="xs" variant="muted" monospace>
-            {t('Body')}
-          </Text>
-          <ResponseBox>{detail.body}</ResponseBox>
-        </Fragment>
-      )}
-      {detail.response && (
-        <Fragment>
-          <Text size="xs" variant="muted" monospace>
-            {t('Response')}
-          </Text>
-          <ResponseBox>{detail.response}</ResponseBox>
-        </Fragment>
-      )}
+      {detail.body && <PayloadBox>{detail.body}</PayloadBox>}
     </Stack>
   );
 }
@@ -653,6 +651,9 @@ function TodoList({todos}: {todos: TodoItem[]}) {
 const ToolCallText = styled(Text)`
   white-space: normal;
   overflow: visible;
+  /* Disclosure.Title renders its children inside a Button, which centres wrapped text. These rows
+     read as a list, so a title long enough to wrap must stay left-aligned like its siblings. */
+  text-align: left;
   text-decoration: underline;
   text-decoration-color: transparent;
 `;
@@ -696,7 +697,7 @@ const ToolCallLinkIcon = styled(IconLink)`
 
 // Capped and scrollable rather than unbounded: the preview is already truncated server-side, but
 // even 2KB of JSON would otherwise push the rest of the conversation off screen.
-const ResponseBox = styled('pre')`
+const PayloadBox = styled('pre')`
   margin: 0;
   padding: ${p => p.theme.space.md};
   max-height: 240px;
@@ -708,6 +709,16 @@ const ResponseBox = styled('pre')`
   font-size: ${p => p.theme.font.size.xs};
   white-space: pre-wrap;
   word-break: break-word;
+`;
+
+// Holds the space a Disclosure's chevron occupies so a non-expandable row's label lines up with
+// its expandable siblings. Built from the same Button the Disclosure uses rather than from padding
+// tokens: the chevron sits inside a button whose icon gap is inherited, so the footprint cannot be
+// reproduced by hand without drifting the moment button styling changes.
+const ChevronSpacer = styled('span')`
+  visibility: hidden;
+  flex-shrink: 0;
+  pointer-events: none;
 `;
 
 const ToolCallPlainRow = styled('span')`

--- a/static/app/views/seerExplorer/components/chat/toolUse.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.tsx
@@ -427,7 +427,15 @@ function ToolCallRow({
 
   return (
     <Stack gap="xs">
-      <Flex display="inline-flex" align="start" gap="md" maxWidth="100%">
+      {/* Call rows begin with a chevron button that carries its own left padding, so the row gap
+          that separates the indicator from a bare text label would double up into a visible gulf.
+          Let the button's padding do the spacing in that case. */}
+      <Flex
+        display="inline-flex"
+        align="start"
+        gap={hasCallRows ? '0' : 'md'}
+        maxWidth="100%"
+      >
         <Flex
           display="inline-flex"
           align="center"

--- a/static/app/views/seerExplorer/components/chat/toolUse.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.tsx
@@ -500,12 +500,22 @@ function CallRows({
 
         const detail = callRecordDetail(record);
 
+        // The row is the disclosure's own title, so the chevron sits inline with the label rather
+        // than adding a second line beneath it. A row with nothing to show stays plain.
         return (
           <Stack key={record.id} as="li" gap="xs" minWidth={0}>
-            <Flex gap="sm" align="center">
-              {row}
-            </Flex>
-            {detail && <CallDetail detail={detail} />}
+            {detail ? (
+              <Disclosure size="sm">
+                <Disclosure.Title>{row}</Disclosure.Title>
+                <Disclosure.Content>
+                  <CallDetail detail={detail} />
+                </Disclosure.Content>
+              </Disclosure>
+            ) : (
+              <Flex gap="sm" align="center">
+                {row}
+              </Flex>
+            )}
           </Stack>
         );
       })}
@@ -513,35 +523,24 @@ function CallRows({
   );
 }
 
-/** The request behind a row, collapsed by default — the title says what, this says exactly what ran. */
+/** What the row actually ran, and what came back. */
 function CallDetail({
   detail,
 }: {
   detail: NonNullable<ReturnType<typeof callRecordDetail>>;
 }) {
   return (
-    <Disclosure size="sm">
-      <Disclosure.Title>
-        <Text size="xs" variant="muted" monospace>
-          {t('Request')}
+    <Stack gap="xs" minWidth={0}>
+      <Text size="xs" variant="muted" monospace>
+        {detail.request}
+      </Text>
+      {detail.params.map(([key, value]) => (
+        <Text key={key} size="xs" variant="muted" monospace>
+          {key}={value}
         </Text>
-      </Disclosure.Title>
-      <Disclosure.Content>
-        <Stack gap="xs" minWidth={0}>
-          <Text size="xs" variant="muted" monospace>
-            {detail.request}
-          </Text>
-          {detail.params.map(([key, value]) => (
-            <Text key={key} size="xs" variant="muted" monospace>
-              {key}={value}
-            </Text>
-          ))}
-          <Text size="xs" variant="muted" monospace>
-            {t('status: %s', detail.status)}
-          </Text>
-        </Stack>
-      </Disclosure.Content>
-    </Disclosure>
+      ))}
+      {detail.response && <ResponseBox>{detail.response}</ResponseBox>}
+    </Stack>
   );
 }
 
@@ -678,6 +677,22 @@ const ToolCallLinkIcon = styled(IconLink)`
   ${ToolCallLink}:hover & {
     color: ${p => p.theme.tokens.interactive.link.accent.hover};
   }
+`;
+
+// Capped and scrollable rather than unbounded: the preview is already truncated server-side, but
+// even 2KB of JSON would otherwise push the rest of the conversation off screen.
+const ResponseBox = styled('pre')`
+  margin: 0;
+  padding: ${p => p.theme.space.md};
+  max-height: 240px;
+  overflow: auto;
+  border: 1px solid ${p => p.theme.tokens.border.primary};
+  border-radius: ${p => p.theme.radius.md};
+  background: ${p => p.theme.tokens.background.secondary};
+  color: ${p => p.theme.tokens.content.secondary};
+  font-size: ${p => p.theme.font.size.xs};
+  white-space: pre-wrap;
+  word-break: break-word;
 `;
 
 const ToolCallPlainRow = styled('span')`

--- a/static/app/views/seerExplorer/components/chat/toolUse.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.tsx
@@ -545,11 +545,6 @@ function CallDetail({
       <Text size="xs" variant="muted" monospace>
         {detail.request}
       </Text>
-      {detail.params.map(([key, value]) => (
-        <Text key={key} size="xs" variant="muted" monospace>
-          {key}={value}
-        </Text>
-      ))}
       {detail.body && <CodeBlock language="json">{detail.body}</CodeBlock>}
     </Stack>
   );

--- a/static/app/views/seerExplorer/components/chat/toolUse.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.tsx
@@ -1,5 +1,6 @@
 import {useMemo} from 'react';
 import styled from '@emotion/styled';
+import type {LocationDescriptor} from 'history';
 
 import {MessageRow, ToolCallIndicator, type ToolCallStatus} from '@sentry/scraps/chat';
 import {Checkbox} from '@sentry/scraps/checkbox';
@@ -16,8 +17,14 @@ import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
+import {
+  callRecordFailure,
+  callRecordLabel,
+  callRecordUrl,
+} from 'sentry/views/seerExplorer/callRecords';
 import type {
   Block,
+  CallRecord,
   TodoItem,
   ToolLink,
   ToolResult,
@@ -168,6 +175,44 @@ function useToolLinks(block: Block) {
     return map;
   }, [block.tool_results]);
 
+  // The calls a Code Mode execute made (codemode-call-visibility). Keyed by tool_call_id like the
+  // links bus: `sentry_api_execute` is one tool name for every action, so the rows come from what
+  // the sandbox did rather than from the tool's name.
+  const callRecordsByCallId = useMemo(() => {
+    const map = new Map<string, CallRecord[]>();
+    (block.tool_results || []).forEach(result => {
+      const calls = result?.structuredContent?.calls;
+      if (result?.tool_call_id && calls?.length) {
+        map.set(result.tool_call_id, calls);
+      }
+    });
+    return map;
+  }, [block.tool_results]);
+
+  // While an execute is still running there is no tool result yet, so seer mirrors its calls onto
+  // the block itself. Those rows are what make a long run legible; they are replaced by the
+  // per-result records above the moment the execute finishes.
+  //
+  // The mirror lives on the block, not per tool call, so it can only be attributed to a call that
+  // has not reported yet. With several still in flight there is no way to tell whose calls these
+  // are, so it is shown on none of them rather than duplicated across all.
+  const liveCallsForCallId = useMemo(() => {
+    const calls = block.live_calls ?? [];
+    if (!calls.length) {
+      return new Map<string, CallRecord[]>();
+    }
+    const finished = new Set(
+      (block.tool_results ?? []).flatMap(result => result?.tool_call_id ?? [])
+    );
+    const pending = (block.message.tool_calls ?? []).flatMap(toolCall =>
+      toolCall.id && !finished.has(toolCall.id) ? [toolCall.id] : []
+    );
+
+    return pending.length === 1
+      ? new Map([[pending[0]!, calls]])
+      : new Map<string, CallRecord[]>();
+  }, [block.live_calls, block.tool_results, block.message.tool_calls]);
+
   return {
     sortedToolLinks,
     toolCallToLinkIndexMap,
@@ -175,6 +220,8 @@ function useToolLinks(block: Block) {
     rawToolLinkByCallId,
     busLinksByCallId,
     structuredContentMarkdownByCallId,
+    callRecordsByCallId,
+    liveCallsForCallId,
     organization,
     projects,
   };
@@ -194,6 +241,8 @@ function ToolCallList({block, blocks, getPageReferrer}: ToolCallListProps) {
     rawToolLinkByCallId,
     busLinksByCallId,
     structuredContentMarkdownByCallId,
+    callRecordsByCallId,
+    liveCallsForCallId,
     organization,
     projects,
   } = useToolLinks(block);
@@ -283,6 +332,26 @@ function ToolCallList({block, blocks, getPageReferrer}: ToolCallListProps) {
           ? structuredContentMarkdownByCallId.get(toolCall.id)
           : undefined;
 
+        // A Code Mode execute reports the calls it made; those describe the work far better than
+        // its single tool name can, so they replace the generic row when present. Until the result
+        // lands the block's live mirror stands in, so a running execute shows its progress.
+        const finishedCalls = toolCall.id
+          ? (callRecordsByCallId.get(toolCall.id) ?? [])
+          : [];
+        const live = toolCall.id ? (liveCallsForCallId.get(toolCall.id) ?? []) : [];
+        const callRows = (finishedCalls.length ? finishedCalls : live)
+          .map(record => ({
+            record,
+            label: callRecordLabel(record),
+            url: callRecordUrl(record, organization, projects),
+          }))
+          // A record we have no label for is dropped rather than rendered as a route or an
+          // internal identifier — one fewer row beats a raw string on screen.
+          .filter(
+            (row): row is {label: string; record: CallRecord; url: typeof row.url} =>
+              Boolean(row.label)
+          );
+
         return (
           <ToolCallRow
             key={toolCall.id ?? `${toolCall.function}-${idx}`}
@@ -295,6 +364,8 @@ function ToolCallList({block, blocks, getPageReferrer}: ToolCallListProps) {
             navItems={navItems}
             structuredContentMarkdown={structuredContentMarkdown}
             onNavLinkClick={trackLinkClick}
+            callRows={callRows}
+            onCallLinkClick={trackLinkClick}
           />
         );
       })}
@@ -309,6 +380,13 @@ interface NavItem {
   url: NonNullable<ReturnType<typeof buildToolLinkUrl>>;
 }
 
+interface CallRow {
+  /** Resolved at construction, so an unlabeled record never reaches the renderer. */
+  label: string;
+  record: CallRecord;
+  url: LocationDescriptor | null;
+}
+
 function ToolCallRow({
   toolString,
   blockStatus,
@@ -319,6 +397,8 @@ function ToolCallRow({
   navItems,
   structuredContentMarkdown,
   onNavLinkClick,
+  callRows,
+  onCallLinkClick,
 }: {
   blockStatus: ToolCallStatus | undefined;
   failureTooltip: string | null;
@@ -327,10 +407,13 @@ function ToolCallRow({
   todos: TodoItem[] | null;
   toolString: string;
   toolUrl: ReturnType<typeof buildToolLinkUrl>;
+  callRows?: CallRow[];
+  onCallLinkClick?: (kind: string) => (e: React.MouseEvent) => void;
   onLinkClick?: (e: React.MouseEvent) => void;
   onNavLinkClick?: (kind: string) => (e: React.MouseEvent) => void;
 }) {
   const hasLink = toolUrl !== null;
+  const hasCallRows = Boolean(callRows?.length);
 
   const toolCallText = (
     <Tooltip title={failureTooltip ?? ''} disabled={!failureTooltip}>
@@ -354,7 +437,11 @@ function ToolCallRow({
         >
           {blockStatus && <ToolCallIndicator status={blockStatus} />}
         </Flex>
-        {hasLink ? (
+        {/* Call records describe the work better than the tool's name, so they stand in for the
+            generic row rather than sitting beneath it. The status indicator above still applies. */}
+        {hasCallRows ? (
+          <CallRows callRows={callRows!} onCallLinkClick={onCallLinkClick} />
+        ) : hasLink ? (
           <ToolCallLink to={toolUrl} onClick={onLinkClick}>
             {toolCallText}
             <ToolCallLinkIconWrapper>
@@ -375,6 +462,43 @@ function ToolCallRow({
           structuredContent={structuredContentMarkdown.structuredContent}
         />
       )}
+    </Stack>
+  );
+}
+
+function CallRows({
+  callRows,
+  onCallLinkClick,
+}: {
+  callRows: CallRow[];
+  onCallLinkClick?: (kind: string) => (e: React.MouseEvent) => void;
+}) {
+  return (
+    <Stack as="ul" gap="xs" padding="0" minWidth={0}>
+      {callRows.map(({record, label, url}) => {
+        const failure = callRecordFailure(record);
+        const text = (
+          <Tooltip title={failure ?? ''} disabled={!failure}>
+            <ToolCallText size="xs" variant="muted" monospace>
+              {label}
+            </ToolCallText>
+          </Tooltip>
+        );
+        return (
+          <Flex key={record.id} as="li" gap="sm" align="center">
+            {url ? (
+              <ToolCallLink to={url} onClick={onCallLinkClick?.(record.kind)}>
+                {text}
+                <ToolCallLinkIconWrapper>
+                  <ToolCallLinkIcon size="xs" />
+                </ToolCallLinkIconWrapper>
+              </ToolCallLink>
+            ) : (
+              <ToolCallPlainRow>{text}</ToolCallPlainRow>
+            )}
+          </Flex>
+        );
+      })}
     </Stack>
   );
 }

--- a/static/app/views/seerExplorer/components/chat/toolUse.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.tsx
@@ -516,12 +516,14 @@ function CallRows({
         return (
           <Stack key={record.id} as="li" gap="xs" minWidth={0}>
             {detail ? (
-              <Disclosure size="sm">
-                <Disclosure.Title>{row}</Disclosure.Title>
-                <Disclosure.Content>
-                  <CallDetail detail={detail} />
-                </Disclosure.Content>
-              </Disclosure>
+              <CompactDisclosure>
+                <Disclosure size="xs">
+                  <Disclosure.Title>{row}</Disclosure.Title>
+                  <Disclosure.Content>
+                    <CallDetail detail={detail} />
+                  </Disclosure.Content>
+                </Disclosure>
+              </CompactDisclosure>
             ) : (
               // Reserve the chevron's footprint with the chevron itself rather than guessing at
               // padding: it lives inside a Button, so its width is icon + button padding + icon
@@ -530,7 +532,7 @@ function CallRows({
               <Flex align="center">
                 <ChevronSpacer aria-hidden>
                   <Button
-                    size="sm"
+                    size="xs"
                     variant="transparent"
                     aria-label=""
                     icon={<IconChevron direction="right" />}
@@ -721,14 +723,32 @@ const PayloadBox = styled('pre')`
   word-break: break-word;
 `;
 
+// A Disclosure titles itself with a Button, whose vertical padding makes the row roughly twice the
+// height of the plain text rows beside it. These read as a dense list, so the button is stripped
+// back to the line box; the chevron and hover target are unaffected.
+const CompactDisclosure = styled('div')`
+  button {
+    min-height: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+`;
+
 // Holds the space a Disclosure's chevron occupies so a non-expandable row's label lines up with
-// its expandable siblings. Built from the same Button the Disclosure uses rather than from padding
+// its expandable siblings. Built from the same Button at the same size rather than from padding
 // tokens: the chevron sits inside a button whose icon gap is inherited, so the footprint cannot be
 // reproduced by hand without drifting the moment button styling changes.
 const ChevronSpacer = styled('span')`
   visibility: hidden;
   flex-shrink: 0;
   pointer-events: none;
+
+  /* Matches CompactDisclosure so the reserved width equals the real chevron's. */
+  button {
+    min-height: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+  }
 `;
 
 const ToolCallPlainRow = styled('span')`

--- a/static/app/views/seerExplorer/components/chat/toolUse.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.tsx
@@ -196,6 +196,14 @@ function useToolLinks(block: Block) {
     return map;
   }, [block.tool_results]);
 
+  // The tool calls that have reported back. A result means the call returned, whatever it did or
+  // did not carry, which is what tells a row whether anything is still in flight.
+  const settledCallIds = useMemo(
+    () =>
+      new Set((block.tool_results ?? []).flatMap(result => result?.tool_call_id ?? [])),
+    [block.tool_results]
+  );
+
   // While an execute is still running there is no tool result yet, so seer mirrors its calls onto
   // the block itself. Those rows are what make a long run legible; they are replaced by the
   // per-result records above the moment the execute finishes.
@@ -208,17 +216,14 @@ function useToolLinks(block: Block) {
     if (!calls.length) {
       return new Map<string, CallRecord[]>();
     }
-    const finished = new Set(
-      (block.tool_results ?? []).flatMap(result => result?.tool_call_id ?? [])
-    );
     const pending = (block.message.tool_calls ?? []).flatMap(toolCall =>
-      toolCall.id && !finished.has(toolCall.id) ? [toolCall.id] : []
+      toolCall.id && !settledCallIds.has(toolCall.id) ? [toolCall.id] : []
     );
 
     return pending.length === 1
       ? new Map([[pending[0]!, calls]])
       : new Map<string, CallRecord[]>();
-  }, [block.live_calls, block.tool_results, block.message.tool_calls]);
+  }, [block.live_calls, block.message.tool_calls, settledCallIds]);
 
   return {
     sortedToolLinks,
@@ -229,6 +234,7 @@ function useToolLinks(block: Block) {
     structuredContentMarkdownByCallId,
     callRecordsByCallId,
     liveCallsForCallId,
+    settledCallIds,
     organization,
     projects,
   };
@@ -250,6 +256,7 @@ function ToolCallList({block, blocks, getPageReferrer}: ToolCallListProps) {
     structuredContentMarkdownByCallId,
     callRecordsByCallId,
     liveCallsForCallId,
+    settledCallIds,
     organization,
     projects,
   } = useToolLinks(block);
@@ -353,8 +360,11 @@ function ToolCallList({block, blocks, getPageReferrer}: ToolCallListProps) {
           ? (callRecordsByCallId.get(toolCall.id) ?? [])
           : [];
         const live = toolCall.id ? (liveCallsForCallId.get(toolCall.id) ?? []) : [];
-        // A tool result exists, so the execute returned and nothing it reported is still running.
-        const callsAreSettled = finishedCalls.length > 0;
+        // A result exists, so the execute returned and nothing it reported is still running. Read
+        // off the result itself rather than off the records it carried: a call that reports none
+        // has still finished, and reading "settled" as "reported something" would leave any row
+        // built from the live mirror spinning.
+        const callsAreSettled = toolCall.id ? settledCallIds.has(toolCall.id) : false;
         const callRows = visibleCallRecords(finishedCalls.length ? finishedCalls : live)
           .map(record => {
             const link = callRecordLink(record, organization, projects);
@@ -513,15 +523,28 @@ function CallRow({
   );
 
   return (
+    // Matches the block-level indicator's box so a call row's tick sits on the same vertical
+    // rhythm.
     <Flex gap="sm" align="center" minWidth={0} maxWidth="100%">
       {/* One tick per row: a lib helper that fans out into three requests is three separate
           outcomes, and a single tick above the group could not say which of them failed. */}
-      <StatusSlot>{row.status && <ToolCallIndicator status={row.status} />}</StatusSlot>
+      <Flex align="center" justify="center" width="12px" height="12px" flexShrink={0}>
+        {row.status && <ToolCallIndicator status={row.status} />}
+      </Flex>
       {row.detail ? (
-        // The label is the disclosure's own title, so the chevron sits inline with it rather than
-        // adding a second line beneath. A row with nothing to show stays plain.
+        // The title is the disclosure's own, so the chevron sits inline with it rather than adding
+        // a second line beneath. The link cannot go inside it: the title renders as a button, and
+        // an anchor nested in a button is invalid HTML that leaves both controls sharing one click
+        // target and one tab stop. `trailingItems` puts it beside the button instead — the title
+        // expands the request, the icon navigates.
         <Disclosure size="xs">
-          <Disclosure.Title>{label}</Disclosure.Title>
+          <Disclosure.Title
+            trailingItems={
+              row.url && <RowLink url={row.url} label={row.label} onClick={onLinkClick} />
+            }
+          >
+            {text}
+          </Disclosure.Title>
           <Disclosure.Content>
             <CallDetail detail={row.detail} />
           </Disclosure.Content>
@@ -532,6 +555,29 @@ function CallRow({
         </Flex>
       )}
     </Flex>
+  );
+}
+
+/**
+ * The row's destination as a control of its own, for a row that also expands.
+ *
+ * Visible at rest, unlike the inline variant whose icon the label's hover reveals: there is no
+ * label to hover here, and an affordance that only appears under the pointer is one a keyboard
+ * user never finds.
+ */
+function RowLink({
+  url,
+  label,
+  onClick,
+}: {
+  label: string;
+  url: LocationDescriptor;
+  onClick?: (e: React.MouseEvent) => void;
+}) {
+  return (
+    <ToolCallLink to={url} onClick={onClick} aria-label={t('Open %s', label)}>
+      <ToolCallLinkIcon size="xs" />
+    </ToolCallLink>
   );
 }
 
@@ -687,16 +733,6 @@ const ToolCallLinkIcon = styled(IconLink)`
   ${ToolCallLink}:hover & {
     color: ${p => p.theme.tokens.interactive.link.accent.hover};
   }
-`;
-
-// Matches the block-level indicator's box so a call row's tick sits on the same vertical rhythm.
-const StatusSlot = styled('span')`
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 12px;
-  height: 12px;
-  flex-shrink: 0;
 `;
 
 const ToolCallPlainRow = styled('span')`

--- a/static/app/views/seerExplorer/components/chat/toolUse.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.tsx
@@ -22,8 +22,8 @@ import {
   callRecordDetail,
   callRecordFailure,
   callRecordLabel,
+  callRecordLink,
   callRecordStatus,
-  callRecordUrl,
   visibleCallRecords,
 } from 'sentry/views/seerExplorer/callRecords';
 import type {
@@ -356,17 +356,20 @@ function ToolCallList({block, blocks, getPageReferrer}: ToolCallListProps) {
         // A tool result exists, so the execute returned and nothing it reported is still running.
         const callsAreSettled = finishedCalls.length > 0;
         const callRows = visibleCallRecords(finishedCalls.length ? finishedCalls : live)
-          .map(record => ({
-            record,
-            label: callRecordLabel(record),
-            url: callRecordUrl(record, organization, projects),
-          }))
+          .map(record => {
+            const link = callRecordLink(record, organization, projects);
+            return {
+              record,
+              label: callRecordLabel(record),
+              url: link?.url ?? null,
+              // The navigable kind, not `record.kind` — analytics keys `tool_kind` on which
+              // destination was opened, and the record's own kind is only ever api/lib.
+              linkKind: link?.kind ?? record.kind,
+            };
+          })
           // A record we have no label for is dropped rather than rendered as a route or an
           // internal identifier — one fewer row beats a raw string on screen.
-          .filter(
-            (row): row is {label: string; record: CallRecord; url: typeof row.url} =>
-              Boolean(row.label)
-          );
+          .filter(row => Boolean(row.label));
 
         const isCodeMode = CODE_MODE_TOOLS.has(toolCall.function);
         const toolString = isCodeMode ? '' : (toolsUsed[idx] ?? '');
@@ -387,7 +390,7 @@ function ToolCallList({block, blocks, getPageReferrer}: ToolCallListProps) {
         // Both sources normalize to the same row shape. A classic tool contributes one row for
         // itself; a Code Mode call contributes one per api call it made.
         const rows: React.ReactNode[] = callRows.length
-          ? callRows.map(({record, label, url}) => (
+          ? callRows.map(({record, label, url, linkKind}) => (
               <CallRow
                 key={`${key}-${record.id}`}
                 row={{
@@ -397,23 +400,29 @@ function ToolCallList({block, blocks, getPageReferrer}: ToolCallListProps) {
                   status: callRecordStatus(record, callsAreSettled),
                   detail: callRecordDetail(record),
                 }}
-                onLinkClick={trackLinkClick(record.kind)}
+                onLinkClick={trackLinkClick(linkKind)}
               />
             ))
-          : [
-              <CallRow
-                key={key}
-                row={{
-                  label: toolString,
-                  url: toolUrl,
-                  failure: failureTooltip,
-                  // Only the first classic row shows the block status; call rows carry their own.
-                  status: ++rendered === 1 ? blockStatus : undefined,
-                  detail: null,
-                }}
-                onLinkClick={handleLinkClick}
-              />,
-            ];
+          : toolString
+            ? [
+                <CallRow
+                  key={key}
+                  row={{
+                    label: toolString,
+                    url: toolUrl,
+                    failure: failureTooltip,
+                    // Only the first classic row shows the block status; call rows carry their own.
+                    status: ++rendered === 1 ? blockStatus : undefined,
+                    detail: null,
+                  }}
+                  onLinkClick={handleLinkClick}
+                />,
+              ]
+            : // A Code Mode call has no label of its own, so with no call rows there is nothing to
+              // put in a row — `hasContent` got us here for the trailing surfaces (todos, markdown,
+              // links), and rendering the empty label anyway is the lone status tick that guard
+              // exists to avoid.
+              [];
 
         // Trailing per-tool-call surfaces. These belong to the call as a whole rather than to any
         // one row, so they follow its rows rather than sitting inside one.

--- a/static/app/views/seerExplorer/components/chat/toolUse.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.tsx
@@ -1,4 +1,4 @@
-import {useMemo} from 'react';
+import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
 import type {LocationDescriptor} from 'history';
 
@@ -539,7 +539,22 @@ function CallDetail({
           {key}={value}
         </Text>
       ))}
-      {detail.response && <ResponseBox>{detail.response}</ResponseBox>}
+      {detail.body && (
+        <Fragment>
+          <Text size="xs" variant="muted" monospace>
+            {t('Body')}
+          </Text>
+          <ResponseBox>{detail.body}</ResponseBox>
+        </Fragment>
+      )}
+      {detail.response && (
+        <Fragment>
+          <Text size="xs" variant="muted" monospace>
+            {t('Response')}
+          </Text>
+          <ResponseBox>{detail.response}</ResponseBox>
+        </Fragment>
+      )}
     </Stack>
   );
 }

--- a/static/app/views/seerExplorer/components/chat/toolUse.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.tsx
@@ -728,6 +728,9 @@ const PayloadBox = styled('pre')`
 // back to the line box; the chevron and hover target are unaffected.
 const CompactDisclosure = styled('div')`
   button {
+    /* Button sets an explicit height from theme.form, so padding alone leaves the control at its
+       full size. Both have to go for the row to collapse to its text. */
+    height: auto;
     min-height: 0;
     padding-top: 0;
     padding-bottom: 0;
@@ -743,8 +746,9 @@ const ChevronSpacer = styled('span')`
   flex-shrink: 0;
   pointer-events: none;
 
-  /* Matches CompactDisclosure so the reserved width equals the real chevron's. */
+  /* Matches CompactDisclosure so the reserved box equals the real chevron's. */
   button {
+    height: auto;
     min-height: 0;
     padding-top: 0;
     padding-bottom: 0;

--- a/static/app/views/seerExplorer/components/chat/toolUse.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.tsx
@@ -516,14 +516,12 @@ function CallRows({
         return (
           <Stack key={record.id} as="li" gap="xs" minWidth={0}>
             {detail ? (
-              <CompactDisclosure>
-                <Disclosure size="xs">
-                  <Disclosure.Title>{row}</Disclosure.Title>
-                  <Disclosure.Content>
-                    <CallDetail detail={detail} />
-                  </Disclosure.Content>
-                </Disclosure>
-              </CompactDisclosure>
+              <Disclosure size="xs">
+                <Disclosure.Title>{row}</Disclosure.Title>
+                <Disclosure.Content>
+                  <CallDetail detail={detail} />
+                </Disclosure.Content>
+              </Disclosure>
             ) : (
               // Reserve the chevron's footprint with the chevron itself rather than guessing at
               // padding: it lives inside a Button, so its width is icon + button padding + icon
@@ -723,20 +721,6 @@ const PayloadBox = styled('pre')`
   word-break: break-word;
 `;
 
-// A Disclosure titles itself with a Button, whose vertical padding makes the row roughly twice the
-// height of the plain text rows beside it. These read as a dense list, so the button is stripped
-// back to the line box; the chevron and hover target are unaffected.
-const CompactDisclosure = styled('div')`
-  button {
-    /* Button sets an explicit height from theme.form, so padding alone leaves the control at its
-       full size. Both have to go for the row to collapse to its text. */
-    height: auto;
-    min-height: 0;
-    padding-top: 0;
-    padding-bottom: 0;
-  }
-`;
-
 // Holds the space a Disclosure's chevron occupies so a non-expandable row's label lines up with
 // its expandable siblings. Built from the same Button at the same size rather than from padding
 // tokens: the chevron sits inside a button whose icon gap is inherited, so the footprint cannot be
@@ -745,14 +729,6 @@ const ChevronSpacer = styled('span')`
   visibility: hidden;
   flex-shrink: 0;
   pointer-events: none;
-
-  /* Matches CompactDisclosure so the reserved box equals the real chevron's. */
-  button {
-    height: auto;
-    min-height: 0;
-    padding-top: 0;
-    padding-bottom: 0;
-  }
 `;
 
 const ToolCallPlainRow = styled('span')`

--- a/static/app/views/seerExplorer/components/chat/toolUse.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.tsx
@@ -4,6 +4,7 @@ import type {LocationDescriptor} from 'history';
 
 import {MessageRow, ToolCallIndicator, type ToolCallStatus} from '@sentry/scraps/chat';
 import {Checkbox} from '@sentry/scraps/checkbox';
+import {CodeBlock} from '@sentry/scraps/code';
 import {Disclosure} from '@sentry/scraps/disclosure';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
@@ -549,7 +550,7 @@ function CallDetail({
           {key}={value}
         </Text>
       ))}
-      {detail.body && <PayloadBox>{detail.body}</PayloadBox>}
+      {detail.body && <CodeBlock language="json">{detail.body}</CodeBlock>}
     </Stack>
   );
 }
@@ -690,22 +691,6 @@ const ToolCallLinkIcon = styled(IconLink)`
   ${ToolCallLink}:hover & {
     color: ${p => p.theme.tokens.interactive.link.accent.hover};
   }
-`;
-
-// Capped and scrollable rather than unbounded: the preview is already truncated server-side, but
-// even 2KB of JSON would otherwise push the rest of the conversation off screen.
-const PayloadBox = styled('pre')`
-  margin: 0;
-  padding: ${p => p.theme.space.md};
-  max-height: 240px;
-  overflow: auto;
-  border: 1px solid ${p => p.theme.tokens.border.primary};
-  border-radius: ${p => p.theme.radius.md};
-  background: ${p => p.theme.tokens.background.secondary};
-  color: ${p => p.theme.tokens.content.secondary};
-  font-size: ${p => p.theme.font.size.xs};
-  white-space: pre-wrap;
-  word-break: break-word;
 `;
 
 const ToolCallPlainRow = styled('span')`

--- a/static/app/views/seerExplorer/components/chat/toolUse.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.tsx
@@ -368,8 +368,9 @@ function ToolCallList({block, blocks, getPageReferrer}: ToolCallListProps) {
             };
           })
           // A record we have no label for is dropped rather than rendered as a route or an
-          // internal identifier — one fewer row beats a raw string on screen.
-          .filter(row => Boolean(row.label));
+          // internal identifier — one fewer row beats a raw string on screen. The predicate
+          // narrows `label` for the render below, which is why it is not a plain Boolean check.
+          .filter((row): row is typeof row & {label: string} => Boolean(row.label));
 
         const isCodeMode = CODE_MODE_TOOLS.has(toolCall.function);
         const toolString = isCodeMode ? '' : (toolsUsed[idx] ?? '');

--- a/static/app/views/seerExplorer/types.tsx
+++ b/static/app/views/seerExplorer/types.tsx
@@ -90,12 +90,17 @@ export type AgentWriteApproval = EmbedOutput<'agentWriteApproval'>;
  * what makes a link buildable from `path_params`. `parent` nests a lib method's HTTP calls under
  * it; `id` is unique within one execute, so correlation never depends on array position.
  *
- * Deliberately absent: response bodies. Seer emits the request envelope and outcome only; a
- * handler that needs response data fetches it directly.
+ * `body` and `response` are bounded previews, not the payloads — records live in the run state row,
+ * which is re-serialized on every write and re-downloaded by the poll, so seer caps both and flags
+ * when it cut them.
  */
 export interface CallRecord {
   id: number;
   kind: 'api' | 'lib';
+  /** Bounded slice of the request body, if the call had one. */
+  body?: string;
+  /** Whether `body` was cut short. */
+  body_truncated?: boolean;
   /** Transport-level failure (no HTTP response), e.g. `ConnectError`. */
   error?: string;
   method?: string;

--- a/static/app/views/seerExplorer/types.tsx
+++ b/static/app/views/seerExplorer/types.tsx
@@ -106,6 +106,8 @@ export interface CallRecord {
   method?: string;
   /** Lib records only. */
   name?: string;
+  /** Lib records only: the call's scalar arguments, which name what it acted on. */
+  params?: Record<string, string>;
   parent?: number | null;
   path?: string;
   path_params?: Record<string, string>;

--- a/static/app/views/seerExplorer/types.tsx
+++ b/static/app/views/seerExplorer/types.tsx
@@ -107,6 +107,10 @@ export interface CallRecord {
   query_params?: Record<string, string>;
   /** `path` with its params interpolated — the literal path that was requested. */
   resolved_path?: string;
+  /** Bounded slice of the response body — a preview, not the response. */
+  response?: string;
+  /** Whether `response` was cut short of the full body. */
+  response_truncated?: boolean;
   /** HTTP status. Absent when the request never completed. */
   status?: number;
   /** Human name for the operation, from the OpenAPI spec. Absent when it has none. */

--- a/static/app/views/seerExplorer/types.tsx
+++ b/static/app/views/seerExplorer/types.tsx
@@ -90,9 +90,10 @@ export type AgentWriteApproval = EmbedOutput<'agentWriteApproval'>;
  * what makes a link buildable from `path_params`. `parent` nests a lib method's HTTP calls under
  * it; `id` is unique within one execute, so correlation never depends on array position.
  *
- * `body` and `response` are bounded previews, not the payloads — records live in the run state row,
- * which is re-serialized on every write and re-downloaded by the poll, so seer caps both and flags
- * when it cut them.
+ * `body` is a bounded preview, not the payload — records live in the run state row, which is
+ * re-serialized on every write and re-downloaded by the poll, so seer caps it and flags when it
+ * cut it. No response body is carried: it is arbitrary customer data, it can hold a secret a write
+ * hands back, and a row reports the request rather than what came back.
  */
 export interface CallRecord {
   id: number;
@@ -114,10 +115,6 @@ export interface CallRecord {
   query_params?: Record<string, string>;
   /** `path` with its params interpolated — the literal path that was requested. */
   resolved_path?: string;
-  /** Bounded slice of the response body — a preview, not the response. */
-  response?: string;
-  /** Whether `response` was cut short of the full body. */
-  response_truncated?: boolean;
   /** HTTP status. Absent when the request never completed. */
   status?: number;
   /** Human name for the operation, from the OpenAPI spec. Absent when it has none. */

--- a/static/app/views/seerExplorer/types.tsx
+++ b/static/app/views/seerExplorer/types.tsx
@@ -80,7 +80,7 @@ export interface ToolLink {
 export type AgentWriteApproval = EmbedOutput<'agentWriteApproval'>;
 
 /**
- * One Sentry API or lib call a Code Mode execute made (openspec: codemode-call-visibility).
+ * One Sentry API or lib call a Code Mode execute made.
  *
  * `sentry_api_execute` is a single tool name covering every action Code Mode can take, so keying
  * rendering on the tool name (as classic tools do) says nothing useful. Seer instead reports the

--- a/static/app/views/seerExplorer/types.tsx
+++ b/static/app/views/seerExplorer/types.tsx
@@ -79,6 +79,40 @@ export interface ToolLink {
 
 export type AgentWriteApproval = EmbedOutput<'agentWriteApproval'>;
 
+/**
+ * One Sentry API or lib call a Code Mode execute made (openspec: codemode-call-visibility).
+ *
+ * `sentry_api_execute` is a single tool name covering every action Code Mode can take, so keying
+ * rendering on the tool name (as classic tools do) says nothing useful. Seer instead reports the
+ * calls themselves and the client decides how to present them.
+ *
+ * `path` is the *templated* route (`/api/0/.../{issue_id}/`) — the key a handler matches on, and
+ * what makes a link buildable from `path_params`. `parent` nests a lib method's HTTP calls under
+ * it; `id` is unique within one execute, so correlation never depends on array position.
+ *
+ * Deliberately absent: response bodies. Seer emits the request envelope and outcome only; a
+ * handler that needs response data fetches it directly.
+ */
+export interface CallRecord {
+  id: number;
+  kind: 'api' | 'lib';
+  /** Transport-level failure (no HTTP response), e.g. `ConnectError`. */
+  error?: string;
+  method?: string;
+  /** Lib records only. */
+  name?: string;
+  parent?: number | null;
+  path?: string;
+  path_params?: Record<string, string>;
+  query_params?: Record<string, string>;
+  /** `path` with its params interpolated — the literal path that was requested. */
+  resolved_path?: string;
+  /** HTTP status. Absent when the request never completed. */
+  status?: number;
+  /** Human name for the operation, from the OpenAPI spec. Absent when it has none. */
+  title?: string;
+}
+
 export interface ToolResult {
   content: string;
   tool_call_function: string;
@@ -90,6 +124,7 @@ export interface ToolResult {
   structuredContent?: {
     agentWriteApproval?: AgentWriteApproval;
     artifacts?: Artifact[];
+    calls?: CallRecord[];
     links?: ToolLink[];
     todos?: TodoItem[];
   } | null;
@@ -115,6 +150,12 @@ export interface Block {
   timestamp: string;
   artifacts?: Artifact[];
   file_patches?: ExplorerFilePatch[] | null;
+  /**
+   * Calls the in-flight Code Mode execute has made so far, written as they happen so a long run
+   * shows progress instead of nothing. Superseded by the tool result's `structuredContent.calls`
+   * once the execute finishes.
+   */
+  live_calls?: CallRecord[] | null;
   loading?: boolean;
   merged_file_patches?: ExplorerFilePatch[] | null;
   pr_commit_shas?: Record<string, string> | null;

--- a/static/app/views/seerExplorer/types.tsx
+++ b/static/app/views/seerExplorer/types.tsx
@@ -112,8 +112,10 @@ export interface CallRecord {
   parent?: number | null;
   path?: string;
   path_params?: Record<string, string>;
-  query_params?: Record<string, string>;
-  /** `path` with its params interpolated — the literal path that was requested. */
+  /**
+   * `path` with its params interpolated and the query string appended — the literal path that was
+   * requested. Seer carries the query only here, so this is the whole URL.
+   */
   resolved_path?: string;
   /** HTTP status. Absent when the request never completed. */
   status?: number;


### PR DESCRIPTION
A Code Mode execute rendered as one generic "Used tool" row, so an execute that
made eight requests looked the same as one that made none, and a failed request
was invisible.

Seer now reports each call an execute makes on the tool result's
structuredContent. This renders them: one row per call, each with its own status,
expandable to the request URL and body. A lib call that fanned out into API calls
is dropped in favour of the rows beneath it, which say more.

Presentation is decided here rather than in Seer, which ships route metadata
only. Which routes earn a link, and which get a bespoke label instead of their
spec name, lives in a small map in `callRecords.tsx` — so adding a handler stays
a frontend-only deploy and needs no coordination with Seer.

Frontend only. Reads a field Seer already emits, so it is safe to deploy
independently: before Seer ships the data the list is simply empty, which is
today's behavior.