### PR TITLE
fix(issue-stream): remove progress sort option

### DIFF
--- a/static/app/views/issueList/actions/sortOptions.tsx
+++ b/static/app/views/issueList/actions/sortOptions.tsx
@@ -65,9 +65,6 @@ export function IssueListSortOptions({
   // The trigger badge announces the Recommended default. A stored sort means
   // the user has already made an explicit choice, so stop announcing.
   const hasChosenSort = getStoredIssueSort(organization.slug) !== null;
-  const hasProgressSort =
-    organization.features.includes('issue-stream-progress-sort') ||
-    sort === IssueSortOptions.PROGRESS;
   // The explicit v1/v2 sort values are URL-only escape hatches for pinning one of
   // the two recommended scorers; the dropdown just shows them as Recommended.
   const isPinnedRecommended =
@@ -90,7 +87,6 @@ export function IssueListSortOptions({
     IssueSortOptions.TRENDS,
     IssueSortOptions.FREQ,
     IssueSortOptions.USER,
-    ...(hasProgressSort ? [IssueSortOptions.PROGRESS] : []),
   ];
 
   return (

--- a/static/app/views/issueList/issueListCommandPaletteActions.tsx
+++ b/static/app/views/issueList/issueListCommandPaletteActions.tsx
@@ -285,9 +285,6 @@ function SortActions({
     organization.features.includes('issue-stream-recommended-sort') ||
     organization.features.includes('issue-stream-recommended-sort-default') ||
     sort === IssueSortOptions.RECOMMENDED;
-  const hasProgressSort =
-    organization.features.includes('issue-stream-progress-sort') ||
-    sort === IssueSortOptions.PROGRESS;
   const sortKeys = [
     ...(hasRecommendedSort ? [IssueSortOptions.RECOMMENDED] : []),
     ...(FOR_REVIEW_QUERIES.includes(query) ? [IssueSortOptions.INBOX] : []),
@@ -296,7 +293,6 @@ function SortActions({
     IssueSortOptions.TRENDS,
     IssueSortOptions.FREQ,
     IssueSortOptions.USER,
-    ...(hasProgressSort ? [IssueSortOptions.PROGRESS] : []),
   ];
 
   return (


### PR DESCRIPTION
Remove "progress" from the issue stream sort selector, now that we are no longer using this sort in the stream