### PR TITLE
feat(pr-metrics): Persist the branch a coding agent pushed

### DIFF
--- a/src/sentry/seer/autofix/coding_agent_handoffs.py
+++ b/src/sentry/seer/autofix/coding_agent_handoffs.py
@@ -109,11 +109,12 @@ def sync_coding_agent_status(
         try:
             handoff.status = status.value
             update_fields = ["status", "date_updated"]
+            extras: SeerRunCodingAgentHandoffExtras = {**handoff.extras}
             if agent_url is not None:
-                extras: SeerRunCodingAgentHandoffExtras = {
-                    **handoff.extras,
-                    "agent_url": agent_url,
-                }
+                extras["agent_url"] = agent_url
+            if result is not None and result.branch_name:
+                extras["branch_name"] = result.branch_name
+            if extras != handoff.extras:
                 handoff.extras = extras
                 update_fields.append("extras")
             handoff.save(update_fields=update_fields)

--- a/src/sentry/seer/models/run.py
+++ b/src/sentry/seer/models/run.py
@@ -189,6 +189,9 @@ class SeerRunCodingAgentHandoffExtras(TypedDict, total=False):
     # Deep link to the agent's session on the provider's own site (e.g. Cursor).
     # Not every provider supplies one.
     agent_url: str | None
+    # The branch the agent pushed. PRs are only linked on a status transition, so once
+    # the final sync has run this is the only handle on a PR that opens afterwards.
+    branch_name: str | None
 
 
 @cell_silo_model

--- a/tests/sentry/seer/autofix/test_coding_agent_handoffs.py
+++ b/tests/sentry/seer/autofix/test_coding_agent_handoffs.py
@@ -113,6 +113,29 @@ class SyncCodingAgentStatusTest(TestCase):
         assert self.handoff.extras["agent_url"] == "https://github.com/copilot/agents/agent-1"
 
     @patch(MOCK_UPDATE_STATE_PATH)
+    def test_records_branch_of_agent_that_reported_no_pull_request(
+        self, mock_update_state: Mock
+    ) -> None:
+        """An agent that finishes before its PR exists reports a branch and no PR URL;
+        the branch has to survive the sync or that PR is unrecoverable."""
+        mock_update_state.return_value = True
+
+        sync_coding_agent_status(
+            agent_id="agent-1",
+            organization_id=self.organization.id,
+            status=CodingAgentStatus.COMPLETED,
+            result=CodingAgentResult(
+                description="done",
+                repo_provider="github",
+                repo_full_name=REPO_NAME,
+                branch_name="seer/fix-the-thing",
+            ),
+        )
+
+        self.handoff.refresh_from_db()
+        assert self.handoff.extras["branch_name"] == "seer/fix-the-thing"
+
+    @patch(MOCK_UPDATE_STATE_PATH)
     def test_resolves_group_id_from_seer_agent_run(self, mock_update_state: Mock) -> None:
         mock_update_state.return_value = True
         group = self.create_group()


### PR DESCRIPTION
Split out of #121709 at review request — it is independent of the repo-external-id resolution that PR is about, in both directions.

A coding agent can finish before its pull request exists. The PR is only ever linked on a status transition, so once the final sync has run, nothing links a PR that opens afterwards. **~15% of completed handoffs have no linked PR.** Some of those agents never opened one; the rest opened one too late. Today those two cases are indistinguishable, and the second is unrecoverable.

The branch is the remaining handle on the second group, and it already reaches us — `CodingAgentResult.branch_name` arrives on `update_coding_agent_state` and is dropped on our side. This persists it into the handoff's existing `extras` JSONField, so there's no migration.

`extras` is now built once and written only when it actually changed, which keeps the `agent_url` write as narrow as it was.

Recording the branch does not link anything. It makes the population measurable and leaves the re-check buildable.

Refs CW-1726.
