### PR TITLE
fix(issues): Run sentry.tasks.schedule_auto_transition_to_ongoing every 3min (instead of every 5)

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1163,7 +1163,7 @@ TASKWORKER_REGION_SCHEDULES: ScheduleConfigMap = {
     },
     "schedule_auto_transition_to_ongoing": {
         "task": "issues:sentry.tasks.schedule_auto_transition_to_ongoing",
-        "schedule": crontab("*/5", "*", "*", "*", "*"),
+        "schedule": crontab("*/3", "*", "*", "*", "*"),
     },
     "statistical-detectors-detect-regressions": {
         "task": "performance:sentry.tasks.statistical_detectors.run_detection",

--- a/src/sentry/tasks/auto_ongoing_issues.py
+++ b/src/sentry/tasks/auto_ongoing_issues.py
@@ -30,7 +30,7 @@ CHILD_TASK_COUNT = 250
 )
 def schedule_auto_transition_to_ongoing() -> None:
     """
-    Triggered by cronjob every minute. This task will spawn subtasks
+    Triggered by cronjob every 3 minutes. This task will spawn subtasks
     that transition Issues to Ongoing according to their specific
     criteria.
     """


### PR DESCRIPTION
This task creates a spike of concurrent Group changes, which results in spikes of (among other things) action publishes every minute.
It originally ran every minute, but timed out ocassionally; there was performance work to address that, but it was never made more frequent. From recent metrics, it seems like all related tasks reliably finish in under 10s or so, so every 3min should be quite safe, and should distribute the load better.

We'd like to get back to every minute, but given the limited ability to gate scheduling changes, it seems safer to start at every 3.
