### PR TITLE
feat(conversations): Build the transcript per sub-agent run

### DIFF
--- a/static/app/views/explore/conversations/components/messagesPanel.tsx
+++ b/static/app/views/explore/conversations/components/messagesPanel.tsx
@@ -230,13 +230,21 @@ const AssistantTurn = memo(function AssistantTurnImpl({
       )}
       {message.reasoning && (
         <MessageRow from="assistant" density="compact">
-          <ReasoningSection reasoning={message.reasoning} />
+          {/* A reasoning-only turn (no assistant bubble to hang meta on) surfaces
+           * the turn's cost/duration in the thinking row's own meta column. */}
+          <ReasoningSection
+            reasoning={message.reasoning}
+            meta={message.content === '' && hasMeta ? meta : undefined}
+          />
         </MessageRow>
       )}
       {message.content === '' ? (
-        // Tool/reasoning-only turn: no bubble, but still surface the turn's cost
-        // and duration, right-aligned to the meta column like other assistant turns.
-        hasMeta && (
+        // Tool-only turn (no reasoning row to carry it): no bubble, but still
+        // surface the turn's cost and duration, right-aligned to the meta column
+        // like other assistant turns. A reasoning row, when present, shows the
+        // meta itself, so skip this fallback then.
+        hasMeta &&
+        !message.reasoning && (
           <MessageRow from="assistant" density="compact">
             <Flex justify="end" width="100%">
               {meta}
@@ -353,11 +361,18 @@ const EmbeddingTurn = memo(function EmbeddingTurnImpl({
   );
 });
 
-function ReasoningSection({reasoning}: {reasoning: string}) {
+function ReasoningSection({
+  reasoning,
+  meta,
+}: {
+  reasoning: string;
+  meta?: React.ReactNode;
+}) {
   const organization = useOrganization();
 
   return (
     <CollapsibleChatRow
+      meta={meta}
       title={isOpen => (
         <Text size="sm" variant="muted" ellipsis monospace>
           {t('Thinking...')} {isOpen ? null : reasoning}

--- a/static/app/views/explore/conversations/utils/conversationMessages.spec.ts
+++ b/static/app/views/explore/conversations/utils/conversationMessages.spec.ts
@@ -6,7 +6,6 @@ import {
   extractMessagesFromNodes,
   getInputMessageStats,
   getNodeTimestamp,
-  groupNodesByAgentRun,
   mergeEmptyTurns,
   messagesToMarkdown,
   parseAssistantContent,
@@ -664,93 +663,6 @@ describe('conversationMessages utilities', () => {
       const result = partitionSpansByType([embeddingNode] as any);
 
       expect(result.embeddingSpans.map(s => s.id)).toEqual(['embed-1']);
-    });
-  });
-
-  describe('groupNodesByAgentRun', () => {
-    it('puts every span in one root run when there are no agent spans', () => {
-      const gen = createMockNode({id: 'gen-1', startTimestamp: 1000});
-      const tool = createMockToolNode({
-        id: 'tool-1',
-        toolName: 'search',
-        startTimestamp: 1500,
-      });
-
-      const runs = groupNodesByAgentRun(withLineage([gen, tool]) as any);
-
-      expect(runs).toHaveLength(1);
-      expect(runs[0]?.map(n => n.id)).toEqual(['gen-1', 'tool-1']);
-    });
-
-    it('groups each agent with its descendant spans and drops the cross-agent shuffle', () => {
-      const agentA = createMockAgentNode({
-        id: 'agent-a',
-        agentName: 'Errors',
-        startTimestamp: 900,
-      });
-      const genA = createMockNode({
-        id: 'gen-a',
-        startTimestamp: 1000,
-        parentSpanId: 'agent-a',
-      });
-      const toolA = createMockToolNode({
-        id: 'tool-a',
-        toolName: 'query_errors',
-        startTimestamp: 2500,
-        parentSpanId: 'agent-a',
-      });
-      const agentB = createMockAgentNode({
-        id: 'agent-b',
-        agentName: 'Traces',
-        startTimestamp: 3400,
-      });
-      const genB = createMockNode({
-        id: 'gen-b',
-        startTimestamp: 3500,
-        parentSpanId: 'agent-b',
-      });
-
-      // Deliberately unordered input.
-      const runs = groupNodesByAgentRun(
-        withLineage([genB, toolA, agentB, genA, agentA]) as any
-      );
-
-      // Two runs, ordered by earliest span: Errors (900) before Traces (3400).
-      expect(runs.map(run => run.map(n => n.id).sort())).toEqual([
-        ['agent-a', 'gen-a', 'tool-a'],
-        ['agent-b', 'gen-b'],
-      ]);
-    });
-
-    it('groups a nested sub-agent under itself, not its parent agent', () => {
-      const parentAgent = createMockAgentNode({
-        id: 'agent-parent',
-        startTimestamp: 900,
-      });
-      const parentGen = createMockNode({
-        id: 'gen-parent',
-        startTimestamp: 1000,
-        parentSpanId: 'agent-parent',
-      });
-      const childAgent = createMockAgentNode({
-        id: 'agent-child',
-        startTimestamp: 1100,
-        parentSpanId: 'agent-parent',
-      });
-      const childGen = createMockNode({
-        id: 'gen-child',
-        startTimestamp: 1200,
-        parentSpanId: 'agent-child',
-      });
-
-      const runs = groupNodesByAgentRun(
-        withLineage([parentAgent, parentGen, childAgent, childGen]) as any
-      );
-
-      expect(runs.map(run => run.map(n => n.id).sort())).toEqual([
-        ['agent-parent', 'gen-parent'],
-        ['agent-child', 'gen-child'],
-      ]);
     });
   });
 
@@ -1605,6 +1517,95 @@ describe('conversationMessages utilities', () => {
       // Agent A's run renders as one contiguous block before Agent B's.
       const order = messages.map(m => m.content);
       expect(order.indexOf('A done')).toBeLessThan(order.indexOf('B done'));
+    });
+
+    it('splices sub-agents between the parent turns that surround them', () => {
+      // A top-level orchestrator plans, invokes two sub-agents, then answers.
+      // The final turn must land after the sub-agents, not be hoisted above them
+      // the way a flat, per-run concatenation ordered by start time would.
+      const genPlan = createMockNode({
+        id: 'gen-plan',
+        startTimestamp: 1000,
+        endTimestamp: 1100,
+        attributes: {[SpanFields.GEN_AI_RESPONSE_TEXT]: 'Planning'},
+      });
+      const agentA = createMockAgentNode({
+        id: 'agent-a',
+        agentName: 'Errors',
+        startTimestamp: 1200,
+        endTimestamp: 3000,
+      });
+      const genA = createMockNode({
+        id: 'gen-a',
+        startTimestamp: 1300,
+        endTimestamp: 2000,
+        parentSpanId: 'agent-a',
+        attributes: {[SpanFields.GEN_AI_RESPONSE_TEXT]: 'A result'},
+      });
+      const agentB = createMockAgentNode({
+        id: 'agent-b',
+        agentName: 'Traces',
+        startTimestamp: 1400,
+        endTimestamp: 3100,
+      });
+      const genB = createMockNode({
+        id: 'gen-b',
+        startTimestamp: 1500,
+        endTimestamp: 2100,
+        parentSpanId: 'agent-b',
+        attributes: {[SpanFields.GEN_AI_RESPONSE_TEXT]: 'B result'},
+      });
+      const genAnswer = createMockNode({
+        id: 'gen-answer',
+        startTimestamp: 4000,
+        endTimestamp: 4100,
+        attributes: {[SpanFields.GEN_AI_RESPONSE_TEXT]: 'Final answer'},
+      });
+
+      const messages = extractMessagesFromNodes(
+        withLineage([genAnswer, genB, agentB, genA, agentA, genPlan]) as any
+      );
+
+      expect(messages.map(m => m.content)).toEqual([
+        'Planning',
+        'A result',
+        'B result',
+        'Final answer',
+      ]);
+    });
+
+    it('expands nested sub-agents recursively in order', () => {
+      const agentOuter = createMockAgentNode({
+        id: 'agent-outer',
+        startTimestamp: 1000,
+        endTimestamp: 4000,
+      });
+      const genOuter = createMockNode({
+        id: 'gen-outer',
+        startTimestamp: 1100,
+        endTimestamp: 1200,
+        parentSpanId: 'agent-outer',
+        attributes: {[SpanFields.GEN_AI_RESPONSE_TEXT]: 'Outer'},
+      });
+      const agentInner = createMockAgentNode({
+        id: 'agent-inner',
+        startTimestamp: 1500,
+        endTimestamp: 3000,
+        parentSpanId: 'agent-outer',
+      });
+      const genInner = createMockNode({
+        id: 'gen-inner',
+        startTimestamp: 1600,
+        endTimestamp: 1700,
+        parentSpanId: 'agent-inner',
+        attributes: {[SpanFields.GEN_AI_RESPONSE_TEXT]: 'Inner'},
+      });
+
+      const messages = extractMessagesFromNodes(
+        withLineage([agentOuter, genOuter, agentInner, genInner]) as any
+      );
+
+      expect(messages.map(m => m.content)).toEqual(['Outer', 'Inner']);
     });
 
     // Same question in two spans: collapse only for a cumulative tool loop.

--- a/static/app/views/explore/conversations/utils/conversationMessages.spec.ts
+++ b/static/app/views/explore/conversations/utils/conversationMessages.spec.ts
@@ -1608,6 +1608,37 @@ describe('conversationMessages utilities', () => {
       expect(messages.map(m => m.content)).toEqual(['Outer', 'Inner']);
     });
 
+    it('keeps a sub-agent after the long turn that spawned it', () => {
+      // The spawning generation span stays open until the sub-agent returns, so
+      // its turn is stamped (at the turn end) after the sub-agent's own start.
+      // Positioning by the turn end would sort the sub-agent ahead of the turn
+      // that launched it; it must stay after.
+      const genParent = createMockNode({
+        id: 'gen-parent',
+        startTimestamp: 1000,
+        endTimestamp: 5000,
+        attributes: {[SpanFields.GEN_AI_RESPONSE_TEXT]: 'Parent decides'},
+      });
+      const agentSub = createMockAgentNode({
+        id: 'agent-sub',
+        startTimestamp: 1200,
+        endTimestamp: 4500,
+      });
+      const genSub = createMockNode({
+        id: 'gen-sub',
+        startTimestamp: 1300,
+        endTimestamp: 1400,
+        parentSpanId: 'agent-sub',
+        attributes: {[SpanFields.GEN_AI_RESPONSE_TEXT]: 'Sub result'},
+      });
+
+      const messages = extractMessagesFromNodes(
+        withLineage([genParent, agentSub, genSub]) as any
+      );
+
+      expect(messages.map(m => m.content)).toEqual(['Parent decides', 'Sub result']);
+    });
+
     // Same question in two spans: collapse only for a cumulative tool loop.
     const Q = 'How is the weather in Vienna?';
     it.each([

--- a/static/app/views/explore/conversations/utils/conversationMessages.spec.ts
+++ b/static/app/views/explore/conversations/utils/conversationMessages.spec.ts
@@ -6,6 +6,7 @@ import {
   extractMessagesFromNodes,
   getInputMessageStats,
   getNodeTimestamp,
+  groupNodesByAgentRun,
   mergeEmptyTurns,
   messagesToMarkdown,
   parseAssistantContent,
@@ -18,9 +19,16 @@ function createMockNode(overrides: {
   id: string;
   attributes?: Record<string, string | number>;
   endTimestamp?: number;
+  parentSpanId?: string;
   startTimestamp?: number;
 }) {
-  const {id, attributes = {}, startTimestamp = 1000, endTimestamp} = overrides;
+  const {
+    id,
+    attributes = {},
+    startTimestamp = 1000,
+    endTimestamp,
+    parentSpanId,
+  } = overrides;
   const end = endTimestamp ?? startTimestamp + 100;
   return {
     id,
@@ -31,12 +39,14 @@ function createMockNode(overrides: {
     value: {
       start_timestamp: startTimestamp,
       end_timestamp: end,
+      parent_span_id: parentSpanId,
     },
     attributes: {
       [SpanFields.GEN_AI_OPERATION_TYPE]: 'ai_client',
       ...attributes,
     },
     errors: new Set(),
+    findParent: () => null,
   };
 }
 
@@ -44,9 +54,10 @@ function createMockToolNode(overrides: {
   id: string;
   toolName: string;
   endTimestamp?: number;
+  parentSpanId?: string;
   startTimestamp?: number;
 }) {
-  const {id, toolName, startTimestamp = 1000, endTimestamp} = overrides;
+  const {id, toolName, startTimestamp = 1000, endTimestamp, parentSpanId} = overrides;
   const end = endTimestamp ?? startTimestamp + 100;
   return {
     id,
@@ -57,13 +68,71 @@ function createMockToolNode(overrides: {
     value: {
       start_timestamp: startTimestamp,
       end_timestamp: end,
+      parent_span_id: parentSpanId,
     },
     attributes: {
       [SpanFields.GEN_AI_OPERATION_TYPE]: 'tool',
       [SpanFields.GEN_AI_TOOL_NAME]: toolName,
     },
     errors: new Set(),
+    findParent: () => null,
   };
+}
+
+// Agent span ("gen_ai.operation.type: agent") — the anchor a sub-agent run is
+// grouped under. Carries no chat content itself; it only delimits the run.
+function createMockAgentNode(overrides: {
+  id: string;
+  agentName?: string;
+  endTimestamp?: number;
+  parentSpanId?: string;
+  startTimestamp?: number;
+}) {
+  const {id, agentName, startTimestamp = 1000, endTimestamp, parentSpanId} = overrides;
+  const end = endTimestamp ?? startTimestamp + 100;
+  return {
+    id,
+    type: 'span' as const,
+    op: 'gen_ai.invoke_agent',
+    startTimestamp,
+    endTimestamp: end,
+    value: {
+      start_timestamp: startTimestamp,
+      end_timestamp: end,
+      parent_span_id: parentSpanId,
+    },
+    attributes: {
+      [SpanFields.GEN_AI_OPERATION_TYPE]: 'agent',
+      ...(agentName ? {[SpanFields.GEN_AI_AGENT_NAME]: agentName} : {}),
+    },
+    errors: new Set(),
+    findParent: () => null,
+  };
+}
+
+// Wires each mock node's `findParent` to walk `value.parent_span_id` through the
+// given set, mirroring the real node produced by `useConversation`.
+function withLineage<T extends {id: string; value: {parent_span_id?: string}}>(
+  nodes: T[]
+): T[] {
+  const byId = new Map(nodes.map(node => [node.id, node]));
+  for (const node of nodes) {
+    (node as any).findParent = (predicate: (parent: any) => boolean) => {
+      let parentId = node.value.parent_span_id;
+      while (parentId) {
+        const parent = byId.get(parentId);
+        if (!parent) {
+          return null;
+        }
+        if (predicate(parent)) {
+          return parent;
+        }
+        parentId = parent.value.parent_span_id;
+      }
+      return null;
+    };
+  }
+  return nodes;
 }
 
 // Mirrors the node `useConversation` produces for an embeddings span: the op
@@ -107,6 +176,7 @@ function createMockEmbeddingNode(overrides: {
       ...(tokens === undefined ? {} : {[SpanFields.GEN_AI_USAGE_TOTAL_TOKENS]: tokens}),
     },
     errors: new Set(),
+    findParent: () => null,
   };
 }
 
@@ -594,6 +664,93 @@ describe('conversationMessages utilities', () => {
       const result = partitionSpansByType([embeddingNode] as any);
 
       expect(result.embeddingSpans.map(s => s.id)).toEqual(['embed-1']);
+    });
+  });
+
+  describe('groupNodesByAgentRun', () => {
+    it('puts every span in one root run when there are no agent spans', () => {
+      const gen = createMockNode({id: 'gen-1', startTimestamp: 1000});
+      const tool = createMockToolNode({
+        id: 'tool-1',
+        toolName: 'search',
+        startTimestamp: 1500,
+      });
+
+      const runs = groupNodesByAgentRun(withLineage([gen, tool]) as any);
+
+      expect(runs).toHaveLength(1);
+      expect(runs[0]?.map(n => n.id)).toEqual(['gen-1', 'tool-1']);
+    });
+
+    it('groups each agent with its descendant spans and drops the cross-agent shuffle', () => {
+      const agentA = createMockAgentNode({
+        id: 'agent-a',
+        agentName: 'Errors',
+        startTimestamp: 900,
+      });
+      const genA = createMockNode({
+        id: 'gen-a',
+        startTimestamp: 1000,
+        parentSpanId: 'agent-a',
+      });
+      const toolA = createMockToolNode({
+        id: 'tool-a',
+        toolName: 'query_errors',
+        startTimestamp: 2500,
+        parentSpanId: 'agent-a',
+      });
+      const agentB = createMockAgentNode({
+        id: 'agent-b',
+        agentName: 'Traces',
+        startTimestamp: 3400,
+      });
+      const genB = createMockNode({
+        id: 'gen-b',
+        startTimestamp: 3500,
+        parentSpanId: 'agent-b',
+      });
+
+      // Deliberately unordered input.
+      const runs = groupNodesByAgentRun(
+        withLineage([genB, toolA, agentB, genA, agentA]) as any
+      );
+
+      // Two runs, ordered by earliest span: Errors (900) before Traces (3400).
+      expect(runs.map(run => run.map(n => n.id).sort())).toEqual([
+        ['agent-a', 'gen-a', 'tool-a'],
+        ['agent-b', 'gen-b'],
+      ]);
+    });
+
+    it('groups a nested sub-agent under itself, not its parent agent', () => {
+      const parentAgent = createMockAgentNode({
+        id: 'agent-parent',
+        startTimestamp: 900,
+      });
+      const parentGen = createMockNode({
+        id: 'gen-parent',
+        startTimestamp: 1000,
+        parentSpanId: 'agent-parent',
+      });
+      const childAgent = createMockAgentNode({
+        id: 'agent-child',
+        startTimestamp: 1100,
+        parentSpanId: 'agent-parent',
+      });
+      const childGen = createMockNode({
+        id: 'gen-child',
+        startTimestamp: 1200,
+        parentSpanId: 'agent-child',
+      });
+
+      const runs = groupNodesByAgentRun(
+        withLineage([parentAgent, parentGen, childAgent, childGen]) as any
+      );
+
+      expect(runs.map(run => run.map(n => n.id).sort())).toEqual([
+        ['agent-parent', 'gen-parent'],
+        ['agent-child', 'gen-child'],
+      ]);
     });
   });
 
@@ -1362,6 +1519,92 @@ describe('conversationMessages utilities', () => {
         {reasoning: 'Thinking 2', tools: ['search'], content: ''},
         {reasoning: 'Thinking 3', tools: ['calc'], content: 'Done'},
       ]);
+    });
+
+    it('keeps parallel sub-agents from stealing each other tool calls', () => {
+      // Two agents run concurrently. Agent A requests a tool that finishes
+      // between Agent B's generations, so a flat, timestamp-only builder
+      // misattributes it to B. Grouping by agent run keeps it on A.
+      const reasoningAndText = (thought: string, text: string) =>
+        JSON.stringify([
+          {
+            role: 'assistant',
+            parts: [
+              {type: 'reasoning', content: thought},
+              {type: 'text', text},
+            ],
+          },
+        ]);
+
+      const agentA = createMockAgentNode({
+        id: 'agent-a',
+        agentName: 'Errors',
+        startTimestamp: 900,
+        endTimestamp: 5000,
+      });
+      const genA1 = createMockNode({
+        id: 'gen-a1',
+        startTimestamp: 900,
+        endTimestamp: 1000,
+        parentSpanId: 'agent-a',
+        attributes: {
+          [SpanFields.GEN_AI_OUTPUT_MESSAGES]: JSON.stringify([
+            {role: 'assistant', parts: [{type: 'reasoning', content: 'A thinks first'}]},
+          ]),
+        },
+      });
+      const toolA = createMockToolNode({
+        id: 'tool-a',
+        toolName: 'query_errors',
+        startTimestamp: 2500,
+        endTimestamp: 3000,
+        parentSpanId: 'agent-a',
+      });
+      const genA2 = createMockNode({
+        id: 'gen-a2',
+        startTimestamp: 4500,
+        endTimestamp: 5000,
+        parentSpanId: 'agent-a',
+        attributes: {
+          [SpanFields.GEN_AI_OUTPUT_MESSAGES]: reasoningAndText('A concludes', 'A done'),
+        },
+      });
+
+      const agentB = createMockAgentNode({
+        id: 'agent-b',
+        agentName: 'Traces',
+        startTimestamp: 3400,
+        endTimestamp: 4000,
+      });
+      // Ends at 4000, between toolA (3000) and genA2 (5000): the flat builder
+      // would attach toolA to this generation.
+      const genB = createMockNode({
+        id: 'gen-b',
+        startTimestamp: 3500,
+        endTimestamp: 4000,
+        parentSpanId: 'agent-b',
+        attributes: {
+          [SpanFields.GEN_AI_OUTPUT_MESSAGES]: reasoningAndText('B thinks', 'B done'),
+        },
+      });
+
+      const messages = extractMessagesFromNodes(
+        withLineage([genB, toolA, agentB, genA1, agentA, genA2]) as any
+      );
+
+      const bothDone = messages.filter(
+        m => m.content === 'A done' || m.content === 'B done'
+      );
+      const aDone = bothDone.find(m => m.content === 'A done');
+      const bDone = bothDone.find(m => m.content === 'B done');
+
+      // The tool stays with Agent A; Agent B never gets it.
+      expect(aDone?.toolCalls?.map(t => t.name)).toEqual(['query_errors']);
+      expect(bDone?.toolCalls ?? []).toEqual([]);
+
+      // Agent A's run renders as one contiguous block before Agent B's.
+      const order = messages.map(m => m.content);
+      expect(order.indexOf('A done')).toBeLessThan(order.indexOf('B done'));
     });
 
     // Same question in two spans: collapse only for a cumulative tool loop.

--- a/static/app/views/explore/conversations/utils/conversationMessages.spec.ts
+++ b/static/app/views/explore/conversations/utils/conversationMessages.spec.ts
@@ -770,6 +770,36 @@ describe('conversationMessages utilities', () => {
       expect(merged[0]?.toolCalls[0]?.name).toBe('search');
     });
 
+    it('keeps tool calls on a reasoning-only turn instead of carrying them forward', () => {
+      // A think→tool→think→tool loop: each generation reasons but emits no
+      // assistant text. The tool calls must stay attached to their reasoning
+      // turn, not pile onto the final turn.
+      const turns = [
+        makeTurn({
+          generation: {id: 'gen-1'} as any,
+          reasoning: 'Thinking 1',
+        }),
+        makeTurn({
+          generation: {id: 'gen-2'} as any,
+          reasoning: 'Thinking 2',
+          toolCalls: [{name: 'search', nodeId: 'tool-1', hasError: false}],
+        }),
+        makeTurn({
+          generation: {id: 'gen-3'} as any,
+          reasoning: 'Thinking 3',
+          assistantContent: 'Done',
+          toolCalls: [{name: 'calc', nodeId: 'tool-2', hasError: false}],
+        }),
+      ];
+
+      const merged = mergeEmptyTurns(turns);
+
+      expect(merged).toHaveLength(3);
+      expect(merged[0]?.toolCalls.map(t => t.name)).toEqual([]);
+      expect(merged[1]?.toolCalls.map(t => t.name)).toEqual(['search']);
+      expect(merged[2]?.toolCalls.map(t => t.name)).toEqual(['calc']);
+    });
+
     it('preserves user content turns even without assistant response', () => {
       const turns = [
         makeTurn({
@@ -1264,6 +1294,73 @@ describe('conversationMessages utilities', () => {
         'weather',
         'weather',
         'calculator',
+      ]);
+    });
+
+    it('interleaves thinking and tool calls in a reasoning tool loop', () => {
+      // Each generation reasons and requests a tool but emits no assistant text
+      // until the last one. Tool calls must land on their own reasoning turn, so
+      // the transcript reads thinking→tool→thinking→tool rather than all the
+      // thinking rows first and every tool call dumped at the end.
+      const reasoningOutput = (thought: string) =>
+        JSON.stringify([
+          {role: 'assistant', parts: [{type: 'reasoning', content: thought}]},
+        ]);
+
+      const gen1 = createMockNode({
+        id: 'gen-1',
+        startTimestamp: 1000,
+        endTimestamp: 1100,
+        attributes: {[SpanFields.GEN_AI_OUTPUT_MESSAGES]: reasoningOutput('Thinking 1')},
+      });
+      const tool1 = createMockToolNode({
+        id: 'tool-1',
+        toolName: 'search',
+        startTimestamp: 1200,
+        endTimestamp: 1300,
+      });
+      const gen2 = createMockNode({
+        id: 'gen-2',
+        startTimestamp: 1400,
+        endTimestamp: 1500,
+        attributes: {[SpanFields.GEN_AI_OUTPUT_MESSAGES]: reasoningOutput('Thinking 2')},
+      });
+      const tool2 = createMockToolNode({
+        id: 'tool-2',
+        toolName: 'calc',
+        startTimestamp: 1600,
+        endTimestamp: 1700,
+      });
+      const gen3 = createMockNode({
+        id: 'gen-3',
+        startTimestamp: 1800,
+        endTimestamp: 1900,
+        attributes: {
+          [SpanFields.GEN_AI_OUTPUT_MESSAGES]: JSON.stringify([
+            {
+              role: 'assistant',
+              parts: [
+                {type: 'reasoning', content: 'Thinking 3'},
+                {type: 'text', text: 'Done'},
+              ],
+            },
+          ]),
+        },
+      });
+
+      const messages = extractMessagesFromNodes([gen1, tool1, gen2, tool2, gen3] as any);
+
+      const assistants = messages.filter(m => m.role === 'assistant');
+      expect(
+        assistants.map(m => ({
+          reasoning: m.reasoning,
+          tools: m.toolCalls?.map(t => t.name) ?? [],
+          content: m.content,
+        }))
+      ).toEqual([
+        {reasoning: 'Thinking 1', tools: [], content: ''},
+        {reasoning: 'Thinking 2', tools: ['search'], content: ''},
+        {reasoning: 'Thinking 3', tools: ['calc'], content: 'Done'},
       ]);
     });
 

--- a/static/app/views/explore/conversations/utils/conversationMessages.ts
+++ b/static/app/views/explore/conversations/utils/conversationMessages.ts
@@ -76,19 +76,24 @@ interface ConversationTurn {
 /**
  * Extracts conversation messages from trace spans.
  *
- * Spans are first split into agent runs — the top-level conversation plus each
- * sub-agent that ran within it — because the turn builder assumes a single
- * sequential think→tool loop. When sub-agents run concurrently their spans
- * interleave in wall-clock time, so building turns over all spans at once
- * misattributes one agent's tool calls to another's generation. Each run is
- * built independently, then the runs are concatenated in start order. Runs are
- * kept contiguous rather than merged by timestamp so parallel agents read as
- * separate stretches instead of shuffled together.
+ * The turn builder assumes a single sequential think→tool loop, which breaks
+ * when a conversation invokes sub-agents: their spans interleave in wall-clock
+ * time, so building turns over all spans at once attributes one agent's tool
+ * calls to another's generation and shuffles their rows together.
+ *
+ * Instead the span tree is processed as nested agent runs. A run — the top-level
+ * conversation or a single agent span — is built from only the spans it owns
+ * directly (those whose nearest ancestor agent is that run). Each nested agent
+ * is spliced back in as its own sub-conversation, positioned by where it was
+ * invoked and processed recursively, so a sub-agent appears between the parent
+ * turns that surround it rather than being hoisted out of order. Nesting is
+ * taken from the parent-span lineage, not wall-clock containment, since parallel
+ * agents overlap in time.
  */
 export function extractMessagesFromNodes(
   nodes: AITraceSpanNode[]
 ): ConversationMessage[] {
-  return groupNodesByAgentRun(nodes).flatMap(extractMessagesFromAgentRun);
+  return buildAgentRunMessages(ROOT_AGENT_RUN, indexAgentRuns(nodes));
 }
 
 /**
@@ -115,42 +120,85 @@ function extractMessagesFromAgentRun(nodes: AITraceSpanNode[]): ConversationMess
 
 const ROOT_AGENT_RUN = '__root__';
 
+interface AgentRunIndex {
+  // Agent span start timestamp keyed by agent id — positions a sub-conversation
+  // within its parent run.
+  agentStartById: Map<string, number>;
+  // Agent spans nested directly in a run, keyed by the parent run id.
+  childAgentsByRun: Map<string, AITraceSpanNode[]>;
+  // Content spans (generation/tool/embedding) owned directly by a run, keyed by
+  // run id — those whose nearest ancestor agent is that run.
+  ownNodesByRun: Map<string, AITraceSpanNode[]>;
+}
+
 /**
- * Groups spans into agent runs so each is turned into a transcript on its own.
- *
- * A span's run is its nearest ancestor agent span (an `agent` node is its own
- * run), matching how the timeline decides what to indent under an agent. Spans
- * with no agent ancestor — the common single-agent-less conversation — fall
- * into one root run, so those conversations are unaffected.
- *
- * Runs are returned ordered by their earliest span so the concatenated
- * transcript follows the order the agents started in.
+ * Indexes the span tree into agent runs. Every span is attributed to the run of
+ * its nearest ancestor agent (or ROOT when it has none); an agent span is a
+ * child of the run it sits in and opens a run of its own. This is derived from
+ * the parent-span lineage, matching how the timeline decides what to nest under
+ * an agent.
  */
-export function groupNodesByAgentRun(nodes: AITraceSpanNode[]): AITraceSpanNode[][] {
-  const runsByAgentId = new Map<string, AITraceSpanNode[]>();
+function indexAgentRuns(nodes: AITraceSpanNode[]): AgentRunIndex {
+  const ownNodesByRun = new Map<string, AITraceSpanNode[]>();
+  const childAgentsByRun = new Map<string, AITraceSpanNode[]>();
+  const agentStartById = new Map<string, number>();
+
+  const pushInto = (
+    map: Map<string, AITraceSpanNode[]>,
+    key: string,
+    node: AITraceSpanNode
+  ) => {
+    const existing = map.get(key);
+    if (existing) {
+      existing.push(node);
+    } else {
+      map.set(key, [node]);
+    }
+  };
 
   for (const node of nodes) {
-    // Resolve the ancestor agent outside the ternary: getIsAiAgentNode is a type
-    // guard, so branching on it inline would narrow the else branch to `never`
-    // and hide `findParent`. An agent node is its own run.
-    const agentAncestor = node.findParent(parent => getIsAiAgentNode(parent));
-    const agentNode = getIsAiAgentNode(node) ? node : agentAncestor;
-    const runId = agentNode?.id ?? ROOT_AGENT_RUN;
-    const run = runsByAgentId.get(runId);
-    if (run) {
-      run.push(node);
+    // findParent looks at ancestors only, so for an agent node this is its
+    // parent agent — the run it is nested in.
+    const parentAgent = node.findParent(parent => getIsAiAgentNode(parent));
+    const parentRunId = parentAgent?.id ?? ROOT_AGENT_RUN;
+
+    if (getIsAiAgentNode(node)) {
+      agentStartById.set(node.id, getNodeStartTimestamp(node));
+      pushInto(childAgentsByRun, parentRunId, node);
     } else {
-      runsByAgentId.set(runId, [node]);
+      pushInto(ownNodesByRun, parentRunId, node);
     }
   }
 
-  return [...runsByAgentId.values()].sort(
-    (a, b) => earliestNodeStart(a) - earliestNodeStart(b)
-  );
+  return {ownNodesByRun, childAgentsByRun, agentStartById};
 }
 
-function earliestNodeStart(nodes: AITraceSpanNode[]): number {
-  return Math.min(...nodes.map(getNodeStartTimestamp));
+/**
+ * Builds one run's messages and splices its sub-agent runs back in.
+ *
+ * The run's own spans go through the turn-construction pipeline; each nested
+ * agent is expanded recursively and inserted as one atomic block at the agent's
+ * start timestamp. Keeping a sub-conversation contiguous — rather than merging
+ * its messages into the parent by timestamp — is what stops parallel agents from
+ * re-interleaving.
+ */
+function buildAgentRunMessages(
+  runId: string,
+  index: AgentRunIndex
+): ConversationMessage[] {
+  const ownMessages = extractMessagesFromAgentRun(index.ownNodesByRun.get(runId) ?? []);
+  const childAgents = index.childAgentsByRun.get(runId) ?? [];
+
+  const items: Array<{messages: ConversationMessage[]; timestamp: number}> = [
+    ...ownMessages.map(message => ({timestamp: message.timestamp, messages: [message]})),
+    ...childAgents.map(agent => ({
+      timestamp: index.agentStartById.get(agent.id) ?? 0,
+      messages: buildAgentRunMessages(agent.id, index),
+    })),
+  ];
+
+  items.sort((a, b) => a.timestamp - b.timestamp);
+  return items.flatMap(item => item.messages);
 }
 
 export function partitionSpansByType(nodes: AITraceSpanNode[]): {

--- a/static/app/views/explore/conversations/utils/conversationMessages.ts
+++ b/static/app/views/explore/conversations/utils/conversationMessages.ts
@@ -177,10 +177,14 @@ function indexAgentRuns(nodes: AITraceSpanNode[]): AgentRunIndex {
  * Builds one run's messages and splices its sub-agent runs back in.
  *
  * The run's own spans go through the turn-construction pipeline; each nested
- * agent is expanded recursively and inserted as one atomic block at the agent's
- * start timestamp. Keeping a sub-conversation contiguous — rather than merging
- * its messages into the parent by timestamp — is what stops parallel agents from
- * re-interleaving.
+ * agent is expanded recursively and inserted as one atomic block right after the
+ * turn that spawned it, keeping the sub-conversation contiguous.
+ *
+ * Placement keys off each turn's START, not the message timestamp. An assistant
+ * message is stamped at the turn END — `max(generation end, last tool end)` — and
+ * a sub-agent invoked as a long-running tool drags that end out past the
+ * sub-agent's own start, so ordering by it would sort the sub-agent ahead of the
+ * turn that launched it. A turn's start is recoverable as `timestamp - duration`.
  */
 function buildAgentRunMessages(
   runId: string,
@@ -189,16 +193,36 @@ function buildAgentRunMessages(
   const ownMessages = extractMessagesFromAgentRun(index.ownNodesByRun.get(runId) ?? []);
   const childAgents = index.childAgentsByRun.get(runId) ?? [];
 
-  const items: Array<{messages: ConversationMessage[]; timestamp: number}> = [
-    ...ownMessages.map(message => ({timestamp: message.timestamp, messages: [message]})),
-    ...childAgents.map(agent => ({
-      timestamp: index.agentStartById.get(agent.id) ?? 0,
-      messages: buildAgentRunMessages(agent.id, index),
-    })),
-  ];
+  if (childAgents.length === 0) {
+    return ownMessages;
+  }
 
-  items.sort((a, b) => a.timestamp - b.timestamp);
-  return items.flatMap(item => item.messages);
+  const childBlocks = childAgents
+    .map(agent => ({
+      start: index.agentStartById.get(agent.id) ?? 0,
+      messages: buildAgentRunMessages(agent.id, index),
+    }))
+    .sort((a, b) => a.start - b.start);
+
+  // Merge the sub-agent blocks into the run's own messages: before emitting a
+  // turn, flush every sub-agent that started before this turn did (it belongs to
+  // an earlier turn), so each block lands after the turn in progress when the
+  // sub-agent began. Remaining blocks follow the last turn.
+  const merged: ConversationMessage[] = [];
+  let nextChild = 0;
+  for (const message of ownMessages) {
+    const turnStart = message.timestamp - (message.duration ?? 0);
+    while (nextChild < childBlocks.length && childBlocks[nextChild]!.start < turnStart) {
+      merged.push(...childBlocks[nextChild]!.messages);
+      nextChild++;
+    }
+    merged.push(message);
+  }
+  for (; nextChild < childBlocks.length; nextChild++) {
+    merged.push(...childBlocks[nextChild]!.messages);
+  }
+
+  return merged;
 }
 
 export function partitionSpansByType(nodes: AITraceSpanNode[]): {

--- a/static/app/views/explore/conversations/utils/conversationMessages.ts
+++ b/static/app/views/explore/conversations/utils/conversationMessages.ts
@@ -6,6 +6,7 @@ import {
 } from 'sentry/views/insights/pages/agents/utils/aiMessageNormalizer';
 import {
   AGENT_NAME_FIELDS,
+  getIsAiAgentNode,
   getNumberAttr,
   getStringAttr,
   hasError,
@@ -73,7 +74,25 @@ interface ConversationTurn {
 }
 
 /**
- * Extracts conversation messages from trace spans:
+ * Extracts conversation messages from trace spans.
+ *
+ * Spans are first split into agent runs — the top-level conversation plus each
+ * sub-agent that ran within it — because the turn builder assumes a single
+ * sequential think→tool loop. When sub-agents run concurrently their spans
+ * interleave in wall-clock time, so building turns over all spans at once
+ * misattributes one agent's tool calls to another's generation. Each run is
+ * built independently, then the runs are concatenated in start order. Runs are
+ * kept contiguous rather than merged by timestamp so parallel agents read as
+ * separate stretches instead of shuffled together.
+ */
+export function extractMessagesFromNodes(
+  nodes: AITraceSpanNode[]
+): ConversationMessage[] {
+  return groupNodesByAgentRun(nodes).flatMap(extractMessagesFromAgentRun);
+}
+
+/**
+ * Builds the messages for a single agent run — the turn-construction pipeline:
  * 1. Partition spans into generation, tool, and embeddings spans
  * 2. Build conversation turns (user input + assistant output pairs)
  * 3. Merge turns that have no assistant response, carrying tool calls forward
@@ -82,9 +101,7 @@ interface ConversationTurn {
  *    timestamp — unlike tool calls, embeddings don't need a nearby generation
  *    to show up, so they never enter the turn-building pipeline above.
  */
-export function extractMessagesFromNodes(
-  nodes: AITraceSpanNode[]
-): ConversationMessage[] {
+function extractMessagesFromAgentRun(nodes: AITraceSpanNode[]): ConversationMessage[] {
   const {generationSpans, toolSpans, embeddingSpans} = partitionSpansByType(nodes);
   const turns = buildConversationTurns(generationSpans, toolSpans);
   const mergedTurns = mergeEmptyTurns(turns);
@@ -94,6 +111,46 @@ export function extractMessagesFromNodes(
   ];
   messages.sort((a, b) => a.timestamp - b.timestamp);
   return messages;
+}
+
+const ROOT_AGENT_RUN = '__root__';
+
+/**
+ * Groups spans into agent runs so each is turned into a transcript on its own.
+ *
+ * A span's run is its nearest ancestor agent span (an `agent` node is its own
+ * run), matching how the timeline decides what to indent under an agent. Spans
+ * with no agent ancestor — the common single-agent-less conversation — fall
+ * into one root run, so those conversations are unaffected.
+ *
+ * Runs are returned ordered by their earliest span so the concatenated
+ * transcript follows the order the agents started in.
+ */
+export function groupNodesByAgentRun(nodes: AITraceSpanNode[]): AITraceSpanNode[][] {
+  const runsByAgentId = new Map<string, AITraceSpanNode[]>();
+
+  for (const node of nodes) {
+    // Resolve the ancestor agent outside the ternary: getIsAiAgentNode is a type
+    // guard, so branching on it inline would narrow the else branch to `never`
+    // and hide `findParent`. An agent node is its own run.
+    const agentAncestor = node.findParent(parent => getIsAiAgentNode(parent));
+    const agentNode = getIsAiAgentNode(node) ? node : agentAncestor;
+    const runId = agentNode?.id ?? ROOT_AGENT_RUN;
+    const run = runsByAgentId.get(runId);
+    if (run) {
+      run.push(node);
+    } else {
+      runsByAgentId.set(runId, [node]);
+    }
+  }
+
+  return [...runsByAgentId.values()].sort(
+    (a, b) => earliestNodeStart(a) - earliestNodeStart(b)
+  );
+}
+
+function earliestNodeStart(nodes: AITraceSpanNode[]): number {
+  return Math.min(...nodes.map(getNodeStartTimestamp));
 }
 
 export function partitionSpansByType(nodes: AITraceSpanNode[]): {

--- a/static/app/views/explore/conversations/utils/conversationMessages.ts
+++ b/static/app/views/explore/conversations/utils/conversationMessages.ts
@@ -230,7 +230,9 @@ export function mergeEmptyTurns(turns: ConversationTurn[]): ConversationTurn[] {
     const allToolCalls = [...pendingToolCalls, ...turn.toolCalls];
     const allToolSpanNodes = [...pendingToolSpanNodes, ...(turn.toolSpanNodes ?? [])];
 
-    if (turn.assistantContent) {
+    // A reasoning-bearing turn is displayable (see turnsToMessages), so it
+    // anchors its own tool calls instead of being merged forward as empty.
+    if (turn.assistantContent || turn.reasoning) {
       result.push({...turn, toolCalls: allToolCalls, toolSpanNodes: allToolSpanNodes});
       pendingToolCalls = [];
       pendingToolSpanNodes = [];


### PR DESCRIPTION
Fixes transcript ordering for conversations that invoke sub-agents — e.g. Seer running two query-translation agents concurrently. Their spans interleave in wall-clock time, so the flat, timestamp-based turn builder attributed one agent's tool calls to another agent's generation and shuffled their rows together.

The span tree is now processed as nested agent runs. A run — the top-level conversation or a single agent span — is built from only the spans it owns directly (nearest ancestor agent). Each nested agent is expanded recursively and spliced back in as one atomic block at the point it was invoked, so a sub-agent appears between the parent turns that surround it, and a parent orchestrator's final turn stays after the sub-agents it summarizes. Nesting comes from the parent-span lineage rather than wall-clock containment, since parallel agents overlap in time.

Conversations with no agent spans stay a single root run and are unaffected. Sub-agent runs reuse the existing transcript rows with no visual marker for now — a follow-up can add nesting or agent headers if the flat presentation reads ambiguously.

Stacked on #121712 (the think→tool interleaving fix), which the per-run pipeline relies on.