### PR TITLE
fix(onboarding): Fix Rust onboarding steps

### DIFF
--- a/static/app/gettingStartedDocs/rust/logs.tsx
+++ b/static/app/gettingStartedDocs/rust/logs.tsx
@@ -10,8 +10,8 @@ import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersi
 
 type Params = DocsParams;
 
-const getInstallSnippet = (params: Params) => {
-  const version = getPackageVersion(params, 'sentry.rust', '0.42.0');
+const getInstallSnippet = (params: Params, defaultVersion = '0.49.1') => {
+  const version = getPackageVersion(params, 'sentry.rust', defaultVersion);
   return params.isLogsSelected
     ? `
 [dependencies]
@@ -59,14 +59,12 @@ export const logs: OnboardingConfig = {
         {
           type: 'code',
           language: 'rust',
-          code: `let _guard = sentry::init((
-    "${params.dsn.public}",
-    sentry::ClientOptions {
-        release: sentry::release_name!(),
-        enable_logs: true,
-        ..Default::default()
-    }
-));`,
+          code: `let _guard = sentry::init(
+    sentry::ClientOptions::new()
+        .dsn("${params.dsn.public}")
+        .maybe_release(sentry::release_name!())
+        .enable_logs(true),
+);`,
         },
         {
           type: 'text',

--- a/static/app/gettingStartedDocs/rust/onboarding.tsx
+++ b/static/app/gettingStartedDocs/rust/onboarding.tsx
@@ -8,8 +8,8 @@ import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersi
 
 type Params = DocsParams;
 
-const getInstallSnippet = (params: Params) => {
-  const version = getPackageVersion(params, 'sentry.rust', '0.42.0');
+const getInstallSnippet = (params: Params, defaultVersion = '0.49.1') => {
+  const version = getPackageVersion(params, 'sentry.rust', defaultVersion);
   return params.isLogsSelected
     ? `
 [dependencies]
@@ -20,23 +20,25 @@ sentry = "${version}"`;
 };
 
 const getConfigureSnippet = (params: Params) => `
-let _guard = sentry::init(("${params.dsn.public}", sentry::ClientOptions {
-  release: sentry::release_name!(),
-  // Capture user IPs and potentially sensitive headers when using HTTP server integrations
-  // see https://docs.sentry.io/platforms/rust/data-management/data-collected for more info
-  send_default_pii: true,
-  ..Default::default()
-}));`;
+let _guard = sentry::init(
+  sentry::ClientOptions::new()
+    .dsn("${params.dsn.public}")
+    .maybe_release(sentry::release_name!())
+    // Capture user IPs and potentially sensitive headers when using HTTP server integrations
+    // see https://docs.sentry.io/platforms/rust/data-management/data-collected for more info
+    .send_default_pii(true),
+);`;
 
 const getVerifySnippet = (params: Params) => `
 fn main() {
-  let _guard = sentry::init(("${params.dsn.public}", sentry::ClientOptions {
-    release: sentry::release_name!(),
-    // Capture user IPs and potentially sensitive headers when using HTTP server integrations
-    // see https://docs.sentry.io/platforms/rust/data-management/data-collected for more info
-    send_default_pii: true,
-    ..Default::default()
-  }));
+  let _guard = sentry::init(
+    sentry::ClientOptions::new()
+      .dsn("${params.dsn.public}")
+      .maybe_release(sentry::release_name!())
+      // Capture user IPs and potentially sensitive headers when using HTTP server integrations
+      // see https://docs.sentry.io/platforms/rust/data-management/data-collected for more info
+      .send_default_pii(true),
+  );
 
   // Sentry will capture this
   panic!("Everything is on fire!");


### PR DESCRIPTION
Hi!

While following the instructions for setting up sentry for a Rust project, I noticed that the given code doesn't compile. Here is the demo code:
```rs
let _guard = sentry::init(("https://some-dsn-something", sentry::ClientOptions {
  release: sentry::release_name!(),
  // Capture user IPs and potentially sensitive headers when using HTTP server integrations
  // see https://docs.sentry.io/platforms/rust/data-management/data-collected for more info
  send_default_pii: true,
  ..Default::default()
}));
```

and the compiler reports:
```
error[E0639]: cannot create non-exhaustive struct using struct expression
```

Upon further examining, it looks like the [docs](https://docs.sentry.io/platforms/rust/) do not have this issue, and they have been updated properly and the example code compiles.

I just updated the onboarding guide here to match the docs.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
