### PR TITLE
fix(inbound-filters): customer filter table columns

### DIFF
--- a/static/app/views/settings/project/projectFilters/customFilters.tsx
+++ b/static/app/views/settings/project/projectFilters/customFilters.tsx
@@ -747,8 +747,10 @@ export function CustomFilters({project}: {project: Project}) {
   );
 }
 
+// Fixed widths for the columns whose content is a control or a relative date,
+// so the layout stays put as rows come and go. Sizing them to their content
+// makes the columns jump every time the row set changes, and collapses them onto
+// the header text once the last row is gone.
 const CustomFiltersTable = styled(SimpleTable)`
-  grid-template-columns:
-    max-content minmax(0, 1fr) minmax(0, 2fr) max-content max-content
-    max-content;
+  grid-template-columns: 90px minmax(0, 1fr) minmax(0, 2fr) 160px 160px 110px;
 `;

--- a/static/app/views/settings/project/projectFilters/customFilters.tsx
+++ b/static/app/views/settings/project/projectFilters/customFilters.tsx
@@ -599,7 +599,9 @@ export function CustomFilters({project}: {project: Project}) {
   const visibleFilters = filters.filter(filter => matchesQuery(filter, query));
 
   return (
-    <Stack gap="lg">
+    // The table drops its date columns by its own width, not the viewport's, so
+    // it needs a query container of that width to resolve against.
+    <Stack gap="lg" containerType="inline-size">
       <Flex gap="md" align="center">
         <Flex flex={1}>
           <InputGroup style={{width: '100%'}}>
@@ -654,10 +656,12 @@ export function CustomFilters({project}: {project: Project}) {
             <SimpleTable.HeaderCell divider={false}>
               {t('Conditions')}
             </SimpleTable.HeaderCell>
-            <SimpleTable.HeaderCell divider={false}>
+            <SimpleTable.HeaderCell divider={false} data-column-name="created">
               {t('Created')}
             </SimpleTable.HeaderCell>
-            <SimpleTable.HeaderCell divider={false}>{t('Edited')}</SimpleTable.HeaderCell>
+            <SimpleTable.HeaderCell divider={false} data-column-name="edited">
+              {t('Edited')}
+            </SimpleTable.HeaderCell>
             <SimpleTable.HeaderCell divider={false}>{t('Action')}</SimpleTable.HeaderCell>
           </SimpleTable.Header>
           {visibleFilters.length === 0 && (
@@ -696,11 +700,11 @@ export function CustomFilters({project}: {project: Project}) {
                   )}
                 </Stack>
               </SimpleTable.RowCell>
-              <SimpleTable.RowCell>
-                <TimeSince date={filter.dateCreated} />
+              <SimpleTable.RowCell data-column-name="created">
+                <TimeSince date={filter.dateCreated} unitStyle="short" />
               </SimpleTable.RowCell>
-              <SimpleTable.RowCell>
-                <TimeSince date={filter.dateUpdated} />
+              <SimpleTable.RowCell data-column-name="edited">
+                <TimeSince date={filter.dateUpdated} unitStyle="short" />
               </SimpleTable.RowCell>
               <SimpleTable.RowCell>
                 <Flex gap="sm">
@@ -747,10 +751,23 @@ export function CustomFilters({project}: {project: Project}) {
   );
 }
 
-// Fixed widths for the columns whose content is a control or a relative date,
-// so the layout stays put as rows come and go. Sizing them to their content
+// Fixed widths for the columns whose content is a control or a short relative
+// date, so the layout stays put as rows come and go. Sizing them to their content
 // makes the columns jump every time the row set changes, and collapses them onto
 // the header text once the last row is gone.
+//
+// Name and conditions carry the filter, so they keep the remaining width. Once
+// the table is too narrow to give them a useful share of it, the dates go rather
+// than shrink them further.
 const CustomFiltersTable = styled(SimpleTable)`
-  grid-template-columns: 90px minmax(0, 1fr) minmax(0, 2fr) 160px 160px 110px;
+  grid-template-columns: 90px minmax(0, 1fr) minmax(0, 2fr) 100px 100px 110px;
+
+  @container (max-width: ${p => p.theme.container['2xl']}) {
+    grid-template-columns: 90px minmax(0, 1fr) minmax(0, 2fr) 110px;
+
+    [data-column-name='created'],
+    [data-column-name='edited'] {
+      display: none;
+    }
+  }
 `;

--- a/static/app/views/settings/project/projectFilters/customFilters.tsx
+++ b/static/app/views/settings/project/projectFilters/customFilters.tsx
@@ -501,13 +501,19 @@ export function CustomFilters({project}: {project: Project}) {
   const queryClient = useQueryClient();
   const [query, setQuery] = useState('');
 
-  const hasWriteAccess = hasEveryAccess(['project:write'], {organization, project});
+  const hasWriteAccess = hasEveryAccess(['project:write'], {
+    organization,
+    project,
+  });
   const dataTypeOptions = getAvailableDataTypeOptions(organization);
 
   const queryOptions = apiOptions.as<CustomInboundFilter[]>()(
     '/projects/$organizationIdOrSlug/$projectIdOrSlug/custom-inbound-filters/',
     {
-      path: {organizationIdOrSlug: organization.slug, projectIdOrSlug: project.slug},
+      path: {
+        organizationIdOrSlug: organization.slug,
+        projectIdOrSlug: project.slug,
+      },
       staleTime: 0,
     }
   );
@@ -515,7 +521,12 @@ export function CustomFilters({project}: {project: Project}) {
 
   const listUrl = getApiUrl(
     '/projects/$organizationIdOrSlug/$projectIdOrSlug/custom-inbound-filters/',
-    {path: {organizationIdOrSlug: organization.slug, projectIdOrSlug: project.slug}}
+    {
+      path: {
+        organizationIdOrSlug: organization.slug,
+        projectIdOrSlug: project.slug,
+      },
+    }
   );
   const detailUrl = (filterId: string) =>
     getApiUrl(
@@ -538,7 +549,10 @@ export function CustomFilters({project}: {project: Project}) {
       fetchMutation<CustomInboundFilter>({
         method: 'POST',
         url: listUrl,
-        data: {name: values.name.trim(), conditions: formValuesToConditions(values)},
+        data: {
+          name: values.name.trim(),
+          conditions: formValuesToConditions(values),
+        },
       }),
     onSuccess: () => {
       addSuccessMessage(t('Filter created'));
@@ -588,7 +602,10 @@ export function CustomFilters({project}: {project: Project}) {
   const handleEdit = (id: string, values: FilterFormValues) =>
     updateMutation.mutateAsync({
       id,
-      data: {name: values.name.trim(), conditions: formValuesToConditions(values)},
+      data: {
+        name: values.name.trim(),
+        conditions: formValuesToConditions(values),
+      },
     });
 
   const handleToggleActive = (filter: CustomInboundFilter) =>
@@ -747,14 +764,6 @@ export function CustomFilters({project}: {project: Project}) {
   );
 }
 
-// Fixed widths for the columns whose content is a control or a short relative
-// date, so the layout stays put as rows come and go. Sizing them to their content
-// makes the columns jump every time the row set changes, and collapses them onto
-// the header text once the last row is gone.
-//
-// Name and conditions carry the filter, so they take the spare width, and they
-// keep a floor once there is none left. The table scrolls sideways below that
-// floor instead of squeezing them further.
 const CustomFiltersTable = styled(SimpleTable)`
   grid-template-columns: 90px minmax(160px, 1fr) minmax(240px, 2fr) 100px 100px 110px;
   overflow-x: auto;

--- a/static/app/views/settings/project/projectFilters/customFilters.tsx
+++ b/static/app/views/settings/project/projectFilters/customFilters.tsx
@@ -599,9 +599,7 @@ export function CustomFilters({project}: {project: Project}) {
   const visibleFilters = filters.filter(filter => matchesQuery(filter, query));
 
   return (
-    // The table drops its date columns by its own width, not the viewport's, so
-    // it needs a query container of that width to resolve against.
-    <Stack gap="lg" containerType="inline-size">
+    <Stack gap="lg">
       <Flex gap="md" align="center">
         <Flex flex={1}>
           <InputGroup style={{width: '100%'}}>
@@ -656,12 +654,10 @@ export function CustomFilters({project}: {project: Project}) {
             <SimpleTable.HeaderCell divider={false}>
               {t('Conditions')}
             </SimpleTable.HeaderCell>
-            <SimpleTable.HeaderCell divider={false} data-column-name="created">
+            <SimpleTable.HeaderCell divider={false}>
               {t('Created')}
             </SimpleTable.HeaderCell>
-            <SimpleTable.HeaderCell divider={false} data-column-name="edited">
-              {t('Edited')}
-            </SimpleTable.HeaderCell>
+            <SimpleTable.HeaderCell divider={false}>{t('Edited')}</SimpleTable.HeaderCell>
             <SimpleTable.HeaderCell divider={false}>{t('Action')}</SimpleTable.HeaderCell>
           </SimpleTable.Header>
           {visibleFilters.length === 0 && (
@@ -700,11 +696,11 @@ export function CustomFilters({project}: {project: Project}) {
                   )}
                 </Stack>
               </SimpleTable.RowCell>
-              <SimpleTable.RowCell data-column-name="created">
-                <TimeSince date={filter.dateCreated} unitStyle="short" />
+              <SimpleTable.RowCell whiteSpace="nowrap">
+                <TimeSince date={filter.dateCreated} unitStyle="extraShort" />
               </SimpleTable.RowCell>
-              <SimpleTable.RowCell data-column-name="edited">
-                <TimeSince date={filter.dateUpdated} unitStyle="short" />
+              <SimpleTable.RowCell whiteSpace="nowrap">
+                <TimeSince date={filter.dateUpdated} unitStyle="extraShort" />
               </SimpleTable.RowCell>
               <SimpleTable.RowCell>
                 <Flex gap="sm">
@@ -756,18 +752,10 @@ export function CustomFilters({project}: {project: Project}) {
 // makes the columns jump every time the row set changes, and collapses them onto
 // the header text once the last row is gone.
 //
-// Name and conditions carry the filter, so they keep the remaining width. Once
-// the table is too narrow to give them a useful share of it, the dates go rather
-// than shrink them further.
+// Name and conditions carry the filter, so they take the spare width, and they
+// keep a floor once there is none left. The table scrolls sideways below that
+// floor instead of squeezing them further.
 const CustomFiltersTable = styled(SimpleTable)`
-  grid-template-columns: 90px minmax(0, 1fr) minmax(0, 2fr) 100px 100px 110px;
-
-  @container (max-width: ${p => p.theme.container['2xl']}) {
-    grid-template-columns: 90px minmax(0, 1fr) minmax(0, 2fr) 110px;
-
-    [data-column-name='created'],
-    [data-column-name='edited'] {
-      display: none;
-    }
-  }
+  grid-template-columns: 90px minmax(160px, 1fr) minmax(240px, 2fr) 100px 100px 110px;
+  overflow-x: auto;
 `;


### PR DESCRIPTION
- Prevent columns from changing size when the last filter gets deleted
- Use a more compact date representation

|                     | **Before**                                                                                                                                          | **After**                                                                                                                                           |
|---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
| State with 1 filter | <img width="1438" height="233" alt="State with 1 filter Before" src="https://github.com/user-attachments/assets/af208318-f102-4896-be6d-b22396cef917" />             | <img width="1428" height="228" alt="State with 1 filter After" src="https://github.com/user-attachments/assets/18c212a8-a095-4103-a247-8d219091ee65" />              |
| Empty State         | <img width="1238" height="368" alt="Empty State Before" src="https://github.com/user-attachments/assets/7974e984-ce30-4aee-b70d-588c613b7e9d" />                 | <img width="1437" height="369" alt="Empty State After" src="https://github.com/user-attachments/assets/60dd2f54-7d69-417b-8c66-77a764df7ac5" />                 |


Closes TET-2736
