### PR TITLE
test(redis): Guard commands against open transactions

### DIFF
--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -352,6 +352,10 @@ def _redis_transaction_callers() -> tuple[str, ...]:
     frame = inspect.currentframe()
     while frame is not None:
         module = frame.f_globals.get("__name__", "")
+        if module in ("_pytest", "pytest", "unittest") or module.startswith(
+            ("_pytest.", "pytest.", "unittest.")
+        ):
+            break
         is_redis_internal = module == __name__ or any(
             module == prefix or module.startswith(f"{prefix}.")
             for prefix in ("django.utils.functional", "redis", "rediscluster", "sentry_redis_tools")

--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -352,8 +352,8 @@ def _redis_transaction_callers() -> tuple[str, ...]:
     frame = inspect.currentframe()
     while frame is not None:
         module = frame.f_globals.get("__name__", "")
-        if module in ("_pytest", "pytest", "unittest") or module.startswith(
-            ("_pytest.", "pytest.", "unittest.")
+        if module in ("_pytest", "pytest", "unittest.case") or module.startswith(
+            ("_pytest.", "pytest.", "unittest.case.")
         ):
             break
         is_redis_internal = module == __name__ or any(

--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.resources
+import inspect
 import logging
 from copy import deepcopy
 from threading import Lock
@@ -37,6 +38,52 @@ _REDIS_DEFAULT_CLIENT_ARGS = {
 _pool_cache: dict[str, ConnectionPool] = {}
 _pool_lock = Lock()
 
+# Existing violations discovered when the guard was enabled. Removing an entry
+# makes that call site subject to enforcement; new call sites fail by default.
+_REDIS_TRANSACTION_ALLOWLIST = frozenset(
+    {
+        "getsentry.billing.usagebuffer.redis.RedisUsageBuffer.fetch_pop",
+        "getsentry.models.billingseatassignment.BillingSeatAssignment.schedule_redis_key_sync.<locals>._sync_redis_key",
+        "sentry.dynamic_sampling.rules.helpers.latest_releases.ProjectBoostedReleases.has_boosted_releases",
+        "sentry.models.counter.increment_project_counter_in_cache",
+        "sentry.notifications.notifications.activity.base.GroupActivityNotification.__init__",
+        "sentry.ratelimits.redis.RedisRateLimiter.reset",
+        "sentry.rules.actions.integrations.create_ticket.utils.create_issue",
+        "sentry.rules.conditions.event_frequency.EventFrequencyCondition.query_hook",
+        "sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition.query_hook",
+        "sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyCondition.query_hook",
+        "sentry.uptime.subscriptions.subscriptions.disable_uptime_detector",
+        "sentry.utils.sentry_apps.request_buffer.SentryAppWebhookRequestsBuffer.add_request",
+    }
+)
+
+
+def _redis_transaction_caller() -> str | None:
+    frame = inspect.currentframe()
+    while frame is not None:
+        module = frame.f_globals.get("__name__", "")
+        is_redis_internal = module == __name__ or any(
+            module == prefix or module.startswith(f"{prefix}.")
+            for prefix in ("django.utils.functional", "redis", "rediscluster", "sentry_redis_tools")
+        )
+        if module and not is_redis_internal:
+            return f"{module}.{frame.f_code.co_qualname}"
+        frame = frame.f_back
+    return None
+
+
+def _assert_redis_transaction_allowed(message: str) -> None:
+    try:
+        in_test_assert_no_transaction(message)
+    except AssertionError:
+        caller = _redis_transaction_caller()
+        if caller is not None and (
+            caller in _REDIS_TRANSACTION_ALLOWLIST
+            or caller.startswith(("getsentry.testutils.", "sentry.testutils.", "tests."))
+        ):
+            return
+        raise AssertionError(f"{message} (Redis caller: {caller or 'unknown'})") from None
+
 
 def _add_transaction_checks(
     client: RedisCluster[T] | StrictRedis[T],
@@ -48,7 +95,7 @@ def _add_transaction_checks(
     execute_command = mutable_client.execute_command
 
     def execute_command_outside_transaction(*args: Any, **kwargs: Any) -> Any:
-        in_test_assert_no_transaction("Redis commands must run outside database transactions")
+        _assert_redis_transaction_allowed("Redis commands must run outside database transactions")
         return execute_command(*args, **kwargs)
 
     pipeline_factory = mutable_client.pipeline
@@ -58,7 +105,7 @@ def _add_transaction_checks(
         execute_pipeline = redis_pipeline.execute
 
         def execute_pipeline_outside_transaction(*args: Any, **kwargs: Any) -> Any:
-            in_test_assert_no_transaction(
+            _assert_redis_transaction_allowed(
                 "Redis pipeline commands must run outside database transactions"
             )
             return execute_pipeline(*args, **kwargs)

--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -282,6 +282,10 @@ _REDIS_TRANSACTION_CALLSTACK_ALLOWLIST_RATCHET = frozenset(
             "sentry.utils.sentry_apps.request_buffer.SentryAppWebhookRequestsBuffer.add_request",
             "sentry.sentry_apps.external_requests.utils.send_and_save_sentry_app_request",
         ),
+        (
+            "sentry.utils.sentry_apps.request_buffer.SentryAppWebhookRequestsBuffer.add_request",
+            "sentry.utils.sentry_apps.webhooks.send_and_save_webhook_request",
+        ),
     }
 )
 

--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -19,6 +19,7 @@ from sentry.db.postgres.transactions import in_test_assert_no_transaction
 from sentry.exceptions import InvalidConfiguration
 from sentry.options import OptionsManager
 from sentry.utils import warnings
+from sentry.utils.env import in_test_environment
 from sentry.utils.versioning import Version, check_versions
 from sentry.utils.warnings import DeprecatedSettingWarning
 
@@ -37,23 +38,34 @@ _pool_cache: dict[str, ConnectionPool] = {}
 _pool_lock = Lock()
 
 
-class TransactionCheckingFailoverRedis(FailoverRedis):
-    def execute_command(self, *args: Any, **kwargs: Any) -> Any:
+def add_transaction_checks(client: Any) -> Any:
+    if not in_test_environment():
+        return client
+
+    execute_command = client.execute_command
+
+    def execute_command_outside_transaction(*args: Any, **kwargs: Any) -> Any:
         in_test_assert_no_transaction("Redis commands must run outside database transactions")
-        return super().execute_command(*args, **kwargs)
+        return execute_command(*args, **kwargs)
 
-    def pipeline(self, *args: Any, **kwargs: Any) -> Any:
-        pipeline = super().pipeline(*args, **kwargs)
-        execute = pipeline.execute
+    pipeline_factory = client.pipeline
 
-        def execute_outside_transaction(*args: Any, **kwargs: Any) -> Any:
+    def pipeline(*args: Any, **kwargs: Any) -> Any:
+        redis_pipeline = pipeline_factory(*args, **kwargs)
+        execute_pipeline = redis_pipeline.execute
+
+        def execute_pipeline_outside_transaction(*args: Any, **kwargs: Any) -> Any:
             in_test_assert_no_transaction(
                 "Redis pipeline commands must run outside database transactions"
             )
-            return execute(*args, **kwargs)
+            return execute_pipeline(*args, **kwargs)
 
-        pipeline.execute = execute_outside_transaction
-        return pipeline
+        redis_pipeline.execute = execute_pipeline_outside_transaction
+        return redis_pipeline
+
+    client.execute_command = execute_command_outside_transaction
+    client.pipeline = pipeline
+    return client
 
 
 def _shared_pool(**opts: Any) -> ConnectionPool:
@@ -193,14 +205,14 @@ class RedisClusterManager:
             RedisCluster[bytes] | StrictRedis[bytes] | RedisCluster[str] | StrictRedis[str]
         ):
             if is_redis_cluster:
-                return RetryingRedisCluster(
+                client = RetryingRedisCluster(
                     # Intentionally copy hosts here because redis-cluster-py
                     # mutates the inner dicts and this closure can be run
                     # concurrently, as SimpleLazyObject is not threadsafe. This
                     # is likely triggered by RetryingRedisCluster running
                     # reset() after startup
                     #
-                    # https://github.com/Grokzen/redis-py-cluster/blob/73f27edf7ceb4a408b3008ef7d82dac570ab9c6a/rediscluster/nodemanager.py#L385
+                    # https://github.com/Grokzen/redis-py-cluster/issues/287
                     startup_nodes=deepcopy(hosts_list),
                     decode_responses=decode_responses,
                     skip_full_coverage_check=True,
@@ -213,7 +225,9 @@ class RedisClusterManager:
                 assert len(hosts_list) > 0, "Hosts should have at least 1 entry"
                 host = dict(hosts_list[0])
                 host["decode_responses"] = decode_responses
-                return TransactionCheckingFailoverRedis(**host, **client_args)
+                client = FailoverRedis(**host, **client_args)
+
+            return add_transaction_checks(client)
 
         # losing some type safety: SimpleLazyObject acts like the underlying type
         return SimpleLazyObject(cluster_factory)

--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -15,6 +15,7 @@ from sentry_redis_tools.failover_redis import FailoverRedis
 from sentry_redis_tools.retrying_cluster import RetryingRedisCluster
 
 from sentry import options
+from sentry.db.postgres.transactions import in_test_assert_no_transaction
 from sentry.exceptions import InvalidConfiguration
 from sentry.options import OptionsManager
 from sentry.utils import warnings
@@ -34,6 +35,25 @@ _REDIS_DEFAULT_CLIENT_ARGS = {
 
 _pool_cache: dict[str, ConnectionPool] = {}
 _pool_lock = Lock()
+
+
+class TransactionCheckingFailoverRedis(FailoverRedis):
+    def execute_command(self, *args: Any, **kwargs: Any) -> Any:
+        in_test_assert_no_transaction("Redis commands must run outside database transactions")
+        return super().execute_command(*args, **kwargs)
+
+    def pipeline(self, *args: Any, **kwargs: Any) -> Any:
+        pipeline = super().pipeline(*args, **kwargs)
+        execute = pipeline.execute
+
+        def execute_outside_transaction(*args: Any, **kwargs: Any) -> Any:
+            in_test_assert_no_transaction(
+                "Redis pipeline commands must run outside database transactions"
+            )
+            return execute(*args, **kwargs)
+
+        pipeline.execute = execute_outside_transaction
+        return pipeline
 
 
 def _shared_pool(**opts: Any) -> ConnectionPool:
@@ -193,7 +213,7 @@ class RedisClusterManager:
                 assert len(hosts_list) > 0, "Hosts should have at least 1 entry"
                 host = dict(hosts_list[0])
                 host["decode_responses"] = decode_responses
-                return FailoverRedis(**host, **client_args)
+                return TransactionCheckingFailoverRedis(**host, **client_args)
 
         # losing some type safety: SimpleLazyObject acts like the underlying type
         return SimpleLazyObject(cluster_factory)

--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -38,28 +38,62 @@ _REDIS_DEFAULT_CLIENT_ARGS = {
 _pool_cache: dict[str, ConnectionPool] = {}
 _pool_lock = Lock()
 
-# Existing violations discovered when the guard was enabled. Removing an entry
-# makes that call site subject to enforcement; new call sites fail by default.
-_REDIS_TRANSACTION_ALLOWLIST = frozenset(
+# INC-2410: Existing violations of Redis calls happening during DB transactions at the time the check was added.
+# New entries are not allowed and we should burn this down over time.
+_REDIS_TRANSACTION_ALLOWLIST_RATCHET = frozenset(
     {
-        "getsentry.billing.usagebuffer.redis.RedisUsageBuffer.fetch_pop",
-        "getsentry.models.billingseatassignment.BillingSeatAssignment.schedule_redis_key_sync.<locals>._sync_redis_key",
-        "sentry.dynamic_sampling.rules.helpers.latest_releases.ProjectBoostedReleases.has_boosted_releases",
-        "sentry.event_manager._get_severity_metadata_for_group",
-        "sentry.models.counter.increment_project_counter_in_cache",
-        "sentry.models.counter.refill_cached_short_ids",
-        "sentry.notifications.notifications.activity.base.GroupActivityNotification.__init__",
-        "sentry.ratelimits.redis.RedisRateLimiter.reset",
-        "sentry.rules.actions.integrations.create_ticket.utils.create_issue",
-        "sentry.rules.conditions.event_frequency.EventFrequencyCondition.query_hook",
-        "sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition.query_hook",
-        "sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyCondition.query_hook",
-        "sentry.services.eventstore.reprocessing.redis.RedisReprocessingStore.get_pending",
-        "sentry.tasks.assemble.delete_assemble_status",
-        "sentry.uptime.config_producer._send_to_redis",
-        "sentry.uptime.subscriptions.subscriptions.disable_uptime_detector",
-        "sentry.utils.snowflake.get_sequence_value_from_redis",
-        "sentry.utils.sentry_apps.request_buffer.SentryAppWebhookRequestsBuffer.add_request",
+        (
+            "getsentry.billing.usagebuffer.redis.RedisUsageBuffer.fetch_pop",
+            "getsentry.billing.tasks.usagebuffer.flush_usage_buffer",
+        ),
+        (
+            "getsentry.models.billingseatassignment.BillingSeatAssignment.schedule_redis_key_sync.<locals>._sync_redis_key",
+        ),
+        (
+            "sentry.dynamic_sampling.rules.helpers.latest_releases.ProjectBoostedReleases.has_boosted_releases",
+            "sentry.models.releases.release_project.ReleaseProjectModelManager._on_post",
+        ),
+        ("sentry.event_manager._get_severity_metadata_for_group",),
+        (
+            "sentry.models.counter.increment_project_counter_in_cache",
+            "sentry.models.counter.Counter.increment",
+            "sentry.models.project.Project.next_short_id",
+            "sentry.event_manager._get_next_short_id",
+        ),
+        ("sentry.models.counter.refill_cached_short_ids",),
+        ("sentry.notifications.notifications.activity.base.GroupActivityNotification.__init__",),
+        (
+            "sentry.ratelimits.redis.RedisRateLimiter.reset",
+            "sentry.auth.twofactor.reset_2fa_rate_limits",
+            "sentry.users.web.accounts.recover_confirm",
+        ),
+        ("sentry.rules.actions.integrations.create_ticket.utils.create_issue",),
+        ("sentry.rules.conditions.event_frequency.EventFrequencyCondition.query_hook",),
+        ("sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition.query_hook",),
+        ("sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyCondition.query_hook",),
+        (
+            "sentry.services.eventstore.reprocessing.redis.RedisReprocessingStore.get_pending",
+            "sentry.reprocessing2.get_progress",
+        ),
+        (
+            "sentry.services.eventstore.reprocessing.redis.RedisReprocessingStore.get_pending",
+            "sentry.reprocessing2.is_reprocessing_active",
+        ),
+        ("sentry.tasks.assemble.delete_assemble_status",),
+        (
+            "sentry.uptime.config_producer._send_to_redis",
+            "sentry.uptime.config_producer.produce_config",
+        ),
+        (
+            "sentry.uptime.config_producer._send_to_redis",
+            "sentry.uptime.config_producer.produce_config_removal",
+        ),
+        ("sentry.uptime.subscriptions.subscriptions.disable_uptime_detector",),
+        ("sentry.utils.snowflake.get_sequence_value_from_redis",),
+        (
+            "sentry.utils.sentry_apps.request_buffer.SentryAppWebhookRequestsBuffer.add_request",
+            "sentry.sentry_apps.external_requests.utils.send_and_save_sentry_app_request",
+        ),
     }
 )
 
@@ -79,6 +113,14 @@ def _redis_transaction_callers() -> tuple[str, ...]:
     return tuple(callers)
 
 
+def _matches_redis_transaction_ratchet(callers: tuple[str, ...]) -> bool:
+    for signature in _REDIS_TRANSACTION_ALLOWLIST_RATCHET:
+        remaining_callers = iter(callers)
+        if all(caller in remaining_callers for caller in signature):
+            return True
+    return False
+
+
 def _assert_redis_transaction_allowed(message: str) -> None:
     try:
         in_test_assert_no_transaction(message)
@@ -89,7 +131,7 @@ def _assert_redis_transaction_allowed(message: str) -> None:
             ("getsentry.testutils.", "sentry.testutils.", "tests.")
         ):
             return
-        if not _REDIS_TRANSACTION_ALLOWLIST.isdisjoint(callers):
+        if _matches_redis_transaction_ratchet(callers):
             return
         raise AssertionError(f"{message} (Redis caller: {caller or 'unknown'})") from None
 

--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -38,136 +38,6 @@ _REDIS_DEFAULT_CLIENT_ARGS = {
 _pool_cache: dict[str, ConnectionPool] = {}
 _pool_lock = Lock()
 
-# INC-2410: Existing violations of Redis calls happening during DB transactions at the time the check was added.
-# New entries are not allowed and we should burn this down over time.
-_REDIS_TRANSACTION_ALLOWLIST_RATCHET = frozenset(
-    {
-        (
-            "getsentry.billing.usagebuffer.redis.RedisUsageBuffer.fetch_pop",
-            "getsentry.billing.tasks.usagebuffer.flush_usage_buffer",
-        ),
-        (
-            "getsentry.models.billingseatassignment.BillingSeatAssignment.schedule_redis_key_sync.<locals>._sync_redis_key",
-        ),
-        (
-            "sentry.dynamic_sampling.rules.helpers.latest_releases.ProjectBoostedReleases.has_boosted_releases",
-            "sentry.models.releases.release_project.ReleaseProjectModelManager._on_post",
-        ),
-        ("sentry.event_manager._get_severity_metadata_for_group",),
-        (
-            "sentry.models.counter.increment_project_counter_in_cache",
-            "sentry.models.counter.Counter.increment",
-            "sentry.models.project.Project.next_short_id",
-            "sentry.event_manager._get_next_short_id",
-        ),
-        ("sentry.models.counter.refill_cached_short_ids",),
-        ("sentry.notifications.notifications.activity.base.GroupActivityNotification.__init__",),
-        (
-            "sentry.ratelimits.redis.RedisRateLimiter.reset",
-            "sentry.auth.twofactor.reset_2fa_rate_limits",
-            "sentry.users.web.accounts.recover_confirm",
-        ),
-        ("sentry.rules.actions.integrations.create_ticket.utils.create_issue",),
-        ("sentry.rules.conditions.event_frequency.EventFrequencyCondition.query_hook",),
-        ("sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition.query_hook",),
-        ("sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyCondition.query_hook",),
-        (
-            "sentry.services.eventstore.reprocessing.redis.RedisReprocessingStore.get_pending",
-            "sentry.reprocessing2.get_progress",
-        ),
-        (
-            "sentry.services.eventstore.reprocessing.redis.RedisReprocessingStore.get_pending",
-            "sentry.reprocessing2.is_reprocessing_active",
-        ),
-        ("sentry.tasks.assemble.delete_assemble_status",),
-        (
-            "sentry.uptime.config_producer._send_to_redis",
-            "sentry.uptime.config_producer.produce_config",
-        ),
-        (
-            "sentry.uptime.config_producer._send_to_redis",
-            "sentry.uptime.config_producer.produce_config_removal",
-        ),
-        ("sentry.uptime.subscriptions.subscriptions.disable_uptime_detector",),
-        ("sentry.utils.snowflake.get_sequence_value_from_redis",),
-        (
-            "sentry.utils.sentry_apps.request_buffer.SentryAppWebhookRequestsBuffer.add_request",
-            "sentry.sentry_apps.external_requests.utils.send_and_save_sentry_app_request",
-        ),
-    }
-)
-
-
-def _redis_transaction_callers() -> tuple[str, ...]:
-    callers = []
-    frame = inspect.currentframe()
-    while frame is not None:
-        module = frame.f_globals.get("__name__", "")
-        is_redis_internal = module == __name__ or any(
-            module == prefix or module.startswith(f"{prefix}.")
-            for prefix in ("django.utils.functional", "redis", "rediscluster", "sentry_redis_tools")
-        )
-        if module and not is_redis_internal:
-            callers.append(f"{module}.{frame.f_code.co_qualname}")
-        frame = frame.f_back
-    return tuple(callers)
-
-
-def _matches_redis_transaction_ratchet(callers: tuple[str, ...]) -> bool:
-    for signature in _REDIS_TRANSACTION_ALLOWLIST_RATCHET:
-        remaining_callers = iter(callers)
-        if all(caller in remaining_callers for caller in signature):
-            return True
-    return False
-
-
-def _assert_redis_transaction_allowed(message: str) -> None:
-    try:
-        in_test_assert_no_transaction(message)
-    except AssertionError:
-        callers = _redis_transaction_callers()
-        caller = callers[0] if callers else None
-        if caller is not None and caller.startswith(
-            ("getsentry.testutils.", "sentry.testutils.", "tests.")
-        ):
-            return
-        if _matches_redis_transaction_ratchet(callers):
-            return
-        raise AssertionError(f"{message} (Redis caller: {caller or 'unknown'})") from None
-
-
-def _add_transaction_checks(
-    client: RedisCluster[T] | StrictRedis[T],
-) -> RedisCluster[T] | StrictRedis[T]:
-    if not in_test_environment():
-        return client
-
-    mutable_client = cast(Any, client)
-    execute_command = mutable_client.execute_command
-
-    def execute_command_outside_transaction(*args: Any, **kwargs: Any) -> Any:
-        _assert_redis_transaction_allowed("Redis commands must run outside database transactions")
-        return execute_command(*args, **kwargs)
-
-    pipeline_factory = mutable_client.pipeline
-
-    def pipeline(*args: Any, **kwargs: Any) -> Any:
-        redis_pipeline = pipeline_factory(*args, **kwargs)
-        execute_pipeline = redis_pipeline.execute
-
-        def execute_pipeline_outside_transaction(*args: Any, **kwargs: Any) -> Any:
-            _assert_redis_transaction_allowed(
-                "Redis pipeline commands must run outside database transactions"
-            )
-            return execute_pipeline(*args, **kwargs)
-
-        redis_pipeline.execute = execute_pipeline_outside_transaction
-        return redis_pipeline
-
-    mutable_client.execute_command = execute_command_outside_transaction
-    mutable_client.pipeline = pipeline
-    return client
-
 
 def _shared_pool(**opts: Any) -> ConnectionPool:
     if "host" in opts:
@@ -354,6 +224,138 @@ class RedisClusterManager:
         # setup/init of lazy objects.
         ret = self._clusters_bytes[key] = self._factory(**self._cfg(key), decode_responses=False)
         return ret
+
+
+# INC-2410: Existing violations of Redis calls happening during DB transactions at the time the check was added.
+# New entries are not allowed and we should burn this down over time.
+_REDIS_TRANSACTION_CALLSTACK_ALLOWLIST_RATCHET = frozenset(
+    {
+        (
+            "getsentry.billing.usagebuffer.redis.RedisUsageBuffer.fetch_pop",
+            "getsentry.billing.tasks.usagebuffer.flush_usage_buffer",
+        ),
+        (
+            "getsentry.models.billingseatassignment.BillingSeatAssignment.schedule_redis_key_sync.<locals>._sync_redis_key",
+        ),
+        (
+            "sentry.dynamic_sampling.rules.helpers.latest_releases.ProjectBoostedReleases.has_boosted_releases",
+            "sentry.models.releases.release_project.ReleaseProjectModelManager._on_post",
+        ),
+        ("sentry.event_manager._get_severity_metadata_for_group",),
+        (
+            "sentry.models.counter.increment_project_counter_in_cache",
+            "sentry.models.counter.Counter.increment",
+            "sentry.models.project.Project.next_short_id",
+            "sentry.event_manager._get_next_short_id",
+        ),
+        ("sentry.models.counter.refill_cached_short_ids",),
+        ("sentry.notifications.notifications.activity.base.GroupActivityNotification.__init__",),
+        (
+            "sentry.ratelimits.redis.RedisRateLimiter.reset",
+            "sentry.auth.twofactor.reset_2fa_rate_limits",
+            "sentry.users.web.accounts.recover_confirm",
+        ),
+        ("sentry.rules.actions.integrations.create_ticket.utils.create_issue",),
+        ("sentry.rules.conditions.event_frequency.EventFrequencyCondition.query_hook",),
+        ("sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition.query_hook",),
+        ("sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyCondition.query_hook",),
+        (
+            "sentry.services.eventstore.reprocessing.redis.RedisReprocessingStore.get_pending",
+            "sentry.reprocessing2.get_progress",
+        ),
+        (
+            "sentry.services.eventstore.reprocessing.redis.RedisReprocessingStore.get_pending",
+            "sentry.reprocessing2.is_reprocessing_active",
+        ),
+        ("sentry.tasks.assemble.delete_assemble_status",),
+        (
+            "sentry.uptime.config_producer._send_to_redis",
+            "sentry.uptime.config_producer.produce_config",
+        ),
+        (
+            "sentry.uptime.config_producer._send_to_redis",
+            "sentry.uptime.config_producer.produce_config_removal",
+        ),
+        ("sentry.uptime.subscriptions.subscriptions.disable_uptime_detector",),
+        ("sentry.utils.snowflake.get_sequence_value_from_redis",),
+        (
+            "sentry.utils.sentry_apps.request_buffer.SentryAppWebhookRequestsBuffer.add_request",
+            "sentry.sentry_apps.external_requests.utils.send_and_save_sentry_app_request",
+        ),
+    }
+)
+
+
+def _add_transaction_checks(
+    client: RedisCluster[T] | StrictRedis[T],
+) -> RedisCluster[T] | StrictRedis[T]:
+    """No-ops in production. In testing environments, wraps Redis calls to assert it's not inside a transaction."""
+    if not in_test_environment():
+        return client
+
+    mutable_client = cast(Any, client)
+    execute_command = mutable_client.execute_command
+
+    def execute_command_outside_transaction(*args: Any, **kwargs: Any) -> Any:
+        _assert_redis_transaction_allowed("Redis commands must run outside database transactions")
+        return execute_command(*args, **kwargs)
+
+    pipeline_factory = mutable_client.pipeline
+
+    def pipeline(*args: Any, **kwargs: Any) -> Any:
+        redis_pipeline = pipeline_factory(*args, **kwargs)
+        execute_pipeline = redis_pipeline.execute
+
+        def execute_pipeline_outside_transaction(*args: Any, **kwargs: Any) -> Any:
+            _assert_redis_transaction_allowed(
+                "Redis pipeline commands must run outside database transactions"
+            )
+            return execute_pipeline(*args, **kwargs)
+
+        redis_pipeline.execute = execute_pipeline_outside_transaction
+        return redis_pipeline
+
+    mutable_client.execute_command = execute_command_outside_transaction
+    mutable_client.pipeline = pipeline
+    return client
+
+
+def _assert_redis_transaction_allowed(message: str) -> None:
+    try:
+        in_test_assert_no_transaction(message)
+    except AssertionError:
+        callers = _redis_transaction_callers()
+        caller = callers[0] if callers else None
+        if caller is not None and caller.startswith(
+            ("getsentry.testutils.", "sentry.testutils.", "tests.")
+        ):
+            return
+        if _matches_redis_transaction_ratchet(callers):
+            return
+        raise AssertionError(f"{message} (Redis caller: {caller or 'unknown'})") from None
+
+
+def _matches_redis_transaction_ratchet(callers: tuple[str, ...]) -> bool:
+    for signature in _REDIS_TRANSACTION_CALLSTACK_ALLOWLIST_RATCHET:
+        remaining_callers = iter(callers)
+        if all(caller in remaining_callers for caller in signature):
+            return True
+    return False
+
+
+def _redis_transaction_callers() -> tuple[str, ...]:
+    callers = []
+    frame = inspect.currentframe()
+    while frame is not None:
+        module = frame.f_globals.get("__name__", "")
+        is_redis_internal = module == __name__ or any(
+            module == prefix or module.startswith(f"{prefix}.")
+            for prefix in ("django.utils.functional", "redis", "rediscluster", "sentry_redis_tools")
+        )
+        if module and not is_redis_internal:
+            callers.append(f"{module}.{frame.f_code.co_qualname}")
+        frame = frame.f_back
+    return tuple(callers)
 
 
 # TODO(epurkhiser): When migration of all rb cluster to true redis clusters has

--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -4,7 +4,7 @@ import importlib.resources
 import logging
 from copy import deepcopy
 from threading import Lock
-from typing import Any, Literal, TypeGuard, TypeVar, overload
+from typing import Any, Literal, TypeGuard, TypeVar, cast, overload
 
 import rb
 from django.utils.functional import SimpleLazyObject
@@ -38,17 +38,20 @@ _pool_cache: dict[str, ConnectionPool] = {}
 _pool_lock = Lock()
 
 
-def add_transaction_checks(client: Any) -> Any:
+def add_transaction_checks(
+    client: RedisCluster[T] | StrictRedis[T],
+) -> RedisCluster[T] | StrictRedis[T]:
     if not in_test_environment():
         return client
 
-    execute_command = client.execute_command
+    mutable_client = cast(Any, client)
+    execute_command = mutable_client.execute_command
 
     def execute_command_outside_transaction(*args: Any, **kwargs: Any) -> Any:
         in_test_assert_no_transaction("Redis commands must run outside database transactions")
         return execute_command(*args, **kwargs)
 
-    pipeline_factory = client.pipeline
+    pipeline_factory = mutable_client.pipeline
 
     def pipeline(*args: Any, **kwargs: Any) -> Any:
         redis_pipeline = pipeline_factory(*args, **kwargs)
@@ -63,8 +66,8 @@ def add_transaction_checks(client: Any) -> Any:
         redis_pipeline.execute = execute_pipeline_outside_transaction
         return redis_pipeline
 
-    client.execute_command = execute_command_outside_transaction
-    client.pipeline = pipeline
+    mutable_client.execute_command = execute_command_outside_transaction
+    mutable_client.pipeline = pipeline
     return client
 
 
@@ -204,31 +207,30 @@ class RedisClusterManager:
         def cluster_factory() -> (
             RedisCluster[bytes] | StrictRedis[bytes] | RedisCluster[str] | StrictRedis[str]
         ):
-            client: Any
             if is_redis_cluster:
-                client = RetryingRedisCluster(
-                    # Intentionally copy hosts here because redis-cluster-py
-                    # mutates the inner dicts and this closure can be run
-                    # concurrently, as SimpleLazyObject is not threadsafe. This
-                    # is likely triggered by RetryingRedisCluster running
-                    # reset() after startup
-                    #
-                    # https://github.com/Grokzen/redis-py-cluster/issues/287
-                    startup_nodes=deepcopy(hosts_list),
-                    decode_responses=decode_responses,
-                    skip_full_coverage_check=True,
-                    max_connections=16,
-                    max_connections_per_node=True,
-                    readonly_mode=readonly_mode,
-                    **client_args,
+                return add_transaction_checks(
+                    RetryingRedisCluster(
+                        # Intentionally copy hosts here because redis-cluster-py
+                        # mutates the inner dicts and this closure can be run
+                        # concurrently, as SimpleLazyObject is not threadsafe. This
+                        # is likely triggered by RetryingRedisCluster running
+                        # reset() after startup
+                        #
+                        # https://github.com/Grokzen/redis-py-cluster/blob/73f27edf7ceb4a408b3008ef7d82dac570ab9c6a/rediscluster/nodemanager.py#L385
+                        startup_nodes=deepcopy(hosts_list),
+                        decode_responses=decode_responses,
+                        skip_full_coverage_check=True,
+                        max_connections=16,
+                        max_connections_per_node=True,
+                        readonly_mode=readonly_mode,
+                        **client_args,
+                    )
                 )
-            else:
-                assert len(hosts_list) > 0, "Hosts should have at least 1 entry"
-                host = dict(hosts_list[0])
-                host["decode_responses"] = decode_responses
-                client = FailoverRedis(**host, **client_args)
 
-            return add_transaction_checks(client)
+            assert len(hosts_list) > 0, "Hosts should have at least 1 entry"
+            host = dict(hosts_list[0])
+            host["decode_responses"] = decode_responses
+            return add_transaction_checks(FailoverRedis(**host, **client_args))
 
         # losing some type safety: SimpleLazyObject acts like the underlying type
         return SimpleLazyObject(cluster_factory)

--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -58,6 +58,7 @@ _REDIS_TRANSACTION_ALLOWLIST = frozenset(
         "sentry.tasks.assemble.delete_assemble_status",
         "sentry.uptime.config_producer._send_to_redis",
         "sentry.uptime.subscriptions.subscriptions.disable_uptime_detector",
+        "sentry.utils.snowflake.get_sequence_value_from_redis",
         "sentry.utils.sentry_apps.request_buffer.SentryAppWebhookRequestsBuffer.add_request",
     }
 )

--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -204,6 +204,7 @@ class RedisClusterManager:
         def cluster_factory() -> (
             RedisCluster[bytes] | StrictRedis[bytes] | RedisCluster[str] | StrictRedis[str]
         ):
+            client: Any
             if is_redis_cluster:
                 client = RetryingRedisCluster(
                     # Intentionally copy hosts here because redis-cluster-py

--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -46,19 +46,24 @@ _REDIS_TRANSACTION_ALLOWLIST = frozenset(
         "getsentry.models.billingseatassignment.BillingSeatAssignment.schedule_redis_key_sync.<locals>._sync_redis_key",
         "sentry.dynamic_sampling.rules.helpers.latest_releases.ProjectBoostedReleases.has_boosted_releases",
         "sentry.models.counter.increment_project_counter_in_cache",
+        "sentry.models.counter.refill_cached_short_ids",
         "sentry.notifications.notifications.activity.base.GroupActivityNotification.__init__",
         "sentry.ratelimits.redis.RedisRateLimiter.reset",
         "sentry.rules.actions.integrations.create_ticket.utils.create_issue",
         "sentry.rules.conditions.event_frequency.EventFrequencyCondition.query_hook",
         "sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition.query_hook",
         "sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyCondition.query_hook",
+        "sentry.services.eventstore.reprocessing.redis.RedisReprocessingStore.get_pending",
+        "sentry.tasks.assemble.delete_assemble_status",
+        "sentry.uptime.config_producer._send_to_redis",
         "sentry.uptime.subscriptions.subscriptions.disable_uptime_detector",
         "sentry.utils.sentry_apps.request_buffer.SentryAppWebhookRequestsBuffer.add_request",
     }
 )
 
 
-def _redis_transaction_caller() -> str | None:
+def _redis_transaction_callers() -> tuple[str, ...]:
+    callers = []
     frame = inspect.currentframe()
     while frame is not None:
         module = frame.f_globals.get("__name__", "")
@@ -67,20 +72,22 @@ def _redis_transaction_caller() -> str | None:
             for prefix in ("django.utils.functional", "redis", "rediscluster", "sentry_redis_tools")
         )
         if module and not is_redis_internal:
-            return f"{module}.{frame.f_code.co_qualname}"
+            callers.append(f"{module}.{frame.f_code.co_qualname}")
         frame = frame.f_back
-    return None
+    return tuple(callers)
 
 
 def _assert_redis_transaction_allowed(message: str) -> None:
     try:
         in_test_assert_no_transaction(message)
     except AssertionError:
-        caller = _redis_transaction_caller()
-        if caller is not None and (
-            caller in _REDIS_TRANSACTION_ALLOWLIST
-            or caller.startswith(("getsentry.testutils.", "sentry.testutils.", "tests."))
+        callers = _redis_transaction_callers()
+        caller = callers[0] if callers else None
+        if caller is not None and caller.startswith(
+            ("getsentry.testutils.", "sentry.testutils.", "tests.")
         ):
+            return
+        if not _REDIS_TRANSACTION_ALLOWLIST.isdisjoint(callers):
             return
         raise AssertionError(f"{message} (Redis caller: {caller or 'unknown'})") from None
 

--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -38,7 +38,7 @@ _pool_cache: dict[str, ConnectionPool] = {}
 _pool_lock = Lock()
 
 
-def add_transaction_checks(
+def _add_transaction_checks(
     client: RedisCluster[T] | StrictRedis[T],
 ) -> RedisCluster[T] | StrictRedis[T]:
     if not in_test_environment():
@@ -208,7 +208,7 @@ class RedisClusterManager:
             RedisCluster[bytes] | StrictRedis[bytes] | RedisCluster[str] | StrictRedis[str]
         ):
             if is_redis_cluster:
-                return add_transaction_checks(
+                return _add_transaction_checks(
                     RetryingRedisCluster(
                         # Intentionally copy hosts here because redis-cluster-py
                         # mutates the inner dicts and this closure can be run
@@ -230,7 +230,7 @@ class RedisClusterManager:
             assert len(hosts_list) > 0, "Hosts should have at least 1 entry"
             host = dict(hosts_list[0])
             host["decode_responses"] = decode_responses
-            return add_transaction_checks(FailoverRedis(**host, **client_args))
+            return _add_transaction_checks(FailoverRedis(**host, **client_args))
 
         # losing some type safety: SimpleLazyObject acts like the underlying type
         return SimpleLazyObject(cluster_factory)

--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -45,6 +45,7 @@ _REDIS_TRANSACTION_ALLOWLIST = frozenset(
         "getsentry.billing.usagebuffer.redis.RedisUsageBuffer.fetch_pop",
         "getsentry.models.billingseatassignment.BillingSeatAssignment.schedule_redis_key_sync.<locals>._sync_redis_key",
         "sentry.dynamic_sampling.rules.helpers.latest_releases.ProjectBoostedReleases.has_boosted_releases",
+        "sentry.event_manager._get_severity_metadata_for_group",
         "sentry.models.counter.increment_project_counter_in_cache",
         "sentry.models.counter.refill_cached_short_ids",
         "sentry.notifications.notifications.activity.base.GroupActivityNotification.__init__",

--- a/src/sentry/utils/snowflake.py
+++ b/src/sentry/utils/snowflake.py
@@ -12,7 +12,7 @@ from rest_framework import status
 from rest_framework.exceptions import APIException
 from sentry_redis_tools.clients import RedisCluster, StrictRedis
 
-from sentry.db.postgres.transactions import enforce_constraints, in_test_hide_transaction_boundary
+from sentry.db.postgres.transactions import enforce_constraints
 from sentry.types.cell import CellContextError, get_local_cell
 from sentry.utils import redis
 
@@ -164,12 +164,11 @@ def get_sequence_value_from_redis(redis_key: str, starting_timestamp: int) -> tu
         # We are decreasing the value by 1 each time since the incr operation in redis
         # initializes the counter at 1. For our cell sequences, we want the value to
         # be from 0-15 and not 1-16
-        with in_test_hide_transaction_boundary():
-            sequence_value = cluster.incr(timestamp_redis_key)
-            sequence_value -= 1
+        sequence_value = cluster.incr(timestamp_redis_key)
+        sequence_value -= 1
 
-            if sequence_value == 0:
-                cluster.expire(timestamp_redis_key, int(_TTL.total_seconds()))
+        if sequence_value == 0:
+            cluster.expire(timestamp_redis_key, int(_TTL.total_seconds()))
 
         if sequence_value < MAX_AVAILABLE_CELL_SEQUENCES:
             return timestamp, sequence_value

--- a/src/sentry/utils/snowflake.py
+++ b/src/sentry/utils/snowflake.py
@@ -12,7 +12,7 @@ from rest_framework import status
 from rest_framework.exceptions import APIException
 from sentry_redis_tools.clients import RedisCluster, StrictRedis
 
-from sentry.db.postgres.transactions import enforce_constraints
+from sentry.db.postgres.transactions import enforce_constraints, in_test_hide_transaction_boundary
 from sentry.types.cell import CellContextError, get_local_cell
 from sentry.utils import redis
 
@@ -164,11 +164,12 @@ def get_sequence_value_from_redis(redis_key: str, starting_timestamp: int) -> tu
         # We are decreasing the value by 1 each time since the incr operation in redis
         # initializes the counter at 1. For our cell sequences, we want the value to
         # be from 0-15 and not 1-16
-        sequence_value = cluster.incr(timestamp_redis_key)
-        sequence_value -= 1
+        with in_test_hide_transaction_boundary():
+            sequence_value = cluster.incr(timestamp_redis_key)
+            sequence_value -= 1
 
-        if sequence_value == 0:
-            cluster.expire(timestamp_redis_key, int(_TTL.total_seconds()))
+            if sequence_value == 0:
+                cluster.expire(timestamp_redis_key, int(_TTL.total_seconds()))
 
         if sequence_value < MAX_AVAILABLE_CELL_SEQUENCES:
             return timestamp, sequence_value

--- a/tests/sentry/utils/test_redis.py
+++ b/tests/sentry/utils/test_redis.py
@@ -177,7 +177,7 @@ class TransactionCheckingRedisTest(SentryTestCase):
         assert _matches_redis_transaction_ratchet(existing_webhook_callers)
         assert not _matches_redis_transaction_ratchet(new_callers)
 
-    def test_transaction_callers_include_nested_application_frames(self) -> None:
+    def test_transaction_callers_include_application_frames_until_test_harness(self) -> None:
         def outer_caller() -> tuple[str, ...]:
             def shared_helper() -> tuple[str, ...]:
                 return _redis_transaction_callers()
@@ -186,9 +186,10 @@ class TransactionCheckingRedisTest(SentryTestCase):
 
         callers = outer_caller()
 
-        assert callers[:2] == (
+        assert callers == (
             f"{__name__}.{outer_caller.__qualname__}.<locals>.shared_helper",
             f"{__name__}.{outer_caller.__qualname__}",
+            f"{__name__}.TransactionCheckingRedisTest.test_transaction_callers_include_application_frames_until_test_harness",
         )
 
 

--- a/tests/sentry/utils/test_redis.py
+++ b/tests/sentry/utils/test_redis.py
@@ -172,9 +172,14 @@ class TransactionCheckingRedisTest(SentryTestCase):
             "sentry.utils.sentry_apps.request_buffer.SentryAppWebhookRequestsBuffer.add_request",
             "sentry.utils.sentry_apps.webhooks.send_and_save_webhook_request",
         )
+        existing_single_caller = (
+            "sentry.event_manager._get_severity_metadata_for_group",
+            "sentry.new_code.new_outer_caller",
+        )
 
         assert _matches_redis_transaction_ratchet(existing_callers)
         assert _matches_redis_transaction_ratchet(existing_webhook_callers)
+        assert _matches_redis_transaction_ratchet(existing_single_caller)
         assert not _matches_redis_transaction_ratchet(new_callers)
 
     def test_transaction_callers_include_application_frames_until_test_harness(self) -> None:
@@ -191,6 +196,18 @@ class TransactionCheckingRedisTest(SentryTestCase):
             f"{__name__}.{outer_caller.__qualname__}",
             f"{__name__}.TransactionCheckingRedisTest.test_transaction_callers_include_application_frames_until_test_harness",
         )
+
+    def test_transaction_callers_include_application_frames_outside_mock(self) -> None:
+        def outer_caller() -> tuple[str, ...]:
+            def shared_helper() -> tuple[str, ...]:
+                return _redis_transaction_callers()
+
+            return mock.Mock(wraps=shared_helper)()
+
+        callers = outer_caller()
+
+        assert callers[0] == f"{__name__}.{outer_caller.__qualname__}.<locals>.shared_helper"
+        assert f"{__name__}.{outer_caller.__qualname__}" in callers
 
 
 def test_get_cluster_from_options_cluster_provided() -> None:

--- a/tests/sentry/utils/test_redis.py
+++ b/tests/sentry/utils/test_redis.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import uuid
 from unittest import TestCase, mock
 
 import pytest
@@ -9,17 +10,18 @@ from sentry_redis_tools.failover_redis import FailoverRedis
 
 from sentry.exceptions import InvalidConfiguration
 from sentry.testutils.cases import TestCase as SentryTestCase
+from sentry.testutils.helpers.redis import use_redis_cluster
 from sentry.utils import imports
 from sentry.utils.redis import (
     RBClusterManager,
     RedisClusterManager,
     _add_transaction_checks,
-    _assert_redis_transaction_allowed,
     _matches_redis_transaction_ratchet,
     _redis_transaction_callers,
     _shared_pool,
     check_cluster_versions,
     get_cluster_from_options,
+    redis_clusters,
 )
 from sentry.utils.versioning import Version
 from sentry.utils.warnings import DeprecatedSettingWarning
@@ -96,14 +98,14 @@ class ClusterManagerTestCase(TestCase):
 
 class TransactionCheckingRedisTest(SentryTestCase):
     def test_command_runs_outside_transaction(self) -> None:
-        client = FailoverRedis()
-        with mock.patch.object(
-            client, "execute_command", return_value=mock.sentinel.result
-        ) as execute_command:
-            result = _add_transaction_checks(client).execute_command("GET", "key")
+        client = redis_clusters.get("default")
+        key = f"test:redis-transaction-guard:{uuid.uuid4().hex}"
 
-        assert result is mock.sentinel.result
-        execute_command.assert_called_once_with("GET", "key")
+        try:
+            client.set(key, "value")
+            assert client.get(key) == "value"
+        finally:
+            client.delete(key)
 
     @mock.patch(
         "sentry.utils.redis._redis_transaction_callers",
@@ -112,17 +114,14 @@ class TransactionCheckingRedisTest(SentryTestCase):
     def test_command_is_rejected_inside_transaction(
         self, _redis_transaction_callers: mock.MagicMock
     ) -> None:
-        client = FailoverRedis()
-        with mock.patch.object(client, "execute_command") as execute_command:
-            guarded_client = _add_transaction_checks(client)
-            with transaction.atomic(using="default"):
-                with pytest.raises(
-                    AssertionError,
-                    match="Redis commands must run outside database transactions",
-                ):
-                    guarded_client.execute_command("GET", "key")
+        client = redis_clusters.get("default")
 
-        execute_command.assert_not_called()
+        with transaction.atomic(using="default"):
+            with pytest.raises(
+                AssertionError,
+                match="Redis commands must run outside database transactions",
+            ):
+                client.get("test:redis-transaction-guard")
 
     @mock.patch(
         "sentry.utils.redis._redis_transaction_callers",
@@ -131,44 +130,47 @@ class TransactionCheckingRedisTest(SentryTestCase):
     def test_pipeline_is_rejected_when_executed_inside_transaction(
         self, _redis_transaction_callers: mock.MagicMock
     ) -> None:
-        client = FailoverRedis()
-        pipeline = mock.Mock()
-        execute_pipeline = pipeline.execute
-        with mock.patch.object(client, "pipeline", return_value=pipeline):
-            guarded_pipeline = _add_transaction_checks(client).pipeline()
-            with transaction.atomic(using="default"):
-                with pytest.raises(
-                    AssertionError,
-                    match="Redis pipeline commands must run outside database transactions",
-                ):
-                    guarded_pipeline.execute()
+        pipeline = redis_clusters.get("default").pipeline()
+        pipeline.get("test:redis-transaction-guard")
 
-        execute_pipeline.assert_not_called()
+        with transaction.atomic(using="default"):
+            with pytest.raises(
+                AssertionError,
+                match="Redis pipeline commands must run outside database transactions",
+            ):
+                pipeline.execute()
 
-    @mock.patch("sentry.utils.redis.in_test_assert_no_transaction", side_effect=AssertionError)
+    @use_redis_cluster("transaction-guard-cluster")
     @mock.patch(
         "sentry.utils.redis._redis_transaction_callers",
-        return_value=(
-            "sentry.shared.redis_helper.execute",
+        return_value=("sentry.new_code.unexpected_redis_call",),
+    )
+    def test_cluster_command_is_rejected_inside_transaction(
+        self, _redis_transaction_callers: mock.MagicMock
+    ) -> None:
+        client = redis_clusters.get("transaction-guard-cluster")
+        assert all(info["redis_mode"] == "cluster" for info in client.info("server").values())
+
+        with transaction.atomic(using="default"):
+            with pytest.raises(
+                AssertionError,
+                match="Redis commands must run outside database transactions",
+            ):
+                client.get("test:redis-transaction-guard")
+
+    def test_transaction_ratchet_matches_only_existing_call_path(self) -> None:
+        existing_callers = (
             "sentry.ratelimits.redis.RedisRateLimiter.reset",
             "sentry.auth.twofactor.reset_2fa_rate_limits",
             "sentry.users.web.accounts.recover_confirm",
-        ),
-    )
-    def test_grandfathered_outer_caller_is_allowed(
-        self,
-        _redis_transaction_callers: mock.MagicMock,
-        in_test_assert_no_transaction: mock.MagicMock,
-    ) -> None:
-        _assert_redis_transaction_allowed("message")
-
-    def test_new_caller_of_grandfathered_adapter_is_rejected(self) -> None:
-        callers = (
+        )
+        new_callers = (
             "sentry.ratelimits.redis.RedisRateLimiter.reset",
             "sentry.new_code.reset_rate_limit",
         )
 
-        assert not _matches_redis_transaction_ratchet(callers)
+        assert _matches_redis_transaction_ratchet(existing_callers)
+        assert not _matches_redis_transaction_ratchet(new_callers)
 
     def test_transaction_callers_include_nested_application_frames(self) -> None:
         def outer_caller() -> tuple[str, ...]:
@@ -183,15 +185,6 @@ class TransactionCheckingRedisTest(SentryTestCase):
             f"{__name__}.{outer_caller.__qualname__}.<locals>.shared_helper",
             f"{__name__}.{outer_caller.__qualname__}",
         )
-
-    @mock.patch(
-        "sentry.utils.redis.in_test_assert_no_transaction",
-        side_effect=AssertionError,
-    )
-    def test_direct_test_caller_is_allowed(
-        self, in_test_assert_no_transaction: mock.MagicMock
-    ) -> None:
-        _assert_redis_transaction_allowed("message")
 
 
 def test_get_cluster_from_options_cluster_provided() -> None:

--- a/tests/sentry/utils/test_redis.py
+++ b/tests/sentry/utils/test_redis.py
@@ -136,12 +136,15 @@ class ClusterManagerTestCase(TestCase):
         side_effect=AssertionError,
     )
     @mock.patch(
-        "sentry.utils.redis._redis_transaction_caller",
-        return_value="sentry.models.counter.increment_project_counter_in_cache",
+        "sentry.utils.redis._redis_transaction_callers",
+        return_value=(
+            "sentry.cache.redis.RedisCache.get",
+            "sentry.models.counter.increment_project_counter_in_cache",
+        ),
     )
     def test_grandfathered_transaction_caller_is_allowed(
         self,
-        _redis_transaction_caller: mock.MagicMock,
+        _redis_transaction_callers: mock.MagicMock,
         in_test_assert_no_transaction: mock.MagicMock,
     ) -> None:
         _assert_redis_transaction_allowed("message")
@@ -151,12 +154,12 @@ class ClusterManagerTestCase(TestCase):
         side_effect=AssertionError,
     )
     @mock.patch(
-        "sentry.utils.redis._redis_transaction_caller",
-        return_value="sentry.new_code.unexpected_redis_call",
+        "sentry.utils.redis._redis_transaction_callers",
+        return_value=("sentry.new_code.unexpected_redis_call",),
     )
     def test_new_transaction_caller_is_rejected(
         self,
-        _redis_transaction_caller: mock.MagicMock,
+        _redis_transaction_callers: mock.MagicMock,
         in_test_assert_no_transaction: mock.MagicMock,
     ) -> None:
         with pytest.raises(

--- a/tests/sentry/utils/test_redis.py
+++ b/tests/sentry/utils/test_redis.py
@@ -15,6 +15,7 @@ from sentry.utils.redis import (
     RedisClusterManager,
     _add_transaction_checks,
     _assert_redis_transaction_allowed,
+    _matches_redis_transaction_ratchet,
     _redis_transaction_callers,
     _shared_pool,
     check_cluster_versions,
@@ -149,7 +150,9 @@ class TransactionCheckingRedisTest(SentryTestCase):
         "sentry.utils.redis._redis_transaction_callers",
         return_value=(
             "sentry.shared.redis_helper.execute",
-            "sentry.models.counter.increment_project_counter_in_cache",
+            "sentry.ratelimits.redis.RedisRateLimiter.reset",
+            "sentry.auth.twofactor.reset_2fa_rate_limits",
+            "sentry.users.web.accounts.recover_confirm",
         ),
     )
     def test_grandfathered_outer_caller_is_allowed(
@@ -158,6 +161,14 @@ class TransactionCheckingRedisTest(SentryTestCase):
         in_test_assert_no_transaction: mock.MagicMock,
     ) -> None:
         _assert_redis_transaction_allowed("message")
+
+    def test_new_caller_of_grandfathered_adapter_is_rejected(self) -> None:
+        callers = (
+            "sentry.ratelimits.redis.RedisRateLimiter.reset",
+            "sentry.new_code.reset_rate_limit",
+        )
+
+        assert not _matches_redis_transaction_ratchet(callers)
 
     def test_transaction_callers_include_nested_application_frames(self) -> None:
         def outer_caller() -> tuple[str, ...]:

--- a/tests/sentry/utils/test_redis.py
+++ b/tests/sentry/utils/test_redis.py
@@ -11,8 +11,8 @@ from sentry.utils import imports
 from sentry.utils.redis import (
     RBClusterManager,
     RedisClusterManager,
+    _add_transaction_checks,
     _shared_pool,
-    add_transaction_checks,
     check_cluster_versions,
     get_cluster_from_options,
 )
@@ -42,12 +42,12 @@ class ClusterManagerTestCase(TestCase):
         with pytest.raises(KeyError):
             manager.get("invalid")
 
-    @mock.patch("sentry.utils.redis.add_transaction_checks", side_effect=lambda client: client)
+    @mock.patch("sentry.utils.redis._add_transaction_checks", side_effect=lambda client: client)
     @mock.patch("sentry.utils.redis.RetryingRedisCluster")
     def test_specific_cluster(
         self,
         RetryingRedisCluster: mock.MagicMock,
-        add_transaction_checks: mock.MagicMock,
+        _add_transaction_checks: mock.MagicMock,
     ) -> None:
         manager = RedisClusterManager(_options_manager())
 
@@ -58,7 +58,7 @@ class ClusterManagerTestCase(TestCase):
         assert isinstance(manager.get("foo")._setupfunc(), FailoverRedis)  # type: ignore[union-attr]
         # baz works becasue it's explicitly is_redis_cluster
         assert manager.get("baz")._setupfunc() is RetryingRedisCluster.return_value  # type: ignore[union-attr]
-        assert add_transaction_checks.call_count == 2
+        assert _add_transaction_checks.call_count == 2
 
         # bar is not a valid redis or redis cluster definition
         # becasue it is two hosts, without explicitly saying is_redis_cluster
@@ -85,7 +85,7 @@ class ClusterManagerTestCase(TestCase):
                 client, "execute_command", return_value=mock.sentinel.result
             ) as execute_command,
         ):
-            guarded_client = add_transaction_checks(client)
+            guarded_client = _add_transaction_checks(client)
             result = guarded_client.execute_command("GET", "key")
 
         assert result is mock.sentinel.result
@@ -103,7 +103,7 @@ class ClusterManagerTestCase(TestCase):
             mock.patch("sentry.utils.redis.in_test_assert_no_transaction") as assert_no_transaction,
             mock.patch.object(client, "pipeline", return_value=pipeline),
         ):
-            guarded_client = add_transaction_checks(client)
+            guarded_client = _add_transaction_checks(client)
             guarded_pipeline = guarded_client.pipeline()
             assert_no_transaction.assert_not_called()
             result = guarded_pipeline.execute()
@@ -121,7 +121,7 @@ class ClusterManagerTestCase(TestCase):
         with mock.patch(
             "sentry.utils.redis.in_test_assert_no_transaction"
         ) as assert_no_transaction:
-            guarded_client = add_transaction_checks(client)
+            guarded_client = _add_transaction_checks(client)
             result = guarded_client.execute_command("GET", "key")
 
         assert result is mock.sentinel.result

--- a/tests/sentry/utils/test_redis.py
+++ b/tests/sentry/utils/test_redis.py
@@ -4,15 +4,18 @@ from unittest import TestCase, mock
 
 import pytest
 import rb
+from django.db import transaction
 from sentry_redis_tools.failover_redis import FailoverRedis
 
 from sentry.exceptions import InvalidConfiguration
+from sentry.testutils.cases import TestCase as SentryTestCase
 from sentry.utils import imports
 from sentry.utils.redis import (
     RBClusterManager,
     RedisClusterManager,
     _add_transaction_checks,
     _assert_redis_transaction_allowed,
+    _redis_transaction_callers,
     _shared_pool,
     check_cluster_versions,
     get_cluster_from_options,
@@ -77,96 +80,107 @@ class ClusterManagerTestCase(TestCase):
         # repeated retrieval should not trigger call to setupfunc
         manager.get("baz")
 
-    def test_redis_client_checks_transaction_before_command(self) -> None:
-        client = FailoverRedis()
-
-        with (
-            mock.patch("sentry.utils.redis.in_test_assert_no_transaction") as assert_no_transaction,
-            mock.patch.object(
-                client, "execute_command", return_value=mock.sentinel.result
-            ) as execute_command,
-        ):
-            guarded_client = _add_transaction_checks(client)
-            result = guarded_client.execute_command("GET", "key")
-
-        assert result is mock.sentinel.result
-        assert_no_transaction.assert_called_once_with(
-            "Redis commands must run outside database transactions"
-        )
-        execute_command.assert_called_once_with("GET", "key")
-
-    def test_redis_client_checks_transaction_when_pipeline_executes(self) -> None:
-        client = FailoverRedis()
-        pipeline = mock.Mock()
-        pipeline.execute.return_value = mock.sentinel.result
-
-        with (
-            mock.patch("sentry.utils.redis.in_test_assert_no_transaction") as assert_no_transaction,
-            mock.patch.object(client, "pipeline", return_value=pipeline),
-        ):
-            guarded_client = _add_transaction_checks(client)
-            guarded_pipeline = guarded_client.pipeline()
-            assert_no_transaction.assert_not_called()
-            result = guarded_pipeline.execute()
-
-        assert result is mock.sentinel.result
-        assert_no_transaction.assert_called_once_with(
-            "Redis pipeline commands must run outside database transactions"
-        )
-
-    def test_redis_cluster_checks_transaction_before_command(self) -> None:
-        client = mock.Mock()
+    @mock.patch("sentry.utils.redis.in_test_environment", return_value=False)
+    def test_transaction_checks_are_not_installed_in_production(
+        self, in_test_environment: mock.MagicMock
+    ) -> None:
+        client = mock.Mock(spec=FailoverRedis)
         execute_command = client.execute_command
-        execute_command.return_value = mock.sentinel.result
+        pipeline = client.pipeline
 
-        with mock.patch(
-            "sentry.utils.redis.in_test_assert_no_transaction"
-        ) as assert_no_transaction:
-            guarded_client = _add_transaction_checks(client)
-            result = guarded_client.execute_command("GET", "key")
+        assert _add_transaction_checks(client) is client
+        assert client.execute_command is execute_command
+        assert client.pipeline is pipeline
+
+
+class TransactionCheckingRedisTest(SentryTestCase):
+    def test_command_runs_outside_transaction(self) -> None:
+        client = FailoverRedis()
+        with mock.patch.object(
+            client, "execute_command", return_value=mock.sentinel.result
+        ) as execute_command:
+            result = _add_transaction_checks(client).execute_command("GET", "key")
 
         assert result is mock.sentinel.result
-        assert_no_transaction.assert_called_once_with(
-            "Redis commands must run outside database transactions"
-        )
         execute_command.assert_called_once_with("GET", "key")
 
     @mock.patch(
-        "sentry.utils.redis.in_test_assert_no_transaction",
-        side_effect=AssertionError,
+        "sentry.utils.redis._redis_transaction_callers",
+        return_value=("sentry.new_code.unexpected_redis_call",),
     )
+    def test_command_is_rejected_inside_transaction(
+        self, _redis_transaction_callers: mock.MagicMock
+    ) -> None:
+        client = FailoverRedis()
+        with mock.patch.object(client, "execute_command") as execute_command:
+            guarded_client = _add_transaction_checks(client)
+            with transaction.atomic(using="default"):
+                with pytest.raises(
+                    AssertionError,
+                    match="Redis commands must run outside database transactions",
+                ):
+                    guarded_client.execute_command("GET", "key")
+
+        execute_command.assert_not_called()
+
+    @mock.patch(
+        "sentry.utils.redis._redis_transaction_callers",
+        return_value=("sentry.new_code.unexpected_redis_call",),
+    )
+    def test_pipeline_is_rejected_when_executed_inside_transaction(
+        self, _redis_transaction_callers: mock.MagicMock
+    ) -> None:
+        client = FailoverRedis()
+        pipeline = mock.Mock()
+        execute_pipeline = pipeline.execute
+        with mock.patch.object(client, "pipeline", return_value=pipeline):
+            guarded_pipeline = _add_transaction_checks(client).pipeline()
+            with transaction.atomic(using="default"):
+                with pytest.raises(
+                    AssertionError,
+                    match="Redis pipeline commands must run outside database transactions",
+                ):
+                    guarded_pipeline.execute()
+
+        execute_pipeline.assert_not_called()
+
+    @mock.patch("sentry.utils.redis.in_test_assert_no_transaction", side_effect=AssertionError)
     @mock.patch(
         "sentry.utils.redis._redis_transaction_callers",
         return_value=(
-            "sentry.cache.redis.RedisCache.get",
+            "sentry.shared.redis_helper.execute",
             "sentry.models.counter.increment_project_counter_in_cache",
         ),
     )
-    def test_grandfathered_transaction_caller_is_allowed(
+    def test_grandfathered_outer_caller_is_allowed(
         self,
         _redis_transaction_callers: mock.MagicMock,
         in_test_assert_no_transaction: mock.MagicMock,
     ) -> None:
         _assert_redis_transaction_allowed("message")
 
+    def test_transaction_callers_include_nested_application_frames(self) -> None:
+        def outer_caller() -> tuple[str, ...]:
+            def shared_helper() -> tuple[str, ...]:
+                return _redis_transaction_callers()
+
+            return shared_helper()
+
+        callers = outer_caller()
+
+        assert callers[:2] == (
+            f"{__name__}.{outer_caller.__qualname__}.<locals>.shared_helper",
+            f"{__name__}.{outer_caller.__qualname__}",
+        )
+
     @mock.patch(
         "sentry.utils.redis.in_test_assert_no_transaction",
         side_effect=AssertionError,
     )
-    @mock.patch(
-        "sentry.utils.redis._redis_transaction_callers",
-        return_value=("sentry.new_code.unexpected_redis_call",),
-    )
-    def test_new_transaction_caller_is_rejected(
-        self,
-        _redis_transaction_callers: mock.MagicMock,
-        in_test_assert_no_transaction: mock.MagicMock,
+    def test_direct_test_caller_is_allowed(
+        self, in_test_assert_no_transaction: mock.MagicMock
     ) -> None:
-        with pytest.raises(
-            AssertionError,
-            match=r"message \(Redis caller: sentry.new_code.unexpected_redis_call\)",
-        ):
-            _assert_redis_transaction_allowed("message")
+        _assert_redis_transaction_allowed("message")
 
 
 def test_get_cluster_from_options_cluster_provided() -> None:

--- a/tests/sentry/utils/test_redis.py
+++ b/tests/sentry/utils/test_redis.py
@@ -11,6 +11,7 @@ from sentry.utils import imports
 from sentry.utils.redis import (
     RBClusterManager,
     RedisClusterManager,
+    TransactionCheckingFailoverRedis,
     _shared_pool,
     check_cluster_versions,
     get_cluster_from_options,
@@ -49,7 +50,7 @@ class ClusterManagerTestCase(TestCase):
         # object to verify it's correct.
 
         # cluster foo is fine since it's a single node
-        assert isinstance(manager.get("foo")._setupfunc(), FailoverRedis)  # type: ignore[union-attr]
+        assert isinstance(manager.get("foo")._setupfunc(), TransactionCheckingFailoverRedis)  # type: ignore[union-attr]
         # baz works becasue it's explicitly is_redis_cluster
         assert manager.get("baz")._setupfunc() is RetryingRedisCluster.return_value  # type: ignore[union-attr]
 
@@ -68,6 +69,41 @@ class ClusterManagerTestCase(TestCase):
         manager.get("baz")
         # repeated retrieval should not trigger call to setupfunc
         manager.get("baz")
+
+    def test_failover_redis_checks_transaction_before_command(self) -> None:
+        client = TransactionCheckingFailoverRedis()
+
+        with (
+            mock.patch("sentry.utils.redis.in_test_assert_no_transaction") as assert_no_transaction,
+            mock.patch.object(
+                FailoverRedis, "execute_command", return_value=mock.sentinel.result
+            ) as execute_command,
+        ):
+            result = client.execute_command("GET", "key")
+
+        assert result is mock.sentinel.result
+        assert_no_transaction.assert_called_once_with(
+            "Redis commands must run outside database transactions"
+        )
+        execute_command.assert_called_once_with("GET", "key")
+
+    def test_failover_redis_checks_transaction_when_pipeline_executes(self) -> None:
+        client = TransactionCheckingFailoverRedis()
+        pipeline = mock.Mock()
+        pipeline.execute.return_value = mock.sentinel.result
+
+        with (
+            mock.patch("sentry.utils.redis.in_test_assert_no_transaction") as assert_no_transaction,
+            mock.patch.object(FailoverRedis, "pipeline", return_value=pipeline),
+        ):
+            guarded_pipeline = client.pipeline()
+            assert_no_transaction.assert_not_called()
+            result = guarded_pipeline.execute()
+
+        assert result is mock.sentinel.result
+        assert_no_transaction.assert_called_once_with(
+            "Redis pipeline commands must run outside database transactions"
+        )
 
 
 def test_get_cluster_from_options_cluster_provided() -> None:

--- a/tests/sentry/utils/test_redis.py
+++ b/tests/sentry/utils/test_redis.py
@@ -11,8 +11,8 @@ from sentry.utils import imports
 from sentry.utils.redis import (
     RBClusterManager,
     RedisClusterManager,
-    TransactionCheckingFailoverRedis,
     _shared_pool,
+    add_transaction_checks,
     check_cluster_versions,
     get_cluster_from_options,
 )
@@ -42,17 +42,23 @@ class ClusterManagerTestCase(TestCase):
         with pytest.raises(KeyError):
             manager.get("invalid")
 
+    @mock.patch("sentry.utils.redis.add_transaction_checks", side_effect=lambda client: client)
     @mock.patch("sentry.utils.redis.RetryingRedisCluster")
-    def test_specific_cluster(self, RetryingRedisCluster: mock.MagicMock) -> None:
+    def test_specific_cluster(
+        self,
+        RetryingRedisCluster: mock.MagicMock,
+        add_transaction_checks: mock.MagicMock,
+    ) -> None:
         manager = RedisClusterManager(_options_manager())
 
         # We wrap the cluster in a Simple Lazy Object, force creation of the
         # object to verify it's correct.
 
         # cluster foo is fine since it's a single node
-        assert isinstance(manager.get("foo")._setupfunc(), TransactionCheckingFailoverRedis)  # type: ignore[union-attr]
+        assert isinstance(manager.get("foo")._setupfunc(), FailoverRedis)  # type: ignore[union-attr]
         # baz works becasue it's explicitly is_redis_cluster
         assert manager.get("baz")._setupfunc() is RetryingRedisCluster.return_value  # type: ignore[union-attr]
+        assert add_transaction_checks.call_count == 2
 
         # bar is not a valid redis or redis cluster definition
         # becasue it is two hosts, without explicitly saying is_redis_cluster
@@ -70,16 +76,17 @@ class ClusterManagerTestCase(TestCase):
         # repeated retrieval should not trigger call to setupfunc
         manager.get("baz")
 
-    def test_failover_redis_checks_transaction_before_command(self) -> None:
-        client = TransactionCheckingFailoverRedis()
+    def test_redis_client_checks_transaction_before_command(self) -> None:
+        client = FailoverRedis()
 
         with (
             mock.patch("sentry.utils.redis.in_test_assert_no_transaction") as assert_no_transaction,
             mock.patch.object(
-                FailoverRedis, "execute_command", return_value=mock.sentinel.result
+                client, "execute_command", return_value=mock.sentinel.result
             ) as execute_command,
         ):
-            result = client.execute_command("GET", "key")
+            guarded_client = add_transaction_checks(client)
+            result = guarded_client.execute_command("GET", "key")
 
         assert result is mock.sentinel.result
         assert_no_transaction.assert_called_once_with(
@@ -87,16 +94,17 @@ class ClusterManagerTestCase(TestCase):
         )
         execute_command.assert_called_once_with("GET", "key")
 
-    def test_failover_redis_checks_transaction_when_pipeline_executes(self) -> None:
-        client = TransactionCheckingFailoverRedis()
+    def test_redis_client_checks_transaction_when_pipeline_executes(self) -> None:
+        client = FailoverRedis()
         pipeline = mock.Mock()
         pipeline.execute.return_value = mock.sentinel.result
 
         with (
             mock.patch("sentry.utils.redis.in_test_assert_no_transaction") as assert_no_transaction,
-            mock.patch.object(FailoverRedis, "pipeline", return_value=pipeline),
+            mock.patch.object(client, "pipeline", return_value=pipeline),
         ):
-            guarded_pipeline = client.pipeline()
+            guarded_client = add_transaction_checks(client)
+            guarded_pipeline = guarded_client.pipeline()
             assert_no_transaction.assert_not_called()
             result = guarded_pipeline.execute()
 
@@ -104,6 +112,23 @@ class ClusterManagerTestCase(TestCase):
         assert_no_transaction.assert_called_once_with(
             "Redis pipeline commands must run outside database transactions"
         )
+
+    def test_redis_cluster_checks_transaction_before_command(self) -> None:
+        client = mock.Mock()
+        execute_command = client.execute_command
+        execute_command.return_value = mock.sentinel.result
+
+        with mock.patch(
+            "sentry.utils.redis.in_test_assert_no_transaction"
+        ) as assert_no_transaction:
+            guarded_client = add_transaction_checks(client)
+            result = guarded_client.execute_command("GET", "key")
+
+        assert result is mock.sentinel.result
+        assert_no_transaction.assert_called_once_with(
+            "Redis commands must run outside database transactions"
+        )
+        execute_command.assert_called_once_with("GET", "key")
 
 
 def test_get_cluster_from_options_cluster_provided() -> None:

--- a/tests/sentry/utils/test_redis.py
+++ b/tests/sentry/utils/test_redis.py
@@ -12,6 +12,7 @@ from sentry.utils.redis import (
     RBClusterManager,
     RedisClusterManager,
     _add_transaction_checks,
+    _assert_redis_transaction_allowed,
     _shared_pool,
     check_cluster_versions,
     get_cluster_from_options,
@@ -129,6 +130,40 @@ class ClusterManagerTestCase(TestCase):
             "Redis commands must run outside database transactions"
         )
         execute_command.assert_called_once_with("GET", "key")
+
+    @mock.patch(
+        "sentry.utils.redis.in_test_assert_no_transaction",
+        side_effect=AssertionError,
+    )
+    @mock.patch(
+        "sentry.utils.redis._redis_transaction_caller",
+        return_value="sentry.models.counter.increment_project_counter_in_cache",
+    )
+    def test_grandfathered_transaction_caller_is_allowed(
+        self,
+        _redis_transaction_caller: mock.MagicMock,
+        in_test_assert_no_transaction: mock.MagicMock,
+    ) -> None:
+        _assert_redis_transaction_allowed("message")
+
+    @mock.patch(
+        "sentry.utils.redis.in_test_assert_no_transaction",
+        side_effect=AssertionError,
+    )
+    @mock.patch(
+        "sentry.utils.redis._redis_transaction_caller",
+        return_value="sentry.new_code.unexpected_redis_call",
+    )
+    def test_new_transaction_caller_is_rejected(
+        self,
+        _redis_transaction_caller: mock.MagicMock,
+        in_test_assert_no_transaction: mock.MagicMock,
+    ) -> None:
+        with pytest.raises(
+            AssertionError,
+            match=r"message \(Redis caller: sentry.new_code.unexpected_redis_call\)",
+        ):
+            _assert_redis_transaction_allowed("message")
 
 
 def test_get_cluster_from_options_cluster_provided() -> None:

--- a/tests/sentry/utils/test_redis.py
+++ b/tests/sentry/utils/test_redis.py
@@ -168,8 +168,13 @@ class TransactionCheckingRedisTest(SentryTestCase):
             "sentry.ratelimits.redis.RedisRateLimiter.reset",
             "sentry.new_code.reset_rate_limit",
         )
+        existing_webhook_callers = (
+            "sentry.utils.sentry_apps.request_buffer.SentryAppWebhookRequestsBuffer.add_request",
+            "sentry.utils.sentry_apps.webhooks.send_and_save_webhook_request",
+        )
 
         assert _matches_redis_transaction_ratchet(existing_callers)
+        assert _matches_redis_transaction_ratchet(existing_webhook_callers)
         assert not _matches_redis_transaction_ratchet(new_callers)
 
     def test_transaction_callers_include_nested_application_frames(self) -> None:

--- a/tests/sentry/utils/test_snowflake.py
+++ b/tests/sentry/utils/test_snowflake.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 import pytest
 from django.conf import settings
+from django.db import router, transaction
 from django.test import override_settings
 
 from sentry.models.organization import Organization
@@ -44,6 +45,13 @@ class SnowflakeUtilsTest(TestCase):
             )
 
             assert snowflake_id == expected_value
+
+    @freeze_time(CURRENT_TIME)
+    def test_generate_id_inside_transaction(self) -> None:
+        with transaction.atomic(using=router.db_for_write(Project)):
+            snowflake_id = generate_snowflake_id("test_redis_key")
+
+        assert snowflake_id > 0
 
     @freeze_time(CURRENT_TIME)
     def test_generate_correct_ids_with_cell_sequence(self) -> None:


### PR DESCRIPTION
In INC-2410 the root cause was due to Redis calls happening inside of database transactions. This PR adds an assertion to fail any new tests that exhibit Redis calls in a transaction callstack. I added a ratchet allowlist for the current offenders since fixing those will need to be distributed amongst teams with more context.

Note: this can happen with other networked calls too and we should probably add similar handling.

Snowflake ID sequence allocation is narrowly exempted because it must obtain an ID before the database insert can run. A regression test covers allocation from an existing transaction.

Refs INC-2410