### PR TITLE
chore(post-process): clean up rollout option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1087,12 +1087,6 @@ register(
     type=Bool,
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
-register(
-    "seer.post-process-issue-summary.rollout-rate",
-    type=Float,
-    default=0.0,
-    flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 register(
     "seer.similarity-killswitch.enabled",

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -24,7 +24,6 @@ from sentry.killswitches import (
     killswitch_matches_context,
     value_matches,
 )
-from sentry.options.rollout import in_rollout_group
 from sentry.replays.lib.event_linking import transform_event_for_linking_payload
 from sentry.replays.lib.kafka import publish_replay_event
 from sentry.signals import event_processed, issue_unignored
@@ -1570,11 +1569,6 @@ def kick_off_seer_automation(job: PostProcessJob) -> None:
 
     event = job["event"]
     group = event.group
-
-    if not in_rollout_group(
-        "seer.post-process-issue-summary.rollout-rate", event.project.organization_id
-    ):
-        return
 
     if is_seer_seat_based_tier_enabled(group.organization):
         if group.seer_fixability_score is not None:

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -2937,7 +2937,6 @@ class PipelineKillswitchTestMixin(BasePostProcessGroupMixin):
 class KickOffSeerAutomationTestMixin(BasePostProcessGroupMixin):
     @patch("sentry.tasks.seer.autofix.generate_summary_and_run_automation.delay")
     @with_feature("organizations:gen-ai-features")
-    @override_options({"seer.post-process-issue-summary.rollout-rate": 1.0})
     def test_kick_off_seer_automation_with_features(self, mock_generate_summary_and_run_automation):
         self.project.update_option("sentry:seer_scanner_automation", True)
         event = self.create_event(
@@ -2957,7 +2956,6 @@ class KickOffSeerAutomationTestMixin(BasePostProcessGroupMixin):
         )
 
     @patch("sentry.tasks.seer.autofix.generate_summary_and_run_automation.delay")
-    @override_options({"seer.post-process-issue-summary.rollout-rate": 1.0})
     def test_kick_off_seer_automation_without_org_feature(
         self, mock_generate_summary_and_run_automation
     ):
@@ -2977,7 +2975,6 @@ class KickOffSeerAutomationTestMixin(BasePostProcessGroupMixin):
 
     @patch("sentry.tasks.seer.autofix.generate_summary_and_run_automation.delay")
     @with_feature("organizations:gen-ai-features")
-    @override_options({"seer.post-process-issue-summary.rollout-rate": 1.0})
     def test_kick_off_seer_automation_without_scanner_on(
         self, mock_generate_summary_and_run_automation
     ):
@@ -2999,7 +2996,6 @@ class KickOffSeerAutomationTestMixin(BasePostProcessGroupMixin):
 
     @patch("sentry.tasks.seer.autofix.generate_summary_and_run_automation.delay")
     @with_feature("organizations:gen-ai-features")
-    @override_options({"seer.post-process-issue-summary.rollout-rate": 1.0})
     def test_kick_off_seer_automation_skips_existing_fixability_score(
         self, mock_generate_summary_and_run_automation
     ):
@@ -3025,7 +3021,6 @@ class KickOffSeerAutomationTestMixin(BasePostProcessGroupMixin):
 
     @patch("sentry.tasks.seer.autofix.generate_summary_and_run_automation.delay")
     @with_feature("organizations:gen-ai-features")
-    @override_options({"seer.post-process-issue-summary.rollout-rate": 1.0})
     def test_kick_off_seer_automation_runs_with_missing_fixability_score(
         self, mock_generate_summary_and_run_automation
     ):
@@ -3052,7 +3047,6 @@ class KickOffSeerAutomationTestMixin(BasePostProcessGroupMixin):
 
     @patch("sentry.tasks.seer.autofix.generate_summary_and_run_automation.delay")
     @with_feature("organizations:gen-ai-features")
-    @override_options({"seer.post-process-issue-summary.rollout-rate": 1.0})
     def test_kick_off_seer_automation_skips_with_existing_fixability_score(
         self, mock_generate_summary_and_run_automation
     ):
@@ -3086,7 +3080,6 @@ class KickOffSeerAutomationTestMixin(BasePostProcessGroupMixin):
     @patch("sentry.quotas.backend.check_seer_quota")
     @patch("sentry.tasks.seer.autofix.generate_summary_and_run_automation.delay")
     @with_feature("organizations:gen-ai-features")
-    @override_options({"seer.post-process-issue-summary.rollout-rate": 1.0})
     def test_rate_limit_only_checked_after_all_other_checks_pass(
         self,
         mock_generate_summary_and_run_automation,
@@ -3158,7 +3151,6 @@ class KickOffSeerAutomationTestMixin(BasePostProcessGroupMixin):
 
     @patch("sentry.tasks.seer.autofix.generate_summary_and_run_automation.delay")
     @with_feature("organizations:gen-ai-features")
-    @override_options({"seer.post-process-issue-summary.rollout-rate": 1.0})
     def test_kick_off_seer_automation_skips_when_lock_held(
         self, mock_generate_summary_and_run_automation
     ):
@@ -3208,7 +3200,6 @@ class KickOffSeerAutomationTestMixin(BasePostProcessGroupMixin):
 
     @patch("sentry.tasks.seer.autofix.generate_summary_and_run_automation.delay")
     @with_feature("organizations:gen-ai-features")
-    @override_options({"seer.post-process-issue-summary.rollout-rate": 1.0})
     def test_kick_off_seer_automation_with_hide_ai_features_enabled(
         self, mock_generate_summary_and_run_automation
     ):
@@ -3297,19 +3288,6 @@ class SeatBasedSeerAutomationTestMixin(BasePostProcessGroupMixin):
 
     @patch("sentry.tasks.seer.autofix.generate_issue_summary_only.delay")
     @with_feature({"organizations:gen-ai-features": True})
-    @override_options({"seer.post-process-issue-summary.rollout-rate": 0.0})
-    def test_seat_based_org_rollout_skips_tier_check(
-        self, mock_generate_summary_only, mock_seat_based_tier
-    ):
-        event = self.create_event(data={"message": "testing"}, project_id=self.project.id)
-        post_process_module.kick_off_seer_automation({"event": event})
-
-        mock_seat_based_tier.assert_not_called()
-        mock_generate_summary_only.assert_not_called()
-
-    @patch("sentry.tasks.seer.autofix.generate_issue_summary_only.delay")
-    @with_feature({"organizations:gen-ai-features": True})
-    @override_options({"seer.post-process-issue-summary.rollout-rate": 1.0})
     def test_seat_based_org_skips_old_issues(
         self, mock_generate_summary_only, mock_seat_based_tier
     ):
@@ -3318,7 +3296,6 @@ class SeatBasedSeerAutomationTestMixin(BasePostProcessGroupMixin):
 
     @patch("sentry.tasks.seer.autofix.generate_issue_summary_only.delay")
     @with_feature({"organizations:gen-ai-features": True})
-    @override_options({"seer.post-process-issue-summary.rollout-rate": 1.0})
     def test_seat_based_org_skips_when_fixability_exists(
         self, mock_generate_summary_only, mock_seat_based_tier
     ):
@@ -3410,7 +3387,6 @@ class PostProcessGroupErrorTest(
     @patch("sentry.seer.autofix.utils.is_seer_seat_based_tier_enabled", return_value=True)
     @patch("sentry.tasks.seer.autofix.generate_issue_summary_only.delay")
     @with_feature({"organizations:gen-ai-features": True})
-    @override_options({"seer.post-process-issue-summary.rollout-rate": 1.0})
     def test_seat_based_org_generates_summary_for_new_issues(
         self, mock_generate_summary_only, mock_seat_based_tier
     ):


### PR DESCRIPTION
Since we have post process job level killswitches now, and since this has been rolled out fully, we can remove this rollout option added by https://github.com/getsentry/sentry/pull/121481. Basically I don't see a reason why we'd need a rollout that isn't 100% or 0% for the foreseeable future.