### PR TITLE
fix(onboarding): Improve SCM selector search and keyboard navigation

### DIFF
--- a/static/app/components/onboarding/scm/scmIntegrationConnect.spec.tsx
+++ b/static/app/components/onboarding/scm/scmIntegrationConnect.spec.tsx
@@ -21,6 +21,7 @@ jest.mock('@tanstack/react-virtual', () => ({
       })),
     getTotalSize: () => count * 36,
     measureElement: jest.fn(),
+    scrollToIndex: jest.fn(),
   })),
 }));
 

--- a/static/app/components/onboarding/scm/scmPlatformFeaturesCore.spec.tsx
+++ b/static/app/components/onboarding/scm/scmPlatformFeaturesCore.spec.tsx
@@ -32,6 +32,7 @@ jest.mock('@tanstack/react-virtual', () => ({
       })),
     getTotalSize: () => count * 36,
     measureElement: jest.fn(),
+    scrollToIndex: jest.fn(),
   })),
 }));
 

--- a/static/app/components/onboarding/scm/scmRepoSelector.spec.tsx
+++ b/static/app/components/onboarding/scm/scmRepoSelector.spec.tsx
@@ -1,3 +1,4 @@
+import {useVirtualizer} from '@tanstack/react-virtual';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {OrganizationIntegrationsFixture} from 'sentry-fixture/organizationIntegrations';
 import {RepositoryFixture} from 'sentry-fixture/repository';
@@ -9,18 +10,21 @@ import * as analytics from 'sentry/utils/analytics';
 
 import {ScmRepoSelector} from './scmRepoSelector';
 
+const mockScrollToIndex = jest.fn();
+
 // Mock the virtualizer so all items render in JSDOM (no layout engine).
 jest.mock('@tanstack/react-virtual', () => ({
-  useVirtualizer: jest.fn(({count}) => ({
+  useVirtualizer: jest.fn(({count, paddingStart = 0, paddingEnd = 0}) => ({
     getVirtualItems: () =>
       Array.from({length: count}, (_, i) => ({
         key: i,
         index: i,
-        start: i * 36,
+        start: paddingStart + i * 36,
         size: 36,
       })),
-    getTotalSize: () => count * 36,
+    getTotalSize: () => paddingStart + count * 36 + paddingEnd,
     measureElement: jest.fn(),
+    scrollToIndex: mockScrollToIndex,
   })),
 }));
 
@@ -68,6 +72,7 @@ describe('ScmRepoSelector', () => {
 
   afterEach(() => {
     MockApiClient.clearMockResponses();
+    mockScrollToIndex.mockClear();
   });
 
   it('renders search placeholder', () => {
@@ -141,6 +146,147 @@ describe('ScmRepoSelector', () => {
       await screen.findByRole('menuitemradio', {name: 'sentry'})
     ).toBeInTheDocument();
     expect(screen.getByRole('menuitemradio', {name: 'relay'})).toBeInTheDocument();
+  });
+
+  it('ranks exact name and token matches without searching the organization slug', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/${mockIntegration.id}/repos/`,
+      body: {
+        repos: [
+          {
+            externalId: '1',
+            identifier: 'getsentry/sentry-cli',
+            name: 'sentry-cli',
+            isInstalled: false,
+          },
+          {
+            externalId: '2',
+            identifier: 'getsentry/tool-cli',
+            name: 'tool-cli',
+            isInstalled: false,
+          },
+          {
+            externalId: '3',
+            identifier: 'getsentry/clickhouse-sdk',
+            name: 'clickhouse-sdk',
+            isInstalled: false,
+          },
+          {
+            externalId: '4',
+            identifier: 'cli-org/relay',
+            name: 'relay',
+            isInstalled: false,
+          },
+          {
+            externalId: '5',
+            identifier: 'getsentry/cli',
+            name: 'cli',
+            isInstalled: false,
+          },
+          {
+            externalId: '6',
+            identifier: 'getsentry/clickhouse-backup',
+            name: 'clickhouse-backup',
+            isInstalled: false,
+          },
+          {
+            externalId: '7',
+            identifier: 'getsentry/cli-tools',
+            name: 'cli-tools',
+            isInstalled: false,
+          },
+        ],
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/repos/`,
+      body: [
+        RepositoryFixture({
+          externalId: '5',
+          name: 'getsentry/cli',
+          externalSlug: 'getsentry/cli',
+        }),
+      ],
+    });
+
+    const onRepositoryChange = jest.fn();
+    render(
+      <ScmRepoSelector
+        {...defaultProps({integration: mockIntegration, onRepositoryChange})}
+      />,
+      {organization}
+    );
+
+    await userEvent.click(screen.getByRole('textbox'));
+    await userEvent.keyboard('cli');
+
+    expect(
+      screen.getAllByRole('menuitemradio').map(option => option.textContent)
+    ).toEqual([
+      'cli',
+      'cli-tools',
+      'sentry-cli',
+      'tool-cli',
+      'clickhouse-sdk',
+      'clickhouse-backup',
+    ]);
+    expect(screen.queryByRole('menuitemradio', {name: 'relay'})).not.toBeInTheDocument();
+
+    await userEvent.keyboard('{Enter}');
+    expect(onRepositoryChange).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({name: 'cli'})
+    );
+  });
+
+  it('scrolls keyboard focus into view without scrolling on pointer focus', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/${mockIntegration.id}/repos/`,
+      body: {
+        repos: Array.from({length: 20}, (_, index) => ({
+          externalId: String(index),
+          identifier: `getsentry/repo-${index}`,
+          name: `repo-${index}`,
+          isInstalled: false,
+        })),
+      },
+    });
+
+    render(<ScmRepoSelector {...defaultProps({integration: mockIntegration})} />, {
+      organization,
+    });
+
+    await userEvent.click(screen.getByRole('textbox'));
+
+    expect(useVirtualizer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        paddingStart: 4,
+        paddingEnd: 4,
+        scrollPaddingStart: 4,
+        scrollPaddingEnd: 4,
+      })
+    );
+    const firstOption = screen.getByRole('menuitemradio', {name: 'repo-0'});
+    expect(firstOption.parentElement).toHaveStyle({transform: 'translateY(4px)'});
+    expect(firstOption.parentElement?.parentElement?.parentElement).toHaveStyle({
+      maxHeight: '296px',
+    });
+    expect(screen.getByRole('menuitemradio', {name: 'repo-7'}).parentElement).toHaveStyle(
+      {
+        transform: 'translateY(256px)',
+      }
+    );
+
+    mockScrollToIndex.mockClear();
+    await userEvent.keyboard(
+      '{ArrowDown}{ArrowDown}{ArrowDown}{ArrowDown}{ArrowDown}{ArrowDown}{ArrowDown}{ArrowDown}{ArrowDown}{ArrowDown}'
+    );
+
+    expect(mockScrollToIndex).toHaveBeenLastCalledWith(10, {align: 'auto'});
+
+    mockScrollToIndex.mockClear();
+    await userEvent.hover(screen.getByRole('menuitemradio', {name: 'repo-15'}));
+    expect(mockScrollToIndex).not.toHaveBeenCalled();
   });
 
   it('shows selected repo value when one is provided', () => {

--- a/static/app/components/onboarding/scm/scmRepoSelector.tsx
+++ b/static/app/components/onboarding/scm/scmRepoSelector.tsx
@@ -1,4 +1,4 @@
-import {useMemo} from 'react';
+import {useMemo, useState} from 'react';
 
 import {Select} from '@sentry/scraps/select';
 
@@ -17,6 +17,41 @@ const REPO_SELECTED_EVENT = {
   onboarding: 'onboarding.scm_connect_repo_selected',
   'project-creation': 'project_creation.connect_repo_selected',
 } as const;
+
+function getRepositoryNameTokens(label: string) {
+  return label
+    .replace(/([a-z\d])([A-Z])/g, '$1 $2')
+    .split(/[-_.\s/]+/)
+    .filter(Boolean)
+    .map(token => token.toLowerCase());
+}
+
+function getSearchRank(label: string, search: string) {
+  const normalizedLabel = label.toLowerCase();
+  const normalizedSearch = search.trim().toLowerCase();
+
+  if (!normalizedSearch) {
+    return 0;
+  }
+  if (normalizedLabel === normalizedSearch) {
+    return 0;
+  }
+
+  const exactTokenIndex = getRepositoryNameTokens(label).indexOf(normalizedSearch);
+  if (exactTokenIndex === 0) {
+    return 1;
+  }
+  if (exactTokenIndex > 0) {
+    return 2;
+  }
+  if (normalizedLabel.startsWith(normalizedSearch)) {
+    return 3;
+  }
+  if (normalizedLabel.includes(normalizedSearch)) {
+    return 4;
+  }
+  return 5;
+}
 
 interface ScmRepoSelectorProps {
   // Which flow this component is rendered in. Drives analytics event names.
@@ -40,6 +75,7 @@ export function ScmRepoSelector({
   selectedRepository,
 }: ScmRepoSelectorProps) {
   const organization = useOrganization();
+  const [search, setSearch] = useState('');
   const {reposByIdentifier, dropdownItems, isFetching, isError} = useScmRepos(
     integration.id,
     selectedRepository
@@ -62,11 +98,27 @@ export function ScmRepoSelector({
       {
         value: selectedSlug,
         label: selectedRepository.name,
+        textValue: selectedRepository.name,
         disabled: true,
       },
       ...dropdownItems,
     ];
   }, [dropdownItems, selectedRepository]);
+
+  const rankedOptions = useMemo(
+    () =>
+      options
+        .map((option, originalIndex) => ({
+          option,
+          originalIndex,
+          rank: getSearchRank(option.label, search),
+        }))
+        .toSorted((a, b) => a.rank - b.rank || a.originalIndex - b.originalIndex)
+        // react-select preserves focus by object identity. Clone reordered
+        // options so keyboard focus follows the highest-ranked result.
+        .map(({option}) => ({...option})),
+    [options, search]
+  );
 
   function handleChange(option: {value: string} | null) {
     onClearDerivedState();
@@ -99,9 +151,11 @@ export function ScmRepoSelector({
   return (
     <Select
       placeholder={t('Search repositories')}
-      options={options}
+      options={rankedOptions}
       value={selectedRepository?.externalSlug ?? null}
       onChange={handleChange}
+      inputValue={search}
+      onInputChange={setSearch}
       noOptionsMessage={noOptionsMessage}
       isLoading={isFetching}
       isDisabled={busy}

--- a/static/app/components/onboarding/scm/scmVirtualizedMenuList.tsx
+++ b/static/app/components/onboarding/scm/scmVirtualizedMenuList.tsx
@@ -36,7 +36,7 @@ export function ScmVirtualizedMenuList({
   innerRef,
   innerProps,
 }: ScmVirtualizedMenuListProps) {
-  const items = Array.isArray(children) ? children : [];
+  const items: React.ReactNode[] = Array.isArray(children) ? children : [];
   const scrollRef = useRef<HTMLDivElement>(null);
   const combinedRef = mergeRefs(scrollRef, innerRef ?? null);
   const visibleOptionCount = Math.max(

--- a/static/app/components/onboarding/scm/scmVirtualizedMenuList.tsx
+++ b/static/app/components/onboarding/scm/scmVirtualizedMenuList.tsx
@@ -10,15 +10,18 @@
  * Usage: <Select components={{MenuList: ScmVirtualizedMenuList}} />
  */
 
-import {type Ref, useRef} from 'react';
+import {isValidElement, type Ref, useEffect, useRef} from 'react';
+import {getInteractionModality} from '@react-aria/interactions';
 import {mergeRefs} from '@react-aria/utils';
 import {useVirtualizer} from '@tanstack/react-virtual';
 
 const OPTION_HEIGHT = 36;
 const MAX_MENU_HEIGHT = 300;
+const MENU_PADDING = 4;
 
 interface ScmVirtualizedMenuListProps {
   children: React.ReactNode;
+  focusedOption?: unknown;
   innerProps?: React.HTMLAttributes<HTMLDivElement>;
   innerRef?: Ref<HTMLDivElement>;
   maxHeight?: number;
@@ -27,6 +30,7 @@ interface ScmVirtualizedMenuListProps {
 
 export function ScmVirtualizedMenuList({
   children,
+  focusedOption,
   maxHeight = MAX_MENU_HEIGHT,
   optionHeight = OPTION_HEIGHT,
   innerRef,
@@ -35,15 +39,35 @@ export function ScmVirtualizedMenuList({
   const items = Array.isArray(children) ? children : [];
   const scrollRef = useRef<HTMLDivElement>(null);
   const combinedRef = mergeRefs(scrollRef, innerRef ?? null);
+  const visibleOptionCount = Math.max(
+    1,
+    Math.floor((maxHeight - MENU_PADDING * 2) / optionHeight)
+  );
+  const alignedMaxHeight = visibleOptionCount * optionHeight + MENU_PADDING * 2;
 
   const virtualizer = useVirtualizer({
     count: items.length,
     getScrollElement: () => scrollRef.current,
     estimateSize: () => optionHeight,
     overscan: 5,
+    paddingStart: MENU_PADDING,
+    paddingEnd: MENU_PADDING,
+    scrollPaddingStart: MENU_PADDING,
+    scrollPaddingEnd: MENU_PADDING,
   });
 
   const virtualItems = virtualizer.getVirtualItems();
+  // react-select shares focused option identity with each Option child's data.
+  // The focused DOM node may be virtualized out, so scroll by its child index.
+  const focusedIndex = items.findIndex(
+    item => isValidElement<{data?: unknown}>(item) && item.props.data === focusedOption
+  );
+
+  useEffect(() => {
+    if (focusedIndex !== -1 && getInteractionModality() !== 'pointer') {
+      virtualizer.scrollToIndex(focusedIndex, {align: 'auto'});
+    }
+  }, [focusedIndex, virtualizer]);
 
   // When no options match, react-select passes a single NoOptionsMessage
   // element (not an array). Render it directly without virtualization.
@@ -56,7 +80,11 @@ export function ScmVirtualizedMenuList({
   }
 
   return (
-    <div ref={combinedRef} {...innerProps} style={{maxHeight, overflowY: 'auto'}}>
+    <div
+      ref={combinedRef}
+      {...innerProps}
+      style={{maxHeight: alignedMaxHeight, overflowY: 'auto'}}
+    >
       <div style={{height: virtualizer.getTotalSize(), position: 'relative'}}>
         {virtualItems.map(virtualRow => (
           <div

--- a/static/app/components/onboarding/scm/useScmRepos.spec.tsx
+++ b/static/app/components/onboarding/scm/useScmRepos.spec.tsx
@@ -52,8 +52,18 @@ describe('useScmRepos', () => {
     });
 
     expect(result.current.dropdownItems).toEqual([
-      {value: 'getsentry/sentry', label: 'sentry', disabled: false},
-      {value: 'getsentry/relay', label: 'relay', disabled: false},
+      {
+        value: 'getsentry/sentry',
+        label: 'sentry',
+        textValue: 'sentry',
+        disabled: false,
+      },
+      {
+        value: 'getsentry/relay',
+        label: 'relay',
+        textValue: 'relay',
+        disabled: false,
+      },
     ]);
   });
 

--- a/static/app/components/onboarding/scm/useScmRepos.ts
+++ b/static/app/components/onboarding/scm/useScmRepos.ts
@@ -30,6 +30,7 @@ export function useScmRepos(integrationId: string, selectedRepo?: Repository) {
         dropdownItems: Array<{
           disabled: boolean;
           label: string;
+          textValue: string;
           value: string;
         }>;
         reposByIdentifier: Map<string, IntegrationRepository>;
@@ -39,6 +40,9 @@ export function useScmRepos(integrationId: string, selectedRepo?: Repository) {
           acc.dropdownItems.push({
             value: repo.identifier,
             label: repo.name,
+            // The identifier includes the organization slug, which is not
+            // visible in the selector and should not affect search results.
+            textValue: repo.name,
             disabled: repo.identifier === selectedRepoSlug,
           });
           return acc;

--- a/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
@@ -36,6 +36,7 @@ jest.mock('@tanstack/react-virtual', () => ({
       })),
     getTotalSize: () => count * 36,
     measureElement: jest.fn(),
+    scrollToIndex: jest.fn(),
   })),
 }));
 

--- a/static/app/views/projectInstall/scmCreateProject.spec.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.spec.tsx
@@ -36,6 +36,7 @@ jest.mock('@tanstack/react-virtual', () => ({
       })),
     getTotalSize: () => count * 36,
     measureElement: jest.fn(),
+    scrollToIndex: jest.fn(),
   })),
 }));
 


### PR DESCRIPTION
## Summary

Repository search now ranks exact names and exact tokens ahead of broad substring matches, while filtering only on the visible repository name instead of the organization slug.

The shared virtualized menu also keeps keyboard focus in view and reserves consistent space around the first and last options. Its height is aligned to complete rows, so the first scroll no longer changes the bottom spacing.

## Screenshots

### Repository ranking

Previously, broad substring matches could appear before the repository whose name exactly matched the search. Results now rank an exact name first, followed by exact token, prefix, and general substring matches.

| Before | After |
| --- | --- |
| <img width="560" height="140" alt="Repository ranking before" src="https://github.com/user-attachments/assets/b07681c0-5bde-48cf-ad4d-31ee676f9eba" /> | <img width="560" height="140" alt="Repository ranking after" src="https://github.com/user-attachments/assets/0ecb0e73-7596-4169-aa43-ebb6e3cc9847" /> |

### Organization slug is not searched

Previously, search also matched the hidden organization slug in each repository identifier, so entering that slug returned every repository in the organization. Search now considers only the repository name shown in the selector.

| Before | After |
| --- | --- |
| <img width="560" height="150" alt="Organization slug search before" src="https://github.com/user-attachments/assets/d626c1d7-c375-403b-92b2-4624256e2f5c" /> | <img width="560" height="150" alt="Organization slug search after" src="https://github.com/user-attachments/assets/8d683953-6038-45c8-b370-0ec505e892ab" /> |

### Keyboard navigation

Previously, Arrow Down changed the focused SDK but the virtualized list did not scroll with it, so the focused row could move outside the rendered viewport with no visible indication of the current choice. Keyboard focus now scrolls into view while pointer hover continues to avoid forced scrolling.

| Before | After |
| --- | --- |
| <img width="560" height="300" alt="Keyboard navigation before" src="https://github.com/user-attachments/assets/8bace070-b876-4499-998d-f54ab347f6db" /> | <img width="560" height="300" alt="Keyboard navigation after" src="https://github.com/user-attachments/assets/cf09f306-702c-43d5-8d66-86cc9eebe389" /> |

### Consistent menu spacing

Previously, the first row background could sit against the top border, the last visible row left too much space below it, and the next Arrow Down collapsed that gap when scrolling began. The full sequence below shows how consistent insets and complete rows remove all three spacing shifts.

| State | Before | After |
| --- | --- | --- |
| First option focused | <img width="560" height="79" alt="First option spacing before" src="https://github.com/user-attachments/assets/68f96477-2d83-4c4f-8b86-a79e0b71a834" /> | <img width="560" height="79" alt="First option spacing after" src="https://github.com/user-attachments/assets/623ec913-3f5e-474a-b7b9-1afe276cd39b" /> |
| Last visible option focused | <img width="560" height="96" alt="Last visible option spacing before" src="https://github.com/user-attachments/assets/a73a9e22-4d9d-44b8-af1e-058f32f49093" /> | <img width="560" height="96" alt="Last visible option spacing after" src="https://github.com/user-attachments/assets/cc70987b-379b-4444-94a4-754e4d80c628" /> |
| Arrow Down scrolls to the next option | <img width="520" height="64" alt="First scrolled option spacing before" src="https://github.com/user-attachments/assets/c2d54c1a-0823-482c-96ce-b78c2047d6c7" /> | <img width="560" height="95" alt="First scrolled option spacing after" src="https://github.com/user-attachments/assets/67e3f0d1-ad6e-4f9f-854c-38e88fe2886e" /> |

## Test plan

- pnpm test-ci for the six affected SCM suites (73 tests)
- pnpm run lint:js for all changed files
- pnpm run typecheck
- .venv/bin/prek run -q
- Manually verified repository search and keyboard navigation in the project creation flow
