### PR TITLE
fix(spans): Allow filtering by more than one release version

### DIFF
--- a/src/sentry/search/eap/spans/filter_aliases.py
+++ b/src/sentry/search/eap/spans/filter_aliases.py
@@ -108,14 +108,12 @@ def _semver_filter_query(
         # the limit, make an extra query and see whether the inverse has fewer ids.
         # If so, we can do a NOT IN query with these ids instead. Otherwise, we just
         # do our best.
-        negated_operator = constants.OPERATOR_NEGATION_MAP[operator]
+        operator = constants.OPERATOR_NEGATION_MAP[operator]
         # Note that the `order_by` here is important for index usage. Postgres seems
         # to seq scan with this query if the `order_by` isn't included, so we
         # include it even though we don't really care about order for this query
         qs_flipped = (
-            Release.objects.filter_by_semver(
-                organization_id, parse_semver(version, negated_operator)
-            )
+            Release.objects.filter_by_semver(organization_id, parse_semver(version, operator))
             .order_by(*map(_flip_field_sort, order_by))
             .values_list("version", flat=True)[: constants.MAX_SEARCH_RELEASES]
         )

--- a/src/sentry/search/eap/spans/filter_aliases.py
+++ b/src/sentry/search/eap/spans/filter_aliases.py
@@ -212,7 +212,6 @@ def semver_build_filter_converter(
         )
 
     raw_values: list[str] = to_list(search_filter.value.raw_value)
-    is_negated = search_filter.operator == "NOT IN"
     effective_operator = (
         "=" if search_filter.operator in ("IN", "NOT IN") else search_filter.operator
     )
@@ -246,7 +245,9 @@ def semver_build_filter_converter(
         # XXX: Just return a filter that will return no results if we have no versions
         all_versions = [constants.SEMVER_EMPTY_RELEASE]
 
-    final_operator: Literal["IN", "NOT IN"] = "NOT IN" if is_negated else "IN"
+    final_operator: Literal["IN", "NOT IN"] = (
+        "NOT IN" if search_filter.operator == "NOT IN" else "IN"
+    )
     return [
         SearchFilter(SearchKey(constants.RELEASE_ALIAS), final_operator, SearchValue(all_versions))
     ]

--- a/src/sentry/search/eap/spans/filter_aliases.py
+++ b/src/sentry/search/eap/spans/filter_aliases.py
@@ -80,20 +80,12 @@ def release_stage_filter_converter(
     return [SearchFilter(SearchKey(constants.RELEASE_ALIAS), "IN", SearchValue(versions))]
 
 
-def semver_filter_converter(
-    params: SnubaParams, search_filter: SearchFilter, _resolver: Any
-) -> list[SearchFilter]:
-    organization_id = params.organization_id
-    if organization_id is None:
-        raise ValueError("organization is a required param")
-    # We explicitly use `raw_value` here to avoid converting wildcards to shell values
-    if not isinstance(search_filter.value.raw_value, str):
-        raise InvalidSearchQuery(
-            f"{search_filter.key.name}: Invalid value: {search_filter.value.raw_value}. Expected a semver version."
-        )
-    version: str = search_filter.value.raw_value
-    operator: str = search_filter.operator
-
+def _semver_filter_query(
+    organization_id: int,
+    version: str,
+    operator: str,
+    project_ids: list[int] | None,
+) -> tuple[list[str], Literal["IN", "NOT IN"]]:
     # Note that we sort this such that if we end up fetching more than
     # MAX_SEMVER_SEARCH_RELEASES, we will return the releases that are closest to
     # the passed filter.
@@ -104,7 +96,7 @@ def semver_filter_converter(
         Release.objects.filter_by_semver(
             organization_id,
             parse_semver(version, operator),
-            project_ids=params.project_ids,
+            project_ids=project_ids,
         )
         .values_list("version", flat=True)
         .order_by(*order_by)[: constants.MAX_SEARCH_RELEASES]
@@ -116,12 +108,14 @@ def semver_filter_converter(
         # the limit, make an extra query and see whether the inverse has fewer ids.
         # If so, we can do a NOT IN query with these ids instead. Otherwise, we just
         # do our best.
-        operator = constants.OPERATOR_NEGATION_MAP[operator]
+        negated_operator = constants.OPERATOR_NEGATION_MAP[operator]
         # Note that the `order_by` here is important for index usage. Postgres seems
         # to seq scan with this query if the `order_by` isn't included, so we
         # include it even though we don't really care about order for this query
         qs_flipped = (
-            Release.objects.filter_by_semver(organization_id, parse_semver(version, operator))
+            Release.objects.filter_by_semver(
+                organization_id, parse_semver(version, negated_operator)
+            )
             .order_by(*map(_flip_field_sort, order_by))
             .values_list("version", flat=True)[: constants.MAX_SEARCH_RELEASES]
         )
@@ -131,6 +125,35 @@ def semver_filter_converter(
             # Do a negative search instead
             final_operator = "NOT IN"
             versions = exclude_versions
+
+    return versions, final_operator
+
+
+def semver_filter_converter(
+    params: SnubaParams, search_filter: SearchFilter, _resolver: Any
+) -> list[SearchFilter]:
+    organization_id = params.organization_id
+    if organization_id is None:
+        raise ValueError("organization is a required param")
+    # We explicitly use `raw_value` here to avoid converting wildcards to shell values
+    if not isinstance(search_filter.value.raw_value, (str, list)):
+        raise InvalidSearchQuery(
+            f"{search_filter.key.name}: Invalid value: {search_filter.value.raw_value}. Expected a semver version."
+        )
+
+    raw_values: list[str] = to_list(search_filter.value.raw_value)
+    operator = "=" if search_filter.operator in ("IN", "NOT IN") else search_filter.operator
+
+    final_operator: Literal["IN", "NOT IN"] = "IN"
+    if len(raw_values) == 1:
+        versions, final_operator = _semver_filter_query(
+            organization_id, raw_values[0], operator, params.project_ids
+        )
+    else:
+        versions = []
+        for version in raw_values:
+            v, _ = _semver_filter_query(organization_id, version, operator, params.project_ids)
+            versions.extend(v)
 
     if not validate_snuba_array_parameter(versions):
         raise InvalidSearchQuery(
@@ -184,39 +207,46 @@ def semver_build_filter_converter(
     if organization_id is None:
         raise ValueError("organization is a required param")
 
-    if not isinstance(search_filter.value.raw_value, str):
+    if not isinstance(search_filter.value.raw_value, (str, list)):
         raise InvalidSearchQuery(
             f"{search_filter.key.name}: Invalid value: {search_filter.value.raw_value}. Expected a semver build."
         )
-    build: str = search_filter.value.raw_value
 
-    operator, negated = handle_operator_negation(search_filter.operator)
+    raw_values: list[str] = to_list(search_filter.value.raw_value)
+    effective_operator = (
+        "=" if search_filter.operator in ("IN", "NOT IN") else search_filter.operator
+    )
+    operator, negated = handle_operator_negation(effective_operator)
     try:
         django_op = constants.OPERATOR_TO_DJANGO[operator]
     except KeyError:
         raise InvalidSearchQuery("Invalid operation 'IN' for semantic version filter.")
-    versions = list(
-        Release.objects.filter_by_semver_build(
-            organization_id,
-            django_op,
-            build,
-            project_ids=params.project_ids,
-            negated=negated,
-        )
-        .values_list("version", flat=True)
-        .order_by("-date_added")[: constants.MAX_SEARCH_RELEASES]
-    )
 
-    if not validate_snuba_array_parameter(versions):
+    all_versions: list[str] = []
+    for build in raw_values:
+        versions = list(
+            Release.objects.filter_by_semver_build(
+                organization_id,
+                django_op,
+                build,
+                project_ids=params.project_ids,
+                negated=negated,
+            )
+            .values_list("version", flat=True)
+            .order_by("-date_added")[: constants.MAX_SEARCH_RELEASES]
+        )
+        all_versions.extend(versions)
+
+    if not validate_snuba_array_parameter(all_versions):
         raise InvalidSearchQuery(
             "There are too many releases that match your release.build filter, please try again with a narrower range"
         )
 
-    if not versions:
+    if not all_versions:
         # XXX: Just return a filter that will return no results if we have no versions
-        versions = [constants.SEMVER_EMPTY_RELEASE]
+        all_versions = [constants.SEMVER_EMPTY_RELEASE]
 
-    return [SearchFilter(SearchKey(constants.RELEASE_ALIAS), "IN", SearchValue(versions))]
+    return [SearchFilter(SearchKey(constants.RELEASE_ALIAS), "IN", SearchValue(all_versions))]
 
 
 def trace_filter_converter(

--- a/src/sentry/search/eap/spans/filter_aliases.py
+++ b/src/sentry/search/eap/spans/filter_aliases.py
@@ -140,17 +140,20 @@ def semver_filter_converter(
         )
 
     raw_values: list[str] = to_list(search_filter.value.raw_value)
+    is_negated = search_filter.operator == "NOT IN"
     operator = "=" if search_filter.operator in ("IN", "NOT IN") else search_filter.operator
 
-    final_operator: Literal["IN", "NOT IN"] = "IN"
+    final_operator: Literal["IN", "NOT IN"] = "NOT IN" if is_negated else "IN"
     if len(raw_values) == 1:
         versions, final_operator = _semver_filter_query(
             organization_id, raw_values[0], operator, params.project_ids
         )
+        if is_negated:
+            final_operator = "NOT IN" if final_operator == "IN" else "IN"
     else:
         versions = []
         for version in raw_values:
-            v, _ = _semver_filter_query(organization_id, version, operator, params.project_ids)
+            v, _ = _semver_filter_query(organization_id, version, "=", params.project_ids)
             versions.extend(v)
 
     if not validate_snuba_array_parameter(versions):
@@ -244,7 +247,14 @@ def semver_build_filter_converter(
         # XXX: Just return a filter that will return no results if we have no versions
         all_versions = [constants.SEMVER_EMPTY_RELEASE]
 
-    return [SearchFilter(SearchKey(constants.RELEASE_ALIAS), "IN", SearchValue(all_versions))]
+    build_final_operator: Literal["IN", "NOT IN"] = (
+        "NOT IN" if search_filter.operator == "NOT IN" else "IN"
+    )
+    return [
+        SearchFilter(
+            SearchKey(constants.RELEASE_ALIAS), build_final_operator, SearchValue(all_versions)
+        )
+    ]
 
 
 def trace_filter_converter(

--- a/src/sentry/search/eap/spans/filter_aliases.py
+++ b/src/sentry/search/eap/spans/filter_aliases.py
@@ -247,13 +247,11 @@ def semver_build_filter_converter(
         # XXX: Just return a filter that will return no results if we have no versions
         all_versions = [constants.SEMVER_EMPTY_RELEASE]
 
-    build_final_operator: Literal["IN", "NOT IN"] = (
+    final_operator: Literal["IN", "NOT IN"] = (
         "NOT IN" if search_filter.operator == "NOT IN" else "IN"
     )
     return [
-        SearchFilter(
-            SearchKey(constants.RELEASE_ALIAS), build_final_operator, SearchValue(all_versions)
-        )
+        SearchFilter(SearchKey(constants.RELEASE_ALIAS), final_operator, SearchValue(all_versions))
     ]
 
 

--- a/src/sentry/search/eap/spans/filter_aliases.py
+++ b/src/sentry/search/eap/spans/filter_aliases.py
@@ -80,53 +80,6 @@ def release_stage_filter_converter(
     return [SearchFilter(SearchKey(constants.RELEASE_ALIAS), "IN", SearchValue(versions))]
 
 
-def _semver_filter_query(
-    organization_id: int,
-    version: str,
-    operator: str,
-    project_ids: list[int] | None,
-) -> tuple[list[str], Literal["IN", "NOT IN"]]:
-    # Note that we sort this such that if we end up fetching more than
-    # MAX_SEMVER_SEARCH_RELEASES, we will return the releases that are closest to
-    # the passed filter.
-    order_by = Release.SEMVER_COLS
-    if operator.startswith("<"):
-        order_by = list(map(_flip_field_sort, order_by))
-    qs = (
-        Release.objects.filter_by_semver(
-            organization_id,
-            parse_semver(version, operator),
-            project_ids=project_ids,
-        )
-        .values_list("version", flat=True)
-        .order_by(*order_by)[: constants.MAX_SEARCH_RELEASES]
-    )
-    versions = list(qs)
-    final_operator: Literal["IN", "NOT IN"] = "IN"
-    if len(versions) == constants.MAX_SEARCH_RELEASES:
-        # We want to limit how many versions we pass through to Snuba. If we've hit
-        # the limit, make an extra query and see whether the inverse has fewer ids.
-        # If so, we can do a NOT IN query with these ids instead. Otherwise, we just
-        # do our best.
-        operator = constants.OPERATOR_NEGATION_MAP[operator]
-        # Note that the `order_by` here is important for index usage. Postgres seems
-        # to seq scan with this query if the `order_by` isn't included, so we
-        # include it even though we don't really care about order for this query
-        qs_flipped = (
-            Release.objects.filter_by_semver(organization_id, parse_semver(version, operator))
-            .order_by(*map(_flip_field_sort, order_by))
-            .values_list("version", flat=True)[: constants.MAX_SEARCH_RELEASES]
-        )
-
-        exclude_versions = list(qs_flipped)
-        if exclude_versions and len(exclude_versions) < len(versions):
-            # Do a negative search instead
-            final_operator = "NOT IN"
-            versions = exclude_versions
-
-    return versions, final_operator
-
-
 def semver_filter_converter(
     params: SnubaParams, search_filter: SearchFilter, _resolver: Any
 ) -> list[SearchFilter]:
@@ -143,29 +96,74 @@ def semver_filter_converter(
     is_negated = search_filter.operator == "NOT IN"
     operator = "=" if search_filter.operator in ("IN", "NOT IN") else search_filter.operator
 
+    # Note that we sort this such that if we end up fetching more than
+    # MAX_SEMVER_SEARCH_RELEASES, we will return the releases that are closest to
+    # the passed filter.
+    order_by = Release.SEMVER_COLS
+    if operator.startswith("<"):
+        order_by = list(map(_flip_field_sort, order_by))
+
+    all_versions: list[str] = []
     final_operator: Literal["IN", "NOT IN"] = "NOT IN" if is_negated else "IN"
     if len(raw_values) == 1:
-        versions, final_operator = _semver_filter_query(
-            organization_id, raw_values[0], operator, params.project_ids
+        qs = (
+            Release.objects.filter_by_semver(
+                organization_id,
+                parse_semver(raw_values[0], operator),
+                project_ids=params.project_ids,
+            )
+            .values_list("version", flat=True)
+            .order_by(*order_by)[: constants.MAX_SEARCH_RELEASES]
         )
-        if is_negated:
-            final_operator = "NOT IN" if final_operator == "IN" else "IN"
-    else:
-        versions = []
-        for version in raw_values:
-            v, _ = _semver_filter_query(organization_id, version, "=", params.project_ids)
-            versions.extend(v)
+        versions = list(qs)
+        if len(versions) == constants.MAX_SEARCH_RELEASES:
+            # We want to limit how many versions we pass through to Snuba. If we've hit
+            # the limit, make an extra query and see whether the inverse has fewer ids.
+            # If so, we can do a NOT IN query with these ids instead. Otherwise, we just
+            # do our best.
+            negated_operator = constants.OPERATOR_NEGATION_MAP[operator]
+            # Note that the `order_by` here is important for index usage. Postgres seems
+            # to seq scan with this query if the `order_by` isn't included, so we
+            # include it even though we don't really care about order for this query
+            qs_flipped = (
+                Release.objects.filter_by_semver(
+                    organization_id, parse_semver(raw_values[0], negated_operator)
+                )
+                .order_by(*map(_flip_field_sort, order_by))
+                .values_list("version", flat=True)[: constants.MAX_SEARCH_RELEASES]
+            )
 
-    if not validate_snuba_array_parameter(versions):
+            exclude_versions = list(qs_flipped)
+            if exclude_versions and len(exclude_versions) < len(versions):
+                # Do a negative search instead
+                final_operator = "IN" if is_negated else "NOT IN"
+                versions = exclude_versions
+        all_versions.extend(versions)
+    else:
+        for version in raw_values:
+            qs = (
+                Release.objects.filter_by_semver(
+                    organization_id,
+                    parse_semver(version, "="),
+                    project_ids=params.project_ids,
+                )
+                .values_list("version", flat=True)
+                .order_by(*order_by)[: constants.MAX_SEARCH_RELEASES]
+            )
+            all_versions.extend(qs)
+
+    if not validate_snuba_array_parameter(all_versions):
         raise InvalidSearchQuery(
             "There are too many releases that match your release.version filter, please try again with a narrower range"
         )
 
-    if not versions:
+    if not all_versions:
         # XXX: Just return a filter that will return no results if we have no versions
-        versions = [constants.SEMVER_EMPTY_RELEASE]
+        all_versions = [constants.SEMVER_EMPTY_RELEASE]
 
-    return [SearchFilter(SearchKey(constants.RELEASE_ALIAS), final_operator, SearchValue(versions))]
+    return [
+        SearchFilter(SearchKey(constants.RELEASE_ALIAS), final_operator, SearchValue(all_versions))
+    ]
 
 
 def semver_package_filter_converter(
@@ -214,6 +212,7 @@ def semver_build_filter_converter(
         )
 
     raw_values: list[str] = to_list(search_filter.value.raw_value)
+    is_negated = search_filter.operator == "NOT IN"
     effective_operator = (
         "=" if search_filter.operator in ("IN", "NOT IN") else search_filter.operator
     )
@@ -247,9 +246,7 @@ def semver_build_filter_converter(
         # XXX: Just return a filter that will return no results if we have no versions
         all_versions = [constants.SEMVER_EMPTY_RELEASE]
 
-    final_operator: Literal["IN", "NOT IN"] = (
-        "NOT IN" if search_filter.operator == "NOT IN" else "IN"
-    )
+    final_operator: Literal["IN", "NOT IN"] = "NOT IN" if is_negated else "IN"
     return [
         SearchFilter(SearchKey(constants.RELEASE_ALIAS), final_operator, SearchValue(all_versions))
     ]

--- a/src/sentry/search/eap/spans/filter_aliases.py
+++ b/src/sentry/search/eap/spans/filter_aliases.py
@@ -140,6 +140,8 @@ def semver_filter_converter(
                 versions = exclude_versions
         all_versions.extend(versions)
     else:
+        # TODO: filter_by_semver has no bulk lookup for multiple versions, so each value is a separate query.
+        # Adding __in support or Q-object composition to filter_by_semver would reduce the query count.
         for version in raw_values:
             qs = (
                 Release.objects.filter_by_semver(
@@ -221,6 +223,8 @@ def semver_build_filter_converter(
     except KeyError:
         raise InvalidSearchQuery("Invalid operation 'IN' for semantic version filter.")
 
+    # TODO: filter_by_semver_build has no bulk lookup for multiple builds, so each value is a separate query.
+    # Adding __in support or Q-object composition to filter_by_semver_build would reduce the query count.
     all_versions: list[str] = []
     for build in raw_values:
         versions = list(

--- a/src/sentry/search/events/datasets/filter_aliases.py
+++ b/src/sentry/search/events/datasets/filter_aliases.py
@@ -241,14 +241,12 @@ def semver_filter_converter(
             # the limit, make an extra query and see whether the inverse has fewer ids.
             # If so, we can do a NOT IN query with these ids instead. Otherwise, we just
             # do our best.
-            negated_operator = constants.OPERATOR_NEGATION_MAP[operator]
+            operator = constants.OPERATOR_NEGATION_MAP[operator]
             # Note that the `order_by` here is important for index usage. Postgres seems
             # to seq scan with this query if the `order_by` isn't included, so we
             # include it even though we don't really care about order for this query
             qs_flipped = (
-                Release.objects.filter_by_semver(
-                    organization_id, parse_semver(version, negated_operator)
-                )
+                Release.objects.filter_by_semver(organization_id, parse_semver(version, operator))
                 .order_by(*map(_flip_field_sort, order_by))
                 .values_list("version", flat=True)[: constants.MAX_SEARCH_RELEASES]
             )

--- a/src/sentry/search/events/datasets/filter_aliases.py
+++ b/src/sentry/search/events/datasets/filter_aliases.py
@@ -333,7 +333,6 @@ def semver_build_filter_converter(
         raise InvalidSearchQuery("Invalid value for semver build filter")
 
     raw_values: list[str] = to_list(raw_value)
-    is_negated = search_filter.operator == "NOT IN"
     effective_operator = (
         "=" if search_filter.operator in ("IN", "NOT IN") else search_filter.operator
     )
@@ -367,7 +366,7 @@ def semver_build_filter_converter(
         # XXX: Just return a filter that will return no results if we have no versions
         all_versions = [constants.SEMVER_EMPTY_RELEASE]
 
-    final_operator = Op.NOT_IN if is_negated else Op.IN
+    final_operator = Op.NOT_IN if search_filter.operator == "NOT IN" else Op.IN
     return Condition(builder.column("release"), final_operator, all_versions)
 
 

--- a/src/sentry/search/events/datasets/filter_aliases.py
+++ b/src/sentry/search/events/datasets/filter_aliases.py
@@ -214,6 +214,7 @@ def semver_filter_converter(
         raise InvalidSearchQuery("Invalid value for semver filter")
 
     raw_values: list[str] = to_list(raw_value)
+    is_negated = search_filter.operator == "NOT IN"
     operator: str = "=" if search_filter.operator in ("IN", "NOT IN") else search_filter.operator
 
     # Note that we sort this such that if we end up fetching more than
@@ -224,29 +225,31 @@ def semver_filter_converter(
         order_by = list(map(_flip_field_sort, order_by))
 
     all_versions: list[str] = []
-    final_operator = Op.IN
-    for version in raw_values:
+    final_operator = Op.NOT_IN if is_negated else Op.IN
+    if len(raw_values) == 1:
         qs = (
             Release.objects.filter_by_semver(
                 organization_id,
-                parse_semver(version, operator),
+                parse_semver(raw_values[0], operator),
                 project_ids=builder.params.project_ids,
             )
             .values_list("version", flat=True)
             .order_by(*order_by)[: constants.MAX_SEARCH_RELEASES]
         )
         versions = list(qs)
-        if len(raw_values) == 1 and len(versions) == constants.MAX_SEARCH_RELEASES:
+        if len(versions) == constants.MAX_SEARCH_RELEASES:
             # We want to limit how many versions we pass through to Snuba. If we've hit
             # the limit, make an extra query and see whether the inverse has fewer ids.
             # If so, we can do a NOT IN query with these ids instead. Otherwise, we just
             # do our best.
-            operator = constants.OPERATOR_NEGATION_MAP[operator]
+            negated_operator = constants.OPERATOR_NEGATION_MAP[operator]
             # Note that the `order_by` here is important for index usage. Postgres seems
             # to seq scan with this query if the `order_by` isn't included, so we
             # include it even though we don't really care about order for this query
             qs_flipped = (
-                Release.objects.filter_by_semver(organization_id, parse_semver(version, operator))
+                Release.objects.filter_by_semver(
+                    organization_id, parse_semver(raw_values[0], negated_operator)
+                )
                 .order_by(*map(_flip_field_sort, order_by))
                 .values_list("version", flat=True)[: constants.MAX_SEARCH_RELEASES]
             )
@@ -254,9 +257,21 @@ def semver_filter_converter(
             exclude_versions = list(qs_flipped)
             if exclude_versions and len(exclude_versions) < len(versions):
                 # Do a negative search instead
-                final_operator = Op.NOT_IN
+                final_operator = Op.IN if is_negated else Op.NOT_IN
                 versions = exclude_versions
         all_versions.extend(versions)
+    else:
+        for version in raw_values:
+            qs = (
+                Release.objects.filter_by_semver(
+                    organization_id,
+                    parse_semver(version, "="),
+                    project_ids=builder.params.project_ids,
+                )
+                .values_list("version", flat=True)
+                .order_by(*order_by)[: constants.MAX_SEARCH_RELEASES]
+            )
+            all_versions.extend(qs)
 
     if not validate_snuba_array_parameter(all_versions):
         raise InvalidSearchQuery(
@@ -351,7 +366,8 @@ def semver_build_filter_converter(
         # XXX: Just return a filter that will return no results if we have no versions
         all_versions = [constants.SEMVER_EMPTY_RELEASE]
 
-    return Condition(builder.column("release"), Op.IN, all_versions)
+    build_final_operator = Op.NOT_IN if search_filter.operator == "NOT IN" else Op.IN
+    return Condition(builder.column("release"), build_final_operator, all_versions)
 
 
 def device_class_converter(

--- a/src/sentry/search/events/datasets/filter_aliases.py
+++ b/src/sentry/search/events/datasets/filter_aliases.py
@@ -333,6 +333,7 @@ def semver_build_filter_converter(
         raise InvalidSearchQuery("Invalid value for semver build filter")
 
     raw_values: list[str] = to_list(raw_value)
+    is_negated = search_filter.operator == "NOT IN"
     effective_operator = (
         "=" if search_filter.operator in ("IN", "NOT IN") else search_filter.operator
     )
@@ -366,8 +367,8 @@ def semver_build_filter_converter(
         # XXX: Just return a filter that will return no results if we have no versions
         all_versions = [constants.SEMVER_EMPTY_RELEASE]
 
-    build_final_operator = Op.NOT_IN if search_filter.operator == "NOT IN" else Op.IN
-    return Condition(builder.column("release"), build_final_operator, all_versions)
+    final_operator = Op.NOT_IN if is_negated else Op.IN
+    return Condition(builder.column("release"), final_operator, all_versions)
 
 
 def device_class_converter(

--- a/src/sentry/search/events/datasets/filter_aliases.py
+++ b/src/sentry/search/events/datasets/filter_aliases.py
@@ -261,6 +261,8 @@ def semver_filter_converter(
                 versions = exclude_versions
         all_versions.extend(versions)
     else:
+        # TODO: filter_by_semver has no bulk lookup for multiple versions, so each value is a separate query.
+        # Adding __in support or Q-object composition to filter_by_semver would reduce the query count.
         for version in raw_values:
             qs = (
                 Release.objects.filter_by_semver(
@@ -342,6 +344,8 @@ def semver_build_filter_converter(
     except KeyError:
         raise InvalidSearchQuery("Invalid operation 'IN' for semantic version filter.")
 
+    # TODO: filter_by_semver_build has no bulk lookup for multiple builds, so each value is a separate query.
+    # Adding __in support or Q-object composition to filter_by_semver_build would reduce the query count.
     all_versions: list[str] = []
     for build in raw_values:
         versions = list(

--- a/src/sentry/search/events/datasets/filter_aliases.py
+++ b/src/sentry/search/events/datasets/filter_aliases.py
@@ -210,10 +210,11 @@ def semver_filter_converter(
     organization_id: int = builder.params.organization.id
     # We explicitly use `raw_value` here to avoid converting wildcards to shell values
     raw_value = search_filter.value.raw_value
-    if not isinstance(raw_value, str):
+    if not isinstance(raw_value, (str, list)):
         raise InvalidSearchQuery("Invalid value for semver filter")
-    version: str = raw_value
-    operator: str = search_filter.operator
+
+    raw_values: list[str] = to_list(raw_value)
+    operator: str = "=" if search_filter.operator in ("IN", "NOT IN") else search_filter.operator
 
     # Note that we sort this such that if we end up fetching more than
     # MAX_SEMVER_SEARCH_RELEASES, we will return the releases that are closest to
@@ -221,48 +222,54 @@ def semver_filter_converter(
     order_by = Release.SEMVER_COLS
     if operator.startswith("<"):
         order_by = list(map(_flip_field_sort, order_by))
-    qs = (
-        Release.objects.filter_by_semver(
-            organization_id,
-            parse_semver(version, operator),
-            project_ids=builder.params.project_ids,
-        )
-        .values_list("version", flat=True)
-        .order_by(*order_by)[: constants.MAX_SEARCH_RELEASES]
-    )
-    versions = list(qs)
+
+    all_versions: list[str] = []
     final_operator = Op.IN
-    if len(versions) == constants.MAX_SEARCH_RELEASES:
-        # We want to limit how many versions we pass through to Snuba. If we've hit
-        # the limit, make an extra query and see whether the inverse has fewer ids.
-        # If so, we can do a NOT IN query with these ids instead. Otherwise, we just
-        # do our best.
-        operator = constants.OPERATOR_NEGATION_MAP[operator]
-        # Note that the `order_by` here is important for index usage. Postgres seems
-        # to seq scan with this query if the `order_by` isn't included, so we
-        # include it even though we don't really care about order for this query
-        qs_flipped = (
-            Release.objects.filter_by_semver(organization_id, parse_semver(version, operator))
-            .order_by(*map(_flip_field_sort, order_by))
-            .values_list("version", flat=True)[: constants.MAX_SEARCH_RELEASES]
+    for version in raw_values:
+        qs = (
+            Release.objects.filter_by_semver(
+                organization_id,
+                parse_semver(version, operator),
+                project_ids=builder.params.project_ids,
+            )
+            .values_list("version", flat=True)
+            .order_by(*order_by)[: constants.MAX_SEARCH_RELEASES]
         )
+        versions = list(qs)
+        if len(raw_values) == 1 and len(versions) == constants.MAX_SEARCH_RELEASES:
+            # We want to limit how many versions we pass through to Snuba. If we've hit
+            # the limit, make an extra query and see whether the inverse has fewer ids.
+            # If so, we can do a NOT IN query with these ids instead. Otherwise, we just
+            # do our best.
+            negated_operator = constants.OPERATOR_NEGATION_MAP[operator]
+            # Note that the `order_by` here is important for index usage. Postgres seems
+            # to seq scan with this query if the `order_by` isn't included, so we
+            # include it even though we don't really care about order for this query
+            qs_flipped = (
+                Release.objects.filter_by_semver(
+                    organization_id, parse_semver(version, negated_operator)
+                )
+                .order_by(*map(_flip_field_sort, order_by))
+                .values_list("version", flat=True)[: constants.MAX_SEARCH_RELEASES]
+            )
 
-        exclude_versions = list(qs_flipped)
-        if exclude_versions and len(exclude_versions) < len(versions):
-            # Do a negative search instead
-            final_operator = Op.NOT_IN
-            versions = exclude_versions
+            exclude_versions = list(qs_flipped)
+            if exclude_versions and len(exclude_versions) < len(versions):
+                # Do a negative search instead
+                final_operator = Op.NOT_IN
+                versions = exclude_versions
+        all_versions.extend(versions)
 
-    if not validate_snuba_array_parameter(versions):
+    if not validate_snuba_array_parameter(all_versions):
         raise InvalidSearchQuery(
             "There are too many releases that match your release.version filter, please try again with a narrower range"
         )
 
-    if not versions:
+    if not all_versions:
         # XXX: Just return a filter that will return no results if we have no versions
-        versions = [constants.SEMVER_EMPTY_RELEASE]
+        all_versions = [constants.SEMVER_EMPTY_RELEASE]
 
-    return Condition(builder.column("release"), final_operator, versions)
+    return Condition(builder.column("release"), final_operator, all_versions)
 
 
 def semver_package_filter_converter(
@@ -309,37 +316,44 @@ def semver_build_filter_converter(
     if builder.params.organization is None:
         raise ValueError("organization is a required param")
     raw_value = search_filter.value.raw_value
-    if not isinstance(raw_value, str):
+    if not isinstance(raw_value, (str, list)):
         raise InvalidSearchQuery("Invalid value for semver build filter")
-    build: str = raw_value
 
-    operator, negated = handle_operator_negation(search_filter.operator)
+    raw_values: list[str] = to_list(raw_value)
+    effective_operator = (
+        "=" if search_filter.operator in ("IN", "NOT IN") else search_filter.operator
+    )
+    operator, negated = handle_operator_negation(effective_operator)
     try:
         django_op = constants.OPERATOR_TO_DJANGO[operator]
     except KeyError:
         raise InvalidSearchQuery("Invalid operation 'IN' for semantic version filter.")
-    versions = list(
-        Release.objects.filter_by_semver_build(
-            builder.params.organization.id,
-            django_op,
-            build,
-            project_ids=builder.params.project_ids,
-            negated=negated,
-        )
-        .values_list("version", flat=True)
-        .order_by("-date_added")[: constants.MAX_SEARCH_RELEASES]
-    )
 
-    if not validate_snuba_array_parameter(versions):
+    all_versions: list[str] = []
+    for build in raw_values:
+        versions = list(
+            Release.objects.filter_by_semver_build(
+                builder.params.organization.id,
+                django_op,
+                build,
+                project_ids=builder.params.project_ids,
+                negated=negated,
+            )
+            .values_list("version", flat=True)
+            .order_by("-date_added")[: constants.MAX_SEARCH_RELEASES]
+        )
+        all_versions.extend(versions)
+
+    if not validate_snuba_array_parameter(all_versions):
         raise InvalidSearchQuery(
             "There are too many releases that match your release.build filter, please try again with a narrower range"
         )
 
-    if not versions:
+    if not all_versions:
         # XXX: Just return a filter that will return no results if we have no versions
-        versions = [constants.SEMVER_EMPTY_RELEASE]
+        all_versions = [constants.SEMVER_EMPTY_RELEASE]
 
-    return Condition(builder.column("release"), Op.IN, versions)
+    return Condition(builder.column("release"), Op.IN, all_versions)
 
 
 def device_class_converter(

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -5942,6 +5942,16 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
             },
         ]
 
+        response = self.do_request({**request, "query": "!release.version:[3.0.1, 3.0.3]"})
+        assert response.status_code == 200, response.content
+        assert response.data["data"] == [
+            {
+                "id": span2["span_id"],
+                "project.name": self.project.slug,
+                "release": "test@3.0.2",
+            },
+        ]
+
     def test_semver_package(self) -> None:
         release_1 = self.create_release(version="test1@1.2.1")
         release_2 = self.create_release(version="test2@1.2.1")
@@ -6103,6 +6113,16 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
                 "id": span3["span_id"],
                 "project.name": self.project.slug,
                 "release": "test@3.0.0+503",
+            },
+        ]
+
+        response = self.do_request({**request, "query": "!release.build:[501, 503]"})
+        assert response.status_code == 200, response.content
+        assert response.data["data"] == [
+            {
+                "id": span2["span_id"],
+                "project.name": self.project.slug,
+                "release": "test@3.0.0+502",
             },
         ]
 

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -5904,6 +5904,44 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
             },
         ]
 
+    def test_semver_multiple_values(self) -> None:
+        release_1 = self.create_release(version="test@3.0.1")
+        release_2 = self.create_release(version="test@3.0.2")
+        release_3 = self.create_release(version="test@3.0.3")
+
+        span1 = self.create_span(
+            {"sentry_tags": {"release": release_1.version}}, start_ts=self.ten_mins_ago
+        )
+        span2 = self.create_span(
+            {"sentry_tags": {"release": release_2.version}}, start_ts=self.ten_mins_ago
+        )
+        span3 = self.create_span(
+            {"sentry_tags": {"release": release_3.version}}, start_ts=self.ten_mins_ago
+        )
+        self.store_spans([span1, span2, span3])
+
+        request = {
+            "field": ["release"],
+            "project": self.project.id,
+            "dataset": "spans",
+            "orderby": "release",
+        }
+
+        response = self.do_request({**request, "query": "release.version:[3.0.1, 3.0.3]"})
+        assert response.status_code == 200, response.content
+        assert response.data["data"] == [
+            {
+                "id": span1["span_id"],
+                "project.name": self.project.slug,
+                "release": "test@3.0.1",
+            },
+            {
+                "id": span3["span_id"],
+                "project.name": self.project.slug,
+                "release": "test@3.0.3",
+            },
+        ]
+
     def test_semver_package(self) -> None:
         release_1 = self.create_release(version="test1@1.2.1")
         release_2 = self.create_release(version="test2@1.2.1")
@@ -6027,6 +6065,44 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
                 "id": span2["span_id"],
                 "project.name": self.project.slug,
                 "release": "test@1.2.3+122",
+            },
+        ]
+
+    def test_semver_build_multiple_values(self) -> None:
+        release_1 = self.create_release(version="test@3.0.0+501")
+        release_2 = self.create_release(version="test@3.0.0+502")
+        release_3 = self.create_release(version="test@3.0.0+503")
+
+        span1 = self.create_span(
+            {"sentry_tags": {"release": release_1.version}}, start_ts=self.ten_mins_ago
+        )
+        span2 = self.create_span(
+            {"sentry_tags": {"release": release_2.version}}, start_ts=self.ten_mins_ago
+        )
+        span3 = self.create_span(
+            {"sentry_tags": {"release": release_3.version}}, start_ts=self.ten_mins_ago
+        )
+        self.store_spans([span1, span2, span3])
+
+        request = {
+            "field": ["release"],
+            "project": self.project.id,
+            "dataset": "spans",
+            "orderby": "release",
+        }
+
+        response = self.do_request({**request, "query": "release.build:[501, 503]"})
+        assert response.status_code == 200, response.content
+        assert response.data["data"] == [
+            {
+                "id": span1["span_id"],
+                "project.name": self.project.slug,
+                "release": "test@3.0.0+501",
+            },
+            {
+                "id": span3["span_id"],
+                "project.name": self.project.slug,
+                "release": "test@3.0.0+503",
             },
         ]
 


### PR DESCRIPTION
⚠️ Best viewed with whitespace changes off

Fixes a bug where searching for `release.version:[X,Y]` or `release.build:[A,B]` wouldn't pass validation and be handled properly. This PR checks that the raw value can be a list of items, and then builds the correct downstream queries to handle either 1 or many versions

To process many versions, we do not currently have bulk querying support so I added a TODO to follow up on in a different PR as to keep scope low. This PR at least allows us to start querying for multiple values, we can follow up with the improvement.