### PR TITLE
feat(seer): Add free cohort eligibility path for night shift and autofix

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -43,7 +43,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Organization scoped features that are in development or in customer trials. #
     ###############################################################################
 
-    # Kill switch for the agentic triage free cohort — disabling this flag shuts off night shift for all free cohort orgs
+    # Kill switch for the agentic triage free cohort — enabling this flag shuts off night shift for all free cohort orgs
     manager.add("organizations:agentic-triage-free-cohort-killswitch", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable agentic triage sort for night shift candidate selection
     manager.add("organizations:agentic-triage-sort", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -47,6 +47,7 @@ from sentry.seer.autofix.prompts import (
 from sentry.seer.autofix.types import AutofixHandoffResponse
 from sentry.seer.autofix.utils import (
     AutofixStoppingPoint,
+    is_free_cohort_org,
     read_preference_from_sentry_db,
 )
 from sentry.seer.entrypoints.operator import (
@@ -511,7 +512,9 @@ def trigger_autofix_agent(
         stopping_point: Where to stop the automated pipeline (only used for new runs)
     """
     # check billing quota for triggering a new autofix run
-    if run_id is None:
+    # Free cohort orgs have no Subscription so check_seer_quota returns False.
+    # Bypass the check for them — they get autofix without billing.
+    if run_id is None and not is_free_cohort_org(group.organization):
         has_budget: bool = quotas.backend.check_seer_quota(
             org_id=group.organization.id,
             data_category=DataCategory.SEER_AUTOFIX,

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -26,6 +26,7 @@ from sentry.issues.auto_source_code_config.code_mapping import (
     get_sorted_code_mapping_configs,
 )
 from sentry.models.group import Group
+from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.options.project_option import ProjectOption
 from sentry.models.organization import Organization
 from sentry.models.project import Project
@@ -986,6 +987,20 @@ def is_seer_seat_based_tier_enabled(organization: Organization) -> bool:
     cache.set(cache_key, has_seat_based_seer, timeout=60 * 60 * 4)  # 4 hours TTL
 
     return has_seat_based_seer
+
+
+def is_free_cohort_org(organization: Organization) -> bool:
+    """Check if org is in the agentic triage free cohort — selected non-paying
+    orgs that receive night shift and autofix without a Seer subscription.
+
+    Returns True when the FlagPole kill switch is enabled, the org is NOT on
+    a paid seat-based Seer plan, and the org option is set to True.
+    """
+    if not features.has("organizations:agentic-triage-free-cohort-killswitch", organization):
+        return False
+    return not is_seer_seat_based_tier_enabled(organization) and bool(
+        OrganizationOption.objects.get_value(organization, "agentic-triage-free-cohort", False)
+    )
 
 
 def is_issue_category_eligible(group: Group) -> bool:

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -993,10 +993,11 @@ def is_free_cohort_org(organization: Organization) -> bool:
     """Check if org is in the agentic triage free cohort — selected non-paying
     orgs that receive night shift and autofix without a Seer subscription.
 
-    Returns True when the FlagPole kill switch is enabled, the org is NOT on
-    a paid seat-based Seer plan, and the org option is set to True.
+    Returns True when the kill switch is NOT engaged (flag disabled = cohort
+    active), the org is NOT on a paid seat-based Seer plan, and the org
+    option is set to True.
     """
-    if not features.has("organizations:agentic-triage-free-cohort-killswitch", organization):
+    if features.has("organizations:agentic-triage-free-cohort-killswitch", organization):
         return False
     return not is_seer_seat_based_tier_enabled(organization) and bool(
         OrganizationOption.objects.get_value(organization, "agentic-triage-free-cohort", False)

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -997,7 +997,10 @@ def is_free_cohort_org(organization: Organization) -> bool:
     active), the org is NOT on a paid seat-based Seer plan, and the org
     option is set to True.
     """
-    if features.has("organizations:agentic-triage-free-cohort-killswitch", organization):
+    try:
+        if features.has("organizations:agentic-triage-free-cohort-killswitch", organization):
+            return False
+    except Exception:
         return False
     return not is_seer_seat_based_tier_enabled(organization) and bool(
         OrganizationOption.objects.get_value(organization, "agentic-triage-free-cohort", False)

--- a/src/sentry/seer/autofix_rca/dispatch.py
+++ b/src/sentry/seer/autofix_rca/dispatch.py
@@ -7,6 +7,7 @@ from sentry import quotas
 from sentry.constants import DataCategory
 from sentry.seer.agent.client import SeerAgentClient
 from sentry.seer.autofix.autofix_agent import NoSeerQuotaException
+from sentry.seer.autofix.utils import is_free_cohort_org
 from sentry.seer.autofix_rca.models import FEATURE_ID, AutofixRCAPayload, AutofixRCATweaks
 from sentry.utils import metrics
 
@@ -29,12 +30,15 @@ def trigger_autofix_rca_feature(
     reasoning_effort: Literal["low", "medium", "high"] | None = "medium",
     flush: bool = True,
 ) -> SeerRun:
-    has_budget: bool = quotas.backend.check_seer_quota(
-        org_id=group.organization.id,
-        data_category=DataCategory.SEER_AUTOFIX,
-    )
-    if not has_budget:
-        raise NoSeerQuotaException()
+    # Free cohort orgs have no Subscription so check_seer_quota returns False.
+    # Bypass the check for them — night shift dispatches through this path.
+    if not is_free_cohort_org(group.organization):
+        has_budget: bool = quotas.backend.check_seer_quota(
+            org_id=group.organization.id,
+            data_category=DataCategory.SEER_AUTOFIX,
+        )
+        if not has_budget:
+            raise NoSeerQuotaException()
 
     payload = AutofixRCAPayload(
         group_id=group.id,

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -136,14 +136,17 @@ class SeerAutofixOperator[CachePayloadT]:
         Validates Seer access for the organization, the issue category, and autofix quota.
         """
         from sentry import quotas
-        from sentry.seer.autofix.utils import is_issue_category_eligible
+        from sentry.seer.autofix.utils import is_free_cohort_org, is_issue_category_eligible
 
         return (
             has_seer_access(group.organization)
             and is_issue_category_eligible(group)
-            and quotas.backend.check_seer_quota(
-                org_id=group.organization.id,
-                data_category=DataCategory.SEER_AUTOFIX,
+            and (
+                is_free_cohort_org(group.organization)
+                or quotas.backend.check_seer_quota(
+                    org_id=group.organization.id,
+                    data_category=DataCategory.SEER_AUTOFIX,
+                )
             )
         )
 

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -176,21 +176,24 @@ def schedule_night_shift(
 
     # Free cohort orgs may not have SeerProjectRepository rows — include them
     # so they reach the eligibility checks in _get_eligible_orgs_from_batch.
-    free_cohort_org_ids = set(
-        OrganizationOption.objects.filter(
-            key="agentic-triage-free-cohort",
-            value=True,
-        ).values_list("organization_id", flat=True)
-    )
-    seer_org_ids |= free_cohort_org_ids
-    if free_cohort_org_ids:
-        logger.info(
-            "night_shift.free_cohort_org_ids",
-            extra={
-                "num_free_cohort_org_ids": len(free_cohort_org_ids),
-                "sample_org_ids": sorted(free_cohort_org_ids)[:10],
-            },
+    try:
+        free_cohort_org_ids = set(
+            OrganizationOption.objects.filter(
+                key="agentic-triage-free-cohort",
+                value=True,
+            ).values_list("organization_id", flat=True)
         )
+        seer_org_ids |= free_cohort_org_ids
+        if free_cohort_org_ids:
+            logger.info(
+                "night_shift.free_cohort_org_ids",
+                extra={
+                    "num_free_cohort_org_ids": len(free_cohort_org_ids),
+                    "sample_org_ids": sorted(free_cohort_org_ids)[:10],
+                },
+            )
+    except Exception:
+        logger.exception("night_shift.free_cohort_org_ids_failed")
 
     logger.info(
         "night_shift.schedule_org_ids_collected",

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -34,6 +34,7 @@ from sentry.seer.autofix.constants import (
 from sentry.seer.autofix.utils import (
     AutofixStoppingPoint,
     bulk_read_preferences_from_sentry_db,
+    is_free_cohort_org,
     is_seer_autotriggered_autofix_rate_limited,
     is_seer_seat_based_tier_enabled,
 )
@@ -172,6 +173,24 @@ def schedule_night_shift(
         step=1000,
     ):
         seer_org_ids.add(spr.project_repository.project.organization_id)
+
+    # Free cohort orgs may not have SeerProjectRepository rows — include them
+    # so they reach the eligibility checks in _get_eligible_orgs_from_batch.
+    free_cohort_org_ids = set(
+        OrganizationOption.objects.filter(
+            key="agentic-triage-free-cohort",
+            value=True,
+        ).values_list("organization_id", flat=True)
+    )
+    seer_org_ids |= free_cohort_org_ids
+    if free_cohort_org_ids:
+        logger.info(
+            "night_shift.free_cohort_org_ids",
+            extra={
+                "num_free_cohort_org_ids": len(free_cohort_org_ids),
+                "sample_org_ids": sorted(free_cohort_org_ids)[:10],
+            },
+        )
 
     logger.info(
         "night_shift.schedule_org_ids_collected",
@@ -387,7 +406,9 @@ def run_night_shift_execution(
         _complete_run(run)
         return None
 
-    if not quotas.backend.check_seer_quota(
+    # Free cohort orgs have no Subscription so check_seer_quota returns False.
+    # Bypass the check for them — they get night shift without billing.
+    if not is_free_cohort_org(organization) and not quotas.backend.check_seer_quota(
         org_id=organization.id,
         data_category=DataCategory.SEER_AUTOFIX,
     ):
@@ -549,12 +570,16 @@ def _get_eligible_orgs_from_batch(
     if options.get("seer.night_shift.enable_for_legacy_orgs"):
         return eligible
 
-    for feature_name in PER_ORG_FEATURE_NAMES:
-        eligible = [org for org in eligible if features.has(feature_name, org)]
-        if not eligible:
-            return []
+    # seat-based-seer-enabled: required for paid path, bypassed by free cohort
+    paid_eligible: list[Organization] = []
+    free_cohort_eligible: list[Organization] = []
+    for org in eligible:
+        if all(features.has(f, org) for f in PER_ORG_FEATURE_NAMES):
+            paid_eligible.append(org)
+        elif features.has("organizations:gen-ai-features", org) and is_free_cohort_org(org):
+            free_cohort_eligible.append(org)
 
-    return eligible
+    return paid_eligible + free_cohort_eligible
 
 
 def _update_run_extras(


### PR DESCRIPTION
## Summary
- Adds `is_free_cohort_org()` helper that checks: FlagPole kill switch enabled + org not on paid seat-based Seer + OrganizationOption `agentic-triage-free-cohort` set to True
- Includes free cohort orgs in night shift pre-filter by querying `OrganizationOption` directly (they may lack `SeerProjectRepository` rows)
- Adds alternate eligibility path in `_get_eligible_orgs_from_batch()` — free cohort orgs bypass `seat-based-seer-enabled` but still require `gen-ai-features` and `seer-night-shift`
- Bypasses `check_seer_quota` at both call sites (`cron.py` and `autofix_agent.py`) — free cohort orgs have no `Subscription` so the check returns False

Part of the agentic triage free cohort rollout. Depends on the kill switch flag registered in #121630.

## Test plan
- [ ] Unit tests for `is_free_cohort_org` (kill switch on/off, org option set/unset, paid org returns False)
- [ ] Test alternate eligibility path in `_get_eligible_orgs_from_batch`
- [ ] Test pre-filter includes free cohort orgs without `SeerProjectRepository` rows
- [ ] Test quota bypass at both call sites
- [ ] Verify paying orgs are unaffected (normal path unchanged)