### PR TITLE
ref(dashboards): Take keyed params in applyDashboardFilters

### DIFF
--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -249,10 +249,10 @@ export function getWidgetDiscoverUrl(
     }
   });
   discoverLocation.query.field = fields;
-  discoverLocation.query.query = applyDashboardFilters(
-    query.conditions,
-    dashboardFilters
-  );
+  discoverLocation.query.query = applyDashboardFilters({
+    baseQuery: query.conditions,
+    dashboardFilters,
+  });
 
   // Pass empty string when projects is empty to preserve "My Projects" selection in URL
   const projectParam =
@@ -278,12 +278,12 @@ export function getWidgetIssueUrl(
       ? {start: getUtcDateString(start), end: getUtcDateString(end), utc}
       : {statsPeriod: period};
   const issuesLocation = `/organizations/${organization.slug}/issues/?${qs.stringify({
-    query: applyDashboardFilters(
-      widget.queries?.[0]?.conditions,
+    query: applyDashboardFilters({
+      baseQuery: widget.queries?.[0]?.conditions,
       dashboardFilters,
-      widget.widgetType,
-      true // Issue search does not support parens
-    ),
+      widgetType: widget.widgetType,
+      skipParens: true, // Issue search does not support parens
+    }),
     sort: widget.queries?.[0]?.orderby,
     ...datetime,
     // Pass empty string when projects is empty to preserve "My Projects" selection in URL
@@ -306,7 +306,7 @@ export function getWidgetReleasesUrl(
       : {statsPeriod: period};
   const releasesLocation = `/organizations/${organization.slug}/releases/?${qs.stringify({
     ...datetime,
-    query: applyDashboardFilters('', dashboardFilters),
+    query: applyDashboardFilters({baseQuery: '', dashboardFilters}),
     // Pass empty string when projects is empty to preserve "My Projects" selection in URL
     project: selection.projects.length === 0 ? '' : selection.projects,
     environment: selection.environments,
@@ -590,12 +590,17 @@ function _doesWidgetUsePerformanceScore(query: WidgetQuery) {
 
 export const performanceScoreTooltip = t('peformance_score is not supported in Discover');
 
-export function applyDashboardFilters(
-  baseQuery: string | undefined,
-  dashboardFilters: DashboardFilters | undefined,
-  widgetType?: WidgetType,
-  skipParens?: boolean
-): string | undefined {
+export function applyDashboardFilters({
+  baseQuery,
+  dashboardFilters,
+  widgetType,
+  skipParens,
+}: {
+  baseQuery: string | undefined;
+  dashboardFilters: DashboardFilters | undefined;
+  skipParens?: boolean;
+  widgetType?: WidgetType;
+}): string | undefined {
   const dashboardFilterConditions = dashboardFiltersToString(
     dashboardFilters,
     widgetType

--- a/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
+++ b/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
@@ -339,11 +339,11 @@ function _getWidgetExploreUrl(
     visualize,
     groupBy: visualize.length > 0 ? groupBy : [],
     field: fields,
-    query: applyDashboardFilters(
-      overrideQuery?.formatString() ?? decodeScalar(locationQueryParams.query),
+    query: applyDashboardFilters({
+      baseQuery: overrideQuery?.formatString() ?? decodeScalar(locationQueryParams.query),
       dashboardFilters,
-      widget.widgetType
-    ),
+      widgetType: widget.widgetType,
+    }),
     sort: sort || undefined,
     interval:
       decodeScalar(locationQueryParams.interval) ??
@@ -419,7 +419,7 @@ function _getWidgetExploreUrlForMultipleQueries(
     selection: currentSelection,
     queries: widget.queries.map(query => ({
       chartType: getChartType(widget.displayType),
-      query: applyDashboardFilters(query.conditions, dashboardFilters) ?? '',
+      query: applyDashboardFilters({baseQuery: query.conditions, dashboardFilters}) ?? '',
       sortBys: decodeSorts(query.orderby).filter(
         s => s.field !== SpanFields.IS_STARRED_TRANSACTION
       ),

--- a/static/app/views/dashboards/utils/getWidgetMetricsUrl.tsx
+++ b/static/app/views/dashboards/utils/getWidgetMetricsUrl.tsx
@@ -46,11 +46,11 @@ export function getWidgetMetricsUrl(
             groupBy: col,
           }));
           const queryString =
-            applyDashboardFilters(
-              query.conditions,
+            applyDashboardFilters({
+              baseQuery: query.conditions,
               dashboardFilters,
-              widget.widgetType
-            ) ?? '';
+              widgetType: widget.widgetType,
+            }) ?? '';
 
           const parsed = parseAggregateExpression(aggregate, queryString);
           const results: BaseMetricQuery[] = [...parsed.metricQueries];
@@ -71,8 +71,11 @@ export function getWidgetMetricsUrl(
 
       return widget.queries.map(query => {
         const queryString =
-          applyDashboardFilters(query.conditions, dashboardFilters, widget.widgetType) ??
-          '';
+          applyDashboardFilters({
+            baseQuery: query.conditions,
+            dashboardFilters,
+            widgetType: widget.widgetType,
+          }) ?? '';
 
         const groupByFields: GroupBy[] = query.columns.map((col): GroupBy => ({
           groupBy: col,

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -331,11 +331,11 @@ function VisualizationWidgetContent({
             aggregateField: [
               {chartType: getChartType(widget.displayType), yAxes: [yAxis]},
             ],
-            query: applyDashboardFilters(
-              exploreQuery.formatString(),
+            query: applyDashboardFilters({
+              baseQuery: exploreQuery.formatString(),
               dashboardFilters,
-              widget.widgetType
-            ),
+              widgetType: widget.widgetType,
+            }),
           });
           labelContent = <Link to={exploreUrl}>{labelDisplay}</Link>;
         }

--- a/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
@@ -311,11 +311,11 @@ export function getMenuOptions(
         const {timeSeries, label, seriesName, widgetQuery} = transformed;
 
         const baseQuery =
-          applyDashboardFilters(
-            widgetQuery?.conditions,
+          applyDashboardFilters({
+            baseQuery: widgetQuery?.conditions,
             dashboardFilters,
-            widget.widgetType
-          ) ?? '';
+            widgetType: widget.widgetType,
+          }) ?? '';
 
         // Add group-by values as filters to the alert query
         const search = new MutableSearch(baseQuery);

--- a/static/app/views/insights/pages/agents/components/tracesTable.tsx
+++ b/static/app/views/insights/pages/agents/components/tracesTable.tsx
@@ -151,11 +151,12 @@ export function TracesTable({
   });
 
   const combinedQuery =
-    applyDashboardFilters(
-      useCombinedQuery(getHasAiSpansFilter()),
+    applyDashboardFilters({
+      baseQuery: useCombinedQuery(getHasAiSpansFilter()),
       dashboardFilters,
-      WidgetType.SPANS // This widget technically has its own widget type, but it uses the spans dataset
-    ) ?? '';
+      // This widget technically has its own widget type, but it uses the spans dataset
+      widgetType: WidgetType.SPANS,
+    }) ?? '';
 
   const {cursor, setCursor} = useTableCursor();
 


### PR DESCRIPTION
Replaces four positional arguments, the last two optional booleans and enums, with a single options object. Updates all nine call sites. No behavior change.