### PR TITLE
feat(explore): Autocomplete array attribute element values

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -1209,10 +1209,7 @@ class TraceItemAttributeValuesAutocompletionExecutor:
         if self.search_type == "string":
             return self.string_autocomplete_function()
 
-        # Array attributes autocomplete their individual element values. The tag
-        # form resolves to the generic array type, so ask Snuba for the string
-        # elements (e.g. "title") rather than whole arrays. Explicit array tag
-        # syntax resolves regardless of the flag, so gate the behavior here.
+        # Autocomplete values for array attributes (string-typed arrays)
         if self.search_type == "array" and self.supports_arrays:
             array_key = AttributeKey(
                 name=self.attribute_key.name, type=AttributeKey.Type.TYPE_ARRAY_STRING

--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -1096,6 +1096,11 @@ class OrganizationTraceItemAttributeValuesEndpoint(OrganizationTraceItemAttribut
 
         serialized = serializer.validated_data
         substring_match = serialized.get("substring_match", "")
+        supports_arrays = features.has(
+            "organizations:trace-item-array-query-support",
+            organization,
+            actor=request.user,
+        )
         # Deprecating this so we're using the same param name as the events endpoints
         item_type = serialized.get("item_type")
         # Dataset is going to replace item_type
@@ -1116,6 +1121,7 @@ class OrganizationTraceItemAttributeValuesEndpoint(OrganizationTraceItemAttribut
                 limit=limit,
                 offset=offset,
                 definitions=definitions,
+                supports_arrays=supports_arrays,
             )
 
             with handle_query_errors():
@@ -1150,15 +1156,19 @@ class TraceItemAttributeValuesAutocompletionExecutor:
         limit: int,
         offset: int,
         definitions: ColumnDefinitions,
+        supports_arrays: bool = False,
     ):
         self.organization = organization
         self.snuba_params = snuba_params
+        self.supports_arrays = supports_arrays
         self.key = key
         self.query = query or ""
         self.limit = limit
         self.offset = offset
         self.resolver = SearchResolver(
-            params=snuba_params, config=SearchResolverConfig(), definitions=definitions
+            params=snuba_params,
+            config=SearchResolverConfig(disable_array_attributes=not supports_arrays),
+            definitions=definitions,
         )
         self.search_type, self.attribute_key, self.context_definition = self.resolve_attribute_key(
             key
@@ -1198,6 +1208,16 @@ class TraceItemAttributeValuesAutocompletionExecutor:
 
         if self.search_type == "string":
             return self.string_autocomplete_function()
+
+        # Array attributes autocomplete their individual element values. The tag
+        # form resolves to the generic array type, so ask Snuba for the string
+        # elements (e.g. "title") rather than whole arrays. Explicit array tag
+        # syntax resolves regardless of the flag, so gate the behavior here.
+        if self.search_type == "array" and self.supports_arrays:
+            array_key = AttributeKey(
+                name=self.attribute_key.name, type=AttributeKey.Type.TYPE_ARRAY_STRING
+            )
+            return self.string_autocomplete_function(key=array_key)
 
         return []
 
@@ -1390,7 +1410,7 @@ class TraceItemAttributeValuesAutocompletionExecutor:
             ),
         ]
 
-    def string_autocomplete_function(self) -> list[TagValue]:
+    def string_autocomplete_function(self, key: AttributeKey | None = None) -> list[TagValue]:
         adjusted_start_date, adjusted_end_date = adjust_start_end_window(
             self.snuba_params.start_date, self.snuba_params.end_date
         )
@@ -1405,7 +1425,7 @@ class TraceItemAttributeValuesAutocompletionExecutor:
         meta = self.resolver.resolve_meta(referrer=Referrer.API_SPANS_TAG_VALUES_RPC.value)
         rpc_request = TraceItemAttributeValuesRequest(
             meta=meta,
-            key=self.attribute_key,
+            key=key if key is not None else self.attribute_key,
             value_substring_match=query,
             limit=self.limit,
             page_token=PageToken(offset=self.offset),

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -10,7 +10,6 @@ from rest_framework.exceptions import ErrorDetail
 from sentry_conventions.attributes import ATTRIBUTE_METADATA
 from sentry_protos.snuba.v1.endpoint_trace_item_attributes_pb2 import (
     TraceItemAttributeNamesResponse,
-    TraceItemAttributeValuesResponse,
 )
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey
 from sentry_protos.snuba.v1.trace_item_pb2 import AnyValue, ArrayValue
@@ -1983,6 +1982,10 @@ class OrganizationTraceItemAttributeValuesEndpointLogsTest(
 ):
     item_type = SupportedTraceItemType.LOGS
     feature_flags = {"organizations:ourlogs-enabled": True}
+    array_feature_flags = {
+        "organizations:ourlogs-enabled": True,
+        "organizations:trace-item-array-query-support": True,
+    }
 
     def test_no_feature(self) -> None:
         response = self.do_request(features={}, key="test.attribute")
@@ -2034,55 +2037,49 @@ class OrganizationTraceItemAttributeValuesEndpointLogsTest(
         assert "value2" in values
         assert all(item["key"] == "test1" for item in response.data)
 
-    def test_array_attribute_values_are_elements(self) -> None:
+    @pytest.mark.xfail(
+        strict=False,
+        reason=(
+            "Blocked on EAP, the attribute-values RPC "
+            "(snuba/web/rpc/v1/trace_item_attribute_values.py) rejects array types. Remove this marker then."
+        ),
+    )
+    def test_array_attribute_values(self) -> None:
+        """Values endpoint against a string-array attribute.
+
+        The log carries a string-array attribute. The array-tag key form
+        resolves to the array branch (coerced to TYPE_ARRAY_STRING for Snuba),
+        and the endpoint should list the individual element values.
+        """
         key = "tags[data_export.csv_headers,array]"
 
-        # Snuba's attribute-values RPC does not yet enumerate array elements (it
-        # rejects array types), so mock it. This still verifies the endpoint
-        # routes an array key through the string-value path as an array-string
-        # key and returns individual elements rather than whole arrays.
-        with mock.patch(
-            "sentry.utils.snuba_rpc.attribute_values_rpc",
-            return_value=TraceItemAttributeValuesResponse(
-                values=["title", "project"], counts=[2, 1]
-            ),
-        ) as mock_rpc:
-            response = self.do_request(
-                query={"project": self.project.id},
-                key=key,
-                features={
-                    **self.feature_flags,
-                    "organizations:trace-item-array-query-support": True,
+        logs = [
+            self.create_ourlog(
+                organization=self.organization,
+                project=self.project,
+                attributes={
+                    "data_export.csv_headers": {
+                        "array_value": ArrayValue(
+                            values=[
+                                AnyValue(string_value="title"),
+                                AnyValue(string_value="project"),
+                            ]
+                        )
+                    }
                 },
-            )
+            ),
+        ]
+        self.store_eap_items(logs)
 
-        assert response.status_code == 200, response.content
-
-        # The endpoint resolved the array key and asked Snuba for a string-array type.
-        rpc_request = mock_rpc.call_args.args[0]
-        assert rpc_request.key.type == AttributeKey.Type.TYPE_ARRAY_STRING
-
-        # Suggestions are the individual elements, not the whole array.
-        values = {item["value"] for item in response.data}
-        assert values == {"title", "project"}
-        assert all(item["key"] == key for item in response.data)
-
-    def test_array_attribute_values_gated_by_feature(self) -> None:
-        # Explicit array tag syntax resolves even without the flag, so the endpoint
-        # must not query Snuba for array elements when the feature is off.
-        with mock.patch(
-            "sentry.utils.snuba_rpc.attribute_values_rpc",
-            return_value=TraceItemAttributeValuesResponse(values=["title"], counts=[1]),
-        ) as mock_rpc:
-            response = self.do_request(
-                query={"project": self.project.id},
-                key="tags[data_export.csv_headers,array]",
-                features=self.feature_flags,
-            )
-
-        assert response.status_code == 200, response.content
-        assert response.data == []
-        assert mock_rpc.call_count == 0
+        string_response = self.do_request(
+            key=key,
+            query={"attributeType": "array"},
+            features=self.array_feature_flags,
+        )
+        assert string_response.status_code == 200, string_response.content
+        string_values = {item["value"] for item in string_response.data}
+        assert {"title", "project"} <= string_values
+        assert all(item["key"] == key for item in string_response.data)
 
 
 class OrganizationTraceItemAttributeValuesEndpointSpansTest(

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -10,6 +10,7 @@ from rest_framework.exceptions import ErrorDetail
 from sentry_conventions.attributes import ATTRIBUTE_METADATA
 from sentry_protos.snuba.v1.endpoint_trace_item_attributes_pb2 import (
     TraceItemAttributeNamesResponse,
+    TraceItemAttributeValuesResponse,
 )
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey
 from sentry_protos.snuba.v1.trace_item_pb2 import AnyValue, ArrayValue
@@ -2032,6 +2033,56 @@ class OrganizationTraceItemAttributeValuesEndpointLogsTest(
         assert "value1" in values
         assert "value2" in values
         assert all(item["key"] == "test1" for item in response.data)
+
+    def test_array_attribute_values_are_elements(self) -> None:
+        key = "tags[data_export.csv_headers,array]"
+
+        # Snuba's attribute-values RPC does not yet enumerate array elements (it
+        # rejects array types), so mock it. This still verifies the endpoint
+        # routes an array key through the string-value path as an array-string
+        # key and returns individual elements rather than whole arrays.
+        with mock.patch(
+            "sentry.utils.snuba_rpc.attribute_values_rpc",
+            return_value=TraceItemAttributeValuesResponse(
+                values=["title", "project"], counts=[2, 1]
+            ),
+        ) as mock_rpc:
+            response = self.do_request(
+                query={"project": self.project.id},
+                key=key,
+                features={
+                    **self.feature_flags,
+                    "organizations:trace-item-array-query-support": True,
+                },
+            )
+
+        assert response.status_code == 200, response.content
+
+        # The endpoint resolved the array key and asked Snuba for a string-array type.
+        rpc_request = mock_rpc.call_args.args[0]
+        assert rpc_request.key.type == AttributeKey.Type.TYPE_ARRAY_STRING
+
+        # Suggestions are the individual elements, not the whole array.
+        values = {item["value"] for item in response.data}
+        assert values == {"title", "project"}
+        assert all(item["key"] == key for item in response.data)
+
+    def test_array_attribute_values_gated_by_feature(self) -> None:
+        # Explicit array tag syntax resolves even without the flag, so the endpoint
+        # must not query Snuba for array elements when the feature is off.
+        with mock.patch(
+            "sentry.utils.snuba_rpc.attribute_values_rpc",
+            return_value=TraceItemAttributeValuesResponse(values=["title"], counts=[1]),
+        ) as mock_rpc:
+            response = self.do_request(
+                query={"project": self.project.id},
+                key="tags[data_export.csv_headers,array]",
+                features=self.feature_flags,
+            )
+
+        assert response.status_code == 200, response.content
+        assert response.data == []
+        assert mock_rpc.call_count == 0
 
 
 class OrganizationTraceItemAttributeValuesEndpointSpansTest(

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -2081,6 +2081,46 @@ class OrganizationTraceItemAttributeValuesEndpointLogsTest(
         assert {"title", "project"} <= string_values
         assert all(item["key"] == key for item in string_response.data)
 
+    @pytest.mark.xfail(
+        strict=False,
+        reason=(
+            "Blocked on EAP, the attribute-values RPC "
+            "(snuba/web/rpc/v1/trace_item_attribute_values.py) rejects array types. Remove this marker then."
+        ),
+    )
+    def test_array_attribute_values_numeric_returns_nothing(self) -> None:
+        """Numeric arrays yield no value suggestions.
+
+        Only string-array elements are autocompleted. A numeric array resolves to
+        the same array branch (coerced to TYPE_ARRAY_STRING for Snuba), so the
+        string-array lookup finds nothing and the endpoint returns no values,
+        matching scalar number attributes.
+        """
+        key = "tags[data_export.blob_offsets,array]"
+
+        logs = [
+            self.create_ourlog(
+                organization=self.organization,
+                project=self.project,
+                attributes={
+                    "data_export.blob_offsets": {
+                        "array_value": ArrayValue(
+                            values=[AnyValue(int_value=0), AnyValue(int_value=1048576)]
+                        )
+                    }
+                },
+            ),
+        ]
+        self.store_eap_items(logs)
+
+        response = self.do_request(
+            key=key,
+            query={"attributeType": "array"},
+            features=self.array_feature_flags,
+        )
+        assert response.status_code == 200, response.content
+        assert response.data == []
+
 
 class OrganizationTraceItemAttributeValuesEndpointSpansTest(
     OrganizationTraceItemAttributeValuesEndpointBaseTest,


### PR DESCRIPTION
## Summary

Array-typed attributes (e.g. `tags[data_export.csv_headers,array]`) returned **no** value suggestions in the Explore search bar. The trace-item **values** endpoint's `execute()` only handled `string`/`boolean` search types and fell through to `[]` for arrays.
Gated behind `organizations:trace-item-array-query-support`.


Blocked on[ EAP](https://linear.app/getsentry/issue/EAP-698/return-array-information-from-attributevalues-endpoint) to send array attribute values. 

Refs EXP-1135