### PR TITLE
feat(seer): Add Autofix overview UI

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -2545,6 +2545,10 @@ function buildRoutes(): RouteObject[] {
       component: make(() => import('sentry/views/seerWorkflows/overview')),
     },
     {
+      path: 'autofix/overview2/',
+      component: make(() => import('sentry/views/seerWorkflows/overview2')),
+    },
+    {
       path: 'views/:viewId/',
       component: errorHandler(OverviewWrapper),
     },

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -177,6 +177,14 @@ export type PullRequestReviewStatus =
   | 'changes_requested'
   | 'review_required';
 
+export type PullRequestFileChangeType =
+  | 'ADDED'
+  | 'CHANGED'
+  | 'COPIED'
+  | 'DELETED'
+  | 'MODIFIED'
+  | 'RENAMED';
+
 export interface LinkedPullRequest extends Omit<PullRequest, 'author'> {
   attribution: PullRequestAttribution | null;
   checksStatus: PullRequestChecksStatus | null;

--- a/static/app/views/seerExplorer/components/fileDiffViewer.tsx
+++ b/static/app/views/seerExplorer/components/fileDiffViewer.tsx
@@ -31,6 +31,11 @@ interface FileDiffViewerProps {
    */
   defaultExpanded?: boolean;
   /**
+   * Hides the built-in header (path + added/removed) for consumers that render
+   * their own. Default: false
+   */
+  hideHeader?: boolean;
+  /**
    * Optional repo name to display in the file header.
    * If provided, will show as "repoName:filePath", otherwise just "filePath"
    */
@@ -112,6 +117,7 @@ export function FileDiffViewer({
   useFlexForDeleted = false,
   collapsible = false,
   defaultExpanded = false,
+  hideHeader = false,
 }: FileDiffViewerProps) {
   const [isExpanded, setIsExpanded] = useState(collapsible ? defaultExpanded : true);
   const isDelete = patch.type === DiffFileType.DELETED;
@@ -119,18 +125,22 @@ export function FileDiffViewer({
 
   return (
     <FileDiffWrapper showBorder={showBorder}>
-      <FileHeader
-        collapsible={collapsible}
-        onClick={collapsible ? () => setIsExpanded(value => !value) : undefined}
-      >
-        {collapsible && <InteractionStateLayer />}
-        <Flex align="center" gap="md">
-          <FileAdded>+{patch.added}</FileAdded>
-          <FileRemoved>-{patch.removed}</FileRemoved>
-        </Flex>
-        <FilePathName title={filePath}>{filePath}</FilePathName>
-        {collapsible && <IconChevron size="xs" direction={isExpanded ? 'up' : 'down'} />}
-      </FileHeader>
+      {!hideHeader && (
+        <FileHeader
+          collapsible={collapsible}
+          onClick={collapsible ? () => setIsExpanded(value => !value) : undefined}
+        >
+          {collapsible && <InteractionStateLayer />}
+          <Flex align="center" gap="md">
+            <FileAdded>+{patch.added}</FileAdded>
+            <FileRemoved>-{patch.removed}</FileRemoved>
+          </Flex>
+          <FilePathName title={filePath}>{filePath}</FilePathName>
+          {collapsible && (
+            <IconChevron size="xs" direction={isExpanded ? 'up' : 'down'} />
+          )}
+        </FileHeader>
+      )}
       {isExpanded && (
         <Fragment>
           {isDelete ? (

--- a/static/app/views/seerWorkflows/overview2/filePatch.spec.ts
+++ b/static/app/views/seerWorkflows/overview2/filePatch.spec.ts
@@ -1,0 +1,130 @@
+import {DiffFileType, DiffLineType} from 'sentry/components/events/autofix/types';
+
+import {parseFilePatch} from './filePatch';
+
+describe('parseFilePatch', () => {
+  it('parses a modified patch into hunks with line numbers', () => {
+    const patch = ['@@ -1,3 +1,4 @@ def foo():', ' a', '-b', '+c', '+d', ' e'].join('\n');
+
+    const result = parseFilePatch({
+      path: 'src/foo.py',
+      patch,
+      additions: 2,
+      deletions: 1,
+      changeType: 'MODIFIED',
+    });
+
+    expect(result.type).toBe(DiffFileType.MODIFIED);
+    expect(result.path).toBe('src/foo.py');
+    expect(result.source_file).toBe('src/foo.py');
+    expect(result.target_file).toBe('src/foo.py');
+    expect(result.added).toBe(2);
+    expect(result.removed).toBe(1);
+    expect(result.hunks).toHaveLength(1);
+
+    const hunk = result.hunks[0]!;
+    expect(hunk.source_start).toBe(1);
+    expect(hunk.source_length).toBe(3);
+    expect(hunk.target_start).toBe(1);
+    expect(hunk.target_length).toBe(4);
+    expect(hunk.section_header).toBe('def foo():');
+    expect(hunk.lines).toEqual([
+      {
+        line_type: DiffLineType.CONTEXT,
+        value: 'a',
+        source_line_no: 1,
+        target_line_no: 1,
+        diff_line_no: 1,
+      },
+      {
+        line_type: DiffLineType.REMOVED,
+        value: 'b',
+        source_line_no: 2,
+        target_line_no: null,
+        diff_line_no: 2,
+      },
+      {
+        line_type: DiffLineType.ADDED,
+        value: 'c',
+        source_line_no: null,
+        target_line_no: 2,
+        diff_line_no: 3,
+      },
+      {
+        line_type: DiffLineType.ADDED,
+        value: 'd',
+        source_line_no: null,
+        target_line_no: 3,
+        diff_line_no: 4,
+      },
+      {
+        line_type: DiffLineType.CONTEXT,
+        value: 'e',
+        source_line_no: 3,
+        target_line_no: 4,
+        diff_line_no: 5,
+      },
+    ]);
+  });
+
+  it('maps changeType to DiffFileType', () => {
+    const base = {path: 'f', patch: '', additions: 0, deletions: 0};
+    expect(parseFilePatch({...base, changeType: 'ADDED'}).type).toBe(DiffFileType.ADDED);
+    expect(parseFilePatch({...base, changeType: 'DELETED'}).type).toBe(
+      DiffFileType.DELETED
+    );
+    expect(parseFilePatch({...base, changeType: 'RENAMED'}).type).toBe(
+      DiffFileType.MODIFIED
+    );
+    expect(parseFilePatch({...base, changeType: null}).type).toBe(DiffFileType.MODIFIED);
+  });
+
+  it('parses multiple hunks', () => {
+    const patch = ['@@ -1 +1 @@', '-a', '+b', '@@ -10,2 +10,2 @@', ' c', '-d', '+e'].join(
+      '\n'
+    );
+
+    const result = parseFilePatch({
+      path: 'f',
+      patch,
+      additions: 2,
+      deletions: 2,
+      changeType: 'MODIFIED',
+    });
+
+    expect(result.hunks).toHaveLength(2);
+    expect(result.hunks[0]!.source_length).toBe(1);
+    expect(result.hunks[1]!.source_start).toBe(10);
+    expect(result.hunks[1]!.lines[0]!.source_line_no).toBe(10);
+  });
+
+  it('returns empty hunks for a null or empty patch', () => {
+    expect(
+      parseFilePatch({
+        path: 'f',
+        patch: null,
+        additions: 0,
+        deletions: 0,
+        changeType: null,
+      }).hunks
+    ).toEqual([]);
+    expect(
+      parseFilePatch({path: 'f', patch: '', additions: 0, deletions: 0, changeType: null})
+        .hunks
+    ).toEqual([]);
+  });
+
+  it('ignores no-newline markers', () => {
+    const patch = ['@@ -1 +1 @@', '-a', '\\ No newline at end of file', '+b'].join('\n');
+
+    const result = parseFilePatch({
+      path: 'f',
+      patch,
+      additions: 1,
+      deletions: 1,
+      changeType: 'MODIFIED',
+    });
+
+    expect(result.hunks[0]!.lines.map(line => line.value)).toEqual(['a', 'b']);
+  });
+});

--- a/static/app/views/seerWorkflows/overview2/filePatch.ts
+++ b/static/app/views/seerWorkflows/overview2/filePatch.ts
@@ -1,0 +1,99 @@
+import {
+  DiffFileType,
+  DiffLineType,
+  type FilePatch,
+} from 'sentry/components/events/autofix/types';
+import type {PullRequestFileChangeType} from 'sentry/types/integrations';
+
+interface RawPullRequestFile {
+  additions: number;
+  changeType: PullRequestFileChangeType | null;
+  deletions: number;
+  patch: string | null;
+  path: string;
+}
+
+const HUNK_HEADER = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(.*)$/;
+
+const LINE_TYPE_BY_PREFIX: Record<string, DiffLineType> = {
+  ' ': DiffLineType.CONTEXT,
+  '+': DiffLineType.ADDED,
+  '-': DiffLineType.REMOVED,
+};
+
+function toDiffFileType(changeType: PullRequestFileChangeType | null): DiffFileType {
+  if (changeType === 'ADDED') {
+    return DiffFileType.ADDED;
+  }
+  if (changeType === 'DELETED') {
+    return DiffFileType.DELETED;
+  }
+  return DiffFileType.MODIFIED;
+}
+
+// The provider's per-file `patch` is hunks-only (no ---/+++ headers): a series
+// of `@@ -s,l +s,l @@` blocks whose lines are prefixed with ' ', '+' or '-'.
+export function parseFilePatch({
+  path,
+  patch,
+  additions,
+  deletions,
+  changeType,
+}: RawPullRequestFile): FilePatch {
+  const hunks: FilePatch['hunks'] = [];
+  let diffLineNo = 0;
+  // Line offsets reset each hunk: removed lines advance only source, added
+  // lines only target, context lines both.
+  let priorSource = 0;
+  let priorTarget = 0;
+
+  for (const rawLine of patch?.split('\n') ?? []) {
+    const header = rawLine.match(HUNK_HEADER);
+    if (header) {
+      hunks.push({
+        source_start: Number(header[1]),
+        source_length: header[2] ? Number(header[2]) : 1,
+        target_start: Number(header[3]),
+        target_length: header[4] ? Number(header[4]) : 1,
+        section_header: (header[5] ?? '').trim(),
+        lines: [],
+      });
+      priorSource = 0;
+      priorTarget = 0;
+      continue;
+    }
+
+    const hunk = hunks.at(-1);
+    const lineType = LINE_TYPE_BY_PREFIX[rawLine[0] ?? ''];
+    if (!hunk || !lineType) {
+      continue; // preamble, "\ No newline at end of file", or stray lines
+    }
+
+    diffLineNo += 1;
+    hunk.lines.push({
+      line_type: lineType,
+      value: rawLine.slice(1),
+      source_line_no:
+        lineType === DiffLineType.ADDED ? null : hunk.source_start + priorSource,
+      target_line_no:
+        lineType === DiffLineType.REMOVED ? null : hunk.target_start + priorTarget,
+      diff_line_no: diffLineNo,
+    });
+    if (lineType !== DiffLineType.ADDED) {
+      priorSource += 1;
+    }
+    if (lineType !== DiffLineType.REMOVED) {
+      priorTarget += 1;
+    }
+  }
+
+  return {
+    path,
+    source_file: path,
+    target_file: path,
+    type: toDiffFileType(changeType),
+    added: additions,
+    removed: deletions,
+    hunks,
+  };
+}

--- a/static/app/views/seerWorkflows/overview2/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview2/index.spec.tsx
@@ -1,0 +1,830 @@
+import {GroupFixture} from 'sentry-fixture/group';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+  within,
+} from 'sentry-test/reactTestingLibrary';
+
+import {PageFiltersStore} from 'sentry/components/pageFilters/store';
+import {OrganizationStore} from 'sentry/stores/organizationStore';
+import {ProjectsStore} from 'sentry/stores/projectsStore';
+import AutofixOverview2 from 'sentry/views/seerWorkflows/overview2';
+import type {OverviewRunIssue} from 'sentry/views/seerWorkflows/overview2/types';
+
+describe('AutofixOverview2', () => {
+  const organization = OrganizationFixture({
+    features: ['seer-night-shift-ui'],
+  });
+  const basePath = `/organizations/${organization.slug}/issues/autofix/overview2/`;
+
+  const emptyMilestones = {
+    autofix_root_cause: [],
+    autofix_solution: [],
+    autofix_code_changes: [],
+    has_pull_request: [],
+    pull_requests_merged: [],
+  };
+
+  function issueFixture(overrides: Partial<OverviewRunIssue> = {}): OverviewRunIssue {
+    return {
+      ...GroupFixture(),
+      count: '0',
+      userCount: 0,
+      owners: [],
+      substatus: 'ongoing',
+      project: {id: '2', slug: 'project-slug', platform: 'python'},
+      ...overrides,
+    };
+  }
+
+  function pullRequestFixture({number, status}: {number: number; status: string | null}) {
+    return {
+      number,
+      url: `https://github.com/getsentry/sentry/pull/${number}`,
+      status,
+      checksStatus: null,
+      reviewStatus: null,
+      files: [],
+    };
+  }
+
+  const rootCauseRun = {
+    groupId: '2',
+    shortId: 'PROJ-1',
+    title: 'TypeError in checkout cart',
+    rootCause: {
+      oneLineDescription: 'The cart total is read before it is set.',
+    },
+    proposedFix: null,
+    seerRunId: 'run-1',
+    lastTriggeredAt: '2026-07-14T09:00:00Z',
+    pullRequests: [],
+    issue: issueFixture({count: '1200', userCount: 5}),
+  };
+
+  const solutionRun = {
+    groupId: '3',
+    shortId: 'PROJ-2',
+    title: 'KeyError in proxy handler',
+    rootCause: {oneLineDescription: 'The Authorization header is dropped.'},
+    proposedFix: {
+      oneLineSummary: 'Restore the Authorization header as a fallback.',
+    },
+    seerRunId: 'run-2',
+    lastTriggeredAt: '2026-07-14T10:00:00Z',
+    pullRequests: [],
+    issue: issueFixture({project: {id: '3', slug: 'project-slug', platform: 'python'}}),
+  };
+
+  function mockOverview({
+    base,
+    enriched,
+    enrichedAsyncDelay,
+    enrichedStatusCode,
+    baseStatusCode,
+  }: {
+    base: Record<string, unknown[]>;
+    baseStatusCode?: number;
+    enriched?: Record<string, unknown[]>;
+    enrichedAsyncDelay?: number | Promise<void>;
+    enrichedStatusCode?: number;
+  }) {
+    const baseRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/autofix-overview/`,
+      statusCode: baseStatusCode,
+      body: {runsByMilestone: {...emptyMilestones, ...base}},
+    });
+    const enrichedRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/autofix-overview/`,
+      match: [MockApiClient.matchQuery({expand: ['scmInfo', 'issueStats']})],
+      asyncDelay: enrichedAsyncDelay,
+      statusCode: enrichedStatusCode,
+      body: {runsByMilestone: {...emptyMilestones, ...(enriched ?? base)}},
+    });
+    return {baseRequest, enrichedRequest};
+  }
+
+  // The un-expanded call cannot reach Snuba, so it nulls out the issue stats.
+  const unenrichedRootCauseRun = {
+    ...rootCauseRun,
+    issue: issueFixture({count: null, userCount: null, lastSeen: null}),
+  };
+
+  // Holds the enriched response open so the pending state can be asserted, with
+  // no reliance on real timers.
+  function deferEnriched() {
+    let resolve!: () => void;
+    const promise = new Promise<void>(r => {
+      resolve = r;
+    });
+    return {promise, resolve};
+  }
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    localStorage.clear();
+
+    PageFiltersStore.onInitializeUrlState(PageFiltersFixture());
+    ProjectsStore.loadInitialData([ProjectFixture()]);
+    OrganizationStore.onUpdate(organization, {replace: true});
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      body: [ProjectFixture()],
+    });
+    // The reused assignee selector self-fetches its member options.
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/users/`,
+      body: [],
+    });
+  });
+
+  function renderPage() {
+    return render(<AutofixOverview2 />, {
+      organization,
+      initialRouterConfig: {location: {pathname: basePath}},
+    });
+  }
+
+  it('gates the page and issues no requests when the feature is disabled', async () => {
+    const {baseRequest, enrichedRequest} = mockOverview({
+      base: {autofix_root_cause: [rootCauseRun]},
+    });
+
+    render(<AutofixOverview2 />, {
+      organization: OrganizationFixture({features: []}),
+      initialRouterConfig: {location: {pathname: basePath}},
+    });
+
+    expect(
+      await screen.findByText("You don't have access to this feature")
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Autofix Overview')).not.toBeInTheDocument();
+    expect(baseRequest).not.toHaveBeenCalled();
+    expect(enrichedRequest).not.toHaveBeenCalled();
+  });
+
+  it('renders every section with counts from the single endpoint', async () => {
+    mockOverview({
+      base: {
+        autofix_root_cause: [rootCauseRun],
+        autofix_solution: [solutionRun],
+      },
+    });
+
+    renderPage();
+
+    expect(
+      await screen.findByRole('button', {name: 'Create Plan 1'})
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: 'Generate code changes 1'})
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Create PR 0'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Review Open PRs 0'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Merged 0'})).toBeInTheDocument();
+  });
+
+  it('renders card prose and links from the endpoint payload', async () => {
+    mockOverview({
+      base: {
+        autofix_root_cause: [rootCauseRun],
+        autofix_solution: [solutionRun],
+      },
+    });
+
+    renderPage();
+
+    const titleLink = await screen.findByRole('link', {
+      name: 'TypeError in checkout cart',
+    });
+    expect(titleLink).toHaveAttribute(
+      'href',
+      `/organizations/${organization.slug}/issues/2/`
+    );
+    expect(screen.getAllByText('TypeError in checkout cart')).toHaveLength(1);
+
+    expect(
+      screen.getByText('The cart total is read before it is set.')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Restore the Authorization header as a fallback.')
+    ).toBeInTheDocument();
+    expect(screen.getByText('PROJ-1')).toBeInTheDocument();
+
+    // The root-cause-only run has no plan, so only the solution card carries
+    // the plan label.
+    expect(screen.getAllByText('Root cause')).toHaveLength(2);
+    expect(screen.getAllByText('Plan')).toHaveLength(1);
+  });
+
+  it('scopes the request to the selected project', async () => {
+    PageFiltersStore.onInitializeUrlState(PageFiltersFixture({projects: [2]}));
+    const {baseRequest} = mockOverview({
+      base: {autofix_root_cause: [rootCauseRun]},
+    });
+
+    renderPage();
+
+    expect(
+      await screen.findByRole('link', {name: 'TypeError in checkout cart'})
+    ).toBeInTheDocument();
+    expect(baseRequest).toHaveBeenCalledWith(
+      `/organizations/${organization.slug}/seer/autofix-overview/`,
+      expect.objectContaining({
+        query: expect.objectContaining({project: [2]}),
+      })
+    );
+  });
+
+  it('scopes the request to the selected time window', async () => {
+    const {baseRequest} = mockOverview({
+      base: {autofix_root_cause: [rootCauseRun]},
+    });
+
+    render(<AutofixOverview2 />, {
+      organization,
+      initialRouterConfig: {
+        location: {pathname: basePath, query: {statsPeriod: '7d'}},
+      },
+    });
+
+    expect(
+      await screen.findByRole('link', {name: 'TypeError in checkout cart'})
+    ).toBeInTheDocument();
+    expect(baseRequest).toHaveBeenCalledWith(
+      `/organizations/${organization.slug}/seer/autofix-overview/`,
+      expect.objectContaining({
+        query: expect.objectContaining({statsPeriod: '7d'}),
+      })
+    );
+  });
+
+  it('issues a cheap request and an enriched expand request', async () => {
+    const {baseRequest, enrichedRequest} = mockOverview({
+      base: {autofix_root_cause: [rootCauseRun]},
+    });
+    // Overview2 reads everything from the overview endpoint; the legacy
+    // per-card endpoints must never be hit.
+    const runsRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/runs/`,
+      body: [],
+    });
+    const autofixRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/2/autofix/`,
+      body: {autofix: null},
+    });
+    const issuesRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/`,
+      body: [],
+    });
+
+    renderPage();
+
+    expect(
+      await screen.findByRole('link', {name: 'TypeError in checkout cart'})
+    ).toBeInTheDocument();
+    expect(baseRequest).toHaveBeenCalledWith(
+      `/organizations/${organization.slug}/seer/autofix-overview/`,
+      expect.objectContaining({
+        query: expect.not.objectContaining({expand: expect.anything()}),
+      })
+    );
+    expect(baseRequest).toHaveBeenCalledWith(
+      `/organizations/${organization.slug}/seer/autofix-overview/`,
+      expect.objectContaining({
+        query: expect.not.objectContaining({environment: expect.anything()}),
+      })
+    );
+    await waitFor(() =>
+      expect(enrichedRequest).toHaveBeenCalledWith(
+        `/organizations/${organization.slug}/seer/autofix-overview/`,
+        expect.objectContaining({
+          query: expect.objectContaining({expand: ['scmInfo', 'issueStats']}),
+        })
+      )
+    );
+    expect(runsRequest).not.toHaveBeenCalled();
+    expect(autofixRequest).not.toHaveBeenCalled();
+    expect(issuesRequest).not.toHaveBeenCalled();
+  });
+
+  it('shimmers the enriched slots until the expand request resolves', async () => {
+    const enriched = deferEnriched();
+    mockOverview({
+      base: {autofix_root_cause: [unenrichedRootCauseRun]},
+      enriched: {autofix_root_cause: [rootCauseRun]},
+      enrichedAsyncDelay: enriched.promise,
+    });
+
+    renderPage();
+
+    expect(
+      await screen.findByRole('link', {name: 'TypeError in checkout cart'})
+    ).toBeInTheDocument();
+    expect(screen.getAllByTestId('loading-placeholder').length).toBeGreaterThan(0);
+
+    enriched.resolve();
+
+    expect(await screen.findByText('1.2K events')).toBeInTheDocument();
+    expect(screen.queryByTestId('loading-placeholder')).not.toBeInTheDocument();
+  });
+
+  it('stops shimmering when the enriched request fails', async () => {
+    mockOverview({
+      base: {autofix_root_cause: [unenrichedRootCauseRun]},
+      enrichedStatusCode: 500,
+    });
+
+    renderPage();
+
+    expect(
+      await screen.findByRole('link', {name: 'TypeError in checkout cart'})
+    ).toBeInTheDocument();
+
+    await waitFor(() =>
+      expect(screen.queryByTestId('loading-placeholder')).not.toBeInTheDocument()
+    );
+    expect(screen.queryByText(/events/)).not.toBeInTheDocument();
+    expect(screen.getByText('PROJ-1')).toBeInTheDocument();
+  });
+
+  it('renders the enriched payload when the base request fails', async () => {
+    mockOverview({
+      base: {},
+      enriched: {autofix_root_cause: [rootCauseRun]},
+      baseStatusCode: 500,
+    });
+
+    renderPage();
+
+    expect(
+      await screen.findByRole('link', {name: 'TypeError in checkout cart'})
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('There was an error loading data.')
+    ).not.toBeInTheDocument();
+  });
+
+  it('keeps the list up with a spinner while a sort change reloads', async () => {
+    const {baseRequest} = mockOverview({base: {autofix_root_cause: [rootCauseRun]}});
+
+    // The events sort returns a different run; hold its enrichment open to keep
+    // the reloading state on screen.
+    const eventsEnriched = deferEnriched();
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/autofix-overview/`,
+      match: [
+        MockApiClient.matchQuery({sort: 'events', expand: ['scmInfo', 'issueStats']}),
+      ],
+      asyncDelay: eventsEnriched.promise,
+      body: {runsByMilestone: {...emptyMilestones, autofix_solution: [solutionRun]}},
+    });
+
+    renderPage();
+
+    expect(
+      await screen.findByRole('link', {name: 'TypeError in checkout cart'})
+    ).toBeInTheDocument();
+    expect(baseRequest).toHaveBeenCalledTimes(1);
+
+    await userEvent.click(screen.getByRole('button', {name: /Sort/}));
+    await userEvent.click(screen.getByRole('option', {name: 'Most events'}));
+
+    // Base does not refetch on a sort change; the old list stays up with a
+    // spinner while the single enriched request reloads.
+    expect(await screen.findByTestId('loading-indicator')).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', {name: 'TypeError in checkout cart'})
+    ).toBeInTheDocument();
+    expect(baseRequest).toHaveBeenCalledTimes(1);
+
+    eventsEnriched.resolve();
+
+    expect(
+      await screen.findByRole('link', {name: 'KeyError in proxy handler'})
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', {name: 'TypeError in checkout cart'})
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the changed files of an open pull request', async () => {
+    // Without `expand=scmInfo` the endpoint still returns the pull request, but
+    // its SCM-sourced fields come back empty.
+    const unenrichedPullRequest = {
+      number: 42,
+      url: 'https://github.com/getsentry/sentry/pull/42',
+      status: 'open',
+      checksStatus: null,
+      reviewStatus: null,
+      files: [],
+    };
+
+    const enriched = deferEnriched();
+    mockOverview({
+      enrichedAsyncDelay: enriched.promise,
+      base: {
+        has_pull_request: [{...rootCauseRun, pullRequests: [unenrichedPullRequest]}],
+      },
+      enriched: {
+        has_pull_request: [
+          {
+            ...rootCauseRun,
+            pullRequests: [
+              {
+                ...unenrichedPullRequest,
+                files: [
+                  {
+                    path: 'src/sentry/foo.py',
+                    additions: 10,
+                    deletions: 2,
+                    changeType: 'MODIFIED',
+                  },
+                  {
+                    path: 'src/sentry/bar.py',
+                    additions: 3,
+                    deletions: 0,
+                    changeType: 'ADDED',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('PROJ-1')).toBeInTheDocument();
+
+    enriched.resolve();
+
+    expect(await screen.findByText('2 files changed')).toBeInTheDocument();
+    expect(screen.getByText('src/sentry/foo.py')).toBeInTheDocument();
+    expect(screen.getByText('src/sentry/bar.py')).toBeInTheDocument();
+    expect(screen.getByText('+10')).toBeInTheDocument();
+    expect(screen.getByText('-2')).toBeInTheDocument();
+  });
+
+  it('renders the newest actionable pull request, not the oldest link', async () => {
+    const closedPullRequest = {
+      number: 1,
+      url: 'https://github.com/getsentry/sentry/pull/1',
+      status: 'closed',
+      checksStatus: null,
+      reviewStatus: null,
+      files: [],
+    };
+    // The endpoint enriches open/draft links only, so the actionable PR is the
+    // one carrying badges and files.
+    const openPullRequest = {
+      number: 2,
+      url: 'https://github.com/getsentry/sentry/pull/2',
+      status: 'open',
+      checksStatus: 'success',
+      reviewStatus: 'approved',
+      files: [
+        {
+          path: 'src/sentry/foo.py',
+          additions: 10,
+          deletions: 2,
+          changeType: 'MODIFIED',
+        },
+      ],
+    };
+    mockOverview({
+      base: {
+        has_pull_request: [
+          {...rootCauseRun, pullRequests: [closedPullRequest, openPullRequest]},
+        ],
+      },
+    });
+
+    renderPage();
+
+    expect(await screen.findByRole('button', {name: /Review PR #2/})).toHaveAttribute(
+      'href',
+      'https://github.com/getsentry/sentry/pull/2'
+    );
+    expect(screen.queryByRole('button', {name: /Review PR #1/})).not.toBeInTheDocument();
+    expect(screen.getByText('Checks passed')).toBeInTheDocument();
+    expect(screen.getByText('Approved')).toBeInTheDocument();
+    expect(screen.getByText('src/sentry/foo.py')).toBeInTheDocument();
+  });
+
+  it('renders a draft pull request as the actionable one', async () => {
+    mockOverview({
+      base: {
+        has_pull_request: [
+          {
+            ...rootCauseRun,
+            pullRequests: [
+              pullRequestFixture({number: 7, status: 'draft'}),
+              pullRequestFixture({number: 9, status: 'closed'}),
+            ],
+          },
+        ],
+      },
+    });
+
+    renderPage();
+
+    expect(await screen.findByRole('button', {name: /Review PR #7/})).toHaveAttribute(
+      'href',
+      'https://github.com/getsentry/sentry/pull/7'
+    );
+    expect(screen.queryByRole('button', {name: /Review PR #9/})).not.toBeInTheDocument();
+  });
+
+  it('falls back to the newest link when no pull request is actionable', async () => {
+    mockOverview({
+      base: {
+        has_pull_request: [
+          {
+            ...rootCauseRun,
+            pullRequests: [
+              pullRequestFixture({number: 1, status: 'merged'}),
+              pullRequestFixture({number: 5, status: 'closed'}),
+            ],
+          },
+        ],
+      },
+    });
+
+    renderPage();
+
+    expect(await screen.findByRole('button', {name: /Review PR #5/})).toHaveAttribute(
+      'href',
+      'https://github.com/getsentry/sentry/pull/5'
+    );
+    expect(screen.queryByRole('button', {name: /Review PR #1/})).not.toBeInTheDocument();
+  });
+
+  it('labels each changed file with its change type', async () => {
+    mockOverview({
+      base: {
+        has_pull_request: [
+          {
+            ...rootCauseRun,
+            pullRequests: [
+              {
+                number: 42,
+                url: 'https://github.com/getsentry/sentry/pull/42',
+                status: 'open',
+                checksStatus: null,
+                reviewStatus: null,
+                files: [
+                  {
+                    path: 'src/sentry/new.py',
+                    additions: 12,
+                    deletions: 0,
+                    changeType: 'ADDED',
+                  },
+                  {
+                    path: 'src/sentry/gone.py',
+                    additions: 0,
+                    deletions: 30,
+                    changeType: 'DELETED',
+                  },
+                  {
+                    path: 'src/sentry/kept.py',
+                    additions: 1,
+                    deletions: 1,
+                    changeType: 'MODIFIED',
+                  },
+                  {
+                    path: 'src/sentry/moved.py',
+                    additions: 0,
+                    deletions: 0,
+                    changeType: 'RENAMED',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('4 files changed')).toBeInTheDocument();
+    expect(screen.getByText('Added')).toBeInTheDocument();
+    expect(screen.getByText('Deleted')).toBeInTheDocument();
+    expect(screen.getByText('Modified')).toBeInTheDocument();
+    expect(screen.getByText('Renamed')).toBeInTheDocument();
+    expect(screen.getByText('+12')).toBeInTheDocument();
+    expect(screen.getByText('-30')).toBeInTheDocument();
+
+    // Added and deleted keep their own color, rather than all six collapsing
+    // into the muted label used for the rest.
+    const tagClassName = (label: string) =>
+      screen.getByText(label).closest('[data-test-id="tag-background"]')?.className;
+    expect(tagClassName('Added')).not.toEqual(tagClassName('Deleted'));
+    expect(tagClassName('Added')).not.toEqual(tagClassName('Modified'));
+    expect(tagClassName('Deleted')).not.toEqual(tagClassName('Modified'));
+    expect(tagClassName('Renamed')).toEqual(tagClassName('Modified'));
+  });
+
+  it('renders a file with an unknown change type without a tag', async () => {
+    mockOverview({
+      base: {
+        has_pull_request: [
+          {
+            ...rootCauseRun,
+            pullRequests: [
+              {
+                number: 42,
+                url: 'https://github.com/getsentry/sentry/pull/42',
+                status: 'open',
+                checksStatus: null,
+                reviewStatus: null,
+                files: [
+                  {
+                    path: 'src/sentry/mystery.py',
+                    additions: 4,
+                    deletions: 4,
+                    changeType: null,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    renderPage();
+
+    const fileRow = (await screen.findByText('src/sentry/mystery.py')).closest('div')!;
+
+    expect(within(fileRow).getByText('+4')).toBeInTheDocument();
+    expect(within(fileRow).queryByTestId('tag-background')).not.toBeInTheDocument();
+  });
+
+  it('fetches all PR files and renders a diff when a file is expanded', async () => {
+    mockOverview({
+      base: {
+        has_pull_request: [
+          {
+            ...rootCauseRun,
+            pullRequests: [
+              {
+                id: '77',
+                number: 42,
+                url: 'https://github.com/getsentry/sentry/pull/42',
+                status: 'open',
+                checksStatus: null,
+                reviewStatus: null,
+                files: [
+                  {
+                    path: 'src/sentry/foo.py',
+                    additions: 2,
+                    deletions: 1,
+                    changeType: 'MODIFIED',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    });
+    const filesRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/pull-requests/77/files/`,
+      body: {
+        files: [
+          {
+            path: 'src/sentry/foo.py',
+            patch: '@@ -1,2 +1,3 @@\n keep\n-drop\n+addedone\n+addedtwo',
+          },
+        ],
+      },
+    });
+
+    renderPage();
+
+    const fileToggle = await screen.findByRole('button', {name: /src\/sentry\/foo\.py/});
+    // The diff endpoint is only hit once the user expands a file.
+    expect(filesRequest).not.toHaveBeenCalled();
+
+    await userEvent.click(fileToggle);
+
+    await waitFor(() => expect(filesRequest).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText('addedone')).toBeInTheDocument();
+    // The diff viewer must not repeat the file path/stats header we already
+    // render in the row title.
+    expect(screen.getAllByText('src/sentry/foo.py')).toHaveLength(1);
+  });
+
+  it('renders the deleted-file view when a deleted file has no patch', async () => {
+    mockOverview({
+      base: {
+        has_pull_request: [
+          {
+            ...rootCauseRun,
+            pullRequests: [
+              {
+                id: '77',
+                number: 42,
+                url: 'https://github.com/getsentry/sentry/pull/42',
+                status: 'open',
+                checksStatus: null,
+                reviewStatus: null,
+                files: [
+                  {
+                    path: 'src/sentry/gone.py',
+                    additions: 0,
+                    deletions: 9,
+                    changeType: 'DELETED',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/pull-requests/77/files/`,
+      body: {files: [{path: 'src/sentry/gone.py', patch: null}]},
+    });
+
+    renderPage();
+
+    await userEvent.click(
+      await screen.findByRole('button', {name: /src\/sentry\/gone\.py/})
+    );
+
+    expect(await screen.findByText('This file will be deleted.')).toBeInTheDocument();
+    expect(screen.queryByText('No diff available.')).not.toBeInTheDocument();
+  });
+
+  it('defaults to Recent Seer Activity and omits the sort param', async () => {
+    const {baseRequest} = mockOverview({base: {autofix_root_cause: [rootCauseRun]}});
+
+    renderPage();
+
+    expect(
+      await screen.findByRole('link', {name: 'TypeError in checkout cart'})
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: /Sort/})).toHaveTextContent(
+      'Recent Seer Activity'
+    );
+    expect(baseRequest).toHaveBeenCalledWith(
+      `/organizations/${organization.slug}/seer/autofix-overview/`,
+      expect.objectContaining({
+        query: expect.not.objectContaining({sort: expect.anything()}),
+      })
+    );
+  });
+
+  // A sort change refetches only the enriched request, not the base bootstrap.
+  it.each([
+    {option: 'Most events', sort: 'events'},
+    {option: 'Recent Issue Activity', sort: 'issue'},
+    {option: 'Most users', sort: 'users'},
+  ])('sends the $sort sort to the endpoint and URL', async ({option, sort}) => {
+    const {enrichedRequest} = mockOverview({base: {autofix_root_cause: [rootCauseRun]}});
+
+    const {router} = renderPage();
+
+    expect(
+      await screen.findByRole('link', {name: 'TypeError in checkout cart'})
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: /Sort/}));
+    await userEvent.click(screen.getByRole('option', {name: option}));
+
+    await waitFor(() =>
+      expect(enrichedRequest).toHaveBeenCalledWith(
+        `/organizations/${organization.slug}/seer/autofix-overview/`,
+        expect.objectContaining({
+          query: expect.objectContaining({sort}),
+        })
+      )
+    );
+    expect(router.location.query.sort).toBe(sort);
+  });
+
+  it('shows an error state when the request fails', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/autofix-overview/`,
+      statusCode: 500,
+      body: {detail: 'boom'},
+    });
+
+    renderPage();
+
+    expect(
+      await screen.findByText('There was an error loading data.')
+    ).toBeInTheDocument();
+  });
+});

--- a/static/app/views/seerWorkflows/overview2/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview2/index.spec.tsx
@@ -14,8 +14,13 @@ import {
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {OrganizationStore} from 'sentry/stores/organizationStore';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
+import type {PullRequestStatus} from 'sentry/types/integrations';
 import AutofixOverview2 from 'sentry/views/seerWorkflows/overview2';
-import type {OverviewRunIssue} from 'sentry/views/seerWorkflows/overview2/types';
+import type {
+  AutofixOverviewResponse,
+  OverviewPullRequest,
+  OverviewRunIssue,
+} from 'sentry/views/seerWorkflows/overview2/types';
 
 describe('AutofixOverview2', () => {
   const organization = OrganizationFixture({
@@ -43,8 +48,15 @@ describe('AutofixOverview2', () => {
     };
   }
 
-  function pullRequestFixture({number, status}: {number: number; status: string | null}) {
+  function pullRequestFixture({
+    number,
+    status,
+  }: {
+    number: number;
+    status: PullRequestStatus | null;
+  }): OverviewPullRequest {
     return {
+      id: String(number),
       number,
       url: `https://github.com/getsentry/sentry/pull/${number}`,
       status,
@@ -89,9 +101,9 @@ describe('AutofixOverview2', () => {
     enrichedStatusCode,
     baseStatusCode,
   }: {
-    base: Record<string, unknown[]>;
+    base: Partial<AutofixOverviewResponse['runsByMilestone']>;
     baseStatusCode?: number;
-    enriched?: Record<string, unknown[]>;
+    enriched?: Partial<AutofixOverviewResponse['runsByMilestone']>;
     enrichedAsyncDelay?: number | Promise<void>;
     enrichedStatusCode?: number;
   }) {
@@ -417,7 +429,8 @@ describe('AutofixOverview2', () => {
   it('renders the changed files of an open pull request', async () => {
     // Without `expand=scmInfo` the endpoint still returns the pull request, but
     // its SCM-sourced fields come back empty.
-    const unenrichedPullRequest = {
+    const unenrichedPullRequest: OverviewPullRequest = {
+      id: '42',
       number: 42,
       url: 'https://github.com/getsentry/sentry/pull/42',
       status: 'open',
@@ -474,7 +487,8 @@ describe('AutofixOverview2', () => {
   });
 
   it('renders the newest actionable pull request, not the oldest link', async () => {
-    const closedPullRequest = {
+    const closedPullRequest: OverviewPullRequest = {
+      id: '1',
       number: 1,
       url: 'https://github.com/getsentry/sentry/pull/1',
       status: 'closed',
@@ -484,7 +498,8 @@ describe('AutofixOverview2', () => {
     };
     // The endpoint enriches open/draft links only, so the actionable PR is the
     // one carrying badges and files.
-    const openPullRequest = {
+    const openPullRequest: OverviewPullRequest = {
+      id: '2',
       number: 2,
       url: 'https://github.com/getsentry/sentry/pull/2',
       status: 'open',
@@ -575,6 +590,7 @@ describe('AutofixOverview2', () => {
             ...rootCauseRun,
             pullRequests: [
               {
+                id: '42',
                 number: 42,
                 url: 'https://github.com/getsentry/sentry/pull/42',
                 status: 'open',
@@ -641,6 +657,7 @@ describe('AutofixOverview2', () => {
             ...rootCauseRun,
             pullRequests: [
               {
+                id: '42',
                 number: 42,
                 url: 'https://github.com/getsentry/sentry/pull/42',
                 status: 'open',
@@ -823,8 +840,11 @@ describe('AutofixOverview2', () => {
 
     renderPage();
 
+    // Error waits for the enriched request (retry: 1) to also fail.
     expect(
-      await screen.findByText('There was an error loading data.')
+      await screen.findByText('There was an error loading data.', undefined, {
+        timeout: 5000,
+      })
     ).toBeInTheDocument();
   });
 });

--- a/static/app/views/seerWorkflows/overview2/index.tsx
+++ b/static/app/views/seerWorkflows/overview2/index.tsx
@@ -1,0 +1,219 @@
+import styled from '@emotion/styled';
+
+import {Alert} from '@sentry/scraps/alert';
+import {Badge} from '@sentry/scraps/badge';
+import {CompactSelect} from '@sentry/scraps/compactSelect';
+import {Disclosure} from '@sentry/scraps/disclosure';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
+import {Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import Feature from 'sentry/components/acl/feature';
+import * as Layout from 'sentry/components/layouts/thirds';
+import {LoadingError} from 'sentry/components/loadingError';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {PageFiltersContainer} from 'sentry/components/pageFilters/container';
+import {DatePageFilter} from 'sentry/components/pageFilters/date/datePageFilter';
+import {PageFilterBar} from 'sentry/components/pageFilters/pageFilterBar';
+import {ProjectPageFilter} from 'sentry/components/pageFilters/project/projectPageFilter';
+import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
+import {Sticky} from 'sentry/components/sticky';
+import {t} from 'sentry/locale';
+import type {Organization} from 'sentry/types/organization';
+import {decodeScalar} from 'sentry/utils/queryString';
+import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {
+  STATUS_GROUP_META,
+  type StatusGroupKey,
+  StatusGroupTooltip,
+} from 'sentry/views/seerWorkflows/overview/statusGroups';
+
+import {Overview2Card} from './issueCard';
+import {OVERVIEW2_SECTIONS, type OverviewSort} from './types';
+import {useAutofixOverview} from './useAutofixOverview';
+
+const SORT_OPTIONS: Array<{label: string; value: OverviewSort}> = [
+  {value: 'seer', label: t('Recent Seer Activity')},
+  {value: 'issue', label: t('Recent Issue Activity')},
+  {value: 'events', label: t('Most events')},
+  {value: 'users', label: t('Most users')},
+];
+
+export default function AutofixOverview2() {
+  const organization = useOrganization();
+
+  return (
+    <Feature
+      organization={organization}
+      features="seer-night-shift-ui"
+      renderDisabled={() => <NoAccess />}
+    >
+      <PageFiltersContainer
+        skipInitializeUrlParams
+        defaultSelection={{datetime: {period: '14d', start: null, end: null, utc: null}}}
+      >
+        <SentryDocumentTitle title={t('Autofix Overview')} orgSlug={organization.slug}>
+          <Layout.Title>{t('Autofix Overview')}</Layout.Title>
+          <AutofixOverview2Content organization={organization} />
+        </SentryDocumentTitle>
+      </PageFiltersContainer>
+    </Feature>
+  );
+}
+
+// Owns every request so a feature-disabled org mounts no query at all.
+function AutofixOverview2Content({organization}: {organization: Organization}) {
+  const {selection, isReady: pageFiltersReady} = usePageFilters();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [collapsedGroups, setCollapsedGroups] = useLocalStorageState<StatusGroupKey[]>(
+    'seer-autofix-overview2:collapsed-groups',
+    []
+  );
+
+  const sort: OverviewSort =
+    SORT_OPTIONS.find(option => option.value === decodeScalar(location.query.sort))
+      ?.value ?? 'seer';
+
+  const {data, isPending, isError, enrichmentPending, isRefetching, refetch} =
+    useAutofixOverview({
+      organization,
+      selection,
+      sort,
+      enabled: pageFiltersReady,
+    });
+
+  const toggleGroup = (groupKey: StatusGroupKey, expanded: boolean) => {
+    setCollapsedGroups(previous =>
+      expanded
+        ? previous.filter(key => key !== groupKey)
+        : [...previous.filter(key => key !== groupKey), groupKey]
+    );
+  };
+
+  return (
+    <Stack gap="lg" padding="lg xl">
+      <Flex gap="md" align="center" wrap="wrap">
+        <PageFilterBar condensed>
+          <ProjectPageFilter />
+          <DatePageFilter />
+        </PageFilterBar>
+        <CompactSelect
+          value={sort}
+          options={SORT_OPTIONS}
+          onChange={selected =>
+            navigate(
+              {
+                pathname: location.pathname,
+                query: {
+                  ...location.query,
+                  sort: selected.value === 'seer' ? undefined : selected.value,
+                },
+              },
+              {replace: true}
+            )
+          }
+          trigger={triggerProps => (
+            <OverlayTrigger.Button {...triggerProps} size="sm" prefix={t('Sort')} />
+          )}
+        />
+        {isRefetching && <LoadingIndicator mini />}
+      </Flex>
+      {isError ? (
+        <LoadingError onRetry={refetch} />
+      ) : isPending ? (
+        <LoadingIndicator />
+      ) : (
+        <Stack gap="lg">
+          {OVERVIEW2_SECTIONS.map(({key, milestone}) => {
+            const runs = data?.runsByMilestone[milestone] ?? [];
+            const meta = STATUS_GROUP_META[key];
+            const groupLabel =
+              key === 'needs_investigation' ? t('Create Plan') : meta.label;
+            const expanded = !collapsedGroups.includes(key);
+            return (
+              <StatusGroup
+                key={key}
+                size="sm"
+                expanded={expanded}
+                onExpandedChange={next => toggleGroup(key, next)}
+              >
+                <GroupHeader>
+                  <Disclosure.Title>
+                    <Flex gap="sm" align="center">
+                      <Tooltip title={<StatusGroupTooltip groupKey={key} />} skipWrapper>
+                        <meta.Icon size="sm" aria-hidden />
+                      </Tooltip>
+                      <Text bold>{groupLabel}</Text>
+                      <Badge variant="muted">{runs.length}</Badge>
+                    </Flex>
+                  </Disclosure.Title>
+                </GroupHeader>
+                <Disclosure.Content>
+                  {runs.length === 0 ? (
+                    <Container padding="md">
+                      <Text as="p" variant="muted" size="sm">
+                        {t('No issues')}
+                      </Text>
+                    </Container>
+                  ) : (
+                    <Stack gap="md" paddingTop="sm">
+                      {runs.map(run => (
+                        <Overview2Card
+                          key={run.seerRunId}
+                          run={run}
+                          orgSlug={organization.slug}
+                          sectionKey={key}
+                          statsPeriod={selection.datetime.period}
+                          enrichmentPending={enrichmentPending}
+                        />
+                      ))}
+                    </Stack>
+                  )}
+                </Disclosure.Content>
+              </StatusGroup>
+            );
+          })}
+        </Stack>
+      )}
+    </Stack>
+  );
+}
+
+function NoAccess() {
+  return (
+    <Stack flex={1} padding="2xl 3xl">
+      <Alert.Container>
+        <Alert variant="warning" showIcon={false}>
+          {t("You don't have access to this feature")}
+        </Alert>
+      </Alert.Container>
+    </Stack>
+  );
+}
+
+// Disclosure.Content adds its own horizontal panel padding; cards align to the
+// section edge instead.
+const StatusGroup = styled(Disclosure)`
+  && > * + * {
+    padding-left: 0;
+    padding-right: 0;
+  }
+`;
+
+const GroupHeader = styled(Sticky)`
+  z-index: ${p => p.theme.zIndex.initial + 1};
+  align-self: stretch;
+  background: ${p => p.theme.tokens.background.secondary};
+  border-radius: ${p => p.theme.radius.md};
+
+  &[data-stuck] {
+    border-radius: 0;
+    border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
+  }
+`;

--- a/static/app/views/seerWorkflows/overview2/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview2/issueCard.tsx
@@ -1,0 +1,398 @@
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+
+import {Tag} from '@sentry/scraps/badge';
+import {LinkButton} from '@sentry/scraps/button';
+import {InfoText} from '@sentry/scraps/info';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
+import {Link} from '@sentry/scraps/link';
+import {Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import {ErrorLevel} from 'sentry/components/events/errorLevel';
+import {
+  PullRequestChecksBadge,
+  PullRequestReviewBadge,
+} from 'sentry/components/group/externalIssuesList/pullRequestStatusBadge';
+import {Placeholder} from 'sentry/components/placeholder';
+import {TimeSince} from 'sentry/components/timeSince';
+import {
+  IconBug,
+  IconClock,
+  IconCode,
+  IconCommit,
+  IconGraph,
+  IconMerge,
+  IconOpen,
+  IconPullRequest,
+  IconSearch,
+  IconSeer,
+  IconUser,
+} from 'sentry/icons';
+import type {SVGIconProps} from 'sentry/icons/svgIcon';
+import {t} from 'sentry/locale';
+import {IssueCategory, IssueType} from 'sentry/types/group';
+import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
+import {OverviewIssueAssignee} from 'sentry/views/seerWorkflows/overview/overviewIssueAssignee';
+import {
+  OverviewIssuePriority,
+  type OverviewIssuePriorityGroup,
+} from 'sentry/views/seerWorkflows/overview/overviewIssuePriority';
+import type {AutofixStateKey} from 'sentry/views/seerWorkflows/overview/types';
+
+import {periodWindowLabel} from './periods';
+import {PullRequestFiles} from './pullRequestFiles';
+import type {OverviewPullRequest, OverviewRun} from './types';
+
+// The endpoint orders links oldest-first and only enriches open/draft PRs, so
+// the newest actionable link is the one carrying badges and files.
+function selectReviewPullRequest(
+  pullRequests: OverviewPullRequest[]
+): OverviewPullRequest | undefined {
+  const actionable = pullRequests.filter(
+    pr => pr.status === 'open' || pr.status === 'draft'
+  );
+  return actionable.at(-1) ?? pullRequests.at(-1);
+}
+
+interface ActionMeta {
+  Icon: React.ComponentType<SVGIconProps>;
+  description: string;
+  label: string;
+}
+
+// Live status overlays (Running/Retry/Add context) are intentionally omitted here.
+// The merged section has no action button, so it is excluded from the map.
+const ACTION_META: Record<Exclude<AutofixStateKey, 'merged'>, ActionMeta> = {
+  review_pr: {
+    Icon: IconPullRequest,
+    label: t('Review PR'),
+    description: t('Autofix opened a pull request. Review and merge it.'),
+  },
+  code_changes_ready: {
+    Icon: IconCommit,
+    label: t('Draft PR'),
+    description: t('Autofix wrote a diff. Review it and open a pull request.'),
+  },
+  solution_ready: {
+    Icon: IconCode,
+    label: t('Generate code'),
+    description: t('Autofix proposed a fix. Continue the pipeline to generate code.'),
+  },
+  needs_investigation: {
+    Icon: IconSearch,
+    label: t('Create Plan'),
+    description: t('Seer stopped at a diagnosis. Review the root cause to continue.'),
+  },
+};
+
+function Overview2Action({
+  sectionKey,
+  reviewPullRequest,
+  issueUrl,
+  enrichmentPending,
+}: {
+  enrichmentPending: boolean;
+  issueUrl: string;
+  reviewPullRequest: OverviewPullRequest | undefined;
+  sectionKey: AutofixStateKey;
+}) {
+  if (sectionKey === 'merged') {
+    return (
+      <Tooltip title={t('The pull request for this fix was merged.')}>
+        <Tag variant="success" icon={<IconMerge />}>
+          {t('Merged')}
+        </Tag>
+      </Tooltip>
+    );
+  }
+
+  if (sectionKey === 'review_pr' && reviewPullRequest?.url) {
+    return (
+      <Stack align="end" gap="xs">
+        <Tooltip title={ACTION_META.review_pr.description} skipWrapper>
+          <LinkButton size="sm" variant="primary" href={reviewPullRequest.url} external>
+            <Flex as="span" gap="xs" align="center">
+              {t('Review PR #%s', reviewPullRequest.number)}
+              <IconOpen size="xs" />
+            </Flex>
+          </LinkButton>
+        </Tooltip>
+        {enrichmentPending ? (
+          // Two slots mirror the checks + review badges the enriched response
+          // typically fills in, so the row height doesn't jump on resolve.
+          <Fragment>
+            <Placeholder height="1.25rem" width="7rem" />
+            <Placeholder height="1.25rem" width="5.5rem" />
+          </Fragment>
+        ) : (
+          <Fragment>
+            {reviewPullRequest.checksStatus && (
+              <PullRequestChecksBadge status={reviewPullRequest.checksStatus} />
+            )}
+            {reviewPullRequest.reviewStatus && (
+              <PullRequestReviewBadge status={reviewPullRequest.reviewStatus} />
+            )}
+          </Fragment>
+        )}
+      </Stack>
+    );
+  }
+
+  const meta = ACTION_META[sectionKey];
+  return (
+    <Tooltip title={meta.description} skipWrapper>
+      <LinkButton size="sm" variant="secondary" icon={<meta.Icon />} to={issueUrl}>
+        {meta.label}
+      </LinkButton>
+    </Tooltip>
+  );
+}
+
+const TitleLink = styled(Link)`
+  color: inherit;
+  &:hover {
+    color: inherit;
+    text-decoration: underline;
+  }
+`;
+
+// ErrorLevel's colored line stretched from its 1em inline size into an accent
+// bar spanning the full title block (its grid cell stretches it).
+const LevelBar = styled(ErrorLevel)`
+  height: auto;
+  width: 4px;
+`;
+
+function NarrativeBlock({
+  icon,
+  label,
+  children,
+}: {
+  children: string;
+  icon: React.ReactNode;
+  label: string;
+}) {
+  return (
+    <Stack gap="xs">
+      <Flex gap="xs" align="center">
+        {icon}
+        <Text size="xs" bold uppercase variant="secondary">
+          {label}
+        </Text>
+      </Flex>
+      <Text size={{xs: 'md', lg: 'lg'}} density="comfortable" wordBreak="break-word">
+        {children}
+      </Text>
+    </Stack>
+  );
+}
+
+function IssueVitals({
+  run,
+  statsPeriod,
+  enrichmentPending,
+}: {
+  enrichmentPending: boolean;
+  run: OverviewRun;
+  statsPeriod: string | null;
+}) {
+  const eventCount = run.issue.count ? Number(run.issue.count) : null;
+  const userCount = run.issue.userCount ?? 0;
+  const windowLabel = periodWindowLabel(statsPeriod);
+  return (
+    <Fragment>
+      {enrichmentPending ? (
+        <Fragment>
+          <Flex gap="xs" align="center">
+            <IconGraph size="xs" variant="muted" aria-hidden />
+            <Placeholder height="1rem" width="4rem" />
+          </Flex>
+          <Flex gap="xs" align="center">
+            <IconClock size="xs" variant="muted" aria-hidden />
+            <Placeholder height="1rem" width="5rem" />
+          </Flex>
+        </Fragment>
+      ) : (
+        <Fragment>
+          {eventCount !== null && (
+            <Flex gap="xs" align="center">
+              <IconGraph size="xs" variant="muted" aria-hidden />
+              <InfoText
+                size="sm"
+                variant="muted"
+                title={
+                  windowLabel
+                    ? t('%s events %s', eventCount.toLocaleString(), windowLabel)
+                    : t('%s events', eventCount.toLocaleString())
+                }
+              >
+                {eventCount === 1
+                  ? t('1 event')
+                  : t('%s events', formatAbbreviatedNumber(eventCount))}
+              </InfoText>
+            </Flex>
+          )}
+          {userCount > 0 && (
+            <Flex gap="xs" align="center">
+              <IconUser size="xs" variant="muted" aria-hidden />
+              <InfoText
+                size="sm"
+                variant="muted"
+                title={
+                  windowLabel
+                    ? t('%s affected users %s', userCount.toLocaleString(), windowLabel)
+                    : t('%s affected users', userCount.toLocaleString())
+                }
+              >
+                {userCount === 1
+                  ? t('1 user')
+                  : t('%s users', formatAbbreviatedNumber(userCount))}
+              </InfoText>
+            </Flex>
+          )}
+          {run.issue.lastSeen && (
+            <Flex gap="xs" align="center">
+              <IconClock size="xs" variant="muted" aria-hidden />
+              <Text size="sm" variant="muted">
+                <TimeSince
+                  date={run.issue.lastSeen}
+                  tooltipPrefix={t('The most recent event in this issue occurred')}
+                />
+              </Text>
+            </Flex>
+          )}
+        </Fragment>
+      )}
+      <Flex gap="xs" align="center">
+        <IconSeer size="xs" variant="muted" aria-hidden />
+        <Text size="sm" variant="muted">
+          <TimeSince
+            date={run.lastTriggeredAt}
+            tooltipPrefix={t('Last activity on this Seer run')}
+          />
+        </Text>
+      </Flex>
+    </Fragment>
+  );
+}
+
+function PriorityAndAssignee({run}: {run: OverviewRun}) {
+  const {issue} = run;
+  const priorityGroup: OverviewIssuePriorityGroup = {
+    id: run.groupId,
+    priority: issue.priority,
+    priorityLockedAt: issue.priorityLockedAt,
+    // The endpoint may null these out; the reused priority widget needs values.
+    issueType: issue.issueType ?? IssueType.ERROR,
+    issueCategory: issue.issueCategory ?? IssueCategory.ERROR,
+    level: issue.level ?? 'unknown',
+    lastSeen: issue.lastSeen ?? run.lastTriggeredAt,
+    count: issue.count ?? '0',
+    owners: issue.owners,
+    assignedTo: issue.assignedTo,
+    project: {id: issue.project.id},
+  };
+  return (
+    <Flex gap="xs" align="center">
+      <OverviewIssuePriority group={priorityGroup} />
+      <OverviewIssueAssignee
+        groupId={run.groupId}
+        projectId={issue.project.id}
+        projectSlug={issue.project.slug}
+        assignedTo={issue.assignedTo ?? undefined}
+        owners={issue.owners}
+      />
+    </Flex>
+  );
+}
+
+export function Overview2Card({
+  orgSlug,
+  run,
+  sectionKey,
+  statsPeriod,
+  enrichmentPending,
+}: {
+  enrichmentPending: boolean;
+  orgSlug: string;
+  run: OverviewRun;
+  sectionKey: AutofixStateKey;
+  statsPeriod: string | null;
+}) {
+  const rootCause = run.rootCause?.oneLineDescription;
+  const proposedFix = run.proposedFix?.oneLineSummary;
+  const issueUrl = `/organizations/${orgSlug}/issues/${run.groupId}/`;
+  const reviewPullRequest =
+    sectionKey === 'review_pr' ? selectReviewPullRequest(run.pullRequests) : undefined;
+  const changedFiles = reviewPullRequest?.files ?? [];
+
+  return (
+    <Container background="primary" border="primary" radius="md" padding="xl">
+      <Stack gap="xl">
+        <Flex
+          gap={{xs: 'xl', sm: '3xl'}}
+          align="stretch"
+          justify="between"
+          direction={{xs: 'column-reverse', sm: 'row'}}
+        >
+          <Stack gap="lg" minWidth="0" flex="1">
+            {/* Grid, not flex: items stretch by default, so the level bar spans
+                every wrapped title line and the text cell can't escape the row */}
+            <Grid columns="max-content minmax(0, 1fr)" gap="sm">
+              <LevelBar level={run.issue.level ?? undefined} />
+              <Stack minWidth="0" gap="xs">
+                <Text bold display="block" textWrap="pretty" size="lg">
+                  <TitleLink to={issueUrl}>{run.title}</TitleLink>
+                </Text>
+                <Flex wrap="wrap" gap="md" align="center">
+                  <Text size="sm" monospace variant="muted">
+                    {run.shortId}
+                  </Text>
+                  <IssueVitals
+                    run={run}
+                    statsPeriod={statsPeriod}
+                    enrichmentPending={enrichmentPending}
+                  />
+                </Flex>
+              </Stack>
+            </Grid>
+            {rootCause && (
+              <NarrativeBlock
+                icon={<IconBug size="xs" variant="secondary" aria-hidden />}
+                label={t('Root cause')}
+              >
+                {rootCause}
+              </NarrativeBlock>
+            )}
+            {proposedFix && (
+              <NarrativeBlock
+                icon={<IconCommit size="xs" variant="secondary" aria-hidden />}
+                label={t('Plan')}
+              >
+                {proposedFix}
+              </NarrativeBlock>
+            )}
+            {enrichmentPending && reviewPullRequest?.url ? (
+              <Placeholder height="3rem" />
+            ) : reviewPullRequest && changedFiles.length > 0 ? (
+              <PullRequestFiles orgSlug={orgSlug} pullRequest={reviewPullRequest} />
+            ) : null}
+          </Stack>
+
+          {/* justify=between + parent align=stretch pins the action to the top
+              and the priority/assignee controls to the bottom-right */}
+          <Stack gap="lg" align="end" justify="between" flexShrink={0} minWidth="0">
+            <Overview2Action
+              sectionKey={sectionKey}
+              reviewPullRequest={reviewPullRequest}
+              issueUrl={issueUrl}
+              enrichmentPending={enrichmentPending}
+            />
+            <PriorityAndAssignee run={run} />
+          </Stack>
+        </Flex>
+      </Stack>
+    </Container>
+  );
+}

--- a/static/app/views/seerWorkflows/overview2/periods.spec.ts
+++ b/static/app/views/seerWorkflows/overview2/periods.spec.ts
@@ -1,0 +1,12 @@
+import {periodWindowLabel} from 'sentry/views/seerWorkflows/overview2/periods';
+
+describe('periodWindowLabel', () => {
+  it('labels a known period', () => {
+    expect(periodWindowLabel('14d')).toBe('in the last 14 days');
+  });
+
+  it('returns no label for an absolute range or unknown period', () => {
+    expect(periodWindowLabel(null)).toBe('');
+    expect(periodWindowLabel('3d')).toBe('');
+  });
+});

--- a/static/app/views/seerWorkflows/overview2/periods.ts
+++ b/static/app/views/seerWorkflows/overview2/periods.ts
@@ -1,0 +1,20 @@
+import {DEFAULT_RELATIVE_PERIODS} from 'sentry/constants';
+import {t} from 'sentry/locale';
+
+const WINDOW_LABELS: Record<keyof typeof DEFAULT_RELATIVE_PERIODS, string> = {
+  '1h': t('in the last hour'),
+  '24h': t('in the last 24 hours'),
+  '7d': t('in the last 7 days'),
+  '14d': t('in the last 14 days'),
+  '30d': t('in the last 30 days'),
+  '90d': t('in the last 90 days'),
+};
+
+// Absolute ranges (no relative period) get no phrase, so callers drop the
+// window clause rather than naming a window the numbers don't cover.
+export function periodWindowLabel(statsPeriod: string | null): string {
+  if (!statsPeriod) {
+    return '';
+  }
+  return WINDOW_LABELS[statsPeriod as keyof typeof WINDOW_LABELS] ?? '';
+}

--- a/static/app/views/seerWorkflows/overview2/pullRequestFiles.tsx
+++ b/static/app/views/seerWorkflows/overview2/pullRequestFiles.tsx
@@ -91,7 +91,6 @@ export function PullRequestFiles({
   pullRequest: OverviewPullRequest;
 }) {
   const files = pullRequest.files;
-  // Keyed by row index, not path: a rename/copy can repeat a path across rows.
   const [expandedRows, setExpandedRows] = useState<Set<number>>(() => new Set());
 
   const {data, isPending, isError} = useQuery({

--- a/static/app/views/seerWorkflows/overview2/pullRequestFiles.tsx
+++ b/static/app/views/seerWorkflows/overview2/pullRequestFiles.tsx
@@ -1,0 +1,204 @@
+import {useMemo, useState} from 'react';
+import styled from '@emotion/styled';
+import {useQuery} from '@tanstack/react-query';
+
+import {Tag} from '@sentry/scraps/badge';
+import {Disclosure} from '@sentry/scraps/disclosure';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {Placeholder} from 'sentry/components/placeholder';
+import {IconCode} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import type {PullRequestFileChangeType} from 'sentry/types/integrations';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+import type {TagVariant} from 'sentry/utils/theme';
+import {FileDiffViewer} from 'sentry/views/seerExplorer/components/fileDiffViewer';
+
+import {parseFilePatch} from './filePatch';
+import {
+  type OverviewPullRequest,
+  type OverviewPullRequestFile,
+  type PullRequestFileDiff,
+  type PullRequestFilesResponse,
+  QUERY_STALE_TIME,
+} from './types';
+
+const FILE_CHANGE_TAG: Record<
+  PullRequestFileChangeType,
+  {label: string; variant: TagVariant}
+> = {
+  ADDED: {label: t('Added'), variant: 'success'},
+  CHANGED: {label: t('Changed'), variant: 'muted'},
+  COPIED: {label: t('Copied'), variant: 'muted'},
+  DELETED: {label: t('Deleted'), variant: 'danger'},
+  MODIFIED: {label: t('Modified'), variant: 'muted'},
+  RENAMED: {label: t('Renamed'), variant: 'muted'},
+};
+
+function FileDiff({
+  file,
+  diff,
+  isPending,
+  isError,
+}: {
+  diff: PullRequestFileDiff | undefined;
+  file: OverviewPullRequestFile;
+  isError: boolean;
+  isPending: boolean;
+}) {
+  const patch = useMemo(
+    () =>
+      diff && (diff.patch || file.changeType === 'DELETED')
+        ? parseFilePatch({
+            path: file.path,
+            patch: diff.patch,
+            additions: file.additions,
+            deletions: file.deletions,
+            changeType: file.changeType,
+          })
+        : null,
+    [diff, file.path, file.additions, file.deletions, file.changeType]
+  );
+
+  if (isPending && !diff) {
+    return <Placeholder height="4rem" />;
+  }
+  if (isError) {
+    return (
+      <Text size="sm" variant="danger">
+        {t('Failed to load diff.')}
+      </Text>
+    );
+  }
+  if (patch) {
+    return <FileDiffViewer hideHeader patch={patch} />;
+  }
+  return (
+    <Text size="sm" variant="muted">
+      {t('No diff available.')}
+    </Text>
+  );
+}
+
+// Each row expands to its diff. Expanding the first file fetches every file's
+// patch for the PR in one request, so opening the rest is instant from cache.
+export function PullRequestFiles({
+  orgSlug,
+  pullRequest,
+}: {
+  orgSlug: string;
+  pullRequest: OverviewPullRequest;
+}) {
+  const files = pullRequest.files;
+  // Keyed by row index, not path: a rename/copy can repeat a path across rows.
+  const [expandedRows, setExpandedRows] = useState<Set<number>>(() => new Set());
+
+  const {data, isPending, isError} = useQuery({
+    ...apiOptions.as<PullRequestFilesResponse>()(
+      '/organizations/$organizationIdOrSlug/pull-requests/$pullRequestId/files/',
+      {
+        path: {organizationIdOrSlug: orgSlug, pullRequestId: pullRequest.id},
+        staleTime: QUERY_STALE_TIME,
+      }
+    ),
+    enabled: expandedRows.size > 0,
+  });
+
+  const diffByPath = useMemo(
+    () => new Map((data?.files ?? []).map(file => [file.path, file])),
+    [data]
+  );
+
+  const toggle = (index: number, expanded: boolean) =>
+    setExpandedRows(prev => {
+      const next = new Set(prev);
+      if (expanded) {
+        next.add(index);
+      } else {
+        next.delete(index);
+      }
+      return next;
+    });
+
+  return (
+    <Stack gap="sm">
+      <Flex gap="xs" align="center">
+        <IconCode size="xs" variant="secondary" aria-hidden />
+        <Text size="xs" bold uppercase variant="secondary">
+          {t('Code changes')}
+        </Text>
+      </Flex>
+      <Text size="sm" variant="muted">
+        {files.length === 1
+          ? t('1 file changed')
+          : t('%s files changed', files.length.toLocaleString())}
+      </Text>
+      <Container border="primary" radius="md" overflow="hidden" background="secondary">
+        {files.map((file, index) => {
+          const changeTag = file.changeType ? FILE_CHANGE_TAG[file.changeType] : null;
+          const diff = diffByPath.get(file.path);
+          const isExpanded = expandedRows.has(index);
+          return (
+            <FileRow key={`${index}-${file.path}`}>
+              <Disclosure
+                size="sm"
+                expanded={isExpanded}
+                onExpandedChange={next => toggle(index, next)}
+              >
+                <Disclosure.Title
+                  trailingItems={
+                    changeTag ? (
+                      <Tag variant={changeTag.variant}>{changeTag.label}</Tag>
+                    ) : undefined
+                  }
+                >
+                  <Grid
+                    columns="minmax(60px, auto) minmax(0, 1fr)"
+                    gap="xl"
+                    align="center"
+                    width="100%"
+                  >
+                    <Flex gap="md" align="center">
+                      <Text size="sm" monospace variant="success">
+                        +{file.additions}
+                      </Text>
+                      <Text size="sm" monospace variant="danger">
+                        -{file.deletions}
+                      </Text>
+                    </Flex>
+                    <FilePath size="sm" monospace ellipsis title={file.path}>
+                      {file.path}
+                    </FilePath>
+                  </Grid>
+                </Disclosure.Title>
+                <Disclosure.Content>
+                  {isExpanded ? (
+                    <FileDiff
+                      file={file}
+                      diff={diff}
+                      isPending={isPending}
+                      isError={isError}
+                    />
+                  ) : null}
+                </Disclosure.Content>
+              </Disclosure>
+            </FileRow>
+          );
+        })}
+      </Container>
+    </Stack>
+  );
+}
+
+const FileRow = styled('div')`
+  & + & {
+    border-top: 1px solid ${p => p.theme.tokens.border.primary};
+  }
+`;
+
+// Truncates the head of the path so the file name stays visible.
+const FilePath = styled(Text)`
+  direction: rtl;
+  text-align: left;
+`;

--- a/static/app/views/seerWorkflows/overview2/types.ts
+++ b/static/app/views/seerWorkflows/overview2/types.ts
@@ -1,0 +1,108 @@
+import type {Actor} from 'sentry/types/core';
+import type {Level} from 'sentry/types/event';
+import type {
+  IssueCategory,
+  IssueType,
+  PriorityLevel,
+  SuggestedOwner,
+} from 'sentry/types/group';
+import type {
+  PullRequestChecksStatus,
+  PullRequestFileChangeType,
+  PullRequestReviewStatus,
+  PullRequestStatus,
+} from 'sentry/types/integrations';
+import type {PlatformKey} from 'sentry/types/platform';
+import {
+  type AutofixStateKey,
+  SECTION_ORDER,
+} from 'sentry/views/seerWorkflows/overview/types';
+
+export const QUERY_STALE_TIME = 30_000;
+
+export type OverviewSort = 'seer' | 'issue' | 'events' | 'users';
+
+// The milestone a run reached, as keyed in the endpoint's `runsByMilestone`.
+export type MilestoneKey =
+  | 'autofix_root_cause'
+  | 'autofix_solution'
+  | 'autofix_code_changes'
+  | 'has_pull_request'
+  | 'pull_requests_merged';
+
+// Layout is the frontend's: the endpoint groups by milestone, we decide which
+// section each milestone renders into and in what order.
+const MILESTONE_BY_SECTION: Record<AutofixStateKey, MilestoneKey> = {
+  review_pr: 'has_pull_request',
+  code_changes_ready: 'autofix_code_changes',
+  solution_ready: 'autofix_solution',
+  needs_investigation: 'autofix_root_cause',
+  merged: 'pull_requests_merged',
+};
+
+export const OVERVIEW2_SECTIONS: Array<{
+  key: AutofixStateKey;
+  milestone: MilestoneKey;
+}> = SECTION_ORDER.map(key => ({
+  key,
+  milestone: MILESTONE_BY_SECTION[key],
+}));
+
+export interface OverviewPullRequestFile {
+  additions: number;
+  changeType: PullRequestFileChangeType | null;
+  deletions: number;
+  path: string;
+}
+
+export interface OverviewPullRequest {
+  checksStatus: PullRequestChecksStatus | null;
+  files: OverviewPullRequestFile[];
+  id: string;
+  number: number;
+  reviewStatus: PullRequestReviewStatus | null;
+  status: PullRequestStatus | null;
+  url: string | null;
+}
+
+export interface PullRequestFileDiff {
+  patch: string | null;
+  path: string;
+}
+
+export interface PullRequestFilesResponse {
+  files: PullRequestFileDiff[];
+}
+
+// Issue-side facts the endpoint serializes off the Group; mirrors the fields the
+// reused priority/assignee widgets and the vitals row consume.
+export interface OverviewRunIssue {
+  assignedTo: Actor | null;
+  count: string | null;
+  issueCategory: IssueCategory | null;
+  issueType: IssueType | null;
+  lastSeen: string | null;
+  level: Level | null;
+  owners: SuggestedOwner[];
+  priority: PriorityLevel | null;
+  priorityLockedAt: string | null;
+  project: {id: string; slug: string; platform?: PlatformKey};
+  substatus: string | null;
+  userCount: number | null;
+}
+
+export interface OverviewRun {
+  groupId: string;
+  issue: OverviewRunIssue;
+  lastTriggeredAt: string;
+  proposedFix: {oneLineSummary: string | null} | null;
+  pullRequests: OverviewPullRequest[];
+  rootCause: {oneLineDescription: string | null} | null;
+  seerRunId: string;
+  shortId: string;
+  title: string;
+}
+
+export interface AutofixOverviewResponse {
+  runsByMilestone: Record<MilestoneKey, OverviewRun[]>;
+}

--- a/static/app/views/seerWorkflows/overview2/useAutofixOverview.ts
+++ b/static/app/views/seerWorkflows/overview2/useAutofixOverview.ts
@@ -56,8 +56,9 @@ export function useAutofixOverview({
   return {
     data,
     isPending: !data,
-    // Only a bootstrap failure with nothing to show is a real error.
-    isError: baseQuery.isError && !data,
+    // Error only once both fail with nothing to show; base alone may still be
+    // recovered by an in-flight enriched call.
+    isError: baseQuery.isError && enrichedQuery.isError && !data,
     // Cold-load shimmer only: base is painted but no enriched payload yet.
     enrichmentPending: Boolean(data) && !enrichedQuery.data && !enrichedQuery.isError,
     // A later refetch keeps the list up; the caller shows a spinner meanwhile.

--- a/static/app/views/seerWorkflows/overview2/useAutofixOverview.ts
+++ b/static/app/views/seerWorkflows/overview2/useAutofixOverview.ts
@@ -1,0 +1,70 @@
+import {keepPreviousData, useQuery} from '@tanstack/react-query';
+
+import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
+import type {PageFilters} from 'sentry/types/core';
+import type {Organization} from 'sentry/types/organization';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+
+import {type AutofixOverviewResponse, type OverviewSort, QUERY_STALE_TIME} from './types';
+
+// Progressive load: the base request paints the cards fast, then the enriched
+// `expand` request fills in Snuba stats and SCM details.
+export function useAutofixOverview({
+  organization,
+  selection,
+  sort,
+  enabled,
+}: {
+  enabled: boolean;
+  organization: Organization;
+  selection: PageFilters;
+  sort: OverviewSort;
+}) {
+  const overviewQuery = (query: {expand?: Array<'scmInfo' | 'issueStats'>}) =>
+    apiOptions.as<AutofixOverviewResponse>()(
+      '/organizations/$organizationIdOrSlug/seer/autofix-overview/',
+      {
+        path: {organizationIdOrSlug: organization.slug},
+        query: {
+          project: selection.projects,
+          ...normalizeDateTimeParams(selection.datetime),
+          // Default sort keeps the URL clean and adds no backend Snuba work.
+          ...(sort === 'seer' ? {} : {sort}),
+          ...query,
+        },
+        staleTime: QUERY_STALE_TIME,
+      }
+    );
+
+  const enrichedQuery = useQuery({
+    ...overviewQuery({expand: ['scmInfo', 'issueStats']}),
+    enabled,
+    placeholderData: keepPreviousData,
+    // Enrichment is progressive polish: fail fast to empty slots rather than
+    // shimmering through the default retry backoff.
+    retry: 1,
+  });
+  // Base is a one-time bootstrap: it stops fetching once enriched has data, so a
+  // filter/sort change makes a single enriched request rather than two.
+  const baseQuery = useQuery({
+    ...overviewQuery({}),
+    enabled: enabled && !enrichedQuery.data,
+    placeholderData: keepPreviousData,
+  });
+
+  const data = enrichedQuery.data ?? baseQuery.data;
+  return {
+    data,
+    isPending: !data,
+    // Only a bootstrap failure with nothing to show is a real error.
+    isError: baseQuery.isError && !data,
+    // Cold-load shimmer only: base is painted but no enriched payload yet.
+    enrichmentPending: Boolean(data) && !enrichedQuery.data && !enrichedQuery.isError,
+    // A later refetch keeps the list up; the caller shows a spinner meanwhile.
+    isRefetching: enrichedQuery.isFetching && Boolean(enrichedQuery.data),
+    refetch: () => {
+      baseQuery.refetch();
+      enrichedQuery.refetch();
+    },
+  };
+}


### PR DESCRIPTION
## Summary

The Autofix `overview2` page and issue card. Each card shows the run's issue, root cause, proposed fix, and pull requests — with check status, review status, and changed files from the endpoint's SCM enrichment.

The page loads progressively: a cheap Postgres-only request paints the cards immediately, then an `expand=scmInfo&expand=issueStats` request replaces the data with the enriched payload, with shimmer placeholders in the enriched slots until it resolves. If the enriched request fails, those slots degrade to empty rather than shimmering forever.

Stacked on the backend enrichment work (**PR #122105 — land that first**). Because this PR currently targets `master`, its diff includes the backend commits until #122105 merges.

## Rollout / cleanup

`overview2` is a v2 rewrite of the existing `static/app/views/seerWorkflows/overview/` (v1) page, and it intentionally parallels that code while gated behind the `seer-night-shift-ui` feature flag. This duplication is temporary and deliberate: `overview2` is meant to replace v1, and the v1 `overview/` code is slated for deletion once v2 ships. Until then the two divergent copies coexist behind the flag.

## Review feedback folded in

- Data queries are gated behind the `seer-night-shift-ui` feature so orgs without access issue no requests (query owner moved into a child mounted beneath `<Feature>`, mirroring v1).
- The card selects the newest actionable (open/draft) pull request instead of the oldest link, matching the backend's enrichment scope.
- Changed files render as summary rows with correct add/delete/rename semantics instead of empty expandable diffs.
- `changeType` is a precise typed union; the unused-export Knip failure is resolved; the invisible environment filter was removed.
- Two pre-existing bugs are also fixed: cards no longer render their title twice, and the vitals tooltip reports the correct time window on non-default periods.

## Test Plan

- `overview2/index.spec.tsx` covers the page and card: the access gate (zero requests when disabled), the two-request progressive load and shimmer, pull-request selection across mixed open/closed states, and changed-file semantics (including `null`/added/deleted).
- `pnpm run typecheck`, `pnpm run lint:js`, and `pnpm run knip` pass.