### PR TITLE
build: Bump sentry-protos to 0.61.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ dependencies = [
   "sentry-ophio>=1.1.3",
   # sentry-options is only used in getsentry for now
   "sentry-options>=1.2.6",
-  "sentry-protos>=0.60.1",
+  "sentry-protos>=0.61.0",
   "sentry-redis-tools>=0.5.0",
   "sentry-relay>=0.9.27",
   "sentry-scm>=1.3.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2361,7 +2361,7 @@ requires-dist = [
     { name = "sentry-kafka-schemas", specifier = ">=2.2.0" },
     { name = "sentry-ophio", specifier = ">=1.1.3" },
     { name = "sentry-options", specifier = ">=1.2.6" },
-    { name = "sentry-protos", specifier = ">=0.60.1" },
+    { name = "sentry-protos", specifier = ">=0.61.0" },
     { name = "sentry-redis-tools", specifier = ">=0.5.0" },
     { name = "sentry-relay", specifier = ">=0.9.27" },
     { name = "sentry-scm", specifier = ">=1.3.0" },
@@ -2541,7 +2541,7 @@ wheels = [
 
 [[package]]
 name = "sentry-protos"
-version = "0.60.1"
+version = "0.61.0"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 dependencies = [
     { name = "grpc-stubs", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -2549,7 +2549,7 @@ dependencies = [
     { name = "protobuf", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_protos-0.60.1-py3-none-any.whl", hash = "sha256:730270289f8ac800e08f386eb485a5e96375b1e317f8e99a0789988af217a5ce" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_protos-0.61.0-py3-none-any.whl", hash = "sha256:07e78ef857d1d8e32c6c0d4ddfe56f57d9926774656ba6be570511c1fde3006f" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Bumps `sentry-protos` from `0.60.1` to `0.61.0`.
- `0.61.0` adds the `source` field to `EffectiveUnitGrant` ([getsentry/sentry-protos#399](https://github.com/getsentry/sentry-protos/pull/399)), letting callers distinguish trial unit overrides from recurring-credit gifts.
- Needed by getsentry#21453, which serializes gifted capacity from `get_unit_grants` and filters on that field.

## Test plan

- [ ] CI (the lock diff is limited to the specifier, version, and wheel hash for this one package)

Made with [Cursor](https://cursor.com)