### PR TITLE
feat(aci): Add assignee column to alerts table

### DIFF
--- a/static/app/types/workflowEngine/automations.tsx
+++ b/static/app/types/workflowEngine/automations.tsx
@@ -9,6 +9,8 @@ export interface NewAutomation {
   enabled: boolean;
   environment: string | null;
   name: string;
+  // Actor identifier, such as `user:1` or `team:1`
+  owner: string | null;
   triggers: DataConditionGroup | null;
 }
 

--- a/static/app/views/automations/components/automationFormData.spec.tsx
+++ b/static/app/views/automations/components/automationFormData.spec.tsx
@@ -24,6 +24,7 @@ describe('validateAutomationBuilderState', () => {
       environment: null,
       frequency: 0,
       name: 'All projects alert',
+      owner: null,
       projectIds: [],
     };
 

--- a/static/app/views/automations/components/automationFormData.tsx
+++ b/static/app/views/automations/components/automationFormData.tsx
@@ -21,6 +21,8 @@ export interface AutomationFormData {
   environment: string | null;
   frequency: number | null;
   name: string;
+  // Actor identifier, such as `user:1` or `team:1`
+  owner: string | null;
   /**
    * Derived field used for project-based monitor selection.
    * Maps to issue stream detector IDs for the selected projects.
@@ -88,6 +90,7 @@ export function getNewAutomationData({
     },
     detectorIds: data.detectorIds,
     enabled: data.enabled,
+    owner: data.owner ?? null,
   };
 }
 
@@ -101,6 +104,7 @@ export function getAutomationFormData(
     frequency: automation.config.frequency ?? 0,
     name: automation.name,
     enabled: automation.enabled,
+    owner: automation.owner,
     projectIds: [],
   };
 }

--- a/static/app/views/automations/components/automationListTable/assigneeCell.spec.tsx
+++ b/static/app/views/automations/components/automationListTable/assigneeCell.spec.tsx
@@ -1,0 +1,28 @@
+import {parseAutomationOwner} from 'sentry/views/automations/components/automationListTable/assigneeCell';
+
+describe('parseAutomationOwner', () => {
+  it('parses a user identifier', () => {
+    expect(parseAutomationOwner('user:1')).toEqual({type: 'user', id: '1'});
+  });
+
+  it('parses a team identifier', () => {
+    expect(parseAutomationOwner('team:1')).toEqual({type: 'team', id: '1'});
+  });
+
+  it('returns null when there is no owner', () => {
+    expect(parseAutomationOwner(null)).toBeNull();
+    expect(parseAutomationOwner('')).toBeNull();
+  });
+
+  it('returns null when the type or id is missing', () => {
+    expect(parseAutomationOwner('user')).toBeNull();
+    expect(parseAutomationOwner('user:')).toBeNull();
+    expect(parseAutomationOwner(':1')).toBeNull();
+    expect(parseAutomationOwner(':')).toBeNull();
+  });
+
+  it('returns null for an unrecognized actor type', () => {
+    expect(parseAutomationOwner('organization:1')).toBeNull();
+    expect(parseAutomationOwner('Team:1')).toBeNull();
+  });
+});

--- a/static/app/views/automations/components/automationListTable/assigneeCell.tsx
+++ b/static/app/views/automations/components/automationListTable/assigneeCell.tsx
@@ -1,0 +1,44 @@
+import {ActorAvatar} from '@sentry/scraps/avatar';
+
+import {EmptyCell} from 'sentry/components/workflowEngine/gridCell/emptyCell';
+import type {Actor} from 'sentry/types/core';
+
+/**
+ * `automation.owner` is an actor identifier string like `user:1` or `team:1`
+ *
+ * Parse this string to be then passed into `Actor Avatar`, which will resolve the name and avatar itself
+ */
+
+type ParsedOwner = {id: string; type: Actor['type']} | null;
+
+export function parseAutomationOwner(owner: string | null): ParsedOwner {
+  if (!owner) {
+    return null;
+  }
+
+  const [type, id] = owner.split(':');
+
+  if (!type || !id) {
+    return null;
+  }
+
+  if (type !== 'user' && type !== 'team') {
+    return null;
+  }
+
+  return {type, id};
+}
+
+type AssigneeCellProps = {
+  owner: string | null;
+};
+
+export function AssigneeCell({owner}: AssigneeCellProps) {
+  const actor = parseAutomationOwner(owner);
+
+  if (!actor) {
+    return <EmptyCell />;
+  }
+
+  return <ActorAvatar actor={actor} size={24} />;
+}

--- a/static/app/views/automations/components/automationListTable/index.tsx
+++ b/static/app/views/automations/components/automationListTable/index.tsx
@@ -159,6 +159,9 @@ export function AutomationListTable({
           <HeaderCell data-column-name="projects" sort={sort}>
             {t('Projects')}
           </HeaderCell>
+          <HeaderCell data-column-name="assignee" sort={sort}>
+            {t('Assignee')}
+          </HeaderCell>
           <HeaderCell
             data-column-name="connected-monitors"
             sort={sort}
@@ -232,6 +235,7 @@ const AutomationsSimpleTable = styled(SimpleTable)`
   [data-column-name='last-triggered'],
   [data-column-name='action'],
   [data-column-name='projects'],
+  [data-column-name='assignee'],
   [data-column-name='connected-monitors'] {
     display: none;
   }
@@ -245,15 +249,16 @@ const AutomationsSimpleTable = styled(SimpleTable)`
   }
 
   @container (min-width: ${p => p.theme.container.xl}) {
-    grid-template-columns: 2.5fr 1fr 1fr;
+    grid-template-columns: 2.5fr 1fr 1fr 90px;
 
-    [data-column-name='action'] {
+    [data-column-name='action'],
+    [data-column-name='assignee'] {
       display: flex;
     }
   }
 
   @container (min-width: ${p => p.theme.container['3xl']}) {
-    grid-template-columns: 2.5fr minmax(160px, 1fr) 1fr 1fr;
+    grid-template-columns: 2.5fr minmax(160px, 1fr) 1fr 1fr 90px;
 
     [data-column-name='last-triggered'] {
       display: flex;
@@ -261,7 +266,7 @@ const AutomationsSimpleTable = styled(SimpleTable)`
   }
 
   @container (min-width: ${p => p.theme.container['4xl']}) {
-    grid-template-columns: minmax(0, 3fr) minmax(160px, 1fr) 1fr 1fr 1fr;
+    grid-template-columns: minmax(0, 3fr) minmax(160px, 1fr) 1fr 1fr 90px 1fr;
 
     [data-column-name='connected-monitors'] {
       display: flex;

--- a/static/app/views/automations/components/automationListTable/row.tsx
+++ b/static/app/views/automations/components/automationListTable/row.tsx
@@ -9,6 +9,7 @@ import {ActionCell} from 'sentry/components/workflowEngine/gridCell/actionCell';
 import {AutomationTitleCell} from 'sentry/components/workflowEngine/gridCell/automationTitleCell';
 import {TimeAgoCell} from 'sentry/components/workflowEngine/gridCell/timeAgoCell';
 import type {Automation} from 'sentry/types/workflowEngine/automations';
+import {AssigneeCell} from 'sentry/views/automations/components/automationListTable/assigneeCell';
 import {AutomationListConnectedDetectors} from 'sentry/views/automations/components/automationListTable/connectedDetectors';
 import {ProjectsCell} from 'sentry/views/automations/components/automationListTable/projectsCell';
 import {useCanEditAutomation} from 'sentry/views/automations/hooks/useCanEditAutomation';
@@ -28,7 +29,7 @@ export function AutomationListRow({
   const canEditAutomations = useCanEditAutomation();
 
   const actions = getAutomationActions(automation);
-  const {enabled, lastTriggered, detectorIds} = automation;
+  const {enabled, lastTriggered, detectorIds, owner} = automation;
 
   return (
     <AutomationSimpleTableRow
@@ -58,6 +59,9 @@ export function AutomationListRow({
       <SimpleTable.RowCell data-column-name="projects">
         <ProjectsCell automation={automation} />
       </SimpleTable.RowCell>
+      <SimpleTable.RowCell data-column-name="assignee">
+        <AssigneeCell owner={owner} />
+      </SimpleTable.RowCell>
       <SimpleTable.RowCell data-column-name="connected-monitors">
         <AutomationListConnectedDetectors detectorIds={detectorIds} />
       </SimpleTable.RowCell>
@@ -78,6 +82,9 @@ export function AutomationListRowSkeleton() {
         <Placeholder height="20px" />
       </SimpleTable.RowCell>
       <SimpleTable.RowCell data-column-name="projects">
+        <Placeholder height="20px" />
+      </SimpleTable.RowCell>
+      <SimpleTable.RowCell data-column-name="assignee">
         <Placeholder height="20px" />
       </SimpleTable.RowCell>
       <SimpleTable.RowCell data-column-name="connected-monitors">

--- a/static/app/views/automations/list.spec.tsx
+++ b/static/app/views/automations/list.spec.tsx
@@ -10,6 +10,7 @@ import {
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
+import {TeamFixture} from 'sentry-fixture/team';
 import {UserFixture} from 'sentry-fixture/user';
 
 import {
@@ -24,6 +25,7 @@ import {
 import {PageFiltersContainer} from 'sentry/components/pageFilters/container';
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
+import {TeamStore} from 'sentry/stores/teamStore';
 import AutomationsList from 'sentry/views/automations/list';
 
 describe('AutomationsList', () => {
@@ -82,6 +84,27 @@ describe('AutomationsList', () => {
     expect(within(row).getByText('Slack')).toBeInTheDocument();
     // Monitors
     expect(within(row).getByText('1 monitor')).toBeInTheDocument();
+  });
+
+  it('displays the assignee, and a dash when unassigned', async () => {
+    const team = TeamFixture({id: '2', slug: 'team-slug'});
+
+    TeamStore.loadInitialData([team]);
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/workflows/',
+      body: [
+        AutomationFixture({id: '100', name: 'Assigned Automation', owner: 'team:2'}),
+        AutomationFixture({id: '101', name: 'Unassigned Automation', owner: null}),
+      ],
+    });
+
+    render(<AutomationsList />, {organization});
+
+    const rows = await screen.findAllByTestId('automation-list-row');
+
+    expect(within(rows[0]!).getByTitle('team slug')).toBeInTheDocument();
+    expect(within(rows[1]!).getByText('—')).toBeInTheDocument();
   });
 
   it('displays connected detectors and projects via a single batch request', async () => {

--- a/static/app/views/automations/new.spec.tsx
+++ b/static/app/views/automations/new.spec.tsx
@@ -300,6 +300,7 @@ describe('AutomationNewSettings', () => {
             config: {frequency: 0},
             detectorIds: ['123'],
             enabled: true,
+            owner: null,
           },
         })
       )

--- a/static/app/views/automations/new.tsx
+++ b/static/app/views/automations/new.tsx
@@ -76,6 +76,7 @@ const INITIAL_FORM_DATA_DEFAULTS = {
   environment: null,
   frequency: 0,
   enabled: true,
+  owner: null,
   projectIds: [],
   detectorIds: [],
 };

--- a/static/app/views/automations/utils/resolveDetectorIdsForProjects.spec.ts
+++ b/static/app/views/automations/utils/resolveDetectorIdsForProjects.spec.ts
@@ -27,6 +27,7 @@ describe('resolveDetectorIdsForProjects', () => {
       environment: null,
       frequency: 0,
       name: 'All projects alert',
+      owner: null,
       projectIds: [],
     };
     MockApiClient.addMockResponse({

--- a/tests/js/fixtures/automations.ts
+++ b/tests/js/fixtures/automations.ts
@@ -24,6 +24,7 @@ export function AutomationFixture(params: Partial<Automation> = {}): Automation 
     actionFilters: [ActionFilterFixture()],
     detectorIds: ['1'],
     environment: 'production',
+    owner: null,
     triggers: {
       conditions: [],
       id: '1',


### PR DESCRIPTION
Adds a column to the workflow list to show the assignee if present
Otherwise it shows a dash like the detectors page does

<img width="1448" height="380" alt="image" src="https://github.com/user-attachments/assets/4c3e3498-2818-4b52-970d-291aea890805" />


The approach in this PR parses the owner field since it is a string

This is different than the owner field of a detector, which is a full owner object like so

```json
"owner": {
      "type": "team",
      "id": "1",
      "name": "sentry"
    },
```

The reason the workflow serializes only the identifier of the actor was explained in this PR https://github.com/getsentry/sentry/pull/110817

The reason given was that it would match the way detector was serialized, but I am pretty sure they are serialized differently

For backwards compatibility I will not update the workflow serializer to return the same object shape.