### PR TITLE
fix(arithmetic-builder): Align function tokens vertically

### DIFF
--- a/static/app/components/arithmeticBuilder/token/function.tsx
+++ b/static/app/components/arithmeticBuilder/token/function.tsx
@@ -103,7 +103,7 @@ function ArgumentsGrid({
   };
 
   if (!args.length) {
-    return '()';
+    return <BaseGridCell>()</BaseGridCell>;
   }
 
   return (
@@ -696,7 +696,7 @@ function useAttributeItems({
 
 const FunctionWrapper = styled('div')<{state: 'invalid' | 'warning' | 'valid'}>`
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   position: relative;
   border: 1px solid ${p => p.theme.tokens.border.secondary};
   border-radius: ${p => p.theme.radius.md};
@@ -755,6 +755,7 @@ const BaseGridCell = styled('div')`
   align-items: center;
   position: relative;
   height: 100%;
+  min-height: 22px;
 `;
 
 const FunctionGridCell = styled(BaseGridCell)`

--- a/static/app/components/arithmeticBuilder/token/function.tsx
+++ b/static/app/components/arithmeticBuilder/token/function.tsx
@@ -701,6 +701,8 @@ const FunctionWrapper = styled('div')<{state: 'invalid' | 'warning' | 'valid'}>`
   border: 1px solid ${p => p.theme.tokens.border.secondary};
   border-radius: ${p => p.theme.radius.md};
   height: fit-content;
+  min-height: 24px;
+  padding: 1px 0;
   /* Ensures that filters do not grow outside of the container */
   min-width: 0;
   max-width: 100%;

--- a/static/app/components/arithmeticBuilder/token/function.tsx
+++ b/static/app/components/arithmeticBuilder/token/function.tsx
@@ -696,13 +696,12 @@ function useAttributeItems({
 
 const FunctionWrapper = styled('div')<{state: 'invalid' | 'warning' | 'valid'}>`
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   position: relative;
   border: 1px solid ${p => p.theme.tokens.border.secondary};
   border-radius: ${p => p.theme.radius.md};
   height: fit-content;
   min-height: 24px;
-  padding: 1px 0;
   /* Ensures that filters do not grow outside of the container */
   min-width: 0;
   max-width: 100%;

--- a/static/app/components/arithmeticBuilder/token/grid.tsx
+++ b/static/app/components/arithmeticBuilder/token/grid.tsx
@@ -199,7 +199,7 @@ function GridList({showPlaceholder, ...props}: GridListProps) {
 const TokenGridWrapper = styled('div')`
   padding: ${p => p.theme.space.sm};
   display: flex;
-  align-items: stretch;
+  align-items: center;
   row-gap: ${p => p.theme.space.xs};
   flex-wrap: wrap;
 


### PR DESCRIPTION
Arithmetic builder tokens now sit vertically centered within taller equation fields. Function tokens use the same 24px minimum height as literal tokens, with symmetric vertical spacing around their content.

Function token contents are centered within their border while retaining fit-content height, so long argument lists can still wrap and grow.

|Before|After|
|-|-|
|<img width="323" height="178" alt="Screenshot 2026-08-11 at 07 53 53" src="https://github.com/user-attachments/assets/073507c4-c0b8-41f4-8e6a-4aa39c6cb656" />|<img width="324" height="164" alt="Screenshot 2026-08-11 at 08 04 52" src="https://github.com/user-attachments/assets/ea117442-22bc-47ff-accc-dbcba3a1d42e" />|