### PR TITLE
feat(seer): Name the reason an agent token is rejected

### DIFF
--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -4,7 +4,7 @@ import hashlib
 import hmac
 import logging
 from collections.abc import Callable, Iterable
-from typing import Any, ClassVar
+from typing import Any, ClassVar, NoReturn
 
 import sentry_sdk
 from django.conf import settings
@@ -626,21 +626,46 @@ class AgentTokenAuthentication(StandardAuthentication):
         return agent_token.is_agent_token_string(force_str(auth[1]))
 
     def authenticate_token(self, request: Request, token_str: str) -> tuple[Any, Any]:
+        def fail(reason: str, **extra: Any) -> NoReturn:
+            # TODO(jstanley): Temporary logging to disambiguate agent-token 401s. Every
+            # rejection below returns the same opaque message, so a rejected credential
+            # is indistinguishable from no credential at all -- and because the scope
+            # challenge (403 insufficient_scope) lives downstream of authentication, a
+            # failure here silently forecloses the write-approval flow rather than
+            # prompting for it. Mirrors viewer_context_auth.failed below.
+            # Remove once the auth issue is resolved.
+            #
+            # Deliberately free of request-derived strings. `request.path` carries the
+            # org and project slugs, and a JWT library's message can quote the token it
+            # failed on -- neither belongs in a production log. Numeric ids and the
+            # exception's class name say which of the seven rejections fired, which is
+            # the whole diagnostic need.
+            logger.warning(
+                "agent_token_auth.failed",
+                extra={"reason": reason, **extra},
+            )
+            raise AuthenticationFailed("Invalid agent token")
+
         try:
             claims = agent_token.decode_agent_token(token_str)
             # Building the token casts org and scopes too, so any missing/mis-typed claim
             # in a signed token is a clean 401 here, not a 500 downstream.
             auth_token = agent_token.build_authenticated_token(claims)
             user_id = auth_token.user_id
-            if user_id is None:
-                raise ValueError("Agent token has no user principal")
-        except (PyJWTError, KeyError, ValueError, TypeError):
-            raise AuthenticationFailed("Invalid agent token")
+        except (PyJWTError, KeyError, ValueError, TypeError) as exc:
+            fail("decode_failed", error_type=type(exc).__name__)
+
+        if user_id is None:
+            fail("no_user_principal", org_id=auth_token.organization_id)
 
         # The delegating user must still be valid even though they are not the request user.
         user = user_service.get_user(user_id=user_id)
-        if user is None or not user.is_active or getattr(user, "is_suspended", False):
-            raise AuthenticationFailed("Invalid agent token")
+        if user is None:
+            fail("user_not_found", user_id=user_id)
+        if not user.is_active:
+            fail("user_inactive", user_id=user_id)
+        if getattr(user, "is_suspended", False):
+            fail("user_suspended", user_id=user_id)
 
         org_context = organization_service.get_organization_by_id(
             id=auth_token.organization_id,
@@ -648,13 +673,15 @@ class AgentTokenAuthentication(StandardAuthentication):
             include_projects=False,
             include_teams=False,
         )
-        if org_context is None or not features.has(
+        if org_context is None:
+            fail("org_context_missing", user_id=user_id, org_id=auth_token.organization_id)
+        if not features.has(
             agent_token.FEATURE_FLAG,
             org_context.organization,
             actor=user,
             skip_experiment_exposure=True,
         ):
-            raise AuthenticationFailed("Invalid agent token")
+            fail("feature_flag_off", user_id=user_id, org_id=auth_token.organization_id)
 
         return self.transform_auth(None, auth_token)
 

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -46,6 +46,7 @@ from sentry.hybridcloud.apigateway.cell_request_resolvers import CellRequestReso
 from sentry.middleware import is_frontend_request
 from sentry.organizations.absolute_url import generate_organization_url
 from sentry.ratelimits.config import DEFAULT_RATE_LIMIT_CONFIG, RateLimitConfig
+from sentry.seer import agent_token
 from sentry.silo.base import SiloLimit, SiloMode
 from sentry.snuba.query_sources import QuerySource
 from sentry.utils.audit import create_audit_entry
@@ -280,6 +281,38 @@ class Endpoint(APIView):
         the appropriate exception according to parent DRF function.
         """
         required_scopes = getattr(request, INSUFFICIENT_SCOPE_ATTR, None)
+
+        # TODO(jstanley): Temporary logging to explain agent-token 401s. A denial becomes a
+        # 403 insufficient_scope challenge only when required_scopes is set; otherwise DRF
+        # downgrades it to a bare 401 whenever no authenticator claimed the request. Since
+        # the write-approval flow keys on the 403, the downgrade silently forecloses it.
+        # Remove once the auth issue is resolved.
+        #
+        # Scoped to agent-authenticated requests, and free of request-derived strings.
+        # Every permission denial in the product passes through here, so logging them all
+        # would put a line carrying the org and project slugs -- `request.path` -- on
+        # ordinary customer traffic, for a question only agent tokens raise. The endpoint
+        # class names the route without naming the customer.
+        auth = getattr(request, "auth", None)
+        if agent_token.is_agent_auth(auth):
+            logger.warning(
+                "api.permission_denied",
+                extra={
+                    "endpoint": type(self).__name__,
+                    "method": request.method,
+                    "required_scopes": sorted(required_scopes) if required_scopes else None,
+                    "auth_kind": getattr(auth, "kind", None),
+                    "auth_scopes": sorted(getattr(auth, "scopes", None) or []),
+                    "successful_authenticator": (
+                        type(request.successful_authenticator).__name__
+                        if request.successful_authenticator
+                        else None
+                    ),
+                    "user_authenticated": request.user.is_authenticated,
+                    "permission_classes": [type(p).__name__ for p in self.get_permissions()],
+                },
+            )
+
         if required_scopes:
             # A token was denied for insufficient scope; surface the RFC 6750 challenge.
             raise InsufficientScope(required_scopes)


### PR DESCRIPTION
Every rejection path in `AgentTokenAuthentication` raises the same opaque
`AuthenticationFailed`, and a permission denial that sets no insufficient-scope
attribute is downgraded by DRF to a bare 401. A rejected credential is therefore
indistinguishable from no credential, and both look identical to the caller.

Seven distinct causes — a failed decode, a missing or inactive delegating user,
an unresolvable org context, the feature flag being off — all surface as one
`Unauthorized:` line with no body. Diagnosing a Code Mode 401 currently means
guessing between them.

Logs the specific reason at each rejection, and logs what `permission_denied` is
about to raise. Behavior is unchanged: same exceptions, same status codes, same
response bodies.

**Nothing request-derived is recorded.** `request.path` carries the org and
project slugs, and a JWT library's message can quote the token it failed on, so
neither is logged — the exception's class name plus the numeric user and org ids
identify which of the seven rejections fired without describing the customer.

The permission log is additionally scoped to agent-authenticated requests. Every
denial in the product passes through that method, so logging unconditionally
would add a line to ordinary customer traffic for a question only agent tokens
raise; as written, non-agent requests produce no new lines at all.

Mirrors the `viewer_context_auth.failed` block a few lines below, which was added
for the same problem on the viewer-context path. Marked temporary with a removal
TODO, matching that precedent.

Note the auth log fires from both the middleware authentication pass and the DRF
one, so a single rejected request produces two identical lines rather than two
failures.