### PR TITLE
fix(dashboards): Omit parens from Open in Issues query for filtered widgets

### DIFF
--- a/static/app/views/dashboards/utils.spec.tsx
+++ b/static/app/views/dashboards/utils.spec.tsx
@@ -192,7 +192,7 @@ describe('Dashboards util', () => {
       );
       const queryString = url.split('?')[1];
       const urlParams = new URLSearchParams(queryString);
-      expect(urlParams.get('query')).toBe('(is:unresolved) release:["1.0.0","2.0.0"] ');
+      expect(urlParams.get('query')).toBe('is:unresolved release:["1.0.0","2.0.0"] ');
     });
     it('applies global filters scoped to the issue dataset', () => {
       const url = getWidgetIssueUrl(
@@ -216,7 +216,7 @@ describe('Dashboards util', () => {
       );
       const queryString = url.split('?')[1];
       const urlParams = new URLSearchParams(queryString);
-      expect(urlParams.get('query')).toBe('(is:unresolved) transaction:/api/foo');
+      expect(urlParams.get('query')).toBe('is:unresolved transaction:/api/foo');
     });
   });
 

--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -281,7 +281,8 @@ export function getWidgetIssueUrl(
     query: applyDashboardFilters(
       widget.queries?.[0]?.conditions,
       dashboardFilters,
-      widget.widgetType
+      widget.widgetType,
+      true // Issue search does not support parens
     ),
     sort: widget.queries?.[0]?.orderby,
     ...datetime,
@@ -592,7 +593,8 @@ export const performanceScoreTooltip = t('peformance_score is not supported in D
 export function applyDashboardFilters(
   baseQuery: string | undefined,
   dashboardFilters: DashboardFilters | undefined,
-  widgetType?: WidgetType
+  widgetType?: WidgetType,
+  skipParens?: boolean
 ): string | undefined {
   const dashboardFilterConditions = dashboardFiltersToString(
     dashboardFilters,
@@ -600,7 +602,9 @@ export function applyDashboardFilters(
   );
   if (dashboardFilterConditions) {
     if (baseQuery) {
-      return `(${baseQuery}) ${dashboardFilterConditions}`;
+      return skipParens
+        ? `${baseQuery} ${dashboardFilterConditions}`
+        : `(${baseQuery}) ${dashboardFilterConditions}`;
     }
     return dashboardFilterConditions;
   }


### PR DESCRIPTION
Issue search does not support parenthesized query groups, so the wrapping
parens added when merging dashboard filters into a widget query produced an
invalid search on the Issues page. Skip the parens when building the Open in
Issues URL.

Refs DAIN-1828