### PR TITLE
feat(seer): Bypass quota and repo checks in /autofix/setup/ for free cohort orgs

### DIFF
--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -506,6 +506,7 @@ def trigger_autofix_agent(
     enable_bash_tools: bool = False,
     actor_user_id: int | None = None,
     commit_author: SeerCommitAuthor | None = None,
+    allow_free_cohort: bool = False,
 ) -> SeerRun:
     """
     Start or continue an agent-based autofix run.
@@ -515,14 +516,15 @@ def trigger_autofix_agent(
         step: Which autofix step to run
         run_id: Existing run ID to continue, or None for new run
         stopping_point: Where to stop the automated pipeline (only used for new runs)
+        allow_free_cohort: Internal-only flag set by night shift to bypass
+            quota for free cohort orgs. Not exposed via the API.
     """
     # check billing quota for triggering a new autofix run
-    # Free cohort orgs bypass quota only for night shift runs — they can
-    # view results but cannot manually trigger autofix.
+    # Free cohort orgs bypass quota only when called from night shift
+    # (allow_free_cohort=True). The API endpoint never sets this flag,
+    # so manual triggers still require quota.
     if run_id is None:
-        skip_quota = (
-            is_free_cohort_org(group.organization) and referrer == AutofixReferrer.NIGHT_SHIFT
-        )
+        skip_quota = allow_free_cohort and is_free_cohort_org(group.organization)
         if not skip_quota:
             has_budget: bool = quotas.backend.check_seer_quota(
                 org_id=group.organization.id,
@@ -543,6 +545,7 @@ def trigger_autofix_agent(
             referrer=referrer,
             user_context=user_context,
             stopping_point=stopping_point,
+            allow_free_cohort=allow_free_cohort,
         )
         feature_run_id = feature_run.seer_run_state_id
         if feature_run_id is None:

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -517,15 +517,19 @@ def trigger_autofix_agent(
         stopping_point: Where to stop the automated pipeline (only used for new runs)
     """
     # check billing quota for triggering a new autofix run
-    # Free cohort orgs have no Subscription so check_seer_quota returns False.
-    # Bypass the check for them — they get autofix without billing.
-    if run_id is None and not is_free_cohort_org(group.organization):
-        has_budget: bool = quotas.backend.check_seer_quota(
-            org_id=group.organization.id,
-            data_category=DataCategory.SEER_AUTOFIX,
+    # Free cohort orgs bypass quota only for night shift runs — they can
+    # view results but cannot manually trigger autofix.
+    if run_id is None:
+        skip_quota = (
+            is_free_cohort_org(group.organization) and referrer == AutofixReferrer.NIGHT_SHIFT
         )
-        if not has_budget:
-            raise NoSeerQuotaException()
+        if not skip_quota:
+            has_budget: bool = quotas.backend.check_seer_quota(
+                org_id=group.organization.id,
+                data_category=DataCategory.SEER_AUTOFIX,
+            )
+            if not has_budget:
+                raise NoSeerQuotaException()
 
     use_seer_rca_feature = features.has(
         "organizations:autofix-rca-in-seer", group.organization, actor=user

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -927,13 +927,30 @@ def replace_all_seer_project_repos(
 
 
 def has_project_connected_repos(organization: Organization, project: Project) -> bool:
-    """Check if a project has connected repositories for Seer automation."""
-    return SeerProjectRepository.objects.filter(
+    """Check if a project has connected repositories for Seer automation.
+
+    For free cohort orgs (no SeerProjectRepository rows), falls back to
+    checking ProjectRepository directly.
+    """
+    has_seer_repos = SeerProjectRepository.objects.filter(
         project_repository__project=project,
         project_repository__project__organization_id=organization.id,
         project_repository__project__status=ObjectStatus.ACTIVE,
         project_repository__repository__status=ObjectStatus.ACTIVE,
     ).exists()
+    if has_seer_repos:
+        return True
+
+    # Free cohort orgs have ProjectRepository rows but no SeerProjectRepository rows.
+    if is_free_cohort_org(organization):
+        return ProjectRepository.objects.filter(
+            project=project,
+            project__organization_id=organization.id,
+            project__status=ObjectStatus.ACTIVE,
+            repository__status=ObjectStatus.ACTIVE,
+        ).exists()
+
+    return False
 
 
 def get_autofix_repos_from_project_code_mappings(

--- a/src/sentry/seer/autofix_rca/dispatch.py
+++ b/src/sentry/seer/autofix_rca/dispatch.py
@@ -7,13 +7,13 @@ from sentry import quotas
 from sentry.constants import DataCategory
 from sentry.seer.agent.client import SeerAgentClient
 from sentry.seer.autofix.autofix_agent import NoSeerQuotaException
+from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.autofix.utils import is_free_cohort_org
 from sentry.seer.autofix_rca.models import FEATURE_ID, AutofixRCAPayload, AutofixRCATweaks
 from sentry.utils import metrics
 
 if TYPE_CHECKING:
     from sentry.models.group import Group
-    from sentry.seer.autofix.constants import AutofixReferrer
     from sentry.seer.autofix.utils import AutofixStoppingPoint
     from sentry.seer.models.run import SeerRun
 
@@ -30,9 +30,10 @@ def trigger_autofix_rca_feature(
     reasoning_effort: Literal["low", "medium", "high"] | None = "medium",
     flush: bool = True,
 ) -> SeerRun:
-    # Free cohort orgs have no Subscription so check_seer_quota returns False.
-    # Bypass the check for them — night shift dispatches through this path.
-    if not is_free_cohort_org(group.organization):
+    # Free cohort orgs bypass quota only for night shift runs — they can
+    # view results but cannot manually trigger autofix.
+    skip_quota = is_free_cohort_org(group.organization) and referrer == AutofixReferrer.NIGHT_SHIFT
+    if not skip_quota:
         has_budget: bool = quotas.backend.check_seer_quota(
             org_id=group.organization.id,
             data_category=DataCategory.SEER_AUTOFIX,

--- a/src/sentry/seer/autofix_rca/dispatch.py
+++ b/src/sentry/seer/autofix_rca/dispatch.py
@@ -7,13 +7,13 @@ from sentry import quotas
 from sentry.constants import DataCategory
 from sentry.seer.agent.client import SeerAgentClient
 from sentry.seer.autofix.autofix_agent import NoSeerQuotaException
-from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.autofix.utils import is_free_cohort_org
 from sentry.seer.autofix_rca.models import FEATURE_ID, AutofixRCAPayload, AutofixRCATweaks
 from sentry.utils import metrics
 
 if TYPE_CHECKING:
     from sentry.models.group import Group
+    from sentry.seer.autofix.constants import AutofixReferrer
     from sentry.seer.autofix.utils import AutofixStoppingPoint
     from sentry.seer.models.run import SeerRun
 
@@ -29,10 +29,11 @@ def trigger_autofix_rca_feature(
     intelligence_level: Literal["low", "medium", "high"] = "medium",
     reasoning_effort: Literal["low", "medium", "high"] | None = "medium",
     flush: bool = True,
+    allow_free_cohort: bool = False,
 ) -> SeerRun:
-    # Free cohort orgs bypass quota only for night shift runs — they can
-    # view results but cannot manually trigger autofix.
-    skip_quota = is_free_cohort_org(group.organization) and referrer == AutofixReferrer.NIGHT_SHIFT
+    # Free cohort orgs bypass quota only when called from night shift
+    # (allow_free_cohort=True). Not exposed via the API.
+    skip_quota = allow_free_cohort and is_free_cohort_org(group.organization)
     if not skip_quota:
         has_budget: bool = quotas.backend.check_seer_quota(
             org_id=group.organization.id,

--- a/src/sentry/seer/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/seer/endpoints/group_autofix_setup_check.py
@@ -20,6 +20,7 @@ from sentry.ratelimits.config import RateLimitConfig
 from sentry.seer.autofix.constants import AutofixAutomationTuningSettings
 from sentry.seer.autofix.utils import (
     has_project_connected_repos,
+    is_free_cohort_org,
 )
 from sentry.seer.seer_setup import get_supported_scm_providers
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
@@ -94,9 +95,14 @@ class GroupAutofixSetupCheck(GroupAiEndpoint):
                 organization=org, project=group.project
             )
 
-        has_autofix_quota: bool = quotas.backend.check_seer_quota(
-            org_id=org.id, data_category=DataCategory.SEER_AUTOFIX
-        )
+        # Free cohort orgs have no subscription so check_seer_quota returns False.
+        # Bypass the check so they see the autofix UI.
+        if is_free_cohort_org(org):
+            has_autofix_quota = True
+        else:
+            has_autofix_quota = quotas.backend.check_seer_quota(
+                org_id=org.id, data_category=DataCategory.SEER_AUTOFIX
+            )
 
         seer_repos_linked = False
         # Check if org has github integration and is on seat-based tier.

--- a/src/sentry/seer/night_shift/delivery.py
+++ b/src/sentry/seer/night_shift/delivery.py
@@ -228,6 +228,7 @@ def _process_verdicts(
                     referrer=referrer,
                     stopping_point=stopping_point_by_project_id[group.project_id],
                     user_context=user_context,
+                    allow_free_cohort=True,
                 )
             except Exception:
                 logger.exception(

--- a/tests/sentry/seer/endpoints/test_group_autofix_setup_check.py
+++ b/tests/sentry/seer/endpoints/test_group_autofix_setup_check.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 from sentry.integrations.types import IntegrationProviderSlug
+from sentry.models.projectrepository import ProjectRepository
 from sentry.models.repository import Repository
 from sentry.seer.autofix.constants import AutofixAutomationTuningSettings
 from sentry.seer.endpoints.group_autofix_setup_check import (
@@ -272,3 +273,68 @@ class GroupAIAutofixEndpointFailureTest(APITestCase, SnubaTestCase):
         }
         # seerReposLinked should be False when integration is missing
         assert response.data["seerReposLinked"] is False
+
+
+@with_feature("organizations:gen-ai-features")
+class GroupAIAutofixSetupFreeCohortTest(APITestCase, SnubaTestCase):
+    """Tests for free cohort org behavior in the /autofix/setup/ endpoint."""
+
+    def setUp(self) -> None:
+        super().setUp()
+
+        integration = self.create_integration(organization=self.organization, external_id="1")
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.org_integration = integration.add_organization(self.organization, self.user)
+
+        self.repo = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="example",
+            integration_id=integration.id,
+        )
+
+    @patch(
+        "sentry.seer.endpoints.group_autofix_setup_check.is_free_cohort_org",
+        return_value=True,
+    )
+    def test_free_cohort_org_has_autofix_quota(self, mock_is_free_cohort: MagicMock) -> None:
+        """Free cohort orgs bypass check_seer_quota and get hasAutofixQuota: True."""
+        group = self.create_group()
+        self.login_as(user=self.user)
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/autofix/setup/"
+        response = self.client.get(url, format="json")
+
+        assert response.status_code == 200
+        assert response.data["billing"]["hasAutofixQuota"] is True
+
+    @patch(
+        "sentry.seer.endpoints.group_autofix_setup_check.is_free_cohort_org",
+        return_value=True,
+    )
+    @patch(
+        "sentry.seer.autofix.utils.is_free_cohort_org",
+        return_value=True,
+    )
+    @patch(
+        "sentry.seer.endpoints.group_autofix_setup_check.get_autofix_integration_setup_problems",
+        return_value=None,
+    )
+    def test_free_cohort_org_with_project_repos_has_seer_repos_linked(
+        self,
+        mock_integration_check: MagicMock,
+        mock_utils_free_cohort: MagicMock,
+        mock_endpoint_free_cohort: MagicMock,
+    ) -> None:
+        """Free cohort orgs with ProjectRepository rows get seerReposLinked: True."""
+        ProjectRepository.objects.create(
+            project=self.project,
+            repository=self.repo,
+        )
+
+        group = self.create_group()
+        self.login_as(user=self.user)
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/autofix/setup/"
+        response = self.client.get(url, format="json")
+
+        assert response.status_code == 200
+        assert response.data["seerReposLinked"] is True


### PR DESCRIPTION
## Summary
- In `group_autofix_setup_check.py`, bypass `check_seer_quota` for free cohort orgs so `hasAutofixQuota` returns `True` (they have no subscription, so the quota check always returns `False`).
- In `has_project_connected_repos()` (`utils.py`), fall back to `ProjectRepository` for free cohort orgs. They have `ProjectRepository` rows (auto-created by event processing) but no `SeerProjectRepository` rows (requires explicit Seer config), so `seerReposLinked` was always `False`.
- Without these changes, the issue detail UI shows a paywall and "Set Up Seer" prompt for free cohort orgs.

## Test plan
- [x] `test_free_cohort_org_has_autofix_quota` — free cohort org gets `hasAutofixQuota: True`
- [x] `test_free_cohort_org_with_project_repos_has_seer_repos_linked` — free cohort org with `ProjectRepository` rows gets `seerReposLinked: True`
- [x] All 16 existing tests in `test_group_autofix_setup_check.py` pass