### PR TITLE
fix(seer): Only show autofix UI for free cohort issues with existing runs

### DIFF
--- a/src/sentry/seer/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/seer/endpoints/group_autofix_setup_check.py
@@ -104,7 +104,13 @@ class GroupAutofixSetupCheck(GroupAiEndpoint):
         # when an autofix run already exists for this group, which renders
         # the results UI. Otherwise False, which renders the paywall.
         if is_free_cohort_org(org):
-            has_autofix_quota = runs_for_group(group.id, "autofix").exists()
+            # Night shift can go through either the regular autofix path
+            # (source="autofix") or the RCA feature path (source="autofix_rca")
+            # depending on the organizations:autofix-rca-in-seer flag.
+            has_autofix_quota = (
+                runs_for_group(group.id, "autofix").exists()
+                or runs_for_group(group.id, "autofix_rca").exists()
+            )
         else:
             has_autofix_quota = quotas.backend.check_seer_quota(
                 org_id=org.id, data_category=DataCategory.SEER_AUTOFIX

--- a/src/sentry/seer/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/seer/endpoints/group_autofix_setup_check.py
@@ -23,6 +23,7 @@ from sentry.seer.autofix.utils import (
     is_free_cohort_org,
 )
 from sentry.seer.seer_setup import get_supported_scm_providers
+from sentry.seer.utils import runs_for_group
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
@@ -95,10 +96,15 @@ class GroupAutofixSetupCheck(GroupAiEndpoint):
                 organization=org, project=group.project
             )
 
-        # Free cohort orgs have no subscription so check_seer_quota returns False.
-        # Bypass the check so they see the autofix UI.
+        # Free cohort orgs have no Seer subscription, so check_seer_quota
+        # always returns False. We want them to see autofix results when
+        # night shift has already processed the issue, but NOT show the
+        # "Start Analysis" button for issues night shift skipped — manual
+        # triggers would fail with a quota error. So we return True only
+        # when an autofix run already exists for this group, which renders
+        # the results UI. Otherwise False, which renders the paywall.
         if is_free_cohort_org(org):
-            has_autofix_quota = True
+            has_autofix_quota = runs_for_group(group.id, "autofix").exists()
         else:
             has_autofix_quota = quotas.backend.check_seer_quota(
                 org_id=org.id, data_category=DataCategory.SEER_AUTOFIX

--- a/tests/sentry/seer/endpoints/test_group_autofix_setup_check.py
+++ b/tests/sentry/seer/endpoints/test_group_autofix_setup_check.py
@@ -297,15 +297,36 @@ class GroupAIAutofixSetupFreeCohortTest(APITestCase, SnubaTestCase):
         "sentry.seer.endpoints.group_autofix_setup_check.is_free_cohort_org",
         return_value=True,
     )
-    def test_free_cohort_org_has_autofix_quota(self, mock_is_free_cohort: MagicMock) -> None:
-        """Free cohort orgs bypass check_seer_quota and get hasAutofixQuota: True."""
+    def test_free_cohort_org_with_existing_run_has_autofix_quota(
+        self, mock_is_free_cohort: MagicMock
+    ) -> None:
+        """Free cohort orgs with an existing autofix run get hasAutofixQuota: True."""
         group = self.create_group()
+        run = self.create_seer_run(organization=self.organization)
+        self.create_seer_agent_run(run, source="autofix", group=group)
+
         self.login_as(user=self.user)
         url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/autofix/setup/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200
         assert response.data["billing"]["hasAutofixQuota"] is True
+
+    @patch(
+        "sentry.seer.endpoints.group_autofix_setup_check.is_free_cohort_org",
+        return_value=True,
+    )
+    def test_free_cohort_org_without_existing_run_has_no_autofix_quota(
+        self, mock_is_free_cohort: MagicMock
+    ) -> None:
+        """Free cohort orgs without an existing autofix run get hasAutofixQuota: False."""
+        group = self.create_group()
+        self.login_as(user=self.user)
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/autofix/setup/"
+        response = self.client.get(url, format="json")
+
+        assert response.status_code == 200
+        assert response.data["billing"]["hasAutofixQuota"] is False
 
     @patch(
         "sentry.seer.endpoints.group_autofix_setup_check.is_free_cohort_org",


### PR DESCRIPTION
## Summary
Free cohort orgs have no Seer subscription, so `check_seer_quota` always returns `False`. PR #121848 returned `hasAutofixQuota: True` unconditionally for free cohort orgs so they could see autofix results from night shift. But for issues that night shift skipped (no autofix run exists), this showed a broken "Start Analysis" button — manual triggers fail with a quota error.

Now `hasAutofixQuota` returns `True` only when an autofix run already exists for the specific group (using `runs_for_group(group.id, "autofix").exists()`). Issues with night shift results show the autofix UI; skipped issues show the paywall.

## Test plan
- [x] `test_free_cohort_org_with_existing_run_has_autofix_quota` — group with autofix run gets `True`
- [x] `test_free_cohort_org_without_existing_run_has_no_autofix_quota` — group without run gets `False`
- [x] All 17 tests in `test_group_autofix_setup_check.py` pass