### PR TITLE
fix(refactor-tasks): Add -w to pnpm add in no-derived-state detector

### DIFF
--- a/.sentry-refactor-tasks/conventions/no-derived-state.detect.sh
+++ b/.sentry-refactor-tasks/conventions/no-derived-state.detect.sh
@@ -44,7 +44,7 @@ trap cleanup EXIT
 # Bring up the repo's toolchain, then pin the plugin to the version this
 # convention's detection depends on — independent of the repo's own lockfile.
 pnpm install --frozen-lockfile 1>&2
-pnpm add -D eslint-plugin-react-you-might-not-need-an-effect@1.0.1 1>&2
+pnpm add -D -w eslint-plugin-react-you-might-not-need-an-effect@1.0.1 1>&2
 
 # Write a standalone flat config that loads only this rule. Bypassing the
 # repo's own eslint.config avoids failures from rule names that differ between


### PR DESCRIPTION
`no-derived-state` and `no-effect-set-state` have been failing on every
`refactor-tasks.yml` run: `no-derived-state.detect.sh` calls
`pnpm add -D eslint-plugin-react-you-might-not-need-an-effect@1.0.1` at the
repo root, and pnpm 10.30.2 rejects that without an explicit `-w` since
sentry is a pnpm workspace (`ERR_PNPM_ADDING_TO_ROOT`). The script's
`set -euo pipefail` then kills it before eslint ever runs, leaving stdout
empty — which `@sentry/refactor-tasks` 0.2.0 now correctly reports as a
scan failure instead of silently logging 0 violations.

`no-effect-set-state.detect_command` reuses this script as its
`excluded_detector` (to dedupe overlapping findings), so it fails identically
as a cascade of the same root cause, not a separate bug.

Fix: add `-w` to the `pnpm add` call. Verified locally against this checkout
with pnpm 10.30.2 — the command now exits 0 instead of `ERR_PNPM_ADDING_TO_ROOT`.
