### PR TITLE
test(search): Add backend parser coverage for array typed tags

### DIFF
--- a/fixtures/search-syntax/explicit_array_tag.json
+++ b/fixtures/search-syntax/explicit_array_tag.json
@@ -1,0 +1,87 @@
+[
+  {
+    "query": "tags[fruit,array][*]:apple release:1.2.1 tags[project_id,array][*]:123",
+    "result": [
+      {
+        "type": "spaces",
+        "value": ""
+      },
+      {
+        "type": "filter",
+        "filter": "arrayIncludes",
+        "key": {
+          "type": "keyArrayIncludes",
+          "key": {
+            "type": "keyExplicitArrayTag",
+            "prefix": "tags",
+            "key": {
+              "type": "keySimple",
+              "value": "fruit",
+              "quoted": false
+            }
+          },
+          "index": "*"
+        },
+        "value": {
+          "type": "valueText",
+          "value": "apple",
+          "quoted": false
+        },
+        "negated": false,
+        "operator": ""
+      },
+      {
+        "type": "spaces",
+        "value": " "
+      },
+      {
+        "type": "filter",
+        "filter": "text",
+        "key": {
+          "type": "keySimple",
+          "value": "release",
+          "quoted": false
+        },
+        "value": {
+          "type": "valueText",
+          "value": "1.2.1",
+          "quoted": false
+        },
+        "negated": false,
+        "operator": ""
+      },
+      {
+        "type": "spaces",
+        "value": " "
+      },
+      {
+        "type": "filter",
+        "filter": "arrayIncludes",
+        "key": {
+          "type": "keyArrayIncludes",
+          "key": {
+            "type": "keyExplicitArrayTag",
+            "prefix": "tags",
+            "key": {
+              "type": "keySimple",
+              "value": "project_id",
+              "quoted": false
+            }
+          },
+          "index": "*"
+        },
+        "value": {
+          "type": "valueText",
+          "value": "123",
+          "quoted": false
+        },
+        "negated": false,
+        "operator": ""
+      },
+      {
+        "type": "spaces",
+        "value": ""
+      }
+    ]
+  }
+]

--- a/static/app/components/searchSyntax/parser.spec.tsx
+++ b/static/app/components/searchSyntax/parser.spec.tsx
@@ -101,6 +101,11 @@ function treeTransformer({tree, transform}: TreeTransformerOpts) {
           ...token,
           key: nodeVisitor(token.key),
         });
+      case Token.KEY_ARRAY_INCLUDES:
+        return transform({
+          ...token,
+          key: nodeVisitor(token.key),
+        });
       case Token.LOGIC_GROUP:
         return transform({
           ...token,

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -115,6 +115,15 @@ def result_transformer(result):
         if token["type"] == "keyExplicitBooleanTag":
             return SearchKey(name=f"tags[{token['key']['value']},boolean]")
 
+        if token["type"] == "keyExplicitArrayTag":
+            return SearchKey(name=f"tags[{token['key']['value']},array]")
+
+        if token["type"] == "keyArrayIncludes":
+            # The `[*]` membership suffix carries the operation, not the key
+            # name, so the backend key drops it and resolves to the inner
+            # (array tag or simple) key, matching visit_array_includes_key.
+            return node_visitor(token["key"])
+
         if token["type"] == "keyExplicitFlag":
             return SearchKey(name=f"flags[{token['key']['value']}]")
 


### PR DESCRIPTION
Adds a shared `fixtures/search-syntax/` acceptance case for array-tag search syntax, exercised by both the frontend and backend parsers so the two grammars stay in sync.

- `explicit_array_tag.json` — asserts `tags[<name>,array][*]:value` parses as an `arrayIncludes` filter (key `keyArrayIncludes` wrapping `keyExplicitArrayTag`, `index: "*"`) on both sides.
- `parser.spec.tsx` — recurse into `KEY_ARRAY_INCLUDES` when normalizing the parsed tree.
- `test_event_search.py` — map `keyArrayIncludes` to its inner key in `result_transformer`, matching `visit_array_includes_key`.

Refs EXP-1129
