### PR TITLE
chore(ACI): Point backend alert links at monitors instead of legacy alert pages

### DIFF
--- a/src/sentry/integrations/msteams/card_builder/installation.py
+++ b/src/sentry/integrations/msteams/card_builder/installation.py
@@ -85,8 +85,8 @@ def build_installation_confirmation_message(
 def build_team_installation_confirmation_message(
     organization: Organization | RpcOrganizationSummary,
 ) -> AdaptiveCard:
-    alert_rule_url = absolute_uri(
-        InstallationMessages.ALERT_RULE_URL.format(organization_slug=organization.slug)
+    monitors_url = absolute_uri(
+        InstallationMessages.MONITORS_URL.format(organization_slug=organization.slug)
     )
 
     return build_installation_confirmation_message(
@@ -95,7 +95,7 @@ def build_team_installation_confirmation_message(
         ),
         text=InstallationMessages.TEAM_INSTALLATION_CONFIRMATION_INSTRUCTION,
         button_title=InstallationMessages.TEAM_INSTALLATION_CONFIRMATION_BUTTON,
-        url=alert_rule_url,
+        url=monitors_url,
     )
 
 

--- a/src/sentry/integrations/msteams/card_builder/utils.py
+++ b/src/sentry/integrations/msteams/card_builder/utils.py
@@ -65,7 +65,7 @@ class InstallationMessages:
     TEAM_INSTALLATION_CONFIRMATION_INSTRUCTION = (
         "Now that setup is complete, you can continue by configuring alerts."
     )
-    TEAM_INSTALLATION_CONFIRMATION_BUTTON = "Add Alert Rules"
+    TEAM_INSTALLATION_CONFIRMATION_BUTTON = "Add Monitors"
     MONITORS_URL = "organizations/{organization_slug}/monitors/"
 
     PERSONAL_INSTALLATION_CONFIRMATION_TITLE = "Personal installation successful"

--- a/src/sentry/integrations/msteams/card_builder/utils.py
+++ b/src/sentry/integrations/msteams/card_builder/utils.py
@@ -66,7 +66,7 @@ class InstallationMessages:
         "Now that setup is complete, you can continue by configuring alerts."
     )
     TEAM_INSTALLATION_CONFIRMATION_BUTTON = "Add Alert Rules"
-    ALERT_RULE_URL = "organizations/{organization_slug}/alerts/rules/"
+    MONITORS_URL = "organizations/{organization_slug}/monitors/"
 
     PERSONAL_INSTALLATION_CONFIRMATION_TITLE = "Personal installation successful"
     PERSONAL_INSTALLATION_CONFIRMATION_INSTRUCTION = (

--- a/src/sentry/notifications/platform/templates/metric_alert.py
+++ b/src/sentry/notifications/platform/templates/metric_alert.py
@@ -50,7 +50,7 @@ class MetricAlertNotificationTemplate(NotificationTemplate[MetricAlertNotificati
         open_period_context=_EXAMPLE_OPEN_PERIOD_CONTEXT,
         new_status=20,  # IncidentStatus.CRITICAL
         title="Critical: Example Alert",
-        title_link="https://sentry.io/organizations/example/alerts/rules/details/1/",
+        title_link="https://sentry.io/organizations/example/monitors/1/",
         text="123 events in the last 5 minutes",
     )
 

--- a/src/sentry/notifications/utils/__init__.py
+++ b/src/sentry/notifications/utils/__init__.py
@@ -36,10 +36,8 @@ from sentry.models.project import Project
 from sentry.models.release import Release
 from sentry.models.releasecommit import ReleaseCommit
 from sentry.models.repository import Repository
-from sentry.models.rule import Rule
 from sentry.services.eventstore.models import BaseEvent, Event, GroupEvent
 from sentry.silo.base import cell_silo_function
-from sentry.types.rules import NotificationRuleDetails
 from sentry.users.services.user import RpcUser
 from sentry.utils.committers import (
     AuthorCommitsSerialized,
@@ -124,20 +122,6 @@ def get_environment_for_deploy(deploy: Deploy | None) -> str:
         if environment and environment.name:
             return str(environment.name)
     return "Default Environment"
-
-
-def get_rules(
-    rules: Sequence[Rule], organization: Organization, project: Project
-) -> Sequence[NotificationRuleDetails]:
-    return [
-        NotificationRuleDetails(
-            rule.id,
-            rule.label,
-            f"/organizations/{organization.slug}/issues/alerts/rules/{project.slug}/{rule.id}/",
-            f"/organizations/{organization.slug}/issues/alerts/rules/{project.slug}/{rule.id}/details/",
-        )
-        for rule in rules
-    ]
 
 
 def process_serialized_committers(

--- a/tests/sentry/integrations/msteams/test_integration.py
+++ b/tests/sentry/integrations/msteams/test_integration.py
@@ -150,7 +150,7 @@ class MsTeamsApiPipelineTest(APITestCase):
     @responses.activate
     def test_team_installation(self) -> None:
         post_install_body = self._complete_install(installation_type="team")
-        assert f"organizations/{self.organization.slug}/alerts/rules/" in post_install_body
+        assert f"organizations/{self.organization.slug}/monitors/" in post_install_body
         assert self.organization.name in post_install_body
 
     @responses.activate


### PR DESCRIPTION
Update a few remaining links to old alerts pages to go to monitors pages instead, which is a step towards removing the remaining redirects.