### PR TITLE
fix(seer): Record autofix trigger before RCA start

### DIFF
--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -435,6 +435,22 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                             status=status.HTTP_409_CONFLICT,
                         )
 
+                if is_autofix_kickoff:
+                    actor = resolve_action_actor(request)
+                    with action_context_scope(
+                        source=resolve_action_source(request),
+                        actor=actor,
+                    ):
+                        Activity.objects.create_group_activity(
+                            group,
+                            ActivityType.TRIGGER_AUTOFIX,
+                            user_id=(
+                                actor.actor_id if actor.actor_type == GroupActorType.USER else None
+                            ),
+                            data={"referrer": referrer.value},
+                            send_notification=False,
+                        )
+
                 try:
                     run = trigger_autofix_agent(
                         group=group,
@@ -461,20 +477,6 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                 run_id = run.seer_run_state_id
 
                 if is_autofix_kickoff:
-                    actor = resolve_action_actor(request)
-                    with action_context_scope(
-                        source=resolve_action_source(request),
-                        actor=actor,
-                    ):
-                        Activity.objects.create_group_activity(
-                            group,
-                            ActivityType.TRIGGER_AUTOFIX,
-                            user_id=(
-                                actor.actor_id if actor.actor_type == GroupActorType.USER else None
-                            ),
-                            data={"referrer": referrer.value},
-                            send_notification=False,
-                        )
                     sentry_run_id = str(run.uuid)
                 else:
                     sentry_run_id = resolved_sentry_run_id

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -3,6 +3,7 @@ from unittest.mock import ANY, Mock, patch
 
 from sentry.integrations.services.integration import RpcIntegration
 from sentry.integrations.types import ExternalProviders
+from sentry.issues.action_log import SYSTEM_ACTOR, ActionSource, action_context_scope
 from sentry.issues.action_log.types import GroupActionActor, TriggerAutofixAction
 from sentry.models.activity import Activity
 from sentry.seer.agent.client_models import (
@@ -20,6 +21,7 @@ from sentry.seer.models import SeerPermissionError
 from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.action_log import capture_action_log
 from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
 
@@ -479,24 +481,52 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
             referrer=AutofixReferrer.GROUP_AUTOFIX_ENDPOINT.value,
         )
 
+    @with_feature(
+        [
+            "projects:issue-action-log-write-to-db",
+            "projects:issue-action-log-activity",
+        ]
+    )
     @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
     def test_kickoff_creates_trigger_autofix_activity(self, mock_trigger):
         group = self.create_group()
-        mock_trigger.return_value = self.create_seer_run(
-            organization=self.organization, seer_run_state_id=123
-        )
+        run = self.create_seer_run(organization=self.organization, seer_run_state_id=123)
+
+        def trigger(*_args, **_kwargs):
+            with action_context_scope(ActionSource.SEER_EXPLORER, SYSTEM_ACTOR):
+                self.create_group_activity(
+                    group=group,
+                    type=ActivityType.SEER_RCA_STARTED.value,
+                    data={"run_id": 123},
+                )
+            return run
+
+        mock_trigger.side_effect = trigger
 
         self.login_as(user=self.user)
-        response = self.client.post(
-            self._get_url(group.id),
-            data={"step": "root_cause", "referrer": AutofixReferrer.WEB.value},
-            format="json",
-        )
+        with outbox_runner():
+            response = self.client.post(
+                self._get_url(group.id),
+                data={"step": "root_cause", "referrer": AutofixReferrer.WEB.value},
+                format="json",
+            )
 
         assert response.status_code == 202, response.data
         activity = Activity.objects.get(group=group, type=ActivityType.TRIGGER_AUTOFIX.value)
         assert activity.user_id == self.user.id
         assert activity.data == {"referrer": AutofixReferrer.WEB.value}
+
+        activity_response = self.client.get(
+            f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/activities/",
+            format="json",
+        )
+
+        assert activity_response.status_code == 200, activity_response.data
+        assert [item["type"] for item in activity_response.data["activity"]] == [
+            "seer_rca_started",
+            "trigger_autofix",
+            "first_seen",
+        ]
 
     @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
     def test_advancing_existing_run_skips_action(self, mock_trigger):


### PR DESCRIPTION
Keep Autofix trigger activities ahead of RCA started activities in the issue feed.

#120983 and #121117 fixed ordering between adjacent Seer activities, but this endpoint still recorded the user trigger after the RCA started activity. Record the trigger first and cover the action-log-backed API order.