### PR TITLE
fix: Reject source files greater than 190 MiB

### DIFF
--- a/src/sentry/models/artifactbundle.py
+++ b/src/sentry/models/artifactbundle.py
@@ -27,6 +27,8 @@ from sentry.utils.hashlib import sha1_text
 NULL_UUID = "00000000-00000000-00000000-00000000"
 NULL_STRING = ""
 
+MAX_SOURCE_FILE_SIZE = 190 * 1024 * 1024
+
 
 class SourceFileType(Enum):
     SOURCE = 1
@@ -236,6 +238,9 @@ class ArtifactBundleArchive:
 
     def info(self, filename: str) -> zipfile.ZipInfo:
         return self._zip_file.getinfo(filename)
+
+    def infolist(self) -> list[zipfile.ZipInfo]:
+        return self._zip_file.infolist()
 
     def read(self, filename: str) -> bytes:
         return self._zip_file.read(filename)

--- a/src/sentry/models/artifactbundle.py
+++ b/src/sentry/models/artifactbundle.py
@@ -27,6 +27,7 @@ from sentry.utils.hashlib import sha1_text
 NULL_UUID = "00000000-00000000-00000000-00000000"
 NULL_STRING = ""
 
+# Must stay in sync with Symbolicator's `object_file_max_decompressed_source_size`
 MAX_SOURCE_FILE_SIZE = 190 * 1024 * 1024
 
 

--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -24,6 +24,7 @@ from sentry.debug_files.artifact_bundles import (
 )
 from sentry.debug_files.tasks import backfill_artifact_bundle_db_indexing
 from sentry.models.artifactbundle import (
+    MAX_SOURCE_FILE_SIZE,
     NULL_STRING,
     ArtifactBundle,
     ArtifactBundleArchive,
@@ -400,11 +401,13 @@ class ArtifactBundlePostAssembler:
     def _validate_bundle_guarded(self):
         try:
             self._validate_bundle()
-        except Exception:
+        except Exception as e:
             metrics.incr("tasks.assemble.invalid_bundle")
             # In case the bundle is invalid, we want to delete the actual `File` object created in the database, to
             # avoid orphan entries.
             self.delete_bundle_file_object()
+            if isinstance(e, AssembleArtifactsError):
+                raise
             raise AssembleArtifactsError("the bundle is invalid")
 
     def _validate_bundle(self):
@@ -412,6 +415,13 @@ class ArtifactBundlePostAssembler:
         metrics.incr(
             "tasks.assemble.artifact_bundle.artifact_count", amount=self.archive.artifact_count
         )
+        for info in self.archive.infolist():
+            if info.file_size > MAX_SOURCE_FILE_SIZE:
+                metrics.incr("tasks.assemble.artifact_bundle.file_size_exceeded")
+                raise AssembleArtifactsError(
+                    f"file {info.filename} exceeds the maximum uncompressed file size "
+                    f"({info.file_size} > {MAX_SOURCE_FILE_SIZE} bytes)"
+                )
 
     def __enter__(self):
         return self

--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -379,6 +379,10 @@ class AssembleArtifactsError(Exception):
     pass
 
 
+class AssembleArtifactsTooLargeError(AssembleArtifactsError):
+    pass
+
+
 class ArtifactBundlePostAssembler:
     def __init__(
         self,
@@ -401,13 +405,11 @@ class ArtifactBundlePostAssembler:
     def _validate_bundle_guarded(self):
         try:
             self._validate_bundle()
-        except Exception as e:
-            metrics.incr("tasks.assemble.invalid_bundle")
-            # In case the bundle is invalid, we want to delete the actual `File` object created in the database, to
-            # avoid orphan entries.
-            self.delete_bundle_file_object()
-            if isinstance(e, AssembleArtifactsError):
-                raise
+        except AssembleArtifactsTooLargeError:
+            self._cleanup_invalid_bundle()
+            raise
+        except Exception:
+            self._cleanup_invalid_bundle()
             raise AssembleArtifactsError("the bundle is invalid")
 
     def _validate_bundle(self):
@@ -418,10 +420,16 @@ class ArtifactBundlePostAssembler:
         for info in self.archive.infolist():
             if info.file_size > MAX_SOURCE_FILE_SIZE:
                 metrics.incr("tasks.assemble.artifact_bundle.file_size_exceeded")
-                raise AssembleArtifactsError(
+                raise AssembleArtifactsTooLargeError(
                     f"file {info.filename} exceeds the maximum uncompressed file size "
                     f"({info.file_size} > {MAX_SOURCE_FILE_SIZE} bytes)"
                 )
+
+    def _cleanup_invalid_bundle(self):
+        metrics.incr("tasks.assemble.invalid_bundle")
+        # In case the bundle is invalid, we want to delete the actual `File` object created in the database, to
+        # avoid orphan entries.
+        self.delete_bundle_file_object()
 
     def __enter__(self):
         return self

--- a/tests/sentry/tasks/test_assemble.py
+++ b/tests/sentry/tasks/test_assemble.py
@@ -353,6 +353,32 @@ class AssembleArtifactsTest(BaseAssembleTest):
         files = File.objects.filter()
         assert len(files) == 0
 
+    @patch("sentry.tasks.assemble.MAX_SOURCE_FILE_SIZE", 10)
+    def test_assembled_bundle_is_rejected_if_a_file_is_too_large(self) -> None:
+        bundle_file = self.create_artifact_bundle_zip(
+            fixture_path="artifact_bundle_debug_ids", project=self.project.id
+        )
+        blob1 = FileBlob.from_file_with_organization(ContentFile(bundle_file), self.organization)
+        total_checksum = sha1(bundle_file).hexdigest()
+
+        assemble_artifacts(
+            org_id=self.organization.id,
+            project_ids=[self.project.id],
+            version="1.0",
+            dist="android",
+            checksum=total_checksum,
+            chunks=[blob1.checksum],
+        )
+
+        status, details = get_assemble_status(
+            AssembleTask.ARTIFACT_BUNDLE, self.organization.id, total_checksum
+        )
+        assert status == ChunkFileState.ERROR
+        assert "exceeds the maximum uncompressed file size" in details
+
+        files = File.objects.filter()
+        assert len(files) == 0
+
     def test_assembled_bundle_is_deleted_if_checksum_mismatches(self) -> None:
         bundle_file = self.create_artifact_bundle_zip(
             fixture_path="artifact_bundle_debug_ids", project=self.project.id


### PR DESCRIPTION
Reject source files greater than 190 MiB - Symbolicator now ignores these. Verified locally with:

`SENTRY_URL=http://127.0.0.1:8000 SENTRY_AUTH_TOKEN=<token> SENTRY_ORG=sentry SENTRY_PROJECT=internal sentry-cli sourcemaps upload --wait --release test-release-1.0`

Ref: https://linear.app/getsentry/issue/INGEST-1112