### PR TITLE
feat(scm-first-messaging-integration): Adding providerRow component

### DIFF
--- a/static/app/components/onboarding/onboardingContext.spec.tsx
+++ b/static/app/components/onboarding/onboardingContext.spec.tsx
@@ -24,7 +24,6 @@ const selectedMessagingSetup = {
   providerKey: 'slack',
   integrationId: '15',
   channelId: 'C123',
-  actionTarget: '#alerts',
   channelName: '#alerts',
 } as const satisfies ScmMessagingSetup;
 
@@ -140,7 +139,6 @@ describe('OnboardingContextProvider', () => {
           providerKey: 'discord',
           integrationId: '20',
           channelId: '123456789',
-          actionTarget: '123456789',
           channelName: '#dev-alerts',
         },
       })

--- a/static/app/components/onboarding/scm/messagingProviders.ts
+++ b/static/app/components/onboarding/scm/messagingProviders.ts
@@ -20,3 +20,12 @@ export const SCM_MESSAGING_PROVIDER_DESCRIPTIONS: Record<
   msteams: t('Send issue alerts directly to Microsoft Teams.'),
   discord: t('Keep your team updated with issue alerts in Discord.'),
 };
+
+/**
+ * Tooltip text shown on the info icon in the installable row state.
+ */
+export const SCM_MESSAGING_PROVIDER_TOOLTIPS: Record<ScmMessagingProviderKey, string> = {
+  slack: t('Requires permission to install apps in your Slack workspace.'),
+  msteams: t("You'll add Sentry to a team and channel in Microsoft Teams."),
+  discord: t('Requires the Manage Server permission.'),
+};

--- a/static/app/components/onboarding/scm/scmMessagingChannelPicker.spec.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingChannelPicker.spec.tsx
@@ -1,0 +1,482 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {OrganizationIntegrationsFixture} from 'sentry-fixture/organizationIntegrations';
+
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {selectEvent} from 'sentry-test/selectEvent';
+
+import type {OrganizationIntegration} from 'sentry/types/integrations';
+
+import type {ScmMessagingProviderKey} from './messagingProviders';
+import {ScmMessagingChannelPicker} from './scmMessagingChannelPicker';
+import type {ScmMessagingSetup} from './scmMessagingSetup';
+
+const organization = OrganizationFixture();
+
+const slackIntegration = OrganizationIntegrationsFixture({
+  id: '10',
+  name: 'test-workspace',
+  provider: {
+    key: 'slack',
+    slug: 'slack',
+    name: 'Slack',
+    canAdd: true,
+    canDisable: false,
+    features: [],
+    aspects: {},
+  },
+});
+
+const discordIntegration = OrganizationIntegrationsFixture({
+  id: '20',
+  name: 'test-server',
+  provider: {
+    key: 'discord',
+    slug: 'discord',
+    name: 'Discord',
+    canAdd: true,
+    canDisable: false,
+    features: [],
+    aspects: {},
+  },
+});
+
+const msteamsIntegration = OrganizationIntegrationsFixture({
+  id: '30',
+  name: 'test-team',
+  provider: {
+    key: 'msteams',
+    slug: 'msteams',
+    name: 'MS Teams',
+    canAdd: true,
+    canDisable: false,
+    features: [],
+    aspects: {},
+  },
+});
+
+// Both providers format `display` as `#{name}`; only `id` distinguishes them,
+// which is what makes the name/ID mixup easy to write and hard to spot.
+const slackChannel = {id: 'C123', name: 'general', display: '#general', type: 'channel'};
+const discordChannel = {
+  id: '1234567890',
+  name: 'general',
+  display: '#general',
+  type: 'text',
+};
+
+function mockChannels(integrationId: string, results: Array<Record<string, string>>) {
+  return MockApiClient.addMockResponse({
+    url: `/organizations/${organization.slug}/integrations/${integrationId}/channels/`,
+    body: {results},
+  });
+}
+
+function mockChannelValidate(valid: boolean, integrationId: string) {
+  return MockApiClient.addMockResponse({
+    url: `/organizations/${organization.slug}/integrations/${integrationId}/channel-validate/`,
+    body: {valid},
+  });
+}
+
+function renderPicker({
+  eligibleIntegrations = [slackIntegration],
+  existingSetup,
+  providerKey = 'slack',
+}: {
+  eligibleIntegrations?: OrganizationIntegration[];
+  existingSetup?: ScmMessagingSetup;
+  providerKey?: ScmMessagingProviderKey;
+} = {}) {
+  const onConfigured = jest.fn();
+
+  render(
+    <ScmMessagingChannelPicker
+      eligibleIntegrations={eligibleIntegrations}
+      providerKey={providerKey}
+      onConfigured={onConfigured}
+      existingSetup={existingSetup}
+    />,
+    {organization}
+  );
+
+  return {onConfigured};
+}
+
+const selectedDiscordSetup: ScmMessagingSetup = {
+  mode: 'selected',
+  providerKey: 'discord',
+  integrationId: '20',
+  channelId: '1234567890',
+  channelName: '#general',
+};
+
+const selectedSlackSetup: ScmMessagingSetup = {
+  mode: 'selected',
+  providerKey: 'slack',
+  integrationId: '10',
+  channelId: 'C123',
+  channelName: '#general',
+};
+
+const selectedMsTeamsSetup: ScmMessagingSetup = {
+  mode: 'selected',
+  providerKey: 'msteams',
+  integrationId: '30',
+  channelId: '19:abc123@thread.tacv2',
+  channelName: 'General',
+};
+
+describe('ScmMessagingChannelPicker', () => {
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+    jest.restoreAllMocks();
+  });
+
+  describe('staging a new destination', () => {
+    it('stores Slack by display name', async () => {
+      mockChannels('10', [slackChannel]);
+      const {onConfigured} = renderPicker({eligibleIntegrations: [slackIntegration]});
+
+      await selectEvent.select(screen.getByLabelText('channel'), '#general');
+      await userEvent.click(screen.getByRole('button', {name: 'Add destination'}));
+
+      expect(onConfigured).toHaveBeenCalledWith({
+        mode: 'selected',
+        providerKey: 'slack',
+        integrationId: '10',
+        channelId: 'C123',
+        channelName: '#general',
+      });
+    });
+
+    it('stores Discord by channel ID', async () => {
+      mockChannels('20', [discordChannel]);
+      const {onConfigured} = renderPicker({
+        eligibleIntegrations: [discordIntegration],
+        providerKey: 'discord',
+      });
+
+      await selectEvent.select(screen.getByLabelText('channel'), '#general (1234567890)');
+      await userEvent.click(screen.getByRole('button', {name: 'Add destination'}));
+
+      expect(onConfigured).toHaveBeenCalledWith({
+        mode: 'selected',
+        providerKey: 'discord',
+        integrationId: '20',
+        channelId: '1234567890',
+        channelName: '#general',
+      });
+    });
+
+    it('disables Add destination until a channel is chosen', () => {
+      mockChannels('10', [slackChannel]);
+      renderPicker({eligibleIntegrations: [slackIntegration]});
+
+      expect(screen.getByRole('button', {name: 'Add destination'})).toBeDisabled();
+    });
+  });
+
+  describe('manual entry', () => {
+    it('keeps a typed Discord channel URL as the action target', async () => {
+      mockChannels('20', [discordChannel]);
+      // Manual entries validate as you type, via the shared hook's
+      // `enabled: !!channel?.new` query.
+      mockChannelValidate(true, '20');
+      const {onConfigured} = renderPicker({
+        eligibleIntegrations: [discordIntegration],
+        providerKey: 'discord',
+      });
+
+      const channelUrl = 'https://discord.com/channels/111/1234567890';
+      // ChannelSelect sets formatCreateLabel to the raw input, so the create
+      // option is labelled with the typed value, not the default `Create "..."`.
+      await selectEvent.create(screen.getByLabelText('channel'), channelUrl, {
+        createOptionText: channelUrl,
+      });
+      await userEvent.click(screen.getByRole('button', {name: 'Add destination'}));
+
+      // Stored as-is: the backend resolves URL to ID in both the validate
+      // endpoint and DiscordNotifyServiceForm.clean.
+      expect(onConfigured).toHaveBeenCalledWith({
+        mode: 'selected',
+        providerKey: 'discord',
+        integrationId: '20',
+        channelId: channelUrl,
+        channelName: channelUrl,
+      });
+    });
+  });
+
+  describe('editing an existing destination', () => {
+    it('preserves the Discord channel ID through a no-op edit', async () => {
+      mockChannels('20', [discordChannel]);
+      const {onConfigured} = renderPicker({
+        eligibleIntegrations: [discordIntegration],
+        existingSetup: selectedDiscordSetup,
+        providerKey: 'discord',
+      });
+
+      await userEvent.click(screen.getByRole('button', {name: 'Add destination'}));
+
+      expect(onConfigured).toHaveBeenCalledWith({
+        mode: 'selected',
+        providerKey: 'discord',
+        integrationId: '20',
+        channelId: '1234567890',
+        channelName: '#general',
+      });
+    });
+
+    it('preserves the Slack channel name through a no-op edit', async () => {
+      mockChannels('10', [slackChannel]);
+      const {onConfigured} = renderPicker({
+        eligibleIntegrations: [slackIntegration],
+        existingSetup: selectedSlackSetup,
+      });
+
+      await userEvent.click(screen.getByRole('button', {name: 'Add destination'}));
+
+      expect(onConfigured).toHaveBeenCalledWith({
+        mode: 'selected',
+        providerKey: 'slack',
+        integrationId: '10',
+        channelId: 'C123',
+        channelName: '#general',
+      });
+    });
+
+    it('preserves stored MS Teams identifiers when the channel list is empty', async () => {
+      // msteams selects by id but validates by name, so overwriting channelName
+      // with the id (the fallback when the list can't resolve the selection)
+      // breaks revalidation. An empty /channels/ must not corrupt the saved name.
+      mockChannels('30', []);
+      const {onConfigured} = renderPicker({
+        eligibleIntegrations: [msteamsIntegration],
+        existingSetup: selectedMsTeamsSetup,
+        providerKey: 'msteams',
+      });
+
+      await userEvent.click(screen.getByRole('button', {name: 'Add destination'}));
+
+      expect(onConfigured).toHaveBeenCalledWith({
+        mode: 'selected',
+        providerKey: 'msteams',
+        integrationId: '30',
+        channelId: '19:abc123@thread.tacv2',
+        channelName: 'General',
+      });
+    });
+
+    it('preserves stored Discord identifiers when the saved channel is absent from the list', async () => {
+      // /channels/ no longer returns the saved channel; a no-op re-save must keep
+      // the stored name rather than overwrite it with the id.
+      mockChannels('20', []);
+      const {onConfigured} = renderPicker({
+        eligibleIntegrations: [discordIntegration],
+        existingSetup: selectedDiscordSetup,
+        providerKey: 'discord',
+      });
+
+      await userEvent.click(screen.getByRole('button', {name: 'Add destination'}));
+
+      expect(onConfigured).toHaveBeenCalledWith({
+        mode: 'selected',
+        providerKey: 'discord',
+        integrationId: '20',
+        channelId: '1234567890',
+        channelName: '#general',
+      });
+    });
+  });
+
+  describe('multi-workspace', () => {
+    const slackIntegration2 = OrganizationIntegrationsFixture({
+      id: '11',
+      name: 'second-workspace',
+      provider: {
+        key: 'slack',
+        slug: 'slack',
+        name: 'Slack',
+        canAdd: true,
+        canDisable: false,
+        features: [],
+        aspects: {},
+      },
+    });
+
+    it('enables the Workspace select when there are multiple eligible integrations', () => {
+      mockChannels('10', [slackChannel]);
+      mockChannels('11', []);
+      renderPicker({eligibleIntegrations: [slackIntegration, slackIntegration2]});
+
+      expect(screen.getByLabelText('workspace')).toBeEnabled();
+    });
+
+    it('disables the Workspace select when there is only one eligible integration', () => {
+      mockChannels('10', [slackChannel]);
+      renderPicker({eligibleIntegrations: [slackIntegration]});
+
+      expect(screen.getByLabelText('workspace')).toBeDisabled();
+    });
+
+    it('writes the selected workspace integrationId on save', async () => {
+      mockChannels('10', [slackChannel]);
+      mockChannels('11', [slackChannel]);
+      const {onConfigured} = renderPicker({
+        eligibleIntegrations: [slackIntegration, slackIntegration2],
+      });
+
+      // Switch to the second workspace.
+      await selectEvent.select(screen.getByLabelText('workspace'), 'second-workspace');
+      await selectEvent.select(screen.getByLabelText('channel'), '#general');
+      await userEvent.click(screen.getByRole('button', {name: 'Add destination'}));
+
+      expect(onConfigured).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mode: 'selected',
+          providerKey: 'slack',
+          integrationId: '11',
+        })
+      );
+    });
+
+    it('seeds the channel from the saved workspace and not the other', async () => {
+      mockChannels('10', [slackChannel]);
+      mockChannels('11', []);
+      renderPicker({
+        eligibleIntegrations: [slackIntegration, slackIntegration2],
+        existingSetup: selectedSlackSetup,
+      });
+
+      // The saved workspace (id 10) seeds a channel; wait for channel loading to
+      // settle before checking the Add destination button is enabled.
+      await waitFor(() => {
+        expect(screen.getByRole('button', {name: 'Add destination'})).toBeEnabled();
+      });
+    });
+
+    it('falls back to the first survivor and clears the channel when the selected workspace is removed', async () => {
+      mockChannels('10', [slackChannel]);
+      mockChannels('11', [slackChannel]);
+
+      const onConfigured = jest.fn();
+      const {rerender} = render(
+        <ScmMessagingChannelPicker
+          eligibleIntegrations={[slackIntegration, slackIntegration2]}
+          providerKey="slack"
+          onConfigured={onConfigured}
+        />,
+        {organization}
+      );
+
+      // Switch to the second workspace and pick a channel.
+      await selectEvent.select(screen.getByLabelText('workspace'), 'second-workspace');
+      await selectEvent.select(screen.getByLabelText('channel'), '#general');
+
+      // The second workspace disappears (e.g. after a refetch).
+      rerender(
+        <ScmMessagingChannelPicker
+          eligibleIntegrations={[slackIntegration]}
+          providerKey="slack"
+          onConfigured={onConfigured}
+        />
+      );
+
+      // Workspace falls back to the first survivor and channel is cleared.
+      await waitFor(() => {
+        expect(screen.getByRole('button', {name: 'Add destination'})).toBeDisabled();
+      });
+
+      // Save writes the surviving integration id.
+      await selectEvent.select(screen.getByLabelText('channel'), '#general');
+      await userEvent.click(screen.getByRole('button', {name: 'Add destination'}));
+
+      expect(onConfigured).toHaveBeenCalledWith(
+        expect.objectContaining({integrationId: '10'})
+      );
+    });
+
+    it('clears the seeded channel and falls back when the default (saved) workspace is removed', async () => {
+      // Regression: when selectedIntegrationId is undefined (user never explicitly
+      // switched workspaces), the removal effect's guard (`selectedIntegrationId &&`)
+      // would short-circuit and leave the seeded channel intact. A subsequent save
+      // would then pair the stale channel with the new fallback integrationId.
+      mockChannels('10', [slackChannel]);
+      mockChannels('11', [slackChannel]);
+
+      const onConfigured = jest.fn();
+      const {rerender} = render(
+        <ScmMessagingChannelPicker
+          eligibleIntegrations={[slackIntegration, slackIntegration2]}
+          providerKey="slack"
+          onConfigured={onConfigured}
+          existingSetup={selectedSlackSetup}
+        />,
+        {organization}
+      );
+
+      // The saved workspace (id 10) seeds the channel. The user never explicitly
+      // switched workspaces, so selectedIntegrationId is initialized to '10' and
+      // remains at its initial value throughout.
+      await waitFor(() => {
+        expect(screen.getByRole('button', {name: 'Add destination'})).toBeEnabled();
+      });
+
+      // Saved workspace (id 10) is removed from the list — e.g. after a refetch.
+      rerender(
+        <ScmMessagingChannelPicker
+          eligibleIntegrations={[slackIntegration2]}
+          providerKey="slack"
+          onConfigured={onConfigured}
+          existingSetup={selectedSlackSetup}
+        />
+      );
+
+      // Channel must be cleared; Add destination disabled.
+      await waitFor(() => {
+        expect(screen.getByRole('button', {name: 'Add destination'})).toBeDisabled();
+      });
+
+      // Save must write the surviving workspace id, not the vanished one paired
+      // with the stale channel.
+      await selectEvent.select(screen.getByLabelText('channel'), '#general');
+      await userEvent.click(screen.getByRole('button', {name: 'Add destination'}));
+
+      expect(onConfigured).toHaveBeenCalledWith(
+        expect.objectContaining({integrationId: '11'})
+      );
+      expect(onConfigured).not.toHaveBeenCalledWith(
+        expect.objectContaining({integrationId: '10'})
+      );
+    });
+
+    it('only shows the integrations it receives — eligibility is enforced upstream', () => {
+      // The row (via the view model) is responsible for filtering to eligibleIntegrations
+      // before passing them to the picker. The picker renders whatever it receives.
+      const msteamsTeam = OrganizationIntegrationsFixture({
+        id: '41',
+        name: 'team-workspace',
+        provider: {
+          key: 'msteams',
+          slug: 'msteams',
+          name: 'Microsoft Teams',
+          canAdd: true,
+          canDisable: false,
+          features: [],
+          aspects: {},
+        },
+        configData: {installationType: 'team'},
+      });
+
+      mockChannels('41', []);
+      // Only the eligible team integration is passed; the tenant was excluded by the row.
+      renderPicker({
+        eligibleIntegrations: [msteamsTeam],
+        providerKey: 'msteams',
+      });
+
+      expect(screen.getByLabelText('workspace')).toBeDisabled(); // only 1 workspace
+      expect(screen.getByText('team-workspace')).toBeInTheDocument();
+    });
+  });
+});

--- a/static/app/components/onboarding/scm/scmMessagingChannelPicker.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingChannelPicker.tsx
@@ -1,0 +1,233 @@
+import {useCallback, useMemo, useState} from 'react';
+
+import {Alert} from '@sentry/scraps/alert';
+import {Button} from '@sentry/scraps/button';
+import {Flex, Grid, Stack} from '@sentry/scraps/layout';
+import {Select} from '@sentry/scraps/select';
+import {Text} from '@sentry/scraps/text';
+
+import {t} from 'sentry/locale';
+import type {OrganizationIntegration} from 'sentry/types/integrations';
+import {
+  providerDetails,
+  RAW_CHANNEL_FIELD,
+  type IntegrationChannel,
+} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
+import {
+  type Channel,
+  ChannelField,
+  ChannelSelect,
+  useMessagingIntegrationAlertRule,
+} from 'sentry/views/projectInstall/messagingIntegrationAlertRule';
+
+import type {ScmMessagingProviderKey} from './messagingProviders';
+import type {ScmMessagingSetup} from './scmMessagingSetup';
+
+export interface ScmMessagingChannelPickerProps {
+  /**
+   * Eligible integrations for this provider — already filtered to those that
+   * can receive Issue Alert actions.
+   */
+  eligibleIntegrations: OrganizationIntegration[];
+  onConfigured: (setup: ScmMessagingSetup & {mode: 'selected'}) => void;
+  providerKey: ScmMessagingProviderKey;
+  /** Pre-seeds the channel selector when editing an existing destination. */
+  existingSetup?: ScmMessagingSetup;
+  /** When provided a Cancel button is shown (e.g. in Edit mode). */
+  onCancel?: () => void;
+}
+
+export function ScmMessagingChannelPicker({
+  eligibleIntegrations,
+  onCancel,
+  onConfigured,
+  existingSetup,
+  providerKey,
+}: ScmMessagingChannelPickerProps) {
+  const {channelSelectedBy} = providerDetails[providerKey];
+
+  // The saved destination we're editing, if any. Drives both the dropdown seed
+  // and the preserve-on-no-op-save logic below.
+  const savedSelection =
+    existingSetup?.mode === 'selected' && existingSetup.providerKey === providerKey
+      ? existingSetup
+      : undefined;
+
+  const [selectedIntegrationId, setSelectedIntegrationId] = useState(
+    savedSelection?.integrationId
+  );
+
+  const selectedIntegration =
+    eligibleIntegrations.find(i => i.id === selectedIntegrationId) ??
+    eligibleIntegrations[0];
+
+  // Keep the chosen channel bound to the workspace it was chosen for. It only
+  // surfaces (and is only saved) while its workspace is the selected one, so a
+  // fallback after the workspace is removed can never pair a stale channel with a
+  // different integration.
+  const [channelState, setChannelState] = useState<{
+    channel: IntegrationChannel | undefined;
+    integrationId: string | undefined;
+  }>(() => ({
+    integrationId: savedSelection?.integrationId,
+    // Only seed the channel when the default workspace is the saved one. Switching
+    // workspaces starts blank.
+    channel: savedSelection
+      ? {label: savedSelection.channelName, value: savedSelection[channelSelectedBy]}
+      : undefined,
+  }));
+
+  const setChannel = useCallback(
+    (nextChannel: IntegrationChannel | undefined) =>
+      setChannelState({channel: nextChannel, integrationId: selectedIntegration?.id}),
+    [selectedIntegration?.id]
+  );
+
+  const channel =
+    channelState.integrationId === selectedIntegration?.id
+      ? channelState.channel
+      : undefined;
+
+  const providersToIntegrations = useMemo(
+    () => ({[providerKey]: eligibleIntegrations}),
+    [providerKey, eligibleIntegrations]
+  );
+
+  const {
+    channelOptions,
+    isChannelLoading,
+    isChannelsError,
+    channelsData,
+    channelError,
+    onChannelChange,
+    onCreateChannel,
+    onIntegrationChange,
+    integrationOptions,
+    integrationDisabled,
+  } = useMessagingIntegrationAlertRule({
+    channel,
+    integration: selectedIntegration,
+    provider: providerKey,
+    setChannel,
+    setIntegration: i => {
+      if (i) {
+        setSelectedIntegrationId(i.id);
+      }
+    },
+    setProvider: () => {},
+    providersToIntegrations,
+    actions: [],
+    setActions: () => {},
+    queryError: false,
+    querySuccess: true,
+    shouldRenderSetupButton: false,
+  });
+
+  if (!selectedIntegration) {
+    return null;
+  }
+
+  const handleSave = () => {
+    if (!channel) {
+      return;
+    }
+
+    // Match the selected value against whichever field this provider's options
+    // are keyed on. Manual entries (channel.new) are not in the list.
+    const rawChannel = channel.new
+      ? undefined
+      : channelsData?.results.find(
+          (ch: Channel) => ch[RAW_CHANNEL_FIELD[channelSelectedBy]] === channel.value
+        );
+
+    // Prefer the resolved raw channel. If it can't be resolved (empty/errored
+    // /channels/ or a dropped channel) but the selection and workspace are unchanged,
+    // keep the stored identifiers — otherwise id-keyed providers (msteams, discord)
+    // would overwrite channelName with the id and break name-based revalidation.
+    // A new value falls through to itself.
+    let stored: {channelId: string; channelName: string};
+
+    if (rawChannel) {
+      stored = {channelId: rawChannel.id, channelName: rawChannel.display};
+    } else if (
+      selectedIntegration.id === savedSelection?.integrationId &&
+      channel.value === savedSelection?.[channelSelectedBy]
+    ) {
+      stored = {
+        channelId: savedSelection.channelId,
+        channelName: savedSelection.channelName,
+      };
+    } else {
+      stored = {channelId: channel.value, channelName: channel.value};
+    }
+
+    onConfigured({
+      mode: 'selected',
+      providerKey,
+      integrationId: selectedIntegration.id,
+      ...stored,
+    });
+  };
+
+  return (
+    <Stack gap="md">
+      <Grid columns="1fr 1fr" gap="md">
+        <Stack gap="xs">
+          <Text bold size="sm">
+            {t('Workspace')}
+          </Text>
+          <Select
+            aria-label={t('workspace')}
+            disabled={integrationDisabled}
+            value={selectedIntegration}
+            options={integrationOptions}
+            onChange={onIntegrationChange}
+          />
+        </Stack>
+        <Stack gap="xs">
+          <Text bold size="sm">
+            {t('Channel')}
+          </Text>
+          <ChannelField
+            name="channel"
+            error={channelError}
+            inline={false}
+            flexibleControlStateSize
+          >
+            {() => (
+              <ChannelSelect
+                provider={providerKey}
+                options={channelOptions}
+                value={channel}
+                isLoading={isChannelLoading}
+                disabled={false}
+                onChange={onChannelChange}
+                onCreateOption={onCreateChannel}
+              />
+            )}
+          </ChannelField>
+        </Stack>
+      </Grid>
+      {isChannelsError && (
+        <Alert variant="warning">
+          {t('Failed to load channels. You can still type a channel name.')}
+        </Alert>
+      )}
+      <Flex gap="sm" justify="end">
+        {onCancel && (
+          <Button size="sm" onClick={onCancel}>
+            {t('Cancel')}
+          </Button>
+        )}
+        <Button
+          size="sm"
+          variant="primary"
+          disabled={!channel || !!channelError || isChannelLoading}
+          onClick={handleSave}
+        >
+          {t('Add destination')}
+        </Button>
+      </Flex>
+    </Stack>
+  );
+}

--- a/static/app/components/onboarding/scm/scmMessagingProviderRow.spec.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingProviderRow.spec.tsx
@@ -1,0 +1,419 @@
+import {act} from 'react';
+import {GitHubIntegrationProviderFixture} from 'sentry-fixture/githubIntegrationProvider';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {OrganizationIntegrationsFixture} from 'sentry-fixture/organizationIntegrations';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {UNCONFIGURED_SCM_MESSAGING_SETUP} from 'sentry/components/onboarding/scm/scmMessagingSetup';
+import type {ScmMessagingSetup} from 'sentry/components/onboarding/scm/scmMessagingSetup';
+import * as pipelineModal from 'sentry/components/pipeline/modal';
+import type {OrganizationIntegration} from 'sentry/types/integrations';
+
+import {ScmMessagingProviderRow} from './scmMessagingProviderRow';
+import type {ScmMessagingProviderViewModel} from './useScmMessagingProviders';
+
+const organization = OrganizationFixture();
+
+const slackProvider = GitHubIntegrationProviderFixture({key: 'slack', name: 'Slack'});
+const msteamsProvider = GitHubIntegrationProviderFixture({
+  key: 'msteams',
+  name: 'Microsoft Teams',
+});
+
+const slackIntegration = OrganizationIntegrationsFixture({
+  id: 'slack-1',
+  name: 'test-workspace',
+  provider: {
+    key: 'slack',
+    slug: 'slack',
+    name: 'Slack',
+    canAdd: true,
+    canDisable: false,
+    features: [],
+    aspects: {},
+  },
+});
+
+const msteamsIntegration = OrganizationIntegrationsFixture({
+  id: 'msteams-1',
+  name: 'Contoso Teams',
+  provider: {
+    key: 'msteams',
+    slug: 'msteams',
+    name: 'Microsoft Teams',
+    canAdd: true,
+    canDisable: false,
+    features: [],
+    aspects: {},
+  },
+  configData: {installationType: 'tenant'},
+});
+
+const installableSlack: ScmMessagingProviderViewModel = {
+  providerKey: 'slack',
+  provider: slackProvider,
+  status: 'installable',
+  integration: undefined,
+};
+
+const connectedSlack: ScmMessagingProviderViewModel = {
+  providerKey: 'slack',
+  provider: slackProvider,
+  status: 'connected',
+  integration: slackIntegration,
+};
+
+const permissionLimitedMsteams: ScmMessagingProviderViewModel = {
+  providerKey: 'msteams',
+  provider: msteamsProvider,
+  status: 'permission-limited',
+  integration: msteamsIntegration,
+};
+
+const selectedSlackSetup: ScmMessagingSetup = {
+  mode: 'selected',
+  providerKey: 'slack',
+  integrationId: 'slack-1',
+  channelId: 'C123',
+  channelName: '#alerts',
+  actionTarget: '#alerts',
+};
+
+type PipelineCallbacks = {
+  onClose?: () => void;
+  onComplete?: (data: OrganizationIntegration) => void;
+  onError?: (error: string) => void;
+};
+
+function mockPipeline(): {callbacks: PipelineCallbacks} {
+  const callbacks: PipelineCallbacks = {};
+  jest.spyOn(pipelineModal, 'openPipelineModal').mockImplementation((opts: any) => {
+    callbacks.onComplete = opts.onComplete;
+    callbacks.onError = opts.onError;
+    callbacks.onClose = opts.onClose;
+  });
+  return {callbacks};
+}
+
+function renderRow(
+  viewModel: ScmMessagingProviderViewModel,
+  messagingSetup: ScmMessagingSetup = UNCONFIGURED_SCM_MESSAGING_SETUP,
+  overrides: {
+    onInstallComplete?: jest.Mock;
+    onMessagingSetupChange?: jest.Mock;
+    renderChannelPicker?: jest.Mock;
+  } = {}
+) {
+  const onInstallComplete = overrides.onInstallComplete ?? jest.fn();
+  const onMessagingSetupChange = overrides.onMessagingSetupChange ?? jest.fn();
+  const renderChannelPicker = overrides.renderChannelPicker;
+
+  return render(
+    <ScmMessagingProviderRow
+      viewModel={viewModel}
+      messagingSetup={messagingSetup}
+      onInstallComplete={onInstallComplete}
+      onMessagingSetupChange={onMessagingSetupChange}
+      renderChannelPicker={renderChannelPicker}
+    />,
+    {organization}
+  );
+}
+
+describe('ScmMessagingProviderRow', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  describe('installable state', () => {
+    it('renders provider name, description, and Connect button', () => {
+      renderRow(installableSlack);
+
+      expect(screen.getByText('Slack')).toBeInTheDocument();
+      expect(
+        screen.getByText(/Get real-time alerts and triage issues without leaving Slack/)
+      ).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: /Connect Slack/})).toBeInTheDocument();
+    });
+
+    it('opens the install flow when Connect is clicked', async () => {
+      const {callbacks} = mockPipeline();
+
+      renderRow(installableSlack);
+
+      await userEvent.click(screen.getByRole('button', {name: /Connect/}));
+
+      expect(pipelineModal.openPipelineModal).toHaveBeenCalledTimes(1);
+      expect(callbacks.onComplete).toBeDefined();
+    });
+
+    it('fires install start analytics with onboarding view and scm variant', async () => {
+      mockPipeline();
+      const trackSpy = jest.spyOn(
+        await import('sentry/utils/integrationUtil'),
+        'trackIntegrationAnalytics'
+      );
+
+      renderRow(installableSlack);
+      await userEvent.click(screen.getByRole('button', {name: /Connect/}));
+
+      expect(trackSpy).toHaveBeenCalledWith(
+        'integrations.installation_start',
+        expect.objectContaining({
+          integration: 'slack',
+          view: 'onboarding',
+          variant: 'scm',
+        })
+      );
+    });
+  });
+
+  describe('installing state', () => {
+    it('shows a spinner while the install modal is open', async () => {
+      mockPipeline();
+      renderRow(installableSlack);
+
+      await userEvent.click(screen.getByRole('button', {name: /Connect/}));
+
+      expect(screen.queryByRole('button', {name: /Connect/})).not.toBeInTheDocument();
+      expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
+    });
+  });
+
+  describe('install-error state', () => {
+    it('shows the error message and a Try again button after install fails', async () => {
+      const {callbacks} = mockPipeline();
+      renderRow(installableSlack);
+
+      await userEvent.click(screen.getByRole('button', {name: /Connect/}));
+      act(() => callbacks.onError?.('Something went wrong with the OAuth flow.'));
+
+      expect(
+        screen.getByText('Something went wrong with the OAuth flow.')
+      ).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: /Try again/})).toBeInTheDocument();
+    });
+
+    it('shows the error state when the modal is closed after a failure', async () => {
+      const {callbacks} = mockPipeline();
+      renderRow(installableSlack);
+
+      await userEvent.click(screen.getByRole('button', {name: /Connect/}));
+      act(() => {
+        callbacks.onError?.('OAuth failed');
+        callbacks.onClose?.();
+      });
+
+      expect(screen.getByText('OAuth failed')).toBeInTheDocument();
+    });
+
+    it('reopens the install flow when Try again is clicked', async () => {
+      const {callbacks} = mockPipeline();
+      renderRow(installableSlack);
+
+      await userEvent.click(screen.getByRole('button', {name: /Connect/}));
+      act(() => callbacks.onError?.('Error'));
+
+      await userEvent.click(screen.getByRole('button', {name: /Try again/}));
+
+      expect(pipelineModal.openPipelineModal).toHaveBeenCalledTimes(2);
+    });
+
+    it('surfaces a repeated identical error after Try again', async () => {
+      const {callbacks} = mockPipeline();
+      renderRow(installableSlack);
+
+      await userEvent.click(screen.getByRole('button', {name: /Connect/}));
+      act(() => callbacks.onError?.('Connection refused'));
+
+      await userEvent.click(screen.getByRole('button', {name: /Try again/}));
+      act(() => callbacks.onError?.('Connection refused'));
+
+      expect(screen.getByText('Connection refused')).toBeInTheDocument();
+    });
+
+    it('shows a fallback error when no message is available', async () => {
+      const {callbacks} = mockPipeline();
+      renderRow(installableSlack);
+
+      await userEvent.click(screen.getByRole('button', {name: /Connect/}));
+      act(() => callbacks.onError?.(''));
+
+      expect(
+        screen.getByText('Installation failed. Please try again.')
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('cancelled without error', () => {
+    it('returns to the installable state when the modal is closed cleanly', async () => {
+      const {callbacks} = mockPipeline();
+      renderRow(installableSlack);
+
+      await userEvent.click(screen.getByRole('button', {name: /Connect/}));
+      act(() => callbacks.onClose?.());
+
+      expect(screen.getByRole('button', {name: /Connect/})).toBeInTheDocument();
+    });
+  });
+
+  describe('loading state', () => {
+    it('shows a spinner after install completes while the view model is still stale', async () => {
+      const {callbacks} = mockPipeline();
+      const onInstallComplete = jest.fn();
+      renderRow(installableSlack, UNCONFIGURED_SCM_MESSAGING_SETUP, {
+        onInstallComplete,
+      });
+
+      await userEvent.click(screen.getByRole('button', {name: /Connect/}));
+      act(() => callbacks.onComplete?.(slackIntegration));
+
+      expect(onInstallComplete).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
+    });
+  });
+
+  describe('permission-limited state', () => {
+    it('shows workspace name, an explanation, and a disabled Add destination button', () => {
+      renderRow(permissionLimitedMsteams);
+
+      expect(screen.getByText('Microsoft Teams')).toBeInTheDocument();
+      expect(screen.getByText('Contoso Teams')).toBeInTheDocument();
+      expect(screen.getByText(/tenant-level connection/)).toBeInTheDocument();
+
+      const addBtn = screen.getByRole('button', {name: /Add destination/});
+      expect(addBtn).toBeDisabled();
+    });
+  });
+
+  describe('connected state', () => {
+    it('shows workspace name and Add destination button', () => {
+      renderRow(connectedSlack);
+
+      expect(screen.getByText('Slack')).toBeInTheDocument();
+      expect(screen.getByText('test-workspace')).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: /Add destination/})).toBeInTheDocument();
+    });
+  });
+
+  describe('configuring state', () => {
+    it('enters configuring state and calls renderChannelPicker when Add destination is clicked', async () => {
+      const renderChannelPicker = jest.fn(() => <div>channel-picker</div>);
+      renderRow(connectedSlack, UNCONFIGURED_SCM_MESSAGING_SETUP, {
+        renderChannelPicker,
+      });
+
+      await userEvent.click(screen.getByRole('button', {name: /Add destination/}));
+
+      expect(screen.getByText('channel-picker')).toBeInTheDocument();
+      expect(renderChannelPicker).toHaveBeenCalledWith(
+        expect.objectContaining({
+          integration: slackIntegration,
+          onCancel: expect.any(Function),
+          onConfigured: expect.any(Function),
+        })
+      );
+    });
+
+    it('exits configuring state when onCancel is called', async () => {
+      let capturedOnCancel: (() => void) | undefined;
+      const renderChannelPicker = jest.fn(({onCancel}: {onCancel: () => void}) => {
+        capturedOnCancel = onCancel;
+        return <div>channel-picker</div>;
+      });
+
+      renderRow(connectedSlack, UNCONFIGURED_SCM_MESSAGING_SETUP, {
+        renderChannelPicker,
+      });
+
+      await userEvent.click(screen.getByRole('button', {name: /Add destination/}));
+      expect(screen.getByText('channel-picker')).toBeInTheDocument();
+
+      act(() => capturedOnCancel?.());
+
+      expect(screen.queryByText('channel-picker')).not.toBeInTheDocument();
+      expect(screen.getByRole('button', {name: /Add destination/})).toBeInTheDocument();
+    });
+
+    it('saves the setup and exits configuring when onConfigured is called', async () => {
+      const onMessagingSetupChange = jest.fn();
+      let capturedOnConfigured:
+        | ((setup: ScmMessagingSetup & {mode: 'selected'}) => void)
+        | undefined;
+
+      const renderChannelPicker = jest.fn(
+        ({onConfigured}: {onConfigured: (s: any) => void}) => {
+          capturedOnConfigured = onConfigured;
+          return <div>channel-picker</div>;
+        }
+      );
+
+      renderRow(connectedSlack, UNCONFIGURED_SCM_MESSAGING_SETUP, {
+        onMessagingSetupChange,
+        renderChannelPicker,
+      });
+
+      await userEvent.click(screen.getByRole('button', {name: /Add destination/}));
+
+      act(() => capturedOnConfigured?.(selectedSlackSetup));
+
+      expect(onMessagingSetupChange).toHaveBeenCalledWith(selectedSlackSetup);
+      expect(screen.queryByText('channel-picker')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('configured state', () => {
+    it('shows workspace · channel and Edit + Remove buttons', () => {
+      renderRow(connectedSlack, selectedSlackSetup);
+
+      expect(screen.getByText('Slack')).toBeInTheDocument();
+      expect(screen.getByText('test-workspace')).toBeInTheDocument();
+      expect(screen.getByText('#alerts')).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: /Edit/})).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: /Remove/})).toBeInTheDocument();
+    });
+
+    it('enters configuring state when Edit is clicked', async () => {
+      const renderChannelPicker = jest.fn(() => <div>channel-picker</div>);
+      renderRow(connectedSlack, selectedSlackSetup, {renderChannelPicker});
+
+      await userEvent.click(screen.getByRole('button', {name: /Edit/}));
+
+      expect(screen.getByText('channel-picker')).toBeInTheDocument();
+    });
+  });
+
+  describe('removing state', () => {
+    it('shows a confirmation when Remove is clicked', async () => {
+      renderRow(connectedSlack, selectedSlackSetup);
+
+      await userEvent.click(screen.getByRole('button', {name: /Remove/}));
+
+      expect(screen.getByText(/Remove #alerts/)).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: /Cancel/})).toBeInTheDocument();
+    });
+
+    it('returns to configured when Cancel is clicked', async () => {
+      renderRow(connectedSlack, selectedSlackSetup);
+
+      await userEvent.click(screen.getByRole('button', {name: /Remove/}));
+      await userEvent.click(screen.getByRole('button', {name: /Cancel/}));
+
+      expect(screen.getByRole('button', {name: /Edit/})).toBeInTheDocument();
+      expect(
+        screen.queryByText(/The .* workspace will remain connected/)
+      ).not.toBeInTheDocument();
+    });
+
+    it('calls onMessagingSetupChange with unconfigured when confirmed', async () => {
+      const onMessagingSetupChange = jest.fn();
+      renderRow(connectedSlack, selectedSlackSetup, {onMessagingSetupChange});
+
+      await userEvent.click(screen.getByRole('button', {name: /Remove/}));
+
+      const [confirmBtn] = screen.getAllByRole('button', {name: /Remove/});
+      await userEvent.click(confirmBtn);
+
+      expect(onMessagingSetupChange).toHaveBeenCalledWith({mode: 'unconfigured'});
+    });
+  });
+});

--- a/static/app/components/onboarding/scm/scmMessagingProviderRow.spec.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingProviderRow.spec.tsx
@@ -9,6 +9,7 @@ import {UNCONFIGURED_SCM_MESSAGING_SETUP} from 'sentry/components/onboarding/scm
 import type {ScmMessagingSetup} from 'sentry/components/onboarding/scm/scmMessagingSetup';
 import * as pipelineModal from 'sentry/components/pipeline/modal';
 import type {OrganizationIntegration} from 'sentry/types/integrations';
+import type {Organization} from 'sentry/types/organization';
 
 import {ScmMessagingProviderRow} from './scmMessagingProviderRow';
 import type {ScmMessagingProviderViewModel} from './useScmMessagingProviders';
@@ -54,21 +55,24 @@ const installableSlack: ScmMessagingProviderViewModel = {
   providerKey: 'slack',
   provider: slackProvider,
   status: 'installable',
-  integration: undefined,
+  eligibleIntegrations: [],
+  permissionLimitedIntegration: undefined,
 };
 
 const connectedSlack: ScmMessagingProviderViewModel = {
   providerKey: 'slack',
   provider: slackProvider,
   status: 'connected',
-  integration: slackIntegration,
+  eligibleIntegrations: [slackIntegration],
+  permissionLimitedIntegration: undefined,
 };
 
 const permissionLimitedMsteams: ScmMessagingProviderViewModel = {
   providerKey: 'msteams',
   provider: msteamsProvider,
   status: 'permission-limited',
-  integration: msteamsIntegration,
+  eligibleIntegrations: [],
+  permissionLimitedIntegration: msteamsIntegration,
 };
 
 const selectedSlackSetup: ScmMessagingSetup = {
@@ -77,7 +81,6 @@ const selectedSlackSetup: ScmMessagingSetup = {
   integrationId: 'slack-1',
   channelId: 'C123',
   channelName: '#alerts',
-  actionTarget: '#alerts',
 };
 
 type PipelineCallbacks = {
@@ -100,14 +103,17 @@ function renderRow(
   viewModel: ScmMessagingProviderViewModel,
   messagingSetup: ScmMessagingSetup = UNCONFIGURED_SCM_MESSAGING_SETUP,
   overrides: {
+    isRefetchingIntegrations?: boolean;
     onInstallComplete?: jest.Mock;
     onMessagingSetupChange?: jest.Mock;
+    organization?: Partial<Organization>;
     renderChannelPicker?: jest.Mock;
   } = {}
 ) {
   const onInstallComplete = overrides.onInstallComplete ?? jest.fn();
   const onMessagingSetupChange = overrides.onMessagingSetupChange ?? jest.fn();
   const renderChannelPicker = overrides.renderChannelPicker;
+  const org = overrides.organization ?? organization;
 
   return render(
     <ScmMessagingProviderRow
@@ -116,8 +122,9 @@ function renderRow(
       onInstallComplete={onInstallComplete}
       onMessagingSetupChange={onMessagingSetupChange}
       renderChannelPicker={renderChannelPicker}
+      isRefetchingIntegrations={overrides.isRefetchingIntegrations ?? false}
     />,
-    {organization}
+    {organization: org}
   );
 }
 
@@ -164,6 +171,54 @@ describe('ScmMessagingProviderRow', () => {
           variant: 'scm',
         })
       );
+    });
+  });
+
+  describe('install-forbidden state', () => {
+    const noAccessOrg = OrganizationFixture({access: []});
+
+    it('renders the description and a disabled Connect button', () => {
+      renderRow(installableSlack, UNCONFIGURED_SCM_MESSAGING_SETUP, {
+        organization: noAccessOrg,
+      });
+
+      expect(
+        screen.getByText(/Get real-time alerts and triage issues without leaving Slack/)
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText('Ask an organization admin to connect Slack.')
+      ).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: /Connect Slack/})).toBeDisabled();
+    });
+
+    it('does not open the install pipeline when Connect is clicked', async () => {
+      mockPipeline();
+      renderRow(installableSlack, UNCONFIGURED_SCM_MESSAGING_SETUP, {
+        organization: noAccessOrg,
+      });
+
+      // The button is disabled so the click is a no-op, but confirm openPipelineModal
+      // was never called regardless of how the disabled state is enforced.
+      await userEvent.click(screen.getByRole('button', {name: /Connect Slack/}));
+      expect(pipelineModal.openPipelineModal).not.toHaveBeenCalled();
+    });
+
+    it('still shows the channel picker for a connected provider', () => {
+      // A member without org:integrations cannot install, but can still configure
+      // a destination on an integration that is already connected.
+      // The auto-expanded channel picker fetches channels — provide an empty result.
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/integrations/slack-1/channels/',
+        body: {results: []},
+      });
+
+      renderRow(connectedSlack, UNCONFIGURED_SCM_MESSAGING_SETUP, {
+        organization: noAccessOrg,
+      });
+
+      expect(screen.getByText('Connected')).toBeInTheDocument();
+      // Channel picker renders inline — the Workspace label is its first visible element.
+      expect(screen.getByText('Workspace')).toBeInTheDocument();
     });
   });
 
@@ -244,6 +299,10 @@ describe('ScmMessagingProviderRow', () => {
     });
 
     it('clears the error when the integration surfaces via a shared refetch', async () => {
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/integrations/slack-1/channels/',
+        body: {results: []},
+      });
       const {callbacks} = mockPipeline();
 
       const {rerender} = render(
@@ -292,10 +351,11 @@ describe('ScmMessagingProviderRow', () => {
   });
 
   describe('loading state', () => {
-    it('shows a spinner after install completes while the view model is still stale', async () => {
+    it('shows a spinner after install completes while integrations are refetching', async () => {
       const {callbacks} = mockPipeline();
       const onInstallComplete = jest.fn();
-      renderRow(installableSlack, UNCONFIGURED_SCM_MESSAGING_SETUP, {
+      // Simulate the parent's refetch being in-flight after install.
+      const {rerender} = renderRow(installableSlack, UNCONFIGURED_SCM_MESSAGING_SETUP, {
         onInstallComplete,
       });
 
@@ -303,6 +363,18 @@ describe('ScmMessagingProviderRow', () => {
       act(() => callbacks.onComplete?.(slackIntegration));
 
       expect(onInstallComplete).toHaveBeenCalledTimes(1);
+
+      // Parent signals that refetch is now active.
+      rerender(
+        <ScmMessagingProviderRow
+          viewModel={installableSlack}
+          messagingSetup={UNCONFIGURED_SCM_MESSAGING_SETUP}
+          onInstallComplete={onInstallComplete}
+          onMessagingSetupChange={jest.fn()}
+          isRefetchingIntegrations
+        />
+      );
+
       expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
     });
 
@@ -312,7 +384,8 @@ describe('ScmMessagingProviderRow', () => {
         providerKey: 'msteams',
         provider: msteamsProvider,
         status: 'installable',
-        integration: undefined,
+        eligibleIntegrations: [],
+        permissionLimitedIntegration: undefined,
       };
 
       const {rerender} = render(
@@ -321,12 +394,26 @@ describe('ScmMessagingProviderRow', () => {
           messagingSetup={UNCONFIGURED_SCM_MESSAGING_SETUP}
           onInstallComplete={jest.fn()}
           onMessagingSetupChange={jest.fn()}
+          isRefetchingIntegrations={false}
         />,
         {organization}
       );
 
       await userEvent.click(screen.getByRole('button', {name: /Connect/}));
       act(() => callbacks.onComplete?.(msteamsIntegration));
+
+      // Simulate parent refetch starting.
+      rerender(
+        <ScmMessagingProviderRow
+          viewModel={installableMsteams}
+          messagingSetup={UNCONFIGURED_SCM_MESSAGING_SETUP}
+          onInstallComplete={jest.fn()}
+          onMessagingSetupChange={jest.fn()}
+          isRefetchingIntegrations
+        />
+      );
+
+      expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
 
       // The refetched view model settles to a tenant (permission-limited) result.
       rerender(
@@ -335,15 +422,19 @@ describe('ScmMessagingProviderRow', () => {
           messagingSetup={UNCONFIGURED_SCM_MESSAGING_SETUP}
           onInstallComplete={jest.fn()}
           onMessagingSetupChange={jest.fn()}
+          isRefetchingIntegrations={false}
         />
       );
 
       expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
       expect(screen.getByText(/tenant-level connection/)).toBeInTheDocument();
-      expect(screen.getByRole('button', {name: /Add destination/})).toBeDisabled();
+      expect(screen.getByRole('button', {name: /Connect/})).toBeDisabled();
     });
 
-    it('shows Connect (not a spinner) if the integration disappears after install', async () => {
+    it('shows Connect once the refetch settles even when no integration surfaced', async () => {
+      // Regression: previously the awaitingInstall latch was only cleared when
+      // the integration appeared, so a refetch that returned nothing left the
+      // row spinning forever with no way to retry.
       const {callbacks} = mockPipeline();
 
       const {rerender} = render(
@@ -352,6 +443,7 @@ describe('ScmMessagingProviderRow', () => {
           messagingSetup={UNCONFIGURED_SCM_MESSAGING_SETUP}
           onInstallComplete={jest.fn()}
           onMessagingSetupChange={jest.fn()}
+          isRefetchingIntegrations={false}
         />,
         {organization}
       );
@@ -359,23 +451,27 @@ describe('ScmMessagingProviderRow', () => {
       await userEvent.click(screen.getByRole('button', {name: /Connect/}));
       act(() => callbacks.onComplete?.(slackIntegration));
 
-      // Integration surfaces...
-      rerender(
-        <ScmMessagingProviderRow
-          viewModel={connectedSlack}
-          messagingSetup={UNCONFIGURED_SCM_MESSAGING_SETUP}
-          onInstallComplete={jest.fn()}
-          onMessagingSetupChange={jest.fn()}
-        />
-      );
-
-      // ...then is removed externally, returning the row to installable.
+      // Simulate parent refetch starting (spinner should show).
       rerender(
         <ScmMessagingProviderRow
           viewModel={installableSlack}
           messagingSetup={UNCONFIGURED_SCM_MESSAGING_SETUP}
           onInstallComplete={jest.fn()}
           onMessagingSetupChange={jest.fn()}
+          isRefetchingIntegrations
+        />
+      );
+
+      expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
+
+      // Refetch settles but still no integration — must fall back to Connect.
+      rerender(
+        <ScmMessagingProviderRow
+          viewModel={installableSlack}
+          messagingSetup={UNCONFIGURED_SCM_MESSAGING_SETUP}
+          onInstallComplete={jest.fn()}
+          onMessagingSetupChange={jest.fn()}
+          isRefetchingIntegrations={false}
         />
       );
 
@@ -385,68 +481,111 @@ describe('ScmMessagingProviderRow', () => {
   });
 
   describe('permission-limited state', () => {
-    it('shows workspace name, an explanation, and a disabled Add destination button', () => {
+    it('shows workspace name, an explanation, and a disabled Connect button', () => {
       renderRow(permissionLimitedMsteams);
 
       expect(screen.getByText('Microsoft Teams')).toBeInTheDocument();
       expect(screen.getByText('Contoso Teams')).toBeInTheDocument();
       expect(screen.getByText(/tenant-level connection/)).toBeInTheDocument();
 
-      const addBtn = screen.getByRole('button', {name: /Add destination/});
+      const addBtn = screen.getByRole('button', {name: /Connect/});
       expect(addBtn).toBeDisabled();
     });
   });
 
-  describe('connected state', () => {
-    it('shows workspace name and Add destination button', () => {
-      renderRow(connectedSlack);
-
-      expect(screen.getByText('Slack')).toBeInTheDocument();
-      expect(screen.getByText('test-workspace')).toBeInTheDocument();
-      expect(screen.getByRole('button', {name: /Add destination/})).toBeInTheDocument();
-    });
-  });
-
-  describe('configuring state', () => {
-    it('enters configuring state and calls renderChannelPicker when Add destination is clicked', async () => {
+  describe('configuring state (connected, not yet configured)', () => {
+    it('immediately renders the channel picker without any interaction', () => {
       const renderChannelPicker = jest.fn(() => <div>channel-picker</div>);
-      renderRow(connectedSlack, UNCONFIGURED_SCM_MESSAGING_SETUP, {
-        renderChannelPicker,
-      });
-
-      await userEvent.click(screen.getByRole('button', {name: /Add destination/}));
+      renderRow(connectedSlack, UNCONFIGURED_SCM_MESSAGING_SETUP, {renderChannelPicker});
 
       expect(screen.getByText('channel-picker')).toBeInTheDocument();
       expect(renderChannelPicker).toHaveBeenCalledWith(
         expect.objectContaining({
-          integration: slackIntegration,
-          onCancel: expect.any(Function),
+          integrations: [slackIntegration],
+          onCancel: undefined,
           onConfigured: expect.any(Function),
         })
       );
     });
 
-    it('exits configuring state when onCancel is called', async () => {
-      let capturedOnCancel: (() => void) | undefined;
-      const renderChannelPicker = jest.fn(({onCancel}: {onCancel: () => void}) => {
-        capturedOnCancel = onCancel;
-        return <div>channel-picker</div>;
+    it('passes only eligible integrations to the picker when a provider has mixed installations', () => {
+      const msteamsTeamIntegration = OrganizationIntegrationsFixture({
+        id: 'msteams-team',
+        name: 'Team Workspace',
+        provider: {
+          key: 'msteams',
+          slug: 'msteams',
+          name: 'Microsoft Teams',
+          canAdd: true,
+          canDisable: false,
+          features: [],
+          aspects: {},
+        },
+        configData: {installationType: 'team'},
       });
 
-      renderRow(connectedSlack, UNCONFIGURED_SCM_MESSAGING_SETUP, {
-        renderChannelPicker,
-      });
+      const mixedMsteams: ScmMessagingProviderViewModel = {
+        providerKey: 'msteams',
+        provider: msteamsProvider,
+        status: 'connected',
+        eligibleIntegrations: [msteamsTeamIntegration],
+        permissionLimitedIntegration: undefined,
+      };
 
-      await userEvent.click(screen.getByRole('button', {name: /Add destination/}));
-      expect(screen.getByText('channel-picker')).toBeInTheDocument();
+      const renderChannelPicker = jest.fn(() => <div>channel-picker</div>);
+      renderRow(mixedMsteams, UNCONFIGURED_SCM_MESSAGING_SETUP, {renderChannelPicker});
 
-      act(() => capturedOnCancel?.());
-
-      expect(screen.queryByText('channel-picker')).not.toBeInTheDocument();
-      expect(screen.getByRole('button', {name: /Add destination/})).toBeInTheDocument();
+      expect(renderChannelPicker).toHaveBeenCalledWith(
+        expect.objectContaining({
+          integrations: [msteamsTeamIntegration],
+        })
+      );
     });
 
-    it('saves the setup and exits configuring when onConfigured is called', async () => {
+    it('does not treat a setup referencing an ineligible integration as configured', () => {
+      const msteamsTeamIntegration = OrganizationIntegrationsFixture({
+        id: 'msteams-team',
+        name: 'Team Workspace',
+        provider: {
+          key: 'msteams',
+          slug: 'msteams',
+          name: 'Microsoft Teams',
+          canAdd: true,
+          canDisable: false,
+          features: [],
+          aspects: {},
+        },
+        configData: {installationType: 'team'},
+      });
+
+      const mixedMsteams: ScmMessagingProviderViewModel = {
+        providerKey: 'msteams',
+        provider: msteamsProvider,
+        status: 'connected',
+        eligibleIntegrations: [msteamsTeamIntegration],
+        permissionLimitedIntegration: undefined,
+      };
+
+      // A destination previously saved against the tenant (ineligible) integration.
+      const tenantSetup: ScmMessagingSetup = {
+        mode: 'selected',
+        providerKey: 'msteams',
+        integrationId: 'msteams-tenant',
+        channelId: 'C1',
+        channelName: '#general',
+      };
+
+      const renderChannelPicker = jest.fn(() => <div>channel-picker</div>);
+      renderRow(mixedMsteams, tenantSetup, {renderChannelPicker});
+
+      // Should NOT be in configured state — the tenant integration is not eligible.
+      expect(screen.queryByRole('button', {name: /Edit/})).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', {name: /Remove/})).not.toBeInTheDocument();
+      // Picker is auto-expanded for the unconfigured connected state.
+      expect(screen.getByText('channel-picker')).toBeInTheDocument();
+    });
+
+    it('saves the setup and transitions to configured when onConfigured is called', () => {
       const onMessagingSetupChange = jest.fn();
       let capturedOnConfigured:
         | ((setup: ScmMessagingSetup & {mode: 'selected'}) => void)
@@ -459,22 +598,31 @@ describe('ScmMessagingProviderRow', () => {
         }
       );
 
-      renderRow(connectedSlack, UNCONFIGURED_SCM_MESSAGING_SETUP, {
+      const {rerender} = renderRow(connectedSlack, UNCONFIGURED_SCM_MESSAGING_SETUP, {
         onMessagingSetupChange,
         renderChannelPicker,
       });
 
-      await userEvent.click(screen.getByRole('button', {name: /Add destination/}));
-
       act(() => capturedOnConfigured?.(selectedSlackSetup));
-
       expect(onMessagingSetupChange).toHaveBeenCalledWith(selectedSlackSetup);
+
+      // Simulate the parent updating the prop after receiving the save callback.
+      rerender(
+        <ScmMessagingProviderRow
+          viewModel={connectedSlack}
+          messagingSetup={selectedSlackSetup}
+          onInstallComplete={jest.fn()}
+          onMessagingSetupChange={onMessagingSetupChange}
+          renderChannelPicker={renderChannelPicker}
+        />
+      );
+
       expect(screen.queryByText('channel-picker')).not.toBeInTheDocument();
     });
   });
 
   describe('configured state', () => {
-    it('shows workspace · channel and Edit + Remove buttons', () => {
+    it('shows workspace / channel and Edit + Remove buttons', () => {
       renderRow(connectedSlack, selectedSlackSetup);
 
       expect(screen.getByText('Slack')).toBeInTheDocument();
@@ -484,13 +632,24 @@ describe('ScmMessagingProviderRow', () => {
       expect(screen.getByRole('button', {name: /Remove/})).toBeInTheDocument();
     });
 
-    it('enters configuring state when Edit is clicked', async () => {
+    it('shows the Connected tag', () => {
+      renderRow(connectedSlack, selectedSlackSetup);
+
+      expect(screen.getByText('Connected')).toBeInTheDocument();
+    });
+
+    it('enters configuring state when Edit is clicked and passes onCancel to the picker', async () => {
       const renderChannelPicker = jest.fn(() => <div>channel-picker</div>);
       renderRow(connectedSlack, selectedSlackSetup, {renderChannelPicker});
 
       await userEvent.click(screen.getByRole('button', {name: /Edit/}));
 
       expect(screen.getByText('channel-picker')).toBeInTheDocument();
+      expect(renderChannelPicker).toHaveBeenCalledWith(
+        expect.objectContaining({
+          onCancel: expect.any(Function),
+        })
+      );
     });
   });
 
@@ -500,7 +659,12 @@ describe('ScmMessagingProviderRow', () => {
 
       await userEvent.click(screen.getByRole('button', {name: /Remove/}));
 
-      expect(screen.getByText(/Remove #alerts/)).toBeInTheDocument();
+      expect(screen.getByText('Remove this destination?')).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          'This removes the destination from project setup. The integration stays connected to your organization.'
+        )
+      ).toBeInTheDocument();
       expect(screen.getByRole('button', {name: /Cancel/})).toBeInTheDocument();
     });
 
@@ -512,7 +676,9 @@ describe('ScmMessagingProviderRow', () => {
 
       expect(screen.getByRole('button', {name: /Edit/})).toBeInTheDocument();
       expect(
-        screen.queryByText(/The .* workspace will remain connected/)
+        screen.queryByText(
+          'This removes the destination from project setup. The integration stays connected to your organization.'
+        )
       ).not.toBeInTheDocument();
     });
 
@@ -521,9 +687,7 @@ describe('ScmMessagingProviderRow', () => {
       renderRow(connectedSlack, selectedSlackSetup, {onMessagingSetupChange});
 
       await userEvent.click(screen.getByRole('button', {name: /Remove/}));
-
-      const [confirmBtn] = screen.getAllByRole('button', {name: /Remove/});
-      await userEvent.click(confirmBtn);
+      await userEvent.click(screen.getByRole('button', {name: 'Remove destination'}));
 
       expect(onMessagingSetupChange).toHaveBeenCalledWith({mode: 'unconfigured'});
     });

--- a/static/app/components/onboarding/scm/scmMessagingProviderRow.spec.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingProviderRow.spec.tsx
@@ -270,6 +270,83 @@ describe('ScmMessagingProviderRow', () => {
       expect(onInstallComplete).toHaveBeenCalledTimes(1);
       expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
     });
+
+    it('stops spinning when the installed integration resolves to permission-limited', async () => {
+      const {callbacks} = mockPipeline();
+      const installableMsteams: ScmMessagingProviderViewModel = {
+        providerKey: 'msteams',
+        provider: msteamsProvider,
+        status: 'installable',
+        integration: undefined,
+      };
+
+      const {rerender} = render(
+        <ScmMessagingProviderRow
+          viewModel={installableMsteams}
+          messagingSetup={UNCONFIGURED_SCM_MESSAGING_SETUP}
+          onInstallComplete={jest.fn()}
+          onMessagingSetupChange={jest.fn()}
+        />,
+        {organization}
+      );
+
+      await userEvent.click(screen.getByRole('button', {name: /Connect/}));
+      act(() => callbacks.onComplete?.(msteamsIntegration));
+
+      // The refetched view model settles to a tenant (permission-limited) result.
+      rerender(
+        <ScmMessagingProviderRow
+          viewModel={permissionLimitedMsteams}
+          messagingSetup={UNCONFIGURED_SCM_MESSAGING_SETUP}
+          onInstallComplete={jest.fn()}
+          onMessagingSetupChange={jest.fn()}
+        />
+      );
+
+      expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
+      expect(screen.getByText(/tenant-level connection/)).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: /Add destination/})).toBeDisabled();
+    });
+
+    it('shows Connect (not a spinner) if the integration disappears after install', async () => {
+      const {callbacks} = mockPipeline();
+
+      const {rerender} = render(
+        <ScmMessagingProviderRow
+          viewModel={installableSlack}
+          messagingSetup={UNCONFIGURED_SCM_MESSAGING_SETUP}
+          onInstallComplete={jest.fn()}
+          onMessagingSetupChange={jest.fn()}
+        />,
+        {organization}
+      );
+
+      await userEvent.click(screen.getByRole('button', {name: /Connect/}));
+      act(() => callbacks.onComplete?.(slackIntegration));
+
+      // Integration surfaces...
+      rerender(
+        <ScmMessagingProviderRow
+          viewModel={connectedSlack}
+          messagingSetup={UNCONFIGURED_SCM_MESSAGING_SETUP}
+          onInstallComplete={jest.fn()}
+          onMessagingSetupChange={jest.fn()}
+        />
+      );
+
+      // ...then is removed externally, returning the row to installable.
+      rerender(
+        <ScmMessagingProviderRow
+          viewModel={installableSlack}
+          messagingSetup={UNCONFIGURED_SCM_MESSAGING_SETUP}
+          onInstallComplete={jest.fn()}
+          onMessagingSetupChange={jest.fn()}
+        />
+      );
+
+      expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
+      expect(screen.getByRole('button', {name: /Connect/})).toBeInTheDocument();
+    });
   });
 
   describe('permission-limited state', () => {

--- a/static/app/components/onboarding/scm/scmMessagingProviderRow.spec.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingProviderRow.spec.tsx
@@ -242,6 +242,41 @@ describe('ScmMessagingProviderRow', () => {
         screen.getByText('Installation failed. Please try again.')
       ).toBeInTheDocument();
     });
+
+    it('clears the error when the integration surfaces via a shared refetch', async () => {
+      const {callbacks} = mockPipeline();
+
+      const {rerender} = render(
+        <ScmMessagingProviderRow
+          viewModel={installableSlack}
+          messagingSetup={UNCONFIGURED_SCM_MESSAGING_SETUP}
+          onInstallComplete={jest.fn()}
+          onMessagingSetupChange={jest.fn()}
+        />,
+        {organization}
+      );
+
+      await userEvent.click(screen.getByRole('button', {name: /Connect/}));
+      act(() => callbacks.onError?.('OAuth failed'));
+
+      expect(screen.getByText('OAuth failed')).toBeInTheDocument();
+
+      // The integrations query is shared: another row's successful install
+      // refetches it and reveals this provider's integration despite the local
+      // error. The row must drop the error instead of offering a Try again that
+      // would reinstall an existing integration.
+      rerender(
+        <ScmMessagingProviderRow
+          viewModel={connectedSlack}
+          messagingSetup={UNCONFIGURED_SCM_MESSAGING_SETUP}
+          onInstallComplete={jest.fn()}
+          onMessagingSetupChange={jest.fn()}
+        />
+      );
+
+      expect(screen.queryByText('OAuth failed')).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', {name: /Try again/})).not.toBeInTheDocument();
+    });
   });
 
   describe('cancelled without error', () => {

--- a/static/app/components/onboarding/scm/scmMessagingProviderRow.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingProviderRow.tsx
@@ -1,0 +1,438 @@
+import {Fragment, useCallback, useEffect, useState} from 'react';
+import type {ReactNode} from 'react';
+import styled from '@emotion/styled';
+
+import {Alert} from '@sentry/scraps/alert';
+import {Button} from '@sentry/scraps/button';
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {PluginIcon} from 'sentry/icons/pluginIcon';
+import {t} from 'sentry/locale';
+import type {
+  IntegrationWithConfig,
+  OrganizationIntegration,
+} from 'sentry/types/integrations';
+import {useAddIntegration} from 'sentry/utils/integrations/useAddIntegration';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {MessagingIntegrationAnalyticsView} from 'sentry/views/alerts/rules/issue/setupMessagingIntegrationButton';
+
+import {SCM_MESSAGING_PROVIDER_DESCRIPTIONS} from './messagingProviders';
+import type {ScmMessagingSetup} from './scmMessagingSetup';
+import {ScmSelectableContainer} from './scmSelectableContainer';
+import type {ScmMessagingProviderViewModel} from './useScmMessagingProviders';
+
+/**
+ * The visual state of a single provider row. Derived from the view model,
+ * the install-flow state machine, and the current messaging setup in session
+ * storage.
+ */
+type RowVisualState =
+  | 'installable'
+  /** OAuth modal is open / install in progress. */
+  | 'installing'
+  /** Install attempt ended with an error (or was closed after one). */
+  | 'install-error'
+  /** Install confirmed; waiting for the integrations query to re-settle. */
+  | 'loading'
+  /** Active integration exists but is ineligible for Issue Alert actions. */
+  | 'permission-limited'
+  /** Active, eligible integration; no destination configured yet. */
+  | 'connected'
+  /** Destination is being configured (channel picker rendered inline). */
+  | 'configuring'
+  /** A destination has been saved to session state. */
+  | 'configured'
+  /** User is confirming a destination removal. */
+  | 'removing';
+
+function deriveVisualState({
+  viewModel,
+  installState,
+  messagingSetup,
+  isConfiguring,
+  isRemoving,
+}: {
+  installState: ReturnType<typeof useAddIntegration>['state'];
+  isConfiguring: boolean;
+  isRemoving: boolean;
+  messagingSetup: ScmMessagingSetup;
+  viewModel: ScmMessagingProviderViewModel;
+}): RowVisualState {
+  const forThisProvider =
+    installState.status !== 'idle' && installState.providerKey === viewModel.providerKey;
+
+  if (forThisProvider) {
+    if (installState.status === 'installing') {
+      return 'installing';
+    }
+    if (installState.status === 'error') {
+      return 'install-error';
+    }
+    if (installState.status === 'cancelled' && installState.lastError) {
+      return 'install-error';
+    }
+    // Install confirmed — stay in loading until the view model catches up.
+    if (installState.status === 'complete' && viewModel.status !== 'connected') {
+      return 'loading';
+    }
+  }
+
+  if (viewModel.status === 'installable') {
+    return 'installable';
+  }
+
+  if (viewModel.status === 'permission-limited') {
+    return 'permission-limited';
+  }
+
+  // status === 'connected'
+  const isConfigured =
+    messagingSetup.mode === 'selected' &&
+    messagingSetup.providerKey === viewModel.providerKey &&
+    messagingSetup.integrationId === viewModel.integration?.id;
+
+  // Configuring takes priority so Edit can open the picker even when a
+  // destination is already saved.
+  if (isConfiguring) {
+    return 'configuring';
+  }
+  if (isConfigured && isRemoving) {
+    return 'removing';
+  }
+  if (isConfigured) {
+    return 'configured';
+  }
+  return 'connected';
+}
+
+export interface ScmMessagingProviderRowProps {
+  messagingSetup: ScmMessagingSetup;
+  onInstallComplete: () => void;
+  onMessagingSetupChange: (setup: ScmMessagingSetup) => void;
+  viewModel: ScmMessagingProviderViewModel;
+  /**
+   * Render prop for the inline channel picker.
+   *
+   * When the user opens the configuring state this is called with the active
+   * integration and two callbacks: `onConfigured` (save the chosen destination
+   * to session state) and `onCancel` (close without saving).
+   *
+   * Omitting this prop leaves the configuring state with an empty body.
+   */
+  renderChannelPicker?: (props: {
+    integration: OrganizationIntegration;
+    onCancel: () => void;
+    onConfigured: (setup: ScmMessagingSetup & {mode: 'selected'}) => void;
+  }) => ReactNode;
+}
+
+export function ScmMessagingProviderRow({
+  viewModel,
+  messagingSetup,
+  onMessagingSetupChange,
+  onInstallComplete,
+  renderChannelPicker,
+}: ScmMessagingProviderRowProps) {
+  const organization = useOrganization();
+  const {startFlow, state: installState} = useAddIntegration();
+  const [isConfiguring, setIsConfiguring] = useState(false);
+  const [isRemoving, setIsRemoving] = useState(false);
+
+  const isConfigured =
+    messagingSetup.mode === 'selected' &&
+    messagingSetup.providerKey === viewModel.providerKey &&
+    messagingSetup.integrationId === viewModel.integration?.id;
+
+  const visualState = deriveVisualState({
+    viewModel,
+    installState,
+    messagingSetup,
+    isConfiguring,
+    isRemoving,
+  });
+
+  // When the integration goes away (e.g. removed externally), close any
+  // expanded state so the row does not get stuck showing a stale UI.
+  useEffect(() => {
+    if (viewModel.status !== 'connected') {
+      setIsConfiguring(false);
+      setIsRemoving(false);
+    }
+  }, [viewModel.status]);
+
+  // If the configured destination is cleared externally (validation reset),
+  // exit the removing confirmation.
+  useEffect(() => {
+    if (!isConfigured) {
+      setIsRemoving(false);
+    }
+  }, [isConfigured]);
+
+  const handleConnect = useCallback(() => {
+    startFlow({
+      provider: viewModel.provider,
+      organization,
+      onInstall: (_integration: IntegrationWithConfig) => {
+        onInstallComplete();
+      },
+      suppressSuccessMessage: true,
+      analyticsParams: {
+        view: MessagingIntegrationAnalyticsView.ONBOARDING,
+        already_installed: false,
+        variant: 'scm',
+      },
+    });
+  }, [startFlow, viewModel.provider, organization, onInstallComplete]);
+
+  const handleAddDestination = () => setIsConfiguring(true);
+  const handleEditDestination = () => setIsConfiguring(true);
+  const handleCancelConfiguring = () => setIsConfiguring(false);
+  const handleStartRemoving = () => setIsRemoving(true);
+  const handleCancelRemoving = () => setIsRemoving(false);
+  const handleConfirmRemove = () => {
+    onMessagingSetupChange({mode: 'unconfigured'});
+    setIsRemoving(false);
+  };
+
+  const handleConfigured = useCallback(
+    (setup: ScmMessagingSetup & {mode: 'selected'}) => {
+      onMessagingSetupChange(setup);
+      setIsConfiguring(false);
+    },
+    [onMessagingSetupChange]
+  );
+
+  const errorMessage =
+    installState.status === 'error'
+      ? installState.error
+      : installState.status === 'cancelled' && installState.lastError
+        ? installState.lastError
+        : undefined;
+
+  return (
+    <ScmSelectableContainer isSelected={isConfigured}>
+      <RowBody>
+        {(visualState === 'loading' || visualState === 'installing') && (
+          <Flex justify="center" align="center" padding="lg">
+            <LoadingIndicator mini style={{margin: 0}} />
+          </Flex>
+        )}
+
+        {visualState === 'install-error' && (
+          <Stack padding="md" gap="md" align="start">
+            <Alert
+              variant="danger"
+              trailingItems={
+                <Alert.Button onClick={handleConnect}>{t('Try again')}</Alert.Button>
+              }
+            >
+              {errorMessage || t('Installation failed. Please try again.')}
+            </Alert>
+          </Stack>
+        )}
+
+        {visualState !== 'loading' &&
+          visualState !== 'installing' &&
+          visualState !== 'install-error' && (
+            <Flex padding="lg" gap="md" align="start" justify="between">
+              <Flex gap="md" align="start" style={{flex: 1, minWidth: 0}}>
+                <IconWrapper>
+                  <PluginIcon pluginId={viewModel.providerKey} size={24} />
+                </IconWrapper>
+                <Stack gap="xs">
+                  <Text bold size="sm">
+                    {viewModel.provider.name}
+                  </Text>
+                  <RowSubtitle
+                    visualState={visualState}
+                    viewModel={viewModel}
+                    messagingSetup={messagingSetup}
+                  />
+                </Stack>
+              </Flex>
+
+              <Flex gap="sm" align="center" style={{flexShrink: 0}}>
+                <RowActions
+                  visualState={visualState}
+                  viewModel={viewModel}
+                  onConnect={handleConnect}
+                  onAddDestination={handleAddDestination}
+                  onEditDestination={handleEditDestination}
+                  onStartRemoving={handleStartRemoving}
+                  onCancelRemoving={handleCancelRemoving}
+                  onConfirmRemove={handleConfirmRemove}
+                />
+              </Flex>
+            </Flex>
+          )}
+
+        {visualState === 'configuring' && viewModel.integration && (
+          <ChannelPickerSlot>
+            {renderChannelPicker?.({
+              integration: viewModel.integration,
+              onCancel: handleCancelConfiguring,
+              onConfigured: handleConfigured,
+            })}
+          </ChannelPickerSlot>
+        )}
+      </RowBody>
+    </ScmSelectableContainer>
+  );
+}
+
+function RowSubtitle({
+  visualState,
+  viewModel,
+  messagingSetup,
+}: {
+  messagingSetup: ScmMessagingSetup;
+  viewModel: ScmMessagingProviderViewModel;
+  visualState: RowVisualState;
+}) {
+  if (visualState === 'installable') {
+    return (
+      <Text variant="muted" size="sm">
+        {SCM_MESSAGING_PROVIDER_DESCRIPTIONS[viewModel.providerKey]}
+      </Text>
+    );
+  }
+
+  if (visualState === 'permission-limited') {
+    return (
+      <Stack gap="2xs">
+        <Text size="sm">{viewModel.integration?.name}</Text>
+        <Text variant="muted" size="sm">
+          {t(
+            'This Microsoft Teams workspace uses a tenant-level connection and cannot receive issue alerts directly. Reinstall with a team-level connection to enable destinations.'
+          )}
+        </Text>
+      </Stack>
+    );
+  }
+
+  if (visualState === 'connected') {
+    return <Text size="sm">{viewModel.integration?.name}</Text>;
+  }
+
+  if (visualState === 'configured' && messagingSetup.mode === 'selected') {
+    return (
+      <Flex gap="xs" align="center">
+        <Text size="sm">{viewModel.integration?.name}</Text>
+        <Text variant="muted" size="sm" aria-hidden>
+          ·
+        </Text>
+        <Text size="sm">{messagingSetup.channelName}</Text>
+      </Flex>
+    );
+  }
+
+  if (visualState === 'removing' && messagingSetup.mode === 'selected') {
+    return (
+      <Text variant="muted" size="sm">
+        {t(
+          'Remove %s from your destinations? The %s workspace will remain connected.',
+          messagingSetup.channelName,
+          viewModel.integration?.name ?? viewModel.provider.name
+        )}
+      </Text>
+    );
+  }
+
+  return null;
+}
+
+interface RowActionsProps {
+  onAddDestination: () => void;
+  onCancelRemoving: () => void;
+  onConfirmRemove: () => void;
+  onConnect: () => void;
+  onEditDestination: () => void;
+  onStartRemoving: () => void;
+  viewModel: ScmMessagingProviderViewModel;
+  visualState: RowVisualState;
+}
+
+function RowActions({
+  visualState,
+  viewModel,
+  onConnect,
+  onAddDestination,
+  onEditDestination,
+  onStartRemoving,
+  onCancelRemoving,
+  onConfirmRemove,
+}: RowActionsProps) {
+  if (visualState === 'installable') {
+    return (
+      <Button
+        size="sm"
+        disabled={!viewModel.provider.canAdd}
+        onClick={onConnect}
+        aria-label={t('Connect %s', viewModel.provider.name)}
+      >
+        {t('Connect')}
+      </Button>
+    );
+  }
+
+  if (visualState === 'permission-limited') {
+    return (
+      <Button size="sm" disabled>
+        {t('Add destination')}
+      </Button>
+    );
+  }
+
+  if (visualState === 'connected') {
+    return (
+      <Button size="sm" onClick={onAddDestination}>
+        {t('Add destination')}
+      </Button>
+    );
+  }
+
+  if (visualState === 'configured') {
+    return (
+      <Fragment>
+        <Button size="sm" variant="secondary" onClick={onEditDestination}>
+          {t('Edit')}
+        </Button>
+        <Button size="sm" variant="danger" onClick={onStartRemoving}>
+          {t('Remove')}
+        </Button>
+      </Fragment>
+    );
+  }
+
+  if (visualState === 'removing') {
+    return (
+      <Fragment>
+        <Button size="sm" onClick={onCancelRemoving}>
+          {t('Cancel')}
+        </Button>
+        <Button size="sm" variant="danger" onClick={onConfirmRemove}>
+          {t('Remove')}
+        </Button>
+      </Fragment>
+    );
+  }
+
+  return null;
+}
+
+const RowBody = styled('div')`
+  display: flex;
+  flex-direction: column;
+`;
+
+const IconWrapper = styled('div')`
+  flex-shrink: 0;
+  margin-top: 2px;
+`;
+
+const ChannelPickerSlot = styled('div')`
+  border-top: 1px solid ${p => p.theme.border};
+  padding: ${p => p.theme.space['lg']};
+`;

--- a/static/app/components/onboarding/scm/scmMessagingProviderRow.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingProviderRow.tsx
@@ -1,10 +1,9 @@
 import {Fragment, useCallback, useEffect, useState} from 'react';
 import type {ReactNode} from 'react';
-import styled from '@emotion/styled';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
-import {Flex, Stack} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
@@ -62,30 +61,31 @@ function deriveVisualState({
   messagingSetup: ScmMessagingSetup;
   viewModel: ScmMessagingProviderViewModel;
 }): RowVisualState {
-  const forThisProvider =
-    installState.status !== 'idle' && installState.providerKey === viewModel.providerKey;
-
-  if (forThisProvider) {
-    if (installState.status === 'installing') {
-      return 'installing';
-    }
+  // `installState` is local to this row's `useAddIntegration`, so it always
+  // refers to this provider's flow.
+  if (installState.status === 'installing') {
+    return 'installing';
+  }
+  // Only surface an install error while still uninstalled; a shared-query
+  // refetch may reveal the integration after a local error.
+  if (viewModel.status === 'installable') {
     if (installState.status === 'error') {
       return 'install-error';
     }
     if (installState.status === 'cancelled' && installState.lastError) {
       return 'install-error';
     }
-    // Hold the spinner only while waiting for the just-installed integration to
-    // surface. Once the view model settles to anything other than `installable`
-    // (connected or permission-limited) that state is terminal, so falling
-    // through avoids spinning forever on an ineligible or vanished integration.
-    if (
-      installState.status === 'complete' &&
-      awaitingInstall &&
-      viewModel.status === 'installable'
-    ) {
-      return 'loading';
-    }
+  }
+  // Hold the spinner only while waiting for the just-installed integration to
+  // surface. Once the view model settles to anything other than `installable`
+  // (connected or permission-limited) that state is terminal, so falling
+  // through avoids spinning forever on an ineligible or vanished integration.
+  if (
+    installState.status === 'complete' &&
+    awaitingInstall &&
+    viewModel.status === 'installable'
+  ) {
+    return 'loading';
   }
 
   if (viewModel.status === 'installable') {
@@ -114,6 +114,18 @@ function deriveVisualState({
     return 'configured';
   }
   return 'connected';
+}
+
+function getInstallErrorMessage(
+  installState: ReturnType<typeof useAddIntegration>['state']
+): string | undefined {
+  if (installState.status === 'error') {
+    return installState.error;
+  }
+  if (installState.status === 'cancelled') {
+    return installState.lastError;
+  }
+  return undefined;
 }
 
 export interface ScmMessagingProviderRowProps {
@@ -226,12 +238,14 @@ export function ScmMessagingProviderRow({
     [onMessagingSetupChange]
   );
 
-  const errorMessage =
-    installState.status === 'error'
-      ? installState.error
-      : installState.status === 'cancelled' && installState.lastError
-        ? installState.lastError
-        : undefined;
+  const errorMessage = getInstallErrorMessage(installState);
+
+  const showRowContent =
+    visualState !== 'loading' &&
+    visualState !== 'installing' &&
+    visualState !== 'install-error';
+
+  const showChannelPicker = visualState === 'configuring' && viewModel.integration;
 
   return (
     <ScmSelectableContainer isSelected={isConfigured}>
@@ -255,49 +269,47 @@ export function ScmMessagingProviderRow({
           </Stack>
         )}
 
-        {visualState !== 'loading' &&
-          visualState !== 'installing' &&
-          visualState !== 'install-error' && (
-            <Flex padding="lg" gap="md" align="start" justify="between">
-              <Flex gap="md" align="start" style={{flex: 1, minWidth: 0}}>
-                <IconWrapper>
-                  <PluginIcon pluginId={viewModel.providerKey} size={24} />
-                </IconWrapper>
-                <Stack gap="xs">
-                  <Text bold size="sm">
-                    {viewModel.provider.name}
-                  </Text>
-                  <RowSubtitle
-                    visualState={visualState}
-                    viewModel={viewModel}
-                    messagingSetup={messagingSetup}
-                  />
-                </Stack>
-              </Flex>
-
-              <Flex gap="sm" align="center" style={{flexShrink: 0}}>
-                <RowActions
+        {showRowContent && (
+          <Flex padding="lg" gap="md" align="start" justify="between">
+            <Flex gap="md" align="start" style={{flex: 1, minWidth: 0}}>
+              <Container flexShrink={0} paddingTop="2xs">
+                <PluginIcon pluginId={viewModel.providerKey} size={24} />
+              </Container>
+              <Stack gap="xs">
+                <Text bold size="sm">
+                  {viewModel.provider.name}
+                </Text>
+                <RowSubtitle
                   visualState={visualState}
                   viewModel={viewModel}
-                  onConnect={handleConnect}
-                  onAddDestination={handleAddDestination}
-                  onEditDestination={handleEditDestination}
-                  onStartRemoving={handleStartRemoving}
-                  onCancelRemoving={handleCancelRemoving}
-                  onConfirmRemove={handleConfirmRemove}
+                  messagingSetup={messagingSetup}
                 />
-              </Flex>
+              </Stack>
             </Flex>
-          )}
 
-        {visualState === 'configuring' && viewModel.integration && (
-          <ChannelPickerSlot>
+            <Flex gap="sm" align="center" style={{flexShrink: 0}}>
+              <RowActions
+                visualState={visualState}
+                viewModel={viewModel}
+                onConnect={handleConnect}
+                onAddDestination={handleAddDestination}
+                onEditDestination={handleEditDestination}
+                onStartRemoving={handleStartRemoving}
+                onCancelRemoving={handleCancelRemoving}
+                onConfirmRemove={handleConfirmRemove}
+              />
+            </Flex>
+          </Flex>
+        )}
+
+        {showChannelPicker && (
+          <Container borderTop="primary" padding="lg">
             {renderChannelPicker?.({
-              integration: viewModel.integration,
+              integration: showChannelPicker,
               onCancel: handleCancelConfiguring,
               onConfigured: handleConfigured,
             })}
-          </ChannelPickerSlot>
+          </Container>
         )}
       </Stack>
     </ScmSelectableContainer>
@@ -443,13 +455,3 @@ function RowActions({
 
   return null;
 }
-
-const IconWrapper = styled('div')`
-  flex-shrink: 0;
-  margin-top: 2px;
-`;
-
-const ChannelPickerSlot = styled('div')`
-  border-top: 1px solid ${p => p.theme.border};
-  padding: ${p => p.theme.space.lg};
-`;

--- a/static/app/components/onboarding/scm/scmMessagingProviderRow.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingProviderRow.tsx
@@ -53,7 +53,9 @@ function deriveVisualState({
   messagingSetup,
   isConfiguring,
   isRemoving,
+  awaitingInstall,
 }: {
+  awaitingInstall: boolean;
   installState: ReturnType<typeof useAddIntegration>['state'];
   isConfiguring: boolean;
   isRemoving: boolean;
@@ -73,8 +75,15 @@ function deriveVisualState({
     if (installState.status === 'cancelled' && installState.lastError) {
       return 'install-error';
     }
-    // Install confirmed — stay in loading until the view model catches up.
-    if (installState.status === 'complete' && viewModel.status !== 'connected') {
+    // Hold the spinner only while waiting for the just-installed integration to
+    // surface. Once the view model settles to anything other than `installable`
+    // (connected or permission-limited) that state is terminal, so falling
+    // through avoids spinning forever on an ineligible or vanished integration.
+    if (
+      installState.status === 'complete' &&
+      awaitingInstall &&
+      viewModel.status === 'installable'
+    ) {
       return 'loading';
     }
   }
@@ -139,6 +148,9 @@ export function ScmMessagingProviderRow({
   const {startFlow, state: installState} = useAddIntegration();
   const [isConfiguring, setIsConfiguring] = useState(false);
   const [isRemoving, setIsRemoving] = useState(false);
+  // `useAddIntegration` never leaves `complete`, so latch the post-install wait
+  // ourselves and release it once the integration surfaces.
+  const [awaitingInstall, setAwaitingInstall] = useState(false);
 
   const isConfigured =
     messagingSetup.mode === 'selected' &&
@@ -151,6 +163,7 @@ export function ScmMessagingProviderRow({
     messagingSetup,
     isConfiguring,
     isRemoving,
+    awaitingInstall,
   });
 
   // When the integration goes away (e.g. removed externally), close any
@@ -159,6 +172,14 @@ export function ScmMessagingProviderRow({
     if (viewModel.status !== 'connected') {
       setIsConfiguring(false);
       setIsRemoving(false);
+    }
+  }, [viewModel.status]);
+
+  // Release the post-install latch once the integration surfaces (connected or
+  // permission-limited), so a later external removal cannot re-trigger loading.
+  useEffect(() => {
+    if (viewModel.status !== 'installable') {
+      setAwaitingInstall(false);
     }
   }, [viewModel.status]);
 
@@ -171,6 +192,7 @@ export function ScmMessagingProviderRow({
   }, [isConfigured]);
 
   const handleConnect = useCallback(() => {
+    setAwaitingInstall(true);
     startFlow({
       provider: viewModel.provider,
       organization,
@@ -213,7 +235,7 @@ export function ScmMessagingProviderRow({
 
   return (
     <ScmSelectableContainer isSelected={isConfigured}>
-      <RowBody>
+      <Stack>
         {(visualState === 'loading' || visualState === 'installing') && (
           <Flex justify="center" align="center" padding="lg">
             <LoadingIndicator mini style={{margin: 0}} />
@@ -277,7 +299,7 @@ export function ScmMessagingProviderRow({
             })}
           </ChannelPickerSlot>
         )}
-      </RowBody>
+      </Stack>
     </ScmSelectableContainer>
   );
 }
@@ -421,11 +443,6 @@ function RowActions({
 
   return null;
 }
-
-const RowBody = styled('div')`
-  display: flex;
-  flex-direction: column;
-`;
 
 const IconWrapper = styled('div')`
   flex-shrink: 0;

--- a/static/app/components/onboarding/scm/scmMessagingProviderRow.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingProviderRow.tsx
@@ -451,5 +451,5 @@ const IconWrapper = styled('div')`
 
 const ChannelPickerSlot = styled('div')`
   border-top: 1px solid ${p => p.theme.border};
-  padding: ${p => p.theme.space['lg']};
+  padding: ${p => p.theme.space.lg};
 `;

--- a/static/app/components/onboarding/scm/scmMessagingProviderRow.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingProviderRow.tsx
@@ -2,11 +2,17 @@ import {Fragment, useCallback, useEffect, useState} from 'react';
 import type {ReactNode} from 'react';
 
 import {Alert} from '@sentry/scraps/alert';
+import {Tag} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
 
+import {hasEveryAccess} from 'sentry/components/acl/access';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {IconAdd} from 'sentry/icons/iconAdd';
+import {IconCheckmark} from 'sentry/icons/iconCheckmark';
+import {IconInfo} from 'sentry/icons/iconInfo';
 import {PluginIcon} from 'sentry/icons/pluginIcon';
 import {t} from 'sentry/locale';
 import type {
@@ -17,7 +23,11 @@ import {useAddIntegration} from 'sentry/utils/integrations/useAddIntegration';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {MessagingIntegrationAnalyticsView} from 'sentry/views/alerts/rules/issue/setupMessagingIntegrationButton';
 
-import {SCM_MESSAGING_PROVIDER_DESCRIPTIONS} from './messagingProviders';
+import {
+  SCM_MESSAGING_PROVIDER_DESCRIPTIONS,
+  SCM_MESSAGING_PROVIDER_TOOLTIPS,
+} from './messagingProviders';
+import {ScmMessagingChannelPicker} from './scmMessagingChannelPicker';
 import type {ScmMessagingSetup} from './scmMessagingSetup';
 import {ScmSelectableContainer} from './scmSelectableContainer';
 import type {ScmMessagingProviderViewModel} from './useScmMessagingProviders';
@@ -29,6 +39,12 @@ import type {ScmMessagingProviderViewModel} from './useScmMessagingProviders';
  */
 type RowVisualState =
   | 'installable'
+  /**
+   * User lacks org:integrations so they cannot start an installation.
+   * Distinct from 'permission-limited', which describes a tenant-level MS Teams
+   * integration that is ineligible for Issue Alert actions regardless of user scope.
+   */
+  | 'install-forbidden'
   /** OAuth modal is open / install in progress. */
   | 'installing'
   /** Install attempt ended with an error (or was closed after one). */
@@ -37,8 +53,6 @@ type RowVisualState =
   | 'loading'
   /** Active integration exists but is ineligible for Issue Alert actions. */
   | 'permission-limited'
-  /** Active, eligible integration; no destination configured yet. */
-  | 'connected'
   /** Destination is being configured (channel picker rendered inline). */
   | 'configuring'
   /** A destination has been saved to session state. */
@@ -52,11 +66,13 @@ function deriveVisualState({
   messagingSetup,
   isConfiguring,
   isRemoving,
-  awaitingInstall,
+  hasInstallAccess,
+  isRefetchingIntegrations,
 }: {
-  awaitingInstall: boolean;
+  hasInstallAccess: boolean;
   installState: ReturnType<typeof useAddIntegration>['state'];
   isConfiguring: boolean;
+  isRefetchingIntegrations: boolean;
   isRemoving: boolean;
   messagingSetup: ScmMessagingSetup;
   viewModel: ScmMessagingProviderViewModel;
@@ -76,20 +92,20 @@ function deriveVisualState({
       return 'install-error';
     }
   }
-  // Hold the spinner only while waiting for the just-installed integration to
-  // surface. Once the view model settles to anything other than `installable`
-  // (connected or permission-limited) that state is terminal, so falling
-  // through avoids spinning forever on an ineligible or vanished integration.
+  // Show the spinner only while the shared integrations query is actively
+  // refetching after install. Once it settles — whether or not the integration
+  // surfaced — isRefetchingIntegrations becomes false and the row falls back to
+  // installable (Connect), so it can never spin forever.
   if (
     installState.status === 'complete' &&
-    awaitingInstall &&
+    isRefetchingIntegrations &&
     viewModel.status === 'installable'
   ) {
     return 'loading';
   }
 
   if (viewModel.status === 'installable') {
-    return 'installable';
+    return hasInstallAccess ? 'installable' : 'install-forbidden';
   }
 
   if (viewModel.status === 'permission-limited') {
@@ -100,12 +116,10 @@ function deriveVisualState({
   const isConfigured =
     messagingSetup.mode === 'selected' &&
     messagingSetup.providerKey === viewModel.providerKey &&
-    messagingSetup.integrationId === viewModel.integration?.id;
+    viewModel.eligibleIntegrations.some(i => i.id === messagingSetup.integrationId);
 
-  // Configuring takes priority so Edit can open the picker even when a
-  // destination is already saved.
-  if (isConfiguring) {
-    return 'configuring';
+  if (isConfigured && isConfiguring) {
+    return 'configuring'; // Edit mode
   }
   if (isConfigured && isRemoving) {
     return 'removing';
@@ -113,7 +127,8 @@ function deriveVisualState({
   if (isConfigured) {
     return 'configured';
   }
-  return 'connected';
+  // Auto-expand the form immediately when connected but not yet configured.
+  return 'configuring';
 }
 
 function getInstallErrorMessage(
@@ -134,17 +149,24 @@ export interface ScmMessagingProviderRowProps {
   onMessagingSetupChange: (setup: ScmMessagingSetup) => void;
   viewModel: ScmMessagingProviderViewModel;
   /**
+   * True while the parent's integrations query is actively refetching (e.g.
+   * after a fresh install). Drives the post-install loading spinner; scoped to
+   * this prop so the spinner clears as soon as the refetch settles even if no
+   * integration surfaced, preventing an infinite spin.
+   */
+  isRefetchingIntegrations?: boolean;
+  /**
    * Render prop for the inline channel picker.
    *
-   * When the user opens the configuring state this is called with the active
-   * integration and two callbacks: `onConfigured` (save the chosen destination
-   * to session state) and `onCancel` (close without saving).
+   * Called with the eligible (non-empty) integrations for this provider and two
+   * callbacks: `onConfigured` (save the chosen destination to session state) and
+   * `onCancel` (close without saving). Only invoked when `status === 'connected'`.
    *
    * Omitting this prop leaves the configuring state with an empty body.
    */
   renderChannelPicker?: (props: {
-    integration: OrganizationIntegration;
-    onCancel: () => void;
+    integrations: OrganizationIntegration[];
+    onCancel: (() => void) | undefined;
     onConfigured: (setup: ScmMessagingSetup & {mode: 'selected'}) => void;
   }) => ReactNode;
 }
@@ -155,19 +177,19 @@ export function ScmMessagingProviderRow({
   onMessagingSetupChange,
   onInstallComplete,
   renderChannelPicker,
+  isRefetchingIntegrations = false,
 }: ScmMessagingProviderRowProps) {
   const organization = useOrganization();
   const {startFlow, state: installState} = useAddIntegration();
   const [isConfiguring, setIsConfiguring] = useState(false);
   const [isRemoving, setIsRemoving] = useState(false);
-  // `useAddIntegration` never leaves `complete`, so latch the post-install wait
-  // ourselves and release it once the integration surfaces.
-  const [awaitingInstall, setAwaitingInstall] = useState(false);
+
+  const hasInstallAccess = hasEveryAccess(['org:integrations'], {organization});
 
   const isConfigured =
     messagingSetup.mode === 'selected' &&
     messagingSetup.providerKey === viewModel.providerKey &&
-    messagingSetup.integrationId === viewModel.integration?.id;
+    viewModel.eligibleIntegrations.some(i => i.id === messagingSetup.integrationId);
 
   const visualState = deriveVisualState({
     viewModel,
@@ -175,7 +197,8 @@ export function ScmMessagingProviderRow({
     messagingSetup,
     isConfiguring,
     isRemoving,
-    awaitingInstall,
+    hasInstallAccess,
+    isRefetchingIntegrations,
   });
 
   // When the integration goes away (e.g. removed externally), close any
@@ -184,14 +207,6 @@ export function ScmMessagingProviderRow({
     if (viewModel.status !== 'connected') {
       setIsConfiguring(false);
       setIsRemoving(false);
-    }
-  }, [viewModel.status]);
-
-  // Release the post-install latch once the integration surfaces (connected or
-  // permission-limited), so a later external removal cannot re-trigger loading.
-  useEffect(() => {
-    if (viewModel.status !== 'installable') {
-      setAwaitingInstall(false);
     }
   }, [viewModel.status]);
 
@@ -204,7 +219,6 @@ export function ScmMessagingProviderRow({
   }, [isConfigured]);
 
   const handleConnect = useCallback(() => {
-    setAwaitingInstall(true);
     startFlow({
       provider: viewModel.provider,
       organization,
@@ -220,7 +234,6 @@ export function ScmMessagingProviderRow({
     });
   }, [startFlow, viewModel.provider, organization, onInstallComplete]);
 
-  const handleAddDestination = () => setIsConfiguring(true);
   const handleEditDestination = () => setIsConfiguring(true);
   const handleCancelConfiguring = () => setIsConfiguring(false);
   const handleStartRemoving = () => setIsRemoving(true);
@@ -240,22 +253,9 @@ export function ScmMessagingProviderRow({
 
   const errorMessage = getInstallErrorMessage(installState);
 
-  const showRowContent =
-    visualState !== 'loading' &&
-    visualState !== 'installing' &&
-    visualState !== 'install-error';
-
-  const showChannelPicker = visualState === 'configuring' && viewModel.integration;
-
   return (
     <ScmSelectableContainer isSelected={isConfigured}>
       <Stack>
-        {(visualState === 'loading' || visualState === 'installing') && (
-          <Flex justify="center" align="center" padding="lg">
-            <LoadingIndicator mini style={{margin: 0}} />
-          </Flex>
-        )}
-
         {visualState === 'install-error' && (
           <Stack padding="md" gap="md" align="start">
             <Alert
@@ -269,16 +269,34 @@ export function ScmMessagingProviderRow({
           </Stack>
         )}
 
-        {showRowContent && (
-          <Flex padding="lg" gap="md" align="start" justify="between">
-            <Flex gap="md" align="start" style={{flex: 1, minWidth: 0}}>
+        {visualState !== 'install-error' && (
+          <Flex padding="lg" gap="md" align="center" justify="between">
+            <Flex gap="md" align="center" style={{flex: 1, minWidth: 0}}>
               <Container flexShrink={0} paddingTop="2xs">
                 <PluginIcon pluginId={viewModel.providerKey} size={24} />
               </Container>
               <Stack gap="xs">
-                <Text bold size="sm">
-                  {viewModel.provider.name}
-                </Text>
+                <Flex gap="xs" align="center">
+                  <Text bold size="md">
+                    {visualState === 'removing'
+                      ? t('Remove this destination?')
+                      : viewModel.provider.name}
+                  </Text>
+                  {viewModel.status !== 'connected' && visualState !== 'removing' && (
+                    <Tooltip
+                      title={SCM_MESSAGING_PROVIDER_TOOLTIPS[viewModel.providerKey]}
+                    >
+                      <Flex align="center">
+                        <IconInfo size="xs" variant="muted" />
+                      </Flex>
+                    </Tooltip>
+                  )}
+                  {viewModel.status === 'connected' && visualState !== 'removing' && (
+                    <Tag variant="success" icon={<IconCheckmark />}>
+                      {t('Connected')}
+                    </Tag>
+                  )}
+                </Flex>
                 <RowSubtitle
                   visualState={visualState}
                   viewModel={viewModel}
@@ -292,7 +310,6 @@ export function ScmMessagingProviderRow({
                 visualState={visualState}
                 viewModel={viewModel}
                 onConnect={handleConnect}
-                onAddDestination={handleAddDestination}
                 onEditDestination={handleEditDestination}
                 onStartRemoving={handleStartRemoving}
                 onCancelRemoving={handleCancelRemoving}
@@ -302,13 +319,23 @@ export function ScmMessagingProviderRow({
           </Flex>
         )}
 
-        {showChannelPicker && (
+        {visualState === 'configuring' && viewModel.eligibleIntegrations.length > 0 && (
           <Container borderTop="primary" padding="lg">
-            {renderChannelPicker?.({
-              integration: showChannelPicker,
-              onCancel: handleCancelConfiguring,
-              onConfigured: handleConfigured,
-            })}
+            {renderChannelPicker ? (
+              renderChannelPicker({
+                integrations: viewModel.eligibleIntegrations,
+                onCancel: isConfigured ? handleCancelConfiguring : undefined,
+                onConfigured: handleConfigured,
+              })
+            ) : (
+              <ScmMessagingChannelPicker
+                eligibleIntegrations={viewModel.eligibleIntegrations}
+                providerKey={viewModel.providerKey}
+                onCancel={isConfigured ? handleCancelConfiguring : undefined}
+                onConfigured={handleConfigured}
+                existingSetup={isConfigured ? messagingSetup : undefined}
+              />
+            )}
           </Container>
         )}
       </Stack>
@@ -325,7 +352,11 @@ function RowSubtitle({
   viewModel: ScmMessagingProviderViewModel;
   visualState: RowVisualState;
 }) {
-  if (visualState === 'installable') {
+  if (
+    visualState === 'installable' ||
+    visualState === 'loading' ||
+    visualState === 'installing'
+  ) {
     return (
       <Text variant="muted" size="sm">
         {SCM_MESSAGING_PROVIDER_DESCRIPTIONS[viewModel.providerKey]}
@@ -333,10 +364,23 @@ function RowSubtitle({
     );
   }
 
+  if (visualState === 'install-forbidden') {
+    return (
+      <Stack gap="2xs">
+        <Text variant="muted" size="sm">
+          {SCM_MESSAGING_PROVIDER_DESCRIPTIONS[viewModel.providerKey]}
+        </Text>
+        <Text variant="muted" size="sm">
+          {t('Ask an organization admin to connect %s.', viewModel.provider.name)}
+        </Text>
+      </Stack>
+    );
+  }
+
   if (visualState === 'permission-limited') {
     return (
       <Stack gap="2xs">
-        <Text size="sm">{viewModel.integration?.name}</Text>
+        <Text size="sm">{viewModel.permissionLimitedIntegration?.name}</Text>
         <Text variant="muted" size="sm">
           {t(
             'This Microsoft Teams workspace uses a tenant-level connection and cannot receive issue alerts directly. Reinstall with a team-level connection to enable destinations.'
@@ -346,16 +390,18 @@ function RowSubtitle({
     );
   }
 
-  if (visualState === 'connected') {
-    return <Text size="sm">{viewModel.integration?.name}</Text>;
-  }
-
   if (visualState === 'configured' && messagingSetup.mode === 'selected') {
     return (
       <Flex gap="xs" align="center">
-        <Text size="sm">{viewModel.integration?.name}</Text>
+        <Text size="sm">
+          {
+            viewModel.eligibleIntegrations.find(
+              i => i.id === messagingSetup.integrationId
+            )?.name
+          }
+        </Text>
         <Text variant="muted" size="sm" aria-hidden>
-          ·
+          /
         </Text>
         <Text size="sm">{messagingSetup.channelName}</Text>
       </Flex>
@@ -366,9 +412,7 @@ function RowSubtitle({
     return (
       <Text variant="muted" size="sm">
         {t(
-          'Remove %s from your destinations? The %s workspace will remain connected.',
-          messagingSetup.channelName,
-          viewModel.integration?.name ?? viewModel.provider.name
+          'This removes the destination from project setup. The integration stays connected to your organization.'
         )}
       </Text>
     );
@@ -378,7 +422,6 @@ function RowSubtitle({
 }
 
 interface RowActionsProps {
-  onAddDestination: () => void;
   onCancelRemoving: () => void;
   onConfirmRemove: () => void;
   onConnect: () => void;
@@ -392,16 +435,24 @@ function RowActions({
   visualState,
   viewModel,
   onConnect,
-  onAddDestination,
   onEditDestination,
   onStartRemoving,
   onCancelRemoving,
   onConfirmRemove,
 }: RowActionsProps) {
+  if (visualState === 'loading' || visualState === 'installing') {
+    return (
+      <Flex justify="center" align="center" style={{minWidth: 88}}>
+        <LoadingIndicator mini style={{margin: 0}} />
+      </Flex>
+    );
+  }
+
   if (visualState === 'installable') {
     return (
       <Button
         size="sm"
+        icon={<IconAdd size="xs" />}
         disabled={!viewModel.provider.canAdd}
         onClick={onConnect}
         aria-label={t('Connect %s', viewModel.provider.name)}
@@ -411,18 +462,18 @@ function RowActions({
     );
   }
 
-  if (visualState === 'permission-limited') {
+  if (visualState === 'install-forbidden') {
     return (
-      <Button size="sm" disabled>
-        {t('Add destination')}
+      <Button size="sm" disabled aria-label={t('Connect %s', viewModel.provider.name)}>
+        {t('Connect')}
       </Button>
     );
   }
 
-  if (visualState === 'connected') {
+  if (visualState === 'permission-limited') {
     return (
-      <Button size="sm" onClick={onAddDestination}>
-        {t('Add destination')}
+      <Button size="sm" disabled>
+        {t('Connect')}
       </Button>
     );
   }
@@ -430,10 +481,10 @@ function RowActions({
   if (visualState === 'configured') {
     return (
       <Fragment>
-        <Button size="sm" variant="secondary" onClick={onEditDestination}>
+        <Button size="sm" variant="link" onClick={onEditDestination}>
           {t('Edit')}
         </Button>
-        <Button size="sm" variant="danger" onClick={onStartRemoving}>
+        <Button size="sm" variant="link" onClick={onStartRemoving}>
           {t('Remove')}
         </Button>
       </Fragment>
@@ -443,11 +494,11 @@ function RowActions({
   if (visualState === 'removing') {
     return (
       <Fragment>
-        <Button size="sm" onClick={onCancelRemoving}>
+        <Button size="sm" variant="link" onClick={onCancelRemoving}>
           {t('Cancel')}
         </Button>
         <Button size="sm" variant="danger" onClick={onConfirmRemove}>
-          {t('Remove')}
+          {t('Remove destination')}
         </Button>
       </Fragment>
     );

--- a/static/app/components/onboarding/scm/scmMessagingSetup.ts
+++ b/static/app/components/onboarding/scm/scmMessagingSetup.ts
@@ -1,18 +1,9 @@
 import type {ScmMessagingProviderKey} from 'sentry/components/onboarding/scm/messagingProviders';
 
-export type {ScmMessagingProviderKey};
-
 export type ScmMessagingSetup =
   | {mode: 'unconfigured'}
   | {mode: 'skipped'}
   | {
-      /**
-       * The value written into the alert rule action payload.
-       * Slack: display name (e.g. "#general") — Slack actions address by name.
-       * Discord: channel ID — Discord actions address by ID.
-       * msteams: channel ID — msteams actions address by ID.
-       */
-      actionTarget: string;
       /**
        * The real backend channel ID for all providers (e.g. C123 for Slack,
        * a numeric string for Discord, a UUID-like string for msteams).

--- a/static/app/components/onboarding/scm/useScmMessagingProviders.spec.ts
+++ b/static/app/components/onboarding/scm/useScmMessagingProviders.spec.ts
@@ -69,7 +69,9 @@ describe('useScmMessagingProviders', () => {
 
     const slack = result.current.providers.find(p => p.providerKey === 'slack');
     expect(slack?.status).toBe('connected');
-    expect(slack?.integration?.id).toBe('10');
+    expect(slack?.eligibleIntegrations).toHaveLength(1);
+    expect(slack?.eligibleIntegrations[0]?.id).toBe('10');
+    expect(slack?.permissionLimitedIntegration).toBeUndefined();
 
     result.current.providers
       .filter(p => p.providerKey !== 'slack')
@@ -113,8 +115,9 @@ describe('useScmMessagingProviders', () => {
 
     const msteams = result.current.providers.find(p => p.providerKey === 'msteams');
     expect(msteams?.status).toBe('permission-limited');
-    // The integration is still exposed so the row can show the workspace name.
-    expect(msteams?.integration?.id).toBe('12');
+    expect(msteams?.eligibleIntegrations).toHaveLength(0);
+    // The tenant integration is surfaced for workspace-name display.
+    expect(msteams?.permissionLimitedIntegration?.id).toBe('12');
   });
 
   it('marks a team-type msteams integration as connected', async () => {
@@ -151,6 +154,127 @@ describe('useScmMessagingProviders', () => {
 
     expect(result.current.isError).toBe(true);
     expect(result.current.providers).toHaveLength(0);
+  });
+
+  it('exposes all eligible integrations when a provider has multiple workspaces', async () => {
+    mockProviders();
+    mockIntegrations([
+      OrganizationIntegrationsFixture({
+        id: '20',
+        name: 'workspace-a',
+        provider: {key: 'slack'} as any,
+        status: 'active',
+        organizationIntegrationStatus: 'active',
+      }),
+      OrganizationIntegrationsFixture({
+        id: '21',
+        name: 'workspace-b',
+        provider: {key: 'slack'} as any,
+        status: 'active',
+        organizationIntegrationStatus: 'active',
+      }),
+    ]);
+
+    const {result} = renderProviders();
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    const slack = result.current.providers.find(p => p.providerKey === 'slack');
+    expect(slack?.status).toBe('connected');
+    // Both workspaces are eligible (Slack has no tenant restriction).
+    expect(slack?.eligibleIntegrations).toHaveLength(2);
+    expect(slack?.eligibleIntegrations.map(i => i.id)).toEqual(['20', '21']);
+    expect(slack?.permissionLimitedIntegration).toBeUndefined();
+  });
+
+  it('is connected when msteams has both a tenant and a team installation', async () => {
+    mockProviders();
+    mockIntegrations([
+      OrganizationIntegrationsFixture({
+        id: '30',
+        name: 'tenant',
+        provider: {key: 'msteams'} as any,
+        status: 'active',
+        organizationIntegrationStatus: 'active',
+        configData: {installationType: 'tenant'},
+      }),
+      OrganizationIntegrationsFixture({
+        id: '31',
+        name: 'team',
+        provider: {key: 'msteams'} as any,
+        status: 'active',
+        organizationIntegrationStatus: 'active',
+        configData: {installationType: 'team'},
+      }),
+    ]);
+
+    const {result} = renderProviders();
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    const msteams = result.current.providers.find(p => p.providerKey === 'msteams');
+    expect(msteams?.status).toBe('connected');
+    // Only the team installation is eligible.
+    expect(msteams?.eligibleIntegrations).toHaveLength(1);
+    expect(msteams?.eligibleIntegrations[0]?.id).toBe('31');
+    // Status is connected (not permission-limited), so this is unset.
+    expect(msteams?.permissionLimitedIntegration).toBeUndefined();
+  });
+
+  it('returns isError when a provider config query fails', async () => {
+    // discord config query fails; the other two config queries succeed.
+    ['slack', 'msteams'].forEach(key => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/config/integrations/`,
+        body: {providers: [GitHubIntegrationProviderFixture({key})]},
+        match: [MockApiClient.matchQuery({provider_key: key})],
+      });
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/config/integrations/`,
+      statusCode: 500,
+      match: [MockApiClient.matchQuery({provider_key: 'discord'})],
+    });
+    mockIntegrations([]);
+
+    const {result} = renderProviders();
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    expect(result.current.isError).toBe(true);
+    expect(result.current.providers).toHaveLength(0);
+  });
+
+  it('retry() refetches provider config queries and clears the error', async () => {
+    ['slack', 'msteams'].forEach(key => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/config/integrations/`,
+        body: {providers: [GitHubIntegrationProviderFixture({key})]},
+        match: [MockApiClient.matchQuery({provider_key: key})],
+      });
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/config/integrations/`,
+      statusCode: 500,
+      match: [MockApiClient.matchQuery({provider_key: 'discord'})],
+    });
+    mockIntegrations([]);
+
+    const {result} = renderProviders();
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    // Fix the failing endpoint and call retry() — all query sets refetch.
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/config/integrations/`,
+      body: {providers: [GitHubIntegrationProviderFixture({key: 'discord'})]},
+      match: [MockApiClient.matchQuery({provider_key: 'discord'})],
+    });
+
+    result.current.retry();
+
+    await waitFor(() => expect(result.current.isError).toBe(false));
+    expect(result.current.providers).toHaveLength(3);
   });
 
   it('preserves provider order matching SCM_MESSAGING_PROVIDER_KEYS', async () => {

--- a/static/app/components/onboarding/scm/useScmMessagingProviders.ts
+++ b/static/app/components/onboarding/scm/useScmMessagingProviders.ts
@@ -5,7 +5,10 @@ import {
   SCM_MESSAGING_PROVIDER_KEYS,
   type ScmMessagingProviderKey,
 } from 'sentry/components/onboarding/scm/messagingProviders';
-import {isIntegrationActive} from 'sentry/components/onboarding/scm/useScmMessagingSetupValidation';
+import {
+  isEligibleForIssueAlerts,
+  isIntegrationActive,
+} from 'sentry/components/onboarding/scm/useScmMessagingSetupValidation';
 import type {
   IntegrationProvider,
   OrganizationIntegration,
@@ -23,45 +26,31 @@ import {useOrganization} from 'sentry/utils/useOrganization';
  * - `connected`          An active, eligible integration is present and ready to
  *                        have a destination configured.
  */
-export type ScmMessagingProviderStatus =
-  | 'installable'
-  | 'permission-limited'
-  | 'connected';
+type ScmMessagingProviderStatus = 'installable' | 'permission-limited' | 'connected';
 
 export type ScmMessagingProviderViewModel = {
-  /** Defined when status is `connected` or `permission-limited`. */
-  integration: OrganizationIntegration | undefined;
+  /**
+   * Active integrations that can receive Issue Alert actions.
+   * Non-empty iff `status === 'connected'`.
+   */
+  eligibleIntegrations: OrganizationIntegration[];
+  /**
+   * The ineligible active integration shown in the `permission-limited` state
+   * so the row can display its workspace name. `undefined` for other statuses.
+   */
+  permissionLimitedIntegration: OrganizationIntegration | undefined;
   provider: IntegrationProvider;
   providerKey: ScmMessagingProviderKey;
   status: ScmMessagingProviderStatus;
 };
 
-/**
- * Returns true when the integration can receive Issue Alert actions.
- * MS Teams "tenant" installations route notifications differently and
- * cannot be used as an issue-alert destination.
- */
-function isEligibleForIssueAlerts(integration: OrganizationIntegration): boolean {
-  if (integration.provider.key !== 'msteams') {
-    return true;
-  }
-  return integration.configData?.installationType !== 'tenant';
-}
-
-function toStatus(
-  integration: OrganizationIntegration | undefined
-): ScmMessagingProviderStatus {
-  if (!integration) {
-    return 'installable';
-  }
-  return isEligibleForIssueAlerts(integration) ? 'connected' : 'permission-limited';
-}
-
 export function useScmMessagingProviders(): {
   isError: boolean;
   isPending: boolean;
+  isRefetchingIntegrations: boolean;
   providers: ScmMessagingProviderViewModel[];
   refetchIntegrations: () => void;
+  retry: () => void;
 } {
   const organization = useOrganization();
 
@@ -94,6 +83,7 @@ export function useScmMessagingProviders(): {
       ) as Partial<Record<ScmMessagingProviderKey, IntegrationProvider>>,
       isPending: results.some(r => r.isPending),
       isError: results.some(r => r.isError),
+      refetch: () => results.forEach(r => r.refetch()),
     }),
   });
 
@@ -113,18 +103,24 @@ export function useScmMessagingProviders(): {
         return [];
       }
 
-      // Find the first active integration for this provider. Inactive
-      // integrations are treated the same as no integration.
-      const integration = integrations.find(
+      const active = integrations.filter(
         i => i.provider.key === providerKey && isIntegrationActive(i)
       );
+      const eligible = active.filter(isEligibleForIssueAlerts);
+      const status = eligible.length
+        ? 'connected'
+        : active.length
+          ? 'permission-limited'
+          : 'installable';
 
       return [
         {
           providerKey,
           provider,
-          status: toStatus(integration),
-          integration,
+          status,
+          eligibleIntegrations: eligible,
+          permissionLimitedIntegration:
+            status === 'permission-limited' ? active[0] : undefined,
         },
       ];
     });
@@ -134,6 +130,11 @@ export function useScmMessagingProviders(): {
     providers,
     isPending,
     isError,
+    isRefetchingIntegrations: integrationsQuery.isRefetching,
     refetchIntegrations: () => integrationsQuery.refetch(),
+    retry: () => {
+      integrationsQuery.refetch();
+      providerQueries.refetch();
+    },
   };
 }

--- a/static/app/components/onboarding/scm/useScmMessagingSetupValidation.ts
+++ b/static/app/components/onboarding/scm/useScmMessagingSetupValidation.ts
@@ -6,14 +6,31 @@ import type {OrganizationIntegration} from 'sentry/types/integrations';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {isNotFoundError} from 'sentry/utils/requestError/requestError';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {providerDetails} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 
-export type StaleDestinationReason = 'channel' | 'inactiveIntegration' | 'integration';
+export type StaleDestinationReason =
+  | 'channel'
+  | 'inactiveIntegration'
+  | 'ineligibleIntegration'
+  | 'integration';
 
 export function isIntegrationActive(integration: OrganizationIntegration): boolean {
   return (
     integration.status === 'active' &&
     integration.organizationIntegrationStatus === 'active'
   );
+}
+
+/**
+ * Returns true when the integration can receive Issue Alert actions.
+ * MS Teams "tenant" installations route notifications differently and
+ * cannot be used as an issue-alert destination.
+ */
+export function isEligibleForIssueAlerts(integration: OrganizationIntegration): boolean {
+  if (integration.provider.key !== 'msteams') {
+    return true;
+  }
+  return integration.configData?.installationType !== 'tenant';
 }
 
 /**
@@ -33,7 +50,8 @@ function resolveSavedIntegration(
   if (
     candidate.id !== messagingSetup.integrationId ||
     candidate.provider.key !== messagingSetup.providerKey ||
-    !isIntegrationActive(candidate)
+    !isIntegrationActive(candidate) ||
+    !isEligibleForIssueAlerts(candidate)
   ) {
     return undefined;
   }
@@ -42,20 +60,17 @@ function resolveSavedIntegration(
 }
 
 /**
- * Returns the value to send as the `channel` query param to channel-validate/.
- *
- * Slack and msteams resolve channels by name; Discord resolves by ID.
- * Returns undefined when the required field is absent (e.g. msteams data
- * written before channelName was required).
+ * Returns the value to send as the `channel` query param to channel-validate/,
+ * reading the field this provider validates by from the provider table.
+ * Returns undefined when that field is absent (e.g. legacy msteams data written
+ * before channelName was required).
  */
 function channelValidateParam(messagingSetup: ScmMessagingSetup): string | undefined {
   if (messagingSetup.mode !== 'selected') {
     return undefined;
   }
-  // Discord takes the numeric channel ID; Slack and msteams take the display name.
-  return messagingSetup.providerKey === 'discord'
-    ? messagingSetup.channelId
-    : messagingSetup.channelName || undefined;
+  const {channelValidatedBy} = providerDetails[messagingSetup.providerKey];
+  return messagingSetup[channelValidatedBy] || undefined;
 }
 
 interface UseScmMessagingSetupValidationParams {
@@ -100,6 +115,8 @@ export function useScmMessagingSetupValidation({
   const fetchedIntegration = isMissingIntegration ? undefined : integrationQuery.data;
   const hasInactiveIntegration =
     fetchedIntegration !== undefined && !isIntegrationActive(fetchedIntegration);
+  const hasIneligibleIntegration =
+    fetchedIntegration !== undefined && !isEligibleForIssueAlerts(fetchedIntegration);
   const integration = resolveSavedIntegration(fetchedIntegration, messagingSetup);
 
   // A 404 settles the query as conclusively as a successful fetch does; any
@@ -145,7 +162,13 @@ export function useScmMessagingSetupValidation({
     }
 
     if (!integration) {
-      setStaleReason(hasInactiveIntegration ? 'inactiveIntegration' : 'integration');
+      setStaleReason(
+        hasInactiveIntegration
+          ? 'inactiveIntegration'
+          : hasIneligibleIntegration
+            ? 'ineligibleIntegration'
+            : 'integration'
+      );
       onMessagingSetupChange({mode: 'unconfigured'});
       return;
     }
@@ -168,6 +191,7 @@ export function useScmMessagingSetupValidation({
   }, [
     channelValidateQuery.data,
     hasInactiveIntegration,
+    hasIneligibleIntegration,
     integration,
     isChannelSettled,
     isIntegrationSettled,
@@ -195,7 +219,7 @@ export function useScmMessagingSetupValidation({
       isIntegrationSettled &&
       integration !== undefined &&
       isChannelSettled &&
-      channelValidateQuery.data?.valid === true,
+      !!channelValidateQuery.data?.valid,
     staleReason,
   };
 }

--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -567,7 +567,6 @@ describe('Onboarding', () => {
       providerKey: 'slack',
       integrationId: '15',
       channelId: 'C123',
-      actionTarget: '#alerts',
       channelName: '#alerts',
     } as const satisfies ScmMessagingSetup;
 

--- a/static/app/views/onboarding/scmMessaging.spec.tsx
+++ b/static/app/views/onboarding/scmMessaging.spec.tsx
@@ -1,5 +1,6 @@
 import {Fragment, useState} from 'react';
 import {QueryClientProvider} from '@tanstack/react-query';
+import {IntegrationProviderFixture} from 'sentry-fixture/integrationProvider';
 import {OrganizationIntegrationsFixture} from 'sentry-fixture/organizationIntegrations';
 
 import {makeTestQueryClient} from 'sentry-test/queryClient';
@@ -24,15 +25,11 @@ const selectedPlatform = {
   category: 'browser',
 } as const;
 
-// Slack: channelId = real Slack channel ID, actionTarget = display name
-// (Slack alert rules address by name), channelName = display name (also
-// the channel-validate param for Slack).
 const selectedMessagingSetup: ScmMessagingSetup = {
   mode: 'selected',
   providerKey: 'slack',
   integrationId: '15',
   channelId: 'C123',
-  actionTarget: '#alerts',
   channelName: '#alerts',
 };
 
@@ -53,20 +50,43 @@ function mockChannelValidate(valid: boolean, channel = '#alerts') {
   });
 }
 
+function mockProviderQueries(integrations: OrganizationIntegration[] = []) {
+  MockApiClient.addMockResponse({
+    url: '/organizations/org-slug/integrations/',
+    match: [MockApiClient.matchQuery({integrationType: 'messaging'})],
+    body: integrations,
+  });
+  for (const key of ['slack', 'discord', 'msteams']) {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/config/integrations/',
+      match: [MockApiClient.matchQuery({provider_key: key})],
+      body: {
+        providers: [IntegrationProviderFixture({key, slug: key, name: key})],
+      },
+    });
+  }
+}
+
 function renderMessaging(
   onMessagingSetupChange = jest.fn(),
-  messagingSetup: ScmMessagingSetup = selectedMessagingSetup
+  messagingSetup: ScmMessagingSetup = selectedMessagingSetup,
+  onComplete = jest.fn()
 ) {
   return render(
     <ScmMessaging
       messagingSetup={messagingSetup}
       onMessagingSetupChange={onMessagingSetupChange}
       selectedPlatform={selectedPlatform}
+      onComplete={onComplete}
     />
   );
 }
 
 describe('ScmMessaging', () => {
+  beforeEach(() => {
+    mockProviderQueries();
+  });
+
   afterEach(() => {
     MockApiClient.clearMockResponses();
     // Context-backed tests persist onboarding state to session storage, and
@@ -173,7 +193,6 @@ describe('ScmMessaging', () => {
       providerKey: 'discord',
       integrationId: '15',
       channelId: '1234567890',
-      actionTarget: '1234567890',
       channelName: '#dev-alerts',
     };
     MockApiClient.addMockResponse({
@@ -316,5 +335,130 @@ describe('ScmMessaging', () => {
 
     await userEvent.click(screen.getByRole('button', {name: 'New reference'}));
     expect(screen.getByText(warning)).toBeInTheDocument();
+  });
+
+  it('renders provider rows once integrations and config queries settle', async () => {
+    mockProviderQueries([
+      OrganizationIntegrationsFixture({
+        id: '15',
+        provider: {key: 'slack', slug: 'slack', name: 'Slack'} as any,
+        status: 'active',
+      }),
+    ]);
+    // A connected-but-unconfigured row auto-expands its channel picker, which
+    // loads the integration's channels.
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/15/channels/',
+      body: {results: []},
+    });
+
+    renderMessaging(jest.fn(), {mode: 'unconfigured'});
+
+    expect(await screen.findByText('slack')).toBeInTheDocument();
+    expect(screen.getByText('discord')).toBeInTheDocument();
+    expect(screen.getByText('msteams')).toBeInTheDocument();
+  });
+
+  it('Continue is disabled when no destination is configured', () => {
+    renderMessaging(jest.fn(), {mode: 'unconfigured'});
+    expect(screen.getByRole('button', {name: 'Continue'})).toBeDisabled();
+  });
+
+  it('Continue is enabled once a configured destination revalidates', async () => {
+    mockIntegration();
+    mockChannelValidate(true);
+    renderMessaging(jest.fn(), selectedMessagingSetup);
+
+    // Revalidation is still in flight on first paint, so the restored
+    // destination is not submittable yet.
+    expect(screen.getByRole('button', {name: 'Continue'})).toBeDisabled();
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', {name: 'Continue'})).toBeEnabled()
+    );
+  });
+
+  it('Continue stays disabled while the saved channel is stale', async () => {
+    mockIntegration();
+    mockChannelValidate(false);
+    renderMessaging(jest.fn(), selectedMessagingSetup);
+
+    expect(
+      await screen.findByText(
+        "We couldn't verify the saved channel. Choose a destination again."
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Continue'})).toBeDisabled();
+  });
+
+  it('Continue stays disabled when the saved destination cannot be checked', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/15/',
+      statusCode: 500,
+    });
+    renderMessaging(jest.fn(), selectedMessagingSetup);
+
+    expect(
+      await screen.findByText(
+        "We couldn't check the saved destination. Reload the page to try again."
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Continue'})).toBeDisabled();
+  });
+
+  it('Continue calls onComplete', async () => {
+    mockIntegration();
+    mockChannelValidate(true);
+    const onComplete = jest.fn();
+    renderMessaging(jest.fn(), selectedMessagingSetup, onComplete);
+
+    const continueButton = await screen.findByRole('button', {name: 'Continue'});
+    await waitFor(() => expect(continueButton).toBeEnabled());
+
+    await userEvent.click(continueButton);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('Set up later marks setup as skipped and calls onComplete', async () => {
+    const onMessagingSetupChange = jest.fn();
+    const onComplete = jest.fn();
+    renderMessaging(onMessagingSetupChange, {mode: 'unconfigured'}, onComplete);
+
+    await userEvent.click(screen.getByRole('button', {name: 'Set up later'}));
+    expect(onMessagingSetupChange).toHaveBeenCalledWith({mode: 'skipped'});
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears an ineligible destination with an explanation', async () => {
+    // A tenant-type MS Teams integration is active but cannot receive issue alerts.
+    const msteamsSetup: ScmMessagingSetup = {
+      mode: 'selected',
+      providerKey: 'msteams',
+      integrationId: '15',
+      channelId: '19:abc@thread.tacv2',
+      channelName: 'General',
+    };
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/15/',
+      body: OrganizationIntegrationsFixture({
+        id: '15',
+        provider: {key: 'msteams'} as any,
+        status: 'active',
+        organizationIntegrationStatus: 'active',
+        configData: {installationType: 'tenant'},
+      }),
+    });
+    const onMessagingSetupChange = jest.fn();
+
+    renderMessaging(onMessagingSetupChange, msteamsSetup);
+
+    expect(
+      await screen.findByText(
+        'The saved workspace can no longer receive issue alerts. Choose a destination again.'
+      )
+    ).toBeInTheDocument();
+    expect(onMessagingSetupChange).toHaveBeenCalledWith({mode: 'unconfigured'});
+    expect(screen.queryByText('Destination selected')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Continue'})).toBeDisabled();
   });
 });

--- a/static/app/views/onboarding/scmMessaging.tsx
+++ b/static/app/views/onboarding/scmMessaging.tsx
@@ -1,9 +1,14 @@
 import {Alert} from '@sentry/scraps/alert';
-import {Stack} from '@sentry/scraps/layout';
+import {Button} from '@sentry/scraps/button';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {ScmMessagingProviderRow} from 'sentry/components/onboarding/scm/scmMessagingProviderRow';
 import type {ScmMessagingSetup} from 'sentry/components/onboarding/scm/scmMessagingSetup';
+import {useScmMessagingProviders} from 'sentry/components/onboarding/scm/useScmMessagingProviders';
 import {useScmMessagingSetupValidation} from 'sentry/components/onboarding/scm/useScmMessagingSetupValidation';
+import {IconMail} from 'sentry/icons/iconMail';
 import {t} from 'sentry/locale';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import {SCM_STEP_CONTENT_WIDTH} from 'sentry/views/onboarding/consts';
@@ -21,12 +26,14 @@ interface ScmMessagingProps {
   onMessagingSetupChange: (messagingSetup: ScmMessagingSetup) => void;
   selectedPlatform: OnboardingSelectedSDK;
   genBackButton?: StepProps['genBackButton'];
+  onComplete?: StepProps['onComplete'];
 }
 
 export function ScmMessaging({
   genBackButton,
   messagingSetup,
   onMessagingSetupChange,
+  onComplete,
   selectedPlatform,
 }: ScmMessagingProps) {
   const validation = useScmMessagingSetupValidation({
@@ -34,11 +41,32 @@ export function ScmMessaging({
     onMessagingSetupChange,
   });
 
+  const {
+    providers,
+    isPending,
+    isError,
+    isRefetchingIntegrations,
+    refetchIntegrations,
+    retry,
+  } = useScmMessagingProviders();
+
+  // Continue creates the project and alert rules, so it must wait for a
+  // conclusively revalidated destination — not merely the absence of a
+  // problem, which is briefly true before the stale-check effect runs.
+  const canContinue = validation.isValid;
+
+  const handleContinue = () => onComplete?.();
+
+  const handleSetupLater = () => {
+    onMessagingSetupChange({mode: 'skipped'});
+    onComplete?.();
+  };
+
   return (
     <Stack align="center" gap="2xl" flexGrow={1}>
-      <Stack gap="xl" maxWidth={`min(${SCM_STEP_CONTENT_WIDTH}, 100%)`} width="100%">
-        <Stack gap="md">
-          <Heading as="h2" size="4xl">
+      <Stack gap="2xl" maxWidth={`min(${SCM_STEP_CONTENT_WIDTH}, 100%)`} width="100%">
+        <Stack gap="lg">
+          <Heading as="h2" size="3xl">
             {SCM_MESSAGING_TITLE}
           </Heading>
           <Text variant="muted" size="md" density="comfortable">
@@ -57,6 +85,13 @@ export function ScmMessaging({
         {validation.staleReason === 'inactiveIntegration' && (
           <Alert variant="warning" showIcon>
             {t('The saved integration is no longer active. Choose a destination again.')}
+          </Alert>
+        )}
+        {validation.staleReason === 'ineligibleIntegration' && (
+          <Alert variant="warning" showIcon>
+            {t(
+              'The saved workspace can no longer receive issue alerts. Choose a destination again.'
+            )}
           </Alert>
         )}
         {validation.staleReason === 'channel' && (
@@ -78,8 +113,65 @@ export function ScmMessaging({
           </Text>
         )}
 
-        <Text variant="muted">{t('Email alerts will be included by default')}</Text>
-        <Stack align="start">{genBackButton?.()}</Stack>
+        <Flex align="center" gap="sm">
+          <IconMail size="sm" variant="muted" />
+          <Text variant="muted">{t('Email alerts will be included by default')}</Text>
+        </Flex>
+
+        {isPending && (
+          <Flex justify="center">
+            <LoadingIndicator />
+          </Flex>
+        )}
+
+        {isError && !isPending && (
+          <Alert
+            variant="warning"
+            trailingItems={<Alert.Button onClick={retry}>{t('Retry')}</Alert.Button>}
+          >
+            {t('Failed to load integrations.')}
+          </Alert>
+        )}
+
+        {!isPending && !isError && providers.length > 0 && (
+          <Stack gap="md">
+            {providers.map(viewModel => (
+              <ScmMessagingProviderRow
+                key={viewModel.providerKey}
+                viewModel={viewModel}
+                messagingSetup={messagingSetup}
+                onMessagingSetupChange={onMessagingSetupChange}
+                onInstallComplete={refetchIntegrations}
+                isRefetchingIntegrations={isRefetchingIntegrations}
+              />
+            ))}
+          </Stack>
+        )}
+
+        <Flex align="center" justify="between" width="100%" paddingTop="sm">
+          <Flex align="center">{genBackButton?.()}</Flex>
+          <Flex align="center" gap="md">
+            <Button
+              size="sm"
+              variant="secondary"
+              analyticsEventKey="onboarding.scm_messaging_setup_later_clicked"
+              analyticsEventName="Onboarding: SCM Messaging Setup Later Clicked"
+              onClick={handleSetupLater}
+            >
+              {t('Set up later')}
+            </Button>
+            <Button
+              size="sm"
+              variant="primary"
+              analyticsEventKey="onboarding.scm_messaging_continue_clicked"
+              analyticsEventName="Onboarding: SCM Messaging Continue Clicked"
+              disabled={!canContinue}
+              onClick={handleContinue}
+            >
+              {t('Continue')}
+            </Button>
+          </Flex>
+        </Flex>
       </Stack>
     </Stack>
   );

--- a/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
@@ -31,11 +31,40 @@ import {
 import type {RequestDataFragment} from 'sentry/views/projectInstall/issueAlertOptions';
 import {MessagingIntegrationAlertRule} from 'sentry/views/projectInstall/messagingIntegrationAlertRule';
 
+type ChannelIdentityField = 'channelId' | 'channelName';
+
+interface MessagingProviderDetail {
+  action: IssueAlertActionType;
+  channelSelectedBy: ChannelIdentityField;
+  channelTargetedBy: ChannelIdentityField;
+  channelValidatedBy: ChannelIdentityField;
+  makeSentence: (args: any) => ReactNode;
+  name: string;
+  placeholder: string;
+}
+
+/**
+ * Maps a stored destination field onto its counterpart in the raw `/channels/`
+ * response, so a stored value can be matched back to a channel.
+ */
+export const RAW_CHANNEL_FIELD = {
+  channelName: 'display',
+  channelId: 'id',
+} as const satisfies Record<ChannelIdentityField, 'display' | 'id'>;
+
+/**
+ * Providers disagree on what identifies a channel. MS Teams is the only row
+ * that is not uniform: it validates by name but is addressed by id, because
+ * Sentry built a name-to-id resolver for it while all three send by id.
+ */
 export const providerDetails = {
   slack: {
     name: t('Slack'),
     action: IssueAlertActionType.SLACK,
     placeholder: t('channel, e.g. #critical'),
+    channelSelectedBy: 'channelName',
+    channelValidatedBy: 'channelName',
+    channelTargetedBy: 'channelName',
     makeSentence: ({providerName, integrationName, target}: any) =>
       tct(
         'Send [providerName] notification to the [integrationName] workspace to [target]',
@@ -50,6 +79,9 @@ export const providerDetails = {
     name: t('Discord'),
     action: IssueAlertActionType.DISCORD,
     placeholder: t('channel ID or URL'),
+    channelSelectedBy: 'channelId',
+    channelValidatedBy: 'channelId',
+    channelTargetedBy: 'channelId',
     makeSentence: ({providerName, integrationName, target}: any) =>
       tct(
         'Send [providerName] notification to the [integrationName] server in the channel [target]',
@@ -64,6 +96,9 @@ export const providerDetails = {
     name: t('MS Teams'),
     action: IssueAlertActionType.MS_TEAMS,
     placeholder: t('channel ID'),
+    channelSelectedBy: 'channelId',
+    channelValidatedBy: 'channelName',
+    channelTargetedBy: 'channelId',
     makeSentence: ({providerName, integrationName, target}: any) =>
       tct('Send [providerName] notification to the [integrationName] team to [target]', {
         providerName,
@@ -71,7 +106,20 @@ export const providerDetails = {
         target,
       }),
   },
-};
+} satisfies Record<string, MessagingProviderDetail>;
+
+type MessagingProviderKey = keyof typeof providerDetails;
+
+/**
+ * Defaults to `channelId` for an unrecognized provider, preserving the prior
+ * inline conditional that singled out Slack and treated everything else as
+ * id-keyed.
+ */
+export function getChannelSelectedBy(provider: string | undefined): ChannelIdentityField {
+  return (
+    providerDetails[provider as MessagingProviderKey]?.channelSelectedBy ?? 'channelId'
+  );
+}
 
 export const enum MultipleCheckboxOptions {
   EMAIL = 'email',

--- a/static/app/views/projectInstall/messagingIntegrationAlertRule.tsx
+++ b/static/app/views/projectInstall/messagingIntegrationAlertRule.tsx
@@ -2,17 +2,19 @@ import {useEffect, useMemo} from 'react';
 import styled from '@emotion/styled';
 import {skipToken, useQuery, useQueryClient} from '@tanstack/react-query';
 
-import {Select, SelectOption} from '@sentry/scraps/select';
+import {Select, SelectOption, type SelectValue} from '@sentry/scraps/select';
 
 import {FormField} from 'sentry/components/forms/formField';
 import {t} from 'sentry/locale';
+import type {OrganizationIntegration} from 'sentry/types/integrations';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {
+  getChannelSelectedBy,
+  providerDetails,
   type IntegrationChannel,
   type IssueAlertNotificationProps,
-  providerDetails,
 } from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 import {validateChannelQueryOptions} from 'sentry/views/projectInstall/useValidateChannel';
 
@@ -22,6 +24,8 @@ type Channel = {
   name: string;
   type: string;
 };
+
+export type {Channel};
 
 type ChannelListResponse = {
   results: Channel[];
@@ -54,7 +58,11 @@ export function useMessagingIntegrationAlertRule(
   const organization = useOrganization();
   const queryClient = useQueryClient();
 
-  const {data: channels, isPending} = useQuery(
+  const {
+    data: channels,
+    isPending,
+    isError: isChannelsError,
+  } = useQuery(
     apiOptions.as<ChannelListResponse>()(
       '/organizations/$organizationIdOrSlug/integrations/$integrationId/channels/',
       {
@@ -107,15 +115,16 @@ export function useMessagingIntegrationAlertRule(
     [providersToIntegrations, provider]
   );
 
-  const channelOptions = useMemo(
-    () =>
-      channels?.results.map(ch =>
-        provider === 'slack'
-          ? {label: ch.display, value: ch.display}
-          : {label: `${ch.display} (${ch.id})`, value: ch.id}
-      ),
-    [channels, provider]
-  );
+  const channelOptions = useMemo(() => {
+    // Id-keyed providers show the id alongside the name, since the name alone
+    // cannot tell two same-named channels apart.
+    const keyedByName = getChannelSelectedBy(provider) === 'channelName';
+    return channels?.results.map(ch =>
+      keyedByName
+        ? {label: ch.display, value: ch.display}
+        : {label: `${ch.display} (${ch.id})`, value: ch.id}
+    );
+  }, [channels, provider]);
 
   useEffect(() => {
     // A restored channel (e.g. from persisted/default actions) only has a raw
@@ -139,10 +148,16 @@ export function useMessagingIntegrationAlertRule(
     integrationOptions,
     channelOptions,
     isChannelLoading: isPending || validateChannel.isFetching,
+    // The channels endpoint returns HTTP 200 with an empty results list when the
+    // upstream provider API fails, so isChannelsError only catches network or auth
+    // failures. An empty channelOptions list may still indicate an unreachable
+    // provider rather than a genuinely empty workspace.
+    isChannelsError,
+    channelsData: channels,
     channelError,
     providerDisabled: Object.keys(providersToIntegrations).length === 1,
     integrationDisabled: integrationOptions.length === 1,
-    onProviderChange: (option: any) => {
+    onProviderChange: (option: SelectValue<string>) => {
       setProvider(option.value);
       setIntegration(providersToIntegrations[option.value]![0]);
       setChannel(undefined);
@@ -155,7 +170,7 @@ export function useMessagingIntegrationAlertRule(
         });
       }
     },
-    onIntegrationChange: (option: any) => {
+    onIntegrationChange: (option: SelectValue<OrganizationIntegration>) => {
       setIntegration(option.value);
       setChannel(undefined);
       clearChannelValidation();


### PR DESCRIPTION
## Problem

The new inline messaging step renders one row per curated provider (Slack, Discord, MS Teams), and each row has to represent a lot of states: not yet installed, install in progress, install failed, freshly installed, connected, ineligible (tenant MS Teams), configuring a destination, configured, and confirming removal. The `useScmMessagingProviders` hook already exposes the settled data per provider, but there was no component to turn that view model — plus the live install flow and the destination saved in session — into a single coherent row UI.

## Change

Adds `ScmMessagingProviderRow`, a self-contained row component for one messaging provider. It drives installs through `useAddIntegration` and collapses the view model, install-flow state, and session setup into one pure `deriveVisualState` function, so each render resolves to exactly one visual state (installable, installing, install-error, loading, permission-limited, connected, configuring, configured, removing). The install lifecycle is fully wired — Connect opens the flow, a spinner covers the post-install window, errors surface a retry, and remove asks for confirmation — while