### PR TITLE
fix(code-mappings): Decode path mapping url before validation

### DIFF
--- a/src/sentry/api/endpoints/project_repo_path_parsing.py
+++ b/src/sentry/api/endpoints/project_repo_path_parsing.py
@@ -1,6 +1,6 @@
 from pathlib import PurePath, PureWindowsPath
 from typing import Any, TypedDict
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse, urlunparse
 
 from drf_spectacular.utils import extend_schema
 from rest_framework import serializers, status
@@ -44,6 +44,20 @@ class RepoPathParsingResponse(TypedDict):
     defaultBranch: str
 
 
+def unquote_source_url_path(source_url: str) -> str:
+    """
+    Percent-decode the path of a source code URL.
+
+    Providers percent-encode characters that are legal in a file name but
+    reserved in a URL, so the URL a user copies from their browser does not
+    match the raw stack trace path (e.g. `+page.svelte` appears as
+    `%2Bpage.svelte`). Only the path is decoded; the query string is left
+    untouched since providers use it for real parameters (branch, line number).
+    """
+    parsed = urlparse(source_url)
+    return urlunparse(parsed._replace(path=unquote(parsed.path)))
+
+
 class PathMappingSerializer(CamelSnakeSerializer[dict[str, str]]):
     stack_path = serializers.CharField(
         help_text="A file path as it appears in a stack trace frame."
@@ -68,6 +82,10 @@ class PathMappingSerializer(CamelSnakeSerializer[dict[str, str]]):
         return self.context["organization_id"]
 
     def validate_source_url(self, source_url: str) -> str:
+        # URLs copied from a provider's UI are percent-encoded, but stack trace
+        # paths are not, so decode before comparing or extracting paths
+        source_url = unquote_source_url_path(source_url)
+
         # first check to see if we are even looking at the same file
         stack_path = self.initial_data["stack_path"]
 

--- a/src/sentry/api/endpoints/project_repo_path_parsing.py
+++ b/src/sentry/api/endpoints/project_repo_path_parsing.py
@@ -45,15 +45,6 @@ class RepoPathParsingResponse(TypedDict):
 
 
 def unquote_source_url_path(source_url: str) -> str:
-    """
-    Percent-decode the path of a source code URL.
-
-    Providers percent-encode characters that are legal in a file name but
-    reserved in a URL, so the URL a user copies from their browser does not
-    match the raw stack trace path (e.g. `+page.svelte` appears as
-    `%2Bpage.svelte`). Only the path is decoded; the query string is left
-    untouched since providers use it for real parameters (branch, line number).
-    """
     parsed = urlparse(source_url)
     return urlunparse(parsed._replace(path=unquote(parsed.path)))
 
@@ -82,7 +73,7 @@ class PathMappingSerializer(CamelSnakeSerializer[dict[str, str]]):
         return self.context["organization_id"]
 
     def validate_source_url(self, source_url: str) -> str:
-        # URLs copied from a provider's UI are percent-encoded, but stack trace
+        # URLs copied from a provider's UI can be percent-encoded, but stack trace
         # paths are not, so decode before comparing or extracting paths
         source_url = unquote_source_url_path(source_url)
 

--- a/tests/sentry/api/endpoints/test_project_repo_path_parsing.py
+++ b/tests/sentry/api/endpoints/test_project_repo_path_parsing.py
@@ -249,6 +249,23 @@ class ProjectStacktraceLinkGithubTest(BaseStacktraceLinkTest):
             "defaultBranch": "master",
         }
 
+    def test_percent_encoded_source_url(self) -> None:
+        # URLs copied from GitHub encode characters that are legal in a filename,
+        # e.g. the leading `+` of a SvelteKit route file
+        source_url = "https://github.com/getsentry/sentry/blob/master/src/routes/%2Bpage.svelte"
+        stack_path = "routes/+page.svelte"
+        resp = self.make_post(source_url, stack_path)
+        assert resp.status_code == 200, resp.content
+
+        assert resp.data == {
+            "integrationId": self.integration.id,
+            "repositoryId": self.repo.id,
+            "provider": "github",
+            "stackRoot": "routes/",
+            "sourceRoot": "src/routes/",
+            "defaultBranch": "master",
+        }
+
     def test_java_path(self) -> None:
         src_file = "src/com/example/foo/Bar.kt"
         source_url = f"https://github.com/getsentry/sentry/blob/master/{src_file}"


### PR DESCRIPTION
Noticed while adding a code mapping for a `+page.svelte` file in my side project that we don't seem to handle encoded characters in the URL users can provide in the code mapping modal on the issue details page.

Instead of applying the mapping, the "Source code URL points to a different file than the stack trace" error was returned.

This PR adds unquoting to the passed URL so that this class of URLs can successfully be code-mapped.