### PR TITLE
feat(reports): Add PR links to past resolved issues

### DIFF
--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -15,7 +15,7 @@ from snuba_sdk.orderby import Direction, LimitBy, OrderBy
 from snuba_sdk.query import Join, Limit, Query
 from snuba_sdk.relationships import Relationship
 
-from sentry.constants import DataCategory
+from sentry.constants import DataCategory, ObjectStatus
 from sentry.issues.grouptype import (
     PERFORMANCE_ISSUE_CATEGORIES,
     GroupCategory,
@@ -23,15 +23,20 @@ from sentry.issues.grouptype import (
 )
 from sentry.models.group import DEFAULT_TYPE_ID, Group, GroupStatus
 from sentry.models.grouphistory import GroupHistory
+from sentry.models.grouplink import GroupLink
 from sentry.models.groupresolution import GroupResolution
 from sentry.models.organization import Organization
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.project import Project
+from sentry.models.pullrequest import PullRequest
+from sentry.models.releasecommit import ReleaseCommit
+from sentry.models.repository import Repository
 from sentry.models.team import TeamStatus
 from sentry.search.eap.occurrences.query_utils import keyed_counts_subset_match
 from sentry.search.eap.occurrences.rollout_utils import EAPOccurrencesComparator
 from sentry.search.eap.types import SearchResolverConfig
 from sentry.search.events.types import SnubaParams
+from sentry.seer.models import SeerRunPullRequest
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.occurrences_rpc import OccurrenceCategory, Occurrences
 from sentry.snuba.spans_rpc import Spans
@@ -98,8 +103,8 @@ class ProjectContext:
         self.key_error_issues: list[tuple[Group, int]] = []
         # Array of (Group, count)
         self.key_performance_issues = []
-        # Array of (Group, event_count, resolution_label)
-        self.past_resolved_issues: list[tuple[Group, int, str]] = []
+        # Array of (Group, event_count, resolution_label, resolution_url)
+        self.past_resolved_issues: list[tuple[Group, int, str, str | None]] = []
 
         self.key_replay_events = []
 
@@ -509,7 +514,7 @@ PAST_ISSUES_LINK_BOOST = 2
 
 def project_past_resolved_issues(
     ctx: OrganizationReportContext, project: Project, referrer: str
-) -> list[tuple[Group, int, str]]:
+) -> list[tuple[Group, int, str, str | None]]:
     if not project.first_event:
         return []
 
@@ -575,12 +580,12 @@ def project_past_resolved_issues(
             event_counts.update(performance_counts)
 
         # resolution_label defaults to "Resolved"; enriched by fetch_past_resolved_issue_links at org level
-        scored = []
+        scored: list[tuple[Group, int, str, str | None]] = []
         for group_id, count in event_counts.items():
             group = group_id_to_group.get(group_id)
             if group is None:
                 continue
-            scored.append((group, count, "Resolved"))
+            scored.append((group, count, "Resolved", None))
 
         scored.sort(key=lambda x: x[1], reverse=True)
         return scored
@@ -661,15 +666,41 @@ def _past_resolved_performance_counts(
     return {row["group_id"]: row["count()"] for row in rows}
 
 
+def _pick_resolution(
+    group_id: int,
+    resolution_labels: dict[int, str],
+    pr_resolution_info: dict[int, tuple[bool, str | None]],
+) -> tuple[str, str | None]:
+    label = resolution_labels.get(group_id, "Resolved")
+    pr_info = pr_resolution_info.get(group_id)
+    if pr_info is None:
+        return (label, None)
+
+    is_seer_fix, url = pr_info
+    return ("Resolved by Seer Fix" if is_seer_fix else label, url)
+
+
+def _pull_request_url(pull_request: PullRequest, repository: Repository) -> str | None:
+    if not repository.url:
+        return None
+    provider = repository.get_provider()
+    if provider is None:
+        return None
+    return provider.pull_request_url(repository, pull_request)
+
+
 def fetch_past_resolved_issue_links(ctx: OrganizationReportContext) -> None:
     all_group_ids: list[int] = []
     for project_ctx in ctx.projects_context_map.values():
-        all_group_ids.extend(group.id for group, _count, _label in project_ctx.past_resolved_issues)
+        all_group_ids.extend(
+            group.id for group, _count, _label, _url in project_ctx.past_resolved_issues
+        )
 
     if not all_group_ids:
         return
 
     resolution_labels: dict[int, str] = {}
+    resolution_release_by_group: dict[int, int] = {}
 
     # GroupResolution.group is unique, so there is at most one row per group
     for gr in GroupResolution.objects.filter(group_id__in=all_group_ids):
@@ -681,10 +712,86 @@ def fetch_past_resolved_issue_links(ctx: OrganizationReportContext) -> None:
         else:
             resolution_labels[gr.group_id] = "Resolved in release"
 
+        if gr.status == GroupResolution.Status.resolved:
+            resolution_release_by_group[gr.group_id] = gr.release_id
+
+    pr_resolution_info: dict[int, tuple[bool, str | None]] = {}
+    release_ids = set(resolution_release_by_group.values())
+    if release_ids:
+        release_ids_by_repo_and_sha: dict[tuple[int, str], set[int]] = {}
+        for release_id, repository_id, commit_sha in ReleaseCommit.objects.filter(
+            release_id__in=release_ids,
+            organization_id=ctx.organization.id,
+        ).values_list("release_id", "commit__repository_id", "commit__key"):
+            release_ids_by_repo_and_sha.setdefault((repository_id, commit_sha), set()).add(
+                release_id
+            )
+
+        repository_ids = {key[0] for key in release_ids_by_repo_and_sha}
+        commit_shas = {key[1] for key in release_ids_by_repo_and_sha}
+        pull_requests: dict[int, PullRequest] = {}
+        release_ids_by_pr: dict[int, set[int]] = {}
+        for pull_request in PullRequest.objects.filter(
+            organization_id=ctx.organization.id,
+            repository_id__in=repository_ids,
+            merge_commit_sha__in=commit_shas,
+        ):
+            if pull_request.merge_commit_sha is None:
+                continue
+            matching_release_ids = release_ids_by_repo_and_sha.get(
+                (pull_request.repository_id, pull_request.merge_commit_sha)
+            )
+            if matching_release_ids is None:
+                continue
+            pull_requests[pull_request.id] = pull_request
+            release_ids_by_pr[pull_request.id] = matching_release_ids
+
+        repositories = Repository.objects.filter(
+            id__in={pull_request.repository_id for pull_request in pull_requests.values()},
+            organization_id=ctx.organization.id,
+            status=ObjectStatus.ACTIVE,
+        ).in_bulk()
+        pull_requests = {
+            pull_request_id: pull_request
+            for pull_request_id, pull_request in pull_requests.items()
+            if pull_request.repository_id in repositories
+        }
+
+        selected_pr_by_group: dict[int, int] = {}
+        for group_id, pull_request_id in (
+            GroupLink.objects.filter(
+                group_id__in=resolution_release_by_group,
+                project_id__in=ctx.projects_context_map,
+                linked_id__in=pull_requests,
+                linked_type=GroupLink.LinkedType.pull_request,
+                relationship=GroupLink.Relationship.resolves,
+            )
+            .order_by("-datetime", "-id")
+            .values_list("group_id", "linked_id")
+        ):
+            if resolution_release_by_group[group_id] not in release_ids_by_pr[pull_request_id]:
+                continue
+            selected_pr_by_group.setdefault(group_id, pull_request_id)
+
+        selected_pr_ids = set(selected_pr_by_group.values())
+        seer_pr_ids = set(
+            SeerRunPullRequest.objects.filter(pull_request_id__in=selected_pr_ids).values_list(
+                "pull_request_id", flat=True
+            )
+        )
+
+        for group_id, pull_request_id in selected_pr_by_group.items():
+            pull_request = pull_requests[pull_request_id]
+            repository = repositories[pull_request.repository_id]
+            pr_resolution_info[group_id] = (
+                pull_request_id in seer_pr_ids,
+                _pull_request_url(pull_request, repository),
+            )
+
     for project_ctx in ctx.projects_context_map.values():
         project_ctx.past_resolved_issues = [
-            (group, count, resolution_labels.get(group.id, "Resolved"))
-            for group, count, _label in project_ctx.past_resolved_issues
+            (group, count, *_pick_resolution(group.id, resolution_labels, pr_resolution_info))
+            for group, count, _label, _url in project_ctx.past_resolved_issues
         ]
 
     # Re-sort with link boost applied, then truncate to top 3

--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -3,7 +3,7 @@ from collections.abc import Sequence
 from datetime import datetime, timedelta
 from typing import Any
 
-from django.db.models import Count
+from django.db.models import Count, Prefetch, prefetch_related_objects
 from django.db.models.functions import TruncDay
 from snuba_sdk import Request
 from snuba_sdk.column import Column
@@ -28,10 +28,11 @@ from sentry.models.groupresolution import GroupResolution
 from sentry.models.organization import Organization
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.project import Project
-from sentry.models.pullrequest import PullRequest
+from sentry.models.pullrequest import PullRequest, PullRequestAttribution
 from sentry.models.releasecommit import ReleaseCommit
 from sentry.models.repository import Repository
 from sentry.models.team import TeamStatus
+from sentry.pr_metrics.attribution import is_seer_attribution
 from sentry.search.eap.occurrences.query_utils import keyed_counts_subset_match
 from sentry.search.eap.occurrences.rollout_utils import EAPOccurrencesComparator
 from sentry.search.eap.types import SearchResolverConfig
@@ -774,7 +775,25 @@ def fetch_past_resolved_issue_links(ctx: OrganizationReportContext) -> None:
             selected_pr_by_group.setdefault(group_id, pull_request_id)
 
         selected_pr_ids = set(selected_pr_by_group.values())
+        selected_pull_requests = [
+            pull_requests[pull_request_id] for pull_request_id in selected_pr_ids
+        ]
+        prefetch_related_objects(
+            selected_pull_requests,
+            Prefetch(
+                "pullrequestattribution_set",
+                queryset=PullRequestAttribution.objects.filter(is_valid=True),
+            ),
+        )
         seer_pr_ids = set(
+            pull_request.id
+            for pull_request in selected_pull_requests
+            if any(
+                is_seer_attribution(attribution)
+                for attribution in pull_request.pullrequestattribution_set.all()
+            )
+        )
+        seer_pr_ids.update(
             SeerRunPullRequest.objects.filter(pull_request_id__in=selected_pr_ids).values_list(
                 "pull_request_id", flat=True
             )

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -883,7 +883,12 @@ def render_template_context(
     def past_issues():
         def all_past_issues():
             for project_ctx in user_projects:
-                for group, count, resolution_label in project_ctx.past_resolved_issues:
+                for (
+                    group,
+                    count,
+                    resolution_label,
+                    resolution_url,
+                ) in project_ctx.past_resolved_issues:
                     display = get_group_display(group)
                     yield {
                         "count": count,
@@ -891,6 +896,7 @@ def render_template_context(
                         "title": display["title"],
                         "message": display["message"],
                         "resolution_label": resolution_label,
+                        "resolution_url": resolution_url,
                         "_relevance": count
                         * (PAST_ISSUES_LINK_BOOST if resolution_label != "Resolved" else 1),
                     }

--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -469,7 +469,11 @@
         <div title="{{a.message}}" class="issue-message">{{a.message}}</div>
         <div style="font-size: 12px; color: #80708F;">{{a.group.project.name}}</div>
       </div>
+      {% if a.resolution_url %}
+      <a href="{{ a.resolution_url }}" style="background-color: #E3F7E3; color: #008900; border-radius: 8px; font-size: 12px; align-self: center; padding: 0 10px; margin-left: auto; text-align: center; line-height: 22px; white-space: nowrap; height: 22px; text-decoration: none; display: inline-block;">{{ a.resolution_label }}</a>
+      {% else %}
       <span style="background-color: #E3F7E3; color: #008900; border-radius: 8px; font-size: 12px; align-self: center; padding: 0 10px; margin-left: auto; text-align: center; line-height: 22px; white-space: nowrap; height: 22px;">{{ a.resolution_label }}</span>
+      {% endif %}
     </div>
     {% endfor %}
   </div>

--- a/src/sentry/web/frontend/debug/debug_weekly_report.py
+++ b/src/sentry/web/frontend/debug/debug_weekly_report.py
@@ -26,7 +26,6 @@ from sentry.tasks.summaries.weekly_reports import (
     CHART_PALETTE,
     _pct_change,
     _top_spans_chart_url,
-    get_group_display,
     render_template_context,
 )
 from sentry.types.group import GroupSubStatus
@@ -207,11 +206,18 @@ class DebugWeeklyReportView(MailPreviewView):
                         substatus=GroupSubStatus.NEW,
                     ),
                     random.randint(100, 5000),
-                    random.choice(
+                    *random.choice(
                         [
-                            "Resolved",
-                            "Resolved in release",
-                            "Resolved in next release",
+                            ("Resolved", None),
+                            (
+                                "Resolved in release",
+                                "https://github.com/getsentry/sentry/pull/12345",
+                            ),
+                            ("Resolved in next release", None),
+                            (
+                                "Resolved by Seer Fix",
+                                "https://github.com/getsentry/sentry/pull/12345",
+                            ),
                         ]
                     ),
                 )
@@ -280,21 +286,6 @@ class DebugWeeklyReportView(MailPreviewView):
             chart_url = _top_spans_chart_url(context["top_spans_table"], ctx, None)
             if chart_url:
                 context["spans_chart_url"] = chart_url
-            past_issues: list[dict[str, Any]] = []
-            for project_ctx in ctx.projects_context_map.values():
-                for group, count, resolution_label in project_ctx.past_resolved_issues:
-                    display = get_group_display(group)
-                    past_issues.append(
-                        {
-                            "count": count,
-                            "group": group,
-                            "title": display["title"],
-                            "message": display["message"],
-                            "resolution_label": resolution_label,
-                        }
-                    )
-            past_issues.sort(key=lambda x: x["count"], reverse=True)
-            context["past_issues"] = past_issues[:3]
         return context
 
     @property

--- a/tests/sentry/tasks/test_weekly_report_utils.py
+++ b/tests/sentry/tasks/test_weekly_report_utils.py
@@ -7,11 +7,14 @@ from django.utils import timezone
 
 from sentry.constants import DataCategory
 from sentry.issues.grouptype import GroupCategory, PerformanceNPlusOneGroupType
-from sentry.models.group import GroupStatus
+from sentry.models.group import Group, GroupStatus
 from sentry.models.grouplink import GroupLink
 from sentry.models.groupresolution import GroupResolution
 from sentry.models.organization import Organization
 from sentry.models.project import Project
+from sentry.models.pullrequest import PullRequest
+from sentry.models.release import Release
+from sentry.models.repository import Repository
 from sentry.snuba.referrer import Referrer
 from sentry.tasks.summaries.organization_report_context_factory import (
     OrganizationReportContextFactory,
@@ -511,6 +514,7 @@ class WeeklyReportUtilsTest(
         assert results[0][0].id == group1.id
         assert results[0][1] >= 1
         assert results[0][2] == "Resolved"
+        assert results[0][3] is None
 
     @mock.patch("sentry.tasks.summaries.utils._past_resolved_performance_counts")
     @freeze_time(before_now(days=2).replace(hour=0, minute=0, second=0, microsecond=0))
@@ -537,7 +541,7 @@ class WeeklyReportUtilsTest(
             ctx, self.project, Referrer.REPORTS_PAST_RESOLVED_ISSUES.value
         )
 
-        assert results == [(group, 1, "Resolved")]
+        assert results == [(group, 1, "Resolved", None)]
         mock_perf_counts.assert_called_once()
         assert mock_perf_counts.call_args.args[2] == [group.id]
 
@@ -598,330 +602,237 @@ class WeeklyReportUtilsTest(
         )
         assert len(results) == 0
 
-    @freeze_time(before_now(days=2).replace(hour=0, minute=0, second=0, microsecond=0))
-    def test_fetch_past_resolved_issue_links(self) -> None:
-        self.project.first_event = self.now - timedelta(days=3)
-        self.project.save()
-        min_ago = (self.now - timedelta(minutes=1)).isoformat()
 
-        event1 = self.store_event(
-            data={
-                "event_id": "a" * 32,
-                "message": "linked error",
-                "timestamp": min_ago,
-                "fingerprint": ["linked-1"],
-            },
-            project_id=self.project.id,
-            default_event_type=EventType.DEFAULT,
+class PastResolvedIssuesTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.now = timezone.now()
+
+    def _create_resolved_group(self) -> Group:
+        self.group.status = GroupStatus.RESOLVED
+        self.group.substatus = None
+        self.group.resolved_at = self.now - timedelta(minutes=1)
+        return self.group
+
+    def _enrich_resolution(self, group: Group) -> tuple[Group, int, str, str | None]:
+        ctx = OrganizationReportContext(self.now.timestamp(), ONE_DAY * 7, self.organization)
+        ctx.projects_context_map[self.project.id].past_resolved_issues = [
+            (group, 1, "Resolved", None)
+        ]
+
+        fetch_past_resolved_issue_links(ctx)
+
+        [resolution] = ctx.projects_context_map[self.project.id].past_resolved_issues
+        return resolution
+
+    def _create_release_resolution(
+        self,
+        group: Group,
+        *,
+        version: str = "1.2.3",
+        type: int | None = GroupResolution.Type.in_release,
+        status: int = GroupResolution.Status.resolved,
+        current_release_version: str | None = None,
+    ) -> Release:
+        release = self.create_release(project=self.project, version=version)
+        self.create_group_resolution(
+            group=group,
+            release=release,
+            type=type,
+            status=status,
+            current_release_version=current_release_version,
         )
-        event2 = self.store_event(
-            data={
-                "event_id": "b" * 32,
-                "message": "unlinked error",
-                "timestamp": min_ago,
-                "fingerprint": ["unlinked-1"],
-            },
-            project_id=self.project.id,
-            default_event_type=EventType.DEFAULT,
+        return release
+
+    def _create_released_resolving_pr(
+        self,
+        group: Group,
+        release: Release,
+        repository: Repository,
+        *,
+        key: str,
+        order: int = 1,
+        linked_at: datetime | None = None,
+    ) -> PullRequest:
+        commit = self.create_commit(repository)
+        self.create_release_commit(release, commit, order=order)
+        pull_request = self.create_pull_request(
+            organization_id=self.organization.id,
+            repository_id=repository.id,
+            key=key,
         )
-
-        group1 = event1.group
-        group1.status = GroupStatus.RESOLVED
-        group1.substatus = None
-        group1.resolved_at = self.now - timedelta(minutes=1)
-        group1.save()
-
-        group2 = event2.group
-        group2.status = GroupStatus.RESOLVED
-        group2.substatus = None
-        group2.resolved_at = self.now - timedelta(minutes=1)
-        group2.save()
-
+        pull_request.merge_commit_sha = commit.key
+        pull_request.save(update_fields=["merge_commit_sha"])
         self.create_group_link(
-            group=group1,
+            group=group,
+            linked_id=pull_request.id,
+            linked_type=GroupLink.LinkedType.pull_request,
+            relationship=GroupLink.Relationship.resolves,
+            **({"datetime": linked_at} if linked_at is not None else {}),
+        )
+        return pull_request
+
+    def test_fetch_resolution_ignores_commit_links(self) -> None:
+        group = self._create_resolved_group()
+        self.create_group_link(
+            group=group,
             linked_id=1,
             linked_type=GroupLink.LinkedType.commit,
             relationship=GroupLink.Relationship.resolves,
         )
-        self.create_group_link(
-            group=group2,
-            linked_id=2,
-            linked_type=GroupLink.LinkedType.commit,
-            relationship=GroupLink.Relationship.references,
+
+        assert self._enrich_resolution(group)[2:] == ("Resolved", None)
+
+    def test_fetch_resolution_ignores_unreleased_pr(self) -> None:
+        group = self._create_resolved_group()
+        repository = self.create_repo(
+            self.project,
+            provider="integrations:github",
+            url="https://github.com/getsentry/sentry",
         )
-
-        timestamp = self.now.timestamp()
-        ctx = OrganizationReportContext(timestamp, ONE_DAY * 7, self.organization)
-
-        results = project_past_resolved_issues(
-            ctx, self.project, Referrer.REPORTS_PAST_RESOLVED_ISSUES.value
+        pull_request = self.create_pull_request(
+            organization_id=self.organization.id,
+            repository_id=repository.id,
+            key="1",
         )
-        ctx.projects_context_map[self.project.id].past_resolved_issues = results
-
-        fetch_past_resolved_issue_links(ctx)
-
-        updated = ctx.projects_context_map[self.project.id].past_resolved_issues
-        label_by_group = {group.id: label for group, _count, label in updated}
-        assert label_by_group[group1.id] == "Resolved"
-        assert label_by_group[group2.id] == "Resolved"
-
-    @freeze_time(before_now(days=2).replace(hour=0, minute=0, second=0, microsecond=0))
-    def test_fetch_resolution_label_pr_link_ignored(self) -> None:
-        self.project.first_event = self.now - timedelta(days=3)
-        self.project.save()
-        min_ago = (self.now - timedelta(minutes=1)).isoformat()
-
-        event = self.store_event(
-            data={
-                "event_id": "a" * 32,
-                "message": "pr resolved error",
-                "timestamp": min_ago,
-                "fingerprint": ["pr-resolved-1"],
-            },
-            project_id=self.project.id,
-            default_event_type=EventType.DEFAULT,
-        )
-        group = event.group
-        group.status = GroupStatus.RESOLVED
-        group.substatus = None
-        group.resolved_at = self.now - timedelta(minutes=1)
-        group.save()
-
         self.create_group_link(
             group=group,
-            linked_id=1,
+            linked_id=pull_request.id,
             linked_type=GroupLink.LinkedType.pull_request,
             relationship=GroupLink.Relationship.resolves,
         )
 
-        timestamp = self.now.timestamp()
-        ctx = OrganizationReportContext(timestamp, ONE_DAY * 7, self.organization)
-        results = project_past_resolved_issues(
-            ctx, self.project, Referrer.REPORTS_PAST_RESOLVED_ISSUES.value
-        )
-        ctx.projects_context_map[self.project.id].past_resolved_issues = results
-        fetch_past_resolved_issue_links(ctx)
+        assert self._enrich_resolution(group)[2:] == ("Resolved", None)
 
-        updated = ctx.projects_context_map[self.project.id].past_resolved_issues
-        assert len(updated) == 1
-        assert updated[0][2] == "Resolved"
-
-    @freeze_time(before_now(days=2).replace(hour=0, minute=0, second=0, microsecond=0))
     def test_fetch_resolution_label_release(self) -> None:
-        self.project.first_event = self.now - timedelta(days=3)
-        self.project.save()
-        min_ago = (self.now - timedelta(minutes=1)).isoformat()
+        group = self._create_resolved_group()
+        self._create_release_resolution(group)
 
-        event = self.store_event(
-            data={
-                "event_id": "a" * 32,
-                "message": "release resolved error",
-                "timestamp": min_ago,
-                "fingerprint": ["release-resolved-1"],
-            },
-            project_id=self.project.id,
-            default_event_type=EventType.DEFAULT,
-        )
-        group = event.group
-        group.status = GroupStatus.RESOLVED
-        group.substatus = None
-        group.resolved_at = self.now - timedelta(minutes=1)
-        group.save()
+        assert self._enrich_resolution(group)[2:] == ("Resolved in release", None)
 
-        release = self.create_release(project=self.project, version="1.2.3")
-        self.create_group_resolution(
-            group=group,
-            release=release,
-            type=GroupResolution.Type.in_release,
-            status=GroupResolution.Status.resolved,
-        )
-
-        timestamp = self.now.timestamp()
-        ctx = OrganizationReportContext(timestamp, ONE_DAY * 7, self.organization)
-        results = project_past_resolved_issues(
-            ctx, self.project, Referrer.REPORTS_PAST_RESOLVED_ISSUES.value
-        )
-        ctx.projects_context_map[self.project.id].past_resolved_issues = results
-        fetch_past_resolved_issue_links(ctx)
-
-        updated = ctx.projects_context_map[self.project.id].past_resolved_issues
-        assert len(updated) == 1
-        assert updated[0][2] == "Resolved in release"
-
-    @freeze_time(before_now(days=2).replace(hour=0, minute=0, second=0, microsecond=0))
     def test_fetch_resolution_label_next_release(self) -> None:
-        self.project.first_event = self.now - timedelta(days=3)
-        self.project.save()
-        min_ago = (self.now - timedelta(minutes=1)).isoformat()
-
-        event = self.store_event(
-            data={
-                "event_id": "a" * 32,
-                "message": "next release resolved error",
-                "timestamp": min_ago,
-                "fingerprint": ["next-release-resolved-1"],
-            },
-            project_id=self.project.id,
-            default_event_type=EventType.DEFAULT,
-        )
-        group = event.group
-        group.status = GroupStatus.RESOLVED
-        group.substatus = None
-        group.resolved_at = self.now - timedelta(minutes=1)
-        group.save()
-
-        release = self.create_release(project=self.project, version="2.0.0")
-        self.create_group_resolution(
-            group=group,
-            release=release,
+        group = self._create_resolved_group()
+        release = self._create_release_resolution(
+            group,
+            version="2.0.0",
             type=GroupResolution.Type.in_next_release,
             status=GroupResolution.Status.pending,
         )
-
-        timestamp = self.now.timestamp()
-        ctx = OrganizationReportContext(timestamp, ONE_DAY * 7, self.organization)
-        results = project_past_resolved_issues(
-            ctx, self.project, Referrer.REPORTS_PAST_RESOLVED_ISSUES.value
+        repository = self.create_repo(
+            self.project,
+            provider="integrations:github",
+            url="https://github.com/getsentry/sentry",
         )
-        ctx.projects_context_map[self.project.id].past_resolved_issues = results
-        fetch_past_resolved_issue_links(ctx)
+        self._create_released_resolving_pr(group, release, repository, key="1")
 
-        updated = ctx.projects_context_map[self.project.id].past_resolved_issues
-        assert len(updated) == 1
-        assert updated[0][2] == "Resolved in next release"
+        assert self._enrich_resolution(group)[2:] == ("Resolved in next release", None)
 
-    @freeze_time(before_now(days=2).replace(hour=0, minute=0, second=0, microsecond=0))
-    def test_fetch_resolution_label_release_with_pr_link(self) -> None:
-        self.project.first_event = self.now - timedelta(days=3)
-        self.project.save()
-        min_ago = (self.now - timedelta(minutes=1)).isoformat()
-
-        event = self.store_event(
-            data={
-                "event_id": "a" * 32,
-                "message": "pr and release resolved error",
-                "timestamp": min_ago,
-                "fingerprint": ["pr-release-resolved-1"],
-            },
-            project_id=self.project.id,
-            default_event_type=EventType.DEFAULT,
-        )
-        group = event.group
-        group.status = GroupStatus.RESOLVED
-        group.substatus = None
-        group.resolved_at = self.now - timedelta(minutes=1)
-        group.save()
-
-        self.create_group_link(
-            group=group,
-            linked_id=1,
-            linked_type=GroupLink.LinkedType.pull_request,
-            relationship=GroupLink.Relationship.resolves,
-        )
-
-        release = self.create_release(project=self.project, version="1.2.3")
-        self.create_group_resolution(
-            group=group,
-            release=release,
-            type=GroupResolution.Type.in_release,
-            status=GroupResolution.Status.resolved,
-        )
-
-        timestamp = self.now.timestamp()
-        ctx = OrganizationReportContext(timestamp, ONE_DAY * 7, self.organization)
-        results = project_past_resolved_issues(
-            ctx, self.project, Referrer.REPORTS_PAST_RESOLVED_ISSUES.value
-        )
-        ctx.projects_context_map[self.project.id].past_resolved_issues = results
-        fetch_past_resolved_issue_links(ctx)
-
-        updated = ctx.projects_context_map[self.project.id].past_resolved_issues
-        assert len(updated) == 1
-        assert updated[0][2] == "Resolved in release"
-
-    @freeze_time(before_now(days=2).replace(hour=0, minute=0, second=0, microsecond=0))
     def test_fetch_resolution_label_null_type(self) -> None:
-        self.project.first_event = self.now - timedelta(days=3)
-        self.project.save()
-        min_ago = (self.now - timedelta(minutes=1)).isoformat()
-
-        event = self.store_event(
-            data={
-                "event_id": "a" * 32,
-                "message": "null type resolved error",
-                "timestamp": min_ago,
-                "fingerprint": ["null-type-resolved-1"],
-            },
-            project_id=self.project.id,
-            default_event_type=EventType.DEFAULT,
-        )
-        group = event.group
-        group.status = GroupStatus.RESOLVED
-        group.substatus = None
-        group.resolved_at = self.now - timedelta(minutes=1)
-        group.save()
-
-        release = self.create_release(project=self.project, version="1.0.0")
-        self.create_group_resolution(
-            group=group,
-            release=release,
+        group = self._create_resolved_group()
+        self._create_release_resolution(
+            group,
             type=None,
             status=GroupResolution.Status.pending,
         )
 
-        timestamp = self.now.timestamp()
-        ctx = OrganizationReportContext(timestamp, ONE_DAY * 7, self.organization)
-        results = project_past_resolved_issues(
-            ctx, self.project, Referrer.REPORTS_PAST_RESOLVED_ISSUES.value
-        )
-        ctx.projects_context_map[self.project.id].past_resolved_issues = results
-        fetch_past_resolved_issue_links(ctx)
+        assert self._enrich_resolution(group)[2:] == ("Resolved in next release", None)
 
-        updated = ctx.projects_context_map[self.project.id].past_resolved_issues
-        assert len(updated) == 1
-        assert updated[0][2] == "Resolved in next release"
-
-    @freeze_time(before_now(days=2).replace(hour=0, minute=0, second=0, microsecond=0))
     def test_fetch_resolution_label_expired_next_release(self) -> None:
-        """After clear_expired_resolutions rewrites type to in_release,
-        current_release_version still identifies next-release resolutions."""
-        self.project.first_event = self.now - timedelta(days=3)
-        self.project.save()
-        min_ago = (self.now - timedelta(minutes=1)).isoformat()
-
-        event = self.store_event(
-            data={
-                "event_id": "a" * 32,
-                "message": "expired next release error",
-                "timestamp": min_ago,
-                "fingerprint": ["expired-next-release-1"],
-            },
-            project_id=self.project.id,
-            default_event_type=EventType.DEFAULT,
-        )
-        group = event.group
-        group.status = GroupStatus.RESOLVED
-        group.substatus = None
-        group.resolved_at = self.now - timedelta(minutes=1)
-        group.save()
-
-        release = self.create_release(project=self.project, version="2.0.0")
-        self.create_group_resolution(
-            group=group,
-            release=release,
-            type=GroupResolution.Type.in_release,
-            status=GroupResolution.Status.resolved,
+        """Keep the next-release label after clear_expired_resolutions rewrites the type."""
+        group = self._create_resolved_group()
+        self._create_release_resolution(
+            group,
+            version="2.0.0",
             current_release_version="1.9.0",
         )
 
-        timestamp = self.now.timestamp()
-        ctx = OrganizationReportContext(timestamp, ONE_DAY * 7, self.organization)
-        results = project_past_resolved_issues(
-            ctx, self.project, Referrer.REPORTS_PAST_RESOLVED_ISSUES.value
-        )
-        ctx.projects_context_map[self.project.id].past_resolved_issues = results
-        fetch_past_resolved_issue_links(ctx)
+        assert self._enrich_resolution(group)[2:] == ("Resolved in next release", None)
 
-        updated = ctx.projects_context_map[self.project.id].past_resolved_issues
-        assert len(updated) == 1
-        assert updated[0][2] == "Resolved in next release"
+    def test_fetch_resolution_links_released_pr(self) -> None:
+        group = self._create_resolved_group()
+        release = self._create_release_resolution(group)
+        repository = self.create_repo(
+            self.project,
+            provider="integrations:github",
+            url="https://github.com/getsentry/sentry",
+        )
+        self._create_released_resolving_pr(group, release, repository, key="5131")
+
+        assert self._enrich_resolution(group)[2:] == (
+            "Resolved in release",
+            "https://github.com/getsentry/sentry/pull/5131",
+        )
+
+    def test_fetch_resolution_ignores_pr_from_different_release(self) -> None:
+        group = self._create_resolved_group()
+        self._create_release_resolution(group, version="1.0.0")
+        unrelated_release = self.create_release(project=self.project, version="2.0.0")
+        repository = self.create_repo(
+            self.project,
+            provider="integrations:github",
+            url="https://github.com/getsentry/sentry",
+        )
+        self._create_released_resolving_pr(group, unrelated_release, repository, key="5132")
+
+        assert self._enrich_resolution(group)[2:] == ("Resolved in release", None)
+
+    def test_fetch_resolution_uses_most_recent_released_pr(self) -> None:
+        group = self._create_resolved_group()
+        release = self._create_release_resolution(group)
+        repository = self.create_repo(
+            self.project,
+            provider="integrations:github",
+            url="https://github.com/getsentry/sentry",
+        )
+        self._create_released_resolving_pr(
+            group,
+            release,
+            repository,
+            key="1",
+            order=1,
+            linked_at=self.now - timedelta(hours=2),
+        )
+        self._create_released_resolving_pr(
+            group,
+            release,
+            repository,
+            key="2",
+            order=2,
+            linked_at=self.now - timedelta(hours=1),
+        )
+
+        assert self._enrich_resolution(group)[2:] == (
+            "Resolved in release",
+            "https://github.com/getsentry/sentry/pull/2",
+        )
+
+    def test_fetch_resolution_label_seer_fix(self) -> None:
+        group = self._create_resolved_group()
+        release = self._create_release_resolution(group)
+        repository = self.create_repo(
+            self.project,
+            provider="integrations:github",
+            url="https://github.com/getsentry/sentry",
+        )
+        pull_request = self._create_released_resolving_pr(group, release, repository, key="9999")
+        self.create_seer_run_pull_request(self.create_seer_run(), pull_request)
+
+        assert self._enrich_resolution(group)[2:] == (
+            "Resolved by Seer Fix",
+            "https://github.com/getsentry/sentry/pull/9999",
+        )
+
+    def test_fetch_resolution_gitlab_url(self) -> None:
+        group = self._create_resolved_group()
+        release = self._create_release_resolution(group)
+        repository = self.create_repo(
+            self.project,
+            provider="integrations:gitlab",
+            url="https://gitlab.com/getsentry/sentry",
+        )
+        self._create_released_resolving_pr(group, release, repository, key="42")
+
+        assert self._enrich_resolution(group)[2:] == (
+            "Resolved in release",
+            "https://gitlab.com/getsentry/sentry/merge_requests/42",
+        )

--- a/tests/sentry/tasks/test_weekly_report_utils.py
+++ b/tests/sentry/tasks/test_weekly_report_utils.py
@@ -12,7 +12,12 @@ from sentry.models.grouplink import GroupLink
 from sentry.models.groupresolution import GroupResolution
 from sentry.models.organization import Organization
 from sentry.models.project import Project
-from sentry.models.pullrequest import PullRequest
+from sentry.models.pullrequest import (
+    PullRequest,
+    PullRequestAttribution,
+    PullRequestAttributionSignalType,
+    PullRequestAttributionSource,
+)
 from sentry.models.release import Release
 from sentry.models.repository import Repository
 from sentry.snuba.referrer import Referrer
@@ -806,7 +811,7 @@ class PastResolvedIssuesTest(TestCase):
             "https://github.com/getsentry/sentry/pull/2",
         )
 
-    def test_fetch_resolution_label_seer_fix(self) -> None:
+    def test_fetch_resolution_label_seer_fix_from_run_link(self) -> None:
         group = self._create_resolved_group()
         release = self._create_release_resolution(group)
         repository = self.create_repo(
@@ -819,6 +824,48 @@ class PastResolvedIssuesTest(TestCase):
 
         assert self._enrich_resolution(group)[2:] == (
             "Resolved by Seer Fix",
+            "https://github.com/getsentry/sentry/pull/9999",
+        )
+
+    def test_fetch_resolution_label_seer_fix_from_attribution(self) -> None:
+        group = self._create_resolved_group()
+        release = self._create_release_resolution(group)
+        repository = self.create_repo(
+            self.project,
+            provider="integrations:github",
+            url="https://github.com/getsentry/sentry",
+        )
+        pull_request = self._create_released_resolving_pr(group, release, repository, key="9999")
+        PullRequestAttribution.objects.create(
+            pull_request=pull_request,
+            signal_type=PullRequestAttributionSignalType.SENTRY_APP,
+            source=PullRequestAttributionSource.SEER_DATA,
+            is_valid=True,
+        )
+
+        assert self._enrich_resolution(group)[2:] == (
+            "Resolved by Seer Fix",
+            "https://github.com/getsentry/sentry/pull/9999",
+        )
+
+    def test_fetch_resolution_ignores_invalid_seer_attribution(self) -> None:
+        group = self._create_resolved_group()
+        release = self._create_release_resolution(group)
+        repository = self.create_repo(
+            self.project,
+            provider="integrations:github",
+            url="https://github.com/getsentry/sentry",
+        )
+        pull_request = self._create_released_resolving_pr(group, release, repository, key="9999")
+        PullRequestAttribution.objects.create(
+            pull_request=pull_request,
+            signal_type=PullRequestAttributionSignalType.SENTRY_APP,
+            source=PullRequestAttributionSource.SEER_DATA,
+            is_valid=False,
+        )
+
+        assert self._enrich_resolution(group)[2:] == (
+            "Resolved in release",
             "https://github.com/getsentry/sentry/pull/9999",
         )
 

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -7,6 +7,7 @@ from django.core import mail
 from django.core.mail.message import EmailMultiAlternatives
 from django.db import router
 from django.db.models import F
+from django.template.loader import render_to_string
 from django.utils import timezone
 
 from sentry.analytics.events.weekly_report import WeeklyReportSent
@@ -2052,3 +2053,21 @@ class WeeklyReportsTest(
 
     def test_project_breakdown_equals_covers_project_limit(self):
         assert len(project_breakdown_colors) == TOP_SPANS_LIMIT
+
+    @with_feature("organizations:weekly-report-past-issues")
+    def test_resolution_url_is_rendered_as_label_link(self) -> None:
+        resolution_url = "https://github.com/getsentry/sentry/pull/5131"
+        ctx = OrganizationReportContext(timezone.now().timestamp(), ONE_DAY * 7, self.organization)
+        ctx.projects_context_map = {self.project.id: ProjectContext(self.project)}
+        ctx.project_ownership[self.user.id] = {self.project.id}
+        ctx.projects_context_map[self.project.id].past_resolved_issues = [
+            (self.group, 1, "Resolved by Seer Fix", resolution_url)
+        ]
+
+        context = render_template_context(ctx, self.user.id)
+
+        assert context is not None
+        assert context["past_issues"][0]["resolution_url"] == resolution_url
+        html = render_to_string("sentry/emails/reports/body.html", context)
+        assert f'href="{resolution_url}"' in html
+        assert "Resolved by Seer Fix" in html


### PR DESCRIPTION
Resolves [ID-1764](https://linear.app/getsentry/issue/ID-1764/add-pr-links-and-resolved-by-seer-fix-label-to-past-resolved-issues).

Past resolved issues in weekly report emails now link their resolution badge to the PR that resolved the issue when its merge commit belongs to the issue's resolved release. Seer-created PRs display a "Resolved by Seer Fix" label, while existing generic and release labels remain unchanged.

The lookup is organization-scoped and batched, and deterministically selects the most recently linked qualifying PR when multiple matches exist.