### PR TITLE
fix(dashboards): Memoize unstable references to heat map data in widgets

### DIFF
--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useMemo} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {LegendComponentOption} from 'echarts';
@@ -457,11 +457,13 @@ function CategoricalSeriesComponent(props: TableComponentProps): React.ReactNode
 function HeatmapSeriesComponent(props: TableComponentProps): React.ReactNode {
   const {heatmapResults, loading} = props;
 
-  if (loading || !heatmapResults) {
+  const plottables = useMemo(() => {
+    return heatmapResults ? ([new HeatMap(heatmapResults)] as [HeatMap]) : null;
+  }, [heatmapResults]);
+
+  if (loading || plottables === null) {
     return <HeatMapWidgetVisualization.LoadingPlaceholder />;
   }
-
-  const plottables: [HeatMap] = [new HeatMap(heatmapResults)];
 
   if (!plottablesCanBeVisualized(plottables)) {
     return <HeatMapWidgetVisualization.NoData />;

--- a/static/app/views/explore/metrics/hooks/useMetricHeatMapData.tsx
+++ b/static/app/views/explore/metrics/hooks/useMetricHeatMapData.tsx
@@ -123,10 +123,15 @@ export function useMetricHeatMapData({
     isPartial,
   } = useQueries({queries, combine});
 
-  // Patch the metric unit onto the Y-axis, since the server can't infer this
-  const series = chunkSeries
-    ? mergeMetricUnit(chunkSeries, traceMetric.unit ?? undefined)
-    : chunkSeries;
+  // Patch the metric unit onto the Y-axis, since the server can't infer this.
+  // Memoized to make stable because `mergeMetricUnit` always returns a new object.
+  const series = useMemo(
+    () =>
+      chunkSeries
+        ? mergeMetricUnit(chunkSeries, traceMetric.unit ?? undefined)
+        : undefined,
+    [chunkSeries, traceMetric.unit]
+  );
 
   return {
     series,


### PR DESCRIPTION
Memoize unstable references to heat map data in widgets to prevent excessive rerender and possible looping.

Refs DAIN-1830
