### PR TITLE
fix(trace): Show all contexts in span details pane

### DIFF
--- a/static/app/components/events/contexts/knownContext/profile.tsx
+++ b/static/app/components/events/contexts/knownContext/profile.tsx
@@ -102,8 +102,8 @@ function getProfilerIdEntry(
   };
 }
 
-function getStartEnd(event: any): [string | null, string | null] {
-  if (!isTransaction(event)) {
+function getStartEnd(event: Event | undefined): [string | null, string | null] {
+  if (!event || !isTransaction(event)) {
     return [null, null];
   }
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/contexts.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/contexts.tsx
@@ -12,23 +12,6 @@ import {
   hasAdditionalData,
 } from 'sentry/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/additionalData';
 
-// List of context types that are displayed as span attributes.
-// These should not be displayed in the contexts section.
-const DUPLICATES_FROM_ATTRIBUTES = [
-  'feedback',
-  'response',
-  'browser',
-  'runtime',
-  'os',
-  'flags',
-  'user',
-  'profile',
-  'replay',
-  'device',
-  'trace',
-  'environment',
-];
-
 export function Contexts({
   contexts,
   extra,
@@ -38,9 +21,7 @@ export function Contexts({
   extra: EventTransaction['context'] | undefined;
   project: Project | undefined;
 }) {
-  const extraContexts = getOrderedContextItemsFromContexts({contexts}).filter(
-    ({type}) => !DUPLICATES_FROM_ATTRIBUTES.includes(type)
-  );
+  const extraContexts = getOrderedContextItemsFromContexts({contexts});
   const eventHasExtraContexts = extraContexts.length > 0;
   const eventHasAdditionalData = hasAdditionalData(extra);
 


### PR DESCRIPTION
We chose to hide a bunch of contexts from the EAP version of the span details pane with the comment:

> List of context types that are displayed as span attributes.

but in practice many of these were only partially covered by attributes. It doesn't hurt to show everything.