### PR TITLE
feat(conversations): Expand user_message XML tags by default

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentRenderer.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentRenderer.spec.tsx
@@ -131,4 +131,21 @@ describe('AIContentRenderer', () => {
     render(<AIContentRenderer text={'```\nconst x = 1;\n```'} inline />);
     expect(await screen.findByText(/const x = 1;/)).toBeInTheDocument();
   });
+
+  it('collapses generic XML tags by default', () => {
+    const text = '<thinking>\nhidden thought\n</thinking>';
+    render(<AIContentRenderer text={text} inline collapsibleXmlTags />);
+
+    expect(screen.getByText('<thinking>').closest('details')).not.toHaveAttribute('open');
+  });
+
+  it.each(['user_message', 'user-message', 'userMessage', 'user_msg', 'user_input'])(
+    'expands the %s tag by default',
+    tagName => {
+      const text = `<${tagName}>\nhello there\n</${tagName}>`;
+      render(<AIContentRenderer text={text} inline collapsibleXmlTags />);
+
+      expect(screen.getByText(`<${tagName}>`).closest('details')).toHaveAttribute('open');
+    }
+  );
 });

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentRenderer.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentRenderer.tsx
@@ -109,6 +109,17 @@ interface AIContentRendererProps {
   maxJsonDepth?: number;
 }
 
+/**
+ * Tag names (case-insensitive, punctuation-insensitive) whose collapsible
+ * blocks start expanded — the user's own message is the most useful content in
+ * a transcript, so we don't hide it behind a caret.
+ */
+const EXPANDED_BY_DEFAULT_TAGS = new Set(['usermessage', 'usermsg', 'userinput']);
+
+function isExpandedByDefaultTag(tagName: string): boolean {
+  return EXPANDED_BY_DEFAULT_TAGS.has(tagName.toLowerCase().replace(/[-_]/g, ''));
+}
+
 function XmlTagBlock({
   tagName,
   attributes,
@@ -143,7 +154,7 @@ function XmlTagBlock({
   if (collapsible) {
     return (
       <Container margin="sm 0">
-        <CollapsibleContent title={label}>
+        <CollapsibleContent title={label} defaultOpen={isExpandedByDefaultTag(tagName)}>
           <Container paddingTop="md" paddingLeft="md">
             {body}
           </Container>


### PR DESCRIPTION
XML tag blocks rendered inside AI conversation message bubbles are collapsible and start collapsed by default, hiding the content behind a caret. The user's own message (`<user_message>`) is usually the most useful content in a transcript, so this makes those tags start expanded.

An allowlist of tag names starts expanded, matched case-insensitively and ignoring hyphens/underscores so common variations all qualify:

- `user_message`
- `user-message`
- `userMessage`
- `user_msg`
- `user_input`

Every other tag keeps the existing collapsed-by-default behavior.