### PR TITLE
fix(pr_metrics): Group check rollups per suite, not per app

### DIFF
--- a/src/sentry/pr_metrics/activity_doc.py
+++ b/src/sentry/pr_metrics/activity_doc.py
@@ -404,6 +404,17 @@ def _apply_check_run(
         group["first_failure_at"] = _min_ts(group.get("first_failure_at"), completed_at)
 
 
+def _forward_priority(group: CheckGroup) -> tuple[bool, str]:
+    """Sort key shared by the within-head eviction and the judge-forward trim:
+    failing (ever-failed) groups last, then most recent — so ``min()`` evicts and
+    ``[-N:]`` drops non-failing stale groups first, and a recorded failure is
+    never displaced by a fresher green."""
+    failed = is_failing_conclusion(group.get("suite_conclusion")) or bool(
+        group.get("first_failure_at")
+    )
+    return (failed, group.get("last_event_at") or "")
+
+
 def _get_or_create_group(doc: ActivityDoc, payload: Mapping[str, Any]) -> CheckGroup:
     """The rollup for a check payload's ``(head_sha, app_slug, check_suite_id)``.
 
@@ -419,11 +430,12 @@ def _get_or_create_group(doc: ActivityDoc, payload: Mapping[str, Any]) -> CheckG
     ``_any_group_failing``) see such a head+app twice and a frozen failure is not
     cleared by suite-scoped greens — accepted over erasing a recorded failure.
 
-    A newcomer past a cap evicts the least-recently-updated group rather than
-    being dropped (the judge cares most about the *final* head's CI state):
-    ``MAX_GROUPS_PER_HEAD`` evicts within the newcomer's head, so suite spam
-    degrades only that head; ``MAX_CHECK_GROUPS`` evicts document-wide, shedding
-    the stalest head first.
+    A newcomer past a cap evicts an existing group rather than being dropped
+    (the judge cares most about the *final* head's CI state):
+    ``MAX_GROUPS_PER_HEAD`` evicts within the newcomer's head — non-failing and
+    stalest first (``_forward_priority``), so suite spam degrades only that head
+    and never displaces a recorded failure; ``MAX_CHECK_GROUPS`` evicts
+    document-wide, shedding the stalest head first.
     """
     head_sha = payload.get("head_sha") or ""
     app_slug = payload.get("app_slug") or ""
@@ -443,9 +455,7 @@ def _get_or_create_group(doc: ActivityDoc, payload: Mapping[str, Any]) -> CheckG
         if existing_group.get("head_sha") == head_sha
     ]
     if len(same_head) >= MAX_GROUPS_PER_HEAD:
-        evicted_key = min(
-            same_head, key=lambda existing: checks[existing].get("last_event_at") or ""
-        )
+        evicted_key = min(same_head, key=lambda existing: _forward_priority(checks[existing]))
         del checks[evicted_key]
         logger.warning(
             "pr_metrics.activity_doc.check_head_groups_capped",
@@ -507,9 +517,12 @@ def _min_ts(current: str | None, candidate: str | None) -> str | None:
 # --- readers: pure projections of a stored document -----------------------
 
 # The judge forward collapses each checks group into one synthesized event,
-# mirroring the legacy row cap. The store can hold more (MAX_CHECK_GROUPS);
-# past this cap only the most recently updated groups are forwarded.
-MAX_FORWARDED_CHECK_GROUPS = 100
+# trimmed per head so every head stays represented — the fail → push → green
+# iteration story must reach the judge — keeping failures over fresher greens
+# (_forward_priority). The flat cap is a backstop only: the store already
+# bounds groups to MAX_CHECK_GROUPS.
+MAX_FORWARDED_GROUPS_PER_HEAD = 20
+MAX_FORWARDED_CHECK_GROUPS = MAX_CHECK_GROUPS
 
 
 def has_commits_after_open(doc: ActivityDoc) -> bool:
@@ -724,6 +737,11 @@ def timeline_events_from_doc(doc: ActivityDoc) -> list[dict[str, Any]]:
     ``check_suite_completed`` timestamped at its ``last_event_at``. The merged list
     is sorted by timestamp, matching the legacy forward's shape — only the check
     events are pre-collapsed (what Seer's timeline does anyway).
+
+    Check groups are trimmed per head (``MAX_FORWARDED_GROUPS_PER_HEAD``), never
+    dropping a whole head and keeping failures over fresher greens
+    (``_forward_priority``), so the fail → push → green iteration story always
+    reaches the judge.
     """
     events: list[dict[str, Any]] = [
         {
@@ -734,7 +752,26 @@ def timeline_events_from_doc(doc: ActivityDoc) -> list[dict[str, Any]]:
         for entry in doc.get("events", [])
     ]
 
-    groups = list(doc.get("checks", {}).values())
+    by_head: dict[str, list[CheckGroup]] = {}
+    for group in doc.get("checks", {}).values():
+        by_head.setdefault(group.get("head_sha") or "", []).append(group)
+
+    groups: list[CheckGroup] = []
+    for head_sha, head_groups in by_head.items():
+        if len(head_groups) > MAX_FORWARDED_GROUPS_PER_HEAD:
+            logger.warning(
+                "pr_metrics.activity_doc.forward_head_groups_capped",
+                extra={
+                    "head_sha": head_sha,
+                    "dropped": len(head_groups) - MAX_FORWARDED_GROUPS_PER_HEAD,
+                },
+            )
+            metrics.incr("pr_metrics.activity_doc.forward_head_groups_capped")
+            head_groups = sorted(head_groups, key=_forward_priority)[
+                -MAX_FORWARDED_GROUPS_PER_HEAD:
+            ]
+        groups.extend(head_groups)
+
     if len(groups) > MAX_FORWARDED_CHECK_GROUPS:
         dropped = len(groups) - MAX_FORWARDED_CHECK_GROUPS
         logger.warning(
@@ -742,9 +779,7 @@ def timeline_events_from_doc(doc: ActivityDoc) -> list[dict[str, Any]]:
             extra={"check_groups": len(groups), "dropped": dropped},
         )
         metrics.incr("pr_metrics.activity_doc.forward_groups_capped")
-        groups = sorted(groups, key=lambda group: group.get("last_event_at") or "")[
-            -MAX_FORWARDED_CHECK_GROUPS:
-        ]
+        groups = sorted(groups, key=_forward_priority)[-MAX_FORWARDED_CHECK_GROUPS:]
 
     for group in groups:
         events.append(

--- a/src/sentry/pr_metrics/activity_doc.py
+++ b/src/sentry/pr_metrics/activity_doc.py
@@ -32,12 +32,17 @@ MAX_EVENTS = 500
 # the events cap: below MAX_SYNC_CHAIN the chain is complete; past it the NEWEST
 # links — the ones the head-anchored commit-chain walk starts from — are retained.
 MAX_SYNC_CHAIN = 500
-# Check-rollup bounds: distinct ``(head_sha, app_slug, check_suite_id)`` groups
-# per PR, and ever-failing runs tracked per group. Both are pathology backstops.
-# Groups are per suite and one app emits one suite per workflow run (a
-# workflow-heavy repo sees tens of github-actions suites on a single head), so
-# the group cap sits well above heads x suites for a normal PR.
-MAX_CHECK_GROUPS = 500
+# Check-rollup bounds, each surfaced via log + metric when hit. Groups are per
+# ``(head_sha, app_slug, check_suite_id)`` and one app emits one suite per
+# workflow run. ``MAX_GROUPS_PER_HEAD`` bounds a single head's suite fan-out so
+# a suite-spam pathology (e.g. a workflow re-trigger loop) cannot evict every
+# other head out of the document; the busiest observed repo emits ~26 suites
+# across all apps on one head, so 40 sits above real CI. ``MAX_CHECK_GROUPS``
+# bounds the document across heads (~10 spam-free busiest-repo heads, ~30
+# typical ones). ``MAX_RUNS_PER_GROUP`` bounds the ever-failing runs tracked
+# per group.
+MAX_CHECK_GROUPS = 300
+MAX_GROUPS_PER_HEAD = 40
 MAX_RUNS_PER_GROUP = 50
 
 # Conclusion vocabulary shared with Seer's ``timeline.py``: a clean pass, an
@@ -416,19 +421,27 @@ def _get_or_create_group(doc: ActivityDoc, payload: Mapping[str, Any]) -> CheckG
     concurrent workflows apart, while a rerun of one suite (same id) still
     converges latest-wins.
 
-    A payload without a suite id falls back to the suite-less legacy key, so
-    documents persisted before the split keep folding such events into their
-    existing groups with no migration. Suite-scoped events never fold into a
-    legacy group: on an old document the merged group simply goes stale next to
-    the new per-suite groups — a reader may transiently re-report a failure it
-    froze on, which beats erasing one.
+    A payload without a suite id falls back to the suite-less legacy key. That
+    keeps two populations working with no migration: documents persisted before
+    the split keep resolving their merged per-app groups, and during a rolling
+    deploy — updated and not-yet-updated webhook processors interleaving on the
+    same live PR — the id-less half keeps folding into the merged group while
+    the id-carrying half builds per-suite groups beside it. Suite-scoped events
+    never fold into a merged group, so once the rollout completes the merged
+    group freezes and persists for the rest of the document's life (the document
+    is only swept after terminal emit). Readers that scan every group
+    (``_any_group_failing``) see such a head+app twice, and a failure frozen in
+    the merged group is not cleared by suite-scoped greens — over-reporting a
+    recorded failure is accepted over erasing one.
 
-    Existing groups always resolve. A new group beyond ``MAX_CHECK_GROUPS`` evicts
-    the least-recently-updated group (by ``last_event_at``) to make room rather than
-    dropping the newcomer: the judge cares most about the *final* head's CI state, so
-    a green-heavy PR that fills the cap must not freeze on stale SHAs and silently
-    drop a failing check that lands on a newer one. Each eviction is a cap hit,
-    surfaced via a log + metric — the cap is a pathology backstop, never silent.
+    Existing groups always resolve. A newcomer past a cap evicts the
+    least-recently-updated group (by ``last_event_at``) rather than being
+    dropped: the judge cares most about the *final* head's CI state, so a PR
+    that fills a cap must not freeze on stale entries and silently drop a
+    failing check that lands later. ``MAX_GROUPS_PER_HEAD`` evicts within the
+    newcomer's head, so one head's suite spam degrades only that head;
+    ``MAX_CHECK_GROUPS`` evicts document-wide, shedding the stalest head first
+    on many-push PRs. Each eviction is a cap hit, surfaced via a log + metric.
     """
     head_sha = payload.get("head_sha") or ""
     app_slug = payload.get("app_slug") or ""
@@ -442,7 +455,22 @@ def _get_or_create_group(doc: ActivityDoc, payload: Mapping[str, Any]) -> CheckG
     group = checks.get(key)
     if group is not None:
         return group
-    if len(checks) >= MAX_CHECK_GROUPS:
+    same_head = [
+        existing
+        for existing, existing_group in checks.items()
+        if existing_group.get("head_sha") == head_sha
+    ]
+    if len(same_head) >= MAX_GROUPS_PER_HEAD:
+        evicted_key = min(
+            same_head, key=lambda existing: checks[existing].get("last_event_at") or ""
+        )
+        del checks[evicted_key]
+        logger.warning(
+            "pr_metrics.activity_doc.check_head_groups_capped",
+            extra={"head_sha": head_sha, "app_slug": app_slug, "evicted_key": evicted_key},
+        )
+        metrics.incr("pr_metrics.activity_doc.check_head_groups_capped")
+    elif len(checks) >= MAX_CHECK_GROUPS:
         evicted_key = min(checks, key=lambda existing: checks[existing].get("last_event_at") or "")
         del checks[evicted_key]
         logger.warning(

--- a/src/sentry/pr_metrics/activity_doc.py
+++ b/src/sentry/pr_metrics/activity_doc.py
@@ -32,15 +32,11 @@ MAX_EVENTS = 500
 # the events cap: below MAX_SYNC_CHAIN the chain is complete; past it the NEWEST
 # links — the ones the head-anchored commit-chain walk starts from — are retained.
 MAX_SYNC_CHAIN = 500
-# Check-rollup bounds, each surfaced via log + metric when hit. Groups are per
-# ``(head_sha, app_slug, check_suite_id)`` and one app emits one suite per
-# workflow run. ``MAX_GROUPS_PER_HEAD`` bounds a single head's suite fan-out so
-# a suite-spam pathology (e.g. a workflow re-trigger loop) cannot evict every
-# other head out of the document; the busiest observed repo emits ~26 suites
-# across all apps on one head, so 40 sits above real CI. ``MAX_CHECK_GROUPS``
-# bounds the document across heads (~10 spam-free busiest-repo heads, ~30
-# typical ones). ``MAX_RUNS_PER_GROUP`` bounds the ever-failing runs tracked
-# per group.
+# Check-rollup caps, each eviction surfaced via log + metric. MAX_GROUPS_PER_HEAD
+# bounds one head's suite fan-out (the busiest observed repo emits ~26 suites per
+# head across all apps) so suite spam can't evict other heads; MAX_CHECK_GROUPS
+# bounds the document across heads; MAX_RUNS_PER_GROUP bounds the ever-failing
+# runs tracked per group.
 MAX_CHECK_GROUPS = 300
 MAX_GROUPS_PER_HEAD = 40
 MAX_RUNS_PER_GROUP = 50
@@ -70,10 +66,9 @@ class CheckRun(TypedDict):
 class CheckGroup(TypedDict):
     head_sha: str
     app_slug: str
-    # Numeric id of the owning check suite (``check_suite.id``). Groups persisted
-    # before the per-suite split lack the key entirely (readers must ``.get``);
-    # None when the payload carried no suite id, in which case the group also
-    # keys on the suite-less legacy form (see ``_get_or_create_group``).
+    # Numeric id of the owning check suite (``check_suite.id``); None when the
+    # payload carried none. Absent entirely in groups persisted before the
+    # per-suite split — readers must ``.get``.
     check_suite_id: int | None
     suite_conclusion: str | None
     suite_updated_at: str | None
@@ -331,12 +326,10 @@ def _apply_check_suite(
     check_suite_id)`` group.
 
     The suite carries the aggregate conclusion (latest verdict wins on
-    ``updated_at`` — see :func:`_wins_conclusion` for why an aborted suite does not
-    count) and the run count (``max`` of ``latest_check_runs_count``). Grouping is
-    per suite, so latest-wins only ever arbitrates reruns of the *same* suite,
-    never unrelated workflows from the same app. A failing suite also lowers
-    ``first_failure_at`` so the signal survives even for CI apps that only emit
-    suite events.
+    ``updated_at`` — see :func:`_wins_conclusion`; per-suite grouping means this
+    only ever arbitrates reruns of the same suite) and the run count (``max`` of
+    ``latest_check_runs_count``). A failing suite also lowers ``first_failure_at``
+    so the signal survives even for CI apps that only emit suite events.
     """
     group = _get_or_create_group(doc, payload)
 
@@ -414,34 +407,23 @@ def _apply_check_run(
 def _get_or_create_group(doc: ActivityDoc, payload: Mapping[str, Any]) -> CheckGroup:
     """The rollup for a check payload's ``(head_sha, app_slug, check_suite_id)``.
 
-    Per-suite, not per-app: one GitHub App emits one check suite per workflow run
-    (a workflow-heavy repo raises many github-actions suites on a single head), so
-    folding an app's suites together let the last suite to complete overwrite every
-    other workflow's conclusion, run count, and same-named runs. The suite id keeps
-    concurrent workflows apart, while a rerun of one suite (same id) still
-    converges latest-wins.
+    Per-suite, not per-app: one app emits one suite per workflow run, so folding
+    an app's suites together let the last suite to complete overwrite every other
+    workflow's conclusion, run count, and same-named runs.
 
-    A payload without a suite id falls back to the suite-less legacy key. That
-    keeps two populations working with no migration: documents persisted before
-    the split keep resolving their merged per-app groups, and during a rolling
-    deploy — updated and not-yet-updated webhook processors interleaving on the
-    same live PR — the id-less half keeps folding into the merged group while
-    the id-carrying half builds per-suite groups beside it. Suite-scoped events
-    never fold into a merged group, so once the rollout completes the merged
-    group freezes and persists for the rest of the document's life (the document
-    is only swept after terminal emit). Readers that scan every group
-    (``_any_group_failing``) see such a head+app twice, and a failure frozen in
-    the merged group is not cleared by suite-scoped greens — over-reporting a
-    recorded failure is accepted over erasing one.
+    A payload without a suite id falls back to the suite-less legacy key, so
+    pre-split documents — and id-less events from not-yet-updated processors
+    during the rolling deploy — keep folding into their merged groups with no
+    migration. Suite-scoped events never fold into a merged group: it freezes and
+    persists until the post-emit sweep, so readers that scan every group (e.g.
+    ``_any_group_failing``) see such a head+app twice and a frozen failure is not
+    cleared by suite-scoped greens — accepted over erasing a recorded failure.
 
-    Existing groups always resolve. A newcomer past a cap evicts the
-    least-recently-updated group (by ``last_event_at``) rather than being
-    dropped: the judge cares most about the *final* head's CI state, so a PR
-    that fills a cap must not freeze on stale entries and silently drop a
-    failing check that lands later. ``MAX_GROUPS_PER_HEAD`` evicts within the
-    newcomer's head, so one head's suite spam degrades only that head;
-    ``MAX_CHECK_GROUPS`` evicts document-wide, shedding the stalest head first
-    on many-push PRs. Each eviction is a cap hit, surfaced via a log + metric.
+    A newcomer past a cap evicts the least-recently-updated group rather than
+    being dropped (the judge cares most about the *final* head's CI state):
+    ``MAX_GROUPS_PER_HEAD`` evicts within the newcomer's head, so suite spam
+    degrades only that head; ``MAX_CHECK_GROUPS`` evicts document-wide, shedding
+    the stalest head first.
     """
     head_sha = payload.get("head_sha") or ""
     app_slug = payload.get("app_slug") or ""
@@ -524,11 +506,9 @@ def _min_ts(current: str | None, candidate: str | None) -> str | None:
 
 # --- readers: pure projections of a stored document -----------------------
 
-# The judge forward collapses each checks group into one synthesized event and
-# caps the number forwarded, mirroring the legacy row cap. Per-suite grouping can
-# store more groups than this (``MAX_CHECK_GROUPS``), so past the cap only the
-# most recently updated groups — the final heads' CI state, which the judge cares
-# most about — are forwarded.
+# The judge forward collapses each checks group into one synthesized event,
+# mirroring the legacy row cap. The store can hold more (MAX_CHECK_GROUPS);
+# past this cap only the most recently updated groups are forwarded.
 MAX_FORWARDED_CHECK_GROUPS = 100
 
 
@@ -712,8 +692,7 @@ def _synthesized_check_suite_payload(group: CheckGroup) -> dict[str, Any]:
         # Additive keys the legacy row forward never carried (Seer ignores unknown
         # payload keys, so this doesn't change the wire contract).
         "head_sha": group.get("head_sha", ""),
-        # None for groups persisted before the per-suite split (one merged group
-        # per app) and for payloads that carried no suite id.
+        # None for pre-split merged groups and payloads without a suite id.
         "check_suite_id": group.get("check_suite_id"),
         "failing_check_names": sorted(
             name for name, run in runs.items() if is_failing_conclusion(run.get("conclusion"))

--- a/src/sentry/pr_metrics/activity_doc.py
+++ b/src/sentry/pr_metrics/activity_doc.py
@@ -418,9 +418,10 @@ def _forward_priority(group: CheckGroup) -> tuple[bool, str]:
 def _get_or_create_group(doc: ActivityDoc, payload: Mapping[str, Any]) -> CheckGroup:
     """The rollup for a check payload's ``(head_sha, app_slug, check_suite_id)``.
 
-    Per-suite, not per-app: one app emits one suite per workflow run, so folding
-    an app's suites together let the last suite to complete overwrite every other
-    workflow's conclusion, run count, and same-named runs.
+    Per-suite, not per-app: nothing limits an app to one suite per head — GitHub
+    Actions raises one per workflow run — so folding an app's suites together let
+    the last suite to complete overwrite every other suite's conclusion, run
+    count, and same-named runs.
 
     A payload without a suite id falls back to the suite-less legacy key, so
     pre-split documents — and id-less events from not-yet-updated processors

--- a/src/sentry/pr_metrics/activity_doc.py
+++ b/src/sentry/pr_metrics/activity_doc.py
@@ -6,8 +6,8 @@ docs can be re-folded through the same reducer (emit-time parity check, corpus
 rebuilds). :func:`apply_activity` dispatches three event families: lifecycle
 **entries** (appended to ``events`` in arrival order, deduped by ``webhook_id``,
 synchronize links folded into ``sync_chain``), **checks** (collapsed into
-per-``(head_sha, app_slug)`` rollups), and **comments** (folded into
-``participants`` only, never stored).
+per-``(head_sha, app_slug, check_suite_id)`` rollups), and **comments** (folded
+into ``participants`` only, never stored).
 """
 
 from __future__ import annotations
@@ -32,9 +32,12 @@ MAX_EVENTS = 500
 # the events cap: below MAX_SYNC_CHAIN the chain is complete; past it the NEWEST
 # links — the ones the head-anchored commit-chain walk starts from — are retained.
 MAX_SYNC_CHAIN = 500
-# Check-rollup bounds: distinct ``(head_sha, app_slug)`` groups per PR, and
-# ever-failing runs tracked per group. Both are pathology backstops.
-MAX_CHECK_GROUPS = 100
+# Check-rollup bounds: distinct ``(head_sha, app_slug, check_suite_id)`` groups
+# per PR, and ever-failing runs tracked per group. Both are pathology backstops.
+# Groups are per suite and one app emits one suite per workflow run (a
+# workflow-heavy repo sees tens of github-actions suites on a single head), so
+# the group cap sits well above heads x suites for a normal PR.
+MAX_CHECK_GROUPS = 500
 MAX_RUNS_PER_GROUP = 50
 
 # Conclusion vocabulary shared with Seer's ``timeline.py``: a clean pass, an
@@ -62,6 +65,11 @@ class CheckRun(TypedDict):
 class CheckGroup(TypedDict):
     head_sha: str
     app_slug: str
+    # Numeric id of the owning check suite (``check_suite.id``). Groups persisted
+    # before the per-suite split lack the key entirely (readers must ``.get``);
+    # None when the payload carried no suite id, in which case the group also
+    # keys on the suite-less legacy form (see ``_get_or_create_group``).
+    check_suite_id: int | None
     suite_conclusion: str | None
     suite_updated_at: str | None
     check_runs_count: int
@@ -314,13 +322,16 @@ def _fold_sync_chain(doc: ActivityDoc, payload: Mapping[str, Any]) -> None:
 def _apply_check_suite(
     doc: ActivityDoc, payload: Mapping[str, Any], suite_updated_at: str | None
 ) -> None:
-    """Fold a completed ``check_suite`` into its ``(head_sha, app_slug)`` group.
+    """Fold a completed ``check_suite`` into its ``(head_sha, app_slug,
+    check_suite_id)`` group.
 
     The suite carries the aggregate conclusion (latest verdict wins on
     ``updated_at`` — see :func:`_wins_conclusion` for why an aborted suite does not
-    count) and the run count (``max`` of ``latest_check_runs_count``). A failing
-    suite also lowers ``first_failure_at`` so the signal survives even for CI apps
-    that only emit suite events.
+    count) and the run count (``max`` of ``latest_check_runs_count``). Grouping is
+    per suite, so latest-wins only ever arbitrates reruns of the *same* suite,
+    never unrelated workflows from the same app. A failing suite also lowers
+    ``first_failure_at`` so the signal survives even for CI apps that only emit
+    suite events.
     """
     group = _get_or_create_group(doc, payload)
 
@@ -396,7 +407,21 @@ def _apply_check_run(
 
 
 def _get_or_create_group(doc: ActivityDoc, payload: Mapping[str, Any]) -> CheckGroup:
-    """The rollup for a check payload's ``(head_sha, app_slug)``.
+    """The rollup for a check payload's ``(head_sha, app_slug, check_suite_id)``.
+
+    Per-suite, not per-app: one GitHub App emits one check suite per workflow run
+    (a workflow-heavy repo raises many github-actions suites on a single head), so
+    folding an app's suites together let the last suite to complete overwrite every
+    other workflow's conclusion, run count, and same-named runs. The suite id keeps
+    concurrent workflows apart, while a rerun of one suite (same id) still
+    converges latest-wins.
+
+    A payload without a suite id falls back to the suite-less legacy key, so
+    documents persisted before the split keep folding such events into their
+    existing groups with no migration. Suite-scoped events never fold into a
+    legacy group: on an old document the merged group simply goes stale next to
+    the new per-suite groups — a reader may transiently re-report a failure it
+    froze on, which beats erasing one.
 
     Existing groups always resolve. A new group beyond ``MAX_CHECK_GROUPS`` evicts
     the least-recently-updated group (by ``last_event_at``) to make room rather than
@@ -407,7 +432,12 @@ def _get_or_create_group(doc: ActivityDoc, payload: Mapping[str, Any]) -> CheckG
     """
     head_sha = payload.get("head_sha") or ""
     app_slug = payload.get("app_slug") or ""
-    key = f"{head_sha}|{app_slug}"
+    check_suite_id = payload.get("check_suite_id")
+    key = (
+        f"{head_sha}|{app_slug}"
+        if check_suite_id is None
+        else f"{head_sha}|{app_slug}|{check_suite_id}"
+    )
     checks = doc["checks"]
     group = checks.get(key)
     if group is not None:
@@ -423,6 +453,7 @@ def _get_or_create_group(doc: ActivityDoc, payload: Mapping[str, Any]) -> CheckG
     group = {
         "head_sha": head_sha,
         "app_slug": app_slug,
+        "check_suite_id": check_suite_id,
         "suite_conclusion": None,
         "suite_updated_at": None,
         "check_runs_count": 0,
@@ -466,8 +497,10 @@ def _min_ts(current: str | None, candidate: str | None) -> str | None:
 # --- readers: pure projections of a stored document -----------------------
 
 # The judge forward collapses each checks group into one synthesized event and
-# caps the number forwarded, mirroring the legacy row cap. The write-time group
-# cap already bounds this; the forward cap is a defensive backstop.
+# caps the number forwarded, mirroring the legacy row cap. Per-suite grouping can
+# store more groups than this (``MAX_CHECK_GROUPS``), so past the cap only the
+# most recently updated groups — the final heads' CI state, which the judge cares
+# most about — are forwarded.
 MAX_FORWARDED_CHECK_GROUPS = 100
 
 
@@ -651,6 +684,9 @@ def _synthesized_check_suite_payload(group: CheckGroup) -> dict[str, Any]:
         # Additive keys the legacy row forward never carried (Seer ignores unknown
         # payload keys, so this doesn't change the wire contract).
         "head_sha": group.get("head_sha", ""),
+        # None for groups persisted before the per-suite split (one merged group
+        # per app) and for payloads that carried no suite id.
+        "check_suite_id": group.get("check_suite_id"),
         "failing_check_names": sorted(
             name for name, run in runs.items() if is_failing_conclusion(run.get("conclusion"))
         ),
@@ -676,7 +712,8 @@ def timeline_events_from_doc(doc: ActivityDoc) -> list[dict[str, Any]]:
     """Project the document into the judge's activity timeline, oldest first.
 
     Lifecycle entries pass through unchanged (``event_type``, ``timestamp`` = the
-    arrival ``ts``, ``payload``); each checks group collapses into one synthesized
+    arrival ``ts``, ``payload``); each checks group — one per check suite, mirroring
+    GitHub's own completion events — collapses into one synthesized
     ``check_suite_completed`` timestamped at its ``last_event_at``. The merged list
     is sorted by timestamp, matching the legacy forward's shape — only the check
     events are pre-collapsed (what Seer's timeline does anyway).

--- a/src/sentry/pr_metrics/activity_doc.py
+++ b/src/sentry/pr_metrics/activity_doc.py
@@ -431,11 +431,11 @@ def _get_or_create_group(doc: ActivityDoc, payload: Mapping[str, Any]) -> CheckG
     cleared by suite-scoped greens — accepted over erasing a recorded failure.
 
     A newcomer past a cap evicts an existing group rather than being dropped
-    (the judge cares most about the *final* head's CI state):
-    ``MAX_GROUPS_PER_HEAD`` evicts within the newcomer's head — non-failing and
-    stalest first (``_forward_priority``), so suite spam degrades only that head
-    and never displaces a recorded failure; ``MAX_CHECK_GROUPS`` evicts
-    document-wide, shedding the stalest head first.
+    (the judge cares most about the *final* head's CI state), non-failing and
+    stalest first (``_forward_priority``) so a recorded failure is never
+    displaced by fresher greens: ``MAX_GROUPS_PER_HEAD`` evicts within the
+    newcomer's head, so suite spam degrades only that head; ``MAX_CHECK_GROUPS``
+    evicts document-wide, shedding stale heads' greens first.
     """
     head_sha = payload.get("head_sha") or ""
     app_slug = payload.get("app_slug") or ""
@@ -463,7 +463,7 @@ def _get_or_create_group(doc: ActivityDoc, payload: Mapping[str, Any]) -> CheckG
         )
         metrics.incr("pr_metrics.activity_doc.check_head_groups_capped")
     elif len(checks) >= MAX_CHECK_GROUPS:
-        evicted_key = min(checks, key=lambda existing: checks[existing].get("last_event_at") or "")
+        evicted_key = min(checks, key=lambda existing: _forward_priority(checks[existing]))
         del checks[evicted_key]
         logger.warning(
             "pr_metrics.activity_doc.check_groups_capped",

--- a/src/sentry/pr_metrics/activity_doc.py
+++ b/src/sentry/pr_metrics/activity_doc.py
@@ -738,10 +738,8 @@ def timeline_events_from_doc(doc: ActivityDoc) -> list[dict[str, Any]]:
     is sorted by timestamp, matching the legacy forward's shape — only the check
     events are pre-collapsed (what Seer's timeline does anyway).
 
-    Check groups are trimmed per head (``MAX_FORWARDED_GROUPS_PER_HEAD``), never
-    dropping a whole head and keeping failures over fresher greens
-    (``_forward_priority``), so the fail → push → green iteration story always
-    reaches the judge.
+    Check groups are trimmed per head (``MAX_FORWARDED_GROUPS_PER_HEAD``,
+    failures kept first — see ``_forward_priority``); no head is ever dropped.
     """
     events: list[dict[str, Any]] = [
         {

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -233,9 +233,11 @@ _FAILING_CHECK_CONCLUSIONS = frozenset({"failure", "timed_out", "startup_failure
 def _any_group_failing(groups: Iterable[activity_doc.CheckGroup]) -> bool:
     """Whether any check-suite group's latest conclusion is a failure.
 
-    Shared by every doc-store reader over the checks rollup: each group already
-    keeps the latest suite conclusion (a rerun with no new push overwrites the
-    earlier one), so this is just the narrow-vocabulary failing check.
+    Shared by every doc-store reader over the checks rollup: groups are per check
+    suite and each keeps that suite's latest conclusion (a rerun of the suite —
+    no new push — overwrites the earlier one), so one workflow's late green never
+    masks another workflow's standing failure and this is just the
+    narrow-vocabulary failing check.
     """
     return any(group.get("suite_conclusion") in _FAILING_CHECK_CONCLUSIONS for group in groups)
 
@@ -278,6 +280,9 @@ def _ci_failing_at_close(
     if doc is not None:
         # Same narrow failing vocabulary and suite-only read as the legacy path
         # (a check_run-only app has no suite conclusion and doesn't count).
+        # Deliberately sharper than the legacy latest-per-app collapse: groups
+        # are per suite, so an app running several workflows reports a failure
+        # any one of them left standing.
         return _any_group_failing(doc.get("checks", {}).values())
 
     rows = (
@@ -314,8 +319,8 @@ def _ci_failed_at_open(pull_request: PullRequest, *, doc: activity_doc.ActivityD
 
     Doc store: keyed precisely off the opening head SHA (see
     ``_opened_head_sha_from_doc``), via the checks rollup's ``(head_sha,
-    app_slug)`` grouping — a later push's checks, recorded under a different
-    head, are correctly excluded.
+    app_slug, check_suite_id)`` grouping — a later push's checks, recorded under
+    a different head, are correctly excluded.
 
     Legacy store: the row payload carries no ``head_sha`` at all (see
     ``CheckSuiteCompletedPayload``), so the opening head's checks are

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -233,11 +233,9 @@ _FAILING_CHECK_CONCLUSIONS = frozenset({"failure", "timed_out", "startup_failure
 def _any_group_failing(groups: Iterable[activity_doc.CheckGroup]) -> bool:
     """Whether any check-suite group's latest conclusion is a failure.
 
-    Shared by every doc-store reader over the checks rollup: groups are per check
-    suite and each keeps that suite's latest conclusion (a rerun of the suite —
-    no new push — overwrites the earlier one), so one workflow's late green never
-    masks another workflow's standing failure and this is just the
-    narrow-vocabulary failing check.
+    Shared by every doc-store reader over the checks rollup. Groups are per check
+    suite (a rerun overwrites its own suite's conclusion only), so one workflow's
+    late green never masks another workflow's standing failure.
     """
     return any(group.get("suite_conclusion") in _FAILING_CHECK_CONCLUSIONS for group in groups)
 
@@ -278,11 +276,9 @@ def _ci_failing_at_close(
     identical query, so ``doc`` is mandatory here rather than optional.
     """
     if doc is not None:
-        # Same narrow failing vocabulary and suite-only read as the legacy path
-        # (a check_run-only app has no suite conclusion and doesn't count).
-        # Deliberately sharper than the legacy latest-per-app collapse: groups
-        # are per suite, so an app running several workflows reports a failure
-        # any one of them left standing.
+        # Same narrow failing vocabulary and suite-only read as the legacy path,
+        # but per-suite: a failure any workflow left standing is reported, not
+        # just the app's latest suite to complete.
         return _any_group_failing(doc.get("checks", {}).values())
 
     rows = (

--- a/src/sentry/pr_metrics/judge.py
+++ b/src/sentry/pr_metrics/judge.py
@@ -109,10 +109,8 @@ def _pr_activity_timeline(pull_request: PullRequest) -> tuple[list[PrActivityEve
 
     Document-path PRs project the same wire shape: lifecycle entries pass through,
     and each checks group becomes one synthesized ``check_suite_completed`` — one
-    per check suite, matching the cardinality of GitHub's own completion webhooks
-    rather than a one-per-app collapse, with additive payload keys
-    (``check_suite_id``, ``failing_check_names``, ...) legacy rows never carried.
-    Seer ignores unknown payload keys, so the contract stays field-compatible.
+    per suite (GitHub's own cardinality), with additive payload keys legacy rows
+    never carried; Seer ignores unknown keys, so the contract stays compatible.
     """
     doc = load_activity_document(pull_request)
     if doc is not None:

--- a/src/sentry/pr_metrics/judge.py
+++ b/src/sentry/pr_metrics/judge.py
@@ -108,8 +108,11 @@ def _pr_activity_timeline(pull_request: PullRequest) -> tuple[list[PrActivityEve
     can't balloon the Seer request.
 
     Document-path PRs project the same wire shape: lifecycle entries pass through,
-    and each checks group becomes one synthesized ``check_suite_completed`` (the
-    collapse Seer's timeline does anyway), so the Seer contract is unchanged.
+    and each checks group becomes one synthesized ``check_suite_completed`` — one
+    per check suite, matching the cardinality of GitHub's own completion webhooks
+    rather than a one-per-app collapse, with additive payload keys
+    (``check_suite_id``, ``failing_check_names``, ...) legacy rows never carried.
+    Seer ignores unknown payload keys, so the contract stays field-compatible.
     """
     doc = load_activity_document(pull_request)
     if doc is not None:

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -924,6 +924,7 @@ def handle_check_suite(
                 payload,
                 provider_ts=check_suite.get("updated_at"),
                 head_sha=check_suite.get("head_sha"),
+                check_suite_id=check_suite.get("id"),
             )
 
 
@@ -972,6 +973,7 @@ def handle_check_run(
                 payload,
                 provider_ts=check_run.get("completed_at"),
                 head_sha=check_run.get("head_sha"),
+                check_suite_id=(check_run.get("check_suite") or {}).get("id"),
             )
 
 
@@ -1471,24 +1473,30 @@ def _record_activity_event(
     event_at: str | None = None,
     provider_ts: str | None = None,
     head_sha: str | None = None,
+    check_suite_id: int | None = None,
     use_doc: bool | None = None,
 ) -> None:
     """Route one processed event to the document or a legacy row per this PR's store.
 
-    ``event_at``, ``provider_ts`` and ``head_sha`` only feed the document path; see
-    ``apply_activity`` for their per-family semantics (``head_sha`` keys the check
-    rollup's per-push groups, so the legacy row's payload is left exactly as
-    before). Callers that already resolved the routing decision — because the
-    payload's shape depends on it — pass it as ``use_doc``; otherwise it is
-    computed here.
+    ``event_at``, ``provider_ts``, ``head_sha`` and ``check_suite_id`` only feed the
+    document path; see ``apply_activity`` for their per-family semantics
+    (``head_sha`` and ``check_suite_id`` key the check rollup's per-push, per-suite
+    groups, so the legacy row's payload is left exactly as before). Callers that
+    already resolved the routing decision — because the payload's shape depends on
+    it — pass it as ``use_doc``; otherwise it is computed here.
     """
     if use_doc is None:
         use_doc = _use_activity_document(pr, organization)
     if use_doc:
+        doc_extras = {
+            key: value
+            for key, value in (("head_sha", head_sha), ("check_suite_id", check_suite_id))
+            if value is not None
+        }
         _apply_activity_into_doc(
             pr,
             event_type=event_type,
-            payload=payload if head_sha is None else {**payload, "head_sha": head_sha},
+            payload={**payload, **doc_extras} if doc_extras else payload,
             webhook_id=webhook_id,
             event_at=event_at,
             provider_ts=provider_ts,

--- a/tests/sentry/pr_metrics/test_activity_doc.py
+++ b/tests/sentry/pr_metrics/test_activity_doc.py
@@ -81,18 +81,24 @@ def _suite(
     conclusion: str = "success",
     head_sha: str = "sha1",
     app_slug: str = "github-actions",
+    check_suite_id: int | None = 1,
     check_runs_count: int = 4,
     updated_at: str = "2026-07-10T12:00:00Z",
 ) -> None:
+    payload: dict[str, Any] = {
+        "conclusion": conclusion,
+        "app_slug": app_slug,
+        "check_runs_count": check_runs_count,
+        "head_sha": head_sha,
+    }
+    if check_suite_id is not None:
+        # Mirrors the write path: the suite id is merged into the doc payload only
+        # when the webhook carried one.
+        payload["check_suite_id"] = check_suite_id
     apply_activity(
         doc,
         event_type=PullRequestActivityType.CHECK_SUITE_COMPLETED,
-        payload={
-            "conclusion": conclusion,
-            "app_slug": app_slug,
-            "check_runs_count": check_runs_count,
-            "head_sha": head_sha,
-        },
+        payload=payload,
         ts="2026-07-10T12:00:00Z",
         provider_ts=updated_at,
     )
@@ -105,24 +111,38 @@ def _run(
     conclusion: str = "failure",
     head_sha: str = "sha1",
     app_slug: str = "github-actions",
+    check_suite_id: int | None = 1,
     completed_at: str = "2026-07-10T12:00:00Z",
 ) -> None:
+    payload: dict[str, Any] = {
+        "check_name": check_name,
+        "conclusion": conclusion,
+        "app_slug": app_slug,
+        "head_sha": head_sha,
+    }
+    if check_suite_id is not None:
+        payload["check_suite_id"] = check_suite_id
     apply_activity(
         doc,
         event_type=PullRequestActivityType.CHECK_RUN_COMPLETED,
-        payload={
-            "check_name": check_name,
-            "conclusion": conclusion,
-            "app_slug": app_slug,
-            "head_sha": head_sha,
-        },
+        payload=payload,
         ts="2026-07-10T12:00:00Z",
         provider_ts=completed_at,
     )
 
 
-def _group(doc: ActivityDoc, head_sha: str = "sha1", app_slug: str = "github-actions") -> Any:
-    return doc["checks"][f"{head_sha}|{app_slug}"]
+def _group(
+    doc: ActivityDoc,
+    head_sha: str = "sha1",
+    app_slug: str = "github-actions",
+    check_suite_id: int | None = 1,
+) -> Any:
+    key = (
+        f"{head_sha}|{app_slug}"
+        if check_suite_id is None
+        else f"{head_sha}|{app_slug}|{check_suite_id}"
+    )
+    return doc["checks"][key]
 
 
 # --- document shape -------------------------------------------------------
@@ -469,6 +489,7 @@ def test_single_failing_run_creates_group_and_entry() -> None:
     group = _group(doc)
     assert group["head_sha"] == "sha1"
     assert group["app_slug"] == "github-actions"
+    assert group["check_suite_id"] == 1
     assert group["runs"] == {
         "test (3.11)": {
             "conclusion": "failure",
@@ -581,16 +602,86 @@ def test_failing_suite_sets_first_failure_at() -> None:
 # --- checks: grouping keys -------------------------------------------------
 
 
-def test_distinct_head_sha_and_app_slug_are_distinct_groups() -> None:
+def test_distinct_head_sha_app_slug_and_suite_are_distinct_groups() -> None:
     doc = new_document()
-    _run(doc, head_sha="sha1", app_slug="github-actions", check_name="t")
-    _run(doc, head_sha="sha2", app_slug="github-actions", check_name="t")
-    _run(doc, head_sha="sha1", app_slug="circleci", check_name="t")
+    _run(doc, head_sha="sha1", app_slug="github-actions", check_suite_id=1, check_name="t")
+    _run(doc, head_sha="sha2", app_slug="github-actions", check_suite_id=2, check_name="t")
+    _run(doc, head_sha="sha1", app_slug="circleci", check_suite_id=3, check_name="t")
+    # One app raises one suite per workflow run, so a single head can carry
+    # several suites from the same app — each is its own group.
+    _run(doc, head_sha="sha1", app_slug="github-actions", check_suite_id=4, check_name="t")
     assert set(doc["checks"].keys()) == {
-        "sha1|github-actions",
-        "sha2|github-actions",
-        "sha1|circleci",
+        "sha1|github-actions|1",
+        "sha2|github-actions|2",
+        "sha1|circleci|3",
+        "sha1|github-actions|4",
     }
+
+
+def test_suites_from_one_app_at_same_head_keep_their_conclusions() -> None:
+    # The regression this grouping fixes: github-actions emits one suite per
+    # workflow run, and under (head_sha, app_slug) grouping the last suite to
+    # complete overwrote every other workflow's conclusion — a failed workflow
+    # was erased by a later green one.
+    doc = new_document()
+    _suite(doc, check_suite_id=1, conclusion="failure", updated_at="2026-07-10T12:00:00Z")
+    _suite(doc, check_suite_id=2, conclusion="success", updated_at="2026-07-10T12:05:00Z")
+    assert _group(doc, check_suite_id=1)["suite_conclusion"] == "failure"
+    assert _group(doc, check_suite_id=2)["suite_conclusion"] == "success"
+
+
+def test_check_runs_count_kept_per_suite_not_max_across_workflows() -> None:
+    doc = new_document()
+    _suite(doc, check_suite_id=1, check_runs_count=10, updated_at="2026-07-10T12:00:00Z")
+    _suite(doc, check_suite_id=2, check_runs_count=4, updated_at="2026-07-10T12:05:00Z")
+    assert _group(doc, check_suite_id=1)["check_runs_count"] == 10
+    assert _group(doc, check_suite_id=2)["check_runs_count"] == 4
+
+
+def test_same_named_runs_in_different_suites_do_not_collide() -> None:
+    # Two workflows can both have a job named "test". A green completion in one
+    # suite must not read as a recovery of the other suite's failure.
+    doc = new_document()
+    _run(doc, check_suite_id=1, check_name="test", conclusion="failure")
+    _run(doc, check_suite_id=2, check_name="test", conclusion="success")
+    assert _group(doc, check_suite_id=1)["runs"]["test"]["conclusion"] == "failure"
+    assert _group(doc, check_suite_id=2)["runs"] == {}  # never-failed runs aren't tracked
+
+
+def test_event_without_suite_id_folds_into_legacy_key() -> None:
+    # A payload with no suite id (a document written before the per-suite split
+    # keeps receiving events shaped by the old code during a rolling deploy, or a
+    # provider payload lacks the id) falls back to the suite-less key and keeps
+    # converging there.
+    doc = new_document()
+    _suite(doc, check_suite_id=None, conclusion="failure", updated_at="2026-07-10T12:00:00Z")
+    assert set(doc["checks"].keys()) == {"sha1|github-actions"}
+    assert _group(doc, check_suite_id=None)["check_suite_id"] is None
+    _suite(doc, check_suite_id=None, conclusion="success", updated_at="2026-07-10T12:05:00Z")
+    assert set(doc["checks"].keys()) == {"sha1|github-actions"}
+    assert _group(doc, check_suite_id=None)["suite_conclusion"] == "success"
+
+
+def test_suite_scoped_event_leaves_pre_split_group_untouched() -> None:
+    # A stored document written before the per-suite split holds one merged group
+    # per (head_sha, app_slug), without a check_suite_id key. A new suite-scoped
+    # event must not fold into it — it would corrupt it the old way — so the
+    # merged group stays frozen next to the new per-suite groups.
+    doc = new_document()
+    legacy_group: Any = {
+        "head_sha": "sha1",
+        "app_slug": "github-actions",
+        "suite_conclusion": "failure",
+        "suite_updated_at": "2026-07-10T11:00:00Z",
+        "check_runs_count": 3,
+        "runs": {},
+        "first_failure_at": "2026-07-10T11:00:00Z",
+        "last_event_at": "2026-07-10T11:00:00Z",
+    }
+    doc["checks"]["sha1|github-actions"] = copy.deepcopy(legacy_group)
+    _suite(doc, check_suite_id=7, conclusion="success", updated_at="2026-07-10T12:00:00Z")
+    assert doc["checks"]["sha1|github-actions"] == legacy_group
+    assert _group(doc, check_suite_id=7)["suite_conclusion"] == "success"
 
 
 # --- checks: idempotency & permutation convergence ------------------------
@@ -613,8 +704,8 @@ def test_reapplying_failing_run_only_bumps_failed_attempts() -> None:
     _run(doc, check_name="test", conclusion="failure", completed_at="2026-07-10T12:00:00Z")
     after = doc["checks"]
     # Everything is identical except the accepted failed_attempts magnitude drift.
-    assert after["sha1|github-actions"]["runs"]["test"]["failed_attempts"] == 2
-    before["sha1|github-actions"]["runs"]["test"]["failed_attempts"] = 2
+    assert after["sha1|github-actions|1"]["runs"]["test"]["failed_attempts"] == 2
+    before["sha1|github-actions|1"]["runs"]["test"]["failed_attempts"] = 2
     assert after == before
 
 
@@ -668,7 +759,7 @@ def test_check_events_converge_under_any_permutation() -> None:
         assert fold(list(order)) == baseline
 
     # Sanity on the converged values.
-    group = baseline["sha1|github-actions"]
+    group = baseline["sha1|github-actions|1"]
     assert group["suite_conclusion"] == "success"  # latest updated_at
     assert group["check_runs_count"] == 8  # max
     assert group["first_failure_at"] == "2026-07-10T12:00:00Z"  # min failing ts
@@ -685,7 +776,7 @@ def test_check_events_converge_under_any_permutation() -> None:
 def test_check_group_cap_evicts_least_recent_group() -> None:
     doc = new_document()
     # Fill the cap with green CI suites on distinct SHAs, strictly increasing recency
-    # (sha0000 oldest ... sha0099 newest).
+    # (sha0000 the oldest).
     with patch(f"{MODULE}.metrics") as mock_metrics, patch(f"{MODULE}.logger") as mock_logger:
         for i in range(MAX_CHECK_GROUPS):
             _suite(
@@ -709,10 +800,10 @@ def test_check_group_cap_evicts_least_recent_group() -> None:
 
     assert len(doc["checks"]) == MAX_CHECK_GROUPS
     # The newcomer is present and carries the failure.
-    assert doc["checks"]["sha-final|github-actions"]["runs"]["build"]["conclusion"] == "failure"
+    assert doc["checks"]["sha-final|github-actions|1"]["runs"]["build"]["conclusion"] == "failure"
     # The least-recently-updated group was evicted; a newer green group survived.
-    assert "sha0000|github-actions" not in doc["checks"]
-    assert "sha0099|github-actions" in doc["checks"]
+    assert "sha0000|github-actions|1" not in doc["checks"]
+    assert "sha0001|github-actions|1" in doc["checks"]
     mock_metrics.incr.assert_any_call("pr_metrics.activity_doc.check_groups_capped")
     assert mock_logger.warning.call_count == 1
 
@@ -723,7 +814,7 @@ def test_existing_group_still_updates_after_group_cap() -> None:
         _run(doc, head_sha=f"sha{i}", check_name="t", conclusion="failure")
     # A new event for an EXISTING group is not a new group — it must still apply.
     _run(doc, head_sha="sha0", check_name="t", conclusion="failure")
-    assert doc["checks"]["sha0|github-actions"]["runs"]["t"]["failed_attempts"] == 2
+    assert doc["checks"]["sha0|github-actions|1"]["runs"]["t"]["failed_attempts"] == 2
 
 
 def test_check_runs_per_group_cap_drops_new_failing_runs() -> None:
@@ -1036,7 +1127,28 @@ def test_timeline_projects_entries_and_synthesized_suite() -> None:
     assert suite["payload"]["conclusion"] == "failure"
     assert suite["payload"]["failing_check_names"] == ["test"]
     assert suite["payload"]["head_sha"] == "sha1"
+    assert suite["payload"]["check_suite_id"] == 1
     assert suite["payload"]["first_failure_at"] == "2026-07-10T12:05:00Z"
+
+
+def test_timeline_synthesizes_one_event_per_suite() -> None:
+    # Each suite is its own group, so the judge sees one completion per suite —
+    # mirroring GitHub's own webhooks — instead of one per app whose conclusion
+    # was whatever suite happened to finish last.
+    doc = new_document()
+    _run(doc, check_suite_id=1, check_name="test", conclusion="failure")
+    _suite(doc, check_suite_id=1, conclusion="failure", updated_at="2026-07-10T12:01:00Z")
+    _suite(doc, check_suite_id=2, conclusion="success", updated_at="2026-07-10T12:05:00Z")
+
+    events = timeline_events_from_doc(doc)
+    assert [
+        (
+            e["payload"]["check_suite_id"],
+            e["payload"]["conclusion"],
+            e["payload"]["failing_check_names"],
+        )
+        for e in events
+    ] == [(1, "failure", ["test"]), (2, "success", [])]
 
 
 def test_timeline_suite_conclusion_derived_from_runs_when_absent() -> None:

--- a/tests/sentry/pr_metrics/test_activity_doc.py
+++ b/tests/sentry/pr_metrics/test_activity_doc.py
@@ -16,6 +16,7 @@ from sentry.pr_metrics.activity_doc import (
     DOC_VERSION,
     MAX_CHECK_GROUPS,
     MAX_EVENTS,
+    MAX_FORWARDED_GROUPS_PER_HEAD,
     MAX_GROUPS_PER_HEAD,
     MAX_RUNS_PER_GROUP,
     MAX_SYNC_CHAIN,
@@ -849,6 +850,26 @@ def test_head_group_cap_evicts_within_the_head_only() -> None:
     assert mock_logger.warning.call_count == 1
 
 
+def test_head_group_cap_never_evicts_a_recorded_failure() -> None:
+    doc = new_document()
+    # The failure lands first, so it is the stalest group on the head…
+    _run(
+        doc,
+        check_suite_id=0,
+        check_name="unit",
+        conclusion="failure",
+        completed_at="2026-07-10T11:00:00Z",
+    )
+    with patch(f"{MODULE}.metrics"), patch(f"{MODULE}.logger"):
+        for i in range(1, MAX_GROUPS_PER_HEAD):
+            _suite(doc, check_suite_id=i, updated_at=f"2026-07-10T12:00:{i % 60:02d}Z")
+        _suite(doc, check_suite_id=1000, updated_at="2026-07-10T13:00:00Z")
+    # …yet the eviction takes the stalest green, not the failure.
+    assert "sha1|github-actions|0" in doc["checks"]
+    assert "sha1|github-actions|1" not in doc["checks"]
+    assert _group(doc, check_suite_id=1000)["suite_conclusion"] == "success"
+
+
 def test_existing_group_still_updates_after_group_cap() -> None:
     doc = new_document()
     for i in range(MAX_CHECK_GROUPS):
@@ -1189,6 +1210,65 @@ def test_timeline_synthesizes_one_event_per_suite() -> None:
         )
         for e in events
     ] == [(1, "failure", ["test"]), (2, "success", [])]
+
+
+def test_timeline_forward_trims_per_head_keeping_failures() -> None:
+    doc = new_document()
+    # A currently-failing suite and a fail→green recovery, both early (stalest)…
+    _suite(doc, check_suite_id=0, conclusion="failure", updated_at="2026-07-10T11:00:00Z")
+    _run(
+        doc,
+        check_suite_id=1,
+        check_name="flaky",
+        conclusion="failure",
+        completed_at="2026-07-10T11:01:00Z",
+    )
+    _run(
+        doc,
+        check_suite_id=1,
+        check_name="flaky",
+        conclusion="success",
+        completed_at="2026-07-10T11:02:00Z",
+    )
+    # …buried under a full trim window of fresher green suites.
+    for i in range(2, MAX_FORWARDED_GROUPS_PER_HEAD + 2):
+        _suite(doc, check_suite_id=i, updated_at=f"2026-07-10T12:00:{i:02d}Z")
+
+    with patch(f"{MODULE}.metrics") as mock_metrics, patch(f"{MODULE}.logger") as mock_logger:
+        events = timeline_events_from_doc(doc)
+
+    ids = [e["payload"]["check_suite_id"] for e in events]
+    assert len(ids) == MAX_FORWARDED_GROUPS_PER_HEAD
+    # Both failure-bearing groups survive; the dropped ones are the stalest greens.
+    assert 0 in ids and 1 in ids
+    assert 2 not in ids and 3 not in ids
+    mock_logger.warning.assert_called_once_with(
+        "pr_metrics.activity_doc.forward_head_groups_capped",
+        extra={"head_sha": "sha1", "dropped": 2},
+    )
+    mock_metrics.incr.assert_any_call("pr_metrics.activity_doc.forward_head_groups_capped")
+
+
+def test_timeline_forward_keeps_every_head_represented() -> None:
+    # Trimming is per head, so a quiet old head is never displaced by a busier,
+    # fresher one — the flat-cap failure mode was dropping whole heads.
+    doc = new_document()
+    _suite(
+        doc,
+        head_sha="sha-old",
+        check_suite_id=0,
+        conclusion="failure",
+        updated_at="2026-07-10T11:00:00Z",
+    )
+    for i in range(1, MAX_FORWARDED_GROUPS_PER_HEAD + 2):
+        _suite(doc, head_sha="sha-new", check_suite_id=i, updated_at=f"2026-07-10T12:00:{i:02d}Z")
+
+    with patch(f"{MODULE}.metrics"), patch(f"{MODULE}.logger"):
+        events = timeline_events_from_doc(doc)
+
+    heads = {e["payload"]["head_sha"] for e in events}
+    assert heads == {"sha-old", "sha-new"}
+    assert len(events) == 1 + MAX_FORWARDED_GROUPS_PER_HEAD
 
 
 def test_timeline_suite_conclusion_derived_from_runs_when_absent() -> None:

--- a/tests/sentry/pr_metrics/test_activity_doc.py
+++ b/tests/sentry/pr_metrics/test_activity_doc.py
@@ -93,8 +93,7 @@ def _suite(
         "head_sha": head_sha,
     }
     if check_suite_id is not None:
-        # Mirrors the write path: the suite id is merged into the doc payload only
-        # when the webhook carried one.
+        # Mirrors the write path: the suite id is only merged in when present.
         payload["check_suite_id"] = check_suite_id
     apply_activity(
         doc,
@@ -620,10 +619,8 @@ def test_distinct_head_sha_app_slug_and_suite_are_distinct_groups() -> None:
 
 
 def test_suites_from_one_app_at_same_head_keep_their_conclusions() -> None:
-    # The regression this grouping fixes: github-actions emits one suite per
-    # workflow run, and under (head_sha, app_slug) grouping the last suite to
-    # complete overwrote every other workflow's conclusion — a failed workflow
-    # was erased by a later green one.
+    # The regression this fixes: one app emits one suite per workflow run, and
+    # per-app grouping let the last suite to complete overwrite the others.
     doc = new_document()
     _suite(doc, check_suite_id=1, conclusion="failure", updated_at="2026-07-10T12:00:00Z")
     _suite(doc, check_suite_id=2, conclusion="success", updated_at="2026-07-10T12:05:00Z")
@@ -650,10 +647,8 @@ def test_same_named_runs_in_different_suites_do_not_collide() -> None:
 
 
 def test_event_without_suite_id_folds_into_legacy_key() -> None:
-    # A payload with no suite id (a document written before the per-suite split
-    # keeps receiving events shaped by the old code during a rolling deploy, or a
-    # provider payload lacks the id) falls back to the suite-less key and keeps
-    # converging there.
+    # No suite id (pre-split documents, old processors during the rolling
+    # deploy, or a payload lacking the id) → the suite-less legacy key.
     doc = new_document()
     _suite(doc, check_suite_id=None, conclusion="failure", updated_at="2026-07-10T12:00:00Z")
     assert set(doc["checks"].keys()) == {"sha1|github-actions"}
@@ -664,10 +659,9 @@ def test_event_without_suite_id_folds_into_legacy_key() -> None:
 
 
 def test_suite_scoped_event_leaves_pre_split_group_untouched() -> None:
-    # A stored document written before the per-suite split holds one merged group
-    # per (head_sha, app_slug), without a check_suite_id key. A new suite-scoped
-    # event must not fold into it — it would corrupt it the old way — so the
-    # merged group stays frozen next to the new per-suite groups.
+    # A pre-split document holds one merged group per (head_sha, app_slug) with
+    # no check_suite_id key. Suite-scoped events must not fold into it — it
+    # stays frozen beside the new per-suite groups.
     doc = new_document()
     legacy_group: Any = {
         "head_sha": "sha1",
@@ -686,12 +680,9 @@ def test_suite_scoped_event_leaves_pre_split_group_untouched() -> None:
 
 
 def test_timeline_forwards_both_merged_and_suite_groups_for_same_head() -> None:
-    # The state a rolling deploy produces on a live PR: id-less events (from
-    # not-yet-updated processors) fold into the merged legacy group while
-    # id-carrying events build per-suite groups beside it, and the merged group
-    # then persists for the rest of the document's life. Both representations of
-    # the same head+app reach the judge, each with its own conclusion — the
-    # frozen failure is double-reported rather than erased.
+    # The rolling-deploy state: id-less events fold into the merged group while
+    # id-carrying events build per-suite groups beside it. Both reach the judge,
+    # each with its own conclusion — the frozen failure is reported, not erased.
     doc = new_document()
     _suite(doc, check_suite_id=None, conclusion="failure", updated_at="2026-07-10T12:00:00Z")
     _suite(doc, check_suite_id=2, conclusion="success", updated_at="2026-07-10T12:05:00Z")
@@ -1182,9 +1173,8 @@ def test_timeline_projects_entries_and_synthesized_suite() -> None:
 
 
 def test_timeline_synthesizes_one_event_per_suite() -> None:
-    # Each suite is its own group, so the judge sees one completion per suite —
-    # mirroring GitHub's own webhooks — instead of one per app whose conclusion
-    # was whatever suite happened to finish last.
+    # One synthesized completion per suite — GitHub's own cardinality — instead
+    # of one per app carrying whichever suite finished last.
     doc = new_document()
     _run(doc, check_suite_id=1, check_name="test", conclusion="failure")
     _suite(doc, check_suite_id=1, conclusion="failure", updated_at="2026-07-10T12:01:00Z")

--- a/tests/sentry/pr_metrics/test_activity_doc.py
+++ b/tests/sentry/pr_metrics/test_activity_doc.py
@@ -16,6 +16,7 @@ from sentry.pr_metrics.activity_doc import (
     DOC_VERSION,
     MAX_CHECK_GROUPS,
     MAX_EVENTS,
+    MAX_GROUPS_PER_HEAD,
     MAX_RUNS_PER_GROUP,
     MAX_SYNC_CHAIN,
     ActivityDoc,
@@ -684,6 +685,24 @@ def test_suite_scoped_event_leaves_pre_split_group_untouched() -> None:
     assert _group(doc, check_suite_id=7)["suite_conclusion"] == "success"
 
 
+def test_timeline_forwards_both_merged_and_suite_groups_for_same_head() -> None:
+    # The state a rolling deploy produces on a live PR: id-less events (from
+    # not-yet-updated processors) fold into the merged legacy group while
+    # id-carrying events build per-suite groups beside it, and the merged group
+    # then persists for the rest of the document's life. Both representations of
+    # the same head+app reach the judge, each with its own conclusion — the
+    # frozen failure is double-reported rather than erased.
+    doc = new_document()
+    _suite(doc, check_suite_id=None, conclusion="failure", updated_at="2026-07-10T12:00:00Z")
+    _suite(doc, check_suite_id=2, conclusion="success", updated_at="2026-07-10T12:05:00Z")
+
+    events = timeline_events_from_doc(doc)
+    assert [(e["payload"]["check_suite_id"], e["payload"]["conclusion"]) for e in events] == [
+        (None, "failure"),
+        (2, "success"),
+    ]
+
+
 # --- checks: idempotency & permutation convergence ------------------------
 
 
@@ -805,6 +824,37 @@ def test_check_group_cap_evicts_least_recent_group() -> None:
     assert "sha0000|github-actions|1" not in doc["checks"]
     assert "sha0001|github-actions|1" in doc["checks"]
     mock_metrics.incr.assert_any_call("pr_metrics.activity_doc.check_groups_capped")
+    assert mock_logger.warning.call_count == 1
+
+
+def test_head_group_cap_evicts_within_the_head_only() -> None:
+    doc = new_document()
+    # A real (failing) group on an old head…
+    _suite(
+        doc,
+        head_sha="sha-old",
+        check_suite_id=999,
+        conclusion="failure",
+        updated_at="2026-07-10T11:00:00Z",
+    )
+    # …then a suite-spam loop (e.g. a workflow re-trigger bot) fills a newer head
+    # to its cap, with strictly increasing recency (suite 0 the stalest).
+    with patch(f"{MODULE}.metrics") as mock_metrics, patch(f"{MODULE}.logger") as mock_logger:
+        for i in range(MAX_GROUPS_PER_HEAD):
+            _suite(
+                doc, head_sha="sha-spam", check_suite_id=i, updated_at=f"2026-07-10T12:{i:02d}:00Z"
+            )
+        assert mock_metrics.incr.call_count == 0  # filling exactly to the cap evicts nothing
+        _suite(doc, head_sha="sha-spam", check_suite_id=1000, updated_at="2026-07-10T13:00:00Z")
+
+    # The spam head evicted its own stalest suite to admit the newcomer…
+    assert "sha-spam|github-actions|0" not in doc["checks"]
+    assert _group(doc, head_sha="sha-spam", check_suite_id=1000) is not None
+    spam_groups = [g for g in doc["checks"].values() if g["head_sha"] == "sha-spam"]
+    assert len(spam_groups) == MAX_GROUPS_PER_HEAD
+    # …and the other head — far staler than anything on the spam head — survived.
+    assert _group(doc, head_sha="sha-old", check_suite_id=999)["suite_conclusion"] == "failure"
+    mock_metrics.incr.assert_any_call("pr_metrics.activity_doc.check_head_groups_capped")
     assert mock_logger.warning.call_count == 1
 
 

--- a/tests/sentry/pr_metrics/test_activity_doc.py
+++ b/tests/sentry/pr_metrics/test_activity_doc.py
@@ -850,6 +850,31 @@ def test_head_group_cap_evicts_within_the_head_only() -> None:
     assert mock_logger.warning.call_count == 1
 
 
+def test_document_group_cap_never_evicts_a_recorded_failure() -> None:
+    doc = new_document()
+    # A failing suite on the oldest head — the natural LRU victim…
+    _suite(
+        doc,
+        head_sha="sha-fail",
+        check_suite_id=0,
+        conclusion="failure",
+        updated_at="2026-07-10T10:00:00Z",
+    )
+    with patch(f"{MODULE}.metrics"), patch(f"{MODULE}.logger"):
+        for i in range(1, MAX_CHECK_GROUPS):
+            _suite(
+                doc,
+                head_sha=f"sha{i:04d}",
+                check_suite_id=i,
+                updated_at=f"2026-07-10T12:{i // 60:02d}:{i % 60:02d}Z",
+            )
+        _suite(doc, head_sha="sha-final", check_suite_id=9999, updated_at="2026-07-10T13:00:00Z")
+    # …yet the document-wide eviction takes the stalest green instead.
+    assert "sha-fail|github-actions|0" in doc["checks"]
+    assert "sha0001|github-actions|1" not in doc["checks"]
+    assert _group(doc, head_sha="sha-final", check_suite_id=9999)["suite_conclusion"] == "success"
+
+
 def test_head_group_cap_never_evicts_a_recorded_failure() -> None:
     doc = new_document()
     # The failure lands first, so it is the stalest group on the head…

--- a/tests/sentry/pr_metrics/test_readers_activity_doc.py
+++ b/tests/sentry/pr_metrics/test_readers_activity_doc.py
@@ -178,6 +178,20 @@ class ActivityDocumentReadersTest(TestCase):
         self._write_doc(_doc(checks={"sha1|github-actions": _group(suite_conclusion="success")}))
         assert _ci_failing_at_close(self.pr, doc=load_activity_document(self.pr)) is False
 
+    def test_ci_failing_at_close_failure_not_masked_by_sibling_suite(self) -> None:
+        # One app, two suites (two workflow runs) at the same head: the workflow
+        # that failed keeps its own group, so the other workflow's later green
+        # completion doesn't erase the failure.
+        self._write_doc(
+            _doc(
+                checks={
+                    "sha1|github-actions|1": _group(check_suite_id=1, suite_conclusion="failure"),
+                    "sha1|github-actions|2": _group(check_suite_id=2, suite_conclusion="success"),
+                }
+            )
+        )
+        assert _ci_failing_at_close(self.pr, doc=load_activity_document(self.pr)) is True
+
     # --- review_activity (requested_count, results) -------------------------
 
     def test_reviews_requested_count_from_doc(self) -> None:

--- a/tests/sentry/pr_metrics/test_readers_activity_doc.py
+++ b/tests/sentry/pr_metrics/test_readers_activity_doc.py
@@ -193,12 +193,9 @@ class ActivityDocumentReadersTest(TestCase):
         assert _ci_failing_at_close(self.pr, doc=load_activity_document(self.pr)) is True
 
     def test_ci_failing_at_close_mixed_merged_and_suite_groups_keeps_frozen_failure(self) -> None:
-        # The rolling-deploy state: id-less events froze a failure into the
-        # merged legacy group, then suite-scoped greens landed beside it under
-        # per-suite keys. Any-failure-wins across all groups means the frozen
-        # failure is still reported for the document's whole life — the accepted
-        # over-report documented on _get_or_create_group, chosen over erasing a
-        # recorded failure.
+        # Rolling-deploy state: a failure frozen in the merged legacy group,
+        # suite-scoped greens beside it. Any-failure-wins keeps reporting it for
+        # the document's life — the accepted over-report, not an erasure.
         self._write_doc(
             _doc(
                 checks={

--- a/tests/sentry/pr_metrics/test_readers_activity_doc.py
+++ b/tests/sentry/pr_metrics/test_readers_activity_doc.py
@@ -192,6 +192,23 @@ class ActivityDocumentReadersTest(TestCase):
         )
         assert _ci_failing_at_close(self.pr, doc=load_activity_document(self.pr)) is True
 
+    def test_ci_failing_at_close_mixed_merged_and_suite_groups_keeps_frozen_failure(self) -> None:
+        # The rolling-deploy state: id-less events froze a failure into the
+        # merged legacy group, then suite-scoped greens landed beside it under
+        # per-suite keys. Any-failure-wins across all groups means the frozen
+        # failure is still reported for the document's whole life — the accepted
+        # over-report documented on _get_or_create_group, chosen over erasing a
+        # recorded failure.
+        self._write_doc(
+            _doc(
+                checks={
+                    "sha1|github-actions": _group(suite_conclusion="failure"),
+                    "sha1|github-actions|2": _group(check_suite_id=2, suite_conclusion="success"),
+                }
+            )
+        )
+        assert _ci_failing_at_close(self.pr, doc=load_activity_document(self.pr)) is True
+
     # --- review_activity (requested_count, results) -------------------------
 
     def test_reviews_requested_count_from_doc(self) -> None:

--- a/tests/sentry/pr_metrics/test_webhooks_activity_doc.py
+++ b/tests/sentry/pr_metrics/test_webhooks_activity_doc.py
@@ -177,6 +177,7 @@ class ActivityDocumentWritePathTest(TestCase):
         conclusion: str = "failure",
         updated_at: str = "2026-07-10T12:00:00Z",
         head_sha: str = "headsha1",
+        suite_id: int | None = 101,
         webhook_id: str = "cs1",
     ) -> None:
         handle_check_suite(
@@ -184,6 +185,7 @@ class ActivityDocumentWritePathTest(TestCase):
             event={
                 "action": "completed",
                 "check_suite": {
+                    "id": suite_id,
                     "head_sha": head_sha,
                     "conclusion": conclusion,
                     "app": {"slug": "github-actions"},
@@ -205,6 +207,7 @@ class ActivityDocumentWritePathTest(TestCase):
         conclusion: str = "failure",
         completed_at: str = "2026-07-10T12:00:00Z",
         head_sha: str = "headsha1",
+        suite_id: int | None = 101,
         webhook_id: str = "cr1",
     ) -> None:
         handle_check_run(
@@ -216,6 +219,7 @@ class ActivityDocumentWritePathTest(TestCase):
                     "head_sha": head_sha,
                     "conclusion": conclusion,
                     "app": {"slug": "github-actions"},
+                    "check_suite": {"id": suite_id},
                     "completed_at": completed_at,
                     "pull_requests": [{"number": 42, "base": {"repo": {"id": 99}}}],
                 },
@@ -556,19 +560,45 @@ class ActivityDocumentWritePathTest(TestCase):
         assert self._doc_or_none() is None
         assert self._rows() == 0
 
-    def test_check_group_keyed_on_head_sha(self) -> None:
+    def test_check_group_keyed_on_head_sha_and_suite(self) -> None:
+        # The check_run path reads its suite id off ``check_run.check_suite.id``.
         with self.feature(DOC_FLAG):
             self._check_run(check_name="t", conclusion="failure", webhook_id="cr1")
-        assert "headsha1|github-actions" in self._doc()["checks"]
+        assert "headsha1|github-actions|101" in self._doc()["checks"]
 
     def test_check_groups_split_by_head_sha(self) -> None:
         with self.feature(DOC_FLAG):
             self._check_suite(head_sha="headsha1", webhook_id="cs1")
             self._check_suite(head_sha="headsha2", webhook_id="cs2")
         assert set(self._doc()["checks"].keys()) == {
-            "headsha1|github-actions",
-            "headsha2|github-actions",
+            "headsha1|github-actions|101",
+            "headsha2|github-actions|101",
         }
+
+    def test_check_groups_split_by_suite_within_one_app(self) -> None:
+        # One app, one head, two suites (two workflow runs): the later green suite
+        # must not overwrite the earlier failed one.
+        with self.feature(DOC_FLAG):
+            self._check_suite(
+                suite_id=1,
+                conclusion="failure",
+                updated_at="2026-07-10T12:00:00Z",
+                webhook_id="cs1",
+            )
+            self._check_suite(
+                suite_id=2,
+                conclusion="success",
+                updated_at="2026-07-10T12:05:00Z",
+                webhook_id="cs2",
+            )
+        checks = self._doc()["checks"]
+        assert checks["headsha1|github-actions|1"]["suite_conclusion"] == "failure"
+        assert checks["headsha1|github-actions|2"]["suite_conclusion"] == "success"
+
+    def test_check_event_without_suite_id_uses_legacy_key(self) -> None:
+        with self.feature(DOC_FLAG):
+            self._check_suite(suite_id=None, webhook_id="cs1")
+        assert "headsha1|github-actions" in self._doc()["checks"]
 
     def test_auto_merge_enabled_captures_sender_on_document(self) -> None:
         with self.feature(DOC_FLAG):


### PR DESCRIPTION
## Problem

One GitHub App emits one check suite per **workflow run**, so a single head can carry many suites from the same app (a recent getsentry/sentry master commit: 10 github-actions suites, 26 across all apps). The activity-document check rollup grouped by `(head_sha, app_slug)`, folding them into one group whose latest-wins reduction let the last workflow to complete overwrite the others — **a failed workflow was erased by a later green one**. `check_runs_count` (max across workflows) and the `runs` map (same-named jobs colliding) were corrupted the same way, so the Seer judge timeline and the `ci_failing_at_close` / `ci_failed_at_open` labels under-reported failures.

## Approach

Group by `(head_sha, app_slug, check_suite_id)`:

- The suite id (`check_suite.id` / `check_run.check_suite.id`) is threaded into the document path the same way `head_sha` already is; legacy row payloads stay frozen.
- Latest-wins now only arbitrates reruns of the same suite; concurrent workflows keep their own conclusions, run counts, and run maps.
- The judge gets one synthesized completion per suite (GitHub's own cardinality) with `check_suite_id` as an additive payload key (Seer ignores unknown keys). The diagnosis labels need no reader changes.

## Compatibility — no migration

Payloads without a suite id fall back to the old suite-less key, so existing documents keep folding and readers (which never parse keys) work unchanged. The rolling deploy itself produces mixed documents: id-less events keep folding into the merged group while id-carrying events build per-suite groups beside it. Suite-scoped events never fold into a merged group, so it freezes and persists until the post-emit sweep; a failure frozen there keeps being reported next to suite-scoped greens — over-reporting a recorded failure is the accepted trade-off over erasing one. Pinned by tests at the fold, timeline, and reader level.

## Bounds & retention

The flat `MAX_CHECK_GROUPS = 100` becomes a two-level cap: `MAX_GROUPS_PER_HEAD = 40` (eviction within the head, so suite spam degrades only that head; observed real max ~26 suites/head) and `MAX_CHECK_GROUPS = 300` document-wide (stalest heads shed first).

The judge forward is trimmed per head too (`MAX_FORWARDED_GROUPS_PER_HEAD = 20`) instead of the old flat newest-100, which dropped whole heads oldest-first — erasing the fail → push → green transitions the judge reads iteration from. Both the forward trim and the within-head eviction share one priority key (`_forward_priority`: failing or ever-failed groups kept over fresher greens), since plain recency has the same inversion this PR fixes — an early failure that went quiet was the first LRU victim, turning a red head green. Per-head trims log `head_sha` and the dropped count; the flat forward cap remains only as a backstop (`= MAX_CHECK_GROUPS`) that the store's own caps already satisfy.

Measured on prod (Redash, region DB): per-document group count **p99 = 21, max = 100** — the max sits exactly at the old cap, i.e. the tail is cap-clipped, matching Datadog's `check_groups_capped` firing ~136k times/30d. The per-suite multiplier is suites-per-app, ~2.5–3× on the busiest observed head (26 suites vs ~10 apps), so the p99 document projects to ~60 groups — far under 300, which stays a pathology backstop — while the clipped tail's projected demand (~250–300) keeps roughly the retention horizon it had at 100 per-app groups.