### PR TITLE
fix(replays): further stop trusting the SDK type for click frame nodes

### DIFF
--- a/static/app/utils/replays/getFrameDetails.tsx
+++ b/static/app/utils/replays/getFrameDetails.tsx
@@ -33,6 +33,7 @@ import {TabKey} from 'sentry/utils/replays/hooks/useActiveReplayTab';
 import type {
   BreadcrumbFrame,
   ClickFrame,
+  ClickFrameNode,
   ConsoleFrame,
   DeviceBatteryFrame,
   DeviceConnectivityFrame,
@@ -487,10 +488,10 @@ export function defaultTitle(frame: ReplayFrame | RawBreadcrumbFrame) {
   return 'description' in frame ? (frame.description ?? '') : '';
 }
 
-function stringifyNodeAttributes(node: SlowClickFrame['data']['node']) {
+function stringifyNodeAttributes(node: ClickFrameNode | undefined) {
   const {tagName, attributes} = node ?? {};
   const attributesEntries = Object.entries(attributes ?? {});
-  const componentName = node?.attributes['data-sentry-component'];
+  const componentName = attributes?.['data-sentry-component'];
 
   return `${componentName ?? tagName}${
     attributesEntries.length

--- a/static/app/utils/replays/replayReader.spec.tsx
+++ b/static/app/utils/replays/replayReader.spec.tsx
@@ -232,6 +232,42 @@ describe('ReplayReader', () => {
     });
   });
 
+  it('excludes a slow click from the chapter frames when its node has no tagName', () => {
+    const timestamp = new Date('2023-12-25T00:02:00');
+
+    const scrubbedSlowClick = {
+      type: EventType.Custom,
+      timestamp: timestamp.getTime(),
+      data: {
+        tag: 'breadcrumb',
+        payload: {
+          category: 'ui.slowClickDetected',
+          message: 'div',
+          timestamp: timestamp.getTime() / 1000,
+          type: BreadcrumbType.DEFAULT,
+          data: {
+            node: {id: 42},
+            nodeId: 42,
+            url: '',
+            timeAfterClickMs: 7000,
+            endReason: 'timeout',
+          },
+        },
+      },
+    };
+
+    const replay = ReplayReader.factory({
+      attachments: [scrubbedSlowClick],
+      errors: [],
+      fetching: false,
+      replayRecord,
+    });
+
+    expect(replay?.getChapterFrames()).toStrictEqual([
+      expect.objectContaining({category: 'replay.init'}),
+    ]);
+  });
+
   it('shoud return the SDK config if there is a RecordingOptions event found', () => {
     const timestamp = new Date();
     const optionsFrame = ReplayOptionFrameFixture();

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -34,7 +34,6 @@ import type {
   RecordingFrame,
   ReplayFrame,
   serializedNodeWithId,
-  SlowClickFrame,
   SpanFrame,
   VideoEvent,
   WebVitalFrame,
@@ -49,6 +48,7 @@ import {
   isDeadRageClick,
   isMetaFrame,
   isPaintFrame,
+  isSlowClickFrame,
   isTouchEndFrame,
   isTouchMoveFrame,
   isTouchStartFrame,
@@ -706,7 +706,7 @@ export class ReplayReader {
             frame =>
               !(
                 (frame.category === 'ui.slowClickDetected' &&
-                  !isDeadClick(frame as SlowClickFrame)) ||
+                  !(isSlowClickFrame(frame) && isDeadClick(frame))) ||
                 frame.category === 'ui.multiClick'
               )
           )
@@ -780,9 +780,7 @@ export class ReplayReader {
           ['navigation', 'ui.click', 'ui.tap', 'ui.swipe', 'ui.scroll'].includes(
             frame.category
           ) ||
-          (frame.category === 'ui.slowClickDetected' &&
-            (isDeadClick(frame as SlowClickFrame) ||
-              isDeadRageClick(frame as SlowClickFrame)))
+          (isSlowClickFrame(frame) && (isDeadClick(frame) || isDeadRageClick(frame)))
       )
     );
     const spans = this._sortedSpanFrames.filter(frame =>

--- a/static/app/utils/replays/types.tsx
+++ b/static/app/utils/replays/types.tsx
@@ -372,13 +372,6 @@ export type FeedbackFrame = {
   type: string;
 };
 
-/**
- * The SDK marks every field inside a click frame's `node` as required, which
- * describes what a healthy SDK emits rather than what the API returns: replay
- * attachments are third-party data that nothing validates on the way in, and
- * nodes do reach us with fields missing. Sentry's ingest already treats them as
- * optional, see `sentry.replays.usecases.ingest.event_parser`.
- */
 export type ClickFrameNode = {
   attributes?: Record<string, string>;
   id?: number;

--- a/static/app/utils/replays/types.tsx
+++ b/static/app/utils/replays/types.tsx
@@ -263,9 +263,19 @@ export function isPaintFrame(frame: SpanFrame): frame is PaintFrame {
   return frame.op === 'paint';
 }
 
-export function isDeadClick(frame: SlowClickFrame) {
+export function isSlowClickFrame(frame: BreadcrumbFrame): frame is SlowClickFrame {
   return (
-    ['a', 'button', 'input'].includes(frame.data.node?.tagName.toLowerCase() ?? '') &&
+    frame.category === 'ui.slowClickDetected' &&
+    typeof frame.data === 'object' &&
+    frame.data !== null
+  );
+}
+
+export function isDeadClick(frame: SlowClickFrame) {
+  const node: ClickFrameNode | undefined = frame.data.node;
+
+  return (
+    ['a', 'button', 'input'].includes(node?.tagName?.toLowerCase() ?? '') &&
     frame.data.endReason === 'timeout'
   );
 }
@@ -360,6 +370,20 @@ export type FeedbackFrame = {
   timestamp: Date;
   timestampMs: number;
   type: string;
+};
+
+/**
+ * The SDK marks every field inside a click frame's `node` as required, which
+ * describes what a healthy SDK emits rather than what the API returns: replay
+ * attachments are third-party data that nothing validates on the way in, and
+ * nodes do reach us with fields missing. Sentry's ingest already treats them as
+ * optional, see `sentry.replays.usecases.ingest.event_parser`.
+ */
+export type ClickFrameNode = {
+  attributes?: Record<string, string>;
+  id?: number;
+  tagName?: string;
+  textContent?: string;
 };
 
 export type ClickFrame = HydratedBreadcrumb<'ui.click'>;

--- a/static/app/utils/replays/types.tsx
+++ b/static/app/utils/replays/types.tsx
@@ -372,12 +372,7 @@ export type FeedbackFrame = {
   type: string;
 };
 
-export type ClickFrameNode = {
-  attributes?: Record<string, string>;
-  id?: number;
-  tagName?: string;
-  textContent?: string;
-};
+export type ClickFrameNode = Partial<NonNullable<SlowClickFrame['data']['node']>>;
 
 export type ClickFrame = HydratedBreadcrumb<'ui.click'>;
 export type TapFrame = HydratedBreadcrumb<'ui.tap'>;


### PR DESCRIPTION
Replay attachments are third-party data that nothing validates on the way in, but the SDK type marks every field inside a click frame's `node` as required. This:

1. Type-land: updates the types to not assume all properties are there
2. Value-land: uses a new type predicate to make sure data is valid

Kind of a continuation of / sibling to #120949.

Closes JAVASCRIPT-3BBT. Closes REPLAY-980.
