### PR TITLE
fix(issues): Cancel pending stream prefetches

### DIFF
--- a/static/app/components/groupHeaderRow.tsx
+++ b/static/app/components/groupHeaderRow.tsx
@@ -1,6 +1,6 @@
-import {useRef} from 'react';
 import styled from '@emotion/styled';
 import {useHover} from '@react-aria/interactions';
+import {useDebouncer} from '@tanstack/react-pacer';
 import {useQueryClient} from '@tanstack/react-query';
 
 import {Link} from '@sentry/scraps/link';
@@ -39,27 +39,24 @@ function usePreloadGroupOnHover({
   organization: Organization;
 }) {
   const queryClient = useQueryClient();
-  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
   const {selection} = usePageFilters();
+  const preloadDebouncer = useDebouncer(
+    () => {
+      void queryClient.prefetchQuery(
+        groupApiOptions({
+          groupId,
+          organizationSlug: organization.slug,
+          environments: selection.environments,
+          expandDerivedData: organization.features.includes('issue-stream-progress-ui'),
+        })
+      );
+    },
+    {wait: 300}
+  );
 
   const {hoverProps} = useHover({
-    onHoverStart: () => {
-      timeoutRef.current = setTimeout(() => {
-        queryClient.prefetchQuery(
-          groupApiOptions({
-            groupId,
-            organizationSlug: organization.slug,
-            environments: selection.environments,
-            expandDerivedData: organization.features.includes('issue-stream-progress-ui'),
-          })
-        );
-      }, 300);
-    },
-    onHoverEnd: () => {
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
-      }
-    },
+    onHoverStart: () => preloadDebouncer.maybeExecute(),
+    onHoverEnd: () => preloadDebouncer.cancel(),
     isDisabled: disabled,
   });
 


### PR DESCRIPTION
The issue stream's delayed hover prefetch can outlive its row and fire after teardown.

Uses Pacer's debouncer so hover end and component unmount both cancel pending prefetches. Same cleanup as #121792.