### PR TITLE
feat(sentry-apps): collapse the permissions panel in creation templates

### DIFF
--- a/static/app/views/settings/organizationDeveloperSettings/permissionsObserver.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/permissionsObserver.spec.tsx
@@ -1,4 +1,4 @@
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {PermissionsObserver} from 'sentry/views/settings/organizationDeveloperSettings/permissionsObserver';
 
@@ -71,5 +71,78 @@ describe('PermissionsObserver', () => {
     expect(
       screen.getByRole('checkbox', {name: 'Continuous Integration (CI)'})
     ).not.toBeChecked();
+  });
+
+  it('renders the permissions panel statically by default', () => {
+    render(
+      <PermissionsObserver
+        scopes={[]}
+        events={[]}
+        newApp={false}
+        onScopesChange={noop}
+        onEventsChange={noop}
+      />
+    );
+
+    expect(screen.getByText('Permissions')).toBeInTheDocument();
+    expect(screen.getByText('Webhooks')).toBeInTheDocument();
+    expect(screen.getByRole('textbox', {name: 'Project'})).toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Permissions'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Webhooks'})).not.toBeInTheDocument();
+  });
+
+  it('can render the permissions panel collapsed', async () => {
+    render(
+      <PermissionsObserver
+        scopes={['project:read']}
+        events={[]}
+        newApp={false}
+        collapsePermissions
+        onScopesChange={noop}
+        onEventsChange={noop}
+      />
+    );
+
+    expect(screen.queryByRole('textbox', {name: 'Project'})).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Permissions'}));
+
+    expect(screen.getByRole('textbox', {name: 'Project'})).toBeInTheDocument();
+  });
+
+  it.each([
+    {
+      errorProps: {permissionErrors: {Project: 'Requires at least read access'}},
+      message: 'Requires at least read access',
+      type: 'resource permission',
+    },
+    {
+      errorProps: {continuousIntegrationError: 'Continuous integration is required'},
+      message: 'Continuous integration is required',
+      type: 'continuous integration',
+    },
+  ])('expands the permissions panel for $type errors', ({errorProps, message}) => {
+    const props: React.ComponentProps<typeof PermissionsObserver> = {
+      scopes: ['project:read'],
+      events: [],
+      newApp: false,
+      collapsePermissions: true,
+      onScopesChange: noop,
+      onEventsChange: noop,
+    };
+    const {rerender} = render(<PermissionsObserver {...props} />);
+
+    expect(screen.getByRole('button', {name: 'Permissions'})).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
+
+    rerender(<PermissionsObserver {...props} {...errorProps} />);
+
+    expect(screen.getByRole('button', {name: 'Permissions'})).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent(message);
   });
 });

--- a/static/app/views/settings/organizationDeveloperSettings/permissionsObserver.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/permissionsObserver.tsx
@@ -1,11 +1,18 @@
-import {Fragment, useState} from 'react';
+import {Fragment, useRef, useState} from 'react';
+import styled from '@emotion/styled';
+import {useDisclosure} from '@react-aria/disclosure';
+import {usePress} from '@react-aria/interactions';
+import {useDisclosureState} from '@react-stately/disclosure';
 
 import {Alert} from '@sentry/scraps/alert';
+import {Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
 
 import {Panel} from 'sentry/components/panels/panel';
 import {PanelBody} from 'sentry/components/panels/panelBody';
 import {PanelHeader} from 'sentry/components/panels/panelHeader';
 import {CONTINUOUS_INTEGRATION_SENTRY_APP_PERMISSION} from 'sentry/constants';
+import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Scope} from 'sentry/types/core';
 import type {PermissionResource, Permissions} from 'sentry/types/integrations';
@@ -25,6 +32,7 @@ type Props = {
   newApp: boolean;
   scopes: Scope[];
   appPublished?: boolean;
+  collapsePermissions?: boolean;
   continuousIntegrationError?: string;
   onEventsChange?: (events: WebhookSubscription[]) => void;
   onScopesChange?: (scopes: Scope[]) => void;
@@ -36,10 +44,11 @@ export function PermissionsObserver({
   events: initialEvents,
   newApp,
   scopes,
+  collapsePermissions = false,
   continuousIntegrationError,
   onEventsChange,
   onScopesChange,
-  permissionErrors,
+  permissionErrors = {},
 }: Props) {
   const checkContinuousIntegration = () =>
     scopes.includes(CONTINUOUS_INTEGRATION_SENTRY_APP_PERMISSION.scope);
@@ -52,6 +61,10 @@ export function PermissionsObserver({
     checkContinuousIntegration()
   );
   const [elevating, setElevating] = useState(false);
+  const forcePermissionsExpanded = [
+    continuousIntegrationError,
+    ...Object.values(permissionErrors),
+  ].some(Boolean);
 
   const handlePermissionChange = (
     newPermissions: Permissions,
@@ -91,30 +104,42 @@ export function PermissionsObserver({
     onEventsChange?.(newEvents);
   };
 
+  const permissionsContent = (
+    <Fragment>
+      <PermissionSelection
+        hasContinuousIntegration={hasContinuousIntegration}
+        permissions={permissions}
+        onChange={handlePermissionChange}
+        appPublished={appPublished}
+        errors={permissionErrors}
+        continuousIntegrationError={continuousIntegrationError}
+      />
+      {!newApp && elevating && (
+        <Alert.Container>
+          <Alert variant="warning">
+            {t(
+              'You are going to increase privileges for this integration. Organization members who already had access to the Client Secret may gain extra permissions due to this change. If this is not what you are expecting, consider rotating the Client Secret below.'
+            )}
+          </Alert>
+        </Alert.Container>
+      )}
+    </Fragment>
+  );
+
+  const permissionsPanel = collapsePermissions ? (
+    <CollapsiblePanel title={t('Permissions')} forceExpanded={forcePermissionsExpanded}>
+      {permissionsContent}
+    </CollapsiblePanel>
+  ) : (
+    <Panel>
+      <PanelHeader>{t('Permissions')}</PanelHeader>
+      <PanelBody>{permissionsContent}</PanelBody>
+    </Panel>
+  );
+
   return (
     <Fragment>
-      <Panel>
-        <PanelHeader>{t('Permissions')}</PanelHeader>
-        <PanelBody>
-          <PermissionSelection
-            hasContinuousIntegration={hasContinuousIntegration}
-            permissions={permissions}
-            onChange={handlePermissionChange}
-            appPublished={appPublished}
-            errors={permissionErrors}
-            continuousIntegrationError={continuousIntegrationError}
-          />
-          {!newApp && elevating && (
-            <Alert.Container>
-              <Alert variant="warning">
-                {t(
-                  'You are going to increase privileges for this integration. Organization members who already had access to the Client Secret may gain extra permissions due to this change. If this is not what you are expecting, consider rotating the Client Secret below.'
-                )}
-              </Alert>
-            </Alert.Container>
-          )}
-        </PanelBody>
-      </Panel>
+      {permissionsPanel}
       <Panel>
         <PanelHeader>{t('Webhooks')}</PanelHeader>
         <PanelBody>
@@ -128,3 +153,82 @@ export function PermissionsObserver({
     </Fragment>
   );
 }
+
+type CollapsiblePanelProps = {
+  children: React.ReactNode;
+  title: string;
+  forceExpanded?: boolean;
+};
+
+/**
+ * A disclosure that preserves the dimensions and typography of adjacent Panel headers.
+ * The core Disclosure uses a different title and content layout.
+ */
+function CollapsiblePanel({
+  children,
+  title,
+  forceExpanded = false,
+}: CollapsiblePanelProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const [isExpandedByUser, setIsExpandedByUser] = useState(false);
+  const isExpanded = forceExpanded || isExpandedByUser;
+  const disclosureProps = {
+    isExpanded,
+    onExpandedChange: setIsExpandedByUser,
+  };
+  const state = useDisclosureState(disclosureProps);
+  const {buttonProps, panelProps} = useDisclosure(disclosureProps, state, panelRef);
+  const {pressProps} = usePress(buttonProps);
+
+  return (
+    <Panel>
+      <CollapsiblePanelHeader type="button" {...pressProps}>
+        <Flex as="span" align="center" gap="md">
+          <IconChevron direction={state.isExpanded ? 'down' : 'right'} size="xs" />
+          <Text bold uppercase density="compressed" size="sm" variant="inherit">
+            {title}
+          </Text>
+        </Flex>
+      </CollapsiblePanelHeader>
+      <PanelBody ref={panelRef} {...panelProps}>
+        {children}
+      </PanelBody>
+    </Panel>
+  );
+}
+
+const CollapsiblePanelHeader = styled('button')`
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  width: 100%;
+  appearance: none;
+  padding: ${p => p.theme.space.xl};
+  color: ${p => p.theme.tokens.content.primary};
+  background: ${p => p.theme.tokens.background.secondary};
+  border: 0;
+  border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
+  border-radius: calc(${p => p.theme.radius.md} + 1px)
+    calc(${p => p.theme.radius.md} + 1px) 0 0;
+  position: relative;
+  cursor: pointer;
+  text-align: left;
+
+  &:hover {
+    background: ${p => p.theme.tokens.interactive.transparent.neutral.background.hover};
+  }
+
+  &:active {
+    background: ${p => p.theme.tokens.interactive.transparent.neutral.background.active};
+  }
+
+  &:focus-visible {
+    ${p => p.theme.focusRing()};
+    outline-offset: -2px;
+  }
+
+  &[aria-expanded='false'] {
+    border-bottom: 0;
+    border-radius: calc(${p => p.theme.radius.md} + 1px);
+  }
+`;

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.tsx
@@ -290,6 +290,10 @@ describe('Sentry Application Details', () => {
         expect(
           screen.getByRole('button', {name: 'Copy a starter prompt'})
         ).toBeInTheDocument();
+        expect(screen.getByRole('button', {name: 'Permissions'})).toHaveAttribute(
+          'aria-expanded',
+          'false'
+        );
 
         expect(screen.getByRole('checkbox', {name: 'issue'})).toBeEnabled();
         expect(screen.getByRole('checkbox', {name: 'issue'})).toBePartiallyChecked();

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -515,6 +515,7 @@ function ClaudeRoutineTemplateForm() {
         scopes={CLAUDE_ROUTINE_SCOPES}
         events={CLAUDE_ROUTINE_EVENTS}
         newApp
+        collapsePermissions
         permissionErrors={scopeErrors.permissions}
         continuousIntegrationError={scopeErrors.continuousIntegration}
         onScopesChange={scopes => form.setFieldValue('scopes', scopes)}


### PR DESCRIPTION
Collapse app permissions in sentry creation template
<img width="1232" height="452" alt="Screenshot 2026-08-10 at 1 49 56 PM" src="https://github.com/user-attachments/assets/bb9ae7f1-930f-498a-a30a-651208624ff0" />

Refs https://linear.app/getsentry/issue/ISWF-3211/clean-up-claude-routine-template-ui
