### PR TITLE
feat(skills): Add remove-option-or-flag skill

### DIFF
--- a/.agents/skills/feature-flags/SKILL.md
+++ b/.agents/skills/feature-flags/SKILL.md
@@ -36,4 +36,6 @@ New features should be gated behind a feature flag.
 
 5. **Rollout**: FlagPole YAML config lives in the `sentry-options-automator` repo, not here.
 
+6. **Removal**: once the rollout is finished, the flag comes out in a fixed three-PR order — see the `remove-option-or-flag` skill.
+
 See https://develop.sentry.dev/feature-flags/ for full docs.

--- a/.agents/skills/remove-option-or-flag/SKILL.md
+++ b/.agents/skills/remove-option-or-flag/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: remove-option-or-flag
+description: Remove a Sentry option or FlagPole feature flag whose rollout is finished, in the correct PR order across sentry, getsentry, and sentry-options-automator. Use when deleting an option from defaults.py, removing a flag from temporary.py, cleaning up a flag that reached 100%, unsetting a value in the options automator, or diagnosing an automator run that reports an unregistered option. Trigger on "remove this feature flag", "delete this option", "clean up the flag", "the flag is fully rolled out", "deprecate an option", "unregistered option", "options drift on main".
+---
+
+# Remove a Sentry Option or Feature Flag
+
+Removal takes **three PRs in a fixed order**, each deployed — not merely merged — before the next one merges. sentry and getsentry roll out region-by-region via GoCD; the automator runs its own pipeline. Wrong order either flips production behavior or turns the automator red on `main` for everyone.
+
+FlagPole flags follow the same order for the same reason: registering a flag auto-registers an option `feature.<flag-name>` with `FLAG_AUTOMATOR_MODIFIABLE` ([manager.py](https://github.com/getsentry/sentry/blob/master/src/sentry/features/manager.py)), so flags travel the identical `configoptions` path as options.
+
+## Order
+
+| #   | Repo                     | Change                                                              | Merge only after                     |
+| --- | ------------------------ | ------------------------------------------------------------------- | ------------------------------------ |
+| 1   | sentry / getsentry       | Collapse every read to the outcome that won; delete the dead branch | —                                    |
+| 2   | sentry-options-automator | Remove the value / flag block from YAML                             | step 1 deployed to **all** regions   |
+| 3   | sentry                   | Remove the registration (`defaults.py` / `temporary.py`)            | step 2 deployed, automator run green |
+
+Step 1 is usually **two PRs** when a flag is read in both `static/` and `src/` — frontend and backend are not atomically deployed. That is the repo-wide rule in AGENTS.md, not an options-specific one; "step 1 deployed" therefore means both PRs are out.
+
+## Step 0 — preconditions
+
+| Check                         | Command / location                                                        | What it means                                                                                                      |
+| ----------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Is it automator-managed?      | Option has `FLAG_AUTOMATOR_MODIFIABLE` in `defaults.py`; flags always are | Options with `FLAG_PRIORITIZE_DISK` or without `FLAG_AUTOMATOR_MODIFIABLE` come from ops config, not this workflow |
+| Should it be deleted at all?  | A flag gating a plan/tier entitlement is permanent                        | Move `manager.add(...)` from `temporary.py` to `permanent.py`; keep the automator entry                            |
+| Where is it read?             | `rg -n '<name>' src/ static/ tests/` in sentry **and** getsentry          | Every hit is step-1 work, including `with self.feature(...)` in tests                                              |
+| Where is it set, and to what? | Automator **at HEAD**: `rg -n '<name>' options/`                          | Every hit is step-2 work; together they are the outcome step 1 collapses to                                        |
+
+## Step 1 — collapse the call sites
+
+Read the value from automator `main` at HEAD — not from the rollout PR, the ticket, or the registered default; it may have moved since.
+
+**Stop and ask the user** if either holds. Report the values you found and let them decide — do not pick a value and proceed:
+
+- **Regions disagree.** `options/default/` and the region files hold different values, so there is no single rolled-out outcome to collapse to. Which one wins, or whether the option should stay, is a product decision.
+- **The option is drifted** (`[DRIFT]` in the automator run). The live value differs from the file, so the file is not the truth. Someone changed it through another channel, and the why matters before anything is deleted.
+
+Otherwise collapse each call site to the outcome that won. Do not leave the value behind as an `if True` or a lone constant — that is the dead code the flag was supposed to retire. Two safe variants:
+
+- **Collapse the branch** (default). Delete the `options.get(...)` / `features.has(...)` / `organization.features.includes(...)` condition, keep the branch that won, delete the branch that lost.
+- **Move the value into the registered default first.** Change `default=` in `defaults.py` to the rolled-out value and deploy that before step 2, then collapse the call sites. Use when the option must stay readable during a longer transition.
+
+Doing neither is the common mistake: step 2 then changes production behavior.
+
+### Sweep what the collapse orphans
+
+The losing branch is rarely the only thing that dies. Delete:
+
+- functions, components, serializers, and hooks reached only from the losing branch
+- tests for the old path, plus `with self.feature(...)` blocks and mocked responses that now assert nothing
+- fixtures, analytics events, styles, and types used only by the old path
+- feature-gated route entries and navigation items
+
+The gate for step 2 is only that **no read of the option remains**. If the sweep is large, land the collapse first and the deletions right behind it — a follow-up PR that touches no reads does not affect the ordering.
+
+## Step 2 — remove the value from the automator
+
+What removal actually falls back to:
+
+| Kind          | Falls back to                                                                                                                              | Risk if usage still exists                           |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------- |
+| Option        | registered default in `src/sentry/options/defaults.py`                                                                                     | prod reverts to the pre-rollout default              |
+| FlagPole flag | auto-registered `{}` → FlagPole abstains → `settings.SENTRY_FEATURES[name]`, i.e. the `default=` kwarg on `manager.add` (normally `False`) | **flag turns off for everyone**, not "stays at 100%" |
+
+Check every file that sets it:
+
+- Options: `options/default/<file>.yaml` **and every** `options/regions/*/<file>.yaml`. Region values clobber the default, so a leftover region entry keeps the option set there and breaks step 3.
+- Flags: only `options/default/flagpole.yaml`. There are no per-region flagpole files.
+- Watch for a `default=True` on the flag registration — that keeps it on after the YAML is gone.
+
+Merge, then confirm the deploy is green in `#feed-options-automator` before step 3.
+
+## Step 3 — remove the registration
+
+Delete the `options.register(...)` line from `defaults.py`, or the `manager.add(...)` line from `temporary.py`. For an `api_expose=True` flag this also drops it from the org serializer's `features` array, so any surviving frontend check silently evaluates false rather than erroring — which is why step 1's frontend PR must already be deployed.
+
+## Failure modes
+
+| Symptom                                                                                 | Cause                                                                                                                                    | Fix                                                                                                                                               |
+| --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `[ERROR] ... unregistered` in automator CI; `options-drift` job red on automator `main` | registration removed while values still in the automator                                                                                 | land the step-2 removal; `Trigger: Override Options Validation` unblocks an unrelated PR meanwhile, but it bypasses the gate — ask the user first |
+| Value stuck in `sentry_option` with no way to unset                                     | same inversion — `configoptions sync` only iterates _registered_ `FLAG_AUTOMATOR_MODIFIABLE` options, so nothing can ever delete the row | re-register the option, let the automator unset it, then remove the registration                                                                  |
+| Behavior flipped right after the automator PR                                           | step 2 landed before step 1 finished deploying everywhere                                                                                | revert the automator PR — `Trigger: Revert` label                                                                                                 |
+| Automator PR CI green but `main` red after merge                                        | the PR check only fails on errors _new_ vs. its base; the push-to-`main` drift job fails on any error                                    | fix the pre-existing error, or land the missing step                                                                                              |

--- a/.agents/skills/remove-option-or-flag/SOURCES.md
+++ b/.agents/skills/remove-option-or-flag/SOURCES.md
@@ -1,0 +1,27 @@
+# Sources
+
+Captured 2026-08-12.
+
+## Authoritative
+
+| Source                                                                         | Supports                                                                                                                            |
+| ------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `getsentry/sentry-options-automator` `README.md` → "Deleting an Option"        | the three-step order; `Trigger: Revert` label; automator-as-source-of-truth                                                         |
+| `src/sentry/runner/commands/configoptions.py` → `_validate_options`            | unregistered option raises `UnknownOption`, is reported and returns exit 2                                                          |
+| `src/sentry/runner/commands/configoptions.py` → `sync`                         | iterates `options.filter(FLAG_AUTOMATOR_MODIFIABLE)` only — deregistered options leave orphaned `sentry_option` rows                |
+| `src/sentry/runner/commands/configoptions.py` → `_attempt_update`              | the "set to current default, then change the default" pattern behind step 1's second variant                                        |
+| `src/sentry/features/manager.py` → `FeatureManager.add`                        | FLAGPOLE features auto-register `feature.<name>` with default `{}` and `FLAG_AUTOMATOR_MODIFIABLE`                                  |
+| `src/sentry/features/manager.py` → `FeatureManager.has`                        | fallback chain ending at `settings.SENTRY_FEATURES[name]`, set from the `default=` kwarg                                            |
+| `getsentry/sentry-options-automator` `.github/workflows/sentry-validation.yml` | PR check compares base-vs-PR errors; `options-drift` job hard-fails on push to `main`; `Trigger: Override Options Validation` label |
+| `getsentry/sentry-options-automator` repo tree                                 | `options/default/flagpole.yaml` is the only flagpole file; options are split across `options/default/` and `options/regions/*/`     |
+
+## Decisions
+
+- Single inline `SKILL.md`, no `references/` — one ordered procedure with a small failure matrix; splitting it would add lookups without adding branches.
+- Mechanism included alongside the order. The automator README states the order but not why, and the why is what prevents an agent from "optimizing" the sequence.
+- Scoped to the legacy DB-backed options path. The file-based `sentry-options` platform validates values against fetched schemas instead of the in-code registry; folding both into one skill would blur the failure matrix.
+
+## Gaps
+
+- Whether the in-cluster reconcile runs `configoptions sync` or `patch` is inferred from the README's documented unset-on-removal behavior, not read from the deployment manifest. The GoCD script (`gocd/pipelines/sentry-options.sh`) only generates and applies the ConfigMap.
+- No worked example of a real removal PR trio; the skill is procedure-only.

--- a/.agents/skills/remove-option-or-flag/SPEC.md
+++ b/.agents/skills/remove-option-or-flag/SPEC.md
@@ -1,0 +1,59 @@
+# Remove Option or Flag Specification
+
+## Intent
+
+Encode the fixed three-PR order for deleting a Sentry option or FlagPole feature flag once its rollout is finished, and the failure modes that follow from getting the order wrong. The order is not arbitrary: it is forced by `configoptions` validation, by `configoptions sync` only iterating registered options, and by what each kind falls back to when its automator value disappears.
+
+## Scope
+
+In scope:
+
+- Deleting an automator-modifiable option (`src/sentry/options/defaults.py`)
+- Deleting a FlagPole feature flag (`src/sentry/features/temporary.py`)
+- Collapsing the gated call sites and deleting the code the losing branch reached
+- Removing the corresponding values from `sentry-options-automator`
+- Diagnosing unregistered-option and drift failures caused by a wrong-order removal
+
+Out of scope:
+
+- Adding an option or flag — use the `feature-flags` skill and the automator README
+- Changing a value or rollout percentage (a single automator PR, no ordering constraint)
+- Options with `FLAG_PRIORITIZE_DISK` or without `FLAG_AUTOMATOR_MODIFIABLE` — those come from ops config
+- The newer `getsentry/sentry-options` platform (`option-values/`, schema-in-service-repo)
+
+## Users And Trigger Context
+
+- Common user requests: "remove this feature flag", "the flag is at 100%, clean it up", "delete this option", "why is the automator complaining about an unregistered option"
+- Should not trigger for: registering a new flag, adjusting a rollout, flag checks in tests, Flagr/legacy flag systems
+
+## Runtime Contract
+
+- Required first actions: confirm the option/flag is automator-managed and locate every read (sentry, getsentry, static) and every set (all automator region files)
+- Required outputs: an ordered PR plan naming which repo each PR targets and what must be deployed before the next merges
+- Non-negotiable constraints: usage removed before value; value removed before registration; deployed, not merged, gates each step; region divergence, drift, and validation-gate overrides are surfaced to the user for a decision, never resolved by the agent
+- Expected bundled files loaded at runtime: none — `SKILL.md` is self-contained
+
+## Source And Evidence Model
+
+Authoritative sources: see `SOURCES.md`. The behavioral claims are anchored in sentry source (`configoptions.py`, `features/manager.py`) and automator CI config, not in prose docs, because the prose docs state the order without the mechanism.
+
+Data that must not be stored:
+
+- Region directory names that identify single-tenant customers
+- Option values containing credentials
+
+## Validation
+
+- Lightweight: the ordering table and failure matrix match `src/sentry/runner/commands/configoptions.py` (`_validate_options`, `sync`) and `src/sentry/features/manager.py` (`add`)
+- Deeper: a real removal lands with a green automator run and no `[DRIFT]`/unregistered entries in `#feed-options-automator`
+
+## Known Limitations
+
+- Covers the legacy DB-backed options path only; the file-based `sentry-options` platform has a different validation surface
+- Automator file layout (`options/default/`, `options/regions/`) is verified against `main` as of 2026-08-12 and is not machine-checked here
+- Cannot verify deploy completion; the agent must confirm rollout externally
+
+## Maintenance Notes
+
+- Update `SKILL.md` when `configoptions` validation semantics change, when per-region flagpole files appear, or when the automator adds/renames revert or override labels
+- Update `SOURCES.md` when a cited file moves or its behavior changes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,7 @@ Skills under `.agents/skills/` should follow the same current-practice conventio
 
 ## Feature Flags (FlagPole)
 
-New features should be gated behind a flag: register in `src/sentry/features/temporary.py`, check with `features.has(...)` (Python) or `organization.features.includes(...)` (frontend). For the full workflow (registration, `api_expose`, tests, rollout) → use the **`feature-flags`** skill, or see https://develop.sentry.dev/feature-flags/.
+New features should be gated behind a flag: register in `src/sentry/features/temporary.py`, check with `features.has(...)` (Python) or `organization.features.includes(...)` (frontend). For the full workflow (registration, `api_expose`, tests, rollout) → use the **`feature-flags`** skill, or see https://develop.sentry.dev/feature-flags/. Deleting a finished flag or option requires a fixed PR order across sentry and sentry-options-automator → use the **`remove-option-or-flag`** skill.
 
 ## Customer Information
 


### PR DESCRIPTION
Adds a skill for deleting a Sentry option or FlagPole feature flag once its rollout is finished.

## Why

The [automator README](https://github.com/getsentry/sentry-options-automator#deleting-an-option) documents the three-step order but not the mechanism behind it, so the sequence reads as arbitrary — and an agent (or a person in a hurry) reorders it. The mechanisms are concrete:

- `configoptions validate` raises `UnknownOption` for a value whose option is no longer registered. The automator's `options-drift` job hard-fails on push to `main`, so the wrong order turns the automator red for everyone, not just the person doing the removal.
- `configoptions sync` iterates `options.filter(FLAG_AUTOMATOR_MODIFIABLE)` — registered options only. Deregistering before unsetting strands the `sentry_option` row with nothing able to delete it.

## What it covers

- The three-PR order (collapse call sites → remove automator value → remove registration), with what must be **deployed**, not merely merged, before each step.
- What removing the automator value actually falls back to, which differs by kind: an option reverts to its registered default; a FlagPole flag falls through the auto-registered `{}` to its `default=` kwarg, which turns a fully rolled-out feature **off for everyone**. This is the one most likely to cause an incident.
- Why flags follow the same path at all: `FeatureManager.add` auto-registers `feature.<name>` with `FLAG_AUTOMATOR_MODIFIABLE`, so flags travel the identical `configoptions` route as options.
- The dead-code sweep the branch collapse creates, and the fact that it can be a follow-up PR — the ordering gate is only that no read of the option remains.
- A failure-mode matrix for diagnosing a removal that already went wrong.

## Notes for reviewers

- **Stop-and-ask conditions.** Region divergence, `[DRIFT]`, and the `Trigger: Override Options Validation` label are framed as decisions to surface to the user, not steps for an agent to resolve. Each has a cause worth understanding before anything is deleted.
- **Scope.** Legacy DB-backed options only. The newer file-based `sentry-options` platform validates values against fetched schemas rather than the in-code registry, so its failure modes differ — declared out of scope in `SPEC.md` rather than half-covered.
- **One inferred claim**, recorded as a gap in `SOURCES.md`: whether the in-cluster reconcile runs `configoptions sync` or `patch`. The behavior is documented (removal unsets), and only `sync` provides it, but the GoCD script only generates and applies the ConfigMap, so I could not read it directly. Correct me if you know.
- Docs only. `AGENTS.md` and the `feature-flags` skill get a one-line pointer each for discoverability, matching how the other skills are referenced.
