### PR TITLE
feat(replays): Add a script to expire Replay deletion jobs

### DIFF
--- a/src/sentry/replays/endpoints/project_replay_jobs_delete.py
+++ b/src/sentry/replays/endpoints/project_replay_jobs_delete.py
@@ -22,7 +22,7 @@ from sentry.apidocs.parameters import GlobalParams, ReplayParams
 from sentry.apidocs.response_types import ValidationErrorResponse, as_validation_errors
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.replays.endpoints.project_replay_endpoint import ProjectReplayEndpoint
-from sentry.replays.models import ReplayDeletionJobModel
+from sentry.replays.models import DeletionJobStatus, ReplayDeletionJobModel
 from sentry.replays.permissions import has_replay_permission
 from sentry.replays.tasks import run_bulk_replay_delete_job
 
@@ -177,7 +177,7 @@ class ProjectReplayDeletionJobsIndexEndpoint(ProjectEndpoint):
             organization_id=project.organization_id,
             project_id=project.id,
             query=data["query"] or "",
-            status="pending",
+            status=DeletionJobStatus.PENDING,
         )
 
         # We don't check Seer features because an org may have previously had them on, then turned them off.

--- a/src/sentry/replays/scripts/expire_replay_deletion_jobs.py
+++ b/src/sentry/replays/scripts/expire_replay_deletion_jobs.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+
+from django.utils import timezone
+
+from sentry.models.project import Project
+from sentry.replays.models import DeletionJobStatus, ReplayDeletionJobModel
+
+logger = logging.getLogger()
+
+
+def expire_replay_deletion_jobs(
+    project_id: int, job_ids: Sequence[int], dry_run: bool
+) -> list[int]:
+    """Mark a project's deletion jobs completed because we deleted the replays ourselves.
+
+    When a customer's bulk deletion job fails we sometimes finish the deletion out-of-band with
+    `delete_replays`. The job row is left in a non-completed status, so the UI keeps claiming a
+    deletion is in flight and polls the audit log forever. This closes those rows out.
+
+    Jobs are looked up scoped to `project_id`, so a job ID belonging to another project is reported
+    as not found rather than expired.
+
+    Returns the IDs that were (or, on a dry run, would have been) transitioned.
+    """
+    project = Project.objects.get(id=project_id)
+
+    jobs = list(
+        ReplayDeletionJobModel.objects.filter(
+            organization_id=project.organization_id,
+            project_id=project.id,
+            id__in=job_ids,
+        )
+    )
+
+    expirable_ids = []
+    for job in jobs:
+        logging_context = {
+            "job_id": job.id,
+            "organization_id": job.organization_id,
+            "project_id": job.project_id,
+            "status": job.status,
+            "range_start": job.range_start,
+            "range_end": job.range_end,
+            "query": job.query,
+            "offset": job.offset,
+            "dry_run": dry_run,
+        }
+        if job.status == DeletionJobStatus.COMPLETED:
+            logger.info("Replay deletion job is already completed.", extra=logging_context)
+        else:
+            # `failed` is expirable too, and is the common case: the customer's job failed, so we
+            # ran the deletion by hand.
+            expirable_ids.append(job.id)
+            logger.info("Expiring replay deletion job.", extra=logging_context)
+
+    missing_ids = sorted(set(job_ids) - {job.id for job in jobs})
+    if missing_ids:
+        logger.warning(
+            "Replay deletion jobs not found in project.",
+            extra={"project_id": project.id, "job_ids": missing_ids},
+        )
+
+    if expirable_ids and not dry_run:
+        # Compare-and-set, mirroring `_transition_status` in tasks.py. `date_updated` is set by hand
+        # because `auto_now` does not fire on `.update()`. A chained activation of
+        # `run_bulk_replay_delete_job` that is still in flight re-reads the status and returns early
+        # on anything that isn't `in-progress`, so there is nothing to revoke here.
+        ReplayDeletionJobModel.objects.filter(
+            organization_id=project.organization_id,
+            project_id=project.id,
+            id__in=expirable_ids,
+        ).exclude(status=DeletionJobStatus.COMPLETED).update(
+            status=DeletionJobStatus.COMPLETED, date_updated=timezone.now()
+        )
+
+    logger.info(
+        "Expired replay deletion jobs.",
+        extra={
+            "project_id": project.id,
+            "expired_job_ids": expirable_ids,
+            "expired_count": len(expirable_ids),
+            "dry_run": dry_run,
+        },
+    )
+
+    return expirable_ids

--- a/src/sentry/replays/scripts/expire_replay_deletion_jobs.py
+++ b/src/sentry/replays/scripts/expire_replay_deletion_jobs.py
@@ -51,7 +51,8 @@ def expire_replay_deletion_jobs(
             "status": job.status,
             "range_start": job.range_start,
             "range_end": job.range_end,
-            "query": job.query,
+            # `job.query` is deliberately absent: it is a customer-authored search string and can
+            # carry PII like `user.email:`. `tasks.py` leaves it out of its Sentry context too.
             "offset": job.offset,
             "dry_run": dry_run,
         }

--- a/src/sentry/replays/scripts/expire_replay_deletion_jobs.py
+++ b/src/sentry/replays/scripts/expire_replay_deletion_jobs.py
@@ -24,8 +24,15 @@ def expire_replay_deletion_jobs(
     as not found rather than expired.
 
     Returns the IDs that were (or, on a dry run, would have been) transitioned.
+
+    Raises `Project.DoesNotExist` for an unknown `project_id`. An operator supplies that ID by hand,
+    so a typo has to fail the run loudly rather than report zero jobs expired and look like success.
     """
-    project = Project.objects.get(id=project_id)
+    project = Project.objects.filter(id=project_id).first()
+    if project is None:
+        raise Project.DoesNotExist(
+            f"expire_replay_deletion_jobs got project_id={project_id}, which does not exist"
+        )
 
     jobs = list(
         ReplayDeletionJobModel.objects.filter(

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -174,6 +174,7 @@ from sentry.preprod.models import (
     PreprodSnapshotComparison,
     PreprodSnapshotMetrics,
 )
+from sentry.replays.models import DeletionJobStatus, ReplayDeletionJobModel
 from sentry.seer.autofix.constants import CodingAgentStatus
 from sentry.seer.models.agent_write_grant import SeerAgentWriteGrant
 from sentry.seer.models.project_repository import SeerProjectRepository
@@ -732,6 +733,26 @@ class Factories:
     @assume_test_silo_mode(SiloMode.CELL)
     def create_project_bookmark(project, user):
         return ProjectBookmark.objects.create(project_id=project.id, user_id=user.id)
+
+    @staticmethod
+    @assume_test_silo_mode(SiloMode.CELL)
+    def create_replay_deletion_job(
+        project: Project,
+        range_start: datetime,
+        range_end: datetime,
+        status: str = DeletionJobStatus.PENDING,
+        query: str = "",
+        environments: list[str] | None = None,
+    ) -> ReplayDeletionJobModel:
+        return ReplayDeletionJobModel.objects.create(
+            organization_id=project.organization_id,
+            project_id=project.id,
+            range_start=range_start,
+            range_end=range_end,
+            status=status,
+            query=query,
+            environments=environments or [],
+        )
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.CELL)

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -56,6 +56,7 @@ from sentry.preprod.models import (
     PreprodSnapshotComparison,
     PreprodSnapshotMetrics,
 )
+from sentry.replays.models import ReplayDeletionJobModel
 from sentry.services.eventstore.models import Event
 from sentry.silo.base import SiloMode
 from sentry.tempest.models import TempestCredentials
@@ -275,6 +276,11 @@ class Fixtures:
         if project is None:
             project = self.project
         return Factories.create_ai_conversation_metadata(project, *args, **kwargs)
+
+    def create_replay_deletion_job(self, project=None, **kwargs) -> ReplayDeletionJobModel:
+        if project is None:
+            project = self.project
+        return Factories.create_replay_deletion_job(project, **kwargs)
 
     def create_project_key(self, project=None, *args, **kwargs):
         if project is None:

--- a/tests/sentry/replays/scripts/test_expire_replay_deletion_jobs.py
+++ b/tests/sentry/replays/scripts/test_expire_replay_deletion_jobs.py
@@ -52,7 +52,7 @@ class TestExpireReplayDeletionJobs(TestCase):
         assert job.status == DeletionJobStatus.COMPLETED
 
     def test_unknown_project_id_raises(self) -> None:
-        with pytest.raises(Project.DoesNotExist):
+        with pytest.raises(Project.DoesNotExist, match="project_id=1234567"):
             expire_replay_deletion_jobs(1234567, [1], dry_run=False)
 
     def test_dry_run_mutates_nothing(self) -> None:

--- a/tests/sentry/replays/scripts/test_expire_replay_deletion_jobs.py
+++ b/tests/sentry/replays/scripts/test_expire_replay_deletion_jobs.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import pytest
+
+from sentry.models.project import Project
+from sentry.replays.models import DeletionJobStatus, ReplayDeletionJobModel
+from sentry.replays.scripts.expire_replay_deletion_jobs import expire_replay_deletion_jobs
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.datetime import before_now
+
+
+class TestExpireReplayDeletionJobs(TestCase):
+    def create_job(self, status: str) -> ReplayDeletionJobModel:
+        return self.create_replay_deletion_job(
+            status=status,
+            range_start=before_now(days=7),
+            range_end=before_now(days=1),
+        )
+
+    def test_expires_pending_in_progress_and_failed(self) -> None:
+        pending = self.create_job(DeletionJobStatus.PENDING)
+        in_progress = self.create_job(DeletionJobStatus.IN_PROGRESS)
+        failed = self.create_job(DeletionJobStatus.FAILED)
+
+        expired = expire_replay_deletion_jobs(
+            self.project.id, [pending.id, in_progress.id, failed.id], dry_run=False
+        )
+
+        assert sorted(expired) == sorted([pending.id, in_progress.id, failed.id])
+        for job in (pending, in_progress, failed):
+            job.refresh_from_db()
+            assert job.status == DeletionJobStatus.COMPLETED
+
+    def test_already_completed_job_is_untouched(self) -> None:
+        job = self.create_job(DeletionJobStatus.COMPLETED)
+        date_updated = job.date_updated
+
+        assert expire_replay_deletion_jobs(self.project.id, [job.id], dry_run=False) == []
+
+        job.refresh_from_db()
+        assert job.status == DeletionJobStatus.COMPLETED
+        assert job.date_updated == date_updated
+
+    def test_unknown_job_id_is_skipped(self) -> None:
+        job = self.create_job(DeletionJobStatus.FAILED)
+
+        assert expire_replay_deletion_jobs(self.project.id, [job.id, 1234567], dry_run=False) == [
+            job.id
+        ]
+
+        job.refresh_from_db()
+        assert job.status == DeletionJobStatus.COMPLETED
+
+    def test_unknown_project_id_raises(self) -> None:
+        with pytest.raises(Project.DoesNotExist):
+            expire_replay_deletion_jobs(1234567, [1], dry_run=False)
+
+    def test_dry_run_mutates_nothing(self) -> None:
+        job = self.create_job(DeletionJobStatus.IN_PROGRESS)
+        date_updated = job.date_updated
+
+        assert expire_replay_deletion_jobs(self.project.id, [job.id], dry_run=True) == [job.id]
+
+        job.refresh_from_db()
+        assert job.status == DeletionJobStatus.IN_PROGRESS
+        assert job.date_updated == date_updated
+
+    def test_unlisted_jobs_are_untouched(self) -> None:
+        expired_job = self.create_job(DeletionJobStatus.FAILED)
+        untouched_job = self.create_job(DeletionJobStatus.IN_PROGRESS)
+
+        assert expire_replay_deletion_jobs(self.project.id, [expired_job.id], dry_run=False) == [
+            expired_job.id
+        ]
+
+        untouched_job.refresh_from_db()
+        assert untouched_job.status == DeletionJobStatus.IN_PROGRESS


### PR DESCRIPTION
Adds a new job to _expire_ (mark completed) Replay deletion jobs. Sometimes customers will queue up deletion jobs that stall or fail, and we end up intervening manually. In those cases, it's polite to _clean up_ these stalled or failed jobs because they show banners in the UI to tell the user that Replays are being deleted.


References REPLAY-977