### PR TITLE
fix(replays): unsquish the text unmasking banner in the player

### DIFF
--- a/static/app/components/replays/unmaskAlert.tsx
+++ b/static/app/components/replays/unmaskAlert.tsx
@@ -1,7 +1,8 @@
-import styled from '@emotion/styled';
+import {useTheme} from '@emotion/react';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
+import {Container} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 
 import {useUserViewedReplays} from 'sentry/components/replays/useUserViewedReplays';
@@ -12,6 +13,7 @@ import {useDismissAlert} from 'sentry/utils/useDismissAlert';
 const LOCAL_STORAGE_KEY = 'replay-unmask-alert-dismissed';
 
 export function UnmaskAlert() {
+  const theme = useTheme();
   const {dismiss, isDismissed} = useDismissAlert({key: LOCAL_STORAGE_KEY});
   const {data, isError, isPending} = useUserViewedReplays();
 
@@ -20,7 +22,13 @@ export function UnmaskAlert() {
   }
 
   return (
-    <UnmaskAlertContainer data-test-id="unmask-alert">
+    <Container
+      data-test-id="unmask-alert"
+      position="absolute"
+      bottom={theme.space.md}
+      left={theme.space.md}
+      right={theme.space.md}
+    >
       <Alert
         variant="info"
         trailingItems={
@@ -42,11 +50,6 @@ export function UnmaskAlert() {
           }
         )}
       </Alert>
-    </UnmaskAlertContainer>
+    </Container>
   );
 }
-
-const UnmaskAlertContainer = styled('div')`
-  position: absolute;
-  bottom: ${p => p.theme.space.md};
-`;


### PR DESCRIPTION
Switches from an ad hoc div with absolute positioning to the more design-system-y `Container` with `left`, `bottom`, and `right` all set.

Closes REPLAY-974.

| Before | After |
| --- | --- |
| <img width="642" height="578" alt="replay-unmask-banner-before" src="https://github.com/user-attachments/assets/d6a24a73-c29c-4951-9b85-909434eb3c45" /> | <img width="642" height="578" alt="replay-unmask-banner-after" src="https://github.com/user-attachments/assets/94b8c922-90b3-4c67-ac89-24689cce67de" /> |
