### PR TITLE
feat(seerExplorer): Report page location and timezone-aware send times

### DIFF
--- a/static/app/views/seerExplorer/contexts/llmContext.spec.tsx
+++ b/static/app/views/seerExplorer/contexts/llmContext.spec.tsx
@@ -82,6 +82,113 @@ describe('LLMContextProvider — empty state', () => {
   });
 });
 
+describe('LLMContextProvider — location', () => {
+  it('reports route params even with no nodes registered', async () => {
+    const {ContextCapture, getSnapshot} = makeContextCapture();
+
+    render(
+      <LLMContextProvider>
+        <ContextCapture />
+      </LLMContextProvider>,
+      {
+        initialRouterConfig: {
+          route: '/issues/:groupId/',
+          location: {pathname: '/issues/123/'},
+        },
+      }
+    );
+
+    // A snapshot with no registered nodes still carries location — that is the
+    // point, since most routes register nothing.
+    await waitFor(() => {
+      expect(getSnapshot().nodes).toEqual([]);
+      expect(getSnapshot().location?.params).toEqual({groupId: '123'});
+    });
+    expect(getSnapshot().location?.url).toBe(window.location.href);
+  });
+
+  it('reads the query string off window.location at snapshot time', async () => {
+    const {ContextCapture, getSnapshot} = makeContextCapture();
+    const {search} = window.location;
+    window.history.replaceState(
+      {},
+      '',
+      '/issues/123/?query=is%3Aunresolved&project=1&project=2'
+    );
+
+    try {
+      render(
+        <LLMContextProvider>
+          <ContextCapture />
+        </LLMContextProvider>
+      );
+
+      await waitFor(() => {
+        expect(getSnapshot().location?.query).toEqual({
+          query: 'is:unresolved',
+          project: ['1', '2'],
+        });
+      });
+    } finally {
+      window.history.replaceState({}, '', search || '/');
+    }
+  });
+
+  it('includes location on a component-scoped snapshot too', async () => {
+    const {ContextCapture, getSnapshot} = makeContextCapture();
+
+    render(
+      <LLMContextProvider>
+        <ContextWidget title="Error Rate">
+          <ContextCapture />
+        </ContextWidget>
+      </LLMContextProvider>,
+      {
+        initialRouterConfig: {
+          route: '/issues/:groupId/',
+          location: {pathname: '/issues/456/'},
+        },
+      }
+    );
+
+    await waitFor(() => {
+      expect(getSnapshot(true).location?.params).toEqual({groupId: '456'});
+    });
+  });
+
+  it('does not re-render the provider when the route changes', async () => {
+    let providerRenders = 0;
+    function CountingChild() {
+      providerRenders += 1;
+      return null;
+    }
+
+    const {router} = render(
+      <LLMContextProvider>
+        <CountingChild />
+      </LLMContextProvider>,
+      {
+        initialRouterConfig: {
+          route: '/issues/:groupId/',
+          location: {pathname: '/issues/1/'},
+        },
+      }
+    );
+
+    await waitFor(() => {
+      expect(providerRenders).toBe(1);
+    });
+
+    router.navigate('/issues/2/');
+
+    // The watcher re-renders, but it renders null and the provider's children
+    // are untouched — so nothing below the provider re-renders.
+    await waitFor(() => {
+      expect(providerRenders).toBe(1);
+    });
+  });
+});
+
 describe('registerLLMContext — nesting', () => {
   it('nests Chart inside Widget inside Dashboard in the snapshot', async () => {
     const {ContextCapture, getSnapshot} = makeContextCapture();
@@ -102,6 +209,7 @@ describe('registerLLMContext — nesting', () => {
     await waitFor(() => {
       expect(getSnapshot()).toEqual({
         version: expect.any(Number),
+        location: expect.any(Object),
         nodes: [
           {
             nodeType: 'dashboard',

--- a/static/app/views/seerExplorer/contexts/llmContext.tsx
+++ b/static/app/views/seerExplorer/contexts/llmContext.tsx
@@ -7,14 +7,28 @@ import {
   useMemo,
   useRef,
 } from 'react';
+import {useMatches} from 'react-router-dom';
+
+import {getRouteStringFromRoutes} from 'sentry/utils/getRouteStringFromRoutes';
+import {useParams} from 'sentry/utils/useParams';
 
 import type {
   LLMContextInternalValue,
+  LLMContextLocation,
   LLMContextNode,
   LLMContextNodeSnapshot,
   LLMContextSnapshot,
   LLMContextState,
 } from './llmContextTypes';
+
+/**
+ * The half of the location that needs router hooks to know. The URL and query
+ * string are read from `window.location` at snapshot time instead.
+ */
+interface RouteIdentity {
+  name: string;
+  params: Record<string, string>;
+}
 
 // Internal context — holds the registry operations (registerNode, etc.)
 
@@ -89,15 +103,69 @@ function buildTree(
   return children;
 }
 
+/**
+ * Reports the current route into the provider's location ref.
+ *
+ * A separate component on purpose: `useLocation`/`useParams`/`useMatches` all
+ * re-render their caller on every navigation, and the provider wraps the entire
+ * app — it currently never re-renders after mount and should stay that way. This
+ * renders null, so its own re-renders cost nothing.
+ *
+ * Only the route *pattern* and params need router hooks. The URL and query string
+ * are read straight off `window.location` at snapshot time, which is why they are
+ * absent here.
+ */
+function LocationWatcher({
+  onChange,
+}: {
+  onChange: (location: RouteIdentity) => void;
+}): null {
+  const params = useParams();
+  const matches = useMatches();
+  const name = getRouteStringFromRoutes({matches});
+
+  useEffect(() => {
+    onChange({name, params});
+  }, [name, params, onChange]);
+
+  return null;
+}
+
+/**
+ * Assembles the location at snapshot time. The URL and query string come from
+ * `window.location` rather than a subscription, so they cannot go stale; the
+ * route pattern and params come from the watcher's last report.
+ */
+function readLocation(route: RouteIdentity | null): LLMContextLocation | undefined {
+  if (typeof window === 'undefined') {
+    return undefined;
+  }
+
+  const query: Record<string, string | string[]> = {};
+  for (const key of new Set(new URLSearchParams(window.location.search).keys())) {
+    const all = new URLSearchParams(window.location.search).getAll(key);
+    query[key] = all.length > 1 ? all : (all[0] ?? '');
+  }
+
+  return {
+    url: window.location.href,
+    name: route?.name ?? '',
+    params: route?.params ?? {},
+    query,
+  };
+}
+
 function serializeState(
   state: LLMContextState,
   nodeData: Map<string, unknown>,
+  route: RouteIdentity | null,
   fromNodeId?: string
 ): LLMContextSnapshot {
+  const location = readLocation(route);
   if (fromNodeId) {
     const node = state.nodes.get(fromNodeId);
     if (!node) {
-      return {version: state.version, nodes: []};
+      return {version: state.version, nodes: [], location};
     }
     const raw = nodeData.has(fromNodeId) ? nodeData.get(fromNodeId) : {};
     let priority = 0;
@@ -119,11 +187,13 @@ function serializeState(
           children: buildTree(state.nodes, nodeData, fromNodeId),
         },
       ],
+      location,
     };
   }
   return {
     version: state.version,
     nodes: buildTree(state.nodes, nodeData, undefined),
+    location,
   };
 }
 
@@ -143,9 +213,20 @@ export function LLMContextProvider({children}: LLMContextProviderProps) {
   // the latest data imperatively via getSnapshot().
   const stateRef = useRef(INITIAL_STATE);
   const nodeDataRef = useRef(new Map<string, unknown>());
+  const routeRef = useRef<RouteIdentity | null>(null);
+
+  // Stable so LocationWatcher's effect doesn't refire on every provider render.
+  const handleRouteChange = useCallback((route: RouteIdentity) => {
+    routeRef.current = route;
+  }, []);
 
   const getSnapshot = useCallback((fromNodeId?: string): LLMContextSnapshot => {
-    return serializeState(stateRef.current, nodeDataRef.current, fromNodeId);
+    return serializeState(
+      stateRef.current,
+      nodeDataRef.current,
+      routeRef.current,
+      fromNodeId
+    );
   }, []);
 
   const registerNode = useCallback(
@@ -184,7 +265,12 @@ export function LLMContextProvider({children}: LLMContextProviderProps) {
     [getSnapshot, registerNode, unregisterNode, updateNodeData]
   );
 
-  return <LLMInternalContext value={value}>{children}</LLMInternalContext>;
+  return (
+    <LLMInternalContext value={value}>
+      <LocationWatcher onChange={handleRouteChange} />
+      {children}
+    </LLMInternalContext>
+  );
 }
 
 /**

--- a/static/app/views/seerExplorer/contexts/llmContextTypes.ts
+++ b/static/app/views/seerExplorer/contexts/llmContextTypes.ts
@@ -61,12 +61,30 @@ export interface LLMContextState {
 }
 
 /**
+ * Where the user is in the app, independent of what any page registered.
+ *
+ * `name` is the route pattern and `params` its filled-in values, so
+ * `/issues/:groupId/` plus `{groupId: '123'}` tells the reader what `123` *is* —
+ * something a bare URL leaves it to guess.
+ */
+export interface LLMContextLocation {
+  name: string;
+  params: Record<string, string>;
+  query: Record<string, string | string[]>;
+  url: string;
+}
+
+/**
  * The snapshot format returned by `getSnapshot()`. This is what gets sent
  * to the LLM API — a plain-JSON-serializable nested tree.
+ *
+ * `location` is present regardless of whether any component registered a node,
+ * so a page with no LLMContext coverage still reports where the user is.
  */
 export interface LLMContextSnapshot {
   nodes: LLMContextNodeSnapshot[];
   version: number;
+  location?: LLMContextLocation;
 }
 
 export interface LLMContextNodeSnapshot {

--- a/static/app/views/seerExplorer/hooks/useAsciiSnapshot.spec.tsx
+++ b/static/app/views/seerExplorer/hooks/useAsciiSnapshot.spec.tsx
@@ -44,3 +44,50 @@ describe('buildResult whitespace trimming', () => {
     expect(trimmedBody.length).toBeLessThan(naiveResult.length);
   });
 });
+
+describe('buildResult location header', () => {
+  it('falls back to the bare URL when no location is passed', () => {
+    const grid = createGridHelpers(2, 4);
+    grid.writeOverlay(0, 0, 'hi');
+
+    const result = buildResult(grid, [], []);
+
+    expect(result.split('\n')[0]).toBe(window.location.href);
+  });
+
+  it('leads with the full location so the reader need not parse the URL', () => {
+    const grid = createGridHelpers(2, 4);
+    grid.writeOverlay(0, 0, 'hi');
+
+    const result = buildResult(grid, [], [], {
+      url: 'https://sentry.io/issues/123/?statsPeriod=14d',
+      name: '/issues/:groupId/',
+      params: {groupId: '123'},
+      query: {statsPeriod: '14d'},
+    });
+
+    expect(result).toContain('https://sentry.io/issues/123/?statsPeriod=14d');
+    expect(result).toContain('Route: /issues/:groupId/');
+    expect(result).toContain('Route params: {"groupId":"123"}');
+    expect(result).toContain('Query params: {"statsPeriod":"14d"}');
+    // Body still follows the header.
+    expect(result).toContain('hi');
+  });
+
+  it('omits empty location fields rather than emitting blank lines', () => {
+    const grid = createGridHelpers(2, 4);
+    grid.writeOverlay(0, 0, 'hi');
+
+    const result = buildResult(grid, [], [], {
+      url: 'https://sentry.io/insights/',
+      name: '',
+      params: {},
+      query: {},
+    });
+
+    expect(result.split('\n')[0]).toBe('https://sentry.io/insights/');
+    expect(result).not.toContain('Route:');
+    expect(result).not.toContain('Route params:');
+    expect(result).not.toContain('Query params:');
+  });
+});

--- a/static/app/views/seerExplorer/hooks/useAsciiSnapshot.tsx
+++ b/static/app/views/seerExplorer/hooks/useAsciiSnapshot.tsx
@@ -15,6 +15,7 @@ import {
 import {formatMetricUsingUnit} from 'sentry/utils/number/formatMetricUsingUnit';
 import {useProjects} from 'sentry/utils/useProjects';
 import {prettifyAggregation} from 'sentry/views/explore/utils';
+import type {LLMContextLocation} from 'sentry/views/seerExplorer/contexts/llmContextTypes';
 
 // Types
 type SeriesData = {
@@ -891,9 +892,26 @@ function renderTextNodes(
 export function buildResult(
   gridHelpers: GridHelpers,
   chartTables: string[],
-  projectSlugs: string[]
+  projectSlugs: string[],
+  location?: LLMContextLocation
 ): string {
-  const url = window.location.href;
+  // The URL alone leaves the reader to infer what each path segment means. When
+  // the caller has the full location, lead with all of it — the route pattern
+  // plus params says `123` is a groupId, which a bare URL does not.
+  const header = location
+    ? [
+        location.url,
+        location.name ? `Route: ${location.name}` : '',
+        Object.keys(location.params).length > 0
+          ? `Route params: ${JSON.stringify(location.params)}`
+          : '',
+        Object.keys(location.query).length > 0
+          ? `Query params: ${JSON.stringify(location.query)}`
+          : '',
+      ]
+        .filter(Boolean)
+        .join('\n')
+    : window.location.href;
 
   // Step 1: Strip trailing spaces from each row. The grid is initialized as
   // all-space cells so rows are always full-width;
@@ -912,7 +930,7 @@ export function buildResult(
   // Step 3: Drop all blank rows
   const nonBlank = lines.filter(l => l.length > 0);
 
-  let result = url + '\n' + nonBlank.join('\n');
+  let result = header + '\n' + nonBlank.join('\n');
 
   if (chartTables.length > 0 || projectSlugs.length > 0) {
     result += '\n\n=== FOOTNOTES ===\n\n';
@@ -943,53 +961,56 @@ export function useAsciiSnapshot() {
   const {selection} = usePageFilters();
   const {projects} = useProjects();
 
-  const capture = useCallback(() => {
-    if (typeof document === 'undefined' || typeof window === 'undefined') {
-      return '';
-    }
+  const capture = useCallback(
+    (location?: LLMContextLocation) => {
+      if (typeof document === 'undefined' || typeof window === 'undefined') {
+        return '';
+      }
 
-    const viewportWidth = Math.max(0, Math.floor(window.innerWidth));
-    const viewportHeight = Math.max(0, Math.floor(window.innerHeight));
+      const viewportWidth = Math.max(0, Math.floor(window.innerWidth));
+      const viewportHeight = Math.max(0, Math.floor(window.innerHeight));
 
-    const cellWidthPx = 6;
-    const cellHeightPx = 14;
+      const cellWidthPx = 6;
+      const cellHeightPx = 14;
 
-    const cols = Math.max(1, Math.floor(viewportWidth / cellWidthPx));
-    const rows = Math.max(1, Math.floor(viewportHeight / cellHeightPx));
+      const cols = Math.max(1, Math.floor(viewportWidth / cellWidthPx));
+      const rows = Math.max(1, Math.floor(viewportHeight / cellHeightPx));
 
-    const leftShiftPx = computeLeftShiftPx(viewportWidth);
-    const gridHelpers = createGridHelpers(rows, cols);
-    const isExcluded = createIsExcluded();
-    const isVisible = createIsVisible(viewportWidth, viewportHeight);
+      const leftShiftPx = computeLeftShiftPx(viewportWidth);
+      const gridHelpers = createGridHelpers(rows, cols);
+      const isExcluded = createIsExcluded();
+      const isVisible = createIsVisible(viewportWidth, viewportHeight);
 
-    const context: ChartProcessingContext = {
-      gridHelpers,
-      viewportWidth,
-      viewportHeight,
-      cellWidthPx,
-      cellHeightPx,
-      leftShiftPx,
-      isExcluded,
-      isVisible,
-    };
+      const context: ChartProcessingContext = {
+        gridHelpers,
+        viewportWidth,
+        viewportHeight,
+        cellWidthPx,
+        cellHeightPx,
+        leftShiftPx,
+        isExcluded,
+        isVisible,
+      };
 
-    const chartTables: string[] = [];
-    const chartContainers = processCharts(context, chartTables);
-    renderTextNodes(context, chartContainers);
+      const chartTables: string[] = [];
+      const chartContainers = processCharts(context, chartTables);
+      renderTextNodes(context, chartContainers);
 
-    const projectSlugs: string[] = [];
-    if (selection.projects.length > 0) {
-      const projectIdToSlug = new Map(projects.map(p => [parseInt(p.id, 10), p.slug]));
-      for (const projectId of selection.projects) {
-        const slug = projectIdToSlug.get(projectId);
-        if (slug) {
-          projectSlugs.push(slug);
+      const projectSlugs: string[] = [];
+      if (selection.projects.length > 0) {
+        const projectIdToSlug = new Map(projects.map(p => [parseInt(p.id, 10), p.slug]));
+        for (const projectId of selection.projects) {
+          const slug = projectIdToSlug.get(projectId);
+          if (slug) {
+            projectSlugs.push(slug);
+          }
         }
       }
-    }
 
-    return buildResult(gridHelpers, chartTables, projectSlugs);
-  }, [selection.projects, projects]);
+      return buildResult(gridHelpers, chartTables, projectSlugs, location);
+    },
+    [selection.projects, projects]
+  );
 
   return capture;
 }

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.spec.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.spec.tsx
@@ -16,7 +16,16 @@ describe('useSeerExplorer', () => {
       getPageReferrer: () => '/issues/',
     });
     jest.spyOn(llmContextModule, 'useLLMContext').mockReturnValue({
-      getLLMContext: () => ({version: 0, nodes: []}),
+      getLLMContext: () => ({
+        version: 0,
+        nodes: [],
+        location: {
+          url: window.location.href,
+          name: '/issues/',
+          params: {},
+          query: {},
+        },
+      }),
     });
   });
 
@@ -228,6 +237,50 @@ describe('useSeerExplorer', () => {
         // /monitors/mobile-builds/ is not in STRUCTURED_CONTEXT_ROUTES — falls back to ASCII snapshot
         const ctx = postMock.mock.calls[0][1].data.on_page_context;
         expect(() => JSON.parse(ctx)).toThrow();
+      });
+    });
+
+    it('sends page_location even on a non-structured-context page', async () => {
+      jest.spyOn(seerExplorerUtils, 'usePageReferrer').mockReturnValue({
+        getPageReferrer: () => '/monitors/mobile-builds/',
+      });
+      const org = OrganizationFixture({features: ['seer-explorer']});
+      MockApiClient.addMockResponse({
+        url: `/organizations/${org.slug}/seer/explorer-chat/`,
+        method: 'GET',
+        body: {session: null},
+      });
+      const postMock = MockApiClient.addMockResponse({
+        url: `/organizations/${org.slug}/seer/explorer-chat/`,
+        method: 'POST',
+        body: {run_id: 1},
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${org.slug}/seer/explorer-chat/1/`,
+        method: 'GET',
+        body: {session: {blocks: [], run_id: 1, status: 'completed', updated_at: ''}},
+      });
+
+      const {result} = renderHookWithProviders(() => useSeerExplorer(), {
+        organization: org,
+      });
+      act(() => {
+        result.current.sendMessage('q');
+      });
+
+      // Location is independent of the structured-context allowlist — the ASCII
+      // branch reports it too.
+      await waitFor(() => {
+        expect(postMock.mock.calls[0][1].data.page_location).toEqual(
+          expect.objectContaining({url: window.location.href})
+        );
+        // Local (zone name in brackets) then UTC, as display strings.
+        const sentAt = postMock.mock.calls[0][1].data.sent_at;
+        expect(sentAt).toHaveLength(2);
+        expect(sentAt[0]).toContain(
+          `[${Intl.DateTimeFormat().resolvedOptions().timeZone}]`
+        );
+        expect(sentAt[1]).toMatch(/(Z|\+00:00)$/);
       });
     });
 

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.spec.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.spec.tsx
@@ -1,3 +1,4 @@
+import moment from 'moment-timezone';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {act, renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -277,10 +278,14 @@ describe('useSeerExplorer', () => {
         // Local (zone name in brackets) then UTC, as display strings.
         const sentAt = postMock.mock.calls[0][1].data.sent_at;
         expect(sentAt).toHaveLength(2);
-        expect(sentAt[0]).toContain(
-          `[${Intl.DateTimeFormat().resolvedOptions().timeZone}]`
-        );
         expect(sentAt[1]).toMatch(/(Z|\+00:00)$/);
+
+        // The offset and the bracketed zone name must describe the same zone.
+        // ConfigStore points moment's default at the account timezone preference,
+        // so deriving them from different sources yields a contradictory string.
+        const [, offset, zone] = sentAt[0].match(/([+-]\d{2}:\d{2}|Z)\[(.+)\]$/) ?? [];
+        expect(zone).toBeTruthy();
+        expect(moment.tz(zone).format('Z')).toBe(offset === 'Z' ? '+00:00' : offset);
       });
     });
 

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -1,6 +1,7 @@
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import * as Sentry from '@sentry/react';
 import {useMutation, useQueryClient} from '@tanstack/react-query';
+import moment from 'moment-timezone';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {t} from 'sentry/locale';
@@ -11,6 +12,10 @@ import {RequestError} from 'sentry/utils/requestError/requestError';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useLLMContext} from 'sentry/views/seerExplorer/contexts/llmContext';
+import type {
+  LLMContextLocation,
+  LLMContextSnapshot,
+} from 'sentry/views/seerExplorer/contexts/llmContextTypes';
 import {useAsciiSnapshot} from 'sentry/views/seerExplorer/hooks/useAsciiSnapshot';
 import {
   useSeerExplorerChatDispatch,
@@ -186,10 +191,12 @@ export const useSeerExplorer = () => {
       overrideBashModeEnabled: boolean;
       overrideCodeModeEnable: 'off' | 'on' | 'only';
       overrideCtxEngEnable: boolean;
+      pageLocation: LLMContextLocation | undefined;
       pageName: string;
       query: string;
       runId: SeerExplorerRunId | null;
       screenshot: string | undefined;
+      sentAt: string[];
     }
   >({
     mutationFn: async params => {
@@ -220,6 +227,8 @@ export const useSeerExplorer = () => {
           insert_index: params.insertIndex,
           on_page_context: params.screenshot,
           page_name: params.pageName,
+          page_location: params.pageLocation,
+          sent_at: params.sentAt,
           override_ce_enable: params.overrideCtxEngEnable,
           override_bash_mode_enabled: params.overrideBashModeEnabled,
           override_code_mode_enable: params.overrideCodeModeEnable,
@@ -466,21 +475,31 @@ export const useSeerExplorer = () => {
       // explicitRunId: undefined = use current runId, null = force new run, number = use that run
       const effectiveRunId = explicitRunId === undefined ? runId : explicitRunId;
 
+      // The snapshot is the source of location for both branches below, so take it
+      // once here rather than only on the structured path.
+      let snapshot: LLMContextSnapshot | undefined;
+      try {
+        snapshot = getLLMContext();
+      } catch (e) {
+        Sentry.captureException(e);
+      }
+
       // Send structured LLMContext JSON on supported pages when the feature flag
       // is enabled; fall back to a coarse ASCII screenshot otherwise.
       let screenshot: string | undefined;
       if (
+        snapshot &&
         overrideCtxEngEnable &&
         supportsStructuredContext(getPageReferrer(), organization)
       ) {
         try {
-          screenshot = JSON.stringify(getLLMContext());
+          screenshot = JSON.stringify(snapshot);
         } catch (e) {
           Sentry.captureException(e);
-          screenshot = captureAsciiSnapshot?.();
+          screenshot = captureAsciiSnapshot?.(snapshot?.location);
         }
       } else {
-        screenshot = captureAsciiSnapshot?.();
+        screenshot = captureAsciiSnapshot?.(snapshot?.location);
       }
 
       const pageName = getPageReferrer();
@@ -525,6 +544,14 @@ export const useSeerExplorer = () => {
         runId: effectiveRunId,
         orgSlug,
         pageName,
+        pageLocation: snapshot?.location,
+        // Local time first, then the same instant in UTC. Both are display strings
+        // the agent reads directly — nothing downstream parses them, so the zone
+        // name travels in the string (RFC 9557) rather than as a separate field.
+        sentAt: [
+          `${moment().format()}[${Intl.DateTimeFormat().resolvedOptions().timeZone}]`,
+          moment().utc().format(),
+        ],
         screenshot,
         overrideBashModeEnabled,
         overrideCtxEngEnable,

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -4,6 +4,7 @@ import {useMutation, useQueryClient} from '@tanstack/react-query';
 import moment from 'moment-timezone';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
+import {useTimezone} from 'sentry/components/timezoneProvider';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {parseQueryKey} from 'sentry/utils/api/apiQueryKey';
@@ -139,6 +140,7 @@ export const useSeerExplorer = () => {
   const captureAsciiSnapshot = useAsciiSnapshot();
   const {getPageReferrer} = usePageReferrer();
   const {getLLMContext} = useLLMContext();
+  const timezone = useTimezone();
   const [overrideCtxEngEnable, setOverrideCtxEngEnable] = useLocalStorageState(
     'seer-explorer.override.ctx-eng',
     true
@@ -548,8 +550,13 @@ export const useSeerExplorer = () => {
         // Local time first, then the same instant in UTC. Both are display strings
         // the agent reads directly — nothing downstream parses them, so the zone
         // name travels in the string (RFC 9557) rather than as a separate field.
+        //
+        // The offset and the bracketed name must come from one source: ConfigStore
+        // calls moment.tz.setDefault with the account timezone preference, so a bare
+        // moment() would render that offset while the browser reported a different
+        // name. useTimezone() is that single source (preference, else browser).
         sentAt: [
-          `${moment().format()}[${Intl.DateTimeFormat().resolvedOptions().timeZone}]`,
+          `${moment().tz(timezone).format()}[${timezone}]`,
           moment().utc().format(),
         ],
         screenshot,
@@ -571,6 +578,7 @@ export const useSeerExplorer = () => {
       overrideCodeModeEnable,
       sendMessageMutate,
       setLastSentMessage,
+      timezone,
     ]
   );
 


### PR DESCRIPTION
Reports where the user is — url, route pattern, route params, query params — as `page_location`, and folds the whole thing into both context formats so the ASCII path carries more than a URL.

Seer could see what was rendered on the page but not where the user was. The URL rode along as line 1 of the ASCII snapshot and was dropped entirely on the structured path, and `page_name` was sent but never reached the agent. The route params are the reason this beats a bare URL: `/issues/:groupId/` plus `{groupId: '123'}` says what the segment means.

`LLMContextProvider` wraps the whole app and never re-renders after mount — its state lives in refs and its value is memoized. Calling `useLocation` in it directly would re-render it on every navigation, so a `LocationWatcher` child owns the router hooks and renders null. Only the route pattern and params need hooks, so url and query are read off `window.location` when the snapshot is taken and cannot go stale.

The field is optional end to end, so nothing breaks before getsentry/sentry#121757 lands. getsentry/seer#7715 renders it, and also adds a per-turn send timestamp it derives server-side — that half needs nothing from here. All three merge in any order.