### PR TITLE
feat(seer): Persist code change diffs in milestone extras

### DIFF
--- a/src/sentry/seer/milestones.py
+++ b/src/sentry/seer/milestones.py
@@ -57,8 +57,16 @@ def milestones_from_state(state: SeerRunState) -> dict[str, SeerRunMilestoneExtr
         result[SeerRunMilestoneType.SOLUTION] = (
             {"solution_artifact": {"one_line_summary": summary}} if isinstance(summary, str) else {}
         )
-    if state.get_diffs_by_repo():
-        result[SeerRunMilestoneType.CODE_CHANGES] = {}
+    diffs_by_repo = state.get_diffs_by_repo()
+    if diffs_by_repo:
+        result[SeerRunMilestoneType.CODE_CHANGES] = {
+            "code_changes_artifact": {
+                "diffs_by_repo": {
+                    repo_name: [patch.dict() for patch in patches]
+                    for repo_name, patches in diffs_by_repo.items()
+                }
+            }
+        }
     if _has_pull_request(state):
         result[SeerRunMilestoneType.HAS_PULL_REQUEST] = {}
     return result

--- a/src/sentry/seer/models/run.py
+++ b/src/sentry/seer/models/run.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import Any, TypedDict
 from uuid import uuid4
 
 from django.db import models
@@ -142,9 +142,15 @@ class SolutionArtifactExtras(TypedDict):
     one_line_summary: str
 
 
+class CodeChangesArtifactExtras(TypedDict):
+    # Each patch is AgentFilePatch.dict() verbatim; read back with AgentFilePatch.parse_obj.
+    diffs_by_repo: dict[str, list[dict[str, Any]]]
+
+
 class SeerRunMilestoneExtras(TypedDict, total=False):
     root_cause_artifact: RootCauseArtifactExtras
     solution_artifact: SolutionArtifactExtras
+    code_changes_artifact: CodeChangesArtifactExtras
 
 
 @cell_silo_model

--- a/tests/sentry/seer/test_milestones.py
+++ b/tests/sentry/seer/test_milestones.py
@@ -7,7 +7,9 @@ from sentry.seer.agent.client_models import (
     Artifact,
     CodingAgentResult,
     CodingAgentState,
+    DiffLine,
     FilePatch,
+    Hunk,
     MemoryBlock,
     Message,
     RepoPRState,
@@ -81,6 +83,52 @@ def _block(
             else None
         ),
         pr_commit_shas=pr_commit_shas,
+    )
+
+
+def _agent_file_patch(path: str = "a.py", value: str = "+added line") -> AgentFilePatch:
+    return AgentFilePatch(
+        repo_name="getsentry/sentry",
+        patch=FilePatch(
+            path=path,
+            type="M",
+            added=1,
+            removed=0,
+            source_file=path,
+            target_file=path,
+            hunks=[
+                Hunk(
+                    source_start=1,
+                    source_length=1,
+                    target_start=1,
+                    target_length=2,
+                    section_header="@@ -1,1 +1,2 @@",
+                    lines=[
+                        DiffLine(
+                            diff_line_no=1,
+                            source_line_no=None,
+                            target_line_no=2,
+                            line_type="+",
+                            value=value,
+                        )
+                    ],
+                )
+            ],
+        ),
+        diff=f"--- a/{path}\n+++ b/{path}\n@@ -1,1 +1,2 @@\n{value}\n",
+    )
+
+
+def _diff_state(*patches: AgentFilePatch) -> SeerRunState:
+    return _state(
+        blocks=[
+            MemoryBlock(
+                id="b",
+                message=Message(role="assistant", content="c"),
+                timestamp="2026-02-10T00:00:00Z",
+                merged_file_patches=list(patches),
+            )
+        ]
     )
 
 
@@ -182,6 +230,26 @@ class MilestonesFromStateTest(TestCase):
         result = milestones_from_state(state)
         assert result[SeerRunMilestoneType.HAS_PULL_REQUEST] == {}
 
+    def test_code_changes_extras_hold_diffs_grouped_by_repo(self) -> None:
+        patch = _agent_file_patch()
+        result = milestones_from_state(_diff_state(patch))
+
+        assert result[SeerRunMilestoneType.CODE_CHANGES] == {
+            "code_changes_artifact": {"diffs_by_repo": {"getsentry/sentry": [patch.dict()]}}
+        }
+
+    def test_no_code_changes_milestone_without_merged_file_patches(self) -> None:
+        block = MemoryBlock(
+            id="b",
+            message=Message(role="assistant", content="c"),
+            timestamp="2026-02-10T00:00:00Z",
+            merged_file_patches=None,
+        )
+        assert SeerRunMilestoneType.CODE_CHANGES not in milestones_from_state(
+            _state(blocks=[block])
+        )
+        assert SeerRunMilestoneType.CODE_CHANGES not in milestones_from_state(_diff_state())
+
     def test_extra_unexpected_artifact_field_is_not_stored(self) -> None:
         block = MemoryBlock(
             id="b",
@@ -235,6 +303,23 @@ class ReconcileMilestonesTest(TestCase):
         reconcile_milestones(self.seer_run, self._root_cause_state("second"))
         assert self._extras(SeerRunMilestoneType.ROOT_CAUSE) == {
             "root_cause_artifact": {"one_line_description": "second"}
+        }
+
+    def test_reconcile_persists_code_changes_diffs(self) -> None:
+        patch = _agent_file_patch()
+        reconcile_milestones(self.seer_run, _diff_state(patch))
+
+        assert self._extras(SeerRunMilestoneType.CODE_CHANGES) == {
+            "code_changes_artifact": {"diffs_by_repo": {"getsentry/sentry": [patch.dict()]}}
+        }
+
+    def test_reconcile_refreshes_code_changes_diffs_on_rerun(self) -> None:
+        reconcile_milestones(self.seer_run, _diff_state(_agent_file_patch(path="a.py")))
+        second = _agent_file_patch(path="b.py", value="+other line")
+        reconcile_milestones(self.seer_run, _diff_state(second))
+
+        assert self._extras(SeerRunMilestoneType.CODE_CHANGES) == {
+            "code_changes_artifact": {"diffs_by_repo": {"getsentry/sentry": [second.dict()]}}
         }
 
     def test_reconcile_sets_date_updated_on_insert_and_conflict_update(self) -> None:


### PR DESCRIPTION
The CODE_CHANGES milestone recorded that a run produced diffs but not what they were, so the file changes couldn't be shown without re-fetching the full Seer run state. This stores the generated diffs on the milestone so downstream consumers can read them directly.

When the CODE_CHANGES milestone is derived from run state, the deduped per-repo file patches from `SeerRunState.get_diffs_by_repo()` are now serialized into `extras["code_changes_artifact"]["diffs_by_repo"]` (repo name → list of `AgentFilePatch`). The dedup (latest patch per file) is reused from the existing helper rather than reimplemented, and the stored shape is the same parsed `FilePatch`/`hunks`/`lines` structure the frontend diff viewer already consumes. No migration is needed — the value rides the existing `extras` JSONField.

Reviewers: the behavior change is isolated to `milestones_from_state` in `milestones.py`; `run.py` only widens the `SeerRunMilestoneExtras` TypedDict with the new key.