### PR TITLE
Stream agentic onboarding progress over Conduit

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -169,7 +169,9 @@ def apply_cors_headers(
         "sentry-trace, baggage, X-CSRFToken"
     )
     response["Access-Control-Expose-Headers"] = (
-        "X-Sentry-Error, X-Sentry-Direct-Hit, X-Hits, X-Max-Hits, Endpoint, Retry-After, Link"
+        "X-Sentry-Error, X-Sentry-Direct-Hit, X-Hits, X-Max-Hits, "
+        "X-Conduit-Token, X-Conduit-Channel-Id, X-Conduit-Url, "
+        "Endpoint, Retry-After, Link"
     )
 
     if request.META.get("HTTP_ORIGIN") == "null":

--- a/src/sentry/api/endpoints/organization_agentic_onboarding.py
+++ b/src/sentry/api/endpoints/organization_agentic_onboarding.py
@@ -1,4 +1,6 @@
-from typing import Literal, NotRequired, TypedDict
+import logging
+from collections.abc import Mapping
+from typing import Any, Literal, NotRequired, TypedDict
 from uuid import UUID
 
 from drf_spectacular.utils import extend_schema
@@ -16,10 +18,13 @@ from sentry.api.serializers.models.agentic_onboarding import (
     AgenticOnboardingRunSerializer,
 )
 from sentry.api.serializers.rest_framework import CamelSnakeSerializer
+from sentry.conduit.api import add_conduit_response_headers
+from sentry.conduit.tasks import publish_onboarding_progress
 from sentry.models.organization import Organization
 from sentry.onboarding.agentic_progress.model import (
     MAX_EVENT_NOTE_LENGTH,
     InvalidProgressUpdate,
+    OnboardingRun,
     OnboardingRunExpired,
     OnboardingRunTerminal,
     ProgressUpdate,
@@ -34,7 +39,30 @@ from sentry.onboarding.agentic_progress.service import (
     get_onboarding_progress_service,
 )
 
+logger = logging.getLogger(__name__)
+
 INVALID_PROGRESS_UPDATE_DETAIL = "Invalid onboarding progress update"
+
+
+def enqueue_onboarding_progress(
+    organization_id: int,
+    run: OnboardingRun,
+    snapshot: Mapping[str, Any],
+) -> None:
+    """Publish an API mutation without making Conduit part of its success path."""
+    try:
+        publish_onboarding_progress.delay(
+            organization_id,
+            run.channel_id,
+            run.sequence,
+            dict(snapshot),
+        )
+    except Exception:
+        logger.exception(
+            "conduit.enqueue_onboarding_progress.failed",
+            extra={"organization_id": organization_id},
+        )
+
 
 StageValue = Literal[
     "connect_mcp",
@@ -147,7 +175,7 @@ class OrganizationAgenticOnboardingRunIndexEndpoint(OrganizationEndpoint):
         except ValueError:
             return Response({"detail": "Onboarding code is unavailable"}, status=409)
 
-        return Response(
+        response = Response(
             serialize(
                 run,
                 request.user,
@@ -156,6 +184,8 @@ class OrganizationAgenticOnboardingRunIndexEndpoint(OrganizationEndpoint):
             ),
             status=status.HTTP_201_CREATED,
         )
+        add_conduit_response_headers(response, organization.id, channel_id=run.channel_id)
+        return response
 
 
 @cell_silo_endpoint
@@ -176,7 +206,7 @@ class OrganizationAgenticOnboardingStatusEndpoint(OrganizationEndpoint):
         assert user_id is not None
 
         try:
-            run, _ = get_onboarding_progress_service().update(
+            run, changed = get_onboarding_progress_service().update(
                 token=values["run_token"],
                 user_id=user_id,
                 organization_id=organization.id,
@@ -192,4 +222,7 @@ class OrganizationAgenticOnboardingStatusEndpoint(OrganizationEndpoint):
             return Response({"detail": INVALID_PROGRESS_UPDATE_DETAIL}, status=400)
 
         snapshot = serialize(run, request.user, AgenticOnboardingRunSerializer())
+        if changed:
+            enqueue_onboarding_progress(organization.id, run, snapshot)
+
         return Response(snapshot)

--- a/src/sentry/api/endpoints/organization_agentic_onboarding_run_details.py
+++ b/src/sentry/api/endpoints/organization_agentic_onboarding_run_details.py
@@ -6,11 +6,15 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
-from sentry.api.endpoints.organization_agentic_onboarding import AgenticOnboardingPermission
+from sentry.api.endpoints.organization_agentic_onboarding import (
+    AgenticOnboardingPermission,
+    enqueue_onboarding_progress,
+)
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.agentic_onboarding import (
     AgenticOnboardingRunSerializer,
 )
+from sentry.conduit.api import add_conduit_response_headers
 from sentry.models.organization import Organization
 from sentry.onboarding.agentic_progress.model import OnboardingRunTerminal
 from sentry.onboarding.agentic_progress.service import (
@@ -35,14 +39,22 @@ class OrganizationAgenticOnboardingRunDetailsEndpoint(OrganizationEndpoint):
         if run is None:
             return Response({"detail": "Onboarding run not found"}, status=404)
 
-        return Response(serialize(run, request.user, AgenticOnboardingRunSerializer()))
+        response = Response(
+            serialize(
+                run,
+                request.user,
+                AgenticOnboardingRunSerializer(),
+            )
+        )
+        add_conduit_response_headers(response, organization.id, channel_id=run.channel_id)
+        return response
 
     @extend_schema(responses={200: AgenticOnboardingRunSerializer})
     def delete(self, request: Request, organization: Organization, run_id: str) -> Response:
         user_id = request.user.id
         assert user_id is not None
         try:
-            run = get_onboarding_progress_service().cancel(
+            run, changed = get_onboarding_progress_service().cancel(
                 run_id=run_id, user_id=user_id, organization_id=organization.id
             )
         except RunNotFound:
@@ -50,4 +62,7 @@ class OrganizationAgenticOnboardingRunDetailsEndpoint(OrganizationEndpoint):
         except OnboardingRunTerminal:
             return Response({"detail": "Onboarding run is terminal"}, status=409)
 
-        return Response(serialize(run, request.user, AgenticOnboardingRunSerializer()))
+        snapshot = serialize(run, request.user, AgenticOnboardingRunSerializer())
+        if changed:
+            enqueue_onboarding_progress(organization.id, run, snapshot)
+        return Response(snapshot)

--- a/src/sentry/conduit/api.py
+++ b/src/sentry/conduit/api.py
@@ -1,0 +1,25 @@
+from django.http.response import HttpResponseBase
+
+from sentry.conduit.auth import ConduitCredentials, get_conduit_credentials
+
+CONDUIT_TOKEN_HEADER = "X-Conduit-Token"
+CONDUIT_CHANNEL_ID_HEADER = "X-Conduit-Channel-Id"
+CONDUIT_URL_HEADER = "X-Conduit-Url"
+
+
+def add_conduit_response_headers(
+    response: HttpResponseBase,
+    organization_id: int,
+    *,
+    channel_id: str | None = None,
+) -> ConduitCredentials | None:
+    """Attach the credentials needed by conduit-client to an API response."""
+    try:
+        credentials = get_conduit_credentials(organization_id, channel_id=channel_id)
+    except ValueError:
+        return None
+
+    response.headers[CONDUIT_TOKEN_HEADER] = credentials.token
+    response.headers[CONDUIT_CHANNEL_ID_HEADER] = credentials.channel_id
+    response.headers[CONDUIT_URL_HEADER] = credentials.url
+    return credentials

--- a/src/sentry/conduit/auth.py
+++ b/src/sentry/conduit/auth.py
@@ -67,6 +67,7 @@ def generate_conduit_token(
 def get_conduit_credentials(
     org_id: int,
     gateway_url: str | None = None,
+    channel_id: str | None = None,
 ) -> ConduitCredentials:
     """
     Generate all credentials needed to connect to Conduit.
@@ -76,7 +77,10 @@ def get_conduit_credentials(
     """
     if gateway_url is None:
         gateway_url = settings.CONDUIT_GATEWAY_URL
-    channel_id = generate_channel_id()
+    if not gateway_url:
+        raise ValueError("CONDUIT_GATEWAY_URL not configured")
+    if channel_id is None:
+        channel_id = generate_channel_id()
     token = generate_conduit_token(org_id, channel_id)
 
     metrics.incr(

--- a/src/sentry/conduit/endpoints/organization_conduit_demo.py
+++ b/src/sentry/conduit/endpoints/organization_conduit_demo.py
@@ -1,5 +1,4 @@
-import sentry_sdk
-from rest_framework import serializers, status
+from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -9,19 +8,9 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import OrganizationEndpoint
 from sentry.api.bases.organization import OrganizationPermission
-from sentry.conduit.auth import get_conduit_credentials
+from sentry.conduit.api import add_conduit_response_headers
 from sentry.conduit.tasks import stream_demo_data
 from sentry.models.organization import Organization
-
-
-class ConduitCredentialsSerializer(serializers.Serializer):
-    token = serializers.CharField()
-    channel_id = serializers.UUIDField()
-    url = serializers.URLField()
-
-
-class ConduitCredentialsResponseSerializer(serializers.Serializer):
-    conduit = ConduitCredentialsSerializer()
 
 
 class OrganizationConduitDemoPermission(OrganizationPermission):
@@ -47,22 +36,13 @@ class OrganizationConduitDemoEndpoint(OrganizationEndpoint):
     def post(self, request: Request, organization: Organization) -> Response:
         if not features.has("organizations:conduit-demo", organization, actor=request.user):
             return Response(status=404)
-        try:
-            conduit_credentials = get_conduit_credentials(
-                organization.id,
-            )
-        except ValueError as e:
-            sentry_sdk.capture_exception(e, level="warning")
+        response = Response(status=status.HTTP_201_CREATED)
+        conduit_credentials = add_conduit_response_headers(response, organization.id)
+        if conduit_credentials is None:
             return Response(
                 {"error": "Conduit is not configured properly"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
         # Kick off a task to stream data to Conduit
         stream_demo_data.delay(organization.id, conduit_credentials.channel_id)
-        serializer = ConduitCredentialsResponseSerializer(
-            {
-                "conduit": conduit_credentials._asdict(),
-            }
-        )
-        # Respond back to the user with the credentials needed to connect to Conduit
-        return Response(serializer.data, status=status.HTTP_201_CREATED)
+        return response

--- a/src/sentry/conduit/tasks.py
+++ b/src/sentry/conduit/tasks.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 import time
 from functools import partial
+from typing import Any
 from uuid import uuid4
 
 import requests
@@ -27,6 +28,54 @@ NUM_DELTAS = 100
 SEND_INTERVAL_SECONDS = 0.15
 JWT_EXPIRATION_SECONDS = 300  # 5 minutes
 TASK_PROCESSING_DEADLINE_SECONDS = 60 * 3  # 3 minutes
+
+
+@instrumented_task(
+    name="sentry.conduit.tasks.publish_onboarding_progress",
+    namespace=conduit_tasks,
+    processing_deadline_duration=TASK_PROCESSING_DEADLINE_SECONDS,
+    silo_mode=SiloMode.CELL,
+)
+def publish_onboarding_progress(
+    org_id: int, channel_id: str, sequence: int, payload_data: dict[str, Any]
+) -> None:
+    """Publish an agentic onboarding snapshot without blocking its API request."""
+    try:
+        token = generate_jwt(subject="agentic-onboarding")
+    except ValueError as error:
+        sentry_sdk.capture_exception(error, level="warning")
+        return
+
+    try:
+        if sequence == 1:
+            # START establishes the Conduit stream lifecycle. The client forwards
+            # application payloads from DELTA messages, so keep START empty and
+            # publish the first onboarding snapshot separately below.
+            start_request = PublishRequest(
+                channel_id=channel_id,
+                message_id=str(uuid4()),
+                sequence=0,
+                client_timestamp=get_timestamp(),
+                phase=Phase.PHASE_START,
+            )
+            publish_data(org_id, start_request, token)
+
+        payload = Struct()
+        payload.update(payload_data)
+        snapshot_request = PublishRequest(
+            channel_id=channel_id,
+            message_id=str(uuid4()),
+            sequence=sequence,
+            client_timestamp=get_timestamp(),
+            phase=Phase.PHASE_DELTA,
+            payload=payload,
+        )
+        publish_data(org_id, snapshot_request, token)
+    except RequestException:
+        logger.exception(
+            "conduit.publish_onboarding_progress.failed",
+            extra={"organization_id": org_id},
+        )
 
 
 @instrumented_task(

--- a/src/sentry/onboarding/agentic_progress/service.py
+++ b/src/sentry/onboarding/agentic_progress/service.py
@@ -151,7 +151,7 @@ class OnboardingProgressService:
 
         return self._atomic_update(run_id, mutate)
 
-    def cancel(self, *, run_id: str, user_id: int, organization_id: int) -> OnboardingRun:
+    def cancel(self, *, run_id: str, user_id: int, organization_id: int) -> UpdatedRun:
         def mutate(run: OnboardingRun) -> OnboardingRun:
             if run.user_id != user_id or run.organization_id != organization_id:
                 raise RunNotFound
@@ -167,8 +167,7 @@ class OnboardingProgressService:
                 sequence=run.sequence + 1,
             )
 
-        result = self._atomic_update(run_id, mutate)
-        return result.run
+        return self._atomic_update(run_id, mutate)
 
     def _claim_client_run(self, index_key: str) -> ClientRunClaim:
         """Return the active indexed run or atomically claim the client id for a new run."""

--- a/tests/sentry/api/endpoints/test_organization_agentic_onboarding.py
+++ b/tests/sentry/api/endpoints/test_organization_agentic_onboarding.py
@@ -7,6 +7,7 @@ from django.urls import reverse
 from django.utils import timezone
 from rest_framework.response import Response
 
+from sentry.conduit.auth import ConduitCredentials
 from sentry.onboarding.agentic_progress.model import ProgressUpdate, RunStatus, Stage, StageStatus
 from sentry.onboarding.agentic_progress.service import OnboardingProgressService
 from sentry.testutils.cases import APITestCase
@@ -27,7 +28,18 @@ class OrganizationAgenticOnboardingEndpointTest(APITestCase):
         service_path = (
             "sentry.api.endpoints.organization_agentic_onboarding.get_onboarding_progress_service"
         )
-        with patch(service_path, return_value=self.service):
+        conduit = ConduitCredentials(
+            token="conduit-token",
+            channel_id="00000000-0000-0000-0000-000000000001",
+            url="https://conduit.example.com/events/1",
+        )
+        with (
+            patch(service_path, return_value=self.service),
+            patch(
+                "sentry.conduit.api.get_conduit_credentials",
+                return_value=conduit,
+            ),
+        ):
             response = self.client.post(
                 index_path,
                 {"clientRunId": str(uuid4()), "onboardingCode": "a1B2c3D4e5"},
@@ -36,12 +48,22 @@ class OrganizationAgenticOnboardingEndpointTest(APITestCase):
         assert response.status_code == 201, response.content
         assert response.data["onboardingCode"] == "a1B2c3D4e5"
         assert response.data["sequence"] == 0
+        assert "conduit" not in response.data
+        assert response["X-Conduit-Token"] == "conduit-token"
+        assert response["X-Conduit-Channel-Id"] == conduit.channel_id
+        assert response["X-Conduit-Url"] == conduit.url
 
         status_path = reverse(
             "sentry-api-0-organization-agentic-onboarding-status",
             args=[self.organization.slug],
         )
-        with patch(service_path, return_value=self.service):
+        with (
+            patch(service_path, return_value=self.service),
+            patch(
+                "sentry.api.endpoints.organization_agentic_onboarding."
+                "publish_onboarding_progress.delay"
+            ) as publish,
+        ):
             response = self.client.post(
                 status_path,
                 {
@@ -58,6 +80,29 @@ class OrganizationAgenticOnboardingEndpointTest(APITestCase):
         assert response.data["stages"][0]["status"] == "bypassed"
         assert response.data["stages"][1]["status"] == "bypassed"
         assert response.data["stages"][2]["status"] == "completed"
+        publish.assert_called_once()
+
+        with (
+            patch(service_path, return_value=self.service),
+            patch(
+                "sentry.api.endpoints.organization_agentic_onboarding."
+                "publish_onboarding_progress.delay"
+            ) as publish,
+        ):
+            duplicate = self.client.post(
+                status_path,
+                {
+                    "schemaVersion": 1,
+                    "runToken": "a1B2c3D4e5",
+                    "stage": "create_project",
+                    "status": "completed",
+                    "eventNote": "Project already existed.",
+                },
+            )
+
+        assert duplicate.status_code == 200
+        assert duplicate.data["sequence"] == 1
+        publish.assert_not_called()
 
     def test_status_rejects_unknown_run(self) -> None:
         path = reverse(
@@ -105,6 +150,32 @@ class OrganizationAgenticOnboardingEndpointTest(APITestCase):
 
         assert response.status_code == 404
         assert response.data == {"detail": "Onboarding run not found"}
+
+    def test_registration_works_without_conduit_configuration(self) -> None:
+        path = reverse(
+            "sentry-api-0-organization-agentic-onboarding-run-index",
+            args=[self.organization.slug],
+        )
+        with (
+            patch(
+                "sentry.api.endpoints.organization_agentic_onboarding."
+                "get_onboarding_progress_service",
+                return_value=self.service,
+            ),
+            patch(
+                "sentry.conduit.api.get_conduit_credentials",
+                side_effect=ValueError("Conduit is unavailable"),
+            ),
+        ):
+            response = self.client.post(
+                path,
+                {"clientRunId": str(uuid4()), "onboardingCode": "a1B2c3D4e5"},
+            )
+
+        assert response.status_code == 201
+        assert "X-Conduit-Token" not in response
+        assert "X-Conduit-Channel-Id" not in response
+        assert "X-Conduit-Url" not in response
 
     def test_registration_rejects_code_reserved_by_another_run(self) -> None:
         self.service.create_or_resume(

--- a/tests/sentry/api/endpoints/test_organization_agentic_onboarding_run_details.py
+++ b/tests/sentry/api/endpoints/test_organization_agentic_onboarding_run_details.py
@@ -5,6 +5,7 @@ from django.urls import reverse
 
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.agentic_onboarding import AgenticOnboardingRunSerializer
+from sentry.conduit.auth import ConduitCredentials
 from sentry.onboarding.agentic_progress.model import ProgressUpdate, RunStatus, Stage, StageStatus
 from sentry.onboarding.agentic_progress.service import OnboardingProgressService
 from sentry.testutils.cases import APITestCase
@@ -32,7 +33,22 @@ class OrganizationAgenticOnboardingRunDetailsEndpointTest(APITestCase):
             "sentry.api.endpoints.organization_agentic_onboarding_run_details."
             "get_onboarding_progress_service"
         )
-        with patch(service_path, return_value=self.service):
+        conduit = ConduitCredentials(
+            token="conduit-token",
+            channel_id=run.channel_id,
+            url="https://conduit.example.com/events/1",
+        )
+        with (
+            patch(service_path, return_value=self.service),
+            patch(
+                "sentry.conduit.api.get_conduit_credentials",
+                return_value=conduit,
+            ),
+            patch(
+                "sentry.api.endpoints.organization_agentic_onboarding."
+                "publish_onboarding_progress.delay"
+            ) as publish,
+        ):
             expected_fetched = serialize(
                 run,
                 self.user,
@@ -40,6 +56,7 @@ class OrganizationAgenticOnboardingRunDetailsEndpointTest(APITestCase):
             )
             fetched = self.client.get(path)
             cancelled = self.client.delete(path)
+            replayed = self.client.delete(path)
 
         cancelled_run = self.service.get(
             run_id=run.run_id,
@@ -55,8 +72,19 @@ class OrganizationAgenticOnboardingRunDetailsEndpointTest(APITestCase):
 
         assert fetched.status_code == 200
         assert fetched.data == expected_fetched
+        assert fetched["X-Conduit-Token"] == conduit.token
+        assert fetched["X-Conduit-Channel-Id"] == conduit.channel_id
+        assert fetched["X-Conduit-Url"] == conduit.url
         assert cancelled.status_code == 200
         assert cancelled.data == expected_cancelled
+        assert replayed.status_code == 200
+        assert replayed.data == expected_cancelled
+        publish.assert_called_once_with(
+            self.organization.id,
+            cancelled_run.channel_id,
+            cancelled_run.sequence,
+            dict(expected_cancelled),
+        )
 
     def test_get_unknown_run(self) -> None:
         path = reverse(

--- a/tests/sentry/api/test_base.py
+++ b/tests/sentry/api/test_base.py
@@ -134,7 +134,9 @@ class EndpointTest(APITestCase):
             "sentry-trace, baggage, X-CSRFToken"
         )
         assert response["Access-Control-Expose-Headers"] == (
-            "X-Sentry-Error, X-Sentry-Direct-Hit, X-Hits, X-Max-Hits, Endpoint, Retry-After, Link"
+            "X-Sentry-Error, X-Sentry-Direct-Hit, X-Hits, X-Max-Hits, "
+            "X-Conduit-Token, X-Conduit-Channel-Id, X-Conduit-Url, "
+            "Endpoint, Retry-After, Link"
         )
         assert response["Access-Control-Allow-Methods"] == "GET, HEAD, OPTIONS"
         assert "Access-Control-Allow-Credentials" not in response
@@ -161,7 +163,9 @@ class EndpointTest(APITestCase):
             "sentry-trace, baggage, X-CSRFToken"
         )
         assert response["Access-Control-Expose-Headers"] == (
-            "X-Sentry-Error, X-Sentry-Direct-Hit, X-Hits, X-Max-Hits, Endpoint, Retry-After, Link"
+            "X-Sentry-Error, X-Sentry-Direct-Hit, X-Hits, X-Max-Hits, "
+            "X-Conduit-Token, X-Conduit-Channel-Id, X-Conduit-Url, "
+            "Endpoint, Retry-After, Link"
         )
         assert response["Access-Control-Allow-Methods"] == "GET, HEAD, OPTIONS"
         assert response["Access-Control-Allow-Credentials"] == "true"
@@ -188,7 +192,9 @@ class EndpointTest(APITestCase):
             "sentry-trace, baggage, X-CSRFToken"
         )
         assert response["Access-Control-Expose-Headers"] == (
-            "X-Sentry-Error, X-Sentry-Direct-Hit, X-Hits, X-Max-Hits, Endpoint, Retry-After, Link"
+            "X-Sentry-Error, X-Sentry-Direct-Hit, X-Hits, X-Max-Hits, "
+            "X-Conduit-Token, X-Conduit-Channel-Id, X-Conduit-Url, "
+            "Endpoint, Retry-After, Link"
         )
         assert response["Access-Control-Allow-Methods"] == "GET, HEAD, OPTIONS"
         assert response["Access-Control-Allow-Credentials"] == "true"
@@ -216,7 +222,9 @@ class EndpointTest(APITestCase):
             "sentry-trace, baggage, X-CSRFToken"
         )
         assert response["Access-Control-Expose-Headers"] == (
-            "X-Sentry-Error, X-Sentry-Direct-Hit, X-Hits, X-Max-Hits, Endpoint, Retry-After, Link"
+            "X-Sentry-Error, X-Sentry-Direct-Hit, X-Hits, X-Max-Hits, "
+            "X-Conduit-Token, X-Conduit-Channel-Id, X-Conduit-Url, "
+            "Endpoint, Retry-After, Link"
         )
         assert response["Access-Control-Allow-Methods"] == "GET, HEAD, OPTIONS"
         assert response["Access-Control-Allow-Credentials"] == "true"
@@ -288,7 +296,9 @@ class EndpointTest(APITestCase):
             "sentry-trace, baggage, X-CSRFToken"
         )
         assert response["Access-Control-Expose-Headers"] == (
-            "X-Sentry-Error, X-Sentry-Direct-Hit, X-Hits, X-Max-Hits, Endpoint, Retry-After, Link"
+            "X-Sentry-Error, X-Sentry-Direct-Hit, X-Hits, X-Max-Hits, "
+            "X-Conduit-Token, X-Conduit-Channel-Id, X-Conduit-Url, "
+            "Endpoint, Retry-After, Link"
         )
         assert response["Access-Control-Allow-Methods"] == "GET, HEAD, OPTIONS"
 

--- a/tests/sentry/conduit/endpoints/test_organization_conduit_demo.py
+++ b/tests/sentry/conduit/endpoints/test_organization_conduit_demo.py
@@ -35,11 +35,9 @@ class OrganizationConduitDemoEndpointTest(APITestCase):
             status_code=201,
         )
 
-        assert "conduit" in response.data
-        assert "token" in response.data["conduit"]
-        assert "channel_id" in response.data["conduit"]
-        assert "url" in response.data["conduit"]
-        assert str(self.organization.id) in response.data["conduit"]["url"]
+        assert response["X-Conduit-Token"]
+        assert response["X-Conduit-Channel-Id"]
+        assert str(self.organization.id) in response["X-Conduit-Url"]
 
     @override_settings(
         CONDUIT_GATEWAY_PRIVATE_KEY=RS256_KEY_B64,
@@ -65,9 +63,8 @@ class OrganizationConduitDemoEndpointTest(APITestCase):
             status_code=201,
         )
 
-        assert "conduit" in response.data
-        assert "token" in response.data["conduit"]
-        assert "channel_id" in response.data["conduit"]
+        assert response["X-Conduit-Token"]
+        assert response["X-Conduit-Channel-Id"]
 
     @with_feature("organizations:conduit-demo")
     def test_post_without_org_access(self) -> None:
@@ -112,8 +109,8 @@ class OrganizationConduitDemoEndpointTest(APITestCase):
             status_code=201,
         )
 
-        assert response1.data["conduit"]["token"] != response2.data["conduit"]["token"]
-        assert response1.data["conduit"]["channel_id"] != response2.data["conduit"]["channel_id"]
+        assert response1["X-Conduit-Token"] != response2["X-Conduit-Token"]
+        assert response1["X-Conduit-Channel-Id"] != response2["X-Conduit-Channel-Id"]
 
     @override_settings(
         CONDUIT_GATEWAY_PRIVATE_KEY=RS256_KEY_B64,

--- a/tests/sentry/conduit/test_auth.py
+++ b/tests/sentry/conduit/test_auth.py
@@ -1,6 +1,7 @@
 import base64
 import time
 from unittest.mock import patch
+from uuid import uuid4
 
 import jwt as pyjwt
 import pytest
@@ -166,6 +167,14 @@ def test_get_conduit_credentials_returns_all_credentials() -> None:
         assert result.url == f"{gateway_url}/events/{org_id}"
 
 
+def test_get_conduit_credentials_requires_gateway_url() -> None:
+    with patch("sentry.conduit.auth.settings") as mock_settings:
+        mock_settings.CONDUIT_GATEWAY_URL = None
+
+        with pytest.raises(ValueError, match="CONDUIT_GATEWAY_URL not configured"):
+            get_conduit_credentials(123)
+
+
 def test_get_conduit_credentials_uses_custom_url() -> None:
     """Should use provided gateway_url instead of settings."""
     gateway_url = "https://custom.conduit.io"
@@ -183,6 +192,20 @@ def test_get_conduit_credentials_uses_custom_url() -> None:
 
         assert str(org_id) in result.url
         assert result.url == f"{gateway_url}/events/{org_id}"
+
+
+def test_get_conduit_credentials_uses_existing_channel() -> None:
+    gateway_url = "https://conduit.example.com"
+    channel_id = str(uuid4())
+    with patch("sentry.conduit.auth.settings") as mock_settings:
+        mock_settings.CONDUIT_GATEWAY_PRIVATE_KEY = RS256_KEY_B64
+        mock_settings.CONDUIT_GATEWAY_JWT_ISSUER = "sentry"
+        mock_settings.CONDUIT_GATEWAY_JWT_AUDIENCE = "conduit"
+        mock_settings.CONDUIT_GATEWAY_URL = gateway_url
+
+        result = get_conduit_credentials(123, channel_id=channel_id)
+
+        assert result.channel_id == channel_id
 
 
 def test_get_conduit_credentials_token_is_valid() -> None:

--- a/tests/sentry/conduit/test_tasks.py
+++ b/tests/sentry/conduit/test_tasks.py
@@ -16,6 +16,7 @@ from sentry.conduit.tasks import (
     generate_jwt,
     get_timestamp,
     publish_data,
+    publish_onboarding_progress,
     stream_demo_data,
 )
 from sentry.testutils.cases import TestCase
@@ -80,6 +81,61 @@ class GetTimestampTest(TestCase):
 
         dt = timestamp.ToDatetime()
         assert dt == custom_dt
+
+
+class PublishOnboardingProgressTest(TestCase):
+    @patch("sentry.conduit.tasks.publish_data")
+    @patch("sentry.conduit.tasks.generate_jwt", return_value="token")
+    def test_publishes_snapshot(self, mock_generate_jwt, mock_publish_data) -> None:
+        channel_id = str(uuid4())
+
+        publish_onboarding_progress(
+            org_id=123,
+            channel_id=channel_id,
+            sequence=4,
+            payload_data={"schemaVersion": 1, "sequence": 4},
+        )
+
+        mock_generate_jwt.assert_called_once_with(subject="agentic-onboarding")
+        request = mock_publish_data.call_args.args[1]
+        assert request.channel_id == channel_id
+        assert request.sequence == 4
+        assert request.phase == Phase.PHASE_DELTA
+        assert request.payload["schemaVersion"] == 1
+        assert request.payload["sequence"] == 4
+
+    @patch("sentry.conduit.tasks.publish_data")
+    @patch("sentry.conduit.tasks.generate_jwt", return_value="token")
+    def test_first_snapshot_starts_stream_then_publishes_delta(
+        self, mock_generate_jwt, mock_publish_data
+    ) -> None:
+        publish_onboarding_progress(
+            org_id=123,
+            channel_id=str(uuid4()),
+            sequence=1,
+            payload_data={"sequence": 1},
+        )
+
+        assert mock_publish_data.call_count == 2
+        start_request = mock_publish_data.call_args_list[0].args[1]
+        assert start_request.sequence == 0
+        assert start_request.phase == Phase.PHASE_START
+        assert not start_request.HasField("payload")
+
+        snapshot_request = mock_publish_data.call_args_list[1].args[1]
+        assert snapshot_request.sequence == 1
+        assert snapshot_request.phase == Phase.PHASE_DELTA
+        assert snapshot_request.payload["sequence"] == 1
+
+    @patch("sentry.conduit.tasks.publish_data", side_effect=RequestException)
+    @patch("sentry.conduit.tasks.generate_jwt", return_value="token")
+    def test_publish_failure_is_best_effort(self, mock_generate_jwt, mock_publish_data) -> None:
+        publish_onboarding_progress(
+            org_id=123,
+            channel_id=str(uuid4()),
+            sequence=1,
+            payload_data={"sequence": 1},
+        )
 
 
 class PublishDataTest(TestCase):

--- a/tests/sentry/onboarding/agentic_progress/test_service.py
+++ b/tests/sentry/onboarding/agentic_progress/test_service.py
@@ -162,11 +162,13 @@ def test_token_and_ownership_are_validated(service: OnboardingProgressService) -
 def test_cancel_is_terminal_and_idempotent(service: OnboardingProgressService) -> None:
     created, _ = create_run(service, user_id=1, organization_id=2, client_run_id="browser-session")
 
-    cancelled = service.cancel(run_id=created.run_id, user_id=1, organization_id=2)
-    replay = service.cancel(run_id=created.run_id, user_id=1, organization_id=2)
+    cancelled, changed = service.cancel(run_id=created.run_id, user_id=1, organization_id=2)
+    replay, replay_changed = service.cancel(run_id=created.run_id, user_id=1, organization_id=2)
 
     assert cancelled.run_status is RunStatus.CANCELLED
     assert replay == cancelled
+    assert changed is True
+    assert replay_changed is False
 
 
 def test_cancel_rejects_completed_run(service: OnboardingProgressService) -> None:


### PR DESCRIPTION
Depends on #122061.

Publish changed agentic onboarding snapshots asynchronously through Conduit after status updates and cancellation. Polling remains available when Conduit is unavailable.

Publishing is best effort, carries the Redis sequence for stale-message rejection, and suppresses duplicate broadcasts for idempotent updates.

Follow-ups: MCP tool https://github.com/getsentry/sentry-mcp/pull/1244 and skill instructions https://github.com/getsentry/sentry-for-ai/pull/331.