### PR TITLE
ui(workflow-engine): Correctly position tooltip for disabled monitor mode

### DIFF
--- a/static/app/views/automations/components/editConnectedMonitors.spec.tsx
+++ b/static/app/views/automations/components/editConnectedMonitors.spec.tsx
@@ -86,11 +86,7 @@ describe('EditConnectedMonitors', () => {
     expect(allProjectsRadio).toBeDisabled();
 
     await userEvent.hover(allProjectsRadio);
-    expect(
-      await screen.findByText(
-        'Only organization owners and managers can create global issue monitors.'
-      )
-    ).toBeInTheDocument();
+    expect(await screen.findByText(/owners and managers/)).toBeInTheDocument();
   });
 
   it('selects all projects', async () => {

--- a/static/app/views/automations/components/editConnectedMonitors.tsx
+++ b/static/app/views/automations/components/editConnectedMonitors.tsx
@@ -350,7 +350,9 @@ function EditConnectedMonitorsContent({
     if (!canEditAllProjects) {
       disabledChoices.push([
         'allProjects',
-        t('Only organization owners and managers can create global issue monitors.'),
+        t(
+          'Only organization owners and managers can create/modify global issue monitors.'
+        ),
       ]);
     }
   }
@@ -370,6 +372,7 @@ function EditConnectedMonitorsContent({
             choices={monitorModeChoices}
             disabledChoices={disabledChoices}
             onChange={handleModeChange}
+            tooltipPosition="top-start"
           />
           {monitorMode === 'project' ? (
             <AllProjectIssuesSection onProjectChange={handleProjectChange} />


### PR DESCRIPTION
When a user lacks permissions for an all-project monitor, we disable the monitor mode but the tooltip appears floating pretty far from the text.

<img width="467" height="110" alt="image" src="https://github.com/user-attachments/assets/e9ff9818-259a-433e-b6fe-3a1ff2b3499b" />



The row is full is full width and needs to stay that way for when the monitor list or project selector need to be rendered (so can't `align="start"`), but this works as well.


Also updates the copy