### PR TITLE
fix(autofix): don't treat a failed push as an opened PR

### DIFF
--- a/src/sentry/seer/agent/client_models.py
+++ b/src/sentry/seer/agent/client_models.py
@@ -289,11 +289,15 @@ class SeerRunState(BaseModel):
         ``repo_pr_states`` also holds repos whose push failed, so a plain
         truthiness check treats a failed run as one that opened PRs — which
         would, for instance, refuse to re-run a step that stranded nothing.
+
+        ``pr_number`` is what says the PR exists: seer only ever sets it from a
+        created pull request, so an errored state that carries one is a PR that
+        opened and then took a failed push, not a creation that never landed.
         """
         return [
             pr_state
             for pr_state in self.repo_pr_states.values()
-            if pr_state.pr_creation_status != "error"
+            if pr_state.pr_creation_status != "error" or pr_state.pr_number is not None
         ]
 
     def get_artifacts(self) -> dict[str, Artifact]:

--- a/src/sentry/seer/agent/client_models.py
+++ b/src/sentry/seer/agent/client_models.py
@@ -112,12 +112,6 @@ class RepoPRState(BaseModel):
     commit_sha: str | None = None
     pr_creation_status: Literal["creating", "completed", "error"] | None = None
     pr_creation_error: str | None = None
-    # Attributed cause of a push failure, when seer could determine one. Both
-    # values mean the push carried a `.github/workflows/` entry, which the
-    # GitHub App is not allowed to write: "workflow_patch" when the run's own
-    # changes touch a workflow file, "workflow_drift" when the base branch moved
-    # past our pinned commit with a workflow change of someone else's.
-    pr_creation_error_reason: Literal["workflow_patch", "workflow_drift"] | None = None
     title: str | None = None
     description: str | None = None
     integration_id: str | None = None

--- a/src/sentry/seer/agent/client_models.py
+++ b/src/sentry/seer/agent/client_models.py
@@ -112,6 +112,12 @@ class RepoPRState(BaseModel):
     commit_sha: str | None = None
     pr_creation_status: Literal["creating", "completed", "error"] | None = None
     pr_creation_error: str | None = None
+    # Attributed cause of a push failure, when seer could determine one. Both
+    # values mean the push carried a `.github/workflows/` entry, which the
+    # GitHub App is not allowed to write: "workflow_patch" when the run's own
+    # changes touch a workflow file, "workflow_drift" when the base branch moved
+    # past our pinned commit with a workflow change of someone else's.
+    pr_creation_error_reason: Literal["workflow_patch", "workflow_drift"] | None = None
     title: str | None = None
     description: str | None = None
     integration_id: str | None = None
@@ -275,6 +281,20 @@ class SeerRunState(BaseModel):
 
     class Config:
         extra = "ignore"
+
+    def get_created_pull_request_states(self) -> list[RepoPRState]:
+        """
+        The repos this run actually got a pull request onto.
+
+        ``repo_pr_states`` also holds repos whose push failed, so a plain
+        truthiness check treats a failed run as one that opened PRs — which
+        would, for instance, refuse to re-run a step that stranded nothing.
+        """
+        return [
+            pr_state
+            for pr_state in self.repo_pr_states.values()
+            if pr_state.pr_creation_status != "error"
+        ]
 
     def get_artifacts(self) -> dict[str, Artifact]:
         """

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -373,7 +373,7 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                 except SeerPermissionError:
                     raise PermissionDenied(SEER_PERMISSION_DENIED)
 
-                if not run_state.repo_pr_states:
+                if not run_state.get_created_pull_request_states():
                     return Response(
                         {"detail": "Cannot iterate on a PR before one has been created"},
                         status=status.HTTP_400_BAD_REQUEST,
@@ -421,7 +421,7 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                             return Response(status=status.HTTP_404_NOT_FOUND)
                         raise PermissionDenied(SEER_PERMISSION_DENIED)
 
-                    if run_state.repo_pr_states or run_state.coding_agents:
+                    if run_state.get_created_pull_request_states() or run_state.coding_agents:
                         return Response(
                             {
                                 "detail": "Cannot re-run a step after a pull request or coding agent has started"

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -440,6 +440,39 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
 
     @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
     @patch("sentry.seer.endpoints.group_ai_autofix.get_autofix_run_state")
+    def test_insert_index_rejected_when_push_failed_onto_open_pr(
+        self, mock_run_state, mock_trigger_explorer
+    ):
+        """A push onto an already-open PR can fail, and that PR is still stranded."""
+        group = self.create_group()
+        mock_run_state.return_value = SeerRunState(
+            run_id=42,
+            blocks=[],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+            repo_pr_states={
+                "owner/repo": RepoPRState(
+                    repo_name="owner/repo",
+                    pr_number=7,
+                    pr_url="https://github.com/owner/repo/pull/7",
+                    pr_creation_status="error",
+                    pr_creation_error_reason="workflow_drift",
+                )
+            },
+        )
+
+        self.login_as(user=self.user)
+        response = self.client.post(
+            self._get_url(group.id),
+            data={"step": "solution", "run_id": 42, "insert_index": 3},
+            format="json",
+        )
+
+        assert response.status_code == 409, response.data
+        mock_trigger_explorer.assert_not_called()
+
+    @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
+    @patch("sentry.seer.endpoints.group_ai_autofix.get_autofix_run_state")
     def test_insert_index_unknown_run_returns_404(self, mock_run_state, mock_trigger_explorer):
         """The re-run guard surfaces an unknown run as 404, not 403."""
         group = self.create_group()
@@ -661,6 +694,42 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert response.status_code == 400, response.data
         assert response.data["detail"] == "Cannot iterate on a PR before one has been created"
         mock_try_enqueue.assert_not_called()
+
+    @with_feature("organizations:autofix-pr-iteration-manual")
+    @patch("sentry.seer.endpoints.group_ai_autofix.consume_queued_autofix_feedback")
+    @patch("sentry.seer.endpoints.group_ai_autofix.try_enqueue_autofix_feedback")
+    @patch("sentry.seer.endpoints.group_ai_autofix.get_autofix_run_state")
+    def test_pr_iteration_allowed_when_push_failed_onto_open_pr(
+        self, mock_run_state, mock_try_enqueue, mock_consume
+    ):
+        """The failed push is the thing to iterate out of, so the PR still counts."""
+        group = self.create_group()
+        mock_run_state.return_value = SeerRunState(
+            run_id=123,
+            blocks=[],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+            repo_pr_states={
+                "owner/repo": RepoPRState(
+                    repo_name="owner/repo",
+                    pr_number=7,
+                    pr_url="https://github.com/owner/repo/pull/7",
+                    pr_creation_status="error",
+                    pr_creation_error_reason="workflow_drift",
+                )
+            },
+        )
+
+        self.login_as(user=self.user)
+        response = self.client.post(
+            self._get_url(group.id),
+            data={"step": "pr_iteration", "run_id": 123, "user_context": "please fix this"},
+            format="json",
+        )
+
+        assert response.status_code == 202, response.data
+        mock_try_enqueue.assert_called_once()
+        mock_consume.apply_async.assert_called_once()
 
     @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
     def test_post_continue_unknown_run_returns_404(self, mock_trigger_explorer):

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -423,7 +423,6 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
                 "owner/repo": RepoPRState(
                     repo_name="owner/repo",
                     pr_creation_status="error",
-                    pr_creation_error_reason="workflow_patch",
                 )
             },
         )
@@ -456,7 +455,6 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
                     pr_number=7,
                     pr_url="https://github.com/owner/repo/pull/7",
                     pr_creation_status="error",
-                    pr_creation_error_reason="workflow_drift",
                 )
             },
         )
@@ -715,7 +713,6 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
                     pr_number=7,
                     pr_url="https://github.com/owner/repo/pull/7",
                     pr_creation_status="error",
-                    pr_creation_error_reason="workflow_drift",
                 )
             },
         )

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -406,6 +406,40 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
 
     @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
     @patch("sentry.seer.endpoints.group_ai_autofix.get_autofix_run_state")
+    def test_insert_index_allowed_when_pr_creation_failed(
+        self, mock_run_state, mock_trigger_explorer
+    ):
+        """A push that failed stranded no PR, so the re-run is allowed."""
+        group = self.create_group()
+        mock_trigger_explorer.return_value = self.create_seer_run(
+            organization=self.organization, seer_run_state_id=42
+        )
+        mock_run_state.return_value = SeerRunState(
+            run_id=42,
+            blocks=[],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+            repo_pr_states={
+                "owner/repo": RepoPRState(
+                    repo_name="owner/repo",
+                    pr_creation_status="error",
+                    pr_creation_error_reason="workflow_patch",
+                )
+            },
+        )
+
+        self.login_as(user=self.user)
+        response = self.client.post(
+            self._get_url(group.id),
+            data={"step": "code_changes", "run_id": 42, "insert_index": 3},
+            format="json",
+        )
+
+        assert response.status_code == 202, response.data
+        mock_trigger_explorer.assert_called_once()
+
+    @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
+    @patch("sentry.seer.endpoints.group_ai_autofix.get_autofix_run_state")
     def test_insert_index_unknown_run_returns_404(self, mock_run_state, mock_trigger_explorer):
         """The re-run guard surfaces an unknown run as 404, not 403."""
         group = self.create_group()


### PR DESCRIPTION
A push that failed still leaves an entry in repo_pr_states, so the
re-run guard rejected retrying a step that stranded nothing (409) and
PR iteration counted a failed repo toward the multi-repo rejection.
Count only repos that actually got a pull request.

Related to CW-1589 — does not resolve it.