### PR TITLE
feat(preprod): Log snapshot manifest payload size

### DIFF
--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
@@ -833,8 +833,10 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
             # Write manifest inside the transaction so that a failed objectstore
             # write rolls back the DB records, ensuring both succeed or neither does.
             session = get_preprod_session(project.organization_id, project.id)
-            manifest_json = manifest.json(exclude_none=True)
-            session.put(manifest_json.encode(), key=manifest_key)
+            manifest_bytes = manifest.json(exclude_none=True).encode()
+            manifest_size_bytes = len(manifest_bytes)
+            session.put(manifest_bytes, key=manifest_key)
+            del manifest_bytes
 
         logger.info(
             "Created preprod artifact and stored snapshot manifest",
@@ -846,6 +848,7 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
                 "head_sha": head_sha,
                 "manifest_key": manifest_key,
                 "image_count": len(images),
+                "manifest_size_bytes": manifest_size_bytes,
             },
         )
 

--- a/src/sentry/preprod/snapshots/zip_tasks.py
+++ b/src/sentry/preprod/snapshots/zip_tasks.py
@@ -162,12 +162,13 @@ def build_snapshot_images_zip(
                 extra={"preprod_artifact_id": artifact_id, "key": key},
             )
         else:
-            manifest = _load_manifest(session, manifest_key)
+            manifest, manifest_size_bytes = _load_manifest(session, manifest_key)
             logger.info(
                 "preprod_snapshot_zip.manifest_loaded",
                 extra={
                     "preprod_artifact_id": artifact_id,
                     "image_count": len(manifest.images),
+                    "manifest_size_bytes": manifest_size_bytes,
                 },
             )
             with NamedTemporaryFile() as tmp:
@@ -221,12 +222,16 @@ def build_snapshot_images_zip(
     _send_archive_email(organization, user_id, artifact_id, ready=True)
 
 
-def _load_manifest(session: Session, manifest_key: str) -> SnapshotManifest:
+def _load_manifest(session: Session, manifest_key: str) -> tuple[SnapshotManifest, int]:
+    """Return the validated manifest and its original objectstore payload size in bytes."""
     response = session.get(manifest_key)
     if response is None:
         raise FileNotFoundError("Manifest does not exist in objectstore")
     try:
-        manifest_data = orjson.loads(response.payload.read())
+        manifest_bytes = response.payload.read()
+        manifest_size_bytes = len(manifest_bytes)
+        manifest_data = orjson.loads(manifest_bytes)
+        del manifest_bytes
     finally:
         response.payload.close()
-    return SnapshotManifest(**manifest_data)
+    return SnapshotManifest(**manifest_data), manifest_size_bytes


### PR DESCRIPTION
Log the size of the snapshot manifest in a couple spots to evaluate potential impact of returning it in the snapshot archive payload.

Refs [EME-1246](https://linear.app/getsentry/issue/EME-1246/return-manifestjson-when-downloading-snapshots)
