### PR TITLE
chore(workflow-engine): Skip PR workflows being automatically created if self-hosted

### DIFF
--- a/src/sentry/workflow_engine/defaults/workflows.py
+++ b/src/sentry/workflow_engine/defaults/workflows.py
@@ -8,6 +8,7 @@ from sentry.models.project import Project
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.types import FallthroughChoiceType
 from sentry.utils.locking import UnableToAcquireLock
+from sentry.utils.settings import is_self_hosted
 from sentry.workflow_engine.defaults.detectors import (
     UnableToAcquireLockApiError,
     _ensure_detector,
@@ -214,5 +215,7 @@ def ensure_pull_request_workflow(organization: Organization, detector: Detector)
 
 def ensure_default_organization_workflows(organization: Organization) -> list[Workflow]:
     all_projects_detector = ensure_default_all_projects_detector(organization.id)
-    workflows = [ensure_pull_request_workflow(organization, all_projects_detector)]
+    workflows: list[Workflow] = []
+    if not is_self_hosted():
+        workflows.append(ensure_pull_request_workflow(organization, all_projects_detector))
     return workflows

--- a/tests/sentry/workflow_engine/defaults/test_workflows.py
+++ b/tests/sentry/workflow_engine/defaults/test_workflows.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from sentry.notifications.types import FallthroughChoiceType
 from sentry.testutils.cases import TestCase
 from sentry.workflow_engine.defaults.detectors import (
@@ -321,7 +323,8 @@ class TestEnsurePullRequestWorkflow(TestCase):
 
 
 class TestEnsureDefaultOrganizationWorkflows(TestCase):
-    def test_creates_and_connects_workflows(self) -> None:
+    @mock.patch("sentry.workflow_engine.defaults.workflows.is_self_hosted", return_value=False)
+    def test_creates_and_connects_workflows(self, mock_is_self_hosted: mock.MagicMock) -> None:
         workflows = ensure_default_organization_workflows(self.organization)
 
         assert len(workflows) == 1
@@ -334,7 +337,8 @@ class TestEnsureDefaultOrganizationWorkflows(TestCase):
         assert connection.detector.project is None
         assert connection.detector.config["organization_id"] == self.organization.id
 
-    def test_uses_existing_all_projects_detector(self) -> None:
+    @mock.patch("sentry.workflow_engine.defaults.workflows.is_self_hosted", return_value=False)
+    def test_uses_existing_all_projects_detector(self, mock_is_self_hosted: mock.MagicMock) -> None:
         existing_detector = ensure_default_all_projects_detector(self.organization.id)
         workflows = ensure_default_organization_workflows(self.organization)
 
@@ -350,7 +354,15 @@ class TestEnsureDefaultOrganizationWorkflows(TestCase):
             == 1
         )
 
-    def test_returns_workflows_list(self) -> None:
+    @mock.patch("sentry.workflow_engine.defaults.workflows.is_self_hosted", return_value=False)
+    def test_returns_workflows_list(self, mock_is_self_hosted: mock.MagicMock) -> None:
         workflows = ensure_default_organization_workflows(self.organization)
         assert isinstance(workflows, list)
         assert all(isinstance(w, Workflow) for w in workflows)
+
+    @mock.patch("sentry.workflow_engine.defaults.workflows.is_self_hosted", return_value=True)
+    def test_skips_pull_request_workflow_when_self_hosted(
+        self, mock_is_self_hosted: mock.MagicMock
+    ) -> None:
+        workflows = ensure_default_organization_workflows(self.organization)
+        assert workflows == []

--- a/tests/sentry/workflow_engine/receivers/test_organization_workflows.py
+++ b/tests/sentry/workflow_engine/receivers/test_organization_workflows.py
@@ -24,7 +24,8 @@ class TestCreateOrganizationWorkflows(TestCase):
         ).exists()
 
     @override_options({"workflow_engine.all_projects_auto_creation_enabled": True})
-    def test_creates_workflow(self) -> None:
+    @mock.patch("sentry.workflow_engine.defaults.workflows.is_self_hosted", return_value=False)
+    def test_creates_workflow(self, mock_is_self_hosted: mock.MagicMock) -> None:
         self.send_signal()
         workflow = Workflow.objects.get(
             organization=self.organization, name=PULL_REQUEST_WORKFLOW_LABEL
@@ -32,7 +33,8 @@ class TestCreateOrganizationWorkflows(TestCase):
         assert workflow.enabled
 
     @override_options({"workflow_engine.all_projects_auto_creation_enabled": True})
-    def test_connects_workflow_to_detector(self) -> None:
+    @mock.patch("sentry.workflow_engine.defaults.workflows.is_self_hosted", return_value=False)
+    def test_connects_workflow_to_detector(self, mock_is_self_hosted: mock.MagicMock) -> None:
         self.send_signal()
         workflow = Workflow.objects.get(
             organization=self.organization, name=PULL_REQUEST_WORKFLOW_LABEL
@@ -40,7 +42,8 @@ class TestCreateOrganizationWorkflows(TestCase):
         assert DetectorWorkflow.objects.filter(workflow=workflow).exists()
 
     @override_options({"workflow_engine.all_projects_auto_creation_enabled": True})
-    def test_no_duplicates_ever(self) -> None:
+    @mock.patch("sentry.workflow_engine.defaults.workflows.is_self_hosted", return_value=False)
+    def test_no_duplicates_ever(self, mock_is_self_hosted: mock.MagicMock) -> None:
         # Multiple signal emissions
         self.send_signal()
         self.send_signal()


### PR DESCRIPTION
They don't have seer, so it just adds work as they'd immediately remove it right after.

Updates tests and adds one more to make sure self-hosted doesn't get anything.