### PR TITLE
ref(ui): Allow abbreviations in camel-cased filenames

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -843,10 +843,17 @@ export default typescript.config([
         {
           case: 'camelCase',
           ignore: [
-            'jest-pegjs-transform\\.js',
-            'jest-environment\\.js',
-            'jest-environment-node\\.js',
-            '/__mocks__/',
+            '^jest-pegjs-transform\\.js$',
+            '^jest-environment\\.js$',
+            '^jest-environment-node\\.js$',
+            // Mocks named after external packages must preserve the package's
+            // kebab-case basename so Jest can resolve them.
+            '^(?:analytics-browser|react-(?:date-range|lazyload))\\.tsx$',
+            // Unicorn changes capitalized abbreviations in camel-cased filenames:
+            // CTA to Cta, SDK to Sdk, and WebGL to WebGl. Keep the conventional
+            // capitalization when the rest of the filename is camel-cased.
+            '^[a-z][a-zA-Z\\d]*[A-Z]{2,}[a-zA-Z\\d]*(?:\\.[a-z\\d]+)+$',
+            '^[A-Z]{2,}[a-zA-Z\\d]*(?:\\.[a-z\\d]+)+$',
             // Shebang scripts can't use an inline disable comment (it must sit
             // on line 1, where the shebang is) and are invoked by their
             // kebab-case names from package.json/CI, so ignore them here.

--- a/static/app/__mocks__/react-date-range.tsx
+++ b/static/app/__mocks__/react-date-range.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import type {CalendarProps, DateRangeProps, Range, RangeKeyDict} from 'react-date-range';
 import moment from 'moment-timezone';
 

--- a/static/app/__mocks__/react-lazyload.tsx
+++ b/static/app/__mocks__/react-lazyload.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 /**
  * Auto-mock of the react-lazyload library for jest
  *

--- a/static/app/components/events/featureFlags/cta/featureFlagCTAContent.tsx
+++ b/static/app/components/events/featureFlags/cta/featureFlagCTAContent.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import {Fragment, useEffect} from 'react';
 import styled from '@emotion/styled';
 

--- a/static/app/components/events/rrwebReplayer/baseRRWebReplayer.tsx
+++ b/static/app/components/events/rrwebReplayer/baseRRWebReplayer.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import {useCallback, useEffect, useRef} from 'react';
 import styled from '@emotion/styled';
 import RRWebPlayer from '@sentry-internal/rrweb-player';

--- a/static/app/components/feedback/feedbackItem/replayInlineCTAPanel.tsx
+++ b/static/app/components/feedback/feedbackItem/replayInlineCTAPanel.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import styled from '@emotion/styled';
 
 import replaysInlineOnboarding from 'sentry-images/spot/replay-onboarding-backend.svg';

--- a/static/app/components/feedbackButton/useFeedbackSDKIntegration.tsx
+++ b/static/app/components/feedbackButton/useFeedbackSDKIntegration.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import {useMemo} from 'react';
 import type * as Sentry from '@sentry/react';
 

--- a/static/app/components/profiling/flamegraph/flamegraphUIFrames.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphUIFrames.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import type {CSSProperties} from 'react';
 import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';

--- a/static/app/components/profiling/flamegraph/flamegraphUIFramesTooltip.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphUIFramesTooltip.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import {Fragment, useMemo} from 'react';
 import type {vec2} from 'gl-matrix';
 

--- a/static/app/components/quietZoneQRCode.tsx
+++ b/static/app/components/quietZoneQRCode.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import type React from 'react';
 import styled from '@emotion/styled';
 import {QRCodeCanvas} from 'qrcode.react';

--- a/static/app/utils/profiling/renderers/UIFramesRenderer.tsx
+++ b/static/app/utils/profiling/renderers/UIFramesRenderer.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import type {mat3, vec2} from 'gl-matrix';
 
 import type {

--- a/static/app/utils/profiling/renderers/UIFramesRenderer2D.tsx
+++ b/static/app/utils/profiling/renderers/UIFramesRenderer2D.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import type {mat3} from 'gl-matrix';
 
 import {colorComponentsToRGBA} from 'sentry/utils/profiling/colors/utils';

--- a/static/app/utils/profiling/renderers/flamegraphRendererWebGL.spec.tsx
+++ b/static/app/utils/profiling/renderers/flamegraphRendererWebGL.spec.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import {vec2} from 'gl-matrix';
 import {ThemeFixture} from 'sentry-fixture/theme';
 

--- a/static/app/utils/profiling/renderers/flamegraphRendererWebGL.tsx
+++ b/static/app/utils/profiling/renderers/flamegraphRendererWebGL.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import * as Sentry from '@sentry/react';
 import type {vec2} from 'gl-matrix';
 import {mat3} from 'gl-matrix';

--- a/static/app/utils/profiling/renderers/uiFramesRendererWebGL.spec.tsx
+++ b/static/app/utils/profiling/renderers/uiFramesRendererWebGL.spec.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import {vec2} from 'gl-matrix';
 import {ThemeFixture} from 'sentry-fixture/theme';
 

--- a/static/app/utils/profiling/renderers/uiFramesRendererWebGL.tsx
+++ b/static/app/utils/profiling/renderers/uiFramesRendererWebGL.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import * as Sentry from '@sentry/react';
 import {mat3} from 'gl-matrix';
 

--- a/static/app/utils/replays/hydrateRRWebRecordingFrames.spec.tsx
+++ b/static/app/utils/replays/hydrateRRWebRecordingFrames.spec.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import {ReplayRecordFixture} from 'sentry-fixture/replayRecord';
 
 import {recordingEndFrame} from 'sentry/utils/replays/hydrateRRWebRecordingFrames';

--- a/static/app/utils/replays/hydrateRRWebRecordingFrames.tsx
+++ b/static/app/utils/replays/hydrateRRWebRecordingFrames.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import type {RecordingFrame} from 'sentry/utils/replays/types';
 import {EventType} from 'sentry/utils/replays/types';
 import type {HydratedReplayRecord} from 'sentry/views/explore/replays/types';

--- a/static/app/utils/string/containsCRLF.ts
+++ b/static/app/utils/string/containsCRLF.ts
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 const CRLF_REGEXP = /[\r\n]/;
 
 export function containsCRLF(value: string) {

--- a/static/app/utils/string/isUUID.spec.tsx
+++ b/static/app/utils/string/isUUID.spec.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import {isUUID} from 'sentry/utils/string/isUUID';
 
 describe('isUUID', () => {

--- a/static/app/utils/string/isUUID.tsx
+++ b/static/app/utils/string/isUUID.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 export function isUUID(uuid: string): boolean {
   const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
   return uuidRegex.test(uuid);

--- a/static/app/utils/string/looksLikeAJSONArray.spec.tsx
+++ b/static/app/utils/string/looksLikeAJSONArray.spec.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import {looksLikeAJSONArray} from './looksLikeAJSONArray';
 
 describe('looksLikeAJSONArray', () => {

--- a/static/app/utils/string/looksLikeAJSONArray.tsx
+++ b/static/app/utils/string/looksLikeAJSONArray.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 /**
  * Check if a string value looks like it could be a JSON-encoded array. This is
  useful for situations where we used JSON strings to store array values because

--- a/static/app/utils/string/looksLikeAJSONObject.spec.tsx
+++ b/static/app/utils/string/looksLikeAJSONObject.spec.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import {looksLikeAJSONObject} from './looksLikeAJSONObject';
 
 describe('looksLikeAJSONObject', () => {

--- a/static/app/utils/string/looksLikeAJSONObject.tsx
+++ b/static/app/utils/string/looksLikeAJSONObject.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 /**
  * Check if a string value looks like it could be a JSON-encoded object. This is
  useful for situations where we used JSON strings to store object values because

--- a/static/app/utils/url/safeURL.spec.tsx
+++ b/static/app/utils/url/safeURL.spec.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import {safeURL} from './safeURL';
 
 describe('safeURL', () => {

--- a/static/app/utils/url/safeURL.tsx
+++ b/static/app/utils/url/safeURL.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 /**
  * Does not throw error on invalid input and returns the parsed URL object
  * if the input is a valid URL, otherwise returns undefined.

--- a/static/app/utils/url/stripURLOrigin.spec.tsx
+++ b/static/app/utils/url/stripURLOrigin.spec.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import {stripURLOrigin} from 'sentry/utils/url/stripURLOrigin';
 
 describe('stripURLOrigin', () => {

--- a/static/app/utils/url/stripURLOrigin.tsx
+++ b/static/app/utils/url/stripURLOrigin.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import {safeURL} from 'sentry/utils/url/safeURL';
 
 /**

--- a/static/app/utils/useRAF.tsx
+++ b/static/app/utils/useRAF.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import {useEffect} from 'react';
 
 export function useRAF(callback: () => unknown, opts?: {enabled: boolean}) {

--- a/static/app/views/app/asyncSDKIntegrationProvider.tsx
+++ b/static/app/views/app/asyncSDKIntegrationProvider.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import {createContext, useContext, useState} from 'react';
 import type {addIntegration} from '@sentry/react';
 

--- a/static/app/views/dashboards/widgetCard/dashboardsMEPContext.tsx
+++ b/static/app/views/dashboards/widgetCard/dashboardsMEPContext.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import type {ReactNode} from 'react';
 import {createContext, useContext, useState} from 'react';
 

--- a/static/app/views/dashboards/widgetCard/widgetLLMContext.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetLLMContext.spec.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import {WidgetFixture} from 'sentry-fixture/widget';
 
 import {DisplayType} from 'sentry/views/dashboards/types';

--- a/static/app/views/dashboards/widgetCard/widgetLLMContext.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetLLMContext.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import {OP_LABELS} from 'sentry/components/searchQueryBuilder/tokens/filter/utils';
 import type {Widget} from 'sentry/views/dashboards/types';
 import {DisplayType} from 'sentry/views/dashboards/types';

--- a/static/app/views/dashboards/widgets/tableWidget/fixtures/sampleHTTPRequestTableData.ts
+++ b/static/app/views/dashboards/widgets/tableWidget/fixtures/sampleHTTPRequestTableData.ts
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import type {TabularData} from 'sentry/views/dashboards/widgets/common/types';
 
 export const sampleHTTPRequestTableData: TabularData = {

--- a/static/app/views/explore/metrics/hooks/useHasMetricUnitsUI.tsx
+++ b/static/app/views/explore/metrics/hooks/useHasMetricUnitsUI.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 export function useHasMetricUnitsUI() {

--- a/static/app/views/explore/releases/list/releaseHealthCTA.tsx
+++ b/static/app/views/explore/releases/list/releaseHealthCTA.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import styled from '@emotion/styled';
 
 import {Alert} from '@sentry/scraps/alert';

--- a/static/app/views/explore/replays/detail/browserOSIcons.tsx
+++ b/static/app/views/explore/replays/detail/browserOSIcons.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 import {PlatformIcon} from 'platformicons';

--- a/static/app/views/explore/replays/list/setupReplaysCTA.spec.tsx
+++ b/static/app/views/explore/replays/list/setupReplaysCTA.spec.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {SetupReplaysCTA} from 'sentry/views/explore/replays/list/replayOnboardingPanel';

--- a/static/app/views/insights/common/utils/hasEAPAlerts.tsx
+++ b/static/app/views/insights/common/utils/hasEAPAlerts.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import type {Organization} from 'sentry/types/organization';
 
 export function deprecateTransactionAlerts(organization: Organization): boolean {

--- a/static/app/views/insights/common/utils/useModuleURL.tsx
+++ b/static/app/views/insights/common/utils/useModuleURL.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {BASE_URL as AGENT_MODELS_BASE_URL} from 'sentry/views/insights/agentModels/settings';

--- a/static/app/views/insights/database/queries/useOutdatedSDKProjects.tsx
+++ b/static/app/views/insights/database/queries/useOutdatedSDKProjects.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import uniqBy from 'lodash/uniqBy';
 
 import {ProjectsStore} from 'sentry/stores/projectsStore';

--- a/static/app/views/insights/database/utils/formatMongoDBQuery.spec.tsx
+++ b/static/app/views/insights/database/utils/formatMongoDBQuery.spec.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import {Fragment} from 'react';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';

--- a/static/app/views/insights/database/utils/formatMongoDBQuery.tsx
+++ b/static/app/views/insights/database/utils/formatMongoDBQuery.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import type {ReactElement} from 'react';
 import * as Sentry from '@sentry/react';
 import {jsonrepair} from 'jsonrepair';

--- a/static/app/views/insights/pages/agents/hooks/useAITrace.tsx
+++ b/static/app/views/insights/pages/agents/hooks/useAITrace.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import {useEffect, useState} from 'react';
 
 import {useApi} from 'sentry/utils/useApi';

--- a/static/app/views/insights/pages/agents/utils/formatLLMCosts.tsx
+++ b/static/app/views/insights/pages/agents/utils/formatLLMCosts.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import {formatDollars} from 'sentry/utils/formatters';
 
 export function formatLLMCosts(cost: string | number | null) {

--- a/static/app/views/insights/pages/mcp/hooks/useShowMCPOnboarding.tsx
+++ b/static/app/views/insights/pages/mcp/hooks/useShowMCPOnboarding.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {getSelectedProjectList} from 'sentry/utils/project/useSelectedProjectsHaveField';
 import {useProjects} from 'sentry/utils/useProjects';

--- a/static/app/views/issueDetails/groupFeatureFlags/flagDrawerCTA.tsx
+++ b/static/app/views/issueDetails/groupFeatureFlags/flagDrawerCTA.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import {useDrawerContentContext} from '@sentry/scraps/drawer';
 
 import {

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiIOAlert.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiIOAlert.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import {Fragment} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';

--- a/static/app/views/performance/newTraceDetails/traceRow/traceEAPSpanRow.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceEAPSpanRow.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import {Fragment} from 'react';
 import {PlatformIcon} from 'platformicons';
 

--- a/static/app/views/performance/newTraceDetails/useIsEAPTraceEnabled.tsx
+++ b/static/app/views/performance/newTraceDetails/useIsEAPTraceEnabled.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 export function useIsEAPTraceEnabled() {

--- a/static/app/views/seerExplorer/contexts/registerLLMContext.tsx
+++ b/static/app/views/seerExplorer/contexts/registerLLMContext.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import type {ComponentType} from 'react';
 import {useContext, useEffect, useId} from 'react';
 

--- a/static/app/views/settings/project/tempest/allowListIPAddresses.tsx
+++ b/static/app/views/settings/project/tempest/allowListIPAddresses.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import {OnboardingCodeSnippet} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCodeSnippet';
 import {t} from 'sentry/locale';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';

--- a/static/gsAdmin/components/changeARRAction.spec.tsx
+++ b/static/gsAdmin/components/changeARRAction.spec.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import {
   render,
   renderGlobalModal,

--- a/static/gsAdmin/components/changeARRAction.tsx
+++ b/static/gsAdmin/components/changeARRAction.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import {Component, Fragment} from 'react';
 
 import {Button, ButtonBar} from '@sentry/scraps/button';

--- a/static/gsAdmin/views/privateAPIs.tsx
+++ b/static/gsAdmin/views/privateAPIs.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import {Fragment, useState} from 'react';
 
 import {Button} from '@sentry/scraps/button';

--- a/static/gsApp/__mocks__/@amplitude/analytics-browser.tsx
+++ b/static/gsApp/__mocks__/@amplitude/analytics-browser.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 const identifyInstance: any = {
   set: jest.fn(() => identifyInstance),
 };

--- a/static/gsApp/components/addEventsCTA.tsx
+++ b/static/gsApp/components/addEventsCTA.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import {useState} from 'react';
 
 import {
@@ -32,7 +31,9 @@ import {trackGetsentryAnalytics} from 'getsentry/utils/trackGetsentryAnalytics';
  *
  */
 export type EventType = {
-  [K in keyof typeof DATA_CATEGORY_INFO]: (typeof DATA_CATEGORY_INFO)[K]['isBilledCategory'] extends true
+  [
+    K in keyof typeof DATA_CATEGORY_INFO
+  ]: (typeof DATA_CATEGORY_INFO)[K]['isBilledCategory'] extends true
     ? (typeof DATA_CATEGORY_INFO)[K]['singular']
     : never;
 }[keyof typeof DATA_CATEGORY_INFO];

--- a/static/gsApp/components/addEventsCTA.tsx
+++ b/static/gsApp/components/addEventsCTA.tsx
@@ -31,9 +31,7 @@ import {trackGetsentryAnalytics} from 'getsentry/utils/trackGetsentryAnalytics';
  *
  */
 export type EventType = {
-  [
-    K in keyof typeof DATA_CATEGORY_INFO
-  ]: (typeof DATA_CATEGORY_INFO)[K]['isBilledCategory'] extends true
+  [K in keyof typeof DATA_CATEGORY_INFO]: (typeof DATA_CATEGORY_INFO)[K]['isBilledCategory'] extends true
     ? (typeof DATA_CATEGORY_INFO)[K]['singular']
     : never;
 }[keyof typeof DATA_CATEGORY_INFO];

--- a/static/gsApp/components/crons/cronsBannerUpgradeCTA.tsx
+++ b/static/gsApp/components/crons/cronsBannerUpgradeCTA.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import {Button, LinkButton} from '@sentry/scraps/button';
 import {useModal} from '@sentry/scraps/modal';
 

--- a/static/gsApp/components/productUnavailableCTA.spec.tsx
+++ b/static/gsApp/components/productUnavailableCTA.spec.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';

--- a/static/gsApp/components/productUnavailableCTA.tsx
+++ b/static/gsApp/components/productUnavailableCTA.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import {useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 

--- a/static/gsApp/components/replayOnboardingCTA.tsx
+++ b/static/gsApp/components/replayOnboardingCTA.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import type {ReactNode} from 'react';
 import {Fragment, useEffect, useState} from 'react';
 import styled from '@emotion/styled';

--- a/static/gsApp/hooks/useAM2ProfilingUpsellModal.tsx
+++ b/static/gsApp/hooks/useAM2ProfilingUpsellModal.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import {useCallback} from 'react';
 
 import {useOrganization} from 'sentry/utils/useOrganization';

--- a/static/gsApp/hooks/useAM2UpsellModal.tsx
+++ b/static/gsApp/hooks/useAM2UpsellModal.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import {useCallback} from 'react';
 
 import {useOrganization} from 'sentry/utils/useOrganization';

--- a/static/gsApp/overrides/firstPartyIntegrationAdditionalCTA.tsx
+++ b/static/gsApp/overrides/firstPartyIntegrationAdditionalCTA.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import {Flex} from '@sentry/scraps/layout';
 
 import type {Integration} from 'sentry/types/integrations';

--- a/static/gsApp/utils/ISO3166codes.ts
+++ b/static/gsApp/utils/ISO3166codes.ts
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 type CountryCode = {
   code: string;
   'country-code': string;

--- a/tests/js/fixtures/sourceMapsDebugIDBundles.ts
+++ b/tests/js/fixtures/sourceMapsDebugIDBundles.ts
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import type {DebugIdBundle} from 'sentry/types/sourceMaps';
 
 export function SourceMapsDebugIDBundlesFixture(

--- a/tests/js/fixtures/sourceMapsDebugIDBundlesArtifacts.ts
+++ b/tests/js/fixtures/sourceMapsDebugIDBundlesArtifacts.ts
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/filename-case */
 import type {DebugIdBundleArtifact} from 'sentry/types/sourceMaps';
 
 export function SourceMapsDebugIDBundlesArtifactsFixture(


### PR DESCRIPTION
The filename-case rule was forcing inline disables for otherwise camel-cased names that preserve abbreviations like CTA, SDK, URL, and WebGL.

Allow those names in the shared config and remove 67 redundant disables. Also replaces the non-functional mock-directory regex with the package basenames it intended to cover.