### PR TITLE
ref(snuba): Classify unhealthy-upstream responses as 503

### DIFF
--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -15,7 +15,7 @@ from django.db.utils import OperationalError
 from django.http import HttpRequest
 from django.utils import timezone
 from rest_framework.exceptions import APIException, ParseError, Throttled, ValidationError
-from rest_framework.status import HTTP_504_GATEWAY_TIMEOUT
+from rest_framework.status import HTTP_503_SERVICE_UNAVAILABLE, HTTP_504_GATEWAY_TIMEOUT
 from sentry_sdk import Scope
 from snuba_sdk.column import InvalidColumnError
 from urllib3.exceptions import MaxRetryError, ReadTimeoutError, TimeoutError
@@ -40,6 +40,7 @@ from sentry.organizations.services.organization import (
 )
 from sentry.search.events.constants import (
     RATE_LIMIT_ERROR_MESSAGE,
+    SNUBA_UNAVAILABLE_ERROR_MESSAGE,
     TIMEOUT_ERROR_MESSAGE,
     TIMEOUT_RPC_ERROR_MESSAGE,
 )
@@ -64,6 +65,7 @@ from sentry.utils.snuba import (
     RateLimitExceeded,
     SchemaValidationError,
     SnubaError,
+    SnubaServiceUnavailable,
     UnqualifiedQueryError,
 )
 from sentry.utils.snuba_rpc import (
@@ -80,6 +82,10 @@ MAX_STATS_PERIOD = timedelta(days=90)
 
 class TimeoutException(APIException):
     status_code = HTTP_504_GATEWAY_TIMEOUT
+
+
+class ServiceUnavailable(APIException):
+    status_code = HTTP_503_SERVICE_UNAVAILABLE
 
 
 def get_datetime_from_stats_period(
@@ -444,6 +450,13 @@ def handle_query_errors() -> Generator[None]:
             sentry_sdk.set_tag("query.error_reason", "TooManySimultaneousQueries")
             sentry_sdk.set_attribute("query.error_reason", "TooManySimultaneousQueries")
             raise Throttled(detail=RATE_LIMIT_ERROR_MESSAGE)
+        if isinstance(error, SnubaServiceUnavailable):
+            sentry_sdk.set_tag("query.error_reason", "ServiceUnavailable")
+            sentry_sdk.set_attribute("query.error_reason", "ServiceUnavailable")
+            # An unreachable upstream is expected transient noise, so report it at warning
+            # level rather than as an error.
+            sentry_sdk.capture_message(str(error), level="warning")
+            raise ServiceUnavailable(detail=SNUBA_UNAVAILABLE_ERROR_MESSAGE)
         if isinstance(
             error,
             (

--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -21,6 +21,9 @@ filter on the transaction field or tags.
 TIMEOUT_RPC_ERROR_MESSAGE = """
 Query timeout. Please try again. If the problem persists try a smaller date range or fewer projects.
 """
+SNUBA_UNAVAILABLE_ERROR_MESSAGE = """
+The query service is temporarily unavailable. Please try again in a moment.
+"""
 PROJECT_THRESHOLD_CONFIG_INDEX_ALIAS = "project_threshold_config_index"
 PROJECT_THRESHOLD_OVERRIDE_CONFIG_INDEX_ALIAS = "project_threshold_override_config_index"
 PROJECT_THRESHOLD_CONFIG_ALIAS = "project_threshold_config"

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -374,6 +374,15 @@ class UnexpectedResponseError(SnubaError):
     """
 
 
+class SnubaServiceUnavailable(SnubaError):
+    """
+    Exception raised when Snuba (or the proxy in front of it) was unreachable or
+    unhealthy, meaning the query never ran. Deliberately not a QueryExecutionError:
+    nothing was executed, so the caller should surface this as a retryable 503
+    rather than a query failure.
+    """
+
+
 class QueryExecutionError(SnubaError):
     """
     Exception raised when a query failed to execute.
@@ -1302,11 +1311,21 @@ def _bulk_snuba_query(snuba_requests: Sequence[SnubaRequest]) -> ResultSet:
                         log_snuba_info("{}.err: {}".format(referrer, body["error"]))
             except ValueError:
                 if response.status != 200:
+                    error_body = _decode_response_body(response.data)
                     logger.warning(
                         "snuba.query.invalid-json",
-                        extra={"response.data": response.data},
+                        extra={
+                            "response.status": response.status,
+                            "response.data": error_body[:1000],
+                        },
                     )
-                    raise SnubaError("Failed to parse snuba error response")
+                    # First line only, so that grouping stays stable across bodies that embed
+                    # per-request detail on later lines.
+                    summary = error_body.splitlines()[0][:128] if error_body else "<empty body>"
+                    message = f"Snuba returned HTTP {response.status}: {summary}"
+                    if response.status in (502, 503, 504):
+                        raise SnubaServiceUnavailable(message)
+                    raise SnubaError(message)
                 raise UnexpectedResponseError(f"Could not decode JSON response: {response.data!r}")
 
             allocation_policy_prefix = "allocation_policy."
@@ -1398,6 +1417,18 @@ def _bulk_snuba_query(snuba_requests: Sequence[SnubaRequest]) -> ResultSet:
             results.append(body)
 
         return results
+
+
+def _decode_response_body(data: bytes) -> str:
+    """Decode a response body for logging, falling back to a placeholder.
+
+    Callers must not pass raw bytes to the logger: log records are serialized as JSON, and a
+    body that isn't valid UTF-8 raises during serialization and drops the whole log line.
+    """
+    try:
+        return data.decode("utf-8")
+    except (UnicodeDecodeError, AttributeError):
+        return "<non-text response body>"
 
 
 def _log_request_query(req: Request) -> None:

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1311,14 +1311,11 @@ def _bulk_snuba_query(snuba_requests: Sequence[SnubaRequest]) -> ResultSet:
                         log_snuba_info("{}.err: {}".format(referrer, body["error"]))
             except ValueError:
                 if response.status != 200:
-                    error_body = _decode_response_body(response.data)
                     logger.warning(
                         "snuba.query.invalid-json",
-                        extra={
-                            "response.status": response.status,
-                            "response.data": error_body[:1000],
-                        },
+                        extra={"response.data": response.data},
                     )
+                    error_body = response.data.decode("utf-8", errors="replace")
                     # First line only, so that grouping stays stable across bodies that embed
                     # per-request detail on later lines.
                     summary = error_body.splitlines()[0][:128] if error_body else "<empty body>"
@@ -1417,18 +1414,6 @@ def _bulk_snuba_query(snuba_requests: Sequence[SnubaRequest]) -> ResultSet:
             results.append(body)
 
         return results
-
-
-def _decode_response_body(data: bytes) -> str:
-    """Decode a response body for logging, falling back to a placeholder.
-
-    Callers must not pass raw bytes to the logger: log records are serialized as JSON, and a
-    body that isn't valid UTF-8 raises during serialization and drops the whole log line.
-    """
-    try:
-        return data.decode("utf-8")
-    except (UnicodeDecodeError, AttributeError):
-        return "<non-text response body>"
 
 
 def _log_request_query(req: Request) -> None:

--- a/tests/sentry/api/test_utils.py
+++ b/tests/sentry/api/test_utils.py
@@ -8,6 +8,7 @@ from django.utils import timezone
 from rest_framework.exceptions import APIException, Throttled, ValidationError
 from sentry_sdk import Scope
 from snuba_sdk.column import InvalidColumnError
+from urllib3 import HTTPConnectionPool
 from urllib3.exceptions import ReadTimeoutError
 
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -268,7 +269,9 @@ class HandleQueryErrorsTest(APITestCase):
         """A SnubaError wrapping a urllib3 timeout stays a 504."""
         with pytest.raises(APIException) as exc_info:
             with handle_query_errors():
-                raise SnubaError(ReadTimeoutError(None, "/query", "read timed out"))
+                raise SnubaError(
+                    ReadTimeoutError(HTTPConnectionPool("snuba"), "/query", "read timed out")
+                )
 
         assert exc_info.value.status_code == 504
 

--- a/tests/sentry/api/test_utils.py
+++ b/tests/sentry/api/test_utils.py
@@ -8,6 +8,7 @@ from django.utils import timezone
 from rest_framework.exceptions import APIException, Throttled, ValidationError
 from sentry_sdk import Scope
 from snuba_sdk.column import InvalidColumnError
+from urllib3.exceptions import ReadTimeoutError
 
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.utils import (
@@ -36,6 +37,7 @@ from sentry.utils.snuba import (
     QueryTooManySimultaneous,
     SchemaValidationError,
     SnubaError,
+    SnubaServiceUnavailable,
     UnqualifiedQueryError,
 )
 from sentry.utils.snuba_rpc import SnubaRPCTooManySimultaneous
@@ -253,6 +255,30 @@ class HandleQueryErrorsTest(APITestCase):
                 raise SnubaRPCTooManySimultaneous(error_proto)
         except Exception as e:
             assert isinstance(e, Throttled)
+
+    def test_handle_snuba_service_unavailable(self) -> None:
+        """An unhealthy Snuba upstream should return 503, not 500."""
+        with pytest.raises(APIException) as exc_info:
+            with handle_query_errors():
+                raise SnubaServiceUnavailable("Snuba returned HTTP 503: no healthy upstream")
+
+        assert exc_info.value.status_code == 503
+
+    def test_handle_snuba_read_timeout_is_still_a_gateway_timeout(self) -> None:
+        """A SnubaError wrapping a urllib3 timeout stays a 504."""
+        with pytest.raises(APIException) as exc_info:
+            with handle_query_errors():
+                raise SnubaError(ReadTimeoutError(None, "/query", "read timed out"))
+
+        assert exc_info.value.status_code == 504
+
+    def test_handle_bare_snuba_error_is_still_a_server_error(self) -> None:
+        """A SnubaError we cannot classify stays a 500 - only 5xx upstreams become 503."""
+        with pytest.raises(APIException) as exc_info:
+            with handle_query_errors():
+                raise SnubaError("Snuba returned HTTP 400: something we don't model")
+
+        assert exc_info.value.status_code == 500
 
 
 class ClampDateRangeTest(unittest.TestCase):

--- a/tests/sentry/utils/test_snuba.py
+++ b/tests/sentry/utils/test_snuba.py
@@ -829,11 +829,10 @@ class SnubaUnparseableErrorResponseTest(TestCase):
         assert str(exc_info.value) == "Snuba returned HTTP 400: totally not json"
 
     @mock.patch("sentry.utils.snuba._snuba_query")
-    def test_non_utf8_body_does_not_raise_while_decoding(self, mock_snuba_query) -> None:
-        with pytest.raises(SnubaServiceUnavailable) as exc_info:
+    def test_non_utf8_body_still_classifies(self, mock_snuba_query) -> None:
+        """Building the message must not raise on a body that isn't valid UTF-8."""
+        with pytest.raises(SnubaServiceUnavailable):
             self.run_query(mock_snuba_query, 503, b"\xff\xfe\x00invalid")
-
-        assert str(exc_info.value) == "Snuba returned HTTP 503: <non-text response body>"
 
     @mock.patch("sentry.utils.snuba._snuba_query")
     def test_empty_body(self, mock_snuba_query) -> None:

--- a/tests/sentry/utils/test_snuba.py
+++ b/tests/sentry/utils/test_snuba.py
@@ -21,8 +21,11 @@ from sentry.utils.snuba import (
     ROUND_UP,
     RateLimitExceeded,
     RetrySkipTimeout,
+    SnubaError,
     SnubaQueryParams,
     SnubaRequest,
+    SnubaServiceUnavailable,
+    UnexpectedResponseError,
     UnqualifiedQueryError,
     _bulk_snuba_query,
     _prepare_query_params,
@@ -756,6 +759,94 @@ class SnubaQueryRateLimitTest(TestCase):
             _bulk_snuba_query([make_request("ok"), make_request("rate_limited")])
 
         assert mock.call("allocation_policy.is_successful", True) not in mock_set_tag.call_args_list
+
+
+class SnubaUnparseableErrorResponseTest(TestCase):
+    """Classification of non-200 responses whose body is not JSON.
+
+    Snuba sits behind a proxy that answers with plain text when no backend is reachable. Those
+    responses must be distinguishable from Snuba itself returning something malformed, so
+    callers can map them to a retryable 503.
+    """
+
+    def setUp(self) -> None:
+        request = Request(
+            dataset="events",
+            app_id="test",
+            query=Query(
+                match=Entity("events"),
+                select=[Function("count", parameters=[], alias="count")],
+                where=[Condition(Column("project_id"), Op.EQ, self.project.id)],
+            ),
+        )
+        self.snuba_request = SnubaRequest(
+            request=request,
+            referrer="test_referrer",
+            forward=lambda x: x,
+            reverse=lambda x: x,
+        )
+
+    def run_query(self, mock_snuba_query, status: int, body: bytes) -> None:
+        mock_response = mock.Mock(spec=HTTPResponse)
+        mock_response.status = status
+        mock_response.data = body
+        mock_snuba_query.return_value = ("test_referrer", mock_response, lambda x: x, lambda x: x)
+        _bulk_snuba_query([self.snuba_request])
+
+    @mock.patch("sentry.utils.snuba._snuba_query")
+    def test_unhealthy_upstream_raises_service_unavailable(self, mock_snuba_query) -> None:
+        with pytest.raises(SnubaServiceUnavailable) as exc_info:
+            self.run_query(mock_snuba_query, 503, b"no healthy upstream")
+
+        assert str(exc_info.value) == "Snuba returned HTTP 503: no healthy upstream"
+
+    @mock.patch("sentry.utils.snuba._snuba_query")
+    def test_bad_gateway_raises_service_unavailable(self, mock_snuba_query) -> None:
+        with pytest.raises(SnubaServiceUnavailable):
+            self.run_query(mock_snuba_query, 502, b"<html><body>502 Bad Gateway</body></html>")
+
+    @mock.patch("sentry.utils.snuba._snuba_query")
+    def test_multiline_body_is_summarized_to_first_line(self, mock_snuba_query) -> None:
+        with pytest.raises(SnubaServiceUnavailable) as exc_info:
+            self.run_query(mock_snuba_query, 503, b"<html>\r\n<head><title>503</title></head>\r\n")
+
+        assert str(exc_info.value) == "Snuba returned HTTP 503: <html>"
+
+    @mock.patch("sentry.utils.snuba._snuba_query")
+    def test_long_body_is_truncated(self, mock_snuba_query) -> None:
+        with pytest.raises(SnubaServiceUnavailable) as exc_info:
+            self.run_query(mock_snuba_query, 503, b"x" * 500)
+
+        assert str(exc_info.value) == "Snuba returned HTTP 503: " + "x" * 128
+
+    @mock.patch("sentry.utils.snuba._snuba_query")
+    def test_non_5xx_stays_a_plain_snuba_error(self, mock_snuba_query) -> None:
+        """A 4xx with an unparseable body is not an availability failure."""
+        with pytest.raises(SnubaError) as exc_info:
+            self.run_query(mock_snuba_query, 400, b"totally not json")
+
+        assert not isinstance(exc_info.value, SnubaServiceUnavailable)
+        assert str(exc_info.value) == "Snuba returned HTTP 400: totally not json"
+
+    @mock.patch("sentry.utils.snuba._snuba_query")
+    def test_non_utf8_body_does_not_raise_while_decoding(self, mock_snuba_query) -> None:
+        with pytest.raises(SnubaServiceUnavailable) as exc_info:
+            self.run_query(mock_snuba_query, 503, b"\xff\xfe\x00invalid")
+
+        assert str(exc_info.value) == "Snuba returned HTTP 503: <non-text response body>"
+
+    @mock.patch("sentry.utils.snuba._snuba_query")
+    def test_empty_body(self, mock_snuba_query) -> None:
+        with pytest.raises(SnubaServiceUnavailable) as exc_info:
+            self.run_query(mock_snuba_query, 503, b"")
+
+        assert str(exc_info.value) == "Snuba returned HTTP 503: <empty body>"
+
+    @mock.patch("sentry.utils.snuba._snuba_query")
+    def test_unparseable_200_still_raises_unexpected_response(self, mock_snuba_query) -> None:
+        """A 200 we cannot parse is a real bug, not an outage, and keeps its own class."""
+        with pytest.raises(UnexpectedResponseError):
+            self.run_query(mock_snuba_query, 200, b"not json")
 
 
 class SnubaResponseCompressionTest(unittest.TestCase):


### PR DESCRIPTION
Snuba sits behind a proxy that answers with plain text when no backend is reachable. We discarded the response status and raised a constant `SnubaError("Failed to parse snuba error response")` because we were hoping for JSON, which sends a 500 to the UI. It's not ... fully correct?

Instead, try to recover from those a bit more gracefully. 5xx from Snuba, even if they're not JSON, now raise a new `SnubaServiceUnavailable`, which `handle_query_errors` maps to 503.

Refs SENTRY-5BCG