### PR TITLE
ref(workflow-engine): separate out detector/workflow auto creation

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3461,7 +3461,13 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
-    "workflow_engine.all_projects_auto_creation_enabled",
+    "workflow_engine.auto_creation.pull_request_workflow",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "workflow_engine.auto_creation.all_projects_detector",
     type=Bool,
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,

--- a/src/sentry/workflow_engine/defaults/detectors.py
+++ b/src/sentry/workflow_engine/defaults/detectors.py
@@ -6,7 +6,7 @@ from functools import cache
 from django.db import router, transaction
 from rest_framework import status
 
-from sentry import features
+from sentry import features, options
 from sentry.api.exceptions import SentryAPIException
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.incidents.grouptype import MetricIssue
@@ -332,9 +332,10 @@ def ensure_default_all_projects_detector(organization_id: int) -> Detector:
 
 def ensure_default_organization_detectors(organization: Organization) -> dict[str, Detector]:
     detectors: dict[str, Detector] = {}
-    detectors[IssueStreamGroupType.slug] = ensure_default_all_projects_detector(
-        organization_id=organization.id
-    )
+    if options.get("workflow_engine.auto_creation.all_projects_detector"):
+        detectors[IssueStreamGroupType.slug] = ensure_default_all_projects_detector(
+            organization_id=organization.id
+        )
     return detectors
 
 

--- a/src/sentry/workflow_engine/defaults/workflows.py
+++ b/src/sentry/workflow_engine/defaults/workflows.py
@@ -2,13 +2,13 @@ from typing import Sequence
 
 from django.db import router, transaction
 
+from sentry import options
 from sentry.locks import locks
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.types import FallthroughChoiceType
 from sentry.utils.locking import UnableToAcquireLock
-from sentry.utils.settings import is_self_hosted
 from sentry.workflow_engine.defaults.detectors import (
     UnableToAcquireLockApiError,
     _ensure_detector,
@@ -214,8 +214,9 @@ def ensure_pull_request_workflow(organization: Organization, detector: Detector)
 
 
 def ensure_default_organization_workflows(organization: Organization) -> list[Workflow]:
-    all_projects_detector = ensure_default_all_projects_detector(organization.id)
     workflows: list[Workflow] = []
-    if not is_self_hosted():
-        workflows.append(ensure_pull_request_workflow(organization, all_projects_detector))
+    if not options.get("workflow_engine.auto_creation.pull_request_workflow"):
+        return workflows
+    all_projects_detector = ensure_default_all_projects_detector(organization.id)
+    workflows.append(ensure_pull_request_workflow(organization, all_projects_detector))
     return workflows

--- a/src/sentry/workflow_engine/receivers/organization_detectors.py
+++ b/src/sentry/workflow_engine/receivers/organization_detectors.py
@@ -2,7 +2,6 @@ from typing import Any
 
 import sentry_sdk
 
-from sentry import options
 from sentry.models.organization import Organization
 from sentry.signals import organization_created
 from sentry.workflow_engine.defaults.detectors import (
@@ -13,8 +12,6 @@ from sentry.workflow_engine.models import Detector
 
 
 def create_organization_detectors(organization: Organization, **kwargs: Any) -> dict[str, Detector]:
-    if not options.get("workflow_engine.all_projects_auto_creation_enabled"):
-        return {}
     try:
         return ensure_default_organization_detectors(organization)
     except UnableToAcquireLockApiError as e:

--- a/src/sentry/workflow_engine/receivers/organization_workflows.py
+++ b/src/sentry/workflow_engine/receivers/organization_workflows.py
@@ -2,7 +2,6 @@ from typing import Any
 
 import sentry_sdk
 
-from sentry import options
 from sentry.models.organization import Organization
 from sentry.signals import organization_created
 from sentry.workflow_engine.defaults.detectors import (
@@ -12,8 +11,6 @@ from sentry.workflow_engine.defaults.workflows import ensure_default_organizatio
 
 
 def create_organization_workflows(organization: Organization, **kwargs: Any) -> None:
-    if not options.get("workflow_engine.all_projects_auto_creation_enabled"):
-        return
     try:
         ensure_default_organization_workflows(organization)
     except UnableToAcquireLockApiError as e:

--- a/tests/sentry/workflow_engine/defaults/test_detectors.py
+++ b/tests/sentry/workflow_engine/defaults/test_detectors.py
@@ -4,6 +4,7 @@ import pytest
 
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.options import override_options
 from sentry.utils.locking import UnableToAcquireLock
 from sentry.workflow_engine.defaults.detectors import (
     UnableToAcquireLockApiError,
@@ -56,6 +57,7 @@ class TestEnsureDefaultDetectors(TestCase):
                 project = self.create_project()
                 ensure_default_detectors(project)
 
+    @override_options({"workflow_engine.auto_creation.all_projects_detector": True})
     def test_ensure_default_organization_detectors_creates_all_projects(self) -> None:
         ensure_default_organization_detectors(self.organization)
 
@@ -115,3 +117,7 @@ class TestEnsureDefaultAllProjectsDetector(TestCase):
             mock_lock.return_value.blocking_acquire.side_effect = UnableToAcquireLock
             with pytest.raises(UnableToAcquireLockApiError):
                 ensure_default_all_projects_detector(self.organization.id)
+
+    def test_returns_none_when_option_disabled(self) -> None:
+        result = ensure_default_organization_detectors(self.organization)
+        assert result == {}

--- a/tests/sentry/workflow_engine/defaults/test_workflows.py
+++ b/tests/sentry/workflow_engine/defaults/test_workflows.py
@@ -1,11 +1,9 @@
-from unittest import mock
-
 from sentry.notifications.types import FallthroughChoiceType
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.options import override_options
 from sentry.workflow_engine.defaults.detectors import (
     ensure_default_all_projects_detector,
     ensure_default_detectors,
-    ensure_default_organization_detectors,
 )
 from sentry.workflow_engine.defaults.workflows import (
     connect_workflows_to_issue_stream,
@@ -204,9 +202,7 @@ class TestEnsureDefaultWorkflows(TestCase):
 
 class TestCreateAndConnectPullRequestWorkflow(TestCase):
     def setUp(self) -> None:
-        self.all_projects_detector = ensure_default_organization_detectors(self.organization)[
-            IssueStreamGroupType.slug
-        ]
+        self.all_projects_detector = ensure_default_all_projects_detector(self.organization.id)
 
     def test_creates_workflow_with_correct_name(self) -> None:
         workflow = create_and_connect_pull_request_workflow(
@@ -283,9 +279,7 @@ class TestCreateAndConnectPullRequestWorkflow(TestCase):
 
 class TestEnsurePullRequestWorkflow(TestCase):
     def setUp(self) -> None:
-        self.all_projects_detector = ensure_default_organization_detectors(self.organization)[
-            IssueStreamGroupType.slug
-        ]
+        self.all_projects_detector = ensure_default_all_projects_detector(self.organization.id)
 
     def test_creates_and_connects_workflow(self) -> None:
         workflow = ensure_pull_request_workflow(self.organization, self.all_projects_detector)
@@ -323,8 +317,8 @@ class TestEnsurePullRequestWorkflow(TestCase):
 
 
 class TestEnsureDefaultOrganizationWorkflows(TestCase):
-    @mock.patch("sentry.workflow_engine.defaults.workflows.is_self_hosted", return_value=False)
-    def test_creates_and_connects_workflows(self, mock_is_self_hosted: mock.MagicMock) -> None:
+    @override_options({"workflow_engine.auto_creation.pull_request_workflow": True})
+    def test_creates_and_connects_workflows(self) -> None:
         workflows = ensure_default_organization_workflows(self.organization)
 
         assert len(workflows) == 1
@@ -337,8 +331,8 @@ class TestEnsureDefaultOrganizationWorkflows(TestCase):
         assert connection.detector.project is None
         assert connection.detector.config["organization_id"] == self.organization.id
 
-    @mock.patch("sentry.workflow_engine.defaults.workflows.is_self_hosted", return_value=False)
-    def test_uses_existing_all_projects_detector(self, mock_is_self_hosted: mock.MagicMock) -> None:
+    @override_options({"workflow_engine.auto_creation.pull_request_workflow": True})
+    def test_uses_existing_all_projects_detector(self) -> None:
         existing_detector = ensure_default_all_projects_detector(self.organization.id)
         workflows = ensure_default_organization_workflows(self.organization)
 
@@ -354,15 +348,12 @@ class TestEnsureDefaultOrganizationWorkflows(TestCase):
             == 1
         )
 
-    @mock.patch("sentry.workflow_engine.defaults.workflows.is_self_hosted", return_value=False)
-    def test_returns_workflows_list(self, mock_is_self_hosted: mock.MagicMock) -> None:
+    @override_options({"workflow_engine.auto_creation.pull_request_workflow": True})
+    def test_returns_workflows_list(self) -> None:
         workflows = ensure_default_organization_workflows(self.organization)
         assert isinstance(workflows, list)
         assert all(isinstance(w, Workflow) for w in workflows)
 
-    @mock.patch("sentry.workflow_engine.defaults.workflows.is_self_hosted", return_value=True)
-    def test_skips_pull_request_workflow_when_self_hosted(
-        self, mock_is_self_hosted: mock.MagicMock
-    ) -> None:
+    def test_skips_pull_request_workflow_when_option_disabled(self) -> None:
         workflows = ensure_default_organization_workflows(self.organization)
         assert workflows == []

--- a/tests/sentry/workflow_engine/models/test_detector.py
+++ b/tests/sentry/workflow_engine/models/test_detector.py
@@ -4,6 +4,7 @@ import pytest
 
 from sentry.constants import ObjectStatus
 from sentry.grouping.grouptype import ErrorGroupType
+from sentry.testutils.helpers.options import override_options
 from sentry.workflow_engine.defaults.detectors import ensure_default_all_projects_detector
 from sentry.workflow_engine.models import Detector
 from sentry.workflow_engine.models.detector import get_detector_project_type_cache_key
@@ -28,6 +29,7 @@ class DetectorTest(BaseWorkflowTest):
         self.detector.save()
         assert not Detector.objects.filter(id=self.detector.id).exists()
 
+    @override_options({"workflow_engine.auto_creation.all_projects_detector": True})
     def test_detectors_by_organization(self) -> None:
         project_detector = self.create_detector(project=self.project)
         all_projects_detector = ensure_default_all_projects_detector(self.organization.id)
@@ -35,6 +37,7 @@ class DetectorTest(BaseWorkflowTest):
         assert project_detector in result
         assert all_projects_detector in result
 
+    @override_options({"workflow_engine.auto_creation.all_projects_detector": True})
     def test_excludes_other_organizations(self) -> None:
         other_org = self.create_organization()
         other_project = self.create_project(organization=other_org)

--- a/tests/sentry/workflow_engine/receivers/test_organization_detectors.py
+++ b/tests/sentry/workflow_engine/receivers/test_organization_detectors.py
@@ -27,7 +27,7 @@ class TestCreateOrganizationDetectors(TestCase):
             config__organization_id=self.organization.id,
         ).exists()
 
-    @override_options({"workflow_engine.all_projects_auto_creation_enabled": True})
+    @override_options({"workflow_engine.auto_creation.all_projects_detector": True})
     def test_creates_detector(self) -> None:
         self.send_signal()
         detector = Detector.objects.get(
@@ -37,7 +37,7 @@ class TestCreateOrganizationDetectors(TestCase):
         )
         assert detector.enabled
 
-    @override_options({"workflow_engine.all_projects_auto_creation_enabled": True})
+    @override_options({"workflow_engine.auto_creation.all_projects_detector": True})
     def test_no_duplicates_ever(self) -> None:
         # Multiple signal emissions
         self.send_signal()
@@ -55,7 +55,7 @@ class TestCreateOrganizationDetectors(TestCase):
             == 1
         )
 
-    @override_options({"workflow_engine.all_projects_auto_creation_enabled": True})
+    @override_options({"workflow_engine.auto_creation.all_projects_detector": True})
     @mock.patch("sentry.workflow_engine.receivers.organization_detectors.sentry_sdk")
     def test_captures_exception_on_creation_failure(self, mock_sdk: mock.MagicMock) -> None:
         organization = self.create_organization()

--- a/tests/sentry/workflow_engine/receivers/test_organization_workflows.py
+++ b/tests/sentry/workflow_engine/receivers/test_organization_workflows.py
@@ -23,27 +23,24 @@ class TestCreateOrganizationWorkflows(TestCase):
             organization=self.organization, name=PULL_REQUEST_WORKFLOW_LABEL
         ).exists()
 
-    @override_options({"workflow_engine.all_projects_auto_creation_enabled": True})
-    @mock.patch("sentry.workflow_engine.defaults.workflows.is_self_hosted", return_value=False)
-    def test_creates_workflow(self, mock_is_self_hosted: mock.MagicMock) -> None:
+    @override_options({"workflow_engine.auto_creation.pull_request_workflow": True})
+    def test_creates_workflow(self) -> None:
         self.send_signal()
         workflow = Workflow.objects.get(
             organization=self.organization, name=PULL_REQUEST_WORKFLOW_LABEL
         )
         assert workflow.enabled
 
-    @override_options({"workflow_engine.all_projects_auto_creation_enabled": True})
-    @mock.patch("sentry.workflow_engine.defaults.workflows.is_self_hosted", return_value=False)
-    def test_connects_workflow_to_detector(self, mock_is_self_hosted: mock.MagicMock) -> None:
+    @override_options({"workflow_engine.auto_creation.pull_request_workflow": True})
+    def test_connects_workflow_to_detector(self) -> None:
         self.send_signal()
         workflow = Workflow.objects.get(
             organization=self.organization, name=PULL_REQUEST_WORKFLOW_LABEL
         )
         assert DetectorWorkflow.objects.filter(workflow=workflow).exists()
 
-    @override_options({"workflow_engine.all_projects_auto_creation_enabled": True})
-    @mock.patch("sentry.workflow_engine.defaults.workflows.is_self_hosted", return_value=False)
-    def test_no_duplicates_ever(self, mock_is_self_hosted: mock.MagicMock) -> None:
+    @override_options({"workflow_engine.auto_creation.pull_request_workflow": True})
+    def test_no_duplicates_ever(self) -> None:
         # Multiple signal emissions
         self.send_signal()
         self.send_signal()
@@ -59,7 +56,7 @@ class TestCreateOrganizationWorkflows(TestCase):
             == 1
         )
 
-    @override_options({"workflow_engine.all_projects_auto_creation_enabled": True})
+    @override_options({"workflow_engine.auto_creation.pull_request_workflow": True})
     @mock.patch("sentry.workflow_engine.receivers.organization_workflows.sentry_sdk")
     def test_captures_exception_on_creation_failure(self, mock_sdk: mock.MagicMock) -> None:
         organization = self.create_organization()


### PR DESCRIPTION
A refactor of https://github.com/getsentry/sentry/pull/121737

I realized that it's not just for self-hosted, we need to separate out auto-creation of the detector from the workflow for release as well.

So this pr removes the current flag, replaces it with two separate ones `auto_creation.all_projects_detector` and `auto_creation.pull_request_workflow`. For self-hosted, we can just enable all_projects_detector (or remove that option all together) but the other option will stay permanently as false (that way any org workflows we add by default later can still be made auto-available to self-hosted.

Also moved where we check the option to inside the `ensure_workflows/detectors` functions rather than the `organization-created` signal, that way we skip only the detector/workflow from the option, not the whole function.