### PR TITLE
fix(refactor-tasks): Stop routing eslint-json-runner through npx

### DIFF
--- a/.sentry-refactor-tasks/conventions/eslint-json-runner.ts
+++ b/.sentry-refactor-tasks/conventions/eslint-json-runner.ts
@@ -52,11 +52,16 @@ const startedAt = Date.now();
 // Use only the supplied config (--no-config-lookup) so detection is independent
 // of the target repo's own eslint setup. Inline eslint-disable directives are
 // still honored (no --no-inline-config), so findings match the repo's own lint.
+// `pnpm exec` rather than `npx`: this script itself runs nested inside a
+// `pnpm exec`/`pnpm dlx` call, which forwards its own config as env vars that
+// `npx` (npm's CLI) doesn't recognize and crashes on. `pnpm exec` handles its
+// own env fine.
 let rawOutput = '';
 try {
   rawOutput = execFileSync(
-    'npx',
+    'pnpm',
     [
+      'exec',
       'eslint',
       '--config',
       configPath,
@@ -76,8 +81,9 @@ try {
 } catch (err: any) {
   // eslint exits 0 when clean and 1 when it reports problems; both are real
   // runs whose JSON is on stdout. Anything else — 2 for a fatal config/CLI
-  // error, ENOENT when npx is missing, ENOBUFS when output overflows maxBuffer,
-  // a signal from an OOM kill — means we never got a trustworthy result.
+  // error, ENOENT when pnpm is missing, ENOBUFS when output overflows
+  // maxBuffer, a signal from an OOM kill — means we never got a trustworthy
+  // result.
   if (err.status !== 1) {
     const stderr = String(err.stderr ?? '').trim();
     die(
@@ -85,7 +91,7 @@ try {
         `(exit=${err.status ?? 'n/a'} signal=${err.signal ?? 'n/a'} code=${
           err.code ?? 'n/a'
         }).\n` +
-        `command: npx eslint --config ${configPath} ... (${files.length} files)\n` +
+        `command: pnpm exec eslint --config ${configPath} ... (${files.length} files)\n` +
         `stderr:\n${stderr || '(empty)'}`
     );
   }


### PR DESCRIPTION
`eslint-json-runner.ts` (the shared detect-command runner behind
`no-deprecated-callsite` and `no-derived-state`) shelled out to `npx eslint`.
In CI, the whole call chain is `pnpm dlx @sentry/refactor-tasks
scan-and-report` → `pnpm exec node eslint-json-runner.ts` → `npx eslint`.
`pnpm exec`/`pnpm dlx` set pnpm's own config as `npm_config_*` env vars for
whatever they spawn, and those inherit down to the nested `npx` call. `npx`
(npm's own CLI) doesn't recognize several of pnpm's config keys and crashed
instantly with exit 249 and no useful stderr — eslint never started.

This is what let `no-deprecated-callsite` report a silent, clean-looking zero
violations on every CI run for weeks (getsentry/sentry-refactor-tasks#20 made
that failure loud instead of silent; this fixes the underlying crash). A
local run outside `pnpm dlx` never hit the polluted environment, so it always
looked fine: 1917 real violations across 1025 files.

Swaps `npx eslint` for `pnpm exec eslint`. `pnpm exec` handles its own
inherited env fine, and this repo is pinned to pnpm, so there's no need for
anything more elaborate than the one-word swap.

Verified locally by reproducing the same `npm_config_*` pollution `pnpm dlx`
produces: the old `npx`-based call crashes under it, the new `pnpm exec` call
runs clean and correctly reports real `@typescript-eslint/no-deprecated`
violations.
