### PR TITLE
feat(seer): Fall back to ProjectRepository for free cohort repo defin…

### DIFF
--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -586,6 +586,34 @@ def build_repo_definition_from_project_repo(
     )
 
 
+def build_repo_definition_from_project_repo_fallback(
+    project_repo: ProjectRepository,
+) -> SeerRepoDefinition | None:
+    """Build a SeerRepoDefinition from a ProjectRepository → Repository, without
+    Seer-specific fields. Used as a fallback for free cohort orgs that have no
+    SeerProjectRepository rows.
+
+    Returns None if Repository name is invalid."""
+    repo = project_repo.repository
+    repo_name_sections = get_repo_url_path(repo).split("/")
+    if len(repo_name_sections) < 2:
+        sentry_sdk.capture_exception(ValueError(f"Invalid repository name format: {repo.name}"))
+        return None
+
+    return SeerRepoDefinition(
+        repository_id=repo.id,
+        organization_id=repo.organization_id,
+        integration_id=str(repo.integration_id) if repo.integration_id is not None else None,
+        provider=repo.provider or "",
+        owner=repo_name_sections[0],
+        name="/".join(repo_name_sections[1:]),
+        external_id=repo.external_id or "",
+        branch_name=None,
+        instructions=None,
+        branch_overrides=[],
+    )
+
+
 def get_automation_handoff(
     get_option: Callable[[str], Any],
 ) -> SeerAutomationHandoffConfiguration | None:
@@ -607,19 +635,32 @@ def get_automation_handoff(
 
 def read_preference_from_sentry_db(project: Project) -> SeerProjectPreference:
     """Read a single project's Seer preferences from Sentry DB."""
-    seer_project_repo_qs = (
-        SeerProjectRepository.objects.filter(
-            project_repository__project=project,
-            project_repository__repository__status=ObjectStatus.ACTIVE,
+    if is_free_cohort_org(project.organization):
+        # Free cohort orgs have no SeerProjectRepository rows — use
+        # ProjectRepository → Repository directly.
+        project_repo_qs = ProjectRepository.objects.filter(
+            project=project,
+            repository__status=ObjectStatus.ACTIVE,
+        ).select_related("repository")
+        repo_definitions = [
+            repo_def
+            for pr in project_repo_qs
+            if (repo_def := build_repo_definition_from_project_repo_fallback(pr)) is not None
+        ]
+    else:
+        seer_project_repo_qs = (
+            SeerProjectRepository.objects.filter(
+                project_repository__project=project,
+                project_repository__repository__status=ObjectStatus.ACTIVE,
+            )
+            .select_related("project_repository", "project_repository__repository")
+            .prefetch_related("branch_overrides")
         )
-        .select_related("project_repository", "project_repository__repository")
-        .prefetch_related("branch_overrides")
-    )
-    repo_definitions = [
-        repo_def
-        for project_repo in seer_project_repo_qs
-        if (repo_def := build_repo_definition_from_project_repo(project_repo)) is not None
-    ]
+        repo_definitions = [
+            repo_def
+            for project_repo in seer_project_repo_qs
+            if (repo_def := build_repo_definition_from_project_repo(project_repo)) is not None
+        ]
 
     return SeerProjectPreference(
         organization_id=project.organization_id,
@@ -641,18 +682,33 @@ def bulk_read_preferences_from_sentry_db(
     projects = list(Project.objects.filter(id__in=project_ids, organization_id=organization_id))
 
     repo_definitions_by_project: defaultdict[int, list[SeerRepoDefinition]] = defaultdict(list)
-    seer_repo_qs = (
-        SeerProjectRepository.objects.filter(
-            project_repository__project_id__in=project_ids,
-            project_repository__repository__status=ObjectStatus.ACTIVE,
+    org = Organization.objects.filter(id=organization_id).first()
+    if org is not None and is_free_cohort_org(org):
+        # Free cohort orgs have no SeerProjectRepository rows — use
+        # ProjectRepository → Repository directly.
+        fallback_qs = ProjectRepository.objects.filter(
+            project_id__in=project_ids,
+            repository__status=ObjectStatus.ACTIVE,
+        ).select_related("repository")
+        for pr in fallback_qs:
+            repo_def = build_repo_definition_from_project_repo_fallback(pr)
+            if repo_def is not None:
+                repo_definitions_by_project[pr.project_id].append(repo_def)
+    else:
+        seer_repo_qs = (
+            SeerProjectRepository.objects.filter(
+                project_repository__project_id__in=project_ids,
+                project_repository__repository__status=ObjectStatus.ACTIVE,
+            )
+            .select_related("project_repository", "project_repository__repository")
+            .prefetch_related("branch_overrides")
         )
-        .select_related("project_repository", "project_repository__repository")
-        .prefetch_related("branch_overrides")
-    )
-    for seer_repo in seer_repo_qs:
-        repo_def = build_repo_definition_from_project_repo(seer_repo)
-        if repo_def is not None:
-            repo_definitions_by_project[seer_repo.project_repository.project_id].append(repo_def)
+        for seer_repo in seer_repo_qs:
+            repo_def = build_repo_definition_from_project_repo(seer_repo)
+            if repo_def is not None:
+                repo_definitions_by_project[seer_repo.project_repository.project_id].append(
+                    repo_def
+                )
 
     # get_value_bulk_id returns None for missing options, unlike project.get_option
     # which automatically falls back to the registered well-known key default.


### PR DESCRIPTION
+ Free cohort orgs have ProjectRepository rows (auto-created by event processing, name matching, SCM onboarding) but no SeerProjectRepository rows (requires explicit Seer project settings config). The repo lookup returns empty, blocking night shift project eligibility and coding agent handoff.

+ For free cohort orgs only (is_free_cohort_org check), fall back to ProjectRepository → Repository to build SeerRepoDefinition with no branch overrides or instructions. Paying orgs are unaffected.