### PR TITLE
feat(seer): Enrich Autofix overview pull requests with SCM status

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -1231,9 +1231,13 @@ class GitHubBaseClient(
         )
 
     def _get_pull_request_status_cache_key(self, pull_request: PullRequestStatusRequest) -> str:
-        cache_data = orjson.dumps(
-            {"repo": pull_request.repo, "pull_number": pull_request.pull_number}
-        ).decode()
+        cache_key_data: dict[str, str | bool] = {
+            "repo": pull_request.repo,
+            "pull_number": pull_request.pull_number,
+        }
+        if pull_request.include_files:
+            cache_key_data["include_files"] = True
+        cache_data = orjson.dumps(cache_key_data).decode()
         return self.get_cache_key("/graphql/pull-request-status", "", cache_data)
 
     def get_pull_request_statuses(

--- a/src/sentry/integrations/github/pull_request_status.py
+++ b/src/sentry/integrations/github/pull_request_status.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 from sentry.integrations.source_code_management.status_check import (
     AggregateChecksStatus,
     AggregateReviewStatus,
+    PullRequestFileSummary,
     PullRequestStatusRequest,
     PullRequestStatusResult,
 )
@@ -21,6 +22,19 @@ fragment PullRequestStatusFields on PullRequest {
           state
         }
       }
+    }
+  }
+}
+"""
+
+PULL_REQUEST_FILES_FRAGMENT = """
+fragment PullRequestFilesFields on PullRequest {
+  files(first: 100) {
+    nodes {
+      path
+      additions
+      deletions
+      changeType
     }
   }
 }
@@ -71,21 +85,56 @@ def create_pull_request_status_query(
                 f"number{index}": int(pull_request.pull_number),
             }
         )
+        fragment_spreads = ["...PullRequestStatusFields"]
+        if pull_request.include_files:
+            fragment_spreads.append("...PullRequestFilesFields")
+        selection = "\n      ".join(fragment_spreads)
         repository_queries.append(
             f"""  repository{index}: repository(owner: $owner{index}, name: $name{index}) {{
     pullRequest(number: $number{index}) {{
-      ...PullRequestStatusFields
+      {selection}
     }}
   }}"""
         )
 
     repository_query = "\n".join(repository_queries)
+    fragments = PULL_REQUEST_STATUS_FRAGMENT
+    if any(pull_request.include_files for pull_request in pull_requests):
+        fragments += PULL_REQUEST_FILES_FRAGMENT
     query = (
         f"query pullRequestStatuses({', '.join(variable_definitions)}) {{\n"
         f"{repository_query}\n"
-        f"}}\n{PULL_REQUEST_STATUS_FRAGMENT}"
+        f"}}\n{fragments}"
     )
     return {"query": query, "variables": variables}
+
+
+def _extract_files(pull_request: Any) -> tuple[PullRequestFileSummary, ...]:
+    nodes = get_path(pull_request, "files", "nodes") or []
+    files: list[PullRequestFileSummary] = []
+    for node in nodes:
+        if not isinstance(node, Mapping):
+            continue
+        path = node.get("path")
+        additions = node.get("additions")
+        deletions = node.get("deletions")
+        change_type = node.get("changeType")
+        if not (
+            isinstance(path, str)
+            and isinstance(additions, int)
+            and isinstance(deletions, int)
+            and isinstance(change_type, str)
+        ):
+            continue
+        files.append(
+            PullRequestFileSummary(
+                path=path,
+                additions=additions,
+                deletions=deletions,
+                change_type=change_type,
+            )
+        )
+    return tuple(files)
 
 
 def _extract_pull_request_status(pull_request: Any) -> PullRequestStatusResult:
@@ -94,6 +143,7 @@ def _extract_pull_request_status(pull_request: Any) -> PullRequestStatusResult:
     return PullRequestStatusResult(
         checks=_CHECKS_STATUS_BY_STATE.get(state),
         review=_REVIEW_STATUS_BY_DECISION.get(decision),
+        files=_extract_files(pull_request),
     )
 
 

--- a/src/sentry/integrations/source_code_management/pull_request_status_batch.py
+++ b/src/sentry/integrations/source_code_management/pull_request_status_batch.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+
+from sentry.api.serializers.models.pullrequest import PullRequestStatus
+from sentry.constants import ObjectStatus
+from sentry.integrations.base import IntegrationInstallation
+from sentry.integrations.services.integration import integration_service
+from sentry.integrations.source_code_management.status_check import (
+    PullRequestStatusClient,
+    PullRequestStatusRequest,
+    PullRequestStatusResult,
+)
+from sentry.models.pullrequest import PullRequest
+from sentry.models.repository import Repository
+
+logger = logging.getLogger(__name__)
+
+
+def get_pull_request_repo_name(repository: Repository) -> str:
+    config_name = repository.config.get("name")
+    if isinstance(config_name, str) and config_name:
+        return config_name
+    return repository.name
+
+
+def get_provider_installation(
+    pull_request: PullRequest, repository: Repository
+) -> IntegrationInstallation | None:
+    """The repository's active integration, installed for the pull request's organization."""
+    if repository.integration_id is None:
+        return None
+
+    integration = integration_service.get_integration(
+        integration_id=repository.integration_id,
+        organization_id=pull_request.organization_id,
+        status=ObjectStatus.ACTIVE,
+    )
+    if integration is None:
+        return None
+
+    return integration.get_installation(organization_id=pull_request.organization_id)
+
+
+def get_checks_and_review(
+    pull_requests: Sequence[PullRequest],
+    repositories_by_id: Mapping[int, Repository],
+    lifecycle_status_by_pr_id: Mapping[int, PullRequestStatus | None],
+    *,
+    include_files: bool = False,
+) -> dict[int, PullRequestStatusResult]:
+    """Fetch open pull requests in one provider request per integration."""
+    requests_by_integration_id: dict[
+        int, list[tuple[PullRequest, Repository, PullRequestStatusRequest]]
+    ] = defaultdict(list)
+
+    for pull_request in pull_requests:
+        repository = repositories_by_id.get(pull_request.repository_id)
+        if (
+            repository is None
+            or repository.integration_id is None
+            or lifecycle_status_by_pr_id.get(pull_request.id) not in ("open", "draft")
+        ):
+            continue
+
+        try:
+            int(pull_request.key)
+        except (TypeError, ValueError):
+            continue
+
+        request = PullRequestStatusRequest(
+            repo=get_pull_request_repo_name(repository),
+            pull_number=pull_request.key,
+            include_files=include_files,
+        )
+        requests_by_integration_id[repository.integration_id].append(
+            (pull_request, repository, request)
+        )
+
+    results_by_pr_id: dict[int, PullRequestStatusResult] = {}
+    for integration_id, request_items in requests_by_integration_id.items():
+        representative_pull_request, representative_repository, _ = request_items[0]
+        try:
+            installation = get_provider_installation(
+                representative_pull_request, representative_repository
+            )
+            if installation is None:
+                continue
+
+            client = installation.get_client()
+            if not isinstance(client, PullRequestStatusClient):
+                continue
+
+            status_by_request = client.get_pull_request_statuses(
+                [request for _, _, request in request_items]
+            )
+        except Exception:
+            logger.info(
+                "pull_request_status_batch.fetch_failed",
+                exc_info=True,
+                extra={
+                    "organization_id": representative_pull_request.organization_id,
+                    "integration_id": integration_id,
+                    "pull_request_ids": [pull_request.id for pull_request, _, _ in request_items],
+                },
+            )
+            continue
+
+        for pull_request, _, request in request_items:
+            results_by_pr_id[pull_request.id] = status_by_request.get(
+                request, PullRequestStatusResult()
+            )
+
+    return results_by_pr_id

--- a/src/sentry/integrations/source_code_management/status_check.py
+++ b/src/sentry/integrations/source_code_management/status_check.py
@@ -55,17 +55,29 @@ class AggregateReviewStatus(enum.StrEnum):
 
 
 @dataclass(frozen=True)
+class PullRequestFileSummary:
+    """One changed file, without its contents."""
+
+    path: str
+    additions: int
+    deletions: int
+    change_type: str
+
+
+@dataclass(frozen=True)
 class PullRequestStatusResult:
     """A pull request's checks and review state, as far as the provider reports it."""
 
     checks: AggregateChecksStatus | None = None
     review: AggregateReviewStatus | None = None
+    files: tuple[PullRequestFileSummary, ...] = ()
 
 
 @dataclass(frozen=True)
 class PullRequestStatusRequest:
     repo: str
     pull_number: str
+    include_files: bool = False
 
 
 class PullRequestStatusClient(ABC):

--- a/src/sentry/issues/endpoints/group_pull_requests.py
+++ b/src/sentry/issues/endpoints/group_pull_requests.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 import logging
-from collections import defaultdict
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from typing import TypedDict, cast
 
 from django.db.models import Exists, OuterRef
@@ -21,13 +20,12 @@ from sentry.api.serializers.models.pullrequest import (
     get_stored_pull_request_status,
 )
 from sentry.constants import ObjectStatus
-from sentry.integrations.base import IntegrationInstallation
-from sentry.integrations.services.integration import integration_service
-from sentry.integrations.source_code_management.status_check import (
-    PullRequestStatusClient,
-    PullRequestStatusRequest,
-    PullRequestStatusResult,
+from sentry.integrations.source_code_management.pull_request_status_batch import (
+    get_checks_and_review,
+    get_provider_installation,
+    get_pull_request_repo_name,
 )
+from sentry.integrations.source_code_management.status_check import PullRequestStatusResult
 from sentry.issues.endpoints.bases.group import GroupEndpoint
 from sentry.models.group import Group
 from sentry.models.grouplink import GroupLink
@@ -73,35 +71,10 @@ def _get_valid_group_pull_request_links(group: Group, organization_id: int) -> l
     )
 
 
-def _get_pull_request_repo_name(repository: Repository) -> str:
-    config_name = repository.config.get("name")
-    if isinstance(config_name, str) and config_name:
-        return config_name
-    return repository.name
-
-
-def _get_provider_installation(
-    pull_request: PullRequest, repository: Repository
-) -> IntegrationInstallation | None:
-    """The repository's active integration, installed for the pull request's organization."""
-    if repository.integration_id is None:
-        return None
-
-    integration = integration_service.get_integration(
-        integration_id=repository.integration_id,
-        organization_id=pull_request.organization_id,
-        status=ObjectStatus.ACTIVE,
-    )
-    if integration is None:
-        return None
-
-    return integration.get_installation(organization_id=pull_request.organization_id)
-
-
 def _fetch_pull_request_status_response(
     pull_request: PullRequest, repository: Repository
 ) -> ProviderPullRequestResponse | None:
-    installation = _get_provider_installation(pull_request, repository)
+    installation = get_provider_installation(pull_request, repository)
     if installation is None:
         return None
 
@@ -109,7 +82,7 @@ def _fetch_pull_request_status_response(
     if not callable(get_pull_request):
         return None
 
-    response = get_pull_request(_get_pull_request_repo_name(repository), pull_request.key)
+    response = get_pull_request(get_pull_request_repo_name(repository), pull_request.key)
     if not isinstance(response, Mapping):
         return None
 
@@ -169,69 +142,6 @@ def _get_pull_request_status(
     return _get_provider_pull_request_status(pull_request, repository)
 
 
-def _get_checks_and_review(
-    pull_requests: Sequence[PullRequest],
-    repositories_by_id: Mapping[int, Repository],
-    lifecycle_status_by_pr_id: Mapping[int, PullRequestStatus],
-) -> dict[int, PullRequestStatusResult]:
-    """Fetch open pull requests in one provider request per integration."""
-    requests_by_integration_id: dict[
-        int, list[tuple[PullRequest, Repository, PullRequestStatusRequest]]
-    ] = defaultdict(list)
-
-    for pull_request in pull_requests:
-        repository = repositories_by_id.get(pull_request.repository_id)
-        if (
-            repository is None
-            or repository.integration_id is None
-            or lifecycle_status_by_pr_id[pull_request.id] not in ("open", "draft")
-        ):
-            continue
-
-        request = PullRequestStatusRequest(
-            repo=_get_pull_request_repo_name(repository), pull_number=pull_request.key
-        )
-        requests_by_integration_id[repository.integration_id].append(
-            (pull_request, repository, request)
-        )
-
-    results_by_pr_id: dict[int, PullRequestStatusResult] = {}
-    for integration_id, request_items in requests_by_integration_id.items():
-        representative_pull_request, representative_repository, _ = request_items[0]
-        try:
-            installation = _get_provider_installation(
-                representative_pull_request, representative_repository
-            )
-            if installation is None:
-                continue
-
-            client = installation.get_client()
-            if not isinstance(client, PullRequestStatusClient):
-                continue
-
-            status_by_request = client.get_pull_request_statuses(
-                [request for _, _, request in request_items]
-            )
-        except Exception:
-            logger.info(
-                "group_pull_requests.checks_and_review_fetch_failed",
-                exc_info=True,
-                extra={
-                    "organization_id": representative_pull_request.organization_id,
-                    "integration_id": integration_id,
-                    "pull_request_ids": [pull_request.id for pull_request, _, _ in request_items],
-                },
-            )
-            continue
-
-        for pull_request, _, request in request_items:
-            results_by_pr_id[pull_request.id] = status_by_request.get(
-                request, PullRequestStatusResult()
-            )
-
-    return results_by_pr_id
-
-
 @cell_silo_endpoint
 class GroupPullRequestsEndpoint(GroupEndpoint):
     owner = ApiOwner.ISSUES
@@ -279,7 +189,7 @@ class GroupPullRequestsEndpoint(GroupEndpoint):
         if "checksAndReview" in request.GET.getlist("expand") and features.has(
             "organizations:issue-pr-checks-status", group.project.organization
         ):
-            checks_and_review_by_pr_id = _get_checks_and_review(
+            checks_and_review_by_pr_id = get_checks_and_review(
                 pull_requests, repositories_by_id, status_by_pr_id
             )
 

--- a/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
+++ b/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
@@ -1,49 +1,51 @@
 from __future__ import annotations
 
+from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime
 
-from rest_framework.exceptions import NotFound
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group_stream import StreamGroupSerializerSnuba
+from sentry.api.serializers.models.pullrequest import (
+    PullRequestStatus,
+    get_stored_pull_request_status,
+)
 from sentry.api.utils import get_date_range_from_stats_period
+from sentry.constants import ObjectStatus
+from sentry.integrations.source_code_management.pull_request_status_batch import (
+    get_checks_and_review,
+)
+from sentry.integrations.source_code_management.status_check import PullRequestStatusResult
 from sentry.models.group import Group
 from sentry.models.organization import Organization
+from sentry.models.pullrequest import PullRequest
+from sentry.models.repository import Repository
+from sentry.plugins.base import bindings
+from sentry.plugins.providers.integration_repository import IntegrationRepositoryProvider
+from sentry.seer.endpoints.organization_seer_autofix_overview_types import (
+    IssuePayload,
+    OverviewResponse,
+    ProposedFixPayload,
+    PullRequestPayload,
+    RootCausePayload,
+    RunPayload,
+)
 from sentry.seer.models.run import (
     RootCauseArtifactExtras,
     SeerRun,
     SeerRunMilestone,
     SeerRunMilestoneExtras,
     SeerRunMilestoneType,
+    SeerRunPullRequest,
     SolutionArtifactExtras,
 )
-
-# NOTE: Pull-request (SCM) enrichment — checks, review status, and changed
-# files — lands in a follow-up PR. The imports, helpers, and wiring it needs
-# are commented out below with the same NOTE marker; re-enable them together.
-# from collections import defaultdict
-#
-# from sentry.api.serializers.models.pullrequest import (
-#     PullRequestStatus,
-#     get_stored_pull_request_status,
-# )
-# from sentry.integrations.source_code_management.pull_request_status_batch import (
-#     get_checks_and_review,
-# )
-# from sentry.integrations.source_code_management.status_check import PullRequestStatusResult
-# from sentry.models.pullrequest import PullRequest
-# from sentry.models.repository import Repository
-# from sentry.plugins.base import bindings
-# from sentry.plugins.providers.integration_repository import IntegrationRepositoryProvider
-# from sentry.seer.models.run import SeerRunPullRequest
 
 # The autofix pipeline in order. A run is grouped under its furthest-reached
 # milestone; the frontend owns section labels, ordering, and layout.
@@ -82,86 +84,94 @@ class _RunMilestones:
         return extras.get("solution_artifact")
 
 
-# NOTE: SCM enrichment — see follow-up PR. Re-enable with the imports above.
-# def _serialize_pull_request(
-#     number: int,
-#     url: str | None,
-#     status: PullRequestStatus | None,
-#     checks_and_review: PullRequestStatusResult,
-# ) -> dict:
-#     return {
-#         "number": number,
-#         "url": url,
-#         "status": status,
-#         "checksStatus": checks_and_review.checks.value if checks_and_review.checks else None,
-#         "reviewStatus": checks_and_review.review.value if checks_and_review.review else None,
-#         "files": [
-#             {
-#                 "path": file.path,
-#                 "additions": file.additions,
-#                 "deletions": file.deletions,
-#                 "changeType": file.change_type,
-#             }
-#             for file in checks_and_review.files
-#         ],
-#     }
-#
-#
-# def _pull_requests_by_seer_run_id(seer_run_ids: list[int]) -> dict[int, list[dict]]:
-#     by_run: dict[int, list[dict]] = defaultdict(list)
-#     links = list(
-#         SeerRunPullRequest.objects.filter(seer_run_id__in=seer_run_ids)
-#         .select_related("pull_request")
-#         .order_by("date_added")
-#     )
-#     if not links:
-#         return by_run
-#
-#     repos_by_id = Repository.objects.in_bulk({link.pull_request.repository_id for link in links})
-#     registry = bindings.get("integration-repository.provider")
-#     providers: dict[str, IntegrationRepositoryProvider] = {}
-#
-#     def _external_url(pr: PullRequest) -> str | None:
-#         repo = repos_by_id.get(pr.repository_id)
-#         if repo is None:
-#             return None
-#         provider_id = repo.provider
-#         if not provider_id or not provider_id.startswith("integrations:"):
-#             return None
-#         provider = providers.get(provider_id)
-#         if provider is None:
-#             provider = registry.get(provider_id)(provider_id)
-#             providers[provider_id] = provider
-#         return provider.pull_request_url(repo, pr)
-#
-#     pull_requests = [link.pull_request for link in links]
-#     status_by_pr_id: dict[int, PullRequestStatus | None] = {
-#         pr.id: get_stored_pull_request_status(pr) for pr in pull_requests
-#     }
-#     # TODO: this hits the provider (GitHub GraphQL) on every page load. If latency
-#     # bites, gate it behind an `expand=checksAndReview` param like the issues endpoint.
-#     checks_and_review_by_pr_id = get_checks_and_review(
-#         pull_requests, repos_by_id, status_by_pr_id, include_files=True
-#     )
-#
-#     for link in links:
-#         pr = link.pull_request
-#         try:
-#             number = int(pr.key)
-#         except (TypeError, ValueError):
-#             continue
-#         by_run[link.seer_run_id].append(
-#             _serialize_pull_request(
-#                 number=number,
-#                 url=_external_url(pr),
-#                 status=status_by_pr_id[pr.id],
-#                 checks_and_review=checks_and_review_by_pr_id.get(pr.id, PullRequestStatusResult()),
-#             )
-#         )
-#     return by_run
+def _serialize_pull_request(
+    number: int,
+    url: str | None,
+    status: PullRequestStatus | None,
+    checks_and_review: PullRequestStatusResult,
+) -> PullRequestPayload:
+    return {
+        "number": number,
+        "url": url,
+        "status": status,
+        "checksStatus": checks_and_review.checks.value if checks_and_review.checks else None,
+        "reviewStatus": checks_and_review.review.value if checks_and_review.review else None,
+        "files": [
+            {
+                "path": file.path,
+                "additions": file.additions,
+                "deletions": file.deletions,
+                "changeType": file.change_type,
+            }
+            for file in checks_and_review.files
+        ],
+    }
 
 
-def _serialize_issue(group: Group, serialized_group: dict) -> dict:
+def _pull_requests_by_seer_run_id(seer_run_ids: list[int]) -> dict[int, list[PullRequestPayload]]:
+    by_run: dict[int, list[PullRequestPayload]] = defaultdict(list)
+    links = list(
+        SeerRunPullRequest.objects.filter(seer_run_id__in=seer_run_ids)
+        .select_related("pull_request")
+        .order_by("date_added")
+    )
+    if not links:
+        return by_run
+
+    repos_by_id = Repository.objects.filter(
+        organization_id__in={link.pull_request.organization_id for link in links},
+        id__in={link.pull_request.repository_id for link in links},
+        status=ObjectStatus.ACTIVE,
+    ).in_bulk()
+    registry = bindings.get("integration-repository.provider")
+    providers: dict[str, IntegrationRepositoryProvider] = {}
+
+    def _external_url(pr: PullRequest) -> str | None:
+        repo = repos_by_id.get(pr.repository_id)
+        if repo is None:
+            return None
+        provider_id = repo.provider
+        if not provider_id or not provider_id.startswith("integrations:"):
+            return None
+        provider = providers.get(provider_id)
+        if provider is None:
+            try:
+                provider = registry.get(provider_id)(provider_id)
+            except KeyError:
+                # `integrations:` is a shape check, not a registry-membership one;
+                # stale/unregistered providers exist in repo data.
+                return None
+            providers[provider_id] = provider
+        return provider.pull_request_url(repo, pr)
+
+    pull_requests = [link.pull_request for link in links]
+    status_by_pr_id: dict[int, PullRequestStatus | None] = {
+        pr.id: get_stored_pull_request_status(pr) for pr in pull_requests
+    }
+    # TODO: this hits the provider (GitHub GraphQL) on every page load. If latency
+    # bites, gate it behind an `expand=checksAndReview` param like the issues endpoint.
+    checks_and_review_by_pr_id = get_checks_and_review(
+        pull_requests, repos_by_id, status_by_pr_id, include_files=True
+    )
+
+    for link in links:
+        pr = link.pull_request
+        try:
+            number = int(pr.key)
+        except (TypeError, ValueError):
+            continue
+        by_run[link.seer_run_id].append(
+            _serialize_pull_request(
+                number=number,
+                url=_external_url(pr),
+                status=status_by_pr_id[pr.id],
+                checks_and_review=checks_and_review_by_pr_id.get(pr.id, PullRequestStatusResult()),
+            )
+        )
+    return by_run
+
+
+def _serialize_issue(group: Group, serialized_group: dict) -> IssuePayload:
     return {
         "count": serialized_group.get("count"),
         "userCount": serialized_group.get("userCount"),
@@ -182,32 +192,35 @@ def _serialize_issue(group: Group, serialized_group: dict) -> dict:
     }
 
 
-def _serialize_run(group: Group, run: _RunMilestones, serialized_group: dict) -> dict:
-    result = {
+def _serialize_run(
+    group: Group,
+    run: _RunMilestones,
+    serialized_group: dict,
+    pull_requests: list[PullRequestPayload],
+) -> RunPayload:
+    root_cause_artifact = run.root_cause_artifact
+    root_cause: RootCausePayload | None = (
+        {"oneLineDescription": root_cause_artifact.get("one_line_description")}
+        if root_cause_artifact
+        else None
+    )
+
+    solution_artifact = run.solution_artifact
+    proposed_fix: ProposedFixPayload | None = (
+        {"oneLineSummary": solution_artifact.get("one_line_summary")} if solution_artifact else None
+    )
+
+    return {
         "groupId": str(group.id),
         "shortId": group.qualified_short_id,
         "title": group.title,
-        "rootCause": None,
-        "proposedFix": None,
+        "rootCause": root_cause,
+        "proposedFix": proposed_fix,
         "seerRunId": str(run.seer_run.uuid),
         "lastTriggeredAt": run.seer_run.last_triggered_at,
-        # NOTE: SCM enrichment — see follow-up PR. Re-add the `pull_requests`
-        # parameter above with this field.
-        # "pullRequests": pull_requests,
+        "pullRequests": pull_requests,
         "issue": _serialize_issue(group, serialized_group),
     }
-
-    root_cause_artifact = run.root_cause_artifact
-    if root_cause_artifact:
-        result["rootCause"] = {
-            "oneLineDescription": root_cause_artifact.get("one_line_description")
-        }
-
-    solution_artifact = run.solution_artifact
-    if solution_artifact:
-        result["proposedFix"] = {"oneLineSummary": solution_artifact.get("one_line_summary")}
-
-    return result
 
 
 class OrganizationSeerAutofixOverviewPermission(OrganizationPermission):
@@ -221,9 +234,6 @@ class OrganizationSeerAutofixOverviewEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationSeerAutofixOverviewPermission,)
 
     def get(self, request: Request, organization: Organization) -> Response:
-        if not features.has("organizations:seer-night-shift-ui", organization):
-            raise NotFound
-
         projects = self.get_projects(request, organization, include_all_accessible=True)
         project_ids = [p.id for p in projects]
 
@@ -266,13 +276,11 @@ class OrganizationSeerAutofixOverviewEndpoint(OrganizationEndpoint):
             )
         }
 
-        # NOTE: SCM enrichment — see follow-up PR. Re-enable with the
-        # `_pull_requests_by_seer_run_id` helper and the `_serialize_run` arg below.
-        # pull_requests_by_seer_run_id = _pull_requests_by_seer_run_id(
-        #     [run.seer_run.id for _, run in capped]
-        # )
+        pull_requests_by_seer_run_id = _pull_requests_by_seer_run_id(
+            [run.seer_run.id for _, run in capped]
+        )
 
-        runs_by_milestone: dict[str, list[dict]] = {milestone: [] for milestone in _PIPELINE}
+        runs_by_milestone: dict[str, list[RunPayload]] = {milestone: [] for milestone in _PIPELINE}
         for milestone, pairs in capped_runs_by_milestone.items():
             for group_id, run in pairs:
                 group = groups.get(group_id)
@@ -283,11 +291,12 @@ class OrganizationSeerAutofixOverviewEndpoint(OrganizationEndpoint):
                         group,
                         run,
                         serialized_by_id[str(group_id)],
-                        # pull_requests_by_seer_run_id.get(run.seer_run.id, []),
+                        pull_requests_by_seer_run_id.get(run.seer_run.id, []),
                     )
                 )
 
-        return Response({"runsByMilestone": runs_by_milestone})
+        response: OverviewResponse = {"runsByMilestone": runs_by_milestone}
+        return Response(response)
 
     def _latest_run_per_group(
         self,

--- a/src/sentry/seer/endpoints/organization_seer_autofix_overview_types.py
+++ b/src/sentry/seer/endpoints/organization_seer_autofix_overview_types.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TypedDict
+
+
+class PullRequestFilePayload(TypedDict):
+    path: str
+    additions: int
+    deletions: int
+    changeType: str
+
+
+class PullRequestPayload(TypedDict):
+    number: int
+    url: str | None
+    status: str | None
+    checksStatus: str | None
+    reviewStatus: str | None
+    files: list[PullRequestFilePayload]
+
+
+class IssueProjectPayload(TypedDict):
+    id: str
+    slug: str
+    platform: str | None
+
+
+class IssuePayload(TypedDict):
+    count: int | None
+    userCount: int | None
+    lastSeen: str | None
+    level: str | None
+    substatus: str | None
+    priority: str | None
+    priorityLockedAt: str | None
+    issueType: str | None
+    issueCategory: str | None
+    assignedTo: dict | None
+    owners: list
+    project: IssueProjectPayload
+
+
+class RootCausePayload(TypedDict):
+    oneLineDescription: str | None
+
+
+class ProposedFixPayload(TypedDict):
+    oneLineSummary: str | None
+
+
+class RunPayload(TypedDict):
+    groupId: str
+    shortId: str
+    title: str
+    rootCause: RootCausePayload | None
+    proposedFix: ProposedFixPayload | None
+    seerRunId: str
+    lastTriggeredAt: datetime
+    pullRequests: list[PullRequestPayload]
+    issue: IssuePayload
+
+
+class OverviewResponse(TypedDict):
+    runsByMilestone: dict[str, list[RunPayload]]

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -17,7 +17,10 @@ from sentry.integrations.github.blame import create_blame_query, generate_file_p
 from sentry.integrations.github.client import GitHubApiClient, GitHubApiRequestType, GitHubReaction
 from sentry.integrations.github.constants import GITHUB_API_ACCEPT_HEADER
 from sentry.integrations.github.integration import GitHubIntegration
-from sentry.integrations.github.pull_request_status import PULL_REQUEST_STATUS_FRAGMENT
+from sentry.integrations.github.pull_request_status import (
+    PULL_REQUEST_FILES_FRAGMENT,
+    PULL_REQUEST_STATUS_FRAGMENT,
+)
 from sentry.integrations.source_code_management.commit_context import (
     CommitInfo,
     FileBlameInfo,
@@ -1104,6 +1107,7 @@ class GitHubApiClientTest(TestCase):
 
         body = orjson.loads(responses.calls[-1].request.body)
         assert PULL_REQUEST_STATUS_FRAGMENT in body["query"]
+        assert PULL_REQUEST_FILES_FRAGMENT not in body["query"]
         assert body["variables"] == {
             "owner0": "Test-Organization",
             "name0": "foo",
@@ -1192,6 +1196,19 @@ class GitHubApiClientTest(TestCase):
         # A different pull request keys separately, so it still reaches GitHub.
         self.github_client.get_pull_request_status(repo=self.repo.name, pull_number="46")
         assert len(responses.calls) == 2
+
+    def test_pull_request_status_cache_separates_file_expansion(self) -> None:
+        status_only = PullRequestStatusRequest(repo=self.repo.name, pull_number="45")
+        with_files = PullRequestStatusRequest(
+            repo=self.repo.name, pull_number="45", include_files=True
+        )
+        previous_cache_data = orjson.dumps({"repo": self.repo.name, "pull_number": "45"}).decode()
+
+        status_only_key = self.github_client._get_pull_request_status_cache_key(status_only)
+        assert status_only_key == self.github_client.get_cache_key(
+            "/graphql/pull-request-status", "", previous_cache_data
+        )
+        assert status_only_key != self.github_client._get_pull_request_status_cache_key(with_files)
 
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate

--- a/tests/sentry/integrations/github/test_pull_request_status.py
+++ b/tests/sentry/integrations/github/test_pull_request_status.py
@@ -5,6 +5,7 @@ from typing import Any
 import pytest
 
 from sentry.integrations.github.pull_request_status import (
+    PULL_REQUEST_FILES_FRAGMENT,
     PULL_REQUEST_STATUS_FRAGMENT,
     create_pull_request_status_query,
     extract_pull_request_status_from_response,
@@ -13,13 +14,16 @@ from sentry.integrations.github.pull_request_status import (
 from sentry.integrations.source_code_management.status_check import (
     AggregateChecksStatus,
     AggregateReviewStatus,
+    PullRequestFileSummary,
     PullRequestStatusRequest,
     PullRequestStatusResult,
 )
 
 
 def response(
-    rollup: dict[str, Any] | None = None, review_decision: str | None = None
+    rollup: dict[str, Any] | None = None,
+    review_decision: str | None = None,
+    files: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     return {
         "data": {
@@ -27,6 +31,7 @@ def response(
                 "pullRequest": {
                     "reviewDecision": review_decision,
                     "commits": {"nodes": [{"commit": {"statusCheckRollup": rollup}}]},
+                    "files": files,
                 }
             }
         }
@@ -52,6 +57,7 @@ def test_create_pull_request_status_query() -> None:
     assert "repository0: repository(owner: $owner0, name: $name0)" in query["query"]
     assert "repository1: repository(owner: $owner1, name: $name1)" in query["query"]
     assert query["query"].count("...PullRequestStatusFields") == 2
+    assert PULL_REQUEST_FILES_FRAGMENT not in query["query"]
 
 
 def test_create_pull_request_status_query_requires_a_pull_request() -> None:
@@ -133,6 +139,81 @@ def test_extract_reads_checks_and_review_from_one_response() -> None:
 def test_extract_without_ci_or_required_review() -> None:
     # No CI and no required review are absent states, not pending ones.
     assert extract_pull_request_status_from_response(response()) == PullRequestStatusResult()
+
+
+def test_query_reads_changed_files_when_requested() -> None:
+    query = create_pull_request_status_query(
+        [PullRequestStatusRequest(repo="getsentry/sentry", pull_number="42", include_files=True)]
+    )
+
+    assert "...PullRequestFilesFields" in query["query"]
+    assert PULL_REQUEST_FILES_FRAGMENT in query["query"]
+
+
+def test_extract_files() -> None:
+    result = extract_pull_request_status_from_response(
+        response(
+            files={
+                "nodes": [
+                    {
+                        "path": "src/sentry/foo.py",
+                        "additions": 10,
+                        "deletions": 2,
+                        "changeType": "MODIFIED",
+                    },
+                    {
+                        "path": "src/sentry/bar.py",
+                        "additions": 3,
+                        "deletions": 0,
+                        "changeType": "ADDED",
+                    },
+                ]
+            }
+        )
+    )
+
+    assert result.files == (
+        PullRequestFileSummary(
+            path="src/sentry/foo.py", additions=10, deletions=2, change_type="MODIFIED"
+        ),
+        PullRequestFileSummary(
+            path="src/sentry/bar.py", additions=3, deletions=0, change_type="ADDED"
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "files",
+    (None, {"nodes": None}, {"nodes": []}),
+    ids=("no_files", "no_nodes", "empty_nodes"),
+)
+def test_extract_files_without_nodes(files: dict[str, Any] | None) -> None:
+    assert extract_pull_request_status_from_response(response(files=files)).files == ()
+
+
+def test_extract_files_skips_partial_nodes() -> None:
+    result = extract_pull_request_status_from_response(
+        response(
+            files={
+                "nodes": [
+                    None,
+                    {"path": "missing-counts.py"},
+                    {
+                        "path": "src/sentry/valid.py",
+                        "additions": 2,
+                        "deletions": 1,
+                        "changeType": "MODIFIED",
+                    },
+                ]
+            }
+        )
+    )
+
+    assert result.files == (
+        PullRequestFileSummary(
+            path="src/sentry/valid.py", additions=2, deletions=1, change_type="MODIFIED"
+        ),
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/sentry/integrations/source_code_management/test_pull_request_status_batch.py
+++ b/tests/sentry/integrations/source_code_management/test_pull_request_status_batch.py
@@ -1,0 +1,73 @@
+from collections.abc import Sequence
+from unittest import mock
+
+from sentry.api.serializers.models.pullrequest import PullRequestStatus
+from sentry.integrations.source_code_management.pull_request_status_batch import (
+    get_checks_and_review,
+)
+from sentry.integrations.source_code_management.status_check import (
+    AggregateChecksStatus,
+    PullRequestStatusClient,
+    PullRequestStatusRequest,
+    PullRequestStatusResult,
+)
+from sentry.testutils.cases import TestCase
+
+_INTEGRATION_SERVICE = (
+    "sentry.integrations.source_code_management.pull_request_status_batch."
+    "integration_service.get_integration"
+)
+
+
+class PullRequestStatusClientFake(PullRequestStatusClient):
+    def __init__(self) -> None:
+        # One entry per call, each holding that call's requested keys.
+        self.calls: list[list[str]] = []
+
+    def get_pull_request_statuses(
+        self, pull_requests: Sequence[PullRequestStatusRequest]
+    ) -> dict[PullRequestStatusRequest, PullRequestStatusResult]:
+        self.calls.append([pull_request.pull_number for pull_request in pull_requests])
+        return {
+            pull_request: PullRequestStatusResult(checks=AggregateChecksStatus.SUCCESS)
+            for pull_request in pull_requests
+        }
+
+
+class GetChecksAndReviewTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.repo = self.create_repo(
+            project=self.project,
+            name="getsentry/sentry",
+            provider="integrations:github",
+            integration_id=123,
+        )
+
+    def _set_client(
+        self, mock_get_integration: mock.MagicMock, client: PullRequestStatusClientFake
+    ) -> None:
+        installation = mock.Mock()
+        installation.get_client.return_value = client
+        integration = mock.Mock()
+        integration.get_installation.return_value = installation
+        mock_get_integration.return_value = integration
+
+    @mock.patch(_INTEGRATION_SERVICE)
+    def test_non_numeric_keys_are_skipped(self, mock_get_integration: mock.MagicMock) -> None:
+        client = PullRequestStatusClientFake()
+        self._set_client(mock_get_integration, client)
+        good = self.create_pull_request(
+            repository_id=self.repo.id, organization_id=self.organization.id, key="7"
+        )
+        bad = self.create_pull_request(
+            repository_id=self.repo.id, organization_id=self.organization.id, key="²"
+        )
+        status_by_pr_id: dict[int, PullRequestStatus | None] = {good.id: "open", bad.id: "open"}
+
+        results = get_checks_and_review([good, bad], {self.repo.id: self.repo}, status_by_pr_id)
+
+        # "²".isdigit() is True but int("²") raises; the good sibling must still
+        # be enriched instead of the whole integration batch being discarded.
+        assert client.calls == [["7"]]
+        assert list(results) == [good.id]

--- a/tests/sentry/issues/endpoints/test_group_pull_requests.py
+++ b/tests/sentry/issues/endpoints/test_group_pull_requests.py
@@ -41,6 +41,7 @@ class PullRequestStatusClientFake(PullRequestStatusClient):
         self.status_by_key = status_by_key or {}
         self.error = error
         self.requested_keys: list[str] = []
+        self.requested_include_files: list[bool] = []
         self.request_count = 0
 
     def get_pull_request_statuses(
@@ -48,6 +49,9 @@ class PullRequestStatusClientFake(PullRequestStatusClient):
     ) -> dict[PullRequestStatusRequest, PullRequestStatusResult]:
         self.request_count += 1
         self.requested_keys.extend(pull_request.pull_number for pull_request in pull_requests)
+        self.requested_include_files.extend(
+            pull_request.include_files for pull_request in pull_requests
+        )
         if self.error is not None:
             raise self.error
         return {
@@ -347,7 +351,9 @@ class GroupPullRequestsEndpointTest(APITestCase):
         assert response.status_code == 200
         assert response.data["pullRequests"][0]["attribution"] is None
 
-    @patch("sentry.issues.endpoints.group_pull_requests.integration_service.get_integration")
+    @patch(
+        "sentry.integrations.source_code_management.pull_request_status_batch.integration_service.get_integration"
+    )
     def test_status_derivation_prefers_stored_lifecycle_fields(
         self, mock_get_integration: Mock
     ) -> None:
@@ -387,7 +393,9 @@ class GroupPullRequestsEndpointTest(APITestCase):
         ]
         mock_get_integration.assert_not_called()
 
-    @patch("sentry.issues.endpoints.group_pull_requests.integration_service.get_integration")
+    @patch(
+        "sentry.integrations.source_code_management.pull_request_status_batch.integration_service.get_integration"
+    )
     def test_incomplete_stored_status_falls_back_to_provider(
         self, mock_get_integration: Mock
     ) -> None:
@@ -425,7 +433,9 @@ class GroupPullRequestsEndpointTest(APITestCase):
             for call in mock_get_integration.call_args_list
         )
 
-    @patch("sentry.issues.endpoints.group_pull_requests.integration_service.get_integration")
+    @patch(
+        "sentry.integrations.source_code_management.pull_request_status_batch.integration_service.get_integration"
+    )
     def test_provider_status_fetch_failure_returns_unknown(
         self, mock_get_integration: Mock
     ) -> None:
@@ -442,7 +452,7 @@ class GroupPullRequestsEndpointTest(APITestCase):
         self.create_linked_pull_request(key="1", state=PullRequestLifecycleState.OPEN, draft=False)
 
         with patch(
-            "sentry.issues.endpoints.group_pull_requests.integration_service.get_integration"
+            "sentry.integrations.source_code_management.pull_request_status_batch.integration_service.get_integration"
         ) as mock_get_integration:
             assert self.get_checks_and_review() == [(None, None)]
 
@@ -454,14 +464,16 @@ class GroupPullRequestsEndpointTest(APITestCase):
         self.create_linked_pull_request(key="1", state=PullRequestLifecycleState.OPEN, draft=False)
 
         with patch(
-            "sentry.issues.endpoints.group_pull_requests.integration_service.get_integration"
+            "sentry.integrations.source_code_management.pull_request_status_batch.integration_service.get_integration"
         ) as mock_get_integration:
             assert self.get_checks_and_review(expand=False) == [(None, None)]
 
         mock_get_integration.assert_not_called()
 
     @with_feature("organizations:issue-pr-checks-status")
-    @patch("sentry.issues.endpoints.group_pull_requests.integration_service.get_integration")
+    @patch(
+        "sentry.integrations.source_code_management.pull_request_status_batch.integration_service.get_integration"
+    )
     def test_checks_and_review_for_open_pull_requests(self, mock_get_integration: Mock) -> None:
         self.create_linked_pull_request(
             key="1",
@@ -504,11 +516,14 @@ class GroupPullRequestsEndpointTest(APITestCase):
             ("failure", "changes_requested"),
         ]
         assert set(client.requested_keys) == {"1", "2", "3"}
+        assert client.requested_include_files == [False, False, False]
         assert client.request_count == 1
         assert mock_get_integration.call_count == 1
 
     @with_feature("organizations:issue-pr-checks-status")
-    @patch("sentry.issues.endpoints.group_pull_requests.integration_service.get_integration")
+    @patch(
+        "sentry.integrations.source_code_management.pull_request_status_batch.integration_service.get_integration"
+    )
     def test_checks_and_review_skipped_for_finished_pull_requests(
         self, mock_get_integration: Mock
     ) -> None:
@@ -529,7 +544,9 @@ class GroupPullRequestsEndpointTest(APITestCase):
         assert client.requested_keys == []
 
     @with_feature("organizations:issue-pr-checks-status")
-    @patch("sentry.issues.endpoints.group_pull_requests.integration_service.get_integration")
+    @patch(
+        "sentry.integrations.source_code_management.pull_request_status_batch.integration_service.get_integration"
+    )
     def test_checks_and_review_fetch_failure_is_not_fatal(self, mock_get_integration: Mock) -> None:
         pull_request, _ = self.create_linked_pull_request(
             key="1", state=PullRequestLifecycleState.OPEN, draft=False
@@ -548,8 +565,10 @@ class GroupPullRequestsEndpointTest(APITestCase):
         assert response.data["pullRequests"][0]["status"] == "open"
 
     @with_feature("organizations:issue-pr-checks-status")
-    @patch("sentry.issues.endpoints.group_pull_requests.logger")
-    @patch("sentry.issues.endpoints.group_pull_requests.integration_service.get_integration")
+    @patch("sentry.integrations.source_code_management.pull_request_status_batch.logger")
+    @patch(
+        "sentry.integrations.source_code_management.pull_request_status_batch.integration_service.get_integration"
+    )
     def test_checks_and_review_without_client_support(
         self, mock_get_integration: Mock, mock_logger: Mock
     ) -> None:
@@ -562,7 +581,9 @@ class GroupPullRequestsEndpointTest(APITestCase):
         mock_logger.info.assert_not_called()
 
     @with_feature("organizations:issue-pr-checks-status")
-    @patch("sentry.issues.endpoints.group_pull_requests.integration_service.get_integration")
+    @patch(
+        "sentry.integrations.source_code_management.pull_request_status_batch.integration_service.get_integration"
+    )
     def test_checks_and_review_without_integration(self, mock_get_integration: Mock) -> None:
         self.create_linked_pull_request(key="1", state=PullRequestLifecycleState.OPEN, draft=False)
         mock_get_integration.return_value = None

--- a/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
@@ -1,10 +1,54 @@
+from collections.abc import Sequence
 from unittest import mock
 
+from sentry.constants import ObjectStatus
+from sentry.integrations.source_code_management.status_check import (
+    AggregateChecksStatus,
+    AggregateReviewStatus,
+    PullRequestFileSummary,
+    PullRequestStatusClient,
+    PullRequestStatusRequest,
+    PullRequestStatusResult,
+)
+from sentry.models.pullrequest import PullRequestLifecycleState
 from sentry.seer.milestones import reconcile_milestones
 from sentry.seer.models.run import SeerRunMilestoneType
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.types.group import PriorityLevel
+
+_INTEGRATION_SERVICE = (
+    "sentry.integrations.source_code_management.pull_request_status_batch."
+    "integration_service.get_integration"
+)
+
+
+class PullRequestStatusClientFake(PullRequestStatusClient):
+    def __init__(
+        self,
+        status_by_key: dict[str, PullRequestStatusResult] | None = None,
+        error: Exception | None = None,
+    ) -> None:
+        self.status_by_key = status_by_key or {}
+        self.error = error
+        self.requested_keys: list[str] = []
+        self.requested_include_files: list[bool] = []
+
+    def get_pull_request_statuses(
+        self, pull_requests: Sequence[PullRequestStatusRequest]
+    ) -> dict[PullRequestStatusRequest, PullRequestStatusResult]:
+        self.requested_keys.extend(pull_request.pull_number for pull_request in pull_requests)
+        self.requested_include_files.extend(
+            pull_request.include_files for pull_request in pull_requests
+        )
+        if self.error is not None:
+            raise self.error
+        return {
+            pull_request: self.status_by_key.get(
+                pull_request.pull_number, PullRequestStatusResult()
+            )
+            for pull_request in pull_requests
+        }
 
 
 def _root_cause_state(description):
@@ -42,14 +86,10 @@ class OrganizationSeerAutofixOverviewTest(APITestCase):
         reconcile_milestones(run, _root_cause_state(description))
         return run
 
-    def test_feature_flag_off_returns_404(self):
-        self.get_error_response(self.organization.slug, status_code=404)
-
     def test_root_cause_run_grouped_under_root_cause_milestone(self):
         group = self.create_group()
         self._run_for_group(group, "the boom")
-        with self.feature("organizations:seer-night-shift-ui"):
-            resp = self.get_success_response(self.organization.slug)
+        resp = self.get_success_response(self.organization.slug)
         runs = resp.data["runsByMilestone"][SeerRunMilestoneType.ROOT_CAUSE]
         assert len(runs) == 1
         assert runs[0]["shortId"] == group.qualified_short_id
@@ -81,8 +121,7 @@ class OrganizationSeerAutofixOverviewTest(APITestCase):
         run = self.create_seer_run(organization=self.organization)
         self.create_seer_agent_run(run, source="autofix", group=group, project=group.project)
         reconcile_milestones(run, self._solution_state("rc text", "fix text"))
-        with self.feature("organizations:seer-night-shift-ui"):
-            resp = self.get_success_response(self.organization.slug)
+        resp = self.get_success_response(self.organization.slug)
         runs_by_milestone = resp.data["runsByMilestone"]
         assert runs_by_milestone[SeerRunMilestoneType.ROOT_CAUSE] == []
         runs = runs_by_milestone[SeerRunMilestoneType.SOLUTION]
@@ -94,8 +133,7 @@ class OrganizationSeerAutofixOverviewTest(APITestCase):
         group = self.create_group()
         self._run_for_group(group, "old run")
         self._run_for_group(group, "new run")
-        with self.feature("organizations:seer-night-shift-ui"):
-            resp = self.get_success_response(self.organization.slug)
+        resp = self.get_success_response(self.organization.slug)
         runs = resp.data["runsByMilestone"][SeerRunMilestoneType.ROOT_CAUSE]
         assert len(runs) == 1
         assert runs[0]["rootCause"]["oneLineDescription"] == "new run"
@@ -107,24 +145,21 @@ class OrganizationSeerAutofixOverviewTest(APITestCase):
         run = self.create_seer_run(organization=other_org)
         self.create_seer_agent_run(run, source="autofix", group=other_group, project=other_project)
         reconcile_milestones(run, _root_cause_state("hidden"))
-        with self.feature("organizations:seer-night-shift-ui"):
-            resp = self.get_success_response(self.organization.slug)
+        resp = self.get_success_response(self.organization.slug)
         assert resp.data["runsByMilestone"][SeerRunMilestoneType.ROOT_CAUSE] == []
 
     def test_deleted_group_id_is_tolerated(self):
         group = self.create_group()
         self._run_for_group(group, "gone")
         group.delete()
-        with self.feature("organizations:seer-night-shift-ui"):
-            resp = self.get_success_response(self.organization.slug)
+        resp = self.get_success_response(self.organization.slug)
         # Stale group id points at a deleted group; run is skipped, no 500.
         assert resp.data["runsByMilestone"][SeerRunMilestoneType.ROOT_CAUSE] == []
 
     def test_run_includes_nested_issue_object(self):
         group = self.create_group(priority=PriorityLevel.HIGH)
         self._run_for_group(group, "the boom")
-        with self.feature("organizations:seer-night-shift-ui"):
-            resp = self.get_success_response(self.organization.slug)
+        resp = self.get_success_response(self.organization.slug)
         issue = resp.data["runsByMilestone"][SeerRunMilestoneType.ROOT_CAUSE][0]["issue"]
         assert issue["project"]["id"] == str(group.project_id)
         assert issue["project"]["slug"] == group.project.slug
@@ -135,6 +170,240 @@ class OrganizationSeerAutofixOverviewTest(APITestCase):
         assert issue["assignedTo"] is None
         assert issue["owners"] == []
 
+    def _pull_request_for_run(self, group, run, *, key="123", **updates):
+        repo = self.create_repo(
+            project=group.project,
+            name="getsentry/sentry",
+            provider="integrations:github",
+            integration_id=123,
+            url="https://github.com/getsentry/sentry",
+        )
+        pull_request = self.create_pull_request(
+            repository_id=repo.id, organization_id=self.organization.id, key=key
+        )
+        pull_request.update(**updates)
+        self.create_seer_run_pull_request(run=run, pull_request=pull_request)
+        return pull_request
+
+    def _set_provider_client(self, mock_get_integration, client):
+        installation = mock.Mock()
+        installation.get_client.return_value = client
+        integration = mock.Mock()
+        integration.get_installation.return_value = installation
+        mock_get_integration.return_value = integration
+        return client
+
+    def _pull_requests(self):
+        resp = self.get_success_response(self.organization.slug)
+        run_data = resp.data["runsByMilestone"][SeerRunMilestoneType.ROOT_CAUSE][0]
+        return run_data["pullRequests"]
+
+    def test_run_includes_pull_requests(self):
+        group = self.create_group()
+        run = self._run_for_group(group, "boom")
+        self._pull_request_for_run(group, run, state=PullRequestLifecycleState.OPEN, draft=False)
+        resp = self.get_success_response(self.organization.slug)
+        run_data = resp.data["runsByMilestone"][SeerRunMilestoneType.ROOT_CAUSE][0]
+        assert run_data["pullRequests"] == [
+            {
+                "number": 123,
+                "url": "https://github.com/getsentry/sentry/pull/123",
+                "status": "open",
+                "checksStatus": None,
+                "reviewStatus": None,
+                "files": [],
+            }
+        ]
+
+    @mock.patch(_INTEGRATION_SERVICE)
+    def test_open_pull_request_includes_changed_files(self, mock_get_integration):
+        group = self.create_group()
+        run = self._run_for_group(group, "boom")
+        self._pull_request_for_run(group, run, state=PullRequestLifecycleState.OPEN, draft=False)
+        client = self._set_provider_client(
+            mock_get_integration,
+            PullRequestStatusClientFake(
+                {
+                    "123": PullRequestStatusResult(
+                        files=(
+                            PullRequestFileSummary(
+                                path="src/sentry/foo.py",
+                                additions=10,
+                                deletions=2,
+                                change_type="MODIFIED",
+                            ),
+                            PullRequestFileSummary(
+                                path="src/sentry/bar.py",
+                                additions=3,
+                                deletions=0,
+                                change_type="ADDED",
+                            ),
+                        )
+                    )
+                }
+            ),
+        )
+
+        pull_requests = self._pull_requests()
+
+        assert pull_requests[0]["files"] == [
+            {
+                "path": "src/sentry/foo.py",
+                "additions": 10,
+                "deletions": 2,
+                "changeType": "MODIFIED",
+            },
+            {"path": "src/sentry/bar.py", "additions": 3, "deletions": 0, "changeType": "ADDED"},
+        ]
+        assert client.requested_include_files == [True]
+
+    @mock.patch(_INTEGRATION_SERVICE)
+    def test_open_pull_request_includes_checks_and_review(self, mock_get_integration):
+        group = self.create_group()
+        run = self._run_for_group(group, "boom")
+        self._pull_request_for_run(group, run, state=PullRequestLifecycleState.OPEN, draft=False)
+        client = self._set_provider_client(
+            mock_get_integration,
+            PullRequestStatusClientFake(
+                {
+                    "123": PullRequestStatusResult(
+                        checks=AggregateChecksStatus.SUCCESS,
+                        review=AggregateReviewStatus.APPROVED,
+                    )
+                }
+            ),
+        )
+
+        pull_requests = self._pull_requests()
+
+        assert pull_requests[0]["checksStatus"] == "success"
+        assert pull_requests[0]["reviewStatus"] == "approved"
+        assert client.requested_keys == ["123"]
+
+    @mock.patch(_INTEGRATION_SERVICE)
+    def test_merged_pull_request_skips_provider_fetch(self, mock_get_integration):
+        group = self.create_group()
+        run = self._run_for_group(group, "boom")
+        self._pull_request_for_run(
+            group, run, state=PullRequestLifecycleState.MERGED, merged_at=before_now(days=1)
+        )
+        client = self._set_provider_client(mock_get_integration, PullRequestStatusClientFake())
+
+        pull_requests = self._pull_requests()
+
+        assert pull_requests[0]["status"] == "merged"
+        assert pull_requests[0]["checksStatus"] is None
+        assert pull_requests[0]["reviewStatus"] is None
+        assert client.requested_keys == []
+
+    @mock.patch(_INTEGRATION_SERVICE)
+    def test_provider_failure_degrades_to_null_statuses(self, mock_get_integration):
+        group = self.create_group()
+        run = self._run_for_group(group, "boom")
+        self._pull_request_for_run(group, run, state=PullRequestLifecycleState.OPEN, draft=False)
+        self._set_provider_client(
+            mock_get_integration, PullRequestStatusClientFake(error=RuntimeError("nope"))
+        )
+
+        pull_requests = self._pull_requests()
+
+        assert pull_requests[0]["number"] == 123
+        assert pull_requests[0]["status"] == "open"
+        assert pull_requests[0]["checksStatus"] is None
+        assert pull_requests[0]["reviewStatus"] is None
+
+    def test_unregistered_repository_provider_yields_null_url(self):
+        group = self.create_group()
+        run = self._run_for_group(group, "boom")
+        repo = self.create_repo(
+            project=group.project,
+            name="getsentry/sentry",
+            provider="integrations:custom_scm",
+            integration_id=123,
+            url="https://github.com/getsentry/sentry",
+        )
+        pull_request = self.create_pull_request(
+            repository_id=repo.id, organization_id=self.organization.id, key="123"
+        )
+        pull_request.update(state=PullRequestLifecycleState.MERGED, merged_at=before_now(days=1))
+        self.create_seer_run_pull_request(run=run, pull_request=pull_request)
+
+        resp = self.get_success_response(self.organization.slug)
+
+        pull_requests = resp.data["runsByMilestone"][SeerRunMilestoneType.ROOT_CAUSE][0][
+            "pullRequests"
+        ]
+        assert pull_requests[0]["url"] is None
+
+    @mock.patch(_INTEGRATION_SERVICE)
+    def test_non_ascii_digit_key_does_not_poison_integration_batch(self, mock_get_integration):
+        group = self.create_group()
+        run = self._run_for_group(group, "boom")
+        repo = self.create_repo(
+            project=group.project,
+            name="getsentry/sentry",
+            provider="integrations:github",
+            integration_id=123,
+            url="https://github.com/getsentry/sentry",
+        )
+        # "²".isdigit() is True but int("²") raises; the batch guard must match int().
+        for key in ("123", "²"):
+            pull_request = self.create_pull_request(
+                repository_id=repo.id, organization_id=self.organization.id, key=key
+            )
+            pull_request.update(state=PullRequestLifecycleState.OPEN, draft=False)
+            self.create_seer_run_pull_request(run=run, pull_request=pull_request)
+        client = self._set_provider_client(
+            mock_get_integration,
+            PullRequestStatusClientFake(
+                {"123": PullRequestStatusResult(checks=AggregateChecksStatus.SUCCESS)}
+            ),
+        )
+
+        pull_requests = self._pull_requests()
+
+        assert client.requested_keys == ["123"]
+        assert [pr["number"] for pr in pull_requests] == [123]
+        assert pull_requests[0]["checksStatus"] == "success"
+
+    @mock.patch(_INTEGRATION_SERVICE)
+    def test_pull_request_on_inactive_repo_is_not_enriched(self, mock_get_integration):
+        group = self.create_group()
+        run = self._run_for_group(group, "boom")
+        repo = self.create_repo(
+            project=group.project,
+            name="getsentry/sentry",
+            provider="integrations:github",
+            integration_id=123,
+            url="https://github.com/getsentry/sentry",
+        )
+        repo.update(status=ObjectStatus.PENDING_DELETION)
+        pull_request = self.create_pull_request(
+            repository_id=repo.id, organization_id=self.organization.id, key="123"
+        )
+        pull_request.update(state=PullRequestLifecycleState.OPEN, draft=False)
+        self.create_seer_run_pull_request(run=run, pull_request=pull_request)
+        client = self._set_provider_client(
+            mock_get_integration,
+            PullRequestStatusClientFake(
+                {"123": PullRequestStatusResult(checks=AggregateChecksStatus.SUCCESS)}
+            ),
+        )
+
+        pull_requests = self._pull_requests()
+
+        # A disconnected repo is skipped: no provider call, no url, null enrichment.
+        assert client.requested_keys == []
+        assert pull_requests[0]["url"] is None
+        assert pull_requests[0]["checksStatus"] is None
+
+    def test_run_without_pull_requests_has_empty_list(self):
+        group = self.create_group()
+        self._run_for_group(group, "boom")
+        resp = self.get_success_response(self.organization.slug)
+        run_data = resp.data["runsByMilestone"][SeerRunMilestoneType.ROOT_CAUSE][0]
+        assert run_data["pullRequests"] == []
+
     def test_runs_outside_stats_period_are_excluded(self):
         recent = self.create_group()
         self._run_for_group(recent, "recent boom")
@@ -142,10 +411,7 @@ class OrganizationSeerAutofixOverviewTest(APITestCase):
         old_run = self._run_for_group(old, "old boom")
         old_run.update(last_triggered_at=before_now(days=30))
 
-        with self.feature("organizations:seer-night-shift-ui"):
-            resp = self.get_success_response(
-                self.organization.slug, qs_params={"statsPeriod": "14d"}
-            )
+        resp = self.get_success_response(self.organization.slug, qs_params={"statsPeriod": "14d"})
 
         runs = resp.data["runsByMilestone"][SeerRunMilestoneType.ROOT_CAUSE]
         assert [r["shortId"] for r in runs] == [recent.qualified_short_id]
@@ -157,7 +423,6 @@ class OrganizationSeerAutofixOverviewTest(APITestCase):
         for i in range(3):
             self._run_for_group(self.create_group(), f"boom {i}")
 
-        with self.feature("organizations:seer-night-shift-ui"):
-            resp = self.get_success_response(self.organization.slug)
+        resp = self.get_success_response(self.organization.slug)
 
         assert len(resp.data["runsByMilestone"][SeerRunMilestoneType.ROOT_CAUSE]) == 2


### PR DESCRIPTION
## Summary

Second of three stacked PRs for the Autofix overview feature. **Stacked on #121747 — review/merge that first.**

Adds pull-request SCM enrichment and wires it into the Autofix overview endpoint:

- New `pull_request_status_batch` module extracts the shared batch helpers (`get_checks_and_review` + provider resolution) out of the group pull requests endpoint so both consumers share one implementation.
- Adds batched checks, review status, and changed-file enrichment. GitHub file expansion is opt-in and keyed separately in the provider cache, so existing status-only consumers are unaffected.
- Re-enables the pull-request serialization in the overview endpoint that was stubbed behind `NOTE:` markers in #121747.

## Stack

1. #121747 — endpoint core
2. **This PR** — SCM enrichment + endpoint wiring
3. #121749 — frontend UI

## Test Plan

- Overview endpoint tests now cover pull requests, checks/review status, changed files, merged-PR fetch skipping, and provider-failure degradation.
- `test_group_pull_requests`, `test_client`, and `test_pull_request_status` updated for the extracted batch module and file expansion.

