### PR TITLE
feat(aci): Show alert assignee in details view

### DIFF
--- a/static/app/views/automations/detail.tsx
+++ b/static/app/views/automations/detail.tsx
@@ -180,7 +180,7 @@ function AutomationDetailContent({automation}: {automation: Automation}) {
                   <InfoTip
                     size="sm"
                     title={t(
-                      'Used to organize Alerts in your organization.This has no effect on when the alert fires or who it notifies.'
+                      'Used to organize Alerts in your organization. This has no effect on when the alert fires or who it notifies.'
                     )}
                   />
                 </Flex>

--- a/static/app/views/automations/detail.tsx
+++ b/static/app/views/automations/detail.tsx
@@ -180,7 +180,7 @@ function AutomationDetailContent({automation}: {automation: Automation}) {
                   <InfoTip
                     size="sm"
                     title={t(
-                      'This has no effect on when the alert fires or who it notifies. It is purely an organizational tool.'
+                      'Used to organize Alerts in your organization.This has no effect on when the alert fires or who it notifies.'
                     )}
                   />
                 </Flex>

--- a/static/app/views/automations/detail.tsx
+++ b/static/app/views/automations/detail.tsx
@@ -2,6 +2,7 @@ import {Fragment, useState} from 'react';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Button, LinkButton} from '@sentry/scraps/button';
+import {InfoTip} from '@sentry/scraps/info';
 import {Flex} from '@sentry/scraps/layout';
 
 import {addSuccessMessage} from 'sentry/actionCreators/indicator';
@@ -31,6 +32,7 @@ import {useParams} from 'sentry/utils/useParams';
 import {useUserFromId} from 'sentry/utils/useUserFromId';
 import {AutomationFeedbackButton} from 'sentry/views/automations/components/automationFeedbackButton';
 import {AutomationHistoryList} from 'sentry/views/automations/components/automationHistoryList';
+import {AssigneeCell} from 'sentry/views/automations/components/automationListTable/assigneeCell';
 import {AutomationStatsChart} from 'sentry/views/automations/components/automationStatsChart';
 import {ConditionsPanel} from 'sentry/views/automations/components/conditionsPanel';
 import {ConnectedMonitorsList} from 'sentry/views/automations/components/connectedMonitorsList';
@@ -170,6 +172,25 @@ function AutomationDetailContent({automation}: {automation: Automation}) {
             </DetailSection>
             <DetailSection title={t('Environment')}>
               {automation.environment || t('All environments')}
+            </DetailSection>
+            <DetailSection
+              title={
+                <Flex as="span" align="center" gap="xs">
+                  {t('Assignee')}
+                  <InfoTip
+                    size="sm"
+                    title={t(
+                      'This has no effect on when the alert fires or who it notifies. It is purely an organizational tool.'
+                    )}
+                  />
+                </Flex>
+              }
+            >
+              {automation.owner ? (
+                <AssigneeCell owner={automation.owner} />
+              ) : (
+                t('Unassigned')
+              )}
             </DetailSection>
             <DetailSection title={t('Throttling')}>
               {automation.config.frequency


### PR DESCRIPTION
Show the alert in the detail view with the tooltip to prevent confusion

This is its own PR specifically if any UX discussions come up

<img width="182" height="74" alt="image" src="https://github.com/user-attachments/assets/4fade922-6628-4b95-aea4-676eaaf460a0" />

<img width="188" height="90" alt="image" src="https://github.com/user-attachments/assets/e72064ff-ee5e-4303-a0dd-559be0ad37d6" />

<img width="276" height="144" alt="image" src="https://github.com/user-attachments/assets/634085d3-716b-4e0b-8189-860d5213258a" />