### PR TITLE
feat(seer): Enable Code Mode as the only tool surface for flagged orgs

### DIFF
--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -585,6 +585,27 @@ class SeerAgentClient:
             flush=flush,
         )
 
+    def _embed_widgets_enabled(self) -> bool:
+        """Whether to tell the agent it may emit embed widgets.
+
+        Code Mode ships the embed surface itself, so a run using it renders the same
+        widgets whether or not the org holds the embeds flag. Gating on the flag alone
+        would leave those runs emitting plain text where the rest of the product shows a
+        widget — a difference the user sees but cannot explain.
+
+        Widening this changes only what the agent is told it may emit: rendering is not
+        flag-gated on the frontend, and per-widget flags still apply in
+        ``get_embed_widgets``. ``enable_embeds`` remains the hard opt-out for surfaces
+        that cannot render Markdoc, such as Slack.
+        """
+        if not self.enable_embeds:
+            return False
+        if self.enable_code_mode_tools != "off":
+            return True
+        return features.has(
+            "organizations:seer-explorer-embeds", self.organization, actor=self.user
+        )
+
     def _build_agent_run_options(self, *, override_ce_enable: bool = True) -> dict[str, Any]:
         """Resolve org-flag-driven agent run options, shared by start_run and start_feature_run."""
         opts: dict[str, Any] = {}
@@ -621,11 +642,7 @@ class SeerAgentClient:
         ):
             opts["enable_tool_summary"] = True
 
-        if self.enable_embeds and features.has(
-            "organizations:seer-explorer-embeds",
-            self.organization,
-            actor=self.user,
-        ):
+        if self._embed_widgets_enabled():
             opts["embed_widgets"] = get_embed_widgets(self.organization, self.user)
 
         if features.has(
@@ -764,11 +781,7 @@ class SeerAgentClient:
         ):
             agent_run_options["enable_tool_summary"] = True
 
-        if self.enable_embeds and features.has(
-            "organizations:seer-explorer-embeds",
-            self.organization,
-            actor=self.user,
-        ):
+        if self._embed_widgets_enabled():
             agent_run_options["embed_widgets"] = get_embed_widgets(self.organization, self.user)
 
         if features.has(

--- a/src/sentry/seer/endpoints/organization_seer_agent_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_agent_chat.py
@@ -292,7 +292,11 @@ class OrganizationSeerAgentChatEndpoint(OrganizationEndpoint):
             elif override_code_mode_enable is not None:
                 enable_code_mode_tools = override_code_mode_enable
             else:
-                enable_code_mode_tools = "on"
+                # "only" rather than "on": running Code Mode alongside the classic tools
+                # gives the agent two ways to do everything and it mixes them, so the
+                # surface being dogfooded is never the one that ships. The frontend
+                # override still selects either mode for comparison.
+                enable_code_mode_tools = "only"
 
             client = SeerAgentClient(
                 organization,

--- a/tests/sentry/seer/agent/test_agent_client.py
+++ b/tests/sentry/seer/agent/test_agent_client.py
@@ -300,6 +300,64 @@ class TestSeerAgentClient(TestCase):
         assert "embed_widgets" not in body["agent_run_options"]
 
     @patch("sentry.seer.agent.client.has_seer_access_with_detail")
+    @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
+    @patch("sentry.seer.agent.client.collect_user_org_context")
+    def test_code_mode_grants_embed_widgets_without_the_embeds_flag(
+        self, mock_collect_context, mock_post, mock_access
+    ):
+        """Code Mode ships the embed surface, so a run using it renders widgets whether
+        or not the org holds the embeds flag. Gating on the flag alone would leave those
+        runs emitting plain text where the rest of the product shows a widget."""
+        mock_access.return_value = (True, None)
+        mock_collect_context.return_value = {"user_id": self.user.id}
+        mock_post.return_value = self._mock_run_response()
+
+        client = SeerAgentClient(self.organization, self.user, enable_code_mode_tools="only")
+        client.start_run("Test query")
+
+        body = mock_post.call_args[0][0]
+        assert "embed_widgets" in body["agent_run_options"]
+
+    @patch("sentry.seer.agent.client.has_seer_access_with_detail")
+    @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
+    @patch("sentry.seer.agent.client.collect_user_org_context")
+    def test_no_embed_widgets_without_code_mode_or_the_flag(
+        self, mock_collect_context, mock_post, mock_access
+    ):
+        mock_access.return_value = (True, None)
+        mock_collect_context.return_value = {"user_id": self.user.id}
+        mock_post.return_value = self._mock_run_response()
+
+        client = SeerAgentClient(self.organization, self.user, enable_code_mode_tools="off")
+        client.start_run("Test query")
+
+        body = mock_post.call_args[0][0]
+        assert "embed_widgets" not in body["agent_run_options"]
+
+    @patch("sentry.seer.agent.client.has_seer_access_with_detail")
+    @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
+    @patch("sentry.seer.agent.client.collect_user_org_context")
+    def test_enable_embeds_false_still_wins_over_code_mode(
+        self, mock_collect_context, mock_post, mock_access
+    ):
+        """`enable_embeds=False` is the hard opt-out for surfaces that cannot render
+        Markdoc, such as Slack, where the tags would leak as raw text."""
+        mock_access.return_value = (True, None)
+        mock_collect_context.return_value = {"user_id": self.user.id}
+        mock_post.return_value = self._mock_run_response()
+
+        client = SeerAgentClient(
+            self.organization,
+            self.user,
+            enable_code_mode_tools="only",
+            enable_embeds=False,
+        )
+        client.start_run("Test query")
+
+        body = mock_post.call_args[0][0]
+        assert "embed_widgets" not in body["agent_run_options"]
+
+    @patch("sentry.seer.agent.client.has_seer_access_with_detail")
     @patch("sentry.seer.agent.client.make_agent_chat_request")
     @with_feature("organizations:seer-explorer-embeds")
     def test_continue_run_includes_embed_widgets_by_default(self, mock_post, mock_access):

--- a/tests/sentry/seer/endpoints/test_organization_seer_agent_chat.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_agent_chat.py
@@ -102,6 +102,49 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
 
         assert response.status_code == 400
 
+    @with_feature("organizations:seer-explorer-code-mode-tools")
+    @patch("sentry.seer.endpoints.organization_seer_agent_chat.SeerAgentClient")
+    def test_code_mode_feature_selects_only(self, mock_client_class: MagicMock):
+        """The flag means Code Mode instead of the classic tools, not alongside them.
+
+        Running both gives the agent two ways to do everything and it mixes them, so the
+        surface being dogfooded is never the one that ships.
+        """
+        mock_client = MagicMock()
+        mock_client.start_run.return_value = MagicMock(seer_run_state_id=456, uuid=uuid.uuid4())
+        mock_client_class.return_value = mock_client
+
+        response = self.client.post(self.url, {"query": "hi"}, format="json")
+
+        assert response.status_code == 200
+        assert mock_client_class.call_args.kwargs["enable_code_mode_tools"] == "only"
+
+    @with_feature("organizations:seer-explorer-code-mode-tools")
+    @patch("sentry.seer.endpoints.organization_seer_agent_chat.SeerAgentClient")
+    def test_frontend_override_still_selects_the_mode(self, mock_client_class: MagicMock):
+        """The override is how the two surfaces get compared, so it outranks the flag."""
+        mock_client = MagicMock()
+        mock_client.start_run.return_value = MagicMock(seer_run_state_id=456, uuid=uuid.uuid4())
+        mock_client_class.return_value = mock_client
+
+        response = self.client.post(
+            self.url, {"query": "hi", "override_code_mode_enable": "on"}, format="json"
+        )
+
+        assert response.status_code == 200
+        assert mock_client_class.call_args.kwargs["enable_code_mode_tools"] == "on"
+
+    @patch("sentry.seer.endpoints.organization_seer_agent_chat.SeerAgentClient")
+    def test_no_code_mode_feature_stays_off(self, mock_client_class: MagicMock):
+        mock_client = MagicMock()
+        mock_client.start_run.return_value = MagicMock(seer_run_state_id=456, uuid=uuid.uuid4())
+        mock_client_class.return_value = mock_client
+
+        response = self.client.post(self.url, {"query": "hi"}, format="json")
+
+        assert response.status_code == 200
+        assert mock_client_class.call_args.kwargs["enable_code_mode_tools"] == "off"
+
     @patch("sentry.seer.endpoints.organization_seer_agent_chat.SeerAgentClient")
     def test_post_new_conversation_calls_client(self, mock_client_class: MagicMock):
         run_uuid = uuid.uuid4()


### PR DESCRIPTION
Turns Code Mode on properly for the team, in two parts.

**Code Mode becomes the whole surface, not an addition.** The
`seer-explorer-code-mode-tools` branch selected `"on"`, which mounts Code Mode
*alongside* the classic tools. The agent then has two ways to do everything and
mixes them, so the surface being dogfooded is never the one that would ship and
a gap in Code Mode is silently papered over by a classic tool. `"only"` is what
we actually want to be exercising. Orgs without the flag are untouched, and the
frontend override still selects either mode so the two can be compared directly.

**Embeds follow Code Mode.** `embed_widgets` was gated on
`seer-explorer-embeds` alone, so a Code Mode run in an org without that flag
emitted plain text where the rest of the product renders a widget — a difference
the user sees and cannot explain. Code Mode ships the embed surface itself, so
the check now passes if either holds.

That widening is narrower than it reads: nothing on the frontend gates rendering
on `seer-explorer-embeds` (it has no references in `static/`), per-widget flags
still apply in `get_embed_widgets`, and `enable_embeds=False` remains the hard
opt-out for surfaces that cannot render Markdoc — Slack still passes it, so tags
will not leak there.

Both checks moved into one `_embed_widgets_enabled` helper rather than being
duplicated at the two call sites in `client.py`.

**Sequencing worth knowing:** `"only"` is the mode that triggers context-pack
hydration in Seer, and hydration currently drops page context from the first
user message (getsentry/seer#7680). Landing this before that fix would give
every flagged org the "Code Mode can't see the page I'm on" symptom, so #7680
should go out first.

cc @natemoo-re