### PR TITLE
ref(emptyState): earlier breakpoints

### DIFF
--- a/static/app/components/core/emptyState/emptyState.tsx
+++ b/static/app/components/core/emptyState/emptyState.tsx
@@ -22,37 +22,39 @@ export function EmptyState({
   const textAlign: TextProps<'p'>['align'] = {zero: 'center', [switchOn]: 'left'};
 
   return (
-    <Flex
-      direction={{zero: 'column', [switchOn]: 'row'}}
-      flexGrow={1}
-      align="center"
-      gap={{zero: 'xl', [switchOn]: '2xl'}}
-      justify={{zero: 'start', [switchOn]: 'center'}}
-      data-test-id="empty-state"
-      {...props}
-    >
-      {illustration && (
-        <Flex justify="center" align="center" overflow="hidden" flexShrink={0}>
-          {illustration}
-        </Flex>
-      )}
-      <Stack gap="xl">
-        <Stack gap="md" width="100%" maxWidth="48ch">
-          <Heading as="h3" size="lg" align={textAlign}>
-            {title}
-          </Heading>
-          {description && (
-            <Text as="p" size="md" variant="muted" align={textAlign} textWrap="balance">
-              {description}
-            </Text>
-          )}
-        </Stack>
-        {action && (
-          <Flex gap="md" justify={{zero: 'center', [switchOn]: 'start'}} wrap="wrap">
-            {action}
+    <Flex containerType="inline-size" width="100%" flexGrow={1} minWidth={0}>
+      <Flex
+        direction={{zero: 'column', [switchOn]: 'row'}}
+        flexGrow={1}
+        align="center"
+        gap={{zero: 'xl', [switchOn]: '2xl'}}
+        justify={{zero: 'start', [switchOn]: 'center'}}
+        data-test-id="empty-state"
+        {...props}
+      >
+        {illustration && (
+          <Flex justify="center" align="center" overflow="hidden" flexShrink={0}>
+            {illustration}
           </Flex>
         )}
-      </Stack>
+        <Stack gap="xl">
+          <Stack gap="md" width="100%" maxWidth="48ch">
+            <Heading as="h3" size="lg" align={textAlign}>
+              {title}
+            </Heading>
+            {description && (
+              <Text as="p" size="md" variant="muted" align={textAlign} textWrap="balance">
+                {description}
+              </Text>
+            )}
+          </Stack>
+          {action && (
+            <Flex gap="md" justify={{zero: 'center', [switchOn]: 'start'}} wrap="wrap">
+              {action}
+            </Flex>
+          )}
+        </Stack>
+      </Flex>
     </Flex>
   );
 }

--- a/static/app/components/core/emptyState/emptyState.tsx
+++ b/static/app/components/core/emptyState/emptyState.tsx
@@ -18,43 +18,41 @@ export function EmptyState({
   action,
   ...props
 }: EmptyStateProps) {
-  const switchOn = 'xs';
+  const switchOn = 'md';
   const textAlign: TextProps<'p'>['align'] = {zero: 'center', [switchOn]: 'left'};
 
   return (
-    <Flex containerType="inline-size" width="100%" flexGrow={1} minWidth={0}>
-      <Flex
-        direction={{zero: 'column', [switchOn]: 'row'}}
-        flexGrow={1}
-        align="center"
-        gap={{zero: 'xl', [switchOn]: '2xl'}}
-        justify={{zero: 'start', [switchOn]: 'center'}}
-        data-test-id="empty-state"
-        {...props}
-      >
-        {illustration && (
-          <Flex justify="center" align="center" overflow="hidden" flexShrink={0}>
-            {illustration}
-          </Flex>
-        )}
-        <Stack gap="xl">
-          <Stack gap="md" width="100%" maxWidth="48ch">
-            <Heading as="h3" size="lg" align={textAlign}>
-              {title}
-            </Heading>
-            {description && (
-              <Text as="p" size="md" variant="muted" align={textAlign} textWrap="balance">
-                {description}
-              </Text>
-            )}
-          </Stack>
-          {action && (
-            <Flex gap="md" justify={{zero: 'center', [switchOn]: 'start'}} wrap="wrap">
-              {action}
-            </Flex>
+    <Flex
+      direction={{zero: 'column', [switchOn]: 'row'}}
+      flexGrow={1}
+      align="center"
+      gap={{zero: 'xl', [switchOn]: '2xl'}}
+      justify={{zero: 'start', [switchOn]: 'center'}}
+      data-test-id="empty-state"
+      {...props}
+    >
+      {illustration && (
+        <Flex justify="center" align="center" overflow="hidden" flexShrink={0}>
+          {illustration}
+        </Flex>
+      )}
+      <Stack gap="xl">
+        <Stack gap="md" width="100%" maxWidth="48ch">
+          <Heading as="h3" size="lg" align={textAlign}>
+            {title}
+          </Heading>
+          {description && (
+            <Text as="p" size="md" variant="muted" align={textAlign} textWrap="balance">
+              {description}
+            </Text>
           )}
         </Stack>
-      </Flex>
+        {action && (
+          <Flex gap="md" justify={{zero: 'center', [switchOn]: 'start'}} wrap="wrap">
+            {action}
+          </Flex>
+        )}
+      </Stack>
     </Flex>
   );
 }


### PR DESCRIPTION
as discussed with @natemoo-re, we want an earlier breakpoint (`md`) to avoid having graphics next to long text where we don’t have enough space for the text