### PR TITLE
feat(scm-first-messaging-integration): Fixing discord channel resolution

### DIFF
--- a/static/app/components/onboarding/onboardingContext.spec.tsx
+++ b/static/app/components/onboarding/onboardingContext.spec.tsx
@@ -24,7 +24,6 @@ const selectedMessagingSetup = {
   providerKey: 'slack',
   integrationId: '15',
   channelId: 'C123',
-  actionTarget: '#alerts',
   channelName: '#alerts',
 } as const satisfies ScmMessagingSetup;
 
@@ -140,7 +139,6 @@ describe('OnboardingContextProvider', () => {
           providerKey: 'discord',
           integrationId: '20',
           channelId: '123456789',
-          actionTarget: '123456789',
           channelName: '#dev-alerts',
         },
       })

--- a/static/app/components/onboarding/scm/scmMessagingChannelPicker.spec.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingChannelPicker.spec.tsx
@@ -88,7 +88,6 @@ const selectedDiscordSetup: ScmMessagingSetup = {
   integrationId: '20',
   channelId: '1234567890',
   channelName: '#general',
-  actionTarget: '1234567890',
 };
 
 const selectedSlackSetup: ScmMessagingSetup = {
@@ -97,7 +96,6 @@ const selectedSlackSetup: ScmMessagingSetup = {
   integrationId: '10',
   channelId: 'C123',
   channelName: '#general',
-  actionTarget: '#general',
 };
 
 describe('ScmMessagingChannelPicker', () => {
@@ -120,7 +118,6 @@ describe('ScmMessagingChannelPicker', () => {
         integrationId: '10',
         channelId: 'C123',
         channelName: '#general',
-        actionTarget: '#general',
       });
     });
 
@@ -137,7 +134,6 @@ describe('ScmMessagingChannelPicker', () => {
         integrationId: '20',
         channelId: '1234567890',
         channelName: '#general',
-        actionTarget: '1234567890',
       });
     });
 
@@ -173,7 +169,6 @@ describe('ScmMessagingChannelPicker', () => {
         integrationId: '20',
         channelId: channelUrl,
         channelName: channelUrl,
-        actionTarget: channelUrl,
       });
     });
   });
@@ -194,7 +189,6 @@ describe('ScmMessagingChannelPicker', () => {
         integrationId: '20',
         channelId: '1234567890',
         channelName: '#general',
-        actionTarget: '1234567890',
       });
     });
 
@@ -213,7 +207,6 @@ describe('ScmMessagingChannelPicker', () => {
         integrationId: '10',
         channelId: 'C123',
         channelName: '#general',
-        actionTarget: '#general',
       });
     });
   });

--- a/static/app/components/onboarding/scm/scmMessagingChannelPicker.spec.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingChannelPicker.spec.tsx
@@ -1,0 +1,220 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {OrganizationIntegrationsFixture} from 'sentry-fixture/organizationIntegrations';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {selectEvent} from 'sentry-test/selectEvent';
+
+import {ScmMessagingChannelPicker} from './scmMessagingChannelPicker';
+import type {ScmMessagingSetup} from './scmMessagingSetup';
+
+const organization = OrganizationFixture();
+
+const slackIntegration = OrganizationIntegrationsFixture({
+  id: '10',
+  name: 'test-workspace',
+  provider: {
+    key: 'slack',
+    slug: 'slack',
+    name: 'Slack',
+    canAdd: true,
+    canDisable: false,
+    features: [],
+    aspects: {},
+  },
+});
+
+const discordIntegration = OrganizationIntegrationsFixture({
+  id: '20',
+  name: 'test-server',
+  provider: {
+    key: 'discord',
+    slug: 'discord',
+    name: 'Discord',
+    canAdd: true,
+    canDisable: false,
+    features: [],
+    aspects: {},
+  },
+});
+
+// Both providers format `display` as `#{name}`; only `id` distinguishes them,
+// which is what makes the name/ID mixup easy to write and hard to spot.
+const slackChannel = {id: 'C123', name: 'general', display: '#general', type: 'channel'};
+const discordChannel = {
+  id: '1234567890',
+  name: 'general',
+  display: '#general',
+  type: 'text',
+};
+
+function mockChannels(integrationId: string, results: Array<Record<string, string>>) {
+  return MockApiClient.addMockResponse({
+    url: `/organizations/${organization.slug}/integrations/${integrationId}/channels/`,
+    body: {results},
+  });
+}
+
+function mockChannelValidate(valid: boolean, integrationId: string) {
+  return MockApiClient.addMockResponse({
+    url: `/organizations/${organization.slug}/integrations/${integrationId}/channel-validate/`,
+    body: {valid},
+  });
+}
+
+function renderPicker({
+  integration = slackIntegration,
+  existingSetup,
+}: {
+  existingSetup?: ScmMessagingSetup;
+  integration?: typeof slackIntegration;
+} = {}) {
+  const onConfigured = jest.fn();
+
+  render(
+    <ScmMessagingChannelPicker
+      integration={integration}
+      onConfigured={onConfigured}
+      existingSetup={existingSetup}
+    />,
+    {organization}
+  );
+
+  return {onConfigured};
+}
+
+const selectedDiscordSetup: ScmMessagingSetup = {
+  mode: 'selected',
+  providerKey: 'discord',
+  integrationId: '20',
+  channelId: '1234567890',
+  channelName: '#general',
+  actionTarget: '1234567890',
+};
+
+const selectedSlackSetup: ScmMessagingSetup = {
+  mode: 'selected',
+  providerKey: 'slack',
+  integrationId: '10',
+  channelId: 'C123',
+  channelName: '#general',
+  actionTarget: '#general',
+};
+
+describe('ScmMessagingChannelPicker', () => {
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+    jest.restoreAllMocks();
+  });
+
+  describe('staging a new destination', () => {
+    it('stores Slack by display name', async () => {
+      mockChannels('10', [slackChannel]);
+      const {onConfigured} = renderPicker({integration: slackIntegration});
+
+      await selectEvent.select(screen.getByLabelText('channel'), '#general');
+      await userEvent.click(screen.getByRole('button', {name: 'Add destination'}));
+
+      expect(onConfigured).toHaveBeenCalledWith({
+        mode: 'selected',
+        providerKey: 'slack',
+        integrationId: '10',
+        channelId: 'C123',
+        channelName: '#general',
+        actionTarget: '#general',
+      });
+    });
+
+    it('stores Discord by channel ID', async () => {
+      mockChannels('20', [discordChannel]);
+      const {onConfigured} = renderPicker({integration: discordIntegration});
+
+      await selectEvent.select(screen.getByLabelText('channel'), '#general (1234567890)');
+      await userEvent.click(screen.getByRole('button', {name: 'Add destination'}));
+
+      expect(onConfigured).toHaveBeenCalledWith({
+        mode: 'selected',
+        providerKey: 'discord',
+        integrationId: '20',
+        channelId: '1234567890',
+        channelName: '#general',
+        actionTarget: '1234567890',
+      });
+    });
+
+    it('disables Add destination until a channel is chosen', () => {
+      mockChannels('10', [slackChannel]);
+      renderPicker({integration: slackIntegration});
+
+      expect(screen.getByRole('button', {name: 'Add destination'})).toBeDisabled();
+    });
+  });
+
+  describe('manual entry', () => {
+    it('keeps a typed Discord channel URL as the action target', async () => {
+      mockChannels('20', [discordChannel]);
+      // Manual entries validate as you type, via the shared hook's
+      // `enabled: !!channel?.new` query.
+      mockChannelValidate(true, '20');
+      const {onConfigured} = renderPicker({integration: discordIntegration});
+
+      const channelUrl = 'https://discord.com/channels/111/1234567890';
+      // ChannelSelect sets formatCreateLabel to the raw input, so the create
+      // option is labelled with the typed value, not the default `Create "..."`.
+      await selectEvent.create(screen.getByLabelText('channel'), channelUrl, {
+        createOptionText: channelUrl,
+      });
+      await userEvent.click(screen.getByRole('button', {name: 'Add destination'}));
+
+      // Stored as-is: the backend resolves URL to ID in both the validate
+      // endpoint and DiscordNotifyServiceForm.clean.
+      expect(onConfigured).toHaveBeenCalledWith({
+        mode: 'selected',
+        providerKey: 'discord',
+        integrationId: '20',
+        channelId: channelUrl,
+        channelName: channelUrl,
+        actionTarget: channelUrl,
+      });
+    });
+  });
+
+  describe('editing an existing destination', () => {
+    it('preserves the Discord channel ID through a no-op edit', async () => {
+      mockChannels('20', [discordChannel]);
+      const {onConfigured} = renderPicker({
+        integration: discordIntegration,
+        existingSetup: selectedDiscordSetup,
+      });
+
+      await userEvent.click(screen.getByRole('button', {name: 'Add destination'}));
+
+      expect(onConfigured).toHaveBeenCalledWith({
+        mode: 'selected',
+        providerKey: 'discord',
+        integrationId: '20',
+        channelId: '1234567890',
+        channelName: '#general',
+        actionTarget: '1234567890',
+      });
+    });
+
+    it('preserves the Slack channel name through a no-op edit', async () => {
+      mockChannels('10', [slackChannel]);
+      const {onConfigured} = renderPicker({
+        integration: slackIntegration,
+        existingSetup: selectedSlackSetup,
+      });
+
+      await userEvent.click(screen.getByRole('button', {name: 'Add destination'}));
+
+      expect(onConfigured).toHaveBeenCalledWith({
+        mode: 'selected',
+        providerKey: 'slack',
+        integrationId: '10',
+        channelId: 'C123',
+        channelName: '#general',
+        actionTarget: '#general',
+      });
+    });
+  });
+});

--- a/static/app/components/onboarding/scm/scmMessagingChannelPicker.spec.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingChannelPicker.spec.tsx
@@ -1,9 +1,12 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {OrganizationIntegrationsFixture} from 'sentry-fixture/organizationIntegrations';
 
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 import {selectEvent} from 'sentry-test/selectEvent';
 
+import type {OrganizationIntegration} from 'sentry/types/integrations';
+
+import type {ScmMessagingProviderKey} from './messagingProviders';
 import {ScmMessagingChannelPicker} from './scmMessagingChannelPicker';
 import type {ScmMessagingSetup} from './scmMessagingSetup';
 
@@ -76,17 +79,20 @@ function mockChannelValidate(valid: boolean, integrationId: string) {
 }
 
 function renderPicker({
-  integration = slackIntegration,
+  eligibleIntegrations = [slackIntegration],
   existingSetup,
+  providerKey = 'slack',
 }: {
+  eligibleIntegrations?: OrganizationIntegration[];
   existingSetup?: ScmMessagingSetup;
-  integration?: typeof slackIntegration;
+  providerKey?: ScmMessagingProviderKey;
 } = {}) {
   const onConfigured = jest.fn();
 
   render(
     <ScmMessagingChannelPicker
-      integration={integration}
+      eligibleIntegrations={eligibleIntegrations}
+      providerKey={providerKey}
       onConfigured={onConfigured}
       existingSetup={existingSetup}
     />,
@@ -129,7 +135,7 @@ describe('ScmMessagingChannelPicker', () => {
   describe('staging a new destination', () => {
     it('stores Slack by display name', async () => {
       mockChannels('10', [slackChannel]);
-      const {onConfigured} = renderPicker({integration: slackIntegration});
+      const {onConfigured} = renderPicker({eligibleIntegrations: [slackIntegration]});
 
       await selectEvent.select(screen.getByLabelText('channel'), '#general');
       await userEvent.click(screen.getByRole('button', {name: 'Add destination'}));
@@ -145,7 +151,10 @@ describe('ScmMessagingChannelPicker', () => {
 
     it('stores Discord by channel ID', async () => {
       mockChannels('20', [discordChannel]);
-      const {onConfigured} = renderPicker({integration: discordIntegration});
+      const {onConfigured} = renderPicker({
+        eligibleIntegrations: [discordIntegration],
+        providerKey: 'discord',
+      });
 
       await selectEvent.select(screen.getByLabelText('channel'), '#general (1234567890)');
       await userEvent.click(screen.getByRole('button', {name: 'Add destination'}));
@@ -161,7 +170,7 @@ describe('ScmMessagingChannelPicker', () => {
 
     it('disables Add destination until a channel is chosen', () => {
       mockChannels('10', [slackChannel]);
-      renderPicker({integration: slackIntegration});
+      renderPicker({eligibleIntegrations: [slackIntegration]});
 
       expect(screen.getByRole('button', {name: 'Add destination'})).toBeDisabled();
     });
@@ -173,7 +182,10 @@ describe('ScmMessagingChannelPicker', () => {
       // Manual entries validate as you type, via the shared hook's
       // `enabled: !!channel?.new` query.
       mockChannelValidate(true, '20');
-      const {onConfigured} = renderPicker({integration: discordIntegration});
+      const {onConfigured} = renderPicker({
+        eligibleIntegrations: [discordIntegration],
+        providerKey: 'discord',
+      });
 
       const channelUrl = 'https://discord.com/channels/111/1234567890';
       // ChannelSelect sets formatCreateLabel to the raw input, so the create
@@ -199,8 +211,9 @@ describe('ScmMessagingChannelPicker', () => {
     it('preserves the Discord channel ID through a no-op edit', async () => {
       mockChannels('20', [discordChannel]);
       const {onConfigured} = renderPicker({
-        integration: discordIntegration,
+        eligibleIntegrations: [discordIntegration],
         existingSetup: selectedDiscordSetup,
+        providerKey: 'discord',
       });
 
       await userEvent.click(screen.getByRole('button', {name: 'Add destination'}));
@@ -217,7 +230,7 @@ describe('ScmMessagingChannelPicker', () => {
     it('preserves the Slack channel name through a no-op edit', async () => {
       mockChannels('10', [slackChannel]);
       const {onConfigured} = renderPicker({
-        integration: slackIntegration,
+        eligibleIntegrations: [slackIntegration],
         existingSetup: selectedSlackSetup,
       });
 
@@ -238,8 +251,9 @@ describe('ScmMessagingChannelPicker', () => {
       // breaks revalidation. An empty /channels/ must not corrupt the saved name.
       mockChannels('30', []);
       const {onConfigured} = renderPicker({
-        integration: msteamsIntegration,
+        eligibleIntegrations: [msteamsIntegration],
         existingSetup: selectedMsTeamsSetup,
+        providerKey: 'msteams',
       });
 
       await userEvent.click(screen.getByRole('button', {name: 'Add destination'}));
@@ -258,8 +272,9 @@ describe('ScmMessagingChannelPicker', () => {
       // the stored name rather than overwrite it with the id.
       mockChannels('20', []);
       const {onConfigured} = renderPicker({
-        integration: discordIntegration,
+        eligibleIntegrations: [discordIntegration],
         existingSetup: selectedDiscordSetup,
+        providerKey: 'discord',
       });
 
       await userEvent.click(screen.getByRole('button', {name: 'Add destination'}));
@@ -271,6 +286,197 @@ describe('ScmMessagingChannelPicker', () => {
         channelId: '1234567890',
         channelName: '#general',
       });
+    });
+  });
+
+  describe('multi-workspace', () => {
+    const slackIntegration2 = OrganizationIntegrationsFixture({
+      id: '11',
+      name: 'second-workspace',
+      provider: {
+        key: 'slack',
+        slug: 'slack',
+        name: 'Slack',
+        canAdd: true,
+        canDisable: false,
+        features: [],
+        aspects: {},
+      },
+    });
+
+    it('enables the Workspace select when there are multiple eligible integrations', () => {
+      mockChannels('10', [slackChannel]);
+      mockChannels('11', []);
+      renderPicker({eligibleIntegrations: [slackIntegration, slackIntegration2]});
+
+      expect(screen.getByLabelText('workspace')).toBeEnabled();
+    });
+
+    it('disables the Workspace select when there is only one eligible integration', () => {
+      mockChannels('10', [slackChannel]);
+      renderPicker({eligibleIntegrations: [slackIntegration]});
+
+      expect(screen.getByLabelText('workspace')).toBeDisabled();
+    });
+
+    it('writes the selected workspace integrationId on save', async () => {
+      mockChannels('10', [slackChannel]);
+      mockChannels('11', [slackChannel]);
+      const {onConfigured} = renderPicker({
+        eligibleIntegrations: [slackIntegration, slackIntegration2],
+      });
+
+      // Switch to the second workspace.
+      await selectEvent.select(screen.getByLabelText('workspace'), 'second-workspace');
+      await selectEvent.select(screen.getByLabelText('channel'), '#general');
+      await userEvent.click(screen.getByRole('button', {name: 'Add destination'}));
+
+      expect(onConfigured).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mode: 'selected',
+          providerKey: 'slack',
+          integrationId: '11',
+        })
+      );
+    });
+
+    it('seeds the channel from the saved workspace and not the other', async () => {
+      mockChannels('10', [slackChannel]);
+      mockChannels('11', []);
+      renderPicker({
+        eligibleIntegrations: [slackIntegration, slackIntegration2],
+        existingSetup: selectedSlackSetup,
+      });
+
+      // The saved workspace (id 10) seeds a channel; wait for channel loading to
+      // settle before checking the Add destination button is enabled.
+      await waitFor(() => {
+        expect(screen.getByRole('button', {name: 'Add destination'})).toBeEnabled();
+      });
+    });
+
+    it('falls back to the first survivor and clears the channel when the selected workspace is removed', async () => {
+      mockChannels('10', [slackChannel]);
+      mockChannels('11', [slackChannel]);
+
+      const onConfigured = jest.fn();
+      const {rerender} = render(
+        <ScmMessagingChannelPicker
+          eligibleIntegrations={[slackIntegration, slackIntegration2]}
+          providerKey="slack"
+          onConfigured={onConfigured}
+        />,
+        {organization}
+      );
+
+      // Switch to the second workspace and pick a channel.
+      await selectEvent.select(screen.getByLabelText('workspace'), 'second-workspace');
+      await selectEvent.select(screen.getByLabelText('channel'), '#general');
+
+      // The second workspace disappears (e.g. after a refetch).
+      rerender(
+        <ScmMessagingChannelPicker
+          eligibleIntegrations={[slackIntegration]}
+          providerKey="slack"
+          onConfigured={onConfigured}
+        />
+      );
+
+      // Workspace falls back to the first survivor and channel is cleared.
+      await waitFor(() => {
+        expect(screen.getByRole('button', {name: 'Add destination'})).toBeDisabled();
+      });
+
+      // Save writes the surviving integration id.
+      await selectEvent.select(screen.getByLabelText('channel'), '#general');
+      await userEvent.click(screen.getByRole('button', {name: 'Add destination'}));
+
+      expect(onConfigured).toHaveBeenCalledWith(
+        expect.objectContaining({integrationId: '10'})
+      );
+    });
+
+    it('clears the seeded channel and falls back when the default (saved) workspace is removed', async () => {
+      // Regression: when selectedIntegrationId is undefined (user never explicitly
+      // switched workspaces), the removal effect's guard (`selectedIntegrationId &&`)
+      // would short-circuit and leave the seeded channel intact. A subsequent save
+      // would then pair the stale channel with the new fallback integrationId.
+      mockChannels('10', [slackChannel]);
+      mockChannels('11', [slackChannel]);
+
+      const onConfigured = jest.fn();
+      const {rerender} = render(
+        <ScmMessagingChannelPicker
+          eligibleIntegrations={[slackIntegration, slackIntegration2]}
+          providerKey="slack"
+          onConfigured={onConfigured}
+          existingSetup={selectedSlackSetup}
+        />,
+        {organization}
+      );
+
+      // The saved workspace (id 10) seeds the channel. The user never explicitly
+      // switched workspaces, so selectedIntegrationId is initialized to '10' and
+      // remains at its initial value throughout.
+      await waitFor(() => {
+        expect(screen.getByRole('button', {name: 'Add destination'})).toBeEnabled();
+      });
+
+      // Saved workspace (id 10) is removed from the list — e.g. after a refetch.
+      rerender(
+        <ScmMessagingChannelPicker
+          eligibleIntegrations={[slackIntegration2]}
+          providerKey="slack"
+          onConfigured={onConfigured}
+          existingSetup={selectedSlackSetup}
+        />
+      );
+
+      // Channel must be cleared; Add destination disabled.
+      await waitFor(() => {
+        expect(screen.getByRole('button', {name: 'Add destination'})).toBeDisabled();
+      });
+
+      // Save must write the surviving workspace id, not the vanished one paired
+      // with the stale channel.
+      await selectEvent.select(screen.getByLabelText('channel'), '#general');
+      await userEvent.click(screen.getByRole('button', {name: 'Add destination'}));
+
+      expect(onConfigured).toHaveBeenCalledWith(
+        expect.objectContaining({integrationId: '11'})
+      );
+      expect(onConfigured).not.toHaveBeenCalledWith(
+        expect.objectContaining({integrationId: '10'})
+      );
+    });
+
+    it('only shows the integrations it receives — eligibility is enforced upstream', () => {
+      // The row (via the view model) is responsible for filtering to eligibleIntegrations
+      // before passing them to the picker. The picker renders whatever it receives.
+      const msteamsTeam = OrganizationIntegrationsFixture({
+        id: '41',
+        name: 'team-workspace',
+        provider: {
+          key: 'msteams',
+          slug: 'msteams',
+          name: 'Microsoft Teams',
+          canAdd: true,
+          canDisable: false,
+          features: [],
+          aspects: {},
+        },
+        configData: {installationType: 'team'},
+      });
+
+      mockChannels('41', []);
+      // Only the eligible team integration is passed; the tenant was excluded by the row.
+      renderPicker({
+        eligibleIntegrations: [msteamsTeam],
+        providerKey: 'msteams',
+      });
+
+      expect(screen.getByLabelText('workspace')).toBeDisabled(); // only 1 workspace
+      expect(screen.getByText('team-workspace')).toBeInTheDocument();
     });
   });
 });

--- a/static/app/components/onboarding/scm/scmMessagingChannelPicker.spec.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingChannelPicker.spec.tsx
@@ -37,6 +37,20 @@ const discordIntegration = OrganizationIntegrationsFixture({
   },
 });
 
+const msteamsIntegration = OrganizationIntegrationsFixture({
+  id: '30',
+  name: 'test-team',
+  provider: {
+    key: 'msteams',
+    slug: 'msteams',
+    name: 'MS Teams',
+    canAdd: true,
+    canDisable: false,
+    features: [],
+    aspects: {},
+  },
+});
+
 // Both providers format `display` as `#{name}`; only `id` distinguishes them,
 // which is what makes the name/ID mixup easy to write and hard to spot.
 const slackChannel = {id: 'C123', name: 'general', display: '#general', type: 'channel'};
@@ -96,6 +110,14 @@ const selectedSlackSetup: ScmMessagingSetup = {
   integrationId: '10',
   channelId: 'C123',
   channelName: '#general',
+};
+
+const selectedMsTeamsSetup: ScmMessagingSetup = {
+  mode: 'selected',
+  providerKey: 'msteams',
+  integrationId: '30',
+  channelId: '19:abc123@thread.tacv2',
+  channelName: 'General',
 };
 
 describe('ScmMessagingChannelPicker', () => {
@@ -206,6 +228,47 @@ describe('ScmMessagingChannelPicker', () => {
         providerKey: 'slack',
         integrationId: '10',
         channelId: 'C123',
+        channelName: '#general',
+      });
+    });
+
+    it('preserves stored MS Teams identifiers when the channel list is empty', async () => {
+      // msteams selects by id but validates by name, so overwriting channelName
+      // with the id (the fallback when the list can't resolve the selection)
+      // breaks revalidation. An empty /channels/ must not corrupt the saved name.
+      mockChannels('30', []);
+      const {onConfigured} = renderPicker({
+        integration: msteamsIntegration,
+        existingSetup: selectedMsTeamsSetup,
+      });
+
+      await userEvent.click(screen.getByRole('button', {name: 'Add destination'}));
+
+      expect(onConfigured).toHaveBeenCalledWith({
+        mode: 'selected',
+        providerKey: 'msteams',
+        integrationId: '30',
+        channelId: '19:abc123@thread.tacv2',
+        channelName: 'General',
+      });
+    });
+
+    it('preserves stored Discord identifiers when the saved channel is absent from the list', async () => {
+      // /channels/ no longer returns the saved channel; a no-op re-save must keep
+      // the stored name rather than overwrite it with the id.
+      mockChannels('20', []);
+      const {onConfigured} = renderPicker({
+        integration: discordIntegration,
+        existingSetup: selectedDiscordSetup,
+      });
+
+      await userEvent.click(screen.getByRole('button', {name: 'Add destination'}));
+
+      expect(onConfigured).toHaveBeenCalledWith({
+        mode: 'selected',
+        providerKey: 'discord',
+        integrationId: '20',
+        channelId: '1234567890',
         channelName: '#general',
       });
     });

--- a/static/app/components/onboarding/scm/scmMessagingChannelPicker.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingChannelPicker.tsx
@@ -40,7 +40,7 @@ export function ScmMessagingChannelPicker({
 }: ScmMessagingChannelPickerProps) {
   const providerKey = integration.provider.key as ScmMessagingProviderKey;
 
-  const {channelSelectedBy, channelTargetedBy} = providerDetails[providerKey];
+  const {channelSelectedBy} = providerDetails[providerKey];
 
   const [channel, setChannel] = useState<IntegrationChannel | undefined>(() => {
     if (existingSetup?.mode === 'selected' && existingSetup.providerKey === providerKey) {
@@ -107,7 +107,6 @@ export function ScmMessagingChannelPicker({
       providerKey,
       integrationId: integration.id,
       ...stored,
-      actionTarget: stored[channelTargetedBy],
     });
   };
 

--- a/static/app/components/onboarding/scm/scmMessagingChannelPicker.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingChannelPicker.tsx
@@ -42,17 +42,20 @@ export function ScmMessagingChannelPicker({
 
   const {channelSelectedBy} = providerDetails[providerKey];
 
-  const [channel, setChannel] = useState<IntegrationChannel | undefined>(() => {
-    if (existingSetup?.mode === 'selected' && existingSetup.providerKey === providerKey) {
-      // Seed by whatever field this provider's options are keyed on. Seeding the
-      // wrong one resolves to no option and handleSave rewrites the identifiers.
-      return {
-        label: existingSetup.channelName,
-        value: existingSetup[channelSelectedBy],
-      };
-    }
-    return;
-  });
+  // The saved destination we're editing, if any. Drives both the dropdown seed
+  // and the preserve-on-no-op-save logic below.
+  const savedSelection =
+    existingSetup?.mode === 'selected' && existingSetup.providerKey === providerKey
+      ? existingSetup
+      : undefined;
+
+  const [channel, setChannel] = useState<IntegrationChannel | undefined>(() =>
+    // Seed by whatever field this provider's options are keyed on. Seeding the
+    // wrong one resolves to no option and handleSave rewrites the identifiers.
+    savedSelection
+      ? {label: savedSelection.channelName, value: savedSelection[channelSelectedBy]}
+      : undefined
+  );
 
   const providersToIntegrations = useMemo(
     () => ({[providerKey]: [integration]}),
@@ -97,10 +100,23 @@ export function ScmMessagingChannelPicker({
           (ch: Channel) => ch[RAW_CHANNEL_FIELD[channelSelectedBy]] === channel.value
         );
 
-    const stored = {
-      channelId: rawChannel?.id ?? channel.value,
-      channelName: rawChannel?.display ?? channel.value,
-    };
+    // Prefer the resolved raw channel. If it can't be resolved (empty/errored
+    // /channels/ or a dropped channel) but the selection is unchanged, keep the
+    // stored identifiers — otherwise id-keyed providers (msteams, discord) would
+    // overwrite channelName with the id and break name-based revalidation. A new
+    // value falls through to itself.
+    let stored: {channelId: string; channelName: string};
+
+    if (rawChannel) {
+      stored = {channelId: rawChannel.id, channelName: rawChannel.display};
+    } else if (savedSelection && channel.value === savedSelection[channelSelectedBy]) {
+      stored = {
+        channelId: savedSelection.channelId,
+        channelName: savedSelection.channelName,
+      };
+    } else {
+      stored = {channelId: channel.value, channelName: channel.value};
+    }
 
     onConfigured({
       mode: 'selected',

--- a/static/app/components/onboarding/scm/scmMessagingChannelPicker.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingChannelPicker.tsx
@@ -8,7 +8,11 @@ import {Text} from '@sentry/scraps/text';
 
 import {t} from 'sentry/locale';
 import type {OrganizationIntegration} from 'sentry/types/integrations';
-import type {IntegrationChannel} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
+import {
+  providerDetails,
+  RAW_CHANNEL_FIELD,
+  type IntegrationChannel,
+} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 import {
   type Channel,
   ChannelField,
@@ -36,15 +40,15 @@ export function ScmMessagingChannelPicker({
 }: ScmMessagingChannelPickerProps) {
   const providerKey = integration.provider.key as ScmMessagingProviderKey;
 
+  const {channelSelectedBy, channelTargetedBy} = providerDetails[providerKey];
+
   const [channel, setChannel] = useState<IntegrationChannel | undefined>(() => {
     if (existingSetup?.mode === 'selected' && existingSetup.providerKey === providerKey) {
-      // Seed by whatever field this provider's options are keyed on: Slack by
-      // display name, Discord and msteams by id. Seeding the wrong one resolves
-      // to no option and handleSave rewrites the stored identifiers.
+      // Seed by whatever field this provider's options are keyed on. Seeding the
+      // wrong one resolves to no option and handleSave rewrites the identifiers.
       return {
         label: existingSetup.channelName,
-        value:
-          providerKey === 'slack' ? existingSetup.channelName : existingSetup.channelId,
+        value: existingSetup[channelSelectedBy],
       };
     }
     return;
@@ -85,28 +89,25 @@ export function ScmMessagingChannelPicker({
       return;
     }
 
-    // Look up the real backend channel ID by matching the selected value in
-    // the raw channel list. Manual entries (channel.new) have no raw match.
+    // Match the selected value against whichever field this provider's options
+    // are keyed on. Manual entries (channel.new) are not in the list.
     const rawChannel = channel.new
       ? undefined
-      : channelsData?.results.find((ch: Channel) =>
-          providerKey === 'slack' ? ch.display === channel.value : ch.id === channel.value
+      : channelsData?.results.find(
+          (ch: Channel) => ch[RAW_CHANNEL_FIELD[channelSelectedBy]] === channel.value
         );
 
-    // Slack revalidation and alert-rule actions both use the display name, so
-    // channelId falls back to channel.value for Slack without losing anything.
-    const channelId = rawChannel?.id ?? channel.value;
-    const channelName =
-      providerKey === 'slack' ? channel.value : (rawChannel?.display ?? channel.value);
-    const actionTarget = providerKey === 'slack' ? channelName : channelId;
+    const stored = {
+      channelId: rawChannel?.id ?? channel.value,
+      channelName: rawChannel?.display ?? channel.value,
+    };
 
     onConfigured({
       mode: 'selected',
       providerKey,
       integrationId: integration.id,
-      channelId,
-      channelName,
-      actionTarget,
+      ...stored,
+      actionTarget: stored[channelTargetedBy],
     });
   };
 

--- a/static/app/components/onboarding/scm/scmMessagingChannelPicker.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingChannelPicker.tsx
@@ -1,4 +1,4 @@
-import {useMemo, useState} from 'react';
+import {useCallback, useMemo, useState} from 'react';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
@@ -24,8 +24,13 @@ import type {ScmMessagingProviderKey} from './messagingProviders';
 import type {ScmMessagingSetup} from './scmMessagingSetup';
 
 export interface ScmMessagingChannelPickerProps {
-  integration: OrganizationIntegration;
+  /**
+   * Eligible integrations for this provider — already filtered to those that
+   * can receive Issue Alert actions.
+   */
+  eligibleIntegrations: OrganizationIntegration[];
   onConfigured: (setup: ScmMessagingSetup & {mode: 'selected'}) => void;
+  providerKey: ScmMessagingProviderKey;
   /** Pre-seeds the channel selector when editing an existing destination. */
   existingSetup?: ScmMessagingSetup;
   /** When provided a Cancel button is shown (e.g. in Edit mode). */
@@ -33,13 +38,12 @@ export interface ScmMessagingChannelPickerProps {
 }
 
 export function ScmMessagingChannelPicker({
-  integration,
+  eligibleIntegrations,
   onCancel,
   onConfigured,
   existingSetup,
+  providerKey,
 }: ScmMessagingChannelPickerProps) {
-  const providerKey = integration.provider.key as ScmMessagingProviderKey;
-
   const {channelSelectedBy} = providerDetails[providerKey];
 
   // The saved destination we're editing, if any. Drives both the dropdown seed
@@ -49,17 +53,44 @@ export function ScmMessagingChannelPicker({
       ? existingSetup
       : undefined;
 
-  const [channel, setChannel] = useState<IntegrationChannel | undefined>(() =>
-    // Seed by whatever field this provider's options are keyed on. Seeding the
-    // wrong one resolves to no option and handleSave rewrites the identifiers.
-    savedSelection
-      ? {label: savedSelection.channelName, value: savedSelection[channelSelectedBy]}
-      : undefined
+  const [selectedIntegrationId, setSelectedIntegrationId] = useState(
+    savedSelection?.integrationId
   );
 
+  const selectedIntegration =
+    eligibleIntegrations.find(i => i.id === selectedIntegrationId) ??
+    eligibleIntegrations[0];
+
+  // Keep the chosen channel bound to the workspace it was chosen for. It only
+  // surfaces (and is only saved) while its workspace is the selected one, so a
+  // fallback after the workspace is removed can never pair a stale channel with a
+  // different integration.
+  const [channelState, setChannelState] = useState<{
+    channel: IntegrationChannel | undefined;
+    integrationId: string | undefined;
+  }>(() => ({
+    integrationId: savedSelection?.integrationId,
+    // Only seed the channel when the default workspace is the saved one. Switching
+    // workspaces starts blank.
+    channel: savedSelection
+      ? {label: savedSelection.channelName, value: savedSelection[channelSelectedBy]}
+      : undefined,
+  }));
+
+  const setChannel = useCallback(
+    (nextChannel: IntegrationChannel | undefined) =>
+      setChannelState({channel: nextChannel, integrationId: selectedIntegration?.id}),
+    [selectedIntegration?.id]
+  );
+
+  const channel =
+    channelState.integrationId === selectedIntegration?.id
+      ? channelState.channel
+      : undefined;
+
   const providersToIntegrations = useMemo(
-    () => ({[providerKey]: [integration]}),
-    [providerKey, integration]
+    () => ({[providerKey]: eligibleIntegrations}),
+    [providerKey, eligibleIntegrations]
   );
 
   const {
@@ -70,14 +101,19 @@ export function ScmMessagingChannelPicker({
     channelError,
     onChannelChange,
     onCreateChannel,
+    onIntegrationChange,
     integrationOptions,
     integrationDisabled,
   } = useMessagingIntegrationAlertRule({
     channel,
-    integration,
+    integration: selectedIntegration,
     provider: providerKey,
     setChannel,
-    setIntegration: () => {},
+    setIntegration: i => {
+      if (i) {
+        setSelectedIntegrationId(i.id);
+      }
+    },
     setProvider: () => {},
     providersToIntegrations,
     actions: [],
@@ -86,6 +122,10 @@ export function ScmMessagingChannelPicker({
     querySuccess: true,
     shouldRenderSetupButton: false,
   });
+
+  if (!selectedIntegration) {
+    return null;
+  }
 
   const handleSave = () => {
     if (!channel) {
@@ -101,15 +141,18 @@ export function ScmMessagingChannelPicker({
         );
 
     // Prefer the resolved raw channel. If it can't be resolved (empty/errored
-    // /channels/ or a dropped channel) but the selection is unchanged, keep the
-    // stored identifiers — otherwise id-keyed providers (msteams, discord) would
-    // overwrite channelName with the id and break name-based revalidation. A new
-    // value falls through to itself.
+    // /channels/ or a dropped channel) but the selection and workspace are unchanged,
+    // keep the stored identifiers — otherwise id-keyed providers (msteams, discord)
+    // would overwrite channelName with the id and break name-based revalidation.
+    // A new value falls through to itself.
     let stored: {channelId: string; channelName: string};
 
     if (rawChannel) {
       stored = {channelId: rawChannel.id, channelName: rawChannel.display};
-    } else if (savedSelection && channel.value === savedSelection[channelSelectedBy]) {
+    } else if (
+      selectedIntegration.id === savedSelection?.integrationId &&
+      channel.value === savedSelection?.[channelSelectedBy]
+    ) {
       stored = {
         channelId: savedSelection.channelId,
         channelName: savedSelection.channelName,
@@ -121,7 +164,7 @@ export function ScmMessagingChannelPicker({
     onConfigured({
       mode: 'selected',
       providerKey,
-      integrationId: integration.id,
+      integrationId: selectedIntegration.id,
       ...stored,
     });
   };
@@ -136,9 +179,9 @@ export function ScmMessagingChannelPicker({
           <Select
             aria-label={t('workspace')}
             disabled={integrationDisabled}
-            value={integration}
+            value={selectedIntegration}
             options={integrationOptions}
-            onChange={() => {}}
+            onChange={onIntegrationChange}
           />
         </Stack>
         <Stack gap="xs">
@@ -179,7 +222,7 @@ export function ScmMessagingChannelPicker({
         <Button
           size="sm"
           variant="primary"
-          disabled={!channel || !!channelError}
+          disabled={!channel || !!channelError || isChannelLoading}
           onClick={handleSave}
         >
           {t('Add destination')}

--- a/static/app/components/onboarding/scm/scmMessagingChannelPicker.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingChannelPicker.tsx
@@ -38,7 +38,14 @@ export function ScmMessagingChannelPicker({
 
   const [channel, setChannel] = useState<IntegrationChannel | undefined>(() => {
     if (existingSetup?.mode === 'selected' && existingSetup.providerKey === providerKey) {
-      return {label: existingSetup.channelName, value: existingSetup.channelName};
+      // Seed by whatever field this provider's options are keyed on: Slack by
+      // display name, Discord and msteams by id. Seeding the wrong one resolves
+      // to no option and handleSave rewrites the stored identifiers.
+      return {
+        label: existingSetup.channelName,
+        value:
+          providerKey === 'slack' ? existingSetup.channelName : existingSetup.channelId,
+      };
     }
     return;
   });

--- a/static/app/components/onboarding/scm/scmMessagingProviderRow.spec.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingProviderRow.spec.tsx
@@ -78,7 +78,6 @@ const selectedSlackSetup: ScmMessagingSetup = {
   integrationId: 'slack-1',
   channelId: 'C123',
   channelName: '#alerts',
-  actionTarget: '#alerts',
 };
 
 type PipelineCallbacks = {

--- a/static/app/components/onboarding/scm/scmMessagingProviderRow.spec.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingProviderRow.spec.tsx
@@ -55,21 +55,24 @@ const installableSlack: ScmMessagingProviderViewModel = {
   providerKey: 'slack',
   provider: slackProvider,
   status: 'installable',
-  integration: undefined,
+  eligibleIntegrations: [],
+  permissionLimitedIntegration: undefined,
 };
 
 const connectedSlack: ScmMessagingProviderViewModel = {
   providerKey: 'slack',
   provider: slackProvider,
   status: 'connected',
-  integration: slackIntegration,
+  eligibleIntegrations: [slackIntegration],
+  permissionLimitedIntegration: undefined,
 };
 
 const permissionLimitedMsteams: ScmMessagingProviderViewModel = {
   providerKey: 'msteams',
   provider: msteamsProvider,
   status: 'permission-limited',
-  integration: msteamsIntegration,
+  eligibleIntegrations: [],
+  permissionLimitedIntegration: msteamsIntegration,
 };
 
 const selectedSlackSetup: ScmMessagingSetup = {
@@ -343,11 +346,88 @@ describe('ScmMessagingProviderRow', () => {
       expect(screen.getByText('channel-picker')).toBeInTheDocument();
       expect(renderChannelPicker).toHaveBeenCalledWith(
         expect.objectContaining({
-          integration: slackIntegration,
+          integrations: [slackIntegration],
           onCancel: undefined,
           onConfigured: expect.any(Function),
         })
       );
+    });
+
+    it('passes only eligible integrations to the picker when a provider has mixed installations', () => {
+      const msteamsTeamIntegration = OrganizationIntegrationsFixture({
+        id: 'msteams-team',
+        name: 'Team Workspace',
+        provider: {
+          key: 'msteams',
+          slug: 'msteams',
+          name: 'Microsoft Teams',
+          canAdd: true,
+          canDisable: false,
+          features: [],
+          aspects: {},
+        },
+        configData: {installationType: 'team'},
+      });
+
+      const mixedMsteams: ScmMessagingProviderViewModel = {
+        providerKey: 'msteams',
+        provider: msteamsProvider,
+        status: 'connected',
+        eligibleIntegrations: [msteamsTeamIntegration],
+        permissionLimitedIntegration: undefined,
+      };
+
+      const renderChannelPicker = jest.fn(() => <div>channel-picker</div>);
+      renderRow(mixedMsteams, UNCONFIGURED_SCM_MESSAGING_SETUP, {renderChannelPicker});
+
+      expect(renderChannelPicker).toHaveBeenCalledWith(
+        expect.objectContaining({
+          integrations: [msteamsTeamIntegration],
+        })
+      );
+    });
+
+    it('does not treat a setup referencing an ineligible integration as configured', () => {
+      const msteamsTeamIntegration = OrganizationIntegrationsFixture({
+        id: 'msteams-team',
+        name: 'Team Workspace',
+        provider: {
+          key: 'msteams',
+          slug: 'msteams',
+          name: 'Microsoft Teams',
+          canAdd: true,
+          canDisable: false,
+          features: [],
+          aspects: {},
+        },
+        configData: {installationType: 'team'},
+      });
+
+      const mixedMsteams: ScmMessagingProviderViewModel = {
+        providerKey: 'msteams',
+        provider: msteamsProvider,
+        status: 'connected',
+        eligibleIntegrations: [msteamsTeamIntegration],
+        permissionLimitedIntegration: undefined,
+      };
+
+      // A destination previously saved against the tenant (ineligible) integration.
+      const tenantSetup: ScmMessagingSetup = {
+        mode: 'selected',
+        providerKey: 'msteams',
+        integrationId: 'msteams-tenant',
+        channelId: 'C1',
+        channelName: '#general',
+      };
+
+      const renderChannelPicker = jest.fn(() => <div>channel-picker</div>);
+      renderRow(mixedMsteams, tenantSetup, {renderChannelPicker});
+
+      // Should NOT be in configured state — the tenant integration is not eligible.
+      expect(screen.queryByRole('button', {name: /Edit/})).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', {name: /Remove/})).not.toBeInTheDocument();
+      // Picker is auto-expanded for the unconfigured connected state.
+      expect(screen.getByText('channel-picker')).toBeInTheDocument();
     });
 
     it('saves the setup and transitions to configured when onConfigured is called', () => {

--- a/static/app/components/onboarding/scm/scmMessagingProviderRow.spec.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingProviderRow.spec.tsx
@@ -384,7 +384,8 @@ describe('ScmMessagingProviderRow', () => {
         providerKey: 'msteams',
         provider: msteamsProvider,
         status: 'installable',
-        integration: undefined,
+        eligibleIntegrations: [],
+        permissionLimitedIntegration: undefined,
       };
 
       const {rerender} = render(

--- a/static/app/components/onboarding/scm/scmMessagingProviderRow.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingProviderRow.tsx
@@ -107,7 +107,7 @@ function deriveVisualState({
   const isConfigured =
     messagingSetup.mode === 'selected' &&
     messagingSetup.providerKey === viewModel.providerKey &&
-    messagingSetup.integrationId === viewModel.integration?.id;
+    viewModel.eligibleIntegrations.some(i => i.id === messagingSetup.integrationId);
 
   if (isConfigured && isConfiguring) {
     return 'configuring'; // Edit mode
@@ -130,14 +130,14 @@ export interface ScmMessagingProviderRowProps {
   /**
    * Render prop for the inline channel picker.
    *
-   * When the user opens the configuring state this is called with the active
-   * integration and two callbacks: `onConfigured` (save the chosen destination
-   * to session state) and `onCancel` (close without saving).
+   * Called with the eligible (non-empty) integrations for this provider and two
+   * callbacks: `onConfigured` (save the chosen destination to session state) and
+   * `onCancel` (close without saving). Only invoked when `status === 'connected'`.
    *
    * Omitting this prop leaves the configuring state with an empty body.
    */
   renderChannelPicker?: (props: {
-    integration: OrganizationIntegration;
+    integrations: OrganizationIntegration[];
     onCancel: (() => void) | undefined;
     onConfigured: (setup: ScmMessagingSetup & {mode: 'selected'}) => void;
   }) => ReactNode;
@@ -160,7 +160,7 @@ export function ScmMessagingProviderRow({
   const isConfigured =
     messagingSetup.mode === 'selected' &&
     messagingSetup.providerKey === viewModel.providerKey &&
-    messagingSetup.integrationId === viewModel.integration?.id;
+    viewModel.eligibleIntegrations.some(i => i.id === messagingSetup.integrationId);
 
   const visualState = deriveVisualState({
     viewModel,
@@ -294,17 +294,18 @@ export function ScmMessagingProviderRow({
           </Flex>
         )}
 
-        {visualState === 'configuring' && viewModel.integration && (
+        {visualState === 'configuring' && (
           <ChannelPickerSlot>
             {renderChannelPicker ? (
               renderChannelPicker({
-                integration: viewModel.integration,
+                integrations: viewModel.eligibleIntegrations,
                 onCancel: isConfigured ? handleCancelConfiguring : undefined,
                 onConfigured: handleConfigured,
               })
             ) : (
               <ScmMessagingChannelPicker
-                integration={viewModel.integration}
+                eligibleIntegrations={viewModel.eligibleIntegrations}
+                providerKey={viewModel.providerKey}
                 onCancel={isConfigured ? handleCancelConfiguring : undefined}
                 onConfigured={handleConfigured}
                 existingSetup={isConfigured ? messagingSetup : undefined}
@@ -354,7 +355,7 @@ function RowSubtitle({
   if (visualState === 'permission-limited') {
     return (
       <Stack gap="2xs">
-        <Text size="sm">{viewModel.integration?.name}</Text>
+        <Text size="sm">{viewModel.permissionLimitedIntegration?.name}</Text>
         <Text variant="muted" size="sm">
           {t(
             'This Microsoft Teams workspace uses a tenant-level connection and cannot receive issue alerts directly. Reinstall with a team-level connection to enable destinations.'
@@ -367,7 +368,13 @@ function RowSubtitle({
   if (visualState === 'configured' && messagingSetup.mode === 'selected') {
     return (
       <Flex gap="xs" align="center">
-        <Text size="sm">{viewModel.integration?.name}</Text>
+        <Text size="sm">
+          {
+            viewModel.eligibleIntegrations.find(
+              i => i.id === messagingSetup.integrationId
+            )?.name
+          }
+        </Text>
         <Text variant="muted" size="sm" aria-hidden>
           /
         </Text>

--- a/static/app/components/onboarding/scm/scmMessagingSetup.ts
+++ b/static/app/components/onboarding/scm/scmMessagingSetup.ts
@@ -5,13 +5,6 @@ export type ScmMessagingSetup =
   | {mode: 'skipped'}
   | {
       /**
-       * The value written into the alert rule action payload.
-       * Slack: display name (e.g. "#general") — Slack actions address by name.
-       * Discord: channel ID — Discord actions address by ID.
-       * msteams: channel ID — msteams actions address by ID.
-       */
-      actionTarget: string;
-      /**
        * The real backend channel ID for all providers (e.g. C123 for Slack,
        * a numeric string for Discord, a UUID-like string for msteams).
        * Used as the Discord channel-validate param and as the Discord action value.

--- a/static/app/components/onboarding/scm/useScmMessagingProviders.spec.ts
+++ b/static/app/components/onboarding/scm/useScmMessagingProviders.spec.ts
@@ -69,7 +69,9 @@ describe('useScmMessagingProviders', () => {
 
     const slack = result.current.providers.find(p => p.providerKey === 'slack');
     expect(slack?.status).toBe('connected');
-    expect(slack?.integration?.id).toBe('10');
+    expect(slack?.eligibleIntegrations).toHaveLength(1);
+    expect(slack?.eligibleIntegrations[0]?.id).toBe('10');
+    expect(slack?.permissionLimitedIntegration).toBeUndefined();
 
     result.current.providers
       .filter(p => p.providerKey !== 'slack')
@@ -113,8 +115,9 @@ describe('useScmMessagingProviders', () => {
 
     const msteams = result.current.providers.find(p => p.providerKey === 'msteams');
     expect(msteams?.status).toBe('permission-limited');
-    // The integration is still exposed so the row can show the workspace name.
-    expect(msteams?.integration?.id).toBe('12');
+    expect(msteams?.eligibleIntegrations).toHaveLength(0);
+    // The tenant integration is surfaced for workspace-name display.
+    expect(msteams?.permissionLimitedIntegration?.id).toBe('12');
   });
 
   it('marks a team-type msteams integration as connected', async () => {
@@ -151,6 +154,71 @@ describe('useScmMessagingProviders', () => {
 
     expect(result.current.isError).toBe(true);
     expect(result.current.providers).toHaveLength(0);
+  });
+
+  it('exposes all eligible integrations when a provider has multiple workspaces', async () => {
+    mockProviders();
+    mockIntegrations([
+      OrganizationIntegrationsFixture({
+        id: '20',
+        name: 'workspace-a',
+        provider: {key: 'slack'} as any,
+        status: 'active',
+        organizationIntegrationStatus: 'active',
+      }),
+      OrganizationIntegrationsFixture({
+        id: '21',
+        name: 'workspace-b',
+        provider: {key: 'slack'} as any,
+        status: 'active',
+        organizationIntegrationStatus: 'active',
+      }),
+    ]);
+
+    const {result} = renderProviders();
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    const slack = result.current.providers.find(p => p.providerKey === 'slack');
+    expect(slack?.status).toBe('connected');
+    // Both workspaces are eligible (Slack has no tenant restriction).
+    expect(slack?.eligibleIntegrations).toHaveLength(2);
+    expect(slack?.eligibleIntegrations.map(i => i.id)).toEqual(['20', '21']);
+    expect(slack?.permissionLimitedIntegration).toBeUndefined();
+  });
+
+  it('is connected when msteams has both a tenant and a team installation', async () => {
+    mockProviders();
+    mockIntegrations([
+      OrganizationIntegrationsFixture({
+        id: '30',
+        name: 'tenant',
+        provider: {key: 'msteams'} as any,
+        status: 'active',
+        organizationIntegrationStatus: 'active',
+        configData: {installationType: 'tenant'},
+      }),
+      OrganizationIntegrationsFixture({
+        id: '31',
+        name: 'team',
+        provider: {key: 'msteams'} as any,
+        status: 'active',
+        organizationIntegrationStatus: 'active',
+        configData: {installationType: 'team'},
+      }),
+    ]);
+
+    const {result} = renderProviders();
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    const msteams = result.current.providers.find(p => p.providerKey === 'msteams');
+    expect(msteams?.status).toBe('connected');
+    // Only the team installation is eligible.
+    expect(msteams?.eligibleIntegrations).toHaveLength(1);
+    expect(msteams?.eligibleIntegrations[0]?.id).toBe('31');
+    // Status is connected (not permission-limited), so this is unset.
+    expect(msteams?.permissionLimitedIntegration).toBeUndefined();
   });
 
   it('preserves provider order matching SCM_MESSAGING_PROVIDER_KEYS', async () => {

--- a/static/app/components/onboarding/scm/useScmMessagingProviders.ts
+++ b/static/app/components/onboarding/scm/useScmMessagingProviders.ts
@@ -5,7 +5,10 @@ import {
   SCM_MESSAGING_PROVIDER_KEYS,
   type ScmMessagingProviderKey,
 } from 'sentry/components/onboarding/scm/messagingProviders';
-import {isIntegrationActive} from 'sentry/components/onboarding/scm/useScmMessagingSetupValidation';
+import {
+  isEligibleForIssueAlerts,
+  isIntegrationActive,
+} from 'sentry/components/onboarding/scm/useScmMessagingSetupValidation';
 import type {
   IntegrationProvider,
   OrganizationIntegration,
@@ -26,33 +29,20 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 type ScmMessagingProviderStatus = 'installable' | 'permission-limited' | 'connected';
 
 export type ScmMessagingProviderViewModel = {
-  /** Defined when status is `connected` or `permission-limited`. */
-  integration: OrganizationIntegration | undefined;
+  /**
+   * Active integrations that can receive Issue Alert actions.
+   * Non-empty iff `status === 'connected'`.
+   */
+  eligibleIntegrations: OrganizationIntegration[];
+  /**
+   * The ineligible active integration shown in the `permission-limited` state
+   * so the row can display its workspace name. `undefined` for other statuses.
+   */
+  permissionLimitedIntegration: OrganizationIntegration | undefined;
   provider: IntegrationProvider;
   providerKey: ScmMessagingProviderKey;
   status: ScmMessagingProviderStatus;
 };
-
-/**
- * Returns true when the integration can receive Issue Alert actions.
- * MS Teams "tenant" installations route notifications differently and
- * cannot be used as an issue-alert destination.
- */
-function isEligibleForIssueAlerts(integration: OrganizationIntegration): boolean {
-  if (integration.provider.key !== 'msteams') {
-    return true;
-  }
-  return integration.configData?.installationType !== 'tenant';
-}
-
-function toStatus(
-  integration: OrganizationIntegration | undefined
-): ScmMessagingProviderStatus {
-  if (!integration) {
-    return 'installable';
-  }
-  return isEligibleForIssueAlerts(integration) ? 'connected' : 'permission-limited';
-}
 
 export function useScmMessagingProviders(): {
   isError: boolean;
@@ -110,18 +100,24 @@ export function useScmMessagingProviders(): {
         return [];
       }
 
-      // Find the first active integration for this provider. Inactive
-      // integrations are treated the same as no integration.
-      const integration = integrations.find(
+      const active = integrations.filter(
         i => i.provider.key === providerKey && isIntegrationActive(i)
       );
+      const eligible = active.filter(isEligibleForIssueAlerts);
+      const status = eligible.length
+        ? 'connected'
+        : active.length
+          ? 'permission-limited'
+          : 'installable';
 
       return [
         {
           providerKey,
           provider,
-          status: toStatus(integration),
-          integration,
+          status,
+          eligibleIntegrations: eligible,
+          permissionLimitedIntegration:
+            status === 'permission-limited' ? active[0] : undefined,
         },
       ];
     });

--- a/static/app/components/onboarding/scm/useScmMessagingSetupValidation.ts
+++ b/static/app/components/onboarding/scm/useScmMessagingSetupValidation.ts
@@ -6,6 +6,7 @@ import type {OrganizationIntegration} from 'sentry/types/integrations';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {isNotFoundError} from 'sentry/utils/requestError/requestError';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {providerDetails} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 
 export type StaleDestinationReason = 'channel' | 'inactiveIntegration' | 'integration';
 
@@ -42,20 +43,17 @@ function resolveSavedIntegration(
 }
 
 /**
- * Returns the value to send as the `channel` query param to channel-validate/.
- *
- * Slack and msteams resolve channels by name; Discord resolves by ID.
- * Returns undefined when the required field is absent (e.g. msteams data
- * written before channelName was required).
+ * Returns the value to send as the `channel` query param to channel-validate/,
+ * reading the field this provider validates by from the provider table.
+ * Returns undefined when that field is absent (e.g. legacy msteams data written
+ * before channelName was required).
  */
 function channelValidateParam(messagingSetup: ScmMessagingSetup): string | undefined {
   if (messagingSetup.mode !== 'selected') {
     return undefined;
   }
-  // Discord takes the numeric channel ID; Slack and msteams take the display name.
-  return messagingSetup.providerKey === 'discord'
-    ? messagingSetup.channelId
-    : messagingSetup.channelName || undefined;
+  const {channelValidatedBy} = providerDetails[messagingSetup.providerKey];
+  return messagingSetup[channelValidatedBy] || undefined;
 }
 
 interface UseScmMessagingSetupValidationParams {

--- a/static/app/components/onboarding/scm/useScmMessagingSetupValidation.ts
+++ b/static/app/components/onboarding/scm/useScmMessagingSetupValidation.ts
@@ -8,13 +8,29 @@ import {isNotFoundError} from 'sentry/utils/requestError/requestError';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {providerDetails} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 
-export type StaleDestinationReason = 'channel' | 'inactiveIntegration' | 'integration';
+export type StaleDestinationReason =
+  | 'channel'
+  | 'inactiveIntegration'
+  | 'ineligibleIntegration'
+  | 'integration';
 
 export function isIntegrationActive(integration: OrganizationIntegration): boolean {
   return (
     integration.status === 'active' &&
     integration.organizationIntegrationStatus === 'active'
   );
+}
+
+/**
+ * Returns true when the integration can receive Issue Alert actions.
+ * MS Teams "tenant" installations route notifications differently and
+ * cannot be used as an issue-alert destination.
+ */
+export function isEligibleForIssueAlerts(integration: OrganizationIntegration): boolean {
+  if (integration.provider.key !== 'msteams') {
+    return true;
+  }
+  return integration.configData?.installationType !== 'tenant';
 }
 
 /**
@@ -34,7 +50,8 @@ function resolveSavedIntegration(
   if (
     candidate.id !== messagingSetup.integrationId ||
     candidate.provider.key !== messagingSetup.providerKey ||
-    !isIntegrationActive(candidate)
+    !isIntegrationActive(candidate) ||
+    !isEligibleForIssueAlerts(candidate)
   ) {
     return undefined;
   }
@@ -98,6 +115,8 @@ export function useScmMessagingSetupValidation({
   const fetchedIntegration = isMissingIntegration ? undefined : integrationQuery.data;
   const hasInactiveIntegration =
     fetchedIntegration !== undefined && !isIntegrationActive(fetchedIntegration);
+  const hasIneligibleIntegration =
+    fetchedIntegration !== undefined && !isEligibleForIssueAlerts(fetchedIntegration);
   const integration = resolveSavedIntegration(fetchedIntegration, messagingSetup);
 
   // A 404 settles the query as conclusively as a successful fetch does; any
@@ -143,7 +162,13 @@ export function useScmMessagingSetupValidation({
     }
 
     if (!integration) {
-      setStaleReason(hasInactiveIntegration ? 'inactiveIntegration' : 'integration');
+      setStaleReason(
+        hasInactiveIntegration
+          ? 'inactiveIntegration'
+          : hasIneligibleIntegration
+            ? 'ineligibleIntegration'
+            : 'integration'
+      );
       onMessagingSetupChange({mode: 'unconfigured'});
       return;
     }
@@ -166,6 +191,7 @@ export function useScmMessagingSetupValidation({
   }, [
     channelValidateQuery.data,
     hasInactiveIntegration,
+    hasIneligibleIntegration,
     integration,
     isChannelSettled,
     isIntegrationSettled,

--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -567,7 +567,6 @@ describe('Onboarding', () => {
       providerKey: 'slack',
       integrationId: '15',
       channelId: 'C123',
-      actionTarget: '#alerts',
       channelName: '#alerts',
     } as const satisfies ScmMessagingSetup;
 

--- a/static/app/views/onboarding/scmMessaging.spec.tsx
+++ b/static/app/views/onboarding/scmMessaging.spec.tsx
@@ -428,4 +428,37 @@ describe('ScmMessaging', () => {
     expect(onMessagingSetupChange).toHaveBeenCalledWith({mode: 'skipped'});
     expect(onComplete).toHaveBeenCalledTimes(1);
   });
+
+  it('clears an ineligible destination with an explanation', async () => {
+    // A tenant-type MS Teams integration is active but cannot receive issue alerts.
+    const msteamsSetup: ScmMessagingSetup = {
+      mode: 'selected',
+      providerKey: 'msteams',
+      integrationId: '15',
+      channelId: '19:abc@thread.tacv2',
+      channelName: 'General',
+    };
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/15/',
+      body: OrganizationIntegrationsFixture({
+        id: '15',
+        provider: {key: 'msteams'} as any,
+        status: 'active',
+        organizationIntegrationStatus: 'active',
+        configData: {installationType: 'tenant'},
+      }),
+    });
+    const onMessagingSetupChange = jest.fn();
+
+    renderMessaging(onMessagingSetupChange, msteamsSetup);
+
+    expect(
+      await screen.findByText(
+        'The saved workspace can no longer receive issue alerts. Choose a destination again.'
+      )
+    ).toBeInTheDocument();
+    expect(onMessagingSetupChange).toHaveBeenCalledWith({mode: 'unconfigured'});
+    expect(screen.queryByText('Destination selected')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Continue'})).toBeDisabled();
+  });
 });

--- a/static/app/views/onboarding/scmMessaging.spec.tsx
+++ b/static/app/views/onboarding/scmMessaging.spec.tsx
@@ -25,15 +25,11 @@ const selectedPlatform = {
   category: 'browser',
 } as const;
 
-// Slack: channelId = real Slack channel ID, actionTarget = display name
-// (Slack alert rules address by name), channelName = display name (also
-// the channel-validate param for Slack).
 const selectedMessagingSetup: ScmMessagingSetup = {
   mode: 'selected',
   providerKey: 'slack',
   integrationId: '15',
   channelId: 'C123',
-  actionTarget: '#alerts',
   channelName: '#alerts',
 };
 
@@ -197,7 +193,6 @@ describe('ScmMessaging', () => {
       providerKey: 'discord',
       integrationId: '15',
       channelId: '1234567890',
-      actionTarget: '1234567890',
       channelName: '#dev-alerts',
     };
     MockApiClient.addMockResponse({

--- a/static/app/views/onboarding/scmMessaging.tsx
+++ b/static/app/views/onboarding/scmMessaging.tsx
@@ -86,6 +86,13 @@ export function ScmMessaging({
             {t('The saved integration is no longer active. Choose a destination again.')}
           </Alert>
         )}
+        {validation.staleReason === 'ineligibleIntegration' && (
+          <Alert variant="warning" showIcon>
+            {t(
+              'The saved workspace can no longer receive issue alerts. Choose a destination again.'
+            )}
+          </Alert>
+        )}
         {validation.staleReason === 'channel' && (
           <Alert variant="warning" showIcon>
             {t("We couldn't verify the saved channel. Choose a destination again.")}

--- a/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
@@ -31,11 +31,40 @@ import {
 import type {RequestDataFragment} from 'sentry/views/projectInstall/issueAlertOptions';
 import {MessagingIntegrationAlertRule} from 'sentry/views/projectInstall/messagingIntegrationAlertRule';
 
+type ChannelIdentityField = 'channelId' | 'channelName';
+
+interface MessagingProviderDetail {
+  action: IssueAlertActionType;
+  channelSelectedBy: ChannelIdentityField;
+  channelTargetedBy: ChannelIdentityField;
+  channelValidatedBy: ChannelIdentityField;
+  makeSentence: (args: any) => ReactNode;
+  name: string;
+  placeholder: string;
+}
+
+/**
+ * Maps a stored destination field onto its counterpart in the raw `/channels/`
+ * response, so a stored value can be matched back to a channel.
+ */
+export const RAW_CHANNEL_FIELD = {
+  channelName: 'display',
+  channelId: 'id',
+} as const satisfies Record<ChannelIdentityField, 'display' | 'id'>;
+
+/**
+ * Providers disagree on what identifies a channel. MS Teams is the only row
+ * that is not uniform: it validates by name but is addressed by id, because
+ * Sentry built a name-to-id resolver for it while all three send by id.
+ */
 export const providerDetails = {
   slack: {
     name: t('Slack'),
     action: IssueAlertActionType.SLACK,
     placeholder: t('channel, e.g. #critical'),
+    channelSelectedBy: 'channelName',
+    channelValidatedBy: 'channelName',
+    channelTargetedBy: 'channelName',
     makeSentence: ({providerName, integrationName, target}: any) =>
       tct(
         'Send [providerName] notification to the [integrationName] workspace to [target]',
@@ -50,6 +79,9 @@ export const providerDetails = {
     name: t('Discord'),
     action: IssueAlertActionType.DISCORD,
     placeholder: t('channel ID or URL'),
+    channelSelectedBy: 'channelId',
+    channelValidatedBy: 'channelId',
+    channelTargetedBy: 'channelId',
     makeSentence: ({providerName, integrationName, target}: any) =>
       tct(
         'Send [providerName] notification to the [integrationName] server in the channel [target]',
@@ -64,6 +96,9 @@ export const providerDetails = {
     name: t('MS Teams'),
     action: IssueAlertActionType.MS_TEAMS,
     placeholder: t('channel ID'),
+    channelSelectedBy: 'channelId',
+    channelValidatedBy: 'channelName',
+    channelTargetedBy: 'channelId',
     makeSentence: ({providerName, integrationName, target}: any) =>
       tct('Send [providerName] notification to the [integrationName] team to [target]', {
         providerName,
@@ -71,7 +106,20 @@ export const providerDetails = {
         target,
       }),
   },
-};
+} satisfies Record<string, MessagingProviderDetail>;
+
+type MessagingProviderKey = keyof typeof providerDetails;
+
+/**
+ * Defaults to `channelId` for an unrecognized provider, preserving the prior
+ * inline conditional that singled out Slack and treated everything else as
+ * id-keyed.
+ */
+export function getChannelSelectedBy(provider: string | undefined): ChannelIdentityField {
+  return (
+    providerDetails[provider as MessagingProviderKey]?.channelSelectedBy ?? 'channelId'
+  );
+}
 
 export const enum MultipleCheckboxOptions {
   EMAIL = 'email',

--- a/static/app/views/projectInstall/messagingIntegrationAlertRule.tsx
+++ b/static/app/views/projectInstall/messagingIntegrationAlertRule.tsx
@@ -2,10 +2,11 @@ import {useEffect, useMemo} from 'react';
 import styled from '@emotion/styled';
 import {skipToken, useQuery, useQueryClient} from '@tanstack/react-query';
 
-import {Select, SelectOption} from '@sentry/scraps/select';
+import {Select, SelectOption, type SelectValue} from '@sentry/scraps/select';
 
 import {FormField} from 'sentry/components/forms/formField';
 import {t} from 'sentry/locale';
+import type {OrganizationIntegration} from 'sentry/types/integrations';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -156,7 +157,7 @@ export function useMessagingIntegrationAlertRule(
     channelError,
     providerDisabled: Object.keys(providersToIntegrations).length === 1,
     integrationDisabled: integrationOptions.length === 1,
-    onProviderChange: (option: any) => {
+    onProviderChange: (option: SelectValue<string>) => {
       setProvider(option.value);
       setIntegration(providersToIntegrations[option.value]![0]);
       setChannel(undefined);
@@ -169,7 +170,7 @@ export function useMessagingIntegrationAlertRule(
         });
       }
     },
-    onIntegrationChange: (option: any) => {
+    onIntegrationChange: (option: SelectValue<OrganizationIntegration>) => {
       setIntegration(option.value);
       setChannel(undefined);
       clearChannelValidation();

--- a/static/app/views/projectInstall/messagingIntegrationAlertRule.tsx
+++ b/static/app/views/projectInstall/messagingIntegrationAlertRule.tsx
@@ -10,9 +10,10 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {
+  getChannelSelectedBy,
+  providerDetails,
   type IntegrationChannel,
   type IssueAlertNotificationProps,
-  providerDetails,
 } from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 import {validateChannelQueryOptions} from 'sentry/views/projectInstall/useValidateChannel';
 
@@ -113,15 +114,16 @@ export function useMessagingIntegrationAlertRule(
     [providersToIntegrations, provider]
   );
 
-  const channelOptions = useMemo(
-    () =>
-      channels?.results.map(ch =>
-        provider === 'slack'
-          ? {label: ch.display, value: ch.display}
-          : {label: `${ch.display} (${ch.id})`, value: ch.id}
-      ),
-    [channels, provider]
-  );
+  const channelOptions = useMemo(() => {
+    // Id-keyed providers show the id alongside the name, since the name alone
+    // cannot tell two same-named channels apart.
+    const keyedByName = getChannelSelectedBy(provider) === 'channelName';
+    return channels?.results.map(ch =>
+      keyedByName
+        ? {label: ch.display, value: ch.display}
+        : {label: `${ch.display} (${ch.id})`, value: ch.id}
+    );
+  }, [channels, provider]);
 
   useEffect(() => {
     // A restored channel (e.g. from persisted/default actions) only has a raw


### PR DESCRIPTION
## Problem

Editing a saved Discord or MS Teams destination and re-saving without changing anything silently corrupted the stored `channelId` and `actionTarget`, rewriting them from the backend id to the display name (e.g. `1234567890` → `#general`). On next load, revalidation sent that name to `channel-validate/` — which needs a digit string or Discord URL — so it returned `{valid: false}`, the user saw "We couldn't verify the saved channel," and Continue went disabled. Root cause: the edit dropdown was seeded from `channelName` for every provider, but Discord and MS Teams option lists are keyed by `channelId`, so the seed matched no option and `handleSave` re-derived every identifier from the unresolved value. More broadly, channel identity was decided by one-off `=== 'slack'` / `=== 'discord'` ternaries scattered across five sites in three files, so each provider's real rules were hard to see and easy to get subtly wrong.

## Change

Consolidates channel identity into the `providerDetails` table as three explicit axes — `channelSelectedBy` (what the dropdown value is keyed on), `channelValidatedBy` (the field sent to `channel-validate/`), and `channelTargetedBy` (the field written into the alert-rule action) — so each provider's behavior is declared in one place, with MS Teams captured as the one non-uniform case (selected/targeted by id, validated by name). The picker now seeds the edit dropdown by `existingSetup[channelSelectedBy]`, matches the selection back to a raw channel via a new `RAW_CHANNEL_FIELD` map, and derives `actionTarget` from `channelTargetedBy`, fixing the corruption. The revalidation hook and the shared alert-rule hook read the same table (`channelValidatedBy` / `getChannelSelectedBy`) instead of inline conditionals. `providerDetails` is closed with `satisfies Record<string, MessagingProviderDetail>` to keep the field types narrowed to literals. Adds a `scmMessagingChannelPicker` spec covering Slack/Discord staging, no-op edits, Discord manual URL entry, and the disabled state, with the Discord no-op edit as the regression test (fails before the fix, passes after).