### PR TITLE
Add API endpoint to get agentic onboarding runs

### DIFF
--- a/src/sentry/api/endpoints/organization_agentic_onboarding_run_details.py
+++ b/src/sentry/api/endpoints/organization_agentic_onboarding_run_details.py
@@ -1,0 +1,53 @@
+from drf_spectacular.utils import extend_schema
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import cell_silo_endpoint
+from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.api.endpoints.organization_agentic_onboarding import AgenticOnboardingPermission
+from sentry.api.serializers import serialize
+from sentry.api.serializers.models.agentic_onboarding import (
+    AgenticOnboardingRunSerializer,
+)
+from sentry.models.organization import Organization
+from sentry.onboarding.agentic_progress.model import OnboardingRunTerminal
+from sentry.onboarding.agentic_progress.service import (
+    RunNotFound,
+    get_onboarding_progress_service,
+)
+
+
+@cell_silo_endpoint
+class OrganizationAgenticOnboardingRunDetailsEndpoint(OrganizationEndpoint):
+    permission_classes = (AgenticOnboardingPermission,)
+    publish_status = {"GET": ApiPublishStatus.PRIVATE, "DELETE": ApiPublishStatus.PRIVATE}
+    owner = ApiOwner.VALUE_DISCOVERY
+
+    @extend_schema(responses={200: AgenticOnboardingRunSerializer})
+    def get(self, request: Request, organization: Organization, run_id: str) -> Response:
+        user_id = request.user.id
+        assert user_id is not None
+        run = get_onboarding_progress_service().get(
+            run_id=run_id, user_id=user_id, organization_id=organization.id
+        )
+        if run is None:
+            return Response({"detail": "Onboarding run not found"}, status=404)
+
+        return Response(serialize(run, request.user, AgenticOnboardingRunSerializer()))
+
+    @extend_schema(responses={200: AgenticOnboardingRunSerializer})
+    def delete(self, request: Request, organization: Organization, run_id: str) -> Response:
+        user_id = request.user.id
+        assert user_id is not None
+        try:
+            run = get_onboarding_progress_service().cancel(
+                run_id=run_id, user_id=user_id, organization_id=organization.id
+            )
+        except RunNotFound:
+            return Response({"detail": "Onboarding run not found"}, status=404)
+        except OnboardingRunTerminal:
+            return Response({"detail": "Onboarding run is terminal"}, status=409)
+
+        return Response(serialize(run, request.user, AgenticOnboardingRunSerializer()))

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -752,6 +752,9 @@ from .endpoints.organization_agentic_onboarding import (
     OrganizationAgenticOnboardingRunIndexEndpoint,
     OrganizationAgenticOnboardingStatusEndpoint,
 )
+from .endpoints.organization_agentic_onboarding_run_details import (
+    OrganizationAgenticOnboardingRunDetailsEndpoint,
+)
 from .endpoints.organization_api_key_details import OrganizationApiKeyDetailsEndpoint
 from .endpoints.organization_api_key_index import OrganizationApiKeyIndexEndpoint
 from .endpoints.organization_artifactbundle_assemble import (
@@ -2587,6 +2590,11 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^/]+)/onboarding/agent/runs/$",
         OrganizationAgenticOnboardingRunIndexEndpoint.as_view(),
         name="sentry-api-0-organization-agentic-onboarding-run-index",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/onboarding/agent/runs/(?P<run_id>[a-f0-9]{32})/$",
+        OrganizationAgenticOnboardingRunDetailsEndpoint.as_view(),
+        name="sentry-api-0-organization-agentic-onboarding-run-details",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/onboarding/agent/status/$",

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -278,6 +278,7 @@ export type KnownSentryApiUrls =
   | '/organizations/$organizationIdOrSlug/onboarding-continuation-email/'
   | '/organizations/$organizationIdOrSlug/onboarding-tasks/'
   | '/organizations/$organizationIdOrSlug/onboarding/agent/runs/'
+  | '/organizations/$organizationIdOrSlug/onboarding/agent/runs/$runId/'
   | '/organizations/$organizationIdOrSlug/onboarding/agent/status/'
   | '/organizations/$organizationIdOrSlug/ondemand-rules-stats/'
   | '/organizations/$organizationIdOrSlug/open-periods/'

--- a/tests/sentry/api/endpoints/test_organization_agentic_onboarding_run_details.py
+++ b/tests/sentry/api/endpoints/test_organization_agentic_onboarding_run_details.py
@@ -1,0 +1,120 @@
+from unittest.mock import patch
+from uuid import uuid4
+
+from django.urls import reverse
+
+from sentry.api.serializers import serialize
+from sentry.api.serializers.models.agentic_onboarding import AgenticOnboardingRunSerializer
+from sentry.onboarding.agentic_progress.model import ProgressUpdate, RunStatus, Stage, StageStatus
+from sentry.onboarding.agentic_progress.service import OnboardingProgressService
+from sentry.testutils.cases import APITestCase
+
+
+class OrganizationAgenticOnboardingRunDetailsEndpointTest(APITestCase):
+    def setUp(self) -> None:
+        self.user = self.create_user()
+        self.organization = self.create_organization(owner=self.user)
+        self.login_as(self.user)
+        self.service = OnboardingProgressService()
+
+    def test_get_and_cancel_run(self) -> None:
+        run, _ = self.service.create_or_resume(
+            user_id=self.user.id,
+            organization_id=self.organization.id,
+            client_run_id=str(uuid4()),
+            onboarding_code="abcdefghij",
+        )
+        path = reverse(
+            "sentry-api-0-organization-agentic-onboarding-run-details",
+            args=[self.organization.slug, run.run_id],
+        )
+        service_path = (
+            "sentry.api.endpoints.organization_agentic_onboarding_run_details."
+            "get_onboarding_progress_service"
+        )
+        with patch(service_path, return_value=self.service):
+            expected_fetched = serialize(
+                run,
+                self.user,
+                AgenticOnboardingRunSerializer(),
+            )
+            fetched = self.client.get(path)
+            cancelled = self.client.delete(path)
+
+        cancelled_run = self.service.get(
+            run_id=run.run_id,
+            user_id=self.user.id,
+            organization_id=self.organization.id,
+        )
+        assert cancelled_run is not None
+        expected_cancelled = serialize(
+            cancelled_run,
+            self.user,
+            AgenticOnboardingRunSerializer(),
+        )
+
+        assert fetched.status_code == 200
+        assert fetched.data == expected_fetched
+        assert cancelled.status_code == 200
+        assert cancelled.data == expected_cancelled
+
+    def test_get_unknown_run(self) -> None:
+        path = reverse(
+            "sentry-api-0-organization-agentic-onboarding-run-details",
+            args=[self.organization.slug, "0" * 32],
+        )
+        with patch(
+            "sentry.api.endpoints.organization_agentic_onboarding_run_details."
+            "get_onboarding_progress_service",
+            return_value=self.service,
+        ):
+            response = self.client.get(path)
+
+        assert response.status_code == 404
+        assert response.data == {"detail": "Onboarding run not found"}
+
+    def test_cancel_unknown_run(self) -> None:
+        path = reverse(
+            "sentry-api-0-organization-agentic-onboarding-run-details",
+            args=[self.organization.slug, "0" * 32],
+        )
+        with patch(
+            "sentry.api.endpoints.organization_agentic_onboarding_run_details."
+            "get_onboarding_progress_service",
+            return_value=self.service,
+        ):
+            response = self.client.delete(path)
+
+        assert response.status_code == 404
+        assert response.data == {"detail": "Onboarding run not found"}
+
+    def test_cancel_terminal_run_is_invalid(self) -> None:
+        run, token = self.service.create_or_resume(
+            user_id=self.user.id,
+            organization_id=self.organization.id,
+            client_run_id=str(uuid4()),
+            onboarding_code="abcdefghij",
+        )
+        self.service.update(
+            token=token,
+            user_id=self.user.id,
+            organization_id=self.organization.id,
+            update=ProgressUpdate(
+                stage=Stage.CHECK_STACK_TRACE_QUALITY,
+                status=StageStatus.SKIPPED,
+                run_status=RunStatus.COMPLETED,
+            ),
+        )
+        path = reverse(
+            "sentry-api-0-organization-agentic-onboarding-run-details",
+            args=[self.organization.slug, run.run_id],
+        )
+        with patch(
+            "sentry.api.endpoints.organization_agentic_onboarding_run_details."
+            "get_onboarding_progress_service",
+            return_value=self.service,
+        ):
+            response = self.client.delete(path)
+
+        assert response.status_code == 409
+        assert response.data == {"detail": "Onboarding run is terminal"}


### PR DESCRIPTION
Stack 4 of 5. Previous: https://github.com/getsentry/sentry/pull/121914. Next: https://github.com/getsentry/sentry/pull/121916

Add an API endpoint for retrieving the complete state of an agentic onboarding run by ID. The endpoint also lets the browser cancel an active run while preserving its final state for rendering.

The onboarding UI will use this endpoint as a fallback polling path when Conduit is unavailable. Reads and cancellation enforce the original user and organization ownership boundary.