### PR TITLE
chore(workflow-engine): Add metrics to all projects detector processor cache

### DIFF
--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -31,6 +31,7 @@ from sentry.workflow_engine.typings.grouptype import IssueStreamGroupType
 
 logger = logging.getLogger(__name__)
 
+ALL_PROJECTS_TIMER_METRIC = "workflow_engine.all_projects_detector_fetch"
 
 _DETECTOR_SENTINEL = object()
 
@@ -40,16 +41,27 @@ def _get_all_projects_detector_cache_key(organization_id: int) -> str:
 
 
 def get_all_projects_detector(organization_id: int) -> Detector | None:
-    cache_key = _get_all_projects_detector_cache_key(organization_id)
-    cached = cache.get(cache_key, default=_DETECTOR_SENTINEL)
-    if cached is not _DETECTOR_SENTINEL:
-        return cached
-    result = Detector.objects.filter(
-        project__isnull=True,
-        type=IssueStreamGroupType.slug,
-        config__organization_id=organization_id,
-    ).first()
-    cache.set(cache_key, result, Detector.CACHE_TTL)
+    with metrics.timer(ALL_PROJECTS_TIMER_METRIC) as metrics_tags:
+        cache_key = _get_all_projects_detector_cache_key(organization_id)
+        cached = cache.get(cache_key, default=_DETECTOR_SENTINEL)
+        if cached is not _DETECTOR_SENTINEL:
+            metrics_tags["cache_hit"] = "true"
+            metrics_tags["detector_found"] = "true" if cached is not None else "false"
+            return cached
+
+        metrics_tags["cache_hit"] = "false"
+        result = Detector.objects.filter(
+            project__isnull=True,
+            type=IssueStreamGroupType.slug,
+            config__organization_id=organization_id,
+        ).first()
+        cache.set(cache_key, result, Detector.CACHE_TTL)
+
+        if result is not None:
+            metrics_tags["detector_found"] = "true"
+        else:
+            metrics_tags["detector_found"] = "false"
+
     return result
 
 

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -31,7 +31,6 @@ from sentry.workflow_engine.typings.grouptype import IssueStreamGroupType
 
 logger = logging.getLogger(__name__)
 
-ALL_PROJECTS_TIMER_METRIC = "workflow_engine.all_projects_detector_fetch"
 
 _DETECTOR_SENTINEL = object()
 
@@ -41,7 +40,7 @@ def _get_all_projects_detector_cache_key(organization_id: int) -> str:
 
 
 def get_all_projects_detector(organization_id: int) -> Detector | None:
-    with metrics.timer(ALL_PROJECTS_TIMER_METRIC) as metrics_tags:
+    with metrics.timer("workflow_engine.cache.all_projects_detector") as metrics_tags:
         cache_key = _get_all_projects_detector_cache_key(organization_id)
         cached = cache.get(cache_key, default=_DETECTOR_SENTINEL)
         if cached is not _DETECTOR_SENTINEL:
@@ -49,18 +48,14 @@ def get_all_projects_detector(organization_id: int) -> Detector | None:
             metrics_tags["detector_found"] = "true" if cached is not None else "false"
             return cached
 
-        metrics_tags["cache_hit"] = "false"
         result = Detector.objects.filter(
             project__isnull=True,
             type=IssueStreamGroupType.slug,
             config__organization_id=organization_id,
         ).first()
+        metrics_tags["cache_hit"] = "false"
+        metrics_tags["detector_found"] = "true" if result is not None else "false"
         cache.set(cache_key, result, Detector.CACHE_TTL)
-
-        if result is not None:
-            metrics_tags["detector_found"] = "true"
-        else:
-            metrics_tags["detector_found"] = "false"
 
     return result
 

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -1053,6 +1053,33 @@ class TestEventDetectorsAllProject(TestCase):
 
         assert get_all_projects_detector(self.organization.id) == detector
 
+    @patch("sentry.utils.metrics.timer")
+    def test_metrics_all_projects_cache(self, mock_timer: MagicMock) -> None:
+        cache.clear()
+        mock_tags: MagicMock = mock_timer.return_value.__enter__.return_value
+
+        get_all_projects_detector(self.organization.id)
+        assert mock.call("cache_hit", "false") in mock_tags.__setitem__.call_args_list
+        assert mock.call("detector_found", "true") in mock_tags.__setitem__.call_args_list
+        mock_tags.reset_mock()
+
+        get_all_projects_detector(self.organization.id)
+        assert mock.call("cache_hit", "true") in mock_tags.__setitem__.call_args_list
+        assert mock.call("detector_found", "true") in mock_tags.__setitem__.call_args_list
+        mock_tags.reset_mock()
+
+        other_org = self.create_organization()
+        result = get_all_projects_detector(other_org.id)
+        assert result is None
+        assert mock.call("cache_hit", "false") in mock_tags.__setitem__.call_args_list
+        assert mock.call("detector_found", "false") in mock_tags.__setitem__.call_args_list
+        mock_tags.reset_mock()
+
+        result = get_all_projects_detector(other_org.id)
+        assert result is None
+        assert mock.call("cache_hit", "true") in mock_tags.__setitem__.call_args_list
+        assert mock.call("detector_found", "false") in mock_tags.__setitem__.call_args_list
+
 
 class TestGetDetectorsForEventAllProject(TestCase):
     def setUp(self) -> None:

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -11,10 +11,12 @@ from sentry.models.environment import Environment
 from sentry.services.eventstore.models import GroupEvent
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.helpers.options import override_options
 from sentry.types.activity import ActivityType
 from sentry.utils import json
 from sentry.utils.cache import cache
 from sentry.workflow_engine.buffer.batch_client import DelayedWorkflowClient, DelayedWorkflowItem
+from sentry.workflow_engine.defaults.detectors import ensure_default_all_projects_detector
 from sentry.workflow_engine.models import Action, DataConditionGroup
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.models.workflow_fire_history import WorkflowFireHistory
@@ -496,6 +498,33 @@ class TestProcessWorkflows(BaseWorkflowTest):
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
         assert result.triggered_workflows == {self.error_workflow}
         assert result.associated_detector == self.error_detector
+
+    @override_options({"workflow_engine.all_projects_detectors_enabled": True})
+    def test_all_projects_workflow_via_process_workflows(self) -> None:
+        all_projects_detector = ensure_default_all_projects_detector(self.organization.id)
+
+        all_projects_triggers = self.create_data_condition_group()
+        self.create_data_condition(
+            condition_group=all_projects_triggers,
+            type=Condition.EVENT_SEEN_COUNT,
+            comparison=1,
+            condition_result=True,
+        )
+        all_projects_workflow = self.create_workflow(
+            name="all_projects_workflow",
+            when_condition_group=all_projects_triggers,
+            organization=self.organization,
+        )
+        self.create_detector_workflow(
+            detector=all_projects_detector,
+            workflow=all_projects_workflow,
+        )
+
+        result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
+        assert result.workflows
+        assert all_projects_workflow in result.workflows
+        assert result.triggered_workflows
+        assert all_projects_workflow in result.triggered_workflows
 
 
 class TestEvaluateWorkflowTriggers(BaseWorkflowTest):


### PR DESCRIPTION
I added the cache and sentinel and all that good stuff but realized it wasn't instrumented. I didn't feel super comfortable allowing processing without it since it'll determine if we'll need to add an index or something to improve how we querying for these detectors.

Also noticed a test missing that these all detector workflows are picked up in `process_workflows`. 