### PR TITLE
feat(aci): Add ability to select assignee when creating or editing alert

### DIFF
--- a/static/app/views/automations/components/automationForm.tsx
+++ b/static/app/views/automations/components/automationForm.tsx
@@ -12,6 +12,7 @@ import type {Automation} from 'sentry/types/workflowEngine/automations';
 import {AutomationBuilder} from 'sentry/views/automations/components/automationBuilder';
 import {EditConnectedMonitors} from 'sentry/views/automations/components/editConnectedMonitors';
 import {ActionThrottleSelectField} from 'sentry/views/automations/components/forms/actionThrottleSelectField';
+import {AssigneeSelectorField} from 'sentry/views/automations/components/forms/assigneeSelectorField';
 import {useSetAutomaticAutomationName} from 'sentry/views/automations/components/forms/useSetAutomaticAutomationName';
 
 export function AutomationForm({model}: {model: FormModel}) {
@@ -37,6 +38,11 @@ export function AutomationForm({model}: {model: FormModel}) {
           description={t('Only get alerted on Issues from these environments.')}
         >
           <EnvironmentSelector />
+        </FormSection>
+      </Card>
+      <Card>
+        <FormSection title={t('Assignee')}>
+          <AssigneeSelectorField />
         </FormSection>
       </Card>
       <Card>

--- a/static/app/views/automations/components/automationFormData.tsx
+++ b/static/app/views/automations/components/automationFormData.tsx
@@ -90,7 +90,7 @@ export function getNewAutomationData({
     },
     detectorIds: data.detectorIds,
     enabled: data.enabled,
-    owner: data.owner ?? null,
+    owner: data.owner,
   };
 }
 

--- a/static/app/views/automations/components/forms/assigneeSelectorField.tsx
+++ b/static/app/views/automations/components/forms/assigneeSelectorField.tsx
@@ -1,0 +1,29 @@
+import styled from '@emotion/styled';
+
+import {SentryMemberTeamSelectorField} from 'sentry/components/forms/fields/sentryMemberTeamSelectorField';
+import {t} from 'sentry/locale';
+
+/**
+ * The assignee is purely an organizational tool — it has no effect on when the
+ * alert fires or who it notifies.
+ */
+export function AssigneeSelectorField() {
+  return (
+    <EmbeddedMemberTeamSelectorField
+      name="owner"
+      label={t('Assign')}
+      placeholder={t('Select a member or team')}
+      help={t(
+        "Make it easier to search through your organization's alerts by assigning a user or team. This has no effect on when the alert fires or who it notifies."
+      )}
+      inline={false}
+      flexibleControlStateSize
+    />
+  );
+}
+
+const EmbeddedMemberTeamSelectorField = styled(SentryMemberTeamSelectorField)`
+  padding: 0;
+  font-weight: ${p => p.theme.font.weight.sans.regular};
+  text-transform: none;
+`;

--- a/static/app/views/automations/edit.spec.tsx
+++ b/static/app/views/automations/edit.spec.tsx
@@ -253,7 +253,7 @@ describe('EditAutomation', () => {
     render(<AutomationEdit />, {organization});
 
     await selectEvent.select(
-      screen.getByRole('textbox', {name: 'Assign'}),
+      await screen.findByRole('textbox', {name: 'Assign'}),
       `#${team.slug}`
     );
 

--- a/static/app/views/automations/edit.spec.tsx
+++ b/static/app/views/automations/edit.spec.tsx
@@ -1,5 +1,6 @@
 import {ActionFilterFixture, AutomationFixture} from 'sentry-fixture/automations';
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {TeamFixture} from 'sentry-fixture/team';
 
 import {
   render,
@@ -9,7 +10,9 @@ import {
   waitFor,
   within,
 } from 'sentry-test/reactTestingLibrary';
+import {selectEvent} from 'sentry-test/selectEvent';
 
+import {OrganizationStore} from 'sentry/stores/organizationStore';
 import {DataConditionGroupLogicType} from 'sentry/types/workflowEngine/dataConditions';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useParams} from 'sentry/utils/useParams';
@@ -21,9 +24,27 @@ jest.mock('sentry/utils/analytics');
 describe('EditAutomation', () => {
   const automation = AutomationFixture();
   const organization = OrganizationFixture();
+  const team = TeamFixture({id: '2', slug: 'team-slug'});
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();
+
+    // useTeams (via the assignee selector) reads the organization from the store
+    OrganizationStore.init();
+    OrganizationStore.onUpdate(organization, {replace: true});
+
+    // Members and teams for the assignee selector
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/members/`,
+      method: 'GET',
+      body: [],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/teams/`,
+      method: 'GET',
+      body: [team],
+    });
 
     // Mock the GET request to fetch automation data
     MockApiClient.addMockResponse({
@@ -220,5 +241,57 @@ describe('EditAutomation', () => {
         `/organizations/${organization.slug}/monitors/alerts/${automation.id}/`
       )
     );
+  });
+
+  it('updates the assignee', async () => {
+    const mockUpdateAutomation = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/workflows/${automation.id}/`,
+      method: 'PUT',
+      body: automation,
+    });
+
+    render(<AutomationEdit />, {organization});
+
+    await selectEvent.select(
+      screen.getByRole('textbox', {name: 'Assign'}),
+      `#${team.slug}`
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Save'}));
+
+    await waitFor(() => {
+      expect(mockUpdateAutomation).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          data: expect.objectContaining({owner: `team:${team.id}`}),
+        })
+      );
+    });
+  });
+
+  it('preserves the existing assignee when it is not edited', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/workflows/${automation.id}/`,
+      method: 'GET',
+      body: AutomationFixture({owner: `team:${team.id}`}),
+    });
+    const mockUpdateAutomation = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/workflows/${automation.id}/`,
+      method: 'PUT',
+      body: automation,
+    });
+
+    render(<AutomationEdit />, {organization});
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Save'}));
+
+    await waitFor(() => {
+      expect(mockUpdateAutomation).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          data: expect.objectContaining({owner: `team:${team.id}`}),
+        })
+      );
+    });
   });
 });

--- a/static/app/views/automations/new.spec.tsx
+++ b/static/app/views/automations/new.spec.tsx
@@ -15,6 +15,7 @@ import {selectEvent} from 'sentry-test/selectEvent';
 
 import * as indicators from 'sentry/actionCreators/indicator';
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
+import {OrganizationStore} from 'sentry/stores/organizationStore';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import type {Action} from 'sentry/types/workflowEngine/actions';
 import {ActionGroup, ActionType} from 'sentry/types/workflowEngine/actions';
@@ -37,6 +38,10 @@ describe('AutomationNewSettings', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     MockApiClient.clearMockResponses();
+
+    // useTeams (via the assignee selector) reads the organization from the store
+    OrganizationStore.init();
+    OrganizationStore.onUpdate(organization, {replace: true});
 
     // Available actions (include Slack with a default integration)
     MockApiClient.addMockResponse({
@@ -188,6 +193,13 @@ describe('AutomationNewSettings', () => {
       body: [mockMember],
     });
 
+    // Teams for the assignee selector
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/teams/`,
+      method: 'GET',
+      body: [],
+    });
+
     // Detectors list used by EditConnectedMonitors inside the form
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/detectors/`,
@@ -217,6 +229,9 @@ describe('AutomationNewSettings', () => {
         location: {pathname: '/', query: {connectedIds: '123'}},
       },
     });
+
+    // Select an assignee
+    await selectEvent.select(screen.getByRole('textbox', {name: 'Assign'}), 'Moo Deng');
 
     // Add an action filter (tagged event)
     await selectEvent.select(
@@ -300,7 +315,7 @@ describe('AutomationNewSettings', () => {
             config: {frequency: 0},
             detectorIds: ['123'],
             enabled: true,
-            owner: null,
+            owner: 'user:1',
           },
         })
       )


### PR DESCRIPTION
Adds the ability to assign an alert in the new / edit form of the alert

<img width="1317" height="511" alt="image" src="https://github.com/user-attachments/assets/b86c8111-28ed-419d-b5ea-69d92731c4ad" />
