### PR TITLE
ref(onboarding): Share SCM project creation in a reusable hook

### DIFF
--- a/static/app/components/onboarding/scm/linkProjectToRepository.ts
+++ b/static/app/components/onboarding/scm/linkProjectToRepository.ts
@@ -1,0 +1,28 @@
+import * as Sentry from '@sentry/react';
+
+import {fetchMutation} from 'sentry/utils/queryClient';
+
+/**
+ * Best-effort link of a repository to a freshly created project. Linking is
+ * deliberately non-blocking: a failure is reported to Sentry but never stops
+ * the flow, since the project itself was created successfully.
+ */
+export async function linkProjectToRepository({
+  orgSlug,
+  projectSlug,
+  repositoryId,
+}: {
+  orgSlug: string;
+  projectSlug: string;
+  repositoryId: string;
+}): Promise<void> {
+  try {
+    await fetchMutation({
+      url: `/projects/${orgSlug}/${projectSlug}/repo/`,
+      method: 'POST',
+      data: {repositoryId},
+    });
+  } catch (error) {
+    Sentry.captureException(error);
+  }
+}

--- a/static/app/components/onboarding/scm/useScmProjectCreation.spec.tsx
+++ b/static/app/components/onboarding/scm/useScmProjectCreation.spec.tsx
@@ -1,0 +1,206 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+import {RepositoryFixture} from 'sentry-fixture/repository';
+import {TeamFixture} from 'sentry-fixture/team';
+
+import {act, renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
+
+import {ProjectsStore} from 'sentry/stores/projectsStore';
+import {TeamStore} from 'sentry/stores/teamStore';
+import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
+
+import {useScmProjectCreation} from './useScmProjectCreation';
+
+const pythonPlatform: OnboardingSelectedSDK = {
+  key: 'python',
+  name: 'Python',
+  language: 'python',
+  type: 'language',
+  link: 'https://docs.sentry.io/platforms/python/',
+  category: 'popular',
+};
+
+describe('useScmProjectCreation', () => {
+  const organization = OrganizationFixture();
+  const adminTeam = TeamFixture({slug: 'admin-team', access: ['team:admin']});
+  const createdProject = ProjectFixture({slug: 'python', platform: 'python'});
+
+  function renderCreation(
+    overrides: Partial<Parameters<typeof useScmProjectCreation>[0]> = {}
+  ) {
+    return renderHookWithProviders(
+      () =>
+        useScmProjectCreation({
+          createdProjectSlug: undefined,
+          onProjectCreated: jest.fn(),
+          selectedRepository: undefined,
+          ...overrides,
+        }),
+      {organization}
+    );
+  }
+
+  function mockCreateProject() {
+    return MockApiClient.addMockResponse({
+      url: `/teams/${organization.slug}/${adminTeam.slug}/projects/`,
+      method: 'POST',
+      body: createdProject,
+    });
+  }
+
+  beforeEach(() => {
+    TeamStore.loadInitialData([adminTeam]);
+    ProjectsStore.loadInitialData([]);
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/teams/`,
+      body: [adminTeam],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      body: [],
+    });
+    // ProjectsStore.onCreateSuccess reloads organization details.
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/`,
+      body: organization,
+    });
+  });
+
+  afterEach(() => {
+    TeamStore.reset();
+    ProjectsStore.reset();
+    MockApiClient.clearMockResponses();
+  });
+
+  it('creates the project with default rules and persists the slug before completing', async () => {
+    const createRequest = mockCreateProject();
+    const onProjectCreated = jest.fn();
+    const onSuccess = jest.fn();
+    const {result} = renderCreation({onProjectCreated});
+
+    await act(() =>
+      result.current.createOrReuseProject({platform: pythonPlatform, onSuccess})
+    );
+
+    expect(createRequest).toHaveBeenCalledWith(
+      `/teams/${organization.slug}/${adminTeam.slug}/projects/`,
+      expect.objectContaining({
+        method: 'POST',
+        data: expect.objectContaining({
+          platform: 'python',
+          name: 'python',
+          default_rules: true,
+        }),
+      })
+    );
+    expect(onProjectCreated).toHaveBeenCalledWith('python');
+    expect(onSuccess).toHaveBeenCalledWith(
+      expect.objectContaining({project: createdProject, reused: false, ruleIds: []})
+    );
+    // The slug must be persisted before completion so the duplicate-prevention
+    // handoff to SDK setup survives a failure later in the sequence.
+    expect(onProjectCreated.mock.invocationCallOrder[0]).toBeLessThan(
+      onSuccess.mock.invocationCallOrder[0]!
+    );
+  });
+
+  it('reuses the created project when the platform is unchanged', async () => {
+    const createRequest = mockCreateProject();
+    ProjectsStore.loadInitialData([createdProject]);
+    const onSuccess = jest.fn();
+    const {result} = renderCreation({createdProjectSlug: createdProject.slug});
+
+    await act(() =>
+      result.current.createOrReuseProject({platform: pythonPlatform, onSuccess})
+    );
+
+    expect(createRequest).not.toHaveBeenCalled();
+    expect(onSuccess).toHaveBeenCalledWith(
+      expect.objectContaining({project: createdProject, reused: true})
+    );
+  });
+
+  it('creates a new project when the platform changed', async () => {
+    const createRequest = mockCreateProject();
+    ProjectsStore.loadInitialData([
+      ProjectFixture({slug: 'old-project', platform: 'javascript'}),
+    ]);
+    const {result} = renderCreation({createdProjectSlug: 'old-project'});
+
+    await act(() =>
+      result.current.createOrReuseProject({
+        platform: pythonPlatform,
+        onSuccess: jest.fn(),
+      })
+    );
+
+    expect(createRequest).toHaveBeenCalled();
+  });
+
+  it('creates at most one project for concurrent submissions', async () => {
+    const createRequest = mockCreateProject();
+    const {result} = renderCreation();
+
+    await act(() =>
+      Promise.all([
+        result.current.createOrReuseProject({
+          platform: pythonPlatform,
+          onSuccess: jest.fn(),
+        }),
+        result.current.createOrReuseProject({
+          platform: pythonPlatform,
+          onSuccess: jest.fn(),
+        }),
+      ])
+    );
+
+    expect(createRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('completes even when best-effort repository linking fails', async () => {
+    mockCreateProject();
+    const repository = RepositoryFixture({id: '42'});
+    const repoLinkRequest = MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${createdProject.slug}/repo/`,
+      method: 'POST',
+      statusCode: 500,
+      body: {},
+    });
+    const onSuccess = jest.fn();
+    const {result} = renderCreation({selectedRepository: repository});
+
+    await act(() =>
+      result.current.createOrReuseProject({platform: pythonPlatform, onSuccess})
+    );
+
+    expect(repoLinkRequest).toHaveBeenCalledWith(
+      `/projects/${organization.slug}/${createdProject.slug}/repo/`,
+      expect.objectContaining({method: 'POST', data: {repositoryId: '42'}})
+    );
+    expect(onSuccess).toHaveBeenCalled();
+  });
+
+  it('does not complete when project creation fails', async () => {
+    MockApiClient.addMockResponse({
+      url: `/teams/${organization.slug}/${adminTeam.slug}/projects/`,
+      method: 'POST',
+      statusCode: 400,
+      body: {},
+    });
+    const onProjectCreated = jest.fn();
+    const onSuccess = jest.fn();
+    const {result} = renderCreation({onProjectCreated});
+
+    let outcome: unknown;
+    await act(async () => {
+      outcome = await result.current.createOrReuseProject({
+        platform: pythonPlatform,
+        onSuccess,
+      });
+    });
+
+    expect(outcome).toBeUndefined();
+    expect(onProjectCreated).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/static/app/components/onboarding/scm/useScmProjectCreation.ts
+++ b/static/app/components/onboarding/scm/useScmProjectCreation.ts
@@ -1,0 +1,191 @@
+import {useCallback, useRef, useState} from 'react';
+import * as Sentry from '@sentry/react';
+
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
+import {linkProjectToRepository} from 'sentry/components/onboarding/scm/linkProjectToRepository';
+import {useCreateProjectAndRules} from 'sentry/components/onboarding/useCreateProjectAndRules';
+import {t} from 'sentry/locale';
+import type {IssueAlertRule} from 'sentry/types/alerts';
+import type {Repository} from 'sentry/types/integrations';
+import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
+import type {Team} from 'sentry/types/organization';
+import type {Project} from 'sentry/types/project';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {useProjects} from 'sentry/utils/useProjects';
+import {useTeams} from 'sentry/utils/useTeams';
+import type {useCreateNotificationAction} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
+import type {RequestDataFragment} from 'sentry/views/projectInstall/issueAlertOptions';
+
+type CreateNotificationAction = ReturnType<
+  typeof useCreateNotificationAction
+>['createNotificationAction'];
+
+export interface ScmProjectCreationResult {
+  project: Project;
+  /**
+   * True when an already-created project was reused (back-nav with an
+   * unchanged platform) instead of creating a new one.
+   */
+  reused: boolean;
+  ruleIds: string[];
+  notificationRule?: IssueAlertRule;
+}
+
+interface UseScmProjectCreationOptions {
+  /**
+   * Slug of a project created earlier in this onboarding session, used for the
+   * reuse-on-back check. Persisted via onProjectCreated.
+   */
+  createdProjectSlug: string | undefined;
+  /**
+   * Persists the created project slug (onboarding session state). Called
+   * immediately after the project POST succeeds and before repository linking
+   * or completion, so the duplicate-prevention handoff to SDK setup is never
+   * skipped by a later failure.
+   */
+  onProjectCreated: (slug: string) => void;
+  selectedRepository: Repository | undefined;
+}
+
+interface CreateOrReuseProjectOptions {
+  /**
+   * Runs after creation (or reuse) succeeds, while the duplicate-submit guard
+   * is still held. Completion must happen inside the guarded window: the
+   * projects store and session slug update asynchronously, so a second click
+   * after the guard released but before the re-render could pass the reuse
+   * check with stale data and create a duplicate.
+   */
+  onSuccess: (result: ScmProjectCreationResult) => void;
+  platform: OnboardingSelectedSDK;
+  /**
+   * Alert rules to create alongside the project. Defaults to the server-side
+   * default (email) rules only.
+   */
+  alertRuleConfig?: Partial<RequestDataFragment>;
+  /**
+   * Creates the messaging-integration notification rule, if one is configured.
+   * Defaults to a no-op (email-only creation).
+   */
+  createNotificationAction?: CreateNotificationAction;
+}
+
+const noopNotificationAction: CreateNotificationAction = () => {};
+
+/**
+ * Shared project + alert-rule creation for the SCM onboarding flow. Both
+ * experiment branches call this from their respective creation boundaries:
+ * control after platform/features, treatment on the messaging step's final
+ * Continue / Set up later.
+ *
+ * Owns the onboarding-specific concerns around useCreateProjectAndRules:
+ * synchronous duplicate-submit protection, reuse of an unchanged project on
+ * back-navigation, slug persistence ordering, default team/name resolution,
+ * and best-effort repository linking.
+ */
+export function useScmProjectCreation({
+  createdProjectSlug,
+  onProjectCreated,
+  selectedRepository,
+}: UseScmProjectCreationOptions) {
+  const organization = useOrganization();
+  const {teams, fetching: isLoadingTeams} = useTeams();
+  const {projects, initiallyLoaded: projectsLoaded} = useProjects();
+  const createProjectAndRules = useCreateProjectAndRules();
+
+  // The ref is the synchronous re-entry guard; the state drives busy/disabled
+  // UI. See useScmProjectDetails for the same pattern and rationale.
+  const isCreatingRef = useRef(false);
+  const [isCreating, setIsCreating] = useState(false);
+
+  // Callers must gate submission on this so the reuse check below can't be
+  // bypassed by a race while the teams/projects stores load.
+  const isDataPending = isLoadingTeams || !projectsLoaded;
+
+  const createOrReuseProject = useCallback(
+    async ({
+      platform,
+      alertRuleConfig,
+      createNotificationAction,
+      onSuccess,
+    }: CreateOrReuseProjectOptions): Promise<ScmProjectCreationResult | undefined> => {
+      if (isCreatingRef.current) {
+        return undefined;
+      }
+
+      // If a project was already created for this platform (e.g. the user
+      // went back after the project received its first event), reuse it.
+      // If the platform changed, abandon the old project and create a new
+      // one — matching legacy onboarding behavior.
+      const existingProject = createdProjectSlug
+        ? projects.find(p => p.slug === createdProjectSlug)
+        : undefined;
+      if (existingProject?.platform === platform.key) {
+        const result: ScmProjectCreationResult = {
+          project: existingProject,
+          reused: true,
+          ruleIds: [],
+        };
+        onSuccess(result);
+        return result;
+      }
+
+      const firstAdminTeam = teams.find((team: Team) =>
+        team.access.includes('team:admin')
+      );
+
+      isCreatingRef.current = true;
+      setIsCreating(true);
+      try {
+        const creation = await createProjectAndRules
+          .mutateAsync({
+            projectName: platform.key,
+            platform,
+            team: firstAdminTeam?.slug,
+            alertRuleConfig: alertRuleConfig ?? {defaultRules: true},
+            createNotificationAction: createNotificationAction ?? noopNotificationAction,
+          })
+          .catch(error => {
+            addErrorMessage(t('Failed to create project'));
+            Sentry.captureException(error);
+            return null;
+          });
+        if (!creation) {
+          return undefined;
+        }
+
+        onProjectCreated(creation.project.slug);
+
+        if (selectedRepository?.id) {
+          await linkProjectToRepository({
+            orgSlug: organization.slug,
+            projectSlug: creation.project.slug,
+            repositoryId: selectedRepository.id,
+          });
+        }
+
+        const result: ScmProjectCreationResult = {
+          project: creation.project,
+          reused: false,
+          ruleIds: creation.ruleIds,
+          notificationRule: creation.notificationRule,
+        };
+        onSuccess(result);
+        return result;
+      } finally {
+        isCreatingRef.current = false;
+        setIsCreating(false);
+      }
+    },
+    [
+      createProjectAndRules,
+      createdProjectSlug,
+      onProjectCreated,
+      organization.slug,
+      projects,
+      selectedRepository,
+      teams,
+    ]
+  );
+
+  return {createOrReuseProject, isCreating, isDataPending};
+}

--- a/static/app/components/onboarding/scm/useScmProjectDetails.ts
+++ b/static/app/components/onboarding/scm/useScmProjectDetails.ts
@@ -1,9 +1,9 @@
 import {useCallback, useRef, useState} from 'react';
-import * as Sentry from '@sentry/react';
 import isEqual from 'lodash/isEqual';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {captureProjectCreationFailure} from 'sentry/components/onboarding/captureProjectCreationFailure';
+import {linkProjectToRepository} from 'sentry/components/onboarding/scm/linkProjectToRepository';
 import type {ProjectDetailsFormState} from 'sentry/components/onboarding/scm/scmProjectDetailsTypes';
 import {useCreateProjectAndRules} from 'sentry/components/onboarding/useCreateProjectAndRules';
 import {t} from 'sentry/locale';
@@ -12,7 +12,6 @@ import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import type {Team} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {fetchMutation} from 'sentry/utils/queryClient';
 import type {RequestError} from 'sentry/utils/requestError/requestError';
 import {slugify} from 'sentry/utils/slugify';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -415,15 +414,11 @@ export function useScmProjectDetails({
       const {project, ruleIds, notificationRule} = creation;
 
       if (selectedRepository?.id) {
-        try {
-          await fetchMutation({
-            url: `/projects/${organization.slug}/${project.slug}/repo/`,
-            method: 'POST',
-            data: {repositoryId: selectedRepository.id},
-          });
-        } catch (error) {
-          Sentry.captureException(error);
-        }
+        await linkProjectToRepository({
+          orgSlug: organization.slug,
+          projectSlug: project.slug,
+          repositoryId: selectedRepository.id,
+        });
       }
 
       trackAnalytics('project_creation_page.created', {

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -1,12 +1,9 @@
-import {useRef, useState} from 'react';
-import * as Sentry from '@sentry/react';
 import {LayoutGroup, motion} from 'framer-motion';
 
 import {Button} from '@sentry/scraps/button';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
-import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import type {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {ScmFeatureSelectionPanel} from 'sentry/components/onboarding/scm/scmFeatureSelectionPanel';
 import {ScmPlatformFeaturesCore} from 'sentry/components/onboarding/scm/scmPlatformFeaturesCore';
@@ -16,16 +13,10 @@ import {
   toSelectedSdk,
 } from 'sentry/components/onboarding/scm/scmPlatformHelpers';
 import {useScmPlatformDetection} from 'sentry/components/onboarding/scm/useScmPlatformDetection';
-import {useCreateProject} from 'sentry/components/onboarding/useCreateProject';
+import {useScmProjectCreation} from 'sentry/components/onboarding/scm/useScmProjectCreation';
 import {t} from 'sentry/locale';
 import type {Repository} from 'sentry/types/integrations';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
-import type {Team} from 'sentry/types/organization';
-import type {Project} from 'sentry/types/project';
-import {fetchMutation} from 'sentry/utils/queryClient';
-import {useOrganization} from 'sentry/utils/useOrganization';
-import {useProjects} from 'sentry/utils/useProjects';
-import {useTeams} from 'sentry/utils/useTeams';
 import {SCM_STEP_CONTENT_WIDTH} from 'sentry/views/onboarding/consts';
 
 import type {StepProps} from './types';
@@ -55,13 +46,11 @@ export function ScmPlatformFeatures({
   selectedRepository,
   genBackButton,
 }: ScmPlatformFeaturesProps) {
-  const organization = useOrganization();
-
-  const {teams, fetching: isLoadingTeams} = useTeams();
-  const {projects, initiallyLoaded: projectsLoaded} = useProjects();
-  const createProject = useCreateProject();
-  const isCompletingRef = useRef(false);
-  const [isCompleting, setIsCompleting] = useState(false);
+  const {createOrReuseProject, isCreating, isDataPending} = useScmProjectCreation({
+    createdProjectSlug,
+    onProjectCreated,
+    selectedRepository,
+  });
 
   // React Query dedupes with the core's call; we only need detectedPlatformKey
   // here so handleContinue's auto-create path can fall back to the
@@ -89,19 +78,11 @@ export function ScmPlatformFeatures({
     }
   };
 
-  const existingProject = createdProjectSlug
-    ? projects.find(p => p.slug === createdProjectSlug)
-    : undefined;
-
   // Control auto-creates the project and needs both stores loaded. Treatment
   // only stages platform/features here; its messaging step owns creation.
-  const autoCreateDataPending =
-    !deferProjectCreation && (isLoadingTeams || !projectsLoaded);
+  const autoCreateDataPending = !deferProjectCreation && isDataPending;
 
   async function handleContinue() {
-    if (isCompletingRef.current) {
-      return;
-    }
     // Persist derived defaults if the user accepted them without an explicit click
     if (currentPlatformKey && !selectedPlatform?.key) {
       setPlatform(currentPlatformKey);
@@ -125,56 +106,13 @@ export function ScmPlatformFeatures({
       return;
     }
 
-    // If a project was already created for this platform (e.g. the user
-    // went back after the project received its first event), reuse it.
-    // If the platform changed, abandon the old project and create a new
-    // one — matching legacy onboarding behavior.
     // `platform` is forwarded because setPlatform's context update has not
     // propagated to the captured onComplete closure yet, and goNextStep's
     // SETUP_DOCS guard would otherwise block navigation.
-    if (existingProject?.platform === platform.key) {
-      onComplete(platform, {product: currentFeatures});
-      return;
-    }
-
-    const firstAdminTeam = teams.find((team: Team) => team.access.includes('team:admin'));
-
-    isCompletingRef.current = true;
-    setIsCompleting(true);
-    try {
-      let project: Project;
-      try {
-        project = await createProject.mutateAsync({
-          name: platform.key,
-          platform,
-          default_rules: true,
-          firstTeamSlug: firstAdminTeam?.slug,
-        });
-      } catch (error) {
-        addErrorMessage(t('Failed to create project'));
-        Sentry.captureException(error);
-        return;
-      }
-
-      onProjectCreated(project.slug);
-
-      if (selectedRepository?.id) {
-        try {
-          await fetchMutation({
-            url: `/projects/${organization.slug}/${project.slug}/repo/`,
-            method: 'POST',
-            data: {repositoryId: selectedRepository.id},
-          });
-        } catch (error) {
-          Sentry.captureException(error);
-        }
-      }
-
-      onComplete(platform, {product: currentFeatures});
-    } finally {
-      isCompletingRef.current = false;
-      setIsCompleting(false);
-    }
+    await createOrReuseProject({
+      platform,
+      onSuccess: () => onComplete(platform, {product: currentFeatures}),
+    });
   }
 
   return (
@@ -228,8 +166,8 @@ export function ScmPlatformFeatures({
                   features: currentFeatures,
                 }}
                 onClick={handleContinue}
-                disabled={!currentPlatformKey || isCompleting || autoCreateDataPending}
-                busy={isCompleting}
+                disabled={!currentPlatformKey || isCreating || autoCreateDataPending}
+                busy={isCreating}
               >
                 {t('Continue')}
               </Button>


### PR DESCRIPTION
## TLDR

Extracts control's onboarding auto-create path into a shared `useScmProjectCreation` hook so the treatment messaging step can create the project and alert rules from the same orchestration at its own boundary. Control behavior is unchanged.

## Details

The SCM messaging experiment needs both branches to share one safe creation path with different boundaries: control creates after platform/features, treatment will create on the messaging step's final Continue or Set up later. This PR builds the shared half. `useScmProjectCreation` wraps `useCreateProjectAndRules` with the onboarding-specific concerns that previously lived inline in `scmPlatformFeatures.tsx`: the synchronous duplicate-submit guard, reuse of an unchanged project on back-navigation, persisting the created slug before completion, first `team:admin` team and platform-key name defaults, and best-effort repository linking (now deduped with `useScmProjectDetails` into `linkProjectToRepository`).

Completion runs inside the guarded window via `onSuccess` because the projects store and session slug update asynchronously; releasing the guard before completing would let a fast second click pass the reuse check on stale data and create a duplicate. The hook accepts an optional `alertRuleConfig`/`createNotificationAction` (defaulting to email-only) that the treatment step will use in a follow-up PR; control passes neither.

Refs VDY-141
