### PR TITLE
ref(scm): Centralize PR -> Autofix run resolution

### DIFF
--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -43,6 +43,7 @@ from sentry.integrations.services.integration.model import (
 )
 from sentry.integrations.services.integration.service import integration_service
 from sentry.integrations.services.repository.service import repository_service
+from sentry.integrations.source_code_management.pr_id_cache import set_cached_pr_id
 from sentry.integrations.source_code_management.webhook import SCMWebhook
 from sentry.integrations.types import (
     ExternalActorSource,
@@ -1112,6 +1113,20 @@ class PullRequestEventWebhook(GitHubWebhook):
     ) -> None:
         pull_request = event["pull_request"]
         number = pull_request["number"]
+        # Warm the number -> id map while both are in hand. Payloads that carry
+        # only the number (issue_comment, notably) otherwise pay a REST call to
+        # recover the id. Never raises; a cache outage cannot affect the rest of
+        # this handler. GitHub Enterprise reaches this handler through the
+        # subclass in `github_enterprise.webhook`; passing `repo.provider` is
+        # what keeps its repos out of a cache that only github.com repo ids can
+        # be keyed on.
+        set_cached_pr_id(
+            provider=repo.provider,
+            repo_external_id=repo.external_id,
+            pr_number=number,
+            pr_id=pull_request["id"],
+        )
+
         title = pull_request["title"]
         body = pull_request["body"]
         user = pull_request["user"]

--- a/src/sentry/integrations/source_code_management/pr_id_cache.py
+++ b/src/sentry/integrations/source_code_management/pr_id_cache.py
@@ -66,6 +66,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 
+from sentry import options
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.utils import metrics
 from sentry.utils.cache import cache
@@ -97,12 +98,36 @@ _CACHE_KEY_VERSION = 1
 # key to an arm by a stable hash of the key itself, so an entry is always read
 # under the arm that wrote it, tag the counter with the arm, and compare hit
 # rates across what are then two identical populations.
-PR_ID_CACHE_TTL = 24 * 60 * 60
+#
+# The number itself lives with the registration in ``sentry.options.defaults``,
+# so it can be moved — or the cache switched off outright — without a deploy. It
+# is deliberately not mirrored here: a module constant that the option overrides
+# is a second source of truth that looks authoritative and changes nothing.
+PR_ID_CACHE_TTL_OPTION = "integrations.pr-id-cache.ttl"
 
 # github.com, whose repo ids are unique across every repository GitHub knows
 # about — which is what makes a key without any tenant scope safe. Every other
 # provider, GitHub Enterprise included, is not cached; see the module docstring.
 SUPPORTED_PROVIDER = f"integrations:{IntegrationProviderSlug.GITHUB.value}"
+
+
+def _cache_ttl() -> int | None:
+    """Seconds to keep an entry, or ``None`` to bypass the cache entirely.
+
+    Zero is the off switch, and it turns the cache off on *both* sides rather
+    than storing entries nothing will read: a lookup skips the read and every
+    caller goes back to paying the REST call it paid before this module existed.
+    That is a latency regression and never a correctness one, which is what makes
+    it safe to reach for from the automator mid-incident.
+
+    The question asked of the option is "is this a usable lifetime?", not "is
+    this zero": the options system has no way to declare a bound, so a negative
+    is registerable and settable. Reading it as off keeps that misconfiguration
+    equivalent to the off switch instead of handing the backend a write that is
+    already expired.
+    """
+    ttl = options.get(PR_ID_CACHE_TTL_OPTION)
+    return ttl if ttl > 0 else None
 
 
 def _cache_key(provider: str, repo_external_id: str, pr_number: int) -> str:
@@ -133,6 +158,14 @@ def get_cached_pr_id(
         metrics.incr(
             f"{_METRICS_KEY}.get", tags={"result": "unkeyable", "missing": "repo_external_id"}
         )
+        return None
+
+    # Last, so that the diagnostics above keep their meaning while the cache is
+    # off: `unkeyable` reports rows with nothing to key on, which is an upstream
+    # bug either way. `disabled` therefore counts exactly the lookups that would
+    # otherwise have gone to the backend.
+    if _cache_ttl() is None:
+        metrics.incr(f"{_METRICS_KEY}.get", tags={"result": "disabled"})
         return None
 
     key = _cache_key(provider, repo_external_id, pr_number)
@@ -189,10 +222,18 @@ def set_cached_pr_id(
         )
         return
 
+    # Both sides read the option, so switching it off stops new entries as well
+    # as reads. Entries already stored are left to expire under the TTL they were
+    # written with rather than being deleted.
+    ttl = _cache_ttl()
+    if ttl is None:
+        metrics.incr(f"{_METRICS_KEY}.set", tags={"result": "disabled"})
+        return
+
     key = _cache_key(provider, repo_external_id, pr_number)
 
     try:
-        cache.set(key, pr_id, PR_ID_CACHE_TTL)
+        cache.set(key, pr_id, ttl)
     except Exception:
         logger.exception("scm.pr_id_cache.set_failed", extra={"repo_external_id": repo_external_id})
         metrics.incr(f"{_METRICS_KEY}.set", tags={"result": "error"})

--- a/src/sentry/integrations/source_code_management/pr_id_cache.py
+++ b/src/sentry/integrations/source_code_management/pr_id_cache.py
@@ -1,0 +1,221 @@
+"""Cache of ``(GitHub repository, pull request number) -> GitHub pull request id``.
+
+Some GitHub payloads carry only a repo-scoped PR *number* while the lookups
+downstream are keyed on GitHub's global numeric PR *id*. The ``issue_comment``
+event — the one behind ``@sentry`` mentions — is the case that motivated this
+module: it describes the PR with URLs and a number only, so recovering the id
+costs a REST round-trip on every mention.
+
+The mapping is permanently immutable, which is what makes it cacheable at all:
+
+* a PR number is never reused within a repository;
+* a PR's global id never changes;
+* repository transfers and renames preserve the repo id, the PR numbers and the
+  PR ids.
+
+So there is no invalidation path and none is needed. The TTL below is purely a
+memory-versus-hit-rate tradeoff.
+
+Four things about the key are deliberate:
+
+**github.com is the only supported provider.** Not a limitation to lift later:
+the key's uniqueness rests on ``repo_external_id`` being unique within
+``provider``, and a self-hosted GitHub Enterprise instance hands out small,
+per-instance repo ids, so repo id ``1`` names a different repository on every
+host while the provider string is the same ``integrations:github_enterprise``
+for all of them. Caching those would be a cross-host id mix-up. GHE shares
+GitHub's webhook handlers, so it reaches this module and is turned away here
+rather than at each call site; PR iteration does not support GHE either (see
+``PR_ITERATION_PROVIDER`` in ``sentry.seer.autofix.pr_iteration.constants``).
+Nothing is lost by that: this is a latency optimization, so a repo that is not
+cached simply keeps paying the REST round-trip it already pays.
+
+**It is keyed on GitHub's repo id, never on ``owner/repo``.** Repository names
+are reusable — delete or rename a repo and someone else can take the name — so a
+name-keyed entry can silently start pointing at a different repository's PR.
+GitHub repo ids are never reused.
+
+**A repo missing half of the key is skipped, and counted.**
+``Repository.provider`` and ``Repository.external_id`` are both nullable
+columns, so a caller holding a ``Repository`` cannot promise us either one. Such
+a row has nothing that identifies it to GitHub, and keying on the empty value
+would collide every such repo onto a single entry — so those lookups skip the
+cache and keep paying the REST call. They are counted as ``result:unkeyable``,
+tagged ``missing`` with the column at fault, rather than passed over silently:
+if that counter is more than noise, the fix belongs upstream in whatever leaves
+those columns unset, not here.
+
+A *present but unsupported* provider is a different thing and is not counted —
+GHE is working as designed, and metering it would bury the broken rows under
+traffic that was never cacheable. So the checks run null-provider, then
+unsupported-provider, then null-external-id: the last is reached only by repos
+we would otherwise have cached, while a null provider is counted wherever it
+comes from.
+
+**No organization appears in the key.** Not the GitHub org, which is already
+subsumed by the globally unique repo id, and not the Sentry organization: the
+value is a fact about GitHub, not about a tenant. One GitHub App installation
+can be linked to several Sentry organizations (see
+``resolve_check_suite_repositories`` in
+``sentry.seer.autofix.pr_iteration.check_suites``), so an org-scoped key would
+store N identical copies of one fact and miss on N-1 of them.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+
+from sentry.integrations.types import IntegrationProviderSlug
+from sentry.utils import metrics
+from sentry.utils.cache import cache
+
+logger = logging.getLogger(__name__)
+
+_METRICS_KEY = "integrations.source_code_management.pr_id_cache"
+
+# Bump when the key layout or the stored value's encoding changes; old entries
+# are then simply never read again and age out on their own.
+_CACHE_KEY_VERSION = 1
+
+# 1 day. There is no correctness reason to expire an entry — the mapping it holds
+# can never become wrong — so the only question this number answers is how much
+# cache memory we are willing to spend to keep entries around for a repeat
+# lookup. We are starting deliberately short rather than guessing high, because
+# we do not yet know how long a PR keeps being touched. Widen it once
+# ``integrations.source_code_management.pr_id_cache.get``, split by its
+# ``result`` tag, shows the misses are entries that expired rather than PRs seen
+# for the first time.
+PR_ID_CACHE_TTL = 24 * 60 * 60
+
+# github.com, whose repo ids are unique across every repository GitHub knows
+# about — which is what makes a key without any tenant scope safe. Every other
+# provider, GitHub Enterprise included, is not cached; see the module docstring.
+SUPPORTED_PROVIDER = f"integrations:{IntegrationProviderSlug.GITHUB.value}"
+
+
+def _cache_key(provider: str, repo_external_id: str, pr_number: int) -> str:
+    return f"scm:pr-id:{_CACHE_KEY_VERSION}:{provider}:{repo_external_id}:{pr_number}"
+
+
+def get_cached_pr_id(
+    *,
+    provider: str | None,
+    repo_external_id: str | None,
+    pr_number: int,
+) -> int | None:
+    """The GitHub PR id previously stored for this repo + PR number, if any.
+
+    Returns ``None`` for a miss, for an unkeyable/unsupported repo (anything but
+    ``SUPPORTED_PROVIDER``), and for a cache backend failure — all three mean
+    "ask GitHub".
+    """
+
+    if not provider:
+        metrics.incr(f"{_METRICS_KEY}.get", tags={"result": "unkeyable", "missing": "provider"})
+        return None
+
+    if provider != SUPPORTED_PROVIDER:
+        return None
+
+    if not repo_external_id:
+        metrics.incr(
+            f"{_METRICS_KEY}.get", tags={"result": "unkeyable", "missing": "repo_external_id"}
+        )
+        return None
+
+    key = _cache_key(provider, repo_external_id, pr_number)
+
+    try:
+        value = cache.get(key)
+    except Exception:
+        logger.exception("scm.pr_id_cache.get_failed", extra={"repo_external_id": repo_external_id})
+        metrics.incr(f"{_METRICS_KEY}.get", tags={"result": "error"})
+        return None
+
+    # bool is an int subclass and would sail through an isinstance check.
+    if not isinstance(value, int) or isinstance(value, bool):
+        metrics.incr(f"{_METRICS_KEY}.get", tags={"result": "miss"})
+        return None
+
+    metrics.incr(f"{_METRICS_KEY}.get", tags={"result": "hit"})
+    return value
+
+
+def set_cached_pr_id(
+    *,
+    provider: str | None,
+    repo_external_id: str | None,
+    pr_number: int,
+    pr_id: int,
+) -> None:
+    """Record ``pr_number -> pr_id`` for this repo.
+
+    Never raises: callers are webhook handlers whose real work must not depend on
+    the cache backend being reachable.
+    """
+
+    if not provider:
+        metrics.incr(f"{_METRICS_KEY}.set", tags={"result": "unkeyable", "missing": "provider"})
+        return
+
+    if provider != SUPPORTED_PROVIDER:
+        return
+
+    if not repo_external_id:
+        metrics.incr(
+            f"{_METRICS_KEY}.set", tags={"result": "unkeyable", "missing": "repo_external_id"}
+        )
+        return
+
+    key = _cache_key(provider, repo_external_id, pr_number)
+
+    try:
+        cache.set(key, pr_id, PR_ID_CACHE_TTL)
+    except Exception:
+        logger.exception("scm.pr_id_cache.set_failed", extra={"repo_external_id": repo_external_id})
+        metrics.incr(f"{_METRICS_KEY}.set", tags={"result": "error"})
+        return
+
+    metrics.incr(f"{_METRICS_KEY}.set", tags={"result": "stored"})
+
+
+def get_or_fetch_pr_id(
+    *,
+    provider: str | None,
+    repo_external_id: str | None,
+    pr_number: int,
+    fetch: Callable[[], int | None],
+) -> int | None:
+    """Read the PR id from cache, falling back to ``fetch`` on a miss.
+
+    ``fetch`` is called on every miss and its exceptions propagate untouched, so
+    callers keep whatever error handling they already had around it. An
+    unsupported provider or an unkeyable repo is a permanent miss rather than a
+    failure: those callers reach ``fetch`` the same as anyone else and simply
+    never get an entry stored for them.
+
+    A ``None`` from ``fetch`` is **not** cached. A missing id means lost
+    installation access, a repo gone private, or a transient provider error —
+    caching that would turn a recoverable state into a persistent one for the
+    whole TTL.
+    """
+
+    cached = get_cached_pr_id(
+        provider=provider, repo_external_id=repo_external_id, pr_number=pr_number
+    )
+    if cached is not None:
+        return cached
+
+    pr_id = fetch()
+    if pr_id is None:
+        return None
+
+    set_cached_pr_id(
+        provider=provider,
+        repo_external_id=repo_external_id,
+        pr_number=pr_number,
+        pr_id=pr_id,
+    )
+
+    return pr_id

--- a/src/sentry/integrations/source_code_management/pr_id_cache.py
+++ b/src/sentry/integrations/source_code_management/pr_id_cache.py
@@ -81,11 +81,22 @@ _CACHE_KEY_VERSION = 1
 # 1 day. There is no correctness reason to expire an entry — the mapping it holds
 # can never become wrong — so the only question this number answers is how much
 # cache memory we are willing to spend to keep entries around for a repeat
-# lookup. We are starting deliberately short rather than guessing high, because
-# we do not yet know how long a PR keeps being touched. Widen it once
-# ``integrations.source_code_management.pr_id_cache.get``, split by its
-# ``result`` tag, shows the misses are entries that expired rather than PRs seen
-# for the first time.
+# lookup. Note that every warm re-``set``s the key and pushes the deadline out,
+# so what expires is not a PR first seen a day ago but one that has been silent
+# for a day: ``sentry.integrations.github.webhook`` renews it on every
+# ``pull_request`` event and ``sentry.seer.autofix.pr_iteration.check_suites`` on
+# every ``check_suite``. We are starting deliberately short rather than guessing
+# high, because we do not yet know how long a PR stays quiet before someone
+# mentions ``@sentry`` on it.
+#
+# ``integrations.source_code_management.pr_id_cache.get`` will not tell you
+# whether widening this would pay, whichever way you split it: ``cache.get``
+# returns ``None`` for an entry that expired and for one that was never stored
+# alike, so ``result:miss`` folds the two together and no tag on it can take them
+# apart after the fact. Deciding needs the two TTLs running at once — assign each
+# key to an arm by a stable hash of the key itself, so an entry is always read
+# under the arm that wrote it, tag the counter with the arm, and compare hit
+# rates across what are then two identical populations.
 PR_ID_CACHE_TTL = 24 * 60 * 60
 
 # github.com, whose repo ids are unique across every repository GitHub knows
@@ -107,8 +118,8 @@ def get_cached_pr_id(
     """The GitHub PR id previously stored for this repo + PR number, if any.
 
     Returns ``None`` for a miss, for an unkeyable/unsupported repo (anything but
-    ``SUPPORTED_PROVIDER``), and for a cache backend failure — all three mean
-    "ask GitHub".
+    ``SUPPORTED_PROVIDER``), for a cache backend failure, and for a stored value
+    this module would not have written — all four mean "ask GitHub".
     """
 
     if not provider:
@@ -133,9 +144,19 @@ def get_cached_pr_id(
         metrics.incr(f"{_METRICS_KEY}.get", tags={"result": "error"})
         return None
 
+    if value is None:
+        metrics.incr(f"{_METRICS_KEY}.get", tags={"result": "miss"})
+        return None
+
+    # Counted apart from the miss it is indistinguishable from at the call site:
+    # nothing here writes a non-int, so one turning up means the entry did not
+    # come from `set_cached_pr_id` — a key collision, or an encoding change that
+    # went out without the version bump above. Folded into `miss` it would read
+    # as ordinary cold-cache traffic.
+    #
     # bool is an int subclass and would sail through an isinstance check.
     if not isinstance(value, int) or isinstance(value, bool):
-        metrics.incr(f"{_METRICS_KEY}.get", tags={"result": "miss"})
+        metrics.incr(f"{_METRICS_KEY}.get", tags={"result": "invalid"})
         return None
 
     metrics.incr(f"{_METRICS_KEY}.get", tags={"result": "hit"})

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -4012,6 +4012,27 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Seconds to remember "this organization has no Autofix run for this PR", the
+# negative half of the PR -> run lookup. 0 disables the cache: every lookup asks
+# Seer. See ``sentry.seer.autofix.pr_iteration.run_resolution``.
+register(
+    "autofix.pr-iteration.no-run-cache-ttl",
+    type=Int,
+    default=24 * 60 * 60,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+# Seconds to keep a cached SCM pull-request number -> pull-request id mapping. 0
+# disables the cache on both sides: no reads, no new entries, and every caller
+# pays the REST round-trip instead. See
+# ``sentry.integrations.source_code_management.pr_id_cache``.
+register(
+    "integrations.pr-id-cache.ttl",
+    type=Int,
+    default=24 * 60 * 60,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # TODO(telkins): Remove once we no longer need integration_id on SLO metrics
 register(
     "integrations.slo.integration-id-tag-enabled",

--- a/src/sentry/seer/autofix/pr_iteration/check_suites.py
+++ b/src/sentry/seer/autofix/pr_iteration/check_suites.py
@@ -31,9 +31,9 @@ from sentry.models.organization import Organization
 from sentry.models.repository import Repository
 from sentry.scm.types import CheckSuiteEvent
 from sentry.seer.agent.client_models import SeerRunState
-from sentry.seer.agent.client_utils import get_agent_state_from_pr_id
 from sentry.seer.autofix.pr_iteration.constants import PR_ITERATION_PROVIDER, REVIEW_REQUEST_FLAG
 from sentry.seer.autofix.pr_iteration.run_markers import get_run_marker
+from sentry.seer.autofix.pr_iteration.run_resolution import get_run_state_for_pr_id
 from sentry.seer.models import SeerApiError
 from sentry.seer.models.run import SeerRun
 from sentry.utils import metrics
@@ -272,8 +272,14 @@ def resolve_check_suite_autofix_run(
     for pr_id in (pr.id for pr in pull_requests):
         for candidate in repos:
             try:
-                state = get_agent_state_from_pr_id(
-                    candidate.organization_id, SEER_GITHUB_PROVIDER, pr_id
+                # A 404 comes back as None and is remembered for a minute: one
+                # PR fans out across every candidate organization, and a push to
+                # a non-Autofix PR replays this whole loop per suite.
+                state = get_run_state_for_pr_id(
+                    organization_id=candidate.organization_id,
+                    provider=SEER_GITHUB_PROVIDER,
+                    pr_id=pr_id,
+                    caller="check_suite",
                 )
             except SeerApiError as e:
                 sentry_sdk.capture_exception(e)

--- a/src/sentry/seer/autofix/pr_iteration/check_suites.py
+++ b/src/sentry/seer/autofix/pr_iteration/check_suites.py
@@ -25,6 +25,7 @@ from scm.types import ActionResult, GetPullRequestProtocol, ListCheckRunsForRefP
 from sentry import features
 from sentry.constants import ObjectStatus
 from sentry.integrations.services.integration import integration_service
+from sentry.integrations.source_code_management.pr_id_cache import set_cached_pr_id
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.organization import Organization
 from sentry.models.repository import Repository
@@ -87,6 +88,10 @@ class GithubCheckSuitePullRequest(BaseModel):
     # an entry is skipped, which strands nothing: `extra = "allow"` round-tripped
     # `base` through the model that predates the field, so it parses back in here.
     base: GithubCheckSuitePullRequestBase | None = None
+    # Only used to warm the PR-number -> PR-id cache; optional on the same
+    # round-tripping grounds as `base`, and an entry without it is just not
+    # cached.
+    number: int | None = None
 
     class Config:
         extra = "allow"
@@ -246,6 +251,22 @@ def resolve_check_suite_autofix_run(
         pull_requests.append(pr)
     if not pull_requests:
         return None
+
+    # Warm the number -> id map for the entries we kept, while both halves are in
+    # hand. The `@sentry` mention path only ever receives the number and would
+    # otherwise spend a REST call recovering the id. `event.repository.id` is
+    # optional on the model but cannot be None here: `is_own_repo_pull_request`
+    # rejects every entry when it is, so `pull_requests` is empty and we have
+    # returned above.
+    repo_external_id = str(event.repository.id)
+    for pr in pull_requests:
+        if pr.number is not None:
+            set_cached_pr_id(
+                provider=SEER_GITHUB_PROVIDER,
+                repo_external_id=repo_external_id,
+                pr_number=pr.number,
+                pr_id=pr.id,
+            )
 
     matches: list[CheckSuiteAutofixRun] = []
     for pr_id in (pr.id for pr in pull_requests):

--- a/src/sentry/seer/autofix/pr_iteration/listeners/check_suite.py
+++ b/src/sentry/seer/autofix/pr_iteration/listeners/check_suite.py
@@ -16,6 +16,7 @@ from sentry.seer.autofix.pr_iteration.check_suites import (
     confirm_green_check_suite,
     resolve_green_check_suite,
 )
+from sentry.seer.autofix.pr_iteration.constants import PR_ITERATION_PROVIDER_SLUG
 from sentry.seer.autofix.pr_iteration.feedback import Feedback
 from sentry.seer.autofix.pr_iteration.feedback_sources.check_suite import (
     CheckSuiteFeedbackSource,
@@ -32,6 +33,20 @@ logger = logging.getLogger(__name__)
 @scm_event_stream.listen_for(event_type="check_suite")
 def pr_iteration_from_check_suite_listener(check_suite_event: CheckSuiteEvent):
     if check_suite_event.action != "completed":
+        return None
+
+    # ``subscription_event["type"]`` is the integration provider slug. GitHub
+    # Enterprise delivers the same ``check_suite`` events onto this stream, so it
+    # is turned away here, before any Seer RPC or repo query — the same gate the
+    # review listener applies. This is the *only* provider decision on the path:
+    # everything downstream pins ``PR_ITERATION_PROVIDER``, so re-enabling a
+    # provider is a change to that constant and these entry points.
+    provider = check_suite_event.subscription_event["type"]
+    if provider != PR_ITERATION_PROVIDER_SLUG:
+        logger.warning(
+            "autofix.pr_iteration.check_suite.unsupported_provider",
+            extra={"provider": provider},
+        )
         return None
 
     conclusion = check_suite_event.check_suite["conclusion"]

--- a/src/sentry/seer/autofix/pr_iteration/run_resolution.py
+++ b/src/sentry/seer/autofix/pr_iteration/run_resolution.py
@@ -1,0 +1,252 @@
+"""Uniform "which Autofix run owns this pull request" resolution for SCM listeners.
+
+Every PR-iteration listener needs the same thing — the Seer run behind a pull
+request — but each SCM event describes its PR differently. ``check_suite``
+carries the provider's global numeric PR id outright and goes straight to
+:func:`get_run_state_for_pr_id`. ``issue_comment`` (the ``@sentry`` mention path)
+and ``pull_request_review`` carry only a repo-scoped number and reach the same
+lookup through :func:`resolve_pr_id`: GitHub's ``issue.pull_request`` object is
+five URL/timestamp fields with no id in it, and the normalized review event's
+``pull_request_id`` is the number the REST path uses rather than the id its name
+suggests.
+
+The two steps stay separate rather than collapsing into one call because every
+caller wants the id even when there is no run: it is what the ``no_run`` log
+lines are searched by, and a combined helper could only return it by returning
+something on the failure path.
+
+**Why the provider round-trip lives here.** Both number-carrying listeners
+recover the id the same way — one ``get_pull_request`` — so that call sits
+inside :func:`resolve_pr_id` rather than being written out per call site, where
+it was duplicated verbatim. Its failures stay the caller's: ``ApiError`` propagates
+untouched, so each task keeps reporting them under its own log key.
+
+Two caches sit under this, and they cache opposite halves for opposite reasons:
+
+* ``pr_id_cache`` caches *positives*, because number -> id can never become
+  wrong. Its TTL is a memory budget rather than an invalidation — see
+  ``PR_ID_CACHE_TTL`` — so an expired entry costs a REST call, never a wrong id.
+* This module caches only *negatives*, for the same reason and just as long.
+  See below.
+
+**Why run state is never cached.** :class:`SeerRunState` is live, mutable state —
+``status``, ``updated_at``, ``blocks``, and the ``repo_pr_states`` that downstream
+staleness checks compare head shas against. Serving a stale copy would mean
+enqueueing feedback against a head the run has already moved past, which is
+exactly the failure the staleness checks exist to prevent. So a run that exists
+is always fetched fresh; only its *absence* is remembered.
+
+**Why the negative TTL is long.** Every negative this module stores is
+permanently true in practice, so it is held for a day rather than re-derived.
+The two that dominate are "this PR has no Autofix run at all" — every push to
+every non-Autofix PR in an installed repo — and "the run belongs to another
+organization", which is what a region that does not own the session sees on
+every webhook GitHub fans out to it. Neither answer can change: Autofix creates
+the run before it creates the PR, so a PR cannot acquire its first run after we
+have already looked.
+
+The one answer that could go stale is a 404 served while Seer's PR -> run row is
+still uncommitted. Seer inserts it immediately after the GitHub API returns the
+created PR (``create_pr_step.py``), and every caller here is a webhook about a
+PR that already exists — so reaching that window would mean a ``check_suite``
+whose ``pull_requests[]`` is already populated (the PR exists) racing through
+GitHub's delivery queue and ours inside the few lines between that API response
+and the insert. It is not a window a webhook can realistically land in.
+
+What would invalidate this is a future path that attaches a run to a PR that
+already existed when we first looked. If one appears, ``result:cached_missing``
+on the lookup metric is where it will show up first, and the fix is to shorten
+this or to have that path delete the key.
+
+**Why the negative key is organization-scoped.** Seer resolves the run from
+``(provider, pr_id)`` globally and only then checks the caller's organization,
+returning 404 when it belongs to someone else. A negative therefore means "not
+for *this* organization", not "not for anyone" — storing it unscoped would poison
+the lookup for the organization that does own the run.
+
+**Why the provider is a parameter, but callers pin it.** The provider is part of
+the identity of everything keyed below, so this module takes it explicitly rather
+than assuming one: pass ``integrations:github_enterprise`` and each layer does the
+right thing on its own. ``pr_id_cache`` declines to store it — GHE repo external
+ids are unique per instance, not globally — so the caller keeps paying the REST
+call it already paid, and the negative key below stays distinct from github.com's.
+
+Callers do not thread a runtime provider in, though. PR iteration is github.com
+only and every listener turns anything else away at its entry point, so they pass
+``PR_ITERATION_PROVIDER`` directly. That keeps the one supported-provider decision
+at the entry points instead of spread across the resolve helpers, while leaving
+this module honest if another provider is ever admitted.
+"""
+
+from __future__ import annotations
+
+import logging
+from functools import partial
+from typing import Literal
+
+from sentry.integrations.services.integration.model import RpcIntegration
+from sentry.integrations.source_code_management.pr_id_cache import get_or_fetch_pr_id
+from sentry.seer.agent.client_models import SeerRunState
+from sentry.seer.agent.client_utils import get_agent_state_from_pr_id
+from sentry.seer.models import SeerApiError
+from sentry.utils import metrics
+from sentry.utils.cache import cache
+
+logger = logging.getLogger(__name__)
+
+_METRICS_KEY = "autofix.pr_iteration.run_resolution"
+
+# Bump when the key layout changes; stale entries are then never read again and
+# age out on their own.
+_CACHE_KEY_VERSION = 1
+
+# 1 day. The answers stored under it cannot become wrong -- see the module
+# docstring -- so this is a memory budget, not an invalidation, exactly like
+# ``PR_ID_CACHE_TTL``.
+NO_RUN_CACHE_TTL = 24 * 60 * 60
+
+_NO_RUN_SENTINEL = 1
+
+# Which listener a lookup came from. Bounded on purpose: it is a metrics tag, and
+# the whole point is to be able to split hit rates by path without unbounded
+# cardinality.
+Caller = Literal["mention", "review", "check_suite"]
+
+
+def _incr_lookup(caller: Caller, outcome: str) -> None:
+    metrics.incr(f"{_METRICS_KEY}.lookup", tags={"caller": caller, "result": outcome})
+
+
+def _no_run_cache_key(*, provider: str, pr_id: int, organization_id: int) -> str:
+    return f"autofix:pr-iteration:no-run:{_CACHE_KEY_VERSION}:{provider}:{pr_id}:{organization_id}"
+
+
+def _is_known_missing(*, provider: str, pr_id: int, organization_id: int) -> bool:
+    """Whether this org has already been told there is no run for this PR."""
+    try:
+        return (
+            cache.get(
+                _no_run_cache_key(provider=provider, pr_id=pr_id, organization_id=organization_id)
+            )
+            is not None
+        )
+    except Exception:
+        # A cache we cannot read is a cache miss: fall through and ask Seer.
+        logger.exception(
+            "autofix.pr_iteration.run_resolution.no_run_cache_get_failed",
+            extra={"organization_id": organization_id, "pr_id": pr_id},
+        )
+        return False
+
+
+def _mark_missing(*, provider: str, pr_id: int, organization_id: int) -> None:
+    """Remember that this org has no run for this PR."""
+    try:
+        cache.set(
+            _no_run_cache_key(provider=provider, pr_id=pr_id, organization_id=organization_id),
+            _NO_RUN_SENTINEL,
+            NO_RUN_CACHE_TTL,
+        )
+    except Exception:
+        # Losing a negative only costs an RPC next time round.
+        logger.exception(
+            "autofix.pr_iteration.run_resolution.no_run_cache_set_failed",
+            extra={"organization_id": organization_id, "pr_id": pr_id},
+        )
+
+
+def resolve_pr_id(
+    *,
+    provider: str | None,
+    organization_id: int,
+    integration: RpcIntegration,
+    repo_external_id: str | None,
+    repo_name: str,
+    pr_number: int,
+    caller: Caller,
+) -> int | None:
+    """The provider's global PR id for a repo-scoped ``pr_number``.
+
+    Reads the immutable number -> id cache and only pays the provider round-trip
+    on a miss. That round-trip's exceptions propagate untouched, so callers keep
+    their existing error handling around this call.
+
+    ``repo_external_id`` keys the cache -- see
+    :mod:`sentry.integrations.source_code_management.pr_id_cache` for why the key
+    is the repo's external id and never its name -- while ``repo_name`` and the
+    ``integration`` are what a miss is paid with.
+
+    The SCM client is built here rather than handed in so that it is built only
+    on a miss: the cache is warm for almost every event, and the review path has
+    no other use for a client at all.
+
+    ``caller`` splits the resulting metric by listener. Without it a listener
+    that quietly stopped hitting the cache would be invisible: the id cache's own
+    counter sums every path into one number.
+    """
+
+    def fetch() -> int | None:
+        # Only reached on a cache miss. Runs inside async tasks, where the PR may
+        # have been deleted or made private, or GitHub may simply fail, between
+        # webhook receipt and execution -- so a missing ``id`` is ``None`` rather
+        # than a KeyError, and ``ApiError`` is left to the caller.
+        client = integration.get_installation(organization_id=organization_id).get_client()
+        pull_request = client.get_pull_request(repo_name, str(pr_number))
+        pr_id: int | None = pull_request.get("id")
+        return pr_id
+
+    pr_id = get_or_fetch_pr_id(
+        provider=provider,
+        repo_external_id=repo_external_id,
+        pr_number=pr_number,
+        fetch=fetch,
+    )
+
+    metrics.incr(
+        f"{_METRICS_KEY}.resolve",
+        tags={"caller": caller, "result": "resolved" if pr_id is not None else "no_pr_id"},
+    )
+    return pr_id
+
+
+def get_run_state_for_pr_id(
+    *, organization_id: int, provider: str, pr_id: int, caller: Caller
+) -> SeerRunState | None:
+    """The Seer run state for ``pr_id`` as seen by ``organization_id``.
+
+    Returns ``None`` when this organization has no run for the PR, which covers
+    both "no run exists" and "the run belongs to another organization" -- Seer
+    reports the second as a 404 and the caller cannot tell them apart anyway.
+
+    Only that absence is remembered, for :data:`NO_RUN_CACHE_TTL`. Transport
+    failures and Seer errors other than 404 are *not* remembered: they say nothing
+    about whether a run exists, and caching them would turn a blip into a day of
+    blindness. They propagate as :class:`SeerApiError` so callers keep reporting
+    them.
+    """
+    incr = partial(_incr_lookup, caller)
+
+    if _is_known_missing(provider=provider, pr_id=pr_id, organization_id=organization_id):
+        incr("cached_missing")
+        return None
+
+    try:
+        state = get_agent_state_from_pr_id(organization_id, provider, pr_id)
+    except SeerApiError as e:
+        if e.status == 404:
+            # The run exists but is owned elsewhere, or the run id resolved to a
+            # state this org cannot read. Either way there is nothing here.
+            _mark_missing(provider=provider, pr_id=pr_id, organization_id=organization_id)
+            incr("not_found")
+            return None
+
+        incr("error")
+        raise
+
+    if state is None:
+        _mark_missing(provider=provider, pr_id=pr_id, organization_id=organization_id)
+        incr("no_run")
+        return None
+
+    incr("found")
+    return state

--- a/src/sentry/seer/autofix/pr_iteration/run_resolution.py
+++ b/src/sentry/seer/autofix/pr_iteration/run_resolution.py
@@ -25,7 +25,8 @@ Two caches sit under this, and they cache opposite halves for opposite reasons:
 
 * ``pr_id_cache`` caches *positives*, because number -> id can never become
   wrong. Its TTL is a memory budget rather than an invalidation — see
-  ``PR_ID_CACHE_TTL`` — so an expired entry costs a REST call, never a wrong id.
+  ``PR_ID_CACHE_TTL_OPTION`` — so an expired entry costs a REST call, never a
+  wrong id.
 * This module caches only *negatives*, for the same reason and just as long.
   See below.
 
@@ -84,6 +85,7 @@ import logging
 from functools import partial
 from typing import Literal
 
+from sentry import options
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.integrations.source_code_management.pr_id_cache import get_or_fetch_pr_id
 from sentry.seer.agent.client_models import SeerRunState
@@ -100,10 +102,15 @@ _METRICS_KEY = "autofix.pr_iteration.run_resolution"
 # age out on their own.
 _CACHE_KEY_VERSION = 1
 
-# 1 day. The answers stored under it cannot become wrong -- see the module
-# docstring -- so this is a memory budget, not an invalidation, exactly like
-# ``PR_ID_CACHE_TTL``.
-NO_RUN_CACHE_TTL = 24 * 60 * 60
+# The answers stored under this cannot become wrong -- see the module docstring
+# -- so it is a memory budget, not an invalidation, exactly like the PR-id cache
+# it sits next to. Both default to a day, and the number for each lives with its
+# registration in ``sentry.options.defaults`` rather than being mirrored here.
+#
+# The argument for a day rests on a race being unreachable, and the cost of being
+# wrong about that is a PR that stays dark for a day -- so the number is
+# reachable without a deploy, and so is switching it off entirely.
+NO_RUN_CACHE_TTL_OPTION = "autofix.pr-iteration.no-run-cache-ttl"
 
 _NO_RUN_SENTINEL = 1
 
@@ -121,8 +128,27 @@ def _no_run_cache_key(*, provider: str, pr_id: int, organization_id: int) -> str
     return f"autofix:pr-iteration:no-run:{_CACHE_KEY_VERSION}:{provider}:{pr_id}:{organization_id}"
 
 
+def _cache_ttl() -> int | None:
+    """Seconds to remember an absence, or ``None`` to remember nothing.
+
+    Zero is the off switch. Turning it off costs a Seer RPC per lookup -- the
+    traffic this module was written to remove -- and buys back the one thing the
+    long TTL gives up: a PR that acquires a run after we looked is picked up on
+    the next webhook instead of a day later.
+
+    Anything that is not a usable lifetime reads as off -- see the matching
+    helper in ``pr_id_cache``, which explains why a negative has to be handled
+    rather than declared impossible.
+    """
+    ttl = options.get(NO_RUN_CACHE_TTL_OPTION)
+    return ttl if ttl > 0 else None
+
+
 def _is_known_missing(*, provider: str, pr_id: int, organization_id: int) -> bool:
     """Whether this org has already been told there is no run for this PR."""
+    if _cache_ttl() is None:
+        return False
+
     try:
         return (
             cache.get(
@@ -141,11 +167,15 @@ def _is_known_missing(*, provider: str, pr_id: int, organization_id: int) -> boo
 
 def _mark_missing(*, provider: str, pr_id: int, organization_id: int) -> None:
     """Remember that this org has no run for this PR."""
+    ttl = _cache_ttl()
+    if ttl is None:
+        return
+
     try:
         cache.set(
             _no_run_cache_key(provider=provider, pr_id=pr_id, organization_id=organization_id),
             _NO_RUN_SENTINEL,
-            NO_RUN_CACHE_TTL,
+            ttl,
         )
     except Exception:
         # Losing a negative only costs an RPC next time round.
@@ -218,7 +248,8 @@ def get_run_state_for_pr_id(
     both "no run exists" and "the run belongs to another organization" -- Seer
     reports the second as a 404 and the caller cannot tell them apart anyway.
 
-    Only that absence is remembered, for :data:`NO_RUN_CACHE_TTL`. Transport
+    Only that absence is remembered, and only for as long as
+    :data:`NO_RUN_CACHE_TTL_OPTION` says -- zero remembers nothing. Transport
     failures and Seer errors other than 404 are *not* remembered: they say nothing
     about whether a run exists, and caching them would turn a blip into a day of
     blindness. They propagate as :class:`SeerApiError` so callers keep reporting

--- a/src/sentry/tasks/seer/pr_iteration.py
+++ b/src/sentry/tasks/seer/pr_iteration.py
@@ -39,6 +39,7 @@ from taskbroker_client.retry import Retry
 from sentry import options
 from sentry.cache import default_cache
 from sentry.integrations.services.integration import integration_service
+from sentry.integrations.source_code_management.pr_id_cache import get_or_fetch_pr_id
 from sentry.integrations.utils.scm_actors import find_user_for_scm_actor
 from sentry.locks import locks
 from sentry.models.group import Group
@@ -588,10 +589,25 @@ def trigger_pr_iteration_from_comment(
         return None
 
     client = integration.get_installation(organization_id=organization_id).get_client()
-    try:
+
+    def _fetch_pr_id() -> int | None:
         # Async task: the PR may be deleted, made private, or GitHub may return a
         # transient error between webhook receipt and execution.
         pull_request = client.get_pull_request(repo.name, str(pr_number))
+        pr_id: int | None = pull_request.get("id")
+        return pr_id
+
+    try:
+        # The issue_comment payload behind an `@sentry` mention carries only the
+        # PR number, but Seer's run lookup is keyed on GitHub's numeric PR id.
+        # The mapping is immutable, so it is cached; the fetch above only runs
+        # when no webhook has warmed this PR yet.
+        pr_id = get_or_fetch_pr_id(
+            provider=repo.provider,
+            repo_external_id=repo.external_id,
+            pr_number=pr_number,
+            fetch=_fetch_pr_id,
+        )
     except ApiError:
         logger.warning(
             "autofix.pr_iteration.comment_trigger.get_pull_request_failed",
@@ -599,7 +615,6 @@ def trigger_pr_iteration_from_comment(
             exc_info=True,
         )
         return None
-    pr_id = pull_request.get("id")
     if pr_id is None:
         return None
 

--- a/src/sentry/tasks/seer/pr_iteration.py
+++ b/src/sentry/tasks/seer/pr_iteration.py
@@ -575,6 +575,22 @@ def trigger_pr_iteration_from_comment(
         )
         return None
 
+    if repo.provider != PR_ITERATION_PROVIDER:
+        # Everything below reads the provider off the constant rather than the
+        # repo, so this is where the two are held to be the same thing. The entry
+        # point already rejects anything else, which makes reaching this a
+        # disagreement between that gate and this task rather than ordinary
+        # traffic — hence warning, and hence the provider in `extra`.
+        logger.warning(
+            "autofix.pr_iteration.comment_trigger.unsupported_provider",
+            extra={
+                "organization_id": organization_id,
+                "repo_id": repo.id,
+                "provider": repo.provider,
+            },
+        )
+        return None
+
     integration = integration_service.get_integration(integration_id=integration_id)
     if integration is None:
         logger.warning(
@@ -597,11 +613,6 @@ def trigger_pr_iteration_from_comment(
         # PR number, but Seer's run lookup is keyed on GitHub's numeric PR id.
         # The mapping is immutable, so it is cached; the fetch above only runs
         # when no webhook has warmed this PR yet.
-        #
-        # The provider is pinned to github.com: the entry point,
-        # ``handle_issue_comment_for_autofix_iteration`` in
-        # ``sentry/seer/autofix/pr_iteration/mention.py``, turns away everything
-        # but ``PR_ITERATION_PROVIDER_SLUG`` before dispatching this task.
         pr_id = get_or_fetch_pr_id(
             provider=PR_ITERATION_PROVIDER,
             repo_external_id=repo.external_id,
@@ -891,6 +902,16 @@ def trigger_pr_iteration_from_review(
         logger.info("autofix.pr_iteration.review_trigger.missing_repo", extra=log_extra)
         return None
 
+    if repo.provider != PR_ITERATION_PROVIDER:
+        # See the matching guard in `trigger_pr_iteration_from_comment`: the
+        # provider read below comes from the constant, so it is held equal to the
+        # repo's here, before any external call.
+        logger.warning(
+            "autofix.pr_iteration.review_trigger.unsupported_provider",
+            extra={**log_extra, "provider": repo.provider},
+        )
+        return None
+
     integration = integration_service.get_integration(integration_id=integration_id)
     if integration is None:
         logger.warning("autofix.pr_iteration.review_trigger.missing_integration", extra=log_extra)
@@ -910,12 +931,6 @@ def trigger_pr_iteration_from_review(
         # run lookup is keyed on GitHub's numeric PR id. A pull_request or
         # check_suite webhook on this PR has almost certainly warmed the cache
         # already, so the fetch above is the exception rather than the rule.
-        #
-        # The provider is pinned to github.com: the entry point,
-        # ``handle_pull_request_review_for_autofix_iteration`` in
-        # ``sentry/seer/autofix/pr_iteration/listeners/review.py``, turns away
-        # everything but ``PR_ITERATION_PROVIDER_SLUG`` before dispatching this
-        # task.
         pr_id = get_or_fetch_pr_id(
             provider=PR_ITERATION_PROVIDER,
             repo_external_id=repo.external_id,

--- a/src/sentry/tasks/seer/pr_iteration.py
+++ b/src/sentry/tasks/seer/pr_iteration.py
@@ -56,6 +56,7 @@ from sentry.seer.autofix.autofix_agent import (
 )
 from sentry.seer.autofix.commit_author import commit_author_for_feedback
 from sentry.seer.autofix.constants import AutofixReferrer
+from sentry.seer.autofix.pr_iteration.constants import PR_ITERATION_PROVIDER
 from sentry.seer.autofix.pr_iteration.feedback import Feedback, automated_iteration_cap_reached
 from sentry.seer.autofix.pr_iteration.feedback_sources.base import ConsumeTask
 from sentry.seer.autofix.pr_iteration.feedback_sources.check_suite import CheckSuiteFeedbackSource
@@ -573,12 +574,6 @@ def trigger_pr_iteration_from_comment(
             extra={"organization_id": organization_id, "repo_id": repo_id},
         )
         return None
-    if repo.provider is None:
-        logger.warning(
-            "autofix.pr_iteration.comment_trigger.no_provider",
-            extra={"organization_id": organization_id, "repo_id": repo.id},
-        )
-        return None
 
     integration = integration_service.get_integration(integration_id=integration_id)
     if integration is None:
@@ -602,8 +597,13 @@ def trigger_pr_iteration_from_comment(
         # PR number, but Seer's run lookup is keyed on GitHub's numeric PR id.
         # The mapping is immutable, so it is cached; the fetch above only runs
         # when no webhook has warmed this PR yet.
+        #
+        # The provider is pinned to github.com: the entry point,
+        # ``handle_issue_comment_for_autofix_iteration`` in
+        # ``sentry/seer/autofix/pr_iteration/mention.py``, turns away everything
+        # but ``PR_ITERATION_PROVIDER_SLUG`` before dispatching this task.
         pr_id = get_or_fetch_pr_id(
-            provider=repo.provider,
+            provider=PR_ITERATION_PROVIDER,
             repo_external_id=repo.external_id,
             pr_number=pr_number,
             fetch=_fetch_pr_id,
@@ -618,7 +618,7 @@ def trigger_pr_iteration_from_comment(
     if pr_id is None:
         return None
 
-    agent_state = get_agent_state_from_pr_id(organization_id, repo.provider, pr_id)
+    agent_state = get_agent_state_from_pr_id(organization_id, PR_ITERATION_PROVIDER, pr_id)
     if agent_state is None:
         # No-op: missing runs are expected on regions that don't own the session
         # when webhooks are fanned out everywhere. Do not react/comment as
@@ -890,9 +890,6 @@ def trigger_pr_iteration_from_review(
     if repo is None:
         logger.info("autofix.pr_iteration.review_trigger.missing_repo", extra=log_extra)
         return None
-    if repo.provider is None:
-        logger.warning("autofix.pr_iteration.review_trigger.no_provider", extra=log_extra)
-        return None
 
     integration = integration_service.get_integration(integration_id=integration_id)
     if integration is None:
@@ -913,8 +910,14 @@ def trigger_pr_iteration_from_review(
         # run lookup is keyed on GitHub's numeric PR id. A pull_request or
         # check_suite webhook on this PR has almost certainly warmed the cache
         # already, so the fetch above is the exception rather than the rule.
+        #
+        # The provider is pinned to github.com: the entry point,
+        # ``handle_pull_request_review_for_autofix_iteration`` in
+        # ``sentry/seer/autofix/pr_iteration/listeners/review.py``, turns away
+        # everything but ``PR_ITERATION_PROVIDER_SLUG`` before dispatching this
+        # task.
         pr_id = get_or_fetch_pr_id(
-            provider=repo.provider,
+            provider=PR_ITERATION_PROVIDER,
             repo_external_id=repo.external_id,
             pr_number=pr_number,
             fetch=_fetch_pr_id,
@@ -929,7 +932,7 @@ def trigger_pr_iteration_from_review(
     if pr_id is None:
         return None
 
-    agent_state = get_agent_state_from_pr_id(organization_id, repo.provider, pr_id)
+    agent_state = get_agent_state_from_pr_id(organization_id, PR_ITERATION_PROVIDER, pr_id)
     if agent_state is None or not agent_state.repo_pr_states:
         metrics.incr("autofix.pr_iteration.review_trigger.no_run")
         logger.info(

--- a/src/sentry/tasks/seer/pr_iteration.py
+++ b/src/sentry/tasks/seer/pr_iteration.py
@@ -525,6 +525,20 @@ def _comment_pr_iteration_ineligible(
         pass
 
 
+def _fetch_pr_id(client: Any, repo_name: str, pr_number: int) -> int | None:
+    """Recover a PR's GitHub id from its repo-scoped number over the REST API.
+
+    The fallback behind `get_or_fetch_pr_id`, so it runs only when no webhook has
+    warmed this PR into the id cache. Both trigger tasks run async, meaning the
+    PR may have been deleted or made private, or GitHub may return a transient
+    error, between webhook receipt and execution — `ApiError` propagates to the
+    caller, which is where the drop is logged.
+    """
+    pull_request = client.get_pull_request(repo_name, str(pr_number))
+    pr_id: int | None = pull_request.get("id")
+    return pr_id
+
+
 @instrumented_task(
     name="sentry.tasks.autofix.trigger_pr_iteration_from_comment",
     namespace=seer_tasks,
@@ -601,23 +615,16 @@ def trigger_pr_iteration_from_comment(
 
     client = integration.get_installation(organization_id=organization_id).get_client()
 
-    def _fetch_pr_id() -> int | None:
-        # Async task: the PR may be deleted, made private, or GitHub may return a
-        # transient error between webhook receipt and execution.
-        pull_request = client.get_pull_request(repo.name, str(pr_number))
-        pr_id: int | None = pull_request.get("id")
-        return pr_id
-
     try:
         # The issue_comment payload behind an `@sentry` mention carries only the
         # PR number, but Seer's run lookup is keyed on GitHub's numeric PR id.
-        # The mapping is immutable, so it is cached; the fetch above only runs
-        # when no webhook has warmed this PR yet.
+        # The mapping is immutable, so it is cached; the fetch runs only when no
+        # webhook has warmed this PR yet.
         pr_id = get_or_fetch_pr_id(
             provider=PR_ITERATION_PROVIDER,
             repo_external_id=repo.external_id,
             pr_number=pr_number,
-            fetch=_fetch_pr_id,
+            fetch=lambda: _fetch_pr_id(client, repo.name, pr_number),
         )
     except ApiError:
         logger.warning(
@@ -919,23 +926,16 @@ def trigger_pr_iteration_from_review(
 
     client = integration.get_installation(organization_id=organization_id).get_client()
 
-    def _fetch_pr_id() -> int | None:
-        # Async task: the PR may be deleted, made private, or GitHub may return a
-        # transient error between webhook receipt and execution.
-        pull_request = client.get_pull_request(repo.name, str(pr_number))
-        pr_id: int | None = pull_request.get("id")
-        return pr_id
-
     try:
         # The pull_request_review payload carries only the PR number, but Seer's
         # run lookup is keyed on GitHub's numeric PR id. A pull_request or
         # check_suite webhook on this PR has almost certainly warmed the cache
-        # already, so the fetch above is the exception rather than the rule.
+        # already, so the fetch is the exception rather than the rule.
         pr_id = get_or_fetch_pr_id(
             provider=PR_ITERATION_PROVIDER,
             repo_external_id=repo.external_id,
             pr_number=pr_number,
-            fetch=_fetch_pr_id,
+            fetch=lambda: _fetch_pr_id(client, repo.name, pr_number),
         )
     except ApiError:
         logger.warning(

--- a/src/sentry/tasks/seer/pr_iteration.py
+++ b/src/sentry/tasks/seer/pr_iteration.py
@@ -39,7 +39,6 @@ from taskbroker_client.retry import Retry
 from sentry import options
 from sentry.cache import default_cache
 from sentry.integrations.services.integration import integration_service
-from sentry.integrations.source_code_management.pr_id_cache import get_or_fetch_pr_id
 from sentry.integrations.utils.scm_actors import find_user_for_scm_actor
 from sentry.locks import locks
 from sentry.models.group import Group
@@ -47,7 +46,7 @@ from sentry.models.organization import Organization
 from sentry.models.repository import Repository
 from sentry.scm.factory import new as make_scm
 from sentry.seer.agent.client_models import SeerRunState
-from sentry.seer.agent.client_utils import fetch_run_status, get_agent_state_from_pr_id
+from sentry.seer.agent.client_utils import fetch_run_status
 from sentry.seer.autofix.autofix_agent import (
     AutofixStep,
     PrIterationNoPullRequestException,
@@ -72,6 +71,10 @@ from sentry.seer.autofix.pr_iteration.queue import (
     QueuedAutofixFeedback,
     pop_queued_autofix_feedback,
     try_enqueue_autofix_feedback,
+)
+from sentry.seer.autofix.pr_iteration.run_resolution import (
+    get_run_state_for_pr_id,
+    resolve_pr_id,
 )
 from sentry.seer.models import SeerApiError, SeerPermissionError
 from sentry.shared_integrations.exceptions import ApiError
@@ -525,20 +528,6 @@ def _comment_pr_iteration_ineligible(
         pass
 
 
-def _fetch_pr_id(client: Any, repo_name: str, pr_number: int) -> int | None:
-    """Recover a PR's GitHub id from its repo-scoped number over the REST API.
-
-    The fallback behind `get_or_fetch_pr_id`, so it runs only when no webhook has
-    warmed this PR into the id cache. Both trigger tasks run async, meaning the
-    PR may have been deleted or made private, or GitHub may return a transient
-    error, between webhook receipt and execution — `ApiError` propagates to the
-    caller, which is where the drop is logged.
-    """
-    pull_request = client.get_pull_request(repo_name, str(pr_number))
-    pr_id: int | None = pull_request.get("id")
-    return pr_id
-
-
 @instrumented_task(
     name="sentry.tasks.autofix.trigger_pr_iteration_from_comment",
     namespace=seer_tasks,
@@ -613,18 +602,19 @@ def trigger_pr_iteration_from_comment(
         )
         return None
 
-    client = integration.get_installation(organization_id=organization_id).get_client()
-
     try:
         # The issue_comment payload behind an `@sentry` mention carries only the
         # PR number, but Seer's run lookup is keyed on GitHub's numeric PR id.
-        # The mapping is immutable, so it is cached; the fetch runs only when no
-        # webhook has warmed this PR yet.
-        pr_id = get_or_fetch_pr_id(
+        # The mapping is immutable, so it is cached; the client is built and
+        # touched only when no webhook has warmed this PR yet.
+        pr_id = resolve_pr_id(
             provider=PR_ITERATION_PROVIDER,
+            organization_id=organization_id,
+            integration=integration,
             repo_external_id=repo.external_id,
+            repo_name=repo.name,
             pr_number=pr_number,
-            fetch=lambda: _fetch_pr_id(client, repo.name, pr_number),
+            caller="mention",
         )
     except ApiError:
         logger.warning(
@@ -636,7 +626,12 @@ def trigger_pr_iteration_from_comment(
     if pr_id is None:
         return None
 
-    agent_state = get_agent_state_from_pr_id(organization_id, PR_ITERATION_PROVIDER, pr_id)
+    agent_state = get_run_state_for_pr_id(
+        organization_id=organization_id,
+        provider=PR_ITERATION_PROVIDER,
+        pr_id=pr_id,
+        caller="mention",
+    )
     if agent_state is None:
         # No-op: missing runs are expected on regions that don't own the session
         # when webhooks are fanned out everywhere. Do not react/comment as
@@ -662,7 +657,7 @@ def trigger_pr_iteration_from_comment(
             },
         )
         _comment_pr_iteration_ineligible(
-            client,
+            integration.get_installation(organization_id=organization_id).get_client(),
             organization_id=organization_id,
             repo_id=repo.id,
             repo_name=repo.name,
@@ -924,18 +919,18 @@ def trigger_pr_iteration_from_review(
         logger.warning("autofix.pr_iteration.review_trigger.missing_integration", extra=log_extra)
         return None
 
-    client = integration.get_installation(organization_id=organization_id).get_client()
-
     try:
-        # The pull_request_review payload carries only the PR number, but Seer's
-        # run lookup is keyed on GitHub's numeric PR id. A pull_request or
-        # check_suite webhook on this PR has almost certainly warmed the cache
-        # already, so the fetch is the exception rather than the rule.
-        pr_id = get_or_fetch_pr_id(
+        # Same number -> id recovery as the mention path. A check_suite on this
+        # PR has almost certainly warmed the cache already, so building a client
+        # and calling it is the exception rather than the rule.
+        pr_id = resolve_pr_id(
             provider=PR_ITERATION_PROVIDER,
+            organization_id=organization_id,
+            integration=integration,
             repo_external_id=repo.external_id,
+            repo_name=repo.name,
             pr_number=pr_number,
-            fetch=lambda: _fetch_pr_id(client, repo.name, pr_number),
+            caller="review",
         )
     except ApiError:
         logger.warning(
@@ -947,7 +942,12 @@ def trigger_pr_iteration_from_review(
     if pr_id is None:
         return None
 
-    agent_state = get_agent_state_from_pr_id(organization_id, PR_ITERATION_PROVIDER, pr_id)
+    agent_state = get_run_state_for_pr_id(
+        organization_id=organization_id,
+        provider=PR_ITERATION_PROVIDER,
+        pr_id=pr_id,
+        caller="review",
+    )
     if agent_state is None or not agent_state.repo_pr_states:
         metrics.incr("autofix.pr_iteration.review_trigger.no_run")
         logger.info(

--- a/src/sentry/tasks/seer/pr_iteration.py
+++ b/src/sentry/tasks/seer/pr_iteration.py
@@ -900,10 +900,25 @@ def trigger_pr_iteration_from_review(
         return None
 
     client = integration.get_installation(organization_id=organization_id).get_client()
-    try:
+
+    def _fetch_pr_id() -> int | None:
         # Async task: the PR may be deleted, made private, or GitHub may return a
         # transient error between webhook receipt and execution.
         pull_request = client.get_pull_request(repo.name, str(pr_number))
+        pr_id: int | None = pull_request.get("id")
+        return pr_id
+
+    try:
+        # The pull_request_review payload carries only the PR number, but Seer's
+        # run lookup is keyed on GitHub's numeric PR id. A pull_request or
+        # check_suite webhook on this PR has almost certainly warmed the cache
+        # already, so the fetch above is the exception rather than the rule.
+        pr_id = get_or_fetch_pr_id(
+            provider=repo.provider,
+            repo_external_id=repo.external_id,
+            pr_number=pr_number,
+            fetch=_fetch_pr_id,
+        )
     except ApiError:
         logger.warning(
             "autofix.pr_iteration.review_trigger.get_pull_request_failed",
@@ -911,7 +926,6 @@ def trigger_pr_iteration_from_review(
             exc_info=True,
         )
         return None
-    pr_id = pull_request.get("id")
     if pr_id is None:
         return None
 

--- a/tests/sentry/integrations/github/test_webhook.py
+++ b/tests/sentry/integrations/github/test_webhook.py
@@ -38,6 +38,7 @@ from sentry.integrations.models.external_actor import ExternalActor
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.services.integration import integration_service
+from sentry.integrations.source_code_management.pr_id_cache import get_cached_pr_id
 from sentry.integrations.types import ExternalActorSource, ExternalProviders
 from sentry.middleware.integrations.parsers.github import GithubRequestParser
 from sentry.models.activity import Activity
@@ -1375,6 +1376,20 @@ class PullRequestEventWebhookTest(APITestCase):
 
         assert response.status_code == 204
         return integration
+
+    def test_warms_pr_id_cache(self) -> None:
+        # An `@sentry` mention arrives as an issue_comment, which carries only the
+        # PR number; warming here is what keeps that path off the REST API.
+        self._create_integration_and_repo()
+
+        self._post_pull_request_event(PULL_REQUEST_OPENED_EVENT_EXAMPLE)
+
+        assert (
+            get_cached_pr_id(
+                provider="integrations:github", repo_external_id="35129377", pr_number=1
+            )
+            == 34778301
+        )
 
     @patch("sentry.integrations.github.webhook.PullRequestEventWebhook.__call__")
     def test_github_delivery_id_extracted_and_passed_to_processors(

--- a/tests/sentry/integrations/github_enterprise/test_webhooks.py
+++ b/tests/sentry/integrations/github_enterprise/test_webhooks.py
@@ -710,19 +710,17 @@ class PullRequestEventWebhook(APITestCase):
 
     def test_does_not_warm_pr_id_cache(self, mock_get_installation_metadata: MagicMock) -> None:
         # GHE shares github.com's handler, but its repo ids restart at 1 on every
-        # instance, so an entry keyed on them could name another host's repo.
+        # instance, so an entry keyed on one could name another host's repo.
+        #
+        # Read back under the *github.com* provider: that is the key a handler
+        # passing anything but `repo.provider` would have written, and the only
+        # one that can fail here. Reading back under `integrations:github_enterprise`
+        # would assert nothing, since `get_cached_pr_id` turns every unsupported
+        # provider away before it reaches the cache at all.
         mock_get_installation_metadata.return_value = self.metadata
 
         self._post_pull_request_event(PULL_REQUEST_OPENED_EVENT_EXAMPLE)
 
-        assert (
-            get_cached_pr_id(
-                provider="integrations:github_enterprise",
-                repo_external_id=self.repo.external_id,
-                pr_number=1,
-            )
-            is None
-        )
         assert (
             get_cached_pr_id(
                 provider="integrations:github",

--- a/tests/sentry/integrations/github_enterprise/test_webhooks.py
+++ b/tests/sentry/integrations/github_enterprise/test_webhooks.py
@@ -32,6 +32,7 @@ from sentry.integrations.github_enterprise.webhook import (
     get_host,
 )
 from sentry.integrations.services.integration import integration_service
+from sentry.integrations.source_code_management.pr_id_cache import get_cached_pr_id
 from sentry.issues.action_log import SYSTEM_ACTOR, ActionSource
 from sentry.issues.action_log.types import PullRequestMergedAction
 from sentry.middleware.integrations.parsers.github_enterprise import (
@@ -706,6 +707,30 @@ class PullRequestEventWebhook(APITestCase):
         assert pr.author.name == "baxterthehacker"
 
         assert_success_metric(mock_record)
+
+    def test_does_not_warm_pr_id_cache(self, mock_get_installation_metadata: MagicMock) -> None:
+        # GHE shares github.com's handler, but its repo ids restart at 1 on every
+        # instance, so an entry keyed on them could name another host's repo.
+        mock_get_installation_metadata.return_value = self.metadata
+
+        self._post_pull_request_event(PULL_REQUEST_OPENED_EVENT_EXAMPLE)
+
+        assert (
+            get_cached_pr_id(
+                provider="integrations:github_enterprise",
+                repo_external_id=self.repo.external_id,
+                pr_number=1,
+            )
+            is None
+        )
+        assert (
+            get_cached_pr_id(
+                provider="integrations:github",
+                repo_external_id=self.repo.external_id,
+                pr_number=1,
+            )
+            is None
+        )
 
     @patch("sentry.integrations.github.webhook.PullRequestEventWebhook.__call__")
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")

--- a/tests/sentry/integrations/source_code_management/test_pr_id_cache.py
+++ b/tests/sentry/integrations/source_code_management/test_pr_id_cache.py
@@ -3,12 +3,13 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from sentry.integrations.source_code_management.pr_id_cache import (
-    PR_ID_CACHE_TTL,
+    PR_ID_CACHE_TTL_OPTION,
     get_cached_pr_id,
     get_or_fetch_pr_id,
     set_cached_pr_id,
 )
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.options import override_options
 
 MODULE_PATH = "sentry.integrations.source_code_management.pr_id_cache"
 METRICS_KEY = "integrations.source_code_management.pr_id_cache"
@@ -131,12 +132,64 @@ class PrIdCacheTest(TestCase):
 
     @patch(f"{MODULE_PATH}.cache")
     def test_ttl_is_applied(self, mock_cache: MagicMock) -> None:
-        set_cached_pr_id(provider=GITHUB, repo_external_id="654321", pr_number=7, pr_id=111)
+        with override_options({PR_ID_CACHE_TTL_OPTION: 3600}):
+            set_cached_pr_id(provider=GITHUB, repo_external_id="654321", pr_number=7, pr_id=111)
 
         key, value, ttl = mock_cache.set.call_args[0]
         assert value == 111
-        assert ttl == PR_ID_CACHE_TTL
+        assert ttl == 3600
         assert key == "scm:pr-id:1:integrations:github:654321:7"
+
+    @patch(f"{MODULE_PATH}.cache")
+    def test_zero_ttl_stores_nothing(self, mock_cache: MagicMock) -> None:
+        """The off switch, so an entry nothing will read is never written."""
+        with override_options({PR_ID_CACHE_TTL_OPTION: 0}):
+            set_cached_pr_id(provider=GITHUB, repo_external_id="654321", pr_number=7, pr_id=111)
+
+        mock_cache.set.assert_not_called()
+
+    @patch(f"{MODULE_PATH}.cache")
+    def test_zero_ttl_reads_nothing(self, mock_cache: MagicMock) -> None:
+        with override_options({PR_ID_CACHE_TTL_OPTION: 0}):
+            assert (
+                get_cached_pr_id(provider=GITHUB, repo_external_id="654321", pr_number=7) is None
+            )
+
+        mock_cache.get.assert_not_called()
+
+    def test_zero_ttl_sends_every_caller_to_the_fetch(self) -> None:
+        """Turning the cache off is a latency regression, never a wrong id."""
+        calls = []
+
+        def fetch() -> int | None:
+            calls.append(1)
+            return 279147437
+
+        with override_options({PR_ID_CACHE_TTL_OPTION: 0}):
+            for _ in range(2):
+                assert (
+                    get_or_fetch_pr_id(
+                        provider=GITHUB,
+                        repo_external_id="654321",
+                        pr_number=7,
+                        fetch=fetch,
+                    )
+                    == 279147437
+                )
+
+        assert len(calls) == 2
+
+    @patch(f"{MODULE_PATH}.metrics.incr")
+    @patch(f"{MODULE_PATH}.cache")
+    def test_disabled_is_counted_apart_from_a_miss(
+        self, mock_cache: MagicMock, mock_incr: MagicMock
+    ) -> None:
+        with override_options({PR_ID_CACHE_TTL_OPTION: 0}):
+            get_cached_pr_id(provider=GITHUB, repo_external_id="654321", pr_number=7)
+            set_cached_pr_id(provider=GITHUB, repo_external_id="654321", pr_number=7, pr_id=111)
+
+        assert mock_incr.call_args_list[0].kwargs["tags"] == {"result": "disabled"}
+        assert mock_incr.call_args_list[1].kwargs["tags"] == {"result": "disabled"}
 
     @patch(f"{MODULE_PATH}.cache")
     def test_cache_backend_failure_on_set_is_swallowed(self, mock_cache: MagicMock) -> None:

--- a/tests/sentry/integrations/source_code_management/test_pr_id_cache.py
+++ b/tests/sentry/integrations/source_code_management/test_pr_id_cache.py
@@ -1,0 +1,226 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sentry.integrations.source_code_management.pr_id_cache import (
+    PR_ID_CACHE_TTL,
+    get_cached_pr_id,
+    get_or_fetch_pr_id,
+    set_cached_pr_id,
+)
+from sentry.testutils.cases import TestCase
+
+MODULE_PATH = "sentry.integrations.source_code_management.pr_id_cache"
+METRICS_KEY = "integrations.source_code_management.pr_id_cache"
+GITHUB = "integrations:github"
+
+
+class PrIdCacheTest(TestCase):
+    def test_set_then_get_round_trips(self) -> None:
+        set_cached_pr_id(provider=GITHUB, repo_external_id="654321", pr_number=7, pr_id=279147437)
+
+        assert (
+            get_cached_pr_id(provider=GITHUB, repo_external_id="654321", pr_number=7) == 279147437
+        )
+
+    def test_get_misses_for_unknown_pr(self) -> None:
+        assert get_cached_pr_id(provider=GITHUB, repo_external_id="654321", pr_number=99) is None
+
+    def test_pr_number_scopes_the_entry(self) -> None:
+        set_cached_pr_id(provider=GITHUB, repo_external_id="654321", pr_number=7, pr_id=111)
+
+        assert get_cached_pr_id(provider=GITHUB, repo_external_id="654321", pr_number=8) is None
+
+    def test_repo_scopes_the_entry(self) -> None:
+        set_cached_pr_id(provider=GITHUB, repo_external_id="654321", pr_number=7, pr_id=111)
+
+        assert get_cached_pr_id(provider=GITHUB, repo_external_id="999999", pr_number=7) is None
+
+    def test_missing_repo_external_id_is_not_cached(self) -> None:
+        set_cached_pr_id(provider=GITHUB, repo_external_id=None, pr_number=7, pr_id=111)
+
+        assert get_cached_pr_id(provider=GITHUB, repo_external_id=None, pr_number=7) is None
+
+    @patch(f"{MODULE_PATH}.metrics.incr")
+    def test_missing_repo_external_id_is_counted(self, mock_incr: MagicMock) -> None:
+        # `Repository.external_id` is nullable, so this is how we find out how
+        # many lookups a null one costs us.
+        set_cached_pr_id(provider=GITHUB, repo_external_id=None, pr_number=7, pr_id=111)
+        get_cached_pr_id(provider=GITHUB, repo_external_id=None, pr_number=7)
+
+        assert [(call.args[0], call.kwargs["tags"]) for call in mock_incr.call_args_list] == [
+            (f"{METRICS_KEY}.set", {"result": "unkeyable", "missing": "repo_external_id"}),
+            (f"{METRICS_KEY}.get", {"result": "unkeyable", "missing": "repo_external_id"}),
+        ]
+
+    @patch(f"{MODULE_PATH}.metrics.incr")
+    def test_missing_provider_is_counted(self, mock_incr: MagicMock) -> None:
+        # `Repository.provider` is nullable too, and a row without one is broken
+        # rather than merely unsupported — so it is counted wherever it comes
+        # from, before the supported-provider check can absorb it.
+        set_cached_pr_id(provider=None, repo_external_id="654321", pr_number=7, pr_id=111)
+        get_cached_pr_id(provider=None, repo_external_id="654321", pr_number=7)
+
+        assert [(call.args[0], call.kwargs["tags"]) for call in mock_incr.call_args_list] == [
+            (f"{METRICS_KEY}.set", {"result": "unkeyable", "missing": "provider"}),
+            (f"{METRICS_KEY}.get", {"result": "unkeyable", "missing": "provider"}),
+        ]
+
+    @patch(f"{MODULE_PATH}.metrics.incr")
+    def test_unsupported_provider_is_not_counted(self, mock_incr: MagicMock) -> None:
+        # A present-but-unsupported provider is working as designed. Counting it
+        # would bury the broken rows under traffic that was never cacheable —
+        # including its missing external id, which never reaches that check.
+        set_cached_pr_id(
+            provider="integrations:github_enterprise", repo_external_id=None, pr_number=7, pr_id=111
+        )
+        get_cached_pr_id(
+            provider="integrations:github_enterprise", repo_external_id=None, pr_number=7
+        )
+
+        mock_incr.assert_not_called()
+
+    def test_github_enterprise_is_not_cached(self) -> None:
+        # GitHub Enterprise repo ids restart at 1 on every instance, so an entry
+        # keyed on the provider string alone could name another host's repo.
+        set_cached_pr_id(
+            provider="integrations:github_enterprise",
+            repo_external_id="1",
+            pr_number=7,
+            pr_id=111,
+        )
+
+        assert (
+            get_cached_pr_id(
+                provider="integrations:github_enterprise", repo_external_id="1", pr_number=7
+            )
+            is None
+        )
+
+    @patch(f"{MODULE_PATH}.cache")
+    def test_ttl_is_applied(self, mock_cache: MagicMock) -> None:
+        set_cached_pr_id(provider=GITHUB, repo_external_id="654321", pr_number=7, pr_id=111)
+
+        key, value, ttl = mock_cache.set.call_args[0]
+        assert value == 111
+        assert ttl == PR_ID_CACHE_TTL
+        assert key == "scm:pr-id:1:integrations:github:654321:7"
+
+    @patch(f"{MODULE_PATH}.cache")
+    def test_cache_backend_failure_on_set_is_swallowed(self, mock_cache: MagicMock) -> None:
+        mock_cache.set.side_effect = RuntimeError("cache is down")
+
+        set_cached_pr_id(provider=GITHUB, repo_external_id="654321", pr_number=7, pr_id=111)
+
+    @patch(f"{MODULE_PATH}.cache")
+    def test_cache_backend_failure_on_get_reads_as_a_miss(self, mock_cache: MagicMock) -> None:
+        mock_cache.get.side_effect = RuntimeError("cache is down")
+
+        assert get_cached_pr_id(provider=GITHUB, repo_external_id="654321", pr_number=7) is None
+
+
+class PrIdCacheKeyScopeTest(TestCase):
+    def test_key_is_unaffected_by_sentry_org(self) -> None:
+        # One GitHub App installation can be linked to several Sentry orgs; the
+        # mapping is a fact about GitHub, so every org must share one entry.
+        other_org = self.create_organization()
+        repo = self.create_repo(
+            project=self.project, provider=GITHUB, external_id="654321", name="owner/repo"
+        )
+        other_repo = self.create_repo(
+            project=self.create_project(organization=other_org),
+            provider=GITHUB,
+            external_id="654321",
+            name="owner/repo",
+        )
+        assert repo.organization_id != other_repo.organization_id
+
+        set_cached_pr_id(
+            provider=repo.provider,
+            repo_external_id=repo.external_id,
+            pr_number=7,
+            pr_id=279147437,
+        )
+
+        assert (
+            get_cached_pr_id(
+                provider=other_repo.provider,
+                repo_external_id=other_repo.external_id,
+                pr_number=7,
+            )
+            == 279147437
+        )
+
+
+class GetOrFetchPrIdTest(TestCase):
+    def test_hit_does_not_call_fetch(self) -> None:
+        set_cached_pr_id(provider=GITHUB, repo_external_id="654321", pr_number=7, pr_id=111)
+        fetch = MagicMock()
+
+        result = get_or_fetch_pr_id(
+            provider=GITHUB, repo_external_id="654321", pr_number=7, fetch=fetch
+        )
+
+        assert result == 111
+        fetch.assert_not_called()
+
+    def test_miss_fetches_and_populates(self) -> None:
+        fetch = MagicMock(return_value=222)
+
+        result = get_or_fetch_pr_id(
+            provider=GITHUB, repo_external_id="654321", pr_number=7, fetch=fetch
+        )
+
+        assert result == 222
+        fetch.assert_called_once_with()
+        assert get_cached_pr_id(provider=GITHUB, repo_external_id="654321", pr_number=7) == 222
+
+    def test_negative_result_is_not_cached(self) -> None:
+        fetch = MagicMock(return_value=None)
+
+        assert (
+            get_or_fetch_pr_id(provider=GITHUB, repo_external_id="654321", pr_number=7, fetch=fetch)
+            is None
+        )
+        assert get_cached_pr_id(provider=GITHUB, repo_external_id="654321", pr_number=7) is None
+
+        # The next call still asks the provider, so a transient failure cannot
+        # become a persistent one.
+        fetch.return_value = 333
+        assert (
+            get_or_fetch_pr_id(provider=GITHUB, repo_external_id="654321", pr_number=7, fetch=fetch)
+            == 333
+        )
+
+    def test_unkeyable_repo_still_fetches(self) -> None:
+        # A repo we cannot key is a permanent miss, not a failure: the caller
+        # keeps paying the REST call it already paid before this cache existed.
+        fetch = MagicMock(return_value=444)
+
+        result = get_or_fetch_pr_id(
+            provider=GITHUB, repo_external_id=None, pr_number=7, fetch=fetch
+        )
+
+        assert result == 444
+        fetch.assert_called_once_with()
+
+    def test_unsupported_provider_still_fetches(self) -> None:
+        fetch = MagicMock(return_value=555)
+
+        result = get_or_fetch_pr_id(
+            provider="integrations:github_enterprise",
+            repo_external_id="1",
+            pr_number=7,
+            fetch=fetch,
+        )
+
+        assert result == 555
+        fetch.assert_called_once_with()
+
+    def test_fetch_exception_propagates(self) -> None:
+        fetch = MagicMock(side_effect=ValueError("boom"))
+
+        with pytest.raises(ValueError):
+            get_or_fetch_pr_id(provider=GITHUB, repo_external_id="654321", pr_number=7, fetch=fetch)
+
+        assert get_cached_pr_id(provider=GITHUB, repo_external_id="654321", pr_number=7) is None

--- a/tests/sentry/integrations/source_code_management/test_pr_id_cache.py
+++ b/tests/sentry/integrations/source_code_management/test_pr_id_cache.py
@@ -151,9 +151,7 @@ class PrIdCacheTest(TestCase):
     @patch(f"{MODULE_PATH}.cache")
     def test_zero_ttl_reads_nothing(self, mock_cache: MagicMock) -> None:
         with override_options({PR_ID_CACHE_TTL_OPTION: 0}):
-            assert (
-                get_cached_pr_id(provider=GITHUB, repo_external_id="654321", pr_number=7) is None
-            )
+            assert get_cached_pr_id(provider=GITHUB, repo_external_id="654321", pr_number=7) is None
 
         mock_cache.get.assert_not_called()
 

--- a/tests/sentry/integrations/source_code_management/test_pr_id_cache.py
+++ b/tests/sentry/integrations/source_code_management/test_pr_id_cache.py
@@ -26,6 +26,38 @@ class PrIdCacheTest(TestCase):
     def test_get_misses_for_unknown_pr(self) -> None:
         assert get_cached_pr_id(provider=GITHUB, repo_external_id="654321", pr_number=99) is None
 
+    @patch(f"{MODULE_PATH}.metrics.incr")
+    def test_unknown_pr_is_counted_as_a_miss(self, mock_incr: MagicMock) -> None:
+        get_cached_pr_id(provider=GITHUB, repo_external_id="654321", pr_number=99)
+
+        assert [(call.args[0], call.kwargs["tags"]) for call in mock_incr.call_args_list] == [
+            (f"{METRICS_KEY}.get", {"result": "miss"}),
+        ]
+
+    @patch(f"{MODULE_PATH}.cache")
+    def test_unusable_cached_value_is_not_returned(self, mock_cache: MagicMock) -> None:
+        # `True` is the one worth pinning: bool is an int subclass, so it would
+        # sail through an isinstance check and be handed back as a PR id.
+        mock_cache.get.return_value = True
+
+        assert get_cached_pr_id(provider=GITHUB, repo_external_id="654321", pr_number=7) is None
+
+    @patch(f"{MODULE_PATH}.metrics.incr")
+    @patch(f"{MODULE_PATH}.cache")
+    def test_unusable_cached_value_is_counted_apart_from_a_miss(
+        self, mock_cache: MagicMock, mock_incr: MagicMock
+    ) -> None:
+        # Nothing here writes a non-int, so one turning up means the entry did
+        # not come from `set_cached_pr_id`. Counted as a miss it would be
+        # indistinguishable from ordinary cold-cache traffic.
+        mock_cache.get.return_value = "279147437"
+
+        get_cached_pr_id(provider=GITHUB, repo_external_id="654321", pr_number=7)
+
+        assert [(call.args[0], call.kwargs["tags"]) for call in mock_incr.call_args_list] == [
+            (f"{METRICS_KEY}.get", {"result": "invalid"}),
+        ]
+
     def test_pr_number_scopes_the_entry(self) -> None:
         set_cached_pr_id(provider=GITHUB, repo_external_id="654321", pr_number=7, pr_id=111)
 

--- a/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
@@ -103,18 +103,18 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
             metadata={"group_id": self.group.id},
         )
 
-    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITES_PATH}.get_run_state_for_pr_id")
     def test_skips_non_completed_action(self, mock_get_state: MagicMock) -> None:
         pr_iteration_from_check_suite_listener(self._event(action="requested"))
         mock_get_state.assert_not_called()
 
-    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITES_PATH}.get_run_state_for_pr_id")
     def test_skips_uninteresting_conclusion(self, mock_get_state: MagicMock) -> None:
         pr_iteration_from_check_suite_listener(self._event(conclusion="cancelled"))
         mock_get_state.assert_not_called()
 
     @patch(f"{CHECK_PATH}.resolve_green_check_suite")
-    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITES_PATH}.get_run_state_for_pr_id")
     def test_skips_github_enterprise(
         self, mock_get_state: MagicMock, mock_resolve: MagicMock
     ) -> None:
@@ -133,7 +133,7 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
     @patch(f"{CHECK_PATH}.mark_ready_for_review")
     @patch(f"{CHECK_PATH}.confirm_green_check_suite")
     @patch(f"{CHECK_PATH}.resolve_green_check_suite")
-    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITES_PATH}.get_run_state_for_pr_id")
     def test_green_conclusion_bootstraps_then_side_effects(
         self,
         mock_get_state: MagicMock,
@@ -166,7 +166,7 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
     @patch(f"{CHECK_PATH}.mark_ready_for_review")
     @patch(f"{CHECK_PATH}.confirm_green_check_suite")
     @patch(f"{CHECK_PATH}.resolve_green_check_suite")
-    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITES_PATH}.get_run_state_for_pr_id")
     def test_green_conclusion_runs_only_needed_side_effects(
         self,
         mock_get_state: MagicMock,
@@ -204,7 +204,7 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
     @patch(f"{CHECK_PATH}.mark_ready_for_review")
     @patch(f"{CHECK_PATH}.confirm_green_check_suite")
     @patch(f"{CHECK_PATH}.resolve_green_check_suite")
-    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITES_PATH}.get_run_state_for_pr_id")
     def test_green_conclusion_skips_scm_when_both_markers_set(
         self,
         mock_get_state: MagicMock,
@@ -228,7 +228,7 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
     @patch(f"{CHECK_PATH}.mark_ready_for_review")
     @patch(f"{CHECK_PATH}.confirm_green_check_suite", return_value=None)
     @patch(f"{CHECK_PATH}.resolve_green_check_suite")
-    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITES_PATH}.get_run_state_for_pr_id")
     def test_green_conclusion_skips_side_effects_when_confirm_empty(
         self,
         mock_get_state: MagicMock,
@@ -246,13 +246,13 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         mock_get_state.assert_not_called()
 
     @patch(f"{CHECK_SUITES_PATH}.resolve_check_suite_repositories", return_value=[])
-    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITES_PATH}.get_run_state_for_pr_id")
     def test_no_repository(self, mock_get_state: MagicMock, _mock_resolve: MagicMock) -> None:
         pr_iteration_from_check_suite_listener(self._event(self._raw()))
         mock_get_state.assert_not_called()
 
     @patch(f"{CHECK_PATH}.sentry_sdk.capture_exception")
-    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITES_PATH}.get_run_state_for_pr_id")
     def test_invalid_payload_captures_and_returns(
         self, mock_get_state: MagicMock, mock_capture: MagicMock
     ) -> None:
@@ -263,7 +263,7 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         mock_get_state.assert_not_called()
 
     @patch(f"{CHECK_PATH}.sentry_sdk.capture_exception")
-    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITES_PATH}.get_run_state_for_pr_id")
     def test_invalid_json_captures_and_returns(
         self, mock_get_state: MagicMock, mock_capture: MagicMock
     ) -> None:
@@ -274,7 +274,7 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         mock_get_state.assert_not_called()
 
     @patch(f"{CHECK_PATH}.try_enqueue_autofix_feedback")
-    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id", return_value=None)
+    @patch(f"{CHECK_SUITES_PATH}.get_run_state_for_pr_id", return_value=None)
     @patch(f"{CHECK_SUITES_PATH}.resolve_check_suite_repositories")
     def test_skips_pr_without_run(
         self,
@@ -290,7 +290,7 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         mock_enqueue.assert_not_called()
 
     @patch(f"{CHECK_PATH}.try_enqueue_autofix_feedback")
-    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITES_PATH}.get_run_state_for_pr_id")
     @patch(f"{CHECK_SUITES_PATH}.resolve_check_suite_repositories")
     def test_skips_run_missing_group_id(
         self,
@@ -311,7 +311,7 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
     @patch(f"{CHECK_PATH}.assign_user_for_exhausted_cap")
     @patch(TRIGGER_CONSUME_PATH)
     @patch(f"{CHECK_PATH}.try_enqueue_autofix_feedback", return_value=False)
-    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITES_PATH}.get_run_state_for_pr_id")
     @patch(f"{CHECK_SUITES_PATH}.resolve_check_suite_repositories")
     def test_does_not_trigger_when_not_enqueued(
         self,
@@ -338,7 +338,7 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
     @patch(f"{CHECK_PATH}.assign_user_for_exhausted_cap")
     @patch(TRIGGER_CONSUME_PATH)
     @patch(f"{CHECK_PATH}.try_enqueue_autofix_feedback", return_value=True)
-    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITES_PATH}.get_run_state_for_pr_id")
     @patch(f"{CHECK_SUITES_PATH}.resolve_check_suite_repositories")
     def test_enqueues_and_triggers_for_matched_run(
         self,
@@ -373,7 +373,7 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
     @patch(f"{CHECK_SUITES_PATH}.sentry_sdk.capture_exception")
     @patch(TRIGGER_CONSUME_PATH)
     @patch(f"{CHECK_PATH}.try_enqueue_autofix_feedback", return_value=True)
-    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITES_PATH}.get_run_state_for_pr_id")
     @patch(f"{CHECK_SUITES_PATH}.resolve_check_suite_repositories")
     def test_seer_error_on_one_pr_continues_to_remaining(
         self,
@@ -399,7 +399,7 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
 
     @patch(TRIGGER_CONSUME_PATH)
     @patch(f"{CHECK_PATH}.try_enqueue_autofix_feedback", return_value=True)
-    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITES_PATH}.get_run_state_for_pr_id")
     @patch(f"{CHECK_SUITES_PATH}.resolve_check_suite_repositories")
     def test_tries_each_org_until_agent_state_found(
         self,
@@ -417,8 +417,15 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         pr_iteration_from_check_suite_listener(self._event(raw))
 
         assert mock_get_state.call_count == 2
-        mock_get_state.assert_any_call(111, "integrations:github", 555)
-        mock_get_state.assert_any_call(self.organization.id, "integrations:github", 555)
+        mock_get_state.assert_any_call(
+            organization_id=111, provider="integrations:github", pr_id=555, caller="check_suite"
+        )
+        mock_get_state.assert_any_call(
+            organization_id=self.organization.id,
+            provider="integrations:github",
+            pr_id=555,
+            caller="check_suite",
+        )
         _, kwargs = mock_enqueue.call_args
         assert kwargs["organization_id"] == self.organization.id
         mock_trigger_consume.assert_called_once()
@@ -455,7 +462,7 @@ class ResolveCheckSuiteAutofixRunTest(TestCase):
             metadata={"group_id": 1},
         )
 
-    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITES_PATH}.get_run_state_for_pr_id")
     @patch(f"{CHECK_SUITES_PATH}.resolve_check_suite_repositories")
     def test_warms_pr_id_cache_for_kept_entries(
         self,
@@ -474,7 +481,7 @@ class ResolveCheckSuiteAutofixRunTest(TestCase):
                     {"id": 222, "number": 8, "base": {"repo": {"id": 456}}},
                 ],
                 repository_id=OWN_REPO_ID,
-            )
+            ),
         )
 
         assert (
@@ -496,7 +503,7 @@ class ResolveCheckSuiteAutofixRunTest(TestCase):
         )
 
     @patch(f"{CHECK_SUITES_PATH}.logger")
-    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITES_PATH}.get_run_state_for_pr_id")
     @patch(f"{CHECK_SUITES_PATH}.resolve_check_suite_repositories")
     def test_warns_and_returns_first_when_multiple_matches(
         self,
@@ -513,7 +520,7 @@ class ResolveCheckSuiteAutofixRunTest(TestCase):
         result = resolve_check_suite_autofix_run(
             self._event(
                 pull_requests=[own_repo_pr(111), own_repo_pr(222)], repository_id=OWN_REPO_ID
-            )
+            ),
         )
 
         assert result is not None
@@ -529,7 +536,7 @@ class ResolveCheckSuiteAutofixRunTest(TestCase):
             },
         )
 
-    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITES_PATH}.get_run_state_for_pr_id")
     @patch(f"{CHECK_SUITES_PATH}.resolve_check_suite_repositories")
     def test_skips_pull_request_based_in_another_repo(
         self, mock_resolve: MagicMock, mock_get_state: MagicMock
@@ -541,13 +548,13 @@ class ResolveCheckSuiteAutofixRunTest(TestCase):
             self._event(
                 repository_id=123,
                 pull_requests=[{"id": 111, "base": {"repo": {"id": 456}}}],
-            )
+            ),
         )
 
         assert result is None
         assert mock_get_state.call_count == 0
 
-    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITES_PATH}.get_run_state_for_pr_id")
     @patch(f"{CHECK_SUITES_PATH}.resolve_check_suite_repositories")
     def test_foreign_entry_does_not_shadow_own_repo_entry(
         self, mock_resolve: MagicMock, mock_get_state: MagicMock
@@ -563,14 +570,19 @@ class ResolveCheckSuiteAutofixRunTest(TestCase):
                     {"id": 111, "base": {"repo": {"id": 456}}},
                     {"id": 222, "base": {"repo": {"id": 123}}},
                 ],
-            )
+            ),
         )
 
         assert result is not None
         assert result.pr_id == 222
-        mock_get_state.assert_called_once_with(self.organization.id, "integrations:github", 222)
+        mock_get_state.assert_called_once_with(
+            organization_id=self.organization.id,
+            provider="integrations:github",
+            pr_id=222,
+            caller="check_suite",
+        )
 
-    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITES_PATH}.get_run_state_for_pr_id")
     @patch(f"{CHECK_SUITES_PATH}.resolve_check_suite_repositories")
     def test_skips_entry_carrying_no_base_repo(
         self, mock_resolve: MagicMock, mock_get_state: MagicMock
@@ -588,7 +600,7 @@ class ResolveCheckSuiteAutofixRunTest(TestCase):
         assert result is None
         assert mock_get_state.call_count == 0
 
-    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITES_PATH}.get_run_state_for_pr_id")
     @patch(f"{CHECK_SUITES_PATH}.resolve_check_suite_repositories")
     def test_unplaceable_entry_does_not_shadow_own_repo_entry(
         self, mock_resolve: MagicMock, mock_get_state: MagicMock
@@ -601,14 +613,19 @@ class ResolveCheckSuiteAutofixRunTest(TestCase):
             self._event(
                 repository_id=123,
                 pull_requests=[{"id": 111}, {"id": 222, "base": {"repo": {"id": 123}}}],
-            )
+            ),
         )
 
         assert result is not None
         assert result.pr_id == 222
-        mock_get_state.assert_called_once_with(self.organization.id, "integrations:github", 222)
+        mock_get_state.assert_called_once_with(
+            organization_id=self.organization.id,
+            provider="integrations:github",
+            pr_id=222,
+            caller="check_suite",
+        )
 
-    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITES_PATH}.get_run_state_for_pr_id")
     @patch(f"{CHECK_SUITES_PATH}.resolve_check_suite_repositories")
     def test_resolves_legacy_entry_round_tripped_through_the_old_model(
         self, mock_resolve: MagicMock, mock_get_state: MagicMock

--- a/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock, patch
 
 import orjson
 
+from sentry.integrations.source_code_management.pr_id_cache import get_cached_pr_id
 from sentry.scm.types import CheckSuiteEvent
 from sentry.seer.agent.client_models import MemoryBlock, Message, RepoPRState, SeerRunState
 from sentry.seer.autofix.constants import AutofixReferrer
@@ -431,6 +432,46 @@ class ResolveCheckSuiteAutofixRunTest(TestCase):
             updated_at="2024-01-01T00:00:00Z",
             repo_pr_states={"owner/repo": RepoPRState(repo_name="owner/repo", commit_sha="abc")},
             metadata={"group_id": 1},
+        )
+
+    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITES_PATH}.resolve_check_suite_repositories")
+    def test_warms_pr_id_cache_for_kept_entries(
+        self,
+        mock_resolve: MagicMock,
+        mock_get_state: MagicMock,
+    ) -> None:
+        # The mention path only ever receives the PR number, so this event —
+        # which holds both halves — is one of the two places that can warm it.
+        mock_resolve.return_value = [MagicMock(organization_id=self.organization.id, id=2)]
+        mock_get_state.return_value = None
+
+        resolve_check_suite_autofix_run(
+            self._event(
+                pull_requests=[
+                    {"id": 111, "number": 7, "base": {"repo": {"id": OWN_REPO_ID}}},
+                    {"id": 222, "number": 8, "base": {"repo": {"id": 456}}},
+                ],
+                repository_id=OWN_REPO_ID,
+            )
+        )
+
+        assert (
+            get_cached_pr_id(
+                provider="integrations:github",
+                repo_external_id=str(OWN_REPO_ID),
+                pr_number=7,
+            )
+            == 111
+        )
+        # The entry based in another repo was dropped before the warm.
+        assert (
+            get_cached_pr_id(
+                provider="integrations:github",
+                repo_external_id=str(OWN_REPO_ID),
+                pr_number=8,
+            )
+            is None
         )
 
     @patch(f"{CHECK_SUITES_PATH}.logger")

--- a/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 import orjson
+from scm.types import ProviderName
 
 from sentry.integrations.source_code_management.pr_id_cache import get_cached_pr_id
 from sentry.scm.types import CheckSuiteEvent
@@ -50,7 +51,12 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         self.group = self.create_group(project=self.project)
 
     def _event(
-        self, raw: dict | None = None, *, action="completed", conclusion="failure"
+        self,
+        raw: dict | None = None,
+        *,
+        action="completed",
+        conclusion="failure",
+        provider: ProviderName = "github",
     ) -> CheckSuiteEvent:
         return CheckSuiteEvent(
             action=action,
@@ -67,7 +73,7 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
                 "extra": {},
                 "received_at": 0,
                 "sentry_meta": None,
-                "type": "github",
+                "type": provider,
             },
         )
 
@@ -106,6 +112,21 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
     def test_skips_uninteresting_conclusion(self, mock_get_state: MagicMock) -> None:
         pr_iteration_from_check_suite_listener(self._event(conclusion="cancelled"))
         mock_get_state.assert_not_called()
+
+    @patch(f"{CHECK_PATH}.resolve_green_check_suite")
+    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
+    def test_skips_github_enterprise(
+        self, mock_get_state: MagicMock, mock_resolve: MagicMock
+    ) -> None:
+        """GHE delivers the same events onto this stream; both paths turn it away."""
+        pr_iteration_from_check_suite_listener(
+            self._event(self._raw(), conclusion="failure", provider="github_enterprise")
+        )
+        pr_iteration_from_check_suite_listener(
+            self._event(self._raw(), conclusion="success", provider="github_enterprise")
+        )
+        mock_get_state.assert_not_called()
+        mock_resolve.assert_not_called()
 
     @patch(f"{CHECK_PATH}.get_run_marker", return_value=None)
     @patch(f"{CHECK_PATH}.request_review_from_context")

--- a/tests/sentry/seer/autofix/pr_iteration/test_run_resolution.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_run_resolution.py
@@ -9,12 +9,13 @@ from sentry.integrations.source_code_management.pr_id_cache import (
 )
 from sentry.seer.agent.client_models import RepoPRState, SeerRunState
 from sentry.seer.autofix.pr_iteration.run_resolution import (
-    NO_RUN_CACHE_TTL,
+    NO_RUN_CACHE_TTL_OPTION,
     get_run_state_for_pr_id,
     resolve_pr_id,
 )
 from sentry.seer.models import SeerApiError
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.options import override_options
 
 MODULE_PATH = "sentry.seer.autofix.pr_iteration.run_resolution"
 METRICS_KEY = "autofix.pr_iteration.run_resolution"
@@ -283,20 +284,74 @@ class GetRunStateForPrIdTest(TestCase):
 
     @patch(f"{MODULE_PATH}.cache")
     @patch(f"{MODULE_PATH}.get_agent_state_from_pr_id")
-    def test_negative_is_written_with_the_long_ttl(
+    def test_negative_is_written_with_the_configured_ttl(
         self, mock_get_state: MagicMock, mock_cache: MagicMock
     ) -> None:
         mock_cache.get.return_value = None
         mock_get_state.return_value = None
 
-        get_run_state_for_pr_id(
-            organization_id=self.organization.id, provider=GITHUB, pr_id=561, caller="mention"
-        )
+        with override_options({NO_RUN_CACHE_TTL_OPTION: 3600}):
+            get_run_state_for_pr_id(
+                organization_id=self.organization.id, provider=GITHUB, pr_id=561, caller="mention"
+            )
 
         key, _value, ttl = mock_cache.set.call_args.args
-        assert ttl == NO_RUN_CACHE_TTL
+        assert ttl == 3600
         assert str(self.organization.id) in key
         assert "561" in key
+
+    @patch(f"{MODULE_PATH}.cache")
+    @patch(f"{MODULE_PATH}.get_agent_state_from_pr_id")
+    def test_zero_ttl_remembers_nothing_and_reads_nothing(
+        self, mock_get_state: MagicMock, mock_cache: MagicMock
+    ) -> None:
+        """The off switch: every lookup asks Seer, so a late-arriving run is seen."""
+        mock_get_state.return_value = None
+
+        with override_options({NO_RUN_CACHE_TTL_OPTION: 0}):
+            for _ in range(2):
+                assert (
+                    get_run_state_for_pr_id(
+                        organization_id=self.organization.id,
+                        provider=GITHUB,
+                        pr_id=565,
+                        caller="mention",
+                    )
+                    is None
+                )
+
+        assert mock_get_state.call_count == 2
+        mock_cache.get.assert_not_called()
+        mock_cache.set.assert_not_called()
+
+    @patch(f"{MODULE_PATH}.get_agent_state_from_pr_id")
+    def test_zero_ttl_sees_a_run_that_appears_after_a_negative(
+        self, mock_get_state: MagicMock
+    ) -> None:
+        """What the long TTL trades away, and what turning it off buys back."""
+        mock_get_state.return_value = None
+
+        with override_options({NO_RUN_CACHE_TTL_OPTION: 0}):
+            assert (
+                get_run_state_for_pr_id(
+                    organization_id=self.organization.id,
+                    provider=GITHUB,
+                    pr_id=566,
+                    caller="mention",
+                )
+                is None
+            )
+
+            mock_get_state.return_value = _run_state()
+            assert (
+                get_run_state_for_pr_id(
+                    organization_id=self.organization.id,
+                    provider=GITHUB,
+                    pr_id=566,
+                    caller="mention",
+                )
+                is not None
+            )
 
     @patch(f"{MODULE_PATH}.metrics.incr")
     @patch(f"{MODULE_PATH}.get_agent_state_from_pr_id")

--- a/tests/sentry/seer/autofix/pr_iteration/test_run_resolution.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_run_resolution.py
@@ -1,0 +1,336 @@
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sentry.integrations.source_code_management.pr_id_cache import (
+    get_cached_pr_id,
+    set_cached_pr_id,
+)
+from sentry.seer.agent.client_models import RepoPRState, SeerRunState
+from sentry.seer.autofix.pr_iteration.run_resolution import (
+    NO_RUN_CACHE_TTL,
+    get_run_state_for_pr_id,
+    resolve_pr_id,
+)
+from sentry.seer.models import SeerApiError
+from sentry.testutils.cases import TestCase
+
+MODULE_PATH = "sentry.seer.autofix.pr_iteration.run_resolution"
+METRICS_KEY = "autofix.pr_iteration.run_resolution"
+GITHUB = "integrations:github"
+
+
+def _run_state(run_id: int = 67890) -> SeerRunState:
+    return SeerRunState(
+        run_id=run_id,
+        blocks=[],
+        status="completed",
+        updated_at="2024-01-01T00:00:00Z",
+        repo_pr_states={"owner/repo": RepoPRState(repo_name="owner/repo", commit_sha="abc")},
+        metadata={"group_id": 1},
+    )
+
+
+def _client(pr_id: int | None = 279147437) -> MagicMock:
+    client = MagicMock()
+    client.get_pull_request.return_value = {"id": pr_id} if pr_id is not None else {}
+    return client
+
+
+def _integration(client: MagicMock) -> MagicMock:
+    """An integration whose installation hands back ``client``."""
+    integration = MagicMock()
+    integration.get_installation.return_value.get_client.return_value = client
+    return integration
+
+
+def _ref(pr_number: int, client: MagicMock | None = None) -> dict[str, Any]:
+    """The identifying kwargs :func:`resolve_pr_id` takes, minus ``caller``."""
+    return {
+        "provider": GITHUB,
+        "organization_id": 1,
+        "integration": _integration(client if client is not None else _client()),
+        "repo_external_id": "654321",
+        "repo_name": "owner/repo",
+        "pr_number": pr_number,
+    }
+
+
+class ResolvePrIdTest(TestCase):
+    def test_reads_the_warmed_cache_without_touching_the_client(self) -> None:
+        set_cached_pr_id(provider=GITHUB, repo_external_id="654321", pr_number=7, pr_id=279147437)
+        client = _client()
+        ref = _ref(7, client)
+
+        assert resolve_pr_id(**ref, caller="mention") == 279147437
+
+        client.get_pull_request.assert_not_called()
+        # The client is not even built on a hit -- the whole reason the
+        # integration is passed instead of a ready-made client.
+        ref["integration"].get_installation.assert_not_called()
+
+    def test_asks_the_provider_on_a_miss_and_stores_the_answer(self) -> None:
+        client = _client()
+        ref = _ref(8, client)
+
+        assert resolve_pr_id(**ref, caller="mention") == 279147437
+        client.get_pull_request.assert_called_once_with("owner/repo", "8")
+
+        # Second call is served from the cache the first one warmed.
+        assert resolve_pr_id(**ref, caller="mention") == 279147437
+        assert client.get_pull_request.call_count == 1
+
+    def test_a_response_without_an_id_is_none_rather_than_a_key_error(self) -> None:
+        """A PR deleted or made private between webhook and task is not a crash."""
+        assert resolve_pr_id(**_ref(9, _client(pr_id=None)), caller="mention") is None
+
+    def test_provider_errors_propagate(self) -> None:
+        """Callers keep their own ``except ApiError`` around this call."""
+        client = _client()
+        client.get_pull_request.side_effect = ValueError("boom")
+
+        with pytest.raises(ValueError):
+            resolve_pr_id(**_ref(10, client), caller="mention")
+
+    def test_passes_the_callers_provider_to_the_cache(self) -> None:
+        with patch(f"{MODULE_PATH}.get_or_fetch_pr_id", return_value=279147437) as mock_cache:
+            resolve_pr_id(**_ref(7), caller="mention")
+
+        assert mock_cache.call_args.kwargs["provider"] == GITHUB
+
+    def test_a_ghe_ref_degrades_to_an_uncached_fetch_rather_than_colliding(self) -> None:
+        """GHE repo ids are per-instance, so the cache declines to store them.
+
+        The provider reaching ``pr_id_cache`` intact is what makes that decision
+        possible -- pinned to github.com, this entry would be stored under an id
+        that names a different repository on every other host.
+        """
+        client = _client()
+        ghe_ref: dict[str, Any] = {
+            "provider": "integrations:github_enterprise",
+            "organization_id": 1,
+            "integration": _integration(client),
+            "repo_external_id": "1",
+            "repo_name": "owner/repo",
+            "pr_number": 7,
+        }
+
+        assert resolve_pr_id(**ghe_ref, caller="mention") == 279147437
+        assert resolve_pr_id(**ghe_ref, caller="mention") == 279147437
+
+        # Every call pays the round-trip, and nothing lands in github.com's keyspace.
+        assert client.get_pull_request.call_count == 2
+        assert get_cached_pr_id(provider=GITHUB, repo_external_id="1", pr_number=7) is None
+
+
+class GetRunStateForPrIdTest(TestCase):
+    @patch(f"{MODULE_PATH}.get_agent_state_from_pr_id")
+    def test_returns_the_run_and_never_caches_it(self, mock_get_state: MagicMock) -> None:
+        mock_get_state.return_value = _run_state()
+
+        assert (
+            get_run_state_for_pr_id(
+                organization_id=self.organization.id, provider=GITHUB, pr_id=555, caller="mention"
+            )
+            is not None
+        )
+        assert (
+            get_run_state_for_pr_id(
+                organization_id=self.organization.id, provider=GITHUB, pr_id=555, caller="mention"
+            )
+            is not None
+        )
+
+        # Live, mutable state: every caller gets a fresh read.
+        assert mock_get_state.call_count == 2
+        mock_get_state.assert_called_with(self.organization.id, GITHUB, 555)
+
+    @patch(f"{MODULE_PATH}.get_agent_state_from_pr_id")
+    def test_absent_run_is_remembered(self, mock_get_state: MagicMock) -> None:
+        mock_get_state.return_value = None
+
+        assert (
+            get_run_state_for_pr_id(
+                organization_id=self.organization.id, provider=GITHUB, pr_id=556, caller="mention"
+            )
+            is None
+        )
+        assert (
+            get_run_state_for_pr_id(
+                organization_id=self.organization.id, provider=GITHUB, pr_id=556, caller="mention"
+            )
+            is None
+        )
+
+        assert mock_get_state.call_count == 1
+
+    @patch(f"{MODULE_PATH}.get_agent_state_from_pr_id")
+    def test_404_is_treated_as_absent_and_remembered(self, mock_get_state: MagicMock) -> None:
+        mock_get_state.side_effect = SeerApiError("not found", 404)
+
+        assert (
+            get_run_state_for_pr_id(
+                organization_id=self.organization.id, provider=GITHUB, pr_id=557, caller="mention"
+            )
+            is None
+        )
+        assert (
+            get_run_state_for_pr_id(
+                organization_id=self.organization.id, provider=GITHUB, pr_id=557, caller="mention"
+            )
+            is None
+        )
+
+        assert mock_get_state.call_count == 1
+
+    @patch(f"{MODULE_PATH}.get_agent_state_from_pr_id")
+    def test_other_seer_errors_raise_and_are_not_remembered(
+        self, mock_get_state: MagicMock
+    ) -> None:
+        mock_get_state.side_effect = SeerApiError("boom", 500)
+
+        with pytest.raises(SeerApiError):
+            get_run_state_for_pr_id(
+                organization_id=self.organization.id, provider=GITHUB, pr_id=558, caller="mention"
+            )
+
+        # A blip says nothing about whether a run exists, so the next call asks
+        # again rather than going blind for a day.
+        mock_get_state.side_effect = None
+        mock_get_state.return_value = _run_state()
+        assert (
+            get_run_state_for_pr_id(
+                organization_id=self.organization.id, provider=GITHUB, pr_id=558, caller="mention"
+            )
+            is not None
+        )
+        assert mock_get_state.call_count == 2
+
+    @patch(f"{MODULE_PATH}.get_agent_state_from_pr_id")
+    def test_negative_is_scoped_to_the_provider(self, mock_get_state: MagicMock) -> None:
+        """A GHE PR id and a github.com PR id can be the same integer."""
+        mock_get_state.return_value = None
+        assert (
+            get_run_state_for_pr_id(
+                organization_id=self.organization.id,
+                provider="integrations:github_enterprise",
+                pr_id=570,
+                caller="mention",
+            )
+            is None
+        )
+
+        mock_get_state.return_value = _run_state()
+        state = get_run_state_for_pr_id(
+            organization_id=self.organization.id, provider=GITHUB, pr_id=570, caller="mention"
+        )
+
+        assert state is not None
+        assert mock_get_state.call_count == 2
+
+    @patch(f"{MODULE_PATH}.get_agent_state_from_pr_id")
+    def test_asks_seer_under_the_callers_provider(self, mock_get_state: MagicMock) -> None:
+        mock_get_state.return_value = _run_state()
+
+        get_run_state_for_pr_id(
+            organization_id=self.organization.id,
+            provider="integrations:github_enterprise",
+            pr_id=571,
+            caller="mention",
+        )
+
+        mock_get_state.assert_called_once_with(
+            self.organization.id, "integrations:github_enterprise", 571
+        )
+
+    @patch(f"{MODULE_PATH}.get_agent_state_from_pr_id")
+    def test_negative_is_scoped_to_the_organization(self, mock_get_state: MagicMock) -> None:
+        """One PR fans out across orgs; a 404 for one says nothing about the owner."""
+        other_org = self.create_organization()
+        mock_get_state.return_value = None
+
+        assert (
+            get_run_state_for_pr_id(
+                organization_id=other_org.id, provider=GITHUB, pr_id=559, caller="mention"
+            )
+            is None
+        )
+
+        mock_get_state.return_value = _run_state()
+        state = get_run_state_for_pr_id(
+            organization_id=self.organization.id, provider=GITHUB, pr_id=559, caller="mention"
+        )
+
+        assert state is not None
+        assert mock_get_state.call_count == 2
+
+    @patch(f"{MODULE_PATH}.cache")
+    @patch(f"{MODULE_PATH}.get_agent_state_from_pr_id")
+    def test_unreadable_cache_falls_through_to_seer(
+        self, mock_get_state: MagicMock, mock_cache: MagicMock
+    ) -> None:
+        mock_cache.get.side_effect = Exception("cache down")
+        mock_cache.set.side_effect = Exception("cache down")
+        mock_get_state.return_value = _run_state()
+
+        assert (
+            get_run_state_for_pr_id(
+                organization_id=self.organization.id, provider=GITHUB, pr_id=560, caller="mention"
+            )
+            is not None
+        )
+
+    @patch(f"{MODULE_PATH}.cache")
+    @patch(f"{MODULE_PATH}.get_agent_state_from_pr_id")
+    def test_negative_is_written_with_the_long_ttl(
+        self, mock_get_state: MagicMock, mock_cache: MagicMock
+    ) -> None:
+        mock_cache.get.return_value = None
+        mock_get_state.return_value = None
+
+        get_run_state_for_pr_id(
+            organization_id=self.organization.id, provider=GITHUB, pr_id=561, caller="mention"
+        )
+
+        key, _value, ttl = mock_cache.set.call_args.args
+        assert ttl == NO_RUN_CACHE_TTL
+        assert str(self.organization.id) in key
+        assert "561" in key
+
+    @patch(f"{MODULE_PATH}.metrics.incr")
+    @patch(f"{MODULE_PATH}.get_agent_state_from_pr_id")
+    def test_cached_negative_is_counted_apart_from_a_fresh_one(
+        self, mock_get_state: MagicMock, mock_incr: MagicMock
+    ) -> None:
+        mock_get_state.return_value = None
+
+        get_run_state_for_pr_id(
+            organization_id=self.organization.id, provider=GITHUB, pr_id=562, caller="mention"
+        )
+        get_run_state_for_pr_id(
+            organization_id=self.organization.id, provider=GITHUB, pr_id=562, caller="mention"
+        )
+
+        # `metrics` is the shared module object, so filter to this module's key.
+        lookups = [c for c in mock_incr.call_args_list if c.args[:1] == (f"{METRICS_KEY}.lookup",)]
+        assert [c.kwargs["tags"]["result"] for c in lookups] == ["no_run", "cached_missing"]
+        assert {c.kwargs["tags"]["caller"] for c in lookups} == {"mention"}
+
+    @patch(f"{MODULE_PATH}.metrics.incr")
+    @patch(f"{MODULE_PATH}.get_agent_state_from_pr_id")
+    def test_the_caller_tag_distinguishes_the_listeners(
+        self, mock_get_state: MagicMock, mock_incr: MagicMock
+    ) -> None:
+        """Without this the three paths' hit rates sum into one unreadable number."""
+        mock_get_state.return_value = _run_state()
+
+        get_run_state_for_pr_id(
+            organization_id=self.organization.id, provider=GITHUB, pr_id=563, caller="review"
+        )
+        get_run_state_for_pr_id(
+            organization_id=self.organization.id, provider=GITHUB, pr_id=564, caller="check_suite"
+        )
+
+        lookups = [c for c in mock_incr.call_args_list if c.args[:1] == (f"{METRICS_KEY}.lookup",)]
+        assert [c.kwargs["tags"]["caller"] for c in lookups] == ["review", "check_suite"]

--- a/tests/sentry/seer/autofix/pr_iteration/test_types.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_types.py
@@ -776,7 +776,9 @@ class ResolveCheckSuiteRepositoriesTest(TestCase):
         )
         assert (
             resolve_check_suite_repositories(
-                GithubCheckSuiteEvent.parse_obj({**_check_suite_event(), "installation": {"id": 1}})
+                GithubCheckSuiteEvent.parse_obj(
+                    {**_check_suite_event(), "installation": {"id": 1}}
+                ),
             )
             == []
         )
@@ -792,7 +794,7 @@ class ResolveCheckSuiteRepositoriesTest(TestCase):
                     "installation": {"id": 1},
                     "repository": {"id": 2, "html_url": "https://github.com/owner/repo"},
                 }
-            )
+            ),
         )
 
         assert result == []
@@ -817,7 +819,7 @@ class ResolveCheckSuiteRepositoriesTest(TestCase):
                     "installation": {"id": 1},
                     "repository": {"id": 2, "html_url": "https://github.com/owner/repo"},
                 }
-            )
+            ),
         )
 
         assert [r.id for r in result] == [repo.id]
@@ -853,7 +855,7 @@ class ResolveCheckSuiteRepositoriesTest(TestCase):
                     "installation": {"id": 1},
                     "repository": {"id": 2, "html_url": "https://github.com/owner/repo"},
                 }
-            )
+            ),
         )
 
         assert {repo.id for repo in result} == {repo_a.id, repo_b.id}

--- a/tests/sentry/seer/autofix/test_pr_iteration_review.py
+++ b/tests/sentry/seer/autofix/test_pr_iteration_review.py
@@ -368,9 +368,7 @@ class TriggerPrIterationFromReviewTest(TestCase):
 
         self._run()
 
-        client = (
-            self.mock_get_integration.return_value.get_installation.return_value.get_client.return_value
-        )
+        client = self.mock_get_integration.return_value.get_installation.return_value.get_client.return_value
         client.get_pull_request.assert_not_called()
         self.mock_get_state.assert_called_once_with(
             self.organization.id, "integrations:github", 555
@@ -379,9 +377,7 @@ class TriggerPrIterationFromReviewTest(TestCase):
     def test_populates_pr_id_cache_on_a_miss(self) -> None:
         self._run()
 
-        client = (
-            self.mock_get_integration.return_value.get_installation.return_value.get_client.return_value
-        )
+        client = self.mock_get_integration.return_value.get_installation.return_value.get_client.return_value
         client.get_pull_request.assert_called_once_with("owner/repo", "7")
         assert (
             get_cached_pr_id(
@@ -393,9 +389,7 @@ class TriggerPrIterationFromReviewTest(TestCase):
         )
 
     def test_returns_when_get_pull_request_fails(self) -> None:
-        client = (
-            self.mock_get_integration.return_value.get_installation.return_value.get_client.return_value
-        )
+        client = self.mock_get_integration.return_value.get_installation.return_value.get_client.return_value
         client.get_pull_request.side_effect = ApiError("boom")
 
         self._run()

--- a/tests/sentry/seer/autofix/test_pr_iteration_review.py
+++ b/tests/sentry/seer/autofix/test_pr_iteration_review.py
@@ -388,6 +388,31 @@ class TriggerPrIterationFromReviewTest(TestCase):
             == 555
         )
 
+    def test_stops_on_a_repo_whose_provider_is_not_pinned(self) -> None:
+        # Everything downstream reads github.com off `PR_ITERATION_PROVIDER`
+        # instead of the repo, so a GHE repo reaching this task would key its
+        # per-instance repo id into a cache that only github.com ids are unique
+        # in — and ask Seer for a run under the wrong provider. The listener
+        # rejects GHE before dispatch; this pins that the task does not depend on
+        # it having done so.
+        self.repo.provider = "integrations:github_enterprise"
+        self.repo.save()
+
+        self._run()
+
+        self.mock_get_integration.assert_not_called()
+        self.mock_get_state.assert_not_called()
+        client = self.mock_get_integration.return_value.get_installation.return_value.get_client.return_value
+        client.get_pull_request.assert_not_called()
+        assert (
+            get_cached_pr_id(
+                provider="integrations:github",
+                repo_external_id=self.repo.external_id,
+                pr_number=7,
+            )
+            is None
+        )
+
     def test_returns_when_get_pull_request_fails(self) -> None:
         client = self.mock_get_integration.return_value.get_installation.return_value.get_client.return_value
         client.get_pull_request.side_effect = ApiError("boom")

--- a/tests/sentry/seer/autofix/test_pr_iteration_review.py
+++ b/tests/sentry/seer/autofix/test_pr_iteration_review.py
@@ -226,7 +226,7 @@ class TriggerPrIterationFromReviewTest(TestCase):
         # exercises. The mocks are exposed as ``self.mock_*``.
         for attr, target in (
             ("mock_get_integration", "integration_service.get_integration"),
-            ("mock_get_state", "get_agent_state_from_pr_id"),
+            ("mock_get_state", "get_run_state_for_pr_id"),
             ("mock_enqueue", "try_enqueue_autofix_feedback"),
             ("mock_consume", "consume_queued_autofix_feedback.apply_async"),
             ("mock_make_scm", "make_scm"),
@@ -371,7 +371,10 @@ class TriggerPrIterationFromReviewTest(TestCase):
         client = self.mock_get_integration.return_value.get_installation.return_value.get_client.return_value
         client.get_pull_request.assert_not_called()
         self.mock_get_state.assert_called_once_with(
-            self.organization.id, "integrations:github", 555
+            organization_id=self.organization.id,
+            provider=self.repo.provider,
+            pr_id=555,
+            caller="review",
         )
 
     def test_populates_pr_id_cache_on_a_miss(self) -> None:
@@ -461,7 +464,10 @@ class TriggerPrIterationFromReviewTest(TestCase):
             "owner/repo", "7"
         )
         self.mock_get_state.assert_called_once_with(
-            self.organization.id, "integrations:github", 555
+            organization_id=self.organization.id,
+            provider=self.repo.provider,
+            pr_id=555,
+            caller="review",
         )
 
         # Two inline comments + one review body item.

--- a/tests/sentry/seer/autofix/test_pr_iteration_review.py
+++ b/tests/sentry/seer/autofix/test_pr_iteration_review.py
@@ -3,6 +3,10 @@ from unittest.mock import ANY, MagicMock, patch
 
 from scm.errors import ResourceNotFound
 
+from sentry.integrations.source_code_management.pr_id_cache import (
+    get_cached_pr_id,
+    set_cached_pr_id,
+)
 from sentry.scm.types import PullRequestReviewEvent, SubscriptionEvent
 from sentry.seer.agent.client_models import MemoryBlock, Message, RepoPRState, SeerRunState
 from sentry.seer.autofix.constants import AutofixReferrer
@@ -14,6 +18,7 @@ from sentry.seer.autofix.pr_iteration.feedback_sources.github_comment import (
 from sentry.seer.autofix.pr_iteration.listeners.review import (
     handle_pull_request_review_for_autofix_iteration,
 )
+from sentry.shared_integrations.exceptions import ApiError
 from sentry.tasks.seer.pr_iteration import _REVIEW_PAGE_SIZE, trigger_pr_iteration_from_review
 from sentry.testutils.cases import TestCase
 
@@ -349,6 +354,77 @@ class TriggerPrIterationFromReviewTest(TestCase):
             author_external_id=author_external_id,
             author_is_bot=author_is_bot,
             delivery_authenticated=delivery_authenticated,
+        )
+
+    def test_resolves_pr_id_from_cache_without_calling_github(self) -> None:
+        # The pull_request_review payload carries only the PR number; a warmed
+        # cache is what keeps that from costing a REST round-trip per review.
+        set_cached_pr_id(
+            provider=self.repo.provider,
+            repo_external_id=self.repo.external_id,
+            pr_number=7,
+            pr_id=555,
+        )
+
+        self._run()
+
+        client = (
+            self.mock_get_integration.return_value.get_installation.return_value.get_client.return_value
+        )
+        client.get_pull_request.assert_not_called()
+        self.mock_get_state.assert_called_once_with(
+            self.organization.id, "integrations:github", 555
+        )
+
+    def test_populates_pr_id_cache_on_a_miss(self) -> None:
+        self._run()
+
+        client = (
+            self.mock_get_integration.return_value.get_installation.return_value.get_client.return_value
+        )
+        client.get_pull_request.assert_called_once_with("owner/repo", "7")
+        assert (
+            get_cached_pr_id(
+                provider=self.repo.provider,
+                repo_external_id=self.repo.external_id,
+                pr_number=7,
+            )
+            == 555
+        )
+
+    def test_returns_when_get_pull_request_fails(self) -> None:
+        client = (
+            self.mock_get_integration.return_value.get_installation.return_value.get_client.return_value
+        )
+        client.get_pull_request.side_effect = ApiError("boom")
+
+        self._run()
+
+        self.mock_get_state.assert_not_called()
+        self.mock_enqueue.assert_not_called()
+        assert (
+            get_cached_pr_id(
+                provider=self.repo.provider,
+                repo_external_id=self.repo.external_id,
+                pr_number=7,
+            )
+            is None
+        )
+
+    def test_does_not_cache_a_missing_pr_id(self) -> None:
+        self.mock_get_integration.return_value = self._mock_integration(pr_id=None)
+
+        self._run()
+
+        self.mock_get_state.assert_not_called()
+        self.mock_enqueue.assert_not_called()
+        assert (
+            get_cached_pr_id(
+                provider=self.repo.provider,
+                repo_external_id=self.repo.external_id,
+                pr_number=7,
+            )
+            is None
         )
 
     def test_batch_review_with_inline_comments_and_body(self) -> None:

--- a/tests/sentry/seer/autofix/test_pr_iteration_webhook.py
+++ b/tests/sentry/seer/autofix/test_pr_iteration_webhook.py
@@ -186,7 +186,7 @@ class TriggerPrIterationFromCommentTest(TestCase):
     @patch(f"{TASK_PATH}._github_commenter_has_repo_write_access", return_value=True)
     @patch(f"{TASK_PATH}.consume_queued_autofix_feedback.apply_async")
     @patch(f"{TASK_PATH}.try_enqueue_autofix_feedback")
-    @patch(f"{TASK_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{TASK_PATH}.get_run_state_for_pr_id")
     @patch(f"{TASK_PATH}.integration_service.get_integration")
     def test_triggers_agent_when_authorized(
         self,
@@ -240,7 +240,7 @@ class TriggerPrIterationFromCommentTest(TestCase):
     @patch(f"{TASK_PATH}._github_commenter_has_repo_write_access", return_value=False)
     @patch(f"{TASK_PATH}.consume_queued_autofix_feedback.apply_async")
     @patch(f"{TASK_PATH}.try_enqueue_autofix_feedback")
-    @patch(f"{TASK_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{TASK_PATH}.get_run_state_for_pr_id")
     @patch(f"{TASK_PATH}.integration_service.get_integration")
     def test_skips_when_no_write_access(
         self,
@@ -265,7 +265,7 @@ class TriggerPrIterationFromCommentTest(TestCase):
     @patch(f"{TASK_PATH}._github_commenter_has_repo_write_access")
     @patch(f"{TASK_PATH}.consume_queued_autofix_feedback.apply_async")
     @patch(f"{TASK_PATH}.try_enqueue_autofix_feedback")
-    @patch(f"{TASK_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{TASK_PATH}.get_run_state_for_pr_id")
     @patch(f"{TASK_PATH}.integration_service.get_integration")
     def test_skips_when_no_agent_state(
         self,
@@ -296,7 +296,7 @@ class TriggerPrIterationFromCommentTest(TestCase):
     @patch(f"{TASK_PATH}._github_commenter_has_repo_write_access", return_value=True)
     @patch(f"{TASK_PATH}.consume_queued_autofix_feedback.apply_async")
     @patch(f"{TASK_PATH}.try_enqueue_autofix_feedback")
-    @patch(f"{TASK_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{TASK_PATH}.get_run_state_for_pr_id")
     @patch(f"{TASK_PATH}.integration_service.get_integration")
     def test_review_comment_hoists_file_and_line(
         self,

--- a/tests/sentry/tasks/seer/test_pr_iteration.py
+++ b/tests/sentry/tasks/seer/test_pr_iteration.py
@@ -103,7 +103,7 @@ class TriggerPrIterationFromCommentTest(TestCase):
     @patch(f"{TASK_PATH}._github_commenter_has_repo_write_access", return_value=True)
     @patch(f"{TASK_PATH}.trigger_consume_pr_iteration_feedback")
     @patch(f"{TASK_PATH}.try_enqueue_autofix_feedback", return_value=True)
-    @patch(f"{TASK_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{TASK_PATH}.get_run_state_for_pr_id")
     @patch(f"{TASK_PATH}.integration_service.get_integration")
     def test_triggers_agent_when_authorized(
         self,
@@ -154,7 +154,7 @@ class TriggerPrIterationFromCommentTest(TestCase):
             reaction="eyes",
         )
 
-    @patch(f"{TASK_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{TASK_PATH}.get_run_state_for_pr_id")
     @patch(f"{TASK_PATH}.integration_service.get_integration")
     def test_resolves_pr_id_from_cache_without_calling_github(
         self,
@@ -177,9 +177,14 @@ class TriggerPrIterationFromCommentTest(TestCase):
 
         client = mock_integration.get_installation.return_value.get_client.return_value
         client.get_pull_request.assert_not_called()
-        mock_get_state.assert_called_once_with(self.organization.id, "integrations:github", 555)
+        mock_get_state.assert_called_once_with(
+            organization_id=self.organization.id,
+            provider=self.repo.provider,
+            pr_id=555,
+            caller="mention",
+        )
 
-    @patch(f"{TASK_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{TASK_PATH}.get_run_state_for_pr_id")
     @patch(f"{TASK_PATH}.integration_service.get_integration")
     def test_populates_pr_id_cache_on_a_miss(
         self,
@@ -203,7 +208,7 @@ class TriggerPrIterationFromCommentTest(TestCase):
             == 555
         )
 
-    @patch(f"{TASK_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{TASK_PATH}.get_run_state_for_pr_id")
     @patch(f"{TASK_PATH}.integration_service.get_integration")
     def test_returns_when_get_pull_request_fails(
         self,
@@ -227,7 +232,7 @@ class TriggerPrIterationFromCommentTest(TestCase):
             is None
         )
 
-    @patch(f"{TASK_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{TASK_PATH}.get_run_state_for_pr_id")
     @patch(f"{TASK_PATH}.integration_service.get_integration")
     def test_does_not_cache_a_missing_pr_id(
         self,
@@ -249,7 +254,7 @@ class TriggerPrIterationFromCommentTest(TestCase):
             is None
         )
 
-    @patch(f"{TASK_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{TASK_PATH}.get_run_state_for_pr_id")
     @patch(f"{TASK_PATH}.integration_service.get_integration")
     def test_stops_on_a_repo_whose_provider_is_not_pinned(
         self,
@@ -286,7 +291,7 @@ class TriggerPrIterationFromCommentTest(TestCase):
     @patch(f"{TASK_PATH}._github_commenter_has_repo_write_access", return_value=False)
     @patch(f"{TASK_PATH}.trigger_consume_pr_iteration_feedback")
     @patch(f"{TASK_PATH}.try_enqueue_autofix_feedback", return_value=True)
-    @patch(f"{TASK_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{TASK_PATH}.get_run_state_for_pr_id")
     @patch(f"{TASK_PATH}.integration_service.get_integration")
     def test_skips_when_no_write_access(
         self,
@@ -312,7 +317,7 @@ class TriggerPrIterationFromCommentTest(TestCase):
     @patch(f"{TASK_PATH}._github_commenter_has_repo_write_access")
     @patch(f"{TASK_PATH}.trigger_consume_pr_iteration_feedback")
     @patch(f"{TASK_PATH}.try_enqueue_autofix_feedback", return_value=True)
-    @patch(f"{TASK_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{TASK_PATH}.get_run_state_for_pr_id")
     @patch(f"{TASK_PATH}.integration_service.get_integration")
     def test_skips_when_no_agent_state(
         self,
@@ -349,7 +354,7 @@ class TriggerPrIterationFromCommentTest(TestCase):
     @patch(f"{TASK_PATH}._github_commenter_has_repo_write_access")
     @patch(f"{TASK_PATH}.trigger_consume_pr_iteration_feedback")
     @patch(f"{TASK_PATH}.try_enqueue_autofix_feedback", return_value=True)
-    @patch(f"{TASK_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{TASK_PATH}.get_run_state_for_pr_id")
     @patch(f"{TASK_PATH}.integration_service.get_integration")
     def test_comments_ineligible_when_run_has_no_repo_pr_states(
         self,
@@ -401,7 +406,7 @@ class TriggerPrIterationFromCommentTest(TestCase):
     @patch(f"{TASK_PATH}._github_commenter_has_repo_write_access")
     @patch(f"{TASK_PATH}.trigger_consume_pr_iteration_feedback")
     @patch(f"{TASK_PATH}.try_enqueue_autofix_feedback", return_value=True)
-    @patch(f"{TASK_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{TASK_PATH}.get_run_state_for_pr_id")
     @patch(f"{TASK_PATH}.integration_service.get_integration")
     def test_skips_ineligible_comment_when_already_posted(
         self,
@@ -445,7 +450,7 @@ class TriggerPrIterationFromCommentTest(TestCase):
     @patch(f"{TASK_PATH}._github_commenter_has_repo_write_access", return_value=True)
     @patch(f"{TASK_PATH}.trigger_consume_pr_iteration_feedback")
     @patch(f"{TASK_PATH}.try_enqueue_autofix_feedback", return_value=True)
-    @patch(f"{TASK_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{TASK_PATH}.get_run_state_for_pr_id")
     @patch(f"{TASK_PATH}.integration_service.get_integration")
     def test_triggers_comment_reaction(
         self,
@@ -477,7 +482,7 @@ class TriggerPrIterationFromCommentTest(TestCase):
     @patch(f"{TASK_PATH}._github_commenter_has_repo_write_access", return_value=True)
     @patch(f"{TASK_PATH}.trigger_consume_pr_iteration_feedback")
     @patch(f"{TASK_PATH}.try_enqueue_autofix_feedback", return_value=True)
-    @patch(f"{TASK_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{TASK_PATH}.get_run_state_for_pr_id")
     @patch(f"{TASK_PATH}.integration_service.get_integration")
     def test_iterates_past_max_iterations(
         self,

--- a/tests/sentry/tasks/seer/test_pr_iteration.py
+++ b/tests/sentry/tasks/seer/test_pr_iteration.py
@@ -5,6 +5,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 from scm.types import ReviewComment
 
+from sentry.integrations.source_code_management.pr_id_cache import (
+    get_cached_pr_id,
+    set_cached_pr_id,
+)
 from sentry.seer.agent.client_models import MemoryBlock, Message, RepoPRState, SeerRunState
 from sentry.seer.autofix.autofix_agent import (
     PrIterationNoPullRequestException,
@@ -24,6 +28,7 @@ from sentry.seer.autofix.pr_iteration.feedback_sources.github_comment import (
 from sentry.seer.autofix.pr_iteration.feedback_sources.user_ui import UserUIFeedbackSource
 from sentry.seer.autofix.pr_iteration.queue import QueuedAutofixFeedback
 from sentry.seer.models import SeerApiError
+from sentry.shared_integrations.exceptions import ApiError
 from sentry.tasks.seer.pr_iteration import (
     UnsupportedProviderError,
     _build_review_feedback,
@@ -147,6 +152,101 @@ class TriggerPrIterationFromCommentTest(TestCase):
             pr_number=7,
             comment_id=999,
             reaction="eyes",
+        )
+
+    @patch(f"{TASK_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{TASK_PATH}.integration_service.get_integration")
+    def test_resolves_pr_id_from_cache_without_calling_github(
+        self,
+        mock_get_integration: MagicMock,
+        mock_get_state: MagicMock,
+    ) -> None:
+        # The issue_comment payload carries only the PR number; a warmed cache
+        # is what keeps that from costing a REST round-trip per mention.
+        mock_integration = self._mock_integration()
+        mock_get_integration.return_value = mock_integration
+        mock_get_state.return_value = None
+        set_cached_pr_id(
+            provider=self.repo.provider,
+            repo_external_id=self.repo.external_id,
+            pr_number=7,
+            pr_id=555,
+        )
+
+        self._call()
+
+        client = mock_integration.get_installation.return_value.get_client.return_value
+        client.get_pull_request.assert_not_called()
+        mock_get_state.assert_called_once_with(self.organization.id, "integrations:github", 555)
+
+    @patch(f"{TASK_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{TASK_PATH}.integration_service.get_integration")
+    def test_populates_pr_id_cache_on_a_miss(
+        self,
+        mock_get_integration: MagicMock,
+        mock_get_state: MagicMock,
+    ) -> None:
+        mock_integration = self._mock_integration()
+        mock_get_integration.return_value = mock_integration
+        mock_get_state.return_value = None
+
+        self._call()
+
+        client = mock_integration.get_installation.return_value.get_client.return_value
+        client.get_pull_request.assert_called_once_with("owner/repo", "7")
+        assert (
+            get_cached_pr_id(
+                provider=self.repo.provider,
+                repo_external_id=self.repo.external_id,
+                pr_number=7,
+            )
+            == 555
+        )
+
+    @patch(f"{TASK_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{TASK_PATH}.integration_service.get_integration")
+    def test_returns_when_get_pull_request_fails(
+        self,
+        mock_get_integration: MagicMock,
+        mock_get_state: MagicMock,
+    ) -> None:
+        mock_integration = self._mock_integration()
+        client = mock_integration.get_installation.return_value.get_client.return_value
+        client.get_pull_request.side_effect = ApiError("boom")
+        mock_get_integration.return_value = mock_integration
+
+        self._call()
+
+        mock_get_state.assert_not_called()
+        assert (
+            get_cached_pr_id(
+                provider=self.repo.provider,
+                repo_external_id=self.repo.external_id,
+                pr_number=7,
+            )
+            is None
+        )
+
+    @patch(f"{TASK_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{TASK_PATH}.integration_service.get_integration")
+    def test_does_not_cache_a_missing_pr_id(
+        self,
+        mock_get_integration: MagicMock,
+        mock_get_state: MagicMock,
+    ) -> None:
+        mock_get_integration.return_value = self._mock_integration(pr_id=None)
+        mock_get_state.return_value = None
+
+        self._call()
+
+        mock_get_state.assert_not_called()
+        assert (
+            get_cached_pr_id(
+                provider=self.repo.provider,
+                repo_external_id=self.repo.external_id,
+                pr_number=7,
+            )
+            is None
         )
 
     @patch(f"{TASK_PATH}.make_scm")

--- a/tests/sentry/tasks/seer/test_pr_iteration.py
+++ b/tests/sentry/tasks/seer/test_pr_iteration.py
@@ -249,6 +249,39 @@ class TriggerPrIterationFromCommentTest(TestCase):
             is None
         )
 
+    @patch(f"{TASK_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{TASK_PATH}.integration_service.get_integration")
+    def test_stops_on_a_repo_whose_provider_is_not_pinned(
+        self,
+        mock_get_integration: MagicMock,
+        mock_get_state: MagicMock,
+    ) -> None:
+        # Everything downstream reads github.com off `PR_ITERATION_PROVIDER`
+        # instead of the repo, so a GHE repo reaching this task would key its
+        # per-instance repo id into a cache that only github.com ids are unique
+        # in — and ask Seer for a run under the wrong provider. The entry point
+        # rejects GHE before dispatch; this pins that the task does not depend on
+        # it having done so.
+        mock_integration = self._mock_integration()
+        mock_get_integration.return_value = mock_integration
+        self.repo.provider = "integrations:github_enterprise"
+        self.repo.save()
+
+        self._call()
+
+        mock_get_integration.assert_not_called()
+        mock_get_state.assert_not_called()
+        client = mock_integration.get_installation.return_value.get_client.return_value
+        client.get_pull_request.assert_not_called()
+        assert (
+            get_cached_pr_id(
+                provider="integrations:github",
+                repo_external_id=self.repo.external_id,
+                pr_number=7,
+            )
+            is None
+        )
+
     @patch(f"{TASK_PATH}.make_scm")
     @patch(f"{TASK_PATH}._github_commenter_has_repo_write_access", return_value=False)
     @patch(f"{TASK_PATH}.trigger_consume_pr_iteration_feedback")


### PR DESCRIPTION

The mention and review tasks each recovered a PR's global id with the
same copy-pasted block, and check_suite called Seer directly once per
candidate org per PR per suite. Move both steps into
seer/autofix/pr_iteration/run_resolution.py:

- resolve_pr_id: number -> id via pr_id_cache. The SCM client is built
  inside, so it's only constructed on a miss. ApiError still propagates
  so callers keep their existing handling.
- get_run_state_for_pr_id: the Seer lookup, caching only the absence of
  a run for a day, keyed by (provider, pr_id, organization_id).

Run state itself is never cached since it's live and downstream
staleness checks compare head shas against it. The negatives are what
repeat (pushes to non-Autofix PRs, webhooks fanned out to regions that
don't own the session) and can't go stale, because Autofix creates the
run before the PR. Non-404 errors aren't cached.

Both metrics are tagged by calling listener so the paths can be split
apart.

Also gate the check_suite listener on github.com at its entry point, as
the mention and review listeners already do. That's what lets callers
here pass PR_ITERATION_PROVIDER directly instead of threading a runtime
provider through.