### PR TITLE
feat(auto_ongoing_issue): Smooth issue transition load

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1313,6 +1313,14 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Spread child run_auto_transition_issues_* tasks across this many seconds
+# after each schedule tick, to smooth burst load (DB/signals/queues).
+register(
+    "issues.auto_ongoing_issues.child_task_spread_seconds",
+    type=Int,
+    default=120,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 register(
     "issues.backfill_group_action_log.killswitch",
     type=Bool,

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1318,7 +1318,7 @@ register(
 register(
     "issues.auto_ongoing_issues.child_task_spread_seconds",
     type=Int,
-    default=120,
+    default=0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(

--- a/src/sentry/tasks/auto_ongoing_issues.py
+++ b/src/sentry/tasks/auto_ongoing_issues.py
@@ -1,9 +1,11 @@
 import logging
+import time
 from datetime import datetime, timedelta, timezone
 
 from django.db.models import Max, OuterRef, Subquery
 from taskbroker_client.retry import Retry
 
+from sentry import options
 from sentry.issues.ongoing import TRANSITION_AFTER_DAYS, bulk_transition_group_to_ongoing
 from sentry.models.group import Group, GroupStatus
 from sentry.models.grouphistory import GroupHistory, GroupHistoryStatus
@@ -22,6 +24,24 @@ ITERATOR_CHUNK = 100
 CHILD_TASK_COUNT = 250
 
 
+def child_task_countdown(
+    batch_index: int,
+    spread_seconds: int,
+    max_batches: int,
+    elapsed_seconds: float,
+) -> int:
+    """
+    Pure countdown math: land batch `batch_index` evenly across `spread_seconds`
+    from schedule start. `elapsed_seconds` is time already spent paging so slow
+    iterators don't double-delay later batches.
+    """
+    if spread_seconds <= 0 or max_batches <= 1 or batch_index <= 0:
+        return 0
+    capped_index = min(batch_index, max_batches - 1)
+    target_offset = (capped_index * spread_seconds) // (max_batches - 1)
+    return max(0, int(target_offset - elapsed_seconds))
+
+
 def _schedule_limit() -> int:
     return ITERATOR_CHUNK * CHILD_TASK_COUNT
 
@@ -34,9 +54,9 @@ def _schedule_limit() -> int:
 )
 def schedule_auto_transition_to_ongoing() -> None:
     """
-    Triggered by cronjob every minute. This task will spawn subtasks
-    that transition Issues to Ongoing according to their specific
-    criteria.
+    Triggered by cronjob (every few minutes). Spawns schedule subtasks that
+    enqueue run_* child tasks spread over
+    issues.auto_ongoing_issues.child_task_spread_seconds.
     """
     now = datetime.now(tz=timezone.utc)
 
@@ -89,21 +109,31 @@ def schedule_auto_transition_issues_new_to_ongoing(
         extra=logger_extra,
     )
 
+    spread_seconds = max(0, options.get("issues.auto_ongoing_issues.child_task_spread_seconds"))
     scheduled = 0
     with start_span(name="iterate_chunked_group_ids"):
-        for groups in chunked(
-            RangeQuerySetWrapper(
-                base_queryset,
-                step=ITERATOR_CHUNK,
-                limit=_schedule_limit(),
-                order_by="first_seen",
-                override_unique_safety_check=True,
-            ),
-            ITERATOR_CHUNK,
+        started = time.monotonic()
+        for batch_index, groups in enumerate(
+            chunked(
+                RangeQuerySetWrapper(
+                    base_queryset,
+                    step=ITERATOR_CHUNK,
+                    limit=_schedule_limit(),
+                    order_by="first_seen",
+                    override_unique_safety_check=True,
+                ),
+                ITERATOR_CHUNK,
+            )
         ):
             scheduled += len(groups)
-            run_auto_transition_issues_new_to_ongoing.delay(
-                group_ids=[group.id for group in groups],
+            run_auto_transition_issues_new_to_ongoing.apply_async(
+                kwargs={"group_ids": [group.id for group in groups]},
+                countdown=child_task_countdown(
+                    batch_index,
+                    spread_seconds,
+                    CHILD_TASK_COUNT,
+                    time.monotonic() - started,
+                ),
             )
 
     metrics.incr(
@@ -177,20 +207,30 @@ def schedule_auto_transition_issues_regressed_to_ongoing(
         .filter(recent_regressed_history__lte=date_threshold)
     )
 
+    spread_seconds = max(0, options.get("issues.auto_ongoing_issues.child_task_spread_seconds"))
     scheduled = 0
     with start_span(name="iterate_chunked_group_ids"):
-        for group_ids_with_regressed_history in chunked(
-            RangeQuerySetWrapper(
-                base_queryset.values_list("id", flat=True),
-                step=ITERATOR_CHUNK,
-                limit=_schedule_limit(),
-                result_value_getter=lambda item: item,
-            ),
-            ITERATOR_CHUNK,
+        started = time.monotonic()
+        for batch_index, group_ids_with_regressed_history in enumerate(
+            chunked(
+                RangeQuerySetWrapper(
+                    base_queryset.values_list("id", flat=True),
+                    step=ITERATOR_CHUNK,
+                    limit=_schedule_limit(),
+                    result_value_getter=lambda item: item,
+                ),
+                ITERATOR_CHUNK,
+            )
         ):
             scheduled += len(group_ids_with_regressed_history)
-            run_auto_transition_issues_regressed_to_ongoing.delay(
-                group_ids=group_ids_with_regressed_history,
+            run_auto_transition_issues_regressed_to_ongoing.apply_async(
+                kwargs={"group_ids": group_ids_with_regressed_history},
+                countdown=child_task_countdown(
+                    batch_index,
+                    spread_seconds,
+                    CHILD_TASK_COUNT,
+                    time.monotonic() - started,
+                ),
             )
 
     metrics.incr(
@@ -264,20 +304,30 @@ def schedule_auto_transition_issues_escalating_to_ongoing(
         .filter(recent_escalating_history__lte=date_threshold)
     )
 
+    spread_seconds = max(0, options.get("issues.auto_ongoing_issues.child_task_spread_seconds"))
     scheduled = 0
     with start_span(name="iterate_chunked_group_ids"):
-        for new_group_ids in chunked(
-            RangeQuerySetWrapper(
-                base_queryset.values_list("id", flat=True),
-                step=ITERATOR_CHUNK,
-                limit=_schedule_limit(),
-                result_value_getter=lambda item: item,
-            ),
-            ITERATOR_CHUNK,
+        started = time.monotonic()
+        for batch_index, new_group_ids in enumerate(
+            chunked(
+                RangeQuerySetWrapper(
+                    base_queryset.values_list("id", flat=True),
+                    step=ITERATOR_CHUNK,
+                    limit=_schedule_limit(),
+                    result_value_getter=lambda item: item,
+                ),
+                ITERATOR_CHUNK,
+            )
         ):
             scheduled += len(new_group_ids)
-            run_auto_transition_issues_escalating_to_ongoing.delay(
-                group_ids=new_group_ids,
+            run_auto_transition_issues_escalating_to_ongoing.apply_async(
+                kwargs={"group_ids": new_group_ids},
+                countdown=child_task_countdown(
+                    batch_index,
+                    spread_seconds,
+                    CHILD_TASK_COUNT,
+                    time.monotonic() - started,
+                ),
             )
 
     metrics.incr(

--- a/tests/sentry/tasks/test_auto_ongoing_issues.py
+++ b/tests/sentry/tasks/test_auto_ongoing_issues.py
@@ -6,11 +6,38 @@ from sentry.models.activity import Activity
 from sentry.models.group import Group, GroupStatus
 from sentry.models.grouphistory import GroupHistory, GroupHistoryStatus, record_group_history
 from sentry.models.groupinbox import GroupInbox, GroupInboxReason, add_group_to_inbox
-from sentry.tasks.auto_ongoing_issues import schedule_auto_transition_to_ongoing
+from sentry.tasks.auto_ongoing_issues import (
+    child_task_countdown,
+    schedule_auto_transition_to_ongoing,
+)
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.helpers.options import override_options
 from sentry.types.activity import ActivityType
 from sentry.types.group import GroupSubStatus
+
+
+class ChildTaskCountdownTest(TestCase):
+    def test_endpoints(self) -> None:
+        assert child_task_countdown(0, 120, 250, 0) == 0
+        assert child_task_countdown(249, 120, 250, 0) == 120
+
+    def test_monotone_within_spread(self) -> None:
+        previous = -1
+        for batch_index in range(250):
+            countdown = child_task_countdown(batch_index, 120, 250, 0)
+            assert previous <= countdown <= 120
+            previous = countdown
+
+    def test_zero_spread_disables_stagger(self) -> None:
+        assert child_task_countdown(100, 0, 250, 0) == 0
+
+    def test_subtracts_elapsed_query_time(self) -> None:
+        # Target for batch 249 is 120s; 40s already spent iterating → 80s countdown.
+        assert child_task_countdown(249, 120, 250, 40) == 80
+
+    def test_elapsed_beyond_target_is_zero(self) -> None:
+        assert child_task_countdown(10, 120, 250, 999) == 0
 
 
 class ScheduleAutoNewOngoingIssuesTest(TestCase):
@@ -509,3 +536,35 @@ class ScheduleAutoEscalatingOngoingIssuesTest(TestCase):
             sample_rate=1.0,
             tags={"hit_limit": "true"},
         )
+
+
+class ScheduleChildTaskSpreadTest(TestCase):
+    @freeze_time("2023-07-12 18:40:00Z")
+    @mock.patch("sentry.tasks.auto_ongoing_issues.ITERATOR_CHUNK", new=2)
+    @mock.patch("sentry.tasks.auto_ongoing_issues.CHILD_TASK_COUNT", new=50)
+    @override_options({"issues.auto_ongoing_issues.child_task_spread_seconds": 120})
+    def test_new_to_ongoing_child_tasks_use_countdown(self) -> None:
+        now = datetime.now(tz=timezone.utc)
+        project = self.create_project()
+        for _ in range(6):
+            self.create_group(
+                project=project,
+                status=GroupStatus.UNRESOLVED,
+                substatus=GroupSubStatus.NEW,
+                first_seen=now - timedelta(days=TRANSITION_AFTER_DAYS, hours=1),
+            )
+
+        with (
+            self.tasks(),
+            mock.patch(
+                "sentry.tasks.auto_ongoing_issues.run_auto_transition_issues_new_to_ongoing.apply_async"
+            ) as mock_apply_async,
+        ):
+            schedule_auto_transition_to_ongoing()
+
+        assert mock_apply_async.call_count >= 3
+        countdowns = [call.kwargs["countdown"] for call in mock_apply_async.call_args_list]
+        # Fast test DB: elapsed ≈ 0, so countdowns match the pure target offsets.
+        assert countdowns == [child_task_countdown(i, 120, 50, 0) for i in range(len(countdowns))]
+        assert countdowns[0] == 0
+        assert countdowns[-1] > countdowns[0]


### PR DESCRIPTION
Automated issue transitions are run every 5 minutes, and essentially try to schedule all the transitions in their budget immediately. These aren't particularly latency sensitive (just background transitions) and they result in narrow spikes in activity/action logging. These spikes aren't necessary or useful.

This change adds a notion of "spread seconds" to configure how many seconds we want to spread the start of these batches out over, and spreads them essentially linearly, adjusting slightly for query delay.
This should result in fairly even distribution; these tasks being delayed are typically less than 5s, so we're not increasing risk of periodic overlap meaningfully, but since they should be idempotent, that risk is mostly in rarely wasting resources.