### PR TITLE
fix(replays): Keep issue toggles enabled after save

### DIFF
--- a/static/app/views/settings/project/projectReplays.spec.tsx
+++ b/static/app/views/settings/project/projectReplays.spec.tsx
@@ -28,6 +28,11 @@ describe('ProjectReplays', () => {
       method: 'GET',
       body: [],
     });
+    MockApiClient.addMockResponse({
+      url: getProjectEndpoint,
+      method: 'GET',
+      body: project,
+    });
   });
 
   it('renders the bulk delete tab when the user has write access', async () => {
@@ -94,15 +99,25 @@ describe('ProjectReplays', () => {
       initialRouterConfig,
     });
 
+    const updatedProject = {
+      ...project,
+      options: {...project.options, 'sentry:replay_rage_click_issues': true},
+    };
     const mock = MockApiClient.addMockResponse({
       url: getProjectEndpoint,
       method: 'PUT',
-      body: {},
+      body: updatedProject,
     });
 
-    await userEvent.click(
-      await screen.findByRole('checkbox', {name: 'Create Rage Click Issues'})
-    );
+    const checkbox = await screen.findByRole('checkbox', {
+      name: 'Create Rage Click Issues',
+    });
+    MockApiClient.addMockResponse({
+      url: getProjectEndpoint,
+      method: 'GET',
+      body: updatedProject,
+    });
+    await userEvent.click(checkbox);
 
     await waitFor(() =>
       expect(mock).toHaveBeenCalledWith(
@@ -115,6 +130,8 @@ describe('ProjectReplays', () => {
         })
       )
     );
+    await waitFor(() => expect(checkbox).toBeEnabled());
+    expect(checkbox).toBeChecked();
   });
 
   it('can toggle hydration error issue creation', async () => {
@@ -124,15 +141,25 @@ describe('ProjectReplays', () => {
       initialRouterConfig,
     });
 
+    const updatedProject = {
+      ...project,
+      options: {...project.options, 'sentry:replay_hydration_error_issues': true},
+    };
     const mock = MockApiClient.addMockResponse({
       url: getProjectEndpoint,
       method: 'PUT',
-      body: {},
+      body: updatedProject,
     });
 
-    await userEvent.click(
-      await screen.findByRole('checkbox', {name: 'Create Hydration Error Issues'})
-    );
+    const checkbox = await screen.findByRole('checkbox', {
+      name: 'Create Hydration Error Issues',
+    });
+    MockApiClient.addMockResponse({
+      url: getProjectEndpoint,
+      method: 'GET',
+      body: updatedProject,
+    });
+    await userEvent.click(checkbox);
 
     await waitFor(() =>
       expect(mock).toHaveBeenCalledWith(
@@ -145,5 +172,7 @@ describe('ProjectReplays', () => {
         })
       )
     );
+    await waitFor(() => expect(checkbox).toBeEnabled());
+    expect(checkbox).toBeChecked();
   });
 });

--- a/static/app/views/settings/project/projectReplays.tsx
+++ b/static/app/views/settings/project/projectReplays.tsx
@@ -11,9 +11,8 @@ import {OverrideOrDefault} from 'sentry/components/overrideOrDefault';
 import {ReplayBulkDeleteAuditLog} from 'sentry/components/replays/bulkDelete/replayBulkDeleteAuditLog';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
-import {ProjectsStore} from 'sentry/stores/projectsStore';
-import type {Project} from 'sentry/types/project';
-import {fetchMutation} from 'sentry/utils/queryClient';
+import {useDetailedProject} from 'sentry/utils/project/useDetailedProject';
+import {useUpdateProject} from 'sentry/utils/project/useUpdateProject';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 import {ProjectPermissionAlert} from 'sentry/views/settings/project/projectPermissionAlert';
@@ -33,21 +32,19 @@ const ReplaySettingsAlert = OverrideOrDefault({
 
 export default function ProjectReplaySettings() {
   const organization = useOrganization();
-  const {project} = useProjectSettingsOutlet();
+  const {project: outletProject} = useProjectSettingsOutlet();
+  const {data: project = outletProject} = useDetailedProject({
+    orgSlug: organization.slug,
+    projectSlug: outletProject.slug,
+  });
+  const updateProject = useUpdateProject(project);
   const hasWriteAccess = hasEveryAccess(['project:write'], {organization, project});
   const hasAdminAccess = hasEveryAccess(['project:admin'], {organization, project});
   const hasAccess = hasWriteAccess || hasAdminAccess;
 
-  const projectEndpoint = `/projects/${organization.slug}/${project.slug}/`;
-
   const mutationOptions = {
     mutationFn: (data: Partial<ReplaySchema>) =>
-      fetchMutation<Project>({
-        url: projectEndpoint,
-        method: 'PUT',
-        data: {options: data},
-      }),
-    onSuccess: (response: Project) => ProjectsStore.onUpdateSuccess(response),
+      updateProject.mutateAsync({options: data}),
   };
 
   const [tab, setTab] = useQueryState(

--- a/static/app/views/settings/project/projectReplays.tsx
+++ b/static/app/views/settings/project/projectReplays.tsx
@@ -12,23 +12,18 @@ import {ReplayBulkDeleteAuditLog} from 'sentry/components/replays/bulkDelete/rep
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
 import {useDetailedProject} from 'sentry/utils/project/useDetailedProject';
-import {useUpdateProjectMutationOptions} from 'sentry/utils/project/useUpdateProject';
+import {useUpdateProject} from 'sentry/utils/project/useUpdateProject';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 import {ProjectPermissionAlert} from 'sentry/views/settings/project/projectPermissionAlert';
 import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSettingsLayout';
 
-const rageClickSchema = z.object({
-  options: z.boolean().transform(value => ({
-    'sentry:replay_rage_click_issues': value,
-  })),
+const replaySchema = z.object({
+  'sentry:replay_rage_click_issues': z.boolean(),
+  'sentry:replay_hydration_error_issues': z.boolean(),
 });
 
-const hydrationErrorSchema = z.object({
-  options: z.boolean().transform(value => ({
-    'sentry:replay_hydration_error_issues': value,
-  })),
-});
+type ReplaySchema = z.infer<typeof replaySchema>;
 
 const ReplaySettingsAlert = OverrideOrDefault({
   overrideName: 'component:replay-settings-alert',
@@ -42,10 +37,15 @@ export default function ProjectReplaySettings() {
     orgSlug: organization.slug,
     projectSlug: outletProject.slug,
   });
-  const projectMutationOptions = useUpdateProjectMutationOptions(project);
+  const updateProject = useUpdateProject(project);
   const hasWriteAccess = hasEveryAccess(['project:write'], {organization, project});
   const hasAdminAccess = hasEveryAccess(['project:admin'], {organization, project});
   const hasAccess = hasWriteAccess || hasAdminAccess;
+
+  const mutationOptions = {
+    mutationFn: (data: Partial<ReplaySchema>) =>
+      updateProject.mutateAsync({options: data}),
+  };
 
   const [tab, setTab] = useQueryState(
     'replaySettingsTab',
@@ -75,10 +75,10 @@ export default function ProjectReplaySettings() {
 
               <FieldGroup title={t('Replay Issues')}>
                 <AutoSaveForm
-                  name="options"
-                  schema={rageClickSchema}
+                  name="sentry:replay_rage_click_issues"
+                  schema={replaySchema}
                   initialValue={!!project.options?.['sentry:replay_rage_click_issues']}
-                  mutationOptions={projectMutationOptions}
+                  mutationOptions={mutationOptions}
                 >
                   {field => (
                     <field.Layout.Row
@@ -97,12 +97,12 @@ export default function ProjectReplaySettings() {
                 </AutoSaveForm>
 
                 <AutoSaveForm
-                  name="options"
-                  schema={hydrationErrorSchema}
+                  name="sentry:replay_hydration_error_issues"
+                  schema={replaySchema}
                   initialValue={
                     !!project.options?.['sentry:replay_hydration_error_issues']
                   }
-                  mutationOptions={projectMutationOptions}
+                  mutationOptions={mutationOptions}
                 >
                   {field => (
                     <field.Layout.Row

--- a/static/app/views/settings/project/projectReplays.tsx
+++ b/static/app/views/settings/project/projectReplays.tsx
@@ -12,18 +12,23 @@ import {ReplayBulkDeleteAuditLog} from 'sentry/components/replays/bulkDelete/rep
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
 import {useDetailedProject} from 'sentry/utils/project/useDetailedProject';
-import {useUpdateProject} from 'sentry/utils/project/useUpdateProject';
+import {useUpdateProjectMutationOptions} from 'sentry/utils/project/useUpdateProject';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 import {ProjectPermissionAlert} from 'sentry/views/settings/project/projectPermissionAlert';
 import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSettingsLayout';
 
-const replaySchema = z.object({
-  'sentry:replay_rage_click_issues': z.boolean(),
-  'sentry:replay_hydration_error_issues': z.boolean(),
+const rageClickSchema = z.object({
+  options: z.boolean().transform(value => ({
+    'sentry:replay_rage_click_issues': value,
+  })),
 });
 
-type ReplaySchema = z.infer<typeof replaySchema>;
+const hydrationErrorSchema = z.object({
+  options: z.boolean().transform(value => ({
+    'sentry:replay_hydration_error_issues': value,
+  })),
+});
 
 const ReplaySettingsAlert = OverrideOrDefault({
   overrideName: 'component:replay-settings-alert',
@@ -37,15 +42,10 @@ export default function ProjectReplaySettings() {
     orgSlug: organization.slug,
     projectSlug: outletProject.slug,
   });
-  const updateProject = useUpdateProject(project);
+  const projectMutationOptions = useUpdateProjectMutationOptions(project);
   const hasWriteAccess = hasEveryAccess(['project:write'], {organization, project});
   const hasAdminAccess = hasEveryAccess(['project:admin'], {organization, project});
   const hasAccess = hasWriteAccess || hasAdminAccess;
-
-  const mutationOptions = {
-    mutationFn: (data: Partial<ReplaySchema>) =>
-      updateProject.mutateAsync({options: data}),
-  };
 
   const [tab, setTab] = useQueryState(
     'replaySettingsTab',
@@ -75,10 +75,10 @@ export default function ProjectReplaySettings() {
 
               <FieldGroup title={t('Replay Issues')}>
                 <AutoSaveForm
-                  name="sentry:replay_rage_click_issues"
-                  schema={replaySchema}
+                  name="options"
+                  schema={rageClickSchema}
                   initialValue={!!project.options?.['sentry:replay_rage_click_issues']}
-                  mutationOptions={mutationOptions}
+                  mutationOptions={projectMutationOptions}
                 >
                   {field => (
                     <field.Layout.Row
@@ -97,12 +97,12 @@ export default function ProjectReplaySettings() {
                 </AutoSaveForm>
 
                 <AutoSaveForm
-                  name="sentry:replay_hydration_error_issues"
-                  schema={replaySchema}
+                  name="options"
+                  schema={hydrationErrorSchema}
                   initialValue={
                     !!project.options?.['sentry:replay_hydration_error_issues']
                   }
-                  mutationOptions={mutationOptions}
+                  mutationOptions={projectMutationOptions}
                 >
                   {field => (
                     <field.Layout.Row


### PR DESCRIPTION
The replay issue switches flipped back when their saves finished even though the settings persisted.

Use the shared project update path so both switches keep their saved state.