### PR TITLE
feat(action-log): Record pull request origins

### DIFF
--- a/src/sentry/issues/action_log/backfill.py
+++ b/src/sentry/issues/action_log/backfill.py
@@ -24,6 +24,7 @@ from sentry.issues.action_log.types import (
     GroupActionType,
     PullRequestClosedAction,
     PullRequestMergedAction,
+    PullRequestOrigin,
     PullRequestReopenedAction,
 )
 from sentry.issues.derived.processing import invalidate_group_derived_data
@@ -35,6 +36,7 @@ from sentry.models.pullrequest import (
     PullRequestLifecycleState,
     is_open_pull_request_state,
 )
+from sentry.seer.models.run import SeerRunPullRequest
 from sentry.utils import json, metrics
 from sentry.utils.action_log.activity_translator import activity_to_action
 
@@ -231,14 +233,11 @@ def backfill_group_activities(
     return total_created
 
 
-def _latest_pr_lifecycle_actions(
+def _pr_lifecycle_actions_by_pull_request(
     *, group_id: int, project_id: int
-) -> dict[int, GroupActionLogEntry]:
-    """Map pull request id to its most recently logged lifecycle action.
-
-    Entries are scanned oldest first so the last write per pull request wins.
-    """
-    latest_actions: dict[int, GroupActionLogEntry] = {}
+) -> dict[int, list[GroupActionLogEntry]]:
+    """Group lifecycle actions by pull request in chronological order."""
+    actions_by_pull_request: dict[int, list[GroupActionLogEntry]] = {}
     logged_entries = GroupActionLogEntry.objects.filter(
         group_id=group_id,
         project_id=project_id,
@@ -252,23 +251,42 @@ def _latest_pr_lifecycle_actions(
             pull_request_id = int(data["pull_request"])
         except (KeyError, TypeError, ValueError):
             continue
-        latest_actions[pull_request_id] = entry
-    return latest_actions
+        actions_by_pull_request.setdefault(pull_request_id, []).append(entry)
+    return actions_by_pull_request
 
 
-def _heal_has_other_open_prs(
+def _heal_pr_lifecycle_data(
     *,
     entry: GroupActionLogEntry,
-    has_other_open_prs: bool,
-) -> bool:
-    """Heal the has_other_open_prs field on any action where it is present but null."""
-    if "has_other_open_prs" not in entry.data or entry.data["has_other_open_prs"] is not None:
-        return False
+    has_other_open_prs: bool | None = None,
+    pull_request_origin: PullRequestOrigin,
+) -> None:
+    """Reconcile lifecycle fields on previously logged actions."""
+    updated_data = dict(entry.data)
 
-    entry.data = {**entry.data, "has_other_open_prs": has_other_open_prs}
+    if (
+        has_other_open_prs is not None
+        and "has_other_open_prs" in updated_data
+        and updated_data["has_other_open_prs"] is None
+    ):
+        updated_data["has_other_open_prs"] = has_other_open_prs
+
+    if entry.type == GroupActionType.PULL_REQUEST_CLOSED:
+        recorded_origin = updated_data.get("pull_request_origin")
+        # Attribution can arrive after the close event. Upgrade a prior value,
+        # but never downgrade an automated origin if its Seer link disappears.
+        if recorded_origin is None or (
+            pull_request_origin == PullRequestOrigin.AUTOMATED_FIX
+            and recorded_origin != PullRequestOrigin.AUTOMATED_FIX.value
+        ):
+            updated_data["pull_request_origin"] = pull_request_origin.value
+
+    if updated_data == entry.data:
+        return
+
+    entry.data = updated_data
     entry.save(update_fields=["data", "date_updated"])
     invalidate_group_derived_data(entry.group_id, cursor=(entry.date_added, entry.id))
-    return True
 
 
 def _get_new_pr_lifecycle_action(
@@ -276,6 +294,7 @@ def _get_new_pr_lifecycle_action(
     pull_request: _PullRequestLifecycleDetails,
     latest_action_type: int | None,
     has_other_open_prs: bool,
+    pull_request_origin: PullRequestOrigin,
     group_id: int,
     project_id: int,
 ) -> (
@@ -324,6 +343,7 @@ def _get_new_pr_lifecycle_action(
                 PullRequestClosedAction(
                     pull_request=pull_request.id,
                     has_other_open_prs=has_other_open_prs,
+                    pull_request_origin=pull_request_origin,
                 ),
                 pull_request.closed_at,
             )
@@ -392,26 +412,40 @@ def backfill_group_pr_lifecycle(*, group_id: int, project_id: int) -> int:
         for pull_request in pull_requests
         if is_open_pull_request_state(pull_request.state)
     }
+    automated_fix_pull_request_ids = set(
+        SeerRunPullRequest.objects.filter(pull_request_id__in=pull_request_ids).values_list(
+            "pull_request_id", flat=True
+        )
+    )
 
-    latest_actions = _latest_pr_lifecycle_actions(group_id=group_id, project_id=project_id)
+    logged_actions = _pr_lifecycle_actions_by_pull_request(group_id=group_id, project_id=project_id)
 
     entries: list[BackfillEntry] = []
     for pull_request in pull_requests:
-        latest_action = latest_actions.get(pull_request.id)
+        pull_request_actions = logged_actions.get(pull_request.id, ())
+        latest_action = pull_request_actions[-1] if pull_request_actions else None
         has_other_open_prs = bool(open_pull_request_ids - {pull_request.id})
+        pull_request_origin = (
+            PullRequestOrigin.AUTOMATED_FIX
+            if pull_request.id in automated_fix_pull_request_ids
+            else PullRequestOrigin.OTHER
+        )
+        for logged_action in pull_request_actions:
+            _heal_pr_lifecycle_data(
+                entry=logged_action,
+                has_other_open_prs=(has_other_open_prs if logged_action is latest_action else None),
+                pull_request_origin=pull_request_origin,
+            )
+
         action_and_date = _get_new_pr_lifecycle_action(
             pull_request=pull_request,
             latest_action_type=latest_action.type if latest_action is not None else None,
             has_other_open_prs=has_other_open_prs,
+            pull_request_origin=pull_request_origin,
             group_id=group_id,
             project_id=project_id,
         )
         if action_and_date is None:
-            if latest_action is not None:
-                _heal_has_other_open_prs(
-                    entry=latest_action,
-                    has_other_open_prs=has_other_open_prs,
-                )
             continue
         action, date_added = action_and_date
 

--- a/src/sentry/issues/action_log/types.py
+++ b/src/sentry/issues/action_log/types.py
@@ -155,6 +155,13 @@ class ActionSource(StrEnum):
     )
 
 
+class PullRequestOrigin(StrEnum):
+    """How a pull request was created, independent of a specific automation provider."""
+
+    AUTOMATED_FIX = "automated_fix"
+    OTHER = "other"
+
+
 COMMIT_ACTION_TYPES = {
     GroupActionType.SET_RESOLVED_IN_COMMIT.value,
     GroupActionType.REFERENCED_IN_COMMIT.value,
@@ -508,6 +515,7 @@ class PullRequestClosedAction(GroupAction):
     pull_request: Optional[int | str] = None  # PullRequest model ID
     # Whether the issue has other linked PRs still open when this one closed
     has_other_open_prs: Optional[bool] = None
+    pull_request_origin: PullRequestOrigin | None = None
 
     @classmethod
     def get_type(cls) -> GroupActionType:

--- a/src/sentry/receivers/releases.py
+++ b/src/sentry/receivers/releases.py
@@ -17,7 +17,7 @@ from sentry.issues.action_log import (
     action_context_scope,
     get_action_context,
 )
-from sentry.issues.action_log.types import GroupActorType
+from sentry.issues.action_log.types import GroupActorType, PullRequestOrigin
 from sentry.models.activity import Activity
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
@@ -39,6 +39,7 @@ from sentry.models.release import Release
 from sentry.models.releases.release_project import ReleaseProject
 from sentry.models.repository import Repository
 from sentry.notifications.types import GroupSubscriptionReason
+from sentry.seer.models.run import SeerRunPullRequest
 from sentry.signals import buffer_incr_complete
 from sentry.tasks.clear_expired_resolutions import clear_expired_resolutions
 from sentry.types.activity import ActivityType
@@ -365,6 +366,14 @@ def _create_pull_request_activities(
         if not groups:
             return
 
+        pull_request_origin: PullRequestOrigin | None = None
+        if activity_type == ActivityType.PULL_REQUEST_CLOSED:
+            pull_request_origin = (
+                PullRequestOrigin.AUTOMATED_FIX
+                if SeerRunPullRequest.objects.filter(pull_request_id=pull_request_id).exists()
+                else PullRequestOrigin.OTHER
+            )
+
         has_other_open_prs_by_group: set[int] | None = None
         if activity_type != ActivityType.PULL_REQUEST_REOPENED:
             has_other_open_prs_by_group = _groups_with_other_open_prs(
@@ -372,7 +381,9 @@ def _create_pull_request_activities(
             )
 
         for group in groups:
-            data: dict[str, int | bool] = {"pull_request": pull_request_id}
+            data: dict[str, object] = {"pull_request": pull_request_id}
+            if pull_request_origin is not None:
+                data["pull_request_origin"] = pull_request_origin.value
             if has_other_open_prs_by_group is not None:
                 data["has_other_open_prs"] = group.id in has_other_open_prs_by_group
 

--- a/tests/sentry/issues/action_log/test_backfill.py
+++ b/tests/sentry/issues/action_log/test_backfill.py
@@ -18,6 +18,7 @@ from sentry.issues.action_log.types import (
     GroupActionActor,
     GroupActionType,
     GroupActorType,
+    PullRequestOrigin,
     ResolveAction,
     ResolvedInPullRequestAction,
     ViewAction,
@@ -405,6 +406,22 @@ class BackfillGroupPullRequestLifecycleTest(TestCase):
         }
         assert {entry.date_added for entry in entries} == {closed_at}
 
+    def test_backfills_automated_fix_origin(self) -> None:
+        pull_request = self._create_linked_pull_request(
+            state=PullRequestLifecycleState.CLOSED,
+            closed_at=self.now - timedelta(minutes=1),
+        )
+        seer_run = self.create_seer_run(organization=self.organization)
+        self.create_seer_run_pull_request(run=seer_run, pull_request=pull_request)
+
+        assert self._backfill_pr_lifecycle() == 1
+
+        entry = GroupActionLogEntry.objects.get(
+            group_id=self.group.id,
+            type=GroupActionType.PULL_REQUEST_CLOSED,
+        )
+        assert entry.data["pull_request_origin"] == PullRequestOrigin.AUTOMATED_FIX.value
+
     def test_skips_open_pull_requests(self) -> None:
         self._create_linked_pull_request(state=None)
         self._create_linked_pull_request(state=PullRequestLifecycleState.OPEN)
@@ -464,7 +481,93 @@ class BackfillGroupPullRequestLifecycleTest(TestCase):
         )
 
         assert self._backfill_pr_lifecycle() == 0
-        assert GroupActionLogEntry.objects.filter(group_id=self.group.id).count() == 1
+        entry = GroupActionLogEntry.objects.get(group_id=self.group.id)
+        assert entry.data["pull_request_origin"] == PullRequestOrigin.OTHER.value
+
+    def test_heals_automated_fix_origin_on_existing_closed_action(self) -> None:
+        pull_request = self._create_linked_pull_request(
+            state=PullRequestLifecycleState.CLOSED,
+            closed_at=self.now - timedelta(minutes=1),
+        )
+        seer_run = self.create_seer_run(organization=self.organization)
+        self.create_seer_run_pull_request(run=seer_run, pull_request=pull_request)
+        self.create_group_action_log_entry(
+            group=self.group,
+            type=GroupActionType.PULL_REQUEST_CLOSED,
+            data={"pull_request": pull_request.id, "has_other_open_prs": False},
+            date_added=self.now - timedelta(minutes=1),
+        )
+
+        assert self._backfill_pr_lifecycle() == 0
+
+        entry = GroupActionLogEntry.objects.get(group_id=self.group.id)
+        assert entry.data["pull_request_origin"] == PullRequestOrigin.AUTOMATED_FIX.value
+
+    def test_upgrades_other_origin_when_automated_fix_link_arrives_late(self) -> None:
+        pull_request = self._create_linked_pull_request(
+            state=PullRequestLifecycleState.CLOSED,
+            closed_at=self.now - timedelta(minutes=1),
+        )
+        self.create_group_action_log_entry(
+            group=self.group,
+            type=GroupActionType.PULL_REQUEST_CLOSED,
+            data={
+                "pull_request": pull_request.id,
+                "has_other_open_prs": False,
+                "pull_request_origin": PullRequestOrigin.OTHER.value,
+            },
+            date_added=self.now - timedelta(minutes=1),
+        )
+        seer_run = self.create_seer_run(organization=self.organization)
+        self.create_seer_run_pull_request(run=seer_run, pull_request=pull_request)
+
+        assert self._backfill_pr_lifecycle() == 0
+
+        entry = GroupActionLogEntry.objects.get(group_id=self.group.id)
+        assert entry.data["pull_request_origin"] == PullRequestOrigin.AUTOMATED_FIX.value
+
+    def test_does_not_downgrade_automated_fix_origin(self) -> None:
+        pull_request = self._create_linked_pull_request(
+            state=PullRequestLifecycleState.CLOSED,
+            closed_at=self.now - timedelta(minutes=1),
+        )
+        entry = self.create_group_action_log_entry(
+            group=self.group,
+            type=GroupActionType.PULL_REQUEST_CLOSED,
+            data={
+                "pull_request": pull_request.id,
+                "has_other_open_prs": False,
+                "pull_request_origin": PullRequestOrigin.AUTOMATED_FIX.value,
+            },
+            date_added=self.now - timedelta(minutes=1),
+        )
+
+        assert self._backfill_pr_lifecycle() == 0
+
+        entry.refresh_from_db()
+        assert entry.data["pull_request_origin"] == PullRequestOrigin.AUTOMATED_FIX.value
+
+    def test_heals_automated_fix_origin_before_existing_reopen(self) -> None:
+        pull_request = self._create_linked_pull_request(state=PullRequestLifecycleState.OPEN)
+        seer_run = self.create_seer_run(organization=self.organization)
+        self.create_seer_run_pull_request(run=seer_run, pull_request=pull_request)
+        closed_entry = self.create_group_action_log_entry(
+            group=self.group,
+            type=GroupActionType.PULL_REQUEST_CLOSED,
+            data={"pull_request": pull_request.id, "has_other_open_prs": False},
+            date_added=self.now - timedelta(minutes=2),
+        )
+        self.create_group_action_log_entry(
+            group=self.group,
+            type=GroupActionType.PULL_REQUEST_REOPENED,
+            data={"pull_request": pull_request.id},
+            date_added=self.now - timedelta(minutes=1),
+        )
+
+        assert self._backfill_pr_lifecycle() == 0
+
+        closed_entry.refresh_from_db()
+        assert closed_entry.data["pull_request_origin"] == PullRequestOrigin.AUTOMATED_FIX.value
 
     def test_heals_activity_backfill_with_unknown_open_pr_state(self) -> None:
         pull_request = self._create_linked_pull_request(

--- a/tests/sentry/receivers/test_releases.py
+++ b/tests/sentry/receivers/test_releases.py
@@ -7,6 +7,7 @@ from sentry.integrations.types import ExternalProviders
 from sentry.issues.action_log.types import (
     PullRequestClosedAction,
     PullRequestMergedAction,
+    PullRequestOrigin,
     PullRequestReopenedAction,
     PullRequestUnlinkedAction,
 )
@@ -474,7 +475,27 @@ class PullRequestLifecycleSignalTest(TestCase):
         assert activity.data == {
             "pull_request": self.pull_request.id,
             "has_other_open_prs": False,
+            "pull_request_origin": PullRequestOrigin.OTHER.value,
         }
+
+    def test_closed_automated_fix_emits_origin(self) -> None:
+        seer_run = self.create_seer_run(organization=self.organization)
+        self.create_seer_run_pull_request(run=seer_run, pull_request=self.pull_request)
+
+        with capture_action_log() as action_log:
+            self._save_with_state(PullRequestLifecycleState.CLOSED)
+
+        activity = Activity.objects.get(
+            group=self.group, type=ActivityType.PULL_REQUEST_CLOSED.value
+        )
+        assert activity.data["pull_request_origin"] == PullRequestOrigin.AUTOMATED_FIX.value
+        action_log.assert_logged(
+            PullRequestClosedAction,
+            group_id=self.group.id,
+            pull_request=self.pull_request.id,
+            has_other_open_prs=False,
+            pull_request_origin=PullRequestOrigin.AUTOMATED_FIX,
+        )
 
     @with_feature({"organizations:pr-lifecycle-activity": False})
     def test_flag_disabled_still_emits_closed_activity(self) -> None:
@@ -594,12 +615,14 @@ class PullRequestLifecycleSignalTest(TestCase):
         assert activity.data == {
             "pull_request": self.pull_request.id,
             "has_other_open_prs": False,
+            "pull_request_origin": PullRequestOrigin.OTHER.value,
         }
         action_log.assert_logged(
             PullRequestClosedAction,
             group_id=self.group.id,
             pull_request=self.pull_request.id,
             has_other_open_prs=False,
+            pull_request_origin=PullRequestOrigin.OTHER,
         )
 
     def test_reopened_emits_activity(self) -> None:


### PR DESCRIPTION
Within issue progress, we want to be able to distinguish between Seer created PRs and non-Seer created PRs. This sets up tracking for `pull_request_origin`. Follow up will start actually writing these.

This also allows late automated attribution to upgrade recorded origins without downgrading known automation.

Refs ISWF-3134