### PR TITLE
chore(sentryapps): add an option to override default webhook timeout for specific apps

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2610,18 +2610,18 @@ register(
     default=1.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
-# Which app slugs to override the webhook timeout and their timeout value
-# Example: {"my-test-app": 3.0}
+# Which organization IDs to override the webhook timeout and their timeout value
+# Example: {123456: 3.0}
 register(
-    "sentry-apps.override.app_slugs.webhook.timeout.sec",
+    "sentry-apps.override.organization_ids.webhook.timeout.sec",
     type=Dict,
     default={},
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
-# Which app slugs to override the hard timeout for and their timeout value
-# Example: {"my-test-app": 8.0}
+# Which organization IDs to override the hard timeout for and their timeout value
+# Example: {123456: 8.0}
 register(
-    "sentry-apps.override.app_slugs.webhook.hard-timeout.sec",
+    "sentry-apps.override.organization_ids.webhook.hard-timeout.sec",
     type=Dict,
     default={},
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2610,6 +2610,20 @@ register(
     default=1.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+# Sets the timeout override for webhooks
+register(
+    "sentry-apps.override.webhook.timeout.sec",
+    type=Float,
+    default=1.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+# Which app slugs to override the webhook timeout for
+register(
+    "sentry-apps.override.app_slugs.webhook.timeout",
+    type=Sequence,
+    default=[],
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # Hard timeout for webhook requests to prevent indefinite hangs.
 # Must be strictly less than the shortest task processing_deadline_duration that

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2611,7 +2611,7 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 # Which organization IDs to override the webhook timeout and their timeout value
-# Example: {123456: 3.0}
+# Example: {"123456": 3.0}
 register(
     "sentry-apps.override.organization_ids.webhook.timeout.sec",
     type=Dict,
@@ -2619,7 +2619,7 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
 # Which organization IDs to override the hard timeout for and their timeout value
-# Example: {123456: 8.0}
+# Example: {"123456": 8.0}
 register(
     "sentry-apps.override.organization_ids.webhook.hard-timeout.sec",
     type=Dict,

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2610,18 +2610,20 @@ register(
     default=1.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
-# Sets the timeout override for webhooks
+# Which app slugs to override the webhook timeout and their timeout value
+# Example: {"my-test-app": 3.0}
 register(
-    "sentry-apps.override.webhook.timeout.sec",
-    type=Float,
-    default=1.0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
+    "sentry-apps.override.app_slugs.webhook.timeout.sec",
+    type=Dict,
+    default={},
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
-# Which app slugs to override the webhook timeout for
+# Which app slugs to override the hard timeout for and their timeout value
+# Example: {"my-test-app": 8.0}
 register(
-    "sentry-apps.override.app_slugs.webhook.timeout",
-    type=Sequence,
-    default=[],
+    "sentry-apps.override.app_slugs.webhook.hard-timeout.sec",
+    type=Dict,
+    default={},
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2610,18 +2610,10 @@ register(
     default=1.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
-# Which organization IDs to override the webhook timeout and their timeout value
-# Example: {"123456": 3.0}
+# Webhook timeout overrides by installation organization ID. Values are seconds.
+# Example: {"123456": {"webhook_timeout_override": 0.5, "hard_timeout_override": 5.0}}
 register(
-    "sentry-apps.override.organization_ids.webhook.timeout.sec",
-    type=Dict,
-    default={},
-    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
-)
-# Which organization IDs to override the hard timeout for and their timeout value
-# Example: {"123456": 8.0}
-register(
-    "sentry-apps.override.organization_ids.webhook.hard-timeout.sec",
+    "sentry-apps.override.organization_ids.webhook.timeouts.sec",
     type=Dict,
     default={},
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,

--- a/src/sentry/utils/sentry_apps/webhooks.py
+++ b/src/sentry/utils/sentry_apps/webhooks.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import contextlib
 import logging
 import re
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Generator, Mapping
 from types import FrameType
 from typing import TYPE_CHECKING, Any, Concatenate, ParamSpec, TypeVar
 from urllib.parse import urlparse
@@ -51,7 +51,8 @@ from sentry.utils.tracing import trace
 
 if TYPE_CHECKING:
     from sentry.sentry_apps.api.serializers.app_platform_event import AppPlatformEvent
-    from sentry.sentry_apps.services.app.model import RpcSentryApp
+    from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallation
+    from sentry.sentry_apps.services.app.model import RpcSentryApp, RpcSentryAppInstallation
 
 
 TIMEOUT_STATUS_CODE = 0
@@ -198,59 +199,66 @@ def _circuit_breaker_allows_request(
     return False
 
 
+@contextlib.contextmanager
+def _webhook_timeout(
+    installation: SentryAppInstallation | RpcSentryAppInstallation,
+) -> Generator[float]:
+    timeout_seconds = options.get("sentry-apps.webhook.timeout.sec")
+
+    # Installation webhooks are low volume and may not run in the main thread,
+    # so they do not use the signal-based hard timeout or organization overrides.
+    if SiloMode.get_current_mode() is SiloMode.CONTROL:
+        yield timeout_seconds
+        return
+
+    hard_timeout_seconds = options.get("sentry-apps.webhook.hard-timeout.sec")
+    timeout_overrides = options.get(
+        "sentry-apps.override.organization_ids.webhook.timeouts.sec"
+    ).get(str(installation.organization_id))
+
+    # We're using a signal based timeout here because we need to interrupt the blocking
+    # socket.connect() operation. See SENTRY-5HA6 for more context. Here we're hanging at
+    # the socket.connect() call and the timeout we set in safe_urlopen is not being respected.
+    if timeout_overrides is None:
+        with timeout_alarm(hard_timeout_seconds, _handle_webhook_timeout):
+            yield timeout_seconds
+        return
+
+    timeout_override = timeout_overrides.get("webhook_timeout_override", timeout_seconds)
+    hard_timeout_override = timeout_overrides.get("hard_timeout_override", hard_timeout_seconds)
+    if timeout_override > hard_timeout_override:
+        logger.warning(
+            "sentry_app.webhook.invalid_timeout_overrides",
+            extra={
+                "organization_id": installation.organization_id,
+                "webhook_timeout_override": timeout_override,
+                "hard_timeout_override": hard_timeout_override,
+            },
+        )
+        with timeout_alarm(hard_timeout_seconds, _handle_webhook_timeout):
+            yield timeout_seconds
+        return
+
+    with sentry_sdk.start_span(op="sentry-app.webhook.overridden_timeout") as span:
+        span.set_tag("app_slug", installation.sentry_app.slug)
+        span.set_tag("organization_id", installation.organization_id)
+        span.set_tag("timeout_seconds", timeout_override)
+        span.set_tag("hard_timeout_seconds", hard_timeout_override)
+
+        with timeout_alarm(hard_timeout_override, _handle_webhook_timeout):
+            yield timeout_override
+
+
 def _send_webhook_request(
     url: str,
     app_platform_event: AppPlatformEvent[T],
 ) -> Response:
-    organization_id = app_platform_event.install.organization_id
-    override_key = str(organization_id)
-
-    # We don't want to use the alarm in CONTROL silo as it's only used for installation webhooks which are v. low volume
-    # Also that we aren't guaranteed to be in main thread
-    context_wrapper: contextlib.AbstractContextManager[None]
-    timeout_seconds = None
-
-    if SiloMode.get_current_mode() is SiloMode.CONTROL:
-        context_wrapper = contextlib.nullcontext()
-    else:
-        hard_timeout_override = options.get(
-            "sentry-apps.override.organization_ids.webhook.hard-timeout.sec"
-        ).get(override_key, None)
-
-        timeout_seconds = hard_timeout_override or options.get(
-            "sentry-apps.webhook.hard-timeout.sec"
-        )
-        context_wrapper = timeout_alarm(timeout_seconds, _handle_webhook_timeout)
-
-    timeout_override = options.get("sentry-apps.override.organization_ids.webhook.timeout.sec").get(
-        override_key, None
-    )
-
-    if timeout_override is not None:
-        with sentry_sdk.start_span(op="sentry-app.webhook.overriden_timeout") as span:
-            span.set_tag("app_slug", app_platform_event.install.sentry_app.slug)
-            span.set_tag("organization_id", organization_id)
-            span.set_tag("timeout_seconds", timeout_override)
-            span.set_tag("hard_timeout_seconds", timeout_seconds)
-
-            # We're using a signal based timeout here because we need to interrupt the blocking
-            # socket.connect() operation. See SENTRY-5HA6 for more context. Here we're hanging at
-            # the socket.connect() call and the timeout we set in safe_urlopen is not being respected.
-            with context_wrapper:
-                return safe_urlopen(
-                    url=url,
-                    data=app_platform_event.body,
-                    headers=app_platform_event.headers,
-                    timeout=timeout_override,
-                )
-
-    # See comment above
-    with context_wrapper:
+    with _webhook_timeout(app_platform_event.install) as timeout_seconds:
         return safe_urlopen(
             url=url,
             data=app_platform_event.body,
             headers=app_platform_event.headers,
-            timeout=options.get("sentry-apps.webhook.timeout.sec"),
+            timeout=timeout_seconds,
         )
 
 

--- a/src/sentry/utils/sentry_apps/webhooks.py
+++ b/src/sentry/utils/sentry_apps/webhooks.py
@@ -207,14 +207,18 @@ def _send_webhook_request(
     if SiloMode.get_current_mode() is SiloMode.CONTROL:
         context_wrapper = contextlib.nullcontext()
     else:
-        timeout_seconds = options.get("sentry-apps.webhook.hard-timeout.sec")
+        hard_timeout_override = options.get(
+            "sentry-apps.override.app_slugs.webhook.hard-timeout.sec"
+        ).get(app_platform_event.install.sentry_app.slug, None)
+
+        timeout_seconds = hard_timeout_override or options.get(
+            "sentry-apps.webhook.hard-timeout.sec"
+        )
         context_wrapper = timeout_alarm(timeout_seconds, _handle_webhook_timeout)
 
-    timeout_override = None
-    if app_platform_event.install.sentry_app.slug in options.get(
-        "sentry-apps.override.app_slugs.webhook.timeout"
-    ):
-        timeout_override = options.get("sentry-apps.override.webhook.timeout.sec")
+    timeout_override = options.get("sentry-apps.override.app_slugs.webhook.timeout.sec").get(
+        app_platform_event.install.sentry_app.slug, None
+    )
 
     # We're using a signal based timeout here because we need to interrupt the blocking
     # socket.connect() operation. See SENTRY-5HA6 for more context. Here we're hanging at

--- a/src/sentry/utils/sentry_apps/webhooks.py
+++ b/src/sentry/utils/sentry_apps/webhooks.py
@@ -210,6 +210,12 @@ def _send_webhook_request(
         timeout_seconds = options.get("sentry-apps.webhook.hard-timeout.sec")
         context_wrapper = timeout_alarm(timeout_seconds, _handle_webhook_timeout)
 
+    timeout_override = None
+    if app_platform_event.install.sentry_app.slug in options.get(
+        "sentry-apps.override.app_slugs.webhook.timeout"
+    ):
+        timeout_override = options.get("sentry-apps.override.webhook.timeout.sec")
+
     # We're using a signal based timeout here because we need to interrupt the blocking
     # socket.connect() operation. See SENTRY-5HA6 for more context. Here we're hanging at
     # the socket.connect() call and the timeout we set in safe_urlopen is not being respected.
@@ -218,7 +224,7 @@ def _send_webhook_request(
             url=url,
             data=app_platform_event.body,
             headers=app_platform_event.headers,
-            timeout=options.get("sentry-apps.webhook.timeout.sec"),
+            timeout=timeout_override or options.get("sentry-apps.webhook.timeout.sec"),
         )
 
 

--- a/src/sentry/utils/sentry_apps/webhooks.py
+++ b/src/sentry/utils/sentry_apps/webhooks.py
@@ -205,6 +205,8 @@ def _send_webhook_request(
     # We don't want to use the alarm in CONTROL silo as it's only used for installation webhooks which are v. low volume
     # Also that we aren't guaranteed to be in main thread
     context_wrapper: contextlib.AbstractContextManager[None]
+    timeout_seconds = None
+
     if SiloMode.get_current_mode() is SiloMode.CONTROL:
         context_wrapper = contextlib.nullcontext()
     else:

--- a/src/sentry/utils/sentry_apps/webhooks.py
+++ b/src/sentry/utils/sentry_apps/webhooks.py
@@ -203,6 +203,7 @@ def _send_webhook_request(
     app_platform_event: AppPlatformEvent[T],
 ) -> Response:
     organization_id = app_platform_event.install.organization_id
+    override_key = str(organization_id)
 
     # We don't want to use the alarm in CONTROL silo as it's only used for installation webhooks which are v. low volume
     # Also that we aren't guaranteed to be in main thread
@@ -214,7 +215,7 @@ def _send_webhook_request(
     else:
         hard_timeout_override = options.get(
             "sentry-apps.override.organization_ids.webhook.hard-timeout.sec"
-        ).get(organization_id, None)
+        ).get(override_key, None)
 
         timeout_seconds = hard_timeout_override or options.get(
             "sentry-apps.webhook.hard-timeout.sec"
@@ -222,7 +223,7 @@ def _send_webhook_request(
         context_wrapper = timeout_alarm(timeout_seconds, _handle_webhook_timeout)
 
     timeout_override = options.get("sentry-apps.override.organization_ids.webhook.timeout.sec").get(
-        organization_id, None
+        override_key, None
     )
 
     if timeout_override is not None:

--- a/src/sentry/utils/sentry_apps/webhooks.py
+++ b/src/sentry/utils/sentry_apps/webhooks.py
@@ -8,6 +8,7 @@ from types import FrameType
 from typing import TYPE_CHECKING, Any, Concatenate, ParamSpec, TypeVar
 from urllib.parse import urlparse
 
+import sentry_sdk
 from django.conf import settings
 from requests import RequestException, Response
 from requests.exceptions import ChunkedEncodingError, ConnectionError, Timeout
@@ -220,15 +221,30 @@ def _send_webhook_request(
         app_platform_event.install.sentry_app.slug, None
     )
 
-    # We're using a signal based timeout here because we need to interrupt the blocking
-    # socket.connect() operation. See SENTRY-5HA6 for more context. Here we're hanging at
-    # the socket.connect() call and the timeout we set in safe_urlopen is not being respected.
+    if timeout_override is not None:
+        with sentry_sdk.start_span(op="sentry-app.webhook.overriden_timeout") as span:
+            span.set_tag("app_slug", app_platform_event.install.sentry_app.slug)
+            span.set_tag("timeout_seconds", timeout_override)
+            span.set_tag("hard_timeout_seconds", timeout_seconds)
+
+            # We're using a signal based timeout here because we need to interrupt the blocking
+            # socket.connect() operation. See SENTRY-5HA6 for more context. Here we're hanging at
+            # the socket.connect() call and the timeout we set in safe_urlopen is not being respected.
+            with context_wrapper:
+                return safe_urlopen(
+                    url=url,
+                    data=app_platform_event.body,
+                    headers=app_platform_event.headers,
+                    timeout=timeout_override,
+                )
+
+    # See comment above
     with context_wrapper:
         return safe_urlopen(
             url=url,
             data=app_platform_event.body,
             headers=app_platform_event.headers,
-            timeout=timeout_override or options.get("sentry-apps.webhook.timeout.sec"),
+            timeout=options.get("sentry-apps.webhook.timeout.sec"),
         )
 
 

--- a/src/sentry/utils/sentry_apps/webhooks.py
+++ b/src/sentry/utils/sentry_apps/webhooks.py
@@ -202,6 +202,8 @@ def _send_webhook_request(
     url: str,
     app_platform_event: AppPlatformEvent[T],
 ) -> Response:
+    organization_id = app_platform_event.install.organization_id
+
     # We don't want to use the alarm in CONTROL silo as it's only used for installation webhooks which are v. low volume
     # Also that we aren't guaranteed to be in main thread
     context_wrapper: contextlib.AbstractContextManager[None]
@@ -211,21 +213,22 @@ def _send_webhook_request(
         context_wrapper = contextlib.nullcontext()
     else:
         hard_timeout_override = options.get(
-            "sentry-apps.override.app_slugs.webhook.hard-timeout.sec"
-        ).get(app_platform_event.install.sentry_app.slug, None)
+            "sentry-apps.override.organization_ids.webhook.hard-timeout.sec"
+        ).get(organization_id, None)
 
         timeout_seconds = hard_timeout_override or options.get(
             "sentry-apps.webhook.hard-timeout.sec"
         )
         context_wrapper = timeout_alarm(timeout_seconds, _handle_webhook_timeout)
 
-    timeout_override = options.get("sentry-apps.override.app_slugs.webhook.timeout.sec").get(
-        app_platform_event.install.sentry_app.slug, None
+    timeout_override = options.get("sentry-apps.override.organization_ids.webhook.timeout.sec").get(
+        organization_id, None
     )
 
     if timeout_override is not None:
         with sentry_sdk.start_span(op="sentry-app.webhook.overriden_timeout") as span:
             span.set_tag("app_slug", app_platform_event.install.sentry_app.slug)
+            span.set_tag("organization_id", organization_id)
             span.set_tag("timeout_seconds", timeout_override)
             span.set_tag("hard_timeout_seconds", timeout_seconds)
 

--- a/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
@@ -1749,6 +1749,24 @@ class TestWebhookRequests(TestCase):
         assert first_request["error_id"] == "d5111da2c28645c5889d072017e3445d"
         assert first_request["project_id"] == 1
 
+    @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen", return_value=MockResponseInstance)
+    def test_uses_app_specific_timeout_override(self, safe_urlopen: MagicMock) -> None:
+        with override_options(
+            {
+                "sentry-apps.webhook.timeout.sec": 1.0,
+                "sentry-apps.override.webhook.timeout.sec": 3.0,
+                "sentry-apps.override.app_slugs.webhook.timeout": [self.sentry_app.slug],
+            }
+        ):
+            send_webhooks(
+                installation=self.install,
+                event="issue.assigned",
+                data={"issue": serialize(self.issue)},
+                actor=self.user,
+            )
+
+        assert safe_urlopen.call_args.kwargs["timeout"] == 3.0
+
 
 @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen", return_value=MockResponseInstance)
 class TestExpandedSentryAppsWebhooks(TestCase):

--- a/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
@@ -1751,19 +1751,27 @@ class TestWebhookRequests(TestCase):
 
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen", return_value=MockResponseInstance)
     @patch("sentry.utils.sentry_apps.webhooks.timeout_alarm")
-    def test_uses_app_specific_timeout_override(
+    def test_uses_installation_organization_specific_timeout_override(
         self, timeout_alarm: MagicMock, safe_urlopen: MagicMock
     ) -> None:
+        installation_organization = self.create_organization()
+        installation = self.create_sentry_app_installation(
+            organization=installation_organization, slug=self.sentry_app.slug
+        )
+        assert installation.organization_id != self.sentry_app.owner_id
+
         with override_options(
             {
-                "sentry-apps.override.app_slugs.webhook.timeout.sec": {self.sentry_app.slug: 3.0},
-                "sentry-apps.override.app_slugs.webhook.hard-timeout.sec": {
-                    self.sentry_app.slug: 8.0
+                "sentry-apps.override.organization_ids.webhook.timeout.sec": {
+                    installation.organization_id: 3.0
+                },
+                "sentry-apps.override.organization_ids.webhook.hard-timeout.sec": {
+                    installation.organization_id: 8.0
                 },
             }
         ):
             send_webhooks(
-                installation=self.install,
+                installation=installation,
                 event="issue.assigned",
                 data={"issue": serialize(self.issue)},
                 actor=self.user,

--- a/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
@@ -1763,10 +1763,10 @@ class TestWebhookRequests(TestCase):
         with override_options(
             {
                 "sentry-apps.override.organization_ids.webhook.timeout.sec": {
-                    installation.organization_id: 3.0
+                    str(installation.organization_id): 3.0
                 },
                 "sentry-apps.override.organization_ids.webhook.hard-timeout.sec": {
-                    installation.organization_id: 8.0
+                    str(installation.organization_id): 8.0
                 },
             }
         ):

--- a/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
@@ -1762,11 +1762,11 @@ class TestWebhookRequests(TestCase):
 
         with override_options(
             {
-                "sentry-apps.override.organization_ids.webhook.timeout.sec": {
-                    str(installation.organization_id): 3.0
-                },
-                "sentry-apps.override.organization_ids.webhook.hard-timeout.sec": {
-                    str(installation.organization_id): 8.0
+                "sentry-apps.override.organization_ids.webhook.timeouts.sec": {
+                    str(installation.organization_id): {
+                        "webhook_timeout_override": 3.0,
+                        "hard_timeout_override": 8.0,
+                    }
                 },
             }
         ):
@@ -1779,6 +1779,46 @@ class TestWebhookRequests(TestCase):
 
         assert safe_urlopen.call_args.kwargs["timeout"] == 3.0
         timeout_alarm.assert_called_once_with(8.0, ANY)
+
+    @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen", return_value=MockResponseInstance)
+    @patch("sentry.utils.sentry_apps.webhooks.timeout_alarm")
+    @patch("sentry.utils.sentry_apps.webhooks.logger.warning")
+    def test_uses_defaults_when_webhook_timeout_override_exceeds_hard_timeout(
+        self,
+        warning: MagicMock,
+        timeout_alarm: MagicMock,
+        safe_urlopen: MagicMock,
+    ) -> None:
+        with override_options(
+            {
+                "sentry-apps.webhook.timeout.sec": 1.0,
+                "sentry-apps.webhook.hard-timeout.sec": 5.0,
+                "sentry-apps.override.organization_ids.webhook.timeouts.sec": {
+                    str(self.install.organization_id): {
+                        "webhook_timeout_override": 9.0,
+                        "hard_timeout_override": 8.0,
+                    }
+                },
+            }
+        ):
+            send_webhooks(
+                installation=self.install,
+                event="issue.assigned",
+                data={"issue": serialize(self.issue)},
+                actor=self.user,
+            )
+
+        warning.assert_called_once_with(
+            "sentry_app.webhook.invalid_timeout_overrides",
+            extra={
+                "app_slug": self.sentry_app.slug,
+                "organization_id": self.install.organization_id,
+                "webhook_timeout_override": 9.0,
+                "hard_timeout_override": 8.0,
+            },
+        )
+        assert safe_urlopen.call_args.kwargs["timeout"] == 1.0
+        timeout_alarm.assert_called_once_with(5.0, ANY)
 
 
 @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen", return_value=MockResponseInstance)

--- a/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
@@ -1750,12 +1750,16 @@ class TestWebhookRequests(TestCase):
         assert first_request["project_id"] == 1
 
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen", return_value=MockResponseInstance)
-    def test_uses_app_specific_timeout_override(self, safe_urlopen: MagicMock) -> None:
+    @patch("sentry.utils.sentry_apps.webhooks.timeout_alarm")
+    def test_uses_app_specific_timeout_override(
+        self, timeout_alarm: MagicMock, safe_urlopen: MagicMock
+    ) -> None:
         with override_options(
             {
-                "sentry-apps.webhook.timeout.sec": 1.0,
-                "sentry-apps.override.webhook.timeout.sec": 3.0,
-                "sentry-apps.override.app_slugs.webhook.timeout": [self.sentry_app.slug],
+                "sentry-apps.override.app_slugs.webhook.timeout.sec": {self.sentry_app.slug: 3.0},
+                "sentry-apps.override.app_slugs.webhook.hard-timeout.sec": {
+                    self.sentry_app.slug: 8.0
+                },
             }
         ):
             send_webhooks(
@@ -1766,6 +1770,7 @@ class TestWebhookRequests(TestCase):
             )
 
         assert safe_urlopen.call_args.kwargs["timeout"] == 3.0
+        timeout_alarm.assert_called_once_with(8.0, ANY)
 
 
 @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen", return_value=MockResponseInstance)

--- a/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
@@ -1791,8 +1791,6 @@ class TestWebhookRequests(TestCase):
     ) -> None:
         with override_options(
             {
-                "sentry-apps.webhook.timeout.sec": 1.0,
-                "sentry-apps.webhook.hard-timeout.sec": 5.0,
                 "sentry-apps.override.organization_ids.webhook.timeouts.sec": {
                     str(self.install.organization_id): {
                         "webhook_timeout_override": 9.0,
@@ -1811,7 +1809,6 @@ class TestWebhookRequests(TestCase):
         warning.assert_called_once_with(
             "sentry_app.webhook.invalid_timeout_overrides",
             extra={
-                "app_slug": self.sentry_app.slug,
                 "organization_id": self.install.organization_id,
                 "webhook_timeout_override": 9.0,
                 "hard_timeout_override": 8.0,


### PR DESCRIPTION
per [this thread](https://sentry.slack.com/archives/CD4NYFD34/p1786472251664339), somewhat experimental though. My current worries are
- Any overrides will be hitting up against the hard-timeout limit of 5s (so we could accidentally count and disable the app). So may need to another option to override the hard-timeout which is also not ideal. 
  - Ended up adding this anyway
- This could hog connections and cause downstream effects for other webhooks, (i.e backlogging) if they send too many and take too long