### PR TITLE
feat(refactor-tasks): Add lint-ignore and any-usage convention prototypes

### DIFF
--- a/.sentry-refactor-tasks/conventions/no-any-callsite.detect.sh
+++ b/.sentry-refactor-tasks/conventions/no-any-callsite.detect.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+#
+# Detector for the `no-any-callsite` convention.
+#
+# Flags TypeScript type-safety escape hatches across the frontend codebase:
+# explicit `any` usage (annotations, `as any`, `any[]`, `Array<any>`,
+# `Record<string, any>`, `Promise<any>`, and `Foo<any>` generic type
+# arguments) plus compiler-suppression comments (`@ts-ignore`,
+# `@ts-expect-error`, `@ts-nocheck`). This is pure grep, not a type-aware analysis — it cannot see
+# inferred `any` (e.g. an untyped third-party import flowing through) or
+# widened `any` from a missing type on a boundary. That's a real gap; a
+# type-aware detector (in the spirit of no-deprecated-callsite's
+# `@typescript-eslint/no-unsafe-*` rules) would be needed to close it, and is
+# out of scope here.
+#
+# Emits a JSON array on stdout, one object per hit:
+#   {"file": "...", "line": N, "category": "...", "context": "..."}
+# `category` is one of: ts-nocheck, ts-expect-error, ts-ignore, any-array,
+# any-record, any-promise, any-as, any-generic-arg, any-annotation.
+# All diagnostics go to stderr.
+#
+# Usage: no-any-callsite.detect.sh <repo-path>
+#   <repo-path>  checkout of the target repo (scanned at <repo-path>/static)
+set -euo pipefail
+
+repo_path="$1"
+static_dir="$repo_path/static"
+
+echo "Scanning $static_dir for TypeScript any-usage and suppression comments..." 1>&2
+
+# Candidate lines: anything that could plausibly be one of our categories.
+# Kept broad on purpose - exact classification happens in the python pass
+# below, in priority order, so a line matching more than one shape (e.g.
+# "state: any[]") is only counted once, under its most specific category.
+pattern='@ts-nocheck|@ts-expect-error|@ts-ignore|\bany\[\]|Array<\s*any\s*>|Record<\s*string\s*,\s*any\s*>|Promise<\s*any\s*>|\bas\s+any\b|<any>|:\s*any\b'
+
+if command -v rg >/dev/null 2>&1; then
+  matches=$(rg -n --no-heading --no-config -e "$pattern" \
+    -g '*.ts' -g '*.tsx' \
+    -g '!**/node_modules/**' -g '!**/__mocks__/**' -g '!**/__fixtures__/**' \
+    -g '!**/*.spec.*' -g '!**/*.test.*' -g '!**/test/**' \
+    "$static_dir" || true)
+else
+  matches=$(grep -rn -E --include='*.ts' --include='*.tsx' -e "$pattern" "$static_dir" \
+    | grep -v -E '/(node_modules|__mocks__|__fixtures__|test)/' \
+    | grep -v -E '\.(spec|test)\.' || true)
+fi
+
+hit_count=$(printf '%s\n' "$matches" | grep -c . || true)
+echo "Found $hit_count candidate line(s); classifying each..." 1>&2
+
+# Parse each "file:line:content" match into {file, line, category, context}.
+# Passed via process substitution (a filename), not `python3 - <<PYEOF`,
+# because a heredoc attached to the same command would redirect stdin too -
+# that would swallow the piped match data instead of leaving it for the
+# script's own `sys.stdin` read.
+printf '%s\n' "$matches" | python3 <(cat <<'PYEOF'
+import json
+import re
+import sys
+
+repo_path = sys.argv[1]
+
+# Checked in order; first match wins, so a line matching more than one shape
+# (e.g. "state: any[]" also trips the bare ": any" pattern) is classified
+# under its most specific category rather than double-counted.
+PATTERNS = [
+    ('ts-nocheck', re.compile(r'@ts-nocheck\b')),
+    ('ts-expect-error', re.compile(r'@ts-expect-error\b')),
+    ('ts-ignore', re.compile(r'@ts-ignore\b')),
+    ('any-array', re.compile(r'\bany\[\]|\bArray<\s*any\s*>')),
+    ('any-record', re.compile(r'\bRecord<\s*string\s*,\s*any\s*>')),
+    ('any-promise', re.compile(r'\bPromise<\s*any\s*>')),
+    ('any-as', re.compile(r'\bas\s+any\b')),
+    # `Foo<any>` generic type arguments (including the rare prefix-cast form
+    # `<any>value`). Angle brackets collide with JSX syntax, so this category
+    # is only ever matched for .ts files - the .tsx guard lives in the loop
+    # below.
+    ('any-generic-arg', re.compile(r'<any>')),
+    ('any-annotation', re.compile(r':\s*any\b')),
+]
+
+findings = []
+for raw_line in sys.stdin:
+    line = raw_line.rstrip('\n')
+    if not line:
+        continue
+    # file paths may contain ':' (rare), so split only on the first two
+    # colons after stripping the repo prefix rg/grep printed.
+    try:
+        file_part, lineno_part, content = line.split(':', 2)
+    except ValueError:
+        continue
+
+    is_tsx = file_part.endswith('.tsx')
+
+    category = None
+    for cat, pattern in PATTERNS:
+        if cat == 'any-generic-arg' and is_tsx:
+            continue
+        if pattern.search(content):
+            category = cat
+            break
+
+    if category is None:
+        continue
+
+    rel_file = file_part[len(repo_path) + 1 :] if file_part.startswith(repo_path) else file_part
+    findings.append(
+        {
+            'file': rel_file,
+            'line': int(lineno_part),
+            'category': category,
+            'context': content.strip(),
+        }
+    )
+
+json.dump(findings, sys.stdout)
+print()
+PYEOF
+) "$repo_path"

--- a/.sentry-refactor-tasks/conventions/no-any-callsite.yaml
+++ b/.sentry-refactor-tasks/conventions/no-any-callsite.yaml
@@ -1,0 +1,133 @@
+name: no-any-callsite
+severity: warning
+tags: [typescript, type-safety, tech-debt]
+
+why: |
+  `any` opts a value out of type checking entirely — every operation on it,
+  every property access, every value that flows from it into other code is
+  silently unchecked. A single `any` at a boundary can erase type safety for
+  everything downstream of it, which is worse than it looks at the callsite
+  where it's written. `@ts-ignore` and `@ts-expect-error` are the same problem
+  at the statement level (they silence whatever the checker would have
+  reported, correct or not), and `@ts-nocheck` at the file level.
+
+  Each hit here is either a real gap where the actual type was never worked
+  out (worth fixing), or a deliberate escape hatch for something the type
+  system can't express cleanly (worth understanding, possibly worth a better
+  type instead of `any`). The point isn't "delete every `any`" — some are
+  genuinely hard to avoid (untyped third-party libs, `JSON.parse` results) —
+  it's that each one should be a considered choice, not a shortcut past a type
+  error nobody looked at.
+
+  Scope note: this is a grep-based detector, not a type-aware one. It only
+  catches `any` written explicitly in source — `: any`, `as any`, `any[]`,
+  `Array<any>`, `Record<string, any>`, `Promise<any>`, and `Foo<any>` generic
+  arguments — plus the three compiler-suppression comments. It cannot see
+  *inferred* `any` (e.g. a value that becomes `any` because it flows in from
+  an untyped import, or a missing type at a module boundary that widens
+  silently). Closing that gap would need a type-aware rule in the spirit of
+  `no-deprecated-callsite`'s `@typescript-eslint/no-unsafe-*` family — a
+  separate, future convention, not this one.
+
+  Deliberately left out: `as unknown as X` (double-cast escape hatch) and bare
+  non-null assertions (`!`). Both are real type-safety escape hatches, but
+  neither greps reliably enough to be worth a false-positive rate this high —
+  `!` collides with the logical-not operator and definite-assignment
+  assertions on nearly every line of the codebase, and `as unknown as X`
+  requires distinguishing a genuine double-cast from two unrelated, adjacent
+  `as` expressions without an AST. Revisit both if a type-aware detector ever
+  covers this convention.
+
+detect_command: 'bash {convention_dir}/no-any-callsite.detect.sh {repo_path}'
+
+fix: |
+  Each finding names a `category`:
+    - any-annotation, any-array, any-record, any-promise, any-as,
+      any-generic-arg: explicit `any` written at the callsite.
+    - ts-ignore, ts-expect-error: a suppressed type error on the next
+      line/statement.
+    - ts-nocheck: type checking disabled for the whole file.
+
+  For explicit `any` (any-* categories):
+    1. Work out the real type from how the value is used: its call sites,
+       what's assigned to it, what shape the surrounding code expects. Prefer
+       the narrowest accurate type over a broad one.
+    2. If the value comes from a third-party library, check whether
+       `@types/<pkg>` or the package's own types already describe it — reach
+       for those before hand-writing a type.
+    3. If the value is genuinely unknown at this point (e.g. `JSON.parse`,
+       an untyped external payload), prefer `unknown` over `any` and narrow it
+       with a type guard where it's consumed — `unknown` still forces a check
+       before use, `any` doesn't.
+    4. Replace the `any` with the derived type. For `Record<string, any>`,
+       consider whether a specific interface fits better than a wider
+       `Record<string, unknown>`.
+
+  For `@ts-ignore` / `@ts-expect-error`:
+    1. Temporarily remove the comment and run
+       `pnpm tsc --noEmit <file>` (or open the file in an editor with the TS
+       language server) to see the actual error it was hiding.
+    2. Fix the real type error the suppression was masking — do not just
+       delete the comment and leave the code as-is if that reintroduces a
+       type error; do not just re-add the comment either.
+    3. If the error turns out to be a false positive from the checker itself
+       (rare), keep `@ts-expect-error` (never bare `@ts-ignore` — it doesn't
+       fail loudly when the underlying error is later fixed) and add a
+       comment explaining why.
+
+  For `@ts-nocheck`:
+    1. This disables checking for the entire file, so there may be many
+       latent errors underneath it — removing it can surface a large number
+       of type errors at once. Remove it and fix errors incrementally rather
+       than reverting if the count is large; do not re-add it as a shortcut.
+
+  Verify the fix by re-running the TypeScript checker on the changed file(s)
+  from the repo root:
+    pnpm tsc --noEmit --project config/tsconfig.build.json
+
+  Gotchas:
+    1. `any` is contagious — fixing one callsite may reveal that a type
+       upstream or downstream is also `any` (or was silently widened to it).
+       Follow the type through its immediate callers/callees rather than
+       stopping at the first line.
+    2. Don't replace `any` with `unknown` and stop there if the code then
+       needs an unsafe cast to use the value — that just moves the escape
+       hatch one line down. Narrow it properly, or leave a clear reason if a
+       cast is genuinely unavoidable.
+    3. Generic-arg hits (`Foo<any>`) sometimes exist because the generic type
+       itself has no other reasonable default — check the generic's
+       definition before assuming a concrete type is always available.
+    4. `@ts-expect-error` above a line that no longer errors will itself
+       become a type error ("Unused '@ts-expect-error' directive") once the
+       underlying bug is fixed — that's expected and confirms the fix worked.
+
+examples:
+  bad:
+    - 'function handleClick(event: any) { ... }'
+    - 'const data = response as any;'
+    - 'function useItems(): any[] { ... }'
+    - 'const config: Record<string, any> = loadConfig();'
+    - '// @ts-ignore\nconst value = maybeUndefined.property;'
+    - '// @ts-nocheck'
+  good:
+    - 'function handleClick(event: React.MouseEvent<HTMLButtonElement>) { ... }'
+    - 'const data = response as ApiResponse;'
+    - 'function useItems(): Item[] { ... }'
+    - 'const config: AppConfig = loadConfig();'
+    - 'const value = (maybeUndefined as {property?: string} | undefined)?.property;'
+
+# Test files are excluded: an untyped mock or fixture is a much more common
+# and more defensible pattern than untyped production code (the point of a
+# mock is often to stand in loosely for a shape you don't want to fully type),
+# so folding them into the same convention as production `any` usage would
+# mostly add noise. Mirrors no-unjustified-lint-ignore's exclude list.
+include:
+  - 'static/**/*.tsx'
+  - 'static/**/*.ts'
+exclude:
+  - '**/node_modules/**'
+  - '**/__fixtures__/**'
+  - '**/__mocks__/**'
+  - '**/*.spec.*'
+  - '**/*.test.*'
+  - '**/test/**'

--- a/.sentry-refactor-tasks/conventions/no-unjustified-lint-ignore.detect.sh
+++ b/.sentry-refactor-tasks/conventions/no-unjustified-lint-ignore.detect.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+#
+# Detector for the `no-unjustified-lint-ignore` convention.
+#
+# Flags inline lint-suppression comments — eslint-disable*, oxlint-disable*,
+# and biome-ignore* — across the frontend codebase. This is pure grep, not a
+# linter run: the target is the ignore *comment* itself (a callsite that opts
+# out of a rule), not a lint violation, so there is nothing to execute.
+#
+# Emits a JSON array on stdout, one object per hit:
+#   {"file": "...", "line": N, "tool": "eslint"|"oxlint"|"biome", "rules": [...]}
+# `rules` is empty for a bare `eslint-disable`/`oxlint-disable` (no rule name
+# listed — suppresses everything on that line/block, so there's no single
+# rule to look up docs for). All diagnostics go to stderr.
+#
+# Usage: no-unjustified-lint-ignore.detect.sh <repo-path>
+#   <repo-path>  checkout of the target repo (scanned at <repo-path>/static)
+set -euo pipefail
+
+repo_path="$1"
+static_dir="$repo_path/static"
+
+echo "Scanning $static_dir for lint-ignore comments..." 1>&2
+
+if command -v rg >/dev/null 2>&1; then
+  matches=$(rg -n --no-heading --no-config \
+    -e 'eslint-disable' -e 'oxlint-disable' -e 'biome-ignore' \
+    -g '*.ts' -g '*.tsx' -g '*.js' -g '*.jsx' \
+    -g '!**/node_modules/**' -g '!**/__mocks__/**' -g '!**/__fixtures__/**' \
+    -g '!**/*.spec.*' -g '!**/*.test.*' -g '!**/test/**' \
+    "$static_dir" || true)
+else
+  matches=$(grep -rn -E \
+    --include='*.ts' --include='*.tsx' --include='*.js' --include='*.jsx' \
+    -e 'eslint-disable' -e 'oxlint-disable' -e 'biome-ignore' "$static_dir" \
+    | grep -v -E '/(node_modules|__mocks__|__fixtures__|test)/' \
+    | grep -v -E '\.(spec|test)\.' || true)
+fi
+
+hit_count=$(printf '%s\n' "$matches" | grep -c . || true)
+echo "Found $hit_count candidate line(s); parsing tool/rule out of each..." 1>&2
+
+# Parse each "file:line:content" match into {file, line, tool, rules}. Kept as
+# a plain Python filter (not a separate script) so this convention stays a
+# single self-contained pair of files, mirroring how no-deprecated-callsite's
+# detector embeds its Node filter inline.
+#
+# The script body is passed via process substitution (a filename), not `python3
+# - <<PYEOF`, because a heredoc attached to the same command redirects stdin
+# too — that would swallow the piped match data instead of leaving it for the
+# script's own `sys.stdin` read.
+printf '%s\n' "$matches" | python3 <(cat <<'PYEOF'
+import json
+import re
+import sys
+
+repo_path = sys.argv[1]
+
+RULE_TOKEN = r'[A-Za-z0-9_@./-]+'
+RULES_LIST = rf'{RULE_TOKEN}(?:\s*,\s*{RULE_TOKEN})*'
+
+# Order matters within a tool: the "-line"/"-next-line" variants are checked
+# implicitly via the negative lookahead on the bare pattern, so a single pass
+# per tool is enough — each line matches at most one pattern.
+PATTERNS = [
+    ('eslint', re.compile(rf'\beslint-disable-next-line\b[ \t]*({RULES_LIST})?')),
+    ('eslint', re.compile(rf'\beslint-disable-line\b[ \t]*({RULES_LIST})?')),
+    ('eslint', re.compile(rf'\beslint-disable(?!-(?:next-)?line)\b[ \t]*({RULES_LIST})?')),
+    ('oxlint', re.compile(rf'\boxlint-disable-next-line\b[ \t]*({RULES_LIST})?')),
+    ('oxlint', re.compile(rf'\boxlint-disable-line\b[ \t]*({RULES_LIST})?')),
+    ('oxlint', re.compile(rf'\boxlint-disable(?!-(?:next-)?line)\b[ \t]*({RULES_LIST})?')),
+    ('biome', re.compile(rf'\bbiome-ignore-all\b[ \t]+lint/({RULE_TOKEN})\s*:')),
+    ('biome', re.compile(rf'\bbiome-ignore\b[ \t]+lint/({RULE_TOKEN})\s*:')),
+]
+
+findings = []
+for raw_line in sys.stdin:
+    line = raw_line.rstrip('\n')
+    if not line:
+        continue
+    # file paths may contain ':' (rare), so split only on the first two colons
+    # after stripping the repo prefix rg/grep printed.
+    try:
+        file_part, lineno_part, content = line.split(':', 2)
+    except ValueError:
+        continue
+
+    tool = None
+    rules: list[str] = []
+    for pattern_tool, pattern in PATTERNS:
+        m = pattern.search(content)
+        if m:
+            tool = pattern_tool
+            if m.group(1):
+                rules = [r.strip() for r in m.group(1).split(',') if r.strip()]
+            break
+
+    if tool is None:
+        continue
+
+    rel_file = file_part[len(repo_path) + 1 :] if file_part.startswith(repo_path) else file_part
+    findings.append(
+        {
+            'file': rel_file,
+            'line': int(lineno_part),
+            'tool': tool,
+            'rules': rules,
+            'context': content.strip(),
+        }
+    )
+
+json.dump(findings, sys.stdout)
+print()
+PYEOF
+) "$repo_path"

--- a/.sentry-refactor-tasks/conventions/no-unjustified-lint-ignore.yaml
+++ b/.sentry-refactor-tasks/conventions/no-unjustified-lint-ignore.yaml
@@ -1,0 +1,98 @@
+name: no-unjustified-lint-ignore
+severity: warning
+tags: [linting, tech-debt, documentation]
+
+why: |
+  An inline eslint-disable, oxlint-disable, or biome-ignore comment silences a
+  rule that someone, at some point, decided the codebase should follow. Left
+  alone, each one is either a violation that should have been fixed instead of
+  hidden, or a genuine exception that nobody wrote down the reasoning for — so
+  the next person to touch that line has no way to tell which.
+
+  A bare disable (no rule name — silences everything on that line/block) is
+  worse: it can mask new violations introduced later by unrelated edits, and
+  there's no single rule to go verify.
+
+  The point of this convention isn't "delete every ignore comment" — some
+  suppressions are correct. It's that whoever looks at a hit should see what
+  the suppressed rule actually wants (its own documented bad/good examples),
+  so they can tell the difference between a violation worth fixing and an
+  exception worth documenting, instead of guessing.
+
+detect_command: 'bash {convention_dir}/no-unjustified-lint-ignore.detect.sh {repo_path}'
+
+fix: |
+  Each finding names a `tool` (eslint, oxlint, or biome) and one or more
+  `rules` suppressed at that line (empty `rules` means a bare disable with no
+  rule listed — see the gotcha below).
+
+  Steps:
+    1. For each rule name in the finding, look up its canonical doc page:
+         - eslint core/plugin rule:  https://eslint.org/docs/latest/rules/<rule>
+           (for a scoped/plugin rule like `react-hooks/exhaustive-deps` or
+           `@typescript-eslint/no-base-to-string`, search the plugin's own docs
+           instead — eslint.org only hosts core rules)
+         - oxlint:  https://oxc.rs/docs/guide/usage/linter/rules/<rule>.html
+         - biome:   the finding's rule is `<group>/<name>` (e.g.
+           `suspicious/noExplicitAny`); the doc lives at
+           https://biomejs.dev/linter/rules/<kebab-case-name>/ — drop the group,
+           kebab-case the rule name (`noExplicitAny` -> `no-explicit-any`)
+    2. Pull that page's "incorrect"/"correct" (or bad/good) example snippets.
+       Put them in the generated issue body under the finding, alongside a
+       one-line summary of what the rule enforces — this lookup is the reason
+       this convention exists; do not skip it even if the fix looks obvious.
+    3. Decide, using those examples plus the actual code at the callsite:
+         - If the code is a real violation: fix it and remove the ignore
+           comment (or narrow it to just the rules still legitimately needed,
+           if the line trips more than one).
+         - If the suppression is genuinely necessary: keep it, but replace or
+           add a comment stating *why*, next to the disable/ignore comment.
+           Biome already requires a reason after `biome-ignore lint/x/y:` —
+           make sure that reason is still accurate, not boilerplate.
+    4. Re-run the tool that owns the rule (`pnpm eslint <file>`, the oxlint or
+       biome equivalent) to confirm the line is clean or, if kept, that the
+       reason comment doesn't trip a "require description" meta-rule.
+
+  Gotchas:
+    1. A bare `eslint-disable`/`oxlint-disable` (no rule name, `rules: []` in
+       the finding) silences everything on that line/block — there is no
+       single doc page to fetch. Read the surrounding code to work out which
+       rule(s) were actually being avoided (temporarily removing the comment
+       and running the linter on that file is the fastest way to find out),
+       then treat each one individually per the steps above.
+    2. `eslint-disable` / `oxlint-disable` with no `-line`/`-next-line` suffix
+       suppresses the rule(s) for the rest of the file (or until a matching
+       `-enable`), not just one line — check how much code it actually covers
+       before deciding a targeted fix is even possible.
+    3. Don't just delete the comment without addressing the underlying code —
+       that turns a documented suppression into an undocumented lint failure
+       (or reintroduces the very bug the rule exists to catch) and breaks CI.
+    4. Some suppressions guard against false positives in the rule itself
+       (common with type-narrowing edge cases); the doc's examples should make
+       that distinguishable from an actual violation, but when genuinely
+       unsure, prefer keeping the suppression with a clearer reason over
+       guessing at a code change.
+
+examples:
+  bad:
+    - '// eslint-disable-next-line react-hooks/exhaustive-deps'
+    - 'console.error(err); // eslint-disable-line no-console'
+    - '/* eslint-disable unicorn/filename-case */'
+    - '// eslint-disable-next-line'
+  good:
+    - '// eslint-disable-next-line react-hooks/exhaustive-deps -- deliberately omitting `dispatch`, which is stable per React docs'
+    - 'logger.error(err); // structured logger, no-console does not apply'
+    - '// biome-ignore lint/suspicious/noExplicitAny: bridging an untyped third-party callback'
+
+include:
+  - 'static/**/*.tsx'
+  - 'static/**/*.ts'
+  - 'static/**/*.jsx'
+  - 'static/**/*.js'
+exclude:
+  - '**/node_modules/**'
+  - '**/__fixtures__/**'
+  - '**/__mocks__/**'
+  - '**/*.spec.*'
+  - '**/*.test.*'
+  - '**/test/**'


### PR DESCRIPTION
Two prototype `@sentry/refactor-tasks` conventions, each a grep-based `detect_command` (no LLM, no eslint/tsc invocation) with a local run recorded in the yaml's `why`/notes for scale sanity-checking:

**`no-unjustified-lint-ignore`** — flags every `eslint-disable`/`oxlint-disable`/`biome-ignore` callsite in `static/`, capturing the tool and suppressed rule name(s) per hit. 495 hits locally today, all ESLint (repo doesn't use oxlint/biome yet), zero bare/unnamed disables. Its `fix` instructions tell the fixing agent to look up the suppressed rule's own doc page and pull good/bad examples into the generated issue, rather than just deleting the ignore comment blind.

**`no-any-callsite`** — flags `any` usage (`: any`, `as any`, `any[]`, `Record<string, any>`, `Promise<any>`, generic `Foo<any>`) and TS compiler-suppression comments (`@ts-ignore`, `@ts-expect-error`, `@ts-nocheck`) in `static/`, excluding test/mock/fixture files. 1,853 hits locally today; `@ts-expect-error` alone accounts for 392. `as unknown as X` and bare `!` were left out — both need real AST matching to avoid false positives via grep, noted as a gap for a future type-aware detector.

Both are prototypes to size the problem before wiring into the scheduled scan — not yet added to the daily workflow.
