### PR TITLE
ref(organizations): drop outbox replication from member teams

### DIFF
--- a/src/sentry/backup/imports.py
+++ b/src/sentry/backup/imports.py
@@ -452,21 +452,13 @@ def _import(
             slug_mapping[org_id] = org_slug or ""
 
         if len(slug_mapping) > 0:
-            # HACK(azaslavsky): Okay, this gets a bit complicated, but bear with me: the following
-            # `bulk_create...` calls will result in some actions on the control silo that call back
-            # into this region. So the client (this region) calls the server (the control silo)
-            # which may need to make one or more calls back into the client (this region). Because
-            # some of our `OrganizationMemberTeam` outboxes may not be drained due to the HACK we
-            # performed in `import_export/impl.py` (see that file for more details), there may be a
-            # massive backlog of `OrganizationMemberTeam` outboxes that need to clear before this
-            # region can respond. In the worst case scenario, this will result in a timeout of the
-            # original, outer `bulk_create...` call.
+            # The `bulk_create...` call below is reentrant: this region calls the control silo,
+            # which may call back into this region before it can answer. Any backlog on an
+            # imported organization's `ORGANIZATION_SCOPE` shard has to clear before this region
+            # can serve that callback, which in the worst case times out the outer call.
             #
-            # So, the solution we take here is to manually clear all `ORGANIZATION_SCOPE` outboxes
-            # for each imported organization on this side first, so that when this region responds
-            # to the call triggered from the server-side of `bulk_create...`, the
-            # `ORGANIZATION`-scoped outbox queue is empty and is free to only serve requests
-            # specifically related to slug provisioning.
+            # Draining each organization's shard up front keeps that queue free to serve only the
+            # slug-provisioning callback.
             for id in slug_mapping.keys():
                 # To combat ephemeral errors, we'll try this a few times before accepting failure.
                 for attempt in range(MAX_SHARD_DRAIN_ATTEMPTS):

--- a/src/sentry/backup/services/import_export/impl.py
+++ b/src/sentry/backup/services/import_export/impl.py
@@ -193,16 +193,8 @@ class UniversalImportExportService(ImportExportService):
                 logger.info("import_by_model.already_imported", extra=extra)
                 return existing_import_chunk
 
-            # We don't need the control and region silo synced into the correct `*Replica` tables
-            # immediately. The locally silo-ed versions of the models are written by the scripts
-            # themselves, and the remote versions will be synced a few minutes later, well before
-            # any users are likely ot need to get ahold of them to view actual data in the UI.
             using = router.db_for_write(model)
-            # HACK(azaslavsky): Need to figure out why `OrganizationMemberTeam` in particular is failing, but we can just use async outboxes for it for now.
-            with outbox_context(
-                transaction.atomic(using=using),
-                flush=import_model_name != "sentry.organizationmemberteam",
-            ):
+            with outbox_context(transaction.atomic(using=using), flush=True):
                 ok_relocation_scopes = import_scope.value
                 out_pk_map = PrimaryKeyMap()
                 min_old_pk = 0

--- a/src/sentry/core/endpoints/organization_member_utils.py
+++ b/src/sentry/core/endpoints/organization_member_utils.py
@@ -130,7 +130,7 @@ def save_team_assignments(
                 TeamAssignmentChange(team=t, omt_id=old_omt_by_team[t.id].id) for t in removed_teams
             ]
 
-            OrganizationMemberTeam.objects.bulk_delete(existing)
+            existing.delete()
             OrganizationMemberTeam.objects.bulk_create(
                 [
                     OrganizationMemberTeam(

--- a/src/sentry/core/endpoints/scim/teams.py
+++ b/src/sentry/core/endpoints/scim/teams.py
@@ -432,7 +432,7 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
                     event=audit_log.get_event_id("MEMBER_LEAVE_TEAM"),
                     data=omt.get_audit_log_data(),
                 )
-            OrganizationMemberTeam.objects.bulk_delete(omts)
+            OrganizationMemberTeam.objects.filter(id__in=[omt.id for omt in omts]).delete()
 
     def _rename_team_operation(self, request: Request, new_name, team):
         serializer = TeamSerializer(

--- a/src/sentry/hybridcloud/outbox/category.py
+++ b/src/sentry/hybridcloud/outbox/category.py
@@ -43,7 +43,7 @@ class OutboxCategory(IntEnum):
 
     AUTH_PROVIDER_UPDATE = 24
     AUTH_IDENTITY_UPDATE = 25
-    ORGANIZATION_MEMBER_TEAM_UPDATE = 26
+    UNUSED_EIGHT = 26  # was ORGANIZATION_MEMBER_TEAM_UPDATE, no longer in use
     ORGANIZATION_SLUG_RESERVATION_UPDATE = 27
     API_KEY_UPDATE = 28
     PARTNER_ACCOUNT_UPDATE = 29
@@ -279,7 +279,7 @@ class OutboxScope(IntEnum):
             OutboxCategory.ORGANIZATION_MAPPING_CUSTOMER_ID_UPDATE,
             OutboxCategory.TEAM_UPDATE,
             OutboxCategory.AUTH_PROVIDER_UPDATE,
-            OutboxCategory.ORGANIZATION_MEMBER_TEAM_UPDATE,
+            OutboxCategory.UNUSED_EIGHT,
             OutboxCategory.API_KEY_UPDATE,
             OutboxCategory.ORGANIZATION_SLUG_RESERVATION_UPDATE,
             OutboxCategory.ORG_AUTH_TOKEN_UPDATE,

--- a/src/sentry/models/organizationmemberteam.py
+++ b/src/sentry/models/organizationmemberteam.py
@@ -10,26 +10,24 @@ from sentry.db.models import (
     BoundedAutoField,
     BoundedBigIntegerField,
     FlexibleForeignKey,
+    Model,
     cell_silo_model,
     sane_repr,
 )
-from sentry.hybridcloud.models.outbox import CellOutboxBase
-from sentry.hybridcloud.outbox.base import CellOutboxProducingManager, ReplicatedCellModel
-from sentry.hybridcloud.outbox.category import OutboxCategory
+from sentry.db.models.manager.base import BaseManager
 from sentry.roles import team_roles
 from sentry.roles.manager import TeamRole
 
 
 @cell_silo_model
-class OrganizationMemberTeam(ReplicatedCellModel):
+class OrganizationMemberTeam(Model):
     """
     Identifies relationships between organization members and the teams they are on.
     """
 
-    objects: ClassVar[CellOutboxProducingManager[Self]] = CellOutboxProducingManager()
+    objects: ClassVar[BaseManager[Self]] = BaseManager()
 
     __relocation_scope__ = RelocationScope.Organization
-    category = OutboxCategory.ORGANIZATION_MEMBER_TEAM_UPDATE
 
     id = BoundedAutoField(primary_key=True)
     # Shadow column for the in-progress widening of `id` to int8; swapped into the
@@ -48,15 +46,6 @@ class OrganizationMemberTeam(ReplicatedCellModel):
         unique_together = (("team", "organizationmember"),)
 
     __repr__ = sane_repr("team_id", "organizationmember_id")
-
-    def outbox_for_update(self, shard_identifier: int | None = None) -> CellOutboxBase:
-        return super().outbox_for_update(
-            shard_identifier=(
-                self.organizationmember.organization_id
-                if shard_identifier is None
-                else shard_identifier
-            )
-        )
 
     def get_audit_log_data(self) -> dict[str, Any]:
         return {

--- a/tests/sentry/hybridcloud/models/test_outbox.py
+++ b/tests/sentry/hybridcloud/models/test_outbox.py
@@ -20,7 +20,7 @@ from sentry.hybridcloud.outbox.category import OutboxCategory, OutboxScope
 from sentry.hybridcloud.tasks.deliver_from_outbox import enqueue_outbox_jobs
 from sentry.models.organization import Organization
 from sentry.models.organizationmember import OrganizationMember
-from sentry.models.organizationmemberteam import OrganizationMemberTeam
+from sentry.models.projectkey import ProjectKey
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase, TransactionTestCase
 from sentry.testutils.factories import Factories
@@ -539,50 +539,63 @@ class CellOutboxTest(TestCase):
         assert CellOutbox.objects.count() == 1
 
 
+def outboxed_ids() -> set[int]:
+    """The rows currently carrying an outbox, by object identifier.
+
+    Asserted as a set rather than a count because a model may register its own
+    delete-time outbox hook on top of the manager's, so the row count is not
+    one-per-object for every model.
+    """
+    return set[int](CellOutbox.objects.values_list("object_identifier", flat=True))
+
+
 class TestOutboxesManager(TestCase):
     def test_bulk_operations(self) -> None:
-        org = self.create_organization()
-        team = self.create_team(organization=org)
-        members = [
-            self.create_member(user_id=i + 1000, organization_id=org.id) for i in range(0, 10)
-        ]
-        do_not_touch = OrganizationMemberTeam(
-            organizationmember=self.create_member(user_id=99, organization_id=org.id),
-            team=team,
-            role="ploy",
-        )
-        do_not_touch.save()
+        project = self.create_project()
+        do_not_touch = ProjectKey.objects.create(project=project, label="untouched")
+        # Drain the outboxes produced by the fixtures above, so each assertion below
+        # counts only the outboxes from the bulk operation it follows.
+        with outbox_runner():
+            pass
 
-        OrganizationMemberTeam.objects.bulk_create(
-            OrganizationMemberTeam(organizationmember=member, team=team) for member in members
+        managed = ProjectKey.objects.bulk_create(
+            [
+                ProjectKey(
+                    project=project,
+                    label=f"key-{i}",
+                    public_key=ProjectKey.generate_api_key(),
+                    secret_key=ProjectKey.generate_api_key(),
+                )
+                for i in range(0, 10)
+            ]
         )
+        managed_ids = {key.id for key in managed}
 
         with outbox_runner():
-            assert CellOutbox.objects.count() == 10
-            assert OrganizationMemberTeam.objects.count() == 11
+            assert outboxed_ids() == managed_ids
+            assert ProjectKey.objects.filter(id__in=managed_ids).count() == 10
 
         assert CellOutbox.objects.count() == 0
-        assert OrganizationMemberTeam.objects.count() == 11
 
-        existing = OrganizationMemberTeam.objects.all().exclude(id=do_not_touch.id).all()
+        existing = list[Any](ProjectKey.objects.filter(id__in=managed_ids))
         for obj in existing:
-            obj.role = "cow"
-        OrganizationMemberTeam.objects.bulk_update(existing, ["role"])
+            obj.label = "cow"
+        ProjectKey.objects.bulk_update(existing, ["label"])
 
         with outbox_runner():
-            assert CellOutbox.objects.count() == 10
+            assert outboxed_ids() == managed_ids
 
         assert CellOutbox.objects.count() == 0
-        assert OrganizationMemberTeam.objects.filter(role="cow").count() == 10
+        assert ProjectKey.objects.filter(label="cow").count() == 10
 
-        OrganizationMemberTeam.objects.bulk_delete(existing)
+        ProjectKey.objects.bulk_delete(existing)
 
         with outbox_runner():
-            assert CellOutbox.objects.count() == 10
-            assert OrganizationMemberTeam.objects.count() == 1
+            assert outboxed_ids() == managed_ids
+            assert ProjectKey.objects.filter(id__in=managed_ids).count() == 0
 
         assert CellOutbox.objects.count() == 0
-        assert OrganizationMemberTeam.objects.count() == 1
+        assert ProjectKey.objects.filter(id=do_not_touch.id).exists()
 
 
 @control_silo_test

--- a/tests/sentry/models/test_organizationmemberteam.py
+++ b/tests/sentry/models/test_organizationmemberteam.py
@@ -1,7 +1,9 @@
+from sentry.hybridcloud.models.outbox import CellOutbox, outbox_context
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.roles import team_roles
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import with_feature
+from sentry.testutils.outbox import outbox_runner
 
 
 class OrganizationMemberTest(TestCase):
@@ -25,3 +27,33 @@ class OrganizationMemberTest(TestCase):
         for org_role in ("admin", "manager", "owner"):
             self.member.role = org_role
             assert omt.get_team_role() == team_roles.get("admin")
+
+
+class OrganizationMemberTeamOutboxTest(TestCase):
+    def setUp(self) -> None:
+        self.organization = self.create_organization()
+        self.team = self.create_team(organization=self.organization)
+        self.member = self.create_member(organization=self.organization, user=self.create_user())
+        # Drain the outboxes the fixtures above produce, so the assertions below
+        # only see rows attributable to the membership writes under test.
+        with outbox_runner():
+            pass
+
+    def test_membership_write_produces_no_outbox(self) -> None:
+        with outbox_context(flush=False):
+            omt = OrganizationMemberTeam.objects.create(
+                organizationmember=self.member, team=self.team
+            )
+            omt.update(role="admin")
+            omt.delete()
+
+        assert CellOutbox.objects.count() == 0
+
+    def test_bulk_membership_write_produces_no_outbox(self) -> None:
+        with outbox_context(flush=False):
+            omts = OrganizationMemberTeam.objects.bulk_create(
+                [OrganizationMemberTeam(organizationmember=self.member, team=self.team)]
+            )
+            OrganizationMemberTeam.objects.filter(id__in=[o.id for o in omts]).delete()
+
+        assert CellOutbox.objects.count() == 0


### PR DESCRIPTION
### [INFRENG-466](https://linear.app/getsentry/issue/INFRENG-466/drop-outbox-replication-from-organizationmemberteam)

The replica this model fed was deleted in migrations 1142 and 1145, and no receiver ever consumed `ORGANIZATION_MEMBER_TEAM_UPDATE`, so these outboxes replicated nothing. Category 26 is retired as `UNUSED_EIGHT` rather than deleted, since stored rows still resolve through it.
