### PR TITLE
fix(issue detection): Handle URL placeholders more gracefully

### DIFF
--- a/src/sentry/issue_detection/detectors/consecutive_http_detector.py
+++ b/src/sentry/issue_detection/detectors/consecutive_http_detector.py
@@ -13,8 +13,8 @@ from sentry.issue_detection.detectors.utils import (
     get_span_evidence_value,
     get_total_span_duration,
     get_url_from_span,
-    is_filtered_url,
     safer_urlparse,
+    span_has_obfuscated_hostname,
 )
 from sentry.issues.grouptype import PerformanceConsecutiveHTTPQueriesGroupType
 from sentry.issues.issue_occurrence import IssueEvidence
@@ -188,8 +188,9 @@ class ConsecutiveHTTPSpanDetector(PerformanceDetector):
         if any([x in description for x in ["_next/static/", "_next/data/", "googleapis.com"]]):
             return False
 
-        url = get_url_from_span(span)
-        if is_filtered_url(url):
+        # We match spans based on hostname, so make sure we have a value we can use (not one masked
+        # by data scurbbing or parameterization)
+        if span_has_obfuscated_hostname(span):
             return False
 
         return True

--- a/src/sentry/issue_detection/detectors/consecutive_http_detector.py
+++ b/src/sentry/issue_detection/detectors/consecutive_http_detector.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import Any
-from urllib.parse import urlparse
 
 from sentry.issue_detection.base import DetectorType, PerformanceDetector
 from sentry.issue_detection.detectors.utils import (
@@ -15,6 +14,7 @@ from sentry.issue_detection.detectors.utils import (
     get_total_span_duration,
     get_url_from_span,
     is_filtered_url,
+    safer_urlparse,
 )
 from sentry.issues.grouptype import PerformanceConsecutiveHTTPQueriesGroupType
 from sentry.issues.issue_occurrence import IssueEvidence
@@ -197,7 +197,7 @@ class ConsecutiveHTTPSpanDetector(PerformanceDetector):
     def _extract_host_from_span(self, span: Span) -> str:
         """Extract the host from a span's URL."""
         url = get_url_from_span(span)
-        return urlparse(url).netloc
+        return safer_urlparse(url).netloc
 
     def _fingerprint(self) -> str:
         hashed_url_paths = fingerprint_http_spans(self.consecutive_http_spans)

--- a/src/sentry/issue_detection/detectors/http_overhead_detector.py
+++ b/src/sentry/issue_detection/detectors/http_overhead_detector.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import urllib.parse
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import Any
@@ -14,6 +13,7 @@ from sentry.issue_detection.detectors.utils import (
     get_url_from_span,
     is_filtered_url,
     log_invalid_span_data,
+    safer_urlparse,
 )
 from sentry.issues.grouptype import PerformanceHTTPOverheadGroupType
 from sentry.issues.issue_occurrence import IssueEvidence
@@ -106,7 +106,7 @@ class HTTPOverheadDetector(PerformanceDetector):
         if url.startswith("/"):
             location = "/"
         else:
-            parsed_url = urllib.parse.urlparse(url)
+            parsed_url = safer_urlparse(url)
             location = parsed_url.netloc
 
         if not location:

--- a/src/sentry/issue_detection/detectors/http_overhead_detector.py
+++ b/src/sentry/issue_detection/detectors/http_overhead_detector.py
@@ -10,10 +10,9 @@ from sentry.issue_detection.detectors.utils import (
     does_overlap_previous_span,
     get_notification_attachment_body,
     get_span_evidence_value,
-    get_url_from_span,
-    is_filtered_url,
     log_invalid_span_data,
     safer_urlparse,
+    span_has_obfuscated_hostname,
 )
 from sentry.issues.grouptype import PerformanceHTTPOverheadGroupType
 from sentry.issues.issue_occurrence import IssueEvidence
@@ -148,9 +147,9 @@ class HTTPOverheadDetector(PerformanceDetector):
         if not span_op or not span_op == "http.client" or not protocol_version == "1.1":
             return False
 
-        # Check if any spans have filtered URLs
-        url = get_url_from_span(span)
-        if is_filtered_url(url):
+        # We match spans based on hostname, so make sure we have a value we can use (not one masked
+        # by data scurbbing or parameterization)
+        if span_has_obfuscated_hostname(span):
             return False
 
         return True

--- a/src/sentry/issue_detection/detectors/n_plus_one_api_calls_detector.py
+++ b/src/sentry/issue_detection/detectors/n_plus_one_api_calls_detector.py
@@ -13,7 +13,6 @@ from sentry.issue_detection.detectors.utils import (
     get_span_evidence_value,
     get_total_span_duration,
     get_url_from_span,
-    is_filtered_url,
     parameterize_url,
     parameterize_url_with_result,
     safer_urlparse,
@@ -123,9 +122,6 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
             return False
 
         if not url:
-            return False
-
-        if is_filtered_url(url):
             return False
 
         # Once most users update their SDKs to use the latest standard, we

--- a/src/sentry/issue_detection/detectors/n_plus_one_api_calls_detector.py
+++ b/src/sentry/issue_detection/detectors/n_plus_one_api_calls_detector.py
@@ -5,7 +5,6 @@ import os
 from collections import defaultdict
 from datetime import timedelta
 from typing import Any
-from urllib.parse import urlparse
 
 from sentry.issue_detection.base import DetectorType, PerformanceDetector
 from sentry.issue_detection.detectors.utils import (
@@ -17,6 +16,7 @@ from sentry.issue_detection.detectors.utils import (
     is_filtered_url,
     parameterize_url,
     parameterize_url_with_result,
+    safer_urlparse,
 )
 from sentry.issue_detection.performance_problem import PerformanceProblem
 from sentry.issue_detection.types import Span
@@ -131,7 +131,7 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
         # Once most users update their SDKs to use the latest standard, we
         # won't have to do this, since the URLs will be sent in as `span.data`
         # in a parsed format
-        parsed_url = urlparse(str(url))
+        parsed_url = safer_urlparse(str(url))
 
         # Ignore anything that looks like an asset. Some frameworks (and apps)
         # fetch assets via XHR, which is not our concern
@@ -259,7 +259,7 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
             return ""
 
         url = get_url_from_span(repeating_span)
-        parsed_url = urlparse(url)
+        parsed_url = safer_urlparse(url)
         return parsed_url.path or ""
 
     def _fingerprint(self) -> str | None:

--- a/src/sentry/issue_detection/detectors/utils.py
+++ b/src/sentry/issue_detection/detectors/utils.py
@@ -164,7 +164,7 @@ def safer_urlparse(url: str) -> ParseResult:
 
 # Creates a stable fingerprint for resource spans from their description (url), removing common cache busting tokens.
 def fingerprint_resource_span(span: Span) -> str:
-    url = urlparse(span.get("description") or "")
+    url = safer_urlparse(span.get("description") or "")
     path = url.path
     path = UUID_REGEX.sub("*", path)
     path = CHUNK_HASH_REGEX.sub(".*.chunk", path)
@@ -187,7 +187,7 @@ def parameterize_url_with_result(url: str) -> ParameterizedUrl:
     Given a URL, return the URL with parsed path and query parameters replaced with '*',
     a list of the path parameters, and a dict of the query parameters.
     """
-    parsed_url = urlparse(str(url))
+    parsed_url = safer_urlparse(str(url))
 
     protocol_fragments = []
     if parsed_url.scheme:
@@ -246,7 +246,7 @@ def fingerprint_http_spans(spans: list[Span]) -> str:
         url = get_url_from_span(http_span)
         if url and not is_filtered_url(url):
             parametrized_url = parameterize_url(url)
-            path = urlparse(parametrized_url).path
+            path = safer_urlparse(parametrized_url).path
             if path not in url_paths:
                 url_paths.append(path)
     url_paths.sort()

--- a/src/sentry/issue_detection/detectors/utils.py
+++ b/src/sentry/issue_detection/detectors/utils.py
@@ -3,7 +3,7 @@ import logging
 import re
 from datetime import timedelta
 from typing import Any, TypedDict
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import ParseResult, parse_qs, urlparse
 
 from ..types import Span
 
@@ -20,6 +20,44 @@ FILTERED_KEYWORDS = [
     "[Filtered email]",
     "[Email]",
 ]
+
+URL_WITH_BRACKETED_HOSTNAME_REGEX = re.compile(
+    r"""
+    ^
+    # Scheme (`http`, `https`, `ftp`, `mailto`, `file`, etc). Everything before the `//` is optional
+    # to handle the legacy case where it used to be left off to allow for both `http` and `https`
+    # (before `https` was the default).
+    ([a-z][a-z0-9+.-]{1,32}:)?//
+    # The full hostname - everything between the `//` after the scheme and the `/` which marks the
+    # start of the path
+    (?P<full_hostname>
+        # Zero or more non-bracket, non-slash, legal hostname characters
+        [^\[\]/'"`\\<>{}|\^\s?#]*
+        (?P<value_with_brackets>
+            \[
+            (?P<bracketed_value>
+                # One or more such characters. Allows spaces in order to catch values like
+                # `[Filtered UUID]` and `[REDACTED IP]`.
+                [^\[\]/'"`\\<>{}|\^?#]+
+            )
+            \]
+        )
+        # Zero or more such characters
+        [^\[\]/'"`\\<>{}|\^\s?#]* # Zero or more such characters
+    )
+    # The rest of the URL (path, query string, and fragment) is technically optional
+    (
+        /
+        # Any number of copies of anything not globally invalid - slashes and brackets allowed now
+        # that we've gotten to the path
+        [^'"`\\<>{}|\^\s]*
+        # Final character - must be both valid in general and allowable in the last spot (so no
+        # trailing punctuation)
+        [^'"`\\<>{}|\^\s.,;]
+    )?
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
 
 PARAMETERIZED_URL_REGEX = re.compile(
     r"""(?x)
@@ -82,6 +120,46 @@ def escape_transaction(transaction: str) -> str:
 
 def is_filtered_url(url: str) -> bool:
     return any(keyword in url for keyword in FILTERED_KEYWORDS)
+
+
+def safer_urlparse(url: str) -> ParseResult:
+    """
+    `urlparse`, but tolerant of hostnames which include bracketed values as a result of having been
+    scrubbed and/or parameterized.
+
+    `urlparse` reads `[...]` in a URL's hostname as an IPv6 literal and errors out if it isn't a
+    valid IP. In cases where that happens, this temporarily strips the brackets for parsing, then
+    restores them in the final result.
+
+    Reraises parsing errors caused by other invalid URL patterns.
+    """
+    try:
+        return urlparse(url)
+    except ValueError:
+        bracketed_hostname_match = URL_WITH_BRACKETED_HOSTNAME_REGEX.search(url)
+
+        if bracketed_hostname_match:
+            match_groups = bracketed_hostname_match.groupdict()
+            orig_hostname = match_groups["full_hostname"]
+            value_with_brackets = match_groups["value_with_brackets"]
+            bracketed_value = match_groups["bracketed_value"]
+
+            # Strip the brackets (and any spaces between them) and try parsing again
+            debracketed_url = url.replace(
+                value_with_brackets,
+                bracketed_value.replace(" ", ""),
+                # In case the same parameterization exists later in the URL, too, only replace the
+                # one in the hostname
+                count=1,
+            )
+            parsed = urlparse(debracketed_url)
+
+            # Restore the original hostname value before returning the result
+            return parsed._replace(netloc=orig_hostname)
+
+        # If the problem isn't a bracketed hostname, reraise to surface the issue
+        else:
+            raise
 
 
 # Creates a stable fingerprint for resource spans from their description (url), removing common cache busting tokens.

--- a/src/sentry/issue_detection/detectors/utils.py
+++ b/src/sentry/issue_detection/detectors/utils.py
@@ -5,21 +5,12 @@ from datetime import timedelta
 from typing import Any, TypedDict
 from urllib.parse import ParseResult, parse_qs, urlparse
 
+from sentry.utils.http import is_valid_ip
+
 from ..types import Span
 
 logger = logging.getLogger("issue_detectors")
 
-
-FILTERED_KEYWORDS = [
-    "[Filtered]",
-    "[ip]",
-    "[REDACTED]",
-    "[id]",
-    "[Filtered Email]",
-    "[filtered]",
-    "[Filtered email]",
-    "[Email]",
-]
 
 URL_WITH_BRACKETED_HOSTNAME_REGEX = re.compile(
     r"""
@@ -55,6 +46,19 @@ URL_WITH_BRACKETED_HOSTNAME_REGEX = re.compile(
         # trailing punctuation)
         [^'"`\\<>{}|\^\s.,;]
     )?
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+# Regex for bracketed URL values, which can come from data scrubbing (things like `[Filtered]`,
+# `[REDACTED]`, `[filtered UUID]`, etc.) or from parameterization (things like `[id]` and `[email]`)
+BRACKETED_URL_PLACEHOLDER_REGEX = re.compile(
+    r"""
+    \[
+    # Zero or more non-bracket valid URL characters. Allows spaces in order to catch values like
+    # `[Filtered UUID]` and `[REDACTED IP]`.
+    [^'"`\\<>{}|\^\[\]]{0,32}
+    \]
     """,
     re.IGNORECASE | re.VERBOSE,
 )
@@ -118,8 +122,26 @@ def escape_transaction(transaction: str) -> str:
     return transaction
 
 
-def is_filtered_url(url: str) -> bool:
-    return any(keyword in url for keyword in FILTERED_KEYWORDS)
+def span_has_obfuscated_hostname(span: Span) -> bool:
+    """
+    Check if the span's URL has a hostname we can use for matching up request spans.
+
+    If two spans have parameterized and/or scrubbed hostnames in their URLs (indicated by the
+    presence of any non-IP bracketed value), it's impossible to tell if they originally pointed to
+    the same domain. This presents an obvious problem in detectors where we do hostname matching, so
+    we need to be able to recognize such spans so we can skip over them in those detectors.
+    """
+    url = get_url_from_span(span)
+    bracketed_hostname_match = URL_WITH_BRACKETED_HOSTNAME_REGEX.search(url)
+
+    # If there are no bracketed values, we can definitely use the hostname
+    if not bracketed_hostname_match:
+        return False
+
+    # If there are brackets, we can still use the hostname as long as the bracketed value is a valid
+    # IP address.
+    maybe_ip = bracketed_hostname_match.group("bracketed_value")
+    return not is_valid_ip(maybe_ip)
 
 
 def safer_urlparse(url: str) -> ParseResult:

--- a/src/sentry/issue_detection/detectors/utils.py
+++ b/src/sentry/issue_detection/detectors/utils.py
@@ -244,7 +244,7 @@ def fingerprint_http_spans(spans: list[Span]) -> str:
     url_paths = []
     for http_span in spans:
         url = get_url_from_span(http_span)
-        if url and not is_filtered_url(url):
+        if url:
             parametrized_url = parameterize_url(url)
             path = safer_urlparse(parametrized_url).path
             if path not in url_paths:

--- a/src/sentry/issue_detection/detectors/utils.py
+++ b/src/sentry/issue_detection/detectors/utils.py
@@ -228,7 +228,10 @@ def parameterize_url_with_result(url: str) -> ParameterizedUrl:
         path_fragments.append(parsed_url.path)
     else:
         for fragment in parsed_url.path.split("/"):
-            path_param = PARAMETERIZED_URL_REGEX.search(fragment)
+            # Treat bracketed placeholders as pre-parameterized values
+            path_param = BRACKETED_URL_PLACEHOLDER_REGEX.search(
+                fragment
+            ) or PARAMETERIZED_URL_REGEX.search(fragment)
             if path_param:
                 path_fragments.append("*")
                 path_params.append(path_param.group())

--- a/tests/sentry/issue_detection/test_consecutive_http_detector.py
+++ b/tests/sentry/issue_detection/test_consecutive_http_detector.py
@@ -387,6 +387,55 @@ class ConsecutiveHTTPSpansDetectorTest(TestCase):
 
         assert not detector.is_creation_allowed()
 
+    def test_ignores_spans_with_scrubbed_hostname(self) -> None:
+        span_duration = 2000
+        normal_hostname_spans: list[Span] = []
+        scrubbed_hostname_spans: list[Span] = []
+
+        for hostname, span_list in [
+            ("dogs.are.great", normal_hostname_spans),
+            ("[Filtered]", scrubbed_hostname_spans),
+        ]:
+            for i in range(0, 4):
+                span = create_span(
+                    "http.client", span_duration, f"GET https://{hostname}/dogs/dog_{i}", f"hash{i}"
+                )
+                modify_span_start(span, i * span_duration)
+                span_list.append(span)
+
+        normal_hostname_problems = self.find_problems(create_event(normal_hostname_spans))
+        scrubbed_hostname_problems = self.find_problems(create_event(scrubbed_hostname_spans))
+
+        # Only the non-scrubbed hostname spans are used to find a problem
+        assert len(normal_hostname_problems) == 1
+        assert len(scrubbed_hostname_problems) == 0
+
+    def test_does_not_ignore_spans_with_scrubbed_path(self) -> None:
+        span_duration = 2000
+        normal_path_spans: list[Span] = []
+        scrubbed_path_spans: list[Span] = []
+
+        for path_part, span_list in [
+            ("dogs", normal_path_spans),
+            ("[Filtered]", scrubbed_path_spans),
+        ]:
+            for i in range(0, 4):
+                span = create_span(
+                    "http.client",
+                    span_duration,
+                    f"GET https://dogs.are.great/{path_part}/dog_{i}",
+                    f"hash{i}",
+                )
+                modify_span_start(span, i * span_duration)
+                span_list.append(span)
+
+        normal_path_problems = self.find_problems(create_event(normal_path_spans))
+        scrubbed_path_problems = self.find_problems(create_event(scrubbed_path_spans))
+
+        # Problems are detected whether or not the path has been scrubbed
+        assert len(normal_path_problems) == 1
+        assert len(scrubbed_path_problems) == 1
+
     def test_ignores_non_http_operations(self) -> None:
         span_duration = 2000
         spans = [

--- a/tests/sentry/issue_detection/test_http_overhead_detector.py
+++ b/tests/sentry/issue_detection/test_http_overhead_detector.py
@@ -16,7 +16,6 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.issue_detection.event_generators import (
     PROJECT_ID,
     create_span,
-    get_event,
     modify_span_start,
 )
 
@@ -343,6 +342,18 @@ class HTTPOverheadDetectorTest(TestCase):
                 },
             )
 
-    def test_filtered_url(self) -> None:
-        injection_event = get_event("http-overhead/http-overhead-filtered-url")
-        assert len(self.find_problems(injection_event)) == 0
+    def test_ignores_spans_with_scrubbed_hostname(self) -> None:
+        event = _valid_http_overhead_event("https://[Filtered]/dogs/1121")
+        assert self.find_problems(event) == []
+
+    def test_treats_bracketed_path_values_as_parameters(self) -> None:
+        parameterized_path_event = _valid_http_overhead_event(
+            "https://dogs.are.great/dogs/[number]"
+        )
+        normal_path_event = _valid_http_overhead_event("https://dogs.are.great/dogs/1231")
+
+        # The same problem is detected whether we parameterize during detection or treat a bracketed
+        # value as an already-parameterized value
+        assert self.find_problems(parameterized_path_event)[0].fingerprint == (
+            self.find_problems(normal_path_event)[0].fingerprint
+        )

--- a/tests/sentry/issue_detection/test_n_plus_one_api_calls_detector.py
+++ b/tests/sentry/issue_detection/test_n_plus_one_api_calls_detector.py
@@ -210,6 +210,39 @@ class NPlusOneAPICallsDetectorTest(TestCase):
         assert query_params == ["id: 0, 1, 2, 3, 4, 5"]
         assert problem.fingerprint == f"1-{self.type_id}-8bf177290e2d78550fef5a1f6e9ddf115e4b0614"
 
+    def test_does_detect_problem_with_previously_parameterized_urls(self) -> None:
+        event = self.create_event(lambda i: "GET /dogs/[number]/records/[date]/?sort=[bool]")
+        [problem] = self.find_problems(event)
+
+        assert problem.desc == "/dogs/*/records/*/?sort=*"
+        assert problem.evidence_data is not None
+        assert problem.evidence_data["path_parameters"] == ["[number], [date]"]
+        assert problem.evidence_data["parameters"] == [
+            "sort: [bool], [bool], [bool], [bool], [bool], [bool]"
+        ]
+
+    def test_does_detect_problem_with_scrubbed_host(self) -> None:
+        event = self.create_event(lambda i: f"GET https://[Filtered]/dogs/{i}")
+        [problem] = self.find_problems(event)
+
+        assert problem.desc == "https://[Filtered]/dogs/*"
+        assert problem.evidence_data["common_url"] == "https://[Filtered]/dogs/*"
+
+    def test_treats_bracketed_path_values_as_parameters(self) -> None:
+        parameterized_url_event = self.create_event(lambda i: "GET /dogs/[number]")
+        normal_event = self.create_event(lambda i: f"GET /dogs/{i}")
+
+        [parameterized_url_problem] = self.find_problems(parameterized_url_event)
+        [normal_problem] = self.find_problems(normal_event)
+
+        assert parameterized_url_problem.fingerprint == normal_problem.fingerprint
+        assert parameterized_url_problem.desc == normal_problem.desc == "/dogs/*"
+        assert (
+            parameterized_url_problem.evidence_data["common_url"]
+            == normal_problem.evidence_data["common_url"]
+            == "/dogs/*"
+        )
+
     def test_does_not_detect_problem_with_concurrent_calls_to_different_urls(self) -> None:
         event = get_event("n-plus-one-api-calls/not-n-plus-one-api-calls")
         assert self.find_problems(event) == []
@@ -409,6 +442,36 @@ class NPlusOneAPICallsDetectorTest(TestCase):
         (
             "/item/defaced12-abba/details",  # false short hash 2
             "/item/defaced12-abba/details",
+        ),
+        # Placeholders stand in for a value which has already been removed, so they parameterize
+        # the same way a hardcoded value does.
+        (
+            "https://dogs.are.great/dogs/1231",
+            "https://dogs.are.great/dogs/*",
+        ),
+        (
+            "https://dogs.are.great/dogs/[Filtered]",
+            "https://dogs.are.great/dogs/*",
+        ),
+        (
+            "https://dogs.are.great/dogs/[REDACTED]",
+            "https://dogs.are.great/dogs/*",
+        ),
+        (
+            "https://dogs.are.great/dogs/[Filtered UUID]",
+            "https://dogs.are.great/dogs/*",
+        ),
+        (
+            "https://dogs.are.great/dogs/[redacted-ip]",
+            "https://dogs.are.great/dogs/*",
+        ),
+        (
+            "https://dogs.are.great/dogs/[id]",
+            "https://dogs.are.great/dogs/*",
+        ),
+        (
+            "https://dogs.are.great/dogs/[number]",
+            "https://dogs.are.great/dogs/*",
         ),
     ],
 )

--- a/tests/sentry/issue_detection/test_utils.py
+++ b/tests/sentry/issue_detection/test_utils.py
@@ -1,0 +1,110 @@
+import pytest
+
+from sentry.issue_detection.detectors.utils import (
+    parameterize_url_with_result,
+    safer_urlparse,
+    span_has_obfuscated_hostname,
+)
+from sentry.testutils.issue_detection.event_generators import create_span
+
+
+@pytest.mark.parametrize(
+    ("url", "expected_result"),
+    [
+        ("https://[Filtered]/dogs/1121", True),
+        ("https://[Redacted IP]/dogs/1231", True),
+        ("https://[dogs].are.great/dogs/908", True),
+        ("https://[Filtered]:8080/dogs/415", True),
+        ("https://user:[Filtered]@dogs.are.great/x", True),
+        ("//[Filtered]/dogs/2012", True),  # protocol-relative
+        ("https://[4.15.9.8]/dogs/2013", False),  # a real IP address
+        ("https://dogs.are.great/dogs/[number]", False),
+        ("https://dogs.are.great/dogs/[filtered id]", False),
+        ("https://dogs.are.great/dogs/1121", False),
+        ("https://dogs.are.great/dogs/1231?year=2012", False),
+    ],
+)
+def test_span_has_obfuscated_hostname(url: str, expected_result: bool) -> None:
+    span = create_span("http.client", 320415204, f"GET {url}")
+    assert span_has_obfuscated_hostname(span) == expected_result
+
+
+@pytest.mark.parametrize(
+    ("url", "expected_netloc"),
+    [
+        ("https://[Filtered]/dogs/1121", "[Filtered]"),
+        ("https://[Redacted IP]/dogs/1231", "[Redacted IP]"),
+        ("https://[dogs].are.great/dogs/908", "[dogs].are.great"),
+        ("https://[Filtered]:8080/dogs/415", "[Filtered]:8080"),
+        ("https://user:[Filtered]@dogs.are.great/x", "user:[Filtered]@dogs.are.great"),
+        ("//[Filtered]/dogs/2012", "[Filtered]"),  # protocol-relative
+        ("https://[4.15.9.8]/dogs/2013", "[4.15.9.8]"),  # a real IP address
+        ("https://dogs.are.great/dogs/[number]", "dogs.are.great"),
+        ("https://dogs.are.great/dogs/[filtered id]", "dogs.are.great"),
+        ("https://dogs.are.great/dogs/1121", "dogs.are.great"),
+        ("https://dogs.are.great/dogs/1231?year=2012", "dogs.are.great"),
+    ],
+)
+def test_safe_urlparse(url: str, expected_netloc: str) -> None:
+    assert safer_urlparse(url).netloc == expected_netloc
+
+
+@pytest.mark.parametrize(
+    ("url", "expected_result_data"),  # Expected result is (url, path_params, query_params)
+    [
+        (
+            "https://[Filtered]/dogs/1121",
+            ("https://[Filtered]/dogs/*", ["1121"], {}),
+        ),
+        (
+            "https://[Redacted IP]/dogs/1231",
+            ("https://[Redacted IP]/dogs/*", ["1231"], {}),
+        ),
+        (
+            "https://[dogs].are.great/dogs/908",
+            ("https://[dogs].are.great/dogs/*", ["908"], {}),
+        ),
+        (
+            "https://[Filtered]:8080/dogs/415",
+            ("https://[Filtered]:8080/dogs/*", ["415"], {}),
+        ),
+        (
+            "https://user:[Filtered]@dogs.are.great/x",
+            ("https://user:[Filtered]@dogs.are.great/x", [], {}),
+        ),
+        (
+            "//[Filtered]/dogs/2012",  # protocol-relative
+            ("[Filtered]/dogs/*", ["2012"], {}),
+        ),
+        (
+            "https://[4.15.9.8]/dogs/2013",  # a real IP address
+            ("https://[4.15.9.8]/dogs/*", ["2013"], {}),
+        ),
+        (
+            "https://dogs.are.great/dogs/[number]",
+            ("https://dogs.are.great/dogs/*", ["[number]"], {}),
+        ),
+        (
+            "https://dogs.are.great/dogs/[filtered id]",
+            ("https://dogs.are.great/dogs/*", ["[filtered id]"], {}),
+        ),
+        (
+            "https://dogs.are.great/dogs/1121",
+            ("https://dogs.are.great/dogs/*", ["1121"], {}),
+        ),
+        (
+            "https://dogs.are.great/dogs/1231?year=2012",
+            ("https://dogs.are.great/dogs/*?year=*", ["1231"], {"year": ["2012"]}),
+        ),
+    ],
+)
+def test_parameterize_url_with_result(
+    url: str, expected_result_data: tuple[str, list[str], dict[str, list[str]]]
+) -> None:
+    expected_parameterized_url, expected_path_params, expected_query_params = expected_result_data
+
+    assert parameterize_url_with_result(url) == {
+        "url": expected_parameterized_url,
+        "path_params": expected_path_params,
+        "query_params": expected_query_params,
+    }


### PR DESCRIPTION
In a number of our issue detectors, we ignore spans whose URLs include bracketed placeholders (which come from data scrubbing and/or parameterization).

According to the commit history (see https://github.com/getsentry/sentry/pull/97104 and its follow-up https://github.com/getsentry/sentry/pull/99833), this was to prevent errors when calling `urlparse`. Unfortunately, this fix is both too broad and not broad enough. On the one hand, we're ignoring spans we don't need to, because we reject spans with bracketed values anywhere in the URL, even though it's only bracketed values in the hostname that cause parsing errors. On the other hand, we decide whether to ignore a span by checking for a hardcoded list of values, meaning we miss spans whose URLs contain bracketed values not on the list.

This improves things by making a few changes to our logic.

- Add a `safer_urlparse` helper, which will try regular parsing, and if that fails, temporarily remove any brackets it finds in the hostname before trying again. The brackets are then restored in the final result.

- Use a regex rather than a hard-coded list for matching bracketed values.

- Restrict our "should we ignore this span?" check to checking hostname rather than the whole URL. 

- Continue to use the check in detectors which match spans on hostname (since it's impossible to tell if two redacted or parameterized hostnames agree), but stop using it in places where it only existed to prevent `urlparse` from crashing. (In the former category: The consecutive HTTP and HTTP overhead detectors. In the latter category: The N+1 API calls detector and HTTP span fingerprinting logic.)

- When parameterizing URL paths, treat any bracketed values we find the same way we treat values we're parameterizing ourselves. In other words, treat `http://dogs.are.great/dogs/[dog_id]` the same way we'd treat `http://dogs.are.great/dogs/1231`, turning both into `http://dogs.are.great/dogs/*`.

Fixes https://sentry.sentry.io/issues/7650213363
Fixes https://sentry.sentry.io/issues/7652746498
Fixes https://sentry.sentry.io/issues/7650316258
Fixes https://sentry.sentry.io/issues/7623504944
Fixes https://sentry.sentry.io/issues/7650213366
Fixes https://sentry.sentry.io/issues/7665432056
Fixes https://sentry.sentry.io/issues/7651610504