### PR TITLE
feat(hybridcloud): Tag webhook delivery time by provider

### DIFF
--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -489,7 +489,10 @@ def _get_github_delivery_time_tags(payload: WebhookPayload) -> dict[str, str]:
 def _record_delivery_time_metrics(payload: WebhookPayload) -> None:
     """Record delivery time metrics for a successfully delivered webhook payload."""
     duration = timezone.now() - payload.date_added
-    tags = {"region_sent_to": payload.cell_name} | _get_github_delivery_time_tags(payload)
+    tags = {
+        "region_sent_to": payload.cell_name,
+        "provider": _provider_tag(payload),
+    } | _get_github_delivery_time_tags(payload)
     metrics.distribution(
         "hybridcloud.deliver_webhooks.delivery_time_ms",
         # e.g. 0.123 seconds → 123 milliseconds

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -973,7 +973,10 @@ class DeliveryTimeMetricsTest(TestCase):
             if c[0][0] == "hybridcloud.deliver_webhooks.delivery_time_ms"
         ]
         assert len(delivery_time_ms_calls) == 1
-        assert delivery_time_ms_calls[0][1].get("tags", {}).get("region_sent_to") == "us"
+        tags = delivery_time_ms_calls[0][1].get("tags", {})
+        assert tags.get("region_sent_to") == "us"
+        # Rows predating the provider column still drain through here.
+        assert tags.get("provider") == "unknown"
 
     @responses.activate
     @override_cells(cell_config)
@@ -1004,6 +1007,7 @@ class DeliveryTimeMetricsTest(TestCase):
         assert len(delivery_time_ms_calls) == 1
         tags = delivery_time_ms_calls[0][1].get("tags", {})
         assert tags.get("region_sent_to") == "us"
+        assert tags.get("provider") == "github"
         assert tags.get("github_event_and_action") == "pull_request.opened"
 
     @responses.activate
@@ -1062,6 +1066,7 @@ class DeliveryTimeMetricsTest(TestCase):
         assert len(delivery_time_ms_calls) == 1
         tags = delivery_time_ms_calls[0][1].get("tags", {})
         assert tags.get("region_sent_to") == "us"
+        assert tags.get("provider") == "stripe"
         assert "github_event_and_action" not in tags
 
 


### PR DESCRIPTION
## Problem

`hybridcloud.deliver_webhooks.delivery_time_ms` is tagged with `region_sent_to` and, for GitHub, `github_event_and_action` — but not `provider`. A latency regression confined to one integration is invisible until it is large enough to move the aggregate, and the `$provider` selector on the Hybrid Cloud Webhook Forwarding dashboard cannot reach the latency charts at all.

#121609 added a `provider` tag to every `delivery`, `failure`, `saved` and `push_trigger.*` emission. `delivery_time_ms` was left out because it is emitted from a different helper; this closes that gap.

## Change

`_record_delivery_time_metrics` now includes `provider` via the existing `_provider_tag` helper, so payloads predating the nullable `provider` column report `unknown` rather than dropping the tag.

The three existing `DeliveryTimeMetricsTest` cases already cover the branches that matter, so they gained assertions instead of new tests: a payload with no provider (`unknown`), a GitHub payload (`github`), and a non-GitHub payload (`stripe`).

## No Datadog config needed

The metrics in #121609 sit behind an allowlist tag configuration that has to be widened before `provider` becomes queryable. `delivery_time_ms` configures tags by *exclusion* — only infra tags are stripped — so `provider` is queryable as soon as it is emitted.