### PR TITLE
ref(hybridcloud): Log webhook discards at warning and stop sampling their counters

### DIFF
--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -391,15 +391,20 @@ def _discard_stale_mailbox_payloads(payload: WebhookPayload) -> None:
         ).values("id")[:10000]
         deleted, _ = WebhookPayload.objects.filter(id__in=stale_query).delete()
         if deleted:
-            logger.info(
+            logger.warning(
                 "deliver_webhook_parallel.max_age_discard",
                 extra={
                     **payload.as_dict(),
                     "deleted": deleted,
                 },
             )
+            # Unsampled: `amount` is scaled by 1/sample_rate, so at the default 10% a
+            # sweep is reported as either nothing or ten times what it deleted.
             metrics.incr(
-                "hybridcloud.deliver_webhooks.delivery", amount=deleted, tags={"outcome": "max_age"}
+                "hybridcloud.deliver_webhooks.delivery",
+                amount=deleted,
+                tags={"outcome": "max_age"},
+                sample_rate=1.0,
             )
 
 
@@ -460,11 +465,14 @@ def _handle_parallel_delivery_result(
     if err:
         if payload_record.attempts >= MAX_ATTEMPTS:
             payload_record.delete()
+            # Unsampled: this is the count of webhooks we permanently dropped, so it
+            # wants an exact total rather than an estimated rate.
             metrics.incr(
                 "hybridcloud.deliver_webhooks.delivery",
                 tags={"outcome": "attempts_exceed"},
+                sample_rate=1.0,
             )
-            logger.info(
+            logger.warning(
                 "deliver_webhook_parallel.discard",
                 extra={**payload_data},
             )
@@ -623,8 +631,13 @@ def deliver_message(payload: WebhookPayload) -> None:
     if payload.attempts >= MAX_ATTEMPTS:
         payload.delete()
 
-        metrics.incr("hybridcloud.deliver_webhooks.delivery", tags={"outcome": "attempts_exceed"})
-        logger.info("deliver_webhook.discard", extra={**payload_data})
+        # Unsampled: see the parallel discard path above.
+        metrics.incr(
+            "hybridcloud.deliver_webhooks.delivery",
+            tags={"outcome": "attempts_exceed"},
+            sample_rate=1.0,
+        )
+        logger.warning("deliver_webhook.discard", extra={**payload_data})
         return
 
     payload.schedule_next_attempt()
@@ -740,7 +753,7 @@ def perform_cell_request(cell: Cell, payload: WebhookPayload) -> None:
                     "hybridcloud.deliver_webhooks.failure",
                     tags={"reason": reason, "destination_region": cell.name},
                 )
-                logger.info(
+                logger.warning(
                     "deliver_webhooks.40x_error",
                     extra={"reason": reason, **payload.as_dict()},
                 )


### PR DESCRIPTION
Audit of the logging and metrics in `deliver_webhooks.py`, keeping only the changes that measurement supported.

### Log levels

Four call sites logged at `info` for events that permanently drop a webhook, which is data loss:

- `deliver_webhook.discard` and `deliver_webhook_parallel.discard` — retry exhaustion at `MAX_ATTEMPTS`
- `deliver_webhook_parallel.max_age_discard` — the `>3-day` stale-mailbox sweep, which deletes up to 10k rows at a time
- `deliver_webhooks.40x_error` — returns without rescheduling, so the payload is dropped

All four move to `warning`. The 4xx case was also inconsistent with its neighbours: a 409 conflict, which is the cell explicitly asking us to drop the payload, already logged at `warning` while a 401 did not.

Level is the only per-call lever the log pipeline exposes here — `LoggingIntegration(event_level=None, sentry_logs_level=logging.INFO)` forwards everything at info and above to Sentry Logs, unsampled (`ourlogs.sentry-emit-rollout` is `1.0`), and none of it creates error events.

### Metric sampling

Production runs `SENTRY_METRICS_SAMPLE_RATE = 0.1`, so every counter here was 10%-sampled. Two are now explicitly unsampled:

**`delivery{outcome:max_age}`** — a correctness bug rather than lost resolution. `incr()` scales `amount` by `1/sample_rate`, so a sweep is reported as either nothing or ten times what it deleted. Over 24h this produced exactly one surviving emission reporting 21,419 discarded payloads, against a true value near 2,142.

**`delivery{outcome:attempts_exceed}`** — around 63/day across 7 of 288 five-minute buckets. Far too sparse to estimate from a tenth of the samples, and it answers "how many webhooks did we drop" rather than reporting a rate. Its blowup is well damped: with `MAX_ATTEMPTS=10` and a 3min × 1.4ⁿ backoff capped at 60min, it needs roughly 4.4h of sustained total outage to reach full delivery volume.

### Deliberately left sampled

`retry`, the five `failure{reason:*}` counters and `delivery_deadline` all scale to full delivery volume during a cell incident. At that point 10% already reports the rate precisely — 25.6M deliveries/day is ~1,778 packets/min even when sampled — and unsampling would only multiply packet volume at the worst possible moment. The rare trickle is covered by the paired `logger.warning`.

Same reasoning for the high-volume paths that were never candidates: `outcome:ok` (17.8k/min), `send_request`, and `push_trigger.{success,skipped,backoff}`. `outcome:race` was measured at 773/min with full bucket coverage, so 10% is already ample.
