### PR TITLE
feat(seer): Pass code_mode to search agent translate

### DIFF
--- a/static/app/views/discover/results/issueListSeerComboBox.tsx
+++ b/static/app/views/discover/results/issueListSeerComboBox.tsx
@@ -46,6 +46,7 @@ export function IssueListSeerComboBox({onSearch}: IssueListSeerComboBoxProps) {
   const initialSeerQuery = useInitialSeerQuery();
   const selectedProjectIds = useSelectedProjectIds();
   const selectedProjectIdsForMutation = useSelectedProjectIdsForMutation();
+  const hasCodeMode = organization.features.includes('seer-assisted-query-codemode');
 
   const transformResponse = useCallback(
     (response: AskSeerSearchQuery): AskSeerSearchQuery[] =>
@@ -70,6 +71,7 @@ export function IssueListSeerComboBox({onSearch}: IssueListSeerComboBoxProps) {
           project_ids: selectedProjectIdsForMutation,
           strategy: 'Errors',
           user_email: user?.email,
+          code_mode: hasCodeMode,
         },
       });
 

--- a/static/app/views/explore/logs/logsTabSeerComboBox.tsx
+++ b/static/app/views/explore/logs/logsTabSeerComboBox.tsx
@@ -156,6 +156,7 @@ export function LogsTabSeerComboBox() {
   const initialSeerQuery = useInitialSeerQuery();
   const selectedProjectIds = useSelectedProjectIds();
   const selectedProjectIdsForMutation = useSelectedProjectIdsForMutation();
+  const hasCodeMode = organization.features.includes('seer-assisted-query-codemode');
 
   const logsTabAskSeerMutationOptions = mutationOptions({
     mutationFn: async (queryToSubmit: string) => {
@@ -170,6 +171,7 @@ export function LogsTabSeerComboBox() {
           project_ids: selectedProjectIdsForMutation,
           strategy: 'Logs',
           user_email: user?.email,
+          code_mode: hasCodeMode,
         },
       });
 

--- a/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
+++ b/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
@@ -75,6 +75,7 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
   const initialSeerQuery = useInitialSeerQuery();
   const selectedProjectIds = useSelectedProjectIds();
   const selectedProjectIdsForMutation = useSelectedProjectIdsForMutation();
+  const hasCodeMode = organization.features.includes('seer-assisted-query-codemode');
 
   const metricsTabAskSeerMutationOptions = mutationOptions({
     mutationFn: async (queryToSubmit: string) => {
@@ -89,6 +90,7 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
           project_ids: selectedProjectIdsForMutation,
           strategy: 'Metrics',
           user_email: user?.email,
+          code_mode: hasCodeMode,
           options: {
             metric_context: {
               metric_name: traceMetric.name,

--- a/static/app/views/explore/spans/spansTabSeerComboBox.tsx
+++ b/static/app/views/explore/spans/spansTabSeerComboBox.tsx
@@ -57,6 +57,7 @@ export function SpansTabSeerComboBox() {
   const initialSeerQuery = useInitialSeerQuery();
   const selectedProjectIds = useSelectedProjectIds();
   const selectedProjectIdsForMutation = useSelectedProjectIdsForMutation();
+  const hasCodeMode = organization.features.includes('seer-assisted-query-codemode');
 
   const useTranslateEndpoint = organization.features.includes(
     'gen-ai-search-agent-translate'
@@ -71,6 +72,7 @@ export function SpansTabSeerComboBox() {
           data: {
             natural_language_query: queryToSubmit,
             project_ids: selectedProjectIdsForMutation,
+            code_mode: hasCodeMode,
           },
         });
 

--- a/static/app/views/issueList/issueListSeerComboBox.tsx
+++ b/static/app/views/issueList/issueListSeerComboBox.tsx
@@ -40,6 +40,7 @@ export function IssueListSeerComboBox({className}: {className?: string}) {
   const initialSeerQuery = useInitialSeerQuery();
   const selectedProjectIds = useSelectedProjectIds();
   const selectedProjectIdsForMutation = useSelectedProjectIdsForMutation();
+  const hasCodeMode = organization.features.includes('seer-assisted-query-codemode');
 
   const transformResponse = useCallback(
     (response: AskSeerSearchQuery): AskSeerSearchQuery[] =>
@@ -60,6 +61,7 @@ export function IssueListSeerComboBox({className}: {className?: string}) {
           natural_language_query: queryToSubmit,
           project_ids: selectedProjectIdsForMutation,
           strategy: 'Issues',
+          code_mode: hasCodeMode,
         },
       });
 


### PR DESCRIPTION
Every Seer combobox that POSTs to `/organizations/{org}/search-agent/translate/` now sends a boolean `code_mode` field, gated behind the `organizations:seer-assisted-query-codemode` feature flag (already registered, `api_expose=True`).

Covered comboboxes:

- `static/app/views/issueList/issueListSeerComboBox.tsx`
- `static/app/views/discover/results/issueListSeerComboBox.tsx`
- `static/app/views/explore/spans/spansTabSeerComboBox.tsx`
- `static/app/views/explore/logs/logsTabSeerComboBox.tsx`
- `static/app/views/explore/metrics/metricsTabSeerComboBox.tsx`

Notes:

- The spans tab sends `code_mode` only on the translate branch; the legacy `trace-explorer-ai/query/` fallback is unchanged.
- Frontend-only; no backend changes needed since the flag already exists.