### PR TITLE
feat(projects): Migrate filter debouncing to Pacer

### DIFF
--- a/static/app/components/teamFilter.tsx
+++ b/static/app/components/teamFilter.tsx
@@ -1,6 +1,6 @@
 import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
-import debounce from 'lodash/debounce';
+import {useDebouncedCallback} from '@tanstack/react-pacer';
 import partition from 'lodash/partition';
 
 import {TeamAvatar} from '@sentry/scraps/avatar';
@@ -52,6 +52,9 @@ export function TeamFilter({
   hideOtherTeams = false,
 }: Props) {
   const {teams, onSearch, fetching} = useTeams();
+  const handleSearch = useDebouncedCallback((value: string) => void onSearch(value), {
+    wait: DEFAULT_DEBOUNCE_DURATION,
+  });
 
   const [myTeams, otherTeams] = partition(teams, team => team.isMember);
   const myTeamOptions = myTeams.map(makeTeamOption);
@@ -82,7 +85,7 @@ export function TeamFilter({
     <CompactSelect
       multiple
       clearable
-      search={{onChange: debounce(val => void onSearch(val), DEFAULT_DEBOUNCE_DURATION)}}
+      search={{onChange: handleSearch}}
       disabled={isDemoModeActive()}
       loading={fetching}
       menuTitle={t('Filter teams')}

--- a/static/app/views/projectsDashboard/index.spec.tsx
+++ b/static/app/views/projectsDashboard/index.spec.tsx
@@ -14,26 +14,6 @@ import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {TeamStore} from 'sentry/stores/teamStore';
 import ProjectsDashboard from 'sentry/views/projectsDashboard';
 
-jest.unmock('lodash/debounce');
-jest.mock('lodash/debounce', () => {
-  const debounceMap = new Map();
-  const mockDebounce =
-    (fn: (...args: any[]) => void, timeout: number) =>
-    (...args: any[]) => {
-      if (debounceMap.has(fn)) {
-        clearTimeout(debounceMap.get(fn));
-      }
-      debounceMap.set(
-        fn,
-        setTimeout(() => {
-          fn.apply(fn, args);
-          debounceMap.delete(fn);
-        }, timeout)
-      );
-    };
-  return mockDebounce;
-});
-
 describe('ProjectsDashboard', () => {
   const org = OrganizationFixture();
   const team = TeamFixture();

--- a/static/app/views/projectsDashboard/index.tsx
+++ b/static/app/views/projectsDashboard/index.tsx
@@ -2,7 +2,7 @@ import {Fragment, useEffect, useMemo, useState} from 'react';
 import LazyLoad, {forceCheck} from 'react-lazyload';
 import styled from '@emotion/styled';
 import {withProfiler} from '@sentry/react';
-import debounce from 'lodash/debounce';
+import {useDebouncedValue} from '@tanstack/react-pacer';
 import uniqBy from 'lodash/uniqBy';
 
 import {LinkButton} from '@sentry/scraps/button';
@@ -141,10 +141,9 @@ function Dashboard() {
   });
   const user = useUser();
   const [projectQuery, setProjectQuery] = useState('');
-  const debouncedSearchQuery = useMemo(
-    () => debounce(handleSearch, DEFAULT_DEBOUNCE_DURATION),
-    []
-  );
+  const [debouncedProjectQuery] = useDebouncedValue(projectQuery, {
+    wait: DEFAULT_DEBOUNCE_DURATION,
+  });
   const {projects, fetching, fetchError} = useProjects();
   const canUserCreateProject = useCanCreateProject();
 
@@ -171,7 +170,7 @@ function Dashboard() {
     isAllTeams,
     showNonMemberProjects,
     projects,
-    projectQuery,
+    projectQuery: debouncedProjectQuery,
   });
 
   setGroupedEntityTag('projects.total', 1000, projects.length);
@@ -179,10 +178,6 @@ function Dashboard() {
   const showResources = projects.length === 1 && !projects[0]!.firstEvent;
 
   const canJoinTeam = organization.access.includes('team:read');
-
-  function handleSearch(searchQuery: string) {
-    setProjectQuery(searchQuery);
-  }
 
   function handleChangeFilter(activeFilters: string[]) {
     navigate({
@@ -250,7 +245,7 @@ function Dashboard() {
             <StyledSearchBar
               defaultQuery=""
               placeholder={t('Search for projects by name')}
-              onChange={debouncedSearchQuery}
+              onChange={setProjectQuery}
               query={projectQuery}
             />
           </SearchAndSelectorWrapper>

--- a/static/app/views/projectsDashboard/index.tsx
+++ b/static/app/views/projectsDashboard/index.tsx
@@ -143,6 +143,7 @@ function Dashboard() {
   const [projectQuery, setProjectQuery] = useState('');
   const [debouncedProjectQuery] = useDebouncedValue(projectQuery, {
     wait: DEFAULT_DEBOUNCE_DURATION,
+    leading: true,
   });
   const {projects, fetching, fetchError} = useProjects();
   const canUserCreateProject = useCanCreateProject();


### PR DESCRIPTION
team filter here was creating a new debounce function on every call, adds leading filtering to projects. Both did not destroy the timeout on unmount.