### PR TITLE
RFC: Batch id-range fan-out

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -973,6 +973,7 @@ TASKWORKER_IMPORTS: tuple[str, ...] = (
     "sentry.tasks.codeowners.code_owners_auto_sync",
     "sentry.tasks.codeowners.update_code_owners_schema",
     "sentry.tasks.collect_project_platforms",
+    "sentry.tasks.process_active_projects",
     "sentry.tasks.commit_context",
     "sentry.tasks.commits",
     "sentry.tasks.console_platform_cleanup",

--- a/src/sentry/tasks/process_active_projects.py
+++ b/src/sentry/tasks/process_active_projects.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import logging
+
+from sentry import features
+from sentry.constants import ObjectStatus
+from sentry.models.project import Project
+from sentry.silo.base import SiloMode
+from sentry.tasks.base import instrumented_task
+from sentry.taskworker.namespaces import issues_tasks
+from sentry.utils import metrics
+from sentry.utils.query import iter_id_ranges
+
+logger = logging.getLogger(__name__)
+
+ISSUE_ACTION_LOG_WRITE_TO_DB = "projects:issue-action-log-write-to-db"
+MAX_RANGES_PER_COORDINATOR = 100
+PROJECTS_PER_RANGE = 500
+
+
+def _active_projects_qs():
+    return Project.objects.filter(status=ObjectStatus.ACTIVE)
+
+
+@instrumented_task(
+    name="sentry.tasks.process_active_projects.process_active_projects",
+    namespace=issues_tasks,
+    processing_deadline_duration=5 * 60,
+    silo_mode=SiloMode.CELL,
+)
+def process_active_projects(start_id: int = 0, **kwargs: object) -> None:
+    """
+    Walk active projects in id order, dispatching batch tasks for up to
+    ``MAX_RANGES_PER_COORDINATOR`` id ranges, then reschedule with a new
+    ``start_id`` until the table is exhausted.
+    """
+    ranges = list(
+        iter_id_ranges(
+            _active_projects_qs(),
+            PROJECTS_PER_RANGE,
+            start_after=start_id,
+            max_ranges=MAX_RANGES_PER_COORDINATOR,
+        )
+    )
+
+    if not ranges:
+        logger.info(
+            "process_active_projects.completed",
+            extra={"start_id": start_id},
+        )
+        return
+
+    for first_id, last_id in ranges:
+        process_active_projects_batch.delay(first_id=first_id, last_id=last_id)
+
+    last_id = ranges[-1][1]
+    logger.info(
+        "process_active_projects.dispatched",
+        extra={
+            "start_id": start_id,
+            "range_count": len(ranges),
+            "first_id": ranges[0][0],
+            "last_id": last_id,
+        },
+    )
+
+    if len(ranges) == MAX_RANGES_PER_COORDINATOR:
+        process_active_projects.delay(start_id=last_id)
+
+
+@instrumented_task(
+    name="sentry.tasks.process_active_projects.process_active_projects_batch",
+    namespace=issues_tasks,
+    processing_deadline_duration=5 * 60,
+    silo_mode=SiloMode.CELL,
+)
+def process_active_projects_batch(first_id: int, last_id: int, **kwargs: object) -> None:
+    """
+    Process active projects with ``first_id <= id <= last_id``.
+
+    Counts how many have the action-log write-to-db feature enabled.
+    """
+    projects = _active_projects_qs().filter(id__gte=first_id, id__lte=last_id).order_by("id")
+
+    enabled = 0
+    checked = 0
+    for project in projects.iterator():
+        checked += 1
+        if features.has(ISSUE_ACTION_LOG_WRITE_TO_DB, project):
+            enabled += 1
+
+    if enabled:
+        metrics.incr(
+            "process_active_projects.action_log_write_to_db_enabled",
+            amount=enabled,
+            sample_rate=1.0,
+        )
+
+    logger.info(
+        "process_active_projects.batch_complete",
+        extra={
+            "first_id": first_id,
+            "last_id": last_id,
+            "checked": checked,
+            "enabled": enabled,
+        },
+    )

--- a/src/sentry/utils/query.py
+++ b/src/sentry/utils/query.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, TypedDict
 
 import click
 from django.db import connections, router
+from django.db.models import Max, Min
 from django.db.models.fields import Field
 from django.db.models.query import QuerySet
 from django.db.models.query_utils import Q
@@ -104,6 +105,67 @@ def task_run_batch_query(
         state = None
 
     return state, events
+
+
+def iter_id_ranges(
+    queryset: QuerySet[Any],
+    range_size: int,
+    *,
+    start_after: int | None = None,
+    max_ranges: int | None = None,
+    id_field: str = "id",
+) -> Iterator[tuple[int, int]]:
+    """
+    Yield inclusive ``(first_id, last_id)`` ranges of up to ``range_size`` rows
+    matching the queryset filters, ascending by ``id_field``.
+
+    Uses keyset pagination (``id > cursor ORDER BY id LIMIT range_size``) and one
+    query per range that returns only bounds (MIN/MAX over a sliced id subquery).
+    Does not use OFFSET from 0 and does not materialize all ids.
+
+    Child-task contract:
+    Children re-query with the same filters plus ``id__gte=first_id``,
+    ``id__lte=last_id``, iterate in id order, and on timeout re-enqueue
+    ``(next_unprocessed_id, last_id)`` (same end).
+    """
+    if range_size < 1:
+        raise ValueError("range_size must be >= 1")
+
+    if queryset.query.low_mark != 0 or queryset.query.high_mark is not None:
+        raise InvalidQuerySetError("Cannot use a pre-sliced queryset")
+
+    id_col = queryset.model._meta.get_field(id_field)
+    if not isinstance(id_col, Field) or not id_col.unique:
+        raise InvalidQuerySetError(
+            f"id_field must be unique to produce stable ranges. Got {id_field!r}."
+        )
+
+    base = queryset.order_by()
+    cursor = start_after
+    ranges_yielded = 0
+
+    while True:
+        if max_ranges is not None and ranges_yielded >= max_ranges:
+            break
+
+        page = base.order_by(id_field)
+        if cursor is not None:
+            page = page.filter(**{f"{id_field}__gt": cursor})
+        page_ids = page.values(id_field)[:range_size]
+
+        bounds = (
+            queryset.model.objects.using(queryset.db)
+            .filter(**{f"{id_field}__in": page_ids})
+            .aggregate(first_id=Min(id_field), last_id=Max(id_field))
+        )
+        first_id = bounds["first_id"]
+        last_id = bounds["last_id"]
+        if first_id is None or last_id is None:
+            break
+
+        yield (first_id, last_id)
+        cursor = last_id
+        ranges_yielded += 1
 
 
 class RangeQuerySetWrapper[V]:

--- a/tests/sentry/tasks/test_process_active_projects.py
+++ b/tests/sentry/tasks/test_process_active_projects.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from sentry.constants import ObjectStatus
+from sentry.models.project import Project
+from sentry.tasks.process_active_projects import (
+    ISSUE_ACTION_LOG_WRITE_TO_DB,
+    process_active_projects,
+    process_active_projects_batch,
+)
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.features import with_feature
+
+
+class ProcessActiveProjectsBatchTest(TestCase):
+    def test_counts_enabled_feature(self) -> None:
+        enabled = self.create_project()
+        disabled = self.create_project()
+        inactive = self.create_project(status=ObjectStatus.DISABLED)
+
+        def feature_has(name: str, project: Project, *args: object, **kwargs: object) -> bool:
+            return name == ISSUE_ACTION_LOG_WRITE_TO_DB and project.id == enabled.id
+
+        with (
+            patch(
+                "sentry.tasks.process_active_projects.features.has",
+                side_effect=feature_has,
+            ),
+            patch("sentry.tasks.process_active_projects.metrics.incr") as mock_incr,
+        ):
+            process_active_projects_batch(
+                first_id=min(enabled.id, disabled.id, inactive.id),
+                last_id=max(enabled.id, disabled.id, inactive.id),
+            )
+
+        mock_incr.assert_called_once_with(
+            "process_active_projects.action_log_write_to_db_enabled",
+            amount=1,
+            sample_rate=1.0,
+        )
+
+    def test_no_metric_when_none_enabled(self) -> None:
+        project = self.create_project()
+        with patch("sentry.tasks.process_active_projects.metrics.incr") as mock_incr:
+            process_active_projects_batch(first_id=project.id, last_id=project.id)
+        mock_incr.assert_not_called()
+
+    @with_feature(ISSUE_ACTION_LOG_WRITE_TO_DB)
+    def test_skips_projects_outside_range(self) -> None:
+        inside = self.create_project()
+        outside = self.create_project()
+        assert outside.id > inside.id
+
+        with patch("sentry.tasks.process_active_projects.metrics.incr") as mock_incr:
+            process_active_projects_batch(first_id=inside.id, last_id=inside.id)
+
+        mock_incr.assert_called_once_with(
+            "process_active_projects.action_log_write_to_db_enabled",
+            amount=1,
+            sample_rate=1.0,
+        )
+
+
+class ProcessActiveProjectsTest(TestCase):
+    def _max_project_id(self) -> int:
+        return Project.objects.order_by("-id").values_list("id", flat=True).first() or 0
+
+    def test_empty(self) -> None:
+        start_id = self._max_project_id()
+        with (
+            patch.object(process_active_projects_batch, "delay") as mock_batch,
+            patch.object(process_active_projects, "delay") as mock_self,
+        ):
+            process_active_projects(start_id=start_id)
+        mock_batch.assert_not_called()
+        mock_self.assert_not_called()
+
+    def test_dispatches_batches_for_ranges(self) -> None:
+        start_id = self._max_project_id()
+        projects = [self.create_project() for _ in range(5)]
+        ids = sorted(p.id for p in projects)
+
+        with (
+            patch.object(process_active_projects_batch, "delay") as mock_batch,
+            patch.object(process_active_projects, "delay") as mock_self,
+            patch("sentry.tasks.process_active_projects.PROJECTS_PER_RANGE", 2),
+            patch("sentry.tasks.process_active_projects.MAX_RANGES_PER_COORDINATOR", 10),
+        ):
+            process_active_projects(start_id=start_id)
+
+        assert mock_batch.call_count == 3
+        mock_batch.assert_any_call(first_id=ids[0], last_id=ids[1])
+        mock_batch.assert_any_call(first_id=ids[2], last_id=ids[3])
+        mock_batch.assert_any_call(first_id=ids[4], last_id=ids[4])
+        mock_self.assert_not_called()
+
+    def test_reschedules_when_max_ranges_reached(self) -> None:
+        start_id = self._max_project_id()
+        projects = [self.create_project() for _ in range(6)]
+        ids = sorted(p.id for p in projects)
+
+        with (
+            patch.object(process_active_projects_batch, "delay") as mock_batch,
+            patch.object(process_active_projects, "delay") as mock_self,
+            patch("sentry.tasks.process_active_projects.PROJECTS_PER_RANGE", 2),
+            patch("sentry.tasks.process_active_projects.MAX_RANGES_PER_COORDINATOR", 2),
+        ):
+            process_active_projects(start_id=start_id)
+
+        assert mock_batch.call_count == 2
+        mock_batch.assert_any_call(first_id=ids[0], last_id=ids[1])
+        mock_batch.assert_any_call(first_id=ids[2], last_id=ids[3])
+        mock_self.assert_called_once_with(start_id=ids[3])
+
+        with (
+            patch.object(process_active_projects_batch, "delay") as mock_batch,
+            patch.object(process_active_projects, "delay") as mock_self,
+            patch("sentry.tasks.process_active_projects.PROJECTS_PER_RANGE", 2),
+            patch("sentry.tasks.process_active_projects.MAX_RANGES_PER_COORDINATOR", 2),
+        ):
+            process_active_projects(start_id=ids[3])
+
+        assert mock_batch.call_count == 1
+        mock_batch.assert_called_once_with(first_id=ids[4], last_id=ids[5])
+        mock_self.assert_not_called()
+
+    def test_skips_inactive_projects(self) -> None:
+        start_id = self._max_project_id()
+        active = self.create_project()
+        self.create_project(status=ObjectStatus.DISABLED)
+
+        with (
+            patch.object(process_active_projects_batch, "delay") as mock_batch,
+            patch.object(process_active_projects, "delay"),
+            patch("sentry.tasks.process_active_projects.PROJECTS_PER_RANGE", 10),
+        ):
+            process_active_projects(start_id=start_id)
+
+        mock_batch.assert_called_once_with(first_id=active.id, last_id=active.id)

--- a/tests/sentry/utils/test_query.py
+++ b/tests/sentry/utils/test_query.py
@@ -20,6 +20,7 @@ from sentry.utils.query import (
     RangeQuerySetWrapperWithProgressBar,
     RangeQuerySetWrapperWithProgressBarApprox,
     bulk_delete_objects,
+    iter_id_ranges,
 )
 
 
@@ -32,6 +33,131 @@ class InIexactQueryTest(TestCase):
         assert Organization.objects.filter(in_iexact("slug", ["sluga", "slugb"])).count() == 2
         assert Organization.objects.filter(in_iexact("slug", ["slugC"])).count() == 1
         assert Organization.objects.filter(in_iexact("slug", [])).count() == 0
+
+
+@no_silo_test
+class IterIdRangesTest(TestCase):
+    def test_empty(self) -> None:
+        assert list(iter_id_ranges(User.objects.all(), 10)) == []
+
+    def test_exact_multiple(self) -> None:
+        users = [self.create_user() for _ in range(6)]
+        ids = sorted(u.id for u in users)
+        qs = User.objects.filter(id__in=ids)
+        assert list(iter_id_ranges(qs, 3)) == [
+            (ids[0], ids[2]),
+            (ids[3], ids[5]),
+        ]
+
+    def test_remainder(self) -> None:
+        users = [self.create_user() for _ in range(5)]
+        ids = sorted(u.id for u in users)
+        qs = User.objects.filter(id__in=ids)
+        assert list(iter_id_ranges(qs, 2)) == [
+            (ids[0], ids[1]),
+            (ids[2], ids[3]),
+            (ids[4], ids[4]),
+        ]
+
+    def test_start_after(self) -> None:
+        users = [self.create_user() for _ in range(5)]
+        ids = sorted(u.id for u in users)
+        qs = User.objects.filter(id__in=ids)
+        assert list(iter_id_ranges(qs, 2, start_after=ids[1])) == [
+            (ids[2], ids[3]),
+            (ids[4], ids[4]),
+        ]
+
+    def test_max_ranges_continue_without_gap_or_overlap(self) -> None:
+        users = [self.create_user() for _ in range(7)]
+        ids = sorted(u.id for u in users)
+        qs = User.objects.filter(id__in=ids)
+
+        first_pass = list(iter_id_ranges(qs, 2, max_ranges=2))
+        assert first_pass == [(ids[0], ids[1]), (ids[2], ids[3])]
+
+        second_pass = list(iter_id_ranges(qs, 2, start_after=first_pass[-1][1]))
+        assert second_pass == [(ids[4], ids[5]), (ids[6], ids[6])]
+
+        combined = first_pass + second_pass
+        assert combined == list(iter_id_ranges(qs, 2))
+
+        covered: list[int] = []
+        for first_id, last_id in combined:
+            covered.extend(
+                User.objects.filter(id__in=ids, id__gte=first_id, id__lte=last_id)
+                .order_by("id")
+                .values_list("id", flat=True)
+            )
+        assert covered == ids
+
+    def test_extra_predicate(self) -> None:
+        active = [self.create_user(is_active=True) for _ in range(3)]
+        inactive = [self.create_user(is_active=False) for _ in range(3)]
+        all_ids = [u.id for u in active + inactive]
+        active_ids = sorted(u.id for u in active)
+        qs = User.objects.filter(id__in=all_ids, is_active=True)
+        assert list(iter_id_ranges(qs, 2)) == [
+            (active_ids[0], active_ids[1]),
+            (active_ids[2], active_ids[2]),
+        ]
+        for first_id, last_id in iter_id_ranges(qs, 2):
+            batch = list(
+                User.objects.filter(id__in=all_ids, id__gte=first_id, id__lte=last_id)
+                .order_by("id")
+                .values_list("id", "is_active")
+            )
+            assert all(is_active for _, is_active in batch)
+            assert [pk for pk, _ in batch] == [pk for pk in active_ids if first_id <= pk <= last_id]
+
+    def test_sparse_ids(self) -> None:
+        users = [self.create_user() for _ in range(10)]
+        # Delete every other user so remaining ids are sparse
+        for user in users[1::2]:
+            user.delete()
+        remaining = sorted(u.id for u in users[0::2])
+        qs = User.objects.filter(id__in=remaining)
+        ranges = list(iter_id_ranges(qs, 2))
+        assert ranges == [
+            (remaining[0], remaining[1]),
+            (remaining[2], remaining[3]),
+            (remaining[4], remaining[4]),
+        ]
+        # Range bounds span gaps in id space but cover only matching rows
+        for first_id, last_id in ranges:
+            matched = list(
+                User.objects.filter(id__in=remaining, id__gte=first_id, id__lte=last_id)
+                .order_by("id")
+                .values_list("id", flat=True)
+            )
+            assert 1 <= len(matched) <= 2
+
+    def test_invalid_inputs(self) -> None:
+        with pytest.raises(ValueError, match="range_size"):
+            list(iter_id_ranges(User.objects.all(), 0))
+        with pytest.raises(ValueError, match="range_size"):
+            list(iter_id_ranges(User.objects.all(), -1))
+        with pytest.raises(InvalidQuerySetError, match="pre-sliced"):
+            list(iter_id_ranges(User.objects.all()[:5], 2))
+        with pytest.raises(InvalidQuerySetError, match="unique"):
+            list(iter_id_ranges(User.objects.all(), 2, id_field="name"))
+
+    def test_full_coverage_of_matching_pks(self) -> None:
+        users = [self.create_user() for _ in range(11)]
+        ids = sorted(u.id for u in users)
+        qs = User.objects.filter(id__in=ids)
+        covered: list[int] = []
+        for first_id, last_id in iter_id_ranges(qs, 3):
+            batch = list(
+                qs.filter(id__gte=first_id, id__lte=last_id)
+                .order_by("id")
+                .values_list("id", flat=True)
+            )
+            assert batch[0] == first_id
+            assert batch[-1] == last_id
+            assert len(batch) <= 3
+            covered.extend(batch)
+        assert covered == ids
 
 
 @no_silo_test


### PR DESCRIPTION
A pattern of "cheaply scan for id ranges, farm them out to child tasks, then (ideally after some delay) do it again".
