### PR TITLE
ref(cmdk): Use Pacer for query settling

### DIFF
--- a/static/app/components/commandPalette/ui/commandPalette.modal.spec.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.modal.spec.tsx
@@ -1,4 +1,4 @@
-jest.unmock('lodash/debounce');
+jest.unmock('@tanstack/react-pacer');
 
 jest.mock('@tanstack/react-virtual', () => ({
   useVirtualizer: ({count}: {count: number}) => {

--- a/static/app/components/commandPalette/ui/commandPalette.spec.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.spec.tsx
@@ -4,7 +4,7 @@ import {QueryClientProvider} from '@tanstack/react-query';
 import {makeTestQueryClient} from 'sentry-test/queryClient';
 import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
-jest.unmock('lodash/debounce');
+jest.unmock('@tanstack/react-pacer');
 
 jest.mock('@tanstack/react-virtual', () => ({
   useVirtualizer: ({count}: {count: number}) => {
@@ -359,6 +359,29 @@ describe('CommandPalette', () => {
       await userEvent.type(input, 'xyzzy');
 
       expect(screen.queryAllByRole('option')).toHaveLength(0);
+    });
+
+    it('waits for search to settle before showing the Seer fallback', async () => {
+      render(
+        <CommandPaletteProvider>
+          <CMDKAction to="/known/" display={{label: 'Known Action'}} />
+          <CommandPalette {...makeRenderProps(jest.fn())} openSeerExplorer={jest.fn()} />
+        </CommandPaletteProvider>
+      );
+
+      await userEvent.type(
+        screen.getByRole('textbox', {name: 'Search commands'}),
+        'xyzzy'
+      );
+
+      expect(screen.getByTestId('command-palette-loading')).toBeInTheDocument();
+      expect(
+        screen.queryByRole('option', {name: 'Ask Seer: xyzzy'})
+      ).not.toBeInTheDocument();
+
+      expect(
+        await screen.findByRole('option', {name: 'Ask Seer: xyzzy'})
+      ).toBeInTheDocument();
     });
 
     it('clearing the query restores all top-level items', async () => {

--- a/static/app/components/commandPalette/ui/commandPalette.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.tsx
@@ -6,6 +6,7 @@ import {ListKeyboardDelegate, useSelectableCollection} from '@react-aria/selecti
 import {mergeProps} from '@react-aria/utils';
 import {Item} from '@react-stately/collections';
 import {useTreeState} from '@react-stately/tree';
+import {useDebouncedValue} from '@tanstack/react-pacer';
 import {useIsFetching} from '@tanstack/react-query';
 import {animate, AnimatePresence, motion} from 'framer-motion';
 
@@ -36,6 +37,7 @@ import {
 import {useCommandPaletteAnalytics} from 'sentry/components/commandPalette/useCommandPaletteAnalytics';
 import {FeedbackButton} from 'sentry/components/feedbackButton/feedbackButton';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {DEFAULT_DEBOUNCE_DURATION} from 'sentry/constants';
 import {
   IconArrow,
   IconClose,
@@ -50,7 +52,6 @@ import {t} from 'sentry/locale';
 import {fzf} from 'sentry/utils/search/fzf';
 import type {Theme} from 'sentry/utils/theme';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
-import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import {useNavigate} from 'sentry/utils/useNavigate';
 const MotionButton = motion.create(Button);
@@ -140,7 +141,9 @@ export function CommandPalette({
     preload(errorIllustration, {as: 'image'});
   }
 
-  const debouncedQuery = useDebouncedValue(state.query, 300);
+  const [debouncedQuery] = useDebouncedValue(state.query, {
+    wait: DEFAULT_DEBOUNCE_DURATION,
+  });
   const isFetchingQueries = useIsFetching({predicate: q => q.meta?.cmdk === true});
   const isLoading =
     state.list === 'active' &&


### PR DESCRIPTION
Command Palette keeps local filtering and async resources immediate, then waits 300ms before deciding a query has no results. Migrate that settling window to Pacer without delaying search requests.

Adds coverage that the loading state appears first and the Seer fallback only shows after the query settles.