### PR TITLE
feat(scraps): interactive Chip compound components

### DIFF
--- a/static/app/components/core/chip/chip.mdx
+++ b/static/app/components/core/chip/chip.mdx
@@ -41,6 +41,39 @@ token, or pass `value` alone for a standalone token.
 <Chip value="Chrome" />
 ```
 
+## Interactive sections
+
+Compose the primitives when individual sections need to be interactive
+(click-to-edit, remove). Each section renders inert text until you give it an
+`onClick`, at which point it becomes a focusable button. `Chip.Dismiss` is always
+a button and stops its click from bubbling to the chip.
+
+By default `Chip.Root` manages a roving tabindex: a single tab stop enters the
+chip and <kbd>←</kbd>/<kbd>→</kbd>/<kbd>Home</kbd>/<kbd>End</kbd> move between
+sections. Pass `focus="manual"` when an outer system (e.g. the search query
+builder grid) already owns focus — sections then defer entirely to the props you
+spread onto them.
+
+<Storybook.Demo>
+  <Flex gap="md" align="center" wrap="wrap">
+    <Chip.Root size="sm">
+      <Chip.Property onClick={() => {}}>browser</Chip.Property>
+      <Chip.Operator onClick={() => {}}>is</Chip.Operator>
+      <Chip.Value onClick={() => {}}>Chrome</Chip.Value>
+      <Chip.Dismiss onClick={() => {}} />
+    </Chip.Root>
+  </Flex>
+</Storybook.Demo>
+
+```jsx
+<Chip.Root size="sm">
+  <Chip.Property onClick={editKey}>browser</Chip.Property>
+  <Chip.Operator onClick={editOperator}>is</Chip.Operator>
+  <Chip.Value onClick={editValue}>Chrome</Chip.Value>
+  <Chip.Dismiss onClick={remove} />
+</Chip.Root>
+```
+
 ## Sizes
 
 Available sizes are `xs`, `sm`, and `md` (default).

--- a/static/app/components/core/chip/chip.mdx
+++ b/static/app/components/core/chip/chip.mdx
@@ -48,11 +48,11 @@ Compose the primitives when individual sections need to be interactive
 `onClick`, at which point it becomes a focusable button. `Chip.Dismiss` is always
 a button and stops its click from bubbling to the chip.
 
-By default `Chip.Root` manages a roving tabindex: a single tab stop enters the
-chip and <kbd>←</kbd>/<kbd>→</kbd>/<kbd>Home</kbd>/<kbd>End</kbd> move between
-sections. Pass `focus="manual"` when an outer system (e.g. the search query
-builder grid) already owns focus — sections then defer entirely to the props you
-spread onto them.
+By default (`focus="auto"`) `Chip.Root` manages a roving tabindex: a single tab
+stop enters the chip and <kbd>←</kbd>/<kbd>→</kbd>/<kbd>Home</kbd>/<kbd>End</kbd>
+move between sections. Pass `focus="manual"` when an outer system (e.g. the
+search query builder grid) already owns focus — sections then defer entirely to
+the props you spread onto them.
 
 <Storybook.Demo>
   <Flex gap="md" align="center" wrap="wrap">

--- a/static/app/components/core/chip/chip.snapshots.tsx
+++ b/static/app/components/core/chip/chip.snapshots.tsx
@@ -86,5 +86,60 @@ describe('Chip', () => {
       ),
       {tags: {variant: 'query', interactive: 'true', area: 'core'}}
     );
+
+    it.snapshot(
+      'interactive-section-hover',
+      () => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8}}>
+            <Chip.Root size="sm">
+              <Chip.Property onClick={() => {}}>browser</Chip.Property>
+              <Chip.Operator onClick={() => {}}>is</Chip.Operator>
+              <Chip.Value onClick={() => {}}>Chrome</Chip.Value>
+              <Chip.Dismiss onClick={() => {}} />
+            </Chip.Root>
+          </div>
+        </ThemeProvider>
+      ),
+      {
+        tags: {variant: 'query', interactive: 'true', state: 'hover', area: 'core'},
+        interaction: {hover: '[data-chip-interactive]'},
+      }
+    );
+
+    it.snapshot(
+      'interactive-section-active',
+      () => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8}}>
+            <Chip.Root size="sm">
+              <Chip.Property onClick={() => {}}>browser</Chip.Property>
+              <Chip.Operator onClick={() => {}}>is</Chip.Operator>
+              <Chip.Value onClick={() => {}}>Chrome</Chip.Value>
+              <Chip.Dismiss onClick={() => {}} />
+            </Chip.Root>
+          </div>
+        </ThemeProvider>
+      ),
+      {
+        tags: {variant: 'query', interactive: 'true', state: 'active', area: 'core'},
+        interaction: {active: '[data-chip-interactive]'},
+      }
+    );
+
+    it.snapshot(
+      'dismiss-hover',
+      () => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8}}>
+            <Chip value="Chrome" onDismiss={() => {}} />
+          </div>
+        </ThemeProvider>
+      ),
+      {
+        tags: {variant: 'value', dismissable: 'true', state: 'hover', area: 'core'},
+        interaction: {hover: '[data-chip-dismiss]'},
+      }
+    );
   });
 });

--- a/static/app/components/core/chip/chip.snapshots.tsx
+++ b/static/app/components/core/chip/chip.snapshots.tsx
@@ -69,5 +69,22 @@ describe('Chip', () => {
       ),
       {tags: {variant: 'value', dismissable: 'true', area: 'core'}}
     );
+
+    it.snapshot(
+      'interactive-sections',
+      () => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8}}>
+            <Chip.Root size="sm">
+              <Chip.Property onClick={() => {}}>browser</Chip.Property>
+              <Chip.Operator onClick={() => {}}>is</Chip.Operator>
+              <Chip.Value onClick={() => {}}>Chrome</Chip.Value>
+              <Chip.Dismiss onClick={() => {}} />
+            </Chip.Root>
+          </div>
+        </ThemeProvider>
+      ),
+      {tags: {variant: 'query', interactive: 'true', area: 'core'}}
+    );
   });
 });

--- a/static/app/components/core/chip/chip.spec.tsx
+++ b/static/app/components/core/chip/chip.spec.tsx
@@ -43,7 +43,9 @@ describe('Chip', () => {
         // @ts-expect-error onDismiss is not allowed alongside readonly
         <Chip readonly property="browser" value="Chrome" onDismiss={() => {}} />
       );
-      expect(screen.queryByRole('button', {name: 'Remove browser Chrome'})).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', {name: 'Remove browser Chrome'})
+      ).not.toBeInTheDocument();
     });
   });
 
@@ -148,6 +150,41 @@ describe('Chip', () => {
 
       await userEvent.keyboard('{ArrowLeft}');
       expect(screen.getByRole('button', {name: 'Remove'})).toHaveFocus();
+    });
+
+    it('moves the tab stop to follow the focused section', async () => {
+      render(<InteractiveChip />);
+
+      await userEvent.tab();
+      await userEvent.keyboard('{ArrowRight}');
+
+      // The single tab stop follows focus rather than snapping back to the first
+      // section, so tabbing away and back returns to where the user left off.
+      expect(screen.getByRole('button', {name: 'browser'})).toHaveAttribute(
+        'tabindex',
+        '-1'
+      );
+      expect(screen.getByRole('button', {name: 'is'})).toHaveAttribute('tabindex', '0');
+    });
+
+    it('keeps the managed tab stop authoritative over a caller tabIndex', () => {
+      render(
+        <Chip.Root>
+          <Chip.Property onClick={() => {}} tabIndex={5}>
+            browser
+          </Chip.Property>
+          <Chip.Value onClick={() => {}}>Chrome</Chip.Value>
+        </Chip.Root>
+      );
+      // A caller tabIndex must not override roving management in auto mode.
+      expect(screen.getByRole('button', {name: 'browser'})).toHaveAttribute(
+        'tabindex',
+        '0'
+      );
+      expect(screen.getByRole('button', {name: 'Chrome'})).toHaveAttribute(
+        'tabindex',
+        '-1'
+      );
     });
 
     it('defers focus to caller props in manual mode', () => {

--- a/static/app/components/core/chip/chip.spec.tsx
+++ b/static/app/components/core/chip/chip.spec.tsx
@@ -3,43 +3,166 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {Chip} from '@sentry/scraps/chip';
 
 describe('Chip', () => {
-  it('renders property, operator, and value', () => {
-    render(<Chip property="browser" operator="is" value="Chrome" />);
-    expect(screen.getByText('browser')).toBeInTheDocument();
-    expect(screen.getByText('is')).toBeInTheDocument();
-    expect(screen.getByText('Chrome')).toBeInTheDocument();
+  describe('flat API', () => {
+    it('renders property, operator, and value', () => {
+      render(<Chip property="browser" operator="is" value="Chrome" />);
+      expect(screen.getByText('browser')).toBeInTheDocument();
+      expect(screen.getByText('is')).toBeInTheDocument();
+      expect(screen.getByText('Chrome')).toBeInTheDocument();
+    });
+
+    it('omits the operator when not provided', () => {
+      render(<Chip property="browser" value="Chrome" />);
+      expect(screen.getByText('browser')).toBeInTheDocument();
+      expect(screen.getByText('Chrome')).toBeInTheDocument();
+      expect(screen.queryByText('is')).not.toBeInTheDocument();
+    });
+
+    it('renders only the value when property is omitted', () => {
+      render(<Chip value="Chrome" />);
+      expect(screen.getByText('Chrome')).toBeInTheDocument();
+      expect(screen.queryByText('browser')).not.toBeInTheDocument();
+    });
+
+    it('is not interactive by default', () => {
+      render(<Chip property="browser" operator="is" value="Chrome" />);
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+
+    it('renders a dismiss button and fires onDismiss', async () => {
+      const onDismiss = jest.fn();
+      render(<Chip property="browser" value="Chrome" onDismiss={onDismiss} />);
+      await userEvent.click(screen.getByRole('button', {name: 'Remove browser Chrome'}));
+      expect(onDismiss).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not render a dismiss button when readonly', () => {
+      render(
+        // readonly chips cannot be dismissed — the union rejects onDismiss at
+        // compile time; assert the runtime guard suppresses it as well.
+        // @ts-expect-error onDismiss is not allowed alongside readonly
+        <Chip readonly property="browser" value="Chrome" onDismiss={() => {}} />
+      );
+      expect(screen.queryByRole('button', {name: 'Remove browser Chrome'})).not.toBeInTheDocument();
+    });
   });
 
-  it('omits the operator when not provided', () => {
-    render(<Chip property="browser" value="Chrome" />);
-    expect(screen.getByText('browser')).toBeInTheDocument();
-    expect(screen.getByText('Chrome')).toBeInTheDocument();
-    expect(screen.queryByText('is')).not.toBeInTheDocument();
+  describe('compound API', () => {
+    it('renders sections as inert text by default', () => {
+      render(
+        <Chip.Root>
+          <Chip.Property>browser</Chip.Property>
+          <Chip.Operator>is</Chip.Operator>
+          <Chip.Value>Chrome</Chip.Value>
+        </Chip.Root>
+      );
+      expect(screen.getByText('browser')).toBeInTheDocument();
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+
+    it('renders a section as a button when given onClick and fires it', async () => {
+      const editValue = jest.fn();
+      render(
+        <Chip.Root>
+          <Chip.Property>browser</Chip.Property>
+          <Chip.Value onClick={editValue}>Chrome</Chip.Value>
+        </Chip.Root>
+      );
+
+      // Property stays inert, value becomes a button.
+      expect(screen.queryByRole('button', {name: 'browser'})).not.toBeInTheDocument();
+      await userEvent.click(screen.getByRole('button', {name: 'Chrome'}));
+      expect(editValue).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps dismiss clicks from bubbling to the chip', async () => {
+      const onChipClick = jest.fn();
+      const onDismiss = jest.fn();
+      render(
+        <Chip.Root onClick={onChipClick}>
+          <Chip.Value>Chrome</Chip.Value>
+          <Chip.Dismiss onClick={onDismiss} />
+        </Chip.Root>
+      );
+
+      await userEvent.click(screen.getByRole('button', {name: 'Remove'}));
+      expect(onDismiss).toHaveBeenCalledTimes(1);
+      expect(onChipClick).not.toHaveBeenCalled();
+    });
+
+    it('renders interactive sections as inert when the root is readonly', () => {
+      render(
+        <Chip.Root readonly>
+          <Chip.Value onClick={() => {}}>Chrome</Chip.Value>
+          <Chip.Dismiss onClick={() => {}} />
+        </Chip.Root>
+      );
+      expect(screen.getByText('Chrome')).toBeInTheDocument();
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
   });
 
-  it('renders only the value when property is omitted', () => {
-    render(<Chip value="Chrome" />);
-    expect(screen.getByText('Chrome')).toBeInTheDocument();
-    expect(screen.queryByText('browser')).not.toBeInTheDocument();
-    expect(screen.queryByText('is')).not.toBeInTheDocument();
-  });
+  describe('roving focus', () => {
+    function InteractiveChip() {
+      return (
+        <Chip.Root>
+          <Chip.Property onClick={() => {}}>browser</Chip.Property>
+          <Chip.Operator onClick={() => {}}>is</Chip.Operator>
+          <Chip.Value onClick={() => {}}>Chrome</Chip.Value>
+          <Chip.Dismiss onClick={() => {}} />
+        </Chip.Root>
+      );
+    }
 
-  it('renders property/operator/value when readonly', () => {
-    render(<Chip readonly property="browser" operator="is" value="Chrome" />);
-    expect(screen.getByText('browser')).toBeInTheDocument();
-    expect(screen.getByText('is')).toBeInTheDocument();
-    expect(screen.getByText('Chrome')).toBeInTheDocument();
-  });
+    it('exposes a single tab stop', () => {
+      render(<InteractiveChip />);
+      expect(screen.getByRole('button', {name: 'browser'})).toHaveAttribute(
+        'tabindex',
+        '0'
+      );
+      expect(screen.getByRole('button', {name: 'is'})).toHaveAttribute('tabindex', '-1');
+      expect(screen.getByRole('button', {name: 'Chrome'})).toHaveAttribute(
+        'tabindex',
+        '-1'
+      );
+      expect(screen.getByRole('button', {name: 'Remove'})).toHaveAttribute(
+        'tabindex',
+        '-1'
+      );
+    });
 
-  it('is not dismissable by default', () => {
-    render(<Chip property="browser" value="Chrome" />);
-    expect(screen.queryByRole('button', {name: 'Remove'})).not.toBeInTheDocument();
-  });
+    it('moves focus between sections with the arrow keys', async () => {
+      render(<InteractiveChip />);
 
-  it('renders a dismiss button and fires onDismiss', async () => {
-    const onDismiss = jest.fn();
-    render(<Chip property="browser" value="Chrome" onDismiss={onDismiss} />);
-    await userEvent.click(screen.getByRole('button', {name: 'Remove browser Chrome'}));
-    expect(onDismiss).toHaveBeenCalledTimes(1);
+      await userEvent.tab();
+      expect(screen.getByRole('button', {name: 'browser'})).toHaveFocus();
+
+      await userEvent.keyboard('{ArrowRight}');
+      expect(screen.getByRole('button', {name: 'is'})).toHaveFocus();
+
+      await userEvent.keyboard('{End}');
+      expect(screen.getByRole('button', {name: 'Remove'})).toHaveFocus();
+
+      await userEvent.keyboard('{Home}');
+      expect(screen.getByRole('button', {name: 'browser'})).toHaveFocus();
+
+      await userEvent.keyboard('{ArrowLeft}');
+      expect(screen.getByRole('button', {name: 'Remove'})).toHaveFocus();
+    });
+
+    it('defers focus to caller props in manual mode', () => {
+      render(
+        <Chip.Root focus="manual">
+          <Chip.Value onClick={() => {}} tabIndex={5}>
+            Chrome
+          </Chip.Value>
+        </Chip.Root>
+      );
+      // Manual mode installs no roving tabindex; the caller value is preserved.
+      expect(screen.getByRole('button', {name: 'Chrome'})).toHaveAttribute(
+        'tabindex',
+        '5'
+      );
+    });
   });
 });

--- a/static/app/components/core/chip/chip.tsx
+++ b/static/app/components/core/chip/chip.tsx
@@ -481,15 +481,19 @@ const ChipRootElement = styled('div')<{chipSize: ChipSize}>`
   /*
    * Overflow stays visible so a segment's focus ring isn't clipped. Round the
    * leading and trailing children instead, so their hover/active backgrounds
-   * still follow the chip's corners in the flush interactive layout.
+   * still follow the chip's corners in the flush interactive layout. The inner
+   * radius is the chip radius minus the 1px border so the corners stay
+   * concentric with the chip.
    */
   & > :first-child {
-    border-start-start-radius: ${p => p.theme.radius[SIZES[p.chipSize].radius]};
-    border-end-start-radius: ${p => p.theme.radius[SIZES[p.chipSize].radius]};
+    border-start-start-radius: calc(
+      ${p => p.theme.radius[SIZES[p.chipSize].radius]} - 1px
+    );
+    border-end-start-radius: calc(${p => p.theme.radius[SIZES[p.chipSize].radius]} - 1px);
   }
   & > :last-child {
-    border-start-end-radius: ${p => p.theme.radius[SIZES[p.chipSize].radius]};
-    border-end-end-radius: ${p => p.theme.radius[SIZES[p.chipSize].radius]};
+    border-start-end-radius: calc(${p => p.theme.radius[SIZES[p.chipSize].radius]} - 1px);
+    border-end-end-radius: calc(${p => p.theme.radius[SIZES[p.chipSize].radius]} - 1px);
   }
 `;
 

--- a/static/app/components/core/chip/chip.tsx
+++ b/static/app/components/core/chip/chip.tsx
@@ -151,17 +151,22 @@ function useRovingController(
  */
 function useChipSegment(interactive: boolean): ChipSegmentProps {
   const {roving} = useChipContext('Chip section');
+  // `register` is stable, but the roving object identity changes whenever the
+  // active tab stop moves. Depend only on `register` so the registration effect
+  // runs on mount/unmount — not on every focus change, which would otherwise
+  // unregister the focused section and reset the tab stop to the first one.
+  const {enabled, register, getItemProps} = roving;
   const id = useId();
-  const active = interactive && roving.enabled;
+  const active = interactive && enabled;
 
   useEffect(() => {
     if (active) {
-      return roving.register(id);
+      return register(id);
     }
     return () => {};
-  }, [active, id, roving]);
+  }, [active, id, register]);
 
-  return active ? roving.getItemProps(id) : {};
+  return active ? getItemProps(id) : {};
 }
 
 interface ChipRootProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -257,14 +262,14 @@ function ChipSection({
   );
 
   if (!isInteractive) {
-    return <InertSegment chipSize={size}>{content}</InertSegment>;
+    return <InertSegment>{content}</InertSegment>;
   }
 
   return (
     <InteractiveSegment
       ref={ref}
       type="button"
-      chipSize={size}
+      data-chip-interactive=""
       {...mergeProps(segmentProps, rest, {onClick})}
     >
       {content}
@@ -322,6 +327,7 @@ function ChipDismiss({onClick, ref, ...rest}: ChipDismissProps) {
       variant="transparent"
       icon={<IconClose size="xs" />}
       aria-label={t('Remove')}
+      data-chip-dismiss=""
       {...mergeProps(segmentProps, rest, {
         onClick: (event: React.MouseEvent<HTMLButtonElement>) => {
           event.stopPropagation();
@@ -424,27 +430,40 @@ const ChipRootElement = styled('div')<{chipSize: ChipSize}>`
   box-sizing: border-box;
   overflow: hidden;
   height: ${p => SIZES[p.chipSize].height};
+  /* Inert layout: generous end padding, tight gap between the value parts. */
+  gap: ${p => p.theme.space.xs};
+  padding-inline: ${p => p.theme.space[SIZES[p.chipSize].pad]};
   border: 1px solid ${p => p.theme.tokens.interactive.chonky.embossed.neutral.chonk};
   border-radius: ${p => p.theme.radius[SIZES[p.chipSize].radius]};
   background: ${p => p.theme.tokens.interactive.chonky.embossed.neutral.background};
   box-shadow: 0 1px 0 0 ${p => p.theme.tokens.interactive.chonky.embossed.neutral.chonk};
   line-height: 16px;
+
+  /* Let the trailing dismiss button sit flush against the edge. */
+  &:has([data-chip-dismiss]) {
+    padding-right: 0;
+  }
+
+  /* Interactive layout: dense, segmented buttons that own their own padding. */
+  &:has([data-chip-interactive]) {
+    gap: 0;
+    padding-inline: 0;
+  }
 `;
 
-const InertSegment = styled('div')<{chipSize: ChipSize}>`
+const InertSegment = styled('div')`
   display: inline-flex;
   align-items: center;
-  padding: 0 ${p => p.theme.space[SIZES[p.chipSize].pad]};
 `;
 
-const InteractiveSegment = styled('button')<{chipSize: ChipSize}>`
+const InteractiveSegment = styled('button')`
   display: inline-flex;
   align-items: center;
   align-self: stretch;
   margin: 0;
   border: 0;
   background: ${p => p.theme.tokens.interactive.transparent.neutral.background.rest};
-  padding: 0 ${p => p.theme.space[SIZES[p.chipSize].pad]};
+  padding: 0 ${p => p.theme.space.sm};
   color: inherit;
   cursor: pointer;
 

--- a/static/app/components/core/chip/chip.tsx
+++ b/static/app/components/core/chip/chip.tsx
@@ -270,7 +270,10 @@ function ChipSection({
       ref={ref}
       type="button"
       data-chip-interactive=""
-      {...mergeProps(segmentProps, rest, {onClick})}
+      // `segmentProps` comes last so the roving-managed tabIndex/handlers stay
+      // authoritative over any caller-supplied `tabIndex`. In manual mode
+      // `segmentProps` is empty, so caller props win there instead.
+      {...mergeProps(rest, segmentProps, {onClick})}
     >
       {content}
     </InteractiveSegment>
@@ -328,7 +331,7 @@ function ChipDismiss({onClick, ref, ...rest}: ChipDismissProps) {
       icon={<IconClose size="xs" />}
       aria-label={t('Remove')}
       data-chip-dismiss=""
-      {...mergeProps(segmentProps, rest, {
+      {...mergeProps(rest, segmentProps, {
         onClick: (event: React.MouseEvent<HTMLButtonElement>) => {
           event.stopPropagation();
           onClick?.(event);
@@ -410,7 +413,10 @@ export function Chip({
       <ChipValue variant={valueVariant}>{value}</ChipValue>
       {!readonly && onDismiss ? (
         <ChipDismiss
-          aria-label={t('Remove %s', [property, operator, value].filter(Boolean).join(' '))}
+          aria-label={t(
+            'Remove %s',
+            [property, operator, value].filter(Boolean).join(' ')
+          )}
           onClick={() => onDismiss()}
         />
       ) : null}

--- a/static/app/components/core/chip/chip.tsx
+++ b/static/app/components/core/chip/chip.tsx
@@ -164,7 +164,7 @@ function useChipSegment(interactive: boolean): ChipSegmentProps {
     if (active) {
       return register(id);
     }
-    return () => {};
+    return;
   }, [active, id, register]);
 
   return active ? getItemProps(id) : {};

--- a/static/app/components/core/chip/chip.tsx
+++ b/static/app/components/core/chip/chip.tsx
@@ -12,6 +12,7 @@ import styled from '@emotion/styled';
 import {mergeProps} from '@react-aria/utils';
 
 import {Button} from '@sentry/scraps/button';
+import {Flex} from '@sentry/scraps/layout';
 import {Text, type TextProps} from '@sentry/scraps/text';
 import {useTranslation} from '@sentry/scraps/translationContext';
 
@@ -262,7 +263,11 @@ function ChipSection({
   );
 
   if (!isInteractive) {
-    return <InertSegment>{content}</InertSegment>;
+    return (
+      <Flex display="inline-flex" align="center">
+        {content}
+      </Flex>
+    );
   }
 
   return (
@@ -468,11 +473,6 @@ const ChipRootElement = styled('div')<{chipSize: ChipSize}>`
     border-start-end-radius: ${p => p.theme.radius[SIZES[p.chipSize].radius]};
     border-end-end-radius: ${p => p.theme.radius[SIZES[p.chipSize].radius]};
   }
-`;
-
-const InertSegment = styled('div')`
-  display: inline-flex;
-  align-items: center;
 `;
 
 const InteractiveSegment = styled('button')`

--- a/static/app/components/core/chip/chip.tsx
+++ b/static/app/components/core/chip/chip.tsx
@@ -21,13 +21,13 @@ type ChipSize = 'xs' | 'sm' | 'md';
 
 /**
  * How focus is managed across the chip's interactive sections.
- * - `roving` (default): the chip owns a roving-tabindex — a single tab stop
+ * - `auto` (default): the chip owns a roving tabindex — a single tab stop
  *   enters the chip and Arrow/Home/End move between sections. Use standalone.
  * - `manual`: the chip sets no tabindex and installs no key handling; each
  *   section defers entirely to caller-supplied props. Use when an outer system
  *   (e.g. the search query builder grid) already manages focus.
  */
-type ChipFocus = 'roving' | 'manual';
+type ChipFocus = 'auto' | 'manual';
 
 const SIZES = {
   xs: {height: '20px', radius: '2xs', pad: 'xs', font: 'sm', dismiss: '20px'},
@@ -172,7 +172,7 @@ function useChipSegment(interactive: boolean): ChipSegmentProps {
 interface ChipRootProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
   /**
-   * @default 'roving'
+   * @default 'auto'
    */
   focus?: ChipFocus;
   /**
@@ -190,12 +190,12 @@ interface ChipRootProps extends React.HTMLAttributes<HTMLDivElement> {
 function ChipRoot({
   size = 'md',
   readonly = false,
-  focus = 'roving',
+  focus = 'auto',
   children,
   ...rest
 }: ChipRootProps) {
   const rootRef = useRef<HTMLDivElement>(null);
-  const roving = useRovingController(!readonly && focus === 'roving', rootRef);
+  const roving = useRovingController(!readonly && focus === 'auto', rootRef);
 
   const context = useMemo<ChipContextValue>(
     () => ({size, readonly, roving}),

--- a/static/app/components/core/chip/chip.tsx
+++ b/static/app/components/core/chip/chip.tsx
@@ -1,7 +1,17 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import styled from '@emotion/styled';
+import {mergeProps} from '@react-aria/utils';
 
 import {Button} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
 import {Text, type TextProps} from '@sentry/scraps/text';
 import {useTranslation} from '@sentry/scraps/translationContext';
 
@@ -9,7 +19,320 @@ import {IconClose} from 'sentry/icons';
 
 type ChipSize = 'xs' | 'sm' | 'md';
 
-interface BaseChipProps extends React.HTMLAttributes<HTMLDivElement> {
+/**
+ * How focus is managed across the chip's interactive sections.
+ * - `roving` (default): the chip owns a roving-tabindex — a single tab stop
+ *   enters the chip and Arrow/Home/End move between sections. Use standalone.
+ * - `manual`: the chip sets no tabindex and installs no key handling; each
+ *   section defers entirely to caller-supplied props. Use when an outer system
+ *   (e.g. the search query builder grid) already manages focus.
+ */
+type ChipFocus = 'roving' | 'manual';
+
+const SIZES = {
+  xs: {height: '20px', radius: '2xs', pad: 'xs', font: 'sm', dismiss: '20px'},
+  sm: {height: '24px', radius: 'xs', pad: 'sm', font: 'md', dismiss: '20px'},
+  md: {height: '28px', radius: 'sm', pad: 'md', font: 'md', dismiss: '24px'},
+} as const;
+
+const SEGMENT_ATTR = 'data-chip-segment';
+
+type ChipSegmentProps = React.HTMLAttributes<HTMLElement> & {
+  [SEGMENT_ATTR]?: '';
+};
+
+interface RovingController {
+  activeId: string | null;
+  enabled: boolean;
+  getItemProps: (id: string) => ChipSegmentProps;
+  register: (id: string) => () => void;
+}
+
+interface ChipContextValue {
+  readonly: boolean;
+  roving: RovingController;
+  size: ChipSize;
+}
+
+const ChipContext = createContext<ChipContextValue | null>(null);
+
+function useChipContext(component: string): ChipContextValue {
+  const context = useContext(ChipContext);
+  if (!context) {
+    throw new Error(`${component} must be rendered inside <Chip.Root>`);
+  }
+  return context;
+}
+
+/**
+ * Roving-tabindex controller for the chip's interactive sections.
+ *
+ * The first registered section becomes the single tab stop; Arrow/Home/End
+ * move focus between the sections that are actually in the DOM (queried live so
+ * order stays correct regardless of registration order). When `enabled` is
+ * false (manual focus mode) it becomes inert and yields no props.
+ */
+function useRovingController(
+  enabled: boolean,
+  rootRef: React.RefObject<HTMLDivElement | null>
+): RovingController {
+  const idsRef = useRef<string[]>([]);
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  const register = useCallback((id: string) => {
+    if (!idsRef.current.includes(id)) {
+      idsRef.current = [...idsRef.current, id];
+    }
+    setActiveId(current => current ?? id);
+
+    return () => {
+      idsRef.current = idsRef.current.filter(existing => existing !== id);
+      setActiveId(current => (current === id ? (idsRef.current[0] ?? null) : current));
+    };
+  }, []);
+
+  const onItemKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLElement>) => {
+      const root = rootRef.current;
+      if (!root) {
+        return;
+      }
+
+      const items = Array.from(root.querySelectorAll<HTMLElement>(`[${SEGMENT_ATTR}]`));
+      const currentIndex = items.indexOf(event.currentTarget);
+      if (currentIndex === -1) {
+        return;
+      }
+
+      let nextIndex = -1;
+      switch (event.key) {
+        case 'ArrowRight':
+          nextIndex = (currentIndex + 1) % items.length;
+          break;
+        case 'ArrowLeft':
+          nextIndex = (currentIndex - 1 + items.length) % items.length;
+          break;
+        case 'Home':
+          nextIndex = 0;
+          break;
+        case 'End':
+          nextIndex = items.length - 1;
+          break;
+        default:
+          return;
+      }
+
+      event.preventDefault();
+      items[nextIndex]?.focus();
+    },
+    [rootRef]
+  );
+
+  const getItemProps = useCallback(
+    (id: string): ChipSegmentProps => ({
+      [SEGMENT_ATTR]: '',
+      tabIndex: activeId === id ? 0 : -1,
+      onFocus: () => setActiveId(id),
+      onKeyDown: onItemKeyDown,
+    }),
+    [activeId, onItemKeyDown]
+  );
+
+  return useMemo(
+    () => ({enabled, activeId, register, getItemProps}),
+    [enabled, activeId, register, getItemProps]
+  );
+}
+
+/**
+ * Wires a section into the chip's roving-tabindex when it is interactive and the
+ * chip is in `roving` focus mode. Returns the props to spread onto the focusable
+ * element (empty in manual mode or for inert sections).
+ */
+function useChipSegment(interactive: boolean): ChipSegmentProps {
+  const {roving} = useChipContext('Chip section');
+  const id = useId();
+  const active = interactive && roving.enabled;
+
+  useEffect(() => {
+    if (active) {
+      return roving.register(id);
+    }
+    return () => {};
+  }, [active, id, roving]);
+
+  return active ? roving.getItemProps(id) : {};
+}
+
+interface ChipRootProps extends React.HTMLAttributes<HTMLDivElement> {
+  children: React.ReactNode;
+  /**
+   * @default 'roving'
+   */
+  focus?: ChipFocus;
+  /**
+   * Renders a non-interactive summary: interactive sections fall back to inert
+   * text and the dismiss affordance is suppressed.
+   */
+  readonly?: boolean;
+  size?: ChipSize;
+}
+
+/**
+ * The chonky-embossed container. Owns `size`, `readonly`, and focus management
+ * for the sections composed inside it.
+ */
+function ChipRoot({
+  size = 'md',
+  readonly = false,
+  focus = 'roving',
+  children,
+  ...rest
+}: ChipRootProps) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const roving = useRovingController(!readonly && focus === 'roving', rootRef);
+
+  const context = useMemo<ChipContextValue>(
+    () => ({size, readonly, roving}),
+    [size, readonly, roving]
+  );
+
+  return (
+    <ChipContext.Provider value={context}>
+      <ChipRootElement ref={rootRef} chipSize={size} {...rest}>
+        {children}
+      </ChipRootElement>
+    </ChipContext.Provider>
+  );
+}
+
+type SectionTone = 'property' | 'operator' | 'value';
+
+interface ChipSectionProps extends Omit<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  'children'
+> {
+  children: React.ReactNode;
+  /**
+   * Force interactive (button) rendering even without an `onClick`. Interactive
+   * is otherwise inferred from the presence of `onClick`.
+   */
+  interactive?: boolean;
+  ref?: React.Ref<HTMLButtonElement>;
+  /**
+   * Overrides the default text color for the section.
+   */
+  variant?: TextProps<'span'>['variant'];
+}
+
+function resolveTone(tone: SectionTone, readonly: boolean): TextProps<'span'>['variant'] {
+  if (tone === 'operator') {
+    return 'secondary';
+  }
+  if (tone === 'value') {
+    return readonly ? 'secondary' : 'accent';
+  }
+  return 'primary';
+}
+
+function ChipSection({
+  tone,
+  children,
+  variant,
+  interactive,
+  onClick,
+  ref,
+  ...rest
+}: ChipSectionProps & {tone: SectionTone}) {
+  const {size, readonly} = useChipContext('Chip section');
+  const isInteractive = !readonly && (interactive ?? onClick !== undefined);
+  const segmentProps = useChipSegment(isInteractive);
+  const textVariant = variant ?? resolveTone(tone, readonly);
+  const textSize = SIZES[size].font;
+
+  const content = (
+    <Text size={textSize} variant={textVariant} wrap="nowrap">
+      {children}
+    </Text>
+  );
+
+  if (!isInteractive) {
+    return <InertSegment chipSize={size}>{content}</InertSegment>;
+  }
+
+  return (
+    <InteractiveSegment
+      ref={ref}
+      type="button"
+      chipSize={size}
+      {...mergeProps(segmentProps, rest, {onClick})}
+    >
+      {content}
+    </InteractiveSegment>
+  );
+}
+
+/**
+ * The filter key, shown first. Becomes a button when given an `onClick`.
+ */
+function ChipProperty(props: ChipSectionProps) {
+  return <ChipSection tone="property" {...props} />;
+}
+
+/**
+ * The comparison operator (e.g. `is`). Becomes a button when given an `onClick`.
+ */
+function ChipOperator(props: ChipSectionProps) {
+  return <ChipSection tone="operator" {...props} />;
+}
+
+/**
+ * The filter value. Becomes a button when given an `onClick`.
+ */
+function ChipValue(props: ChipSectionProps) {
+  return <ChipSection tone="value" {...props} />;
+}
+
+interface ChipDismissProps extends Omit<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  'children'
+> {
+  ref?: React.Ref<HTMLButtonElement>;
+}
+
+/**
+ * The trailing ✕ button. Suppressed when the chip is `readonly`. Clicks are kept
+ * from bubbling so removing a chip does not also trigger click handlers on the
+ * chip itself or an ancestor (e.g. click-to-edit).
+ */
+function ChipDismiss({onClick, ref, ...rest}: ChipDismissProps) {
+  const {t} = useTranslation();
+  const {size, readonly} = useChipContext('Chip.Dismiss');
+  const segmentProps = useChipSegment(!readonly);
+
+  if (readonly) {
+    return null;
+  }
+
+  return (
+    <DismissButton
+      ref={ref}
+      chipSize={size}
+      size="zero"
+      variant="transparent"
+      icon={<IconClose size="xs" />}
+      aria-label={t('Remove')}
+      {...mergeProps(segmentProps, rest, {
+        onClick: (event: React.MouseEvent<HTMLButtonElement>) => {
+          event.stopPropagation();
+          onClick?.(event);
+        },
+      })}
+    />
+  );
+}
+
+interface BaseFlatChipProps extends React.HTMLAttributes<HTMLDivElement> {
   value: string;
   /**
    * The comparison operator shown between property and value (e.g. `is`).
@@ -22,7 +345,7 @@ interface BaseChipProps extends React.HTMLAttributes<HTMLDivElement> {
   size?: ChipSize;
 }
 
-interface DismissableChipProps extends BaseChipProps {
+interface DismissableFlatChipProps extends BaseFlatChipProps {
   /**
    * Called when the dismiss affordance is activated. Providing it renders a
    * trailing ✕ button; omit it for a static chip.
@@ -31,7 +354,7 @@ interface DismissableChipProps extends BaseChipProps {
   readonly?: false;
 }
 
-interface ReadonlyChipProps extends BaseChipProps {
+interface ReadonlyFlatChipProps extends BaseFlatChipProps {
   /**
    * Renders a non-interactive summary: the value reads as secondary and the
    * dismiss affordance is suppressed. Readonly chips cannot be dismissed.
@@ -40,21 +363,23 @@ interface ReadonlyChipProps extends BaseChipProps {
   onDismiss?: never;
 }
 
-type ChipProps = DismissableChipProps | ReadonlyChipProps;
-
-const SIZES = {
-  xs: {height: '20px', radius: '2xs', pad: 'xs', font: 'sm', dismiss: '20px'},
-  sm: {height: '24px', radius: 'xs', pad: 'sm', font: 'md', dismiss: '20px'},
-  md: {height: '28px', radius: 'sm', pad: 'md', font: 'md', dismiss: '24px'},
-} as const;
+type FlatChipProps = DismissableFlatChipProps | ReadonlyFlatChipProps;
 
 /**
  * A compact, chonky-embossed token for search filters and standalone values.
  *
- * Renders `property operator value` or alone `value`, in three sizes. Pass
- * `onDismiss` to make it removable, or `readonly` for a non-interactive
- * summary. Presentation only — it holds no filter state; the caller owns the
- * values and dismiss behavior.
+ * The flat form renders `property operator value` or a lone `value` from
+ * strings — presentation only, no interaction. For per-section interaction
+ * (click-to-edit, remove), compose the primitives directly:
+ *
+ * ```tsx
+ * <Chip.Root size="sm">
+ *   <Chip.Property onClick={editKey}>{key}</Chip.Property>
+ *   <Chip.Operator onClick={editOperator}>{operator}</Chip.Operator>
+ *   <Chip.Value onClick={editValue}>{value}</Chip.Value>
+ *   <Chip.Dismiss onClick={remove} />
+ * </Chip.Root>
+ * ```
  */
 export function Chip({
   size = 'md',
@@ -64,71 +389,77 @@ export function Chip({
   value,
   onDismiss,
   ...rest
-}: ChipProps) {
+}: FlatChipProps) {
   const {t} = useTranslation();
-  const textSize = SIZES[size].font;
-  const textVariant: TextProps<'span'>['variant'] = readonly
+  const valueVariant = readonly
     ? 'secondary'
     : property === undefined
       ? 'primary'
       : 'accent';
 
   return (
-    <ChipRoot
-      display="inline-flex"
-      align="center"
-      overflow="hidden"
-      height={SIZES[size].height}
-      paddingLeft={SIZES[size].pad}
-      paddingRight={onDismiss ? '0' : SIZES[size].pad}
-      radius={SIZES[size].radius}
-      {...rest}
-    >
-      <Flex align="center" gap="xs" padding="2xs 0">
-        {property !== undefined && (
-          <Text size={textSize} variant="primary" wrap="nowrap">
-            {property}
-          </Text>
-        )}
-        {operator && (
-          <Text size={textSize} variant="secondary" wrap="nowrap">
-            {operator}
-          </Text>
-        )}
-        {value !== undefined && (
-          <Text size={textSize} variant={textVariant} wrap="nowrap">
-            {value}
-          </Text>
-        )}
-      </Flex>
-      {onDismiss ? (
-        <DismissButton
-          chipSize={size}
-          size="zero"
-          variant="transparent"
-          icon={<IconClose />}
-          onClick={e => {
-            // Keep dismissing a chip from also triggering click handlers on the
-            // chip itself or any ancestor (e.g. click-to-edit).
-            e.stopPropagation();
-            onDismiss();
-          }}
-          aria-label={t(
-            'Remove %s',
-            [property, operator, value].filter(Boolean).join(' ')
-          )}
+    <ChipRoot size={size} readonly={readonly} {...rest}>
+      {property !== undefined && <ChipProperty>{property}</ChipProperty>}
+      {operator ? <ChipOperator>{operator}</ChipOperator> : null}
+      <ChipValue variant={valueVariant}>{value}</ChipValue>
+      {!readonly && onDismiss ? (
+        <ChipDismiss
+          aria-label={t('Remove %s', [property, operator, value].filter(Boolean).join(' '))}
+          onClick={() => onDismiss()}
         />
       ) : null}
     </ChipRoot>
   );
 }
 
-const ChipRoot = styled(Flex)`
+Chip.Root = ChipRoot;
+Chip.Property = ChipProperty;
+Chip.Operator = ChipOperator;
+Chip.Value = ChipValue;
+Chip.Dismiss = ChipDismiss;
+
+const ChipRootElement = styled('div')<{chipSize: ChipSize}>`
+  display: inline-flex;
+  align-items: stretch;
   box-sizing: border-box;
+  overflow: hidden;
+  height: ${p => SIZES[p.chipSize].height};
   border: 1px solid ${p => p.theme.tokens.interactive.chonky.embossed.neutral.chonk};
+  border-radius: ${p => p.theme.radius[SIZES[p.chipSize].radius]};
   background: ${p => p.theme.tokens.interactive.chonky.embossed.neutral.background};
   box-shadow: 0 1px 0 0 ${p => p.theme.tokens.interactive.chonky.embossed.neutral.chonk};
   line-height: 16px;
+`;
+
+const InertSegment = styled('div')<{chipSize: ChipSize}>`
+  display: inline-flex;
+  align-items: center;
+  padding: 0 ${p => p.theme.space[SIZES[p.chipSize].pad]};
+`;
+
+const InteractiveSegment = styled('button')<{chipSize: ChipSize}>`
+  display: inline-flex;
+  align-items: center;
+  align-self: stretch;
+  margin: 0;
+  border: 0;
+  background: ${p => p.theme.tokens.interactive.transparent.neutral.background.rest};
+  padding: 0 ${p => p.theme.space[SIZES[p.chipSize].pad]};
+  color: inherit;
+  cursor: pointer;
+
+  &:hover {
+    background: ${p => p.theme.tokens.interactive.transparent.neutral.background.hover};
+  }
+
+  &:active {
+    background: ${p => p.theme.tokens.interactive.transparent.neutral.background.active};
+  }
+
+  &:focus-visible {
+    ${p => p.theme.focusRing()};
+    z-index: 1;
+  }
 `;
 
 const DismissButton = styled(Button)<{chipSize: ChipSize}>`
@@ -137,11 +468,16 @@ const DismissButton = styled(Button)<{chipSize: ChipSize}>`
   height: auto;
   min-height: 0;
   padding: 0 ${p => p.theme.space.xs};
+  border: 0;
   border-radius: 0;
   color: ${p => p.theme.tokens.interactive.chonky.embossed.neutral.content.secondary};
 
   &:hover {
-    background: ${p => p.theme.tokens.background.secondary};
+    background: ${p => p.theme.tokens.interactive.transparent.neutral.background.hover};
     color: ${p => p.theme.tokens.interactive.chonky.embossed.neutral.content.primary};
+  }
+
+  &:active {
+    background: ${p => p.theme.tokens.interactive.transparent.neutral.background.active};
   }
 `;

--- a/static/app/components/core/chip/chip.tsx
+++ b/static/app/components/core/chip/chip.tsx
@@ -453,6 +453,16 @@ const ChipRootElement = styled('div')<{chipSize: ChipSize}>`
   &:has([data-chip-dismiss]) {
     padding-right: 0;
   }
+  /*
+   * The dismiss button's own inline padding already supplies the flat gap
+   * on this seam (see DismissButton below), so cancel out the inert
+   * layout's uniform gap here rather than doubling it. Only applies when
+   * there are no interactive segments — that layout redistributes this
+   * seam's spacing itself, below.
+   */
+  &:not(:has([data-chip-interactive])) > [data-chip-dismiss] {
+    margin-inline-start: calc(-1 * ${p => p.theme.space.xs});
+  }
 
   /*
    * Interactive layout: segmented buttons abut and fill the chip. Redistribute
@@ -473,9 +483,13 @@ const ChipRootElement = styled('div')<{chipSize: ChipSize}>`
   &:has([data-chip-interactive]) > [data-chip-interactive]:last-child {
     padding-inline-end: ${p => p.theme.space[SIZES[p.chipSize].pad]};
   }
-  /* A segment flush against the dismiss keeps a single flat gap on that seam. */
+  /*
+   * A segment flush against the dismiss yields its half of the seam — the
+   * dismiss button's own inline padding (see DismissButton below) supplies
+   * the single flat gap, same as the inert layout above.
+   */
   &:has([data-chip-interactive]) > [data-chip-interactive]:has(+ [data-chip-dismiss]) {
-    padding-inline-end: ${p => p.theme.space.xs};
+    padding-inline-end: 0;
   }
 
   /*

--- a/static/app/components/core/chip/chip.tsx
+++ b/static/app/components/core/chip/chip.tsx
@@ -454,10 +454,28 @@ const ChipRootElement = styled('div')<{chipSize: ChipSize}>`
     padding-right: 0;
   }
 
-  /* Interactive layout: dense, segmented buttons that own their own padding. */
+  /*
+   * Interactive layout: segmented buttons abut and fill the chip. Redistribute
+   * padding so labels line up exactly with the flat chip — the flat end padding
+   * on the outer edges and half the flat gap on each inner seam, so adjacent
+   * segments sum to a single gap instead of doubling.
+   */
   &:has([data-chip-interactive]) {
     gap: 0;
     padding-inline: 0;
+  }
+  &:has([data-chip-interactive]) [data-chip-interactive] {
+    padding-inline: calc(${p => p.theme.space.xs} / 2);
+  }
+  &:has([data-chip-interactive]) > [data-chip-interactive]:first-child {
+    padding-inline-start: ${p => p.theme.space[SIZES[p.chipSize].pad]};
+  }
+  &:has([data-chip-interactive]) > [data-chip-interactive]:last-child {
+    padding-inline-end: ${p => p.theme.space[SIZES[p.chipSize].pad]};
+  }
+  /* A segment flush against the dismiss keeps a single flat gap on that seam. */
+  &:has([data-chip-interactive]) > [data-chip-interactive]:has(+ [data-chip-dismiss]) {
+    padding-inline-end: ${p => p.theme.space.xs};
   }
 
   /*
@@ -482,7 +500,7 @@ const InteractiveSegment = styled('button')`
   margin: 0;
   border: 0;
   background: ${p => p.theme.tokens.interactive.transparent.neutral.background.rest};
-  padding: 0 ${p => p.theme.space.sm};
+  padding: 0;
   color: inherit;
   cursor: pointer;
 

--- a/static/app/components/core/chip/chip.tsx
+++ b/static/app/components/core/chip/chip.tsx
@@ -17,8 +17,6 @@ import {useTranslation} from '@sentry/scraps/translationContext';
 
 import {IconClose} from 'sentry/icons';
 
-type ChipSize = 'xs' | 'sm' | 'md';
-
 /**
  * How focus is managed across the chip's interactive sections.
  * - `auto` (default): the chip owns a roving tabindex — a single tab stop
@@ -34,6 +32,8 @@ const SIZES = {
   sm: {height: '24px', radius: 'xs', pad: 'sm', font: 'md', dismiss: '20px'},
   md: {height: '28px', radius: 'sm', pad: 'md', font: 'md', dismiss: '24px'},
 } as const;
+
+type ChipSize = keyof typeof SIZES;
 
 const SEGMENT_ATTR = 'data-chip-segment';
 

--- a/static/app/components/core/chip/chip.tsx
+++ b/static/app/components/core/chip/chip.tsx
@@ -434,7 +434,6 @@ const ChipRootElement = styled('div')<{chipSize: ChipSize}>`
   display: inline-flex;
   align-items: stretch;
   box-sizing: border-box;
-  overflow: hidden;
   height: ${p => SIZES[p.chipSize].height};
   /* Inert layout: generous end padding, tight gap between the value parts. */
   gap: ${p => p.theme.space.xs};
@@ -454,6 +453,20 @@ const ChipRootElement = styled('div')<{chipSize: ChipSize}>`
   &:has([data-chip-interactive]) {
     gap: 0;
     padding-inline: 0;
+  }
+
+  /*
+   * Overflow stays visible so a segment's focus ring isn't clipped. Round the
+   * leading and trailing children instead, so their hover/active backgrounds
+   * still follow the chip's corners in the flush interactive layout.
+   */
+  & > :first-child {
+    border-start-start-radius: ${p => p.theme.radius[SIZES[p.chipSize].radius]};
+    border-end-start-radius: ${p => p.theme.radius[SIZES[p.chipSize].radius]};
+  }
+  & > :last-child {
+    border-start-end-radius: ${p => p.theme.radius[SIZES[p.chipSize].radius]};
+    border-end-end-radius: ${p => p.theme.radius[SIZES[p.chipSize].radius]};
   }
 `;
 

--- a/tests/js/sentry-test/snapshots/snapshot-framework.ts
+++ b/tests/js/sentry-test/snapshots/snapshot-framework.ts
@@ -6,7 +6,7 @@ import {Tooltip as mockTooltip} from 'sentry-test/snapshots/mocks/tooltip';
 // eslint-disable-next-line no-restricted-imports -- SSR snapshot rendering needs direct theme access
 import {lightTheme} from 'sentry/utils/theme/theme';
 
-import {closeBrowser, takeSnapshot} from './snapshot';
+import {closeBrowser, takeSnapshot, type SnapshotInteraction} from './snapshot';
 import type {SnapshotTestMetadata} from './snapshot-image-metadata';
 
 // Tooltip portals to document.body, unavailable under SSR; mock globally.
@@ -20,7 +20,10 @@ type BreakpointName = keyof typeof BREAKPOINT_WIDTHS;
 
 type SnapshotViewport = BreakpointName | number | {width: number; height?: number};
 
-type SnapshotTestInput = SnapshotTestMetadata & {viewport?: SnapshotViewport};
+type SnapshotTestInput = SnapshotTestMetadata & {
+  interaction?: SnapshotInteraction;
+  viewport?: SnapshotViewport;
+};
 
 interface SnapshotDetails {
   displayName: string;
@@ -92,7 +95,7 @@ function snapshotTest(
   renderFn: () => ReactElement,
   metadata: SnapshotTestInput = {}
 ): void {
-  const {viewport: viewportInput, ...restMetadata} = metadata;
+  const {viewport: viewportInput, interaction, ...restMetadata} = metadata;
 
   const resolved = viewportInput ? resolveViewport(viewportInput) : undefined;
 
@@ -123,6 +126,7 @@ function snapshotTest(
       metadata: restMetadata,
       viewport: resolved ? {width: resolved.width, height: resolved.height} : undefined,
       viewportLabel: resolved?.label,
+      interaction,
     });
   });
 }

--- a/tests/js/sentry-test/snapshots/snapshot.ts
+++ b/tests/js/sentry-test/snapshots/snapshot.ts
@@ -110,9 +110,21 @@ interface TakeSnapshotOptions {
   metadata: SnapshotTestMetadata;
   renderFn: () => ReactElement;
   testFilePath: string;
+  interaction?: SnapshotInteraction;
   theme?: 'light' | 'dark';
   viewport?: {width: number; height?: number};
   viewportLabel?: string;
+}
+
+/**
+ * A pointer interaction to perform before capturing, so snapshots can cover
+ * `:hover` / `:active` states. Each value is a CSS selector; the first match is
+ * used. `:focus-visible` is intentionally unsupported — Chromium only applies it
+ * to keyboard-driven focus, so it cannot be forced reliably from a screenshot.
+ */
+export interface SnapshotInteraction {
+  active?: string;
+  hover?: string;
 }
 
 export async function takeSnapshot({
@@ -125,6 +137,7 @@ export async function takeSnapshot({
   metadata,
   viewport,
   viewportLabel,
+  interaction,
 }: TakeSnapshotOptions): Promise<void> {
   const element = renderFn();
   const fullHTML = renderToHTML(element, viewport ? 'block' : 'inline-block');
@@ -144,8 +157,21 @@ export async function takeSnapshot({
     // Wait for fonts to load
     await page.evaluate(() => document.fonts.ready);
 
+    // Drive pointer states (:hover / :active) before capturing, if requested.
+    let releaseActive: (() => Promise<void>) | undefined;
+    if (interaction?.hover) {
+      await page.locator(interaction.hover).first().hover();
+    }
+    if (interaction?.active) {
+      await page.locator(interaction.active).first().hover();
+      await page.mouse.down();
+      releaseActive = () => page.mouse.up();
+    }
+
     const rootElement = page.locator('#root');
     const screenshot = await rootElement.screenshot({type: 'png', omitBackground: true});
+
+    await releaseActive?.();
 
     const relativePath = path.relative(PROJECT_ROOT, testFilePath);
     const dirOfTestFile = path.dirname(relativePath);


### PR DESCRIPTION
Expands the `Chip` API so callers can interact with the individual `property` / `operator` / `value` / close sections, while keeping the existing flat string API fully backward compatible.

```tsx
<Chip.Root size="sm"> {/* focus: "auto" (default) | "manual" */}
  <Chip.Property onClick={editKey}>{key}</Chip.Property>
  <Chip.Operator onClick={editOperator}>{operator}</Chip.Operator>
  <Chip.Value onClick={editValue}>{value}</Chip.Value>
  <Chip.Dismiss onClick={remove} />
</Chip.Root>
```

- **Sections** render inert `Text` by default and become focusable `<button>`s when given `onClick` (or `interactive`). They accept `React.ButtonHTMLAttributes` + `ref` + rich `ReactNode` children, so external props (grid cell props, react-aria props) spread straight through.
- **Interactive states** use `tokens.interactive.transparent.neutral.*` (rest / hover / active) with `theme.focusRing()` on `:focus-visible`; text keeps the chonky embossed content tokens.
- **Roving focus by default** (`focus="auto"`): a single tab stop enters the chip; ArrowLeft/Right + Home/End move between sections.
- **`focus="manual"`** escape hatch: the chip installs no tabindex/key handling so an outer system (e.g. the SearchQueryBuilder grid) keeps full control of focus.
- **`Chip.Dismiss`** stops its click from bubbling; suppressed when `readonly`.
- `<Chip property="…" operator="…" value="…" onDismiss>` still works and is now built on the compound parts.

Stacked on top of #121345