### PR TITLE
ref(replays): Remove unused bulk delete job chunk size option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -511,13 +511,6 @@ register(
     default=0.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
-# Chunk size for bulk delete job
-register(
-    "replay.bulk_delete_job.chunk_size_days",
-    default=7,
-    type=Int,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # User Feedback Options
 register(


### PR DESCRIPTION
The option was introduced when the Replay bulk deletion job chunked its range into configurable N-day windows (#120456). The job was later reworked to *always* window by UTC day — `day_aligned_windows()` in `src/sentry/replays/usecases/delete.py` — and the `options.get()` read was dropped in #121372

Refs [REPLAY-986](https://linear.app/getsentry/issue/REPLAY-986)