### PR TITLE
chore(mypy): exclude bin/ from type checking

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,6 +48,7 @@ repos:
         stages: [pre-push]
         types: [python]
         require_serial: true
+        exclude: ^bin/
       - id: lint-requirements
         name: lint-requirements
         entry: python -m tools.lint_requirements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -314,7 +314,7 @@ num_workers = 5
 mypy_path = ["fixtures/stubs-for-mypy"]
 plugins = ["pydantic.mypy", "mypy_django_plugin.main", "tools.mypy_helpers.plugin"]
 files = ["."]
-exclude = ["^.venv/", "^venv/", "^self-hosted/"]
+exclude = ["^.venv/", "^venv/", "^self-hosted/", "^bin/"]
 
 # minimal strictness settings
 check_untyped_defs = true
@@ -402,7 +402,6 @@ disable_error_code = [
 # - python3 -m tools.mypy_helpers.find_easiest_modules
 [[tool.mypy.overrides]]
 module = [
-    "bin.*",
     "bitfield.*",
     "django_picklefield.*",
     "fixtures.apidocs_test_case",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Exclude top-level `bin/` from mypy in all invocations (CI bare `mypy`, local discovery, IDE), not only pre-commit.

- Add `"^bin/"` to `[tool.mypy] exclude` in `pyproject.toml`
- Remove `"bin.*"` from the mypy weaklist (no longer discovered)
- Add `exclude: ^bin/` on the pre-push mypy hook so explicit `--files` paths cannot reintroduce checking

## Why both files change

`exclude` only governs recursive directory discovery; it does not apply to files passed explicitly as CLI arguments, which is exactly what the pre-push hook does via `"$@"`. Without the hook-level `exclude`, editing a `bin/` script would still type check it — and more strictly than before, since dropping the weaklist entry removes the relaxed settings that used to apply.

mypy also follows imports into excluded modules, so an excluded script that is imported by checked code still gets checked. That does not apply here: nothing in the repo imports `bin` or `bin.*`, so no `follow_imports` override is needed (adding one would just be an unused config section). The companion getsentry change does need one, because `tests/bin/` imports those scripts.

## Verification

- `check_stronglist` passes
- mypy source discovery: 5 `bin/` modules → 0 with the new exclude

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's [choice of terms](https://docs.sentry.io/internal/contributing/#submit-a-pull-request).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-021d2276-8534-4842-b086-9adf2b0f6264?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-021d2276-8534-4842-b086-9adf2b0f6264&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

