### PR TITLE
fix(aci): Allow adding triggers to an alert with `triggers: null`

### DIFF
--- a/src/sentry/workflow_engine/endpoints/validators/base/data_condition_group.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/data_condition_group.py
@@ -46,17 +46,18 @@ class BaseDataConditionGroupValidator(CamelSnakeSerializer[Any]):
                 raise serializers.ValidationError("Triggers' logic type must be 'any-short'")
 
     def update_or_create_condition(
-        self, condition_data: dict[str, Any], organization_id: int
+        self, condition_data: dict[str, Any], condition_group_id: int
     ) -> DataCondition:
         validator = BaseDataConditionValidator()
         condition_id = condition_data.get("id")
 
         if condition_id:
             try:
-                # Validate that the condition belongs to this organization
+                # Validate that the condition already belongs to this condition group, preventing
+                # a condition from another group from being re-parented into this one.
                 condition = DataCondition.objects.get(
                     id=condition_id,
-                    condition_group__organization_id=organization_id,
+                    condition_group_id=condition_group_id,
                 )
             except DataCondition.DoesNotExist as exc:
                 raise serializers.ValidationError(
@@ -68,6 +69,15 @@ class BaseDataConditionGroupValidator(CamelSnakeSerializer[Any]):
             condition = validator.create(condition_data)
 
         return condition
+
+    def _validate_new_conditions(self, condition_data: list[dict[str, Any]]) -> None:
+        """
+        When creating a new data condition, ensure that the conditions don't reference existing conditions.
+        """
+        for condition in condition_data:
+            condition_id = condition.get("id")
+            if condition_id:
+                raise serializers.ValidationError(f"Condition with id {condition_id} not found.")
 
     def update(
         self,
@@ -87,7 +97,7 @@ class BaseDataConditionGroupValidator(CamelSnakeSerializer[Any]):
             for condition_data in conditions:
                 # Always set condition_group_id programmatically to prevent cross-org IDOR
                 condition_data["condition_group_id"] = instance.id
-                self.update_or_create_condition(condition_data, context_org.id)
+                self.update_or_create_condition(condition_data, instance.id)
 
         # update the condition group
         instance.update(**validated_data)
@@ -97,6 +107,7 @@ class BaseDataConditionGroupValidator(CamelSnakeSerializer[Any]):
         logic_type = validated_data.get("logic_type", DataConditionGroup.Type.ANY.value)
         conditions = validated_data.get("conditions", [])
         self._validate_logic_type(conditions, logic_type)
+        self._validate_new_conditions(conditions)
 
         with transaction.atomic(router.db_for_write(DataConditionGroup)):
             condition_group = DataConditionGroup.objects.create(

--- a/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
@@ -108,6 +108,12 @@ class WorkflowValidator(CamelSnakeSerializer[Any]):
         schema = Workflow.config_schema
         return validate_json_schema(value, schema)
 
+    def validate_triggers(self, value: InputData) -> InputData:
+        if "workflow" in self.context:
+            self._validate_trigger_ownership(value)
+
+        return value
+
     def validate_action_filters(self, value: ListInputData) -> ListInputData:
         if "workflow" in self.context:
             self._validate_action_filter_ownership(value)
@@ -260,6 +266,21 @@ class WorkflowValidator(CamelSnakeSerializer[Any]):
             self.update_or_create_actions(actions, condition_group)
 
         return condition_group
+
+    def _validate_trigger_ownership(self, triggers: InputData) -> None:
+        """
+        If a data_condition_group id is passed in, it must belong to the workflow being updated
+        to prevent claiming another workflow's group
+        """
+        workflow = self.context["workflow"]
+
+        condition_group_id = triggers.get("id")
+
+        if (
+            condition_group_id is not None
+            and int(condition_group_id) != workflow.when_condition_group_id
+        ):
+            raise serializers.ValidationError(f"Invalid Condition Group ID {condition_group_id}")
 
     def _validate_action_filter_ownership(self, action_filters: ListInputData) -> None:
         workflow = self.context["workflow"]

--- a/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
@@ -236,7 +236,7 @@ class WorkflowValidator(CamelSnakeSerializer[Any]):
 
     def update_or_create_data_condition_group(
         self,
-        condition_group_data: InputData,
+        condition_group_data: InputData | None,
         instance: DataConditionGroup | None = None,
     ) -> DataConditionGroup:
         validator = BaseDataConditionGroupValidator(context=self.context)
@@ -319,8 +319,15 @@ class WorkflowValidator(CamelSnakeSerializer[Any]):
         with transaction.atomic(router.db_for_write(Workflow)):
             # Update the Workflow.when_condition_group
             triggers = validated_data.pop("triggers", None)
+
             if triggers is not None:
-                self.update_or_create_data_condition_group(triggers, instance.when_condition_group)
+                when_condition_group = self.update_or_create_data_condition_group(
+                    triggers, instance.when_condition_group
+                )
+
+                # Bind new condition group to workflow if it didn't have one before
+                if instance.when_condition_group_id is None:
+                    instance.when_condition_group = when_condition_group
 
             # Update the Action Filters and Actions
             action_filters = validated_data.pop("action_filters", None)

--- a/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
@@ -236,7 +236,7 @@ class WorkflowValidator(CamelSnakeSerializer[Any]):
 
     def update_or_create_data_condition_group(
         self,
-        condition_group_data: InputData | None,
+        condition_group_data: InputData,
         instance: DataConditionGroup | None = None,
     ) -> DataConditionGroup:
         validator = BaseDataConditionGroupValidator(context=self.context)

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
@@ -367,7 +367,7 @@ class OrganizationUpdateWorkflowTest(OrganizationWorkflowDetailsBaseTest, BaseWo
             when_condition_group=None,
         )
 
-        assert workflow.when_condition_group is None
+        assert workflow.when_condition_group_id is None
 
         data = {
             **self.valid_workflow,
@@ -389,10 +389,11 @@ class OrganizationUpdateWorkflowTest(OrganizationWorkflowDetailsBaseTest, BaseWo
 
         workflow.refresh_from_db()
 
-        assert workflow.when_condition_group is not None
-        assert workflow.when_condition_group.logic_type == DataConditionGroup.Type.ANY_SHORT_CIRCUIT
-        assert workflow.when_condition_group.organization_id == self.organization.id
-        assert workflow.when_condition_group.conditions.count() == 1
+        when_condition_group = workflow.when_condition_group
+        assert when_condition_group is not None
+        assert when_condition_group.logic_type == DataConditionGroup.Type.ANY_SHORT_CIRCUIT
+        assert when_condition_group.organization_id == self.organization.id
+        assert when_condition_group.conditions.count() == 1
 
     def test_update_detectors_add_detector(self) -> None:
         detector1 = self.create_detector(project=self.project)

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
@@ -1004,8 +1004,9 @@ class OrganizationUpdateWorkflowTest(OrganizationWorkflowDetailsBaseTest, BaseWo
 
         other_workflow.refresh_from_db()
 
+        assert other_workflow.when_condition_group is not None
         assert other_workflow.when_condition_group.conditions.count() == 1
-        assert other_workflow.when_condition_group.conditions.first().id == other_data_condition.id
+        assert other_workflow.when_condition_group.conditions.first() == other_data_condition
 
     def test_update_trigger_conditions_from_same_organization_without_data_condition_group(
         self,
@@ -1064,8 +1065,9 @@ class OrganizationUpdateWorkflowTest(OrganizationWorkflowDetailsBaseTest, BaseWo
 
         other_workflow.refresh_from_db()
 
+        assert other_workflow.when_condition_group is not None
         assert other_workflow.when_condition_group.conditions.count() == 1
-        assert other_workflow.when_condition_group.conditions.first().id == other_data_condition.id
+        assert other_workflow.when_condition_group.conditions.first() == other_data_condition
 
     def test_update_trigger_conditions_from_different_organization(self) -> None:
         other_organization = self.create_organization()
@@ -1115,8 +1117,9 @@ class OrganizationUpdateWorkflowTest(OrganizationWorkflowDetailsBaseTest, BaseWo
 
         other_workflow.refresh_from_db()
 
+        assert other_workflow.when_condition_group is not None
         assert other_workflow.when_condition_group.conditions.count() == 1
-        assert other_workflow.when_condition_group.conditions.first().id == other_data_condition.id
+        assert other_workflow.when_condition_group.conditions.first() == other_data_condition
 
     def test_update_trigger_conditions_from_different_organization_without_data_condition_group(
         self,
@@ -1173,8 +1176,9 @@ class OrganizationUpdateWorkflowTest(OrganizationWorkflowDetailsBaseTest, BaseWo
 
         other_workflow.refresh_from_db()
 
+        assert other_workflow.when_condition_group is not None
         assert other_workflow.when_condition_group.conditions.count() == 1
-        assert other_workflow.when_condition_group.conditions.first().id == other_data_condition.id
+        assert other_workflow.when_condition_group.conditions.first() == other_data_condition
 
     def test_update_triggers_from_same_organization(self) -> None:
         other_data_condition_group = self.create_data_condition_group(
@@ -1209,7 +1213,7 @@ class OrganizationUpdateWorkflowTest(OrganizationWorkflowDetailsBaseTest, BaseWo
 
         other_workflow.refresh_from_db()
 
-        assert other_workflow.when_condition_group.id == other_data_condition_group.id
+        assert other_workflow.when_condition_group_id == other_data_condition_group.id
 
     def test_update_triggers_from_same_organization_without_data_condition_group(self) -> None:
         workflow = self.create_workflow(
@@ -1253,7 +1257,7 @@ class OrganizationUpdateWorkflowTest(OrganizationWorkflowDetailsBaseTest, BaseWo
 
         other_workflow.refresh_from_db()
 
-        assert other_workflow.when_condition_group.id == other_data_condition_group.id
+        assert other_workflow.when_condition_group_id == other_data_condition_group.id
 
     def test_update_triggers_from_different_organization(self) -> None:
         other_organization = self.create_organization()

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
@@ -855,45 +855,6 @@ class OrganizationUpdateWorkflowTest(OrganizationWorkflowDetailsBaseTest, BaseWo
         other_action.refresh_from_db()
         assert other_action.config == original_config
 
-    def test_update_trigger_condition_from_different_organization(self) -> None:
-        """Test that conditionGroupId in trigger conditions cannot reference another org's group"""
-        other_org = self.create_organization()
-        other_dcg = DataConditionGroup.objects.create(
-            organization=other_org,
-            logic_type=DataConditionGroup.Type.ALL,
-        )
-        original_condition_count = other_dcg.conditions.count()
-
-        data = {
-            **self.valid_workflow,
-            "triggers": {
-                "logicType": "any",
-                "conditions": [
-                    {
-                        "conditionGroupId": other_dcg.id,
-                        "type": "first_seen_event",
-                        "comparison": True,
-                        "conditionResult": True,
-                    }
-                ],
-            },
-        }
-
-        self.get_success_response(
-            self.organization.slug,
-            self.workflow.id,
-            raw_data=data,
-        )
-
-        # Workflow should be updated successfully, but the conditionGroupId should be ignored
-        self.workflow.refresh_from_db()
-        assert self.workflow.when_condition_group is not None
-        assert self.workflow.when_condition_group.organization_id == self.organization.id
-
-        # Verify the other org's condition group was not modified
-        other_dcg.refresh_from_db()
-        assert other_dcg.conditions.count() == original_condition_count
-
     def test_update_action_filter_condition_from_different_organization(self) -> None:
         """Test that conditionGroupId in action filter conditions cannot reference another org's group"""
         other_org = self.create_organization()
@@ -988,6 +949,398 @@ class OrganizationUpdateWorkflowTest(OrganizationWorkflowDetailsBaseTest, BaseWo
             status_code=400,
         )
         assert "not supported for activity triggers" in str(response.data)
+
+    """
+    Ensure data integrity for
+    1. data condition and data condition group updates
+    2. whether or not the request data is in the same organization or another
+    3. whether or not the workflow originally had a data condition group or not
+    2 x 2 x 2 scenarios = 8 tests
+    """
+
+    def test_update_trigger_conditions_from_same_organization(self) -> None:
+        other_data_condition_group = self.create_data_condition_group(
+            organization=self.organization,
+            logic_type=DataConditionGroup.Type.ALL,
+        )
+
+        other_data_condition = self.create_data_condition(
+            condition_group=other_data_condition_group,
+            type=Condition.FIRST_SEEN_EVENT,
+            comparison=True,
+            condition_result=True,
+        )
+
+        other_workflow = self.create_workflow(
+            organization=self.organization,
+            when_condition_group=other_data_condition_group,
+        )
+
+        data = {
+            **self.valid_workflow,
+            "triggers": {
+                "logicType": "any-short",
+                "conditions": [
+                    {
+                        "id": other_data_condition.id,
+                        "type": "first_seen_event",
+                        "comparison": True,
+                        "conditionResult": True,
+                    }
+                ],
+            },
+        }
+
+        response = self.get_error_response(
+            self.organization.slug,
+            self.workflow.id,
+            raw_data=data,
+            status_code=400,
+        )
+
+        response_data = str(response.data).lower()
+
+        assert "condition with id" in response_data and "not found" in response_data
+
+        other_workflow.refresh_from_db()
+
+        assert other_workflow.when_condition_group.conditions.count() == 1
+        assert other_workflow.when_condition_group.conditions.first().id == other_data_condition.id
+
+    def test_update_trigger_conditions_from_same_organization_without_data_condition_group(
+        self,
+    ) -> None:
+        workflow = self.create_workflow(
+            organization=self.organization,
+            when_condition_group=None,
+        )
+
+        other_data_condition_group = self.create_data_condition_group(
+            organization=self.organization,
+            logic_type=DataConditionGroup.Type.ALL,
+        )
+
+        other_data_condition = self.create_data_condition(
+            condition_group=other_data_condition_group,
+            type=Condition.FIRST_SEEN_EVENT,
+            comparison=True,
+            condition_result=True,
+        )
+
+        other_workflow = self.create_workflow(
+            organization=self.organization,
+            when_condition_group=other_data_condition_group,
+        )
+
+        data = {
+            **self.valid_workflow,
+            "triggers": {
+                "logicType": "any-short",
+                "conditions": [
+                    {
+                        "id": other_data_condition.id,
+                        "type": "first_seen_event",
+                        "comparison": True,
+                        "conditionResult": True,
+                    }
+                ],
+            },
+        }
+
+        response = self.get_error_response(
+            self.organization.slug,
+            workflow.id,
+            raw_data=data,
+            status_code=400,
+        )
+
+        response_data = str(response.data).lower()
+
+        assert "condition with id" in response_data and "not found" in response_data
+
+        workflow.refresh_from_db()
+
+        assert workflow.when_condition_group_id != other_data_condition_group.id
+
+        other_workflow.refresh_from_db()
+
+        assert other_workflow.when_condition_group.conditions.count() == 1
+        assert other_workflow.when_condition_group.conditions.first().id == other_data_condition.id
+
+    def test_update_trigger_conditions_from_different_organization(self) -> None:
+        other_organization = self.create_organization()
+
+        other_data_condition_group = self.create_data_condition_group(
+            organization=other_organization,
+            logic_type=DataConditionGroup.Type.ALL,
+        )
+
+        other_data_condition = self.create_data_condition(
+            condition_group=other_data_condition_group,
+            type=Condition.FIRST_SEEN_EVENT,
+            comparison=True,
+            condition_result=True,
+        )
+
+        other_workflow = self.create_workflow(
+            organization=other_organization,
+            when_condition_group=other_data_condition_group,
+        )
+
+        data = {
+            **self.valid_workflow,
+            "triggers": {
+                "logicType": "any-short",
+                "conditions": [
+                    {
+                        "id": other_data_condition.id,
+                        "type": "first_seen_event",
+                        "comparison": True,
+                        "conditionResult": True,
+                    }
+                ],
+            },
+        }
+
+        response = self.get_error_response(
+            self.organization.slug,
+            self.workflow.id,
+            raw_data=data,
+            status_code=400,
+        )
+
+        response_data = str(response.data).lower()
+
+        assert "condition with id" in response_data and "not found" in response_data
+
+        other_workflow.refresh_from_db()
+
+        assert other_workflow.when_condition_group.conditions.count() == 1
+        assert other_workflow.when_condition_group.conditions.first().id == other_data_condition.id
+
+    def test_update_trigger_conditions_from_different_organization_without_data_condition_group(
+        self,
+    ) -> None:
+        workflow = self.create_workflow(
+            organization=self.organization,
+            when_condition_group=None,
+        )
+
+        other_organization = self.create_organization()
+
+        other_data_condition_group = self.create_data_condition_group(
+            organization=other_organization,
+            logic_type=DataConditionGroup.Type.ALL,
+        )
+
+        other_data_condition = self.create_data_condition(
+            condition_group=other_data_condition_group,
+            type=Condition.FIRST_SEEN_EVENT,
+            comparison=True,
+            condition_result=True,
+        )
+
+        other_workflow = self.create_workflow(
+            organization=other_organization,
+            when_condition_group=other_data_condition_group,
+        )
+
+        data = {
+            **self.valid_workflow,
+            "triggers": {
+                "logicType": "any-short",
+                "conditions": [
+                    {
+                        "id": other_data_condition.id,
+                        "type": "first_seen_event",
+                        "comparison": True,
+                        "conditionResult": True,
+                    }
+                ],
+            },
+        }
+
+        response = self.get_error_response(
+            self.organization.slug,
+            workflow.id,
+            raw_data=data,
+            status_code=400,
+        )
+
+        response_data = str(response.data).lower()
+
+        assert "condition with id" in response_data and "not found" in response_data
+
+        other_workflow.refresh_from_db()
+
+        assert other_workflow.when_condition_group.conditions.count() == 1
+        assert other_workflow.when_condition_group.conditions.first().id == other_data_condition.id
+
+    def test_update_triggers_from_same_organization(self) -> None:
+        other_data_condition_group = self.create_data_condition_group(
+            organization=self.organization,
+            logic_type=DataConditionGroup.Type.ALL,
+        )
+
+        other_workflow = self.create_workflow(
+            organization=self.organization,
+            when_condition_group=other_data_condition_group,
+        )
+
+        data = {
+            **self.valid_workflow,
+            "triggers": {
+                "id": other_data_condition_group.id,
+                "logicType": "any-short",
+                "conditions": [],
+            },
+        }
+
+        response = self.get_error_response(
+            self.organization.slug,
+            self.workflow.id,
+            raw_data=data,
+            status_code=400,
+        )
+
+        response_data = str(response.data).lower()
+
+        assert "invalid condition group id" in response_data
+
+        other_workflow.refresh_from_db()
+
+        assert other_workflow.when_condition_group.id == other_data_condition_group.id
+
+    def test_update_triggers_from_same_organization_without_data_condition_group(self) -> None:
+        workflow = self.create_workflow(
+            organization=self.organization,
+            when_condition_group=None,
+        )
+
+        other_data_condition_group = self.create_data_condition_group(
+            organization=self.organization,
+            logic_type=DataConditionGroup.Type.ALL,
+        )
+
+        other_workflow = self.create_workflow(
+            organization=self.organization,
+            when_condition_group=other_data_condition_group,
+        )
+
+        data = {
+            **self.valid_workflow,
+            "triggers": {
+                "id": other_data_condition_group.id,
+                "logicType": "any-short",
+                "conditions": [],
+            },
+        }
+
+        response = self.get_error_response(
+            self.organization.slug,
+            workflow.id,
+            raw_data=data,
+            status_code=400,
+        )
+
+        response_data = str(response.data).lower()
+
+        assert "invalid condition group id" in response_data
+
+        workflow.refresh_from_db()
+
+        assert workflow.when_condition_group_id is None
+
+        other_workflow.refresh_from_db()
+
+        assert other_workflow.when_condition_group.id == other_data_condition_group.id
+
+    def test_update_triggers_from_different_organization(self) -> None:
+        other_organization = self.create_organization()
+
+        other_data_condition_group = self.create_data_condition_group(
+            organization=other_organization,
+            logic_type=DataConditionGroup.Type.ALL,
+        )
+
+        other_workflow = self.create_workflow(
+            organization=other_organization,
+            when_condition_group=other_data_condition_group,
+        )
+
+        data = {
+            **self.valid_workflow,
+            "triggers": {
+                "id": other_data_condition_group.id,
+                "logicType": "any-short",
+                "conditions": [],
+            },
+        }
+
+        response = self.get_error_response(
+            self.organization.slug,
+            self.workflow.id,
+            raw_data=data,
+            status_code=400,
+        )
+
+        response_data = str(response.data).lower()
+
+        assert "invalid condition group id" in response_data
+
+        self.workflow.refresh_from_db()
+
+        assert self.workflow.when_condition_group_id != other_data_condition_group.id
+
+        other_workflow.refresh_from_db()
+
+        assert other_workflow.when_condition_group_id == other_data_condition_group.id
+
+    def test_update_triggers_from_different_organization_without_data_condition_group(self) -> None:
+        workflow = self.create_workflow(
+            organization=self.organization,
+            when_condition_group=None,
+        )
+
+        other_organization = self.create_organization()
+
+        other_data_condition_group = self.create_data_condition_group(
+            organization=other_organization,
+            logic_type=DataConditionGroup.Type.ALL,
+        )
+
+        other_workflow = self.create_workflow(
+            organization=other_organization,
+            when_condition_group=other_data_condition_group,
+        )
+
+        data = {
+            **self.valid_workflow,
+            "triggers": {
+                "id": other_data_condition_group.id,
+                "logicType": "any-short",
+                "conditions": [],
+            },
+        }
+
+        response = self.get_error_response(
+            self.organization.slug,
+            workflow.id,
+            raw_data=data,
+            status_code=400,
+        )
+
+        response_data = str(response.data).lower()
+
+        assert "invalid condition group id" in response_data
+
+        workflow.refresh_from_db()
+
+        assert workflow.when_condition_group_id is None
+
+        other_workflow.refresh_from_db()
+
+        assert other_workflow.when_condition_group_id == other_data_condition_group.id
 
 
 @cell_silo_test

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
@@ -359,6 +359,41 @@ class OrganizationUpdateWorkflowTest(OrganizationWorkflowDetailsBaseTest, BaseWo
         assert workflow.when_condition_group is not None
         assert workflow.when_condition_group.conditions.count() == 0
 
+    def test_update_triggers_when_workflow_has_no_when_condition_group(self) -> None:
+        """Test that updating triggers on a workflow without a when_condition_group connects
+        the newly created condition group to the workflow"""
+        workflow = self.create_workflow(
+            organization=self.organization,
+            when_condition_group=None,
+        )
+
+        assert workflow.when_condition_group is None
+
+        data = {
+            **self.valid_workflow,
+            "triggers": {
+                "logicType": "any-short",
+                "conditions": [
+                    {"type": "every_event", "comparison": True, "conditionResult": True},
+                ],
+            },
+        }
+
+        response = self.get_success_response(self.organization.slug, workflow.id, raw_data=data)
+
+        assert response.status_code == 200
+        assert response.data["triggers"] is not None
+        assert response.data["triggers"]["logicType"] == "any-short"
+        assert len(response.data["triggers"]["conditions"]) == 1
+        assert response.data["triggers"]["conditions"][0]["type"] == "every_event"
+
+        workflow.refresh_from_db()
+
+        assert workflow.when_condition_group is not None
+        assert workflow.when_condition_group.logic_type == DataConditionGroup.Type.ANY_SHORT_CIRCUIT
+        assert workflow.when_condition_group.organization_id == self.organization.id
+        assert workflow.when_condition_group.conditions.count() == 1
+
     def test_update_detectors_add_detector(self) -> None:
         detector1 = self.create_detector(project=self.project)
         detector2 = self.create_detector(project=self.project, type=MetricIssue.slug)

--- a/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
@@ -809,10 +809,24 @@ class TestWorkflowValidatorUpdate(TestCase):
         }
 
         validator = WorkflowValidator(data=self.valid_saved_data, context=self.context)
-        assert validator.is_valid() is True
 
-        with pytest.raises(ValidationError):
-            validator.update(self.workflow, validator.validated_data)
+        with pytest.raises(ValidationError) as excinfo:
+            validator.is_valid(raise_exception=True)
+
+        assert excinfo.value.detail == {
+            "triggers": [
+                ErrorDetail(
+                    string=f"Invalid Condition Group ID {fake_dcg.id}",
+                    code="invalid",
+                )
+            ]
+        }
+
+        # The workflow keeps its own trigger group, and the other group is untouched
+        self.workflow.refresh_from_db()
+
+        assert self.workflow.when_condition_group_id != fake_dcg.id
+        assert fake_dcg.conditions.count() == 0
 
     def test_update__remove_action_filter(self, mock_action_validator: mock.MagicMock) -> None:
         self.valid_saved_data["actionFilters"] = []


### PR DESCRIPTION
If `triggers: null` it would create a row in the DB for the DataConditionGroup but it would not set the foreign key on the Workflow (the alert) so nothing actually changed