### PR TITLE
feat(inbox): Adjust inbox preview PR section formatting

### DIFF
--- a/static/app/views/issueDetails/issuePreview/issuePreview.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreview.tsx
@@ -10,7 +10,10 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 import {ErrorBoundary} from 'sentry/components/errorBoundary';
 import {useExplorerAutofix} from 'sentry/components/events/autofix/useExplorerAutofix';
 import {EventMessage} from 'sentry/components/events/eventMessage';
-import {LinkedPullRequests} from 'sentry/components/group/externalIssuesList/linkedPullRequests';
+import {
+  LinkedPullRequests,
+  useLinkedPullRequests,
+} from 'sentry/components/group/externalIssuesList/linkedPullRequests';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {Placeholder} from 'sentry/components/placeholder';
@@ -38,6 +41,7 @@ import {IssueIdBreadcrumb} from 'sentry/views/issueDetails/header/issueIdBreadcr
 import {useAiConfig} from 'sentry/views/issueDetails/hooks/useAiConfig';
 import {IssuePreviewActions} from 'sentry/views/issueDetails/issuePreview/issuePreviewActions';
 import {IssuePreviewAutofixSummary} from 'sentry/views/issueDetails/issuePreview/issuePreviewAutofixSummary';
+import {IssuePreviewSection} from 'sentry/views/issueDetails/issuePreview/issuePreviewSection';
 import {useGroup} from 'sentry/views/issueDetails/useGroup';
 import {useMarkGroupSeen} from 'sentry/views/issueDetails/useMarkGroupSeen';
 import {
@@ -130,6 +134,7 @@ function IssuePreviewContent() {
   const autofix = useExplorerAutofix(group, {
     enabled: hasAutofix,
   });
+  const linkedPullRequests = useLinkedPullRequests({group});
   const {title: primaryTitle} = getTitle(group);
   const secondaryTitle = getMessage(group);
   const disableActions = [
@@ -230,12 +235,19 @@ function IssuePreviewContent() {
           />
         </Flex>
       </Flex>
-      {/* Autofix summary goes at the top, so to avoid pop-in we block everything until it's available */}
-      {hasAutofix && autofix.isLoading ? (
+      {/* Top sections load asynchronously, so block everything to avoid pop-in. */}
+      {(hasAutofix && autofix.isLoading) || linkedPullRequests.isPending ? (
         <LoadingIndicator />
       ) : (
         <Dividers>
-          <LinkedPullRequests group={group} showEmptyState={false} />
+          {linkedPullRequests.data?.pullRequests.length ? (
+            <IssuePreviewSection aria-label={t('Pull Requests')} defaultExpanded>
+              <IssuePreviewSection.Title>{t('Pull Requests')}</IssuePreviewSection.Title>
+              <IssuePreviewSection.Content>
+                <LinkedPullRequests group={group} showEmptyState={false} />
+              </IssuePreviewSection.Content>
+            </IssuePreviewSection>
+          ) : null}
           {hasAutofix ? (
             <IssuePreviewAutofixSummary
               key={group.id}

--- a/static/app/views/issueDetails/issuePreview/issuePreviewAutofixProposalSection.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewAutofixProposalSection.tsx
@@ -61,11 +61,11 @@ export function IssuePreviewAutofixProposalSection({
         </IssuePreviewSection.Title>
         <IssuePreviewSection.Summary>
           <RetryableAutofixSection.Prompt
-            placeholder={t('Give Seer additional context to improve this proposal.')}
+            placeholder={t('Give Seer additional context to improve these code changes.')}
             prompt={t('How can this code change be improved?')}
           />
           {section.status === 'processing' ? (
-            <WorkingIndicator>{t('Generating proposal...')}</WorkingIndicator>
+            <WorkingIndicator>{t('Generating code changes...')}</WorkingIndicator>
           ) : patchesByRepo.size > 0 ? (
             <Text>{proposalSummary}</Text>
           ) : (

--- a/static/app/views/issueDetails/issuePreview/issuePreviewAutofixProposalSection.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewAutofixProposalSection.tsx
@@ -45,7 +45,10 @@ export function IssuePreviewAutofixProposalSection({
 
   return (
     <RetryableAutofixSection autofix={autofix} section={section} step="code_changes">
-      <IssuePreviewSection aria-label={t('Proposal')} defaultExpanded={defaultExpanded}>
+      <IssuePreviewSection
+        aria-label={t('Code Changes')}
+        defaultExpanded={defaultExpanded}
+      >
         <IssuePreviewSection.Title
           trailingItems={
             <Fragment>
@@ -54,7 +57,7 @@ export function IssuePreviewAutofixProposalSection({
             </Fragment>
           }
         >
-          {t('Proposal')}
+          {t('Code Changes')}
         </IssuePreviewSection.Title>
         <IssuePreviewSection.Summary>
           <RetryableAutofixSection.Prompt

--- a/static/app/views/issueDetails/issuePreview/issuePreviewAutofixSummary.spec.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewAutofixSummary.spec.tsx
@@ -119,13 +119,13 @@ describe('IssuePreviewAutofixSummary', () => {
 
     expect(
       screen.getAllByRole('heading', {level: 3}).map(heading => heading.textContent)
-    ).toEqual(['Proposal', 'Implementation Plan', 'Root Cause']);
+    ).toEqual(['Code Changes', 'Implementation Plan', 'Root Cause']);
 
-    const proposal = screen.getByRole('region', {name: 'Proposal'});
+    const proposal = screen.getByRole('region', {name: 'Code Changes'});
     const plan = screen.getByRole('region', {name: 'Implementation Plan'});
     const rootCause = screen.getByRole('region', {name: 'Root Cause'});
 
-    expect(within(proposal).getByRole('button', {name: 'Proposal'})).toHaveAttribute(
+    expect(within(proposal).getByRole('button', {name: 'Code Changes'})).toHaveAttribute(
       'aria-expanded',
       'true'
     );
@@ -195,7 +195,7 @@ describe('IssuePreviewAutofixSummary', () => {
     expect(
       screen.queryByRole('region', {name: 'Implementation Plan'})
     ).not.toBeInTheDocument();
-    expect(screen.queryByRole('region', {name: 'Proposal'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('region', {name: 'Code Changes'})).not.toBeInTheDocument();
   });
 
   it('renders the section with a loading indicator while it is processing', () => {
@@ -226,7 +226,7 @@ describe('IssuePreviewAutofixSummary', () => {
     expect(
       screen.queryByRole('region', {name: 'Implementation Plan'})
     ).not.toBeInTheDocument();
-    expect(screen.queryByRole('region', {name: 'Proposal'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('region', {name: 'Code Changes'})).not.toBeInTheDocument();
   });
 
   it.each([
@@ -260,7 +260,7 @@ describe('IssuePreviewAutofixSummary', () => {
       />
     );
 
-    expect(screen.queryByRole('region', {name: 'Proposal'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('region', {name: 'Code Changes'})).not.toBeInTheDocument();
     expect(
       screen.queryByRole('region', {name: 'Implementation Plan'})
     ).not.toBeInTheDocument();


### PR DESCRIPTION
Closes ISWF-3279

- Place pull requests their own section 
- Rename "proposal" to match autofix "code changes"

<img width="996" height="794" alt="CleanShot 2026-08-12 at 13 09 55@2x" src="https://github.com/user-attachments/assets/aa8900e0-4207-4fcc-a753-f845092eca37" />
