### PR TITLE
fix(dashboards): Reject saving non-text widgets with no dataset

### DIFF
--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -31,7 +31,7 @@ from sentry.search.events.fields import is_function, parse_arguments
 from sentry.snuba.metrics.extraction import OnDemandMetricSpecVersioning
 from sentry.users.api.serializers.user import UserSerializerResponse
 from sentry.users.services.user.service import user_service
-from sentry.utils import json
+from sentry.utils import json, metrics
 from sentry.utils.avatar import get_gravatar_url
 from sentry.utils.dates import outside_retention_with_modified_start, parse_timestamp
 
@@ -311,10 +311,20 @@ class DashboardWidgetSerializer(Serializer[DashboardWidgetResponse]):
         if obj.display_type == DashboardWidgetDisplayTypes.TEXT:
             widget_type = None
         else:
-            widget_type = (
-                DashboardWidgetTypes.get_type_name(obj.widget_type)
-                or DashboardWidgetTypes.TYPE_NAMES[0]
-            )
+            widget_type = DashboardWidgetTypes.get_type_name(obj.widget_type)
+            if widget_type is None:
+                # The stored widget_type resolves to no name: either NULL, or an int absent
+                # from TYPES such as METRICS=3. Reported as `discover` unless the
+                # discover_widget_split below rescues it. Counted so the remaining invalid
+                # rows stay visible -- new ones are rejected on write.
+                metrics.incr(
+                    "dashboards.serializer.unresolved_widget_type",
+                    tags={
+                        "widget_type": str(obj.widget_type),
+                        "has_split": obj.discover_widget_split is not None,
+                    },
+                )
+                widget_type = DashboardWidgetTypes.get_type_name(DashboardWidgetTypes.DISCOVER)
 
         discover_widget_type = (
             obj.widget_type == DashboardWidgetTypes.DISCOVER or obj.widget_type is None

--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from typing import Any, NotRequired, TypedDict
 from urllib.parse import urlencode
 
+import sentry_sdk
 from django.db.models import prefetch_related_objects
 
 from sentry import features
@@ -31,7 +32,7 @@ from sentry.search.events.fields import is_function, parse_arguments
 from sentry.snuba.metrics.extraction import OnDemandMetricSpecVersioning
 from sentry.users.api.serializers.user import UserSerializerResponse
 from sentry.users.services.user.service import user_service
-from sentry.utils import json, metrics
+from sentry.utils import json
 from sentry.utils.avatar import get_gravatar_url
 from sentry.utils.dates import outside_retention_with_modified_start, parse_timestamp
 
@@ -313,17 +314,16 @@ class DashboardWidgetSerializer(Serializer[DashboardWidgetResponse]):
         else:
             widget_type = DashboardWidgetTypes.get_type_name(obj.widget_type)
             if widget_type is None:
-                # The stored widget_type resolves to no name: either NULL, or an int absent
-                # from TYPES such as METRICS=3. Reported as `discover` unless the
-                # discover_widget_split below rescues it. Counted so the remaining invalid
-                # rows stay visible -- new ones are rejected on write.
-                metrics.incr(
-                    "dashboards.serializer.unresolved_widget_type",
-                    tags={
-                        "widget_type": str(obj.widget_type),
-                        "has_split": obj.discover_widget_split is not None,
+                sentry_sdk.set_context(
+                    "dashboard",
+                    {
+                        "dashboard_id": obj.dashboard_id,
+                        "widget_id": obj.id,
+                        "widget_type": obj.widget_type,
+                        "discover_widget_split": obj.discover_widget_split,
                     },
                 )
+                sentry_sdk.capture_message("Widget has an unresolvable widget_type", level="error")
                 widget_type = DashboardWidgetTypes.get_type_name(DashboardWidgetTypes.DISCOVER)
 
         discover_widget_type = (

--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -324,6 +324,10 @@ class DashboardWidgetSerializer(Serializer[DashboardWidgetResponse]):
                     },
                 )
                 sentry_sdk.capture_message("Widget has an unresolvable widget_type", level="error")
+                # Preserves the existing behaviour rather than the desired state. There is
+                # no correct dataset to report for these widgets, and `discover` is
+                # deprecated -- but clients already receive it, so keep it until the
+                # underlying rows are gone.
                 widget_type = DashboardWidgetTypes.get_type_name(DashboardWidgetTypes.DISCOVER)
 
         discover_widget_type = (

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -1347,9 +1347,6 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
             widget.discover_widget_split = None
             widget.dataset_source = DatasetSourcesTypes.UNKNOWN.value
 
-        # Only text widgets may have a NULL widget_type. Any other widget without one
-        # serializes as `discover` and reads from the transactions dataset, so refuse to
-        # write that state at all.
         if widget.widget_type is None and widget.display_type != DashboardWidgetDisplayTypes.TEXT:
             raise serializers.ValidationError(
                 {"widget_type": "`widgetType` is required for widgets that are not text widgets"}

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -1347,6 +1347,14 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
             widget.discover_widget_split = None
             widget.dataset_source = DatasetSourcesTypes.UNKNOWN.value
 
+        # Only text widgets may have a NULL widget_type. Any other widget without one
+        # serializes as `discover` and reads from the transactions dataset, so refuse to
+        # write that state at all.
+        if widget.widget_type is None and widget.display_type != DashboardWidgetDisplayTypes.TEXT:
+            raise serializers.ValidationError(
+                {"widget_type": "`widgetType` is required for widgets that are not text widgets"}
+            )
+
         widget.save()
 
         if is_text_widget:

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -269,6 +269,31 @@ class OrganizationDashboardDetailsGetTest(OrganizationDashboardDetailsTestCase):
         assert response.data["widgets"][2]["widgetType"] == "discover"
         assert response.data["widgets"][3]["widgetType"] == "transaction-like"
 
+    @mock.patch("sentry.api.serializers.models.dashboard.metrics.incr")
+    def test_unresolvable_widget_type_reports_discover_and_counts(self, mock_incr) -> None:
+        dashboard = Dashboard.objects.create(
+            title="Dashboard With An Unresolvable Widget",
+            created_by_id=self.user.id,
+            organization=self.organization,
+        )
+        self.create_dashboard_widget(
+            dashboard=dashboard,
+            title="null type widget",
+            display_type=DashboardWidgetDisplayTypes.LINE_CHART,
+        )
+
+        response = self.do_request("get", self.url(dashboard.id))
+        assert response.status_code == 200, response.content
+        assert response.data["widgets"][0]["widgetType"] == "discover"
+
+        assert (
+            mock.call(
+                "dashboards.serializer.unresolved_widget_type",
+                tags={"widget_type": "None", "has_split": False},
+            )
+            in mock_incr.mock_calls
+        )
+
     def test_dashboard_widget_returns_dataset_source(self) -> None:
         dashboard = Dashboard.objects.create(
             title="Dashboard With Dataset Source",
@@ -3981,6 +4006,120 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
 
         assert "queries" in response.data["widgets"][1], response.data
         assert response.data["widgets"][1]["queries"][0] == "Text widgets don't have queries"
+
+    def test_text_widget_to_chart_widget_requires_widget_type(self) -> None:
+        text_widget = self.create_dashboard_widget(
+            dashboard=self.dashboard,
+            order=2,
+            title="Text Widget",
+            display_type=DashboardWidgetDisplayTypes.TEXT,
+        )
+        assert text_widget.widget_type is None
+
+        data = {
+            "title": "First dashboard",
+            "widgets": [
+                {"id": str(self.widget_1.id)},
+                {"id": str(self.widget_2.id)},
+                {
+                    "id": str(text_widget.id),
+                    "displayType": "line",
+                    "queries": [
+                        {
+                            "name": "errors",
+                            "conditions": "event.type:error",
+                            "fields": ["count()"],
+                            "columns": [],
+                            "aggregates": ["count()"],
+                        }
+                    ],
+                },
+            ],
+        }
+        response = self.do_request("put", self.url(self.dashboard.id), data=data)
+        assert response.status_code == 400, response.data
+        assert (
+            response.data["widget_type"]
+            == "`widgetType` is required for widgets that are not text widgets"
+        )
+
+        # The write happens inside a transaction, so the rejection rolls it back.
+        text_widget.refresh_from_db()
+        assert text_widget.widget_type is None
+        assert text_widget.display_type == DashboardWidgetDisplayTypes.TEXT
+
+    def test_partial_update_keeps_existing_discover_widget_type(self) -> None:
+        # Legacy `discover` widgets are migrated separately -- saving a dashboard that
+        # contains one must keep working. DISCOVER is 0, so this also covers the stored
+        # widget_type being compared against None rather than tested for truthiness.
+        data = {
+            "title": "First dashboard",
+            "widgets": [
+                {"id": str(self.widget_1.id), "title": "Renamed"},
+                {"id": str(self.widget_2.id)},
+            ],
+        }
+        response = self.do_request("put", self.url(self.dashboard.id), data=data)
+        assert response.status_code == 200, response.data
+
+        self.widget_1.refresh_from_db()
+        assert self.widget_1.title == "Renamed"
+        assert self.widget_1.widget_type == DashboardWidgetTypes.DISCOVER
+
+    def test_partial_update_rejects_existing_null_widget_type(self) -> None:
+        # Only text widgets may have a NULL widget_type, so a non-text widget that already
+        # stores one cannot be saved until a backfill gives it a real dataset.
+        widget = self.create_dashboard_widget(
+            dashboard=self.dashboard,
+            order=2,
+            title="Null Type Widget",
+            display_type=DashboardWidgetDisplayTypes.LINE_CHART,
+        )
+        assert widget.widget_type is None
+
+        data = {
+            "title": "First dashboard",
+            "widgets": [
+                {"id": str(self.widget_1.id)},
+                {"id": str(self.widget_2.id)},
+                {"id": str(widget.id), "title": "Renamed"},
+            ],
+        }
+        response = self.do_request("put", self.url(self.dashboard.id), data=data)
+        assert response.status_code == 400, response.data
+        assert (
+            response.data["widget_type"]
+            == "`widgetType` is required for widgets that are not text widgets"
+        )
+
+        widget.refresh_from_db()
+        assert widget.title == "Null Type Widget"
+
+    def test_text_widget_update_without_display_type(self) -> None:
+        # `displayType` is omitted, so the widget stays a text widget and its NULL
+        # widget_type is still correct.
+        text_widget = self.create_dashboard_widget(
+            dashboard=self.dashboard,
+            order=2,
+            title="Text Widget",
+            display_type=DashboardWidgetDisplayTypes.TEXT,
+        )
+
+        data = {
+            "title": "First dashboard",
+            "widgets": [
+                {"id": str(self.widget_1.id)},
+                {"id": str(self.widget_2.id)},
+                {"id": str(text_widget.id), "title": "Renamed"},
+            ],
+        }
+        response = self.do_request("put", self.url(self.dashboard.id), data=data)
+        assert response.status_code == 200, response.data
+
+        text_widget.refresh_from_db()
+        assert text_widget.title == "Renamed"
+        assert text_widget.widget_type is None
+        assert text_widget.display_type == DashboardWidgetDisplayTypes.TEXT
 
     def test_put_creates_dashboard_revision(self) -> None:
         response = self.do_request(

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -269,31 +269,6 @@ class OrganizationDashboardDetailsGetTest(OrganizationDashboardDetailsTestCase):
         assert response.data["widgets"][2]["widgetType"] == "discover"
         assert response.data["widgets"][3]["widgetType"] == "transaction-like"
 
-    @mock.patch("sentry.api.serializers.models.dashboard.metrics.incr")
-    def test_unresolvable_widget_type_reports_discover_and_counts(self, mock_incr) -> None:
-        dashboard = Dashboard.objects.create(
-            title="Dashboard With An Unresolvable Widget",
-            created_by_id=self.user.id,
-            organization=self.organization,
-        )
-        self.create_dashboard_widget(
-            dashboard=dashboard,
-            title="null type widget",
-            display_type=DashboardWidgetDisplayTypes.LINE_CHART,
-        )
-
-        response = self.do_request("get", self.url(dashboard.id))
-        assert response.status_code == 200, response.content
-        assert response.data["widgets"][0]["widgetType"] == "discover"
-
-        assert (
-            mock.call(
-                "dashboards.serializer.unresolved_widget_type",
-                tags={"widget_type": "None", "has_split": False},
-            )
-            in mock_incr.mock_calls
-        )
-
     def test_dashboard_widget_returns_dataset_source(self) -> None:
         dashboard = Dashboard.objects.create(
             title="Dashboard With Dataset Source",
@@ -4065,35 +4040,6 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         self.widget_1.refresh_from_db()
         assert self.widget_1.title == "Renamed"
         assert self.widget_1.widget_type == DashboardWidgetTypes.DISCOVER
-
-    def test_partial_update_rejects_existing_null_widget_type(self) -> None:
-        # Only text widgets may have a NULL widget_type, so a non-text widget that already
-        # stores one cannot be saved until a backfill gives it a real dataset.
-        widget = self.create_dashboard_widget(
-            dashboard=self.dashboard,
-            order=2,
-            title="Null Type Widget",
-            display_type=DashboardWidgetDisplayTypes.LINE_CHART,
-        )
-        assert widget.widget_type is None
-
-        data = {
-            "title": "First dashboard",
-            "widgets": [
-                {"id": str(self.widget_1.id)},
-                {"id": str(self.widget_2.id)},
-                {"id": str(widget.id), "title": "Renamed"},
-            ],
-        }
-        response = self.do_request("put", self.url(self.dashboard.id), data=data)
-        assert response.status_code == 400, response.data
-        assert (
-            response.data["widget_type"]
-            == "`widgetType` is required for widgets that are not text widgets"
-        )
-
-        widget.refresh_from_db()
-        assert widget.title == "Null Type Widget"
 
     def test_text_widget_update_without_display_type(self) -> None:
         # `displayType` is omitted, so the widget stays a text widget and its NULL

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -4023,50 +4023,6 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         assert text_widget.widget_type is None
         assert text_widget.display_type == DashboardWidgetDisplayTypes.TEXT
 
-    def test_partial_update_keeps_existing_discover_widget_type(self) -> None:
-        # Legacy `discover` widgets are migrated separately -- saving a dashboard that
-        # contains one must keep working. DISCOVER is 0, so this also covers the stored
-        # widget_type being compared against None rather than tested for truthiness.
-        data = {
-            "title": "First dashboard",
-            "widgets": [
-                {"id": str(self.widget_1.id), "title": "Renamed"},
-                {"id": str(self.widget_2.id)},
-            ],
-        }
-        response = self.do_request("put", self.url(self.dashboard.id), data=data)
-        assert response.status_code == 200, response.data
-
-        self.widget_1.refresh_from_db()
-        assert self.widget_1.title == "Renamed"
-        assert self.widget_1.widget_type == DashboardWidgetTypes.DISCOVER
-
-    def test_text_widget_update_without_display_type(self) -> None:
-        # `displayType` is omitted, so the widget stays a text widget and its NULL
-        # widget_type is still correct.
-        text_widget = self.create_dashboard_widget(
-            dashboard=self.dashboard,
-            order=2,
-            title="Text Widget",
-            display_type=DashboardWidgetDisplayTypes.TEXT,
-        )
-
-        data = {
-            "title": "First dashboard",
-            "widgets": [
-                {"id": str(self.widget_1.id)},
-                {"id": str(self.widget_2.id)},
-                {"id": str(text_widget.id), "title": "Renamed"},
-            ],
-        }
-        response = self.do_request("put", self.url(self.dashboard.id), data=data)
-        assert response.status_code == 200, response.data
-
-        text_widget.refresh_from_db()
-        assert text_widget.title == "Renamed"
-        assert text_widget.widget_type is None
-        assert text_widget.display_type == DashboardWidgetDisplayTypes.TEXT
-
     def test_put_creates_dashboard_revision(self) -> None:
         response = self.do_request(
             "put", self.url(self.dashboard.id), data={"title": "Updated Title"}


### PR DESCRIPTION
Text widgets are the only dashboard widgets allowed a NULL `widget_type`. On any other widget a `NULL` serializes as `discover` and we do not want that, `discover` is extremely deprecated! Illegal widgets have already been migrated and this case is very rare, but good to guard again.

The new check reads resolved state immediately before `widget.save()` rather than inspecting the payload, so it cannot be sidestepped by omitting `displayType`

Fixes [BROWSE-687](https://linear.app/getsentry/issue/BROWSE-687/prevent-creating-dashboard-widgets-of-discover-type)