### PR TITLE
fix(tests): Keep EAP snuba tests within 30d full-fidelity window

### DIFF
--- a/src/sentry/testutils/helpers/eap.py
+++ b/src/sentry/testutils/helpers/eap.py
@@ -58,7 +58,7 @@ def is_eap_dataset(dataset: str | None) -> bool:
 
 
 def _dataset_from_query(query: Mapping[str, Any]) -> str | None:
-    for key in ("dataset", "itemType", "item_type"):
+    for key in ("dataset", "itemType", "item_type", "data_source"):
         value = query.get(key)
         if value is None:
             continue

--- a/tests/sentry/seer/anomaly_detection/test_store_data.py
+++ b/tests/sentry/seer/anomaly_detection/test_store_data.py
@@ -18,6 +18,8 @@ from tests.sentry.incidents.endpoints.test_organization_alert_rule_index import 
 
 pytestmark = pytest.mark.sentry_metrics
 
+_EAP_SPANS_FREEZE_AT = before_now(hours=1).replace(minute=37, second=0, microsecond=0)
+
 
 def make_event(**kwargs: Any) -> dict[str, Any]:
     result = {
@@ -154,7 +156,7 @@ class AnomalyDetectionStoreDataTest(
         )
         snuba_query = SnubaQuery.objects.get(id=alert_rule.snuba_query_id)
 
-        with freeze_time(before_now(days=2).replace(hour=0, minute=37, second=0, microsecond=0)):
+        with freeze_time(_EAP_SPANS_FREEZE_AT):
             now = datetime.now(UTC)
             time_1_dt = now - timedelta(days=2)
             time_1_ts = time_1_dt.timestamp()

--- a/tests/sentry/testutils/helpers/test_eap.py
+++ b/tests/sentry/testutils/helpers/test_eap.py
@@ -31,6 +31,16 @@ def test_apply_defaults_for_item_type() -> None:
     assert query["statsPeriod"] == EAP_DEFAULT_STATS_PERIOD
 
 
+def test_apply_defaults_for_data_source() -> None:
+    query: dict[str, str] = {"data_source": "spans", "query": 'transaction:["/api/foo/"]'}
+    apply_eap_default_stats_period(query)
+    assert query["statsPeriod"] == EAP_DEFAULT_STATS_PERIOD
+
+    query = {"data_source": "discover"}
+    apply_eap_default_stats_period(query)
+    assert "statsPeriod" not in query
+
+
 def test_apply_defaults_for_eap_path_without_dataset() -> None:
     query: dict[str, str] = {"project": "1"}
     apply_eap_default_stats_period(query, path="/api/0/organizations/org/trace-items/stats/")


### PR DESCRIPTION
## Summary
- Teach `EAPClient` to treat `data_source` like `dataset`/`itemType` so replay-count requests with `data_source=spans` get `statsPeriod=30d` instead of the API 90d default (which Snuba routes to tier 8).
- Anchor the EAP spans anomaly-detection freeze at import-time wall clock so nested `freeze_time(before_now(...))` no longer double-shifts `fetch_historical_data`'s 28d window past Snuba's 30d full-fidelity retention.
- Add unit coverage for the `data_source` heuristic.

## Testing
- `.venv/bin/pytest -q --reuse-db tests/sentry/testutils/helpers/test_eap.py tests/sentry/replays/endpoints/test_organization_replay_count.py::OrganizationReplayCountEndpointTest::test_eap_spans_transaction tests/sentry/replays/endpoints/test_organization_replay_count.py::OrganizationReplayCountEndpointTest::test_eap_spans_multiple_values_rejected tests/sentry/seer/anomaly_detection/test_store_data.py::AnomalyDetectionStoreDataTest::test_anomaly_detection_fetch_historical_data_eap_spans`
- `.venv/bin/prek run -q --files src/sentry/testutils/helpers/eap.py tests/sentry/testutils/helpers/test_eap.py tests/sentry/seer/anomaly_detection/test_store_data.py`

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
