### PR TITLE
feat(autofix): slow PR-watch polling in the autofix drawer

### DIFF
--- a/static/app/components/events/autofix/useExplorerAutofix.spec.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.spec.tsx
@@ -51,10 +51,10 @@ describe('getPollInterval', () => {
     'org/repo': {pr_creation_status: 'completed'} as any,
   };
 
-  it('polls when pollPR is set and a PR has been created, even when idle', () => {
+  it('polls slowly when pollPR is set and a PR has been created, even when idle', () => {
     const state = makeState({status: 'completed', repo_pr_states: completedPr});
     expect(getPollInterval({autofixState: state, runStarted: false, pollPR: true})).toBe(
-      1000
+      10000
     );
   });
 
@@ -70,9 +70,16 @@ describe('getPollInterval', () => {
     expect(getPollInterval({autofixState: state, runStarted: false})).toBe(false);
   });
 
-  it('polls while processing regardless of pollPR', () => {
+  it('polls faster while processing regardless of pollPR', () => {
     const state = makeState({status: 'processing'});
     expect(getPollInterval({autofixState: state, runStarted: false})).toBe(1000);
+    expect(getPollInterval({autofixState: state, runStarted: false, pollPR: true})).toBe(
+      1000
+    );
+  });
+
+  it('polls faster while processing even when a PR has been created', () => {
+    const state = makeState({status: 'processing', repo_pr_states: completedPr});
     expect(getPollInterval({autofixState: state, runStarted: false, pollPR: true})).toBe(
       1000
     );

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -229,7 +229,18 @@ export interface ExplorerAutofixResponse {
   autofix: ExplorerAutofixState | null;
 }
 
-const POLL_INTERVAL = 1000;
+/**
+ * Poll interval while a run is active, so streaming blocks show up promptly in
+ * the drawer.
+ */
+const ACTIVE_POLL_INTERVAL = 1000;
+
+/**
+ * Poll interval while idle and only watching an already created PR. These are
+ * slow external events (automated CI iteration pushes, review comments), so
+ * polling stays cheap rather than matching the active-run rate.
+ */
+const PR_POLL_INTERVAL = 10000;
 
 function explorerAutofixApiOptions(orgSlug: string, groupId: string) {
   return apiOptions.as<ExplorerAutofixResponse>()(
@@ -318,8 +329,12 @@ export const getPollInterval = ({
   const shouldPollPR = pollPR && hasCreatedPullRequest(autofixState);
   const shouldPollProcessing = isActivelyProcessing(autofixState, runStarted);
 
-  if (shouldPollPR || shouldPollProcessing) {
-    return POLL_INTERVAL;
+  if (shouldPollProcessing) {
+    return ACTIVE_POLL_INTERVAL;
+  }
+
+  if (shouldPollPR) {
+    return PR_POLL_INTERVAL;
   }
 
   return false;

--- a/static/app/views/issueDetails/sidebar/seerDrawer.spec.tsx
+++ b/static/app/views/issueDetails/sidebar/seerDrawer.spec.tsx
@@ -375,9 +375,10 @@ describe('SeerDrawer', () => {
           () => {
             expect(getMock.mock.calls.length).toBeGreaterThan(callsAfterLoad);
           },
-          {timeout: 5000}
+          {timeout: 15_000}
         );
-      }
+      },
+      20_000
     );
   });
 });


### PR DESCRIPTION
The drawer had a single 1000ms poll interval covering two states: a run
actively streaming blocks, and an idle run being watched for an already
created PR. The second state was added later and inherited the first
state's interval, so it polled at 1Hz for slow external events — an
automated CI iteration push or a review comment.

Split the two apart and give the PR-watch state 10000ms. Active runs keep
their original 1000ms, and idle-with-no-PR still does not poll.

Fixes CW-1858