### PR TITLE
feat(hybridcloud): Tag webhook delivery metrics by provider

### DIFF
--- a/src/sentry/hybridcloud/models/webhookpayload.py
+++ b/src/sentry/hybridcloud/models/webhookpayload.py
@@ -112,7 +112,7 @@ class WebhookPayload(Model):
         request: HttpRequest,
         integration_id: int | None = None,
     ) -> Self:
-        metrics.incr("hybridcloud.deliver_webhooks.saved")
+        metrics.incr("hybridcloud.deliver_webhooks.saved", tags={"provider": provider})
         return cls.objects.create(
             mailbox_name=f"{provider}:{identifier}",
             provider=provider,

--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -85,6 +85,26 @@ PROVIDER_PRIORITY = {
 DEFAULT_PROVIDER_PRIORITY = 10
 
 
+UNKNOWN_PROVIDER = "unknown"
+"""The payload predates the provider column, or the mailbox name carries no provider."""
+
+
+def _provider_tag(payload: WebhookPayload) -> str:
+    """The provider column is nullable, and rows predating it still drain through here."""
+    return payload.provider or UNKNOWN_PROVIDER
+
+
+def _provider_from_mailbox(mailbox_name: str | None) -> str:
+    """
+    Recover the provider where only the mailbox name is in hand.
+
+    Mailboxes are named `<provider>:<identifier>`, and it is the identifier that later
+    gains bucket and event-type suffixes, so the first segment stays the provider.
+    """
+    provider, separator, _ = (mailbox_name or "").partition(":")
+    return provider if separator and provider else UNKNOWN_PROVIDER
+
+
 def _set_webhook_delivery_sentry_context(payload: WebhookPayload) -> None:
     """Set Sentry context at webhook delivery entrypoint for easier debugging."""
     sentry_sdk.set_tag("mailbox_name", payload.mailbox_name)
@@ -155,6 +175,7 @@ def maybe_trigger_drain(mailbox_name: str) -> None:
         return
 
     lock_key = _drain_lock_key(mailbox_name)
+    trigger_tags = {"provider": _provider_from_mailbox(mailbox_name)}
     lock_acquired = False
     try:
         if cache.add(lock_key, 1, timeout=15):
@@ -173,20 +194,20 @@ def maybe_trigger_drain(mailbox_name: str) -> None:
                 # Mailbox is empty or head is in backoff — release the lock and let
                 # the scheduler handle it when schedule_for comes due.
                 _release_drain_lock(mailbox_name)
-                metrics.incr("hybridcloud.deliver_webhooks.push_trigger.backoff")
+                metrics.incr("hybridcloud.deliver_webhooks.push_trigger.backoff", tags=trigger_tags)
                 return
             head_id = head[0]
             drain_mailbox.delay(head_id, mailbox_name=mailbox_name)
-            metrics.incr("hybridcloud.deliver_webhooks.push_trigger.success")
+            metrics.incr("hybridcloud.deliver_webhooks.push_trigger.success", tags=trigger_tags)
         else:
-            metrics.incr("hybridcloud.deliver_webhooks.push_trigger.skipped")
+            metrics.incr("hybridcloud.deliver_webhooks.push_trigger.skipped", tags=trigger_tags)
     except Exception:
         # Only release the lock if this caller acquired it. Releasing unconditionally
         # would delete another process's lock when cache.add returned False and a
         # subsequent operation (e.g. metrics.incr) raised.
         if lock_acquired:
             _release_drain_lock(mailbox_name)
-        metrics.incr("hybridcloud.deliver_webhooks.push_trigger.error")
+        metrics.incr("hybridcloud.deliver_webhooks.push_trigger.error", tags=trigger_tags)
 
 
 @instrumented_task(
@@ -291,7 +312,10 @@ def drain_mailbox(payload_id: int, mailbox_name: str | None = None) -> None:
     except WebhookPayload.DoesNotExist:
         # We could have hit a race condition. Since we've lost already return
         # and let the other process continue, or a future process.
-        metrics.incr("hybridcloud.deliver_webhooks.delivery", tags={"outcome": "race"})
+        metrics.incr(
+            "hybridcloud.deliver_webhooks.delivery",
+            tags={"outcome": "race", "provider": _provider_from_mailbox(mailbox_name)},
+        )
         logger.info("deliver_webhook.potential_race", extra={"id": payload_id})
         # Release the drain lock if we know the mailbox name. Otherwise the lock is
         # held, blocking both push triggers and the scheduler for the full 15s TTL.
@@ -323,7 +347,8 @@ def drain_mailbox(payload_id: int, mailbox_name: str | None = None) -> None:
                     },
                 )
                 metrics.incr(
-                    "hybridcloud.deliver_webhooks.delivery", tags={"outcome": "delivery_deadline"}
+                    "hybridcloud.deliver_webhooks.delivery",
+                    tags={"outcome": "delivery_deadline", "provider": _provider_tag(payload)},
                 )
                 break
 
@@ -349,7 +374,10 @@ def drain_mailbox(payload_id: int, mailbox_name: str | None = None) -> None:
                         delivered += 1
                 except DeliveryFailed:
                     failed += 1
-                    metrics.incr("hybridcloud.deliver_webhooks.delivery", tags={"outcome": "retry"})
+                    metrics.incr(
+                        "hybridcloud.deliver_webhooks.delivery",
+                        tags={"outcome": "retry", "provider": _provider_tag(payload)},
+                    )
                     if not skip_on_failure:
                         # For providers that require strict ordering, stop on the
                         # first failure so subsequent messages are not delivered
@@ -420,7 +448,7 @@ def _discard_stale_mailbox_payloads(payload: WebhookPayload) -> None:
             metrics.incr(
                 "hybridcloud.deliver_webhooks.delivery",
                 amount=deleted,
-                tags={"outcome": "max_age"},
+                tags={"outcome": "max_age", "provider": _provider_tag(payload)},
                 sample_rate=1.0,
             )
 
@@ -483,7 +511,10 @@ def _handle_parallel_delivery_result(
         # Permanently rejected, so it is neither a delivery nor a retryable failure:
         # drop it and let the drain continue to the next record.
         payload_record.delete()
-        metrics.incr("hybridcloud.deliver_webhooks.delivery", tags={"outcome": err.outcome})
+        metrics.incr(
+            "hybridcloud.deliver_webhooks.delivery",
+            tags={"outcome": err.outcome, "provider": _provider_tag(payload_record)},
+        )
         return (False, False)
     if err:
         if payload_record.attempts >= MAX_ATTEMPTS:
@@ -492,7 +523,7 @@ def _handle_parallel_delivery_result(
             # wants an exact total rather than an estimated rate.
             metrics.incr(
                 "hybridcloud.deliver_webhooks.delivery",
-                tags={"outcome": "attempts_exceed"},
+                tags={"outcome": "attempts_exceed", "provider": _provider_tag(payload_record)},
                 sample_rate=1.0,
             )
             logger.warning(
@@ -501,14 +532,20 @@ def _handle_parallel_delivery_result(
             )
             request_failed = False
         else:
-            metrics.incr("hybridcloud.deliver_webhooks.delivery", tags={"outcome": "retry"})
+            metrics.incr(
+                "hybridcloud.deliver_webhooks.delivery",
+                tags={"outcome": "retry", "provider": _provider_tag(payload_record)},
+            )
             payload_record.schedule_next_attempt()
             request_failed = True
         return (request_failed, not isinstance(err, DeliveryFailed))
     date_added = payload_record.date_added
     payload_record.delete()
     _record_delivery_time_metrics(payload_record)
-    metrics.incr("hybridcloud.deliver_webhooks.delivery", tags={"outcome": "ok"})
+    metrics.incr(
+        "hybridcloud.deliver_webhooks.delivery",
+        tags={"outcome": "ok", "provider": _provider_tag(payload_record)},
+    )
     if timezone.now() - date_added >= SLOW_DELIVERY_THRESHOLD:
         logger.warning("deliver_webhook.slow_delivery", extra=payload_data)
     return (False, False)
@@ -582,7 +619,10 @@ def drain_mailbox_parallel(payload_id: int, mailbox_name: str | None = None) -> 
     except WebhookPayload.DoesNotExist:
         # We could have hit a race condition. Since we've lost already return
         # and let the other process continue, or a future process.
-        metrics.incr("hybridcloud.deliver_webhooks.delivery", tags={"outcome": "race"})
+        metrics.incr(
+            "hybridcloud.deliver_webhooks.delivery",
+            tags={"outcome": "race", "provider": _provider_from_mailbox(mailbox_name)},
+        )
         logger.info("deliver_webhook_parallel.potential_race", extra={"id": payload_id})
         if mailbox_name and options.get("hybridcloud.webhookpayload.push_drain_trigger"):
             _release_drain_lock(mailbox_name)
@@ -608,7 +648,8 @@ def drain_mailbox_parallel(payload_id: int, mailbox_name: str | None = None) -> 
             if timezone.now() >= deadline:
                 logger.info("deliver_webhook_parallel.delivery_deadline", extra=extra)
                 metrics.incr(
-                    "hybridcloud.deliver_webhooks.delivery", tags={"outcome": "delivery_deadline"}
+                    "hybridcloud.deliver_webhooks.delivery",
+                    tags={"outcome": "delivery_deadline", "provider": _provider_tag(payload)},
                 )
                 break
 
@@ -663,7 +704,7 @@ def deliver_message(payload: WebhookPayload) -> bool:
         # Unsampled: see the parallel discard path above.
         metrics.incr(
             "hybridcloud.deliver_webhooks.delivery",
-            tags={"outcome": "attempts_exceed"},
+            tags={"outcome": "attempts_exceed", "provider": _provider_tag(payload)},
             sample_rate=1.0,
         )
         logger.warning("deliver_webhook.discard", extra={**payload_data})
@@ -676,14 +717,20 @@ def deliver_message(payload: WebhookPayload) -> bool:
         # The cell rejected the payload permanently. Delete it like a delivery, but
         # don't record delivery time or count it as one — it never arrived.
         payload.delete()
-        metrics.incr("hybridcloud.deliver_webhooks.delivery", tags={"outcome": err.outcome})
+        metrics.incr(
+            "hybridcloud.deliver_webhooks.delivery",
+            tags={"outcome": err.outcome, "provider": _provider_tag(payload)},
+        )
         return False
     date_added = payload.date_added
     payload.delete()
     _record_delivery_time_metrics(payload)
     if timezone.now() - date_added >= SLOW_DELIVERY_THRESHOLD:
         logger.warning("deliver_webhook.slow_delivery", extra=payload_data)
-    metrics.incr("hybridcloud.deliver_webhooks.delivery", tags={"outcome": "ok"})
+    metrics.incr(
+        "hybridcloud.deliver_webhooks.delivery",
+        tags={"outcome": "ok", "provider": _provider_tag(payload)},
+    )
     return True
 
 
@@ -725,7 +772,11 @@ def perform_cell_request(cell: Cell, payload: WebhookPayload) -> None:
     except ApiHostError as err:
         metrics.incr(
             "hybridcloud.deliver_webhooks.failure",
-            tags={"reason": "host_error", "destination_region": cell.name},
+            tags={
+                "reason": "host_error",
+                "destination_region": cell.name,
+                "provider": _provider_tag(payload),
+            },
         )
         with sentry_sdk.isolation_scope() as scope:
             scope.set_context(
@@ -751,7 +802,11 @@ def perform_cell_request(cell: Cell, payload: WebhookPayload) -> None:
     except ApiConflictError as err:
         metrics.incr(
             "hybridcloud.deliver_webhooks.failure",
-            tags={"reason": "conflict", "destination_region": cell.name},
+            tags={
+                "reason": "conflict",
+                "destination_region": cell.name,
+                "provider": _provider_tag(payload),
+            },
         )
         logger.warning(
             "deliver_webhooks.conflict_occurred",
@@ -762,7 +817,11 @@ def perform_cell_request(cell: Cell, payload: WebhookPayload) -> None:
     except (ApiTimeoutError, ApiConnectionResetError) as err:
         metrics.incr(
             "hybridcloud.deliver_webhooks.failure",
-            tags={"reason": "timeout_reset", "destination_region": cell.name},
+            tags={
+                "reason": "timeout_reset",
+                "destination_region": cell.name,
+                "provider": _provider_tag(payload),
+            },
         )
         logger.warning("deliver_webhooks.timeout_error", extra=payload.as_dict())
         raise DeliveryFailed() from err
@@ -789,7 +848,11 @@ def perform_cell_request(cell: Cell, payload: WebhookPayload) -> None:
                     reason = "forbidden"
                 metrics.incr(
                     "hybridcloud.deliver_webhooks.failure",
-                    tags={"reason": reason, "destination_region": cell.name},
+                    tags={
+                        "reason": reason,
+                        "destination_region": cell.name,
+                        "provider": _provider_tag(payload),
+                    },
                 )
                 logger.warning(
                     "deliver_webhooks.40x_error",
@@ -800,7 +863,11 @@ def perform_cell_request(cell: Cell, payload: WebhookPayload) -> None:
         # Other ApiErrors should be retried
         metrics.incr(
             "hybridcloud.deliver_webhooks.failure",
-            tags={"reason": "api_error", "destination_region": cell.name},
+            tags={
+                "reason": "api_error",
+                "destination_region": cell.name,
+                "provider": _provider_tag(payload),
+            },
         )
         logger.warning(
             "deliver_webhooks.api_error",

--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -376,7 +376,7 @@ def drain_mailbox(payload_id: int, mailbox_name: str | None = None) -> None:
                     failed += 1
                     metrics.incr(
                         "hybridcloud.deliver_webhooks.delivery",
-                        tags={"outcome": "retry", "provider": _provider_tag(payload)},
+                        tags={"outcome": "retry", "provider": _provider_tag(record)},
                     )
                     if not skip_on_failure:
                         # For providers that require strict ordering, stop on the

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -1203,6 +1203,143 @@ class DroppedDeliveryOutcomeTest(TestCase):
 
 
 @control_silo_test
+class ProviderMetricTagTest(TestCase):
+    """
+    The `$provider` dashboard selector filters on this tag, so a delivery metric
+    emitted without it silently disappears when a provider is selected.
+    """
+
+    def tags_for(self, mock_metrics: MagicMock, metric: str) -> list[dict[str, str]]:
+        return [c[1].get("tags", {}) for c in mock_metrics.incr.call_args_list if c[0][0] == metric]
+
+    @responses.activate
+    @override_cells(cell_config)
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    def test_delivery_tagged_with_provider(self, mock_metrics: MagicMock) -> None:
+        responses.add(
+            responses.POST,
+            "http://us.testserver/extensions/github/webhook/",
+            status=200,
+            body="",
+        )
+        webhook = self.create_webhook_payload(
+            mailbox_name="github:123", cell_name="us", provider="github"
+        )
+
+        drain_mailbox(webhook.id)
+
+        assert self.tags_for(mock_metrics, "hybridcloud.deliver_webhooks.delivery") == [
+            {"outcome": "ok", "provider": "github"}
+        ]
+
+    @responses.activate
+    @override_cells(cell_config)
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    def test_failure_tagged_with_provider(self, mock_metrics: MagicMock) -> None:
+        responses.add(
+            responses.POST,
+            "http://us.testserver/extensions/github/webhook/",
+            status=401,
+            body="",
+        )
+        webhook = self.create_webhook_payload(
+            mailbox_name="github:123", cell_name="us", provider="github"
+        )
+
+        drain_mailbox(webhook.id)
+
+        assert self.tags_for(mock_metrics, "hybridcloud.deliver_webhooks.failure") == [
+            {"reason": "unauthorized", "destination_region": "us", "provider": "github"}
+        ]
+
+    @responses.activate
+    @override_cells(cell_config)
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    def test_dropped_outcomes_tagged_with_provider(self, mock_metrics: MagicMock) -> None:
+        # `conflict` and `dropped_4xx` are delivery outcomes like any other, so they
+        # must carry the tag too or they vanish when a provider is selected.
+        responses.add(
+            responses.POST,
+            "http://us.testserver/extensions/github/webhook/",
+            status=409,
+            body="",
+        )
+        webhook = self.create_webhook_payload(
+            mailbox_name="github:123", cell_name="us", provider="github"
+        )
+
+        drain_mailbox(webhook.id)
+
+        assert self.tags_for(mock_metrics, "hybridcloud.deliver_webhooks.delivery") == [
+            {"outcome": "conflict", "provider": "github"}
+        ]
+
+    @responses.activate
+    @override_cells(cell_config)
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    def test_parallel_dropped_outcome_tagged_with_provider(self, mock_metrics: MagicMock) -> None:
+        responses.add(
+            responses.POST,
+            "http://us.testserver/extensions/github/webhook/",
+            status=401,
+            body="",
+        )
+        webhook = self.create_webhook_payload(
+            mailbox_name="github:123", cell_name="us", provider="github"
+        )
+
+        drain_mailbox_parallel(webhook.id)
+
+        assert self.tags_for(mock_metrics, "hybridcloud.deliver_webhooks.delivery") == [
+            {"outcome": "dropped_4xx", "provider": "github"}
+        ]
+
+    @responses.activate
+    @override_cells(cell_config)
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    def test_provider_falls_back_to_unknown(self, mock_metrics: MagicMock) -> None:
+        # Rows predating the provider column still drain through here.
+        responses.add(
+            responses.POST,
+            "http://us.testserver/extensions/github/webhook/",
+            status=200,
+            body="",
+        )
+        webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
+        webhook.update(provider=None)
+
+        drain_mailbox(webhook.id)
+
+        assert self.tags_for(mock_metrics, "hybridcloud.deliver_webhooks.delivery") == [
+            {"outcome": "ok", "provider": "unknown"}
+        ]
+
+    @override_options({"hybridcloud.webhookpayload.push_drain_trigger": True})
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_push_trigger_provider_from_mailbox_name(
+        self, mock_drain: MagicMock, mock_metrics: MagicMock
+    ) -> None:
+        # No payload row is loaded on this path, so the provider comes from the name.
+        webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
+
+        maybe_trigger_drain(webhook.mailbox_name)
+
+        assert self.tags_for(mock_metrics, "hybridcloud.deliver_webhooks.push_trigger.success") == [
+            {"provider": "github"}
+        ]
+
+    @override_options({"hybridcloud.webhookpayload.push_drain_trigger": True})
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    def test_race_provider_from_mailbox_name(self, mock_metrics: MagicMock) -> None:
+        drain_mailbox(999999, mailbox_name="gitlab:7")
+
+        assert self.tags_for(mock_metrics, "hybridcloud.deliver_webhooks.delivery") == [
+            {"outcome": "race", "provider": "gitlab"}
+        ]
+
+
+@control_silo_test
 class PushTriggerTest(TestCase):
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
     @override_options({"hybridcloud.webhookpayload.push_drain_trigger": True})

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -1329,6 +1329,38 @@ class ProviderMetricTagTest(TestCase):
             {"provider": "github"}
         ]
 
+    @responses.activate
+    @override_cells(cell_config)
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    def test_retry_tagged_from_failing_record_not_mailbox_head(
+        self, mock_metrics: MagicMock
+    ) -> None:
+        # The sequential drain loops over records but holds a separate reference to
+        # the mailbox head, so `retry` must read the record that actually failed.
+        responses.add(
+            responses.POST,
+            "http://us.testserver/extensions/github/webhook/",
+            status=200,
+            body="",
+        )
+        responses.add(
+            responses.POST,
+            "http://us.testserver/extensions/github/webhook/",
+            body=ReadTimeout(),
+        )
+        head = self.create_webhook_payload(
+            mailbox_name="github:123", cell_name="us", provider="github"
+        )
+        legacy = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
+        legacy.update(provider=None)
+
+        drain_mailbox(head.id)
+
+        assert self.tags_for(mock_metrics, "hybridcloud.deliver_webhooks.delivery") == [
+            {"outcome": "ok", "provider": "github"},
+            {"outcome": "retry", "provider": "unknown"},
+        ]
+
     @override_options({"hybridcloud.webhookpayload.push_drain_trigger": True})
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
     def test_race_provider_from_mailbox_name(self, mock_metrics: MagicMock) -> None:


### PR DESCRIPTION
### Why

The [Hybrid Cloud Webhook Forwarding](https://app.datadoghq.com/dashboard/tqt-8cb-xmj/hybrid-cloud-webhook-forwarding) dashboard has a `provider` template variable, but `deliver_webhooks.{delivery,saved,failure}` carry no such tag — only the `webhookpayload.mailbox.*` gauges do. Verified against Datadog: `sum:...delivery{*} by {provider}` returns zero series.

So selecting a provider does not filter those widgets, it **blanks** them, which reads as "no traffic" rather than "this metric cannot answer that question".

It also makes per-provider delivery health answerable at all. The 401s and 409s behind `failure` are ~376k/day between them and there is currently no way to see which integration they belong to.

### Where provider comes from

From the payload column wherever a row is loaded. Two paths have no row:

- **the push trigger** — `maybe_trigger_drain` only receives a mailbox name
- **the DoesNotExist race** — the row is already gone

Both read the first segment of the mailbox name. Mailboxes are `<provider>:<identifier>`, and it is the *identifier* that later gains bucket and event-type suffixes, so the first segment stays the provider. The column is nullable and rows predating it still drain through, hence the `unknown` fallback — matching what `record_mailbox_depth_metrics` already does.

### Rebased onto #121606

That PR added two new `delivery` outcomes — `conflict` and `dropped_4xx` — for payloads a cell permanently rejects. Both are tagged here too, so every `delivery` emission carries `provider`; otherwise those two would have been the only outcomes to vanish when a provider is selected, which is the exact failure this PR exists to remove.

### Deliberately left untagged

Following the cardinality restraint in #121601 ("every tag value costs a series per worker"):

- **`send_request` timer** — a timer is seven series, so this would be 7 × cells × providers, for a latency question `delivery_time_ms` already answers.
- **`schedule_webhook_delivery.mailbox_count`** — aggregates across every mailbox in a scheduler run, so there is no single provider to attribute it to.

### Cost

`delivery` goes to outcome × provider, `failure` to reason × cell × provider. Provider values are bounded by the integration list — Datadog currently sees 10 distinct values on the mailbox gauges.

