### PR TITLE
ref: Remove latest tier check

### DIFF
--- a/static/gsAdmin/components/trialSubscriptionAction.spec.tsx
+++ b/static/gsAdmin/components/trialSubscriptionAction.spec.tsx
@@ -72,54 +72,6 @@ describe('TrialSubscriptionAction', () => {
     });
   });
 
-  it('can pass startTrialOnLatestTier for an enterprise trial', async () => {
-    jest.mock('@sentry/scraps/alert');
-
-    openAdminConfirmModal({
-      onConfirm,
-      renderModalSpecificContent: deps => (
-        <TrialSubscriptionAction
-          subscription={SubscriptionFixture({
-            organization,
-            plan: 'mm2_f',
-            isFree: true,
-          })}
-          startEnterpriseTrial
-          {...deps}
-        />
-      ),
-    });
-
-    renderGlobalModal();
-
-    await userEvent.click(screen.getByRole('checkbox', {name: 'Trial the latest tier'}));
-    await confirmTrialDays('45');
-
-    expect(onConfirm).toHaveBeenCalledWith({
-      trialDays: 45,
-      startEnterpriseTrial: true,
-      startTrialOnLatestTier: true,
-    });
-  });
-
-  it('does not show the latest tier checkbox for a regular trial', () => {
-    openAdminConfirmModal({
-      onConfirm,
-      renderModalSpecificContent: deps => (
-        <TrialSubscriptionAction
-          subscription={SubscriptionFixture({organization})}
-          {...deps}
-        />
-      ),
-    });
-
-    renderGlobalModal();
-
-    expect(
-      screen.queryByRole('checkbox', {name: 'Trial the latest tier'})
-    ).not.toBeInTheDocument();
-  });
-
   it('can pass trialDays and extend enterprise plan onConfirm', async () => {
     jest.mock('@sentry/scraps/alert');
 

--- a/static/gsAdmin/components/trialSubscriptionAction.tsx
+++ b/static/gsAdmin/components/trialSubscriptionAction.tsx
@@ -3,7 +3,6 @@ import moment from 'moment-timezone';
 
 import {Alert} from '@sentry/scraps/alert';
 
-import {BooleanField} from 'sentry/components/forms/fields/booleanField';
 import {NumberField} from 'sentry/components/forms/fields/numberField';
 
 import type {
@@ -19,7 +18,6 @@ type Props = AdminConfirmRenderProps & {
 };
 
 type State = {
-  startTrialOnLatestTier: boolean;
   trialDays: number;
 };
 
@@ -32,7 +30,6 @@ export class TrialSubscriptionAction extends Component<Props, State> {
       this.props.subscription.isEnterpriseTrial || this.props.startEnterpriseTrial
         ? 28
         : 14,
-    startTrialOnLatestTier: false,
   };
 
   componentDidMount() {
@@ -40,19 +37,17 @@ export class TrialSubscriptionAction extends Component<Props, State> {
   }
 
   handleConfirm = (_params: AdminConfirmParams) => {
-    const {trialDays, startTrialOnLatestTier} = this.state;
+    const {trialDays} = this.state;
     const {startEnterpriseTrial, onConfirm} = this.props;
 
     // XXX(epurkhiser): In the original implementation none of the audit params
     // were passed, is that an oversight?
     //
-    // The trial tier is resolved server-side (omitting `trialTier` falls back
-    // to the subscription's default enterprise-trial plan). Passing
-    // `startTrialOnLatestTier` instead opts into the latest available tier.
+    // The trial plan is resolved server-side: new enterprise trials always
+    // start on the latest tier.
     const data = {
       trialDays,
       ...(startEnterpriseTrial && {startEnterpriseTrial}),
-      ...(startEnterpriseTrial && startTrialOnLatestTier && {startTrialOnLatestTier}),
     };
 
     onConfirm?.(data);
@@ -75,7 +70,7 @@ export class TrialSubscriptionAction extends Component<Props, State> {
 
   render() {
     const {subscription, startEnterpriseTrial} = this.props;
-    const {trialDays, startTrialOnLatestTier} = this.state;
+    const {trialDays} = this.state;
 
     if (!subscription) {
       return null;
@@ -109,18 +104,6 @@ export class TrialSubscriptionAction extends Component<Props, State> {
           value={trialDays}
           onChange={this.onDaysChange}
         />
-        {startEnterpriseTrial && (
-          <BooleanField
-            inline={false}
-            stacked
-            flexibleControlStateSize
-            label="Trial the latest tier"
-            help="Start the trial on the latest available tier instead of the tier that matches their current plan."
-            name="startTrialOnLatestTier"
-            value={startTrialOnLatestTier}
-            onChange={(value: boolean) => this.setState({startTrialOnLatestTier: value})}
-          />
-        )}
       </Fragment>
     );
   }


### PR DESCRIPTION
Remove param for using a legacy enterprise trial, we'll only support the latest trial plan for now