### PR TITLE
ref(api): Withhold attribute context from the public spec

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -215,7 +215,9 @@ EXPAND_QUERY_PARAM = OpenApiParameter(
     many=True,
     type=str,
     enum=["context"],
-    # Internal-only for now, so exclude it from the public OpenAPI spec.
+    # Withheld from the public OpenAPI spec because the context shape it returns
+    # is still evolving. The matching half is the ``exclude_fields=["context"]``
+    # on ``TraceItemAttributeKey``, which keeps that shape out of the spec too.
     exclude=True,
     description=(
         "Optional fields to expand. Pass `context` to include attribute metadata "

--- a/src/sentry/api/endpoints/organization_trace_item_attributes_types.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes_types.py
@@ -1,5 +1,7 @@
 from typing import Any, Literal, NotRequired, TypedDict
 
+from drf_spectacular.utils import extend_schema_serializer
+
 from sentry.search.eap.types import ColumnType
 
 
@@ -40,6 +42,7 @@ class TraceItemAttributeContext(TypedDict):
     replacementAttribute: NotRequired[str]
 
 
+@extend_schema_serializer(exclude_fields=["context"])
 class TraceItemAttributeKey(TypedDict):
     key: str
     name: str
@@ -48,4 +51,8 @@ class TraceItemAttributeKey(TypedDict):
     attributeType: ColumnType
     # Attribute context, only present when requested via ``expand=context``.
     # Attached to every attribute, and empty when it has no metadata.
+    #
+    # Excluded from the OpenAPI spec above: the context shape is still evolving,
+    # so we don't want public consumers depending on it. It stays on the
+    # TypedDict, so mypy and the runtime are unaffected.
     context: NotRequired[TraceItemAttributeContext]


### PR DESCRIPTION
The public docs for `GET /organizations/{org}/trace-items/attributes/` showed the `context` part of the response, but not the `expand=context` param needed to fetch it.

We want `context` to stay undocumented so we can change its shape without breaking consumers. So this hides it from the spec rather than documenting the param.

`context` stays on the TypedDict, so mypy and the runtime are unaffected — only the spec loses it, and `TraceItemAttributeContext` drops out of `components` automatically. No runtime, serializer, or test-behaviour changes.

### Verification

Before/after `openapi-derefed.json` diff: exactly one path differs, and after deleting `context` from the baseline the two are byte-identical. Same for the one changed component.

- `make build-api-docs` succeeds; `prek` and mypy clean.
- mypy still resolves `k["context"]` to the full shape (`k["notARealKey"]` still errors) — hidden from the spec only.
- Confirmed the validator isn't strict on extra keys: a real `?expand=context` response where every attribute carried `context` still passes `validate_schema`.
- Existing `context` assertions in `tests/snuba/.../test_organization_trace_item_attributes.py` pass **untouched** — the evidence this is spec-only.

Refs BROWSE-701
