### PR TITLE
fix(seer): Bypass project eligibility filters for free cohort orgs

### DIFF
--- a/src/sentry/seer/night_shift/delivery.py
+++ b/src/sentry/seer/night_shift/delivery.py
@@ -21,6 +21,7 @@ from sentry.seer.autofix.issue_summary import referrer_map
 from sentry.seer.autofix.utils import (
     AutofixStoppingPoint,
     bulk_read_preferences_from_sentry_db,
+    is_free_cohort_org,
     is_seer_autotriggered_autofix_rate_limited_and_increment,
     is_seer_seat_based_tier_enabled,
 )
@@ -202,6 +203,13 @@ def _process_verdicts(
             else default_stopping_point
             for pid in project_ids
         }
+
+        # Free cohort orgs have no project settings — override to OPEN_PR
+        # so night shift runs produce PRs.
+        if is_free_cohort_org(organization):
+            stopping_point_by_project_id = {
+                pid: AutofixStoppingPoint.OPEN_PR for pid in project_ids
+            }
 
         referrer = referrer_map[SeerAutomationSource.NIGHT_SHIFT]
 

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -664,6 +664,12 @@ def _get_eligible_projects(
     preferences = bulk_read_preferences_from_sentry_db(organization.id, list(project_map))
 
     is_legacy_org = not is_seer_seat_based_tier_enabled(organization)
+    is_free_cohort = is_free_cohort_org(organization)
+    if is_free_cohort:
+        logger.info(
+            "night_shift.free_cohort_project_overrides",
+            extra={"organization_id": organization.id, "num_projects": len(project_map)},
+        )
 
     eligible: list[EligibleProject] = []
     for pid, project in project_map.items():
@@ -671,14 +677,23 @@ def _get_eligible_projects(
         if pref is None:
             continue
         tweaks = get_night_shift_tweaks(project)
-        stopping_point = AutofixStoppingPoint(
-            pref.automated_run_stopping_point or SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT
+        # Free cohort orgs have no project settings configured — override
+        # stopping_point to OPEN_PR so night shift can produce PRs.
+        stopping_point = (
+            AutofixStoppingPoint.OPEN_PR
+            if is_free_cohort
+            else AutofixStoppingPoint(
+                pref.automated_run_stopping_point or SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT
+            )
         )
 
         reasons: list[str] = []
         if not pref.repositories:
             reasons.append("no_connected_repos")
-        if pref.autofix_automation_tuning == AutofixAutomationTuningSettings.OFF:
+        if (
+            not is_free_cohort
+            and pref.autofix_automation_tuning == AutofixAutomationTuningSettings.OFF
+        ):
             reasons.append("automation_tuning_off")
         if source == "cron" and not tweaks.enabled:
             reasons.append("tweaks_disabled")
@@ -709,7 +724,9 @@ def _get_eligible_projects(
                 tweaks=tweaks,
                 stopping_point=stopping_point,
                 connected_repos=[f"{repo.owner}/{repo.name}" for repo in pref.repositories],
-                automation_tuning=pref.autofix_automation_tuning if is_legacy_org else None,
+                automation_tuning=pref.autofix_automation_tuning
+                if is_legacy_org and not is_free_cohort
+                else None,
             )
         )
 

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -10,6 +10,7 @@ from sentry.issues.search import group_types_from
 from sentry.models.group import Group
 from sentry.models.organization import OrganizationStatus
 from sentry.models.project import Project
+from sentry.models.projectrepository import ProjectRepository
 from sentry.processing_errors.grouptype import LowValueSpanConfigurationType
 from sentry.seer.agent.client import SeerAgentClient
 from sentry.seer.autofix.constants import AutofixAutomationTuningSettings
@@ -576,6 +577,38 @@ class TestGetEligibleProjects(NightShiftFixtures, TestCase):
             result = _get_eligible_projects(org, "manual")
 
         assert result[0].automation_tuning is None
+
+    def test_free_cohort_bypasses_automation_tuning_and_stopping_point(self) -> None:
+        """Free cohort projects with default options (automation_tuning=OFF,
+        stopping_point=code_changes) are not filtered out."""
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        # Only set up a repo (via ProjectRepository) — no automation tuning or
+        # stopping point configured, so defaults (OFF / code_changes) apply.
+        repo = self.create_repo(project=project, provider="github", name="owner/proj")
+        ProjectRepository.objects.create(project=project, repository=repo)
+
+        with (
+            patch("sentry.seer.autofix.utils.is_free_cohort_org", return_value=True),
+            patch("sentry.tasks.seer.night_shift.cron.is_free_cohort_org", return_value=True),
+        ):
+            result = _get_eligible_projects(org, "cron")
+
+        assert len(result) == 1
+        assert result[0].project == project
+        assert result[0].stopping_point == AutofixStoppingPoint.OPEN_PR
+
+    @patch("sentry.tasks.seer.night_shift.cron.is_free_cohort_org", return_value=False)
+    def test_paying_org_with_defaults_still_filtered(self, _mock_free_cohort) -> None:
+        """Non-free-cohort org with default options is still filtered out."""
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        repo = self.create_repo(project=project, provider="github", name="owner/proj")
+        self.create_seer_project_repository(project=project, repository=repo)
+
+        result = _get_eligible_projects(org, "manual")
+
+        assert result == []
 
 
 @django_db_all


### PR DESCRIPTION
+ Free cohort orgs have no project-level Seer settings configured, so they inherit defaults (automation_tuning=OFF, stopping_point=code_changes) which cause _get_eligible_projects() to filter out every project.

+ Override at runtime instead of writing project options: skip the automation_tuning_off check and hardcode stopping_point=OPEN_PR for free cohort orgs. No state to clean up if the org starts paying.

