### PR TITLE
fix(trace-view): Build the loading placeholder out of spans

### DIFF
--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -127,7 +127,7 @@ function TraceViewImplInner({traceSlug}: {traceSlug: string}) {
       'span.status',
     ],
   });
-  const tree = useTraceTree({traceSlug, trace, replay: null});
+  const tree = useTraceTree({trace, replay: null});
   const overview = useTraceOverviewData({
     logsEnabled,
     meta: meta.data,

--- a/static/app/views/performance/newTraceDetails/traceApi/useIssuesTraceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useIssuesTraceTree.tsx
@@ -4,7 +4,6 @@ import type {QueryStatus} from '@tanstack/react-query';
 import type {UseApiQueryResult} from 'sentry/utils/queryClient';
 import {useApi} from 'sentry/utils/useApi';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {useProjects} from 'sentry/utils/useProjects';
 import type {HydratedReplayRecord} from 'sentry/views/explore/replays/types';
 import {IssuesTraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/issuesTraceTree';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
@@ -15,7 +14,6 @@ import {isEmptyTrace} from './utils';
 type UseTraceTreeParams = {
   replay: HydratedReplayRecord | null;
   trace: UseApiQueryResult<TraceTree.Trace | undefined, any>;
-  traceSlug?: string;
 };
 
 function getTraceViewQueryStatus(traceQueryStatus: QueryStatus): QueryStatus {
@@ -30,13 +28,8 @@ function getTraceViewQueryStatus(traceQueryStatus: QueryStatus): QueryStatus {
   return 'success';
 }
 
-export function useIssuesTraceTree({
-  trace,
-  replay,
-  traceSlug,
-}: UseTraceTreeParams): IssuesTraceTree {
+export function useIssuesTraceTree({trace, replay}: UseTraceTreeParams): IssuesTraceTree {
   const api = useApi();
-  const {projects} = useProjects();
   const traceState = useTraceState();
   const organization = useOrganization();
 
@@ -46,17 +39,7 @@ export function useIssuesTraceTree({
     const status = getTraceViewQueryStatus(trace.status);
 
     if (status === 'error') {
-      setTree(t =>
-        t.type === 'error'
-          ? t
-          : IssuesTraceTree.ErrorState(
-              {
-                project_slug: projects?.[0]?.slug ?? '',
-                event_id: traceSlug,
-              },
-              organization
-            )
-      );
+      setTree(t => (t.type === 'error' ? t : IssuesTraceTree.ErrorState(organization)));
       return;
     }
 
@@ -66,17 +49,7 @@ export function useIssuesTraceTree({
     }
 
     if (status === 'pending') {
-      setTree(t =>
-        t.type === 'loading'
-          ? t
-          : IssuesTraceTree.Loading(
-              {
-                project_slug: projects?.[0]?.slug ?? '',
-                event_id: traceSlug,
-              },
-              organization
-            )
-      );
+      setTree(t => (t.type === 'loading' ? t : IssuesTraceTree.Loading(organization)));
       return;
     }
 
@@ -94,7 +67,7 @@ export function useIssuesTraceTree({
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [api, organization, projects, replay, trace.status, trace.data, traceSlug]);
+  }, [api, organization, replay, trace.status, trace.data]);
 
   return tree;
 }

--- a/static/app/views/performance/newTraceDetails/traceApi/useTraceTree.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTraceTree.spec.tsx
@@ -37,7 +37,6 @@ describe('useTraceTree', () => {
       () =>
         useTraceTree({
           trace: getMockedTraceResults('error'),
-          traceSlug: 'test-trace',
           replay: null,
         }),
       {additionalWrapper: contextWrapper()}
@@ -53,7 +52,6 @@ describe('useTraceTree', () => {
       () =>
         useTraceTree({
           trace: getMockedTraceResults('pending'),
-          traceSlug: 'test-trace',
           replay: null,
         }),
       {additionalWrapper: contextWrapper()}
@@ -72,7 +70,6 @@ describe('useTraceTree', () => {
             transactions: [],
             orphan_errors: [],
           }),
-          traceSlug: 'test-trace',
           replay: null,
         }),
       {additionalWrapper: contextWrapper()}
@@ -123,7 +120,6 @@ describe('useTraceTree', () => {
       () =>
         useTraceTree({
           trace: getMockedTraceResults('success', mockedTrace),
-          traceSlug: 'test-trace',
           replay: null,
         }),
       {additionalWrapper: contextWrapper()}

--- a/static/app/views/performance/newTraceDetails/traceApi/useTraceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTraceTree.tsx
@@ -3,7 +3,6 @@ import {useEffect, useState} from 'react';
 import type {UseApiQueryResult} from 'sentry/utils/queryClient';
 import {useApi} from 'sentry/utils/useApi';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {useProjects} from 'sentry/utils/useProjects';
 import type {HydratedReplayRecord} from 'sentry/views/explore/replays/types';
 import {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import {useTraceState} from 'sentry/views/performance/newTraceDetails/traceState/traceStateProvider';
@@ -13,12 +12,10 @@ import {isEmptyTrace} from './utils';
 type UseTraceTreeParams = {
   replay: HydratedReplayRecord | null;
   trace: UseApiQueryResult<TraceTree.Trace | undefined, any>;
-  traceSlug?: string;
 };
 
-export function useTraceTree({trace, replay, traceSlug}: UseTraceTreeParams): TraceTree {
+export function useTraceTree({trace, replay}: UseTraceTreeParams): TraceTree {
   const api = useApi();
-  const {projects} = useProjects();
   const organization = useOrganization();
   const traceState = useTraceState();
 
@@ -26,17 +23,7 @@ export function useTraceTree({trace, replay, traceSlug}: UseTraceTreeParams): Tr
 
   useEffect(() => {
     if (trace.status === 'error') {
-      setTree(t =>
-        t.type === 'error'
-          ? t
-          : TraceTree.ErrorState(
-              {
-                project_slug: projects?.[0]?.slug ?? '',
-                event_id: traceSlug,
-              },
-              organization
-            )
-      );
+      setTree(t => (t.type === 'error' ? t : TraceTree.ErrorState(organization)));
 
       return;
     }
@@ -47,17 +34,7 @@ export function useTraceTree({trace, replay, traceSlug}: UseTraceTreeParams): Tr
     }
 
     if (trace.status === 'pending') {
-      setTree(t =>
-        t.type === 'loading'
-          ? t
-          : TraceTree.Loading(
-              {
-                project_slug: projects?.[0]?.slug ?? '',
-                event_id: traceSlug,
-              },
-              organization
-            )
-      );
+      setTree(t => (t.type === 'loading' ? t : TraceTree.Loading(organization)));
       return;
     }
 
@@ -75,7 +52,7 @@ export function useTraceTree({trace, replay, traceSlug}: UseTraceTreeParams): Tr
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [api, organization, projects, replay, trace.status, trace.data, traceSlug]);
+  }, [api, organization, replay, trace.status, trace.data]);
 
   return tree;
 }

--- a/static/app/views/performance/newTraceDetails/traceModels/issuesTraceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/issuesTraceTree.tsx
@@ -17,11 +17,8 @@ export class IssuesTraceTree extends TraceTree {
     return tree;
   }
 
-  static Loading(
-    metadata: TraceTree.Metadata,
-    organization: Organization
-  ): IssuesTraceTree {
-    const t = makeExampleTrace(metadata, organization);
+  static Loading(organization: Organization): IssuesTraceTree {
+    const t = makeExampleTrace(organization);
     const tree = new IssuesTraceTree();
     tree.root = t.root;
     tree.type = 'loading';
@@ -29,11 +26,8 @@ export class IssuesTraceTree extends TraceTree {
     return tree;
   }
 
-  static ErrorState(
-    metadata: TraceTree.Metadata,
-    organization: Organization
-  ): IssuesTraceTree {
-    const t = makeExampleTrace(metadata, organization);
+  static ErrorState(organization: Organization): IssuesTraceTree {
+    const t = makeExampleTrace(organization);
     const tree = new IssuesTraceTree();
     tree.root = t.root;
     tree.type = 'error';

--- a/static/app/views/performance/newTraceDetails/traceModels/makeExampleTrace.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/makeExampleTrace.spec.tsx
@@ -1,0 +1,25 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {isEAPSpanNode} from './../traceGuards';
+import {makeExampleTrace} from './makeExampleTrace';
+import {TraceTree} from './traceTree';
+
+describe('makeExampleTrace', () => {
+  it('renders a multi level waterfall', () => {
+    const tree = makeExampleTrace(OrganizationFixture());
+    tree.build();
+
+    // Root span + its descendants
+    expect(tree.list).toHaveLength(22);
+    expect(Math.max(...tree.list.map(node => TraceTree.Depth(node)))).toBeGreaterThan(1);
+  });
+
+  it('makes spans with unique ids so none are dropped as cycles', () => {
+    const tree = makeExampleTrace(OrganizationFixture());
+    tree.build();
+
+    const spans = tree.list.filter(isEAPSpanNode);
+    expect(spans).toHaveLength(21);
+    expect(new Set(spans.map(span => span.id)).size).toBe(spans.length);
+  });
+});

--- a/static/app/views/performance/newTraceDetails/traceModels/makeExampleTrace.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/makeExampleTrace.tsx
@@ -2,89 +2,77 @@ import type {Organization} from 'sentry/types/organization';
 
 import {TraceTree} from './traceTree';
 
+const EXAMPLE_SPAN_COUNT = 20;
+
 // Creates an example trace response that we use to render the loading placeholder
-function partialTransaction(
-  partial: Partial<TraceTree.Transaction>
-): TraceTree.Transaction {
-  return {
-    start_timestamp: 0,
-    timestamp: 0,
-    errors: [],
-    performance_issues: [],
-    parent_span_id: '',
-    span_id: '',
-    parent_event_id: '',
-    project_id: 0,
-    sdk_name: '',
-    profiler_id: '',
-    'transaction.duration': 0,
-    'transaction.op': 'loading-transaction',
-    'transaction.status': 'loading-status',
-    generation: 0,
-    project_slug: '',
-    event_id: 'event_id',
-    transaction: 'transaction',
-    children: [],
-    ...partial,
-  };
-}
+export function makeExampleTrace(organization: Organization): TraceTree {
+  let start = Date.now() / 1e3;
 
-export function makeExampleTrace(
-  metadata: TraceTree.Metadata,
-  organization: Organization
-): TraceTree {
-  const trace: TraceTree.Trace = {
-    transactions: [],
-    orphan_errors: [],
-  };
-
-  function randomBetween(min: number, max: number) {
-    return Math.floor(Math.random() * (max - min + 1) + min);
-  }
-
-  let start = Date.now();
-
-  const root = partialTransaction({
-    ...metadata,
-    generation: 0,
+  const root = partialEAPSpan({
+    event_id: 'example-span-0',
     start_timestamp: start,
-    transaction: 'root transaction',
-    timestamp: start + randomBetween(100, 200),
+    end_timestamp: start + randomBetween(100, 200) / 1e3,
+    name: 'root span',
   });
 
-  trace.transactions.push(root);
+  const trace: TraceTree.EAPTrace = [root];
 
-  for (let i = 0; i < 50; i++) {
-    const end = start + randomBetween(100, 200);
-    const nest = i > 0 && Math.random() > 0.33;
+  for (let i = 1; i <= EXAMPLE_SPAN_COUNT; i++) {
+    const end = start + randomBetween(100, 200) / 1e3;
+    // The first child has to attach to the root, otherwise there is no previous
+    // sibling to nest under.
+    const nest = i > 1 && Math.random() > 0.33;
+    const parent = nest ? root.children[root.children.length - 1]! : root;
 
-    if (nest) {
-      const parent = root.children[root.children.length - 1]!;
-      parent.children.push(
-        partialTransaction({
-          ...metadata,
-          generation: 0,
-          start_timestamp: start,
-          transaction: `parent transaction ${i}`,
-          timestamp: end,
-        })
-      );
-      parent.timestamp = end;
-    } else {
-      root.children.push(
-        partialTransaction({
-          ...metadata,
-          generation: 0,
-          start_timestamp: start,
-          transaction: 'loading...',
-          ['transaction.op']: 'loading',
-          timestamp: end,
-        })
-      );
-    }
+    parent.children.push(
+      partialEAPSpan({
+        event_id: `example-span-${i}`,
+        parent_span_id: parent.event_id,
+        start_timestamp: start,
+        end_timestamp: end,
+        name: nest ? `nested span ${i}` : 'loading...',
+      })
+    );
+
+    // Grow the ancestors so they contain their children
+    parent.end_timestamp = Math.max(parent.end_timestamp, end);
+    parent.duration = (parent.end_timestamp - parent.start_timestamp) * 1e3;
+    root.end_timestamp = Math.max(root.end_timestamp, end);
+    root.duration = (root.end_timestamp - root.start_timestamp) * 1e3;
 
     start = end;
   }
 
   return TraceTree.FromTrace(trace, {meta: null, replay: null, organization});
+}
+
+function partialEAPSpan(
+  partial: Partial<TraceTree.EAPSpan> &
+    Pick<TraceTree.EAPSpan, 'event_id' | 'start_timestamp' | 'end_timestamp'>
+): TraceTree.EAPSpan {
+  return {
+    children: [],
+    duration: (partial.end_timestamp - partial.start_timestamp) * 1e3,
+    errors: [],
+    event_type: 'span',
+    // Spans render collapsed when they are transactions, which would hide the
+    // rest of the placeholder rows
+    is_transaction: false,
+    name: 'loading...',
+    occurrences: [],
+    op: 'loading',
+    parent_span_id: null,
+    profile_id: '',
+    profiler_id: '',
+    project_id: 0,
+    project_slug: '',
+    sdk_name: '',
+    transaction: 'transaction',
+    transaction_id: '',
+    ...partial,
+  };
+}
+
+function randomBetween(min: number, max: number) {
+  return Math.floor(Math.random() * (max - min + 1) + min);
 }

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -304,17 +304,6 @@ export declare namespace TraceTree {
     | 'root';
   type NodePath = `${NodeType}-${string}`;
 
-  type Metadata = {
-    event_id: string | undefined;
-    project_slug: string | undefined;
-    // This is used to track the traceslug associated with a trace in a replay.
-    // This is necessary because a replay has multiple traces and the current ui requires
-    // us to merge them into one trace. We still need to keep track of the original traceSlug
-    // to be able to fetch the correct trace-item details from EAP, in the trace drawer.
-    replayTraceSlug?: string;
-    spans?: number;
-  };
-
   type OpsBreakdown = Array<{
     count: number;
     op: string;
@@ -383,15 +372,15 @@ export class TraceTree extends TraceTreeEventDispatcher {
     return tree;
   }
 
-  static Loading(metadata: TraceTree.Metadata, organization: Organization): TraceTree {
-    const trace = makeExampleTrace(metadata, organization);
+  static Loading(organization: Organization): TraceTree {
+    const trace = makeExampleTrace(organization);
     trace.type = 'loading';
     trace.build();
     return trace;
   }
 
-  static ErrorState(metadata: TraceTree.Metadata, organization: Organization): TraceTree {
-    const trace = makeExampleTrace(metadata, organization);
+  static ErrorState(organization: Organization): TraceTree {
+    const trace = makeExampleTrace(organization);
     trace.type = 'error';
     trace.build();
     return trace;


### PR DESCRIPTION
`makeExampleTrace` makes a fake trace to show in the Trace Waterfall for loading and error states, but it has two problems:

1. It's making a _transaction_ based trace (which we want to delete)
2. It's not working properly!

This PR changes it to make span-based traces with fewer items that have proper nesting. It also doesn't need to pass metadata around. You can see the difference:

**Before:**
<img width="1021" height="515" alt="Screenshot 2026-08-11 at 5 34 11 PM" src="https://github.com/user-attachments/assets/0d86db2b-7d8e-498a-a573-bbb21a538c8c" />

**After:**

<img width="948" height="755" alt="Screenshot 2026-08-11 at 5 47 36 PM" src="https://github.com/user-attachments/assets/15ea9d54-2764-4f16-8242-da075a2e8cbc" />

Closes BROWSE-707
