### PR TITLE
feat(issue-inbox): link issue title

### DIFF
--- a/static/app/views/issueDetails/issuePreview/issuePreview.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreview.tsx
@@ -277,5 +277,6 @@ const Dividers = styled('div')`
 const TitleLink = styled(Link)`
   &:hover {
     text-decoration: underline;
+    text-decoration-color: ${p => p.theme.tokens.content.secondary};
   }
 `;

--- a/static/app/views/issueDetails/issuePreview/issuePreview.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreview.tsx
@@ -155,36 +155,25 @@ function IssuePreviewContent() {
                   showOnlyOnOverflow
                   delay={1000}
                 >
-                  <Flex
-                    display="inline-flex"
-                    align="center"
-                    gap="xs"
-                    minWidth={0}
-                    overflow="hidden"
+                  <TitleLink
+                    to={issueDetailsUrl}
+                    analyticsEventKey="issue_inbox.open_issue_clicked"
+                    analyticsEventName="Issue Inbox: Open Issue Clicked"
+                    analyticsParams={{
+                      group_id: group.id,
+                      progress: group.derivedData?.progress,
+                      source: 'title',
+                    }}
                   >
-                    {({className}) => (
-                      <TitleLink
-                        className={className}
-                        to={issueDetailsUrl}
-                        analyticsEventKey="issue_inbox.open_issue_clicked"
-                        analyticsEventName="Issue Inbox: Open Issue Clicked"
-                        analyticsParams={{
-                          group_id: group.id,
-                          progress: group.derivedData?.progress,
-                          source: 'title',
-                        }}
-                      >
-                        <Container flex="1" minWidth={0}>
-                          <Heading as="h3" size="lg" ellipsis>
-                            {primaryTitle}
-                          </Heading>
-                        </Container>
-                        <Flex align="center" flexShrink={0}>
-                          <IconOpen size="xs" variant="muted" />
-                        </Flex>
-                      </TitleLink>
-                    )}
-                  </Flex>
+                    <Container flex="1" minWidth={0}>
+                      <Heading as="h3" size="lg" ellipsis>
+                        {primaryTitle}
+                      </Heading>
+                    </Container>
+                    <Flex align="center" flexShrink={0}>
+                      <IconOpen size="xs" variant="muted" />
+                    </Flex>
+                  </TitleLink>
                 </Tooltip>
               </Flex>
               <IssueSeenTimes group={group} />
@@ -291,6 +280,12 @@ const Dividers = styled('div')`
 `;
 
 const TitleLink = styled(Link)`
+  display: inline-flex;
+  align-items: center;
+  gap: ${p => p.theme.space.xs};
+  min-width: 0;
+  overflow: hidden;
+
   &:hover {
     text-decoration: underline;
     text-decoration-color: ${p => p.theme.tokens.content.secondary};

--- a/static/app/views/issueDetails/issuePreview/issuePreview.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreview.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import {LinkButton} from '@sentry/scraps/button';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {Link} from '@sentry/scraps/link';
 import {Heading} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -13,6 +14,7 @@ import {LinkedPullRequests} from 'sentry/components/group/externalIssuesList/lin
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {Placeholder} from 'sentry/components/placeholder';
+import {IconOpen} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Group} from 'sentry/types/group';
 import {getMessage, getTitle} from 'sentry/utils/events';
@@ -91,6 +93,7 @@ export function IssuePreview({groupId}: IssuePreviewProps) {
               analyticsParams={{
                 group_id: group.id,
                 progress: group.derivedData?.progress,
+                source: 'button',
               }}
             >
               {t('Open Issue')}
@@ -152,9 +155,20 @@ function IssuePreviewContent() {
                   showOnlyOnOverflow
                   delay={1000}
                 >
-                  <Heading as="h3" size="lg" ellipsis>
-                    {primaryTitle}
-                  </Heading>
+                  <Link
+                    to={issueDetailsUrl}
+                    analyticsEventKey="issue_inbox.open_issue_clicked"
+                    analyticsEventName="Issue Inbox: Open Issue Clicked"
+                    analyticsParams={{
+                      group_id: group.id,
+                      progress: group.derivedData?.progress,
+                      source: 'title',
+                    }}
+                  >
+                    <Heading as="h3" size="lg" ellipsis>
+                      {primaryTitle} <IconOpen size="xs" />
+                    </Heading>
+                  </Link>
                 </Tooltip>
               </Flex>
               <IssueSeenTimes group={group} />

--- a/static/app/views/issueDetails/issuePreview/issuePreview.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreview.tsx
@@ -155,20 +155,36 @@ function IssuePreviewContent() {
                   showOnlyOnOverflow
                   delay={1000}
                 >
-                  <TitleLink
-                    to={issueDetailsUrl}
-                    analyticsEventKey="issue_inbox.open_issue_clicked"
-                    analyticsEventName="Issue Inbox: Open Issue Clicked"
-                    analyticsParams={{
-                      group_id: group.id,
-                      progress: group.derivedData?.progress,
-                      source: 'title',
-                    }}
+                  <Flex
+                    display="inline-flex"
+                    align="center"
+                    gap="xs"
+                    minWidth={0}
+                    overflow="hidden"
                   >
-                    <Heading as="h3" size="lg" ellipsis>
-                      {primaryTitle} <IconOpen size="xs" />
-                    </Heading>
-                  </TitleLink>
+                    {({className}) => (
+                      <TitleLink
+                        className={className}
+                        to={issueDetailsUrl}
+                        analyticsEventKey="issue_inbox.open_issue_clicked"
+                        analyticsEventName="Issue Inbox: Open Issue Clicked"
+                        analyticsParams={{
+                          group_id: group.id,
+                          progress: group.derivedData?.progress,
+                          source: 'title',
+                        }}
+                      >
+                        <Container flex="1" minWidth={0}>
+                          <Heading as="h3" size="lg" ellipsis>
+                            {primaryTitle}
+                          </Heading>
+                        </Container>
+                        <Flex align="center" flexShrink={0}>
+                          <IconOpen size="xs" variant="muted" />
+                        </Flex>
+                      </TitleLink>
+                    )}
+                  </Flex>
                 </Tooltip>
               </Flex>
               <IssueSeenTimes group={group} />

--- a/static/app/views/issueDetails/issuePreview/issuePreview.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreview.tsx
@@ -155,7 +155,7 @@ function IssuePreviewContent() {
                   showOnlyOnOverflow
                   delay={1000}
                 >
-                  <Link
+                  <TitleLink
                     to={issueDetailsUrl}
                     analyticsEventKey="issue_inbox.open_issue_clicked"
                     analyticsEventName="Issue Inbox: Open Issue Clicked"
@@ -168,7 +168,7 @@ function IssuePreviewContent() {
                     <Heading as="h3" size="lg" ellipsis>
                       {primaryTitle} <IconOpen size="xs" />
                     </Heading>
-                  </Link>
+                  </TitleLink>
                 </Tooltip>
               </Flex>
               <IssueSeenTimes group={group} />
@@ -271,5 +271,11 @@ const Dividers = styled('div')`
   & > * + * {
     border-top: 1px solid ${p => p.theme.tokens.border.primary};
     padding-top: ${p => p.theme.space.md};
+  }
+`;
+
+const TitleLink = styled(Link)`
+  &:hover {
+    text-decoration: underline;
   }
 `;


### PR DESCRIPTION
Closes ISWF-3285

Feedback suggests that we should make the header link to the full issue details, so this linkifies the title and adds a hover underline effect.

<img width="638" height="248" alt="CleanShot 2026-08-12 at 11 59 05@2x" src="https://github.com/user-attachments/assets/ba1b563c-b939-42c6-a617-287f8a3bf61c" />
