### PR TITLE
feat(smart-assignment): Increase daily caps, sample non-Seer triggers at 10%

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1303,14 +1303,21 @@ register(
 register(
     "seer.smart_assignment.max_dispatches_per_org_per_day",
     type=Int,
-    default=500,
+    default=1000,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
     "seer.smart_assignment.max_dispatches_per_day",
     type=Int,
-    default=1500,
+    default=2000,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+# The ratio of ASSIGNED / resolution activities that we sample for evaluation.
+register(
+    "seer.smart_assignment.eval_sample_rate",
+    type=Float,
+    default=0.10,
+    flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
 register(

--- a/src/sentry/seer/smart_assignment/models.py
+++ b/src/sentry/seer/smart_assignment/models.py
@@ -30,14 +30,26 @@ SEER_FEATURE_ID = "smart_assignment"
 # who should have owned it.
 # SET_RESOLVED_BY_AGE is excluded (auto-resolve cron, no acting user, so no signal).
 # SET_RESOLVED_IN_PULL_REQUEST is excluded (it will trigger ASSIGNED in practice, which we already capture).
-# Other ground-truth activities include ASSIGNED and SEER_*_STARTED,
-# configured in workflow_activity_handlers.py
 RESOLUTION_ACTIVITIES = frozenset(
     {
         ActivityType.SET_RESOLVED,
         ActivityType.SET_RESOLVED_IN_RELEASE,
         ActivityType.SET_RESOLVED_IN_COMMIT,
     }
+)
+
+# Seer workflow steps that need an assignee for notification. Never sampled.
+SEER_START_ACTIVITIES = frozenset(
+    {
+        ActivityType.SEER_RCA_STARTED,
+        ActivityType.SEER_SOLUTION_STARTED,
+        ActivityType.SEER_CODING_STARTED,
+    }
+)
+
+# Every activity the smart assignment feature reacts to.
+SMART_ASSIGNMENT_ACTIVITIES = (
+    RESOLUTION_ACTIVITIES | SEER_START_ACTIVITIES | frozenset({ActivityType.ASSIGNED})
 )
 
 # We invalidate scoring against "ground truth" assignments from these sources, because they're

--- a/src/sentry/seer/smart_assignment/trigger.py
+++ b/src/sentry/seer/smart_assignment/trigger.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import random
 
 from sentry import features, options
 from sentry.models.activity import Activity
@@ -13,6 +14,7 @@ from sentry.seer.models.run import SeerRun
 from sentry.seer.smart_assignment.models import (
     RESOLUTION_ACTIVITIES,
     SEER_FEATURE_ID,
+    SEER_START_ACTIVITIES,
     SmartAssignmentPayload,
     is_unscorable_assignment,
 )
@@ -78,7 +80,11 @@ def trigger_smart_assignment(
     # code (not a DB constraint) so re-runs are cheap to enable later -- e.g. gate on
     # a cooldown or a new-signal check against the latest run instead. The run mirror
     # is our durable record that a run was dispatched.
-    if not _already_predicted(group) and not _dispatch_rate_limited(organization):
+    if (
+        not _already_predicted(group)
+        and _should_sample_for_eval(activity_type)
+        and not _dispatch_rate_limited(organization)
+    ):
         _dispatch(group, activity_type, activity)
 
     record_ground_truth(group, activity_type, activity)
@@ -92,6 +98,20 @@ def _already_predicted(group: Group) -> bool:
     run past this before the first mirror commits, which the daily caps still bound.
     """
     return runs_for_group(group.id, SEER_FEATURE_ID).exists()
+
+
+def _should_sample_for_eval(activity_type: ActivityType) -> bool:
+    if activity_type in SEER_START_ACTIVITIES:
+        return True
+    rate = options.get("seer.smart_assignment.eval_sample_rate")
+    if random.random() >= rate:
+        metrics.incr(
+            "smart_assignment.trigger.skipped",
+            tags={"reason": "eval_sampled_out"},
+            sample_rate=1.0,
+        )
+        return False
+    return True
 
 
 def _dispatch_rate_limited(organization: Organization) -> bool:

--- a/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
+++ b/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
@@ -2,7 +2,7 @@ import logging
 
 from sentry.models.activity import Activity
 from sentry.models.group import Group
-from sentry.seer.smart_assignment.models import RESOLUTION_ACTIVITIES
+from sentry.seer.smart_assignment.models import SMART_ASSIGNMENT_ACTIVITIES
 from sentry.types.activity import ActivityType
 from sentry.utils import metrics
 from sentry.workflow_engine.models import Detector
@@ -30,19 +30,6 @@ SUPPORTED_ACTIVITIES = [
     # We omit SET_RESOLVED_IN_PULL_REQUEST because it's a misnomer.
     # When it fires, it means the issue was referenced in a pull request, not resolved.
 ]
-
-# Activities the smart assignment feature reacts to: a Seer AI step starting, an
-# assignment, or a resolution. Each triggers a prediction (deduped to one per group)
-# and records ground truth; gating lives in trigger_smart_assignment. The exact
-# ActivityType is forwarded through as the trigger (see smart_assignment.models).
-_SMART_ASSIGNMENT_ACTIVITIES = RESOLUTION_ACTIVITIES | frozenset(
-    {
-        ActivityType.SEER_RCA_STARTED,
-        ActivityType.SEER_SOLUTION_STARTED,
-        ActivityType.SEER_CODING_STARTED,
-        ActivityType.ASSIGNED,
-    }
-)
 
 
 @workflow_activity_registry.register("seer_activity")
@@ -111,7 +98,7 @@ def smart_assignment_trigger_handler(
     except ValueError:
         return
 
-    if activity_type not in _SMART_ASSIGNMENT_ACTIVITIES:
+    if activity_type not in SMART_ASSIGNMENT_ACTIVITIES:
         return
 
     from sentry.seer.smart_assignment.trigger import trigger_smart_assignment

--- a/tests/sentry/seer/smart_assignment/test_trigger.py
+++ b/tests/sentry/seer/smart_assignment/test_trigger.py
@@ -125,7 +125,10 @@ class TriggerSmartAssignmentTest(TestCase):
         GroupAssignee.objects.create(
             group=self.group, project=self.group.project, user_id=assignee.id
         )
-        with self.feature("organizations:seer-smart-assignment-run"):
+        with (
+            self.feature("organizations:seer-smart-assignment-run"),
+            self.options({"seer.smart_assignment.eval_sample_rate": 1.0}),
+        ):
             trigger_smart_assignment(
                 self.group, ActivityType.ASSIGNED, self._assigned_activity(assignee.id)
             )
@@ -143,7 +146,10 @@ class TriggerSmartAssignmentTest(TestCase):
         self._wire_client(mock_client_cls)
         team = self.create_team(organization=self.organization)
         GroupAssignee.objects.create(group=self.group, project=self.group.project, team=team)
-        with self.feature("organizations:seer-smart-assignment-run"):
+        with (
+            self.feature("organizations:seer-smart-assignment-run"),
+            self.options({"seer.smart_assignment.eval_sample_rate": 1.0}),
+        ):
             trigger_smart_assignment(
                 self.group, ActivityType.ASSIGNED, self._assigned_activity(team.id, "team")
             )
@@ -156,7 +162,10 @@ class TriggerSmartAssignmentTest(TestCase):
     def test_user_resolution_records_resolver_as_assignee(self, mock_client_cls: MagicMock) -> None:
         self._wire_client(mock_client_cls)
         resolver = self.create_user()
-        with self.feature("organizations:seer-smart-assignment-run"):
+        with (
+            self.feature("organizations:seer-smart-assignment-run"),
+            self.options({"seer.smart_assignment.eval_sample_rate": 1.0}),
+        ):
             trigger_smart_assignment(
                 self.group,
                 ActivityType.SET_RESOLVED,
@@ -207,6 +216,80 @@ class TriggerSmartAssignmentTest(TestCase):
         ):
             trigger_smart_assignment(
                 self.group, ActivityType.SEER_RCA_STARTED, self._seer_started()
+            )
+
+        assert self._mirrors() == []
+        mock_client_cls.return_value.start_feature_run.assert_not_called()
+
+    @patch(CLIENT_PATH)
+    def test_eval_sample_rate_zero_skips_assignment_dispatch(
+        self, mock_client_cls: MagicMock
+    ) -> None:
+        self._wire_client(mock_client_cls)
+        assignee = self.create_user()
+        GroupAssignee.objects.create(
+            group=self.group, project=self.group.project, user_id=assignee.id
+        )
+        with (
+            self.feature("organizations:seer-smart-assignment-run"),
+            self.options({"seer.smart_assignment.eval_sample_rate": 0.0}),
+        ):
+            trigger_smart_assignment(
+                self.group, ActivityType.ASSIGNED, self._assigned_activity(assignee.id)
+            )
+
+        assert self._mirrors() == []
+        mock_client_cls.return_value.start_feature_run.assert_not_called()
+
+    @patch(CLIENT_PATH)
+    def test_eval_sample_rate_does_not_gate_seer_starts(self, mock_client_cls: MagicMock) -> None:
+        self._wire_client(mock_client_cls)
+        with (
+            self.feature("organizations:seer-smart-assignment-run"),
+            self.options({"seer.smart_assignment.eval_sample_rate": 0.0}),
+        ):
+            trigger_smart_assignment(
+                self.group, ActivityType.SEER_RCA_STARTED, self._seer_started()
+            )
+
+        assert len(self._mirrors()) == 1
+
+    @patch("sentry.seer.smart_assignment.trigger.random.random", return_value=0.05)
+    @patch(CLIENT_PATH)
+    def test_eval_sample_rate_admits_when_roll_is_below_rate(
+        self, mock_client_cls: MagicMock, _mock_random: MagicMock
+    ) -> None:
+        self._wire_client(mock_client_cls)
+        assignee = self.create_user()
+        GroupAssignee.objects.create(
+            group=self.group, project=self.group.project, user_id=assignee.id
+        )
+        with (
+            self.feature("organizations:seer-smart-assignment-run"),
+            self.options({"seer.smart_assignment.eval_sample_rate": 0.10}),
+        ):
+            trigger_smart_assignment(
+                self.group, ActivityType.ASSIGNED, self._assigned_activity(assignee.id)
+            )
+
+        assert len(self._mirrors()) == 1
+
+    @patch("sentry.seer.smart_assignment.trigger.random.random", return_value=0.50)
+    @patch(CLIENT_PATH)
+    def test_eval_sample_rate_rejects_when_roll_is_at_or_above_rate(
+        self, mock_client_cls: MagicMock, _mock_random: MagicMock
+    ) -> None:
+        self._wire_client(mock_client_cls)
+        assignee = self.create_user()
+        GroupAssignee.objects.create(
+            group=self.group, project=self.group.project, user_id=assignee.id
+        )
+        with (
+            self.feature("organizations:seer-smart-assignment-run"),
+            self.options({"seer.smart_assignment.eval_sample_rate": 0.10}),
+        ):
+            trigger_smart_assignment(
+                self.group, ActivityType.ASSIGNED, self._assigned_activity(assignee.id)
             )
 
         assert self._mirrors() == []
@@ -326,7 +409,10 @@ class TriggerSmartAssignmentTest(TestCase):
             group=self.group, project=self.group.project, team=team
         )
         human = self.create_user()
-        with self.feature("organizations:seer-smart-assignment-run"):
+        with (
+            self.feature("organizations:seer-smart-assignment-run"),
+            self.options({"seer.smart_assignment.eval_sample_rate": 1.0}),
+        ):
             trigger_smart_assignment(
                 self.group,
                 ActivityType.ASSIGNED,


### PR DESCRIPTION
(I'm not sure how our `feat(thingy)` nomenclature is defined, but I think `smart-assignment` deserves its own?!)

In preparation for rolling Smart Assignment out to all ~2400 Seer customers (from the current ~400), I did some math to balance daily spend and statistical significance of our scored runs. Basically, we always want to run on `SEER_*` activities that _need_ a suggested assignee (and thus aren't likely to give us a ground truth to score against), but for `SET_RESOLVED_*` and `ASSIGNED` activities (which give us a guaranteed ground truth but are only used for internal scoring) we can run them about 10% of the time and still get the data we need.

This will cost us about $100/day at current costs per run ($0.10), but the global cap increase will set the max spend per day at about $200. An increase in the per-org cap also just ensures we're preventing one customer breaking SA for everyone else, but we should never hit that.

I'll be adding datadog monitors for when we hit the daily caps--turns out we WERE hitting them, before #121368 significantly reduced the number of (useless) SA runs. This change will further reduce our number of daily runs by only running on 10% of resolved/assigned activities, though we'll counteract that by 6x-ing the number of enabled orgs.

Resolves ISWF-3269