### PR TITLE
feat(navigation): relocate settings access into the org dropdown

### DIFF
--- a/static/app/components/dropdownMenu/index.tsx
+++ b/static/app/components/dropdownMenu/index.tsx
@@ -48,6 +48,30 @@ function removeHiddenItemsAndSetHref(source: MenuItemProps[]): MenuItemProps[] {
 }
 
 /**
+ * Combines an explicit `maxMenuHeight` with the height the overlay actually has
+ * room for, which popper derives from the distance to its boundary.
+ *
+ * These have to be combined rather than one replacing the other: an explicit cap
+ * that exceeds the available space renders the menu past the edge of the screen,
+ * putting anything pinned to its bottom — a footer — out of view.
+ *
+ * Popper's value is ignored when it is not a positive number, which is the case
+ * before it has measured anything.
+ */
+function resolveMaxHeight(
+  maxMenuHeight: number | undefined,
+  availableMaxHeight: React.CSSProperties['maxHeight']
+): React.CSSProperties['maxHeight'] {
+  if (maxMenuHeight === undefined) {
+    return availableMaxHeight;
+  }
+
+  return typeof availableMaxHeight === 'number' && availableMaxHeight > 0
+    ? Math.min(maxMenuHeight, availableMaxHeight)
+    : maxMenuHeight;
+}
+
+/**
  * Recursively finds and returns disabled items
  */
 function getDisabledKeys(source: MenuItemProps[]): Array<MenuItemProps['key']> {
@@ -269,7 +293,7 @@ function DropdownMenu({
           style: {
             ...overlayProps.style,
             minWidth: minMenuWidth ?? overlayProps.style?.minWidth,
-            maxHeight: maxMenuHeight ?? overlayProps.style?.maxHeight,
+            maxHeight: resolveMaxHeight(maxMenuHeight, overlayProps.style?.maxHeight),
           },
         }}
         overlayState={overlayState}

--- a/static/app/components/dropdownMenu/index.tsx
+++ b/static/app/components/dropdownMenu/index.tsx
@@ -103,10 +103,6 @@ export interface DropdownMenuProps
    */
   isDisabled?: boolean;
   /**
-   * Maximum menu width
-   */
-  maxMenuHeight?: number;
-  /**
    * Title for the current menu.
    */
   menuTitle?: React.ReactNode;
@@ -266,6 +262,7 @@ function DropdownMenu({
         {...props}
         {...resolvedMenuProps}
         size={size}
+        maxMenuHeight={maxMenuHeight}
         disabledKeys={disabledKeys ?? defaultDisabledKeys}
         overlayPositionProps={{
           ...overlayProps,

--- a/static/app/components/dropdownMenu/item.tsx
+++ b/static/app/components/dropdownMenu/item.tsx
@@ -60,8 +60,12 @@ export interface MenuItemProps extends MenuListItemProps {
    * `children` is also defined). Pass `true` for the defaults, or an object to
    * customize the sub-menu: `title` is shown as its header, and `position`
    * overrides where it opens relative to this item (defaults to `right-start`).
+   *
+   * `title` may be any node, so it can hold interactive content such as a
+   * search field. It renders outside the menu's `ul`, so keystrokes there are
+   * not intercepted by the menu's typeahead and arrow-key handling.
    */
-  submenu?: boolean | {position?: UseOverlayProps['position']; title?: string};
+  submenu?: boolean | {position?: UseOverlayProps['position']; title?: React.ReactNode};
   /**
    * A plain text version of the `label` prop if the label is not a string. Used for
    * filtering and keyboard select (quick-focusing on options by typing the first letter).

--- a/static/app/components/dropdownMenu/item.tsx
+++ b/static/app/components/dropdownMenu/item.tsx
@@ -58,14 +58,22 @@ export interface MenuItemProps extends MenuListItemProps {
   /**
    * Renders this item as a trigger for a nested sub-menu (only works when
    * `children` is also defined). Pass `true` for the defaults, or an object to
-   * customize the sub-menu: `title` is shown as its header, and `position`
-   * overrides where it opens relative to this item (defaults to `right-start`).
+   * customize the sub-menu: `title` is shown as its header, `footer` is pinned
+   * below the items, and `position` overrides where it opens relative to this
+   * item (defaults to `right-start`).
    *
-   * `title` may be any node, so it can hold interactive content such as a
-   * search field. It renders outside the menu's `ul`, so keystrokes there are
+   * `title` and `footer` may be any node, so they can hold interactive content
+   * such as a search field or a call to action. Both render outside the menu's
+   * `ul`, so they stay put while a long list scrolls, and keystrokes in them are
    * not intercepted by the menu's typeahead and arrow-key handling.
    */
-  submenu?: boolean | {position?: UseOverlayProps['position']; title?: React.ReactNode};
+  submenu?:
+    | boolean
+    | {
+        footer?: React.ReactNode;
+        position?: UseOverlayProps['position'];
+        title?: React.ReactNode;
+      };
   /**
    * A plain text version of the `label` prop if the label is not a string. Used for
    * filtering and keyboard select (quick-focusing on options by typing the first letter).

--- a/static/app/components/dropdownMenu/list.tsx
+++ b/static/app/components/dropdownMenu/list.tsx
@@ -63,6 +63,11 @@ export interface DropdownMenuListProps
    */
   disableTextSelection?: boolean;
   /**
+   * Maximum menu height, in pixels. Inherited by any submenus so that a long
+   * list of items scrolls rather than running off the screen.
+   */
+  maxMenuHeight?: number;
+  /**
    * To be displayed below the menu items
    */
   menuFooter?: React.ReactNode;
@@ -83,6 +88,7 @@ export function DropdownMenuList({
   closeOnSelect = true,
   onClose,
   size,
+  maxMenuHeight,
   menuTitle,
   menuFooter,
   disableTextSelection,
@@ -202,6 +208,7 @@ export function DropdownMenuList({
         position={submenuOptions.position ?? 'right-start'}
         offset={-4}
         size={size}
+        maxMenuHeight={maxMenuHeight}
       />
     );
   };
@@ -250,7 +257,7 @@ export function DropdownMenuList({
         {...overlayPositionProps}
       >
         <DropdownMenuContext value={contextValue}>
-          <StyledOverlay>
+          <StyledOverlay style={{maxHeight: overlayPositionProps.style?.maxHeight}}>
             {menuTitle && <MenuTitle>{menuTitle}</MenuTitle>}
             <DropdownMenuListWrap
               ref={menuRef}
@@ -258,7 +265,10 @@ export function DropdownMenuList({
               disableTextSelection={disableTextSelection}
               {...mergeProps(modifiedMenuProps, keyboardProps)}
               style={{
-                maxHeight: overlayPositionProps.style?.maxHeight,
+                // The overlay above is already capped, so the list only needs to
+                // shrink within it — a hard maxHeight here would let the list
+                // claim the full cap and push a title/footer past it.
+                minHeight: 0,
               }}
             >
               {renderCollection(stateCollection)}
@@ -314,6 +324,13 @@ const MenuTitle = styled('div')`
   color: ${p => p.theme.tokens.content.primary};
   white-space: nowrap;
   padding: ${p => p.theme.space.sm} ${p => p.theme.space.lg};
+
+  /* Titles are usually a short string, but may hold interactive content such as
+  a search field, which needs the full width to lay out. */
+  &:has(input) {
+    white-space: normal;
+    padding: ${p => p.theme.space.xs};
+  }
   /* eslint-disable-next-line @sentry/scraps/use-semantic-token */
   box-shadow: 0 1px 0 0 ${p => p.theme.tokens.border.transparent.neutral.muted};
   z-index: 2;

--- a/static/app/components/dropdownMenu/list.tsx
+++ b/static/app/components/dropdownMenu/list.tsx
@@ -202,6 +202,7 @@ export function DropdownMenuList({
         closeOnSelect={closeOnSelect}
         disableTextSelection={disableTextSelection}
         menuTitle={submenuOptions.title}
+        menuFooter={submenuOptions.footer}
         shouldCloseOnBlur={false}
         preventOverflowOptions={{boundary: document.body, altAxis: true}}
         renderWrapAs="li"
@@ -264,16 +265,10 @@ export function DropdownMenuList({
               hasTitle={!!menuTitle}
               disableTextSelection={disableTextSelection}
               {...mergeProps(modifiedMenuProps, keyboardProps)}
-              style={{
-                // The overlay above is already capped, so the list only needs to
-                // shrink within it — a hard maxHeight here would let the list
-                // claim the full cap and push a title/footer past it.
-                minHeight: 0,
-              }}
             >
               {renderCollection(stateCollection)}
             </DropdownMenuListWrap>
-            {menuFooter}
+            {menuFooter && <MenuFooter>{menuFooter}</MenuFooter>}
           </StyledOverlay>
         </DropdownMenuContext>
       </PositionWrapper>
@@ -295,6 +290,13 @@ const DropdownMenuListWrap = styled('ul')<{
   font-size: ${p => p.theme.font.size.md};
   overflow-x: hidden;
   overflow-y: auto;
+
+  /* The overlay carries the height cap, so the list scrolls inside whatever space
+  is left over once a title and footer have taken theirs. Without min-height a
+  flex item refuses to shrink below its content, which would push the footer out
+  of the overlay. */
+  flex: 1 1 auto;
+  min-height: 0;
 
   ${p =>
     p.disableTextSelection &&
@@ -333,6 +335,18 @@ const MenuTitle = styled('div')`
   }
   /* eslint-disable-next-line @sentry/scraps/use-semantic-token */
   box-shadow: 0 1px 0 0 ${p => p.theme.tokens.border.transparent.neutral.muted};
+  z-index: 2;
+`;
+
+/**
+ * Sits outside the scrolling list, so footer actions stay reachable no matter how
+ * many items there are.
+ */
+const MenuFooter = styled('div')`
+  flex-shrink: 0;
+  /* eslint-disable-next-line @sentry/scraps/use-semantic-token */
+  box-shadow: 0 -1px 0 0 ${p => p.theme.tokens.border.transparent.neutral.muted};
+  padding: ${p => p.theme.space.md} ${p => p.theme.space.lg};
   z-index: 2;
 `;
 

--- a/static/app/views/navigation/index.desktop.spec.tsx
+++ b/static/app/views/navigation/index.desktop.spec.tsx
@@ -206,19 +206,19 @@ describe('desktop navigation', () => {
       const primaryNav = screen.getByRole('navigation', {name: 'Primary Navigation'});
       const links = within(primaryNav).getAllByRole('link');
 
-      expect(links).toHaveLength(6);
+      // Settings has moved into the organization dropdown, so it is no longer a
+      // primary navigation link.
+      expect(links).toHaveLength(5);
       expect(links[0]).toHaveAccessibleName('Issues');
       expect(links[1]).toHaveAccessibleName('Explore');
       expect(links[2]).toHaveAccessibleName('Dashboards');
       expect(links[3]).toHaveAccessibleName('Insights');
       expect(links[4]).toHaveAccessibleName('Monitors');
-      expect(links[5]).toHaveAccessibleName('Settings');
 
       expect(links[0]).toHaveAttribute('href', '/organizations/org-slug/issues/');
       expect(links[2]).toHaveAttribute('href', '/organizations/org-slug/dashboards/');
       expect(links[3]).toHaveAttribute('href', '/organizations/org-slug/insights/');
       expect(links[4]).toHaveAttribute('href', '/organizations/org-slug/monitors/');
-      expect(links[5]).toHaveAttribute('href', '/settings/org-slug/');
     });
 
     it('hides Insights nav item when insights-to-dashboards-ui-rollout is enabled', () => {
@@ -305,7 +305,8 @@ describe('desktop navigation', () => {
     describe('route inference', () => {
       async function assertNavStructureAndActiveLinksForRoute(
         pathname: string,
-        activePrimaryLink: string,
+        // `null` for routes with no corresponding primary nav item, e.g. settings
+        activePrimaryLink: string | null,
         activeSecondaryLink: string,
         route?: string
       ) {
@@ -320,9 +321,11 @@ describe('desktop navigation', () => {
         );
 
         const primaryNav = screen.getByRole('navigation', {name: 'Primary Navigation'});
-        assertActivePrimaryNavLink(
-          within(primaryNav).getByRole('link', {name: activePrimaryLink})
-        );
+        if (activePrimaryLink !== null) {
+          assertActivePrimaryNavLink(
+            within(primaryNav).getByRole('link', {name: activePrimaryLink})
+          );
+        }
 
         within(primaryNav).getAllByRole('list').forEach(assertValidListHTML);
         within(primaryNav)
@@ -352,8 +355,8 @@ describe('desktop navigation', () => {
         unmount();
       }
 
-      // [pathname, primary nav label, secondary nav label, route?]
-      type RouteCase = [string, string, string, string?];
+      // [pathname, primary nav label (null if none), secondary nav label, route?]
+      type RouteCase = [string, string | null, string, string?];
 
       it('non-customer domain', async () => {
         const ORG = '/organizations/org-slug';
@@ -391,11 +394,11 @@ describe('desktop navigation', () => {
           [`${ORG}/monitors/metrics/`, 'Monitors', 'Metric'],
           [`${ORG}/monitors/crons/`, 'Monitors', 'Cron'],
           [`${ORG}/monitors/alerts/`, 'Monitors', 'Alerts'],
-          // Settings
-          ['/settings/org-slug/', 'Settings', 'General Settings'],
+          // Settings (no primary nav item — reached via the org dropdown)
+          ['/settings/org-slug/', null, 'General Settings'],
           [
             '/settings/org-slug/projects/project-slug/teams/',
-            'Settings',
+            null,
             'Project Teams',
             '/settings/:orgId/projects/:projectId/teams/',
           ],
@@ -484,11 +487,11 @@ describe('desktop navigation', () => {
           // Monitors
           ['/monitors/', 'Monitors', 'All Monitors'],
           ['/monitors/my-monitors/', 'Monitors', 'My Monitors'],
-          // Settings
-          ['/settings/organization/', 'Settings', 'General Settings'],
+          // Settings (no primary nav item — reached via the org dropdown)
+          ['/settings/organization/', null, 'General Settings'],
           [
             '/settings/projects/project-slug/',
-            'Settings',
+            null,
             'General Settings',
             '/settings/projects/:projectId/',
           ],

--- a/static/app/views/navigation/index.mobile.spec.tsx
+++ b/static/app/views/navigation/index.mobile.spec.tsx
@@ -177,9 +177,7 @@ describe('mobile navigation', () => {
 
     // The org dropdown menu is portaled to document.body, so clicking it
     // triggers click-outside on the nav panel. The nav should stay open.
-    await userEvent.click(
-      await screen.findByRole('menuitemradio', {name: 'Organization Settings'})
-    );
+    await userEvent.click(await screen.findByRole('menuitemradio', {name: 'Settings'}));
 
     expect(
       screen.getByRole('navigation', {name: 'Primary Navigation'})

--- a/static/app/views/navigation/navigation.tsx
+++ b/static/app/views/navigation/navigation.tsx
@@ -14,7 +14,7 @@ import {
   IconDashboard,
   IconGraph,
   IconIssues,
-  IconSettings,
+  // IconSettings, // Prototype: restore with the settings nav item below
   IconSiren,
 } from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -259,27 +259,32 @@ export function PrimaryNavigationItems({listRef}: PrimaryNavigationItemsProps) {
         </PrimaryNavigation.Link>
       </PrimaryNavigation.ListItem>
 
-      <NavigationTourElement id={NavigationTour.SETTINGS} title={null} description={null}>
-        {tourProps => (
-          <PrimaryNavigation.ListItem>
-            <PrimaryNavigation.Link
-              to={`/settings/${organization.slug}/`}
-              analyticsKey="settings"
-              label={t('Settings')}
-              {...mergeProps(
-                makeNavigationItemProps(
-                  'settings',
-                  `/settings/${organization.slug}/`,
-                  '/settings/'
-                ),
-                tourProps
-              )}
-            >
-              <IconSettings />
-            </PrimaryNavigation.Link>
-          </PrimaryNavigation.ListItem>
-        )}
-      </NavigationTourElement>
+      {/*
+       * Prototype: settings now live in the organization dropdown, so this
+       * primary nav entry point is temporarily removed.
+       *
+       * <NavigationTourElement id={NavigationTour.SETTINGS} title={null} description={null}>
+       *   {tourProps => (
+       *     <PrimaryNavigation.ListItem>
+       *       <PrimaryNavigation.Link
+       *         to={`/settings/${organization.slug}/`}
+       *         analyticsKey="settings"
+       *         label={t('Settings')}
+       *         {...mergeProps(
+       *           makeNavigationItemProps(
+       *             'settings',
+       *             `/settings/${organization.slug}/`,
+       *             '/settings/'
+       *           ),
+       *           tourProps
+       *         )}
+       *       >
+       *         <IconSettings />
+       *       </PrimaryNavigation.Link>
+       *     </PrimaryNavigation.ListItem>
+       *   )}
+       * </NavigationTourElement>
+       */}
     </Fragment>
   );
 }

--- a/static/app/views/navigation/primary/organizationDropdown.spec.tsx
+++ b/static/app/views/navigation/primary/organizationDropdown.spec.tsx
@@ -1,12 +1,12 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
 import {UserFixture} from 'sentry-fixture/user';
 
 import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
-import {CUSTOM_REFERRER_KEY} from 'sentry/constants';
 import {ConfigStore} from 'sentry/stores/configStore';
 import {OrganizationsStore} from 'sentry/stores/organizationsStore';
-import {readStorageValue} from 'sentry/utils/useSessionStorage';
+import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {OrganizationDropdown} from 'sentry/views/navigation/primary/organizationDropdown';
 
 describe('OrganizationDropdown', () => {
@@ -16,6 +16,7 @@ describe('OrganizationDropdown', () => {
 
   beforeEach(() => {
     ConfigStore.set('user', UserFixture());
+    ProjectsStore.reset();
   });
 
   it('displays org info and links', async () => {
@@ -26,17 +27,14 @@ describe('OrganizationDropdown', () => {
     expect(screen.getByText('Organization Name')).toBeInTheDocument();
     expect(screen.getByText('0 Projects')).toBeInTheDocument();
 
+    expect(screen.getByRole('menuitemradio', {name: 'Settings'})).toHaveAttribute(
+      'href',
+      `/settings/${organization.slug}/`
+    );
     expect(
-      screen.getByRole('menuitemradio', {name: 'Organization Settings'})
-    ).toHaveAttribute('href', `/settings/${organization.slug}/`);
-    expect(screen.getByRole('menuitemradio', {name: 'Members'})).toHaveAttribute(
-      'href',
-      `/settings/${organization.slug}/members/`
-    );
-    expect(screen.getByRole('menuitemradio', {name: 'Teams'})).toHaveAttribute(
-      'href',
-      `/settings/${organization.slug}/teams/`
-    );
+      screen.getByRole('menuitemradio', {name: 'Switch Organization'})
+    ).toBeInTheDocument();
+    expect(screen.getByRole('menuitemradio', {name: 'All Projects'})).toBeInTheDocument();
   });
 
   it('can switch orgs', async () => {
@@ -62,7 +60,7 @@ describe('OrganizationDropdown', () => {
     );
   });
 
-  it('Shows inactive orgs in their own section', async () => {
+  it('shows inactive orgs alongside active ones', async () => {
     OrganizationsStore.addOrReplace(
       OrganizationFixture({id: '1', name: 'Org 1', slug: 'org-1'})
     );
@@ -74,46 +72,187 @@ describe('OrganizationDropdown', () => {
         status: {id: 'pending_deletion', name: 'pending deletion'},
       })
     );
-    OrganizationsStore.addOrReplace(
-      OrganizationFixture({
-        id: '3',
-        name: 'Disabled org',
-        slug: 'org-3',
-        status: {id: 'disabled', name: 'disabled'},
-      })
-    );
 
     render(<OrganizationDropdown />, {organization});
 
     await userEvent.click(screen.getByRole('button', {name: 'Toggle organization menu'}));
     await userEvent.hover(screen.getByText('Switch Organization'));
 
-    const separator = await screen.findByRole('separator');
-    expect(separator).toBeInTheDocument();
-
-    const inactiveGroup = separator.nextElementSibling?.firstElementChild;
-    if (!(inactiveGroup instanceof HTMLElement)) {
-      throw new Error('Expected group of inactive organizations');
-    }
-
-    expect(inactiveGroup).toHaveRole('group');
+    expect(await screen.findByRole('menuitemradio', {name: /Org 1/})).toBeInTheDocument();
     expect(
-      within(inactiveGroup).getByRole('menuitemradio', {name: /Disabled org/})
-    ).toBeInTheDocument();
-    expect(
-      within(inactiveGroup).getByRole('menuitemradio', {name: /Deleting org/})
+      await screen.findByRole('menuitemradio', {name: /Deleting org/})
     ).toBeInTheDocument();
   });
 
-  it('clicking project sets referrer in session storage', async () => {
+  it('lists every project when there are only a few, starred or not', async () => {
+    ProjectsStore.loadInitialData([
+      ProjectFixture({id: '1', slug: 'plain-project', isBookmarked: false}),
+      ProjectFixture({id: '2', slug: 'other-project', isBookmarked: false}),
+    ]);
+
     render(<OrganizationDropdown />, {organization});
     await userEvent.click(screen.getByRole('button', {name: 'Toggle organization menu'}));
-    // We use onAction to navigationigate, no href is set:
-    expect(screen.getByRole('menuitemradio', {name: 'Projects'})).not.toHaveAttribute(
-      'href'
+
+    // Nothing is starred, but the section is still useful
+    expect(screen.getByRole('menuitemradio', {name: 'plain-project'})).toHaveAttribute(
+      'href',
+      `/settings/${organization.slug}/projects/plain-project/`
     );
-    // onClick should take precedence setting session storage value and navigationigating:
-    await userEvent.click(screen.getByRole('menuitemradio', {name: 'Projects'}));
-    expect(readStorageValue(CUSTOM_REFERRER_KEY, null)).toBe('org-dropdown');
+    expect(
+      screen.getByRole('menuitemradio', {name: 'other-project'})
+    ).toBeInTheDocument();
+    expect(screen.getByText('Project Settings')).toBeInTheDocument();
+
+    // Every project is already listed, so this links out rather than opening a
+    // submenu that would repeat them
+    expect(screen.getByRole('menuitemradio', {name: /All Projects/})).toHaveAttribute(
+      'href',
+      `/settings/${organization.slug}/projects/`
+    );
+  });
+
+  it('narrows to starred projects once there are many', async () => {
+    ProjectsStore.loadInitialData([
+      ProjectFixture({id: '1', slug: 'starred-project', isBookmarked: true}),
+      ...Array.from({length: 8}, (_, i) =>
+        ProjectFixture({id: `${i + 2}`, slug: `plain-project-${i + 1}`})
+      ),
+    ]);
+
+    render(<OrganizationDropdown />, {organization});
+    await userEvent.click(screen.getByRole('button', {name: 'Toggle organization menu'}));
+
+    expect(screen.getByText('Starred Projects')).toBeInTheDocument();
+    expect(
+      screen.getByRole('menuitemradio', {name: 'starred-project'})
+    ).toBeInTheDocument();
+    // Non-starred projects are only reachable through the submenu
+    expect(
+      screen.queryByRole('menuitemradio', {name: 'plain-project-1'})
+    ).not.toBeInTheDocument();
+
+    await userEvent.hover(screen.getByText('All Projects'));
+
+    expect(
+      await screen.findByRole('menuitemradio', {name: /plain-project-1/})
+    ).toBeInTheDocument();
+  });
+
+  it('shows the project count on the All Projects row', async () => {
+    ProjectsStore.loadInitialData(
+      Array.from({length: 12}, (_, i) =>
+        ProjectFixture({id: `${i + 1}`, slug: `project-${i + 1}`})
+      )
+    );
+
+    render(<OrganizationDropdown />, {organization});
+    await userEvent.click(screen.getByRole('button', {name: 'Toggle organization menu'}));
+
+    const row = screen.getByRole('menuitemradio', {name: /All Projects/});
+    expect(within(row).getByText('12')).toBeInTheDocument();
+  });
+
+  it('caps the height of the menu and its submenus', async () => {
+    ProjectsStore.loadInitialData(
+      Array.from({length: 12}, (_, i) =>
+        ProjectFixture({id: `${i + 1}`, slug: `project-${i + 1}`})
+      )
+    );
+
+    render(<OrganizationDropdown />, {organization});
+    await userEvent.click(screen.getByRole('button', {name: 'Toggle organization menu'}));
+
+    const menus = screen.getAllByRole('menu');
+    expect(menus[0]?.closest('[data-overlay]')).toHaveStyle({maxHeight: '600px'});
+
+    // Submenus inherit the cap, so a long project list scrolls instead of
+    // running off the screen
+    await userEvent.hover(screen.getByText('All Projects'));
+
+    const submenu = (await screen.findAllByRole('menu'))[1];
+    expect(submenu?.closest('[data-overlay]')).toHaveStyle({maxHeight: '600px'});
+  });
+
+  it('can star a project from the All Projects submenu', async () => {
+    ProjectsStore.loadInitialData(
+      Array.from({length: 12}, (_, i) =>
+        ProjectFixture({id: `${i + 1}`, slug: `project-${i + 1}`})
+      )
+    );
+    const starRequest = MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/project-1/`,
+      method: 'PUT',
+      body: ProjectFixture({id: '1', slug: 'project-1', isBookmarked: true}),
+    });
+
+    render(<OrganizationDropdown />, {organization});
+    await userEvent.click(screen.getByRole('button', {name: 'Toggle organization menu'}));
+    await userEvent.hover(screen.getByText('All Projects'));
+
+    const row = await screen.findByRole('menuitemradio', {name: 'project-1'});
+    await userEvent.click(within(row).getByRole('button', {name: 'Bookmark'}));
+
+    expect(starRequest).toHaveBeenCalledWith(
+      `/projects/${organization.slug}/project-1/`,
+      expect.objectContaining({data: {isBookmarked: true}})
+    );
+  });
+
+  it('filters projects in the All Projects submenu', async () => {
+    ProjectsStore.loadInitialData(
+      Array.from({length: 12}, (_, i) =>
+        ProjectFixture({id: `${i + 1}`, slug: `project-${i + 1}`})
+      )
+    );
+
+    render(<OrganizationDropdown />, {organization});
+    await userEvent.click(screen.getByRole('button', {name: 'Toggle organization menu'}));
+    await userEvent.hover(screen.getByText('All Projects'));
+
+    const search = await screen.findByPlaceholderText('Search projects');
+    await userEvent.type(search, 'project-3');
+
+    expect(
+      await screen.findByRole('menuitemradio', {name: /project-3/})
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('menuitemradio', {name: /project-1$/})
+    ).not.toBeInTheDocument();
+  });
+
+  it('hides current-org links and project settings when asked', async () => {
+    ProjectsStore.loadInitialData([
+      ProjectFixture({id: '1', slug: 'starred-project', isBookmarked: true}),
+    ]);
+
+    render(<OrganizationDropdown hideCurrentOrganizationLinks />, {organization});
+    await userEvent.click(screen.getByRole('button', {name: 'Toggle organization menu'}));
+
+    expect(
+      screen.queryByRole('menuitemradio', {name: 'Settings'})
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('menuitemradio', {name: 'All Projects'})
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('menuitemradio', {name: 'starred-project'})
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows an empty message when no project matches', async () => {
+    ProjectsStore.loadInitialData(
+      Array.from({length: 12}, (_, i) =>
+        ProjectFixture({id: `${i + 1}`, slug: `project-${i + 1}`})
+      )
+    );
+
+    render(<OrganizationDropdown />, {organization});
+    await userEvent.click(screen.getByRole('button', {name: 'Toggle organization menu'}));
+    await userEvent.hover(screen.getByText('All Projects'));
+
+    const search = await screen.findByPlaceholderText('Search projects');
+    await userEvent.type(search, 'nothing-matches-this');
+
+    expect(await screen.findByText('No projects found')).toBeInTheDocument();
   });
 });

--- a/static/app/views/navigation/primary/organizationDropdown.spec.tsx
+++ b/static/app/views/navigation/primary/organizationDropdown.spec.tsx
@@ -11,7 +11,7 @@ import {OrganizationDropdown} from 'sentry/views/navigation/primary/organization
 
 describe('OrganizationDropdown', () => {
   const organization = OrganizationFixture({
-    access: ['org:read', 'member:read', 'team:read'],
+    access: ['org:read', 'member:read', 'team:read', 'project:write'],
   });
 
   beforeEach(() => {
@@ -34,7 +34,7 @@ describe('OrganizationDropdown', () => {
     expect(
       screen.getByRole('menuitemradio', {name: 'Switch Organization'})
     ).toBeInTheDocument();
-    expect(screen.getByRole('menuitemradio', {name: 'All Projects'})).toBeInTheDocument();
+    expect(screen.getByRole('menuitemradio', {name: /All Projects/})).toBeInTheDocument();
   });
 
   it('can switch orgs', async () => {
@@ -84,7 +84,7 @@ describe('OrganizationDropdown', () => {
     ).toBeInTheDocument();
   });
 
-  it('lists every project when there are only a few, starred or not', async () => {
+  it('lists every project when there are only a few', async () => {
     ProjectsStore.loadInitialData([
       ProjectFixture({id: '1', slug: 'plain-project', isBookmarked: false}),
       ProjectFixture({id: '2', slug: 'other-project', isBookmarked: false}),
@@ -101,41 +101,125 @@ describe('OrganizationDropdown', () => {
     expect(
       screen.getByRole('menuitemradio', {name: 'other-project'})
     ).toBeInTheDocument();
-    expect(screen.getByText('Project Settings')).toBeInTheDocument();
+    expect(screen.getByText('Projects')).toBeInTheDocument();
+  });
 
-    // Every project is already listed, so this links out rather than opening a
-    // submenu that would repeat them
-    expect(screen.getByRole('menuitemradio', {name: /All Projects/})).toHaveAttribute(
-      'href',
-      `/settings/${organization.slug}/projects/`
+  it('can star a project from the projects section', async () => {
+    ProjectsStore.loadInitialData([ProjectFixture({id: '1', slug: 'plain-project'})]);
+    const starRequest = MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/plain-project/`,
+      method: 'PUT',
+      body: ProjectFixture({id: '1', slug: 'plain-project', isBookmarked: true}),
+    });
+
+    render(<OrganizationDropdown />, {organization});
+    await userEvent.click(screen.getByRole('button', {name: 'Toggle organization menu'}));
+
+    const row = screen.getByRole('menuitemradio', {name: 'plain-project'});
+    await userEvent.click(within(row).getByRole('button', {name: 'Bookmark'}));
+
+    expect(starRequest).toHaveBeenCalledWith(
+      `/projects/${organization.slug}/plain-project/`,
+      expect.objectContaining({data: {isBookmarked: true}})
     );
   });
 
-  it('narrows to starred projects once there are many', async () => {
+  it('pins Create Project to the All Projects submenu footer', async () => {
+    // Enough projects to scroll, where an in-list action would be out of reach
+    ProjectsStore.loadInitialData(
+      Array.from({length: 40}, (_, i) =>
+        ProjectFixture({id: `${i + 1}`, slug: `project-${i + 1}`})
+      )
+    );
+
+    render(<OrganizationDropdown />, {organization});
+    await userEvent.click(screen.getByRole('button', {name: 'Toggle organization menu'}));
+
+    expect(
+      screen.queryByRole('button', {name: 'Create Project'})
+    ).not.toBeInTheDocument();
+
+    await userEvent.hover(screen.getByText('All Projects'));
+
+    // Rendered as a LinkButton, so the anchor carries role="button"
+    // Path depends on the insights rollout flag, so match the meaningful suffix
+    const createProject = await screen.findByRole('button', {name: 'Create Project'});
+    expect(createProject).toHaveAttribute(
+      'href',
+      expect.stringMatching(/\/projects\/new\/$/)
+    );
+
+    // Lives outside the scrolling list, so it stays put while the list scrolls
+    const submenu = (await screen.findAllByRole('menu'))[1]!;
+    expect(submenu).not.toContainElement(createProject);
+  });
+
+  it('hides Create Project without project:write access', async () => {
+    ProjectsStore.loadInitialData([ProjectFixture({id: '1', slug: 'plain-project'})]);
+
+    render(<OrganizationDropdown />, {
+      organization: OrganizationFixture({access: ['org:read']}),
+    });
+    await userEvent.click(screen.getByRole('button', {name: 'Toggle organization menu'}));
+    await userEvent.hover(screen.getByText('All Projects'));
+
+    // The submenu is open (it lists the project), but offers no create action
+    const submenu = (await screen.findAllByRole('menu'))[1]!;
+    expect(
+      within(submenu).getByRole('menuitemradio', {name: 'plain-project'})
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: 'Create Project'})
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows member projects with starred ones first once there are many', async () => {
     ProjectsStore.loadInitialData([
-      ProjectFixture({id: '1', slug: 'starred-project', isBookmarked: true}),
+      ProjectFixture({id: '1', slug: 'zeta-member'}),
+      ProjectFixture({id: '2', slug: 'alpha-member'}),
+      ProjectFixture({id: '3', slug: 'starred-member', isBookmarked: true}),
       ...Array.from({length: 8}, (_, i) =>
-        ProjectFixture({id: `${i + 2}`, slug: `plain-project-${i + 1}`})
+        ProjectFixture({id: `${i + 4}`, slug: `other-member-${i + 1}`})
       ),
     ]);
 
     render(<OrganizationDropdown />, {organization});
     await userEvent.click(screen.getByRole('button', {name: 'Toggle organization menu'}));
 
-    expect(screen.getByText('Starred Projects')).toBeInTheDocument();
+    const listed = screen
+      .getAllByRole('menuitemradio')
+      .map(row => row.getAttribute('data-test-id'))
+      .filter(id => id?.startsWith('project-'));
+
+    // Capped at 5, starred elevated to the top, the rest alphabetical
+    expect(listed).toHaveLength(5);
+    expect(listed[0]).toBe('project-3');
+    expect(listed[1]).toBe('project-2');
+
+    // The remainder is reachable through the submenu
+    expect(screen.getByRole('menuitemradio', {name: /All Projects/})).toBeInTheDocument();
+  });
+
+  it('falls back to all projects when the user is a member of none', async () => {
+    ProjectsStore.loadInitialData(
+      Array.from({length: 12}, (_, i) =>
+        ProjectFixture({
+          id: `${i + 1}`,
+          slug: `project-${String(i + 1).padStart(2, '0')}`,
+          isMember: false,
+        })
+      )
+    );
+
+    render(<OrganizationDropdown />, {organization});
+    await userEvent.click(screen.getByRole('button', {name: 'Toggle organization menu'}));
+
+    // Alphabetical, capped at 5
+    expect(screen.getByRole('menuitemradio', {name: 'project-01'})).toBeInTheDocument();
+    expect(screen.getByRole('menuitemradio', {name: 'project-05'})).toBeInTheDocument();
     expect(
-      screen.getByRole('menuitemradio', {name: 'starred-project'})
-    ).toBeInTheDocument();
-    // Non-starred projects are only reachable through the submenu
-    expect(
-      screen.queryByRole('menuitemradio', {name: 'plain-project-1'})
+      screen.queryByRole('menuitemradio', {name: 'project-06'})
     ).not.toBeInTheDocument();
-
-    await userEvent.hover(screen.getByText('All Projects'));
-
-    expect(
-      await screen.findByRole('menuitemradio', {name: /plain-project-1/})
-    ).toBeInTheDocument();
   });
 
   it('shows the project count on the All Projects row', async () => {
@@ -189,7 +273,9 @@ describe('OrganizationDropdown', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Toggle organization menu'}));
     await userEvent.hover(screen.getByText('All Projects'));
 
-    const row = await screen.findByRole('menuitemradio', {name: 'project-1'});
+    // Scope to the submenu: only its rows carry the star toggle
+    const submenu = (await screen.findAllByRole('menu'))[1]!;
+    const row = within(submenu).getByRole('menuitemradio', {name: 'project-1'});
     await userEvent.click(within(row).getByRole('button', {name: 'Bookmark'}));
 
     expect(starRequest).toHaveBeenCalledWith(
@@ -212,11 +298,13 @@ describe('OrganizationDropdown', () => {
     const search = await screen.findByPlaceholderText('Search projects');
     await userEvent.type(search, 'project-3');
 
+    // Scope to the submenu: the inline list above holds the same projects
+    const submenu = (await screen.findAllByRole('menu'))[1]!;
     expect(
-      await screen.findByRole('menuitemradio', {name: /project-3/})
+      await within(submenu).findByRole('menuitemradio', {name: 'project-3'})
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole('menuitemradio', {name: /project-1$/})
+      within(submenu).queryByRole('menuitemradio', {name: 'project-1'})
     ).not.toBeInTheDocument();
   });
 
@@ -231,8 +319,9 @@ describe('OrganizationDropdown', () => {
     expect(
       screen.queryByRole('menuitemradio', {name: 'Settings'})
     ).not.toBeInTheDocument();
+    expect(screen.queryByText('Project Settings')).not.toBeInTheDocument();
     expect(
-      screen.queryByRole('menuitemradio', {name: 'All Projects'})
+      screen.queryByRole('menuitemradio', {name: 'Create Project'})
     ).not.toBeInTheDocument();
     expect(
       screen.queryByRole('menuitemradio', {name: 'starred-project'})

--- a/static/app/views/navigation/primary/organizationDropdown.tsx
+++ b/static/app/views/navigation/primary/organizationDropdown.tsx
@@ -1,9 +1,9 @@
-import {useEffect, useRef} from 'react';
+import {useEffect, useMemo, useRef} from 'react';
 import {useTheme} from '@emotion/react';
 import orderBy from 'lodash/orderBy';
 import partition from 'lodash/partition';
 
-import {OrganizationAvatar} from '@sentry/scraps/avatar';
+import {OrganizationAvatar, ProjectAvatar} from '@sentry/scraps/avatar';
 import {AvatarButton} from '@sentry/scraps/avatarButton';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {useSizeContext} from '@sentry/scraps/sizeContext';
@@ -12,31 +12,38 @@ import {Text} from '@sentry/scraps/text';
 import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
 import {OrganizationBadge} from 'sentry/components/idBadge/organizationBadge';
 import {QuestionTooltip} from 'sentry/components/questionTooltip';
-import {CUSTOM_REFERRER_KEY} from 'sentry/constants';
-import {IconAdd} from 'sentry/icons';
+import {IconAdd, IconAllProjects, IconBuilding, IconSettings} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import {ConfigStore} from 'sentry/stores/configStore';
 import {OrganizationsStore} from 'sentry/stores/organizationsStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
-import type {OrganizationSummary} from 'sentry/types/organization';
+import type {Organization, OrganizationSummary} from 'sentry/types/organization';
+import type {Project} from 'sentry/types/project';
 import {isDemoModeActive} from 'sentry/utils/demoMode';
 import {localizeDomain, resolveRoute} from 'sentry/utils/resolveRoute';
-import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
-import {useSessionStorage} from 'sentry/utils/useSessionStorage';
-import {makeProjectsPathname} from 'sentry/views/projects/pathname';
+import {ProjectStarToggle} from 'sentry/views/navigation/primary/projectStarToggle';
+import {useSearchableMenuItems} from 'sentry/views/navigation/primary/useSearchableMenuItems';
+
+/**
+ * How many projects the menu will list directly before it stops trying to show
+ * them all. At or below this count, starring is pointless overhead — there is no
+ * list to curate — so every project is listed and the section never sits empty.
+ * Above it, only starred projects are listed and "All Projects" is the way in.
+ */
+const MAX_INLINE_PROJECTS = 8;
 
 interface OrganizationDropdownProps {
   /**
-   * When true, hides settings, projects, members, teams, and billing links for the current organization.
+   * When true, hides the settings and project links for the current
+   * organization, leaving only the organization switcher.
    */
   hideCurrentOrganizationLinks?: boolean;
   onClick?: () => void;
 }
 
 export function OrganizationDropdown(props: OrganizationDropdownProps) {
-  const navigate = useNavigate();
   const config = useLegacyStore(ConfigStore);
   const theme = useTheme();
   const portalContainerRef = useRef<HTMLElement | null>(null);
@@ -54,7 +61,56 @@ export function OrganizationDropdown(props: OrganizationDropdownProps) {
   );
 
   const {projects} = useProjects();
-  const [, setReferrer] = useSessionStorage<string | null>(CUSTOM_REFERRER_KEY, null);
+
+  // Most organizations have only a handful of projects, where starring is pure
+  // overhead — list them all so the section is never empty. Past that the list
+  // would crowd out the rest of the menu, so it narrows to starred projects and
+  // "All Projects" carries the remainder.
+  const {inlineProjects, isShowingAllProjects} = useMemo(() => {
+    const sorted = orderBy(projects, ['slug']);
+
+    if (sorted.length <= MAX_INLINE_PROJECTS) {
+      return {inlineProjects: sorted, isShowingAllProjects: true};
+    }
+
+    return {
+      inlineProjects: sorted
+        .filter(project => project.isBookmarked)
+        .slice(0, MAX_INLINE_PROJECTS),
+      isShowingAllProjects: false,
+    };
+  }, [projects]);
+
+  const allProjectsSearch = useSearchableMenuItems({
+    items: useMemo(
+      () =>
+        orderBy(projects, ['slug']).map(project => ({
+          item: makeProjectMenuItem(project, organization, {starrable: true}),
+          searchText: project.slug,
+        })),
+      [projects, organization]
+    ),
+    placeholder: t('Search projects'),
+    emptyMessage: t('No projects found'),
+  });
+
+  const switchOrganizationSearch = useSearchableMenuItems({
+    items: useMemo(
+      () => [
+        ...orderBy(activeOrgs, ['name']).map(org => ({
+          item: makeOrganizationMenuItem(org),
+          searchText: `${org.name} ${org.slug}`,
+        })),
+        ...orderBy(inactiveOrgs, ['name']).map(org => ({
+          item: makeInactiveOrganizationMenuItem(org),
+          searchText: `${org.name} ${org.slug}`,
+        })),
+      ],
+      [activeOrgs, inactiveOrgs]
+    ),
+    placeholder: t('Search organizations'),
+    emptyMessage: t('No organizations found'),
+  });
 
   const letterAvatarProps = {
     identifier: organization.slug,
@@ -99,7 +155,10 @@ export function OrganizationDropdown(props: OrganizationDropdownProps) {
         />
       )}
       position="right-start"
-      minMenuWidth={200}
+      minMenuWidth={274}
+      // Organizations and projects are unbounded lists, so cap the height and
+      // let them scroll. Inherited by the submenus.
+      maxMenuHeight={600}
       items={[
         {
           key: 'organization',
@@ -123,65 +182,81 @@ export function OrganizationDropdown(props: OrganizationDropdownProps) {
               : [
                   {
                     key: 'organization-settings',
-                    label: t('Organization Settings'),
+                    label: t('Settings'),
+                    leadingItems: <IconSettings />,
                     to: `/settings/${organization.slug}/`,
                     hidden: !organization.access?.includes('org:read'),
-                  },
-                  {
-                    key: 'projects',
-                    label: t('Projects'),
-                    onAction: () => {
-                      setReferrer('org-dropdown');
-                      navigate(makeProjectsPathname({path: '/', organization}));
-                    },
-                  },
-                  {
-                    key: 'members',
-                    label: t('Members'),
-                    to: `/settings/${organization.slug}/members/`,
-                    hidden: !organization.access?.includes('member:read'),
-                  },
-                  {
-                    key: 'teams',
-                    label: t('Teams'),
-                    to: `/settings/${organization.slug}/teams/`,
-                    hidden: !organization.access?.includes('team:read'),
-                  },
-                  {
-                    key: 'billing',
-                    label: t('Usage & Billing'),
-                    to: `/settings/${organization.slug}/billing/`,
-                    hidden: !organization.access?.includes('org:billing'),
                   },
                 ]),
             {
               key: 'switch-organization',
               label: t('Switch Organization'),
-              submenu: true,
+              leadingItems: <IconBuilding />,
+              submenu: {title: switchOrganizationSearch.title},
               hidden: config.singleOrganization || isDemoModeActive(),
               children: [
-                {
-                  key: 'active-orgs',
-                  children: orderBy(activeOrgs, ['name']).map(makeOrganizationMenuItem),
-                  // Hide entire submenu if there are no active organizations
-                  hidden: activeOrgs.length === 0,
-                },
-                {
-                  key: 'inactive-ogs',
-                  children: orderBy(inactiveOrgs, ['name']).map(
-                    makeInactiveOrganizationMenuItem
-                  ),
-                  // Hide entire submenu if there are no inactive organizations
-                  hidden: inactiveOrgs.length === 0,
-                },
+                ...switchOrganizationSearch.items,
                 makeCreateOrganizationMenuItem(),
               ],
+            },
+          ],
+        },
+        {
+          key: 'project-settings',
+          // Reflect what the list below actually is, so the heading does not
+          // promise starred projects when it is showing all of them.
+          label: isShowingAllProjects ? t('Project Settings') : t('Starred Projects'),
+          // Project settings belong to the current organization, so they follow
+          // the same access rules as the links above.
+          hidden: props.hideCurrentOrganizationLinks,
+          children: [
+            ...inlineProjects.map(project => makeProjectMenuItem(project, organization)),
+            {
+              key: 'all-projects',
+              label: t('All Projects'),
+              leadingItems: <IconAllProjects />,
+              // Set expectations before the click: a small number says the
+              // submenu is trivial, a large one says to expect the search field.
+              trailingItems: (
+                <Text size="sm" variant="muted" tabular>
+                  {projects.length}
+                </Text>
+              ),
+              // When every project is already listed above, a submenu would just
+              // repeat those rows, so link straight to the projects index
+              // instead. Otherwise it opens the full searchable list.
+              ...(isShowingAllProjects
+                ? {to: `/settings/${organization.slug}/projects/`}
+                : {
+                    submenu: {title: allProjectsSearch.title},
+                    children: allProjectsSearch.items,
+                  }),
             },
           ],
         },
       ]}
     />
   );
+}
+
+function makeProjectMenuItem(
+  project: Project,
+  organization: Organization,
+  {starrable = false}: {starrable?: boolean} = {}
+): MenuItemProps {
+  return {
+    key: `project-${project.id}`,
+    label: project.slug,
+    textValue: project.slug,
+    leadingItems: <ProjectAvatar project={project} />,
+    // Starring is offered where the user is browsing the full list, which is
+    // where they can act on what they find. Pinned rows omit it: the star would
+    // only ever unpin, and the row would vanish from under the cursor.
+    trailingItems: starrable ? (
+      <ProjectStarToggle organization={organization} project={project} />
+    ) : undefined,
+    to: `/settings/${organization.slug}/projects/${project.slug}/`,
+  };
 }
 
 function makeOrganizationMenuItem(org: OrganizationSummary): MenuItemProps {

--- a/static/app/views/navigation/primary/organizationDropdown.tsx
+++ b/static/app/views/navigation/primary/organizationDropdown.tsx
@@ -2,9 +2,11 @@ import {useEffect, useMemo, useRef} from 'react';
 import {useTheme} from '@emotion/react';
 import orderBy from 'lodash/orderBy';
 import partition from 'lodash/partition';
+import sortBy from 'lodash/sortBy';
 
 import {OrganizationAvatar, ProjectAvatar} from '@sentry/scraps/avatar';
 import {AvatarButton} from '@sentry/scraps/avatarButton';
+import {MenuComponents} from '@sentry/scraps/compactSelect';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {useSizeContext} from '@sentry/scraps/sizeContext';
 import {Text} from '@sentry/scraps/text';
@@ -25,14 +27,14 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
 import {ProjectStarToggle} from 'sentry/views/navigation/primary/projectStarToggle';
 import {useSearchableMenuItems} from 'sentry/views/navigation/primary/useSearchableMenuItems';
+import {makeProjectsPathname} from 'sentry/views/projects/pathname';
 
 /**
- * How many projects the menu will list directly before it stops trying to show
- * them all. At or below this count, starring is pointless overhead — there is no
- * list to curate — so every project is listed and the section never sits empty.
- * Above it, only starred projects are listed and "All Projects" is the way in.
+ * How many projects the menu lists directly. Most organizations have fewer than
+ * this, so the section shows everything and never sits empty; larger ones get the
+ * most relevant few here and reach the rest through "All Projects".
  */
-const MAX_INLINE_PROJECTS = 8;
+const MAX_INLINE_PROJECTS = 5;
 
 interface OrganizationDropdownProps {
   /**
@@ -62,29 +64,34 @@ export function OrganizationDropdown(props: OrganizationDropdownProps) {
 
   const {projects} = useProjects();
 
-  // Most organizations have only a handful of projects, where starring is pure
-  // overhead — list them all so the section is never empty. Past that the list
-  // would crowd out the rest of the menu, so it narrows to starred projects and
-  // "All Projects" carries the remainder.
-  const {inlineProjects, isShowingAllProjects} = useMemo(() => {
-    const sorted = orderBy(projects, ['slug']);
+  // Mirrors how ProjectPageFilter picks and orders its list, so the two surfaces
+  // agree on which projects are the relevant ones.
+  const inlineProjects = useMemo(() => {
+    const memberProjects = projects.filter(project => project.isMember);
 
-    if (sorted.length <= MAX_INLINE_PROJECTS) {
-      return {inlineProjects: sorted, isShowingAllProjects: true};
-    }
+    // "My Projects" is the filter's default selection, so prefer it. Users on no
+    // projects at all fall back to everything they can access.
+    const candidates = memberProjects.length > 0 ? memberProjects : projects;
 
-    return {
-      inlineProjects: sorted
-        .filter(project => project.isBookmarked)
-        .slice(0, MAX_INLINE_PROJECTS),
-      isShowingAllProjects: false,
-    };
+    // Starred first, then projects the user is a member of, then alphabetically —
+    // the same precedence the filter's list uses, minus its selection key.
+    return sortBy(candidates, [
+      project => !project.isBookmarked,
+      project => !project.isMember,
+      project => project.slug,
+    ]).slice(0, MAX_INLINE_PROJECTS);
   }, [projects]);
 
   const allProjectsSearch = useSearchableMenuItems({
     items: useMemo(
       () =>
-        orderBy(projects, ['slug']).map(project => ({
+        // Same precedence as the inline list above, so the relevant projects stay
+        // near the top here too.
+        sortBy(projects, [
+          project => !project.isBookmarked,
+          project => !project.isMember,
+          project => project.slug,
+        ]).map(project => ({
           item: makeProjectMenuItem(project, organization, {starrable: true}),
           searchText: project.slug,
         })),
@@ -203,34 +210,41 @@ export function OrganizationDropdown(props: OrganizationDropdownProps) {
         },
         {
           key: 'project-settings',
-          // Reflect what the list below actually is, so the heading does not
-          // promise starred projects when it is showing all of them.
-          label: isShowingAllProjects ? t('Project Settings') : t('Starred Projects'),
+          label: t('Projects'),
           // Project settings belong to the current organization, so they follow
           // the same access rules as the links above.
           hidden: props.hideCurrentOrganizationLinks,
           children: [
-            ...inlineProjects.map(project => makeProjectMenuItem(project, organization)),
+            // Starrable here too, so the star that drives the ordering is visible
+            // on the rows it orders.
+            ...inlineProjects.map(project =>
+              makeProjectMenuItem(project, organization, {starrable: true})
+            ),
             {
               key: 'all-projects',
               label: t('All Projects'),
               leadingItems: <IconAllProjects />,
-              // Set expectations before the click: a small number says the
-              // submenu is trivial, a large one says to expect the search field.
+              // Set expectations before the click: a small number says the submenu
+              // is trivial, a large one says to expect the search field.
               trailingItems: (
                 <Text size="sm" variant="muted" tabular>
                   {projects.length}
                 </Text>
               ),
-              // When every project is already listed above, a submenu would just
-              // repeat those rows, so link straight to the projects index
-              // instead. Otherwise it opens the full searchable list.
-              ...(isShowingAllProjects
-                ? {to: `/settings/${organization.slug}/projects/`}
-                : {
-                    submenu: {title: allProjectsSearch.title},
-                    children: allProjectsSearch.items,
-                  }),
+              submenu: {
+                title: allProjectsSearch.title,
+                // Pinned below the list so it stays reachable in organizations
+                // with enough projects to scroll.
+                footer: organization.access?.includes('project:write') ? (
+                  <MenuComponents.CTALinkButton
+                    icon={<IconAdd />}
+                    to={makeProjectsPathname({path: '/new/', organization})}
+                  >
+                    {t('Create Project')}
+                  </MenuComponents.CTALinkButton>
+                ) : null,
+              },
+              children: allProjectsSearch.items,
             },
           ],
         },

--- a/static/app/views/navigation/primary/projectStarToggle.tsx
+++ b/static/app/views/navigation/primary/projectStarToggle.tsx
@@ -1,0 +1,36 @@
+import {BookmarkStar} from 'sentry/components/projects/bookmarkStar';
+import type {Organization} from 'sentry/types/organization';
+import type {Project} from 'sentry/types/project';
+
+interface ProjectStarToggleProps {
+  organization: Organization;
+  project: Project;
+}
+
+/**
+ * A star toggle for a project row inside a dropdown menu.
+ *
+ * Menu rows render their trailing items inside the row's link, and the menu
+ * itself acts on Enter/Space, so the toggle has to keep its own events from
+ * bubbling — otherwise starring a project would navigate to it or close the
+ * menu. `BookmarkStar` spreads its props after its own `onClick`, so the
+ * interception happens on this wrapper rather than on the button.
+ */
+export function ProjectStarToggle({organization, project}: ProjectStarToggleProps) {
+  return (
+    <div
+      onClick={event => {
+        // Stop the enclosing link from navigating.
+        event.preventDefault();
+        event.stopPropagation();
+      }}
+      onKeyDown={event => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.stopPropagation();
+        }
+      }}
+    >
+      <BookmarkStar organization={organization} project={project} />
+    </div>
+  );
+}

--- a/static/app/views/navigation/primary/useSearchableMenuItems.tsx
+++ b/static/app/views/navigation/primary/useSearchableMenuItems.tsx
@@ -1,0 +1,159 @@
+import {useCallback, useMemo, useState} from 'react';
+import styled from '@emotion/styled';
+
+import {InputGroup} from '@sentry/scraps/input';
+
+import type {MenuItemProps} from 'sentry/components/dropdownMenu';
+import {IconSearch} from 'sentry/icons';
+import {t} from 'sentry/locale';
+
+/**
+ * A menu item paired with the plain text that the query is matched against.
+ * `MenuItemProps.label` is often a React node (e.g. a badge), so the searchable
+ * text has to be supplied separately.
+ */
+interface SearchableMenuItem {
+  item: MenuItemProps;
+  searchText: string;
+}
+
+interface UseSearchableMenuItemsOptions {
+  /**
+   * Items to filter, each paired with the text to match the query against.
+   */
+  items: SearchableMenuItem[];
+  /**
+   * Rendered when the query matches nothing.
+   */
+  emptyMessage?: string;
+  /**
+   * Minimum number of items before the search field is shown. Below this the
+   * list is short enough to scan by eye.
+   */
+  minItemsForSearch?: number;
+  placeholder?: string;
+}
+
+interface SearchableMenuItemsResult {
+  /**
+   * The items matching the current query, to pass as the submenu's `children`.
+   */
+  items: MenuItemProps[];
+  /**
+   * The search field, to pass as the submenu's `title`. `null` when there are
+   * too few items to be worth filtering.
+   */
+  title: React.ReactNode;
+}
+
+/**
+ * `DropdownMenu` has no built-in filtering, so this hook provides it for a
+ * submenu: it returns a search field to render as the submenu's title, plus the
+ * items matching what the user typed.
+ *
+ * The field goes in the title rather than in the item list because the title
+ * renders outside the menu's `ul` — inside it, react-aria's typeahead and
+ * arrow-key navigation would swallow the keystrokes, and the enclosing menu
+ * item's accessible name would track the input's value.
+ */
+export function useSearchableMenuItems({
+  items,
+  placeholder,
+  emptyMessage,
+  minItemsForSearch = 7,
+}: UseSearchableMenuItemsOptions): SearchableMenuItemsResult {
+  const [query, setQuery] = useState('');
+  const isSearchable = items.length >= minItemsForSearch;
+
+  const matches = useMemo(
+    () => (isSearchable ? filterMenuItems(items, query) : items),
+    [isSearchable, items, query]
+  );
+
+  // Let Escape close the menu, but keep the rest of the keystrokes here rather
+  // than letting the parent menu act on them.
+  const stopPropagation = useCallback((event: React.KeyboardEvent) => {
+    if (event.key !== 'Escape') {
+      event.stopPropagation();
+    }
+  }, []);
+
+  const title = useMemo((): React.ReactNode => {
+    if (!isSearchable) {
+      return null;
+    }
+
+    return (
+      <InputGroup>
+        <InputGroup.LeadingItems disablePointerEvents>
+          <IconSearch size="xs" variant="muted" />
+        </InputGroup.LeadingItems>
+        <SearchInput
+          autoFocus
+          size="xs"
+          // Password managers try to autofill menu inputs.
+          data-1p-ignore
+          aria-label={placeholder ?? t('Search')}
+          placeholder={placeholder ?? t('Search')}
+          value={query}
+          onChange={event => setQuery(event.target.value)}
+          onKeyDown={stopPropagation}
+          onKeyUp={stopPropagation}
+        />
+      </InputGroup>
+    );
+  }, [isSearchable, placeholder, query, stopPropagation]);
+
+  const resolvedItems = useMemo(() => {
+    if (isSearchable && matches.length === 0) {
+      return [
+        {
+          key: 'no-results',
+          label: emptyMessage ?? t('No results'),
+          disabled: true,
+        },
+      ];
+    }
+
+    return matches.map(({item}) => item);
+  }, [isSearchable, matches, emptyMessage]);
+
+  return {title, items: resolvedItems};
+}
+
+/**
+ * Case-insensitive substring match, ranking items whose text starts with the
+ * query above those that merely contain it.
+ */
+function filterMenuItems(
+  items: SearchableMenuItem[],
+  query: string
+): SearchableMenuItem[] {
+  const trimmedQuery = query.trim().toLowerCase();
+
+  if (!trimmedQuery) {
+    return items;
+  }
+
+  const scored: Array<{index: number; score: number; searchable: SearchableMenuItem}> =
+    [];
+
+  items.forEach((searchable, index) => {
+    const matchIndex = searchable.searchText.toLowerCase().indexOf(trimmedQuery);
+
+    if (matchIndex === -1) {
+      return;
+    }
+
+    scored.push({searchable, index, score: matchIndex === 0 ? 0 : 1});
+  });
+
+  // Stable sort: preserve the caller's ordering within each score bucket.
+  return scored
+    .sort((a, b) => a.score - b.score || a.index - b.index)
+    .map(({searchable}) => searchable);
+}
+
+const SearchInput = styled(InputGroup.Input)`
+  appearance: none;
+`;


### PR DESCRIPTION
Prototype relocating how users reach organization, project, and user settings. Settings move out of the primary navigation and into the organization dropdown, which is restructured to match the [Figma design](https://www.figma.com/design/FThgiKJFHFag7Qmt1SOz65/Untitled?node-id=1-739).

## Organization dropdown

The menu is now two sections:

- **Organization** — `Settings` (renamed from "Organization Settings") and a `Switch Organization` submenu.
- **Projects** — up to 5 projects, then an `All Projects` submenu with a project count.

The `Projects`, `Members`, `Teams`, and `Usage & Billing` items are removed; the project section replaces them. This also retires the `org-dropdown` session-storage referrer that the old `Projects` item set.

## Project selection

Which projects appear mirrors `ProjectPageFilter`, so the two surfaces agree on what's relevant: prefer the projects the user is a member of, falling back to every accessible project, ordered starred first, then by membership, then alphabetically — the same precedence as the filter's list, minus its selection key. Clamped to 5.

Rows carry an inline star toggle in both the section and the submenu, so the control driving the order is visible on the rows it orders, and starring is discoverable at the moment the user is browsing. Previously the menu had no way to set a star at all.

`Create Project` is pinned to the `All Projects` submenu footer. As a list item it sat below the entire scroll region and was unreachable in organizations with many projects.

## Submenu filtering

`DropdownMenu` had no filtering, so `useSearchableMenuItems` adds it for the organization and project submenus. Matching is case-insensitive substring, ranking prefix matches first, and the field appears only at 7+ items.

The field renders in the submenu's `title` slot rather than as a menu item, because inside the item list react-aria's typeahead swallowed the keystrokes and the enclosing row's accessible name tracked the input's value.

## Shared component changes

`submenu` config gains `footer`, and `title`/`footer` widen from `string` to `React.ReactNode`. Both render outside the scrolling `ul`, so they stay put while a long list scrolls.

Three fixes needed for the above, all pre-existing:

- `maxMenuHeight` was not forwarded to submenus, so a capped menu's submenus were uncapped.
- An explicit `maxMenuHeight` *replaced* the boundary-aware height popper computes instead of being clamped by it, so a capped menu could render past the edge of the screen — putting a footer out of view.
- The height cap applied only to the inner list, which could claim the full cap and push a title or footer outside the overlay. The cap now bounds the overlay and the list shrinks within it.

The dropdown sets a 600px cap so long organization and project lists scroll.

Note: the overlay deliberately does **not** get `overflow: hidden` (unlike `compactSelect`'s). It is `position: relative`, so it is the containing block for submenu overlays, and hiding overflow would clip every submenu.

## Primary navigation

The `Settings` item is commented out rather than deleted, so the prototype is easy to revert. `NavigationTour.SETTINGS` remains registered but no longer has an anchor element — worth a look before this ships.

## Notes for reviewers

- `isBookmarked` is org-wide, so starring from this menu also reorders the sidebar and project pages.
- The `All Projects` count renders visually but is not in the row's accessible name, since `MenuListItem` points `aria-labelledby` only at the label element. Fixing that means changing how `MenuListItem` computes its label, which felt out of scope here.
- The 5-project clamp and the 7-item search threshold are product choices, not derived from anything.
- **Not yet verified in a browser.** Tests cover DOM structure, but jsdom does no layout, so the sticky footer's rendered position is unconfirmed.
