### PR TITLE
fix(admin): hide enterprise trial for non-free plans

### DIFF
--- a/static/gsAdmin/views/customerDetails.spec.tsx
+++ b/static/gsAdmin/views/customerDetails.spec.tsx
@@ -1182,11 +1182,13 @@ describe('Customer Details', () => {
       })[0]!
     );
 
+    expect(
+      screen.getByRole('option', {name: /Start Enterprise Trial/})
+    ).toBeInTheDocument();
     expect(screen.getByText(/capped event limits/)).toBeInTheDocument();
-    expect(screen.queryByText(/unlimited events/)).not.toBeInTheDocument();
   });
 
-  it('shows unlimited events help text for paid plan enterprise trial', async () => {
+  it('hides Start Enterprise Trial for paid plans', async () => {
     setUpMocks(organization, {plan: 'am3_business', isFree: false});
 
     render(<CustomerDetails />, {
@@ -1205,8 +1207,9 @@ describe('Customer Details', () => {
       })[0]!
     );
 
-    expect(screen.getByText(/unlimited events/)).toBeInTheDocument();
-    expect(screen.queryByText(/capped event limits/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('option', {name: /Start Enterprise Trial/})
+    ).not.toBeInTheDocument();
   });
 
   it('renders and hides generic confirmation modals', async () => {

--- a/static/gsAdmin/views/customerDetails.tsx
+++ b/static/gsAdmin/views/customerDetails.tsx
@@ -541,9 +541,9 @@ export function CustomerDetails() {
           {
             key: 'startEnterpriseTrial',
             name: 'Start Enterprise Trial',
-            help: subscription.isFree
-              ? 'Start enterprise trial with capped event limits (includes SSO).'
-              : 'Start enterprise trial with unlimited events (includes SSO).',
+            help: 'Start enterprise trial with capped event limits (includes SSO).',
+            // Enterprise trials from admin are only offered on free/developer plans.
+            visible: subscription.isFree,
             disabled: subscription.isPartner || subscription.isEnterpriseTrial,
             disabledReason: subscription.isPartner
               ? 'This account is managed by a third-party.'


### PR DESCRIPTION
Only show Start Enterprise Trial on free/developer plans in Customer Actions.

<img width="1990" height="778" alt="image" src="https://github.com/user-attachments/assets/1c784540-59af-4910-ba44-d5264d5e3d7d" />
<img width="1954" height="718" alt="image" src="https://github.com/user-attachments/assets/637bdb4d-31b6-4bc6-ba55-f962400d305f" />
<img width="1964" height="642" alt="image" src="https://github.com/user-attachments/assets/055cb7e5-bdad-4eea-a3ca-af1184ffca0c" />
<img width="2150" height="672" alt="image" src="https://github.com/user-attachments/assets/af32aa40-2bac-40ab-aeca-9ec1933cbe1c" />
