### PR TITLE
docs(settings): Document token exclusion when Allowed Domains is *

### DIFF
--- a/static/app/views/settings/projectGeneralSettings/index.tsx
+++ b/static/app/views/settings/projectGeneralSettings/index.tsx
@@ -345,7 +345,7 @@ function AutoResolveForm({
 }
 
 const SECURITY_TOKEN_HELP = t(
-  'Outbound requests matching Allowed Domains will have the header "{token_header}: {token}" appended'
+  'Outbound requests matching Allowed Domains will have the header "{token_header}: {token}" appended. This does not apply to sourcemap scraping when Allowed Domains is *.'
 );
 
 function SecurityTokenForm({


### PR DESCRIPTION
After [https://github.com/getsentry/sentry/pull/120182](<https://github.com/getsentry/sentry/pull/120182>), sentry no longer sends the user-provided security token to symbolicator - which uses it for sourcemap scraping - if `Allowed Domains` is set to `*`. Unfortunately, this has broken stack traces for customers without them understanding why. This change is one step towards preventing this.

Ref: [INGEST-1111](https://linear.app/getsentry/issue/INGEST-1111/sourcemap-scraping-403s)