### PR TITLE
fix(java): Deobfuscate bare class names in cast exception messages

### DIFF
--- a/src/sentry/lang/java/exceptions.py
+++ b/src/sentry/lang/java/exceptions.py
@@ -1,4 +1,5 @@
 import re
+from collections.abc import Mapping
 from typing import Any
 
 from sentry.utils.safe import get_path
@@ -26,6 +27,10 @@ _JAVA_CLASS_IN_TEXT_RE = re.compile(
     re.X,
 )
 
+# R8 can flatten packages, leaving bare class names that are only unambiguous
+# in a complete "<source> cannot be cast to <target>" value.
+_BARE_CLASS_CAST_MESSAGE_RE = re.compile(r"([A-Za-z_$][\w$]*) cannot be cast to ([A-Za-z_$][\w$]*)")
+
 
 class Exceptions:
     def __init__(self, data: Any):
@@ -37,6 +42,8 @@ class Exceptions:
                 self._processable_exceptions.append(exc)
             if value := exc.get("value", None):
                 class_matches = _JAVA_CLASS_IN_TEXT_RE.findall(value)
+                if match := _BARE_CLASS_CAST_MESSAGE_RE.fullmatch(value):
+                    class_matches.extend(match.groups())
                 if class_matches:
                     self._processable_exceptions_with_values.append((exc, class_matches))
 
@@ -75,6 +82,12 @@ class Exceptions:
         if classes:
             for exc, class_names in self._processable_exceptions_with_values:
                 original_value = exc["value"]
+
+                if mapped_value := _deobfuscate_bare_class_cast_message(original_value, classes):
+                    exc["raw_value"] = original_value
+                    exc["value"] = mapped_value
+                    continue
+
                 new_value = original_value
 
                 # Preserve order but ensure uniqueness, then sort by stripped length desc
@@ -99,6 +112,20 @@ class Exceptions:
 
                 if performed_replacement:
                     exc["value"] = new_value
+
+
+def _deobfuscate_bare_class_cast_message(value: str, classes: Mapping[str, str]) -> str | None:
+    match = _BARE_CLASS_CAST_MESSAGE_RE.fullmatch(value)
+    if not match:
+        return None
+
+    from_class, to_class = match.groups()
+    mapped_from_class = classes.get(from_class)
+    mapped_to_class = classes.get(to_class)
+    if not mapped_from_class and not mapped_to_class:
+        return None
+
+    return f"{mapped_from_class or from_class} cannot be cast to {mapped_to_class or to_class}"
 
 
 def _is_quoted(token: str) -> bool:

--- a/src/sentry/lang/java/exceptions.py
+++ b/src/sentry/lang/java/exceptions.py
@@ -30,7 +30,12 @@ _JAVA_CLASS_IN_TEXT_RE = re.compile(
 # R8 can flatten packages, leaving class names without one. Those are only
 # unambiguous in a complete "<source> cannot be cast to <target>" value. Either
 # operand may still be dotted, since a keep rule can preserve one of the two.
-_CLASS_CAST_MESSAGE_RE = re.compile(r"([A-Za-z_$][\w$.]*) cannot be cast to ([A-Za-z_$][\w$.]*)")
+# Array suffixes are captured separately so Symbolicator receives only the base
+# class names, then reattached when rebuilding the message.
+_CLASS_CAST_MESSAGE_RE = re.compile(
+    r"(?P<from_class>[A-Za-z_$][\w$.]*)(?P<from_array_suffix>(?:\[\])*) cannot be cast to "
+    r"(?P<to_class>[A-Za-z_$][\w$.]*)(?P<to_array_suffix>(?:\[\])*)"
+)
 
 
 class Exceptions:
@@ -43,7 +48,7 @@ class Exceptions:
                 self._processable_exceptions.append(exc)
             if value := exc.get("value", None):
                 if match := _CLASS_CAST_MESSAGE_RE.fullmatch(value):
-                    class_matches = list(match.groups())
+                    class_matches = list(match.group("from_class", "to_class"))
                 else:
                     class_matches = _JAVA_CLASS_IN_TEXT_RE.findall(value)
                 if class_matches:
@@ -121,13 +126,17 @@ def _deobfuscate_class_cast_message(value: str, classes: Mapping[str, str]) -> s
     if not match:
         return None
 
-    from_class, to_class = match.groups()
+    from_class = match["from_class"]
+    to_class = match["to_class"]
     mapped_from_class = classes.get(from_class)
     mapped_to_class = classes.get(to_class)
     if not mapped_from_class and not mapped_to_class:
         return None
 
-    return f"{mapped_from_class or from_class} cannot be cast to {mapped_to_class or to_class}"
+    return (
+        f"{mapped_from_class or from_class}{match['from_array_suffix']} cannot be cast to "
+        f"{mapped_to_class or to_class}{match['to_array_suffix']}"
+    )
 
 
 def _is_quoted(token: str) -> bool:

--- a/src/sentry/lang/java/exceptions.py
+++ b/src/sentry/lang/java/exceptions.py
@@ -27,9 +27,10 @@ _JAVA_CLASS_IN_TEXT_RE = re.compile(
     re.X,
 )
 
-# R8 can flatten packages, leaving bare class names that are only unambiguous
-# in a complete "<source> cannot be cast to <target>" value.
-_BARE_CLASS_CAST_MESSAGE_RE = re.compile(r"([A-Za-z_$][\w$]*) cannot be cast to ([A-Za-z_$][\w$]*)")
+# R8 can flatten packages, leaving class names without one. Those are only
+# unambiguous in a complete "<source> cannot be cast to <target>" value. Either
+# operand may still be dotted, since a keep rule can preserve one of the two.
+_CLASS_CAST_MESSAGE_RE = re.compile(r"([A-Za-z_$][\w$.]*) cannot be cast to ([A-Za-z_$][\w$.]*)")
 
 
 class Exceptions:
@@ -41,9 +42,10 @@ class Exceptions:
             if exc.get("type", None):
                 self._processable_exceptions.append(exc)
             if value := exc.get("value", None):
-                class_matches = _JAVA_CLASS_IN_TEXT_RE.findall(value)
-                if match := _BARE_CLASS_CAST_MESSAGE_RE.fullmatch(value):
-                    class_matches.extend(match.groups())
+                if match := _CLASS_CAST_MESSAGE_RE.fullmatch(value):
+                    class_matches = list(match.groups())
+                else:
+                    class_matches = _JAVA_CLASS_IN_TEXT_RE.findall(value)
                 if class_matches:
                     self._processable_exceptions_with_values.append((exc, class_matches))
 
@@ -83,7 +85,7 @@ class Exceptions:
             for exc, class_names in self._processable_exceptions_with_values:
                 original_value = exc["value"]
 
-                if mapped_value := _deobfuscate_bare_class_cast_message(original_value, classes):
+                if mapped_value := _deobfuscate_class_cast_message(original_value, classes):
                     exc["raw_value"] = original_value
                     exc["value"] = mapped_value
                     continue
@@ -114,8 +116,8 @@ class Exceptions:
                     exc["value"] = new_value
 
 
-def _deobfuscate_bare_class_cast_message(value: str, classes: Mapping[str, str]) -> str | None:
-    match = _BARE_CLASS_CAST_MESSAGE_RE.fullmatch(value)
+def _deobfuscate_class_cast_message(value: str, classes: Mapping[str, str]) -> str | None:
+    match = _CLASS_CAST_MESSAGE_RE.fullmatch(value)
     if not match:
         return None
 

--- a/tests/relay_integration/lang/java/test_plugin.py
+++ b/tests/relay_integration/lang/java/test_plugin.py
@@ -28,6 +28,13 @@ org.slf4j.helpers.Util$ClassContextSecurityManager -> org.a.b.g$a:
 org.slf4j.helpers.Util$ClassContext -> org.a.b.g$b:
     65:65:void <init>() -> <init>
 """
+PROGUARD_BARE_CAST_UUID = "ce501fd8-36ed-4a47-93bf-801010cd4e5d"
+PROGUARD_BARE_CAST_SOURCE = b"""\
+com.example.CastSource -> a0o$b:
+    1:1:void sourceMethod():1:1 -> a
+com.example.CastTarget -> chf:
+    1:1:void targetMethod():1:1 -> a
+"""
 PROGUARD_INLINE_UUID = "d748e578-b3d1-5be5-b0e5-a42e8c9bf8e0"
 PROGUARD_INLINE_SOURCE = b"""\
 # compiler: R8
@@ -540,6 +547,24 @@ class BasicResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase):
         # Ensure the value got deobfuscated via classes mapping
         assert "org.slf4j.helpers.Util$ClassContextSecurityManager" in exc.value
         assert "org.a.b.g$a" not in exc.value
+
+    @requires_symbolicator
+    def test_value_only_bare_cast_class_names_are_deobfuscated(self) -> None:
+        self.upload_proguard_mapping(PROGUARD_BARE_CAST_UUID, PROGUARD_BARE_CAST_SOURCE)
+
+        event_data = {
+            "project": self.project.id,
+            "platform": "java",
+            "debug_meta": {"images": [{"type": "proguard", "uuid": PROGUARD_BARE_CAST_UUID}]},
+            "exception": {"values": [{"value": "a0o$b cannot be cast to chf"}]},
+            "timestamp": before_now(seconds=1).isoformat(),
+        }
+
+        event = self.post_and_retrieve_event(event_data)
+
+        exc = event.interfaces["exception"].values[0]
+        assert exc.value == "com.example.CastSource cannot be cast to com.example.CastTarget"
+        assert exc.raw_value == "a0o$b cannot be cast to chf"
 
     @requires_symbolicator
     def test_value_only_multiple_exceptions_are_all_deobfuscated(self) -> None:

--- a/tests/sentry/lang/java/test_exceptions.py
+++ b/tests/sentry/lang/java/test_exceptions.py
@@ -175,6 +175,51 @@ def test_cast_message_class_names_are_matched_when_bare() -> None:
     assert excs.get_exception_class_names() == ["a0o$b", "chf", "ft70$a", "l260", "ymu", "nbx"]
 
 
+def test_cast_message_class_names_are_matched_when_mixed() -> None:
+    # A keep rule can preserve one class while R8 flattens the other.
+    data = build_event(
+        [
+            {"value": "com.example.Foo cannot be cast to chf"},
+            {"value": "chf cannot be cast to com.example.Foo"},
+        ]
+    )
+
+    excs = Exceptions(data)
+    class_names = excs.get_exception_class_names()
+
+    assert class_names == ["com.example.Foo", "chf", "chf", "com.example.Foo"]
+
+
+def test_deobfuscate_mixed_cast_message_class_names() -> None:
+    # com.example.Foo is kept by a keep rule, so it has no mapping of its own.
+    bare_target = {"value": "com.example.Foo cannot be cast to chf"}
+    bare_source = {"value": "chf cannot be cast to com.example.Foo"}
+    data = build_event([bare_target, bare_source])
+
+    excs = Exceptions(data)
+
+    excs.deobfuscate_and_save({"chf": "com.example.CastTarget"}, mapped_exceptions=[])
+
+    assert bare_target["value"] == "com.example.Foo cannot be cast to com.example.CastTarget"
+    assert bare_target["raw_value"] == "com.example.Foo cannot be cast to chf"
+    assert bare_source["value"] == "com.example.CastTarget cannot be cast to com.example.Foo"
+    assert bare_source["raw_value"] == "chf cannot be cast to com.example.Foo"
+
+
+def test_deobfuscate_qualified_cast_message_class_names() -> None:
+    # Fully qualified operands take the same rebuild path as bare ones, so an
+    # unmapped operand is kept as-is rather than dropped.
+    exc = {"value": "com.example.Foo cannot be cast to com.example.Bar"}
+    data = build_event([exc])
+
+    excs = Exceptions(data)
+
+    excs.deobfuscate_and_save({"com.example.Bar": "com.example.MappedBar"}, mapped_exceptions=[])
+
+    assert exc["value"] == "com.example.Foo cannot be cast to com.example.MappedBar"
+    assert exc["raw_value"] == "com.example.Foo cannot be cast to com.example.Bar"
+
+
 def test_cast_message_is_not_matched_in_prose() -> None:
     # A real cast message ends on the target class. Without that anchor, ordinary
     # prose that happens to contain the word "cast" would offer candidates.

--- a/tests/sentry/lang/java/test_exceptions.py
+++ b/tests/sentry/lang/java/test_exceptions.py
@@ -220,6 +220,24 @@ def test_deobfuscate_qualified_cast_message_class_names() -> None:
     assert exc["raw_value"] == "com.example.Foo cannot be cast to com.example.Bar"
 
 
+def test_deobfuscate_array_cast_message_class_names() -> None:
+    exc = {"value": "a0o$b[][] cannot be cast to chf[]"}
+    data = build_event([exc])
+
+    excs = Exceptions(data)
+
+    assert excs.get_exception_class_names() == ["a0o$b", "chf"]
+
+    classes = {
+        "a0o$b": "com.example.CastSource",
+        "chf": "com.example.CastTarget",
+    }
+    excs.deobfuscate_and_save(classes, mapped_exceptions=[])
+
+    assert exc["value"] == ("com.example.CastSource[][] cannot be cast to com.example.CastTarget[]")
+    assert exc["raw_value"] == "a0o$b[][] cannot be cast to chf[]"
+
+
 def test_cast_message_is_not_matched_in_prose() -> None:
     # A real cast message ends on the target class. Without that anchor, ordinary
     # prose that happens to contain the word "cast" would offer candidates.

--- a/tests/sentry/lang/java/test_exceptions.py
+++ b/tests/sentry/lang/java/test_exceptions.py
@@ -162,6 +162,84 @@ def test_deobfuscate_value_preserves_quotes_in_replacements() -> None:
     assert exc["raw_value"].startswith("Got '")
 
 
+def test_cast_message_class_names_are_matched_when_bare() -> None:
+    data = build_event(
+        [
+            {"value": "a0o$b cannot be cast to chf"},
+            {"value": "ft70$a cannot be cast to l260"},
+            {"value": "ymu cannot be cast to nbx"},
+        ]
+    )
+
+    excs = Exceptions(data)
+    assert excs.get_exception_class_names() == ["a0o$b", "chf", "ft70$a", "l260", "ymu", "nbx"]
+
+
+def test_cast_message_is_not_matched_in_prose() -> None:
+    # A real cast message ends on the target class. Without that anchor, ordinary
+    # prose that happens to contain the word "cast" would offer candidates.
+    data = build_event(
+        [
+            {"value": "The provided value cannot be cast to a number, check the input"},
+            {"value": "Failed to cast the vote before the deadline"},
+        ]
+    )
+
+    excs = Exceptions(data)
+
+    assert excs.get_exception_class_names() == []
+
+
+def test_deobfuscate_bare_cast_message_class_names() -> None:
+    mapped_both = {"value": "a0o$b cannot be cast to chf"}
+    mapped_from = {"value": "a0o$b cannot be cast to missing"}
+    mapped_to = {"value": "unknown cannot be cast to chf"}
+    unmapped = {"value": "unknown cannot be cast to missing"}
+    data = build_event([mapped_both, mapped_from, mapped_to, unmapped])
+
+    excs = Exceptions(data)
+
+    classes = {
+        "a0o$b": "com.example.CastSource",
+        "chf": "com.example.CastTarget",
+    }
+
+    excs.deobfuscate_and_save(classes, mapped_exceptions=[])
+
+    assert mapped_both["value"] == (
+        "com.example.CastSource cannot be cast to com.example.CastTarget"
+    )
+    assert mapped_both["raw_value"] == "a0o$b cannot be cast to chf"
+    assert mapped_from["value"] == "com.example.CastSource cannot be cast to missing"
+    assert mapped_from["raw_value"] == "a0o$b cannot be cast to missing"
+    assert mapped_to["value"] == "unknown cannot be cast to com.example.CastTarget"
+    assert mapped_to["raw_value"] == "unknown cannot be cast to chf"
+    assert unmapped["value"] == "unknown cannot be cast to missing"
+    assert "raw_value" not in unmapped
+
+
+def test_deobfuscate_bare_cast_message_uses_atomic_reconstruction() -> None:
+    # `to` is a valid obfuscated class name and also appears in the message
+    # template. Reconstructing the value avoids replacing both occurrences.
+    exc = {"value": "a0o$b cannot be cast to to"}
+    data = build_event([exc])
+
+    excs = Exceptions(data)
+
+    classes = {
+        "a0o$b": "com.example.FirstNavigationResult$Declared",
+        "to": "com.example.SecondRegionResult",
+    }
+
+    excs.deobfuscate_and_save(classes, mapped_exceptions=[])
+
+    assert exc["value"] == (
+        "com.example.FirstNavigationResult$Declared cannot be cast to "
+        "com.example.SecondRegionResult"
+    )
+    assert exc["raw_value"] == "a0o$b cannot be cast to to"
+
+
 def test_deobfuscate_is_noop_when_no_classes_mapping() -> None:
     # Only value matches; no module/type entries and no classes mapping
     original = "Refs com.example.A and a.b$c$1 and 'o'"


### PR DESCRIPTION
  R8 package flattening can leave class names without a package, such as `a0o$b`
  or `chf`. We previously extracted only dotted class names or single names in
  quotes, so the operands in `a0o$b cannot be cast to chf` never made it into
  Symbolicator's class lookup.

  This change extracts bare names only when the entire exception value matches
  `<source> cannot be cast to <target>`. If either name has a mapping, it rebuilds
  the message and preserves the original in `raw_value`. Rebuilding instead of
  using substring replacement also avoids corrupting the message when a class
  name is a word from the template, such as `to`. The existing dotted and quoted
  name handling is unchanged.

  Tests cover extraction, prose that should not match, all mapping combinations,
  the `to` replacement case, and Relay/Symbolicator processing through both
  debug-file backends.