### PR TITLE
fix(dashboards): Prevent threshold color indicators from being squished

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/thresholds.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/thresholds.tsx
@@ -75,7 +75,9 @@ function ThresholdRow({
 
   return (
     <Flex align="center" gap="xl">
-      <CircleIndicator color={color} size={WIDGET_INDICATOR_SIZE} />
+      <IndicatorWrapper>
+        <CircleIndicator color={color} size={WIDGET_INDICATOR_SIZE} />
+      </IndicatorWrapper>
       <StyledNumberField {...minInputProps} inline={false} disabled />
       {t('to')}
       <StyledNumberField onChange={handleChange} {...maxInputProps} inline={false} />
@@ -215,6 +217,10 @@ const ThresholdsContainer = styled('div')`
     padding: 0;
     border-bottom: none;
   }
+`;
+
+const IndicatorWrapper = styled('div')`
+  flex-shrink: 0;
 `;
 
 const StyledNumberField = styled(NumberField)`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The threshold color indicators (green, orange, red circles) in the Widget Builder were getting squished into ovals when the window was shrunk horizontally. This happened because the `CircleIndicator` components were direct children of a `Flex` container, and flex items have `flex-shrink: 1` by default, allowing them to shrink below their minimum content size.

![Screenshot showing squished indicators](https://uploads.linear.app/3ed206af-f87a-40aa-82a0-150bf83e43e6/d86e776f-6f13-4648-8743-220157ef11df/2d4045c8-0612-466c-91bd-80e26daf24ac)

## Solution

Wrapped each `CircleIndicator` in an `IndicatorWrapper` div with `flex-shrink: 0`. This prevents the indicators from shrinking and ensures they maintain their circular shape even when horizontal space is constrained.

## Manual Testing

To verify the fix:
1. Navigate to a dashboard and open the Widget Builder
2. Go to the Thresholds section
3. Shrink the browser window horizontally until the Widget Builder starts to shrink
4. Verify that the green, orange, and red circle indicators remain perfectly circular (not squished into ovals)

Fixes [DAIN-1816](https://linear.app/sentry/issue/DAIN-1816)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DAIN-1816](https://linear.app/getsentry/issue/DAIN-1816/threshold-colour-indicators-are-squished-in-widget-builder)

<div><a href="https://cursor.com/agents/bc-084dbbe8-be15-4c1f-a53b-e964c3a4144c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-084dbbe8-be15-4c1f-a53b-e964c3a4144c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

