### PR TITLE
feat(issues): Expose activity sources (mcp)

### DIFF
--- a/src/sentry/api/serializers/models/groupactionlogentry.py
+++ b/src/sentry/api/serializers/models/groupactionlogentry.py
@@ -41,6 +41,7 @@ class GroupActionLogEntrySerializerResponse(TypedDict):
     user: dict[str, Any] | None
     sentry_app: _ActivitySentryAppEmbed | None
     type: str
+    source: str | None
     data: dict[str, Any]
     dateCreated: datetime
 
@@ -59,6 +60,7 @@ def serialize_first_seen_entry(group: "Group") -> GroupActionLogEntrySerializerR
         "user": None,
         "sentry_app": None,
         "type": ActivityType.FIRST_SEEN.name.lower(),
+        "source": None,
         "data": {"priority": initial_priority},
         "dateCreated": group.first_seen,
     }
@@ -218,5 +220,6 @@ class GroupActionLogEntrySerializer(Serializer):
             "user": attrs["user"],
             "sentry_app": attrs["sentry_app"],
             "data": data,
+            "source": obj.source,
             "dateCreated": obj.date_added,
         }

--- a/tests/sentry/issues/endpoints/test_group_notes.py
+++ b/tests/sentry/issues/endpoints/test_group_notes.py
@@ -214,7 +214,13 @@ class GroupNoteCreateTest(APITestCase):
         self.login_as(user=self.user)
 
         url = f"/api/0/issues/{group.id}/comments/"
-        response = self.client.post(url, format="json", data={"text": "hello world"})
+        response = self.client.post(
+            url,
+            format="json",
+            data={"text": "hello world"},
+            HTTP_USER_AGENT="sentry-mcp/1.0",
+            HTTP_X_SENTRY_MCP_CLIENT_FAMILY="claude-code",
+        )
         assert response.status_code == 201, response.content
 
         activity = Activity.objects.get(
@@ -225,6 +231,7 @@ class GroupNoteCreateTest(APITestCase):
         # `id` is the Activity id (comment_id), matching the flag-off contract
         assert response.data["id"] == str(activity.id)
         assert response.data["type"] == "note"
+        assert response.data["source"] == "mcp:claude-code"
         assert response.data["user"]["id"] == str(self.user.id)
         assert response.data["data"]["text"] == "hello world"
         assert response.data["data"]["comment_id"] == activity.id


### PR DESCRIPTION
Group action log entries already record how an action reached Sentry, but activity serialization drops it.

Include `source` in action-log-backed activity responses so the frontend can show attribution such as `via Claude Code`.

Frontend: [#121813](https://github.com/getsentry/sentry/pull/121813)

refs ID-1765