### PR TITLE
fix(issues): Show Sentry Apps as activity sources

### DIFF
--- a/static/app/views/issueDetails/activitySection/activityLineItem/activityItem.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/activityItem.tsx
@@ -33,6 +33,7 @@ import {getArchiveDetails} from './archiveDetails';
 interface ActivityItem {
   title: React.ReactNode;
   details?: React.ReactNode;
+  source?: string;
 }
 
 export function getActivityNoteAuthor(
@@ -132,6 +133,18 @@ interface GetActivityItemParams {
 
 const MINIMUM_SEER_ACTIVITY_DURATION_SECONDS = 5 * 60;
 
+function getSentryAppSource(activity: GroupActivity): string | undefined {
+  if (
+    !activity.sentry_app ||
+    activity.type === GroupActivityType.NOTE ||
+    activity.type === GroupActivityType.CREATE_ISSUE
+  ) {
+    return undefined;
+  }
+
+  return activity.sentry_app.name;
+}
+
 function getSeerActivityDuration(
   activity: CollapsedSeerActivity
 ): React.ReactNode | null {
@@ -162,7 +175,14 @@ function getCollapsedSeerIterationReferrer(item: ActivityFeedItem) {
   return getSeerIterationReferrer(item.startedActivity.data.referrer);
 }
 
-export function getActivityItem({
+export function getActivityItem(params: GetActivityItemParams): ActivityItem {
+  const activityItem = getActivityItemContent(params);
+  const source = getSentryAppSource(params.item.activity);
+
+  return source ? {...activityItem, source} : activityItem;
+}
+
+function getActivityItemContent({
   item,
   organization,
   project,

--- a/static/app/views/issueDetails/activitySection/activityLineItem/actor.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/actor.tsx
@@ -6,7 +6,7 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 import {IconSeer} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {GroupActivity} from 'sentry/types/group';
-import {SEER_ACTIVITY_TYPES} from 'sentry/types/group';
+import {GroupActivityType, SEER_ACTIVITY_TYPES} from 'sentry/types/group';
 
 export function ActivityLineActor({item}: {item: GroupActivity}) {
   return <ActorSlot>{renderActivityLineActor(item)}</ActorSlot>;
@@ -14,6 +14,10 @@ export function ActivityLineActor({item}: {item: GroupActivity}) {
 
 export function renderActivityLineActor(item: GroupActivity): React.ReactElement | null {
   if (item.sentry_app) {
+    if (item.type !== GroupActivityType.NOTE) {
+      return null;
+    }
+
     return (
       <Tooltip title={item.sentry_app.name}>
         <SentryAppAvatar sentryApp={item.sentry_app} size={22} />

--- a/static/app/views/issueDetails/activitySection/activityLineItem/index.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/index.tsx
@@ -50,6 +50,7 @@ export function ActivityLine({item, group, timestampUnitStyle}: ActivityLineProp
       <ActivityLineHeadline
         title={activityItem.title}
         details={activityItem.details}
+        source={activityItem.source}
         timestamp={timestamp}
       />
     </ActivityLineRow>

--- a/static/app/views/issueDetails/activitySection/activityLineItem/layout.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/layout.tsx
@@ -4,17 +4,21 @@ import styled from '@emotion/styled';
 import {Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
+import {tct} from 'sentry/locale';
+
 export type ActivityLineVariant = 'compact' | 'full';
 
 interface ActivityLineHeadlineProps {
   timestamp: React.ReactNode;
   title: React.ReactNode;
   details?: React.ReactNode;
+  source?: string;
 }
 
 export function ActivityLineHeadline({
   title,
   details,
+  source,
   timestamp,
 }: ActivityLineHeadlineProps) {
   return (
@@ -32,6 +36,12 @@ export function ActivityLineHeadline({
           <Fragment>
             {' '}
             <ActivityLineDetails>{details}</ActivityLineDetails>
+          </Fragment>
+        ) : null}
+        {source ? (
+          <Fragment>
+            {' '}
+            <ActivityLineDetails>{tct('via [source]', {source})}</ActivityLineDetails>
           </Fragment>
         ) : null}
         <Fragment>

--- a/static/app/views/issueDetails/activitySection/index.spec.tsx
+++ b/static/app/views/issueDetails/activitySection/index.spec.tsx
@@ -871,6 +871,34 @@ describe('ActivitySection', () => {
     expect(screen.queryByText(newUser.name)).not.toBeInTheDocument();
   });
 
+  it('renders a sentry app as the source instead of the actor', async () => {
+    const activityGroup = GroupFixture({
+      id: 'sentry-app-activity',
+      activity: [
+        {
+          type: GroupActivityType.SET_RESOLVED,
+          id: 'resolved-by-sentry-app',
+          data: {},
+          dateCreated: '2020-01-01T00:00:00',
+          sentry_app: SentryAppFixture({name: 'Linear'}),
+          user: UserFixture({name: 'sentry-app-proxy-user-abcd123'}),
+        },
+      ],
+      project,
+    });
+
+    render(
+      <GroupDataContextProvider group={activityGroup} project={activityGroup.project}>
+        <ActivitySection group={activityGroup} />
+      </GroupDataContextProvider>
+    );
+
+    expect(await screen.findByTestId('activity-timeline')).toHaveTextContent(
+      'Resolved via Linear'
+    );
+    expect(screen.getByRole('img', {name: 'Activity update'})).toBeInTheDocument();
+  });
+
   it('renders note but does not allow for deletion if written by someone else', async () => {
     const updatedActivityGroup = GroupFixture({
       id: '1338',


### PR DESCRIPTION
Sentry App activity currently uses the app avatar like it is the person who made the change.

Show the app as an inline source instead, such as `Resolved via Linear`, and use a neutral marker. App-authored comments keep their avatar. It doesn't seem right now its possible to get the user.

fixes ID-1766

before

<img width="365" height="51" alt="image" src="https://github.com/user-attachments/assets/70db64b9-c53b-4c10-b9b4-7670f7be7111" />


after

<img width="389" height="56" alt="image" src="https://github.com/user-attachments/assets/38c82174-6d87-48b4-a648-43893f2daf95" />
