### PR TITLE
ref(seer): Skip check-suite pull requests not based in the suite's repo

### DIFF
--- a/src/sentry/integrations/github/check_payloads.py
+++ b/src/sentry/integrations/github/check_payloads.py
@@ -1,0 +1,72 @@
+"""Reading the ``pull_requests`` list on GitHub check payloads.
+
+GitHub attaches a pull request to a ``check_run`` or ``check_suite`` whenever the
+two share a head sha (plus head branch, for suites). That includes pull requests
+whose *base* is a different repository — a fork syncing from upstream has its head
+here, so it matches every default-branch check in this repo while belonging to the
+other one.
+
+Every consumer of that list therefore has to decide which entries are the
+webhook's own, and they all have to decide it the same way. The control parser
+drops check payloads that reference no own-repo pull request before they are ever
+stored (``ActionFilter.own_repo_pr_actions``), so a consumer reading the list more
+permissively than this module would simply stop receiving those events, with
+nothing to signal it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from sentry.utils.safe import get_path
+
+
+def pull_request_base_repo_id(ref: Any) -> Any | None:
+    """The ``base.repo.id`` of one ``pull_requests`` entry, or None when absent.
+
+    Tolerates a malformed entry: these payloads are read in the control parser
+    before the body has been signature-verified, so any level may be missing or
+    the wrong type.
+    """
+    return get_path(ref, "base", "repo", "id")
+
+
+def is_own_repo_pull_request(base_repo_id: Any | None, repo_id: Any | None) -> bool:
+    """Whether a ``pull_requests`` entry is a pull request based in ``repo_id``.
+
+    Compared as strings so callers can pass either the payload's integer
+    ``repository.id`` or a ``Repository.external_id``, which stores the same value
+    as text.
+
+    An entry with no base repo is **not** ours. It cannot be placed, and for the
+    consumer resolving a repo-scoped ``number`` that is the only safe reading:
+    numbers repeat across repositories, so treating an unplaceable entry as ours
+    risks attributing another repo's pull request to this one. Consumers resolving
+    by global pull request id could technically place it, but follow the same rule
+    so that the set of entries every consumer acts on is identical to the set the
+    control parser preserves.
+    """
+    if base_repo_id is None or repo_id is None:
+        return False
+    return str(base_repo_id) == str(repo_id)
+
+
+def references_own_repo_pull_request(event: Mapping[str, Any], container_key: str) -> bool:
+    """Whether a check payload references a pull request based in its own repo.
+
+    ``container_key`` is the payload member holding the list, which is named after
+    the event itself (``check_run`` / ``check_suite``).
+
+    Used to *drop*, so it must never return True for a payload no consumer would
+    act on: it is fine to be conservative here, never optimistic.
+    """
+    repo_id = get_path(event, "repository", "id")
+    if repo_id is None:
+        return False
+
+    refs = get_path(event, container_key, "pull_requests")
+    if not isinstance(refs, list):
+        return False
+
+    return any(is_own_repo_pull_request(pull_request_base_repo_id(ref), repo_id) for ref in refs)

--- a/src/sentry/integrations/github/check_payloads.py
+++ b/src/sentry/integrations/github/check_payloads.py
@@ -1,17 +1,13 @@
 """Reading the ``pull_requests`` list on GitHub check payloads.
 
-GitHub attaches a pull request to a ``check_run`` or ``check_suite`` whenever the
-two share a head sha (plus head branch, for suites). That includes pull requests
-whose *base* is a different repository — a fork syncing from upstream has its head
-here, so it matches every default-branch check in this repo while belonging to the
-other one.
+GitHub lists a PR on a ``check_run``/``check_suite`` whenever the two share a head
+sha, which includes PRs based in *other* repositories: a fork syncing from upstream
+has its head here, so it matches every default-branch check in this repo.
 
-Every consumer of that list therefore has to decide which entries are the
-webhook's own, and they all have to decide it the same way. The control parser
-drops check payloads that reference no own-repo pull request before they are ever
-stored (``ActionFilter.own_repo_pr_actions``), so a consumer reading the list more
-permissively than this module would simply stop receiving those events, with
-nothing to signal it.
+Every consumer has to decide which entries are the webhook's own, and all of them
+must decide it the same way — the control parser drops payloads referencing no
+own-repo PR before they are stored (``ActionFilter.own_repo_pr_actions``), so a
+consumer reading the list more permissively silently stops receiving those events.
 """
 
 from __future__ import annotations
@@ -23,29 +19,24 @@ from sentry.utils.safe import get_path
 
 
 def pull_request_base_repo_id(ref: Any) -> Any | None:
-    """The ``base.repo.id`` of one ``pull_requests`` entry, or None when absent.
+    """``base.repo.id`` of one ``pull_requests`` entry, or None.
 
-    Tolerates a malformed entry: these payloads are read in the control parser
-    before the body has been signature-verified, so any level may be missing or
-    the wrong type.
+    Tolerates junk at any level: the control parser reads these before the body has
+    been signature-verified.
     """
     return get_path(ref, "base", "repo", "id")
 
 
 def is_own_repo_pull_request(base_repo_id: Any | None, repo_id: Any | None) -> bool:
-    """Whether a ``pull_requests`` entry is a pull request based in ``repo_id``.
+    """Whether a ``pull_requests`` entry is based in ``repo_id``.
 
-    Compared as strings so callers can pass either the payload's integer
-    ``repository.id`` or a ``Repository.external_id``, which stores the same value
-    as text.
+    Compared as strings so callers can pass the payload's integer ``repository.id``
+    or a ``Repository.external_id``, which holds the same value as text.
 
-    An entry with no base repo is **not** ours. It cannot be placed, and for the
-    consumer resolving a repo-scoped ``number`` that is the only safe reading:
-    numbers repeat across repositories, so treating an unplaceable entry as ours
-    risks attributing another repo's pull request to this one. Consumers resolving
-    by global pull request id could technically place it, but follow the same rule
-    so that the set of entries every consumer acts on is identical to the set the
-    control parser preserves.
+    An entry with no base repo is not ours: numbers repeat across repositories, so
+    placing one here could attribute another repo's PR to this one. Consumers that
+    resolve by global id could place it, but follow the same rule so they all act
+    on the set the control parser preserves.
     """
     if base_repo_id is None or repo_id is None:
         return False
@@ -55,11 +46,11 @@ def is_own_repo_pull_request(base_repo_id: Any | None, repo_id: Any | None) -> b
 def references_own_repo_pull_request(event: Mapping[str, Any], container_key: str) -> bool:
     """Whether a check payload references a pull request based in its own repo.
 
-    ``container_key`` is the payload member holding the list, which is named after
-    the event itself (``check_run`` / ``check_suite``).
+    ``container_key`` is the payload member holding the list, named after the event
+    itself (``check_run`` / ``check_suite``).
 
-    Used to *drop*, so it must never return True for a payload no consumer would
-    act on: it is fine to be conservative here, never optimistic.
+    A False drops the payload, so it must never be False for one a consumer would
+    act on. Erring True only costs a forwarded no-op.
     """
     repo_id = get_path(event, "repository", "id")
     if repo_id is None:

--- a/src/sentry/integrations/github/check_payloads.py
+++ b/src/sentry/integrations/github/check_payloads.py
@@ -4,10 +4,10 @@ GitHub lists a PR on a ``check_run``/``check_suite`` whenever the two share a he
 sha, which includes PRs based in *other* repositories: a fork syncing from upstream
 has its head here, so it matches every default-branch check in this repo.
 
-Every consumer has to decide which entries are the webhook's own, and all of them
-must decide it the same way — the control parser drops payloads referencing no
-own-repo PR before they are stored (``ActionFilter.own_repo_pr_actions``), so a
-consumer reading the list more permissively silently stops receiving those events.
+Every consumer has to decide which entries are the webhook's own. Keeping that in
+one place is what lets the control parser reason about the whole set at once — it
+is the only reader that sees a payload before it is stored, and it cannot be more
+permissive than the consumers downstream of it.
 """
 
 from __future__ import annotations
@@ -33,10 +33,12 @@ def is_own_repo_pull_request(base_repo_id: Any | None, repo_id: Any | None) -> b
     Compared as strings so callers can pass the payload's integer ``repository.id``
     or a ``Repository.external_id``, which holds the same value as text.
 
-    An entry with no base repo is not ours: numbers repeat across repositories, so
-    placing one here could attribute another repo's PR to this one. Consumers that
-    resolve by global id could place it, but follow the same rule so they all act
-    on the set the control parser preserves.
+    An entry with no base repo is not ours. GitHub always sends ``base.repo``, so
+    this is not a shape a live payload takes; treating it as ours would mean
+    guessing. For the consumer resolving a repo-scoped ``number`` the guess is
+    unsafe outright — numbers repeat across repositories — and a consumer resolving
+    by global id gains nothing from a different answer to a case that does not
+    occur, so they share this one.
     """
     if base_repo_id is None or repo_id is None:
         return False

--- a/src/sentry/middleware/integrations/parsers/github.py
+++ b/src/sentry/middleware/integrations/parsers/github.py
@@ -9,6 +9,7 @@ from django.http import HttpRequest, HttpResponse
 from django.http.response import HttpResponseBase
 
 from sentry.hybridcloud.outbox.category import WebhookProviderIdentifier
+from sentry.integrations.github.check_payloads import references_own_repo_pull_request
 from sentry.integrations.github.webhook import (
     GitHubIntegrationsWebhookEndpoint,
     get_github_external_id,
@@ -26,7 +27,6 @@ from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.silo.base import control_silo_function
 from sentry.utils import metrics
-from sentry.utils.safe import get_path
 
 logger = logging.getLogger(__name__)
 
@@ -41,30 +41,6 @@ def _bounded_action_tag(action: Any, action_filter: ActionFilter) -> str:
     if isinstance(action, str) and action in action_filter.known:
         return action
     return "unknown"
-
-
-def _references_own_repo_pull_request(event: Mapping[str, Any], container_key: str) -> bool:
-    """Whether a check payload references a pull request in the webhook's own repo.
-
-    ``pull_requests`` can list PRs that live in *other* repositories, and the cell's
-    ``_prs_from_check_payload`` resolves only entries whose ``base.repo`` is the repo
-    the webhook is for — a payload carrying none of those is a no-op there. Both
-    sides of that comparison are in the payload, so control can measure how much of
-    the forwarded check volume it could stop storing.
-    """
-    repo_id = get_path(event, "repository", "id")
-    if repo_id is None:
-        return False
-
-    refs = get_path(event, container_key, "pull_requests")
-    if not isinstance(refs, list):
-        return False
-
-    for ref in refs:
-        base_repo_id = get_path(ref, "base", "repo", "id")
-        if base_repo_id is not None and str(base_repo_id) == str(repo_id):
-            return True
-    return False
 
 
 def _forwarded_event_tags(
@@ -88,7 +64,7 @@ def _forwarded_event_tags(
     # only the completed action has a cell-side consumer that reads it.
     if action == "completed":
         tags["has_own_repo_pr"] = (
-            "true" if _references_own_repo_pull_request(event, github_event) else "false"
+            "true" if references_own_repo_pull_request(event, github_event) else "false"
         )
     return tags
 

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -990,17 +990,11 @@ def _prs_from_check_payload(
 ) -> list[PullRequest]:
     """Resolve the tracked PRs a check_suite/check_run payload references.
 
-    GitHub lists a PR on a check when they share ``head_sha`` + ``head_branch``,
-    so ``pull_requests`` can include PRs that live in *other* repositories. The
-    common case: a PR opened to merge this repo's default branch into another
-    repo (e.g. a fork syncing from upstream) has its head in this repo, so it
-    matches every default-branch check here — but the PR belongs to that other
-    repo and its ``number`` is scoped to it. Each entry carries its own
-    ``base.repo``, so an entry is only ours to resolve when its base repo is the
-    one this webhook is for. Resolving a foreign entry's number against ``repo``
-    would miss, or — on a number collision — attribute another repo's PR activity
-    to ours, so it is skipped. ``is_own_repo_pull_request`` holds that rule, shared
-    with the other consumers of these payloads.
+    ``pull_requests`` can include PRs based in *other* repositories, and a
+    ``number`` is scoped to its base repo, so resolving a foreign entry against
+    ``repo`` would miss or — on a number collision — attribute another repo's PR
+    activity to ours. ``is_own_repo_pull_request`` holds that rule, shared with the
+    other consumers of these payloads.
 
     Numbers are deduped before resolving each to its stored row; unknown PRs are
     dropped by ``_get_pull_request``.

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -30,6 +30,10 @@ from django.utils.dateparse import parse_datetime
 from pydantic import ValidationError
 
 from sentry import features, options
+from sentry.integrations.github.check_payloads import (
+    is_own_repo_pull_request,
+    pull_request_base_repo_id,
+)
 from sentry.integrations.github.webhook_types import GithubWebhookType
 from sentry.integrations.services.integration import RpcIntegration
 from sentry.issues.constants import cache_key_for_issue_view
@@ -995,7 +999,8 @@ def _prs_from_check_payload(
     ``base.repo``, so an entry is only ours to resolve when its base repo is the
     one this webhook is for. Resolving a foreign entry's number against ``repo``
     would miss, or — on a number collision — attribute another repo's PR activity
-    to ours, so it is skipped.
+    to ours, so it is skipped. ``is_own_repo_pull_request`` holds that rule, shared
+    with the other consumers of these payloads.
 
     Numbers are deduped before resolving each to its stored row; unknown PRs are
     dropped by ``_get_pull_request``.
@@ -1006,11 +1011,7 @@ def _prs_from_check_payload(
         number = ref.get("number")
         if number is None or str(number) in seen:
             continue
-        # A PR's number is scoped to its own base repo; resolve it against
-        # ``repo`` only when the PR lives here. Entries whose base is another repo
-        # (a PR merging this repo's branch elsewhere) are not ours to record.
-        base_repo_id = ((ref.get("base") or {}).get("repo") or {}).get("id")
-        if base_repo_id is None or str(base_repo_id) != repo.external_id:
+        if not is_own_repo_pull_request(pull_request_base_repo_id(ref), repo.external_id):
             metrics.incr("pr_metrics.check.foreign_pull_request")
             continue
         seen.add(str(number))

--- a/src/sentry/seer/autofix/pr_iteration/check_suites.py
+++ b/src/sentry/seer/autofix/pr_iteration/check_suites.py
@@ -80,7 +80,11 @@ class GithubCheckSuitePullRequestBase(BaseModel):
 
 class GithubCheckSuitePullRequest(BaseModel):
     id: int
-    # Optional so feedback serialized before this field existed still parses.
+    # Optional so feedback serialized before this field existed still parses. Such
+    # an entry is skipped rather than kept (see `resolve_check_suite_autofix_run`), which
+    # is safe because `Config.extra = "allow"` already round-tripped `base` through
+    # the model that predates this field — GitHub always sends it, so it survived
+    # serialization as an extra and parses into this field on the way back in.
     base: GithubCheckSuitePullRequestBase | None = None
 
     class Config:
@@ -197,18 +201,6 @@ class CheckSuiteAutofixRun:
     group_id: int
 
 
-def _is_foreign_base_repo(pr: GithubCheckSuitePullRequest, repository_id: int | None) -> bool:
-    """Whether this entry's PR is based in a repository other than the suite's.
-
-    Only ``True`` when both ids are present and differ — an entry we cannot place
-    is kept, since dropping one costs a real iteration.
-    """
-    if repository_id is None:
-        return False
-    base_repo_id = pr.base.repo.id if pr.base and pr.base.repo else None
-    return base_repo_id is not None and base_repo_id != repository_id
-
-
 def resolve_check_suite_autofix_run(
     event: GithubCheckSuiteEvent, repositories: Sequence[Repository] | None = None
 ) -> CheckSuiteAutofixRun | None:
@@ -227,7 +219,18 @@ def resolve_check_suite_autofix_run(
     resolving it would bind the suite to whatever run owns that foreign PR:
     ``repository`` below is this suite's repo, not the entry's, and the first
     match wins. Skipping them keeps the own-repo entry from being shadowed.
+
+    An entry carrying no ``base.repo`` at all is skipped on the same rule (see
+    ``is_own_repo_pull_request``). Resolving by global ``pr.id`` could place it,
+    but the control parser drops payloads made only of such entries, so acting on
+    them here would be acting on events this path no longer receives.
     """
+    # `sentry.integrations.github` registers rule actions at import time, and this
+    # module is imported while the SCM stream listeners initialize in
+    # AppConfig.ready — before options init. Deferred for the same reason as
+    # `make_scm` in `confirm_green_check_suite`.
+    from sentry.integrations.github.check_payloads import is_own_repo_pull_request
+
     repos = (
         list(repositories) if repositories is not None else resolve_check_suite_repositories(event)
     )
@@ -236,7 +239,8 @@ def resolve_check_suite_autofix_run(
 
     pull_requests = []
     for pr in event.check_suite.pull_requests:
-        if _is_foreign_base_repo(pr, event.repository.id):
+        base_repo_id = pr.base.repo.id if pr.base and pr.base.repo else None
+        if not is_own_repo_pull_request(base_repo_id, event.repository.id):
             metrics.incr("autofix.pr_iteration.check_suite.foreign_pull_request")
             continue
         pull_requests.append(pr)

--- a/src/sentry/seer/autofix/pr_iteration/check_suites.py
+++ b/src/sentry/seer/autofix/pr_iteration/check_suites.py
@@ -218,9 +218,10 @@ def resolve_check_suite_autofix_run(
     ``repository`` below is this suite's repo, not the entry's, and the first
     match wins. Skipping them keeps the own-repo entry from being shadowed.
 
-    An entry with no ``base.repo`` is skipped on the same rule: a global ``pr.id``
-    could place it, but the control parser drops payloads made only of those, so
-    this path no longer receives them anyway.
+    An entry with no ``base.repo`` is skipped on the same rule. A global ``pr.id``
+    could place it, but GitHub always sends ``base.repo``, so such an entry is not
+    a payload this path receives — and resolving one anyway would re-admit, for the
+    entry we cannot place, exactly the shadowing above.
     """
     # `sentry.integrations.github` registers rule actions at import time, and this
     # module loads while the SCM stream listeners initialize in AppConfig.ready,

--- a/src/sentry/seer/autofix/pr_iteration/check_suites.py
+++ b/src/sentry/seer/autofix/pr_iteration/check_suites.py
@@ -81,10 +81,8 @@ class GithubCheckSuitePullRequestBase(BaseModel):
 class GithubCheckSuitePullRequest(BaseModel):
     id: int
     # Optional so feedback serialized before this field existed still parses. Such
-    # an entry is skipped rather than kept (see `resolve_check_suite_autofix_run`), which
-    # is safe because `Config.extra = "allow"` already round-tripped `base` through
-    # the model that predates this field — GitHub always sends it, so it survived
-    # serialization as an extra and parses into this field on the way back in.
+    # an entry is skipped, which strands nothing: `extra = "allow"` round-tripped
+    # `base` through the model that predates the field, so it parses back in here.
     base: GithubCheckSuitePullRequestBase | None = None
 
     class Config:
@@ -220,15 +218,13 @@ def resolve_check_suite_autofix_run(
     ``repository`` below is this suite's repo, not the entry's, and the first
     match wins. Skipping them keeps the own-repo entry from being shadowed.
 
-    An entry carrying no ``base.repo`` at all is skipped on the same rule (see
-    ``is_own_repo_pull_request``). Resolving by global ``pr.id`` could place it,
-    but the control parser drops payloads made only of such entries, so acting on
-    them here would be acting on events this path no longer receives.
+    An entry with no ``base.repo`` is skipped on the same rule: a global ``pr.id``
+    could place it, but the control parser drops payloads made only of those, so
+    this path no longer receives them anyway.
     """
     # `sentry.integrations.github` registers rule actions at import time, and this
-    # module is imported while the SCM stream listeners initialize in
-    # AppConfig.ready — before options init. Deferred for the same reason as
-    # `make_scm` in `confirm_green_check_suite`.
+    # module loads while the SCM stream listeners initialize in AppConfig.ready,
+    # before options init. Deferred like `make_scm` in `confirm_green_check_suite`.
     from sentry.integrations.github.check_payloads import is_own_repo_pull_request
 
     repos = (

--- a/src/sentry/seer/autofix/pr_iteration/check_suites.py
+++ b/src/sentry/seer/autofix/pr_iteration/check_suites.py
@@ -64,8 +64,24 @@ class GithubCheckSuiteApp(BaseModel):
         extra = "allow"
 
 
+class GithubCheckSuitePullRequestRepository(BaseModel):
+    id: int | None = None
+
+    class Config:
+        extra = "allow"
+
+
+class GithubCheckSuitePullRequestBase(BaseModel):
+    repo: GithubCheckSuitePullRequestRepository | None = None
+
+    class Config:
+        extra = "allow"
+
+
 class GithubCheckSuitePullRequest(BaseModel):
     id: int
+    # Optional so feedback serialized before this field existed still parses.
+    base: GithubCheckSuitePullRequestBase | None = None
 
     class Config:
         extra = "allow"
@@ -181,6 +197,18 @@ class CheckSuiteAutofixRun:
     group_id: int
 
 
+def _is_foreign_base_repo(pr: GithubCheckSuitePullRequest, repository_id: int | None) -> bool:
+    """Whether this entry's PR is based in a repository other than the suite's.
+
+    Only ``True`` when both ids are present and differ — an entry we cannot place
+    is kept, since dropping one costs a real iteration.
+    """
+    if repository_id is None:
+        return False
+    base_repo_id = pr.base.repo.id if pr.base and pr.base.repo else None
+    return base_repo_id is not None and base_repo_id != repository_id
+
+
 def resolve_check_suite_autofix_run(
     event: GithubCheckSuiteEvent, repositories: Sequence[Repository] | None = None
 ) -> CheckSuiteAutofixRun | None:
@@ -191,6 +219,14 @@ def resolve_check_suite_autofix_run(
     match, logs a warning and returns the first. Callers that already resolved
     (or filtered) the candidate repos can pass ``repositories`` to restrict the
     search.
+
+    GitHub matches a PR to a suite on ``head_sha`` + ``head_branch``, so an entry
+    whose ``base.repo`` is not this suite's repo is a PR with its *head* here and
+    its base elsewhere — a fork syncing from upstream, say. Autofix opens both
+    sides of a PR in one repo, so such an entry can never be one of its own, and
+    resolving it would bind the suite to whatever run owns that foreign PR:
+    ``repository`` below is this suite's repo, not the entry's, and the first
+    match wins. Skipping them keeps the own-repo entry from being shadowed.
     """
     repos = (
         list(repositories) if repositories is not None else resolve_check_suite_repositories(event)
@@ -198,7 +234,12 @@ def resolve_check_suite_autofix_run(
     if not repos:
         return None
 
-    pull_requests = event.check_suite.pull_requests
+    pull_requests = []
+    for pr in event.check_suite.pull_requests:
+        if _is_foreign_base_repo(pr, event.repository.id):
+            metrics.incr("autofix.pr_iteration.check_suite.foreign_pull_request")
+            continue
+        pull_requests.append(pr)
     if not pull_requests:
         return None
 

--- a/tests/sentry/integrations/github/test_check_payloads.py
+++ b/tests/sentry/integrations/github/test_check_payloads.py
@@ -1,0 +1,97 @@
+import pytest
+
+from sentry.integrations.github.check_payloads import (
+    is_own_repo_pull_request,
+    pull_request_base_repo_id,
+    references_own_repo_pull_request,
+)
+
+
+class TestPullRequestBaseRepoId:
+    def test_reads_the_nested_id(self) -> None:
+        assert pull_request_base_repo_id({"base": {"repo": {"id": 123}}}) == 123
+
+    @pytest.mark.parametrize(
+        "ref",
+        [
+            {},
+            {"base": None},
+            {"base": {}},
+            {"base": {"repo": None}},
+            {"base": {"repo": {}}},
+            {"base": "junk"},
+            {"base": {"repo": []}},
+            "junk",
+            None,
+        ],
+    )
+    def test_missing_or_malformed_reads_as_none(self, ref: object) -> None:
+        """Read before the body is signature-verified, so any level may be junk."""
+        assert pull_request_base_repo_id(ref) is None
+
+
+class TestIsOwnRepoPullRequest:
+    def test_matches_across_int_and_str(self) -> None:
+        """Callers pass either the payload's int `repository.id` or a str
+        `Repository.external_id`, which stores the same value as text."""
+        assert is_own_repo_pull_request(123, 123)
+        assert is_own_repo_pull_request(123, "123")
+        assert is_own_repo_pull_request("123", 123)
+
+    def test_different_repo_is_not_ours(self) -> None:
+        assert not is_own_repo_pull_request(456, 123)
+
+    @pytest.mark.parametrize(
+        ("base_repo_id", "repo_id"),
+        [(None, 123), (123, None), (None, None)],
+    )
+    def test_unplaceable_is_not_ours(self, base_repo_id: object, repo_id: object) -> None:
+        """An entry with no base repo cannot be placed. Every consumer skips it, so
+        that the entries they act on match the ones the control parser preserves."""
+        assert not is_own_repo_pull_request(base_repo_id, repo_id)
+
+
+class TestReferencesOwnRepoPullRequest:
+    def _event(self, refs: object, repo_id: object = 123) -> dict:
+        return {"repository": {"id": repo_id}, "check_run": {"pull_requests": refs}}
+
+    def test_true_for_an_own_repo_entry(self) -> None:
+        assert references_own_repo_pull_request(
+            self._event([{"base": {"repo": {"id": 123}}}]), "check_run"
+        )
+
+    def test_scans_past_a_foreign_entry(self) -> None:
+        """GitHub's ordering must not decide this."""
+        assert references_own_repo_pull_request(
+            self._event([{"base": {"repo": {"id": 456}}}, {"base": {"repo": {"id": 123}}}]),
+            "check_run",
+        )
+
+    def test_false_for_only_foreign_entries(self) -> None:
+        assert not references_own_repo_pull_request(
+            self._event([{"base": {"repo": {"id": 456}}}]), "check_run"
+        )
+
+    def test_false_for_an_empty_list(self) -> None:
+        assert not references_own_repo_pull_request(self._event([]), "check_run")
+
+    def test_false_for_only_unplaceable_entries(self) -> None:
+        assert not references_own_repo_pull_request(self._event([{"number": 7}]), "check_run")
+
+    @pytest.mark.parametrize("refs", ["junk", 7, {"not": "a list"}, None])
+    def test_false_when_the_list_is_not_a_list(self, refs: object) -> None:
+        assert not references_own_repo_pull_request(self._event(refs), "check_run")
+
+    def test_false_without_a_repository_id(self) -> None:
+        """Nothing can be placed against an unknown repo, so nothing is ours."""
+        assert not references_own_repo_pull_request(
+            self._event([{"base": {"repo": {"id": 123}}}], repo_id=None), "check_run"
+        )
+
+    def test_container_key_selects_the_event_member(self) -> None:
+        event = {
+            "repository": {"id": 123},
+            "check_suite": {"pull_requests": [{"base": {"repo": {"id": 123}}}]},
+        }
+        assert references_own_repo_pull_request(event, "check_suite")
+        assert not references_own_repo_pull_request(event, "check_run")

--- a/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
@@ -387,7 +387,9 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
 
 
 class ResolveCheckSuiteAutofixRunTest(TestCase):
-    def _event(self, *, pull_requests: list[dict]) -> GithubCheckSuiteEvent:
+    def _event(
+        self, *, pull_requests: list[dict], repository_id: int | None = None
+    ) -> GithubCheckSuiteEvent:
         return GithubCheckSuiteEvent.parse_obj(
             {
                 "check_suite": {
@@ -398,7 +400,10 @@ class ResolveCheckSuiteAutofixRunTest(TestCase):
                     "updated_at": "2024-01-01T00:00:00Z",
                     "pull_requests": pull_requests,
                 },
-                "repository": {"html_url": "https://github.com/owner/repo"},
+                "repository": {
+                    "html_url": "https://github.com/owner/repo",
+                    "id": repository_id,
+                },
             }
         )
 
@@ -443,6 +448,63 @@ class ResolveCheckSuiteAutofixRunTest(TestCase):
                 "organization_ids": [self.organization.id, self.organization.id],
             },
         )
+
+    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITES_PATH}.resolve_check_suite_repositories")
+    def test_skips_pull_request_based_in_another_repo(
+        self, mock_resolve: MagicMock, mock_get_state: MagicMock
+    ) -> None:
+        """A PR with its head here and its base elsewhere is never an Autofix PR."""
+        mock_resolve.return_value = [MagicMock(organization_id=self.organization.id, id=2)]
+
+        result = resolve_check_suite_autofix_run(
+            self._event(
+                repository_id=123,
+                pull_requests=[{"id": 111, "base": {"repo": {"id": 456}}}],
+            )
+        )
+
+        assert result is None
+        assert mock_get_state.call_count == 0
+
+    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITES_PATH}.resolve_check_suite_repositories")
+    def test_foreign_entry_does_not_shadow_own_repo_entry(
+        self, mock_resolve: MagicMock, mock_get_state: MagicMock
+    ) -> None:
+        """The first match wins, so GitHub's ordering must not pick the run."""
+        mock_resolve.return_value = [MagicMock(organization_id=self.organization.id, id=2)]
+        mock_get_state.return_value = self._agent_state(run_id=222)
+
+        result = resolve_check_suite_autofix_run(
+            self._event(
+                repository_id=123,
+                pull_requests=[
+                    {"id": 111, "base": {"repo": {"id": 456}}},
+                    {"id": 222, "base": {"repo": {"id": 123}}},
+                ],
+            )
+        )
+
+        assert result is not None
+        assert result.pr_id == 222
+        mock_get_state.assert_called_once_with(self.organization.id, "integrations:github", 222)
+
+    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITES_PATH}.resolve_check_suite_repositories")
+    def test_resolves_entry_carrying_no_base_repo(
+        self, mock_resolve: MagicMock, mock_get_state: MagicMock
+    ) -> None:
+        """An entry we cannot place stays in: dropping one costs a real iteration."""
+        mock_resolve.return_value = [MagicMock(organization_id=self.organization.id, id=2)]
+        mock_get_state.return_value = self._agent_state(run_id=111)
+
+        result = resolve_check_suite_autofix_run(
+            self._event(repository_id=123, pull_requests=[{"id": 111}])
+        )
+
+        assert result is not None
+        assert result.pr_id == 111
 
 
 def _run_state(*, blocks: list[MemoryBlock] | None = None) -> SeerRunState:

--- a/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
@@ -31,10 +31,10 @@ OWN_REPO_ID = 123
 
 
 def own_repo_pr(pr_id: int) -> dict:
-    """A ``pull_requests`` entry as GitHub sends it, based in the suite's own repo.
+    """A ``pull_requests`` entry as GitHub sends it: based in the suite's own repo.
 
-    Entries always carry ``base.repo``, and only own-repo ones are resolved, so a
-    fixture without it is not a payload this path can receive.
+    GitHub always carries ``base.repo``, so a fixture without it is not a payload
+    this path can receive.
     """
     return {"id": pr_id, "base": {"repo": {"id": OWN_REPO_ID}}}
 

--- a/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
@@ -514,8 +514,9 @@ class ResolveCheckSuiteAutofixRunTest(TestCase):
         self, mock_resolve: MagicMock, mock_get_state: MagicMock
     ) -> None:
         """An entry we cannot place is skipped, on the same rule pr_metrics uses.
-        Resolving by global id could place it, but the control parser drops payloads
-        made only of these, so acting on them would act on events we no longer get."""
+        Resolving by global id could place it, but GitHub always sends base.repo, so
+        this is not a payload shape that reaches us — see the legacy test below for
+        why serialized feedback is not one either."""
         mock_resolve.return_value = [MagicMock(organization_id=self.organization.id, id=2)]
 
         result = resolve_check_suite_autofix_run(

--- a/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
@@ -26,6 +26,19 @@ from sentry.testutils.cases import TestCase
 CHECK_PATH = "sentry.seer.autofix.pr_iteration.listeners.check_suite"
 CHECK_SUITE_SOURCE_PATH = "sentry.seer.autofix.pr_iteration.feedback_sources.check_suite"
 CHECK_SUITES_PATH = "sentry.seer.autofix.pr_iteration.check_suites"
+
+OWN_REPO_ID = 123
+
+
+def own_repo_pr(pr_id: int) -> dict:
+    """A ``pull_requests`` entry as GitHub sends it, based in the suite's own repo.
+
+    Entries always carry ``base.repo``, and only own-repo ones are resolved, so a
+    fixture without it is not a payload this path can receive.
+    """
+    return {"id": pr_id, "base": {"repo": {"id": OWN_REPO_ID}}}
+
+
 # Lazy-imported inside the listener (must not load at AppConfig.ready).
 TRIGGER_CONSUME_PATH = "sentry.tasks.seer.pr_iteration.trigger_consume_pr_iteration_feedback"
 
@@ -67,7 +80,10 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
                 "updated_at": "2024-01-01T00:00:00Z",
                 "pull_requests": pull_requests or [],
             },
-            "repository": {"html_url": "https://github.com/owner/repo"},
+            "repository": {
+                "html_url": "https://github.com/owner/repo",
+                "id": OWN_REPO_ID,
+            },
         }
 
     def _agent_state(self) -> SeerRunState:
@@ -245,7 +261,7 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         mock_enqueue: MagicMock,
     ) -> None:
         mock_resolve.return_value = [MagicMock(organization_id=self.organization.id)]
-        raw = self._raw(pull_requests=[{"id": 555}])
+        raw = self._raw(pull_requests=[own_repo_pr(555)])
 
         pr_iteration_from_check_suite_listener(self._event(raw))
 
@@ -264,7 +280,7 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         state = self._agent_state()
         state.metadata = {}
         mock_get_state.return_value = state
-        raw = self._raw(pull_requests=[{"id": 555}])
+        raw = self._raw(pull_requests=[own_repo_pr(555)])
 
         pr_iteration_from_check_suite_listener(self._event(raw))
 
@@ -285,7 +301,7 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
     ) -> None:
         mock_resolve.return_value = [MagicMock(organization_id=self.organization.id, id=2)]
         mock_get_state.return_value = self._agent_state()
-        raw = self._raw(pull_requests=[{"id": 555}])
+        raw = self._raw(pull_requests=[own_repo_pr(555)])
 
         pr_iteration_from_check_suite_listener(self._event(raw))
 
@@ -312,7 +328,7 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
     ) -> None:
         mock_resolve.return_value = [MagicMock(organization_id=self.organization.id, id=2)]
         mock_get_state.return_value = self._agent_state()
-        raw = self._raw(pull_requests=[{"id": 555}])
+        raw = self._raw(pull_requests=[own_repo_pr(555)])
 
         pr_iteration_from_check_suite_listener(self._event(raw))
 
@@ -350,7 +366,7 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         mock_resolve.return_value = [MagicMock(organization_id=self.organization.id, id=2)]
         error = SeerApiError("transient", 500)
         mock_get_state.side_effect = [error, self._agent_state()]
-        raw = self._raw(pull_requests=[{"id": 111}, {"id": 222}])
+        raw = self._raw(pull_requests=[own_repo_pr(111), own_repo_pr(222)])
 
         pr_iteration_from_check_suite_listener(self._event(raw))
 
@@ -374,7 +390,7 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         right_org_repo = MagicMock(organization_id=self.organization.id, id=2)
         mock_resolve.return_value = [wrong_org_repo, right_org_repo]
         mock_get_state.side_effect = [None, self._agent_state()]
-        raw = self._raw(pull_requests=[{"id": 555}])
+        raw = self._raw(pull_requests=[own_repo_pr(555)])
 
         pr_iteration_from_check_suite_listener(self._event(raw))
 
@@ -433,7 +449,9 @@ class ResolveCheckSuiteAutofixRunTest(TestCase):
         mock_get_state.side_effect = [first, second]
 
         result = resolve_check_suite_autofix_run(
-            self._event(pull_requests=[{"id": 111}, {"id": 222}])
+            self._event(
+                pull_requests=[own_repo_pr(111), own_repo_pr(222)], repository_id=OWN_REPO_ID
+            )
         )
 
         assert result is not None
@@ -492,15 +510,56 @@ class ResolveCheckSuiteAutofixRunTest(TestCase):
 
     @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
     @patch(f"{CHECK_SUITES_PATH}.resolve_check_suite_repositories")
-    def test_resolves_entry_carrying_no_base_repo(
+    def test_skips_entry_carrying_no_base_repo(
         self, mock_resolve: MagicMock, mock_get_state: MagicMock
     ) -> None:
-        """An entry we cannot place stays in: dropping one costs a real iteration."""
+        """An entry we cannot place is skipped, on the same rule pr_metrics uses.
+        Resolving by global id could place it, but the control parser drops payloads
+        made only of these, so acting on them would act on events we no longer get."""
         mock_resolve.return_value = [MagicMock(organization_id=self.organization.id, id=2)]
-        mock_get_state.return_value = self._agent_state(run_id=111)
 
         result = resolve_check_suite_autofix_run(
             self._event(repository_id=123, pull_requests=[{"id": 111}])
+        )
+
+        assert result is None
+        assert mock_get_state.call_count == 0
+
+    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITES_PATH}.resolve_check_suite_repositories")
+    def test_unplaceable_entry_does_not_shadow_own_repo_entry(
+        self, mock_resolve: MagicMock, mock_get_state: MagicMock
+    ) -> None:
+        """Same shadowing guarantee as the foreign case, for the entry we cannot place."""
+        mock_resolve.return_value = [MagicMock(organization_id=self.organization.id, id=2)]
+        mock_get_state.return_value = self._agent_state(run_id=222)
+
+        result = resolve_check_suite_autofix_run(
+            self._event(
+                repository_id=123,
+                pull_requests=[{"id": 111}, {"id": 222, "base": {"repo": {"id": 123}}}],
+            )
+        )
+
+        assert result is not None
+        assert result.pr_id == 222
+        mock_get_state.assert_called_once_with(self.organization.id, "integrations:github", 222)
+
+    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITES_PATH}.resolve_check_suite_repositories")
+    def test_resolves_legacy_entry_round_tripped_through_the_old_model(
+        self, mock_resolve: MagicMock, mock_get_state: MagicMock
+    ) -> None:
+        """Feedback serialized before `base` was declared still carries it: the model
+        that predates the field had `extra = "allow"`, so `base` survived the round
+        trip as an extra and parses into the field now. This is why skipping the
+        unplaceable entry does not strand in-flight iterations."""
+        mock_resolve.return_value = [MagicMock(organization_id=self.organization.id, id=2)]
+        mock_get_state.return_value = self._agent_state(run_id=111)
+
+        legacy_entry = {"id": 111, "number": 3, "base": {"repo": {"id": 123, "name": "x"}}}
+        result = resolve_check_suite_autofix_run(
+            self._event(repository_id=123, pull_requests=[legacy_entry])
         )
 
         assert result is not None


### PR DESCRIPTION
## Problem

`resolve_check_suite_autofix_run` looks every `check_suite.pull_requests` entry up by its **global** `pr.id` and returns `matches[0]`, pairing it with `repository=candidate` — the repo the *suite* fired for, not the entry's own `base.repo`.

GitHub attaches a PR to a check suite whenever they share `head_sha` **and** `head_branch`. So an entry can be a PR with its **head in this repo** and its **base in another one** — a fork syncing from upstream is the usual shape. Autofix opens both sides of a PR in a single repo, so such an entry is never one of its own.

That entry ordered ahead of the legitimate own-repo entry shadowed it. The run it resolves has no `repo_pr_states` for this repo, so both downstream paths bail:

- failure path — `check_suite_head_match` returns `matched=False`, and `should_queue` / `should_consume` are `matched and ...`
- green path — `resolve_green_check_suite` gets no `pr_number` and skips with `no_pr_number`

The own-repo run's CI feedback is then dropped with no signal: the suite already resolved "successfully" to the wrong run.

## Changes

`GithubCheckSuitePullRequest` now parses `base.repo.id`, and the resolver skips entries the payload does not place in this repo before spending a Seer lookup on them.

**The rule now has one home.** Three call sites decided which entries belong to the webhook's repo — pr_metrics' `_prs_from_check_payload`, the control parser's `has_own_repo_pr` tag, and this resolver — and they disagreed. `sentry/integrations/github/check_payloads.py` holds the comparison and the reasoning; all three call it.

**The disagreement was the entry with no `base.repo`**, resolved here by skipping, matching pr_metrics rather than the reverse:

- pr_metrics *must* skip it — it resolves a repo-scoped `number`, and numbers repeat across repositories, so placing an unplaceable entry here can attribute another repo's PR to this one.
- This resolver *could* keep it, since a global `pr.id` has no such collision. But GitHub always sends `base.repo`, so it would be guessing at a shape live payloads do not take — and resolving one anyway re-admits, for the entry we cannot place, the shadowing this PR fixes.

Skipping strands no in-flight feedback: `base` is new here, but the model that predates it had `extra = "allow"`, so `base` round-tripped through as an extra and parses into the field on the way back in. Pinned by `test_resolves_legacy_entry_round_tripped_through_the_old_model`.

Skipped entries are counted as `autofix.pr_iteration.check_suite.foreign_pull_request`. Paired with `green_check_suite.run_resolved{found:true}`, a nonzero skip count with unchanged resolves confirms the filter only removes entries that could never have resolved.

## Note on the import

The resolver imports `check_payloads` inside the function. `sentry/integrations/github/__init__.py` registers rule actions at import time, and this module loads while the SCM stream listeners initialize in `AppConfig.ready`, before options init — the same constraint that already defers `make_scm` in `confirm_green_check_suite`. At module scope it breaks test collection outright.
