### PR TITLE
fix(seer): accept PR reviews from bot authors

### DIFF
--- a/src/sentry/seer/autofix/pr_iteration/listeners/review.py
+++ b/src/sentry/seer/autofix/pr_iteration/listeners/review.py
@@ -17,9 +17,9 @@ another, and take a single ``PullRequestReviewEvent`` argument.
 The listener filters to submitted reviews, resolves org/integration/repo context
 from the event, feature-gates, and hands off to ``trigger_pr_iteration_from_review``
 which fetches the review's inline comments and summary body and dispatches an
-Autofix PR iteration. The task gates on the review author's repo write access, so
-a review only drives an iteration when its author could push the change
-themselves.
+Autofix PR iteration. The task gates human review authors on repo write access, so
+a human review only drives an iteration when its author could push the change
+themselves; bot reviews are instead bounded by the automated-iteration cap.
 """
 
 from __future__ import annotations

--- a/src/sentry/seer/autofix/pr_iteration/listeners/review.py
+++ b/src/sentry/seer/autofix/pr_iteration/listeners/review.py
@@ -66,6 +66,9 @@ def handle_pull_request_review_for_autofix_iteration(event: PullRequestReviewEve
     extra = subscription.get("extra") or {}
     installation_id = extra.get("installation_id")
     repository_id = extra.get("repository_id")
+    # Legacy GitHub Enterprise hosts may deliver without a verified signature, so
+    # the payload's author fields are unattested.
+    delivery_authenticated = not extra.get("skipped-authentication", False)
 
     provider = subscription.get("type")
     author_id = event.author.get("id")
@@ -160,6 +163,7 @@ def handle_pull_request_review_for_autofix_iteration(event: PullRequestReviewEve
             author_username=event.author.get("username"),
             author_external_id=event.author.get("id"),
             author_is_bot=event.is_bot,
+            delivery_authenticated=delivery_authenticated,
         )
         dispatched = True
 

--- a/src/sentry/seer/autofix/pr_iteration/mention.py
+++ b/src/sentry/seer/autofix/pr_iteration/mention.py
@@ -11,7 +11,7 @@ This covers only top-level PR comments (``issue_comment``). Inline review
 comments arrive via the ``pull_request_review`` SCM listener (see
 ``listeners/review.py``),
 which acts on the whole submitted review without requiring an ``@sentry`` command
-but still gates on the review author's repo write access.
+but still gates human review authors on repo write access.
 """
 
 from __future__ import annotations

--- a/src/sentry/tasks/seer/pr_iteration.py
+++ b/src/sentry/tasks/seer/pr_iteration.py
@@ -75,6 +75,7 @@ from sentry.seer.models import SeerApiError, SeerPermissionError
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import seer_tasks
+from sentry.users.services.user.model import RpcUser
 from sentry.utils import metrics
 from sentry.utils.locking import UnableToAcquireLock
 
@@ -852,9 +853,9 @@ def trigger_pr_iteration_from_review(
     to recover its GitHub id, looks up the agent run keyed on that id, fetches the
     review's inline comments and summary body, and triggers the iteration with the
     whole review as feedback. Unlike the comment path there is no ``@sentry``
-    command gate — any submitted review with content is acted on — but the review
-    author must have repo write/admin access, so an untrusted reviewer can't spend
-    Autofix quota or inject feedback that rewrites the PR.
+    command gate — any submitted review with content is acted on — but a human
+    review author must have repo write/admin access, so an untrusted reviewer can't
+    spend Autofix quota or inject feedback that rewrites the PR.
 
     ``author_is_bot`` reviews (test-coverage bots and the like) count toward the
     automated-iteration streak cap and are dropped once it's reached; human
@@ -937,24 +938,22 @@ def trigger_pr_iteration_from_review(
         logger.warning("autofix.pr_iteration.review_trigger.unsupported_provider", extra=log_extra)
         return None
 
-    # Gate on repo write access before fetching, enqueueing, or acking: a review
-    # from someone without write/admin is silently dropped so an untrusted
-    # reviewer can't spend Autofix quota or inject feedback that rewrites the PR.
-    if not author_username or not _github_commenter_has_repo_write_access(scm, author_username):
+    # Bots skip the write-access gate: a bot account is never a repo collaborator.
+    actor_user: RpcUser | None = None
+    if author_is_bot:
+        metrics.incr("autofix.pr_iteration.review_trigger.write_access_gate_skipped")
+    elif not author_username or not _github_commenter_has_repo_write_access(scm, author_username):
         metrics.incr("autofix.pr_iteration.review_trigger.no_write_access")
         logger.info("autofix.pr_iteration.review_trigger.no_write_access", extra=log_extra)
         return None
-
-    actor_user = (
-        find_user_for_scm_actor(
+    else:
+        actor_user = find_user_for_scm_actor(
             organization_id=organization_id,
             integration_id=integration_id,
             username=author_username,
             external_id=author_external_id,
         )
-        if not author_is_bot
-        else None
-    )
+
     inline_comments = _fetch_all_review_comments(scm, pr_number=pr_number, review_id=review_id)
     review = _fetch_review_body(scm, pr_number=pr_number, review_id=review_id)
     review_body = (review.get("body") or "").strip() if review else None

--- a/src/sentry/tasks/seer/pr_iteration.py
+++ b/src/sentry/tasks/seer/pr_iteration.py
@@ -845,6 +845,7 @@ def trigger_pr_iteration_from_review(
     author_username: str | None = None,
     author_external_id: str | int | None = None,
     author_is_bot: bool = False,
+    delivery_authenticated: bool = True,
 ) -> None:
     """
     Resolve the Autofix run behind a submitted PR review and kick off an iteration.
@@ -939,8 +940,9 @@ def trigger_pr_iteration_from_review(
         return None
 
     # Bots skip the write-access gate: a bot account is never a repo collaborator.
+    # An unauthenticated delivery can forge the bot flag, so it stays gated.
     actor_user: RpcUser | None = None
-    if author_is_bot:
+    if author_is_bot and delivery_authenticated:
         metrics.incr("autofix.pr_iteration.review_trigger.write_access_gate_skipped")
     elif not author_username or not _github_commenter_has_repo_write_access(scm, author_username):
         metrics.incr("autofix.pr_iteration.review_trigger.no_write_access")

--- a/tests/sentry/seer/autofix/test_pr_iteration_review.py
+++ b/tests/sentry/seer/autofix/test_pr_iteration_review.py
@@ -6,6 +6,7 @@ from scm.errors import ResourceNotFound
 from sentry.scm.types import PullRequestReviewEvent, SubscriptionEvent
 from sentry.seer.agent.client_models import MemoryBlock, Message, RepoPRState, SeerRunState
 from sentry.seer.autofix.constants import AutofixReferrer
+from sentry.seer.autofix.pr_iteration.feedback import Feedback, serialize_feedback
 from sentry.seer.autofix.pr_iteration.feedback_sources.github_comment import (
     GithubPrReviewBodyFeedbackSource,
     GithubPrReviewCommentFeedbackSource,
@@ -239,6 +240,28 @@ class TriggerPrIterationFromReviewTest(TestCase):
             message=Message(
                 role="assistant",
                 metadata={"step": "pr_iteration", "iteration_index": idx},
+            ),
+            timestamp="2024-01-01T00:00:00Z",
+        )
+
+    def _feedback_iteration_block(self, idx: int, *, author_is_bot: bool) -> MemoryBlock:
+        """An iteration block carrying real serialized review feedback."""
+        feedback = Feedback(
+            source=GithubPrReviewBodyFeedbackSource(
+                review_id=idx,
+                body="fix this",
+                author_is_bot=author_is_bot,
+            )
+        )
+        return MemoryBlock(
+            id=f"iter{idx}",
+            message=Message(
+                role="assistant",
+                metadata={
+                    "step": "pr_iteration",
+                    "iteration_index": idx,
+                    "feedback": serialize_feedback([feedback]),
+                },
             ),
             timestamp="2024-01-01T00:00:00Z",
         )
@@ -548,6 +571,45 @@ class TriggerPrIterationFromReviewTest(TestCase):
         self.mock_actions.create_review_comment_reaction.assert_not_called()
         # The cap drops the bot, not the write-access gate.
         self.mock_actions.get_repository_user_permission.assert_not_called()
+
+    def test_bot_review_capped_when_prior_iterations_recorded_bot_feedback(self) -> None:
+        # Bot reviews recorded as automated feedback trip the cap, so bot-vs-agent
+        # ping-pong is bounded even though the bot skips the write-access gate.
+        self.mock_get_state.return_value = self._agent_state(
+            blocks=[
+                self._feedback_iteration_block(1, author_is_bot=True),
+                self._feedback_iteration_block(2, author_is_bot=True),
+            ]
+        )
+        self.mock_actions.get_review_comments.return_value = self._paginated(
+            [self._review_comment(comment_id="1", body="fix this")]
+        )
+
+        with self.options({"autofix.pr-iteration.max-iterations": 2}):
+            self._run(author_is_bot=True)
+
+        self.mock_enqueue.assert_not_called()
+        self.mock_consume.assert_not_called()
+        self.mock_actions.create_review_comment_reaction.assert_not_called()
+
+    def test_bot_review_proceeds_when_prior_iteration_had_human_feedback(self) -> None:
+        # One human feedback item in a drained iteration makes it manual, which
+        # breaks the streak and lets the next bot review through.
+        self.mock_get_state.return_value = self._agent_state(
+            blocks=[
+                self._feedback_iteration_block(1, author_is_bot=False),
+                self._feedback_iteration_block(2, author_is_bot=True),
+            ]
+        )
+        self.mock_actions.get_review_comments.return_value = self._paginated(
+            [self._review_comment(comment_id="1", body="fix this")]
+        )
+
+        with self.options({"autofix.pr-iteration.max-iterations": 2}):
+            self._run(author_is_bot=True)
+
+        self.mock_enqueue.assert_called()
+        self.mock_consume.assert_called_once()
 
     def test_human_review_proceeds_when_automated_streak_capped(self) -> None:
         # The streak cap only bounds automated (bot) reviews; a human review always

--- a/tests/sentry/seer/autofix/test_pr_iteration_review.py
+++ b/tests/sentry/seer/autofix/test_pr_iteration_review.py
@@ -38,6 +38,7 @@ class HandlePullRequestReviewForAutofixIterationTest(TestCase):
         state: str = "commented",
         author_id: str = "999",
         is_bot: bool = False,
+        skipped_authentication: bool = False,
         installation_id: int | None = 12345,
         repository_id: int | None = 7654321,
         pull_request_id: str = "7",
@@ -52,6 +53,7 @@ class HandlePullRequestReviewForAutofixIterationTest(TestCase):
             "extra": {
                 "installation_id": installation_id,
                 "repository_id": repository_id,
+                "skipped-authentication": skipped_authentication,
             },
             "sentry_meta": None,
         }
@@ -122,6 +124,20 @@ class HandlePullRequestReviewForAutofixIterationTest(TestCase):
         mock_delay.assert_called_once()
         # Bot authorship is threaded through so the task can apply the streak cap.
         assert mock_delay.call_args.kwargs["author_is_bot"] is True
+        assert mock_delay.call_args.kwargs["delivery_authenticated"] is True
+
+    @patch(f"{TASK_PATH}.trigger_pr_iteration_from_review.delay")
+    @patch(f"{REVIEW_PATH}.integration_service.organization_contexts")
+    def test_unsigned_delivery_is_marked_unauthenticated(
+        self, mock_contexts: MagicMock, mock_delay: MagicMock
+    ) -> None:
+        self._mock_org_contexts(mock_contexts)
+        with self.feature("organizations:autofix-pr-iteration-manual"):
+            handle_pull_request_review_for_autofix_iteration(
+                self._event(is_bot=True, skipped_authentication=True)
+            )
+        mock_delay.assert_called_once()
+        assert mock_delay.call_args.kwargs["delivery_authenticated"] is False
 
     @patch(f"{TASK_PATH}.trigger_pr_iteration_from_review.delay")
     @patch(f"{REVIEW_PATH}.integration_service.organization_contexts")
@@ -307,6 +323,7 @@ class TriggerPrIterationFromReviewTest(TestCase):
         author_username: str | None = "reviewer",
         author_external_id: str | int | None = "999",
         author_is_bot: bool = False,
+        delivery_authenticated: bool = True,
     ) -> None:
         trigger_pr_iteration_from_review(
             organization_id=self.organization.id,
@@ -317,6 +334,7 @@ class TriggerPrIterationFromReviewTest(TestCase):
             author_username=author_username,
             author_external_id=author_external_id,
             author_is_bot=author_is_bot,
+            delivery_authenticated=delivery_authenticated,
         )
 
     def test_batch_review_with_inline_comments_and_body(self) -> None:
@@ -660,6 +678,21 @@ class TriggerPrIterationFromReviewTest(TestCase):
         sources = [c.kwargs["feedback"].source for c in self.mock_enqueue.call_args_list]
         assert all(s.author_is_bot for s in sources)
         assert all(c.kwargs["actor_user_id"] is None for c in self.mock_enqueue.call_args_list)
+
+    def test_unauthenticated_bot_review_still_needs_write_access(self) -> None:
+        # A legacy GitHub Enterprise host can deliver without a verified signature,
+        # so the bot flag is forgeable and must not skip the gate.
+        self.mock_actions.get_repository_user_permission.return_value = {"data": {"perms": "none"}}
+        self.mock_actions.get_review_comments.return_value = self._paginated(
+            [self._review_comment(comment_id="1", body="fix this")]
+        )
+
+        self._run(author_is_bot=True, delivery_authenticated=False)
+
+        self.mock_actions.get_repository_user_permission.assert_called_once()
+        self.mock_enqueue.assert_not_called()
+        self.mock_consume.assert_not_called()
+        self.mock_actions.create_review_comment_reaction.assert_not_called()
 
     def test_bot_review_proceeds_without_author_username(self) -> None:
         # GitHub always sends a login, but the bot path must not depend on one.

--- a/tests/sentry/seer/autofix/test_pr_iteration_review.py
+++ b/tests/sentry/seer/autofix/test_pr_iteration_review.py
@@ -546,6 +546,8 @@ class TriggerPrIterationFromReviewTest(TestCase):
         self.mock_enqueue.assert_not_called()
         self.mock_consume.assert_not_called()
         self.mock_actions.create_review_comment_reaction.assert_not_called()
+        # The cap drops the bot, not the write-access gate.
+        self.mock_actions.get_repository_user_permission.assert_not_called()
 
     def test_human_review_proceeds_when_automated_streak_capped(self) -> None:
         # The streak cap only bounds automated (bot) reviews; a human review always
@@ -576,6 +578,38 @@ class TriggerPrIterationFromReviewTest(TestCase):
         self.mock_enqueue.assert_not_called()
         self.mock_consume.assert_not_called()
         self.mock_actions.create_review_comment_reaction.assert_not_called()
+
+    def test_bot_review_proceeds_without_repo_write_access(self) -> None:
+        # A bot account is never a repo collaborator, so it skips the gate.
+        self.mock_actions.get_repository_user_permission.return_value = {"data": {"perms": "none"}}
+        self.mock_actions.get_review_comments.return_value = self._paginated(
+            [self._review_comment(comment_id="1", body="fix this")]
+        )
+
+        self._run(author_is_bot=True)
+
+        self.mock_enqueue.assert_called()
+        self.mock_consume.assert_called_once()
+        self.mock_actions.get_repository_user_permission.assert_not_called()
+        self.mock_actions.create_review_comment_reaction.assert_called_once()
+
+        # The review still counts as automated, so the streak cap can stop it later.
+        self.mock_find_user.assert_not_called()
+        sources = [c.kwargs["feedback"].source for c in self.mock_enqueue.call_args_list]
+        assert all(s.author_is_bot for s in sources)
+        assert all(c.kwargs["actor_user_id"] is None for c in self.mock_enqueue.call_args_list)
+
+    def test_bot_review_proceeds_without_author_username(self) -> None:
+        # GitHub always sends a login, but the bot path must not depend on one.
+        self.mock_actions.get_review_comments.return_value = self._paginated(
+            [self._review_comment(comment_id="1", body="fix this")]
+        )
+
+        self._run(author_username=None, author_is_bot=True)
+
+        self.mock_enqueue.assert_called()
+        self.mock_consume.assert_called_once()
+        self.mock_actions.get_repository_user_permission.assert_not_called()
 
     def test_skips_review_with_no_author(self) -> None:
         # No author username means we can't check access, so drop without even


### PR DESCRIPTION
A GitHub App bot account is never a repo collaborator, so its permission is always `none` and every bot-authored review was dropped at the write-access gate. Skip the gate for bot authors.

Human authors are unchanged.

## Loop protection

Bot reviews are bundled into the existing automated-iteration streak cap, which runs before the gate. A bot review sets `is_automated=True` on its feedback source. When the queue drains, an iteration counts as automated only if *every* feedback item in it is automated — one human review, comment, or UI feedback in the batch makes the whole iteration manual and resets the streak. After `autofix.pr-iteration.max-iterations` (default 5) consecutive automated iterations, further bot reviews are dropped. So bot-vs-agent ping-pong ("A is broken" → fix → "B is broken" → fix → "A is broken") is bounded.

The prior cap test used iteration blocks with no feedback metadata, so it passed through the empty-metadata fallback and never proved this. Replaced with blocks built from serialized review feedback.

## Authenticated deliveries only

Legacy GitHub Enterprise hosts on the `github-enterprise-app.allowed-hosts-legacy-webhooks` allowlist may deliver without a verified signature, which makes the payload's bot flag forgeable. The bypass requires `delivery_authenticated`; an unsigned delivery falls through to the write-access gate. `author_is_bot` stays truthful so a forged bot review still counts toward the cap.

## Trade-off

Any third-party bot that can post a review on a repo where the Sentry App is installed can now drive up to 5 consecutive runs before the cap stops it. Any human feedback resets that streak.

Review path only. The `@sentry` comment path has no bot signal and no cap, so it is left alone.

CW-1718
