### PR TITLE
chore(ACI): Remove legacy default rule creation from project workflows receiver

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2007,7 +2007,7 @@ def _get_severity_metadata_for_group(
 
     Returns {} if conditions aren't met or on exception.
     """
-    from sentry.workflow_engine.receivers.project_workflows import PLATFORMS_WITH_PRIORITY_ALERTS
+    PLATFORMS_WITH_PRIORITY_ALERTS = ["python", "javascript"]
 
     if killswitch_matches_context(
         "issues.severity.skip-seer-requests", {"project_id": event.project_id}

--- a/src/sentry/workflow_engine/receivers/project_workflows.py
+++ b/src/sentry/workflow_engine/receivers/project_workflows.py
@@ -1,93 +1,23 @@
-import logging
 from typing import Any
 
 from django.db import router, transaction
 
 from sentry.models.project import Project
-from sentry.models.rule import Rule
-from sentry.notifications.types import FallthroughChoiceType
-from sentry.signals import alert_rule_created, project_created
-from sentry.users.services.user.model import RpcUser
+from sentry.signals import project_created
 from sentry.workflow_engine.defaults.workflows import ensure_default_workflows
-from sentry.workflow_engine.models import AlertRuleWorkflow
-
-logger = logging.getLogger("sentry")
-
-DEFAULT_RULE_LABEL = "Send a notification for high priority issues"
-DEFAULT_RULE_ACTIONS = [
-    {
-        "id": "sentry.mail.actions.NotifyEmailAction",
-        "targetType": "IssueOwners",
-        "targetIdentifier": None,
-        "fallthroughType": FallthroughChoiceType.ACTIVE_MEMBERS.value,
-    }
-]
-DEFAULT_RULE_DATA = {
-    "action_match": "any",
-    "conditions": [
-        {"id": "sentry.rules.conditions.high_priority_issue.NewHighPriorityIssueCondition"},
-        {"id": "sentry.rules.conditions.high_priority_issue.ExistingHighPriorityIssueCondition"},
-    ],
-    "actions": DEFAULT_RULE_ACTIONS,
-}
-
-
-# TODO(snigdha): Remove this constant when seer-based-priority is GA
-PLATFORMS_WITH_PRIORITY_ALERTS = ["python", "javascript"]
+from sentry.workflow_engine.models import Workflow
 
 
 def create_default_workflows(
     project: Project,
     default_rules: bool = True,
-    RuleModel: type[Rule] = Rule,
     **kwargs: Any,
 ) -> None:
-    rule_data = DEFAULT_RULE_DATA
-
     if not default_rules:
         return
 
-    with transaction.atomic(router.db_for_write(RuleModel)):
-        workflows = ensure_default_workflows(project)
-
-        # TODO - we can remove the legacy code below once
-        # we launch the new UI (and stop referencing legacy models)
-        rule = RuleModel.objects.create(
-            project=project,
-            label=DEFAULT_RULE_LABEL,
-            data=rule_data,
-        )
-
-        legacy_references = [
-            AlertRuleWorkflow(
-                rule_id=rule.id,
-                workflow=workflow,
-            )
-            for workflow in workflows
-        ]
-
-        AlertRuleWorkflow.objects.bulk_create(legacy_references)
-
-    try:
-        user: RpcUser = project.organization.get_default_owner()
-    except IndexError:
-        logger.warning(
-            "Cannot record default rule created for organization (%s) due to missing owners",
-            project.organization_id,
-        )
-        return
-
-    # When a user creates a new project and opts to set up an issue alert within it,
-    # the corresponding task in the quick start sidebar is automatically marked as complete.
-    alert_rule_created.send_robust(
-        user=user,
-        project=project,
-        rule_id=rule.id,
-        # The default rule created within a new project is always of type 'issue'
-        rule_type="issue",
-        sender=type(project),
-        is_api_token=False,
-    )
+    with transaction.atomic(router.db_for_write(Workflow)):
+        ensure_default_workflows(project)
 
 
 project_created.connect(

--- a/tests/acceptance/test_scm_onboarding.py
+++ b/tests/acceptance/test_scm_onboarding.py
@@ -14,6 +14,8 @@ from sentry.testutils.asserts import assert_existing_projects_status
 from sentry.testutils.cases import AcceptanceTestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import no_silo_test
+from sentry.workflow_engine.defaults.workflows import DEFAULT_WORKFLOW_LABEL
+from sentry.workflow_engine.models import Workflow
 
 pytestmark = pytest.mark.sentry_metrics
 
@@ -555,7 +557,10 @@ class ScmOnboardingTest(AcceptanceTestCase):
             project = Project.objects.get(organization=self.org)
             assert project.platform == "javascript-react"
             assert project.slug == "javascript-react"
-            assert Rule.objects.filter(project=project).count() == 1
+            assert not Rule.objects.filter(project=project).exists()
+            assert Workflow.objects.filter(
+                organization=project.organization, name=DEFAULT_WORKFLOW_LABEL
+            ).exists()
             assert_existing_projects_status(
                 self.org, active_project_ids=[project.id], deleted_project_ids=[]
             )

--- a/tests/sentry/api/endpoints/test_project_rule_task_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_task_details.py
@@ -11,7 +11,7 @@ class ProjectRuleTaskDetailsTest(APITestCase):
         super().setUp()
         self.login_as(user=self.user)
         self.project = self.create_project(fire_project_created=True)
-        self.rule = self.project.rule_set.order_by("id")[0]
+        self.rule = self.create_project_rule(project=self.project)
         self.uuid = uuid4().hex
 
     @patch("sentry.integrations.slack.utils.rule_status.RedisRuleStatus.get_value")

--- a/tests/sentry/core/endpoints/test_organization_projects_create.py
+++ b/tests/sentry/core/endpoints/test_organization_projects_create.py
@@ -17,6 +17,8 @@ from sentry.models.team import Team
 from sentry.signals import project_created
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.features import with_feature
+from sentry.workflow_engine.defaults.workflows import DEFAULT_WORKFLOW_LABEL
+from sentry.workflow_engine.models import Workflow
 
 
 class OrganizationProjectsCreateTest(APITestCase):
@@ -188,7 +190,10 @@ class OrganizationProjectsCreateTest(APITestCase):
         assert project.name == project.slug == self.p1
         assert project.slug
 
-        assert Rule.objects.filter(project=project).exists()
+        assert not Rule.objects.filter(project=project).exists()
+        assert Workflow.objects.filter(
+            organization=project.organization, name=DEFAULT_WORKFLOW_LABEL
+        ).exists()
 
     @with_feature(["organizations:team-roles"])
     def test_without_default_rules(self) -> None:

--- a/tests/sentry/core/endpoints/test_project_details.py
+++ b/tests/sentry/core/endpoints/test_project_details.py
@@ -1468,7 +1468,6 @@ class CopyProjectSettingsTest(APITestCase):
         self.create_project_rule(project=self.other_project, name="rule1")
         self.create_project_rule(project=self.other_project, name="rule2")
         self.create_project_rule(project=self.other_project, name="rule3")
-        # there is a default rule added to project
         self.rules = Rule.objects.filter(project_id=self.other_project.id).order_by("label")
 
     def assert_other_project_settings_not_changed(self):
@@ -1507,10 +1506,8 @@ class CopyProjectSettingsTest(APITestCase):
 
         assert not ProjectOwnership.objects.filter(project_id=project.id).exists()
 
-        # default rule
-        rules = Rule.objects.filter(project_id=project.id)
-        assert len(rules) == 1
-        assert rules[0].label == "Send a notification for high priority issues"
+        # project creation creates a default workflow, not a rule
+        assert not Rule.objects.filter(project_id=project.id).exists()
 
     def test_simple(self) -> None:
         project = self.create_project()

--- a/tests/sentry/core/endpoints/test_team_projects.py
+++ b/tests/sentry/core/endpoints/test_team_projects.py
@@ -6,11 +6,12 @@ from sentry.ingest import inbound_filters
 from sentry.models.options.project_option import ProjectOption
 from sentry.models.project import Project
 from sentry.models.rule import Rule
-from sentry.notifications.types import FallthroughChoiceType
 from sentry.signals import alert_rule_created, project_created
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.options import override_options
 from sentry.utils.slug import DEFAULT_SLUG_ERROR_MESSAGE
+from sentry.workflow_engine.defaults.workflows import DEFAULT_WORKFLOW_LABEL
+from sentry.workflow_engine.models import Workflow
 
 
 class TeamProjectsListTest(APITestCase):
@@ -135,15 +136,14 @@ class TeamProjectsCreateTest(APITestCase, TestCase):
         )
 
         project = Project.objects.get(id=response.data["id"])
-        rule = Rule.objects.get(project=project)
+        assert not Rule.objects.filter(project=project).exists()
+        assert Workflow.objects.filter(
+            organization=project.organization, name=DEFAULT_WORKFLOW_LABEL
+        ).exists()
 
-        assert (
-            rule.data["actions"][0]["fallthroughType"] == FallthroughChoiceType.ACTIVE_MEMBERS.value
-        )
-
-        # Ensure that creating the default alert rule does trigger the
+        # Ensure that creating the default workflow does not trigger the
         # alert_rule_created signal
-        assert signal_handler.call_count == 1
+        assert signal_handler.call_count == 0
         alert_rule_created.disconnect(signal_handler)
 
     def test_without_default_rules_disable_member_project_creation(self) -> None:

--- a/tests/sentry/digests/backends/test_redis.py
+++ b/tests/sentry/digests/backends/test_redis.py
@@ -18,7 +18,7 @@ class RedisBackendTestCase(TestCase):
 
     @cached_property
     def notification(self) -> Notification:
-        rule = self.event.project.rule_set.all().order_by("id")[0]
+        rule = self.create_project_rule(project=self.project)
         return Notification(self.event, (rule.id,), str(uuid.uuid4()))
 
     def test_basic(self) -> None:

--- a/tests/sentry/digests/test_notifications.py
+++ b/tests/sentry/digests/test_notifications.py
@@ -32,8 +32,7 @@ class BindRecordsTestCase(TestCase):
 
     @cached_property
     def rule(self) -> Rule:
-        rule = self.event.project.rule_set.all().order_by("id")[0]
-        rule.data["actions"][0]["legacy_rule_id"] = rule.id
+        rule = self.create_project_rule(project=self.project)
         rule.save()
         return rule
 
@@ -72,7 +71,7 @@ class GroupRecordsTestCase(TestCase):
 
     @cached_property
     def rule(self) -> Rule:
-        return self.project.rule_set.all().order_by("id")[0]
+        return self.create_project_rule(project=self.project)
 
     def test_success(self) -> None:
         events = [
@@ -99,7 +98,15 @@ class SortDigestTestCase(TestCase):
         return self.create_project(fire_project_created=True)
 
     def test_success(self) -> None:
-        self.create_project_rule(
+        first_rule = self.create_project_rule(
+            project=self.project,
+            name="Send a notification for new issues",
+            condition_data=[
+                {"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"}
+            ],
+            action_data=[{"id": "sentry.rules.actions.notify_event.NotifyEventAction"}],
+        )
+        second_rule = self.create_project_rule(
             project=self.project,
             name="Send a notification for regressions",
             condition_data=[
@@ -108,7 +115,7 @@ class SortDigestTestCase(TestCase):
             action_data=[{"id": "sentry.rules.actions.notify_event.NotifyEventAction"}],
         )
 
-        rules = list(self.project.rule_set.all())
+        rules = [first_rule, second_rule]
         groups = [self.create_group() for _ in range(3)]
 
         event_counts = {groups[0].id: 10, groups[1].id: 5, groups[2].id: 5}

--- a/tests/sentry/digests/test_utilities.py
+++ b/tests/sentry/digests/test_utilities.py
@@ -38,7 +38,7 @@ def _get_records(project: Project, rules: Collection[RuleModel], event: Event) -
 class UtilitiesHelpersTestCase(TestCase, SnubaTestCase):
     def test_get_event_from_groups_in_digest(self) -> None:
         project = self.create_project(fire_project_created=True)
-        rule = project.rule_set.all().order_by("id")[0]
+        rule = self.create_project_rule(project=project)
 
         events = [
             self.store_event(

--- a/tests/sentry/integrations/slack/tasks/test_tasks.py
+++ b/tests/sentry/integrations/slack/tasks/test_tasks.py
@@ -19,7 +19,6 @@ from sentry.models.rule import Rule
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import install_slack
 from sentry.testutils.skips import requires_snuba
-from sentry.workflow_engine.receivers.project_workflows import DEFAULT_RULE_LABEL
 from tests.sentry.integrations.slack.utils.test_mock_slack_response import mock_slack_response
 
 pytestmark = [requires_snuba]
@@ -100,7 +99,7 @@ class SlackTasksTest(TestCase):
         with self.tasks():
             find_channel_id_for_rule(**data)
 
-        rule = Rule.objects.exclude(label__in=[DEFAULT_RULE_LABEL]).get(project_id=self.project.id)
+        rule = Rule.objects.get(project_id=self.project.id)
         mock_set_value.assert_called_with("success", rule.id)
         assert rule.label == "New Rule"
         # check that the channel_id got added
@@ -144,7 +143,7 @@ class SlackTasksTest(TestCase):
         with self.tasks():
             find_channel_id_for_rule(**data)
 
-        rule = Rule.objects.exclude(label__in=[DEFAULT_RULE_LABEL]).get(project_id=self.project.id)
+        rule = Rule.objects.get(project_id=self.project.id)
         mock_set_value.assert_called_with("success", rule.id)
         assert rule.label == "New Rule"
         # check that the channel_id got added
@@ -192,9 +191,7 @@ class SlackTasksTest(TestCase):
         with self.tasks():
             find_channel_id_for_rule(**data)
 
-        rule = Rule.objects.exclude(label__in=[DEFAULT_RULE_LABEL]).get(
-            project_id=self.project.id,
-        )
+        rule = Rule.objects.get(project_id=self.project.id)
         mock_set_value.assert_called_with("success", rule.id)
         assert rule.label == "New Rule with Owner"
         assert rule.owner_team_id == team.id

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -1374,7 +1374,7 @@ class MailAdapterNotifyDigestTest(BaseMailAdapterTest, ReplaysSnubaTestCase):
             project_id=project.id,
         )
 
-        rule = project.rule_set.all().order_by("id")[0]
+        rule = self.create_project_rule(project=project)
         ProjectOwnership.objects.create(project_id=self.project.id, fallthrough=True)
         digest = build_digest(
             project, (event_to_record(event, (rule,)), event_to_record(event2, (rule,)))
@@ -1430,7 +1430,7 @@ class MailAdapterNotifyDigestTest(BaseMailAdapterTest, ReplaysSnubaTestCase):
             )
         )
 
-        rule = project.rule_set.all().order_by("id")[0]
+        rule = self.create_project_rule(project=project)
         ProjectOwnership.objects.create(project_id=self.project.id, fallthrough=True)
         digest = build_digest(
             project, (event_to_record(event, (rule,)), event_to_record(event2, (rule,)))
@@ -1458,7 +1458,7 @@ class MailAdapterNotifyDigestTest(BaseMailAdapterTest, ReplaysSnubaTestCase):
     @mock.patch.object(MessageBuilder, "send_async", autospec=True)
     def test_notify_digest_single_record(self, send_async: MagicMock, notify: MagicMock) -> None:
         event = self.store_event(data={}, project_id=self.project.id)
-        rule = self.project.rule_set.all().order_by("id")[0]
+        rule = self.create_project_rule(project=self.project)
         ProjectOwnership.objects.create(project_id=self.project.id, fallthrough=True)
         digest = build_digest(self.project, (event_to_record(event, (rule,)),))
         self.adapter.notify_digest(
@@ -1485,7 +1485,7 @@ class MailAdapterNotifyDigestTest(BaseMailAdapterTest, ReplaysSnubaTestCase):
             project_id=self.project.id,
         )
 
-        rule = self.project.rule_set.all().order_by("id")[0]
+        rule = self.create_project_rule(project=self.project)
 
         digest = build_digest(
             self.project, (event_to_record(event, (rule,)), event_to_record(event2, (rule,)))

--- a/tests/sentry/models/test_project.py
+++ b/tests/sentry/models/test_project.py
@@ -1033,7 +1033,6 @@ class CopyProjectSettingsTest(TestCase):
         project.update_option("sentry:resolve_age", 200)
         ProjectTeam.objects.create(team=self.create_team(), project=project)
         self.create_environment(project=project)
-        Rule.objects.filter(project_id=project.id).order_by("id")[0]
 
         assert project.copy_settings_from(self.other_project.id)
         self.assert_settings_copied(project)

--- a/tests/sentry/receivers/test_featureadoption.py
+++ b/tests/sentry/receivers/test_featureadoption.py
@@ -20,7 +20,6 @@ from sentry.signals import (
     user_feedback_received,
 )
 from sentry.testutils.cases import SnubaTestCase, TestCase
-from sentry.workflow_engine.receivers.project_workflows import DEFAULT_RULE_DATA
 
 
 class FeatureAdoptionTest(TestCase, SnubaTestCase):
@@ -526,7 +525,24 @@ class FeatureAdoptionTest(TestCase, SnubaTestCase):
 
     def test_alert_rules(self) -> None:
         rule = Rule.objects.create(
-            project=self.project, label="Trivially modified rule", data=DEFAULT_RULE_DATA
+            project=self.project,
+            label="Trivially modified rule",
+            data={
+                "action_match": "any",
+                "conditions": [
+                    {
+                        "id": "sentry.rules.conditions.high_priority_issue.NewHighPriorityIssueCondition"
+                    },
+                ],
+                "actions": [
+                    {
+                        "id": "sentry.mail.actions.NotifyEmailAction",
+                        "targetType": "IssueOwners",
+                        "targetIdentifier": None,
+                        "fallthroughType": "ActiveMembers",
+                    }
+                ],
+            },
         )
 
         alert_rule_created.send(

--- a/tests/sentry/receivers/test_onboarding.py
+++ b/tests/sentry/receivers/test_onboarding.py
@@ -167,7 +167,6 @@ class OrganizationOnboardingTaskTest(TestCase):
     def test_project_created__default_workflow(self) -> None:
         project = self.create_project(fire_project_created=True)
 
-        assert Rule.objects.filter(project=project).exists()
         workflow = Workflow.objects.get(
             organization=project.organization,
             name=DEFAULT_WORKFLOW_LABEL,
@@ -867,34 +866,6 @@ class OrganizationOnboardingTaskTest(TestCase):
         )
         assert task is not None
 
-    def test_issue_alert_received_through_project_creation(self) -> None:
-        now = timezone.now()
-
-        first_organization = self.create_organization(owner=self.user, slug="first-org")
-        first_project = self.create_project(first_event=now, organization=first_organization)
-        # By default, the project creation will create a default rule
-        project_created.send(project=first_project, user=self.user, sender=None)
-        assert OrganizationOnboardingTask.objects.filter(
-            organization=first_project.organization,
-            task=OnboardingTask.ALERT_RULE,
-            status=OnboardingTaskStatus.COMPLETE,
-        ).exists()
-
-        second_organization = self.create_organization(owner=self.user, slug="second-org")
-        second_project = self.create_project(first_event=now, organization=second_organization)
-        # When creating a project, a user can opt out of creating a default rule
-        project_created.send(
-            project=second_project,
-            user=self.user,
-            sender=None,
-            default_rules=False,
-        )
-        assert not OrganizationOnboardingTask.objects.filter(
-            organization=second_project.organization,
-            task=OnboardingTask.ALERT_RULE,
-            status=OnboardingTaskStatus.COMPLETE,
-        ).exists()
-
     @patch("sentry.analytics.record", wraps=record)
     def test_new_onboarding_complete(self, record_analytics: MagicMock) -> None:
         """
@@ -1201,6 +1172,16 @@ class OrganizationOnboardingTaskTest(TestCase):
         project = self.create_project(platform="javascript")
         project_created.send(project=project, user=self.user, sender=None)
 
+        # project creation no longer creates a default alert, so create one explicitly
+        alert_rule_created.send(
+            rule_id=Rule(id=1).id,
+            project=project,
+            user=self.user,
+            rule_type="issue",
+            sender=None,
+            is_api_token=False,
+        )
+
         # Capture first transaction + release
         transaction_event = load_data("transaction")
         transaction_event.update({"release": "my-first-release", "tags": []})
@@ -1361,6 +1342,16 @@ class OrganizationOnboardingTaskTest(TestCase):
 
         project = self.create_project(platform="python")
         project_created.send(project=project, user=self.user, default_rules=True, sender=None)
+
+        # project creation no longer creates a default alert, so create one explicitly
+        alert_rule_created.send(
+            rule_id=Rule(id=1).id,
+            project=project,
+            user=self.user,
+            rule_type="issue",
+            sender=None,
+            is_api_token=False,
+        )
 
         transaction_event = load_data("transaction")
         transaction_event.update({"user": None, "release": "my-first-release", "tags": []})


### PR DESCRIPTION
We no longer need to be creating a `Rule` when a new project is created. Remove all of the receiver code for that.