### PR TITLE
ref(preprod): Accept extra task keyword arguments

### DIFF
--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -6,7 +6,7 @@ import time
 from collections.abc import Callable
 from datetime import datetime
 from difflib import SequenceMatcher
-from typing import NamedTuple
+from typing import Any, NamedTuple
 
 import orjson
 from django.contrib.postgres.fields import ArrayField
@@ -683,6 +683,7 @@ def process_snapshot_comparison_chunk(
     project_id: int,
     head_artifact_id: int,
     base_artifact_id: int,
+    **kwargs: Any,
 ) -> None:
     session = get_preprod_session(org_id, project_id)
     plan_key = _plan_key(org_id, project_id, head_artifact_id, base_artifact_id)
@@ -735,6 +736,7 @@ def compare_snapshots(
     org_id: int,
     head_artifact_id: int,
     base_artifact_id: int,
+    **kwargs: Any,
 ) -> None:
     task_start_time = timezone.now()
     logger.info(
@@ -1113,6 +1115,7 @@ def finalize_snapshot_comparison(
     project_id: int,
     head_artifact_id: int,
     base_artifact_id: int,
+    **kwargs: Any,
 ) -> None:
     comparison = PreprodSnapshotComparison.objects.filter(id=comparison_id).first()
     if comparison is None:

--- a/src/sentry/preprod/snapshots/zip_tasks.py
+++ b/src/sentry/preprod/snapshots/zip_tasks.py
@@ -4,7 +4,7 @@ import logging
 import os
 import time
 from tempfile import NamedTemporaryFile
-from typing import IO
+from typing import IO, Any
 
 import orjson
 from objectstore_client import RequestError, Session
@@ -119,6 +119,7 @@ def build_snapshot_images_zip(
     artifact_id: int,
     user_id: int | None = None,
     include_manifest: bool = False,
+    **kwargs: Any,
 ) -> None:
     logger.info(
         "preprod_snapshot_zip.build_started",

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -66,7 +66,9 @@ logger = logging.getLogger(__name__)
     retry=Retry(times=3),
     processing_deadline_duration=60 * 15,
 )
-def process_artifact(artifact_id: str, project_id: str, organization_id: str) -> None:
+def process_artifact(
+    artifact_id: str, project_id: str, organization_id: str, **kwargs: Any
+) -> None:
     pass
 
 
@@ -834,7 +836,7 @@ def assemble_preprod_artifact_installable_app(
     processing_deadline_duration=60,
     silo_mode=SiloMode.CELL,
 )
-def detect_expired_preprod_artifacts() -> None:
+def detect_expired_preprod_artifacts(**kwargs: Any) -> None:
     """
     Detects PreprodArtifacts and related entities that have been processing for more than 30 minutes
     and updates their state to errored.


### PR DESCRIPTION
Update some preprod tasks to use the [recommended pattern](https://develop.sentry.dev/backend/application-domains/tasks/#defining-tasks) of accepting variable length kwargs as their final argument.
