### PR TITLE
feat(investigations): add investigation experience and entry points [9/4/13]

### DIFF
--- a/static/app/components/seer/markdown/embeds/components/chart.spec.tsx
+++ b/static/app/components/seer/markdown/embeds/components/chart.spec.tsx
@@ -181,4 +181,41 @@ describe('Chart embed', () => {
 
     expect(screen.getByTestId('seer-chart-embed')).toBeInTheDocument();
   });
+
+  it('applies notebook presentation controls', () => {
+    renderChart({
+      title: 'Hidden title',
+      visualization: 'bar',
+      x_axis: 'time',
+      y_axis_label: 'Errors per minute',
+      stacked: false,
+      show_legend: false,
+      show_title: false,
+      frameless: true,
+      series: [
+        {
+          label: 'Errors',
+          data: [
+            {x: '2026-07-30T12:00:00Z', y: 12},
+            {x: '2026-07-30T13:00:00Z', y: 18},
+          ],
+        },
+        {
+          label: 'Warnings',
+          data: [
+            {x: '2026-07-30T12:00:00Z', y: 4},
+            {x: '2026-07-30T13:00:00Z', y: 6},
+          ],
+        },
+      ],
+    });
+
+    expect(screen.queryByText('Hidden title')).not.toBeInTheDocument();
+    expect(screen.getByTestId('seer-chart-y-axis-label')).toHaveTextContent(
+      'Errors per minute'
+    );
+    const props = jest.mocked(BaseChart).mock.calls.at(-1)![0];
+    expect(props.legend).toBeUndefined();
+    expect(props.series?.[0]).not.toHaveProperty('stack', 'seer-chart');
+  });
 });

--- a/static/app/components/seer/markdown/embeds/components/chart.tsx
+++ b/static/app/components/seer/markdown/embeds/components/chart.tsx
@@ -55,6 +55,11 @@ export const Chart = defineSeerEmbed({
     visualization,
     x_axis: xAxis,
     y_axis_unit: yAxisUnit,
+    y_axis_label: yAxisLabel,
+    stacked,
+    show_legend: showLegend,
+    show_title: showTitle,
+    frameless,
     series,
   }) {
     const metadata = UNIT_METADATA[yAxisUnit];
@@ -73,8 +78,10 @@ export const Chart = defineSeerEmbed({
             };
             return new CategoricalBars(categoricalSeries, {
               alias: getSeriesLabel(item),
+              stack: stacked ? 'seer-chart' : undefined,
             });
           })}
+          showLegend={showLegend ? 'auto' : 'never'}
         />
       ) : (
         <TimeSeriesWidgetVisualization
@@ -123,34 +130,43 @@ export const Chart = defineSeerEmbed({
                 {
                   alias: getSeriesLabel(item),
                   name: `seer-chart-series-${index}`,
+                  stack: stacked ? 'seer-chart' : `seer-chart-series-${index}`,
                 }
               );
             })
             .filter((plottable): plottable is Plottable => plottable !== null)}
           showReleaseAs="none"
+          showLegend={showLegend ? 'auto' : 'never'}
         />
       );
 
     return (
       <Container
         as="section"
-        background="primary"
-        border="primary"
+        background={frameless ? undefined : 'primary'}
+        border={frameless ? undefined : 'primary'}
         data-test-id="seer-chart-embed"
-        margin="lg 0"
-        padding="lg xl md"
-        radius="md"
+        margin={frameless ? undefined : 'lg 0'}
+        padding={frameless ? undefined : 'lg xl md'}
+        radius={frameless ? undefined : 'md'}
       >
-        <Stack gap="2xs" paddingBottom="sm">
-          <Heading as="h3" size="md">
-            {title}
-          </Heading>
-          {subtitle && (
-            <Text size="sm" variant="muted">
-              {subtitle}
-            </Text>
-          )}
-        </Stack>
+        {showTitle && (
+          <Stack gap="2xs" paddingBottom="sm">
+            <Heading as="h3" size="md">
+              {title}
+            </Heading>
+            {subtitle && (
+              <Text size="sm" variant="muted">
+                {subtitle}
+              </Text>
+            )}
+          </Stack>
+        )}
+        {yAxisLabel && (
+          <Text data-test-id="seer-chart-y-axis-label" size="xs" variant="muted">
+            {yAxisLabel}
+          </Text>
+        )}
         <Container height="220px">{visualizationComponent}</Container>
       </Container>
     );

--- a/static/app/components/seer/markdown/embeds/schemas.ts
+++ b/static/app/components/seer/markdown/embeds/schemas.ts
@@ -51,8 +51,14 @@ export const SEER_EMBED_SCHEMAS = {
       format: z.enum(['absolute', 'relative']).default('absolute'),
     }),
     examples: [
-      {label: 'Absolute', data: {value: '2025-07-15T14:30:00Z', format: 'absolute'}},
-      {label: 'Relative', data: {value: '2025-07-15T14:30:00Z', format: 'relative'}},
+      {
+        label: 'Absolute',
+        data: {value: '2025-07-15T14:30:00Z', format: 'absolute'},
+      },
+      {
+        label: 'Relative',
+        data: {value: '2025-07-15T14:30:00Z', format: 'relative'},
+      },
     ],
   },
   docs: {
@@ -65,7 +71,10 @@ export const SEER_EMBED_SCHEMAS = {
     examples: [
       {
         label: 'Doc link',
-        data: {href: 'https://docs.sentry.io/product/issues/', title: 'Issues'},
+        data: {
+          href: 'https://docs.sentry.io/product/issues/',
+          title: 'Issues',
+        },
       },
     ],
   },
@@ -129,7 +138,9 @@ export const SEER_EMBED_SCHEMAS = {
       {
         label: 'Block',
         level: 'block',
-        data: {ids: ['JAVASCRIPT-22SP', 'JAVASCRIPT-39HX', 'JAVASCRIPT-39ZF']},
+        data: {
+          ids: ['JAVASCRIPT-22SP', 'JAVASCRIPT-39HX', 'JAVASCRIPT-39ZF'],
+        },
       },
     ],
   },
@@ -143,12 +154,17 @@ export const SEER_EMBED_SCHEMAS = {
     schema: z
       .object({
         title: z.string().min(1),
-        subtitle: z.string().optional(),
+        subtitle: z.string().nullable().optional(),
         visualization: z.enum(['line', 'area', 'bar']).default('line'),
         x_axis: z.enum(['time', 'category']).default('time'),
         y_axis_unit: z
           .enum(['number', 'percentage', 'duration', 'bytes'])
           .default('number'),
+        y_axis_label: z.string().nullable().optional(),
+        stacked: z.boolean().default(true),
+        show_legend: z.boolean().default(true),
+        show_title: z.boolean().default(true),
+        frameless: z.boolean().default(false),
         series: z.array(chartSeriesSchema).min(1).max(5),
       })
       .superRefine((chart, context) => {

--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -2764,6 +2764,20 @@ function buildRoutes(): RouteObject[] {
   const organizationRoutes: SentryRouteObject = {
     component: errorHandler(OrganizationLayout),
     children: [
+      {
+        path: '/seer/',
+        withOrgPath: true,
+        children: [
+          {
+            index: true,
+            component: make(() => import('sentry/views/seerNotebook')),
+          },
+          {
+            path: ':investigationId/',
+            component: make(() => import('sentry/views/seerNotebook/investigation')),
+          },
+        ],
+      },
       settingsRoutes,
       projectsRoutes,
       dashboardRoutes,

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/area.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/area.tsx
@@ -13,10 +13,14 @@ import {
 } from './continuousTimeSeries';
 import type {Plottable} from './plottable';
 
-export class Area extends ContinuousTimeSeries implements Plottable {
+interface AreaConfig extends ContinuousTimeSeriesConfig {
+  stack?: string;
+}
+
+export class Area extends ContinuousTimeSeries<AreaConfig> implements Plottable {
   #timeSeriesAndIsIncomplete: Array<[TimeSeries, boolean]>;
 
-  constructor(timeSeries: TimeSeries, config?: ContinuousTimeSeriesConfig) {
+  constructor(timeSeries: TimeSeries, config?: AreaConfig) {
     super(timeSeries, config);
 
     this.#timeSeriesAndIsIncomplete = segmentTimeSeriesByIncompleteData(timeSeries);
@@ -80,7 +84,7 @@ export class Area extends ContinuousTimeSeries implements Plottable {
         plottableSeries.push(
           LineSeries({
             ...commonOptions,
-            stack: `complete-${index}`,
+            stack: config.stack ?? `complete-${index}`,
             areaStyle: {
               color,
               opacity: 1,

--- a/static/app/views/issueDetails/sidebar/breachedMetricInvestigationSection.spec.tsx
+++ b/static/app/views/issueDetails/sidebar/breachedMetricInvestigationSection.spec.tsx
@@ -1,0 +1,66 @@
+import {GroupFixture} from 'sentry-fixture/group';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {IssueCategory} from 'sentry/types/group';
+import {BreachedMetricInvestigationSection} from 'sentry/views/issueDetails/sidebar/breachedMetricInvestigationSection';
+
+describe('BreachedMetricInvestigationSection', () => {
+  const organization = OrganizationFixture({
+    features: ['investigations', 'investigations-query-execution'],
+  });
+  const group = GroupFixture({
+    id: '123',
+    issueCategory: IssueCategory.METRIC,
+  });
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('launches an investigation from a breached metric sidebar', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/investigations/breached-metric/status/`,
+      method: 'POST',
+      body: {
+        items: {
+          [group.id]: {status: 'investigate', openPeriodId: '456'},
+        },
+      },
+    });
+    const launchRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/investigations/breached-metric/launch/`,
+      method: 'POST',
+      body: {id: 'investigation-id'},
+    });
+
+    const {router} = render(<BreachedMetricInvestigationSection group={group} />, {
+      organization,
+    });
+
+    expect(screen.getByText('Investigation')).toBeInTheDocument();
+    await userEvent.click(await screen.findByRole('button', {name: 'Investigate'}));
+
+    expect(launchRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: {groupId: group.id, openPeriodId: '456'},
+      })
+    );
+    expect(router.location.pathname).toBe(
+      `/organizations/${organization.slug}/seer/investigation-id/`
+    );
+  });
+
+  it('does not render for non-metric issues', () => {
+    const {container} = render(
+      <BreachedMetricInvestigationSection
+        group={GroupFixture({issueCategory: IssueCategory.ERROR})}
+      />,
+      {organization}
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/static/app/views/issueDetails/sidebar/breachedMetricInvestigationSection.tsx
+++ b/static/app/views/issueDetails/sidebar/breachedMetricInvestigationSection.tsx
@@ -1,0 +1,38 @@
+import {useMemo} from 'react';
+
+import {Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {t} from 'sentry/locale';
+import {IssueCategory, type Group} from 'sentry/types/group';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {SidebarSectionTitle} from 'sentry/views/issueDetails/sidebar/sidebar';
+import {BreachedMetricInvestigationAction} from 'sentry/views/issueList/pages/breachedMetricInvestigationAction';
+import {BreachedMetricInvestigationStore} from 'sentry/views/issueList/pages/breachedMetricInvestigationStore';
+
+export function BreachedMetricInvestigationSection({group}: {group: Group}) {
+  const organization = useOrganization();
+  const navigate = useNavigate();
+  const store = useMemo(
+    () => new BreachedMetricInvestigationStore(organization.slug, path => navigate(path)),
+    [navigate, organization.slug]
+  );
+  const enabled =
+    organization.features.includes('investigations') &&
+    organization.features.includes('investigations-query-execution');
+
+  if (!enabled || group.issueCategory !== IssueCategory.METRIC) {
+    return null;
+  }
+
+  return (
+    <Stack gap="md">
+      <SidebarSectionTitle style={{margin: 0}}>{t('Investigation')}</SidebarSectionTitle>
+      <Text variant="muted">
+        {t('Use Seer to investigate what caused this metric to breach.')}
+      </Text>
+      <BreachedMetricInvestigationAction groupId={group.id} store={store} />
+    </Stack>
+  );
+}

--- a/static/app/views/issueDetails/sidebar/sidebar.tsx
+++ b/static/app/views/issueDetails/sidebar/sidebar.tsx
@@ -23,6 +23,7 @@ import {
   IssueDetailsTourContext,
 } from 'sentry/views/issueDetails/issueDetailsTour';
 import {AutofixSection} from 'sentry/views/issueDetails/sidebar/autofixSection';
+import {BreachedMetricInvestigationSection} from 'sentry/views/issueDetails/sidebar/breachedMetricInvestigationSection';
 import {DetectorSection} from 'sentry/views/issueDetails/sidebar/detectorSection';
 import {ExternalIssueSidebarList} from 'sentry/views/issueDetails/sidebar/externalIssueSidebarList';
 import {FirstLastSeenSection} from 'sentry/views/issueDetails/sidebar/firstLastSeenSection';
@@ -114,6 +115,9 @@ export function IssueDetailsSidebar({group, event, project}: Props) {
               viewers={viewers}
             />
           )}
+          <ErrorBoundary mini>
+            <BreachedMetricInvestigationSection group={group} />
+          </ErrorBoundary>
           {issueTypeConfig.similarIssues.enabled && (
             <Fragment>
               <SimilarIssuesSidebarSection />

--- a/static/app/views/issueList/pages/breachedMetricInvestigationAction.tsx
+++ b/static/app/views/issueList/pages/breachedMetricInvestigationAction.tsx
@@ -1,0 +1,39 @@
+import {useEffect} from 'react';
+import {observer} from 'mobx-react-lite';
+
+import {Button} from '@sentry/scraps/button';
+
+import {t} from 'sentry/locale';
+import type {BreachedMetricInvestigationStore} from 'sentry/views/issueList/pages/breachedMetricInvestigationStore';
+
+type Props = {
+  groupId: string;
+  store: BreachedMetricInvestigationStore;
+};
+
+export const BreachedMetricInvestigationAction = observer(function Action({
+  groupId,
+  store,
+}: Props) {
+  useEffect(() => store.register(groupId), [groupId, store]);
+
+  const action = store.actionFor(groupId);
+  if (!action) {
+    return null;
+  }
+  return (
+    <Button
+      size="sm"
+      variant={action.kind === 'investigate' ? 'primary' : 'secondary'}
+      busy={action.busy}
+      disabled={action.busy}
+      style={{width: '100%'}}
+      onClick={event => {
+        event.stopPropagation();
+        void store.launch(groupId);
+      }}
+    >
+      {action.kind === 'view' ? t('View investigation') : t('Investigate')}
+    </Button>
+  );
+});

--- a/static/app/views/issueList/pages/breachedMetricInvestigationStore.spec.ts
+++ b/static/app/views/issueList/pages/breachedMetricInvestigationStore.spec.ts
@@ -1,0 +1,105 @@
+import * as indicators from 'sentry/actionCreators/indicator';
+import * as queryClient from 'sentry/utils/queryClient';
+import {BreachedMetricInvestigationStore} from 'sentry/views/issueList/pages/breachedMetricInvestigationStore';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return {promise, reject, resolve};
+}
+
+describe('BreachedMetricInvestigationStore', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('batches registered rows and hides them until availability resolves', async () => {
+    const request = deferred<{
+      items: Record<string, {openPeriodId: string; status: 'investigate'}>;
+    }>();
+    const fetchMutation = jest
+      .spyOn(queryClient, 'fetchMutation')
+      .mockReturnValue(request.promise);
+    const store = new BreachedMetricInvestigationStore('sentry', jest.fn());
+
+    store.register('1');
+    store.register('2');
+    expect(store.actionFor('1')).toBeNull();
+    await Promise.resolve();
+
+    expect(fetchMutation).toHaveBeenCalledTimes(1);
+    expect(fetchMutation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: {groupIds: ['1', '2']},
+        method: 'POST',
+      })
+    );
+
+    request.resolve({
+      items: {
+        '1': {status: 'investigate', openPeriodId: 'period-1'},
+        '2': {status: 'investigate', openPeriodId: 'period-2'},
+      },
+    });
+    await request.promise;
+    await Promise.resolve();
+
+    expect(store.actionFor('1')).toEqual({kind: 'investigate', busy: false});
+    expect(store.actionFor('2')).toEqual({kind: 'investigate', busy: false});
+  });
+
+  it('launches optimistically and transitions to View investigation', async () => {
+    const request = deferred<{id: string}>();
+    jest.spyOn(queryClient, 'fetchMutation').mockReturnValue(request.promise);
+    const navigate = jest.fn();
+    const store = new BreachedMetricInvestigationStore('sentry', navigate);
+    store.availability.set('1', {
+      status: 'investigate',
+      openPeriodId: 'period-1',
+    });
+
+    const launch = store.launch('1');
+    expect(store.actionFor('1')).toEqual({kind: 'investigate', busy: true});
+
+    request.resolve({id: 'investigation-1'});
+    await launch;
+
+    expect(store.actionFor('1')).toEqual({kind: 'view', busy: false});
+    expect(navigate).toHaveBeenCalledWith('/organizations/sentry/seer/investigation-1/');
+  });
+
+  it('rolls back a failed optimistic launch', async () => {
+    jest.spyOn(queryClient, 'fetchMutation').mockRejectedValue(new Error('offline'));
+    const errorMessage = jest.spyOn(indicators, 'addErrorMessage');
+    const store = new BreachedMetricInvestigationStore('sentry', jest.fn());
+    store.availability.set('1', {
+      status: 'investigate',
+      openPeriodId: 'period-1',
+    });
+
+    await store.launch('1');
+
+    expect(store.actionFor('1')).toEqual({kind: 'investigate', busy: false});
+    expect(errorMessage).toHaveBeenCalledWith(
+      'Unable to create the investigation. Please try again.'
+    );
+  });
+
+  it('opens an existing investigation without launching', async () => {
+    const fetchMutation = jest.spyOn(queryClient, 'fetchMutation');
+    const navigate = jest.fn();
+    const store = new BreachedMetricInvestigationStore('sentry', navigate);
+    store.availability.set('1', {
+      status: 'view',
+      investigationId: 'existing',
+      openPeriodId: 'period-1',
+    });
+
+    await store.launch('1');
+
+    expect(fetchMutation).not.toHaveBeenCalled();
+    expect(navigate).toHaveBeenCalledWith('/organizations/sentry/seer/existing/');
+  });
+});

--- a/static/app/views/issueList/pages/breachedMetricInvestigationStore.ts
+++ b/static/app/views/issueList/pages/breachedMetricInvestigationStore.ts
@@ -1,0 +1,134 @@
+import {action, makeObservable, observable, runInAction} from 'mobx';
+
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
+import {t} from 'sentry/locale';
+import {fetchMutation} from 'sentry/utils/queryClient';
+import type {InvestigationDetail} from 'sentry/views/seerNotebook/types';
+
+type Availability =
+  | {status: 'loading' | 'unavailable'}
+  | {openPeriodId: string; status: 'investigate'}
+  | {investigationId: string; openPeriodId: string; status: 'view'};
+
+type StatusResponse = {
+  items: Record<string, Exclude<Availability, {status: 'loading'}>>;
+};
+
+export type BreachedMetricInvestigationActionState = {
+  busy: boolean;
+  kind: 'investigate' | 'view';
+};
+
+export class BreachedMetricInvestigationStore {
+  availability = new Map<string, Availability>();
+  launching = new Set<string>();
+
+  private pendingGroupIds = new Set<string>();
+  private flushScheduled = false;
+
+  constructor(
+    private organizationSlug: string,
+    private navigate: (path: string) => void
+  ) {
+    makeObservable(this, {
+      availability: observable,
+      launching: observable,
+      register: action,
+      launch: action,
+    });
+  }
+
+  register(groupId: string) {
+    if (this.availability.has(groupId)) {
+      return;
+    }
+    this.availability.set(groupId, {status: 'loading'});
+    this.pendingGroupIds.add(groupId);
+    if (this.flushScheduled) {
+      return;
+    }
+    this.flushScheduled = true;
+    queueMicrotask(() => void this.loadPending());
+  }
+
+  actionFor(groupId: string): BreachedMetricInvestigationActionState | null {
+    const availability = this.availability.get(groupId);
+    if (availability?.status !== 'investigate' && availability?.status !== 'view') {
+      return null;
+    }
+    return {kind: availability.status, busy: this.launching.has(groupId)};
+  }
+
+  async launch(groupId: string) {
+    const current = this.availability.get(groupId);
+    if (current?.status === 'view') {
+      this.open(current.investigationId);
+      return;
+    }
+    if (current?.status !== 'investigate' || this.launching.has(groupId)) {
+      return;
+    }
+
+    this.launching.add(groupId);
+    try {
+      const investigation = await fetchMutation<InvestigationDetail>({
+        url: `/organizations/${this.organizationSlug}/investigations/breached-metric/launch/`,
+        method: 'POST',
+        data: {groupId, openPeriodId: current.openPeriodId},
+      });
+      runInAction(() => {
+        this.launching.delete(groupId);
+        this.availability.set(groupId, {
+          status: 'view',
+          investigationId: investigation.id,
+          openPeriodId: current.openPeriodId,
+        });
+      });
+      this.open(investigation.id);
+    } catch {
+      runInAction(() => {
+        this.launching.delete(groupId);
+        this.availability.set(groupId, current);
+      });
+      addErrorMessage(t('Unable to create the investigation. Please try again.'));
+    }
+  }
+
+  private async loadPending() {
+    const groupIds = Array.from(this.pendingGroupIds);
+    this.pendingGroupIds.clear();
+    this.flushScheduled = false;
+    if (!groupIds.length) {
+      return;
+    }
+    try {
+      const response = await fetchMutation<StatusResponse>({
+        url: `/organizations/${this.organizationSlug}/investigations/breached-metric/status/`,
+        method: 'POST',
+        data: {groupIds},
+      });
+      runInAction(() => {
+        for (const groupId of groupIds) {
+          this.availability.set(
+            groupId,
+            response.items[groupId] ?? {status: 'unavailable'}
+          );
+        }
+      });
+    } catch {
+      runInAction(() => {
+        for (const groupId of groupIds) {
+          this.availability.set(groupId, {status: 'unavailable'});
+        }
+      });
+    }
+  }
+
+  private open(investigationId: string) {
+    this.navigate(
+      `/organizations/${this.organizationSlug}/seer/${encodeURIComponent(
+        investigationId
+      )}/`
+    );
+  }
+}

--- a/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.spec.tsx
+++ b/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.spec.tsx
@@ -8,7 +8,7 @@ import {SecondaryNavigationContextProvider} from 'sentry/views/navigation/second
 describe('ExploreSecondaryNavigation', () => {
   const {organization} = initializeOrg({
     organization: {
-      features: ['performance-view', 'visibility-explore-view'],
+      features: ['investigations', 'performance-view', 'visibility-explore-view'],
     },
   });
 
@@ -56,6 +56,10 @@ describe('ExploreSecondaryNavigation', () => {
     );
 
     expect(screen.getByText('Traces')).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: /Investigations/})).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/seer/'
+    );
   });
 
   it('marks Releases as active on preprod pages', () => {

--- a/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
@@ -137,6 +137,18 @@ export function ExploreSecondaryNavigation() {
                 {t('Releases')}
               </SecondaryNavigation.Link>
             </SecondaryNavigation.ListItem>
+            <Feature features="investigations">
+              <SecondaryNavigation.ListItem>
+                <SecondaryNavigation.Link
+                  to={`/organizations/${organization.slug}/seer/`}
+                  activeTo={`/organizations/${organization.slug}/seer/`}
+                  analyticsItemName="explore_investigations"
+                  trailingItems={<FeatureBadge type="beta" />}
+                >
+                  {t('Investigations')}
+                </SecondaryNavigation.Link>
+              </SecondaryNavigation.ListItem>
+            </Feature>
             <Feature features="gen-ai-conversations">
               <SecondaryNavigation.ListItem>
                 <SecondaryNavigation.Link

--- a/static/app/views/seerNotebook/api.ts
+++ b/static/app/views/seerNotebook/api.ts
@@ -32,14 +32,16 @@ const investigationPath = (organizationSlug: string, investigationId: string) =>
 export function investigationListQueryOptions({
   cursor,
   organizationSlug,
+  query,
 }: {
   organizationSlug: string;
   cursor?: string;
+  query?: string;
 }) {
   return {
     ...apiOptions.as<InvestigationListItem[]>()(COLLECTION_PATH, {
       path: organizationPath(organizationSlug),
-      query: {cursor, status: 'active'},
+      query: {cursor, query, status: 'active'},
       staleTime: 0,
     }),
     select: selectJsonWithHeaders<InvestigationListItem[]>,

--- a/static/app/views/seerNotebook/index.spec.tsx
+++ b/static/app/views/seerNotebook/index.spec.tsx
@@ -1,0 +1,189 @@
+import {
+  InvestigationDetailFixture,
+  InvestigationListItemFixture,
+} from 'sentry-fixture/investigation';
+import {MemberFixture} from 'sentry-fixture/member';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {
+  render,
+  renderGlobalModal,
+  screen,
+  userEvent,
+  waitFor,
+  within,
+} from 'sentry-test/reactTestingLibrary';
+
+import SeerNotebookLauncher from 'sentry/views/seerNotebook';
+
+describe('SeerNotebookLauncher', () => {
+  const organization = OrganizationFixture({features: ['investigations']});
+
+  beforeEach(() => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/investigations/`,
+      body: [InvestigationListItemFixture()],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/members/`,
+      body: [MemberFixture({id: '1', name: 'Investigation Owner'})],
+    });
+  });
+
+  it('loads persisted investigations and fills a suggested Seer prompt', async () => {
+    render(<SeerNotebookLauncher />, {organization});
+
+    expect(await screen.findByText('Checkout regression')).toBeInTheDocument();
+    await userEvent.click(screen.getByText('Why did checkout get slower?'));
+
+    expect(screen.getByRole('textbox', {name: 'Ask Seer'})).toHaveValue(
+      'Why did checkout get slower?'
+    );
+  });
+
+  it('creates an empty investigation and navigates to it', async () => {
+    const created = InvestigationDetailFixture({id: 'new-investigation'});
+    const createRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/investigations/`,
+      method: 'POST',
+      body: created,
+    });
+    const {router} = render(<SeerNotebookLauncher />, {organization});
+
+    await userEvent.click(screen.getByRole('button', {name: 'New Investigation'}));
+
+    await waitFor(() => expect(createRequest).toHaveBeenCalled());
+    expect(router.location.pathname).toBe(
+      `/organizations/${organization.slug}/seer/new-investigation/`
+    );
+  });
+
+  it('renders the feature-disabled state when investigations are unavailable', () => {
+    render(<SeerNotebookLauncher />, {
+      organization: OrganizationFixture({features: []}),
+    });
+
+    expect(
+      screen.getByText('This feature is not enabled on your Sentry installation.')
+    ).toBeInTheDocument();
+  });
+
+  it('searches investigations through the collection API', async () => {
+    const listRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/investigations/`,
+      body: [
+        InvestigationListItemFixture({
+          id: 'checkout',
+          title: 'Checkout regression',
+        }),
+        InvestigationListItemFixture({
+          id: 'payments',
+          title: 'Payments latency',
+        }),
+      ],
+    });
+    render(<SeerNotebookLauncher />, {organization});
+
+    const search = await screen.findByPlaceholderText('Search Investigations');
+    await userEvent.type(search, 'payments');
+
+    await waitFor(() =>
+      expect(listRequest).toHaveBeenLastCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          query: expect.objectContaining({query: 'payments'}),
+        })
+      )
+    );
+  });
+
+  it('stars an investigation optimistically', async () => {
+    const favoriteRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/investigations/${
+        InvestigationListItemFixture().id
+      }/favorite/`,
+      method: 'PUT',
+      statusCode: 204,
+    });
+    render(<SeerNotebookLauncher />, {organization});
+
+    await userEvent.click(
+      await screen.findByRole('button', {name: 'Star investigation'})
+    );
+
+    expect(
+      screen.getByRole('button', {name: 'Unstar investigation'})
+    ).toBeInTheDocument();
+    expect(favoriteRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({data: {shouldFavorite: true}})
+    );
+  });
+
+  it('sorts the visible investigations in the browser', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/investigations/`,
+      body: [
+        InvestigationListItemFixture({
+          id: 'alpha',
+          title: 'Alpha investigation',
+        }),
+        InvestigationListItemFixture({
+          id: 'zulu',
+          title: 'Zulu investigation',
+        }),
+      ],
+    });
+    render(<SeerNotebookLauncher />, {organization});
+
+    await screen.findByText('Alpha investigation');
+    await userEvent.click(
+      screen.getByRole('button', {name: 'Sort By My Investigations'})
+    );
+    await userEvent.click(
+      await screen.findByRole('option', {name: 'Investigation Name (Z-A)'})
+    );
+
+    const rows = screen.getAllByTestId('grid-body-row');
+    expect(within(rows[0]!).getByText('Zulu investigation')).toBeInTheDocument();
+    expect(within(rows[1]!).getByText('Alpha investigation')).toBeInTheDocument();
+  });
+
+  it('duplicates and deletes investigations from row actions', async () => {
+    const item = InvestigationListItemFixture();
+    const duplicateRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/investigations/${item.id}/duplicate/`,
+      method: 'POST',
+      body: InvestigationDetailFixture({id: 'duplicate'}),
+    });
+    const deleteRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/investigations/${item.id}/`,
+      method: 'DELETE',
+      statusCode: 204,
+    });
+    render(<SeerNotebookLauncher />, {organization});
+    renderGlobalModal();
+
+    await userEvent.click(
+      await screen.findByRole('button', {name: 'Duplicate investigation'})
+    );
+    await userEvent.click(
+      within(screen.getByRole('dialog')).getByRole('button', {
+        name: /confirm/i,
+      })
+    );
+    await waitFor(() => expect(duplicateRequest).toHaveBeenCalled());
+
+    await userEvent.click(screen.getByRole('button', {name: 'Delete investigation'}));
+    await userEvent.click(
+      within(screen.getByRole('dialog')).getByRole('button', {
+        name: /confirm/i,
+      })
+    );
+    await waitFor(() => expect(deleteRequest).toHaveBeenCalled());
+    expect(deleteRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({data: {investigationVersion: item.version}})
+    );
+  });
+});

--- a/static/app/views/seerNotebook/index.tsx
+++ b/static/app/views/seerNotebook/index.tsx
@@ -1,0 +1,682 @@
+import {useMemo, useState} from 'react';
+import styled from '@emotion/styled';
+import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
+import {useReducedMotion} from 'framer-motion';
+
+import {UserAvatar} from '@sentry/scraps/avatar';
+import {Button} from '@sentry/scraps/button';
+import {CompactSelect} from '@sentry/scraps/compactSelect';
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Link} from '@sentry/scraps/link';
+import {IndeterminateLoader} from '@sentry/scraps/loader';
+import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
+import {Pagination} from '@sentry/scraps/pagination';
+import {Text} from '@sentry/scraps/text';
+
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {FeatureDisabled} from 'sentry/components/acl/featureDisabled';
+import {openConfirmModal} from 'sentry/components/confirm';
+import {EmptyStateWarning} from 'sentry/components/emptyStateWarning';
+import {LoadingError} from 'sentry/components/loadingError';
+import {SearchBar} from 'sentry/components/searchBar';
+import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
+import {
+  COL_WIDTH_UNDEFINED,
+  GridEditable,
+  type GridColumnOrder,
+} from 'sentry/components/tables/gridEditable';
+import {TimeSince} from 'sentry/components/timeSince';
+import {IconAdd, IconCopy, IconDelete, IconSeer, IconStar} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {useMembers} from 'sentry/utils/members/useMembers';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {useUser} from 'sentry/utils/useUser';
+import {useSeerExplorerContext} from 'sentry/views/seerExplorer/useSeerExplorerContext';
+
+import {
+  archiveInvestigation,
+  createInvestigation,
+  duplicateInvestigation,
+  investigationListQueryOptions,
+  updateInvestigationFavorite,
+  updatePermissions,
+} from './api';
+import {InvestigationAccessSelector} from './investigationAccessSelector';
+import type {InvestigationListItem} from './types';
+
+const SUGGESTIONS = [
+  t('Why did checkout get slower?'),
+  t('Summarize my highest priority issues'),
+  t('Compare errors before and after the latest release'),
+];
+
+type InvestigationSort =
+  | 'mine'
+  | 'title'
+  | '-title'
+  | '-dateCreated'
+  | 'dateCreated'
+  | '-dateUpdated';
+
+const SORT_OPTIONS: Array<{label: string; value: InvestigationSort}> = [
+  {label: t('My Investigations'), value: 'mine'},
+  {label: t('Investigation Name (A-Z)'), value: 'title'},
+  {label: t('Investigation Name (Z-A)'), value: '-title'},
+  {label: t('Date Created (Newest)'), value: '-dateCreated'},
+  {label: t('Date Created (Oldest)'), value: 'dateCreated'},
+  {label: t('Recently Updated'), value: '-dateUpdated'},
+];
+
+type InvestigationColumn =
+  | 'title'
+  | 'blockCount'
+  | 'createdBy'
+  | 'permissions'
+  | 'dateCreated';
+
+const COLUMN_ORDER: Array<GridColumnOrder<InvestigationColumn>> = [
+  {key: 'title', name: t('Name'), width: COL_WIDTH_UNDEFINED},
+  {key: 'blockCount', name: t('Blocks'), width: COL_WIDTH_UNDEFINED},
+  {key: 'createdBy', name: t('Owner'), width: COL_WIDTH_UNDEFINED},
+  {key: 'permissions', name: t('Access'), width: COL_WIDTH_UNDEFINED},
+  {key: 'dateCreated', name: t('Created'), width: COL_WIDTH_UNDEFINED},
+];
+
+export default function SeerNotebookLauncher() {
+  const organization = useOrganization();
+  if (!organization.features.includes('investigations')) {
+    return (
+      <FeatureDisabled
+        features="organizations:investigations"
+        featureName={t('Investigations')}
+      />
+    );
+  }
+
+  return <SeerNotebookLauncherContent />;
+}
+
+function SeerNotebookLauncherContent() {
+  const [prompt, setPrompt] = useState('');
+  const [search, setSearch] = useState('');
+  const [cursor, setCursor] = useState<string>();
+  const [sort, setSort] = useState<InvestigationSort>('mine');
+  const [favoriteOverrides, setFavoriteOverrides] = useState<Record<string, boolean>>({});
+  const organization = useOrganization();
+  const currentUser = useUser();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const {openSeerExplorer, sessionState} = useSeerExplorerContext();
+  const prefersReducedMotion = useReducedMotion();
+  const listOptions = investigationListQueryOptions({
+    organizationSlug: organization.slug,
+    cursor,
+    query: search.trim() || undefined,
+  });
+  const investigationsQuery = useQuery(listOptions);
+  const investigations = useMemo(
+    () => investigationsQuery.data?.json ?? [],
+    [investigationsQuery.data?.json]
+  );
+  const ownerIds = useMemo(
+    () =>
+      investigations.flatMap(investigation =>
+        investigation.createdBy ? [investigation.createdBy] : []
+      ),
+    [investigations]
+  );
+  const {data: owners = []} = useMembers({
+    ids: ownerIds,
+    enabled: ownerIds.length > 0,
+  });
+  const ownersById = new Map(owners.map(owner => [String(owner.id), owner]));
+  const visibleInvestigations = useMemo(() => {
+    const filtered = investigations.map(investigation => ({
+      ...investigation,
+      isFavorited: favoriteOverrides[investigation.id] ?? investigation.isFavorited,
+    }));
+    const compareTitle = (left: InvestigationListItem, right: InvestigationListItem) =>
+      left.title.localeCompare(right.title);
+    const compareDate = (
+      left: InvestigationListItem,
+      right: InvestigationListItem,
+      field: 'dateCreated' | 'dateUpdated'
+    ) => new Date(left[field]).getTime() - new Date(right[field]).getTime();
+
+    return filtered.toSorted((left, right) => {
+      if (left.isFavorited !== right.isFavorited) {
+        return left.isFavorited ? -1 : 1;
+      }
+      if (sort === 'mine') {
+        const leftIsMine = left.createdBy === String(currentUser.id);
+        const rightIsMine = right.createdBy === String(currentUser.id);
+        return leftIsMine === rightIsMine
+          ? compareTitle(left, right)
+          : leftIsMine
+            ? -1
+            : 1;
+      }
+      if (sort === 'title') {
+        return compareTitle(left, right);
+      }
+      if (sort === '-title') {
+        return compareTitle(right, left);
+      }
+      if (sort === 'dateCreated') {
+        return compareDate(left, right, 'dateCreated');
+      }
+      if (sort === '-dateCreated') {
+        return compareDate(right, left, 'dateCreated');
+      }
+      return compareDate(right, left, 'dateUpdated');
+    });
+  }, [currentUser.id, favoriteOverrides, investigations, sort]);
+
+  const updateSearch = (value: string) => {
+    setSearch(value);
+    setCursor(undefined);
+  };
+
+  const refreshInvestigations = () =>
+    queryClient.invalidateQueries({queryKey: listOptions.queryKey});
+  const createMutation = useMutation({
+    mutationFn: () =>
+      createInvestigation(organization.slug, {
+        title: t('Untitled investigation'),
+      }),
+    onSuccess: investigation => {
+      queryClient.invalidateQueries({queryKey: [listOptions.queryKey[0]]});
+      navigate(`/organizations/${organization.slug}/seer/${investigation.id}/`);
+    },
+    onError: () => addErrorMessage(t('Unable to create the investigation.')),
+  });
+
+  const toggleFavorite = async (
+    investigation: InvestigationListItem,
+    shouldFavorite: boolean
+  ) => {
+    setFavoriteOverrides(current => ({
+      ...current,
+      [investigation.id]: shouldFavorite,
+    }));
+    try {
+      await updateInvestigationFavorite(
+        organization.slug,
+        investigation.id,
+        shouldFavorite
+      );
+      await refreshInvestigations();
+    } catch {
+      setFavoriteOverrides(current => ({
+        ...current,
+        [investigation.id]: investigation.isFavorited,
+      }));
+      addErrorMessage(t('Unable to update the investigation star.'));
+    }
+  };
+
+  const renderRowActions = (investigation: InvestigationListItem) => (
+    <Flex gap="xs">
+      <RowAction
+        size="sm"
+        variant="transparent"
+        icon={<IconCopy />}
+        aria-label={t('Duplicate investigation')}
+        onClick={event => {
+          event.stopPropagation();
+          openConfirmModal({
+            message: t('Are you sure you want to duplicate this investigation?'),
+            priority: 'primary',
+            onConfirm: async () => {
+              await duplicateInvestigation(organization.slug, investigation.id);
+              await refreshInvestigations();
+              addSuccessMessage(t('Investigation duplicated.'));
+            },
+          });
+        }}
+      />
+      <RowAction
+        size="sm"
+        variant="transparent"
+        icon={<IconDelete />}
+        aria-label={t('Delete investigation')}
+        disabled={!investigation.permissions.canManage}
+        tooltipProps={{
+          title: investigation.permissions.canManage
+            ? undefined
+            : t(
+                'Only the creator or an organization manager can delete this investigation.'
+              ),
+        }}
+        onClick={event => {
+          event.stopPropagation();
+          openConfirmModal({
+            message: t('Are you sure you want to delete this investigation?'),
+            priority: 'danger',
+            onConfirm: async () => {
+              await archiveInvestigation(
+                organization.slug,
+                investigation.id,
+                investigation.version
+              );
+              await refreshInvestigations();
+              addSuccessMessage(t('Investigation deleted.'));
+            },
+          });
+        }}
+      />
+    </Flex>
+  );
+
+  const renderBodyCell = (
+    column: GridColumnOrder<InvestigationColumn>,
+    investigation: InvestigationListItem
+  ) => {
+    if (column.key === 'title') {
+      return (
+        <Text ellipsis variant="accent">
+          <Link to={`/organizations/${organization.slug}/seer/${investigation.id}/`}>
+            {investigation.title}
+          </Link>
+        </Text>
+      );
+    }
+    if (column.key === 'blockCount') {
+      return investigation.blockCount;
+    }
+    if (column.key === 'createdBy') {
+      const owner = investigation.createdBy
+        ? ownersById.get(investigation.createdBy)
+        : undefined;
+      return owner ? <UserAvatar hasTooltip user={owner} size={26} /> : '—';
+    }
+    if (column.key === 'permissions') {
+      return (
+        <InvestigationAccessSelector
+          permissions={investigation.permissions}
+          onChange={async permissions => {
+            await updatePermissions(organization.slug, investigation.id, {
+              investigationVersion: investigation.version,
+              isEditableByEveryone: permissions.isEditableByEveryone,
+              teamIds: permissions.teamIds,
+            });
+            await refreshInvestigations();
+            addSuccessMessage(t('Investigation edit access updated.'));
+          }}
+        />
+      );
+    }
+    return (
+      <Flex align="center" justify="between" gap="3xl">
+        <TimeSince date={investigation.dateCreated} />
+        {renderRowActions(investigation)}
+      </Flex>
+    );
+  };
+
+  return (
+    <SentryDocumentTitle title={t('Seer')}>
+      <Page>
+        <Hero>
+          <HeroContent>
+            <BrandLockup>
+              <HeroSeerIcon aria-label={t('Seer')} />
+              <Stack gap="sm">
+                <Title>{t('Start with a question')}</Title>
+                <Subtitle>
+                  {t(
+                    'Ask Seer about your application, follow the evidence, and keep what you find in one place.'
+                  )}
+                </Subtitle>
+              </Stack>
+            </BrandLockup>
+
+            <PromptForm
+              onSubmit={event => {
+                event.preventDefault();
+                const query = prompt.trim();
+                if (query) {
+                  openSeerExplorer({initialQuery: query, startNewRun: true});
+                }
+              }}
+            >
+              <PromptInput
+                aria-label={t('Ask Seer')}
+                placeholder={t('What would you like to investigate?')}
+                value={prompt}
+                onChange={event => setPrompt(event.target.value)}
+              />
+              <PromptSubmit
+                variant="primary"
+                aria-label={
+                  sessionState === 'thinking' ? t('Seer is thinking...') : t('Ask Seer')
+                }
+                icon={
+                  <IconSeer
+                    animation={sessionState === 'thinking' ? 'loading' : undefined}
+                  />
+                }
+                disabled={!prompt.trim()}
+                type="submit"
+              >
+                <Flex position="relative">
+                  <span
+                    style={{
+                      visibility: sessionState === 'thinking' ? 'hidden' : undefined,
+                    }}
+                  >
+                    {t('Ask Seer')}
+                  </span>
+                  {sessionState === 'thinking' ? (
+                    <ButtonLoader>
+                      {prefersReducedMotion ? (
+                        <Text variant="primary">{t('Thinking...')}</Text>
+                      ) : (
+                        <IndeterminateLoader variant="monochrome" />
+                      )}
+                    </ButtonLoader>
+                  ) : null}
+                </Flex>
+              </PromptSubmit>
+            </PromptForm>
+
+            <Suggestions aria-label={t('Suggested prompts')}>
+              {SUGGESTIONS.map(suggestion => (
+                <Suggestion
+                  key={suggestion}
+                  type="button"
+                  onClick={() => setPrompt(suggestion)}
+                >
+                  {suggestion}
+                </Suggestion>
+              ))}
+            </Suggestions>
+          </HeroContent>
+        </Hero>
+
+        <InvestigationSection>
+          <Toolbar>
+            <SearchBar
+              defaultQuery=""
+              query={search}
+              placeholder={t('Search Investigations')}
+              onChange={updateSearch}
+            />
+            <CompactSelect
+              value={sort}
+              options={SORT_OPTIONS}
+              onChange={option => setSort(option.value)}
+              position="bottom-end"
+              trigger={triggerProps => (
+                <OverlayTrigger.Button {...triggerProps} prefix={t('Sort By')} />
+              )}
+            />
+            <Button
+              variant="primary"
+              icon={<IconAdd />}
+              busy={createMutation.isPending}
+              onClick={() => createMutation.mutate()}
+            >
+              {t('New Investigation')}
+            </Button>
+          </Toolbar>
+
+          {investigationsQuery.isError ? (
+            <LoadingError onRetry={() => investigationsQuery.refetch()} />
+          ) : (
+            <GridEditable
+              data={visibleInvestigations}
+              columnOrder={COLUMN_ORDER}
+              columnSortBy={[]}
+              grid={{
+                renderBodyCell,
+                renderHeadCell: column => column.name,
+                renderPrependColumns: (
+                  isHeader: boolean,
+                  investigation?: InvestigationListItem
+                ) => {
+                  if (isHeader) {
+                    return [
+                      <IconStar
+                        key="favorite-header"
+                        variant="warning"
+                        isSolid
+                        aria-label={t('Star column')}
+                      />,
+                    ];
+                  }
+                  if (!investigation) {
+                    return [];
+                  }
+                  return [
+                    <Button
+                      key={investigation.id}
+                      size="zero"
+                      variant="transparent"
+                      aria-label={
+                        investigation.isFavorited
+                          ? t('Unstar investigation')
+                          : t('Star investigation')
+                      }
+                      icon={
+                        <IconStar
+                          size="sm"
+                          variant={investigation.isFavorited ? 'warning' : 'muted'}
+                          isSolid={investigation.isFavorited}
+                        />
+                      }
+                      onClick={() =>
+                        toggleFavorite(investigation, !investigation.isFavorited)
+                      }
+                    />,
+                  ];
+                },
+                prependColumnWidths: ['max-content'],
+              }}
+              isLoading={investigationsQuery.isPending}
+              emptyMessage={
+                <EmptyStateWarning>
+                  <p>{t('Sorry, no Investigations match your filters.')}</p>
+                </EmptyStateWarning>
+              }
+            />
+          )}
+          <Pagination
+            pageLinks={investigationsQuery.data?.headers.Link}
+            onCursor={nextCursor => setCursor(nextCursor)}
+          />
+        </InvestigationSection>
+      </Page>
+    </SentryDocumentTitle>
+  );
+}
+
+const Page = styled('div')`
+  min-height: 100%;
+  background: ${p => p.theme.tokens.background.primary};
+`;
+
+const Hero = styled('section')`
+  --isometric-dot: color-mix(
+    in srgb,
+    ${p => p.theme.tokens.border.primary} 40%,
+    transparent
+  );
+
+  position: relative;
+  overflow: hidden;
+  border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
+  background-image:
+    radial-gradient(circle, var(--isometric-dot) 1px, transparent 1.25px),
+    radial-gradient(circle, var(--isometric-dot) 1px, transparent 1.25px);
+  background-position:
+    0 0,
+    14px 8px;
+  background-size: 28px 16px;
+  background-color: ${p => p.theme.tokens.background.secondary};
+`;
+
+const HeroContent = styled('div')`
+  display: flex;
+  width: min(960px, calc(100% - 48px));
+  align-items: center;
+  margin: 0 auto;
+  padding: 56px 0 52px;
+  flex-direction: column;
+
+  @media (max-width: 600px) {
+    width: calc(100% - 32px);
+    padding: 42px 0 38px;
+  }
+`;
+
+const BrandLockup = styled('div')`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: ${p => p.theme.space.lg};
+  text-align: center;
+`;
+
+const HeroSeerIcon = styled(IconSeer)`
+  width: 52px;
+  height: 52px;
+  flex: 0 0 auto;
+  color: ${p => p.theme.tokens.content.primary};
+`;
+
+const Title = styled('h1')`
+  margin: 0;
+  color: ${p => p.theme.tokens.content.primary};
+  font-size: 28px;
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+`;
+
+const Subtitle = styled('p')`
+  max-width: 660px;
+  margin: 0 auto;
+  color: ${p => p.theme.tokens.content.secondary};
+  font-size: ${p => p.theme.font.size.md};
+  line-height: 1.4;
+`;
+
+const PromptForm = styled('form')`
+  display: grid;
+  width: 100%;
+  max-width: 760px;
+  grid-template-columns: 1fr auto;
+  gap: ${p => p.theme.space.sm};
+  margin-top: ${p => p.theme.space['3xl']};
+  padding: ${p => p.theme.space.md};
+  border: 1px solid ${p => p.theme.tokens.border.primary};
+  border-radius: ${p => p.theme.radius.md};
+  background: color-mix(
+    in srgb,
+    ${p => p.theme.tokens.background.primary} 44%,
+    ${p => p.theme.tokens.background.secondary}
+  );
+  box-shadow: ${p => p.theme.shadow.low};
+
+  &:focus-within {
+    border-color: ${p => p.theme.tokens.border.accent.moderate};
+    box-shadow:
+      0 0 0 1px ${p => p.theme.tokens.focus.default},
+      ${p => p.theme.shadow.low};
+  }
+`;
+
+const PromptInput = styled('textarea')`
+  min-height: 74px;
+  resize: none;
+  border: 0;
+  outline: 0;
+  padding: ${p => p.theme.space.sm} ${p => p.theme.space.md};
+  background: transparent;
+  color: ${p => p.theme.tokens.content.primary};
+  font-family: inherit;
+  font-size: ${p => p.theme.font.size.md};
+  line-height: 1.4;
+
+  &::placeholder {
+    color: ${p => p.theme.tokens.content.secondary};
+  }
+`;
+
+const PromptSubmit = styled(Button)`
+  align-self: end;
+
+  > span:last-child {
+    overflow: visible;
+  }
+`;
+
+const ButtonLoader = styled(Flex)`
+  position: absolute;
+  inset: 0;
+  align-items: center;
+  justify-content: center;
+  color: ${p => p.theme.tokens.graphics.accent.vibrant};
+`;
+
+const Suggestions = styled('div')`
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: ${p => p.theme.space.xs};
+  margin-top: ${p => p.theme.space.md};
+`;
+
+const Suggestion = styled('button')`
+  appearance: none;
+  border: 1px solid ${p => p.theme.tokens.border.secondary};
+  border-radius: 999px;
+  padding: ${p => p.theme.space.xs} ${p => p.theme.space.md};
+  background: color-mix(
+    in srgb,
+    ${p => p.theme.tokens.background.primary} 42%,
+    transparent
+  );
+  color: ${p => p.theme.tokens.content.secondary};
+  cursor: pointer;
+  font: inherit;
+  font-size: ${p => p.theme.font.size.xs};
+
+  &:hover {
+    border-color: ${p => p.theme.tokens.border.accent.moderate};
+    background: ${p => p.theme.tokens.background.primary};
+    color: ${p => p.theme.tokens.content.primary};
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${p => p.theme.tokens.focus.default};
+    outline-offset: 2px;
+  }
+`;
+
+const InvestigationSection = styled('section')`
+  box-sizing: border-box;
+  width: 100%;
+  padding: 32px 32px 64px;
+
+  @media (max-width: 600px) {
+    padding: 24px 16px 48px;
+  }
+`;
+
+const Toolbar = styled('div')`
+  display: grid;
+  grid-template-columns: minmax(240px, 1fr) max-content max-content;
+  gap: ${p => p.theme.space.md};
+  margin-bottom: ${p => p.theme.space.xl};
+
+  @media (max-width: 600px) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const RowAction = styled(Button)`
+  border: 0;
+  box-shadow: none;
+`;

--- a/static/app/views/seerNotebook/investigation.performance.spec.tsx
+++ b/static/app/views/seerNotebook/investigation.performance.spec.tsx
@@ -1,0 +1,362 @@
+import {Profiler, useState, type ProfilerOnRenderCallback} from 'react';
+import {
+  InvestigationBlockFixture,
+  InvestigationDetailFixture,
+} from 'sentry-fixture/investigation';
+import {MemberFixture} from 'sentry-fixture/member';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  userEvent,
+  waitFor,
+} from 'sentry-test/reactTestingLibrary';
+
+import {PageFiltersStore} from 'sentry/components/pageFilters/store';
+import {ProjectsStore} from 'sentry/stores/projectsStore';
+import {TopBar} from 'sentry/views/navigation/topBar';
+import {SeerInvestigationPerformanceHarness} from 'sentry/views/seerNotebook/investigation';
+
+type ProfileCommit = {
+  actualDuration: number;
+  baseDuration: number;
+  phase: 'mount' | 'nested-update' | 'update';
+};
+
+function summarize(commits: ProfileCommit[]) {
+  return {
+    commits: commits.length,
+    phases: commits.reduce<Record<string, number>>((counts, commit) => {
+      counts[commit.phase] = (counts[commit.phase] ?? 0) + 1;
+      return counts;
+    }, {}),
+    maxActualDuration: Math.max(0, ...commits.map(commit => commit.actualDuration)),
+    totalActualDuration: commits.reduce(
+      (total, commit) => total + commit.actualDuration,
+      0
+    ),
+    totalBaseDuration: commits.reduce((total, commit) => total + commit.baseDuration, 0),
+  };
+}
+
+function ControlledTextArea() {
+  const [value, setValue] = useState('Paragraph 0');
+  return (
+    <textarea
+      aria-label="Control editor"
+      value={value}
+      onChange={event => setValue(event.target.value)}
+    />
+  );
+}
+
+describe('SeerInvestigation performance', () => {
+  const organization = OrganizationFixture({features: ['investigations']});
+  const blocks = Array.from({length: 40}, (_, index) =>
+    InvestigationBlockFixture({
+      id: `block-${index}`,
+      position: index,
+      content: `Paragraph ${index}`,
+    })
+  );
+  const detail = InvestigationDetailFixture({blocks});
+  const detailUrl = `/organizations/${organization.slug}/investigations/${detail.id}/`;
+
+  beforeEach(() => {
+    act(() =>
+      ProjectsStore.loadInitialData([ProjectFixture({id: '1', slug: 'frontend'})])
+    );
+    MockApiClient.addMockResponse({url: detailUrl, body: detail});
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/members/`,
+      body: [MemberFixture({id: '1', name: 'Test User'})],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      body: [ProjectFixture({id: '1', slug: 'frontend'})],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/releases/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/investigations/${
+        detail.id
+      }/blocks/${blocks[0]!.id}/`,
+      method: 'PUT',
+      body: {
+        ...blocks[0],
+        content: `${blocks[0]!.content}abcdefghijklmnopqrst`,
+        version: 2,
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/investigations/${detail.id}/blocks/`,
+      method: 'POST',
+      body: InvestigationBlockFixture({
+        id: 'block-40',
+        position: 40,
+        content: '',
+        version: 1,
+      }),
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/investigations/${detail.id}/blocks/order/`,
+      method: 'PUT',
+      body: {
+        ...detail,
+        version: detail.version + 1,
+        blocks: [blocks[1]!, blocks[0]!, ...blocks.slice(2)],
+      },
+    });
+  });
+
+  afterEach(() => PageFiltersStore.reset());
+
+  it('calibrates the profiler harness with a controlled textarea', () => {
+    const commits: ProfileCommit[] = [];
+    const onRender: ProfilerOnRenderCallback = (
+      _id,
+      phase,
+      actualDuration,
+      baseDuration
+    ) => commits.push({phase, actualDuration, baseDuration});
+    render(
+      <Profiler id="control" onRender={onRender}>
+        <ControlledTextArea />
+      </Profiler>
+    );
+    commits.length = 0;
+    const editor = screen.getByRole('textbox', {name: 'Control editor'});
+    let value = 'Paragraph 0';
+    for (const character of 'abcdefghijklmnopqrst') {
+      value += character;
+      fireEvent.change(editor, {target: {value}});
+    }
+
+    expect(summarize(commits).commits).toBe(20);
+  });
+
+  it('tracks large-notebook render and typing costs', async () => {
+    const commits: ProfileCommit[] = [];
+    const blockListCommits: ProfileCommit[] = [];
+    const updatedBlockIds = new Set<string>();
+    const onRender: ProfilerOnRenderCallback = (
+      _id,
+      phase,
+      actualDuration,
+      baseDuration
+    ) => {
+      commits.push({phase, actualDuration, baseDuration});
+    };
+    const onBlockListRender: ProfilerOnRenderCallback = (
+      _id,
+      phase,
+      actualDuration,
+      baseDuration
+    ) => {
+      blockListCommits.push({phase, actualDuration, baseDuration});
+    };
+    const onBlockRender = (id: string) => updatedBlockIds.add(id);
+
+    const view = render(
+      <Profiler id="investigation" onRender={onRender}>
+        <TopBar.Slot.Provider>
+          <TopBar />
+          <SeerInvestigationPerformanceHarness
+            onBlockListRender={onBlockListRender}
+            onBlockRender={onBlockRender}
+          />
+        </TopBar.Slot.Provider>
+      </Profiler>,
+      {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/seer/${detail.id}/`,
+          },
+          route: '/organizations/:orgId/seer/:investigationId/',
+        },
+      }
+    );
+
+    await screen.findByText('Paragraph 39');
+    const initialRender = summarize(commits);
+    const initialBlockListRender = summarize(blockListCommits);
+
+    jest.useFakeTimers();
+    fireEvent.click(screen.getByText('Paragraph 0'));
+    updatedBlockIds.clear();
+    const editor = screen.getByRole('textbox', {name: 'Text block 1'});
+    commits.length = 0;
+    blockListCommits.length = 0;
+    let value = blocks[0]!.content;
+    for (const character of 'abcdefghijklmnopqrst') {
+      value += character;
+      fireEvent.change(editor, {target: {value}});
+    }
+    const typing = summarize(commits);
+    const typingBlockList = summarize(blockListCommits);
+
+    commits.length = 0;
+    blockListCommits.length = 0;
+    await act(async () => {
+      jest.advanceTimersByTime(600);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const autosave = summarize(commits);
+    const autosaveBlockList = summarize(blockListCommits);
+
+    view.unmount();
+    jest.clearAllTimers();
+    jest.useRealTimers();
+
+    if (process.env.SENTRY_PERF_LOG) {
+      // eslint-disable-next-line no-console
+      console.info(
+        'SEER_NOTEBOOK_PERF',
+        JSON.stringify({
+          initialRender,
+          initialBlockListRender,
+          typing,
+          typingBlockList,
+          autosave,
+          autosaveBlockList,
+        })
+      );
+    }
+
+    expect(typing.commits).toBeLessThanOrEqual(40);
+    expect(typingBlockList.commits).toBeLessThanOrEqual(20);
+    expect([...updatedBlockIds]).toEqual(['block-0']);
+    expect(autosave.commits).toBeLessThanOrEqual(3);
+    expect(autosaveBlockList.commits).toBeLessThanOrEqual(1);
+  });
+
+  it('tracks optimistic insertion cost in a large notebook', async () => {
+    const commits: ProfileCommit[] = [];
+    const blockListCommits: ProfileCommit[] = [];
+    const onRender: ProfilerOnRenderCallback = (
+      _id,
+      phase,
+      actualDuration,
+      baseDuration
+    ) => commits.push({phase, actualDuration, baseDuration});
+    const onBlockListRender: ProfilerOnRenderCallback = (
+      _id,
+      phase,
+      actualDuration,
+      baseDuration
+    ) => blockListCommits.push({phase, actualDuration, baseDuration});
+
+    render(
+      <Profiler id="investigation" onRender={onRender}>
+        <TopBar.Slot.Provider>
+          <TopBar />
+          <SeerInvestigationPerformanceHarness onBlockListRender={onBlockListRender} />
+        </TopBar.Slot.Provider>
+      </Profiler>,
+      {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/seer/${detail.id}/`,
+          },
+          route: '/organizations/:orgId/seer/:investigationId/',
+        },
+      }
+    );
+
+    await screen.findByText('Paragraph 39');
+    const initialBlockListRender = summarize(blockListCommits);
+    const articles = document.querySelectorAll('article');
+    expect(articles).toHaveLength(40);
+    articles.forEach((article, index) => {
+      article.getBoundingClientRect = () => ({
+        bottom: index * 100 + 80,
+        height: 80,
+        left: 0,
+        right: 800,
+        top: index * 100,
+        width: 800,
+        x: 0,
+        y: index * 100,
+        toJSON: () => {},
+      });
+    });
+
+    const firstDragHandle = screen.getAllByRole('button', {
+      name: 'Drag to reorder',
+    })[0]!;
+    commits.length = 0;
+    blockListCommits.length = 0;
+    fireEvent(firstDragHandle, makePointerEvent('pointerdown', 10));
+    fireEvent(document, makePointerEvent('pointermove', 20));
+    await waitForDndAnnouncement('was moved over');
+    commits.length = 0;
+    blockListCommits.length = 0;
+    fireEvent(document, makePointerEvent('pointermove', 130));
+    await waitForDndAnnouncement('block-1');
+    const dragOver = summarize(commits);
+    const dragOverBlockList = summarize(blockListCommits);
+    fireEvent(document, makePointerEvent('pointerup', 130));
+    await act(async () => Promise.resolve());
+    commits.length = 0;
+    blockListCommits.length = 0;
+
+    await userEvent.click(screen.getByRole('button', {name: 'Add block'}));
+    const openMenu = summarize(commits);
+    const openMenuBlockList = summarize(blockListCommits);
+    commits.length = 0;
+    blockListCommits.length = 0;
+    await userEvent.click(screen.getByRole('menuitemradio', {name: 'Text'}));
+    await screen.findByRole('textbox', {name: 'Text block 41'});
+
+    const insertion = summarize(commits);
+    const insertionBlockList = summarize(blockListCommits);
+    if (process.env.SENTRY_PERF_LOG) {
+      // eslint-disable-next-line no-console
+      console.info(
+        'SEER_NOTEBOOK_INSERT_PERF',
+        JSON.stringify({
+          initialBlockListRender,
+          dragOver,
+          dragOverBlockList,
+          openMenu,
+          openMenuBlockList,
+          insertion,
+          insertionBlockList,
+        })
+      );
+    }
+
+    expect(dragOver.commits).toBeLessThanOrEqual(2);
+    expect(dragOverBlockList.commits).toBeLessThanOrEqual(2);
+    expect(openMenu.commits).toBeLessThanOrEqual(9);
+    expect(insertion.commits).toBeLessThanOrEqual(8);
+    expect(insertionBlockList.commits).toBeLessThanOrEqual(3);
+  });
+});
+
+async function waitForDndAnnouncement(text: string) {
+  await waitFor(() =>
+    expect(document.querySelector('[id^="DndLiveRegion"]')).toHaveTextContent(text)
+  );
+}
+
+function makePointerEvent(type: string, clientY: number) {
+  const event = new Event(type, {bubbles: true, cancelable: true});
+  Object.defineProperties(event, {
+    button: {value: 0},
+    clientX: {value: 10},
+    clientY: {value: clientY},
+    isPrimary: {value: true},
+    pointerId: {value: 1},
+  });
+  return event;
+}

--- a/static/app/views/seerNotebook/investigation.spec.tsx
+++ b/static/app/views/seerNotebook/investigation.spec.tsx
@@ -1,0 +1,973 @@
+import {
+  InvestigationBlockFixture,
+  InvestigationDetailFixture,
+} from 'sentry-fixture/investigation';
+import {MemberFixture} from 'sentry-fixture/member';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {
+  act,
+  fireEvent,
+  render,
+  renderGlobalModal,
+  screen,
+  userEvent,
+  waitFor,
+} from 'sentry-test/reactTestingLibrary';
+
+import {PageFiltersStore} from 'sentry/components/pageFilters/store';
+import {ProjectsStore} from 'sentry/stores/projectsStore';
+import {TopBar} from 'sentry/views/navigation/topBar';
+import SeerInvestigation from 'sentry/views/seerNotebook/investigation';
+
+describe('SeerInvestigation', () => {
+  const organization = OrganizationFixture({
+    features: ['investigations', 'investigations-query-execution'],
+  });
+  const detail = InvestigationDetailFixture();
+  const detailUrl = `/organizations/${organization.slug}/investigations/${detail.id}/`;
+
+  beforeEach(() => {
+    act(() =>
+      ProjectsStore.loadInitialData([ProjectFixture({id: '1', slug: 'frontend'})])
+    );
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/members/`,
+      body: [MemberFixture({id: '1', name: 'Test User'})],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      body: [ProjectFixture({id: '1', slug: 'frontend'})],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/releases/`,
+      body: [],
+    });
+  });
+
+  afterEach(() => PageFiltersStore.reset());
+
+  function renderInvestigation(response = detail, currentOrganization = organization) {
+    MockApiClient.addMockResponse({url: detailUrl, body: response});
+    return render(
+      <TopBar.Slot.Provider>
+        <TopBar />
+        <SeerInvestigation />
+      </TopBar.Slot.Provider>,
+      {
+        organization: currentOrganization,
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/seer/${detail.id}/`,
+          },
+          route: '/organizations/:orgId/seer/:investigationId/',
+        },
+      }
+    );
+  }
+
+  it('shows the investigation breadcrumb and notebook header controls', async () => {
+    renderInvestigation();
+
+    expect(await screen.findByRole('link', {name: 'Investigations'})).toHaveAttribute(
+      'href',
+      `/organizations/${organization.slug}/seer/`
+    );
+    expect(screen.getByRole('button', {name: 'Star investigation'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Edit history'})).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: 'Investigation settings'})
+    ).toBeInTheDocument();
+    expect(screen.getByText('All Envs')).toBeInTheDocument();
+    expect(screen.getByText('All Releases')).toBeInTheDocument();
+    expect(screen.getByText('10 minutes')).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: detail.title})).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: 'Edit investigation name'})
+    ).toHaveTextContent(detail.title);
+  });
+
+  it('keeps only access and archive controls in investigation settings', async () => {
+    MockApiClient.addMockResponse({
+      url: `${detailUrl}permissions/`,
+      body: detail.permissions,
+    });
+    renderGlobalModal();
+    renderInvestigation();
+
+    await userEvent.click(
+      await screen.findByRole('button', {name: 'Investigation settings'})
+    );
+
+    expect(
+      await screen.findByRole('heading', {name: 'Investigation settings'})
+    ).toBeInTheDocument();
+    expect(screen.getByText('Access')).toBeInTheDocument();
+    expect(screen.getByRole('radiogroup', {name: 'Who can edit'})).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: 'Archive investigation'})
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Default project')).not.toBeInTheDocument();
+  });
+
+  it('loads persisted blocks and saves a renamed investigation', async () => {
+    const updateRequest = MockApiClient.addMockResponse({
+      url: detailUrl,
+      method: 'PUT',
+      body: {...detail, title: 'Checkout follow-up', version: 2},
+    });
+    renderInvestigation();
+
+    await userEvent.click(
+      await screen.findByRole('button', {name: 'Edit investigation name'})
+    );
+    const title = await screen.findByRole('textbox', {
+      name: 'Investigation name',
+    });
+    await userEvent.clear(title);
+    await userEvent.type(title, 'Checkout follow-up');
+    await userEvent.keyboard('{Enter}');
+
+    await waitFor(() => expect(updateRequest).toHaveBeenCalled());
+    expect(updateRequest).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: expect.objectContaining({title: 'Checkout follow-up'}),
+      })
+    );
+    expect(screen.getByRole('button', {name: 'Run'})).toBeDisabled();
+  });
+
+  it('creates a persisted query block', async () => {
+    const queryBlock = InvestigationBlockFixture({
+      id: 'query-block',
+      position: 1,
+      kind: 'query',
+      title: '',
+      content: '',
+      display: {type: 'table', queryCollapsed: false},
+    });
+    const createRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/investigations/${detail.id}/blocks/`,
+      method: 'POST',
+      body: queryBlock,
+    });
+    renderInvestigation();
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Add block'}));
+    await userEvent.click(screen.getByRole('menuitemradio', {name: 'Query'}));
+
+    await waitFor(() => expect(createRequest).toHaveBeenCalled());
+    const queryEditor = await screen.findByRole('textbox', {
+      name: 'Query block 2',
+    });
+    expect(queryEditor).toBeInTheDocument();
+    expect(screen.getAllByRole('button', {name: 'Run'}).at(-1)).toBeDisabled();
+
+    const suggestion =
+      'Compare error volume over time across the selected projects. Show daily error counts for the last 30 days, grouped by project.';
+    await userEvent.click(screen.getByRole('button', {name: 'see an example'}));
+    expect(queryEditor).not.toHaveValue(suggestion);
+    await waitFor(() => expect(queryEditor).toHaveValue(suggestion), {
+      timeout: 3000,
+    });
+  });
+
+  it('keeps a legacy query empty after deleting all of its text', async () => {
+    const queryBlock = InvestigationBlockFixture({
+      id: 'query-block',
+      kind: 'query',
+      content: 'Show unresolved errors',
+      generationPrompt: '',
+      display: {type: 'table', queryCollapsed: false},
+    });
+    const withLegacyQuery = InvestigationDetailFixture({blocks: [queryBlock]});
+    const updateRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/investigations/${withLegacyQuery.id}/blocks/${queryBlock.id}/`,
+      method: 'PUT',
+      body: {
+        ...queryBlock,
+        content: '',
+        generationPrompt: '',
+        version: queryBlock.version + 1,
+      },
+    });
+    renderInvestigation(withLegacyQuery);
+
+    const queryEditor = await screen.findByRole('textbox', {
+      name: 'Query block 1',
+    });
+    expect(queryEditor).toHaveValue('Show unresolved errors');
+
+    await userEvent.clear(queryEditor);
+
+    expect(queryEditor).toHaveValue('');
+    expect(screen.getByRole('button', {name: 'Run'})).toBeDisabled();
+    await waitFor(() => expect(updateRequest).toHaveBeenCalled(), {
+      timeout: 2000,
+    });
+    expect(updateRequest).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: expect.objectContaining({content: '', generationPrompt: ''}),
+      })
+    );
+  });
+
+  it('runs a query block through its durable execution endpoint', async () => {
+    const queryBlock = InvestigationBlockFixture({
+      id: 'query-block',
+      kind: 'query',
+      generationPrompt: 'Show unresolved errors over the last day',
+      outputStatus: 'notRun',
+      version: 3,
+    });
+    const withQuery = InvestigationDetailFixture({
+      blocks: [queryBlock],
+      version: 7,
+    });
+    const executeRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/investigations/${withQuery.id}/blocks/${queryBlock.id}/execute/`,
+      method: 'POST',
+      body: {id: 'execution-1', status: 'running'},
+    });
+    renderInvestigation(withQuery);
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Run'}));
+
+    await waitFor(() => expect(executeRequest).toHaveBeenCalled());
+    expect(executeRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: {
+          investigationVersion: 7,
+          requestId: expect.any(String),
+          version: 3,
+        },
+      })
+    );
+  });
+
+  it('restores a running button after reload without starting another execution', async () => {
+    const queryBlock = InvestigationBlockFixture({
+      id: 'query-block',
+      kind: 'query',
+      generationPrompt: 'Show unresolved errors over the last day',
+      outputStatus: 'running',
+      currentExecution: {
+        id: 'execution-1',
+        status: 'running',
+        executor: 'code_mode',
+        schemaVersion: 1,
+        error: null,
+        startedAt: '2026-08-02T05:40:19Z',
+        completedAt: null,
+      },
+    });
+    const withRunningQuery = InvestigationDetailFixture({blocks: [queryBlock]});
+    const executeRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/investigations/${withRunningQuery.id}/blocks/${queryBlock.id}/execute/`,
+      method: 'POST',
+      body: {id: 'unexpected', status: 'running'},
+    });
+
+    renderInvestigation(withRunningQuery);
+
+    const runningButton = await screen.findByRole('button', {
+      name: 'Stop query',
+    });
+    expect(runningButton).toBeEnabled();
+    expect(runningButton).not.toHaveTextContent('Working');
+    expect(screen.getByTestId('block-run-spinner')).toBeInTheDocument();
+    expect(await screen.findByText('Thinking')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Thinking'})).toBeDisabled();
+    expect(executeRequest).not.toHaveBeenCalled();
+  });
+
+  it('shows a persisted query error and retries it inline', async () => {
+    const queryBlock = InvestigationBlockFixture({
+      id: 'query-block',
+      kind: 'query',
+      generationPrompt: 'Show unresolved errors over the last day',
+      outputStatus: 'failed',
+      currentExecution: {
+        id: 'execution-1',
+        status: 'failed',
+        executor: 'code_mode',
+        schemaVersion: 1,
+        error: {
+          code: 'seer_execution_failed',
+          message: 'agent_run_errored',
+        },
+        startedAt: '2026-08-02T05:40:19Z',
+        completedAt: '2026-08-02T05:40:40Z',
+      },
+    });
+    const withFailedQuery = InvestigationDetailFixture({blocks: [queryBlock]});
+    const executeRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/investigations/${withFailedQuery.id}/blocks/${queryBlock.id}/execute/`,
+      method: 'POST',
+      body: {id: 'execution-2', status: 'running'},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/investigations/${withFailedQuery.id}/blocks/${queryBlock.id}/executions/execution-1/`,
+      body: {
+        id: 'execution-1',
+        status: 'failed',
+        blocks: [
+          {
+            id: 'tool',
+            loading: false,
+            message: {
+              role: 'tool_use',
+              tool_calls: [
+                {
+                  function: 'sentry_api_execute',
+                  args: '{"code":"sentry.telemetry_live_search()"}',
+                },
+              ],
+            },
+            toolResults: [{content: 'Lint failed'}],
+          },
+        ],
+        transcriptTruncated: false,
+        pendingUserInput: null,
+        partialMarkdown: null,
+        error: queryBlock.currentExecution?.error,
+      },
+    });
+
+    renderInvestigation(withFailedQuery);
+
+    expect(await screen.findByText('agent_run_errored')).toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole('button', {name: 'Stopped because of an error'})
+    );
+    expect(await screen.findByText('sentry.telemetry_live_search()')).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', {name: 'Retry'}));
+
+    await waitFor(() => expect(executeRequest).toHaveBeenCalled());
+    expect(executeRequest).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: expect.objectContaining({requestId: expect.any(String)}),
+      })
+    );
+  });
+
+  it('does not expose inline execution when the execution flag is explicitly off', async () => {
+    const queryBlock = InvestigationBlockFixture({
+      id: 'query-block',
+      kind: 'query',
+      generationPrompt: 'Show unresolved errors over the last day',
+    });
+    const organizationWithoutExecution = OrganizationFixture({
+      slug: organization.slug,
+      features: ['investigations'],
+    });
+
+    renderInvestigation(
+      InvestigationDetailFixture({blocks: [queryBlock]}),
+      organizationWithoutExecution
+    );
+
+    expect(await screen.findByRole('button', {name: 'Run'})).toBeDisabled();
+  });
+
+  it('persists collapsing only the natural language query section', async () => {
+    const queryBlock = InvestigationBlockFixture({
+      id: 'query-block',
+      kind: 'query',
+      generationPrompt: 'Show error volume',
+      display: {type: 'table', queryCollapsed: false},
+    });
+    const withQuery = InvestigationDetailFixture({blocks: [queryBlock]});
+    const updateRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/investigations/${withQuery.id}/blocks/${queryBlock.id}/`,
+      method: 'PUT',
+      body: {
+        ...queryBlock,
+        version: queryBlock.version + 1,
+        display: {version: 1, type: 'table', queryCollapsed: true},
+      },
+    });
+    renderInvestigation(withQuery);
+
+    expect(
+      await screen.findByRole('textbox', {name: 'Query block 1'})
+    ).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', {name: 'Natural language query'}));
+
+    expect(
+      screen.queryByRole('textbox', {name: 'Query block 1'})
+    ).not.toBeInTheDocument();
+    await waitFor(() => expect(updateRequest).toHaveBeenCalled(), {
+      timeout: 2000,
+    });
+    expect(updateRequest).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          display: expect.objectContaining({
+            version: 1,
+            queryCollapsed: true,
+          }),
+        }),
+      })
+    );
+  });
+
+  it('collapses prompt sections by default while keeping their actions visible', async () => {
+    const queryBlock = InvestigationBlockFixture({
+      id: 'query-block',
+      kind: 'query',
+      generationPrompt: 'Show error volume grouped by project and environment',
+      display: {type: 'table'},
+    });
+    const textBlock = InvestigationBlockFixture({
+      id: 'text-block',
+      position: 1,
+      generationPrompt: 'Summarize the most important changes in the result',
+      display: {type: 'markdown'},
+    });
+
+    renderInvestigation(InvestigationDetailFixture({blocks: [queryBlock, textBlock]}));
+
+    expect(
+      await screen.findByRole('button', {
+        name: 'Show error volume grouped by project and environment',
+      })
+    ).toHaveAttribute('aria-expanded', 'false');
+    expect(
+      screen.getByRole('button', {
+        name: 'Summarize the most important changes in the result',
+      })
+    ).toHaveAttribute('aria-expanded', 'false');
+    expect(
+      screen.queryByRole('textbox', {name: 'Query block 1'})
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('textbox', {name: 'Text generation prompt 2'})
+    ).not.toBeInTheDocument();
+    expect(screen.getAllByRole('button', {name: 'Run'})).toHaveLength(2);
+    expect(screen.queryByRole('button', {name: 'Generate'})).not.toBeInTheDocument();
+  });
+
+  it('shows dependent auto-run blocks as waiting for earlier blocks', async () => {
+    const parent = InvestigationBlockFixture({
+      id: 'parent-block',
+      kind: 'query',
+      generationPrompt: 'Count checkout errors',
+      config: {autoRun: true},
+      display: {type: 'table'},
+    });
+    const dependent = InvestigationBlockFixture({
+      id: 'dependent-block',
+      position: 1,
+      generationPrompt: 'Summarize the result briefly',
+      config: {autoRun: true},
+      dependencies: [parent.id],
+      display: {type: 'markdown'},
+    });
+
+    renderInvestigation(InvestigationDetailFixture({blocks: [parent, dependent]}));
+
+    expect(await screen.findByText('Waiting for earlier blocks')).toBeInTheDocument();
+    expect(screen.queryByText('Completed')).not.toBeInTheDocument();
+  });
+
+  it('shows dependent auto-run blocks as blocked when an earlier block fails', async () => {
+    const parent = InvestigationBlockFixture({
+      id: 'parent-block',
+      kind: 'query',
+      generationPrompt: 'Count checkout errors',
+      config: {autoRun: true},
+      outputStatus: 'failed',
+      currentExecution: {
+        id: 'parent-execution',
+        status: 'failed',
+        executor: 'code_mode',
+        schemaVersion: 1,
+        error: {code: 'invalid_result', message: 'Malformed result'},
+        startedAt: '2026-08-05T00:00:00Z',
+        completedAt: '2026-08-05T00:01:00Z',
+      },
+      display: {type: 'table'},
+    });
+    const dependent = InvestigationBlockFixture({
+      id: 'dependent-block',
+      position: 1,
+      generationPrompt: 'Summarize the result briefly',
+      config: {autoRun: true},
+      dependencies: [parent.id],
+      display: {type: 'markdown'},
+    });
+
+    renderInvestigation(InvestigationDetailFixture({blocks: [parent, dependent]}));
+
+    expect(
+      await screen.findByText('Blocked because an earlier block did not complete.')
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Waiting for earlier blocks')).not.toBeInTheDocument();
+  });
+
+  it('switches a typed persisted result from table to chart without rerunning', async () => {
+    const queryBlock = InvestigationBlockFixture({
+      id: 'query-block',
+      kind: 'query',
+      generationPrompt: 'Show error volume',
+      outputStatus: 'available',
+      display: {
+        version: 1,
+        type: 'table',
+        defaultView: 'table',
+        queryCollapsed: false,
+      },
+      output: {
+        schemaVersion: 1,
+        tableMarkdown: '| Errors |\n| ---: |\n| 12 |',
+        chart: {
+          x_axis: 'time',
+          visualization: 'area',
+          title: 'Error volume',
+          y_axis_unit: 'number',
+          stacked: false,
+          show_legend: true,
+          series: [
+            {
+              name: 'count()',
+              data: [
+                {x: '2026-07-31T12:00:00Z', y: 12},
+                {x: '2026-07-31T13:00:00Z', y: 18},
+                {x: '2026-07-31T14:00:00Z', y: 15},
+              ],
+            },
+          ],
+        },
+        preferredView: 'table',
+        isEmpty: false,
+        chartUnavailableReason: null,
+        queryLinks: [
+          {
+            kind: 'telemetry',
+            params: {dataset: 'errors', query: 'is:unresolved'},
+          },
+        ],
+      },
+    });
+    const withResult = InvestigationDetailFixture({blocks: [queryBlock]});
+    const executeRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/investigations/${withResult.id}/blocks/${queryBlock.id}/execute/`,
+      method: 'POST',
+      body: {id: 'unexpected', status: 'running'},
+    });
+    const updateRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/investigations/${withResult.id}/blocks/${queryBlock.id}/`,
+      method: 'PUT',
+      body: {
+        ...queryBlock,
+        version: queryBlock.version + 1,
+        display: {
+          version: 1,
+          type: 'area',
+          defaultView: 'chart',
+          xAxis: 'timestamp',
+          yAxes: ['count()'],
+          unit: 'number',
+          stacked: false,
+          showLegend: true,
+          title: 'Error volume',
+          sort: 'descending',
+        },
+      },
+    });
+    renderInvestigation(withResult);
+
+    expect(await screen.findByText('Errors')).toBeInTheDocument();
+    expect(screen.getByRole('textbox', {name: 'Query block 1'})).toHaveValue(
+      'Show error volume'
+    );
+    expect(
+      screen.queryByRole('button', {name: 'Generated query'})
+    ).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', {name: '1 underlying queries'}));
+    expect(screen.getByText(/is:unresolved/)).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', {name: 'Result settings'}));
+    expect(screen.getByRole('dialog', {name: 'Result settings'})).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', {name: 'Chart'}));
+
+    expect(await screen.findByTestId('seer-chart-embed')).toBeInTheDocument();
+    await waitFor(() => expect(updateRequest).toHaveBeenCalled(), {
+      timeout: 2000,
+    });
+    expect(updateRequest).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          display: expect.objectContaining({
+            defaultView: 'chart',
+          }),
+        }),
+      })
+    );
+    expect(executeRequest).not.toHaveBeenCalled();
+    expect(screen.queryByText('Completed')).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Table'}));
+    expect(screen.getByText('Errors')).toBeInTheDocument();
+    await waitFor(() => expect(updateRequest).toHaveBeenCalledTimes(2), {
+      timeout: 2000,
+    });
+    expect(updateRequest).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          display: expect.objectContaining({defaultView: 'table'}),
+        }),
+      })
+    );
+  });
+
+  it('renders a table shell when a successful query returns no rows or columns', async () => {
+    const queryBlock = InvestigationBlockFixture({
+      id: 'query-block',
+      kind: 'query',
+      generationPrompt: 'Show errors from a nonexistent release',
+      outputStatus: 'available',
+      display: {version: 1, type: 'table', defaultView: 'table'},
+      output: {
+        schemaVersion: 1,
+        tableMarkdown: '| Result |\n| --- |',
+        chart: null,
+        preferredView: 'table',
+        isEmpty: true,
+        chartUnavailableReason: 'No meaningful chart data was returned.',
+        queryLinks: [],
+      },
+    });
+
+    renderInvestigation(InvestigationDetailFixture({blocks: [queryBlock]}));
+
+    expect(await screen.findByText('Result')).toBeInTheDocument();
+    expect(screen.getByText('No data returned for this query.')).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', {name: 'Result settings'}));
+    expect(screen.getByRole('button', {name: 'Chart'})).toBeDisabled();
+  });
+
+  it('opens the lazy add-block menu from the keyboard', async () => {
+    renderInvestigation();
+
+    const addBlock = await screen.findByRole('button', {name: 'Add block'});
+    addBlock.focus();
+    await userEvent.keyboard('{ArrowDown}');
+
+    expect(screen.getByRole('menuitemradio', {name: 'Text'})).toBeInTheDocument();
+    expect(screen.getByRole('menuitemradio', {name: 'Query'})).toBeInTheDocument();
+  });
+
+  it('keeps notebook edits disabled for viewers', async () => {
+    const readOnly = InvestigationDetailFixture({
+      permissions: {...detail.permissions, canEdit: false, canManage: false},
+    });
+    renderInvestigation(readOnly);
+
+    expect(await screen.findByText('View only')).toBeInTheDocument();
+    expect(screen.getByText('Understand the regression.')).toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Add block'})).not.toBeInTheDocument();
+  });
+
+  it('filters and keyboard-navigates block commands in a text block', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/investigations/${
+        detail.id
+      }/blocks/${detail.blocks[0]!.id}/`,
+      method: 'PUT',
+      body: InvestigationBlockFixture({content: '## ', version: 2}),
+    });
+    renderInvestigation(
+      InvestigationDetailFixture({
+        blocks: [InvestigationBlockFixture({content: ''})],
+      })
+    );
+
+    const editor = await screen.findByRole('textbox', {name: 'Text block 1'});
+    await userEvent.type(editor, '/');
+
+    expect(screen.getByRole('option', {name: 'Heading 1 #'})).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', {name: 'Query block Insert below'})
+    ).toBeInTheDocument();
+
+    await userEvent.type(editor, 'head');
+    expect(
+      screen.queryByRole('option', {name: 'Query block Insert below'})
+    ).not.toBeInTheDocument();
+    await userEvent.keyboard('{ArrowDown}{Enter}');
+
+    expect(editor).toHaveValue('## ');
+  });
+
+  it('renders markdown syntax in place when a text block is committed', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/investigations/${
+        detail.id
+      }/blocks/${detail.blocks[0]!.id}/`,
+      method: 'PUT',
+      body: InvestigationBlockFixture({content: '# Hello', version: 2}),
+    });
+    renderInvestigation(
+      InvestigationDetailFixture({
+        blocks: [InvestigationBlockFixture({content: ''})],
+      })
+    );
+
+    const editor = await screen.findByRole('textbox', {name: 'Text block 1'});
+    await userEvent.type(editor, '# Hello');
+    await userEvent.tab();
+
+    expect(screen.getByRole('heading', {name: 'Hello'})).toBeInTheDocument();
+  });
+
+  it('runs a text-block prompt inline and shows its linked context', async () => {
+    const textBlock = InvestigationBlockFixture({
+      id: 'text-block',
+      kind: 'text',
+      content: 'Existing notes',
+      generationPrompt: 'Summarize the most important change as Markdown.',
+      dependencies: ['query-block'],
+      outputStatus: 'notRun',
+      display: {type: 'markdown', promptCollapsed: false},
+      version: 3,
+    });
+    const withTextPrompt = InvestigationDetailFixture({
+      blocks: [textBlock],
+      version: 7,
+    });
+    const executeRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/investigations/${withTextPrompt.id}/blocks/${textBlock.id}/execute/`,
+      method: 'POST',
+      body: {id: 'execution-1', status: 'running'},
+    });
+    renderInvestigation(withTextPrompt);
+
+    expect(
+      await screen.findByRole('textbox', {name: 'Text generation prompt 1'})
+    ).toHaveValue('Summarize the most important change as Markdown.');
+    expect(screen.getByText('Uses 1 linked block(s) as context.')).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', {name: 'Run'}));
+
+    await waitFor(() => expect(executeRequest).toHaveBeenCalled());
+    expect(executeRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: {
+          investigationVersion: 7,
+          requestId: expect.any(String),
+          version: 3,
+        },
+      })
+    );
+  });
+
+  it('restores an in-block text generation state after reload', async () => {
+    const textBlock = InvestigationBlockFixture({
+      id: 'text-block',
+      kind: 'text',
+      content: 'Previous summary',
+      generationPrompt: 'Rewrite this summary.',
+      outputStatus: 'running',
+      currentExecution: {
+        id: 'execution-1',
+        status: 'running',
+        executor: 'text_generation',
+        schemaVersion: 1,
+        error: null,
+        startedAt: '2026-08-03T12:00:00Z',
+        completedAt: null,
+      },
+    });
+    renderInvestigation(InvestigationDetailFixture({blocks: [textBlock]}));
+
+    const stopButton = await screen.findByRole('button', {
+      name: 'Stop generation',
+    });
+    expect(stopButton).toBeEnabled();
+    expect(screen.getByText('Thinking')).toBeInTheDocument();
+    expect(screen.getByText('Previous summary')).toBeInTheDocument();
+  });
+
+  it('inserts a block between existing blocks and persists the new order', async () => {
+    const secondBlock = InvestigationBlockFixture({
+      id: 'second-block',
+      position: 1,
+    });
+    const withTwoBlocks = InvestigationDetailFixture({
+      blocks: [detail.blocks[0]!, secondBlock],
+    });
+    const insertedBlock = InvestigationBlockFixture({
+      id: 'inserted-block',
+      position: 2,
+      content: '',
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/investigations/${detail.id}/blocks/`,
+      method: 'POST',
+      body: insertedBlock,
+    });
+    const reorderRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/investigations/${detail.id}/blocks/order/`,
+      method: 'PUT',
+      body: {
+        ...withTwoBlocks,
+        version: 3,
+        blocks: [withTwoBlocks.blocks[0]!, insertedBlock, secondBlock],
+      },
+    });
+    renderInvestigation(withTwoBlocks);
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Add block here'}));
+    await userEvent.click(screen.getByRole('menuitemradio', {name: 'Text'}));
+
+    await waitFor(() => expect(reorderRequest).toHaveBeenCalled());
+    expect(reorderRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          blockIds: [detail.blocks[0]!.id, insertedBlock.id, secondBlock.id],
+        }),
+      })
+    );
+  });
+
+  it('preserves the local draft and offers recovery after a version conflict', async () => {
+    MockApiClient.addMockResponse({
+      url: detailUrl,
+      method: 'PUT',
+      statusCode: 409,
+      body: {detail: 'Version conflict'},
+    });
+    renderInvestigation();
+
+    await userEvent.click(
+      await screen.findByRole('button', {name: 'Edit investigation name'})
+    );
+    const title = await screen.findByRole('textbox', {
+      name: 'Investigation name',
+    });
+    await userEvent.clear(title);
+    await userEvent.type(title, 'My local draft');
+    await userEvent.keyboard('{Enter}');
+
+    expect(
+      await screen.findByText(
+        'This investigation changed elsewhere. Your local draft is still here.'
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: 'Edit investigation name'})
+    ).toHaveTextContent('My local draft');
+    expect(screen.getByRole('button', {name: 'Reload latest'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Retry my change'})).toBeInTheDocument();
+  });
+
+  it('reorders blocks through the drag handle', async () => {
+    const secondBlock = InvestigationBlockFixture({
+      id: 'second-block',
+      position: 1,
+    });
+    const withTwoBlocks = InvestigationDetailFixture({
+      blocks: [detail.blocks[0]!, secondBlock],
+    });
+    const reorderRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/investigations/${detail.id}/blocks/order/`,
+      method: 'PUT',
+      body: {
+        ...withTwoBlocks,
+        version: 2,
+        blocks: [secondBlock, detail.blocks[0]!],
+      },
+    });
+    renderInvestigation(withTwoBlocks);
+
+    expect(await screen.findAllByText('Understand the regression.')).toHaveLength(2);
+    const articles = document.querySelectorAll('article');
+    expect(articles).toHaveLength(2);
+    articles.forEach((article, index) => {
+      article.getBoundingClientRect = () => ({
+        bottom: index * 100 + 80,
+        height: 80,
+        left: 0,
+        right: 800,
+        top: index * 100,
+        width: 800,
+        x: 0,
+        y: index * 100,
+        toJSON: () => {},
+      });
+    });
+
+    const handles = screen.getAllByRole('button', {name: 'Drag to reorder'});
+    fireEvent(handles[0]!, makePointerEvent('pointerdown', 10));
+    fireEvent(document, makePointerEvent('pointermove', 20));
+    await waitFor(() =>
+      expect(document.querySelector('[id^="DndLiveRegion"]')).toHaveTextContent(
+        'was moved over'
+      )
+    );
+    fireEvent(document, makePointerEvent('pointermove', 130));
+    await act(async () => Promise.resolve());
+    fireEvent(document, makePointerEvent('pointerup', 130));
+
+    await waitFor(() => expect(reorderRequest).toHaveBeenCalled());
+    expect(reorderRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          blockIds: [secondBlock.id, detail.blocks[0]!.id],
+        }),
+      })
+    );
+  });
+
+  it('validates declared parameter constraints before saving', async () => {
+    const withParameter = InvestigationDetailFixture({
+      parameters: [
+        {
+          id: 'parameter-id',
+          key: 'environment',
+          label: 'Environment',
+          description: '',
+          type: 'string',
+          required: true,
+          constraints: {maxLength: 5},
+          defaultValue: 'prod',
+          savedValue: 'prod',
+          source: 'template',
+          position: 0,
+          version: 1,
+        },
+      ],
+    });
+    renderInvestigation(withParameter);
+
+    const parameter = await screen.findByDisplayValue('prod');
+    fireEvent.change(parameter, {target: {value: ''}});
+    expect(screen.getByText('This parameter is required.')).toBeInTheDocument();
+
+    fireEvent.change(parameter, {target: {value: 'production'}});
+    expect(screen.getByText('Use no more than 5 characters.')).toBeInTheDocument();
+  });
+});
+
+function makePointerEvent(type: string, clientY: number) {
+  const event = new Event(type, {bubbles: true, cancelable: true});
+  Object.defineProperties(event, {
+    button: {value: 0},
+    clientX: {value: 10},
+    clientY: {value: clientY},
+    isPrimary: {value: true},
+    pointerId: {value: 1},
+  });
+  return event;
+}

--- a/static/app/views/seerNotebook/investigation.tsx
+++ b/static/app/views/seerNotebook/investigation.tsx
@@ -1,0 +1,1758 @@
+import {
+  Fragment,
+  memo,
+  Profiler,
+  type ProfilerOnRenderCallback,
+  type ReactNode,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import {useParams} from 'react-router-dom';
+import {
+  closestCenter,
+  DndContext,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import {CSS} from '@dnd-kit/utilities';
+import {css, keyframes} from '@emotion/react';
+import styled from '@emotion/styled';
+import {uuid4} from '@sentry/core';
+import {useQueryClient} from '@tanstack/react-query';
+import {observer} from 'mobx-react-lite';
+
+import {Alert} from '@sentry/scraps/alert';
+import {Badge} from '@sentry/scraps/badge';
+import {BreadcrumbList} from '@sentry/scraps/breadcrumbList';
+import {Button} from '@sentry/scraps/button';
+import {CompactSelect} from '@sentry/scraps/compactSelect';
+import {Disclosure} from '@sentry/scraps/disclosure';
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Markdown} from '@sentry/scraps/markdown';
+import {useModal} from '@sentry/scraps/modal';
+import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
+import {Heading, Text} from '@sentry/scraps/text';
+import {TextArea} from '@sentry/scraps/textarea';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
+import type {ModalRenderProps} from 'sentry/actionCreators/modal';
+import {FeatureDisabled} from 'sentry/components/acl/featureDisabled';
+import {openConfirmModal} from 'sentry/components/confirm';
+import {DateTime} from 'sentry/components/dateTime';
+import {DragReorderButton} from 'sentry/components/dnd/dragReorderButton';
+import {DropdownMenu, type DropdownMenuProps} from 'sentry/components/dropdownMenu';
+import {LoadingError} from 'sentry/components/loadingError';
+import {PageFiltersContainer} from 'sentry/components/pageFilters/container';
+import {DatePageFilter} from 'sentry/components/pageFilters/date/datePageFilter';
+import {EnvironmentPageFilter} from 'sentry/components/pageFilters/environment/environmentPageFilter';
+import {PageFilterBar} from 'sentry/components/pageFilters/pageFilterBar';
+import {ProjectPageFilter} from 'sentry/components/pageFilters/project/projectPageFilter';
+import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
+import {DEFAULT_RELEASES_SORT} from 'sentry/constants/releases';
+import {
+  IconAdd,
+  IconClock,
+  IconCode,
+  IconDelete,
+  IconMarkdown,
+  IconPause,
+  IconPlay,
+  IconSettings,
+  IconStar,
+} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {SortableReleasesSelect} from 'sentry/views/dashboards/sortableReleasesSelect';
+import {DashboardFilterKeys} from 'sentry/views/dashboards/types';
+import {TopBar} from 'sentry/views/navigation/topBar';
+import type {BlockStore} from 'sentry/views/seerNotebook/stores/blockStore';
+import {NotebookStore} from 'sentry/views/seerNotebook/stores/notebookStore';
+import {
+  NotebookStoreProvider,
+  useNotebookStore,
+} from 'sentry/views/seerNotebook/stores/storeContext';
+import {QueryClientInvestigationTransport} from 'sentry/views/seerNotebook/stores/transport';
+
+import {
+  ChartSettingsControl,
+  PersistedBlockOutput,
+  TextBlockExecutionOutput,
+} from './output';
+import {InvestigationParameters} from './parameters';
+import {InvestigationSettings} from './settings';
+import type {
+  InvestigationBlockKind,
+  InvestigationDetail,
+  InvestigationFilters,
+} from './types';
+
+const QUERY_EXAMPLE_STREAM_FRAMES = 24;
+const QUERY_EXAMPLE_STREAM_INTERVAL_MS = 16;
+
+type SeerInvestigationProps = {
+  onBlockListRender?: ProfilerOnRenderCallback;
+  onBlockRender?: (clientKey: string) => void;
+};
+
+export default function SeerInvestigation() {
+  return <SeerInvestigationView />;
+}
+
+export function SeerInvestigationPerformanceHarness(props: SeerInvestigationProps) {
+  return <SeerInvestigationView {...props} />;
+}
+
+function SeerInvestigationView({
+  onBlockListRender,
+  onBlockRender,
+}: SeerInvestigationProps) {
+  const organization = useOrganization();
+  const {investigationId} = useParams<{investigationId: string}>();
+  if (!organization.features.includes('investigations')) {
+    return (
+      <FeatureDisabled
+        features="organizations:investigations"
+        featureName={t('Investigations')}
+      />
+    );
+  }
+  return (
+    <SeerInvestigationContent
+      key={investigationId ?? 'missing'}
+      onBlockListRender={onBlockListRender}
+      onBlockRender={onBlockRender}
+    />
+  );
+}
+
+function SeerInvestigationContent({
+  onBlockListRender,
+  onBlockRender,
+}: SeerInvestigationProps) {
+  const {investigationId} = useParams<{investigationId: string}>();
+  const organization = useOrganization();
+  const queryClient = useQueryClient();
+  const [store] = useState(
+    () =>
+      new NotebookStore({
+        idGenerator: uuid4,
+        investigationId: investigationId ?? 'missing',
+        organizationSlug: organization.slug,
+        queryExecutionEnabled: organization.features.includes(
+          'investigations-query-execution'
+        ),
+        transport: new QueryClientInvestigationTransport(
+          queryClient,
+          organization.slug,
+          investigationId ?? 'missing'
+        ),
+      })
+  );
+
+  useEffect(() => {
+    void store.load();
+    return () => store.dispose();
+  }, [store]);
+
+  if (!investigationId) {
+    return <LoadingError message={t('No investigation was selected.')} />;
+  }
+
+  return (
+    <NotebookStoreProvider store={store}>
+      <InvestigationEditor
+        onBlockListRender={onBlockListRender}
+        onBlockRender={onBlockRender}
+      />
+    </NotebookStoreProvider>
+  );
+}
+
+const InvestigationEditor = observer(
+  ({onBlockListRender, onBlockRender}: SeerInvestigationProps) => {
+    const store = useNotebookStore();
+    const organization = useOrganization();
+    const {openModal} = useModal();
+    const [isEditingTitle, setIsEditingTitle] = useState(false);
+    const sensors = useSensors(
+      useSensor(PointerSensor, {activationConstraint: {distance: 6}})
+    );
+
+    if (store.loadState === 'error') {
+      return <LoadingError onRetry={() => store.retryLoad()} />;
+    }
+    if (store.loadState !== 'ready') {
+      return <LoadingState>{t('Loading investigation…')}</LoadingState>;
+    }
+
+    const detail = store.detail;
+    const readOnly = store.isReadOnly;
+
+    const commitTitle = () => {
+      setIsEditingTitle(false);
+      void store
+        .commitTitle()
+        .catch(() => addErrorMessage(t('The investigation change could not be saved.')));
+    };
+
+    const saveMetadata = (values: {
+      filters?: Partial<InvestigationFilters>;
+      projectIds?: number[];
+    }) => store.saveMetadata(values);
+
+    const toggleFavorite = async () => {
+      try {
+        await store.toggleFavorite();
+      } catch {
+        addErrorMessage(t('The investigation favorite could not be updated.'));
+      }
+    };
+
+    const openSettings = () => {
+      openModal(
+        modalProps => (
+          <InvestigationSettingsModal
+            {...modalProps}
+            store={store}
+            onArchive={() => {
+              openConfirmModal({
+                message: t('Archive this investigation? It will become read-only.'),
+                confirmText: t('Archive'),
+                priority: 'danger',
+                onConfirm: () => store.archive(),
+              });
+            }}
+          />
+        ),
+        {
+          modalCss: css`
+            width: min(600px, 90vw);
+          `,
+        }
+      );
+    };
+
+    const openHistory = () => {
+      openModal(
+        modalProps => <InvestigationHistoryModal {...modalProps} detail={detail} />,
+        {
+          modalCss: css`
+            width: min(600px, 90vw);
+          `,
+        }
+      );
+    };
+
+    const editor = (
+      <EditorPage>
+        {store.conflict ? (
+          <Alert.Container>
+            <Alert
+              variant="warning"
+              trailingItems={
+                <Flex gap="sm">
+                  <Alert.Button onClick={() => void store.reloadLatest()}>
+                    {t('Reload latest')}
+                  </Alert.Button>
+                  <Alert.Button
+                    onClick={() => void store.retryChange()}
+                    variant="primary"
+                  >
+                    {t('Retry my change')}
+                  </Alert.Button>
+                </Flex>
+              }
+            >
+              {t('This investigation changed elsewhere. Your local draft is still here.')}
+            </Alert>
+          </Alert.Container>
+        ) : null}
+        <NotebookControls>
+          <FilterControls>
+            <PageFilterBar condensed>
+              <ProjectPageFilter
+                disabled={readOnly}
+                onChange={projectIds => saveMetadata({projectIds})}
+              />
+              <EnvironmentPageFilter
+                disabled={readOnly}
+                onChange={environments => saveMetadata({filters: {environments}})}
+              />
+              <DatePageFilter
+                disabled={readOnly}
+                onChange={({relative, start, end, utc}) =>
+                  saveMetadata({
+                    filters: {
+                      datetime: {
+                        period: relative ?? undefined,
+                        start: start?.toISOString(),
+                        end: end?.toISOString(),
+                        utc: utc ?? undefined,
+                      },
+                    },
+                  })
+                }
+              />
+            </PageFilterBar>
+            <SortableReleasesSelect
+              sortBy={DEFAULT_RELEASES_SORT}
+              selectedReleases={detail.filters.releases ?? []}
+              isDisabled={readOnly}
+              handleChangeFilter={filters =>
+                saveMetadata({
+                  filters: {
+                    releases: filters[DashboardFilterKeys.RELEASE] ?? [],
+                  },
+                })
+              }
+            />
+            <InvestigationParameters store={store} />
+          </FilterControls>
+          <CompactSelect
+            value={detail.filters.interval ?? '10m'}
+            disabled={readOnly}
+            onChange={option => saveMetadata({filters: {interval: option.value}})}
+            trigger={triggerProps => (
+              <OverlayTrigger.Button {...triggerProps} icon={<IconClock />} />
+            )}
+            menuTitle={t('Interval')}
+            options={[
+              {value: '5m', label: t('5 minutes')},
+              {value: '10m', label: t('10 minutes')},
+              {value: '30m', label: t('30 minutes')},
+              {value: '1h', label: t('1 hour')},
+            ]}
+          />
+        </NotebookControls>
+        <NotebookContent>
+          <NotebookHeading>
+            {isEditingTitle ? (
+              <NotebookTitleInput
+                autoFocus
+                aria-label={t('Investigation name')}
+                value={store.titleDraft}
+                onChange={event => store.editTitle(event.target.value)}
+                onBlur={commitTitle}
+                onKeyDown={event => {
+                  if (event.key === 'Enter') {
+                    event.preventDefault();
+                    commitTitle();
+                  } else if (event.key === 'Escape') {
+                    store.cancelTitleEdit();
+                    setIsEditingTitle(false);
+                  }
+                }}
+              />
+            ) : (
+              <NotebookTitleButton
+                type="button"
+                disabled={readOnly || store.isTitleGenerating}
+                aria-label={t('Edit investigation name')}
+                onClick={() => {
+                  store.editTitle(detail.title);
+                  setIsEditingTitle(true);
+                }}
+              >
+                {store.isTitleGenerating
+                  ? store.titleGenerationPreview || t('Writing title…')
+                  : detail.title}
+              </NotebookTitleButton>
+            )}
+            <Flex align="center" gap="sm" wrap="wrap">
+              <Badge variant={detail.status === 'active' ? 'success' : 'muted'}>
+                {detail.status === 'active' ? t('Active') : t('Archived')}
+              </Badge>
+              <InvestigationSavingStatus store={store} />
+              {detail.permissions.canEdit ? null : (
+                <Badge variant="muted">{t('View only')}</Badge>
+              )}
+            </Flex>
+          </NotebookHeading>
+
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={(event: DragEndEvent) => {
+              if (readOnly || !event.over || event.active.id === event.over.id) {
+                return;
+              }
+              void store
+                .moveBlock(String(event.active.id), String(event.over.id))
+                .catch(() =>
+                  addErrorMessage(t('The investigation change could not be saved.'))
+                );
+            }}
+          >
+            <SortableContext
+              items={store.blockKeys}
+              strategy={verticalListSortingStrategy}
+            >
+              <OptionalProfiler
+                id="investigation-block-list"
+                onRender={onBlockListRender}
+              >
+                <BlockList>
+                  {store.blocksInOrder.map((blockStore, index) => (
+                    <Fragment key={blockStore.clientKey}>
+                      {index > 0 && !readOnly ? (
+                        <MemoizedBlockInsertDivider
+                          index={index}
+                          onInsert={(kind, insertIndex) =>
+                            store.insertBlock(kind, insertIndex)
+                          }
+                        />
+                      ) : null}
+                      <MemoizedSortableBlock
+                        block={blockStore}
+                        index={index}
+                        disabled={readOnly}
+                        onInsertAfter={kind => store.insertBlock(kind, index + 1)}
+                        onRender={onBlockRender}
+                        onDelete={() =>
+                          openConfirmModal({
+                            message: t('Delete this block?'),
+                            confirmText: t('Delete'),
+                            priority: 'danger',
+                            onConfirm: () => store.deleteBlock(blockStore.clientKey),
+                          })
+                        }
+                      />
+                    </Fragment>
+                  ))}
+                </BlockList>
+              </OptionalProfiler>
+            </SortableContext>
+          </DndContext>
+
+          {readOnly ? null : (
+            <MemoizedBlockInsertDivider
+              index={detail.blocks.length}
+              isEnd
+              onInsert={(kind, index) => store.insertBlock(kind, index)}
+            />
+          )}
+        </NotebookContent>
+      </EditorPage>
+    );
+
+    const savedDatetime = detail.filters.datetime ?? {};
+
+    return (
+      <PageFiltersContainer
+        key={`${detail.id}:filters`}
+        disablePersistence
+        skipLoadLastUsed
+        defaultSelection={{
+          projects: detail.projectIds.length ? detail.projectIds : [-1],
+          environments: detail.filters.environments ?? [],
+          datetime: {
+            period: savedDatetime.period ?? '24h',
+            start: savedDatetime.start ?? null,
+            end: savedDatetime.end ?? null,
+            utc: savedDatetime.utc ?? false,
+          },
+        }}
+      >
+        <SentryDocumentTitle title={detail.title}>
+          <TopBar.Slot name="breadcrumbs">
+            <BreadcrumbList
+              items={[
+                {
+                  type: 'link',
+                  label: t('Investigations'),
+                  to: `/organizations/${organization.slug}/seer/`,
+                },
+              ]}
+            />
+          </TopBar.Slot>
+          <TopBar.Slot name="title">
+            <BreadcrumbList.Title
+              item={{
+                type: 'page-title',
+                label: detail.title,
+              }}
+            />
+          </TopBar.Slot>
+          <TopBar.Slot name="actions">
+            <Tooltip title={detail.isFavorited ? t('Unstar') : t('Star')}>
+              <Button
+                size="sm"
+                aria-label={
+                  detail.isFavorited ? t('Unstar investigation') : t('Star investigation')
+                }
+                icon={
+                  <IconStar
+                    isSolid={detail.isFavorited}
+                    variant={detail.isFavorited ? 'warning' : 'muted'}
+                  />
+                }
+                disabled={store.isUpdatingFavorite}
+                onClick={toggleFavorite}
+              />
+            </Tooltip>
+            <Tooltip title={t('Edit history')}>
+              <Button
+                size="sm"
+                aria-label={t('Edit history')}
+                icon={<IconClock />}
+                onClick={openHistory}
+              />
+            </Tooltip>
+            <Tooltip title={t('Investigation settings')}>
+              <Button
+                size="sm"
+                aria-label={t('Investigation settings')}
+                icon={<IconSettings />}
+                onClick={openSettings}
+              />
+            </Tooltip>
+          </TopBar.Slot>
+          <Workspace>{editor}</Workspace>
+        </SentryDocumentTitle>
+      </PageFiltersContainer>
+    );
+  }
+);
+
+const InvestigationSavingStatus = observer(({store}: {store: NotebookStore}) => {
+  return (
+    <Text size="sm" variant="muted">
+      {store.isSaving ? t('Saving…') : t('All changes saved')}
+    </Text>
+  );
+});
+
+function OptionalProfiler({
+  children,
+  id,
+  onRender,
+}: {
+  children: ReactNode;
+  id: string;
+  onRender?: ProfilerOnRenderCallback;
+}) {
+  return onRender ? (
+    <Profiler id={id} onRender={onRender}>
+      {children}
+    </Profiler>
+  ) : (
+    children
+  );
+}
+
+function InvestigationSettingsModal({
+  Header,
+  Body,
+  Footer,
+  closeModal,
+  store,
+  onArchive,
+}: ModalRenderProps & {
+  onArchive: () => void;
+  store: NotebookStore;
+}) {
+  return (
+    <Fragment>
+      <Header closeButton>
+        <Heading as="h4">{t('Investigation settings')}</Heading>
+      </Header>
+      <Body>
+        <InvestigationSettings store={store} onArchive={onArchive} />
+      </Body>
+      <Footer>
+        <Button size="sm" onClick={closeModal}>
+          {t('Done')}
+        </Button>
+      </Footer>
+    </Fragment>
+  );
+}
+
+function InvestigationHistoryModal({
+  Header,
+  Body,
+  Footer,
+  closeModal,
+  detail,
+}: ModalRenderProps & {detail: InvestigationDetail}) {
+  return (
+    <Fragment>
+      <Header closeButton>
+        <Heading as="h4">{t('Edit history')}</Heading>
+      </Header>
+      <Body>
+        <HistoryCurrent>
+          <Stack gap="xs">
+            <Text bold>{t('Current version')}</Text>
+            <Text size="sm" variant="muted">
+              {t('Version %s', detail.version)} · <DateTime date={detail.dateUpdated} />
+            </Text>
+          </Stack>
+          <Badge variant="success">{t('Current')}</Badge>
+        </HistoryCurrent>
+        <Text size="sm" variant="muted">
+          {t('Earlier notebook versions will appear here as edit history is recorded.')}
+        </Text>
+      </Body>
+      <Footer>
+        <Button size="sm" onClick={closeModal}>
+          {t('Done')}
+        </Button>
+      </Footer>
+    </Fragment>
+  );
+}
+
+type SortableBlockProps = {
+  block: BlockStore;
+  disabled: boolean;
+  index: number;
+  onDelete: () => void;
+  onInsertAfter: (kind: InvestigationBlockKind) => Promise<void>;
+  onRender?: (clientKey: string) => void;
+};
+
+type SortableBlockState = ReturnType<typeof useSortable>;
+type SortableBlockPresentation = {
+  dropIndicator: 'after' | 'before' | null;
+  isDragActive: boolean;
+};
+
+const BlockExecutionControl = observer(
+  ({
+    block,
+    hidden,
+    disabled,
+  }: {
+    block: BlockStore;
+    disabled: boolean;
+    hidden: boolean;
+  }) => {
+    const mode = block.executionControlMode;
+    const isWorking = mode === 'stop';
+    const isStopping = block.outputStatus === 'stopping';
+    const isTextBlock = block.kind === 'text';
+
+    const activate = async () => {
+      try {
+        await block.activateExecutionControl();
+      } catch {
+        addErrorMessage(
+          mode === 'stop'
+            ? isTextBlock
+              ? t('The generation could not be stopped.')
+              : t('The query could not be stopped.')
+            : isTextBlock
+              ? t('The generation could not be started.')
+              : t('The query could not be started.')
+        );
+      }
+    };
+
+    return (
+      <QueryRunButton
+        $hidden={hidden}
+        $stoppable={isWorking && !isStopping && !block.isRunRequested}
+        size="xs"
+        variant={mode === 'retry' ? 'primary' : block.runButtonVariant}
+        icon={isWorking || mode === 'retry' ? undefined : <IconPlay size="xs" />}
+        aria-label={
+          isWorking ? (isTextBlock ? t('Stop generation') : t('Stop query')) : undefined
+        }
+        disabled={
+          disabled ||
+          block.isRunRequested ||
+          isStopping ||
+          (mode !== 'stop' && !block.canRun)
+        }
+        onClick={() => void activate()}
+      >
+        {isWorking ? (
+          <ExecutionButtonLabels>
+            <WorkingButtonLabel>
+              <LoadingDot aria-hidden="true" data-test-id="block-run-spinner" />
+            </WorkingButtonLabel>
+            <StopButtonLabel>
+              <IconPause size="xs" />
+              {t('Stop')}
+            </StopButtonLabel>
+          </ExecutionButtonLabels>
+        ) : mode === 'retry' ? (
+          t('Retry')
+        ) : (
+          t('Run')
+        )}
+      </QueryRunButton>
+    );
+  }
+);
+
+function SortableBlock(props: SortableBlockProps) {
+  const sortable = useSortable({
+    id: props.block.clientKey,
+    disabled: props.disabled,
+  });
+  const isDragActive = sortable.activeIndex >= 0;
+  const dropIndicator =
+    isDragActive &&
+    sortable.overIndex === props.index &&
+    sortable.activeIndex !== props.index
+      ? sortable.activeIndex < props.index
+        ? 'after'
+        : 'before'
+      : null;
+  return (
+    <MemoizedSortableBlockContent
+      {...props}
+      sortable={sortable}
+      isDragActive={isDragActive}
+      dropIndicator={dropIndicator}
+    />
+  );
+}
+
+function SortableBlockContent({
+  block,
+  index,
+  dropIndicator,
+  isDragActive,
+  disabled,
+  onInsertAfter,
+  onDelete,
+  onRender,
+  sortable,
+}: SortableBlockProps & SortableBlockPresentation & {sortable: SortableBlockState}) {
+  onRender?.(block.clientKey);
+  const draft = {
+    title: block.title,
+    content: block.content,
+    generationPrompt: block.generationPrompt,
+    display: block.display,
+  };
+  const {notebook} = block;
+  const queryExecutionEnabled = notebook.queryExecutionEnabled;
+  const [isEditingText, setIsEditingText] = useState(!block.content && !disabled);
+  const [showSlashMenu, setShowSlashMenu] = useState(false);
+  const [slashCommandIndex, setSlashCommandIndex] = useState(0);
+  const textInputRef = useRef<HTMLTextAreaElement>(null);
+  const slashMenuRef = useRef<HTMLDivElement>(null);
+  const suggestionTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const previousOutputStatusRef = useRef(block.outputStatus);
+  const queryIntent = block.queryIntent;
+  const promptCollapsed = draft.display.promptCollapsed !== false;
+  const queryCollapsed = draft.display.queryCollapsed !== false;
+
+  useEffect(() => {
+    const previousStatus = previousOutputStatusRef.current;
+    previousOutputStatusRef.current = block.outputStatus;
+    if (
+      block.kind === 'text' &&
+      ['pending', 'running'].includes(previousStatus) &&
+      block.outputStatus === 'available'
+    ) {
+      setIsEditingText(false);
+    }
+  }, [block.kind, block.outputStatus]);
+  useEffect(
+    () => () => {
+      if (suggestionTimerRef.current) {
+        clearInterval(suggestionTimerRef.current);
+      }
+    },
+    []
+  );
+
+  useEffect(() => {
+    if (!isEditingText) {
+      return;
+    }
+    requestAnimationFrame(() => {
+      textInputRef.current?.focus();
+      const position = textInputRef.current?.value.length ?? 0;
+      textInputRef.current?.setSelectionRange(position, position);
+    });
+  }, [isEditingText]);
+
+  const saveOnBlur = () => {
+    void block
+      .flush()
+      .catch(() => addErrorMessage(t('The block change could not be saved.')));
+  };
+
+  const applySlashCommand = (prefix: string) => {
+    block.applySlashCommand(prefix);
+    setShowSlashMenu(false);
+    requestAnimationFrame(() => {
+      textInputRef.current?.focus();
+      const position = block.content.length;
+      textInputRef.current?.setSelectionRange(position, position);
+    });
+  };
+
+  const slashCommands = [
+    {key: 'text', label: t('Text'), hint: t('Plain text'), prefix: ''},
+    {key: 'h1', label: t('Heading 1'), hint: '#', prefix: '# '},
+    {key: 'h2', label: t('Heading 2'), hint: '##', prefix: '## '},
+    {key: 'h3', label: t('Heading 3'), hint: '###', prefix: '### '},
+    {key: 'bullet', label: t('Bulleted list'), hint: '•', prefix: '- '},
+    {key: 'number', label: t('Numbered list'), hint: '1.', prefix: '1. '},
+    {key: 'quote', label: t('Quote'), hint: '>', prefix: '> '},
+    {key: 'code', label: t('Code block'), hint: '```', prefix: '```\n\n```'},
+    {key: 'divider', label: t('Divider'), hint: '—', prefix: '---'},
+    {
+      key: 'query',
+      label: t('Query block'),
+      hint: t('Insert below'),
+      prefix: '',
+    },
+  ];
+  const slashQuery =
+    draft.content.split('\n').at(-1)?.slice(1).trim().toLowerCase() ?? '';
+  const filteredSlashCommands = slashCommands.filter(command =>
+    `${command.label} ${command.key}`.toLowerCase().includes(slashQuery)
+  );
+
+  const selectSlashCommand = (command: (typeof slashCommands)[number]) => {
+    if (command.key === 'query') {
+      const nextDraft = {
+        ...draft,
+        content: draft.content.replace(/\/[^\n]*$/, ''),
+      };
+      block.editContent(nextDraft.content);
+      void block.flush();
+      setShowSlashMenu(false);
+      void onInsertAfter('query');
+      return;
+    }
+    applySlashCommand(command.prefix);
+  };
+
+  const queryExample = t(
+    'Compare error volume over time across the selected projects. Show daily error counts for the last 30 days, grouped by project.'
+  );
+
+  const streamQuerySuggestion = (suggestion: string) => {
+    if (suggestionTimerRef.current) {
+      clearInterval(suggestionTimerRef.current);
+    }
+    let characterIndex = 0;
+    const charactersPerFrame = Math.max(
+      1,
+      Math.ceil(suggestion.length / QUERY_EXAMPLE_STREAM_FRAMES)
+    );
+    block.clearQueryIntent();
+    textInputRef.current?.focus();
+    suggestionTimerRef.current = setInterval(() => {
+      characterIndex = Math.min(suggestion.length, characterIndex + charactersPerFrame);
+      block.editQueryIntent(suggestion.slice(0, characterIndex));
+      if (characterIndex >= suggestion.length) {
+        if (suggestionTimerRef.current) {
+          clearInterval(suggestionTimerRef.current);
+          suggestionTimerRef.current = null;
+        }
+      }
+    }, QUERY_EXAMPLE_STREAM_INTERVAL_MS);
+  };
+
+  return (
+    <BlockCard
+      $kind={block.kind}
+      $isDragging={sortable.isDragging}
+      $dropIndicator={dropIndicator}
+      ref={sortable.setNodeRef}
+      style={{
+        transform: sortable.transform
+          ? `${CSS.Transform.toString({
+              ...sortable.transform,
+              scaleX: 1,
+              scaleY: 1,
+            })} rotate(${sortable.isDragging ? 1.5 : 0}deg)`
+          : undefined,
+        transition: sortable.transition,
+      }}
+    >
+      {disabled ? null : (
+        <BlockDragHandle $isDragActive={isDragActive} $isDragging={sortable.isDragging}>
+          <DragReorderButton {...sortable.attributes} {...sortable.listeners} size="xs" />
+        </BlockDragHandle>
+      )}
+      <BlockActionsRail $hidden={isDragActive}>
+        {disabled ? null : (
+          <Button
+            size="xs"
+            variant="transparent"
+            icon={<IconDelete />}
+            aria-label={t('Delete block %s', index + 1)}
+            onClick={onDelete}
+          />
+        )}
+      </BlockActionsRail>
+      <BlockSurface $isDragging={sortable.isDragging}>
+        {block.kind === 'text' ? (
+          <Fragment>
+            <QueryPromptDisclosure
+              $expanded={!promptCollapsed}
+              size="sm"
+              expanded={!promptCollapsed}
+              onExpandedChange={expanded =>
+                block.setPromptSectionCollapsed('prompt', !expanded)
+              }
+            >
+              <Disclosure.Title
+                trailingItems={
+                  <HeaderActions>
+                    <BlockExecutionControl
+                      block={block}
+                      hidden={isDragActive}
+                      disabled={
+                        disabled ||
+                        !draft.generationPrompt.trim() ||
+                        !queryExecutionEnabled
+                      }
+                    />
+                  </HeaderActions>
+                }
+              >
+                <QuerySummary size="sm">
+                  {promptCollapsed
+                    ? draft.generationPrompt || t('Text generation prompt')
+                    : t('Text generation prompt')}
+                </QuerySummary>
+              </Disclosure.Title>
+              <QueryPromptContent>
+                <QueryEditorWrap>
+                  <BlockInput
+                    $kind="query"
+                    aria-label={t('Text generation prompt %s', index + 1)}
+                    autosize
+                    rows={2}
+                    maxRows={18}
+                    disabled={disabled}
+                    placeholder={t('Describe the Markdown you want the agent to write')}
+                    value={draft.generationPrompt}
+                    onChange={event => block.editGenerationPrompt(event.target.value)}
+                    onBlur={saveOnBlur}
+                  />
+                  {block.dependencies.length ? (
+                    <ContextHint size="xs" variant="muted">
+                      {t(
+                        'Uses %s linked block(s) as context.',
+                        block.dependencies.length
+                      )}
+                    </ContextHint>
+                  ) : null}
+                </QueryEditorWrap>
+              </QueryPromptContent>
+            </QueryPromptDisclosure>
+            <TextBlockBody>
+              {isEditingText ? (
+                <TextEditorWrap>
+                  <BlockInput
+                    ref={textInputRef}
+                    $kind="text"
+                    aria-label={t('Text block %s', index + 1)}
+                    autosize
+                    autoFocus={!draft.content}
+                    rows={Math.max(2, draft.content.split('\n').length)}
+                    maxRows={24}
+                    placeholder={t("Type '/' for commands")}
+                    value={draft.content}
+                    onChange={event => {
+                      const content = event.target.value;
+                      const nextShowSlashMenu =
+                        content.split('\n').at(-1)?.startsWith('/') ?? false;
+                      block.editContent(content);
+                      if (showSlashMenu !== nextShowSlashMenu) {
+                        setShowSlashMenu(nextShowSlashMenu);
+                      }
+                      if (nextShowSlashMenu && slashCommandIndex !== 0) {
+                        setSlashCommandIndex(0);
+                      }
+                    }}
+                    onKeyDown={event => {
+                      if (!showSlashMenu || !filteredSlashCommands.length) {
+                        return;
+                      }
+                      if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+                        event.preventDefault();
+                        const direction = event.key === 'ArrowDown' ? 1 : -1;
+                        setSlashCommandIndex(
+                          current =>
+                            (current + direction + filteredSlashCommands.length) %
+                            filteredSlashCommands.length
+                        );
+                      } else if (event.key === 'Enter') {
+                        event.preventDefault();
+                        selectSlashCommand(
+                          filteredSlashCommands[
+                            Math.min(slashCommandIndex, filteredSlashCommands.length - 1)
+                          ]!
+                        );
+                      } else if (event.key === 'Escape') {
+                        event.preventDefault();
+                        setShowSlashMenu(false);
+                      }
+                    }}
+                    onBlur={event => {
+                      if (slashMenuRef.current?.contains(event.relatedTarget)) {
+                        return;
+                      }
+                      saveOnBlur();
+                      if (draft.content) {
+                        setIsEditingText(false);
+                      }
+                      setShowSlashMenu(false);
+                    }}
+                  />
+                  {showSlashMenu ? (
+                    <SlashCommandMenu ref={slashMenuRef} role="listbox">
+                      {filteredSlashCommands.map((command, commandIndex) => (
+                        <SlashCommandButton
+                          key={command.key}
+                          type="button"
+                          role="option"
+                          aria-selected={commandIndex === slashCommandIndex}
+                          $selected={commandIndex === slashCommandIndex}
+                          onPointerMove={() => setSlashCommandIndex(commandIndex)}
+                          onClick={() => selectSlashCommand(command)}
+                        >
+                          <Text>{command.label}</Text>
+                          <Text size="xs" variant="muted">
+                            {command.hint}
+                          </Text>
+                        </SlashCommandButton>
+                      ))}
+                      {filteredSlashCommands.length ? null : (
+                        <SlashCommandEmpty>
+                          <Text size="sm" variant="muted">
+                            {t('No matching blocks')}
+                          </Text>
+                        </SlashCommandEmpty>
+                      )}
+                    </SlashCommandMenu>
+                  ) : null}
+                </TextEditorWrap>
+              ) : (
+                <RenderedMarkdown
+                  role={disabled ? undefined : 'button'}
+                  tabIndex={disabled ? undefined : 0}
+                  onClick={() => !disabled && setIsEditingText(true)}
+                  onKeyDown={event => {
+                    if (!disabled && (event.key === 'Enter' || event.key === ' ')) {
+                      event.preventDefault();
+                      setIsEditingText(true);
+                    }
+                  }}
+                >
+                  <Markdown raw={draft.content} />
+                </RenderedMarkdown>
+              )}
+            </TextBlockBody>
+            <TextBlockExecutionOutput block={block} />
+          </Fragment>
+        ) : (
+          <Fragment>
+            <QueryPromptDisclosure
+              $expanded={!queryCollapsed}
+              size="sm"
+              expanded={!queryCollapsed}
+              onExpandedChange={expanded =>
+                block.setPromptSectionCollapsed('query', !expanded)
+              }
+            >
+              <Disclosure.Title
+                trailingItems={
+                  <HeaderActions>
+                    <ChartSettingsControl block={block} disabled={disabled} />
+                    <BlockExecutionControl
+                      block={block}
+                      hidden={isDragActive}
+                      disabled={disabled || !queryIntent.trim() || !queryExecutionEnabled}
+                    />
+                  </HeaderActions>
+                }
+              >
+                <QuerySummary size="sm">
+                  {queryCollapsed
+                    ? queryIntent || t('Natural language query')
+                    : t('Natural language query')}
+                </QuerySummary>
+              </Disclosure.Title>
+              <QueryPromptContent>
+                <QueryEditorWrap>
+                  <BlockInput
+                    ref={textInputRef}
+                    $kind="query"
+                    aria-label={t('Query block %s', index + 1)}
+                    autosize
+                    rows={2}
+                    maxRows={18}
+                    disabled={disabled}
+                    placeholder=""
+                    value={queryIntent}
+                    onChange={event => {
+                      if (suggestionTimerRef.current) {
+                        clearInterval(suggestionTimerRef.current);
+                        suggestionTimerRef.current = null;
+                      }
+                      block.editQueryIntent(event.target.value);
+                    }}
+                    onBlur={saveOnBlur}
+                  />
+                  {queryIntent ? null : (
+                    <QueryPlaceholder>
+                      <Text variant="muted">
+                        {t('Describe what you want to see, or ')}
+                        {disabled ? (
+                          t('see an example')
+                        ) : (
+                          <QueryExampleButton
+                            type="button"
+                            onClick={() => streamQuerySuggestion(queryExample)}
+                          >
+                            {t('see an example')}
+                          </QueryExampleButton>
+                        )}
+                      </Text>
+                    </QueryPlaceholder>
+                  )}
+                </QueryEditorWrap>
+              </QueryPromptContent>
+            </QueryPromptDisclosure>
+            <PersistedBlockOutput block={block} disabled={disabled} />
+          </Fragment>
+        )}
+      </BlockSurface>
+    </BlockCard>
+  );
+}
+
+function areSortableBlockPropsEqual(
+  previous: SortableBlockProps,
+  next: SortableBlockProps
+) {
+  return (
+    previous.block === next.block &&
+    previous.index === next.index &&
+    previous.disabled === next.disabled &&
+    previous.onRender === next.onRender
+  );
+}
+
+const MemoizedSortableBlockContent = memo(
+  observer(SortableBlockContent),
+  (previous, next) =>
+    areSortableBlockPropsEqual(previous, next) &&
+    previous.dropIndicator === next.dropIndicator &&
+    previous.isDragActive === next.isDragActive &&
+    previous.sortable.isDragging === next.sortable.isDragging &&
+    previous.sortable.transition === next.sortable.transition &&
+    previous.sortable.transform?.x === next.sortable.transform?.x &&
+    previous.sortable.transform?.y === next.sortable.transform?.y &&
+    previous.sortable.transform?.scaleX === next.sortable.transform?.scaleX &&
+    previous.sortable.transform?.scaleY === next.sortable.transform?.scaleY
+);
+
+const MemoizedSortableBlock = memo(SortableBlock, areSortableBlockPropsEqual);
+
+function BlockTypeMenu({
+  isOpen,
+  onOpenChange,
+  onInsert,
+  trigger,
+}: {
+  onInsert: (kind: InvestigationBlockKind) => Promise<void>;
+  trigger: DropdownMenuProps['trigger'];
+  isOpen?: boolean;
+  onOpenChange?: (isOpen: boolean) => void;
+}) {
+  return (
+    <DropdownMenu
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      items={[
+        {
+          key: 'text',
+          label: t('Text'),
+          leadingItems: <IconMarkdown />,
+          onAction: () => onInsert('text'),
+        },
+        {
+          key: 'query',
+          label: t('Query'),
+          leadingItems: <IconCode />,
+          onAction: () => onInsert('query'),
+        },
+      ]}
+      position="bottom"
+      trigger={trigger}
+    />
+  );
+}
+
+function BlockInsertDivider({
+  index,
+  isEnd = false,
+  onInsert,
+}: {
+  index: number;
+  onInsert: (kind: InvestigationBlockKind, index: number) => Promise<void>;
+  isEnd?: boolean;
+}) {
+  const [isMenuReady, setIsMenuReady] = useState(false);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const label = isEnd ? t('Add block') : t('Add block here');
+  const openMenu = () => {
+    setIsMenuReady(true);
+    setIsMenuOpen(true);
+  };
+
+  return (
+    <InsertDivider>
+      {isMenuReady ? (
+        <BlockTypeMenu
+          isOpen={isMenuOpen}
+          onOpenChange={setIsMenuOpen}
+          onInsert={kind => onInsert(kind, index)}
+          trigger={triggerProps => (
+            <InsertButton
+              {...triggerProps}
+              size="xs"
+              variant="secondary"
+              icon={<IconAdd />}
+              aria-label={label}
+            />
+          )}
+        />
+      ) : (
+        <InsertPlaceholderButton
+          type="button"
+          aria-label={label}
+          onClick={openMenu}
+          onKeyDown={event => {
+            if (event.key === 'ArrowDown') {
+              event.preventDefault();
+              openMenu();
+            }
+          }}
+        >
+          <IconAdd size="xs" />
+        </InsertPlaceholderButton>
+      )}
+    </InsertDivider>
+  );
+}
+
+const MemoizedBlockInsertDivider = memo(
+  BlockInsertDivider,
+  (previous, next) => previous.index === next.index && previous.isEnd === next.isEnd
+);
+
+const Workspace = styled(Flex)`
+  width: 100%;
+  min-height: calc(100dvh - var(--top-bar-height, 53px));
+  background: ${p => p.theme.tokens.background.primary};
+`;
+
+const LoadingState = styled(Text)`
+  display: block;
+  padding: ${p => p.theme.space['3xl']};
+`;
+
+const EditorPage = styled('section')`
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 980px;
+  min-height: calc(100dvh - var(--top-bar-height, 53px));
+  margin: 0 auto;
+  padding: ${p => p.theme.space.xl} ${p => p.theme.space['2xl']};
+  background: ${p => p.theme.tokens.background.primary};
+`;
+
+const NotebookContent = styled('div')`
+  width: 100%;
+  max-width: 980px;
+  margin: 0 auto;
+  padding-top: ${p => p.theme.space.md};
+`;
+
+const NotebookControls = styled('div')`
+  display: flex;
+  width: 100%;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: ${p => p.theme.space.md};
+  margin-bottom: ${p => p.theme.space['2xl']};
+`;
+
+const NotebookHeading = styled('div')`
+  display: flex;
+  align-items: flex-start;
+  gap: ${p => p.theme.space.sm};
+  flex-direction: column;
+  margin-bottom: ${p => p.theme.space['2xl']};
+
+  h1 {
+    margin: 0;
+    font-size: 28px;
+  }
+`;
+
+const NotebookTitleButton = styled('button')`
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: ${p => p.theme.tokens.content.primary};
+  cursor: text;
+  font-size: 28px;
+  font-weight: ${p => p.theme.font.weight.sans.medium};
+  line-height: 1.2;
+  text-align: left;
+
+  &:disabled {
+    cursor: default;
+  }
+`;
+
+const NotebookTitleInput = styled('input')`
+  width: 100%;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: ${p => p.theme.tokens.content.primary};
+  font-size: 28px;
+  font-weight: ${p => p.theme.font.weight.sans.medium};
+  line-height: 1.2;
+
+  &:focus {
+    outline: none;
+  }
+`;
+
+const FilterControls = styled('div')`
+  display: flex;
+  min-width: 0;
+  align-items: flex-start;
+  gap: ${p => p.theme.space.md};
+  flex: 1;
+  flex-wrap: wrap;
+`;
+
+const HistoryCurrent = styled(Flex)`
+  align-items: center;
+  justify-content: space-between;
+  gap: ${p => p.theme.space.lg};
+  margin-bottom: ${p => p.theme.space.lg};
+  padding: ${p => p.theme.space.lg};
+  border: 1px solid ${p => p.theme.tokens.border.primary};
+  border-radius: ${p => p.theme.radius.md};
+`;
+
+const BlockList = styled(Stack)`
+  width: calc(100% + ${p => p.theme.space.lg} + ${p => p.theme.space.lg});
+  margin-left: -${p => p.theme.space.lg};
+`;
+
+const BlockCard = styled('article')<{
+  $dropIndicator: 'after' | 'before' | null;
+  $isDragging: boolean;
+  $kind: InvestigationBlockKind;
+}>`
+  position: relative;
+  z-index: ${p => (p.$isDragging ? 3 : 'auto')};
+  background: ${p => p.theme.tokens.background.primary};
+  box-shadow: ${p =>
+    p.$isDragging
+      ? p.$kind === 'text'
+        ? p.theme.shadow.low
+        : p.theme.shadow.medium
+      : 'none'};
+
+  &::after {
+    position: absolute;
+    z-index: 5;
+    right: 0;
+    left: 0;
+    ${p =>
+      p.$dropIndicator === 'before'
+        ? 'top: -18px;'
+        : p.$dropIndicator === 'after'
+          ? 'bottom: -18px;'
+          : 'display: none;'}
+    height: 3px;
+    border-radius: 999px;
+    background: ${p => p.theme.tokens.background.accent.vibrant};
+    content: '';
+  }
+`;
+
+const BlockSurface = styled('div')<{$isDragging: boolean}>`
+  position: relative;
+  overflow: hidden;
+  border: 1px solid
+    ${p =>
+      p.$isDragging ? p.theme.tokens.border.secondary : p.theme.tokens.border.primary};
+  border-radius: ${p => p.theme.radius.md};
+  background: ${p =>
+    p.theme.type === 'dark'
+      ? p.theme.tokens.background.secondary
+      : p.theme.tokens.background.primary};
+`;
+
+const BlockDragHandle = styled('div')<{
+  $isDragActive: boolean;
+  $isDragging: boolean;
+}>`
+  position: absolute;
+  z-index: 2;
+  top: 4px;
+  left: -36px;
+  opacity: ${p => (p.$isDragging ? 1 : 0)};
+  pointer-events: ${p => (p.$isDragActive && !p.$isDragging ? 'none' : 'auto')};
+  transition: opacity 120ms ease;
+
+  ${BlockCard}:hover & {
+    opacity: ${p => (p.$isDragActive && !p.$isDragging ? 0 : 1)};
+  }
+`;
+
+const BlockActionsRail = styled(Stack)<{$hidden: boolean}>`
+  position: absolute;
+  z-index: 2;
+  top: ${p => p.theme.space.md};
+  right: -40px;
+  align-items: center;
+  gap: 1px;
+  opacity: 0;
+  pointer-events: ${p => (p.$hidden ? 'none' : 'auto')};
+  transition: opacity 120ms ease;
+
+  ${BlockCard}:hover & {
+    ${p => (p.$hidden ? '' : 'opacity: 1;')}
+  }
+
+  > button,
+  > span > button {
+    width: 26px;
+    min-width: 26px;
+    height: 26px;
+    min-height: 26px;
+    padding: 4px;
+
+    svg {
+      width: 15px;
+      height: 15px;
+    }
+  }
+`;
+
+const spin = keyframes`
+  to { transform: rotate(360deg); }
+`;
+
+const ExecutionButtonLabels = styled('span')`
+  display: inline-flex;
+  align-items: center;
+`;
+
+const WorkingButtonLabel = styled('span')`
+  display: inline-flex;
+  align-items: center;
+  gap: ${p => p.theme.space.xs};
+`;
+
+const StopButtonLabel = styled('span')`
+  display: none;
+  align-items: center;
+  gap: ${p => p.theme.space.xs};
+`;
+
+const LoadingDot = styled('span')`
+  width: 12px;
+  height: 12px;
+  border: 2px solid currentcolor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  animation: ${spin} 700ms linear infinite;
+`;
+
+const QueryRunButton = styled(Button)<{
+  $hidden: boolean;
+  $stoppable?: boolean;
+}>`
+  width: 54px;
+  min-width: 54px;
+  height: 24px;
+  min-height: 24px;
+  flex-shrink: 0;
+  padding: 4px 7px;
+  opacity: ${p => (p.$hidden ? 0 : 1)};
+
+  ${p =>
+    p.$stoppable &&
+    css`
+      &:hover ${WorkingButtonLabel}, &:focus-visible ${WorkingButtonLabel} {
+        display: none;
+      }
+      &:hover ${StopButtonLabel}, &:focus-visible ${StopButtonLabel} {
+        display: inline-flex;
+      }
+    `}
+`;
+
+const QueryPromptDisclosure = styled(Disclosure)<{$expanded: boolean}>`
+  padding: 0;
+
+  > div:first-of-type {
+    min-height: 32px;
+    padding: 4px;
+    border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
+    border-radius: 0;
+    background: ${p =>
+      p.$expanded ? p.theme.tokens.background.secondary : 'transparent'};
+
+    &:hover {
+      background: ${p => p.theme.tokens.background.secondary};
+    }
+  }
+
+  > div:first-of-type > button:first-of-type {
+    min-width: 0;
+    min-height: 24px;
+    height: 24px;
+    padding-top: 4px;
+    padding-bottom: 4px;
+    border-radius: 0;
+  }
+`;
+
+const QueryPromptContent = styled(Disclosure.Content)`
+  padding: 0;
+  border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
+  background: ${p => p.theme.tokens.background.secondary};
+`;
+
+const QuerySummary = styled(Text)`
+  display: block;
+  width: 100%;
+  max-width: 56ch;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const HeaderActions = styled(Flex)`
+  flex-shrink: 0;
+  align-items: center;
+  gap: 4px;
+`;
+
+const QueryEditorWrap = styled('div')`
+  position: relative;
+`;
+
+const ContextHint = styled(Text)`
+  display: block;
+  padding: 0 ${p => p.theme.space.lg} ${p => p.theme.space.md};
+`;
+
+const BlockInput = styled(TextArea)<{$kind: InvestigationBlockKind}>`
+  width: 100%;
+  border: 0;
+  border-radius: 0;
+  padding: 0;
+  background: transparent;
+  box-shadow: none;
+  font-family: ${p => p.theme.font.family.sans};
+  font-size: ${p => p.theme.font.size.md};
+  line-height: 1.55;
+  resize: none !important;
+
+  &:focus,
+  &:focus-visible {
+    border: 0;
+    outline: none;
+    box-shadow: none;
+  }
+
+  ${p =>
+    p.$kind === 'query'
+      ? css`
+          min-height: 68px;
+          padding-top: ${p.theme.space.md};
+          padding-left: ${p.theme.space.lg};
+          padding-right: ${p.theme.space.lg};
+          padding-bottom: ${p.theme.space.md};
+        `
+      : ''}
+`;
+
+const QueryPlaceholder = styled('div')`
+  position: absolute;
+  top: ${p => p.theme.space.md};
+  left: ${p => p.theme.space.lg};
+  pointer-events: none;
+`;
+
+const QueryExampleButton = styled('button')`
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: ${p => p.theme.tokens.content.accent};
+  cursor: pointer;
+  font: inherit;
+  pointer-events: auto;
+
+  &:hover,
+  &:focus-visible {
+    text-decoration: underline;
+  }
+`;
+
+const TextBlockBody = styled('div')`
+  position: relative;
+  min-height: 44px;
+  padding: ${p => p.theme.space.md} ${p => p.theme.space.lg};
+`;
+
+const TextEditorWrap = styled('div')`
+  position: relative;
+`;
+
+const RenderedMarkdown = styled('div')`
+  min-height: 32px;
+  cursor: text;
+
+  &:focus-visible {
+    outline: none;
+  }
+`;
+
+const SlashCommandMenu = styled('div')`
+  position: absolute;
+  z-index: ${p => p.theme.zIndex.dropdown};
+  top: calc(100% + ${p => p.theme.space.xs});
+  left: 0;
+  width: min(320px, 100%);
+  max-height: 360px;
+  overflow-y: auto;
+  padding: ${p => p.theme.space.xs};
+  border: 1px solid ${p => p.theme.tokens.border.primary};
+  border-radius: ${p => p.theme.radius.md};
+  background: ${p => p.theme.tokens.background.primary};
+  box-shadow: ${p => p.theme.shadow.medium};
+`;
+
+const SlashCommandButton = styled('button')<{$selected: boolean}>`
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: ${p => p.theme.space.md};
+  padding: ${p => p.theme.space.sm} ${p => p.theme.space.md};
+  border: 0;
+  border-radius: ${p => p.theme.radius.sm};
+  background: ${p => (p.$selected ? p.theme.tokens.background.secondary : 'transparent')};
+  cursor: pointer;
+  text-align: left;
+
+  &:hover,
+  &:focus-visible {
+    background: ${p => p.theme.tokens.background.secondary};
+    outline: none;
+  }
+`;
+
+const SlashCommandEmpty = styled('div')`
+  padding: ${p => p.theme.space.md};
+  text-align: center;
+`;
+
+const InsertDivider = styled('div')`
+  position: relative;
+  display: flex;
+  height: 22px;
+  align-items: center;
+  justify-content: center;
+
+  &::before {
+    position: absolute;
+    right: 0;
+    left: 0;
+    height: 0;
+    border-top: 2px solid ${p => p.theme.tokens.border.accent.vibrant};
+    content: '';
+    opacity: 0;
+    transition: opacity 120ms ease;
+  }
+
+  &:hover::before,
+  &:focus-within::before {
+    opacity: 1;
+  }
+`;
+
+const InsertButton = styled(Button)`
+  z-index: 1;
+  min-width: 20px;
+  height: 20px;
+  padding: 0;
+  border-radius: 999px;
+  opacity: 0;
+  transition: opacity 120ms ease;
+  color: ${p => p.theme.tokens.content.accent};
+
+  svg {
+    width: 10px;
+    height: 10px;
+  }
+
+  ${InsertDivider}:hover &,
+  ${InsertDivider}:focus-within & {
+    opacity: 1;
+  }
+`;
+
+const InsertPlaceholderButton = styled('button')`
+  z-index: 1;
+  display: grid;
+  width: 20px;
+  height: 20px;
+  place-items: center;
+  padding: 0;
+  border: 1px solid ${p => p.theme.tokens.border.primary};
+  border-radius: 999px;
+  background: ${p => p.theme.tokens.background.primary};
+  color: ${p => p.theme.tokens.content.accent};
+  cursor: pointer;
+  opacity: 0;
+  transition:
+    opacity 120ms ease,
+    background 120ms ease;
+
+  svg {
+    width: 10px;
+    height: 10px;
+  }
+
+  &:hover,
+  &:focus-visible {
+    background: ${p => p.theme.tokens.background.secondary};
+    outline: none;
+  }
+
+  ${InsertDivider}:hover &,
+  ${InsertDivider}:focus-within & {
+    opacity: 1;
+  }
+`;

--- a/static/app/views/seerNotebook/investigationAccessSelector.tsx
+++ b/static/app/views/seerNotebook/investigationAccessSelector.tsx
@@ -1,0 +1,92 @@
+import {useState} from 'react';
+import styled from '@emotion/styled';
+
+import {Tag} from '@sentry/scraps/badge';
+import {CompactSelect} from '@sentry/scraps/compactSelect';
+import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
+import {Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import {t, tn} from 'sentry/locale';
+import {useTeams} from 'sentry/utils/useTeams';
+
+import type {InvestigationPermissions} from './types';
+
+type Props = {
+  onChange: (permissions: InvestigationPermissions) => Promise<void>;
+  permissions: InvestigationPermissions;
+};
+
+export function InvestigationAccessSelector({permissions, onChange}: Props) {
+  const {teams} = useTeams();
+  const [pending, setPending] = useState(false);
+  const selected = permissions.isEditableByEveryone
+    ? ['_all']
+    : permissions.teamIds.map(String);
+  const options = [
+    {value: '_all', label: t('Everyone in the organization')},
+    ...teams.map(team => ({value: team.id, label: `#${team.slug}`})),
+  ];
+
+  const selector = (
+    <CompactSelect
+      multiple
+      size="sm"
+      value={selected}
+      options={options}
+      disabled={!permissions.canManage || pending}
+      onChange={async nextOptions => {
+        let values = nextOptions.map(option => option.value);
+        if (!selected.includes('_all') && values.includes('_all')) {
+          values = ['_all'];
+        } else if (selected.includes('_all') && values.some(value => value !== '_all')) {
+          values = values.filter(value => value !== '_all');
+        }
+
+        setPending(true);
+        try {
+          await onChange({
+            ...permissions,
+            isEditableByEveryone: values.includes('_all'),
+            teamIds: values
+              .filter(value => value !== '_all')
+              .map(Number)
+              .sort((a, b) => a - b),
+          });
+        } finally {
+          setPending(false);
+        }
+      }}
+      trigger={triggerProps => (
+        <OverlayTrigger.Button
+          {...triggerProps}
+          variant="transparent"
+          style={{padding: 2}}
+        >
+          {permissions.isEditableByEveryone ? (
+            <AllTag variant="info">{t('All')}</AllTag>
+          ) : permissions.teamIds.length ? (
+            <Text size="sm">{tn('%s team', '%s teams', permissions.teamIds.length)}</Text>
+          ) : (
+            <Text size="sm">{t('Owner')}</Text>
+          )}
+        </OverlayTrigger.Button>
+      )}
+      position="bottom-end"
+      strategy="fixed"
+    />
+  );
+
+  return permissions.canManage ? (
+    selector
+  ) : (
+    <Tooltip title={t('Only the creator or an organization manager can edit access.')}>
+      {selector}
+    </Tooltip>
+  );
+}
+
+const AllTag = styled(Tag)`
+  min-width: 30px;
+  justify-content: center;
+`;

--- a/static/app/views/seerNotebook/output.tsx
+++ b/static/app/views/seerNotebook/output.tsx
@@ -1,0 +1,584 @@
+import {Fragment} from 'react';
+import {createPortal} from 'react-dom';
+import {keyframes, useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
+import {observer} from 'mobx-react-lite';
+
+import {Alert} from '@sentry/scraps/alert';
+import {Button} from '@sentry/scraps/button';
+import {Disclosure} from '@sentry/scraps/disclosure';
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {Overlay, PositionWrapper} from 'sentry/components/overlay';
+import {SeerMarkdown} from 'sentry/components/seer/markdown';
+import {Chart} from 'sentry/components/seer/markdown/embeds/components/chart';
+import {IconSettings} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {useOverlay} from 'sentry/utils/useOverlay';
+import type {BlockStore} from 'sentry/views/seerNotebook/stores/blockStore';
+import {isQueryResult} from 'sentry/views/seerNotebook/stores/visualization';
+
+import type {InvestigationQueryResult} from './types';
+
+type PersistedBlockOutputProps = {block: BlockStore; disabled: boolean};
+
+/** @public */ export function getOutputColumns(_output: unknown): string[] {
+  return [];
+}
+
+export const PersistedBlockOutput = observer(({block}: PersistedBlockOutputProps) => {
+  const queryOutput = isQueryResult(block.output) ? block.output : null;
+  const hasResult = queryOutput !== null;
+  const hasError = block.executionStatusKind === 'error';
+  if (
+    !block.hasExecutionFooter &&
+    !hasResult &&
+    !block.isWaitingForDependencies &&
+    !block.isBlockedByDependencies &&
+    !hasError
+  ) {
+    return null;
+  }
+  if (block.outputStatus === 'restricted') {
+    return (
+      <OutputMessage>
+        {t('You cannot access every project used by this investigation.')}
+      </OutputMessage>
+    );
+  }
+
+  return (
+    <Stack gap="md">
+      {block.isExecutionRunning && hasResult ? (
+        <Text variant="muted">{t('Refreshing saved result…')}</Text>
+      ) : null}
+      {queryOutput ? <QueryOutput block={block} output={queryOutput} /> : null}
+      {block.isWaitingForDependencies ? <DependencyWaitingStatus /> : null}
+      {block.isBlockedByDependencies ? <DependencyBlockedStatus /> : null}
+      {hasError ? <ExecutionError block={block} /> : null}
+      {block.hasExecutionFooter ? <ExecutionFooter block={block} /> : null}
+    </Stack>
+  );
+});
+
+export const TextBlockExecutionOutput = observer(({block}: {block: BlockStore}) => {
+  const hasError = block.executionStatusKind === 'error';
+  if (
+    !block.hasExecutionFooter &&
+    !block.partialMarkdown &&
+    !block.isWaitingForDependencies &&
+    !block.isBlockedByDependencies &&
+    !hasError
+  ) {
+    return null;
+  }
+
+  return (
+    <Stack gap="sm">
+      {block.isExecutionRunning && block.partialMarkdown ? (
+        <StreamPreview>
+          <SeerMarkdown raw={block.partialMarkdown} variant="streaming" />
+        </StreamPreview>
+      ) : null}
+      {block.isWaitingForDependencies ? <DependencyWaitingStatus /> : null}
+      {block.isBlockedByDependencies ? <DependencyBlockedStatus /> : null}
+      {hasError ? <ExecutionError block={block} /> : null}
+      {block.hasExecutionFooter ? <ExecutionFooter block={block} /> : null}
+    </Stack>
+  );
+});
+
+const ExecutionFooter = observer(({block}: {block: BlockStore}) => {
+  return (
+    <ActivityDisclosure
+      size="sm"
+      disabled={
+        !block.currentExecution ||
+        (block.isExecutionRunning && block.activityEntries.length === 0)
+      }
+      expanded={block.activityExpanded}
+      onExpandedChange={expanded => block.setActivityExpanded(expanded)}
+    >
+      <Disclosure.Title>
+        <ExecutionStatus
+          role={block.executionStatusKind === 'error' ? 'alert' : 'status'}
+          aria-live="polite"
+        >
+          <StatusDot $status={block.executionStatusKind} />
+          <FlippingStatus key={block.executionStatusLabelVersion}>
+            {block.executionStatusLabel}
+          </FlippingStatus>
+        </ExecutionStatus>
+      </Disclosure.Title>
+      <Disclosure.Content>
+        <Stack gap="sm">
+          {block.isLoadingExecutionActivity ? (
+            <Text size="sm" variant="muted">
+              {t('Loading activity…')}
+            </Text>
+          ) : null}
+          {block.activityEntries.map(entry => (
+            <ActivityBlock key={entry.id}>
+              {entry.content ? <SeerMarkdown raw={entry.content} /> : null}
+              {entry.calls.map((call, callIndex) => (
+                <Disclosure size="sm" key={callIndex}>
+                  <Disclosure.Title>{call.function}</Disclosure.Title>
+                  <Disclosure.Content>
+                    <Stack gap="xs">
+                      {call.code ? (
+                        <div>
+                          <Text size="xs" bold>
+                            {t('Code')}
+                          </Text>
+                          <pre>{call.code}</pre>
+                        </div>
+                      ) : null}
+                      <div>
+                        <Text size="xs" bold>
+                          {t('Result')}
+                        </Text>
+                        <pre>{call.result ?? t('No result yet')}</pre>
+                      </div>
+                    </Stack>
+                  </Disclosure.Content>
+                </Disclosure>
+              ))}
+              {entry.policyError ? (
+                <Text size="sm" variant="danger">
+                  {entry.policyError}
+                </Text>
+              ) : null}
+            </ActivityBlock>
+          ))}
+          {block.transcriptTruncated ? (
+            <Text size="xs" variant="muted">
+              {t('Large tool results were truncated.')}
+            </Text>
+          ) : null}
+          {block.pendingUserInput ? (
+            <Stack gap="xs">
+              <Text>
+                {typeof block.pendingUserInput.data.question === 'string'
+                  ? block.pendingUserInput.data.question
+                  : t('Add context')}
+              </Text>
+              {block.clarificationOptions.length ? (
+                <Flex gap="xs" wrap="wrap">
+                  {block.clarificationOptions.map(option => (
+                    <Button
+                      size="xs"
+                      key={option.value}
+                      onClick={() => void block.respondToPendingInput(option.value)}
+                    >
+                      {option.label}
+                    </Button>
+                  ))}
+                </Flex>
+              ) : null}
+              <ClarificationInput
+                value={block.clarificationDraft}
+                onChange={event => block.editClarificationDraft(event.target.value)}
+                placeholder={t('Your response')}
+              />
+              <Button
+                size="xs"
+                disabled={!block.clarificationDraft.trim()}
+                onClick={() => void block.respondToPendingInput()}
+              >
+                {t('Continue')}
+              </Button>
+            </Stack>
+          ) : null}
+        </Stack>
+      </Disclosure.Content>
+    </ActivityDisclosure>
+  );
+});
+
+function DependencyWaitingStatus() {
+  return (
+    <WaitingStatus role="status">
+      <WaitingSpinner aria-hidden="true" />
+      <Text size="sm" variant="muted">
+        {t('Waiting for earlier blocks')}
+      </Text>
+    </WaitingStatus>
+  );
+}
+
+function DependencyBlockedStatus() {
+  return (
+    <ErrorMessage role="alert" size="sm" variant="danger">
+      {t('Blocked because an earlier block did not complete.')}
+    </ErrorMessage>
+  );
+}
+
+function ExecutionError({block}: {block: BlockStore}) {
+  return (
+    <ErrorMessage role="alert" size="sm" variant="danger">
+      {block.currentExecution?.error?.message ??
+        (block.kind === 'text'
+          ? t('The generation did not finish.')
+          : t('The query did not finish.'))}
+    </ErrorMessage>
+  );
+}
+
+const QueryOutput = observer(
+  ({block, output}: {block: BlockStore; output: InvestigationQueryResult}) => {
+    const activeView = block.effectiveView;
+    const chartData = block.chartEmbedData;
+    return (
+      <OutputWrap>
+        {block.chartFallbackWarning ? (
+          <Alert
+            variant="warning"
+            trailingItems={
+              <Button size="xs" onClick={() => void block.run()}>
+                {t('Retry')}
+              </Button>
+            }
+          >
+            {block.chartFallbackWarning}
+          </Alert>
+        ) : null}
+        {activeView === 'chart' && chartData ? (
+          <Chart name="chart" level="block" data={chartData} />
+        ) : (
+          <Stack gap="xs">
+            <SeerMarkdown raw={output.tableMarkdown} />
+            {output.isEmpty ? (
+              <Text variant="muted">{t('No data returned for this query.')}</Text>
+            ) : null}
+          </Stack>
+        )}
+        {output.queryLinks.length ? (
+          <UnderlyingQueries>
+            <Disclosure size="sm">
+              <Disclosure.Title>
+                {t('%s underlying queries', output.queryLinks.length)}
+              </Disclosure.Title>
+              <Disclosure.Content>
+                <pre>{JSON.stringify(output.queryLinks, null, 2)}</pre>
+              </Disclosure.Content>
+            </Disclosure>
+          </UnderlyingQueries>
+        ) : null}
+      </OutputWrap>
+    );
+  }
+);
+
+export const ChartSettingsControl = observer(
+  ({block, disabled}: {block: BlockStore; disabled: boolean}) => {
+    const theme = useTheme();
+    const {isOpen, triggerProps, overlayProps, arrowProps} = useOverlay({
+      offset: 6,
+      position: 'bottom-end',
+      shouldApplyMinWidth: false,
+      strategy: 'fixed',
+    });
+    if (!block.queryResult) {
+      return null;
+    }
+
+    return (
+      <Fragment>
+        <SettingsButton
+          {...triggerProps}
+          size="xs"
+          variant="transparent"
+          icon={<IconSettings />}
+          aria-label={t('Result settings')}
+        />
+        {isOpen
+          ? createPortal(
+              <PositionWrapper zIndex={theme.zIndex.dropdown} {...overlayProps}>
+                <Overlay arrowProps={arrowProps}>
+                  <SettingsPanel role="dialog" aria-label={t('Result settings')}>
+                    <Text size="sm" bold>
+                      {t('Result display')}
+                    </Text>
+                    <ViewSwitcher>
+                      <Button
+                        size="xs"
+                        variant={
+                          block.effectiveView === 'table' ? 'primary' : 'secondary'
+                        }
+                        disabled={disabled}
+                        onClick={() => block.setResultView('table')}
+                      >
+                        {t('Table')}
+                      </Button>
+                      <Button
+                        size="xs"
+                        variant={
+                          block.effectiveView === 'chart' ? 'primary' : 'secondary'
+                        }
+                        disabled={disabled || !block.chartAvailable}
+                        onClick={() => block.setResultView('chart')}
+                      >
+                        {t('Chart')}
+                      </Button>
+                    </ViewSwitcher>
+                    {block.chartAvailable ? (
+                      <ChartPresentation block={block} disabled={disabled} />
+                    ) : null}
+                  </SettingsPanel>
+                </Overlay>
+              </PositionWrapper>,
+              document.body
+            )
+          : null}
+      </Fragment>
+    );
+  }
+);
+
+const ChartPresentation = observer(
+  ({block, disabled}: {block: BlockStore; disabled: boolean}) => {
+    return (
+      <Stack gap="sm">
+        <Text size="sm" bold>
+          {t('Chart presentation')}
+        </Text>
+        <PresentationGrid>
+          <label>
+            <Text size="xs">{t('Chart type')}</Text>
+            <PresentationSelect
+              disabled={disabled}
+              value={block.chartPresentationType}
+              onChange={event =>
+                block.applyVisualizationChange({
+                  type: event.target.value as 'line' | 'bar' | 'area',
+                })
+              }
+            >
+              {block.compatibleChartTypes.map(type => (
+                <option value={type} key={type}>
+                  {type}
+                </option>
+              ))}
+            </PresentationSelect>
+          </label>
+          <PresentationField
+            disabled={disabled}
+            label={t('Title')}
+            value={block.display.title ?? ''}
+            onChange={title => block.applyVisualizationChange({title})}
+          />
+          <PresentationField
+            disabled={disabled}
+            label={t('Subtitle')}
+            value={block.display.subtitle ?? ''}
+            onChange={subtitle => block.applyVisualizationChange({subtitle})}
+          />
+          <PresentationField
+            disabled={disabled}
+            label={t('Axis label')}
+            value={block.display.axisLabel ?? ''}
+            onChange={axisLabel => block.applyVisualizationChange({axisLabel})}
+          />
+          <label>
+            <Text size="xs">{t('Unit')}</Text>
+            <PresentationSelect
+              disabled={disabled}
+              value={block.display.unit ?? 'number'}
+              onChange={event =>
+                block.applyVisualizationChange({
+                  unit: event.target.value as
+                    | 'number'
+                    | 'percentage'
+                    | 'duration'
+                    | 'bytes',
+                })
+              }
+            >
+              {(['number', 'percentage', 'duration', 'bytes'] as const).map(unit => (
+                <option value={unit} key={unit}>
+                  {unit}
+                </option>
+              ))}
+            </PresentationSelect>
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              disabled={disabled}
+              checked={block.display.showLegend ?? true}
+              onChange={event =>
+                block.applyVisualizationChange({
+                  showLegend: event.target.checked,
+                })
+              }
+            />{' '}
+            {t('Show legend')}
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              disabled={disabled}
+              checked={block.display.stacked ?? false}
+              onChange={event =>
+                block.applyVisualizationChange({stacked: event.target.checked})
+              }
+            />{' '}
+            {t('Stack series')}
+          </label>
+        </PresentationGrid>
+      </Stack>
+    );
+  }
+);
+
+function PresentationField({
+  label,
+  onChange,
+  value,
+  disabled,
+}: {
+  disabled: boolean;
+  label: string;
+  onChange: (value: string) => void;
+  value: string;
+}) {
+  return (
+    <label>
+      <Text size="xs">{label}</Text>
+      <ClarificationInput
+        disabled={disabled}
+        value={value}
+        onChange={event => onChange(event.target.value)}
+      />
+    </label>
+  );
+}
+
+const OutputWrap = styled('section')`
+  display: grid;
+  gap: ${p => p.theme.space.md};
+
+  > [data-test-id='seer-chart-embed'] {
+    border: 0;
+    border-radius: 0;
+  }
+`;
+const UnderlyingQueries = styled('div')`
+  width: 100%;
+
+  [data-disclosure] {
+    width: 100%;
+  }
+`;
+const SettingsButton = styled(Button)`
+  width: 24px;
+  min-width: 24px;
+  height: 24px;
+  min-height: 24px;
+  padding: 4px;
+`;
+const SettingsPanel = styled(Stack)`
+  width: min(420px, calc(100vw - 32px));
+  max-height: min(620px, calc(100vh - 48px));
+  overflow-y: auto;
+  gap: ${p => p.theme.space.md};
+  padding: ${p => p.theme.space.lg};
+`;
+const ViewSwitcher = styled(Flex)`
+  gap: ${p => p.theme.space.xs};
+`;
+const OutputMessage = styled(Text)`
+  padding: ${p => p.theme.space.md};
+`;
+const ErrorMessage = styled(Text)`
+  display: block;
+  padding: ${p => p.theme.space.md} ${p => p.theme.space.lg};
+  border-top: 1px solid ${p => p.theme.tokens.border.primary};
+`;
+const WaitingStatus = styled(Flex)`
+  align-items: center;
+  gap: ${p => p.theme.space.sm};
+  padding: ${p => p.theme.space.sm} ${p => p.theme.space.lg};
+  border-top: 1px solid ${p => p.theme.tokens.border.primary};
+`;
+const WaitingSpinner = styled('span')`
+  width: 12px;
+  height: 12px;
+  border: 2px solid ${p => p.theme.tokens.border.secondary};
+  border-right-color: transparent;
+  border-radius: 50%;
+  animation: ${keyframes`to { transform: rotate(360deg); }`} 700ms linear infinite;
+`;
+const ActivityDisclosure = styled(Disclosure)`
+  border: 0;
+  border-top: 1px solid ${p => p.theme.tokens.border.primary};
+  border-radius: 0;
+
+  > div:first-of-type {
+    padding-right: 0;
+    border-radius: 0;
+  }
+
+  > div:first-of-type > button:first-of-type {
+    border-radius: 0;
+  }
+`;
+const ExecutionStatus = styled('span')`
+  display: inline-flex;
+  align-items: center;
+  gap: ${p => p.theme.space.sm};
+  min-height: 20px;
+`;
+const StatusDot = styled('span')<{$status: BlockStore['executionStatusKind']}>`
+  width: 8px;
+  height: 8px;
+  flex: 0 0 8px;
+  border-radius: 50%;
+  color: ${p =>
+    p.$status === 'error'
+      ? p.theme.tokens.content.danger
+      : p.$status === 'working'
+        ? p.theme.tokens.content.accent
+        : p.theme.tokens.content.secondary};
+  background: currentcolor;
+`;
+const flipStatus = keyframes`
+  from {
+    opacity: 0;
+    transform: translateY(5px) rotateX(-35deg);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) rotateX(0);
+  }
+`;
+const FlippingStatus = styled('span')`
+  animation: ${flipStatus} 180ms ease-out;
+`;
+const ActivityBlock = styled('div')`
+  pre {
+    max-height: 240px;
+    overflow: auto;
+    white-space: pre-wrap;
+  }
+`;
+const StreamPreview = styled('div')`
+  opacity: 0.8;
+  border-left: 2px solid ${p => p.theme.tokens.border.accent.vibrant};
+  padding-left: ${p => p.theme.space.md};
+`;
+const ClarificationInput = styled('input')`
+  width: 100%;
+  padding: ${p => p.theme.space.sm};
+`;
+const PresentationGrid = styled('div')`
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: ${p => p.theme.space.sm};
+`;
+const PresentationSelect = styled('select')`
+  width: 100%;
+  padding: ${p => p.theme.space.sm};
+`;

--- a/static/app/views/seerNotebook/parameters.tsx
+++ b/static/app/views/seerNotebook/parameters.tsx
@@ -1,0 +1,238 @@
+import styled from '@emotion/styled';
+import {observer} from 'mobx-react-lite';
+
+import {Checkbox} from '@sentry/scraps/checkbox';
+import {Input} from '@sentry/scraps/input';
+import {Flex, Grid, Stack} from '@sentry/scraps/layout';
+import {Select} from '@sentry/scraps/select';
+import {Text} from '@sentry/scraps/text';
+
+import {t} from 'sentry/locale';
+import {useProjects} from 'sentry/utils/useProjects';
+import type {
+  NotebookStore,
+  ParameterValidationError,
+} from 'sentry/views/seerNotebook/stores/notebookStore';
+
+type Props = {
+  store: NotebookStore;
+};
+
+export const InvestigationParameters = observer(
+  function InvestigationParametersComponent({store}: Props) {
+    const {projects} = useProjects();
+    const {parameters, parameterValues: values, parameterErrors: errors} = store;
+    const disabled = store.isReadOnly;
+    const projectOptions = projects.map(project => ({
+      label: project.slug,
+      value: project.id,
+    }));
+
+    if (parameters.length === 0) {
+      return null;
+    }
+
+    const update = (key: string, value: unknown) => store.editParameterValue(key, value);
+
+    return (
+      <ParameterSection onBlur={() => void store.flushParameterValues()}>
+        {parameters.map(parameter => {
+          const value = values[parameter.key];
+          const options = Array.isArray(parameter.constraints.options)
+            ? parameter.constraints.options.map(option => ({
+                label: String(option),
+                value: String(option),
+              }))
+            : [];
+
+          return (
+            <ParameterControl key={parameter.key} gap="xs">
+              <Text size="xs" bold>
+                {parameter.label}
+                {parameter.required ? ' *' : ''}
+              </Text>
+              {parameter.type === 'boolean' ? (
+                <Checkbox
+                  checked={Boolean(value)}
+                  disabled={disabled}
+                  onChange={event => update(parameter.key, event.target.checked)}
+                >
+                  {t('Enabled')}
+                </Checkbox>
+              ) : parameter.type === 'enum' ? (
+                <Select
+                  options={options}
+                  value={primitiveString(value)}
+                  disabled={disabled}
+                  onChange={option => update(parameter.key, option.value)}
+                />
+              ) : parameter.type === 'project' ? (
+                <Select
+                  options={projectOptions}
+                  value={typeof value === 'number' ? value : undefined}
+                  disabled={disabled}
+                  onChange={option => update(parameter.key, option.value)}
+                />
+              ) : parameter.type === 'project_list' ? (
+                <Select
+                  multiple
+                  options={projectOptions}
+                  value={Array.isArray(value) ? value : []}
+                  disabled={disabled}
+                  onChange={selected =>
+                    update(
+                      parameter.key,
+                      selected.map(option => option.value)
+                    )
+                  }
+                />
+              ) : parameter.type === 'datetime_range' ? (
+                <Grid columns={2} gap="sm">
+                  <Input
+                    type="datetime-local"
+                    aria-label={t('%s start', parameter.label)}
+                    disabled={disabled}
+                    value={datetimeLocalValue(getRangeValue(value, 'start'))}
+                    onChange={event =>
+                      update(parameter.key, {
+                        ...asRange(value),
+                        start: toIsoDate(event.target.value),
+                      })
+                    }
+                  />
+                  <Input
+                    type="datetime-local"
+                    aria-label={t('%s end', parameter.label)}
+                    disabled={disabled}
+                    value={datetimeLocalValue(getRangeValue(value, 'end'))}
+                    onChange={event =>
+                      update(parameter.key, {
+                        ...asRange(value),
+                        end: toIsoDate(event.target.value),
+                      })
+                    }
+                  />
+                </Grid>
+              ) : (
+                <Input
+                  aria-label={parameter.label}
+                  type={
+                    parameter.type === 'number' || parameter.type === 'duration'
+                      ? 'number'
+                      : 'text'
+                  }
+                  disabled={disabled}
+                  value={
+                    parameter.type === 'environment_list'
+                      ? (Array.isArray(value) ? value : []).join(', ')
+                      : primitiveString(value)
+                  }
+                  placeholder={
+                    parameter.type === 'environment_list'
+                      ? t('production, staging')
+                      : parameter.description || undefined
+                  }
+                  onChange={event => {
+                    const raw = event.target.value;
+                    if (parameter.type === 'environment_list') {
+                      update(
+                        parameter.key,
+                        raw
+                          .split(',')
+                          .map(item => item.trim())
+                          .filter(Boolean)
+                      );
+                    } else if (
+                      parameter.type === 'number' ||
+                      parameter.type === 'duration'
+                    ) {
+                      update(parameter.key, raw === '' ? null : Number(raw));
+                    } else {
+                      update(parameter.key, raw);
+                    }
+                  }}
+                />
+              )}
+              {errors[parameter.key] ? (
+                <Text size="xs" variant="danger">
+                  {parameterErrorMessage(errors[parameter.key])}
+                </Text>
+              ) : null}
+            </ParameterControl>
+          );
+        })}
+        {store.parameterSaveState === 'unsaved' ? (
+          <Text size="sm" variant="danger">
+            {t('Some parameter values could not be saved.')}
+          </Text>
+        ) : null}
+      </ParameterSection>
+    );
+  }
+);
+
+function asRange(value: unknown): {end?: string; start?: string} {
+  return typeof value === 'object' && value !== null ? value : {};
+}
+
+function getRangeValue(value: unknown, key: 'start' | 'end'): string | undefined {
+  const range = asRange(value);
+  return typeof range[key] === 'string' ? range[key] : undefined;
+}
+
+function datetimeLocalValue(value?: string): string {
+  return value ? value.slice(0, 16) : '';
+}
+
+function toIsoDate(value: string): string {
+  return value ? new Date(value).toISOString() : '';
+}
+
+function primitiveString(value: unknown): string {
+  return typeof value === 'string' || typeof value === 'number' ? String(value) : '';
+}
+
+function parameterErrorMessage(error?: ParameterValidationError): string {
+  switch (error?.code) {
+    case 'required':
+      return t('This parameter is required.');
+    case 'text':
+      return t('Enter text.');
+    case 'max_length':
+      return t('Use no more than %s characters.', error.limit);
+    case 'number':
+      return t('Enter a number.');
+    case 'integer_seconds':
+      return t('Enter a whole number of seconds.');
+    case 'min':
+      return t('Enter a value of at least %s.', error.limit);
+    case 'max':
+      return t('Enter a value of at most %s.', error.limit);
+    case 'enum':
+      return t('Choose one of the available options.');
+    case 'date_range':
+      return t('Choose a start and end time.');
+    case 'date_order':
+      return t('The start must be before the end.');
+    case 'max_days':
+      return t('The range cannot exceed %s days.', error.limit);
+    case 'duplicate_environments':
+      return t('Environment names must be unique.');
+    case 'max_environments':
+      return t('Choose no more than %s environments.', error.limit);
+    case 'duplicate_projects':
+      return t('Projects must be unique.');
+    default:
+      return '';
+  }
+}
+
+const ParameterSection = styled(Flex)`
+  align-items: flex-start;
+  gap: ${p => p.theme.space.md};
+  flex-wrap: wrap;
+`;
+
+const ParameterControl = styled(Stack)`
+  min-width: 180px;
+`;

--- a/static/app/views/seerNotebook/settings.tsx
+++ b/static/app/views/seerNotebook/settings.tsx
@@ -1,0 +1,132 @@
+import styled from '@emotion/styled';
+import {observer} from 'mobx-react-lite';
+
+import {Button} from '@sentry/scraps/button';
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {SegmentedControl} from '@sentry/scraps/segmentedControl';
+import {Select} from '@sentry/scraps/select';
+import {Text} from '@sentry/scraps/text';
+
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
+import {t} from 'sentry/locale';
+import {useTeams} from 'sentry/utils/useTeams';
+import type {NotebookStore} from 'sentry/views/seerNotebook/stores/notebookStore';
+
+type Props = {
+  onArchive: () => void;
+  store: NotebookStore;
+};
+
+export const InvestigationSettings = observer(function InvestigationSettingsComponent({
+  store,
+  onArchive,
+}: Props) {
+  return (
+    <SettingsSurface>
+      {store.permissions.canManage ? (
+        <SettingsRow>
+          <Stack gap="xs">
+            <Text bold>{t('Access')}</Text>
+            <Text size="sm" variant="muted">
+              {t('Choose who can edit this investigation.')}
+            </Text>
+          </Stack>
+          <AccessSettings store={store} />
+        </SettingsRow>
+      ) : null}
+      {store.permissions.canManage ? (
+        <SettingsRow>
+          <Stack gap="xs">
+            <Text bold>{t('Archive')}</Text>
+            <Text size="sm" variant="muted">
+              {t('Preserve this investigation and make it read-only.')}
+            </Text>
+          </Stack>
+          {store.status === 'active' ? (
+            <Button variant="danger" onClick={onArchive}>
+              {t('Archive investigation')}
+            </Button>
+          ) : (
+            <Button variant="primary" onClick={() => void store.restoreInvestigation()}>
+              {t('Restore investigation')}
+            </Button>
+          )}
+        </SettingsRow>
+      ) : null}
+    </SettingsSurface>
+  );
+});
+
+const AccessSettings = observer(function AccessSettingsComponent({
+  store,
+}: {
+  store: NotebookStore;
+}) {
+  const permissions = store.permissions;
+  const mode = permissions.isEditableByEveryone ? 'everyone' : 'restricted';
+  const teamIds = permissions.teamIds;
+  const {teams} = useTeams();
+  const teamOptions = teams.map(team => ({
+    label: `#${team.slug}`,
+    value: Number(team.id),
+  }));
+
+  const save = (nextMode: 'everyone' | 'restricted', nextTeamIds: number[]) =>
+    store
+      .updateAccess({
+        isEditableByEveryone: nextMode === 'everyone',
+        teamIds: nextMode === 'everyone' ? [] : nextTeamIds,
+      })
+      .catch(() => addErrorMessage(t('The access settings could not be saved.')));
+
+  return (
+    <AccessControl>
+      <SegmentedControl
+        aria-label={t('Who can edit')}
+        value={mode}
+        disabled={store.isUpdatingAccess}
+        onChange={nextMode => {
+          void save(nextMode, nextMode === 'everyone' ? [] : teamIds);
+        }}
+      >
+        <SegmentedControl.Item key="everyone">{t('Everyone')}</SegmentedControl.Item>
+        <SegmentedControl.Item key="restricted">
+          {t('Creator and teams')}
+        </SegmentedControl.Item>
+      </SegmentedControl>
+      {mode === 'restricted' ? (
+        <Select
+          multiple
+          options={teamOptions}
+          value={teamIds}
+          disabled={store.isUpdatingAccess}
+          onChange={selected => {
+            const nextTeamIds = selected.map(option => option.value);
+            void save('restricted', nextTeamIds);
+          }}
+        />
+      ) : null}
+    </AccessControl>
+  );
+});
+
+const SettingsSurface = styled(Stack)`
+  gap: 0;
+`;
+
+const SettingsRow = styled(Flex)`
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: ${p => p.theme.space['2xl']};
+  padding: ${p => p.theme.space.xl} 0;
+
+  & + & {
+    border-top: 1px solid ${p => p.theme.tokens.border.secondary};
+  }
+`;
+
+const AccessControl = styled(Stack)`
+  width: 260px;
+  align-items: flex-end;
+  gap: ${p => p.theme.space.sm};
+`;


### PR DESCRIPTION
This is part 4 of 4 in the Investigation execution/frontend split and is stacked on #121697.

This PR exposes the complete Investigation frontend:

- Investigation launcher, routes, and editor
- query/text execution controls and streamed output
- chart/table rendering, parameters, settings, and access controls
- breached-metric entry points in issue details and the issue list
- Explore navigation
- frontend integration and performance coverage

All Investigation UI remains gated by `organizations:investigations`. Query/text execution and breached-metric entry points additionally require `organizations:investigations-query-execution`.

Validation:
- seven focused frontend suites: 59 passed
- pre-commit eslint, stylelint, and formatting hooks passed
- pre-push mypy and knip passed