### PR TITLE
feat(conversations): Return gen_ai.embeddings.input for AI conversation spans

### DIFF
--- a/src/sentry/api/endpoints/organization_ai_conversation_details.py
+++ b/src/sentry/api/endpoints/organization_ai_conversation_details.py
@@ -62,6 +62,7 @@ AI_CONVERSATION_ATTRIBUTES = [
     "gen_ai.tool.input",
     "gen_ai.tool.call.result",
     "gen_ai.tool.output",
+    "gen_ai.embeddings.input",
     "gen_ai.usage.total_tokens",
     "gen_ai.request.model",
     "gen_ai.response.model",

--- a/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
@@ -389,6 +389,35 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         assert span["gen_ai.tool.call.result"] == "found 3 rows"
         assert span["gen_ai.tool.output"] == "tool output payload"
 
+    def test_returns_embeddings_attributes(self) -> None:
+        now = before_now(days=5).replace(microsecond=0)
+        trace_id = uuid4().hex
+        conversation_id = uuid4().hex
+
+        self.store_ai_span(
+            conversation_id=conversation_id,
+            timestamp=now,
+            op="gen_ai.embeddings",
+            operation_type="embeddings",
+            trace_id=trace_id,
+            embeddings_input="search query text",
+        )
+
+        query = {
+            "project": [self.project.id],
+            "start": (now - timedelta(hours=1)).isoformat(),
+            "end": (now + timedelta(hours=1)).isoformat(),
+        }
+
+        response = self.do_request(conversation_id, query)
+        assert response.status_code == 200
+        assert len(response.data["spans"]) == 1
+
+        span = response.data["spans"][0]
+        assert span["span.op"] == "gen_ai.embeddings"
+        assert span["gen_ai.operation.type"] == "embeddings"
+        assert span["gen_ai.embeddings.input"] == "search query text"
+
     def test_stats_period_is_tried_first_then_widened(self) -> None:
         timestamp_15d = before_now(days=15).replace(microsecond=0)
         trace_id = uuid4().hex

--- a/tests/sentry/api/endpoints/test_organization_ai_conversations_base.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversations_base.py
@@ -36,6 +36,7 @@ class BaseAIConversationsTestCase(BaseSpansTestCase, SpanTestCase, APITestCase):
         tool_name=None,
         tool_result=None,
         tool_output=None,
+        embeddings_input=None,
         user_id=None,
         user_email=None,
         user_username=None,
@@ -67,6 +68,7 @@ class BaseAIConversationsTestCase(BaseSpansTestCase, SpanTestCase, APITestCase):
             tool_name: The gen_ai.tool.name attribute
             tool_result: The gen_ai.tool.call.result attribute
             tool_output: The gen_ai.tool.output attribute
+            embeddings_input: The gen_ai.embeddings.input attribute
             user_id: User ID (sentry.user.id)
             user_email: User email (sentry.user.email)
             user_username: User username (sentry.user.username)
@@ -107,6 +109,8 @@ class BaseAIConversationsTestCase(BaseSpansTestCase, SpanTestCase, APITestCase):
             span_data["gen_ai.tool.call.result"] = tool_result
         if tool_output is not None:
             span_data["gen_ai.tool.output"] = tool_output
+        if embeddings_input is not None:
+            span_data["gen_ai.embeddings.input"] = embeddings_input
         # New format attributes
         if input_messages is not None:
             span_data["gen_ai.input.messages"] = json.dumps(input_messages)


### PR DESCRIPTION
The AI conversation details endpoint now returns `gen_ai.embeddings.input` alongside the other span attributes in its bulk span page. Previously the embeddings input text was only reachable through a separate per-span trace-item fetch, so anything rendering the whole conversation at once had no access to it.

This unblocks showing embeddings spans directly in the conversation transcript (the frontend change follows in its own PR); on its own it just widens the returned attribute set, with no change to filtering, pagination, or the response shape.
