### PR TITLE
fix(replays): don't discard a whole segment over one malformed click

### DIFF
--- a/src/sentry/replays/usecases/ingest/event_parser.py
+++ b/src/sentry/replays/usecases/ingest/event_parser.py
@@ -680,6 +680,13 @@ def as_string_strict(value: Any) -> str:
     raise ValueError("Value was not a string.")
 
 
+def as_int_or_none(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
 T = TypeVar("T")
 
 
@@ -740,7 +747,7 @@ def parse_highlighted_event(
     """Attempt to parse an event to a highlighted event."""
     try:
         return as_highlighted_event(event, event_type, sampled)
-    except (AssertionError, AttributeError, KeyError, TypeError):
+    except (AssertionError, AttributeError, KeyError, TypeError, ValueError):
         logger.warning(
             "[EVENT PARSE FAIL] Could not parse identified event.",
             exc_info=True,
@@ -819,9 +826,13 @@ def parse_network_content_lengths(event: dict[str, Any]) -> tuple[int | None, in
 
 
 def parse_tap_event(payload: dict[str, Any]) -> TapEvent | None:
+    timestamp = as_int_or_none(payload.get("timestamp"))
+    if timestamp is None:
+        return None
+
     payload_data = payload.get("data", {})
     return TapEvent(
-        timestamp=int(payload["timestamp"]),
+        timestamp=timestamp,
         message=payload.get("message", ""),
         view_class=payload_data.get("view.class", ""),
         view_id=payload_data.get("view.id", ""),
@@ -832,6 +843,10 @@ def parse_click_event(payload: dict[str, Any], is_dead: bool, is_rage: bool) -> 
     node = payload["data"].get("node")
 
     if not isinstance(node, dict) or node.get("id", -1) < 0:
+        return None
+
+    timestamp = as_int_or_none(payload.get("timestamp"))
+    if timestamp is None:
         return None
 
     attributes = node.get("attributes", {})
@@ -850,7 +865,7 @@ def parse_click_event(payload: dict[str, Any], is_dead: bool, is_rage: bool) -> 
         tag=node["tagName"][:32],
         testid=_get_testid(attributes)[:64],
         text=node["textContent"][:1024],
-        timestamp=int(payload["timestamp"]),
+        timestamp=timestamp,
         title=attributes.get("title", "")[:64],
         url=payload["data"].get("url"),
     )

--- a/tests/sentry/replays/unit/test_event_parser.py
+++ b/tests/sentry/replays/unit/test_event_parser.py
@@ -389,6 +389,56 @@ def test_parse_highlighted_events_click_events_missing_node() -> None:
     assert len(builder.result.click_events) == 0
 
 
+def test_parse_highlighted_events_click_events_scrubbed_timestamp() -> None:
+    event = {
+        "type": 5,
+        "timestamp": 1674298825,
+        "data": {
+            "tag": "breadcrumb",
+            "payload": {
+                "timestamp": "[Filtered]",
+                "type": "default",
+                "category": "ui.click",
+                "message": "div#hello.hello.world",
+                "data": {
+                    "nodeId": 1,
+                    "node": {
+                        "id": 1,
+                        "tagName": "div",
+                        "attributes": {"id": "hello"},
+                        "textContent": "Hello, world!",
+                    },
+                },
+            },
+        },
+    }
+
+    builder = HighlightedEventsBuilder()
+    builder.add(which(event), event, sampled=False)
+    assert len(builder.result.click_events) == 0
+
+
+def test_parse_highlighted_events_with_tap_event_scrubbed_timestamp() -> None:
+    event = {
+        "type": 5,
+        "timestamp": 1758523985314,
+        "data": {
+            "tag": "breadcrumb",
+            "payload": {
+                "type": "default",
+                "timestamp": "[Filtered]",
+                "category": "ui.tap",
+                "message": "send_user_feedback",
+                "data": {"view.id": "send_user_feedback"},
+            },
+        },
+    }
+
+    builder = HighlightedEventsBuilder()
+    builder.add(which(event), event, sampled=True)
+    assert len(builder.result.tap_events) == 0
+
+
 def test_parse_highlighted_events_click_event_str_payload() -> None:
     event = {"type": 5, "data": {"tag": "breadcrumb", "payload": "hello world"}}
     builder = HighlightedEventsBuilder()
@@ -1198,6 +1248,19 @@ def test_parse_highlighted_events_fault_tolerance(event: dict[str, Any]) -> None
     # If the test raises an exception we fail. All of these events are invalid.
     builder = HighlightedEventsBuilder()
     builder.add(which(event), event, sampled=True)
+
+
+def test_parse_highlighted_events_contains_value_error() -> None:
+    event = {"type": 5, "data": {"tag": "breadcrumb", "payload": {"category": "ui.click"}}}
+
+    with mock.patch(
+        "sentry.replays.usecases.ingest.event_parser.as_highlighted_event",
+        side_effect=ValueError("Value was not a string."),
+    ):
+        builder = HighlightedEventsBuilder()
+        builder.add(which(event), event, sampled=True)
+
+    assert builder.result.click_events == []
 
 
 # Tests for trace item functions


### PR DESCRIPTION
PII scrubbing can replace a click breadcrumb's numeric `timestamp` with a marker string. `int()` then raised `ValueError`, which `parse_highlighted_event` did not catch.

Supersedes #121665, which adds the same `ValueError` catch; this additionally stops the click and tap parsers from raising in the first place.

Closes SENTRY-5SF0. Closes REPLAY-983.

Related: REPLAY-975 (root cause — click timestamps being scrubbed at all), REPLAY-982 (surfacing dropped data to users).
