### PR TITLE
feat(seer): Resolve a coding agent's repo by the id it was launched against

### DIFF
--- a/src/sentry/seer/agent/coding_agent_handoff.py
+++ b/src/sentry/seer/agent/coding_agent_handoff.py
@@ -193,7 +193,9 @@ def launch_coding_agents(
             }
         )
 
-        create_seer_run_coding_agent_handoff(organization, run_id, coding_agent_state)
+        create_seer_run_coding_agent_handoff(
+            organization, run_id, coding_agent_state, repo_external_id=repo.external_id
+        )
 
     # Store the coding agent states to Seer
     try:

--- a/src/sentry/seer/autofix/coding_agent_handoffs.py
+++ b/src/sentry/seer/autofix/coding_agent_handoffs.py
@@ -50,7 +50,16 @@ def create_seer_run_coding_agent_handoff(
     organization: Organization,
     run_id: int,
     state: CodingAgentState,
+    *,
+    repo_external_id: str,
 ) -> None:
+    """Record the agent Seer just handed ``run_id`` off to.
+
+    ``repo_external_id`` is the repo it was launched against, kept because the agent
+    reports its pull request back under a repo name we can't reliably resolve. It is
+    required rather than optional so a new launch path can't silently drop it; pass ``""``
+    when the repository genuinely has no provider-side id.
+    """
     log_context = {"organization_id": organization.id, "run_id": run_id}
 
     try:
@@ -60,6 +69,8 @@ def create_seer_run_coding_agent_handoff(
             return
 
         extras: SeerRunCodingAgentHandoffExtras = {"agent_url": state.agent_url}
+        if repo_external_id:
+            extras["repo_external_id"] = repo_external_id
         SeerRunCodingAgentHandoff.objects.create(
             seer_run=seer_run,
             provider=state.provider.value,
@@ -125,10 +136,13 @@ def sync_coding_agent_status(
         if result and result.pr_url:
             parsed_pr = parse_pull_request_url(result.pr_url)
             pr_number = parsed_pr.number if parsed_pr else None
+            # Recorded at launch; absent on handoffs created before it was.
+            repo_external_id = handoff.extras.get("repo_external_id")
             link_log_context = {
                 **log_context,
                 "repo_name": result.repo_full_name,
                 "provider": result.repo_provider,
+                "repo_external_id": repo_external_id,
                 "pr_number": pr_number,
             }
 
@@ -140,6 +154,7 @@ def sync_coding_agent_status(
                 pr_number=pr_number,
                 log_context=link_log_context,
                 coding_agent_handoff=handoff,
+                repo_external_id=repo_external_id,
             )
 
             if pr_number is not None:

--- a/src/sentry/seer/models/run.py
+++ b/src/sentry/seer/models/run.py
@@ -189,6 +189,10 @@ class SeerRunCodingAgentHandoffExtras(TypedDict, total=False):
     # Deep link to the agent's session on the provider's own site (e.g. Cursor).
     # Not every provider supplies one.
     agent_url: str | None
+    # `Repository.external_id` of the repo the agent was launched against. Known only at
+    # launch -- the agent reports its PR back under a repo *name*, which resolves the row
+    # ambiguously at best, and for GitLab never at all.
+    repo_external_id: str | None
 
 
 @cell_silo_model

--- a/tests/sentry/models/test_pullrequest.py
+++ b/tests/sentry/models/test_pullrequest.py
@@ -539,6 +539,20 @@ class GetOrCreateFromReferenceTest(TestCase):
         assert resolved.pull_request is not None
         assert resolved.pull_request.repository_id == duplicate.id
 
+    def test_treats_an_empty_external_id_as_absent(self) -> None:
+        """A reporter with no id for the repo sends ``""``. Querying it would match a row
+        that also has none, attaching the PR to an unrelated repository."""
+        self.create_repo(
+            self.project, name="unrelated/repo", provider="integrations:github", external_id=""
+        )
+
+        resolved = self._resolve(repo_external_id="")
+
+        assert resolved.repo_resolution == "resolved"
+        assert resolved.resolved_by == "name"
+        assert resolved.pull_request is not None
+        assert resolved.pull_request.repository_id == self.repo.id
+
     def test_falls_back_to_name_when_external_id_is_stale(self) -> None:
         """A repo re-added under a new external id must be no worse off than before."""
         resolved = self._resolve(repo_external_id="no-longer-in-use")

--- a/tests/sentry/models/test_pullrequest.py
+++ b/tests/sentry/models/test_pullrequest.py
@@ -529,9 +529,15 @@ class GetOrCreateFromReferenceTest(TestCase):
         """Duplicate rows sharing a provider are ambiguous by name, and no provider value
         can separate them -- only the external id can."""
         duplicate = self.create_repo(
-            self.project, name="getsentry/sentry", provider="integrations:github"
+            self.project,
+            name="getsentry/sentry",
+            provider="integrations:github",
+            external_id="99",
         )
-        duplicate.update(external_id="99")
+        # create_repo get_or_creates: without a distinguishing field it returns the setUp
+        # row, and the duplicate this test is named for never exists.
+        assert duplicate.id != self.repo.id
+        assert self._resolve().repo_resolution == "ambiguous"
 
         resolved = self._resolve(repo_external_id="99")
 

--- a/tests/sentry/seer/agent/test_coding_agent_handoff.py
+++ b/tests/sentry/seer/agent/test_coding_agent_handoff.py
@@ -134,6 +134,8 @@ class TestLaunchCodingAgents(TestCase):
         assert handoff.seer_run_id == seer_run.id
         assert handoff.provider == "cursor_background_agent"
         assert handoff.extras["agent_url"] == "https://cursor.sh/agent"
+        # The launch is the only point that knows which repo row the agent got.
+        assert handoff.extras["repo_external_id"] == "123"
         assert handoff.status == "pending"
 
     @patch("sentry.seer.agent.coding_agent_handoff.store_coding_agent_states_to_seer")

--- a/tests/sentry/seer/autofix/test_coding_agent_handoffs.py
+++ b/tests/sentry/seer/autofix/test_coding_agent_handoffs.py
@@ -45,19 +45,44 @@ class CreateSeerRunCodingAgentHandoffTest(TestCase):
         )
 
     def test_creates_row_for_state(self) -> None:
-        create_seer_run_coding_agent_handoff(self.organization, RUN_STATE_ID, _state())
+        create_seer_run_coding_agent_handoff(
+            self.organization, RUN_STATE_ID, _state(), repo_external_id="28"
+        )
 
         handoff = SeerRunCodingAgentHandoff.objects.get(seer_run=self.seer_run)
         assert handoff.agent_id == "agent-1"
         assert handoff.provider == "github_copilot_agent"
         assert handoff.status == "running"
 
+    def test_records_launch_repo_the_agent_will_not_report_back(self) -> None:
+        """The agent names its repo, and a name can't resolve one. The id it was launched
+        against is the only exact identity, and this is the last point that has it."""
+        create_seer_run_coding_agent_handoff(
+            self.organization, RUN_STATE_ID, _state(), repo_external_id="28"
+        )
+
+        handoff = SeerRunCodingAgentHandoff.objects.get(seer_run=self.seer_run)
+        assert handoff.extras["repo_external_id"] == "28"
+
+    def test_omits_repo_external_id_when_the_repo_has_none(self) -> None:
+        """An empty id must not be stored -- resolution treats it as absent either way,
+        and a stored empty reads as "we recorded one"."""
+        create_seer_run_coding_agent_handoff(
+            self.organization, RUN_STATE_ID, _state(), repo_external_id=""
+        )
+
+        handoff = SeerRunCodingAgentHandoff.objects.get(seer_run=self.seer_run)
+        assert "repo_external_id" not in handoff.extras
+
     def test_called_once_per_launched_state(self) -> None:
-        create_seer_run_coding_agent_handoff(self.organization, RUN_STATE_ID, _state("agent-1"))
+        create_seer_run_coding_agent_handoff(
+            self.organization, RUN_STATE_ID, _state("agent-1"), repo_external_id="28"
+        )
         create_seer_run_coding_agent_handoff(
             self.organization,
             RUN_STATE_ID,
             _state("agent-2", provider=CodingAgentProviderType.CLAUDE_CODE_AGENT),
+            repo_external_id="28",
         )
 
         handoffs = SeerRunCodingAgentHandoff.objects.filter(seer_run=self.seer_run).order_by(
@@ -68,7 +93,9 @@ class CreateSeerRunCodingAgentHandoffTest(TestCase):
 
     @patch("sentry.seer.autofix.coding_agent_handoffs.logger")
     def test_noop_when_run_not_found(self, mock_logger: Mock) -> None:
-        create_seer_run_coding_agent_handoff(self.organization, 999, _state())
+        create_seer_run_coding_agent_handoff(
+            self.organization, 999, _state(), repo_external_id="28"
+        )
 
         assert not SeerRunCodingAgentHandoff.objects.exists()
         mock_logger.info.assert_called_once_with(
@@ -173,6 +200,64 @@ class SyncCodingAgentStatusTest(TestCase):
         assert SeerRunMilestone.objects.filter(
             seer_run=self.seer_run, milestone=SeerRunMilestoneType.HAS_PULL_REQUEST
         ).exists()
+
+    @patch(MOCK_UPDATE_STATE_PATH)
+    def test_links_gitlab_pull_request_the_reported_name_cannot_resolve(
+        self, mock_update_state: Mock
+    ) -> None:
+        """GitLab repos are stored under `name_with_namespace` but handed out (and so
+        reported back) as `path_with_namespace`, which matches no row. The external id
+        recorded at launch is what links the PR."""
+        mock_update_state.return_value = True
+        gitlab_repo = self.create_repo(
+            self.project,
+            name="My Group / My Project",
+            provider="integrations:gitlab",
+            external_id="28",
+        )
+        handoff = self.create_seer_run_coding_agent_handoff(
+            self.seer_run,
+            agent_id="agent-gitlab",
+            provider="cursor_background_agent",
+            extras={"repo_external_id": "28"},
+        )
+
+        sync_coding_agent_status(
+            agent_id="agent-gitlab",
+            organization_id=self.organization.id,
+            status=CodingAgentStatus.COMPLETED,
+            result=CodingAgentResult(
+                description="Fixed the bug",
+                repo_provider="gitlab",
+                repo_full_name="my-group/my-project",
+                pr_url="https://gitlab.com/my-group/my-project/-/merge_requests/42",
+            ),
+        )
+
+        pull_request = PullRequest.objects.get(repository_id=gitlab_repo.id, key="42")
+        assert list(handoff.pull_requests) == [pull_request]
+
+    @patch(MOCK_UPDATE_STATE_PATH)
+    def test_links_by_name_when_launch_recorded_no_external_id(
+        self, mock_update_state: Mock
+    ) -> None:
+        """Handoffs launched before the id was recorded keep resolving by name."""
+        mock_update_state.return_value = True
+
+        sync_coding_agent_status(
+            agent_id="agent-1",
+            organization_id=self.organization.id,
+            status=CodingAgentStatus.COMPLETED,
+            result=CodingAgentResult(
+                description="Fixed the bug",
+                repo_provider="github",
+                repo_full_name=REPO_NAME,
+                pr_url="https://github.com/getsentry/sentry/pull/42",
+            ),
+        )
+
+        assert "repo_external_id" not in self.handoff.extras
+        assert PullRequest.objects.filter(repository_id=self.repo.id, key="42").exists()
 
     @patch(MOCK_UPDATE_STATE_PATH)
     def test_no_pull_request_milestone_for_branch_without_pr(self, mock_update_state: Mock) -> None:


### PR DESCRIPTION
#121709 made reported repos resolvable by `Repository.external_id`, and getsentry/seer#7706 makes Seer's own notify path send it. That covers one of the two reporters. The other — a delegated coding agent's PR, linked in `sync_coding_agent_status` — still resolves by name, with the same two failure modes: ambiguous across duplicate `(org, name)` rows, and for GitLab never matching at all, since Sentry stores `name_with_namespace` but hands out `path_with_namespace`.

It can't be fixed the way the Seer path was. A `CodingAgentResult` carries only `repo_provider` and `repo_full_name`; the provider's agent has no idea which `Repository` row it came from, so there is nothing for it to report back.

The id *is* in scope, exactly once — at launch, where the repo is a `SeerRepoDefinition` whose `external_id` is that row's `Repository.external_id`. So record it there, in the handoff's existing `extras` JSONField (no migration), and read it back when the PR arrives.

`create_seer_run_coding_agent_handoff` takes `repo_external_id` as a required keyword rather than an optional one. This gap exists because an identity was available at one point and silently not carried forward; a required argument is what stops the next launch path from doing it again. Repos with no provider-side id pass `""`, and nothing is stored.

**Nothing regresses.** Handoffs launched before this deploys have no id in `extras`, and `get_or_create_from_reference` falls back to name resolution exactly as today — same for repos with no external id.

Refs CW-1726.
