### PR TITLE
feat(preprod): Include manifest in snapshot archives

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -236,6 +236,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:preprod-size-analysis-pr-comments", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable preprod size monitors frontend
     manager.add("organizations:preprod-size-monitors-frontend", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Include the snapshot manifest in downloaded snapshot archives
+    manager.add("organizations:preprod-snapshot-archive-manifest", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enables the playstation ingestion in relay
     manager.add("organizations:relay-playstation-ingestion", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable the new apiFetch implementation that uses cell fetch.

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
@@ -14,7 +14,7 @@ from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import analytics
+from sentry import analytics, features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -62,7 +62,11 @@ from sentry.preprod.snapshots.comparison_categorizer import (
     CategorizedComparison,
     categorize_comparison_images,
 )
-from sentry.preprod.snapshots.constants import MISSING_BASE_GRACE_PERIOD_SECONDS
+from sentry.preprod.snapshots.constants import (
+    MISSING_BASE_GRACE_PERIOD_SECONDS,
+    SNAPSHOT_ARCHIVE_MANIFEST_FEATURE,
+    SNAPSHOT_ARCHIVE_MANIFEST_FILENAME,
+)
 from sentry.preprod.snapshots.manifest import (
     ComparisonManifest,
     ImageMetadata,
@@ -730,6 +734,14 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
         app_id = data.get("app_id")
         images = data.get("images", {})
         diff_threshold = data.get("diff_threshold")
+
+        if features.has(SNAPSHOT_ARCHIVE_MANIFEST_FEATURE, project.organization) and (
+            SNAPSHOT_ARCHIVE_MANIFEST_FILENAME in images
+        ):
+            return Response(
+                {"detail": f"The filename {SNAPSHOT_ARCHIVE_MANIFEST_FILENAME} is reserved."},
+                status=400,
+            )
 
         # VCS info
         head_sha = data.get("head_sha")

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_archive.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_archive.py
@@ -23,11 +23,7 @@ from sentry.preprod.analytics import PreprodArtifactApiSnapshotArchiveDownloadEv
 from sentry.preprod.models import PreprodArtifact
 from sentry.preprod.snapshots.constants import SNAPSHOT_ARCHIVE_MANIFEST_FEATURE
 from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
-from sentry.preprod.snapshots.zip_builder import (
-    SnapshotArchiveVersion,
-    archive_exists,
-    archive_object_key,
-)
+from sentry.preprod.snapshots.zip_builder import archive_exists, archive_object_key
 from sentry.preprod.snapshots.zip_tasks import build_snapshot_images_zip
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
@@ -35,12 +31,6 @@ from sentry.types.ratelimit import RateLimit, RateLimitCategory
 logger = logging.getLogger(__name__)
 
 DOWNLOAD_CHUNK_SIZE = 8192
-
-
-def _archive_version(organization: Organization) -> SnapshotArchiveVersion:
-    if features.has(SNAPSHOT_ARCHIVE_MANIFEST_FEATURE, organization):
-        return SnapshotArchiveVersion.V2
-    return SnapshotArchiveVersion.V1
 
 
 def _stream_object(payload: IO[bytes]) -> Iterator[bytes]:
@@ -97,11 +87,9 @@ class OrganizationPreprodSnapshotArchiveEndpoint(OrganizationEndpoint):
 
         return artifact, metrics
 
-    def _download(
-        self, artifact: PreprodArtifact, archive_version: SnapshotArchiveVersion
-    ) -> HttpResponseBase:
+    def _download(self, artifact: PreprodArtifact) -> HttpResponseBase:
         session = get_preprod_session(artifact.project.organization_id, artifact.project_id)
-        result = session.get(archive_object_key(artifact.id, archive_version))
+        result = session.get(archive_object_key(artifact.id))
         if result is None:
             return Response({"detail": "Download not ready"}, status=409)
 
@@ -116,12 +104,10 @@ class OrganizationPreprodSnapshotArchiveEndpoint(OrganizationEndpoint):
         response["X-Accel-Buffering"] = "no"
         return response
 
-    def _archive_exists(
-        self, artifact: PreprodArtifact, archive_version: SnapshotArchiveVersion
-    ) -> bool:
+    def _archive_exists(self, artifact: PreprodArtifact) -> bool:
         session = get_preprod_session(artifact.project.organization_id, artifact.project_id)
         try:
-            return archive_exists(session, archive_object_key(artifact.id, archive_version))
+            return archive_exists(session, archive_object_key(artifact.id))
         except RequestError:
             return False
 
@@ -132,7 +118,6 @@ class OrganizationPreprodSnapshotArchiveEndpoint(OrganizationEndpoint):
         if isinstance(resolved, Response):
             return resolved
         artifact, _metrics = resolved
-        archive_version = _archive_version(organization)
 
         if request.GET.get("download") is not None:
             analytics.record(
@@ -146,11 +131,11 @@ class OrganizationPreprodSnapshotArchiveEndpoint(OrganizationEndpoint):
                     client=resolve_action_source(request),
                 )
             )
-            return self._download(artifact, archive_version)
+            return self._download(artifact)
 
         # Readiness probe (no side effect): lets the UI download a ready archive
         # directly instead of re-triggering a build.
-        return Response({"ready": self._archive_exists(artifact, archive_version)})
+        return Response({"ready": self._archive_exists(artifact)})
 
     def post(
         self, request: Request, organization: Organization, snapshot_id: str
@@ -160,15 +145,15 @@ class OrganizationPreprodSnapshotArchiveEndpoint(OrganizationEndpoint):
             return resolved
         artifact, _metrics = resolved
         user_id = getattr(request.user, "id", None)
-        archive_version = _archive_version(organization)
         task_kwargs = {
             "org_id": artifact.project.organization_id,
             "project_id": artifact.project_id,
             "artifact_id": artifact.id,
             "user_id": user_id,
         }
-        if archive_version == SnapshotArchiveVersion.V2:
-            task_kwargs["archive_version"] = archive_version
+        include_manifest = features.has(SNAPSHOT_ARCHIVE_MANIFEST_FEATURE, organization)
+        if include_manifest:
+            task_kwargs["include_manifest"] = True
 
         try:
             build_snapshot_images_zip.apply_async(kwargs=task_kwargs)
@@ -180,7 +165,7 @@ class OrganizationPreprodSnapshotArchiveEndpoint(OrganizationEndpoint):
                     "organization_id": artifact.project.organization_id,
                     "project_id": artifact.project_id,
                     "user_id": user_id,
-                    "archive_version": archive_version,
+                    "include_manifest": include_manifest,
                 },
             )
             return Response(
@@ -194,7 +179,7 @@ class OrganizationPreprodSnapshotArchiveEndpoint(OrganizationEndpoint):
                 "organization_id": artifact.project.organization_id,
                 "project_id": artifact.project_id,
                 "user_id": user_id,
-                "archive_version": archive_version,
+                "include_manifest": include_manifest,
             },
         )
         return Response(

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_archive.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_archive.py
@@ -10,7 +10,7 @@ from objectstore_client import RequestError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import analytics
+from sentry import analytics, features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -21,8 +21,13 @@ from sentry.models.organization import Organization
 from sentry.objectstore import get_preprod_session
 from sentry.preprod.analytics import PreprodArtifactApiSnapshotArchiveDownloadEvent
 from sentry.preprod.models import PreprodArtifact
+from sentry.preprod.snapshots.constants import SNAPSHOT_ARCHIVE_MANIFEST_FEATURE
 from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
-from sentry.preprod.snapshots.zip_builder import archive_exists, archive_object_key
+from sentry.preprod.snapshots.zip_builder import (
+    SnapshotArchiveVersion,
+    archive_exists,
+    archive_object_key,
+)
 from sentry.preprod.snapshots.zip_tasks import build_snapshot_images_zip
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
@@ -30,6 +35,12 @@ from sentry.types.ratelimit import RateLimit, RateLimitCategory
 logger = logging.getLogger(__name__)
 
 DOWNLOAD_CHUNK_SIZE = 8192
+
+
+def _archive_version(organization: Organization) -> SnapshotArchiveVersion:
+    if features.has(SNAPSHOT_ARCHIVE_MANIFEST_FEATURE, organization):
+        return SnapshotArchiveVersion.V2
+    return SnapshotArchiveVersion.V1
 
 
 def _stream_object(payload: IO[bytes]) -> Iterator[bytes]:
@@ -86,9 +97,11 @@ class OrganizationPreprodSnapshotArchiveEndpoint(OrganizationEndpoint):
 
         return artifact, metrics
 
-    def _download(self, artifact: PreprodArtifact) -> HttpResponseBase:
+    def _download(
+        self, artifact: PreprodArtifact, archive_version: SnapshotArchiveVersion
+    ) -> HttpResponseBase:
         session = get_preprod_session(artifact.project.organization_id, artifact.project_id)
-        result = session.get(archive_object_key(artifact.id))
+        result = session.get(archive_object_key(artifact.id, archive_version))
         if result is None:
             return Response({"detail": "Download not ready"}, status=409)
 
@@ -103,10 +116,12 @@ class OrganizationPreprodSnapshotArchiveEndpoint(OrganizationEndpoint):
         response["X-Accel-Buffering"] = "no"
         return response
 
-    def _archive_exists(self, artifact: PreprodArtifact) -> bool:
+    def _archive_exists(
+        self, artifact: PreprodArtifact, archive_version: SnapshotArchiveVersion
+    ) -> bool:
         session = get_preprod_session(artifact.project.organization_id, artifact.project_id)
         try:
-            return archive_exists(session, archive_object_key(artifact.id))
+            return archive_exists(session, archive_object_key(artifact.id, archive_version))
         except RequestError:
             return False
 
@@ -117,6 +132,7 @@ class OrganizationPreprodSnapshotArchiveEndpoint(OrganizationEndpoint):
         if isinstance(resolved, Response):
             return resolved
         artifact, _metrics = resolved
+        archive_version = _archive_version(organization)
 
         if request.GET.get("download") is not None:
             analytics.record(
@@ -130,11 +146,11 @@ class OrganizationPreprodSnapshotArchiveEndpoint(OrganizationEndpoint):
                     client=resolve_action_source(request),
                 )
             )
-            return self._download(artifact)
+            return self._download(artifact, archive_version)
 
         # Readiness probe (no side effect): lets the UI download a ready archive
         # directly instead of re-triggering a build.
-        return Response({"ready": self._archive_exists(artifact)})
+        return Response({"ready": self._archive_exists(artifact, archive_version)})
 
     def post(
         self, request: Request, organization: Organization, snapshot_id: str
@@ -144,16 +160,18 @@ class OrganizationPreprodSnapshotArchiveEndpoint(OrganizationEndpoint):
             return resolved
         artifact, _metrics = resolved
         user_id = getattr(request.user, "id", None)
+        archive_version = _archive_version(organization)
+        task_kwargs = {
+            "org_id": artifact.project.organization_id,
+            "project_id": artifact.project_id,
+            "artifact_id": artifact.id,
+            "user_id": user_id,
+        }
+        if archive_version == SnapshotArchiveVersion.V2:
+            task_kwargs["archive_version"] = archive_version
 
         try:
-            build_snapshot_images_zip.apply_async(
-                kwargs={
-                    "org_id": artifact.project.organization_id,
-                    "project_id": artifact.project_id,
-                    "artifact_id": artifact.id,
-                    "user_id": user_id,
-                }
-            )
+            build_snapshot_images_zip.apply_async(kwargs=task_kwargs)
         except Exception:
             logger.exception(
                 "preprod_snapshot_zip.enqueue_failed",
@@ -162,6 +180,7 @@ class OrganizationPreprodSnapshotArchiveEndpoint(OrganizationEndpoint):
                     "organization_id": artifact.project.organization_id,
                     "project_id": artifact.project_id,
                     "user_id": user_id,
+                    "archive_version": archive_version,
                 },
             )
             return Response(
@@ -175,6 +194,7 @@ class OrganizationPreprodSnapshotArchiveEndpoint(OrganizationEndpoint):
                 "organization_id": artifact.project.organization_id,
                 "project_id": artifact.project_id,
                 "user_id": user_id,
+                "archive_version": archive_version,
             },
         )
         return Response(

--- a/src/sentry/preprod/snapshots/constants.py
+++ b/src/sentry/preprod/snapshots/constants.py
@@ -2,3 +2,5 @@ from __future__ import annotations
 
 MISSING_BASE_GRACE_PERIOD_SECONDS = 600
 RECONSTRUCTION_RETRY_COUNTDOWN_SECONDS = 60
+SNAPSHOT_ARCHIVE_MANIFEST_FEATURE = "organizations:preprod-snapshot-archive-manifest"
+SNAPSHOT_ARCHIVE_MANIFEST_FILENAME = "manifest.json"

--- a/src/sentry/preprod/snapshots/zip_builder.py
+++ b/src/sentry/preprod/snapshots/zip_builder.py
@@ -4,10 +4,12 @@ import logging
 import zipfile
 from collections import defaultdict
 from concurrent.futures import as_completed
+from enum import IntEnum
 from typing import IO
 
 from objectstore_client import Session
 
+from sentry.preprod.snapshots.constants import SNAPSHOT_ARCHIVE_MANIFEST_FILENAME
 from sentry.preprod.snapshots.manifest import SnapshotManifest
 from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 from sentry.utils.zip import is_unsafe_path
@@ -17,8 +19,20 @@ logger = logging.getLogger(__name__)
 FETCH_MAX_WORKERS = 16
 
 
-def archive_object_key(artifact_id: int) -> str:
-    return f"snapshot_archives/{artifact_id}.zip"
+class SnapshotArchiveVersion(IntEnum):
+    V1 = 1  # Images only.
+    V2 = 2  # Images plus a compressed manifest.
+
+
+def archive_object_key(
+    artifact_id: int,
+    archive_version: SnapshotArchiveVersion,
+) -> str:
+    if archive_version == SnapshotArchiveVersion.V1:
+        return f"snapshot_archives/{artifact_id}.zip"
+    if archive_version == SnapshotArchiveVersion.V2:
+        return f"snapshot_archives/v{archive_version}/{artifact_id}.zip"
+    raise ValueError(f"Unsupported snapshot archive version: {archive_version}")
 
 
 def archive_exists(session: Session, key: str) -> bool:
@@ -39,8 +53,9 @@ def build_snapshot_zip(
     key_prefix: str,
     out: IO[bytes],
     artifact_id: int,
+    manifest_bytes: bytes | None = None,
 ) -> None:
-    """Build a ZIP_STORED archive of all snapshot images into ``out``.
+    """Build an archive of snapshot images and an optional manifest into ``out``.
 
     Images sharing a content hash are fetched once and written under each
     original filename. Raises SnapshotZipBuildError if any image fails to
@@ -48,6 +63,10 @@ def build_snapshot_zip(
     """
     hash_to_filenames: dict[str, list[str]] = defaultdict(list)
     for filename, meta in manifest.images.items():
+        if manifest_bytes is not None and filename == SNAPSHOT_ARCHIVE_MANIFEST_FILENAME:
+            raise SnapshotZipBuildError(
+                f"snapshot image filename conflicts with {SNAPSHOT_ARCHIVE_MANIFEST_FILENAME}"
+            )
         if not is_unsafe_path(filename):
             hash_to_filenames[meta.content_hash].append(filename)
     unique_hashes = list(hash_to_filenames.keys())
@@ -83,6 +102,12 @@ def build_snapshot_zip(
                 )
             for filename in hash_to_filenames[image_hash]:
                 zf.writestr(filename, data)
+        if manifest_bytes is not None:
+            zf.writestr(
+                SNAPSHOT_ARCHIVE_MANIFEST_FILENAME,
+                manifest_bytes,
+                compress_type=zipfile.ZIP_DEFLATED,
+            )
         logger.info(
             "preprod_snapshot_zip.zip_build_completed",
             extra={"preprod_artifact_id": artifact_id, "image_hash_count": len(unique_hashes)},

--- a/src/sentry/preprod/snapshots/zip_builder.py
+++ b/src/sentry/preprod/snapshots/zip_builder.py
@@ -4,7 +4,6 @@ import logging
 import zipfile
 from collections import defaultdict
 from concurrent.futures import as_completed
-from enum import IntEnum
 from typing import IO
 
 from objectstore_client import Session
@@ -19,20 +18,8 @@ logger = logging.getLogger(__name__)
 FETCH_MAX_WORKERS = 16
 
 
-class SnapshotArchiveVersion(IntEnum):
-    V1 = 1  # Images only.
-    V2 = 2  # Images plus a compressed manifest.
-
-
-def archive_object_key(
-    artifact_id: int,
-    archive_version: SnapshotArchiveVersion,
-) -> str:
-    if archive_version == SnapshotArchiveVersion.V1:
-        return f"snapshot_archives/{artifact_id}.zip"
-    if archive_version == SnapshotArchiveVersion.V2:
-        return f"snapshot_archives/v{archive_version}/{artifact_id}.zip"
-    raise ValueError(f"Unsupported snapshot archive version: {archive_version}")
+def archive_object_key(artifact_id: int) -> str:
+    return f"snapshot_archives/{artifact_id}.zip"
 
 
 def archive_exists(session: Session, key: str) -> bool:

--- a/src/sentry/preprod/snapshots/zip_tasks.py
+++ b/src/sentry/preprod/snapshots/zip_tasks.py
@@ -16,6 +16,7 @@ from sentry.objectstore import get_preprod_session
 from sentry.preprod.snapshots.manifest import SnapshotManifest
 from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
 from sentry.preprod.snapshots.zip_builder import (
+    SnapshotArchiveVersion,
     SnapshotZipBuildError,
     archive_exists,
     archive_object_key,
@@ -77,10 +78,15 @@ def _put_part_with_retry(upload: MultipartUpload, chunk: bytes, part_number: int
     raise AssertionError("unreachable")
 
 
-def _archive_available(org_id: int, project_id: int, artifact_id: int) -> bool:
+def _archive_available(
+    org_id: int,
+    project_id: int,
+    artifact_id: int,
+    archive_version: SnapshotArchiveVersion,
+) -> bool:
     try:
         session = get_preprod_session(org_id, project_id)
-        return archive_exists(session, archive_object_key(artifact_id))
+        return archive_exists(session, archive_object_key(artifact_id, archive_version))
     except Exception:
         return False
 
@@ -114,7 +120,11 @@ def _upload_archive_multipart(session: Session, key: str, tmp: IO[bytes]) -> Non
     processing_deadline_duration=900,
 )
 def build_snapshot_images_zip(
-    org_id: int, project_id: int, artifact_id: int, user_id: int | None = None
+    org_id: int,
+    project_id: int,
+    artifact_id: int,
+    user_id: int | None = None,
+    archive_version: SnapshotArchiveVersion = SnapshotArchiveVersion.V1,
 ) -> None:
     logger.info(
         "preprod_snapshot_zip.build_started",
@@ -123,6 +133,7 @@ def build_snapshot_images_zip(
             "organization_id": org_id,
             "project_id": project_id,
             "user_id": user_id,
+            "archive_version": archive_version,
         },
     )
     try:
@@ -135,6 +146,7 @@ def build_snapshot_images_zip(
                 "organization_id": org_id,
                 "project_id": project_id,
                 "user_id": user_id,
+                "archive_version": archive_version,
             },
         )
         return
@@ -152,7 +164,7 @@ def build_snapshot_images_zip(
             raise SnapshotZipBuildError(f"missing manifest_key for artifact {artifact_id}")
 
         session = get_preprod_session(org_id, project_id)
-        key = archive_object_key(artifact_id)
+        key = archive_object_key(artifact_id, archive_version)
 
         # Snapshot images for a given artifact are immutable, so a stored archive
         # is always valid: skip the rebuild and just re-send the link.
@@ -162,7 +174,8 @@ def build_snapshot_images_zip(
                 extra={"preprod_artifact_id": artifact_id, "key": key},
             )
         else:
-            manifest, manifest_size_bytes = _load_manifest(session, manifest_key)
+            manifest, manifest_bytes = _load_manifest(session, manifest_key)
+            manifest_size_bytes = len(manifest_bytes)
             logger.info(
                 "preprod_snapshot_zip.manifest_loaded",
                 extra={
@@ -173,7 +186,14 @@ def build_snapshot_images_zip(
             )
             with NamedTemporaryFile() as tmp:
                 build_snapshot_zip(
-                    manifest, session, f"{org_id}/{project_id}", tmp, artifact_id=artifact_id
+                    manifest,
+                    session,
+                    f"{org_id}/{project_id}",
+                    tmp,
+                    artifact_id=artifact_id,
+                    manifest_bytes=(
+                        manifest_bytes if archive_version == SnapshotArchiveVersion.V2 else None
+                    ),
                 )
                 tmp.flush()
                 tmp.seek(0)
@@ -200,7 +220,7 @@ def build_snapshot_images_zip(
             "preprod_snapshot_zip.build_failed",
             extra={"preprod_artifact_id": artifact_id},
         )
-        if _archive_available(org_id, project_id, artifact_id):
+        if _archive_available(org_id, project_id, artifact_id, archive_version):
             logger.info(
                 "preprod_snapshot_zip.failure_superseded_by_existing_archive",
                 extra={"preprod_artifact_id": artifact_id},
@@ -217,21 +237,20 @@ def build_snapshot_images_zip(
             "organization_id": org_id,
             "project_id": project_id,
             "user_id": user_id,
+            "archive_version": archive_version,
         },
     )
     _send_archive_email(organization, user_id, artifact_id, ready=True)
 
 
-def _load_manifest(session: Session, manifest_key: str) -> tuple[SnapshotManifest, int]:
-    """Return the validated manifest and its original objectstore payload size in bytes."""
+def _load_manifest(session: Session, manifest_key: str) -> tuple[SnapshotManifest, bytes]:
+    """Return the validated manifest and its original objectstore payload bytes."""
     response = session.get(manifest_key)
     if response is None:
         raise FileNotFoundError("Manifest does not exist in objectstore")
     try:
         manifest_bytes = response.payload.read()
-        manifest_size_bytes = len(manifest_bytes)
         manifest_data = orjson.loads(manifest_bytes)
-        del manifest_bytes
     finally:
         response.payload.close()
-    return SnapshotManifest(**manifest_data), manifest_size_bytes
+    return SnapshotManifest(**manifest_data), manifest_bytes

--- a/src/sentry/preprod/snapshots/zip_tasks.py
+++ b/src/sentry/preprod/snapshots/zip_tasks.py
@@ -16,7 +16,6 @@ from sentry.objectstore import get_preprod_session
 from sentry.preprod.snapshots.manifest import SnapshotManifest
 from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
 from sentry.preprod.snapshots.zip_builder import (
-    SnapshotArchiveVersion,
     SnapshotZipBuildError,
     archive_exists,
     archive_object_key,
@@ -78,15 +77,10 @@ def _put_part_with_retry(upload: MultipartUpload, chunk: bytes, part_number: int
     raise AssertionError("unreachable")
 
 
-def _archive_available(
-    org_id: int,
-    project_id: int,
-    artifact_id: int,
-    archive_version: SnapshotArchiveVersion,
-) -> bool:
+def _archive_available(org_id: int, project_id: int, artifact_id: int) -> bool:
     try:
         session = get_preprod_session(org_id, project_id)
-        return archive_exists(session, archive_object_key(artifact_id, archive_version))
+        return archive_exists(session, archive_object_key(artifact_id))
     except Exception:
         return False
 
@@ -124,7 +118,7 @@ def build_snapshot_images_zip(
     project_id: int,
     artifact_id: int,
     user_id: int | None = None,
-    archive_version: SnapshotArchiveVersion = SnapshotArchiveVersion.V1,
+    include_manifest: bool = False,
 ) -> None:
     logger.info(
         "preprod_snapshot_zip.build_started",
@@ -133,7 +127,7 @@ def build_snapshot_images_zip(
             "organization_id": org_id,
             "project_id": project_id,
             "user_id": user_id,
-            "archive_version": archive_version,
+            "include_manifest": include_manifest,
         },
     )
     try:
@@ -146,7 +140,7 @@ def build_snapshot_images_zip(
                 "organization_id": org_id,
                 "project_id": project_id,
                 "user_id": user_id,
-                "archive_version": archive_version,
+                "include_manifest": include_manifest,
             },
         )
         return
@@ -164,7 +158,7 @@ def build_snapshot_images_zip(
             raise SnapshotZipBuildError(f"missing manifest_key for artifact {artifact_id}")
 
         session = get_preprod_session(org_id, project_id)
-        key = archive_object_key(artifact_id, archive_version)
+        key = archive_object_key(artifact_id)
 
         # Snapshot images for a given artifact are immutable, so a stored archive
         # is always valid: skip the rebuild and just re-send the link.
@@ -191,9 +185,7 @@ def build_snapshot_images_zip(
                     f"{org_id}/{project_id}",
                     tmp,
                     artifact_id=artifact_id,
-                    manifest_bytes=(
-                        manifest_bytes if archive_version == SnapshotArchiveVersion.V2 else None
-                    ),
+                    manifest_bytes=manifest_bytes if include_manifest else None,
                 )
                 tmp.flush()
                 tmp.seek(0)
@@ -220,7 +212,7 @@ def build_snapshot_images_zip(
             "preprod_snapshot_zip.build_failed",
             extra={"preprod_artifact_id": artifact_id},
         )
-        if _archive_available(org_id, project_id, artifact_id, archive_version):
+        if _archive_available(org_id, project_id, artifact_id):
             logger.info(
                 "preprod_snapshot_zip.failure_superseded_by_existing_archive",
                 extra={"preprod_artifact_id": artifact_id},
@@ -237,7 +229,7 @@ def build_snapshot_images_zip(
             "organization_id": org_id,
             "project_id": project_id,
             "user_id": user_id,
-            "archive_version": archive_version,
+            "include_manifest": include_manifest,
         },
     )
     _send_archive_email(organization, user_id, artifact_id, ready=True)

--- a/tests/sentry/preprod/api/endpoints/snapshots/test_preprod_artifact_snapshot_archive.py
+++ b/tests/sentry/preprod/api/endpoints/snapshots/test_preprod_artifact_snapshot_archive.py
@@ -12,7 +12,6 @@ from sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot_archive im
 )
 from sentry.preprod.models import PreprodArtifact
 from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
-from sentry.preprod.snapshots.zip_builder import SnapshotArchiveVersion
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.analytics import assert_last_analytics_event
 from sentry.types.ratelimit import RateLimitCategory
@@ -71,9 +70,7 @@ class SnapshotArchiveTriggerTest(BaseSnapshotArchiveTest):
         with self.feature("organizations:preprod-snapshot-archive-manifest"):
             response = self.client.post(self._url(artifact.id))
         assert response.status_code == 202
-        assert mock_task.apply_async.call_args.kwargs["kwargs"]["archive_version"] == (
-            SnapshotArchiveVersion.V2
-        )
+        assert mock_task.apply_async.call_args.kwargs["kwargs"]["include_manifest"] is True
 
     @patch(ENQUEUE_TARGET)
     def test_post_returns_503_when_enqueue_fails(self, mock_task):
@@ -103,18 +100,6 @@ class SnapshotArchiveReadinessTest(BaseSnapshotArchiveTest):
         session.get.assert_called_once_with(f"snapshot_archives/{artifact.id}.zip")
 
     @patch(SESSION_TARGET)
-    def test_get_checks_manifest_archive_when_feature_enabled(self, mock_session):
-        artifact = self._artifact()
-        session = MagicMock()
-        session.get.return_value = MagicMock()
-        mock_session.return_value = session
-        with self.feature("organizations:preprod-snapshot-archive-manifest"):
-            response = self.client.get(self._url(artifact.id))
-        assert response.status_code == 200
-        assert response.data["ready"] is True
-        session.get.assert_called_once_with(f"snapshot_archives/v2/{artifact.id}.zip")
-
-    @patch(SESSION_TARGET)
     def test_get_reports_not_ready_when_archive_absent(self, mock_session):
         artifact = self._artifact()
         session = MagicMock()
@@ -137,7 +122,7 @@ class SnapshotArchiveReadinessTest(BaseSnapshotArchiveTest):
 
 class SnapshotArchiveDownloadTest(BaseSnapshotArchiveTest):
     @patch(SESSION_TARGET)
-    def test_download_streams_manifest_archive_when_feature_enabled(self, mock_session):
+    def test_download_streams_when_object_present(self, mock_session):
         artifact = self._artifact()
         result = MagicMock()
         result.payload.read.side_effect = [b"ZIPBYTES", b""]
@@ -145,12 +130,11 @@ class SnapshotArchiveDownloadTest(BaseSnapshotArchiveTest):
         session = MagicMock()
         session.get.return_value = result
         mock_session.return_value = session
-        with self.feature("organizations:preprod-snapshot-archive-manifest"):
-            response = self.client.get(self._url(artifact.id, download=True))
+        response = self.client.get(self._url(artifact.id, download=True))
         assert response.status_code == 200
         assert response["Content-Type"] == "application/zip"
         assert b"".join(response.streaming_content) == b"ZIPBYTES"
-        session.get.assert_called_once_with(f"snapshot_archives/v2/{artifact.id}.zip")
+        session.get.assert_called_once_with(f"snapshot_archives/{artifact.id}.zip")
 
     @patch(SESSION_TARGET)
     def test_download_returns_409_when_absent(self, mock_session):

--- a/tests/sentry/preprod/api/endpoints/snapshots/test_preprod_artifact_snapshot_archive.py
+++ b/tests/sentry/preprod/api/endpoints/snapshots/test_preprod_artifact_snapshot_archive.py
@@ -12,6 +12,7 @@ from sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot_archive im
 )
 from sentry.preprod.models import PreprodArtifact
 from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
+from sentry.preprod.snapshots.zip_builder import SnapshotArchiveVersion
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.analytics import assert_last_analytics_event
 from sentry.types.ratelimit import RateLimitCategory
@@ -65,6 +66,16 @@ class SnapshotArchiveTriggerTest(BaseSnapshotArchiveTest):
         )
 
     @patch(ENQUEUE_TARGET)
+    def test_post_enqueues_manifest_archive_when_feature_enabled(self, mock_task):
+        artifact = self._artifact()
+        with self.feature("organizations:preprod-snapshot-archive-manifest"):
+            response = self.client.post(self._url(artifact.id))
+        assert response.status_code == 202
+        assert mock_task.apply_async.call_args.kwargs["kwargs"]["archive_version"] == (
+            SnapshotArchiveVersion.V2
+        )
+
+    @patch(ENQUEUE_TARGET)
     def test_post_returns_503_when_enqueue_fails(self, mock_task):
         artifact = self._artifact()
         mock_task.apply_async.side_effect = RuntimeError("broker down")
@@ -89,6 +100,19 @@ class SnapshotArchiveReadinessTest(BaseSnapshotArchiveTest):
         response = self.client.get(self._url(artifact.id))
         assert response.status_code == 200
         assert response.data["ready"] is True
+        session.get.assert_called_once_with(f"snapshot_archives/{artifact.id}.zip")
+
+    @patch(SESSION_TARGET)
+    def test_get_checks_manifest_archive_when_feature_enabled(self, mock_session):
+        artifact = self._artifact()
+        session = MagicMock()
+        session.get.return_value = MagicMock()
+        mock_session.return_value = session
+        with self.feature("organizations:preprod-snapshot-archive-manifest"):
+            response = self.client.get(self._url(artifact.id))
+        assert response.status_code == 200
+        assert response.data["ready"] is True
+        session.get.assert_called_once_with(f"snapshot_archives/v2/{artifact.id}.zip")
 
     @patch(SESSION_TARGET)
     def test_get_reports_not_ready_when_archive_absent(self, mock_session):
@@ -113,7 +137,7 @@ class SnapshotArchiveReadinessTest(BaseSnapshotArchiveTest):
 
 class SnapshotArchiveDownloadTest(BaseSnapshotArchiveTest):
     @patch(SESSION_TARGET)
-    def test_download_streams_when_object_present(self, mock_session):
+    def test_download_streams_manifest_archive_when_feature_enabled(self, mock_session):
         artifact = self._artifact()
         result = MagicMock()
         result.payload.read.side_effect = [b"ZIPBYTES", b""]
@@ -121,10 +145,12 @@ class SnapshotArchiveDownloadTest(BaseSnapshotArchiveTest):
         session = MagicMock()
         session.get.return_value = result
         mock_session.return_value = session
-        response = self.client.get(self._url(artifact.id, download=True))
+        with self.feature("organizations:preprod-snapshot-archive-manifest"):
+            response = self.client.get(self._url(artifact.id, download=True))
         assert response.status_code == 200
         assert response["Content-Type"] == "application/zip"
         assert b"".join(response.streaming_content) == b"ZIPBYTES"
+        session.get.assert_called_once_with(f"snapshot_archives/v2/{artifact.id}.zip")
 
     @patch(SESSION_TARGET)
     def test_download_returns_409_when_absent(self, mock_session):

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
@@ -66,6 +66,41 @@ class ProjectPreprodSnapshotTest(APITestCase):
         assert snapshot_metrics.preprod_artifact == artifact
         assert snapshot_metrics.image_count == 1
 
+    def test_snapshot_upload_rejects_reserved_archive_filename(self) -> None:
+        data = {
+            "app_id": "com.example.app",
+            "images": {
+                "manifest.json": {
+                    "content_hash": "abc123def456",
+                    "width": 375,
+                    "height": 812,
+                },
+            },
+        }
+
+        with self.feature("organizations:preprod-snapshot-archive-manifest"):
+            response = self.client.post(self._get_create_url(), data, format="json")
+
+        assert response.status_code == 400
+        assert response.data["detail"] == "The filename manifest.json is reserved."
+        assert not PreprodArtifact.objects.filter(project=self.project).exists()
+
+    def test_snapshot_upload_allows_reserved_archive_filename_when_feature_disabled(self) -> None:
+        data = {
+            "app_id": "com.example.app",
+            "images": {
+                "manifest.json": {
+                    "content_hash": "abc123def456",
+                    "width": 375,
+                    "height": 812,
+                },
+            },
+        }
+
+        response = self.client.post(self._get_create_url(), data, format="json")
+
+        assert response.status_code == 200
+
     def _compressible_snapshot_payload(self) -> bytes:
         data = {
             "app_id": "com.example.app",

--- a/tests/sentry/preprod/snapshots/test_zip_builder.py
+++ b/tests/sentry/preprod/snapshots/test_zip_builder.py
@@ -4,10 +4,12 @@ import zipfile
 from io import BytesIO
 from unittest.mock import MagicMock
 
+import orjson
 import pytest
 
 from sentry.preprod.snapshots.manifest import ImageMetadata, SnapshotManifest
 from sentry.preprod.snapshots.zip_builder import (
+    SnapshotArchiveVersion,
     SnapshotZipBuildError,
     archive_object_key,
     build_snapshot_zip,
@@ -33,22 +35,40 @@ def _session(data_by_key: dict[str, bytes]) -> MagicMock:
 
 
 def test_build_snapshot_zip_writes_all_images_and_dedupes() -> None:
-    manifest = SnapshotManifest(
-        images={
-            "a.png": _meta("hash_a"),
-            "b.png": _meta("hash_b"),
-            "c.png": _meta("hash_a"),  # shares hash_a -> dedup fetch, two filenames
+    manifest_bytes = orjson.dumps(
+        {
+            "images": {
+                "a.png": {
+                    "content_hash": "hash_a",
+                    "width": 10,
+                    "height": 10,
+                    "source_location": "tests/a.py",
+                },
+                "b.png": {"content_hash": "hash_b", "width": 10, "height": 10},
+                "c.png": {"content_hash": "hash_a", "width": 10, "height": 10},
+            },
+            "custom_top_level": "preserved",
         }
     )
+    manifest = SnapshotManifest(**orjson.loads(manifest_bytes))
     key_prefix = "1/2"
     session = _session({"1/2/hash_a": b"AAA", "1/2/hash_b": b"BBB"})
 
     out = BytesIO()
-    build_snapshot_zip(manifest, session, key_prefix, out, artifact_id=99)
+    build_snapshot_zip(
+        manifest,
+        session,
+        key_prefix,
+        out,
+        artifact_id=99,
+        manifest_bytes=manifest_bytes,
+    )
 
     out.seek(0)
     with zipfile.ZipFile(out) as zf:
-        assert sorted(zf.namelist()) == ["a.png", "b.png", "c.png"]
+        assert sorted(zf.namelist()) == ["a.png", "b.png", "c.png", "manifest.json"]
+        assert zf.namelist()[-1] == "manifest.json"
+        assert zf.read("manifest.json") == manifest_bytes
         assert zf.read("a.png") == b"AAA"
         assert zf.read("c.png") == b"AAA"
         assert zf.read("b.png") == b"BBB"
@@ -58,14 +78,23 @@ def test_build_snapshot_zip_writes_all_images_and_dedupes() -> None:
 
 def test_build_snapshot_zip_empty_manifest() -> None:
     manifest = SnapshotManifest(images={})
+    manifest_bytes = b'{"images":{}}'
     session = _session({})
 
     out = BytesIO()
-    build_snapshot_zip(manifest, session, "1/2", out, artifact_id=99)
+    build_snapshot_zip(
+        manifest,
+        session,
+        "1/2",
+        out,
+        artifact_id=99,
+        manifest_bytes=manifest_bytes,
+    )
 
     out.seek(0)
     with zipfile.ZipFile(out) as zf:
-        assert zf.namelist() == []
+        assert zf.namelist() == ["manifest.json"]
+        assert zf.read("manifest.json") == manifest_bytes
     assert session.get.call_count == 0
 
 
@@ -77,5 +106,22 @@ def test_build_snapshot_zip_raises_on_fetch_failure() -> None:
         build_snapshot_zip(manifest, session, "1/2", BytesIO(), artifact_id=99)
 
 
-def test_archive_object_key_is_deterministic() -> None:
-    assert archive_object_key(284978) == "snapshot_archives/284978.zip"
+def test_build_snapshot_zip_rejects_manifest_filename_collision() -> None:
+    manifest = SnapshotManifest(images={"manifest.json": _meta("hash_a")})
+
+    with pytest.raises(SnapshotZipBuildError, match="filename conflicts"):
+        build_snapshot_zip(
+            manifest,
+            _session({}),
+            "1/2",
+            BytesIO(),
+            artifact_id=99,
+            manifest_bytes=b'{"images":{}}',
+        )
+
+
+def test_archive_object_key_is_versioned() -> None:
+    assert archive_object_key(284978, SnapshotArchiveVersion.V1) == "snapshot_archives/284978.zip"
+    assert archive_object_key(284978, SnapshotArchiveVersion.V2) == (
+        "snapshot_archives/v2/284978.zip"
+    )

--- a/tests/sentry/preprod/snapshots/test_zip_builder.py
+++ b/tests/sentry/preprod/snapshots/test_zip_builder.py
@@ -9,7 +9,6 @@ import pytest
 
 from sentry.preprod.snapshots.manifest import ImageMetadata, SnapshotManifest
 from sentry.preprod.snapshots.zip_builder import (
-    SnapshotArchiveVersion,
     SnapshotZipBuildError,
     archive_object_key,
     build_snapshot_zip,
@@ -120,8 +119,5 @@ def test_build_snapshot_zip_rejects_manifest_filename_collision() -> None:
         )
 
 
-def test_archive_object_key_is_versioned() -> None:
-    assert archive_object_key(284978, SnapshotArchiveVersion.V1) == "snapshot_archives/284978.zip"
-    assert archive_object_key(284978, SnapshotArchiveVersion.V2) == (
-        "snapshot_archives/v2/284978.zip"
-    )
+def test_archive_object_key_is_deterministic() -> None:
+    assert archive_object_key(284978) == "snapshot_archives/284978.zip"

--- a/tests/sentry/preprod/snapshots/test_zip_tasks.py
+++ b/tests/sentry/preprod/snapshots/test_zip_tasks.py
@@ -12,7 +12,6 @@ from objectstore_client.multipart import CompletePart
 from sentry.preprod.models import PreprodArtifact
 from sentry.preprod.snapshots import zip_tasks
 from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
-from sentry.preprod.snapshots.zip_builder import SnapshotArchiveVersion
 from sentry.preprod.snapshots.zip_tasks import (
     _put_part_with_retry,
     _upload_archive_multipart,
@@ -65,7 +64,7 @@ class BuildSnapshotImagesZipTest(TestCase):
 
     @patch("sentry.preprod.snapshots.zip_tasks._send_archive_email")
     @patch(SESSION_TARGET)
-    def test_v2_builds_and_uploads_via_multipart_then_emails(self, mock_session, mock_email):
+    def test_build_includes_manifest_when_requested(self, mock_session, mock_email):
         session = self._session()
         mock_session.return_value = session
         build_snapshot_images_zip(
@@ -73,11 +72,11 @@ class BuildSnapshotImagesZipTest(TestCase):
             project_id=self.project.id,
             artifact_id=self.artifact.id,
             user_id=self.user.id,
-            archive_version=SnapshotArchiveVersion.V2,
+            include_manifest=True,
         )
         session.initiate_multipart_upload.assert_called_once()
         kwargs = session.initiate_multipart_upload.call_args.kwargs
-        assert kwargs["key"] == f"snapshot_archives/v2/{self.artifact.id}.zip"
+        assert kwargs["key"] == f"snapshot_archives/{self.artifact.id}.zip"
         assert kwargs["compression"] == "none"
         assert kwargs["content_type"] == "application/zip"
 
@@ -93,7 +92,7 @@ class BuildSnapshotImagesZipTest(TestCase):
 
     @patch("sentry.preprod.snapshots.zip_tasks._send_archive_email")
     @patch(SESSION_TARGET)
-    def test_v1_build_uses_unversioned_key_and_omits_manifest(self, mock_session, mock_email):
+    def test_build_omits_manifest_by_default(self, mock_session, mock_email):
         session = self._session()
         mock_session.return_value = session
 
@@ -114,7 +113,7 @@ class BuildSnapshotImagesZipTest(TestCase):
 
     @patch("sentry.preprod.snapshots.zip_tasks._send_archive_email")
     @patch(SESSION_TARGET)
-    def test_skips_rebuild_when_archive_exists(self, mock_session, mock_email):
+    def test_reuses_existing_archive_when_manifest_requested(self, mock_session, mock_email):
         session = self._session(existing_archive_key=f"snapshot_archives/{self.artifact.id}.zip")
         mock_session.return_value = session
         build_snapshot_images_zip(
@@ -122,6 +121,7 @@ class BuildSnapshotImagesZipTest(TestCase):
             project_id=self.project.id,
             artifact_id=self.artifact.id,
             user_id=self.user.id,
+            include_manifest=True,
         )
         session.initiate_multipart_upload.assert_not_called()
         mock_email.assert_called_once()

--- a/tests/sentry/preprod/snapshots/test_zip_tasks.py
+++ b/tests/sentry/preprod/snapshots/test_zip_tasks.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import zipfile
 from unittest.mock import MagicMock, patch
 
 import orjson
@@ -11,6 +12,7 @@ from objectstore_client.multipart import CompletePart
 from sentry.preprod.models import PreprodArtifact
 from sentry.preprod.snapshots import zip_tasks
 from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
+from sentry.preprod.snapshots.zip_builder import SnapshotArchiveVersion
 from sentry.preprod.snapshots.zip_tasks import (
     _put_part_with_retry,
     _upload_archive_multipart,
@@ -39,13 +41,16 @@ class BuildSnapshotImagesZipTest(TestCase):
             preprod_artifact=self.artifact, image_count=1, extras={"manifest_key": "mk"}
         )
 
-    def _session(self, *, archive_exists: bool) -> MagicMock:
+    def _session(
+        self,
+        *,
+        existing_archive_key: str | None = None,
+    ) -> MagicMock:
         manifest_key = "mk"
-        archive_key = f"snapshot_archives/{self.artifact.id}.zip"
         image_key = f"{self.org.id}/{self.project.id}/hash_a"
         data = {manifest_key: _manifest_bytes(), image_key: b"PNGDATA"}
-        if archive_exists:
-            data[archive_key] = b"ZIPBYTES"
+        if existing_archive_key is not None:
+            data[existing_archive_key] = b"ZIPBYTES"
 
         def _get(key):
             if key not in data:
@@ -60,31 +65,57 @@ class BuildSnapshotImagesZipTest(TestCase):
 
     @patch("sentry.preprod.snapshots.zip_tasks._send_archive_email")
     @patch(SESSION_TARGET)
-    def test_builds_and_uploads_via_multipart_then_emails(self, mock_session, mock_email):
-        session = self._session(archive_exists=False)
+    def test_v2_builds_and_uploads_via_multipart_then_emails(self, mock_session, mock_email):
+        session = self._session()
         mock_session.return_value = session
         build_snapshot_images_zip(
             org_id=self.org.id,
             project_id=self.project.id,
             artifact_id=self.artifact.id,
             user_id=self.user.id,
+            archive_version=SnapshotArchiveVersion.V2,
         )
         session.initiate_multipart_upload.assert_called_once()
         kwargs = session.initiate_multipart_upload.call_args.kwargs
-        assert kwargs["key"] == f"snapshot_archives/{self.artifact.id}.zip"
+        assert kwargs["key"] == f"snapshot_archives/v2/{self.artifact.id}.zip"
         assert kwargs["compression"] == "none"
         assert kwargs["content_type"] == "application/zip"
 
         upload = session.initiate_multipart_upload.return_value
         assert upload.put_part.call_count >= 1
+        archive_bytes = b"".join(call.args[0] for call in upload.put_part.call_args_list)
+        with zipfile.ZipFile(io.BytesIO(archive_bytes)) as archive:
+            assert sorted(archive.namelist()) == ["a.png", "manifest.json"]
+            assert archive.read("manifest.json") == _manifest_bytes()
         upload.complete.assert_called_once()
         mock_email.assert_called_once()
         assert mock_email.call_args.kwargs["ready"] is True
 
     @patch("sentry.preprod.snapshots.zip_tasks._send_archive_email")
     @patch(SESSION_TARGET)
+    def test_v1_build_uses_unversioned_key_and_omits_manifest(self, mock_session, mock_email):
+        session = self._session()
+        mock_session.return_value = session
+
+        build_snapshot_images_zip(
+            org_id=self.org.id,
+            project_id=self.project.id,
+            artifact_id=self.artifact.id,
+            user_id=self.user.id,
+        )
+
+        kwargs = session.initiate_multipart_upload.call_args.kwargs
+        assert kwargs["key"] == f"snapshot_archives/{self.artifact.id}.zip"
+        upload = session.initiate_multipart_upload.return_value
+        archive_bytes = b"".join(call.args[0] for call in upload.put_part.call_args_list)
+        with zipfile.ZipFile(io.BytesIO(archive_bytes)) as archive:
+            assert archive.namelist() == ["a.png"]
+        assert mock_email.call_args.kwargs["ready"] is True
+
+    @patch("sentry.preprod.snapshots.zip_tasks._send_archive_email")
+    @patch(SESSION_TARGET)
     def test_skips_rebuild_when_archive_exists(self, mock_session, mock_email):
-        session = self._session(archive_exists=True)
+        session = self._session(existing_archive_key=f"snapshot_archives/{self.artifact.id}.zip")
         mock_session.return_value = session
         build_snapshot_images_zip(
             org_id=self.org.id,
@@ -99,7 +130,7 @@ class BuildSnapshotImagesZipTest(TestCase):
     @patch("sentry.preprod.snapshots.zip_tasks._send_archive_email")
     @patch(SESSION_TARGET)
     def test_emails_failure_when_upload_raises(self, mock_session, mock_email):
-        session = self._session(archive_exists=False)
+        session = self._session()
         session.initiate_multipart_upload.side_effect = RuntimeError("boom")
         mock_session.return_value = session
         build_snapshot_images_zip(
@@ -117,7 +148,7 @@ class BuildSnapshotImagesZipTest(TestCase):
     def test_emails_ready_when_failure_superseded_by_existing_archive(
         self, mock_session, mock_email, mock_available
     ):
-        session = self._session(archive_exists=False)
+        session = self._session()
         session.initiate_multipart_upload.side_effect = RuntimeError("boom")
         mock_session.return_value = session
         build_snapshot_images_zip(
@@ -133,7 +164,7 @@ class BuildSnapshotImagesZipTest(TestCase):
     @patch(SESSION_TARGET)
     def test_emails_failure_when_metrics_missing(self, mock_session, mock_email):
         self.artifact.preprodsnapshotmetrics.delete()
-        mock_session.return_value = self._session(archive_exists=False)
+        mock_session.return_value = self._session()
         build_snapshot_images_zip(
             org_id=self.org.id,
             project_id=self.project.id,


### PR DESCRIPTION
Add a flag to gate new logic which will cause snapshot archives to include the associated JSON manifest file alongside image data. This will be written to the archive as the top-level file `manifest.json`. When enabled, we'll write the manifest into the archive when the archive is lazily produced. Existing archives will not be altered. The change is disabled by default as we need workers to accept a new parameter thus need to roll out a deployment before enabling the flag.

Refs EME-1246