### PR TITLE
fix(refactor-tasks): Fail loudly when the eslint detector cannot run

### DIFF
--- a/.sentry-refactor-tasks/conventions/eslint-json-runner.ts
+++ b/.sentry-refactor-tasks/conventions/eslint-json-runner.ts
@@ -9,16 +9,25 @@ import fg from 'fast-glob';
 // on. This script just resolves the file set, runs eslint with that config,
 // and emits the matching violations as JSON. It contains nothing specific to
 // any one repo or plugin.
+//
+// Failure policy: never print an empty result for a run that did not actually
+// complete. Every unexpected condition exits non-zero with an explanation on
+// stderr and writes nothing to stdout, so the scanner reports "produced no
+// output" instead of "Found 0 violations". The earlier version degraded to `[]`
+// whenever eslint failed to start, which made a completely non-functional rule
+// look like a clean codebase for weeks.
+function die(message: string): never {
+  console.error(`eslint-json-runner: ${message}`);
+  process.exit(1);
+}
+
 const repoPath = process.argv[2];
 const rule = process.argv[3];
 const configPath = process.argv[4];
 const scanPaths = process.argv.slice(5);
 
 if (!repoPath || !rule || !configPath || scanPaths.length === 0) {
-  console.error(
-    'Usage: eslint-json-runner <repo-path> <rule-id> <config-path> <path...>'
-  );
-  process.exit(1);
+  die('usage: eslint-json-runner <repo-path> <rule-id> <config-path> <path...>');
 }
 
 const patterns = scanPaths.map(p => (p.includes('*') ? p : `${p}/**/*.{ts,tsx}`));
@@ -29,15 +38,21 @@ const files = fg.sync(patterns, {
   absolute: false,
 });
 
+// Matching nothing means the glob or the checkout is wrong, not that the repo
+// is clean — every convention here targets paths that are known to exist.
 if (files.length === 0) {
-  console.log('[]');
-  process.exit(0);
+  die(`no files matched ${JSON.stringify(patterns)} under ${repoPath}`);
 }
+
+// The scanner kills a detect command after 300s and keeps whatever it captured,
+// so a run that creeps past that budget silently becomes an empty result. Time
+// the eslint call and report it, to make the remaining headroom observable.
+const startedAt = Date.now();
 
 // Use only the supplied config (--no-config-lookup) so detection is independent
 // of the target repo's own eslint setup. Inline eslint-disable directives are
 // still honored (no --no-inline-config), so findings match the repo's own lint.
-let rawOutput: string;
+let rawOutput = '';
 try {
   rawOutput = execFileSync(
     'npx',
@@ -59,12 +74,29 @@ try {
     }
   );
 } catch (err: any) {
-  rawOutput = err.stdout ?? '';
+  // eslint exits 0 when clean and 1 when it reports problems; both are real
+  // runs whose JSON is on stdout. Anything else — 2 for a fatal config/CLI
+  // error, ENOENT when npx is missing, ENOBUFS when output overflows maxBuffer,
+  // a signal from an OOM kill — means we never got a trustworthy result.
+  if (err.status !== 1) {
+    const stderr = String(err.stderr ?? '').trim();
+    die(
+      `eslint did not run to completion ` +
+        `(exit=${err.status ?? 'n/a'} signal=${err.signal ?? 'n/a'} code=${
+          err.code ?? 'n/a'
+        }).\n` +
+        `command: npx eslint --config ${configPath} ... (${files.length} files)\n` +
+        `stderr:\n${stderr || '(empty)'}`
+    );
+  }
+  rawOutput = String(err.stdout ?? '');
 }
 
-if (!rawOutput) {
-  console.log('[]');
-  process.exit(0);
+if (!rawOutput.trim()) {
+  die(
+    `eslint exited without writing anything to stdout, so a clean run cannot be ` +
+      `distinguished from a crash (${files.length} files were passed)`
+  );
 }
 
 interface EslintResult {
@@ -73,13 +105,37 @@ interface EslintResult {
     column: number;
     line: number;
     message: string;
-    ruleId: string;
+    ruleId: string | null;
     endColumn?: number;
     endLine?: number;
+    fatal?: boolean;
   }>;
 }
 
-const parsed: EslintResult[] = JSON.parse(rawOutput);
+let parsed: EslintResult[];
+try {
+  parsed = JSON.parse(rawOutput);
+} catch {
+  die(`eslint output was not valid JSON. First 500 chars:\n${rawOutput.slice(0, 500)}`);
+}
+
+// A fatal message means eslint never evaluated the rule for that file — a parse
+// error, or for type-aware rules a file the TypeScript project service could
+// not resolve. Those files silently drop out of the result set, so report the
+// run as failed rather than under-reporting violations.
+const fatals = parsed.flatMap(f =>
+  f.messages.filter(m => m.fatal).map(m => `${f.filePath}: ${m.message}`)
+);
+if (fatals.length > 0) {
+  die(
+    `eslint reported ${fatals.length} fatal error(s), so the run is incomplete. First 5:\n` +
+      fatals
+        .slice(0, 5)
+        .map(line => `  ${line}`)
+        .join('\n')
+  );
+}
+
 const withViolations = parsed
   .map(f => ({
     filePath: f.filePath,
@@ -93,5 +149,14 @@ const withViolations = parsed
       })),
   }))
   .filter(f => f.messages.length > 0);
+
+const violationCount = withViolations.reduce((sum, f) => sum + f.messages.length, 0);
+console.error(
+  `eslint-json-runner: linted ${files.length} files in ${Math.round(
+    (Date.now() - startedAt) / 1000
+  )}s ` +
+    `(scanner kills the detect command at 300s), eslint returned ${parsed.length} results, ` +
+    `${rule} matched ${violationCount} violations in ${withViolations.length} files`
+);
 
 console.log(JSON.stringify(withViolations));

--- a/.sentry-refactor-tasks/conventions/no-deprecated-callsite.detect.sh
+++ b/.sentry-refactor-tasks/conventions/no-deprecated-callsite.detect.sh
@@ -27,15 +27,32 @@ config_path="$repo_path/.no-deprecated-callsite.eslint.config.mjs"
 
 cd "$repo_path"
 
+detector_log="$(mktemp)"
+
 # Only the temp config is created; nothing else in the tree is mutated.
 cleanup() {
-  rm -f "$config_path"
+  rm -f "$config_path" "$detector_log"
 }
 trap cleanup EXIT
 
+# The scanner captures and discards this script's stderr, so a failure written
+# there alone is invisible in CI logs — which is how this convention reported a
+# clean zero on every scheduled run for weeks. Mirror diagnostics into the job
+# summary when running under GitHub Actions so the reason is actually readable.
+report() {
+  printf '%s\n' "$1" >&2
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    printf '### refactor-tasks: no-deprecated-callsite\n\n```\n%s\n```\n' "$1" \
+      >>"$GITHUB_STEP_SUMMARY"
+  fi
+}
+
 # Bring up the repo's toolchain. No `pnpm add` — the no-deprecated rule ships
 # with the repo's own @typescript-eslint, so the working tree stays clean.
-pnpm install --frozen-lockfile 1>&2
+if ! pnpm install --frozen-lockfile 1>&2; then
+  report "pnpm install --frozen-lockfile failed; cannot lint without the repo toolchain"
+  exit 1
+fi
 
 # Standalone flat config loading only this rule. It lives inside the repo so its
 # imports resolve from the repo's node_modules, and `projectService` discovers
@@ -71,12 +88,36 @@ export NODE_OPTIONS="${NODE_OPTIONS:-} --max-old-space-size=8192"
 # deprecation gives a caller nothing to act on (that gap is the
 # `deprecated-needs-replacement` convention's concern), so drop those here and
 # report only the instances we can actually tell Seer how to fix.
-pnpm exec node "$script_dir/eslint-json-runner.ts" "$repo_path" "$rule" "$config_path" static \
-  | node --input-type=module -e '
+#
+# Run the detector on its own rather than piping it straight into the filter.
+# As a pipeline, a detector that died before writing anything reached the filter
+# as empty input, and the filter's `JSON.parse(data || "[]")` turned that into a
+# valid empty result — so "eslint never ran" and "the codebase is clean" were
+# indistinguishable downstream. Capture the output, then decide.
+if ! raw="$(pnpm exec node "$script_dir/eslint-json-runner.ts" \
+  "$repo_path" "$rule" "$config_path" static 2>"$detector_log")"; then
+  report "detector failed:
+$(cat "$detector_log")"
+  exit 1
+fi
+
+# Mirror the successful run's counts and timing too, not just failures: knowing
+# how close the run came to the scanner's 300s kill is what tells us whether a
+# future empty result was a timeout.
+report "$(cat "$detector_log")"
+
+if [ -z "$raw" ]; then
+  report "detector exited 0 but wrote nothing; refusing to report a clean scan"
+  exit 1
+fi
+
+printf '%s' "$raw" | node --input-type=module -e '
       let data = "";
       process.stdin.on("data", chunk => (data += chunk));
       process.stdin.on("end", () => {
-        const files = JSON.parse(data || "[]");
+        // No `|| "[]"` fallback here: empty input means the detector broke, and
+        // an exception is the signal we want rather than a clean empty result.
+        const files = JSON.parse(data);
         const hasInstruction = m => /is deprecated\.\s*\S/.test(m.message);
         const filtered = files
           .map(f => ({...f, messages: f.messages.filter(hasInstruction)}))


### PR DESCRIPTION
The `no-deprecated-callsite` convention (#119325) has reported 0 violations on every scheduled CI run since it landed (Aug 5, 7, 9, 10), while a local scan of the same commit finds 1608. The rule step consistently finished in ~2.7s — far too fast for a type-aware eslint pass over 6,826 files — meaning eslint was failing at startup, not finding nothing.

Two layers turned that crash into a clean-looking zero:

- `eslint-json-runner.ts` swallowed any `execFileSync` error and fell back to `err.stdout ?? ''`, printing `[]` and exiting 0.
- `no-deprecated-callsite.detect.sh` piped the runner straight into a filter whose `JSON.parse(data || "[]")` turned even empty input into a valid empty result.

So "eslint never ran" and "the codebase is clean" were indistinguishable downstream, and the scanner itself compounds this: it runs detect commands through `execShellPermissive`, which ignores the exit code and discards stderr, so stdout was the only channel either layer could have used to surface a failure — and neither did.

This change makes both layers fail loudly instead:

- The runner now exits non-zero with eslint's exit status, signal, code, and stderr rather than degrading to `[]`. Only eslint exit 0/1 are treated as completed runs.
- A zero-file glob and any `fatal` eslint message are now failures — a fatal means the rule was never evaluated for that file, which would otherwise silently shrink the result set for a type-aware rule.
- Non-JSON stdout is a failure.
- The runner reports files linted, duration, and result counts on stderr.
- The detect script now runs the detector separately from the filter, so a detector failure can't be laundered into `[]` by the filter's fallback, and it guards `pnpm install` the same way.
- Diagnostics are mirrored to `$GITHUB_STEP_SUMMARY`, since it's the only CI-visible channel given `execShellPermissive`'s behavior above.

Verified by running the full scan 3 times end-to-end (1608 violations each time — 1365 in `static/app`, 124 `gsApp`, 119 `gsAdmin`), including once in a clean worktree with a fresh `pnpm install`, and by exercising four failure paths (missing eslint config, unresolvable plugin import, zero-file glob, `$GITHUB_STEP_SUMMARY` write) to confirm each now exits non-zero with diagnostics and empty stdout instead of the old `[]`/exit-0 behavior.

One thing this doesn't fix: the scanner hard-kills a detect command at 300s, and a full pass measures ~190s locally on an M-series Mac. That fits today but leaves thin headroom on a 4-vCPU GitHub runner. The exact CI-side root cause is also still a hypothesis rather than a confirmed diagnosis — these new diagnostics are what will name it on the next scheduled run; a `workflow_dispatch` run would confirm it sooner.
