### PR TITLE
feat(hybridcloud): Attribute drain dispatches to push trigger vs scheduler

### DIFF
--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -260,20 +260,14 @@ def _record_dispatch(
     claimed: int | None = None,
 ) -> None:
     """
-    Record that a drain task was enqueued, so push- and scheduler-dispatched work
-    are comparable on one chart rather than only through each path's own counters.
+    Record a drain enqueue so push- and scheduler-dispatched work stay comparable.
 
-    Two instruments, because the two questions have different answers. `dispatch`
-    counts enqueues and rides every path. `dispatch.claimed` carries the size of
-    the claim behind the enqueue, which is what makes webhook volume — not just
-    invocation count — attributable: a scheduler drain can claim up to
-    MAX_MAILBOX_DRAIN records while a push drain typically claims one or two, so
-    dispatch share and delivery share are not the same number.
+    `dispatch` counts enqueues; `dispatch.claimed` carries the claim behind each
+    one. A scheduler drain can claim up to MAX_MAILBOX_DRAIN records where a push
+    drain typically claims one or two, so the two shares are different numbers.
 
-    `claimed` is omitted only by the lease-mode push trigger, which claims nothing
-    at all (its dedupe is the lock the drain holds). It has no depth to report, so
-    it lands in the counter alone and `dispatch.claimed` stays free of a fabricated
-    value. That gap closes on its own once the claim rollout retires lease mode.
+    Lease-mode push triggers claim nothing, so they have no depth to report and
+    emit the counter alone rather than a fabricated size.
     """
     tags = {
         "dispatcher": dispatcher,

--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -257,7 +257,7 @@ def _record_dispatch(
     mode: str,
     drain: DispatchOutcome,
     mailbox_name: str,
-    claimed: int | None = None,
+    claimed: int = 0,
 ) -> None:
     """
     Record a drain enqueue so push- and scheduler-dispatched work stay comparable.
@@ -266,8 +266,13 @@ def _record_dispatch(
     one. A scheduler drain can claim up to MAX_MAILBOX_DRAIN records where a push
     drain typically claims one or two, so the two shares are different numbers.
 
-    Lease-mode push triggers claim nothing, so they have no depth to report and
-    emit the counter alone rather than a fabricated size.
+    Emitted unconditionally, including the zero a lease-mode push trigger claims:
+    a tag value with no samples yields no series at all rather than a line of
+    zeros, which blanks any formula comparing the two dispatchers. Zeros leave
+    `.sum` untouched, and `{mode:claim}` recovers a true claim depth from `.avg`.
+
+    `.sum` under-attributes push while lease mode is the majority — those drains
+    deliver webhooks no claim ever counted. It converges as the rollout ramps.
     """
     tags = {
         "dispatcher": dispatcher,
@@ -276,8 +281,7 @@ def _record_dispatch(
         "provider": _provider_from_mailbox(mailbox_name),
     }
     metrics.incr("hybridcloud.deliver_webhooks.dispatch", tags=tags)
-    if claimed is not None:
-        metrics.distribution("hybridcloud.deliver_webhooks.dispatch.claimed", claimed, tags=tags)
+    metrics.distribution("hybridcloud.deliver_webhooks.dispatch.claimed", claimed, tags=tags)
 
 
 def _claim_and_dispatch(

--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -244,7 +244,51 @@ class DispatchOutcome(enum.StrEnum):
     PARALLEL = "parallel"
 
 
-def _claim_and_dispatch(head_id: int, mailbox_name: str) -> DispatchOutcome:
+class Dispatcher(enum.StrEnum):
+    """Which dispatcher enqueued a drain; a metric tag."""
+
+    PUSH = "push"
+    SCHEDULER = "scheduler"
+
+
+def _record_dispatch(
+    *,
+    dispatcher: Dispatcher,
+    mode: str,
+    drain: DispatchOutcome,
+    mailbox_name: str,
+    claimed: int | None = None,
+) -> None:
+    """
+    Record that a drain task was enqueued, so push- and scheduler-dispatched work
+    are comparable on one chart rather than only through each path's own counters.
+
+    Two instruments, because the two questions have different answers. `dispatch`
+    counts enqueues and rides every path. `dispatch.claimed` carries the size of
+    the claim behind the enqueue, which is what makes webhook volume — not just
+    invocation count — attributable: a scheduler drain can claim up to
+    MAX_MAILBOX_DRAIN records while a push drain typically claims one or two, so
+    dispatch share and delivery share are not the same number.
+
+    `claimed` is omitted only by the lease-mode push trigger, which claims nothing
+    at all (its dedupe is the lock the drain holds). It has no depth to report, so
+    it lands in the counter alone and `dispatch.claimed` stays free of a fabricated
+    value. That gap closes on its own once the claim rollout retires lease mode.
+    """
+    tags = {
+        "dispatcher": dispatcher,
+        "mode": mode,
+        "drain": drain,
+        "provider": _provider_from_mailbox(mailbox_name),
+    }
+    metrics.incr("hybridcloud.deliver_webhooks.dispatch", tags=tags)
+    if claimed is not None:
+        metrics.distribution("hybridcloud.deliver_webhooks.dispatch.claimed", claimed, tags=tags)
+
+
+def _claim_and_dispatch(
+    head_id: int, mailbox_name: str, *, dispatcher: Dispatcher
+) -> DispatchOutcome:
     """
     Claim a batch for the mailbox and dispatch the drain matching its depth.
     Callers must hold the mailbox's drain lock so concurrent dispatchers cannot
@@ -259,15 +303,26 @@ def _claim_and_dispatch(head_id: int, mailbox_name: str) -> DispatchOutcome:
     bound a fast drain walks past its claim into unclaimed rows, at which point
     the mailbox head is due again and another dispatcher can start a second,
     overlapping drain — duplicating deliveries and breaking mailbox ordering.
+
+    `dispatcher` only tags the dispatch metrics; both callers claim identically.
     """
     claimed = _claim_mailbox_batch(head_id, mailbox_name, only_if_head_due=True)
     if not claimed:
         return DispatchOutcome.NOT_DUE
     if claimed >= PARALLEL_DRAIN_THRESHOLD:
         drain_mailbox_parallel.delay(head_id, claimed_count=claimed)
-        return DispatchOutcome.PARALLEL
-    drain_mailbox.delay(head_id, claimed_count=claimed)
-    return DispatchOutcome.SEQUENTIAL
+        outcome = DispatchOutcome.PARALLEL
+    else:
+        drain_mailbox.delay(head_id, claimed_count=claimed)
+        outcome = DispatchOutcome.SEQUENTIAL
+    _record_dispatch(
+        dispatcher=dispatcher,
+        mode="claim",
+        drain=outcome,
+        mailbox_name=mailbox_name,
+        claimed=claimed,
+    )
+    return outcome
 
 
 def _maybe_trigger_drain_claim(mailbox_name: str) -> None:
@@ -305,7 +360,7 @@ def _maybe_trigger_drain_claim(mailbox_name: str) -> None:
                 tags={**trigger_tags, "mode": "claim"},
             )
             return
-        outcome = _claim_and_dispatch(head[0], mailbox_name)
+        outcome = _claim_and_dispatch(head[0], mailbox_name, dispatcher=Dispatcher.PUSH)
         if outcome is DispatchOutcome.NOT_DUE:
             # The head moved between our read and the claim; whoever moved it has
             # the mailbox covered.
@@ -364,6 +419,12 @@ def _maybe_trigger_drain_lease(mailbox_name: str) -> None:
                 return
             head_id = head[0]
             drain_mailbox.delay(head_id, mailbox_name=mailbox_name)
+            _record_dispatch(
+                dispatcher=Dispatcher.PUSH,
+                mode="lease",
+                drain=DispatchOutcome.SEQUENTIAL,
+                mailbox_name=mailbox_name,
+            )
             metrics.incr(
                 "hybridcloud.deliver_webhooks.push_trigger.success",
                 tags={**trigger_tags, "mode": "lease", "drain": "sequential"},
@@ -472,8 +533,17 @@ def schedule_webhook_delivery() -> None:
             claimed = _claim_mailbox_batch(record["id"], mailbox_name)
             if claimed >= PARALLEL_DRAIN_THRESHOLD:
                 drain_mailbox_parallel.delay(record["id"])
+                drain = DispatchOutcome.PARALLEL
             else:
                 drain_mailbox.delay(record["id"])
+                drain = DispatchOutcome.SEQUENTIAL
+            _record_dispatch(
+                dispatcher=Dispatcher.SCHEDULER,
+                mode="lease",
+                drain=drain,
+                mailbox_name=mailbox_name,
+                claimed=claimed,
+            )
             continue
         try:
             if not cache.add(_drain_lock_key(mailbox_name), 1, timeout=DRAIN_LOCK_TTL):
@@ -485,7 +555,7 @@ def schedule_webhook_delivery() -> None:
             # proceed — just without serialization against push triggers.
             lock_acquired = False
         try:
-            _claim_and_dispatch(record["id"], mailbox_name)
+            _claim_and_dispatch(record["id"], mailbox_name, dispatcher=Dispatcher.SCHEDULER)
         finally:
             if lock_acquired:
                 _release_drain_lock(mailbox_name)

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -1548,9 +1548,8 @@ class ProviderMetricTagTest(TestCase):
 @control_silo_test
 class DispatchMetricTest(TestCase):
     """
-    Push- and scheduler-dispatched drains must land on one metric so their shares
-    are comparable. Every dispatch path is pinned here: a path that stops emitting
-    silently attributes its work to the other dispatcher.
+    One test per dispatch path: a path that stops emitting silently attributes its
+    work to the other dispatcher.
     """
 
     def dispatch_tags(self, mock_metrics: MagicMock) -> list[dict[str, str]]:
@@ -1603,9 +1602,7 @@ class DispatchMetricTest(TestCase):
     def test_push_lease_dispatch_counted_without_a_claim_size(
         self, mock_drain: MagicMock, mock_metrics: MagicMock
     ) -> None:
-        # Lease mode claims nothing, so this path has no depth to report. It must
-        # still be counted, or push work looks like it stops during the ramp — but
-        # it must not invent a claim size.
+        # Lease mode claims nothing: counted, but without an invented claim size.
         webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
 
         maybe_trigger_drain(webhook.mailbox_name)
@@ -1619,36 +1616,6 @@ class DispatchMetricTest(TestCase):
             }
         ]
         assert self.claimed_calls(mock_metrics) == []
-
-    @override_options(CLAIM_MODE_OPTIONS)
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    def test_scheduler_claim_dispatch_attributed_to_scheduler(
-        self, mock_drain: MagicMock, mock_metrics: MagicMock
-    ) -> None:
-        self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
-
-        schedule_webhook_delivery()
-
-        assert self.dispatch_tags(mock_metrics) == [
-            {
-                "dispatcher": "scheduler",
-                "mode": "claim",
-                "drain": "sequential",
-                "provider": "github",
-            }
-        ]
-        assert self.claimed_calls(mock_metrics) == [
-            (
-                1,
-                {
-                    "dispatcher": "scheduler",
-                    "mode": "claim",
-                    "drain": "sequential",
-                    "provider": "github",
-                },
-            )
-        ]
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
@@ -1682,12 +1649,11 @@ class DispatchMetricTest(TestCase):
     @override_options(CLAIM_MODE_OPTIONS)
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox_parallel")
-    def test_claimed_reports_batch_depth_not_one_per_dispatch(
+    def test_scheduler_claim_dispatch_reports_batch_depth(
         self, mock_drain_parallel: MagicMock, mock_metrics: MagicMock
     ) -> None:
-        # The whole point of the distribution: one dispatch can carry many webhooks,
-        # so dispatch share and webhook share are different numbers. A counter alone
-        # would report this deep drain as a single unit of work.
+        # Deep on purpose: `claimed` must report the batch, not one per dispatch,
+        # or webhook share collapses back into dispatch share.
         for _ in range(PARALLEL_DRAIN_THRESHOLD):
             self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
 

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -18,6 +18,7 @@ from sentry.hybridcloud.tasks.deliver_webhooks import (
     MAX_MAILBOX_DRAIN,
     PARALLEL_DRAIN_THRESHOLD,
     SLOW_DELIVERY_THRESHOLD,
+    Dispatcher,
     _claim_and_dispatch,
     _use_claim_dispatch,
     drain_mailbox,
@@ -185,7 +186,9 @@ class ScheduleWebhooksTest(TestCase):
             schedule_for=claimed_for,
         )
 
-        outcome = _claim_and_dispatch(webhook.id, webhook.mailbox_name)
+        outcome = _claim_and_dispatch(
+            webhook.id, webhook.mailbox_name, dispatcher=Dispatcher.SCHEDULER
+        )
 
         assert outcome == "not_due"
         mock_drain.delay.assert_not_called()
@@ -208,7 +211,9 @@ class ScheduleWebhooksTest(TestCase):
         )
 
         with CaptureQueriesContext(connections["control"]) as ctx:
-            outcome = _claim_and_dispatch(webhook.id, webhook.mailbox_name)
+            outcome = _claim_and_dispatch(
+                webhook.id, webhook.mailbox_name, dispatcher=Dispatcher.SCHEDULER
+            )
 
         assert outcome == "sequential"
         mock_drain.delay.assert_called_once_with(webhook.id, claimed_count=1)
@@ -1537,6 +1542,175 @@ class ProviderMetricTagTest(TestCase):
 
         assert self.tags_for(mock_metrics, "hybridcloud.deliver_webhooks.delivery") == [
             {"outcome": "race", "provider": "gitlab"}
+        ]
+
+
+@control_silo_test
+class DispatchMetricTest(TestCase):
+    """
+    Push- and scheduler-dispatched drains must land on one metric so their shares
+    are comparable. Every dispatch path is pinned here: a path that stops emitting
+    silently attributes its work to the other dispatcher.
+    """
+
+    def dispatch_tags(self, mock_metrics: MagicMock) -> list[dict[str, str]]:
+        return [
+            c[1].get("tags", {})
+            for c in mock_metrics.incr.call_args_list
+            if c[0][0] == "hybridcloud.deliver_webhooks.dispatch"
+        ]
+
+    def claimed_calls(self, mock_metrics: MagicMock) -> list[tuple[int, dict[str, str]]]:
+        return [
+            (c[0][1], c[1].get("tags", {}))
+            for c in mock_metrics.distribution.call_args_list
+            if c[0][0] == "hybridcloud.deliver_webhooks.dispatch.claimed"
+        ]
+
+    @override_options(CLAIM_MODE_OPTIONS)
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_push_claim_dispatch_attributed_to_push(
+        self, mock_drain: MagicMock, mock_metrics: MagicMock
+    ) -> None:
+        webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
+
+        maybe_trigger_drain(webhook.mailbox_name)
+
+        assert self.dispatch_tags(mock_metrics) == [
+            {
+                "dispatcher": "push",
+                "mode": "claim",
+                "drain": "sequential",
+                "provider": "github",
+            }
+        ]
+        assert self.claimed_calls(mock_metrics) == [
+            (
+                1,
+                {
+                    "dispatcher": "push",
+                    "mode": "claim",
+                    "drain": "sequential",
+                    "provider": "github",
+                },
+            )
+        ]
+
+    @override_options({"hybridcloud.webhookpayload.push_drain_trigger": True})
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_push_lease_dispatch_counted_without_a_claim_size(
+        self, mock_drain: MagicMock, mock_metrics: MagicMock
+    ) -> None:
+        # Lease mode claims nothing, so this path has no depth to report. It must
+        # still be counted, or push work looks like it stops during the ramp — but
+        # it must not invent a claim size.
+        webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
+
+        maybe_trigger_drain(webhook.mailbox_name)
+
+        assert self.dispatch_tags(mock_metrics) == [
+            {
+                "dispatcher": "push",
+                "mode": "lease",
+                "drain": "sequential",
+                "provider": "github",
+            }
+        ]
+        assert self.claimed_calls(mock_metrics) == []
+
+    @override_options(CLAIM_MODE_OPTIONS)
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_scheduler_claim_dispatch_attributed_to_scheduler(
+        self, mock_drain: MagicMock, mock_metrics: MagicMock
+    ) -> None:
+        self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
+
+        schedule_webhook_delivery()
+
+        assert self.dispatch_tags(mock_metrics) == [
+            {
+                "dispatcher": "scheduler",
+                "mode": "claim",
+                "drain": "sequential",
+                "provider": "github",
+            }
+        ]
+        assert self.claimed_calls(mock_metrics) == [
+            (
+                1,
+                {
+                    "dispatcher": "scheduler",
+                    "mode": "claim",
+                    "drain": "sequential",
+                    "provider": "github",
+                },
+            )
+        ]
+
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_scheduler_lease_dispatch_attributed_to_scheduler(
+        self, mock_drain: MagicMock, mock_metrics: MagicMock
+    ) -> None:
+        self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
+
+        schedule_webhook_delivery()
+
+        assert self.dispatch_tags(mock_metrics) == [
+            {
+                "dispatcher": "scheduler",
+                "mode": "lease",
+                "drain": "sequential",
+                "provider": "github",
+            }
+        ]
+        assert self.claimed_calls(mock_metrics) == [
+            (
+                1,
+                {
+                    "dispatcher": "scheduler",
+                    "mode": "lease",
+                    "drain": "sequential",
+                    "provider": "github",
+                },
+            )
+        ]
+
+    @override_options(CLAIM_MODE_OPTIONS)
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox_parallel")
+    def test_claimed_reports_batch_depth_not_one_per_dispatch(
+        self, mock_drain_parallel: MagicMock, mock_metrics: MagicMock
+    ) -> None:
+        # The whole point of the distribution: one dispatch can carry many webhooks,
+        # so dispatch share and webhook share are different numbers. A counter alone
+        # would report this deep drain as a single unit of work.
+        for _ in range(PARALLEL_DRAIN_THRESHOLD):
+            self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
+
+        schedule_webhook_delivery()
+
+        assert self.dispatch_tags(mock_metrics) == [
+            {
+                "dispatcher": "scheduler",
+                "mode": "claim",
+                "drain": "parallel",
+                "provider": "github",
+            }
+        ]
+        assert self.claimed_calls(mock_metrics) == [
+            (
+                PARALLEL_DRAIN_THRESHOLD,
+                {
+                    "dispatcher": "scheduler",
+                    "mode": "claim",
+                    "drain": "parallel",
+                    "provider": "github",
+                },
+            )
         ]
 
 

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -1599,10 +1599,12 @@ class DispatchMetricTest(TestCase):
     @override_options({"hybridcloud.webhookpayload.push_drain_trigger": True})
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    def test_push_lease_dispatch_counted_without_a_claim_size(
+    def test_push_lease_dispatch_claims_zero(
         self, mock_drain: MagicMock, mock_metrics: MagicMock
     ) -> None:
-        # Lease mode claims nothing: counted, but without an invented claim size.
+        # Lease mode runs no claim UPDATE, so zero is the true claim size. Skipping
+        # the emit instead would leave this dispatcher with no series at all while
+        # lease mode is the majority, blanking any push-vs-scheduler formula.
         webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
 
         maybe_trigger_drain(webhook.mailbox_name)
@@ -1615,7 +1617,17 @@ class DispatchMetricTest(TestCase):
                 "provider": "github",
             }
         ]
-        assert self.claimed_calls(mock_metrics) == []
+        assert self.claimed_calls(mock_metrics) == [
+            (
+                0,
+                {
+                    "dispatcher": "push",
+                    "mode": "lease",
+                    "drain": "sequential",
+                    "provider": "github",
+                },
+            )
+        ]
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")


### PR DESCRIPTION
Adds dispatcher-attributed metrics for drain dispatches, so push-triggered and scheduler-dispatched work can be compared on one chart.

### Why

`push_trigger.*` counts what the push trigger does; the scheduler has no equivalent. Its only counter, `schedule_webhook_delivery.mailbox_count`, is taken before the `[:BATCH_SIZE]` slice and before the skip branches, so it measures mailboxes **due** (~964/cycle) rather than drains **dispatched** (~88/cycle). The "97.6% of drains" figure in getsentry/sentry#121221 had to be derived from Sentry spans by hand, and there is no way to build a standing chart today: the taskworker enqueue counter has an empty tag allowlist, and this service emits no Datadog APM spans.

Dispatch count is also not webhook count. A scheduler drain can claim up to `MAX_MAILBOX_DRAIN` (300) records where a push drain typically claims one or two, so its ~2.4% share of *drains* is consistent with anywhere from ~3% to ~47% of *webhooks*. Nothing today narrows that range.

### What

Two instruments at every dispatch site, tagged `dispatcher: push|scheduler`, `mode: lease|claim`, `drain: sequential|parallel`, `provider`:

- **`hybridcloud.deliver_webhooks.dispatch`** (counter) — enqueues. `by {dispatcher}` is the invocation comparison.
- **`hybridcloud.deliver_webhooks.dispatch.claimed`** (distribution) — the claim behind each enqueue. `.sum by {dispatcher}` is the webhook comparison, `.avg` the drain depth.

Both are emitted unconditionally. A lease-mode push trigger runs no claim UPDATE, so it records a claim of zero: a tag value with no samples returns no series at all rather than a line of zeros, which would blank any push-vs-scheduler formula for as long as lease mode is the majority. Zeros leave `.sum` untouched, and `{mode:claim}` recovers a true claim depth from `.avg`.

`.sum by {dispatcher}` under-attributes push until the ramp completes — lease drains deliver webhooks that no claim ever counted. That is inherent to lease mode, not to this choice, and it converges as the rollout proceeds.

Both metric names are new, so they land in `exclude_tags_mode` and need no pre-deploy tag config — unlike `push_trigger.*`, which is allowlisted and needed `mode`/`drain` added by hand. Worth confirming once after deploy.

### Scope

No behavior change: no query, claim, dispatch decision, or task argument is altered. Tests cover all four dispatch paths (push/scheduler x claim/lease).

Part of [CW-1830](https://linear.app/getsentry/issue/CW-1830). Follow-up to getsentry/sentry#121221.
