### PR TITLE
fix(traces): Replace count(span.duration) with count(spans) in explore equations

### DIFF
--- a/static/app/components/arithmeticBuilder/token/function.tsx
+++ b/static/app/components/arithmeticBuilder/token/function.tsx
@@ -246,8 +246,25 @@ function InternalInput({
   const hasNextArgument = argumentIndex < functionToken.attributes.length - 1;
   const hasPrevArgument = argumentIndex > 0;
 
+  const {
+    dispatch,
+    functionArguments: builderFunctionArguments,
+    getFieldDefinition,
+    getSuggestedKey,
+  } = useArithmeticBuilder();
+
+  const parameterDefinition = useMemo(
+    () => getFieldDefinition(functionToken.function)?.parameters?.[argumentIndex],
+    [argumentIndex, getFieldDefinition, functionToken]
+  );
+
+  const initialLabel =
+    parameterDefinition?.kind === 'column' && parameterDefinition.defaultLabel
+      ? parameterDefinition.defaultLabel
+      : argument.label;
+
   const [inputValue, setInputValue] = useState('');
-  const [currentValue, setCurrentValue] = useState(argument.label);
+  const [currentValue, setCurrentValue] = useState(initialLabel);
   const [isCurrentlyEditing, setIsCurrentlyEditing] = useState(false);
   const [_selectionIndex, setSelectionIndex] = useState(0); // TODO
   const [_isOpen, setIsOpen] = useState(false); // TODO
@@ -263,18 +280,6 @@ function InternalInput({
     setInputValue('');
     updateSelectionIndex();
   }, [updateSelectionIndex]);
-
-  const {
-    dispatch,
-    functionArguments: builderFunctionArguments,
-    getFieldDefinition,
-    getSuggestedKey,
-  } = useArithmeticBuilder();
-
-  const parameterDefinition = useMemo(
-    () => getFieldDefinition(functionToken.function)?.parameters?.[argumentIndex],
-    [argumentIndex, getFieldDefinition, functionToken]
-  );
 
   const updateAttrsWith = useCallback(
     (value: string) => {
@@ -400,7 +405,11 @@ function InternalInput({
       value = getSuggestedKey(value) ?? value;
     }
 
-    setCurrentValue(value);
+    const commitLabel =
+      parameterDefinition?.kind === 'column' && parameterDefinition.defaultLabel
+        ? parameterDefinition.defaultLabel
+        : value;
+    setCurrentValue(commitLabel);
     onArgumentsChange(argumentIndex, value);
 
     dispatch({
@@ -540,8 +549,11 @@ function InternalInput({
 
   const onOptionSelected = useCallback(
     (option: SelectOptionWithKey<string>) => {
-      // Check if there's a next argument to focus on
-      setCurrentValue(prettifyTagKey(option.value));
+      const displayLabel =
+        parameterDefinition?.kind === 'column' && parameterDefinition.defaultLabel
+          ? parameterDefinition.defaultLabel
+          : prettifyTagKey(option.value);
+      setCurrentValue(displayLabel);
       if (hasNextArgument) {
         focusTarget(
           argumentsListState,
@@ -566,6 +578,7 @@ function InternalInput({
     },
     [
       hasNextArgument,
+      parameterDefinition,
       resetInputValue,
       argumentsListState,
       argumentItem.key,
@@ -611,14 +624,22 @@ function InternalInput({
 
   return (
     <ArgumentGridRow {...rowProps} tabIndex={isFocused ? 0 : -1} ref={gridCellRef}>
-      <ArgumentGridCell {...gridCellProps}>
+      <ArgumentGridCell
+        {...rowProps}
+        {...gridCellProps}
+        tabIndex={isFocused ? 0 : -1}
+        ref={gridCellRef}
+      >
         <ComboBox
           items={items}
           ref={inputRef}
           placeholder={
-            parameterDefinition?.kind === 'value' && 'placeholder' in parameterDefinition
-              ? (argument.label ?? parameterDefinition.placeholder)
-              : argument.label
+            parameterDefinition?.kind === 'column' && parameterDefinition.defaultLabel
+              ? parameterDefinition.defaultLabel
+              : parameterDefinition?.kind === 'value' &&
+                  'placeholder' in parameterDefinition
+                ? (argument.label ?? parameterDefinition.placeholder)
+                : argument.label
           }
           inputLabel={
             parameterDefinition?.kind === 'column'

--- a/static/app/components/arithmeticBuilder/token/function.tsx
+++ b/static/app/components/arithmeticBuilder/token/function.tsx
@@ -85,10 +85,25 @@ function ArgumentsGrid({
   token: functionToken,
   rowRef,
 }: ArgumentsGridProps) {
+  const {getFieldDefinition} = useArithmeticBuilder();
+
+  const resolveArgumentLabel = useCallback(
+    (index: number, fallbackLabel: string) => {
+      const fieldDefinition = getFieldDefinition(functionToken.function)?.parameters?.[
+        index
+      ];
+      if (fieldDefinition?.kind === 'column') {
+        return fieldDefinition?.defaultLabel ?? fallbackLabel;
+      }
+      return fallbackLabel;
+    },
+    [getFieldDefinition, functionToken]
+  );
+
   const [args, setArguments] = useState(
-    functionToken.attributes.map(attr => {
+    functionToken.attributes.map((attr, index) => {
       return {
-        label: attr.attribute,
+        label: resolveArgumentLabel(index, attr.attribute),
         value: attr.text,
       };
     })
@@ -97,7 +112,13 @@ function ArgumentsGrid({
   const updateArgumentAtIndex = (index: number, argument: string) => {
     setArguments(prev =>
       prev.map((item, i) =>
-        index === i ? {...item, value: argument, label: prettifyTagKey(argument)} : item
+        index === i
+          ? {
+              ...item,
+              value: argument,
+              label: resolveArgumentLabel(index, prettifyTagKey(argument)),
+            }
+          : item
       )
     );
   };
@@ -343,7 +364,22 @@ function InternalInput({
         }));
     }
 
-    // Otherwise, use the attribute-based items
+    if (
+      parameterDefinition?.kind === 'column' &&
+      parameterDefinition.defaultLabel &&
+      parameterDefinition.defaultValue
+    ) {
+      return attributeItems.map(item =>
+        item.value === parameterDefinition.defaultValue
+          ? {
+              ...item,
+              label: parameterDefinition.defaultLabel!,
+              textValue: parameterDefinition.defaultLabel!,
+            }
+          : item
+      );
+    }
+
     return attributeItems;
   }, [parameterDefinition, filterValue, attributeItems]);
 
@@ -360,11 +396,27 @@ function InternalInput({
     setIsCurrentlyEditing(false);
   }, [resetInputValue]);
 
+  const resolveValue = useCallback(
+    (raw: string): string => {
+      if (
+        parameterDefinition?.kind === 'column' &&
+        parameterDefinition.defaultLabel &&
+        parameterDefinition.defaultValue &&
+        raw === parameterDefinition.defaultLabel
+      ) {
+        return parameterDefinition.defaultValue;
+      }
+      return raw;
+    },
+    [parameterDefinition]
+  );
+
   const onTextInputBlur = useCallback(() => {
     if (inputValue) {
-      onArgumentsChange(argumentIndex, inputValue);
+      const resolved = resolveValue(inputValue);
+      onArgumentsChange(argumentIndex, resolved);
       dispatch({
-        text: `${functionToken.function}(${updateAttrsWith(inputValue)})`,
+        text: `${functionToken.function}(${updateAttrsWith(resolved)})`,
         type: 'REPLACE_TOKEN',
         token: functionToken,
         focusOverride: {
@@ -386,6 +438,7 @@ function InternalInput({
     inputValue,
     onArgumentsChange,
     resetInputValue,
+    resolveValue,
     updateAttrsWith,
   ]);
 
@@ -404,6 +457,8 @@ function InternalInput({
     if (defined(getSuggestedKey) && parameterDefinition?.kind === 'column') {
       value = getSuggestedKey(value) ?? value;
     }
+
+    value = resolveValue(value);
 
     const commitLabel =
       parameterDefinition?.kind === 'column' && parameterDefinition.defaultLabel
@@ -430,6 +485,7 @@ function InternalInput({
     argument.label,
     getSuggestedKey,
     parameterDefinition,
+    resolveValue,
     onArgumentsChange,
     argumentIndex,
     dispatch,

--- a/static/app/components/arithmeticBuilder/token/function.tsx
+++ b/static/app/components/arithmeticBuilder/token/function.tsx
@@ -279,10 +279,15 @@ function InternalInput({
     [argumentIndex, getFieldDefinition, functionToken]
   );
 
-  const initialLabel =
-    parameterDefinition?.kind === 'column' && parameterDefinition.defaultLabel
-      ? parameterDefinition.defaultLabel
-      : argument.label;
+  const resolveDisplayLabel = useCallback(
+    (fallback: string): string =>
+      parameterDefinition?.kind === 'column' && parameterDefinition.defaultLabel
+        ? parameterDefinition.defaultLabel
+        : fallback,
+    [parameterDefinition]
+  );
+
+  const initialLabel = resolveDisplayLabel(argument.label);
 
   const [inputValue, setInputValue] = useState('');
   const [currentValue, setCurrentValue] = useState(initialLabel);
@@ -413,10 +418,9 @@ function InternalInput({
 
   const onTextInputBlur = useCallback(() => {
     if (inputValue) {
-      const resolved = resolveValue(inputValue);
-      onArgumentsChange(argumentIndex, resolved);
+      onArgumentsChange(argumentIndex, inputValue);
       dispatch({
-        text: `${functionToken.function}(${updateAttrsWith(resolved)})`,
+        text: `${functionToken.function}(${updateAttrsWith(inputValue)})`,
         type: 'REPLACE_TOKEN',
         token: functionToken,
         focusOverride: {
@@ -438,7 +442,6 @@ function InternalInput({
     inputValue,
     onArgumentsChange,
     resetInputValue,
-    resolveValue,
     updateAttrsWith,
   ]);
 
@@ -460,11 +463,7 @@ function InternalInput({
 
     value = resolveValue(value);
 
-    const commitLabel =
-      parameterDefinition?.kind === 'column' && parameterDefinition.defaultLabel
-        ? parameterDefinition.defaultLabel
-        : value;
-    setCurrentValue(commitLabel);
+    setCurrentValue(resolveDisplayLabel(value));
     onArgumentsChange(argumentIndex, value);
 
     dispatch({
@@ -485,6 +484,7 @@ function InternalInput({
     argument.label,
     getSuggestedKey,
     parameterDefinition,
+    resolveDisplayLabel,
     resolveValue,
     onArgumentsChange,
     argumentIndex,
@@ -605,11 +605,7 @@ function InternalInput({
 
   const onOptionSelected = useCallback(
     (option: SelectOptionWithKey<string>) => {
-      const displayLabel =
-        parameterDefinition?.kind === 'column' && parameterDefinition.defaultLabel
-          ? parameterDefinition.defaultLabel
-          : prettifyTagKey(option.value);
-      setCurrentValue(displayLabel);
+      setCurrentValue(resolveDisplayLabel(prettifyTagKey(option.value)));
       if (hasNextArgument) {
         focusTarget(
           argumentsListState,
@@ -634,7 +630,7 @@ function InternalInput({
     },
     [
       hasNextArgument,
-      parameterDefinition,
+      resolveDisplayLabel,
       resetInputValue,
       argumentsListState,
       argumentItem.key,
@@ -680,22 +676,14 @@ function InternalInput({
 
   return (
     <ArgumentGridRow {...rowProps} tabIndex={isFocused ? 0 : -1} ref={gridCellRef}>
-      <ArgumentGridCell
-        {...rowProps}
-        {...gridCellProps}
-        tabIndex={isFocused ? 0 : -1}
-        ref={gridCellRef}
-      >
+      <ArgumentGridCell {...gridCellProps}>
         <ComboBox
           items={items}
           ref={inputRef}
           placeholder={
-            parameterDefinition?.kind === 'column' && parameterDefinition.defaultLabel
-              ? parameterDefinition.defaultLabel
-              : parameterDefinition?.kind === 'value' &&
-                  'placeholder' in parameterDefinition
-                ? (argument.label ?? parameterDefinition.placeholder)
-                : argument.label
+            parameterDefinition?.kind === 'value' && 'placeholder' in parameterDefinition
+              ? (argument.label ?? parameterDefinition.placeholder)
+              : resolveDisplayLabel(argument.label)
           }
           inputLabel={
             parameterDefinition?.kind === 'column'

--- a/static/app/components/arithmeticBuilder/token/function.tsx
+++ b/static/app/components/arithmeticBuilder/token/function.tsx
@@ -378,8 +378,8 @@ function InternalInput({
         item.value === parameterDefinition.defaultValue
           ? {
               ...item,
-              label: parameterDefinition.defaultLabel!,
-              textValue: parameterDefinition.defaultLabel!,
+              label: parameterDefinition.defaultLabel,
+              textValue: parameterDefinition.defaultLabel,
             }
           : item
       );

--- a/static/app/components/arithmeticBuilder/token/function.tsx
+++ b/static/app/components/arithmeticBuilder/token/function.tsx
@@ -345,13 +345,9 @@ function InternalInput({
     });
   }, [attributesFilter, builderFunctionArguments, getFieldDefinition]);
 
-  const attributeItems = useAttributeItems({
-    allowedAttributes,
-    filterValue,
-  });
+  const attributeItems = useAttributeItems(allowedAttributes);
 
   const items = useMemo(() => {
-    // If this is a dropdown parameter, use the predefined options
     if (parameterDefinition?.kind === 'value' && parameterDefinition.options) {
       return parameterDefinition.options
         .filter(
@@ -369,12 +365,14 @@ function InternalInput({
         }));
     }
 
+    // Remap labels (e.g. span.duration → spans for count), then filter
+    let result = attributeItems;
     if (
       parameterDefinition?.kind === 'column' &&
       parameterDefinition.defaultLabel &&
       parameterDefinition.defaultValue
     ) {
-      return attributeItems.map(item =>
+      result = result.map(item =>
         item.value === parameterDefinition.defaultValue
           ? {
               ...item,
@@ -385,7 +383,16 @@ function InternalInput({
       );
     }
 
-    return attributeItems;
+    if (filterValue) {
+      const lower = filterValue.toLowerCase();
+      result = result.filter(
+        item =>
+          item.value.includes(filterValue) ||
+          (item.textValue?.toLowerCase().includes(lower) ?? false)
+      );
+    }
+
+    return result;
   }, [parameterDefinition, filterValue, attributeItems]);
 
   const shouldCloseOnInteractOutside = useCallback((el: Element) => {
@@ -734,29 +741,18 @@ function InternalInput({
   );
 }
 
-function useAttributeItems({
-  allowedAttributes,
-  filterValue,
-}: {
-  allowedAttributes: FunctionArgument[];
-  filterValue: string;
-}): Array<SelectOptionWithKey<string>> {
-  // TODO: use a config
-  const attributes: Array<SelectOptionWithKey<string>> = useMemo(() => {
-    const items = filterValue
-      ? allowedAttributes.filter(attr => attr.name.includes(filterValue))
-      : allowedAttributes;
-
-    return items.map(item => ({
+function useAttributeItems(
+  allowedAttributes: FunctionArgument[]
+): Array<SelectOptionWithKey<string>> {
+  return useMemo(() => {
+    return allowedAttributes.map(item => ({
       key: item.name,
       label: item.label ?? item.name,
       value: item.name,
       textValue: item.name,
       hideCheck: true,
     }));
-  }, [allowedAttributes, filterValue]);
-
-  return attributes;
+  }, [allowedAttributes]);
 }
 
 const FunctionWrapper = styled('div')<{state: 'invalid' | 'warning' | 'valid'}>`

--- a/static/app/components/arithmeticBuilder/token/index.spec.tsx
+++ b/static/app/components/arithmeticBuilder/token/index.spec.tsx
@@ -20,7 +20,7 @@ import {
 import {TokenGrid} from 'sentry/components/arithmeticBuilder/token/grid';
 import {FieldKind, getFieldDefinition} from 'sentry/utils/fields';
 
-const aggregations = ['avg', 'sum', 'epm', 'count_unique', 'count_if'];
+const aggregations = ['avg', 'sum', 'epm', 'count', 'count_unique', 'count_if'];
 
 const functionArguments = [
   {name: 'span.duration', kind: FieldKind.MEASUREMENT},
@@ -688,6 +688,93 @@ describe('token', () => {
       expect(options[1]).toHaveTextContent('span.description');
       await userEvent.type(input, 'desc');
       expect(screen.getByRole('option')).toHaveTextContent('span.description');
+    });
+
+    it('shows "spans" placeholder for count argument input', async () => {
+      render(<Tokens expression="count(span.duration)" />);
+
+      const input = await screen.findByRole('combobox', {
+        name: 'Select an attribute',
+      });
+      expect(input).toHaveAttribute('placeholder', 'spans');
+    });
+
+    it('shows "span.duration" placeholder for avg argument input', async () => {
+      render(<Tokens expression="avg(span.duration)" />);
+
+      const input = await screen.findByRole('combobox', {
+        name: 'Select an attribute',
+      });
+      expect(input).toHaveAttribute('placeholder', 'span.duration');
+    });
+
+    it('shows "spans" as the dropdown label for count argument', async () => {
+      render(<Tokens expression="count(span.duration)" />);
+
+      const input = screen.getByRole('combobox', {
+        name: 'Select an attribute',
+      });
+      await userEvent.click(input);
+
+      const options = screen.getAllByRole('option');
+      expect(options).toHaveLength(1);
+      expect(options[0]).toHaveTextContent('spans');
+    });
+
+    it('resolves typed "spans" to "span.duration" for count', async () => {
+      const dispatch = jest.fn();
+      render(<Tokens expression="count(span.duration)" dispatch={dispatch} />);
+
+      const input = screen.getByRole('combobox', {
+        name: 'Select an attribute',
+      });
+
+      await userEvent.click(input);
+      await userEvent.clear(input);
+      await userEvent.type(input, 'spans{Enter}');
+
+      await waitFor(() => {
+        expect(dispatch).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: 'REPLACE_TOKEN',
+            text: 'count(span.duration)',
+          })
+        );
+      });
+    });
+
+    it('dispatches span.duration when selecting dropdown option for count', async () => {
+      const dispatch = jest.fn();
+      render(<Tokens expression="count(span.duration)" dispatch={dispatch} />);
+
+      const input = screen.getByRole('combobox', {
+        name: 'Select an attribute',
+      });
+      await userEvent.click(input);
+      await userEvent.click(screen.getByRole('option', {name: 'spans'}));
+
+      await waitFor(() => {
+        expect(dispatch).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: 'REPLACE_TOKEN',
+            text: 'count(span.duration)',
+          })
+        );
+      });
+    });
+
+    it('shows "span.duration" as the dropdown label for avg argument', async () => {
+      render(<Tokens expression="avg(span.duration)" />);
+
+      const input = screen.getByRole('combobox', {
+        name: 'Select an attribute',
+      });
+      await userEvent.click(input);
+
+      const options = screen.getAllByRole('option');
+      expect(options).toHaveLength(2);
+      expect(options[0]).toHaveTextContent('span.duration');
+      expect(options[1]).toHaveTextContent('span.self_time');
     });
 
     it('skips input when function has no arguments', async () => {

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -456,6 +456,7 @@ type AggregateColumnParameter = {
   kind: 'column';
   name: string;
   required: boolean;
+  defaultLabel?: string;
   defaultValue?: string;
 };
 
@@ -1329,6 +1330,7 @@ const SPAN_AGGREGATION_FIELDS: Record<AggregationKey, FieldDefinition> = {
             (valueType === FieldValueType.DURATION || valueType === FieldValueType.NUMBER)
           );
         },
+        defaultLabel: 'spans',
         defaultValue: 'span.duration',
         required: false,
       },


### PR DESCRIPTION
Since we change `span.duration` in the other UI selectors with `count`, `count(span.duration)` isn't expected or consistent with what the user sees predominantly. Update the arithmetic builder to show `count(spans)` instead of `count(span.duration)`.

We still want the "value" to be `span.duration` when making the requests, so we need to add a label that maps `span.duration` to `spans`, and when a user types `spans`, it should be translated to the value `span.duration` downstream.


**Before:**
<img width="464" height="332" alt="Screenshot 2026-08-10 at 2 35 53 PM" src="https://github.com/user-attachments/assets/6de2b6dc-1359-4f1d-99f4-a1ff44a83714" />

---

**After:**
<img width="424" height="217" alt="Screenshot 2026-08-10 at 2 38 45 PM" src="https://github.com/user-attachments/assets/a5b26adb-da60-4f4f-9d17-2978cd2ee9f3" />
