### PR TITLE
fix(inbox): clear the preview prefetch timer on unmount

### DIFF
--- a/static/app/views/issueList/pages/useInboxPreviewPrefetch.spec.tsx
+++ b/static/app/views/issueList/pages/useInboxPreviewPrefetch.spec.tsx
@@ -1,7 +1,7 @@
 import {GroupFixture} from 'sentry-fixture/group';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {act, fireEvent, render, screen} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {useInboxPreviewPrefetch} from 'sentry/views/issueList/pages/useInboxPreviewPrefetch';
 
@@ -35,18 +35,20 @@ describe('useInboxPreviewPrefetch', () => {
     jest.useRealTimers();
   });
 
+  const user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});
+
   function hover() {
-    fireEvent.mouseEnter(screen.getByText('Issue card'));
+    return user.hover(screen.getByText('Issue card'));
   }
 
   function unhover() {
-    fireEvent.mouseLeave(screen.getByText('Issue card'));
+    return user.unhover(screen.getByText('Issue card'));
   }
 
-  it('prefetches the issue when hovered for the delay', () => {
+  it('prefetches the issue when hovered for the delay', async () => {
     render(<IssueCard groupId={group.id} />, {organization});
 
-    hover();
+    await hover();
     act(() => {
       jest.advanceTimersByTime(PREFETCH_DELAY_MS);
     });
@@ -54,11 +56,11 @@ describe('useInboxPreviewPrefetch', () => {
     expect(groupRequest).toHaveBeenCalledTimes(1);
   });
 
-  it('does not prefetch the issue when unhovered before the delay', () => {
+  it('does not prefetch the issue when unhovered before the delay', async () => {
     render(<IssueCard groupId={group.id} />, {organization});
 
-    hover();
-    unhover();
+    await hover();
+    await unhover();
     act(() => {
       jest.advanceTimersByTime(PREFETCH_DELAY_MS);
     });
@@ -66,10 +68,10 @@ describe('useInboxPreviewPrefetch', () => {
     expect(groupRequest).not.toHaveBeenCalled();
   });
 
-  it('does not prefetch the issue when unmounted before the delay', () => {
+  it('does not prefetch the issue when unmounted before the delay', async () => {
     const {unmount} = render(<IssueCard groupId={group.id} />, {organization});
 
-    hover();
+    await hover();
     unmount();
     act(() => {
       jest.advanceTimersByTime(PREFETCH_DELAY_MS);

--- a/static/app/views/issueList/pages/useInboxPreviewPrefetch.spec.tsx
+++ b/static/app/views/issueList/pages/useInboxPreviewPrefetch.spec.tsx
@@ -1,0 +1,80 @@
+import {GroupFixture} from 'sentry-fixture/group';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {act, fireEvent, render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {useInboxPreviewPrefetch} from 'sentry/views/issueList/pages/useInboxPreviewPrefetch';
+
+const PREFETCH_DELAY_MS = 300;
+
+function IssueCard({groupId}: {groupId: string}) {
+  const hoverProps = useInboxPreviewPrefetch(groupId);
+
+  return <div {...hoverProps}>Issue card</div>;
+}
+
+describe('useInboxPreviewPrefetch', () => {
+  const organization = OrganizationFixture();
+  const group = GroupFixture({id: '101'});
+
+  let groupRequest: jest.Mock;
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    groupRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${group.id}/`,
+      body: group,
+    });
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  function hover() {
+    fireEvent.mouseEnter(screen.getByText('Issue card'));
+  }
+
+  function unhover() {
+    fireEvent.mouseLeave(screen.getByText('Issue card'));
+  }
+
+  it('prefetches the issue when hovered for the delay', () => {
+    render(<IssueCard groupId={group.id} />, {organization});
+
+    hover();
+    act(() => {
+      jest.advanceTimersByTime(PREFETCH_DELAY_MS);
+    });
+
+    expect(groupRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not prefetch the issue when unhovered before the delay', () => {
+    render(<IssueCard groupId={group.id} />, {organization});
+
+    hover();
+    unhover();
+    act(() => {
+      jest.advanceTimersByTime(PREFETCH_DELAY_MS);
+    });
+
+    expect(groupRequest).not.toHaveBeenCalled();
+  });
+
+  it('does not prefetch the issue when unmounted before the delay', () => {
+    const {unmount} = render(<IssueCard groupId={group.id} />, {organization});
+
+    hover();
+    unmount();
+    act(() => {
+      jest.advanceTimersByTime(PREFETCH_DELAY_MS);
+    });
+
+    expect(groupRequest).not.toHaveBeenCalled();
+  });
+});

--- a/static/app/views/issueList/pages/useInboxPreviewPrefetch.tsx
+++ b/static/app/views/issueList/pages/useInboxPreviewPrefetch.tsx
@@ -1,4 +1,4 @@
-import {useRef} from 'react';
+import {useEffect, useRef} from 'react';
 import {useHover} from '@react-aria/interactions';
 import {useQueryClient} from '@tanstack/react-query';
 
@@ -35,6 +35,10 @@ export function useInboxPreviewPrefetch(groupId: string) {
       clearTimeout(timeoutRef.current);
     },
   });
+
+  // Unmounting does not run onHoverEnd, so without this a card that unmounts
+  // while hovered still fires its prefetch.
+  useEffect(() => () => clearTimeout(timeoutRef.current), []);
 
   return hoverProps;
 }

--- a/static/app/views/issueList/pages/useInboxPreviewPrefetch.tsx
+++ b/static/app/views/issueList/pages/useInboxPreviewPrefetch.tsx
@@ -1,8 +1,8 @@
-import {useEffect, useRef} from 'react';
 import {useHover} from '@react-aria/interactions';
 import {useQueryClient} from '@tanstack/react-query';
 
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {useTimeout} from 'sentry/utils/useTimeout';
 import {groupApiOptions} from 'sentry/views/issueDetails/useGroup';
 import {useEnvironmentsFromUrl} from 'sentry/views/issueDetails/utils';
 
@@ -16,29 +16,27 @@ export function useInboxPreviewPrefetch(groupId: string) {
   const organization = useOrganization();
   const queryClient = useQueryClient();
   const environments = useEnvironmentsFromUrl();
-  const timeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
 
-  const {hoverProps} = useHover({
-    onHoverStart: () => {
-      timeoutRef.current = setTimeout(() => {
-        queryClient.prefetchQuery(
-          groupApiOptions({
-            groupId,
-            organizationSlug: organization.slug,
-            environments,
-            expandDerivedData: organization.features.includes('issue-stream-progress-ui'),
-          })
-        );
-      }, PREFETCH_DELAY_MS);
-    },
-    onHoverEnd: () => {
-      clearTimeout(timeoutRef.current);
+  const {start, cancel} = useTimeout({
+    timeMs: PREFETCH_DELAY_MS,
+    onTimeout: () => {
+      queryClient.prefetchQuery(
+        groupApiOptions({
+          groupId,
+          organizationSlug: organization.slug,
+          environments,
+          expandDerivedData: organization.features.includes('issue-stream-progress-ui'),
+        })
+      );
     },
   });
 
-  // Unmounting does not run onHoverEnd, so without this a card that unmounts
-  // while hovered still fires its prefetch.
-  useEffect(() => () => clearTimeout(timeoutRef.current), []);
+  const {hoverProps} = useHover({
+    // Both are wrapped because react-aria passes a hover event, which `start`
+    // would read as an override duration.
+    onHoverStart: () => start(),
+    onHoverEnd: () => cancel(),
+  });
 
   return hoverProps;
 }


### PR DESCRIPTION
Master's frontend workflow has been red since #121729, with `inbox.spec.tsx › shows suggested owners on inbox cards` failing on `No mocked response found for request: GET /organizations/org-slug/issues/101/`. Issue 101 is `fixProposedGroup`, which that test deliberately mocks *out* of every section, so the request cannot originate there.

`useInboxPreviewPrefetch` arms a 300ms timer on hover start and clears it on hover end. Unmounting never runs `onHoverEnd`, so a card unmounted while hovered still fires its prefetch — after the test that armed it has finished and its mocks have been cleared. `jest-fail-on-console` then bills the resulting error to whichever test happens to be running.

### Measured

Instrumenting the timer callback with the current jest test name, running `inbox.spec.tsx`:

**Before** — 10 prefetches fire, 9 of them during a different test than the one that armed them:

| armed in | fired during |
| --- | --- |
| `loads and renders the three progress sections` | `shows a plus sign when a section count reaches the API cap` |
| `marks an issue as seen…`, `keeps an issue unread…` | `loads and appends the next page of a section`, `prefetches the preview on hover` |
| `continues in Seer when…`, `retries a failed Autofix pull request` | `on desktop follows section order even when a later section resolves first` |

The reach is wider than the two explicit `hover()` calls: any `userEvent` interaction that moves the pointer across a card arms the timer, which happens in 14 of the file's tests.

**After** — zero cross-test fires. The only prefetch left is inside `prefetches the preview on hover`, the test that asserts it.

What that does and does not establish: the suite is green locally both before and after, because locally the strays land in tests that happen to mock 101. This removes the only mechanism that emits `GET /organizations/:org/issues/:id/` outside the test that triggered it, which is the request CI is complaining about. This PR's own CI run is the confirmation.

### Fix

`useTimeout` already cancels on unmount, and drops a pending timer when restarted — both of which the hand-rolled ref lacked. The new spec covers hover, unhover, and unmount; the unmount case fails against the current implementation and passes with this one.

Not only a test concern: hovering a card and navigating away inside 300ms fires a request nobody consumes.

### Follow-up left alone

`shows up to two pull request badges only in pull request sections` mocks `/issues/101/` without ever opening the preview, which looks like it was absorbing this same stray. The file is green locally without that mock, but I could not verify it under CI's timing, so I left it in place rather than risk trading one CI-only failure for another.
