### PR TITLE
fix(explore): Skip empty group by sample filters

### DIFF
--- a/static/app/views/explore/logs/utils.spec.tsx
+++ b/static/app/views/explore/logs/utils.spec.tsx
@@ -1,7 +1,11 @@
+import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {LogFixture} from 'sentry-fixture/log';
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
 
 import type {Sort} from 'sentry/utils/discover/fields';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {LOGS_GROUP_BY_KEY} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {SavedQuery} from 'sentry/views/explore/hooks/useGetSavedQueries';
 import {
   OurLogKnownFieldKey,
@@ -12,9 +16,38 @@ import {
   createErrorLogRow,
   getLogsUrlFromSavedQueryUrl,
   type LogTableRowItem,
+  viewLogsSamplesTarget,
 } from 'sentry/views/explore/logs/utils';
 import {Mode} from 'sentry/views/explore/queryParams/mode';
+import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
+
+describe('viewLogsSamplesTarget', () => {
+  it('does not add a filter for an empty group by', () => {
+    const location = LocationFixture({
+      query: {
+        [LOGS_GROUP_BY_KEY]: '',
+        aggregateField: JSON.stringify({groupBy: ''}),
+        logsAggregateSortBys: '-count(message)',
+      },
+    });
+    const target = viewLogsSamplesTarget({
+      location,
+      search: new MutableSearch(''),
+      fields: ['message'],
+      groupBys: [''],
+      visualizes: [new VisualizeFunction('count(message)')],
+      sorts: [{field: 'count(message)', kind: 'desc'}],
+      row: {},
+      projects: [ProjectFixture()],
+    });
+
+    expect(target.query[LOGS_GROUP_BY_KEY]).toBe('');
+    expect(target.query.aggregateField).toBe(location.query.aggregateField);
+    expect(target.query.logsAggregateSortBys).toBe('-count(message)');
+    expect(target.query.logsQuery).toBe('');
+  });
+});
 
 describe('getLogsUrlFromSavedQueryUrl', () => {
   const organization = OrganizationFixture();

--- a/static/app/views/explore/multiQueryMode/locationUtils.spec.tsx
+++ b/static/app/views/explore/multiQueryMode/locationUtils.spec.tsx
@@ -1,0 +1,27 @@
+import {LocationFixture} from 'sentry-fixture/locationFixture';
+
+import {getSamplesTargetAtIndex} from 'sentry/views/explore/multiQueryMode/locationUtils';
+
+describe('getSamplesTargetAtIndex', () => {
+  it('does not add a filter for an empty group by', () => {
+    const target = getSamplesTargetAtIndex(
+      0,
+      [
+        {
+          fields: ['span.op', 'count(span.duration)'],
+          groupBys: ['span.op', ''],
+          query: '',
+          sortBys: [{field: 'count(span.duration)', kind: 'desc'}],
+          yAxes: ['count(span.duration)'],
+        },
+      ],
+      {'span.op': 'http'},
+      LocationFixture()
+    );
+    const queries = target.query.queries;
+    const query = JSON.parse(Array.isArray(queries) ? queries[0]! : queries!);
+
+    expect(query.groupBys).toEqual([]);
+    expect(query.query).toBe('span.op:http');
+  });
+});

--- a/static/app/views/explore/multiQueryMode/locationUtils.tsx
+++ b/static/app/views/explore/multiQueryMode/locationUtils.tsx
@@ -259,6 +259,9 @@ export function getSamplesTargetAtIndex(
   const queryString = queryToUpdate.query ?? '';
   const search = new MutableSearch(queryString);
   for (const groupBy of queryToUpdate.groupBys) {
+    if (!groupBy) {
+      continue;
+    }
     const value = row[groupBy];
     search.setFilterValues(groupBy, [value]);
   }

--- a/static/app/views/explore/utils.spec.tsx
+++ b/static/app/views/explore/utils.spec.tsx
@@ -47,6 +47,36 @@ describe('viewSamplesTarget', () => {
     });
   });
 
+  it('does not add a filter for an empty group by', () => {
+    const location = LocationFixture({
+      query: {
+        aggregateField: [
+          JSON.stringify({groupBy: ''}),
+          JSON.stringify({yAxes: ['count(span.duration)']}),
+        ],
+        aggregateSort: '-count(span.duration)',
+        groupBy: '',
+        visualize: JSON.stringify({yAxes: ['count(span.duration)']}),
+      },
+    });
+    const target = viewSamplesTarget({
+      location,
+      query: '',
+      fields: ['foo'],
+      groupBys: [''],
+      visualizes: [visualize],
+      sorts: [sort],
+      row: {},
+      projects,
+    });
+
+    expect(target.query.aggregateField).toEqual(location.query.aggregateField);
+    expect(target.query.aggregateSort).toBe('-count(span.duration)');
+    expect(target.query.groupBy).toBe('');
+    expect(target.query.visualize).toBe(location.query.visualize);
+    expect(target.query.query).toBe('');
+  });
+
   it('simple drill down with single group by', () => {
     const location = LocationFixture();
     const target = viewSamplesTarget({

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -311,6 +311,9 @@ export function generateTargetQuery({
 
   // first update the resulting query to filter for the target group
   for (const groupBy of groupBys) {
+    if (!groupBy) {
+      continue;
+    }
     const value = row[groupBy];
     // some fields require special handling so make sure to handle it here
     if (groupBy === 'project' && typeof value === 'string') {


### PR DESCRIPTION
Opening View Samples from Explore aggregate tables no longer turns blank group-by placeholders into malformed `has` or `!has` filters. This covers spans, logs, and Compare/Multi-query Explore while retaining the empty group-by state so switching modes preserves the existing configuration.

The drill-down builders now ignore blank field names only while generating sample filters. Filtering for non-empty group-by fields is unchanged.

Closes EXP-1073
