### PR TITLE
chore(inbox): Update inbox to use "new" badge

### DIFF
--- a/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.tsx
@@ -45,8 +45,8 @@ export function IssuesSecondaryNavigation() {
                   analyticsItemName="issues_inbox"
                   trailingItems={
                     <Fragment>
-                      <FeatureBadge type="experimental" />
                       <InboxCountBadge />
+                      <FeatureBadge type="new" />
                     </Fragment>
                   }
                 >


### PR DESCRIPTION
We are going to treat this feature as "new" rather than "experimental" since we are releasing to all Seer orgs.

Also places the icon on the right side of the count to reduce pop-in.

<img width="204" height="144" alt="CleanShot 2026-08-11 at 12 42 47" src="https://github.com/user-attachments/assets/ffdfd8c2-b696-4834-b171-c25b3f4de313" />
