### PR TITLE
fix(autofix): Hide feedback form in UI for multi-repo Autofix runs

### DIFF
--- a/src/sentry/seer/agent/client_models.py
+++ b/src/sentry/seer/agent/client_models.py
@@ -112,6 +112,12 @@ class RepoPRState(BaseModel):
     commit_sha: str | None = None
     pr_creation_status: Literal["creating", "completed", "error"] | None = None
     pr_creation_error: str | None = None
+    # Attributed cause of a push failure, when seer could determine one. Both
+    # values mean the push carried a `.github/workflows/` entry, which the
+    # GitHub App is not allowed to write: "workflow_patch" when the run's own
+    # changes touch a workflow file, "workflow_drift" when the base branch moved
+    # past our pinned commit with a workflow change of someone else's.
+    pr_creation_error_reason: Literal["workflow_patch", "workflow_drift"] | None = None
     title: str | None = None
     description: str | None = None
     integration_id: str | None = None
@@ -275,6 +281,20 @@ class SeerRunState(BaseModel):
 
     class Config:
         extra = "ignore"
+
+    def get_created_pull_request_states(self) -> list[RepoPRState]:
+        """
+        The repos this run actually got a pull request onto.
+
+        ``repo_pr_states`` also holds repos whose push failed, so a plain
+        truthiness check treats a failed run as one that opened PRs — which
+        would, for instance, refuse to re-run a step that stranded nothing.
+        """
+        return [
+            pr_state
+            for pr_state in self.repo_pr_states.values()
+            if pr_state.pr_creation_status != "error"
+        ]
 
     def get_artifacts(self) -> dict[str, Artifact]:
         """

--- a/src/sentry/seer/autofix/pr_iteration/feedback.py
+++ b/src/sentry/seer/autofix/pr_iteration/feedback.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Sequence
 from datetime import datetime
 from typing import Annotated, Any
@@ -16,7 +17,7 @@ from sentry.seer.autofix.pr_iteration.feedback_sources.github_comment import (
     GithubPrReviewCommentFeedbackSource,
 )
 from sentry.seer.autofix.pr_iteration.feedback_sources.user_ui import UserUIFeedbackSource
-from sentry.utils import json
+from sentry.utils import json, metrics
 
 FeedbackSource = Annotated[
     UserUIFeedbackSource
@@ -26,6 +27,8 @@ FeedbackSource = Annotated[
     | CheckSuiteFeedbackSource,
     Field(discriminator="type"),
 ]
+
+logger = logging.getLogger(__name__)
 
 _PARSE_FEEDBACK_ERRORS = (ValidationError, ValueError)
 
@@ -91,6 +94,43 @@ def iteration_is_automated(iteration_blocks: Sequence[MemoryBlock]) -> bool:
     # An iteration with no parseable feedback isn't a human iteration, so treat it
     # as automated (don't let a metadata gap reset the streak).
     return all(feedback.source.is_automated for feedback in feedbacks)
+
+
+def is_multi_repo_run(run_state: SeerRunState) -> bool:
+    """Whether this Autofix run opened PRs in more than one repository.
+
+    PR iteration is single-repository: CI completion, comments, and reviews are
+    all per-repository, while feedback is queued per run. Rather than partially
+    supporting these runs, feedback for them is rejected explicitly (AIML-3278).
+    """
+    return len(run_state.repo_pr_states) > 1
+
+
+def log_multi_repo_rejection(
+    run_state: SeerRunState,
+    *,
+    source: str,
+    organization_id: int,
+    pr_id: int | None = None,
+) -> None:
+    """Record a rejected multi-repo PR-iteration trigger.
+
+    ``run_id``/repo names stay in the log rather than metric tags: the metrics
+    middleware denylists keys ending in ``_id`` and rejects unbounded values.
+    The metric carries only the bounded ``source`` tag.
+    """
+    logger.info(
+        "autofix.pr_iteration.multi_repo_rejected",
+        extra={
+            "run_id": run_state.run_id,
+            "organization_id": organization_id,
+            "repo_count": len(run_state.repo_pr_states),
+            "repo_names": sorted(run_state.repo_pr_states),
+            "source": source,
+            "pr_id": pr_id,
+        },
+    )
+    metrics.incr("autofix.pr_iteration.multi_repo_rejected", tags={"source": source})
 
 
 def automated_iteration_cap_reached(run_state: SeerRunState) -> bool:

--- a/src/sentry/seer/autofix/pr_iteration/listeners/check_suite.py
+++ b/src/sentry/seer/autofix/pr_iteration/listeners/check_suite.py
@@ -16,7 +16,11 @@ from sentry.seer.autofix.pr_iteration.check_suites import (
     confirm_green_check_suite,
     resolve_green_check_suite,
 )
-from sentry.seer.autofix.pr_iteration.feedback import Feedback
+from sentry.seer.autofix.pr_iteration.feedback import (
+    Feedback,
+    is_multi_repo_run,
+    log_multi_repo_rejection,
+)
 from sentry.seer.autofix.pr_iteration.feedback_sources.check_suite import (
     CheckSuiteFeedbackSource,
     MissingCheckSuiteAutofixRun,
@@ -80,6 +84,18 @@ def pr_iteration_from_check_suite_listener(check_suite_event: CheckSuiteEvent):
     repo = autofix_run.repository
     organization_id = repo.organization_id
     agent_state = autofix_run.run_state
+
+    if is_multi_repo_run(agent_state):
+        # Single-repository only: take no action on CI for multi-repo runs —
+        # don't enqueue failure feedback, don't schedule a consume (AIML-3278).
+        log_multi_repo_rejection(
+            agent_state,
+            source="check_suite",
+            organization_id=organization_id,
+            pr_id=autofix_run.pr_id,
+        )
+        return None
+
     feedback = Feedback(source=source)
 
     enqueued = try_enqueue_autofix_feedback(

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -373,7 +373,7 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                 except SeerPermissionError:
                     raise PermissionDenied(SEER_PERMISSION_DENIED)
 
-                if not run_state.repo_pr_states:
+                if not run_state.get_created_pull_request_states():
                     return Response(
                         {"detail": "Cannot iterate on a PR before one has been created"},
                         status=status.HTTP_400_BAD_REQUEST,
@@ -421,7 +421,7 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                             return Response(status=status.HTTP_404_NOT_FOUND)
                         raise PermissionDenied(SEER_PERMISSION_DENIED)
 
-                    if run_state.repo_pr_states or run_state.coding_agents:
+                    if run_state.get_created_pull_request_states() or run_state.coding_agents:
                         return Response(
                             {
                                 "detail": "Cannot re-run a step after a pull request or coding agent has started"

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -59,7 +59,11 @@ from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.autofix.github_perms import (
     get_out_of_date_github_permissions,
 )
-from sentry.seer.autofix.pr_iteration.feedback import Feedback
+from sentry.seer.autofix.pr_iteration.feedback import (
+    Feedback,
+    is_multi_repo_run,
+    log_multi_repo_rejection,
+)
 from sentry.seer.autofix.pr_iteration.queue import (
     peek_queued_autofix_feedback,
     try_enqueue_autofix_feedback,
@@ -379,6 +383,22 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                         status=status.HTTP_400_BAD_REQUEST,
                     )
 
+                if is_multi_repo_run(run_state):
+                    log_multi_repo_rejection(
+                        run_state,
+                        source="ui",
+                        organization_id=group.organization.id,
+                    )
+                    return Response(
+                        {
+                            "detail": (
+                                "PR iteration isn't supported for Autofix runs that opened "
+                                "pull requests in more than one repository"
+                            )
+                        },
+                        status=status.HTTP_400_BAD_REQUEST,
+                    )
+
                 serialized_users = user_service.serialize_many(
                     filter={"user_ids": [request.user.id]},
                 )
@@ -391,6 +411,10 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                     },
                 )
 
+                # UI feedback is not tied to a repository. Fanning it out to
+                # every repo queue would duplicate it (UserUIFeedbackSource has
+                # no consume-time dedupe), so it stays on the run-level queue,
+                # which every consumer reads.
                 try_enqueue_autofix_feedback(
                     run_id=resolved_run_id,
                     organization_id=group.organization.id,

--- a/src/sentry/tasks/seer/pr_iteration.py
+++ b/src/sentry/tasks/seer/pr_iteration.py
@@ -48,7 +48,12 @@ from sentry.seer.autofix.autofix_agent import (
     trigger_autofix_agent,
 )
 from sentry.seer.autofix.constants import AutofixReferrer
-from sentry.seer.autofix.pr_iteration.feedback import Feedback, automated_iteration_cap_reached
+from sentry.seer.autofix.pr_iteration.feedback import (
+    Feedback,
+    automated_iteration_cap_reached,
+    is_multi_repo_run,
+    log_multi_repo_rejection,
+)
 from sentry.seer.autofix.pr_iteration.feedback_sources.base import ConsumeTask
 from sentry.seer.autofix.pr_iteration.feedback_sources.check_suite import CheckSuiteFeedbackSource
 from sentry.seer.autofix.pr_iteration.feedback_sources.github_comment import (
@@ -84,6 +89,16 @@ INELIGIBLE_PR_ITERATION_COMMENT = (
     "created by the Coding Agent handoff and unrelated human PRs."
 )
 
+# Posted when someone iterates on a PR from an Autofix run that opened PRs in
+# more than one repository. PR iteration is single-repository (CI completion,
+# comments, and reviews are all per-repo), so these runs are rejected outright
+# rather than partially iterated (AIML-3278).
+MULTI_REPO_PR_ITERATION_COMMENT = (
+    "PR iteration isn't supported for Autofix runs that opened pull requests in "
+    "more than one repository. This run spans multiple repositories, so feedback "
+    "on this pull request won't be picked up."
+)
+
 # One explanatory comment per PR; further pings still get a :confused: reaction.
 _INELIGIBLE_COMMENT_CACHE_TTL = int(timedelta(days=7).total_seconds())
 
@@ -92,8 +107,10 @@ def _ineligible_comment_cache_key(*, organization_id: int, repo_id: int, pr_numb
     return f"autofix:pr_iteration:ineligible_comment:{organization_id}:{repo_id}:{pr_number}"
 
 
-def _ineligible_pr_iteration_comment_body(github_username: str) -> str:
-    return f"@{github_username}\n\n{INELIGIBLE_PR_ITERATION_COMMENT}"
+def _ineligible_pr_iteration_comment_body(
+    github_username: str, body: str = INELIGIBLE_PR_ITERATION_COMMENT
+) -> str:
+    return f"@{github_username}\n\n{body}"
 
 
 def _get_feedback_referrer(items: list[QueuedAutofixFeedback]) -> AutofixReferrer:
@@ -193,6 +210,13 @@ def consume_queued_autofix_feedback(
         if not queued_items:
             return
 
+        if is_multi_repo_run(state):
+            # Backstop: the triggers reject multi-repo runs, but anything
+            # enqueued before this shipped is already drained off the queue
+            # here — drop it rather than hand it to the agent (AIML-3278).
+            log_multi_repo_rejection(state, source="consume", organization_id=organization_id)
+            return
+
         consumable_items: list[QueuedAutofixFeedback] = []
         feedback_items = []
         # Keyed by (source class, id): issue-comment, review-comment, and review
@@ -203,7 +227,8 @@ def consume_queued_autofix_feedback(
         # (suite id, updated_at). Legacy feedback without updated_at uses suite id.
         seen_check_suite_keys: set[tuple[int, str] | int] = set()
         for item in queued_items:
-            if not item.feedback.source.should_consume(state):
+            source = item.feedback.source
+            if not source.should_consume(state):
                 logger.info(
                     "autofix.pr_iteration.consume_feedback.stale_feedback",
                     extra={
@@ -215,7 +240,6 @@ def consume_queued_autofix_feedback(
 
                 continue
 
-            source = item.feedback.source
             comment_dedupe_id: int | None = None
             if isinstance(
                 source, (GithubPrCommentFeedbackSource, GithubPrReviewCommentFeedbackSource)
@@ -388,6 +412,7 @@ def _comment_pr_iteration_ineligible(
     github_username: str,
     source_type: GithubPrCommentFeedbackType,
     comment_id: int | None,
+    body: str = INELIGIBLE_PR_ITERATION_COMMENT,
 ) -> None:
     """React :confused: and, at most once per PR, explain why iteration didn't run."""
     log_extra = {
@@ -432,7 +457,7 @@ def _comment_pr_iteration_ineligible(
                 client.create_comment(
                     repo_name,
                     str(pr_number),
-                    {"body": _ineligible_pr_iteration_comment_body(github_username)},
+                    {"body": _ineligible_pr_iteration_comment_body(github_username, body)},
                 )
             except Exception:
                 logger.warning(
@@ -561,6 +586,28 @@ def trigger_pr_iteration_from_comment(
             github_username=github_username,
             source_type=source.type,
             comment_id=comment.id,
+        )
+        return None
+
+    if is_multi_repo_run(agent_state):
+        # PR iteration is single-repository; reject rather than partially
+        # iterate on one repo's PR while other repos are mid-flight (AIML-3278).
+        log_multi_repo_rejection(
+            agent_state,
+            source="comment",
+            organization_id=organization_id,
+            pr_id=pr_id,
+        )
+        _comment_pr_iteration_ineligible(
+            client,
+            organization_id=organization_id,
+            repo_id=repo.id,
+            repo_name=repo.name,
+            pr_number=pr_number,
+            github_username=github_username,
+            source_type=source.type,
+            comment_id=comment.id,
+            body=MULTI_REPO_PR_ITERATION_COMMENT,
         )
         return None
 
@@ -822,6 +869,16 @@ def trigger_pr_iteration_from_review(
         logger.info(
             "autofix.pr_iteration.review_trigger.no_run",
             extra={**log_extra, "pr_id": pr_id},
+        )
+        return None
+
+    if is_multi_repo_run(agent_state):
+        # See the comment path: single-repository only, reject explicitly.
+        log_multi_repo_rejection(
+            agent_state,
+            source="review",
+            organization_id=organization_id,
+            pr_id=pr_id,
         )
         return None
 

--- a/static/app/components/events/autofix/useExplorerAutofix.spec.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.spec.tsx
@@ -918,6 +918,58 @@ describe('useExplorerAutofix - startStep pr_iteration', () => {
 
     expect(result.current.runState?.queued_feedback).toHaveLength(1);
   });
+
+  it('keeps the existing run visible when the step is rejected', async () => {
+    MockApiClient.addMockResponse({
+      url: AUTOFIX_URL,
+      method: 'POST',
+      statusCode: 409,
+      body: {detail: 'Cannot re-run a step after a pull request has started'},
+    });
+
+    const {result} = renderHookWithProviders(() => useExplorerAutofix(MOCK_GROUP));
+
+    await waitFor(() => expect(result.current.runState?.run_id).toBe(42));
+
+    await act(async () => {
+      await expect(
+        result.current.startStep('code_changes', {runId: 42, insertIndex: 3})
+      ).rejects.toBeDefined();
+    });
+
+    // The run is untouched server-side, so it must still be readable rather
+    // than replaced by an error-only placeholder.
+    expect(result.current.runState?.run_id).toBe(42);
+    expect(result.current.runState?.status).toBe('processing');
+  });
+
+  it('shows the error when a kickoff has no run to fall back on', async () => {
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: AUTOFIX_URL,
+      method: 'GET',
+      body: {autofix: null},
+    });
+    MockApiClient.addMockResponse({
+      url: AUTOFIX_URL,
+      method: 'POST',
+      statusCode: 500,
+      body: {detail: 'Something broke'},
+    });
+
+    const {result} = renderHookWithProviders(() => useExplorerAutofix(MOCK_GROUP));
+
+    await waitFor(() => expect(result.current.runState).toBeNull());
+
+    await act(async () => {
+      await expect(result.current.startStep('root_cause')).rejects.toBeDefined();
+    });
+
+    expect(result.current.runState?.status).toBe('error');
+    expect(result.current.runState?.blocks[0]?.message.content).toBe(
+      'Error: Something broke'
+    );
+  });
 });
 
 describe('useExplorerAutofix - codingAgentErrors', () => {

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -514,6 +514,21 @@ export function isCodingAgentsSection(section: AutofixSection): boolean {
   return section.step === 'coding_agents';
 }
 
+/**
+ * The repos this run actually got a pull request onto.
+ *
+ * `repo_pr_states` also holds repos whose push failed, so a plain key count
+ * treats a failed run as one that opened PRs — which would, for instance, lock
+ * a step out of being re-run.
+ */
+export function getCreatedPullRequestStates(
+  runState: ExplorerAutofixState | null | undefined
+): RepoPRState[] {
+  return Object.values(runState?.repo_pr_states ?? {}).filter(
+    state => state.pr_creation_status !== 'error'
+  );
+}
+
 export function isRunValidForPrIteration(organization: Organization): boolean {
   return organization.features.includes('autofix-pr-iteration-manual');
 }
@@ -745,12 +760,21 @@ export function useExplorerAutofix(
         setWaitingForResponse(false);
         queryClient.setQueryData(
           explorerAutofixApiOptions(orgSlug, groupId).queryKey,
-          prev => ({
-            headers: prev?.headers ?? {},
-            json: makeErrorExplorerAutofixData(
-              e?.responseJSON?.detail ?? 'An error occurred'
-            ),
-          })
+          prev => {
+            // A step that failed to start left the run untouched, so keep
+            // showing it. Only a kickoff with nothing to fall back on gets
+            // replaced by the error placeholder — otherwise a rejected retry
+            // would blank out a run the user can still read and act on.
+            if (prev?.json?.autofix) {
+              return prev;
+            }
+            return {
+              headers: prev?.headers ?? {},
+              json: makeErrorExplorerAutofixData(
+                e?.responseJSON?.detail ?? 'An error occurred'
+              ),
+            };
+          }
         );
         throw e;
       }

--- a/static/app/components/events/autofix/v3/artifactCard.tsx
+++ b/static/app/components/events/autofix/v3/artifactCard.tsx
@@ -1,4 +1,4 @@
-import {Fragment, type ReactNode} from 'react';
+import {Fragment, type ReactNode, type Ref} from 'react';
 
 import {Button} from '@sentry/scraps/button';
 import {Disclosure} from '@sentry/scraps/disclosure';
@@ -16,6 +16,8 @@ interface ArtifactCardProps {
   allowReset?: boolean;
   onCopy?: () => void;
   onReset?: () => void;
+  /** Lets a card scroll itself into view, e.g. when a banner points at it. */
+  ref?: Ref<HTMLDivElement>;
 }
 
 export function ArtifactCard({
@@ -25,9 +27,16 @@ export function ArtifactCard({
   onCopy,
   allowReset,
   onReset,
+  ref,
 }: ArtifactCardProps) {
   return (
-    <Container border="primary" radius="md" padding="lg" background="primary">
+    <Container
+      ref={ref}
+      border="primary"
+      radius="md"
+      padding="lg"
+      background="primary"
+    >
       <Disclosure defaultExpanded>
         <Disclosure.Title
           trailingItems={

--- a/static/app/components/events/autofix/v3/codeChangesCard.tsx
+++ b/static/app/components/events/autofix/v3/codeChangesCard.tsx
@@ -10,6 +10,7 @@ import {getAutofixRunId} from 'sentry/components/events/autofix/autofixRunId';
 import {
   collectPatches,
   getAutofixArtifactFromSection,
+  getCreatedPullRequestStates,
   isCodeChangesArtifact,
   isPrIterationBlock,
   type AutofixSection,
@@ -101,7 +102,8 @@ export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProp
     [artifact]
   );
 
-  const hasPRs = Object.keys(autofix.runState?.repo_pr_states ?? {}).length > 0;
+  const createdPRs = getCreatedPullRequestStates(autofix.runState);
+  const hasPRs = createdPRs.length > 0;
   const noCodingAgents =
     Object.values(autofix.runState?.coding_agents ?? {}).length === 0;
 
@@ -110,7 +112,7 @@ export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProp
     ? noCodingAgents && (hasPRs || autofix.runState?.status !== 'processing')
     : noCodingAgents && !hasPRs && autofix.runState?.status !== 'processing';
 
-  const {canReset, shouldShowReset, setShouldShowReset, handleReset} =
+  const {cardRef, canReset, shouldShowReset, setShouldShowReset, handleReset} =
     useResetAutofixStep({
       autofix,
       canReset: isResetEligible,
@@ -276,6 +278,7 @@ export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProp
 
   return (
     <ArtifactCard
+      ref={cardRef}
       icon={<IconCode />}
       title={title}
       onCopy={

--- a/static/app/components/events/autofix/v3/codeChangesCard.tsx
+++ b/static/app/components/events/autofix/v3/codeChangesCard.tsx
@@ -104,6 +104,11 @@ export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProp
 
   const createdPRs = getCreatedPullRequestStates(autofix.runState);
   const hasPRs = createdPRs.length > 0;
+  // PR iteration is single-repository. Runs that opened PRs in more than one
+  // repo are rejected by the backend, so don't offer the form (AIML-3278).
+  // Counts created PRs, not `repo_pr_states` entries: a repo whose push failed
+  // never got a PR, so it must not push the run over the single-repo line.
+  const isMultiRepoRun = createdPRs.length > 1;
   const noCodingAgents =
     Object.values(autofix.runState?.coding_agents ?? {}).length === 0;
 
@@ -145,7 +150,7 @@ export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProp
     return t('%s files changed in %s repos', filesChanged.size, reposChanged);
   }, [patchesByRepo]);
 
-  const showPrIterationForm = hasPRs && hasManualPrIterationFeature;
+  const showPrIterationForm = hasPRs && hasManualPrIterationFeature && !isMultiRepoRun;
   const prIterationForm = (
     <PrIterationFeedbackForm
       autofix={autofix}

--- a/static/app/components/events/autofix/v3/drawer.tsx
+++ b/static/app/components/events/autofix/v3/drawer.tsx
@@ -8,6 +8,7 @@ import {useModal} from '@sentry/scraps/modal';
 
 import {AutofixGithubAppPermissionsModal} from 'sentry/components/events/autofix/autofixGithubAppPermissionsModal';
 import {getReferrerFromBlocks} from 'sentry/components/events/autofix/autofixReferrer';
+import type {ExplorerAutofixState} from 'sentry/components/events/autofix/useExplorerAutofix';
 import {
   getAutofixArtifactFromSection,
   getOrderedAutofixSections,
@@ -89,6 +90,7 @@ export function SeerDrawer({group, project}: SeerDrawerProps) {
         />
         <AutofixWarnings warnings={aiAutofix.warnings} groupId={group.id} />
         <WorkflowFileWarning runState={aiAutofix.runState} />
+        <MultiRepoPrIterationWarning runState={aiAutofix.runState} groupId={group.id} />
         <SeerDrawerBody ref={containerRef} onScroll={onScrollHandler}>
           {aiConfig.isAutofixSetupLoading ? (
             <Stack data-test-id="ai-setup-loading-indicator" gap="xl">
@@ -197,6 +199,57 @@ function ConfigurationPermissionsButton() {
     <LinkButton to={configurationUrl} variant="primary" size="xs">
       {t('Update Permissions')}
     </LinkButton>
+  );
+}
+
+export function MultiRepoPrIterationWarning({
+  runState,
+  groupId,
+}: {
+  groupId: string;
+  runState: ExplorerAutofixState | null | undefined;
+}) {
+  const organization = useOrganization();
+  const {dismiss, isDismissed} = useDismissAlert({
+    key: `${organization.id}:${groupId}:autofix-multi-repo-pr-iteration-warning`,
+    expirationDays: 7,
+  });
+
+  // Derived here rather than sent from the backend: the run state the drawer
+  // already has is enough, so no new field has to cross the API boundary.
+  const repoNames = Object.keys(runState?.repo_pr_states ?? {});
+
+  if (repoNames.length <= 1 || isDismissed) {
+    return null;
+  }
+
+  const repoNamesNode = repoNames.map((repoName, index) => (
+    <Fragment key={repoName}>
+      {index > 0 && ', '}
+      <code>{repoName}</code>
+    </Fragment>
+  ));
+
+  return (
+    <Stack gap="md" padding="md 2xl 0">
+      <Alert
+        variant="warning"
+        trailingItems={
+          <Button
+            icon={<IconClose />}
+            variant="transparent"
+            size="xs"
+            aria-label={t('Dismiss')}
+            onClick={dismiss}
+          />
+        }
+      >
+        {tct(
+          "This fix opened pull requests in [repoNames]. Seer can't iterate on pull requests from a run that spans multiple repositories, so feedback on them won't be picked up.",
+          {repoNames: repoNamesNode}
+        )}
+      </Alert>
+    </Stack>
   );
 }
 

--- a/static/app/components/events/autofix/v3/drawer.tsx
+++ b/static/app/components/events/autofix/v3/drawer.tsx
@@ -16,7 +16,9 @@ import {
 import {SeerDrawerBody} from 'sentry/components/events/autofix/v3/body';
 import {SeerDrawerContent} from 'sentry/components/events/autofix/v3/content';
 import {SeerDrawerHeader} from 'sentry/components/events/autofix/v3/header';
+import {RetryStepProvider} from 'sentry/components/events/autofix/v3/retryStepContext';
 import {artifactToMarkdown} from 'sentry/components/events/autofix/v3/utils';
+import {WorkflowFileWarning} from 'sentry/components/events/autofix/v3/workflowFileWarning';
 import {Placeholder} from 'sentry/components/placeholder';
 import {IconClose} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
@@ -69,32 +71,37 @@ export function SeerDrawer({group, project}: SeerDrawerProps) {
   });
 
   return (
-    <Stack
-      className="seer-drawer-container"
-      position="relative"
-      height="100%"
-      overflowY="hidden"
-      background="secondary"
-    >
-      <SeerDrawerHeader
-        onCopyMarkdown={handleCopyMarkdown}
-        onOpenSeerAgent={handleOpenSeerAgent}
-        onReset={handleRestart}
-        referrer={referrer}
-      />
-      <AutofixWarnings warnings={aiAutofix.warnings} groupId={group.id} />
-      <SeerDrawerBody ref={containerRef} onScroll={onScrollHandler}>
-        {aiConfig.isAutofixSetupLoading ? (
-          <Stack data-test-id="ai-setup-loading-indicator" gap="xl">
-            <Placeholder height="10rem" />
-            <Placeholder height="15rem" />
-            <Placeholder height="15rem" />
-          </Stack>
-        ) : (
-          <SeerDrawerContent group={group} autofix={aiAutofix} aiConfig={aiConfig} />
-        )}
-      </SeerDrawerBody>
-    </Stack>
+    // The workflow-file banner points the user at the code changes card's retry
+    // prompt, so both live under the same provider.
+    <RetryStepProvider>
+      <Stack
+        className="seer-drawer-container"
+        position="relative"
+        height="100%"
+        overflowY="hidden"
+        background="secondary"
+      >
+        <SeerDrawerHeader
+          onCopyMarkdown={handleCopyMarkdown}
+          onOpenSeerAgent={handleOpenSeerAgent}
+          onReset={handleRestart}
+          referrer={referrer}
+        />
+        <AutofixWarnings warnings={aiAutofix.warnings} groupId={group.id} />
+        <WorkflowFileWarning runState={aiAutofix.runState} />
+        <SeerDrawerBody ref={containerRef} onScroll={onScrollHandler}>
+          {aiConfig.isAutofixSetupLoading ? (
+            <Stack data-test-id="ai-setup-loading-indicator" gap="xl">
+              <Placeholder height="10rem" />
+              <Placeholder height="15rem" />
+              <Placeholder height="15rem" />
+            </Stack>
+          ) : (
+            <SeerDrawerContent group={group} autofix={aiAutofix} aiConfig={aiConfig} />
+          )}
+        </SeerDrawerBody>
+      </Stack>
+    </RetryStepProvider>
   );
 }
 

--- a/static/app/components/events/autofix/v3/retryStepContext.tsx
+++ b/static/app/components/events/autofix/v3/retryStepContext.tsx
@@ -1,0 +1,42 @@
+import {createContext, useContext, useMemo, useState, type ReactNode} from 'react';
+
+import type {AutofixExplorerStep} from 'sentry/components/events/autofix/useExplorerAutofix';
+
+type RetryStepContextValue = {
+  clearRequest: () => void;
+  requestRetry: (step: AutofixExplorerStep) => void;
+  requestedStep: AutofixExplorerStep | null;
+};
+
+const RetryStepContext = createContext<RetryStepContextValue | null>(null);
+
+/**
+ * Lets something outside a step's card — a drawer-level banner, say — ask that
+ * card to open its retry prompt, instead of silently re-running the step.
+ *
+ * The request is a one-shot signal: the card that owns the step opens and
+ * scrolls to its retry prompt, then clears the request so the user's own
+ * dismissal sticks.
+ */
+export function RetryStepProvider({children}: {children: ReactNode}) {
+  const [requestedStep, setRequestedStep] = useState<AutofixExplorerStep | null>(null);
+
+  const value = useMemo(
+    () => ({
+      requestedStep,
+      requestRetry: setRequestedStep,
+      clearRequest: () => setRequestedStep(null),
+    }),
+    [requestedStep]
+  );
+
+  return <RetryStepContext value={value}>{children}</RetryStepContext>;
+}
+
+/**
+ * Null outside a provider, so cards and banners rendered on their own (stories,
+ * tests) keep working without one.
+ */
+export function useRetryStep() {
+  return useContext(RetryStepContext);
+}

--- a/static/app/components/events/autofix/v3/useResetAutofixStep.spec.tsx
+++ b/static/app/components/events/autofix/v3/useResetAutofixStep.spec.tsx
@@ -1,9 +1,18 @@
-import {act, renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
+import {
+  act,
+  renderHookWithProviders,
+  screen,
+  userEvent,
+} from 'sentry-test/reactTestingLibrary';
 
 import type {
   AutofixSection,
   useExplorerAutofix,
 } from 'sentry/components/events/autofix/useExplorerAutofix';
+import {
+  RetryStepProvider,
+  useRetryStep,
+} from 'sentry/components/events/autofix/v3/retryStepContext';
 import {useResetAutofixStep} from 'sentry/components/events/autofix/v3/useResetAutofixStep';
 
 function makeAutofix(
@@ -248,6 +257,105 @@ describe('useResetAutofixStep', () => {
         insertIndex: 1,
       });
     });
+  });
+
+  describe('external retry requests', () => {
+    const scrollIntoView = jest.fn();
+
+    beforeEach(() => {
+      scrollIntoView.mockClear();
+      // jsdom has no layout, so scrollIntoView is not implemented on elements.
+      Element.prototype.scrollIntoView = scrollIntoView;
+    });
+
+    function renderWithBanner(step: 'root_cause' | 'code_changes') {
+      const autofix = makeAutofix({
+        runState: {
+          run_id: 1,
+          status: 'completed',
+          blocks: [],
+          updated_at: '2024-01-01T00:00:00Z',
+          repo_pr_states: {},
+          coding_agents: {},
+        },
+      });
+
+      // A banner outside the card asks for the code changes step to be retried.
+      function Banner() {
+        const retryStep = useRetryStep();
+        return (
+          <button onClick={() => retryStep?.requestRetry('code_changes')}>request</button>
+        );
+      }
+
+      const rendered = renderHookWithProviders(
+        () => useResetAutofixStep({autofix, section: makeSection(), step}),
+        {
+          additionalWrapper: ({children}) => (
+            <RetryStepProvider>
+              <Banner />
+              {children}
+            </RetryStepProvider>
+          ),
+        }
+      );
+
+      return {...rendered, autofix};
+    }
+
+    it('opens and scrolls to the prompt when its own step is requested', async () => {
+      const {result, autofix} = renderWithBanner('code_changes');
+
+      // The hook's ref is only attached once a card renders it.
+      result.current.cardRef.current = document.createElement('div');
+
+      await userEvent.click(screen.getByRole('button', {name: 'request'}));
+
+      expect(result.current.shouldShowReset).toBe(true);
+      expect(scrollIntoView).toHaveBeenCalled();
+      // Requesting a retry must not start the step on the user's behalf.
+      expect(autofix.startStep).not.toHaveBeenCalled();
+    });
+
+    it('ignores a request aimed at another step', async () => {
+      const {result} = renderWithBanner('root_cause');
+
+      await userEvent.click(screen.getByRole('button', {name: 'request'}));
+
+      expect(result.current.shouldShowReset).toBe(false);
+      expect(scrollIntoView).not.toHaveBeenCalled();
+    });
+  });
+
+  it('stays resettable when a push failed instead of opening a PR', () => {
+    const autofix = makeAutofix({
+      runState: {
+        run_id: 1,
+        status: 'completed',
+        blocks: [],
+        updated_at: '2024-01-01T00:00:00Z',
+        repo_pr_states: {
+          'repo-1': {
+            repo_name: 'repo-1',
+            branch_name: 'fix/branch',
+            commit_sha: 'abc123',
+            pr_creation_error: 'Resource not accessible by integration',
+            pr_creation_status: 'error',
+            pr_id: null,
+            pr_number: null,
+            pr_url: null,
+            title: 'Fix bug',
+          },
+        },
+        coding_agents: {},
+      },
+    });
+
+    const {result} = renderHookWithProviders(() =>
+      useResetAutofixStep({autofix, section: makeSection(), step: 'code_changes'})
+    );
+
+    expect(result.current.canReset).toBe(true);
   });
 
   describe('state management', () => {

--- a/static/app/components/events/autofix/v3/useResetAutofixStep.tsx
+++ b/static/app/components/events/autofix/v3/useResetAutofixStep.tsx
@@ -1,12 +1,14 @@
-import {useMemo, useState} from 'react';
+import {useEffect, useMemo, useRef, useState} from 'react';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {getAutofixRunId} from 'sentry/components/events/autofix/autofixRunId';
 import {
+  getCreatedPullRequestStates,
   type AutofixExplorerStep,
   type AutofixSection,
   type useExplorerAutofix,
 } from 'sentry/components/events/autofix/useExplorerAutofix';
+import {useRetryStep} from 'sentry/components/events/autofix/v3/retryStepContext';
 import {t} from 'sentry/locale';
 
 interface UseResetAutofixStepOptions {
@@ -23,11 +25,12 @@ export function useResetAutofixStep({
   step,
 }: UseResetAutofixStepOptions) {
   const [shouldShowReset, setShouldShowReset] = useState(false);
+  const cardRef = useRef<HTMLDivElement>(null);
 
   const {runState, startStep} = autofix;
   const runId = getAutofixRunId(runState);
   const notProcessing = autofix.runState?.status !== 'processing';
-  const noPRs = Object.values(autofix.runState?.repo_pr_states ?? {}).length === 0;
+  const noPRs = getCreatedPullRequestStates(autofix.runState).length === 0;
   const noCodingAgents =
     Object.values(autofix.runState?.coding_agents ?? {}).length === 0;
   const defaultCanReset = notProcessing && noPRs && noCodingAgents;
@@ -48,7 +51,29 @@ export function useResetAutofixStep({
     };
   }, [startStep, step, runId, section.index]);
 
+  // Something outside this card (the drawer's workflow-file banner, today) can
+  // ask for this step's retry prompt. Open it and bring it into view rather
+  // than re-running the step behind the user's back.
+  const retryStep = useRetryStep();
+  const isRetryRequested = retryStep?.requestedStep === step;
+  const clearRetryRequest = retryStep?.clearRequest;
+
+  useEffect(() => {
+    if (!isRetryRequested) {
+      return;
+    }
+    clearRetryRequest?.();
+    if (!isResetEligible) {
+      return;
+    }
+    setShouldShowReset(true);
+    // The prompt autofocuses its textarea once mounted; scrolling the whole
+    // card into view keeps the surrounding context visible with it.
+    cardRef.current?.scrollIntoView({behavior: 'smooth', block: 'center'});
+  }, [isRetryRequested, clearRetryRequest, isResetEligible]);
+
   return {
+    cardRef,
     canReset:
       // can only reset if reset prompt is not showing
       !shouldShowReset && isResetEligible,

--- a/static/app/components/events/autofix/v3/workflowFileWarning.spec.tsx
+++ b/static/app/components/events/autofix/v3/workflowFileWarning.spec.tsx
@@ -1,0 +1,121 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import type {ExplorerAutofixState} from 'sentry/components/events/autofix/useExplorerAutofix';
+import {
+  RetryStepProvider,
+  useRetryStep,
+} from 'sentry/components/events/autofix/v3/retryStepContext';
+import {WorkflowFileWarning} from 'sentry/components/events/autofix/v3/workflowFileWarning';
+import type {RepoPRState} from 'sentry/views/seerExplorer/types';
+
+const makeRepoPRState = (overrides: Partial<RepoPRState> = {}): RepoPRState => ({
+  repo_name: 'getsentry/sentry',
+  branch_name: 'seer/fix',
+  commit_sha: null,
+  pr_creation_error: 'resource forbidden',
+  pr_creation_status: 'error',
+  pr_creation_error_reason: 'workflow_patch',
+  pr_id: null,
+  pr_number: null,
+  pr_url: null,
+  title: 'Fix the thing',
+  ...overrides,
+});
+
+type Block = ExplorerAutofixState['blocks'][number];
+
+const makeBlock = (step: string): Block =>
+  ({
+    id: 'block-1',
+    timestamp: '2026-08-10T00:00:00Z',
+    loading: false,
+    message: {role: 'assistant', content: '', metadata: {step}},
+  }) as unknown as Block;
+
+const makeRunState = (
+  repoPRStates: Record<string, RepoPRState>,
+  blocks: Block[] = []
+): ExplorerAutofixState => ({
+  run_id: 7,
+  blocks,
+  status: 'error',
+  updated_at: '2026-08-10T00:00:00Z',
+  repo_pr_states: repoPRStates,
+});
+
+// Stands in for the code changes card: reports what step the banner asked to
+// retry, without pulling the whole card into the test.
+function RequestedStep() {
+  const retryStep = useRetryStep();
+  return <div>requested: {retryStep?.requestedStep ?? 'none'}</div>;
+}
+
+describe('WorkflowFileWarning', () => {
+  const organization = OrganizationFixture();
+
+  it('renders nothing when no push failed on a workflow file', () => {
+    const {container} = render(
+      <WorkflowFileWarning
+        runState={makeRunState({
+          'getsentry/sentry': makeRepoPRState({
+            pr_creation_status: 'completed',
+            pr_creation_error_reason: null,
+          }),
+        })}
+      />,
+      {organization}
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('explains that Seer cannot write workflow files it edited', () => {
+    render(
+      <WorkflowFileWarning
+        runState={makeRunState({'getsentry/sentry': makeRepoPRState()})}
+      />,
+      {organization}
+    );
+
+    expect(
+      screen.getByText(/they edit GitHub Actions workflow files/)
+    ).toBeInTheDocument();
+  });
+
+  it('explains base branch drift without blaming the run', () => {
+    render(
+      <WorkflowFileWarning
+        runState={makeRunState({
+          'getsentry/sentry': makeRepoPRState({
+            pr_creation_error_reason: 'workflow_drift',
+          }),
+        })}
+      />,
+      {organization}
+    );
+
+    expect(screen.getByText(/the base branch picked up/)).toBeInTheDocument();
+  });
+
+  it('asks the code changes card to open its retry prompt', async () => {
+    render(
+      <RetryStepProvider>
+        <WorkflowFileWarning
+          runState={makeRunState({'getsentry/sentry': makeRepoPRState()}, [
+            makeBlock('code_changes'),
+          ])}
+        />
+        <RequestedStep />
+      </RetryStepProvider>,
+      {organization}
+    );
+
+    expect(screen.getByText('requested: none')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Retry'}));
+
+    expect(screen.getByText('requested: code_changes')).toBeInTheDocument();
+  });
+});

--- a/static/app/components/events/autofix/v3/workflowFileWarning.tsx
+++ b/static/app/components/events/autofix/v3/workflowFileWarning.tsx
@@ -1,0 +1,86 @@
+import {Alert} from '@sentry/scraps/alert';
+import {Button} from '@sentry/scraps/button';
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import type {ExplorerAutofixState} from 'sentry/components/events/autofix/useExplorerAutofix';
+import {useRetryStep} from 'sentry/components/events/autofix/v3/retryStepContext';
+import {t} from 'sentry/locale';
+
+/**
+ * Seer's GitHub App deliberately has no `workflows` permission, so any push
+ * whose tree carries a `.github/workflows/` entry is rejected by GitHub — even
+ * when the rest of the change is fine. Seer attributes such a failure on the
+ * repo's PR state (`pr_creation_error_reason`), and this banner turns that into
+ * something the user can act on:
+ *
+ * - `workflow_patch`: Seer itself edited a workflow file. Seer cannot make that
+ *   edit at all, so the user has to either let Seer retry without touching
+ *   workflows, or make the workflow change by hand. The offending files are
+ *   already visible in the code changes, so the banner doesn't repeat them.
+ * - `workflow_drift`: Seer's changes are clean, but the base branch moved past
+ *   the commit Seer pinned and the newer commits touched a workflow file.
+ *   Retrying re-pins to the current tip, which is usually enough.
+ *
+ * Retry doesn't re-run the step on its own: the user has to say what Seer
+ * should do differently, so it opens the code changes card's retry prompt (or
+ * the PR iteration form, whichever that card is showing) and scrolls to it.
+ */
+
+function getWorkflowFailureReason(
+  runState: ExplorerAutofixState | null | undefined
+): 'workflow_patch' | 'workflow_drift' | null {
+  for (const state of Object.values(runState?.repo_pr_states ?? {})) {
+    if (state.pr_creation_status !== 'error') {
+      continue;
+    }
+    // zLooseEnum widens unknown values to string, so narrow explicitly.
+    if (state.pr_creation_error_reason === 'workflow_patch') {
+      return 'workflow_patch';
+    }
+    if (state.pr_creation_error_reason === 'workflow_drift') {
+      return 'workflow_drift';
+    }
+  }
+  return null;
+}
+
+export function WorkflowFileWarning({runState}: {runState?: ExplorerAutofixState | null}) {
+  const retryStep = useRetryStep();
+  const reason = getWorkflowFailureReason(runState);
+
+  if (!reason) {
+    return null;
+  }
+
+  // Deliberately not dismissible: the run is in a failed state, and hiding the
+  // banner would leave no explanation for why nothing was pushed.
+  return (
+    <Stack gap="md" padding="md 2xl 0">
+      <Alert
+        variant="warning"
+        trailingItems={
+          <Flex alignSelf="center">
+            <Button
+              variant="primary"
+              size="xs"
+              onClick={() => retryStep?.requestRetry('code_changes')}
+            >
+              {t('Retry')}
+            </Button>
+          </Flex>
+        }
+      >
+        <Text>
+          {reason === 'workflow_patch'
+            ? t(
+                "Seer couldn't push its changes because they edit GitHub Actions workflow files, which Seer isn't allowed to write. Retry and ask for the fix without them, or make the workflow changes yourself."
+              )
+            : t(
+                "Seer couldn't push its changes: the base branch picked up GitHub Actions workflow file changes after Seer started, and Seer isn't allowed to write those files. Retry to start again from the current branch tip."
+              )}
+        </Text>
+      </Alert>
+    </Stack>
+  );
+}

--- a/static/app/views/seerExplorer/types.tsx
+++ b/static/app/views/seerExplorer/types.tsx
@@ -29,6 +29,11 @@ const repoPRStateSchema = z.object({
   branch_name: z.string().nullable(),
   commit_sha: z.string().nullable(),
   pr_creation_error: z.string().nullable(),
+  // Optional: absent on runs whose state was written before seer attributed
+  // push failures, so a missing field must not fail the type guard.
+  pr_creation_error_reason: zLooseEnum(['workflow_patch', 'workflow_drift'])
+    .nullish()
+    .optional(),
   pr_creation_status: zLooseEnum(['creating', 'completed', 'error']).nullable(),
   pr_id: z.number().nullable(),
   pr_number: z.number().nullable(),

--- a/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
@@ -80,6 +80,20 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
             metadata={"group_id": self.group.id},
         )
 
+    def _multi_repo_state(self) -> SeerRunState:
+        """A run that opened PRs in more than one repo — rejected by PR iteration."""
+        return SeerRunState(
+            run_id=67890,
+            blocks=[],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+            repo_pr_states={
+                "owner/repo": RepoPRState(repo_name="owner/repo", commit_sha="abc", pr_number=42),
+                "owner/other": RepoPRState(repo_name="owner/other", commit_sha="def", pr_number=43),
+            },
+            metadata={"group_id": self.group.id},
+        )
+
     @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
     def test_skips_non_completed_action(self, mock_get_state: MagicMock) -> None:
         pr_iteration_from_check_suite_listener(self._event(action="requested"))
@@ -330,6 +344,30 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         assert autofix.repository.id == 2
         assert autofix.run_state is not None
         mock_trigger_consume.assert_called_once()
+        mock_assign.assert_not_called()
+
+    @patch(f"{CHECK_PATH}.assign_user_for_exhausted_cap")
+    @patch(TRIGGER_CONSUME_PATH)
+    @patch(f"{CHECK_PATH}.try_enqueue_autofix_feedback")
+    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITES_PATH}.resolve_check_suite_repositories")
+    def test_takes_no_action_for_multi_repo_run(
+        self,
+        mock_resolve: MagicMock,
+        mock_get_state: MagicMock,
+        mock_enqueue: MagicMock,
+        mock_trigger_consume: MagicMock,
+        mock_assign: MagicMock,
+    ) -> None:
+        """Single-repository only: no enqueue, no consume, and no cap hand-off."""
+        mock_resolve.return_value = [MagicMock(organization_id=self.organization.id, id=2)]
+        mock_get_state.return_value = self._multi_repo_state()
+        raw = self._raw(pull_requests=[{"id": 555}])
+
+        pr_iteration_from_check_suite_listener(self._event(raw))
+
+        mock_enqueue.assert_not_called()
+        mock_trigger_consume.assert_not_called()
         mock_assign.assert_not_called()
 
     @patch(f"{CHECK_SUITES_PATH}.sentry_sdk.capture_exception")

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -406,6 +406,40 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
 
     @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
     @patch("sentry.seer.endpoints.group_ai_autofix.get_autofix_run_state")
+    def test_insert_index_allowed_when_pr_creation_failed(
+        self, mock_run_state, mock_trigger_explorer
+    ):
+        """A push that failed stranded no PR, so the re-run is allowed."""
+        group = self.create_group()
+        mock_trigger_explorer.return_value = self.create_seer_run(
+            organization=self.organization, seer_run_state_id=42
+        )
+        mock_run_state.return_value = SeerRunState(
+            run_id=42,
+            blocks=[],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+            repo_pr_states={
+                "owner/repo": RepoPRState(
+                    repo_name="owner/repo",
+                    pr_creation_status="error",
+                    pr_creation_error_reason="workflow_patch",
+                )
+            },
+        )
+
+        self.login_as(user=self.user)
+        response = self.client.post(
+            self._get_url(group.id),
+            data={"step": "code_changes", "run_id": 42, "insert_index": 3},
+            format="json",
+        )
+
+        assert response.status_code == 202, response.data
+        mock_trigger_explorer.assert_called_once()
+
+    @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
+    @patch("sentry.seer.endpoints.group_ai_autofix.get_autofix_run_state")
     def test_insert_index_unknown_run_returns_404(self, mock_run_state, mock_trigger_explorer):
         """The re-run guard surfaces an unknown run as 404, not 403."""
         group = self.create_group()

--- a/tests/sentry/tasks/seer/test_pr_iteration.py
+++ b/tests/sentry/tasks/seer/test_pr_iteration.py
@@ -8,7 +8,11 @@ from sentry.seer.autofix.autofix_agent import (
 )
 from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.autofix.pr_iteration.check_suites import CheckSuiteAutofixRun
-from sentry.seer.autofix.pr_iteration.feedback import Feedback, serialize_feedback
+from sentry.seer.autofix.pr_iteration.feedback import (
+    Feedback,
+    is_multi_repo_run,
+    serialize_feedback,
+)
 from sentry.seer.autofix.pr_iteration.feedback_sources.base import ConsumeTask
 from sentry.seer.autofix.pr_iteration.feedback_sources.check_suite import (
     CheckSuiteFeedbackSource,
@@ -1101,3 +1105,67 @@ class DeleteOwnCommentEyesReactionTest(TestCase):
         )
 
         mock_scm_actions.delete_pull_request_comment_reaction.assert_not_called()
+
+
+class MultiRepoRejectionTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.group = self.create_group(project=self.project)
+
+    def _state(self, repos: list[str]) -> SeerRunState:
+        return SeerRunState(
+            run_id=67890,
+            blocks=[],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+            repo_pr_states={name: RepoPRState(repo_name=name, commit_sha="abc") for name in repos},
+            metadata={"group_id": self.group.id},
+        )
+
+    def _ui_feedback(self) -> QueuedAutofixFeedback:
+        return QueuedAutofixFeedback(
+            organization_id=self.organization.id,
+            group_id=self.group.id,
+            feedback=Feedback(source=UserUIFeedbackSource(user_id=1, user_feedback="fix it")),
+            referrer=AutofixReferrer.WEB,
+        )
+
+    def test_single_repo_run_is_not_multi_repo(self) -> None:
+        assert is_multi_repo_run(self._state(["owner/a"])) is False
+
+    def test_two_repos_is_multi_repo(self) -> None:
+        assert is_multi_repo_run(self._state(["owner/a", "owner/b"])) is True
+
+    @patch(f"{TASK_PATH}.trigger_autofix_agent")
+    @patch(f"{TASK_PATH}.pop_queued_autofix_feedback")
+    @patch(f"{TASK_PATH}.fetch_run_status")
+    def test_consume_drops_queued_feedback_for_multi_repo_run(
+        self,
+        mock_fetch: MagicMock,
+        mock_pop: MagicMock,
+        mock_trigger: MagicMock,
+    ) -> None:
+        mock_fetch.return_value = self._state(["owner/a", "owner/b"])
+        mock_pop.return_value = [self._ui_feedback()]
+
+        consume_queued_autofix_feedback(run_id=67890, organization_id=self.organization.id)
+
+        # pop_* already drained it off the queue; it must not reach the agent.
+        mock_pop.assert_called_once_with(67890)
+        mock_trigger.assert_not_called()
+
+    @patch(f"{TASK_PATH}.trigger_autofix_agent")
+    @patch(f"{TASK_PATH}.pop_queued_autofix_feedback")
+    @patch(f"{TASK_PATH}.fetch_run_status")
+    def test_consume_still_processes_single_repo_run(
+        self,
+        mock_fetch: MagicMock,
+        mock_pop: MagicMock,
+        mock_trigger: MagicMock,
+    ) -> None:
+        mock_fetch.return_value = self._state(["owner/a"])
+        mock_pop.return_value = [self._ui_feedback()]
+
+        consume_queued_autofix_feedback(run_id=67890, organization_id=self.organization.id)
+
+        mock_trigger.assert_called_once()


### PR DESCRIPTION

matching the UI to the backend change this is stacked on top of
we don't show the feedback form when the FE detects it's on a multi-repo autofix run
since we don't support routing feedback to the correct repo currently

also it's obvious: since the BE doesn't support it, the FE should match and not
give the user the option to pass feedback