### PR TITLE
fix(onboarding): Clarify team access to project alerts

### DIFF
--- a/static/app/components/onboarding/scm/scmProjectDetailsCore.tsx
+++ b/static/app/components/onboarding/scm/scmProjectDetailsCore.tsx
@@ -71,7 +71,7 @@ export function ScmProjectDetailsCore({
             />
             <Container>
               <Text variant="muted" density="comfortable" size="sm">
-                {t('Set who owns alerts for this project')}
+                {t('This team can access the project and receive alerts')}
               </Text>
             </Container>
           </Stack>


### PR DESCRIPTION
Updates the Team helper text in SCM project creation to describe project access and alert delivery without implying that alerts are team-owned.

Fixes VDY-156
