### PR TITLE
ref(trace-view): Remove demo mode from the trace waterfall

### DIFF
--- a/static/app/utils/discover/urls.tsx
+++ b/static/app/utils/discover/urls.tsx
@@ -54,7 +54,6 @@ export function generateLinkToEventInTraceView({
   eventId,
   eventView,
   targetId,
-  demo,
   source,
   view,
   tab,
@@ -63,7 +62,6 @@ export function generateLinkToEventInTraceView({
   organization: Organization;
   timestamp: string | number;
   traceSlug: string;
-  demo?: string;
   eventId?: string;
   eventView?: EventView;
   source?: TraceViewSources;
@@ -94,7 +92,6 @@ export function generateLinkToEventInTraceView({
     eventId,
     targetId,
     spanId,
-    demo,
     location,
     source,
     view,

--- a/static/app/views/performance/newTraceDetails/traceApi/useTrace.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTrace.tsx
@@ -6,7 +6,6 @@ import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
 import type {PageFilters} from 'sentry/types/core';
-import type {EventTransaction} from 'sentry/types/event';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {useApiQuery, type UseApiQueryResult} from 'sentry/utils/queryClient';
 import {decodeScalar} from 'sentry/utils/queryString';
@@ -16,7 +15,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import {useIsEAPTraceEnabled} from 'sentry/views/performance/newTraceDetails/useIsEAPTraceEnabled';
 
-import type {TraceFullDetailed, TraceSplitResults} from './types';
+import type {TraceSplitResults} from './types';
 
 const DEFAULT_TIMESTAMP_LIMIT = 10_000;
 const DEFAULT_LIMIT = 1_000;
@@ -62,7 +61,6 @@ function getTargetIdParams(
 
 type TraceQueryParams = {
   limit: number;
-  demo?: string;
   pageEnd?: string;
   pageStart?: string;
   statsPeriod?: string;
@@ -79,7 +77,6 @@ export function getTraceQueryParams(
     allowAbsolutePageDatetime: true,
   });
   const statsPeriod = decodeScalar(normalizedParams.statsPeriod);
-  const demo = decodeScalar(normalizedParams.demo);
 
   const timestamp = options.timestamp ?? decodeScalar(normalizedParams.timestamp);
   let limit = options.limit ?? decodeScalar(normalizedParams.limit);
@@ -109,7 +106,6 @@ export function getTraceQueryParams(
   const queryParams = {
     ...timeRangeParams,
     ...targetEventParams,
-    demo,
     limit,
     timestamp: timestamp?.toString(),
     include_uptime: '1',
@@ -126,100 +122,6 @@ export function getTraceQueryParams(
   }
 
   return queryParams;
-}
-
-function parseDemoEventSlug(
-  demoEventSlug: string | undefined
-): {event_id: string; project_slug: string} | null {
-  if (!demoEventSlug) {
-    return null;
-  }
-
-  const [project_slug, event_id] = demoEventSlug.split(':');
-  return {project_slug: project_slug!, event_id: event_id!};
-}
-
-function makeTraceFromTransaction(
-  event: EventTransaction | undefined
-): TraceSplitResults<TraceFullDetailed> | undefined {
-  if (!event) {
-    return undefined;
-  }
-
-  const traceContext = event.contexts?.trace;
-
-  const transaction = {
-    event_id: event.eventID,
-    generation: 0,
-    parent_event_id: '',
-    parent_span_id: traceContext?.parent_span_id ?? '',
-    performance_issues: [],
-    project_id: Number(event.projectID),
-    project_slug: event.projectSlug ?? '',
-    span_id: traceContext?.span_id ?? '',
-    timestamp: event.endTimestamp,
-    transaction: event.title,
-    'transaction.duration': (event.endTimestamp - event.startTimestamp) * 1000,
-    errors: [],
-    sdk_name: event.sdk?.name ?? '',
-    children: [],
-    start_timestamp: event.startTimestamp,
-    'transaction.op': traceContext?.op ?? '',
-    'transaction.status': traceContext?.status ?? '',
-    measurements: event.measurements ?? {},
-    tags: [],
-  };
-
-  return {transactions: [transaction], orphan_errors: []};
-}
-
-function useDemoTrace(
-  demo: string | undefined,
-  organization: {slug: string}
-): UseApiQueryResult<TraceSplitResults<TraceTree.Transaction>, RequestError> {
-  const demoEventSlug = parseDemoEventSlug(demo);
-
-  // When projects don't have performance set up, we allow them to view a demo transaction.
-  // The backend creates the demo transaction, however the trace is created async, so when the
-  // page loads, we cannot guarantee that querying the trace will succeed as it may not have been stored yet.
-  // When this happens, we assemble a fake trace response to only include the transaction that had already been
-  // created and stored already so that the users can visualize in the context of a trace.
-  const demoEventQuery = useApiQuery<EventTransaction>(
-    [
-      getApiUrl(
-        '/organizations/$organizationIdOrSlug/events/$projectIdOrSlug:$eventId/',
-        {
-          path: {
-            organizationIdOrSlug: organization.slug,
-            projectIdOrSlug: demoEventSlug?.project_slug!,
-            eventId: demoEventSlug?.event_id!,
-          },
-        }
-      ),
-      {
-        query: {
-          referrer: 'trace-view',
-        },
-      },
-    ],
-    {
-      staleTime: Infinity,
-      enabled: !!demoEventSlug,
-    }
-  );
-
-  // Without the useMemo, the trace from the transformed response  will be re-created on every render,
-  // causing the trace view to re-render as we interact with it.
-  const data = useMemo(() => {
-    return makeTraceFromTransaction(demoEventQuery.data);
-  }, [demoEventQuery.data]);
-
-  // Casting here since the 'select' option is not available in the useApiQuery hook to transform the data
-  // from EventTransaction to TraceSplitResults<TraceFullDetailed>
-  return {...demoEventQuery, data} as unknown as UseApiQueryResult<
-    TraceSplitResults<TraceTree.Transaction>,
-    any
-  >;
 }
 
 type UseTraceOptions = {
@@ -269,9 +171,6 @@ export function useTrace(options: UseTraceOptions): TraceQueryResult {
     filters.selection,
   ]);
 
-  const isDemoMode = Boolean(queryParams.demo);
-  const demoTrace = useDemoTrace(queryParams.demo, organization);
-
   const maxPickableDays = useDefaultMaxPickableDays();
 
   // Only retry when using statsPeriod (no specific timestamp or absolute date range)
@@ -300,7 +199,7 @@ export function useTrace(options: UseTraceOptions): TraceQueryResult {
     ],
     {
       staleTime: Infinity,
-      enabled: hasValidTrace && !isDemoMode && !isEAPEnabled,
+      enabled: hasValidTrace && !isEAPEnabled,
     }
   );
 
@@ -321,7 +220,7 @@ export function useTrace(options: UseTraceOptions): TraceQueryResult {
     {
       staleTime: Infinity,
       retry: false,
-      enabled: hasValidTrace && !isDemoMode && isEAPEnabled,
+      enabled: hasValidTrace && isEAPEnabled,
     }
   );
 
@@ -345,11 +244,7 @@ export function useTrace(options: UseTraceOptions): TraceQueryResult {
     {
       staleTime: Infinity,
       enabled:
-        hasValidTrace &&
-        !isDemoMode &&
-        !isEAPEnabled &&
-        isInitialTraceEmpty &&
-        canRetryWithWiderPeriod,
+        hasValidTrace && !isEAPEnabled && isInitialTraceEmpty && canRetryWithWiderPeriod,
     }
   );
 
@@ -371,16 +266,12 @@ export function useTrace(options: UseTraceOptions): TraceQueryResult {
       retry: false,
       enabled:
         hasValidTrace &&
-        !isDemoMode &&
         isEAPEnabled &&
         isInitialEAPTraceEmpty &&
         canRetryWithWiderPeriod,
     }
   );
 
-  if (isDemoMode) {
-    return demoTrace;
-  }
   if (isEAPEnabled) {
     return isInitialEAPTraceEmpty && canRetryWithWiderPeriod
       ? eapTraceFallbackQuery

--- a/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.tsx
@@ -332,10 +332,6 @@ export function useTraceMeta(options: UseTraceMetaOptions): TraceMetaQueryResult
     allowAbsolutePageDatetime: true,
   });
 
-  // demo has the format ${projectSlug}:${eventId}
-  // used to query a demo transaction event from the backend.
-  const mode = decodeScalar(normalizedParams.demo) ? 'demo' : undefined;
-
   // eslint-disable-next-line @tanstack/query/exhaustive-deps
   const {data, isLoading, status} = useQuery({
     queryKey: ['traceData', traces.map(trace => trace.traceSlug)],
@@ -373,43 +369,6 @@ export function useTraceMeta(options: UseTraceMetaOptions): TraceMetaQueryResult
     staleTime: 1000 * 60 * 10,
     enabled: traces.length > 0,
   });
-
-  /**
-   * When projects don't have performance set up, we allow them to view a sample
-   * transaction. The backend creates the sample transaction, however the trace is
-   * created async, so when the page loads, we cannot guarantee that querying the trace
-   * will succeed as it may not have been stored yet. When this happens, we assemble a
-   * fake trace response to only include the transaction that had already been created
-   * and stored already so that the users can visualize in the context of a trace. The
-   * trace meta query has to reflect this by returning a single transaction and project.
-   */
-  if (mode === 'demo') {
-    return {
-      errors: [],
-      status: 'success',
-      isLoading: false,
-      data: isEAP
-        ? {
-            errorsCount: 0,
-            logsCount: 0,
-            metricsCount: 0,
-            performanceIssuesCount: 0,
-            spansCount: 0,
-            spansCountMap: {},
-            transactionChildCountMap: {},
-            uptimeCount: 0,
-          }
-        : {
-            errors: 0,
-            performance_issues: 0,
-            projects: 1,
-            transactions: 1,
-            transaction_child_count_map: {},
-            span_count: 0,
-            span_count_map: {},
-          },
-    };
-  }
 
   const allRequestsFailed = data?.apiErrors.length === traces.length;
 

--- a/static/app/views/performance/traceDetails/utils.tsx
+++ b/static/app/views/performance/traceDetails/utils.tsx
@@ -52,7 +52,6 @@ export function getTraceDetailsUrl({
   spanId,
   eventId,
   targetId,
-  demo,
   location,
   source,
   view,
@@ -62,7 +61,6 @@ export function getTraceDetailsUrl({
   location: Location;
   organization: Organization;
   traceSlug: string;
-  demo?: string;
   eventId?: string;
   source?: TraceViewSources;
   spanId?: string;
@@ -98,7 +96,6 @@ export function getTraceDetailsUrl({
       timestamp: getTimeStampFromTableDateField(timestamp),
       eventId,
       targetId,
-      demo,
       source,
       tab,
     },


### PR DESCRIPTION
Removes the `?demo=${projectSlug}:${eventId}` URL param from the trace waterfall. When present it skipped the trace and trace-meta queries entirely and made a fake trace with hard-coded data. We actually removed the button that lead to this view recently, so no one is hitting it. Might as well remove it, and makes removal of the transaction-based Span Waterfall a bit easier.

Closes BROWSE-706