### PR TITLE
chore(hybridcloud): remove dead member teams replication option

### DIFF
--- a/src/sentry/hybridcloud/options.py
+++ b/src/sentry/hybridcloud/options.py
@@ -37,13 +37,6 @@ register(
 )
 
 register(
-    "outbox_replication.sentry_organizationmember_teams.replication_version",
-    type=Int,
-    default=0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
-register(
     "outbox_replication.sentry_apikey.replication_version",
     type=Int,
     default=0,


### PR DESCRIPTION
[INFRENG-469](https://linear.app/getsentry/issue/INFRENG-469/unregister-dead-organizationmember-teams-replication-option)

OrganizationMemberTeam no longer produces outboxes, so backfill_outboxes never resolves a replication version for this table and nothing reads the option.
