### PR TITLE
feat(hybridcloud): Tag webhook backlog depth by event type

### DIFF
--- a/src/sentry/hybridcloud/tasks/webhook_backlog_metrics.py
+++ b/src/sentry/hybridcloud/tasks/webhook_backlog_metrics.py
@@ -9,6 +9,8 @@ from django.db.models import Count, Min
 from django.utils import timezone
 
 from sentry.hybridcloud.models.webhookpayload import WebhookPayload
+from sentry.integrations.github.webhook_types import CELL_PROCESSED_GITHUB_EVENTS
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import hybridcloud_control_tasks
@@ -36,6 +38,32 @@ the one that could turn this monitor into a second incident. Bounding it means a
 pathological table loses the per-provider breakdown rather than pinning a control
 replica; the far cheaper `backlog.*` signals still report.
 """
+
+_EVENT_TYPED_MAILBOX_PROVIDERS = frozenset(
+    {IntegrationProviderSlug.GITHUB.value, IntegrationProviderSlug.GITHUB_ENTERPRISE.value}
+)
+"""Providers whose parser appends the event type to the mailbox name."""
+
+NO_EVENT_TYPE = "none"
+"""The provider doesn't mailbox by event type — not a parse failure."""
+
+UNKNOWN_EVENT_TYPE = "unknown"
+"""The provider does, but this mailbox carries no event type to read."""
+
+
+def _event_type_from_mailbox(provider: str, mailbox_name: str) -> str:
+    """
+    Recover the event type a mailbox holds, for the providers that encode one.
+
+    A delivery with no `X-GitHub-Event` header mailboxes without the suffix, leaving a
+    bucket number where this reads, so only known event names are trusted. Gated on the
+    provider column rather than the mailbox prefix, so legacy rows predating that column
+    report `none` even when they are GitHub mailboxes.
+    """
+    if provider not in _EVENT_TYPED_MAILBOX_PROVIDERS:
+        return NO_EVENT_TYPE
+    suffix = mailbox_name.rpartition(":")[2]
+    return suffix if suffix in CELL_PROCESSED_GITHUB_EVENTS else UNKNOWN_EVENT_TYPE
 
 
 @contextmanager
@@ -140,6 +168,11 @@ def record_mailbox_depth_metrics() -> None:
     behind it while the totals still look healthy — `max_depth` is what makes that
     visible. Establishing it means aggregating every row, so this runs on a slower
     schedule than `record_webhook_backlog_metrics` and under a statement timeout.
+
+    `pending_count` is additionally tagged by `event_type`, which says what the backlog
+    is made of and joins to `github.webhook.forwarded_event`; summing over the tag
+    reproduces the provider-only value. Only that metric — the rest read fine per
+    provider, and every tag value costs a series per worker that runs the task.
     """
     replica = WebhookPayload.objects.using_replica()
     mailboxes = replica.values("provider", "mailbox_name").annotate(
@@ -155,7 +188,7 @@ def record_mailbox_depth_metrics() -> None:
         return
 
     now = timezone.now()
-    pending: dict[str, int] = defaultdict(int)
+    pending: dict[tuple[str, str], int] = defaultdict(int)
     mailbox_count: dict[str, int] = defaultdict(int)
     max_depth: dict[str, int] = defaultdict(int)
     oldest: dict[str, datetime.datetime] = {}
@@ -163,22 +196,25 @@ def record_mailbox_depth_metrics() -> None:
         # The column is nullable, and rows predating it still drain through here.
         provider = row["provider"] or "unknown"
         depth, row_oldest = row["depth"], row["oldest"]
-        pending[provider] += depth
+        event_type = _event_type_from_mailbox(provider, row["mailbox_name"])
+        pending[(provider, event_type)] += depth
         mailbox_count[provider] += 1
         max_depth[provider] = max(max_depth[provider], depth)
         oldest[provider] = min(oldest.get(provider, row_oldest), row_oldest)
 
-    for provider, pending_count in pending.items():
-        tags = {"provider": provider}
+    for (provider, event_type), pending_count in pending.items():
         metrics.gauge(
             "hybridcloud.webhookpayload.mailbox.pending_count",
             pending_count,
-            tags=tags,
+            tags={"provider": provider, "event_type": event_type},
             sample_rate=1.0,
         )
+
+    for provider, active_count in mailbox_count.items():
+        tags = {"provider": provider}
         metrics.gauge(
             "hybridcloud.webhookpayload.mailbox.active_count",
-            mailbox_count[provider],
+            active_count,
             tags=tags,
             sample_rate=1.0,
         )

--- a/tests/sentry/hybridcloud/tasks/test_webhook_backlog_metrics.py
+++ b/tests/sentry/hybridcloud/tasks/test_webhook_backlog_metrics.py
@@ -170,16 +170,18 @@ class WebhookBacklogMetricsTest(TestCase):
 class MailboxDepthMetricsTest(TestCase):
     @patch("sentry.hybridcloud.tasks.webhook_backlog_metrics.metrics")
     def test_depth_is_grouped_by_provider(self, mock_metrics: MagicMock) -> None:
-        create_payloads(3, "github:123", provider="github")
-        create_payloads(1, "github:456", provider="github")
+        create_payloads(3, "github:123:push", provider="github")
+        create_payloads(1, "github:456:push", provider="github")
         create_payloads(2, "gitlab:789", provider="gitlab")
 
         record_mailbox_depth_metrics()
 
         assert sorted(gauge_calls(mock_metrics, MAILBOX_PENDING_METRIC)) == [
-            (2, {"provider": "gitlab"}),
-            (4, {"provider": "github"}),
+            (2, {"provider": "gitlab", "event_type": "none"}),
+            (4, {"provider": "github", "event_type": "push"}),
         ]
+        # Only pending_count carries event_type; the rest would cost a series per
+        # event type per control worker to say something they already say.
         assert sorted(gauge_calls(mock_metrics, MAILBOX_ACTIVE_METRIC)) == [
             (1, {"provider": "gitlab"}),
             (2, {"provider": "github"}),
@@ -196,17 +198,77 @@ class MailboxDepthMetricsTest(TestCase):
 
         record_mailbox_depth_metrics()
 
-        assert gauge_calls(mock_metrics, MAILBOX_PENDING_METRIC) == [(1, {"provider": "unknown"})]
+        # No event type either: the provider column is the only thing that says whether
+        # the mailbox name encodes one, and these legacy rows have none.
+        assert gauge_calls(mock_metrics, MAILBOX_PENDING_METRIC) == [
+            (1, {"provider": "unknown", "event_type": "none"})
+        ]
 
     @patch("sentry.hybridcloud.tasks.webhook_backlog_metrics.metrics")
-    def test_bucketed_mailboxes_roll_up_to_one_provider(self, mock_metrics: MagicMock) -> None:
+    def test_bucketed_mailboxes_roll_up_within_an_event_type(self, mock_metrics: MagicMock) -> None:
         create_payloads(2, "github:123:7:pull_request", provider="github")
-        create_payloads(1, "github:123:8:push", provider="github")
+        create_payloads(1, "github:123:8:pull_request", provider="github")
 
         record_mailbox_depth_metrics()
 
-        assert gauge_calls(mock_metrics, MAILBOX_PENDING_METRIC) == [(3, {"provider": "github"})]
+        # Repository buckets are an implementation detail of parallel delivery, so they
+        # collapse; the event type they carry does not.
+        assert gauge_calls(mock_metrics, MAILBOX_PENDING_METRIC) == [
+            (3, {"provider": "github", "event_type": "pull_request"})
+        ]
         assert gauge_calls(mock_metrics, MAILBOX_ACTIVE_METRIC) == [(2, {"provider": "github"})]
+
+    @patch("sentry.hybridcloud.tasks.webhook_backlog_metrics.metrics")
+    def test_event_types_are_reported_separately(self, mock_metrics: MagicMock) -> None:
+        create_payloads(3, "github:123:7:check_run", provider="github")
+        create_payloads(1, "github:123:7:push", provider="github")
+
+        record_mailbox_depth_metrics()
+
+        # The point of the dimension: one event type dominating the backlog is exactly
+        # what the provider-only rollup hid, and what `github.webhook.forwarded_event`
+        # is joined against to size a parser-side drop.
+        assert sorted(gauge_calls(mock_metrics, MAILBOX_PENDING_METRIC)) == [
+            (1, {"provider": "github", "event_type": "push"}),
+            (3, {"provider": "github", "event_type": "check_run"}),
+        ]
+
+    @patch("sentry.hybridcloud.tasks.webhook_backlog_metrics.metrics")
+    def test_github_enterprise_mailboxes_carry_an_event_type(self, mock_metrics: MagicMock) -> None:
+        # GithubEnterpriseRequestParser inherits get_mailbox_identifier, so its mailbox
+        # names have the same shape.
+        create_payloads(1, "github_enterprise:123:7:push", provider="github_enterprise")
+
+        record_mailbox_depth_metrics()
+
+        assert gauge_calls(mock_metrics, MAILBOX_PENDING_METRIC) == [
+            (1, {"provider": "github_enterprise", "event_type": "push"})
+        ]
+
+    @patch("sentry.hybridcloud.tasks.webhook_backlog_metrics.metrics")
+    def test_unparseable_event_type_is_bounded(self, mock_metrics: MagicMock) -> None:
+        # A delivery with no X-GitHub-Event header mailboxes without an event suffix,
+        # leaving a bucket number where this reads. Tagging that verbatim would put an
+        # unbounded id into the tag, so anything that isn't a known event is "unknown".
+        create_payloads(1, "github:123:7", provider="github")
+
+        record_mailbox_depth_metrics()
+
+        assert gauge_calls(mock_metrics, MAILBOX_PENDING_METRIC) == [
+            (1, {"provider": "github", "event_type": "unknown"})
+        ]
+
+    @patch("sentry.hybridcloud.tasks.webhook_backlog_metrics.metrics")
+    def test_control_only_event_names_are_not_trusted(self, mock_metrics: MagicMock) -> None:
+        # Installation events are answered in control and never reach a cell mailbox, so
+        # a mailbox claiming to hold them is not a name this task should report back.
+        create_payloads(1, "github:123:7:installation", provider="github")
+
+        record_mailbox_depth_metrics()
+
+        assert gauge_calls(mock_metrics, MAILBOX_PENDING_METRIC) == [
+            (1, {"provider": "github", "event_type": "unknown"})
+        ]
 
     @patch("sentry.hybridcloud.tasks.webhook_backlog_metrics.metrics")
     def test_oldest_age_is_per_provider(self, mock_metrics: MagicMock) -> None:
@@ -236,6 +298,20 @@ class MailboxDepthMetricsTest(TestCase):
         }
         assert ages["github"] == pytest.approx(timedelta(hours=2).total_seconds(), abs=60)
         assert ages["gitlab"] == pytest.approx(timedelta(minutes=5).total_seconds(), abs=60)
+
+    @patch("sentry.hybridcloud.tasks.webhook_backlog_metrics.metrics")
+    def test_only_pending_count_is_tagged_by_event_type(self, mock_metrics: MagicMock) -> None:
+        # Each event_type value costs a series per control worker on every metric that
+        # carries it, so the dimension is confined to the one metric that needs it.
+        create_payloads(1, "github:123:7:check_run", provider="github")
+        create_payloads(1, "github:123:7:push", provider="github")
+
+        record_mailbox_depth_metrics()
+
+        for metric in (MAILBOX_ACTIVE_METRIC, MAILBOX_MAX_DEPTH_METRIC, MAILBOX_AGE_METRIC):
+            assert [tags for _, tags in gauge_calls(mock_metrics, metric)] == [
+                {"provider": "github"}
+            ], metric
 
     def test_aggregate_runs_under_a_statement_timeout(self) -> None:
         create_payloads(1, "github:123", provider="github")


### PR DESCRIPTION
## Problem

The mailbox gauges from #121506 report the backlog per provider — who sent the queued webhooks, not what they are. Sizing a parser-side drop needs the latter.

#121434 dropped 13.6M unconsumed `check_suite` deliveries a day. The follow-up it names — dropping `check_run.completed` payloads that reference no pull request based in their own repo, the largest remaining line at 12.1M/day — has an inflow number (`github.webhook.forwarded_event`) and a latency number (`delivery_time_ms{github_event_and_action}`), but nothing that says what is actually *sitting* in the mailboxes. That is the INC-2324/INC-2421 question, and today it is only answerable per provider.

## Changes

`hybridcloud.webhookpayload.mailbox.pending_count` gains an `event_type` tag.

GitHub mailboxes already carry the answer. `GithubRequestParser.get_mailbox_identifier` appends the event type to the mailbox name so deliveries of different types don't queue behind each other (`GithubEnterpriseRequestParser` inherits it), and the aggregate already groups by `mailbox_name`. So this is a re-key of rows that are in memory either way — **no extra query, no change to the statement-timeout envelope**.

Two things the derivation has to get right:

- A delivery that arrives with no `X-GitHub-Event` header mailboxes *without* the suffix, leaving a bucket number where this reads. Tagging that verbatim would put unbounded ints in a tag, so only names in `CELL_PROCESSED_GITHUB_EVENTS` are trusted; anything else is `unknown`.
- `none` (provider doesn't mailbox by event type) is kept distinct from `unknown` (it does, but this mailbox has none to read). Conflating them would hide the header-less deliveries.

It reads the `provider` column rather than the mailbox prefix, so legacy rows predating that column report `none` even when they are GitHub mailboxes. Those are draining out, and deriving a provider two different ways is worse than under-reporting them.

## Why only `pending_count`

Every emission is host-tagged by the Datadog backend, so each tag value costs a series per worker that runs the task. Tagging all four gauges would take this from `4 × 7 providers` to `4 × 25` combinations; confining it to `pending_count` makes that `3 × 7 + 25`.

The other three read fine per provider:

- `max_depth` — GitHub mailboxes are per-event-type by construction, so this is *already* one event type's mailbox. The tag would only name which one, and `pending_count` names it.
- `active_count` — a routing/fan-out signal, not a composition one.
- `oldest_pending_age_seconds` — a single stalled event type does hide inside the provider-wide age. That is an alerting concern for INC-2421 and a one-line addition if that work wants it; not worth paying for speculatively.

Kept the full 9-event set rather than a hardcoded high-volume subset with an `other` bucket. That would be cheaper, but the list would go stale silently and hide the next `check_suite` — the exact thing this exists to catch. The 9 are bounded and grow only when someone adds a `GithubWebhookType`.

## Compatibility

Summing `pending_count` over `event_type` reproduces the provider-only value, so anything built on the existing series keeps working. No in-repo consumers reference these metric names.
