### PR TITLE
fix(refactor-tasks): Pass --verbose to the convention scanner in CI

### DIFF
--- a/.github/workflows/refactor-tasks.yml
+++ b/.github/workflows/refactor-tasks.yml
@@ -48,4 +48,4 @@ jobs:
           OPENROUTER_API_KEY: ${{ secrets.REFACTOR_TASKS_OPENROUTER_API_KEY }}
           INFERENCE_MODEL: haiku
           SCAN_CONCURRENCY: '4'
-        run: pnpm dlx @sentry/refactor-tasks scan-and-report
+        run: pnpm dlx @sentry/refactor-tasks scan-and-report --verbose


### PR DESCRIPTION
## Summary
- The `@sentry/refactor-tasks` CLI already supports a `-v, --verbose` flag on `scan-and-report` that logs extra diagnostics (e.g. which detect command ran, per-pattern timing), but `.github/workflows/refactor-tasks.yml` never passed it, so none of that detail showed up in CI runs.
- This hid diagnostic detail during a recent incident where `no-deprecated-callsite`'s detector silently reported 0 violations on CI for weeks with no visible reason (#121760, since hardened).
- A companion fix in `sentry-refactor-tasks` (in progress separately) makes detect-command failures surface `stderr` through the scanner's normal logging; enabling `--verbose` here ensures the rest of the scanner's diagnostic output is visible too.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/refactor-tasks.yml'))"` — YAML is valid
- [x] `prek` (Validate GitHub Workflows hook) passed on commit
- [ ] Next scheduled/triggered run of the `refactor tasks` workflow shows verbose diagnostic output in the "Scan and report" step logs