### PR TITLE
fix(replays): Issue Replay archive events in the the time range of the original Replay

### DIFF
--- a/src/sentry/replays/scripts/delete_replays.py
+++ b/src/sentry/replays/scripts/delete_replays.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import functools
 import logging
-import uuid
 from collections.abc import Sequence
 from datetime import datetime, timezone
 
@@ -26,9 +25,11 @@ from sentry.replays.query import replay_url_parser_config
 from sentry.replays.tasks import archive_replay, delete_replays_script_async
 from sentry.replays.usecases.delete import (
     SNUBA_RETRY_EXCEPTIONS,
+    MatchedRow,
     datetime_as_start_of_day_conditions,
     day_aligned_windows,
     delete_seer_replay_data,
+    snuba_timestamp_as_utc,
 )
 from sentry.replays.usecases.query import execute_query, handle_search_filters
 from sentry.replays.usecases.query.configs.scalar import scalar_search_config
@@ -121,7 +122,7 @@ def translate_cli_tags_param_to_snuba_tag_param(tags: list[str]) -> Sequence[Que
 def delete_replay_ids(
     project_id: int,
     organization_id: int,
-    rows: list[tuple[int, str, int]],
+    rows: list[MatchedRow],
     has_seer_data: bool,
     total_replays: int,
     *,
@@ -153,8 +154,8 @@ def delete_replay_ids(
         # This also gives us reasonable assurances that if the script ran to completion the customer
         # will not be able to access their deleted data even if the actual deletion takes place some
         # time later
-        for _, replay_id, _ in rows:
-            archive_replay(project_id, replay_id)
+        for row in rows:
+            archive_replay(project_id, row["replay_id"].replace("-", ""), row["timestamp"])
     else:
         # Archiving is the only step the customer can observe. Without it they keep their Replays.
         logger.warning(
@@ -164,9 +165,8 @@ def delete_replay_ids(
         )
 
     if has_seer_data and delete_seer_data:
-        # The finder strips dashes from `replay_id`; Seer keys on the dashed UUID
         logger.info("Deleting Seer data for %d Replays.", len(rows), extra=logging_context)
-        replay_ids = [str(uuid.UUID(replay_id)) for _, replay_id, _ in rows]
+        replay_ids = [row["replay_id"] for row in rows]
         # Raises once the request's retries are spent, which aborts the run!
         delete_seer_replay_data(organization_id, project_id, replay_ids)
 
@@ -178,8 +178,13 @@ def delete_replay_ids(
         # Because this operation could involve millions of requests to the blob storage provider we
         # schedule the tasks to run on a cluster of workers. This allows us to parallelize the work
         # and complete the task as quickly as possible.
-        for retention_days, replay_id, max_segment_id in rows:
-            delete_replays_script_async.delay(retention_days, project_id, replay_id, max_segment_id)
+        for row in rows:
+            delete_replays_script_async.delay(
+                row["retention_days"],
+                project_id,
+                row["replay_id"].replace("-", ""),
+                row["max_segment_id"],
+            )
 
     logger.info(
         "Finished processing %d Replays.",
@@ -197,7 +202,7 @@ def _get_rows_matching_deletion_pattern(
     start: datetime,
     search_filters: Sequence[QueryToken],
     environment: list[str],
-) -> tuple[list[tuple[int, str, int]], bool, int | None]:
+) -> tuple[list[MatchedRow], bool, int | None]:
     where = handle_search_filters(scalar_search_config, search_filters)
 
     if environment:
@@ -223,6 +228,7 @@ def _get_rows_matching_deletion_pattern(
             Function("any", parameters=[Column("retention_days")], alias="retention_days"),
             Column("replay_id"),
             Function("max", parameters=[Column("segment_id")], alias="max_segment_id"),
+            Function("max", parameters=[Column("timestamp")], alias="finished_at"),
             replay_id_hash_column,
         ],
         where=[
@@ -262,7 +268,12 @@ def _get_rows_matching_deletion_pattern(
 
     return (
         [
-            (item["retention_days"], item["replay_id"].replace("-", ""), item["max_segment_id"])
+            {
+                "retention_days": item["retention_days"],
+                "replay_id": item["replay_id"],
+                "max_segment_id": item["max_segment_id"],
+                "timestamp": snuba_timestamp_as_utc(item["finished_at"]),
+            }
             for item in data
             if item["max_segment_id"] is not None
         ],

--- a/src/sentry/replays/tasks.py
+++ b/src/sentry/replays/tasks.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 from typing import Any
 
 import sentry_sdk
@@ -54,7 +55,11 @@ def delete_replay(
 ) -> None:
     """Asynchronously delete a replay."""
     metrics.incr("replays.delete_replay", amount=1, tags={"status": "started"})
-    archive_replay(project_id, replay_id)
+    # It would be _much better_ to actually fetch the Replay's timestamp here,
+    # and issue `archive_replay` with a timestamp. Something to fix in the near
+    # future. Otherwise, if the delete event is too far away from the Replay it
+    # might show up as un-archived in the UI depending on the query range.
+    archive_replay(project_id, replay_id, timezone.now())
     delete_replay_recording(project_id, replay_id)
 
     if has_seer_data and organization_id is not None:
@@ -181,9 +186,9 @@ def delete_replay_recording(project_id: int, replay_id: str) -> None:
         segment_model.delete()
 
 
-def archive_replay(project_id: int, replay_id: str) -> None:
+def archive_replay(project_id: int, replay_id: str, timestamp: datetime) -> None:
     """Archive a Replay instance. The Replay is not deleted."""
-    message = archive_event(project_id, replay_id)
+    message = archive_event(project_id, replay_id, timestamp)
 
     # We publish manually here because we sometimes provide a managed Kafka
     # publisher interface which has its own setup and teardown behavior.

--- a/src/sentry/replays/usecases/delete.py
+++ b/src/sentry/replays/usecases/delete.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import functools
 import logging
 from collections.abc import Iterator
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import TypedDict
 
 from google.cloud.exceptions import NotFound
@@ -44,6 +44,7 @@ from sentry.utils.snuba import (
     RateLimitExceeded,
     SnubaError,
     UnexpectedResponseError,
+    parse_snuba_datetime,
 )
 
 SNUBA_RETRY_EXCEPTIONS = (
@@ -121,14 +122,18 @@ def delete_matched_rows(project_id: int, rows: list[MatchedRow]) -> int | None:
         return None
 
     delete_filenames_concurrently(list(_make_recording_filenames(project_id, rows)))
-    delete_replays(project_id, [row["replay_id"] for row in rows])
+    delete_replays(project_id, rows)
     return None
 
 
-def delete_replays(project_id: int, replay_ids: list[str]) -> None:
-    """Set the archived bit flag to true on each replay."""
-    for replay_id in replay_ids:
-        publish_replay_event(archive_event(project_id, replay_id))
+def delete_replays(project_id: int, rows: list[MatchedRow]) -> None:
+    """Set the archived bit flag to true on each replay.
+
+    Each archive event is stamped with the replay's own timestamp rather than "now" so it lands in
+    the same date range the replay does and hides it there.
+    """
+    for row in rows:
+        publish_replay_event(archive_event(project_id, row["replay_id"], row["timestamp"]))
 
 
 #  Keeping this small bounds threads-per-task so `worker_concurrency x N` stays under pod memory limit
@@ -197,8 +202,11 @@ def _make_recording_filenames(project_id: int, rows: list[MatchedRow]) -> Iterat
 
 class MatchedRow(TypedDict):
     retention_days: int
+    # Replay ID with dashes
     replay_id: str
     max_segment_id: int | None
+    # The Replay's last segment within the queried window
+    timestamp: datetime
 
 
 class MatchedRows(TypedDict):
@@ -243,6 +251,7 @@ def fetch_rows_matching_pattern(
             Function("any", parameters=[Column("retention_days")], alias="retention_days"),
             Column("replay_id"),
             Function("max", parameters=[Column("segment_id")], alias="max_segment_id"),
+            Function("max", parameters=[Column("timestamp")], alias="finished_at"),
             replay_id_hash_column,
         ],
         where=[
@@ -293,10 +302,22 @@ def fetch_rows_matching_pattern(
                 "max_segment_id": row["max_segment_id"],
                 "replay_id": row["replay_id"],
                 "retention_days": row["retention_days"],
+                "timestamp": snuba_timestamp_as_utc(row["finished_at"]),
             }
             for row in rows
         ],
     }
+
+
+def snuba_timestamp_as_utc(value: str) -> datetime:
+    """Parse a timestamp Snuba returned, as UTC.
+
+    Snuba renders datetimes with a zone sometimes and without one others. They are UTC either way,
+    and an unzoned one has to be told so before anything reads it as an instant -- `.timestamp()`
+    treats a naive datetime as local time, which would shift it by the host's offset.
+    """
+    parsed = parse_snuba_datetime(value)
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
 
 
 SEER_DELETE_RETRY = Retry(

--- a/src/sentry/replays/usecases/events.py
+++ b/src/sentry/replays/usecases/events.py
@@ -2,13 +2,20 @@ from __future__ import annotations
 
 import time
 import uuid
+from datetime import datetime
 from typing import Any
 
 from sentry.utils import json
 
 
-def archive_event(project_id: int, replay_id: str) -> str:
-    """Create an archive "replay_event" message."""
+def archive_event(project_id: int, replay_id: str, timestamp: datetime) -> str:
+    """Create an archive "replay_event" message.
+
+    `timestamp` decides which day the archive row lands in. Replay queries always carry a timestamp
+    window and aggregate `is_archived` per replay within it, so an archive row stamped "now" is
+    invisible to anyone looking at the deleted replay's own date range. Pass the replay's own
+    timestamp whenever the caller knows it.
+    """
     return _replay_event(
         project_id=project_id,
         replay_id=replay_id,
@@ -20,7 +27,7 @@ def archive_event(project_id: int, replay_id: str) -> str:
             "trace_ids": [],
             "error_ids": [],
             "urls": [],
-            "timestamp": time.time(),
+            "timestamp": timestamp.timestamp(),
             "is_archived": True,
             "platform": "",
         },

--- a/tests/sentry/replays/tasks/test_delete_replays_bulk.py
+++ b/tests/sentry/replays/tasks/test_delete_replays_bulk.py
@@ -23,6 +23,10 @@ from sentry.replays.usecases.delete import (
 )
 from sentry.testutils.cases import APITestCase, ReplaysSnubaTestCase
 from sentry.testutils.helpers import TaskRunner
+from sentry.utils import json
+
+# Stand-in for rows whose timestamp the test does not care about.
+EPOCH = datetime.datetime(1970, 1, 1, tzinfo=datetime.UTC)
 
 
 class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
@@ -67,11 +71,13 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
                     "retention_days": 90,
                     "replay_id": "a",
                     "max_segment_id": 1,
+                    "timestamp": EPOCH,
                 },
                 {
                     "retention_days": 90,
                     "replay_id": "b",
                     "max_segment_id": 0,
+                    "timestamp": EPOCH,
                 },
             ],
             "has_more": True,
@@ -131,11 +137,13 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
                     "retention_days": 90,
                     "replay_id": "a",
                     "max_segment_id": 1,
+                    "timestamp": EPOCH,
                 },
                 {
                     "retention_days": 90,
                     "replay_id": "b",
                     "max_segment_id": None,
+                    "timestamp": EPOCH,
                 },
             ],
             "has_more": False,
@@ -278,7 +286,9 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
     ) -> None:
         """Test a duplicate activation behind the checkpoint does not rewind progress"""
         mock_fetch_rows.return_value = {
-            "rows": [{"retention_days": 90, "replay_id": "a", "max_segment_id": 1}],
+            "rows": [
+                {"retention_days": 90, "replay_id": "a", "max_segment_id": 1, "timestamp": EPOCH}
+            ],
             "has_more": True,
             "next_cursor": 1234,
         }
@@ -301,7 +311,9 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
     ) -> None:
         """Test an activation killed between checkpointing and enqueueing still finishes"""
         mock_fetch_rows.return_value = {
-            "rows": [{"retention_days": 90, "replay_id": "a", "max_segment_id": 1}],
+            "rows": [
+                {"retention_days": 90, "replay_id": "a", "max_segment_id": 1, "timestamp": EPOCH}
+            ],
             "has_more": False,
             "next_cursor": 1234,
         }
@@ -323,7 +335,9 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
     ) -> None:
         """Test a checkpoint written by a further-along chain is not overwritten"""
         mock_fetch_rows.return_value = {
-            "rows": [{"retention_days": 90, "replay_id": "a", "max_segment_id": 1}],
+            "rows": [
+                {"retention_days": 90, "replay_id": "a", "max_segment_id": 1, "timestamp": EPOCH}
+            ],
             "has_more": True,
             "next_cursor": 1234,
         }
@@ -441,7 +455,9 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
     ) -> None:
         """Test a chain finishing after another completed the job leaves it completed"""
         mock_fetch_rows.return_value = {
-            "rows": [{"retention_days": 90, "replay_id": "a", "max_segment_id": 1}],
+            "rows": [
+                {"retention_days": 90, "replay_id": "a", "max_segment_id": 1, "timestamp": EPOCH}
+            ],
             "has_more": True,
             "next_cursor": 1234,
         }
@@ -483,6 +499,10 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
         )
         assert len(result["rows"]) == 1
         assert result["rows"][0]["replay_id"] == str(uuid.UUID(replay_id))
+        # The replay's own timestamp comes back so the archive event can be stamped with it.
+        # `mock_replay` writes `int(timestamp.timestamp())` and the column is a ClickHouse
+        # `DateTime`, so `t3` arrives truncated to the second.
+        assert result["rows"][0]["timestamp"] == t3.replace(tzinfo=datetime.UTC, microsecond=0)
 
     def test_fetch_rows_matching_pattern_keyset_pagination(self) -> None:
         """Test paging by `cityHash64(replay_id)` returns every replay exactly once.
@@ -549,6 +569,7 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
                     "retention_days": retention_days,
                     "replay_id": str(uuid.UUID(replay_id)),
                     "max_segment_id": max_segment_id,
+                    "timestamp": EPOCH,
                 }
             ],
         )
@@ -566,6 +587,34 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
                 is None
             )
 
+    @patch("sentry.replays.usecases.delete.publish_replay_event")
+    def test_delete_matched_rows_archives_in_the_replays_own_range(
+        self, mock_publish: MagicMock
+    ) -> None:
+        """The archive event carries the replay's own timestamp, not "now".
+
+        Replay queries aggregate `is_archived` per replay within a timestamp window, so an archive
+        row stamped "now" leaves a replay deleted today still looking un-archived to anyone querying
+        the range it was actually recorded in.
+        """
+        timestamp = datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(days=30)
+
+        delete_matched_rows(
+            self.project.id,
+            [
+                {
+                    "retention_days": 30,
+                    "replay_id": str(uuid.uuid4()),
+                    "max_segment_id": None,
+                    "timestamp": timestamp,
+                }
+            ],
+        )
+
+        message = json.loads(mock_publish.call_args[0][0])
+        assert message["payload"]["timestamp"] == timestamp.timestamp()
+        assert message["payload"]["is_archived"] is True
+
     @patch("sentry.replays.usecases.delete.make_replay_delete_request")
     @patch("sentry.replays.tasks.fetch_rows_matching_pattern")
     @patch("sentry.replays.tasks.delete_matched_rows")
@@ -582,11 +631,13 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
                         "retention_days": 90,
                         "replay_id": "a",
                         "max_segment_id": 1,
+                        "timestamp": EPOCH,
                     },
                     {
                         "retention_days": 90,
                         "replay_id": "b",
                         "max_segment_id": 0,
+                        "timestamp": EPOCH,
                     },
                 ],
                 "has_more": True,
@@ -598,6 +649,7 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
                         "retention_days": 90,
                         "replay_id": "c",
                         "max_segment_id": 1,
+                        "timestamp": EPOCH,
                     },
                 ],
                 "has_more": False,
@@ -742,13 +794,27 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
         def row_generator() -> Generator[MatchedRows]:
             # Window 1, page 1: has_more=True triggers pagination within the same window
             yield {
-                "rows": [{"retention_days": 90, "replay_id": "a", "max_segment_id": 1}],
+                "rows": [
+                    {
+                        "retention_days": 90,
+                        "replay_id": "a",
+                        "max_segment_id": 1,
+                        "timestamp": EPOCH,
+                    }
+                ],
                 "has_more": True,
                 "next_cursor": 1234,
             }
             # Window 1, page 2: no more rows, advance to next window
             yield {
-                "rows": [{"retention_days": 90, "replay_id": "b", "max_segment_id": 1}],
+                "rows": [
+                    {
+                        "retention_days": 90,
+                        "replay_id": "b",
+                        "max_segment_id": 1,
+                        "timestamp": EPOCH,
+                    }
+                ],
                 "has_more": False,
                 "next_cursor": 1234,
             }
@@ -800,11 +866,13 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
                         "retention_days": 90,
                         "replay_id": "a",
                         "max_segment_id": 1,
+                        "timestamp": EPOCH,
                     },
                     {
                         "retention_days": 90,
                         "replay_id": "b",
                         "max_segment_id": 0,
+                        "timestamp": EPOCH,
                     },
                 ],
                 "has_more": True,
@@ -816,6 +884,7 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
                         "retention_days": 90,
                         "replay_id": "c",
                         "max_segment_id": 1,
+                        "timestamp": EPOCH,
                     },
                 ],
                 "has_more": False,
@@ -850,7 +919,9 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
         still needs running.
         """
         mock_fetch_rows.return_value = {
-            "rows": [{"retention_days": 90, "replay_id": "a", "max_segment_id": 1}],
+            "rows": [
+                {"retention_days": 90, "replay_id": "a", "max_segment_id": 1, "timestamp": EPOCH}
+            ],
             "has_more": False,
             "next_cursor": None,
         }

--- a/tests/sentry/replays/unit/usecases/test_events.py
+++ b/tests/sentry/replays/unit/usecases/test_events.py
@@ -1,4 +1,5 @@
 import time
+from datetime import datetime, timezone
 
 from sentry.replays.usecases.events import archive_event, viewed_event
 from sentry.utils import json
@@ -6,7 +7,9 @@ from sentry.utils import json
 
 def test_archive_event() -> None:
     """Test archive event generator."""
-    event = archive_event(1, "2")
+    # An old timestamp: the archive row has to land in the replay's own date range, not today's.
+    ts = datetime(2023, 6, 21, tzinfo=timezone.utc)
+    event = archive_event(1, "2", ts)
 
     parsed_event = json.loads(event)
     assert parsed_event["type"] == "replay_event"
@@ -23,7 +26,9 @@ def test_archive_event() -> None:
     assert parsed_event["payload"]["urls"] == []
     assert parsed_event["payload"]["is_archived"] is True
     assert parsed_event["payload"]["platform"] == ""
-    assert isinstance(parsed_event["payload"]["timestamp"], float)
+    assert parsed_event["payload"]["timestamp"] == ts.timestamp()
+    # "now" belongs to the envelope, which only feeds consumer latency metrics.
+    assert parsed_event["start_time"] != int(ts.timestamp())
 
 
 def test_viewed_event() -> None:


### PR DESCRIPTION
So. When we archive a Replay, we send an "archived" event to ClickHouse, with that Replay's ID. When we then fetch Replays, we do so by _aggregating_ on the Replay ID. If there was an "archive" event there, the whole Replay is archived.

The difficulty is what if the archive event is months later than the Replay? Imagine we archive a Replay from May 10th on August 10th. If a user looks at a list of Replays by filtering for May, the "archive" event isn't even part of the returned data, so the Replay looks unarchived!

The solution here is to issue the Replay "Archive" event with a timestamp that's very close to the actual Replay contents. For now I'm just doing this for bulk deletes, which are more likely to run into this issue.

N.B. This isn't fully free. This will create new parts in ClickHouse that have to be merged with old parts via `MergeTree`. In theory this _could_ cause ClickHouse to get mad. We run these bulks jobs manually though, and we can keep an eye on ClickHouse performance as we do it, and simply run them slower.

One review note:

Snuba returns Replay IDs with `"-"` dashes in them. _Seer_ needs dashed IDs to remove the data. GCS needs _undashed_ ones. ClickHouse is agnostic. That's why there's conversion code.

Closes REPLAY-976