### PR TITLE
fix(settings): Debounce team search requests

### DIFF
--- a/static/app/views/settings/organizationTeams/organizationTeams.spec.tsx
+++ b/static/app/views/settings/organizationTeams/organizationTeams.spec.tsx
@@ -25,11 +25,11 @@ jest.mock('sentry/actionCreators/modal', () => ({
 const TEAM_SEARCH = 'frontend';
 
 describe('OrganizationTeams', () => {
+  beforeEach(() => TeamStore.loadInitialData([], false, null));
+
   afterEach(() => {
     jest.useRealTimers();
-    if (TeamStore.getBySlug(TEAM_SEARCH)) {
-      act(() => TeamStore.onRemoveSuccess(TEAM_SEARCH));
-    }
+    act(() => TeamStore.reset());
   });
 
   it('debounces team search requests', async () => {

--- a/static/app/views/settings/organizationTeams/organizationTeams.spec.tsx
+++ b/static/app/views/settings/organizationTeams/organizationTeams.spec.tsx
@@ -5,21 +5,60 @@ import {TeamFixture} from 'sentry-fixture/team';
 import {UserFixture} from 'sentry-fixture/user';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {openCreateTeamModal} from 'sentry/actionCreators/modal';
+import {DEFAULT_DEBOUNCE_DURATION} from 'sentry/constants';
+import {OrganizationStore} from 'sentry/stores/organizationStore';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {TeamStore} from 'sentry/stores/teamStore';
 import {recreateRoute} from 'sentry/utils/recreateRoute';
 import {OrganizationTeams} from 'sentry/views/settings/organizationTeams/organizationTeams';
 
 jest.mocked(recreateRoute).mockReturnValue('');
+jest.unmock('@tanstack/react-pacer');
 
 jest.mock('sentry/actionCreators/modal', () => ({
   openCreateTeamModal: jest.fn(),
 }));
 
 describe('OrganizationTeams', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('debounces team search requests', async () => {
+    jest.useFakeTimers();
+    const user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});
+    const {organization} = initializeOrg();
+    OrganizationStore.onUpdate(organization, {replace: true});
+    TeamStore.loadInitialData([TeamFixture()], false, null);
+    const searchRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/teams/`,
+      match: [MockApiClient.matchQuery({query: 'frontend'})],
+      body: [],
+    });
+
+    render(
+      <OrganizationTeams
+        organization={organization}
+        access={new Set()}
+        features={new Set()}
+        requestList={[]}
+        onRemoveAccessRequest={() => {}}
+      />,
+      {organization}
+    );
+
+    await user.type(screen.getByPlaceholderText('Search teams'), 'frontend');
+
+    expect(searchRequest).not.toHaveBeenCalled();
+
+    await act(() => jest.advanceTimersByTimeAsync(DEFAULT_DEBOUNCE_DURATION));
+
+    expect(searchRequest).toHaveBeenCalledTimes(1);
+  });
+
   describe('Open Membership', () => {
     const {organization} = initializeOrg({
       organization: {

--- a/static/app/views/settings/organizationTeams/organizationTeams.spec.tsx
+++ b/static/app/views/settings/organizationTeams/organizationTeams.spec.tsx
@@ -22,9 +22,14 @@ jest.mock('sentry/actionCreators/modal', () => ({
   openCreateTeamModal: jest.fn(),
 }));
 
+const TEAM_SEARCH = 'frontend';
+
 describe('OrganizationTeams', () => {
   afterEach(() => {
     jest.useRealTimers();
+    if (TeamStore.getBySlug(TEAM_SEARCH)) {
+      act(() => TeamStore.onRemoveSuccess(TEAM_SEARCH));
+    }
   });
 
   it('debounces team search requests', async () => {
@@ -33,10 +38,11 @@ describe('OrganizationTeams', () => {
     const {organization} = initializeOrg();
     OrganizationStore.onUpdate(organization, {replace: true});
     TeamStore.loadInitialData([TeamFixture()], false, null);
+    const matchingTeam = TeamFixture({id: '2', slug: TEAM_SEARCH});
     const searchRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/teams/`,
-      match: [MockApiClient.matchQuery({query: 'frontend'})],
-      body: [],
+      match: [MockApiClient.matchQuery({query: TEAM_SEARCH})],
+      body: [matchingTeam],
     });
 
     render(
@@ -50,13 +56,14 @@ describe('OrganizationTeams', () => {
       {organization}
     );
 
-    await user.type(screen.getByPlaceholderText('Search teams'), 'frontend');
+    await user.type(screen.getByPlaceholderText('Search teams'), TEAM_SEARCH);
 
     expect(searchRequest).not.toHaveBeenCalled();
 
     await act(() => jest.advanceTimersByTimeAsync(DEFAULT_DEBOUNCE_DURATION));
 
     expect(searchRequest).toHaveBeenCalledTimes(1);
+    expect(await screen.findByText(`#${TEAM_SEARCH}`)).toBeInTheDocument();
   });
 
   describe('Open Membership', () => {

--- a/static/app/views/settings/organizationTeams/organizationTeams.tsx
+++ b/static/app/views/settings/organizationTeams/organizationTeams.tsx
@@ -1,6 +1,6 @@
 import {useState} from 'react';
 import styled from '@emotion/styled';
-import debounce from 'lodash/debounce';
+import {useDebouncedCallback} from '@tanstack/react-pacer';
 import partition from 'lodash/partition';
 
 import {Button} from '@sentry/scraps/button';
@@ -39,6 +39,9 @@ export function OrganizationTeams({
   const [teamQuery, setTeamQuery] = useState('');
   const {initiallyLoaded} = useTeams({provideUserTeams: true});
   const {teams, onSearch, loadMore, hasMore, fetching} = useTeams();
+  const debouncedSearch = useDebouncedCallback((query: string) => void onSearch(query), {
+    wait: DEFAULT_DEBOUNCE_DURATION,
+  });
 
   if (!organization) {
     return null;
@@ -66,7 +69,6 @@ export function OrganizationTeams({
 
   const title = t('Teams');
 
-  const debouncedSearch = debounce(onSearch, DEFAULT_DEBOUNCE_DURATION);
   function handleSearch(query: string) {
     setTeamQuery(query);
     debouncedSearch(query);


### PR DESCRIPTION
team search recreated its lodash debouncer after every local query update, so rapid typing still scheduled one API search per character. Keep one Pacer debouncer across renders while preserving immediate local filtering.