### PR TITLE
fix(objectstore): Close the upstream response when a proxied download is abandoned

### DIFF
--- a/src/sentry/objectstore/endpoints/organization.py
+++ b/src/sentry/objectstore/endpoints/organization.py
@@ -183,12 +183,13 @@ def stream_response(
     CHUNK_SIZE = 512 * 1024
 
     def stream_generator() -> Generator[bytes]:
-        external_response.raw.decode_content = decode_content
-        while True:
-            chunk = external_response.raw.read(CHUNK_SIZE)
-            if not chunk:
-                break
-            yield chunk
+        with external_response:
+            external_response.raw.decode_content = decode_content
+            while True:
+                chunk = external_response.raw.read(CHUNK_SIZE)
+                if not chunk:
+                    break
+                yield chunk
 
     response = StreamingHttpResponse(
         streaming_content=stream_generator(),

--- a/tests/sentry/objectstore/endpoints/test_organization.py
+++ b/tests/sentry/objectstore/endpoints/test_organization.py
@@ -10,6 +10,7 @@ from django.urls import reverse
 from objectstore_client import Client, Session, Usecase
 from pytest_django.live_server_helper import LiveServer
 
+from sentry.objectstore.endpoints.organization import stream_response
 from sentry.silo.base import SiloMode, SingleProcessSiloModeState
 from sentry.testutils.asserts import assert_status_code
 from sentry.testutils.cases import TransactionTestCase
@@ -327,3 +328,35 @@ class ObjectstoreProxyQueryForwardingTest(TransactionTestCase):
             ObjectstoreEndpoint()._proxy(Request(request), "v1/objects/test/org=1/key")
 
         assert mock_request.call_args.kwargs["params"] == query
+
+
+class ObjectstoreProxyStreamCloseTest(TransactionTestCase):
+    def make_upstream_response(self) -> requests.Response:
+        response = requests.Response()
+        response.status_code = 200
+        response.raw = MagicMock()
+        response.raw.read.side_effect = [b"foo", b"bar", b""]
+        return response
+
+    def test_closes_upstream_response_when_fully_streamed(self) -> None:
+        response = self.make_upstream_response()
+
+        with patch.object(response, "close") as mock_close:
+            streamed = close_streaming_response(stream_response(response))
+
+        assert streamed == b"foobar"
+        assert mock_close.called
+
+    def test_closes_upstream_response_when_client_disconnects(self) -> None:
+        response = self.make_upstream_response()
+
+        with patch.object(response, "close") as mock_close:
+            streaming_response = stream_response(response)
+            assert next(iter(streaming_response)) == b"foo"
+            assert not mock_close.called
+
+            # Django closes the response, and with it the generator, when the client
+            # disconnects part-way through the download.
+            streaming_response.close()
+
+            assert mock_close.called


### PR DESCRIPTION
The Objectstore proxy's streaming generator now closes the upstream response when it finishes, including when a client disconnects part-way through a download.

This may be related to protocol errors in internal proxies that we've been observing.

Refs FS-487
