### PR TITLE
fix(jira): add request timeout when fetching Connect install public key

### DIFF
--- a/src/sentry/integrations/utils/atlassian_connect.py
+++ b/src/sentry/integrations/utils/atlassian_connect.py
@@ -136,7 +136,9 @@ def authenticate_asymmetric_jwt(token: str | None, key_id: str) -> dict[str, str
     """
     if token is None:
         raise AtlassianConnectValidationError("No token parameter")
-    key_response = requests.get(f"https://connect-install-keys.atlassian.com/{key_id}")
+    key_response = requests.get(
+        f"https://connect-install-keys.atlassian.com/{key_id}", timeout=5
+    )
     public_key = key_response.content.decode("utf-8").strip()
     decoded_claims = jwt.decode(token, public_key, audience=absolute_uri(), algorithms=["RS256"])
     if not decoded_claims:


### PR DESCRIPTION
## What

`authenticate_asymmetric_jwt` in `src/sentry/integrations/utils/atlassian_connect.py` fetches the Atlassian Connect installation public key with a bare `requests.get()` call and no `timeout`:

```python
key_response = requests.get(f"https://connect-install-keys.atlassian.com/{key_id}")
```

`requests` defaults to no timeout, so this call can block indefinitely.

## Why it matters

This runs synchronously inside the request/response cycle of the Jira installed webhook (`sentry/integrations/jira/webhooks/installed.py`), whose base class sets `authentication_classes = ()`, `permission_classes = ()` and `@csrf_exempt`. The endpoint is therefore reachable unauthenticated. Every POST with a JWT that carries a `kid` header triggers this outbound GET before any signature is verified.

If the upstream CDN is slow or unreachable, the worker handling the request stays blocked with no upper bound. Under transient upstream latency or a burst of crafted requests, blocked workers accumulate and can exhaust the pool, degrading availability. Making an external HTTP call with no timeout in a request handler is a well-known reliability and denial-of-service gap (Bandit B113).

## Fix

Add an explicit `timeout=5` to the request, matching the timeout convention already used across Sentry integration clients (for example `integrations/discord/client.py`, `integrations/vsts/client.py`, `integrations/data_forwarding/splunk/forwarder.py`). One-line change, no behavior change on the happy path.

## Test

Existing Jira installation webhook tests continue to pass. The request now raises `requests.exceptions.Timeout` instead of hanging forever when the key CDN does not respond within 5 seconds; that exception is already surfaced through the webhook's error handling.
