### PR TITLE
feat(pr-metrics): Link a delegated agent's PR on the match that attributes it

### DIFF
--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -1405,10 +1405,13 @@ def _link_matched_delegated_agent_pr(
 ) -> None:
     """Link a matched PR to the run that produced it, on the same 200 that attributes it.
 
-    A coding agent's PR is normally linked when the agent reports it, but an agent that
-    finished before its PR existed reported no PR, and the link is only ever written on a
-    status transition. This webhook is the next time anyone sees that PR, and Seer has
-    just told us which run it came from -- so it is the last chance to link it.
+    A coding agent's PR is linked only from an observation of that agent that carries the
+    PR url - a Cursor webhook, or a Claude Code / Copilot poll, and those polls run only
+    while a user is loading the issue's autofix state. So an agent that goes terminal
+    before its PR is visible reports no PR, and one that finishes with nobody watching is
+    never observed at all; neither is ever looked at again. This webhook is the next time
+    anyone sees that PR, and Seer has just told us which run it came from -- so it is the
+    last chance to link it.
 
     Attribution and the run link answer the same question and are trusted on the same
     signal, so this fires wherever attribution does. Best-effort: a failure here must not

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -107,6 +107,8 @@ from sentry.seer.autofix.utils import (
     make_match_coding_agent_pr_request,
 )
 from sentry.seer.models import SeerRepoDefinition
+from sentry.seer.models.run import SeerRunCodingAgentHandoff
+from sentry.seer.pull_requests import link_resolved_pull_request_to_seer_run
 from sentry.seer.seer_setup import has_seer_access
 from sentry.utils import metrics
 
@@ -1391,7 +1393,65 @@ def _send_seer_delegated_agent_match(
             group_ids=request_body.group_ids,
         ).dict(),
     )
+    _link_matched_delegated_agent_pr(match, pr, provider_hint)
     _record_delegated_candidate(provider_hint, "sync_matched")
+
+
+def _link_matched_delegated_agent_pr(
+    match: DelegatedAgentMatch,
+    pr: PullRequest,
+    provider_hint: str,
+) -> None:
+    """Link a matched PR to the run that produced it, on the same 200 that attributes it.
+
+    A coding agent's PR is normally linked when the agent reports it, but an agent that
+    finished before its PR existed reported no PR, and the link is only ever written on a
+    status transition. This webhook is the next time anyone sees that PR, and Seer has
+    just told us which run it came from -- so it is the last chance to link it.
+
+    Attribution and the run link answer the same question and are trusted on the same
+    signal, so this fires wherever attribution does. Best-effort: a failure here must not
+    cost the attribution already recorded above.
+    """
+    log_extra = {
+        "pull_request_id": pr.id,
+        "organization_id": pr.organization_id,
+        "provider_hint": provider_hint,
+        "agent_id": match.agent_id,
+        "run_id": match.run_id,
+        "match_path": match.match_path,
+    }
+    try:
+        handoff = SeerRunCodingAgentHandoff.objects.select_related("seer_run").get(
+            agent_id=match.agent_id, seer_run__organization_id=pr.organization_id
+        )
+    except SeerRunCodingAgentHandoff.DoesNotExist:
+        # Seer knows agents whose handoff row we never wrote (a failed create, or a launch
+        # that predates the row). Nothing to link to, and not an error.
+        logger.info("pr_metrics.delegated_agent.handoff_not_found", extra=log_extra)
+        metrics.incr(
+            "pr_metrics.delegated_agent.link",
+            tags={"provider": provider_hint, "outcome": "no_handoff"},
+        )
+        return
+    except Exception:
+        logger.exception("pr_metrics.delegated_agent.handoff_lookup_failed", extra=log_extra)
+        return
+
+    linked = link_resolved_pull_request_to_seer_run(
+        seer_run=handoff.seer_run,
+        pull_request=pr,
+        log_context=log_extra,
+        coding_agent_handoff=handoff,
+    )
+    metrics.incr(
+        "pr_metrics.delegated_agent.link",
+        tags={
+            "provider": provider_hint,
+            "outcome": "linked" if linked is not None else "link_failed",
+            "match_path": match.match_path,
+        },
+    )
 
 
 def _write_mcp_attribution(pr: PullRequest) -> None:

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -106,6 +106,7 @@ from sentry.seer.autofix.utils import (
     MatchDelegatedAgentPrRequest,
     make_match_coding_agent_pr_request,
 )
+from sentry.seer.milestones import record_has_pull_request
 from sentry.seer.models import SeerRepoDefinition
 from sentry.seer.models.run import SeerRunCodingAgentHandoff
 from sentry.seer.pull_requests import link_resolved_pull_request_to_seer_run
@@ -1421,6 +1422,17 @@ def _link_matched_delegated_agent_pr(
         "run_id": match.run_id,
         "match_path": match.match_path,
     }
+
+    def record_outcome(outcome: str) -> None:
+        metrics.incr(
+            "pr_metrics.delegated_agent.link",
+            tags={
+                "provider": provider_hint,
+                "outcome": outcome,
+                "match_path": match.match_path,
+            },
+        )
+
     try:
         handoff = SeerRunCodingAgentHandoff.objects.select_related("seer_run").get(
             agent_id=match.agent_id, seer_run__organization_id=pr.organization_id
@@ -1429,13 +1441,11 @@ def _link_matched_delegated_agent_pr(
         # Seer knows agents whose handoff row we never wrote (a failed create, or a launch
         # that predates the row). Nothing to link to, and not an error.
         logger.info("pr_metrics.delegated_agent.handoff_not_found", extra=log_extra)
-        metrics.incr(
-            "pr_metrics.delegated_agent.link",
-            tags={"provider": provider_hint, "outcome": "no_handoff"},
-        )
+        record_outcome("no_handoff")
         return
     except Exception:
         logger.exception("pr_metrics.delegated_agent.handoff_lookup_failed", extra=log_extra)
+        record_outcome("lookup_failed")
         return
 
     linked = link_resolved_pull_request_to_seer_run(
@@ -1444,14 +1454,16 @@ def _link_matched_delegated_agent_pr(
         log_context=log_extra,
         coding_agent_handoff=handoff,
     )
-    metrics.incr(
-        "pr_metrics.delegated_agent.link",
-        tags={
-            "provider": provider_hint,
-            "outcome": "linked" if linked is not None else "link_failed",
-            "match_path": match.match_path,
-        },
-    )
+    if linked is not None:
+        try:
+            # The run's furthest milestone drives which stage it appears under. Nothing
+            # else records this one for a PR that arrives after reconcile_milestones --
+            # the status sync records it for its own PRs, and this path is later still.
+            record_has_pull_request(handoff.seer_run)
+        except Exception:
+            logger.exception("pr_metrics.delegated_agent.milestone_failed", extra=log_extra)
+
+    record_outcome("linked" if linked is not None else "link_failed")
 
 
 def _write_mcp_attribution(pr: PullRequest) -> None:

--- a/src/sentry/seer/pull_requests.py
+++ b/src/sentry/seer/pull_requests.py
@@ -122,36 +122,57 @@ def link_pull_request_to_seer_run(
         )
         return None
 
+    return link_resolved_pull_request_to_seer_run(
+        seer_run=seer_run,
+        pull_request=resolved.pull_request,
+        log_context={**log_context, "resolved_by": resolved.resolved_by},
+        coding_agent_handoff=coding_agent_handoff,
+    )
+
+
+def link_resolved_pull_request_to_seer_run(
+    *,
+    seer_run: SeerRun,
+    pull_request: PullRequest,
+    log_context: Mapping[str, Any],
+    coding_agent_handoff: SeerRunCodingAgentHandoff | None = None,
+) -> PullRequest | None:
+    """Idempotently link a ``PullRequest`` we already hold to ``seer_run``.
+
+    For callers that reached the row some other way than a reported repo reference --
+    an SCM webhook holds the PR itself, so re-deriving it from a name would be both
+    wasteful and less reliable. Never raises; returns None on failure. Checks the
+    killswitch itself so every write path respects it.
+    """
+    if options.get("seer.pull-request-linking.killswitch.enabled"):
+        return None
+
     try:
         _, created = SeerRunPullRequest.objects.get_or_create(
-            pull_request=resolved.pull_request,
+            pull_request=pull_request,
             defaults={"seer_run": seer_run, "coding_agent_handoff": coding_agent_handoff},
         )
     except Exception:
         logger.exception(
             "seer.pr_link.write_failed",
-            extra={**log_context, "pull_request_id": resolved.pull_request.id},
+            extra={**log_context, "pull_request_id": pull_request.id},
         )
         return None
 
     if created:
         logger.info(
             "seer.pr_link.created",
-            extra={
-                **log_context,
-                "pull_request_id": resolved.pull_request.id,
-                "resolved_by": resolved.resolved_by,
-            },
+            extra={**log_context, "pull_request_id": pull_request.id},
         )
         try:
             reconcile_pull_requests_merged_milestone(seer_run)
         except Exception:
             logger.exception(
                 "seer.pr_link.milestone_failed",
-                extra={**log_context, "pull_request_id": resolved.pull_request.id},
+                extra={**log_context, "pull_request_id": pull_request.id},
             )
 
-    return resolved.pull_request
+    return pull_request
 
 
 def record_seer_created_pull_requests(

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -37,9 +37,11 @@ from sentry.pr_metrics.webhooks import (
     handle_review_comment,
     handle_review_thread,
 )
+from sentry.seer.models.run import SeerRunPullRequest, SeerRunType
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.analytics import get_event_count
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import cell_silo_test
 
 MODULE = "sentry.pr_metrics.webhooks"
@@ -2546,6 +2548,89 @@ class HandleDelegatedAgentDetectionTest(TestCase):
             "provider": "claude_code",
             "outcome": "sync_matched",
         }
+
+    def _match_body(self, agent_id: str = "agent-1", match_path: str = "branch") -> dict[str, Any]:
+        return {
+            "run_id": 123,
+            "agent_id": agent_id,
+            "signal_type": PullRequestAttributionSignalType.SEER_DELEGATED_CLAUDE_CODE.value,
+            "match_path": match_path,
+        }
+
+    def _create_handoff(self, agent_id: str = "agent-1", organization: Any = None) -> Any:
+        organization = organization or self.organization
+        seer_run = self.create_seer_run(organization, type=SeerRunType.FEATURE_RUN)
+        return self.create_seer_run_coding_agent_handoff(
+            seer_run, agent_id=agent_id, provider="claude_code_agent"
+        )
+
+    def test_sync_match_links_pull_request_to_its_run(self) -> None:
+        """The agent finished before its PR existed, so nothing linked the PR when it
+        opened. Seer has just named the run it came from -- this is the last chance."""
+        handoff = self._create_handoff()
+
+        with self._mock_org_check(), self._mock_seer(status=200, body=self._match_body()):
+            self._call(head_ref="claude/fix")
+
+        link = SeerRunPullRequest.objects.get(pull_request=self.pr)
+        assert link.seer_run_id == handoff.seer_run_id
+        assert link.coding_agent_handoff_id == handoff.id
+
+    def test_sync_match_links_on_the_looser_group_id_match_path(self) -> None:
+        """Linking fires wherever attribution does; Seer already declined ambiguous
+        fan-out before returning a 200."""
+        handoff = self._create_handoff()
+
+        with (
+            self._mock_org_check(),
+            self._mock_seer(status=200, body=self._match_body(match_path="group_id")),
+        ):
+            self._call(head_ref="claude/fix")
+
+        assert (
+            SeerRunPullRequest.objects.get(pull_request=self.pr).seer_run_id == handoff.seer_run_id
+        )
+
+    def test_sync_match_keeps_attribution_when_no_handoff_row_exists(self) -> None:
+        """Seer knows agents whose handoff row we never wrote. That must not cost the
+        attribution recorded alongside the link."""
+        with self._mock_org_check(), self._mock_seer(status=200, body=self._match_body()):
+            self._call(head_ref="claude/fix")
+
+        assert not SeerRunPullRequest.objects.filter(pull_request=self.pr).exists()
+        assert PullRequestAttribution.objects.filter(
+            pull_request=self.pr,
+            signal_type=PullRequestAttributionSignalType.SEER_DELEGATED_CLAUDE_CODE,
+        ).exists()
+
+    def test_sync_match_does_not_link_a_handoff_from_another_org(self) -> None:
+        """agent_id is unique globally, so an unscoped lookup would cross orgs."""
+        other_org = self.create_organization()
+        self._create_handoff(organization=other_org)
+
+        with self._mock_org_check(), self._mock_seer(status=200, body=self._match_body()):
+            self._call(head_ref="claude/fix")
+
+        assert not SeerRunPullRequest.objects.filter(pull_request=self.pr).exists()
+
+    def test_sync_match_link_is_idempotent_across_open_and_close(self) -> None:
+        """The funnel re-runs on close; the second pass must not double-write."""
+        self._create_handoff()
+
+        with self._mock_org_check(), self._mock_seer(status=200, body=self._match_body()):
+            self._call(action="opened", head_ref="claude/fix")
+            self._call(action="closed", head_ref="claude/fix")
+
+        assert SeerRunPullRequest.objects.filter(pull_request=self.pr).count() == 1
+
+    @override_options({"seer.pull-request-linking.killswitch.enabled": True})
+    def test_sync_match_respects_the_linking_killswitch(self) -> None:
+        self._create_handoff()
+
+        with self._mock_org_check(), self._mock_seer(status=200, body=self._match_body()):
+            self._call(head_ref="claude/fix")
+
+        assert not SeerRunPullRequest.objects.filter(pull_request=self.pr).exists()
 
     def test_sync_match_bad_body_records_error_outcome(self) -> None:
         with (

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import orjson
 from django.conf import settings
 from django.core.cache import cache
+from django.db import OperationalError
 
 from sentry.analytics.events.pr_metrics_events import PrCloseMetricsEvent
 from sentry.integrations.github.webhook import PullRequestEventWebhook
@@ -37,7 +38,13 @@ from sentry.pr_metrics.webhooks import (
     handle_review_comment,
     handle_review_thread,
 )
-from sentry.seer.models.run import SeerRunPullRequest, SeerRunType
+from sentry.seer.models.run import (
+    SeerRunCodingAgentHandoff,
+    SeerRunMilestone,
+    SeerRunMilestoneType,
+    SeerRunPullRequest,
+    SeerRunType,
+)
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.analytics import get_event_count
@@ -2549,6 +2556,16 @@ class HandleDelegatedAgentDetectionTest(TestCase):
             "outcome": "sync_matched",
         }
 
+    def _link_outcome(self, mock_incr: MagicMock) -> dict[str, str] | None:
+        """The tags of the single ``delegated_agent.link`` emission."""
+        calls = [
+            c
+            for c in mock_incr.call_args_list
+            if c.args and c.args[0] == "pr_metrics.delegated_agent.link"
+        ]
+        assert len(calls) == 1
+        return calls[0].kwargs.get("tags")
+
     def _match_body(self, agent_id: str = "agent-1", match_path: str = "branch") -> dict[str, Any]:
         return {
             "run_id": 123,
@@ -2590,6 +2607,56 @@ class HandleDelegatedAgentDetectionTest(TestCase):
         assert (
             SeerRunPullRequest.objects.get(pull_request=self.pr).seer_run_id == handoff.seer_run_id
         )
+
+    def test_sync_match_advances_the_run_to_the_pull_request_milestone(self) -> None:
+        """A run is grouped under its furthest milestone. Linking without recording this
+        one leaves the run showing below the PR stage despite having a linked PR."""
+        handoff = self._create_handoff()
+
+        with self._mock_org_check(), self._mock_seer(status=200, body=self._match_body()):
+            self._call(head_ref="claude/fix")
+
+        assert SeerRunMilestone.objects.filter(
+            seer_run_id=handoff.seer_run_id, milestone=SeerRunMilestoneType.HAS_PULL_REQUEST
+        ).exists()
+
+    def test_sync_match_link_outcome_metric_carries_the_match_path(self) -> None:
+        self._create_handoff()
+
+        with (
+            self._mock_org_check(),
+            self._mock_seer(status=200, body=self._match_body(match_path="group_id")),
+            patch(f"{MODULE}.metrics.incr") as mock_incr,
+        ):
+            self._call(head_ref="claude/fix")
+
+        assert self._link_outcome(mock_incr) == {
+            "provider": "claude_code",
+            "outcome": "linked",
+            "match_path": "group_id",
+        }
+
+    def test_sync_match_reports_a_failed_handoff_lookup(self) -> None:
+        """A lookup that fails for any other reason than a missing row must not be
+        invisible -- it is an operational fault, not an expected miss."""
+        broken = MagicMock()
+        broken.objects.select_related.return_value.get.side_effect = OperationalError("db gone")
+        broken.DoesNotExist = SeerRunCodingAgentHandoff.DoesNotExist
+
+        with (
+            self._mock_org_check(),
+            self._mock_seer(status=200, body=self._match_body()),
+            patch(f"{MODULE}.SeerRunCodingAgentHandoff", broken),
+            patch(f"{MODULE}.metrics.incr") as mock_incr,
+        ):
+            self._call(head_ref="claude/fix")
+
+        assert self._link_outcome(mock_incr) == {
+            "provider": "claude_code",
+            "outcome": "lookup_failed",
+            "match_path": "branch",
+        }
+        assert PullRequestAttribution.objects.filter(pull_request=self.pr).exists()
 
     def test_sync_match_keeps_attribution_when_no_handoff_row_exists(self) -> None:
         """Seer knows agents whose handoff row we never wrote. That must not cost the

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -2582,7 +2582,7 @@ class HandleDelegatedAgentDetectionTest(TestCase):
         )
 
     def test_sync_match_links_pull_request_to_its_run(self) -> None:
-        """The agent finished before its PR existed, so nothing linked the PR when it
+        """No observation of the agent ever carried this PR, so nothing linked it when it
         opened. Seer has just named the run it came from -- this is the last chance."""
         handoff = self._create_handoff()
 


### PR DESCRIPTION
A coding agent's pull request is linked to its run when the agent reports it. An agent that finishes before its PR exists reports no PR, and the link is only ever written on a status transition — so nothing links the PR that opens afterwards. **15% of completed handoffs over 30d have no linked PR.**

Seer already answers this. The opened-PR webhook sends it the head branch, its matcher prefers the branch pass over the looser group-id pass, and it declines ambiguous fan-out before replying. On a 200 it hands back the run and the agent.

Sentry took the attribution out of that response and dropped the rest on the floor:

| From one 200 | Before | After |
|---|---|---|
| `PullRequestAttribution` | written | written |
| `SeerRunPullRequest` | — | written |

The PR came out attributed but unlinked — two halves of the same fact, available from the same signal, and `SeerRunPullRequest` has exactly one creation site in the codebase, which this path never reached.

So link it there too, keyed on the `agent_id` the match returns. The lookup is org-scoped: `agent_id` is globally unique, so an unscoped `get` would cross orgs — there's a test for that.

**Linking fires wherever attribution does**, including the `group_id` match path. Seer has already refused to guess by then, and treating one signal as good enough to attribute but not to link would be arbitrary. `match_path` is on the emitted metric so the split is visible.

`link_resolved_pull_request_to_seer_run` splits the write half of `link_pull_request_to_seer_run` out for callers that already hold the row — a webhook has the `PullRequest` itself, so re-deriving it from a repo name would be both wasteful and less reliable. It checks the same killswitch, so the new write path respects it.

**This does not fix the whole 15%.** The funnel drops PRs before the match on a missing provider hint, on `no_group_ids`, and on the `pr-metrics-attribution` flag. This closes the subset that reaches a 200.

Refs CW-1726.

