### PR TITLE
fix(hybridcloud): Stop counting rejected webhooks as successful deliveries

### DIFF
--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -105,6 +105,23 @@ class DeliveryFailed(Exception):
     pass
 
 
+class DeliveryDropped(Exception):
+    """
+    Signals that the cell rejected the payload in a way retrying cannot fix, so
+    it is discarded instead of rescheduled.
+
+    Distinct from `DeliveryFailed`, which is retryable. Both end in the payload
+    being deleted, but only this one means the webhook never reached the cell,
+    so callers must not count it as a delivery.
+
+    `outcome` is the `delivery` metric tag describing why it was dropped.
+    """
+
+    def __init__(self, outcome: str) -> None:
+        super().__init__(outcome)
+        self.outcome = outcome
+
+
 def _drain_lock_key(mailbox_name: str) -> str:
     return f"wh:drain_active:{mailbox_name}"
 
@@ -328,8 +345,8 @@ def drain_mailbox(payload_id: int, mailbox_name: str | None = None) -> None:
                 if mailbox_name and options.get("hybridcloud.webhookpayload.push_drain_trigger"):
                     _refresh_drain_lock(payload.mailbox_name)
                 try:
-                    deliver_message(record)
-                    delivered += 1
+                    if deliver_message(record):
+                        delivered += 1
                 except DeliveryFailed:
                     failed += 1
                     metrics.incr("hybridcloud.deliver_webhooks.delivery", tags={"outcome": "retry"})
@@ -462,6 +479,12 @@ def _handle_parallel_delivery_result(
     Returns (request_failed, should_reraise).
     """
     payload_data = payload_record.as_dict()
+    if isinstance(err, DeliveryDropped):
+        # Permanently rejected, so it is neither a delivery nor a retryable failure:
+        # drop it and let the drain continue to the next record.
+        payload_record.delete()
+        metrics.incr("hybridcloud.deliver_webhooks.delivery", tags={"outcome": err.outcome})
+        return (False, False)
     if err:
         if payload_record.attempts >= MAX_ATTEMPTS:
             payload_record.delete()
@@ -625,8 +648,14 @@ def deliver_message_parallel(payload: WebhookPayload) -> tuple[WebhookPayload, E
         return (payload, err)
 
 
-def deliver_message(payload: WebhookPayload) -> None:
-    """Deliver a message if it still has delivery attempts remaining"""
+def deliver_message(payload: WebhookPayload) -> bool:
+    """
+    Deliver a message if it still has delivery attempts remaining.
+
+    Returns whether the payload actually reached the cell. A payload that was
+    discarded — attempts exhausted, or permanently rejected — returns False even
+    though it was removed from the mailbox.
+    """
     payload_data = payload.as_dict()
     if payload.attempts >= MAX_ATTEMPTS:
         payload.delete()
@@ -638,16 +667,24 @@ def deliver_message(payload: WebhookPayload) -> None:
             sample_rate=1.0,
         )
         logger.warning("deliver_webhook.discard", extra={**payload_data})
-        return
+        return False
 
     payload.schedule_next_attempt()
-    perform_request(payload)
+    try:
+        perform_request(payload)
+    except DeliveryDropped as err:
+        # The cell rejected the payload permanently. Delete it like a delivery, but
+        # don't record delivery time or count it as one — it never arrived.
+        payload.delete()
+        metrics.incr("hybridcloud.deliver_webhooks.delivery", tags={"outcome": err.outcome})
+        return False
     date_added = payload.date_added
     payload.delete()
     _record_delivery_time_metrics(payload)
     if timezone.now() - date_added >= SLOW_DELIVERY_THRESHOLD:
         logger.warning("deliver_webhook.slow_delivery", extra=payload_data)
     metrics.incr("hybridcloud.deliver_webhooks.delivery", tags={"outcome": "ok"})
+    return True
 
 
 def perform_request(payload: WebhookPayload) -> None:
@@ -721,6 +758,7 @@ def perform_cell_request(cell: Cell, payload: WebhookPayload) -> None:
             extra={"conflict_text": err.text, **payload.as_dict()},
         )
         # We don't retry conflicts as those are explicit failure code to drop webhook.
+        raise DeliveryDropped("conflict") from err
     except (ApiTimeoutError, ApiConnectionResetError) as err:
         metrics.incr(
             "hybridcloud.deliver_webhooks.failure",
@@ -757,7 +795,7 @@ def perform_cell_request(cell: Cell, payload: WebhookPayload) -> None:
                     "deliver_webhooks.40x_error",
                     extra={"reason": reason, **payload.as_dict()},
                 )
-                return
+                raise DeliveryDropped("dropped_4xx") from err
 
         # Other ApiErrors should be retried
         metrics.incr(

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -1066,6 +1066,143 @@ class DeliveryTimeMetricsTest(TestCase):
 
 
 @control_silo_test
+class DroppedDeliveryOutcomeTest(TestCase):
+    """
+    A payload the cell permanently rejects is deleted just like a delivered one, so
+    it must not be reported as a delivery.
+    """
+
+    def delivery_outcomes(self, mock_metrics: MagicMock) -> list[str]:
+        return [
+            c[1]["tags"]["outcome"]
+            for c in mock_metrics.incr.call_args_list
+            if c[0][0] == "hybridcloud.deliver_webhooks.delivery"
+        ]
+
+    def delivery_time_calls(self, mock_metrics: MagicMock) -> list[Any]:
+        return [
+            c
+            for c in mock_metrics.distribution.call_args_list
+            if c[0][0] == "hybridcloud.deliver_webhooks.delivery_time_ms"
+        ]
+
+    @responses.activate
+    @override_cells(cell_config)
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    def test_drain_conflict_not_counted_as_delivered(self, mock_metrics: MagicMock) -> None:
+        responses.add(
+            responses.POST,
+            "http://us.testserver/extensions/github/webhook/",
+            status=409,
+            body="",
+        )
+        webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
+
+        drain_mailbox(webhook.id)
+
+        assert not WebhookPayload.objects.filter(id=webhook.id).exists()
+        assert self.delivery_outcomes(mock_metrics) == ["conflict"]
+        assert self.delivery_time_calls(mock_metrics) == []
+
+    @responses.activate
+    @override_cells(cell_config)
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    def test_drain_unauthorized_not_counted_as_delivered(self, mock_metrics: MagicMock) -> None:
+        responses.add(
+            responses.POST,
+            "http://us.testserver/extensions/github/webhook/",
+            status=401,
+            body="",
+        )
+        webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
+
+        drain_mailbox(webhook.id)
+
+        assert not WebhookPayload.objects.filter(id=webhook.id).exists()
+        assert self.delivery_outcomes(mock_metrics) == ["dropped_4xx"]
+        assert self.delivery_time_calls(mock_metrics) == []
+
+    @responses.activate
+    @override_cells(cell_config)
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    def test_drain_success_still_counted_as_delivered(self, mock_metrics: MagicMock) -> None:
+        responses.add(
+            responses.POST,
+            "http://us.testserver/extensions/github/webhook/",
+            status=200,
+            body="",
+        )
+        webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
+
+        drain_mailbox(webhook.id)
+
+        assert self.delivery_outcomes(mock_metrics) == ["ok"]
+        assert len(self.delivery_time_calls(mock_metrics)) == 1
+
+    @responses.activate
+    @override_cells(cell_config)
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    def test_parallel_conflict_not_counted_as_delivered(self, mock_metrics: MagicMock) -> None:
+        responses.add(
+            responses.POST,
+            "http://us.testserver/extensions/github/webhook/",
+            status=409,
+            body="",
+        )
+        webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
+
+        drain_mailbox_parallel(webhook.id)
+
+        assert not WebhookPayload.objects.filter(id=webhook.id).exists()
+        assert self.delivery_outcomes(mock_metrics) == ["conflict"]
+        assert self.delivery_time_calls(mock_metrics) == []
+
+    @responses.activate
+    @override_cells(cell_config)
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    def test_parallel_unauthorized_not_counted_as_delivered(self, mock_metrics: MagicMock) -> None:
+        responses.add(
+            responses.POST,
+            "http://us.testserver/extensions/github/webhook/",
+            status=401,
+            body="",
+        )
+        webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
+
+        drain_mailbox_parallel(webhook.id)
+
+        assert not WebhookPayload.objects.filter(id=webhook.id).exists()
+        assert self.delivery_outcomes(mock_metrics) == ["dropped_4xx"]
+        assert self.delivery_time_calls(mock_metrics) == []
+
+    @responses.activate
+    @override_cells(cell_config)
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    def test_dropped_payload_does_not_stall_ordered_mailbox(self, mock_metrics: MagicMock) -> None:
+        # A drop is terminal, not a retryable failure, so the drain must continue
+        # past it even for providers that stop on the first failure.
+        responses.add(
+            responses.POST,
+            "http://us.testserver/extensions/github/webhook/",
+            status=401,
+            body="",
+        )
+        responses.add(
+            responses.POST,
+            "http://us.testserver/extensions/github/webhook/",
+            status=200,
+            body="",
+        )
+        first = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
+        second = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
+
+        drain_mailbox(first.id)
+
+        assert not WebhookPayload.objects.filter(id=second.id).exists()
+        assert self.delivery_outcomes(mock_metrics) == ["dropped_4xx", "ok"]
+
+
+@control_silo_test
 class PushTriggerTest(TestCase):
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
     @override_options({"hybridcloud.webhookpayload.push_drain_trigger": True})


### PR DESCRIPTION
### The problem

`perform_cell_request` handles a 409 conflict and a 400/401/403/404 by incrementing `deliver_webhooks.failure` and then **returning normally** instead of raising. Control falls back to `deliver_message`, which proceeds straight through `payload.delete()` → `_record_delivery_time_metrics()` → `metrics.incr(outcome="ok")`. The parallel drain does the same, since `deliver_message_parallel` returns a null error and `_handle_parallel_delivery_result` reads that as success.

So a webhook the cell refused is reported as delivered.

Measured over 24h in production, that is **379,521 payloads**:

| reason | per day |
|---|---|
| conflict | 213,606 |
| unauthorized | 162,729 |
| bad_request | 2,916 |
| not_found | 261 |
| forbidden | 9 |

About 1.5% of the 25.6M `outcome:ok`. Their latency is also folded into `delivery_time_ms`, biased low because a rejection returns faster than a real delivery. The only trace of them is the `failure` counter, which no dashboard widget plots — which is why this went unnoticed.

### The change

Both paths now raise `DeliveryDropped`, distinct from the retryable `DeliveryFailed`, carrying the outcome tag. Callers delete the payload exactly as before, but record `outcome:conflict` or `outcome:dropped_4xx` instead of `ok`, and skip the delivery-time distribution.

Per-reason detail stays on `failure{reason:*}` rather than being duplicated onto `outcome`, keeping that tag low-cardinality.

`deliver_message` now returns whether the payload reached the cell, so the sequential drain's `delivered` counter stops including discards — the parallel drain already excluded them.

### Not changed

What gets retried or deleted is identical. A drop is terminal rather than a failure, so ordering-sensitive providers continue past it just as they did when the 4xx fell through as success; there is a regression test for that.

### After deploy

`outcome:ok` drops by ~1.5% and two new series appear on the **Delivery Outcomes** widget of the [Hybrid Cloud Webhook Forwarding](https://app.datadoghq.com/dashboard/tqt-8cb-xmj/hybrid-cloud-webhook-forwarding) dashboard. `delivery_time_ms` percentiles may tick up slightly as the fast rejections stop being counted.
