### PR TITLE
feat(seer): Add an agent token compatibility user

### DIFF
--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -614,9 +614,10 @@ class UserAuthTokenAuthentication(StandardAuthentication):
 class AgentTokenAuthentication(StandardAuthentication):
     """Authenticates the Seer agent's typed capability JWT.
 
-    Authenticates as a non-user actor -- the request stays anonymous -- so user-only web
-    views fail closed; API access is derived from the delegating member in
-    ``access.from_agent_auth``."""
+    The agent credential remains the authorization authority. A non-authoritative,
+    ephemeral copy of the delegating user is returned only for compatibility with
+    callsites that still require ``request.user``; API access is derived from the
+    delegating member and capped by the token in ``access.from_agent_auth``."""
 
     token_name = b"bearer"
 
@@ -683,7 +684,19 @@ class AgentTokenAuthentication(StandardAuthentication):
         ):
             fail("feature_flag_off", user_id=user_id, org_id=auth_token.organization_id)
 
-        return self.transform_auth(None, auth_token)
+        # Legacy callsites use request.user for identity, serialization, feature flags,
+        # preferences, and ownership. Give them the delegating user without creating a
+        # proxy-user row, but strip platform elevation: an agent token must never inherit
+        # staff/superuser authority or global user permissions outside its own scopes.
+        compatibility_user = user.copy(
+            update={
+                "is_staff": False,
+                "is_superuser": False,
+                "permissions": frozenset(),
+                "roles": frozenset(),
+            }
+        )
+        return self.transform_auth(compatibility_user, auth_token)
 
 
 @AuthenticationSiloLimit(SiloMode.CONTROL, SiloMode.CELL)

--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -676,6 +676,8 @@ class AgentTokenAuthentication(StandardAuthentication):
         )
         if org_context is None:
             fail("org_context_missing", user_id=user_id, org_id=auth_token.organization_id)
+        if org_context.member is None:
+            fail("org_membership_missing", user_id=user_id, org_id=auth_token.organization_id)
         if not features.has(
             agent_token.FEATURE_FLAG,
             org_context.organization,

--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -684,10 +684,6 @@ class AgentTokenAuthentication(StandardAuthentication):
         ):
             fail("feature_flag_off", user_id=user_id, org_id=auth_token.organization_id)
 
-        # Legacy callsites use request.user for identity, serialization, feature flags,
-        # preferences, and ownership. Give them the delegating user without creating a
-        # proxy-user row, but strip platform elevation: an agent token must never inherit
-        # staff/superuser authority or global user permissions outside its own scopes.
         compatibility_user = user.copy(
             update={
                 "is_staff": False,

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -839,10 +839,12 @@ class OrganizationReleasesBaseEndpoint(OrganizationEndpoint):
         actor_id = None
         has_perms = None
         key = None
-        if request.user.is_authenticated:
-            actor_id = "user:%s" % request.user.id
-        elif request.auth is not None and not is_agent_auth(request.auth):
-            actor_id = "apikey:%s" % request.auth.entity_id
+        # Agent authority is re-derived from live membership on every request.
+        if not is_agent_auth(request.auth):
+            if request.user.is_authenticated:
+                actor_id = "user:%s" % request.user.id
+            elif request.auth is not None:
+                actor_id = "apikey:%s" % request.auth.entity_id
         if actor_id is not None:
             if project_ids:
                 requested_projects = ParsedProjectIdOrSlugParams(ids=project_ids, slugs=set())

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -839,7 +839,6 @@ class OrganizationReleasesBaseEndpoint(OrganizationEndpoint):
         actor_id = None
         has_perms = None
         key = None
-        # Agent authority is re-derived from live membership on every request.
         if not is_agent_auth(request.auth):
             if request.user.is_authenticated:
                 actor_id = "user:%s" % request.user.id

--- a/src/sentry/api/decorators.py
+++ b/src/sentry/api/decorators.py
@@ -10,9 +10,13 @@ from sentry.api.exceptions import PrimaryEmailVerificationRequired, SudoRequired
 from sentry.models.apikey import is_api_key_auth
 from sentry.models.apitoken import is_api_token_auth
 from sentry.models.orgauthtoken import is_org_auth_token_auth
+from sentry.seer.agent_token import is_agent_auth
 
 
 def is_considered_sudo(request: Request) -> bool:
+    if is_agent_auth(request.auth):
+        return False
+
     # Right now, only password reauthentication (django-sudo) is supported,
     # so if a user doesn't have a password (for example, only has github auth)
     # then we shouldn't prompt them for the password they don't have.

--- a/src/sentry/api/endpoints/api_token_details.py
+++ b/src/sentry/api/endpoints/api_token_details.py
@@ -12,7 +12,11 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.api.endpoints.api_tokens import get_appropriate_user_id
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.api.permissions import DisallowImpersonatedTokenCreation, SentryIsAuthenticated
+from sentry.api.permissions import (
+    DisallowAgentToken,
+    DisallowImpersonatedTokenCreation,
+    SentryIsAuthenticated,
+)
 from sentry.api.serializers import serialize
 from sentry.api.utils import to_valid_int_id
 from sentry.models.apitoken import ApiToken
@@ -32,7 +36,11 @@ class ApiTokenDetailsEndpoint(Endpoint):
         "DELETE": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.SECURITY
-    permission_classes = (SentryIsAuthenticated, DisallowImpersonatedTokenCreation)
+    permission_classes = (
+        SentryIsAuthenticated,
+        DisallowAgentToken,
+        DisallowImpersonatedTokenCreation,
+    )
 
     def convert_args(self, request: Request, token_id: str, *args, **kwargs):
         validated_token_id = to_valid_int_id("token_id", token_id, raise_404=True)

--- a/src/sentry/api/permissions.py
+++ b/src/sentry/api/permissions.py
@@ -185,21 +185,11 @@ class SentryPermission(ScopedPermission):
         from sentry.api.base import logger
 
         user_id = request.user.id if request.user else None
-
-        # An agent token is a non-user actor acting on behalf of a member. Resolve the org
-        # context for that member (not the anonymous request user) so access derives from
-        # their real membership -- scopes and project/team access.
         agent_auth = request.auth if agent_token.is_agent_auth(request.auth) else None
-        if agent_auth is not None:
-            user_id = agent_auth.user_id
 
         org_context: RpcUserOrganizationContext | None
         if isinstance(organization, RpcUserOrganizationContext):
             org_context = organization
-            if agent_auth is not None and org_context.user_id != user_id:
-                org_context = organization_service.get_organization_by_id(
-                    id=org_context.organization.id, user_id=user_id
-                )
         else:
             org_context = organization_service.get_organization_by_id(
                 id=extract_id_from(organization), user_id=user_id

--- a/src/sentry/api/permissions.py
+++ b/src/sentry/api/permissions.py
@@ -212,7 +212,13 @@ class SentryPermission(ScopedPermission):
         extra = {"organization_id": organization.id, "user_id": user_id}
 
         if request.auth:
-            if request.user and request.user.is_authenticated:
+            # Agent authorization is selected by credential type, never by the
+            # compatibility request.user returned by AgentTokenAuthentication.
+            if agent_auth is not None:
+                request.access = access.from_rpc_auth(
+                    auth=agent_auth, rpc_user_org_context=org_context
+                )
+            elif request.user and request.user.is_authenticated:
                 request.access = access.from_request_org_and_scopes(
                     request=request,
                     rpc_user_org_context=org_context,

--- a/src/sentry/api/permissions.py
+++ b/src/sentry/api/permissions.py
@@ -212,8 +212,6 @@ class SentryPermission(ScopedPermission):
         extra = {"organization_id": organization.id, "user_id": user_id}
 
         if request.auth:
-            # Agent authorization is selected by credential type, never by the
-            # compatibility request.user returned by AgentTokenAuthentication.
             if agent_auth is not None:
                 request.access = access.from_rpc_auth(
                     auth=agent_auth, rpc_user_org_context=org_context

--- a/src/sentry/api/permissions.py
+++ b/src/sentry/api/permissions.py
@@ -420,6 +420,11 @@ class DisallowImpersonatedTokenCreation(BasePermission):
         return True
 
 
+class DisallowAgentToken(BasePermission):
+    def has_permission(self, request: Request, view: object) -> bool:
+        return not agent_token.is_agent_auth(request.auth)
+
+
 class SentryIsAuthenticated(IsAuthenticated):
     """
     Used to deny access for demo users in both view and object permission checks.

--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -928,7 +928,7 @@ def from_request_org_and_scopes(
     Note that `scopes` is usually None because request.auth is not set at `get_authorization_header`
     when the request is made from the frontend using cookies
     """
-    if request.auth is not None and is_agent_auth(request.auth):
+    if is_agent_auth(request.auth):
         if rpc_user_org_context is None:
             return DEFAULT
         return from_agent_auth(request.auth, rpc_user_org_context)
@@ -1032,7 +1032,7 @@ def from_user_and_rpc_user_org_context(
 def from_request(
     request: Request, organization: Organization | None = None, scopes: Iterable[str] | None = None
 ) -> Access:
-    if request.auth is not None and is_agent_auth(request.auth):
+    if is_agent_auth(request.auth):
         if organization is None:
             return DEFAULT
         return from_auth(request.auth, organization)

--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -928,9 +928,6 @@ def from_request_org_and_scopes(
     Note that `scopes` is usually None because request.auth is not set at `get_authorization_header`
     when the request is made from the frontend using cookies
     """
-    # request.user is only a compatibility identity for an agent request. Dispatch on
-    # the credential before user/staff/superuser handling so every caller of this shared
-    # factory, including server-rendered views, preserves the member and token scope caps.
     if request.auth is not None and is_agent_auth(request.auth):
         if rpc_user_org_context is None:
             return DEFAULT
@@ -1035,8 +1032,6 @@ def from_user_and_rpc_user_org_context(
 def from_request(
     request: Request, organization: Organization | None = None, scopes: Iterable[str] | None = None
 ) -> Access:
-    # As in from_request_org_and_scopes, the compatibility user on an agent request
-    # carries identity only. Credential type must select the scope-capped access path.
     if request.auth is not None and is_agent_auth(request.auth):
         if organization is None:
             return DEFAULT

--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -928,6 +928,14 @@ def from_request_org_and_scopes(
     Note that `scopes` is usually None because request.auth is not set at `get_authorization_header`
     when the request is made from the frontend using cookies
     """
+    # request.user is only a compatibility identity for an agent request. Dispatch on
+    # the credential before user/staff/superuser handling so every caller of this shared
+    # factory, including server-rendered views, preserves the member and token scope caps.
+    if request.auth is not None and is_agent_auth(request.auth):
+        if rpc_user_org_context is None:
+            return DEFAULT
+        return from_agent_auth(request.auth, rpc_user_org_context)
+
     is_staff = is_active_staff(request)
 
     if not rpc_user_org_context:
@@ -1027,6 +1035,13 @@ def from_user_and_rpc_user_org_context(
 def from_request(
     request: Request, organization: Organization | None = None, scopes: Iterable[str] | None = None
 ) -> Access:
+    # As in from_request_org_and_scopes, the compatibility user on an agent request
+    # carries identity only. Credential type must select the scope-capped access path.
+    if request.auth is not None and is_agent_auth(request.auth):
+        if organization is None:
+            return DEFAULT
+        return from_auth(request.auth, organization)
+
     is_staff = is_active_staff(request)
 
     if not organization:

--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -1264,6 +1264,8 @@ def from_agent_auth(
     # delegating user is also a member of the requested org.
     if auth.organization_id != rpc_user_org_context.organization.id:
         return DEFAULT
+    if auth.user_id != rpc_user_org_context.user_id:
+        return DEFAULT
     # No membership (never a member, or revoked since mint) -> no access. Required
     # explicitly because RpcBackedAccess would otherwise hand back the full token
     # scopes uncapped when member is None.

--- a/src/sentry/auth_v2/endpoints/auth_user_merge_verification_code.py
+++ b/src/sentry/auth_v2/endpoints/auth_user_merge_verification_code.py
@@ -5,7 +5,7 @@ from rest_framework.response import Response
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, control_silo_endpoint
-from sentry.api.permissions import SentryIsAuthenticated
+from sentry.api.permissions import DisallowAgentToken, SentryIsAuthenticated
 from sentry.users.models.user_merge_verification_code import UserMergeVerificationCode
 
 
@@ -15,7 +15,7 @@ class AuthUserMergeVerificationCodeEndpoint(Endpoint):
         "POST": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.FOUNDATIONS
-    permission_classes = (SentryIsAuthenticated,)
+    permission_classes = (SentryIsAuthenticated, DisallowAgentToken)
     """
     Generate and update verification codes for the user account merge flow.
     """

--- a/src/sentry/core/endpoints/organization_index.py
+++ b/src/sentry/core/endpoints/organization_index.py
@@ -452,6 +452,9 @@ class OrganizationIndexEndpoint(Endpoint):
                                 terms of service and privacy policy.
         :auth: required, user-context-needed
         """
+        if is_agent_auth(request.auth):
+            raise PermissionDenied
+
         if SiloMode.get_current_mode() == SiloMode.CELL:
             metrics.incr("api.organization_index.post.rejected")
             base_url = options.get("system.url-prefix")

--- a/src/sentry/core/endpoints/organization_index.py
+++ b/src/sentry/core/endpoints/organization_index.py
@@ -37,6 +37,7 @@ from sentry.models.organizationmember import OrganizationMember
 from sentry.models.organizationmembermapping import OrganizationMemberMapping
 from sentry.organizations.services.organization import organization_service
 from sentry.search.utils import tokenize_query
+from sentry.seer.agent_token import is_agent_auth
 from sentry.services.organization import (
     OrganizationOptions,
     OrganizationProvisioningOptions,
@@ -159,22 +160,23 @@ class OrganizationIndexEndpoint(Endpoint):
         metrics.incr("api.organization_index.get", tags={"silo": "cell"}, sample_rate=1.0)
 
         owner_only = request.GET.get("owner") in ("1", "true")
+        agent_organization_id = None
+        if is_agent_auth(request.auth):
+            agent_organization_id = request.auth.organization_id
+            if agent_organization_id is None:
+                raise PermissionDenied
 
         queryset = Organization.objects.distinct()
 
-        if request.auth and not request.user.is_authenticated:
-            if hasattr(request.auth, "project"):
-                queryset = queryset.filter(id=request.auth.project.organization_id)
-            elif request.auth.organization_id is not None:
-                queryset = queryset.filter(id=request.auth.organization_id)
-
-        elif owner_only and request.user.is_authenticated:
-            # This is used when closing an account
-
-            # also fetches organizations in which you are a member of an owner team
+        if owner_only and request.user.is_authenticated:
+            # This is used when closing an account. An agent's compatibility user
+            # supplies identity, but the credential still caps that identity to the
+            # organization for which it was minted.
             queryset = Organization.objects.get_organizations_where_user_is_owner(
                 user_id=request.user.id
             )
+            if agent_organization_id is not None:
+                queryset = queryset.filter(id=agent_organization_id)
             org_results = []
             for org in sorted(queryset, key=lambda x: x.name):
                 # O(N) query
@@ -183,6 +185,14 @@ class OrganizationIndexEndpoint(Endpoint):
                 )
 
             return Response(org_results)
+
+        if agent_organization_id is not None:
+            queryset = queryset.filter(id=agent_organization_id)
+        elif request.auth and not request.user.is_authenticated:
+            if hasattr(request.auth, "project"):
+                queryset = queryset.filter(id=request.auth.project.organization_id)
+            elif request.auth.organization_id is not None:
+                queryset = queryset.filter(id=request.auth.organization_id)
 
         elif not (is_active_superuser(request) and request.GET.get("show") == "all"):
             queryset = queryset.filter(
@@ -259,6 +269,11 @@ class OrganizationIndexEndpoint(Endpoint):
         metrics.incr("api.organization_index.get", tags={"silo": "control"}, sample_rate=1.0)
 
         owner_only = request.GET.get("owner") in ("1", "true")
+        agent_organization_id = None
+        if is_agent_auth(request.auth):
+            agent_organization_id = request.auth.organization_id
+            if agent_organization_id is None:
+                raise PermissionDenied
 
         # owner=1 (used by the account-close flow) means "orgs I own", which is
         # defined by the user's membership. A userless token (org auth token or
@@ -267,11 +282,16 @@ class OrganizationIndexEndpoint(Endpoint):
         if owner_only:
             if not request.user.is_authenticated:
                 raise PermissionDenied
-            return self._get_owned_from_control(request)
+            return self._get_owned_from_control(
+                request,
+                organization_id=agent_organization_id,
+            )
 
         queryset = OrganizationMapping.objects.distinct()
 
-        if request.auth and not request.user.is_authenticated:
+        if agent_organization_id is not None:
+            queryset = queryset.filter(organization_id=agent_organization_id)
+        elif request.auth and not request.user.is_authenticated:
             if hasattr(request.auth, "project"):
                 queryset = queryset.filter(organization_id=request.auth.project.organization_id)
             elif request.auth.organization_id is not None:
@@ -369,7 +389,9 @@ class OrganizationIndexEndpoint(Endpoint):
             paginator_cls=paginator_cls,
         )
 
-    def _get_owned_from_control(self, request: Request) -> Response:
+    def _get_owned_from_control(
+        self, request: Request, *, organization_id: int | None = None
+    ) -> Response:
         assert request.user.id is not None
         owner_role = roles.get_top_dog().id
 
@@ -378,12 +400,13 @@ class OrganizationIndexEndpoint(Endpoint):
             role=owner_role,
         ).values_list("organization_id", flat=True)
 
-        org_mappings = list(
-            OrganizationMapping.objects.filter(
-                organization_id__in=owner_org_ids,
-                status=OrganizationStatus.ACTIVE,
-            ).order_by("name")
+        org_mappings_query = OrganizationMapping.objects.filter(
+            organization_id__in=owner_org_ids,
+            status=OrganizationStatus.ACTIVE,
         )
+        if organization_id is not None:
+            org_mappings_query = org_mappings_query.filter(organization_id=organization_id)
+        org_mappings = list(org_mappings_query.order_by("name"))
 
         owner_counts = (
             OrganizationMemberMapping.objects.filter(

--- a/src/sentry/core/endpoints/organization_index.py
+++ b/src/sentry/core/endpoints/organization_index.py
@@ -9,6 +9,7 @@ from rest_framework import serializers, status
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
 from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from sentry import features, options, roles
 from sentry import ratelimits as ratelimiter
@@ -59,6 +60,13 @@ from sentry.utils import metrics
 from sentry.utils.pagination_factory import PaginatorLike
 
 logger = logging.getLogger(__name__)
+
+
+class OrganizationIndexPermission(OrganizationPermission):
+    def has_permission(self, request: Request, view: APIView) -> bool:
+        if request.method == "POST" and is_agent_auth(request.auth):
+            return False
+        return super().has_permission(request, view)
 
 
 class OrganizationPostSerializer(BaseOrganizationSerializer):
@@ -123,7 +131,7 @@ class OrganizationIndexEndpoint(Endpoint):
         "GET": ApiPublishStatus.PUBLIC,
         "POST": ApiPublishStatus.PRIVATE,
     }
-    permission_classes = (OrganizationPermission,)
+    permission_classes = (OrganizationIndexPermission,)
 
     @extend_schema(
         operation_id="listOrganizations",
@@ -452,9 +460,6 @@ class OrganizationIndexEndpoint(Endpoint):
                                 terms of service and privacy policy.
         :auth: required, user-context-needed
         """
-        if is_agent_auth(request.auth):
-            raise PermissionDenied
-
         if SiloMode.get_current_mode() == SiloMode.CELL:
             metrics.incr("api.organization_index.post.rejected")
             base_url = options.get("system.url-prefix")

--- a/src/sentry/core/endpoints/organization_index.py
+++ b/src/sentry/core/endpoints/organization_index.py
@@ -169,9 +169,9 @@ class OrganizationIndexEndpoint(Endpoint):
         queryset = Organization.objects.distinct()
 
         if owner_only and request.user.is_authenticated:
-            # This is used when closing an account. An agent's compatibility user
-            # supplies identity, but the credential still caps that identity to the
-            # organization for which it was minted.
+            # This is used when closing an account
+
+            # also fetches organizations in which you are a member of an owner team
             queryset = Organization.objects.get_organizations_where_user_is_owner(
                 user_id=request.user.id
             )

--- a/src/sentry/core/endpoints/organization_projects.py
+++ b/src/sentry/core/endpoints/organization_projects.py
@@ -58,6 +58,7 @@ from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.project import Project
 from sentry.models.team import Team
 from sentry.search.utils import tokenize_query
+from sentry.seer.agent_token import is_agent_auth
 from sentry.signals import project_created, team_created
 from sentry.snuba import discover, metrics_enhanced_performance, metrics_performance
 from sentry.users.models.user import User
@@ -176,7 +177,14 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint):
         dataset = get_dataset(datasetName)
 
         queryset: QuerySet[Project]
-        if request.auth and not request.user.is_authenticated:
+        if is_agent_auth(request.auth):
+            # OrganizationPermission has already built member-derived, token-capped
+            # request.access. The compatibility user must not turn this into the
+            # broader browser-user project listing.
+            queryset = Project.objects.filter(organization=organization)
+            if not request.access.has_global_access:
+                queryset = queryset.filter(id__in=request.access.accessible_project_ids)
+        elif request.auth and not request.user.is_authenticated:
             # TODO: remove this, no longer supported probably
             if hasattr(request.auth, "project"):
                 queryset = Project.objects.filter(id=request.auth.project.id)

--- a/src/sentry/core/endpoints/organization_projects.py
+++ b/src/sentry/core/endpoints/organization_projects.py
@@ -178,9 +178,6 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint):
 
         queryset: QuerySet[Project]
         if is_agent_auth(request.auth):
-            # OrganizationPermission has already built member-derived, token-capped
-            # request.access. The compatibility user must not turn this into the
-            # broader browser-user project listing.
             queryset = Project.objects.filter(organization=organization)
             if not request.access.has_global_access:
                 queryset = queryset.filter(id__in=request.access.accessible_project_ids)

--- a/src/sentry/core/endpoints/project_index.py
+++ b/src/sentry/core/endpoints/project_index.py
@@ -10,11 +10,13 @@ from sentry.api.bases.project import ProjectPermission
 from sentry.api.helpers.deprecation import deprecated
 from sentry.api.paginator import DateTimePaginator
 from sentry.api.serializers import ProjectWithOrganizationSerializer, serialize
+from sentry.auth import access
 from sentry.auth.superuser import is_active_superuser
 from sentry.constants import CELL_API_DEPRECATION_DATE, ObjectStatus
 from sentry.db.models.query import in_iexact
 from sentry.models.project import Project
 from sentry.models.projectplatform import ProjectPlatform
+from sentry.organizations.services.organization import organization_service
 from sentry.search.utils import tokenize_query
 from sentry.seer.agent_token import is_agent_auth
 from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallation
@@ -52,10 +54,19 @@ class ProjectIndexEndpoint(Endpoint):
             if request.auth.organization_id is None or request.auth.user_id is None:
                 queryset = queryset.none()
             else:
-                queryset = queryset.filter(
-                    organization_id=request.auth.organization_id,
-                    teams__organizationmember__user_id=request.auth.user_id,
+                org_context = organization_service.get_organization_by_id(
+                    id=request.auth.organization_id,
+                    user_id=request.auth.user_id,
+                    include_projects=False,
+                    include_teams=False,
                 )
+                if org_context is None:
+                    queryset = queryset.none()
+                else:
+                    agent_access = access.from_agent_auth(request.auth, org_context)
+                    queryset = queryset.filter(organization_id=request.auth.organization_id)
+                    if not agent_access.has_global_access:
+                        queryset = queryset.filter(id__in=agent_access.accessible_project_ids)
         elif request.auth and not request.user.is_authenticated:
             if request.auth.project_id:
                 queryset = queryset.filter(id=request.auth.project_id)

--- a/src/sentry/core/endpoints/project_index.py
+++ b/src/sentry/core/endpoints/project_index.py
@@ -49,9 +49,6 @@ class ProjectIndexEndpoint(Endpoint):
             queryset = queryset.none()
 
         if is_agent_auth(request.auth):
-            # The compatibility user carries identity only. Keep the global list
-            # intersected with both the credential's organization and the delegating
-            # member's project/team access.
             if request.auth.organization_id is None or request.auth.user_id is None:
                 queryset = queryset.none()
             else:

--- a/src/sentry/core/endpoints/project_index.py
+++ b/src/sentry/core/endpoints/project_index.py
@@ -16,6 +16,7 @@ from sentry.db.models.query import in_iexact
 from sentry.models.project import Project
 from sentry.models.projectplatform import ProjectPlatform
 from sentry.search.utils import tokenize_query
+from sentry.seer.agent_token import is_agent_auth
 from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallation
 
 
@@ -47,7 +48,18 @@ class ProjectIndexEndpoint(Endpoint):
         elif status:
             queryset = queryset.none()
 
-        if request.auth and not request.user.is_authenticated:
+        if is_agent_auth(request.auth):
+            # The compatibility user carries identity only. Keep the global list
+            # intersected with both the credential's organization and the delegating
+            # member's project/team access.
+            if request.auth.organization_id is None or request.auth.user_id is None:
+                queryset = queryset.none()
+            else:
+                queryset = queryset.filter(
+                    organization_id=request.auth.organization_id,
+                    teams__organizationmember__user_id=request.auth.user_id,
+                )
+        elif request.auth and not request.user.is_authenticated:
             if request.auth.project_id:
                 queryset = queryset.filter(id=request.auth.project_id)
             elif request.auth.organization_id is not None:

--- a/src/sentry/core/endpoints/project_index.py
+++ b/src/sentry/core/endpoints/project_index.py
@@ -1,6 +1,6 @@
 from django.db.models import Q
 from django.db.models.query import EmptyQuerySet
-from rest_framework.exceptions import AuthenticationFailed, ParseError
+from rest_framework.exceptions import AuthenticationFailed, ParseError, PermissionDenied
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -52,7 +52,7 @@ class ProjectIndexEndpoint(Endpoint):
 
         if is_agent_auth(request.auth):
             if request.auth.organization_id is None or request.auth.user_id is None:
-                queryset = queryset.none()
+                raise PermissionDenied
             else:
                 org_context = organization_service.get_organization_by_id(
                     id=request.auth.organization_id,

--- a/src/sentry/middleware/sudo.py
+++ b/src/sentry/middleware/sudo.py
@@ -1,10 +1,14 @@
 from django.http.request import HttpRequest
 
+from sentry.seer.agent_token import is_agent_auth
 from sudo.middleware import SudoMiddleware as BaseSudoMiddleware
 
 
 class SudoMiddleware(BaseSudoMiddleware):
     def has_sudo_privileges(self, request: HttpRequest) -> bool:
+        if is_agent_auth(request.auth):
+            return False
+
         # Right now, only password reauthentication (django-sudo) is supported,
         # so if a user doesn't have a password (for example, only has github auth)
         # then we shouldn't prompt them for the password they don't have.

--- a/src/sentry/relocation/api/endpoints/index.py
+++ b/src/sentry/relocation/api/endpoints/index.py
@@ -19,7 +19,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, cell_silo_endpoint
 from sentry.api.paginator import OffsetPaginator
-from sentry.api.permissions import SentryIsAuthenticated
+from sentry.api.permissions import DisallowAgentToken, SentryIsAuthenticated
 from sentry.api.serializers import serialize
 from sentry.auth.elevated_mode import has_elevated_mode
 from sentry.models.files.file import File
@@ -165,7 +165,7 @@ class RelocationIndexEndpoint(Endpoint):
         "GET": ApiPublishStatus.EXPERIMENTAL,
         "POST": ApiPublishStatus.EXPERIMENTAL,
     }
-    permission_classes = (SentryIsAuthenticated,)
+    permission_classes = (SentryIsAuthenticated, DisallowAgentToken)
 
     def get(self, request: Request) -> Response:
         """

--- a/src/sentry/relocation/api/endpoints/retry.py
+++ b/src/sentry/relocation/api/endpoints/retry.py
@@ -13,7 +13,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, cell_silo_endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.api.permissions import SentryIsAuthenticated
+from sentry.api.permissions import DisallowAgentToken, SentryIsAuthenticated
 from sentry.api.serializers import serialize
 from sentry.models.files.file import File
 from sentry.relocation.api.endpoints.index import (
@@ -45,7 +45,7 @@ class RelocationRetryEndpoint(Endpoint):
         # TODO(getsentry/team-ospo#214): Stabilize before GA.
         "POST": ApiPublishStatus.EXPERIMENTAL,
     }
-    permission_classes = (SentryIsAuthenticated,)
+    permission_classes = (SentryIsAuthenticated, DisallowAgentToken)
 
     def post(self, request: Request, relocation_uuid: str) -> Response:
         """

--- a/src/sentry/users/api/bases/user.py
+++ b/src/sentry/users/api/bases/user.py
@@ -17,12 +17,18 @@ from sentry.models.organization import OrganizationStatus
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.organizationmembermapping import OrganizationMemberMapping
 from sentry.organizations.services.organization import organization_service
+from sentry.seer import agent_token
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
 from sentry.users.services.user.service import user_service
 
 
 class UserPermission(DemoSafePermission):
+    def has_permission(self, request: Request, view: APIView) -> bool:
+        if agent_token.is_agent_auth(request.auth):
+            return False
+        return super().has_permission(request, view)
+
     def has_object_permission(
         self, request: Request, view: APIView, user: User | RpcUser | None
     ) -> bool:

--- a/tests/sentry/api/endpoints/test_api_token_details.py
+++ b/tests/sentry/api/endpoints/test_api_token_details.py
@@ -1,10 +1,14 @@
+from django.test import override_settings
 from django.urls import reverse
 from rest_framework import status
 
 from sentry.models.apitoken import ApiToken
+from sentry.seer import agent_token
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.impersonation import simulate_impersonation
 from sentry.testutils.silo import control_silo_test
+
+SECRET = "test-seer-api-shared-secret-thirty-two-bytes!"
 
 
 @control_silo_test
@@ -224,3 +228,31 @@ class ApiTokenDetailsImpersonationTest(APITestCase):
         with simulate_impersonation(self.impersonator):
             response = self.client.get(url)
         assert response.status_code == status.HTTP_200_OK
+
+
+@control_silo_test
+@override_settings(SEER_API_SHARED_SECRET=SECRET)
+class ApiTokenDetailsAgentTokenTest(APITestCase):
+    def test_agent_token_cannot_manage_personal_tokens(self) -> None:
+        organization = self.create_organization(owner=self.user)
+        bearer, _ = agent_token.encode_agent_token(
+            user_id=self.user.id,
+            organization_id=organization.id,
+            scopes=["org:read", "org:write"],
+            session_id="api-token-details",
+        )
+
+        with self.feature(agent_token.FEATURE_FLAG):
+            for method in ("get", "put", "delete"):
+                with self.subTest(method=method):
+                    personal_token = ApiToken.objects.create(user=self.user, name="personal token")
+                    url = reverse("sentry-api-0-api-token-details", args=[personal_token.id])
+                    response = getattr(self.client, method)(
+                        url,
+                        data={"name": "renamed"},
+                        format="json",
+                        HTTP_AUTHORIZATION=f"Bearer {bearer}",
+                    )
+
+                    assert response.status_code == status.HTTP_403_FORBIDDEN
+                    assert ApiToken.objects.filter(id=personal_token.id).exists()

--- a/tests/sentry/api/endpoints/test_sudo.py
+++ b/tests/sentry/api/endpoints/test_sudo.py
@@ -1,12 +1,37 @@
 from django.conf import settings
 from django.urls import reverse
 
+from sentry.seer import agent_token
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import no_silo_test
 
 
 @no_silo_test
 class SudoTest(APITestCase):
+    def test_agent_token_never_satisfies_sudo(self) -> None:
+        org = self.create_organization()
+        user = self.create_user()
+        user.set_unusable_password()
+        user.save(update_fields=["password"])
+        self.create_member(organization=org, user=user, role="owner")
+        url = reverse(
+            "sentry-api-0-organization-details", kwargs={"organization_id_or_slug": org.slug}
+        )
+        with (
+            self.settings(SEER_API_SHARED_SECRET="sudo-test-secret"),
+            self.feature(agent_token.FEATURE_FLAG),
+        ):
+            token, _ = agent_token.encode_agent_token(
+                user_id=user.id,
+                organization_id=org.id,
+                scopes=["org:admin"],
+                session_id="sudo-boundary",
+            )
+            response = self.client.delete(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+
+        assert response.status_code == 401
+        assert response.data["detail"]["code"] == "sudo-required"
+
     def test_sudo_required_del_org(self) -> None:
         org = self.create_organization()
         url = reverse(

--- a/tests/sentry/api/endpoints/test_sudo.py
+++ b/tests/sentry/api/endpoints/test_sudo.py
@@ -1,6 +1,9 @@
 from django.conf import settings
 from django.urls import reverse
 
+from sentry.auth.services.auth import AuthenticatedToken
+from sentry.middleware.placeholder import placeholder_get_response
+from sentry.middleware.sudo import SudoMiddleware
 from sentry.seer import agent_token
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import no_silo_test
@@ -8,6 +11,19 @@ from sentry.testutils.silo import no_silo_test
 
 @no_silo_test
 class SudoTest(APITestCase):
+    def test_agent_token_does_not_inherit_passwordless_sudo(self) -> None:
+        user = self.create_user()
+        user.set_unusable_password()
+        user.save(update_fields=["password"])
+        middleware = SudoMiddleware(placeholder_get_response)
+
+        assert middleware.has_sudo_privileges(self.make_request(user=user))
+        request = self.make_request(
+            user=user,
+            auth=AuthenticatedToken(kind=agent_token.AGENT_TOKEN_KIND),
+        )
+        assert not middleware.has_sudo_privileges(request)
+
     def test_agent_token_never_satisfies_sudo(self) -> None:
         org = self.create_organization()
         user = self.create_user()

--- a/tests/sentry/core/endpoints/test_project_index.py
+++ b/tests/sentry/core/endpoints/test_project_index.py
@@ -2,7 +2,9 @@ import responses
 from django.db import router
 from django.urls import reverse
 from rest_framework import status
+from rest_framework.test import APIClient
 
+from sentry.auth.services.auth import AuthenticatedToken
 from sentry.constants import ObjectStatus
 from sentry.deletions.tasks.hybrid_cloud import (
     schedule_hybrid_cloud_foreign_key_jobs,
@@ -11,6 +13,7 @@ from sentry.deletions.tasks.hybrid_cloud import (
 from sentry.models.apitoken import ApiToken
 from sentry.models.project import Project
 from sentry.models.projectkey import ProjectKey
+from sentry.seer import agent_token
 from sentry.sentry_apps.models.sentry_app_installation_token import SentryAppInstallationToken
 from sentry.silo.base import SiloMode
 from sentry.silo.safety import unguarded_write
@@ -21,6 +24,28 @@ from sentry.testutils.silo import assume_test_silo_mode
 
 class ProjectsListTest(APITestCase):
     endpoint = "sentry-api-0-projects"
+
+    def test_agent_auth_missing_required_context_is_forbidden(self) -> None:
+        user = self.create_user()
+
+        for auth in (
+            AuthenticatedToken(
+                kind=agent_token.AGENT_TOKEN_KIND,
+                scopes=["project:read"],
+                user_id=user.id,
+            ),
+            AuthenticatedToken(
+                kind=agent_token.AGENT_TOKEN_KIND,
+                scopes=["project:read"],
+                organization_id=self.organization.id,
+            ),
+        ):
+            with self.subTest(auth=auth):
+                client = APIClient()
+                client.force_authenticate(user=user, token=auth)
+                response = client.get(reverse(self.endpoint))
+
+                assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_member_constraints(self) -> None:
         user = self.create_user(is_superuser=True)

--- a/tests/sentry/core/endpoints/test_project_index.py
+++ b/tests/sentry/core/endpoints/test_project_index.py
@@ -1,11 +1,13 @@
+import pytest
 import responses
 from django.db import router
 from django.urls import reverse
 from rest_framework import status
-from rest_framework.test import APIClient
+from rest_framework.exceptions import PermissionDenied
 
 from sentry.auth.services.auth import AuthenticatedToken
 from sentry.constants import ObjectStatus
+from sentry.core.endpoints.project_index import ProjectIndexEndpoint
 from sentry.deletions.tasks.hybrid_cloud import (
     schedule_hybrid_cloud_foreign_key_jobs,
     schedule_hybrid_cloud_foreign_key_jobs_control,
@@ -19,6 +21,7 @@ from sentry.silo.base import SiloMode
 from sentry.silo.safety import unguarded_write
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.outbox import outbox_runner
+from sentry.testutils.requests import drf_request_from_request
 from sentry.testutils.silo import assume_test_silo_mode
 
 
@@ -41,11 +44,12 @@ class ProjectsListTest(APITestCase):
             ),
         ):
             with self.subTest(auth=auth):
-                client = APIClient()
-                client.force_authenticate(user=user, token=auth)
-                response = client.get(reverse(self.endpoint))
+                request = drf_request_from_request(
+                    self.make_request(user=user, auth=auth, method="GET")
+                )
 
-                assert response.status_code == status.HTTP_403_FORBIDDEN
+                with pytest.raises(PermissionDenied):
+                    ProjectIndexEndpoint().get(request)
 
     def test_member_constraints(self) -> None:
         user = self.create_user(is_superuser=True)

--- a/tests/sentry/core/endpoints/test_project_index.py
+++ b/tests/sentry/core/endpoints/test_project_index.py
@@ -31,19 +31,25 @@ class ProjectsListTest(APITestCase):
     def test_agent_auth_missing_required_context_is_forbidden(self) -> None:
         user = self.create_user()
 
-        for auth in (
-            AuthenticatedToken(
-                kind=agent_token.AGENT_TOKEN_KIND,
-                scopes=["project:read"],
-                user_id=user.id,
+        for missing_context, auth in (
+            (
+                "organization",
+                AuthenticatedToken(
+                    kind=agent_token.AGENT_TOKEN_KIND,
+                    scopes=["project:read"],
+                    user_id=user.id,
+                ),
             ),
-            AuthenticatedToken(
-                kind=agent_token.AGENT_TOKEN_KIND,
-                scopes=["project:read"],
-                organization_id=self.organization.id,
+            (
+                "user",
+                AuthenticatedToken(
+                    kind=agent_token.AGENT_TOKEN_KIND,
+                    scopes=["project:read"],
+                    organization_id=self.organization.id,
+                ),
             ),
         ):
-            with self.subTest(auth=auth):
+            with self.subTest(missing_context=missing_context):
                 request = drf_request_from_request(
                     self.make_request(user=user, auth=auth, method="GET")
                 )

--- a/tests/sentry/middleware/test_auth.py
+++ b/tests/sentry/middleware/test_auth.py
@@ -119,8 +119,6 @@ class AuthenticationMiddlewareTestCase(TestCase):
         return token
 
     def test_process_request_valid_agent_token(self) -> None:
-        # Legacy identity-shaped callsites receive the delegating user, while the agent
-        # credential remains the authorization authority.
         with (
             override_settings(SEER_API_SHARED_SECRET="test-secret"),
             self.feature(agent_token.FEATURE_FLAG),
@@ -153,8 +151,6 @@ class AuthenticationMiddlewareTestCase(TestCase):
         assert request.auth is None
 
     def test_process_request_agent_token_supplies_compatibility_user_on_non_api_path(self) -> None:
-        # The compatibility identity is supplied regardless of path; the bearer remains
-        # distinguishable as an agent credential in request.auth.
         with (
             override_settings(SEER_API_SHARED_SECRET="test-secret"),
             self.feature(agent_token.FEATURE_FLAG),
@@ -168,8 +164,6 @@ class AuthenticationMiddlewareTestCase(TestCase):
         assert request.auth.user_id == self.user.id
 
     def test_process_request_agent_token_wins_over_session(self) -> None:
-        # An Authorization header takes precedence over a session cookie: the agent bearer
-        # is processed and its delegating user replaces the unrelated session user.
         session_user = self.create_user()
         request = Request(self.make_request(method="GET", path="/api/0/organizations/"))
         with assume_test_silo_mode(SiloMode.MONOLITH):

--- a/tests/sentry/middleware/test_auth.py
+++ b/tests/sentry/middleware/test_auth.py
@@ -119,8 +119,8 @@ class AuthenticationMiddlewareTestCase(TestCase):
         return token
 
     def test_process_request_valid_agent_token(self) -> None:
-        # The agent is a non-user actor: the request user stays anonymous; the credential
-        # records the delegating user and org.
+        # Legacy identity-shaped callsites receive the delegating user, while the agent
+        # credential remains the authorization authority.
         with (
             override_settings(SEER_API_SHARED_SECRET="test-secret"),
             self.feature(agent_token.FEATURE_FLAG),
@@ -128,7 +128,8 @@ class AuthenticationMiddlewareTestCase(TestCase):
             request = Request(self.make_request(method="GET", path="/api/0/organizations/"))
             request.META["HTTP_AUTHORIZATION"] = f"Bearer {self._agent_token(self.user)}"
             self.middleware.process_request(request)
-        assert request.user.is_anonymous
+        assert request.user.is_authenticated
+        assert request.user.id == self.user.id
         assert request.auth is not None
         assert request.auth.kind == agent_token.AGENT_TOKEN_KIND
         assert request.auth.user_id == self.user.id
@@ -151,9 +152,9 @@ class AuthenticationMiddlewareTestCase(TestCase):
         assert request.user.is_anonymous
         assert request.auth is None
 
-    def test_process_request_agent_token_never_becomes_a_user(self) -> None:
-        # Even on a non-API path, the agent authenticates as a non-user actor: the request
-        # user is anonymous, so user-only web views fail closed. (No path gate needed.)
+    def test_process_request_agent_token_supplies_compatibility_user_on_non_api_path(self) -> None:
+        # The compatibility identity is supplied regardless of path; the bearer remains
+        # distinguishable as an agent credential in request.auth.
         with (
             override_settings(SEER_API_SHARED_SECRET="test-secret"),
             self.feature(agent_token.FEATURE_FLAG),
@@ -161,23 +162,27 @@ class AuthenticationMiddlewareTestCase(TestCase):
             request = Request(self.make_request(method="GET", path="/organizations/"))
             request.META["HTTP_AUTHORIZATION"] = f"Bearer {self._agent_token(self.user)}"
             self.middleware.process_request(request)
-        assert request.user.is_anonymous
+        assert request.user.is_authenticated
+        assert request.user.id == self.user.id
         assert request.auth is not None
         assert request.auth.user_id == self.user.id
 
     def test_process_request_agent_token_wins_over_session(self) -> None:
         # An Authorization header takes precedence over a session cookie: the agent bearer
-        # is processed and the session user is not adopted. The agent stays a non-user actor.
+        # is processed and its delegating user replaces the unrelated session user.
+        session_user = self.create_user()
         request = Request(self.make_request(method="GET", path="/api/0/organizations/"))
         with assume_test_silo_mode(SiloMode.MONOLITH):
-            assert login(request, self.user)
+            assert login(request, session_user)
         with (
             override_settings(SEER_API_SHARED_SECRET="test-secret"),
             self.feature(agent_token.FEATURE_FLAG),
         ):
             request.META["HTTP_AUTHORIZATION"] = f"Bearer {self._agent_token(self.user)}"
             self.middleware.process_request(request)
-        assert request.user.is_anonymous
+        assert request.user.is_authenticated
+        assert request.user.id == self.user.id
+        assert request.user.id != session_user.id
         assert request.auth is not None
         assert request.auth.user_id == self.user.id
 

--- a/tests/sentry/seer/endpoints/test_organization_agent_token.py
+++ b/tests/sentry/seer/endpoints/test_organization_agent_token.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from django.test import override_settings
+from rest_framework.test import APIClient
 
 from sentry.seer import agent_token
 from sentry.seer.models.agent_write_grant import SeerAgentWriteGrant
@@ -184,6 +185,71 @@ class OrganizationAgentTokenTest(APITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
         assert write.status_code == 403
+
+    def test_organization_owner_listing_remains_token_org_bound(self) -> None:
+        other_org = self.create_organization(owner=self.owner)
+        self.login_as(self.owner)
+
+        with self.feature(FLAG):
+            token = self._mint(sessionId="s1").data["token"]
+            for silo_mode in (SiloMode.CELL, SiloMode.CONTROL):
+                with self.subTest(silo_mode=silo_mode):
+                    with assume_test_silo_mode(silo_mode):
+                        response = APIClient().get(
+                            "/api/0/organizations/?owner=1",
+                            HTTP_AUTHORIZATION=f"Bearer {token}",
+                        )
+
+                    assert response.status_code == 200, response.content
+                    listed_ids = {int(item["organization"]["id"]) for item in response.data}
+                    assert listed_ids == {self.org.id}
+                    assert other_org.id not in listed_ids
+
+    def test_project_listings_retain_agent_org_and_member_bounds(self) -> None:
+        self.org.flags.allow_joinleave = False
+        self.org.save()
+        member_team = self.create_team(organization=self.org)
+        member_project = self.create_project(organization=self.org, teams=[member_team])
+        other_team = self.create_team(organization=self.org)
+        self.create_project(organization=self.org, teams=[other_team])
+
+        other_org = self.create_organization()
+        cross_org_team = self.create_team(organization=other_org)
+        self.create_project(organization=other_org, teams=[cross_org_team])
+
+        member_user = self.create_user()
+        self.create_member(
+            user=member_user,
+            organization=self.org,
+            role="member",
+            teams=[member_team],
+        )
+        self.create_member(
+            user=member_user,
+            organization=other_org,
+            role="member",
+            teams=[cross_org_team],
+        )
+        self.login_as(member_user)
+
+        with self.feature(FLAG):
+            token = self._mint(sessionId="s1").data["token"]
+            client = APIClient()
+            responses = {
+                "global": client.get(
+                    "/api/0/projects/",
+                    HTTP_AUTHORIZATION=f"Bearer {token}",
+                ),
+                "organization": client.get(
+                    f"/api/0/organizations/{self.org.slug}/projects/",
+                    HTTP_AUTHORIZATION=f"Bearer {token}",
+                ),
+            }
+
+        for surface, response in responses.items():
+            with self.subTest(surface=surface):
+                assert response.status_code == 200, response.content
+                assert {int(item["id"]) for item in response.data} == {member_project.id}
 
     def test_end_to_end_read_allowed_write_denied(self) -> None:
         # Mint via session, then use the minted token as a bearer: read passes; an

--- a/tests/sentry/seer/endpoints/test_organization_agent_token.py
+++ b/tests/sentry/seer/endpoints/test_organization_agent_token.py
@@ -185,20 +185,31 @@ class OrganizationAgentTokenTest(APITestCase):
         assert write.status_code == 403
 
     def test_agent_token_cannot_create_an_organization(self) -> None:
-        self._grant(session_id="s1", scopes=["org:write"])
         self.login_as(self.owner)
 
         with self.feature(FLAG):
-            token = self._mint(sessionId="s1").data["token"]
+            readonly_token = self._mint(sessionId="s1").data["token"]
             with assume_test_silo_mode(SiloMode.CONTROL):
-                response = APIClient().post(
+                readonly_response = APIClient().post(
                     "/api/0/organizations/",
                     data={"name": "Outside Token Organization"},
                     format="json",
-                    HTTP_AUTHORIZATION=f"Bearer {token}",
+                    HTTP_AUTHORIZATION=f"Bearer {readonly_token}",
                 )
 
-        assert response.status_code == 403
+            self._grant(session_id="s1", scopes=["org:write"])
+            approved_token = self._mint(sessionId="s1").data["token"]
+            with assume_test_silo_mode(SiloMode.CONTROL):
+                approved_response = APIClient().post(
+                    "/api/0/organizations/",
+                    data={"name": "Outside Token Organization"},
+                    format="json",
+                    HTTP_AUTHORIZATION=f"Bearer {approved_token}",
+                )
+
+        for response in (readonly_response, approved_response):
+            assert response.status_code == 403
+            assert "insufficient_scope" not in response.get("WWW-Authenticate", "")
 
     def test_organization_owner_listing_remains_token_org_bound(self) -> None:
         other_org = self.create_organization(owner=self.owner)

--- a/tests/sentry/seer/endpoints/test_organization_agent_token.py
+++ b/tests/sentry/seer/endpoints/test_organization_agent_token.py
@@ -249,6 +249,28 @@ class OrganizationAgentTokenTest(APITestCase):
                 assert response.status_code == 200, response.content
                 assert {int(item["id"]) for item in response.data} == {member_project.id}
 
+    def test_owner_agent_project_listing_is_org_bound(self) -> None:
+        self.org.flags.allow_joinleave = False
+        self.org.save()
+        unjoined_team = self.create_team(organization=self.org)
+        unjoined_project = self.create_project(organization=self.org, teams=[unjoined_team])
+
+        other_org = self.create_organization(owner=self.owner)
+        other_project = self.create_project(organization=other_org)
+        self.login_as(self.owner)
+
+        with self.feature(FLAG):
+            token = self._mint(sessionId="s1").data["token"]
+            response = APIClient().get(
+                "/api/0/projects/",
+                HTTP_AUTHORIZATION=f"Bearer {token}",
+            )
+
+        assert response.status_code == 200, response.content
+        listed_ids = {int(item["id"]) for item in response.data}
+        assert listed_ids == {unjoined_project.id}
+        assert other_project.id not in listed_ids
+
     def test_end_to_end_read_allowed_write_denied(self) -> None:
         # Mint via session, then use the minted token as a bearer: read passes; an
         # under-scoped write is denied with the RFC 6750 insufficient_scope challenge naming

--- a/tests/sentry/seer/endpoints/test_organization_agent_token.py
+++ b/tests/sentry/seer/endpoints/test_organization_agent_token.py
@@ -135,8 +135,6 @@ class OrganizationAgentTokenTest(APITestCase):
         assert "org:write" not in claims["scopes"]
 
     def test_agent_token_cannot_mint(self) -> None:
-        # Minting is user-initiated. The agent credential must be rejected even though its
-        # compatibility request.user resolves to the delegating user.
         self.login_as(self.owner)
         with self.feature(FLAG):
             minted = self._mint(sessionId="s1")

--- a/tests/sentry/seer/endpoints/test_organization_agent_token.py
+++ b/tests/sentry/seer/endpoints/test_organization_agent_token.py
@@ -193,7 +193,7 @@ class OrganizationAgentTokenTest(APITestCase):
         with self.feature(FLAG):
             token = self._mint(sessionId="s1").data["token"]
             for silo_mode in (SiloMode.CELL, SiloMode.CONTROL):
-                with self.subTest(silo_mode=silo_mode):
+                with self.subTest(silo_mode=silo_mode.value):
                     with assume_test_silo_mode(silo_mode):
                         response = APIClient().get(
                             "/api/0/organizations/?owner=1",

--- a/tests/sentry/seer/endpoints/test_organization_agent_token.py
+++ b/tests/sentry/seer/endpoints/test_organization_agent_token.py
@@ -184,6 +184,22 @@ class OrganizationAgentTokenTest(APITestCase):
             )
         assert write.status_code == 403
 
+    def test_agent_token_cannot_create_an_organization(self) -> None:
+        self._grant(session_id="s1", scopes=["org:write"])
+        self.login_as(self.owner)
+
+        with self.feature(FLAG):
+            token = self._mint(sessionId="s1").data["token"]
+            with assume_test_silo_mode(SiloMode.CONTROL):
+                response = APIClient().post(
+                    "/api/0/organizations/",
+                    data={"name": "Outside Token Organization"},
+                    format="json",
+                    HTTP_AUTHORIZATION=f"Bearer {token}",
+                )
+
+        assert response.status_code == 403
+
     def test_organization_owner_listing_remains_token_org_bound(self) -> None:
         other_org = self.create_organization(owner=self.owner)
         self.login_as(self.owner)

--- a/tests/sentry/seer/endpoints/test_organization_agent_token.py
+++ b/tests/sentry/seer/endpoints/test_organization_agent_token.py
@@ -134,8 +134,8 @@ class OrganizationAgentTokenTest(APITestCase):
         assert "org:write" not in claims["scopes"]
 
     def test_agent_token_cannot_mint(self) -> None:
-        # Minting is user-initiated; an agent token is a non-user actor and must be rejected
-        # cleanly (not 500 on the anonymous request user).
+        # Minting is user-initiated. The agent credential must be rejected even though its
+        # compatibility request.user resolves to the delegating user.
         self.login_as(self.owner)
         with self.feature(FLAG):
             minted = self._mint(sessionId="s1")

--- a/tests/sentry/seer/endpoints/test_organization_agent_token.py
+++ b/tests/sentry/seer/endpoints/test_organization_agent_token.py
@@ -211,6 +211,43 @@ class OrganizationAgentTokenTest(APITestCase):
             assert response.status_code == 403
             assert "insufficient_scope" not in response.get("WWW-Authenticate", "")
 
+    def test_agent_token_cannot_use_user_account_or_relocation_workflows(self) -> None:
+        self.login_as(self.owner)
+
+        with self.feature(FLAG):
+            token = self._mint(sessionId="s1").data["token"]
+            client = APIClient()
+            responses = {
+                "list relocations": client.get(
+                    "/api/0/relocations/",
+                    HTTP_AUTHORIZATION=f"Bearer {token}",
+                ),
+                "start relocation": client.post(
+                    "/api/0/relocations/",
+                    data={},
+                    format="json",
+                    HTTP_AUTHORIZATION=f"Bearer {token}",
+                ),
+                "retry relocation": client.post(
+                    "/api/0/relocations/00000000-0000-0000-0000-000000000000/retry/",
+                    data={},
+                    format="json",
+                    HTTP_AUTHORIZATION=f"Bearer {token}",
+                ),
+            }
+            with assume_test_silo_mode(SiloMode.CONTROL):
+                responses["generate user merge code"] = client.post(
+                    "/api/0/auth-v2/user-merge-verification-codes/",
+                    data={},
+                    format="json",
+                    HTTP_AUTHORIZATION=f"Bearer {token}",
+                )
+
+        for endpoint, response in responses.items():
+            with self.subTest(endpoint=endpoint):
+                assert response.status_code == 403, response.content
+                assert "insufficient_scope" not in response.get("WWW-Authenticate", "")
+
     def test_organization_owner_listing_remains_token_org_bound(self) -> None:
         other_org = self.create_organization(owner=self.owner)
         self.login_as(self.owner)

--- a/tests/sentry/seer/test_agent_token.py
+++ b/tests/sentry/seer/test_agent_token.py
@@ -290,6 +290,23 @@ class AgentTokenAuthAndGateTest(TestCase):
         with pytest.raises(AuthenticationFailed):
             self._auth(token, feature_enabled=False)
 
+    def test_revoked_member_is_rejected_on_reauthentication(self) -> None:
+        token, _ = agent_token.encode_agent_token(
+            user_id=self.member.id,
+            organization_id=self.org.id,
+            scopes=["org:read"],
+            session_id="s1",
+        )
+        assert self._auth(token) is not None
+
+        OrganizationMember.objects.get(
+            user_id=self.member.id,
+            organization=self.org,
+        ).delete()
+
+        with pytest.raises(AuthenticationFailed):
+            self._auth(token)
+
     def test_signed_but_malformed_claims_are_rejected(self) -> None:
         # Right key and audience but broken claims -> clean auth failure, not a 500.
         null_sub = self._typed_token(

--- a/tests/sentry/seer/test_agent_token.py
+++ b/tests/sentry/seer/test_agent_token.py
@@ -374,6 +374,19 @@ class AgentTokenAuthAndGateTest(TestCase):
         assert not permission.has_permission(request, APIView())
         assert not permission.has_object_permission(request, APIView(), self.org)
 
+    def test_agent_access_rejects_context_for_different_user(self) -> None:
+        request = self._agent_request(self.member, ["org:admin"], method="DELETE")
+        owner_context = organization_service.get_organization_by_id(
+            id=self.org.id,
+            user_id=self.owner.id,
+            include_projects=False,
+            include_teams=False,
+        )
+        assert owner_context is not None
+
+        assert not OrganizationPermission().has_object_permission(request, APIView(), owner_context)
+        assert request.access is DEFAULT
+
     def test_shared_request_access_factory_dispatches_by_agent_credential(self) -> None:
         request = self._agent_request(self.owner, ["org:read"], method="GET")
         org_context = organization_service.get_organization_by_id(

--- a/tests/sentry/seer/test_agent_token.py
+++ b/tests/sentry/seer/test_agent_token.py
@@ -17,9 +17,10 @@ from rest_framework.views import APIView
 
 from sentry.api.authentication import AgentTokenAuthentication, UserAuthTokenAuthentication
 from sentry.api.bases.organization import OrganizationPermission, OrganizationReleasesBaseEndpoint
-from sentry.auth.access import Access, from_auth
+from sentry.auth.access import DEFAULT, Access, from_auth, from_request, from_request_org_and_scopes
 from sentry.auth.services.auth import AuthenticatedToken
 from sentry.models.organizationmember import OrganizationMember
+from sentry.organizations.services.organization import organization_service
 from sentry.seer import agent_token
 from sentry.seer.models.agent_write_grant import SeerAgentWriteGrant
 from sentry.testutils.cases import TestCase
@@ -128,15 +129,29 @@ class AgentTokenAuthAndGateTest(TestCase):
             with pytest.raises(jwt.DecodeError):
                 agent_token.decode_principal_subject(subject)
 
-    def test_valid_token_authenticates_as_non_user_actor(self) -> None:
-        # The agent is a non-user actor: the request user is anonymous and the credential
-        # records the delegating user it acts on behalf of.
+    def test_valid_token_supplies_compatibility_user_and_preserves_agent_auth(self) -> None:
+        # The agent remains the credential while legacy identity-only callsites receive an
+        # ephemeral representation of the user who delegated to it.
         request = self._agent_request(self.owner, ["org:read"], method="GET")
-        assert request.user.is_anonymous
+        assert request.user.is_authenticated
+        assert request.user.id == self.owner.id
+        assert request.user.email == self.owner.email
         assert request.auth is not None
         assert request.auth.kind == agent_token.AGENT_TOKEN_KIND
         assert request.auth.user_id == self.owner.id
         assert request.auth.get_scopes() == ["org:read"]
+
+    def test_compatibility_user_strips_platform_elevation(self) -> None:
+        elevated_user = self.create_user(is_staff=True, is_superuser=True)
+        self.create_member(user=elevated_user, organization=self.org, role="owner")
+
+        request = self._agent_request(elevated_user, ["org:read"], method="GET")
+
+        assert request.user.id == elevated_user.id
+        assert not request.user.is_staff
+        assert not request.user.is_superuser
+        assert getattr(request.user, "permissions", None) == frozenset()
+        assert getattr(request.user, "roles", None) == frozenset()
 
     def _auth(self, bearer: str, *, feature_enabled: bool = True) -> tuple[Any, Any] | None:
         request = RequestFactory().get("/api/0/organizations/")
@@ -336,6 +351,45 @@ class AgentTokenAuthAndGateTest(TestCase):
         # intersection in the access layer removes it -> denied at the object level.
         request = self._agent_request(self.member, ["org:read", "org:write"], method="PUT")
         assert self._has_object_perm(request) is False
+
+    def test_compatibility_user_does_not_bypass_readonly_scope(self) -> None:
+        request = self._agent_request(self.owner, ["org:read"], method="PUT")
+        permission = OrganizationPermission()
+
+        assert not permission.has_permission(request, APIView())
+        assert not permission.has_object_permission(request, APIView(), self.org)
+
+    def test_shared_request_access_factory_dispatches_by_agent_credential(self) -> None:
+        request = self._agent_request(self.owner, ["org:read"], method="GET")
+        org_context = organization_service.get_organization_by_id(
+            id=self.org.id,
+            user_id=self.owner.id,
+            include_projects=False,
+            include_teams=False,
+        )
+        assert org_context is not None
+
+        resolved_access = from_request_org_and_scopes(
+            request=request,
+            rpc_user_org_context=org_context,
+        )
+
+        assert resolved_access.has_scope("org:read")
+        assert not resolved_access.has_scope("org:write")
+
+    def test_shared_request_access_factory_denies_contextless_agent(self) -> None:
+        request = self._agent_request(self.owner, ["org:read"], method="GET")
+
+        assert from_request_org_and_scopes(request=request) is DEFAULT
+
+    def test_orm_request_access_factory_dispatches_by_agent_credential(self) -> None:
+        request = self._agent_request(self.owner, ["org:read"], method="GET")
+
+        resolved_access = from_request(request, organization=self.org)
+
+        assert resolved_access.has_scope("org:read")
+        assert not resolved_access.has_scope("org:write")
+        assert from_request(request) is DEFAULT
 
     def _access_for(self, request: Request) -> Access:
         OrganizationPermission().has_object_permission(request, APIView(), self.org)

--- a/tests/sentry/seer/test_agent_token.py
+++ b/tests/sentry/seer/test_agent_token.py
@@ -130,8 +130,6 @@ class AgentTokenAuthAndGateTest(TestCase):
                 agent_token.decode_principal_subject(subject)
 
     def test_valid_token_supplies_compatibility_user_and_preserves_agent_auth(self) -> None:
-        # The agent remains the credential while legacy identity-only callsites receive an
-        # ephemeral representation of the user who delegated to it.
         request = self._agent_request(self.owner, ["org:read"], method="GET")
         assert request.user.is_authenticated
         assert request.user.id == self.owner.id

--- a/tests/sentry/users/api/endpoints/test_user_regions.py
+++ b/tests/sentry/users/api/endpoints/test_user_regions.py
@@ -1,3 +1,6 @@
+from django.test import override_settings
+
+from sentry.seer import agent_token
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.cell import override_cells
 from sentry.testutils.silo import control_silo_test
@@ -7,6 +10,7 @@ us = Cell("us", 1, "https://us.testserver")
 de = Cell("de", 2, "https://de.testserver")
 st = Cell("acme", 3, "https://acme.testserver")
 cell_config = (us, de, st)
+SECRET = "test-seer-api-shared-secret-thirty-two-bytes!"
 
 us_locality = Locality(
     name="us", cells=frozenset(["us"]), category=RegionCategory.MULTI_TENANT, new_org_cell="us"
@@ -105,6 +109,25 @@ class UserUserRolesTest(APITestCase):
             de_locality.api_serialize(),
             us_locality.api_serialize(),
         ]
+
+    @override_cells(cell_config)
+    @override_settings(SEER_API_SHARED_SECRET=SECRET)
+    def test_get_for_user_with_agent_token_error(self) -> None:
+        organization = self.create_organization(cell="us", owner=self.user)
+        bearer, _ = agent_token.encode_agent_token(
+            user_id=self.user.id,
+            organization_id=organization.id,
+            scopes=["org:read"],
+            session_id="user-regions",
+        )
+
+        with self.feature(agent_token.FEATURE_FLAG):
+            response = self.get_response(
+                "me", extra_headers={"HTTP_AUTHORIZATION": f"Bearer {bearer}"}
+            )
+
+        assert response.status_code == 403
+        assert "insufficient_scope" not in response.get("WWW-Authenticate", "")
 
     @override_cells(cell_config)
     def test_get_other_user_with_auth_token_error(self) -> None:


### PR DESCRIPTION
Agent bearer tokens now provide legacy `request.user` callsites with an ephemeral copy of the delegating RPC user, so valid agent requests no longer fail only because identity is absent. `request.auth` remains the authorization authority, and no proxy user row is created.

Credential-first dispatch in the shared access factories keeps effective access at the intersection of minted scopes and live organization membership. A token is rejected during authentication if its delegating membership has been revoked. Ordinary members remain team/project-bound, while managers and owners retain their existing organization-wide resource access only inside the organization encoded in the token. Organization and project listing paths explicitly preserve those boundaries, and the compatibility copy strips staff, superuser, global-role, and global-permission elevation.

Agent credentials can never satisfy sudo or step-up authentication, including through the passwordless-user shortcut. The compatibility identity therefore cannot unlock organization or team deletion merely because the delegating user has no usable password. Existing non-agent authentication behavior is unchanged.

This is a compatibility bridge while identity-shaped callsites migrate toward ViewerContext. The matrix in #121840 is validation tooling only; this production change remains directly based on master and can land independently.
