### PR TITLE
fix(inbox): Cancel issue preview prefetch on unmount

### DIFF
--- a/static/app/views/issueList/pages/useInboxPreviewPrefetch.tsx
+++ b/static/app/views/issueList/pages/useInboxPreviewPrefetch.tsx
@@ -1,3 +1,4 @@
+import {useEffect} from 'react';
 import {useHover} from '@react-aria/interactions';
 import {useDebouncer} from '@tanstack/react-pacer';
 import {useQueryClient} from '@tanstack/react-query';
@@ -29,6 +30,8 @@ export function useInboxPreviewPrefetch(groupId: string) {
     },
     {wait: PREFETCH_DELAY_MS}
   );
+
+  useEffect(() => () => prefetchDebouncer.cancel(), [prefetchDebouncer]);
 
   const {hoverProps} = useHover({
     onHoverStart: () => prefetchDebouncer.maybeExecute(),


### PR DESCRIPTION
This was (I believe) causing some race conditions in CI tests. The previous test would queue a prefecth when hovering and the next one would clear mocks and get a error about a missing mock when the prefetch occurred.