### PR TITLE
Add agentic onboarding progress endpoints

### DIFF
--- a/src/sentry/api/endpoints/organization_agentic_onboarding.py
+++ b/src/sentry/api/endpoints/organization_agentic_onboarding.py
@@ -1,0 +1,195 @@
+from typing import Literal, NotRequired, TypedDict
+from uuid import UUID
+
+from drf_spectacular.utils import extend_schema
+from rest_framework import serializers, status
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import cell_silo_endpoint
+from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
+from sentry.api.serializers import serialize
+from sentry.api.serializers.models.agentic_onboarding import (
+    AgenticOnboardingRunSerializer,
+)
+from sentry.api.serializers.rest_framework import CamelSnakeSerializer
+from sentry.models.organization import Organization
+from sentry.onboarding.agentic_progress.model import (
+    MAX_EVENT_NOTE_LENGTH,
+    InvalidProgressUpdate,
+    OnboardingRunExpired,
+    OnboardingRunTerminal,
+    ProgressUpdate,
+    RunStatus,
+    Stage,
+    StageStatus,
+    validate_update,
+)
+from sentry.onboarding.agentic_progress.service import (
+    RunNotFound,
+    RunOwnershipMismatch,
+    get_onboarding_progress_service,
+)
+
+INVALID_PROGRESS_UPDATE_DETAIL = "Invalid onboarding progress update"
+
+StageValue = Literal[
+    "connect_mcp",
+    "analyze_project",
+    "create_project",
+    "instrument_app",
+    "plan_test_error",
+    "send_verification_error",
+    "receive_verification_error",
+    "prepare_production",
+    "check_stack_trace_quality",
+]
+StageStatusValue = Literal["active", "waiting", "completed", "skipped", "failed"]
+
+
+class AgenticOnboardingRunRequest(TypedDict):
+    client_run_id: UUID
+    onboarding_code: str
+
+
+class AgenticOnboardingStatusRequest(TypedDict):
+    schema_version: int
+    run_token: str
+    stage: StageValue
+    status: StageStatusValue
+    run_status: NotRequired[Literal["completed", "failed"]]
+    event_note: NotRequired[str]
+    project_slug: NotRequired[str]
+    issue_id: NotRequired[str]
+
+
+class AgenticOnboardingStatusData(TypedDict):
+    run_token: str
+    update: ProgressUpdate
+
+
+class AgenticOnboardingPermission(OrganizationPermission):
+    scope_map = {"GET": ["org:read"], "POST": ["org:read"], "DELETE": ["org:read"]}
+
+    def has_permission(self, request: Request, view: APIView) -> bool:
+        return request.user.is_authenticated and super().has_permission(request, view)
+
+
+class AgenticOnboardingRunRequestSerializer(CamelSnakeSerializer[AgenticOnboardingRunRequest]):
+    client_run_id = serializers.UUIDField()
+    onboarding_code = serializers.RegexField(r"^[A-Za-z0-9]{10}$")
+
+
+class AgenticOnboardingStatusRequestSerializer(CamelSnakeSerializer[AgenticOnboardingStatusData]):
+    schema_version = serializers.IntegerField(min_value=1, max_value=1)
+    run_token = serializers.RegexField(r"^[A-Za-z0-9]{10}$")
+    stage = serializers.ChoiceField(choices=[stage.value for stage in Stage])
+    status = serializers.ChoiceField(
+        choices=[
+            stage_status.value
+            for stage_status in StageStatus
+            if stage_status is not StageStatus.BYPASSED
+        ]
+    )
+    run_status = serializers.ChoiceField(
+        choices=[RunStatus.COMPLETED.value, RunStatus.FAILED.value], required=False
+    )
+    event_note = serializers.CharField(
+        required=False, allow_blank=False, max_length=MAX_EVENT_NOTE_LENGTH
+    )
+    project_slug = serializers.SlugField(required=False)
+    issue_id = serializers.CharField(required=False)
+
+    def validate(self, attrs: AgenticOnboardingStatusRequest) -> AgenticOnboardingStatusData:
+        update = ProgressUpdate(
+            stage=Stage(attrs["stage"]),
+            status=StageStatus(attrs["status"]),
+            event_note=attrs.get("event_note"),
+            project_slug=attrs.get("project_slug"),
+            issue_id=attrs.get("issue_id"),
+            run_status=(RunStatus(attrs["run_status"]) if "run_status" in attrs else None),
+        )
+        try:
+            validate_update(update)
+        except InvalidProgressUpdate as error:
+            raise serializers.ValidationError({error.field.value: str(error)}) from error
+
+        return {"run_token": attrs["run_token"], "update": update}
+
+
+@cell_silo_endpoint
+class OrganizationAgenticOnboardingRunIndexEndpoint(OrganizationEndpoint):
+    permission_classes = (AgenticOnboardingPermission,)
+    publish_status = {"POST": ApiPublishStatus.PRIVATE}
+    owner = ApiOwner.VALUE_DISCOVERY
+
+    @extend_schema(
+        request=AgenticOnboardingRunRequestSerializer,
+        responses={201: AgenticOnboardingRunSerializer},
+    )
+    def post(self, request: Request, organization: Organization) -> Response:
+        serializer = AgenticOnboardingRunRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        user_id = request.user.id
+        assert user_id is not None
+        try:
+            run, onboarding_code = get_onboarding_progress_service().create_or_resume(
+                user_id=user_id,
+                organization_id=organization.id,
+                client_run_id=str(serializer.validated_data["client_run_id"]),
+                onboarding_code=serializer.validated_data["onboarding_code"],
+            )
+        except RunOwnershipMismatch:
+            return Response({"detail": "Onboarding run not found"}, status=404)
+        except ValueError:
+            return Response({"detail": "Onboarding code is unavailable"}, status=409)
+
+        return Response(
+            serialize(
+                run,
+                request.user,
+                AgenticOnboardingRunSerializer(),
+                onboarding_code=onboarding_code,
+            ),
+            status=status.HTTP_201_CREATED,
+        )
+
+
+@cell_silo_endpoint
+class OrganizationAgenticOnboardingStatusEndpoint(OrganizationEndpoint):
+    permission_classes = (AgenticOnboardingPermission,)
+    publish_status = {"POST": ApiPublishStatus.PRIVATE}
+    owner = ApiOwner.VALUE_DISCOVERY
+
+    @extend_schema(
+        request=AgenticOnboardingStatusRequestSerializer,
+        responses={200: AgenticOnboardingRunSerializer},
+    )
+    def post(self, request: Request, organization: Organization) -> Response:
+        serializer = AgenticOnboardingStatusRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        values = serializer.validated_data
+        user_id = request.user.id
+        assert user_id is not None
+
+        try:
+            run, _ = get_onboarding_progress_service().update(
+                token=values["run_token"],
+                user_id=user_id,
+                organization_id=organization.id,
+                update=values["update"],
+            )
+        except (RunNotFound, RunOwnershipMismatch):
+            return Response({"detail": "Onboarding run not found"}, status=404)
+        except OnboardingRunExpired:
+            return Response({"detail": "Onboarding run has expired"}, status=410)
+        except OnboardingRunTerminal:
+            return Response({"detail": "Onboarding run is terminal"}, status=409)
+        except ValueError:
+            return Response({"detail": INVALID_PROGRESS_UPDATE_DETAIL}, status=400)
+
+        snapshot = serialize(run, request.user, AgenticOnboardingRunSerializer())
+        return Response(snapshot)

--- a/src/sentry/api/serializers/models/agentic_onboarding.py
+++ b/src/sentry/api/serializers/models/agentic_onboarding.py
@@ -1,0 +1,66 @@
+from collections.abc import Mapping
+from typing import Any, NotRequired, TypedDict
+
+from sentry.api.serializers import Serializer
+from sentry.onboarding.agentic_progress.model import OnboardingRun, RunStatus, Stage, StageStatus
+
+
+class AgenticOnboardingStageResponse(TypedDict):
+    stage: Stage
+    status: StageStatus | None
+    eventNote: str | None
+
+
+class AgenticOnboardingRunResponse(TypedDict):
+    schemaVersion: int
+    runId: str
+    channelId: str
+    onboardingCode: NotRequired[str]
+    clientRunId: str
+    createdAt: str
+    updatedAt: str
+    sequence: int
+    expiresAt: str
+    continueUpdates: bool
+    runStatus: RunStatus
+    projectSlug: str | None
+    issueId: str | None
+    stages: list[AgenticOnboardingStageResponse]
+
+
+class AgenticOnboardingRunSerializer(Serializer[AgenticOnboardingRunResponse]):
+    def serialize(
+        self,
+        obj: OnboardingRun,
+        attrs: Mapping[str, Any],
+        user: Any,
+        **kwargs: Any,
+    ) -> AgenticOnboardingRunResponse:
+        data = AgenticOnboardingRunResponse(
+            schemaVersion=obj.schema_version,
+            runId=obj.run_id,
+            channelId=obj.channel_id,
+            clientRunId=obj.client_run_id,
+            createdAt=obj.created_at.isoformat(),
+            updatedAt=obj.updated_at.isoformat(),
+            sequence=obj.sequence,
+            expiresAt=obj.expires_at.isoformat(),
+            continueUpdates=obj.run_status is RunStatus.ACTIVE,
+            runStatus=obj.run_status,
+            projectSlug=obj.project_slug,
+            issueId=obj.issue_id,
+            stages=[
+                AgenticOnboardingStageResponse(
+                    stage=state.stage,
+                    status=state.status,
+                    eventNote=state.event_note,
+                )
+                for state in obj.stages
+            ],
+        )
+
+        onboarding_code = kwargs.get("onboarding_code")
+        if onboarding_code is not None:
+            data["onboardingCode"] = onboarding_code
+
+        return data

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -748,6 +748,10 @@ from .endpoints.internal import (
 )
 from .endpoints.internal_ea_features import InternalEAFeaturesEndpoint
 from .endpoints.organization_access_request_details import OrganizationAccessRequestDetailsEndpoint
+from .endpoints.organization_agentic_onboarding import (
+    OrganizationAgenticOnboardingRunIndexEndpoint,
+    OrganizationAgenticOnboardingStatusEndpoint,
+)
 from .endpoints.organization_api_key_details import OrganizationApiKeyDetailsEndpoint
 from .endpoints.organization_api_key_index import OrganizationApiKeyIndexEndpoint
 from .endpoints.organization_artifactbundle_assemble import (
@@ -2578,6 +2582,16 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^/]+)/onboarding-tasks/$",
         OrganizationOnboardingTaskEndpoint.as_view(),
         name="sentry-api-0-organization-onboardingtasks",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/onboarding/agent/runs/$",
+        OrganizationAgenticOnboardingRunIndexEndpoint.as_view(),
+        name="sentry-api-0-organization-agentic-onboarding-run-index",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/onboarding/agent/status/$",
+        OrganizationAgenticOnboardingStatusEndpoint.as_view(),
+        name="sentry-api-0-organization-agentic-onboarding-status",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/environments/$",

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -277,6 +277,8 @@ export type KnownSentryApiUrls =
   | '/organizations/$organizationIdOrSlug/objectstore/$path'
   | '/organizations/$organizationIdOrSlug/onboarding-continuation-email/'
   | '/organizations/$organizationIdOrSlug/onboarding-tasks/'
+  | '/organizations/$organizationIdOrSlug/onboarding/agent/runs/'
+  | '/organizations/$organizationIdOrSlug/onboarding/agent/status/'
   | '/organizations/$organizationIdOrSlug/ondemand-rules-stats/'
   | '/organizations/$organizationIdOrSlug/open-periods/'
   | '/organizations/$organizationIdOrSlug/org-auth-tokens/'

--- a/tests/sentry/api/endpoints/test_organization_agentic_onboarding.py
+++ b/tests/sentry/api/endpoints/test_organization_agentic_onboarding.py
@@ -1,0 +1,271 @@
+from dataclasses import replace
+from datetime import timedelta
+from unittest.mock import patch
+from uuid import uuid4
+
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework.response import Response
+
+from sentry.onboarding.agentic_progress.model import ProgressUpdate, RunStatus, Stage, StageStatus
+from sentry.onboarding.agentic_progress.service import OnboardingProgressService
+from sentry.testutils.cases import APITestCase
+
+
+class OrganizationAgenticOnboardingEndpointTest(APITestCase):
+    def setUp(self) -> None:
+        self.user = self.create_user()
+        self.organization = self.create_organization(owner=self.user)
+        self.login_as(self.user)
+        self.service = OnboardingProgressService()
+
+    def test_create_and_update_run(self) -> None:
+        index_path = reverse(
+            "sentry-api-0-organization-agentic-onboarding-run-index",
+            args=[self.organization.slug],
+        )
+        service_path = (
+            "sentry.api.endpoints.organization_agentic_onboarding.get_onboarding_progress_service"
+        )
+        with patch(service_path, return_value=self.service):
+            response = self.client.post(
+                index_path,
+                {"clientRunId": str(uuid4()), "onboardingCode": "a1B2c3D4e5"},
+            )
+
+        assert response.status_code == 201, response.content
+        assert response.data["onboardingCode"] == "a1B2c3D4e5"
+        assert response.data["sequence"] == 0
+
+        status_path = reverse(
+            "sentry-api-0-organization-agentic-onboarding-status",
+            args=[self.organization.slug],
+        )
+        with patch(service_path, return_value=self.service):
+            response = self.client.post(
+                status_path,
+                {
+                    "schemaVersion": 1,
+                    "runToken": "a1B2c3D4e5",
+                    "stage": "create_project",
+                    "status": "completed",
+                    "eventNote": "Project already existed.",
+                },
+            )
+
+        assert response.status_code == 200, response.content
+        assert response.data["sequence"] == 1
+        assert response.data["stages"][0]["status"] == "bypassed"
+        assert response.data["stages"][1]["status"] == "bypassed"
+        assert response.data["stages"][2]["status"] == "completed"
+
+    def test_status_rejects_unknown_run(self) -> None:
+        path = reverse(
+            "sentry-api-0-organization-agentic-onboarding-status",
+            args=[self.organization.slug],
+        )
+        with patch(
+            "sentry.api.endpoints.organization_agentic_onboarding.get_onboarding_progress_service",
+            return_value=self.service,
+        ):
+            response = self.client.post(
+                path,
+                {
+                    "schemaVersion": 1,
+                    "runToken": "abcdefghij",
+                    "stage": "connect_mcp",
+                    "status": "completed",
+                },
+            )
+
+        assert response.status_code == 404
+        assert response.data == {"detail": "Onboarding run not found"}
+
+    def test_registration_rejects_mismatched_code(self) -> None:
+        client_run_id = str(uuid4())
+        self.service.create_or_resume(
+            user_id=self.user.id,
+            organization_id=self.organization.id,
+            client_run_id=client_run_id,
+            onboarding_code="abcdefghij",
+        )
+        path = reverse(
+            "sentry-api-0-organization-agentic-onboarding-run-index",
+            args=[self.organization.slug],
+        )
+
+        with patch(
+            "sentry.api.endpoints.organization_agentic_onboarding.get_onboarding_progress_service",
+            return_value=self.service,
+        ):
+            response = self.client.post(
+                path,
+                {"clientRunId": client_run_id, "onboardingCode": "klmnopqrst"},
+            )
+
+        assert response.status_code == 404
+        assert response.data == {"detail": "Onboarding run not found"}
+
+    def test_registration_rejects_code_reserved_by_another_run(self) -> None:
+        self.service.create_or_resume(
+            user_id=self.user.id,
+            organization_id=self.organization.id,
+            client_run_id=str(uuid4()),
+            onboarding_code="abcdefghij",
+        )
+        path = reverse(
+            "sentry-api-0-organization-agentic-onboarding-run-index",
+            args=[self.organization.slug],
+        )
+
+        with patch(
+            "sentry.api.endpoints.organization_agentic_onboarding.get_onboarding_progress_service",
+            return_value=self.service,
+        ):
+            response = self.client.post(
+                path,
+                {"clientRunId": str(uuid4()), "onboardingCode": "abcdefghij"},
+            )
+
+        assert response.status_code == 409
+        assert response.data == {"detail": "Onboarding code is unavailable"}
+
+    def test_status_requires_event_note_for_failure(self) -> None:
+        _, token = self.service.create_or_resume(
+            user_id=self.user.id,
+            organization_id=self.organization.id,
+            client_run_id=str(uuid4()),
+            onboarding_code="abcdefghij",
+        )
+        path = reverse(
+            "sentry-api-0-organization-agentic-onboarding-status",
+            args=[self.organization.slug],
+        )
+        with patch(
+            "sentry.api.endpoints.organization_agentic_onboarding.get_onboarding_progress_service",
+            return_value=self.service,
+        ):
+            response = self.client.post(
+                path,
+                {
+                    "schemaVersion": 1,
+                    "runToken": token,
+                    "stage": "create_project",
+                    "status": "failed",
+                },
+            )
+
+        assert response.status_code == 400
+        assert response.data == {"eventNote": ["Failed stages require an event note"]}
+
+    def test_status_returns_conflict_for_terminal_run(self) -> None:
+        _, token = self.service.create_or_resume(
+            user_id=self.user.id,
+            organization_id=self.organization.id,
+            client_run_id=str(uuid4()),
+            onboarding_code="abcdefghij",
+        )
+        self.service.update(
+            token=token,
+            user_id=self.user.id,
+            organization_id=self.organization.id,
+            update=ProgressUpdate(
+                stage=Stage.CHECK_STACK_TRACE_QUALITY,
+                status=StageStatus.SKIPPED,
+                run_status=RunStatus.COMPLETED,
+            ),
+        )
+
+        response = self._post_status(token)
+
+        assert response.status_code == 409
+        assert response.data == {"detail": "Onboarding run is terminal"}
+
+    def test_status_returns_gone_for_expired_run(self) -> None:
+        run, token = self.service.create_or_resume(
+            user_id=self.user.id,
+            organization_id=self.organization.id,
+            client_run_id=str(uuid4()),
+            onboarding_code="abcdefghij",
+        )
+        expired = replace(run, expires_at=timezone.now() - timedelta(seconds=1))
+        self.service.redis.set(
+            self.service._state_key(run.run_id),
+            self.service._serialize(expired),
+            ex=60,
+        )
+
+        response = self._post_status(token)
+
+        assert response.status_code == 410
+        assert response.data == {"detail": "Onboarding run has expired"}
+
+    def _post_status(self, token: str) -> Response:
+        path = reverse(
+            "sentry-api-0-organization-agentic-onboarding-status",
+            args=[self.organization.slug],
+        )
+        with patch(
+            "sentry.api.endpoints.organization_agentic_onboarding.get_onboarding_progress_service",
+            return_value=self.service,
+        ):
+            return self.client.post(
+                path,
+                {
+                    "schemaVersion": 1,
+                    "runToken": token,
+                    "stage": "connect_mcp",
+                    "status": "completed",
+                },
+            )
+
+    def test_status_rejects_backend_derived_bypassed_status(self) -> None:
+        _, token = self.service.create_or_resume(
+            user_id=self.user.id,
+            organization_id=self.organization.id,
+            client_run_id=str(uuid4()),
+            onboarding_code="abcdefghij",
+        )
+        path = reverse(
+            "sentry-api-0-organization-agentic-onboarding-status",
+            args=[self.organization.slug],
+        )
+
+        with patch(
+            "sentry.api.endpoints.organization_agentic_onboarding.get_onboarding_progress_service",
+            return_value=self.service,
+        ):
+            response = self.client.post(
+                path,
+                {
+                    "schemaVersion": 1,
+                    "runToken": token,
+                    "stage": "analyze_project",
+                    "status": "bypassed",
+                },
+            )
+
+        assert response.status_code == 400
+        assert "status" in response.data
+
+    def test_status_does_not_expose_domain_validation_details(self) -> None:
+        path = reverse(
+            "sentry-api-0-organization-agentic-onboarding-status",
+            args=[self.organization.slug],
+        )
+        with patch(
+            "sentry.api.endpoints.organization_agentic_onboarding.get_onboarding_progress_service"
+        ) as get_service:
+            get_service.return_value.update.side_effect = ValueError("sensitive internal context")
+            response = self.client.post(
+                path,
+                {
+                    "schemaVersion": 1,
+                    "runToken": "abcdefghij",
+                    "stage": "connect_mcp",
+                    "status": "completed",
+                },
+            )
+
+        assert response.status_code == 400
+        assert response.data == {"detail": "Invalid onboarding progress update"}


### PR DESCRIPTION
Stack 3 of 5. Previous: https://github.com/getsentry/sentry/pull/121913. Next: https://github.com/getsentry/sentry/pull/121915

Expose private organization endpoints for registering a browser run and accepting stage updates from the MCP tool. Requests require `org:read` access and bind every run to both the authenticated user and organization.

The API returns the complete normalized snapshot after each update so callers can observe accepted state and stop after a terminal run.