### PR TITLE
fix(onboarding): Link SCM providers to repository settings

### DIFF
--- a/static/app/components/onboarding/scm/scmIntegrationSelect.spec.tsx
+++ b/static/app/components/onboarding/scm/scmIntegrationSelect.spec.tsx
@@ -76,7 +76,7 @@ describe('ScmIntegrationSelect', () => {
     expect(onChange).toHaveBeenCalledWith(gitlabAcme);
   });
 
-  it('links the Manage providers footer to SCM integration settings', async () => {
+  it('links the Manage providers footer to repository settings', async () => {
     render(
       <ScmIntegrationSelect
         analyticsFlow="project-creation"
@@ -91,7 +91,7 @@ describe('ScmIntegrationSelect', () => {
 
     expect(await screen.findByRole('button', {name: 'Manage providers'})).toHaveAttribute(
       'href',
-      '/settings/org-slug/integrations/?category=source%20code%20management'
+      '/settings/org-slug/repos/'
     );
   });
 

--- a/static/app/components/onboarding/scm/scmIntegrationSelect.tsx
+++ b/static/app/components/onboarding/scm/scmIntegrationSelect.tsx
@@ -21,7 +21,7 @@ interface ScmIntegrationSelectProps {
  * Compact dropdown for choosing which connected SCM integration (provider plus
  * org/account) to search repositories within. The trigger shows the selected
  * integration's provider icon and name; the menu lists every active
- * integration and links out to integration settings via a "Manage providers"
+ * integration and links out to repository settings via a "Manage providers"
  * footer.
  */
 export function ScmIntegrationSelect({
@@ -63,7 +63,7 @@ export function ScmIntegrationSelect({
       menuFooter={({closeOverlay}) => (
         <MenuComponents.CTALinkButton
           icon={<IconSettings />}
-          to={`/settings/${organization.slug}/integrations/?category=source%20code%20management`}
+          to={`/settings/${organization.slug}/repos/`}
           onClick={() => {
             trackAnalytics('project_creation.manage_providers_clicked', {
               organization,


### PR DESCRIPTION
## TLDR

The SCM project-creation provider menu now sends users to Repository Settings.

## Details

Repository settings is better suited as the destination for the “Manage providers” button in `ScmIntegrationSelect` because you can configure providers & repos there as opposed to just providers (as would be the case in integration settings).

Session replays showed us people were confused by the lack of ability to configure repos in this scenario.

Fixes VDY-157
