### PR TITLE
fix(charts): Prevent chart zoom handler invoked on propagated synced zoom actions

### DIFF
--- a/static/app/components/charts/useChartZoom.spec.tsx
+++ b/static/app/components/charts/useChartZoom.spec.tsx
@@ -114,4 +114,32 @@ describe('useChartZoom', () => {
       })
     );
   });
+
+  it('ignores synced zooms relayed from another chart', () => {
+    const {result, router} = renderHookWithProviders<
+      ReturnType<typeof useChartZoom>,
+      UseChartZoomProps
+    >((props: UseChartZoomProps) => useChartZoom(props), {
+      initialProps: {usePageDate: true},
+      initialRouterConfig: {
+        location: {pathname: '/dashboard/1/', query: {statsPeriod: '7d'}},
+      },
+    });
+
+    act(() => {
+      result.current.onDataZoom(
+        dataZoomPayload(
+          Date.UTC(2026, 6, 4, 11, 1, 30),
+          Date.UTC(2026, 6, 4, 16, 54, 30)
+        ),
+        {
+          __connectUpdateStatus: 0, // This flag the zoom as a synced action from another chart.
+        } as any
+      );
+    });
+
+    expect(router.location.query.statsPeriod).toBe('7d');
+    expect(router.location.query.start).toBeUndefined();
+    expect(router.location.query.end).toBeUndefined();
+  });
 });

--- a/static/app/components/charts/useChartZoom.spec.tsx
+++ b/static/app/components/charts/useChartZoom.spec.tsx
@@ -142,4 +142,41 @@ describe('useChartZoom', () => {
     expect(router.location.query.start).toBeUndefined();
     expect(router.location.query.end).toBeUndefined();
   });
+
+  it('only writes URL state once for user zooms on main chart', () => {
+    const {result, router} = renderHookWithProviders<
+      ReturnType<typeof useChartZoom>,
+      UseChartZoomProps
+    >((props: UseChartZoomProps) => useChartZoom(props), {
+      initialProps: {usePageDate: true},
+      initialRouterConfig: {
+        location: {pathname: '/dashboard/1/', query: {statsPeriod: '7d'}},
+      },
+    });
+
+    act(() => {
+      result.current.onDataZoom(
+        dataZoomPayload(
+          Date.UTC(2026, 6, 4, 11, 1, 30),
+          Date.UTC(2026, 6, 4, 16, 54, 30)
+        ),
+        {} as any
+      );
+      result.current.onDataZoom(
+        dataZoomPayload(
+          Date.UTC(2026, 6, 4, 11, 1, 30),
+          Date.UTC(2026, 6, 4, 16, 54, 30)
+        ),
+        {
+          __connectUpdateStatus: 0, // This flag the zoom as a synced action from another chart.
+        } as any
+      );
+    });
+
+    expect(router.location.query.start).toBe('2026-07-04T11:01:00');
+    expect(router.location.query.end).toBe('2026-07-04T16:55:00');
+    router.navigate(-1); // Should return to the pre-zoom period.
+    expect(router.location.query.start).toBeUndefined();
+    expect(router.location.query.end).toBeUndefined();
+  });
 });

--- a/static/app/components/charts/useChartZoom.tsx
+++ b/static/app/components/charts/useChartZoom.tsx
@@ -51,6 +51,18 @@ function getFormattedPeriod({period, start, end}: DateTimeUpdate) {
 
 type FormattedPeriod = ReturnType<typeof getFormattedPeriod>;
 
+/**
+ * ECharts flags synced charts using the __connectUpdateStatus key.
+ * We use this to determine if a chart is receiving a synced zoom
+ * relayed from a main chart that the user is interacting with.
+ */
+const CONNECT_STATUS_KEY = '__connectUpdateStatus';
+const CONNECT_STATUS_PENDING = 0;
+
+function isRelayedZoom(chart: ECharts): boolean {
+  return chart[CONNECT_STATUS_KEY] === CONNECT_STATUS_PENDING;
+}
+
 function hasZoomValues(payload: DataZoomRangePayload): payload is DataZoomRange {
   return (
     payload.startValue !== null &&
@@ -243,8 +255,14 @@ export function useChartZoom({
   );
 
   const handleDataZoom = useCallback<EChartDataZoomHandler>(
-    evt => {
+    (evt, chart) => {
       if (disabled) {
+        return;
+      }
+
+      // Only the chart the user actually zoomed should write URL state.
+      // Don't write URL state for charts that received a synced zoom.
+      if (isRelayedZoom(chart)) {
         return;
       }
 


### PR DESCRIPTION
ECharts chart syncing feature also propagates zooms from the main user interacted chart to all other charts within the same group. This is an issue for the `useChartZoom` hook because the zoom handler will be fired for every synced chart. For dashboards where there are many charts, this causes a single zoom to sync and write time range changes many times to the browser history.

Fixes this issue by returning zoom handler early when a synced zoom is detected via an internal echarts property (`__connectUpdateStatus`) 

Refs DAIN-1789