### PR TITLE
perf(seer): Reduce recommended event query fanout

### DIFF
--- a/src/sentry/seer/agent/tools.py
+++ b/src/sentry/seer/agent/tools.py
@@ -1,5 +1,4 @@
 import logging
-import time
 import uuid
 from datetime import UTC, datetime, timedelta, timezone
 from typing import Any, TypedDict, cast
@@ -29,7 +28,8 @@ from sentry.models.activity import Activity
 from sentry.models.apikey import ApiKey
 from sentry.models.commit import Commit
 from sentry.models.commitfilechange import CommitFileChange
-from sentry.models.group import EventOrdering, Group
+from sentry.models.group import Group
+from sentry.models.group import get_recommended_event as get_group_recommended_event
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.projectkey import ProjectKey, ProjectKeyStatus, UseCase
@@ -63,7 +63,6 @@ from sentry.seer.agent.utils import (
     _convert_profile_to_execution_tree,
     fetch_profile_data,
     get_group_date_range,
-    get_retention_boundary,
 )
 from sentry.seer.autofix.autofix import get_all_tags_overview
 from sentry.seer.autofix.utils import get_repo_url_path
@@ -1188,168 +1187,27 @@ def _get_recommended_event(
     start: datetime | None = None,
     end: datetime | None = None,
 ) -> GroupEvent | None:
-    """
-    Our own implementation of Group.get_recommended_event. Requires the return event to fall in the time range and have a non-empty trace.
-    Time range defaults to the group's first and last seen times.
-    If multiple events are valid, return the one with highest RECOMMENDED ordering.
-    If no events are valid, return the highest recommended event.
-
-    Also falls back to the regular recommended event in case of query failures or custom timeout.
-    """
-    start_time = time.time()
-
-    # Config
-    max_date_range = timedelta(days=14)  # Clamp date range as the query loop can be very expensive.
-    timeout = 50  # Sentry API timeout is 60s - 10s buffer.
-    event_query_limit = 50  # Events/trace IDs to query in each window.
-    window_size = timedelta(days=3)
-
+    """Return the recommended event from a bounded range, then fall back to the latest event."""
     start, end = get_group_date_range(group, organization, start, end)
     unclamped_start = start
-    start = max(start, end - max_date_range)
-    retention_boundary = get_retention_boundary(organization, bool(start.tzinfo))
-    window_start = max(end - window_size, start)
-    window_end = end
-    # Fallback to first event we find (most recommended in most recent window).
-    fallback_event: GroupEvent | None = None
+    start = max(start, end - timedelta(days=14))
 
-    if group.issue_category == GroupCategory.ERROR:
-        dataset = Dataset.Events
-    else:
-        dataset = Dataset.IssuePlatform
+    try:
+        event = get_group_recommended_event(group=group, start=start, end=end)
+    except Exception:
+        logger.exception(
+            "_get_recommended_event: eventstore query failed",
+            extra={
+                "organization_id": organization.id,
+                "project_id": group.project.id,
+                "issue_id": group.id,
+                "start": start,
+                "end": end,
+            },
+        )
+        event = None
 
-    def get_latest_event() -> GroupEvent | None:
-        """If no events are found in the clamped range, use this query to return most recent event in the full range."""
-        return group.get_latest_event(start=unclamped_start, end=end)
-
-    logger.info(
-        "_get_recommended_event: starting query loop",
-        extra={
-            "organization_id": organization.id,
-            "project_id": group.project.id,
-            "issue_id": group.id,
-            "timedelta": end - start,
-            "start": start,
-            "end": end,
-            "dataset": dataset.value,
-        },
-    )
-
-    while window_start >= start:
-        if time.time() - start_time > timeout:
-            logger.warning(
-                "_get_recommended_event: timeout reached",
-                extra={
-                    "organization_id": organization.id,
-                    "project_id": group.project.id,
-                    "issue_id": group.id,
-                    "timedelta": end - start,
-                    "start": start,
-                    "end": end,
-                    "dataset": dataset.value,
-                    "timeout": timeout,
-                },
-            )
-            return fallback_event or get_latest_event()
-
-        # Get candidate events with the standard recommended ordering.
-        # This is an expensive orderby, hence the inner limit and sliding window.
-        try:
-            events: list[Event] = eventstore.backend.get_events_snql(
-                organization_id=organization.id,
-                group_id=group.id,
-                start=window_start,
-                end=window_end,
-                conditions=[
-                    Condition(Column("project_id"), Op.IN, [group.project.id]),
-                    Condition(Column("group_id"), Op.IN, [group.id]),
-                ],
-                limit=event_query_limit,
-                orderby=EventOrdering.RECOMMENDED.value,
-                referrer=Referrer.SEER_EXPLORER_TOOLS,
-                dataset=dataset,
-                tenant_ids={"organization_id": group.project.organization_id},
-                inner_limit=1000,
-            )
-        except Exception:
-            logger.exception(
-                "_get_recommended_event: eventstore query failed",
-                extra={
-                    "organization_id": organization.id,
-                    "project_id": group.project.id,
-                    "issue_id": group.id,
-                    "dataset": dataset.value,
-                },
-            )
-            return fallback_event or get_latest_event()
-
-        if events and not fallback_event:
-            fallback_event = events[0].for_group(group)
-
-        trace_ids = list({e.trace_id for e in events if e.trace_id})
-
-        if len(trace_ids) > 0:
-            # Query EAP to get the span count of each trace.
-            # Extend the time range by +-1 day to account for min/max trace start/end times.
-            # Clamp spans_start to retention boundary to avoid QueryOutsideRetentionError.
-            spans_start = max(window_start - timedelta(days=1), retention_boundary)
-            spans_end = window_end + timedelta(days=1)
-            count_field = "count(span.duration)"
-
-            try:
-                result = execute_table_query(
-                    org_id=organization.id,
-                    dataset="spans",
-                    per_page=len(trace_ids),
-                    fields=["trace", count_field],
-                    query=f"trace:[{','.join(trace_ids)}]",
-                    start=spans_start.isoformat(),
-                    end=spans_end.isoformat(),
-                )
-            except Exception:
-                logger.exception(
-                    "_get_recommended_event: spans query failed",
-                    extra={
-                        "organization_id": organization.id,
-                        "project_id": group.project.id,
-                        "issue_id": group.id,
-                        "num_trace_ids": len(trace_ids),
-                    },
-                )
-                return fallback_event or get_latest_event()
-
-            if isinstance(result, ExecuteQuerySuccessResponse) and result.data:
-                # Return the first event with a span count greater than 0.
-                traces_with_spans = {
-                    item["trace"]
-                    for item in result.data
-                    if item.get("trace") and item.get(count_field, 0) > 0
-                }
-
-                for e in events:
-                    if e.trace_id in traces_with_spans:
-                        return e.for_group(group)
-
-        if window_start == start:
-            break
-
-        window_end = window_start
-        window_start = max(window_start - window_size, start)
-
-    logger.warning(
-        "_get_recommended_event: no event with a span found",
-        extra={
-            "issue_id": group.id,
-            "organization_id": organization.id,
-            "project_id": group.project.id,
-            "start": start,
-            "end": end,
-            "timedelta": end - start,
-            "dataset": dataset.value,
-            "has_fallback_event": bool(fallback_event),
-        },
-    )
-    return fallback_event or get_latest_event()
+    return event or group.get_latest_event(start=unclamped_start, end=end)
 
 
 # Activity types to include in issue details for Seer Agent (manual actions only)
@@ -1679,13 +1537,6 @@ class _IssueCommitters:
                 self.group, self.organization, self.start_dt, self.end_dt
             )
             if event is None:
-                # Frame blame only needs a stacktrace, not a span/trace.
-                # _get_recommended_event requires a span-bearing event and returns None
-                # for issues without spans (the common case for error issues), which
-                # would silently drop frame blame. Fall back to the latest event so the
-                # failing frames are still available. Frame paths are stable across an
-                # issue's events, so this is a safe source for blame. Thread the window
-                # through so a caller-supplied start/end is still honored (no-op when empty).
                 event = self.group.get_latest_event(start=self.start_dt, end=self.end_dt)
             if event is None:
                 return []
@@ -2001,7 +1852,15 @@ def get_event_details(
         Dict with serialized event, event_id, event_trace_id, project_id, project_slug, or None if not found.
     """
     if bool(event_id) == bool(issue_id):
-        raise BadRequest("Either event_id or issue_id must be provided, but not both.")
+        raise ParseError("Provide exactly one of event_id or issue_id.")
+    if event_id is not None:
+        try:
+            event_id = uuid.UUID(event_id).hex
+        except ValueError as e:
+            raise ParseError(
+                "event_id must be the full 32-character hexadecimal event ID. "
+                "Use the complete event ID from issue details, not its 8-character prefix."
+            ) from e
 
     organization = Organization.objects.get(id=organization_id)
 
@@ -2033,8 +1892,6 @@ def get_event_details(
         if not project_ids:
             return None
 
-        # Fetch the event directly by ID.
-        uuid.UUID(event_id)  # Raises ValueError if not valid UUID
         if len(project_ids) == 1:
             event = eventstore.backend.get_event_by_id(
                 project_id=project_ids[0],

--- a/tests/sentry/seer/agent/test_tools.py
+++ b/tests/sentry/seer/agent/test_tools.py
@@ -7,6 +7,7 @@ import pytest
 from django.core.cache import cache
 from django.core.exceptions import BadRequest, ObjectDoesNotExist
 from pydantic import BaseModel
+from rest_framework.exceptions import ParseError
 from sentry_protos.snuba.v1.trace_item_pb2 import TraceItem
 
 from sentry.api import client
@@ -2039,7 +2040,7 @@ class TestGetEventDetails(
     # --- both params / neither param ---
 
     def test_raises_if_both_event_id_and_issue_id(self) -> None:
-        with pytest.raises(BadRequest):
+        with pytest.raises(ParseError):
             get_event_details(
                 organization_id=self.organization.id,
                 event_id=uuid.uuid4().hex,
@@ -2047,7 +2048,7 @@ class TestGetEventDetails(
             )
 
     def test_raises_if_neither_event_id_nor_issue_id(self) -> None:
-        with pytest.raises(BadRequest):
+        with pytest.raises(ParseError):
             get_event_details(organization_id=self.organization.id)
 
     # --- fetch by event_id ---
@@ -2084,12 +2085,11 @@ class TestGetEventDetails(
         )
         assert result is None
 
-    def test_by_event_id_invalid_uuid_raises(self) -> None:
-        with pytest.raises(ValueError):
+    def test_by_event_id_invalid_uuid_returns_actionable_error(self) -> None:
+        with pytest.raises(ParseError, match="full 32-character hexadecimal event ID"):
             get_event_details(
-                organization_id=self.organization.id,
+                organization_id=1,
                 event_id="not-a-uuid",
-                project_slug=self.project.slug,
             )
 
     def test_by_event_id_wrong_project_returns_none(self) -> None:
@@ -2436,45 +2436,37 @@ class TestGetRecommendedEvent(APITransactionTestCase, SnubaTestCase):
         return self.store_event(data=data, project_id=project_id)
 
     def test_get_recommended_event_start_clamped_to_retention(self) -> None:
-        """
-        Start is clamped to retention boundary. Spans query should also be clamped.
-        """
         project = self.create_project()
         now = datetime.now(UTC)
         start = now - timedelta(days=11)
         end = now
-
         retention_days = 5
         retention_boundary = now - timedelta(days=retention_days)
-
-        # Event right after boundary to test spans query clamping to boundary
         event = self.store_event_helper(
             dt=retention_boundary + timedelta(hours=1),
             project_id=project.id,
-            trace_id=uuid.uuid4().hex,
-            span_id="1" + uuid.uuid4().hex[:15],
         )
         assert event.group is not None
 
-        with patch(
-            "sentry.quotas.backend.get_event_retention",
-            return_value=retention_days,
+        with (
+            patch("sentry.quotas.backend.get_event_retention", return_value=retention_days),
+            patch(
+                "sentry.seer.agent.tools.get_group_recommended_event",
+                return_value=event.for_group(event.group),
+            ) as mock_get_recommended_event,
         ):
-            with patch("sentry.seer.agent.tools.execute_table_query") as mock_execute_table_query:
-                mock_execute_table_query.return_value = {"data": []}
-                result = _get_recommended_event(
-                    group=event.group,
-                    organization=project.organization,
-                    start=start,
-                    end=end,
-                )
+            result = _get_recommended_event(
+                group=event.group,
+                organization=project.organization,
+                start=start,
+                end=end,
+            )
 
-                assert isinstance(result, GroupEvent)
-                assert result.event_id == event.event_id
-
-                # spans query should use retention boundary
-                spans_start = datetime.fromisoformat(mock_execute_table_query.call_args[1]["start"])
-                assert abs(spans_start - retention_boundary) < timedelta(minutes=1)
+        assert isinstance(result, GroupEvent)
+        assert result.event_id == event.event_id
+        query_start = mock_get_recommended_event.call_args.kwargs["start"]
+        assert abs(query_start - retention_boundary) < timedelta(minutes=1)
+        mock_get_recommended_event.assert_called_once()
 
     def test_get_recommended_event_end_outside_retention(self) -> None:
         """
@@ -2529,38 +2521,28 @@ class TestGetRecommendedEvent(APITransactionTestCase, SnubaTestCase):
         assert isinstance(result, GroupEvent)
         assert result.event_id == event2.event_id
 
-    def test_get_recommended_event_fallback_if_no_events_with_spans_in_clamped_range(self) -> None:
-        """Falls back to most recent event if no events with spans in clamped range."""
+    def test_get_recommended_event_does_not_query_spans(self) -> None:
         project = self.create_project()
         now = datetime.now(UTC)
-        start = now - timedelta(days=30)
-        end = now
-        clamped_start = end - self.max_date_range
-
-        # Event before clamped start
-        event1 = self.store_event_helper(
-            dt=clamped_start - timedelta(hours=10),
+        event = self.store_event_helper(
+            dt=now - timedelta(hours=1),
             project_id=project.id,
+            trace_id=uuid.uuid4().hex,
+            span_id="1" + uuid.uuid4().hex[:15],
         )
+        assert event.group is not None
 
-        # Event with trace, but no stored spans after clamped start
-        event2 = self.store_event_helper(
-            dt=clamped_start + timedelta(hours=10),
-            project_id=project.id,
-            # trace_id=uuid.uuid4().hex,
-            # span_id="1" + uuid.uuid4().hex[:15],
-        )
-        assert event1.group is not None
-        assert event1.group == event2.group
+        with patch("sentry.seer.agent.tools.execute_table_query") as mock_execute_table_query:
+            result = _get_recommended_event(
+                group=event.group,
+                organization=project.organization,
+                start=now - timedelta(days=1),
+                end=now,
+            )
 
-        result = _get_recommended_event(
-            group=event1.group,
-            organization=project.organization,
-            start=start,
-            end=end,
-        )
         assert isinstance(result, GroupEvent)
-        assert result.event_id == event2.event_id
+        assert result.event_id == event.event_id
+        mock_execute_table_query.assert_not_called()
 
 
 class TestGetRepositoryDefinition(APITransactionTestCase):

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -144,6 +144,24 @@ class TestSeerRpc(APITestCase):
         assert response.status_code == 503
         assert "Service temporarily unavailable" in response.data["detail"]
 
+    def test_short_event_id_returns_actionable_400(self) -> None:
+        organization = self.create_organization()
+        path = self._get_path("get_event_details")
+        data: dict[str, Any] = {
+            "args": {"organization_id": organization.id, "event_id": "deadbeef"},
+            "meta": {},
+        }
+
+        response = self.client.post(
+            path, data=data, HTTP_AUTHORIZATION=self.auth_header(path, data)
+        )
+
+        assert response.status_code == 400
+        assert response.data["detail"] == (
+            "event_id must be the full 32-character hexadecimal event ID. "
+            "Use the complete event ID from issue details, not its 8-character prefix."
+        )
+
     def test_generic_exceptions_return_500(self) -> None:
         """Test that generic exceptions return 500 instead of 400."""
         path = self._get_path("get_organization_slug")


### PR DESCRIPTION
Seer event retrieval now uses one normal recommended-event query over a range capped at 14 days, then falls back to the latest event in the original range. This removes the sliding-window event queries and per-window EAP span lookups that multiply work during Night Shift runs.

The selected event is no longer required to have stored spans; event details remain available even when trace data is absent. Malformed event IDs now return an actionable 400 response instead of becoming an internal error.

Observed in [SEER-91X](https://sentry.sentry.io/issues/7609006133/).
