### PR TITLE
ref(traces): Rename "Agent Timeline" tab to "Agent Activity"

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -450,7 +450,7 @@ function Highlights({
                 },
               }}
             >
-              {t('Open Agent Timeline')}
+              {t('Open Agent Activity')}
             </OpenInAIFocusButton>
           )}
           {!hidePanelAndBreakdown && (

--- a/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.tsx
@@ -53,7 +53,7 @@ const TAB_DEFINITIONS: Record<TraceLayoutTabKeys, Tab> = {
   },
   [TraceLayoutTabKeys.AI_SPANS]: {
     slug: TraceLayoutTabKeys.AI_SPANS,
-    label: t('Agent Timeline'),
+    label: t('Agent Activity'),
   },
 };
 


### PR DESCRIPTION
Renames the `ai-spans` tab label from "Agent Timeline" to "Agent Activity" on the trace detail page.

## Changes

- `useTraceLayoutTabs.tsx` — the tab label in `TAB_DEFINITIONS`, the single source of truth for this label across all versions of the trace detail page.
- `styles.tsx` — the "Open Agent Timeline" button in the trace drawer that navigates to this tab, so the two stay consistent.

The `ai-spans` URL slug is unchanged, so existing links and bookmarks still work. Both strings remain wrapped in `t()`.

## Note

Authored from a sparse design-reference checkout without `node_modules`, so lint and typecheck were not run locally — relying on CI. No tests or snapshots assert on the old string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)