### PR TITLE
fix(conversations): ensure that conversation timeline nesting/ordering agrees with trace view

### DIFF
--- a/static/app/views/explore/conversations/hooks/useConversation.spec.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversation.spec.tsx
@@ -424,7 +424,7 @@ describe('useConversation', () => {
     expect(value?.name).toBe('My AI Agent');
   });
 
-  it('sorts nodes by start timestamp for AI spans list', async () => {
+  it('sorts sibling nodes by start timestamp', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/agents/conversations/conv-sort/`,
       body: envelope([
@@ -470,6 +470,91 @@ describe('useConversation', () => {
     // Sorted by start timestamp: span-a (1000) before span-b (1001)
     expect(result.current.nodes[0]?.id).toBe('span-a');
     expect(result.current.nodes[1]?.id).toBe('span-b');
+  });
+
+  it('keeps each agent next to the spans it produced', async () => {
+    const span = (
+      spanId: string,
+      parentSpan: string,
+      operationType: string,
+      startTs: number
+    ) => ({
+      ...BASE_SPAN,
+      'gen_ai.conversation.id': 'conv-nesting',
+      span_id: spanId,
+      parent_span: parentSpan,
+      'gen_ai.operation.type': operationType,
+      'precise.start_ts': startTs,
+      'precise.finish_ts': startTs + 1,
+      trace: 'trace-nesting',
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/agents/conversations/conv-nesting/`,
+      body: envelope([
+        span('lead', 'outside-the-conversation', 'agent', 1000),
+        span('read-diff', 'lead', 'tool', 1001),
+        // The two subagents run in parallel, so start time alone interleaves them.
+        span('correctness-reviewer', 'lead', 'agent', 1002),
+        span('style-reviewer', 'lead', 'agent', 1002.001),
+        span('correctness-chat', 'correctness-reviewer', 'ai_client', 1003),
+        span('style-chat', 'style-reviewer', 'ai_client', 1003.5),
+        span('search-issues', 'lead', 'tool', 1004),
+      ]),
+    });
+
+    const {result} = renderHookWithProviders(
+      () => useConversation({conversationId: 'conv-nesting'}),
+      {organization}
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.nodes.map(node => node.id)).toEqual([
+      'lead',
+      'read-diff',
+      'correctness-reviewer',
+      'correctness-chat',
+      'style-reviewer',
+      'style-chat',
+      'search-issues',
+    ]);
+  });
+
+  it('keeps spans whose parent links form a cycle', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/agents/conversations/conv-cycle/`,
+      body: envelope([
+        {
+          ...BASE_SPAN,
+          'gen_ai.conversation.id': 'conv-cycle',
+          span_id: 'span-a',
+          parent_span: 'span-b',
+        },
+        {
+          ...BASE_SPAN,
+          'gen_ai.conversation.id': 'conv-cycle',
+          span_id: 'span-b',
+          parent_span: 'span-a',
+        },
+      ]),
+    });
+
+    const {result} = renderHookWithProviders(
+      () => useConversation({conversationId: 'conv-cycle'}),
+      {organization}
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.nodes.map(node => node.id).sort()).toEqual([
+      'span-a',
+      'span-b',
+    ]);
   });
 
   it('uses project from page filters, not hardcoded -1', async () => {

--- a/static/app/views/explore/conversations/hooks/useConversation.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversation.tsx
@@ -218,6 +218,76 @@ function createNodeFromApiSpan(
   return node as unknown as AITraceSpanNode;
 }
 
+/**
+ * Orders the conversation's spans so that an agent is always followed by its own
+ * descendants, the way the trace drawer reads them off the trace tree. Sorting by
+ * start time alone interleaves agents that run in parallel, which separates each
+ * agent from the spans it produced.
+ *
+ * Spans whose parent is not part of the conversation become roots. Roots and
+ * siblings are ordered by start time, so reading order stays chronological at
+ * every level.
+ */
+function orderDepthFirst(
+  nodes: AITraceSpanNode[],
+  nodeMap: Map<string, AITraceSpanNode>
+): AITraceSpanNode[] {
+  const byStartTimestamp = (a: AITraceSpanNode, b: AITraceSpanNode) =>
+    (a.startTimestamp ?? 0) - (b.startTimestamp ?? 0);
+
+  const roots: AITraceSpanNode[] = [];
+  const childrenByParentId = new Map<string, AITraceSpanNode[]>();
+
+  for (const node of nodes) {
+    const parentId = node.value?.parent_span_id;
+    const parent = parentId ? nodeMap.get(parentId) : undefined;
+    if (!parentId || !parent || parent === node) {
+      roots.push(node);
+      continue;
+    }
+    const siblings = childrenByParentId.get(parentId);
+    if (siblings) {
+      siblings.push(node);
+    } else {
+      childrenByParentId.set(parentId, [node]);
+    }
+  }
+
+  for (const siblings of childrenByParentId.values()) {
+    siblings.sort(byStartTimestamp);
+  }
+
+  const ordered: AITraceSpanNode[] = [];
+  const visited = new Set<string>();
+  const stack = roots.toSorted(byStartTimestamp).reverse();
+
+  while (stack.length > 0) {
+    const node = stack.pop()!;
+    if (visited.has(node.id)) {
+      continue;
+    }
+    visited.add(node.id);
+    ordered.push(node);
+
+    const children = childrenByParentId.get(node.id);
+    if (children) {
+      for (let i = children.length - 1; i >= 0; i--) {
+        stack.push(children[i]!);
+      }
+    }
+  }
+
+  // A cycle in the parent links leaves spans unreachable from any root. Keep them
+  // rather than dropping rows from the timeline.
+  for (const node of nodes) {
+    if (!visited.has(node.id)) {
+      ordered.push(node);
+    }
+  }
+
+  return ordered;
+}
+
 const MAX_PAGES = 10;
 
 export function useConversation(
@@ -310,9 +380,7 @@ export function useConversation(
       return node;
     });
 
-    transformedNodes.sort((a, b) => (a.startTimestamp ?? 0) - (b.startTimestamp ?? 0));
-
-    return {nodes: transformedNodes, nodeTraceMap: traceMap};
+    return {nodes: orderDepthFirst(transformedNodes, nodeMap), nodeTraceMap: traceMap};
   }, [allSpans]);
 
   if (!conversation.conversationId) {


### PR DESCRIPTION
- Introduce a new ordering function `orderDepthFirst` to prevent parallel sub-agents from interleaving their conversation timelines

Before: 
<img width="302" height="204" alt="image" src="https://github.com/user-attachments/assets/13ff2509-bb3d-4553-a3af-e23c454aac31" />
After: 
<img width="278" height="242" alt="image" src="https://github.com/user-attachments/assets/d15dca64-e42b-4e91-b8bf-7dee1ea37b0c" />

Trace View of connected trace:
<img width="291" height="212" alt="image" src="https://github.com/user-attachments/assets/5c12c99f-1416-42c2-a21f-d0bf5f306daf" />


Contributes to TET-2852
