### PR TITLE
fix(jira): Add pagination to Jira project status getting

### DIFF
--- a/src/sentry/integrations/jira/client.py
+++ b/src/sentry/integrations/jira/client.py
@@ -21,6 +21,9 @@ JIRA_KEY = f"{urlparse(absolute_uri()).hostname}.jira"
 ISSUE_KEY_RE = re.compile(r"^[A-Za-z][A-Za-z0-9]*-\d+$")
 CUSTOMFIELD_PREFIX = "customfield_"
 
+STATUS_SEARCH_PAGE_SIZE = 200
+STATUS_SEARCH_MAX_PAGES = 20
+
 
 class JiraCloudClient(ApiClient):
     # TODO: Update to v3 endpoints
@@ -46,6 +49,9 @@ class JiraCloudClient(ApiClient):
     PROPERTIES_URL = "/rest/api/3/issue/%s/properties/%s"
 
     integration_name = IntegrationProviderSlug.JIRA.value
+    # Configures `get_with_pagination`, used by the paginated `get_project_statuses`.
+    page_size = STATUS_SEARCH_PAGE_SIZE
+    page_number_limit = STATUS_SEARCH_MAX_PAGES
 
     # This timeout is completely arbitrary. Jira doesn't give us any
     # caching headers to work with. Ideally we want a duration that
@@ -231,5 +237,18 @@ class JiraCloudClient(ApiClient):
             self.AUTOCOMPLETE_URL, params={"fieldName": jql_name, "fieldValue": value}
         )
 
-    def get_project_statuses(self, project_id: str) -> dict[str, Any]:
-        return dict(self.get_cached(self.STATUS_SEARCH_URL, params={"projectId": project_id}))
+    def get_project_statuses(self, project_id: str, paginate: bool = False) -> dict[str, Any]:
+        if not paginate:
+            # TODO: Remove this after rolling out lazy status feature flag fully
+            return dict(self.get_cached(self.STATUS_SEARCH_URL, params={"projectId": project_id}))
+
+        values = self.get_with_pagination(
+            self.STATUS_SEARCH_URL,
+            gen_params=lambda page_num, page_size: {
+                "projectId": project_id,
+                "startAt": page_num * page_size,
+                "maxResults": page_size,
+            },
+            get_results=lambda resp: resp.get("values", []),
+        )
+        return {"values": values}

--- a/src/sentry/integrations/jira/endpoints/search.py
+++ b/src/sentry/integrations/jira/endpoints/search.py
@@ -72,7 +72,7 @@ class JiraSearchEndpoint(IntegrationEndpoint):
             ).capture() as lifecycle:
                 lifecycle.add_extra("field", field)
                 try:
-                    response = jira_client.get_project_statuses(project_id)
+                    response = jira_client.get_project_statuses(project_id, paginate=True)
                 except (ApiUnauthorized, ApiError) as e:
                     lifecycle.record_halt(e)
                     return Response({"detail": "Unable to fetch statuses from Jira"}, status=400)

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -356,9 +356,9 @@ class JiraIntegration(IssueSyncIntegration):
         )
         for project in configured_projects:
             try:
-                project_statuses = client.get_project_statuses(project.external_id).get(
-                    "values", []
-                )
+                project_statuses = client.get_project_statuses(
+                    project.external_id, paginate=True
+                ).get("values", [])
             except ApiError:
                 continue
             statuses = [(c["id"], c["name"]) for c in project_statuses]

--- a/tests/sentry/integrations/jira/test_client.py
+++ b/tests/sentry/integrations/jira/test_client.py
@@ -5,6 +5,7 @@ import responses
 from requests import PreparedRequest, Request
 from responses.matchers import header_matcher, query_string_matcher
 
+from sentry.integrations.jira.client import STATUS_SEARCH_MAX_PAGES, STATUS_SEARCH_PAGE_SIZE
 from sentry.integrations.utils.atlassian_connect import get_query_hash
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
@@ -111,3 +112,120 @@ class JiraClientTest(TestCase):
                 uri=self.jira_client.SERVER_INFO_URL, method=method, query_params=params
             ),
         }
+
+    @responses.activate
+    @mock.patch(
+        "sentry.integrations.jira.integration.JiraCloudClient.finalize_request",
+        side_effect=mock_finalize_request,
+    )
+    def test_get_project_statuses_default_no_pagination(
+        self, mock_finalize: mock.MagicMock
+    ) -> None:
+        """Without paginate=True, we make a single (200-capped) request and return it raw."""
+        body = {"values": [{"id": "1", "name": "Status 1"}], "isLast": True}
+        responses.add(
+            method=responses.GET,
+            url="https://example.atlassian.net/rest/api/2/statuses/search",
+            body=json.dumps(body),
+            status=200,
+            content_type="application/json",
+        )
+
+        result = self.jira_client.get_project_statuses("99999")
+
+        assert result == body
+        assert len(responses.calls) == 1
+        assert "startAt" not in responses.calls[0].request.url
+
+    @responses.activate
+    @mock.patch(
+        "sentry.integrations.jira.integration.JiraCloudClient.finalize_request",
+        side_effect=mock_finalize_request,
+    )
+    def test_get_project_statuses_single_page(self, mock_finalize: mock.MagicMock) -> None:
+        statuses = [{"id": str(i), "name": f"Status {i}"} for i in range(5)]
+        responses.add(
+            method=responses.GET,
+            url="https://example.atlassian.net/rest/api/2/statuses/search",
+            body=json.dumps({"values": statuses, "isLast": True}),
+            status=200,
+            content_type="application/json",
+        )
+
+        result = self.jira_client.get_project_statuses("10001", paginate=True)
+
+        assert result == {"values": statuses}
+        assert len(responses.calls) == 1
+
+    @responses.activate
+    @mock.patch(
+        "sentry.integrations.jira.integration.JiraCloudClient.finalize_request",
+        side_effect=mock_finalize_request,
+    )
+    def test_get_project_statuses_multiple_pages(self, mock_finalize: mock.MagicMock) -> None:
+        page1 = [{"id": str(i), "name": f"Status {i}"} for i in range(STATUS_SEARCH_PAGE_SIZE)]
+        page2 = [
+            {"id": str(i), "name": f"Status {i}"}
+            for i in range(STATUS_SEARCH_PAGE_SIZE, STATUS_SEARCH_PAGE_SIZE + 50)
+        ]
+        responses.add(
+            method=responses.GET,
+            url="https://example.atlassian.net/rest/api/2/statuses/search",
+            body=json.dumps({"values": page1, "isLast": False}),
+            status=200,
+            content_type="application/json",
+        )
+        responses.add(
+            method=responses.GET,
+            url="https://example.atlassian.net/rest/api/2/statuses/search",
+            body=json.dumps({"values": page2, "isLast": True}),
+            status=200,
+            content_type="application/json",
+        )
+
+        result = self.jira_client.get_project_statuses("10001", paginate=True)
+
+        assert result == {"values": page1 + page2}
+        assert len(responses.calls) == 2
+
+    @responses.activate
+    @mock.patch(
+        "sentry.integrations.jira.integration.JiraCloudClient.finalize_request",
+        side_effect=mock_finalize_request,
+    )
+    def test_get_project_statuses_page_cap(self, mock_finalize: mock.MagicMock) -> None:
+        full_page = [{"id": str(i), "name": f"Status {i}"} for i in range(STATUS_SEARCH_PAGE_SIZE)]
+        for _ in range(STATUS_SEARCH_MAX_PAGES):
+            responses.add(
+                method=responses.GET,
+                url="https://example.atlassian.net/rest/api/2/statuses/search",
+                body=json.dumps({"values": full_page, "isLast": False}),
+                status=200,
+                content_type="application/json",
+            )
+
+        result = self.jira_client.get_project_statuses("10001", paginate=True)
+
+        assert len(result["values"]) == STATUS_SEARCH_PAGE_SIZE * STATUS_SEARCH_MAX_PAGES
+        assert len(responses.calls) == STATUS_SEARCH_MAX_PAGES
+
+    @responses.activate
+    @mock.patch(
+        "sentry.integrations.jira.integration.JiraCloudClient.finalize_request",
+        side_effect=mock_finalize_request,
+    )
+    def test_get_project_statuses_stops_on_short_page(self, mock_finalize: mock.MagicMock) -> None:
+        """Even if isLast is not set, a short page stops pagination."""
+        short_page = [{"id": "1", "name": "Status 1"}]
+        responses.add(
+            method=responses.GET,
+            url="https://example.atlassian.net/rest/api/2/statuses/search",
+            body=json.dumps({"values": short_page}),
+            status=200,
+            content_type="application/json",
+        )
+
+        result = self.jira_client.get_project_statuses("10001", paginate=True)
+
+        assert result == {"values": short_page}
+        assert len(responses.calls) == 1


### PR DESCRIPTION
Basically gated behind the lazy-status feature flag, but for those processes we're getting the default first 200 statuses but that's not enough for big projects that have like 500+