### PR TITLE
feat(onboarding): Expand manual setup overview

### DIFF
--- a/static/app/views/onboarding/components/welcomeAgentSetup.tsx
+++ b/static/app/views/onboarding/components/welcomeAgentSetup.tsx
@@ -8,10 +8,13 @@ import {ListItem} from 'sentry/components/list/listItem';
 import {TextCopyInput} from 'sentry/components/textCopyInput';
 import {
   IconBot,
+  IconBranch,
   IconChat,
   IconCheckmark,
+  IconCode,
   IconGlobe,
   IconInfo,
+  IconStack,
   IconTerminal,
 } from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -48,10 +51,10 @@ export function WelcomeAgentSetup({
       columns={{'screen:xs': '1fr', 'screen:md': 'repeat(2, 1fr)'}}
       gap="2xl"
       width="100%"
-      align="start"
+      align="stretch"
     >
       <Stack border="accent" radius="lg" overflow="hidden" gap="0">
-        <Stack padding="xl" gap="xl">
+        <Stack padding="xl" gap="xl" flex="1">
           <Flex align="center" gap="sm">
             <IconBot size="md" variant="secondary" />
             {/* The slight offset optically aligns the label with the bot icon. */}
@@ -193,18 +196,73 @@ export function WelcomeAgentSetup({
               {t('Set up in browser')}
             </Heading>
             <Text variant="muted" size="md" density="comfortable" textWrap="pretty">
-              {t(
-                'Connect your repo, choose your platform, select, and instrument each product, step-by-step.'
-              )}
+              {t("Configure your application the ol'fashioned way.")}
             </Text>
           </Stack>
 
-          <Button onClick={onSetupInBrowser} data-test-id="onboarding-setup-in-browser">
+          <Stack gap="lg" width="100%">
+            <Stack.Separator border="muted" />
+            <ManualSetupStep
+              icon={<IconBranch size="xs" variant="secondary" />}
+              title={t('Connect your repository')}
+              description={t('GitHub, GitLab, Bitbucket and more')}
+            />
+            <Stack.Separator border="muted" />
+            <ManualSetupStep
+              icon={<IconStack size="xs" variant="secondary" />}
+              title={t('Choose your platform')}
+              description={t("We'll detect your framework")}
+            />
+            <Stack.Separator border="muted" />
+            <ManualSetupStep
+              icon={<IconCode size="xs" variant="secondary" />}
+              title={t('Install the SDK')}
+              description={t('Add our code snippet to your project')}
+            />
+            <Stack.Separator border="muted" />
+            <ManualSetupStep
+              icon={<IconCheckmark size="xs" variant="secondary" />}
+              title={t('Verify your setup')}
+              description={t('Send a test event to confirm it all works')}
+            />
+          </Stack>
+
+          <Button
+            variant="primary"
+            onClick={onSetupInBrowser}
+            data-test-id="onboarding-setup-in-browser"
+          >
             {t('Start setup')}
           </Button>
         </Stack>
       </Grid>
     </Grid>
+  );
+}
+
+function ManualSetupStep({
+  description,
+  icon,
+  title,
+}: {
+  description: string;
+  icon: React.ReactNode;
+  title: string;
+}) {
+  return (
+    <Flex align="start" gap="md">
+      <Flex flexShrink={0} paddingTop="2xs">
+        {icon}
+      </Flex>
+      <Stack gap="xs">
+        <Text size="sm" bold>
+          {title}
+        </Text>
+        <Text size="sm" variant="muted">
+          {description}
+        </Text>
+      </Stack>
+    </Flex>
   );
 }
 

--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -670,6 +670,10 @@ describe('Onboarding', () => {
         await screen.findByDisplayValue('npx @sentry/agent-plugin install')
       ).toBeInTheDocument();
       expect(screen.getByDisplayValue('Help me setup Sentry')).toBeInTheDocument();
+      expect(screen.getByText('Connect your repository')).toBeInTheDocument();
+      expect(screen.getByText('Choose your platform')).toBeInTheDocument();
+      expect(screen.getByText('Install the SDK')).toBeInTheDocument();
+      expect(screen.getByText('Verify your setup')).toBeInTheDocument();
       // The org has no projects yet, so the waiter is on its first milestone
       expect(await screen.findByText('Waiting for project creation')).toBeInTheDocument();
       expect(


### PR DESCRIPTION
The browser setup card now previews the four stages of the guided flow—repository connection, platform selection, SDK installation, and verification—so users can compare it with automatic setup before choosing a path. The two cards stretch to a shared height, with the automatic card footer pinned to the bottom, and the browser action uses the primary button treatment.