### PR TITLE
feat(aci): Add ability to filter alerts by assignee on frontend

### DIFF
--- a/static/app/views/automations/list.spec.tsx
+++ b/static/app/views/automations/list.spec.tsx
@@ -277,6 +277,25 @@ describe('AutomationsList', () => {
       await screen.findByText('My Automation');
       expect(mockAutomationCreatedBy).toHaveBeenCalled();
     });
+
+    it('can filter by assignee', async () => {
+      const mockAutomationAssignee = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/workflows/',
+        body: [AutomationFixture({name: 'Assigned Automation'})],
+        match: [MockApiClient.matchQuery({query: 'assignee:me'})],
+      });
+
+      render(<AutomationsList />, {organization});
+      await screen.findByText('Automation 1');
+
+      // Click through menus to select assignee:me
+      await userEvent.click(screen.getByRole('combobox', {name: 'Add a search term'}));
+      await userEvent.click(await screen.findByRole('option', {name: 'assignee'}));
+      await userEvent.click(await screen.findByRole('option', {name: 'me'}));
+
+      await screen.findByText('Assigned Automation');
+      expect(mockAutomationAssignee).toHaveBeenCalled();
+    });
   });
 
   describe('bulk actions', () => {

--- a/static/app/views/automations/utils/useAutomationFilterKeys.tsx
+++ b/static/app/views/automations/utils/useAutomationFilterKeys.tsx
@@ -8,6 +8,7 @@ import {t} from 'sentry/locale';
 import type {TagCollection} from 'sentry/types/group';
 import {FieldKind, FieldValueType, type FieldDefinition} from 'sentry/utils/fields';
 import {useMembers} from 'sentry/utils/members/useMembers';
+import {useAssignedSearchValues} from 'sentry/utils/membersAndTeams/useAssignedSearchValues';
 import {getUsername} from 'sentry/utils/membersAndTeams/userUtils';
 import {ActionType} from 'sentry/views/alerts/rules/metric/types';
 
@@ -47,6 +48,16 @@ const AUTOMATION_FILTER_KEYS: Record<
       keywords: ['creator', 'author'],
     },
   },
+  assignee: {
+    predefined: true,
+    fieldDefinition: {
+      desc: 'User or team assigned to the Alert.',
+      kind: FieldKind.FIELD,
+      valueType: FieldValueType.STRING,
+      allowWildcard: false,
+      keywords: ['assigned', 'owner'],
+    },
+  },
 };
 
 const convertToSearchItem = (value: string) => {
@@ -63,6 +74,8 @@ export function useAutomationFilterKeys(): {
   getFieldDefinition: FieldDefinitionGetter;
 } {
   const {data: members = []} = useMembers();
+
+  const assignedValues = useAssignedSearchValues();
 
   const createdByValues: SearchGroup[] = useMemo(() => {
     const usernames = members.map(getUsername);
@@ -84,18 +97,23 @@ export function useAutomationFilterKeys(): {
   }, [members]);
 
   const filterKeys = useMemo(() => {
+    const valuesByKey: Record<string, SearchGroup[]> = {
+      created_by: createdByValues,
+      assignee: assignedValues,
+    };
+
     const entries = Object.entries(AUTOMATION_FILTER_KEYS).map(([key, config]) => [
       key,
       {
         key,
         name: key,
         predefined: config.predefined,
-        values: key === 'created_by' ? createdByValues : undefined,
+        values: valuesByKey[key],
       },
     ]);
 
     return Object.fromEntries(entries);
-  }, [createdByValues]);
+  }, [createdByValues, assignedValues]);
 
   const getFieldDefinition = useCallback<FieldDefinitionGetter>((key: string) => {
     return AUTOMATION_FILTER_KEYS[key]?.fieldDefinition ?? null;


### PR DESCRIPTION
Update the frontend of the alerts page so in the bar you can do assigned is/is not ..... (team or user)

[ISWF-2858](https://linear.app/getsentry/issue/ISWF-2858/feature-request-ability-to-assign-alerts-to-teams)

<img width="685" height="402" alt="image" src="https://github.com/user-attachments/assets/bf0858f8-fd14-42d5-9091-3fa676f3390f" />
