### PR TITLE
fix(scraps): emptyState responsiveness

### DIFF
--- a/static/app/components/core/emptyState/emptyState.tsx
+++ b/static/app/components/core/emptyState/emptyState.tsx
@@ -1,4 +1,4 @@
-import {Container, Flex, Stack, type FlexProps} from '@sentry/scraps/layout';
+import {Flex, Stack, type FlexProps} from '@sentry/scraps/layout';
 import {Heading, Text, type TextProps} from '@sentry/scraps/text';
 
 interface EmptyStateProps extends Omit<
@@ -22,7 +22,7 @@ export function EmptyState({
   const textAlign: TextProps<'p'>['align'] = {zero: 'center', [switchOn]: 'left'};
 
   return (
-    <Container containerType="inline-size" width="100%" flexGrow={1} minWidth={0}>
+    <Flex containerType="inline-size" width="100%" flexGrow={1} minWidth={0}>
       <Flex
         direction={{zero: 'column', [switchOn]: 'row'}}
         flexGrow={1}
@@ -55,6 +55,6 @@ export function EmptyState({
           )}
         </Stack>
       </Flex>
-    </Container>
+    </Flex>
   );
 }

--- a/static/app/components/core/emptyState/emptyState.tsx
+++ b/static/app/components/core/emptyState/emptyState.tsx
@@ -1,7 +1,10 @@
-import {Flex, Stack, type FlexProps} from '@sentry/scraps/layout';
+import {Container, Flex, Stack, type FlexProps} from '@sentry/scraps/layout';
 import {Heading, Text, type TextProps} from '@sentry/scraps/text';
 
-interface EmptyStateProps extends Omit<FlexProps, 'title' | 'children'> {
+interface EmptyStateProps extends Omit<
+  FlexProps,
+  'title' | 'children' | 'containerType'
+> {
   title: React.ReactNode;
   action?: React.ReactNode;
   description?: React.ReactNode;
@@ -19,38 +22,39 @@ export function EmptyState({
   const textAlign: TextProps<'p'>['align'] = {zero: 'center', [switchOn]: 'left'};
 
   return (
-    <Flex
-      containerType="inline-size"
-      direction={{zero: 'column', [switchOn]: 'row'}}
-      flexGrow={1}
-      align="center"
-      gap={{zero: 'xl', [switchOn]: '2xl'}}
-      justify={{zero: 'start', [switchOn]: 'center'}}
-      data-test-id="empty-state"
-      {...props}
-    >
-      {illustration && (
-        <Flex justify="center" align="center" overflow="hidden" flexShrink={0}>
-          {illustration}
-        </Flex>
-      )}
-      <Stack gap="xl">
-        <Stack gap="md" width="100%" maxWidth="48ch">
-          <Heading as="h3" size="lg" align={textAlign}>
-            {title}
-          </Heading>
-          {description && (
-            <Text as="p" size="md" variant="muted" align={textAlign} textWrap="balance">
-              {description}
-            </Text>
-          )}
-        </Stack>
-        {action && (
-          <Flex gap="md" justify={{zero: 'center', [switchOn]: 'start'}}>
-            {action}
+    <Container containerType="inline-size" width="100%" flexGrow={1} minWidth={0}>
+      <Flex
+        direction={{zero: 'column', [switchOn]: 'row'}}
+        flexGrow={1}
+        align="center"
+        gap={{zero: 'xl', [switchOn]: '2xl'}}
+        justify={{zero: 'start', [switchOn]: 'center'}}
+        data-test-id="empty-state"
+        {...props}
+      >
+        {illustration && (
+          <Flex justify="center" align="center" overflow="hidden" flexShrink={0}>
+            {illustration}
           </Flex>
         )}
-      </Stack>
-    </Flex>
+        <Stack gap="xl">
+          <Stack gap="md" width="100%" maxWidth="48ch">
+            <Heading as="h3" size="lg" align={textAlign}>
+              {title}
+            </Heading>
+            {description && (
+              <Text as="p" size="md" variant="muted" align={textAlign} textWrap="balance">
+                {description}
+              </Text>
+            )}
+          </Stack>
+          {action && (
+            <Flex gap="md" justify={{zero: 'center', [switchOn]: 'start'}} wrap="wrap">
+              {action}
+            </Flex>
+          )}
+        </Stack>
+      </Flex>
+    </Container>
   );
 }


### PR DESCRIPTION
emptyState was querying two different containers: the top level flex was querying the #main container while the elements inside it where querying the internally created inline-size container

that led to situations where, even though they were all using the same `switchOn` breakpoint, items could still be row-aligned while they already got the center textAlign set. This happens when e.g. the EmptyState gets a `padding` assigned, which was also visible in the stories.


before:

notice how on  `xs`, illustration is next to the text but the text is already center aligned, which should only happen when the illustration is above the text:

<img width="532" height="292" alt="Screenshot 2026-08-11 at 13 24 30" src="https://github.com/user-attachments/assets/ef15097a-7b19-4059-a89c-cad6ba854f1d" />

<img width="571" height="274" alt="Screenshot 2026-08-11 at 13 26 16" src="https://github.com/user-attachments/assets/023d7041-59d0-47e6-b5a7-3e31efe6b890" />


after:

<img width="494" height="364" alt="Screenshot 2026-08-11 at 13 25 29" src="https://github.com/user-attachments/assets/cf7f8200-364b-4451-a26b-3737e8aa0461" />
<img width="559" height="269" alt="Screenshot 2026-08-11 at 13 25 38" src="https://github.com/user-attachments/assets/b9da9892-3e0c-494d-82bb-efc62e741477" />
