### PR TITLE
feat(assisted-query): Forward flag options from the search-agent start endpoint

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -554,9 +554,15 @@ def register_temporary_features(manager: FeatureManager) -> None:
 
     manager.add("organizations:claude-code-vault-reuse", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
 
-    # seer feature flags for assisted query agent org scoped
-    manager.add("organizations:assisted-query-cross-event-explorer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    manager.add("organizations:assisted-query-project-expansion", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Assisted query agent feature flags — forwarded to Seer
+    # Enable cross-event queries for the Traces strategy
+    manager.add("organizations:seer-assisted-query-cross-event-explorer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable LLM project expansion feature
+    manager.add("organizations:seer-assisted-query-project-expansion", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable reflection step feature
+    manager.add("organizations:seer-assisted-query-reflection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Run the agent in code mode
+    manager.add("organizations:seer-assisted-query-codemode", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
 
     # Enable humanized string to ESQ conversion
     manager.add("organizations:search-query-builder-humanized-esq", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -554,15 +554,9 @@ def register_temporary_features(manager: FeatureManager) -> None:
 
     manager.add("organizations:claude-code-vault-reuse", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
 
-    # Assisted query agent feature flags — forwarded to Seer as TranslateRequestOptions
-    # Enable cross-event queries for the Traces strategy
-    manager.add("organizations:seer-assisted-query-cross-event-explorer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable LLM project expansion feature
-    manager.add("organizations:seer-assisted-query-project-expansion", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable reflection step feature
-    manager.add("organizations:seer-assisted-query-reflection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Run the agent in code mode
-    manager.add("organizations:seer-assisted-query-codemode", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # seer feature flags for assisted query agent org scoped
+    manager.add("organizations:assisted-query-cross-event-explorer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    manager.add("organizations:assisted-query-project-expansion", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
 
     # Enable humanized string to ESQ conversion
     manager.add("organizations:search-query-builder-humanized-esq", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)

--- a/src/sentry/seer/endpoints/search_agent_start.py
+++ b/src/sentry/seer/endpoints/search_agent_start.py
@@ -66,6 +66,10 @@ def send_search_agent_start_request(
     model_name: str | None = None,
     metric_context: dict[str, Any] | None = None,
     viewer_context: SeerViewerContext | None = None,
+    cross_event: bool = False,
+    project_expansion: bool = False,
+    reflection_step: bool = False,
+    code_mode: bool = False,
 ) -> SeerRun:
     """Create the SeerRun mirror and enqueue the outbox that starts the agent in Seer."""
     body = SearchAgentStartRequest(
@@ -80,7 +84,12 @@ def send_search_agent_start_request(
     if timezone:
         body["timezone"] = timezone
 
-    options: dict[str, Any] = {}
+    options: dict[str, Any] = {
+        "cross_event": cross_event,
+        "project_expansion": project_expansion,
+        "reflection_step": reflection_step,
+        "code_mode": code_mode,
+    }
     if model_name is not None:
         options["model_name"] = model_name
     if metric_context is not None:
@@ -130,6 +139,7 @@ class SearchAgentStartEndpoint(OrganizationEndpoint):
         options = validated_data.get("options") or {}
         model_name = options.get("model_name")
         metric_context = options.get("metric_context")
+        code_mode_toggle = bool(options.get("code_mode"))
 
         projects = self.get_projects(
             request, organization, project_ids=set(validated_data["project_ids"])
@@ -189,6 +199,27 @@ class SearchAgentStartEndpoint(OrganizationEndpoint):
                 model_name=model_name,
                 metric_context=metric_context,
                 viewer_context=viewer_context,
+                cross_event=features.has(
+                    "organizations:seer-assisted-query-cross-event-explorer",
+                    organization,
+                    actor=request.user,
+                ),
+                project_expansion=features.has(
+                    "organizations:seer-assisted-query-project-expansion",
+                    organization,
+                    actor=request.user,
+                ),
+                reflection_step=features.has(
+                    "organizations:seer-assisted-query-reflection",
+                    organization,
+                    actor=request.user,
+                ),
+                code_mode=code_mode_toggle
+                and features.has(
+                    "organizations:seer-assisted-query-codemode",
+                    organization,
+                    actor=request.user,
+                ),
             )
             return Response(
                 {

--- a/src/sentry/seer/endpoints/trace_explorer_ai_translate_agentic.py
+++ b/src/sentry/seer/endpoints/trace_explorer_ai_translate_agentic.py
@@ -43,11 +43,6 @@ class SearchAgentTranslateSerializer(serializers.Serializer):
         default="Traces",
         help_text="Search strategy to use.",
     )
-    code_mode = serializers.BooleanField(
-        required=False,
-        default=False,
-        help_text="Request code mode execution for the agent.",
-    )
     options = serializers.DictField(
         required=False,
         allow_null=True,
@@ -71,10 +66,6 @@ def send_translate_agentic_request(
     model_name: str | None = None,
     metric_context: dict[str, Any] | None = None,
     viewer_context: SeerViewerContext | None = None,
-    cross_event: bool = False,
-    project_expansion: bool = False,
-    reflection_step: bool = False,
-    code_mode: bool = False,
 ) -> Any:
     """
     Sends a request to seer to translate a natural language query using the agentic search API.
@@ -86,12 +77,7 @@ def send_translate_agentic_request(
         natural_language_query=natural_language_query,
         strategy=strategy,
     )
-    options: dict[str, Any] = {
-        "cross_event": cross_event,
-        "project_expansion": project_expansion,
-        "reflection_step": reflection_step,
-        "code_mode": code_mode,
-    }
+    options: dict[str, Any] = {}
     if model_name is not None:
         options["model_name"] = model_name
     if metric_context is not None:
@@ -128,7 +114,6 @@ class SearchAgentTranslateEndpoint(OrganizationEndpoint):
         validated_data = serializer.validated_data
         natural_language_query = validated_data["natural_language_query"]
         strategy = validated_data.get("strategy", "Traces")
-        code_mode_toggle = validated_data["code_mode"]
         options = validated_data.get("options") or {}
         model_name = options.get("model_name")
         metric_context = options.get("metric_context")
@@ -167,26 +152,5 @@ class SearchAgentTranslateEndpoint(OrganizationEndpoint):
             model_name=model_name,
             metric_context=metric_context,
             viewer_context=viewer_context,
-            cross_event=features.has(
-                "organizations:seer-assisted-query-cross-event-explorer",
-                organization,
-                actor=request.user,
-            ),
-            project_expansion=features.has(
-                "organizations:seer-assisted-query-project-expansion",
-                organization,
-                actor=request.user,
-            ),
-            reflection_step=features.has(
-                "organizations:seer-assisted-query-reflection",
-                organization,
-                actor=request.user,
-            ),
-            code_mode=code_mode_toggle
-            and features.has(
-                "organizations:seer-assisted-query-codemode",
-                organization,
-                actor=request.user,
-            ),
         )
         return Response(data)

--- a/tests/sentry/seer/endpoints/test_search_agent_start.py
+++ b/tests/sentry/seer/endpoints/test_search_agent_start.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -124,7 +125,7 @@ class SearchAgentStartEndpointTest(APITestCase):
         self.seer_access_patcher.stop()
         super().tearDown()
 
-    def _post(self, **extra_data: object) -> object:
+    def _post(self, **extra_data: Any) -> Any:
         return self.client.post(
             self.url,
             data={

--- a/tests/sentry/seer/endpoints/test_search_agent_start.py
+++ b/tests/sentry/seer/endpoints/test_search_agent_start.py
@@ -1,12 +1,14 @@
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+from rest_framework import status
 
 from sentry.seer.endpoints.search_agent_start import send_search_agent_start_request
 from sentry.seer.models import SeerApiError
 from sentry.seer.models.run import SeerRun, SeerRunMirrorStatus, SeerRunType
 from sentry.seer.signed_seer_api import SeerViewerContext
-from sentry.testutils.cases import TestCase
+from sentry.testutils.cases import APITestCase, TestCase
+from sentry.testutils.helpers.features import with_feature
 
 
 class SendSearchAgentStartRequestTest(TestCase):
@@ -64,3 +66,130 @@ class SendSearchAgentStartRequestTest(TestCase):
                 natural_language_query="errors today",
                 viewer_context=viewer_context,
             )
+
+    @patch("sentry.receivers.outbox.cell.make_search_agent_start_request")
+    def test_flag_options_default_to_false(self, mock_request: Mock) -> None:
+        mock_request.return_value = Mock(status=200, json=Mock(return_value={"run_id": 42}))
+
+        send_search_agent_start_request(
+            organization=self.organization,
+            user_id=self.user.id,
+            project_ids=[self.project.id],
+            natural_language_query="errors today",
+        )
+
+        sent_options = mock_request.call_args[0][0]["options"]
+        for flag in ["cross_event", "project_expansion", "reflection_step", "code_mode"]:
+            assert sent_options[flag] is False
+
+    @patch("sentry.receivers.outbox.cell.make_search_agent_start_request")
+    def test_flag_options_are_sent_to_seer(self, mock_request: Mock) -> None:
+        mock_request.return_value = Mock(status=200, json=Mock(return_value={"run_id": 42}))
+
+        send_search_agent_start_request(
+            organization=self.organization,
+            user_id=self.user.id,
+            project_ids=[self.project.id],
+            natural_language_query="errors today",
+            model_name="gpt-5",
+            cross_event=True,
+            project_expansion=True,
+            reflection_step=True,
+            code_mode=True,
+        )
+
+        sent_options = mock_request.call_args[0][0]["options"]
+        for flag in ["cross_event", "project_expansion", "reflection_step", "code_mode"]:
+            assert sent_options[flag] is True
+        assert sent_options["model_name"] == "gpt-5"
+
+
+@with_feature("organizations:gen-ai-search-agent-translate")
+@with_feature("organizations:gen-ai-features")
+class SearchAgentStartEndpointTest(APITestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(user=self.user)
+        self.organization = self.create_organization(owner=self.user)
+        self.project = self.create_project(organization=self.organization)
+        self.url = f"/api/0/organizations/{self.organization.slug}/search-agent/start/"
+
+        self.seer_access_patcher = patch(
+            "sentry.seer.endpoints.search_agent_start.has_seer_access_with_detail",
+            return_value=(True, None),
+        )
+        self.seer_access_patcher.start()
+
+    def tearDown(self) -> None:
+        self.seer_access_patcher.stop()
+        super().tearDown()
+
+    def _post(self, **extra_data: object) -> object:
+        return self.client.post(
+            self.url,
+            data={
+                "project_ids": [self.project.id],
+                "natural_language_query": "show errors",
+                **extra_data,
+            },
+            format="json",
+        )
+
+    @patch("sentry.seer.endpoints.search_agent_start.send_search_agent_start_request")
+    @patch("django.conf.settings.SEER_AUTOFIX_URL", "https://seer.example.com")
+    @with_feature("organizations:seer-assisted-query-cross-event-explorer")
+    @with_feature("organizations:seer-assisted-query-project-expansion")
+    @with_feature("organizations:seer-assisted-query-reflection")
+    @with_feature("organizations:seer-assisted-query-codemode")
+    def test_start_forwards_feature_flags(self, mock_send_request: MagicMock) -> None:
+        """Feature flags are forwarded to Seer as request options. Code mode tested separately."""
+        mock_send_request.return_value = Mock(seer_run_state_id=42, uuid="run-uuid")
+
+        response = self._post()
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == {"run_id": 42, "sentry_run_id": "run-uuid"}
+        kwargs = mock_send_request.call_args.kwargs
+        assert kwargs["cross_event"] is True
+        assert kwargs["project_expansion"] is True
+        assert kwargs["reflection_step"] is True
+
+    @patch("sentry.seer.endpoints.search_agent_start.send_search_agent_start_request")
+    @patch("django.conf.settings.SEER_AUTOFIX_URL", "https://seer.example.com")
+    def test_start_without_feature_flags(self, mock_send_request: MagicMock) -> None:
+        """Options are False when the org has none of the flags."""
+        mock_send_request.return_value = Mock(seer_run_state_id=42, uuid="run-uuid")
+
+        response = self._post()
+
+        assert response.status_code == status.HTTP_200_OK
+        kwargs = mock_send_request.call_args.kwargs
+        assert kwargs["cross_event"] is False
+        assert kwargs["project_expansion"] is False
+        assert kwargs["reflection_step"] is False
+
+    @patch("sentry.seer.endpoints.search_agent_start.send_search_agent_start_request")
+    @patch("django.conf.settings.SEER_AUTOFIX_URL", "https://seer.example.com")
+    @with_feature("organizations:seer-assisted-query-codemode")
+    def test_code_mode_requires_toggle_and_flag(self, mock_send_request: MagicMock) -> None:
+        """code_mode is False when the request toggle is off, even if the flag is on."""
+        mock_send_request.return_value = Mock(seer_run_state_id=42, uuid="run-uuid")
+
+        response = self._post()
+
+        assert response.status_code == status.HTTP_200_OK
+        assert mock_send_request.call_args.kwargs["code_mode"] is False
+
+    @patch("sentry.seer.endpoints.search_agent_start.send_search_agent_start_request")
+    @patch("django.conf.settings.SEER_AUTOFIX_URL", "https://seer.example.com")
+    @with_feature("organizations:seer-assisted-query-codemode")
+    def test_code_mode_toggle_enables_code_mode(self, mock_send_request: MagicMock) -> None:
+        """The toggle rides in `options` alongside model_name/metric_context."""
+        mock_send_request.return_value = Mock(seer_run_state_id=42, uuid="run-uuid")
+
+        response = self._post(options={"code_mode": True, "model_name": "gpt-5"})
+
+        assert response.status_code == status.HTTP_200_OK
+        kwargs = mock_send_request.call_args.kwargs
+        assert kwargs["code_mode"] is True
+        assert kwargs["model_name"] == "gpt-5"

--- a/tests/sentry/seer/endpoints/test_trace_explorer_ai_translate_agentic.py
+++ b/tests/sentry/seer/endpoints/test_trace_explorer_ai_translate_agentic.py
@@ -57,78 +57,7 @@ class SearchAgentTranslateEndpointTest(APITestCase):
                 "organization_id": self.organization.id,
                 "user_id": self.user.id,
             },
-            cross_event=False,
-            project_expansion=False,
-            reflection_step=False,
-            code_mode=False,
         )
-
-    @patch(
-        "sentry.seer.endpoints.trace_explorer_ai_translate_agentic.send_translate_agentic_request"
-    )
-    @patch("django.conf.settings.SEER_AUTOFIX_URL", "https://seer.example.com")
-    @with_feature("organizations:seer-assisted-query-cross-event-explorer")
-    @with_feature("organizations:seer-assisted-query-project-expansion")
-    @with_feature("organizations:seer-assisted-query-reflection")
-    @with_feature("organizations:seer-assisted-query-codemode")
-    def test_translate_forwards_feature_flags(self, mock_send_request: MagicMock) -> None:
-        """Feature flags are forwarded to Seer as request options."""
-        mock_send_request.return_value = {"status": "ok"}
-
-        response = self.client.post(
-            self.url,
-            data={
-                "project_ids": [self.project.id],
-                "natural_language_query": "show errors",
-                "code_mode": True,
-            },
-            format="json",
-        )
-
-        assert response.status_code == status.HTTP_200_OK
-        _, kwargs = mock_send_request.call_args
-        assert kwargs["cross_event"] is True
-        assert kwargs["project_expansion"] is True
-        assert kwargs["reflection_step"] is True
-        assert kwargs["code_mode"] is True
-
-    @patch(
-        "sentry.seer.endpoints.trace_explorer_ai_translate_agentic.send_translate_agentic_request"
-    )
-    @patch("django.conf.settings.SEER_AUTOFIX_URL", "https://seer.example.com")
-    @with_feature("organizations:seer-assisted-query-codemode")
-    def test_code_mode_requires_toggle_and_flag(self, mock_send_request: MagicMock) -> None:
-        """code_mode is False when the toggle is off, even if the flag is on."""
-        mock_send_request.return_value = {"status": "ok"}
-
-        self.client.post(
-            self.url,
-            data={
-                "project_ids": [self.project.id],
-                "natural_language_query": "show errors",
-            },
-            format="json",
-        )
-        assert mock_send_request.call_args.kwargs["code_mode"] is False
-
-    @patch(
-        "sentry.seer.endpoints.trace_explorer_ai_translate_agentic.send_translate_agentic_request"
-    )
-    @patch("django.conf.settings.SEER_AUTOFIX_URL", "https://seer.example.com")
-    def test_code_mode_toggle_without_flag(self, mock_send_request: MagicMock) -> None:
-        """code_mode is False when the toggle is on but the flag is off."""
-        mock_send_request.return_value = {"status": "ok"}
-
-        self.client.post(
-            self.url,
-            data={
-                "project_ids": [self.project.id],
-                "natural_language_query": "show errors",
-                "code_mode": True,
-            },
-            format="json",
-        )
-        assert mock_send_request.call_args.kwargs["code_mode"] is False
 
     @patch(
         "sentry.seer.endpoints.trace_explorer_ai_translate_agentic.send_translate_agentic_request"


### PR DESCRIPTION
Moves assisted-query flag forwarding from the legacy `search-agent/translate/` endpoint onto the polling `search-agent/start/` endpoint, which is the path the Seer comboboxes actually use. Reverts #121784's endpoint changes and re-implements them where they belong.

### What changes

`send_search_agent_start_request` always includes four keys in the Seer request `options`, defaulting to `False`:

- `cross_event` ← `organizations:seer-assisted-query-cross-event-explorer`
- `project_expansion` ← `organizations:seer-assisted-query-project-expansion`
- `reflection_step` ← `organizations:seer-assisted-query-reflection`
- `code_mode` ← `organizations:seer-assisted-query-codemode` **and** the client opting in via `options.code_mode`

`code_mode` is the only one gated on both, so enabling the flag alone doesn't switch a run into code mode — the caller still has to ask for it.

The four flag registrations in `temporary.py` end up identical to master (the two revert commits churn them, the final commit restores them).

### Tests

`tests/sentry/seer/endpoints/test_search_agent_start.py` — 9 passing.

- Helper-level: options default to `False`, and all four forward `True` alongside `model_name`. Both assert on the body that reaches Seer (`make_search_agent_start_request` call args), so the outbox hop is covered.
- Endpoint-level (new `SearchAgentStartEndpointTest`; this endpoint had no request-level coverage before): all flags on → all `True`; no flags → all `False` even with `code_mode: true` in the request; flag on + no toggle → `False`; flag on + toggle → `True`.