### PR TITLE
ref(notifications): Seer activity alerts link to issue inbox if available

### DIFF
--- a/src/sentry/notifications/platform/templates/activity/base.py
+++ b/src/sentry/notifications/platform/templates/activity/base.py
@@ -1,6 +1,7 @@
 from typing import Any
 from urllib.parse import urlencode
 
+from sentry import features
 from sentry.models.activity import Activity
 from sentry.models.commit import Commit
 from sentry.models.group import Group
@@ -181,15 +182,20 @@ def build_activity_notification_data(
         except Workflow.DoesNotExist:
             raise ValueError(f"Workflow not found: {workflow_id}")
 
-    issue_url_params: dict[str, str] = {}
+    issue_url = group.get_absolute_url()
     if ActivityType(activity.type) in SEER_ACTIVITY_TYPES:
-        issue_url_params.update({"seerDrawer": "true"})
+        issue_url = group.get_absolute_url(params={"seerDrawer": "true"})
+        if features.has("organizations:issue-stream-progress-ui", organization):
+            issue_url = organization.absolute_url(
+                f"organizations/{organization.slug}/issues/inbox/",
+                query=urlencode({"project": project.id, "preview": group.id}),
+            )
 
     action_data = dict(
         source=source,
         activity_type=activity.type,
         issue_short_id=group.qualified_short_id,
-        issue_url=absolute_uri(group.get_absolute_url(params=issue_url_params)),
+        issue_url=absolute_uri(issue_url),
         issue_title=build_attachment_title(group) or "",
         issue_culprit=group.culprit,
         issue_description=build_attachment_text(group),

--- a/tests/sentry/notifications/platform/templates/test_activity.py
+++ b/tests/sentry/notifications/platform/templates/test_activity.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlencode
+
 from sentry.notifications.platform.target import GenericNotificationTarget
 from sentry.notifications.platform.templates.activity.base import (
     ACTIVITY_TYPE_TO_SOURCE,
@@ -26,6 +28,7 @@ from sentry.notifications.platform.types import (
     NotificationTextBlockType,
 )
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.features import with_feature
 from sentry.types.activity import ActivityType
 from sentry.utils.http import absolute_uri
 
@@ -196,6 +199,28 @@ class ActivityAlertBaseTest(TestCase):
         data = build_activity_notification_data(activity, target=target)
 
         assert data.user_settings_url is None
+
+    @with_feature("organizations:issue-stream-progress-ui")
+    def test_build_activity_notification_data_seer_activity_inbox_url(self) -> None:
+        activity = self.create_group_activity(
+            group=self.group, type=ActivityType.SEER_RCA_STARTED.value
+        )
+        data = build_activity_notification_data(activity)
+
+        expected_inbox_url = self.organization.absolute_url(
+            f"organizations/{self.organization.slug}/issues/inbox/",
+            query=urlencode({"project": self.project.id, "preview": self.group.id}),
+        )
+        assert absolute_uri(expected_inbox_url) == data.issue_url
+
+    @with_feature("organizations:issue-stream-progress-ui")
+    def test_build_activity_notification_data_non_seer_activity_uses_issue_url(self) -> None:
+        activity = self.create_group_activity(
+            group=self.group, type=ActivityType.SET_RESOLVED.value
+        )
+        data = build_activity_notification_data(activity)
+
+        assert absolute_uri(self.group.get_absolute_url()) == data.issue_url
 
 
 class ActivitySeerAlertBaseTest(TestCase):


### PR DESCRIPTION
If the organization has access to the inbox feature, swap the link to that view instead of the autofix drawer on the issue details page. 

Adds some tests for that as well.