### PR TITLE
ref(relay): Separate project config invalidations from computations

### DIFF
--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -10,7 +10,7 @@ from sentry.models.organization import Organization
 from sentry.relay import projectconfig_cache, projectconfig_debounce_cache
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
-from sentry.taskworker.namespaces import relay_tasks
+from sentry.taskworker.namespaces import relay_invalidation_tasks, relay_tasks
 from sentry.utils import metrics
 from sentry.utils.exceptions import quiet_redis_noise
 from sentry.utils.sdk import set_current_event_project
@@ -212,7 +212,8 @@ def compute_projectkey_config(key):
 
 @instrumented_task(
     name="sentry.tasks.relay.invalidate_project_config",
-    namespace=relay_tasks,
+    namespace=relay_invalidation_tasks,
+    alias_namespace=relay_tasks,
     processing_deadline_duration=25 * 60 + 5,
     silo_mode=SiloMode.CELL,
 )

--- a/src/sentry/taskworker/namespaces.py
+++ b/src/sentry/taskworker/namespaces.py
@@ -225,6 +225,14 @@ relay_tasks = app.taskregistry.create_namespace(
     "relay",
     app_feature="shared",
 )
+# Namespace used for lower priority project config invalidations.
+#
+# Project configs requested by Relay must be computed as soon as possible to serve traffic,
+# invalidations can be slightly delayed.
+relay_invalidation_tasks = app.taskregistry.create_namespace(
+    "relay.invalidation",
+    app_feature="shared",
+)
 
 relocation_tasks = app.taskregistry.create_namespace(
     "relocation",


### PR DESCRIPTION
Separates the invalidations task from the computation task to be able to put the invalidations in a different (lower priority) pool then the computations.

Especially at around midnight UTC there is a large burst of invalidations triggered by crons jobs impacting the availability of project configs.

Any project config requested by Relay must be available as soon as possible to unblock ingestion, invalidations are not as important and can be slightly delayed.

By separating the namespace, the invalidations task will be moved from the Relay/Internal pool to default pool. The average produce rate of invalidations is ~15/s, with spikes every 10 minutes (due to dynamic sampling rule updates).

Follows: https://develop.sentry.dev/backend/application-domains/tasks/#moving-to-a-different-namespace