### PR TITLE
ref(utils): Move `is_valid_ip` to shared utils module

### DIFF
--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -3,10 +3,10 @@ import logging
 import re
 from collections import Counter, OrderedDict, defaultdict
 from collections.abc import Sequence
-from ipaddress import ip_address, ip_interface, ip_network
 from typing import Any, Callable
 
 from sentry.utils import metrics
+from sentry.utils.http import is_valid_ip
 
 logger = logging.getLogger("sentry.events.grouping")
 
@@ -63,25 +63,6 @@ class ParameterizationRegex:
         Returns the regex pattern inside of a named matching group.
         """
         return rf"(?P<{self.name}>{raw_pattern})"
-
-
-def is_valid_ip(maybe_ip_str: str) -> bool:
-    # Validate the string by attempting to pass it to the three built-in factory functions for
-    # creating different types of ip address objects. If any of them succeeds, it's a valid IP. If
-    # all three raise an error, it's not.
-    for fn, kwargs in (
-        (ip_address, {}),
-        (ip_interface, {}),
-        (ip_network, {"strict": False}),  # `strict: False` allows host bits
-    ):
-        try:
-            fn(maybe_ip_str, **kwargs)
-        except ValueError:
-            pass
-        else:
-            return True
-
-    return False
 
 
 # fmt: off

--- a/src/sentry/utils/http.py
+++ b/src/sentry/utils/http.py
@@ -14,6 +14,8 @@ from sentry import options
 if TYPE_CHECKING:
     from sentry.models.project import Project
 
+from ipaddress import ip_address, ip_interface, ip_network
+
 # User-agent prefix set by the official Sentry MCP server (source of truth:
 # getsentry/sentry-mcp). Used to attribute requests originating from the MCP.
 MCP_USER_AGENT_PREFIX = "sentry-mcp/"
@@ -238,6 +240,25 @@ class _HttpRequestWithSubdomain(HttpRequest):
 
 def is_using_customer_domain(request: HttpRequest) -> TypeGuard[_HttpRequestWithSubdomain]:
     return bool(hasattr(request, "subdomain") and request.subdomain)
+
+
+def is_valid_ip(maybe_ip_str: str) -> bool:
+    # Validate the string by attempting to pass it to the three built-in factory functions for
+    # creating different types of ip address objects. If any of them succeeds, it's a valid IP. If
+    # all three raise an error, it's not.
+    for fn, kwargs in (
+        (ip_address, {}),
+        (ip_interface, {}),
+        (ip_network, {"strict": False}),  # `strict: False` allows host bits
+    ):
+        try:
+            fn(maybe_ip_str, **kwargs)
+        except ValueError:
+            pass
+        else:
+            return True
+
+    return False
 
 
 class BodyAsyncWrapper:

--- a/tests/sentry/grouping/test_parameterization.py
+++ b/tests/sentry/grouping/test_parameterization.py
@@ -15,7 +15,6 @@ from sentry.grouping.parameterization import (
     Parameterizer,
     _log_example_data,
     experimental_parameterizer,
-    is_valid_ip,
     parameterizer,
 )
 from sentry.grouping.variants import ComponentVariant, CustomFingerprintVariant
@@ -23,6 +22,7 @@ from sentry.models.project import Project
 from sentry.services.eventstore.models import Event
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.pytest.mocking import capture_results, count_matching_calls
+from sentry.utils.http import is_valid_ip
 
 standard_cases = [
     ("email", "maisey@dogsaregreat.com", "<email>"),

--- a/tests/sentry/utils/test_http.py
+++ b/tests/sentry/utils/test_http.py
@@ -1,11 +1,18 @@
 import unittest
 from unittest import mock
 
+import pytest
 from django.http import HttpRequest
 
 from sentry import options
 from sentry.testutils.cases import TestCase
-from sentry.utils.http import absolute_uri, get_origins, is_valid_origin, origin_from_request
+from sentry.utils.http import (
+    absolute_uri,
+    get_origins,
+    is_valid_ip,
+    is_valid_origin,
+    origin_from_request,
+)
 
 
 class AbsoluteUriTest(unittest.TestCase):
@@ -240,3 +247,40 @@ class OriginFromRequestTestCase(TestCase):
 
         request.META["HTTP_REFERER"] = "http://example.com"
         assert origin_from_request(request) == "http://example.com"
+
+
+class TestIsValidIP:
+    ip_test_cases = [
+        # Adapted from grouping parameterization tests
+        # (name, input, expected result)
+        ("IPv4", "11.21.12.31", True),
+        ("IPv6 unspecified", "::", True),
+        ("IPv6 loopback", "::1", True),
+        ("IPv6 ULA", "fc00::/7", True),
+        ("IPv6 initial compressed segment", "::cbe:908:2013", True),
+        ("IPv6 compressed segment in middle", "2012:d157::cbe:908:2013", True),
+        ("IPv6 final compressed segment", "2012:d157::", True),
+        ("IPv4 mapped to v6", "::ffff:192.168.1.1", True),
+        ("IPv6 full", "1121:0c03:1231:130d:0000:16da:0908:da07", True),
+        ("IPv4 too few segments", "12:31:99", False),
+        ("IPv4 too many segments", "11.21.12.31.12", False),
+        ("IPv4 segment > 255", "12.31.12.908", False),
+        ("IPv4 leading zeros", "11.21.12.001", False),
+        ("double colon object property", "Option::unwrap()", False),
+        ("double colon object property including hex", "Bee::buzz()", False),
+        ("too many initial characters", "12345::6:789", False),
+        ("too many final characters", "123:4::56789", False),
+        ("too many initial colons", ":::1121", False),
+        ("too many interior colons", "1231:::1121", False),
+        ("too many final colons", "1231:::", False),
+        ("three colons alone", ":::", False),
+        ("single leading colon", "Script error. :0:0", False),
+        ("already parameterized", "ip", False),
+        ("filtering placeholder", "Filtered", False),
+        ("filtering placeholder with type", "redacted_number", False),
+        ("random non-IP value", "dogs_are_great", False),
+    ]
+
+    @pytest.mark.parametrize(("name", "input", "expected_result"), ip_test_cases)
+    def test_is_valid_ip(self, name: str, input: str, expected_result: bool) -> None:
+        assert is_valid_ip(input) == expected_result


### PR DESCRIPTION
This moves our `is_valid_ip` helper function from its current home in the message parameterization module to `utils`, in preparation for also using it in issue detection. It also adds some tests for it.