### PR TITLE
feat(issues): Expose delegated PR attribution agent

### DIFF
--- a/src/sentry/api/serializers/models/pullrequest.py
+++ b/src/sentry/api/serializers/models/pullrequest.py
@@ -17,6 +17,7 @@ from sentry.models.commitauthor import CommitAuthor
 from sentry.models.pullrequest import (
     PullRequest,
     PullRequestAttribution,
+    PullRequestAttributionSignalType,
     PullRequestLifecycleState,
 )
 from sentry.models.repository import Repository
@@ -51,12 +52,24 @@ class PullRequestSerializerResponse(TypedDict):
     externalUrl: str
 
 
+LinkedPullRequestAttributionAgent = Literal["cursor", "github_copilot", "claude_code", "unknown"]
+
+
 class LinkedPullRequestSeerAttributionResponse(TypedDict):
     type: Literal["seer"]
     id: Literal["seer"]
+    agent: LinkedPullRequestAttributionAgent | None
 
 
 LinkedPullRequestAttributionResponse = LinkedPullRequestSeerAttributionResponse
+
+
+DELEGATED_AGENT_BY_SIGNAL_TYPE: dict[str, LinkedPullRequestAttributionAgent] = {
+    PullRequestAttributionSignalType.SEER_DELEGATED_CURSOR: "cursor",
+    PullRequestAttributionSignalType.SEER_DELEGATED_GITHUB_COPILOT: "github_copilot",
+    PullRequestAttributionSignalType.SEER_DELEGATED_CLAUDE_CODE: "claude_code",
+    PullRequestAttributionSignalType.SEER_DELEGATED_UNKNOWN: "unknown",
+}
 
 
 class LinkedPullRequestResponse(PullRequestSerializerResponse):
@@ -117,12 +130,22 @@ class PullRequestSerializer(Serializer[PullRequestSerializerResponse]):
 def _serialize_attribution(
     attributions: Sequence[PullRequestAttribution],
 ) -> LinkedPullRequestAttributionResponse | None:
+    signal_types = {attribution.signal_type for attribution in attributions}
+    for signal_type, agent in DELEGATED_AGENT_BY_SIGNAL_TYPE.items():
+        if signal_type in signal_types:
+            return {
+                "type": "seer",
+                "id": "seer",
+                "agent": agent,
+            }
+
     if not any(is_seer_attribution(attribution) for attribution in attributions):
         return None
 
     return {
         "type": "seer",
         "id": "seer",
+        "agent": None,
     }
 
 

--- a/tests/sentry/issues/endpoints/test_group_pull_requests.py
+++ b/tests/sentry/issues/endpoints/test_group_pull_requests.py
@@ -290,14 +290,15 @@ class GroupPullRequestsEndpointTest(APITestCase):
         delegated_pull_request, _ = self.create_linked_pull_request(key="1")
         PullRequestAttribution.objects.create(
             pull_request=delegated_pull_request,
-            signal_type=PullRequestAttributionSignalType.MCP,
-            source=PullRequestAttributionSource.WEBHOOK_DATA,
-        )
-        PullRequestAttribution.objects.create(
-            pull_request=delegated_pull_request,
             signal_type=PullRequestAttributionSignalType.SEER_DELEGATED_CLAUDE_CODE,
             source=PullRequestAttributionSource.SEER_DATA,
         )
+        PullRequestAttribution.objects.create(
+            pull_request=delegated_pull_request,
+            signal_type=PullRequestAttributionSignalType.SENTRY_APP,
+            source=PullRequestAttributionSource.SEER_DATA,
+        )
+
         sentry_app_pull_request, _ = self.create_linked_pull_request(key="2")
         PullRequestAttribution.objects.create(
             pull_request=sentry_app_pull_request,
@@ -319,11 +320,32 @@ class GroupPullRequestsEndpointTest(APITestCase):
         assert attribution_by_id["1"] == {
             "type": "seer",
             "id": "seer",
+            "agent": "claude_code",
         }
         assert attribution_by_id["2"] == {
             "type": "seer",
             "id": "seer",
+            "agent": None,
         }
+
+    def test_ignores_invalid_display_pull_request_attribution(self) -> None:
+        pull_request, _ = self.create_linked_pull_request(key="1")
+        PullRequestAttribution.objects.create(
+            pull_request=pull_request,
+            signal_type=PullRequestAttributionSignalType.SEER_DELEGATED_CURSOR,
+            source=PullRequestAttributionSource.SEER_DATA,
+            is_valid=False,
+        )
+        PullRequestAttribution.objects.create(
+            pull_request=pull_request,
+            signal_type=PullRequestAttributionSignalType.MCP,
+            source=PullRequestAttributionSource.WEBHOOK_DATA,
+        )
+
+        response = self.client.get(self.path)
+
+        assert response.status_code == 200
+        assert response.data["pullRequests"][0]["attribution"] is None
 
     @patch("sentry.issues.endpoints.group_pull_requests.integration_service.get_integration")
     def test_status_derivation_prefers_stored_lifecycle_fields(


### PR DESCRIPTION
Linked pull request attribution currently collapses direct Seer and delegated agent work into the same response.

Adds a backward-compatible agent field so the frontend can render the actual delegated agent. Delegated signals take precedence when both forms are present.

Frontend: https://github.com/getsentry/sentry/pull/121690