### PR TITLE
feat(workflow_engine): Add evaluation logs to detectors

### DIFF
--- a/src/sentry/workflow_engine/caches/detector.py
+++ b/src/sentry/workflow_engine/caches/detector.py
@@ -46,7 +46,7 @@ def _query_detectors(source_id: str, query_type: str) -> list[Detector]:
             data_sources__source_id=source_id,
             data_sources__type=query_type,
         )
-        .select_related("workflow_condition_group")
+        .select_related("project__organization", "workflow_condition_group")
         .prefetch_related("workflow_condition_group__conditions")
         .distinct()
         .order_by("id")

--- a/src/sentry/workflow_engine/caches/detector.py
+++ b/src/sentry/workflow_engine/caches/detector.py
@@ -46,7 +46,7 @@ def _query_detectors(source_id: str, query_type: str) -> list[Detector]:
             data_sources__source_id=source_id,
             data_sources__type=query_type,
         )
-        .select_related("project__organization", "workflow_condition_group")
+        .select_related("workflow_condition_group")
         .prefetch_related("workflow_condition_group__conditions")
         .distinct()
         .order_by("id")

--- a/src/sentry/workflow_engine/processors/__init__.py
+++ b/src/sentry/workflow_engine/processors/__init__.py
@@ -2,6 +2,12 @@ __all__ = [
     "DataConditionEvaluation",
     "DataConditionGroupEvaluation",
     "DetectorEvaluation",
+    "ProcessDetectorsResult",
 ]
 
-from .evaluations import DataConditionEvaluation, DataConditionGroupEvaluation, DetectorEvaluation
+from .evaluations import (
+    DataConditionEvaluation,
+    DataConditionGroupEvaluation,
+    DetectorEvaluation,
+    ProcessDetectorsResult,
+)

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -10,6 +10,7 @@ from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
 from sentry.models.activity import Activity
 from sentry.models.group import Group
+from sentry.models.organization import Organization
 from sentry.services.eventstore.models import GroupEvent
 from sentry.utils import metrics
 from sentry.utils.cache import cache
@@ -21,7 +22,8 @@ from sentry.workflow_engine.defaults.detectors import (
 )
 from sentry.workflow_engine.models import DataPacket, Detector
 from sentry.workflow_engine.models.detector_group import DetectorGroup
-from sentry.workflow_engine.processors import DetectorEvaluation
+from sentry.workflow_engine.processors import DetectorEvaluation, ProcessDetectorsResult
+from sentry.workflow_engine.processors.evaluation_logging import emit_detector_evaluation_logs
 from sentry.workflow_engine.types import (
     DetectorGroupKey,
     DetectorId,
@@ -271,6 +273,16 @@ def create_issue_platform_payload(result: DetectorEvaluation, detector_type: str
     )
 
 
+def _get_detector_organization(detector: Detector) -> Organization:
+    if detector.project_id is not None:
+        return detector.linked_project.organization
+
+    organization_id = detector.config.get("organization_id")
+    if not isinstance(organization_id, int):
+        raise ValueError("Organization-scoped detector is missing organization_id")
+    return Organization.objects.get_from_cache(id=organization_id)
+
+
 @trace
 def process_detectors[T](
     data_packet: DataPacket[T], detectors: list[Detector]
@@ -292,6 +304,17 @@ def process_detectors[T](
             "workflow_engine.process_detectors.evaluate", tags={"detector_type": detector.type}
         ):
             detector_results = handler.evaluate(data_packet)
+
+        emit_detector_evaluation_logs(
+            logger,
+            organization=_get_detector_organization(detector),
+            result=ProcessDetectorsResult(
+                detector_id=detector.id,
+                detector_type=detector.type,
+                project_id=detector.project_id,
+                evaluations=detector_results,
+            ),
+        )
 
         for result in detector_results.values():
             logger_extra = {

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -4,14 +4,13 @@ import logging
 from dataclasses import dataclass, field
 
 from sentry import features, options
+from sentry.db.models.utils import is_model_attr_cached
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.incidents.grouptype import MetricIssue
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
 from sentry.models.activity import Activity
 from sentry.models.group import Group
-from sentry.models.organization import Organization
-from sentry.models.project import Project
 from sentry.services.eventstore.models import GroupEvent
 from sentry.utils import metrics
 from sentry.utils.cache import cache
@@ -26,7 +25,6 @@ from sentry.workflow_engine.models.detector_group import DetectorGroup
 from sentry.workflow_engine.processors import DetectorEvaluation, ProcessDetectorsResult
 from sentry.workflow_engine.processors.evaluation_logging import emit_detector_evaluation_logs
 from sentry.workflow_engine.types import (
-    ConditionError,
     DetectorGroupKey,
     DetectorId,
     WorkflowEventData,
@@ -37,10 +35,6 @@ logger = logging.getLogger(__name__)
 
 
 _DETECTOR_SENTINEL = object()
-
-
-class DetectorProcessingException(Exception):
-    pass
 
 
 def _get_all_projects_detector_cache_key(organization_id: int) -> str:
@@ -279,21 +273,14 @@ def create_issue_platform_payload(result: DetectorEvaluation, detector_type: str
     )
 
 
-def _get_detector_organization(detector: Detector) -> Organization:
+def _get_detector_organization_id(detector: Detector) -> int | None:
     if detector.project_id is not None:
-        try:
-            return detector.linked_project.organization
-        except Project.DoesNotExist as error:
-            raise DetectorProcessingException("Detector project does not exist") from error
+        if is_model_attr_cached(detector, "project"):
+            project = detector.project
+            return project.organization_id if project is not None else None
+        return None
 
-    organization_id = detector.config.get("organization_id")
-    if not isinstance(organization_id, int):
-        raise DetectorProcessingException("Organization-scoped detector is missing organization_id")
-
-    try:
-        return Organization.objects.get_from_cache(id=organization_id)
-    except Organization.DoesNotExist as error:
-        raise DetectorProcessingException("Detector organization does not exist") from error
+    return detector.config.get("organization_id", None)
 
 
 @trace
@@ -313,22 +300,6 @@ def process_detectors[T](
             tags={"detector_type": detector.type},
         )
 
-        try:
-            organization = _get_detector_organization(detector)
-        except DetectorProcessingException as error:
-            emit_detector_evaluation_logs(
-                logger,
-                organization=None,
-                result=ProcessDetectorsResult(
-                    detector_id=detector.id,
-                    detector_type=detector.type,
-                    project_id=detector.project_id,
-                    evaluations={},
-                    error=ConditionError(msg=str(error)),
-                ),
-            )
-            continue
-
         with metrics.timer(
             "workflow_engine.process_detectors.evaluate", tags={"detector_type": detector.type}
         ):
@@ -336,7 +307,7 @@ def process_detectors[T](
 
         emit_detector_evaluation_logs(
             logger,
-            organization=organization,
+            organization_id=_get_detector_organization_id(detector),
             result=ProcessDetectorsResult(
                 detector_id=detector.id,
                 detector_type=detector.type,

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -346,31 +346,15 @@ def process_detectors[T](
         )
 
         for result in detector_results.values():
-            logger_extra = {
-                "detector": detector.id,
-                "detector_type": detector.type,
-                "evaluation_data": data_packet.packet,
-                "result": result,
-            }
             if result.result is not None:
-                if isinstance(result.result, IssueOccurrence):
-                    metrics.incr(
-                        "workflow_engine.process_detector.triggered",
-                        tags={"detector_type": detector.type},
-                    )
-                    logger.info(
-                        "detector_triggered",
-                        extra=logger_extra,
-                    )
-                else:
-                    metrics.incr(
-                        "workflow_engine.process_detector.resolved",
-                        tags={"detector_type": detector.type},
-                    )
-                    logger.info(
-                        "detector_resolved",
-                        extra=logger_extra,
-                    )
+                metric_label = (
+                    "triggered" if isinstance(result.result, IssueOccurrence) else "resolved"
+                )
+                metrics.incr(
+                    f"workflow_engine.process_detector.{metric_label}",
+                    tags={"detector_type": detector.type},
+                )
+
                 create_issue_platform_payload(result, detector.type)
 
         if detector_results:

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -11,6 +11,7 @@ from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
 from sentry.models.activity import Activity
 from sentry.models.group import Group
 from sentry.models.organization import Organization
+from sentry.models.project import Project
 from sentry.services.eventstore.models import GroupEvent
 from sentry.utils import metrics
 from sentry.utils.cache import cache
@@ -25,6 +26,7 @@ from sentry.workflow_engine.models.detector_group import DetectorGroup
 from sentry.workflow_engine.processors import DetectorEvaluation, ProcessDetectorsResult
 from sentry.workflow_engine.processors.evaluation_logging import emit_detector_evaluation_logs
 from sentry.workflow_engine.types import (
+    ConditionError,
     DetectorGroupKey,
     DetectorId,
     WorkflowEventData,
@@ -35,6 +37,10 @@ logger = logging.getLogger(__name__)
 
 
 _DETECTOR_SENTINEL = object()
+
+
+class DetectorProcessingException(Exception):
+    pass
 
 
 def _get_all_projects_detector_cache_key(organization_id: int) -> str:
@@ -275,12 +281,19 @@ def create_issue_platform_payload(result: DetectorEvaluation, detector_type: str
 
 def _get_detector_organization(detector: Detector) -> Organization:
     if detector.project_id is not None:
-        return detector.linked_project.organization
+        try:
+            return detector.linked_project.organization
+        except Project.DoesNotExist as error:
+            raise DetectorProcessingException("Detector project does not exist") from error
 
     organization_id = detector.config.get("organization_id")
     if not isinstance(organization_id, int):
-        raise ValueError("Organization-scoped detector is missing organization_id")
-    return Organization.objects.get_from_cache(id=organization_id)
+        raise DetectorProcessingException("Organization-scoped detector is missing organization_id")
+
+    try:
+        return Organization.objects.get_from_cache(id=organization_id)
+    except Organization.DoesNotExist as error:
+        raise DetectorProcessingException("Detector organization does not exist") from error
 
 
 @trace
@@ -300,6 +313,22 @@ def process_detectors[T](
             tags={"detector_type": detector.type},
         )
 
+        try:
+            organization = _get_detector_organization(detector)
+        except DetectorProcessingException as error:
+            emit_detector_evaluation_logs(
+                logger,
+                organization=None,
+                result=ProcessDetectorsResult(
+                    detector_id=detector.id,
+                    detector_type=detector.type,
+                    project_id=detector.project_id,
+                    evaluations={},
+                    error=ConditionError(msg=str(error)),
+                ),
+            )
+            continue
+
         with metrics.timer(
             "workflow_engine.process_detectors.evaluate", tags={"detector_type": detector.type}
         ):
@@ -307,7 +336,7 @@ def process_detectors[T](
 
         emit_detector_evaluation_logs(
             logger,
-            organization=_get_detector_organization(detector),
+            organization=organization,
             result=ProcessDetectorsResult(
                 detector_id=detector.id,
                 detector_type=detector.type,

--- a/src/sentry/workflow_engine/processors/evaluation_logging.py
+++ b/src/sentry/workflow_engine/processors/evaluation_logging.py
@@ -59,7 +59,6 @@ def emit_detector_evaluation_logs(
     result: ProcessDetectorsResult,
     log_prefix: str = DETECTOR_EVALUATION_LOG_PREFIX,
 ) -> bool:
-    """Sample a detector and emit one self-contained artifact per grouped evaluation."""
     if not _is_sampled():
         return False
 
@@ -79,7 +78,11 @@ def emit_workflow_evaluation_logs(
     result: ProcessWorkflowsResult,
     log_prefix: str = WORKFLOW_EVALUATION_LOG_PREFIX,
 ) -> bool:
-    """Sample a batch and emit one self-contained artifact per workflow evaluation."""
+    """
+    This method is used to log the workflows batched evaluations
+    to individual logs, allowing us to easily filter and search for
+    a specific workflow's evaluation.
+    """
     if not should_log(organization, result):
         return False
 

--- a/src/sentry/workflow_engine/processors/evaluation_logging.py
+++ b/src/sentry/workflow_engine/processors/evaluation_logging.py
@@ -17,9 +17,7 @@ DETECTOR_EVALUATION_LOG_PREFIX = "workflow_engine.process_detectors.evaluation"
 WORKFLOW_EVALUATION_LOG_PREFIX = "workflow_engine.process_workflows.evaluation"
 
 
-def _should_emit_evaluation_logs(organization: Organization) -> bool:
-    if features.has("organizations:workflow-engine-log-evaluations", organization):
-        return True
+def _is_sampled() -> bool:
     sample_rate = cast(float, options.get("workflow_engine.evaluation_log_sample_rate"))
     return random.random() < sample_rate
 
@@ -33,8 +31,7 @@ def should_log(organization: Organization, result: ProcessWorkflowsResult) -> bo
     )
     if any(workflow_id in result.evaluations for workflow_id in target_workflow_ids):
         return True
-    sample_rate = cast(float, options.get("workflow_engine.evaluation_log_sample_rate"))
-    return random.random() < sample_rate
+    return _is_sampled()
 
 
 def _emit_evaluation_artifacts(
@@ -58,17 +55,17 @@ def _emit_evaluation_artifacts(
 def emit_detector_evaluation_logs(
     logger: Logger,
     *,
-    organization: Organization | None,
+    organization_id: int | None,
     result: ProcessDetectorsResult,
     log_prefix: str = DETECTOR_EVALUATION_LOG_PREFIX,
 ) -> bool:
     """Sample a detector and emit one self-contained artifact per grouped evaluation."""
-    if organization is not None and not _should_emit_evaluation_logs(organization):
+    if not _is_sampled():
         return False
 
     _emit_evaluation_artifacts(
         logger,
-        organization_id=organization.id if organization is not None else None,
+        organization_id=organization_id,
         artifacts=result.evaluation_artifacts(),
         log_prefix=log_prefix,
     )

--- a/src/sentry/workflow_engine/processors/evaluation_logging.py
+++ b/src/sentry/workflow_engine/processors/evaluation_logging.py
@@ -39,13 +39,14 @@ def should_log_workflows(organization: Organization, result: ProcessWorkflowsRes
 def _emit_evaluation_artifacts(
     logger: Logger,
     *,
-    organization_id: int,
+    organization_id: int | None,
     artifacts: list[dict[str, object]],
     log_prefix: str,
 ) -> None:
     direct_to_sentry = options.get("workflow_engine.evaluation_logs_direct_to_sentry")
     for artifact in artifacts:
-        artifact["organization_id"] = organization_id
+        if organization_id is not None:
+            artifact["organization_id"] = organization_id
 
         if direct_to_sentry:
             sdk_logger.info(log_prefix, attributes=artifact)
@@ -56,17 +57,17 @@ def _emit_evaluation_artifacts(
 def emit_detector_evaluation_logs(
     logger: Logger,
     *,
-    organization: Organization,
+    organization: Organization | None,
     result: ProcessDetectorsResult,
     log_prefix: str = DETECTOR_EVALUATION_LOG_PREFIX,
 ) -> bool:
     """Sample a detector and emit one self-contained artifact per grouped evaluation."""
-    if not _should_emit_evaluation_logs(organization):
+    if organization is not None and not _should_emit_evaluation_logs(organization):
         return False
 
     _emit_evaluation_artifacts(
         logger,
-        organization_id=organization.id,
+        organization_id=organization.id if organization is not None else None,
         artifacts=result.evaluation_artifacts(),
         log_prefix=log_prefix,
     )

--- a/src/sentry/workflow_engine/processors/evaluation_logging.py
+++ b/src/sentry/workflow_engine/processors/evaluation_logging.py
@@ -24,16 +24,17 @@ def _should_emit_evaluation_logs(organization: Organization) -> bool:
     return random.random() < sample_rate
 
 
-def should_log_workflows(organization: Organization, result: ProcessWorkflowsResult) -> bool:
+def should_log(organization: Organization, result: ProcessWorkflowsResult) -> bool:
     if features.has("organizations:workflow-engine-log-evaluations", organization):
         return True
 
-    all_workflow_ids = result.evaluations.keys()
-    if set(options.get("workflow_engine.evaluation_log_target_workflow_ids")).intersection(
-        all_workflow_ids
-    ):
+    target_workflow_ids = cast(
+        list[int], options.get("workflow_engine.evaluation_log_target_workflow_ids")
+    )
+    if any(workflow_id in result.evaluations for workflow_id in target_workflow_ids):
         return True
-    return random.random() < options.get("workflow_engine.evaluation_log_sample_rate")
+    sample_rate = cast(float, options.get("workflow_engine.evaluation_log_sample_rate"))
+    return random.random() < sample_rate
 
 
 def _emit_evaluation_artifacts(
@@ -82,7 +83,7 @@ def emit_workflow_evaluation_logs(
     log_prefix: str = WORKFLOW_EVALUATION_LOG_PREFIX,
 ) -> bool:
     """Sample a batch and emit one self-contained artifact per workflow evaluation."""
-    if not should_log_workflows(organization, result):
+    if not should_log(organization, result):
         return False
 
     artifacts = (

--- a/src/sentry/workflow_engine/processors/evaluation_logging.py
+++ b/src/sentry/workflow_engine/processors/evaluation_logging.py
@@ -2,28 +2,75 @@ from __future__ import annotations
 
 import random
 from logging import Logger
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from sentry import features, options
 from sentry.utils.sdk import sdk_logger
+from sentry.workflow_engine.processors.evaluations.detector import ProcessDetectorsResult
 from sentry.workflow_engine.processors.evaluations.workflow import ProcessWorkflowsResult
 
 if TYPE_CHECKING:
     from sentry.models.organization import Organization
 
 
+DETECTOR_EVALUATION_LOG_PREFIX = "workflow_engine.process_detectors.evaluation"
 WORKFLOW_EVALUATION_LOG_PREFIX = "workflow_engine.process_workflows.evaluation"
 
 
-def should_log(organization: Organization, result: ProcessWorkflowsResult) -> bool:
+def _should_emit_evaluation_logs(organization: Organization) -> bool:
     if features.has("organizations:workflow-engine-log-evaluations", organization):
         return True
+    sample_rate = cast(float, options.get("workflow_engine.evaluation_log_sample_rate"))
+    return random.random() < sample_rate
+
+
+def should_log_workflows(organization: Organization, result: ProcessWorkflowsResult) -> bool:
+    if features.has("organizations:workflow-engine-log-evaluations", organization):
+        return True
+
     all_workflow_ids = result.evaluations.keys()
     if set(options.get("workflow_engine.evaluation_log_target_workflow_ids")).intersection(
         all_workflow_ids
     ):
         return True
     return random.random() < options.get("workflow_engine.evaluation_log_sample_rate")
+
+
+def _emit_evaluation_artifacts(
+    logger: Logger,
+    *,
+    organization_id: int,
+    artifacts: list[dict[str, object]],
+    log_prefix: str,
+) -> None:
+    direct_to_sentry = options.get("workflow_engine.evaluation_logs_direct_to_sentry")
+    for artifact in artifacts:
+        artifact["organization_id"] = organization_id
+
+        if direct_to_sentry:
+            sdk_logger.info(log_prefix, attributes=artifact)
+        else:
+            logger.info(log_prefix, extra=artifact)
+
+
+def emit_detector_evaluation_logs(
+    logger: Logger,
+    *,
+    organization: Organization,
+    result: ProcessDetectorsResult,
+    log_prefix: str = DETECTOR_EVALUATION_LOG_PREFIX,
+) -> bool:
+    """Sample a detector and emit one self-contained artifact per grouped evaluation."""
+    if not _should_emit_evaluation_logs(organization):
+        return False
+
+    _emit_evaluation_artifacts(
+        logger,
+        organization_id=organization.id,
+        artifacts=result.evaluation_artifacts(),
+        log_prefix=log_prefix,
+    )
+    return True
 
 
 def emit_workflow_evaluation_logs(
@@ -34,21 +81,18 @@ def emit_workflow_evaluation_logs(
     log_prefix: str = WORKFLOW_EVALUATION_LOG_PREFIX,
 ) -> bool:
     """Sample a batch and emit one self-contained artifact per workflow evaluation."""
-    if not should_log(organization, result):
+    if not should_log_workflows(organization, result):
         return False
 
-    direct_to_sentry = options.get("workflow_engine.evaluation_logs_direct_to_sentry")
     artifacts = (
         [evaluation.to_artifact() for evaluation in result.evaluations.values()]
         if result.evaluations
         else [result.to_artifact()]
     )
-    for artifact in artifacts:
-        artifact["organization_id"] = organization.id
-
-        if direct_to_sentry:
-            sdk_logger.info(log_prefix, attributes=artifact)
-        else:
-            logger.info(log_prefix, extra=artifact)
-
+    _emit_evaluation_artifacts(
+        logger,
+        organization_id=organization.id,
+        artifacts=artifacts,
+        log_prefix=log_prefix,
+    )
     return True

--- a/src/sentry/workflow_engine/processors/evaluations/__init__.py
+++ b/src/sentry/workflow_engine/processors/evaluations/__init__.py
@@ -6,6 +6,8 @@ __all__ = [
     "DetectorEvaluationData",
     "DetectorEvaluationOutcome",
     "DeferredWorkflowEvaluationResult",
+    "EvaluationPhase",
+    "EvaluationType",
     "ProcessDetectorsResult",
     "ProcessWorkflowsResult",
     "WorkflowEvaluation",
@@ -13,6 +15,7 @@ __all__ = [
     "WorkflowEvaluationOutcome",
 ]
 
+from .base import EvaluationPhase, EvaluationType
 from .condition import DataConditionEvaluation, DataConditionEvaluationException
 from .condition_group import DataConditionGroupEvaluation
 from .detector import (

--- a/src/sentry/workflow_engine/processors/evaluations/__init__.py
+++ b/src/sentry/workflow_engine/processors/evaluations/__init__.py
@@ -4,7 +4,9 @@ __all__ = [
     "DataConditionGroupEvaluation",
     "DetectorEvaluation",
     "DetectorEvaluationData",
+    "DetectorEvaluationOutcome",
     "DeferredWorkflowEvaluationResult",
+    "ProcessDetectorsResult",
     "ProcessWorkflowsResult",
     "WorkflowEvaluation",
     "WorkflowEvaluationData",
@@ -13,7 +15,12 @@ __all__ = [
 
 from .condition import DataConditionEvaluation, DataConditionEvaluationException
 from .condition_group import DataConditionGroupEvaluation
-from .detector import DetectorEvaluation, DetectorEvaluationData
+from .detector import (
+    DetectorEvaluation,
+    DetectorEvaluationData,
+    DetectorEvaluationOutcome,
+    ProcessDetectorsResult,
+)
 from .workflow import (
     DeferredWorkflowEvaluationResult,
     ProcessWorkflowsResult,

--- a/src/sentry/workflow_engine/processors/evaluations/base.py
+++ b/src/sentry/workflow_engine/processors/evaluations/base.py
@@ -1,9 +1,20 @@
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field, replace
+from enum import StrEnum
 from typing import Any
 
 from sentry.workflow_engine.types import ConditionError
+
+
+class EvaluationType(StrEnum):
+    DETECTOR = "detector"
+    WORKFLOW = "workflow"
+
+
+class EvaluationPhase(StrEnum):
+    INITIAL = "initial"
+    DELAYED = "delayed"
 
 
 def _find_error(

--- a/src/sentry/workflow_engine/processors/evaluations/detector.py
+++ b/src/sentry/workflow_engine/processors/evaluations/detector.py
@@ -2,7 +2,12 @@ from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any, TypedDict
 
-from sentry.workflow_engine.types import DetectorGroupKey, DetectorPriorityLevel, DetectorResult
+from sentry.workflow_engine.types import (
+    ConditionError,
+    DetectorGroupKey,
+    DetectorPriorityLevel,
+    DetectorResult,
+)
 
 from .base import BaseWorkflowEngineEvaluation
 from .condition_group import DataConditionGroupEvaluation
@@ -16,6 +21,7 @@ class DetectorEvaluationData(TypedDict):
 
 class DetectorEvaluationOutcome(StrEnum):
     COMPLETED = "completed"
+    ERROR = "error"
     NO_RESULTS = "no_results"
 
 
@@ -63,14 +69,25 @@ class ProcessDetectorsResult:
     detector_type: str
     project_id: int | None
     evaluations: dict[DetectorGroupKey, DetectorEvaluation]
+    error: ConditionError | None = None
+
+    @property
+    def evaluation_error(self) -> ConditionError | None:
+        return self.error or next(
+            (evaluation.error for evaluation in self.evaluations.values() if evaluation.error),
+            None,
+        )
 
     @property
     def outcome(self) -> DetectorEvaluationOutcome:
+        if self.evaluation_error:
+            return DetectorEvaluationOutcome.ERROR
         if self.evaluations:
             return DetectorEvaluationOutcome.COMPLETED
         return DetectorEvaluationOutcome.NO_RESULTS
 
-    def to_artifact(self) -> dict[str, object]:
+    @property
+    def artifact_data(self) -> dict[str, object]:
         return {
             "detector_id": self.detector_id,
             "detector_type": self.detector_type,
@@ -78,12 +95,17 @@ class ProcessDetectorsResult:
             "outcome": self.outcome,
         }
 
+    def to_artifact(self) -> dict[str, object]:
+        return {
+            **self.artifact_data,
+            "error": self.evaluation_error.msg if self.evaluation_error else None,
+        }
+
     def evaluation_artifacts(self) -> list[dict[str, object]]:
-        detector_artifact = self.to_artifact()
         if not self.evaluations:
-            return [detector_artifact]
+            return [self.to_artifact()]
 
         return [
-            {**detector_artifact, **evaluation.to_artifact()}
+            {**self.artifact_data, **evaluation.to_artifact()}
             for evaluation in self.evaluations.values()
         ]

--- a/src/sentry/workflow_engine/processors/evaluations/detector.py
+++ b/src/sentry/workflow_engine/processors/evaluations/detector.py
@@ -11,7 +11,7 @@ from sentry.workflow_engine.types import (
     DetectorResult,
 )
 
-from .base import BaseWorkflowEngineEvaluation, EvaluationPhase, EvaluationType
+from .base import BaseWorkflowEngineEvaluation, EvaluationType
 from .condition_group import DataConditionGroupEvaluation
 
 
@@ -108,7 +108,6 @@ class ProcessDetectorsResult:
     def artifact_data(self) -> dict[str, object]:
         return {
             "evaluation_type": EvaluationType.DETECTOR,
-            "evaluation_phase": EvaluationPhase.INITIAL,
             "detector_id": self.detector_id,
             "detector_type": self.detector_type,
             "project_id": self.project_id,

--- a/src/sentry/workflow_engine/processors/evaluations/detector.py
+++ b/src/sentry/workflow_engine/processors/evaluations/detector.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from enum import StrEnum
 from typing import Any, TypedDict
 
 from sentry.workflow_engine.types import DetectorGroupKey, DetectorPriorityLevel, DetectorResult
@@ -11,6 +12,11 @@ class DetectorEvaluationData(TypedDict):
     group_key: DetectorGroupKey
     trigger_group_evaluation: DataConditionGroupEvaluation
     event_data: dict[str, Any] | None  # TODO - improve this typing, for now migrating
+
+
+class DetectorEvaluationOutcome(StrEnum):
+    COMPLETED = "completed"
+    NO_RESULTS = "no_results"
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -49,3 +55,35 @@ class DetectorEvaluation(
             "priority": self.priority.value,
             "trigger_group_evaluation": self.data["trigger_group_evaluation"].to_artifact(),
         }
+
+
+@dataclass(frozen=True, kw_only=True)
+class ProcessDetectorsResult:
+    detector_id: int
+    detector_type: str
+    project_id: int | None
+    evaluations: dict[DetectorGroupKey, DetectorEvaluation]
+
+    @property
+    def outcome(self) -> DetectorEvaluationOutcome:
+        if self.evaluations:
+            return DetectorEvaluationOutcome.COMPLETED
+        return DetectorEvaluationOutcome.NO_RESULTS
+
+    def to_artifact(self) -> dict[str, object]:
+        return {
+            "detector_id": self.detector_id,
+            "detector_type": self.detector_type,
+            "project_id": self.project_id,
+            "outcome": self.outcome,
+        }
+
+    def evaluation_artifacts(self) -> list[dict[str, object]]:
+        detector_artifact = self.to_artifact()
+        if not self.evaluations:
+            return [detector_artifact]
+
+        return [
+            {**detector_artifact, **evaluation.to_artifact()}
+            for evaluation in self.evaluations.values()
+        ]

--- a/src/sentry/workflow_engine/processors/evaluations/detector.py
+++ b/src/sentry/workflow_engine/processors/evaluations/detector.py
@@ -93,11 +93,6 @@ class ProcessDetectorsResult:
             "detector_type": self.detector_type,
             "project_id": self.project_id,
             "outcome": self.outcome,
-        }
-
-    def to_artifact(self) -> dict[str, object]:
-        return {
-            **self.artifact_data,
             "error": self.evaluation_error.msg if self.evaluation_error else None,
         }
 

--- a/src/sentry/workflow_engine/processors/evaluations/detector.py
+++ b/src/sentry/workflow_engine/processors/evaluations/detector.py
@@ -96,6 +96,9 @@ class ProcessDetectorsResult:
             "error": self.evaluation_error.msg if self.evaluation_error else None,
         }
 
+    def to_artifact(self) -> dict[str, object]:
+        return self.artifact_data
+
     def evaluation_artifacts(self) -> list[dict[str, object]]:
         if not self.evaluations:
             return [self.to_artifact()]

--- a/src/sentry/workflow_engine/processors/evaluations/detector.py
+++ b/src/sentry/workflow_engine/processors/evaluations/detector.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any, TypedDict
 
+from sentry.issues.issue_occurrence import IssueOccurrence
+from sentry.issues.status_change_message import StatusChangeMessage
 from sentry.workflow_engine.types import (
     ConditionError,
     DetectorGroupKey,
@@ -9,7 +11,7 @@ from sentry.workflow_engine.types import (
     DetectorResult,
 )
 
-from .base import BaseWorkflowEngineEvaluation
+from .base import BaseWorkflowEngineEvaluation, EvaluationPhase, EvaluationType
 from .condition_group import DataConditionGroupEvaluation
 
 
@@ -23,6 +25,9 @@ class DetectorEvaluationOutcome(StrEnum):
     COMPLETED = "completed"
     ERROR = "error"
     NO_RESULTS = "no_results"
+    NOT_TRIGGERED = "not_triggered"
+    RESOLVED = "resolved"
+    TRIGGERED = "triggered"
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -53,10 +58,23 @@ class DetectorEvaluation(
     priority: DetectorPriorityLevel
 
     @property
+    def outcome(self) -> DetectorEvaluationOutcome:
+        if self.error:
+            return DetectorEvaluationOutcome.ERROR
+        if isinstance(self.result, StatusChangeMessage):
+            return DetectorEvaluationOutcome.RESOLVED
+        if self.triggered or isinstance(self.result, IssueOccurrence):
+            return DetectorEvaluationOutcome.TRIGGERED
+        return DetectorEvaluationOutcome.NOT_TRIGGERED
+
+    @property
     def artifact_fields(self) -> dict[str, Any]:
         # Each trigger group evaluation will log the value used in evaluation
         # We only need to extract the top level detector items for tracking here.
+        event_data = self.data["event_data"] or {}
+        event_id = event_data.get("event_id")
         return {
+            "event_id": str(event_id) if event_id else None,
             "group_key": self.data["group_key"],
             "priority": self.priority.value,
             "trigger_group_evaluation": self.data["trigger_group_evaluation"].to_artifact(),
@@ -89,6 +107,8 @@ class ProcessDetectorsResult:
     @property
     def artifact_data(self) -> dict[str, object]:
         return {
+            "evaluation_type": EvaluationType.DETECTOR,
+            "evaluation_phase": EvaluationPhase.INITIAL,
             "detector_id": self.detector_id,
             "detector_type": self.detector_type,
             "project_id": self.project_id,
@@ -104,6 +124,10 @@ class ProcessDetectorsResult:
             return [self.to_artifact()]
 
         return [
-            {**self.artifact_data, **evaluation.to_artifact()}
+            {
+                **self.artifact_data,
+                **evaluation.to_artifact(),
+                "outcome": evaluation.outcome,
+            }
             for evaluation in self.evaluations.values()
         ]

--- a/src/sentry/workflow_engine/processors/evaluations/workflow.py
+++ b/src/sentry/workflow_engine/processors/evaluations/workflow.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import TYPE_CHECKING, Protocol, TypedDict, cast
+from typing import TYPE_CHECKING, TypedDict
 
 from sentry.services.eventstore.models import GroupEvent
 from sentry.workflow_engine.types import (
@@ -17,10 +17,6 @@ from .condition_group import DataConditionGroupEvaluation
 
 if TYPE_CHECKING:
     from sentry.workflow_engine.models import Action
-
-
-class _ProjectScopedEvent(Protocol):
-    project_id: int
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -124,15 +120,15 @@ class WorkflowEvaluation(
             "workflow_id": self.workflow_id,
             "detector_id": self.detector_id,
             "detector_type": self.detector_type,
-            "project_id": cast(_ProjectScopedEvent, event_data.event).project_id,
+            "project_id": event_data.event.project_id,
             "event_id": str(event_id) if event_id else None,
             "group_id": event_data.group.id,
             "outcome": self.outcome,
             "triggered_action_ids": triggered_action_ids,
             **({"deferred": deferred} if deferred else {}),
-            "trigger_group_evaluation": self.data["trigger_group_eval"].to_artifact(),
+            "trigger_group_evaluation": self.data.get("trigger_group_eval").to_artifact(),
             "filter_group_evaluations": [
-                evaluation.to_artifact() for evaluation in self.data["filter_group_evals"]
+                evaluation.to_artifact() for evaluation in self.data.get("filter_group_evals")
             ],
         }
 

--- a/src/sentry/workflow_engine/processors/evaluations/workflow.py
+++ b/src/sentry/workflow_engine/processors/evaluations/workflow.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, Protocol, TypedDict, cast
 
 from sentry.services.eventstore.models import GroupEvent
 from sentry.workflow_engine.types import (
@@ -12,11 +12,15 @@ from sentry.workflow_engine.types import (
     WorkflowId,
 )
 
-from .base import BaseWorkflowEngineEvaluation
+from .base import BaseWorkflowEngineEvaluation, EvaluationPhase, EvaluationType
 from .condition_group import DataConditionGroupEvaluation
 
 if TYPE_CHECKING:
     from sentry.workflow_engine.models import Action
+
+
+class _ProjectScopedEvent(Protocol):
+    project_id: int
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -98,15 +102,13 @@ class WorkflowEvaluation(
     @property
     def artifact_fields(self) -> dict[str, object]:
         if isinstance(self.result, DeferredWorkflowEvaluationResult):
-            result_type = "deferred"
             triggered_action_ids: list[int] = []
             deferred: dict[str, object] | None = {
-                "delayed_when_group_id": self.result.delayed_when_group_id,
-                "delayed_if_group_ids": sorted(self.result.delayed_if_group_ids),
-                "passing_if_group_ids": sorted(self.result.passing_if_group_ids),
+                "trigger_group_id": self.result.delayed_when_group_id,
+                "filter_group_ids": sorted(self.result.delayed_if_group_ids),
+                "passing_filter_group_ids": sorted(self.result.passing_if_group_ids),
             }
         else:
-            result_type = "actions"
             triggered_action_ids = [action.id for action in self.result]
             deferred = None
 
@@ -117,16 +119,17 @@ class WorkflowEvaluation(
             else event_data.event.id
         )
         return {
+            "evaluation_type": EvaluationType.WORKFLOW,
+            "evaluation_phase": EvaluationPhase.INITIAL,
             "workflow_id": self.workflow_id,
             "detector_id": self.detector_id,
             "detector_type": self.detector_type,
-            "project_id": event_data.event.project_id,
+            "project_id": cast(_ProjectScopedEvent, event_data.event).project_id,
             "event_id": str(event_id) if event_id else None,
             "group_id": event_data.group.id,
             "outcome": self.outcome,
-            "result_type": result_type,
             "triggered_action_ids": triggered_action_ids,
-            "deferred": deferred,
+            **({"deferred": deferred} if deferred else {}),
             "trigger_group_evaluation": self.data["trigger_group_eval"].to_artifact(),
             "filter_group_evaluations": [
                 evaluation.to_artifact() for evaluation in self.data["filter_group_evals"]
@@ -153,10 +156,13 @@ class ProcessWorkflowsResult:
 
     def to_artifact(self) -> dict[str, object]:
         return {
+            "evaluation_type": EvaluationType.WORKFLOW,
+            "evaluation_phase": EvaluationPhase.INITIAL,
             "outcome": self.outcome,
             "project_id": self.project_id,
             "group_id": self.group_id,
             "event_id": self.event_id,
             "detector_id": self.detector_id,
             "detector_type": self.detector_type,
+            "error": None,
         }

--- a/tests/sentry/workflow_engine/processors/evaluations/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/evaluations/test_workflow.py
@@ -12,6 +12,8 @@ from sentry.workflow_engine.processors.evaluations import (
     DataConditionEvaluation,
     DataConditionGroupEvaluation,
     DeferredWorkflowEvaluationResult,
+    EvaluationPhase,
+    EvaluationType,
     ProcessWorkflowsResult,
     WorkflowEvaluation,
     WorkflowEvaluationOutcome,
@@ -86,7 +88,7 @@ class TestWorkflowEvaluationArtifact(TestCase):
             evaluations=evaluations or {},
             outcome=outcome,
             project_id=self.project.id,
-            group_id=self.event.group.id,
+            group_id=self.group.id,
             event_id=self.event.event_id,
             detector_id=self.detector.id,
             detector_type=self.detector.type,
@@ -100,16 +102,16 @@ class TestWorkflowEvaluationArtifact(TestCase):
         assert evaluation.to_artifact() == {
             "triggered": True,
             "error": "evaluation failed",
+            "evaluation_type": EvaluationType.WORKFLOW,
+            "evaluation_phase": EvaluationPhase.INITIAL,
             "workflow_id": 10,
             "detector_id": self.detector.id,
             "detector_type": self.detector.type,
             "project_id": self.project.id,
             "event_id": self.event.event_id,
-            "group_id": self.event.group.id,
+            "group_id": self.group.id,
             "outcome": WorkflowEvaluationOutcome.ERROR,
-            "result_type": "actions",
             "triggered_action_ids": [],
-            "deferred": None,
             "trigger_group_evaluation": {
                 "triggered": True,
                 "error": "evaluation failed",
@@ -125,12 +127,11 @@ class TestWorkflowEvaluationArtifact(TestCase):
 
         artifact = evaluation.to_artifact()
 
-        assert artifact["result_type"] == "deferred"
         assert artifact["outcome"] == WorkflowEvaluationOutcome.DEFERRED
         assert artifact["deferred"] == {
-            "delayed_when_group_id": 20,
-            "delayed_if_group_ids": [30],
-            "passing_if_group_ids": [40],
+            "trigger_group_id": 20,
+            "filter_group_ids": [30],
+            "passing_filter_group_ids": [40],
         }
 
     def test_deferred_outcome_takes_precedence_over_error(self) -> None:
@@ -312,12 +313,15 @@ class TestWorkflowEvaluationArtifact(TestCase):
         mock_logger.info.assert_called_once_with(
             "workflow_engine.process_workflows.evaluation",
             extra={
+                "evaluation_type": EvaluationType.WORKFLOW,
+                "evaluation_phase": EvaluationPhase.INITIAL,
                 "outcome": WorkflowEvaluationOutcome.NO_WORKFLOWS,
                 "project_id": self.project.id,
-                "group_id": self.event.group.id,
+                "group_id": self.group.id,
                 "event_id": self.event.event_id,
                 "detector_id": self.detector.id,
                 "detector_type": self.detector.type,
+                "error": None,
                 "organization_id": self.organization.id,
             },
         )

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -16,11 +16,9 @@ from sentry.issues.producer import PayloadType
 from sentry.issues.status_change_message import StatusChangeMessage
 from sentry.models.activity import Activity
 from sentry.models.group import GroupStatus
-from sentry.models.organization import Organization
 from sentry.services.eventstore.models import GroupEvent
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
-from sentry.testutils.helpers.features import Feature
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.types.activity import ActivityType
@@ -115,8 +113,12 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
         data_packet = self.build_data_packet(secret="do-not-log")
 
         with (
-            Feature({"organizations:workflow-engine-log-evaluations": True}),
-            override_options({"workflow_engine.evaluation_logs_direct_to_sentry": False}),
+            override_options(
+                {
+                    "workflow_engine.evaluation_log_sample_rate": 1.0,
+                    "workflow_engine.evaluation_logs_direct_to_sentry": False,
+                }
+            ),
             mock.patch("sentry.workflow_engine.processors.detector.logger") as mock_logger,
         ):
             process_detectors(data_packet, [detector])
@@ -153,8 +155,12 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
         assert handler is not None
 
         with (
-            Feature({"organizations:workflow-engine-log-evaluations": True}),
-            override_options({"workflow_engine.evaluation_logs_direct_to_sentry": False}),
+            override_options(
+                {
+                    "workflow_engine.evaluation_log_sample_rate": 1.0,
+                    "workflow_engine.evaluation_logs_direct_to_sentry": False,
+                }
+            ),
             mock.patch.object(type(handler), "evaluate", return_value={}),
             mock.patch("sentry.workflow_engine.processors.detector.logger") as mock_logger,
         ):
@@ -184,7 +190,6 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
         mock_logger = mock.MagicMock()
 
         with (
-            Feature({"organizations:workflow-engine-log-evaluations": False}),
             override_options(
                 {
                     "workflow_engine.evaluation_log_sample_rate": 0.5,
@@ -198,7 +203,7 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
         ):
             assert emit_detector_evaluation_logs(
                 mock_logger,
-                organization=self.organization,
+                organization_id=None,
                 result=ProcessDetectorsResult(
                     detector_id=detector.id,
                     detector_type=detector.type,
@@ -222,15 +227,19 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
         mock_logger = mock.MagicMock()
 
         with (
-            Feature({"organizations:workflow-engine-log-evaluations": True}),
-            override_options({"workflow_engine.evaluation_logs_direct_to_sentry": True}),
+            override_options(
+                {
+                    "workflow_engine.evaluation_log_sample_rate": 1.0,
+                    "workflow_engine.evaluation_logs_direct_to_sentry": True,
+                }
+            ),
             mock.patch(
                 "sentry.workflow_engine.processors.evaluation_logging.sdk_logger"
             ) as mock_sentry_logger,
         ):
             assert emit_detector_evaluation_logs(
                 mock_logger,
-                organization=self.organization,
+                organization_id=self.organization.id,
                 result=ProcessDetectorsResult(
                     detector_id=detector.id,
                     detector_type=detector.type,
@@ -253,7 +262,28 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
         )
         mock_logger.info.assert_not_called()
 
-    def test_all_projects_detector_uses_configured_organization(self) -> None:
+    def test_project_detector_uses_cached_project_organization_id(self) -> None:
+        detector = self.create_detector(type=self.handler_type.slug)
+
+        with mock.patch(
+            "sentry.workflow_engine.processors.detector.emit_detector_evaluation_logs"
+        ) as mock_emit:
+            process_detectors(self.build_data_packet(), [detector])
+
+        assert mock_emit.call_args.kwargs["organization_id"] == self.organization.id
+
+    def test_project_detector_without_cached_project_uses_none(self) -> None:
+        detector = self.create_detector(type=self.handler_type.slug)
+        detector = Detector.objects.get(id=detector.id)
+
+        with mock.patch(
+            "sentry.workflow_engine.processors.detector.emit_detector_evaluation_logs"
+        ) as mock_emit:
+            process_detectors(self.build_data_packet(), [detector])
+
+        assert mock_emit.call_args.kwargs["organization_id"] is None
+
+    def test_all_projects_detector_uses_configured_organization_id(self) -> None:
         detector = self.create_detector(type=self.handler_type.slug)
         detector.update(project=None, config={"organization_id": self.organization.id})
 
@@ -262,73 +292,19 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
         ) as mock_emit:
             process_detectors(self.build_data_packet(), [detector])
 
-        assert mock_emit.call_args.kwargs["organization"] == self.organization
+        assert mock_emit.call_args.kwargs["organization_id"] == self.organization.id
 
-    def test_invalid_organization_config_logs_error_and_continues(self) -> None:
-        invalid_detector = self.create_detector(type=self.handler_type.slug)
-        invalid_detector.update(project=None, config={})
-        valid_detector = self.create_detector(type=self.handler_type.slug)
-
-        with mock.patch(
-            "sentry.workflow_engine.processors.detector.emit_detector_evaluation_logs"
-        ) as mock_emit:
-            results = process_detectors(
-                self.build_data_packet(), [invalid_detector, valid_detector]
-            )
-
-        assert [detector for detector, _ in results] == [valid_detector]
-        error_result = mock_emit.call_args_list[0].kwargs["result"]
-        assert error_result.outcome == DetectorEvaluationOutcome.ERROR
-        assert error_result.to_artifact()["error"] == (
-            "Organization-scoped detector is missing organization_id"
-        )
-        assert mock_emit.call_args_list[0].kwargs["organization"] is None
-        assert mock_emit.call_args_list[1].kwargs["organization"] == self.organization
-
-    def test_missing_project_logs_error_and_continues(self) -> None:
-        invalid_detector = self.create_detector(type=self.handler_type.slug)
-        setattr(invalid_detector, "project_id", 0)
-        valid_detector = self.create_detector(type=self.handler_type.slug)
+    def test_all_projects_detector_without_organization_id_uses_none(self) -> None:
+        detector = self.create_detector(type=self.handler_type.slug)
+        detector.update(project=None, config={})
 
         with mock.patch(
             "sentry.workflow_engine.processors.detector.emit_detector_evaluation_logs"
         ) as mock_emit:
-            results = process_detectors(
-                self.build_data_packet(), [invalid_detector, valid_detector]
-            )
+            results = process_detectors(self.build_data_packet(), [detector])
 
-        assert [detector for detector, _ in results] == [valid_detector]
-        error_result = mock_emit.call_args_list[0].kwargs["result"]
-        assert error_result.to_artifact()["error"] == "Detector project does not exist"
-
-    def test_missing_organization_logs_error_and_continues(self) -> None:
-        invalid_detector = self.create_detector(type=self.handler_type.slug)
-        invalid_detector.update(project=None, config={"organization_id": self.organization.id})
-        valid_detector = self.create_detector(type=self.handler_type.slug)
-
-        original_get_from_cache = Organization.objects.get_from_cache
-
-        def get_organization(*, id: int) -> Organization:
-            if id == self.organization.id:
-                raise Organization.DoesNotExist
-            return original_get_from_cache(id=id)
-
-        with (
-            mock.patch(
-                "sentry.workflow_engine.processors.detector.Organization.objects.get_from_cache",
-                side_effect=get_organization,
-            ),
-            mock.patch(
-                "sentry.workflow_engine.processors.detector.emit_detector_evaluation_logs"
-            ) as mock_emit,
-        ):
-            results = process_detectors(
-                self.build_data_packet(), [invalid_detector, valid_detector]
-            )
-
-        assert [detector for detector, _ in results] == [valid_detector]
-        error_result = mock_emit.call_args_list[0].kwargs["result"]
-        assert error_result.to_artifact()["error"] == "Detector organization does not exist"
+        assert [result_detector for result_detector, _ in results] == [detector]
+        assert mock_emit.call_args.kwargs["organization_id"] is None
 
     def test_evaluation_error_sets_process_result_outcome(self) -> None:
         detector = self.create_detector(type=self.handler_type.slug)
@@ -345,29 +321,27 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
         assert result.outcome == DetectorEvaluationOutcome.ERROR
         assert result.evaluation_artifacts()[0]["error"] == "evaluation failed"
 
-    def test_detector_emitter_logs_error_without_organization(self) -> None:
+    def test_detector_emitter_logs_error_without_organization_id(self) -> None:
         mock_logger = mock.MagicMock()
         result = ProcessDetectorsResult(
             detector_id=1,
             detector_type=self.handler_type.slug,
             project_id=None,
             evaluations={},
-            error=ConditionError(msg="organization lookup failed"),
+            error=ConditionError(msg="evaluation failed"),
         )
 
-        with (
-            override_options({"workflow_engine.evaluation_logs_direct_to_sentry": False}),
-            mock.patch(
-                "sentry.workflow_engine.processors.evaluation_logging.random.random"
-            ) as mock_random,
+        with override_options(
+            {
+                "workflow_engine.evaluation_log_sample_rate": 1.0,
+                "workflow_engine.evaluation_logs_direct_to_sentry": False,
+            }
         ):
             assert emit_detector_evaluation_logs(
                 mock_logger,
-                organization=None,
+                organization_id=None,
                 result=result,
             )
-
-        mock_random.assert_not_called()
         mock_logger.info.assert_called_once_with(
             "workflow_engine.process_detectors.evaluation",
             extra={
@@ -377,7 +351,7 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
                 "detector_type": self.handler_type.slug,
                 "project_id": None,
                 "outcome": DetectorEvaluationOutcome.ERROR,
-                "error": "organization lookup failed",
+                "error": "evaluation failed",
             },
         )
 

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -18,6 +18,7 @@ from sentry.models.group import GroupStatus
 from sentry.services.eventstore.models import GroupEvent
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.helpers.features import Feature
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.types.activity import ActivityType
@@ -28,6 +29,7 @@ from sentry.workflow_engine.handlers.detector import DetectorStateData
 from sentry.workflow_engine.handlers.detector.stateful import get_redis_client
 from sentry.workflow_engine.models import DataPacket, Detector, DetectorState
 from sentry.workflow_engine.models.detector_group import DetectorGroup
+from sentry.workflow_engine.processors import ProcessDetectorsResult
 from sentry.workflow_engine.processors.detector import (
     EventDetectors,
     associate_new_group_with_detector,
@@ -37,6 +39,8 @@ from sentry.workflow_engine.processors.detector import (
     get_preferred_detector,
     process_detectors,
 )
+from sentry.workflow_engine.processors.evaluation_logging import emit_detector_evaluation_logs
+from sentry.workflow_engine.processors.evaluations import DetectorEvaluationOutcome
 from sentry.workflow_engine.types import (
     DetectorPriorityLevel,
     WorkflowEventData,
@@ -98,6 +102,154 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
             triggered=True,
             priority=DetectorPriorityLevel.HIGH,
         )
+
+    def test_logs_canonical_evaluation_artifact(self) -> None:
+        detector = self.create_detector(type=self.handler_type.slug)
+        data_packet = self.build_data_packet(secret="do-not-log")
+
+        with (
+            Feature({"organizations:workflow-engine-log-evaluations": True}),
+            override_options({"workflow_engine.evaluation_logs_direct_to_sentry": False}),
+            mock.patch("sentry.workflow_engine.processors.detector.logger") as mock_logger,
+        ):
+            process_detectors(data_packet, [detector])
+
+        mock_logger.info.assert_called_once_with(
+            "workflow_engine.process_detectors.evaluation",
+            extra={
+                "detector_id": detector.id,
+                "detector_type": detector.type,
+                "project_id": detector.project_id,
+                "outcome": DetectorEvaluationOutcome.COMPLETED,
+                "group_key": None,
+                "priority": DetectorPriorityLevel.HIGH.value,
+                "trigger_group_evaluation": {
+                    "logic_type": "any",
+                    "result": True,
+                    "condition_evaluations": [],
+                    "triggered": True,
+                    "error": None,
+                },
+                "triggered": True,
+                "error": None,
+                "organization_id": self.organization.id,
+            },
+        )
+        assert "do-not-log" not in str(mock_logger.info.call_args)
+
+    def test_logs_detector_with_no_evaluation_results(self) -> None:
+        detector = self.create_detector(type=self.handler_type.slug)
+        handler = detector.detector_handler
+        assert handler is not None
+
+        with (
+            Feature({"organizations:workflow-engine-log-evaluations": True}),
+            override_options({"workflow_engine.evaluation_logs_direct_to_sentry": False}),
+            mock.patch.object(type(handler), "evaluate", return_value={}),
+            mock.patch("sentry.workflow_engine.processors.detector.logger") as mock_logger,
+        ):
+            assert process_detectors(self.build_data_packet(), [detector]) == []
+
+        mock_logger.info.assert_called_once_with(
+            "workflow_engine.process_detectors.evaluation",
+            extra={
+                "detector_id": detector.id,
+                "detector_type": detector.type,
+                "project_id": detector.project_id,
+                "outcome": DetectorEvaluationOutcome.NO_RESULTS,
+                "organization_id": self.organization.id,
+            },
+        )
+
+    def test_detector_emitter_samples_once_for_grouped_results(self) -> None:
+        detector, _ = self.create_detector_and_condition(type=self.handler_state_type.slug)
+        handler = detector.detector_handler
+        assert handler is not None
+        evaluations = handler.evaluate(
+            DataPacket("1", {"dedupe": 2, "group_vals": {"group_1": 6, "group_2": 10}})
+        )
+        mock_logger = mock.MagicMock()
+
+        with (
+            Feature({"organizations:workflow-engine-log-evaluations": False}),
+            override_options(
+                {
+                    "workflow_engine.evaluation_log_sample_rate": 0.5,
+                    "workflow_engine.evaluation_logs_direct_to_sentry": False,
+                }
+            ),
+            mock.patch(
+                "sentry.workflow_engine.processors.evaluation_logging.random.random",
+                return_value=0.1,
+            ) as mock_random,
+        ):
+            assert emit_detector_evaluation_logs(
+                mock_logger,
+                organization=self.organization,
+                result=ProcessDetectorsResult(
+                    detector_id=detector.id,
+                    detector_type=detector.type,
+                    project_id=detector.project_id,
+                    evaluations=evaluations,
+                ),
+            )
+
+        mock_random.assert_called_once_with()
+        assert mock_logger.info.call_count == 2
+        assert {item.kwargs["extra"]["group_key"] for item in mock_logger.info.call_args_list} == {
+            "group_1",
+            "group_2",
+        }
+
+    def test_detector_emitter_can_log_directly_to_sentry(self) -> None:
+        detector = self.create_detector(type=self.handler_type.slug)
+        handler = detector.detector_handler
+        assert handler is not None
+        evaluations = handler.evaluate(self.build_data_packet())
+        mock_logger = mock.MagicMock()
+
+        with (
+            Feature({"organizations:workflow-engine-log-evaluations": True}),
+            override_options({"workflow_engine.evaluation_logs_direct_to_sentry": True}),
+            mock.patch(
+                "sentry.workflow_engine.processors.evaluation_logging.sdk_logger"
+            ) as mock_sentry_logger,
+        ):
+            assert emit_detector_evaluation_logs(
+                mock_logger,
+                organization=self.organization,
+                result=ProcessDetectorsResult(
+                    detector_id=detector.id,
+                    detector_type=detector.type,
+                    project_id=detector.project_id,
+                    evaluations=evaluations,
+                ),
+            )
+
+        mock_sentry_logger.info.assert_called_once_with(
+            "workflow_engine.process_detectors.evaluation",
+            attributes={
+                **ProcessDetectorsResult(
+                    detector_id=detector.id,
+                    detector_type=detector.type,
+                    project_id=detector.project_id,
+                    evaluations=evaluations,
+                ).evaluation_artifacts()[0],
+                "organization_id": self.organization.id,
+            },
+        )
+        mock_logger.info.assert_not_called()
+
+    def test_all_projects_detector_uses_configured_organization(self) -> None:
+        detector = self.create_detector(type=self.handler_type.slug)
+        detector.update(project=None, config={"organization_id": self.organization.id})
+
+        with mock.patch(
+            "sentry.workflow_engine.processors.detector.emit_detector_evaluation_logs"
+        ) as mock_emit:
+            process_detectors(self.build_data_packet(), [detector])
+
+        assert mock_emit.call_args.kwargs["organization"] == self.organization
 
     @mock.patch("sentry.workflow_engine.processors.detector.produce_occurrence_to_kafka")
     def test_state_results(self, mock_produce_occurrence_to_kafka: MagicMock) -> None:
@@ -293,8 +445,7 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
                 ),
             ],
         )
-        assert mock_logger.info.call_count == 1
-        assert mock_logger.info.call_args[0][0] == "detector_triggered"
+        assert any(call.args[0] == "detector_triggered" for call in mock_logger.info.call_args_list)
 
     @mock.patch("sentry.workflow_engine.processors.detector.produce_occurrence_to_kafka")
     @mock.patch("sentry.workflow_engine.processors.detector.metrics")
@@ -341,8 +492,7 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
                 ),
             ],
         )
-        assert mock_logger.info.call_count == 2
-        assert mock_logger.info.call_args[0][0] == "detector_resolved"
+        assert any(call.args[0] == "detector_resolved" for call in mock_logger.info.call_args_list)
 
     def test_doesnt_send_metric(self) -> None:
         detector = self.create_detector(type=self.no_handler_type.slug)

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -1,5 +1,6 @@
 import unittest
 import uuid
+from dataclasses import replace
 from typing import Any
 from unittest import mock
 from unittest.mock import MagicMock, call, patch
@@ -15,6 +16,7 @@ from sentry.issues.producer import PayloadType
 from sentry.issues.status_change_message import StatusChangeMessage
 from sentry.models.activity import Activity
 from sentry.models.group import GroupStatus
+from sentry.models.organization import Organization
 from sentry.services.eventstore.models import GroupEvent
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
@@ -42,6 +44,7 @@ from sentry.workflow_engine.processors.detector import (
 from sentry.workflow_engine.processors.evaluation_logging import emit_detector_evaluation_logs
 from sentry.workflow_engine.processors.evaluations import DetectorEvaluationOutcome
 from sentry.workflow_engine.types import (
+    ConditionError,
     DetectorPriorityLevel,
     WorkflowEventData,
 )
@@ -157,6 +160,7 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
                 "detector_type": detector.type,
                 "project_id": detector.project_id,
                 "outcome": DetectorEvaluationOutcome.NO_RESULTS,
+                "error": None,
                 "organization_id": self.organization.id,
             },
         )
@@ -250,6 +254,121 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
             process_detectors(self.build_data_packet(), [detector])
 
         assert mock_emit.call_args.kwargs["organization"] == self.organization
+
+    def test_invalid_organization_config_logs_error_and_continues(self) -> None:
+        invalid_detector = self.create_detector(type=self.handler_type.slug)
+        invalid_detector.update(project=None, config={})
+        valid_detector = self.create_detector(type=self.handler_type.slug)
+
+        with mock.patch(
+            "sentry.workflow_engine.processors.detector.emit_detector_evaluation_logs"
+        ) as mock_emit:
+            results = process_detectors(
+                self.build_data_packet(), [invalid_detector, valid_detector]
+            )
+
+        assert [detector for detector, _ in results] == [valid_detector]
+        error_result = mock_emit.call_args_list[0].kwargs["result"]
+        assert error_result.outcome == DetectorEvaluationOutcome.ERROR
+        assert error_result.to_artifact()["error"] == (
+            "Organization-scoped detector is missing organization_id"
+        )
+        assert mock_emit.call_args_list[0].kwargs["organization"] is None
+        assert mock_emit.call_args_list[1].kwargs["organization"] == self.organization
+
+    def test_missing_project_logs_error_and_continues(self) -> None:
+        invalid_detector = self.create_detector(type=self.handler_type.slug)
+        invalid_detector.project_id = 0
+        valid_detector = self.create_detector(type=self.handler_type.slug)
+
+        with mock.patch(
+            "sentry.workflow_engine.processors.detector.emit_detector_evaluation_logs"
+        ) as mock_emit:
+            results = process_detectors(
+                self.build_data_packet(), [invalid_detector, valid_detector]
+            )
+
+        assert [detector for detector, _ in results] == [valid_detector]
+        error_result = mock_emit.call_args_list[0].kwargs["result"]
+        assert error_result.to_artifact()["error"] == "Detector project does not exist"
+
+    def test_missing_organization_logs_error_and_continues(self) -> None:
+        invalid_detector = self.create_detector(type=self.handler_type.slug)
+        invalid_detector.update(project=None, config={"organization_id": self.organization.id})
+        valid_detector = self.create_detector(type=self.handler_type.slug)
+
+        original_get_from_cache = Organization.objects.get_from_cache
+
+        def get_organization(*, id: int) -> Organization:
+            if id == self.organization.id:
+                raise Organization.DoesNotExist
+            return original_get_from_cache(id=id)
+
+        with (
+            mock.patch(
+                "sentry.workflow_engine.processors.detector.Organization.objects.get_from_cache",
+                side_effect=get_organization,
+            ),
+            mock.patch(
+                "sentry.workflow_engine.processors.detector.emit_detector_evaluation_logs"
+            ) as mock_emit,
+        ):
+            results = process_detectors(
+                self.build_data_packet(), [invalid_detector, valid_detector]
+            )
+
+        assert [detector for detector, _ in results] == [valid_detector]
+        error_result = mock_emit.call_args_list[0].kwargs["result"]
+        assert error_result.to_artifact()["error"] == "Detector organization does not exist"
+
+    def test_evaluation_error_sets_process_result_outcome(self) -> None:
+        detector = self.create_detector(type=self.handler_type.slug)
+        handler = detector.detector_handler
+        assert handler is not None
+        evaluation = handler.evaluate(self.build_data_packet())[None]
+        result = ProcessDetectorsResult(
+            detector_id=detector.id,
+            detector_type=detector.type,
+            project_id=detector.project_id,
+            evaluations={None: replace(evaluation, error=ConditionError(msg="evaluation failed"))},
+        )
+
+        assert result.outcome == DetectorEvaluationOutcome.ERROR
+        assert result.evaluation_artifacts()[0]["error"] == "evaluation failed"
+
+    def test_detector_emitter_logs_error_without_organization(self) -> None:
+        mock_logger = mock.MagicMock()
+        result = ProcessDetectorsResult(
+            detector_id=1,
+            detector_type=self.handler_type.slug,
+            project_id=None,
+            evaluations={},
+            error=ConditionError(msg="organization lookup failed"),
+        )
+
+        with (
+            override_options({"workflow_engine.evaluation_logs_direct_to_sentry": False}),
+            mock.patch(
+                "sentry.workflow_engine.processors.evaluation_logging.random.random"
+            ) as mock_random,
+        ):
+            assert emit_detector_evaluation_logs(
+                mock_logger,
+                organization=None,
+                result=result,
+            )
+
+        mock_random.assert_not_called()
+        mock_logger.info.assert_called_once_with(
+            "workflow_engine.process_detectors.evaluation",
+            extra={
+                "detector_id": 1,
+                "detector_type": self.handler_type.slug,
+                "project_id": None,
+                "outcome": DetectorEvaluationOutcome.ERROR,
+                "error": "organization lookup failed",
+            },
+        )
 
     @mock.patch("sentry.workflow_engine.processors.detector.produce_occurrence_to_kafka")
     def test_state_results(self, mock_produce_occurrence_to_kafka: MagicMock) -> None:

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -42,7 +42,6 @@ from sentry.workflow_engine.processors.detector import (
 from sentry.workflow_engine.processors.evaluation_logging import emit_detector_evaluation_logs
 from sentry.workflow_engine.processors.evaluations import (
     DetectorEvaluationOutcome,
-    EvaluationPhase,
     EvaluationType,
 )
 from sentry.workflow_engine.types import (
@@ -127,7 +126,6 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
             "workflow_engine.process_detectors.evaluation",
             extra={
                 "evaluation_type": EvaluationType.DETECTOR,
-                "evaluation_phase": EvaluationPhase.INITIAL,
                 "detector_id": detector.id,
                 "detector_type": detector.type,
                 "project_id": detector.linked_project.id,
@@ -170,7 +168,6 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
             "workflow_engine.process_detectors.evaluation",
             extra={
                 "evaluation_type": EvaluationType.DETECTOR,
-                "evaluation_phase": EvaluationPhase.INITIAL,
                 "detector_id": detector.id,
                 "detector_type": detector.type,
                 "project_id": detector.linked_project.id,
@@ -346,7 +343,6 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
             "workflow_engine.process_detectors.evaluation",
             extra={
                 "evaluation_type": EvaluationType.DETECTOR,
-                "evaluation_phase": EvaluationPhase.INITIAL,
                 "detector_id": 1,
                 "detector_type": self.handler_type.slug,
                 "project_id": None,

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -42,7 +42,11 @@ from sentry.workflow_engine.processors.detector import (
     process_detectors,
 )
 from sentry.workflow_engine.processors.evaluation_logging import emit_detector_evaluation_logs
-from sentry.workflow_engine.processors.evaluations import DetectorEvaluationOutcome
+from sentry.workflow_engine.processors.evaluations import (
+    DetectorEvaluationOutcome,
+    EvaluationPhase,
+    EvaluationType,
+)
 from sentry.workflow_engine.types import (
     ConditionError,
     DetectorPriorityLevel,
@@ -120,10 +124,13 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
         mock_logger.info.assert_called_once_with(
             "workflow_engine.process_detectors.evaluation",
             extra={
+                "evaluation_type": EvaluationType.DETECTOR,
+                "evaluation_phase": EvaluationPhase.INITIAL,
                 "detector_id": detector.id,
                 "detector_type": detector.type,
                 "project_id": detector.linked_project.id,
-                "outcome": DetectorEvaluationOutcome.COMPLETED,
+                "outcome": DetectorEvaluationOutcome.TRIGGERED,
+                "event_id": None,
                 "group_key": None,
                 "priority": DetectorPriorityLevel.HIGH.value,
                 "trigger_group_evaluation": {
@@ -156,6 +163,8 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
         mock_logger.info.assert_called_once_with(
             "workflow_engine.process_detectors.evaluation",
             extra={
+                "evaluation_type": EvaluationType.DETECTOR,
+                "evaluation_phase": EvaluationPhase.INITIAL,
                 "detector_id": detector.id,
                 "detector_type": detector.type,
                 "project_id": detector.linked_project.id,
@@ -362,6 +371,8 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
         mock_logger.info.assert_called_once_with(
             "workflow_engine.process_detectors.evaluation",
             extra={
+                "evaluation_type": EvaluationType.DETECTOR,
+                "evaluation_phase": EvaluationPhase.INITIAL,
                 "detector_id": 1,
                 "detector_type": self.handler_type.slug,
                 "project_id": None,

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -122,7 +122,7 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
             extra={
                 "detector_id": detector.id,
                 "detector_type": detector.type,
-                "project_id": detector.project_id,
+                "project_id": detector.linked_project.id,
                 "outcome": DetectorEvaluationOutcome.COMPLETED,
                 "group_key": None,
                 "priority": DetectorPriorityLevel.HIGH.value,
@@ -158,7 +158,7 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
             extra={
                 "detector_id": detector.id,
                 "detector_type": detector.type,
-                "project_id": detector.project_id,
+                "project_id": detector.linked_project.id,
                 "outcome": DetectorEvaluationOutcome.NO_RESULTS,
                 "error": None,
                 "organization_id": self.organization.id,
@@ -193,7 +193,7 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
                 result=ProcessDetectorsResult(
                     detector_id=detector.id,
                     detector_type=detector.type,
-                    project_id=detector.project_id,
+                    project_id=detector.linked_project.id,
                     evaluations=evaluations,
                 ),
             )
@@ -225,7 +225,7 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
                 result=ProcessDetectorsResult(
                     detector_id=detector.id,
                     detector_type=detector.type,
-                    project_id=detector.project_id,
+                    project_id=detector.linked_project.id,
                     evaluations=evaluations,
                 ),
             )
@@ -236,7 +236,7 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
                 **ProcessDetectorsResult(
                     detector_id=detector.id,
                     detector_type=detector.type,
-                    project_id=detector.project_id,
+                    project_id=detector.linked_project.id,
                     evaluations=evaluations,
                 ).evaluation_artifacts()[0],
                 "organization_id": self.organization.id,
@@ -278,7 +278,7 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
 
     def test_missing_project_logs_error_and_continues(self) -> None:
         invalid_detector = self.create_detector(type=self.handler_type.slug)
-        invalid_detector.project_id = 0
+        setattr(invalid_detector, "project_id", 0)
         valid_detector = self.create_detector(type=self.handler_type.slug)
 
         with mock.patch(
@@ -329,7 +329,7 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
         result = ProcessDetectorsResult(
             detector_id=detector.id,
             detector_type=detector.type,
-            project_id=detector.project_id,
+            project_id=detector.linked_project.id,
             evaluations={None: replace(evaluation, error=ConditionError(msg="evaluation failed"))},
         )
 
@@ -513,10 +513,8 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
 
     @mock.patch("sentry.workflow_engine.processors.detector.produce_occurrence_to_kafka")
     @mock.patch("sentry.workflow_engine.processors.detector.metrics")
-    @mock.patch("sentry.workflow_engine.processors.detector.logger")
-    def test_metrics_and_logs_fire(
+    def test_metrics_triggered(
         self,
-        mock_logger: mock.MagicMock,
         mock_metrics: mock.MagicMock,
         mock_produce_occurrence_to_kafka: mock.MagicMock,
     ) -> None:
@@ -564,14 +562,11 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
                 ),
             ],
         )
-        assert any(call.args[0] == "detector_triggered" for call in mock_logger.info.call_args_list)
 
     @mock.patch("sentry.workflow_engine.processors.detector.produce_occurrence_to_kafka")
     @mock.patch("sentry.workflow_engine.processors.detector.metrics")
-    @mock.patch("sentry.workflow_engine.processors.detector.logger")
-    def test_metrics_and_logs_resolve(
+    def test_metrics_resolved(
         self,
-        mock_logger: mock.MagicMock,
         mock_metrics: mock.MagicMock,
         mock_produce_occurrence_to_kafka: mock.MagicMock,
     ) -> None:
@@ -611,7 +606,6 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
                 ),
             ],
         )
-        assert any(call.args[0] == "detector_resolved" for call in mock_logger.info.call_args_list)
 
     def test_doesnt_send_metric(self) -> None:
         detector = self.create_detector(type=self.no_handler_type.slug)
@@ -1362,7 +1356,7 @@ class TestGetDetectorsForEventAllProject(TestCase):
         from sentry.workflow_engine.defaults.detectors import ensure_default_all_projects_detector
 
         self.all_projects_detector = ensure_default_all_projects_detector(
-            self.project.organization_id
+            self.project.organization.id
         )
         self.event = self.store_event(project_id=self.project.id, data={})
         self.group_event = GroupEvent.from_event(self.event, self.group)


### PR DESCRIPTION
## Description
Use the `DetectorEvaluation` to log the results of each detector. This was previously only done for cases when we had a next step (trigger or resolve the detector), now we log every evaluation.

Also included a little minor cleanup to the Workflow Evaluation Log to make it consistent.

## Example Log

Message: `workflow_engine.process_detectors.evaluation`
```json
   {
     "evaluation_type": "detector",
     "detector_id": 12345,
     "detector_type": "metric_issue",
     "project_id": 67890,
     "organization_id": 24680,
     "outcome": "triggered",
     "event_id": null,
     "group_key": null,
     "priority": "high",
     "trigger_group_evaluation": {
       "logic_type": "any",
       "result": true,
       "condition_evaluations": [],
       "triggered": true,
       "error": null
     },
     "triggered": true,
     "error": null
   }
 ```