### PR TITLE
ref(issues): Remove checks for graduated issue flags

### DIFF
--- a/src/sentry/api/serializers/models/group_stream.py
+++ b/src/sentry/api/serializers/models/group_stream.py
@@ -482,43 +482,24 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
             and item_list
             and features.has("organizations:event-attachments", item_list[0].project.organization)
         ):
-            latest_event_attachment_strategy = (
-                "bulk"
-                if features.has(
-                    "organizations:issue-stream-batched-latest-event-attachments",
-                    item_list[0].project.organization,
-                )
-                else "n_plus_one"
-            )
-
             with metrics.timer(
                 "group_stream.get_attrs.latest_event_attachments.duration",
-                tags={"strategy": latest_event_attachment_strategy},
+                tags={"strategy": "bulk"},
             ):
-                if latest_event_attachment_strategy == "bulk":
-                    latest_events = bulk_get_latest_event_ids(item_list)
-                    latest_event_keys = set(latest_events.values())
-                    attachment_event_keys = set(
-                        EventAttachment.objects.filter(
-                            project_id__in={project_id for project_id, _ in latest_event_keys},
-                            event_id__in={event_id for _, event_id in latest_event_keys},
-                        ).values_list("project_id", "event_id")
-                    )
-                    for item in item_list:
-                        latest_event_key = latest_events.get(item.id)
-                        if latest_event_key is not None:
-                            attrs[item]["latestEventHasAttachments"] = (
-                                latest_event_key in attachment_event_keys
-                            )
-                else:
-                    for item in item_list:
-                        latest_event = item.get_latest_event()
-                        if latest_event is not None:
-                            num_attachments = EventAttachment.objects.filter(
-                                project_id=latest_event.project_id,
-                                event_id=latest_event.event_id,
-                            ).count()
-                            attrs[item]["latestEventHasAttachments"] = num_attachments > 0
+                latest_events = bulk_get_latest_event_ids(item_list)
+                latest_event_keys = set(latest_events.values())
+                attachment_event_keys = set(
+                    EventAttachment.objects.filter(
+                        project_id__in={project_id for project_id, _ in latest_event_keys},
+                        event_id__in={event_id for _, event_id in latest_event_keys},
+                    ).values_list("project_id", "event_id")
+                )
+                for item in item_list:
+                    latest_event_key = latest_events.get(item.id)
+                    if latest_event_key is not None:
+                        attrs[item]["latestEventHasAttachments"] = (
+                            latest_event_key in attachment_event_keys
+                        )
 
         return attrs
 

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -372,11 +372,11 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Fetch CI check status from the provider for pull requests linked to an issue
     manager.add("organizations:issue-pr-checks-status", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Merge issue platform category searches into a single Snuba query
-    manager.add("organizations:issue-search-merged-generic-query", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    manager.add("organizations:issue-search-merged-generic-query", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=True, api_expose=False)
     # Enables the shared issue/event formatter module (markdown/xml output for LLMs)
     manager.add("organizations:issue-standardized-markdown-for-llm", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Batch latest-event attachment lookups in the issue stream
-    manager.add("organizations:issue-stream-batched-latest-event-attachments", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    manager.add("organizations:issue-stream-batched-latest-event-attachments", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=True, api_expose=False)
     # Remove trace and breadcrumbs from issue summary input
     manager.add("organizations:issue-summary-experimental", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable new issue stream progress views

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -498,9 +498,6 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
             if group_categories - {GroupCategory.ERROR.value}
             else set()
         )
-        merge_generic_categories = features.has(
-            "organizations:issue-search-merged-generic-query", organization, actor=actor
-        )
         category_filter_groups: list[tuple[list[int], Sequence[SearchFilter]]] = []
         for group_category in sorted(group_categories):
             try:
@@ -512,7 +509,7 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
             except UnsupportedSearchQuery:
                 continue
 
-            if merge_generic_categories and group_category != GroupCategory.ERROR.value:
+            if group_category != GroupCategory.ERROR.value:
                 for grouped_categories, grouped_search_filters in category_filter_groups:
                     if (
                         GroupCategory.ERROR.value not in grouped_categories

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -2263,17 +2263,8 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         ]
         assert len(platform_issue_queries) == 1
 
-    @with_feature(
-        {
-            "organizations:event-attachments": True,
-            "organizations:issue-stream-batched-latest-event-attachments": False,
-        }
-    )
-    @patch("sentry.api.serializers.models.group_stream.metrics")
-    @patch("sentry.api.serializers.models.group_stream.bulk_get_latest_event_ids")
-    def test_expand_latest_event_has_attachments(
-        self, mock_bulk_get_latest_event_ids: MagicMock, mock_metrics: MagicMock
-    ) -> None:
+    @with_feature("organizations:event-attachments")
+    def test_expand_latest_event_has_attachments(self) -> None:
         event = self.store_event(
             data={"timestamp": before_now(seconds=500).isoformat(), "fingerprint": ["group-1"]},
             project_id=self.project.id,
@@ -2310,24 +2301,8 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         )
         assert response.status_code == 200
         assert response.data[0]["latestEventHasAttachments"] is True
-        mock_bulk_get_latest_event_ids.assert_not_called()
-        assert mock_metrics.timer.call_args_list == [
-            call(
-                "group_stream.get_attrs.latest_event_attachments.duration",
-                tags={"strategy": "n_plus_one"},
-            ),
-            call(
-                "group_stream.get_attrs.latest_event_attachments.duration",
-                tags={"strategy": "n_plus_one"},
-            ),
-        ]
 
-    @with_feature(
-        [
-            "organizations:event-attachments",
-            "organizations:issue-stream-batched-latest-event-attachments",
-        ]
-    )
+    @with_feature("organizations:event-attachments")
     @patch("sentry.api.serializers.models.group_stream.metrics")
     @patch("sentry.models.Group.get_latest_event")
     def test_expand_latest_event_has_attachments_is_batched(
@@ -2379,12 +2354,7 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
             tags={"strategy": "bulk"},
         )
 
-    @with_feature(
-        [
-            "organizations:event-attachments",
-            "organizations:issue-stream-batched-latest-event-attachments",
-        ]
-    )
+    @with_feature("organizations:event-attachments")
     def test_expand_latest_event_attachments_match_project_and_event(self) -> None:
         other_project = self.create_project(organization=self.organization, teams=[self.team])
         shared_event_id = "b" * 32
@@ -2438,12 +2408,7 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
             second_project_event.group.id: False,
         }
 
-    @with_feature(
-        [
-            "organizations:event-attachments",
-            "organizations:issue-stream-batched-latest-event-attachments",
-        ]
-    )
+    @with_feature("organizations:event-attachments")
     @patch("sentry.api.serializers.models.group_stream.bulk_get_latest_event_ids", return_value={})
     def test_expand_no_latest_event_has_no_attachments(self, mock_latest_events: MagicMock) -> None:
         self.store_event(
@@ -2459,37 +2424,6 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
 
         # Expand should not execute since there is no latest event
         assert "latestEventHasAttachments" not in response.data[0]
-
-    @with_feature(
-        {
-            "organizations:event-attachments": True,
-            "organizations:issue-stream-batched-latest-event-attachments": False,
-        }
-    )
-    @patch("sentry.api.serializers.models.group_stream.bulk_get_latest_event_ids")
-    @patch("sentry.models.Group.get_latest_event", return_value=None)
-    def test_expand_no_latest_event_has_no_attachments_legacy(
-        self,
-        mock_get_latest_event: MagicMock,
-        mock_bulk_get_latest_event_ids: MagicMock,
-    ) -> None:
-        self.store_event(
-            data={"timestamp": before_now(seconds=500).isoformat(), "fingerprint": ["group-1"]},
-            project_id=self.project.id,
-        )
-        self.login_as(user=self.user)
-
-        response = self.get_response(
-            sort_by="date",
-            limit=10,
-            query="status:unresolved",
-            expand=["latestEventHasAttachments"],
-        )
-
-        assert response.status_code == 200
-        assert "latestEventHasAttachments" not in response.data[0]
-        mock_get_latest_event.assert_called_once_with()
-        mock_bulk_get_latest_event_ids.assert_not_called()
 
     def test_expand_owners(self) -> None:
         event = self.store_event(

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -3795,12 +3795,9 @@ class EventsGenericSnubaSearchTest(TestCase, SharedSnubaMixin, OccurrenceTestMix
         assert list(results) == [performance_group]
 
     def test_merge_default_category_queries(self) -> None:
-        with (
-            self.feature("organizations:issue-search-merged-generic-query"),
-            mock.patch(
-                "sentry.search.snuba.executors.bulk_raw_query", wraps=snuba.bulk_raw_query
-            ) as bulk_query,
-        ):
+        with mock.patch(
+            "sentry.search.snuba.executors.bulk_raw_query", wraps=snuba.bulk_raw_query
+        ) as bulk_query:
             results = self.make_query(search_filter_query="my_tag:1")
 
         assert set(results) == {
@@ -3836,38 +3833,20 @@ class EventsGenericSnubaSearchTest(TestCase, SharedSnubaMixin, OccurrenceTestMix
             self.feature(group_type.build_visible_feature_name()),
             mock.patch(
                 "sentry.search.snuba.executors.bulk_raw_query", wraps=snuba.bulk_raw_query
-            ) as control_bulk_query,
+            ) as bulk_query,
         ):
-            control_results = self.make_query(search_filter_query=query)
+            results = self.make_query(search_filter_query=query)
 
-        with (
-            self.feature(group_type.build_visible_feature_name()),
-            self.feature("organizations:issue-search-merged-generic-query"),
-            mock.patch(
-                "sentry.search.snuba.executors.bulk_raw_query", wraps=snuba.bulk_raw_query
-            ) as merged_bulk_query,
-        ):
-            merged_results = self.make_query(search_filter_query=query)
-
-        assert set(control_results) == expected_groups
-        assert set(merged_results) == expected_groups
-
-        control_query_params = control_bulk_query.call_args.args[0]
-        assert len(control_query_params) == 3
-        assert all(
-            params.kwargs["orderby"] == ["-last_seen", "group_id"]
-            for params in control_query_params
-        )
-
-        merged_query_params = merged_bulk_query.call_args.args[0]
-        assert len(merged_query_params) == 2
-        assert {params.dataset for params in merged_query_params} == {
+        assert set(results) == expected_groups
+        query_params = bulk_query.call_args.args[0]
+        assert len(query_params) == 2
+        assert {params.dataset for params in query_params} == {
             Dataset.Events,
             Dataset.IssuePlatform,
         }
 
         issue_platform_params = next(
-            params for params in merged_query_params if params.dataset == Dataset.IssuePlatform
+            params for params in query_params if params.dataset == Dataset.IssuePlatform
         )
         assert issue_platform_params.kwargs["orderby"] == ["-last_seen", "-group_id"]
         assert set(issue_platform_params.filter_keys["occurrence_type_id"]) >= {
@@ -3890,10 +3869,7 @@ class EventsGenericSnubaSearchTest(TestCase, SharedSnubaMixin, OccurrenceTestMix
             self.error_group_2,
         }
 
-        with (
-            self.feature(group_type.build_visible_feature_name()),
-            self.feature("organizations:issue-search-merged-generic-query"),
-        ):
+        with self.feature(group_type.build_visible_feature_name()):
             first_page = self.make_query(
                 search_filter_query=query,
                 limit=2,


### PR DESCRIPTION
## Description
Clean-up time! Rolled out a few things that improved performance last week, cleaning up the rollout flags and legacy implementation now that it seems stable.