### PR TITLE
feat: Register agentic-triage-free-cohort-killswitch FlagPole flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -43,6 +43,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Organization scoped features that are in development or in customer trials. #
     ###############################################################################
 
+    # Kill switch for the agentic triage free cohort — disabling this flag shuts off night shift for all free cohort orgs
+    manager.add("organizations:agentic-triage-free-cohort-killswitch", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable agentic triage sort for night shift candidate selection
     manager.add("organizations:agentic-triage-sort", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enables alert creation on indexed events in UI (use for PoC/testing only)


### PR DESCRIPTION
## Summary
- Registers `organizations:agentic-triage-free-cohort-killswitch` as a `FLAGPOLE` feature with `api_expose=True` in `temporary.py`
- This is a global kill switch for the agentic triage free cohort feature — when disabled, night shift is shut off for all free cohort orgs instantly without a deploy
- Part of the agentic triage free cohort rollout: giving ~5000 non-paying orgs access to night shift. Eligibility path, quota bypass, and UI changes to follow in subsequent PRs.

## Test plan
- [ ] Flag is registered and available for FlagPole rollout config
- [ ] Flag appears in `organization.features` on the frontend when enabled (verified via `api_expose=True`)