### PR TITLE
ref(explore): Call the renamed agents/conversations API

### DIFF
--- a/static/app/views/explore/conversations/components/conversationView.spec.tsx
+++ b/static/app/views/explore/conversations/components/conversationView.spec.tsx
@@ -43,7 +43,7 @@ const CONVERSATION_BODY = [
 
 function mockConversation() {
   MockApiClient.addMockResponse({
-    url: `/organizations/org-slug/ai-conversations/${CONVERSATION_ID}/`,
+    url: `/organizations/org-slug/agents/conversations/${CONVERSATION_ID}/`,
     body: {conversationId: CONVERSATION_ID, title: null, spans: CONVERSATION_BODY},
   });
   // The detail pane fetches full attributes per span; keep it empty.

--- a/static/app/views/explore/conversations/components/conversationsTable.spec.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTable.spec.tsx
@@ -40,7 +40,7 @@ const organization = OrganizationFixture({
 
 function mockConversations(body: Array<Record<string, unknown>>) {
   MockApiClient.addMockResponse({
-    url: `/organizations/${organization.slug}/ai-conversations/`,
+    url: `/organizations/${organization.slug}/agents/conversations/`,
     body,
   });
 }

--- a/static/app/views/explore/conversations/conversationDetail.spec.tsx
+++ b/static/app/views/explore/conversations/conversationDetail.spec.tsx
@@ -53,7 +53,7 @@ function mockApis(
   spans: Array<Record<string, unknown>> = CONVERSATION_BODY
 ) {
   MockApiClient.addMockResponse({
-    url: `/organizations/org-slug/ai-conversations/${CONVERSATION_ID}/`,
+    url: `/organizations/org-slug/agents/conversations/${CONVERSATION_ID}/`,
     body: {conversationId: CONVERSATION_ID, title, spans},
   });
   MockApiClient.addMockResponse({

--- a/static/app/views/explore/conversations/hooks/useConversation.spec.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversation.spec.tsx
@@ -178,7 +178,7 @@ describe('useConversation', () => {
     // renders it unchanged) and preserve span.op, which the transcript uses to
     // recognize the embedding.
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/ai-conversations/conv-embedding/`,
+      url: `/organizations/${organization.slug}/agents/conversations/conv-embedding/`,
       body: envelope([
         {
           'gen_ai.conversation.id': 'conv-embedding',
@@ -217,7 +217,7 @@ describe('useConversation', () => {
 
   it('maps gen_ai.embeddings.input to node attributes', async () => {
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/ai-conversations/conv-embedding-input/`,
+      url: `/organizations/${organization.slug}/agents/conversations/conv-embedding-input/`,
       body: envelope([
         {
           'gen_ai.conversation.id': 'conv-embedding-input',

--- a/static/app/views/explore/conversations/hooks/useConversation.spec.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversation.spec.tsx
@@ -56,7 +56,7 @@ describe('useConversation', () => {
 
   it('returns the conversation title from the envelope', async () => {
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/ai-conversations/conv-title/`,
+      url: `/organizations/${organization.slug}/agents/conversations/conv-title/`,
       body: envelope(
         [{...BASE_SPAN, 'gen_ai.conversation.id': 'conv-title', span_id: 'span-title'}],
         'My great conversation'
@@ -75,7 +75,7 @@ describe('useConversation', () => {
 
   it('returns a null title when the envelope has none', async () => {
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/ai-conversations/conv-123/`,
+      url: `/organizations/${organization.slug}/agents/conversations/conv-123/`,
       body: envelope([BASE_SPAN]),
     });
 
@@ -93,7 +93,7 @@ describe('useConversation', () => {
     const inputMessages = JSON.stringify([{role: 'user', content: 'Hello from input'}]);
 
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/ai-conversations/conv-123/`,
+      url: `/organizations/${organization.slug}/agents/conversations/conv-123/`,
       body: envelope([
         {
           'gen_ai.conversation.id': 'conv-123',
@@ -137,7 +137,7 @@ describe('useConversation', () => {
     ]);
 
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/ai-conversations/conv-output/`,
+      url: `/organizations/${organization.slug}/agents/conversations/conv-output/`,
       body: envelope([
         {
           'gen_ai.conversation.id': 'conv-output',
@@ -178,7 +178,7 @@ describe('useConversation', () => {
     ]);
 
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/ai-conversations/conv-456/`,
+      url: `/organizations/${organization.slug}/agents/conversations/conv-456/`,
       body: envelope([
         {
           'gen_ai.conversation.id': 'conv-456',
@@ -215,7 +215,7 @@ describe('useConversation', () => {
 
   it('uses empty string for missing optional fields', async () => {
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/ai-conversations/conv-789/`,
+      url: `/organizations/${organization.slug}/agents/conversations/conv-789/`,
       body: envelope([
         {
           'gen_ai.conversation.id': 'conv-789',
@@ -254,7 +254,7 @@ describe('useConversation', () => {
 
   it('uses conversation timestamps when provided', async () => {
     const mockRequest = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/ai-conversations/conv-timestamps/`,
+      url: `/organizations/${organization.slug}/agents/conversations/conv-timestamps/`,
       body: envelope([
         {
           'gen_ai.conversation.id': 'conv-timestamps',
@@ -292,7 +292,7 @@ describe('useConversation', () => {
     // Verify the API was called with correct timestamps (with 1-hour padding)
     // and ALL_ACCESS_PROJECTS (-1) when no project is selected in page filters
     expect(mockRequest).toHaveBeenCalledWith(
-      expect.stringContaining('/ai-conversations/conv-timestamps/'),
+      expect.stringContaining('/agents/conversations/conv-timestamps/'),
       expect.objectContaining({
         query: expect.objectContaining({
           start: new Date(startTimestamp - 60 * 60 * 1000).toISOString(),
@@ -309,7 +309,7 @@ describe('useConversation', () => {
 
   it('uses span.name for description and name fields', async () => {
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/ai-conversations/conv-name/`,
+      url: `/organizations/${organization.slug}/agents/conversations/conv-name/`,
       body: envelope([
         {
           'gen_ai.conversation.id': 'conv-name',
@@ -345,7 +345,7 @@ describe('useConversation', () => {
 
   it('sorts nodes by start timestamp for AI spans list', async () => {
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/ai-conversations/conv-sort/`,
+      url: `/organizations/${organization.slug}/agents/conversations/conv-sort/`,
       body: envelope([
         {
           'gen_ai.conversation.id': 'conv-sort',
@@ -395,7 +395,7 @@ describe('useConversation', () => {
     act(() => PageFiltersStore.updateProjects([456], []));
 
     const mockRequest = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/ai-conversations/conv-123/`,
+      url: `/organizations/${organization.slug}/agents/conversations/conv-123/`,
       body: envelope([BASE_SPAN]),
     });
 
@@ -407,7 +407,7 @@ describe('useConversation', () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
     expect(mockRequest).toHaveBeenCalledWith(
-      expect.stringContaining('/ai-conversations/conv-123/'),
+      expect.stringContaining('/agents/conversations/conv-123/'),
       expect.objectContaining({
         query: expect.objectContaining({project: [456]}),
       })
@@ -425,7 +425,7 @@ describe('useConversation', () => {
     );
 
     const mockRequest = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/ai-conversations/conv-123/`,
+      url: `/organizations/${organization.slug}/agents/conversations/conv-123/`,
       body: envelope([BASE_SPAN]),
     });
 
@@ -437,7 +437,7 @@ describe('useConversation', () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
     expect(mockRequest).toHaveBeenCalledWith(
-      expect.stringContaining('/ai-conversations/conv-123/'),
+      expect.stringContaining('/agents/conversations/conv-123/'),
       expect.objectContaining({
         query: expect.objectContaining({
           start: expect.stringContaining('2026-04-01'),
@@ -452,7 +452,7 @@ describe('useConversation', () => {
 
   it('falls back to ALL_ACCESS_PROJECTS with no time params when no filters are set', async () => {
     const mockRequest = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/ai-conversations/conv-123/`,
+      url: `/organizations/${organization.slug}/agents/conversations/conv-123/`,
       body: envelope([BASE_SPAN]),
     });
 
@@ -464,7 +464,7 @@ describe('useConversation', () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
     expect(mockRequest).toHaveBeenCalledWith(
-      expect.stringContaining('/ai-conversations/conv-123/'),
+      expect.stringContaining('/agents/conversations/conv-123/'),
       expect.objectContaining({
         query: expect.objectContaining({
           project: [-1],
@@ -489,7 +489,7 @@ describe('useConversation', () => {
     );
 
     const mockRequest = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/ai-conversations/conv-123/`,
+      url: `/organizations/${organization.slug}/agents/conversations/conv-123/`,
       body: envelope([BASE_SPAN]),
     });
 
@@ -501,7 +501,7 @@ describe('useConversation', () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
     expect(mockRequest).toHaveBeenCalledWith(
-      expect.stringContaining('/ai-conversations/conv-123/'),
+      expect.stringContaining('/agents/conversations/conv-123/'),
       expect.objectContaining({
         query: expect.objectContaining({
           statsPeriod: '7d',
@@ -515,7 +515,7 @@ describe('useConversation', () => {
 
   it('filters to only gen_ai spans', async () => {
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/ai-conversations/conv-filter/`,
+      url: `/organizations/${organization.slug}/agents/conversations/conv-filter/`,
       body: envelope([
         {
           'gen_ai.conversation.id': 'conv-filter',
@@ -562,7 +562,7 @@ describe('useConversation', () => {
 
   it('maps errors and occurrences from the response onto the node', async () => {
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/ai-conversations/conv-issues/`,
+      url: `/organizations/${organization.slug}/agents/conversations/conv-issues/`,
       body: envelope([
         {
           ...BASE_SPAN,
@@ -616,7 +616,7 @@ describe('useConversation', () => {
 
   it('defaults to no issues when the response omits errors and occurrences', async () => {
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/ai-conversations/conv-no-issues/`,
+      url: `/organizations/${organization.slug}/agents/conversations/conv-no-issues/`,
       body: envelope([
         {...BASE_SPAN, 'gen_ai.conversation.id': 'conv-no-issues', span_id: 'span-x'},
       ]),

--- a/static/app/views/explore/conversations/hooks/useConversation.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversation.tsx
@@ -254,7 +254,7 @@ export function useConversation(
     isError,
   } = useInfiniteQuery(
     apiOptions.asInfinite<ConversationApiResponse>()(
-      '/organizations/$organizationIdOrSlug/ai-conversations/$conversationId/',
+      '/organizations/$organizationIdOrSlug/agents/conversations/$conversationId/',
       {
         path: conversation.conversationId
           ? {

--- a/static/app/views/explore/conversations/hooks/useConversations.spec.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversations.spec.tsx
@@ -32,7 +32,7 @@ describe('useConversations', () => {
 
   it('requests 50 conversations per page', async () => {
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/ai-conversations/`,
+      url: `/organizations/${organization.slug}/agents/conversations/`,
       body: [],
       match: [MockApiClient.matchQuery({per_page: 50})],
     });
@@ -44,7 +44,7 @@ describe('useConversations', () => {
 
   it('normalizes firstInput when it is a string', async () => {
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/ai-conversations/`,
+      url: `/organizations/${organization.slug}/agents/conversations/`,
       body: [{...BASE_CONVERSATION, firstInput: 'hello', lastOutput: null}],
     });
 
@@ -57,7 +57,7 @@ describe('useConversations', () => {
 
   it('normalizes firstInput from array format to string', async () => {
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/ai-conversations/`,
+      url: `/organizations/${organization.slug}/agents/conversations/`,
       body: [
         {
           ...BASE_CONVERSATION,
@@ -79,7 +79,7 @@ describe('useConversations', () => {
 
   it('normalizes firstInput to null when array has no text type', async () => {
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/ai-conversations/`,
+      url: `/organizations/${organization.slug}/agents/conversations/`,
       body: [
         {
           ...BASE_CONVERSATION,
@@ -98,7 +98,7 @@ describe('useConversations', () => {
 
   it('normalizes lastOutput when it is a string', async () => {
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/ai-conversations/`,
+      url: `/organizations/${organization.slug}/agents/conversations/`,
       body: [{...BASE_CONVERSATION, firstInput: null, lastOutput: 'world'}],
     });
 
@@ -111,7 +111,7 @@ describe('useConversations', () => {
 
   it('normalizes lastOutput from array format to string', async () => {
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/ai-conversations/`,
+      url: `/organizations/${organization.slug}/agents/conversations/`,
       body: [
         {
           ...BASE_CONVERSATION,
@@ -135,7 +135,7 @@ describe('useConversations', () => {
 
   it('normalizes lastOutput to null when array has no text type', async () => {
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/ai-conversations/`,
+      url: `/organizations/${organization.slug}/agents/conversations/`,
       body: [
         {
           ...BASE_CONVERSATION,
@@ -154,7 +154,7 @@ describe('useConversations', () => {
 
   it('handles null firstInput and lastOutput', async () => {
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/ai-conversations/`,
+      url: `/organizations/${organization.slug}/agents/conversations/`,
       body: [{...BASE_CONVERSATION, firstInput: null, lastOutput: null}],
     });
 
@@ -168,7 +168,7 @@ describe('useConversations', () => {
 
   it('sorts conversations by endTimestamp descending', async () => {
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/ai-conversations/`,
+      url: `/organizations/${organization.slug}/agents/conversations/`,
       body: [
         {...BASE_CONVERSATION, conversationId: 'older', endTimestamp: 1000},
         {...BASE_CONVERSATION, conversationId: 'newer', endTimestamp: 2000},
@@ -185,7 +185,7 @@ describe('useConversations', () => {
 
   it('reports a direct hit when the header is present', async () => {
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/ai-conversations/`,
+      url: `/organizations/${organization.slug}/agents/conversations/`,
       body: [{...BASE_CONVERSATION, firstInput: null, lastOutput: null}],
       headers: {'X-Sentry-Direct-Hit': '1'},
     });
@@ -199,7 +199,7 @@ describe('useConversations', () => {
 
   it('does not report a direct hit when the header is absent', async () => {
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/ai-conversations/`,
+      url: `/organizations/${organization.slug}/agents/conversations/`,
       body: [{...BASE_CONVERSATION, firstInput: null, lastOutput: null}],
     });
 

--- a/static/app/views/explore/conversations/hooks/useConversations.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversations.tsx
@@ -74,7 +74,7 @@ export function useConversations() {
     error,
   } = useQuery({
     ...apiOptions.as<ConversationApiResponse[]>()(
-      '/organizations/$organizationIdOrSlug/ai-conversations/',
+      '/organizations/$organizationIdOrSlug/agents/conversations/',
       {
         path: {organizationIdOrSlug: organization.slug},
         query: {


### PR DESCRIPTION
Reland of #121703, which was reverted in #121710. The conversation list and detail views call the renamed `agents/conversations` API endpoints instead of the legacy `ai-conversations` paths. The endpoints were renamed backend-side in TET-2824; this is a straight client swap with no behavior change.

The original PR broke `useConversation.spec.tsx` because the embeddings transcript tests, added after that PR was written, still mocked the old `ai-conversations` path. This reland updates those mocks alongside the rename so the suite stays green.

Frontend only — the MCP half of the ticket lives in a separate repo.

Refs TET-2826