### PR TITLE
fix(seer): Default the Code Mode override to only

### DIFF
--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -153,7 +153,11 @@ export const useSeerExplorer = () => {
         if (storedValue === false) {
           return 'off';
         }
-        return 'on'; // default
+        // Matches the server's own default for a flagged org. This value is sent on every
+        // request, so it is not really an override until someone picks one — leaving it at
+        // 'on' meant the server's default branch could never be reached from the UI, and
+        // flagged orgs kept getting Code Mode alongside the classic tools.
+        return 'only';
       }
     );
   const [overrideBashModeEnabled, setOverrideBashModeEnabled] = useLocalStorageState(


### PR DESCRIPTION
The Explorer hook seeds `override_code_mode_enable` from local storage with
`'on'` and sends it on every request, so a user who has never touched the toggle
still looks to the server like they explicitly picked a mode.

That makes the server's own default unreachable from the UI. The endpoint reads:

```python
if not has_code_mode_feature:      enable_code_mode_tools = "off"
elif override_code_mode_enable is not None:  enable_code_mode_tools = override_...
else:                              enable_code_mode_tools = "only"
```

The middle branch always wins for Explorer traffic, so flagged orgs keep getting
Code Mode *alongside* the classic tools — the mixing that getsentry/sentry#121585
set out to stop. Without this, that change is a no-op for the UI.

Seeds the value the server would have chosen instead. Picking a mode explicitly
still works and still wins; the toggle is unchanged.

Note this only affects users with nothing stored yet. Anyone who already has
`'on'` in local storage — which until now was everyone who had opened the
Explorer — keeps it until they choose otherwise. Forcing a stored value would
override a real choice for the people who did make one, so it is left alone;
happy to migrate it instead if we would rather the rollout be immediate.

Frontend half of getsentry/sentry#121585, split per the frontend/backend rule.
Safe in either order: alone it just sends `'only'` where the server already
resolves flagged orgs to Code Mode.

cc @natemoo-re