### PR TITLE
fix(hybridcloud): Size the lease drain lock against a single delivery

### DIFF
--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -152,11 +152,28 @@ class DeliveryDropped(Exception):
 
 DRAIN_LOCK_TTL = 15
 """
-Seconds the drain lock survives without a refresh.
+Seconds the claim guard survives without a refresh.
 
-In claim mode the lock only guards the claim itself, so the TTL is crash cover;
-in lease mode the push-triggered drain holds it for its whole run, refreshing per
-delivery, so the TTL bounds how long a dead drain blocks its mailbox.
+Claim-mode dispatchers hold the lock only across the claim and release it before
+returning, so this TTL is crash cover: it bounds how long a dispatcher that died
+mid-claim keeps other dispatchers off its mailbox.
+"""
+
+
+LEASE_DRAIN_LOCK_TTL = 2 * CellSiloClient.timeout + DRAIN_LOCK_TTL
+"""
+Seconds a lease-mode drain's lock survives without a refresh.
+
+A lease drain owns the lock for its whole run and refreshes it once per record,
+immediately before delivering it, so the widest gap between refreshes is a single
+delivery — which the cell client bounds at its connect timeout plus its read
+timeout. Below that, the lock expires under a running drain: the scheduler stops
+skipping the mailbox, claims it, and dispatches a second drain over the same
+records. DRAIN_LOCK_TTL is added on top to cover the trigger-to-first-refresh gap,
+where the task waits in the queue and nothing refreshes yet.
+
+Only lease mode needs this. It goes away with the lease path once
+claim_dispatch_rollout reaches 1.0.
 """
 
 
@@ -165,9 +182,12 @@ def _drain_lock_key(mailbox_name: str) -> str:
 
 
 def _refresh_drain_lock(mailbox_name: str) -> None:
-    """Refresh the drain lock TTL to signal the drain task is still active."""
+    """Refresh the drain lock TTL to signal the drain task is still active.
+
+    Only lease-mode drains refresh, so this always writes the lease TTL.
+    """
     try:
-        cache.set(_drain_lock_key(mailbox_name), 1, timeout=DRAIN_LOCK_TTL)
+        cache.set(_drain_lock_key(mailbox_name), 1, timeout=LEASE_DRAIN_LOCK_TTL)
     except Exception:
         pass
 
@@ -341,7 +361,9 @@ def _maybe_trigger_drain_lease(mailbox_name: str) -> None:
     trigger_tags = {"provider": _provider_from_mailbox(mailbox_name)}
     lock_acquired = False
     try:
-        if cache.add(lock_key, 1, timeout=DRAIN_LOCK_TTL):
+        # The drain this dispatches inherits the lock and only starts refreshing
+        # once it is picked up, so the lease TTL has to hold from here.
+        if cache.add(lock_key, 1, timeout=LEASE_DRAIN_LOCK_TTL):
             lock_acquired = True
             # Only drain if the true mailbox head (lowest ID) is ready to deliver.
             # We must check the head specifically — filtering by schedule_for first

--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -152,11 +152,8 @@ class DeliveryDropped(Exception):
 
 DRAIN_LOCK_TTL = 15
 """
-Seconds the claim guard survives without a refresh.
-
-Claim-mode dispatchers hold the lock only across the claim and release it before
-returning, so this TTL is crash cover: it bounds how long a dispatcher that died
-mid-claim keeps other dispatchers off its mailbox.
+Seconds the claim guard survives without a refresh. Claim-mode dispatchers release
+it before returning, so this is crash cover for one that died mid-claim.
 """
 
 
@@ -164,16 +161,10 @@ LEASE_DRAIN_LOCK_TTL = 2 * CellSiloClient.timeout + DRAIN_LOCK_TTL
 """
 Seconds a lease-mode drain's lock survives without a refresh.
 
-A lease drain owns the lock for its whole run and refreshes it once per record,
-immediately before delivering it, so the widest gap between refreshes is a single
-delivery — which the cell client bounds at its connect timeout plus its read
-timeout. Below that, the lock expires under a running drain: the scheduler stops
-skipping the mailbox, claims it, and dispatches a second drain over the same
-records. DRAIN_LOCK_TTL is added on top to cover the trigger-to-first-refresh gap,
-where the task waits in the queue and nothing refreshes yet.
-
-Only lease mode needs this. It goes away with the lease path once
-claim_dispatch_rollout reaches 1.0.
+A lease drain refreshes once per record, right before delivering it, so the widest
+gap between refreshes is one delivery — bounded by the cell client's connect plus
+read timeout, plus the queue wait before the first refresh. Under that, the lock
+expires mid-drain and the scheduler dispatches a second drain over the same records.
 """
 
 
@@ -184,7 +175,7 @@ def _drain_lock_key(mailbox_name: str) -> str:
 def _refresh_drain_lock(mailbox_name: str) -> None:
     """Refresh the drain lock TTL to signal the drain task is still active.
 
-    Only lease-mode drains refresh, so this always writes the lease TTL.
+    Only lease-mode drains refresh.
     """
     try:
         cache.set(_drain_lock_key(mailbox_name), 1, timeout=LEASE_DRAIN_LOCK_TTL)
@@ -361,8 +352,7 @@ def _maybe_trigger_drain_lease(mailbox_name: str) -> None:
     trigger_tags = {"provider": _provider_from_mailbox(mailbox_name)}
     lock_acquired = False
     try:
-        # The drain this dispatches inherits the lock and only starts refreshing
-        # once it is picked up, so the lease TTL has to hold from here.
+        # The dispatched drain inherits this lock and only refreshes once picked up.
         if cache.add(lock_key, 1, timeout=LEASE_DRAIN_LOCK_TTL):
             lock_acquired = True
             # Only drain if the true mailbox head (lowest ID) is ready to deliver.

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -1868,10 +1868,8 @@ class PushTriggerTest(TestCase):
             deliver_webhooks._refresh_drain_lock(webhook.mailbox_name)
         refresh_ttl = mock_set.call_args.kwargs["timeout"]
 
-        # A lease drain refreshes once per record, right before delivering it, so
-        # both the TTL it inherits from the trigger and the one it writes have to
-        # outlast a single delivery — the cell client's connect plus read timeout.
-        # Below that the lock expires mid-drain and the scheduler dispatches a
+        # Both the TTL the drain inherits and the one it writes must outlast a single
+        # delivery, or the lock expires mid-drain and the scheduler dispatches a
         # second drain over the same records.
         assert trigger_ttl > 2 * CellSiloClient.timeout
         assert refresh_ttl > 2 * CellSiloClient.timeout
@@ -1884,9 +1882,8 @@ class PushTriggerTest(TestCase):
         with patch.object(cache, "add", wraps=cache.add) as mock_add:
             maybe_trigger_drain(webhook.mailbox_name)
 
-        # Claim mode releases the lock before returning, so its TTL is only crash
-        # cover. Sizing it for a delivery would strand the mailbox for that long
-        # whenever a dispatcher dies mid-claim.
+        # Claim mode releases the lock before returning. Sizing its TTL for a delivery
+        # would strand the mailbox that long whenever a dispatcher dies mid-claim.
         assert mock_add.call_args.kwargs["timeout"] == DRAIN_LOCK_TTL
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -15,6 +15,7 @@ from sentry import options
 from sentry.hybridcloud.models.webhookpayload import MAX_ATTEMPTS, WebhookPayload
 from sentry.hybridcloud.tasks import deliver_webhooks
 from sentry.hybridcloud.tasks.deliver_webhooks import (
+    DRAIN_LOCK_TTL,
     MAX_MAILBOX_DRAIN,
     PARALLEL_DRAIN_THRESHOLD,
     SLOW_DELIVERY_THRESHOLD,
@@ -25,6 +26,7 @@ from sentry.hybridcloud.tasks.deliver_webhooks import (
     maybe_trigger_drain,
     schedule_webhook_delivery,
 )
+from sentry.silo.client import CellSiloClient
 from sentry.testutils.cases import TestCase
 from sentry.testutils.cell import override_cells
 from sentry.testutils.factories import Factories
@@ -1852,6 +1854,40 @@ class PushTriggerTest(TestCase):
         # No claim in lease mode: the batch stays due for the scheduler's view.
         webhook.refresh_from_db()
         assert webhook.schedule_for < timezone.now()
+
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    @override_options({"hybridcloud.webhookpayload.push_drain_trigger": True})
+    def test_lease_lock_outlives_a_single_delivery(self, mock_drain: MagicMock) -> None:
+        webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
+
+        with patch.object(cache, "add", wraps=cache.add) as mock_add:
+            maybe_trigger_drain(webhook.mailbox_name)
+        trigger_ttl = mock_add.call_args.kwargs["timeout"]
+
+        with patch.object(cache, "set", wraps=cache.set) as mock_set:
+            deliver_webhooks._refresh_drain_lock(webhook.mailbox_name)
+        refresh_ttl = mock_set.call_args.kwargs["timeout"]
+
+        # A lease drain refreshes once per record, right before delivering it, so
+        # both the TTL it inherits from the trigger and the one it writes have to
+        # outlast a single delivery — the cell client's connect plus read timeout.
+        # Below that the lock expires mid-drain and the scheduler dispatches a
+        # second drain over the same records.
+        assert trigger_ttl > 2 * CellSiloClient.timeout
+        assert refresh_ttl > 2 * CellSiloClient.timeout
+
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    @override_options(CLAIM_MODE_OPTIONS)
+    def test_claim_guard_keeps_the_short_ttl(self, mock_drain: MagicMock) -> None:
+        webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
+
+        with patch.object(cache, "add", wraps=cache.add) as mock_add:
+            maybe_trigger_drain(webhook.mailbox_name)
+
+        # Claim mode releases the lock before returning, so its TTL is only crash
+        # cover. Sizing it for a delivery would strand the mailbox for that long
+        # whenever a dispatcher dies mid-claim.
+        assert mock_add.call_args.kwargs["timeout"] == DRAIN_LOCK_TTL
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
     @override_options({"hybridcloud.webhookpayload.push_drain_trigger": True})


### PR DESCRIPTION
`DRAIN_LOCK_TTL` is 15s, but a delivery is bounded by `CellSiloClient`'s inherited `timeout = 30`, [applied to both the connect and the read](<https://github.com/getsentry/sentry/blob/master/src/sentry/shared_integrations/client/base.py#L62-L64>) and not overridden in `perform_cell_request` — so \~60s against a 15s lock.

A lease-mode drain owns the lock for its whole run and refreshes it once per record, right before delivering it. Any delivery slower than the TTL expires the lock mid-drain: the scheduler stops skipping the mailbox, claims it, and dispatches a second drain, while the first is unbounded (`claimed_count=None`) and keeps walking the same records. Duplicate deliveries, and broken ordering for providers outside `skip_on_failure_providers`. The trigger's `cache.add` needs the same TTL — the drain inherits that lock and doesn't refresh until a worker picks the task up.

Raising the shared constant isn't right: getsentry/sentry#121221 gave it a second job as the millisecond-scale claim guard, released in a `finally`, which the scheduler also skips on. At 75s a dispatcher dying mid-claim would strand its mailbox that long. So the claim guard keeps 15s and the lease lock gets its own constant, each pinned by a test.

Only lease-mode mailboxes are affected — all of them today, since `claim_dispatch_rollout` is `0.0` — and the constant goes away with the lease path once that reaches 1.0. No option gate: this is a TTL that was too small for the code depending on it.

Extracted from getsentry/sentry#121082, otherwise superseded by getsentry/sentry#121221 and now closed; this was the one piece the claim-dispatch work didn't absorb.

Part of [CW-1830](https://linear.app/getsentry/issue/CW-1830)