### PR TITLE
ref(relay): Remove profiling feature flag from project config

### DIFF
--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -48,7 +48,6 @@ from sentry.utils.tracing import start_span
 EXPOSABLE_FEATURES = [
     "organizations:continuous-profiling",
     "organizations:continuous-profiling-perfetto",
-    "organizations:profiling",
     "organizations:session-replay-recording-scrubbing",
     "organizations:session-replay-video-disabled",
     "organizations:session-replay",


### PR DESCRIPTION
Graduated in Relay here: https://github.com/getsentry/relay/pull/6300