### PR TITLE
fix(auto_ongoing): Don't tag metric with count

### DIFF
--- a/src/sentry/tasks/auto_ongoing_issues.py
+++ b/src/sentry/tasks/auto_ongoing_issues.py
@@ -73,12 +73,6 @@ def schedule_auto_transition_issues_new_to_ongoing(
     to be updated in a single run. However, we expect every instantiation of this task
     to chip away at the backlog of Groups and eventually update all the eligible groups.
     """
-    total_count = 0
-
-    def get_total_count(results):
-        nonlocal total_count
-        total_count += len(results)
-
     first_seen_lte_datetime = datetime.fromtimestamp(first_seen_lte, timezone.utc)
     base_queryset = Group.objects.filter(
         status=GroupStatus.UNRESOLVED,
@@ -95,18 +89,19 @@ def schedule_auto_transition_issues_new_to_ongoing(
         extra=logger_extra,
     )
 
+    scheduled = 0
     with start_span(name="iterate_chunked_group_ids"):
         for groups in chunked(
             RangeQuerySetWrapper(
                 base_queryset,
                 step=ITERATOR_CHUNK,
                 limit=_schedule_limit(),
-                callbacks=[get_total_count],
                 order_by="first_seen",
                 override_unique_safety_check=True,
             ),
             ITERATOR_CHUNK,
         ):
+            scheduled += len(groups)
             run_auto_transition_issues_new_to_ongoing.delay(
                 group_ids=[group.id for group in groups],
             )
@@ -114,7 +109,7 @@ def schedule_auto_transition_issues_new_to_ongoing(
     metrics.incr(
         "sentry.tasks.schedule_auto_transition_issues_new_to_ongoing.executed",
         sample_rate=1.0,
-        tags={"hit_limit": str(total_count >= _schedule_limit()).lower()},
+        tags={"hit_limit": str(scheduled >= _schedule_limit()).lower()},
     )
 
 
@@ -161,12 +156,6 @@ def schedule_auto_transition_issues_regressed_to_ongoing(
     to be updated in a single run. However, we expect every instantiation of this task
     to chip away at the backlog of Groups and eventually update all the eligible groups.
     """
-    total_count = 0
-
-    def get_total_count(results):
-        nonlocal total_count
-        total_count += len(results)
-
     date_threshold = datetime.fromtimestamp(date_added_lte, timezone.utc)
 
     # Use a subquery to get the most recent REGRESSED history date for each group.
@@ -191,6 +180,7 @@ def schedule_auto_transition_issues_regressed_to_ongoing(
         )
     )
 
+    scheduled = 0
     with start_span(name="iterate_chunked_group_ids"):
         for group_ids_with_regressed_history in chunked(
             RangeQuerySetWrapper(
@@ -198,10 +188,10 @@ def schedule_auto_transition_issues_regressed_to_ongoing(
                 step=ITERATOR_CHUNK,
                 limit=_schedule_limit(),
                 result_value_getter=lambda item: item,
-                callbacks=[get_total_count],
             ),
             ITERATOR_CHUNK,
         ):
+            scheduled += len(group_ids_with_regressed_history)
             run_auto_transition_issues_regressed_to_ongoing.delay(
                 group_ids=group_ids_with_regressed_history,
             )
@@ -209,7 +199,7 @@ def schedule_auto_transition_issues_regressed_to_ongoing(
     metrics.incr(
         "sentry.tasks.schedule_auto_transition_issues_regressed_to_ongoing.executed",
         sample_rate=1.0,
-        tags={"hit_limit": str(total_count >= _schedule_limit()).lower()},
+        tags={"hit_limit": str(scheduled >= _schedule_limit()).lower()},
     )
 
 
@@ -256,14 +246,6 @@ def schedule_auto_transition_issues_escalating_to_ongoing(
     to be updated in a single run. However, we expect every instantiation of this task
     to chip away at the backlog of Groups and eventually update all the eligible groups.
     """
-    total_count = 0
-
-    def get_total_count(results):
-        nonlocal total_count
-        total_count += len(results)
-
-    from django.db.models import Max, OuterRef, Subquery
-
     date_threshold = datetime.fromtimestamp(date_added_lte, timezone.utc)
 
     # Use a subquery to get the most recent ESCALATING history date for each group.
@@ -288,6 +270,7 @@ def schedule_auto_transition_issues_escalating_to_ongoing(
         )
     )
 
+    scheduled = 0
     with start_span(name="iterate_chunked_group_ids"):
         for new_group_ids in chunked(
             RangeQuerySetWrapper(
@@ -295,10 +278,10 @@ def schedule_auto_transition_issues_escalating_to_ongoing(
                 step=ITERATOR_CHUNK,
                 limit=_schedule_limit(),
                 result_value_getter=lambda item: item,
-                callbacks=[get_total_count],
             ),
             ITERATOR_CHUNK,
         ):
+            scheduled += len(new_group_ids)
             run_auto_transition_issues_escalating_to_ongoing.delay(
                 group_ids=new_group_ids,
             )
@@ -306,7 +289,7 @@ def schedule_auto_transition_issues_escalating_to_ongoing(
     metrics.incr(
         "sentry.tasks.schedule_auto_transition_issues_escalating_to_ongoing.executed",
         sample_rate=1.0,
-        tags={"hit_limit": str(total_count >= _schedule_limit()).lower()},
+        tags={"hit_limit": str(scheduled >= _schedule_limit()).lower()},
     )
 
 

--- a/src/sentry/tasks/auto_ongoing_issues.py
+++ b/src/sentry/tasks/auto_ongoing_issues.py
@@ -22,6 +22,10 @@ ITERATOR_CHUNK = 100
 CHILD_TASK_COUNT = 250
 
 
+def _schedule_limit() -> int:
+    return ITERATOR_CHUNK * CHILD_TASK_COUNT
+
+
 @instrumented_task(
     name="sentry.tasks.schedule_auto_transition_to_ongoing",
     namespace=issues_tasks,
@@ -96,7 +100,7 @@ def schedule_auto_transition_issues_new_to_ongoing(
             RangeQuerySetWrapper(
                 base_queryset,
                 step=ITERATOR_CHUNK,
-                limit=ITERATOR_CHUNK * CHILD_TASK_COUNT,
+                limit=_schedule_limit(),
                 callbacks=[get_total_count],
                 order_by="first_seen",
                 override_unique_safety_check=True,
@@ -110,7 +114,7 @@ def schedule_auto_transition_issues_new_to_ongoing(
     metrics.incr(
         "sentry.tasks.schedule_auto_transition_issues_new_to_ongoing.executed",
         sample_rate=1.0,
-        tags={"count": total_count},
+        tags={"hit_limit": str(total_count >= _schedule_limit()).lower()},
     )
 
 
@@ -192,7 +196,7 @@ def schedule_auto_transition_issues_regressed_to_ongoing(
             RangeQuerySetWrapper(
                 base_queryset.values_list("id", flat=True),
                 step=ITERATOR_CHUNK,
-                limit=ITERATOR_CHUNK * CHILD_TASK_COUNT,
+                limit=_schedule_limit(),
                 result_value_getter=lambda item: item,
                 callbacks=[get_total_count],
             ),
@@ -205,7 +209,7 @@ def schedule_auto_transition_issues_regressed_to_ongoing(
     metrics.incr(
         "sentry.tasks.schedule_auto_transition_issues_regressed_to_ongoing.executed",
         sample_rate=1.0,
-        tags={"count": total_count},
+        tags={"hit_limit": str(total_count >= _schedule_limit()).lower()},
     )
 
 
@@ -289,7 +293,7 @@ def schedule_auto_transition_issues_escalating_to_ongoing(
             RangeQuerySetWrapper(
                 base_queryset.values_list("id", flat=True),
                 step=ITERATOR_CHUNK,
-                limit=ITERATOR_CHUNK * CHILD_TASK_COUNT,
+                limit=_schedule_limit(),
                 result_value_getter=lambda item: item,
                 callbacks=[get_total_count],
             ),
@@ -302,7 +306,7 @@ def schedule_auto_transition_issues_escalating_to_ongoing(
     metrics.incr(
         "sentry.tasks.schedule_auto_transition_issues_escalating_to_ongoing.executed",
         sample_rate=1.0,
-        tags={"count": total_count},
+        tags={"hit_limit": str(total_count >= _schedule_limit()).lower()},
     )
 
 

--- a/tests/sentry/tasks/test_auto_ongoing_issues.py
+++ b/tests/sentry/tasks/test_auto_ongoing_issues.py
@@ -177,19 +177,19 @@ class ScheduleAutoNewOngoingIssuesTest(TestCase):
         mock_metrics_incr.assert_any_call(
             "sentry.tasks.schedule_auto_transition_issues_new_to_ongoing.executed",
             sample_rate=1.0,
-            tags={"count": 100},
+            tags={"hit_limit": "true"},
         )
 
         mock_metrics_incr.assert_any_call(
             "sentry.tasks.schedule_auto_transition_issues_regressed_to_ongoing.executed",
             sample_rate=1.0,
-            tags={"count": 0},
+            tags={"hit_limit": "false"},
         )
 
         mock_metrics_incr.assert_any_call(
             "sentry.tasks.schedule_auto_transition_issues_escalating_to_ongoing.executed",
             sample_rate=1.0,
-            tags={"count": 0},
+            tags={"hit_limit": "false"},
         )
 
     @freeze_time("2023-07-12 18:40:00Z")
@@ -330,19 +330,19 @@ class ScheduleAutoRegressedOngoingIssuesTest(TestCase):
         mock_metrics_incr.assert_any_call(
             "sentry.tasks.schedule_auto_transition_issues_new_to_ongoing.executed",
             sample_rate=1.0,
-            tags={"count": 0},
+            tags={"hit_limit": "false"},
         )
 
         mock_metrics_incr.assert_any_call(
             "sentry.tasks.schedule_auto_transition_issues_regressed_to_ongoing.executed",
             sample_rate=1.0,
-            tags={"count": 100},
+            tags={"hit_limit": "true"},
         )
 
         mock_metrics_incr.assert_any_call(
             "sentry.tasks.schedule_auto_transition_issues_escalating_to_ongoing.executed",
             sample_rate=1.0,
-            tags={"count": 0},
+            tags={"hit_limit": "false"},
         )
 
     @freeze_time("2023-07-12 18:40:00Z")
@@ -495,17 +495,17 @@ class ScheduleAutoEscalatingOngoingIssuesTest(TestCase):
         mock_metrics_incr.assert_any_call(
             "sentry.tasks.schedule_auto_transition_issues_new_to_ongoing.executed",
             sample_rate=1.0,
-            tags={"count": 0},
+            tags={"hit_limit": "false"},
         )
 
         mock_metrics_incr.assert_any_call(
             "sentry.tasks.schedule_auto_transition_issues_regressed_to_ongoing.executed",
             sample_rate=1.0,
-            tags={"count": 0},
+            tags={"hit_limit": "false"},
         )
 
         mock_metrics_incr.assert_any_call(
             "sentry.tasks.schedule_auto_transition_issues_escalating_to_ongoing.executed",
             sample_rate=1.0,
-            tags={"count": 100},
+            tags={"hit_limit": "true"},
         )


### PR DESCRIPTION
'count' isn't a good tag; too high cardinality, and hard to work with.
Using 'amount=' would work, but would fundamentally change this metric, which is currently doing something useful by precisely counting task executions scheduled.
Instead, we tag with whether it consumed the full amount allowed, letting is also track whether we're backlogged.
